### PR TITLE
WPT CI: shard the full suite, add incremental reruns and auto-issue filing

### DIFF
--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -1,15 +1,23 @@
 name: WPT Tests
 
-# Two entry points:
-#   * Scheduled per-segment matrix (weekly) — the standing coverage signal for
-#     the public-preview roadmap. Each segment is gated against a committed
-#     baseline so CI alarms on *regressions*, not on the absolute backlog of
-#     skipped/failing tests.
-#   * Manual single-subset run (workflow_dispatch) — for targeted investigation.
+# Full-suite Web Platform Tests runner, sharded for parallelism.
 #
-# Reference-image generation (Chromium via Playwright) is expensive, so the
-# matrix runs weekly and caches both the WPT checkout and the generated
-# references. Bump CACHE_EPOCH to force a refresh of WPT master and references.
+# Modeled on Broiler.JS's test262.yml. The whole WPT checkout (~60K+ tests) is
+# split into SHARD_COUNT deterministic shards; each shard is an independent job
+# that generates its own Chromium references and runs only its slice. Shard
+# assignment (FNV-1a of the relative path) is identical in
+# scripts/generate-wpt-references.js and the C# runner, so a shard's references
+# always cover the tests it executes.
+#
+# Entry points:
+#   * Scheduled (weekly): runs every shard of the full suite, merges the
+#     results, and — when failures exist — files a summarizing GitHub issue and
+#     persists the failing-test manifest for incremental reruns.
+#   * Manual (workflow_dispatch): target a subset, a single shard, or rerun only
+#     the previously-failed tests for fast feedback.
+#
+# Reference generation (Chromium via Playwright) is expensive, so each shard
+# caches its reference slice. Bump CACHE_EPOCH to refresh WPT master + refs.
 
 on:
   schedule:
@@ -20,39 +28,112 @@ on:
       subset:
         description: >
           Semicolon-separated WPT subset patterns with optional wildcards.
-          Examples: "css/css-flexbox", "css/CSS2;css/css-*", leave empty for all.
+          Examples: "css/css-flexbox", "css/CSS2;css/css-*". Empty = full suite.
         required: false
         default: ''
+      shard_index:
+        description: Zero-based shard index to run, or -1 for all shards.
+        required: false
+        default: '-1'
+      rerun_failed_only:
+        description: >
+          Rerun only the previously-failed tests from the committed manifest
+          (tests/wpt-baseline/failed-tests.json), reusing cached references.
+        type: boolean
+        required: false
+        default: false
+      test_timeout_seconds:
+        description: Per-test timeout in seconds.
+        required: false
+        default: '30'
 
 permissions:
-  contents: read
+  contents: write   # persist-failed commits the failing-test manifest
+  issues: write
 
 env:
   # Bump to invalidate the cached WPT checkout + references.
   CACHE_EPOCH: '1'
+  SHARD_COUNT: '8'
+  WPT_CHECKOUT_DIR: tests/wpt/checkout
+  REFERENCE_DIR: tests/wpt/references
+  RESULTS_DIR: tests/wpt-results
+  FAILED_TESTS_FILE: tests/wpt-baseline/failed-tests.json
 
 jobs:
-  # ── Scheduled per-segment coverage matrix ────────────────────────────────
-  matrix:
-    name: WPT ${{ matrix.segment.id }}
-    if: github.event_name == 'schedule'
+  # ── Resolve the shard matrix and whether to run incrementally ────────────
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      shard-matrix: ${{ steps.resolve.outputs.shard-matrix }}
+      rerun-failed: ${{ steps.resolve.outputs.rerun-failed }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve plan
+        id: resolve
+        shell: bash
+        env:
+          SELECTED_SHARD_INDEX: ${{ github.event.inputs.shard_index || '-1' }}
+          RERUN_FAILED_ONLY: ${{ github.event.inputs.rerun_failed_only || 'false' }}
+        run: |
+          python <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          shard_count = int(os.environ["SHARD_COUNT"])
+          try:
+              selected = int(os.environ["SELECTED_SHARD_INDEX"])
+          except ValueError:
+              sys.exit(f"shard_index must be an integer, got {os.environ['SELECTED_SHARD_INDEX']!r}")
+
+          if selected == -1:
+              matrix = [{"shard-index": i} for i in range(shard_count)]
+          elif 0 <= selected < shard_count:
+              matrix = [{"shard-index": selected}]
+          else:
+              sys.exit(f"shard_index must be -1 or between 0 and {shard_count - 1}, got {selected}")
+
+          rerun_requested = os.environ["RERUN_FAILED_ONLY"].strip().lower() == "true"
+          rerun_failed = rerun_requested and Path(os.environ["FAILED_TESTS_FILE"]).exists()
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"shard-matrix={json.dumps(matrix)}\n")
+              fh.write(f"rerun-failed={'true' if rerun_failed else 'false'}\n")
+          PY
+
+  # ── Clone + cache the WPT checkout once (shared by all shards) ────────────
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache WPT checkout
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.WPT_CHECKOUT_DIR }}
+          key: wpt-checkout-${{ env.CACHE_EPOCH }}
+
+      - name: Clone WPT (shallow) on cache miss
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          git clone --single-branch --branch master --depth 1 \
+            https://github.com/web-platform-tests/wpt.git "$WPT_CHECKOUT_DIR"
+
+  # ── Run one shard of the suite ───────────────────────────────────────────
+  run:
+    needs: [plan, prepare]
     runs-on: ubuntu-latest
     timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
-        # The "gated" coverage set for the preview. Add segments here as their
-        # references land and (for testharness segments like dom/html) as the
-        # harness-reporting work in Phase 1 makes their results meaningful.
-        segment:
-          - { id: css-css2,    pattern: 'css/CSS2' }
-          - { id: css-flexbox, pattern: 'css/css-flexbox' }
-          - { id: css-text,    pattern: 'css/css-text' }
-          - { id: css-selectors, pattern: 'css/selectors' }
-          # testharness-heavy segments: scaffolded now, meaningful once the
-          # testharness result-reporting work (roadmap task 1.1) lands.
-          - { id: dom,         pattern: 'dom' }
-          - { id: html-parsing, pattern: 'html/syntax' }
+        include: ${{ fromJson(needs.plan.outputs.shard-matrix) }}
+    env:
+      BROILER_WPT_TIMEOUT_SECONDS: ${{ github.event.inputs.test_timeout_seconds || '30' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,138 +149,183 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Cache WPT checkout
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Restore WPT checkout
         uses: actions/cache@v4
         with:
-          path: tests/wpt/checkout
-          key: wpt-checkout-${{ env.CACHE_EPOCH }}-${{ matrix.segment.id }}
+          path: ${{ env.WPT_CHECKOUT_DIR }}
+          key: wpt-checkout-${{ env.CACHE_EPOCH }}
 
-      - name: Cache reference images
+      - name: Cache shard references
         uses: actions/cache@v4
         with:
-          path: tests/wpt/references
-          key: wpt-refs-${{ env.CACHE_EPOCH }}-${{ matrix.segment.id }}
+          path: ${{ env.REFERENCE_DIR }}
+          key: wpt-refs-${{ env.CACHE_EPOCH }}-shard-${{ matrix.shard-index }}
 
-      - name: Run WPT segment
+      - name: Run WPT shard ${{ matrix.shard-index }}
         id: wpt
+        shell: bash
+        env:
+          SUBSET: ${{ github.event.inputs.subset || '' }}
+          RERUN_FAILED: ${{ needs.plan.outputs.rerun-failed }}
         run: |
-          EXIT=0
-          bash scripts/run-wpt-tests.sh --subset "${{ matrix.segment.pattern }}" || EXIT=$?
-          echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
-
-      - name: Regression gate
-        run: |
-          bash scripts/check-wpt-regression.sh \
-            --results tests/wpt-results/wpt-results.json \
-            --baseline "tests/wpt-baseline/${{ matrix.segment.id }}.json"
-
-      - name: Print summary
-        if: always()
-        run: |
-          SUMMARY="tests/wpt-results/wpt-summary.txt"
-          if [ -f "$SUMMARY" ]; then
-            echo "### WPT ${{ matrix.segment.id }} (${{ matrix.segment.pattern }})" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          ARGS=(--shard-index "${{ matrix.shard-index }}" --shard-count "$SHARD_COUNT")
+          if [ -n "$SUBSET" ]; then
+            ARGS+=(--subset "$SUBSET")
           fi
-          TRIAGE="tests/wpt-results/wpt-triage-summary.md"
-          if [ -f "$TRIAGE" ]; then
-            cat "$TRIAGE" >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: wpt-results-${{ matrix.segment.id }}
-          path: |
-            tests/wpt-results/wpt-results.log
-            tests/wpt-results/wpt-summary.txt
-            tests/wpt-results/wpt-root-cause-analysis.txt
-            tests/wpt-results/wpt-results.json
-            tests/wpt-results/wpt-triage-summary.md
-
-  # ── Manual single-subset run ─────────────────────────────────────────────
-  manual:
-    name: WPT manual subset
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Run WPT tests
-        id: wpt
-        run: |
-          ARGS=()
-          if [ -n "${{ github.event.inputs.subset }}" ]; then
-            ARGS+=(--subset "${{ github.event.inputs.subset }}")
+          if [ "$RERUN_FAILED" = "true" ]; then
+            # Incremental: rerun only previously-failed tests, reusing cached refs.
+            ARGS+=(--rerun-json "$FAILED_TESTS_FILE" --skip-reference-generation)
           fi
           EXIT=0
           bash scripts/run-wpt-tests.sh "${ARGS[@]}" || EXIT=$?
           echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
+          echo "Shard ${{ matrix.shard-index }} finished (exit $EXIT)."
 
-      - name: Print summary
+      - name: Collect shard result
         if: always()
         run: |
-          SUMMARY="tests/wpt-results/wpt-summary.txt"
+          mkdir -p shard-out
+          cp "$RESULTS_DIR/wpt-results.json" "shard-out/wpt-shard-${{ matrix.shard-index }}.json" 2>/dev/null || true
+          cp "$RESULTS_DIR/wpt-results.log"  "shard-out/wpt-shard-${{ matrix.shard-index }}.log"  2>/dev/null || true
+
+      - name: Shard step summary
+        if: always()
+        run: |
+          SUMMARY="$RESULTS_DIR/wpt-summary.txt"
           if [ -f "$SUMMARY" ]; then
-            echo "### WPT Test Summary" >> "$GITHUB_STEP_SUMMARY"
+            echo "### WPT shard ${{ matrix.shard-index }}/${SHARD_COUNT}" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
             cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
-            cat "$SUMMARY"
-          else
-            echo "No summary file found."
-          fi
-
-          ANALYSIS="tests/wpt-results/wpt-root-cause-analysis.txt"
-          if [ -f "$ANALYSIS" ]; then
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "### Root Cause Analysis" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            cat "$ANALYSIS" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            echo ""
-            echo "--- Root Cause Analysis ---"
-            cat "$ANALYSIS"
-          fi
-
-          TRIAGE="tests/wpt-results/wpt-triage-summary.md"
-          if [ -f "$TRIAGE" ]; then
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            cat "$TRIAGE" >> "$GITHUB_STEP_SUMMARY"
-            echo ""
-            echo "--- Triage Summary ---"
-            cat "$TRIAGE"
           fi
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: wpt-results
-          path: |
-            tests/wpt-results/wpt-results.log
-            tests/wpt-results/wpt-summary.txt
-            tests/wpt-results/wpt-root-cause-analysis.txt
-            tests/wpt-results/wpt-results.json
-            tests/wpt-results/wpt-triage-summary.md
+          name: wpt-shard-${{ matrix.shard-index }}
+          path: shard-out
 
-      - name: Check test result
+  # ── Merge shard results; file an issue when there are failures ───────────
+  report:
+    needs: run
+    if: always() && needs.run.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Download shard results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wpt-shard-*
+          path: shard-results
+          merge-multiple: true
+
+      - name: Merge shard results
+        id: merge
+        shell: bash
+        env:
+          WPT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ISSUE_TOKEN: ${{ secrets.ISSUE_TOKEN }}
+        run: |
+          python scripts/merge-wpt-shards.py \
+            --shard-dir shard-results \
+            --merged-json wpt-merged/wpt-results.json \
+            --issue-md wpt-merged/issue.md \
+            --github-output "$GITHUB_OUTPUT"
+          if [ -n "${ISSUE_TOKEN:-}" ]; then
+            echo "issue_token_available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "issue_token_available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish merged summary
         if: always()
         run: |
-          EXIT="${{ steps.wpt.outputs.exit_code }}"
-          if [ "$EXIT" != "0" ]; then
-            echo "::error::WPT tests failed (exit code $EXIT). See wpt-results.log for details."
-            exit 1
+          if [ -f wpt-merged/issue.md ]; then
+            cat wpt-merged/issue.md >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: wpt-merged
+          path: wpt-merged
+
+      - name: Report missing ISSUE_TOKEN
+        if: github.event_name == 'schedule' && steps.merge.outputs.create_issue == 'true' && steps.merge.outputs.issue_token_available != 'true'
+        run: |
+          {
+            echo "### WPT issue creation"
+            echo "- Failures were found, but \`ISSUE_TOKEN\` is not configured, so no issue was filed."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create GitHub issue for failures
+        if: github.event_name == 'schedule' && steps.merge.outputs.create_issue == 'true' && steps.merge.outputs.issue_token_available == 'true'
+        uses: actions/github-script@v7
+        env:
+          FAILED_COUNT: ${{ steps.merge.outputs.failed_count }}
+        with:
+          github-token: ${{ secrets.ISSUE_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('wpt-merged/issue.md', 'utf8').trim();
+            const today = new Date().toISOString().slice(0, 10);
+            const title = `WPT scheduled run: ${process.env.FAILED_COUNT} failing test(s) (${today})`;
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+            });
+            core.info(`Created issue #${issue.data.number}: ${issue.data.html_url}`);
+
+  # ── Persist the failing-test manifest for incremental reruns ─────────────
+  persist-failed:
+    needs: run
+    # Only the scheduled full-suite run maintains the canonical manifest; manual
+    # subset/shard runs would persist a narrower set and shrink it incorrectly.
+    if: always() && github.event_name == 'schedule' && needs.run.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Download shard results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wpt-shard-*
+          path: shard-results
+          merge-multiple: true
+
+      - name: Build failed-tests manifest
+        run: |
+          python scripts/merge-wpt-shards.py \
+            --shard-dir shard-results \
+            --merged-json "$FAILED_TESTS_FILE"
+
+      - name: Commit manifest
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- "$FAILED_TESTS_FILE"; then
+            echo "No manifest changes to commit."
+            exit 0
+          fi
+          git add "$FAILED_TESTS_FILE"
+          git commit -m "ci: update WPT failed-tests manifest [skip ci]"
+          git push origin "HEAD:$BRANCH_NAME"

--- a/scripts/generate-wpt-references.js
+++ b/scripts/generate-wpt-references.js
@@ -29,6 +29,27 @@ const TEST_EXTENSIONS = new Set(['.html', '.htm', '.xhtml']);
 const VIEWPORT = { width: 1024, height: 768 };
 const PAGE_LOAD_TIMEOUT = 10_000;   // ms — max time to wait for page load
 const DEFAULT_CONCURRENCY = 8;
+const ALL_SHARDS = -1;              // --shard-index sentinel meaning "all shards"
+
+/**
+ * Deterministic shard index in [0, shardCount) for a forward-slash relative
+ * path, using a 32-bit FNV-1a hash of its UTF-8 bytes.
+ *
+ * This MUST stay byte-for-byte identical to WptTestRunner.GetShardIndex in
+ * src/Broiler.Wpt/WptTestRunner.cs: the C# runner shards the test set the same
+ * way, so shard N here generates references for exactly the tests shard N runs
+ * there. Drift between the two would silently leave tests without references.
+ */
+function shardIndexForPath(relativePath, shardCount) {
+    let hash = 2166136261;            // FNV offset basis (unsigned 32-bit)
+    const bytes = Buffer.from(relativePath, 'utf8');
+    for (const byte of bytes) {
+        hash ^= byte;
+        // Math.imul performs the multiply in 32-bit space; >>> 0 keeps it unsigned.
+        hash = Math.imul(hash, 16777619) >>> 0;
+    }
+    return hash % shardCount;
+}
 
 /**
  * WPT crashtests (filename ending in `-crash.{html,htm,xhtml}`) are security
@@ -76,12 +97,18 @@ function ensureDir(filePath) {
     let outputDir = null;
     let baseDir = null;
     let concurrency = DEFAULT_CONCURRENCY;
+    let shardCount = 1;
+    let shardIndex = ALL_SHARDS;
 
     for (let i = 0; i < args.length; i++) {
         if (args[i] === '--concurrency' && i + 1 < args.length) {
             concurrency = parseInt(args[++i], 10) || DEFAULT_CONCURRENCY;
         } else if (args[i] === '--base-dir' && i + 1 < args.length) {
             baseDir = args[++i];
+        } else if (args[i] === '--shard-count' && i + 1 < args.length) {
+            shardCount = parseInt(args[++i], 10);
+        } else if (args[i] === '--shard-index' && i + 1 < args.length) {
+            shardIndex = parseInt(args[++i], 10);
         } else if (!testDir) {
             testDir = args[i];
         } else if (!outputDir) {
@@ -90,7 +117,16 @@ function ensureDir(filePath) {
     }
 
     if (!testDir || !outputDir) {
-        console.error('Usage: node generate-wpt-references.js <test-dir> <output-dir> [--concurrency N] [--base-dir <dir>]');
+        console.error('Usage: node generate-wpt-references.js <test-dir> <output-dir> [--concurrency N] [--base-dir <dir>] [--shard-count N --shard-index I]');
+        process.exit(1);
+    }
+
+    if (!Number.isInteger(shardCount) || shardCount < 1) {
+        console.error(`Error: --shard-count must be a positive integer (got ${shardCount}).`);
+        process.exit(1);
+    }
+    if (!Number.isInteger(shardIndex) || (shardIndex !== ALL_SHARDS && (shardIndex < 0 || shardIndex >= shardCount))) {
+        console.error(`Error: --shard-index must be ${ALL_SHARDS} (all) or between 0 and ${shardCount - 1} (got ${shardIndex}).`);
         process.exit(1);
     }
 
@@ -108,8 +144,19 @@ function ensureDir(filePath) {
     }
 
     console.log(`Discovering test files in: ${testDir}`);
-    const testFiles = discoverTests(testDir);
+    let testFiles = discoverTests(testDir);
     console.log(`Found ${testFiles.length} test files`);
+
+    // When sharding, keep only the files assigned to this shard by the same
+    // FNV-1a(relative-path) % shardCount rule the C# runner uses, so this shard
+    // generates references for exactly the tests it will later execute.
+    if (shardIndex !== ALL_SHARDS && shardCount > 1) {
+        testFiles = testFiles.filter((testFile) => {
+            const relative = path.relative(baseDir, testFile).split(path.sep).join('/');
+            return shardIndexForPath(relative, shardCount) === shardIndex;
+        });
+        console.log(`Shard ${shardIndex + 1}/${shardCount}: ${testFiles.length} test files in this shard`);
+    }
 
     if (testFiles.length === 0) {
         console.log('Nothing to do.');

--- a/scripts/merge-wpt-shards.py
+++ b/scripts/merge-wpt-shards.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Merge per-shard Broiler.Wpt JSON reports into a single view.
+
+The sharded WPT workflow runs each shard as an independent job that emits its
+own ``wpt-results.json``. This script combines those shard reports to produce:
+
+* ``--merged-json``  — aggregate summary plus the union of every shard's
+  *failing* results, shaped so the C# runner's ``--rerun-json`` can consume it
+  directly (top-level ``results`` array with ``relativeTestPath`` / ``passed`` /
+  ``skipped`` / ``category``). This doubles as the persisted "failed tests"
+  manifest that drives incremental reruns.
+* ``--issue-md``     — a Markdown body summarising totals and the top failing
+  directories / categories, suitable for posting as a GitHub issue.
+
+When ``--github-output`` is given (the ``$GITHUB_OUTPUT`` file), the script also
+writes ``failed_count``, ``total_count`` and ``create_issue`` step outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from pathlib import Path
+
+TOP_BUCKET_LIMIT = 15
+
+
+def _bucket_directory(relative_path: str) -> str:
+    """Group a test by its first two path segments (e.g. ``css/css-flexbox``)."""
+    parts = [segment for segment in relative_path.split("/") if segment]
+    if len(parts) <= 1:
+        return parts[0] if parts else "."
+    return "/".join(parts[:2])
+
+
+def _iter_shard_reports(shard_dir: Path):
+    # Recurse so it does not matter whether artifacts were downloaded flat or
+    # into per-shard subdirectories.
+    for path in sorted(shard_dir.rglob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        # Only consider documents that look like a Broiler.Wpt report.
+        if isinstance(data, dict) and "summary" in data and "results" in data:
+            yield path, data
+
+
+def merge(shard_dir: Path) -> dict:
+    passed = failed = skipped = total = 0
+    shard_count = 0
+    failures: list[dict] = []
+    seen_failures: set[str] = set()
+    directory_counter: Counter[str] = Counter()
+    category_counter: Counter[str] = Counter()
+
+    for _path, report in _iter_shard_reports(shard_dir):
+        shard_count += 1
+        summary = report.get("summary", {})
+        passed += int(summary.get("passed", 0) or 0)
+        failed += int(summary.get("failed", 0) or 0)
+        skipped += int(summary.get("skipped", 0) or 0)
+        total += int(summary.get("total", 0) or 0)
+
+        for result in report.get("results", []):
+            if not isinstance(result, dict):
+                continue
+            if result.get("passed") or result.get("skipped"):
+                continue
+
+            relative_path = result.get("relativeTestPath") or result.get("testPath") or ""
+            if not relative_path or relative_path in seen_failures:
+                continue
+            seen_failures.add(relative_path)
+
+            category = result.get("category") or "Unknown"
+            failures.append(
+                {
+                    "relativeTestPath": relative_path,
+                    "passed": False,
+                    "skipped": False,
+                    "category": category,
+                }
+            )
+            directory_counter[_bucket_directory(relative_path)] += 1
+            category_counter[category] += 1
+
+    failures.sort(key=lambda item: item["relativeTestPath"])
+
+    return {
+        "summary": {
+            "passed": passed,
+            "failed": failed,
+            "skipped": skipped,
+            "total": total,
+        },
+        "shardCount": shard_count,
+        "topFailingDirectories": directory_counter.most_common(TOP_BUCKET_LIMIT),
+        "failuresByCategory": category_counter.most_common(),
+        "results": failures,
+    }
+
+
+def render_issue_markdown(merged: dict, run_url: str | None) -> str:
+    summary = merged["summary"]
+    lines = [
+        "## WPT scheduled run — failing tests",
+        "",
+        f"- Shards merged: {merged['shardCount']}",
+        f"- Total: {summary['total']}",
+        f"- Passed: {summary['passed']}",
+        f"- Failed: {summary['failed']}",
+        f"- Skipped: {summary['skipped']}",
+        "",
+        "### Failures by category",
+        "",
+    ]
+    if merged["failuresByCategory"]:
+        lines += [f"- `{category}` — {count}" for category, count in merged["failuresByCategory"]]
+    else:
+        lines.append("- None")
+
+    lines += ["", "### Top failing directories", ""]
+    if merged["topFailingDirectories"]:
+        lines += [f"- `{directory}` — {count} failure(s)" for directory, count in merged["topFailingDirectories"]]
+    else:
+        lines.append("- None")
+
+    lines += [
+        "",
+        "### CI metadata",
+        f"- Workflow run: {run_url}" if run_url else "- Workflow run: (unknown)",
+        "- Artifact: `wpt-merged`",
+        "",
+        "_Auto-generated by `.github/workflows/wpt-tests.yml`. The full per-shard"
+        " logs and the rerun manifest are attached to the run artifacts._",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--shard-dir", required=True, type=Path, help="Directory containing per-shard JSON reports")
+    parser.add_argument("--merged-json", type=Path, help="Where to write the merged report / rerun manifest")
+    parser.add_argument("--issue-md", type=Path, help="Where to write the Markdown issue body")
+    parser.add_argument("--run-url", default=os.environ.get("WPT_RUN_URL"), help="Workflow run URL for the issue footer")
+    parser.add_argument("--github-output", type=Path, help="Path to $GITHUB_OUTPUT for step outputs")
+    args = parser.parse_args()
+
+    merged = merge(args.shard_dir)
+
+    if args.merged_json:
+        args.merged_json.parent.mkdir(parents=True, exist_ok=True)
+        args.merged_json.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
+
+    if args.issue_md:
+        args.issue_md.parent.mkdir(parents=True, exist_ok=True)
+        args.issue_md.write_text(render_issue_markdown(merged, args.run_url), encoding="utf-8")
+
+    failed = merged["summary"]["failed"]
+    total = merged["summary"]["total"]
+    print(f"Merged {merged['shardCount']} shard(s): {merged['summary']['passed']} passed, "
+          f"{failed} failed, {merged['summary']['skipped']} skipped, {total} total.")
+
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as handle:
+            handle.write(f"failed_count={failed}\n")
+            handle.write(f"total_count={total}\n")
+            handle.write(f"create_issue={'true' if failed > 0 else 'false'}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-wpt-tests.sh
+++ b/scripts/run-wpt-tests.sh
@@ -27,6 +27,11 @@ OUTPUT_DIR="$REPO_ROOT/tests/wpt-results"
 WPT_DIR=""
 SHALLOW=true
 SUBSET=""
+SHARD_INDEX=-1
+SHARD_COUNT=1
+RERUN_JSON=""
+RERUN_KIND=""
+SKIP_REFERENCE_GENERATION=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -47,16 +52,41 @@ while [[ $# -gt 0 ]]; do
             SUBSET="$2"
             shift 2
             ;;
+        --shard-index)
+            SHARD_INDEX="$2"
+            shift 2
+            ;;
+        --shard-count)
+            SHARD_COUNT="$2"
+            shift 2
+            ;;
+        --rerun-json)
+            RERUN_JSON="$2"
+            shift 2
+            ;;
+        --rerun-kind)
+            RERUN_KIND="$2"
+            shift 2
+            ;;
+        --skip-reference-generation)
+            SKIP_REFERENCE_GENERATION=true
+            shift
+            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo ""
             echo "Options:"
-            echo "  --output-dir <dir>   Directory for results (default: tests/wpt-results)"
-            echo "  --wpt-dir <dir>      Use an existing WPT checkout instead of cloning"
-            echo "  --shallow            Shallow-clone only (depth 1, faster; default)"
-            echo "  --subset <patterns>  Semicolon-separated sub-path patterns with wildcards"
-            echo "                       (e.g. \"css/CSS2;css/css-*\" or \"css/css-flexbox\")"
-            echo "  -h, --help           Show this help message"
+            echo "  --output-dir <dir>            Directory for results (default: tests/wpt-results)"
+            echo "  --wpt-dir <dir>               Use an existing WPT checkout instead of cloning"
+            echo "  --shallow                     Shallow-clone only (depth 1, faster; default)"
+            echo "  --subset <patterns>           Semicolon-separated sub-path patterns with wildcards"
+            echo "                                (e.g. \"css/CSS2;css/css-*\" or \"css/css-flexbox\")"
+            echo "  --shard-count <N>             Split the suite into N deterministic shards (default: 1)"
+            echo "  --shard-index <I>             Run only shard I (0-based), or -1 for all (default: -1)"
+            echo "  --rerun-json <path>           Rerun only tests from a prior JSON report (incremental)"
+            echo "  --rerun-kind <failures|timeouts>  Which prior results to rerun (default: failures)"
+            echo "  --skip-reference-generation   Reuse already-generated/cached reference images"
+            echo "  -h, --help                    Show this help message"
             exit 0
             ;;
         *)
@@ -65,6 +95,21 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# Shard arguments shared by the reference generator and the C# runner. Both
+# implement the same FNV-1a(relative-path) % shard-count assignment, so a shard
+# generates references for exactly the tests it runs.
+SHARD_ARGS=()
+if [[ "$SHARD_INDEX" != "-1" || "$SHARD_COUNT" != "1" ]]; then
+    SHARD_ARGS=(--shard-count "$SHARD_COUNT" --shard-index "$SHARD_INDEX")
+fi
+
+# Incremental rerun arguments for the C# runner.
+RERUN_ARGS=()
+if [[ -n "$RERUN_JSON" ]]; then
+    RERUN_ARGS=(--rerun-json "$RERUN_JSON")
+    [[ -n "$RERUN_KIND" ]] && RERUN_ARGS+=(--rerun-kind "$RERUN_KIND")
+fi
 
 mkdir -p "$OUTPUT_DIR"
 
@@ -119,7 +164,9 @@ REFERENCE_DIR="$REPO_ROOT/tests/wpt/references"
 echo "--- Step 2: Generating reference images with Chromium (Playwright) ---"
 
 # Install Playwright dependencies if needed.
-if command -v npx &>/dev/null; then
+if [[ "$SKIP_REFERENCE_GENERATION" == "true" ]]; then
+    echo "  ⏭ Skipping reference generation (--skip-reference-generation); reusing cached/existing references."
+elif command -v npx &>/dev/null; then
     pushd "$REPO_ROOT/tests/wpt" > /dev/null
     if [[ -f package-lock.json ]]; then
         npm ci 2>&1 | tail -10
@@ -152,7 +199,8 @@ if command -v npx &>/dev/null; then
                     echo "  Generating refs for: ${MATCH_DIR#"$WPT_DIR/"}"
                     if ! NODE_PATH="$REPO_ROOT/tests/wpt/node_modules" \
                         node "$SCRIPT_DIR/generate-wpt-references.js" \
-                        "$MATCH_DIR" "$REFERENCE_DIR" --concurrency 8 --base-dir "$WPT_DIR" 2>&1; then
+                        "$MATCH_DIR" "$REFERENCE_DIR" --concurrency 8 --base-dir "$WPT_DIR" \
+                        "${SHARD_ARGS[@]}" 2>&1; then
                         echo "  ✗ Reference generation failed for $MATCH_DIR" >&2
                         REF_GEN_OK=false
                     fi
@@ -166,7 +214,7 @@ if command -v npx &>/dev/null; then
     else
         if ! NODE_PATH="$REPO_ROOT/tests/wpt/node_modules" \
             node "$SCRIPT_DIR/generate-wpt-references.js" \
-            "$TEST_DIR" "$REFERENCE_DIR" --concurrency 8 2>&1; then
+            "$TEST_DIR" "$REFERENCE_DIR" --concurrency 8 "${SHARD_ARGS[@]}" 2>&1; then
             REF_GEN_OK=false
         fi
     fi
@@ -215,7 +263,8 @@ REF_ARGS+=(--markdown-output "$MARKDOWN_REPORT")
 set +e
 dotnet run --project "$REPO_ROOT/src/Broiler.Wpt" \
     --configuration Release --no-build -- \
-    --wpt-dir "$TEST_DIR" "${REF_ARGS[@]}" "${SUBSET_ARGS[@]}" 2>&1 | tee "$LOGFILE"
+    --wpt-dir "$TEST_DIR" "${REF_ARGS[@]}" "${SUBSET_ARGS[@]}" \
+    "${SHARD_ARGS[@]}" "${RERUN_ARGS[@]}" 2>&1 | tee "$LOGFILE"
 WPT_EXIT=$?
 set -e
 

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -10504,4 +10504,74 @@ div {{ width: 256px; height: 768px; }}
         Assert.True(result.MatchPercent >= 90,
             $"clip-text-text-decorations: Match={result.MatchPercent:F1}% Message={result.Message}");
     }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(1)]
+    public void ApplyShard_Returns_All_Tests_When_Not_Sharding(int shardIndex)
+    {
+        var tests = Enumerable.Range(0, 50)
+            .Select(i => Path.Combine(_tempDir, $"dir{i % 5}", $"test{i}.html"))
+            .ToList();
+
+        // shardCount 1 (or shardIndex -1) disables filtering entirely.
+        var result = WptTestRunner.ApplyShard(tests, _tempDir, shardCount: 1, shardIndex).ToList();
+
+        Assert.Equal(tests, result);
+    }
+
+    [Fact]
+    public void ApplyShard_Partitions_Tests_Into_Disjoint_Shards_Covering_The_Whole_Set()
+    {
+        const int shardCount = 8;
+        var tests = Enumerable.Range(0, 500)
+            .Select(i => Path.Combine(_tempDir, $"css/dir{i % 13}", $"test-{i}.html"))
+            .ToList();
+
+        var union = new List<string>();
+        for (int shardIndex = 0; shardIndex < shardCount; shardIndex++)
+        {
+            var shard = WptTestRunner.ApplyShard(tests, _tempDir, shardCount, shardIndex).ToList();
+            union.AddRange(shard);
+        }
+
+        // Every test lands in exactly one shard: the disjoint shards reassemble
+        // the original set with no duplicates and no omissions.
+        Assert.Equal(tests.Count, union.Count);
+        Assert.Equal(new HashSet<string>(tests), new HashSet<string>(union));
+    }
+
+    [Fact]
+    public void ApplyShard_Is_Stable_For_The_Same_Relative_Path()
+    {
+        var tests = Enumerable.Range(0, 100)
+            .Select(i => Path.Combine(_tempDir, "css", $"test-{i}.html"))
+            .ToList();
+
+        var first = WptTestRunner.ApplyShard(tests, _tempDir, shardCount: 4, shardIndex: 2).ToList();
+        var second = WptTestRunner.ApplyShard(tests, _tempDir, shardCount: 4, shardIndex: 2).ToList();
+
+        Assert.Equal(first, second);
+    }
+
+    [Theory]
+    [InlineData("css/CSS2/foo.html", 8)]
+    [InlineData("dom/nodes/bar.xhtml", 8)]
+    [InlineData("html/syntax/baz.htm", 16)]
+    public void GetShardIndex_Is_Within_Range(string relativePath, int shardCount)
+    {
+        var shard = WptTestRunner.GetShardIndex(relativePath, shardCount);
+
+        Assert.InRange(shard, 0, shardCount - 1);
+    }
+
+    [Fact]
+    public void GetShardIndex_Matches_The_FNV1a_Reference_Value()
+    {
+        // Pins the FNV-1a algorithm so it cannot silently drift from the
+        // identical implementation in scripts/generate-wpt-references.js, which
+        // must assign the same shard to keep reference generation and execution
+        // in lock-step. FNV-1a/32 of "css/CSS2/foo.html" is 0x418AB4DC.
+        Assert.Equal((int)(0x418AB4DCu % 8u), WptTestRunner.GetShardIndex("css/CSS2/foo.html", 8));
+    }
 }

--- a/src/Broiler.Wpt/Program.cs
+++ b/src/Broiler.Wpt/Program.cs
@@ -53,6 +53,8 @@ public class Program
         string? rerunJsonPath = null;
         RerunSelectionKind rerunSelectionKind = RerunSelectionKind.Failures;
         double? timeoutSeconds = null;
+        int shardCount = 1;
+        int shardIndex = WptTestRunner.AllShards;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -93,6 +95,22 @@ public class Program
 
                     timeoutSeconds = parsedTimeoutSeconds;
                     break;
+                case "--shard-count" when i + 1 < args.Length:
+                    if (!int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out shardCount) || shardCount < 1)
+                    {
+                        Console.Error.WriteLine("Error: '--shard-count' must be a positive integer.");
+                        return 1;
+                    }
+
+                    break;
+                case "--shard-index" when i + 1 < args.Length:
+                    if (!int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out shardIndex) || shardIndex < WptTestRunner.AllShards)
+                    {
+                        Console.Error.WriteLine($"Error: '--shard-index' must be {WptTestRunner.AllShards} (all shards) or a non-negative integer.");
+                        return 1;
+                    }
+
+                    break;
                 case "--wpt-dir":
                 case "--reference-dir":
                 case "--json-output":
@@ -101,6 +119,8 @@ public class Program
                 case "--rerun-json":
                 case "--rerun-kind":
                 case "--timeout":
+                case "--shard-count":
+                case "--shard-index":
                     Console.Error.WriteLine($"Error: '{args[i]}' requires a value.");
                     PrintUsage();
                     return 1;
@@ -145,11 +165,19 @@ public class Program
             return 1;
         }
 
+        if (shardIndex != WptTestRunner.AllShards && shardIndex >= shardCount)
+        {
+            Console.Error.WriteLine($"Error: '--shard-index' ({shardIndex}) must be less than '--shard-count' ({shardCount}).");
+            return 1;
+        }
+
         Console.WriteLine($"WPT directory : {Path.GetFullPath(wptPath)}");
         Console.WriteLine($"Reference dir : {Path.GetFullPath(referenceDir)}");
         Console.WriteLine($"Timeout       : {runTestTimeout.TotalSeconds:0.###} second(s)");
         if (!string.IsNullOrWhiteSpace(subset))
             Console.WriteLine($"Subset        : {subset}");
+        if (shardIndex != WptTestRunner.AllShards)
+            Console.WriteLine($"Shard         : {shardIndex + 1}/{shardCount}");
         if (!string.IsNullOrWhiteSpace(rerunJsonPath))
         {
             Console.WriteLine($"Rerun JSON    : {Path.GetFullPath(rerunJsonPath)}");
@@ -170,6 +198,15 @@ public class Program
 
             discoveredTests = discoveredTests
                 .Where(testPath => rerunTests.Contains(Path.GetFullPath(testPath)))
+                .ToList();
+        }
+
+        // Apply the shard filter last so each shard runs a deterministic,
+        // disjoint slice of the (optionally subset/rerun-filtered) test set.
+        if (shardIndex != WptTestRunner.AllShards && shardCount > 1)
+        {
+            discoveredTests = WptTestRunner
+                .ApplyShard(discoveredTests, wptPath, shardCount, shardIndex)
                 .ToList();
         }
 
@@ -312,7 +349,7 @@ public class Program
 
         if (jsonOutputPath is not null)
         {
-            WriteJsonReport(allResults, jsonOutputPath, passed, failed, skipped, wptPath);
+            WriteJsonReport(allResults, jsonOutputPath, passed, failed, skipped, wptPath, shardCount, shardIndex);
             Console.WriteLine();
             Console.WriteLine($"JSON report written to: {jsonOutputPath}");
         }
@@ -544,7 +581,9 @@ public class Program
         int passed,
         int failed,
         int skipped,
-        string wptPath)
+        string wptPath,
+        int shardCount = 1,
+        int shardIndex = WptTestRunner.AllShards)
     {
         var dir = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(dir))
@@ -572,6 +611,11 @@ public class Program
                 ["failed"] = failed,
                 ["skipped"] = skipped,
                 ["total"] = allResults.Count,
+            },
+            ["shard"] = new Dictionary<string, object>
+            {
+                ["index"] = shardIndex,
+                ["count"] = shardCount,
             },
             ["triage"] = new Dictionary<string, object?>
             {
@@ -1202,6 +1246,8 @@ public class Program
         Console.WriteLine("                             Example: \"css/CSS2;css/css-*\"");
         Console.WriteLine("  --rerun-json <PATH>        Rerun only the previous failure/timeout set from a JSON report");
         Console.WriteLine("  --rerun-kind <KIND>        Filter reruns to 'failures' (default) or 'timeouts'");
+        Console.WriteLine("  --shard-count <N>          Split discovered tests into N deterministic shards (default: 1)");
+        Console.WriteLine("  --shard-index <I>          Run only shard I (0-based), or -1 for all shards (default: -1)");
         Console.WriteLine("  --timeout <SECS>           Per-test timeout in seconds (default: 30, env:");
         Console.WriteLine($"                             {RunTestTimeoutEnvironmentVariable})");
         Console.WriteLine("  --json-output <PATH>       Write structured JSON report to the given path");

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -552,6 +552,69 @@ internal sealed class WptTestRunner
     }
 
     /// <summary>
+    /// Sentinel <c>--shard-index</c> value meaning "run every shard" (no
+    /// sharding filter is applied).
+    /// </summary>
+    internal const int AllShards = -1;
+
+    /// <summary>
+    /// Filters <paramref name="tests"/> down to the single shard identified by
+    /// <paramref name="shardIndex"/> out of <paramref name="shardCount"/>.
+    /// Shard assignment is a content-independent FNV-1a hash of each test's
+    /// path relative to <paramref name="wptRoot"/> (forward-slash separators),
+    /// so it is stable across runs and — crucially — reproducible byte-for-byte
+    /// by the JavaScript reference generator, which shards the same way. That
+    /// lets shard <c>N</c> generate references for exactly the tests shard
+    /// <c>N</c> later runs. When <paramref name="shardIndex"/> is
+    /// <see cref="AllShards"/> the input is returned unchanged.
+    /// </summary>
+    internal static IEnumerable<string> ApplyShard(
+        IEnumerable<string> tests,
+        string wptRoot,
+        int shardCount,
+        int shardIndex)
+    {
+        if (shardCount <= 0)
+            throw new ArgumentOutOfRangeException(nameof(shardCount), shardCount, "shardCount must be greater than 0.");
+
+        if (shardIndex == AllShards || shardCount == 1)
+            return tests;
+
+        if (shardIndex < 0 || shardIndex >= shardCount)
+            throw new ArgumentOutOfRangeException(
+                nameof(shardIndex),
+                shardIndex,
+                $"shardIndex must be {AllShards} or between 0 and {shardCount - 1}.");
+
+        return tests.Where(testPath =>
+        {
+            var relativePath = Path.GetRelativePath(wptRoot, testPath).Replace('\\', '/');
+            return GetShardIndex(relativePath, shardCount) == shardIndex;
+        });
+    }
+
+    /// <summary>
+    /// Returns the deterministic shard index in <c>[0, shardCount)</c> for a
+    /// forward-slash relative path, using a 32-bit FNV-1a hash of its UTF-8
+    /// bytes. This algorithm is intentionally simple so the reference generator
+    /// (<c>scripts/generate-wpt-references.js</c>) can reproduce it exactly.
+    /// </summary>
+    internal static int GetShardIndex(string relativePath, int shardCount)
+    {
+        const uint fnvOffsetBasis = 2166136261;
+        const uint fnvPrime = 16777619;
+
+        uint hash = fnvOffsetBasis;
+        foreach (var b in System.Text.Encoding.UTF8.GetBytes(relativePath))
+        {
+            hash ^= b;
+            hash *= fnvPrime;
+        }
+
+        return (int)(hash % (uint)shardCount);
+    }
+
+    /// <summary>
     /// Parses a semicolon-separated subset string into individual patterns,
     /// trimming whitespace and discarding empty entries.
     /// </summary>


### PR DESCRIPTION
Advances the WPT integration to match the feature set of Broiler.JS's `test262.yml`. The full ~60K-test suite now runs as a **sharded matrix** (replacing the curated segments) with **incremental reruns** and **automatic GitHub issue filing**.

> **Stacked on #1093.** Base is set to that branch so the diff here is the sharding delta only; GitHub will retarget this PR to `main` automatically once #1093 merges. It shares `scripts/generate-wpt-references.js` with #1093, so please merge #1093 first.

## What changed

**Sharding (8 shards, full suite)**
- `--shard-count`/`--shard-index` added to the C# runner ([Program.cs](src/Broiler.Wpt/Program.cs), [WptTestRunner.cs](src/Broiler.Wpt/WptTestRunner.cs) — `ApplyShard`/`GetShardIndex`) and to [generate-wpt-references.js](scripts/generate-wpt-references.js).
- Shard assignment is **FNV-1a(relative-path) % count**, implemented identically in C# and JS so a shard generates references for exactly the tests it runs. Parity verified across C#/JS/Python; distribution is even (~1/8 each). A unit test pins the FNV value so the two implementations can't silently drift.
- [run-wpt-tests.sh](scripts/run-wpt-tests.sh) forwards shard flags to both the reference generator and the runner; the JSON report records shard index/count.

**Incremental**
- The runner already had `--rerun-json`. Wired it through `run-wpt-tests.sh` (plus a new `--skip-reference-generation`). The workflow's `rerun_failed_only` input reruns only the committed `tests/wpt-baseline/failed-tests.json` (sharded, reusing cached references); the weekly run regenerates the manifest via `persist-failed`.

**Auto-issue**
- New [merge-wpt-shards.py](scripts/merge-wpt-shards.py) aggregates per-shard JSON reports into a merged report + issue body + rerun manifest (dedup, skip-exclusion). Tested against synthetic shard reports.
- Rewritten [wpt-tests.yml](.github/workflows/wpt-tests.yml): `plan → prepare → run` (8-shard matrix) `→ report` (merge + file **one issue on any scheduled run with failures**, gated on `ISSUE_TOKEN`) + `persist-failed` (commit the manifest).

## "Syntax error" question
There was none — the original workflow YAML, both shell scripts, and the ref-gen JS all validate clean. The failures in the CI log were runtime: the ref-generator crash cascade (fixed in #1093) and the full unsharded suite exceeding the 360-min budget (fixed by sharding here).

## Reviewer notes / caveats
- **C# build/tests not run in my sandbox.** `Broiler.Wpt` currently fails to compile on a *pre-existing, unrelated* error — `using Broiler.HTML.Core.Core.Entities;` resolves to a namespace absent from the checked-out `Broiler.HTML` submodule (stale nested submodule). My edits are isolated; please run `dotnet test src/Broiler.Wpt.Tests` locally to confirm the sharding tests.
- **Dropped the per-segment regression gate** (it assumed curated segments). `check-wpt-regression.sh` is left intact for manual use. Happy to add a full-suite gate back into `report` if wanted.
- Cold-cache cost: the first scheduled run after a `CACHE_EPOCH` bump regenerates references for all 8 shards; subsequent runs hit the per-shard reference cache.

## Validation done here
- Workflow YAML parses (5 jobs); plan matrix logic checked for `-1` and single-shard.
- `merge-wpt-shards.py` byte-compiles and produces correct merged totals / rerun manifest on synthetic input.
- `bash -n` clean on `run-wpt-tests.sh`; `node --check` clean on the JS; FNV parity across three languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)