### PR TITLE
WPT #1168: fix css-anchor-position/transform-* crash + transform-005 geometry

### DIFF
--- a/src/Broiler.Cli.Tests/GraphicsAbstractionTests.cs
+++ b/src/Broiler.Cli.Tests/GraphicsAbstractionTests.cs
@@ -766,6 +766,27 @@ public class GraphicsAbstractionTests
     }
 
     [Fact]
+    public void StubCanvas_Exposes_Save_Restore_Translate_Invoked_By_Compat_Reflection()
+    {
+        // Regression guard (WPT css-anchor-position/transform-*): CompatCanvasOperations
+        // invokes Save/Restore/Translate on the OpenCanvas() result by reflection. The
+        // OS-free StubCanvas must expose those exact signatures; when they were missing
+        // every transform-layer push threw InvalidOperationException, surfacing as a
+        // RenderingError across the transform-* family.
+        using var surface = new Broiler.HTML.Image.Compat.StubBitmapCompatSurface();
+        var canvas = surface.OpenCanvas();
+
+        var exception = Record.Exception(() =>
+        {
+            CompatCanvasOperations.Save(canvas);
+            CompatCanvasOperations.Translate(canvas, 3f, 5f);
+            CompatCanvasOperations.Restore(canvas);
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
     public void BBitmap_Default_Compat_Surface_Comes_From_Skia_Compat_Provider()
     {
         var provider = new RecordingCompatProvider(() => new RecordingBitmapCompatSurface(4, 4));

--- a/src/Broiler.Cli.Tests/ScriptEngineExecuteTests.cs
+++ b/src/Broiler.Cli.Tests/ScriptEngineExecuteTests.cs
@@ -1108,6 +1108,39 @@ document.getElementById('out').appendChild(p);
     }
 
     [Fact]
+    public void DomBridge_AnchorSize_Resolves_To_Sized_Ancestor_Not_Viewport_For_NoWidth_Anchor()
+    {
+        // Regression (css-anchor-position transform-005): an anchor with no explicit
+        // width nested inside a no-width containing-block wrapper (e.g. a transformed
+        // div) must take its used width from the nearest sized ancestor, not fall back
+        // to the viewport. anchor-size(width) on the anchored element must therefore
+        // resolve to the 137px ancestor width, not the ~1000px viewport width.
+        const string html = """
+<!DOCTYPE html>
+<html>
+<body>
+  <div style="width:137px; height:100px;">
+    <div style="transform:translateX(0);">
+      <div style="anchor-name:--a; height:50px;"></div>
+    </div>
+    <div id="anchored" style="position:absolute; position-anchor:--a; width:anchor-size(width); height:anchor-size(height);"></div>
+  </div>
+</body>
+</html>
+""";
+
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///test.html");
+        bridge.FireWindowLoadEvent();
+        bridge.ResolveAnchorPositions();
+
+        var anchoredWidth =
+            context.Eval("document.getElementById('anchored').style.width").ToString();
+        Assert.Equal("137px", anchoredWidth);
+    }
+
+    [Fact]
     public void DomBridge_SerializeToHtml_Preserves_Mutated_Iframe_Scroll_State_In_SrcDoc()
     {
         const string html = """

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
@@ -56,6 +56,17 @@ public sealed partial class DomBridge
                     // may not have explicit width. Estimate from content.
                     explicitW = EstimateInlineContentWidth(parent);
                 }
+                if (explicitW == null)
+                {
+                    // A no-width block-level containing block (e.g. a transformed
+                    // wrapper with no explicit width) fills ITS own containing
+                    // block; resolve its used width from the nearest sized
+                    // ancestor up the normal-flow parent chain rather than
+                    // defaulting to the viewport (css-anchor-position transform-005:
+                    // a nested no-width anchor under a sized 100px ancestor made
+                    // anchor-size(width) resolve to the viewport width).
+                    explicitW = ResolveBlockUsedWidthFromAncestors(parent);
+                }
                 double w = explicitW ?? _viewportWidth;
                 // Subtract padding from the CB width to get content width.
                 w -= TryParsePx(parentProps.GetValueOrDefault("padding-left")) ?? 0;
@@ -67,6 +78,34 @@ public sealed partial class DomBridge
         // No positioned ancestor found; use viewport width minus default body
         // margin (8px each side) as the effective content width for block layout.
         return _viewportWidth - 16;
+    }
+    /// <summary>
+    /// Resolves the used content width of a block-level element that has no
+    /// explicit <c>width</c> by walking up the normal-flow parent chain to the
+    /// nearest ancestor with a definite width and returning its content width.
+    /// A block with no explicit width fills its containing block, so a no-width
+    /// wrapper (even one that establishes a containing block, e.g. via
+    /// <c>transform</c>) inherits the width of an outer sized ancestor rather
+    /// than defaulting to the viewport. Returns <c>null</c> when no sized
+    /// ancestor is found (caller falls back to the viewport width).
+    /// </summary>
+    private double? ResolveBlockUsedWidthFromAncestors(DomElement blockEl)
+    {
+        for (var a = blockEl.Parent; a != null && !a.IsTextNode; a = a.Parent)
+        {
+            var ap = GetComputedProps(a);
+            double? w = TryParsePx(ap.GetValueOrDefault("width"));
+            if (w.HasValue)
+            {
+                double cw = w.Value;
+                cw -= TryParsePx(ap.GetValueOrDefault("padding-left")) ?? 0;
+                cw -= TryParsePx(ap.GetValueOrDefault("padding-right")) ?? 0;
+                cw -= TryParsePx(ap.GetValueOrDefault("border-left-width")) ?? 0;
+                cw -= TryParsePx(ap.GetValueOrDefault("border-right-width")) ?? 0;
+                return cw < 0 ? 0 : cw;
+            }
+        }
+        return null;
     }
     /// <summary>
     /// Finds the height of the nearest positioned ancestor (containing block)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
@@ -473,6 +473,29 @@ public sealed partial class DomBridge
                 // and the grid origin must account for body margin.
                 cbOffsetX = FindBodyMarginLeft();
                 cbOffsetY = FindBodyMarginTop();
+
+                // ComputeElementBox measures the anchor relative to its nearest
+                // CB-establishing ancestor and stops there. When that ancestor is
+                // a non-body wrapper (e.g. a transformed div), the returned coords
+                // are wrapper-relative, not document-absolute as assumed above.
+                // Shift the anchor into the document frame by adding the wrapper's
+                // own position (css-anchor-position transform-005: a transformed
+                // anchor wrapper below a <p> otherwise placed block-end one text
+                // line too high, exposing the red containing block).
+                var anchorWrapper = anchor.SourceElement != null
+                    ? FindContainingBlockElement(anchor.SourceElement)
+                    : null;
+                if (anchorWrapper != null)
+                {
+                    var wrapperBox = ComputeElementBox(anchorWrapper);
+                    if (wrapperBox != null)
+                    {
+                        anchorLeft += wrapperBox.Left;
+                        anchorRight += wrapperBox.Left;
+                        anchorTop += wrapperBox.Top;
+                        anchorBottom += wrapperBox.Top;
+                    }
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary

Addresses the `css/css-anchor-position/transform-*` family from issue #1168 in two parts.

### 1. RenderingError crash (8 tests) — `Broiler.HTML` submodule

`CompatCanvasOperations` invokes `Save`/`Restore`/`Translate` on the `OpenCanvas()` result **via reflection** on every transform-layer push. In the OS-free managed raster path that object is `StubCanvas`, whose doc comment promised those no-op members but whose body was empty — so the reflection lookup threw:

```
CompatCanvasOperations.InvokeVoid — Canvas compat object
'Broiler.HTML.Image.Compat.StubCanvas' does not expose method 'Save'.
```

Fix: add the three no-op members with the exact reflection signatures. Submodule pointer bumped to [`609e48d`](https://github.com/Broiler-Platform/Broiler.HTML/commit/609e48d7145d1c3d11001bb8b88b16078f077654).

### 2. transform-005 residual PixelMismatch (93% → 99.0%) — main repo

With the crash gone, `transform-005` rendered but mismatched. Two anchor-resolver estimator bugs:

- **`anchor-size(width)` → viewport width.** The anchor has no explicit width and is nested inside a no-width containing-block wrapper (a transformed `<div>`). A no-width block fills its own containing block, so `FindContainingBlockWidth` now resolves such a wrapper's used width from the nearest sized ancestor up the normal-flow parent chain (`ResolveBlockUsedWidthFromAncestors`) instead of defaulting to the viewport. Fixed the full-width green bar (93% → 98.9%).
- **`position-area: block-end` one text-line too high.** The anchor box from `ComputeElementBox` is measured relative to its transformed wrapper, not document-absolute as the ICB-target branch assumed. Shift it into the document frame by the wrapper's own position (98.9% → 99.0%).

## Verification

- Guard tests: `StubCanvas_Exposes_Save_Restore_Translate_Invoked_By_Compat_Reflection` and `DomBridge_AnchorSize_Resolves_To_Sized_Ancestor_Not_Viewport_For_NoWidth_Anchor` (both pass).
- Full local `css-anchor-position` subset (CI-parity defer flag): **28 pass / 11 fail, zero regressions**. `transform-{010,015,016}` PASS; `transform-005` 93% → 99.0%.

## Known residual

`transform-005` lands at 99.0% (just under the 99% pass line). The remaining <1% is the leading `<p>`'s **auto height**, which the CSS-property-based anchor estimator cannot measure — that's the real-layout-geometry (`UseSharedLayoutGeometry`) domain, out of scope here. The two fixes are correct and general (they also apply to any `anchor-size()` under a transformed/no-width wrapper), so they should help the CI-only `transform-*` PixelMismatch tests that don't hit the auto-height case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)