### PR TITLE
WPT #1115: cache live geometry getters to fix align-content-table-cell timeout

### DIFF
--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -289,6 +289,22 @@ pixel-guessing.
   same files render in ≈ 0.4–1.2 s. Regression guard: `MulticolCheckLayoutTimeoutTests`
   (`Broiler.Wpt.Tests`).
 
+- **⚠️ Perf fix follow-up (WPT #1115)**: the #1113 fix scoped the geometry caches to the
+  static check-layout assertion pass **only**, so tests that drive the *same* exponential
+  recursion through **live JS geometry getters** never benefited. `align-content-table-cell.html`
+  is `testharness`-based (not `checkLayout`): its 8 `test()` blocks evaluate `offsetTop`
+  ~30 times (the no-op `assert_equals` stub still evaluates its arguments), each an un-memoized
+  query → it stayed a hard hang and was one of the 2 Timeout survivors in run #1115. Fixed by
+  wrapping every live geometry getter (`offsetTop`/`offsetLeft`/`offset{Width,Height}`/
+  `client{Width,Height}`/`scroll{Width,Height}`/`getBoundingClientRect`) in
+  `WithLayoutGeometryCache` — the cache lives for the duration of that **one synchronous getter
+  call** (no JS runs mid-getter → static snapshot → sound), and the `owner` flag means a getter
+  invoked inside the check-layout pass simply shares that pass's cache. Behaviour-preserving (same
+  recursion, same `LayoutGeometryCacheEquivalenceTests` guarantee). `align-content-table-cell.html`
+  went from > 15 s hang → ≈ 2 s. Regression guard: `LiveGeometryQueryTimeoutTests`
+  (`Broiler.Wpt.Tests`). The other #1115 survivor `anchor-scroll-004.html` (scroll-linked, not in
+  the local checkout) leans on `getBoundingClientRect` and may also benefit, but is unverified here.
+
 ### ✅ #5 — Richer mismatch metadata (DONE)
 
 `MismatchClassifier` now emits, alongside the sub-category, the **bounding box of the

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -67,33 +67,35 @@ public sealed partial class DomBridge
         }
     }
 
-    private double GetClientWidthForDomElement(DomElement element, bool isRoot)
-    {
-        if (isRoot)
-            return GetViewportReferenceLength(element, vertical: false);
+    private double GetClientWidthForDomElement(DomElement element, bool isRoot) =>
+        WithLayoutGeometryCache(() =>
+        {
+            if (isRoot)
+                return GetViewportReferenceLength(element, vertical: false);
 
-        var props = GetComputedProps(element);
-        var containingBlockWidth = ResolveContainingBlockReferenceLength(element, vertical: false);
-        var width = ResolveContentBoxExtent(element, vertical: false);
+            var props = GetComputedProps(element);
+            var containingBlockWidth = ResolveContainingBlockReferenceLength(element, vertical: false);
+            var width = ResolveContentBoxExtent(element, vertical: false);
 
-        return width
-             + ParseCssLengthToPixelsWithViewport(props.GetValueOrDefault("padding-left"), element, percentageBasis: containingBlockWidth)
-             + ParseCssLengthToPixelsWithViewport(props.GetValueOrDefault("padding-right"), element, percentageBasis: containingBlockWidth);
-    }
+            return width
+                 + ParseCssLengthToPixelsWithViewport(props.GetValueOrDefault("padding-left"), element, percentageBasis: containingBlockWidth)
+                 + ParseCssLengthToPixelsWithViewport(props.GetValueOrDefault("padding-right"), element, percentageBasis: containingBlockWidth);
+        });
 
-    private double GetClientHeightForDomElement(DomElement element, bool isRoot)
-    {
-        if (isRoot)
-            return GetViewportReferenceLength(element, vertical: true);
+    private double GetClientHeightForDomElement(DomElement element, bool isRoot) =>
+        WithLayoutGeometryCache(() =>
+        {
+            if (isRoot)
+                return GetViewportReferenceLength(element, vertical: true);
 
-        var props = GetComputedProps(element);
-        var containingBlockWidth = ResolveContainingBlockReferenceLength(element, vertical: false);
-        var height = ResolveContentBoxExtent(element, vertical: true);
+            var props = GetComputedProps(element);
+            var containingBlockWidth = ResolveContainingBlockReferenceLength(element, vertical: false);
+            var height = ResolveContentBoxExtent(element, vertical: true);
 
-        return height
-             + ParseCssLengthToPixelsWithViewport(props.GetValueOrDefault("padding-top"), element, percentageBasis: containingBlockWidth)
-             + ParseCssLengthToPixelsWithViewport(props.GetValueOrDefault("padding-bottom"), element, percentageBasis: containingBlockWidth);
-    }
+            return height
+                 + ParseCssLengthToPixelsWithViewport(props.GetValueOrDefault("padding-top"), element, percentageBasis: containingBlockWidth)
+                 + ParseCssLengthToPixelsWithViewport(props.GetValueOrDefault("padding-bottom"), element, percentageBasis: containingBlockWidth);
+        });
 
     private double GetClientTopForDomElement(DomElement element)
     {
@@ -107,45 +109,47 @@ public sealed partial class DomBridge
         return ParseCssLengthToPixelsWithViewport(props.GetValueOrDefault("border-left-width"), element);
     }
 
-    private double GetOffsetWidthForDomElement(DomElement element, bool isRoot)
-    {
-        if (isRoot)
-            return GetViewportReferenceLength(element, vertical: false);
+    private double GetOffsetWidthForDomElement(DomElement element, bool isRoot) =>
+        WithLayoutGeometryCache(() =>
+        {
+            if (isRoot)
+                return GetViewportReferenceLength(element, vertical: false);
 
-        if (ShouldReportZeroOffsetMetrics(element))
-            return 0;
+            if (ShouldReportZeroOffsetMetrics(element))
+                return 0;
 
-        var resolved = ResolvePositionAreaForElement(element);
-        if (resolved != null)
-            return resolved.Value.width;
+            var resolved = ResolvePositionAreaForElement(element);
+            if (resolved != null)
+                return resolved.Value.width;
 
-        var props = GetComputedProps(element);
-        var width = GetBorderBoxWidth(props, element);
-        if (width > 0)
-            return width;
+            var props = GetComputedProps(element);
+            var width = GetBorderBoxWidth(props, element);
+            if (width > 0)
+                return width;
 
-        return ResolveBorderBoxExtent(element, vertical: false);
-    }
+            return ResolveBorderBoxExtent(element, vertical: false);
+        });
 
-    private double GetOffsetHeightForDomElement(DomElement element, bool isRoot)
-    {
-        if (isRoot)
-            return GetViewportReferenceLength(element, vertical: true);
+    private double GetOffsetHeightForDomElement(DomElement element, bool isRoot) =>
+        WithLayoutGeometryCache(() =>
+        {
+            if (isRoot)
+                return GetViewportReferenceLength(element, vertical: true);
 
-        if (ShouldReportZeroOffsetMetrics(element))
-            return 0;
+            if (ShouldReportZeroOffsetMetrics(element))
+                return 0;
 
-        var resolved = ResolvePositionAreaForElement(element);
-        if (resolved != null)
-            return resolved.Value.height;
+            var resolved = ResolvePositionAreaForElement(element);
+            if (resolved != null)
+                return resolved.Value.height;
 
-        var props = GetComputedProps(element);
-        var height = GetBorderBoxHeight(props, element);
-        if (height > 0)
-            return height;
+            var props = GetComputedProps(element);
+            var height = GetBorderBoxHeight(props, element);
+            if (height > 0)
+                return height;
 
-        return ResolveBorderBoxExtent(element, vertical: true);
-    }
+            return ResolveBorderBoxExtent(element, vertical: true);
+        });
 
     private static bool ShouldReportZeroOffsetMetrics(DomElement element) =>
         string.Equals(element.TagName, "map", StringComparison.OrdinalIgnoreCase);
@@ -306,33 +310,35 @@ public sealed partial class DomBridge
         return longestLine * fontSize * 0.5;
     }
 
-    private double GetOffsetTopForDomElement(DomElement element)
-    {
-        var resolved = ResolvePositionAreaForElement(element);
-        if (resolved != null)
-            return resolved.Value.top;
+    private double GetOffsetTopForDomElement(DomElement element) =>
+        WithLayoutGeometryCache(() =>
+        {
+            var resolved = ResolvePositionAreaForElement(element);
+            if (resolved != null)
+                return resolved.Value.top;
 
-        var offsetParent = GetOffsetParentForDomElement(element);
-        if (offsetParent != null)
-            return ComputeOffsetRelativeToAncestor(element, offsetParent, vertical: true);
+            var offsetParent = GetOffsetParentForDomElement(element);
+            if (offsetParent != null)
+                return ComputeOffsetRelativeToAncestor(element, offsetParent, vertical: true);
 
-        var layoutRect = ComputeUnzoomedLayoutRect(element);
-        return layoutRect.Top;
-    }
+            var layoutRect = ComputeUnzoomedLayoutRect(element);
+            return layoutRect.Top;
+        });
 
-    private double GetOffsetLeftForDomElement(DomElement element)
-    {
-        var resolved = ResolvePositionAreaForElement(element);
-        if (resolved != null)
-            return resolved.Value.left;
+    private double GetOffsetLeftForDomElement(DomElement element) =>
+        WithLayoutGeometryCache(() =>
+        {
+            var resolved = ResolvePositionAreaForElement(element);
+            if (resolved != null)
+                return resolved.Value.left;
 
-        var offsetParent = GetOffsetParentForDomElement(element);
-        if (offsetParent != null)
-            return ComputeOffsetRelativeToAncestor(element, offsetParent, vertical: false);
+            var offsetParent = GetOffsetParentForDomElement(element);
+            if (offsetParent != null)
+                return ComputeOffsetRelativeToAncestor(element, offsetParent, vertical: false);
 
-        var layoutRect = ComputeUnzoomedLayoutRect(element);
-        return layoutRect.Left;
-    }
+            var layoutRect = ComputeUnzoomedLayoutRect(element);
+            return layoutRect.Left;
+        });
 
     private DomElement? GetOffsetParentForDomElement(DomElement element)
     {
@@ -472,8 +478,9 @@ public sealed partial class DomBridge
                !string.Equals(display, "contents", StringComparison.OrdinalIgnoreCase);
     }
 
-    private double GetScrollWidthForDomElement(DomElement element, bool isRoot)
-    {
+    private double GetScrollWidthForDomElement(DomElement element, bool isRoot) =>
+        WithLayoutGeometryCache(() =>
+        {
         if (TryGetSelectListBoxScrollExtent(element, verticalAxis: false, out var selectScrollWidth))
             return selectScrollWidth;
 
@@ -497,10 +504,11 @@ public sealed partial class DomBridge
         }
 
         return maxWidth;
-    }
+        });
 
-    private double GetScrollHeightForDomElement(DomElement element, bool isRoot)
-    {
+    private double GetScrollHeightForDomElement(DomElement element, bool isRoot) =>
+        WithLayoutGeometryCache(() =>
+        {
         if (TryGetSelectListBoxScrollExtent(element, verticalAxis: true, out var selectScrollHeight))
             return selectScrollHeight;
 
@@ -524,7 +532,7 @@ public sealed partial class DomBridge
         }
 
         return maxHeight;
-    }
+        });
 
     private double ComputeOffsetRelativeToAncestor(DomElement element, DomElement ancestor, bool vertical)
     {
@@ -644,13 +652,14 @@ public sealed partial class DomBridge
                ParseCssLengthToPixelsWithViewport(parentProps.GetValueOrDefault("padding-top"), element.Parent) == 0;
     }
 
-    private (double Left, double Top, double Width, double Height) GetBoundingClientRectForDomElement(DomElement element, bool isRoot)
-    {
-        if (isRoot)
-            return (0, 0, GetViewportReferenceLength(element, vertical: false), GetViewportReferenceLength(element, vertical: true));
+    private (double Left, double Top, double Width, double Height) GetBoundingClientRectForDomElement(DomElement element, bool isRoot) =>
+        WithLayoutGeometryCache(() =>
+        {
+            if (isRoot)
+                return (0, 0, GetViewportReferenceLength(element, vertical: false), GetViewportReferenceLength(element, vertical: true));
 
-        return ComputeRenderedRect(element);
-    }
+            return ComputeRenderedRect(element);
+        });
 
     private (double Left, double Top, double Width, double Height) ComputeRenderedRect(DomElement element)
     {

--- a/src/Broiler.Wpt.Tests/LiveGeometryQueryTimeoutTests.cs
+++ b/src/Broiler.Wpt.Tests/LiveGeometryQueryTimeoutTests.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression guard for WPT #1115: the box-geometry estimators behind the live
+/// JS geometry getters (<c>offsetTop</c>/<c>offsetLeft</c>/<c>offset*</c>/
+/// <c>client*</c>/<c>scroll*</c>/<c>getBoundingClientRect</c>) recurse up
+/// (containing block), down (auto content extent) and across (preceding
+/// siblings), so a single query re-derives the same sub-rects combinatorially —
+/// exponential in DOM nesting depth. WPT #1113 memoized that recursion only for
+/// the static check-layout assertion pass; <c>align-content-table-cell.html</c>
+/// instead drives ~30 live <c>offsetTop</c> reads from a testharness script and
+/// so kept timing out (it was one of the 2 survivors after #1113). The fix wraps
+/// each live geometry getter in <c>DomBridge.WithLayoutGeometryCache</c> for the
+/// duration of that one synchronous query (no JS runs mid-getter → the layout
+/// snapshot is static → caching is sound). This test fails fast if the
+/// exponential blow-up returns to the live-query path.
+/// </summary>
+public class LiveGeometryQueryTimeoutTests
+{
+    [Fact]
+    public async Task AlignContentTableCell_OffsetTopReads_RenderWellWithinRunnerTimeout()
+    {
+        var wptRoot = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(),
+            "..", "..", "..", "..", "..", "tests", "wpt"));
+        var file = Path.Combine(wptRoot, "css", "css-align", "blocks", "align-content-table-cell.html");
+        Assert.True(File.Exists(file), $"missing fixture {file}");
+
+        var runner = new WptTestRunner(800, 800);
+        var sw = Stopwatch.StartNew();
+        var render = Task.Run(() => { using var b = runner.RenderHtmlFileBitmapPublic(file, wptRoot); });
+        // Pre-fix this never completed (hard hang past the runner's 30s per-test
+        // timeout); ~2s after. A 20s ceiling catches any reintroduced
+        // super-linearity in the live-query geometry path.
+        var completed = await Task.WhenAny(render, Task.Delay(System.TimeSpan.FromSeconds(20))) == render;
+        sw.Stop();
+
+        Assert.True(completed,
+            $"align-content-table-cell: render did not complete within 20s ({sw.ElapsedMilliseconds}ms) — " +
+            "the live offsetTop geometry recursion is exponential again.");
+    }
+}

--- a/tests/wpt/css/css-align/blocks/align-content-table-cell.html
+++ b/tests/wpt/css/css-align/blocks/align-content-table-cell.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align/#distribution-block">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+@import "/fonts/ahem.css";
+body {
+  font: 10px/1 Ahem;
+}
+
+td {
+  padding: 0;
+  height: 50px;
+}
+
+td:nth-child(2) {
+  font-size: 20px;
+}
+
+.valign-top td {
+  vertical-align: top;
+}
+.valign-middle td {
+  vertical-align: middle;
+}
+.valign-bottom td {
+  vertical-align: bottom;
+}
+.valign-middle-short td {
+  vertical-align: middle;
+  height: 10px;
+}
+.valign-bottom-short td {
+  vertical-align: bottom;
+  height: 10px;
+}
+.valign-baseline td {
+  vertical-align: baseline;
+}
+
+.alignc-start td {
+  align-content: start;
+}
+.alignc-center td {
+  align-content: unsafe center;
+}
+.alignc-end td {
+  align-content: unsafe end;
+}
+.alignc-center-short td {
+  align-content: unsafe center;
+  height: 10px;
+}
+.alignc-end-short td {
+  align-content: unsafe end;
+  height: 10px;
+}
+.alignc-baseline td {
+  align-content: baseline;
+}
+
+.alignc-safe-center td {
+  align-content: safe center;
+}
+.alignc-safe-end td {
+  align-content: safe end;
+}
+.alignc-safe-center-short td {
+  align-content: safe center;
+  height: 10px;
+}
+.alignc-safe-end-short td {
+  align-content: safe end;
+  height: 10px;
+}
+</style>
+
+<table border="0" id="ref" class="valign-baseline">
+<tr>
+<td><div class="content1">first<br>second</div></td>
+<td><div class="content2">first<br>second</div></td>
+<td><div class="content3">first<br>second<br>third</div></td>
+</tr>
+</table>
+
+<table border="0" id="target" class="alignc-baseline">
+<tr>
+<td><div class="content1">first<br>second</div></td>
+<td><div class="content2">first<br>second</div></td>
+<td><div class="content3">first<br>second<br>third</div></td>
+</tr>
+</table>
+
+<script>
+function testEquivalence(target, ref) {
+  assert_equals(target.querySelector('.content1').offsetTop,
+      ref.querySelector('.content1').offsetTop, 'The first cell content top');
+  assert_equals(target.querySelector('.content2').offsetTop,
+      ref.querySelector('.content2').offsetTop, 'The second cell content top');
+  assert_equals(target.querySelector('.content3').offsetTop,
+      ref.querySelector('.content3').offsetTop, 'The third cell conten topt');
+}
+
+const ref = document.querySelector('#ref');
+const target = document.querySelector('#target');
+const TALL = 50;
+// *-short specifies `height: 10px`, but cells ignore it, and the actual height
+// is the maximum content height in the row.
+const SHORT = 40;
+const C1HEIGHT = 10 * 2;
+
+test(() => {
+  ref.className = 'valign-top';
+  target.className = 'alignc-start';
+  testEquivalence(target, ref);
+  assert_equals(target.querySelector('.content1').offsetTop, 0);
+}, 'vertical-align:top and align-content:start are equivalent');
+
+test(() => {
+  ref.className = 'valign-middle';
+  target.className = 'alignc-center';
+  testEquivalence(target, ref);
+  assert_equals(target.querySelector('.content1').offsetTop, (TALL - C1HEIGHT) / 2);
+
+  ref.className = 'valign-middle-short';
+  target.className = 'alignc-center-short';
+  testEquivalence(target, ref);
+  assert_equals(target.querySelector('.content1').offsetTop, (SHORT - C1HEIGHT) / 2);
+}, 'vertical-align:middle and `align-content:unsafe center` are equivalent');
+
+test(() => {
+  ref.className = 'valign-bottom';
+  target.className = 'alignc-end';
+  testEquivalence(target, ref);
+  assert_equals(target.querySelector('.content1').offsetTop, TALL - C1HEIGHT);
+
+  ref.className = 'valign-bottom-short';
+  target.className = 'alignc-end-short';
+  testEquivalence(target, ref);
+  assert_equals(target.querySelector('.content1').offsetTop, SHORT - C1HEIGHT);
+}, 'vertical-align:bottom and `align-content:unsafe end` are equivalent');
+
+test(() => {
+  ref.className = 'valign-baseline';
+  target.className = 'alignc-baseline';
+  testEquivalence(target, ref);
+}, 'vertical-align:baseline and align-content:baseline are equivalent');
+
+test(() => {
+  ref.className = 'valign-middle';
+  target.className = 'alignc-safe-center';
+  testEquivalence(target, ref);
+  assert_equals(target.querySelector('.content1').offsetTop, (TALL - C1HEIGHT) / 2);
+}, 'vertical-align:middle and `align-content:safe center` are equivalent if the container is tall');
+
+test(() => {
+  ref.className = 'valign-bottom';
+  target.className = 'alignc-safe-end';
+  testEquivalence(target, ref);
+  assert_equals(target.querySelector('.content1').offsetTop, TALL - C1HEIGHT);
+}, 'vertical-align:bottom and `align-content:safe end` are equivalent if the container is tall');
+
+test(() => {
+  ref.className = 'alignc-center-short';
+  target.className = 'alignc-safe-center-short';
+  testEquivalence(target, ref);
+}, '`align-content:safe center` is equivalent to `unsafe center` even if the specified `height` is short');
+
+test(() => {
+  ref.className = 'alignc-end-short';
+  target.className = 'alignc-safe-end-short';
+}, '`align-content:safe end` is equivalent to `unsafe end` even if the specified `height` is short');
+</script>


### PR DESCRIPTION
## Summary

Fixes the first of the 2 residual `Timeout` failures in [WPT run #1115](https://github.com/MaiRat/Broiler/issues/1115): `css/css-align/blocks/align-content-table-cell.html`.

**#1115 is not a regression.** The [#1113 memoization fix](https://github.com/MaiRat/Broiler/pull/1114) worked — `Timeout` dropped 54 → 2. The reclaimed timeouts simply reclassified to their real failing pixel category (`MissingContent` +49); none flipped to pass. The 423 remainder is the same known hard tail. This PR clears one of the 2 surviving timeouts.

## Root cause

`#1113` scoped `DomBridge.WithLayoutGeometryCache` to the **static check-layout assertion pass only**, leaving live JS geometry getters un-memoized (intentional — the DOM can mutate between live queries).

But `align-content-table-cell.html` is **`testharness`-based, not `checkLayout`**: its 8 `test()` blocks call `assert_equals(el.offsetTop, …)` ~30 times. The runner's no-op `assert_equals` stub still *evaluates its arguments*, so each call fires a live `GetOffsetTopForDomElement` query through the same recursion `#1113` fixed — up (containing block), down (auto content extent), across (preceding siblings) — with **no caching** → exponential in DOM depth → hard hang past the 30s per-test timeout.

## Fix

Wrap every live geometry getter (`offsetTop`/`offsetLeft`/`offset{Width,Height}`/`client{Width,Height}`/`scroll{Width,Height}`/`getBoundingClientRect`) in `WithLayoutGeometryCache`.

Sound because **no JS runs mid-getter** → the layout snapshot is static for that one synchronous call → caching is valid, and the cache is torn down on return (so the "DOM mutates between calls" hazard that made #1113 scope narrowly never applies). The existing `owner` flag means a getter invoked *inside* the check-layout pass simply shares that pass's cache (no double-teardown).

`align-content-table-cell.html`: **> 15s hang → ≈ 2s.**

## Verification

- **Reproduced first**, then confirmed fixed (local fixture: the checkout only had the `-002..-005` `rel=match` variants, which don't hit this path — added the real file).
- **Behaviour-preserving:** `LayoutGeometryCacheEquivalenceTests` (byte-identical cached vs uncached) ✅, `CheckLayoutAssertionTests` ✅, `MulticolCheckLayoutTimeoutTests` ✅.
- **Permanent regression guard:** `LiveGeometryQueryTimeoutTests` (`Broiler.Wpt.Tests`, 20s ceiling, ~1s actual).
- Documented under diagnostic #4 in `docs/roadmap/wpt-triage-and-diagnostics.md`.

## Notes

- This **un-hangs** the test; it doesn't make it pass — it'll now report its real pixel result (likely still a fidelity fail, which per the standing bar is "don't chase").
- The other survivor `anchor-scroll-004.html` (scroll-linked, not in the local checkout) also leans on `getBoundingClientRect` and *may* benefit, but is unverified here.
- WPT pixel gate not re-run (heavy Playwright CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)