### PR TITLE
Cap external resource fetch timeout to fail fast (#1147 Timeout cluster)

### DIFF
--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -31,7 +31,17 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// </summary>
     public const int AsyncDrainIterationLimit = 1000;
 
-    private const int FetchTimeoutSeconds = 30;
+    // External resource fetches (stylesheets, iframe documents, JS fetch) block
+    // the synchronous render/script pipeline.  In the sandboxed WPT/headless
+    // environment external http(s) hosts are unreachable, so the only question is
+    // how long each blocked fetch waits before failing — and the per-test budget
+    // (Broiler.Wpt's default 30 s) equals this client's old 30 s timeout, so a
+    // single unreachable stylesheet consumed the entire budget and timed the test
+    // out (WPT #1147 Timeout cluster, e.g. CSS2/cascade-import-* which @link three
+    // delayed-file CGI URLs).  A short timeout fails fast: even several sequential
+    // external fetches stay well under the test budget, converting a 30 s hang
+    // (which also risks aborting the whole shard) into a quick, deterministic miss.
+    private const int FetchTimeoutSeconds = 5;
     private static readonly HttpClient SharedHttpClient = new() { Timeout = TimeSpan.FromSeconds(FetchTimeoutSeconds) };
     private static readonly string[] InlineEventNames = ["click", "load", "change", "input", "submit", "mousedown",
         "mouseup", "mouseover", "mouseout", "keydown", "keyup", "keypress", "focus", "blur", "error", "scroll",


### PR DESCRIPTION
## Summary

Fixes the WPT issue #1147 **Timeout cluster** (14 failures) root cause: external resource fetches block the synchronous render/script pipeline with a timeout **equal to the per-test budget**, so a single unreachable resource consumes the whole budget and times the test out (and a 30 s hang per test risks aborting the whole shard — #1147 had **1 incomplete shard**).

`CSS2/cascade-import-{003,005}.xht` each `<link>` three `software.hixie.ch/.../delayed-file?pause=2/5/8` CGI URLs — unreachable in the sandbox — and are the cluster's representative tests.

## Fix

- **Bridge** (`DomBridge.SharedHttpClient`, main repo): 30 s → **5 s**. This client backs `FetchExternalStylesheet`, iframe-document fetches, and the JS `fetch()` API — all blocking/synchronous on the test path.
- **Renderer** (`StylesheetLoadHandler.SharedHttpClient`, Broiler.HTML): default 100 s → **5 s** — the render-path external-stylesheet fetcher. → MaiRat/Broiler.HTML#198 (pushed; pointer bumped).

A 5 s cap fails fast: even several sequential external fetches stay well under the 30 s test budget, converting a 30 s hang into a quick deterministic miss.

## Verification

- Curated `Broiler.Wpt.Tests`: **zero regressions** (57 fail vs 58 clean baseline — the 5 s cap breaks no legitimate fetch).
- Mechanism confirmed: the blocked fetch path and the timeout==budget equality.
- **Caveat (honest):** local end-to-end timing is *not* representative — this environment can reach `software.hixie.ch` (200 in ~2.5 s) whereas the CI sandbox cannot, so the local hang reflects the CGI's real `pause` delays, not CI's unreachable-host behaviour. The fix bounds the worst-case synchronous-fetch block regardless of which failure mode CI hits. The network-dependent tests will still *fail* (no network → no green), but as fast `PixelMismatch`/`ScriptError` rather than 30 s `Timeout`s, freeing CI budget and removing the incomplete-shard risk.

## Submodule
Broiler.HTML push succeeded; pointer bumped to `8874893`. Companion PR MaiRat/Broiler.HTML#198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)