### PR TITLE
Fix BuildAnchorRegistry 'Collection was modified' crash (WPT #1131)

### DIFF
--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
@@ -284,7 +284,15 @@ public sealed partial class DomBridge
         if (element.Parent == null) return 0;
 
         double totalHeight = 0;
-        foreach (var sibling in element.Parent.Children)
+        // Snapshot the sibling list before walking it: element.Parent.Children
+        // enumerates the live ChildNodes list, so any mutation of it during the
+        // walk (e.g. an anchor-driven DOM move on a node sharing this parent, or
+        // a lazy offset query that re-enters anchor resolution) throws
+        // "Collection was modified" mid-traversal and aborts the registry build
+        // for the whole document (WPT issue #1131, signature
+        // DomBridge.BuildAnchorRegistry). Same defensive idiom as the .ToList()
+        // walks in ResolveAnchorCenter and InlineContainingBlocks.
+        foreach (var sibling in element.Parent.Children.ToList())
         {
             if (sibling == element) break;
             if (sibling.IsTextNode) continue;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
@@ -157,7 +157,11 @@ public sealed partial class DomBridge
             if (parentFs > 0) fontSize = parentFs;
         }
 
-        foreach (var child in element.Children)
+        // Snapshot before iterating: this estimation is reached from
+        // BuildAnchorRegistry's box computation, where the live ChildNodes list
+        // can be mutated mid-walk and throw "Collection was modified" (WPT issue
+        // #1131). Matches the .ToList() idiom used elsewhere in this file.
+        foreach (var child in element.Children.ToList())
         {
             if (child.IsTextNode)
             {


### PR DESCRIPTION
## Problem

WPT issue #1131's only deterministic exception signature:

> `DomBridge.BuildAnchorRegistry — Collection was modified; enumeration operation may not execute.`

On `css/css-anchor-position/popover-implicit-anchor.html` it surfaces as a `ScriptError` (the registry is rebuilt lazily from the JS `offsetTop`/`offsetLeft` path, where the DOM is live).

## Root cause

`BuildAnchorRegistry` computes each anchor's box via `ComputeElementBox`, whose read-only traversals — `ComputePrecedingSiblingHeights` (walking `element.Parent.Children`) and `EstimateInlineContentWidth` (walking `element.Children`) — enumerate the **live** `ChildNodes` list. When that list is mutated mid-walk, the enumerator throws and aborts anchor resolution for the whole document. Both small methods inline into the `BuildAnchorRegistry` frame, which is why the crash surfaces under that signature.

## Fix

Iterate over a `.ToList()` snapshot in both traversals — the same defensive idiom already used by `ResolveAnchorCenter` and `InlineContainingBlocks` (PR for #1124). The reads are behaviour-preserving: the set of preceding siblings / children is fixed for the duration of one box computation, so a snapshot yields identical results and identical pixel output.

## Verification

- Bridge project builds clean.
- WPT `css/css-anchor-position` subset runs with no crash, no `ScriptError`, no timeouts — fail list unchanged otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)