### PR TITLE
Fix scroll-driven anchor positioning + abspos content double-offset (#1163)

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -1544,6 +1544,7 @@ internal class CssBox : CssBoxProperties, IDisposable
 
                     Location = new PointF((float)left, (float)top);
                     ActualBottom = top;
+                    AbsposLocationFinalized = false;
 
                     // CSS2.1 §10.3.7 / §10.6.4: For absolutely positioned
                     // elements with explicit 'top'/'left', override the static
@@ -1590,6 +1591,12 @@ internal class CssBox : CssBoxProperties, IDisposable
 
                         Location = new PointF(newX, newY);
                         ActualBottom = newY;
+                        // Location now holds the final left/top offset; the content
+                        // flow below starts here, so AdjustAbsolutePosition must not
+                        // add the offset again (WPT css-anchor-position anchor-scroll).
+                        if (Left != null && Left != CssConstants.Auto
+                            || Top != null && Top != CssConstants.Auto)
+                            AbsposLocationFinalized = true;
                     }
 
                     // CSS2.1 §10.6.4 / §9.6.1: For fixed-position elements,
@@ -1635,6 +1642,8 @@ internal class CssBox : CssBoxProperties, IDisposable
 
                             Location = new PointF(newX, newY);
                             ActualBottom = newY;
+                            if (hasLeft || hasTop)
+                                AbsposLocationFinalized = true;
                         }
                         // When all offsets are auto, keep the static position
                         // (Location is already set from normal-flow

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -409,6 +409,16 @@ internal abstract class CssBoxProperties
     public string MaxWidth { get; set; } = "none";
     public string MinWidth { get; set; } = "0";
     internal bool IsMinWidthSpecified { get; set; }
+    /// <summary>
+    /// True when this absolutely/fixed-positioned box has already had its
+    /// <see cref="CssBoxProperties.Location"/> advanced to its final CSS
+    /// <c>left</c>/<c>top</c> offset by the positioning pass, so its inline
+    /// content flows at that final origin. <c>AdjustAbsolutePosition</c> must then
+    /// NOT re-add the offset (it would double it). Boxes whose Location stays at
+    /// the static position (e.g. native form controls) keep this false and still
+    /// rely on <c>AdjustAbsolutePosition</c>.
+    /// </summary>
+    internal bool AbsposLocationFinalized { get; set; }
     public string Height
     {
         get => ResolvePhysicalSize(_height, isWidth: false);

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -828,7 +828,20 @@ internal static class CssLayoutEngine
             curx = localCurx;
             maxRight = localMaxRight;
             maxbottom = localmaxbottom;
-            AdjustAbsolutePosition(box, 0, 0);
+
+            // AdjustAbsolutePosition shifts the box's words by its own left/top so
+            // an abspos child laid out at the *parent's* inline cursor (its static
+            // position) lands at its CSS offset. But when the box flows its OWN
+            // content (box == blockbox) AND PerformLayoutImp already advanced its
+            // Location to the final left/top offset (AbsposLocationFinalized), the
+            // words were flowed from startx = box.Location.X = the final origin, so
+            // re-adding left/top would double the inset — painting content at ~2× the
+            // offset while the border/background paint at the correct origin (auto-
+            // sized abspos with inline content, e.g. css-anchor-position anchored
+            // labels, issue #1163). Boxes that keep their static Location (e.g.
+            // native form controls) still rely on the adjustment.
+            if (!(box == blockbox && box.AbsposLocationFinalized))
+                AdjustAbsolutePosition(box, 0, 0);
         }
 
         box.LastHostingLineBox = line;

--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -38,6 +38,7 @@ Status snapshot and next steps for the Web Platform Tests (WPT) effort tracked i
 | 20 | Collapsed-border conflict resolution (`border-collapse`) unimplemented — losing borders (red) still painted at shared edges | ✅ fixed | Broiler.Layout |
 | 21 | Specified table `height` ignored (CSS2 tables all use `height:2in`) → tables rendered collapsed to content | ✅ fixed | Broiler.Layout |
 | 22 | Leading/trailing white space inside a table cell inflated its shrink-to-fit width → adjacent cells did not abut | ✅ fixed | Broiler.Layout |
+| 23 | `css-anchor-position` full-suite run (#1163, 227 fails) — triaged tail; scroll-offset tracking for `anchor()` across scrollers implemented | 🟡 partial | Broiler.HtmlBridge.Dom |
 
 Cluster 13 (issue [#1140](https://github.com/MaiRat/Broiler/issues/1140), the dominant new
 `css-backgrounds` directory — 30 failures, with `background-clip-root` at the worst-case **0 %
@@ -291,6 +292,187 @@ isolation, and uses an empty explicit-width inline-block the fix cannot touch). 
 `Broiler.Layout`; guard `TableCellWhitespaceTests` (fails without the fix at +11px). **Follow-up:**
 the same edge-whitespace model now applies to inline-blocks/floats with padded content, which were
 similarly over-wide; not separately surveyed here.
+
+Cluster 23 (issue [#1163](https://github.com/Broiler-Platform/Broiler/issues/1163)) is the first CI
+run of the **full `css-anchor-position` suite** (497 tests, 270 pass, **227 fail — every failure in
+this one directory**). The report headline (`PixelMismatch / MissingContent` 160, plus
+`ReferenceOverlayExposed` 39, `ColorShift` 18, `LayoutShift` 10) reads like one systematic bug;
+triage shows the opposite — the 227 spread across **125 test families** (largest single family 15),
+a heterogeneous long tail of *advanced anchor-positioning features* and sub-pixel/font fidelity,
+**not a regression and not one fix.** The mature 8-step resolver
+(`src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/`) is correct for the base cases (270 pass);
+the failures are feature depth Broiler has not built yet. Reproduce any test locally with the
+runner's single-file mode — `dotnet run --project src/Broiler.Wpt -c Release -- --render <FILE>
+--render-out <PNG>` — and set `BROILER_WPT_DEFER_PROMISE_TESTS=1` (or `--defer-promise-tests`) to
+match CI. Findings by bucket:
+
+- **Scroll-driven positioning — ~54 tests, the single largest lever.** `anchor-scroll-position-try`
+  (15), `anchor-scroll-update` (7), `scroll-to-anchored-fixed` (7), `position-area-scrolling` (6),
+  `anchor-scroll` (4), `anchor-scroll-chained` (4), `anchor-scroll-to-sticky` (4),
+  `anchor-scroll-fixedpos` (3), `position-visibility-anchors-visible-chained` (4). These need the
+  anchored element to track its anchor's *live scroll offset* and re-evaluate `position-visibility`
+  as the anchor scrolls in/out of the scrollport — a scroll-linked recompute Broiler does
+  statically. **Note the `promise_test` interaction:** these tests set the scroll/redisplay state in
+  post-load `promise_test` bodies; Chromium's reference generator screenshots at `load`, *before*
+  they run, so CI already runs with `BROILER_WPT_DEFER_PROMISE_TESTS=1` (cluster/PR #1159) to match.
+  Confirmed the mechanism: `position-area-scrolling-001` renders **nothing** for the 9 anchored
+  cells when the bodies run (the `scrollTo`+`display:none/block` toggle drops them), but jumps
+  **84 % → 98.5 %** with the bodies deferred — so on CI it is already a *sub-pixel grid-cell gap*
+  (~2 px on the inter-cell borders), **not** MissingContent. The `-003` variant stays failing because
+  it wraps the whole test in `<iframe srcdoc>` (see below), not because of scroll.
+
+  **✅ First increment landed — `anchor()` scroll-offset tracking across scrollers.** Reproducing the
+  canonical `anchor-scroll-001` (anchor inside a scroller, `#outer-anchored` a sibling *of* the
+  scroller anchored into it) exposed **two** independent defects, isolated with `--render` +
+  debug instrumentation:
+  1. **Missing intervening scroll offset (fixed).** `ResolveAnchorFunctions` resolved `anchor()`
+     against the anchor's *unscrolled* layout position and only compensated for the document scroll
+     of **fixed** targets — a nested scroll container between the anchor and the target was ignored,
+     so the target stayed pinned to the anchor's unscrolled position. Added
+     `ComputeInterveningScrollOffset(anchorEl, targetEl)` (`AnchorFunctions.cs`): it accumulates the
+     scroll offset of every scroll container that is an ancestor of the anchor but **not** of the
+     target (stopping at the first scroller that contains the target — that one scrolls both, or is
+     the target's CB), scaled to match `ApplyScrollSimulation` under an active visual viewport, and
+     folds it into the existing `scrollAdj`. The target-*inside*-scroller case is unchanged (it is
+     shifted by `ApplyScrollSimulation` with its subtree). **Additive and narrowly scoped:** the
+     offset is 0 whenever no scroller separates anchor and target, so it can only move boxes that
+     currently render at the wrong (unscrolled) position — no currently-passing config changes.
+     Verified on a controlled block-anchor repro (target tracks anchor from unscrolled (200,300) to
+     scrolled (50,200)); **zero regressions** on the 39-test local `css-anchor-position` subset
+     (28 pass, unchanged) and the curated anchor/position/scroll unit tests (the 13 pre-existing
+     `CssomView`/font-tail failures are identical with the change stashed). Guard:
+     `AnchorScrollTrackingTests.OuterAnchored_TracksAnchorScrolledPositionAcrossScroller`
+     (fails at `left=200` without the fix, passes at `left≈50` with it). Main-repo, active on CI.
+  2. **Inline-anchor box geometry (investigated — needs real layout, deferred).** The whole
+     `anchor-scroll-{001-007}` / `anchor-scroll-update-*` family uses an **inline** `<span>` anchor
+     that follows a 500 px inline-block on the same line, with Ahem metrics. `ComputeElementBox`
+     (`AnchorRegistry.cs`) mis-estimates it: it treats the span as block (width = CB width = 1000
+     instead of the ~120 px text run), gets height 0 (no line-box height), and — critically —
+     computes `Left = 0` because `ComputePrecedingSiblingHeights` accumulates only *vertical* stacking,
+     never the width of preceding **inline** siblings + collapsed whitespace. So the anchor's rect is
+     `L=0 W=1000 H=0` (should be `L=520 W=120 H=20`: 500 px inline-block + one Ahem space + "anchor"
+     = 6×20). Even with (1) correct the anchored boxes land wrong (the inner one off-screen at
+     x≈−450). **Probed three geometry sources for the anchor's rect, none works at registry time:**
+     the coarse `ComputeElementBox` and the richer `GetBoundingClientRectForDomElement` estimator both
+     return `L=0` (neither models inline horizontal flow past an inline-block) with a crude ~10 px/char
+     width (`W=60`, not Ahem's 120); the real-layout `SharedLayoutGeometryProvider`
+     (`UseSharedLayoutGeometry`) returns `0,0,0,0` because its snapshot is keyed by the *render tree's*
+     `DomElement` instances, which differ from the bridge elements the resolver holds. And there is no
+     reusable C# text-measurement in the bridge (only the JS canvas `measureText`), so a registry-level
+     estimate would be font-inaccurate (the 10 px/char fallback) and whitespace-fragile — it would miss
+     the 99 % pixel gate *and* add regression surface to the mature registry (28 local anchor passes).
+     **Correct fix is architectural:** source the anchor rect from real layout. **✅ Now built (see
+     increment 3 below).**
+
+  3. **Render-tree↔bridge element bridging (built — behind the `UseSharedLayoutGeometry` flag).**
+     Investigating the mapping showed the *element* bridging already works: `GetRenderDocument()`
+     returns the **live** `_document`, so `SharedLayoutGeometryProvider.GetGeometry` lays that document
+     out and keys the result by the very `DomElement` instances the resolver holds (probe:
+     `map.Count=19, contains-anchor=True`). The real gap was two-fold, now fixed:
+     - **Inline boxes recorded zero geometry.** `HtmlContainerInt.CollectLayoutGeometry` (Broiler.HTML)
+       recorded `box.Bounds` per element, but an inline box lays out as one rect per line box, so its
+       `Bounds`/`Location` are unset → an inline anchor came back `0,0,0,0`. Fixed to reconstruct the
+       border box from the union of the per-line `Rectangles`. Delivered as
+       `patches/0001-broiler-html-inline-layout-geometry.patch` (the `MaiRat/Broiler.HTML` remote is
+       outside session scope → push 403 → patch, pointer unchanged). After it the anchor reports its
+       real rect `L=520 T=500 W=120 H=23` (500 px inline-block + one Ahem space + 6×20 "anchor").
+       *Ahem note:* the runner only loads `/fonts/ahem.css` when `--wpt-dir` is passed — omit it and
+       inline text falls back to a proportional font, throwing off any Ahem geometry check.
+     - **The resolver did not consult real layout.** `AnchorRegistry.ComputeElementBox` now calls
+       `TryGetAnchorLayoutBox` first: it pulls the anchor's border box from the shared snapshot and
+       converts document coords to the estimator's containing-block-relative frame (subtracting the
+       CB's border-box origin), falling back to the estimator when the geometry is absent. Gated behind
+       `DomBridge.UseSharedLayoutGeometry` (default **off**), so CI is a no-op until the flag + patch
+       land — zero regression (local 28 anchor passes, shared-geometry parity 7/7 unchanged). Guard:
+       `AnchorScrollTrackingTests.OuterAnchored_TracksAnchorScrolledPosition_WithSharedLayoutGeometry`
+       (block anchor, flag on — CI-safe against the un-patched submodule).
+
+     With the flag on + patch applied, `anchor()` now resolves to the **spec-correct** insets for the
+     canonical `anchor-scroll-001` (inner `left=520, bottom=500`; outer `left=70, top=223` — exactly
+     the reference's intent, `520−450 scroll = 70`), and the controlled block-anchor scroll repro
+     renders pixel-correct.
+
+  4. **Downstream render defect — abspos content double-applied its inset (fixed, main-repo).** Even
+     with (1)–(3) correct, `outer-anchored` painted at ~(140,455) though its resolved style was
+     `left:70; top:223` — exactly **2×**. Bisected with explicit-inset repros to a **pre-existing**
+     core-layout bug independent of anchor positioning: `<div style="position:absolute;left:100px;
+     top:150px">HELLO</div>` paints its text at (200,300). The box *origin* (border/background) is
+     correct; only its **inline content** doubles, and only on **auto-sized** axes (explicit width/
+     height are fine — which is why most abspos tests never hit it, but auto-sized anchored labels do).
+     Root cause: `CssLayoutEngine.FlowBox` ends every abspos box with `AdjustAbsolutePosition(box,0,0)`,
+     which adds the box's `left`/`top` to each word — correct for an abspos child positioned at its
+     parent's inline cursor (static position), but a **double** when the box flows its own content and
+     `PerformLayoutImp` already advanced its `Location` to the final `left`/`top` (words flow from
+     `startx = Location.X`). Fixed with an `AbsposLocationFinalized` flag set when `PerformLayoutImp`
+     repositions the box, gating out the redundant `AdjustAbsolutePosition` only then — so native form
+     controls (which keep their static `Location` and rely on the adjustment) are unaffected. The
+     narrow `box != blockbox` first cut regressed one native-button multiline-sizing test; the flag
+     approach fixes that. Main-repo (`Broiler.Layout`), **active on CI**. Verified: the anchor-scroll
+     structure repro now paints `outer` at (70,223); the full curated `Broiler.Wpt.Tests` suite has
+     **zero new failures** (457 pass; the `AdjustAbsolutePosition` change is net-negative-one after the
+     guard). Guard: `AbsposAutoSizeContentTests.AbsposAutoSizedInlineContent_RendersAtInset_NotDoubled`
+     (fails at `left≈200` without the fix).
+
+     With all four increments the `anchor-scroll-*` family's auto-sized anchored labels resolve to the
+     correct insets **and** paint at the correct position. **Validated end-to-end:** with the patch
+     applied and the flag on locally, `anchor-scroll-001` rendered against its reference matches at
+     **99.72 %** (2 240 / 786 432 px differ — text-edge anti-aliasing), clearing the 99 % gate. On CI,
+     (1) and (4) are live now; (2)/(3) activate once the Broiler.HTML patch is applied and
+     `UseSharedLayoutGeometry` is enabled.
+- **Multicol containing blocks — 16 tests.** `anchor-position-multicol` (13) +
+  `anchor-position-multicol-colspan` (3). Blocked on the same real multicol fragmentation engine as
+  the deferred `css-align/align-content-block` cluster — an abspos anchor/target inside a multicol
+  column needs true track/column geometry Broiler approximates. Deferred behind multicol.
+- **Transforms — 11 tests (`transform-{N}`).** Anchor whose ancestor chain carries 2D/3D transforms
+  (`transform-005` uses `rotate3d` + `preserve-3d`); the anchor rect must be resolved in the
+  transformed coordinate space. Needs transform-aware anchor geometry.
+- **Shadow DOM — `position-anchor-002` et al.** Broiler renders the declarative `<#shadow-root>`
+  markers as **literal text** and does no cross-boundary anchor resolution — Shadow DOM is
+  unimplemented on this path. Feature-sized.
+- **`<iframe srcdoc>` nested browsing context — `position-area-scrolling-003`.** The grid lives in an
+  `srcdoc` iframe; Broiler paints only the empty iframe border. Nested-context rendering gap.
+- **Grid-area containing block — `position-try-grid-001`.** Same block noted in the position-try
+  checklist: an abspos grid item's CB is its grid area, worthwhile only once grid tracks actually lay
+  out. Deferred behind flex/grid.
+- **Inline containing block for abspos / inline anchor — `position-area-inline-container`,
+  `position-area-abs-inline-container`, `position-area-percents-001` (3).** These anchor a
+  `position-area` grid to an **inline** (Ahem `XXX`) anchor inside an inline containing block. The
+  render-tree bridging (increment 3 above) helps materially — with the patch + flag the inline anchor
+  now reports its real rect, lifting all three from ~93–94 % to **~96 %** (the anchor text and the
+  cyan cell land correctly). The residual ~4 % is the **position-area grid geometry for an inline
+  anchor / inline CB**: the blue cells are still placed on the wrong grid lines (the cell rects are
+  computed against an approximate CB, not the inline anchor's line box). That is the deferred
+  "inline containing blocks for abspos" position-area work (`PositionArea.cs`) — a separate increment
+  from the geometry bridging, now unblocked by it.
+- **`anchor-center` safe / RTL — `anchor-center-safe-rtl`, `anchor-center-overflow` (5).** The
+  anchored elements collapse to the origin (overlapping text) — `anchor-center` with `safe`/overflow
+  clamping and RTL is not resolving. Advanced position-area centering.
+- **Inline anchors + Ahem + `check-layout` — `anchor-position-inline` (4).** `anchor()` against an
+  inline (`<span>`) anchor, asserted by `check-layout-th.js` with Ahem metrics — the inline
+  static-position + font-metric tail (same shape as the deferred cluster-3 inline-parent variant).
+- **`last-successful-*` / `position-try` cascade / `try-tactic` — `position-try-fallbacks` (4),
+  `position-try` (3), `position-anchor` (5).** The stateful "last successful position option" and
+  cascade-origin interactions already tracked as open in the position-try sub-task checklist.
+- **Sub-pixel / font tail (near-pass).** `position-visibility-anchors-valid` (98.6 %),
+  `position-visibility-remove-anchors-visible` (98.4 %), `position-area-percents-001` /
+  `position-area-inline-container` / `position-area-abs-inline-container` /
+  `position-area-anchor-partially-outside` (93–94 %). Broiler's geometry matches Chromium to a few
+  px; the residual is border anti-aliasing, Ahem glyph metrics, and 50 %-of-cell box placement — the
+  same low-yield fidelity tail flagged for other directions. No local pixel win without touching the
+  mature position-area path (regression-risky, and only 39 anchor tests are in the local checkout to
+  net against).
+
+**Recommendation / status.** The scroll-driven lever is being worked: increment (1) above
+(cross-scroller `anchor()` scroll-offset tracking) is **landed and guarded**. Increment (3), the
+**render-tree↔bridge bridging** that gives the resolver real-layout anchor geometry (inline flow +
+font metrics), is **built** — the Broiler.HTML inline-geometry patch plus the flag-gated
+`TryGetAnchorLayoutBox` wiring — and verified to make `anchor()` resolve to the spec-correct insets
+for the `anchor-scroll-*` family. The **next** increment is the *downstream rendering* defect that
+now blocks those tests: an abspos sibling of a scroll-simulated container is painted at ~2× its
+resolved inset (scroll-simulation / abspos-layout path, not anchor geometry). After that, enable
+`UseSharedLayoutGeometry` once the parity gate confirms it. The remaining buckets (multicol,
+transforms, Shadow DOM, iframe srcdoc, grid tracks, sub-pixel tail) stay filed against the existing
+deferred items rather than chased as a cluster.
 
 Cluster 11 (issue [#1119](https://github.com/MaiRat/Broiler/issues/1119), the dominant
 `PixelMismatch / MissingContent` family, 328 failures) was a render-serialization bug that

--- a/patches/0001-broiler-html-inline-layout-geometry.patch
+++ b/patches/0001-broiler-html-inline-layout-geometry.patch
@@ -1,0 +1,121 @@
+From e9c4aceedab60feaae7fc3c4dc0e74cee9a78685 Mon Sep 17 00:00:00 2001
+From: MaiRat <enrico.bartky@gmail.com>
+Date: Wed, 1 Jul 2026 17:15:07 +0200
+Subject: [PATCH] Collect real geometry for inline boxes in
+ CollectLayoutGeometry
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+An inline box (display:inline) lays out as one rectangle per line box rather
+than a single border box, so box.Location/Size — and box.Bounds — are unset.
+GetLayoutGeometry therefore recorded a zero-size box at the origin for inline
+elements, so getBoundingClientRect / the shared-layout-geometry snapshot
+(RF-BRIDGE-1b) returned no usable geometry for them.
+
+Reconstruct the inline border box from the union of the per-line rectangles so
+inline elements — e.g. an inline anchor queried during CSS anchor-position
+resolution — report their real geometry. Block boxes are unchanged.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+---
+ .../HtmlContainerInt.cs                       | 70 +++++++++++++++----
+ 1 file changed, 55 insertions(+), 15 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs b/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
+index 6bc55f3..fceb3d6 100644
+--- a/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
++++ b/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
+@@ -266,15 +266,15 @@ public sealed class HtmlContainerInt : IHtmlContainerInt, IDisposable
+         if (Broiler.CSS.CssValueParser.TryParseColor(value, out var color))
+             return Color.FromArgb(color.Alpha, color.Red, color.Green, color.Blue);
+ 
+-        // An empty/whitespace value reaches here when a color property resolves to
+-        // nothing (e.g. a `var()` reference with no fallback that substitutes to the
+-        // empty string). RAdapter.GetColor rejects empty input with an
+-        // ArgumentException, which aborts rendering for the whole document
+-        // (RenderingError, signature RAdapter.GetColor). Treat it as an unresolved
+-        // color, mirroring the static PaintWalker.ParseCssColor guard.
+-        if (string.IsNullOrWhiteSpace(value))
+-            return Color.Empty;
+-
++        // An empty/whitespace value reaches here when a color property resolves to
++        // nothing (e.g. a `var()` reference with no fallback that substitutes to the
++        // empty string). RAdapter.GetColor rejects empty input with an
++        // ArgumentException, which aborts rendering for the whole document
++        // (RenderingError, signature RAdapter.GetColor). Treat it as an unresolved
++        // color, mirroring the static PaintWalker.ParseCssColor guard.
++        if (string.IsNullOrWhiteSpace(value))
++            return Color.Empty;
++
+         return Adapter.GetColor(value);
+     }
+ 
+@@ -767,18 +767,58 @@ public sealed class HtmlContainerInt : IHtmlContainerInt, IDisposable
+     {
+         if (box.SourceElement is { } element && !result.ContainsKey(element))
+         {
+-            var paddingBox = RectangleF.FromLTRB(
+-                (float)(box.Location.X + box.ActualBorderLeftWidth),
+-                (float)(box.Location.Y + box.ActualBorderTopWidth),
+-                (float)(box.ActualRight - box.ActualBorderRightWidth),
+-                (float)(box.ActualBottom - box.ActualBorderBottomWidth));
+-            result[element] = new BoxGeometry(box.Bounds, paddingBox, box.ClientRectangle);
++            var borderBox = box.Bounds;
++
++            // Inline boxes (display:inline) lay out as one rectangle per line box
++            // rather than a single border box, so box.Location/Size — and hence
++            // box.Bounds — are unset (empty). Reconstruct the border box from the
++            // union of the per-line rectangles so an inline element (e.g. an inline
++            // anchor, or any inline queried via getBoundingClientRect) reports its
++            // real geometry instead of a zero-size box at the origin.
++            if (borderBox is { Width: 0, Height: 0 } && box.Rectangles.Count > 0)
++            {
++                borderBox = UnionLineRectangles(box.Rectangles.Values);
++                // Inline boxes contribute no box-model padding/border to line
++                // geometry in this engine, so all three levels coincide.
++                result[element] = new BoxGeometry(borderBox, borderBox, borderBox);
++            }
++            else
++            {
++                var paddingBox = RectangleF.FromLTRB(
++                    (float)(box.Location.X + box.ActualBorderLeftWidth),
++                    (float)(box.Location.Y + box.ActualBorderTopWidth),
++                    (float)(box.ActualRight - box.ActualBorderRightWidth),
++                    (float)(box.ActualBottom - box.ActualBorderBottomWidth));
++                result[element] = new BoxGeometry(borderBox, paddingBox, box.ClientRectangle);
++            }
+         }
+ 
+         foreach (var child in box.Boxes)
+             CollectLayoutGeometry(child, result);
+     }
+ 
++    /// <summary>
++    /// Returns the smallest rectangle enclosing every per-line rectangle of an
++    /// inline box — its rendered border box across the lines it spans.
++    /// </summary>
++    private static RectangleF UnionLineRectangles(IEnumerable<RectangleF> rectangles)
++    {
++        float left = float.MaxValue, top = float.MaxValue;
++        float right = float.MinValue, bottom = float.MinValue;
++        foreach (var r in rectangles)
++        {
++            if (r.Width == 0 && r.Height == 0)
++                continue;
++            if (r.Left < left) left = r.Left;
++            if (r.Top < top) top = r.Top;
++            if (r.Right > right) right = r.Right;
++            if (r.Bottom > bottom) bottom = r.Bottom;
++        }
++        return right < left || bottom < top
++            ? RectangleF.Empty
++            : RectangleF.FromLTRB(left, top, right, bottom);
++    }
++
+     public void PerformLayout(RGraphics g)
+     {
+         ArgumentNullException.ThrowIfNull(g);
+-- 
+2.53.0.windows.3
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,36 @@
+# Submodule patches
+
+Changes that belong in a `MaiRat/Broiler.*` submodule but could not be pushed
+from this environment (the submodule remotes are outside the session's GitHub
+scope, so `git push` returns 403). Each patch is captured here for a maintainer
+to apply to the submodule and bump the corresponding pointer. The parent repo's
+submodule pointers are intentionally **left unchanged** — never bump a pointer
+whose commit is not on the remote, or CI (which clones the submodule by pointer)
+would break.
+
+To apply a patch:
+
+```sh
+cd <Submodule>
+git checkout -b <branch>
+git am ../patches/<NNNN>-<slug>.patch    # or: git apply
+git push origin HEAD
+# then, from the parent repo, bump the pointer:
+cd .. && git add <Submodule> && git commit -m "Bump <Submodule>: <summary>"
+```
+
+## Index
+
+- **0001-broiler-html-inline-layout-geometry.patch** → `Broiler.HTML`
+  (`Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs`). Makes
+  `CollectLayoutGeometry` reconstruct an **inline** box's border box from the
+  union of its per-line rectangles instead of recording an empty box at the
+  origin. Enables the shared-layout-geometry snapshot (RF-BRIDGE-1b) — and
+  `getBoundingClientRect` for inline elements — to report real inline geometry.
+  Required for the css-anchor-position `anchor-scroll-*` cluster (issue #1163):
+  an inline `<span>` anchor must report its real rect so `anchor()` resolves
+  against the anchor's true position. See `docs/roadmap/wpt-triage-and-diagnostics.md`
+  Cluster 23. The main-repo consumer (`AnchorRegistry.TryGetAnchorLayoutBox`) is
+  gated behind `DomBridge.UseSharedLayoutGeometry` (default off), so it is a
+  no-op on CI until both this patch is applied and the flag is enabled — nothing
+  regresses in the meantime.

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
@@ -95,8 +95,24 @@ public sealed partial class DomBridge
                     // are still shifted by scroll simulation and need adjustment.
                     bool anchorIsFixed = anchor.SourceElement != null &&
                         GetComputedProps(anchor.SourceElement).GetValueOrDefault("position") == "fixed";
-                    double adjY = anchorIsFixed ? 0 : scrollAdjY;
-                    double adjX = anchorIsFixed ? 0 : scrollAdjX;
+
+                    // Scroll-driven positioning (CSS Anchor Positioning § scroll):
+                    // an anchored element must track its anchor's *scrolled* position.
+                    // When a scroll container is an ancestor of the anchor but NOT of
+                    // the target (the target lives outside that scroller, e.g. a fixed
+                    // or sibling-of-scroller abspos box), the anchor's edges shift by
+                    // that scroller's scroll offset while the target does not — so the
+                    // resolved inset must subtract it. Scrollers that contain the target
+                    // too move both together and are skipped. (The target-inside-scroller
+                    // case is handled separately by ApplyScrollSimulation, which shifts
+                    // the target's own subtree.)
+                    double nestedX = 0, nestedY = 0;
+                    if (!anchorIsFixed && anchor.SourceElement != null)
+                        ComputeInterveningScrollOffset(
+                            anchor.SourceElement, element, out nestedX, out nestedY);
+
+                    double adjY = anchorIsFixed ? 0 : scrollAdjY + nestedY;
+                    double adjX = anchorIsFixed ? 0 : scrollAdjX + nestedX;
 
                     double rawValue = edge switch
                     {
@@ -152,6 +168,50 @@ public sealed partial class DomBridge
         // throws "Collection was modified" (WPT content-visibility-anchor-positioning).
         foreach (var child in element.Children.ToList())
             ResolveAnchorFunctions(child, anchorRegistry);
+    }
+    /// <summary>
+    /// Accumulates the scroll offset of scroll containers that lie between the
+    /// anchor and the target — i.e. that are ancestors of <paramref name="anchorEl"/>
+    /// but do not also contain <paramref name="targetEl"/>. Such a scroller moves the
+    /// anchor (and its edges) but not the target, so an anchored element positioned
+    /// against it must subtract this offset to stay pinned to the anchor's scrolled
+    /// position. The walk stops at the first scroller that also contains the target
+    /// (that scroller scrolls both, or is the target's containing block). The offset
+    /// is scaled to match <c>ApplyScrollSimulation</c> under an active visual viewport.
+    /// </summary>
+    private void ComputeInterveningScrollOffset(
+        DomElement anchorEl, DomElement targetEl, out double offX, out double offY)
+    {
+        offX = 0;
+        offY = 0;
+        var scale = GetScrollSimulationScaleFactor();
+        for (var el = anchorEl.Parent; el != null; el = el.Parent)
+        {
+            var props = GetComputedProps(el);
+            if (!HasOverflowClipping(props))
+                continue;
+
+            // The target lives inside this scroller too → they scroll together
+            // (or this scroller is the target's containing block); no separation.
+            if (IsDescendantOrSelf(targetEl, el))
+                break;
+
+            if (GetElementRuntimeState(el).Scroll.Left.TryGet(out var sl) && sl is double slv)
+                offX += slv * scale;
+            if (GetElementRuntimeState(el).Scroll.Top.TryGet(out var st) && st is double stv)
+                offY += stv * scale;
+        }
+    }
+    /// <summary>
+    /// True when <paramref name="node"/> is <paramref name="ancestor"/> or a
+    /// descendant of it.
+    /// </summary>
+    private static bool IsDescendantOrSelf(DomElement node, DomElement ancestor)
+    {
+        for (var cur = node; cur != null; cur = cur.Parent)
+            if (cur == ancestor)
+                return true;
+        return false;
     }
     private static bool IsLayoutProperty(string prop) => prop switch
     {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
@@ -39,6 +39,19 @@ public sealed partial class DomBridge
     {
         var props = GetComputedProps(element);
 
+        // Prefer the renderer's real layout for the anchor rect when the shared
+        // geometry path is active (RF-BRIDGE-1b). The CSS-property estimator below
+        // cannot model inline flow — an inline anchor after an inline-block, or with
+        // real font metrics, is mis-sized/mis-placed (see AnchorScroll* / the
+        // css-anchor-position anchor-scroll cluster). Real layout gets the inline
+        // border box exactly; convert its document coords to the anchor's
+        // containing-block-relative frame (the estimator's convention) so downstream
+        // anchor() resolution is unchanged. Falls through to the estimator whenever
+        // the geometry is unavailable (flag off, detached, no box) — so this is a
+        // no-op unless UseSharedLayoutGeometry is enabled.
+        if (TryGetAnchorLayoutBox(element, out var layoutBox))
+            return layoutBox;
+
         double width = TryParsePx(props.GetValueOrDefault("width")) ?? 0;
         double height = TryParsePx(props.GetValueOrDefault("height")) ?? 0;
 
@@ -166,6 +179,55 @@ public sealed partial class DomBridge
         }
 
         return new AnchorInfo(accTop, accLeft, width, height);
+    }
+    /// <summary>
+    /// Tries to source the anchor's box from the renderer's real layout
+    /// (RF-BRIDGE-1b), returning it in the same containing-block-relative frame the
+    /// CSS-property estimator uses. This is the accurate path for inline anchors
+    /// (inline flow + font metrics), which the estimator cannot model. Returns
+    /// <c>false</c> — so the caller falls back to the estimator — whenever the shared
+    /// geometry path is disabled (<see cref="UseSharedLayoutGeometry"/>, the default)
+    /// or the element produced no usable box, keeping this a no-op until the parity
+    /// gate enables real-layout geometry.
+    /// </summary>
+    private bool TryGetAnchorLayoutBox(DomElement element, out AnchorInfo box)
+    {
+        box = default!;
+        if (!UseSharedLayoutGeometry)
+            return false;
+        if (!TryGetSharedLayoutGeometry(element, out var geometry))
+            return false;
+
+        var border = geometry.BorderBox;
+        if (border.Width <= 0 && border.Height <= 0)
+            return false;
+
+        // The estimator expresses the box relative to the anchor's nearest
+        // containing-block-establishing ancestor's border-box origin (its ancestor
+        // walk stops there and folds in that ancestor's border+padding). Match that
+        // frame by subtracting the CB's document-space border-box origin.
+        double originX = 0, originY = 0;
+        var cb = FindGeometryContainingBlockAncestor(element);
+        if (cb != null && TryGetSharedLayoutGeometry(cb, out var cbGeometry))
+        {
+            originX = cbGeometry.BorderBox.Left;
+            originY = cbGeometry.BorderBox.Top;
+        }
+
+        box = new AnchorInfo(
+            border.Top - originY, border.Left - originX, border.Width, border.Height);
+        return true;
+    }
+    /// <summary>
+    /// Walks up from <paramref name="element"/> to the nearest ancestor that
+    /// establishes a containing block (the frame the estimator measures against).
+    /// </summary>
+    private DomElement? FindGeometryContainingBlockAncestor(DomElement element)
+    {
+        for (var ancestor = element.Parent; ancestor != null; ancestor = ancestor.Parent)
+            if (EstablishesContainingBlock(GetComputedProps(ancestor)))
+                return ancestor;
+        return null;
     }
     /// <summary>
     /// Parses the 'margin' shorthand into individual margin values,

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -118,6 +118,11 @@ public sealed partial class DomBridge
         // 8. Apply scroll simulation: shift content in scroll containers
         //    where JavaScript set scrollTop/scrollLeft to match Chromium output.
         ApplyScrollSimulation(DocumentElement);
+
+        // Drop any shared-layout-geometry snapshot built for anchor-box geometry
+        // (TryGetAnchorLayoutBox) so later live geometry queries lay out fresh —
+        // the resolution above mutated the DOM. No-op when the shared path is off.
+        ClearSharedGeometrySnapshot();
     }
     private void ApplyVisualViewportSerializationState()
     {

--- a/src/Broiler.Wpt.Tests/AbsposAutoSizeContentTests.cs
+++ b/src/Broiler.Wpt.Tests/AbsposAutoSizeContentTests.cs
@@ -1,0 +1,77 @@
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression test for absolutely-positioned inline content placement.
+///
+/// Root cause fixed: <c>CssLayoutEngine.FlowBox</c> ended every abspos box with
+/// <c>AdjustAbsolutePosition(box, 0, 0)</c>, which adds the box's own
+/// <c>left</c>/<c>top</c> to each of its words. That is correct when an abspos
+/// child is laid out at the parent's inline cursor (its static position), but
+/// when the box flows its OWN content (<c>box == blockbox</c>) the words were
+/// already placed at <c>startx = box.Location.X</c> — and <c>Location</c> is the
+/// box's final absolute origin. Re-adding <c>left</c>/<c>top</c> there applied
+/// the inset twice, painting the content at ~2× the offset (while the box's
+/// border/background painted at the correct origin). Only auto-sized abspos boxes
+/// with inline content manifested it — e.g. the css-anchor-position
+/// <c>anchor-scroll-*</c> anchored labels (issue #1163). Fixed by skipping the
+/// re-offset when <c>box == blockbox</c>.
+/// </summary>
+public class AbsposAutoSizeContentTests : IDisposable
+{
+    public void Dispose() => Program.ResetTestHooks();
+
+    private static (int x0, int y0, int x1, int y1, int count) ColorBox(
+        BBitmap bmp, int w, int h, System.Func<byte, byte, byte, bool> match)
+    {
+        int x0 = int.MaxValue, y0 = int.MaxValue, x1 = -1, y1 = -1, count = 0;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                var p = bmp.GetPixel(x, y);
+                if (match(p.R, p.G, p.B))
+                {
+                    count++;
+                    if (x < x0) x0 = x;
+                    if (y < y0) y0 = y;
+                    if (x > x1) x1 = x;
+                    if (y > y1) y1 = y;
+                }
+            }
+        return (x0, y0, x1, y1, count);
+    }
+
+    // An auto-width/height position:absolute box with inline text and non-zero
+    // left/top. Its content must render at (left, top), not (2*left, 2*top).
+    private const string Html =
+        "<!DOCTYPE html><meta charset=\"utf-8\"><style>body{margin:0}</style>" +
+        "<div style=\"position:absolute; left:100px; top:150px; color:red\">HELLO</div>";
+
+    [Fact]
+    public void AbsposAutoSizedInlineContent_RendersAtInset_NotDoubled()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-abspos-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "abspos.html");
+            File.WriteAllText(file, Html);
+
+            var runner = new WptTestRunner(800, 600);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+
+            var box = ColorBox(bmp, 800, 600, (r, g, b) => r > 200 && g < 80 && b < 80);
+
+            Assert.True(box.count > 0, "abspos text not painted.");
+            // Text top-left ~ (100,150). Without the fix it painted at ~(200,300).
+            Assert.True(System.Math.Abs(box.x0 - 100) <= 3, $"text left={box.x0}, expected ~100 (was ~200 before fix).");
+            Assert.True(System.Math.Abs(box.y0 - 150) <= 6, $"text top={box.y0}, expected ~150 (was ~300 before fix).");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+}

--- a/src/Broiler.Wpt.Tests/AnchorScrollTrackingTests.cs
+++ b/src/Broiler.Wpt.Tests/AnchorScrollTrackingTests.cs
@@ -1,0 +1,131 @@
+using System.IO;
+using Broiler.HTML.Image;
+using Broiler.HtmlBridge;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression test for scroll-driven anchor positioning (CSS Anchor Positioning
+/// § scroll): an anchored element must track its anchor's <em>scrolled</em>
+/// position when a scroll container is an ancestor of the anchor but not of the
+/// anchored element.
+///
+/// Root cause fixed: <c>ResolveAnchorFunctions</c> resolved <c>anchor()</c>
+/// against the anchor's unscrolled layout position and only compensated for the
+/// document scroll offset of <em>fixed</em> targets. A nested scroll container
+/// between the anchor and the target was ignored, so a sibling-of-scroller
+/// abspos box anchored into the scroller stayed pinned to the anchor's
+/// <em>unscrolled</em> position (the css-anchor-position <c>anchor-scroll-*</c>
+/// cluster, issue #1163). <c>ComputeInterveningScrollOffset</c> now subtracts the
+/// scroll offset of every scroller that separates the anchor from the target.
+///
+/// Uses a block anchor with explicit geometry so the check isolates the scroll
+/// offset from inline-anchor box estimation (a separate gap).
+/// </summary>
+public class AnchorScrollTrackingTests : IDisposable
+{
+    public void Dispose() => Program.ResetTestHooks();
+
+    private static (int x0, int y0, int x1, int y1, int count) ColorBox(
+        BBitmap bmp, int w, int h, System.Func<byte, byte, byte, bool> match)
+    {
+        int x0 = int.MaxValue, y0 = int.MaxValue, x1 = -1, y1 = -1, count = 0;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                var p = bmp.GetPixel(x, y);
+                if (match(p.R, p.G, p.B))
+                {
+                    count++;
+                    if (x < x0) x0 = x;
+                    if (y < y0) y0 = y;
+                    if (x > x1) x1 = x;
+                    if (y > y1) y1 = y;
+                }
+            }
+        return (x0, y0, x1, y1, count);
+    }
+
+    // Anchor is a 100x40 block at (200,300) inside a 400x400 scroller that is
+    // scrolled by (150,100); the target sits OUTSIDE the scroller and pins its
+    // top-left to the anchor (left/top: anchor(left/top)). It must therefore
+    // render at the anchor's scrolled visual position (200-150, 300-100)=(50,200).
+    private const string Html = @"<!DOCTYPE html><meta charset=""utf-8"">
+<style>
+  body { margin: 0; }
+  #anchor { position: absolute; left: 200px; top: 300px; width: 100px; height: 40px;
+            anchor-name: --a; background: gray; }
+  #outer  { position: absolute; position-anchor: --a; left: anchor(left);
+            top: anchor(top); width: 60px; height: 20px; background: red; }
+</style>
+<div style=""position:relative"">
+  <div id=""sc"" style=""width:400px;height:400px;overflow:scroll"">
+    <div style=""width:1000px;height:1000px;position:relative""><div id=""anchor""></div></div>
+  </div>
+  <div id=""outer""></div>
+</div>
+<script>document.getElementById('sc').scrollTo(150, 100);</script>";
+
+    [Fact]
+    public void OuterAnchored_TracksAnchorScrolledPositionAcrossScroller()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-anchor-scroll-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "scroll-track.html");
+            File.WriteAllText(file, Html);
+
+            var runner = new WptTestRunner(800, 600);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+
+            // red target ~ (255,0,0), excluding the gray anchor beneath it.
+            var box = ColorBox(bmp, 800, 600, (r, g, b) => r > 200 && g < 80 && b < 80);
+
+            Assert.True(box.count > 0, "red target not painted — anchored element dropped.");
+            // Without the fix the target renders at the anchor's UNSCROLLED position
+            // (200,300); with it, at the scrolled position (50,200).
+            Assert.True(System.Math.Abs(box.x0 - 50) <= 2, $"target left={box.x0}, expected ~50 (was ~200 unfixed).");
+            Assert.True(System.Math.Abs(box.y0 - 200) <= 2, $"target top={box.y0}, expected ~200 (was ~300 unfixed).");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    // Same scenario, but with the shared renderer-layout geometry path enabled
+    // (RF-BRIDGE-1b): the anchor rect is sourced from real layout via
+    // TryGetAnchorLayoutBox and converted to the containing-block-relative frame.
+    // A block anchor's real geometry matches the estimator, so this guards that the
+    // shared-geometry wiring + CB-origin conversion keep the scroll-tracked position
+    // correct (and stays green against the un-patched submodule, where block-box
+    // geometry is already collected correctly).
+    [Fact]
+    public void OuterAnchored_TracksAnchorScrolledPosition_WithSharedLayoutGeometry()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-anchor-slg-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        bool previous = DomBridge.UseSharedLayoutGeometry;
+        DomBridge.UseSharedLayoutGeometry = true;
+        try
+        {
+            string file = Path.Combine(dir, "scroll-track-slg.html");
+            File.WriteAllText(file, Html);
+
+            var runner = new WptTestRunner(800, 600);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+
+            var box = ColorBox(bmp, 800, 600, (r, g, b) => r > 200 && g < 80 && b < 80);
+
+            Assert.True(box.count > 0, "red target not painted — anchored element dropped.");
+            Assert.True(System.Math.Abs(box.x0 - 50) <= 2, $"target left={box.x0}, expected ~50 (shared-geometry path).");
+            Assert.True(System.Math.Abs(box.y0 - 200) <= 2, $"target top={box.y0}, expected ~200 (shared-geometry path).");
+        }
+        finally
+        {
+            DomBridge.UseSharedLayoutGeometry = previous;
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Drives down the `css-anchor-position` **scroll cluster** from WPT issue #1163. Two core-layout fixes land on CI now; a real-layout anchor-geometry bridging step is prepared as a submodule patch + flag-gated wiring.

## Live on CI (main-repo)

**1. Cross-scroller `anchor()` scroll-offset tracking.** `ResolveAnchorFunctions` resolved `anchor()` against the anchor's *unscrolled* layout position and only compensated the document scroll of *fixed* targets, so an element anchored into a scroll container from *outside* it stayed pinned to the anchor's unscrolled position. `ComputeInterveningScrollOffset` now subtracts the scroll offset of every scroller that separates the anchor from the target. **Additive** — the offset is 0 when no scroller separates them, so it can only move boxes that currently render wrong. Guard: `AnchorScrollTrackingTests`.

**2. Abspos content double-offset (pre-existing, general).** `FlowBox` ended every abspos box with `AdjustAbsolutePosition(box, 0, 0)`, which adds the box's own `left`/`top` to each word. That's correct for an abspos child placed at its parent's inline cursor (its static position), but a **double** when the box flows its own content and `PerformLayoutImp` already advanced its `Location` to the final `left`/`top` (words flow from `startx = Location.X`). Result: an auto-sized `position:absolute` box with inline content painted its text at ~**2×** the inset while its border/background painted at the correct origin. Fixed with an `AbsposLocationFinalized` flag, gating out the redundant adjustment only when `Location` was pre-positioned — native form controls (which keep their static `Location`) still rely on it. Guard: `AbsposAutoSizeContentTests`.

## Prepared, off by default (no CI behaviour change until enabled)

**3. Render-tree → resolver geometry bridging.** `AnchorRegistry.ComputeElementBox` now sources the anchor's box from the renderer's real layout (`TryGetAnchorLayoutBox`), converting document coords to the estimator's CB-relative frame, so **inline anchors** report real inline-flow + font geometry instead of the coarse estimate. Behind `DomBridge.UseSharedLayoutGeometry` (default **off**) → a no-op on CI until the flag and the patch below land. CI-safe guard (block anchor, flag on): `OuterAnchored...WithSharedLayoutGeometry`.

**4. `patches/0001-broiler-html-inline-layout-geometry.patch` (Broiler.HTML).** The render layout recorded a zero-size box at the origin for inline elements, so the shared-geometry snapshot returned no usable rect for an inline anchor. The patch reconstructs the inline border box from the union of its per-line rectangles. Delivered as a **patch** — the `MaiRat/Broiler.HTML` remote is outside the session's GitHub scope (push 403); the submodule pointer is intentionally **left unchanged** (never bump a pointer whose commit isn't on the remote). See `patches/README.md` to apply.

## Validation

- **End-to-end:** with the patch applied and the flag on locally, `anchor-scroll-001` matches its reference at **99.72%** (2,240 / 786,432 px differ — text-edge AA), clearing the 99% gate.
- The bridging also lifts the position-area **inline** cluster from ~94% → **~96%**.
- Full curated `Broiler.Wpt.Tests`: **zero new failures** (baseline-diffed; an initial too-broad guard regressed one native-button test — the `AbsposLocationFinalized` flag resolves it).

## Reviewer notes

- Increments 1 and 4 (the abspos fix) are **active on CI**; 2/3 activate once the Broiler.HTML patch is applied and `UseSharedLayoutGeometry` is enabled (a parity-gate decision).
- The submodule pointer is unchanged; `git submodule status` shows no `+`.
- Full write-up: `docs/roadmap/wpt-triage-and-diagnostics.md` (Cluster 23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)