### PR TITLE
Harden CollectStyleElementsInTree against concurrent DOM mutation (#1152)

### DIFF
--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -448,14 +448,7 @@ public sealed partial class DomBridge
     /// </summary>
     private static void CollectStyleElementsInTree(DomElement root, List<DomElement> styleElements)
     {
-        // Snapshot the child list before walking it: root.Children enumerates the
-        // live ChildNodes collection, so any mutation during the walk (e.g. a lazy
-        // sub-document root materialising, or a style query re-entering DOM
-        // construction) throws "Collection was modified" and aborts style
-        // collection for the whole tree (signature
-        // DomBridge.CollectStyleElementsInTree). Same defensive idiom as the other
-        // .ToList() DOM walks in DomBridge.
-        foreach (var child in root.Children.ToList())
+        foreach (var child in SnapshotChildren(root))
         {
             if (!child.IsTextNode)
             {
@@ -469,6 +462,66 @@ public sealed partial class DomBridge
                     CollectStyleElementsInTree(child, styleElements);
             }
         }
+    }
+
+    /// <summary>
+    /// Snapshots an element's children in a way that tolerates concurrent DOM
+    /// mutation (parallel WPT rendering, JS-driven tree edits, or a lazy
+    /// sub-document root materialising during the walk).
+    /// </summary>
+    /// <remarks>
+    /// A plain <c>root.Children.ToList()</c> is NOT thread-safe here.
+    /// <see cref="DomElement.LegacyChildList"/> projects the live
+    /// <c>ChildNodes</c> collection: <see cref="Enumerable.ToList{T}"/> reads
+    /// <c>Count</c>, allocates a destination array of that size, then calls
+    /// <c>CopyTo</c>, which materialises the <em>current</em> (possibly larger)
+    /// child array. If another thread appends between those two steps the copy
+    /// overflows and throws <see cref="ArgumentException"/> ("Destination array
+    /// was not long enough" — signature
+    /// <c>DomBridge.CollectStyleElementsInTree</c>); a mutation during plain
+    /// enumeration instead throws <see cref="InvalidOperationException"/>
+    /// ("Collection was modified"). Either previously aborted style collection
+    /// for the whole tree, leaving the document unstyled. Retry a bounded number
+    /// of times, then fall back to a tolerant index walk.
+    /// </remarks>
+    private static List<DomElement> SnapshotChildren(DomElement root)
+    {
+        for (var attempt = 0; attempt < 4; attempt++)
+        {
+            try
+            {
+                return root.Children.ToList();
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
+            {
+                // Concurrent structural mutation raced the snapshot; retry with a
+                // fresh copy. Transient contention almost always clears in a
+                // couple of attempts.
+            }
+        }
+
+        // Sustained contention: copy element-by-element, re-checking bounds each
+        // step so a shrinking list can only truncate the snapshot, never throw.
+        var snapshot = new List<DomElement>();
+        for (var i = 0; ; i++)
+        {
+            DomElement child;
+            try
+            {
+                if (i >= root.Children.Count)
+                    break;
+                child = root.Children[i];
+            }
+            catch (Exception ex) when (ex is ArgumentOutOfRangeException or InvalidOperationException)
+            {
+                break;
+            }
+
+            if (child is not null)
+                snapshot.Add(child);
+        }
+
+        return snapshot;
     }
 
     private JSObject BuildComputedStyleObject(DomElement? element, string? pseudoElement = null)


### PR DESCRIPTION
## Summary

Fixes the lone exception signature in WPT run [#1152](https://github.com/MaiRat/Broiler/issues/1152):

> `DomBridge.CollectStyleElementsInTree — Destination array was not long enough. Check the destination index, length, and the array's lower bo…`

## Root cause

The existing `root.Children.ToList()` guard (added in #1138 to stop *"Collection was modified"*) does **not** cover this crash. `DomElement.LegacyChildList` projects the *live* `ChildNodes` collection. When `Enumerable.ToList()` sees an `ICollection`, it:

1. reads `Count`,
2. allocates a destination array of that size,
3. calls `LegacyChildList.CopyTo`, which materialises the **current** (possibly larger) child array and copies it in.

If another thread appends a child between steps 1 and 3 (parallel WPT rendering / JS-driven tree edits / a lazy sub-document root materialising during the walk), the copy overflows and throws `ArgumentException` — *"Destination array was not long enough"*. This aborts style collection for the whole tree, so the affected document renders unstyled.

`CollectStyleElementsInTree` runs on the hot `getComputedStyle`/layout path via `GetSyncedScopedEngine`, so the race is reachable whenever the tree mutates during style resolution.

## Fix

Replace the plain snapshot with `SnapshotChildren`:
- a **bounded retry** over `ToList()` (transient contention clears in a couple of attempts), then
- a **tolerant index-walk fallback** that re-checks bounds each step, so a shrinking list can only truncate the snapshot, never throw.

Behaviour-preserving on the non-racing path — `ToList()` succeeds on the first attempt and returns the same list as before. This is the same defensive-snapshot family as the prior re-entrancy fixes (#1131, #1147) but hardened for genuine concurrency.

Main repo (`Broiler.HtmlBridge.Dom`), not a submodule.

## Verification

- `dotnet build src/Broiler.HtmlBridge.Dom -c Release` — clean, 0 warnings/errors.
- `css/css-anchor-position` WPT subset: **26/34 regular pass, 0 crashes / 0 timeouts / 0 regressions** (identical to the pre-change baseline).

The pixel-fidelity tail (compositing/mix-blend-mode `PixelMismatch` dominates) and the `display: grid-lanes` dropped declarations are unchanged — those are the known upstream-experimental / fidelity items, not addressed here. The `shard 7 (exit 134)` SIGABRT is a distinct native/process crash tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)