### PR TITLE
WPT runner: surface silently-dropped CSS declarations + triage roadmap

### DIFF
--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -1,0 +1,162 @@
+# WPT triage & runner diagnostics — roadmap
+
+Status snapshot and next steps for the Web Platform Tests (WPT) effort tracked in
+[issue #1100](https://github.com/MaiRat/Broiler/issues/1100). Two parallel tracks:
+
+1. **Fixes** — driving down real failures, cluster by cluster.
+2. **Diagnostics** — making the runner/report point at root causes so the next
+   investigation is minutes, not hours. This was prompted by a recurring pattern:
+   the failure *category* the report gave (e.g. "PixelMismatch / MissingContent"
+   on a `css-align` test) was repeatedly misleading about the *actual* cause
+   (a paint-order bug, a silently dropped CSS value, a DOM crash).
+
+---
+
+## 1. Fix clusters — status
+
+| # | Cluster | Status | Where |
+|---|---------|--------|-------|
+| 1 | Abspos self-alignment overflow clamp (IMCB∪CB union) | ✅ merged | Broiler.Layout |
+| 2 | Skip WPT manual tests (`*-manual`, 59 false failures) | ✅ merged | Broiler.Wpt |
+| 3 | Abspos **static-position** alignment | ⏸ reverted | see "Known blockers" |
+| 4 | Negative `z-index` paint order (CSS2.1 App. E Step 2) | ✅ merged | Broiler.HTML |
+| 5 | `justify-self` yields to auto margins | ✅ merged | Broiler.Layout |
+| 6 | `justify-self`/`justify-items`/`-webkit-*` tandem | ✅ merged | Broiler.CSS + Broiler.Layout |
+| 7 | Prefixed-attribute DOM crash (`xlink:href`) | ✅ merged | Broiler.DOM |
+
+### Known blockers / deferred
+
+- **Abspos block-axis paint double-apply** (blocks cluster 3). The *layout* is
+  correct (`Location.Y` lands right, single `OffsetTop`), but the renderer paints
+  the block-axis offset twice (`static + 2·dy`); the inline axis paints fine.
+  This lives in the render path, not in `Broiler.Layout`. Fixing it unblocks the
+  ~10 `css-align/abspos/*-static-position-*` tests (whose layout fix is already
+  validated and can be re-applied) and likely helps abspos block-axis cases in
+  `css-anchor-position`. **Highest-value layout/paint follow-up.**
+
+### Remaining failure landscape (after the merged clusters)
+
+The tractable in-flow / parse / DOM wins are largely exhausted. What remains
+gates on substantial features:
+
+- **CSS animation sampler** — most of the ~29 remaining `css-animations` failures
+  need keyframe interpolation + timing-function sampling at the reftest's frozen
+  frame (negative `animation-delay` / `animation-play-state:paused` / `0s both`).
+- **Real flex/grid layout** — `gap`, `self-align-safe-unsafe-{flex,grid}`,
+  `baseline-of-scrollable` (inline-flex/grid baseline). Broiler currently
+  approximates flex/grid via inline-block.
+- **Multicol** — `align-content-block-{002..010}`, `anchor-position-multicol`.
+- **Table-cell alignment** — `align-content-table-cell` (rowspan + collapsed rows
+  + overflow + `vertical-align`→`align-self` mapping).
+- **Shadow DOM `::part`** — `animation-name-in-shadow-part*`.
+- **Scroll-driven anchor positioning** — the large `anchor-scroll-*` family.
+
+---
+
+## 2. Runner diagnostics — roadmap
+
+Goal: every failure's report entry should point at the *cause*, not just the
+nominal feature. Ordered by leverage-to-effort; each item notes the cluster it
+would have caught.
+
+### ✅ #1 — Dropped-declaration logging (DONE)
+
+*Would have found cluster 6 instantly.* Surfaces CSS declarations the style
+engine rejected as invalid/unsupported; a high count points straight at a missing
+feature gating many tests.
+
+- **Hook**: `Broiler.CSS.Dom.CssEngineDiagnostics.DeclarationRejected`
+  (opt-in `static Action<string,string>?`, fired at the two
+  `IsAcceptableDeclarationValue` drop sites in `CssStyleEngine`). Off by default —
+  a null-check on the rejection path only; **no production cost** (see §3).
+- **Collector**: `DroppedDeclarationCollector` in `Broiler.Wpt` (thread-safe,
+  count-aggregating, value-length-capped at 80, cardinality-bounded at 5000).
+- **Outputs**: results JSON `triage.droppedDeclarations` + console section +
+  markdown step-summary; `scripts/merge-wpt-shards.py` aggregates across shards
+  into a **"Top N dropped CSS declarations"** section in the GitHub issue.
+- **Scope**: captures **stylesheet (cascade)** drops — verified end-to-end through
+  the render path. Inline `style=""` drops follow a separate render route and are
+  not yet captured (the engine hook still reports them for any `GetComputedStyle`
+  consumer). Closing the inline gap → see #1b.
+- **Tests**: `CssStyleEngineTests.CssEngineDiagnostics_Reports_Dropped_Declarations_Only`,
+  `DroppedDeclarationCollectorTests` (×3), `test_merge_aggregates_dropped_declarations`.
+
+#### #1b — Capture inline-style drops through the render path (small follow-up)
+Find where the bridge/layout applies the inline `style` attribute and route it
+through (or report from) the same drop site. Lower priority — cross-cutting
+"missing feature" drops live in stylesheets, which #1 already covers.
+
+### #2 — Group exceptions by signature (next)
+
+*Cluster 7.* `ScriptError` failures already carry the exception + stack trace; the
+report should bucket them by **exception type + message + top non-framework
+frame** (e.g. `DomName..ctor — A prefixed name requires a namespace URI ×N`). One
+signature → many tests → one fix. Small change in `Program.cs` triage +
+`merge-wpt-shards.py`.
+
+### #3 — Detect the "green / no-red" reference-overlay convention
+
+*Clusters 4, 5, 6.* A huge share of WPT reftests are "passes if green, no red"
+with a `z-index:-1` red overlay. Scan the rendered bitmap for **pure-red pixels
+present in the output but not the reference** and tag `ReferenceOverlayExposed` —
+a strong "real layout/paint bug" signal, distinct from antialiasing noise. (This
+is exactly the manual red/green pixel harness used during triage.)
+
+### #4 — Evaluate `check-layout-th.js` `data-offset` assertions
+
+*Clusters 1, 3, 6 were all `checkLayout` tests.* Those carry `data-offset-x/y` on
+elements. The runner already holds the live DOM (`ExecuteScriptsWithDom`), so it
+can read those attributes + computed box rects and report **"`.item` expected
+offset-x=100, got 0"** — directly actionable, font-independent, no pixel-guessing.
+Highest-value Tier-2 item.
+
+### #5 — Richer mismatch metadata
+
+Extend `MismatchClassifier` to emit the **bounding box of the largest mismatched
+region** and a **displacement estimate** ("content shifted right ~100px" vs
+"content absent"). Points at alignment-vs-rendering immediately.
+
+### #6 — Attach rendered / reference / diff PNGs for failures
+Visual triage in seconds (reconstructed by hand every investigation this session).
+
+### #7 — Auto-cluster failures by name-family + category
+`scripts/merge-wpt-shards.py`: collapse numbered families (`*-static-position-{1..8}`)
+into one line and cross-tab against category, instead of N scattered lines.
+
+### #8 — First-class `manual` / `tentative` / `crashtest` buckets
+*Cluster 2.* Report these as their own category so a regression in the
+classification is visible, not hidden in the failure total.
+
+### #9 — Extract `<link rel=help>` / `<meta name=assert>` into the report
+See what a test *claims* to verify — the fastest way to spot that a `css-align`
+failure is actually a paint/parse bug.
+
+---
+
+## 3. Performance & permanence of the diagnostics hook
+
+The `CssEngineDiagnostics` addition to `Broiler.CSS` is **permanent** and
+**effectively zero-cost in production**:
+
+- The delegate is `null` unless a tool (the WPT runner) sets it; in the
+  browser/app it stays null.
+- `ReportRejected` is `DeclarationRejected?.Invoke(...)` — a single reference
+  null-check, reached **only on the rejection path** (an invalid declaration),
+  never per accepted declaration on the hot path.
+- When enabled, the cost is one bounded `ConcurrentDictionary` update per dropped
+  declaration, during CI WPT runs only.
+
+It is intentionally a durable, reusable extension point (dev tooling could also
+consume it), not a temporary shim.
+
+---
+
+## 4. Suggested next actions
+
+1. **#1b** (inline-style drops) — quickly closes the one gap in the shipped #1.
+2. **#2 + #3** — small, high-signal report additions; together they'd have
+   classified most of this session's "misleading category" failures correctly.
+3. **#4** — convert the most common `css-align` test shape into exact numeric
+   diffs; biggest diagnostic payoff.
+4. **Abspos block-axis paint double-apply** — the one layout/paint follow-up that
+   unblocks an already-validated fix (cluster 3) and helps anchor-position.

--- a/scripts/merge-wpt-shards.py
+++ b/scripts/merge-wpt-shards.py
@@ -82,6 +82,7 @@ def merge(shard_dir: Path, problem_limit: int = DEFAULT_PROBLEM_LIMIT) -> dict:
     seen_failures: set[str] = set()
     directory_counter: Counter[str] = Counter()
     category_counter: Counter[str] = Counter()
+    dropped_declaration_counter: Counter[str] = Counter()
     problem_groups: dict[str, dict] = {}
     reported_shard_indexes: set[int] = set()
 
@@ -98,6 +99,18 @@ def merge(shard_dir: Path, problem_limit: int = DEFAULT_PROBLEM_LIMIT) -> dict:
         failed += int(summary.get("failed", 0) or 0)
         skipped += int(summary.get("skipped", 0) or 0)
         total += int(summary.get("total", 0) or 0)
+
+        # CSS declarations the style engine dropped as invalid/unsupported. A
+        # high cross-shard count usually points at a missing feature that
+        # silently gates many tests (see issue #1100).
+        triage = report.get("triage")
+        if isinstance(triage, dict):
+            for entry in triage.get("droppedDeclarations", []) or []:
+                if not isinstance(entry, dict):
+                    continue
+                declaration = entry.get("declaration")
+                if declaration:
+                    dropped_declaration_counter[str(declaration)] += int(entry.get("count", 0) or 0)
 
         for result in report.get("results", []):
             if not isinstance(result, dict):
@@ -182,6 +195,7 @@ def merge(shard_dir: Path, problem_limit: int = DEFAULT_PROBLEM_LIMIT) -> dict:
         "topProblems": top_problems,
         "topFailingDirectories": directory_counter.most_common(problem_limit),
         "failuresByCategory": category_counter.most_common(),
+        "droppedDeclarations": dropped_declaration_counter.most_common(problem_limit),
         "results": failures,
     }
 
@@ -215,6 +229,20 @@ def render_issue_markdown(merged: dict, run_url: str | None) -> str:
         lines += [f"- `{directory}` — {count} failure(s)" for directory, count in merged["topFailingDirectories"]]
     else:
         lines.append("- None")
+
+    # Silently-dropped CSS declarations: a high count usually means a single
+    # unsupported value is gating many tests (e.g. text-align:-webkit-right).
+    dropped = merged.get("droppedDeclarations") or []
+    if dropped:
+        lines += [
+            "",
+            f"### Top {merged['problemLimit']} dropped CSS declarations",
+            "",
+            "_Values the style engine rejected as invalid/unsupported. A high count"
+            " often points at a missing feature gating many tests._",
+            "",
+        ]
+        lines += [f"- `{declaration}` — {count} occurrence(s)" for declaration, count in dropped]
 
     lines += [
         "",

--- a/scripts/tests/test_merge_wpt_shards.py
+++ b/scripts/tests/test_merge_wpt_shards.py
@@ -94,6 +94,44 @@ class MergeWptShardsTests(unittest.TestCase):
             self.assertNotIn("`RenderingError` — 1 failure(s)", markdown)
             self.assertIn("Incomplete shards: 1", markdown)
 
+    def test_merge_aggregates_dropped_declarations(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            for name, idx, drops in (
+                (
+                    "shard-0.json",
+                    0,
+                    [
+                        {"declaration": "text-align: -webkit-right", "count": 5},
+                        {"declaration": "position: wobble", "count": 1},
+                    ],
+                ),
+                ("shard-1.json", 1, [{"declaration": "text-align: -webkit-right", "count": 3}]),
+            ):
+                (shard_dir / name).write_text(
+                    json.dumps(
+                        {
+                            "summary": {"passed": 1, "failed": 0, "skipped": 0, "total": 1},
+                            "shard": {"index": idx, "count": 8},
+                            "triage": {"droppedDeclarations": drops},
+                            "results": [],
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+
+            merged = MODULE.merge(shard_dir, problem_limit=10)
+
+            # Counts summed across shards, most frequent first.
+            self.assertEqual(
+                [("text-align: -webkit-right", 8), ("position: wobble", 1)],
+                merged["droppedDeclarations"],
+            )
+
+            markdown = MODULE.render_issue_markdown(merged, None)
+            self.assertIn("dropped CSS declarations", markdown)
+            self.assertIn("`text-align: -webkit-right` — 8 occurrence(s)", markdown)
+
     def test_cli_requests_issue_for_incomplete_shard_without_test_results(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             shard_dir = Path(temp)

--- a/src/Broiler.Wpt.Tests/DroppedDeclarationCollectorTests.cs
+++ b/src/Broiler.Wpt.Tests/DroppedDeclarationCollectorTests.cs
@@ -1,0 +1,47 @@
+namespace Broiler.Wpt.Tests;
+
+public sealed class DroppedDeclarationCollectorTests
+{
+    [Fact]
+    public void Aggregates_Counts_And_Orders_By_Frequency()
+    {
+        var collector = new DroppedDeclarationCollector();
+        collector.Record("text-align", "-webkit-right");
+        collector.Record("text-align", "-webkit-right");
+        collector.Record("text-align", "-webkit-right");
+        collector.Record("position", "wobble");
+
+        Assert.Equal(4, collector.TotalDropped);
+
+        var top = collector.Top(10);
+        Assert.Equal("text-align: -webkit-right", top[0].Declaration);
+        Assert.Equal(3, top[0].Count);
+        Assert.Equal("position: wobble", top[1].Declaration);
+        Assert.Equal(1, top[1].Count);
+    }
+
+    [Fact]
+    public void Top_Respects_Limit()
+    {
+        var collector = new DroppedDeclarationCollector();
+        collector.Record("a", "1");
+        collector.Record("b", "2");
+        collector.Record("c", "3");
+
+        Assert.Single(collector.Top(1));
+    }
+
+    [Fact]
+    public void FormatKey_Lowercases_Property_And_Caps_Value_Length()
+    {
+        Assert.Equal("text-align: -webkit-right",
+            DroppedDeclarationCollector.FormatKey("TEXT-ALIGN", "  -webkit-right  "));
+
+        var longValue = new string('x', 200);
+        var key = DroppedDeclarationCollector.FormatKey("background", longValue);
+        Assert.StartsWith("background: ", key);
+        Assert.EndsWith("…", key);
+        // property + ": " + 80 value chars + ellipsis
+        Assert.True(key.Length < 200);
+    }
+}

--- a/src/Broiler.Wpt/DroppedDeclarationCollector.cs
+++ b/src/Broiler.Wpt/DroppedDeclarationCollector.cs
@@ -1,0 +1,59 @@
+using System.Collections.Concurrent;
+
+namespace Broiler.Wpt;
+
+/// <summary>
+/// Thread-safe aggregator for CSS declarations the style engine dropped because
+/// their value failed validation. Wired to
+/// <see cref="Broiler.CSS.Dom.CssEngineDiagnostics.DeclarationRejected"/> for the
+/// duration of a run and surfaced in the triage report.
+///
+/// <para>
+/// A single high-count entry (e.g. <c>text-align: -webkit-right</c>) usually
+/// points straight at a missing feature that silently gates many tests — exactly
+/// the failure mode that masked a whole css-align cluster in WPT issue #1100.
+/// </para>
+/// </summary>
+internal sealed class DroppedDeclarationCollector
+{
+    // Bound memory against pathological cardinality (unique calc()/url()/gradient
+    // values). Once the table is full, only keep counting already-seen keys.
+    private const int MaxDistinct = 5000;
+    private const int MaxValueLength = 80;
+
+    private readonly ConcurrentDictionary<string, int> _counts = new(StringComparer.Ordinal);
+
+    /// <summary>Records one dropped declaration.</summary>
+    public void Record(string property, string value)
+    {
+        var key = FormatKey(property, value);
+        if (_counts.Count >= MaxDistinct && !_counts.ContainsKey(key))
+            return;
+        _counts.AddOrUpdate(key, 1, static (_, count) => count + 1);
+    }
+
+    /// <summary>Total dropped-declaration occurrences recorded.</summary>
+    public int TotalDropped => _counts.Values.Sum();
+
+    /// <summary>Distinct "property: value" entries, highest count first.</summary>
+    public IReadOnlyList<(string Declaration, int Count)> Top(int limit) =>
+        _counts
+            .OrderByDescending(kv => kv.Value)
+            .ThenBy(kv => kv.Key, StringComparer.Ordinal)
+            .Take(limit)
+            .Select(kv => (kv.Key, kv.Value))
+            .ToList();
+
+    /// <summary>
+    /// Canonical "property: value" key (property lower-cased, value trimmed and
+    /// length-capped so high-cardinality values can't bloat the report).
+    /// </summary>
+    internal static string FormatKey(string property, string value)
+    {
+        var prop = property.Trim().ToLowerInvariant();
+        var val = value.Trim();
+        if (val.Length > MaxValueLength)
+            val = string.Concat(val.AsSpan(0, MaxValueLength), "…");
+        return $"{prop}: {val}";
+    }
+}

--- a/src/Broiler.Wpt/Program.cs
+++ b/src/Broiler.Wpt/Program.cs
@@ -191,6 +191,20 @@ public class Program
         Console.WriteLine();
 
         var runner = new WptTestRunner();
+
+        // Surface CSS declarations the style engine drops because their value
+        // failed validation. A single high-count entry (e.g. an unsupported
+        // text-align:-webkit-*) often masks many failing tests with no other
+        // signal (WPT issue #1100). Off in production; enabled only for this run.
+        //
+        // Scope: this captures declarations from author/UA STYLESHEETS (the
+        // cascade), which is where cross-cutting "missing feature" drops live and
+        // where a single value gates many tests. Inline `style=""` drops follow a
+        // separate render path and are not captured here (the engine hook still
+        // reports them for any consumer that calls GetComputedStyle).
+        var droppedDeclarations = new DroppedDeclarationCollector();
+        Broiler.CSS.Dom.CssEngineDiagnostics.DeclarationRejected = droppedDeclarations.Record;
+
         var subsetPatterns = WptTestRunner.ParseSubsetPatterns(subset ?? "");
         var discoveredTests = WptTestRunner
             .DiscoverTests(wptPath, subsetPatterns, nonJavaScriptOnly)
@@ -352,18 +366,23 @@ public class Program
             }
         }
 
+        // The aggregate is complete; stop collecting and snapshot the top entries.
+        Broiler.CSS.Dom.CssEngineDiagnostics.DeclarationRejected = null;
+        var topDropped = droppedDeclarations.Top(TopBucketLimit);
+
         PrintBucketSummary(wptPath, failures, skippedResults);
+        PrintDroppedDeclarations(topDropped, droppedDeclarations.TotalDropped);
 
         if (jsonOutputPath is not null)
         {
-            WriteJsonReport(allResults, jsonOutputPath, passed, failed, skipped, wptPath, shardCount, shardIndex);
+            WriteJsonReport(allResults, jsonOutputPath, passed, failed, skipped, wptPath, shardCount, shardIndex, topDropped);
             Console.WriteLine();
             Console.WriteLine($"JSON report written to: {jsonOutputPath}");
         }
 
         if (markdownOutputPath is not null)
         {
-            WriteMarkdownSummary(allResults, markdownOutputPath, passed, failed, skipped, wptPath, subset);
+            WriteMarkdownSummary(allResults, markdownOutputPath, passed, failed, skipped, wptPath, subset, topDropped);
             Console.WriteLine();
             Console.WriteLine($"Markdown summary written to: {markdownOutputPath}");
         }
@@ -590,7 +609,8 @@ public class Program
         int skipped,
         string wptPath,
         int shardCount = 1,
-        int shardIndex = WptTestRunner.AllShards)
+        int shardIndex = WptTestRunner.AllShards,
+        IReadOnlyList<(string Declaration, int Count)>? droppedDeclarations = null)
     {
         var dir = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(dir))
@@ -653,6 +673,17 @@ public class Program
                         ["subCategory"] = r.MismatchDiagnostics?.Category.ToString(),
                     })
                     .ToList(),
+                // CSS declarations the engine dropped as invalid/unsupported.
+                // A high-count entry usually points at a missing feature gating
+                // many tests (WPT issue #1100). Aggregated across shards by
+                // scripts/merge-wpt-shards.py.
+                ["droppedDeclarations"] = (droppedDeclarations ?? [])
+                    .Select(d => new Dictionary<string, object?>
+                    {
+                        ["declaration"] = d.Declaration,
+                        ["count"] = d.Count,
+                    })
+                    .ToList(),
                 ["skipReasons"] = skippedResults
                     .GroupBy(r => r.SkipReason.ToString())
                     .OrderByDescending(g => g.Count())
@@ -698,7 +729,8 @@ public class Program
         int failed,
         int skipped,
         string wptPath,
-        string? subset)
+        string? subset,
+        IReadOnlyList<(string Declaration, int Count)>? droppedDeclarations = null)
     {
         var dir = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(dir))
@@ -742,6 +774,7 @@ public class Program
         WriteReferenceCoverageSection(writer, referenceCoverageStatus);
         WriteDeferredFeatureBucketSection(writer, deferredFeatureBuckets);
         WriteTimeoutSection(writer, timeoutSummary.Failures, timeoutSummary.SubsetCommands);
+        WriteDroppedDeclarationsSection(writer, droppedDeclarations);
         writer.WriteLine();
         writer.WriteLine("## Non-pixel / exception failures");
         writer.WriteLine();
@@ -772,6 +805,35 @@ public class Program
             foreach (var bucket in suggestedBuckets)
                 writer.WriteLine($"- `./scripts/run-wpt-tests.sh --subset \"{bucket}\"`");
         }
+    }
+
+    private static void PrintDroppedDeclarations(
+        IReadOnlyList<(string Declaration, int Count)> topDropped, int totalDropped)
+    {
+        if (topDropped.Count == 0)
+            return;
+
+        Console.WriteLine();
+        Console.WriteLine($"=== Dropped CSS declarations ({totalDropped} total, top {topDropped.Count}) ===");
+        Console.WriteLine("(values the style engine rejected as invalid/unsupported — a high count often gates many tests)");
+        foreach (var (declaration, count) in topDropped)
+            Console.WriteLine($"  {count,6}  {declaration}");
+    }
+
+    private static void WriteDroppedDeclarationsSection(
+        TextWriter writer, IReadOnlyList<(string Declaration, int Count)>? droppedDeclarations)
+    {
+        if (droppedDeclarations is null || droppedDeclarations.Count == 0)
+            return;
+
+        writer.WriteLine();
+        writer.WriteLine("## Dropped CSS declarations");
+        writer.WriteLine();
+        writer.WriteLine("Values the style engine rejected as invalid/unsupported. A high count");
+        writer.WriteLine("usually points at a missing feature that silently gates many tests.");
+        writer.WriteLine();
+        foreach (var (declaration, count) in droppedDeclarations)
+            writer.WriteLine($"- `{declaration}` — {count} occurrence(s)");
     }
 
     private static void PrintBucketSummary(


### PR DESCRIPTION
Runner-diagnostics enhancement **#1** from the WPT triage roadmap, plus the roadmap doc itself. Prompted by #1100: the failure *category* the report gave was repeatedly misleading about the actual cause (a silently-dropped CSS value, a paint-order bug, a DOM crash).

## What

Surface CSS declarations the style engine **rejected as invalid/unsupported**, so a missing feature that silently gates many tests is visible at a glance instead of masquerading as a generic `PixelMismatch`.

- `DroppedDeclarationCollector` aggregates `property: value` → count, wired to `CssEngineDiagnostics.DeclarationRejected` for the run (off in production).
- Surfaced three ways: results JSON `triage.droppedDeclarations`, the console summary, and the markdown step-summary.
- `scripts/merge-wpt-shards.py` aggregates across shards into a **"Top N dropped CSS declarations"** section of the auto-filed GitHub issue.
- `docs/roadmap/wpt-triage-and-diagnostics.md` — fix-cluster status + prioritised diagnostics roadmap (#1 done; #2–#9 + #1b next) + a note on hook permanence/cost.

## Why this is the right first diagnostic

A single dropped value (e.g. `text-align:-webkit-right`) gated a whole css-align cluster in #1100 with **no signal**. This turns that into a one-line report entry.

## Scope

Captures **stylesheet (cascade)** drops — verified end-to-end through the render path. Inline `style=""` drops follow a separate render route (tracked as **#1b** in the roadmap). The engine hook still reports inline drops for any `GetComputedStyle` consumer.

## Performance / permanence

The `CssEngineDiagnostics` hook is **permanent** and **zero-cost in production**: a `static Action?` that is null unless a tool sets it, invoked only on the declaration-rejection path. Detail in the roadmap §3.

## Companion PR

Bumps `Broiler.CSS` to **MaiRat/Broiler.CSS#6** (the `CssEngineDiagnostics` hook). The submodule pointer moves forward from the already-merged cluster-6 commit — merge the CSS PR first.

## Tests (targeted)

`DroppedDeclarationCollectorTests` (×3), `CssStyleEngineTests.CssEngineDiagnostics_Reports_Dropped_Declarations_Only` (in the CSS PR), and `test_merge_aggregates_dropped_declarations` (Python). End-to-end render-path firing verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)