### PR TITLE
WPT CI: file a second, severity-ranked "biggest problems" issue

### DIFF
--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -11,7 +11,10 @@ name: WPT Tests
 #
 # The manually dispatched workflow can target the full suite, a subset, a
 # single shard, or only the previously-failed tests. Every run merges the shard
-# results and files a focused GitHub issue when failures exist.
+# results and, when failures exist, files two GitHub issues: one ranking the
+# most common failure groups (by frequency) and a second, severity-focused issue
+# listing the run's few biggest problems (crashes, low-percent matches, and
+# incomplete shards, ranked by blast radius).
 #
 # Reference generation (Chromium via Playwright) is expensive, so each shard
 # caches its reference slice. Bump CACHE_EPOCH to refresh WPT master + refs.
@@ -44,6 +47,10 @@ on:
         description: Maximum number of common failure groups to include in the GitHub issue.
         required: false
         default: '10'
+      biggest_problems_limit:
+        description: Maximum number of biggest problems to include in the second (severity-focused) GitHub issue.
+        required: false
+        default: '3'
 
 permissions:
   contents: write   # persist-failed commits the failing-test manifest
@@ -58,6 +65,7 @@ env:
   RESULTS_DIR: tests/wpt-results
   FAILED_TESTS_FILE: tests/wpt-baseline/failed-tests.json
   MOST_COMMON_PROBLEMS_LIMIT: ${{ github.event.inputs.most_common_problems_limit || '10' }}
+  BIGGEST_PROBLEMS_LIMIT: ${{ github.event.inputs.biggest_problems_limit || '3' }}
 
 jobs:
   # ── Resolve the shard matrix and whether to run incrementally ────────────
@@ -254,7 +262,9 @@ jobs:
             --shard-dir shard-results \
             --merged-json wpt-merged/wpt-results.json \
             --issue-md wpt-merged/issue.md \
+            --biggest-issue-md wpt-merged/biggest-issue.md \
             --problem-limit "$MOST_COMMON_PROBLEMS_LIMIT" \
+            --biggest-problem-limit "$BIGGEST_PROBLEMS_LIMIT" \
             --github-output "$GITHUB_OUTPUT"
 
       - name: Publish merged summary
@@ -295,6 +305,28 @@ jobs:
               body,
             });
             core.info(`Created issue #${issue.data.number}: ${issue.data.html_url}`);
+
+      - name: Create GitHub issue for the biggest problems
+        if: steps.merge.outputs.create_biggest_issue == 'true'
+        uses: actions/github-script@v7
+        env:
+          BIGGEST_PROBLEM_COUNT: ${{ steps.merge.outputs.biggest_problem_count }}
+        with:
+          # Prefer the configured PAT/App token, then use this workflow's token.
+          github-token: ${{ secrets.ISSUE_TOKEN || github.token }}
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('wpt-merged/biggest-issue.md', 'utf8').trim();
+            const today = new Date().toISOString().slice(0, 10);
+            const count = Number(process.env.BIGGEST_PROBLEM_COUNT || 0);
+            const title = `WPT run: top ${count} biggest problem(s) (${today})`;
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+            });
+            core.info(`Created biggest-problems issue #${issue.data.number}: ${issue.data.html_url}`);
 
   # ── Persist the failing-test manifest for incremental reruns ─────────────
   persist-failed:

--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -1182,6 +1182,41 @@ to that ref — so Broiler is correct and the committed PNG is the outlier.
 > ring/centre the ref HTML produces). These stay red until the committed references are
 > regenerated; they are **not** Broiler rendering bugs.
 
+### ✅ #15 — Second "biggest problems" issue, ranked by blast radius (DONE)
+
+The CI runner already files one issue ranking failure groups by **frequency**
+(`--issue-md`). That view buries the *most severe* items — a crashed shard or a
+near-blank render reads the same as any other line. So every failing run now also
+files a **second, severity-focused issue** listing the run's few biggest problems.
+
+- **What's "big"** (`_rank_biggest_problems` in `scripts/merge-wpt-shards.py`), three
+  severity tiers ranked by blast radius:
+  - **tier 0 — incomplete shards** (collapsed into one entry): a shard that never
+    finished leaves a whole slice unmeasured, so its pass/fail is unknown. Sourced
+    from the per-shard `*-status.json` non-zero exits, same signal as the existing
+    `ShardProcessError` group.
+  - **tier 1 — crashes**, one entry per `triage.exceptionSignatures` signature,
+    ordered by the number of tests it gated (one throw → many failures → one fix).
+  - **tier 2 — low percent matches**, one entry per `triage.lowestMatchTests` case
+    below `--low-match-threshold` (default 50%): the render is substantially wrong,
+    not a near-miss. The 99% pass threshold means anything this low is a gross error.
+- **Selection is diversity-first**: the worst entry of each distinct kind is taken
+  before a second slot is spent on a kind already shown, then leftover slots fill by
+  next-worst overall. So the top-3 spans *incomplete shard + crash + low match* when
+  all three exist, rather than three crashes crowding out a near-blank render, while
+  the list stays ordered by severity.
+- **Output**: merged `biggestProblems` (`{kind, tier, severity, impact, title, detail}`)
+  + `--biggest-issue-md` renders the second issue body; the CLI emits
+  `create_biggest_issue` / `biggest_problem_count` step outputs. `wpt-tests.yml`'s
+  report job creates the issue only when there is at least one big problem (a run whose
+  only failures are near-miss mismatches files the primary issue but not this one). The
+  count is bounded by `--biggest-problem-limit` (workflow input `biggest_problems_limit`,
+  default 3).
+- **Tests** (`test_merge_wpt_shards.py`): `test_ranks_biggest_problems_by_blast_radius`,
+  `test_biggest_problems_are_diversity_first`, `test_biggest_problem_limit_bounds_the_list`,
+  `test_cli_emits_biggest_issue_outputs`, `test_no_biggest_issue_when_only_near_miss_mismatches`,
+  `test_cli_rejects_out_of_range_low_match_threshold`.
+
 ---
 
 ## 3. Performance & permanence of the diagnostics hook

--- a/scripts/merge-wpt-shards.py
+++ b/scripts/merge-wpt-shards.py
@@ -11,6 +11,11 @@ own ``wpt-results.json``. This script combines those shard reports to produce:
   manifest that drives incremental reruns.
 * ``--issue-md``     — a Markdown body summarising totals and a bounded list
   of the most common failure groups, suitable for posting as a GitHub issue.
+* ``--biggest-issue-md`` — a Markdown body for a *second*, severity-focused
+  issue that lists only the run's few biggest problems, ranked by blast radius:
+  incomplete shards first (a whole slice went unmeasured), then crashes (one bug
+  gating many tests), then the worst pixel mismatches. This is the "what hurt
+  most this run" companion to the frequency-ranked ``--issue-md`` view.
 
 When ``--merge-into`` names an existing manifest, the run's failures are folded
 into it *by scope* instead of replacing it: entries for tests this run actually
@@ -21,8 +26,9 @@ without shrinking it, so persistence is safe on every run, not just a full-suite
 one.
 
 When ``--github-output`` is given (the ``$GITHUB_OUTPUT`` file), the script also
-writes ``failed_count``, ``total_count``, ``incomplete_shard_count`` and
-``create_issue`` step outputs.
+writes ``failed_count``, ``total_count``, ``incomplete_shard_count``,
+``create_issue``, ``biggest_problem_count`` and ``create_biggest_issue`` step
+outputs. The last two drive the second (biggest-problems) issue.
 """
 
 from __future__ import annotations
@@ -36,6 +42,15 @@ from pathlib import Path
 
 DEFAULT_PROBLEM_LIMIT = 10
 PROBLEM_EXAMPLE_LIMIT = 3
+
+# The second, severity-focused issue reports at most this many of the run's
+# biggest problems.
+DEFAULT_BIGGEST_PROBLEM_LIMIT = 3
+# A pixel mismatch counts as a "low percent match" big problem only when the
+# rendered output matches the reference by less than this percentage — i.e. the
+# render is substantially wrong, not merely off by a hair (the pass threshold is
+# 99%). Runs where every mismatch is a near-miss surface no low-match problem.
+DEFAULT_LOW_MATCH_THRESHOLD = 50.0
 
 
 def _bucket_directory(relative_path: str) -> str:
@@ -97,7 +112,132 @@ def _problem_identity(result: dict) -> tuple[str, str, str | None]:
     return category, category, None
 
 
-def merge(shard_dir: Path, problem_limit: int = DEFAULT_PROBLEM_LIMIT) -> dict:
+def _rank_biggest_problems(
+    incomplete_shards: list[dict],
+    exception_signatures: Counter[str],
+    low_match_tests: list[dict],
+    limit: int,
+    low_match_threshold: float,
+) -> list[dict]:
+    """Rank the run's few most severe problems, worst first.
+
+    Unlike ``topProblems`` (which ranks by *frequency*), this ranks by *blast
+    radius* across three severity tiers:
+
+    * tier 0 — **incomplete shards** (collapsed into one entry). A shard that
+      never finished leaves a whole slice of the suite unmeasured, so its
+      pass/fail is unknown — the most important thing to flag, even if only one
+      shard is affected.
+    * tier 1 — **crashes**, one entry per exception signature, ordered by the
+      number of tests that signature gated. A single engine throw commonly fails
+      many tests at once (one signature → one fix).
+    * tier 2 — **low percent matches**, one entry per test whose render matched
+      the reference by less than ``low_match_threshold`` percent, worst match
+      first.
+
+    Selection is diversity-first: the single worst entry of each distinct kind is
+    taken before any slot is spent on a second entry of a kind already shown, then
+    remaining slots (if ``limit`` exceeds the number of kinds present) are filled
+    by the next-worst overall. This keeps a short list representative — a lone but
+    severe low match still surfaces even when crashes would otherwise fill every
+    slot — while the returned list stays ordered by blast radius. A healthy-ish
+    run with no incomplete shards naturally surfaces its worst crashes and
+    mismatches instead.
+    """
+    problems: list[dict] = []
+
+    if incomplete_shards:
+        shards = sorted(incomplete_shards, key=lambda status: status["shardIndex"])
+        listing = ", ".join(
+            f"shard {status['shardIndex']} (exit {status['exitCode']})" for status in shards
+        )
+        problems.append(
+            {
+                "kind": "IncompleteShards",
+                "tier": 0,
+                "severity": len(shards),
+                "impact": len(shards),
+                "title": f"{len(shards)} shard(s) did not complete",
+                "detail": (
+                    "A whole shard's tests are unaccounted for — the pass/fail of that "
+                    f"slice is unknown. {listing}."
+                ),
+            }
+        )
+
+    for signature, count in exception_signatures.most_common():
+        problems.append(
+            {
+                "kind": "Crash",
+                "tier": 1,
+                "severity": count,
+                "impact": count,
+                "title": f"Crash gating {count} test(s)",
+                "detail": signature,
+            }
+        )
+
+    # A test can appear once per shard at most, but dedupe defensively and keep
+    # the lowest match seen for each path.
+    lowest_by_path: dict[str, dict] = {}
+    for test in low_match_tests:
+        if test["matchPercent"] >= low_match_threshold:
+            continue
+        existing = lowest_by_path.get(test["relativeTestPath"])
+        if existing is None or test["matchPercent"] < existing["matchPercent"]:
+            lowest_by_path[test["relativeTestPath"]] = test
+    for test in lowest_by_path.values():
+        label = test["category"]
+        if test["subCategory"]:
+            label = f"{label} / {test['subCategory']}"
+        problems.append(
+            {
+                "kind": "LowMatch",
+                "tier": 2,
+                "severity": 100.0 - test["matchPercent"],
+                "impact": 1,
+                "matchPercent": test["matchPercent"],
+                "title": f"{test['matchPercent']:.1f}% match — {test['relativeTestPath']}",
+                "detail": (
+                    f"Rendered output matches the reference by only "
+                    f"{test['matchPercent']:.1f}% ({label})."
+                ),
+            }
+        )
+
+    # Lower tier first; within a tier the larger blast radius first; then a stable
+    # alphabetical tie-break on the title.
+    ordered = sorted(
+        problems, key=lambda problem: (problem["tier"], -problem["severity"], problem["title"])
+    )
+
+    # Diversity-first selection over the severity-ordered list: pass 1 takes the
+    # worst entry of each not-yet-seen kind; pass 2 fills any leftover slots with
+    # the next-worst overall. `ordered` is already globally sorted, so slicing the
+    # chosen indices back out in index order keeps the result severity-ranked.
+    selected_indices: list[int] = []
+    seen_kinds: set[str] = set()
+    for index, problem in enumerate(ordered):
+        if len(selected_indices) >= limit:
+            break
+        if problem["kind"] not in seen_kinds:
+            seen_kinds.add(problem["kind"])
+            selected_indices.append(index)
+    for index in range(len(ordered)):
+        if len(selected_indices) >= limit:
+            break
+        if index not in selected_indices:
+            selected_indices.append(index)
+
+    return [ordered[index] for index in sorted(selected_indices)]
+
+
+def merge(
+    shard_dir: Path,
+    problem_limit: int = DEFAULT_PROBLEM_LIMIT,
+    biggest_problem_limit: int = DEFAULT_BIGGEST_PROBLEM_LIMIT,
+    low_match_threshold: float = DEFAULT_LOW_MATCH_THRESHOLD,
+) -> dict:
     passed = failed = skipped = total = 0
     shard_count = 0
     failures: list[dict] = []
@@ -106,6 +246,7 @@ def merge(shard_dir: Path, problem_limit: int = DEFAULT_PROBLEM_LIMIT) -> dict:
     category_counter: Counter[str] = Counter()
     dropped_declaration_counter: Counter[str] = Counter()
     exception_signature_counter: Counter[str] = Counter()
+    low_match_tests: list[dict] = []
     problem_groups: dict[str, dict] = {}
     family_groups: dict[str, dict] = {}
     reported_shard_indexes: set[int] = set()
@@ -145,6 +286,26 @@ def merge(shard_dir: Path, problem_limit: int = DEFAULT_PROBLEM_LIMIT) -> dict:
                 signature = entry.get("signature")
                 if signature:
                     exception_signature_counter[str(signature)] += int(entry.get("count", 0) or 0)
+
+            # The worst-matching pixel comparisons this shard saw (already the N
+            # lowest by matchPercent). Feeds the "low percent match" biggest-problem
+            # entries — a near-0% match means the render is substantially wrong.
+            for entry in triage.get("lowestMatchTests", []) or []:
+                if not isinstance(entry, dict):
+                    continue
+                match_percent = entry.get("matchPercent")
+                relative_path = entry.get("testPath") or entry.get("relativeTestPath")
+                if relative_path is None or not isinstance(match_percent, (int, float)):
+                    continue
+                sub_category = entry.get("subCategory")
+                low_match_tests.append(
+                    {
+                        "relativeTestPath": str(relative_path),
+                        "matchPercent": float(match_percent),
+                        "category": str(entry.get("category") or "Unknown"),
+                        "subCategory": str(sub_category) if sub_category else None,
+                    }
+                )
 
         for result in report.get("results", []):
             if not isinstance(result, dict):
@@ -255,6 +416,14 @@ def merge(shard_dir: Path, problem_limit: int = DEFAULT_PROBLEM_LIMIT) -> dict:
         key=lambda group: (-group["count"], group["family"]),
     )[:problem_limit]
 
+    biggest_problems = _rank_biggest_problems(
+        incomplete_shards,
+        exception_signature_counter,
+        low_match_tests,
+        biggest_problem_limit,
+        low_match_threshold,
+    )
+
     return {
         "summary": {
             "passed": passed,
@@ -271,6 +440,9 @@ def merge(shard_dir: Path, problem_limit: int = DEFAULT_PROBLEM_LIMIT) -> dict:
         "droppedDeclarations": dropped_declaration_counter.most_common(problem_limit),
         "exceptionSignatures": exception_signature_counter.most_common(problem_limit),
         "failureFamilies": top_families,
+        "biggestProblemLimit": biggest_problem_limit,
+        "lowMatchThreshold": low_match_threshold,
+        "biggestProblems": biggest_problems,
         "results": failures,
     }
 
@@ -422,6 +594,50 @@ def render_issue_markdown(merged: dict, run_url: str | None) -> str:
     return "\n".join(lines) + "\n"
 
 
+def render_biggest_problems_markdown(merged: dict, run_url: str | None) -> str:
+    """Render the body of the second, severity-focused issue: the run's few
+    biggest problems ranked by blast radius (see ``_rank_biggest_problems``)."""
+    problems = merged.get("biggestProblems") or []
+    threshold = merged.get("lowMatchThreshold", DEFAULT_LOW_MATCH_THRESHOLD)
+    summary = merged["summary"]
+    lines = [
+        f"## WPT run — top {len(problems)} biggest problem(s)",
+        "",
+        "_The run's most severe issues, ranked by blast radius rather than"
+        " frequency: incomplete shards first (a whole slice went unmeasured), then"
+        " crashes (one bug gating many tests), then the worst pixel mismatches"
+        f" (< {threshold:g}% match). Companion to the most-common-failures issue._",
+        "",
+        f"- Failed: {summary['failed']}",
+        f"- Incomplete shards: {len(merged['incompleteShards'])}",
+        "",
+        "### Biggest problems",
+        "",
+    ]
+    if problems:
+        for index, problem in enumerate(problems, start=1):
+            lines.append(f"{index}. **{problem['title']}**")
+            if problem["kind"] == "Crash":
+                lines.append(f"   - Signature: `{problem['detail']}`")
+            elif problem.get("detail"):
+                lines.append(f"   - {problem['detail']}")
+    else:
+        lines.append(
+            "- None — no incomplete shards, crashes, or sub-threshold pixel matches."
+        )
+
+    lines += [
+        "",
+        "### CI metadata",
+        f"- Workflow run: {run_url}" if run_url else "- Workflow run: (unknown)",
+        "- Artifact: `wpt-merged`",
+        "",
+        "_Auto-generated by `.github/workflows/wpt-tests.yml`. See the companion"
+        " most-common-failures issue for the full frequency breakdown._",
+    ]
+    return "\n".join(lines) + "\n"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--shard-dir", required=True, type=Path, help="Directory containing per-shard JSON reports")
@@ -434,10 +650,29 @@ def main() -> int:
     )
     parser.add_argument("--issue-md", type=Path, help="Where to write the Markdown issue body")
     parser.add_argument(
+        "--biggest-issue-md",
+        type=Path,
+        help="Where to write the Markdown body for the second, biggest-problems issue",
+    )
+    parser.add_argument(
         "--problem-limit",
         type=int,
         default=DEFAULT_PROBLEM_LIMIT,
         help=f"Maximum common failure groups/directories to report (default: {DEFAULT_PROBLEM_LIMIT})",
+    )
+    parser.add_argument(
+        "--biggest-problem-limit",
+        type=int,
+        default=DEFAULT_BIGGEST_PROBLEM_LIMIT,
+        help="Maximum biggest problems to report in the second issue "
+        f"(default: {DEFAULT_BIGGEST_PROBLEM_LIMIT})",
+    )
+    parser.add_argument(
+        "--low-match-threshold",
+        type=float,
+        default=DEFAULT_LOW_MATCH_THRESHOLD,
+        help="A pixel match below this percent counts as a 'low percent match' big "
+        f"problem (default: {DEFAULT_LOW_MATCH_THRESHOLD:g})",
     )
     parser.add_argument("--run-url", default=os.environ.get("WPT_RUN_URL"), help="Workflow run URL for the issue footer")
     parser.add_argument("--github-output", type=Path, help="Path to $GITHUB_OUTPUT for step outputs")
@@ -445,8 +680,17 @@ def main() -> int:
 
     if args.problem_limit < 1:
         parser.error("--problem-limit must be a positive integer")
+    if args.biggest_problem_limit < 1:
+        parser.error("--biggest-problem-limit must be a positive integer")
+    if not 0 <= args.low_match_threshold <= 100:
+        parser.error("--low-match-threshold must be between 0 and 100")
 
-    merged = merge(args.shard_dir, args.problem_limit)
+    merged = merge(
+        args.shard_dir,
+        args.problem_limit,
+        args.biggest_problem_limit,
+        args.low_match_threshold,
+    )
 
     if args.merge_into:
         # Read the existing manifest before any write below (the same path may be
@@ -461,9 +705,16 @@ def main() -> int:
         args.issue_md.parent.mkdir(parents=True, exist_ok=True)
         args.issue_md.write_text(render_issue_markdown(merged, args.run_url), encoding="utf-8")
 
+    if args.biggest_issue_md:
+        args.biggest_issue_md.parent.mkdir(parents=True, exist_ok=True)
+        args.biggest_issue_md.write_text(
+            render_biggest_problems_markdown(merged, args.run_url), encoding="utf-8"
+        )
+
     failed = merged["summary"]["failed"]
     total = merged["summary"]["total"]
     incomplete_shard_count = len(merged["incompleteShards"])
+    biggest_problem_count = len(merged.get("biggestProblems") or [])
     print(f"Merged {merged['shardCount']} shard(s): {merged['summary']['passed']} passed, "
           f"{failed} failed, {merged['summary']['skipped']} skipped, {total} total.")
 
@@ -473,6 +724,8 @@ def main() -> int:
             handle.write(f"total_count={total}\n")
             handle.write(f"incomplete_shard_count={incomplete_shard_count}\n")
             handle.write(f"create_issue={'true' if failed > 0 or incomplete_shard_count > 0 else 'false'}\n")
+            handle.write(f"biggest_problem_count={biggest_problem_count}\n")
+            handle.write(f"create_biggest_issue={'true' if biggest_problem_count > 0 else 'false'}\n")
 
     return 0
 

--- a/scripts/tests/test_merge_wpt_shards.py
+++ b/scripts/tests/test_merge_wpt_shards.py
@@ -340,6 +340,248 @@ class MergeWptShardsTests(unittest.TestCase):
                 ["css/a/one.html"], [entry["relativeTestPath"] for entry in result["results"]]
             )
 
+    def test_ranks_biggest_problems_by_blast_radius(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            (shard_dir / "shard-0.json").write_text(
+                json.dumps(
+                    {
+                        "summary": {"passed": 5, "failed": 3, "skipped": 0, "total": 8},
+                        "shard": {"index": 0, "count": 8},
+                        "triage": {
+                            "exceptionSignatures": [{"signature": "Foo.Bar — boom", "count": 12}],
+                            "lowestMatchTests": [
+                                {
+                                    "testPath": "css/a/broken.html",
+                                    "matchPercent": 3.2,
+                                    "category": "PixelMismatch",
+                                    "subCategory": "MissingContent",
+                                },
+                                # A near-miss above the threshold: NOT a big problem.
+                                {
+                                    "testPath": "css/a/near.html",
+                                    "matchPercent": 88.0,
+                                    "category": "PixelMismatch",
+                                    "subCategory": "LayoutShift",
+                                },
+                            ],
+                        },
+                        "results": [
+                            self._failure("css/a/broken.html", "PixelMismatch", "MissingContent"),
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            # Shard 0 finished (with failures); shard 7 aborted before any report.
+            self._write_status(shard_dir, shard_index=0, exit_code=1)
+            self._write_status(shard_dir, shard_index=7, exit_code=134)
+
+            merged = MODULE.merge(
+                shard_dir, problem_limit=10, biggest_problem_limit=3, low_match_threshold=50.0
+            )
+
+            biggest = merged["biggestProblems"]
+            # Ranked by blast radius: incomplete shard, then crash, then worst match.
+            self.assertEqual(
+                ["IncompleteShards", "Crash", "LowMatch"], [p["kind"] for p in biggest]
+            )
+            self.assertEqual(12, biggest[1]["impact"])
+            low = [p for p in biggest if p["kind"] == "LowMatch"]
+            self.assertEqual(1, len(low))
+            self.assertEqual(3.2, low[0]["matchPercent"])
+            self.assertIn("css/a/broken.html", low[0]["title"])
+
+            markdown = MODULE.render_biggest_problems_markdown(merged, "https://example.test/run/1")
+            self.assertIn("top 3 biggest problem(s)", markdown)
+            self.assertIn("1 shard(s) did not complete", markdown)
+            self.assertIn("shard 7 (exit 134)", markdown)
+            self.assertIn("Crash gating 12 test(s)", markdown)
+            self.assertIn("Foo.Bar — boom", markdown)
+            self.assertIn("3.2% match — css/a/broken.html", markdown)
+            # The 88% near-miss is above threshold and never surfaces.
+            self.assertNotIn("near.html", markdown)
+
+    def test_biggest_problems_are_diversity_first(self) -> None:
+        # Three crashes plus one low match, limit 3: strict severity tiers would
+        # show three crashes and hide the low match. Diversity-first keeps the low
+        # match by spending only one slot on the (worst) crash before covering the
+        # other kind, then fills the last slot with the next crash.
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            (shard_dir / "shard-0.json").write_text(
+                json.dumps(
+                    {
+                        "summary": {"passed": 0, "failed": 4, "skipped": 0, "total": 4},
+                        "shard": {"index": 0, "count": 8},
+                        "triage": {
+                            "exceptionSignatures": [
+                                {"signature": "A.a — big", "count": 30},
+                                {"signature": "B.b — mid", "count": 20},
+                                {"signature": "C.c — small", "count": 6},
+                            ],
+                            "lowestMatchTests": [
+                                {
+                                    "testPath": "css/a/blank.html",
+                                    "matchPercent": 2.0,
+                                    "category": "PixelMismatch",
+                                    "subCategory": "MissingContent",
+                                }
+                            ],
+                        },
+                        "results": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            merged = MODULE.merge(shard_dir, biggest_problem_limit=3)
+
+            biggest = merged["biggestProblems"]
+            self.assertEqual(3, len(biggest))
+            kinds = [p["kind"] for p in biggest]
+            # The low match survives; the smallest (count-6) crash is what drops.
+            self.assertIn("LowMatch", kinds)
+            self.assertEqual([30, 20], [p["impact"] for p in biggest if p["kind"] == "Crash"])
+            # Result stays ordered by blast radius: crashes (tier 1) before the
+            # low match (tier 2).
+            self.assertEqual(["Crash", "Crash", "LowMatch"], kinds)
+
+    def test_biggest_problem_limit_bounds_the_list(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            (shard_dir / "shard-0.json").write_text(
+                json.dumps(
+                    {
+                        "summary": {"passed": 0, "failed": 3, "skipped": 0, "total": 3},
+                        "shard": {"index": 0, "count": 8},
+                        "triage": {
+                            "exceptionSignatures": [
+                                {"signature": "A.a — one", "count": 9},
+                                {"signature": "B.b — two", "count": 4},
+                                {"signature": "C.c — three", "count": 1},
+                            ],
+                        },
+                        "results": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            merged = MODULE.merge(shard_dir, biggest_problem_limit=2)
+
+            # Only the two biggest crashes survive the limit; the smallest drops.
+            self.assertEqual(2, len(merged["biggestProblems"]))
+            self.assertEqual([9, 4], [p["impact"] for p in merged["biggestProblems"]])
+
+    def test_cli_emits_biggest_issue_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            github_output = shard_dir / "github-output.txt"
+            biggest_md = shard_dir / "biggest.md"
+            (shard_dir / "shard-0.json").write_text(
+                json.dumps(
+                    {
+                        "summary": {"passed": 1, "failed": 1, "skipped": 0, "total": 2},
+                        "shard": {"index": 0, "count": 8},
+                        "triage": {
+                            "exceptionSignatures": [{"signature": "Crash.Here — kaput", "count": 7}]
+                        },
+                        "results": [self._failure("css/a/x.html", "ScriptError")],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--shard-dir",
+                    temp,
+                    "--biggest-issue-md",
+                    str(biggest_md),
+                    "--github-output",
+                    str(github_output),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            outputs = github_output.read_text(encoding="utf-8")
+            self.assertIn("create_biggest_issue=true", outputs)
+            self.assertIn("biggest_problem_count=1", outputs)
+            self.assertIn("Crash gating 7 test(s)", biggest_md.read_text(encoding="utf-8"))
+
+    def test_no_biggest_issue_when_only_near_miss_mismatches(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            github_output = shard_dir / "github-output.txt"
+            (shard_dir / "shard-0.json").write_text(
+                json.dumps(
+                    {
+                        "summary": {"passed": 1, "failed": 1, "skipped": 0, "total": 2},
+                        "shard": {"index": 0, "count": 8},
+                        "triage": {
+                            "lowestMatchTests": [
+                                {
+                                    "testPath": "css/a/x.html",
+                                    "matchPercent": 97.5,
+                                    "category": "PixelMismatch",
+                                    "subCategory": "LayoutShift",
+                                }
+                            ]
+                        },
+                        "results": [self._failure("css/a/x.html", "PixelMismatch", "LayoutShift")],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self._write_status(shard_dir, shard_index=0, exit_code=1)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--shard-dir",
+                    temp,
+                    "--github-output",
+                    str(github_output),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            outputs = github_output.read_text(encoding="utf-8")
+            # No crash, no incomplete shard, only a near-miss match → no second issue.
+            self.assertIn("create_biggest_issue=false", outputs)
+            self.assertIn("biggest_problem_count=0", outputs)
+            # The run still failed, so the primary (most-common) issue is still filed.
+            self.assertIn("create_issue=true", outputs)
+
+    def test_cli_rejects_out_of_range_low_match_threshold(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--shard-dir",
+                    temp,
+                    "--low-match-threshold",
+                    "150",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("--low-match-threshold must be between 0 and 100", result.stderr)
+
     def test_cli_rejects_non_positive_problem_limit(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             result = subprocess.run(


### PR DESCRIPTION
## What

Every failing WPT run already files **one** GitHub issue that ranks failure groups by **frequency** (`--issue-md`). This adds a **second issue** that ranks the run's few worst problems by **severity / blast radius**, so a maintainer sees the most urgent items at a glance instead of hunting through a frequency list where a crashed shard reads the same as any other line.

## Why

The frequency view buries the most severe items. "Big problem" here means the things that actually hurt a run: a crash, a near-blank render, or a shard that never finished. Those deserve their own focused, short list.

## How

**`scripts/merge-wpt-shards.py`** — new `_rank_biggest_problems()` builds a severity-ranked list from signals the runner already emits, across three tiers:

1. **Incomplete shards** (tier 0) — a shard that never finished leaves a whole slice unmeasured. Sourced from the per-shard `*-status.json` non-zero exits (same signal as the existing `ShardProcessError` group).
2. **Crashes** (tier 1) — one entry per `triage.exceptionSignatures`, ordered by how many tests the throw gated.
3. **Low percent matches** (tier 2) — one entry per `triage.lowestMatchTests` below `--low-match-threshold` (default 50%). The pass bar is 99%, so anything this low is a gross render error, not a near-miss.

Selection is **diversity-first**: the worst entry of each distinct kind is taken before a second slot is spent on a kind already shown, so the default top 3 spans *incomplete shard + crash + low match* when all three exist rather than three crashes crowding out a near-blank render. The list still displays ordered by severity.

New CLI flags: `--biggest-issue-md`, `--biggest-problem-limit` (default 3), `--low-match-threshold`. New step outputs: `create_biggest_issue`, `biggest_problem_count`.

**`.github/workflows/wpt-tests.yml`** — the merge step also writes `biggest-issue.md`; a new `github-script` step files the second issue, gated on `create_biggest_issue`. A run whose only failures are near-miss mismatches files the primary issue but **not** this one, so green/marginal runs aren't spammed. New workflow input `biggest_problems_limit` (default `3`).

### Sample second issue

```
## WPT run — top 3 biggest problem(s)
1. **1 shard(s) did not complete** — shard 5 (exit 139).
2. **Crash gating 23 test(s)** — Signature: `DomName..ctor — A prefixed name requires a namespace URI`
3. **1.8% match — css/css-grid/grid-items-broken.html** — matches the reference by only 1.8% (PixelMismatch / MissingContent).
```

## Reviewer notes

- **Two decisions worth a look**: incomplete shards are ranked highest (unknown coverage is the most urgent thing to flag), and the low-match threshold is 50%. Both are one-line changes if you'd prefer different weighting.
- Both issue-creation steps share `secrets.ISSUE_TOKEN || github.token`, matching the existing step.
- No behavior change to the primary issue, the merged manifest, or the incremental-rerun path.

## Testing

6 new tests in `scripts/tests/test_merge_wpt_shards.py` (ranking, diversity-first, limit bounding, CLI outputs, the "no second issue on near-misses" case, threshold validation). Full suite: **15/15 pass**. YAML validated, script compiles, end-to-end smoke render confirmed. Documented as catalog entry #15 in `docs/roadmap/wpt-triage-and-diagnostics.md`.
