### PR TITLE
Defer stub promise_test bodies to match Chromium load-capture (scroll cluster, #1159)

### DIFF
--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -170,6 +170,13 @@ jobs:
         env:
           SUBSET: ${{ github.event.inputs.subset || '' }}
           RERUN_FAILED: ${{ needs.plan.outputs.rerun-failed }}
+          # Match Chromium's reference generator, which screenshots at `load` before
+          # any promise_test body runs: skip executing stub promise_test bodies in
+          # Broiler's runner so post-load layout mutations (scrollTo, display toggling)
+          # in the css-anchor-position scroll cluster do not advance the captured DOM
+          # past the reference point. Affects only the C# runner, not the (Chromium)
+          # reference generation. Revert by removing this line if it regresses tests.
+          BROILER_WPT_DEFER_PROMISE_TESTS: '1'
         run: |
           # The regular WPT suite executes JavaScript in both Chromium and
           # Broiler. --non-js remains available only for explicit local runs.

--- a/src/Broiler.Wpt/Program.cs
+++ b/src/Broiler.Wpt/Program.cs
@@ -125,6 +125,9 @@ public class Program
                     }
 
                     break;
+                case "--defer-promise-tests":
+                    WptTestRunner.DeferPromiseTests = true;
+                    break;
                 case "--non-js":
                     nonJavaScriptOnly = true;
                     break;
@@ -1621,6 +1624,9 @@ public class Program
         Console.WriteLine("  --shard-count <N>          Split discovered tests into N deterministic shards (default: 1)");
         Console.WriteLine("  --shard-index <I>          Run only shard I (0-based), or -1 for all shards (default: -1)");
         Console.WriteLine("  --non-js                   Exclude JavaScript-dependent documents (Broiler.HTML WPT policy)");
+        Console.WriteLine("  --defer-promise-tests      Do not run stub promise_test bodies before the snapshot, matching");
+        Console.WriteLine("                             Chromium's reference generator (captures at load). Fixes the");
+        Console.WriteLine("                             css-anchor-position scroll cluster. Env: BROILER_WPT_DEFER_PROMISE_TESTS=1");
         Console.WriteLine("  --timeout <SECS>           Per-test timeout in seconds (default: 30, env:");
         Console.WriteLine($"                             {RunTestTimeoutEnvironmentVariable})");
         Console.WriteLine("  --json-output <PATH>       Write structured JSON report to the given path");

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -307,6 +307,20 @@ internal sealed class WptTestResult
 internal sealed class WptTestRunner
 {
     /// <summary>
+    /// When set, the stub <c>promise_test</c> does NOT run its bodies before the
+    /// render snapshot. WPT <c>promise_test</c> callbacks are assertions that
+    /// commonly mutate layout (scrollTo, display toggling) through post-load rAF
+    /// chains; Chromium's reference generator screenshots at <c>load</c>, before
+    /// they run, so executing them here advances the captured DOM past the
+    /// reference point (the css-anchor-position scroll cluster). Default
+    /// <c>false</c> preserves the historical behaviour; overridden by the
+    /// <c>BROILER_WPT_DEFER_PROMISE_TESTS</c> environment variable and the
+    /// <c>--defer-promise-tests</c> CLI flag.
+    /// </summary>
+    internal static bool DeferPromiseTests { get; set; } =
+        Environment.GetEnvironmentVariable("BROILER_WPT_DEFER_PROMISE_TESTS") is "1" or "true" or "TRUE";
+
+    /// <summary>
     /// File extensions treated as test files.
     /// </summary>
     private static readonly HashSet<string> TestExtensions = new(StringComparer.OrdinalIgnoreCase)
@@ -373,6 +387,14 @@ internal sealed class WptTestRunner
   }
   if (typeof promise_test === 'undefined') {
     function __broilerRunPromiseTest(func) {
+      // Chromium-matching mode: the reference generator screenshots at `load`,
+      // before any promise_test body runs. Those bodies are assertions that
+      // frequently mutate layout (scrollTo, display toggling) via rAF chains;
+      // running them here would advance the captured DOM past the reference point.
+      // Leave them un-run so the snapshot reflects the initial post-load layout.
+      if (window.__broilerDeferPromiseTests) {
+        return;
+      }
       try {
         var result = func();
         if (result && typeof result.then === 'function') {
@@ -1783,6 +1805,11 @@ internal sealed class WptTestRunner
         // testharness.js.  Insert at position 0 so they are available
         // before any test script code runs.
         scripts.Insert(0, BrowserApiStubs);
+
+        // Expose the promise_test deferral setting to the stubs (inserted before
+        // them so the promise_test stub can honour it). See TestharnessStubs.
+        scripts.Insert(0, FormattableString.Invariant(
+            $"window.__broilerDeferPromiseTests = {(DeferPromiseTests ? "true" : "false")};"));
 
         if (scripts.Count == 0 && deferredScripts.Count == 0)
         {


### PR DESCRIPTION
## Summary

Addresses the **dynamic-scroll cluster** of #1159 (`anchor-scroll-*`, `position-area-scrolling-*`, `scroll-to-anchored-fixed-*`, `anchor-scroll-update/chained-*` — ~38 CI tests, the largest remaining `css-anchor-position` group).

### Root cause

These are `testharness.js` tests scored against **Chromium reference PNGs** generated by `scripts/generate-wpt-references.js`, which does `page.goto(..., {waitUntil:'load'})` then screenshots **immediately** — capturing the state at `load`, *before* any `promise_test` body runs. But Broiler's WPT runner executes the stub `promise_test` bodies during the load event, running their post-load layout mutations (`scrollTo`, `display` toggling) before the snapshot. So Broiler's render is advanced *past* the reference capture point.

Verified on `position-area-scrolling-001` (measured with PIL): the reference places the anchor at its correct static position (208,208); Broiler placed it at (168,148) = (208,208) − (40,60), exactly the test's `scrollable.scrollTo(40, 60)`. Removing the `promise_test` scripts makes Broiler render (208,208) exactly — the scroll geometry was already correct; the test just ran too far.

### Fix

Opt-in that makes the stub `promise_test` leave its bodies un-run before the render snapshot, matching the reference-generation capture point:
- `--defer-promise-tests` CLI flag / `BROILER_WPT_DEFER_PROMISE_TESTS=1` env (default **off** — unchanged behaviour).
- Enabled for the CI WPT run via the workflow env. This affects **only** the C# runner, not the (Chromium) reference generation, so Broiler's render is compared against the same references.

### Verification (local, `--defer-promise-tests`)

- `position-area-scrolling-001` **85.6% → 98.45%** match (residual is black-border anti-aliasing — the sub-pixel fidelity tail — not scroll geometry); `-002` similar.
- **Zero regressions** across `CSS2`, `css-align`, `css-animations`, `css-backgrounds`, `css-anchor-position` (before/after failing-test diff).
- `Broiler.Wpt.Tests` unchanged (54 fail / 453 pass).

The local scroll tests happen to use thick-bordered boxes and land just under the 99% gate; many CI scroll tests use borderless filled boxes and should clear it. Revert is a one-line change (remove the workflow env var) if the full-CI net turns out negative.

### Note — separate JS-engine bug found

While investigating I isolated an independent Broiler.JS bug: `await asyncFn()` where the async function `return`s a Promise does **not** adopt the returned promise's state (`JSAsyncFunction.ToPromise` resolves via `CreateResolvedOrRejectedPromise`, which fulfils without thenable adoption). Not needed for this fix (deferred bodies never run) and net-neutral on local WPT, so it's filed as a separate follow-up rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)