### PR TITLE
Fix Collection-modified crash in ResolvePositionAreaValues (#1147)

### DIFF
--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
@@ -392,7 +392,16 @@ public sealed partial class DomBridge
             }
         }
 
-        foreach (var child in element.Children)
+        // Snapshot before the recursive descent: element.Children enumerates the
+        // live ChildNodes list, and resolving a child can re-enter anchor
+        // resolution through a lazy offset/box query (ComputeElementBox →
+        // ResolvePositionAreaForElement) or surface a DOM move on a node sharing
+        // this parent, mutating the list mid-walk and throwing "Collection was
+        // modified" — which aborts position-area resolution for the whole
+        // document (WPT issue #1147, signature
+        // DomBridge.ResolvePositionAreaValues). Same defensive .ToList() idiom as
+        // BuildAnchorRegistry / ResolveAnchorCenter / InlineContainingBlocks.
+        foreach (var child in element.Children.ToList())
             ResolvePositionAreaValues(child, anchorRegistry, scrollContainersNeedingRelative,
                 deferredDomMoves);
     }


### PR DESCRIPTION
## Summary

Fixes the one exception signature gating tests in WPT issue #1147:

> `DomBridge.ResolvePositionAreaValues — Collection was modified; enumeration operation may not execute.`

`ResolvePositionAreaValues` recurses over `element.Children`, which enumerates the **live** ChildNodes list. Resolving a child can re-enter anchor resolution through a lazy offset/box query (`ComputeElementBox → ResolvePositionAreaForElement`) or surface a DOM move on a node sharing this parent, mutating the list mid-walk. The enumerator then throws `Collection was modified`, aborting position-area resolution for the entire document.

## Fix

Iterate over a snapshot (`.ToList()`) — the same defensive idiom already used in `BuildAnchorRegistry`, `ResolveAnchorCenter`, and `InlineContainingBlocks` (commits 0b0be518, 69a882c4). The descent's child set is fixed for the duration of a single traversal, so the snapshot yields identical results and identical pixel output.

## Verification

- `dotnet build src/Broiler.HtmlBridge.Dom -c Release` — green.
- `css/css-anchor-position` WPT subset re-run: 26/34 regular pass, **no crashes, no timeouts, no regression**.

## Scope note

This addresses the managed `Collection was modified` exception signature (1 failure). The separate `shard 7 (exit 134)` SIGABRT is a distinct native/process crash not reproduced here and is not addressed by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)