### PR TITLE
ci: persist WPT failed-tests manifest when shards fail

### DIFF
--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -294,7 +294,15 @@ jobs:
     needs: run
     # Only the scheduled full-suite run maintains the canonical manifest; manual
     # subset/shard runs would persist a narrower set and shrink it incorrectly.
-    if: always() && github.event_name == 'schedule' && needs.run.result == 'success'
+    #
+    # Run whenever the shards actually executed — success OR failure. The run job
+    # reports `failure` precisely when some tests failed (the runner exits 1 on
+    # any failure), which is exactly when the failed-tests manifest needs
+    # rebuilding; gating on `success` alone would skip persistence in that case
+    # and never record the failures. `skipped`/`cancelled` are still excluded.
+    if: >-
+      always() && github.event_name == 'schedule'
+      && (needs.run.result == 'success' || needs.run.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -313,15 +321,26 @@ jobs:
           merge-multiple: true
 
       - name: Build failed-tests manifest
+        id: manifest
         run: |
           python scripts/merge-wpt-shards.py \
             --shard-dir shard-results \
-            --merged-json "$FAILED_TESTS_FILE"
+            --merged-json "$FAILED_TESTS_FILE" \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Commit manifest
         env:
           BRANCH_NAME: ${{ github.ref_name }}
+          INCOMPLETE_SHARD_COUNT: ${{ steps.manifest.outputs.incomplete_shard_count }}
         run: |
+          # A shard that crashed before uploading its report contributes no
+          # failures to the merged manifest. Committing then would drop those
+          # tests from the canonical set and shrink it incorrectly, so skip the
+          # commit and leave the existing manifest untouched for this run.
+          if [ "${INCOMPLETE_SHARD_COUNT:-0}" -gt 0 ]; then
+            echo "::warning::$INCOMPLETE_SHARD_COUNT incomplete shard(s); skipping manifest commit to avoid shrinking it."
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git diff --quiet -- "$FAILED_TESTS_FILE"; then


### PR DESCRIPTION
## What

Fix the `persist-failed` job in `.github/workflows/wpt-tests.yml` so the failed-tests manifest is actually rebuilt when WPT tests fail.

## Why

`persist-failed` was gated on `needs.run.result == 'success'`. But each shard's run step ends with `exit "$EXIT"`, and the WPT runner deliberately returns exit code 1 whenever any test fails (`run-wpt-tests.sh:265,376`). So a run **with** failing test cases reports `failure`, not `success` — which means the job was skipped exactly when it had something to persist. The manifest (`tests/wpt-baseline/failed-tests.json`), which drives the incremental `--rerun-failed-only` flow, was only ever rebuilt when there were no failures at all.

The sibling `report` job already handles this correctly with `needs.run.result != 'skipped'`, so the two jobs were inconsistent.

## Changes

1. **Condition** — run `persist-failed` on `success` **or** `failure` (still excluding `skipped`/`cancelled`), so failures get recorded.
2. **Incomplete-shard guard** — running on `failure` now also covers the case where a shard crashed without uploading its report. Committing then would silently drop that shard's tests and shrink the canonical manifest (exactly what the job's existing comment warns against). The "Build manifest" step now emits `incomplete_shard_count` via `--github-output` (already supported by `merge-wpt-shards.py`), and the commit step skips with a CI warning when any shard is incomplete.

## Reviewer notes

- Persistence still only happens on `github.event_name == 'schedule'` (intentional — manual subset/shard dispatches would persist a narrower set). This fix therefore takes effect on the scheduled cron run, not on manual `workflow_dispatch`.
- No submodule changes; main-repo workflow only.
- YAML validated; the `if` resolves to a single well-formed GitHub expression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)