### PR TITLE
Strip table-cell edge whitespace from shrink-to-fit width (#1147)

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -3668,6 +3668,25 @@ internal class CssBox : CssBoxProperties, IDisposable
 
         maxWidth = paddingSum + maxSum;
         minWidth = paddingSum + (min < 90999 ? min : 0);
+
+        // CSS Text 3 §4.1.1 (phase II): a collapsible space sequence at the
+        // start of the first line / end of the last line of a formatting
+        // context is removed and contributes no width.  Broiler models a
+        // collapsed space as word-spacing carried on the neighbouring word
+        // (HasSpaceBefore / HasSpaceAfter); GetMinMaxSumWords counts that
+        // spacing for every word, so the leading space-before of the box's
+        // first content word and the trailing space-after of its last word
+        // inflate the preferred width by one space each.  This is the box's
+        // own formatting-context edge (GetMinMaxWidth is only queried for
+        // shrink-to-fit roots — table cells, floats, inline-blocks,
+        // abspos), and the paint path already drops those edge spaces, so
+        // the width must match.  Subtracting them makes a whitespace-padded
+        // table cell (e.g. <td> Cell </td>) shrink to the same width as the
+        // tight cell, so adjacent cells abut as in a real <table>
+        // (CSS2 tables/table-anonymous-objects-*).
+        maxWidth -= CssBoxHelper.EdgeWhitespaceSpacing(this);
+        if (maxWidth < minWidth)
+            maxWidth = minWidth;
     }
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxHelper.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxHelper.cs
@@ -251,6 +251,76 @@ internal static class CssBoxHelper
     }
 
     /// <summary>
+    /// CSS Text 3 §4.1.1: collapsible white space at the very start of a
+    /// formatting context's first line and the very end of its last line is
+    /// removed.  Broiler carries a collapsed space as word-spacing on the
+    /// neighbouring word (<c>HasSpaceBefore</c>/<c>HasSpaceAfter</c>), so the
+    /// preferred-width sum in <see cref="GetMinMaxSumWords"/> double-counts the
+    /// leading space-before of <paramref name="box"/>'s first content word and
+    /// the trailing space-after of its last word.  Returns the total of those
+    /// two edge spacings (in CSS px) so the caller can subtract them from the
+    /// shrink-to-fit width; a box that begins/ends on a real word (no edge
+    /// space) contributes nothing.
+    /// </summary>
+    internal static double EdgeWhitespaceSpacing(CssBox box)
+    {
+        double sum = 0;
+
+        var first = FirstContentWord(box);
+        if (first != null && first.HasSpaceBefore && !first.IsImage && first.OwnerBox != null)
+            sum += first.OwnerBox.ActualWordSpacing;
+
+        var last = LastContentWord(box);
+        if (last != null && last.HasSpaceAfter && !last.IsImage && last.OwnerBox != null)
+            sum += last.OwnerBox.ActualWordSpacing;
+
+        return sum > 0 ? sum : 0;
+    }
+
+    /// <summary>
+    /// Returns the first word in document order within <paramref name="box"/>'s
+    /// in-flow inline content, or <c>null</c> if it has none.  Out-of-flow
+    /// children (<c>display:none</c>) do not form the inline edge.
+    /// </summary>
+    private static CssRect FirstContentWord(CssBox box)
+    {
+        if (box.Words.Count > 0)
+            return box.Words[0];
+
+        foreach (CssBox child in box.Boxes)
+        {
+            if (child.Display == CssConstants.None)
+                continue;
+            var w = FirstContentWord(child);
+            if (w != null)
+                return w;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the last word in document order within <paramref name="box"/>'s
+    /// in-flow inline content, or <c>null</c> if it has none.
+    /// </summary>
+    private static CssRect LastContentWord(CssBox box)
+    {
+        if (box.Words.Count > 0)
+            return box.Words[box.Words.Count - 1];
+
+        for (int i = box.Boxes.Count - 1; i >= 0; i--)
+        {
+            if (box.Boxes[i].Display == CssConstants.None)
+                continue;
+            var w = LastContentWord(box.Boxes[i]);
+            if (w != null)
+                return w;
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// CSS2.1 §9.5.2: Returns the maximum bottom outer edge of preceding
     /// floats that the given box needs to clear, considering the box's
     /// <c>clear</c> direction (<c>left</c>, <c>right</c>, or <c>both</c>).

--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -37,6 +37,7 @@ Status snapshot and next steps for the Web Platform Tests (WPT) effort tracked i
 | 19 | CDATA-wrapped `<style>` CSS dropped (every XHTML `.xht` reftest unstyled) + author `border` shorthand colour lost on table cells | ✅ fixed | Broiler.HTML |
 | 20 | Collapsed-border conflict resolution (`border-collapse`) unimplemented — losing borders (red) still painted at shared edges | ✅ fixed | Broiler.Layout |
 | 21 | Specified table `height` ignored (CSS2 tables all use `height:2in`) → tables rendered collapsed to content | ✅ fixed | Broiler.Layout |
+| 22 | Leading/trailing white space inside a table cell inflated its shrink-to-fit width → adjacent cells did not abut | ✅ fixed | Broiler.Layout |
 
 Cluster 13 (issue [#1140](https://github.com/MaiRat/Broiler/issues/1140), the dominant new
 `css-backgrounds` directory — 30 failures, with `background-clip-root` at the worst-case **0 %
@@ -261,6 +262,35 @@ untouched. Verified: a `height:200px` two-row table renders ~200px (was ~40px);
 with no red. Zero curated regressions; guard `TableHeightTests`. (Side effect: full-height tables
 make any *unresolved* border full-length — `border-conflict-element-002`'s deferred outer-corner
 red grew 24→182px, underscoring that the outer table-vs-cell edge model is the next table item.)
+
+Cluster 22 (issue [#1147](https://github.com/MaiRat/Broiler/issues/1147)) is the
+`CSS2/tables/table-anonymous-objects-*` family — **107 failures**, the 2nd-largest `CSS2/tables`
+cluster. These reftests overlay a `display:table` construct (whose cell content is wrapped in
+newlines + indentation) on a real `<table>` with tight `<td>Cell</td>` cells, asserting "no red"
+(the construct must cover an identical red layer beneath a green one). Reproducing
+`table-anonymous-objects-{001,003}` against the live renderer showed the red layer fully exposed —
+but **anonymous table-box generation was already correct**: a `display:table` with cells-only (no
+rows) or full structure both laid out *identically to the real table*. The divergence was purely
+**leading/trailing collapsible white space inside each cell inflating its shrink-to-fit width**.
+CSS Text 3 §4.1.1 removes a collapsible space at the start of a formatting context's first line /
+end of its last line; Broiler carries a collapsed space as word-spacing on the neighbouring word
+(`HasSpaceBefore`/`HasSpaceAfter`), and `CssBoxHelper.GetMinMaxSumWords` counts that spacing for
+every word, so the first content word's leading space and the last word's trailing space each
+added a space to the preferred width. The **paint path already drops** those edge spaces, so a
+`<td> Cell </td>` painted flush-left yet measured wider than the tight cell — adjacent cells
+stopped abutting (the real-`<table>` reference uses tight cells, exposing the gap). Fixed in
+`CssBox.GetMinMaxWidth` by subtracting the formatting context's leading+trailing edge word-spacing
+(`CssBoxHelper.EdgeWhitespaceSpacing`, walking the box's first/last in-flow content word), clamped
+to the min width. `GetMinMaxWidth` is queried only for shrink-to-fit roots (table cells, floats,
+inline-blocks, abspos) — exactly the boxes whose own line edges are where the spec strips the white
+space — so it is behaviour-preserving for content that begins/ends on a real word. Verified:
+`table-anonymous-objects-{001,002,003}` red 370 → ≤26px (glyph-edge anti-aliasing the test allows);
+whitespace-padded cells now render the same width as tight cells. Zero curated regressions (the one
+flagged `CommentWhitespaceCollapse` failure is a pre-existing parallel-render flake — passes 3/3 in
+isolation, and uses an empty explicit-width inline-block the fix cannot touch). Main-repo
+`Broiler.Layout`; guard `TableCellWhitespaceTests` (fails without the fix at +11px). **Follow-up:**
+the same edge-whitespace model now applies to inline-blocks/floats with padded content, which were
+similarly over-wide; not separately surveyed here.
 
 Cluster 11 (issue [#1119](https://github.com/MaiRat/Broiler/issues/1119), the dominant
 `PixelMismatch / MissingContent` family, 328 failures) was a render-serialization bug that

--- a/src/Broiler.Wpt.Tests/TableCellWhitespaceTests.cs
+++ b/src/Broiler.Wpt.Tests/TableCellWhitespaceTests.cs
@@ -1,0 +1,104 @@
+using System.IO;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression test for CSS Text 3 §4.1.1 leading/trailing white-space removal
+/// inside table cells (WPT issue #1147,
+/// <c>css/CSS2/tables/table-anonymous-objects-*</c>).
+///
+/// A table cell establishes its own formatting context, so collapsible
+/// white space at the start of its first line and the end of its last line is
+/// removed. Broiler models a collapsed space as word-spacing carried on the
+/// neighbouring word (<c>HasSpaceBefore</c>/<c>HasSpaceAfter</c>); the
+/// shrink-to-fit width sum in <c>CssBoxHelper.GetMinMaxSumWords</c> counted that
+/// edge spacing, so a whitespace-padded cell (<c>&lt;td&gt; Xy &lt;/td&gt;</c>)
+/// computed a wider intrinsic width than the tight <c>&lt;td&gt;Xy&lt;/td&gt;</c>,
+/// even though the paint path already drops the edge spaces. Adjacent cells then
+/// failed to abut, which is exactly what the anonymous-table reftests detect by
+/// overlaying a <c>display:table</c> construct on a real <c>&lt;table&gt;</c>.
+/// The fix subtracts the formatting context's edge white-space from the
+/// preferred width in <c>CssBox.GetMinMaxWidth</c>.
+/// </summary>
+public class TableCellWhitespaceTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public TableCellWhitespaceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "broiler-cellws-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        Program.ResetTestHooks();
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // Rightmost black (text) pixel across the whole bitmap — the content extent.
+    private int ContentRight(string html)
+    {
+        var file = Path.Combine(_tempDir, "t-" + Guid.NewGuid().ToString("N")[..6] + ".html");
+        File.WriteAllText(file, html);
+        var runner = new WptTestRunner(400, 120);
+        using var bmp = runner.RenderHtmlFileBitmapPublic(file, _tempDir);
+        int right = -1;
+        for (int y = 0; y < 120; y++)
+            for (int x = 0; x < 400; x++)
+            {
+                var p = bmp.GetPixel(x, y);
+                if (p.R < 90 && p.G < 90 && p.B < 90)
+                    if (x > right) right = x;
+            }
+        return right;
+    }
+
+    private const string Style =
+        "<!DOCTYPE html><html><head><style>body{margin:0;font:20px sans-serif}"
+        + "table{border-collapse:collapse;border:none}td{border:none;padding:0}"
+        + "</style></head><body>";
+
+    [Fact]
+    public void WhitespacePaddedCells_AbutLikeTightCells()
+    {
+        // Tight cells: <td>Xy</td><td>Xy</td>.
+        int tight = ContentRight(Style
+            + "<table cellspacing=\"0\" cellpadding=\"0\"><tr><td>Xy</td><td>Xy</td></tr></table></body></html>");
+
+        // Same cells, but each cell's content is wrapped in collapsible
+        // white space (newlines + indentation), as in the WPT reftests.
+        int padded = ContentRight(Style
+            + "<table cellspacing=\"0\" cellpadding=\"0\"><tr><td>\n  Xy\n </td><td>\n  Xy\n </td></tr></table></body></html>");
+
+        Assert.True(tight > 0, "tight table did not paint any text.");
+        Assert.True(padded > 0, "padded table did not paint any text.");
+        // Leading/trailing white space inside each cell must not widen it, so
+        // the second cell starts at the same place and the content ends at the
+        // same x in both tables (allow 1px for anti-aliasing).
+        Assert.True(System.Math.Abs(padded - tight) <= 1,
+            $"whitespace-padded cells did not abut like tight cells: tight right={tight}, padded right={padded}.");
+    }
+
+    [Fact]
+    public void DisplayTableCells_MatchRealTable()
+    {
+        // A real <table> with tight cells …
+        int real = ContentRight(Style
+            + "<table cellspacing=\"0\" cellpadding=\"0\"><tr><td>Xy</td><td>Xy</td></tr></table></body></html>");
+
+        // … and the equivalent display:table construct with whitespace-padded
+        // table-cell spans (the anonymous-table reftest shape) must produce the
+        // same content extent.
+        int css = ContentRight(Style
+            + "<span style=\"display:table\">"
+            + "<span style=\"display:table-cell\">\n  Xy\n </span>"
+            + "<span style=\"display:table-cell\">\n  Xy\n </span>"
+            + "</span></body></html>");
+
+        Assert.True(real > 0 && css > 0, "a construct did not paint any text.");
+        Assert.True(System.Math.Abs(css - real) <= 1,
+            $"display:table cells did not match the real table: real right={real}, css right={css}.");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the `css/CSS2/tables/table-anonymous-objects-*` family (**107 failures**, the 2nd-largest `CSS2/tables` cluster in WPT issue #1147) and the underlying table-cell whitespace bug it exposes.

These reftests overlay a `display:table` construct (cells wrapped in newlines/indentation) on a real `<table>` with tight cells. Anonymous table-box generation (rows-only / cells-only) was **already correct** — the divergence was that **leading/trailing collapsible whitespace inside a cell inflated the cell's intrinsic width**, so adjacent cells failed to abut and the overlay no longer covered the red layer.

## Root cause

CSS Text 3 §4.1.1: collapsible whitespace at the start of a formatting context's first line / end of its last line is removed and contributes no width. Broiler carries a collapsed space as word-spacing on the neighbouring word (`HasSpaceBefore`/`HasSpaceAfter`); `CssBoxHelper.GetMinMaxSumWords` counts that spacing for every word, so the first content word's leading space and the last word's trailing space each added one space to the preferred (shrink-to-fit) width. The paint path already drops those edge spaces, so a `<td> Cell </td>` painted flush-left but measured wider than `<td>Cell</td>` — the cells stopped abutting.

## Fix

`CssBox.GetMinMaxWidth` subtracts the formatting context's leading + trailing edge word-spacing (`CssBoxHelper.EdgeWhitespaceSpacing`, which walks the box's first/last in-flow content word) from the preferred width, clamped to the min width. `GetMinMaxWidth` is only queried for shrink-to-fit roots (table cells, floats, inline-blocks, abspos) — exactly the boxes whose own line edges are where the spec strips the whitespace — so it's behaviour-preserving for content that begins/ends on a real word.

## Verification

- `table-anonymous-objects-{001,002,003}`: red overlay layer goes from fully exposed (**370 red px**) to covered (**≤26 px** glyph-edge anti-aliasing, which the test explicitly allows — "except for antialiasing issues").
- Whitespace-padded cells now compute the **same width** as tight cells (measured identical to the px).
- Curated `Broiler.Wpt.Tests` suite (505): **zero regressions** (the one flagged `CommentWhitespaceCollapse` failure is a pre-existing parallel-render flake — passes 3/3 in isolation, and logically unaffected since it uses an empty explicit-width inline-block).
- Regression guards: **`TableCellWhitespaceTests`** (×2) — fail without the fix (+11px cell inflation), pass with it.

## Note

Independent of #1148 (the `ResolvePositionAreaValues` crash fix); branched from `main`. Both target issue #1147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)