### PR TITLE
WPT biggest-problems: point crashes at a repro + fix the two enumeration crashes

### DIFF
--- a/scripts/merge-wpt-shards.py
+++ b/scripts/merge-wpt-shards.py
@@ -14,8 +14,10 @@ own ``wpt-results.json``. This script combines those shard reports to produce:
 * ``--biggest-issue-md`` — a Markdown body for a *second*, severity-focused
   issue that lists only the run's few biggest problems, ranked by blast radius:
   incomplete shards first (a whole slice went unmeasured), then crashes (one bug
-  gating many tests), then the worst pixel mismatches. This is the "what hurt
-  most this run" companion to the frequency-ranked ``--issue-md`` view.
+  gating many tests), then the worst pixel mismatches. Each crash names an example
+  gated test and the issue spells out the ``--render`` command to reproduce a
+  listed test, so every entry points at its cause. This is the "what hurt most
+  this run" companion to the frequency-ranked ``--issue-md`` view.
 
 When ``--merge-into`` names an existing manifest, the run's failures are folded
 into it *by scope* instead of replacing it: entries for tests this run actually
@@ -42,6 +44,12 @@ from pathlib import Path
 
 DEFAULT_PROBLEM_LIMIT = 10
 PROBLEM_EXAMPLE_LIMIT = 3
+
+# Where the CI workflow checks out WPT (see .github/workflows/wpt-tests.yml
+# WPT_CHECKOUT_DIR and scripts/run-wpt-tests.sh). Test paths in the reports are
+# relative to it, so the biggest-problems issue can spell out a ready-to-run
+# ``--render`` reproduction: <checkout>/<relative-path>.
+WPT_CHECKOUT_DIR = "tests/wpt/checkout"
 
 # The second, severity-focused issue reports at most this many of the run's
 # biggest problems.
@@ -115,6 +123,7 @@ def _problem_identity(result: dict) -> tuple[str, str, str | None]:
 def _rank_biggest_problems(
     incomplete_shards: list[dict],
     exception_signatures: Counter[str],
+    exception_examples: dict[str, list[str]],
     low_match_tests: list[dict],
     limit: int,
     low_match_threshold: float,
@@ -174,6 +183,10 @@ def _rank_biggest_problems(
                 "impact": count,
                 "title": f"Crash gating {count} test(s)",
                 "detail": signature,
+                # Example tests that hit this crash — the reproduction the report
+                # points at. May be empty for reports produced before examples
+                # were emitted.
+                "examples": list(exception_examples.get(signature, [])),
             }
         )
 
@@ -197,6 +210,7 @@ def _rank_biggest_problems(
                 "severity": 100.0 - test["matchPercent"],
                 "impact": 1,
                 "matchPercent": test["matchPercent"],
+                "relativeTestPath": test["relativeTestPath"],
                 "title": f"{test['matchPercent']:.1f}% match — {test['relativeTestPath']}",
                 "detail": (
                     f"Rendered output matches the reference by only "
@@ -246,6 +260,7 @@ def merge(
     category_counter: Counter[str] = Counter()
     dropped_declaration_counter: Counter[str] = Counter()
     exception_signature_counter: Counter[str] = Counter()
+    exception_examples: dict[str, list[str]] = {}
     low_match_tests: list[dict] = []
     problem_groups: dict[str, dict] = {}
     family_groups: dict[str, dict] = {}
@@ -285,7 +300,16 @@ def merge(
                     continue
                 signature = entry.get("signature")
                 if signature:
-                    exception_signature_counter[str(signature)] += int(entry.get("count", 0) or 0)
+                    signature = str(signature)
+                    exception_signature_counter[signature] += int(entry.get("count", 0) or 0)
+                    # Union the example test paths this signature gated across
+                    # shards (bounded, deduped) so the biggest-problems issue can
+                    # name a concrete test to --render for the crash.
+                    examples = exception_examples.setdefault(signature, [])
+                    for example in entry.get("examples", []) or []:
+                        example = str(example)
+                        if example not in examples and len(examples) < PROBLEM_EXAMPLE_LIMIT:
+                            examples.append(example)
 
             # The worst-matching pixel comparisons this shard saw (already the N
             # lowest by matchPercent). Feeds the "low percent match" biggest-problem
@@ -419,6 +443,7 @@ def merge(
     biggest_problems = _rank_biggest_problems(
         incomplete_shards,
         exception_signature_counter,
+        exception_examples,
         low_match_tests,
         biggest_problem_limit,
         low_match_threshold,
@@ -614,17 +639,45 @@ def render_biggest_problems_markdown(merged: dict, run_url: str | None) -> str:
         "### Biggest problems",
         "",
     ]
+    # Concrete test paths a maintainer can render to reproduce, in report order:
+    # a crash's example test(s), a low match's own path. Feeds the reproduce hint.
+    repro_paths: list[str] = []
     if problems:
         for index, problem in enumerate(problems, start=1):
             lines.append(f"{index}. **{problem['title']}**")
             if problem["kind"] == "Crash":
                 lines.append(f"   - Signature: `{problem['detail']}`")
+                examples = problem.get("examples") or []
+                if examples:
+                    rendered = ", ".join(f"`{path}`" for path in examples)
+                    lines.append(f"   - Example test(s): {rendered}")
+                    repro_paths.extend(examples)
             elif problem.get("detail"):
                 lines.append(f"   - {problem['detail']}")
+                if problem["kind"] == "LowMatch" and problem.get("relativeTestPath"):
+                    repro_paths.append(problem["relativeTestPath"])
     else:
         lines.append(
             "- None — no incomplete shards, crashes, or sub-threshold pixel matches."
         )
+
+    # Point at the fix: spell out the exact command to render a listed test against
+    # the live engine. Only when a listed problem has a concrete test path — an
+    # incomplete-shard-only run has nothing single-test to render.
+    if repro_paths:
+        first = repro_paths[0]
+        lines += [
+            "",
+            "### Reproduce locally",
+            "",
+            "_Render a listed test against the live engine to watch the failure happen"
+            " — e.g. the first one. Swap in any `Example test(s)` path above._",
+            "",
+            "```sh",
+            "dotnet run --project src/Broiler.Wpt -- \\",
+            f"  --wpt-dir {WPT_CHECKOUT_DIR} --render {WPT_CHECKOUT_DIR}/{first}",
+            "```",
+        ]
 
     lines += [
         "",

--- a/scripts/tests/test_merge_wpt_shards.py
+++ b/scripts/tests/test_merge_wpt_shards.py
@@ -349,7 +349,13 @@ class MergeWptShardsTests(unittest.TestCase):
                         "summary": {"passed": 5, "failed": 3, "skipped": 0, "total": 8},
                         "shard": {"index": 0, "count": 8},
                         "triage": {
-                            "exceptionSignatures": [{"signature": "Foo.Bar — boom", "count": 12}],
+                            "exceptionSignatures": [
+                                {
+                                    "signature": "Foo.Bar — boom",
+                                    "count": 12,
+                                    "examples": ["css/a/crash.html"],
+                                }
+                            ],
                             "lowestMatchTests": [
                                 {
                                     "testPath": "css/a/broken.html",
@@ -387,6 +393,8 @@ class MergeWptShardsTests(unittest.TestCase):
                 ["IncompleteShards", "Crash", "LowMatch"], [p["kind"] for p in biggest]
             )
             self.assertEqual(12, biggest[1]["impact"])
+            # The crash carries the example test that hit it.
+            self.assertEqual(["css/a/crash.html"], biggest[1]["examples"])
             low = [p for p in biggest if p["kind"] == "LowMatch"]
             self.assertEqual(1, len(low))
             self.assertEqual(3.2, low[0]["matchPercent"])
@@ -399,8 +407,70 @@ class MergeWptShardsTests(unittest.TestCase):
             self.assertIn("Crash gating 12 test(s)", markdown)
             self.assertIn("Foo.Bar — boom", markdown)
             self.assertIn("3.2% match — css/a/broken.html", markdown)
+            # The crash names an example test and the report spells out a --render
+            # reproduction pointed at the first reproducible test (the crash's).
+            self.assertIn("Example test(s): `css/a/crash.html`", markdown)
+            self.assertIn("### Reproduce locally", markdown)
+            self.assertIn(
+                "--wpt-dir tests/wpt/checkout --render tests/wpt/checkout/css/a/crash.html",
+                markdown,
+            )
             # The 88% near-miss is above threshold and never surfaces.
             self.assertNotIn("near.html", markdown)
+
+    def test_crash_examples_union_across_shards_deduped_and_capped(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            # The same signature crashes in two shards, each reporting different
+            # example paths; one path overlaps.
+            (shard_dir / "shard-0.json").write_text(
+                json.dumps(
+                    {
+                        "summary": {"passed": 0, "failed": 3, "skipped": 0, "total": 3},
+                        "shard": {"index": 0, "count": 8},
+                        "triage": {
+                            "exceptionSignatures": [
+                                {
+                                    "signature": "Same.Sig — boom",
+                                    "count": 2,
+                                    "examples": ["css/a/one.html", "css/a/two.html"],
+                                }
+                            ]
+                        },
+                        "results": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (shard_dir / "shard-1.json").write_text(
+                json.dumps(
+                    {
+                        "summary": {"passed": 0, "failed": 3, "skipped": 0, "total": 3},
+                        "shard": {"index": 1, "count": 8},
+                        "triage": {
+                            "exceptionSignatures": [
+                                {
+                                    "signature": "Same.Sig — boom",
+                                    "count": 3,
+                                    # two.html repeats (dedup); three/four push past cap.
+                                    "examples": ["css/a/two.html", "css/a/three.html", "css/a/four.html"],
+                                }
+                            ]
+                        },
+                        "results": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            merged = MODULE.merge(shard_dir, biggest_problem_limit=3)
+
+            crash = next(p for p in merged["biggestProblems"] if p["kind"] == "Crash")
+            self.assertEqual(5, crash["impact"])
+            # Union across shards, deduped, in first-seen order, capped at 3.
+            self.assertEqual(
+                ["css/a/one.html", "css/a/two.html", "css/a/three.html"], crash["examples"]
+            )
 
     def test_biggest_problems_are_diversity_first(self) -> None:
         # Three crashes plus one low match, limit 3: strict severity tiers would

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
@@ -151,7 +151,13 @@ public sealed partial class DomBridge
                 animValue, delayValue, nameValue);
         }
 
-        foreach (var child in element.Children)
+        // Snapshot before recursing: resolving an animation writes inline styles
+        // and can restructure the subtree (e.g. materialising generated content),
+        // and the walk can also race concurrent DOM mutation. Enumerating the live
+        // element.Children then throws "Collection was modified" (crash signature
+        // DomBridge.ResolveAnimationsOnTree). SnapshotChildren guards both, as the
+        // other DomBridge tree walks do.
+        foreach (var child in SnapshotChildren(element))
             ResolveAnimationsOnTree(child, keyframesMap);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -85,7 +85,13 @@ public sealed partial class DomBridge
     /// </summary>
     private void FireDescendantOnloads(DomElement element)
     {
-        foreach (var child in element.Children)
+        // Snapshot before iterating: FireSubDocumentOnload runs a sub-document's
+        // onload handler, whose script can structurally mutate element.Children
+        // mid-walk (append/remove nodes). Enumerating the live collection then
+        // throws "Collection was modified" (crash signature
+        // DomBridge.FireDescendantOnloads). SnapshotChildren also tolerates a
+        // concurrent structural race, like the other DomBridge tree walks.
+        foreach (var child in SnapshotChildren(element))
         {
             var childTag = child.TagName?.ToLowerInvariant();
             if (childTag == "iframe" || childTag == "object")

--- a/src/Broiler.Wpt.Tests/ExceptionSignatureTests.cs
+++ b/src/Broiler.Wpt.Tests/ExceptionSignatureTests.cs
@@ -58,9 +58,9 @@ public sealed class ExceptionSignatureTests
 
         var failures = new[]
         {
-            Failure(FailureCategory.ScriptError, "Script execution failed: bad name", crash),
-            Failure(FailureCategory.ScriptError, "Script execution failed: bad name", crash),
-            Failure(FailureCategory.RenderingError, "Rendering failed: overflow", other),
+            Failure(FailureCategory.ScriptError, "Script execution failed: bad name", crash, "/tmp/wpt/a.html"),
+            Failure(FailureCategory.ScriptError, "Script execution failed: bad name", crash, "/tmp/wpt/b.html"),
+            Failure(FailureCategory.RenderingError, "Rendering failed: overflow", other, "/tmp/wpt/c.html"),
             // No stack trace → excluded (e.g. a pixel mismatch).
             Failure(FailureCategory.PixelMismatch, "mismatch", null),
             // Timeout → excluded (reported in the timeout section).
@@ -72,8 +72,33 @@ public sealed class ExceptionSignatureTests
         Assert.Equal(2, buckets.Count);
         Assert.Equal("DomName..ctor — bad name", buckets[0].Signature);
         Assert.Equal(2, buckets[0].Count);
+        // Each signature carries the test paths that hit it, for reproduction.
+        Assert.Equal(new[] { "/tmp/wpt/a.html", "/tmp/wpt/b.html" }, buckets[0].Examples);
         Assert.Equal("CssBox.Measure — overflow", buckets[1].Signature);
         Assert.Equal(1, buckets[1].Count);
+        Assert.Equal(new[] { "/tmp/wpt/c.html" }, buckets[1].Examples);
+    }
+
+    [Fact]
+    public void Buckets_Collects_Distinct_Example_Paths_Up_To_A_Cap()
+    {
+        const string trace = "   at Broiler.DOM.DomName..ctor(String name)";
+        var failures = new[]
+        {
+            Failure(FailureCategory.ScriptError, "boom", trace, "/tmp/wpt/one.html"),
+            // Same path repeats — must not be listed twice.
+            Failure(FailureCategory.ScriptError, "boom", trace, "/tmp/wpt/one.html"),
+            Failure(FailureCategory.ScriptError, "boom", trace, "/tmp/wpt/two.html"),
+            Failure(FailureCategory.ScriptError, "boom", trace, "/tmp/wpt/three.html"),
+            // Beyond the 3-example cap — counted, but not retained as an example.
+            Failure(FailureCategory.ScriptError, "boom", trace, "/tmp/wpt/four.html"),
+        };
+
+        var bucket = Assert.Single(ExceptionSignature.Buckets(failures, limit: 10));
+        Assert.Equal(5, bucket.Count);
+        Assert.Equal(
+            new[] { "/tmp/wpt/one.html", "/tmp/wpt/two.html", "/tmp/wpt/three.html" },
+            bucket.Examples);
     }
 
     [Fact]
@@ -88,10 +113,12 @@ public sealed class ExceptionSignatureTests
         Assert.Single(ExceptionSignature.Buckets(failures, limit: 1));
     }
 
-    private static WptTestResult Failure(FailureCategory category, string message, string? stackTrace) =>
+    private static WptTestResult Failure(
+        FailureCategory category, string message, string? stackTrace,
+        string testPath = "/tmp/wpt/test.html") =>
         new()
         {
-            TestPath = "/tmp/wpt/test.html",
+            TestPath = testPath,
             Passed = false,
             Category = category,
             Message = message,

--- a/src/Broiler.Wpt/ExceptionSignature.cs
+++ b/src/Broiler.Wpt/ExceptionSignature.cs
@@ -17,6 +17,11 @@ internal static class ExceptionSignature
 {
     private const int MaxMessageLength = 100;
 
+    // At most this many example test paths are kept per signature — enough to
+    // point a maintainer at a concrete reproduction without listing every gated
+    // test (one signature → one fix).
+    private const int MaxExamplesPerSignature = 3;
+
     // Stage prefixes the runner prepends to ex.Message at its catch sites. Stripped
     // so the signature keys on the underlying error rather than the pipeline stage
     // (which the failure category already records).
@@ -46,15 +51,16 @@ internal static class ExceptionSignature
     }
 
     /// <summary>
-    /// Groups exception-bearing failures by signature, most frequent first.
-    /// Only failures that carry a stack trace are bucketed (pixel mismatches and
-    /// other non-exception failures are excluded); timeouts are excluded too because
-    /// their synthetic trace is reported in the dedicated timeout section.
+    /// Groups exception-bearing failures by signature, most frequent first, each
+    /// carrying a few example test paths that hit it. Only failures that carry a
+    /// stack trace are bucketed (pixel mismatches and other non-exception failures
+    /// are excluded); timeouts are excluded too because their synthetic trace is
+    /// reported in the dedicated timeout section.
     /// </summary>
-    public static IReadOnlyList<(string Signature, int Count)> Buckets(
+    public static IReadOnlyList<ExceptionBucket> Buckets(
         IEnumerable<WptTestResult> failures, int limit)
     {
-        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var buckets = new Dictionary<string, Accumulator>(StringComparer.Ordinal);
         foreach (var result in failures)
         {
             if (result.StackTrace is null || result.Category == FailureCategory.Timeout)
@@ -62,15 +68,33 @@ internal static class ExceptionSignature
             var signature = TryCompute(result.Message, result.StackTrace);
             if (signature is null)
                 continue;
-            counts[signature] = counts.GetValueOrDefault(signature) + 1;
+            if (!buckets.TryGetValue(signature, out var accumulator))
+            {
+                accumulator = new Accumulator();
+                buckets[signature] = accumulator;
+            }
+            accumulator.Count++;
+            // Keep the first few distinct paths so the report can name which test
+            // to --render to hit this crash.
+            if (accumulator.Examples.Count < MaxExamplesPerSignature &&
+                !accumulator.Examples.Contains(result.TestPath))
+            {
+                accumulator.Examples.Add(result.TestPath);
+            }
         }
 
-        return counts
-            .OrderByDescending(kv => kv.Value)
+        return buckets
+            .OrderByDescending(kv => kv.Value.Count)
             .ThenBy(kv => kv.Key, StringComparer.Ordinal)
             .Take(limit)
-            .Select(kv => (kv.Key, kv.Value))
+            .Select(kv => new ExceptionBucket(kv.Key, kv.Value.Count, kv.Value.Examples))
             .ToList();
+    }
+
+    private sealed class Accumulator
+    {
+        public int Count;
+        public List<string> Examples { get; } = new();
     }
 
     private static string? NormalizeMessage(string? message)
@@ -192,3 +216,10 @@ internal static class ExceptionSignature
         return builder.ToString();
     }
 }
+
+/// <summary>
+/// One exception-signature group: the <paramref name="Signature"/>, how many
+/// failures share it (<paramref name="Count"/>), and a few example test paths that
+/// hit it (<paramref name="Examples"/>) so a report can point at a reproduction.
+/// </summary>
+public sealed record ExceptionBucket(string Signature, int Count, IReadOnlyList<string> Examples);

--- a/src/Broiler.Wpt/Program.cs
+++ b/src/Broiler.Wpt/Program.cs
@@ -677,7 +677,7 @@ public class Program
         int shardCount = 1,
         int shardIndex = WptTestRunner.AllShards,
         IReadOnlyList<(string Declaration, int Count)>? droppedDeclarations = null,
-        IReadOnlyList<(string Signature, int Count)>? exceptionSignatures = null)
+        IReadOnlyList<ExceptionBucket>? exceptionSignatures = null)
     {
         var dir = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(dir))
@@ -760,6 +760,13 @@ public class Program
                     {
                         ["signature"] = s.Signature,
                         ["count"] = s.Count,
+                        // Example test paths that hit this signature, relativised like
+                        // lowestMatchTests, so the biggest-problems issue can point
+                        // straight at a reproduction (aggregated across shards by
+                        // scripts/merge-wpt-shards.py).
+                        ["examples"] = s.Examples
+                            .Select(p => Path.GetRelativePath(wptPath, p).Replace('\\', '/'))
+                            .ToList(),
                     })
                     .ToList(),
                 // First-class manual / tentative / crashtest buckets with their
@@ -823,7 +830,7 @@ public class Program
         string wptPath,
         string? subset,
         IReadOnlyList<(string Declaration, int Count)>? droppedDeclarations = null,
-        IReadOnlyList<(string Signature, int Count)>? exceptionSignatures = null)
+        IReadOnlyList<ExceptionBucket>? exceptionSignatures = null)
     {
         var dir = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(dir))
@@ -951,7 +958,7 @@ public class Program
     }
 
     private static void PrintExceptionSignatures(
-        IReadOnlyList<(string Signature, int Count)> signatures)
+        IReadOnlyList<ExceptionBucket> signatures)
     {
         if (signatures.Count == 0)
             return;
@@ -959,12 +966,12 @@ public class Program
         Console.WriteLine();
         Console.WriteLine($"=== Exception signatures (top {signatures.Count}) ===");
         Console.WriteLine("(exception failures grouped by top frame + message — one signature often gates many tests)");
-        foreach (var (signature, count) in signatures)
-            Console.WriteLine($"  {count,6}  {signature}");
+        foreach (var bucket in signatures)
+            Console.WriteLine($"  {bucket.Count,6}  {bucket.Signature}");
     }
 
     private static void WriteExceptionSignaturesSection(
-        TextWriter writer, IReadOnlyList<(string Signature, int Count)>? signatures)
+        TextWriter writer, IReadOnlyList<ExceptionBucket>? signatures)
     {
         if (signatures is null || signatures.Count == 0)
             return;
@@ -975,8 +982,8 @@ public class Program
         writer.WriteLine("Exception failures grouped by top non-framework frame and message. A high");
         writer.WriteLine("count usually means one crash gates many tests (one signature → one fix).");
         writer.WriteLine();
-        foreach (var (signature, count) in signatures)
-            writer.WriteLine($"- `{signature}` — {count} failure(s)");
+        foreach (var bucket in signatures)
+            writer.WriteLine($"- `{bucket.Signature}` — {bucket.Count} failure(s)");
     }
 
     private static void PrintLayoutAssertionFailures(WptTestResult result, string indent)


### PR DESCRIPTION
## What

Two related changes to the WPT severity pipeline:

1. **Report enrichment** — the auto-generated **biggest-problems** issue now names an example gated test for each crash and spells out a ready-to-run `--render` reproduction. Continues the report-generator lineage (`shard the suite` → `surface dropped declarations` → `make every failure point at its cause` → `file a second "biggest problems" issue`); that last commit added the second report in a thin form, this brings it to the same "point at its cause" quality as the most-common-failures report.
2. **Crash fixes** — fixes the two crashes that report surfaced in [#1186](https://github.com/Broiler-Platform/Broiler/issues/1186).

## Why

In the biggest-problems issue, each **Crash** entry gave a signature and a gated-test count but never said *which test triggers it*, so a maintainer couldn't jump to a repro. And the two crashes it flagged were live-collection enumeration bugs worth fixing outright.

## Changes

### Report: crashes point at a reproduction

**`Broiler.Wpt` (C#)**
- `ExceptionSignature.Buckets` now returns `ExceptionBucket` records `(Signature, Count, Examples)`, retaining up to 3 distinct gated test paths per signature.
- The `exceptionSignatures` triage JSON gains an `examples` array, relativised like `lowestMatchTests`; console/markdown consumers updated to the record type (no behavioural change to those views).

**`scripts/merge-wpt-shards.py`**
- Unions example paths per signature across shards (deduped, bounded to 3).
- The biggest-problems report renders an `Example test(s):` line under each crash and a new `### Reproduce locally` block with a concrete `--render` command aimed at the first reproducible test.

Sample:
```
1. **Crash gating 1 test(s)**
   - Signature: `DomBridge.ResolveAnimationsOnTree — Collection was modified; enumeration operation may not execute.`
   - Example test(s): `css/css-animations/foo-animation.html`
...
### Reproduce locally
dotnet run --project src/Broiler.Wpt -- \
  --wpt-dir tests/wpt/checkout --render tests/wpt/checkout/css/css-animations/foo-animation.html
```

### Fix: two mutation-during-enumeration crashes

`DomBridge.FireDescendantOnloads` and `DomBridge.ResolveAnimationsOnTree` each enumerated the **live** `element.Children` while their bodies could structurally mutate the DOM mid-walk:
- `FireDescendantOnloads` runs a sub-document's `onload` handler, whose script can append/remove nodes.
- `ResolveAnimationsOnTree` writes inline styles and can restructure the subtree; either walk can also race concurrent DOM mutation.

That threw `Collection was modified; enumeration operation may not execute` — the two crash signatures from #1186. Both now iterate a snapshot via the existing **`SnapshotChildren`** helper (the same guard `CollectStyleElementsInTree` already uses: it retries on the race and falls back to a tolerant index walk).

## Testing

- **Python**: 16/16 `test_merge_wpt_shards` pass — added cross-shard example union/dedup/cap and rendered-section coverage.
- **C#**: `Broiler.Wpt.Tests` builds clean; 7/7 `ExceptionSignatureTests` pass — added example collection/dedup/cap coverage. `Broiler.HtmlBridge.Dom` builds clean.
- The crash fixes are defensive snapshot swaps mirroring the proven `SnapshotChildren` pattern; the WPT run (dispatch-only) is the integration check. The precise trigger is concurrent/structural mutation during the walk, which isn't cheap to reproduce deterministically in a unit test — hence no new unit test for those two.

## Notes for reviewer

- The `examples` field is additive; older shard reports without it degrade gracefully (empty examples, no repro line).
- The reproduce command uses `tests/wpt/checkout`, matching `WPT_CHECKOUT_DIR` in the workflow and `run-wpt-tests.sh`.
- Only the two reported walks were converted to `SnapshotChildren`; the many other read-only `element.Children` walks in `DomBridge` are left as-is to avoid over-scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)