### PR TITLE
WPT #1173: fix anchor-position-writing-modes-001 cascade timeout

### DIFF
--- a/src/Broiler.Wpt.Tests/CascadeMemoizationTimeoutTests.cs
+++ b/src/Broiler.Wpt.Tests/CascadeMemoizationTimeoutTests.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression guard for WPT #1173 (issue: <c>anchor-position-writing-modes-001.html</c>
+/// reported as a hard <c>Timeout</c>). Enabling <c>UseSharedLayoutGeometry</c> (issue
+/// #1170) routed every live <c>getBoundingClientRect</c>/<c>offset*</c> query through a
+/// full renderer layout. This test drives 6^4 = 1296 synchronous <c>test()</c> bodies at
+/// load, each mutating <c>classList</c> (bumping the document version) and reading
+/// <c>target.getBoundingClientRect()</c> — so every read forces a fresh full re-cascade.
+/// The cascade was quadratic per query (<c>CssStyleEngine.CollectCascadedDeclarations</c>
+/// re-matched every UA + author selector for the same element ~25× per query, ~68k
+/// selector scans), pushing the render past the runner's 30s per-test cap. Memoizing the
+/// declared cascade collapses that to a linear pass. This test fails fast if the
+/// per-query re-cascade blows up again.
+/// </summary>
+public class CascadeMemoizationTimeoutTests
+{
+    [Fact]
+    public async Task AnchorPositionWritingModes_ManyGetBoundingClientRect_RenderWellWithinRunnerTimeout()
+    {
+        var wptRoot = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(),
+            "..", "..", "..", "..", "..", "tests", "wpt"));
+        var file = Path.Combine(wptRoot, "css", "css-anchor-position", "anchor-position-writing-modes-001.html");
+        Assert.True(File.Exists(file), $"missing fixture {file}");
+
+        var runner = new WptTestRunner(800, 800);
+        var sw = Stopwatch.StartNew();
+        var render = Task.Run(() => { using var b = runner.RenderHtmlFileBitmapPublic(file, wptRoot); });
+        // Pre-fix this ran ~43s (past the runner's 30s per-test cap → reported Timeout);
+        // ~11s after. A 25s ceiling stays under the 30s cap the real runner enforces yet
+        // leaves ample headroom for the fixed path, so it only trips if the per-query
+        // cascade goes super-linear again.
+        var completed = await Task.WhenAny(render, Task.Delay(System.TimeSpan.FromSeconds(25))) == render;
+        sw.Stop();
+
+        Assert.True(completed,
+            $"anchor-position-writing-modes-001: render did not complete within 25s ({sw.ElapsedMilliseconds}ms) — " +
+            "the per-query declared-cascade recomputation is super-linear again (WPT #1173).");
+    }
+}

--- a/tests/wpt/css/css-anchor-position/anchor-position-writing-modes-001.html
+++ b/tests/wpt/css/css-anchor-position/anchor-position-writing-modes-001.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<title>Tests `anchor` function for `writing-mode`/`direction`s</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/#propdef-anchor-name">
+<link rel="author" href="mailto:kojii@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script><style>
+:root, body {
+  margin: 0;
+}
+#container {
+  position: relative;
+  width: 600px;
+  height: 400px;
+}
+#a1 {
+  anchor-name: --a1;
+  background: orange;
+  margin-left: 100px;
+  margin-top: 100px;
+  width: 100px;
+  height: 100px;
+}
+.htb-rtl #a1 { margin-right: 400px; }
+.vlr-rtl #a1 { margin-bottom: 200px; }
+.vrl-ltr #a1 { margin-right: 400px; }
+.vrl-rtl #a1 { margin-right: 400px; margin-bottom: 200px; }
+#a2 {
+  anchor-name: --a2;
+  background: purple;
+  margin-left: 500px;
+  margin-top: 100px;
+  width: 100px;
+  height: 100px;
+}
+.vlr-ltr #a2 { margin-left: 300px; margin-top: 300px; }
+.vlr-rtl #a2 { margin-left: 300px; margin-top: 300px; }
+.vrl-ltr #a2 { margin-right: -600px; margin-top: 300px; }
+.vrl-rtl #a2 { margin-right: -600px; margin-top: 300px; }
+#target {
+  background: green;
+  position: absolute;
+  left: anchor(--a1 right);
+  top: anchor(--a1 bottom);
+  right: anchor(--a2 left);
+  bottom: anchor(--a2 top);
+}
+.htb-ltr { writing-mode: horizontal-tb; direction: ltr; }
+.htb-rtl { writing-mode: horizontal-tb; direction: rtl; }
+.vlr-ltr { writing-mode: vertical-lr; direction: ltr; }
+.vlr-rtl { writing-mode: vertical-lr; direction: rtl; }
+.vrl-ltr { writing-mode: vertical-rl; direction: ltr; }
+.vrl-rtl { writing-mode: vertical-rl; direction: rtl; }
+</style>
+<body>
+  <div id="container">
+    <div id="a1"></div>
+    <div id="a2"></div>
+    <div id="target"></div>
+  </div>
+<script>
+const classes = [
+  'htb-ltr', 'htb-rtl',
+  'vlr-ltr', 'vlr-rtl',
+  'vrl-ltr', 'vrl-rtl'];
+const combinations = [];
+for (const container_class of classes) {
+  for (const a1_class of classes) {
+    for (const a2_class of classes) {
+      for (const target_class of classes) {
+        combinations.push([container_class, a1_class, a2_class, target_class]);
+      }
+    }
+  }
+}
+
+for (let i = 0; i < combinations.length; ++i)
+  run_test_index(i);
+
+function run_test_index(i) {
+  const combination = combinations[i];
+  run_test(i, ...combination);
+}
+
+function run_test(i, container_class, a1_class, a2_class, target_class) {
+  container.classList.add(container_class);
+  a1.classList.add(a1_class);
+  a2.classList.add(a2_class);
+  target.classList.add(target_class);
+  test(() => {
+    const bounds = target.getBoundingClientRect();
+    assert_array_equals(
+        [bounds.left, bounds.top, bounds.right, bounds.bottom],
+        [200, 200, 500, 300]);
+  }, `${i}: ${container_class}/${a1_class}/${a2_class}/${target_class}`);
+  container.classList.remove(container_class);
+  a1.classList.remove(a1_class);
+  a2.classList.remove(a2_class);
+  target.classList.remove(target_class);
+}
+</script>
+</body>


### PR DESCRIPTION
Fixes the one new, actionable failure in [#1173](https://github.com/Broiler-Platform/Broiler/issues/1173): a hard **Timeout** on `css/css-anchor-position/anchor-position-writing-modes-001.html`. (The other 222 fails are the known heterogeneous css-anchor-position pixel-fidelity tail; total is already down 227 → 223 after #1169/#1171/#1172.)

## Root cause — a regression unmasked by #1170

That test builds 6⁴ = **1296** writing-mode combinations and runs 1296 synchronous `test()` bodies at load, each mutating `classList` (bumping the document version) then reading `target.getBoundingClientRect()`. Since #1170 enabled `UseSharedLayoutGeometry`, every such read routes through a **full renderer layout**, so all 1296 reads force a fresh full re-cascade.

Profiling the render (locally ~43s, past the runner's 30s per-test cap):

- `SetDocumentWithStyleSet` ≈ **29ms/call** (the layout itself ≈ 0.3ms) — 100% in the CSS cascade.
- **68,550 selector-match attempts per single query**: `CssStyleEngine.CollectCascadedDeclarations` was called **375× per query** for a ~15-element document and — unlike the computed-style path (`_cache`, well-cached) — the **declared-cascade path was never memoized**, re-scanning every UA + author selector each time.

## Fix (in the `Broiler.CSS` submodule, pointer bumped here)

Memoize the declared cascade by `(element, pseudo, includeInlineStyle)`, cleared inside the existing `InvalidateAll()` so it shares the **exact same correctness lifecycle** as the computed-style `_cache` (fires on stylesheet / environment / document-mutation changes). A generation counter — captured before the cascade is computed and rechecked before storing — prevents a mid-cascade stylesheet re-sync (the `_sheets` snapshot case) from ever caching a stale entry. The returned map is shared and read-only; callers copy from it.

It's a pure optimization returning **identical cascade values**, so it speeds up *all* rendering and defuses this whole class of geometry-heavy timeouts. Render drops **~43s → ~14s** (runner completes in **~11s**, ~2.7× under the cap).

The submodule commit also restores `CssComputedStyle.GetPropertyValue` (dropped by the "Uncountable refactor"), which had left 82 pre-existing compile errors in `Broiler.CSS.Dom.Tests` — same class of cleanup as #1171's BColor fix.

## Validation — zero regressions

- **`Broiler.CSS.Dom.Tests`: 59/59** — cascade correctness + all invalidation cases + a new declared-cache invalidation test.
- **Full `Broiler.Wpt.Tests` (512 tests), rigorous baseline diff: 0 tests flipped pass→fail; exactly 1 fixed** (the new guard). The pre-existing environmental pixel-tail failures are unchanged.
- **Local `css-anchor-position` subset: 29 pass** — unchanged from the #1170 baseline.
- Guard added: `CascadeMemoizationTimeoutTests` renders the real fixture and fails if the per-query cascade goes super-linear again (25s ceiling, under the 30s runner cap).

## Notes

- The WPT workflow is `workflow_dispatch`-only, so this PR gets no automatic WPT run — a manual dispatch on the branch is needed to confirm the full-suite delta. This is a pure-perf change with no rendering-output change, so no pixel deltas are expected.
- The fix is entirely within `Broiler.CSS` (submodule branch `claude/wpt-1173-cascade-memoization`, pushed to the in-scope Broiler-Platform remote); this PR bumps the pointer `8d302ff → f250e77`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)