### PR TITLE
Complete css-align/abspos: abspos alignment across writing modes + vertical-flow items (WPT #1131)

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -2057,6 +2057,32 @@ internal class CssBox : CssBoxProperties, IDisposable
                         marginBoxWidth, isRtl: true, startIsLow: false);
                     newX = (float)(rectStart + dx + ActualMarginLeft);
                 }
+                else if (cbVertical && !hasT && !hasB
+                         && cb.Direction == "rtl")
+                {
+                    // vertical-rl/lr container: the inline axis is VERTICAL.
+                    // justify-self:auto + auto block insets (top/bottom) → the box
+                    // rests at its static position: the inline-START edge of the
+                    // static-position rectangle. That start follows the inline
+                    // direction — for ltr the top (Broiler's default), for rtl the
+                    // inline axis is reversed so the start is the BOTTOM. Use the
+                    // CB padding box (cbPadTop/cbPadHeight) for the vertical
+                    // extent: block-axis sizes resolve bottom-up, so ParentBox's
+                    // ActualBottom is not final here, whereas cbPad* carries the
+                    // definite-height patch. Without this, abspos items in
+                    // vertical-rl+rtl containers render flush-top
+                    // (WPT css-align/abspos/*-vrl-rtl-*, issue #1131).
+                    double marginBoxHeight = Size.Height + ActualMarginTop + ActualMarginBottom;
+                    double dy = ResolveAbsposSelfAlignment(
+                        "unsafe start", cbPadTop, cbPadHeight, cbPadTop, cbPadHeight,
+                        marginBoxHeight, isRtl: true, startIsLow: false);
+                    newY = (float)(cbPadTop + dy + ActualMarginTop);
+                    // Preserve the box's own (shrink-to-fit) block size: the apply
+                    // step shifts ActualBottom by the same delta as Location, so
+                    // record the height to restore it (mirrors the align-self
+                    // block-axis un-stretch).
+                    alignBlockBorderBoxHeight = Size.Height;
+                }
 
                 // align-self controls the block axis:
                 //   horizontal-tb → vertical (T/B insets)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -2009,6 +2009,15 @@ internal class CssBox : CssBoxProperties, IDisposable
                         double imcbHeight = cbPadHeight - cssTop - cssBottom;
 
                         double boxHeight = GetShrinkToFitHeight();
+                        // Non-stretch justify-self on the vertical inline axis →
+                        // the box uses its content (shrink-to-fit) height, not the
+                        // top-to-bottom inset-stretched height. Record it so the
+                        // shared apply step restores the height after the offset
+                        // (mirrors the width un-stretch in the !cbVertical inline
+                        // branch and the height un-stretch in the align-self
+                        // block-axis branch). Without this the box stays stretched
+                        // to the IMCB height and renders as a tall bar.
+                        alignBlockBorderBoxHeight = boxHeight;
 
                         // Inline axis is vertical here; its start runs top→bottom
                         // unless the CB's direction is rtl.
@@ -2147,6 +2156,29 @@ internal class CssBox : CssBoxProperties, IDisposable
                             marginBoxHeight, false, startIsLow: true);
                         newY = (float)(marginBoxStart + dy + ActualMarginTop);
                     }
+                }
+                else if (cbVertical && !hasL && !hasR && ParentBox != null
+                         && cb.WritingMode == "vertical-rl")
+                {
+                    // align-self:auto (default) + auto block insets (left/right):
+                    // for a vertical-rl container the BLOCK axis is horizontal and
+                    // flows right-to-left, so the block-START edge is the RIGHT.
+                    // The box rests at that block static position, but Broiler's
+                    // base layout placed it flush-left, so flush it right within
+                    // the parent content box. (vertical-lr keeps the left edge —
+                    // its block start — which is Broiler's default, so no branch
+                    // is needed there.) The inline (vertical) axis is handled by
+                    // the justify-self branch above. Mirrors the rtl inline-axis
+                    // static-position fix (WPT css-align/abspos/justify-self-*-vrl-*,
+                    // issue #1131). Widths resolve top-down, so ParentBox's
+                    // horizontal extent is reliable here (unlike its vertical one).
+                    double rectStart = ParentBox.ClientLeft;
+                    double rectWidth = ParentBox.ClientRight - ParentBox.ClientLeft;
+                    double marginBoxWidth = Size.Width + ActualMarginLeft + ActualMarginRight;
+                    double dx = ResolveAbsposSelfAlignment(
+                        "unsafe start", rectStart, rectWidth, rectStart, rectWidth,
+                        marginBoxWidth, isRtl: true, startIsLow: false);
+                    newX = (float)(rectStart + dx + ActualMarginLeft);
                 }
 
                 if (newX != Location.X || newY != Location.Y)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -2037,6 +2037,26 @@ internal class CssBox : CssBoxProperties, IDisposable
                         newX = (float)(rectStart + dx + ActualMarginLeft);
                     }
                 }
+                else if (!cbVertical && !hasL && !hasR && ParentBox != null
+                         && cb.Direction == "rtl")
+                {
+                    // justify-self:auto (default) + auto inline insets → the box
+                    // rests at its static position: the inline-START edge of the
+                    // static-position rectangle (the in-flow parent's content
+                    // box). That start edge follows the containing block's
+                    // direction — for ltr it is the left edge (already set by
+                    // base layout), for rtl it is the RIGHT edge. Without this,
+                    // abspos items in rtl containers render flush-left, shifted
+                    // left by the free inline width
+                    // (WPT css-align/abspos/*-rtl-*, issue #1131).
+                    double rectStart = ParentBox.ClientLeft;
+                    double rectWidth = ParentBox.ClientRight - ParentBox.ClientLeft;
+                    double marginBoxWidth = Size.Width + ActualMarginLeft + ActualMarginRight;
+                    double dx = ResolveAbsposSelfAlignment(
+                        "unsafe start", rectStart, rectWidth, rectStart, rectWidth,
+                        marginBoxWidth, isRtl: true, startIsLow: false);
+                    newX = (float)(rectStart + dx + ActualMarginLeft);
+                }
 
                 // align-self controls the block axis:
                 //   horizontal-tb → vertical (T/B insets)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -231,6 +231,34 @@ internal class CssBox : CssBoxProperties, IDisposable
         }
     }
 
+    /// <summary>
+    /// PROTOTYPE (BROILER_VERTICAL_FLOW): see
+    /// <see cref="CssBoxProperties.WillBeVerticalTransposed"/>.  Walk up the box
+    /// tree: the first vertical-writing-mode ancestor (or this box) whose own
+    /// parent is NOT vertical is a rotation root and transposes this box.  An
+    /// out-of-flow ancestor establishes its own rotation context, so if one is
+    /// reached before any vertical root, the rotation of a further vertical
+    /// ancestor does not reach this box — matching the runtime, where an abspos
+    /// item in a vertical container is left untransposed (its container's
+    /// rotation skips it and it is not a root itself).
+    /// </summary>
+    protected override bool WillBeVerticalTransposed()
+    {
+        if (!VerticalFlowPrototype.Enabled)
+            return false;
+        for (CssBox ctx = this; ctx != null; ctx = ctx.ParentBox)
+        {
+            bool ctxVertical = IsVerticalWritingMode(ctx.WritingMode);
+            bool parentVertical = ctx.ParentBox != null
+                && IsVerticalWritingMode(ctx.ParentBox.WritingMode);
+            if (ctxVertical && !parentVertical)
+                return true;
+            if (ctx.Position == CssConstants.Absolute || ctx.Position == CssConstants.Fixed)
+                return false;
+        }
+        return false;
+    }
+
     public List<CssBox> Boxes { get; } = [];
 
     public override bool AvoidGeometryAntialias => LayoutEnvironment?.AvoidGeometryAntialias ?? false;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -630,8 +630,15 @@ internal class CssBox : CssBoxProperties, IDisposable
         // whole rotated subtree right so the root's block-start edge sits at the
         // containing block's content-right minus the block-start (right) margin.
         // (vertical-lr keeps blockOffset 0: left-aligned is already correct.)
+        // In-flow vertical-rl roots are block-start (right) aligned within their
+        // containing block, so the left-aligned logical frame is shifted right.
+        // An out-of-flow (absolute/fixed) root is already placed at its resolved
+        // physical position by the abspos self-alignment (which aligns using the
+        // post-rotation physical extents), so this shift would override it — keep
+        // blockOffset 0 and rotate the content in place.
         double blockOffset = 0;
-        if (mirror && ContainingBlock is { } cb)
+        if (mirror && Position != CssConstants.Absolute && Position != CssConstants.Fixed
+            && ContainingBlock is { } cb)
         {
             double cbContentRight = cb.Location.X + cb.Size.Width
                 - cb.ActualPaddingRight - cb.ActualBorderRightWidth;
@@ -2021,12 +2028,21 @@ internal class CssBox : CssBoxProperties, IDisposable
                         double boxWidth = GetShrinkToFitWidth();
                         Size = new SizeF((float)boxWidth, Size.Height);
 
+                        // For a box the vertical-flow rotation will transpose, the
+                        // alignment runs on the CB's inline (horizontal) axis but
+                        // the item's PHYSICAL width is its logical HEIGHT (the
+                        // rotation swaps them). Align with the physical extent so
+                        // an overflowing vrl item (laid out with a small logical
+                        // width) is centered/clamped by its true width.
+                        double alignWidth = WillBeVerticalTransposed()
+                            ? GetShrinkToFitHeight() : boxWidth;
+
                         bool isRtl = Direction == "rtl";
                         // Inline-axis start edge follows the CB's direction.
                         bool startIsLow = cb.Direction != "rtl";
                         double dx = ResolveAbsposSelfAlignment(
                             jsPost, imcbLeft, imcbWidth, cbPadLeft, cbPadWidth,
-                            boxWidth, isRtl, startIsLow);
+                            alignWidth, isRtl, startIsLow);
                         newX = (float)(imcbLeft + dx + ActualMarginLeft);
                     }
                     else if (cbVertical && hasT && hasB)
@@ -2088,7 +2104,10 @@ internal class CssBox : CssBoxProperties, IDisposable
                     // (WPT css-align/abspos/*-rtl-*, issue #1131).
                     double rectStart = ParentBox.ClientLeft;
                     double rectWidth = ParentBox.ClientRight - ParentBox.ClientLeft;
-                    double marginBoxWidth = Size.Width + ActualMarginLeft + ActualMarginRight;
+                    // Use the physical width for a box the rotation will transpose
+                    // (its physical width is the logical height).
+                    double boxW = WillBeVerticalTransposed() ? GetShrinkToFitHeight() : Size.Width;
+                    double marginBoxWidth = boxW + ActualMarginLeft + ActualMarginRight;
                     double dx = ResolveAbsposSelfAlignment(
                         "unsafe start", rectStart, rectWidth, rectStart, rectWidth,
                         marginBoxWidth, isRtl: true, startIsLow: false);
@@ -2138,10 +2157,17 @@ internal class CssBox : CssBoxProperties, IDisposable
                         // not the stretched top-to-bottom inset height.
                         alignBlockBorderBoxHeight = boxHeight;
 
+                        // For a box the vertical-flow rotation will transpose, the
+                        // alignment runs on the CB's block (vertical) axis but the
+                        // item's PHYSICAL height is its logical WIDTH (the rotation
+                        // swaps them); align with the physical extent.
+                        double alignHeight = WillBeVerticalTransposed()
+                            ? GetShrinkToFitWidth() : boxHeight;
+
                         // Block-axis start is the top edge for horizontal-tb.
                         double dy = ResolveAbsposSelfAlignment(
                             asPost, imcbTop, imcbHeight, cbPadTop, cbPadHeight,
-                            boxHeight, false, startIsLow: true);
+                            alignHeight, false, startIsLow: true);
                         newY = (float)(imcbTop + dy + ActualMarginTop);
                     }
                     else if (cbVertical && hasL && hasR)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -1130,14 +1130,37 @@ internal abstract class CssBoxProperties
 
     private string ResolvePhysicalSize(string explicitPhysicalValue, bool isWidth)
     {
+        // PROTOTYPE (BROILER_VERTICAL_FLOW): a vertical-writing-mode box that
+        // WILL be transposed by the post-layout rotation is laid out in a logical
+        // (horizontal) frame whose frame-width is the box's INLINE size and
+        // frame-height its BLOCK size; the rotation then swaps them into physical
+        // space.  For a vertical writing mode physical 'width' is the block-size
+        // and physical 'height' the inline-size, so the frame dimensions come
+        // from the *swapped* physical properties (frame-width ← CSS height,
+        // frame-height ← CSS width).  Without this an explicitly-sized box lays
+        // out un-swapped and the rotation transposes it (a 20×80 inner → 80×20).
+        // Gated on WillBeVerticalTransposed so a vertical box that is NOT actually
+        // rotated (e.g. an abspos item nested in a vertical container, which the
+        // runtime excludes from its container's rotation) is left untouched.
+        // The cheap IsVerticalWritingMode check short-circuits the common
+        // horizontal-tb case before the parent-chain walk.
+        if (IsVerticalWritingMode(WritingMode)
+            && VerticalFlowPrototype.Enabled
+            && WillBeVerticalTransposed())
+        {
+            string logical = isWidth ? InlineSize : BlockSize;
+            if (HasExplicitSize(logical))
+                return logical;
+            string swappedPhysical = isWidth ? _height : _width;
+            return HasExplicitSize(swappedPhysical) ? swappedPhysical : explicitPhysicalValue;
+        }
+
         if (HasExplicitSize(explicitPhysicalValue))
             return explicitPhysicalValue;
 
-        // PROTOTYPE (BROILER_VERTICAL_FLOW): when the experimental vertical
-        // flow path is enabled, vertical-writing-mode boxes are laid out in a
-        // logical (horizontal) coordinate frame — inline-size maps to width,
-        // block-size to height — and a post-layout transform rotates the
-        // result into physical space.  So the dimension swap is suppressed.
+        // Legacy path (prototype disabled): vertical-writing-mode boxes swap
+        // inline/block onto physical width/height directly (no post-layout
+        // rotation).
         bool vertical = IsVerticalWritingMode(WritingMode) && !VerticalFlowPrototype.Enabled;
         var logicalValue = isWidth
             ? (vertical ? BlockSize : InlineSize)
@@ -1145,6 +1168,17 @@ internal abstract class CssBoxProperties
 
         return HasExplicitSize(logicalValue) ? logicalValue : explicitPhysicalValue;
     }
+
+    /// <summary>
+    /// PROTOTYPE (BROILER_VERTICAL_FLOW): whether this box will be transposed by
+    /// the post-layout vertical-flow rotation — i.e. it lies inside a vertical
+    /// rotation root (a vertical-writing-mode box whose parent is not vertical),
+    /// reached without first crossing an out-of-flow box that establishes its own
+    /// (non-transposed) rotation context.  Overridden in <see cref="CssBox"/>,
+    /// which has the parent chain; the property base has no parent so it cannot
+    /// be transposed.
+    /// </summary>
+    protected virtual bool WillBeVerticalTransposed() => false;
 
     private static bool HasExplicitSize(string? value) =>
         !string.IsNullOrWhiteSpace(value) &&


### PR DESCRIPTION
Takes the local `css/css-align/abspos` subset from **4/14 → 14/14 passing**, with zero regressions. Part of WPT issue #1131.

All changes are in `Broiler.Layout` (main repo, not a submodule). The cluster tests abspos box-alignment of items across the writing-mode/direction matrix (`{align,justify}-self-default-overflow-{htb,vrl}-{ltr,rtl}-{htb,vrl}`).

## Commits (a coherent arc)

1. **Honor `direction:rtl` for abspos auto-inset static position.** An abspos with both inline insets `auto` rests at its static position, whose inline-start follows the CB's direction — left for ltr, **right** for rtl. Broiler kept the flush-left position. Flips `*-htb-rtl-htb`.

2. **Honor the rtl inline axis in vertical writing modes.** In `vertical-rl; direction:rtl` the inline axis is vertical and rtl reverses it → inline-start = **bottom**. Uses `cbPad*` (carries the definite-height patch) not `ParentBox.ClientBottom` (block sizes resolve bottom-up, so it isn't final here), and preserves the box height so the apply step doesn't stretch it. Flips `*-vrl-rtl-{htb,vrl}`.

3. **Block-axis static position + inline un-stretch for vertical-rl.** For `vertical-rl` the block axis flows right-to-left, so the block-start is the **right** edge. Also un-stretches the vertical inline axis in the `justify-self` branch (it computed the shrink-to-fit height but never applied it → tall bars). Flips `justify-self-vrl-*`.

4. **Vertical-flow box orientation for explicitly-sized content.** The `BROILER_VERTICAL_FLOW` rotation transposes each box's `Size`, so a `20×80` inner rendered `80×20`. `ResolvePhysicalSize` now maps a will-be-transposed box's frame-width ← CSS `height`, frame-height ← CSS `width`. New `WillBeVerticalTransposed()` gates it precisely (the runtime excludes an abspos item nested in a vertical container from its container's rotation, so those must not swap — prevents a regression).

5. **Rotation-frame-aware abspos self-alignment.** A will-be-transposed item is now aligned with its **physical** extent (`GetShrinkToFitHeight()` for the horizontal axis, `GetShrinkToFitWidth()` for the vertical) rather than its logical size, and `ApplyVerticalWritingModeFlow` skips the block-start `blockOffset` for out-of-flow roots (abspos is already placed correctly). Flips the remaining `*-htb-*-vrl`.

## Verification

- **css-align/abspos: 14/14** (was 4)
- **css-align: 15 passing** (was 12)
- **css-anchor-position: fail list unchanged** vs `main` (verified by diff — the heaviest abspos consumer)
- 13 layout unit tests green; all changes guarded so horizontal-tb / non-rotated rendering is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)