### PR TITLE
Clarify skipped vs passed in WPT report summaries

### DIFF
--- a/src/Broiler.Wpt/Program.cs
+++ b/src/Broiler.Wpt/Program.cs
@@ -345,8 +345,33 @@ public class Program
             }
         }
 
+        int comparedCount = passed + failed;
+        int missingReferenceSkipCount =
+            skippedResults.Count(r => r.SkipReason == SkipReason.MissingReferenceImage);
+        double comparedPassRate = comparedCount > 0 ? 100.0 * passed / comparedCount : 0;
+
         Console.WriteLine();
-        Console.WriteLine($"Results: {passed} passed, {failed} failed, {skipped} skipped");
+        Console.WriteLine("=== Results ===");
+        // The three buckets are mutually exclusive and sum to the discovered
+        // total; a skipped test is NOT a pass. Spell that out so a run dominated
+        // by skips (e.g. missing references) is not misread as "almost passing".
+        Console.WriteLine(
+            $"Total discovered : {allResults.Count}  " +
+            $"(= {passed} passed + {failed} failed + {skipped} skipped)");
+        Console.WriteLine(
+            $"Compared         : {comparedCount}  ({comparedPassRate:F1}% of compared passed) " +
+            "— only these were pixel-compared against a reference");
+        Console.WriteLine(
+            $"Skipped          : {skipped}  — not compared and not counted as passed " +
+            "(no reference image / manual / unsupported media)");
+        if (missingReferenceSkipCount > 0)
+            Console.WriteLine(
+                $"                   of which {missingReferenceSkipCount} had no reference image " +
+                "(SkipReason.MissingReferenceImage)");
+        if (skipped > 0 && skipped >= comparedCount)
+            Console.WriteLine(
+                "WARNING: more tests were skipped than compared — reference coverage is low, so " +
+                "most tests are unscored. Generate/fetch references before reading the pass rate.");
 
         if (failures.Count > 0)
         {
@@ -828,12 +853,26 @@ public class Program
         writer.WriteLine($"- Render backend: {BGraphicsBackend.CurrentLabel}");
         writer.WriteLine($"- Subset: {(string.IsNullOrWhiteSpace(subset) ? "(all)" : subset)}");
         writer.WriteLine();
+        int compared = passed + failed;
+        int missingReferenceSkipCount = missingReferenceSkips.Count;
+        double comparedPassRate = compared > 0 ? 100.0 * passed / compared : 0;
+
         writer.WriteLine("## Totals");
         writer.WriteLine();
-        writer.WriteLine($"- Total: {allResults.Count}");
+        writer.WriteLine(
+            $"- Total discovered: {allResults.Count} " +
+            $"(= {passed} passed + {failed} failed + {skipped} skipped — mutually exclusive)");
+        writer.WriteLine(
+            $"- Compared (pixel-tested): {compared} — {comparedPassRate:F1}% of compared passed");
         writer.WriteLine($"- Passed: {passed}");
         writer.WriteLine($"- Failed: {failed}");
-        writer.WriteLine($"- Skipped: {skipped}");
+        writer.WriteLine(
+            $"- Skipped: {skipped} (not compared, **not** counted as passed; " +
+            $"{missingReferenceSkipCount} missing reference image)");
+        if (skipped > 0 && skipped >= compared)
+            writer.WriteLine(
+                "- ⚠️ **Reference coverage low** — more tests were skipped than compared, so most " +
+                "tests are unscored. Generate/fetch references before reading the pass rate.");
         WriteBucketSection(writer, "Top failing buckets", topFailingDirectories);
         WriteBucketSection(writer, "Top skipped buckets", topSkippedDirectories);
         WriteReferenceCoverageSection(writer, referenceCoverageStatus);


### PR DESCRIPTION
## What

Make the WPT runner's console and markdown summaries state, explicitly, that **passed / failed / skipped are mutually exclusive** and sum to the discovered total — and surface the *compared* pass-rate so a run dominated by skips can't be misread as "almost passing".

## Why

A CI `css` run reported `14402 passed, 12647 failed` (total 27350) while an incremental run with the same arguments reported `3 passed, 92 failed, 12714 skipped` (total 12809). This raised the question of whether "skipped" was an accidental mix with "passed".

It isn't. Each test lands in exactly one bucket (`Program.cs` running-tally: `if (Passed) … else if (Skipped) … else failed`), so `total = passed + failed + skipped`:
- CI: 14402 + 12647 + **301** = 27350 — the CI summary just didn't surface its 301 skips.
- Incremental: 3 + 92 + 12714 = 12809 exactly — no overlap with "passed".

A test is **skipped** when there is nothing to pixel-compare against — overwhelmingly a **missing reference image** (`SkipReason.MissingReferenceImage`), plus `-manual` and unsupported-media tests. The incremental environment had references for only 95 tests, so 12714 were skipped; CI's `tests/wpt/references` tree is fully populated, so only 301 skipped. The real signal in the incremental run is "reference coverage is near-zero, the run is unscored," not "3 passed."

## Changes

`src/Broiler.Wpt/Program.cs` — human-facing summaries only (the JSON report already carried `skipped` / `skipReasons` / totals):

- **Console** `=== Results ===` block now prints `Total = passed + failed + skipped`, a `Compared` line (passed + failed) with the pass-rate of compared tests, an explicit "skipped = not compared, not counted as passed" line, the missing-reference skip count, and a `WARNING` when `skipped >= compared`.
- **Markdown `## Totals`** mirrors the same: the mutually-exclusive breakdown, a `Compared (pixel-tested)` pass-rate line, "**not** counted as passed" on the skipped line, and a `⚠️ Reference coverage low` callout when skips outnumber comparisons.

## Notes for reviewer

- No behavior change to pass/fail/skip classification or exit code — reporting/wording only.
- `dotnet build src/Broiler.Wpt -c Release` is green.