### PR TITLE
Extract the layout engine into a standalone Broiler.Layout component

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/Broiler.Layout.Tests.csproj
+++ b/Broiler.Layout/Broiler.Layout.Tests/Broiler.Layout.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Broiler.Layout.Tests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Broiler.Layout\Broiler.Layout.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Broiler.Layout/Broiler.Layout.Tests/LayoutArchitectureTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/LayoutArchitectureTests.cs
@@ -1,0 +1,90 @@
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// Freezes the <c>Broiler.Layout</c> dependency boundary for the layout extraction
+/// (see <c>docs/roadmap/broiler-layout-component.md</c> §3, §7). The component may
+/// reference only <c>Broiler.CSS</c>, <c>Broiler.CSS.Dom</c>, <c>Broiler.Dom</c>
+/// and the BCL; it must not leak the renderer, bridge, JavaScript or graphics
+/// backends through its public surface.
+/// </summary>
+public sealed class LayoutArchitectureTests
+{
+    [Fact]
+    public void Production_Project_References_Only_Css_And_Dom()
+    {
+        var project = XDocument.Load(FindProjectPath());
+        var references = project
+            .Descendants("ProjectReference")
+            .Select(static element => Path.GetFileNameWithoutExtension((string?)element.Attribute("Include")))
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(["Broiler.CSS", "Broiler.CSS.Dom", "Broiler.Dom"], references);
+        Assert.Empty(project.Descendants("PackageReference"));
+    }
+
+    [Fact]
+    public void Public_Surface_Does_Not_Leak_Consumer_Types()
+    {
+        var assembly = typeof(ILayoutEnvironment).Assembly;
+        var forbidden = assembly.GetExportedTypes()
+            .SelectMany(GetMemberTypes)
+            .Where(static type => type.Namespace is not null)
+            .Where(static type =>
+                type.Namespace!.StartsWith("Broiler.HtmlBridge", StringComparison.Ordinal) ||
+                type.Namespace.StartsWith("Broiler.HTML", StringComparison.Ordinal) ||
+                type.Namespace.StartsWith("Broiler.JavaScript", StringComparison.Ordinal) ||
+                type.Namespace.StartsWith("Broiler.Graphics", StringComparison.Ordinal))
+            .Distinct()
+            .ToArray();
+
+        Assert.Empty(forbidden);
+    }
+
+    [Fact]
+    public void Public_Surface_Does_Not_Expose_Mutable_Collections()
+    {
+        var assembly = typeof(ILayoutEnvironment).Assembly;
+        var mutable = assembly.GetExportedTypes()
+            .SelectMany(GetMemberTypes)
+            .Where(static type => type.IsGenericType)
+            .Select(static type => type.GetGenericTypeDefinition())
+            .Where(static definition =>
+                definition == typeof(List<>) ||
+                definition == typeof(Dictionary<,>) ||
+                definition == typeof(HashSet<>))
+            .Distinct()
+            .ToArray();
+
+        Assert.Empty(mutable);
+    }
+
+    private static IEnumerable<Type> GetMemberTypes(Type type)
+    {
+        yield return type;
+        foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+        {
+            yield return method.ReturnType;
+            foreach (var parameter in method.GetParameters())
+                yield return parameter.ParameterType;
+        }
+        foreach (var property in type.GetProperties())
+            yield return property.PropertyType;
+    }
+
+    private static string FindProjectPath()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var path = Path.Combine(directory.FullName, "Broiler.Layout", "Broiler.Layout", "Broiler.Layout.csproj");
+            if (File.Exists(path))
+                return path;
+            directory = directory.Parent;
+        }
+        throw new DirectoryNotFoundException($"Broiler.Layout.csproj not found walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/BoxKind.cs
+++ b/Broiler.Layout/Broiler.Layout/BoxKind.cs
@@ -1,0 +1,62 @@
+namespace Broiler.Layout;
+
+/// <summary>
+/// Classifies the semantic role of a CSS box, derived from the HTML tag name
+/// during style resolution. Layout code uses this enum instead of checking
+/// tag names directly, decoupling layout from the DOM. Relocated from the
+/// renderer's IR into <c>Broiler.Layout</c> with the layout code (see
+/// <c>docs/roadmap/broiler-layout-component.md</c> §2.1).
+/// </summary>
+public enum BoxKind
+{
+    /// <summary>Default value for anonymous boxes or unknown elements.</summary>
+    Anonymous = 0,
+
+    /// <summary>Generic block-level element (div, p, section, etc.).</summary>
+    Block,
+
+    /// <summary>Generic inline element (span, em, strong, etc.).</summary>
+    Inline,
+
+    /// <summary>Replaced image element (<c>&lt;img&gt;</c>).</summary>
+    ReplacedImage,
+
+    /// <summary>Replaced iframe element (<c>&lt;iframe&gt;</c>).</summary>
+    ReplacedIframe,
+
+    /// <summary>Table cell (<c>&lt;td&gt;</c> / <c>&lt;th&gt;</c>).</summary>
+    TableCell,
+
+    /// <summary>Table element (<c>&lt;table&gt;</c>).</summary>
+    Table,
+
+    /// <summary>Table row (<c>&lt;tr&gt;</c>).</summary>
+    TableRow,
+
+    /// <summary>List item (<c>&lt;li&gt;</c>).</summary>
+    ListItem,
+
+    /// <summary>Ordered list (<c>&lt;ol&gt;</c>).</summary>
+    OrderedList,
+
+    /// <summary>Unordered list (<c>&lt;ul&gt;</c>).</summary>
+    UnorderedList,
+
+    /// <summary>Horizontal rule (<c>&lt;hr&gt;</c>).</summary>
+    HorizontalRule,
+
+    /// <summary>Line break (<c>&lt;br&gt;</c>).</summary>
+    LineBreak,
+
+    /// <summary>Anchor / hyperlink (<c>&lt;a&gt;</c>).</summary>
+    Anchor,
+
+    /// <summary>Font element (<c>&lt;font&gt;</c>).</summary>
+    Font,
+
+    /// <summary>Form input element (<c>&lt;input&gt;</c>).</summary>
+    Input,
+
+    /// <summary>Heading elements (<c>&lt;h1&gt;</c>–<c>&lt;h6&gt;</c>).</summary>
+    Heading,
+}

--- a/Broiler.Layout/Broiler.Layout/Broiler.Layout.csproj
+++ b/Broiler.Layout/Broiler.Layout/Broiler.Layout.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Broiler.Layout</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Description>CSS box-model and layout engine over the canonical Broiler DOM and computed style, independent of any graphics backend.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Broiler.CSS\Broiler.CSS.Dom\Broiler.CSS.Dom.csproj" />
+    <ProjectReference Include="..\..\Broiler.CSS\Broiler.CSS\Broiler.CSS.csproj" />
+    <ProjectReference Include="..\..\Broiler.DOM\Broiler.Dom\Broiler.Dom.csproj" />
+  </ItemGroup>
+
+  <!-- The relocated layout types (CssBox, CssBoxProperties, …) are internal; expose them to
+       the renderer assembly that still owns them (Broiler.HTML.Dom) and to the consumers that
+       reach them via InternalsVisibleTo, mirroring the old Broiler.HTML.Dom IVT set. -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="Broiler.HTML.Dom" />
+    <InternalsVisibleTo Include="Broiler.HTML" />
+    <InternalsVisibleTo Include="Broiler.HTML.Core" />
+    <InternalsVisibleTo Include="Broiler.HTML.CSS" />
+    <InternalsVisibleTo Include="Broiler.HTML.Orchestration" />
+    <InternalsVisibleTo Include="Broiler.HTML.Image" />
+    <InternalsVisibleTo Include="Broiler.HTML.Image.Compat" />
+    <InternalsVisibleTo Include="Broiler.HTML.Image.Tests" />
+    <InternalsVisibleTo Include="Broiler.HTML.WPF" />
+    <InternalsVisibleTo Include="Broiler" />
+    <InternalsVisibleTo Include="Broiler.HtmlBridge" />
+    <InternalsVisibleTo Include="Broiler.HtmlBridge.Dom" />
+    <InternalsVisibleTo Include="Broiler.Cli" />
+    <InternalsVisibleTo Include="Broiler.Cli.Tests" />
+    <InternalsVisibleTo Include="Broiler.DevConsole" />
+    <InternalsVisibleTo Include="Broiler.DevConsole.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -1,0 +1,4240 @@
+﻿using Broiler.Layout;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+
+using CssConstants = Broiler.CSS.CssConstants;
+using CssValueParser = Broiler.CSS.CssLengthParser;
+namespace Broiler.Layout;
+
+internal class CssBox : CssBoxProperties, IDisposable
+{
+    private CssBox _parentBox;
+    protected object _htmlContainer;
+    private ILayoutEnvironment _layoutEnvironment;
+    private ReadOnlyMemory<char> _text;
+
+    internal bool _tableFixed;
+
+    /// <summary>
+    /// The canonical <see cref="Broiler.Dom.DomElement"/> this box was built from,
+    /// when the box tree was generated from a <see cref="Broiler.Dom.DomDocument"/>
+    /// (the <c>SetDocument</c> path). <c>null</c> on the legacy HTML-string parse path.
+    /// Phase 5 uses this to run the shared <c>Broiler.CSS.Dom</c> cascade on the
+    /// canonical element and project the result onto this box.
+    /// </summary>
+    internal Broiler.Dom.DomElement SourceElement { get; set; }
+
+    /// <summary>
+    /// When the block-inside-inline correction (CSS2.1 §9.2.1.1) splits a
+    /// positioned inline element into sibling anonymous blocks, the hoisted
+    /// blocks lose their parent–child relationship with the positioned
+    /// inline in the box tree.  This field links back to the original
+    /// positioned ancestor so that <see cref="FindPositionedContainingBlock"/>
+    /// can still find it.
+    /// </summary>
+    internal CssBox SplitPositionedAncestor { get; set; }
+
+    private bool UsesBorderBoxSizing =>
+        BoxSizing != null && BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase);
+
+    private double ResolveSpecifiedWidthToBorderBox(double cssWidth)
+    {
+        if (!UsesBorderBoxSizing)
+            cssWidth += ActualPaddingLeft + ActualPaddingRight + ActualBorderLeftWidth + ActualBorderRightWidth;
+
+        return Math.Max(0, cssWidth);
+    }
+
+    private double ResolveSpecifiedHeightToBorderBox(double cssHeight)
+    {
+        if (!UsesBorderBoxSizing)
+            cssHeight += ActualPaddingTop + ActualPaddingBottom + ActualBorderTopWidth + ActualBorderBottomWidth;
+
+        return Math.Max(0, cssHeight);
+    }
+
+    private double ResolveSpecifiedWidthToContentBox(double cssWidth)
+    {
+        if (UsesBorderBoxSizing)
+            cssWidth -= ActualPaddingLeft + ActualPaddingRight + ActualBorderLeftWidth + ActualBorderRightWidth;
+
+        return Math.Max(0, cssWidth);
+    }
+
+    /// <summary>
+    /// When the block-inside-inline correction splits a positioned inline
+    /// element, the original box loses its children to anonymous "left" and
+    /// "right" copies.  This list tracks those copies so that
+    /// <see cref="GetInlineBoundingBox"/> can compute the bounding box
+    /// across <em>all</em> fragments, not just the (now-empty) original.
+    /// Only populated on the original box that serves as
+    /// <see cref="SplitPositionedAncestor"/> for hoisted descendants.
+    /// </summary>
+    internal List<CssBox> SplitFragments { get; private set; }
+
+    /// <summary>
+    /// Register a box as a fragment of this positioned inline that was
+    /// created during the block-inside-inline split.
+    /// </summary>
+    internal void AddSplitFragment(CssBox fragment)
+    {
+        SplitFragments ??= new List<CssBox>();
+        SplitFragments.Add(fragment);
+    }
+
+    protected bool _wordsSizeMeasured;
+    private CssBox _listItemBox;
+    private List<ILayoutImageLoader?>? _backgroundImageLoadHandlers;
+    private bool _backgroundImagesInitialized;
+
+    /// <summary>
+    /// CSS property names that were applied with <c>!important</c> during
+    /// cascade.  Normal-priority declarations must not override these.
+    /// CSS2.1 §6.4.2.
+    /// </summary>
+    internal HashSet<string> ImportantProperties { get; private set; }
+
+    /// <summary>
+    /// CSS property names that were set by an author-origin declaration
+    /// during cascade.  User-agent declarations must not override these.
+    /// CSS2.1 §6.4.1: Author origin beats UA origin regardless of
+    /// specificity.
+    /// </summary>
+    internal HashSet<string> AuthorProperties { get; private set; }
+
+    internal Dictionary<string, string> CustomProperties { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Marks a property as having been set via an <c>!important</c>
+    /// declaration so that subsequent normal-priority rules cannot
+    /// override it.
+    /// </summary>
+    internal void MarkPropertyImportant(string propertyName)
+    {
+        ImportantProperties ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        ImportantProperties.Add(propertyName);
+    }
+
+    /// <summary>
+    /// Marks a property as having been set by an author-origin
+    /// declaration so that UA declarations cannot override it.
+    /// </summary>
+    internal void MarkPropertyAuthor(string propertyName)
+    {
+        AuthorProperties ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        AuthorProperties.Add(propertyName);
+    }
+
+    internal void SetCustomProperty(string propertyName, string value)
+    {
+        if (string.IsNullOrEmpty(propertyName))
+            return;
+
+        var trimmed = value?.Trim();
+        if (string.Equals(trimmed, "initial", StringComparison.OrdinalIgnoreCase))
+        {
+            CustomProperties[propertyName] = InvalidCustomPropertySentinel;
+            return;
+        }
+
+        if (string.Equals(trimmed, "inherit", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(trimmed, "unset", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(trimmed, "revert", StringComparison.OrdinalIgnoreCase))
+        {
+            CustomProperties.Remove(propertyName);
+            return;
+        }
+
+        CustomProperties[propertyName] = value;
+    }
+
+    /// <summary>
+    /// Returns the loaded background image handle, or null if no background image is loaded.
+    /// Used by <c>FragmentTreeBuilder</c> to capture background images for the new paint path.
+    /// </summary>
+    internal object? LoadedBackgroundImage
+    {
+        get
+        {
+            if (_backgroundImageLoadHandlers == null || _backgroundImageLoadHandlers.Count == 0)
+                return null;
+
+            if (_backgroundImageLoadHandlers.Count == 1)
+                return _backgroundImageLoadHandlers[0]?.Image;
+
+            var layers = new object?[_backgroundImageLoadHandlers.Count];
+            bool hasImage = false;
+            for (int i = 0; i < _backgroundImageLoadHandlers.Count; i++)
+            {
+                var image = _backgroundImageLoadHandlers[i]?.Image;
+                layers[i] = image;
+                hasImage |= image != null;
+            }
+
+            return hasImage ? layers : null;
+        }
+    }
+
+    public CssBox(CssBox parentBox, HtmlTag tag, Uri baseUrl)
+    {
+        if (parentBox != null)
+        {
+            _parentBox = parentBox;
+            _parentBox.Boxes.Add(this);
+        }
+
+        HtmlTag = tag;
+        BaseUrl = baseUrl;
+    }
+
+    /// <summary>
+    /// Opaque host-container handle (the renderer's <c>IHtmlContainerInt</c>),
+    /// kept as the box→container link for renderer/serialization code that reads
+    /// it externally (cast back to the concrete type). Layout itself no longer
+    /// uses it — host services flow through <see cref="LayoutEnvironment"/>.
+    /// Typed as <see cref="object"/> so layout stays free of the renderer's
+    /// container interface (roadmap §4, Phase 4).
+    /// </summary>
+    internal object ContainerInt
+    {
+        get { return _htmlContainer ??= _parentBox?.ContainerInt; }
+        set { _htmlContainer = value; }
+    }
+
+    /// <summary>
+    /// Host-injected layout environment (see <see cref="ILayoutEnvironment"/>),
+    /// resolved up the box tree like <see cref="ContainerInt"/>. Set on the root
+    /// box at the start of each layout pass; supplies the initial-containing-block
+    /// inputs (<see cref="ILayoutEnvironment.ViewportSize"/>,
+    /// <see cref="ILayoutEnvironment.RootLocation"/>) and the
+    /// <see cref="ILayoutEnvironment.ActualSize"/> output that layout reads/writes
+    /// outside the <c>g</c>-threaded methods (roadmap §5, Phase 3).
+    /// </summary>
+    internal ILayoutEnvironment LayoutEnvironment
+    {
+        get { return _layoutEnvironment ??= _parentBox?.LayoutEnvironment; }
+        set { _layoutEnvironment = value; }
+    }
+
+    public CssBox ParentBox
+    {
+        get { return _parentBox; }
+        set
+        {
+            _parentBox?.Boxes.Remove(this);
+            _parentBox = value;
+
+            if (value != null)
+                _parentBox.Boxes.Add(this);
+        }
+    }
+
+    public List<CssBox> Boxes { get; } = [];
+
+    public override bool AvoidGeometryAntialias => LayoutEnvironment?.AvoidGeometryAntialias ?? false;
+
+    protected override bool TryGetCustomPropertyValue(string propertyName, out string value)
+    {
+        if (CustomProperties.TryGetValue(propertyName, out value))
+            return true;
+
+        if (ParentBox != null)
+            return ParentBox.TryGetCustomPropertyValue(propertyName, out value);
+
+        value = string.Empty;
+        return false;
+    }
+
+    public bool IsBrElement => HtmlTag != null && HtmlTag.Name.Equals("br", StringComparison.InvariantCultureIgnoreCase);
+    public bool IsInline => (Display == CssConstants.Inline || Display == CssConstants.InlineBlock
+        || Display == "inline-flex" || Display == "inline-grid") && !IsBrElement;
+    public bool IsBlock => Display == CssConstants.Block || Display == "flex"
+        || Display == "grid";
+    public virtual bool IsClickable
+    {
+        get
+        {
+            if (HtmlTag == null)
+                return false;
+
+            // <a> links (without only an id anchor)
+            if (HtmlTag.Name == HtmlConstants.A && !HtmlTag.HasAttribute("id"))
+                return true;
+
+            // <button> elements
+            if (HtmlTag.Name.Equals("button", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            // <input type="submit|button|reset"> elements
+            if (HtmlTag.Name.Equals("input", StringComparison.OrdinalIgnoreCase))
+            {
+                var inputType = HtmlTag.TryGetAttribute("type")?.ToLowerInvariant() ?? "text";
+                if (inputType is "submit" or "button" or "reset")
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
+    public virtual bool IsFixed
+    {
+        get
+        {
+            if (Position == CssConstants.Fixed)
+                return true;
+
+            if (ParentBox == null)
+                return false;
+
+            CssBox parent = this;
+
+            while (!(parent.ParentBox == null || parent == parent.ParentBox))
+            {
+                parent = parent.ParentBox;
+
+                if (parent.Position == CssConstants.Fixed)
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
+    public virtual string HrefLink => GetAttribute(HtmlConstants.Href);
+
+    public CssBox ContainingBlock
+    {
+        get
+        {
+            if (ParentBox == null)
+                return this; //This is the initial containing block.
+
+            var box = ParentBox;
+
+            // CSS2.1 §10.1: The containing block for a box is the nearest
+            // ancestor that is a block container.  Block containers include:
+            //   - block-level boxes (display:block, flex, grid)
+            //   - inline-block boxes (display:inline-block)
+            //   - list-item boxes
+            //   - table cells (display:table-cell)
+            //   - table boxes (display:table)
+            // Inline-block establishes a BFC (§9.4.1), so its block-level
+            // children must use it as their containing block.
+            while (!box.IsBlock
+                   && box.Display != CssConstants.InlineBlock
+                   && box.Display != CssConstants.ListItem
+                   && box.Display != CssConstants.Table
+                   && box.Display != CssConstants.TableCell
+                   && box.ParentBox != null)
+            {
+                box = box.ParentBox;
+            }
+
+            //Comment this following line to treat always superior box as block
+            if (box == null)
+                throw new Exception("There's no containing block on the chain");
+
+            return box;
+        }
+    }
+
+    /// <summary>
+    /// CSS2.1 §10.1: For absolutely positioned elements, the containing
+    /// block is the padding-box of the nearest ancestor with a computed
+    /// position of <c>absolute</c>, <c>relative</c>, or <c>fixed</c>.
+    /// Falls back to <see cref="ContainingBlock"/> if none is found.
+    /// Also checks <see cref="SplitPositionedAncestor"/> which links back
+    /// to positioned inlines that were restructured by the block-inside-
+    /// inline correction (CSS2.1 §9.2.1.1).
+    /// </summary>
+    private CssBox FindPositionedContainingBlock()
+    {
+        var box = ParentBox;
+        while (box != null)
+        {
+            if (box.Position is CssConstants.Relative or CssConstants.Absolute or CssConstants.Fixed || box.ParentBox == null)
+                return box;
+
+            // If the block-inside-inline correction split a positioned inline
+            // and hoisted this branch out, SplitPositionedAncestor links back
+            // to the original positioned inline ancestor.
+            if (box.SplitPositionedAncestor is { } spa
+                && spa.Position is CssConstants.Relative or CssConstants.Absolute or CssConstants.Fixed)
+                return spa;
+
+            box = box.ParentBox;
+        }
+
+        return ContainingBlock;
+    }
+
+    private bool IsInitialContainingBlock(CssBox cb) =>
+        cb.ParentBox == null && LayoutEnvironment != null;
+
+    private void GetAbsoluteContainingBlockPaddingBox(CssBox cb,
+        out double cbPadLeft,
+        out double cbPadTop,
+        out double cbPadWidth,
+        out double cbPadHeight)
+    {
+        if (IsInlineContainingBlock(cb))
+        {
+            var bbox = GetInlineBoundingBox(cb);
+            if (bbox != RectangleF.Empty)
+            {
+                cbPadLeft = bbox.Left;
+                cbPadTop = bbox.Top;
+                cbPadWidth = bbox.Width;
+                cbPadHeight = bbox.Height;
+                return;
+            }
+        }
+
+        if (IsInitialContainingBlock(cb))
+        {
+            cbPadLeft = 0;
+            cbPadTop = 0;
+            cbPadWidth = LayoutEnvironment.ViewportSize.Width;
+            cbPadHeight = LayoutEnvironment.ViewportSize.Height;
+            return;
+        }
+
+        cbPadLeft = cb.Location.X + cb.ActualBorderLeftWidth;
+        cbPadTop = cb.Location.Y + cb.ActualBorderTopWidth;
+        cbPadWidth = cb.Size.Width - cb.ActualBorderLeftWidth - cb.ActualBorderRightWidth;
+        cbPadHeight = (cb.ActualBottom - cb.Location.Y) - cb.ActualBorderTopWidth - cb.ActualBorderBottomWidth;
+    }
+
+    /// <summary>
+    /// CSS2.1 §10.1: When the containing block for an absolutely positioned
+    /// element is formed by an inline-level element, the containing block is
+    /// the bounding box around the padding boxes of the first and last inline
+    /// boxes generated for that element.  Returns the bounding rectangle in
+    /// absolute coordinates, or <see cref="RectangleF.Empty"/> if the inline
+    /// has no line-box rectangles and no laid-out children.
+    /// </summary>
+    private static RectangleF GetInlineBoundingBox(CssBox cb)
+    {
+        float minX = float.MaxValue, minY = float.MaxValue;
+        float maxX = float.MinValue, maxY = float.MinValue;
+
+        // Accumulate extents from one box (the original or a fragment).
+        void AccumulateBox(CssBox box)
+        {
+            // Try the inline's own Rectangles (populated when the
+            // inline element has direct text words).
+            foreach (var rect in box.Rectangles.Values)
+            {
+                if (rect.Left < minX) minX = rect.Left;
+                if (rect.Top < minY) minY = rect.Top;
+                if (rect.Right > maxX) maxX = rect.Right;
+                if (rect.Bottom > maxY) maxY = rect.Bottom;
+            }
+
+            // Also scan child boxes (inline-blocks etc.) for their
+            // laid-out positions and sizes.
+            foreach (var child in box.Boxes)
+            {
+                if (child.Size.Width <= 0 && child.Size.Height <= 0)
+                    continue;
+                float left = child.Location.X;
+                float top = child.Location.Y;
+                float right = left + child.Size.Width;
+                float bottom = (float)child.ActualBottom;
+                if (bottom <= top) bottom = top + child.Size.Height;
+
+                if (left < minX) minX = left;
+                if (top < minY) minY = top;
+                if (right > maxX) maxX = right;
+                if (bottom > maxY) maxY = bottom;
+            }
+        }
+
+        // Scan the original box.
+        AccumulateBox(cb);
+
+        // If the positioned inline was split by the block-inside-inline
+        // correction, also scan inline fragment copies that received its
+        // children so the bounding box covers the full inline extent.
+        // Only include fragments that are still inline — block-level
+        // anonymous wrappers created during the split are structural
+        // containers, not inline fragments.
+        if (cb.SplitFragments != null)
+        {
+            foreach (var frag in cb.SplitFragments)
+            {
+                if (frag.Display == CssConstants.Inline)
+                    AccumulateBox(frag);
+            }
+        }
+
+        if (minX > maxX || minY > maxY)
+            return RectangleF.Empty;
+
+        return new RectangleF(minX, minY, maxX - minX, maxY - minY);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the given box is a pure inline element
+    /// (not inline-block/inline-table etc.) whose containing-block extent
+    /// must be computed from its line-box rectangles per CSS2.1 §10.1.
+    /// </summary>
+    private static bool IsInlineContainingBlock(CssBox cb) =>
+        cb.Display == CssConstants.Inline;
+
+    /// <summary>
+    /// Returns true when <see cref="Height"/> is a percentage that resolves
+    /// to auto because the containing block's height is not explicitly
+    /// specified (CSS 2.1 §10.5).  Callers must still verify that Height is
+    /// not auto/empty before using this — the check only tests whether a
+    /// non-auto percentage value should be treated as auto.
+    /// </summary>
+    internal bool HeightPercentageResolvesToAuto()
+    {
+        if (!Height.Contains('%'))
+            return false;
+
+        // CSS 2.1 §10.5: "A percentage height on the root element is
+        // relative to the initial containing block."  The initial
+        // containing block always has a definite height (the viewport),
+        // so percentage heights on the root element never resolve to auto.
+        if (ContainingBlock?.ParentBox == null)
+            return false;
+
+        return ContainingBlock.Height == CssConstants.Auto
+            || string.IsNullOrEmpty(ContainingBlock.Height);
+    }
+
+    public HtmlTag HtmlTag { get; }
+
+    public bool IsImage => Words.Count == 1 && Words[0].IsImage;
+
+    public ReadOnlyMemory<char> Text
+    {
+        get { return _text; }
+        set
+        {
+            _text = value;
+            Words.Clear();
+        }
+    }
+
+    internal List<CssLineBox> LineBoxes { get; } = [];
+    internal Dictionary<CssLineBox, RectangleF> Rectangles { get; } = [];
+    internal List<CssRect> Words { get; } = [];
+    internal CssRect FirstWord => Words[0];
+
+    internal CssLineBox FirstHostingLineBox { get; set; }
+
+    internal CssLineBox LastHostingLineBox { get; set; }
+
+    internal Uri BaseUrl { get; set; }
+
+    public void PerformLayout(ILayoutEnvironment g)
+    {
+        try
+        {
+            PerformLayoutImp(g);
+
+            // PROTOTYPE (BROILER_VERTICAL_FLOW): once a vertical-writing-mode
+            // root and its whole subtree have been laid out in the logical
+            // (horizontal) frame, rotate the result into physical space.
+            if (VerticalFlowPrototype.Enabled
+                && IsVerticalWritingMode(WritingMode)
+                && (ParentBox == null || !IsVerticalWritingMode(ParentBox.WritingMode)))
+            {
+                ApplyVerticalWritingModeFlow();
+            }
+        }
+        catch (Exception ex)
+        {
+            LayoutEnvironment.ReportLayoutError("Exception in box layout", ex);
+        }
+    }
+
+    /// <summary>
+    /// PROTOTYPE (BROILER_VERTICAL_FLOW), Stage 1: rotate this vertical
+    /// writing-mode root's subtree from the logical horizontal layout frame
+    /// into physical space.  The inline axis (laid out left→right) becomes
+    /// top→bottom; the block axis (laid out top→bottom) becomes left→right
+    /// for <c>vertical-lr</c> or right→left for <c>vertical-rl</c>.
+    ///
+    /// Positions and box/line rectangle extents are swapped; glyph runs keep
+    /// their horizontal size (no glyph rotation yet — Stage 2), so this is
+    /// positionally correct for square fonts and an approximation otherwise.
+    /// </summary>
+    private void ApplyVerticalWritingModeFlow()
+    {
+        // Capture the root's logical origin and block extent (its logical
+        // height) before any coordinate is rewritten.  For vertical-rl the
+        // block extent is mirrored so the first line sits at the right edge.
+        float rootX = Location.X;
+        float rootY = Location.Y;
+        double logicalBlockExtent = ActualBottom - Location.Y;
+        bool mirror = WritingMode is "vertical-rl" or "sideways-rl";
+
+        // vertical-rl / sideways-rl block flow runs right→left, so the root box
+        // is block-start (right) aligned within its containing block.  The
+        // logical horizontal layout frame left-aligned it at rootX; shift the
+        // whole rotated subtree right so the root's block-start edge sits at the
+        // containing block's content-right minus the block-start (right) margin.
+        // (vertical-lr keeps blockOffset 0: left-aligned is already correct.)
+        double blockOffset = 0;
+        if (mirror && ContainingBlock is { } cb)
+        {
+            double cbContentRight = cb.Location.X + cb.Size.Width
+                - cb.ActualPaddingRight - cb.ActualBorderRightWidth;
+            double desiredRootRight = cbContentRight - ActualMarginRight;
+            double currentRootRight = rootX + logicalBlockExtent;
+            blockOffset = desiredRootRight - currentRootRight;
+        }
+
+        TransformVerticalSubtree(this, rootX, rootY, logicalBlockExtent, mirror, blockOffset, isRoot: true);
+    }
+
+    private static void TransformVerticalSubtree(
+        CssBox box, float rootX, float rootY, double blockExtent, bool mirror, double blockOffset, bool isRoot)
+    {
+        // --- Box border-box: Location + Size ---
+        // logical (x,y) measured from root origin → physical (y,x): the inline
+        // offset becomes vertical, the block offset becomes horizontal.
+        double logicalLeft = box.Location.X - rootX;
+        double logicalTop = box.Location.Y - rootY;
+        double logicalWidth = box.Size.Width;
+        double logicalHeight = box.ActualBottom - box.Location.Y;
+
+        // The root keeps its own physical origin (the parent placed it in the
+        // horizontal frame), apart from the right-alignment shift; only its size
+        // is rotated.  Descendants rotate their position relative to the root.
+        if (!isRoot)
+        {
+            double physLeft = mirror
+                ? blockExtent - logicalTop - logicalHeight
+                : logicalTop;
+            box.Location = new PointF(rootX + (float)(blockOffset + physLeft), rootY + (float)logicalLeft);
+        }
+        else if (blockOffset != 0)
+        {
+            box.Location = new PointF(rootX + (float)blockOffset, rootY);
+        }
+
+        box.Size = new SizeF((float)logicalHeight, (float)logicalWidth);
+        box.ActualBottom = box.Location.Y + logicalWidth;
+
+        // Per-line rectangles cached on the box itself (inline backgrounds).
+        var boxRectKeys = new List<CssLineBox>(box.Rectangles.Keys);
+        foreach (var k in boxRectKeys)
+            box.Rectangles[k] = RotateRect(box.Rectangles[k], rootX, rootY, blockExtent, mirror, blockOffset);
+
+        // --- Line boxes owned by this box: words + per-box rectangles ---
+        foreach (var line in box.LineBoxes)
+        {
+            var rotatedWords = new List<CssRect>(line.Words.Count);
+            foreach (var word in line.Words)
+            {
+                // Column X = the line's block offset (lines advance left→right
+                // for vertical-lr, right→left for vertical-rl).  Column Y top =
+                // the word's inline offset (the inline axis runs top→bottom).
+                double wLeft = word.Left - rootX;
+                double wTop = word.Top - rootY;
+                double colX = rootX + blockOffset + (mirror ? blockExtent - wTop - word.Height : wTop);
+                double colTop = rootY + wLeft;
+
+                // Stage 3: decompose a multi-glyph run into per-glyph cells
+                // stacked along the inline (vertical) axis.  Each glyph advances
+                // by its inline advance (≈ run width / glyph count — exact for
+                // monospace/square fonts, approximate otherwise).  This is what
+                // the position-only transform alone could not do: without it a
+                // run paints horizontally and overlaps the next column.
+                string text = word.Text;
+                if (text != null && text.Length > 1 && !word.IsLineBreak)
+                {
+                    double advance = word.Width / text.Length;
+                    for (int i = 0; i < text.Length; i++)
+                    {
+                        var glyph = new CssRectWord(word.OwnerBox, text[i].ToString(), false, false)
+                        {
+                            Left = colX,
+                            Top = colTop + i * advance,
+                            Width = advance,
+                            Height = word.Height,
+                        };
+                        rotatedWords.Add(glyph);
+                    }
+                }
+                else
+                {
+                    word.Left = colX;
+                    word.Top = colTop;
+                    rotatedWords.Add(word);
+                }
+            }
+
+            line.Words.Clear();
+            line.Words.AddRange(rotatedWords);
+
+            var keys = new List<CssBox>(line.Rectangles.Keys);
+            foreach (var k in keys)
+                line.Rectangles[k] = RotateRect(line.Rectangles[k], rootX, rootY, blockExtent, mirror, blockOffset);
+        }
+
+        foreach (var child in box.Boxes)
+        {
+            if (child.Display == CssConstants.None)
+                continue;
+            TransformVerticalSubtree(child, rootX, rootY, blockExtent, mirror, blockOffset, isRoot: false);
+        }
+    }
+
+    private static RectangleF RotateRect(RectangleF r, float rootX, float rootY, double blockExtent, bool mirror, double blockOffset)
+    {
+        double logicalLeft = r.X - rootX;
+        double logicalTop = r.Y - rootY;
+        double physLeft = mirror ? blockExtent - logicalTop - r.Height : logicalTop;
+        return new RectangleF(
+            rootX + (float)(blockOffset + physLeft),
+            rootY + (float)logicalLeft,
+            r.Height,
+            r.Width);
+    }
+
+    public void SetBeforeBox(CssBox before)
+    {
+        int index = _parentBox.Boxes.IndexOf(before);
+
+        if (index < 0)
+            throw new Exception("before box doesn't exist on parent");
+
+        _parentBox.Boxes.Remove(this);
+        _parentBox.Boxes.Insert(index, this);
+    }
+
+    public void SetAllBoxes(CssBox fromBox)
+    {
+        foreach (var childBox in fromBox.Boxes)
+            childBox._parentBox = this;
+
+        Boxes.AddRange(fromBox.Boxes);
+        fromBox.Boxes.Clear();
+    }
+
+    public void ParseToWords()
+    {
+        Words.Clear();
+
+        // CSS2.1 §4.3.8: UAs should not render characters from the Unicode
+        // "control characters" category (C0 U+0000–U+001F except tab/LF/CR,
+        // and C1 U+007F–U+009F).  Strip them before word splitting.
+        // Per HTML spec §13.2.2, U+0000 (NULL) is replaced with U+FFFD
+        // (REPLACEMENT CHARACTER) so it remains visible.
+        var textSpan = _text.Span;
+        bool hasControl = false;
+        for (int i = 0; i < textSpan.Length; i++)
+        {
+            char c = textSpan[i];
+            if (c != '\t' && c != '\n' && c != '\r'
+                && (char.IsControl(c) || (c >= '\u007F' && c <= '\u009F')))
+            {
+                hasControl = true;
+                break;
+            }
+        }
+        if (hasControl)
+        {
+            var sb = new System.Text.StringBuilder(textSpan.Length);
+            for (int i = 0; i < textSpan.Length; i++)
+            {
+                char c = textSpan[i];
+                if (c == '\0')
+                    sb.Append('\uFFFD'); // HTML spec: NULL → REPLACEMENT CHARACTER
+                else if (c == '\t' || c == '\n' || c == '\r'
+                    || (!char.IsControl(c) && (c < '\u007F' || c > '\u009F')))
+                    sb.Append(c);
+            }
+            _text = sb.ToString().AsMemory();
+        }
+
+        int startIdx = 0;
+        bool preserveSpaces = WhiteSpace == CssConstants.Pre || WhiteSpace == CssConstants.PreWrap;
+        bool respoctNewline = preserveSpaces || WhiteSpace == CssConstants.PreLine;
+
+        textSpan = _text.Span;
+        while (startIdx < textSpan.Length)
+        {
+            while (startIdx < textSpan.Length && textSpan[startIdx] == '\r')
+                startIdx++;
+
+            if (startIdx >= textSpan.Length)
+                continue;
+
+            var endIdx = startIdx;
+
+            while (endIdx < textSpan.Length && char.IsWhiteSpace(textSpan[endIdx]) && textSpan[endIdx] != '\n')
+                endIdx++;
+
+            if (endIdx > startIdx)
+            {
+                if (preserveSpaces)
+                {
+                    // CSS2.1 §16.6: For pre-wrap, emit each space as a
+                    // separate word so the layout engine can break lines
+                    // at any space position.  For pre, emit the entire
+                    // whitespace run as one word (no wrapping allowed).
+                    if (WhiteSpace == CssConstants.PreWrap)
+                    {
+                        // Cache " " string to avoid per-char allocation
+                        const string singleSpace = " ";
+                        for (int i = startIdx; i < endIdx; i++)
+                        {
+                            var ch = _text.Slice(i, 1).ToString();
+                            Words.Add(new CssRectWord(this, ch == " " ? singleSpace : ch, false, false));
+                        }
+                    }
+                    else
+                    {
+                        Words.Add(new CssRectWord(this, HtmlUtils.DecodeHtml(_text.Slice(startIdx, endIdx - startIdx).ToString()), false, false));
+                    }
+                }
+            }
+            else
+            {
+                endIdx = startIdx;
+
+                while (endIdx < textSpan.Length && !char.IsWhiteSpace(textSpan[endIdx]) && textSpan[endIdx] != '-' && WordBreak != CssConstants.BreakAll && !CommonUtils.IsAsianCharecter(textSpan[endIdx]))
+                    endIdx++;
+
+                if (endIdx < textSpan.Length && (textSpan[endIdx] == '-' || WordBreak == CssConstants.BreakAll || CommonUtils.IsAsianCharecter(textSpan[endIdx])))
+                {
+                    endIdx++;
+                    if (endIdx < textSpan.Length &&
+                        char.IsHighSurrogate(textSpan[endIdx - 1]) &&
+                        char.IsLowSurrogate(textSpan[endIdx]))
+                    {
+                        endIdx++;
+                    }
+                }
+
+                if (endIdx > startIdx)
+                {
+                    var hasSpaceBefore = !preserveSpaces && startIdx > 0 && Words.Count == 0 && char.IsWhiteSpace(textSpan[startIdx - 1]);
+                    var hasSpaceAfter = !preserveSpaces && endIdx < textSpan.Length && char.IsWhiteSpace(textSpan[endIdx]);
+
+                    Words.Add(new CssRectWord(this, HtmlUtils.DecodeHtml(_text.Slice(startIdx, endIdx - startIdx).ToString()), hasSpaceBefore, hasSpaceAfter));
+                }
+            }
+
+            // create new-line word so it will effect the layout
+            if (endIdx < textSpan.Length && textSpan[endIdx] == '\n')
+            {
+                endIdx++;
+
+                if (respoctNewline)
+                    Words.Add(new CssRectWord(this, "\n", false, false));
+            }
+
+            startIdx = endIdx;
+        }
+    }
+
+    public virtual void Dispose()
+    {
+        if (_backgroundImageLoadHandlers != null)
+        {
+            foreach (var imageLoadHandler in _backgroundImageLoadHandlers)
+                imageLoadHandler?.Dispose();
+        }
+
+        foreach (var childBox in Boxes)
+            childBox.Dispose();
+    }
+
+    protected virtual void PerformLayoutImp(ILayoutEnvironment g)
+    {
+        if (Display != CssConstants.None)
+        {
+            RectanglesReset();
+            MeasureWordsSize(g);
+        }
+
+        // CSS Box Model 4 §6.2: margin-trim zeroes the block-axis margins of
+        // this container's first/last in-flow block-level children before they
+        // are laid out, so the trimmed margins collapse to nothing.
+        ApplyMarginTrim();
+
+        if (IsBlock || Display == CssConstants.ListItem || Display == CssConstants.Table || Display == CssConstants.InlineTable || Display == CssConstants.TableCell)
+        {
+            // Because their width and height are set by CssTable
+            if (Display != CssConstants.TableCell && Display != CssConstants.Table)
+            {
+                // CSS2.1 §9.6.1: The containing block for a fixed-position
+                // element is the viewport (initial containing block).
+                // CSS2.1 §10.1: For absolutely positioned elements, the
+                // containing block is the padding-box of the nearest
+                // positioned ancestor.
+                // Use the viewport width for percentage/auto resolution.
+                double width;
+                if (Position == CssConstants.Fixed && LayoutEnvironment != null)
+                {
+                    width = LayoutEnvironment.ViewportSize.Width;
+                }
+                else if (Position == CssConstants.Absolute)
+                {
+                    var cb = FindPositionedContainingBlock();
+                    GetAbsoluteContainingBlockPaddingBox(cb, out _, out _, out width, out _);
+                }
+                else
+                {
+                    width = ContainingBlock.Size.Width
+                            - ContainingBlock.ActualPaddingLeft - ContainingBlock.ActualPaddingRight
+                            - ContainingBlock.ActualBorderLeftWidth - ContainingBlock.ActualBorderRightWidth;
+                }
+
+                if (IsIntrinsicWidthKeyword(Width)
+                    && Float == CssConstants.None
+                    && Position != CssConstants.Absolute && Position != CssConstants.Fixed)
+                {
+                    // CSS Sizing 3 §5: width resolves to an intrinsic size
+                    // (min-content / max-content / fit-content).
+                    width = ResolveIntrinsicWidth(g, Width, width);
+                }
+                else if (Width != CssConstants.Auto && !string.IsNullOrEmpty(Width)
+                    && !IsIntrinsicWidthKeyword(Width))
+                {
+                    double containingWidth = width;
+                    width = string.Equals(Width, "inherit", StringComparison.OrdinalIgnoreCase) && GetParent() != null
+                        ? GetParent().ActualWidth
+                        : ParseLengthWithLineHeight(Width, containingWidth);
+
+                    // CSS2.1 §10.4: Apply max-width constraint
+                    if (MaxWidth != "none" && !string.IsNullOrEmpty(MaxWidth))
+                    {
+                        double maxW = ParseLengthWithLineHeight(MaxWidth, containingWidth);
+                        if (width > maxW) width = maxW;
+                    }
+
+                    // CSS2.1 §10.4: Apply min-width constraint (min wins over max per §10.4)
+                    if (MinWidth != "0" && !string.IsNullOrEmpty(MinWidth))
+                    {
+                        double minW = ParseLengthWithLineHeight(MinWidth, containingWidth);
+                        if (width < minW) width = minW;
+                    }
+
+                    width = ResolveSpecifiedWidthToBorderBox(width);
+                }
+                else if ((Position == CssConstants.Absolute || Position == CssConstants.Fixed)
+                    && Left != null && Left != CssConstants.Auto
+                    && Right != null && Right != CssConstants.Auto)
+                {
+                    // CSS2.1 §10.3.7: For absolutely positioned, non-replaced
+                    // elements when width is auto and both left and right are
+                    // specified, compute width from the constraint equation:
+                    // left + margin-left + width + margin-right + right = CB width
+                    double cbContentWidth = width;
+                    if (Position == CssConstants.Fixed && LayoutEnvironment != null)
+                        cbContentWidth = LayoutEnvironment.ViewportSize.Width;
+                    double cssLeft = CssValueParser.ParseLength(Left, cbContentWidth, GetEmHeight());
+                    double cssRight = CssValueParser.ParseLength(Right, cbContentWidth, GetEmHeight());
+                    width = cbContentWidth - cssLeft - cssRight - ActualMarginLeft - ActualMarginRight;
+                    if (width < 0) width = 0;
+                    width = ResolveSpecifiedWidthToBorderBox(width);
+                }
+
+                // CSS2.1 §10.4: Apply max-width constraint even when
+                // Width is auto — the tentative used width must not exceed
+                // max-width.
+                if (MaxWidth != "none" && !string.IsNullOrEmpty(MaxWidth))
+                {
+                    double maxW = ParseLengthWithLineHeight(MaxWidth, width);
+                    maxW = ResolveSpecifiedWidthToBorderBox(maxW);
+                    if (width > maxW) width = maxW;
+                }
+
+                // CSS2.1 §10.4: Apply min-width constraint (min wins over
+                // max per §10.4) — also when Width is auto.
+                if (MinWidth != "0" && !string.IsNullOrEmpty(MinWidth))
+                {
+                    double minW = ParseLengthWithLineHeight(MinWidth, width);
+                    minW = ResolveSpecifiedWidthToBorderBox(minW);
+                    if (width < minW) width = minW;
+                }
+
+                Size = new SizeF((float)width, Size.Height);
+
+                // CSS2.1 §10.3.3: For block-level, non-replaced elements in
+                // normal flow with an explicit width and auto margins, resolve
+                // the auto margins so the element is centered horizontally.
+                if (Width != CssConstants.Auto && !string.IsNullOrEmpty(Width)
+                    && Float == CssConstants.None
+                    && Position != CssConstants.Absolute && Position != CssConstants.Fixed)
+                {
+                    double containingContentWidth = ContainingBlock.Size.Width
+                        - ContainingBlock.ActualPaddingLeft - ContainingBlock.ActualPaddingRight
+                        - ContainingBlock.ActualBorderLeftWidth - ContainingBlock.ActualBorderRightWidth;
+                    double remainingSpace = containingContentWidth - Size.Width;
+
+                    if (MarginLeft == CssConstants.Auto && MarginRight == CssConstants.Auto)
+                    {
+                        if (remainingSpace >= 0)
+                        {
+                            string halfMargin = (remainingSpace / 2).ToString("F4",
+                                CultureInfo.InvariantCulture) + "px";
+                            MarginLeft = halfMargin;
+                            MarginRight = halfMargin;
+                        }
+                        else
+                        {
+                            MarginLeft = "0";
+                            MarginRight = "0";
+                        }
+                    }
+                    else if (MarginLeft == CssConstants.Auto)
+                    {
+                        double rightMargin = ActualMarginRight;
+                        double leftMargin = Math.Max(0, remainingSpace - rightMargin);
+                        MarginLeft = leftMargin.ToString("F4",
+                            CultureInfo.InvariantCulture) + "px";
+                    }
+                    else if (MarginRight == CssConstants.Auto)
+                    {
+                        double leftMargin = ActualMarginLeft;
+                        double rightMargin = Math.Max(0, remainingSpace - leftMargin);
+                        MarginRight = rightMargin.ToString("F4",
+                            CultureInfo.InvariantCulture) + "px";
+                    }
+                }
+
+                // CSS2.1 §10.3.7: Absolutely positioned non-replaced elements
+                // with auto width use shrink-to-fit when at least one of
+                // left/right is auto.  Shrink-to-fit =
+                //   min(max(preferred_minimum, available), preferred)
+                if ((Width == CssConstants.Auto || string.IsNullOrEmpty(Width))
+                    && (Position == CssConstants.Absolute || Position == CssConstants.Fixed)
+                    && (Left == null || Left == CssConstants.Auto
+                     || Right == null || Right == CssConstants.Auto))
+                {
+                    // Ensure descendant word sizes (and ActualWordSpacing) are
+                    // measured before computing intrinsic min/max widths.
+                    // Without this, word.FullWidth may be NaN because
+                    // ActualWordSpacing defaults to NaN until MeasureWordSpacing
+                    // runs, causing the entire shrink-to-fit result to be NaN.
+                    EnsureDescendantWordsMeasured(g);
+
+                    // Compute preferred width by independently measuring each
+                    // direct child and taking the maximum.  This correctly
+                    // treats each block/float child as its own "line" and avoids
+                    // the additive accumulation in GetMinMaxSumWords where a
+                    // float's width would incorrectly sum with a preceding
+                    // block child's width.
+                    double preferred = ComputeShrinkToFitWidth();
+                    double available = width - ActualMarginLeft - ActualMarginRight;
+
+                    GetMinMaxWidth(out double prefMin, out _);
+                    // Guard against NaN from unmeasured descendants
+                    if (double.IsNaN(prefMin)) prefMin = 0;
+                    if (double.IsNaN(preferred)) preferred = 0;
+                    double stfWidth = Math.Min(Math.Max(prefMin, available), preferred);
+
+                    if (MaxWidth != "none" && !string.IsNullOrEmpty(MaxWidth))
+                    {
+                        double maxW = ParseLengthWithLineHeight(MaxWidth, width);
+                        if (stfWidth > maxW) stfWidth = maxW;
+                    }
+                    if (MinWidth != "0" && !string.IsNullOrEmpty(MinWidth))
+                    {
+                        double minW = ParseLengthWithLineHeight(MinWidth, width);
+                        if (stfWidth < minW) stfWidth = minW;
+                    }
+
+                    // CSS2.1 §10.3.7: Shrink-to-fit gives the content
+                    // width; add own borders and padding for the border-box
+                    // width that Size.Width represents.
+                    stfWidth += ActualBorderLeftWidth + ActualBorderRightWidth
+                              + ActualPaddingLeft + ActualPaddingRight;
+
+                    Size = new SizeF((float)stfWidth, Size.Height);
+                }
+                else if ((Width == CssConstants.Auto || string.IsNullOrEmpty(Width))
+                    && Float != CssConstants.None)
+                {
+                    // CSS2.1 §10.3.5: Floating non-replaced elements with
+                    // 'width: auto' use shrink-to-fit width.
+                    EnsureDescendantWordsMeasured(g);
+
+                    double preferred = ComputeShrinkToFitWidth();
+                    double available = width - ActualMarginLeft - ActualMarginRight;
+
+                    GetMinMaxWidth(out double prefMin, out _);
+                    if (double.IsNaN(prefMin)) prefMin = 0;
+                    if (double.IsNaN(preferred)) preferred = 0;
+                    double stfWidth = Math.Min(Math.Max(prefMin, available), preferred);
+
+                    if (MaxWidth != "none" && !string.IsNullOrEmpty(MaxWidth))
+                    {
+                        double maxW = ParseLengthWithLineHeight(MaxWidth, width);
+                        if (stfWidth > maxW) stfWidth = maxW;
+                    }
+                    if (MinWidth != "0" && !string.IsNullOrEmpty(MinWidth))
+                    {
+                        double minW = ParseLengthWithLineHeight(MinWidth, width);
+                        if (stfWidth < minW) stfWidth = minW;
+                    }
+
+                    stfWidth += ActualBorderLeftWidth + ActualBorderRightWidth
+                              + ActualPaddingLeft + ActualPaddingRight;
+
+                    Size = new SizeF((float)stfWidth, Size.Height);
+                }
+                else if (Width == CssConstants.Auto || string.IsNullOrEmpty(Width))
+                {
+                    // Margins reduce the box width only for auto-width elements.
+                    // For explicit widths, margins affect position only (CSS1 box model).
+                    Size = new SizeF((float)(width - ActualMarginLeft - ActualMarginRight), Size.Height);
+                }
+            }
+
+            if (Display != CssConstants.TableCell)
+            {
+                var prevSibling = LayoutBoxUtils.GetPreviousSibling(this);
+
+                // Compute the static position for all elements (including
+                // position:fixed).  Fixed elements need the static position
+                // as fallback when offset properties are auto (CSS2.1 §10.6.4).
+                {
+                    double left = ContainingBlock.Location.X + ContainingBlock.ActualPaddingLeft + ActualMarginLeft + ContainingBlock.ActualBorderLeftWidth;
+
+                    // CSS2.1 §9.5: floats are out of normal flow. Non-floated
+                    // blocks must be positioned as if preceding floats do not
+                    // exist.  For cleared elements this also prevents margin
+                    // collapsing with the float (CSS2.1 §8.3.1).
+                    var flowPrev = prevSibling;
+                    if (Float == CssConstants.None
+                        && flowPrev != null && flowPrev.Float != CssConstants.None)
+                    {
+                        flowPrev = LayoutBoxUtils.GetPreviousInFlowSibling(flowPrev);
+                    }
+
+                    // CSS2.1 §9.4.3: Relative positioning is visual-only.
+                    // Use the flow-position bottom (before relative offset)
+                    // when computing the next sibling's position.
+                    double flowPrevBottom = flowPrev?.ActualBottom ?? 0;
+                    if (flowPrev is CssBox flowPrevBox && flowPrevBox.Position == CssConstants.Relative)
+                        flowPrevBottom -= CssBoxHelper.GetRelativeOffsetY(flowPrevBox);
+
+                    // CSS2.1 §8.3.1: MarginTopCollapse may propagate margins
+                    // and update the parent's Location, so compute it before
+                    // reading ParentBox.ClientTop.
+                    double marginCollapse = MarginTopCollapse(flowPrev);
+                    double top = (flowPrev == null && ParentBox != null ? ParentBox.ClientTop : ParentBox == null ? Location.Y : 0) + marginCollapse + flowPrevBottom;
+
+                    // --- Float positioning ---
+                    if (Float != CssConstants.None)
+                    {
+                        // Align Y with previous float sibling if consecutive
+                        if (prevSibling != null && prevSibling.Float != CssConstants.None)
+                            top = prevSibling.Location.Y;
+
+                        double containerLeft = ContainingBlock.Location.X + ContainingBlock.ActualPaddingLeft + ContainingBlock.ActualBorderLeftWidth;
+                        double containerRight = ContainingBlock.ClientLeft + ContainingBlock.AvailableWidth;
+                        double floatHeight = Math.Max(ActualHeight + ActualPaddingTop + ActualPaddingBottom + ActualBorderTopWidth + ActualBorderBottomWidth, 1);
+
+                        // Collect all preceding floats in the BFC, including
+                        // those nested inside non-BFC siblings (CSS2.1 §9.5.1).
+                        var precedingFloats = CssBoxHelper.CollectPrecedingFloatsInBfc(this);
+
+                        // CSS2.1 §9.5.1 rule 4: A floating box's outer top
+                        // (margin edge) may not be higher than the top of its
+                        // containing block.  `top` already includes the margin
+                        // contribution (from MarginTopCollapse), so the outer
+                        // (margin-edge) top = top - ActualMarginTop.  The
+                        // constraint outer_top >= ClientTop translates to:
+                        //   top >= ClientTop + ActualMarginTop
+                        // This allows negative margins to pull the float above
+                        // the content-area edge while still honoring the rule.
+                        if (ParentBox != null)
+                            top = Math.Max(top, ParentBox.ClientTop + ActualMarginTop);
+
+                        // CSS2.1 §9.5.1 rule 6: The outer top of a floating
+                        // box may not be higher than the outer top of any
+                        // block or floated box generated by an element earlier
+                        // in the source document.
+                        foreach (var pf in precedingFloats)
+                            top = Math.Max(top, pf.Location.Y);
+
+                        if (Float == CssConstants.Left)
+                        {
+                            // Iteratively resolve collisions with all prior floats (CSS1 §5.5.25)
+                            for (int iter = 0; iter < 100; iter++)
+                            {
+                                left = containerLeft + ActualMarginLeft;
+
+                                foreach (var floatBox in precedingFloats)
+                                {
+                                    if (floatBox.Float == CssConstants.Left)
+                                    {
+                                        double fBottom = floatBox.ActualBottom;
+                                        if (top < fBottom && top + floatHeight > floatBox.Location.Y)
+                                            left = Math.Max(left, floatBox.Location.X + floatBox.Size.Width + floatBox.ActualMarginRight + ActualMarginLeft);
+                                    }
+                                }
+
+                                // Also ensure left float doesn't overlap with right floats
+                                double effectiveRight = containerRight;
+                                foreach (var floatBox in precedingFloats)
+                                {
+                                    if (floatBox.Float == CssConstants.Right)
+                                    {
+                                        double fBottom = floatBox.ActualBottom;
+                                        if (top < fBottom && top + floatHeight > floatBox.Location.Y)
+                                            effectiveRight = Math.Min(effectiveRight, floatBox.Location.X - floatBox.ActualMarginLeft);
+                                    }
+                                }
+
+                                if (left + Size.Width <= effectiveRight)
+                                    break;
+
+                                // Move below the lowest overlapping float
+                                double maxBottom = top;
+                                foreach (var floatBox in precedingFloats)
+                                {
+                                    double fBottom = floatBox.ActualBottom;
+                                    if (top < fBottom && top + floatHeight > floatBox.Location.Y)
+                                        maxBottom = Math.Max(maxBottom, fBottom);
+                                }
+
+                                if (maxBottom <= top) break;
+                                top = maxBottom;
+                            }
+                        }
+                        else if (Float == CssConstants.Right)
+                        {
+                            // Iteratively resolve collisions with all prior floats (CSS1 §5.5.26)
+                            for (int iter = 0; iter < 100; iter++)
+                            {
+                                left = containerRight - Size.Width - ActualMarginRight;
+
+                                // Avoid overlapping with preceding right floats
+                                foreach (var floatBox in precedingFloats)
+                                {
+                                    if (floatBox.Float == CssConstants.Right)
+                                    {
+                                        double fBottom = floatBox.ActualBottom;
+                                        if (top < fBottom && top + floatHeight > floatBox.Location.Y)
+                                            left = Math.Min(left, floatBox.Location.X - floatBox.ActualMarginLeft - Size.Width - ActualMarginRight);
+                                    }
+                                }
+
+                                // Ensure right float doesn't overlap with left floats
+                                double leftFloatEdge = containerLeft;
+                                foreach (var floatBox in precedingFloats)
+                                {
+                                    if (floatBox.Float == CssConstants.Left)
+                                    {
+                                        double fBottom = floatBox.ActualBottom;
+                                        if (top < fBottom && top + floatHeight > floatBox.Location.Y)
+                                            leftFloatEdge = Math.Max(leftFloatEdge, floatBox.Location.X + floatBox.Size.Width + floatBox.ActualMarginRight);
+                                    }
+                                }
+
+                                if (left >= leftFloatEdge)
+                                    break;
+
+                                // Move below the lowest overlapping float
+                                double maxBottom = top;
+                                foreach (var floatBox in precedingFloats)
+                                {
+                                    double fBottom = floatBox.ActualBottom;
+                                    if (top < fBottom && top + floatHeight > floatBox.Location.Y)
+                                        maxBottom = Math.Max(maxBottom, fBottom);
+                                }
+
+                                if (maxBottom <= top) break;
+                                top = maxBottom;
+                            }
+                        }
+                    }
+
+                    // CSS2.1 §8.3.1/§9.5.2: Handle clear property.  Clearance
+                    // inhibits margin collapsing and pushes the border edge of the
+                    // cleared element below the bottom outer edge of the relevant
+                    // floats.  Clearance can be negative when the uncollapsed
+                    // position is already past the float.
+                    if (Clear != CssConstants.None)
+                    {
+                        double maxFloatBottom = CssBoxHelper.GetMaxFloatBottom(this);
+                        if (maxFloatBottom > 0)
+                        {
+                            double hypotheticalTop = top;
+
+                            // Compute uncollapsed position: margins are NOT
+                            // collapsed when clearance is present (§8.3.1).
+                            // Use the effective margin for empty collapsible
+                            // boxes (§8.3.1 margin-through-collapse).
+                            double uncollapsedTop;
+                            if (flowPrev != null)
+                            {
+                                double prevMarginBottom = (flowPrev is CssBox fpb)
+                                    ? CssBoxHelper.GetEffectiveMarginBottom(fpb)
+                                    : flowPrev.ActualMarginBottom;
+                                uncollapsedTop = flowPrevBottom
+                                    + prevMarginBottom
+                                    + ActualMarginTop;
+                            }
+                            else if (ParentBox != null)
+                            {
+                                uncollapsedTop = ParentBox.ClientTop + ActualMarginTop;
+                            }
+                            else
+                            {
+                                uncollapsedTop = hypotheticalTop;
+                            }
+
+                            // CSS2.2 §9.5.2: Only introduce clearance when the
+                            // hypothetical position (where the top border edge
+                            // would be if 'clear' were 'none') is NOT past the
+                            // relevant floats.  When the margin alone already
+                            // places the element past the float, no clearance is
+                            // needed and margin collapsing is preserved.
+                            if (hypotheticalTop < maxFloatBottom)
+                            {
+                                // clearance = max(amount to clear float, amount to
+                                // reach hypothetical position).  This can be negative.
+                                double clearance = Math.Max(
+                                    maxFloatBottom - uncollapsedTop,
+                                    hypotheticalTop - uncollapsedTop);
+
+                                top = uncollapsedTop + clearance;
+                            }
+                        }
+                    }
+
+                    // CSS2.1 §9.5: The border box of an element in normal
+                    // flow that establishes a new BFC must not overlap the
+                    // margin box of any floats in the same BFC.  Shift the
+                    // block right past left floats and narrow it to avoid
+                    // right floats.  If it cannot fit beside the floats,
+                    // clear below them.
+                    if (Float == CssConstants.None
+                        && Position != CssConstants.Absolute && Position != CssConstants.Fixed)
+                    {
+                        bool isBfcRoot = Display == CssConstants.InlineBlock
+                            || Display == CssConstants.TableCell
+                            || Display is "flex" or "inline-flex" or "grid" or "inline-grid"
+                            || (Overflow != null && Overflow != CssConstants.Visible)
+                            || (AlignContent != null && AlignContent != "normal");
+
+                        if (isBfcRoot)
+                        {
+                            var precedingFloats = CssBoxHelper.CollectPrecedingFloatsInBfc(this);
+                            if (precedingFloats.Count > 0)
+                            {
+                                double containerLeft = ContainingBlock.Location.X + ContainingBlock.ActualPaddingLeft + ContainingBlock.ActualBorderLeftWidth;
+                                double containerRight = ContainingBlock.ClientLeft + ContainingBlock.AvailableWidth;
+                                double boxHeight = Math.Max(Size.Height, GetEmHeight());
+
+                                // Try to fit beside floats; if not possible, clear
+                                // below them.  100 iterations is a safe upper bound
+                                // since each iteration advances past at least one
+                                // float's bottom edge.
+                                for (int bfcIter = 0; bfcIter < 100; bfcIter++)
+                                {
+                                    double leftEdge = containerLeft + ActualMarginLeft;
+                                    double rightEdge = containerRight - ActualMarginRight;
+
+                                    foreach (var fb in precedingFloats)
+                                    {
+                                        double fbBottom = fb.ActualBottom + fb.ActualMarginBottom;
+                                        if (top < fbBottom && top + boxHeight > fb.Location.Y - fb.ActualMarginTop)
+                                        {
+                                            if (fb.Float == CssConstants.Left)
+                                                leftEdge = Math.Max(leftEdge, fb.Location.X + fb.Size.Width + fb.ActualMarginRight + ActualMarginLeft);
+                                            else if (fb.Float == CssConstants.Right)
+                                                rightEdge = Math.Min(rightEdge, fb.Location.X - fb.ActualMarginLeft - ActualMarginRight);
+                                        }
+                                    }
+
+                                    double availableWidth = rightEdge - leftEdge;
+                                    if (availableWidth >= Size.Width || availableWidth >= 0)
+                                    {
+                                        left = leftEdge;
+                                        if (availableWidth < Size.Width && (Width == CssConstants.Auto || string.IsNullOrEmpty(Width)))
+                                            Size = new SizeF((float)availableWidth, Size.Height);
+                                        break;
+                                    }
+
+                                    // Cannot fit beside floats — clear below them.
+                                    double maxFb = top;
+                                    foreach (var fb in precedingFloats)
+                                    {
+                                        double fbBottom = fb.ActualBottom + fb.ActualMarginBottom;
+                                        if (top < fbBottom && top + boxHeight > fb.Location.Y - fb.ActualMarginTop)
+                                            maxFb = Math.Max(maxFb, fbBottom);
+                                    }
+                                    if (maxFb <= top) break;
+                                    top = maxFb;
+                                }
+                            }
+                        }
+                    }
+
+                    Location = new PointF((float)left, (float)top);
+                    ActualBottom = top;
+
+                    // CSS2.1 §10.3.7 / §10.6.4: For absolutely positioned
+                    // elements with explicit 'top'/'left', override the static
+                    // position with the CSS-specified offset from the containing
+                    // block's padding edge.
+                    if (Position == CssConstants.Absolute)
+                    {
+                        var cb = FindPositionedContainingBlock();
+                        GetAbsoluteContainingBlockPaddingBox(cb, out double cbPadLeft, out double cbPadTop, out double cbPadWidth, out double cbPadHeight);
+
+                        float newX = Location.X, newY = Location.Y;
+
+                        if (Left != null && Left != CssConstants.Auto)
+                        {
+                            double cssLeft = CssValueParser.ParseLength(Left, cbPadWidth, GetEmHeight());
+                            newX = (float)(cbPadLeft + cssLeft + ActualMarginLeft);
+                        }
+                        else if (Right != null && Right != CssConstants.Auto)
+                        {
+                            // CSS2.1 §10.3.7: When left is auto and right is
+                            // specified, position from the right padding edge.
+                            double cssRight = CssValueParser.ParseLength(Right, cbPadWidth, GetEmHeight());
+                            newX = (float)(cbPadLeft + cbPadWidth - cssRight - ActualMarginRight - Size.Width);
+                        }
+
+                        if (Top != null && Top != CssConstants.Auto)
+                        {
+                            double cssTop = CssValueParser.ParseLength(Top, cbPadHeight, GetEmHeight());
+                            newY = (float)(cbPadTop + cssTop + ActualMarginTop);
+                        }
+                        else if (Bottom != null && Bottom != CssConstants.Auto)
+                        {
+                            // CSS2.1 §10.6.4: When top is auto and bottom is
+                            // specified, position from the bottom padding edge.
+                            double cssBottom = CssValueParser.ParseLength(Bottom, cbPadHeight, GetEmHeight());
+                            double boxHeight = ActualBottom - Location.Y;
+                            // boxHeight may be zero when the box position was
+                            // just initialised and children have not yet been
+                            // laid out.  Fall back to Size.Height which reflects
+                            // any explicit CSS height already applied.
+                            if (boxHeight <= 0) boxHeight = Size.Height;
+                            newY = (float)(cbPadTop + cbPadHeight - cssBottom - ActualMarginBottom - boxHeight);
+                        }
+
+                        Location = new PointF(newX, newY);
+                        ActualBottom = newY;
+                    }
+
+                    // CSS2.1 §10.6.4 / §9.6.1: For fixed-position elements,
+                    // the containing block is the viewport.  When top/left/
+                    // bottom/right are explicitly set, use those offsets from
+                    // the viewport edge.  When they are auto, the static
+                    // position (computed above) is kept.
+                    if (Position == CssConstants.Fixed && LayoutEnvironment != null)
+                    {
+                        bool hasLeft = Left != null && Left != CssConstants.Auto;
+                        bool hasRight = Right != null && Right != CssConstants.Auto;
+                        bool hasTop = Top != null && Top != CssConstants.Auto;
+                        bool hasBottom = Bottom != null && Bottom != CssConstants.Auto;
+
+                        if (hasLeft || hasRight || hasTop || hasBottom)
+                        {
+                            var vpSize = LayoutEnvironment.ViewportSize;
+                            float newX = Location.X, newY = Location.Y;
+
+                            if (hasLeft)
+                            {
+                                double cssLeft = CssValueParser.ParseLength(Left, vpSize.Width, GetEmHeight());
+                                newX = (float)(cssLeft + ActualMarginLeft);
+                            }
+                            else if (hasRight)
+                            {
+                                double cssRight = CssValueParser.ParseLength(Right, vpSize.Width, GetEmHeight());
+                                newX = (float)(vpSize.Width - cssRight - ActualMarginRight - Size.Width);
+                            }
+
+                            if (hasTop)
+                            {
+                                double cssTop = CssValueParser.ParseLength(Top, vpSize.Height, GetEmHeight());
+                                newY = (float)(cssTop + ActualMarginTop);
+                            }
+                            else if (hasBottom)
+                            {
+                                double cssBottom = CssValueParser.ParseLength(Bottom, vpSize.Height, GetEmHeight());
+                                double boxHeight = ActualBottom - Location.Y;
+                                if (boxHeight <= 0) boxHeight = Size.Height;
+                                newY = (float)(vpSize.Height - cssBottom - ActualMarginBottom - boxHeight);
+                            }
+
+                            Location = new PointF(newX, newY);
+                            ActualBottom = newY;
+                        }
+                        // When all offsets are auto, keep the static position
+                        // (Location is already set from normal-flow
+                        // calculation above).
+                    }
+                }
+            }
+
+            // CSS2.1 §10.5: Pre-resolve percentage heights so that children
+            // can use ContainingBlock.Size.Height for their own percentage
+            // height resolution.  This must run AFTER position assignment
+            // (which resets Size.Height to 0 via ActualBottom = top) but
+            // BEFORE child layout so descendants see the correct height.
+            if (Height != CssConstants.Auto && !string.IsNullOrEmpty(Height)
+                && Height.Contains('%') && !HeightPercentageResolvesToAuto())
+            {
+                double cbHeight;
+                if (Position == CssConstants.Fixed && LayoutEnvironment != null)
+                    cbHeight = LayoutEnvironment.ViewportSize.Height;
+                else if (ContainingBlock?.ParentBox == null && LayoutEnvironment != null)
+                    cbHeight = LayoutEnvironment.ViewportSize.Height;
+                else
+                    cbHeight = ContainingBlock.Size.Height;
+                double preHeight = ResolveSpecifiedHeightToBorderBox(
+                    CssValueParser.ParseLength(Height, cbHeight, GetEmHeight()));
+                Size = new SizeF(Size.Width, (float)preHeight);
+            }
+
+            //If we're talking about a table here..
+            if (Display == CssConstants.Table || Display == CssConstants.InlineTable)
+            {
+                CssLayoutEngineTable.PerformLayout(g, this, BaseUrl);
+            }
+            else
+            {
+                // CSS Flexbox §8.2/§8.4: Map flex alignment properties to
+                // CSS2.1 text-align so that the inline formatting context
+                // fallback (FlowInlineBlock) produces visually aligned items.
+                // This only applies when the author has not set text-align
+                // explicitly (i.e. it still has the default 'left' value).
+                if (Display is "flex" or "inline-flex" or "grid" or "inline-grid")
+                {
+                    if (JustifyContent is "center" &&
+                        TextAlign is CssConstants.Left or "start" or "")
+                    {
+                        TextAlign = CssConstants.Center;
+                    }
+                    else if (JustifyContent is "flex-end" or "end" &&
+                        TextAlign is CssConstants.Left or "start" or "")
+                    {
+                        TextAlign = CssConstants.Right;
+                    }
+                }
+
+                if (IsRowFlexContainer())
+                {
+                    PerformFlexRowLayout(g);
+                }
+                //If there's just inline boxes, create LineBoxes
+                else if (LayoutBoxUtils.ContainsInlinesOnly(this))
+                {
+                    ActualBottom = Location.Y;
+                    CssLayoutEngine.CreateLineBoxes(g, this); //This will automatically set the bottom of this block
+
+                    // CSS2.1 §9.5: Floated children were skipped by
+                    // CreateLineBoxes (they are out-of-flow).  Lay them out
+                    // now so they are positioned and painted.
+                    foreach (var childBox in Boxes)
+                    {
+                        if (childBox.Float != CssConstants.None)
+                        {
+                            childBox.PerformLayout(g);
+
+                            // CSS2.1 §13.3.1: When page-break-inside:avoid is
+                            // set on a float's containing block, move the float
+                            // to the next page if it would otherwise cross a
+                            // page boundary.
+                            if (PageBreakInside == CssConstants.Avoid)
+                                childBox.BreakPage();
+                        }
+                    }
+
+                    // CSS2.1 §10.6.7: Elements that establish a new block
+                    // formatting context (BFC) must include descendant floats
+                    // in their auto-height calculation.  The inline path above
+                    // does not call MarginBottomCollapse(), so BFC elements
+                    // with only floated children would otherwise have zero
+                    // content height.
+                    bool isBfc = Float != CssConstants.None
+                        || Display == CssConstants.InlineBlock
+                        || Display == CssConstants.TableCell
+                        || Display is "flex" or "inline-flex" or "grid" or "inline-grid"
+                        || (Overflow != null && Overflow != CssConstants.Visible)
+                        || Position == CssConstants.Absolute
+                        || Position == CssConstants.Fixed
+                        || (AlignContent != null && AlignContent != "normal");
+                    if (isBfc)
+                    {
+                        ActualBottom = MarginBottomCollapse();
+                    }
+
+                    // CSS Grid Level 1 §8.5: When all grid items share
+                    // the same grid-row and grid-column, reposition them
+                    // to the container's content-area origin so they
+                    // overlap visually.  (This duplicates the same logic
+                    // in the block path below; it is needed here because
+                    // ContainsInlinesOnly() forces grid containers into
+                    // the inline layout path for shrink-to-fit sizing.)
+                    if (Display is "grid" or "inline-grid")
+                    {
+                        if (!ApplyGridStacking())
+                            ApplyGridAutoPlacement();
+                    }
+
+                    // CSS Box Alignment §6.2: distribute flex/grid items along
+                    // the block (cross) axis per align-items / align-self.
+                    ApplyFlexGridCrossAxisAlignment();
+                    ApplyFlexColumnInlineAxisAlignment();
+                }
+                else if (Boxes.Count > 0)
+                {
+                    // CSS Multi-column: Pre-constrain width so children
+                    // lay out at column width instead of full container width.
+                    float savedWidth = Size.Width;
+                    int preColCount = 0;
+                    bool hasExplicitColCount = ColumnCount != null && ColumnCount != "auto"
+                        && int.TryParse(ColumnCount, out preColCount) && preColCount > 1;
+                    bool hasColWidth = ColumnWidth != null && ColumnWidth != "auto"
+                        && !string.IsNullOrEmpty(ColumnWidth);
+
+                    bool isMultiColumn = hasExplicitColCount || hasColWidth;
+                    if (isMultiColumn && !hasExplicitColCount && hasColWidth)
+                    {
+                        // Auto column-count from column-width: compute the
+                        // number of columns so we can pre-constrain width.
+                        double cwVal = CssValueParser.ParseLength(ColumnWidth, Size.Width, GetEmHeight());
+                        double gap = ResolveColumnGap();
+                        double available = Size.Width - ActualPaddingLeft - ActualPaddingRight
+                            - ActualBorderLeftWidth - ActualBorderRightWidth;
+                        if (cwVal > 0 && available > 0)
+                            preColCount = Math.Max(1, (int)Math.Floor((available + gap) / (cwVal + gap)));
+                        isMultiColumn = preColCount > 1;
+                    }
+
+                    if (isMultiColumn && preColCount > 1)
+                    {
+                        double columnGap = ResolveColumnGap();
+                        double cw = Size.Width - ActualPaddingLeft - ActualPaddingRight
+                            - ActualBorderLeftWidth - ActualBorderRightWidth;
+                        double colWidth = (cw - (preColCount - 1) * columnGap) / preColCount;
+                        if (colWidth > 0)
+                            Size = new SizeF((float)colWidth, Size.Height);
+                    }
+
+                    foreach (var childBox in Boxes)
+                    {
+                        childBox.PerformLayout(g);
+
+                        // CSS2.1 §13.3.1: When page-break-inside:avoid is
+                        // set, move floated children to the next page if they
+                        // would cross a page boundary.
+                        if (childBox.Float != CssConstants.None
+                            && PageBreakInside == CssConstants.Avoid)
+                            childBox.BreakPage();
+                    }
+
+                    // Restore original width after children are laid out.
+                    if (isMultiColumn)
+                        Size = new SizeF(savedWidth, Size.Height);
+
+                    ActualRight = CalculateActualRight();
+                    ActualBottom = MarginBottomCollapse();
+
+                    if (Display is "grid" or "inline-grid")
+                    {
+                        if (!ApplyGridStacking())
+                            ApplyGridAutoPlacement();
+                    }
+                }
+            }
+        }
+        else
+        {
+            var prevSibling = LayoutBoxUtils.GetPreviousSibling(this);
+            if (prevSibling != null)
+            {
+                if (Location == PointF.Empty)
+                    Location = prevSibling.Location;
+
+                ActualBottom = prevSibling.ActualBottom;
+            }
+        }
+
+        // CSS Multi-column Layout §3: When column-count > 1 or column-width
+        // is specified, redistribute in-flow children into multiple columns.
+        // This is a post-layout transformation that moves children
+        // horizontally and vertically to simulate multi-column flow.
+        {
+            int colCount = 0;
+            bool hasExplicitCount = ColumnCount != null && ColumnCount != "auto"
+                && int.TryParse(ColumnCount, out colCount) && colCount > 1;
+            bool hasColumnWidth = ColumnWidth != null && ColumnWidth != "auto"
+                && !string.IsNullOrEmpty(ColumnWidth);
+
+            if (!hasExplicitCount && hasColumnWidth)
+            {
+                // Auto column-count from column-width: CSS Multi-column §3.4
+                double cw = CssValueParser.ParseLength(ColumnWidth, Size.Width, GetEmHeight());
+                double gap = GetEmHeight();
+                double available = Size.Width - ActualPaddingLeft - ActualPaddingRight
+                    - ActualBorderLeftWidth - ActualBorderRightWidth;
+                if (cw > 0 && available > 0)
+                    colCount = Math.Max(1, (int)Math.Floor((available + gap) / (cw + gap)));
+            }
+
+            if (colCount > 1 && Boxes.Count > 0)
+            {
+                ApplyMultiColumnLayout(colCount);
+            }
+        }
+
+        // CSS content-box model: 'height' specifies the content height only;
+        // padding and border are additive (CSS2.1 §10.6.3).
+        if (Height != CssConstants.Auto && !string.IsNullOrEmpty(Height))
+        {
+            // CSS2.1 §10.5: If height is a percentage and the containing
+            // block's height is not explicitly specified (auto), the
+            // percentage resolves to auto and this constraint is skipped.
+            if (!HeightPercentageResolvesToAuto())
+            {
+                // CSS2.1 §10.5: Percentage heights resolve against the
+                // containing block's height, not the element's own size.
+                // ActualHeight uses Size.Height (the element's own height
+                // from child layout), which is wrong for percentage values.
+                // Resolve against the containing block's height instead.
+                double contentHeight;
+                if (Height.Contains('%'))
+                {
+                    double cbHeight;
+                    if (Position == CssConstants.Fixed && LayoutEnvironment != null)
+                        cbHeight = LayoutEnvironment.ViewportSize.Height;
+                    else if (ContainingBlock?.ParentBox == null && LayoutEnvironment != null)
+                        cbHeight = LayoutEnvironment.ViewportSize.Height;
+                    else
+                        cbHeight = ContainingBlock.Size.Height;
+                    contentHeight = CssValueParser.ParseLength(Height, cbHeight, GetEmHeight());
+                }
+                else
+                {
+                    contentHeight = string.Equals(Height, "inherit", StringComparison.OrdinalIgnoreCase) && GetParent() != null
+                        ? GetParent().ActualHeight
+                        : ActualHeight;
+                }
+
+                double borderBoxHeight = ResolveSpecifiedHeightToBorderBox(contentHeight);
+
+                // CSS2.1 §10.6.3: An explicit height sets the content box
+                // height.  Content that exceeds this height overflows
+                // (visible by default) but does not affect sibling
+                // positioning.  Use direct assignment so that explicit
+                // height (e.g. height:0) can override the height computed
+                // by CreateLineBoxes (e.g. from line-height).
+                ActualBottom = Location.Y + borderBoxHeight;
+            }
+        }
+        else if ((Position == CssConstants.Absolute || Position == CssConstants.Fixed)
+            && Top != null && Top != CssConstants.Auto
+            && Bottom != null && Bottom != CssConstants.Auto
+            && (Height == CssConstants.Auto || string.IsNullOrEmpty(Height)))
+        {
+            // CSS2.1 §10.6.4: For absolutely positioned, non-replaced
+            // elements when height is auto and both top and bottom are
+            // specified, compute height from the constraint equation:
+            // top + margin-top + height + margin-bottom + bottom = CB height
+            double cbHeight;
+            if (Position == CssConstants.Fixed && LayoutEnvironment != null)
+                cbHeight = LayoutEnvironment.ViewportSize.Height;
+            else
+            {
+                var cb = FindPositionedContainingBlock();
+                GetAbsoluteContainingBlockPaddingBox(cb, out _, out _, out _, out cbHeight);
+            }
+            double cssTop = CssValueParser.ParseLength(Top, cbHeight, GetEmHeight());
+            double cssBottom = CssValueParser.ParseLength(Bottom, cbHeight, GetEmHeight());
+            double resolvedHeight = cbHeight - cssTop - cssBottom - ActualMarginTop - ActualMarginBottom
+                - ActualPaddingTop - ActualPaddingBottom - ActualBorderTopWidth - ActualBorderBottomWidth;
+            if (resolvedHeight < 0) resolvedHeight = 0;
+            double borderBoxH = resolvedHeight + ActualPaddingTop + ActualPaddingBottom + ActualBorderTopWidth + ActualBorderBottomWidth;
+            ActualBottom = Location.Y + borderBoxH;
+        }
+
+        // CSS2.1 §10.7: Apply min-height / max-height constraints.
+        // When min-height > max-height, min-height wins.
+        {
+            double contentHeight = ActualBottom - Location.Y - ActualPaddingTop - ActualPaddingBottom - ActualBorderTopWidth - ActualBorderBottomWidth;
+            bool constrained = false;
+
+            // CSS2.1 §9.6.1: For fixed-position elements, percentage
+            // heights resolve against the viewport, not the parent.
+            double cbHeight = (Position == CssConstants.Fixed && LayoutEnvironment != null)
+                ? LayoutEnvironment.ViewportSize.Height
+                : ContainingBlock.Size.Height;
+
+            if (MaxHeight != "none" && !string.IsNullOrEmpty(MaxHeight))
+            {
+                // CSS2.1 §10.7: If the containing block's height is not
+                // specified explicitly and this element is not absolutely
+                // positioned, a percentage max-height is treated as 'none'.
+                // Exception: the initial containing block always has a
+                // definite height (the viewport), per §10.5.
+                bool maxIsPercentageAuto = MaxHeight.Contains('%')
+                    && Position != CssConstants.Absolute && Position != CssConstants.Fixed
+                    && ContainingBlock?.ParentBox != null
+                    && (ContainingBlock.Height == CssConstants.Auto || string.IsNullOrEmpty(ContainingBlock.Height));
+
+                if (!maxIsPercentageAuto)
+                {
+                    double maxH = CssValueParser.ParseLength(MaxHeight, cbHeight, GetEmHeight());
+                    if (contentHeight > maxH)
+                    {
+                        contentHeight = maxH;
+                        constrained = true;
+                    }
+                }
+            }
+
+            if (MinHeight != "0" && !string.IsNullOrEmpty(MinHeight))
+            {
+                // CSS2.1 §10.7: If the containing block's height is not
+                // specified explicitly and this element is not absolutely
+                // positioned, a percentage min-height is treated as '0'.
+                // Exception: the initial containing block always has a
+                // definite height (the viewport), per §10.5.
+                bool minIsPercentageAuto = MinHeight.Contains('%')
+                    && Position != CssConstants.Absolute && Position != CssConstants.Fixed
+                    && ContainingBlock?.ParentBox != null
+                    && (ContainingBlock.Height == CssConstants.Auto || string.IsNullOrEmpty(ContainingBlock.Height));
+
+                if (!minIsPercentageAuto)
+                {
+                    double minH = CssValueParser.ParseLength(MinHeight, cbHeight, GetEmHeight());
+                    if (contentHeight < minH)
+                    {
+                        contentHeight = minH;
+                        constrained = true;
+                    }
+                }
+            }
+
+            if (constrained)
+            {
+                ActualBottom = Location.Y + ResolveSpecifiedHeightToBorderBox(contentHeight);
+            }
+        }
+
+        // Floats with an explicit CSS height establish a new BFC.
+        // Their ActualBottom should reflect the stated height, not
+        // content overflow from child floats (CSS2.1 §10.6.1).
+        // CSS2.1 §10.5: Percentage heights resolve to auto when
+        // the containing block's height is not explicitly specified.
+        if (Float != CssConstants.None && Height != CssConstants.Auto && !string.IsNullOrEmpty(Height))
+        {
+            if (!HeightPercentageResolvesToAuto())
+            {
+                // For percentage heights, resolve against the containing
+                // block's height directly.  ActualHeight resolves against
+                // Size.Height which may have been cached before the
+                // percentage height pre-resolution step set the correct
+                // Size.Height (CSS2.1 §10.5).
+                double contentHeight;
+                if (Height.Contains('%'))
+                {
+                    double cbHeight;
+                    if (Position == CssConstants.Fixed && LayoutEnvironment != null)
+                        cbHeight = LayoutEnvironment.ViewportSize.Height;
+                    else if (ContainingBlock?.ParentBox == null && LayoutEnvironment != null)
+                        cbHeight = LayoutEnvironment.ViewportSize.Height;
+                    else
+                        cbHeight = ContainingBlock.Size.Height;
+                    contentHeight = CssValueParser.ParseLength(Height, cbHeight, GetEmHeight());
+                }
+                else
+                {
+                    contentHeight = ActualHeight;
+                }
+                double borderBoxHeight = ResolveSpecifiedHeightToBorderBox(contentHeight);
+                ActualBottom = Location.Y + borderBoxHeight;
+            }
+        }
+
+        if (Position == CssConstants.Absolute)
+        {
+            bool hasLeft = Left != null && Left != CssConstants.Auto;
+            bool hasRight = Right != null && Right != CssConstants.Auto;
+            bool hasTop = Top != null && Top != CssConstants.Auto;
+            bool hasBottom = Bottom != null && Bottom != CssConstants.Auto;
+
+            if ((!hasLeft && hasRight) || (!hasTop && hasBottom))
+            {
+                var cb = FindPositionedContainingBlock();
+                GetAbsoluteContainingBlockPaddingBox(cb, out double cbPadLeft, out double cbPadTop, out double cbPadWidth, out double cbPadHeight);
+
+                float newX = Location.X;
+                float newY = Location.Y;
+
+                if (!hasLeft && hasRight)
+                {
+                    double boxWidth = ActualRight - Location.X;
+                    if (boxWidth <= 0)
+                        boxWidth = Size.Width;
+
+                    double cssRight = CssValueParser.ParseLength(Right, cbPadWidth, GetEmHeight());
+                    newX = (float)(cbPadLeft + cbPadWidth - cssRight - ActualMarginRight - boxWidth);
+                }
+
+                if (!hasTop && hasBottom)
+                {
+                    double boxHeight = ActualBottom - Location.Y;
+                    if (boxHeight <= 0)
+                        boxHeight = Size.Height;
+
+                    double cssBottom = CssValueParser.ParseLength(Bottom, cbPadHeight, GetEmHeight());
+                    newY = (float)(cbPadTop + cbPadHeight - cssBottom - ActualMarginBottom - boxHeight);
+                }
+
+                float deltaX = newX - Location.X;
+                float deltaY = newY - Location.Y;
+                if (deltaX != 0)
+                    OffsetLeft(deltaX);
+                if (deltaY != 0)
+                {
+                    OffsetTop(deltaY);
+                    ActualBottom += deltaY;
+                }
+            }
+
+            // CSS Box Alignment Level 3 §6.1: Post-layout self-alignment for
+            // absolutely positioned elements.  After children are laid out,
+            // shrink the box to fit-content size and align within the IMCB.
+            // This must run after child layout so content dimensions are known.
+            string jsPost = JustifySelf?.Trim().ToLowerInvariant() ?? "auto";
+            bool jsPostNonDefault = jsPost != "auto" && jsPost != "normal" && jsPost != "stretch";
+            string asPost = AlignSelf?.Trim().ToLowerInvariant() ?? "auto";
+            bool asPostNonDefault = asPost != "auto" && asPost != "normal" && asPost != "stretch";
+
+            if (jsPostNonDefault || asPostNonDefault)
+            {
+                var cb = FindPositionedContainingBlock();
+                GetAbsoluteContainingBlockPaddingBox(cb, out double cbPadLeft, out double cbPadTop, out double cbPadWidth, out double cbPadHeight);
+
+                bool hasL = Left != null && Left != CssConstants.Auto;
+                bool hasR = Right != null && Right != CssConstants.Auto;
+                bool hasT = Top != null && Top != CssConstants.Auto;
+                bool hasB = Bottom != null && Bottom != CssConstants.Auto;
+
+                // CSS Writing Modes Level 4: the containing block's writing mode
+                // determines which physical axis corresponds to justify-self (inline)
+                // and align-self (block).
+                bool cbVertical = cb.WritingMode == "vertical-rl" || cb.WritingMode == "vertical-lr";
+
+                float newX = Location.X, newY = Location.Y;
+
+                // justify-self controls the inline axis:
+                //   horizontal-tb → horizontal (L/R insets)
+                //   vertical-rl/lr → vertical (T/B insets)
+                if (jsPostNonDefault)
+                {
+                    if (!cbVertical && hasL && hasR)
+                    {
+                        double cssLeft = CssValueParser.ParseLength(Left, cbPadWidth, GetEmHeight());
+                        double cssRight = CssValueParser.ParseLength(Right, cbPadWidth, GetEmHeight());
+                        double imcbLeft = cbPadLeft + cssLeft;
+                        double imcbWidth = cbPadWidth - cssLeft - cssRight;
+
+                        double boxWidth = GetShrinkToFitWidth();
+                        Size = new SizeF((float)boxWidth, Size.Height);
+
+                        bool isRtl = Direction == "rtl";
+                        double dx = ResolveAbsposSelfAlignment(
+                            jsPost, imcbWidth, boxWidth, isRtl);
+                        newX = (float)(imcbLeft + dx + ActualMarginLeft);
+                    }
+                    else if (cbVertical && hasT && hasB)
+                    {
+                        double cssTop = CssValueParser.ParseLength(Top, cbPadHeight, GetEmHeight());
+                        double cssBottom = CssValueParser.ParseLength(Bottom, cbPadHeight, GetEmHeight());
+                        double imcbTop = cbPadTop + cssTop;
+                        double imcbHeight = cbPadHeight - cssTop - cssBottom;
+
+                        double boxHeight = GetShrinkToFitHeight();
+
+                        double dy = ResolveAbsposSelfAlignment(
+                            jsPost, imcbHeight, boxHeight, false);
+                        newY = (float)(imcbTop + dy + ActualMarginTop);
+                    }
+                }
+
+                // align-self controls the block axis:
+                //   horizontal-tb → vertical (T/B insets)
+                //   vertical-rl/lr → horizontal (L/R insets)
+                if (asPostNonDefault)
+                {
+                    if (!cbVertical && hasT && hasB)
+                    {
+                        double cssTop = CssValueParser.ParseLength(Top, cbPadHeight, GetEmHeight());
+                        double cssBottom = CssValueParser.ParseLength(Bottom, cbPadHeight, GetEmHeight());
+                        double imcbTop = cbPadTop + cssTop;
+                        double imcbHeight = cbPadHeight - cssTop - cssBottom;
+
+                        double boxHeight = GetShrinkToFitHeight();
+
+                        double dy = ResolveAbsposSelfAlignment(
+                            asPost, imcbHeight, boxHeight, false);
+                        newY = (float)(imcbTop + dy + ActualMarginTop);
+                    }
+                    else if (cbVertical && hasL && hasR)
+                    {
+                        double cssLeft = CssValueParser.ParseLength(Left, cbPadWidth, GetEmHeight());
+                        double cssRight = CssValueParser.ParseLength(Right, cbPadWidth, GetEmHeight());
+                        double imcbLeft = cbPadLeft + cssLeft;
+                        double imcbWidth = cbPadWidth - cssLeft - cssRight;
+
+                        double boxWidth = GetShrinkToFitWidth();
+                        Size = new SizeF((float)boxWidth, Size.Height);
+
+                        bool isRtl = Direction == "rtl";
+                        double dx = ResolveAbsposSelfAlignment(
+                            asPost, imcbWidth, boxWidth, isRtl);
+                        newX = (float)(imcbLeft + dx + ActualMarginLeft);
+                    }
+                }
+
+                if (newX != Location.X || newY != Location.Y)
+                {
+                    float deltaX = newX - Location.X;
+                    float deltaY = newY - Location.Y;
+                    if (deltaX != 0)
+                        OffsetLeft(deltaX);
+                    if (deltaY != 0)
+                    {
+                        OffsetTop(deltaY);
+                        ActualBottom += deltaY;
+                    }
+                }
+            }
+        }
+
+        // CSS Box Alignment Level 3 §5.4: align-content on block containers
+        // shifts the in-flow content vertically when the container has a
+        // definite height larger than the content.  Values:
+        //   normal/start/baseline/flex-start → no shift (top-aligned)
+        //   center                           → center vertically
+        //   end/flex-end/last baseline       → bottom-aligned
+        //   space-between/space-around/space-evenly → distribute space
+        // The "unsafe" and "safe" prefixes are stripped; safe alignment
+        // falls back to start when content overflows, but for blocks this
+        // is handled implicitly (shift is clamped to ≥ 0).
+        if (AlignContent != null && AlignContent != "normal"
+            && (IsBlock || Display == CssConstants.ListItem || Display == CssConstants.InlineBlock
+                || Display == CssConstants.TableCell)
+            && Boxes.Count > 0
+            && (Height != CssConstants.Auto && !string.IsNullOrEmpty(Height)
+                || Display == CssConstants.TableCell))
+        {
+            double borderBoxHeight = ActualBottom - Location.Y;
+            double containerContentHeight = borderBoxHeight
+                - ActualPaddingTop - ActualPaddingBottom
+                - ActualBorderTopWidth - ActualBorderBottomWidth;
+
+            // Compute height of in-flow children (excluding overflow:0 boxes,
+            // absolutely positioned elements, and fixed elements).
+            double contentTop = double.MaxValue;
+            double contentBottom = double.MinValue;
+            foreach (var child in Boxes)
+            {
+                if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+                    continue;
+                if (child.Display == CssConstants.None)
+                    continue;
+                double childTop = child.Location.Y;
+                double childBottom = child.ActualBottom;
+                if (childTop < contentTop)
+                    contentTop = childTop;
+                if (childBottom > contentBottom)
+                    contentBottom = childBottom;
+            }
+
+            if (contentTop < double.MaxValue && contentBottom > double.MinValue)
+            {
+                double usedContentHeight = contentBottom - contentTop;
+                double freeSpace = containerContentHeight - usedContentHeight;
+
+                // Normalise the align-content value: strip safe/unsafe prefix.
+                string ac = AlignContent.Trim();
+                bool explicitUnsafe = ac.StartsWith("unsafe ", StringComparison.OrdinalIgnoreCase);
+                bool explicitSafe = ac.StartsWith("safe ", StringComparison.OrdinalIgnoreCase);
+                if (explicitSafe)
+                    ac = ac.Substring(5).Trim();
+                else if (explicitUnsafe)
+                    ac = ac.Substring(7).Trim();
+
+                // CSS Box Alignment §5.3: when no explicit safe/unsafe keyword
+                // is present, the default overflow alignment is "safe".
+                bool isSafe = !explicitUnsafe;
+
+                // Only compute shift when there's free space, or when unsafe
+                // mode allows shifting even into overflow.
+                if (freeSpace > 0.5 || (!isSafe && freeSpace < -0.5))
+                {
+                    double shift = 0;
+                    switch (ac.ToLowerInvariant())
+                    {
+                        case "center":
+                            shift = freeSpace / 2;
+                            break;
+                        case "end":
+                        case "flex-end":
+                        case "last baseline":
+                            shift = freeSpace;
+                            break;
+                        case "space-between":
+                            // Single content group → same as start (no shift).
+                            break;
+                        case "space-around":
+                            shift = freeSpace / 2;
+                            break;
+                        case "space-evenly":
+                            shift = freeSpace / 2;
+                            break;
+                        // start, flex-start, baseline, normal → no shift.
+                    }
+
+                    // Safe alignment: clamp shift to 0 to prevent overflow.
+                    if (isSafe && shift < 0)
+                        shift = 0;
+
+                    if (Math.Abs(shift) > 0.5)
+                    {
+                        foreach (var child in Boxes)
+                        {
+                            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+                                continue;
+                            if (child.Display == CssConstants.None)
+                                continue;
+                            child.OffsetTop(shift);
+                        }
+                    }
+                }
+            }
+        }
+
+        // CSS Box Alignment Level 3 §6.1: justify-self on block-level boxes.
+        // When a non-replaced block has an explicit width narrower than its
+        // containing block, 'justify-self' shifts the box horizontally within
+        // the containing block's content area.  Values:
+        //   auto/normal/stretch → default behaviour (no shift)
+        //   start/flex-start/self-start/left → left-aligned (no shift in LTR)
+        //   end/flex-end/self-end/right → right-aligned
+        //   center → centered
+        // Floated and absolutely/fixed positioned boxes are unaffected.
+        if (JustifySelf != null && JustifySelf != "auto" && JustifySelf != "normal"
+            && JustifySelf != "stretch"
+            && Float == CssConstants.None
+            && Position != CssConstants.Absolute && Position != CssConstants.Fixed
+            && (IsBlock || Display == CssConstants.ListItem)
+            && ParentBox != null)
+        {
+            double boxWidth = ActualRight - Location.X;
+            double containerWidth = ParentBox.ClientRectangle.Width;
+            double freeSpace = containerWidth - boxWidth;
+
+            if (freeSpace > 0.5)
+            {
+                string js = JustifySelf.Trim().ToLowerInvariant();
+                // CSS Box Alignment §6.1: 'start'/'end' use the containing
+                // block's writing direction; 'self-start'/'self-end' use the
+                // element's own writing direction.
+                bool isElementRtl = Direction == "rtl";
+                bool isContainerRtl = ParentBox?.Direction == "rtl";
+
+                double dx = 0;
+                switch (js)
+                {
+                    case "center":
+                        dx = freeSpace / 2;
+                        break;
+                    case "end":
+                    case "flex-end":
+                        dx = isContainerRtl ? 0 : freeSpace;
+                        break;
+                    case "self-end":
+                        dx = isElementRtl ? 0 : freeSpace;
+                        break;
+                    case "right":
+                        dx = freeSpace;
+                        break;
+                    case "start":
+                    case "flex-start":
+                        dx = isContainerRtl ? freeSpace : 0;
+                        break;
+                    case "self-start":
+                        dx = isElementRtl ? freeSpace : 0;
+                        break;
+                    case "left":
+                        dx = 0;
+                        break;
+                }
+
+                if (dx > 0.5)
+                    OffsetLeft(dx);
+            }
+        }
+
+        // Apply position:relative offset after layout (visual only, does not affect flow)
+        // CSS2.1 §9.4.3: For relative positioning, 'left'/'right' and
+        // 'top'/'bottom' form constraint pairs.  When 'top' is auto and
+        // 'bottom' is not, dy = -bottom.  When both are non-auto, 'bottom'
+        // is ignored (in LTR).  Same logic applies to left/right.
+        if (Position == CssConstants.Relative)
+        {
+            double dx = 0, dy = 0;
+
+            bool hasLeft = Left != null && Left != CssConstants.Auto;
+            bool hasRight = Right != null && Right != CssConstants.Auto;
+            bool hasTop = Top != null && Top != CssConstants.Auto;
+            bool hasBottom = Bottom != null && Bottom != CssConstants.Auto;
+
+            if (hasLeft)
+                dx = CssValueParser.ParseLength(Left, Size.Width, GetEmHeight());
+            else if (hasRight)
+                dx = -CssValueParser.ParseLength(Right, Size.Width, GetEmHeight());
+
+            if (hasTop)
+                dy = CssValueParser.ParseLength(Top, Size.Height, GetEmHeight());
+            else if (hasBottom)
+                dy = -CssValueParser.ParseLength(Bottom, Size.Height, GetEmHeight());
+
+            if (dx != 0)
+                OffsetLeft(dx);
+            if (dy != 0)
+                OffsetTop(dy);
+        }
+
+        CreateListItemBox(g);
+
+        if (!IsFixed)
+        {
+            var actualWidth = Math.Max(GetMinimumWidth() + CssBoxHelper.GetWidthMarginDeep(this), Size.Width < 90999 ? ActualRight - LayoutEnvironment.RootLocation.X : 0);
+            LayoutEnvironment.ActualSize = CommonUtils.Max(LayoutEnvironment.ActualSize, new SizeF((float)actualWidth, (float)(ActualBottom - LayoutEnvironment.RootLocation.Y)));
+        }
+    }
+
+    /// <summary>
+    /// CSS Multi-column §6.2: resolves <c>column-gap</c>.  The initial value
+    /// 'normal' is ≈ 1em; an explicit length (including 0) overrides it.
+    /// </summary>
+    private double ResolveColumnGap()
+    {
+        if (!string.IsNullOrEmpty(ColumnGap) && ColumnGap != "normal")
+            return CssValueParser.ParseLength(ColumnGap, Size.Width, GetEmHeight());
+        return GetEmHeight();
+    }
+
+    private sealed class FlexItemLayout
+    {
+        public CssBox Box { get; init; }
+        public double Grow { get; init; }
+        public double Shrink { get; init; }
+        public double BaseOuterWidth { get; init; }
+        public double TargetOuterWidth { get; set; }
+    }
+
+    private sealed class FlexLineLayout
+    {
+        public List<FlexItemLayout> Items { get; } = [];
+        public double BaseOuterWidth { get; set; }
+        public double CrossSize { get; set; }
+    }
+
+    private bool IsFlexContainer() => Display is "flex" or "inline-flex";
+
+    internal bool IsRowFlexContainer()
+    {
+        if (!IsFlexContainer())
+            return false;
+
+        string direction = FlexDirection?.Trim().ToLowerInvariant() ?? "row";
+        return direction is not ("column" or "column-reverse");
+    }
+
+    internal void PerformFlexRowLayout(ILayoutEnvironment g)
+    {
+        EnsureDescendantWordsMeasured(g);
+
+        double contentLeft = ClientLeft;
+        double contentTop = ClientTop;
+        double contentWidth = Math.Max(0, Size.Width
+            - ActualBorderLeftWidth - ActualBorderRightWidth
+            - ActualPaddingLeft - ActualPaddingRight);
+
+        double columnGap = ResolveFlexGap(ColumnGap, contentWidth);
+        double rowGap = ResolveFlexGap(RowGap, Size.Height);
+        bool wrap = FlexWrap is "wrap" or "wrap-reverse";
+
+        var lines = new List<FlexLineLayout>();
+        var currentLine = new FlexLineLayout();
+
+        foreach (var child in Boxes)
+        {
+            if (!IsInFlowFlexItem(child))
+                continue;
+
+            var item = new FlexItemLayout
+            {
+                Box = child,
+                Grow = ParseFlexFactor(child.FlexGrow, 0),
+                Shrink = ParseFlexFactor(child.FlexShrink, 1),
+                BaseOuterWidth = ResolveFlexItemBaseOuterWidth(child, contentWidth)
+            };
+            item.TargetOuterWidth = item.BaseOuterWidth;
+
+            double candidateWidth = currentLine.BaseOuterWidth + item.BaseOuterWidth
+                + (currentLine.Items.Count > 0 ? columnGap : 0);
+
+            if (wrap && currentLine.Items.Count > 0 && candidateWidth > contentWidth + 0.5)
+            {
+                lines.Add(currentLine);
+                currentLine = new FlexLineLayout();
+            }
+
+            currentLine.Items.Add(item);
+            currentLine.BaseOuterWidth += item.BaseOuterWidth;
+        }
+
+        if (currentLine.Items.Count > 0 || lines.Count == 0)
+            lines.Add(currentLine);
+
+        double cursorY = contentTop;
+        bool reverse = FlexDirection?.Trim().Equals("row-reverse", StringComparison.OrdinalIgnoreCase) == true;
+
+        foreach (var line in lines)
+        {
+            ResolveFlexLineWidths(line, contentWidth, columnGap);
+
+            foreach (var item in line.Items)
+            {
+                LayoutFlexItemAtTargetWidth(g, item.Box, item.TargetOuterWidth);
+                double itemHeight = GetFlexItemOuterHeight(item.Box);
+                if (itemHeight > line.CrossSize)
+                    line.CrossSize = itemHeight;
+            }
+
+            double usedWidth = 0;
+            foreach (var item in line.Items)
+                usedWidth += item.TargetOuterWidth;
+
+            int itemCount = line.Items.Count;
+            double freeSpace = contentWidth - usedWidth - Math.Max(0, itemCount - 1) * columnGap;
+            if (freeSpace < 0)
+                freeSpace = 0;
+
+            ResolveJustifyContent(itemCount, freeSpace, columnGap,
+                out double lineOffset, out double itemGap);
+
+            double cursorX = contentLeft + lineOffset;
+            if (reverse)
+                cursorX = contentLeft + contentWidth - lineOffset;
+
+            for (int i = 0; i < itemCount; i++)
+            {
+                int itemIndex = reverse ? itemCount - i - 1 : i;
+                var item = line.Items[itemIndex];
+                var child = item.Box;
+
+                double marginBoxWidth = item.TargetOuterWidth;
+                double borderBoxWidth = Math.Max(0, marginBoxWidth
+                    - child.ActualMarginLeft - child.ActualMarginRight);
+                double itemLeft = reverse
+                    ? cursorX - marginBoxWidth + child.ActualMarginLeft
+                    : cursorX + child.ActualMarginLeft;
+
+                double crossOffset = ResolveFlexCrossOffset(child, line.CrossSize);
+                double itemTop = cursorY + crossOffset + child.ActualMarginTop;
+
+                double dx = itemLeft - child.Location.X;
+                double dy = itemTop - child.Location.Y;
+                if (Math.Abs(dx) > 0.1)
+                    child.OffsetLeft(dx);
+                if (Math.Abs(dy) > 0.1)
+                    child.OffsetTop(dy);
+
+                if (reverse)
+                    cursorX -= marginBoxWidth + itemGap;
+                else
+                    cursorX += marginBoxWidth + itemGap;
+
+                // The temporary width is restored after child layout; keep
+                // the used border-box width in Size for painting/layout dumps.
+                if (borderBoxWidth > 0 && Math.Abs(child.Size.Width - borderBoxWidth) > 0.5)
+                    child.Size = new SizeF((float)borderBoxWidth, child.Size.Height);
+            }
+
+            cursorY += line.CrossSize + rowGap;
+        }
+
+        if (lines.Count > 0)
+            cursorY -= rowGap;
+
+        ActualBottom = cursorY + ActualPaddingBottom + ActualBorderBottomWidth;
+        ActualRight = Location.X + Size.Width;
+    }
+
+    private static bool IsInFlowFlexItem(CssBox child) =>
+        child.Display != CssConstants.None
+        && child.Position is not (CssConstants.Absolute or CssConstants.Fixed);
+
+    private double ResolveFlexItemBaseOuterWidth(CssBox child, double containerContentWidth)
+    {
+        double borderBoxWidth;
+        string basis = child.FlexBasis?.Trim();
+
+        if (!string.IsNullOrEmpty(basis)
+            && !basis.Equals("auto", StringComparison.OrdinalIgnoreCase)
+            && !basis.Equals("content", StringComparison.OrdinalIgnoreCase))
+        {
+            borderBoxWidth = child.ResolveSpecifiedWidthToBorderBox(
+                ParseFlexLengthOrZero(child, basis, containerContentWidth));
+        }
+        else if (child.Width != CssConstants.Auto && !string.IsNullOrEmpty(child.Width)
+            && !IsIntrinsicWidthKeyword(child.Width))
+        {
+            borderBoxWidth = child.ResolveSpecifiedWidthToBorderBox(
+                ParseFlexLengthOrZero(child, child.Width, containerContentWidth));
+        }
+        else
+        {
+            child.GetMinMaxWidth(out _, out double preferred);
+            if (double.IsNaN(preferred) || preferred < 0)
+                preferred = 0;
+
+            borderBoxWidth = preferred + child.ActualBorderLeftWidth + child.ActualBorderRightWidth;
+        }
+
+        borderBoxWidth = ClampFlexItemBorderBoxWidth(child, borderBoxWidth, containerContentWidth);
+        return borderBoxWidth + child.ActualMarginLeft + child.ActualMarginRight;
+    }
+
+    private static double ParseFlexLengthOrZero(CssBox box, string value, double percentBase)
+    {
+        try
+        {
+            return box.ParseLengthWithLineHeight(value, percentBase);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private double ClampFlexItemBorderBoxWidth(CssBox child, double borderBoxWidth, double containerContentWidth)
+    {
+        if (!string.IsNullOrEmpty(child.MaxWidth)
+            && !child.MaxWidth.Equals("none", StringComparison.OrdinalIgnoreCase))
+        {
+            double maxWidth = child.ResolveSpecifiedWidthToBorderBox(
+                ParseFlexLengthOrZero(child, child.MaxWidth, containerContentWidth));
+            if (borderBoxWidth > maxWidth)
+                borderBoxWidth = maxWidth;
+        }
+
+        bool useAutomaticMinWidth = !child.IsMinWidthSpecified
+            || child.MinWidth.Equals("auto", StringComparison.OrdinalIgnoreCase);
+        if (useAutomaticMinWidth)
+        {
+            child.GetMinMaxWidth(out double minContentWidth, out _);
+            if (!double.IsNaN(minContentWidth) && minContentWidth > 0)
+            {
+                double minBorderBoxWidth = minContentWidth
+                    + child.ActualBorderLeftWidth + child.ActualBorderRightWidth;
+                if (borderBoxWidth < minBorderBoxWidth)
+                    borderBoxWidth = minBorderBoxWidth;
+            }
+        }
+        else if (!string.IsNullOrEmpty(child.MinWidth)
+            && !child.MinWidth.Equals("0", StringComparison.OrdinalIgnoreCase))
+        {
+            double minWidth = child.ResolveSpecifiedWidthToBorderBox(
+                ParseFlexLengthOrZero(child, child.MinWidth, containerContentWidth));
+            if (borderBoxWidth < minWidth)
+                borderBoxWidth = minWidth;
+        }
+
+        return Math.Max(0, borderBoxWidth);
+    }
+
+    private void ResolveFlexLineWidths(FlexLineLayout line, double contentWidth, double columnGap)
+    {
+        int itemCount = line.Items.Count;
+        if (itemCount == 0)
+            return;
+
+        double gapTotal = Math.Max(0, itemCount - 1) * columnGap;
+        double freeSpace = contentWidth - line.BaseOuterWidth - gapTotal;
+
+        if (freeSpace > 0.5)
+        {
+            double growTotal = 0;
+            foreach (var item in line.Items)
+                growTotal += item.Grow;
+
+            if (growTotal > 0)
+            {
+                foreach (var item in line.Items)
+                    item.TargetOuterWidth = item.BaseOuterWidth + freeSpace * (item.Grow / growTotal);
+            }
+        }
+        else if (freeSpace < -0.5)
+        {
+            double shrinkTotal = 0;
+            foreach (var item in line.Items)
+                shrinkTotal += item.Shrink * Math.Max(0, item.BaseOuterWidth);
+
+            if (shrinkTotal > 0)
+            {
+                foreach (var item in line.Items)
+                {
+                    double shrinkShare = (item.Shrink * Math.Max(0, item.BaseOuterWidth)) / shrinkTotal;
+                    double target = item.BaseOuterWidth + freeSpace * shrinkShare;
+                    double marginWidth = item.Box.ActualMarginLeft + item.Box.ActualMarginRight;
+                    double borderBoxWidth = ClampFlexItemBorderBoxWidth(
+                        item.Box,
+                        Math.Max(0, target - marginWidth),
+                        contentWidth);
+                    item.TargetOuterWidth = borderBoxWidth + marginWidth;
+                }
+            }
+        }
+    }
+
+    private void LayoutFlexItemAtTargetWidth(ILayoutEnvironment g, CssBox child, double targetOuterWidth)
+    {
+        double targetBorderBoxWidth = Math.Max(0, targetOuterWidth
+            - child.ActualMarginLeft - child.ActualMarginRight);
+        double cssWidth = child.UsesBorderBoxSizing
+            ? targetBorderBoxWidth
+            : targetBorderBoxWidth
+              - child.ActualPaddingLeft - child.ActualPaddingRight
+              - child.ActualBorderLeftWidth - child.ActualBorderRightWidth;
+
+        string savedWidth = child.Width;
+        child.Width = FormatCssPx(Math.Max(0, cssWidth));
+        child.PerformLayout(g);
+        child.Width = savedWidth;
+    }
+
+    private static string FormatCssPx(double value) =>
+        value.ToString("0.####", CultureInfo.InvariantCulture) + "px";
+
+    private static double ParseFlexFactor(string value, double fallback)
+    {
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed)
+            && parsed >= 0)
+        {
+            return parsed;
+        }
+
+        return fallback;
+    }
+
+    private double ResolveFlexGap(string value, double percentBase)
+    {
+        if (string.IsNullOrEmpty(value) || value.Equals("normal", StringComparison.OrdinalIgnoreCase))
+            return 0;
+
+        try
+        {
+            return CssValueParser.ParseLength(value, percentBase, GetEmHeight());
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private void ResolveJustifyContent(int itemCount, double freeSpace, double baseGap,
+        out double lineOffset, out double itemGap)
+    {
+        lineOffset = 0;
+        itemGap = baseGap;
+
+        string justify = NormalizeBoxAlignment(JustifyContent);
+        switch (justify)
+        {
+            case "center":
+                lineOffset = freeSpace / 2;
+                break;
+            case "end":
+            case "flex-end":
+            case "right":
+                lineOffset = freeSpace;
+                break;
+            case "space-between":
+                if (itemCount > 1)
+                    itemGap = baseGap + freeSpace / (itemCount - 1);
+                break;
+            case "space-around":
+                if (itemCount > 0)
+                {
+                    itemGap = baseGap + freeSpace / itemCount;
+                    lineOffset = (itemGap - baseGap) / 2;
+                }
+                break;
+            case "space-evenly":
+                if (itemCount > 0)
+                {
+                    double extraGap = freeSpace / (itemCount + 1);
+                    itemGap = baseGap + extraGap;
+                    lineOffset = extraGap;
+                }
+                break;
+        }
+    }
+
+    private double ResolveFlexCrossOffset(CssBox child, double lineCrossSize)
+    {
+        string align = NormalizeBoxAlignment(child.AlignSelf);
+        if (align is "" or "auto" or "normal")
+            align = NormalizeBoxAlignment(AlignItems);
+
+        double itemOuterHeight = GetFlexItemOuterHeight(child);
+        double freeSpace = lineCrossSize - itemOuterHeight;
+        if (freeSpace <= 0)
+            return 0;
+
+        return align switch
+        {
+            "center" => freeSpace / 2,
+            "end" or "flex-end" or "self-end" => freeSpace,
+            _ => 0
+        };
+    }
+
+    private static double GetFlexItemOuterHeight(CssBox child) =>
+        Math.Max(0, child.ActualBottom - child.Location.Y)
+        + child.ActualMarginTop + child.ActualMarginBottom;
+
+    private void ApplyFlexColumnInlineAxisAlignment()
+    {
+        if (!IsFlexContainer())
+            return;
+
+        string direction = FlexDirection?.Trim().ToLowerInvariant() ?? "row";
+        if (direction is not ("column" or "column-reverse"))
+            return;
+
+        double contentWidth = Math.Max(0, Size.Width
+            - ActualBorderLeftWidth - ActualBorderRightWidth
+            - ActualPaddingLeft - ActualPaddingRight);
+        if (contentWidth <= 0)
+            return;
+
+        string containerAlign = NormalizeBoxAlignment(AlignItems);
+        foreach (var child in Boxes)
+        {
+            if (!IsInFlowFlexItem(child))
+                continue;
+
+            string align = NormalizeBoxAlignment(child.AlignSelf);
+            if (align is "" or "auto" or "normal")
+                align = containerAlign;
+
+            double marginBoxWidth = child.Size.Width + child.ActualMarginLeft + child.ActualMarginRight;
+            double freeSpace = contentWidth - marginBoxWidth;
+            if (freeSpace <= 0.5)
+                continue;
+
+            double offset = align switch
+            {
+                "center" => freeSpace / 2,
+                "end" or "flex-end" or "self-end" or "right" => freeSpace,
+                _ => 0
+            };
+            if (offset <= 0.5)
+                continue;
+
+            double targetLeft = ClientLeft + offset + child.ActualMarginLeft;
+            double dx = targetLeft - child.Location.X;
+            if (Math.Abs(dx) > 0.5)
+                child.OffsetLeft(dx);
+        }
+    }
+
+    /// <summary>
+    /// CSS Multi-column Layout: Redistributes in-flow child boxes into
+    /// multiple columns after single-column layout.  Walks down through
+    /// single-child containers (e.g. html to body) to find the actual
+    /// fragmentable children.
+    /// </summary>
+    private void ApplyMultiColumnLayout(int colCount)
+    {
+        // PROTOTYPE (BROILER_VERTICAL_FLOW), Stage 4: in a vertical writing
+        // mode the whole subtree is laid out in a logical horizontal frame and
+        // rotated into physical space after layout (ApplyVerticalWritingModeFlow).
+        // Multi-column fragmentation runs here, in that logical frame, exactly as
+        // it does for horizontal-tb: columns advance along the logical inline
+        // axis (X). The post-layout rotation then maps the logical inline axis
+        // onto the physical inline axis, so the columns stack along the writing
+        // mode's inline direction — logical left→right becomes physical top→bottom.
+        // Verified against Chromium for css-position/multicol/static-position/
+        // vlr-in-multicol-ref.html: an 80×600 logical run fragmented across
+        // 100px-tall columns rotates to a 100px-wide × 480px-tall vertical strip
+        // (diff 17.3% → ~1.9% vs the legacy single-block run). Right→left modes
+        // (vertical-rl / sideways-rl) fragment identically here and are then
+        // block-start (right) aligned by ApplyVerticalWritingModeFlow.
+        double columnGap = ResolveColumnGap();
+        double contentWidth = Size.Width - ActualPaddingLeft - ActualPaddingRight
+            - ActualBorderLeftWidth - ActualBorderRightWidth;
+        double columnWidth = (contentWidth - (colCount - 1) * columnGap) / colCount;
+        if (columnWidth <= 0) return;
+
+        double containerTop = Location.Y + ActualPaddingTop + ActualBorderTopWidth;
+        double columnLeft = Location.X + ActualPaddingLeft + ActualBorderLeftWidth;
+
+        // Walk down through single-child containers (html -> body) to find
+        // the level with multiple block children to distribute.
+        var fragmentParent = FindMultiColumnFragmentParent();
+        if (fragmentParent == null) return;
+
+        var fragments = new List<CssBox>();
+        foreach (var child in fragmentParent.Boxes)
+        {
+            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+                continue;
+            if (child.Display == CssConstants.None)
+                continue;
+            fragments.Add(child);
+        }
+
+        if (fragments.Count == 0) return;
+
+        double firstTop = fragments[0].Location.Y;
+        double lastBottom = GetVisualBottom(fragments[^1]);
+        foreach (var frag in fragments)
+        {
+            double vb = GetVisualBottom(frag);
+            if (vb > lastBottom) lastBottom = vb;
+        }
+        double totalContentHeight = lastBottom - firstTop;
+
+        if (totalContentHeight <= 0) return;
+
+        // Determine column height: balanced columns for auto/max-height,
+        // or explicit height.
+        bool hasMaxHeight = MaxHeight != "none" && !string.IsNullOrEmpty(MaxHeight);
+        bool hasExplicitHeight = Height != CssConstants.Auto && !string.IsNullOrEmpty(Height);
+        double maxAllowedHeight = double.MaxValue;
+
+        if (hasMaxHeight)
+        {
+            double maxH = CssValueParser.ParseLength(MaxHeight, ContainingBlock?.Size.Height ?? Size.Height, GetEmHeight());
+            maxAllowedHeight = maxH - ActualPaddingTop - ActualPaddingBottom - ActualBorderTopWidth - ActualBorderBottomWidth;
+        }
+
+        double columnHeight;
+        if (hasExplicitHeight)
+        {
+            double h = CssValueParser.ParseLength(Height, ContainingBlock?.Size.Height ?? Size.Height, GetEmHeight());
+            columnHeight = h;
+        }
+        else if (ColumnFill == "auto" && hasMaxHeight)
+        {
+            // column-fill: auto — fill columns sequentially up to max-height.
+            columnHeight = maxAllowedHeight;
+        }
+        else
+        {
+            // Balanced column layout: find the minimum column height that
+            // distributes all fragments across colCount columns.  Use a
+            // binary search between (tallest fragment) and (total height).
+            double lo = 0;
+            foreach (var frag in fragments)
+            {
+                double fh = GetVisualBottom(frag) - frag.Location.Y;
+                if (fh > lo) lo = fh;
+            }
+            double hi = totalContentHeight;
+
+            for (int iter = 0; iter < 20; iter++)
+            {
+                double mid = (lo + hi) / 2;
+                int cols = CountColumnsNeededVisual(fragments, mid);
+                if (cols <= colCount)
+                    hi = mid;
+                else
+                    lo = mid + 0.5;
+            }
+            columnHeight = Math.Ceiling(hi);
+
+            if (columnHeight > maxAllowedHeight)
+                columnHeight = maxAllowedHeight;
+        }
+
+        if (columnHeight <= 0) return;
+
+        // CSS Fragmentation §3: When fragments contain boxes with visible
+        // overflow that exceeds the column height (e.g. height: 0 parents
+        // with overflowing children), flatten the hierarchy by collecting
+        // the deepest fragmentable blocks from inside those containers.
+        bool needsDeepFragment = false;
+        foreach (var frag in fragments)
+        {
+            double visualH = GetVisualBottom(frag) - frag.Location.Y;
+            if (visualH > columnHeight + 0.5 && frag.Boxes.Count > 0)
+            {
+                needsDeepFragment = true;
+                break;
+            }
+        }
+
+        if (needsDeepFragment)
+        {
+            var deepFragments = new List<CssBox>();
+            foreach (var frag in fragments)
+            {
+                double visualH = GetVisualBottom(frag) - frag.Location.Y;
+                if (visualH > columnHeight + 0.5 && frag.Boxes.Count > 0)
+                {
+                    CollectFragmentableBlocksCore(frag, columnHeight, deepFragments, 0);
+                }
+                else
+                {
+                    deepFragments.Add(frag);
+                }
+            }
+
+            if (deepFragments.Count > fragments.Count)
+            {
+                fragments = deepFragments;
+                firstTop = fragments[0].Location.Y;
+                lastBottom = firstTop;
+                foreach (var frag in fragments)
+                {
+                    double vb = GetVisualBottom(frag);
+                    if (vb > lastBottom) lastBottom = vb;
+                }
+                totalContentHeight = lastBottom - firstTop;
+
+                // Re-compute balanced column height for the new fragment set.
+                if (!hasExplicitHeight && !(ColumnFill == "auto" && hasMaxHeight))
+                {
+                    double lo = 0;
+                    foreach (var frag in fragments)
+                    {
+                        double fh = GetVisualBottom(frag) - frag.Location.Y;
+                        if (fh > lo) lo = fh;
+                    }
+                    double hi = totalContentHeight;
+                    for (int iter = 0; iter < 20; iter++)
+                    {
+                        double mid = (lo + hi) / 2;
+                        int cols = CountColumnsNeededVisual(fragments, mid);
+                        if (cols <= colCount) hi = mid;
+                        else lo = mid + 0.5;
+                    }
+                    columnHeight = Math.Ceiling(hi);
+                    if (columnHeight > maxAllowedHeight)
+                        columnHeight = maxAllowedHeight;
+                }
+            }
+        }
+
+        // Distribute fragments across columns.
+        int currentCol = 0;
+        double currentY = containerTop;
+
+        foreach (var frag in fragments)
+        {
+            double fragHeight = GetVisualBottom(frag) - frag.Location.Y;
+
+            bool wouldOverflow = (currentY - containerTop) + fragHeight > columnHeight;
+            // CSS Multi-column §3.3: column-count sets the column *width* but is
+            // not a hard cap on the number of columns.  When content does not fit
+            // in the determined number of columns (e.g. column-fill: auto with a
+            // constrained block-size), additional "overflow columns" are created
+            // in the inline direction rather than piling the remainder into the
+            // last column.  Balance mode keeps content within colCount via the
+            // height search above, so this only takes effect when genuinely
+            // overflowing.
+            if (wouldOverflow && currentY > containerTop + 0.5)
+            {
+                currentCol++;
+                currentY = containerTop;
+            }
+
+            double targetX = columnLeft + currentCol * (columnWidth + columnGap)
+                + (frag.Location.X - fragmentParent.Location.X);
+            double targetY = currentY;
+
+            double dx = targetX - frag.Location.X;
+            double dy = targetY - frag.Location.Y;
+
+            if (Math.Abs(dx) > 0.1 || Math.Abs(dy) > 0.1)
+            {
+                frag.OffsetLeft(dx);
+                frag.OffsetTop(dy);
+            }
+
+            if (frag.Size.Width > columnWidth + 1)
+            {
+                frag.Size = new SizeF((float)columnWidth, frag.Size.Height);
+            }
+
+            currentY += fragHeight;
+        }
+
+        // Update container dimensions.
+        double maxBottom = containerTop;
+        foreach (var frag in fragments)
+        {
+            double vb = GetVisualBottom(frag);
+            if (vb > maxBottom)
+                maxBottom = vb;
+        }
+
+        double newBottom = maxBottom + ActualPaddingBottom + ActualBorderBottomWidth;
+        if (newBottom < ActualBottom)
+            ActualBottom = newBottom;
+
+        if (fragmentParent != this)
+        {
+            double fpBottom = maxBottom + fragmentParent.ActualPaddingBottom + fragmentParent.ActualBorderBottomWidth;
+            if (fpBottom < fragmentParent.ActualBottom)
+                fragmentParent.ActualBottom = fpBottom;
+        }
+
+        // Overflow columns extend the inline (right) edge beyond the declared
+        // column-count, so size the scrollable/overflow extent to the columns
+        // actually used rather than the specified count.
+        int usedCols = Math.Max(colCount, currentCol + 1);
+        double rightEdge = columnLeft + usedCols * columnWidth + (usedCols - 1) * columnGap
+            + ActualPaddingRight + ActualBorderRightWidth;
+        if (rightEdge > ActualRight)
+            ActualRight = rightEdge;
+    }
+
+    /// <summary>
+    /// Walks down through single-child containers to find the nearest
+    /// descendant with multiple in-flow block children for multi-column
+    /// fragmentation.
+    /// </summary>
+    private CssBox FindMultiColumnFragmentParent()
+    {
+        CssBox current = this;
+        for (int depth = 0; depth < 10; depth++)
+        {
+            int inFlowCount = 0;
+            CssBox onlyChild = null;
+            foreach (var child in current.Boxes)
+            {
+                if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+                    continue;
+                if (child.Display == CssConstants.None)
+                    continue;
+                inFlowCount++;
+                onlyChild = child;
+            }
+
+            if (inFlowCount > 1)
+                return current;
+
+            if (inFlowCount == 1 && onlyChild != null && onlyChild.Boxes.Count > 0)
+            {
+                current = onlyChild;
+                continue;
+            }
+
+            break;
+        }
+
+        return current.Boxes.Count > 1 ? current : null;
+    }
+
+
+    /// <summary>
+    /// Counts columns needed using visual (overflow-aware) heights.
+    /// </summary>
+    private static int CountColumnsNeededVisual(List<CssBox> fragments, double columnHeight)
+    {
+        int cols = 1;
+        double currentH = 0;
+        foreach (var frag in fragments)
+        {
+            double fh = GetVisualBottom(frag) - frag.Location.Y;
+            if (currentH + fh > columnHeight && currentH > 0.5)
+            {
+                cols++;
+                currentH = fh;
+            }
+            else
+            {
+                currentH += fh;
+            }
+        }
+        return cols;
+    }
+
+    /// <summary>
+    /// Returns the visual bottom of a box, accounting for children that
+    /// overflow a constrained height (e.g. height: 0 with visible overflow).
+    /// </summary>
+    private static double GetVisualBottom(CssBox box)
+    {
+        double bottom = box.ActualBottom;
+        foreach (var child in box.Boxes)
+        {
+            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+                continue;
+            if (child.Display == CssConstants.None)
+                continue;
+            double cb = GetVisualBottom(child);
+            if (cb > bottom) bottom = cb;
+        }
+        return bottom;
+    }
+
+
+    private static void CollectFragmentableBlocksCore(CssBox parent, double columnHeight,
+        List<CssBox> result, int depth)
+    {
+        if (depth > 15) return; // safety limit
+
+        foreach (var child in parent.Boxes)
+        {
+            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+                continue;
+            if (child.Display == CssConstants.None)
+                continue;
+
+            double childHeight = GetVisualBottom(child) - child.Location.Y;
+
+            // If child fits in a column, or has break-inside: avoid, or
+            // has no block children to further fragment, keep it as-is.
+            bool avoidBreak = child.BreakInside == "avoid" ||
+                child.BreakInside == "avoid-column";
+            bool hasBlockChildren = false;
+            foreach (var gc in child.Boxes)
+            {
+                if (gc.Position != CssConstants.Absolute && gc.Position != CssConstants.Fixed
+                    && gc.Display != CssConstants.None)
+                {
+                    hasBlockChildren = true;
+                    break;
+                }
+            }
+
+            if (childHeight <= columnHeight + 0.5 || avoidBreak || !hasBlockChildren)
+            {
+                result.Add(child);
+            }
+            else
+            {
+                // Recurse: this child is too tall and can be fragmented.
+                CollectFragmentableBlocksCore(child, columnHeight, result, depth + 1);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Loads the CSS background image if one is specified and not yet loaded.
+    /// Called from <see cref="MeasureWordsSize"/> and overridden versions in
+    /// subclasses (e.g. <see cref="CssBoxImage"/>) that replace the base
+    /// measurement logic.
+    /// </summary>
+    protected void LoadBackgroundImageIfNeeded()
+    {
+        if (BackgroundImage == CssConstants.None || _backgroundImagesInitialized)
+            return;
+
+        _backgroundImagesInitialized = true;
+        var layers = SplitBackgroundImageLayers(BackgroundImage);
+        if (layers.Count == 0)
+            return;
+
+        _backgroundImageLoadHandlers = new List<ILayoutImageLoader?>(layers.Count);
+        foreach (var layer in layers)
+        {
+            var src = TryExtractBackgroundImageUrl(layer);
+            if (string.IsNullOrEmpty(src))
+            {
+                _backgroundImageLoadHandlers.Add(null);
+                continue;
+            }
+
+            var imageLoadHandler = LayoutEnvironment.CreateImageLoader(OnImageLoadComplete);
+            _backgroundImageLoadHandlers.Add(imageLoadHandler);
+            imageLoadHandler.LoadImage(src, HtmlTag?.Attributes, BaseUrl);
+        }
+    }
+
+    private static List<string> SplitBackgroundImageLayers(string backgroundImage)
+    {
+        var layers = new List<string>();
+        if (string.IsNullOrWhiteSpace(backgroundImage))
+            return layers;
+
+        int depth = 0;
+        int start = 0;
+        for (int i = 0; i < backgroundImage.Length; i++)
+        {
+            switch (backgroundImage[i])
+            {
+                case '(':
+                    depth++;
+                    break;
+                case ')':
+                    if (depth > 0)
+                        depth--;
+                    break;
+                case ',' when depth == 0:
+                    layers.Add(backgroundImage[start..i].Trim());
+                    start = i + 1;
+                    break;
+            }
+        }
+
+        layers.Add(backgroundImage[start..].Trim());
+        return layers;
+    }
+
+    private static string? TryExtractBackgroundImageUrl(string layer)
+    {
+        if (string.IsNullOrWhiteSpace(layer))
+            return null;
+
+        layer = layer.Trim();
+        if (!layer.StartsWith("url(", StringComparison.OrdinalIgnoreCase))
+            return layer.Contains('(') ? null : layer;
+
+        if (!layer.EndsWith(")", StringComparison.Ordinal))
+            return null;
+
+        var src = layer.Substring(4, layer.Length - 5).Trim();
+        if (src.Length >= 2 &&
+            ((src[0] == '\'' && src[^1] == '\'') ||
+             (src[0] == '"' && src[^1] == '"')))
+        {
+            src = src[1..^1];
+        }
+
+        return src;
+    }
+
+    internal virtual void MeasureWordsSize(ILayoutEnvironment g)
+    {
+        if (_wordsSizeMeasured)
+            return;
+
+        LoadBackgroundImageIfNeeded();
+        MeasureWordSpacing(g);
+
+        if (Words.Count > 0)
+        {
+            foreach (var boxWord in Words)
+            {
+                boxWord.Width = boxWord.Text != "\n" ? g.MeasureText(ActualFont, boxWord.Text).Width : 0;
+                boxWord.Height = ActualFont.Height;
+            }
+        }
+
+        _wordsSizeMeasured = true;
+    }
+
+    /// <summary>
+    /// Recursively calls <see cref="MeasureWordsSize"/> on all descendant
+    /// boxes so that <c>ActualWordSpacing</c> and word dimensions are
+    /// computed before <see cref="GetMinMaxWidth"/> is invoked for
+    /// shrink-to-fit width (CSS2.1 §10.3.7).
+    /// Note: the current box (<c>this</c>) is already measured by the
+    /// <see cref="MeasureWordsSize"/> call at the start of
+    /// <see cref="PerformLayoutImp"/>; only descendants need measuring.
+    /// </summary>
+    private void EnsureDescendantWordsMeasured(ILayoutEnvironment g)
+    {
+        var stack = new Stack<CssBox>();
+        foreach (var child in Boxes)
+            stack.Push(child);
+
+        while (stack.Count > 0)
+        {
+            var box = stack.Pop();
+            box.MeasureWordsSize(g);
+            foreach (var child in box.Boxes)
+                stack.Push(child);
+        }
+    }
+
+    protected override sealed CssBoxProperties GetParent() => _parentBox;
+
+    internal void InvalidateFontDependentSubtree()
+    {
+        InvalidateFontDependentValues();
+        foreach (var child in Boxes)
+            child.InvalidateFontDependentSubtree();
+    }
+
+    private int GetIndexForList()
+    {
+        // Phase 2: Read list attributes from CssBoxProperties instead of GetAttribute().
+        bool reversed = ParentBox.ListReversed;
+
+        int index;
+        if (ParentBox.ListStart.HasValue)
+        {
+            index = ParentBox.ListStart.Value;
+        }
+        else if (reversed)
+        {
+            index = 0;
+            foreach (CssBox b in ParentBox.Boxes)
+            {
+                if (b.Display == CssConstants.ListItem)
+                    index++;
+            }
+        }
+        else
+        {
+            index = 1;
+        }
+
+        foreach (CssBox b in ParentBox.Boxes)
+        {
+            if (b.Equals(this))
+                return index;
+
+            if (b.Display == CssConstants.ListItem)
+                index += reversed ? -1 : 1;
+        }
+
+        return index;
+    }
+
+    private void CreateListItemBox(ILayoutEnvironment g)
+    {
+        if (Display != CssConstants.ListItem || ListStyleType == CssConstants.None)
+            return;
+
+        if (_listItemBox == null)
+        {
+            _listItemBox = new CssBox(null, null, BaseUrl);
+            _listItemBox.InheritStyle(this);
+            _listItemBox.Display = CssConstants.Inline;
+            _listItemBox._htmlContainer = ContainerInt;
+            _listItemBox._layoutEnvironment = LayoutEnvironment;
+
+            if (ListStyleType.Equals(CssConstants.Disc, StringComparison.InvariantCultureIgnoreCase))
+            {
+                _listItemBox.Text = "•".AsMemory();
+            }
+            else if (ListStyleType.Equals(CssConstants.Circle, StringComparison.InvariantCultureIgnoreCase))
+            {
+                _listItemBox.Text = "o".AsMemory();
+            }
+            else if (ListStyleType.Equals(CssConstants.Square, StringComparison.InvariantCultureIgnoreCase))
+            {
+                _listItemBox.Text = "♠".AsMemory();
+            }
+            else if (ListStyleType.Equals(CssConstants.Decimal, StringComparison.InvariantCultureIgnoreCase))
+            {
+                _listItemBox.Text = (GetIndexForList().ToString(CultureInfo.InvariantCulture) + ".").AsMemory();
+            }
+            else if (ListStyleType.Equals(CssConstants.DecimalLeadingZero, StringComparison.InvariantCultureIgnoreCase))
+            {
+                _listItemBox.Text = (GetIndexForList().ToString("00", CultureInfo.InvariantCulture) + ".").AsMemory();
+            }
+            else
+            {
+                _listItemBox.Text = (LayoutEnvironment.FormatListMarker(GetIndexForList(), ListStyleType) + ".").AsMemory();
+            }
+
+            _listItemBox.ParseToWords();
+
+            _listItemBox.PerformLayoutImp(g);
+            _listItemBox.Size = new SizeF((float)_listItemBox.Words[0].Width, (float)_listItemBox.Words[0].Height);
+        }
+
+        _listItemBox.Words[0].Left = Location.X - _listItemBox.Size.Width - 5;
+        _listItemBox.Words[0].Top = Location.Y + ActualPaddingTop; // +FontAscent;
+    }
+
+    internal string GetAttribute(string attribute) => GetAttribute(attribute, string.Empty);
+    internal string GetAttribute(string attribute, string defaultValue) => HtmlTag != null ? HtmlTag.TryGetAttribute(attribute, defaultValue) : defaultValue;
+
+    internal double GetMinimumWidth()
+    {
+        double maxWidth = 0;
+        CssRect maxWidthWord = null;
+        CssBoxHelper.GetMinimumWidth_LongestWord(this, ref maxWidth, ref maxWidthWord);
+
+        double padding = 0f;
+        if (maxWidthWord != null)
+        {
+            var box = maxWidthWord.OwnerBox;
+            while (box != null)
+            {
+                padding += box.ActualBorderRightWidth + box.ActualPaddingRight + box.ActualBorderLeftWidth + box.ActualPaddingLeft;
+                box = box != this ? box.ParentBox : null;
+            }
+        }
+
+        return maxWidth + padding;
+    }
+
+    internal void GetMinMaxWidth(out double minWidth, out double maxWidth)
+    {
+        double min = 0f;
+        double maxSum = 0f;
+        double paddingSum = 0f;
+        double marginSum = 0f;
+
+        CssBoxHelper.GetMinMaxSumWords(this, ref min, ref maxSum, ref paddingSum, ref marginSum);
+
+        maxWidth = paddingSum + maxSum;
+        minWidth = paddingSum + (min < 90999 ? min : 0);
+    }
+
+    /// <summary>
+    /// CSS2.1 §10.3.7: Computes the shrink-to-fit width for an auto-width
+    /// absolutely positioned element by independently measuring each direct
+    /// child's total width and returning the maximum.
+    /// Each block or float child is its own "line"; the preferred width is
+    /// the widest line.  This avoids the incorrect accumulation that occurs
+    /// when <see cref="CssBoxHelper.GetMinMaxSumWords"/> sums float widths
+    /// with preceding block widths.
+    /// </summary>
+    private double ComputeShrinkToFitWidth()
+    {
+        double maxLineWidth = 0;
+
+        foreach (var child in Boxes)
+        {
+            double childWidth;
+
+            if (child.Width != CssConstants.Auto && !string.IsNullOrEmpty(child.Width))
+            {
+                // Explicit width: use declared width + borders/padding
+                double containingBlockWidth = Size.Width > 0 && !double.IsNaN(Size.Width) ? Size.Width : 0;
+                childWidth = child.ParseLengthWithLineHeight(child.Width, containingBlockWidth)
+                           + child.ActualBorderLeftWidth + child.ActualBorderRightWidth
+                           + child.ActualPaddingLeft + child.ActualPaddingRight;
+            }
+            else
+            {
+                // Auto-width child: compute its intrinsic preferred width.
+                // Guard against NaN from unmeasured words in deeply nested
+                // inline elements (e.g. Acid2 .eyes → #eyes-a → <object>).
+                child.GetMinMaxWidth(out _, out double childMax);
+                childWidth = double.IsNaN(childMax) ? 0 : childMax;
+            }
+
+            childWidth += child.ActualMarginLeft + child.ActualMarginRight;
+            if (!double.IsNaN(childWidth))
+                maxLineWidth = Math.Max(maxLineWidth, childWidth);
+        }
+
+        return maxLineWidth;
+    }
+
+    /// <summary>
+    /// CSS Sizing 3 §5.1: <c>true</c> when <paramref name="width"/> is one of
+    /// the intrinsic sizing keywords (<c>min-content</c>, <c>max-content</c>,
+    /// <c>fit-content</c>).
+    /// </summary>
+    private static bool IsIntrinsicWidthKeyword(string width) =>
+        string.Equals(width, "min-content", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(width, "max-content", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(width, "fit-content", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// CSS Sizing 3 §5: Resolves an intrinsic-keyword width to a used
+    /// border-box width.  <c>min-content</c> uses the largest child
+    /// min-content contribution, <c>max-content</c> the largest max-content
+    /// contribution, and <c>fit-content</c> clamps the max-content size into
+    /// the available space (but never below min-content).
+    /// </summary>
+    private double ResolveIntrinsicWidth(ILayoutEnvironment g, string keyword, double availableContentWidth)
+    {
+        EnsureDescendantWordsMeasured(g);
+
+        double available = availableContentWidth - ActualMarginLeft - ActualMarginRight;
+        double content;
+        if (string.Equals(keyword, "min-content", StringComparison.OrdinalIgnoreCase))
+        {
+            content = ComputeIntrinsicInlineSize(useMin: true);
+        }
+        else if (string.Equals(keyword, "max-content", StringComparison.OrdinalIgnoreCase))
+        {
+            content = ComputeIntrinsicInlineSize(useMin: false);
+        }
+        else // fit-content
+        {
+            double max = ComputeIntrinsicInlineSize(useMin: false);
+            double min = ComputeIntrinsicInlineSize(useMin: true);
+            content = Math.Min(Math.Max(min, available), max);
+        }
+
+        if (double.IsNaN(content) || content < 0)
+            content = 0;
+
+        return ResolveSpecifiedWidthToBorderBox(content);
+    }
+
+    /// <summary>
+    /// Computes the intrinsic inline size (content width) as the widest direct
+    /// child contribution.  Each block/float child forms its own line, so the
+    /// container's intrinsic size is the maximum child width rather than the
+    /// sum.  When <paramref name="useMin"/> is set, auto-width children
+    /// contribute their min-content width; otherwise their max-content width.
+    /// </summary>
+    private double ComputeIntrinsicInlineSize(bool useMin)
+    {
+        double maxLineWidth = 0;
+
+        foreach (var child in Boxes)
+        {
+            double childWidth;
+
+            if (child.Width != CssConstants.Auto && !string.IsNullOrEmpty(child.Width)
+                && !IsIntrinsicWidthKeyword(child.Width))
+            {
+                double containingBlockWidth = Size.Width > 0 && !double.IsNaN(Size.Width) ? Size.Width : 0;
+                childWidth = child.ParseLengthWithLineHeight(child.Width, containingBlockWidth)
+                           + child.ActualBorderLeftWidth + child.ActualBorderRightWidth
+                           + child.ActualPaddingLeft + child.ActualPaddingRight;
+            }
+            else
+            {
+                child.GetMinMaxWidth(out double childMin, out double childMax);
+                double intrinsic = useMin ? childMin : childMax;
+                childWidth = double.IsNaN(intrinsic) ? 0 : intrinsic;
+            }
+
+            childWidth += child.ActualMarginLeft + child.ActualMarginRight;
+            if (!double.IsNaN(childWidth))
+                maxLineWidth = Math.Max(maxLineWidth, childWidth);
+        }
+
+        return maxLineWidth;
+    }
+
+    /// <summary>
+    /// CSS Box Model 4 §6.2: Applies <c>margin-trim</c> to this box by zeroing
+    /// the block-start margin of its first in-flow block-level child and/or the
+    /// block-end margin of its last in-flow block-level child, as requested by
+    /// the property value (<c>block</c>, <c>block-start</c>, <c>block-end</c>).
+    /// Inline-axis trimming is not yet supported.
+    /// </summary>
+    private void ApplyMarginTrim()
+    {
+        if (string.IsNullOrEmpty(MarginTrim) || MarginTrim == CssConstants.None)
+            return;
+
+        bool trimBlockStart = false;
+        bool trimBlockEnd = false;
+        foreach (var token in MarginTrim.Split((char[])null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            switch (token.ToLowerInvariant())
+            {
+                case "block":
+                    trimBlockStart = true;
+                    trimBlockEnd = true;
+                    break;
+                case "block-start":
+                    trimBlockStart = true;
+                    break;
+                case "block-end":
+                    trimBlockEnd = true;
+                    break;
+            }
+        }
+
+        if (!trimBlockStart && !trimBlockEnd)
+            return;
+
+        CssBox first = null;
+        CssBox last = null;
+        foreach (var child in Boxes)
+        {
+            if (child.Display == CssConstants.None
+                || child.Position == CssConstants.Absolute
+                || child.Position == CssConstants.Fixed
+                || child.Float != CssConstants.None
+                || child.IsInline)
+                continue;
+
+            first ??= child;
+            last = child;
+        }
+
+        if (trimBlockStart && first != null)
+            first.MarginTop = "0";
+        if (trimBlockEnd && last != null)
+            last.MarginBottom = "0";
+    }
+
+    internal new void InheritStyle(CssBox box = null, bool everything = false) => base.InheritStyle(box ?? ParentBox, everything);
+
+    protected double MarginTopCollapse(CssBoxProperties prevSibling)
+    {
+        double value;
+
+        if (prevSibling != null)
+        {
+            // CSS2.1 §8.3.1: When the previous sibling is an "empty" box
+            // (zero content height, no borders/padding, height auto/0), its
+            // own top and bottom margins — and its children's margins —
+            // collapse through.  The resulting collapsed margin participates
+            // in collapsing with this element's top margin.
+            if (prevSibling is CssBox prevBox && CssBoxHelper.IsEmptyCollapsible(prevBox))
+            {
+                double maxPos = Math.Max(ActualMarginTop, 0);
+                double maxNeg = Math.Min(ActualMarginTop, 0);
+                CssBoxHelper.CollectEmptyBoxMargins(prevBox, ref maxPos, ref maxNeg);
+                double collapsed = maxPos + maxNeg; // maxNeg <= 0
+                // Subtract the portion of the collapsed margin already
+                // consumed when positioning the empty box itself (its
+                // CollapsedMarginTop was recorded during its own layout).
+                value = collapsed - prevBox.CollapsedMarginTop;
+            }
+            else
+            {
+                // CSS2.1 §8.3.1: Adjoining vertical margins collapse.
+                // When both are positive → max(m1, m2).
+                // When one is negative  → max(positives,0) + min(negatives,0).
+                // When both are negative → 0 + min(m1,m2) = most-negative.
+                // The general formula covers all three cases.
+                // Use GetPropagatedMarginBottom so that a last-child's
+                // bottom margin propagates through its parent when the
+                // parent has no bottom border/padding and auto height
+                // (CSS 2.1 §8.3.1 parent-child bottom-margin collapse).
+                double prevMb = (prevSibling is CssBox prevSibBox)
+                    ? CssBoxHelper.GetPropagatedMarginBottom(prevSibBox)
+                    : prevSibling.ActualMarginBottom;
+                double maxPos = Math.Max(
+                    Math.Max(prevMb, 0),
+                    Math.Max(ActualMarginTop, 0));
+                double minNeg = Math.Min(
+                    Math.Min(prevMb, 0),
+                    Math.Min(ActualMarginTop, 0));
+                value = maxPos + minNeg;
+            }
+            CollapsedMarginTop = value;
+        }
+        else if (_parentBox != null && _parentBox.ActualPaddingTop < 0.1 && _parentBox.ActualPaddingBottom < 0.1 && _parentBox.ActualBorderTopWidth < 0.1 && _parentBox.ActualBorderBottomWidth < 0.1
+            // CSS Box Alignment §5.4: align-content != normal establishes
+            // a BFC, which prevents parent–child margin collapsing.
+            && (_parentBox.AlignContent == null || _parentBox.AlignContent == "normal"))
+        {
+            double parentEffective = Math.Max(_parentBox.ActualMarginTop, _parentBox.CollapsedMarginTop);
+
+            // CSS2.1 §8.3.1: First in-flow child's top margin collapses
+            // with the parent's top margin when the parent has no top
+            // border and no top padding.  When the child's margin
+            // exceeds the parent's, propagate the excess upward by
+            // shifting the parent's position down.  Only do this for
+            // non-root containers (not html/body) to avoid disturbing
+            // the root element's established position.
+            if (ActualMarginTop > parentEffective + 0.1
+                && _parentBox.ParentBox != null
+                && _parentBox.ParentBox.ParentBox != null)
+            {
+                double propagation = ActualMarginTop - parentEffective;
+                _parentBox.Location = new PointF(
+                    _parentBox.Location.X,
+                    _parentBox.Location.Y + (float)propagation);
+                _parentBox.CollapsedMarginTop = ActualMarginTop;
+                value = 0;
+            }
+            else
+            {
+                value = Math.Max(0, ActualMarginTop - parentEffective);
+            }
+        }
+        else
+        {
+            value = ActualMarginTop;
+
+            // When the parent establishes a BFC (e.g. via align-content),
+            // the first child's margin is fully consumed for positioning.
+            // Record it so that an empty-collapsible sibling can subtract
+            // the already-consumed portion during its own collapse.
+            if (_parentBox != null
+                && _parentBox.AlignContent != null
+                && _parentBox.AlignContent != "normal")
+            {
+                CollapsedMarginTop = value;
+            }
+        }
+
+        // fix for hr tag
+        if (value < 0.1 && HtmlTag != null && HtmlTag.Name == "hr")
+            value = GetEmHeight() * 1.1f;
+
+        return value;
+    }
+
+    public bool BreakPage()
+    {
+        var container = LayoutEnvironment;
+
+        if (Size.Height >= container.PageSize.Height)
+            return false;
+
+        var remTop = (Location.Y - container.MarginTop) % container.PageSize.Height;
+        var remBottom = (ActualBottom - container.MarginTop) % container.PageSize.Height;
+
+        if (remTop > remBottom)
+        {
+            var diff = container.PageSize.Height - remTop;
+            Location = new PointF(Location.X, (float)(Location.Y + diff + 1));
+            
+            return true;
+        }
+
+        return false;
+    }
+
+    private double CalculateActualRight()
+    {
+        if (ActualRight <= 90999)
+            return ActualRight;
+
+        var maxRight = 0d;
+
+        foreach (var box in Boxes)
+            maxRight = Math.Max(maxRight, box.ActualRight + box.ActualMarginRight);
+
+        return maxRight + ActualPaddingRight + ActualMarginRight + ActualBorderRightWidth;
+    }
+
+    private double MarginBottomCollapse()
+    {
+        double margin = 0;
+
+        // NOTE: When the last in-flow child's bottom margin collapses through
+        // this box (computed below, once the last child is known) the collapsed
+        // margin is NOT included in this box's height — it is external spacing
+        // propagated to the parent via GetPropagatedMarginBottom().  The
+        // `margin` variable stays 0.
+
+        // CSS2.1 §10.6.3 / §10.6.7: Floated children contribute to the
+        // height of their parent only when the parent establishes a new
+        // block formatting context (BFC).  Non-BFC blocks (e.g. a plain
+        // <ul> inside a floated <dd>) must not include descendant floats
+        // in their height calculation.
+        bool isBfc = Float != CssConstants.None
+            || Display == CssConstants.InlineBlock
+            || Display == CssConstants.TableCell
+            || (Overflow != null && Overflow != CssConstants.Visible)
+            || Position == CssConstants.Absolute
+            || Position == CssConstants.Fixed
+            || (AlignContent != null && AlignContent != "normal");
+
+        // Use the maximum ActualBottom across all children to handle
+        // floated children that may not be the last in source order.
+        // Initialize to the content-area top so that padding is preserved
+        // even when all children are floated (CSS2.1 §10.6.3: content
+        // height is zero but padding is additive).
+        double maxChildBottom = Location.Y + ActualBorderTopWidth + ActualPaddingTop;
+        CssBox lastInFlowChild = null;
+        
+        foreach (var child in Boxes)
+        {
+            // CSS2.1 §10.6.3: Only children in the normal flow are taken
+            // into account.  Absolutely positioned and fixed-position boxes
+            // are out of flow and must not influence the parent's auto height.
+            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+                continue;
+
+            if (!isBfc && child.Float != CssConstants.None)
+                continue;
+
+            // CSS2.1 §9.4.3: Relative positioning is visual-only and
+            // does not affect the flow position used for auto-height
+            // calculation.  Undo the relative offset so the parent
+            // measures the child's normal-flow bottom.
+            double childBottom = child.ActualBottom;
+            if (child.Position == CssConstants.Relative)
+                childBottom -= CssBoxHelper.GetRelativeOffsetY(child);
+            maxChildBottom = Math.Max(maxChildBottom, childBottom);
+            lastInFlowChild = child;
+        }
+
+        // CSS2.1 §10.6.7: When a BFC root auto-sizes its height it must
+        // extend to contain all descendant floats — not only direct-child
+        // floats.  Walk the subtree (stopping at nested BFC boundaries)
+        // to find the maximum float bottom.
+        if (isBfc)
+        {
+            double maxFloatDesc = maxChildBottom;
+            FindMaxDescendantFloatBottom(this, ref maxFloatDesc);
+            maxChildBottom = Math.Max(maxChildBottom, maxFloatDesc);
+        }
+
+        // CSS2.1 §8.3.1 / §10.6.3: The auto height extends to the bottom
+        // margin-edge of the last in-flow child unless that child's bottom
+        // margin collapses through this box.  Collapse-through happens when
+        // this box has no bottom border or padding, an auto (or
+        // auto-resolved) height, and a block-level last in-flow child.  This
+        // must match the condition used by GetPropagatedMarginBottom() (which
+        // propagates the same margin to the parent): otherwise the child's
+        // margin is double-counted — once inside this box's height and once as
+        // external spacing.  Note this does NOT depend on whether this box is
+        // its own parent's last child, nor on this box's own bottom margin.
+        bool autoHeight = Height == CssConstants.Auto || string.IsNullOrEmpty(Height)
+            || (Height.Contains('%')
+                && (ContainingBlock == null || ContainingBlock.Height == CssConstants.Auto
+                    || string.IsNullOrEmpty(ContainingBlock.Height)));
+        bool collapseThrough = lastInFlowChild != null
+            && ActualPaddingBottom < 0.1 && ActualBorderBottomWidth < 0.1
+            && autoHeight
+            && lastInFlowChild.Float == CssConstants.None
+            && lastInFlowChild.Display != CssConstants.Inline
+            && lastInFlowChild.Display != CssConstants.InlineBlock;
+        if (!collapseThrough && lastInFlowChild != null)
+            maxChildBottom += lastInFlowChild.ActualMarginBottom;
+        return Math.Max(ActualBottom, maxChildBottom + margin + ActualPaddingBottom + ActualBorderBottomWidth);
+    }
+
+    /// <summary>
+    /// CSS Box Alignment Level 3 §6.1: Resolves justify-self / align-self
+    /// alignment for an absolutely-positioned box within its inset-modified
+    /// containing block (IMCB).  Returns the offset from the IMCB start
+    /// edge.  Default overflow behaviour for abspos is 'safe': when the
+    /// content would overflow the strong CB edge, it is shifted to align
+    /// with the start of the writing direction.
+    /// </summary>
+    private static double ResolveAbsposSelfAlignment(
+        string alignment, double containerSize, double boxSize, bool isRtl)
+    {
+        double freeSpace = containerSize - boxSize;
+
+        // Strip safe/unsafe prefix.
+        string a = alignment;
+        bool isSafe = true; // default for abspos is safe
+        if (a.StartsWith("safe ", StringComparison.OrdinalIgnoreCase))
+        {
+            a = a.Substring(5).Trim();
+            isSafe = true;
+        }
+        else if (a.StartsWith("unsafe ", StringComparison.OrdinalIgnoreCase))
+        {
+            a = a.Substring(7).Trim();
+            isSafe = false;
+        }
+
+        double dx;
+        switch (a)
+        {
+            case "center":
+                dx = freeSpace / 2;
+                break;
+            case "end":
+            case "flex-end":
+                dx = isRtl ? 0 : freeSpace;
+                break;
+            case "self-end":
+                dx = isRtl ? 0 : freeSpace;
+                break;
+            case "right":
+                dx = freeSpace;
+                break;
+            case "start":
+            case "flex-start":
+                dx = isRtl ? freeSpace : 0;
+                break;
+            case "self-start":
+                dx = isRtl ? freeSpace : 0;
+                break;
+            case "left":
+                dx = 0;
+                break;
+            default:
+                dx = 0; // fallback: start-aligned
+                break;
+        }
+
+        // Safe overflow: clamp so the element does not overflow the
+        // strong edge (start edge in the writing direction).
+        if (isSafe)
+        {
+            if (isRtl)
+            {
+                // Strong edge is right (end of CB) — clamp dx ≤ freeSpace
+                dx = Math.Min(dx, Math.Max(freeSpace, 0));
+            }
+            else
+            {
+                // Strong edge is left (start of CB) — clamp dx ≥ 0
+                dx = Math.Max(dx, 0);
+            }
+        }
+
+        return dx;
+    }
+
+    /// <summary>
+    /// Computes the shrink-to-fit content width of this box: the maximum
+    /// right edge of all child boxes (relative to this box) plus padding
+    /// and border.  Used for abspos self-alignment where the box size is
+    /// content-driven rather than stretched.
+    /// </summary>
+    private double GetShrinkToFitWidth()
+    {
+        // If there's an explicit CSS width, use it (plus border/padding).
+        if (Width != CssConstants.Auto && !string.IsNullOrEmpty(Width))
+            return Size.Width;
+
+        double maxRight = 0;
+        foreach (var child in Boxes)
+        {
+            if (child.Display == CssConstants.None) continue;
+            double childRight = (child.Location.X - Location.X)
+                                + child.Size.Width
+                                + child.ActualMarginRight;
+            maxRight = Math.Max(maxRight, childRight);
+        }
+
+        if (maxRight <= 0) return Size.Width;
+
+        return maxRight + ActualPaddingRight + ActualBorderRightWidth;
+    }
+
+    /// <summary>
+    /// Computes the shrink-to-fit content height of this box: the maximum
+    /// bottom edge of all child boxes (relative to this box) plus padding
+    /// and border.  Used for abspos self-alignment where the box size is
+    /// content-driven rather than stretched.
+    /// </summary>
+    private double GetShrinkToFitHeight()
+    {
+        // If there's an explicit CSS height, use it (plus border/padding).
+        if (Height != CssConstants.Auto && !string.IsNullOrEmpty(Height))
+        {
+            double h = ActualBottom - Location.Y;
+            return h > 0 ? h : Size.Height;
+        }
+
+        double maxBottom = 0;
+        foreach (var child in Boxes)
+        {
+            if (child.Display == CssConstants.None) continue;
+            double childBottom = (child.Location.Y - Location.Y)
+                                 + (child.ActualBottom - child.Location.Y)
+                                 + child.ActualMarginBottom;
+            maxBottom = Math.Max(maxBottom, childBottom);
+        }
+
+        if (maxBottom <= 0)
+        {
+            double h = ActualBottom - Location.Y;
+            return h > 0 ? h : Size.Height;
+        }
+
+        return maxBottom + ActualPaddingBottom + ActualBorderBottomWidth;
+    }
+
+    /// <summary>
+    /// Recursively finds the maximum bottom edge of any float in the
+    /// subtree, stopping at nested BFC boundaries.  Used by the BFC
+    /// root height calculation so that grandchild (and deeper) floats
+    /// are properly contained.
+    /// </summary>
+    private static void FindMaxDescendantFloatBottom(CssBox box, ref double maxBottom)
+    {
+        foreach (var child in box.Boxes)
+        {
+            if (child.Float != CssConstants.None && child.Display != CssConstants.None)
+            {
+                maxBottom = Math.Max(maxBottom, child.ActualBottom + child.ActualMarginBottom);
+            }
+
+            // Don't recurse into nested BFC roots — their floats are
+            // contained by them, not by the outer BFC.
+            bool childIsBfc = child.Float != CssConstants.None
+                || child.Display == CssConstants.InlineBlock
+                || child.Display == CssConstants.TableCell
+                || child.Display is "flex" or "inline-flex" or "grid" or "inline-grid"
+                || child.Position == CssConstants.Absolute
+                || child.Position == CssConstants.Fixed
+                || (child.Overflow != null && child.Overflow != CssConstants.Visible)
+                || (child.AlignContent != null && child.AlignContent != "normal");
+            if (!childIsBfc)
+                FindMaxDescendantFloatBottom(child, ref maxBottom);
+        }
+    }
+
+    /// <summary>
+    /// CSS Grid Level 1 §8.5: When all grid items share the same
+    /// grid-row and grid-column (e.g. grid-row: 1; grid-column: 1),
+    /// they overlap in the same grid cell.  Reposition them to the
+    /// container's content-area top-left so they stack visually with
+    /// later items painted on top.
+    /// </summary>
+    /// <returns><c>true</c> if stacking was applied; <c>false</c>
+    /// if items are not all in the same cell.</returns>
+    private bool ApplyGridStacking()
+    {
+        bool allSameCell = true;
+        string firstRow = null, firstCol = null;
+        foreach (var child in Boxes)
+        {
+            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+                continue;
+            if (child.Display == CssConstants.None)
+                continue;
+            var cr = child.GridRow;
+            var cc = child.GridColumn;
+            // Items without explicit grid placement use auto.
+            if (string.IsNullOrEmpty(cr) || cr == "auto"
+                || string.IsNullOrEmpty(cc) || cc == "auto")
+            { allSameCell = false; break; }
+            if (firstRow == null)
+            { firstRow = cr; firstCol = cc; }
+            else if (cr != firstRow || cc != firstCol)
+            { allSameCell = false; break; }
+        }
+
+        if (!allSameCell || firstRow == null)
+            return false;
+
+        double cellLeft = Location.X + ActualPaddingLeft + ActualBorderLeftWidth;
+        double cellTop = Location.Y + ActualPaddingTop + ActualBorderTopWidth;
+        double maxBottom = cellTop;
+        foreach (var child in Boxes)
+        {
+            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+                continue;
+            if (child.Display == CssConstants.None)
+                continue;
+            double dx = cellLeft + child.ActualMarginLeft - child.Location.X;
+            double dy = cellTop + child.ActualMarginTop - child.Location.Y;
+            if (Math.Abs(dx) > 0.1)
+                child.OffsetLeft(dx);
+            if (Math.Abs(dy) > 0.1)
+                child.OffsetTop(dy);
+            double childBottom = child.ActualBottom + child.ActualMarginBottom;
+            if (childBottom > maxBottom)
+                maxBottom = childBottom;
+        }
+        ActualBottom = maxBottom + ActualPaddingBottom + ActualBorderBottomWidth;
+        return true;
+    }
+
+    /// <summary>
+    /// Called from <see cref="CssLayoutEngine.FlowInlineBlock"/> after
+    /// CreateLineBoxes to apply grid stacking or auto-placement for grid
+    /// containers that are laid out via the inline-block path.
+    /// </summary>
+    internal void ApplyGridLayoutAfterInline()
+    {
+        if (!ApplyGridStacking())
+            ApplyGridAutoPlacement();
+    }
+
+    /// <summary>
+    /// CSS Grid Level 1: Auto-placement for grid items that are not all
+    /// in the same cell.  The inline layout path (CreateLineBoxes) places
+    /// grid items as inline-blocks on a single line.  This method
+    /// repositions them into proper grid rows (one item per row for a
+    /// single-column grid) and applies justify-self within the column.
+    /// </summary>
+    private void ApplyGridAutoPlacement()
+    {
+        double cellLeft = Location.X + ActualPaddingLeft + ActualBorderLeftWidth;
+        double cellTop = Location.Y + ActualPaddingTop + ActualBorderTopWidth;
+        double columnWidth = Size.Width - ActualPaddingLeft - ActualPaddingRight
+            - ActualBorderLeftWidth - ActualBorderRightWidth;
+        if (columnWidth <= 0) return;
+
+        double currentY = cellTop;
+        foreach (var child in Boxes)
+        {
+            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+                continue;
+            if (child.Display == CssConstants.None)
+                continue;
+
+            // CSS Grid Level 1 §6.1: Grid items with auto/normal/stretch
+            // justify-self and auto width should stretch to fill the column.
+            bool isAutoWidth = child.Width == CssConstants.Auto
+                || string.IsNullOrEmpty(child.Width);
+            string js = child.JustifySelf?.Trim().ToLowerInvariant();
+            // CSS Box Alignment §6.2: 'justify-self: auto' resolves to the
+            // grid container's 'justify-items' (the intermediate display:
+            // contents ancestor, having no box, does not contribute).
+            if (string.IsNullOrEmpty(js) || js == "auto")
+            {
+                string ji = JustifyItems?.Trim().ToLowerInvariant();
+                js = string.IsNullOrEmpty(ji) || ji == "auto" || ji == "legacy"
+                    ? "normal"
+                    : ji;
+            }
+            bool isStretch = js == "normal" || js == "stretch";
+
+            if (isStretch && isAutoWidth)
+            {
+                double targetWidth = columnWidth
+                    - child.ActualMarginLeft - child.ActualMarginRight;
+                if (targetWidth > 0 && Math.Abs(child.Size.Width - targetWidth) > 0.5)
+                    child.Size = new SizeF((float)targetWidth, child.Size.Height);
+            }
+
+            // Move child to the start of the current row.
+            double dx = cellLeft + child.ActualMarginLeft - child.Location.X;
+            double dy = currentY + child.ActualMarginTop - child.Location.Y;
+            if (Math.Abs(dx) > 0.1)
+                child.OffsetLeft(dx);
+            if (Math.Abs(dy) > 0.1)
+                child.OffsetTop(dy);
+
+            // CSS Grid Level 1 §6.1: Apply justify-self to position the
+            // item within its grid cell (column width).
+            double boxWidth = child.ActualRight - child.Location.X;
+            double freeSpace = columnWidth - boxWidth;
+            if (freeSpace > 0.5 && !isStretch)
+            {
+                bool isElementRtl = child.Direction == "rtl";
+                bool isContainerRtl = Direction == "rtl";
+
+                double justifyDx = 0;
+                switch (js)
+                {
+                    case "center":
+                        justifyDx = freeSpace / 2;
+                        break;
+                    case "end":
+                    case "flex-end":
+                        justifyDx = isContainerRtl ? 0 : freeSpace;
+                        break;
+                    case "self-end":
+                        justifyDx = isElementRtl ? 0 : freeSpace;
+                        break;
+                    case "right":
+                        justifyDx = freeSpace;
+                        break;
+                    case "start":
+                    case "flex-start":
+                        justifyDx = isContainerRtl ? freeSpace : 0;
+                        break;
+                    case "self-start":
+                        justifyDx = isElementRtl ? freeSpace : 0;
+                        break;
+                    case "left":
+                        justifyDx = 0;
+                        break;
+                }
+
+                if (Math.Abs(justifyDx) > 0.5)
+                    child.OffsetLeft(justifyDx);
+            }
+
+            currentY = child.ActualBottom + child.ActualMarginBottom;
+        }
+        ActualBottom = currentY + ActualPaddingBottom + ActualBorderBottomWidth;
+    }
+
+    /// <summary>
+    /// CSS Box Alignment Level 3 §6.2 / CSS Flexbox §8.3: position flex/grid
+    /// items along the block (cross) axis according to <c>align-items</c>
+    /// (overridable per item by <c>align-self</c>).  Broiler approximates
+    /// flex/grid with an inline formatting context (FlowInlineBlock), which
+    /// leaves every item at the content-box block-start; this pass shifts
+    /// items to center/end when the container has a definite block size with
+    /// free space.  Only the common horizontal-writing-mode case is handled
+    /// (grid and row/row-reverse flex); column flex (cross axis = inline)
+    /// and overflowing content fall back to start alignment.
+    /// </summary>
+    private void ApplyFlexGridCrossAxisAlignment()
+    {
+        if (Display is not ("flex" or "inline-flex" or "grid" or "inline-grid"))
+            return;
+
+        // The cross axis must be the block (vertical) axis: true for grid and
+        // for row-direction flex.  Column flex aligns items on the inline
+        // axis, which this approximation does not handle.
+        if (Display is "flex" or "inline-flex"
+            && FlexDirection is "column" or "column-reverse")
+            return;
+
+        // A definite block size is required to have free space to distribute.
+        // (Size.Height is content-derived at this point — the specified height
+        // is only pre-resolved into Size for percentage values — so resolve
+        // the definite block size directly from the 'height' declaration.)
+        if (string.IsNullOrEmpty(Height) || Height == CssConstants.Auto
+            || HeightPercentageResolvesToAuto())
+            return;
+
+        double cbHeight;
+        if (Position == CssConstants.Fixed && LayoutEnvironment != null)
+            cbHeight = LayoutEnvironment.ViewportSize.Height;
+        else if (ContainingBlock?.ParentBox == null && LayoutEnvironment != null)
+            cbHeight = LayoutEnvironment.ViewportSize.Height;
+        else
+            cbHeight = ContainingBlock?.Size.Height ?? 0;
+
+        double contentTop = ClientTop;
+        double contentHeight = ResolveSpecifiedHeightToBorderBox(
+                CssValueParser.ParseLength(Height, cbHeight, GetEmHeight()))
+            - ActualPaddingTop - ActualPaddingBottom
+            - ActualBorderTopWidth - ActualBorderBottomWidth;
+        if (contentHeight <= 0)
+            return;
+
+        string containerAlign = NormalizeBoxAlignment(AlignItems);
+
+        foreach (CssBox item in Boxes)
+        {
+            if (item.Display == CssConstants.None)
+                continue;
+            // CSS2.1 §9.6.1 / §9.5: out-of-flow items are positioned separately.
+            if (item.Position is CssConstants.Absolute or CssConstants.Fixed)
+                continue;
+            if (item.Float != CssConstants.None)
+                continue;
+
+            // 'align-self: auto' (and 'normal') resolve to the container's
+            // 'align-items' (CSS Box Alignment §6.2).
+            string self = NormalizeBoxAlignment(item.AlignSelf);
+            string align = self is "" or "auto" or "normal" ? containerAlign : self;
+
+            bool toCenter = align == "center";
+            bool toEnd = align is "end" or "flex-end" or "self-end";
+            if (!toCenter && !toEnd)
+                continue; // start/flex-start/baseline/stretch → block-start
+
+            double marginBoxHeight = (item.ActualBottom - item.Location.Y)
+                + item.ActualMarginTop + item.ActualMarginBottom;
+            double free = contentHeight - marginBoxHeight;
+            if (free <= 0.5)
+                continue; // safe alignment: no room → keep at start
+
+            double marginBoxOffset = toCenter ? free / 2 : free;
+            double targetTop = contentTop + marginBoxOffset + item.ActualMarginTop;
+            double dy = targetTop - item.Location.Y;
+            if (Math.Abs(dy) > 0.5)
+            {
+                item.OffsetTop(dy);
+                item.ActualBottom += dy;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Normalises a CSS Box Alignment keyword: trims, strips a leading
+    /// <c>safe</c>/<c>unsafe</c> overflow-alignment qualifier, and lower-cases.
+    /// </summary>
+    private static string NormalizeBoxAlignment(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return "";
+        string v = value.Trim();
+        if (v.StartsWith("safe ", StringComparison.OrdinalIgnoreCase))
+            v = v.Substring(5).Trim();
+        else if (v.StartsWith("unsafe ", StringComparison.OrdinalIgnoreCase))
+            v = v.Substring(7).Trim();
+        return v.ToLowerInvariant();
+    }
+
+    internal void OffsetTop(double amount)
+    {
+        List<CssLineBox> lines = [.. Rectangles.Keys];
+
+        foreach (CssLineBox line in lines)
+        {
+            RectangleF r = Rectangles[line];
+            Rectangles[line] = new RectangleF(r.X, (float)(r.Y + amount), r.Width, r.Height);
+        }
+
+        foreach (CssRect word in Words)
+            word.Top += amount;
+
+        foreach (CssBox b in Boxes)
+        {
+            // CSS2.1 §9.6.1: position:fixed elements are positioned relative
+            // to the viewport and must not be shifted by ancestor offsets
+            // (e.g. a parent's position:relative visual offset).
+            if (b.Position != CssConstants.Fixed)
+                b.OffsetTop(amount);
+        }
+
+        _listItemBox?.OffsetTop(amount);
+
+        Location = new PointF(Location.X, (float)(Location.Y + amount));
+    }
+
+    internal void OffsetLeft(double amount)
+    {
+        List<CssLineBox> lines = [.. Rectangles.Keys];
+
+        foreach (CssLineBox line in lines)
+        {
+            RectangleF r = Rectangles[line];
+            Rectangles[line] = new RectangleF((float)(r.X + amount), r.Y, r.Width, r.Height);
+        }
+
+        foreach (CssRect word in Words)
+            word.Left += amount;
+
+        foreach (CssBox b in Boxes)
+        {
+            // CSS2.1 §9.6.1: position:fixed elements are positioned relative
+            // to the viewport and must not be shifted by ancestor offsets.
+            if (b.Position != CssConstants.Fixed)
+                b.OffsetLeft(amount);
+        }
+
+        _listItemBox?.OffsetLeft(amount);
+
+        Location = new PointF((float)(Location.X + amount), Location.Y);
+    }
+
+    internal void OffsetRectangle(CssLineBox lineBox, double gap)
+    {
+        if (Rectangles.TryGetValue(lineBox, out RectangleF r))
+            Rectangles[lineBox] = new RectangleF(r.X, (float)(r.Y + gap), r.Width, r.Height);
+    }
+
+    internal void RectanglesReset() => Rectangles.Clear();
+
+    private void OnImageLoadComplete(object? image, RectangleF rectangle, bool async)
+    {
+        if (image != null && async)
+            LayoutEnvironment.RequestRefresh(false);
+    }
+
+    protected override ILayoutFont GetCachedFont(string fontFamily, double fsize, LayoutFontStyle st, string fontFeatures) => LayoutEnvironment.GetFont(fontFamily, fsize, st, fontFeatures);
+
+    protected override Color GetActualColor(string colorStr) => LayoutEnvironment.ParseColor(colorStr);
+
+    protected override PointF GetActualLocation(string X, string Y)
+    {
+        var vpSize = LayoutEnvironment.ViewportSize;
+        var left = CssValueParser.ParseLength(X, vpSize.Width, GetEmHeight(), null);
+        var top = CssValueParser.ParseLength(Y, vpSize.Height, GetEmHeight(), null);
+
+        return new PointF((float)left, (float)top);
+    }
+
+    public override string ToString()
+    {
+        var tag = HtmlTag != null ? $"<{HtmlTag.Name}>" : "anon";
+
+        if (IsBlock)
+        {
+            return $"{(ParentBox == null ? "Root: " : string.Empty)}{tag} Block {FontSize}, Children:{Boxes.Count}";
+        }
+        else if (Display == CssConstants.None)
+        {
+            return $"{(ParentBox == null ? "Root: " : string.Empty)}{tag} None";
+        }
+        else
+        {
+            return $"{(ParentBox == null ? "Root: " : string.Empty)}{tag} {Display}: {Text}";
+        }
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxHelper.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxHelper.cs
@@ -1,0 +1,586 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using CssConstants = Broiler.CSS.CssConstants;
+using CssValueParser = Broiler.CSS.CssLengthParser;
+namespace Broiler.Layout;
+
+
+internal static class CssBoxHelper
+{
+    public static CssBox CreateBox(HtmlTag tag, Uri baseUrl, CssBox parent = null)
+    {
+        ArgumentNullException.ThrowIfNull(tag);
+
+        if (tag.Name == HtmlConstants.Img)
+        {
+            return new CssBoxImage(parent, tag, baseUrl);
+        }
+        else if (tag.Name.Equals("object", StringComparison.OrdinalIgnoreCase) &&
+                 tag.TryGetAttribute("data") is { } data &&
+                 data.StartsWith("data:image", StringComparison.OrdinalIgnoreCase))
+        {
+            // <object data="data:image/..."> — treat as a replaced image element.
+            // Any nested fallback content will be removed by CorrectObjectBoxes.
+            return new CssBoxImage(parent, tag, baseUrl);
+        }
+        else if (tag.Name == HtmlConstants.Iframe)
+        {
+            return new CssBox(parent, tag, baseUrl);
+        }
+        else if (tag.Name == HtmlConstants.Hr)
+        {
+            return new CssBoxHr(parent, tag, baseUrl);
+        }
+        else
+        {
+            return new CssBox(parent, tag, baseUrl);
+        }
+    }
+
+    public static CssBox CreateBox(CssBox parent, Uri baseUrl, HtmlTag tag = null, CssBox before = null)
+    {
+        ArgumentNullException.ThrowIfNull(parent);
+
+        var newBox = new CssBox(parent, tag, baseUrl);
+        newBox.InheritStyle();
+
+        // Anonymous boxes (tag == null) are fragments of their parent's inline
+        // formatting context — e.g. the wrappers created when content is split
+        // around a <br> or a block-level child.  'unicode-bidi' is not inherited,
+        // so InheritStyle() does not carry it; without this an anonymous block
+        // wrapping a 'unicode-bidi: plaintext' element's content would fall back
+        // to 'normal' and mis-resolve per-line bidi direction.  Explicit CSS on
+        // pseudo-elements is applied later and still overrides this default.
+        if (tag == null)
+            newBox.UnicodeBidi = parent.UnicodeBidi;
+
+        if (before != null)
+            newBox.SetBeforeBox(before);
+
+        return newBox;
+    }
+
+    public static CssBox CreateBlock(Uri baseUrl) => new(null, null, baseUrl) { Display = CssConstants.Block };
+
+    public static CssBox CreateBlock(CssBox parent, Uri baseUrl, HtmlTag tag = null, CssBox before = null)
+    {
+        ArgumentNullException.ThrowIfNull(parent);
+
+        var newBox = CreateBox(parent, baseUrl, tag, before);
+        newBox.Display = CssConstants.Block;
+
+        return newBox;
+    }
+
+    internal static CssRect FirstWordOccourence(CssBox b, CssLineBox line)
+    {
+        if (b.Words.Count == 0 && b.Boxes.Count == 0)
+            return null;
+
+        if (b.Words.Count > 0)
+        {
+            foreach (CssRect word in b.Words)
+            {
+                if (line.Words.Contains(word))
+                    return word;
+            }
+
+            return null;
+        }
+        else
+        {
+            foreach (CssBox bb in b.Boxes)
+            {
+                CssRect w = FirstWordOccourence(bb, line);
+
+                if (w != null)
+                    return w;
+            }
+
+            return null;
+        }
+    }
+
+    public static void GetMinimumWidth_LongestWord(CssBox box, ref double maxWidth, ref CssRect maxWidthWord)
+    {
+        if (box.Words.Count > 0)
+        {
+            foreach (CssRect cssRect in box.Words)
+            {
+                if (cssRect.Width > maxWidth)
+                {
+                    maxWidth = cssRect.Width;
+                    maxWidthWord = cssRect;
+                }
+            }
+        }
+        else
+        {
+            foreach (CssBox childBox in box.Boxes)
+                GetMinimumWidth_LongestWord(childBox, ref maxWidth, ref maxWidthWord);
+        }
+    }
+
+    public static double GetWidthMarginDeep(CssBox box)
+    {
+        double sum = 0f;
+
+        if (box.Size.Width > 90999 || (box.ParentBox != null && box.ParentBox.Size.Width > 90999))
+        {
+            while (box != null)
+            {
+                sum += box.ActualMarginLeft + box.ActualMarginRight;
+                box = box.ParentBox;
+            }
+        }
+
+        return sum;
+    }
+
+    internal static double GetMaximumBottom(CssBox startBox, double currentMaxBottom)
+    {
+        foreach (var line in startBox.Rectangles.Keys)
+            currentMaxBottom = Math.Max(currentMaxBottom, startBox.Rectangles[line].Bottom);
+
+        foreach (var b in startBox.Boxes)
+        {
+            currentMaxBottom = Math.Max(currentMaxBottom, b.ActualBottom + b.ActualMarginBottom);
+            currentMaxBottom = Math.Max(currentMaxBottom, GetMaximumBottom(b, currentMaxBottom));
+        }
+
+        return currentMaxBottom;
+    }
+
+    public static void GetMinMaxSumWords(CssBox box, ref double min, ref double maxSum, ref double paddingSum, ref double marginSum)
+    {
+        double? oldSum = null;
+
+        // not inline (block) boxes start a new line so we need to reset the max sum
+        // CSS2.1 §10.3.7: Floated children contribute to the same "line" for
+        // shrink-to-fit width calculation, so they do not reset maxSum.
+        if (box.Display != CssConstants.Inline && box.Display != CssConstants.TableCell && box.WhiteSpace != CssConstants.NoWrap && box.Float == CssConstants.None)
+        {
+            oldSum = maxSum;
+            maxSum = marginSum;
+        }
+
+        // CSS2.1 §10.3.5/§10.3.7: When a floated child has an explicit width,
+        // use the declared width directly for shrink-to-fit calculation
+        // instead of measuring content words.
+        if (box.Float != CssConstants.None
+            && box.Width != CssConstants.Auto
+            && !string.IsNullOrEmpty(box.Width))
+        {
+            double explicitWidth = CssValueParser.ParseLength(
+                box.Width, box.ContainingBlock?.Size.Width ?? 0, box.GetEmHeight());
+            paddingSum += box.ActualBorderLeftWidth + box.ActualBorderRightWidth
+                        + box.ActualPaddingRight + box.ActualPaddingLeft;
+            maxSum += explicitWidth;
+            min = Math.Max(min, explicitWidth);
+
+            if (oldSum.HasValue)
+                maxSum = Math.Max(maxSum, oldSum.Value);
+            return;
+        }
+
+        // CSS2.1 §17.5.2: Non-floated block-level children (e.g. display:table
+        // or display:list-item inside an anonymous table-cell) with explicit
+        // width contribute that width to the intrinsic minimum/maximum.
+        if (box.Display != CssConstants.Inline
+            && box.Display != CssConstants.TableCell
+            && box.Float == CssConstants.None
+            && box.Width != CssConstants.Auto
+            && !string.IsNullOrEmpty(box.Width))
+        {
+            double explicitWidth = CssValueParser.ParseLength(
+                box.Width, box.ContainingBlock?.Size.Width ?? 0, box.GetEmHeight());
+            if (explicitWidth > 0)
+            {
+                paddingSum += box.ActualBorderLeftWidth + box.ActualBorderRightWidth
+                            + box.ActualPaddingRight + box.ActualPaddingLeft;
+                maxSum += explicitWidth;
+                min = Math.Max(min, explicitWidth);
+
+                if (oldSum.HasValue)
+                    maxSum = Math.Max(maxSum, oldSum.Value);
+                return;
+            }
+        }
+
+        // add the padding 
+        paddingSum += box.ActualBorderLeftWidth + box.ActualBorderRightWidth + box.ActualPaddingRight + box.ActualPaddingLeft;
+
+
+        // for tables the padding also contains the spacing between cells
+        if (box.Display == CssConstants.Table)
+            paddingSum += CssLayoutEngineTable.GetTableSpacing(box);
+
+        if (box.Words.Count > 0)
+        {
+            // calculate the min and max sum for all the words in the box
+            foreach (CssRect word in box.Words)
+            {
+                maxSum += word.FullWidth + (word.HasSpaceBefore ? word.OwnerBox.ActualWordSpacing : 0);
+                min = Math.Max(min, word.Width);
+            }
+
+            // remove the last word padding
+            if (box.Words.Count > 0 && !box.Words[box.Words.Count - 1].HasSpaceAfter)
+                maxSum -= box.Words[box.Words.Count - 1].ActualWordSpacing;
+        }
+        else
+        {
+            // recursively on all the child boxes
+            for (int i = 0; i < box.Boxes.Count; i++)
+            {
+                CssBox childBox = box.Boxes[i];
+                marginSum += childBox.ActualMarginLeft + childBox.ActualMarginRight;
+
+                //maxSum += childBox.ActualMarginLeft + childBox.ActualMarginRight;
+                GetMinMaxSumWords(childBox, ref min, ref maxSum, ref paddingSum, ref marginSum);
+
+                marginSum -= childBox.ActualMarginLeft + childBox.ActualMarginRight;
+            }
+        }
+
+        // max sum is max of all the lines in the box
+        if (oldSum.HasValue)
+            maxSum = Math.Max(maxSum, oldSum.Value);
+    }
+
+    /// <summary>
+    /// CSS2.1 §9.5.2: Returns the maximum bottom outer edge of preceding
+    /// floats that the given box needs to clear, considering the box's
+    /// <c>clear</c> direction (<c>left</c>, <c>right</c>, or <c>both</c>).
+    /// </summary>
+    public static double GetMaxFloatBottom(CssBox box)
+    {
+        double maxBottom = 0;
+        List<(string tag, double bottom)> considered = null;
+
+        if (box.ParentBox == null)
+            return maxBottom;
+
+        string clearDir = box.Clear;
+
+        // Walk up the ancestor chain to find floats in the same block
+        // formatting context (BFC).  Floats from ancestor-level siblings
+        // are relevant for clearance even when the cleared element is
+        // nested deeper (CSS2.1 §9.5.2).
+        CssBox current = box;
+        while (current.ParentBox != null)
+        {
+            foreach (var sibling in current.ParentBox.Boxes)
+            {
+                if (sibling == current) break;
+                CollectMaxFloatBottom(sibling, clearDir, ref maxBottom, ref considered);
+            }
+
+            // Stop at BFC boundaries — floats in an outer BFC don't
+            // participate in clearance for elements in an inner BFC.
+            if (EstablishesBfc(current.ParentBox))
+                break;
+
+            current = current.ParentBox;
+        }
+
+        if (considered != null && considered.Count > 0)
+        {
+            Debug.WriteLine($"[ClearFloat] Clearance for <{box.HtmlTag?.Name ?? "?"}> clear={box.Clear}: " +
+                $"considered {considered.Count} float(s), maxBottom={maxBottom:F1}");
+            foreach (var (tag, bottom) in considered)
+                Debug.WriteLine($"  - <{tag}> bottom={bottom:F1}");
+        }
+
+        return maxBottom;
+    }
+
+    /// <summary>
+    /// Collects the maximum bottom coordinate of floats in the same
+    /// block formatting context (BFC) that match the <paramref name="clearDir"/>
+    /// direction.  Floated elements establish a new BFC, so their descendant
+    /// floats are excluded from clearance calculations outside.
+    /// </summary>
+    private static void CollectMaxFloatBottom(CssBox box, string clearDir, ref double maxBottom, ref List<(string tag, double bottom)> considered)
+    {
+        if (box.Float != CssConstants.None)
+        {
+            // CSS2.1 §9.5.2: Only consider floats in the matching direction.
+            // clear:left → only left floats, clear:right → only right floats,
+            // clear:both → all floats.
+            bool matchesDirection = clearDir == "both"
+                || string.Equals(box.Float, clearDir, StringComparison.OrdinalIgnoreCase);
+            if (!matchesDirection)
+                return;
+
+            // Compute the float's margin-box bottom ("bottom outer edge"
+            // per CSS2.1 §9.5.2) so that clearance positions the cleared
+            // element below the float's full margin box.
+            // CSS2.1 §10.5: Percentage heights resolve to auto when the
+            // containing block's height is not explicitly specified —
+            // use ActualBottom (layout-computed) in that case.
+            double bottom;
+            bool hasExplicitHeight = box.Height != CssConstants.Auto && !string.IsNullOrEmpty(box.Height);
+
+            if (hasExplicitHeight && !box.HeightPercentageResolvesToAuto())
+                bottom = box.Location.Y + box.ActualHeight
+                    + box.ActualPaddingTop + box.ActualPaddingBottom
+                    + box.ActualBorderTopWidth + box.ActualBorderBottomWidth
+                    + box.ActualMarginBottom;
+            else
+                bottom = box.ActualBottom
+                    + box.ActualMarginBottom;
+            maxBottom = Math.Max(maxBottom, bottom);
+            considered ??= new List<(string, double)>();
+            considered.Add((box.HtmlTag?.Name ?? box.Display, bottom));
+            // Float establishes a new BFC – don't recurse into descendants.
+            return;
+        }
+
+        foreach (var child in box.Boxes)
+            CollectMaxFloatBottom(child, clearDir, ref maxBottom, ref considered);
+    }
+
+    /// <summary>
+    /// Returns the effective bottom margin for a box, accounting for
+    /// parent-child bottom-margin collapse (CSS 2.1 §8.3.1).
+    /// When a box has no bottom border, no bottom padding, and auto height,
+    /// the last in-flow block-level child's bottom margin collapses with
+    /// the box's own bottom margin.  This is applied recursively.
+    /// </summary>
+    internal static double GetPropagatedMarginBottom(CssBox box)
+    {
+        double mb = box.ActualMarginBottom;
+
+        if (box.ActualBorderBottomWidth > 0.1 || box.ActualPaddingBottom > 0.1)
+            return mb;
+
+        if (box.Height != CssConstants.Auto && !string.IsNullOrEmpty(box.Height))
+        {
+            bool resolvedToAuto = box.Height.Contains('%')
+                && (box.ContainingBlock.Height == CssConstants.Auto
+                    || string.IsNullOrEmpty(box.ContainingBlock.Height));
+            if (!resolvedToAuto)
+                return mb;
+        }
+
+        // Find last in-flow block-level child (CSS 2.1 §8.3.1).
+        CssBox? lastInFlow = null;
+        foreach (var child in box.Boxes)
+        {
+            if (child.Float != CssConstants.None
+                || child.Position == CssConstants.Absolute
+                || child.Position == CssConstants.Fixed)
+                continue;
+            if (child.Display == CssConstants.Inline
+                || child.Display == CssConstants.InlineBlock)
+                continue;
+            lastInFlow = child;
+        }
+
+        if (lastInFlow == null)
+            return mb;
+
+        double childMb = GetPropagatedMarginBottom(lastInFlow);
+
+        // Collapse: max(positives,0) + min(negatives,0)
+        double maxPos = Math.Max(Math.Max(mb, 0), Math.Max(childMb, 0));
+        double minNeg = Math.Min(Math.Min(mb, 0), Math.Min(childMb, 0));
+        return maxPos + minNeg;
+    }
+
+    /// <summary>
+    /// Computes the vertical offset applied by <c>position: relative</c>.
+    /// CSS2.1 §9.4.3: <c>top</c> takes precedence over <c>bottom</c>.
+    /// Returns 0 if the element is not relatively positioned or has no offset.
+    /// </summary>
+    internal static double GetRelativeOffsetY(CssBoxProperties box)
+    {
+        bool hasTop = box.Top != null && box.Top != CssConstants.Auto;
+        bool hasBottom = box.Bottom != null && box.Bottom != CssConstants.Auto;
+
+        if (hasTop)
+            return CssValueParser.ParseLength(box.Top, box.Size.Height, box.GetEmHeight());
+        if (hasBottom)
+            return -CssValueParser.ParseLength(box.Bottom, box.Size.Height, box.GetEmHeight());
+        return 0;
+    }
+
+    /// <summary>
+    /// Collects all float boxes in the same block formatting context that
+    /// precede <paramref name="box"/> in the DOM tree. This includes floats
+    /// nested inside non-BFC siblings (e.g., floated <c>li</c> elements
+    /// inside a non-floated <c>ul</c>) and floats that are siblings of
+    /// ancestor elements when those ancestors do not establish a new BFC
+    /// (CSS2.1 §9.4.1).
+    /// </summary>
+    internal static List<CssBox> CollectPrecedingFloatsInBfc(CssBox box)
+    {
+        var result = new List<CssBox>();
+        if (box.ParentBox == null) return result;
+
+        // Collect preceding sibling floats (and their non-BFC subtrees).
+        foreach (var sibling in box.ParentBox.Boxes)
+        {
+            if (sibling == box) break;
+            CollectFloatsInSubtree(sibling, result);
+        }
+
+        // Walk up ancestor chain: collect floats from each ancestor's
+        // preceding siblings while the ancestor does not establish a BFC.
+        var current = box.ParentBox;
+        while (current != null && current.ParentBox != null)
+        {
+            if (EstablishesBfc(current))
+                break;
+
+            foreach (var sibling in current.ParentBox.Boxes)
+            {
+                if (sibling == current) break;
+                CollectFloatsInSubtree(sibling, result);
+            }
+
+            current = current.ParentBox;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if <paramref name="box"/> establishes a new
+    /// block formatting context (CSS2.1 §9.4.1, CSS Box Alignment §5.4).
+    /// </summary>
+    private static bool EstablishesBfc(CssBox box)
+    {
+        return box.Float != CssConstants.None
+            || box.Display == CssConstants.InlineBlock
+            || box.Display == CssConstants.TableCell
+            || box.Display is "flex" or "inline-flex" or "grid" or "inline-grid"
+            || box.Position == CssConstants.Absolute
+            || box.Position == CssConstants.Fixed
+            || (box.Overflow != null && box.Overflow != CssConstants.Visible)
+            || (box.AlignContent != null && box.AlignContent != "normal");
+    }
+
+    private static void CollectFloatsInSubtree(CssBox root, List<CssBox> result)
+    {
+        if (root.Float != CssConstants.None && root.Display != CssConstants.None)
+        {
+            result.Add(root);
+            // Float establishes a new BFC – don't recurse into descendants.
+            return;
+        }
+
+        // CSS2.1 §9.5: Don't recurse into elements that establish a new
+        // block formatting context — their inner floats don't participate
+        // in the parent BFC's float list.
+        if (EstablishesBfc(root))
+            return;
+
+        foreach (var child in root.Boxes)
+            CollectFloatsInSubtree(child, result);
+    }
+
+    /// <summary>
+    /// CSS2.1 §8.3.1: Returns <c>true</c> if a box is "empty" — its own
+    /// top and bottom margins are adjoining and collapse through.
+    /// Conditions: min-height is zero, no top/bottom borders or padding,
+    /// height is 0 or auto (or percentage that resolves to auto), no line
+    /// boxes, and all in-flow children's margins also collapse.
+    /// </summary>
+    internal static bool IsEmptyCollapsible(CssBox box)
+    {
+        if (box.ActualBorderTopWidth > 0.1 || box.ActualBorderBottomWidth > 0.1)
+            return false;
+        if (box.ActualPaddingTop > 0.1 || box.ActualPaddingBottom > 0.1)
+            return false;
+
+        // Check if height resolves to zero/auto
+        if (box.Height != CssConstants.Auto && !string.IsNullOrEmpty(box.Height))
+        {
+            bool resolvedToAuto = box.Height.Contains('%')
+                && (box.ContainingBlock.Height == CssConstants.Auto
+                    || string.IsNullOrEmpty(box.ContainingBlock.Height));
+            if (!resolvedToAuto)
+            {
+                double h = CssValueParser.ParseLength(box.Height, box.Size.Height, box.GetEmHeight());
+                if (h > 0.1)
+                    return false;
+            }
+        }
+
+        // Zero content height — ActualBottom should equal Location.Y
+        // (tolerance 0.5 accounts for sub-pixel rounding in layout)
+        if (Math.Abs(box.ActualBottom - box.Location.Y) > 0.5)
+            return false;
+
+        // Must not contain any line boxes with actual content.
+        // CreateLineBoxes always creates at least one CssLineBox for any
+        // element that enters the inline-formatting path, even if the
+        // element is empty.  An empty line box (no words) does not
+        // constitute "content" for margin-through-collapse purposes.
+        //
+        // CSS2.1 §8.3.1: When height is explicitly 0, line boxes contain
+        // overflowing content that doesn't prevent margin collapse.  Only
+        // check for line-box content when height is auto.
+        bool hasExplicitZeroHeight = box.Height != CssConstants.Auto
+            && !string.IsNullOrEmpty(box.Height);
+        if (!hasExplicitZeroHeight)
+        {
+            foreach (var lb in box.LineBoxes)
+            {
+                if (lb.Words.Count > 0)
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Collects the maximum positive and minimum negative margins from an
+    /// empty collapsible box and all its in-flow children (recursively for
+    /// children that are also empty and collapsible).
+    /// </summary>
+    internal static void CollectEmptyBoxMargins(CssBox box, ref double maxPos, ref double maxNeg)
+    {
+        maxPos = Math.Max(maxPos, Math.Max(box.ActualMarginTop, 0));
+        maxPos = Math.Max(maxPos, Math.Max(box.ActualMarginBottom, 0));
+        maxNeg = Math.Min(maxNeg, Math.Min(box.ActualMarginTop, 0));
+        maxNeg = Math.Min(maxNeg, Math.Min(box.ActualMarginBottom, 0));
+
+        foreach (var child in box.Boxes)
+        {
+            if (child.Float != CssConstants.None
+                || child.Position == CssConstants.Absolute
+                || child.Position == CssConstants.Fixed)
+                continue;
+
+            maxPos = Math.Max(maxPos, Math.Max(child.ActualMarginTop, 0));
+            maxPos = Math.Max(maxPos, Math.Max(child.ActualMarginBottom, 0));
+            maxNeg = Math.Min(maxNeg, Math.Min(child.ActualMarginTop, 0));
+            maxNeg = Math.Min(maxNeg, Math.Min(child.ActualMarginBottom, 0));
+
+            if (IsEmptyCollapsible(child))
+                CollectEmptyBoxMargins(child, ref maxPos, ref maxNeg);
+        }
+    }
+
+    /// <summary>
+    /// Returns the effective bottom margin for a box, accounting for margins
+    /// that collapse through the box when it is "empty" per CSS2.1 §8.3.1.
+    /// For non-empty boxes returns <see cref="CssBoxProperties.ActualMarginBottom"/>.
+    /// </summary>
+    internal static double GetEffectiveMarginBottom(CssBox box)
+    {
+        if (!IsEmptyCollapsible(box))
+            return box.ActualMarginBottom;
+
+        double maxPos = 0, maxNeg = 0;
+        CollectEmptyBoxMargins(box, ref maxPos, ref maxNeg);
+        double collapsed = maxPos + maxNeg;
+        return collapsed - box.CollapsedMarginTop;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxHr.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxHr.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Drawing;
+using Broiler.Layout;
+
+using CssConstants = Broiler.CSS.CssConstants;
+using CssValueParser = Broiler.CSS.CssLengthParser;
+namespace Broiler.Layout;
+
+internal sealed class CssBoxHr : CssBox
+{
+    public CssBoxHr(CssBox parent, HtmlTag tag, Uri baseUrl) : base(parent, tag, baseUrl) => Display = CssConstants.Block;
+
+    protected override void PerformLayoutImp(ILayoutEnvironment g)
+    {
+        if (Display == CssConstants.None)
+            return;
+
+        RectanglesReset();
+
+        var prevSibling = LayoutBoxUtils.GetPreviousSibling(this);
+        double left = ContainingBlock.Location.X + ContainingBlock.ActualPaddingLeft + ActualMarginLeft + ContainingBlock.ActualBorderLeftWidth;
+        double marginCollapse = MarginTopCollapse(prevSibling);
+        double top = (prevSibling == null && ParentBox != null ? ParentBox.ClientTop : ParentBox == null ? Location.Y : 0) + marginCollapse + (prevSibling != null ? prevSibling.ActualBottom + prevSibling.ActualBorderBottomWidth : 0);
+        Location = new PointF((float)left, (float)top);
+        ActualBottom = top;
+
+        //width at 100% (or auto)
+        double minwidth = GetMinimumWidth();
+        double width = ContainingBlock.Size.Width
+                       - ContainingBlock.ActualPaddingLeft - ContainingBlock.ActualPaddingRight
+                       - ContainingBlock.ActualBorderLeftWidth - ContainingBlock.ActualBorderRightWidth
+                       - ActualMarginLeft - ActualMarginRight - ActualBorderLeftWidth - ActualBorderRightWidth;
+
+        //Check width if not auto
+        if (Width != CssConstants.Auto && !string.IsNullOrEmpty(Width))
+            width = CssValueParser.ParseLength(Width, width, GetEmHeight());
+
+        if (width < minwidth || width >= 9999)
+            width = minwidth;
+
+        double height = ActualHeight;
+
+        if (height < 1)
+            height = Size.Height + ActualBorderTopWidth + ActualBorderBottomWidth;
+
+        if (height < 1)
+            height = 2;
+
+        if (height <= 2 && ActualBorderTopWidth < 1 && ActualBorderBottomWidth < 1)
+        {
+            BorderTopStyle = BorderBottomStyle = CssConstants.Solid;
+            BorderTopWidth = "1px";
+            BorderBottomWidth = "1px";
+        }
+
+        Size = new SizeF((float)width, (float)height);
+
+        ActualBottom = Location.Y + ActualPaddingTop + ActualPaddingBottom + height;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxImage.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxImage.cs
@@ -1,0 +1,88 @@
+﻿using Broiler.Layout;
+using System;
+using System.Drawing;
+
+using CssConstants = Broiler.CSS.CssConstants;
+using CssLength = Broiler.CSS.CssLength;
+using CssUnit = Broiler.CSS.CssUnit;
+namespace Broiler.Layout;
+
+internal sealed class CssBoxImage : CssBox
+{
+    private readonly CssRectImage _imageWord;
+    private ILayoutImageLoader _imageLoadHandler;
+    private bool _imageLoadingComplete;
+
+    public CssBoxImage(CssBox parent, HtmlTag tag, Uri baseUrl) : base(parent, tag, baseUrl)
+    {
+        _imageWord = new CssRectImage(this);
+        Words.Add(_imageWord);
+
+    }
+
+    public object Image => _imageWord.Image;
+
+    internal override void MeasureWordsSize(ILayoutEnvironment g)
+    {
+        if (!_wordsSizeMeasured)
+        {
+            // Load the CSS background image (if any) via the base class.
+            // CssBoxImage overrides MeasureWordsSize entirely, so the base
+            // class's background-image loading code would otherwise be skipped.
+            LoadBackgroundImageIfNeeded();
+
+            if (_imageLoadHandler == null && (LayoutEnvironment.AvoidAsyncImagesLoading || LayoutEnvironment.AvoidImagesLateLoading))
+            {
+                _imageLoadHandler = LayoutEnvironment.CreateImageLoader(OnLoadImageComplete);
+
+                if (Content != null && Content != CssConstants.Normal)
+                    _imageLoadHandler.LoadImage(Content, HtmlTag?.Attributes, base.BaseUrl);
+                else
+                {
+                    var src = GetAttribute("src");
+                    // <object data="..."> fallback: use 'data' attribute when 'src' is absent
+                    if (string.IsNullOrEmpty(src))
+                        src = GetAttribute("data");
+                    _imageLoadHandler.LoadImage(src, HtmlTag?.Attributes, base.BaseUrl);
+                }
+            }
+
+            MeasureWordSpacing(g);
+            _wordsSizeMeasured = true;
+        }
+
+        CssLayoutEngine.MeasureImageSize(g, _imageWord);
+    }
+
+    public override void Dispose()
+    {
+        _imageLoadHandler?.Dispose();
+        base.Dispose();
+    }
+
+    private void SetErrorBorder()
+    {
+        SetAllBorders(CssConstants.Solid, "2px", "#A0A0A0");
+        BorderRightColor = BorderBottomColor = "#E3E3E3";
+    }
+
+    private void OnLoadImageComplete(object? image, RectangleF rectangle, bool async)
+    {
+        _imageWord.Image = image;
+        _imageWord.ImageRectangle = rectangle;
+        _imageLoadingComplete = true;
+        _wordsSizeMeasured = false;
+
+        if (_imageLoadingComplete && image == null)
+            SetErrorBorder();
+
+        if (!LayoutEnvironment.AvoidImagesLateLoading || async)
+        {
+            var width = new CssLength(Width);
+            var height = new CssLength(Height);
+            var layout = width.Number <= 0 || width.Unit != CssUnit.Px || height.Number <= 0 || height.Unit != CssUnit.Px;
+
+            LayoutEnvironment.RequestRefresh(layout);
+        }
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -1,0 +1,1779 @@
+﻿using Broiler.Layout;
+using RegexParserUtils = Broiler.CSS.RegexParserUtils;
+using System;
+using System.Drawing;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+using CssConstants = Broiler.CSS.CssConstants;
+using CssValueParser = Broiler.CSS.CssLengthParser;
+using CssLength = Broiler.CSS.CssLength;
+using CssUnit = Broiler.CSS.CssUnit;
+namespace Broiler.Layout;
+
+internal abstract class CssBoxProperties
+{
+    internal const string InvalidCustomPropertySentinel = "\u0000";
+
+    #region CSS Fields
+
+    private string _borderTopWidth = "medium";
+    private string _borderRightWidth = "medium";
+    private string _borderBottomWidth = "medium";
+    private string _borderLeftWidth = "medium";
+    private string _borderTopColor = "black";
+    private string _borderRightColor = "black";
+    private string _borderBottomColor = "black";
+    private string _borderLeftColor = "black";
+    private string _bottom = "auto";
+    private string _color = "black";
+    private string _cornerRadius = "0";
+    private string _fontSize = "medium";
+    private string _left = "auto";
+    private string _lineHeight = "normal";
+    private string _paddingLeft = "0";
+    private string _paddingBottom = "0";
+    private string _paddingRight = "0";
+    private string _paddingTop = "0";
+    private string _right = "auto";
+    private string _width = "auto";
+    private string _height = "auto";
+    private string _inlineSize = "auto";
+    private string _blockSize = "auto";
+    private string _writingMode = "horizontal-tb";
+    private string _backgroundColor = "transparent";
+    private string _backgroundImage = "none";
+    private string _backgroundClip = "border-box";
+    private string _clipPath = "none";
+    private string _textIndent = "0";
+    private string _textDecorationColor = "currentcolor";
+    private string _top = "auto";
+    private string _wordSpacing = "normal";
+
+    #endregion
+
+
+    #region Fields
+
+    private PointF _location;
+    private SizeF _size;
+
+    private double _actualCornerNw = double.NaN;
+    private double _actualCornerNe = double.NaN;
+    private double _actualCornerSw = double.NaN;
+    private double _actualCornerSe = double.NaN;
+    private Color _actualColor = System.Drawing.Color.Empty;
+    private double _actualBackgroundGradientAngle = double.NaN;
+    private double _actualHeight = double.NaN;
+    private double _actualWidth = double.NaN;
+    private double _actualPaddingTop = double.NaN;
+    private double _actualPaddingBottom = double.NaN;
+    private double _actualPaddingRight = double.NaN;
+    private double _actualPaddingLeft = double.NaN;
+    private double _actualMarginTop = double.NaN;
+    private double _collapsedMarginTop = double.NaN;
+    private double _actualMarginBottom = double.NaN;
+    private double _actualMarginRight = double.NaN;
+    private double _actualMarginLeft = double.NaN;
+    private double _actualBorderTopWidth = double.NaN;
+    private double _actualBorderLeftWidth = double.NaN;
+    private double _actualBorderBottomWidth = double.NaN;
+    private double _actualBorderRightWidth = double.NaN;
+
+    /// <summary>
+    /// the width of whitespace between words
+    /// </summary>
+    private double _actualLineHeight = double.NaN;
+    private double _actualTextIndent = double.NaN;
+    private double _actualBorderSpacingHorizontal = double.NaN;
+    private double _actualBorderSpacingVertical = double.NaN;
+    private Color _actualBackgroundGradient = System.Drawing.Color.Empty;
+    private Color _actualBorderTopColor = System.Drawing.Color.Empty;
+    private Color _actualBorderLeftColor = System.Drawing.Color.Empty;
+    private Color _actualBorderBottomColor = System.Drawing.Color.Empty;
+    private Color _actualBorderRightColor = System.Drawing.Color.Empty;
+    private Color _actualTextDecorationColor = System.Drawing.Color.Empty;
+    private Color _actualBackgroundColor = System.Drawing.Color.Empty;
+    private ILayoutFont _actualFont;
+
+    #endregion
+
+
+    #region CSS Properties
+
+    public string BorderBottomWidth
+    {
+        get { return _borderBottomWidth; }
+        set
+        {
+            _borderBottomWidth = value;
+            _actualBorderBottomWidth = float.NaN;
+        }
+    }
+
+    public string BorderLeftWidth
+    {
+        get { return _borderLeftWidth; }
+        set
+        {
+            _borderLeftWidth = value;
+            _actualBorderLeftWidth = float.NaN;
+        }
+    }
+
+    public string BorderRightWidth
+    {
+        get { return _borderRightWidth; }
+        set
+        {
+            _borderRightWidth = value;
+            _actualBorderRightWidth = float.NaN;
+        }
+    }
+
+    public string BorderTopWidth
+    {
+        get { return _borderTopWidth; }
+        set
+        {
+            _borderTopWidth = value;
+            _actualBorderTopWidth = float.NaN;
+        }
+    }
+
+    private string _borderBottomStyle = "none";
+    private string _borderLeftStyle = "none";
+    private string _borderRightStyle = "none";
+    private string _borderTopStyle = "none";
+
+    /// <summary>CSS2.1 §8.5.3: Changing border-style affects the used border-width
+    /// (style "none"/"hidden" forces width to zero), so invalidate the cached
+    /// actual width whenever the style changes.</summary>
+    public string BorderBottomStyle
+    {
+        get => _borderBottomStyle;
+        set { _borderBottomStyle = value; _actualBorderBottomWidth = double.NaN; }
+    }
+
+    public string BorderLeftStyle
+    {
+        get => _borderLeftStyle;
+        set { _borderLeftStyle = value; _actualBorderLeftWidth = double.NaN; }
+    }
+
+    public string BorderRightStyle
+    {
+        get => _borderRightStyle;
+        set { _borderRightStyle = value; _actualBorderRightWidth = double.NaN; }
+    }
+
+    public string BorderTopStyle
+    {
+        get => _borderTopStyle;
+        set { _borderTopStyle = value; _actualBorderTopWidth = double.NaN; }
+    }
+
+    public string BorderBottomColor
+    {
+        get { return ResolveCssVariables(_borderBottomColor); }
+        set
+        {
+            _borderBottomColor = value;
+            _actualBorderBottomColor = System.Drawing.Color.Empty;
+        }
+    }
+
+    public string BorderLeftColor
+    {
+        get { return ResolveCssVariables(_borderLeftColor); }
+        set
+        {
+            _borderLeftColor = value;
+            _actualBorderLeftColor = System.Drawing.Color.Empty;
+        }
+    }
+
+    public string BorderRightColor
+    {
+        get { return ResolveCssVariables(_borderRightColor); }
+        set
+        {
+            _borderRightColor = value;
+            _actualBorderRightColor = System.Drawing.Color.Empty;
+        }
+    }
+
+    public string BorderTopColor
+    {
+        get { return ResolveCssVariables(_borderTopColor); }
+        set
+        {
+            _borderTopColor = value;
+            _actualBorderTopColor = System.Drawing.Color.Empty;
+        }
+    }
+
+    public string BorderSpacing { get; set; } = "0";
+    public string BorderCollapse { get; set; } = "separate";
+
+    public string CornerRadius
+    {
+        get { return _cornerRadius; }
+        set
+        {
+            string raw = value ?? string.Empty;
+            int slashIndex = raw.IndexOf('/');
+            if (slashIndex >= 0)
+                raw = raw[..slashIndex];
+
+            string[] r = raw.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
+
+            switch (r.Length)
+            {
+                case 1:
+                    CornerNeRadius = r[0];
+                    CornerNwRadius = r[0];
+                    CornerSeRadius = r[0];
+                    CornerSwRadius = r[0];
+                    break;
+                case 2:
+                    CornerNeRadius = r[0];
+                    CornerNwRadius = r[0];
+                    CornerSeRadius = r[1];
+                    CornerSwRadius = r[1];
+                    break;
+                case 3:
+                    CornerNeRadius = r[0];
+                    CornerNwRadius = r[1];
+                    CornerSeRadius = r[2];
+                    break;
+                case 4:
+                    CornerNeRadius = r[0];
+                    CornerNwRadius = r[1];
+                    CornerSeRadius = r[2];
+                    CornerSwRadius = r[3];
+                    break;
+            }
+
+            _cornerRadius = value;
+        }
+    }
+
+    public string CornerNwRadius { get; set; } = "0";
+    public string CornerNeRadius { get; set; } = "0";
+    public string CornerSeRadius { get; set; } = "0";
+    public string CornerSwRadius { get; set; } = "0";
+    public string MarginBottom { get; set; } = "0";
+    public string MarginLeft { get; set; } = "0";
+    public string MarginRight { get; set; } = "0";
+    public string MarginTop { get; set; } = "0";
+
+    /// <summary>
+    /// CSS Box Model 4 §6.2 <c>margin-trim</c>: controls trimming of a box's
+    /// own margins adjacent to its content edges (e.g. the block-start margin
+    /// of the first child and the block-end margin of the last child).
+    /// Not inherited.  Default <c>none</c>.
+    /// </summary>
+    public string MarginTrim { get; set; } = "none";
+
+    public string PaddingBottom
+    {
+        get { return _paddingBottom; }
+        set
+        {
+            _paddingBottom = value;
+            _actualPaddingBottom = double.NaN;
+        }
+    }
+
+    public string PaddingLeft
+    {
+        get { return _paddingLeft; }
+        set
+        {
+            _paddingLeft = value;
+            _actualPaddingLeft = double.NaN;
+        }
+    }
+
+    public string PaddingRight
+    {
+        get { return _paddingRight; }
+        set
+        {
+            _paddingRight = value;
+            _actualPaddingRight = double.NaN;
+        }
+    }
+
+    public string PaddingTop
+    {
+        get { return _paddingTop; }
+        set
+        {
+            _paddingTop = value;
+            _actualPaddingTop = double.NaN;
+        }
+    }
+
+    public string PageBreakInside { get; set; } = CssConstants.Auto;
+
+    public string Left
+    {
+        get { return _left; }
+        set
+        {
+            _left = value;
+
+            if (Position == CssConstants.Fixed)
+                _location = GetActualLocation(Left, Top);
+        }
+    }
+
+    public string Top
+    {
+        get { return _top; }
+        set 
+        {
+            _top = value;
+
+            if (Position == CssConstants.Fixed)
+                _location = GetActualLocation(Left, Top);
+        }
+    }
+
+    public string Right
+    {
+        get { return _right; }
+        set { _right = value; }
+    }
+
+    public string Bottom
+    {
+        get { return _bottom; }
+        set { _bottom = value; }
+    }
+
+    public string Width
+    {
+        get => ResolvePhysicalSize(_width, isWidth: true);
+        set
+        {
+            _width = value;
+            _actualWidth = double.NaN;
+        }
+    }
+    public string MaxWidth { get; set; } = "none";
+    public string MinWidth { get; set; } = "0";
+    internal bool IsMinWidthSpecified { get; set; }
+    public string Height
+    {
+        get => ResolvePhysicalSize(_height, isWidth: false);
+        set
+        {
+            _height = value;
+            _actualHeight = double.NaN;
+        }
+    }
+    public string MaxHeight { get; set; } = "none";
+    public string MinHeight { get; set; } = "0";
+    public string InlineSize
+    {
+        get => _inlineSize;
+        set
+        {
+            _inlineSize = value;
+            _actualWidth = double.NaN;
+            _actualHeight = double.NaN;
+        }
+    }
+    public string BlockSize
+    {
+        get => _blockSize;
+        set
+        {
+            _blockSize = value;
+            _actualWidth = double.NaN;
+            _actualHeight = double.NaN;
+        }
+    }
+    public string BackgroundColor
+    {
+        get => ResolveCssVariables(_backgroundColor);
+        set
+        {
+            _backgroundColor = value;
+            _actualBackgroundColor = System.Drawing.Color.Empty;
+        }
+    }
+    public string BackgroundImage
+    {
+        get => ResolveCssVariables(_backgroundImage);
+        set => _backgroundImage = value;
+    }
+    public string BackgroundPosition { get; set; } = "0% 0%";
+    public string BackgroundRepeat { get; set; } = "repeat";
+    public string BackgroundAttachment { get; set; } = "scroll";
+    public string BackgroundOrigin { get; set; } = "padding-box";
+    public string BackgroundSize { get; set; } = "auto";
+    public string BackgroundGradient { get; set; } = "none";
+    public string BackgroundGradientAngle { get; set; } = "90";
+
+    // CSS Animations §3: Animation properties for static keyframe resolution.
+    public string AnimationName { get; set; } = "none";
+    public string AnimationDuration { get; set; } = "0s";
+    public string AnimationTimingFunction { get; set; } = "ease";
+    public string AnimationDelay { get; set; } = "0s";
+    public string AnimationIterationCount { get; set; } = "1";
+    public string AnimationDirection { get; set; } = "normal";
+    public string AnimationFillMode { get; set; } = "none";
+    public string AnimationPlayState { get; set; } = "running";
+
+    public string Color
+    {
+        get { return ResolveCssVariables(_color); }
+        set
+        {
+            _color = value;
+            _actualColor = System.Drawing.Color.Empty;
+        }
+    }
+
+    public string Content { get; set; } = "normal";
+    public string Display { get; set; } = "inline";
+    public string Direction { get; set; } = "ltr";
+    public string EmptyCells { get; set; } = "show";
+    public string Float { get; set; } = "none";
+    public string Clear { get; set; } = "none";
+    public string Position { get; set; } = "static";
+
+    public string LineHeight
+    {
+        get { return _lineHeight; }
+        set
+        {
+            // CSS2.1 §10.8: Preserve "normal" and "inherit" keywords as-is
+            if (string.IsNullOrEmpty(value) || value == "normal" || value == "inherit")
+            {
+                _lineHeight = value ?? "normal";
+                return;
+            }
+
+            // Unitless numbers (line-height: <number>) should be treated as a
+            // multiplier of the element's font-size. Store as "Nem" so
+            // ActualLineHeight resolves with the correct em factor at layout time,
+            // avoiding precision loss from premature conversion at parse time
+            // (CSS2.1 §10.8.1).
+            if (!value.EndsWith("px", StringComparison.OrdinalIgnoreCase) &&
+                !value.EndsWith("pt", StringComparison.OrdinalIgnoreCase) &&
+                !value.EndsWith("em", StringComparison.OrdinalIgnoreCase) &&
+                !value.EndsWith("ex", StringComparison.OrdinalIgnoreCase) &&
+                !value.EndsWith("rem", StringComparison.OrdinalIgnoreCase) &&
+                !value.EndsWith("cm", StringComparison.OrdinalIgnoreCase) &&
+                !value.EndsWith("mm", StringComparison.OrdinalIgnoreCase) &&
+                !value.EndsWith("in", StringComparison.OrdinalIgnoreCase) &&
+                !value.EndsWith("pc", StringComparison.OrdinalIgnoreCase) &&
+                !value.EndsWith("%") &&
+                double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+            {
+                _lineHeight = value + "em";
+                return;
+            }
+
+            // CSS2.1 §10.8: For explicit length values (px, em, pt, etc.),
+            // store the raw value and let ActualLineHeight resolve it at
+            // layout time when the element's font-size is finalized.
+            _lineHeight = value;
+        }
+    }
+
+    public string VerticalAlign { get; set; } = "baseline";
+
+    public string TextIndent
+    {
+        get { return _textIndent; }
+        set { _textIndent = value; }
+    }
+
+    public string TextAlign { get; set; } = string.Empty;
+    public string TextDecoration { get; set; } = string.Empty;
+    public string TextDecorationStyle { get; set; } = "solid";
+    public string TextDecorationColor
+    {
+        get => _textDecorationColor;
+        set
+        {
+            _textDecorationColor = value;
+            _actualTextDecorationColor = System.Drawing.Color.Empty;
+        }
+    }
+    public string WhiteSpace { get; set; } = "normal";
+    public string Visibility { get; set; } = "visible";
+
+    public string WordSpacing
+    {
+        get { return _wordSpacing; }
+        set { _wordSpacing = value; }
+    }
+
+    public string WordBreak { get; set; } = "normal";
+    public string Opacity { get; set; } = "1";
+    public string ZIndex { get; set; } = CssConstants.Auto;
+    public string BoxShadow { get; set; } = "none";
+    public string TextShadow { get; set; } = "none";
+    public string MixBlendMode { get; set; } = "normal";
+    public string BackgroundBlendMode { get; set; } = "normal";
+    public string Filter { get; set; } = "none";
+    public string Isolation { get; set; } = "auto";
+    public string BoxSizing { get; set; } = "content-box";
+
+    public string BackgroundClip
+    {
+        get
+        {
+            if (_backgroundClip.Equals("inherit", StringComparison.OrdinalIgnoreCase) && GetParent() != null)
+                return GetParent().BackgroundClip;
+
+            return _backgroundClip;
+        }
+        set
+        {
+            _backgroundClip = value ?? "border-box";
+        }
+    }
+
+    public string ClipPath
+    {
+        get => _clipPath;
+        set => _clipPath = value ?? "none";
+    }
+
+    /// <summary>
+    /// CSS Containment Module Level 2: the <c>contain</c> property.
+    /// Values include <c>none</c>, <c>strict</c>, <c>content</c>,
+    /// <c>size</c>, <c>layout</c>, <c>style</c>, <c>paint</c>,
+    /// or a space-separated combination of the last four keywords.
+    /// Used by background propagation (CSS Backgrounds §2.11.1):
+    /// <c>contain: paint</c> on html or body suppresses canvas
+    /// background propagation.
+    /// </summary>
+    public string Contain { get; set; } = "none";
+    public string Transform { get; set; } = "none";
+    public string FlexDirection { get; set; } = "row";
+    public string FlexGrow { get; set; } = "0";
+    public string FlexShrink { get; set; } = "1";
+    public string FlexBasis { get; set; } = "auto";
+    public string FlexWrap { get; set; } = "nowrap";
+    public string JustifyContent { get; set; } = "flex-start";
+    public string JustifyItems { get; set; } = "normal";
+    public string AlignItems { get; set; } = "stretch";
+    public string AlignContent { get; set; } = "normal";
+    public string JustifySelf { get; set; } = "auto";
+    public string AlignSelf { get; set; } = "auto";
+    public string UnicodeBidi { get; set; } = "normal";
+    public string WritingMode
+    {
+        get => _writingMode;
+        set
+        {
+            _writingMode = value;
+            _actualWidth = double.NaN;
+            _actualHeight = double.NaN;
+        }
+    }
+    public string ColumnCount { get; set; } = "auto";
+    public string ColumnWidth { get; set; } = "auto";
+    public string ColumnFill { get; set; } = "balance";
+    public string RowGap { get; set; } = "normal";
+    public string ColumnGap { get; set; } = "normal";
+    public string BreakInside { get; set; } = "auto";
+    public string GridRow { get; set; } = "auto";
+    public string GridColumn { get; set; } = "auto";
+    public string FontFamily { get; set; }
+
+    /// <summary>
+    /// Raw CSS <c>font-feature-settings</c> value (e.g. <c>"ss05" on, "liga" off</c>),
+    /// inherited.  Resolved to enabled OpenType feature tags by
+    /// <see cref="GetEnabledFontFeatureTags"/>.
+    /// </summary>
+    public string FontFeatureSettings { get; set; }
+
+    /// <summary>
+    /// Raw CSS <c>font-variant-alternates</c> value (e.g.
+    /// <c>styleset(crossed-doubleu)</c>), inherited.  Resolved against
+    /// <c>@font-feature-values</c> into concrete feature tags after the cascade.
+    /// </summary>
+    public string FontVariantAlternates { get; set; }
+
+    /// <summary>
+    /// Parses <see cref="FontFeatureSettings"/> into a space-separated list of
+    /// the OpenType feature tags that are switched on, or <c>null</c> when none.
+    /// </summary>
+    protected string GetEnabledFontFeatureTags()
+    {
+        string value = FontFeatureSettings;
+        if (string.IsNullOrWhiteSpace(value) || value == "normal")
+            return null;
+
+        var tags = new System.Text.StringBuilder();
+        foreach (var part in value.Split(','))
+        {
+            var item = part.Trim();
+            if (item.Length == 0)
+                continue;
+
+            // "<tag>" [ <integer> | on | off ]; a 4-char quoted tag, optionally
+            // followed by an on/off/value flag (default = on).
+            int firstQuote = item.IndexOf('"');
+            int altQuote = item.IndexOf('\'');
+            char quote = firstQuote >= 0 ? '"' : (altQuote >= 0 ? '\'' : '\0');
+            string tag;
+            string flag;
+            if (quote != '\0')
+            {
+                int start = item.IndexOf(quote);
+                int endq = item.IndexOf(quote, start + 1);
+                if (endq <= start)
+                    continue;
+                tag = item.Substring(start + 1, endq - start - 1).Trim();
+                flag = item.Substring(endq + 1).Trim();
+            }
+            else
+            {
+                var sp = item.Split([' ', '\t'], 2, StringSplitOptions.RemoveEmptyEntries);
+                tag = sp[0];
+                flag = sp.Length > 1 ? sp[1].Trim() : string.Empty;
+            }
+
+            if (tag.Length != 4)
+                continue;
+
+            bool enabled = flag.Length == 0
+                || flag.Equals("on", StringComparison.OrdinalIgnoreCase)
+                || flag == "1"
+                || (int.TryParse(flag, out int v) && v != 0);
+            if (enabled)
+            {
+                if (tags.Length > 0)
+                    tags.Append(' ');
+                tags.Append(tag);
+            }
+        }
+
+        return tags.Length > 0 ? tags.ToString() : null;
+    }
+
+    public string FontSize
+    {
+        get { return _fontSize; }
+        set
+        {
+            // CSS2.1 §6.2.1: 'inherit' resolves to the parent's computed value.
+            if (value != null && value.Equals("inherit", StringComparison.OrdinalIgnoreCase) && GetParent() != null)
+            {
+                _fontSize = GetParent().FontSize;
+                InvalidateFontDependentValues();
+                return;
+            }
+
+            // CSS2.1 §15.7: a percentage font-size resolves against the PARENT's
+            // computed font-size.  Resolve it to an absolute length immediately so
+            // that descendants which inherit this computed value (InheritStyle copies
+            // the string verbatim) do not re-apply the percentage and compound it —
+            // e.g. body/div/span all set to 800% must each be 8× the root, not 8×8×8×.
+            var trimmedValue = value?.Trim();
+            if (trimmedValue != null
+                && trimmedValue.EndsWith('%')
+                && GetParent() != null
+                && double.TryParse(trimmedValue[..^1], NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+            {
+                double resolvedPoints = CssValueParser.ParseNumber(trimmedValue, GetParent().ActualFont.Size);
+                _fontSize = resolvedPoints.ToString("0.0###", CultureInfo.InvariantCulture) + "pt";
+                InvalidateFontDependentValues();
+                if (this is CssBox percentBox)
+                {
+                    foreach (var child in percentBox.Boxes)
+                        child.InvalidateFontDependentSubtree();
+                }
+                return;
+            }
+
+            string length = RegexParserUtils.Search(RegexParserUtils.CssLengthRegex(), value);
+
+            if (length != null)
+            {
+                string computedValue;
+                CssLength len = new(length);
+
+                if (len.HasError)
+                {
+                    computedValue = "medium";
+                }
+                else if (len.Unit == CssUnit.Em && GetParent() != null)
+                {
+                    computedValue = len.ConvertEmToPoints(GetParent().ActualFont.Size).ToString();
+                }
+                else
+                {
+                    computedValue = len.ToString();
+                }
+
+                _fontSize = computedValue;
+            }
+            else
+            {
+                _fontSize = value;
+            }
+
+            InvalidateFontDependentValues();
+            if (this is CssBox cssBox)
+            {
+                foreach (var child in cssBox.Boxes)
+                    child.InvalidateFontDependentSubtree();
+            }
+        }
+    }
+
+    public string FontStyle { get; set; } = "normal";
+    public string FontVariant { get; set; } = "normal";
+    public string FontWeight { get; set; } = "normal";
+    public string ListStyle { get; set; } = string.Empty;
+    public string Overflow { get; set; } = "visible";
+    public string ListStylePosition { get; set; } = "outside";
+    public string ListStyleImage { get; set; } = string.Empty;
+    public string ListStyleType { get; set; } = "disc";
+
+    /// <summary>Semantic role of the element, set during style resolution from tag name.</summary>
+    public BoxKind Kind { get; set; } = BoxKind.Anonymous;
+
+    /// <summary>The <c>start</c> attribute of an <c>&lt;ol&gt;</c>, or null if not specified.</summary>
+    public int? ListStart { get; set; }
+
+    /// <summary>Whether an <c>&lt;ol&gt;</c> has the <c>reversed</c> attribute.</summary>
+    public bool ListReversed { get; set; }
+
+    /// <summary>The resolved <c>src</c> attribute for image elements, or null if not applicable.</summary>
+    public string? ImageSource { get; set; }
+
+    #endregion CSS Properties
+
+    public PointF Location
+    {
+        get
+        {
+            if (_location.IsEmpty && Position == CssConstants.Fixed)
+                _location = GetActualLocation(Left, Top);
+
+            return _location;
+        }
+        set
+        {
+            _location = value;
+        }
+    }
+
+    public SizeF Size
+    {
+        get { return _size; }
+        set { _size = value; }
+    }
+
+    public RectangleF Bounds => new(Location, Size);
+
+    public double AvailableWidth => Size.Width - ActualBorderLeftWidth - ActualPaddingLeft - ActualPaddingRight - ActualBorderRightWidth;
+
+    public double ActualRight
+    {
+        get { return Location.X + Size.Width; }
+        set { Size = new SizeF((float)(value - Location.X), Size.Height); }
+    }
+
+    public double ActualBottom
+    {
+        get { return Location.Y + Size.Height; }
+        set { Size = new SizeF(Size.Width, (float)(value - Location.Y)); }
+    }
+
+    public double ClientLeft => Location.X + ActualBorderLeftWidth + ActualPaddingLeft;
+    public double ClientTop => Location.Y + ActualBorderTopWidth + ActualPaddingTop;
+    public double ClientRight => ActualRight - ActualPaddingRight - ActualBorderRightWidth;
+    public double ClientBottom => ActualBottom - ActualPaddingBottom - ActualBorderBottomWidth;
+    public RectangleF ClientRectangle => RectangleF.FromLTRB((float)ClientLeft, (float)ClientTop, (float)ClientRight, (float)ClientBottom);
+
+    public double ActualHeight
+    {
+        get
+        {
+            if (double.IsNaN(_actualHeight))
+            {
+                _actualHeight = string.Equals(Height, "inherit", StringComparison.OrdinalIgnoreCase) && GetParent() != null
+                    ? GetParent().ActualHeight
+                    : ParseLengthWithLineHeight(Height, Size.Height);
+            }
+
+            return _actualHeight;
+        }
+    }
+
+    public double ActualWidth
+    {
+        get
+        {
+            if (double.IsNaN(_actualWidth))
+            {
+                _actualWidth = string.Equals(Width, "inherit", StringComparison.OrdinalIgnoreCase) && GetParent() != null
+                    ? GetParent().ActualWidth
+                    : ParseLengthWithLineHeight(Width, Size.Width);
+            }
+
+            return _actualWidth;
+        }
+    }
+
+    public double ActualPaddingTop
+    {
+        get
+        {
+            if (double.IsNaN(_actualPaddingTop))
+                _actualPaddingTop = ParseLengthWithLineHeight(PaddingTop, Size.Width);
+
+            return _actualPaddingTop;
+        }
+    }
+
+    public double ActualPaddingLeft
+    {
+        get
+        {
+            if (double.IsNaN(_actualPaddingLeft))
+                _actualPaddingLeft = ParseLengthWithLineHeight(PaddingLeft, Size.Width);
+
+            return _actualPaddingLeft;
+        }
+    }
+
+    public double ActualPaddingBottom
+    {
+        get
+        {
+            if (double.IsNaN(_actualPaddingBottom))
+                _actualPaddingBottom = ParseLengthWithLineHeight(PaddingBottom, Size.Width);
+
+            return _actualPaddingBottom;
+        }
+    }
+
+    public double ActualPaddingRight
+    {
+        get
+        {
+            if (double.IsNaN(_actualPaddingRight))
+                _actualPaddingRight = ParseLengthWithLineHeight(PaddingRight, Size.Width);
+
+            return _actualPaddingRight;
+        }
+    }
+
+    public double ActualMarginTop
+    {
+        get
+        {
+            if (double.IsNaN(_actualMarginTop))
+            {
+                if (MarginTop == CssConstants.Auto)
+                    MarginTop = "0";
+
+                var actualMarginTop = ParseLengthWithLineHeight(MarginTop, Size.Width);
+
+                if (MarginTop.EndsWith("%"))
+                    return actualMarginTop;
+
+                _actualMarginTop = actualMarginTop;
+            }
+
+            return _actualMarginTop;
+        }
+    }
+
+    public double CollapsedMarginTop
+    {
+        get { return double.IsNaN(_collapsedMarginTop) ? 0 : _collapsedMarginTop; }
+        set { _collapsedMarginTop = value; }
+    }
+
+    public double ActualMarginLeft
+    {
+        get
+        {
+            if (double.IsNaN(_actualMarginLeft))
+            {
+                if (MarginLeft == CssConstants.Auto)
+                    MarginLeft = "0";
+
+                var actualMarginLeft = ParseLengthWithLineHeight(MarginLeft, Size.Width);
+
+                if (MarginLeft.EndsWith("%"))
+                    return actualMarginLeft;
+
+                _actualMarginLeft = actualMarginLeft;
+            }
+            return _actualMarginLeft;
+        }
+    }
+
+    public double ActualMarginBottom
+    {
+        get
+        {
+            if (double.IsNaN(_actualMarginBottom))
+            {
+                if (MarginBottom == CssConstants.Auto)
+                    MarginBottom = "0";
+
+                var actualMarginBottom = ParseLengthWithLineHeight(MarginBottom, Size.Width);
+
+                if (MarginBottom.EndsWith("%"))
+                    return actualMarginBottom;
+
+                _actualMarginBottom = actualMarginBottom;
+            }
+
+            return _actualMarginBottom;
+        }
+    }
+
+    public double ActualMarginRight
+    {
+        get
+        {
+            if (double.IsNaN(_actualMarginRight))
+            {
+                if (MarginRight == CssConstants.Auto)
+                    MarginRight = "0";
+
+                var actualMarginRight = ParseLengthWithLineHeight(MarginRight, Size.Width);
+                
+                if (MarginRight.EndsWith("%"))
+                    return actualMarginRight;
+                
+                _actualMarginRight = actualMarginRight;
+            }
+            
+            return _actualMarginRight;
+        }
+    }
+
+    public double ActualBorderTopWidth
+    {
+        get
+        {
+            if (double.IsNaN(_actualBorderTopWidth))
+            {
+                _actualBorderTopWidth = CssValueParser.GetActualBorderWidth(BorderTopWidth, GetEmHeight());
+
+                if (string.IsNullOrEmpty(BorderTopStyle) || BorderTopStyle == CssConstants.None)
+                    _actualBorderTopWidth = 0f;
+            }
+
+            return _actualBorderTopWidth;
+        }
+    }
+
+    public double ActualBorderLeftWidth
+    {
+        get
+        {
+            if (double.IsNaN(_actualBorderLeftWidth))
+            {
+                _actualBorderLeftWidth = CssValueParser.GetActualBorderWidth(BorderLeftWidth, GetEmHeight());
+
+                if (string.IsNullOrEmpty(BorderLeftStyle) || BorderLeftStyle == CssConstants.None)
+                    _actualBorderLeftWidth = 0f;
+            }
+
+            return _actualBorderLeftWidth;
+        }
+    }
+
+    public double ActualBorderBottomWidth
+    {
+        get
+        {
+            if (double.IsNaN(_actualBorderBottomWidth))
+            {
+                _actualBorderBottomWidth = CssValueParser.GetActualBorderWidth(BorderBottomWidth, GetEmHeight());
+
+                if (string.IsNullOrEmpty(BorderBottomStyle) || BorderBottomStyle == CssConstants.None)
+                    _actualBorderBottomWidth = 0f;
+            }
+
+            return _actualBorderBottomWidth;
+        }
+    }
+
+    public double ActualBorderRightWidth
+    {
+        get
+        {
+            if (double.IsNaN(_actualBorderRightWidth))
+            {
+                _actualBorderRightWidth = CssValueParser.GetActualBorderWidth(BorderRightWidth, GetEmHeight());
+
+                if (string.IsNullOrEmpty(BorderRightStyle) || BorderRightStyle == CssConstants.None)
+                    _actualBorderRightWidth = 0f;
+            }
+
+            return _actualBorderRightWidth;
+        }
+    }
+
+    public Color ActualBorderTopColor
+    {
+        get
+        {
+            if (_actualBorderTopColor.IsEmpty)
+                _actualBorderTopColor = GetActualColor(BorderTopColor);
+
+            return _actualBorderTopColor;
+        }
+    }
+
+    protected abstract PointF GetActualLocation(string X, string Y);
+
+    protected abstract Color GetActualColor(string colorStr);
+
+    protected virtual bool TryGetCustomPropertyValue(string propertyName, out string value)
+    {
+        value = string.Empty;
+        return false;
+    }
+
+    private string ResolveCssVariables(string value)
+    {
+        if (string.IsNullOrEmpty(value) || value.IndexOf("var(", StringComparison.OrdinalIgnoreCase) < 0)
+            return value;
+
+        string resolved = value;
+        for (int i = 0; i < 8 && resolved.IndexOf("var(", StringComparison.OrdinalIgnoreCase) >= 0; i++)
+        {
+            resolved = Regex.Replace(
+                resolved,
+                @"var\(\s*(--[A-Za-z0-9_-]+)\s*(?:,\s*([^)]+))?\)",
+                match =>
+                {
+                    var propertyName = match.Groups[1].Value;
+                    if (TryGetCustomPropertyValue(propertyName, out var propertyValue))
+                    {
+                        if (propertyValue == InvalidCustomPropertySentinel)
+                            return match.Groups[2].Success ? match.Groups[2].Value.Trim() : string.Empty;
+
+                        return propertyValue;
+                    }
+
+                    return match.Groups[2].Success ? match.Groups[2].Value.Trim() : string.Empty;
+                },
+                RegexOptions.IgnoreCase);
+        }
+
+        return resolved;
+    }
+
+    public Color ActualBorderLeftColor
+    {
+        get
+        {
+            if (_actualBorderLeftColor.IsEmpty)
+                _actualBorderLeftColor = GetActualColor(BorderLeftColor);
+
+            return _actualBorderLeftColor;
+        }
+    }
+
+    public Color ActualBorderBottomColor
+    {
+        get
+        {
+            if (_actualBorderBottomColor.IsEmpty)
+                _actualBorderBottomColor = GetActualColor(BorderBottomColor);
+
+            return _actualBorderBottomColor;
+        }
+    }
+
+    public Color ActualBorderRightColor
+    {
+        get
+        {
+            if (_actualBorderRightColor.IsEmpty)
+                _actualBorderRightColor = GetActualColor(BorderRightColor);
+
+            return _actualBorderRightColor;
+        }
+    }
+
+    public Color ActualTextDecorationColor
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(TextDecorationColor) ||
+                TextDecorationColor.Equals("currentcolor", StringComparison.OrdinalIgnoreCase))
+            {
+                return ActualColor;
+            }
+
+            if (_actualTextDecorationColor.IsEmpty)
+                _actualTextDecorationColor = GetActualColor(TextDecorationColor);
+
+            return _actualTextDecorationColor;
+        }
+    }
+
+    private string ResolvePhysicalSize(string explicitPhysicalValue, bool isWidth)
+    {
+        if (HasExplicitSize(explicitPhysicalValue))
+            return explicitPhysicalValue;
+
+        // PROTOTYPE (BROILER_VERTICAL_FLOW): when the experimental vertical
+        // flow path is enabled, vertical-writing-mode boxes are laid out in a
+        // logical (horizontal) coordinate frame — inline-size maps to width,
+        // block-size to height — and a post-layout transform rotates the
+        // result into physical space.  So the dimension swap is suppressed.
+        bool vertical = IsVerticalWritingMode(WritingMode) && !VerticalFlowPrototype.Enabled;
+        var logicalValue = isWidth
+            ? (vertical ? BlockSize : InlineSize)
+            : (vertical ? InlineSize : BlockSize);
+
+        return HasExplicitSize(logicalValue) ? logicalValue : explicitPhysicalValue;
+    }
+
+    private static bool HasExplicitSize(string? value) =>
+        !string.IsNullOrWhiteSpace(value) &&
+        !value.Equals("auto", StringComparison.OrdinalIgnoreCase);
+
+    internal static bool IsVerticalWritingMode(string? writingMode)
+    {
+        var normalized = writingMode?.Trim().ToLowerInvariant();
+        return normalized is "vertical-rl" or "vertical-lr" or "sideways-rl" or "sideways-lr";
+    }
+
+    private double ParseCornerRadius(string radius)
+    {
+        double basis = radius != null && radius.Contains('%', StringComparison.Ordinal)
+            ? Math.Max(0, Size.Width)
+            : 0;
+
+        return CssValueParser.ParseLength(radius, basis, GetEmHeight());
+    }
+
+    public double ActualCornerNw
+    {
+        get
+        {
+            if (CornerNwRadius != null && CornerNwRadius.Contains('%', StringComparison.Ordinal))
+                return ParseCornerRadius(CornerNwRadius);
+
+            if (double.IsNaN(_actualCornerNw))
+                _actualCornerNw = ParseCornerRadius(CornerNwRadius);
+
+            return _actualCornerNw;
+        }
+    }
+
+    public double ActualCornerNe
+    {
+        get
+        {
+            if (CornerNeRadius != null && CornerNeRadius.Contains('%', StringComparison.Ordinal))
+                return ParseCornerRadius(CornerNeRadius);
+
+            if (double.IsNaN(_actualCornerNe))
+                _actualCornerNe = ParseCornerRadius(CornerNeRadius);
+
+            return _actualCornerNe;
+        }
+    }
+
+    public double ActualCornerSe
+    {
+        get
+        {
+            if (CornerSeRadius != null && CornerSeRadius.Contains('%', StringComparison.Ordinal))
+                return ParseCornerRadius(CornerSeRadius);
+
+            if (double.IsNaN(_actualCornerSe))
+                _actualCornerSe = ParseCornerRadius(CornerSeRadius);
+
+            return _actualCornerSe;
+        }
+    }
+
+    public double ActualCornerSw
+    {
+        get
+        {
+            if (CornerSwRadius != null && CornerSwRadius.Contains('%', StringComparison.Ordinal))
+                return ParseCornerRadius(CornerSwRadius);
+
+            if (double.IsNaN(_actualCornerSw))
+                _actualCornerSw = ParseCornerRadius(CornerSwRadius);
+
+            return _actualCornerSw;
+        }
+    }
+
+    public bool IsRounded => ActualCornerNe > 0f || ActualCornerNw > 0f || ActualCornerSe > 0f || ActualCornerSw > 0f;
+
+    /// <summary>
+    /// Whether geometry anti-aliasing should be avoided. Returns false by
+    /// default; subclasses may override to provide container-specific behavior.
+    /// </summary>
+    public virtual bool AvoidGeometryAntialias => false;
+
+    public double ActualWordSpacing { get; private set; } = double.NaN;
+
+    public Color ActualColor
+    {
+        get
+        {
+            if (_actualColor.IsEmpty)
+                _actualColor = GetActualColor(Color);
+
+            return _actualColor;
+        }
+    }
+
+    public Color ActualBackgroundColor
+    {
+        get
+        {
+            if (_actualBackgroundColor.IsEmpty)
+                _actualBackgroundColor = GetActualColor(BackgroundColor);
+
+            return _actualBackgroundColor;
+        }
+    }
+
+    public Color ActualBackgroundGradient
+    {
+        get
+        {
+            if (_actualBackgroundGradient.IsEmpty)
+            {
+                // "none" is the initial value and means no gradient; resolve to
+                // fully-transparent so callers can simply check A > 0.  Without
+                // this guard, GetActualColor("none") falls back to Color.Black
+                // (opaque), which would cause EmitBackground to paint unintended
+                // black fills.
+                if (string.IsNullOrEmpty(BackgroundGradient) ||
+                    string.Equals(BackgroundGradient, "none", StringComparison.OrdinalIgnoreCase))
+                    _actualBackgroundGradient = System.Drawing.Color.FromArgb(0, 0, 0, 0);
+                else
+                    _actualBackgroundGradient = GetActualColor(BackgroundGradient);
+            }
+
+            return _actualBackgroundGradient;
+        }
+    }
+
+    public double ActualBackgroundGradientAngle
+    {
+        get
+        {
+            if (double.IsNaN(_actualBackgroundGradientAngle))
+                _actualBackgroundGradientAngle = CssValueParser.ParseNumber(BackgroundGradientAngle, 360f);
+
+            return _actualBackgroundGradientAngle;
+        }
+    }
+
+    public ILayoutFont ActualFont
+    {
+        get
+        {
+            if (_actualFont != null)
+                return _actualFont;
+
+            if (string.IsNullOrEmpty(FontFamily))
+                FontFamily = CssConstants.DefaultFont;
+
+            if (string.IsNullOrEmpty(FontSize))
+                FontSize = CssConstants.FontSize.ToString(CultureInfo.InvariantCulture) + "pt";
+
+            LayoutFontStyle st = LayoutFontStyle.Regular;
+
+            if (this.FontStyle == CssConstants.Italic || this.FontStyle == CssConstants.Oblique)
+                st |= LayoutFontStyle.Italic;
+
+            if (IsBoldWeight(FontWeight, GetParent()))
+                st |= LayoutFontStyle.Bold;
+
+            double parentSize = CssConstants.FontSize;
+
+            if (GetParent() != null)
+                parentSize = GetParent().ActualFont.Size;
+
+            var fsize = FontSize switch
+            {
+                CssConstants.Medium => CssConstants.FontSize,
+                CssConstants.XXSmall => CssConstants.FontSize - 4,
+                CssConstants.XSmall => CssConstants.FontSize - 3,
+                CssConstants.Small => CssConstants.FontSize - 2,
+                CssConstants.Large => CssConstants.FontSize + 2,
+                CssConstants.XLarge => CssConstants.FontSize + 3,
+                CssConstants.XXLarge => CssConstants.FontSize + 4,
+                CssConstants.Smaller => parentSize - 2,
+                CssConstants.Larger => parentSize + 2,
+                _ => CssValueParser.ParseLength(FontSize, parentSize, parentSize, null, true, true),
+            };
+
+            // CSS 2.1 §15.4: font-size: 0 results in a zero-size em box.
+            // Use a tiny positive value so the font object remains valid
+            // while producing near-zero word dimensions in the layout engine.
+            if (fsize <= 0)
+                fsize = 0.001;
+
+            _actualFont = GetCachedFont(FontFamily, fsize, st, GetEnabledFontFeatureTags());
+
+            return _actualFont;
+        }
+    }
+
+    protected abstract ILayoutFont GetCachedFont(string fontFamily, double fsize, LayoutFontStyle st, string fontFeatures);
+
+    public double ActualLineHeight
+    {
+        get
+        {
+            if (double.IsNaN(_actualLineHeight))
+            {
+                // CSS2.1 §10.8: "normal" line-height uses a UA-chosen value.
+                // Prefer the font's own line metrics so layout matches browser
+                // line boxes more closely than a fixed 1.2× fallback.
+                if (LineHeight == "normal" || string.IsNullOrEmpty(LineHeight))
+                    _actualLineHeight = GetNormalLineHeight();
+                else
+                    _actualLineHeight = ParseLineHeightLength(LineHeight, Size.Height);
+            }
+
+            return _actualLineHeight;
+        }
+    }
+
+    public double ActualTextIndent
+    {
+        get
+        {
+            if (double.IsNaN(_actualTextIndent))
+                _actualTextIndent = ParseLengthWithLineHeight(TextIndent, Size.Width);
+
+            return _actualTextIndent;
+        }
+    }
+
+    public double ActualBorderSpacingHorizontal
+    {
+        get
+        {
+            if (double.IsNaN(_actualBorderSpacingHorizontal))
+            {
+                MatchCollection matches = RegexParserUtils.Match(RegexParserUtils.CssLengthRegex(), BorderSpacing);
+
+                if (matches.Count == 0)
+                {
+                    _actualBorderSpacingHorizontal = 0;
+                }
+                else if (matches.Count > 0)
+                {
+                    _actualBorderSpacingHorizontal = ParseLengthWithLineHeight(matches[0].Value, 1);
+                }
+            }
+
+            return _actualBorderSpacingHorizontal;
+        }
+    }
+
+    public double ActualBorderSpacingVertical
+    {
+        get
+        {
+            if (double.IsNaN(_actualBorderSpacingVertical))
+            {
+                MatchCollection matches = RegexParserUtils.Match(RegexParserUtils.CssLengthRegex(), BorderSpacing);
+
+                if (matches.Count == 0)
+                {
+                    _actualBorderSpacingVertical = 0;
+                }
+                else if (matches.Count == 1)
+                {
+                    _actualBorderSpacingVertical = ParseLengthWithLineHeight(matches[0].Value, 1);
+                }
+                else
+                {
+                    _actualBorderSpacingVertical = ParseLengthWithLineHeight(matches[1].Value, 1);
+                }
+            }
+
+            return _actualBorderSpacingVertical;
+        }
+    }
+
+    protected abstract CssBoxProperties GetParent();
+
+    public double GetEmHeight() => ActualFont.Size * (96.0 / 72.0);
+
+    protected double ParseLengthWithLineHeight(string length, double hundredPercent)
+    {
+        if (!string.IsNullOrWhiteSpace(length) &&
+            length.EndsWith("rem", StringComparison.OrdinalIgnoreCase) &&
+            double.TryParse(length[..^3], NumberStyles.Float, CultureInfo.InvariantCulture, out var rem))
+        {
+            return rem * GetRootEmHeight();
+        }
+
+        return CssValueParser.ParseLength(
+            length,
+            hundredPercent,
+            GetEmHeight(),
+            null,
+            false,
+            false,
+            ActualLineHeight,
+            GetRootLineHeight());
+    }
+
+    private double ParseLineHeightLength(string length, double hundredPercent)
+    {
+        var parentLineHeight = GetParent()?.ActualLineHeight ?? GetNormalLineHeight();
+        return CssValueParser.ParseLength(
+            length,
+            hundredPercent,
+            GetEmHeight(),
+            null,
+            false,
+            false,
+            parentLineHeight,
+            GetRootLineHeight());
+    }
+
+    private double GetRootLineHeight()
+    {
+        var root = GetEffectiveRootBoxProperties();
+
+        if (!ReferenceEquals(root, this))
+            return root.ActualLineHeight;
+
+        if (!double.IsNaN(_actualLineHeight))
+            return _actualLineHeight;
+
+        if (LineHeight == "normal" || string.IsNullOrEmpty(LineHeight))
+            return GetNormalLineHeight();
+
+        return CssValueParser.ParseLength(
+            LineHeight,
+            Size.Height,
+            GetEmHeight(),
+            null,
+            false,
+            false,
+            GetNormalLineHeight(),
+            GetNormalLineHeight());
+    }
+
+    private double GetNormalLineHeight()
+    {
+        // ActualFont.Height is already expressed in CSS pixels (the font
+        // compat factory bakes the pt→px ratio into the returned metric), so
+        // it must NOT be scaled by 96/72 again here — doing so inflated the
+        // 'normal' line height by ~1.33x (e.g. Arial 32px produced a 50px
+        // line box instead of the ~37px browsers use).
+        double fontHeight = ActualFont.Height;
+        return fontHeight > 0 ? Math.Ceiling(fontHeight) : GetEmHeight() * 1.2;
+    }
+
+    private double GetRootEmHeight()
+    {
+        var root = GetEffectiveRootBoxProperties();
+
+        const double baseRootEmHeight = CssConstants.FontSize * (96.0 / 72.0);
+        if (!string.IsNullOrWhiteSpace(root.FontSize))
+        {
+            var resolved = CssValueParser.ParseLength(
+                root.FontSize,
+                baseRootEmHeight,
+                baseRootEmHeight,
+                null,
+                false,
+                false,
+                baseRootEmHeight * 1.2,
+                baseRootEmHeight * 1.2);
+
+            if (!double.IsNaN(resolved) && resolved > 0)
+                return resolved;
+        }
+
+        return root.GetEmHeight();
+    }
+
+    private CssBoxProperties GetEffectiveRootBoxProperties()
+    {
+        CssBoxProperties root = this;
+        while (root.GetParent() != null)
+            root = root.GetParent();
+
+        if (root is CssBox cssRoot)
+        {
+            while (cssRoot.HtmlTag == null && cssRoot.Boxes.Count == 1)
+            {
+                var child = cssRoot.Boxes[0];
+                if (ReferenceEquals(child, cssRoot))
+                    break;
+
+                cssRoot = child;
+            }
+
+            root = cssRoot;
+        }
+
+        return root;
+    }
+
+    /// <summary>
+    /// Resolves a CSS font-weight value to a numeric weight (100–900)
+    /// per CSS 2.1 §15.6. Handles keywords <c>normal</c>, <c>bold</c>,
+    /// <c>bolder</c>, <c>lighter</c>, and numeric strings.
+    /// </summary>
+    internal static int ResolveNumericFontWeight(string fontWeight, CssBoxProperties parent)
+    {
+        if (string.IsNullOrEmpty(fontWeight) || fontWeight == CssConstants.Normal || fontWeight == CssConstants.Inherit)
+            return 400;
+        if (fontWeight == CssConstants.Bold)
+            return 700;
+
+        if (int.TryParse(fontWeight, out int numeric))
+            return Math.Clamp(numeric, 100, 900);
+
+        if (fontWeight == CssConstants.Bolder || fontWeight == CssConstants.Lighter)
+        {
+            int parentWeight = 400;
+            if (parent != null)
+                parentWeight = ResolveNumericFontWeight(parent.FontWeight, parent.GetParent());
+
+            return fontWeight == CssConstants.Bolder
+                ? ResolveBolder(parentWeight)
+                : ResolveLighter(parentWeight);
+        }
+
+        // Any other non-empty, non-normal value is treated as bold
+        return 700;
+    }
+
+    /// <summary>
+    /// CSS 2.1 §15.6: <c>bolder</c> selects the next weight above the inherited value.
+    /// </summary>
+    private static int ResolveBolder(int parentWeight)
+    {
+        if (parentWeight < 400) return 400;
+        if (parentWeight < 600) return 700;
+        return 900;
+    }
+
+    /// <summary>
+    /// CSS 2.1 §15.6: <c>lighter</c> selects the next weight below the inherited value.
+    /// </summary>
+    private static int ResolveLighter(int parentWeight)
+    {
+        if (parentWeight > 700) return 400;
+        if (parentWeight > 500) return 400;
+        return 100;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the resolved numeric font weight is 600 or above,
+    /// meaning the font should use a bold face.
+    /// </summary>
+    private static bool IsBoldWeight(string fontWeight, CssBoxProperties parent)
+    {
+        if (string.IsNullOrEmpty(fontWeight) || fontWeight == CssConstants.Normal || fontWeight == CssConstants.Inherit)
+            return false;
+        return ResolveNumericFontWeight(fontWeight, parent) >= 600;
+    }
+
+    protected string NoEms(string length)
+    {
+        var len = new CssLength(length);
+
+        if (len.Unit == CssUnit.Em)
+            length = len.ConvertEmToPixels(GetEmHeight()).ToString();
+
+        return length;
+    }
+
+    protected void SetAllBorders(string style = null, string width = null, string color = null)
+    {
+        if (style != null)
+            BorderLeftStyle = BorderTopStyle = BorderRightStyle = BorderBottomStyle = style;
+
+        if (width != null)
+            BorderLeftWidth = BorderTopWidth = BorderRightWidth = BorderBottomWidth = width;
+
+        if (color != null)
+            BorderLeftColor = BorderTopColor = BorderRightColor = BorderBottomColor = color;
+    }
+
+    protected void MeasureWordSpacing(ILayoutEnvironment g)
+    {
+        if (!double.IsNaN(ActualWordSpacing))
+            return;
+
+        ActualWordSpacing = CssUtils.WhiteSpace(g, this);
+
+        if (WordSpacing == CssConstants.Normal)
+            return;
+
+        string len = RegexParserUtils.Search(RegexParserUtils.CssLengthRegex(), WordSpacing);
+        ActualWordSpacing += CssValueParser.ParseLength(len, 1, GetEmHeight());
+    }
+
+    protected void InheritStyle(CssBox p, bool everything)
+    {
+        if (p == null)
+            return;
+
+        BorderSpacing = p.BorderSpacing;
+        BorderCollapse = p.BorderCollapse;
+        _color = p._color;
+        EmptyCells = p.EmptyCells;
+        WhiteSpace = p.WhiteSpace;
+        Visibility = p.Visibility;
+        _textIndent = p._textIndent;
+        TextAlign = p.TextAlign;
+        FontFamily = p.FontFamily;
+        FontFeatureSettings = p.FontFeatureSettings;
+        FontVariantAlternates = p.FontVariantAlternates;
+        _fontSize = p._fontSize;
+        FontStyle = p.FontStyle;
+        FontVariant = p.FontVariant;
+        FontWeight = p.FontWeight;
+        ListStyleImage = p.ListStyleImage;
+        ListStylePosition = p.ListStylePosition;
+        ListStyleType = p.ListStyleType;
+        ListStyle = p.ListStyle;
+        _lineHeight = p._lineHeight;
+        WordBreak = p.WordBreak;
+        Direction = p.Direction;
+        WritingMode = p.WritingMode;
+        TextShadow = p.TextShadow;
+
+        if (!everything)
+            return;
+
+        BackgroundColor = p.BackgroundColor;
+        BackgroundGradient = p.BackgroundGradient;
+        BackgroundGradientAngle = p.BackgroundGradientAngle;
+        BackgroundImage = p.BackgroundImage;
+        BackgroundPosition = p.BackgroundPosition;
+        BackgroundRepeat = p.BackgroundRepeat;
+        BackgroundAttachment = p.BackgroundAttachment;
+        BackgroundOrigin = p.BackgroundOrigin;
+        BackgroundSize = p.BackgroundSize;
+        _borderTopWidth = p._borderTopWidth;
+        _borderRightWidth = p._borderRightWidth;
+        _borderBottomWidth = p._borderBottomWidth;
+        _borderLeftWidth = p._borderLeftWidth;
+        _borderTopColor = p._borderTopColor;
+        _borderRightColor = p._borderRightColor;
+        _borderBottomColor = p._borderBottomColor;
+        _borderLeftColor = p._borderLeftColor;
+        BorderTopStyle = p.BorderTopStyle;
+        BorderRightStyle = p.BorderRightStyle;
+        BorderBottomStyle = p.BorderBottomStyle;
+        BorderLeftStyle = p.BorderLeftStyle;
+        _bottom = p._bottom;
+        CornerNwRadius = p.CornerNwRadius;
+        CornerNeRadius = p.CornerNeRadius;
+        CornerSeRadius = p.CornerSeRadius;
+        CornerSwRadius = p.CornerSwRadius;
+        _cornerRadius = p._cornerRadius;
+        Display = p.Display;
+        Float = p.Float;
+        BlockSize = p.BlockSize;
+        Height = p.Height;
+        InlineSize = p.InlineSize;
+        MarginBottom = p.MarginBottom;
+        MarginLeft = p.MarginLeft;
+        MarginRight = p.MarginRight;
+        MarginTop = p.MarginTop;
+        MarginTrim = p.MarginTrim;
+        _left = p._left;
+        _lineHeight = p._lineHeight;
+        Overflow = p.Overflow;
+        _paddingLeft = p._paddingLeft;
+        _paddingBottom = p._paddingBottom;
+        _paddingRight = p._paddingRight;
+        _paddingTop = p._paddingTop;
+        _right = p._right;
+        TextDecoration = p.TextDecoration;
+        TextDecorationStyle = p.TextDecorationStyle;
+        TextDecorationColor = p.TextDecorationColor;
+        _top = p._top;
+        Position = p.Position;
+        VerticalAlign = p.VerticalAlign;
+        Width = p.Width;
+        MaxWidth = p.MaxWidth;
+        MinWidth = p.MinWidth;
+        IsMinWidthSpecified = p.IsMinWidthSpecified;
+        MinHeight = p.MinHeight;
+        MaxHeight = p.MaxHeight;
+        _wordSpacing = p._wordSpacing;
+        Opacity = p.Opacity;
+        BoxShadow = p.BoxShadow;
+        MixBlendMode = p.MixBlendMode;
+        BackgroundBlendMode = p.BackgroundBlendMode;
+        Filter = p.Filter;
+        Isolation = p.Isolation;
+        BoxSizing = p.BoxSizing;
+        BackgroundClip = p.BackgroundClip;
+        ClipPath = p.ClipPath;
+        FlexDirection = p.FlexDirection;
+        FlexGrow = p.FlexGrow;
+        FlexShrink = p.FlexShrink;
+        FlexBasis = p.FlexBasis;
+        FlexWrap = p.FlexWrap;
+        JustifyContent = p.JustifyContent;
+        JustifyItems = p.JustifyItems;
+        AlignItems = p.AlignItems;
+        AlignContent = p.AlignContent;
+        JustifySelf = p.JustifySelf;
+        AlignSelf = p.AlignSelf;
+        RowGap = p.RowGap;
+        ColumnGap = p.ColumnGap;
+    }
+
+    protected void InvalidateFontDependentValues()
+    {
+        _actualFont = null;
+        _actualHeight = double.NaN;
+        _actualWidth = double.NaN;
+        _actualPaddingTop = double.NaN;
+        _actualPaddingBottom = double.NaN;
+        _actualPaddingRight = double.NaN;
+        _actualPaddingLeft = double.NaN;
+        _actualMarginTop = double.NaN;
+        _actualMarginBottom = double.NaN;
+        _actualMarginRight = double.NaN;
+        _actualMarginLeft = double.NaN;
+        _actualLineHeight = double.NaN;
+        _actualTextIndent = double.NaN;
+        _actualBorderTopWidth = double.NaN;
+        _actualBorderRightWidth = double.NaN;
+        _actualBorderBottomWidth = double.NaN;
+        _actualBorderLeftWidth = double.NaN;
+        _actualCornerNw = double.NaN;
+        _actualCornerNe = double.NaN;
+        _actualCornerSw = double.NaN;
+        _actualCornerSe = double.NaN;
+        _actualBorderSpacingHorizontal = double.NaN;
+        _actualBorderSpacingVertical = double.NaN;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -1,0 +1,1628 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using Broiler.Layout;
+
+using CssConstants = Broiler.CSS.CssConstants;
+using CssValueParser = Broiler.CSS.CssLengthParser;
+using CssLength = Broiler.CSS.CssLength;
+using CssUnit = Broiler.CSS.CssUnit;
+namespace Broiler.Layout;
+
+internal static class CssLayoutEngine
+{
+    /// <summary>
+    /// Returns true when <paramref name="box"/> or any of its ancestors
+    /// (up to but not including <paramref name="stop"/>) has
+    /// <c>position:absolute</c> or <c>position:fixed</c>.
+    /// </summary>
+    private static bool IsInAbsposSubtree(CssBox box, CssBox stop)
+    {
+        for (var b = box; b != null && b != stop; b = b.ParentBox)
+        {
+            if (b.Position == CssConstants.Absolute || b.Position == CssConstants.Fixed)
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Approximate ratio of font ascent to total font height for typical
+    /// Latin fonts.  Used to compute baseline position when full font
+    /// metrics are not directly available (CSS2.1 §10.8 strut).
+    /// </summary>
+    private const double TypicalAscentRatio = 0.8;
+
+    /// <summary>
+    /// Ratio to convert typographic points to CSS pixels (96 DPI / 72 DPI).
+    /// Layout coordinates are in CSS px, but font metrics from the layout
+    /// font are at pt-scale (the layout font is created in canvas units, and
+    /// the layout font is created at pt size).  This factor bridges the gap
+    /// for line-height calculations where font.Height is the fallback.
+    /// </summary>
+    private const double PtToCssPx = 96.0 / 72.0;
+
+    public static void MeasureImageSize(ILayoutEnvironment g, CssRectImage imageWord)
+    {
+        ArgumentNullException.ThrowIfNull(imageWord);
+        ArgumentNullException.ThrowIfNull(imageWord.OwnerBox);
+
+        // Phase 2b: replaced-element intrinsics come from the layout environment
+        // rather than reading RImage members directly (see roadmap §4).
+        ImageIntrinsics? image = imageWord.Image is { } handle ? g.GetImageIntrinsics(handle) : null;
+
+        var width = new CssLength(imageWord.OwnerBox.Width);
+        var height = new CssLength(imageWord.OwnerBox.Height);
+
+        bool hasImageTagWidth = width.Number > 0 && width.Unit == CssUnit.Px;
+        bool hasImageTagHeight = height.Number > 0 && height.Unit == CssUnit.Px;
+        bool scaleImageHeight = false;
+
+        if (hasImageTagWidth)
+        {
+            imageWord.Width = width.Number;
+        }
+        else if (width.Number > 0 && width.IsPercentage)
+        {
+            imageWord.Width = width.Number * imageWord.OwnerBox.ContainingBlock.Size.Width;
+            scaleImageHeight = true;
+        }
+        else if (image != null)
+        {
+            imageWord.Width = imageWord.ImageRectangle == RectangleF.Empty ? image.Value.Width : imageWord.ImageRectangle.Width;
+
+            // CSS2.1 §10.3.2: when width is auto the used value is the
+            // intrinsic width.  Do NOT clamp to the containing block —
+            // inline replaced elements are allowed to overflow their
+            // container.  Authors use max-width:100% to opt into clamping.
+        }
+        else
+        {
+            imageWord.Width = hasImageTagHeight ? height.Number / 1.14f : 20;
+        }
+
+        var maxWidth = new CssLength(imageWord.OwnerBox.MaxWidth);
+        if (maxWidth.Number > 0)
+        {
+            double maxWidthVal = -1;
+            if (maxWidth.Unit == CssUnit.Px)
+            {
+                maxWidthVal = maxWidth.Number;
+            }
+            else if (maxWidth.IsPercentage)
+            {
+                maxWidthVal = maxWidth.Number * imageWord.OwnerBox.ContainingBlock.Size.Width;
+            }
+
+            if (maxWidthVal > -1 && imageWord.Width > maxWidthVal)
+            {
+                imageWord.Width = maxWidthVal;
+                scaleImageHeight = !hasImageTagHeight;
+            }
+        }
+
+        if (hasImageTagHeight)
+        {
+            imageWord.Height = height.Number;
+        }
+        else if (image != null)
+        {
+            imageWord.Height = imageWord.ImageRectangle == RectangleF.Empty ? image.Value.Height : imageWord.ImageRectangle.Height;
+        }
+        else
+        {
+            imageWord.Height = imageWord.Width > 0 ? imageWord.Width * 1.14f : 22.8f;
+        }
+
+        if (image != null && image.Value.HasIntrinsicRatio)
+        {
+            bool widthDriven = (hasImageTagWidth && !hasImageTagHeight) || scaleImageHeight;
+            // If only the width was set in the html tag, ratio the height.
+            if (widthDriven)
+            {
+                // Divide the given tag width with the actual image width, to get the ratio.
+                double ratio = imageWord.Width / image.Value.Width;
+                imageWord.Height = image.Value.Height * ratio;
+            }
+            // If only the height was set in the html tag, ratio the width.
+            else if (hasImageTagHeight && !hasImageTagWidth)
+            {
+                // Divide the given tag height with the actual image height, to get the ratio.
+                double ratio = imageWord.Height / image.Value.Height;
+                imageWord.Width = image.Value.Width * ratio;
+            }
+        }
+
+        // CSS2.1 §10.4/§10.7: Apply min/max width/height constraints
+        // for replaced elements (images).  These are applied after intrinsic
+        // sizing and aspect-ratio adjustments.
+        var minWidth = new CssLength(imageWord.OwnerBox.MinWidth);
+        if (minWidth.Number > 0)
+        {
+            double minWidthVal = minWidth.Unit == CssUnit.Px
+                ? minWidth.Number
+                : minWidth.IsPercentage
+                    ? minWidth.Number * imageWord.OwnerBox.ContainingBlock.Size.Width
+                    : -1;
+            if (minWidthVal > 0 && imageWord.Width < minWidthVal)
+            {
+                if (image != null && !hasImageTagHeight && image.Value.HasIntrinsicRatio)
+                {
+                    double ratio = minWidthVal / imageWord.Width;
+                    imageWord.Height *= ratio;
+                }
+                imageWord.Width = minWidthVal;
+            }
+        }
+
+        var maxHeight = new CssLength(imageWord.OwnerBox.MaxHeight);
+        if (maxHeight.Number > 0)
+        {
+            double maxHeightVal = maxHeight.Unit == CssUnit.Px
+                ? maxHeight.Number
+                : maxHeight.IsPercentage
+                    ? maxHeight.Number * imageWord.OwnerBox.ContainingBlock.Size.Height
+                    : -1;
+            if (maxHeightVal > 0 && imageWord.Height > maxHeightVal)
+            {
+                if (image != null && !hasImageTagWidth && image.Value.HasIntrinsicRatio)
+                {
+                    double ratio = maxHeightVal / imageWord.Height;
+                    imageWord.Width *= ratio;
+                }
+                imageWord.Height = maxHeightVal;
+            }
+        }
+
+        var minHeight = new CssLength(imageWord.OwnerBox.MinHeight);
+        if (minHeight.Number > 0)
+        {
+            double minHeightVal = minHeight.Unit == CssUnit.Px
+                ? minHeight.Number
+                : minHeight.IsPercentage
+                    ? minHeight.Number * imageWord.OwnerBox.ContainingBlock.Size.Height
+                    : -1;
+            if (minHeightVal > 0 && imageWord.Height < minHeightVal)
+            {
+                if (image != null && !hasImageTagWidth && image.Value.HasIntrinsicRatio)
+                {
+                    double ratio = minHeightVal / imageWord.Height;
+                    imageWord.Width *= ratio;
+                }
+                imageWord.Height = minHeightVal;
+            }
+        }
+
+        imageWord.Height += imageWord.OwnerBox.ActualBorderBottomWidth + imageWord.OwnerBox.ActualBorderTopWidth + imageWord.OwnerBox.ActualPaddingTop + imageWord.OwnerBox.ActualPaddingBottom;
+    }
+
+    public static void CreateLineBoxes(ILayoutEnvironment g, CssBox blockBox)
+    {
+        ArgumentNullException.ThrowIfNull(g);
+        ArgumentNullException.ThrowIfNull(blockBox);
+
+        blockBox.LineBoxes.Clear();
+
+        double limitRight = blockBox.ActualRight - blockBox.ActualPaddingRight - blockBox.ActualBorderRightWidth;
+
+        //Get the start x and y of the blockBox
+        double startx = blockBox.Location.X + blockBox.ActualPaddingLeft - 0 + blockBox.ActualBorderLeftWidth;
+        double starty = blockBox.Location.Y + blockBox.ActualPaddingTop - 0 + blockBox.ActualBorderTopWidth;
+        double curx = startx + blockBox.ActualTextIndent;
+        double cury = starty;
+
+        //Reminds the maximum bottom reached
+        double maxRight = startx;
+        double maxBottom = starty;
+
+        //First line box
+        CssLineBox line = new(blockBox);
+
+        //Flow words and boxes
+        FlowBox(g, blockBox, blockBox, limitRight, 0, startx, ref line, ref curx, ref cury, ref maxRight, ref maxBottom);
+
+        // if width is not restricted we need to lower it to the actual width
+        if (blockBox.ActualRight >= 90999)
+        {
+            blockBox.ActualRight = maxRight + blockBox.ActualPaddingRight + blockBox.ActualBorderRightWidth;
+        }
+
+        //Gets the rectangles for each line-box
+        bool plaintext = string.Equals(blockBox.UnicodeBidi, "plaintext", StringComparison.OrdinalIgnoreCase);
+        // CSS Text §bidi-linebox: under unicode-bidi:plaintext each line is its own
+        // bidi paragraph.  Its base direction is the first strong character's; a line
+        // with no strong character inherits the previous paragraph's base direction,
+        // or the containing block's direction when there is none.  Otherwise every
+        // line shares the block's own direction.  Because a <br> splits content into
+        // sibling anonymous blocks, the "previous paragraph" may live in an earlier
+        // sibling — seed the running base direction from the most recent strong
+        // character preceding this block in document order.
+        bool baseRtl = plaintext
+            ? SeedPlaintextBaseRtl(blockBox)
+            : blockBox.Direction == CssConstants.Rtl;
+        foreach (var linebox in blockBox.LineBoxes)
+        {
+            bool lineRtl = baseRtl;
+            if (plaintext)
+            {
+                lineRtl = LineFirstStrongRtl(linebox) ?? baseRtl;
+                baseRtl = lineRtl;
+            }
+            ApplyHorizontalAlignment(g, linebox, lineRtl);
+            ApplyRightToLeft(linebox, lineRtl);
+            BubbleRectangles(blockBox, linebox);
+            ApplyVerticalAlignment(g, linebox);
+            linebox.AssignRectanglesToBoxes();
+        }
+
+        // CSS2.1 §10.8: After vertical alignment adjusts inline-block
+        // positions (e.g. vertical-align: 2em raises boxes), recalculate
+        // maxBottom from the actual post-alignment positions.
+        //
+        // CSS2.1 §10.8.1: The line box height is the distance between
+        // the uppermost box top and the lowermost box bottom.  When
+        // positive vertical-align raises inline-blocks above the flow
+        // start, the line box extends upward.  The full line box height
+        // must be reflected in the block's content height so that
+        // subsequent siblings are positioned correctly.
+        //
+        // Example: Acid3's .buckets div has font: 0/0 (baseline at
+        // content edge) and bucket6 extends 162px above the baseline.
+        // The line box height is 162px, so the div's auto height = 162px
+        // (plus padding/border).
+        maxBottom = starty;
+        double minTop = starty;
+        foreach (var linebox in blockBox.LineBoxes)
+        {
+            foreach (var rect in linebox.Rectangles)
+            {
+                // CSS2.1 §9.6.1: Absolutely/fixed positioned elements are
+                // out of normal flow and must not affect the line box height.
+                if (IsInAbsposSubtree(rect.Key, blockBox))
+                    continue;
+
+                maxBottom = Math.Max(maxBottom, InlineRectLineBoxBottom(rect.Key, rect.Value));
+                minTop = Math.Min(minTop, rect.Value.Top);
+            }
+            foreach (var word in linebox.Words)
+            {
+                if (IsInAbsposSubtree(word.OwnerBox, blockBox))
+                    continue;
+
+                maxBottom = Math.Max(maxBottom, InlineWordLineBoxBottom(word));
+                minTop = Math.Min(minTop, word.Top);
+            }
+
+            if (blockBox.ActualLineHeight > 0)
+            {
+                double lineTop = double.MaxValue;
+                bool hasLineContent = false;
+
+                foreach (var rect in linebox.Rectangles)
+                {
+                    if (IsInAbsposSubtree(rect.Key, blockBox))
+                        continue;
+
+                    lineTop = Math.Min(lineTop, rect.Value.Top);
+                    hasLineContent = true;
+                }
+
+                foreach (var word in linebox.Words)
+                {
+                    if (IsInAbsposSubtree(word.OwnerBox, blockBox))
+                        continue;
+
+                    lineTop = Math.Min(lineTop, word.Top);
+                    hasLineContent = true;
+                }
+
+                if (hasLineContent)
+                    maxBottom = Math.Max(maxBottom, lineTop + blockBox.ActualLineHeight);
+            }
+        }
+        // CSS2.1 §10.8.1: The line box height is the distance between
+        // the uppermost box top and the lowermost box bottom.  When
+        // inline-level boxes overflow above the starting flow position
+        // (minTop < starty), the full line box height must be reflected
+        // in maxBottom so subsequent siblings are positioned correctly.
+        if (minTop < starty)
+        {
+            double lineBoxHeight = maxBottom - minTop;
+            maxBottom = Math.Max(maxBottom, starty + lineBoxHeight);
+
+            // CSS2.1 §9.4.2: Line boxes are laid out beginning at the
+            // top of the containing block.  When vertical-align raises
+            // inline-blocks above the flow start, the entire line box
+            // content must be shifted downward so it renders within the
+            // block container's content area (from starty to
+            // starty + lineBoxHeight) instead of overflowing above.
+            // The shift amount is computed from the global minTop across
+            // ALL line boxes in the block (lines 162-176), so it must be
+            // applied uniformly to all line boxes.
+            double shift = starty - minTop;
+            foreach (var linebox in blockBox.LineBoxes)
+            {
+                // Shift line box rectangle positions
+                var keys = new List<CssBox>(linebox.Rectangles.Keys);
+                foreach (var box in keys)
+                {
+                    var r = linebox.Rectangles[box];
+                    linebox.Rectangles[box] = new RectangleF(r.X, (float)(r.Y + shift), r.Width, r.Height);
+
+                    // For inline-block boxes, also update the CssBox's
+                    // own Location and ActualBottom (used by the paint system).
+                    if (box.Display == CssConstants.InlineBlock)
+                    {
+                        box.Location = new PointF(box.Location.X, (float)(box.Location.Y + shift));
+                        box.ActualBottom += shift;
+                    }
+
+                    // Update the box's own Rectangles copy (assigned
+                    // earlier by AssignRectanglesToBoxes).
+                    if (box.Rectangles.ContainsKey(linebox))
+                        box.Rectangles[linebox] = linebox.Rectangles[box];
+                }
+
+                // Shift word positions
+                foreach (var word in linebox.Words)
+                    word.Top += shift;
+            }
+        }
+
+        // CSS2.1 §10.8: The "strut" — each line box starts with an
+        // imaginary zero-width inline box with the block container's font
+        // and line-height properties.  This establishes the minimum line
+        // box height for inline formatting contexts.
+        // The strut only affects content height when height is 'auto';
+        // an explicit height (CSS2.1 §10.6.3) overrides the content height.
+        // CSS2.1 §9.4.2: The strut only contributes to height when the
+        // inline formatting context has actual inline content (words or
+        // inline-level boxes).  An empty block should have zero content
+        // height from the IFC.
+        bool hasExplicitHeight = blockBox.Height != null && blockBox.Height != CssConstants.Auto;
+        bool hasInlineContent = false;
+        foreach (var lb in blockBox.LineBoxes)
+        {
+            // CSS2.1 §9.6.1: Words and rectangles from absolutely/fixed
+            // positioned elements are not in-flow inline content.
+            foreach (var w in lb.Words)
+            {
+                if (!IsInAbsposSubtree(w.OwnerBox, blockBox))
+                {
+                    hasInlineContent = true;
+                    break;
+                }
+            }
+            if (hasInlineContent) break;
+            foreach (var r in lb.Rectangles)
+            {
+                if (!IsInAbsposSubtree(r.Key, blockBox))
+                {
+                    hasInlineContent = true;
+                    break;
+                }
+            }
+            if (hasInlineContent) break;
+        }
+        if (blockBox.ActualLineHeight > 0 && !hasExplicitHeight && hasInlineContent)
+            maxBottom = Math.Max(maxBottom, starty + blockBox.ActualLineHeight);
+
+        blockBox.ActualBottom = maxBottom + blockBox.ActualPaddingBottom + blockBox.ActualBorderBottomWidth;
+
+        // CSS2.1 §10.6.3: When height is not 'auto', the used value is the
+        // specified value.  Content may overflow (controlled by 'overflow').
+        // For overflow:hidden, overflow:auto, and overflow:scroll the box's
+        // layout height is clamped to the specified height so that subsequent
+        // siblings are not pushed down by overflowing content.
+        if (hasExplicitHeight
+            && blockBox.Overflow is CssConstants.Hidden or CssConstants.Auto or CssConstants.Scroll
+            && blockBox.ActualBottom - blockBox.Location.Y > blockBox.ActualHeight)
+            blockBox.ActualBottom = blockBox.Location.Y + blockBox.ActualHeight;
+    }
+
+    public static void ApplyCellVerticalAlignment(ILayoutEnvironment g, CssBox cell)
+    {
+        ArgumentNullException.ThrowIfNull(g);
+        ArgumentNullException.ThrowIfNull(cell);
+
+        if (cell.VerticalAlign == CssConstants.Top || cell.VerticalAlign == CssConstants.Baseline)
+            return;
+
+        double cellbot = cell.ClientBottom;
+        double bottom = CssBoxHelper.GetMaximumBottom(cell, 0f);
+        double dist = 0f;
+
+        if (cell.VerticalAlign == CssConstants.Bottom)
+        {
+            dist = cellbot - bottom;
+        }
+        else if (cell.VerticalAlign == CssConstants.Middle)
+        {
+            dist = (cellbot - bottom) / 2;
+        }
+
+        // CSS Box Alignment §6.2: When align-content is 'normal' on a
+        // table cell, vertical-align maps to safe alignment.  If the
+        // content overflows the cell (dist < 0), safe alignment clamps
+        // to start (top), preventing negative shifts.
+        if (dist < 0 && (cell.AlignContent == null || cell.AlignContent == "normal"))
+            dist = 0;
+
+        foreach (CssBox b in cell.Boxes)
+        {
+            b.OffsetTop(dist);
+        }
+    }
+
+    private static void FlowBox(ILayoutEnvironment g, CssBox blockbox, CssBox box, double limitRight, double linespacing, double startx, ref CssLineBox line, ref double curx, ref double cury, ref double maxRight, ref double maxbottom)
+    {
+        var startX = curx;
+        var startY = cury;
+        box.FirstHostingLineBox = line;
+        var localCurx = curx;
+        var localMaxRight = maxRight;
+        var localmaxbottom = maxbottom;
+
+        foreach (CssBox b in box.Boxes)
+        {
+            // CSS2.1 §9.2.4: display:none elements generate no boxes and
+            // must not participate in layout — skip them entirely.
+            if (b.Display == CssConstants.None)
+                continue;
+
+            // CSS2.1 §9.5: Floated elements are out of normal flow and
+            // must not participate in the inline formatting context.
+            // Their positioning is handled separately in PerformLayoutImp.
+            if (b.Float != CssConstants.None)
+                continue;
+
+            // CSS2.1 §9.6.1: Absolutely and fixed positioned elements are
+            // out of normal flow.  Save the current flow state so we can
+            // restore it after laying out the child — its words must not
+            // shift subsequent siblings or inflate the parent's content
+            // height.
+            bool isAbsposChild = b.Position == CssConstants.Absolute
+                || b.Position == CssConstants.Fixed;
+            double childSaveCurx = curx;
+            double childSaveCury = cury;
+            double childSaveMaxRight = maxRight;
+            double childSaveMaxBottom = maxbottom;
+            CssLineBox childSaveLine = line;
+
+            double leftspacing = !isAbsposChild ? b.ActualMarginLeft + b.ActualBorderLeftWidth + b.ActualPaddingLeft : 0;
+            double rightspacing = !isAbsposChild ? b.ActualMarginRight + b.ActualBorderRightWidth + b.ActualPaddingRight : 0;
+
+            b.RectanglesReset();
+            b.MeasureWordsSize(g);
+
+            curx += leftspacing;
+
+            if (b.Words.Count > 0)
+            {
+                bool wrapNoWrapBox = false;
+                if (b.WhiteSpace == CssConstants.NoWrap && curx > startx)
+                {
+                    var boxRight = curx;
+                    foreach (var word in b.Words)
+                        boxRight += word.FullWidth;
+
+                    if (boxRight > limitRight)
+                        wrapNoWrapBox = true;
+                }
+
+                if (LayoutBoxUtils.IsBoxHasWhitespace(b))
+                    curx += box.ActualWordSpacing;
+
+                foreach (var word in b.Words)
+                {
+                    // CSS2.1 §10.8: Every line box has a minimum height
+                    // from the block container's line-height (the "strut").
+                    // When line-height is 'normal' (ActualLineHeight == 0),
+                    // the minimum comes from the font metrics, scaled to CSS
+                    // px (font.Height is at pt-scale because the layout font
+                    // is created at pt size in canvas units).
+                    double boxLineHeight = box.ActualLineHeight > 0
+                        ? box.ActualLineHeight
+                        : box.ActualFont.Height * PtToCssPx;
+                    if (maxbottom - cury < boxLineHeight)
+                        maxbottom += boxLineHeight - (maxbottom - cury);
+
+                    // CSS2.1 §10.8: The "strut" — each line box has a minimum
+                    // height from the block container's font and line-height.
+                    // For replaced inline elements (images), apply the block
+                    // container's strut so that baseline alignment pushes the
+                    // image down when the font is larger than the image.
+                    double strutHeight = 0;
+                    if (word.IsImage)
+                    {
+                        strutHeight = blockbox.ActualLineHeight;
+                        if (strutHeight <= 0)
+                            strutHeight = blockbox.ActualFont.Height * PtToCssPx;
+
+                        if (maxbottom - cury < strutHeight)
+                            maxbottom += strutHeight - (maxbottom - cury);
+                    }
+
+                    if ((b.WhiteSpace != CssConstants.NoWrap && b.WhiteSpace != CssConstants.Pre && curx + word.Width + rightspacing > limitRight
+                         && (b.WhiteSpace != CssConstants.PreWrap || !word.IsSpaces)
+                         && (b.WhiteSpace != CssConstants.PreLine || !word.IsSpaces)) || word.IsLineBreak || wrapNoWrapBox)
+                    {
+                        wrapNoWrapBox = false;
+                        curx = startx;
+
+                        // handle if line is wrapped for the first text element where parent has left margin\padding
+                        if (b == box.Boxes[0] && !word.IsLineBreak && (word == b.Words[0] || (box.ParentBox != null && box.ParentBox.IsBlock)))
+                            curx += box.ActualMarginLeft + box.ActualBorderLeftWidth + box.ActualPaddingLeft;
+
+                        cury = maxbottom + linespacing;
+
+                        line = new CssLineBox(blockbox);
+
+                        if (word.IsImage || word.Equals(b.FirstWord))
+                            curx += leftspacing;
+                    }
+
+                    line.ReportExistanceOf(word);
+
+                    word.Left = curx;
+
+                    // CSS2.1 §10.8.1: Replaced inline elements (images) are
+                    // baseline-aligned by default — the bottom of the replaced
+                    // element sits on the baseline.  The baseline position
+                    // within the strut is at the font's ascent from the top.
+                    if (word.IsImage && strutHeight > word.Height)
+                    {
+                        double fontHeight = blockbox.ActualFont.Height * PtToCssPx;
+                        double baseline = fontHeight * TypicalAscentRatio;
+                        word.Top = Math.Max(cury, cury + baseline - word.Height);
+                    }
+                    else
+                    {
+                        word.Top = cury;
+                    }
+
+                    if (!box.IsFixed)
+                    {
+                        word.BreakPage();
+                    }
+
+                    curx = word.Left + word.FullWidth;
+
+                    maxRight = Math.Max(maxRight, word.Right);
+                    maxbottom = Math.Max(maxbottom, InlineWordLineBoxBottom(word));
+
+                    if (b.Position == CssConstants.Absolute)
+                    {
+                        word.Left += box.ActualMarginLeft;
+                        word.Top += box.ActualMarginTop;
+                    }
+                }
+            }
+            else
+            {
+                // Determine if this child should use inline-block sizing:
+                // 1. Explicit display:inline-block
+                // 2. display:inline-flex / inline-grid (inline-level flex/grid)
+                // 3. Direct child of a flex/grid container (all children
+                //    become flex/grid items with shrink-to-fit sizing per
+                //    CSS Flexbox §4 / CSS Grid §6; since Broiler lacks a
+                //    true flex/grid engine, use FlowInlineBlock as a
+                //    reasonable approximation)
+                bool useInlineBlockFlow = b.Display == CssConstants.InlineBlock
+                    || b.Display is "inline-flex" or "inline-grid"
+                    || box.Display is "flex" or "inline-flex" or "grid" or "inline-grid";
+
+                if (useInlineBlockFlow)
+                {
+                    // CSS 2.1 §10.3.9/§10.6.6: Inline-block boxes are laid
+                    // out as blocks internally, then placed atomically in
+                    // the inline flow (like replaced inline elements).
+                    FlowInlineBlock(g, blockbox, b, limitRight, linespacing, startx,
+                        leftspacing, rightspacing,
+                        ref line, ref curx, ref cury, ref maxRight, ref maxbottom);
+
+                    // CSS Flexbox §9.4: flex-direction:column stacks items
+                    // vertically — force a line break after each flex item so
+                    // the next item starts on a new row.
+                    if (box.Display is "flex" or "inline-flex" or "grid" or "inline-grid"
+                        && box.FlexDirection is "column" or "column-reverse")
+                    {
+                        cury = maxbottom;
+                        curx = startx;
+                        line = new CssLineBox(blockbox);
+                    }
+                }
+                else
+                {
+                    // Block-level child inside inline flow: force a line break
+                    // before and after the block (CSS2.1 §9.2.1.1 anonymous
+                    // block boxes).  This ensures elements like <p> inside an
+                    // inline <form> start on their own line.
+                    //
+                    // CSS2.1 §10.3.7/§10.6.4: An out-of-flow positioned child
+                    // is laid out here only to establish its *static position*
+                    // — the place a hypothetical inline box would occupy had
+                    // the element been in flow.  It must therefore be placed at
+                    // the current inline cursor, NOT forced onto its own line.
+                    // (The surrounding flow state is restored after the child,
+                    // so this break would be discarded anyway, but skipping it
+                    // keeps the static position on the current line.)
+                    if (b.IsBlock && !isAbsposChild)
+                    {
+                        if (curx > startx || maxbottom > cury)
+                        {
+                            cury = maxbottom;
+                            curx = startx;
+                            line = new CssLineBox(blockbox);
+                        }
+                    }
+
+                    FlowBox(g, blockbox, b, limitRight, linespacing, startx, ref line, ref curx, ref cury, ref maxRight, ref maxbottom);
+
+                    if (b.IsBlock && !isAbsposChild)
+                    {
+                        cury = maxbottom;
+                        curx = startx;
+                        line = new CssLineBox(blockbox);
+                    }
+                }
+            }
+
+            curx += rightspacing;
+
+            // CSS2.1 §9.6.1: Restore flow state after an absolutely/fixed
+            // positioned child so it does not affect siblings or parent
+            // content height.  This includes the current line (`line`) and
+            // block-axis cursor (`cury`): a block-level out-of-flow child
+            // triggers the block line-break logic above to establish its
+            // static position, but that break must not push subsequent
+            // in-flow inline siblings onto a new line.
+            if (isAbsposChild)
+            {
+                curx = childSaveCurx;
+                cury = childSaveCury;
+                maxRight = childSaveMaxRight;
+                maxbottom = childSaveMaxBottom;
+                line = childSaveLine;
+            }
+        }
+
+        // handle height setting
+        if (maxbottom - startY < box.ActualHeight)
+            maxbottom += box.ActualHeight - (maxbottom - startY);
+
+        // handle width setting
+        // CSS 2.1 §10.3.9: inline-block boxes handle their own sizing in
+        // FlowInlineBlock — do not register them here when processing
+        // their own internal content (box == blockbox).
+        if (box.IsInline && box != blockbox && 0 <= curx - startX && curx - startX < box.ActualWidth)
+        {
+            // hack for actual width handling
+            curx += box.ActualWidth - (curx - startX);
+            line.Rectangles.Add(box, new RectangleF((float)startX, (float)startY, (float)box.ActualWidth, (float)box.ActualHeight));
+        }
+
+        // handle box that is only a whitespace
+        if (box.Text.Length > 0 && box.Text.Span.IsWhiteSpace() && !box.IsImage && box.IsInline && box.Boxes.Count == 0 && box.Words.Count == 0)
+            curx += box.ActualWordSpacing;
+
+        // hack to support specific absolute position elements
+        if (box.Position == CssConstants.Absolute)
+        {
+            curx = localCurx;
+            maxRight = localMaxRight;
+            maxbottom = localmaxbottom;
+            AdjustAbsolutePosition(box, 0, 0);
+        }
+
+        box.LastHostingLineBox = line;
+    }
+
+    /// <summary>
+    /// CSS 2.1 §10.3.9 / §10.6.6: Lay out an inline-block box as a
+    /// block internally, then place it atomically in the inline flow.
+    /// The inline-block establishes a new block formatting context for
+    /// its children while participating in the parent's inline
+    /// formatting context as a single opaque box.
+    /// </summary>
+    private static void FlowInlineBlock(ILayoutEnvironment g, CssBox blockbox, CssBox b,
+        double limitRight, double linespacing, double startx,
+        double leftspacing, double rightspacing,
+        ref CssLineBox line, ref double curx, ref double cury,
+        ref double maxRight, ref double maxbottom)
+    {
+        // Compute the container content width for resolving percentage and
+        // em-based lengths on the inline-block.
+        double containerWidth = blockbox.Size.Width
+            - blockbox.ActualPaddingLeft - blockbox.ActualPaddingRight
+            - blockbox.ActualBorderLeftWidth - blockbox.ActualBorderRightWidth;
+
+        // --- Compute inline-block content width ---
+        double ibContentWidth;
+        if (b.Width != CssConstants.Auto && !string.IsNullOrEmpty(b.Width))
+        {
+            ibContentWidth = CssValueParser.ParseLength(b.Width, containerWidth, b.GetEmHeight());
+            if (b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase))
+            {
+                ibContentWidth -= b.ActualBorderLeftWidth + b.ActualBorderRightWidth
+                    + b.ActualPaddingLeft + b.ActualPaddingRight;
+                if (ibContentWidth < 0)
+                    ibContentWidth = 0;
+            }
+        }
+        else
+        {
+            // CSS 2.1 §10.3.9: auto-width inline-block uses shrink-to-fit.
+            // Measure descendant words for intrinsic width computation.
+            MeasureDescendantWords(g, b);
+            b.GetMinMaxWidth(out double prefMin, out double prefMax);
+            if (double.IsNaN(prefMin)) prefMin = 0;
+            if (double.IsNaN(prefMax)) prefMax = 0;
+            // GetMinMaxWidth returns border-box widths (content + padding +
+            // border).  Convert to content-only widths so the shrink-to-fit
+            // calculation matches the content-only `available` value and the
+            // padding/border added back at ibBoxWidth below.
+            double ownPaddingBorder = b.ActualBorderLeftWidth + b.ActualBorderRightWidth
+                + b.ActualPaddingLeft + b.ActualPaddingRight;
+            prefMin = Math.Max(0, prefMin - ownPaddingBorder);
+            prefMax = Math.Max(0, prefMax - ownPaddingBorder);
+            double available = Math.Max(0, limitRight - curx - rightspacing
+                - b.ActualBorderLeftWidth - b.ActualBorderRightWidth
+                - b.ActualPaddingLeft - b.ActualPaddingRight);
+            ibContentWidth = Math.Min(Math.Max(prefMin, available), prefMax);
+        }
+
+        // CSS 2.1 §10.4: Apply min-width constraint.
+        // min-width takes priority over computed width (including
+        // shrink-to-fit for auto-width inline-blocks).
+        if (b.MinWidth != "0" && !string.IsNullOrEmpty(b.MinWidth))
+        {
+            double minW = CssValueParser.ParseLength(b.MinWidth, containerWidth, b.GetEmHeight());
+            double minContentW = b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase)
+                ? minW - b.ActualBorderLeftWidth - b.ActualBorderRightWidth
+                    - b.ActualPaddingLeft - b.ActualPaddingRight
+                : minW;
+            if (minContentW > ibContentWidth)
+                ibContentWidth = minContentW;
+        }
+
+        // CSS 2.1 §10.4: Apply max-width constraint.
+        // max-width limits the computed width from above.  When both
+        // min-width and max-width are specified, min-width wins if it
+        // exceeds max-width (CSS2.1 §10.4).
+        if (b.MaxWidth != "none" && !string.IsNullOrEmpty(b.MaxWidth))
+        {
+            double maxW = CssValueParser.ParseLength(b.MaxWidth, containerWidth, b.GetEmHeight());
+            double maxContentW = b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase)
+                ? maxW - b.ActualBorderLeftWidth - b.ActualBorderRightWidth
+                    - b.ActualPaddingLeft - b.ActualPaddingRight
+                : maxW;
+            if (maxContentW < ibContentWidth)
+                ibContentWidth = maxContentW;
+        }
+
+        double ibBoxWidth = ibContentWidth
+            + b.ActualBorderLeftWidth + b.ActualBorderRightWidth
+            + b.ActualPaddingLeft + b.ActualPaddingRight;
+
+        // --- Line wrap check ---
+        // Total inline extent: margin-left + box-width + margin-right.
+        // curx already includes leftspacing (margin+border+padding), so the
+        // border-box left edge is at curx - border - padding.
+        double ibBorderLeft = curx - b.ActualBorderLeftWidth - b.ActualPaddingLeft;
+        double edgeBeforeBox = ibBorderLeft - b.ActualMarginLeft;
+        double totalExtent = b.ActualMarginLeft + ibBoxWidth + b.ActualMarginRight;
+        if (edgeBeforeBox + totalExtent > limitRight && edgeBeforeBox > startx)
+        {
+            double lineStrut = blockbox.ActualLineHeight > 0
+                ? blockbox.ActualLineHeight
+                : blockbox.ActualFont.Height * PtToCssPx;
+            double baselineDescent = lineStrut * (1.0 - TypicalAscentRatio);
+
+            curx = startx + leftspacing;
+            cury = maxbottom + linespacing + baselineDescent;
+            line = new CssLineBox(blockbox);
+            ibBorderLeft = curx - b.ActualBorderLeftWidth - b.ActualPaddingLeft;
+        }
+
+        // --- Position and size the inline-block ---
+        b.Location = new PointF((float)ibBorderLeft, (float)(cury + b.ActualMarginTop));
+        b.Size = new SizeF((float)ibBoxWidth, 0);
+        b.ActualBottom = b.Location.Y;
+
+        // --- Lay out children inside the inline-block ---
+        if (b.Display == "flex" && b.IsRowFlexContainer() && HasBlockLevelFlexItems(b))
+        {
+            b.PerformFlexRowLayout(g);
+        }
+        else if (b.Display is "grid" or "inline-grid")
+        {
+            // CSS Grid Level 1: Grid items should be laid out as blocks
+            // (not inline-blocks) so that width:auto stretches to the
+            // column width.  Use the block layout path, then apply grid
+            // stacking or auto-placement to fix positioning.
+            foreach (var child in b.Boxes)
+                child.PerformLayout(g);
+
+            double childMaxBottom = b.Location.Y;
+            foreach (var child in b.Boxes)
+                childMaxBottom = Math.Max(childMaxBottom, child.ActualBottom);
+            b.ActualBottom = childMaxBottom;
+
+            b.ApplyGridLayoutAfterInline();
+        }
+        else if (LayoutBoxUtils.ContainsInlinesOnly(b))
+        {
+            CreateLineBoxes(g, b);
+        }
+        else if (b.Boxes.Count > 0)
+        {
+            foreach (var child in b.Boxes)
+                child.PerformLayout(g);
+
+            double childMaxBottom = b.Location.Y;
+            foreach (var child in b.Boxes)
+                childMaxBottom = Math.Max(childMaxBottom, child.ActualBottom);
+            b.ActualBottom = childMaxBottom;
+        }
+
+        // --- Compute height ---
+        double ibHeight;
+        if (b.Height != CssConstants.Auto && !string.IsNullOrEmpty(b.Height))
+        {
+            double cssHeight = CssValueParser.ParseLength(b.Height, containerWidth, b.GetEmHeight());
+            ibHeight = b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase)
+                ? cssHeight
+                : cssHeight
+                    + b.ActualBorderTopWidth + b.ActualBorderBottomWidth
+                    + b.ActualPaddingTop + b.ActualPaddingBottom;
+        }
+        else
+        {
+            ibHeight = Math.Max(0, b.ActualBottom - b.Location.Y);
+        }
+
+        // CSS 2.1 §10.7: Apply min-height constraint for inline-blocks.
+        if (b.MinHeight != "0" && !string.IsNullOrEmpty(b.MinHeight))
+        {
+            double minH = CssValueParser.ParseLength(b.MinHeight, containerWidth, b.GetEmHeight());
+            double minBoxH = b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase)
+                ? minH
+                : minH
+                    + b.ActualBorderTopWidth + b.ActualBorderBottomWidth
+                    + b.ActualPaddingTop + b.ActualPaddingBottom;
+            if (minBoxH > ibHeight)
+                ibHeight = minBoxH;
+        }
+
+        b.ActualBottom = b.Location.Y + ibHeight;
+        b.Size = new SizeF(b.Size.Width, (float)ibHeight);
+
+        // --- Register the inline-block as a rectangle in the line box ---
+        line.Rectangles[b] = new RectangleF(b.Location.X, b.Location.Y,
+            (float)ibBoxWidth, (float)ibHeight);
+
+        // --- Advance flow position ---
+        // curx has leftspacing (margin+border+padding) already added.
+        // After the inline-block, set curx so that after rightspacing
+        // (margin+border+padding right) is added, we end up at the
+        // right margin edge of the box.
+        curx = ibBorderLeft + ibBoxWidth
+            - b.ActualBorderRightWidth - b.ActualPaddingRight;
+
+        maxRight = Math.Max(maxRight, ibBorderLeft + ibBoxWidth);
+        maxbottom = Math.Max(maxbottom, b.ActualBottom + b.ActualMarginBottom);
+    }
+
+    private static bool HasBlockLevelFlexItems(CssBox box)
+    {
+        foreach (var child in box.Boxes)
+        {
+            if (child.Display == CssConstants.None)
+                continue;
+            if (child.Position is CssConstants.Absolute or CssConstants.Fixed)
+                continue;
+            if (!child.IsInline)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Recursively measures word sizes on all descendant boxes so that
+    /// intrinsic width calculations are reliable.
+    /// </summary>
+    private static void MeasureDescendantWords(ILayoutEnvironment g, CssBox box)
+    {
+        box.MeasureWordsSize(g);
+        foreach (var child in box.Boxes)
+            MeasureDescendantWords(g, child);
+    }
+
+    private static void AdjustAbsolutePosition(CssBox box, double left, double top)
+    {
+        left += box.ActualMarginLeft;
+        top += box.ActualMarginTop;
+
+        // CSS 2.1 §9.3.2: Apply 'top' and 'left' offsets for absolutely
+        // positioned elements.
+        if (box.Top != CssConstants.Auto && !string.IsNullOrEmpty(box.Top))
+        {
+            double topOffset = CssValueParser.ParseLength(box.Top, box.Size.Height, box.GetEmHeight());
+            if (!double.IsNaN(topOffset))
+                top += topOffset;
+        }
+        if (box.Left != CssConstants.Auto && !string.IsNullOrEmpty(box.Left))
+        {
+            double leftOffset = CssValueParser.ParseLength(box.Left, box.Size.Width, box.GetEmHeight());
+            if (!double.IsNaN(leftOffset))
+                left += leftOffset;
+        }
+
+        if (box.Words.Count > 0)
+        {
+            foreach (var word in box.Words)
+            {
+                word.Left += left;
+                word.Top += top;
+            }
+        }
+        else
+        {
+            foreach (var b in box.Boxes)
+                AdjustAbsolutePosition(b, left, top);
+        }
+    }
+
+    private static void BubbleRectangles(CssBox box, CssLineBox line)
+    {
+        if (box.Words.Count > 0)
+        {
+            double x = float.MaxValue, y = float.MaxValue, r = float.MinValue, b = float.MinValue;
+            List<CssRect> words = line.WordsOf(box);
+
+            if (words.Count <= 0)
+                return;
+
+            foreach (CssRect word in words)
+            {
+                // handle if line is wrapped for the first text element where parent has left margin\padding
+                var left = word.Left;
+
+                if (box == box.ParentBox.Boxes[0] && word == box.Words[0] && word == line.Words[0] && line != line.OwnerBox.LineBoxes[0] && !word.IsLineBreak)
+                    left -= box.ParentBox.ActualMarginLeft + box.ParentBox.ActualBorderLeftWidth + box.ParentBox.ActualPaddingLeft;
+
+
+                x = Math.Min(x, left);
+                r = Math.Max(r, word.Right);
+                y = Math.Min(y, word.Top);
+                b = Math.Max(b, word.Bottom);
+            }
+
+            line.UpdateRectangle(box, x, y, r, b);
+        }
+        else
+        {
+            foreach (CssBox b in box.Boxes)
+                BubbleRectangles(b, line);
+        }
+    }
+
+    private static void ApplyHorizontalAlignment(ILayoutEnvironment g, CssLineBox lineBox, bool lineRtl)
+    {
+        var box = lineBox.OwnerBox;
+
+        // Resolve the logical 'start'/'end' keywords (and the initial value, which
+        // is 'start') against the line's base direction.  In a left-to-right base,
+        // start=left and end=right; in a right-to-left base they swap.  Physical
+        // 'left'/'right'/'center'/'justify' values pass through unchanged.  Under
+        // unicode-bidi:plaintext the base is the per-line resolved direction; this
+        // is what keeps right-to-left lines aligned to the right edge and, without
+        // it, an RTL box left its 'start'-aligned text on the left (CSS Text
+        // §text-align).
+        string resolvedAlign = box.TextAlign switch
+        {
+            null or "" or "start" => lineRtl ? CssConstants.Right : CssConstants.Left,
+            "end" => lineRtl ? CssConstants.Left : CssConstants.Right,
+            _ => box.TextAlign
+        };
+
+        switch (resolvedAlign)
+        {
+            case CssConstants.Right:
+                ApplyRightAlignment(g, lineBox);
+                break;
+            case CssConstants.Center:
+                ApplyCenterAlignment(g, lineBox);
+                break;
+            case CssConstants.Justify:
+                ApplyJustifyAlignment(g, lineBox);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Returns the line's base direction as resolved from its first strong
+    /// (Hebrew/Arabic vs. Latin/Greek/Cyrillic) character: <c>true</c> for
+    /// right-to-left, <c>false</c> for left-to-right, or <c>null</c> when the line
+    /// has no strong character (so the caller inherits the previous paragraph's or
+    /// the containing block's direction).  Used for <c>unicode-bidi: plaintext</c>.
+    /// </summary>
+    private static bool? LineFirstStrongRtl(CssLineBox line)
+    {
+        foreach (CssRect word in line.Words)
+        {
+            string text = word.Text;
+            if (string.IsNullOrEmpty(text))
+                continue;
+            foreach (char c in text)
+            {
+                if (IsRtlStrongChar(c))
+                    return true;
+                if (IsLtrStrongChar(c))
+                    return false;
+            }
+        }
+        return null; // no strong character → inherit base direction
+    }
+
+    /// <summary>
+    /// Seeds the running base direction for a <c>unicode-bidi: plaintext</c> block
+    /// whose first paragraph has no strong character of its own.  Such a paragraph
+    /// inherits the previous paragraph's direction; because neutral paragraphs
+    /// propagate that direction forward, the result equals the direction of the most
+    /// recent strong character that appears before this block in document order.
+    /// Falls back to the block's own direction when no preceding strong character
+    /// exists (i.e. the containing block's direction).
+    /// </summary>
+    private static bool SeedPlaintextBaseRtl(CssBox blockBox)
+    {
+        var parent = blockBox.ParentBox;
+        if (parent != null)
+        {
+            int index = parent.Boxes.IndexOf(blockBox);
+            for (int i = index - 1; i >= 0; i--)
+            {
+                bool? strong = LastStrongRtl(parent.Boxes[i]);
+                if (strong.HasValue)
+                    return strong.Value;
+            }
+        }
+        return blockBox.Direction == CssConstants.Rtl;
+    }
+
+    /// <summary>
+    /// Returns the direction of the last strong character within <paramref name="box"/>'s
+    /// subtree in document order (<c>true</c> RTL, <c>false</c> LTR), or <c>null</c>
+    /// when the subtree has no strong character.
+    /// </summary>
+    private static bool? LastStrongRtl(CssBox box)
+    {
+        for (int i = box.Boxes.Count - 1; i >= 0; i--)
+        {
+            bool? strong = LastStrongRtl(box.Boxes[i]);
+            if (strong.HasValue)
+                return strong;
+        }
+
+        for (int i = box.Words.Count - 1; i >= 0; i--)
+        {
+            string text = box.Words[i].Text;
+            if (string.IsNullOrEmpty(text))
+                continue;
+            for (int c = text.Length - 1; c >= 0; c--)
+            {
+                if (IsRtlStrongChar(text[c]))
+                    return true;
+                if (IsLtrStrongChar(text[c]))
+                    return false;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsRtlStrongChar(char c) =>
+        (c >= 0x0590 && c <= 0x05FF) ||   // Hebrew
+        (c >= 0x0600 && c <= 0x06FF) ||   // Arabic
+        (c >= 0x0750 && c <= 0x077F) ||   // Arabic Supplement
+        (c >= 0x08A0 && c <= 0x08FF) ||   // Arabic Extended-A
+        (c >= 0xFB1D && c <= 0xFDFF) ||   // Hebrew/Arabic presentation forms-A
+        (c >= 0xFE70 && c <= 0xFEFF);     // Arabic presentation forms-B
+
+    private static bool IsLtrStrongChar(char c) =>
+        (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+        (c >= 0x00C0 && c <= 0x024F) ||   // Latin-1 supplement / extended
+        (c >= 0x0370 && c <= 0x03FF) ||   // Greek
+        (c >= 0x0400 && c <= 0x04FF);     // Cyrillic
+
+    private static void ApplyRightToLeft(CssLineBox lineBox, bool lineRtl)
+    {
+        // When the line's base direction is right-to-left the whole line is
+        // mirrored; otherwise only the individual inline boxes that opt into RTL
+        // are reversed.  Under unicode-bidi:plaintext 'lineRtl' is the per-line
+        // resolved direction, so left-to-right lines inside an RTL block stay on
+        // the left instead of being mirrored to the right edge.
+        if (lineRtl)
+        {
+            ApplyRightToLeftOnLine(lineBox);
+        }
+        else
+        {
+            foreach (var box in lineBox.RelatedBoxes)
+            {
+                if (box.Direction == CssConstants.Rtl)
+                    ApplyRightToLeftOnSingleBox(lineBox, box);
+            }
+        }
+    }
+
+    private static void ApplyRightToLeftOnLine(CssLineBox line)
+    {
+        if (line.Words.Count <= 0)
+            return;
+
+        double left = line.Words[0].Left;
+        double right = line.Words[line.Words.Count - 1].Right;
+
+        foreach (CssRect word in line.Words)
+        {
+            double diff = word.Left - left;
+            double wright = right - diff;
+
+            word.Left = wright - word.Width;
+        }
+    }
+
+    private static void ApplyRightToLeftOnSingleBox(CssLineBox lineBox, CssBox box)
+    {
+        int leftWordIdx = -1;
+        int rightWordIdx = -1;
+
+        for (int i = 0; i < lineBox.Words.Count; i++)
+        {
+            if (lineBox.Words[i].OwnerBox != box)
+                continue;
+
+            if (leftWordIdx < 0)
+                leftWordIdx = i;
+
+            rightWordIdx = i;
+        }
+
+        if (leftWordIdx <= -1 || rightWordIdx <= leftWordIdx)
+            return;
+
+        double left = lineBox.Words[leftWordIdx].Left;
+        double right = lineBox.Words[rightWordIdx].Right;
+
+        for (int i = leftWordIdx; i <= rightWordIdx; i++)
+        {
+            double diff = lineBox.Words[i].Left - left;
+            double wright = right - diff;
+
+            lineBox.Words[i].Left = wright - lineBox.Words[i].Width;
+        }
+    }
+
+    /// <summary>
+    /// CSS 2.1 §10.8: A text run contributes its inline box's <em>line-height</em>
+    /// to the line box (and hence the block's content height), not its taller
+    /// font content area.  When <c>line-height</c> is smaller than the content
+    /// area the glyphs overflow the line box, but they must not increase it —
+    /// otherwise an explicit small <c>line-height</c> (e.g. <c>line-height:1</c>
+    /// on a font whose natural box is ~1.16em) produces a too-tall block.
+    /// The glyph rectangle itself is left untouched, so glyph positions (and
+    /// calibrated layouts) are unchanged; only the height contribution is
+    /// clamped.  Replaced inline content (images) and runs with no positive
+    /// line-height keep contributing their full box.
+    /// </summary>
+    private static double InlineWordLineBoxBottom(CssRect word)
+    {
+        double ownerLineHeight = word.OwnerBox?.ActualLineHeight ?? 0;
+        if (word.IsImage || ownerLineHeight <= 0)
+            return word.Bottom;
+
+        return Math.Min(word.Bottom, word.Top + ownerLineHeight);
+    }
+
+    /// <summary>
+    /// Same line-height clamp as <see cref="InlineWordLineBoxBottom"/> but for a
+    /// non-atomic inline box's accumulated rectangle.  Inline boxes (incl. the
+    /// anonymous inline box that wraps a block's direct text) contribute their
+    /// line-height to the line box, not their font content area.  Replaced
+    /// inline content (images) and inline-block boxes keep their full margin
+    /// box, which legitimately establishes the line box extent.
+    /// </summary>
+    private static double InlineRectLineBoxBottom(CssBox box, RectangleF rect)
+    {
+        if (box.IsImage
+            || box.Display == CssConstants.InlineBlock
+            || box.Display is "inline-flex" or "inline-grid"
+            || !box.IsInline)
+            return rect.Bottom;
+
+        double lineHeight = box.ActualLineHeight;
+        if (lineHeight <= 0)
+            return rect.Bottom;
+
+        return Math.Min(rect.Bottom, rect.Top + lineHeight);
+    }
+
+    private static void ApplyVerticalAlignment(ILayoutEnvironment g, CssLineBox lineBox)
+    {
+        // CSS 2.1 §10.8: The baseline is where text sits, approximated as
+        // the top of each box plus the font ascent. Most Latin fonts have
+        // an ascent/height ratio near 0.8 (e.g. OS/2 sTypoAscender is
+        // typically ~80% of UPM). This matches common browser heuristics.
+        const double TypicalAscentRatio = 0.8;
+
+        // CSS2.1 §10.8.1: Boxes with vertical-align:top or bottom do not
+        // contribute to the initial line box height calculation.  Collect
+        // them for a second positioning pass.
+        var topBottomBoxes = new HashSet<CssBox>();
+        foreach (var box in lineBox.Rectangles.Keys)
+        {
+            if (box.VerticalAlign == CssConstants.Top
+                || box.VerticalAlign == CssConstants.Bottom)
+                topBottomBoxes.Add(box);
+        }
+
+        // CSS2.1 §10.8: The "strut" — an imaginary zero-width inline box
+        // with the block container's font and line-height — establishes
+        // the initial baseline of the line box.  This is critical when the
+        // parent has font-size: 0 (e.g. .buckets { font: 0/0 }): the strut
+        // baseline is at the top of the content area and must not be
+        // overridden by child inline-block font metrics.
+        double lineTop = double.MaxValue;
+        foreach (var kvp in lineBox.Rectangles)
+        {
+            if (!topBottomBoxes.Contains(kvp.Key))
+                lineTop = Math.Min(lineTop, kvp.Value.Top);
+        }
+
+        // Start with the strut baseline (parent's font ascent from line top).
+        double parentFontHeight = (lineBox.OwnerBox?.ActualFont.Height ?? 0) * PtToCssPx;
+        double baseline = (lineTop < double.MaxValue)
+            ? lineTop + parentFontHeight * TypicalAscentRatio
+            : float.MinValue;
+
+        // Non-inline-block boxes also contribute to the baseline.
+        foreach (var box in lineBox.Rectangles.Keys)
+        {
+            if (box.Display != CssConstants.InlineBlock && !topBottomBoxes.Contains(box))
+            {
+                double boxBaseline = lineBox.Rectangles[box].Top
+                    + box.ActualFont.Height * PtToCssPx * TypicalAscentRatio;
+                baseline = Math.Max(baseline, boxBaseline);
+            }
+        }
+
+        // --- Phase 1: Position all non-top/bottom boxes ---
+
+        var boxes = new List<CssBox>(lineBox.Rectangles.Keys);
+        foreach (CssBox box in boxes)
+        {
+            if (topBottomBoxes.Contains(box))
+                continue;
+
+            // For inline text boxes, SetBaseLine receives the desired
+            // word-top position, so baseline-relative values must be
+            // converted from baseline Y to word-top Y by subtracting
+            // the box's ascent.
+            //
+            // For inline-block boxes, CSS 2.1 §10.8.1: the baseline of
+            // an inline-block with no in-flow line boxes is the bottom
+            // margin edge.  SetBaseLine positions the box by its top, so
+            // we must subtract the box height to convert from the desired
+            // bottom-edge position to the top-edge position.
+            bool isInlineBlock = box.Display == CssConstants.InlineBlock;
+            double boxAscent = isInlineBlock
+                ? lineBox.Rectangles[box].Height
+                : box.ActualFont.Height * PtToCssPx * TypicalAscentRatio;
+
+            //Important notes on http://www.w3.org/TR/CSS21/tables.html#height-layout
+            switch (box.VerticalAlign)
+            {
+                case CssConstants.Sub:
+                    lineBox.SetBaseLine(g, box, baseline - boxAscent + lineBox.Rectangles[box].Height * .5f);
+                    break;
+                case CssConstants.Super:
+                    lineBox.SetBaseLine(g, box, baseline - boxAscent - lineBox.Rectangles[box].Height * .2f);
+                    break;
+                case CssConstants.TextTop:
+                    // CSS 2.1 §10.8.1: Align the top of the box with the
+                    // top of the parent element's content area (font top).
+                    if (baseline > float.MinValue)
+                    {
+                        double parentContentTop = baseline - parentFontHeight * TypicalAscentRatio;
+                        lineBox.SetBaseLine(g, box, parentContentTop);
+                    }
+                    break;
+                case CssConstants.TextBottom:
+                    // CSS 2.1 §10.8.1: Align the bottom of the box with the
+                    // bottom of the parent element's content area (font bottom).
+                    if (baseline > float.MinValue && lineBox.Rectangles.ContainsKey(box))
+                    {
+                        double boxHeight = lineBox.Rectangles[box].Height;
+                        double parentContentBottom = baseline + parentFontHeight * (1.0 - TypicalAscentRatio);
+                        lineBox.SetBaseLine(g, box, parentContentBottom - boxHeight);
+                    }
+                    break;
+                case CssConstants.Middle:
+                    // CSS 2.1 §10.8.1: Align the vertical midpoint of the box
+                    // with the baseline plus half the x-height of the parent.
+                    // x-height ≈ 0.5 × font height for Latin fonts; half of
+                    // that is 0.25 × font height.
+                    if (lineBox.Rectangles.ContainsKey(box) && baseline > float.MinValue)
+                    {
+                        double boxHeight = lineBox.Rectangles[box].Height;
+                        double parentFont = (box.ParentBox?.ActualFont.Height ?? 0) * PtToCssPx;
+                        double halfXHeight = parentFont * 0.25;
+                        lineBox.SetBaseLine(g, box, baseline + halfXHeight - boxHeight / 2);
+                    }
+                    break;
+                default:
+                    // CSS 2.1 §10.8.1: A <length> or <percentage> value
+                    // raises (positive) or lowers (negative) the box by
+                    // the given distance relative to the baseline.
+                    // A percentage is calculated against the line-height
+                    // of the element itself.
+                    if (box.VerticalAlign != CssConstants.Baseline
+                        && !string.IsNullOrEmpty(box.VerticalAlign))
+                    {
+                        double lineHeight = box.ActualLineHeight > 0
+                            ? box.ActualLineHeight
+                            : box.ActualFont.Height * PtToCssPx;
+                        double offset = CssValueParser.ParseLength(
+                            box.VerticalAlign, lineHeight, box.GetEmHeight());
+                        if (!double.IsNaN(offset) && offset != 0)
+                        {
+                            // Positive values move the box UP (raise).
+                            lineBox.SetBaseLine(g, box, baseline - boxAscent - offset);
+                            break;
+                        }
+                    }
+                    //case: baseline
+                    lineBox.SetBaseLine(g, box, baseline - boxAscent);
+                    break;
+            }
+        }
+
+        // --- Phase 2: Position top/bottom-aligned boxes ---
+        // CSS 2.1 §10.8.1: After all other boxes are positioned, compute
+        // the final line box extent and align top/bottom boxes within it.
+        if (topBottomBoxes.Count > 0)
+        {
+            double finalTop = double.MaxValue;
+            double finalBottom = double.MinValue;
+            foreach (var kvp in lineBox.Rectangles)
+            {
+                if (!topBottomBoxes.Contains(kvp.Key))
+                {
+                    finalTop = Math.Min(finalTop, kvp.Value.Top);
+                    finalBottom = Math.Max(finalBottom, kvp.Value.Bottom);
+                }
+            }
+
+            // Also consider word positions for the final line box bounds.
+            foreach (var word in lineBox.Words)
+            {
+                if (!topBottomBoxes.Contains(word.OwnerBox))
+                {
+                    finalTop = Math.Min(finalTop, word.Top);
+                    finalBottom = Math.Max(finalBottom, word.Bottom);
+                }
+            }
+
+            foreach (CssBox box in boxes)
+            {
+                if (!topBottomBoxes.Contains(box))
+                    continue;
+
+                if (box.VerticalAlign == CssConstants.Top)
+                {
+                    if (finalTop < double.MaxValue)
+                        lineBox.SetBaseLine(g, box, finalTop);
+                }
+                else // Bottom
+                {
+                    if (finalBottom > double.MinValue && lineBox.Rectangles.ContainsKey(box))
+                    {
+                        double boxHeight = lineBox.Rectangles[box].Height;
+                        lineBox.SetBaseLine(g, box, finalBottom - boxHeight);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void ApplyJustifyAlignment(ILayoutEnvironment g, CssLineBox lineBox)
+    {
+        if (lineBox.Equals(lineBox.OwnerBox.LineBoxes[lineBox.OwnerBox.LineBoxes.Count - 1]))
+            return;
+
+        double indent = lineBox.Equals(lineBox.OwnerBox.LineBoxes[0]) ? lineBox.OwnerBox.ActualTextIndent : 0f;
+        double textSum = 0f;
+        double words = 0f;
+        double availWidth = lineBox.OwnerBox.ClientRectangle.Width - indent;
+
+        // Gather text sum
+        foreach (CssRect w in lineBox.Words)
+        {
+            textSum += w.Width;
+            words += 1f;
+        }
+
+        if (words <= 0f)
+            return; //Avoid Zero division
+
+        double spacing = (availWidth - textSum) / words; //Spacing that will be used
+        double curx = lineBox.OwnerBox.ClientLeft + indent;
+
+        foreach (CssRect word in lineBox.Words)
+        {
+            word.Left = curx;
+            curx = word.Right + spacing;
+
+            if (word == lineBox.Words[lineBox.Words.Count - 1])
+                word.Left = lineBox.OwnerBox.ClientRight - word.Width;
+        }
+    }
+
+    private static void ApplyCenterAlignment(ILayoutEnvironment g, CssLineBox line)
+    {
+        if (line.Words.Count == 0 && line.Rectangles.Count == 0)
+            return;
+
+        double right = line.OwnerBox.ActualRight - line.OwnerBox.ActualPaddingRight - line.OwnerBox.ActualBorderRightWidth;
+
+        // Find the rightmost content edge from both words and inline-block rectangles.
+        // Lines may contain only inline-block elements (e.g. form controls inside
+        // <center>) with no direct text words.
+        double contentRight = 0;
+        if (line.Words.Count > 0)
+        {
+            CssRect lastWord = line.Words[line.Words.Count - 1];
+            contentRight = lastWord.Right + lastWord.OwnerBox.ActualBorderRightWidth + lastWord.OwnerBox.ActualPaddingRight;
+        }
+
+        foreach (var kvp in line.Rectangles)
+        {
+            if (kvp.Value.Right > contentRight)
+                contentRight = kvp.Value.Right;
+        }
+
+        double diff = (right - contentRight) / 2;
+
+        if (diff <= 0)
+            return;
+
+        foreach (CssRect word in line.Words)
+            word.Left += diff;
+
+        foreach (CssBox b in ToList(line.Rectangles.Keys))
+        {
+            RectangleF r = line.Rectangles[b];
+            line.Rectangles[b] = new RectangleF((float)(r.X + diff), r.Y, r.Width, r.Height);
+            ShiftInlineBlockBox(b, diff);
+        }
+    }
+
+    private static void ApplyRightAlignment(ILayoutEnvironment g, CssLineBox line)
+    {
+        if (line.Words.Count == 0 && line.Rectangles.Count == 0)
+            return;
+
+        double right = line.OwnerBox.ActualRight - line.OwnerBox.ActualPaddingRight - line.OwnerBox.ActualBorderRightWidth;
+
+        // Find the rightmost content edge from both words and inline-block rectangles.
+        double contentRight = 0;
+        if (line.Words.Count > 0)
+        {
+            CssRect lastWord = line.Words[line.Words.Count - 1];
+            contentRight = lastWord.Right + lastWord.OwnerBox.ActualBorderRightWidth + lastWord.OwnerBox.ActualPaddingRight;
+        }
+
+        foreach (var kvp in line.Rectangles)
+        {
+            if (kvp.Value.Right > contentRight)
+                contentRight = kvp.Value.Right;
+        }
+
+        double diff = right - contentRight;
+
+        if (diff <= 0)
+            return;
+
+        foreach (CssRect word in line.Words)
+            word.Left += diff;
+
+        foreach (CssBox b in ToList(line.Rectangles.Keys))
+        {
+            RectangleF r = line.Rectangles[b];
+            line.Rectangles[b] = new RectangleF((float)(r.X + diff), r.Y, r.Width, r.Height);
+            ShiftInlineBlockBox(b, diff);
+        }
+    }
+
+    /// <summary>
+    /// Shifts an inline-block box and all its descendant boxes horizontally.
+    /// Called by <see cref="ApplyCenterAlignment"/> and <see cref="ApplyRightAlignment"/>
+    /// to ensure the box's actual <see cref="CssBox.Location"/> matches the shifted
+    /// line-box rectangle, so background, border, and child content paint at the
+    /// correct position.  CSS 2.1 §9.4.2.
+    /// </summary>
+    private static void ShiftInlineBlockBox(CssBox b, double dx)
+    {
+        if (b.Display != CssConstants.InlineBlock)
+            return;
+
+        b.Location = new PointF((float)(b.Location.X + dx), b.Location.Y);
+
+        // Shift all descendant boxes so child content (text, nested boxes)
+        // renders at the correct position.
+        ShiftDescendantBoxes(b, dx);
+
+        // Shift rectangles already assigned to the inline-block from its own
+        // line boxes (via BubbleRectangles + AssignRectanglesToBoxes that ran
+        // before centering).  Without this, the FragmentTreeBuilder captures
+        // stale InlineRects at the original position, causing double borders.
+        ShiftAssignedRectangles(b, dx);
+    }
+
+    private static void ShiftDescendantBoxes(CssBox parent, double dx)
+    {
+        foreach (var child in parent.Boxes)
+        {
+            child.Location = new PointF((float)(child.Location.X + dx), child.Location.Y);
+
+            // Shift rectangles already assigned to this child.
+            ShiftAssignedRectangles(child, dx);
+
+            ShiftDescendantBoxes(child, dx);
+        }
+
+        // Shift words and rectangles within this box's own line boxes.
+        foreach (var lineBox in parent.LineBoxes)
+        {
+            foreach (var word in lineBox.Words)
+                word.Left += dx;
+
+            foreach (var key in ToList(lineBox.Rectangles.Keys))
+            {
+                var r = lineBox.Rectangles[key];
+                lineBox.Rectangles[key] = new RectangleF((float)(r.X + dx), r.Y, r.Width, r.Height);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Shifts all per-line-box rectangles that have been assigned to a box
+    /// (via <see cref="CssLineBox.AssignRectanglesToBoxes"/>) by <paramref name="dx"/>
+    /// pixels horizontally.
+    /// </summary>
+    private static void ShiftAssignedRectangles(CssBox box, double dx)
+    {
+        if (box.Rectangles.Count == 0)
+            return;
+
+        foreach (var key in ToList(box.Rectangles.Keys))
+        {
+            var r = box.Rectangles[key];
+            box.Rectangles[key] = new RectangleF((float)(r.X + dx), r.Y, r.Width, r.Height);
+        }
+    }
+
+    /// <summary>
+    /// todo: optimizate, not creating a list each time
+    /// </summary>
+    private static List<T> ToList<T>(IEnumerable<T> collection)
+    {
+        List<T> result = [.. collection];
+        return result;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngineTable.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngineTable.cs
@@ -1,0 +1,997 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using Broiler.Layout;
+
+using CssConstants = Broiler.CSS.CssConstants;
+using CssValueParser = Broiler.CSS.CssLengthParser;
+using CssLength = Broiler.CSS.CssLength;
+using CssUnit = Broiler.CSS.CssUnit;
+namespace Broiler.Layout;
+
+internal sealed class CssLayoutEngineTable
+{
+    private readonly CssBox _tableBox;
+
+    private CssBox _headerBox;
+    private CssBox _footerBox;
+
+    private readonly List<CssBox> _bodyrows = [];
+    private readonly List<CssBox> _columns = [];
+    private readonly List<CssBox> _allRows = [];
+
+    private int _columnCount;
+
+    private bool _widthSpecified;
+
+    private double[] _columnWidths;
+    private double[] _columnMinWidths;
+
+    private CssLayoutEngineTable(CssBox tableBox) => _tableBox = tableBox;
+
+    public static double GetTableSpacing(CssBox tableBox)
+    {
+        int count = 0;
+        int columns = 0;
+
+        foreach (var box in tableBox.Boxes)
+        {
+            if (box.Display == CssConstants.TableColumn)
+            {
+                columns += GetSpan(box);
+            }
+            else if (box.Display == CssConstants.TableRowGroup)
+            {
+                foreach (CssBox cr in tableBox.Boxes)
+                {
+                    count++;
+                    if (cr.Display == CssConstants.TableRow)
+                        columns = Math.Max(columns, cr.Boxes.Count);
+                }
+            }
+            else if (box.Display == CssConstants.TableRow)
+            {
+                count++;
+                columns = Math.Max(columns, box.Boxes.Count);
+            }
+
+            // limit the amount of rows to process for performance
+            if (count > 30)
+                break;
+        }
+
+        // +1 columns because padding is between the cell and table borders
+        return (columns + 1) * GetHorizontalSpacing(tableBox);
+    }
+
+    public static void PerformLayout(ILayoutEnvironment g, CssBox tableBox, Uri baseUrl)
+    {
+        ArgumentNullException.ThrowIfNull(g);
+        ArgumentNullException.ThrowIfNull(tableBox);
+
+        try
+        {
+            var table = new CssLayoutEngineTable(tableBox);
+            table.Layout(g, baseUrl);
+        }
+        catch (Exception ex)
+        {
+            tableBox.LayoutEnvironment.ReportLayoutError("Failed table layout", ex);
+        }
+    }
+
+
+    private void Layout(ILayoutEnvironment g, Uri baseUrl)
+    {
+        MeasureWords(_tableBox, g);
+
+        // get the table boxes into the proper fields
+        AssignBoxKinds(baseUrl);
+
+        // Insert EmptyBoxes for vertical cell spanning. 
+        InsertEmptyBoxes(baseUrl);
+
+        // Determine Row and Column Count, and ColumnWidths
+        var availCellSpace = CalculateCountAndWidth();
+
+        DetermineMissingColumnWidths(availCellSpace);
+
+        // Check for minimum sizes (increment widths if necessary)
+        EnforceMinimumSize();
+
+        // While table width is larger than it should, and width is reducible
+        EnforceMaximumSize();
+
+        // Ensure there's no padding
+        _tableBox.PaddingLeft = _tableBox.PaddingTop = _tableBox.PaddingRight = _tableBox.PaddingBottom = "0";
+
+        //Actually layout cells!
+        LayoutCells(g);
+    }
+
+    private void AssignBoxKinds(Uri baseUrl)
+    {
+        // CSS2.1 §17.2.1: Generate anonymous table-row boxes for table-cell
+        // children that are direct children of the table without an
+        // intermediate table-row wrapper.
+        GenerateAnonymousTableRows(baseUrl);
+
+        foreach (var box in _tableBox.Boxes)
+        {
+            switch (box.Display)
+            {
+                case CssConstants.TableCaption:
+                    break;
+                case CssConstants.TableRow:
+                    _bodyrows.Add(box);
+                    break;
+                case CssConstants.TableRowGroup:
+                    foreach (CssBox childBox in box.Boxes)
+                        if (childBox.Display == CssConstants.TableRow)
+                            _bodyrows.Add(childBox);
+                    break;
+                case CssConstants.TableHeaderGroup:
+                    if (_headerBox != null)
+                        _bodyrows.Add(box);
+                    else
+                        _headerBox = box;
+                    break;
+                case CssConstants.TableFooterGroup:
+                    if (_footerBox != null)
+                        _bodyrows.Add(box);
+                    else
+                        _footerBox = box;
+                    break;
+                case CssConstants.TableColumn:
+                    for (int i = 0; i < GetSpan(box); i++)
+                        _columns.Add(box);
+                    break;
+                case CssConstants.TableColumnGroup:
+                    if (box.Boxes.Count == 0)
+                    {
+                        int gspan = GetSpan(box);
+                        for (int i = 0; i < gspan; i++)
+                        {
+                            _columns.Add(box);
+                        }
+                    }
+                    else
+                    {
+                        foreach (CssBox bb in box.Boxes)
+                        {
+                            int bbspan = GetSpan(bb);
+                            for (int i = 0; i < bbspan; i++)
+                            {
+                                _columns.Add(bb);
+                            }
+                        }
+                    }
+                    break;
+            }
+        }
+
+        if (_headerBox != null)
+            _allRows.AddRange(_headerBox.Boxes);
+
+        _allRows.AddRange(_bodyrows);
+
+        if (_footerBox != null)
+            _allRows.AddRange(_footerBox.Boxes);
+    }
+
+    /// <summary>
+    /// CSS2.1 §17.2.1: Generate anonymous table-row boxes for children of a
+    /// table element that are not proper table sub-elements (table-row,
+    /// table-row-group, table-header-group, table-footer-group, table-caption,
+    /// table-column, or table-column-group).  All consecutive non-row children
+    /// are wrapped together in a single anonymous table-row.  Within each
+    /// anonymous row, children that are not table-cell are additionally wrapped
+    /// in anonymous table-cell boxes.
+    /// </summary>
+    private void GenerateAnonymousTableRows(Uri baseUrl)
+    {
+        bool needsWrapping = false;
+        foreach (var box in _tableBox.Boxes)
+        {
+            if (!IsProperTableChild(box.Display))
+            {
+                needsWrapping = true;
+                break;
+            }
+        }
+
+        if (!needsWrapping)
+            return;
+
+        // Collect children and group consecutive non-row children into
+        // anonymous table-row wrappers.
+        var children = new List<CssBox>(_tableBox.Boxes);
+        _tableBox.Boxes.Clear();
+
+        List<CssBox>? pendingNonRow = null;
+
+        foreach (var child in children)
+        {
+            if (IsProperTableChild(child.Display))
+            {
+                if (pendingNonRow != null)
+                {
+                    FlushAnonymousRow(pendingNonRow, baseUrl);
+                    pendingNonRow = null;
+                }
+
+                _tableBox.Boxes.Add(child);
+            }
+            else
+            {
+                pendingNonRow ??= new List<CssBox>();
+                pendingNonRow.Add(child);
+            }
+        }
+
+        if (pendingNonRow != null)
+            FlushAnonymousRow(pendingNonRow, baseUrl);
+    }
+
+    /// <summary>
+    /// Returns true if the display value is a proper direct child of a table
+    /// element per CSS2.1 §17.2.1 (table-row, row-group, caption, column, etc.).
+    /// </summary>
+    private static bool IsProperTableChild(string display)
+    {
+        return display == CssConstants.TableRow
+            || display == CssConstants.TableRowGroup
+            || display == CssConstants.TableHeaderGroup
+            || display == CssConstants.TableFooterGroup
+            || display == CssConstants.TableCaption
+            || display == CssConstants.TableColumn
+            || display == CssConstants.TableColumnGroup;
+    }
+
+    /// <summary>
+    /// Creates an anonymous table-row box, re-parents the given children into
+    /// it, and appends the row to the table.  Children that are not table-cell
+    /// are additionally wrapped in anonymous table-cell boxes (CSS2.1 §17.2.1).
+    /// </summary>
+    private void FlushAnonymousRow(List<CssBox> children, Uri baseUrl)
+    {
+        // Create the anonymous row. The CssBox(parent, tag) constructor
+        // automatically adds the new box to parent.Boxes.
+        var anonRow = new CssBox(_tableBox, null, baseUrl) { Display = CssConstants.TableRow };
+        foreach (var child in children)
+        {
+            if (child.Display == CssConstants.TableCell)
+            {
+                // Already a table-cell — re-parent into the anonymous row.
+                // Using the ParentBox setter updates _parentBox and adds
+                // the child to anonRow.Boxes.
+                child.ParentBox = anonRow;
+            }
+            else
+            {
+                // CSS2.1 §17.2.1: Wrap non-cell children in an anonymous
+                // table-cell box.  The CssBox constructor automatically adds
+                // the anonymous cell to anonRow.Boxes.
+                var anonCell = new CssBox(anonRow, null, baseUrl) { Display = CssConstants.TableCell };
+                child.ParentBox = anonCell;
+            }
+        }
+    }
+
+    private void InsertEmptyBoxes(Uri baseUrl)
+    {
+        if (_tableBox._tableFixed)
+            return;
+
+        int currow = 0;
+        List<CssBox> rows = _bodyrows;
+
+        foreach (CssBox row in rows)
+        {
+            for (int k = 0; k < row.Boxes.Count; k++)
+            {
+                CssBox cell = row.Boxes[k];
+                int rowspan = GetRowSpan(cell);
+                int realcol = GetCellRealColumnIndex(row, cell); //Real column of the cell
+
+                for (int i = currow + 1; i < currow + rowspan; i++)
+                {
+                    if (rows.Count <= i)
+                        continue;
+
+                    int colcount = 0;
+                    for (int j = 0; j < rows[i].Boxes.Count; j++)
+                    {
+                        if (colcount == realcol)
+                        {
+                            rows[i].Boxes.Insert(colcount, new CssSpacingBox(_tableBox, ref cell, currow, baseUrl));
+                            break;
+                        }
+
+                        colcount++;
+                        realcol -= GetColSpan(rows[i].Boxes[j]) - 1;
+                    }
+                }
+            }
+
+            currow++;
+        }
+
+        _tableBox._tableFixed = true;
+    }
+
+    private double CalculateCountAndWidth()
+    {
+        // Columns. Count the effective grid columns, not just the number of
+        // physical cell boxes, because a one-cell row can span several columns.
+        _columnCount = _columns.Count;
+        foreach (CssBox row in _allRows)
+            _columnCount = Math.Max(_columnCount, GetColumnSpanCount(row));
+
+        //Initialize column widths array with NaNs
+        _columnWidths = new double[_columnCount];
+        for (int i = 0; i < _columnWidths.Length; i++)
+            _columnWidths[i] = double.NaN;
+
+        double availCellSpace = GetAvailableCellWidth();
+
+        if (_columns.Count > 0)
+        {
+            // Fill ColumnWidths array by scanning column widths
+            for (int i = 0; i < _columns.Count; i++)
+            {
+                CssLength len = new(_columns[i].Width); //Get specified width
+
+                if (len.Number <= 0) //If some width specified
+                    continue;
+
+                if (len.IsPercentage) //Get width as a percentage
+                {
+                    _columnWidths[i] = CssValueParser.ParseNumber(_columns[i].Width, availCellSpace);
+                }
+                else if (len.Unit == CssUnit.Px || len.Unit == CssUnit.None)
+                {
+                    _columnWidths[i] = len.Number; //Get width as an absolute-pixel value
+                }
+            }
+        }
+        else
+        {
+            // Fill ColumnWidths array by scanning width in table-cell definitions
+            foreach (CssBox row in _allRows)
+            {
+                //Check for column width in table-cell definitions
+                int columnIndex = 0;
+                foreach (CssBox cell in row.Boxes)
+                {
+                    int colspan = GetColSpan(cell);
+                    int endColumn = Math.Min(_columnWidths.Length, columnIndex + colspan);
+                    if (columnIndex >= _columnWidths.Length)
+                        break;
+
+                    if (cell.Display != CssConstants.TableCell)
+                    {
+                        columnIndex += colspan;
+                        continue;
+                    }
+
+                    if (columnIndex >= 20)
+                    {
+                        bool spanAlreadyResolved = true;
+                        for (int j = columnIndex; j < endColumn; j++)
+                        {
+                            if (double.IsNaN(_columnWidths[j]))
+                            {
+                                spanAlreadyResolved = false;
+                                break;
+                            }
+                        }
+
+                        if (spanAlreadyResolved)
+                        {
+                            columnIndex += colspan;
+                            continue;
+                        }
+                    }
+
+                    double len = CssValueParser.ParseLength(cell.Width, availCellSpace, cell.GetEmHeight());
+
+                    if (len <= 0) //If some width specified
+                    {
+                        columnIndex += colspan;
+                        continue;
+                    }
+
+                    len /= Convert.ToSingle(colspan);
+
+                    for (int j = columnIndex; j < endColumn; j++)
+                        _columnWidths[j] = double.IsNaN(_columnWidths[j]) ? len : Math.Max(_columnWidths[j], len);
+
+                    columnIndex += colspan;
+                }
+            }
+        }
+
+        return availCellSpace;
+    }
+
+    private static int GetColumnSpanCount(CssBox row)
+    {
+        int count = 0;
+        foreach (CssBox cell in row.Boxes)
+            count += GetColSpan(cell);
+        return count;
+    }
+
+    private void DetermineMissingColumnWidths(double availCellSpace)
+    {
+        double occupedSpace = 0f;
+
+        if (_widthSpecified) //If a width was specified,
+        {
+            //Assign NaNs equally with space left after gathering not-NaNs
+            int numOfNans = 0;
+
+            //Calculate number of NaNs and occupied space
+            foreach (double colWidth in _columnWidths)
+            {
+                if (double.IsNaN(colWidth))
+                    numOfNans++;
+                else
+                    occupedSpace += colWidth;
+            }
+
+            var orgNumOfNans = numOfNans;
+            double[] orgColWidths = null;
+
+            if (numOfNans < _columnWidths.Length)
+            {
+                orgColWidths = new double[_columnWidths.Length];
+                for (int i = 0; i < _columnWidths.Length; i++)
+                    orgColWidths[i] = _columnWidths[i];
+            }
+
+            if (numOfNans > 0)
+            {
+                // Determine the max width for each column
+                GetColumnsMinMaxWidthByContent(true, out double[] minFullWidths, out double[] maxFullWidths);
+
+                // set the columns that can fulfill by the max width in a loop because it changes the nanWidth
+                int oldNumOfNans;
+                do
+                {
+                    oldNumOfNans = numOfNans;
+
+                    for (int i = 0; i < _columnWidths.Length; i++)
+                    {
+                        var nanWidth = (availCellSpace - occupedSpace) / numOfNans;
+                        if (double.IsNaN(_columnWidths[i]) && nanWidth > maxFullWidths[i])
+                        {
+                            _columnWidths[i] = maxFullWidths[i];
+                            numOfNans--;
+                            occupedSpace += maxFullWidths[i];
+                        }
+                    }
+                } while (oldNumOfNans != numOfNans);
+
+                if (numOfNans > 0)
+                {
+                    // Determine width that will be assigned to un assigned widths
+                    double nanWidth = (availCellSpace - occupedSpace) / numOfNans;
+
+                    for (int i = 0; i < _columnWidths.Length; i++)
+                    {
+                        if (double.IsNaN(_columnWidths[i]))
+                            _columnWidths[i] = nanWidth;
+                    }
+                }
+            }
+
+            if (numOfNans == 0 && occupedSpace < availCellSpace)
+            {
+                if (orgNumOfNans > 0)
+                {
+                    // spread extra width between all non width specified columns
+                    double extWidth = (availCellSpace - occupedSpace) / orgNumOfNans;
+                    for (int i = 0; i < _columnWidths.Length; i++)
+                        if (orgColWidths == null || double.IsNaN(orgColWidths[i]))
+                            _columnWidths[i] += extWidth;
+                }
+                else
+                {
+                    // spread extra width between all columns with respect to relative sizes
+                    for (int i = 0; i < _columnWidths.Length; i++)
+                        _columnWidths[i] += (availCellSpace - occupedSpace) * (_columnWidths[i] / occupedSpace);
+                }
+            }
+        }
+        else
+        {
+            //Get the minimum and maximum full length of NaN boxes
+            GetColumnsMinMaxWidthByContent(true, out double[] minFullWidths, out double[] maxFullWidths);
+
+            for (int i = 0; i < _columnWidths.Length; i++)
+            {
+                if (double.IsNaN(_columnWidths[i]))
+                    _columnWidths[i] = minFullWidths[i];
+                occupedSpace += _columnWidths[i];
+            }
+
+            // spread extra width between all columns
+            for (int i = 0; i < _columnWidths.Length; i++)
+            {
+                if (maxFullWidths[i] > _columnWidths[i])
+                {
+                    var temp = _columnWidths[i];
+                    _columnWidths[i] = Math.Min(_columnWidths[i] + (availCellSpace - occupedSpace) / Convert.ToSingle(_columnWidths.Length - i), maxFullWidths[i]);
+                    occupedSpace = occupedSpace + _columnWidths[i] - temp;
+                }
+            }
+        }
+    }
+
+    private void EnforceMaximumSize()
+    {
+        int curCol = 0;
+        var widthSum = GetWidthSum();
+        while (widthSum > GetAvailableTableWidth() && CanReduceWidth())
+        {
+            while (!CanReduceWidth(curCol))
+                curCol++;
+
+            _columnWidths[curCol] -= 1f;
+
+            curCol++;
+
+            if (curCol >= _columnWidths.Length)
+                curCol = 0;
+        }
+
+        // if table max width is limited by we need to lower the columns width even if it will result in clipping
+        var maxWidth = GetMaxTableWidth();
+        if (maxWidth >= 90999)
+            return;
+
+        widthSum = GetWidthSum();
+
+        if (maxWidth >= widthSum)
+            return;
+
+        //Get the minimum and maximum full length of NaN boxes
+        GetColumnsMinMaxWidthByContent(false, out double[] minFullWidths, out double[] maxFullWidths);
+
+        // lower all the columns to the minimum
+        for (int i = 0; i < _columnWidths.Length; i++)
+            _columnWidths[i] = minFullWidths[i];
+
+        // either min for all column is not enought and we need to lower it more resulting in clipping
+        // or we now have extra space so we can give it to columns than need it
+        widthSum = GetWidthSum();
+
+        if (maxWidth < widthSum)
+        {
+            // lower the width of columns starting from the largest one until the max width is satisfied
+            for (int a = 0; a < 15 && maxWidth < widthSum - 0.1; a++) // limit iteration so bug won't create infinite loop
+            {
+                int nonMaxedColumns = 0;
+                double largeWidth = 0f, secLargeWidth = 0f;
+
+                for (int i = 0; i < _columnWidths.Length; i++)
+                {
+                    if (_columnWidths[i] > largeWidth + 0.1)
+                    {
+                        secLargeWidth = largeWidth;
+                        largeWidth = _columnWidths[i];
+                        nonMaxedColumns = 1;
+                    }
+                    else if (_columnWidths[i] > largeWidth - 0.1)
+                    {
+                        nonMaxedColumns++;
+                    }
+                }
+
+                double decrease = secLargeWidth > 0 ? largeWidth - secLargeWidth : (widthSum - maxWidth) / _columnWidths.Length;
+                if (decrease * nonMaxedColumns > widthSum - maxWidth)
+                    decrease = (widthSum - maxWidth) / nonMaxedColumns;
+
+                for (int i = 0; i < _columnWidths.Length; i++)
+                    if (_columnWidths[i] > largeWidth - 0.1)
+                        _columnWidths[i] -= decrease;
+
+                widthSum = GetWidthSum();
+            }
+        }
+        else
+        {
+            // spread extra width to columns that didn't reached max width where trying to spread it between all columns
+            for (int a = 0; a < 15 && maxWidth > widthSum + 0.1; a++) // limit iteration so bug won't create infinite loop
+            {
+                int nonMaxedColumns = 0;
+                for (int i = 0; i < _columnWidths.Length; i++)
+                    if (_columnWidths[i] + 1 < maxFullWidths[i])
+                        nonMaxedColumns++;
+                if (nonMaxedColumns == 0)
+                    nonMaxedColumns = _columnWidths.Length;
+
+                bool hit = false;
+                double minIncrement = (maxWidth - widthSum) / nonMaxedColumns;
+                for (int i = 0; i < _columnWidths.Length; i++)
+                {
+                    if (_columnWidths[i] + 0.1 < maxFullWidths[i])
+                    {
+                        minIncrement = Math.Min(minIncrement, maxFullWidths[i] - _columnWidths[i]);
+                        hit = true;
+                    }
+                }
+
+                for (int i = 0; i < _columnWidths.Length; i++)
+                    if (!hit || _columnWidths[i] + 1 < maxFullWidths[i])
+                        _columnWidths[i] += minIncrement;
+
+                widthSum = GetWidthSum();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Check for minimum sizes (increment widths if necessary)
+    /// </summary>
+    private void EnforceMinimumSize()
+    {
+        foreach (CssBox row in _allRows)
+        {
+            foreach (CssBox cell in row.Boxes)
+            {
+                int colspan = GetColSpan(cell);
+                int col = GetCellRealColumnIndex(row, cell);
+                int affectcol = col + colspan - 1;
+
+                if (_columnWidths.Length <= col || _columnWidths[col] >= GetColumnMinWidths()[col])
+                    continue;
+
+                double diff = GetColumnMinWidths()[col] - _columnWidths[col];
+                _columnWidths[affectcol] = GetColumnMinWidths()[affectcol];
+
+                if (col < _columnWidths.Length - 1)
+                    _columnWidths[col + 1] -= diff;
+            }
+        }
+    }
+
+    private void LayoutCells(ILayoutEnvironment g)
+    {
+        double startx = Math.Max(_tableBox.ClientLeft + GetHorizontalSpacing(), 0);
+        double starty = Math.Max(_tableBox.ClientTop + GetVerticalSpacing(), 0);
+        double cury = starty;
+        double maxRight = startx;
+        double maxBottom = 0f;
+        int currentrow = 0;
+
+        for (int i = 0; i < _allRows.Count; i++)
+        {
+            var row = _allRows[i];
+
+            // CSS2.1 §17.5.5: Rows with visibility:collapse are hidden and do
+            // not contribute height.  Column widths are still affected (handled
+            // during column width calculation).
+            if (row.Visibility == CssConstants.Collapse)
+            {
+                currentrow++;
+                continue;
+            }
+
+            double curx = startx;
+            int curCol = 0;
+            bool breakPage = false;
+
+            for (int j = 0; j < row.Boxes.Count; j++)
+            {
+                CssBox cell = row.Boxes[j];
+                if (curCol >= _columnWidths.Length)
+                    break;
+
+                int rowspan = GetRowSpan(cell);
+                var columnIndex = GetCellRealColumnIndex(row, cell);
+                double width = GetCellWidth(columnIndex, cell);
+
+                cell.Location = new PointF((float)curx, (float)cury);
+                cell.Size = new SizeF((float)width, 0f);
+                cell.PerformLayout(g); //That will automatically set the bottom of the cell
+
+                //Alter max bottom only if row is cell's row + cell's rowspan - 1
+                if (cell is CssSpacingBox sb)
+                {
+                    if (sb.EndRow == currentrow)
+                        maxBottom = Math.Max(maxBottom, sb.ExtendedBox.ActualBottom);
+                }
+                else if (rowspan == 1)
+                {
+                    maxBottom = Math.Max(maxBottom, cell.ActualBottom);
+                }
+
+                maxRight = Math.Max(maxRight, cell.ActualRight);
+                curCol++;
+                curx = cell.ActualRight + GetHorizontalSpacing();
+            }
+
+            foreach (CssBox cell in row.Boxes)
+            {
+                CssSpacingBox spacer = cell as CssSpacingBox;
+
+                if (spacer == null && GetRowSpan(cell) == 1)
+                {
+                    cell.ActualBottom = maxBottom;
+                    // CSS2.1 §17.5.3: Update Size.Height to match the
+                    // stretched cell so background painting uses the full
+                    // cell height.
+                    cell.Size = new SizeF(cell.Size.Width, (float)(maxBottom - cell.Location.Y));
+                    CssLayoutEngine.ApplyCellVerticalAlignment(g, cell);
+                }
+                else if (spacer != null && spacer.EndRow == currentrow)
+                {
+                    spacer.ExtendedBox.ActualBottom = maxBottom;
+                    spacer.ExtendedBox.Size = new SizeF(spacer.ExtendedBox.Size.Width, (float)(maxBottom - spacer.ExtendedBox.Location.Y));
+                    CssLayoutEngine.ApplyCellVerticalAlignment(g, spacer.ExtendedBox);
+                }
+
+                // If one cell crosses page borders then don't need to check other cells in the row
+                if (_tableBox.PageBreakInside == CssConstants.Avoid)
+                {
+                    breakPage = cell.BreakPage();
+                    if (breakPage)
+                    {
+                        cury = cell.Location.Y;
+                        break;
+                    }
+                }
+            }
+
+            if (breakPage) // go back to move the whole row to the next page
+            {
+                if (i == 1) // do not leave single row in previous page
+                    i = -1; // Start layout from the first row on new page
+                else
+                    i--;
+
+                maxBottom = 0;
+                continue;
+            }
+
+            cury = maxBottom + GetVerticalSpacing();
+
+            currentrow++;
+        }
+
+        maxRight = Math.Max(maxRight, _tableBox.Location.X + _tableBox.ActualWidth);
+        _tableBox.ActualRight = maxRight + GetHorizontalSpacing() + _tableBox.ActualBorderRightWidth;
+        _tableBox.ActualBottom = Math.Max(maxBottom, starty) + GetVerticalSpacing() + _tableBox.ActualBorderBottomWidth;
+
+        // CSS2.1 §17.5.2: Update the table box's Size to match the
+        // computed layout dimensions so background painting, overflow
+        // clipping, and child containing-block queries use the correct
+        // table bounds.
+        _tableBox.Size = new SizeF(
+            (float)(_tableBox.ActualRight - _tableBox.Location.X),
+            (float)(_tableBox.ActualBottom - _tableBox.Location.Y));
+    }
+
+    private double GetSpannedMinWidth(CssBox row, CssBox cell, int realcolindex, int colspan)
+    {
+        double w = 0f;
+
+        for (int i = realcolindex; i < row.Boxes.Count || i < realcolindex + colspan - 1; i++)
+        {
+            if (i < GetColumnMinWidths().Length)
+                w += GetColumnMinWidths()[i];
+        }
+
+        return w;
+    }
+
+    private static int GetCellRealColumnIndex(CssBox row, CssBox cell)
+    {
+        int i = 0;
+
+        foreach (CssBox b in row.Boxes)
+        {
+            if (b.Equals(cell))
+                break;
+
+            i += GetColSpan(b);
+        }
+
+        return i;
+    }
+
+    private double GetCellWidth(int column, CssBox b)
+    {
+        double colspan = Convert.ToSingle(GetColSpan(b));
+        double sum = 0f;
+
+        for (int i = column; i < column + colspan; i++)
+        {
+            if (column >= _columnWidths.Length)
+                break;
+
+            if (_columnWidths.Length <= i)
+                break;
+
+            sum += _columnWidths[i];
+        }
+
+        sum += (colspan - 1) * GetHorizontalSpacing();
+
+        return sum; // -b.ActualBorderLeftWidth - b.ActualBorderRightWidth - b.ActualPaddingRight - b.ActualPaddingLeft;
+    }
+
+    private static int GetColSpan(CssBox b)
+    {
+        string att = b.GetAttribute("colspan", "1");
+
+        if (!int.TryParse(att, out int colspan) || colspan < 1)
+            return 1;
+
+        return colspan;
+    }
+
+    private static int GetRowSpan(CssBox b)
+    {
+        string att = b.GetAttribute("rowspan", "1");
+
+        if (!int.TryParse(att, out int rowspan))
+            return 1;
+
+        return rowspan;
+    }
+
+    private static void MeasureWords(CssBox box, ILayoutEnvironment g)
+    {
+        if (box == null)
+            return;
+
+        foreach (var childBox in box.Boxes)
+        {
+            childBox.MeasureWordsSize(g);
+            MeasureWords(childBox, g);
+        }
+    }
+
+    private bool CanReduceWidth()
+    {
+        for (int i = 0; i < _columnWidths.Length; i++)
+        {
+            if (CanReduceWidth(i))
+                return true;
+        }
+
+        return false;
+    }
+
+    private bool CanReduceWidth(int columnIndex)
+    {
+        if (_columnWidths.Length >= columnIndex || GetColumnMinWidths().Length >= columnIndex)
+            return false;
+
+        return _columnWidths[columnIndex] > GetColumnMinWidths()[columnIndex];
+    }
+
+    private double GetAvailableTableWidth()
+    {
+        CssLength tblen = new(_tableBox.Width);
+
+        if (tblen.Number > 0)
+        {
+            _widthSpecified = true;
+            return CssValueParser.ParseLength(_tableBox.Width, _tableBox.ParentBox.AvailableWidth, _tableBox.GetEmHeight());
+        }
+        else
+        {
+            return _tableBox.ParentBox.AvailableWidth;
+        }
+    }
+
+    private double GetMaxTableWidth()
+    {
+        var tblen = new CssLength(_tableBox.MaxWidth);
+        if (tblen.Number > 0)
+        {
+            _widthSpecified = true;
+            return CssValueParser.ParseLength(_tableBox.MaxWidth, _tableBox.ParentBox.AvailableWidth, _tableBox.GetEmHeight());
+        }
+        else
+        {
+            return 9999f;
+        }
+    }
+
+    private void GetColumnsMinMaxWidthByContent(bool onlyNans, out double[] minFullWidths, out double[] maxFullWidths)
+    {
+        maxFullWidths = new double[_columnWidths.Length];
+        minFullWidths = new double[_columnWidths.Length];
+
+        foreach (CssBox row in _allRows)
+        {
+            for (int i = 0; i < row.Boxes.Count; i++)
+            {
+                int col = GetCellRealColumnIndex(row, row.Boxes[i]);
+                col = _columnWidths.Length > col ? col : _columnWidths.Length - 1;
+
+                if (onlyNans && !double.IsNaN(_columnWidths[col]) || i >= row.Boxes.Count)
+                    continue;
+
+                row.Boxes[i].GetMinMaxWidth(out double minWidth, out double maxWidth);
+
+                var colSpan = GetColSpan(row.Boxes[i]);
+                minWidth = minWidth / colSpan;
+                maxWidth = maxWidth / colSpan;
+
+                for (int j = 0; j < colSpan; j++)
+                {
+                    var colIndex = col + j;
+
+                    if (colIndex < minFullWidths.Length)
+                        minFullWidths[colIndex] = Math.Max(minFullWidths[colIndex], minWidth);
+
+                    if (colIndex < maxFullWidths.Length)
+                        maxFullWidths[colIndex] = Math.Max(maxFullWidths[colIndex], maxWidth);
+                }
+            }
+        }
+    }
+
+    private double GetAvailableCellWidth() => GetAvailableTableWidth() - GetHorizontalSpacing() * (_columnCount + 1) - _tableBox.ActualBorderLeftWidth - _tableBox.ActualBorderRightWidth;
+
+    private double GetWidthSum()
+    {
+        double f = 0f;
+
+        foreach (double t in _columnWidths)
+        {
+            if (double.IsNaN(t))
+                throw new Exception("CssTable Algorithm error: There's a NaN in column widths");
+            else
+                f += t;
+        }
+
+        //Take cell-spacing
+        f += GetHorizontalSpacing() * (_columnWidths.Length + 1);
+
+        //Take table borders
+        f += _tableBox.ActualBorderLeftWidth + _tableBox.ActualBorderRightWidth;
+
+        return f;
+    }
+
+    private static int GetSpan(CssBox b)
+    {
+        double f = CssValueParser.ParseNumber(b.GetAttribute("span"), 1);
+        return Math.Max(1, Convert.ToInt32(f));
+    }
+
+    private double[] GetColumnMinWidths()
+    {
+        if (_columnMinWidths != null)
+            return _columnMinWidths;
+
+        _columnMinWidths = new double[_columnWidths.Length];
+
+        foreach (CssBox row in _allRows)
+        {
+            foreach (CssBox cell in row.Boxes)
+            {
+                int colspan = GetColSpan(cell);
+                int col = GetCellRealColumnIndex(row, cell);
+                int affectcol = Math.Min(col + colspan, _columnMinWidths.Length) - 1;
+                double spannedwidth = GetSpannedMinWidth(row, cell, col, colspan) + (colspan - 1) * GetHorizontalSpacing();
+
+                _columnMinWidths[affectcol] = Math.Max(_columnMinWidths[affectcol], cell.GetMinimumWidth() - spannedwidth);
+            }
+        }
+
+        return _columnMinWidths;
+    }
+
+    private double GetHorizontalSpacing() => _tableBox.BorderCollapse == CssConstants.Collapse ? -1f : _tableBox.ActualBorderSpacingHorizontal;
+    private static double GetHorizontalSpacing(CssBox box) => box.BorderCollapse == CssConstants.Collapse ? -1f : box.ActualBorderSpacingHorizontal;
+    private double GetVerticalSpacing() => _tableBox.BorderCollapse == CssConstants.Collapse ? -1f : _tableBox.ActualBorderSpacingVertical;
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLineBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLineBox.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using Broiler.Layout;
+
+using CssConstants = Broiler.CSS.CssConstants;
+namespace Broiler.Layout;
+
+internal sealed class CssLineBox
+{
+    public CssLineBox(CssBox ownerBox)
+    {
+        Rectangles = [];
+        RelatedBoxes = [];
+        Words = [];
+        OwnerBox = ownerBox;
+        OwnerBox.LineBoxes.Add(this);
+    }
+
+    public List<CssBox> RelatedBoxes { get; }
+    public List<CssRect> Words { get; }
+    public CssBox OwnerBox { get; }
+    public Dictionary<CssBox, RectangleF> Rectangles { get; }
+
+    public double LineBottom
+    {
+        get
+        {
+            double bottom = 0;
+
+            foreach (var rect in Rectangles)
+                bottom = Math.Max(bottom, rect.Value.Bottom);
+
+            return bottom;
+        }
+    }
+
+    internal void ReportExistanceOf(CssRect word)
+    {
+        if (!Words.Contains(word))
+            Words.Add(word);
+
+        if (!RelatedBoxes.Contains(word.OwnerBox))
+            RelatedBoxes.Add(word.OwnerBox);
+    }
+
+    internal List<CssRect> WordsOf(CssBox box)
+    {
+        List<CssRect> r = [];
+
+        foreach (CssRect word in Words)
+            if (word.OwnerBox.Equals(box))
+                r.Add(word);
+
+        return r;
+    }
+
+    internal void UpdateRectangle(CssBox box, double x, double y, double r, double b)
+    {
+        double leftspacing = box.ActualBorderLeftWidth + box.ActualPaddingLeft;
+        double rightspacing = box.ActualBorderRightWidth + box.ActualPaddingRight;
+        double topspacing = box.ActualBorderTopWidth + box.ActualPaddingTop;
+        double bottomspacing = box.ActualBorderBottomWidth + box.ActualPaddingTop;
+
+        if ((box.FirstHostingLineBox != null && box.FirstHostingLineBox.Equals(this)) || box.IsImage)
+            x -= leftspacing;
+
+        if ((box.LastHostingLineBox != null && box.LastHostingLineBox.Equals(this)) || box.IsImage)
+            r += rightspacing;
+
+        if (!box.IsImage)
+        {
+            y -= topspacing;
+            b += bottomspacing;
+        }
+
+        if (!Rectangles.TryGetValue(box, out RectangleF f))
+        {
+            Rectangles.Add(box, RectangleF.FromLTRB((float)x, (float)y, (float)r, (float)b));
+        }
+        else
+        {
+            Rectangles[box] = RectangleF.FromLTRB(
+                (float)Math.Min(f.X, x), (float)Math.Min(f.Y, y),
+                (float)Math.Max(f.Right, r), (float)Math.Max(f.Bottom, b));
+        }
+
+        if (box.ParentBox != null && box.ParentBox.IsInline)
+            UpdateRectangle(box.ParentBox, x, y, r, b);
+    }
+
+    internal void AssignRectanglesToBoxes()
+    {
+        foreach (CssBox b in Rectangles.Keys)
+            b.Rectangles.Add(this, Rectangles[b]);
+    }
+
+    internal void SetBaseLine(ILayoutEnvironment g, CssBox b, double baseline)
+    {
+        //TODO: Aqui me quede, checar poniendo "by the" con un font-size de 3em
+        List<CssRect> ws = WordsOf(b);
+
+        if (!Rectangles.TryGetValue(b, out RectangleF r))
+            return;
+
+        // CSS 2.1 §10.8.1: For inline-block boxes, vertical-align adjusts
+        // the position of the entire atomic box.  Move the box's rectangle
+        // and its Location/ActualBottom directly.
+        if (b.Display == CssConstants.InlineBlock)
+        {
+            bool usesDefaultBaseline = string.IsNullOrEmpty(b.VerticalAlign)
+                || b.VerticalAlign == CssConstants.Baseline;
+            if (usesDefaultBaseline)
+                return;
+
+            if (Math.Abs(baseline - r.Top) > 0.01)
+            {
+                Rectangles[b] = new RectangleF(r.X, (float)baseline, r.Width, r.Height);
+                b.Location = new PointF(b.Location.X, (float)baseline);
+                b.ActualBottom = baseline + r.Height;
+            }
+            return;
+        }
+
+        //Save top of words related to the top of rectangle
+        double gap = 0f;
+
+        if (ws.Count > 0)
+        {
+            gap = ws[0].Top - r.Top;
+        }
+        else
+        {
+            CssRect firstw = CssBoxHelper.FirstWordOccourence(b, this);
+
+            if (firstw != null)
+                gap = firstw.Top - r.Top;
+        }
+
+        // The `baseline` parameter is the desired word.Top (visual text
+        // top coordinate) already computed by ApplyVerticalAlignment.
+        double newtop = baseline;
+
+        if (b.ParentBox != null && b.ParentBox.Rectangles.ContainsKey(this) && r.Height < b.ParentBox.Rectangles[this].Height)
+        {
+            //Do this only if rectangle is shorter than parent's
+            double recttop = newtop - gap;
+            RectangleF newr = new(r.X, (float)recttop, r.Width, r.Height);
+            
+            Rectangles[b] = newr;
+            b.OffsetRectangle(this, gap);
+        }
+
+        foreach (var word in ws)
+        {
+            if (!word.IsImage)
+                word.Top = newtop;
+        }
+    }
+
+    public override string ToString()
+    {
+        string[] ws = new string[Words.Count];
+
+        for (int i = 0; i < ws.Length; i++)
+            ws[i] = Words[i].Text;
+
+        return string.Join(" ", ws);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssRect.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssRect.cs
@@ -1,0 +1,99 @@
+using System.Drawing;
+
+namespace Broiler.Layout;
+
+internal abstract class CssRect(CssBox owner)
+{
+    private RectangleF _rect;
+
+    public CssBox OwnerBox { get; } = owner;
+
+    public RectangleF Rectangle
+    {
+        get { return _rect; }
+        set { _rect = value; }
+    }
+
+    public double Left
+    {
+        get { return _rect.X; }
+        set { _rect.X = (float)value; }
+    }
+
+    public double Top
+    {
+        get { return _rect.Y; }
+        set { _rect.Y = (float)value; }
+    }
+
+    public double Width
+    {
+        get { return _rect.Width; }
+        set { _rect.Width = (float)value; }
+    }
+
+    public double FullWidth => _rect.Width + ActualWordSpacing;
+
+    public double ActualWordSpacing => OwnerBox != null ? (HasSpaceAfter ? OwnerBox.ActualWordSpacing : 0) + (IsImage ? OwnerBox.ActualWordSpacing : 0) : 0;
+
+    public double Height
+    {
+        get { return _rect.Height; }
+        set { _rect.Height = (float)value; }
+    }
+
+    public double Right
+    {
+        get { return Rectangle.Right; }
+        set { Width = value - Left; }
+    }
+
+    public double Bottom
+    {
+        get { return Rectangle.Bottom; }
+        set { Height = value - Top; }
+    }
+
+    public ISelectionHandler Selection { get; set; }
+
+    public virtual bool HasSpaceBefore => false;
+
+    public virtual bool HasSpaceAfter => false;
+
+    public virtual object Image
+    {
+        get { return null; }
+        set { }
+    }
+
+    public virtual bool IsImage => false;
+    public virtual bool IsSpaces => true;
+    public virtual bool IsLineBreak => false;
+    public virtual string Text => null;
+    public bool Selected => Selection != null;
+    public int SelectedStartIndex => Selection != null ? Selection.GetSelectingStartIndex(this) : -1;
+    public int SelectedEndIndexOffset => Selection != null ? Selection.GetSelectedEndIndexOffset(this) : -1;
+    public double SelectedStartOffset => Selection != null ? Selection.GetSelectedStartOffset(this) : -1;
+    public double SelectedEndOffset => Selection != null ? Selection.GetSelectedEndOffset(this) : -1;
+    internal double LeftGlyphPadding => OwnerBox != null ? OwnerBox.ActualFont.LeftPadding : 0;
+    public override string ToString() => $"{Text.Replace(' ', '-').Replace("\n", "\\n")} ({Text.Length} char{(Text.Length != 1 ? "s" : string.Empty)})";
+
+    public bool BreakPage()
+    {
+        var container = OwnerBox.LayoutEnvironment;
+
+        if (Height >= container.PageSize.Height)
+            return false;
+
+        var remTop = (Top - container.MarginTop) % container.PageSize.Height;
+        var remBottom = (Bottom - container.MarginTop) % container.PageSize.Height;
+
+        if (remTop > remBottom)
+        {
+            Top += container.PageSize.Height - remTop + 1;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssRectImage.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssRectImage.cs
@@ -1,0 +1,25 @@
+using System.Drawing;
+
+namespace Broiler.Layout;
+
+internal sealed class CssRectImage(CssBox owner) : CssRect(owner)
+{
+    private object _image;
+    private RectangleF _imageRectangle;
+
+    public override object Image
+    {
+        get { return _image; }
+        set { _image = value; }
+    }
+
+    public override bool IsImage => true;
+
+    public RectangleF ImageRectangle
+    {
+        get { return _imageRectangle; }
+        set { _imageRectangle = value; }
+    }
+
+    public override string ToString() => "Image";
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssRectWord.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssRectWord.cs
@@ -1,0 +1,25 @@
+namespace Broiler.Layout;
+
+internal sealed class CssRectWord(CssBox owner, string text, bool hasSpaceBefore, bool hasSpaceAfter) : CssRect(owner)
+{
+    public override bool HasSpaceBefore => hasSpaceBefore;
+    public override bool HasSpaceAfter => hasSpaceAfter;
+
+    public override bool IsSpaces
+    {
+        get
+        {
+            foreach (var c in Text)
+            {
+                if (!char.IsWhiteSpace(c))
+                    return false;
+            }
+
+            return true;
+        }
+    }
+
+    public override bool IsLineBreak => Text == "\n";
+    public override string Text => text;
+    public override string ToString() => $"{Text.Replace(' ', '-').Replace("\n", "\\n")} ({Text.Length} char{(Text.Length != 1 ? "s" : string.Empty)})";
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssSpacingBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssSpacingBox.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+using CssConstants = Broiler.CSS.CssConstants;
+namespace Broiler.Layout;
+
+internal sealed class CssSpacingBox : CssBox
+{
+    public CssSpacingBox(CssBox tableBox, ref CssBox extendedBox, int startRow, Uri baseUrl)
+        : base(tableBox, new HtmlTag("none", false, new Dictionary<string, string> { { "colspan", "1" } }), baseUrl)
+    {
+        ExtendedBox = extendedBox;
+        Display = CssConstants.None;
+
+        StartRow = startRow;
+        EndRow = startRow + int.Parse(extendedBox.GetAttribute("rowspan", "1")) - 1;
+    }
+
+    public CssBox ExtendedBox { get; }
+    public int StartRow { get; }
+    public int EndRow { get; }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -1,0 +1,797 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Broiler.Layout;
+
+using CssConstants = Broiler.CSS.CssConstants;
+using CssValueParser = Broiler.CSS.CssLengthParser;
+namespace Broiler.Layout;
+
+internal static class CssUtils
+{
+    private static readonly Regex LengthAttrFunctionPattern = new(
+        @"attr\(\s*(?<name>[A-Za-z_][A-Za-z0-9_-]*)\s+type\(\s*<length>\s*\)\s*(?:,\s*(?<fallback>[^)]+?))?\s*\)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    public static double WhiteSpace(ILayoutEnvironment g, CssBoxProperties box)
+    {
+        double w = g.GetWhitespaceWidth(box.ActualFont);
+
+        if (!(string.IsNullOrEmpty(box.WordSpacing) || box.WordSpacing == CssConstants.Normal))
+            w += CssValueParser.ParseLength(box.WordSpacing, 0, box.GetEmHeight(), true);
+
+        return w;
+    }
+
+    public static string GetPropertyValue(CssBox cssBox, string propName)
+    {
+        return propName switch
+        {
+            "border-bottom-width" => cssBox.BorderBottomWidth,
+            "border-left-width" => cssBox.BorderLeftWidth,
+            "border-right-width" => cssBox.BorderRightWidth,
+            "border-top-width" => cssBox.BorderTopWidth,
+            "border-bottom-style" => cssBox.BorderBottomStyle,
+            "border-left-style" => cssBox.BorderLeftStyle,
+            "border-right-style" => cssBox.BorderRightStyle,
+            "border-top-style" => cssBox.BorderTopStyle,
+            "border-bottom-color" => cssBox.BorderBottomColor,
+            "border-left-color" => cssBox.BorderLeftColor,
+            "border-right-color" => cssBox.BorderRightColor,
+            "border-top-color" => cssBox.BorderTopColor,
+            "border-spacing" => cssBox.BorderSpacing,
+            "border-collapse" => cssBox.BorderCollapse,
+            "corner-radius" => cssBox.CornerRadius,
+            "border-radius" => cssBox.CornerRadius,
+            "opacity" => cssBox.Opacity,
+            "box-shadow" => cssBox.BoxShadow,
+            "text-shadow" => cssBox.TextShadow,
+            "flex-direction" => cssBox.FlexDirection,
+            "flex-grow" => cssBox.FlexGrow,
+            "flex-shrink" => cssBox.FlexShrink,
+            "flex-basis" => cssBox.FlexBasis,
+            "flex-wrap" => cssBox.FlexWrap,
+            "justify-content" => cssBox.JustifyContent,
+            "justify-items" => cssBox.JustifyItems,
+            "align-items" => cssBox.AlignItems,
+            "corner-nw-radius" => cssBox.CornerNwRadius,
+            "corner-ne-radius" => cssBox.CornerNeRadius,
+            "corner-se-radius" => cssBox.CornerSeRadius,
+            "corner-sw-radius" => cssBox.CornerSwRadius,
+            "margin-bottom" => cssBox.MarginBottom,
+            "margin-left" => cssBox.MarginLeft,
+            "margin-right" => cssBox.MarginRight,
+            "margin-top" => cssBox.MarginTop,
+            "margin-trim" => cssBox.MarginTrim,
+            "padding-bottom" => cssBox.PaddingBottom,
+            "padding-left" => cssBox.PaddingLeft,
+            "padding-right" => cssBox.PaddingRight,
+            "padding-top" => cssBox.PaddingTop,
+            "page-break-inside" => cssBox.PageBreakInside,
+            "left" => cssBox.Left,
+            "top" => cssBox.Top,
+            "width" => cssBox.Width,
+            "inline-size" => cssBox.InlineSize,
+            "max-width" => cssBox.MaxWidth,
+            "min-width" => cssBox.MinWidth,
+            "height" => cssBox.Height,
+            "block-size" => cssBox.BlockSize,
+            "max-height" => cssBox.MaxHeight,
+            "min-height" => cssBox.MinHeight,
+            "background-color" => cssBox.BackgroundColor,
+            "background-image" => cssBox.BackgroundImage,
+            "background-position" => cssBox.BackgroundPosition,
+            "background-repeat" => cssBox.BackgroundRepeat,
+            "background-attachment" => cssBox.BackgroundAttachment,
+            "background-origin" => cssBox.BackgroundOrigin,
+            "background-size" => cssBox.BackgroundSize,
+            "background-gradient" => cssBox.BackgroundGradient,
+            "background-gradient-angle" => cssBox.BackgroundGradientAngle,
+            "content" => cssBox.Content,
+            "color" => cssBox.Color,
+            "display" => cssBox.Display,
+            "direction" => cssBox.Direction,
+            "empty-cells" => cssBox.EmptyCells,
+            "float" => cssBox.Float,
+            "clear" => cssBox.Clear,
+            "position" => cssBox.Position,
+            "line-height" => cssBox.LineHeight,
+            "vertical-align" => cssBox.VerticalAlign,
+            "text-indent" => cssBox.TextIndent,
+            "text-align" => cssBox.TextAlign,
+            "text-decoration" => cssBox.TextDecoration,
+            "text-decoration-line" => cssBox.TextDecoration,
+            "text-decoration-style" => cssBox.TextDecorationStyle,
+            "text-decoration-color" => cssBox.TextDecorationColor,
+            "white-space" => cssBox.WhiteSpace,
+            "word-break" => cssBox.WordBreak,
+            "visibility" => cssBox.Visibility,
+            "word-spacing" => cssBox.WordSpacing,
+            "font-family" => cssBox.FontFamily,
+            "font-feature-settings" => cssBox.FontFeatureSettings,
+            "font-variant-alternates" => cssBox.FontVariantAlternates,
+            "font-size" => cssBox.FontSize,
+            "font-style" => cssBox.FontStyle,
+            "font-variant" => cssBox.FontVariant,
+            "font-weight" => cssBox.FontWeight,
+            "list-style" => cssBox.ListStyle,
+            "list-style-position" => cssBox.ListStylePosition,
+            "list-style-image" => cssBox.ListStyleImage,
+            "list-style-type" => cssBox.ListStyleType,
+            "overflow" => cssBox.Overflow,
+            "box-sizing" => cssBox.BoxSizing,
+            "clip-path" => cssBox.ClipPath,
+            "transform" => cssBox.Transform,
+            "align-content" => cssBox.AlignContent,
+            "justify-self" => cssBox.JustifySelf,
+            "align-self" => cssBox.AlignSelf,
+            "unicode-bidi" => cssBox.UnicodeBidi,
+            "writing-mode" => cssBox.WritingMode,
+            "column-count" => cssBox.ColumnCount,
+            "column-width" => cssBox.ColumnWidth,
+            "column-fill" => cssBox.ColumnFill,
+            "row-gap" => cssBox.RowGap,
+            "column-gap" => cssBox.ColumnGap,
+            "gap" => cssBox.RowGap == cssBox.ColumnGap ? cssBox.RowGap : $"{cssBox.RowGap} {cssBox.ColumnGap}",
+            "break-inside" => cssBox.BreakInside,
+            "grid-row" => cssBox.GridRow,
+            "grid-column" => cssBox.GridColumn,
+            "contain" => cssBox.Contain,
+            _ => null,
+        };
+    }
+
+    public static void SetPropertyValue(CssBox cssBox, string propName, string value)
+    {
+        value = ResolveLengthAttrFunctions(cssBox, value);
+
+        if (propName.StartsWith("--", StringComparison.Ordinal))
+        {
+            cssBox.SetCustomProperty(propName, value);
+            return;
+        }
+
+        switch (propName)
+        {
+            case "border-bottom-width":
+                cssBox.BorderBottomWidth = value;
+                break;
+            case "border-left-width":
+                cssBox.BorderLeftWidth = value;
+                break;
+            case "border-right-width":
+                cssBox.BorderRightWidth = value;
+                break;
+            case "border-top-width":
+                cssBox.BorderTopWidth = value;
+                break;
+            case "border-bottom-style":
+                cssBox.BorderBottomStyle = value;
+                break;
+            case "border-left-style":
+                cssBox.BorderLeftStyle = value;
+                break;
+            case "border-right-style":
+                cssBox.BorderRightStyle = value;
+                break;
+            case "border-top-style":
+                cssBox.BorderTopStyle = value;
+                break;
+            case "border-bottom-color":
+                cssBox.BorderBottomColor = value;
+                break;
+            case "border-left-color":
+                cssBox.BorderLeftColor = value;
+                break;
+            case "border-right-color":
+                cssBox.BorderRightColor = value;
+                break;
+            case "border-top-color":
+                cssBox.BorderTopColor = value;
+                break;
+            case "border-spacing":
+                cssBox.BorderSpacing = value;
+                break;
+            case "border-collapse":
+                cssBox.BorderCollapse = value;
+                break;
+            case "corner-radius":
+                cssBox.CornerRadius = value;
+                break;
+            case "border-radius":
+                cssBox.CornerRadius = value;
+                break;
+            case "opacity":
+                cssBox.Opacity = value;
+                break;
+            case "mix-blend-mode":
+                cssBox.MixBlendMode = value;
+                break;
+            case "background-blend-mode":
+                cssBox.BackgroundBlendMode = value;
+                break;
+            case "filter":
+                cssBox.Filter = value;
+                break;
+            case "isolation":
+                cssBox.Isolation = value;
+                break;
+            case "box-sizing":
+                cssBox.BoxSizing = value;
+                break;
+            case "background-clip":
+                cssBox.BackgroundClip = value;
+                break;
+            case "clip-path":
+                cssBox.ClipPath = value;
+                break;
+            case "transform":
+                cssBox.Transform = value;
+                break;
+            case "box-shadow":
+                cssBox.BoxShadow = value;
+                break;
+            case "text-shadow":
+                cssBox.TextShadow = value;
+                break;
+            case "text-fill-color":
+            case "-webkit-text-fill-color":
+                cssBox.Color = value;
+                break;
+            case "flex-direction":
+                cssBox.FlexDirection = value;
+                break;
+            case "flex-grow":
+                cssBox.FlexGrow = value;
+                break;
+            case "flex-shrink":
+                cssBox.FlexShrink = value;
+                break;
+            case "flex-basis":
+                cssBox.FlexBasis = value;
+                break;
+            case "flex-wrap":
+                cssBox.FlexWrap = value;
+                break;
+            case "justify-content":
+                cssBox.JustifyContent = value;
+                break;
+            case "justify-items":
+                cssBox.JustifyItems = value;
+                break;
+            case "align-items":
+                cssBox.AlignItems = value;
+                break;
+            case "align-content":
+                cssBox.AlignContent = value;
+                break;
+            case "justify-self":
+                cssBox.JustifySelf = value;
+                break;
+            case "align-self":
+                cssBox.AlignSelf = value;
+                break;
+            case "unicode-bidi":
+                cssBox.UnicodeBidi = value;
+                break;
+            case "writing-mode":
+                cssBox.WritingMode = value;
+                break;
+            case "column-count":
+                cssBox.ColumnCount = value;
+                break;
+            case "column-width":
+                cssBox.ColumnWidth = value;
+                break;
+            case "column-fill":
+                cssBox.ColumnFill = value;
+                break;
+            case "row-gap":
+                cssBox.RowGap = value;
+                break;
+            case "column-gap":
+                cssBox.ColumnGap = value;
+                break;
+            case "gap":
+                {
+                    var parts = value.Trim().Split([' '], StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length == 1)
+                    {
+                        cssBox.RowGap = parts[0];
+                        cssBox.ColumnGap = parts[0];
+                    }
+                    else if (parts.Length >= 2)
+                    {
+                        cssBox.RowGap = parts[0];
+                        cssBox.ColumnGap = parts[1];
+                    }
+                }
+                break;
+            case "break-inside":
+                cssBox.BreakInside = value;
+                break;
+            case "grid-row":
+                cssBox.GridRow = value;
+                break;
+            case "grid-column":
+                cssBox.GridColumn = value;
+                break;
+            case "contain":
+                cssBox.Contain = value;
+                break;
+            case "columns":
+                // CSS Multi-column §3: 'columns' is a shorthand for
+                // 'column-width' and 'column-count'.  A bare integer
+                // value sets column-count; a length sets column-width.
+                var colParts = value.Trim().Split([' '], StringSplitOptions.RemoveEmptyEntries);
+                foreach (var part in colParts)
+                {
+                    if (part == "auto")
+                        continue;
+                    if (int.TryParse(part, out _))
+                        cssBox.ColumnCount = part;
+                    else
+                        cssBox.ColumnWidth = part;
+                }
+                break;
+            case "border-inline":
+                ApplyLogicalBorderShorthand(cssBox, value, inlineAxis: true);
+                break;
+            case "border-block":
+                ApplyLogicalBorderShorthand(cssBox, value, inlineAxis: false);
+                break;
+            case "border-inline-start-color":
+                SetLogicalBorderComponent(cssBox, inlineAxis: true, startSide: true, component: "color", value);
+                break;
+            case "border-inline-end-color":
+                SetLogicalBorderComponent(cssBox, inlineAxis: true, startSide: false, component: "color", value);
+                break;
+            case "border-block-start-color":
+                SetLogicalBorderComponent(cssBox, inlineAxis: false, startSide: true, component: "color", value);
+                break;
+            case "border-block-end-color":
+                SetLogicalBorderComponent(cssBox, inlineAxis: false, startSide: false, component: "color", value);
+                break;
+            case "border-inline-start-style":
+                SetLogicalBorderComponent(cssBox, inlineAxis: true, startSide: true, component: "style", value);
+                break;
+            case "border-inline-end-style":
+                SetLogicalBorderComponent(cssBox, inlineAxis: true, startSide: false, component: "style", value);
+                break;
+            case "border-block-start-style":
+                SetLogicalBorderComponent(cssBox, inlineAxis: false, startSide: true, component: "style", value);
+                break;
+            case "border-block-end-style":
+                SetLogicalBorderComponent(cssBox, inlineAxis: false, startSide: false, component: "style", value);
+                break;
+            case "border-inline-start-width":
+                SetLogicalBorderComponent(cssBox, inlineAxis: true, startSide: true, component: "width", value);
+                break;
+            case "border-inline-end-width":
+                SetLogicalBorderComponent(cssBox, inlineAxis: true, startSide: false, component: "width", value);
+                break;
+            case "border-block-start-width":
+                SetLogicalBorderComponent(cssBox, inlineAxis: false, startSide: true, component: "width", value);
+                break;
+            case "border-block-end-width":
+                SetLogicalBorderComponent(cssBox, inlineAxis: false, startSide: false, component: "width", value);
+                break;
+            case "corner-nw-radius":
+                cssBox.CornerNwRadius = value;
+                break;
+            case "corner-ne-radius":
+                cssBox.CornerNeRadius = value;
+                break;
+            case "corner-se-radius":
+                cssBox.CornerSeRadius = value;
+                break;
+            case "corner-sw-radius":
+                cssBox.CornerSwRadius = value;
+                break;
+            case "margin-bottom":
+                cssBox.MarginBottom = value;
+                break;
+            case "margin-left":
+                cssBox.MarginLeft = value;
+                break;
+            case "margin-right":
+                cssBox.MarginRight = value;
+                break;
+            case "margin-top":
+                cssBox.MarginTop = value;
+                break;
+            case "margin-trim":
+                cssBox.MarginTrim = value;
+                break;
+            case "padding-bottom":
+                cssBox.PaddingBottom = value;
+                break;
+            case "padding-left":
+                cssBox.PaddingLeft = value;
+                break;
+            case "padding-right":
+                cssBox.PaddingRight = value;
+                break;
+            case "padding-top":
+                cssBox.PaddingTop = value;
+                break;
+            case "page-break-inside":
+                cssBox.PageBreakInside = value;
+                break;
+            case "left":
+                cssBox.Left = value;
+                break;
+            case "top":
+                cssBox.Top = value;
+                break;
+            case "right":
+                cssBox.Right = value;
+                break;
+            case "bottom":
+                cssBox.Bottom = value;
+                break;
+            case "width":
+                cssBox.Width = value;
+                break;
+            case "inline-size":
+                cssBox.InlineSize = value;
+                break;
+            case "max-width":
+                cssBox.MaxWidth = value;
+                break;
+            case "min-width":
+                cssBox.MinWidth = value;
+                cssBox.IsMinWidthSpecified = true;
+                break;
+            case "height":
+                cssBox.Height = value;
+                break;
+            case "block-size":
+                cssBox.BlockSize = value;
+                break;
+            case "max-height":
+                cssBox.MaxHeight = value;
+                break;
+            case "min-height":
+                cssBox.MinHeight = value;
+                break;
+            case "background-color":
+                cssBox.BackgroundColor = value;
+                break;
+            case "background-image":
+                cssBox.BackgroundImage = value;
+                break;
+            case "background-position":
+                cssBox.BackgroundPosition = value;
+                break;
+            case "background-repeat":
+                cssBox.BackgroundRepeat = value;
+                break;
+            case "background-attachment":
+                cssBox.BackgroundAttachment = value;
+                break;
+            case "background-origin":
+                cssBox.BackgroundOrigin = value;
+                break;
+            case "background-size":
+                cssBox.BackgroundSize = value;
+                break;
+            case "background-gradient":
+                cssBox.BackgroundGradient = value;
+                break;
+            case "background-gradient-angle":
+                cssBox.BackgroundGradientAngle = value;
+                break;
+            case "color":
+                cssBox.Color = value;
+                break;
+            case "content":
+                cssBox.Content = value;
+                break;
+            case "display":
+                cssBox.Display = value;
+                break;
+            case "direction":
+                cssBox.Direction = value;
+                break;
+            case "empty-cells":
+                cssBox.EmptyCells = value;
+                break;
+            case "float":
+                cssBox.Float = value;
+                break;
+            case "clear":
+                cssBox.Clear = value;
+                break;
+            case "position":
+                cssBox.Position = value;
+                break;
+            case "line-height":
+                cssBox.LineHeight = value;
+                break;
+            case "vertical-align":
+                cssBox.VerticalAlign = value;
+                break;
+            case "text-indent":
+                cssBox.TextIndent = value;
+                break;
+            case "text-align":
+                cssBox.TextAlign = value;
+                break;
+            case "text-decoration":
+                ApplyTextDecorationShorthand(cssBox, value);
+                break;
+            case "text-decoration-line":
+                cssBox.TextDecoration = value;
+                break;
+            case "text-decoration-style":
+                cssBox.TextDecorationStyle = value;
+                break;
+            case "text-decoration-color":
+                cssBox.TextDecorationColor = value;
+                break;
+            case "white-space":
+                cssBox.WhiteSpace = value;
+                break;
+            case "word-break":
+                cssBox.WordBreak = value;
+                break;
+            case "visibility":
+                cssBox.Visibility = value;
+                break;
+            case "word-spacing":
+                cssBox.WordSpacing = value;
+                break;
+            case "font-family":
+                cssBox.FontFamily = value;
+                break;
+            case "font-feature-settings":
+                cssBox.FontFeatureSettings = value;
+                break;
+            case "font-variant-alternates":
+                cssBox.FontVariantAlternates = value;
+                break;
+            case "font-size":
+                cssBox.FontSize = value;
+                break;
+            case "font-style":
+                cssBox.FontStyle = value;
+                break;
+            case "font-variant":
+                cssBox.FontVariant = value;
+                break;
+            case "font-weight":
+                cssBox.FontWeight = value;
+                break;
+            case "list-style":
+                cssBox.ListStyle = value;
+                break;
+            case "list-style-position":
+                cssBox.ListStylePosition = value;
+                break;
+            case "list-style-image":
+                cssBox.ListStyleImage = value;
+                break;
+            case "list-style-type":
+                cssBox.ListStyleType = value;
+                break;
+            case "overflow":
+                cssBox.Overflow = value;
+                break;
+            case "z-index":
+                cssBox.ZIndex = value;
+                break;
+            case "animation-name":
+                cssBox.AnimationName = value;
+                break;
+            case "animation-duration":
+                cssBox.AnimationDuration = value;
+                break;
+            case "animation-timing-function":
+                cssBox.AnimationTimingFunction = value;
+                break;
+            case "animation-delay":
+                cssBox.AnimationDelay = value;
+                break;
+            case "animation-iteration-count":
+                cssBox.AnimationIterationCount = value;
+                break;
+            case "animation-direction":
+                cssBox.AnimationDirection = value;
+                break;
+            case "animation-fill-mode":
+                cssBox.AnimationFillMode = value;
+                break;
+            case "animation-play-state":
+                cssBox.AnimationPlayState = value;
+                break;
+        }
+    }
+
+    private static void ApplyLogicalBorderShorthand(CssBox cssBox, string value, bool inlineAxis)
+    {
+        var parts = value.Trim().Split([' '], StringSplitOptions.RemoveEmptyEntries);
+        string? width = null;
+        string? style = null;
+        string? color = null;
+
+        foreach (var part in parts)
+        {
+            var lower = part.ToLowerInvariant();
+            if (lower is "none" or "hidden" or "dotted" or "dashed" or "solid"
+                or "double" or "groove" or "ridge" or "inset" or "outset")
+            {
+                style ??= part;
+            }
+            else if (lower is "thin" or "medium" or "thick" || CssValueParser.IsValidLength(part))
+            {
+                width ??= part;
+            }
+            else
+            {
+                color ??= part;
+            }
+        }
+
+        if (width != null)
+        {
+            SetLogicalBorderComponent(cssBox, inlineAxis, startSide: true, "width", width);
+            SetLogicalBorderComponent(cssBox, inlineAxis, startSide: false, "width", width);
+        }
+
+        if (style != null)
+        {
+            SetLogicalBorderComponent(cssBox, inlineAxis, startSide: true, "style", style);
+            SetLogicalBorderComponent(cssBox, inlineAxis, startSide: false, "style", style);
+        }
+
+        if (color != null)
+        {
+            SetLogicalBorderComponent(cssBox, inlineAxis, startSide: true, "color", color);
+            SetLogicalBorderComponent(cssBox, inlineAxis, startSide: false, "color", color);
+        }
+    }
+
+    private static void ApplyTextDecorationShorthand(CssBox cssBox, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            cssBox.TextDecoration = string.Empty;
+            return;
+        }
+
+        // Shorthand application resets omitted longhands back to their initial values.
+        cssBox.TextDecoration = "none";
+        cssBox.TextDecorationStyle = "solid";
+        cssBox.TextDecorationColor = "currentcolor";
+
+        var parts = value.Trim().Split([' '], StringSplitOptions.RemoveEmptyEntries);
+        string? line = null;
+
+        foreach (var part in parts)
+        {
+            var lower = part.ToLowerInvariant();
+            if (lower is "underline" or "overline" or "line-through" or "none")
+            {
+                line = part;
+            }
+            else if (lower is "solid" or "double" or "dotted" or "dashed" or "wavy")
+            {
+                cssBox.TextDecorationStyle = part;
+            }
+            else
+            {
+                cssBox.TextDecorationColor = part;
+            }
+        }
+
+        if (line != null)
+            cssBox.TextDecoration = line;
+    }
+
+    private static void SetLogicalBorderComponent(
+        CssBox cssBox,
+        bool inlineAxis,
+        bool startSide,
+        string component,
+        string value)
+    {
+        var side = ResolveLogicalBorderSide(cssBox, inlineAxis, startSide);
+        switch (side, component)
+        {
+            case ("top", "color"):
+                cssBox.BorderTopColor = value;
+                break;
+            case ("right", "color"):
+                cssBox.BorderRightColor = value;
+                break;
+            case ("bottom", "color"):
+                cssBox.BorderBottomColor = value;
+                break;
+            case ("left", "color"):
+                cssBox.BorderLeftColor = value;
+                break;
+            case ("top", "style"):
+                cssBox.BorderTopStyle = value;
+                break;
+            case ("right", "style"):
+                cssBox.BorderRightStyle = value;
+                break;
+            case ("bottom", "style"):
+                cssBox.BorderBottomStyle = value;
+                break;
+            case ("left", "style"):
+                cssBox.BorderLeftStyle = value;
+                break;
+            case ("top", "width"):
+                cssBox.BorderTopWidth = value;
+                break;
+            case ("right", "width"):
+                cssBox.BorderRightWidth = value;
+                break;
+            case ("bottom", "width"):
+                cssBox.BorderBottomWidth = value;
+                break;
+            case ("left", "width"):
+                cssBox.BorderLeftWidth = value;
+                break;
+        }
+    }
+
+    private static string ResolveLogicalBorderSide(CssBox cssBox, bool inlineAxis, bool startSide)
+    {
+        var writingMode = cssBox.WritingMode?.ToLowerInvariant() ?? "horizontal-tb";
+        var direction = cssBox.Direction?.ToLowerInvariant() ?? "ltr";
+
+        if (inlineAxis)
+        {
+            return writingMode switch
+            {
+                "vertical-rl" or "vertical-lr" or "sideways-rl" or "sideways-lr" => startSide ? "top" : "bottom",
+                _ => startSide
+                    ? (direction == "rtl" ? "right" : "left")
+                    : (direction == "rtl" ? "left" : "right"),
+            };
+        }
+
+        return writingMode switch
+        {
+            "vertical-rl" or "sideways-rl" => startSide ? "right" : "left",
+            "vertical-lr" or "sideways-lr" => startSide ? "left" : "right",
+            _ => startSide ? "top" : "bottom",
+        };
+    }
+
+    private static string ResolveLengthAttrFunctions(CssBox cssBox, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value) ||
+            value.IndexOf("attr(", StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return value;
+        }
+
+        return LengthAttrFunctionPattern.Replace(
+            value,
+            match =>
+            {
+                var attrName = match.Groups["name"].Value;
+                var fallback = match.Groups["fallback"].Success
+                    ? match.Groups["fallback"].Value.Trim()
+                    : string.Empty;
+                var attributeValue = cssBox.GetAttribute(attrName, string.Empty).Trim();
+
+                if (!string.IsNullOrEmpty(attributeValue) &&
+                    CssValueParser.IsValidLength(attributeValue))
+                {
+                    return attributeValue;
+                }
+
+                if (!string.IsNullOrEmpty(fallback) &&
+                    CssValueParser.IsValidLength(fallback))
+                {
+                    return fallback;
+                }
+
+                return string.Empty;
+            });
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/ISelectionHandler.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/ISelectionHandler.cs
@@ -1,0 +1,9 @@
+namespace Broiler.Layout;
+
+internal interface ISelectionHandler
+{
+    int GetSelectingStartIndex(CssRect word);
+    int GetSelectedEndIndexOffset(CssRect word);
+    double GetSelectedStartOffset(CssRect word);
+    double GetSelectedEndOffset(CssRect word);
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/LayoutBoxUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/LayoutBoxUtils.cs
@@ -1,0 +1,128 @@
+using CssConstants = Broiler.CSS.CssConstants;
+
+namespace Broiler.Layout;
+
+/// <summary>
+/// Box-tree navigation helpers used by the layout engine (previous-sibling /
+/// in-flow-sibling resolution, inline-content and whitespace checks). Split out
+/// of <c>DomUtils</c> — which also holds renderer-only serialization — so this
+/// pure <see cref="CssBox"/>-tree logic can travel with the layout code into
+/// <c>Broiler.Layout</c> (see <c>docs/roadmap/broiler-layout-component.md</c> §2.1).
+/// </summary>
+internal static class LayoutBoxUtils
+{
+    public static bool ContainsInlinesOnly(CssBox box)
+    {
+        // CSS Flexbox §4 / CSS Grid §6: All direct children of a flex or
+        // grid container become flex/grid items, which are sized using
+        // shrink-to-fit (similar to inline-block).  Since Broiler does
+        // not implement a true flex/grid layout engine, force the inline
+        // formatting context so children are routed to FlowInlineBlock
+        // for content-based sizing instead of the block path (which
+        // would make them expand to full container width).
+        if (box.Display is "flex" or "inline-flex" or "grid" or "inline-grid")
+            return true;
+
+        foreach (CssBox b in box.Boxes)
+        {
+            // CSS2.1 §9.5: Floats are out-of-flow.  Their computed display
+            // is promoted to 'block' (§9.7) but they participate in the
+            // inline formatting context of their parent for line-box
+            // purposes.  Treat them as inline-compatible so that a parent
+            // with only text + floats is laid out using CreateLineBoxes
+            // instead of the block path (which would split the text around
+            // the float and introduce unwanted line breaks).
+            if (!b.IsInline && b.Float == CssConstants.None)
+                return false;
+        }
+
+        return true;
+    }
+
+    public static CssBox GetPreviousSibling(CssBox b)
+    {
+        if (b.ParentBox == null)
+            return null;
+
+        int index = b.ParentBox.Boxes.IndexOf(b);
+
+        if (index > 0)
+        {
+            int diff = 1;
+            CssBox sib = b.ParentBox.Boxes[index - diff];
+
+            while ((sib.Display == CssConstants.None || sib.Position == CssConstants.Absolute || sib.Position == CssConstants.Fixed) && index - diff - 1 >= 0)
+                sib = b.ParentBox.Boxes[index - ++diff];
+
+            return (sib.Display == CssConstants.None || sib.Position == CssConstants.Absolute || sib.Position == CssConstants.Fixed) ? null : sib;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the previous in-flow sibling of <paramref name="b"/>,
+    /// skipping floated, display:none, and absolutely/fixed positioned
+    /// elements (CSS2.1 §9.5, §9.6.1). Relatively positioned elements
+    /// remain in flow and are not skipped (CSS2.1 §9.3.1).
+    /// </summary>
+    public static CssBox GetPreviousInFlowSibling(CssBox b)
+    {
+        if (b.ParentBox == null)
+            return null;
+
+        int index = b.ParentBox.Boxes.IndexOf(b);
+
+        for (int i = index - 1; i >= 0; i--)
+        {
+            var sib = b.ParentBox.Boxes[i];
+            if (sib.Display == CssConstants.None
+                || sib.Position == CssConstants.Absolute
+                || sib.Position == CssConstants.Fixed
+                || sib.Float != CssConstants.None)
+                continue;
+            return sib;
+        }
+
+        return null;
+    }
+
+    public static CssBox GetPreviousContainingBlockSibling(CssBox b)
+    {
+        var conBlock = b;
+        int index = conBlock.ParentBox.Boxes.IndexOf(conBlock);
+
+        while (conBlock.ParentBox != null && index < 1 && conBlock.Display != CssConstants.Block && conBlock.Display != CssConstants.Table && conBlock.Display != CssConstants.TableCell && conBlock.Display != CssConstants.ListItem)
+        {
+            conBlock = conBlock.ParentBox;
+            index = conBlock.ParentBox != null ? conBlock.ParentBox.Boxes.IndexOf(conBlock) : -1;
+        }
+
+        conBlock = conBlock.ParentBox;
+
+        if (conBlock != null && index > 0)
+        {
+            int diff = 1;
+            CssBox sib = conBlock.Boxes[index - diff];
+
+            while ((sib.Display == CssConstants.None || sib.Position == CssConstants.Absolute || sib.Position == CssConstants.Fixed) && index - diff - 1 >= 0)
+                sib = conBlock.Boxes[index - ++diff];
+
+            return sib.Display == CssConstants.None ? null : sib;
+        }
+
+        return null;
+    }
+
+    public static bool IsBoxHasWhitespace(CssBox box)
+    {
+        if (box.Words[0].IsImage || !box.Words[0].HasSpaceBefore || !box.IsInline)
+            return false;
+
+        var sib = GetPreviousContainingBlockSibling(box);
+        if (sib != null && sib.IsInline)
+            return true;
+
+        return false;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/VerticalFlowPrototype.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/VerticalFlowPrototype.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Broiler.Layout;
+
+/// <summary>
+/// Feature gate for vertical writing-mode flow (logical layout + post-layout
+/// coordinate transform).
+///
+/// Enabled by default; set the environment variable <c>BROILER_VERTICAL_FLOW</c>
+/// to <c>0</c> to fall back to the legacy dimension-swap-only path (which does
+/// not rotate content flow). When enabled, it lays vertical-lr / vertical-rl
+/// subtrees out in a logical horizontal frame and rotates box/line/word
+/// positions into physical space (Stage 1), rotates glyphs 90° (Stage 2), does
+/// per-glyph vertical advance (Stage 3), and keeps multi-column content as a
+/// single logical block run so the rotation places it along the block axis
+/// (Stage 4b). All gating is behind <see cref="CssBoxProperties.IsVerticalWritingMode"/>
+/// checks, so horizontal-tb rendering is unaffected either way.
+///
+/// Known limitations: CJK-vs-Latin script detection (mixed orientation assumes
+/// Latin); baseline / vertical-align in a vertical context; genuine multi-column
+/// fragmentation in vertical mode (content flows as a single block run).
+/// </summary>
+internal static class VerticalFlowPrototype
+{
+    private static readonly bool _enabled =
+        Environment.GetEnvironmentVariable("BROILER_VERTICAL_FLOW") != "0";
+
+    public static bool Enabled => _enabled;
+}

--- a/Broiler.Layout/Broiler.Layout/HtmlTag.cs
+++ b/Broiler.Layout/Broiler.Layout/HtmlTag.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+namespace Broiler.Layout;
+
+/// <summary>
+/// Lightweight descriptor of the source HTML element a layout box was built
+/// from: its tag name, self-closing flag, and attribute bag. Relocated from the
+/// renderer into <c>Broiler.Layout</c> with the layout code (see
+/// <c>docs/roadmap/broiler-layout-component.md</c> §2.1). The attribute bag is
+/// exposed read-only to keep the component's public surface free of mutable
+/// collections; the parser still constructs it from a <see cref="Dictionary{TKey,TValue}"/>.
+/// </summary>
+public sealed class HtmlTag
+{
+    public HtmlTag(string name, bool isSingle, IReadOnlyDictionary<string, string>? attributes = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        Name = name;
+        IsSingle = isSingle;
+        Attributes = attributes;
+    }
+
+    public string Name { get; }
+    public IReadOnlyDictionary<string, string>? Attributes { get; }
+    public bool IsSingle { get; }
+    public bool HasAttributes() => Attributes != null && Attributes.Count > 0;
+    public bool HasAttribute(string attribute) => Attributes != null && Attributes.ContainsKey(attribute);
+    public string? TryGetAttribute(string attribute, string? defaultValue = null) =>
+        Attributes != null && Attributes.TryGetValue(attribute, out string? value) ? value : defaultValue;
+
+    public override string ToString() => $"<{Name}>";
+}

--- a/Broiler.Layout/Broiler.Layout/ILayoutEnvironment.cs
+++ b/Broiler.Layout/Broiler.Layout/ILayoutEnvironment.cs
@@ -1,0 +1,106 @@
+using System.Drawing;
+
+namespace Broiler.Layout;
+
+/// <summary>
+/// Host-injected services that layout needs during box construction and flow:
+/// font resolution and text metrics, replaced-element intrinsics, colour
+/// parsing, and a relayout/refresh callback.
+/// </summary>
+/// <remarks>
+/// This is the single seam that replaces layout's current direct use of
+/// <c>RGraphics</c>, <c>RFont</c>, <c>RImage</c> and <c>IHtmlContainerInt</c>
+/// (see <c>docs/roadmap/broiler-layout-component.md</c> §4). It deliberately
+/// exposes a narrow layout-metrics surface rather than the full renderer
+/// adapter/container, and uses only BCL geometry primitives so
+/// <c>Broiler.Layout</c> stays free of any graphics backend.
+/// </remarks>
+public interface ILayoutEnvironment
+{
+    /// <summary>
+    /// Resolves (and caches, host-side) a font for the given family, size and style.
+    /// </summary>
+    ILayoutFont GetFont(string family, double size, LayoutFontStyle style, string? fontFeatures = null);
+
+    /// <summary>Measures the full size of <paramref name="text"/> in <paramref name="font"/>.</summary>
+    SizeF MeasureText(ILayoutFont font, string text);
+
+    /// <summary>
+    /// Measures how much of <paramref name="text"/> fits within
+    /// <paramref name="maxWidth"/>, for line breaking.
+    /// </summary>
+    /// <param name="charFit">Number of characters that fit.</param>
+    /// <param name="charFitWidth">Width consumed by those characters.</param>
+    void MeasureText(ILayoutFont font, string text, double maxWidth, out int charFit, out double charFitWidth);
+
+    /// <summary>Width of a single whitespace glyph in <paramref name="font"/>, for word spacing and baselines.</summary>
+    double GetWhitespaceWidth(ILayoutFont font);
+
+    /// <summary>
+    /// Returns the intrinsic dimensions of a replaced-element image handle
+    /// (the host's opaque image object), for replaced-box sizing.
+    /// </summary>
+    ImageIntrinsics GetImageIntrinsics(object imageHandle);
+
+    /// <summary>Parses a CSS colour string into a concrete colour.</summary>
+    Color ParseColor(string value);
+
+    /// <summary>
+    /// Asks the host to refresh; when <paramref name="relayout"/> is <c>true</c>
+    /// a full layout pass is requested (e.g. after a late image load).
+    /// </summary>
+    void RequestRefresh(bool relayout);
+
+    /// <summary>
+    /// Dimensions of the viewport (initial containing block), in CSS pixels.
+    /// Layout input for viewport units and percentage-height resolution.
+    /// </summary>
+    SizeF ViewportSize { get; }
+
+    /// <summary>Origin of the root box, used to measure the document's actual extent.</summary>
+    PointF RootLocation { get; }
+
+    /// <summary>
+    /// The document's actual laid-out size. Layout accumulates the bottom-right
+    /// extent here (read-modify-write) so the host knows the scrollable size.
+    /// </summary>
+    SizeF ActualSize { get; set; }
+
+    /// <summary>
+    /// Whether the host prefers geometry to be drawn without anti-aliasing
+    /// (affects how layout rounds certain box edges).
+    /// </summary>
+    bool AvoidGeometryAntialias { get; }
+
+    /// <summary>Page dimensions used for pagination / page-break calculations.</summary>
+    SizeF PageSize { get; }
+
+    /// <summary>Top margin of the page box, used for page-break calculations.</summary>
+    int MarginTop { get; }
+
+    /// <summary>
+    /// Reports a non-fatal layout error to the host (always classified as a
+    /// layout-stage error).
+    /// </summary>
+    void ReportLayoutError(string message, Exception? exception = null);
+
+    /// <summary>Whether the host wants images loaded synchronously (no async loading).</summary>
+    bool AvoidAsyncImagesLoading { get; }
+
+    /// <summary>Whether the host wants to avoid late (deferred) image loading.</summary>
+    bool AvoidImagesLateLoading { get; }
+
+    /// <summary>
+    /// Creates a host image loader whose completion callback receives the loaded
+    /// image handle (or <c>null</c> on failure), the source rectangle, and whether
+    /// the load completed asynchronously.
+    /// </summary>
+    ILayoutImageLoader CreateImageLoader(Action<object?, RectangleF, bool> onComplete);
+
+    /// <summary>
+    /// Formats a list-item marker number for the given <c>list-style-type</c>
+    /// (e.g. decimal/roman/alpha/armenian/…). Host-side because it carries the
+    /// non-Latin numbering tables.
+    /// </summary>
+    string FormatListMarker(int number, string style);
+}

--- a/Broiler.Layout/Broiler.Layout/ILayoutFont.cs
+++ b/Broiler.Layout/Broiler.Layout/ILayoutFont.cs
@@ -1,0 +1,28 @@
+namespace Broiler.Layout;
+
+/// <summary>
+/// Font abstraction consumed by layout for text measurement and inline metrics.
+/// Exposes only the metrics layout reads from the renderer's <c>RFont</c> today,
+/// without binding <c>Broiler.Layout</c> to a graphics backend. Instances are
+/// resolved and measured through <see cref="ILayoutEnvironment"/>.
+/// </summary>
+public interface ILayoutFont
+{
+    /// <summary>The font size, in CSS pixels.</summary>
+    double Size { get; }
+
+    /// <summary>The line height of the font, in CSS pixels.</summary>
+    double Height { get; }
+
+    /// <summary>Offset of the underline from the baseline, in CSS pixels.</summary>
+    double UnderlineOffset { get; }
+
+    /// <summary>Left-side bearing applied before the first glyph, in CSS pixels.</summary>
+    double LeftPadding { get; }
+
+    /// <summary>
+    /// Space-separated OpenType feature tags enabled for this font (from
+    /// <c>font-feature-settings</c>), or <c>null</c> when none are set.
+    /// </summary>
+    string? FontFeatures { get; }
+}

--- a/Broiler.Layout/Broiler.Layout/ILayoutImageLoader.cs
+++ b/Broiler.Layout/Broiler.Layout/ILayoutImageLoader.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+
+namespace Broiler.Layout;
+
+/// <summary>
+/// Host-provided loader for a replaced-element or background image. Created via
+/// <see cref="ILayoutEnvironment.CreateImageLoader"/>; the loaded image is an
+/// opaque handle (<see cref="Image"/>) the host understands. Lets layout request
+/// image loading and read intrinsic geometry without binding to a graphics
+/// backend (see <c>docs/roadmap/broiler-layout-component.md</c> §2.2, §4).
+/// </summary>
+public interface ILayoutImageLoader : IDisposable
+{
+    /// <summary>The loaded image handle, or <c>null</c> if not yet loaded or load failed.</summary>
+    object? Image { get; }
+
+    /// <summary>
+    /// Sub-rectangle of the image to use, or <see cref="RectangleF.Empty"/> for the whole image.
+    /// </summary>
+    RectangleF Rectangle { get; }
+
+    /// <summary>Initiates image loading from the given source.</summary>
+    void LoadImage(string src, IReadOnlyDictionary<string, string>? attributes, Uri baseUrl);
+}

--- a/Broiler.Layout/Broiler.Layout/ImageIntrinsics.cs
+++ b/Broiler.Layout/Broiler.Layout/ImageIntrinsics.cs
@@ -1,0 +1,14 @@
+namespace Broiler.Layout;
+
+/// <summary>
+/// Intrinsic dimensions of a replaced element's image, supplied by the host so
+/// layout can size <c>&lt;img&gt;</c> and other replaced boxes without touching a
+/// graphics backend. Mirrors the <c>RImage.Width</c>/<c>Height</c>/
+/// <c>HasIntrinsicRatio</c> surface layout reads today.
+/// </summary>
+/// <param name="Width">Intrinsic width in CSS pixels, or 0 if unknown.</param>
+/// <param name="Height">Intrinsic height in CSS pixels, or 0 if unknown.</param>
+/// <param name="HasIntrinsicRatio">
+/// Whether the image carries an intrinsic aspect ratio usable for sizing.
+/// </param>
+public readonly record struct ImageIntrinsics(double Width, double Height, bool HasIntrinsicRatio);

--- a/Broiler.Layout/Broiler.Layout/LayoutFontStyle.cs
+++ b/Broiler.Layout/Broiler.Layout/LayoutFontStyle.cs
@@ -1,0 +1,18 @@
+namespace Broiler.Layout;
+
+/// <summary>
+/// Font style flags used when resolving a font through
+/// <see cref="ILayoutEnvironment.GetFont"/>. Declared by <c>Broiler.Layout</c>
+/// so the component does not depend on the renderer's font-style enum; the
+/// renderer-side environment implementation maps between the two. Flag values
+/// mirror the conventional <c>FontStyle</c> layout so the mapping is identity.
+/// </summary>
+[Flags]
+public enum LayoutFontStyle
+{
+    Regular = 0,
+    Bold = 1,
+    Italic = 2,
+    Underline = 4,
+    Strikeout = 8,
+}

--- a/Broiler.Layout/Broiler.Layout/LayoutHtmlSupport.cs
+++ b/Broiler.Layout/Broiler.Layout/LayoutHtmlSupport.cs
@@ -1,0 +1,44 @@
+using System.Drawing;
+using System.Net;
+
+namespace Broiler.Layout;
+
+/// <summary>
+/// HTML element/attribute name constants used by layout (tag dispatch, link
+/// detection). Ported from the renderer's <c>Broiler.HTML.Utils.HtmlConstants</c>
+/// for the layout extraction (see <c>docs/roadmap/broiler-layout-component.md</c>);
+/// the renderer keeps its own copy until the Phase 7 cleanup dedups.
+/// </summary>
+public static class HtmlConstants
+{
+    public const string A = "a";
+    public const string Hr = "hr";
+    public const string Iframe = "iframe";
+    public const string Img = "img";
+    public const string Href = "href";
+}
+
+/// <summary>
+/// Small layout helpers ported from the renderer's
+/// <c>Broiler.HTML.Utils.CommonUtils</c>. List-marker number formatting
+/// (<c>ConvertToAlphaNumber</c>) stays host-side and is reached via
+/// <see cref="ILayoutEnvironment.FormatListMarker"/>.
+/// </summary>
+public static class CommonUtils
+{
+    /// <summary>True for CJK-range characters (used as inter-character line-break opportunities).</summary>
+    public static bool IsAsianCharecter(char ch) => ch >= 0x4e00 && ch <= 0xFA2D;
+
+    /// <summary>Component-wise maximum of two sizes.</summary>
+    public static SizeF Max(SizeF size, SizeF other)
+        => new(System.Math.Max(size.Width, other.Width), System.Math.Max(size.Height, other.Height));
+}
+
+/// <summary>
+/// HTML text helpers ported from the renderer's <c>Broiler.HTML.Utils.HtmlUtils</c>.
+/// </summary>
+public static class HtmlUtils
+{
+    /// <summary>Decodes HTML character entities in text content.</summary>
+    public static string DecodeHtml(string str) => WebUtility.HtmlDecode(str);
+}

--- a/Broiler.slnx
+++ b/Broiler.slnx
@@ -9,6 +9,9 @@
     <Project Path="Broiler.CSS/Broiler.CSS/Broiler.CSS.csproj" />
     <Project Path="Broiler.CSS/Broiler.DOM/Broiler.Dom/Broiler.Dom.csproj" />
   </Folder>
+  <Folder Name="/Dependencies/Layout/">
+    <Project Path="Broiler.Layout/Broiler.Layout/Broiler.Layout.csproj" />
+  </Folder>
   <Folder Name="/Dependencies/HTML/">
     <Project Path="Broiler.HTML/Source/Broiler.HTML.Adapters/Broiler.HTML.Adapters.csproj" />
     <Project Path="Broiler.HTML/Source/Broiler.HTML.Core/Broiler.HTML.Core.csproj" />

--- a/docs/roadmap/broiler-layout-component.md
+++ b/docs/roadmap/broiler-layout-component.md
@@ -1,7 +1,416 @@
 # Broiler.Layout Component Plan
 
-**Status:** Decided — to be implemented after the Phase 5 renderer cutover lands.
+**Status:** ✅ **EXTRACTION COMPLETE (2026-06-27).** Phases 1–4 done — the ~9.7k-line layout engine now
+physically lives in `Broiler.Layout` (project references only `Broiler.CSS`/`Broiler.CSS.Dom`/`Broiler.Dom`).
+Full `Broiler.slnx` builds green; behavior preserved (only known flaky/pre-existing test failures); Layout
+arch tests 3/3. Polish done 2026-06-27: **namespace flip** (the 16 moved files are now `namespace Broiler.Layout`;
+~25 renderer/consumer files got `using Broiler.Layout;` + a handful of `Broiler.HTML.Utils` disambiguation aliases;
+full slnx green, arch 3/3, behavior preserved) and **identical-copy dedup** (`CssConstants` + `RegexParserUtils`
+removed from the renderer → it now uses the `Broiler.CSS` versions; `Broiler.HTML.Utils` gained a `Broiler.CSS` ref for
+its `CommonUtils`). Remaining = the **inherent** duplication that can't be deduped (`Broiler.Layout` can't reference the
+renderer, and the renderer's `CssLength`/`CssValueParser` carry colour the layout copies don't; `HtmlConstants`/
+`CommonUtils`/`HtmlUtils` are layout subsets vs renderer full) + re-running the WPT pixel gate on the final state before merge.
 **Date:** 2026-06-26
+
+**Progress (Phase 1):** `Broiler.Layout/Broiler.Layout/` created in the parent repo
+(top-level peer, no submodule per §8), referencing only `Broiler.CSS`, `Broiler.CSS.Dom`,
+`Broiler.Dom`. `ILayoutEnvironment` + `ILayoutFont` / `LayoutFontStyle` / `ImageIntrinsics`
+define the §4 host seam (BCL-only surface). `Broiler.Layout.Tests` mirrors
+`CssDomArchitectureTests` (refs-whitelist, no-consumer-leak, no-mutable-collections) — 3/3
+green; project added to `Broiler.slnx` under `/Dependencies/Layout/`.
+
+**Progress (Phase 2a — graphics/measurement coupling):** The `RGraphics g` parameter
+threaded through the 27 layout method signatures is now `ILayoutEnvironment g`; the two
+measurement sites route through it (`g.MeasureText`, `g.GetWhitespaceWidth`). `RFont`
+adopts `ILayoutFont` (members already matched — zero-cost). `LayoutEnvironment`
+(`Broiler.HTML.Dom`, internal) is the renderer-side adapter wrapping `RGraphics` +
+`IHtmlContainerInt`; the sole external caller `HtmlContainerInt.PerformLayout` constructs
+it. `Broiler.HTML.Adapters` + `.Dom` reference `Broiler.Layout` via the existing
+`..\..\..\` reach-to-root pattern. Full HTML stack + `Broiler.Cli` build green; flex/border
+layout tests match baseline (forwarding-only = behavior-identical; the flaky
+`FlexChildren_DisplayBlock_SideBySide` and pre-existing `MaxWidth_CapsFlexItemWidth` are
+not regressions — verified via stash A/B with an identical narrow filter).
+
+**Progress (Phase 2b — image intrinsics):** `CssLayoutEngine.MeasureImageSize` now takes
+`ILayoutEnvironment g` and computes `ImageIntrinsics? image = imageWord.Image is { } handle ?
+g.GetImageIntrinsics(handle) : null` once, replacing all 10 direct
+`imageWord.Image.Width/Height/HasIntrinsicRatio` reads. Sole caller
+`CssBoxImage.MeasureWordsSize` (already env-threaded) passes `g`. Verified behavior-identical
+via stash A/B: the 2 failing Acid2 tests (`CssBackgroundAttachmentFixed_RendersFromViewportOrigin`,
+`CssDataUriBackgroundImage_RendersCorrectly`) fail at baseline too — pre-existing background-image
+issues, unrelated to replaced-element sizing; the other 23 Acid2 image tests pass.
+
+**Structural finding (de-scopes the rest of §4's container row):** font/colour are **already
+decoupled behind an abstract seam** — `GetActualColor(string)` and `GetCachedFont(...)` are
+`abstract` on the moving base `CssBoxProperties` (decls at 1046/1344) and called there for all
+colour/font resolution; only the *overrides* in `CssBox` (4193/4195) and the async
+`OnImageLoadComplete`/`OnLoadImageComplete` glue (RequestRefresh) touch `ContainerInt`. Those
+overrides are renderer glue that can **stay behind at the Phase 4 move** (e.g. a partial/subclass
+split), so they need no env routing — and forcing them through a stored env would reintroduce a
+null-before-layout lifetime hazard for zero decoupling benefit. The env's `GetFont`/`ParseColor`
+remain available but are effectively redundant with this seam.
+
+**Net:** Phase 2's environment abstraction is complete for every *direct, non-seamed* coupling in
+the moving algorithm (measurement + image intrinsics). The remaining direct `ContainerInt` uses
+are not env material — they split into **layout-context inputs** (`ViewportSize` 15×,
+`RootLocation`, `ActualSize` = the initial containing block → Phase 3 computed-style/used-value)
+and **host services / renderer glue** (`ReportError`, `CreateImageLoadHandler`,
+`AvoidImagesLateLoading`/`AvoidAsyncImagesLoading`, the async RequestRefresh → stay behind at the
+move per §2.2).
+
+**Phase 3 reality-check (2026-06-26).** §3's premise — that `Broiler.CSS` already provides the
+`CssLength`/units/constants layout needs — is **false**. The value types layout depends on have no
+compatible `Broiler.CSS` equivalent and are **shared with the renderer**: `CssConstants` (412×, in
+`Broiler.HTML.Utils`, used across 21 renderer files), the pixel-resolving `CssValueParser` (76×,
+`Broiler.HTML.CSS` — a *different* API from `Broiler.CSS`'s syntax-only parser), `CssLength` (13×,
+`Broiler.HTML.CSS`), `CssUnit` (12×, `Broiler.HTML.Core.Core.Dom` — 16 members `Pixels`/`Ems`, vs
+`Broiler.CSS.CssUnit`'s 28 members `Px`/`Em`), `CssSpacingBox` (4×, a `CssBox` subclass that simply
+moves with layout in Phase 4). **Decision (user):** *add the primitives to `Broiler.CSS`, repoint
+layout only* — the renderer keeps its `Broiler.HTML.*` copies until Phase 7 dedups; temporary
+duplication accepted. Executed in behavior-neutral sub-steps:
+
+- **Phase 3.1 — `CssConstants` DONE 2026-06-26.** Added `Broiler.CSS/Broiler.CSS/CssConstants.cs`
+  (`public static`, 136 constants byte-identical to the `Broiler.HTML.Utils` copy — verified by
+  diff). `Broiler.HTML.Dom` now references `Broiler.CSS`; each of the 10 moving files that use
+  `CssConstants` got a `using CssConstants = Broiler.CSS.CssConstants;` alias (shadows just that
+  identifier — leaves other `Broiler.HTML.Utils` resolution intact, no reference-level edits). All
+  413 references now resolve to `Broiler.CSS`. Broiler.CSS + Dom + Cli build green;
+  `Acid3BorderLayoutTests` 5/5.
+
+- **Phase 3.2 — `CssValueParser` (length core) DONE 2026-06-26.** The moving files use only the
+  *static* length surface (`ParseLength` 65×, `ParseNumber` 4×, `GetActualBorderWidth` 4×,
+  `IsValidLength` 3×) — **not** the instance colour methods (colour goes through the abstract
+  `GetActualColor` seam). Extracted that static core verbatim into
+  `Broiler.CSS/Broiler.CSS/CssLengthParser.cs` (`public static class`; `IsFloat`/`IsInt`/
+  `IsValidLength`/`ParseNumber`/`ParseLength` overloads + `TryEvaluate*`/`GetUnit`/
+  `NormalizeSingleValueLengthFunction` helpers + `GetActualBorderWidth` + viewport `ThreadStatic` +
+  `SetViewportSize`). It touches no `Broiler.HTML.Core` and no `Color` (only `SizeF`). Named
+  `CssLengthParser` to avoid colliding with the pre-existing syntax-only `Broiler.CSS.CssValueParser`;
+  the 7 moving files that call it got a `using CssValueParser = Broiler.CSS.CssLengthParser;` alias
+  (all 76 refs repointed, no per-call edits). Viewport `ThreadStatic` is shared mutable state set at
+  the single caller `HtmlContainerInt` (602) — added a sibling `Broiler.CSS.CssLengthParser.SetViewportSize`
+  call there so the port stays in sync per pass. Broiler.CSS + Dom + Orchestration + Cli build green.
+  Verified behavior-preserving: in the layout-heavy batch the only failures were the 3 known
+  pre-existing (`MaxWidth_CapsFlexItemWidth`, `CssDataUriBackgroundImage`, `CssBackgroundAttachmentFixed`)
+  plus 2 that **pass in isolation** (`Acid2_Render_IsNotBlankOrAllRed`, `FixedChild_DoesNot_Inflate_Parent_AutoHeight`)
+  = the suite's documented order-flakiness; Acid3BorderLayoutTests 5/5 alone. (WPT not re-run.)
+
+- **Phase 3.3 (`CssLength`) + 3.4 (`CssUnit`) + 3.5 (`RegexParserUtils`) DONE 2026-06-26.** Ported
+  `CssLength` to `Broiler.CSS/Broiler.CSS/CssLength.cs` (`public sealed`), remapping its unit enum onto
+  the existing `Broiler.CSS.CssUnit` (`Px`/`Em`/… for `Pixels`/`Ems`/…) — so 3.4 folds in. Layout uses
+  only 3 enum members (`Pixels` 9×→`Px`, `Ems` 2×→`Em`, `None`); all 10 `CssLength` instances are local
+  `new CssLength(...)` (never cross to the renderer). Repointed the 4 files via
+  `using CssLength = Broiler.CSS.CssLength;` + `using CssUnit = Broiler.CSS.CssUnit;` aliases plus the
+  two member renames. Ported the self-contained `RegexParserUtils` (116 lines, `[GeneratedRegex]`, only
+  `System.Text.RegularExpressions`) to `Broiler.CSS/Broiler.CSS/RegexParserUtils.cs`; `CssBoxProperties`
+  repointed via `using RegexParserUtils = Broiler.CSS.RegexParserUtils;`.
+  **Milestone: the moving files are now fully decoupled from `Broiler.HTML.CSS`** — the dead
+  `using Broiler.HTML.CSS;` was removed from all 8 files that had it, and the `Broiler.HTML.CSS.Core.Parse`
+  import is gone; a grep for `Broiler.HTML.CSS` across the 13 moving files returns nothing. Broiler.CSS +
+  Dom + Cli build green; verified behavior-preserving (Acid3BorderLayout 5/5; Acid3CssCompliance 58/59
+  with only the memory-flagged pre-existing `Border_Shorthand_Expands_Color_To_Individual_Sides`,
+  confirmed failing at baseline via stash A/B; FlexLayout only the pre-existing `MaxWidth`). WPT not re-run.
+
+- **Phase 3 computed-style input + ICB inputs DONE 2026-06-26 → Phase 3 COMPLETE.**
+  - *Computed-style input confirmed clean (no code change):* a grep of the 13 moving files for
+    `CssData`/`CssBlock`/`GetComputedStyle`/`CssComputedStyle` returns nothing (only `CssBox.SourceElement`,
+    a property the renderer's projection *sets*). Layout consumes the projected `CssBoxProperties` string
+    fields that Phase 5's `GetCascadedStyle`→`SetPropertyValue` fills — exactly the §5 boundary.
+  - *ICB inputs abstracted:* added `ViewportSize` (get), `RootLocation` (get) and `ActualSize` (get/set) to
+    `ILayoutEnvironment` (BCL `SizeF`/`PointF`); the renamed renderer adapter `HtmlLayoutEnvironment` forwards
+    them to `IHtmlContainerInt`. `CssBox` gained a stored `LayoutEnvironment` property with parent-chain
+    resolution (mirroring `ContainerInt`), set on the root in `HtmlContainerInt.PerformLayout` before
+    `Root.PerformLayout`. Replaced all 19 `ContainerInt.{ViewportSize×15, RootLocation×2, ActualSize×2}`
+    reads/writes in `CssBox.cs` with `LayoutEnvironment.*` (adapter renamed `LayoutEnvironment`→
+    `HtmlLayoutEnvironment` to avoid colliding with the new property name). Dom + Orchestration + Cli build
+    green; Layout arch tests 3/3. Behavior-preserving across a 98-test layout sweep — all 6 failures are
+    pre-existing or flaky (`MaxWidth`, `Border_Shorthand`, the 3 Acid3 DOM-removal/cascade tests — all
+    stash-A/B-confirmed baseline-failing — plus the isolation-passing `FlexChildren` flake). WPT not re-run.
+
+**Phase 4 prep — decisions (user) + first increment (2026-06-26):** Survey of the residual `Broiler.HTML.*`
+coupling drove two decisions: **(1) move `HtmlTag` into `Broiler.Layout`** (self-contained, used 30× for
+Name/Attributes/TryGetAttribute/HasAttribute; constructed by the parser + 4 projects — moving ripples there,
+sequence carefully); **(2) extend `ILayoutEnvironment` and route host-services through the stored env**
+(over the abstract-seam/subclass-split alternative).
+- *Env-lifetime refactor done:* `HtmlLayoutEnvironment` is now container-owned (`ctor(IHtmlContainerInt)` +
+  `SetGraphics(g)` per pass) and bound to the root at construction in `DomParser` (`root.LayoutEnvironment =
+  new HtmlLayoutEnvironment(htmlContainer)` beside `root.ContainerInt = …`), so it's available before the
+  first layout pass. `HtmlContainerInt.PerformLayout` now reuses the bound env and just `SetGraphics(g)`.
+- *Routed via the stored env:* `CssBox`'s `GetCachedFont`→`env.GetFont` (with `(LayoutFontStyle)(int)st` round-trip
+  + `(RFont)` cast), `GetActualColor`→`env.ParseColor`, and `OnImageLoadComplete`'s `RequestRefresh`. Also fixed
+  an ICB site the Phase-3 sed missed (`ContainerInt!.ViewportSize`@401, the `!` form → `LayoutEnvironment.ViewportSize`).
+  Dom+Orchestration+Cli build green; behavior-preserving (89-test font/colour sweep: only the flaky
+  `Acid2_Render` (isolation-pass) + 3 A/B-confirmed pre-existing background/border failures).
+
+**Phase 4 prep — increment 2 done + verified (2026-06-26):** Established the env/container **lockstep** and
+converted the root-detection guards. Found a latent bug: the list-item marker box (`CreateListItemBox`, 3227) is
+created with a **null parent** and set `_htmlContainer` directly but not `_layoutEnvironment` — so after increment 1
+its marker `GetCachedFont`→`env.GetFont` would NRE. Fixed by also propagating `_listItemBox._layoutEnvironment =
+LayoutEnvironment` (correctness + lockstep). Audited every `_htmlContainer`/`.ContainerInt` assignment: only the
+root (`DomParser`, lockstep with the env) and that list-item site touch a CssBox's container directly; all else is
+parent-chain. With lockstep holding, converted the **14 `ContainerInt != null`** guards → `LayoutEnvironment != null`
+and `AvoidGeometryAntialias` → a new bool on `ILayoutEnvironment` (adapter forwards). Layout+Cli build green;
+behavior-preserving (72-test sweep + 41 List* tests — only flaky `FlexChildren` + pre-existing `MaxWidth`/
+`Border_Shorthand`/`SelectListBox`, the last A/B-confirmed baseline-failing).
+
+**ACCURATE remaining `ContainerInt` surface (after increments 1–2):** in `CssBox.cs` — `ReportError` (555, needs
+`HtmlRenderErrorType` abstracted into Layout), `CreateImageLoadHandler` (3069, needs `IImageLoadHandler` abstracted),
+and `BreakPage` (3583)'s `PageSize`/`MarginTop` (pagination inputs — add to `ILayoutEnvironment`, same pattern as the
+ICB inputs); plus the list-item propagation (now sets both container+env) and the property/field definition itself.
+In `CssBoxImage.cs` — `RequestRefresh`, `CreateImageLoadHandler`, `AvoidImagesLateLoading`/`AvoidAsyncImagesLoading`;
+in `CssLayoutEngine`/`Table` — `ReportError`. **Next easy increment:** `PageSize`/`MarginTop` → env. **Then the two
+new abstractions** (`HtmlRenderErrorType`-equivalent enum + `IImageLoadHandler`-equivalent interface in Layout) to
+clear `ReportError`/`CreateImageLoadHandler`/image-loading across `CssBox`+`CssBoxImage`+`CssLayoutEngine`.
+
+**Phase 4 prep — increment 3 done + verified (2026-06-26):** Added `PageSize` (SizeF), `MarginTop` (int) and
+`ReportLayoutError(message, exception)` to `ILayoutEnvironment` (the moving files only ever report
+`HtmlRenderErrorType.Layout`, so a focused method beats dragging the enum into Layout; adapter maps to `.Layout`).
+Routed `BreakPage`'s pagination reads and both `ReportError` sites (`CssBox` catch @555, `CssLayoutEngineTable`
+@83 via `tableBox.LayoutEnvironment`) through the env. Layout+Dom+Cli green; behavior-preserving (72-test sweep —
+only flaky `FixedChild` (isolation-pass) + pre-existing `MaxWidth`/`Border_Shorthand`). **`CssBox.cs` now has a
+single remaining `ContainerInt` member access: `CreateImageLoadHandler` @3069.** All remaining `ContainerInt`
+coupling is in the **image-loading path**: `CssBox.CreateImageLoadHandler`, and `CssBoxImage`'s `RequestRefresh` +
+`CreateImageLoadHandler` + `AvoidImagesLateLoading`/`AvoidAsyncImagesLoading`. This is the entangled increment —
+it needs an `IImageLoadHandler`-equivalent interface in Layout AND the `RImage` callback re-typed to an opaque
+`object` (the `OnImageLoadComplete(RImage,…)`/`OnLoadImageComplete(RImage,…)` signatures). Do it together with the
+`RImage` image-handle re-typing.
+
+**Phase 4 prep — increment 4 (safe subset) done + verified (2026-06-26):** Added `AvoidAsyncImagesLoading` +
+`AvoidImagesLateLoading` (bools) to `ILayoutEnvironment`; routed `CssBoxImage`'s two flag reads + its
+`RequestRefresh` through the env. Cli green; Acid2 image suite 23/25 (only the 2 A/B-confirmed pre-existing
+background failures). **The moving files now have exactly ONE `ContainerInt` member access left:
+`CreateImageLoadHandler` (CssBox @3069 for backgrounds, CssBoxImage @40 for `<img>`).**
+
+**FINAL `ContainerInt` increment — `CreateImageLoadHandler` + `IImageLoadHandler` + `RImage` (the 4-project one):**
+The full surface (mapped): `IImageLoadHandler` (`internal`, `Broiler.HTML.Core`, `IDisposable`) exposes
+`RImage Image`/`RectangleF Rectangle`/`LoadImage(string, Dictionary<string,string>, Uri)`. It threads through
+`CssBox._backgroundImageLoadHandlers` (`List<IImageLoadHandler>`, reads `.Image` into `object?[]` at 170/176),
+`CssBoxImage._imageLoadHandler`, the callback delegate `ActionInt<RImage, RectangleF, bool>` (passed
+`OnImageLoadComplete`/`OnLoadImageComplete`), and the renderer's
+`BackgroundImageDrawHandler.DrawBackgroundImage(…, IImageLoadHandler, …)` which reads `.Image` (RImage) 6× to
+`DrawImage`/`GetTextureBrush`. Plan: define `ILayoutImageLoader : IDisposable` in Layout
+(`object? Image`, `RectangleF Rectangle`, `LoadImage(string, IReadOnlyDictionary<string,string>?, Uri)` — note
+`IReadOnlyDictionary` to satisfy the no-mutable-collections arch test); add
+`ILayoutImageLoader CreateImageLoader(Action<object?, RectangleF, bool> onComplete)` to `ILayoutEnvironment`;
+have the concrete `ImageLoadHandler`/`IImageLoadHandler` provide the `object? Image` via explicit interface
+impl (covariance: `RImage Image` doesn't auto-satisfy `object Image`); re-type the box fields/callbacks to
+`ILayoutImageLoader`/`object`; cast `(RImage)` at the renderer paint boundary (`BackgroundImageDrawHandler` +
+the replaced-`<img>` paint site) — also re-types `CssRect.Image`/`CssRectImage.Image`/`CssBoxImage.Image`
+`RImage`→`object`. Large + crosses Layout/Core/Dom/Rendering; do as a focused step.
+
+**Phase 4 prep — increment 5 (image-loader abstraction) DONE + verified (2026-06-26) → MOVING FILES ARE NOW
+`ContainerInt`-SERVICE-FREE.** Key simplifier discovered: the legacy `BackgroundImageDrawHandler.DrawBackgroundImage(IImageLoadHandler)`
+is **dead** (no callers — only its own interface-dispatch shim), and the active background paint path already reads
+`box.LoadedBackgroundImage` as **`object?`** (via `FragmentTreeBuilder`). So no paint-boundary changes were needed.
+Implemented with a **wrapper adapter** (no `Broiler.HTML.Core` edits): new `ILayoutImageLoader : IDisposable` in Layout
+(`object? Image`, `RectangleF Rectangle`, `LoadImage(string, IReadOnlyDictionary<string,string>?, Uri)` — `IReadOnlyDictionary`
+keeps the no-mutable-collections arch test green); `ILayoutImageLoader CreateImageLoader(Action<object?,RectangleF,bool>)`
+on `ILayoutEnvironment`; the adapter's private `LayoutImageLoader` wraps the renderer's `IImageLoadHandler` and adapts the
+`RImage`→`object` callback. Re-typed `CssBox._backgroundImageLoadHandlers` (`List<IImageLoadHandler>`→`List<ILayoutImageLoader>`)
+and `CssBoxImage._imageLoadHandler`; both `CreateImageLoadHandler` calls → `LayoutEnvironment.CreateImageLoader`; callbacks
+`OnImageLoadComplete`/`OnLoadImageComplete` now take `object?` (the latter casts `(RImage)image` to set the inline word — RImage
+re-typing deferred). Build green Layout+Dom+Orch+Cli; Layout arch 3/3; behavior-preserving (Acid2 image 23/25 only the 2
+A/B-pre-existing bg; broad sweep only flaky `FlexChildren` + pre-existing `MaxWidth`/`Border_Shorthand`).
+
+**STATE: moving files have ZERO `ContainerInt` member accesses + ZERO `IImageLoadHandler`** — every `IHtmlContainerInt`
+host-service now flows through `ILayoutEnvironment`. The only residual `ContainerInt` is the property/field definition itself
+plus the list-item propagation `_listItemBox._htmlContainer = ContainerInt` (vestigial — nothing reads it now; can be dropped,
+keeping only the `_layoutEnvironment` propagation). **Remaining before the file move:** (a) drop the vestigial `ContainerInt`
+property/field + `DomParser` `root.ContainerInt =` if truly unread; (b) move `HtmlTag` into Layout; (c) re-type the `RImage`
+image handle → `object` (`CssRect.Image`/`CssRectImage.Image`/`CssBoxImage.Image` + the `(RImage)` cast) and `ActualFont`
+`RFont`→`ILayoutFont` (renderer casts at paint); plus the smaller `Broiler.HTML.Utils`/`Adapters`/`Core.Entities` bits; then
+the file move (`DomUtils`/`CssUtils` travel with the code).
+
+**Phase 4 prep — increment 6 (RImage + RFont handle re-typing) DONE + verified (2026-06-27).** Confirmed the paint
+path stores both as opaque `object?` handles (`DisplayList.FontHandle`/`ImageHandle` are `object?`; the raster
+backend casts `is RFont`/`is RImage`), and the active path is `FragmentTreeBuilder` (reads `imgBox.Image` and
+`ActualFont` as handles) — so **no paint-boundary changes needed**, the runtime objects stay `RFont`/`RImage`.
+- *RImage→object:* re-typed `CssRect.Image` (virtual), `CssRectImage.Image`/`_image`, `CssBoxImage.Image` to
+  `object`; dropped the `(RImage)` cast in `OnLoadImageComplete`. Renderer-side casts added where external code reads
+  the box image as `RImage`: `ContextMenuHandler` (`SaveToFile`/`SetToClipboard`).
+- *RFont/ActualFont→ILayoutFont (+ FontStyle→LayoutFontStyle):* re-typed `_actualFont`/`ActualFont` and
+  `GetCachedFont` (abstract + `CssBox` override) to `ILayoutFont`; the font-style computation now builds
+  `LayoutFontStyle` (was `Broiler.Graphics.FontStyle`); the override is now `=> LayoutEnvironment.GetFont(…)` (no cast/
+  conversion). Renderer-side cast added: `SelectionHandler` (`control.MeasureString((RFont)…ActualFont, …)`).
+  `ActualFont` is only read for `.Size`/`.Height` (both on `ILayoutFont`). All builds green
+  (Dom/Orch/Cli/WPF/Image/Graphics); behavior-preserving (Acid2 image 23/25 pre-existing-only; broad font/layout sweep
+  only flaky `Acid2_Render` (isolation-pass) + pre-existing `Border_Shorthand`). **`RImage` and `RFont` are gone from
+  the moving files.**
+
+**Remaining `Broiler.HTML.*` in moving files (post-incr-6):** `HtmlTag` (30, MOVE into Layout — ripples to parser+4
+projects), `DomUtils` (7, layout helpers move/port — split from its serialization methods), `HtmlConstants` (5) +
+`CommonUtils` (4, layout bits `IsAsianCharecter`/`Max`) + `HtmlUtils` (2) → PORT to Layout, `IHtmlContainerInt` (3, the
+`ContainerInt` property — read EXTERNALLY by SelectionHandler/DomParser/DomUtils, so a move-time rework not a simple
+drop), plus residual `using Broiler.HTML.Adapters` (likely now vestigial — RFont/RImage gone; test-remove later) /
+`Core.Core.Dom`/`Core.Entities`/`Core.IR`. **Next:** move `HtmlTag`; port the `Utils` bits.
+
+**Phase 4 prep — increment 7 (Utils ports) DONE + verified (2026-06-27).** New
+`Broiler.Layout/Broiler.Layout/LayoutHtmlSupport.cs` ports `HtmlConstants` (A/Hr/Iframe/Img/Href — the 5 layout uses),
+`CommonUtils.IsAsianCharecter`/`Max`, and `HtmlUtils.DecodeHtml` (renderer keeps its copies). The heavier
+`CommonUtils.ConvertToAlphaNumber` (list-marker numbering — pulls Greek/Roman/Armenian/Hebrew/Hiragana tables) stays
+host-side: added `string FormatListMarker(int, string)` to `ILayoutEnvironment` (adapter → the renderer's
+`CommonUtils.ConvertToAlphaNumber`); the one call site (`CssBox.CreateListItemBox` @3252) now uses
+`LayoutEnvironment.FormatListMarker`. Aliased `HtmlConstants`/`CommonUtils`/`HtmlUtils` → `Broiler.Layout.*` in `CssBox`
+(+ `HtmlConstants` in `CssBoxHelper`). Dom+Cli build green; behavior-preserving (Acid3 sweep — ordered-list markers /
+word-break / text-decode exercised — only the known pre-existing DOM-removal/cascade + `Border_Shorthand` failures).
+
+**Remaining `Broiler.HTML.*` in moving files (post-incr-7):** `HtmlTag` (30, MOVE into Layout — only `Broiler.HTML.Image`
+reads it externally besides the parser; `Broiler.HTML.CSS`'s "HtmlTag" was a false positive = a regex string const),
+`DomUtils` (7, layout helpers — `GetPreviousSibling`/whitespace/inline checks — move/port; split from its serialization
+methods), `IHtmlContainerInt` (the `ContainerInt` property, read externally → move-time rework), residual
+`using Broiler.HTML.Adapters` (test-remove — likely vestigial) / `Core.Core.Dom` / `Core.Entities` / `Core.IR`.
+**Next:** move `HtmlTag` (make public, relocate to Layout, add `Broiler.Layout` ref to `Broiler.HTML.Image`, repoint
+parser constructors + alias readers).
+
+**Phase 4 prep — increment 8 (Adapters-vestigial removal) DONE + verified (2026-06-27).** With `RFont`/`RImage` gone,
+`using Broiler.HTML.Adapters;` is now dead in all moving files — test-removed (0 build errors), then deleted
+permanently (incl. the 3 BOM-prefixed files via Edit). Dom+Cli green. **`Broiler.HTML.Adapters` is fully decoupled
+from the moving files.**
+
+**`HtmlTag` move — ANALYZED, deferred as a focused step (largest remaining ripple).** Blocker: `HtmlTag.Attributes`
+is a `public Dictionary<string,string>` (+ `Dictionary` ctor param) → trips the Layout arch test's no-mutable-collections
+rule. Fix is `IReadOnlyDictionary` on the public surface (`Attributes` read-only everywhere — the `tag.Attributes[att]`
+in DomParser is an indexer *get*), BUT two consumers forward it to `Dictionary`-typed PUBLIC FACADE APIs
+(`HtmlLinkClickedEventArgs(string, Dictionary)`; `IStylesheetLoader.LoadStylesheet(…, Dictionary, …)` which further
+forwards into `HtmlStylesheetLoadEventArgs`). Plan (non-breaking): HtmlTag exposes `IReadOnlyDictionary` (ctor accepts
+`Dictionary` implicitly), and cast `(Dictionary<string,string>)…HtmlTag.Attributes` at the 2 forward sites
+(`HtmlContainerInt:875`, `DomParser:98` — runtime is always a `Dictionary`). Then: create public
+`Broiler.Layout/HtmlTag.cs`, delete `Broiler.HTML.Dom/HtmlTag.cs`, add `Broiler.Layout` ref to `Broiler.HTML.Image`
+(Orchestration gets it via Dom transitively, but add explicit), alias `using HtmlTag = Broiler.Layout.HtmlTag;` in the
+~12 referencing files (6 moving + `HtmlParser` + `DomUtils` + `DomParser` + `HtmlContainerInt` + `FragmentTreeBuilder` +
+`Image/HtmlContainer`). ~15-18 edits across 3 projects — do as a focused step.
+
+**Phase 4 prep — increment 9 (HtmlTag move) DONE + verified (2026-06-27).** Executed the plan above. Created public
+`Broiler.Layout/Broiler.Layout/HtmlTag.cs` (`Attributes` as `IReadOnlyDictionary<string,string>?` — passes the arch
+test; ctor still accepts `Dictionary` implicitly); deleted `Broiler.HTML.Dom/HtmlTag.cs`; aliased
+`using HtmlTag = Broiler.Layout.HtmlTag;` in all 13 referencing files (6 moving + `HtmlParser` + `HtmlParserDump` +
+`DomUtils` + `Image/HtmlContainer` + `HtmlContainerInt` + `FragmentTreeBuilder` + `DomParser`); cast
+`(Dictionary<string,string>)…HtmlTag.Attributes` at the two facade-forward sites (`HtmlContainerInt:875`,
+`DomParser:98`). Transitive `Broiler.Layout` ref flows to Orchestration/Image (no explicit csproj ref needed). All
+projects build green (Dom/Orch/Image/Cli/WPF); Layout arch tests 3/3 (IReadOnlyDictionary not flagged);
+behavior-preserving (Acid3 58/59 + Acid2 23/25 — only flaky `FixedChild` + pre-existing). **`HtmlTag` (the biggest
+single coupling, 30 refs) is resolved — it now lives in `Broiler.Layout`.**
+
+**Remaining `Broiler.HTML.*` in moving files (post-incr-9):** `DomUtils` (7, `Broiler.HTML.Dom.Utils` — layout helpers
+`GetPreviousSibling`/`GetPreviousInFlowSibling`/`IsBoxHasWhitespace`/`ContainsInlinesOnly`; move/port, split from its
+serialization methods which stay), `IHtmlContainerInt` (the `ContainerInt` property — read externally → move-time
+rework), small `Core.Core.Dom`/`Core.Entities`/`Core.IR` types (`IBorderRenderData`/`IBackgroundRenderData` on
+`CssBoxProperties`, etc.), and `using Broiler.HTML.Utils;` (now likely vestigial after the Utils ports — test-remove
+like Adapters). **Next:** test-remove vestigial `Broiler.HTML.Utils`; then `DomUtils` split; then the `ContainerInt`
+property + `Core.*` interfaces; then the file move.
+
+**Phase 4 prep — increment 10 (Utils-vestigial + DomUtils split) DONE + verified (2026-06-27).**
+- *`using Broiler.HTML.Utils;` removed* from all moving files (vestigial after the Utils ports — test-removed, 0 errors,
+  deleted). **`Broiler.HTML.Utils` decoupled from moving files.**
+- *`DomUtils` split:* extracted the 5 pure `CssBox`-tree helpers (`ContainsInlinesOnly`, `GetPreviousSibling`,
+  `GetPreviousInFlowSibling`, `GetPreviousContainingBlockSibling` [internal dep], `IsBoxHasWhitespace`) into a new moving
+  file `Broiler.HTML.Dom/Utils/LayoutBoxUtils.cs` (internal static, `Broiler.HTML.Dom` ns, `CssConstants` via Broiler.CSS
+  alias). Deleted them from `DomUtils.cs` (which keeps its renderer-only serialization). Repointed the 4 externally-called
+  ones at all call sites: 3 moving files (`CssBox`/`CssLayoutEngine`/`CssBoxHr`) + `DomParser` (Orchestration) +
+  `DomUtils` itself (one internal `IsBoxHasWhitespace` call in its serialization). Dom+Orch+Cli green; behavior-preserving
+  (layout sweep — only flaky `FlexChildren` + pre-existing `MaxWidth`/`Border_Shorthand`). **`DomUtils` decoupled from
+  moving files.**
+
+**FINAL remaining `Broiler.HTML.*` in moving files — the move-time / inverse-direction couplings:**
+- `IHtmlContainerInt` (the `CssBox.ContainerInt` property, `Broiler.HTML.Core`) — read EXTERNALLY (`SelectionHandler`,
+  `DomParser`, `DomUtils`) as the box→container link; needs a move-time rework (renderer obtains the container another
+  way, or the property is dropped/relocated).
+- `IBorderRenderData`/`IBackgroundRenderData` (`Broiler.HTML.Core.IR`) — `CssBoxProperties` IMPLEMENTS these so the
+  renderer reads border/background geometry off the box; either move the interfaces into `Broiler.Layout` (renderer
+  references them there) or expose the data differently.
+- `using Broiler.HTML.Dom.Utils;` is now only for the moving peers (`CssUtils`/`LayoutBoxUtils`) — resolves after the move.
+  Likely-vestigial `Core.Core.Dom`/`Core.Entities` imports — test-remove like Adapters/Utils.
+These are the inverse-direction couplings (renderer reading the box); resolve them, then **do the file move** (relocate
+the 13 + `LayoutBoxUtils` into `Broiler.Layout`, repoint the `InternalsVisibleTo` consumers, flip namespaces).
+
+**Phase 4 prep — increment 11 (vestigial Core.* removal) DONE + verified (2026-06-27).** `using Broiler.HTML.Core.Core.Dom;`
+(only `CssUnit`, now Broiler.CSS-aliased + `Border`, unused) and `using Broiler.HTML.Core.Entities;` (only `HtmlRenderErrorType`,
+now via env) were vestigial in the moving files — test-removed (0 errors), deleted. Dom+Cli green.
+
+**PHASE 4 PREP ESSENTIALLY COMPLETE.** The moving files are now decoupled from EVERY `Broiler.HTML.*` namespace except the
+two intrinsic move-boundary couplings + the moving peers:
+- `using Broiler.HTML.Dom.Utils;` — only for the moving peers `CssUtils`/`LayoutBoxUtils` (they relocate together; namespace
+  flips at the move).
+- `using Broiler.HTML.Core;` — the `CssBox.ContainerInt` property (`IHtmlContainerInt`). **Inverse-direction:** the renderer
+  SETS it (`DomParser:49`) and READS it (`SelectionHandler`, `DomParser`, `DomUtils`) as the box→container link; the layout
+  algorithm itself no longer touches it (0 member accesses). Resolution at the move: re-type to `object` (renderer casts at
+  the ~9 read sites) OR eliminate it (external readers obtain the container another way — they're all renderer code that
+  already has it).
+- `using Broiler.HTML.Core.IR;` — `CssBoxProperties` IMPLEMENTS `IBorderRenderData`/`IBackgroundRenderData`. **Inverse-direction
+  + legacy:** these (BCL-only string/double/Color contracts) are consumed ONLY by the dead `BordersDrawHandler`/
+  `BackgroundImageDrawHandler` (the active `FragmentTreeBuilder`/`PaintWalker` paint path does NOT use them). Resolution at the
+  move: relocate the two interfaces into `Broiler.Layout` (Core/Rendering reference them there) — or drop the implementation if
+  the legacy paint handlers are confirmed removable (Phase 7 territory).
+
+**Remaining = Phase 4 proper (the file move):** handle the 2 inverse-direction couplings above as part of relocating the 13
+files + `LayoutBoxUtils` into `Broiler.Layout` (set `RootNamespace`, flip `namespace Broiler.HTML.Dom` → `Broiler.Layout`,
+repoint the `InternalsVisibleTo`/8 consumers, move the `Dom.Utils` peers' namespace too). The forward-direction decoupling is
+done: moving files reference only `Broiler.CSS`/`Broiler.CSS.Dom`/`Broiler.Dom`/`Broiler.Layout` + BCL for all their logic.
+
+**Phase 4 prep — increment 12 (the two inverse-direction couplings) DONE + verified (2026-06-27) → PHASE 4 PREP COMPLETE.**
+- *Render-data interfaces (`Core.IR`):* the legacy `BordersDrawHandler`/`BackgroundImageDrawHandler` (+ their
+  `IBorderRenderData`/`IBackgroundRenderData` contracts) are **dead** (no external callers; nothing passes a `CssBox`; active
+  paint = `FragmentTreeBuilder`/`PaintWalker`). So just dropped `: IBorderRenderData, IBackgroundRenderData` from
+  `CssBoxProperties`. The other `Core.IR` type it used — the `BoxKind` enum — was **relocated to `Broiler.Layout/BoxKind.cs`**
+  (public; `ComputedStyle`/`DomParser` repointed — `DomParser` via `using BoxKind = …` to dodge an `HtmlConstants` ambiguity;
+  `Broiler.HTML.Core` reaches it transitively via Adapters→Layout, no new ref/cycle). `using Broiler.HTML.Core.IR;` removed.
+- *`ContainerInt` (`IHtmlContainerInt`):* re-typed `CssBox.ContainerInt` + `_htmlContainer` to **`object`** (layout never reads
+  it); removed `using Broiler.HTML.Core;` from the 3 files; cast `(IHtmlContainerInt)` at the 8 external read sites (`DomUtils`
+  6, `DomParser` 2). Caught a missed layout reader — `CssRect.BreakPage` used `OwnerBox.ContainerInt.PageSize`/`MarginTop` →
+  routed through `OwnerBox.LayoutEnvironment`. Build green Dom/Core/Orch/Cli; Layout arch 3/3; behavior-preserving (only flaky
+  `Acid2_Render`/`Acid2_IntroSection` [isolation+baseline pass] + pre-existing `Border_Shorthand`/bg).
+
+**✅ PHASE 4 PREP COMPLETE — forward-direction decoupling 100%.** Moving files (13 + `LayoutBoxUtils`) reference ONLY
+`Broiler.CSS`/`Broiler.CSS.Dom`/`Broiler.Dom`/`Broiler.Layout` + BCL + the moving peers (`CssUtils`/`LayoutBoxUtils`, ns
+`Broiler.HTML.Dom.Utils` — flips at the move). No renderer coupling remains.
+
+**NEXT = PHASE 4 PROPER (physical file move):** relocate the 13 + `LayoutBoxUtils` + `CssUtils` into the `Broiler.Layout`
+project (move the `.cs`; flip `namespace Broiler.HTML.Dom`/`.Utils` → `Broiler.Layout`; drop them from `Broiler.HTML.Dom.csproj`).
+Then cross-assembly visibility: `CssBox` etc. are `internal` → add `[InternalsVisibleTo]` from `Broiler.Layout` to the 8 consumer
+assemblies (mirror `Broiler.HTML.Dom`'s IVT set); renderer `using Broiler.HTML.Dom;` resolves to the relocated types via
+`renderer → Dom → Layout` transitively or an added `using Broiler.Layout;`. Verify full `Broiler.slnx` + WPT/Acid gates.
+
+**✅ PHASE 4 PROPER — THE FILE MOVE DONE + verified (2026-06-27).** Moved **16 files** into
+`Broiler.Layout/Broiler.Layout/Engine/`: the 13 layout files + `LayoutBoxUtils` + two same-namespace move-blockers
+found via the cycle check — `VerticalFlowPrototype` (self-contained feature flag) and `ISelectionHandler` (interface
+over `CssRect`). Pre-move checks: nullable warnings are NoWarn'd solution-wide (root `Directory.Build.props`), the lone
+`global using FontStyle` is unused by the movers, no remaining cycle. **Kept `namespace Broiler.HTML.Dom`/`.Utils`** so
+the renderer needs no `using` changes (types resolve from `Broiler.Layout.dll` via `renderer→Dom→Layout` transitively).
+Added `[InternalsVisibleTo]` to `Broiler.Layout.csproj` for `Broiler.HTML.Dom` (staying files access the moved internals)
++ the full consumer set (incl. `DevConsole`/`DevConsole.Tests`, initially missed → caught by the slnx build). The
+HtmlTag move had also left `DevConsole.Tests` needing a `using HtmlTag = Broiler.Layout.HtmlTag;` alias (only the full
+slnx build surfaced it — added). **Result:** `Broiler.Layout` builds clean with the moved files (0 errors); the staying
+`Broiler.HTML.Dom` + all consumers (Orchestration/Image/WPF/HtmlBridge/Cli) build clean; **full `Broiler.slnx` green**;
+Layout arch 3/3 (moved types are `internal` → off the public surface); behavior-preserving (97-test + 72-test sweeps —
+only the known flaky `FixedChild`/`Acid2_Render` + pre-existing `MaxWidth`/`Border_Shorthand`/bg). The layout engine now
+lives in `Broiler.Layout`; the renderer keeps the `HtmlLayoutEnvironment` adapter, `DomUtils` serialization, `HtmlParser`,
+`BoxTreeVisitor`, `HtmlSerializer` etc.
+
+**Post-move polish DONE + verified (2026-06-27):**
+- *Namespace flip:* the 16 `Engine/` files flipped `namespace Broiler.HTML.Dom`/`.Utils` → `Broiler.Layout` (and their
+  now-redundant `using Broiler.HTML.Dom.Utils;` + `using …=Broiler.Layout.*` aliases removed). Added `using Broiler.Layout;`
+  to the staying `Broiler.HTML.Dom` files that reference the moved types + the ~19 consumer files (sed after each
+  `using Broiler.HTML.Dom;`). Disambiguated the renderer files that use the *full* `Broiler.HTML.Utils` `HtmlConstants`/
+  `CommonUtils`/`HtmlUtils` against `Broiler.Layout`'s subsets via `using … = Broiler.HTML.Utils.…;` aliases (HtmlParser,
+  DomUtils, DomParser, HtmlContainerInt, Orchestration). Full `Broiler.slnx` green; Layout arch 3/3; behavior-preserving.
+- *Identical-copy dedup:* deleted the renderer's `Broiler.HTML.CSS.Core.Parse.RegexParserUtils` (only `CssParser` used it;
+  `Broiler.HTML.CSS` already refs `Broiler.CSS`) and `Broiler.HTML.Utils.CssConstants` (10 files across CSS/Dom/Orchestration/
+  Rendering/Utils → aliased to `Broiler.CSS.CssConstants`; added a `Broiler.CSS` ref to `Broiler.HTML.Utils` for its
+  `CommonUtils`). Both were byte-identical to the `Broiler.CSS` versions. Full `Broiler.slnx` green; behavior-preserving.
+  **Not deduped (inherent):** `CssLength`/`CssValueParser` (renderer's carry colour parsing the layout copies lack),
+  `CssUnit` (renderer's `Pixels`/`Ems` vs `Broiler.CSS`'s `Px`/`Em`), `HtmlConstants`/`CommonUtils`/`HtmlUtils` (Layout holds
+  layout-only subsets and cannot reference the renderer to share one copy).
+
+**Other `Broiler.HTML.*` couplings before the move (NOT Phase 3):** the moving files still carry these,
+all Phase-4 concerns:
+- `ContainerInt` host-services (11 calls): `GetFont`/`ParseColor` (behind the abstract `GetCachedFont`/
+  `GetActualColor` seam — could route through the now-stored `LayoutEnvironment`, but watch the
+  null-before-layout lifetime since font/colour can resolve pre-layout), `RequestRefresh`, `ReportError`,
+  `CreateImageLoadHandler`, `AvoidImagesLateLoading`/`AvoidAsyncImagesLoading` (renderer glue; §2.2 "stay
+  behind", or split into a renderer subclass at the move).
+- `Broiler.HTML.Adapters` (`RFont`/`RImage`; e.g. `ActualFont` is still `RFont`-typed → would become
+  `ILayoutFont`), `Broiler.HTML.Core.Entities`/`Core.Core.Dom`/`Core.IR`, `Broiler.HTML.Utils` (now only
+  `HtmlUtils`/`CommonUtils`), `Broiler.HTML.Rendering`.
 **Scope:** Extract the renderer's CSS box-model and layout engine out of
 `Broiler.HTML.Dom` into a standalone `Broiler.Layout` component that consumes a
 computed style (from `Broiler.CSS.Dom`) over the canonical `Broiler.Dom` tree and

--- a/src/Broiler.App/DevConsole/DevConsolePanel.xaml.cs
+++ b/src/Broiler.App/DevConsole/DevConsolePanel.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Shapes;
 using Broiler.HtmlBridge;
 using Broiler.DevConsole;
 using Broiler.HTML.Dom;
+using Broiler.Layout;
 
 namespace Broiler.App.DevConsole;
 

--- a/src/Broiler.Cli.Tests/FormControlClickTests.cs
+++ b/src/Broiler.Cli.Tests/FormControlClickTests.cs
@@ -1,4 +1,5 @@
 using Broiler.HTML.Dom;
+using Broiler.Layout;
 using Broiler.HTML.Dom.Utils;
 using Broiler.HTML.Image;
 using System.Drawing;

--- a/src/Broiler.Cli.Tests/Phase5SharedCascadeTests.cs
+++ b/src/Broiler.Cli.Tests/Phase5SharedCascadeTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Broiler.Dom.Html;
 using Broiler.HTML.Dom;
+using Broiler.Layout;
 using Broiler.HTML.Dom.Parse;
 using Broiler.HTML.Orchestration.Parse;
 using Xunit;

--- a/src/Broiler.DevConsole.Tests/BoxTreeVisitorTests.cs
+++ b/src/Broiler.DevConsole.Tests/BoxTreeVisitorTests.cs
@@ -1,6 +1,8 @@
 
 using Broiler.HTML.Dom;
+using Broiler.Layout;
 
+using HtmlTag = Broiler.Layout.HtmlTag;
 namespace Broiler.DevConsole.Tests;
 
 public class BoxTreeVisitorTests

--- a/src/Broiler.DevConsole.Tests/ConsoleServiceTests.cs
+++ b/src/Broiler.DevConsole.Tests/ConsoleServiceTests.cs
@@ -1,6 +1,8 @@
 using Broiler.HTML.Dom;
+using Broiler.Layout;
 using Broiler.HtmlBridge;
 
+using HtmlTag = Broiler.Layout.HtmlTag;
 namespace Broiler.DevConsole.Tests;
 
 public class ConsoleServiceTests : IDisposable

--- a/src/Broiler.DevConsole.Tests/DomQueryHelperTests.cs
+++ b/src/Broiler.DevConsole.Tests/DomQueryHelperTests.cs
@@ -1,6 +1,8 @@
 
 using Broiler.HTML.Dom;
+using Broiler.Layout;
 
+using HtmlTag = Broiler.Layout.HtmlTag;
 namespace Broiler.DevConsole.Tests;
 
 public class DomQueryHelperTests

--- a/src/Broiler.DevConsole/BoxTreeNode.cs
+++ b/src/Broiler.DevConsole/BoxTreeNode.cs
@@ -1,4 +1,5 @@
 using Broiler.HTML.Dom;
+using Broiler.Layout;
 
 namespace Broiler.DevConsole;
 

--- a/src/Broiler.DevConsole/ConsoleService.cs
+++ b/src/Broiler.DevConsole/ConsoleService.cs
@@ -1,5 +1,6 @@
 using Broiler.HtmlBridge;
 using Broiler.HTML.Dom;
+using Broiler.Layout;
 
 namespace Broiler.DevConsole;
 

--- a/src/Broiler.DevConsole/DomQueryHelper.cs
+++ b/src/Broiler.DevConsole/DomQueryHelper.cs
@@ -1,5 +1,6 @@
 
 using Broiler.HTML.Dom;
+using Broiler.Layout;
 
 namespace Broiler.DevConsole;
 


### PR DESCRIPTION
Introduces **`Broiler.Layout`**, a backend-neutral CSS box-model / layout engine that depends only on `Broiler.CSS`, `Broiler.CSS.Dom`, and `Broiler.Dom` (enforced by architecture tests). The ~9.7k-line layout engine — previously embedded in the `Broiler.HTML` renderer — now lives here.

## What changed (parent repo)
- **New `Broiler.Layout` component** (added to `Broiler.slnx`):
  - Public host seam: `ILayoutEnvironment`, `ILayoutFont`, `ILayoutImageLoader`, `LayoutFontStyle`, `ImageIntrinsics`, plus the relocated `HtmlTag`, `BoxKind`, and layout `Utils`.
  - The relocated engine under `Engine/` (`CssBox*`, `CssLayoutEngine*`, `CssRect*`, `CssLineBox`, `CssSpacingBox`, `CssUtils`, `LayoutBoxUtils`, `VerticalFlowPrototype`, `ISelectionHandler`).
  - Architecture tests freezing the dependency boundary (references-whitelist, no renderer-type leak, no mutable collections on the public surface).
- **`src/` consumers** (DevConsole, Cli tests, App) updated with `using Broiler.Layout;`.
- **Submodule bumps** to the matching branches:
  - `Broiler.CSS` → MaiRat/Broiler.CSS#4 (CSS value primitives)
  - `Broiler.HTML` → MaiRat/Broiler.HTML#189 (decoupling + removal of the relocated files)

## Why
Make the layout engine modular and independently testable (CSS → layout → paint), free of the graphics stack / JS bridge / HTML facade, so it can be reused and evolved on its own.

## How it was done
A phased decouple-then-move migration (full plan + outcome in `docs/roadmap/broiler-layout-component.md`): abstract host services behind `ILayoutEnvironment`, re-source CSS value types into `Broiler.CSS`, re-type the box surface off the graphics backend (`RFont`/`RImage`/`IHtmlContainerInt` → `ILayoutFont`/`object`/`object`, renderer casts at the boundary), then physically relocate the files and flip the namespace.

## Verification
- **Full `Broiler.slnx` builds green.**
- Layout architecture tests 3/3.
- Behavior-preserving across the Acid2 / Acid3 / Flex test sweeps — only known pre-existing or order-flaky failures.

## Reviewer notes
- **Merge order:** the two submodule PRs (Broiler.CSS#4, Broiler.HTML#189) must merge first; this PR's submodule pointers should then be re-bumped to their merged `main` commits.
- The renderer retains `CssLength`/`CssValueParser` (they carry colour parsing the layout copies don't) and layout-subset copies of `HtmlConstants`/`CommonUtils`/`HtmlUtils` — this duplication is inherent (Layout can't reference the renderer).
- The heavier **WPT pixel gate** was not re-run on the final state; recommend running it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)