### PR TITLE
WPT: fix display:inline-table drop + abspos block-axis align-self

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -406,6 +406,26 @@ internal class CssBox : CssBoxProperties, IDisposable
         cbPadTop = cb.Location.Y + cb.ActualBorderTopWidth;
         cbPadWidth = cb.Size.Width - cb.ActualBorderLeftWidth - cb.ActualBorderRightWidth;
         cbPadHeight = (cb.ActualBottom - cb.Location.Y) - cb.ActualBorderTopWidth - cb.ActualBorderBottomWidth;
+
+        // Block-axis self-alignment of an absolutely positioned descendant can
+        // run before the containing block has resolved its own block size:
+        // heights resolve bottom-up, yet abspos children are positioned during
+        // the CB's layout, so cb.ActualBottom may still equal cb.Location.Y and
+        // cbPadHeight collapses to ~0 — leaving align-self with no IMCB to work
+        // within (the box stays at its static position).  Widths resolve
+        // top-down, so cbPadWidth is already correct; this only patches the
+        // height.  When the CB carries a definite (non-percentage) specified
+        // height, derive the padding-box height from it directly.
+        if (cbPadHeight <= 0
+            && cb.Height != CssConstants.Auto && !string.IsNullOrEmpty(cb.Height)
+            && !cb.Height.Contains('%'))
+        {
+            double cssHeight = CssValueParser.ParseLength(cb.Height, 0, cb.GetEmHeight());
+            double borderBoxHeight = cb.ResolveSpecifiedHeightToBorderBox(cssHeight);
+            double candidate = borderBoxHeight - cb.ActualBorderTopWidth - cb.ActualBorderBottomWidth;
+            if (candidate > cbPadHeight)
+                cbPadHeight = candidate;
+        }
     }
 
     /// <summary>
@@ -1934,6 +1954,13 @@ internal class CssBox : CssBoxProperties, IDisposable
 
                 float newX = Location.X, newY = Location.Y;
 
+                // When align-self resolves the block axis to a non-stretch value,
+                // the box uses its content (shrink-to-fit) block size rather than
+                // the stretched inset size; record the resolved border-box height
+                // so the apply step can shrink it (mirrors how the inline branch
+                // sets Size.Width).  Null = leave the block size untouched.
+                double? alignBlockBorderBoxHeight = null;
+
                 // justify-self controls the inline axis:
                 //   horizontal-tb → horizontal (L/R insets)
                 //   vertical-rl/lr → vertical (T/B insets)
@@ -1989,6 +2016,9 @@ internal class CssBox : CssBoxProperties, IDisposable
                         double imcbHeight = cbPadHeight - cssTop - cssBottom;
 
                         double boxHeight = GetShrinkToFitHeight();
+                        // Non-stretch align-self → the box is its content height,
+                        // not the stretched top-to-bottom inset height.
+                        alignBlockBorderBoxHeight = boxHeight;
 
                         // Block-axis start is the top edge for horizontal-tb.
                         double dy = ResolveAbsposSelfAlignment(
@@ -2029,6 +2059,13 @@ internal class CssBox : CssBoxProperties, IDisposable
                         ActualBottom += deltaY;
                     }
                 }
+
+                // Un-stretch the block axis to the content height for non-stretch
+                // align-self.  Runs even when the offset was zero (align-self:start
+                // keeps the box at the start edge but still shrinks it), so it is
+                // outside the offset guard above.
+                if (alignBlockBorderBoxHeight is double abh)
+                    ActualBottom = Location.Y + abh;
             }
         }
 

--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -23,6 +23,17 @@ Status snapshot and next steps for the Web Platform Tests (WPT) effort tracked i
 | 5 | `justify-self` yields to auto margins | ✅ merged | Broiler.Layout |
 | 6 | `justify-self`/`justify-items`/`-webkit-*` tandem | ✅ merged | Broiler.CSS + Broiler.Layout |
 | 7 | Prefixed-attribute DOM crash (`xlink:href`) | ✅ merged | Broiler.DOM |
+| 8 | `display:inline-table` dropped by value validator (300 drops → MissingContent) | ✅ fixed | Broiler.CSS |
+
+Cluster 8 was the **first win surfaced by diagnostic #1** (dropped-declaration logging):
+issue [#1103](https://github.com/MaiRat/Broiler/issues/1103)'s "Top dropped CSS declarations"
+section flagged `display: inline-table` **300×** alongside the #1 failure category
+(`PixelMismatch / MissingContent`, 344, concentrated in `css-anchor-position` + `css-align`).
+The `display` allowlist in `CssStyleEngine.Values.cs` (`IsAcceptableDeclarationValue`) omitted
+`inline-table` even though the layout engine + paint walker fully render it, so the renderer
+cascade (Phase 5 routes through this engine) silently dropped it and the boxes collapsed. Same
+shape as cluster 6's `-webkit-right`. Fix added `inline-table` (the real win) plus the other
+valid CSS Display 3 single keywords (`flow`, the ruby family, `math`).
 
 ### Known blockers / deferred
 
@@ -50,6 +61,15 @@ gates on substantial features:
   + overflow + `vertical-align`→`align-self` mapping).
 - **Shadow DOM `::part`** — `animation-name-in-shadow-part*`.
 - **Scroll-driven anchor positioning** — the large `anchor-scroll-*` family.
+
+> **`css-anchor-position` LayoutShift cluster (58, issue #1103) — triaged, no single fix.**
+> These are the residual hard tail, *not* one systematic bug: 550 tests pass including the
+> simple anchor cases, so the anchor-resolution core (the mature 8-step heuristic pipeline in
+> `src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/`) is correct. The representative
+> failures are advanced/dynamic gaps — `last-successful-*` (the CSS "last successful position
+> option" is stateful across layout passes / fallback mutation → not reproducible in a static
+> one-shot renderer) and `anchor-position-multicol-fixed` (multicol + `anchor-size()` + fixed).
+> Enumerating the exact 58 from the merged artifact is currently impossible — see diagnostic #10.
 
 ---
 
@@ -130,6 +150,29 @@ classification is visible, not hidden in the failure total.
 ### #9 — Extract `<link rel=help>` / `<meta name=assert>` into the report
 See what a test *claims* to verify — the fastest way to spot that a `css-align`
 failure is actually a paint/parse bug.
+
+### #10 — Preserve per-test `subCategory` in the merged `results` (small, do next)
+
+*Motivated by the `css-anchor-position` LayoutShift triage above.* The per-shard
+report already carries the pixel-mismatch sub-category per test
+(`mismatchDiagnostics.subCategory`, e.g. `LayoutShift` / `MissingContent` /
+`ColorShift`), and `merge-wpt-shards.py` uses it for the **aggregate** "Top
+problems" section. But the merged **`results`** array — the persisted per-test
+record attached to the issue/artifact and consumed by `--rerun-json` — keeps only
+`relativeTestPath` / `passed` / `skipped` / `category`. The sub-category is
+**dropped**, so a cluster like "the 58 LayoutShift tests" cannot be enumerated
+from the artifact after the fact (only the 3 example paths in `topProblems`
+survive), which is exactly what blocked the triage above.
+
+**Change** (one line, no new computation): in `merge-wpt-shards.py::merge`, the
+loop already computes `sub_category` via `_problem_identity(result)` right after
+building the `failure` dict — add `failure["subCategory"] = sub_category` (or move
+the `_problem_identity` call above the dict literal and include the field). This
+makes every failing-test record self-describing: filtering the merged artifact by
+`subCategory == "LayoutShift"` then yields the full list directly. Backward-
+compatible (additive field; `--rerun-json` ignores unknown keys). Add a merge
+unit test asserting the field round-trips (mirrors
+`test_merge_aggregates_dropped_declarations`).
 
 ---
 

--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -24,6 +24,18 @@ Status snapshot and next steps for the Web Platform Tests (WPT) effort tracked i
 | 6 | `justify-self`/`justify-items`/`-webkit-*` tandem | ✅ merged | Broiler.CSS + Broiler.Layout |
 | 7 | Prefixed-attribute DOM crash (`xlink:href`) | ✅ merged | Broiler.DOM |
 | 8 | `display:inline-table` dropped by value validator (300 drops → MissingContent) | ✅ fixed | Broiler.CSS |
+| 9 | Abspos block-axis `align-self` (unresolved CB height + no height-shrink) | ✅ fixed | Broiler.Layout |
+
+Cluster 9 was the deferred "abspos block-axis paint double-apply" blocker below — but
+the real root cause, found by reproducing `align-self-htb-ltr-htb.html` against the live
+renderer, was **two layout defects**, not a paint double-apply in the current code:
+(1) `GetAbsoluteContainingBlockPaddingBox` derived the containing block's height from
+`cb.ActualBottom`, which is unresolved when an abspos descendant aligns on the block axis
+(heights resolve bottom-up; widths top-down — hence inline `justify-self` worked but block
+`align-self` produced `cbPadHeight≈0` → `dy=0` → box stuck at its static position); and
+(2) a non-stretch `align-self` computed the right offset but never shrank the box from the
+stretched inset height to its content height. Fixed both in `CssBox`; the inline axis was
+already correct. Regression test `AbsposBlockAxisAlignTests` locks start/center/end/stretch.
 
 Cluster 8 was the **first win surfaced by diagnostic #1** (dropped-declaration logging):
 issue [#1103](https://github.com/MaiRat/Broiler/issues/1103)'s "Top dropped CSS declarations"
@@ -37,13 +49,15 @@ valid CSS Display 3 single keywords (`flow`, the ruby family, `math`).
 
 ### Known blockers / deferred
 
-- **Abspos block-axis paint double-apply** (blocks cluster 3). The *layout* is
-  correct (`Location.Y` lands right, single `OffsetTop`), but the renderer paints
-  the block-axis offset twice (`static + 2·dy`); the inline axis paints fine.
-  This lives in the render path, not in `Broiler.Layout`. Fixing it unblocks the
-  ~10 `css-align/abspos/*-static-position-*` tests (whose layout fix is already
-  validated and can be re-applied) and likely helps abspos block-axis cases in
-  `css-anchor-position`. **Highest-value layout/paint follow-up.**
+- **Abspos block-axis `align-self`** — ✅ fixed (cluster 9 above). The earlier
+  "paint double-apply" diagnosis was superseded: re-reproducing against the live
+  renderer showed the box was stuck at its static position (offset `dy=0`) because
+  the containing block's height was unresolved, plus a missing content-height
+  shrink. Both were in `Broiler.Layout`, not the render path.
+- **Abspos *static-position* alignment (cluster 3)** — still deferred. It needs the
+  static (auto-inset) block-axis model re-added on top of the now-correct block-axis
+  apply; the `align-self`/`justify-self` *inset* path (cluster 9) is the prerequisite
+  that is now in place.
 
 ### Remaining failure landscape (after the merged clusters)
 
@@ -201,5 +215,5 @@ consume it), not a temporary shim.
    classified most of this session's "misleading category" failures correctly.
 3. **#4** — convert the most common `css-align` test shape into exact numeric
    diffs; biggest diagnostic payoff.
-4. **Abspos block-axis paint double-apply** — the one layout/paint follow-up that
-   unblocks an already-validated fix (cluster 3) and helps anchor-position.
+4. **Abspos *static-position* alignment (cluster 3)** — now unblocked by the
+   block-axis `align-self` fix (cluster 9); re-add the static (auto-inset) model.

--- a/src/Broiler.Wpt.Tests/AbsposBlockAxisAlignTests.cs
+++ b/src/Broiler.Wpt.Tests/AbsposBlockAxisAlignTests.cs
@@ -1,0 +1,91 @@
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression tests for abspos block-axis self-alignment (<c>align-self</c>) in
+/// horizontal writing mode, modelled on WPT
+/// <c>css/css-align/abspos/align-self-htb-ltr-htb.html</c>.
+///
+/// Two layout defects were fixed together (see <c>CssBox</c>
+/// <c>GetAbsoluteContainingBlockPaddingBox</c> + the abspos self-alignment
+/// apply step):
+///   1. The containing block's height was unresolved when the abspos child
+///      aligned on the block axis (heights resolve bottom-up), so the IMCB
+///      height was 0 and the box never moved.
+///   2. A non-stretch <c>align-self</c> never shrank the box from the stretched
+///      inset height to its content height.
+/// </summary>
+public class AbsposBlockAxisAlignTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public AbsposBlockAxisAlignTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "broiler-abspos-diag-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        Program.ResetTestHooks();
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // Vertical span of green pixels along the box's centre column.
+    private static (int top, int bottom) GreenBand(BBitmap bmp, int x)
+    {
+        int top = -1, bottom = -1;
+        for (int y = 0; y < 200; y++)
+        {
+            var p = bmp.GetPixel(x, y);
+            if (p.G > 100 && p.R < 100 && p.B < 100)
+            {
+                if (top < 0) top = y;
+                bottom = y;
+            }
+        }
+        return (top, bottom);
+    }
+
+    [Theory]
+    // align-self value, expected offset-y (from container content box top=24),
+    // expected border-box height. Mirrors the data-* assertions in the WPT test.
+    [InlineData("start", 0, 20)]
+    [InlineData("center", 10, 20)]
+    [InlineData("end", 20, 20)]
+    [InlineData("stretch", 0, 40)]
+    public void Abspos_BlockAxis_AlignSelf_PositionsAndSizesBox(string align, int offsetY, int height)
+    {
+        // container content box: body margin 0 + container margin 20 + border 4
+        // → top/left = 24, content 40×40. item is 20px tall (20×20 ::before),
+        // full width (inline axis stretches as justify-self is unset).
+        var html = $@"<!DOCTYPE html>
+<style>
+  body {{ margin: 0; }}
+  .container {{ position: relative; display: inline-block; margin: 20px;
+               border: solid 4px; width: 40px; height: 40px; }}
+  .item {{ position: absolute; inset: 0; background: green; align-self: {align}; }}
+  .item::before {{ width: 20px; height: 20px; content: ''; display: block; }}
+</style>
+<div class='container'><div class='item'></div></div>";
+        var file = Path.Combine(_tempDir, "abspos-align.html");
+        File.WriteAllText(file, html);
+
+        var runner = new WptTestRunner(320, 240);
+        using var bmp = runner.RenderHtmlFileBitmapPublic(file, _tempDir);
+
+        var (top, bottom) = GreenBand(bmp, x: 34); // a column inside the box
+        int expectedTop = 24 + offsetY;
+        int expectedBottom = expectedTop + height;
+
+        Assert.True(top >= 0, $"align-self:{align}: box not painted (no green found).");
+        // ±2px tolerance for inclusive pixel scan / antialiasing.
+        Assert.True(System.Math.Abs(top - expectedTop) <= 2,
+            $"align-self:{align}: green top={top}, expected ~{expectedTop}.");
+        Assert.True(System.Math.Abs(bottom - expectedBottom) <= 2,
+            $"align-self:{align}: green bottom={bottom}, expected ~{expectedBottom} (height {height}).");
+    }
+}


### PR DESCRIPTION
Two WPT fixes from issue [#1103](https://github.com/MaiRat/Broiler/issues/1103) triage, plus the triage/diagnostics docs.

## 1. `display: inline-table` dropped by the value validator (high leverage)

The `display` allowlist in the `Broiler.CSS` engine omitted `inline-table`. Because the renderer cascades through that engine (Phase 5), every `display: inline-table` declaration was silently dropped → boxes lost their display and content collapsed → the #1 WPT failure category (`PixelMismatch / MissingContent`, 344, concentrated in `css-anchor-position` + `css-align`). The new dropped-declaration telemetry flagged it **300×**. The layout/paint path already renders `inline-table`; only the validator gated it.

- Submodule change: **MaiRat/Broiler.CSS#7** (this PR bumps the `Broiler.CSS` pointer to it).
- Added `inline-table` plus the other valid CSS Display 3 single keywords (`flow`, ruby family, `math`).

## 2. Abspos block-axis `align-self` (layout)

Absolutely-positioned boxes with a non-default block-axis `align-self` stayed at their static position in horizontal writing mode (`css-align/abspos/align-self-*`), while inline-axis `justify-self` worked. Two layout defects in `CssBox`, both fixed here:

1. `GetAbsoluteContainingBlockPaddingBox` derived the CB height from `cb.ActualBottom`, which is unresolved when an abspos descendant aligns on the block axis (heights resolve bottom-up; widths top-down — hence the asymmetry). `cbPadHeight` collapsed to ~0 → `dy=0` → box stuck. Now derives the padding-box height from the CB's definite specified height.
2. A non-stretch `align-self` computed the right offset but never shrank the box from the stretched inset height to its content height. Now records the resolved content height (mirroring the inline branch's `Size.Width`) and applies it after offsetting — including when the offset is zero (`align-self:start` un-stretches too).

> This supersedes the roadmap's earlier "paint double-apply" diagnosis (that was the now-reverted cluster-3 static-position path); the current blocker was layout, not paint. As a bonus it unblocks deferred cluster 3 (abspos static-position alignment).

## 3. Docs

`docs/roadmap/wpt-triage-and-diagnostics.md`: records both fixes as clusters 8 & 9, the `css-anchor-position` LayoutShift triage (residual hard tail — dynamic position-try / multicol — not one systematic bug), and a new diagnostic #10 (preserve per-test `subCategory` in the merge so sub-category clusters can be enumerated from the artifact).

## Verification

- inline-table: 9 validator unit tests green; end-to-end traced through the cascade drop site → `CssBox.Display`.
- align-self: live-render regression test `AbsposBlockAxisAlignTests` (start/center/end/stretch) green; A/B on the css-align abspos pixel suite shows **no pass/fail count change** (the `DefaultOverflow` family is pre-existing backlog); `Broiler.Layout.Tests` 12/12.
- Caveat: the full Playwright WPT pixel gate is CI-only and was not run locally; the real flip counts land on the next CI run.

## Reviewer notes

- Merge **MaiRat/Broiler.CSS#7** first, then this PR's submodule pointer should track the merged commit.
- The abspos fix is narrowly scoped to abspos boxes with non-default `justify-self`/`align-self`, so default abspos is unaffected by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)