### PR TITLE
Fix WPT reference generation cascading after a renderer crash

### DIFF
--- a/scripts/generate-wpt-references.js
+++ b/scripts/generate-wpt-references.js
@@ -30,14 +30,31 @@ const VIEWPORT = { width: 1024, height: 768 };
 const PAGE_LOAD_TIMEOUT = 10_000;   // ms — max time to wait for page load
 const DEFAULT_CONCURRENCY = 8;
 
-/** Recursively discover test files. */
+/**
+ * WPT crashtests (filename ending in `-crash.{html,htm,xhtml}`) are security
+ * regression tests that deliberately try to crash the browser engine.  They
+ * are not reftests, never have a reference screenshot, and — by design — kill
+ * the Chromium renderer when loaded.  Skip them so they neither waste a render
+ * slot nor poison the worker that loads them.
+ */
+function isCrashTest(name) {
+    // Matches `foo-crash.html` as well as flagged variants like
+    // `foo-crash.https.html` (WPT appends `.flag` segments before the
+    // extension).
+    return /-crash(?:\.[^.]+)*\.(?:html|htm|xhtml)$/i.test(name);
+}
+
+/** Recursively discover test files (excluding WPT crashtests). */
 function discoverTests(dir) {
     const results = [];
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
         const full = path.join(dir, entry.name);
         if (entry.isDirectory()) {
             results.push(...discoverTests(full));
-        } else if (TEST_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+        } else if (
+            TEST_EXTENSIONS.has(path.extname(entry.name).toLowerCase()) &&
+            !isCrashTest(entry.name)
+        ) {
             results.push(full);
         }
     }
@@ -124,40 +141,47 @@ function ensureDir(filePath) {
     let errors = 0;
     const total = testFiles.length;
 
+    // Intercept root-relative /fonts/ requests and serve them from the
+    // local fonts directory.  WPT tests use paths like /fonts/ahem.css
+    // which a real WPT server resolves relative to the WPT root.  When
+    // loading via file://, Chrome resolves them as file:///fonts/... which
+    // does not exist on disk.  Playwright can intercept these requests via
+    // context.route() for both http:// and file:// origin requests.
+    async function fontRouteHandler(route) {
+        const url = route.request().url();
+        // Strip the file:///fonts/ prefix to get the filename/subpath.
+        const subpath = decodeURIComponent(url.replace(/^file:\/\/\/fonts\//i, ''));
+        const localPath = path.join(localFontsDir, subpath);
+        if (fs.existsSync(localPath)) {
+            const body = fs.readFileSync(localPath);
+            const ext = path.extname(localPath).toLowerCase();
+            const contentType =
+                ext === '.css'  ? 'text/css; charset=utf-8' :
+                ext === '.ttf'  ? 'font/truetype' :
+                ext === '.otf'  ? 'font/opentype' :
+                ext === '.woff' ? 'font/woff' :
+                ext === '.woff2'? 'font/woff2' :
+                'application/octet-stream';
+            await route.fulfill({ status: 200, contentType, body });
+        } else {
+            await route.abort('failed');
+        }
+    }
+
+    // Create a fresh context + page, registering the font route.  Used both
+    // for a worker's initial page and to recover after a renderer crash.
+    async function newRenderTarget() {
+        const context = await browser.newContext({ viewport: VIEWPORT });
+        if (hasFontsDir) {
+            await context.route(/file:\/\/\/fonts\//i, fontRouteHandler);
+        }
+        const page = await context.newPage();
+        return { context, page };
+    }
+
     // Worker function — processes one file at a time from the queue.
     async function worker(queue) {
-        const context = await browser.newContext({ viewport: VIEWPORT });
-
-        // Intercept root-relative /fonts/ requests and serve them from the
-        // local fonts directory.  WPT tests use paths like /fonts/ahem.css
-        // which a real WPT server resolves relative to the WPT root.  When
-        // loading via file://, Chrome resolves them as file:///fonts/... which
-        // does not exist on disk.  Playwright can intercept these requests via
-        // context.route() for both http:// and file:// origin requests.
-        if (hasFontsDir) {
-            await context.route(/file:\/\/\/fonts\//i, async (route) => {
-                const url = route.request().url();
-                // Strip the file:///fonts/ prefix to get the filename/subpath.
-                const subpath = decodeURIComponent(url.replace(/^file:\/\/\/fonts\//i, ''));
-                const localPath = path.join(localFontsDir, subpath);
-                if (fs.existsSync(localPath)) {
-                    const body = fs.readFileSync(localPath);
-                    const ext = path.extname(localPath).toLowerCase();
-                    const contentType =
-                        ext === '.css'  ? 'text/css; charset=utf-8' :
-                        ext === '.ttf'  ? 'font/truetype' :
-                        ext === '.otf'  ? 'font/opentype' :
-                        ext === '.woff' ? 'font/woff' :
-                        ext === '.woff2'? 'font/woff2' :
-                        'application/octet-stream';
-                    await route.fulfill({ status: 200, contentType, body });
-                } else {
-                    await route.abort('failed');
-                }
-            });
-        }
-
-        const page = await context.newPage();
+        let { context, page } = await newRenderTarget();
 
         while (queue.length > 0) {
             const testFile = queue.pop();
@@ -183,6 +207,23 @@ function ensureDir(filePath) {
                     console.error(`  ⚠ Failed: ${rel}: ${err.message || err}`);
                 }
                 errors++;
+
+                // A renderer crash leaves `page` permanently dead: every
+                // subsequent goto on it throws "Page crashed", so a single
+                // crashing test would cascade into hundreds of false failures
+                // for unrelated files this worker later picks up.  Rebuild the
+                // context+page so the worker recovers and keeps going.
+                const crashed = page.isClosed() ||
+                    /crash|Target (?:closed|page).*closed|browser has been closed/i.test(String(err && err.message));
+                if (crashed) {
+                    try { await context.close(); } catch { /* already gone */ }
+                    try {
+                        ({ context, page } = await newRenderTarget());
+                    } catch (rebuildErr) {
+                        console.error(`  ⚠ Failed to recover worker after crash: ${rebuildErr.message || rebuildErr}`);
+                        break;   // browser itself is unusable; let other workers finish.
+                    }
+                }
             }
 
             completed++;
@@ -192,8 +233,8 @@ function ensureDir(filePath) {
             }
         }
 
-        await page.close();
-        await context.close();
+        try { await page.close(); } catch { /* may already be closed */ }
+        try { await context.close(); } catch { /* may already be closed */ }
     }
 
     // Shallow-copy as a mutable queue (pop from end is O(1)).


### PR DESCRIPTION
## What

Two fixes to `scripts/generate-wpt-references.js`, the Playwright script that captures Chromium reference screenshots for the WPT suite:

1. **Recover from renderer crashes instead of cascading.** Each worker created a single `page` *outside* its queue loop and reused it for every file it processed. When a test crashed the Chromium renderer, `page.goto` threw `Page crashed` — and the catch block only counted the error and looped on, so **every subsequent `goto` on that now-dead page also threw `Page crashed`**. The worker now detects a dead page and rebuilds its context+page (via an extracted `newRenderTarget()` helper and a hoisted `fontRouteHandler`), so it keeps draining the queue. If the browser itself is gone, the worker bails cleanly and lets the others finish.

2. **Skip WPT crashtests at discovery.** New `isCrashTest()` excludes `*-crash.html` and flagged variants (e.g. `*-crash.https.html`). These are security regression tests built to crash the engine — they are never reftests, have no reference screenshot, and only waste a render slot / poison the worker.

## Why

In CI, the error count jumped disproportionately in a single window:

```
[7.3%] 5000/68171 done (54 errors)
[8.1%] 5500/68171 done (181 errors)   ← +127 in one 500-file window
```

With `concurrency=8`, two `shared-storage` tentative tests crashing near file 5000 killed ~two workers' reused pages, so ~127 unrelated *healthy* tests behind them were falsely reported as failures. That both inflated the error count and corrupted the generated reference set. Genuine crashes are now isolated (or skipped outright), so the `errors` count and the reference output are trustworthy again.

## Notes for reviewers

- The `.tentative.https.sub.html` / shared-storage family is still *attempted* and may fail individually — but it now fails in isolation via the recovery path rather than cascading. Adding a broader filter for `.tentative.`/`.sub.`/`.https.` was left out deliberately as a separate policy call about what belongs in `file://` reference generation.
- `node --check` passes; the `isCrashTest` regex was unit-tested against the real failing names plus non-crash controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)