### PR TITLE
WPT #1181: honor author ::backdrop geometry + position-try fallback

### DIFF
--- a/src/Broiler.Cli.Tests/ScriptEngineExecuteTests.cs
+++ b/src/Broiler.Cli.Tests/ScriptEngineExecuteTests.cs
@@ -1141,6 +1141,51 @@ document.getElementById('out').appendChild(p);
     }
 
     [Fact]
+    public void DomBridge_Backdrop_Honors_Author_Geometry_And_PositionTry_Fallback()
+    {
+        // Regression (css-anchor-position position-try-backdrop): a modal
+        // dialog's ::backdrop with an explicit size and an overflowing inset
+        // must not be materialised as a viewport-covering box. Author geometry
+        // is honoured (100x100) and position-try-fallbacks moves the
+        // overflowing backdrop into view (left:9999px -> left:300px), instead
+        // of painting the whole viewport seagreen (which scored 0.5% on CI).
+        const string html = """
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  @position-try --pt { left: 300px; }
+  dialog::backdrop {
+    background: seagreen;
+    width: 100px;
+    height: 100px;
+    left: 9999px;
+    position-try-fallbacks: --pt;
+  }
+</style>
+</head>
+<body>
+  <dialog id="dialog">Dialog</dialog>
+</body>
+</html>
+""";
+
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///test.html");
+        context.Eval("document.getElementById('dialog').showModal();");
+        bridge.ResolveAnchorPositions();
+
+        var result = bridge.SerializeToHtml();
+
+        // position-try moved the overflowing backdrop from 9999px to 300px.
+        Assert.Contains("left: 300px", result);
+        // The backdrop honours its author 100x100 size and is NOT a
+        // full-viewport box (default viewport height is 768px).
+        Assert.DoesNotContain("768px", result);
+    }
+
+    [Fact]
     public void DomBridge_SerializeToHtml_Preserves_Mutated_Iframe_Scroll_State_In_SrcDoc()
     {
         const string html = """

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -94,7 +94,9 @@ public sealed partial class DomBridge
         }
 
         // 4. Insert backdrop elements for modal dialogs.
-        InsertDialogBackdrops(DocumentElement, viewportWidth, viewportHeight);
+        InsertDialogBackdrops(
+            DocumentElement, viewportWidth, viewportHeight,
+            anchorRegistry, positionTryRules);
 
         // 5. Ensure fixed-position elements from CSS have explicit pixel
         //    dimensions (the Broiler renderer does not resolve width/height

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
@@ -47,7 +47,10 @@ public sealed partial class DomBridge
     // Dialog backdrop insertion
     // -----------------------------------------------------------------
 
-    private void InsertDialogBackdrops(DomElement root, int vpW, int vpH)
+    private void InsertDialogBackdrops(
+        DomElement root, int vpW, int vpH,
+        Dictionary<string, AnchorInfo> anchorRegistry,
+        Dictionary<string, Dictionary<string, string>> positionTryRules)
     {
         var modals = new List<(DomElement dialog, DomElement parent)>();
         FindModalDialogs(root, modals);
@@ -62,6 +65,10 @@ public sealed partial class DomBridge
             // Insert a backdrop div BEFORE the dialog.
             // Use 'position: fixed' with explicit pixel viewport dimensions
             // because the Broiler renderer cannot resolve opposing insets.
+            // These viewport-covering defaults materialise the ::backdrop UA
+            // style (position:fixed; inset:0); any author-declared geometry
+            // overlaid below overrides them, so an explicitly sized/positioned
+            // backdrop is honoured instead of always filling the viewport.
             var backdropStyle = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 ["position"] = "fixed",
@@ -72,6 +79,10 @@ public sealed partial class DomBridge
                 ["background-color"] = backdropBg,
             };
 
+            var backdropDecls = GetSyncedScopedEngine(dialog)
+                .GetCascadedDeclaredValues(dialog, "::backdrop");
+            OverlayBackdropAuthorGeometry(backdropDecls, backdropStyle);
+
             var backdrop = new DomElement(
                 "div", null, null, string.Empty,
                 style: backdropStyle);
@@ -80,6 +91,16 @@ public sealed partial class DomBridge
             int idx = parent.Children.IndexOf(dialog);
             if (idx >= 0)
                 parent.Children.Insert(idx, backdrop);
+
+            // If the ::backdrop declares position-try-fallbacks and its base
+            // geometry overflows the containing block, resolve the fallback
+            // now: the main position-try pass (ResolvePositionTryFallbacks) ran
+            // before this backdrop div existed, so it never saw it.
+            if (backdropStyle.ContainsKey("position-try-fallbacks") ||
+                backdropStyle.ContainsKey("position-try"))
+            {
+                ResolvePositionTryFallbacksTree(backdrop, anchorRegistry, positionTryRules);
+            }
 
             // Ensure the dialog has UA default styles.
             // Check both inline styles and CSS rules before applying defaults.
@@ -104,6 +125,46 @@ public sealed partial class DomBridge
                 dialog.Style["background-color"] = "white";
         }
     }
+    /// <summary>
+    /// Property names on a <c>::backdrop</c> rule that control the backdrop's
+    /// geometry and fallback positioning. When the author declares any of
+    /// these they override the viewport-covering defaults so an explicitly
+    /// sized or positioned backdrop is honoured (e.g. WPT
+    /// <c>position-try-backdrop.html</c>, where the backdrop is a 100×100 box
+    /// moved by <c>position-try-fallbacks</c>).
+    /// </summary>
+    private static readonly string[] BackdropGeometryProps =
+    {
+        "width", "height", "left", "right", "top", "bottom",
+        "position", "position-anchor", "position-try-fallbacks", "position-try",
+    };
+
+    /// <summary>
+    /// Overlays author-declared <c>::backdrop</c> geometry / fallback
+    /// properties onto the synthesized backdrop div's style, replacing the
+    /// viewport-covering defaults where the author was explicit.
+    /// </summary>
+    private static void OverlayBackdropAuthorGeometry(
+        IReadOnlyDictionary<string, string> declarations,
+        Dictionary<string, string> backdropStyle)
+    {
+        foreach (var prop in BackdropGeometryProps)
+        {
+            if (declarations.TryGetValue(prop, out var value) &&
+                !string.IsNullOrWhiteSpace(value))
+                backdropStyle[prop] = value.Trim();
+        }
+
+        // The default fills the viewport with top:0/left:0 + width/height. If
+        // the author positions the backdrop from the opposite edge only, drop
+        // the conflicting default inset so the box is not over-constrained
+        // (the renderer cannot resolve opposing left+right / top+bottom insets).
+        if (declarations.ContainsKey("right") && !declarations.ContainsKey("left"))
+            backdropStyle.Remove("left");
+        if (declarations.ContainsKey("bottom") && !declarations.ContainsKey("top"))
+            backdropStyle.Remove("top");
+    }
+
     /// <summary>
     /// Determines the background color for a dialog's <c>::backdrop</c>
     /// pseudo-element by checking CSS rules for <c>::backdrop</c> selectors


### PR DESCRIPTION
## Problem

WPT issue #1181 ranked `css/css-anchor-position/position-try-backdrop.html` as the run's #1 biggest problem — **0.5% pixel match** (PixelMismatch / MissingContent).

The test gives a modal dialog's `::backdrop` an explicit size and an overflowing inset, then relies on `position-try-fallbacks` to bring it back on-screen:

```css
@position-try --pt { left: 300px; }
dialog::backdrop {
  background: seagreen;
  width: 100px; height: 100px;
  left: 9999px;                    /* force overflow */
  position-try-fallbacks: --pt;
}
```

`DomBridge.InsertDialogBackdrops` synthesized the `::backdrop` as a **viewport-covering** div (`top:0; left:0; width:vpW; height:vpH`), taking only the background colour from the rule and ignoring the author's `width`/`height`/`left`/`position-try-fallbacks`. Result: Broiler painted the **entire viewport seagreen**, while Chromium's reference is mostly white with a single 100×100 seagreen box at (300,0) → 0.5% match.

## Fix (main-repo; ships on CI)

- **`OverlayBackdropAuthorGeometry`** overlays author-declared `::backdrop` geometry (width/height/left/right/top/bottom/position/position-anchor/position-try-fallbacks) onto the synthesized div, keeping the viewport-covering defaults only where the author was not explicit. It drops the conflicting default inset when the author positions from the opposite edge only.
- Backdrop insertion runs *after* the main position-try pass, so the new div was never seen by it. `InsertDialogBackdrops` now receives the anchor registry + `@position-try` rules and runs the overflowing backdrop through `ResolvePositionTryFallbacksTree`, so `left:9999px` → fallback `--pt` → `left:300px`.

Render before → after: whole viewport seagreen → white background, coral `#anchor` box at (150,50), seagreen backdrop 100×100 at (300,0). The one residual (modal `<dialog>` painted top-left instead of Chromium-centered) is a small, separate pre-existing gap that also affects the already-passing `anchor-position-top-layer-*` tests, and is left untouched.

## Testing

- New guard: `ScriptEngineExecuteTests.DomBridge_Backdrop_Honors_Author_Geometry_And_PositionTry_Fallback`.
- Local `css/css-anchor-position` subset (CI-parity `--defer-promise-tests`): **no regression** — 30 pass / 9 fail / 2 skip; the 9 failures are the known deep feature tail, and all six `anchor-position-top-layer-*`/dialog tests still pass.
- Anchor/dialog/position-try C# suites green.

The second-ranked problem in #1181 (`anchor-scroll-to-sticky-005.html`, 14.7% ColorShift) is the known sticky-pinning paint gap (`ScrollSimulation` shifts `position:sticky` children like normal flow rather than pinning them) — deep and unbounded, left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)