### PR TITLE
Fix display:none boxes stacking inline siblings into a column (#1155)

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/LayoutBoxUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/LayoutBoxUtils.cs
@@ -25,6 +25,14 @@ internal static class LayoutBoxUtils
 
         foreach (CssBox b in box.Boxes)
         {
+            // CSS2.1 §9.2.4: A 'display:none' box generates no box at all, so it
+            // is transparent to the inline-only test — an invisible <style>,
+            // <script>, or display:none <span> between two inline-level siblings
+            // must not force the container onto the block path (which wraps the
+            // siblings in anonymous blocks and stacks them vertically).
+            if (b.Display == CssConstants.None)
+                continue;
+
             // CSS2.1 §9.5: Floats are out-of-flow.  Their computed display
             // is promoted to 'block' (§9.7) but they participate in the
             // inline formatting context of their parent for line-box


### PR DESCRIPTION
## Summary

Fixes a general layout bug surfaced by WPT issue #1155: an invisible `<style>`/`<script>` element — or any `display:none` box — sitting between two inline-level siblings forced them to **stack vertically** instead of flowing on one line.

Per CSS2.1 §9.2.4 a `display:none` box generates **no box at all**, so it must be transparent to the inline/block classification. Two code paths counted it as block-level (`isBlock = !IsInline`, and `'none'` is neither inline nor block):

1. **Parse-time** (`Broiler.HTML` submodule, `DomParser.ContainsVariantBoxes`): reported a mixed inline/block situation, so `CorrectInlineBoxesParent` wrapped each run of inline siblings around the invisible box into separate anonymous blocks.
2. **Layout-time** (`Broiler.Layout/LayoutBoxUtils.ContainsInlinesOnly`): returned `false` on the first `display:none` child, routing the container onto the block path instead of `CreateLineBoxes` (which already skips `display:none`).

Both now skip `display:none` children, mirroring the existing float skip.

## Why it matters

This pattern is pervasive in WPT **testharness** tests, which interleave `<style>`/`<script>` between rendered inline content. Minimal repro (`<div style="display:inline-block"></div><style></style><div style="display:inline-block"></div>`) rendered the two boxes in a column before, in a row after.

## Verification

- **`css-anchor-position/position-try-cascade`** flips to PASS (89.8% → 99.0%): its six inline-block containers, separated by `<script>`/`<style>`, laid out in a row instead of a column.
- **Zero regressions** across all locally-reproducible subsets (CSS2, css-align, css-animations, css-backgrounds, css-anchor-position) and the `Broiler.Wpt.Tests` suite (57 failed / 450 passed — identical to baseline; the pre-existing failures are environmental/deferred).
- Full solution builds clean; `Broiler.Layout.Tests` 13/13 pass.
- An earlier broader variant (also touching `ContainsInlinesOnlyDeep` and the anonymous-block wrap loop) regressed `background-color-body-propagation-003` and an anchor test; those two edits were dropped — the two edits here are the minimal regression-free set.

## Submodule

The parse-time half lives in `Broiler.HTML` (pushed to `MaiRat/Broiler.HTML` branch `claude/wpt-1155-display-none-inline-flow`, commit `05c8475e`); the pointer is bumped in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)