### PR TITLE
Fix sticky-anchor scroll regression (#1165): don't subtract scroll offset for pinned anchors

### DIFF
--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -474,6 +474,17 @@ resolved inset (scroll-simulation / abspos-layout path, not anchor geometry). Af
 transforms, Shadow DOM, iframe srcdoc, grid tracks, sub-pixel tail) stay filed against the existing
 deferred items rather than chased as a cluster.
 
+**Regression follow-up (issue [#1165](https://github.com/Broiler-Platform/Broiler/issues/1165),
+227→228).** Increment (1)'s `ComputeInterveningScrollOffset` over-corrected for a `position: sticky`
+anchor: it subtracts the intervening scroller's *full* `scrollTop`, but a sticky anchor stays pinned
+to that scroller's edge and does not translate 1:1 with scroll, so the subtraction drove
+`anchor-scroll-to-sticky-004`'s anchored box off-screen (`MissingContent`). Fixed by skipping a
+scroller's offset contribution when the anchor (or a box between it and the scroller) is sticky —
+i.e. the anchor is pinned to that scroller. Guard: `AnchorScrollTrackingTests.
+OuterAnchored_StickyAnchor_NotShiftedByScroll`. Broiler still doesn't *paint* sticky pinning
+(`ScrollSimulation` shifts sticky children like normal flow), so the remaining
+`anchor-scroll-to-sticky-{002,003,005}` fails are a distinct, still-open gap.
+
 Cluster 11 (issue [#1119](https://github.com/MaiRat/Broiler/issues/1119), the dominant
 `PixelMismatch / MissingContent` family, 328 failures) was a render-serialization bug that
 shifted content horizontally in comment-heavy tests. After scripts run, the bridge serializes

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
@@ -185,23 +185,53 @@ public sealed partial class DomBridge
         offX = 0;
         offY = 0;
         var scale = GetScrollSimulationScaleFactor();
+
+        // A position:sticky element stays pinned to its nearest scroll
+        // container's edge instead of translating with that scroller's scroll.
+        // When the anchor (or a box between it and its scroller) is sticky, the
+        // anchor's scrolled position does NOT shift by the full scroll offset,
+        // so a target outside the scroller must not subtract it — doing so drives
+        // the anchored box off-screen (css-anchor-position anchor-scroll-to-sticky-004).
+        bool stickyToNextScroller = IsSticky(GetComputedProps(anchorEl));
+
         for (var el = anchorEl.Parent; el != null; el = el.Parent)
         {
             var props = GetComputedProps(el);
             if (!HasOverflowClipping(props))
+            {
+                // A sticky box below the next scroller pins the anchor to it;
+                // remember that until we reach the scroller itself.
+                if (IsSticky(props))
+                    stickyToNextScroller = true;
                 continue;
+            }
 
             // The target lives inside this scroller too → they scroll together
             // (or this scroller is the target's containing block); no separation.
             if (IsDescendantOrSelf(targetEl, el))
                 break;
 
-            if (GetElementRuntimeState(el).Scroll.Left.TryGet(out var sl) && sl is double slv)
-                offX += slv * scale;
-            if (GetElementRuntimeState(el).Scroll.Top.TryGet(out var st) && st is double stv)
-                offY += stv * scale;
+            // Skip scrollers the anchor is sticky-pinned to: the anchor resists
+            // this scroller's scroll, so its edges don't move by that offset.
+            if (!stickyToNextScroller)
+            {
+                if (GetElementRuntimeState(el).Scroll.Left.TryGet(out var sl) && sl is double slv)
+                    offX += slv * scale;
+                if (GetElementRuntimeState(el).Scroll.Top.TryGet(out var st) && st is double stv)
+                    offY += stv * scale;
+            }
+
+            // Past this scroller, sticky pinning resets: a sticky box higher up
+            // pins to the next scroll container, not this one.
+            stickyToNextScroller = false;
         }
     }
+    /// <summary>
+    /// True when the computed <c>position</c> in <paramref name="props"/> is
+    /// <c>sticky</c>.
+    /// </summary>
+    private static bool IsSticky(Dictionary<string, string> props) =>
+        string.Equals(props.GetValueOrDefault("position"), "sticky", StringComparison.OrdinalIgnoreCase);
     /// <summary>
     /// True when <paramref name="node"/> is <paramref name="ancestor"/> or a
     /// descendant of it.

--- a/src/Broiler.Wpt.Tests/AnchorScrollTrackingTests.cs
+++ b/src/Broiler.Wpt.Tests/AnchorScrollTrackingTests.cs
@@ -128,4 +128,57 @@ public class AnchorScrollTrackingTests : IDisposable
             try { Directory.Delete(dir, true); } catch { }
         }
     }
+
+    // A position:sticky anchor stays pinned to its scroll container's edge instead
+    // of translating with the scroll, so ComputeInterveningScrollOffset must NOT
+    // subtract that scroller's offset for it. The anchor sits 50px down inside a
+    // scroller scrolled by 100; the target outside the scroller pins to
+    // anchor(top)/anchor(left). Because the anchor is sticky, the target stays at
+    // the anchor's (unshifted) position (0,50) — subtracting the full scroll offset
+    // would drive it to y=-50 and off-screen, which is the css-anchor-position
+    // anchor-scroll-to-sticky-004 regression this guards.
+    private const string StickyHtml = @"<!DOCTYPE html><meta charset=""utf-8"">
+<style>
+  body { margin: 0; }
+  #anchor { position: sticky; top: 0; width: 100px; height: 40px;
+            anchor-name: --a; background: gray; }
+  #outer  { position: absolute; position-anchor: --a; left: anchor(left);
+            top: anchor(top); width: 60px; height: 20px; background: red; }
+</style>
+<div style=""position:relative"">
+  <div id=""sc"" style=""width:400px;height:400px;overflow:scroll"">
+    <div style=""height:50px""></div>
+    <div id=""anchor""></div>
+    <div style=""height:1000px""></div>
+  </div>
+  <div id=""outer""></div>
+</div>
+<script>document.getElementById('sc').scrollTo(0, 100);</script>";
+
+    [Fact]
+    public void OuterAnchored_StickyAnchor_NotShiftedByScroll()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-anchor-sticky-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "sticky-track.html");
+            File.WriteAllText(file, StickyHtml);
+
+            var runner = new WptTestRunner(800, 600);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+
+            var box = ColorBox(bmp, 800, 600, (r, g, b) => r > 200 && g < 80 && b < 80);
+
+            Assert.True(box.count > 0, "red target not painted — sticky anchor's target driven off-screen.");
+            // With the fix the target stays at the anchor's pinned position (0,50);
+            // subtracting the full scroll offset would push it to (0,-50), off-screen.
+            Assert.True(System.Math.Abs(box.x0 - 0) <= 2, $"target left={box.x0}, expected ~0.");
+            Assert.True(System.Math.Abs(box.y0 - 50) <= 2, $"target top={box.y0}, expected ~50 (was ~-50 / off-screen unfixed).");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
 }


### PR DESCRIPTION
## What

Fixes the single test that WPT run [#1165](https://github.com/Broiler-Platform/Broiler/issues/1165) regressed (227 → 228, all in `css/css-anchor-position`): `anchor-scroll-to-sticky-004.html` flipped **pass → fail** (`PixelMismatch / MissingContent`). Nothing newly passed — it's one regression, introduced by the scroll-driven anchor fix in #1163 (`35f25de1`).

## Root cause

`ComputeInterveningScrollOffset` (`AnchorFunctions.cs`) subtracts an intervening scroller's **full `scrollTop`** from the anchor's edges, assuming the anchor translates 1:1 with the scroll. In `-004` the anchor is `position: sticky`, pinned to the scroller's edge (`scrollTop = 200`). It does **not** move by the full scroll amount, so subtracting all 200px drove the anchored `#anchored` box off-screen → blank render → `MissingContent`. The pre-fix code subtracted nothing and happened to land on-screen (its prior pass).

## Fix

Skip a scroller's offset contribution when the anchor — or a box between it and that scroller — is `position: sticky` (the anchor is pinned to it). A `stickyToNextScroller` flag walks the ancestor chain and resets past each scroller, so a sticky box higher up pins to the *next* scroll container rather than the current one. This is a **no-op for non-sticky anchors**, so the #1163 `anchor-scroll-*` wins are preserved.

## Verification

- **Reproduced the regression locally**: bisected by reverting the six #1163 files to the parent and rebuilding — the culprit isolates to `AnchorFunctions.ComputeInterveningScrollOffset` (increment 1), not the `Broiler.Layout` abspos change.
- **After the fix**: `-004` renders the anchored box back on-screen, byte-identical (4908 B) to the prior passing render; the blank HEAD render was 4889 B.
- New guard test `AnchorScrollTrackingTests.OuterAnchored_StickyAnchor_NotShiftedByScroll` + the two existing scroll-tracking tests + abspos tests → **4/4 pass**.
- Local `css/css-anchor-position` subset unchanged (27+1 pass); confirmed **0 sticky tests exist locally**, so this change provably cannot perturb them.

## Reviewer notes / caveats

- `src/Broiler.HtmlBridge.Dom` is **main-repo** (not a submodule) → direct commit, no patch workflow.
- "Pass" is validated against the **pre-fix render**, which itself passed CI (≤1% pixel diff) — I can't mint a fresh Chromium golden locally (no Playwright). Byte-identical restoration makes a CI re-pass very likely, but only a CI run confirms it.
- This fixes the **one** regressed test → net **228 → 227**. Broiler still doesn't *paint* sticky pinning (`ScrollSimulation` shifts sticky children like normal flow), so `anchor-scroll-to-sticky-{002,003,005}` remain failing — they failed before #1163 too, so this is a distinct, still-open gap, not below the prior baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)