### PR TITLE
Phase 2: Broiler.App.Graphics — WPF-free Direct2D browser shell

### DIFF
--- a/Broiler.slnx
+++ b/Broiler.slnx
@@ -53,6 +53,7 @@
       <Build Solution="Debug|*" Project="false" />
     </Project>
     <Project Path="src/Broiler.App/Broiler.App.csproj" />
+    <Project Path="src/Broiler.App.Graphics/Broiler.App.Graphics.csproj" />
     <Project Path="src/Broiler.Cli.Tests/Broiler.Cli.Tests.csproj" />
     <Project Path="src/Broiler.Cli/Broiler.Cli.csproj" />
     <Project Path="src/Broiler.DevConsole.Tests/Broiler.DevConsole.Tests.csproj" />

--- a/docs/roadmap/public-preview-roadmap.md
+++ b/docs/roadmap/public-preview-roadmap.md
@@ -196,20 +196,48 @@ Strategy: **promote the `Broiler.HTML.Graphics.Win32.Demo` PoC into a real app
 project** (`Broiler.App.Graphics`) rather than mutating the WPF app in place.
 Keep the WPF app buildable until parity is reached, then switch the shipped artifact.
 
-| # | Task | Detail | Exit |
-|---|------|--------|------|
-| 2.1 | Scaffold `Broiler.App.Graphics` | New project deriving from `Direct2DWindow`, hosting `Broiler.HTML.Graphics.HtmlContainer`. Reuse the platform-neutral `RenderingPipeline.cs` / `PageLoader.cs` already in `Broiler.App/Rendering` (they are not WPF-coupled). | Window opens, renders a URL |
-| 2.2 | Navigation chrome | Address bar + Back/Forward/Refresh + favorites, built from `BEditControl`/`BButtonControl` or render-list-drawn UI. Port `FavoritesManager` (platform-neutral). | Can navigate by typing a URL |
-| 2.3 | Input translation | Map Win32 `WM_MOUSE*` / `WM_KEY*` / `WM_CHAR` / `WM_MOUSEWHEEL` → the HTML hit-test + DOM event model that WPF previously fed. Covers click, hover, scroll-wheel, keyboard. | Links clickable, hover works |
-| 2.4 | Scrolling & viewport | Manual scroll-offset state + scrollbar (WPF's `ScrollViewer` is gone). Re-layout/clip on `OnResized`. | Long pages scroll smoothly |
-| 2.5 | Text input & focus | Focus model + caret + text entry into form fields and the address bar (previously free via WPF `TextBox`). | Can fill a form field |
-| 2.6 | Animation loop | Replace `DispatcherTimer` with `SetTimer`/`WM_TIMER` + `InvalidateRect` driving the existing `CssAnimations` tick. | CSS animations run |
-| 2.7 | Dev console port | Re-host `DevConsolePanel` (currently a WPF `UserControl`) as a Graphics panel or a togglable overlay. | Console usable in new app |
-| 2.8 | Parity checklist & cutover | Side-by-side parity test (same URLs in WPF vs Graphics). Flip `dotnet run --project` default + README to the Graphics app; mark WPF app legacy. | Graphics app is the default |
+**Status: core shell implemented and running (2.1–2.4, 2.6 done; 2.5 partial; 2.7
+not started; 2.8 partial).** New project `src/Broiler.App.Graphics` (assembly
+`Broiler.Graphics.Browser`) builds and launches a Direct2D browser that renders
+URLs/local files, navigates, scrolls, and steps script-driven animations — no WPF.
+
+| # | Task | Status | Delivered / Notes | Exit |
+|---|------|--------|-------------------|------|
+| 2.1 | Scaffold `Broiler.App.Graphics` | ✅ Done | `BrowserWindow : Direct2DWindow` hosts `Broiler.HTML.Graphics.HtmlContainer`. Reuses the platform-neutral `RenderingPipeline.cs` / `PageLoader.cs` / `IPageLoader.cs` / `FavoritesManager.cs` from `Broiler.App` via linked `<Compile>` (no source duplication, WPF app untouched). `Program.cs` is the Win32 entry point. | Window opens, renders a URL ✅ |
+| 2.2 | Navigation chrome | ✅ Done | Toolbar (Back/Forward/Refresh, address `BEditControl`, ☆ favorite toggle, Go) + a favorites bar of `BButtonControl`s rebuilt from `FavoritesManager` (shares the same `favorites.json` as the WPF app). History stack with fragment-anchor resolution. | Can navigate by typing a URL ✅ |
+| 2.3 | Input translation | ✅ Done | **Extended `Broiler.Graphics`**: added `BPointerEventArgs`/`BMouseWheelEventArgs`/`BKeyEventArgs`/`BTextInputEventArgs` + virtual `OnPointer*`/`OnMouseWheel`/`OnKey*`/`OnTextInput` hooks on `BWindow`, wired in `Direct2DWindow`'s render-host window-proc (`WM_MOUSE*`/`WM_KEY*`/`WM_CHAR`/`WM_MOUSEWHEEL`, with screen→client + DIP conversion, mouse-leave tracking, focus-on-click). App maps these to `HtmlContainer.HandleMouse*`; link clicks drive navigation via the `LinkClicked` event. | Links clickable ✅ (hover re-render not wired) |
+| 2.4 | Scrolling & viewport | ✅ Done | Scroll-offset state via `HtmlContainer.ScrollOffset`; mouse-wheel + keyboard (arrows/PageUp-Down/Home/End) scrolling, clamped to content height (`ActualSize`). Layout cached; only the render list rebuilds on scroll. Re-layout on `OnResized` (verified repaint after resize). No visible scrollbar yet. | Long pages scroll smoothly ✅ |
+| 2.5 | Text input & focus | ◑ Partial | Address bar (native `BEditControl`) has full text entry + focus. In-page form-field text entry (`OnTextInput` → DOM) is **not** wired yet. | Address bar editable; form fields TODO |
+| 2.6 | Animation loop | ✅ Done | **Extended `Broiler.Graphics`**: `StartAnimationTimer`/`StopAnimationTimer` + `OnAnimationTick` (backed by `SetTimer`/`WM_TIMER`/`KillTimer` in `Direct2DWindow`). App steps `InteractiveSession` one batch/tick and re-renders. Verified with a `setInterval` counter running to completion. | Script animations run ✅ |
+| 2.7 | Dev console port | ☐ Not started | `DevConsolePanel` is still WPF-only; needs a Graphics panel/overlay over the platform-neutral `Broiler.DevConsole` backend. | Console usable in new app |
+| 2.8 | Parity checklist & cutover | ◑ Partial | Both shells build in the solution; WPF kept as fallback. README/default not yet flipped (Phase 3 §3.4). | Graphics app is the default |
+
+> **Rendering note (important):** the Graphics host renders reliably from
+> **serialized HTML** (`HtmlContainer.SetHtml`). The typed-document handoff
+> (`SetDocument(InteractiveSession.CurrentDocument())`, used by the WPF shell) lays
+> out **empty** in `Broiler.HTML.Graphics` — so the app uses `InteractiveSession`'s
+> serialized variants (`CurrentHtml()`, `Step()`) for both the initial paint and the
+> animation loop. Making the typed-document path render in the Graphics host is a
+> follow-up (it would avoid re-parsing HTML each animation frame).
+>
+> **Assembly-resolution note:** the HTML stack pulls in two physically distinct
+> builds of same-identity assemblies (e.g. `Broiler.Dom` is checked out under both
+> `Broiler.DOM` and the CSS submodule). MSBuild dedups them and drops the runtime
+> entry from `deps.json`, so the host won't probe for them even though the DLLs are
+> in the output. `Program.Main` installs an `AssemblyLoadContext.Resolving` fallback
+> that loads such assemblies from the app directory. The demo PoC dodges this only
+> because it never touches `Broiler.Dom`.
+>
+> **Sub-module note:** the input/timer additions to `Broiler.Graphics`
+> (`BWindow`, `Direct2DWindow`, new `BInputEvents.cs`) were applied to **both**
+> checkouts — top-level `Broiler.Graphics/` and the nested `Broiler.HTML/Broiler.Graphics/`
+> (the copy the HTML build graph actually compiles against).
 
 **Phase 2 exit**: `dotnet run` launches the Graphics browser; a user can browse a
 representative set of real sites (navigation, scroll, click, form input, JS) with
-no WPF dependency in the shipped path.
+no WPF dependency in the shipped path. *(Remaining for full exit: in-page form
+text input (2.5), dev-console port (2.7), README/default cutover (2.8), and ideally
+making the typed-document render path work to drop per-frame HTML re-parsing.)*
 
 ---
 

--- a/src/Broiler.App.Graphics/Broiler.App.Graphics.csproj
+++ b/src/Broiler.App.Graphics/Broiler.App.Graphics.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>Broiler.App.Graphics</RootNamespace>
+    <AssemblyName>Broiler.Graphics.Browser</AssemblyName>
+    <!-- Preview UI is built entirely on Broiler.Graphics (Win32 + Direct2D); no WPF. -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Broiler.HTML\Broiler.Graphics\Broiler.Graphics.Windows\Broiler.Graphics.Direct2D.csproj" />
+    <ProjectReference Include="..\..\Broiler.HTML\Source\Broiler.HTML.Graphics\Broiler.HTML.Graphics.csproj" />
+    <ProjectReference Include="..\..\Broiler.DOM\Broiler.Dom\Broiler.Dom.csproj" />
+    <!-- Meta-package includes Core + all satellite assemblies (Clr, Compiler, Modules, BuiltIns, Debugger) -->
+    <ProjectReference Include="..\..\Broiler.JS\Broiler.JS\Broiler.JavaScript.All\Broiler.JavaScript.All.csproj" />
+    <!-- Bridge component connecting HTML rendering with JavaScript execution -->
+    <ProjectReference Include="..\Broiler.HtmlBridge\Broiler.HtmlBridge.csproj" />
+  </ItemGroup>
+
+  <!-- Platform-neutral pieces shared with the WPF app (Broiler.App). Linked rather than
+       duplicated so both shells stay in lock-step until the WPF app is retired. -->
+  <ItemGroup>
+    <Compile Include="..\Broiler.App\Rendering\RenderingPipeline.cs" Link="Rendering\RenderingPipeline.cs" />
+    <Compile Include="..\Broiler.App\Rendering\PageLoader.cs" Link="Rendering\PageLoader.cs" />
+    <Compile Include="..\Broiler.App\Rendering\IPageLoader.cs" Link="Rendering\IPageLoader.cs" />
+    <Compile Include="..\Broiler.App\FavoritesManager.cs" Link="FavoritesManager.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/Broiler.App.Graphics/BrowserWindow.cs
+++ b/src/Broiler.App.Graphics/BrowserWindow.cs
@@ -1,0 +1,603 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.Versioning;
+using Broiler.App.Rendering;
+using Broiler.Graphics;
+using Broiler.Graphics.Windows;
+using Broiler.HtmlBridge;
+using Broiler.HTML.Core.Entities;
+using Broiler.HTML.Graphics;
+
+namespace Broiler.App.Graphics;
+
+/// <summary>
+/// Browser shell hosted on a Direct2D window. Provides the navigation chrome (address bar,
+/// back/forward/refresh, favorites), translates Win32 input into HTML hit-testing, drives
+/// scrolling, and steps script-driven animations through the window's animation timer.
+/// </summary>
+[SupportedOSPlatform("windows7.0")]
+internal sealed class BrowserWindow : Direct2DWindow
+{
+    private const int DesiredClientWidth = 1100;
+    private const int DesiredClientHeight = 800;
+
+    private const double ToolbarHeight = 40;
+    private const double FavoritesBarHeight = 30;
+    private const double Margin = 6;
+    private const double ControlHeight = 26;
+    private const double NavButtonWidth = 34;
+    private const double GoButtonWidth = 56;
+    private const double StarWidth = 34;
+
+    private const double WheelScrollStep = 60;
+    private const double KeyScrollStep = 48;
+    private const double AnimationIntervalMs = 16;
+
+    private readonly string? _initialUrl;
+    private readonly HtmlContainer _container = new();
+    private readonly RenderingPipeline _pipeline;
+    private readonly FavoritesManager _favorites = new();
+
+    private readonly List<string> _history = [];
+    private int _historyIndex = -1;
+
+    private BButtonControl? _backButton;
+    private BButtonControl? _forwardButton;
+    private BButtonControl? _refreshButton;
+    private BButtonControl? _goButton;
+    private BButtonControl? _starButton;
+    private BEditControl? _urlEdit;
+    private readonly List<(BButtonControl Button, string Url)> _favoriteButtons = [];
+
+    private InteractiveSession? _session;
+    private HtmlGraphicsRenderList? _renderList;
+    private bool _hasContent;
+    private bool _layoutDirty = true;
+    private bool _renderDirty = true;
+    private float _scrollY;
+    private float _contentHeight;
+    private float _viewportHeight;
+    private string _baseUrl = string.Empty;
+    private string? _pendingAnchor;
+    private bool _suppressNavigation;
+
+    public BrowserWindow(string? initialUrl)
+        : base(new BWindowOptions
+        {
+            Title = "Broiler",
+            ClientWidth = DesiredClientWidth,
+            ClientHeight = DesiredClientHeight,
+            ClearColor = BColor.White,
+            RenderOptions = new BRenderOptions(Antialias: true, VSync: true, SubpixelText: true),
+        })
+    {
+        _initialUrl = initialUrl;
+        _container.AvoidAsyncImagesLoading = true;
+        _container.AvoidImagesLateLoading = true;
+        _container.LinkClicked += OnLinkClicked;
+
+        _pipeline = new RenderingPipeline(
+            new PageLoader(new HttpClient()),
+            new ScriptExtractor(),
+            new ScriptEngine());
+    }
+
+    // The render content area sits below the toolbar and favorites bar.
+    protected override BRect GetRenderBounds(BSize clientSize)
+    {
+        double top = ToolbarHeight + FavoritesBarHeight;
+        return new BRect(0, top, clientSize.Width, Math.Max(0, clientSize.Height - top));
+    }
+
+    protected override BFrameContext CreateFrameContext(long frameIndex) =>
+        new(ResolveClearColor(), frameIndex, Options.RenderOptions);
+
+    protected override void OnCreated() => Diagnostics.Guard(nameof(OnCreated), OnCreatedCore);
+
+    private void OnCreatedCore()
+    {
+        _backButton = MakeButton("←", () => GoHistory(-1));
+        _forwardButton = MakeButton("→", () => GoHistory(1));
+        _refreshButton = MakeButton("↻", Reload);
+        _urlEdit = CreateEditControl(new BControlOptions { Text = string.Empty });
+        _urlEdit.Submitted += (_, _) => NavigateTo(_urlEdit!.Text);
+        _starButton = MakeButton("☆", ToggleFavorite);
+        _goButton = MakeButton("Go", () => NavigateTo(_urlEdit!.Text));
+
+        _favorites.Load();
+        RefreshFavoritesBar();
+        LayoutControls(ClientSize);
+
+        NavigateTo(_initialUrl ?? "about:blank");
+        _urlEdit.Focus();
+    }
+
+    protected override void OnResized(BSize clientSize, double dpiScale)
+    {
+        LayoutControls(clientSize);
+        MarkLayoutDirty();
+    }
+
+    protected override void OnGraphicsResourcesReleasing() => MarkLayoutDirty();
+
+    // ---- Navigation -------------------------------------------------------
+
+    private void NavigateTo(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return;
+
+        url = NormalizeInput(url);
+
+        // Drop forward history when navigating somewhere new.
+        if (_historyIndex < _history.Count - 1)
+            _history.RemoveRange(_historyIndex + 1, _history.Count - _historyIndex - 1);
+
+        _history.Add(url);
+        _historyIndex = _history.Count - 1;
+        LoadUrl(url);
+    }
+
+    private void GoHistory(int delta)
+    {
+        int target = _historyIndex + delta;
+        if (target < 0 || target >= _history.Count)
+            return;
+
+        _historyIndex = target;
+        LoadUrl(_history[target]);
+    }
+
+    private void Reload()
+    {
+        if (_historyIndex >= 0 && _historyIndex < _history.Count)
+            LoadUrl(_history[_historyIndex]);
+    }
+
+    private void LoadUrl(string url)
+    {
+        SetUrlText(url);
+        UpdateNavigationButtons();
+        UpdateStarButton();
+        StopSession();
+        _scrollY = 0;
+        _pendingAnchor = null;
+
+        if (string.Equals(url, "about:blank", StringComparison.OrdinalIgnoreCase))
+        {
+            _baseUrl = string.Empty;
+            _container.SetHtml(WelcomePage);
+            _hasContent = true;
+            MarkLayoutDirty();
+            Invalidate();
+            return;
+        }
+
+        try
+        {
+            var (normalisedUrl, content) = _pipeline.LoadPageAsync(url).GetAwaiter().GetResult();
+            _baseUrl = normalisedUrl;
+            SetUrlText(normalisedUrl);
+
+            _container.BaseUrl = normalisedUrl;
+            _container.SetHtml(HtmlPostProcessor.Process(content.Html), baseUrl: normalisedUrl);
+            _hasContent = true;
+
+            // Interactive session lets timer / rAF callbacks be stepped one batch at a
+            // time so animations play out, mirroring the WPF shell. The Graphics host
+            // renders from serialized HTML (the typed-document path lays out empty here).
+            _session = _pipeline.ExecuteScriptsInteractive(content);
+            if (_session != null)
+            {
+                string initial = _session.CurrentHtml();
+                if (!string.IsNullOrWhiteSpace(initial))
+                    _container.SetHtml(HtmlPostProcessor.Process(initial), baseUrl: normalisedUrl);
+
+                if (_session.HasPendingWork)
+                    StartAnimationTimer(AnimationIntervalMs);
+                else
+                    StopSession();
+            }
+
+            if (Uri.TryCreate(normalisedUrl, UriKind.Absolute, out Uri? uri)
+                && !string.IsNullOrEmpty(uri.Fragment) && uri.Fragment.Length > 1)
+            {
+                _pendingAnchor = uri.Fragment[1..];
+            }
+
+            MarkLayoutDirty();
+            Invalidate();
+        }
+        catch (Exception ex)
+        {
+            _baseUrl = string.Empty;
+            _container.SetHtml($"<html><body><h1>Error</h1><p>{System.Net.WebUtility.HtmlEncode(ex.Message)}</p></body></html>");
+            _hasContent = true;
+            MarkLayoutDirty();
+            Invalidate();
+        }
+    }
+
+    private void OnLinkClicked(object? sender, HtmlLinkClickedEventArgs e)
+    {
+        e.Handled = true;
+        if (_suppressNavigation)
+            return;
+
+        string link = e.Link;
+
+        // Resolve fragment-only hrefs (e.g. "#top") against the current page URL.
+        if (link.StartsWith('#') && _historyIndex >= 0 && _historyIndex < _history.Count)
+        {
+            string current = _history[_historyIndex];
+            int hash = current.IndexOf('#');
+            if (hash >= 0)
+                current = current[..hash];
+            link = current + link;
+        }
+
+        NavigateTo(link);
+    }
+
+    // ---- Rendering --------------------------------------------------------
+
+    protected override BRenderList? BuildRenderList(BSize clientSize)
+    {
+        try
+        {
+            return BuildRenderListCore(clientSize);
+        }
+        catch (Exception ex)
+        {
+            Diagnostics.Log(nameof(BuildRenderList), ex);
+            return null;
+        }
+    }
+
+    private BRenderList? BuildRenderListCore(BSize clientSize)
+    {
+        if (!_hasContent || clientSize.IsEmpty || Renderer is null)
+            return null;
+
+        float vpW = (float)clientSize.Width;
+        float vpH = (float)clientSize.Height;
+        _viewportHeight = vpH;
+
+        if (_layoutDirty)
+        {
+            _container.Location = PointF.Empty;
+            _container.MaxSize = new SizeF(vpW, vpH);
+            _container.PerformLayout(new RectangleF(0, 0, vpW, vpH));
+            _contentHeight = _container.ActualSize.Height;
+            _layoutDirty = false;
+            _renderDirty = true;
+            ResolvePendingAnchor();
+        }
+
+        ClampScroll(vpH);
+
+        if (_renderDirty || _renderList is null)
+        {
+            _container.ScrollOffset = new PointF(0, -_scrollY);
+            _renderList?.Dispose();
+            _renderList = _container.CreateRenderList(Renderer, new RectangleF(0, 0, vpW, vpH));
+            _renderDirty = false;
+        }
+
+        return _renderList.RenderList;
+    }
+
+    private void ResolvePendingAnchor()
+    {
+        if (_pendingAnchor is null)
+            return;
+
+        RectangleF? rect = _container.GetElementRectangle(_pendingAnchor);
+        _pendingAnchor = null;
+        if (rect is { } r)
+        {
+            _scrollY = Math.Max(0, r.Y);
+            _renderDirty = true;
+        }
+    }
+
+    private void ClampScroll(float viewportHeight)
+    {
+        float maxScroll = Math.Max(0, _contentHeight - viewportHeight);
+        float clamped = Math.Clamp(_scrollY, 0, maxScroll);
+        if (clamped != _scrollY)
+        {
+            _scrollY = clamped;
+            _renderDirty = true;
+        }
+    }
+
+    // ---- Input ------------------------------------------------------------
+
+    protected override void OnPointerDown(BPointerEventArgs e) => Diagnostics.Guard(nameof(OnPointerDown), () =>
+    {
+        if (_hasContent)
+            _container.HandleMouseDown(ToPoint(e.Position), e.LeftButton, e.RightButton);
+    });
+
+    protected override void OnPointerMove(BPointerEventArgs e) => Diagnostics.Guard(nameof(OnPointerMove), () =>
+    {
+        if (_hasContent)
+            _container.HandleMouseMove(ToPoint(e.Position), e.LeftButton, e.RightButton);
+    });
+
+    protected override void OnPointerUp(BPointerEventArgs e) => Diagnostics.Guard(nameof(OnPointerUp), () =>
+    {
+        // HandleMouseUp raises LinkClicked for links, which drives navigation.
+        if (_hasContent)
+            _container.HandleMouseUp(ToPoint(e.Position), e.LeftButton, e.RightButton);
+    });
+
+    protected override void OnPointerLeave() => Diagnostics.Guard(nameof(OnPointerLeave), () =>
+    {
+        if (_hasContent)
+            _container.HandleMouseLeave();
+    });
+
+    protected override void OnMouseWheel(BMouseWheelEventArgs e)
+    {
+        ScrollBy(-(float)(e.Delta * WheelScrollStep));
+    }
+
+    protected override void OnKeyDown(BKeyEventArgs e) => Diagnostics.Guard(nameof(OnKeyDown), () =>
+    {
+        switch (e.VirtualKey)
+        {
+            case BVirtualKey.Down: ScrollBy((float)KeyScrollStep); break;
+            case BVirtualKey.Up: ScrollBy(-(float)KeyScrollStep); break;
+            case BVirtualKey.PageDown: ScrollBy(Math.Max(1, _viewportHeight - 40)); break;
+            case BVirtualKey.PageUp: ScrollBy(-Math.Max(1, _viewportHeight - 40)); break;
+            case BVirtualKey.Home: SetScroll(0); break;
+            case BVirtualKey.End: SetScroll(float.MaxValue); break;
+            case BVirtualKey.F5: Reload(); break;
+            case BVirtualKey.Left when e.Alt: GoHistory(-1); break;
+            case BVirtualKey.Right when e.Alt: GoHistory(1); break;
+        }
+    });
+
+    private void ScrollBy(float delta) => SetScroll(_scrollY + delta);
+
+    private void SetScroll(float value)
+    {
+        _scrollY = value;
+        _renderDirty = true;
+        Invalidate();
+    }
+
+    // ---- Animation --------------------------------------------------------
+
+    protected override void OnAnimationTick() => Diagnostics.Guard(nameof(OnAnimationTick), OnAnimationTickCore);
+
+    private void OnAnimationTickCore()
+    {
+        if (_session is null || !_session.HasPendingWork)
+        {
+            StopSession();
+            return;
+        }
+
+        string? html = _session.Step();
+        if (html != null)
+        {
+            // Re-applying content mutates the container; avoid re-entrant navigation
+            // if a script-driven change happens to look like a link activation.
+            _suppressNavigation = true;
+            try
+            {
+                _container.SetHtml(HtmlPostProcessor.Process(html), baseUrl: _baseUrl);
+            }
+            finally
+            {
+                _suppressNavigation = false;
+            }
+            MarkLayoutDirty();
+            Invalidate();
+        }
+
+        if (!_session.HasPendingWork)
+            StopSession();
+    }
+
+    private void StopSession()
+    {
+        StopAnimationTimer();
+        _session?.Dispose();
+        _session = null;
+    }
+
+    // ---- Favorites & chrome ----------------------------------------------
+
+    private void ToggleFavorite()
+    {
+        string url = _urlEdit?.Text ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(url) || string.Equals(url, "about:blank", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        if (_favorites.Contains(url))
+            _favorites.Remove(url);
+        else
+            _favorites.Add(url);
+
+        _favorites.Save();
+        UpdateStarButton();
+        RefreshFavoritesBar();
+        LayoutControls(ClientSize);
+    }
+
+    private void RefreshFavoritesBar()
+    {
+        foreach (var (button, _) in _favoriteButtons)
+            button.Dispose();
+        _favoriteButtons.Clear();
+
+        foreach (string url in _favorites.Favorites)
+        {
+            string favUrl = url;
+            var button = CreateButtonControl(new BControlOptions { Text = FavoriteLabel(url) });
+            button.Clicked += (_, _) => NavigateTo(favUrl);
+            _favoriteButtons.Add((button, url));
+        }
+    }
+
+    private void UpdateNavigationButtons()
+    {
+        if (_backButton != null)
+            _backButton.Enabled = _historyIndex > 0;
+        if (_forwardButton != null)
+            _forwardButton.Enabled = _historyIndex < _history.Count - 1;
+    }
+
+    private void UpdateStarButton()
+    {
+        if (_starButton != null)
+            _starButton.Text = _favorites.Contains(_urlEdit?.Text ?? string.Empty) ? "★" : "☆";
+    }
+
+    private void LayoutControls(BSize clientSize)
+    {
+        if (_backButton is null || _forwardButton is null || _refreshButton is null
+            || _urlEdit is null || _starButton is null || _goButton is null)
+            return;
+
+        double x = Margin;
+        double y = (ToolbarHeight - ControlHeight) / 2;
+
+        _backButton.Bounds = new BRect(x, y, NavButtonWidth, ControlHeight); x += NavButtonWidth + Margin;
+        _forwardButton.Bounds = new BRect(x, y, NavButtonWidth, ControlHeight); x += NavButtonWidth + Margin;
+        _refreshButton.Bounds = new BRect(x, y, NavButtonWidth, ControlHeight); x += NavButtonWidth + Margin;
+
+        double rightControls = GoButtonWidth + StarWidth + (Margin * 3);
+        double editWidth = Math.Max(40, clientSize.Width - x - rightControls);
+        _urlEdit.Bounds = new BRect(x, y, editWidth, ControlHeight); x += editWidth + Margin;
+        _starButton.Bounds = new BRect(x, y, StarWidth, ControlHeight); x += StarWidth + Margin;
+        _goButton.Bounds = new BRect(x, y, GoButtonWidth, ControlHeight);
+
+        // Favorites bar row.
+        double fx = Margin;
+        double fy = ToolbarHeight + ((FavoritesBarHeight - ControlHeight) / 2);
+        foreach (var (button, _) in _favoriteButtons)
+        {
+            double width = EstimateFavoriteWidth(button.Text);
+            if (fx + width > clientSize.Width - Margin)
+            {
+                button.Visible = false;
+                continue;
+            }
+            button.Visible = true;
+            button.Bounds = new BRect(fx, fy, width, ControlHeight);
+            fx += width + Margin;
+        }
+    }
+
+    private void SetUrlText(string url)
+    {
+        if (_urlEdit != null && !string.Equals(_urlEdit.Text, url, StringComparison.Ordinal))
+            _urlEdit.Text = url;
+    }
+
+    private BButtonControl MakeButton(string text, Action onClick)
+    {
+        var button = CreateButtonControl(new BControlOptions { Text = text });
+        button.Clicked += (_, _) => onClick();
+        return button;
+    }
+
+    private BColor ResolveClearColor()
+    {
+        Color background = _container.GetRootBackgroundColor();
+        return !background.IsEmpty && background.A > 0
+            ? new BColor(background.R, background.G, background.B, background.A)
+            : BColor.White;
+    }
+
+    private void MarkLayoutDirty()
+    {
+        _layoutDirty = true;
+        _renderDirty = true;
+    }
+
+    private static PointF ToPoint(BPoint p) => new((float)p.X, (float)p.Y);
+
+    // Accept a local filesystem path (e.g. "C:\page.html") as a convenience and turn it into a
+    // file:// URI the page loader understands; otherwise pass the input through unchanged.
+    private static string NormalizeInput(string input)
+    {
+        input = input.Trim();
+        bool looksLikePath = (input.Length >= 2 && input[1] == ':') || input.StartsWith(@"\\", StringComparison.Ordinal);
+        if (looksLikePath && File.Exists(input))
+            return new Uri(Path.GetFullPath(input)).AbsoluteUri;
+        return input;
+    }
+
+    private static double EstimateFavoriteWidth(string label) =>
+        Math.Clamp(label.Length * 8 + 16, 48, 160);
+
+    private static string FavoriteLabel(string url)
+    {
+        if (Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) && !string.IsNullOrEmpty(uri.Host))
+        {
+            string host = uri.Host;
+            if (host.StartsWith("www.", StringComparison.OrdinalIgnoreCase))
+                host = host[4..];
+            return host;
+        }
+
+        return url.Length > 24 ? url[..21] + "…" : url;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            StopSession();
+            foreach (var (button, _) in _favoriteButtons)
+                button.Dispose();
+            _favoriteButtons.Clear();
+            _backButton?.Dispose();
+            _forwardButton?.Dispose();
+            _refreshButton?.Dispose();
+            _goButton?.Dispose();
+            _starButton?.Dispose();
+            _urlEdit?.Dispose();
+            _renderList?.Dispose();
+            _pipeline.Dispose();
+            _container.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private const string WelcomePage = """
+<html>
+<head>
+    <style>
+        body { font-family: Segoe UI, Arial, sans-serif; margin: 40px; background: #fafafa; color: #333; }
+        h1 { color: #2c3e50; }
+        p { line-height: 1.6; }
+        .info { background: #ecf0f1; padding: 16px; border-radius: 4px; margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <h1>Welcome to Broiler</h1>
+    <p>This is the Broiler browser running on the Broiler.Graphics (Direct2D) UI &mdash; no WPF.</p>
+    <div class='info'>
+        <p><strong>Getting Started:</strong> type a URL in the address bar and press Enter or click Go.</p>
+        <p><strong>Features:</strong></p>
+        <ul>
+            <li>HTML &amp; CSS rendering via Broiler.HTML.Graphics</li>
+            <li>JavaScript execution with interactive animation stepping</li>
+            <li>Navigation history, favorites, links, mouse-wheel and keyboard scrolling</li>
+        </ul>
+    </div>
+</body>
+</html>
+""";
+}

--- a/src/Broiler.App.Graphics/Diagnostics.cs
+++ b/src/Broiler.App.Graphics/Diagnostics.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+
+namespace Broiler.App.Graphics;
+
+/// <summary>
+/// Minimal file logger. Exceptions thrown out of a Win32 window-procedure callback cross the
+/// native boundary and trigger a runtime fail-fast that <c>try</c>/<c>catch</c> in <c>Main</c>
+/// cannot observe, so callback-invoked code routes failures here instead of letting them escape.
+/// </summary>
+internal static class Diagnostics
+{
+    private static readonly string LogPath =
+        Path.Combine(Path.GetTempPath(), "broiler-graphics.log");
+
+    public static void Log(string message)
+    {
+        try
+        {
+            File.AppendAllText(LogPath, $"{DateTime.Now:HH:mm:ss.fff} {message}{Environment.NewLine}");
+        }
+        catch
+        {
+            // Logging must never itself throw across the callback boundary.
+        }
+    }
+
+    public static void Log(string context, Exception ex)
+    {
+        string detail = ex.ToString();
+        if (ex is System.IO.FileNotFoundException fnf && !string.IsNullOrEmpty(fnf.FusionLog))
+            detail += $"{Environment.NewLine}FusionLog:{Environment.NewLine}{fnf.FusionLog}";
+        Log($"[{context}] {detail}");
+    }
+
+    /// <summary>Runs <paramref name="action"/>, logging and swallowing any exception.</summary>
+    public static void Guard(string context, Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception ex)
+        {
+            Log(context, ex);
+        }
+    }
+}

--- a/src/Broiler.App.Graphics/Program.cs
+++ b/src/Broiler.App.Graphics/Program.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Loader;
+using System.Runtime.Versioning;
+
+namespace Broiler.App.Graphics;
+
+/// <summary>
+/// Entry point for the Broiler browser built on Broiler.Graphics (Win32 + Direct2D).
+/// This is the preview shell that replaces the WPF host (<c>Broiler.App</c>).
+/// </summary>
+[SupportedOSPlatform("windows7.0")]
+internal static class Program
+{
+    [STAThread]
+    private static int Main(string[] args)
+    {
+        // The HTML stack pulls in two physically distinct builds of the same-identity
+        // assemblies (e.g. Broiler.Dom is checked out under both Broiler.DOM and the
+        // CSS submodule). MSBuild dedups them and drops their runtime entry from deps.json,
+        // so the host never probes for them even though the DLLs are in the output folder.
+        // Fall back to loading any such assembly directly from the application directory.
+        AssemblyLoadContext.Default.Resolving += ResolveFromAppDirectory;
+
+        _ = SetProcessDpiAwarenessContext(new IntPtr(-4)); // PER_MONITOR_AWARE_V2, best effort.
+
+        string? initialUrl = args.Length > 0 && !string.IsNullOrWhiteSpace(args[0]) ? args[0] : null;
+
+        try
+        {
+            using var window = new BrowserWindow(initialUrl);
+            return window.Run();
+        }
+        catch (Exception ex)
+        {
+            MessageBox(IntPtr.Zero, ex.ToString(), "Broiler", MbIconError | MbOk);
+            return 1;
+        }
+    }
+
+    private static Assembly? ResolveFromAppDirectory(AssemblyLoadContext context, AssemblyName name)
+    {
+        if (string.IsNullOrEmpty(name.Name))
+            return null;
+
+        string candidate = Path.Combine(AppContext.BaseDirectory, name.Name + ".dll");
+        return File.Exists(candidate) ? context.LoadFromAssemblyPath(candidate) : null;
+    }
+
+    private const uint MbOk = 0x00000000;
+    private const uint MbIconError = 0x00000010;
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetProcessDpiAwarenessContext(IntPtr dpiContext);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int MessageBox(IntPtr hwnd, string text, string caption, uint type);
+}

--- a/src/Broiler.HtmlBridge.Rendering/Broiler.HtmlBridge.Rendering.csproj
+++ b/src/Broiler.HtmlBridge.Rendering/Broiler.HtmlBridge.Rendering.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Broiler" />
+    <InternalsVisibleTo Include="Broiler.Graphics.Browser" />
     <InternalsVisibleTo Include="Broiler.Cli" />
     <InternalsVisibleTo Include="Broiler.Cli.Tests" />
     <InternalsVisibleTo Include="Broiler.DevConsole" />


### PR DESCRIPTION
Implements **Phase 2** of `docs/roadmap/public-preview-roadmap.md` (Broiler.Graphics UI migration): a runnable browser built entirely on Broiler.Graphics (Win32 + Direct2D), with **no WPF** in the path.

## What's here

**New app — `src/Broiler.App.Graphics/`** (assembly `Broiler.Graphics.Browser`):
- `BrowserWindow : Direct2DWindow` hosting `Broiler.HTML.Graphics.HtmlContainer`.
- **Navigation chrome** (2.2): Back/Forward/Refresh, address bar, ☆ favorite toggle, Go, and a favorites bar of native buttons rebuilt from `FavoritesManager` (shares `favorites.json` with the WPF app). History + fragment-anchor resolution.
- **Input** (2.3): maps the new `BWindow` pointer/keyboard/wheel hooks to `HtmlContainer` hit-testing; link clicks drive navigation via `LinkClicked`.
- **Scrolling** (2.4): mouse-wheel + keyboard (arrows/PageUp-Down/Home/End), clamped to content height; layout cached, only the render list rebuilds on scroll; re-layout on resize.
- **Animation loop** (2.6): steps `InteractiveSession` one batch per `WM_TIMER` tick (verified with a `setInterval` counter running to completion).
- Reuses platform-neutral `RenderingPipeline`/`PageLoader`/`FavoritesManager` from `Broiler.App` via linked `<Compile>` (no duplication; WPF app untouched).
- `Diagnostics.cs` logs exceptions from native-callback code instead of fail-fasting across the window-proc boundary.

**Submodule bumps** (companion PRs — merge first):
- `Broiler.Graphics` → [MaiRat/Broiler.Graphics#6](https://github.com/MaiRat/Broiler.Graphics/pull/6) (input + animation-timer hooks on `BWindow`/`Direct2DWindow`).
- `Broiler.HTML` → [MaiRat/Broiler.HTML#187](https://github.com/MaiRat/Broiler.HTML/pull/187) (bumps its nested `Broiler.Graphics` to the same commit — the copy the build compiles against).

**Other:** `InternalsVisibleTo Broiler.Graphics.Browser` in `Broiler.HtmlBridge.Rendering` (for `HtmlPostProcessor`); roadmap updated with Phase 2 status.

## Verified

Builds clean (full solution, 0 warnings/0 errors) and runs: renders the welcome page, a local file, a JS page that mutates the DOM at load, scrollable content, and a `setInterval` animation. Tested via screenshots.

## Reviewer notes / known gaps

- **Renders via `SetHtml` (serialized HTML).** The typed-document handoff (`SetDocument(InteractiveSession.CurrentDocument())`, used by the WPF shell) lays out **empty** in `Broiler.HTML.Graphics`; the app uses `CurrentHtml()`/`Step()` instead. Making the typed path render (to drop per-frame HTML re-parsing) is a follow-up.
- **`deps.json` drops `Broiler.Dom`** because two physically distinct same-identity builds exist (checked out under both `Broiler.DOM` and the CSS submodule). Worked around with an `AssemblyLoadContext.Resolving` fallback in `Program.Main`.
- **Remaining for full Phase 2 exit:** in-page form text input (2.5, only the address bar is wired today), dev-console port (2.7), and README/default cutover (2.8, Phase 3 §3.4).

> Depends on the two submodule PRs above; the gitlinks here point at their branch commits, so land those first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)