### PR TITLE
WPT runner diagnostics: make every failure point at its cause (#1b–#10)

### DIFF
--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -157,84 +157,249 @@ feature gating many tests.
   markdown step-summary; `scripts/merge-wpt-shards.py` aggregates across shards
   into a **"Top N dropped CSS declarations"** section in the GitHub issue.
 - **Scope**: captures **stylesheet (cascade)** drops — verified end-to-end through
-  the render path. Inline `style=""` drops follow a separate render route and are
-  not yet captured (the engine hook still reports them for any `GetComputedStyle`
-  consumer). Closing the inline gap → see #1b.
+  the render path — **and** inline `style=""` drops (see #1b). Static inline styles
+  flow through the renderer's style engine, which already reports their drops at the
+  `IsAcceptableDeclarationValue` site; JavaScript-mutated inline styles are dropped
+  earlier by the bridge and are now reported there too.
 - **Tests**: `CssStyleEngineTests.CssEngineDiagnostics_Reports_Dropped_Declarations_Only`,
   `DroppedDeclarationCollectorTests` (×3), `test_merge_aggregates_dropped_declarations`.
 
-#### #1b — Capture inline-style drops through the render path (small follow-up)
-Find where the bridge/layout applies the inline `style` attribute and route it
-through (or report from) the same drop site. Lower priority — cross-cutting
-"missing feature" drops live in stylesheets, which #1 already covers.
+#### ✅ #1b — Capture inline-style drops through the render path (DONE)
+The render path has two routes that ingest an inline `style` attribute:
 
-### #2 — Group exceptions by signature (next)
+1. **Static inline styles** (present in the source HTML) reach the renderer's style
+   engine unchanged, so its existing `IsAcceptableDeclarationValue` drop site
+   (`CssStyleEngine.CollectCascadedDeclarations`, the `includeInlineStyle` branch wired
+   in during the Phase 5 cutover) already reports them — no gap.
+2. **JavaScript-mutated inline styles** are applied by the **bridge** during
+   `WptTestRunner.ExecuteScriptsWithDom`, *before* rendering. `DomBridge.ParseStyle`
+   validates each declaration with the bridge's own `IsAcceptableCssValue` and keeps only
+   the survivors in `element.Style`; `PrepareCanonicalDocumentForRendering` then rewrites
+   the serialized `style` attribute from `element.Style`. A dropped declaration therefore
+   **vanishes from the serialized output before the style engine sees it** — silent unless
+   reported at the bridge.
 
-*Cluster 7.* `ScriptError` failures already carry the exception + stack trace; the
-report should bucket them by **exception type + message + top non-framework
-frame** (e.g. `DomName..ctor — A prefixed name requires a namespace URI ×N`). One
-signature → many tests → one fix. Small change in `Program.cs` triage +
-`merge-wpt-shards.py`.
+Fix: `DomBridge.ParseStyle` gained an opt-in `reportDrops` flag that routes rejected
+declarations to `CssEngineDiagnostics.DeclarationRejected` (the same hook #1 uses). It is
+set `true` only at the five inline-style **ingestion** sites that write `element.Style`
+(`setAttribute("style")` on both the C# and JS paths, `element.style = "…"`, and
+`element.style.cssText = "…"`) and left off for query/bookkeeping re-parses
+(`getComputedStyle`, style invalidation) and for stylesheet-rule/descriptor parsing
+(cascade drops the engine already reports). Regression tests:
+`InlineStyleDropDiagnosticsTests` (×4, in `Broiler.Cli.Tests`), incl. an end-to-end check
+that the dropped declaration is absent from the serialized HTML while the valid one survives.
 
-### #3 — Detect the "green / no-red" reference-overlay convention
+> **Note — not all inline mutations validate.** The per-property setter
+> (`element.style.color = "…"`, `setProperty`) bypasses `ParseStyle`/`IsAcceptableCssValue`
+> entirely and stores the value verbatim, so it neither drops nor needs reporting. Only the
+> whole-attribute / `cssText` paths run the bridge's value filter.
+
+### ✅ #2 — Group exceptions by signature (DONE)
+
+*Cluster 7.* Exception-bearing failures (`ScriptError`, `RenderingError`, `FileIO`,
+`ReferenceDecodeError`) carry the exception message + stack trace; the report now buckets
+them by **top non-framework frame + normalized message**
+(e.g. `DomName..ctor — A prefixed name requires a namespace URI`). One signature → many
+tests → one fix.
+
+- **Signature** (`ExceptionSignature.cs`, `Broiler.Wpt`): `TopNonFrameworkFrame(stackTrace)`
+  takes the first stack frame outside `System.`/`Microsoft.`/`Internal.`, shortened to
+  `Type.Method` (constructors keep the canonical `Type..ctor` double-dot spelling);
+  `NormalizeMessage` strips the runner's stage prefixes (`Script execution failed: ` …),
+  collapses whitespace, and caps length at 100. `Buckets` groups all stack-trace-bearing
+  failures (pixel mismatches excluded — no trace; timeouts excluded — reported separately),
+  most frequent first.
+- **Outputs**: results JSON `triage.exceptionSignatures` (`{signature, count}`) + console
+  section (`PrintExceptionSignatures`) + markdown step-summary
+  (`WriteExceptionSignaturesSection`); `scripts/merge-wpt-shards.py` sums the per-shard
+  counts into a **"Top N exception signatures"** section in the GitHub issue.
+- **Tests**: `ExceptionSignatureTests` (×6, incl. frame-skipping, ctor spelling, message
+  fallback, and bucket grouping/limit) and `test_merge_aggregates_exception_signatures`.
+
+### ✅ #3 — Detect the "green / no-red" reference-overlay convention (DONE)
 
 *Clusters 4, 5, 6.* A huge share of WPT reftests are "passes if green, no red"
-with a `z-index:-1` red overlay. Scan the rendered bitmap for **pure-red pixels
-present in the output but not the reference** and tag `ReferenceOverlayExposed` —
-a strong "real layout/paint bug" signal, distinct from antialiasing noise. (This
-is exactly the manual red/green pixel harness used during triage.)
+with a `z-index:-1` red overlay. The mismatch classifier now scans for **pure-red
+pixels present in the output but not the reference** and tags
+`ReferenceOverlayExposed` — a strong "real layout/paint bug" signal, distinct from
+antialiasing noise. (This is exactly the manual red/green pixel harness used during triage.)
 
-### #4 — Evaluate `check-layout-th.js` `data-offset` assertions
+- **Where**: `MismatchClassifier.Classify` (`Broiler.HTML.Image`, submodule). A new
+  `MismatchCategory.ReferenceOverlayExposed` is checked **first** — ahead of `MinorDiff`
+  and the generic delta buckets — because exposed pure red is the most specific and
+  actionable signal and never arises from anti-aliasing.
+- **Heuristic**: a sampled mismatch counts as overlay-exposed when the **output** pixel is
+  overlay-red (`R≥200`, `G,B≤60` — excludes pinkish AA) and the **reference** pixel has no
+  red content (loose `IsReddish`: red dominant and `R≥64`, so a legitimately-red reference
+  — even a darker red — is not mistaken for an exposed overlay). Fires when ≥10 % of sampled
+  mismatches are overlay-exposed.
+- **Surfacing**: flows through the existing generic sub-category plumbing automatically —
+  results JSON `triage.mismatchSubCategories` / per-test `subCategory`, the console
+  PixelMismatch sub-group, and `merge-wpt-shards.py`'s `PixelMismatch:ReferenceOverlayExposed`
+  problem group; no runner/merge changes needed.
+- **Tests** (`WptTestRunnerTests`): `..._ReferenceOverlayExposed_When_Red_Shows_Through`,
+  `..._Does_Not_Flag_Overlay_When_Reference_Is_Also_Red`; the existing high-delta
+  `LayoutShift` test was switched to a blue↔green pair (its old red↔green pixels now
+  correctly classify as the more-specific overlay-exposed).
 
-*Clusters 1, 3, 6 were all `checkLayout` tests.* Those carry `data-offset-x/y` on
-elements. The runner already holds the live DOM (`ExecuteScriptsWithDom`), so it
-can read those attributes + computed box rects and report **"`.item` expected
-offset-x=100, got 0"** — directly actionable, font-independent, no pixel-guessing.
-Highest-value Tier-2 item.
+### ✅ #4 — Evaluate `check-layout-th.js` `data-offset` assertions (DONE)
 
-### #5 — Richer mismatch metadata
+*Clusters 1, 3, 6 were all `checkLayout` tests.* Those carry `data-offset-x/y`
+(and `data-expected-*` / `data-total-*`) on elements. The runner now reads those
+attributes from the live DOM during `ExecuteScriptsWithDom` and compares them
+against the bridge's computed box geometry, reporting **"`span.abspos[title=start]`
+expected offset-y=0, got 13"** — directly actionable, font-independent, no
+pixel-guessing.
 
-Extend `MismatchClassifier` to emit the **bounding box of the largest mismatched
-region** and a **displacement estimate** ("content shifted right ~100px" vs
-"content absent"). Points at alignment-vs-rendering immediately.
+- **Evaluator** (`DomBridge.EvaluateCheckLayoutAssertions`, `CheckLayoutAssertions.cs`,
+  `Broiler.HtmlBridge.Dom`): walks the post-script DOM and, for each `data-offset-x/y`,
+  `data-expected-{width,height,client-width,client-height}`, `data-total-{x,y}` attribute,
+  computes the matching metric via the bridge's existing `LayoutMetrics` getters
+  (`offsetTop`/`offsetLeft`/`offsetWidth`/`offsetHeight`/`clientWidth`/`clientHeight` — the
+  *same* geometry `check-layout-th.js` reads from `element.offsetTop` etc.). Returns one
+  `CheckLayoutAssertion(Element, Property, Expected, Actual)` per declared attribute.
+- **Why the bridge, not the renderer**: the assertions need `offsetParent`-relative offsets
+  and client/border-box sizes the bridge already models for JS; the post-render bitmap path
+  only exposes `GetElementRectangle(id)` (id-only, document-space), which can't express these.
+- **Runner**: `ExecuteScriptsWithDom` returns the assertions alongside the serialized HTML;
+  `RunTest` filters them to the ones diverging beyond a 1px tolerance (`ComputeLayoutAssertionFailures`,
+  guarding against the estimator's sub-pixel noise) and attaches them to the result as
+  `LayoutAssertionFailures`.
+- **Surfacing**: per-test in the console Root-Cause-Analysis (`layout: … expected …, got …`),
+  the markdown **"check-layout assertion failures"** section, and the results JSON
+  (`results[].layoutAssertionFailures`). *Caveat*: the values come from the bridge's CSS-based
+  geometry estimator, so a reported diff reflects that estimate (which is what the test's own JS
+  would have seen), not necessarily the final rendered pixels.
+- **Not yet covered**: `data-expected-scroll-*` and `data-expected-bounding-client-rect-*`
+  (out of the current metric subset). Tests: `CheckLayoutAssertionTests` (×3, `Broiler.Cli.Tests`)
+  and `LayoutAssertionFailureTests` (×2, `Broiler.Wpt.Tests`).
 
-### #6 — Attach rendered / reference / diff PNGs for failures
+### ✅ #5 — Richer mismatch metadata (DONE)
+
+`MismatchClassifier` now emits, alongside the sub-category, the **bounding box of the
+mismatched region** and a **displacement estimate** ("content shifted right ~100px"
+vs "content absent") — pointing at alignment-vs-rendering immediately.
+
+- **Bounding box** (`MismatchDiagnostics.Bounding{Left,Top,Width,Height}`): the dirty
+  rect enclosing all sampled mismatches, accumulated in the existing per-pixel pass.
+- **Displacement** (`MismatchDiagnostics.Displacement`, nullable): compares the centroid
+  of *content present only in the output* (non-white actual / white reference) against
+  *content present only in the reference* (white actual / non-white reference). A
+  significant centroid offset (≥5px on an axis) → `content shifted right/left/up/down ~Npx`;
+  content only on the reference side → `content absent`; only on the output side →
+  `extra content`; co-located or no transition → null. Reuses the classifier's existing
+  white-threshold logic, so it costs nothing extra and needs only the sampled mismatches
+  (no full-bitmap access).
+- **Surfacing**: the displacement phrase is appended to the human `Summary` (so the console
+  Root-Cause-Analysis and any Summary consumer show it); both the bounding box and
+  displacement are emitted as structured fields in the results JSON
+  (`results[].mismatchDiagnostics.boundingBox` / `.displacement`).
+- **Tests** (`WptTestRunnerTests`): `..._Reports_BoundingBox_Of_Mismatched_Region`,
+  `..._Estimates_Content_Shift_Direction`, `..._Reports_Content_Absent_When_Output_Is_Blank`
+  (the existing classifier tests are unaffected — `Summary` only gains a trailing clause
+  when a transition is present).
+
+### ✅ #6 — Attach rendered / reference / diff PNGs for failures (DONE)
 Visual triage in seconds (reconstructed by hand every investigation this session).
 
-### #7 — Auto-cluster failures by name-family + category
-`scripts/merge-wpt-shards.py`: collapse numbered families (`*-static-position-{1..8}`)
-into one line and cross-tab against category, instead of N scattered lines.
+- **Opt-in**: `--failure-images <DIR>` (wired to `WptTestRunner(failureImageDir:)`). Off by
+  default — no images are written and the result paths stay null, so normal/CI runs that
+  don't pass the flag are unaffected.
+- **What/where**: on a pixel-mismatch failure, `RunTest` saves `rendered.png`,
+  `reference.png`, and (when a diff bitmap exists — i.e. not a size mismatch) `diff.png`
+  (changed pixels in magenta, from `PixelDiffResult.DiffBitmap`) under
+  `<DIR>/<test-relative-path-without-ext>/`, mirroring the test tree so the three images for
+  one case sit together and never collide. Best-effort: an I/O error is logged and never
+  fails the test.
+- **Surfacing**: the paths are recorded on `WptTestResult`
+  (`RenderedImagePath`/`ReferenceImagePath`/`DiffImagePath`), emitted in the results JSON
+  (`results[].failureImages`), and printed in the console Root-Cause-Analysis
+  (`images: <dir> (rendered.png, reference.png, diff.png)`).
+- **Tests** (`WptTestRunnerTests`): `RunTest_Saves_Failure_Images_When_FailureImageDir_Set`
+  (files written + paths recorded) and `RunTest_Does_Not_Save_Failure_Images_By_Default`.
 
-### #8 — First-class `manual` / `tentative` / `crashtest` buckets
-*Cluster 2.* Report these as their own category so a regression in the
-classification is visible, not hidden in the failure total.
+### ✅ #7 — Auto-cluster failures by name-family + category (DONE)
+`scripts/merge-wpt-shards.py` now collapses numbered families
+(`*-static-position-{1..8}`) into one line and cross-tabs against category, instead
+of N scattered lines.
 
-### #9 — Extract `<link rel=help>` / `<meta name=assert>` into the report
-See what a test *claims* to verify — the fastest way to spot that a `css-align`
-failure is actually a paint/parse bug.
+- **Family key** (`_family_key`): collapses every digit run in the *file name* to `{N}`
+  (e.g. `…/static-position-1.html` … `-8.html` → `…/static-position-{N}.html`).
+  Directory segments are left intact, so only same-directory siblings that differ purely by
+  number cluster — non-numbered tests never merge.
+- **Aggregation**: per family, accumulate count + a `Counter` of categories + up to
+  `PROBLEM_EXAMPLE_LIMIT` example paths. Only families with **≥2** members are emitted (a lone
+  numbered test is already in the per-test results list), sorted by count then name and
+  bounded to `--problem-limit`.
+- **Output**: merged `failureFamilies` (`{family, count, categories, examples}`) + a
+  **"Top N failure families"** issue section with a per-category breakdown
+  (`… — 4 failure(s) (PixelMismatch 3, ScriptError 1)`).
+- **Test**: `test_merge_clusters_numbered_families` (clusters a `static-position-{N}` family
+  across shards/categories and confirms a non-numbered sibling stays out).
 
-### #10 — Preserve per-test `subCategory` in the merged `results` (small, do next)
+### ✅ #8 — First-class `manual` / `tentative` / `crashtest` buckets (DONE)
+*Cluster 2.* These are now reported as their own buckets so a regression in the
+classification is visible, not hidden in the failure (or pass) total.
 
-*Motivated by the `css-anchor-position` LayoutShift triage above.* The per-shard
-report already carries the pixel-mismatch sub-category per test
-(`mismatchDiagnostics.subCategory`, e.g. `LayoutShift` / `MissingContent` /
-`ColorShift`), and `merge-wpt-shards.py` uses it for the **aggregate** "Top
-problems" section. But the merged **`results`** array — the persisted per-test
-record attached to the issue/artifact and consumed by `--rerun-json` — keeps only
-`relativeTestPath` / `passed` / `skipped` / `category`. The sub-category is
-**dropped**, so a cluster like "the 58 LayoutShift tests" cannot be enumerated
-from the artifact after the fact (only the 3 example paths in `topProblems`
-survive), which is exactly what blocked the triage above.
+- **Classification** (`WptTestRunner`): new `TestKind` enum (`Regular`/`Manual`/`Tentative`/`CrashTest`)
+  and `ClassifyTestKind(path)`, keyed purely off the path so it is outcome-independent.
+  Added `IsTentativeTest` (`.tentative` in the file name or a `tentative/` dir) to sit
+  alongside the existing `IsManualTest` / `IsCrashTest`. Per-test `testKind` is emitted in the
+  results JSON when not `Regular` (mirrors `skipReason`).
+- **Buckets**: `ComputeTestKindBuckets` tallies every result by kind with its pass/fail/skip
+  breakdown. **All four kinds are always emitted in a fixed order, even at zero count**, so a
+  detection regression — e.g. manual dropping from 59 to 0 — shows as `Manual 0` rather than a
+  vanished line. Surfaced in results JSON (`triage.testKinds`), the console (`=== Test kinds ===`),
+  and a markdown **"Test kinds"** table.
+- **Why it matters**: manual tests (Cluster 2) are *skipped* and crashtests *auto-pass* — both
+  invisible in the failure total today; a broken detector would silently re-inflate failures
+  (manual) or hide them (crashtest). The per-kind tally makes the population explicit.
+- **Tests** (`WptTestRunnerTests`): `IsTentativeTest_Detects_Tentative` (+ negative),
+  `ClassifyTestKind_Returns_Expected_Kind` (crash/manual/tentative/regular precedence).
 
-**Change** (one line, no new computation): in `merge-wpt-shards.py::merge`, the
-loop already computes `sub_category` via `_problem_identity(result)` right after
-building the `failure` dict — add `failure["subCategory"] = sub_category` (or move
-the `_problem_identity` call above the dict literal and include the field). This
-makes every failing-test record self-describing: filtering the merged artifact by
-`subCategory == "LayoutShift"` then yields the full list directly. Backward-
-compatible (additive field; `--rerun-json` ignores unknown keys). Add a merge
-unit test asserting the field round-trips (mirrors
-`test_merge_aggregates_dropped_declarations`).
+### ✅ #9 — Extract `<link rel=help>` / `<meta name=assert>` into the report (DONE)
+The report now shows what a failing test *claims* to verify — the fastest way to spot
+that a `css-align` failure is actually a paint/parse bug.
+
+- **Extraction** (`WptTestRunner.ExtractTestMetadata`): scans the raw test HTML for
+  `<link rel="help" href="…">` targets (the spec section[s] it exercises) and joins the
+  `<meta name="assert" content="…">` text (HTML-decoded). Tolerant of attribute order and
+  quoting; `rel="author"` etc. are ignored. Returns a `TestMetadata(HelpLinks, Assertion)`.
+- **Attachment**: extracted once per `RunTest` (right after the HTML is read) and attached to
+  every failing result — `ScriptError`, `RenderingError`, `ReferenceDecodeError`, and
+  `PixelMismatch` — via `HelpLinks` / `Assertion` on `WptTestResult`.
+- **Surfacing**: results JSON `results[].testMetadata` (`{helpLinks, assert}`), the console
+  Root-Cause-Analysis (`assert: …` / `help: …` per failure), and the markdown non-pixel
+  failures list (`asserts:` / `help:` sub-bullets).
+- **Tests** (`WptTestRunnerTests`): `ExtractTestMetadata_Reads_Help_Links_And_Decoded_Assert`
+  (multiple help links, `rel="author"` excluded, `&amp;` decoded) and
+  `ExtractTestMetadata_Returns_Null_When_Absent`.
+
+> **Note on the local test suite**: three pre-existing `Program_*` tests
+> (`…_Records_Timeouts_…`, `…_Writes_Timeout_StackTrace_…`,
+> `…_Outputs_Triage_Report_…`) fail on a **de-DE** machine because they assert
+> dot-decimal strings (`0.05`, `100.0`) that the runner formats with the OS locale
+> (`0,05`, `100,0`). Verified failing on clean `HEAD` too — unrelated to these
+> diagnostics; they pass under invariant/en-US culture (CI).
+
+### ✅ #10 — Preserve per-test `subCategory` in the merged `results` (DONE)
+
+*Motivated by the `css-anchor-position` LayoutShift triage above.* The merged
+**`results`** array previously kept only `relativeTestPath` / `passed` / `skipped` /
+`category`, dropping the pixel-mismatch sub-category — so a cluster like "the 58
+LayoutShift tests" could not be enumerated from the artifact (only the 3 example paths
+in `topProblems` survived).
+
+**Change**: in `merge-wpt-shards.py::merge`, the `_problem_identity(result)` call was
+moved above the `failure` dict and `failure["subCategory"] = sub_category` added — but only
+when a sub-category exists, so non-pixel records don't gain a null field. Every
+pixel-mismatch failure record is now self-describing: filtering the merged artifact by
+`subCategory == "LayoutShift"` yields the full list directly. Backward-compatible (additive;
+`--rerun-json` ignores unknown keys).
+
+- **Tests**: `test_merge_preserves_subcategory_in_results` (sub-category round-trips for a
+  PixelMismatch record; absent for a RenderingError record), and
+  `test_merge_reports_bounded_common_problem_groups` updated to expect the new key.
 
 ---
 
@@ -258,11 +423,11 @@ consume it), not a temporary shim.
 
 ## 4. Suggested next actions
 
-1. **#1b** (inline-style drops) — quickly closes the one gap in the shipped #1.
-2. **#2 + #3** — small, high-signal report additions; together they'd have
-   classified most of this session's "misleading category" failures correctly.
-3. **#4** — convert the most common `css-align` test shape into exact numeric
-   diffs; biggest diagnostic payoff.
+1. ~~**#1b** (inline-style drops)~~ — ✅ done; the inline gap in #1 is closed.
+2. ~~**#2** (exception signatures) + **#3** (reference-overlay detection)~~ — ✅ both
+   done; together they classify most of the "misleading category" failures.
+3. ~~**#4**~~ — ✅ done; the most common `css-align` `checkLayout` shape now reports
+   exact numeric offset/size diffs.
 4. **Abspos *static-position* alignment (cluster 3)** — now unblocked by the
    block-axis `align-self` fix (cluster 9); re-add the static (auto-inset) model.
 5. **Position-try fallback (cluster 10)** — the comment-parse win is shipped; the

--- a/scripts/merge-wpt-shards.py
+++ b/scripts/merge-wpt-shards.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 from collections import Counter
 from pathlib import Path
 
@@ -35,6 +36,19 @@ def _bucket_directory(relative_path: str) -> str:
     if len(parts) <= 1:
         return parts[0] if parts else "."
     return "/".join(parts[:2])
+
+
+_DIGIT_RUN = re.compile(r"\d+")
+
+
+def _family_key(relative_path: str) -> str:
+    """Collapse the numeric token(s) in a test's file name so a numbered family
+    (e.g. ``…/static-position-1.html`` … ``-8.html``) maps to one key
+    ``…/static-position-{N}.html``. Directory segments are left intact, so only
+    same-directory siblings that differ purely by number cluster together."""
+    directory, _, filename = relative_path.rpartition("/")
+    collapsed = _DIGIT_RUN.sub("{N}", filename)
+    return f"{directory}/{collapsed}" if directory else collapsed
 
 
 def _iter_shard_reports(shard_dir: Path):
@@ -83,7 +97,9 @@ def merge(shard_dir: Path, problem_limit: int = DEFAULT_PROBLEM_LIMIT) -> dict:
     directory_counter: Counter[str] = Counter()
     category_counter: Counter[str] = Counter()
     dropped_declaration_counter: Counter[str] = Counter()
+    exception_signature_counter: Counter[str] = Counter()
     problem_groups: dict[str, dict] = {}
+    family_groups: dict[str, dict] = {}
     reported_shard_indexes: set[int] = set()
 
     for _path, report in _iter_shard_reports(shard_dir):
@@ -112,6 +128,16 @@ def merge(shard_dir: Path, problem_limit: int = DEFAULT_PROBLEM_LIMIT) -> dict:
                 if declaration:
                     dropped_declaration_counter[str(declaration)] += int(entry.get("count", 0) or 0)
 
+            # Exception failures grouped by "top frame — message" signature. A high
+            # cross-shard count means one crash gates many tests (issue #1100, cluster
+            # 7): one signature → one fix.
+            for entry in triage.get("exceptionSignatures", []) or []:
+                if not isinstance(entry, dict):
+                    continue
+                signature = entry.get("signature")
+                if signature:
+                    exception_signature_counter[str(signature)] += int(entry.get("count", 0) or 0)
+
         for result in report.get("results", []):
             if not isinstance(result, dict):
                 continue
@@ -124,17 +150,23 @@ def merge(shard_dir: Path, problem_limit: int = DEFAULT_PROBLEM_LIMIT) -> dict:
             seen_failures.add(relative_path)
 
             category = str(result.get("category") or "Unknown")
+            problem_key, problem_label, sub_category = _problem_identity(result)
             failure = {
                 "relativeTestPath": relative_path,
                 "passed": False,
                 "skipped": False,
                 "category": category,
             }
+            # Preserve the pixel-mismatch sub-category so a whole cluster (e.g. all
+            # LayoutShift tests) can be enumerated from the merged artifact, not just
+            # the 3 example paths in topProblems (#10). Additive and only present when
+            # there is one; --rerun-json ignores unknown keys.
+            if sub_category:
+                failure["subCategory"] = sub_category
             failures.append(failure)
             directory_counter[_bucket_directory(relative_path)] += 1
             category_counter[category] += 1
 
-            problem_key, problem_label, sub_category = _problem_identity(result)
             group = problem_groups.setdefault(
                 problem_key,
                 {
@@ -149,6 +181,23 @@ def merge(shard_dir: Path, problem_limit: int = DEFAULT_PROBLEM_LIMIT) -> dict:
             group["count"] += 1
             if len(group["examples"]) < PROBLEM_EXAMPLE_LIMIT:
                 group["examples"].append(relative_path)
+
+            # Cluster numbered families (…-1.html … -8.html) into one row,
+            # cross-tabbed by category, so they collapse from N scattered lines.
+            family = _family_key(relative_path)
+            family_group = family_groups.setdefault(
+                family,
+                {
+                    "family": family,
+                    "count": 0,
+                    "categories": Counter(),
+                    "examples": [],
+                },
+            )
+            family_group["count"] += 1
+            family_group["categories"][category] += 1
+            if len(family_group["examples"]) < PROBLEM_EXAMPLE_LIMIT:
+                family_group["examples"].append(relative_path)
 
     incomplete_shards = []
     for _path, status in _iter_shard_statuses(shard_dir):
@@ -182,6 +231,22 @@ def merge(shard_dir: Path, problem_limit: int = DEFAULT_PROBLEM_LIMIT) -> dict:
         key=lambda group: (-group["count"], group["label"]),
     )[:problem_limit]
 
+    # Only families that actually clustered (≥2 members) are worth a row; a lone
+    # numbered test is already covered by the per-test results list.
+    top_families = sorted(
+        (
+            {
+                "family": group["family"],
+                "count": group["count"],
+                "categories": dict(group["categories"].most_common()),
+                "examples": group["examples"],
+            }
+            for group in family_groups.values()
+            if group["count"] >= 2
+        ),
+        key=lambda group: (-group["count"], group["family"]),
+    )[:problem_limit]
+
     return {
         "summary": {
             "passed": passed,
@@ -196,6 +261,8 @@ def merge(shard_dir: Path, problem_limit: int = DEFAULT_PROBLEM_LIMIT) -> dict:
         "topFailingDirectories": directory_counter.most_common(problem_limit),
         "failuresByCategory": category_counter.most_common(),
         "droppedDeclarations": dropped_declaration_counter.most_common(problem_limit),
+        "exceptionSignatures": exception_signature_counter.most_common(problem_limit),
+        "failureFamilies": top_families,
         "results": failures,
     }
 
@@ -243,6 +310,38 @@ def render_issue_markdown(merged: dict, run_url: str | None) -> str:
             "",
         ]
         lines += [f"- `{declaration}` — {count} occurrence(s)" for declaration, count in dropped]
+
+    # Exception failures grouped by signature: one high-count signature usually
+    # means a single crash (e.g. a DOM constructor throw) gates many tests.
+    exceptions = merged.get("exceptionSignatures") or []
+    if exceptions:
+        lines += [
+            "",
+            f"### Top {merged['problemLimit']} exception signatures",
+            "",
+            "_Exception failures grouped by top non-framework frame and message. A high"
+            " count usually means one crash gates many tests (one signature → one fix)._",
+            "",
+        ]
+        lines += [f"- `{signature}` — {count} failure(s)" for signature, count in exceptions]
+
+    # Numbered test families collapsed into one row, cross-tabbed by category, so a
+    # ``*-static-position-{1..8}`` cluster reads as one line instead of eight.
+    families = merged.get("failureFamilies") or []
+    if families:
+        lines += [
+            "",
+            f"### Top {merged['problemLimit']} failure families",
+            "",
+            "_Numbered test families (e.g. `…-{N}.html`) collapsed into one row, with a"
+            " per-category breakdown._",
+            "",
+        ]
+        for family in families:
+            breakdown = ", ".join(
+                f"{category} {count}" for category, count in family["categories"].items()
+            )
+            lines.append(f"- `{family['family']}` — {family['count']} failure(s) ({breakdown})")
 
     lines += [
         "",

--- a/scripts/tests/test_merge_wpt_shards.py
+++ b/scripts/tests/test_merge_wpt_shards.py
@@ -81,11 +81,13 @@ class MergeWptShardsTests(unittest.TestCase):
             self.assertEqual([3, 2], [problem["count"] for problem in merged["topProblems"]])
             self.assertEqual(6, len(merged["results"]))
             self.assertEqual([{"shardIndex": 7, "exitCode": 134}], merged["incompleteShards"])
+            # results[0] is a PixelMismatch/MissingContent case → carries subCategory (#10).
             self.assertNotIn("testPath", merged["results"][0])
             self.assertEqual(
-                {"relativeTestPath", "passed", "skipped", "category"},
+                {"relativeTestPath", "passed", "skipped", "category", "subCategory"},
                 set(merged["results"][0]),
             )
+            self.assertEqual("MissingContent", merged["results"][0]["subCategory"])
 
             markdown = MODULE.render_issue_markdown(merged, "https://example.test/run/1")
             self.assertIn("### Top 2 problems", markdown)
@@ -131,6 +133,116 @@ class MergeWptShardsTests(unittest.TestCase):
             markdown = MODULE.render_issue_markdown(merged, None)
             self.assertIn("dropped CSS declarations", markdown)
             self.assertIn("`text-align: -webkit-right` — 8 occurrence(s)", markdown)
+
+    def test_merge_aggregates_exception_signatures(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            for name, idx, signatures in (
+                (
+                    "shard-0.json",
+                    0,
+                    [
+                        {"signature": "DomName..ctor — A prefixed name requires a namespace URI", "count": 4},
+                        {"signature": "CssBox.Measure — overflow", "count": 1},
+                    ],
+                ),
+                (
+                    "shard-1.json",
+                    1,
+                    [{"signature": "DomName..ctor — A prefixed name requires a namespace URI", "count": 2}],
+                ),
+            ):
+                (shard_dir / name).write_text(
+                    json.dumps(
+                        {
+                            "summary": {"passed": 1, "failed": 0, "skipped": 0, "total": 1},
+                            "shard": {"index": idx, "count": 8},
+                            "triage": {"exceptionSignatures": signatures},
+                            "results": [],
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+
+            merged = MODULE.merge(shard_dir, problem_limit=10)
+
+            # Counts summed across shards, most frequent first.
+            self.assertEqual(
+                [
+                    ("DomName..ctor — A prefixed name requires a namespace URI", 6),
+                    ("CssBox.Measure — overflow", 1),
+                ],
+                merged["exceptionSignatures"],
+            )
+
+            markdown = MODULE.render_issue_markdown(merged, None)
+            self.assertIn("exception signatures", markdown)
+            self.assertIn(
+                "`DomName..ctor — A prefixed name requires a namespace URI` — 6 failure(s)",
+                markdown,
+            )
+
+    def test_merge_preserves_subcategory_in_results(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._write_report(
+                shard_dir,
+                "shard-0.json",
+                0,
+                [
+                    self._failure("css/a/layout.html", "PixelMismatch", "LayoutShift"),
+                    self._failure("css/b/render.html", "RenderingError"),
+                ],
+            )
+
+            merged = MODULE.merge(shard_dir, problem_limit=10)
+
+            by_path = {r["relativeTestPath"]: r for r in merged["results"]}
+            # Pixel-mismatch record is self-describing: its sub-category round-trips.
+            self.assertEqual("LayoutShift", by_path["css/a/layout.html"]["subCategory"])
+            # A failure without a sub-category does not gain a null field.
+            self.assertNotIn("subCategory", by_path["css/b/render.html"])
+
+    def test_merge_clusters_numbered_families(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._write_report(
+                shard_dir,
+                "shard-0.json",
+                0,
+                [
+                    self._failure("css/css-align/abspos/static-position-1.html", "PixelMismatch", "LayoutShift"),
+                    self._failure("css/css-align/abspos/static-position-2.html", "PixelMismatch", "LayoutShift"),
+                    self._failure("css/css-align/abspos/static-position-3.html", "ScriptError"),
+                ],
+            )
+            self._write_report(
+                shard_dir,
+                "shard-1.json",
+                1,
+                [
+                    self._failure("css/css-align/abspos/static-position-4.html", "PixelMismatch", "LayoutShift"),
+                    # Non-numbered sibling: a singleton family, must not be reported.
+                    self._failure("css/css-align/abspos/align-self.html", "PixelMismatch", "LayoutShift"),
+                ],
+            )
+
+            merged = MODULE.merge(shard_dir, problem_limit=10)
+
+            families = merged["failureFamilies"]
+            self.assertEqual(1, len(families))
+            family = families[0]
+            self.assertEqual("css/css-align/abspos/static-position-{N}.html", family["family"])
+            self.assertEqual(4, family["count"])
+            self.assertEqual({"PixelMismatch": 3, "ScriptError": 1}, family["categories"])
+
+            markdown = MODULE.render_issue_markdown(merged, None)
+            self.assertIn("failure families", markdown)
+            self.assertIn(
+                "`css/css-align/abspos/static-position-{N}.html` — 4 failure(s)",
+                markdown,
+            )
+            self.assertIn("PixelMismatch 3", markdown)
 
     def test_cli_requests_issue_for_incomplete_shard_without_test_results(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/src/Broiler.Cli.Tests/CheckLayoutAssertionTests.cs
+++ b/src/Broiler.Cli.Tests/CheckLayoutAssertionTests.cs
@@ -1,0 +1,78 @@
+using System.Linq;
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Diagnostic #4: the DomBridge evaluates the <c>check-layout-th.js</c>
+/// <c>data-offset-*</c> / <c>data-expected-*</c> assertions against its computed
+/// box geometry so the WPT runner can report precise layout diffs.
+/// </summary>
+public sealed class CheckLayoutAssertionTests
+{
+    [Fact]
+    public void Evaluates_One_Assertion_Per_Data_Attribute_With_Expected_Values()
+    {
+        const string html =
+            "<!DOCTYPE html><html><body style=\"margin:0\">" +
+            "<div id=\"box\" title=\"t\" style=\"position:absolute; left:10px; top:20px; width:100px; height:40px\" " +
+            "data-offset-x=\"10\" data-offset-y=\"20\" data-expected-width=\"100\" data-expected-height=\"40\"></div>" +
+            "</body></html>";
+
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///check-layout.html");
+
+        var assertions = bridge.EvaluateCheckLayoutAssertions();
+
+        // One entry per declared data-* attribute, all on the same element.
+        Assert.Equal(4, assertions.Count);
+        Assert.All(assertions, a => Assert.Equal("div#box[title=t]", a.Element));
+
+        var byProperty = assertions.ToDictionary(a => a.Property);
+        Assert.Equal(10, byProperty["offset-x"].Expected);
+        Assert.Equal(20, byProperty["offset-y"].Expected);
+        Assert.Equal(100, byProperty["width"].Expected);
+        Assert.Equal(40, byProperty["height"].Expected);
+
+        // The computed actual is a finite number for every assertion (the bridge
+        // produced geometry rather than NaN/throwing).
+        Assert.All(assertions, a => Assert.False(double.IsNaN(a.Actual)));
+    }
+
+    [Fact]
+    public void Computes_Border_Box_Size_For_Explicit_Width_And_Height()
+    {
+        // An element with explicit width/height and no border/padding has a
+        // border-box size equal to those lengths — a deterministic offsetWidth/Height.
+        const string html =
+            "<!DOCTYPE html><html><body style=\"margin:0\">" +
+            "<div style=\"width:120px; height:30px\" " +
+            "data-expected-width=\"120\" data-expected-height=\"30\"></div>" +
+            "</body></html>";
+
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///check-layout-size.html");
+
+        var byProperty = bridge.EvaluateCheckLayoutAssertions().ToDictionary(a => a.Property);
+
+        Assert.True(System.Math.Abs(120 - byProperty["width"].Actual) <= 1.0,
+            $"offsetWidth expected ~120, got {byProperty["width"].Actual}");
+        Assert.True(System.Math.Abs(30 - byProperty["height"].Actual) <= 1.0,
+            $"offsetHeight expected ~30, got {byProperty["height"].Actual}");
+    }
+
+    [Fact]
+    public void Returns_Empty_When_No_Check_Layout_Attributes()
+    {
+        const string html = "<!DOCTYPE html><html><body><div>plain</div></body></html>";
+
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///plain.html");
+
+        Assert.Empty(bridge.EvaluateCheckLayoutAssertions());
+    }
+}

--- a/src/Broiler.Cli.Tests/InlineStyleDropDiagnosticsTests.cs
+++ b/src/Broiler.Cli.Tests/InlineStyleDropDiagnosticsTests.cs
@@ -1,0 +1,92 @@
+using Broiler.CSS.Dom;
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Diagnostic #1b regression tests: inline <c>style</c> declarations the DomBridge
+/// drops (via its own <c>IsAcceptableCssValue</c> filter) must be surfaced through
+/// <see cref="CssEngineDiagnostics.DeclarationRejected"/>.
+///
+/// <para>
+/// The bridge rewrites the serialized <c>style</c> attribute from the survivors of
+/// that filter, so a dropped inline declaration disappears from the rendered output
+/// before the renderer's style engine ever sees it — it is silent unless reported
+/// here. These tests drive the JavaScript ingestion paths (<c>setAttribute("style")</c>,
+/// <c>element.style = "…"</c>, <c>element.style.cssText = "…"</c>) that mutate
+/// <c>element.Style</c> and assert the drop is both reported and silent in the output.
+/// </para>
+/// </summary>
+public sealed class InlineStyleDropDiagnosticsTests
+{
+    private const string Html =
+        "<!DOCTYPE html><html><body><div id=\"t\"></div></body></html>";
+
+    [Fact]
+    public void SetAttribute_Style_With_Invalid_Value_Reports_The_Drop()
+    {
+        var rejected = RunWithDiagnostics(
+            "document.getElementById('t').setAttribute('style', 'position: wobble; color: red');");
+
+        Assert.Contains(("position", "wobble"), rejected);
+        // Valid declarations must never be reported.
+        Assert.DoesNotContain(rejected, e => e.Property == "color");
+    }
+
+    [Fact]
+    public void Style_CssText_With_Invalid_Value_Reports_The_Drop()
+    {
+        var rejected = RunWithDiagnostics(
+            "document.getElementById('t').style.cssText = 'display: nonsense; width: 10px';");
+
+        Assert.Contains(("display", "nonsense"), rejected);
+        Assert.DoesNotContain(rejected, e => e.Property == "width");
+    }
+
+    [Fact]
+    public void Assigning_Style_String_Reports_The_Drop()
+    {
+        var rejected = RunWithDiagnostics(
+            "document.getElementById('t').style = 'position: sideways';");
+
+        Assert.Contains(("position", "sideways"), rejected);
+    }
+
+    [Fact]
+    public void Dropped_Inline_Declaration_Is_Silent_In_Serialized_Output()
+    {
+        // End-to-end: the dropped declaration must be absent from the serialized
+        // HTML (the gap #1b closes), while the valid one survives.
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, Html, "file:///inline-drop.html");
+        context.Eval(
+            "document.getElementById('t').setAttribute('style', 'position: wobble; color: red');");
+
+        var serialized = bridge.SerializeToHtml();
+
+        Assert.DoesNotContain("wobble", serialized);
+        Assert.Contains("color: red", serialized);
+    }
+
+    private static List<(string Property, string Value)> RunWithDiagnostics(string script)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, Html, "file:///inline-drop.html");
+
+        var rejected = new List<(string Property, string Value)>();
+        CssEngineDiagnostics.DeclarationRejected = (p, v) => rejected.Add((p, v));
+        try
+        {
+            context.Eval(script);
+        }
+        finally
+        {
+            CssEngineDiagnostics.DeclarationRejected = null;
+        }
+
+        return rejected;
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -751,7 +751,19 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// same property is declared multiple times, invalid values are discarded so
     /// the last <em>valid</em> value wins (per CSS 2.1 §4.2 / CSS Syntax §5).
     /// </summary>
-    private static Dictionary<string, string> ParseStyle(string styleValue)
+    /// <param name="reportDrops">
+    /// When <c>true</c>, declarations rejected by <see cref="IsAcceptableCssValue"/>
+    /// are surfaced through
+    /// <see cref="Broiler.CSS.Dom.CssEngineDiagnostics.DeclarationRejected"/>
+    /// (diagnostic #1b). The bridge rewrites the serialized <c>style</c> attribute
+    /// from the survivors of this filter (see <c>PrepareCanonicalDocumentForRendering</c>),
+    /// so a dropped inline declaration vanishes before the renderer's own style engine
+    /// can report it — this is the only place such drops are observable. Set it only at
+    /// inline-style <em>ingestion</em> sites that write <c>element.Style</c> (so the drop
+    /// reaches the rendered output); leave it off for query/bookkeeping re-parses and for
+    /// stylesheet-rule / descriptor parsing (cascade drops the style engine already reports).
+    /// </param>
+    private static Dictionary<string, string> ParseStyle(string styleValue, bool reportDrops = false)
     {
         var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var declarations = new Broiler.CSS.CssParser().ParseDeclarations(styleValue);
@@ -769,6 +781,12 @@ public sealed partial class DomBridge : IDomBridgeRuntime
                 var unprefixed = StripVendorPrefix(prop);
                 if (unprefixed != prop && !result.ContainsKey(unprefixed))
                     result[unprefixed] = val;
+            }
+            else if (reportDrops)
+            {
+                // Report the raw value (without the synthetic " !important" suffix) so
+                // inline drops aggregate identically to the engine's stylesheet drops.
+                Broiler.CSS.Dom.CssEngineDiagnostics.DeclarationRejected?.Invoke(prop, declaration.Value.Text);
             }
         }
         return result;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
@@ -236,7 +236,7 @@ public sealed partial class DomBridge
         else if (string.Equals(attrName, "style", StringComparison.OrdinalIgnoreCase))
         {
             element.Style.Clear();
-            foreach (var kv in ParseStyle(attrVal))
+            foreach (var kv in ParseStyle(attrVal, reportDrops: true))
                 element.Style[kv.Key] = kv.Value;
             InvalidateStyleScope(element);
         }
@@ -291,7 +291,7 @@ public sealed partial class DomBridge
         else if (string.Equals(attrName, "style", StringComparison.OrdinalIgnoreCase))
         {
             element.Style.Clear();
-            foreach (var kv in ParseStyle(attrVal))
+            foreach (var kv in ParseStyle(attrVal, reportDrops: true))
                 element.Style[kv.Key] = kv.Value;
             InvalidateStyleScope(element);
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/CheckLayoutAssertions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/CheckLayoutAssertions.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Broiler.HtmlBridge;
+
+public sealed partial class DomBridge
+{
+    /// <summary>
+    /// One <c>check-layout-th.js</c> geometry assertion evaluated against the
+    /// bridge's computed box metrics: the <c>data-*</c> attribute's expected
+    /// value alongside the value the bridge computes for the same element.
+    /// </summary>
+    /// <param name="Element">Human-readable element descriptor (e.g. <c>span.abspos[title=start]</c>).</param>
+    /// <param name="Property">The checked geometry property (e.g. <c>offset-y</c>, <c>width</c>).</param>
+    /// <param name="Expected">The value declared by the test's <c>data-*</c> attribute.</param>
+    /// <param name="Actual">The value the bridge's layout-metrics estimator computes.</param>
+    public readonly record struct CheckLayoutAssertion(
+        string Element, string Property, double Expected, double Actual);
+
+    // Maps the WPT check-layout-th.js data-* attributes this evaluator understands
+    // to a short property label. Restricted to the box metrics the bridge computes
+    // directly (offset / client box); scroll and bounding-client-rect checks are not
+    // yet covered.
+    private static readonly (string Attribute, string Property)[] CheckLayoutAttributeMap =
+    {
+        ("data-offset-x", "offset-x"),
+        ("data-offset-y", "offset-y"),
+        ("data-expected-width", "width"),
+        ("data-expected-height", "height"),
+        ("data-expected-client-width", "client-width"),
+        ("data-expected-client-height", "client-height"),
+        ("data-total-x", "total-x"),
+        ("data-total-y", "total-y"),
+    };
+
+    /// <summary>
+    /// Evaluates the <c>data-offset-*</c> / <c>data-expected-*</c> /
+    /// <c>data-total-*</c> assertions that <c>check-layout-th.js</c> tests carry,
+    /// comparing each against the bridge's computed box geometry — the same metrics
+    /// (<c>offsetTop</c>, <c>offsetWidth</c>, …) the test's own JavaScript would read.
+    /// Returns one entry per declared assertion (the caller decides pass/fail with a
+    /// tolerance). The runner uses this to turn an opaque pixel mismatch on a
+    /// check-layout test into a precise, font-independent "<c>expected offset-y=15,
+    /// got 0</c>" diagnostic.
+    /// </summary>
+    public IReadOnlyList<CheckLayoutAssertion> EvaluateCheckLayoutAssertions()
+    {
+        var results = new List<CheckLayoutAssertion>();
+        if (DocumentElement is { } root)
+            CollectCheckLayoutAssertions(root, results);
+        return results;
+    }
+
+    private void CollectCheckLayoutAssertions(DomElement element, List<CheckLayoutAssertion> results)
+    {
+        foreach (var (attribute, property) in CheckLayoutAttributeMap)
+        {
+            if (element.Attributes.TryGetValue(attribute, out var raw) &&
+                double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var expected))
+            {
+                results.Add(new CheckLayoutAssertion(
+                    DescribeElement(element), property, expected, ComputeCheckLayoutMetric(element, property)));
+            }
+        }
+
+        foreach (var child in element.Children)
+            CollectCheckLayoutAssertions(child, results);
+    }
+
+    private double ComputeCheckLayoutMetric(DomElement element, string property)
+    {
+        var isRoot = IsViewportElementForMetrics(element);
+        return property switch
+        {
+            "offset-x" => GetOffsetLeftForDomElement(element),
+            "offset-y" => GetOffsetTopForDomElement(element),
+            "width" => GetOffsetWidthForDomElement(element, isRoot),
+            "height" => GetOffsetHeightForDomElement(element, isRoot),
+            "client-width" => GetClientWidthForDomElement(element, isRoot),
+            "client-height" => GetClientHeightForDomElement(element, isRoot),
+            // check-layout's data-total-{x,y} is offset + border-box size on that axis.
+            "total-x" => GetOffsetLeftForDomElement(element) + GetOffsetWidthForDomElement(element, isRoot),
+            "total-y" => GetOffsetTopForDomElement(element) + GetOffsetHeightForDomElement(element, isRoot),
+            _ => double.NaN,
+        };
+    }
+
+    /// <summary>Concise CSS-ish descriptor for reporting (tag + id/first-class + title).</summary>
+    private static string DescribeElement(DomElement element)
+    {
+        var builder = new StringBuilder(element.TagName.ToLowerInvariant());
+        if (!string.IsNullOrEmpty(element.Id))
+        {
+            builder.Append('#').Append(element.Id);
+        }
+        else if (!string.IsNullOrEmpty(element.ClassName))
+        {
+            var firstClass = element.ClassName
+                .Split(' ', System.StringSplitOptions.RemoveEmptyEntries)
+                .FirstOrDefault();
+            if (firstClass is not null)
+                builder.Append('.').Append(firstClass);
+        }
+
+        if (element.Attributes.TryGetValue("title", out var title) && !string.IsNullOrEmpty(title))
+            builder.Append("[title=").Append(title).Append(']');
+
+        return builder.ToString();
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -143,7 +143,7 @@ public sealed partial class DomBridge
             // Setting element.style = "prop: val; ..." parses as cssText
             element.Style.Clear();
             element.JsSetStyleProps.Clear();
-            foreach (var kv in ParseStyle(s.ToString()))
+            foreach (var kv in ParseStyle(s.ToString(), reportDrops: true))
             {
                 element.Style[kv.Key] = kv.Value;
                 element.JsSetStyleProps.Add(kv.Key);
@@ -172,7 +172,7 @@ public sealed partial class DomBridge
             else if (string.Equals(attrName, "style", StringComparison.OrdinalIgnoreCase))
             {
                 element.Style.Clear();
-                foreach (var kv in ParseStyle(attrVal))
+                foreach (var kv in ParseStyle(attrVal, reportDrops: true))
                     element.Style[kv.Key] = kv.Value;
                 bridgeForSet.InvalidateStyleScope(element);
             }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Utilities.cs
@@ -42,7 +42,7 @@ public sealed partial class DomBridge
         element.JsSetStyleProps.Clear();
         if (a.Length > 0)
         {
-            foreach (var kv in ParseStyle(a[0].ToString()))
+            foreach (var kv in ParseStyle(a[0].ToString(), reportDrops: true))
             {
                 element.Style[kv.Key] = kv.Value;
                 element.JsSetStyleProps.Add(kv.Key);

--- a/src/Broiler.Wpt.Tests/ExceptionSignatureTests.cs
+++ b/src/Broiler.Wpt.Tests/ExceptionSignatureTests.cs
@@ -1,0 +1,100 @@
+namespace Broiler.Wpt.Tests;
+
+public sealed class ExceptionSignatureTests
+{
+    [Fact]
+    public void TryCompute_Joins_Top_Frame_And_Stripped_Message()
+    {
+        const string message = "Script execution failed: A prefixed name requires a namespace URI";
+        var stackTrace = string.Join('\n', new[]
+        {
+            "   at Broiler.DOM.DomName..ctor(String name) in D:\\Broiler\\Broiler.DOM\\DomName.cs:line 42",
+            "   at Broiler.DOM.DomElement.SetAttribute(String name, String value)",
+            "   at System.RuntimeMethodHandle.InvokeMethod(Object target)",
+        });
+
+        Assert.Equal(
+            "DomName..ctor — A prefixed name requires a namespace URI",
+            ExceptionSignature.TryCompute(message, stackTrace));
+    }
+
+    [Fact]
+    public void TryCompute_Skips_Framework_Frames_To_Find_The_Throw_Site()
+    {
+        const string message = "Rendering failed: boom";
+        var stackTrace = string.Join('\n', new[]
+        {
+            "   at System.ThrowHelper.ThrowArgumentOutOfRangeException()",
+            "   at Microsoft.Something.Internal()",
+            "   at Broiler.Layout.CssBox.Measure(Single width)",
+        });
+
+        Assert.Equal("CssBox.Measure — boom", ExceptionSignature.TryCompute(message, stackTrace));
+    }
+
+    [Fact]
+    public void TryCompute_Returns_Null_When_Nothing_Usable()
+    {
+        Assert.Null(ExceptionSignature.TryCompute(null, null));
+        Assert.Null(ExceptionSignature.TryCompute("   ", ""));
+    }
+
+    [Fact]
+    public void TryCompute_Falls_Back_To_Message_When_No_Application_Frame()
+    {
+        const string stackTrace = "   at System.IO.File.ReadAllText(String path)";
+        Assert.Equal("disk gone", ExceptionSignature.TryCompute("Failed to read test file: disk gone", stackTrace));
+    }
+
+    [Fact]
+    public void Buckets_Groups_By_Signature_Most_Frequent_First()
+    {
+        var crash = string.Join('\n', new[]
+        {
+            "   at Broiler.DOM.DomName..ctor(String name)",
+            "   at Broiler.DOM.DomElement.SetAttribute(String n, String v)",
+        });
+        var other = "   at Broiler.Layout.CssBox.Measure(Single w)";
+
+        var failures = new[]
+        {
+            Failure(FailureCategory.ScriptError, "Script execution failed: bad name", crash),
+            Failure(FailureCategory.ScriptError, "Script execution failed: bad name", crash),
+            Failure(FailureCategory.RenderingError, "Rendering failed: overflow", other),
+            // No stack trace → excluded (e.g. a pixel mismatch).
+            Failure(FailureCategory.PixelMismatch, "mismatch", null),
+            // Timeout → excluded (reported in the timeout section).
+            Failure(FailureCategory.Timeout, "Timed out", "   at Broiler.Wpt.Program.Run()"),
+        };
+
+        var buckets = ExceptionSignature.Buckets(failures, limit: 10);
+
+        Assert.Equal(2, buckets.Count);
+        Assert.Equal("DomName..ctor — bad name", buckets[0].Signature);
+        Assert.Equal(2, buckets[0].Count);
+        Assert.Equal("CssBox.Measure — overflow", buckets[1].Signature);
+        Assert.Equal(1, buckets[1].Count);
+    }
+
+    [Fact]
+    public void Buckets_Respects_Limit()
+    {
+        var failures = new[]
+        {
+            Failure(FailureCategory.ScriptError, "a", "   at App.One.Go()"),
+            Failure(FailureCategory.ScriptError, "b", "   at App.Two.Go()"),
+        };
+
+        Assert.Single(ExceptionSignature.Buckets(failures, limit: 1));
+    }
+
+    private static WptTestResult Failure(FailureCategory category, string message, string? stackTrace) =>
+        new()
+        {
+            TestPath = "/tmp/wpt/test.html",
+            Passed = false,
+            Category = category,
+            Message = message,
+            StackTrace = stackTrace,
+        };
+}

--- a/src/Broiler.Wpt.Tests/LayoutAssertionFailureTests.cs
+++ b/src/Broiler.Wpt.Tests/LayoutAssertionFailureTests.cs
@@ -1,0 +1,20 @@
+namespace Broiler.Wpt.Tests;
+
+public sealed class LayoutAssertionFailureTests
+{
+    [Fact]
+    public void Describe_Formats_Element_Property_Expected_And_Actual()
+    {
+        var failure = new LayoutAssertionFailure("span.abspos[title=start]", "offset-y", 0, 13);
+
+        Assert.Equal("span.abspos[title=start] expected offset-y=0, got 13", failure.Describe());
+    }
+
+    [Fact]
+    public void Describe_Trims_Trailing_Zeros_On_Fractional_Values()
+    {
+        var failure = new LayoutAssertionFailure("div#box", "width", 100, 99.5);
+
+        Assert.Equal("div#box expected width=100, got 99.5", failure.Describe());
+    }
+}

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -4894,6 +4894,69 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
         Assert.False(WptTestRunner.IsManualTest(path));
     }
 
+    // ──────────── Tentative + test-kind classification (#8) ───────────
+
+    [Theory]
+    [InlineData("/wpt/css/css-anchor-position/anchor-scope.tentative.html")]
+    [InlineData("/wpt/css/css-flexbox/foo.tentative.https.html")]
+    [InlineData("C:\\wpt\\css\\tentative\\bar.html")]
+    public void IsTentativeTest_Detects_Tentative(string path)
+    {
+        Assert.True(WptTestRunner.IsTentativeTest(path));
+    }
+
+    [Theory]
+    [InlineData("/wpt/css/css-flexbox/flex-001.html")]
+    [InlineData("/wpt/css/tentatively-named.html")]
+    public void IsTentativeTest_Returns_False_For_Regular_Tests(string path)
+    {
+        Assert.False(WptTestRunner.IsTentativeTest(path));
+    }
+
+    [Theory]
+    [InlineData("/wpt/css/compositing/crashtests/bgblend.html", "CrashTest")]
+    [InlineData("/wpt/css/foo-crash.html", "CrashTest")]
+    [InlineData("/wpt/css/css-animations/anim-001-manual.html", "Manual")]
+    [InlineData("/wpt/css/css-anchor-position/anchor.tentative.html", "Tentative")]
+    [InlineData("/wpt/css/css-flexbox/flex-001.html", "Regular")]
+    public void ClassifyTestKind_Returns_Expected_Kind(string path, string expected)
+    {
+        Assert.Equal(expected, WptTestRunner.ClassifyTestKind(path).ToString());
+    }
+
+    // ──────────── Help/assert metadata extraction (#9) ────────────────
+
+    [Fact]
+    public void ExtractTestMetadata_Reads_Help_Links_And_Decoded_Assert()
+    {
+        const string html =
+            "<!DOCTYPE html>\n" +
+            "<link rel=\"help\" href=\"https://drafts.csswg.org/css-align/#align-block\">\n" +
+            "<link rel=\"author\" href=\"mailto:someone@example.test\">\n" +
+            "<link rel='help' href='https://example.test/spec#two'>\n" +
+            "<meta name=\"assert\" content=\"Box aligned to start &amp; clamped.\">\n" +
+            "<body>content</body>";
+
+        var metadata = WptTestRunner.ExtractTestMetadata(html);
+
+        Assert.Equal(
+            new[] { "https://drafts.csswg.org/css-align/#align-block", "https://example.test/spec#two" },
+            metadata.HelpLinks);
+        // rel="author" is not a help link.
+        Assert.DoesNotContain(metadata.HelpLinks!, link => link.StartsWith("mailto:"));
+        // &amp; is decoded.
+        Assert.Equal("Box aligned to start & clamped.", metadata.Assertion);
+    }
+
+    [Fact]
+    public void ExtractTestMetadata_Returns_Null_When_Absent()
+    {
+        var metadata = WptTestRunner.ExtractTestMetadata("<!DOCTYPE html><body>plain</body>");
+
+        Assert.Null(metadata.HelpLinks);
+        Assert.Null(metadata.Assertion);
+    }
+
     // ──────────── Non-test file detection ────────────────────────────
 
     [Fact]
@@ -5028,6 +5091,57 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
 
         // Assert — crash test auto-passes when rendering doesn't throw.
         Assert.True(result.Passed);
+    }
+
+    [Fact]
+    public void RunTest_Saves_Failure_Images_When_FailureImageDir_Set()
+    {
+        // Arrange — a test that renders a red box vs a solid-blue reference of the
+        // same dimensions → a pixel mismatch with a diff bitmap.
+        var testFile = Path.Combine(_tempDir, "mismatch.html");
+        File.WriteAllText(testFile,
+            @"<!DOCTYPE html><html><body style=""margin:0""><div style=""width:100px;height:100px;background:red""></div></body></html>");
+
+        var refDir = Path.Combine(_tempDir, "references");
+        Directory.CreateDirectory(refDir);
+        CreateSolidReferencePng(Path.Combine(refDir, "mismatch.png"), new BColor(0, 0, 255, 255));
+
+        var imagesDir = Path.Combine(_tempDir, "failure-images");
+        var runner = new WptTestRunner(failureImageDir: imagesDir);
+
+        // Act
+        var result = runner.RunTest(testFile, refDir);
+
+        // Assert — rendered/reference/diff PNGs written and recorded on the result.
+        Assert.Equal(FailureCategory.PixelMismatch, result.Category);
+        Assert.NotNull(result.RenderedImagePath);
+        Assert.NotNull(result.ReferenceImagePath);
+        Assert.NotNull(result.DiffImagePath);
+        Assert.True(File.Exists(result.RenderedImagePath!));
+        Assert.True(File.Exists(result.ReferenceImagePath!));
+        Assert.True(File.Exists(result.DiffImagePath!));
+        Assert.StartsWith(imagesDir, result.RenderedImagePath!);
+    }
+
+    [Fact]
+    public void RunTest_Does_Not_Save_Failure_Images_By_Default()
+    {
+        var testFile = Path.Combine(_tempDir, "mismatch-default.html");
+        File.WriteAllText(testFile,
+            @"<!DOCTYPE html><html><body style=""margin:0""><div style=""width:100px;height:100px;background:red""></div></body></html>");
+
+        var refDir = Path.Combine(_tempDir, "references-default");
+        Directory.CreateDirectory(refDir);
+        CreateSolidReferencePng(Path.Combine(refDir, "mismatch-default.png"), new BColor(0, 0, 255, 255));
+
+        var runner = new WptTestRunner();
+
+        var result = runner.RunTest(testFile, refDir);
+
+        Assert.Equal(FailureCategory.PixelMismatch, result.Category);
+        Assert.Null(result.RenderedImagePath);
+        Assert.Null(result.ReferenceImagePath);
+        Assert.Null(result.DiffImagePath);
     }
 
     [Fact]
@@ -5318,13 +5432,14 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
     [Fact]
     public void MismatchClassifier_LayoutShift_When_Large_Deltas()
     {
-        // High per-channel delta → LayoutShift
+        // High per-channel delta → LayoutShift. Uses a blue↔green pair (no red)
+        // so the more-specific ReferenceOverlayExposed heuristic does not apply.
         var mismatches = new List<PixelMismatch>();
         for (int i = 0; i < 100; i++)
         {
-            // ~255 delta → high
+            // ~127 avg delta → high
             mismatches.Add(new PixelMismatch(i, i,
-                255, 0, 0, 255,
+                0, 0, 255, 255,
                 0, 255, 0, 255));
         }
         var diff = new PixelDiffResult
@@ -5340,6 +5455,60 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
 
         Assert.Equal(MismatchCategory.LayoutShift, diag.Category);
         Assert.Contains("layout", diag.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MismatchClassifier_ReferenceOverlayExposed_When_Red_Shows_Through()
+    {
+        // Output paints pure red where the reference is green (the WPT
+        // "passes if green, no red" overlay convention) → ReferenceOverlayExposed,
+        // even though the raw per-channel delta would otherwise read as LayoutShift.
+        var mismatches = new List<PixelMismatch>();
+        for (int i = 0; i < 100; i++)
+        {
+            mismatches.Add(new PixelMismatch(i, i,
+                255, 0, 0, 255,   // actual: pure red (overlay showing through)
+                0, 128, 0, 255)); // reference: green (pass state)
+        }
+        var diff = new PixelDiffResult
+        {
+            DiffRatio = 0.10,
+            DiffPixelCount = 200,
+            TotalPixelCount = 2000,
+            IsMatch = false,
+            Mismatches = mismatches,
+        };
+
+        var diag = MismatchClassifier.Classify(diff, 100, 100, 100, 100);
+
+        Assert.Equal(MismatchCategory.ReferenceOverlayExposed, diag.Category);
+        Assert.Contains("red", diag.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MismatchClassifier_Does_Not_Flag_Overlay_When_Reference_Is_Also_Red()
+    {
+        // Both output and reference are red (just different shades): red is
+        // legitimately present, so this is NOT an exposed overlay.
+        var mismatches = new List<PixelMismatch>();
+        for (int i = 0; i < 100; i++)
+        {
+            mismatches.Add(new PixelMismatch(i, i,
+                255, 0, 0, 255,    // actual: bright red
+                120, 0, 0, 255));  // reference: darker red (red content present)
+        }
+        var diff = new PixelDiffResult
+        {
+            DiffRatio = 0.10,
+            DiffPixelCount = 200,
+            TotalPixelCount = 2000,
+            IsMatch = false,
+            Mismatches = mismatches,
+        };
+
+        var diag = MismatchClassifier.Classify(diff, 100, 100, 100, 100);
+
+        Assert.NotEqual(MismatchCategory.ReferenceOverlayExposed, diag.Category);
     }
 
     [Fact]
@@ -5393,6 +5562,82 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
         Assert.Equal(2, diag.AffectedRows);  // rows 0, 10
         Assert.Equal(2, diag.AffectedColumns); // cols 0, 5
         Assert.NotNull(diag.Summary);
+    }
+
+    [Fact]
+    public void MismatchClassifier_Reports_BoundingBox_Of_Mismatched_Region()
+    {
+        // Mismatches span x∈[10,50], y∈[5,80] → box (10,5) 41×76.
+        var mismatches = new List<PixelMismatch>
+        {
+            new(10, 20, 200, 100, 50, 255, 150, 50, 0, 255),
+            new(50, 80, 200, 100, 50, 255, 150, 50, 0, 255),
+            new(30, 5, 200, 100, 50, 255, 150, 50, 0, 255),
+        };
+        var diff = new PixelDiffResult
+        {
+            DiffRatio = 0.05,
+            DiffPixelCount = 3,
+            TotalPixelCount = 1000,
+            IsMatch = false,
+            Mismatches = mismatches,
+        };
+
+        var diag = MismatchClassifier.Classify(diff, 100, 100, 100, 100);
+
+        Assert.Equal(10, diag.BoundingLeft);
+        Assert.Equal(5, diag.BoundingTop);
+        Assert.Equal(41, diag.BoundingWidth);   // 50 - 10 + 1
+        Assert.Equal(76, diag.BoundingHeight);  // 80 - 5 + 1
+    }
+
+    [Fact]
+    public void MismatchClassifier_Estimates_Content_Shift_Direction()
+    {
+        // Output paints content at x≈110 where the reference is blank, and the
+        // reference has content at x≈10 where the output is blank → shifted right ~100px.
+        var mismatches = new List<PixelMismatch>();
+        for (int i = 0; i < 50; i++)
+            mismatches.Add(new PixelMismatch(110, 50, 0, 0, 0, 255, 255, 255, 255, 255));
+        for (int i = 0; i < 50; i++)
+            mismatches.Add(new PixelMismatch(10, 50, 255, 255, 255, 255, 0, 0, 0, 255));
+
+        var diff = new PixelDiffResult
+        {
+            DiffRatio = 0.05,
+            DiffPixelCount = 100,
+            TotalPixelCount = 2000,
+            IsMatch = false,
+            Mismatches = mismatches,
+        };
+
+        var diag = MismatchClassifier.Classify(diff, 200, 100, 200, 100);
+
+        Assert.Equal("content shifted right ~100px", diag.Displacement);
+        Assert.Contains("shifted right ~100px", diag.Summary);
+    }
+
+    [Fact]
+    public void MismatchClassifier_Reports_Content_Absent_When_Output_Is_Blank()
+    {
+        // Reference has content; output is white everywhere it differs → content absent.
+        var mismatches = new List<PixelMismatch>();
+        for (int i = 0; i < 100; i++)
+            mismatches.Add(new PixelMismatch(i, 0, 255, 255, 255, 255, 0, 0, 0, 255));
+
+        var diff = new PixelDiffResult
+        {
+            DiffRatio = 0.05,
+            DiffPixelCount = 100,
+            TotalPixelCount = 2000,
+            IsMatch = false,
+            Mismatches = mismatches,
+        };
+
+        var diag = MismatchClassifier.Classify(diff, 100, 100, 100, 100);
+
+        Assert.NotNull(diag.Displacement);
+        Assert.Contains("content absent", diag.Displacement!);
     }
 
     // ──────────── JSON output ────────────────────────────────────────

--- a/src/Broiler.Wpt/ExceptionSignature.cs
+++ b/src/Broiler.Wpt/ExceptionSignature.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Broiler.Wpt;
+
+/// <summary>
+/// Builds a stable, human-readable signature for an exception-bearing WPT failure
+/// so that many tests failing for the same reason collapse into one report line
+/// (diagnostic #2). The signature is the top non-framework stack frame joined with
+/// the normalized exception message, e.g.
+/// <c>DomName..ctor — A prefixed name requires a namespace URI</c>. One signature →
+/// many tests → one fix.
+/// </summary>
+internal static class ExceptionSignature
+{
+    private const int MaxMessageLength = 100;
+
+    // Stage prefixes the runner prepends to ex.Message at its catch sites. Stripped
+    // so the signature keys on the underlying error rather than the pipeline stage
+    // (which the failure category already records).
+    private static readonly string[] StagePrefixes =
+    {
+        "Script execution failed: ",
+        "Rendering failed: ",
+        "Match test failed: ",
+        "Failed to read test file: ",
+    };
+
+    /// <summary>
+    /// Computes the signature for a failure, or <c>null</c> when there is nothing
+    /// usable (neither a parseable application frame nor a message).
+    /// </summary>
+    public static string? TryCompute(string? message, string? stackTrace)
+    {
+        var frame = TopNonFrameworkFrame(stackTrace);
+        var msg = NormalizeMessage(message);
+        return (frame, msg) switch
+        {
+            (null, null) => null,
+            (null, _) => msg,
+            (_, null) => frame,
+            _ => $"{frame} — {msg}",
+        };
+    }
+
+    /// <summary>
+    /// Groups exception-bearing failures by signature, most frequent first.
+    /// Only failures that carry a stack trace are bucketed (pixel mismatches and
+    /// other non-exception failures are excluded); timeouts are excluded too because
+    /// their synthetic trace is reported in the dedicated timeout section.
+    /// </summary>
+    public static IReadOnlyList<(string Signature, int Count)> Buckets(
+        IEnumerable<WptTestResult> failures, int limit)
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var result in failures)
+        {
+            if (result.StackTrace is null || result.Category == FailureCategory.Timeout)
+                continue;
+            var signature = TryCompute(result.Message, result.StackTrace);
+            if (signature is null)
+                continue;
+            counts[signature] = counts.GetValueOrDefault(signature) + 1;
+        }
+
+        return counts
+            .OrderByDescending(kv => kv.Value)
+            .ThenBy(kv => kv.Key, StringComparer.Ordinal)
+            .Take(limit)
+            .Select(kv => (kv.Key, kv.Value))
+            .ToList();
+    }
+
+    private static string? NormalizeMessage(string? message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return null;
+
+        var text = message.Trim();
+        foreach (var prefix in StagePrefixes)
+        {
+            if (text.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                text = text[prefix.Length..];
+                break;
+            }
+        }
+
+        text = CollapseWhitespace(text);
+        if (text.Length == 0)
+            return null;
+        if (text.Length > MaxMessageLength)
+            text = string.Concat(text.AsSpan(0, MaxMessageLength), "…");
+        return text;
+    }
+
+    /// <summary>
+    /// Returns the first stack-trace frame that is not in a framework namespace,
+    /// shortened to <c>Type.Method</c> (constructors keep their <c>..ctor</c>
+    /// spelling). Returns <c>null</c> when the trace has no parseable application frame.
+    /// </summary>
+    private static string? TopNonFrameworkFrame(string? stackTrace)
+    {
+        if (string.IsNullOrEmpty(stackTrace))
+            return null;
+
+        foreach (var rawLine in stackTrace.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (!line.StartsWith("at ", StringComparison.Ordinal))
+                continue;
+
+            var body = line[3..];
+
+            // Drop the " in <file>:line <n>" suffix and the argument list, leaving
+            // the fully-qualified method name.
+            var inIndex = body.IndexOf(" in ", StringComparison.Ordinal);
+            if (inIndex >= 0)
+                body = body[..inIndex];
+            var parenIndex = body.IndexOf('(');
+            if (parenIndex >= 0)
+                body = body[..parenIndex];
+            body = body.Trim();
+
+            if (body.Length == 0 || IsFrameworkFrame(body))
+                continue;
+
+            return ShortenFrame(body);
+        }
+
+        return null;
+    }
+
+    private static bool IsFrameworkFrame(string fullMethod) =>
+        fullMethod.StartsWith("System.", StringComparison.Ordinal) ||
+        fullMethod.StartsWith("Microsoft.", StringComparison.Ordinal) ||
+        fullMethod.StartsWith("Internal.", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Reduces a fully-qualified <c>Namespace.Type.Method</c> to <c>Type.Method</c>,
+    /// preserving the constructor spelling (e.g. <c>Namespace.DomName..ctor</c> →
+    /// <c>DomName..ctor</c>).
+    /// </summary>
+    private static string ShortenFrame(string fullMethod)
+    {
+        string typeFull;
+        string method;
+        if (fullMethod.EndsWith("..ctor", StringComparison.Ordinal))
+        {
+            method = ".ctor";
+            typeFull = fullMethod[..^6];
+        }
+        else if (fullMethod.EndsWith("..cctor", StringComparison.Ordinal))
+        {
+            method = ".cctor";
+            typeFull = fullMethod[..^7];
+        }
+        else
+        {
+            var lastDot = fullMethod.LastIndexOf('.');
+            if (lastDot < 0)
+                return fullMethod;
+            method = fullMethod[(lastDot + 1)..];
+            typeFull = fullMethod[..lastDot];
+        }
+
+        var typeDot = typeFull.LastIndexOf('.');
+        var typeSimple = typeDot >= 0 ? typeFull[(typeDot + 1)..] : typeFull;
+        // method already carries its leading dot for (c)ctors, so joining with '.'
+        // yields the canonical "Type..ctor" double-dot spelling.
+        return $"{typeSimple}.{method}";
+    }
+
+    private static string CollapseWhitespace(string text)
+    {
+        var builder = new StringBuilder(text.Length);
+        var pendingSpace = false;
+        foreach (var ch in text)
+        {
+            if (char.IsWhiteSpace(ch))
+            {
+                pendingSpace = true;
+                continue;
+            }
+            if (pendingSpace && builder.Length > 0)
+                builder.Append(' ');
+            pendingSpace = false;
+            builder.Append(ch);
+        }
+        return builder.ToString();
+    }
+}

--- a/src/Broiler.Wpt/Program.cs
+++ b/src/Broiler.Wpt/Program.cs
@@ -49,6 +49,7 @@ public class Program
         string? referenceDir = null;
         string? jsonOutputPath = null;
         string? markdownOutputPath = null;
+        string? failureImagesDir = null;
         string? subset = null;
         string? rerunJsonPath = null;
         RerunSelectionKind rerunSelectionKind = RerunSelectionKind.Failures;
@@ -72,6 +73,9 @@ public class Program
                     break;
                 case "--markdown-output" when i + 1 < args.Length:
                     markdownOutputPath = args[++i];
+                    break;
+                case "--failure-images" when i + 1 < args.Length:
+                    failureImagesDir = args[++i];
                     break;
                 case "--subset" when i + 1 < args.Length:
                     subset = args[++i];
@@ -119,6 +123,7 @@ public class Program
                 case "--reference-dir":
                 case "--json-output":
                 case "--markdown-output":
+                case "--failure-images":
                 case "--subset":
                 case "--rerun-json":
                 case "--rerun-kind":
@@ -190,7 +195,10 @@ public class Program
         }
         Console.WriteLine();
 
-        var runner = new WptTestRunner();
+        var runner = new WptTestRunner(failureImageDir: failureImagesDir);
+
+        if (!string.IsNullOrWhiteSpace(failureImagesDir))
+            Console.WriteLine($"Failure images: {Path.GetFullPath(failureImagesDir)}");
 
         // Surface CSS declarations the style engine drops because their value
         // failed validation. A single high-count entry (e.g. an unsupported
@@ -351,6 +359,9 @@ public class Program
                             Console.WriteLine($"      • {r.TestPath}");
                             if (r.MismatchDiagnostics is { } d)
                                 Console.WriteLine($"        {d.Summary}");
+                            PrintTestMetadata(r, "        ");
+                            PrintLayoutAssertionFailures(r, "        ");
+                            PrintFailureImages(r, "        ");
                         }
                     }
                 }
@@ -361,6 +372,8 @@ public class Program
                         Console.WriteLine($"    • {r.TestPath}");
                         if (r.Message is not null)
                             Console.WriteLine($"      {r.Message}");
+                        PrintTestMetadata(r, "      ");
+                        PrintLayoutAssertionFailures(r, "      ");
                     }
                 }
             }
@@ -369,20 +382,23 @@ public class Program
         // The aggregate is complete; stop collecting and snapshot the top entries.
         Broiler.CSS.Dom.CssEngineDiagnostics.DeclarationRejected = null;
         var topDropped = droppedDeclarations.Top(TopBucketLimit);
+        var topExceptionSignatures = ExceptionSignature.Buckets(failures, TopBucketLimit);
 
         PrintBucketSummary(wptPath, failures, skippedResults);
         PrintDroppedDeclarations(topDropped, droppedDeclarations.TotalDropped);
+        PrintExceptionSignatures(topExceptionSignatures);
+        PrintTestKinds(allResults);
 
         if (jsonOutputPath is not null)
         {
-            WriteJsonReport(allResults, jsonOutputPath, passed, failed, skipped, wptPath, shardCount, shardIndex, topDropped);
+            WriteJsonReport(allResults, jsonOutputPath, passed, failed, skipped, wptPath, shardCount, shardIndex, topDropped, topExceptionSignatures);
             Console.WriteLine();
             Console.WriteLine($"JSON report written to: {jsonOutputPath}");
         }
 
         if (markdownOutputPath is not null)
         {
-            WriteMarkdownSummary(allResults, markdownOutputPath, passed, failed, skipped, wptPath, subset, topDropped);
+            WriteMarkdownSummary(allResults, markdownOutputPath, passed, failed, skipped, wptPath, subset, topDropped, topExceptionSignatures);
             Console.WriteLine();
             Console.WriteLine($"Markdown summary written to: {markdownOutputPath}");
         }
@@ -610,7 +626,8 @@ public class Program
         string wptPath,
         int shardCount = 1,
         int shardIndex = WptTestRunner.AllShards,
-        IReadOnlyList<(string Declaration, int Count)>? droppedDeclarations = null)
+        IReadOnlyList<(string Declaration, int Count)>? droppedDeclarations = null,
+        IReadOnlyList<(string Signature, int Count)>? exceptionSignatures = null)
     {
         var dir = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(dir))
@@ -684,6 +701,31 @@ public class Program
                         ["count"] = d.Count,
                     })
                     .ToList(),
+                // Exception-bearing failures grouped by "top frame — message"
+                // signature. One high-count signature usually means a single
+                // crash gates many tests (WPT issue #1100 cluster 7). Aggregated
+                // across shards by scripts/merge-wpt-shards.py.
+                ["exceptionSignatures"] = (exceptionSignatures ?? ExceptionSignature.Buckets(failures, TopBucketLimit))
+                    .Select(s => new Dictionary<string, object?>
+                    {
+                        ["signature"] = s.Signature,
+                        ["count"] = s.Count,
+                    })
+                    .ToList(),
+                // First-class manual / tentative / crashtest buckets with their
+                // pass/fail/skip breakdown, so a regression in the classification
+                // (e.g. manual detection breaking) is visible, not hidden in the
+                // failure total (diagnostic #8).
+                ["testKinds"] = ComputeTestKindBuckets(allResults)
+                    .Select(b => new Dictionary<string, object?>
+                    {
+                        ["kind"] = b.Kind.ToString(),
+                        ["total"] = b.Total,
+                        ["passed"] = b.Passed,
+                        ["failed"] = b.Failed,
+                        ["skipped"] = b.Skipped,
+                    })
+                    .ToList(),
                 ["skipReasons"] = skippedResults
                     .GroupBy(r => r.SkipReason.ToString())
                     .OrderByDescending(g => g.Count())
@@ -730,7 +772,8 @@ public class Program
         int skipped,
         string wptPath,
         string? subset,
-        IReadOnlyList<(string Declaration, int Count)>? droppedDeclarations = null)
+        IReadOnlyList<(string Declaration, int Count)>? droppedDeclarations = null,
+        IReadOnlyList<(string Signature, int Count)>? exceptionSignatures = null)
     {
         var dir = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(dir))
@@ -775,6 +818,9 @@ public class Program
         WriteDeferredFeatureBucketSection(writer, deferredFeatureBuckets);
         WriteTimeoutSection(writer, timeoutSummary.Failures, timeoutSummary.SubsetCommands);
         WriteDroppedDeclarationsSection(writer, droppedDeclarations);
+        WriteExceptionSignaturesSection(writer, exceptionSignatures ?? ExceptionSignature.Buckets(failures, TopBucketLimit));
+        WriteTestKindSection(writer, allResults);
+        WriteLayoutAssertionSection(writer, failures, wptPath);
         writer.WriteLine();
         writer.WriteLine("## Non-pixel / exception failures");
         writer.WriteLine();
@@ -790,6 +836,10 @@ public class Program
                 writer.WriteLine($"- `{failure.Category}` `{relativePath}`");
                 if (!string.IsNullOrWhiteSpace(failure.Message))
                     writer.WriteLine($"  - {failure.Message}");
+                if (failure.Assertion is { } assertion)
+                    writer.WriteLine($"  - asserts: {assertion}");
+                if (failure.HelpLinks is { Count: > 0 } helpLinks)
+                    writer.WriteLine($"  - help: {string.Join(", ", helpLinks)}");
             }
         }
 
@@ -834,6 +884,135 @@ public class Program
         writer.WriteLine();
         foreach (var (declaration, count) in droppedDeclarations)
             writer.WriteLine($"- `{declaration}` — {count} occurrence(s)");
+    }
+
+    private static void PrintExceptionSignatures(
+        IReadOnlyList<(string Signature, int Count)> signatures)
+    {
+        if (signatures.Count == 0)
+            return;
+
+        Console.WriteLine();
+        Console.WriteLine($"=== Exception signatures (top {signatures.Count}) ===");
+        Console.WriteLine("(exception failures grouped by top frame + message — one signature often gates many tests)");
+        foreach (var (signature, count) in signatures)
+            Console.WriteLine($"  {count,6}  {signature}");
+    }
+
+    private static void WriteExceptionSignaturesSection(
+        TextWriter writer, IReadOnlyList<(string Signature, int Count)>? signatures)
+    {
+        if (signatures is null || signatures.Count == 0)
+            return;
+
+        writer.WriteLine();
+        writer.WriteLine("## Exception signatures");
+        writer.WriteLine();
+        writer.WriteLine("Exception failures grouped by top non-framework frame and message. A high");
+        writer.WriteLine("count usually means one crash gates many tests (one signature → one fix).");
+        writer.WriteLine();
+        foreach (var (signature, count) in signatures)
+            writer.WriteLine($"- `{signature}` — {count} failure(s)");
+    }
+
+    private static void PrintLayoutAssertionFailures(WptTestResult result, string indent)
+    {
+        if (result.LayoutAssertionFailures is not { Count: > 0 } failures)
+            return;
+
+        foreach (var failure in failures)
+            Console.WriteLine($"{indent}layout: {failure.Describe()}");
+    }
+
+    /// <summary>
+    /// Buckets every result by <see cref="TestKind"/> with its pass/fail/skip
+    /// breakdown. All four kinds are returned in a fixed order (even at zero count)
+    /// so a classification regression — e.g. manual detection dropping to 0 — is
+    /// visible rather than absent (diagnostic #8).
+    /// </summary>
+    private static IReadOnlyList<(TestKind Kind, int Total, int Passed, int Failed, int Skipped)> ComputeTestKindBuckets(
+        IReadOnlyList<WptTestResult> allResults)
+    {
+        var byKind = allResults
+            .GroupBy(r => WptTestRunner.ClassifyTestKind(r.TestPath))
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var buckets = new List<(TestKind, int, int, int, int)>();
+        foreach (var kind in new[] { TestKind.Regular, TestKind.Manual, TestKind.Tentative, TestKind.CrashTest })
+        {
+            var list = byKind.TryGetValue(kind, out var l) ? l : [];
+            var passed = list.Count(r => r.Passed);
+            var skipped = list.Count(r => r.Skipped);
+            buckets.Add((kind, list.Count, passed, list.Count - passed - skipped, skipped));
+        }
+
+        return buckets;
+    }
+
+    private static void PrintTestKinds(IReadOnlyList<WptTestResult> allResults)
+    {
+        var buckets = ComputeTestKindBuckets(allResults);
+        Console.WriteLine();
+        Console.WriteLine("=== Test kinds ===");
+        Console.WriteLine("(manual/tentative/crashtest tracked as first-class buckets — a count dropping to 0 signals a classification regression)");
+        foreach (var (kind, total, passed, failed, skipped) in buckets)
+            Console.WriteLine($"  {kind,-10} {total,6}  (passed {passed}, failed {failed}, skipped {skipped})");
+    }
+
+    private static void WriteTestKindSection(TextWriter writer, IReadOnlyList<WptTestResult> allResults)
+    {
+        writer.WriteLine();
+        writer.WriteLine("## Test kinds");
+        writer.WriteLine();
+        writer.WriteLine("Manual / tentative / crashtest tests tracked as first-class buckets. A count");
+        writer.WriteLine("dropping to 0 signals a regression in the classification (e.g. manual detection).");
+        writer.WriteLine();
+        writer.WriteLine("| Kind | Total | Passed | Failed | Skipped |");
+        writer.WriteLine("|------|------:|-------:|-------:|--------:|");
+        foreach (var (kind, total, passed, failed, skipped) in ComputeTestKindBuckets(allResults))
+            writer.WriteLine($"| {kind} | {total} | {passed} | {failed} | {skipped} |");
+    }
+
+    private static void PrintFailureImages(WptTestResult result, string indent)
+    {
+        if (result.DiffImagePath is { } diff)
+            Console.WriteLine($"{indent}images: {Path.GetDirectoryName(diff)} (rendered.png, reference.png, diff.png)");
+        else if (result.RenderedImagePath is { } rendered)
+            Console.WriteLine($"{indent}images: {Path.GetDirectoryName(rendered)} (rendered.png, reference.png)");
+    }
+
+    private static void PrintTestMetadata(WptTestResult result, string indent)
+    {
+        if (result.Assertion is { } assertion)
+            Console.WriteLine($"{indent}assert: {assertion}");
+        if (result.HelpLinks is { Count: > 0 } helpLinks)
+            Console.WriteLine($"{indent}help: {string.Join(", ", helpLinks)}");
+    }
+
+    private static void WriteLayoutAssertionSection(
+        TextWriter writer, IReadOnlyList<WptTestResult> failures, string wptPath)
+    {
+        var withAssertions = failures
+            .Where(r => r.LayoutAssertionFailures is { Count: > 0 })
+            .OrderBy(r => r.TestPath, StringComparer.Ordinal)
+            .ToList();
+        if (withAssertions.Count == 0)
+            return;
+
+        writer.WriteLine();
+        writer.WriteLine("## check-layout assertion failures");
+        writer.WriteLine();
+        writer.WriteLine("`data-offset-*` / `data-expected-*` assertions whose computed box geometry");
+        writer.WriteLine("diverged from the value the test declares — a precise, font-independent");
+        writer.WriteLine("layout diagnostic, distinct from the pixel comparison.");
+        foreach (var result in withAssertions.Take(TopBucketLimit))
+        {
+            var relativePath = Path.GetRelativePath(wptPath, result.TestPath).Replace('\\', '/');
+            writer.WriteLine();
+            writer.WriteLine($"- `{relativePath}`");
+            foreach (var failure in result.LayoutAssertionFailures!)
+                writer.WriteLine($"  - {failure.Describe()}");
+        }
     }
 
     private static void PrintBucketSummary(
@@ -1322,6 +1501,7 @@ public class Program
         Console.WriteLine($"                             {RunTestTimeoutEnvironmentVariable})");
         Console.WriteLine("  --json-output <PATH>       Write structured JSON report to the given path");
         Console.WriteLine("  --markdown-output <PATH>   Write triage-focused Markdown summary to the given path");
+        Console.WriteLine("  --failure-images <DIR>     Save rendered/reference/diff PNGs for each failure under DIR");
         Console.WriteLine("  --help                     Show this help message");
     }
 }

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -53,6 +53,42 @@ internal enum SkipReason
 }
 
 /// <summary>
+/// First-class classification of a WPT test file by its kind, independent of the
+/// pass/fail outcome (diagnostic #8). Surfacing these as their own buckets keeps a
+/// regression in the classification visible — e.g. if manual-test detection breaks,
+/// 59 tests would silently flip into the failure total — rather than hidden.
+/// </summary>
+internal enum TestKind
+{
+    /// <summary>An ordinary automated test compared against a reference image.</summary>
+    Regular,
+
+    /// <summary>Filename ends in <c>-manual</c>; requires human interaction (skipped).</summary>
+    Manual,
+
+    /// <summary>Tests a not-yet-standardised feature (<c>.tentative</c> in the name or a <c>tentative/</c> dir).</summary>
+    Tentative,
+
+    /// <summary>Passes if rendering does not crash (<c>-crash</c> suffix or <c>crashtests/</c> dir).</summary>
+    CrashTest,
+}
+
+/// <summary>
+/// A single failed <c>check-layout-th.js</c> geometry assertion: the element, the
+/// checked property, and the expected vs. computed value.
+/// </summary>
+internal readonly record struct LayoutAssertionFailure(
+    string Element, string Property, double Expected, double Actual)
+{
+    /// <summary>One-line, directly-actionable description (e.g. <c>span.abspos[title=start] expected offset-y=0, got 13</c>).</summary>
+    public string Describe() =>
+        $"{Element} expected {Property}={Format(Expected)}, got {Format(Actual)}";
+
+    private static string Format(double value) =>
+        value.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture);
+}
+
+/// <summary>
 /// Result of rendering and comparing a single WPT test case.
 /// </summary>
 internal sealed class WptTestResult
@@ -111,6 +147,44 @@ internal sealed class WptTestResult
     public MismatchDiagnostics? MismatchDiagnostics { get; init; }
 
     /// <summary>
+    /// <c>check-layout-th.js</c> geometry assertions whose computed value diverged
+    /// from the test's <c>data-offset-*</c> / <c>data-expected-*</c> attribute, with
+    /// the expected and actual values. Null/empty when the test carries no such
+    /// assertions or all of them matched. Turns an opaque pixel mismatch into a
+    /// precise, font-independent layout diagnostic (diagnostic #4).
+    /// </summary>
+    public IReadOnlyList<LayoutAssertionFailure>? LayoutAssertionFailures { get; init; }
+
+    /// <summary>
+    /// Path to the saved rendered-output PNG for a failing comparison, when failure
+    /// image capture is enabled (diagnostic #6). Null otherwise.
+    /// </summary>
+    public string? RenderedImagePath { get; init; }
+
+    /// <summary>Path to the saved reference PNG for a failing comparison. Null when not captured.</summary>
+    public string? ReferenceImagePath { get; init; }
+
+    /// <summary>
+    /// Path to the saved diff PNG (changed pixels highlighted in magenta) for a
+    /// failing comparison. Null when not captured or when no diff bitmap exists
+    /// (e.g. a size mismatch).
+    /// </summary>
+    public string? DiffImagePath { get; init; }
+
+    /// <summary>
+    /// <c>&lt;link rel="help"&gt;</c> targets declared by the test — the spec
+    /// section(s) it exercises. Null/empty when none (diagnostic #9).
+    /// </summary>
+    public IReadOnlyList<string>? HelpLinks { get; init; }
+
+    /// <summary>
+    /// The test's <c>&lt;meta name="assert"&gt;</c> text — what it claims to verify.
+    /// Reading it is the fastest way to tell whether, say, a <c>css-align</c> failure
+    /// is actually a paint/parse bug. Null when the test declares no assertion.
+    /// </summary>
+    public string? Assertion { get; init; }
+
+    /// <summary>
     /// Serialises this result to a JSON-friendly dictionary.
     /// </summary>
     internal Dictionary<string, object?> ToJsonObject(string? wptPath = null)
@@ -131,6 +205,10 @@ internal sealed class WptTestResult
         if (SkipReason != SkipReason.None)
             obj["skipReason"] = SkipReason.ToString();
 
+        var testKind = WptTestRunner.ClassifyTestKind(TestPath);
+        if (testKind != TestKind.Regular)
+            obj["testKind"] = testKind.ToString();
+
         if (!string.IsNullOrWhiteSpace(wptPath))
         {
             var relativeTestPath = Path.GetRelativePath(wptPath, TestPath).Replace('\\', '/');
@@ -150,7 +228,47 @@ internal sealed class WptTestResult
                 ["maxChannelDelta"] = diag.MaxChannelDelta,
                 ["affectedRows"] = diag.AffectedRows,
                 ["affectedColumns"] = diag.AffectedColumns,
+                ["boundingBox"] = new Dictionary<string, object?>
+                {
+                    ["left"] = diag.BoundingLeft,
+                    ["top"] = diag.BoundingTop,
+                    ["width"] = diag.BoundingWidth,
+                    ["height"] = diag.BoundingHeight,
+                },
+                ["displacement"] = diag.Displacement,
                 ["summary"] = diag.Summary,
+            };
+        }
+
+        if (LayoutAssertionFailures is { Count: > 0 } layoutFailures)
+        {
+            obj["layoutAssertionFailures"] = layoutFailures
+                .Select(f => new Dictionary<string, object?>
+                {
+                    ["element"] = f.Element,
+                    ["property"] = f.Property,
+                    ["expected"] = f.Expected,
+                    ["actual"] = f.Actual,
+                })
+                .ToList();
+        }
+
+        if (RenderedImagePath is not null || ReferenceImagePath is not null || DiffImagePath is not null)
+        {
+            obj["failureImages"] = new Dictionary<string, object?>
+            {
+                ["rendered"] = RenderedImagePath,
+                ["reference"] = ReferenceImagePath,
+                ["diff"] = DiffImagePath,
+            };
+        }
+
+        if (HelpLinks is { Count: > 0 } || Assertion is not null)
+        {
+            obj["testMetadata"] = new Dictionary<string, object?>
+            {
+                ["helpLinks"] = HelpLinks,
+                ["assert"] = Assertion,
             };
         }
 
@@ -514,11 +632,60 @@ internal sealed class WptTestRunner
 
     private readonly int _width;
     private readonly int _height;
+    private readonly string? _failureImageDir;
 
-    public WptTestRunner(int width = 1024, int height = 768)
+    public WptTestRunner(int width = 1024, int height = 768, string? failureImageDir = null)
     {
         _width = width;
         _height = height;
+        _failureImageDir = failureImageDir;
+    }
+
+    /// <summary>
+    /// Saves the rendered, reference, and diff bitmaps for a failing comparison
+    /// under <see cref="_failureImageDir"/> (diagnostic #6), mirroring the test's
+    /// path as a sub-directory. Returns the written paths (any may be null when not
+    /// captured). Best-effort: an I/O error is logged and does not fail the test.
+    /// </summary>
+    private (string? Rendered, string? Reference, string? Diff) SaveFailureImages(
+        string testPath, string? wptRoot, BBitmap rendered, BBitmap reference, BBitmap? diff)
+    {
+        if (string.IsNullOrEmpty(_failureImageDir))
+            return (null, null, null);
+
+        try
+        {
+            // Mirror the test's relative path (without extension) as a folder so the
+            // three images for one test sit together and don't collide across the tree.
+            var relative = wptRoot is not null
+                ? Path.GetRelativePath(wptRoot, testPath)
+                : Path.GetFileName(testPath);
+            var withoutExtension = Path.Combine(
+                Path.GetDirectoryName(relative) ?? string.Empty,
+                Path.GetFileNameWithoutExtension(relative));
+            var caseDir = Path.Combine(_failureImageDir, withoutExtension);
+            Directory.CreateDirectory(caseDir);
+
+            var renderedPath = Path.Combine(caseDir, "rendered.png");
+            var referencePath = Path.Combine(caseDir, "reference.png");
+            rendered.Save(renderedPath);
+            reference.Save(referencePath);
+
+            string? diffPath = null;
+            if (diff is not null)
+            {
+                diffPath = Path.Combine(caseDir, "diff.png");
+                diff.Save(diffPath);
+            }
+
+            return (renderedPath, referencePath, diffPath);
+        }
+        catch (Exception ex)
+        {
+            RenderLogger.LogError(LogCategory.HtmlRenderer, "WptTestRunner.SaveFailureImages",
+                $"Failed to save failure images for {testPath}: {ex.Message}", ex);
+            return (null, null, null);
+        }
     }
 
     /// <summary>
@@ -853,6 +1020,104 @@ internal sealed class WptTestRunner
     }
 
     /// <summary>
+    /// Determines whether the given test path is a WPT <em>tentative</em> test —
+    /// one that exercises a feature whose specification is not yet stable. Per WPT
+    /// convention this is signalled by <c>.tentative</c> in the file name (e.g.
+    /// <c>foo.tentative.html</c>) or by a <c>tentative/</c> directory segment.
+    /// </summary>
+    internal static bool IsTentativeTest(string testPath)
+    {
+        if (testPath.Contains("/tentative/", StringComparison.OrdinalIgnoreCase) ||
+            testPath.Contains("\\tentative\\", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        var nameWithoutExt = Path.GetFileNameWithoutExtension(testPath);
+        return nameWithoutExt.EndsWith(".tentative", StringComparison.OrdinalIgnoreCase) ||
+               nameWithoutExt.Contains(".tentative.", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static readonly Regex LinkTagPattern = new(@"<link\b[^>]*>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex MetaTagPattern = new(@"<meta\b[^>]*>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex RelHelpPattern = new(@"\brel\s*=\s*[""']?\s*help\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex NameAssertPattern = new(@"\bname\s*=\s*[""']?\s*assert\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex HrefValuePattern = new(@"\bhref\s*=\s*(?:""([^""]*)""|'([^']*)'|([^\s>]+))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex ContentValuePattern = new(@"\bcontent\s*=\s*(?:""([^""]*)""|'([^']*)'|([^\s>]+))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// What a test declares about itself: its <c>&lt;link rel="help"&gt;</c> spec
+    /// targets and its <c>&lt;meta name="assert"&gt;</c> claim (diagnostic #9).
+    /// </summary>
+    internal readonly record struct TestMetadata(IReadOnlyList<string>? HelpLinks, string? Assertion);
+
+    /// <summary>
+    /// Extracts the <c>&lt;link rel="help"&gt;</c> hrefs and the joined
+    /// <c>&lt;meta name="assert"&gt;</c> content from a test's HTML. Surfacing these
+    /// in the report shows what a failing test <em>claims</em> to verify — the
+    /// fastest way to spot that a nominal layout failure is really a paint/parse bug.
+    /// </summary>
+    internal static TestMetadata ExtractTestMetadata(string html)
+    {
+        var helpLinks = new List<string>();
+        foreach (Match link in LinkTagPattern.Matches(html))
+        {
+            if (!RelHelpPattern.IsMatch(link.Value))
+                continue;
+            if (TryExtractAttributeValue(HrefValuePattern, link.Value, out var href))
+                helpLinks.Add(href);
+        }
+
+        var assertions = new List<string>();
+        foreach (Match meta in MetaTagPattern.Matches(html))
+        {
+            if (!NameAssertPattern.IsMatch(meta.Value))
+                continue;
+            if (TryExtractAttributeValue(ContentValuePattern, meta.Value, out var content))
+                assertions.Add(System.Net.WebUtility.HtmlDecode(content));
+        }
+
+        return new TestMetadata(
+            helpLinks.Count > 0 ? helpLinks : null,
+            assertions.Count > 0 ? string.Join(" / ", assertions) : null);
+    }
+
+    private static bool TryExtractAttributeValue(Regex pattern, string tag, out string value)
+    {
+        var match = pattern.Match(tag);
+        if (match.Success)
+        {
+            // Groups 1-3 are the double-quoted / single-quoted / unquoted alternatives.
+            for (var i = 1; i < match.Groups.Count; i++)
+            {
+                if (match.Groups[i].Success && match.Groups[i].Value.Trim().Length > 0)
+                {
+                    value = match.Groups[i].Value.Trim();
+                    return true;
+                }
+            }
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Classifies a test file into its <see cref="TestKind"/>. Crash and manual are
+    /// checked first because they drive distinct handling (auto-pass / skip); a test
+    /// is otherwise tentative or regular. Outcome-independent — it keys purely off
+    /// the path so the report can bucket every result by kind.
+    /// </summary>
+    internal static TestKind ClassifyTestKind(string testPath)
+    {
+        if (IsCrashTest(testPath))
+            return TestKind.CrashTest;
+        if (IsManualTest(testPath))
+            return TestKind.Manual;
+        if (IsTentativeTest(testPath))
+            return TestKind.Tentative;
+        return TestKind.Regular;
+    }
+
+    /// <summary>
     /// Runs a single test: renders the HTML with the Broiler stack and
     /// compares the result against a Chromium/Playwright reference image.
     /// </summary>
@@ -919,6 +1184,10 @@ internal sealed class WptTestRunner
             };
         }
 
+        // What the test claims to verify (spec links + assertion); attached to
+        // failures so triage can read intent without opening the file (#9).
+        var metadata = ExtractTestMetadata(html);
+
         // Skip tests that require media playback (video/audio streams)
         // which Broiler cannot decode.
         if (IsMediaPlaybackTest(html))
@@ -933,13 +1202,16 @@ internal sealed class WptTestRunner
         }
 
         // Execute inline scripts via DomBridge.
+        IReadOnlyList<LayoutAssertionFailure>? layoutAssertionFailures = null;
         try
         {
-            html = ExecuteScriptsWithDom(
+            var executed = ExecuteScriptsWithDom(
                 html,
                 new Uri(Path.GetFullPath(testPath)).AbsoluteUri,
                 wptRoot,
                 batchStyleInvalidations: IsCrashTest(testPath));
+            html = executed.Html;
+            layoutAssertionFailures = ComputeLayoutAssertionFailures(executed.LayoutAssertions);
         }
         catch (Exception ex)
         {
@@ -950,6 +1222,8 @@ internal sealed class WptTestRunner
                 Message = $"Script execution failed: {ex.Message}",
                 Category = FailureCategory.ScriptError,
                 StackTrace = ex.StackTrace,
+                HelpLinks = metadata.HelpLinks,
+                Assertion = metadata.Assertion,
             };
         }
 
@@ -1007,6 +1281,8 @@ internal sealed class WptTestRunner
                 Message = $"Rendering failed: {ex.Message}",
                 Category = FailureCategory.RenderingError,
                 StackTrace = ex.StackTrace,
+                HelpLinks = metadata.HelpLinks,
+                Assertion = metadata.Assertion,
             };
         }
 
@@ -1051,6 +1327,8 @@ internal sealed class WptTestRunner
                     Message = $"Failed to decode reference image: {referencePath} ({ex.Message})",
                     Category = FailureCategory.ReferenceDecodeError,
                     StackTrace = ex.StackTrace,
+                    HelpLinks = metadata.HelpLinks,
+                    Assertion = metadata.Assertion,
                 };
             }
 
@@ -1069,6 +1347,7 @@ internal sealed class WptTestRunner
                         TestPath = testPath,
                         Passed = true,
                         MatchPercent = matchPct,
+                        LayoutAssertionFailures = layoutAssertionFailures,
                     };
                 }
 
@@ -1078,6 +1357,9 @@ internal sealed class WptTestRunner
                     rendered.Width, rendered.Height,
                     reference.Width, reference.Height);
 
+                // Capture rendered / reference / diff PNGs for visual triage (#6).
+                var images = SaveFailureImages(testPath, wptRoot, rendered, reference, diff.DiffBitmap);
+
                 return new WptTestResult
                 {
                     TestPath = testPath,
@@ -1086,6 +1368,12 @@ internal sealed class WptTestRunner
                     Message = $"Pixel mismatch: {matchPct:F1}% match ({diff.DiffPixelCount}/{diff.TotalPixelCount} pixels differ) — {diagnostics.Summary}",
                     Category = FailureCategory.PixelMismatch,
                     MismatchDiagnostics = diagnostics,
+                    LayoutAssertionFailures = layoutAssertionFailures,
+                    RenderedImagePath = images.Rendered,
+                    ReferenceImagePath = images.Reference,
+                    DiffImagePath = images.Diff,
+                    HelpLinks = metadata.HelpLinks,
+                    Assertion = metadata.Assertion,
                 };
             }
         }
@@ -1189,7 +1477,7 @@ internal sealed class WptTestRunner
         var testBaseUrl = new Uri(Path.GetFullPath(htmlPath)).AbsoluteUri;
 
         // Set local base path for sub-resource resolution.
-        html = ExecuteScriptsWithDom(html, testBaseUrl, wptRoot);
+        html = ExecuteScriptsWithDom(html, testBaseUrl, wptRoot).Html;
         html = HtmlPostProcessor.Process(html);
 
         EventHandler<HtmlStylesheetLoadEventArgs>? stylesheetHandler = null;
@@ -1267,7 +1555,36 @@ internal sealed class WptTestRunner
     /// Extracts and executes inline/external scripts via the DomBridge,
     /// returning the post-execution HTML with DOM mutations applied.
     /// </summary>
-    private static string ExecuteScriptsWithDom(
+    /// <summary>
+    /// Per-axis pixel tolerance below which a computed geometry value is treated as
+    /// matching its <c>data-*</c> expectation. The bridge metrics are CSS-based
+    /// estimates, so a sub-pixel difference is not a real layout discrepancy.
+    /// </summary>
+    private const double LayoutAssertionTolerancePx = 1.0;
+
+    /// <summary>
+    /// Filters the evaluated <c>check-layout-th.js</c> assertions down to the ones
+    /// whose computed value diverges from the expected value beyond
+    /// <see cref="LayoutAssertionTolerancePx"/>. Returns <c>null</c> when everything
+    /// matched (or there were no assertions) so the result carries no empty list.
+    /// </summary>
+    private static IReadOnlyList<LayoutAssertionFailure>? ComputeLayoutAssertionFailures(
+        IReadOnlyList<DomBridge.CheckLayoutAssertion> assertions)
+    {
+        if (assertions.Count == 0)
+            return null;
+
+        var failures = new List<LayoutAssertionFailure>();
+        foreach (var a in assertions)
+        {
+            if (double.IsNaN(a.Actual) || Math.Abs(a.Expected - a.Actual) > LayoutAssertionTolerancePx)
+                failures.Add(new LayoutAssertionFailure(a.Element, a.Property, a.Expected, a.Actual));
+        }
+
+        return failures.Count > 0 ? failures : null;
+    }
+
+    private static (string Html, IReadOnlyList<DomBridge.CheckLayoutAssertion> LayoutAssertions) ExecuteScriptsWithDom(
         string html,
         string url,
         string? wptRoot = null,
@@ -1370,7 +1687,8 @@ internal sealed class WptTestRunner
             bridge2.FlushTimers();
             bridge2.ResolveAnimationSnapshots();
             bridge2.ResolveAnchorPositions();
-            return bridge2.SerializeToHtml();
+            var assertions2 = bridge2.EvaluateCheckLayoutAssertions();
+            return (bridge2.SerializeToHtml(), assertions2);
         }
 
         using var context = new JSContext();
@@ -1479,7 +1797,8 @@ internal sealed class WptTestRunner
         // backdrop elements for modal <dialog> elements.
         bridge.ResolveAnchorPositions();
 
-        return bridge.SerializeToHtml();
+        var layoutAssertions = bridge.EvaluateCheckLayoutAssertions();
+        return (bridge.SerializeToHtml(), layoutAssertions);
     }
 
     private static void PromoteWindowGlobalsToContext(JSContext context)


### PR DESCRIPTION
Implements the runner-diagnostics roadmap in [`docs/roadmap/wpt-triage-and-diagnostics.md`](docs/roadmap/wpt-triage-and-diagnostics.md) so each WPT failure's report entry points at the **root cause**, not just the nominal feature. Ten diagnostics, each shipped with tests.

## What changed

| # | Diagnostic | Where |
|---|-----------|-------|
| #1b | Inline-style drops captured through the render path | `DomBridge` (bridge `ParseStyle` ingestion → `CssEngineDiagnostics`) |
| #2 | Exception failures grouped by `top frame — message` signature | `ExceptionSignature` + `Program.cs` + merge script |
| #3 | `ReferenceOverlayExposed` for the "green / no-red" reftest convention | `MismatchClassifier` (submodule) |
| #4 | `check-layout-th.js` `data-offset` / `data-expected` assertions evaluated against computed box geometry | `DomBridge.EvaluateCheckLayoutAssertions` + runner |
| #5 | Richer mismatch metadata: bounding box + displacement estimate | `MismatchClassifier` (submodule) |
| #6 | Opt-in `--failure-images` saves rendered/reference/diff PNGs | `WptTestRunner` + `Program.cs` |
| #7 | Auto-cluster numbered test families, cross-tabbed by category | `merge-wpt-shards.py` |
| #8 | First-class `manual` / `tentative` / `crashtest` buckets | `WptTestRunner.TestKind` + `Program.cs` |
| #9 | Extract `<link rel=help>` / `<meta name=assert>` into the report | `WptTestRunner.ExtractTestMetadata` |
| #10 | Preserve per-test `subCategory` in the merged `results` | `merge-wpt-shards.py` |

## Why

Triage repeatedly hit misleading failure *categories* (a paint/parse/DOM-crash bug reported as a generic `PixelMismatch`). These additions surface the actual cause per failure (signatures, overlay detection, exact offset diffs, displacement, PNGs, intent metadata) and make clusters enumerable from the merged artifact.

## Reviewer notes

- **Companion submodule PR required.** #3 and #5 live in `Broiler.HTML/Source/Broiler.HTML.Image/MismatchClassifier.cs`. That commit is on branch [`wpt-mismatch-diagnostics`](https://github.com/MaiRat/Broiler.HTML/pull/new/wpt-mismatch-diagnostics) in `MaiRat/Broiler.HTML`; the gitlink here is bumped to it. The main repo will not compile against an unmodified submodule (it references `ReferenceOverlayExposed`, `BoundingLeft`, `Displacement`). Merge the submodule PR (or its commit) first / together.
- **Production cost is zero by default.** The diagnostics hook stays `null` outside the WPT runner; `--failure-images` is opt-in; the new per-test JSON fields are additive (`--rerun-json` ignores unknown keys).
- **Pre-existing local test failures (not from this PR).** On a **de-DE** machine, three `Program_*` tests fail because they assert dot-decimal strings (`0.05`, `100.0`) the runner formats with the OS locale (`0,05`, `100,0`). Verified failing on clean `HEAD`; they pass under invariant/en-US (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)