### PR TITLE
WPT #1105: fix @position-try fallback dropped by comment-in-body parse

### DIFF
--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -25,6 +25,20 @@ Status snapshot and next steps for the Web Platform Tests (WPT) effort tracked i
 | 7 | Prefixed-attribute DOM crash (`xlink:href`) | ✅ merged | Broiler.DOM |
 | 8 | `display:inline-table` dropped by value validator (300 drops → MissingContent) | ✅ fixed | Broiler.CSS |
 | 9 | Abspos block-axis `align-self` (unresolved CB height + no height-shrink) | ✅ fixed | Broiler.Layout |
+| 10 | `@position-try` fallback dropped by comment-in-body parse bug | 🟡 partial | Broiler.HtmlBridge.Dom |
+
+Cluster 10 (issue [#1105](https://github.com/MaiRat/Broiler/issues/1105), the
+`css-anchor-position` position-try/fallback sub-cluster, ~23 tests) was a parse bug in
+the hand-rolled `@position-try` reader (`AnchorResolver/PositionTry.cs`). Its
+`ParsePositionTryRules` split each rule body on `;`/`:` **without stripping CSS comments**,
+so a comment inside a fallback body — ubiquitous in these WPT files, e.g.
+`/* 2: Position to the right of the anchor. */` — had its `:` mistaken for a declaration
+separator. The real declarations (`left: anchor(--a right)`, …) were silently dropped and the
+fallback applied with the *base* style's insets. Found by reproducing `position-try-002.html`
+against the live renderer (orange target rendered 400×100 at offset-x=0 instead of 200×100 at
+offset-x=200); fixed by stripping `/*…*/` before matching (`CssCommentPattern`). Regression test
+`PositionTryFallbackTests`. The cluster is **partial** — see the position-try sub-tasks checklist
+below for what remains.
 
 Cluster 9 was the deferred "abspos block-axis paint double-apply" blocker below — but
 the real root cause, found by reproducing `align-self-htb-ltr-htb.html` against the live
@@ -58,6 +72,40 @@ valid CSS Display 3 single keywords (`flow`, the ruby family, `math`).
   static (auto-inset) block-axis model re-added on top of the now-correct block-axis
   apply; the `align-self`/`justify-self` *inset* path (cluster 9) is the prerequisite
   that is now in place.
+
+### Position-try fallback — sub-task checklist (cluster 10)
+
+The `@position-try` fallback resolver (`AnchorResolver/PositionTry.cs`) runs as a static
+pre-pass: it detects whether the base style overflows the inset-modified containing block and,
+if so, rewrites the element's inline insets to the first fallback that *fits*. Tracking the
+pieces so the cluster can be closed incrementally:
+
+- [x] **Comment-in-body parse** — strip `/*…*/` from `@position-try` bodies before declaration
+  parsing. ✅ done (cluster 10), verified by `position-try-002.html` + `PositionTryFallbackTests`.
+- ⛔ **Grid-area containing block** — *blocked on real grid track layout* (see "Real flex/grid
+  layout" below), **not** on the position-try resolver. An abspos grid item's containing block is
+  its **grid area**, and `FindContainingBlockWidth` (`InlineContainingBlocks.cs:43`) does return the
+  viewport (1024px) for an auto-width grid CB — but fixing only that is futile here. Probing
+  `position-try-grid-001.html` against the live renderer shows Broiler lays the grid out as a
+  **vertical block stack**, not 4 columns: the orange anchor renders at ~(23, 133) (far left,
+  stacked) instead of grid column 2 at ~(115, 70), and the gray items form a thin vertical strip.
+  The anchor is in grid *flow*, so it is mislaid before position-try runs; the Broiler-vs-Chromium
+  pixel compare already mismatches on the anchor alone. Grid-area CB math (track resolution +
+  `grid-column`/`grid-row` line placement → area rect, then offset the resolved insets by the area
+  origin) becomes worthwhile **only once grid tracks are actually laid out**. Deferred behind the
+  flex/grid feature; revisit then.
+- [ ] **Fit-check geometry parity** — the resolver re-implements anchor coords / CB sizing
+  approximately (its own `ResolveAnchorEdge`, `FindContainingBlock*`, `EstimateMinContentWidth`),
+  so its "fits?" decision can diverge from what the layout engine actually produces. Longer-term:
+  drive the fit-check from real laid-out rects rather than a parallel estimator.
+- [ ] **`last-successful-*` (stateful)** — the CSS "last successful position option" is stateful
+  across layout passes / fallback mutation; not reproducible in a one-shot static renderer
+  without modelling the position-option history. Large; see the LayoutShift note below.
+- [ ] **Cascade interactions** (`position-try-cascade.html`) — `@position-try` vs `!important` /
+  animations / transitions / `revert` / `revert-layer`. Requires cascade-origin tracking the
+  pre-pass does not have. Large.
+- [ ] **`try-tactic` flips** (`flip-block` / `flip-inline` / `flip-start`) — the other fallback
+  mechanism (axis-mirroring tactics) distinct from named `@position-try` rules. Not yet modelled.
 
 ### Remaining failure landscape (after the merged clusters)
 
@@ -217,3 +265,9 @@ consume it), not a temporary shim.
    diffs; biggest diagnostic payoff.
 4. **Abspos *static-position* alignment (cluster 3)** — now unblocked by the
    block-axis `align-self` fix (cluster 9); re-add the static (auto-inset) model.
+5. **Position-try fallback (cluster 10)** — the comment-parse win is shipped; the
+   remaining sub-tasks (see the cluster-10 checklist) are all large or blocked. The
+   highest-value *unblocked* one is **fit-check geometry parity** (drive the
+   "fits?" decision from real laid-out rects instead of the resolver's parallel
+   estimator); **grid-area CB** is gated on real grid track layout; `last-successful`
+   and cascade interactions need stateful cascade modelling the static pre-pass lacks.

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
@@ -15,6 +15,9 @@ public sealed partial class DomBridge
     private static readonly System.Text.RegularExpressions.Regex PositionTryParsePattern = new(
         @"@position-try\s+(?<name>--[a-zA-Z0-9_-]+)\s*\{(?<body>[^}]*)\}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly System.Text.RegularExpressions.Regex CssCommentPattern = new(
+        @"/\*.*?\*/", RegexOptions.Compiled | RegexOptions.Singleline);
     /// <summary>
     /// Parses all <c>@position-try</c> at-rules from <c>&lt;style&gt;</c>
     /// elements, returning a dictionary mapping rule name to its property
@@ -36,7 +39,11 @@ public sealed partial class DomBridge
             {
                 if (child.IsTextNode && !string.IsNullOrEmpty(child.TextContent))
                 {
-                    foreach (Match m in PositionTryParsePattern.Matches(child.TextContent))
+                    // Strip CSS comments first: a comment inside a @position-try
+                    // body (common in WPT, e.g. "/* 2: position right */") contains
+                    // ':' and ';' that would otherwise corrupt declaration parsing.
+                    var styleText = CssCommentPattern.Replace(child.TextContent, " ");
+                    foreach (Match m in PositionTryParsePattern.Matches(styleText))
                     {
                         var name = m.Groups["name"].Value;
                         var body = m.Groups["body"].Value;

--- a/src/Broiler.Wpt.Tests/PositionTryFallbackTests.cs
+++ b/src/Broiler.Wpt.Tests/PositionTryFallbackTests.cs
@@ -1,0 +1,71 @@
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression test for <c>@position-try</c> fallback resolution.
+///
+/// Root cause fixed: a CSS comment inside a <c>@position-try</c> rule body
+/// (common in WPT, e.g. <c>/* 2: position to the right */</c>) was not stripped
+/// before the hand-rolled declaration parser split on ';' and ':'. The ':' in
+/// the comment was mistaken for a declaration separator, so the real
+/// declarations (e.g. <c>left: anchor(--a right)</c>) were never recorded and the
+/// fallback was applied with the base style's insets — leaving the box in the
+/// wrong place / wrong size.
+///
+/// Mirrors WPT <c>css/css-anchor-position/position-try-002.html</c>: the base
+/// style overflows the inset-modified containing block, so fallback <c>--f1</c>
+/// (position to the right of the anchor) must be selected, yielding a 200×100
+/// box at offset-x=200 within the 400×400 containing block.
+/// </summary>
+public class PositionTryFallbackTests : IDisposable
+{
+    public void Dispose() => Program.ResetTestHooks();
+
+    private static (int x0, int y0, int x1, int y1, int count) ColorBox(
+        BBitmap bmp, int w, int h, System.Func<byte, byte, byte, bool> match)
+    {
+        int x0 = int.MaxValue, y0 = int.MaxValue, x1 = -1, y1 = -1, count = 0;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                var p = bmp.GetPixel(x, y);
+                if (match(p.R, p.G, p.B))
+                {
+                    count++;
+                    if (x < x0) x0 = x;
+                    if (y < y0) y0 = y;
+                    if (x > x1) x1 = x;
+                    if (y > y1) y1 = y;
+                }
+            }
+        return (x0, y0, x1, y1, count);
+    }
+
+    [Fact]
+    public void PositionTry002_CommentedFallbackBody_SelectsRightOfAnchor()
+    {
+        string wptRoot = Path.GetFullPath(Path.Combine(
+            Directory.GetCurrentDirectory(), "..", "..", "..", "..", "..",
+            "tests", "wpt"));
+        string file = Path.Combine(wptRoot, "css", "css-anchor-position", "position-try-002.html");
+        Assert.True(File.Exists(file), $"missing test file: {file}");
+
+        var runner = new WptTestRunner(800, 600);
+        using var bmp = runner.RenderHtmlFileBitmapPublic(file, wptRoot);
+
+        // orange ~ (255,165,0)
+        var box = ColorBox(bmp, 800, 600, (r, g, b) => r > 200 && g > 110 && g < 200 && b < 90);
+
+        // .cb content box starts at (8,8) (default body margin). Expected target:
+        // offset-x=200, offset-y=0, width=200, height=100 within the .cb.
+        Assert.True(box.count > 0, "orange target not painted.");
+        int left = box.x0 - 8, top = box.y0 - 8;
+        int width = box.x1 - box.x0 + 1, height = box.y1 - box.y0 + 1;
+        Assert.True(System.Math.Abs(left - 200) <= 2, $"offset-x={left}, expected ~200.");
+        Assert.True(System.Math.Abs(top - 0) <= 2, $"offset-y={top}, expected ~0.");
+        Assert.True(System.Math.Abs(width - 200) <= 2, $"width={width}, expected ~200.");
+        Assert.True(System.Math.Abs(height - 100) <= 2, $"height={height}, expected ~100.");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a parse bug in the `@position-try` fallback resolver that silently dropped fallback declarations, part of the [#1105](https://github.com/MaiRat/Broiler/issues/1105) `css-anchor-position` position-try/fallback cluster.

The hand-rolled reader in `AnchorResolver/PositionTry.cs` split each rule body on `;`/`:` **without stripping CSS comments**. A comment inside a fallback body — ubiquitous in these WPT tests, e.g. `/* 2: Position to the right of the anchor. */` — had its `:` mistaken for a declaration separator, so the real declarations (`left: anchor(--a right)`, …) were never recorded and the fallback was applied with the **base** style's insets, leaving the box in the wrong place/size.

**Fix:** strip `/*…*/` from the style text before matching `@position-try` rules (one new `CssCommentPattern`). Strictly more permissive; isolated to this hand-rolled parser (all other CSS goes through the real engine, which already handles comments).

## Verification

Reproduced end-to-end against the real WPT file `css/css-anchor-position/position-try-002.html` via the live render harness (`RenderHtmlFileBitmapPublic` + coloured-box scan):

| | offset-x | offset-y | width | height |
|---|---|---|---|---|
| Spec (`data-offset`/`data-expected`) | 200 | 0 | 200 | 100 |
| Before fix | 0 | 0 | **400** | 100 |
| After fix | **200** | **0** | **200** | **100** |

- New regression test `PositionTryFallbackTests` (live render, asserts the box lands at the spec offsets).
- Full `Broiler.Wpt.Tests` suite passes (exit 0), no regression.

**Reach:** any position-try test with a comment before the first declaration in a fallback body benefits — the non-local `position-try-fallbacks-*` family in CI is the likely beneficiary (only `position-try-002` and `-grid-001` have body comments in the local checkout).

## Docs / roadmap

Adds the position-try fallback work as **cluster 10** in `docs/roadmap/wpt-triage-and-diagnostics.md` with a sub-task checklist:

- [x] Comment-in-body parse — ✅ this PR
- ⛔ Grid-area containing block — **blocked on real grid track layout** (probed: Broiler stacks the grid vertically instead of laying out tracks; the anchor is mislaid before position-try runs, so the pixel compare mismatches on the anchor alone)
- [ ] Fit-check geometry parity (resolver re-implements layout approximately) — highest-value *unblocked* follow-up
- [ ] `last-successful-*` (stateful position-option history) — large
- [ ] Cascade interactions (`!important`/animations/transitions/`revert`) — large
- [ ] `try-tactic` flips (`flip-block`/`flip-inline`/`flip-start`)

## Scope / what this is not

This does not attempt the larger position-try features (grid-area CB, stateful last-successful, cascade-origin tracking) — those are documented as blocked or large in the roadmap. This is the cluster's bounded, locally-verifiable win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)