### PR TITLE
Fix CollectInlineCBPromotions crash + harden anchor-resolver walks; ignore unknown pseudo-classes (WPT #1195)

### DIFF
--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorCenter.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorCenter.cs
@@ -71,10 +71,10 @@ public sealed partial class DomBridge
         // Snapshot children before recursing: element.Children enumerates the
         // live ChildNodes list, so any concurrent mutation of it (e.g. an
         // anchor-driven DOM move on another node sharing this parent) throws
-        // "Collection was modified" mid-traversal. Iterating a snapshot is the
-        // same defensive idiom already used by the .ToList() walks in
+        // "Collection was modified" mid-traversal (or overflows the ToList() copy).
+        // SnapshotChildren tolerates both, the same defensive idiom used across
         // InlineContainingBlocks and the deferred moves in ResolveAnchorPositions.
-        foreach (var child in element.Children.ToList())
+        foreach (var child in SnapshotChildren(element))
             ResolveAnchorCenter(child, anchorRegistry);
     }
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
@@ -165,8 +165,9 @@ public sealed partial class DomBridge
         // Snapshot the child list: resolving anchor functions on a descendant can
         // mutate the live DOM (e.g. anchor-driven style/structure changes under
         // content-visibility), and iterating the live collection while it changes
-        // throws "Collection was modified" (WPT content-visibility-anchor-positioning).
-        foreach (var child in element.Children.ToList())
+        // throws "Collection was modified" (WPT content-visibility-anchor-positioning)
+        // or overflows the ToList() copy. SnapshotChildren tolerates both.
+        foreach (var child in SnapshotChildren(element))
             ResolveAnchorFunctions(child, anchorRegistry);
     }
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
@@ -411,9 +411,9 @@ public sealed partial class DomBridge
         // a lazy offset query that re-enters anchor resolution) throws
         // "Collection was modified" mid-traversal and aborts the registry build
         // for the whole document (WPT issue #1131, signature
-        // DomBridge.BuildAnchorRegistry). Same defensive idiom as the .ToList()
-        // walks in ResolveAnchorCenter and InlineContainingBlocks.
-        foreach (var sibling in element.Parent.Children.ToList())
+        // DomBridge.BuildAnchorRegistry). Same defensive snapshot (SnapshotChildren)
+        // idiom as ResolveAnchorCenter and InlineContainingBlocks.
+        foreach (var sibling in SnapshotChildren(element.Parent))
         {
             if (sibling == element) break;
             if (sibling.IsTextNode) continue;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ContainingBlocks.cs
@@ -41,7 +41,10 @@ public sealed partial class DomBridge
             }
         }
 
-        foreach (var child in el.Children)
+        // Snapshot before recursing: the live child list can be mutated mid-walk
+        // (concurrent/lazy DOM edit) and throw, aborting resolution. SnapshotChildren
+        // tolerates that — same idiom as the other anchor-resolver tree walks.
+        foreach (var child in SnapshotChildren(el))
             EnsureContainingBlockPositioningTree(child);
     }
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/CssCleanup.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/CssCleanup.cs
@@ -24,15 +24,16 @@ public sealed partial class DomBridge
         {
             // Snapshot: assigning child.TextContent re-parses the <style> element's
             // text node, mutating root.Children mid-enumeration ("Collection was
-            // modified", WPT issue #1143). Same .ToList() idiom as AnchorRegistry.
-            foreach (var child in root.Children.ToList())
+            // modified", WPT issue #1143). SnapshotChildren also guards the ToList()
+            // copy overflow ("Destination array…"), same idiom as AnchorRegistry.
+            foreach (var child in SnapshotChildren(root))
             {
                 if (child.IsTextNode && !string.IsNullOrEmpty(child.TextContent))
                     child.TextContent = RemoveUnsupportedCssRules(child.TextContent);
             }
         }
 
-        foreach (var child in root.Children.ToList())
+        foreach (var child in SnapshotChildren(root))
             NeutralizeStyleElementsForAnchorRules(child);
     }
     private static readonly System.Text.RegularExpressions.Regex CssRuleBlockPattern = new(

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
@@ -240,7 +240,10 @@ public sealed partial class DomBridge
             results.Add((element, element.Parent));
         }
 
-        foreach (var child in element.Children)
+        // Snapshot before recursing: the live child list can be mutated mid-walk
+        // (concurrent/lazy DOM edit) and throw, aborting the walk. SnapshotChildren
+        // tolerates that — same idiom as the other anchor-resolver tree walks.
+        foreach (var child in SnapshotChildren(element))
             FindModalDialogs(child, results);
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/FixedPosition.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/FixedPosition.cs
@@ -84,7 +84,10 @@ public sealed partial class DomBridge
             }
         }
 
-        foreach (var child in el.Children)
+        // Snapshot before recursing: the live child list can be mutated mid-walk
+        // (concurrent/lazy DOM edit) and throw, aborting resolution. SnapshotChildren
+        // tolerates that — same idiom as the other anchor-resolver tree walks.
+        foreach (var child in SnapshotChildren(el))
             ResolveFixedPositionSizingInTree(child, vpW, vpH);
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
@@ -208,8 +208,9 @@ public sealed partial class DomBridge
         // Snapshot before iterating: this estimation is reached from
         // BuildAnchorRegistry's box computation, where the live ChildNodes list
         // can be mutated mid-walk and throw "Collection was modified" (WPT issue
-        // #1131). Matches the .ToList() idiom used elsewhere in this file.
-        foreach (var child in element.Children.ToList())
+        // #1131) or overflow the ToList() copy ("Destination array was not long
+        // enough"). SnapshotChildren tolerates both, matching the other walks here.
+        foreach (var child in SnapshotChildren(element))
         {
             if (child.IsTextNode)
             {
@@ -374,7 +375,7 @@ public sealed partial class DomBridge
             if (blockAncestor != null)
             {
                 // Collect absolutely positioned children.
-                foreach (var child in element.Children.ToList())
+                foreach (var child in SnapshotChildren(element))
                 {
                     if (child.IsTextNode) continue;
                     var childProps = GetComputedProps(child);
@@ -387,7 +388,7 @@ public sealed partial class DomBridge
             }
         }
 
-        foreach (var child in element.Children.ToList())
+        foreach (var child in SnapshotChildren(element))
             CollectInlineCBPromotions(child, promotions);
     }
     /// <summary>
@@ -492,7 +493,11 @@ public sealed partial class DomBridge
         double fontSize = TryParsePx(parentProps.GetValueOrDefault("font-size")) ?? 16;
         double lineHeight = ResolveLineHeight(parentProps, fontSize);
 
-        foreach (var sibling in parent.Children)
+        // Snapshot the child list: a raw foreach over the live LegacyChildList can
+        // throw "Collection was modified" (or the sibling ToList() overflow) if the
+        // tree is mutated mid-walk, aborting anchor resolution. SnapshotChildren
+        // tolerates that, matching the idiom used across these anchor walks.
+        foreach (var sibling in SnapshotChildren(parent))
         {
             if (sibling == element) break;
             if (sibling.IsTextNode)
@@ -563,7 +568,7 @@ public sealed partial class DomBridge
         var props = GetComputedProps(parent);
         double fontSize = TryParsePx(props.GetValueOrDefault("font-size")) ?? 16;
 
-        foreach (var sibling in parent.Children)
+        foreach (var sibling in SnapshotChildren(parent))
         {
             if (sibling == element) break;
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
@@ -399,9 +399,10 @@ public sealed partial class DomBridge
         // this parent, mutating the list mid-walk and throwing "Collection was
         // modified" — which aborts position-area resolution for the whole
         // document (WPT issue #1147, signature
-        // DomBridge.ResolvePositionAreaValues). Same defensive .ToList() idiom as
-        // BuildAnchorRegistry / ResolveAnchorCenter / InlineContainingBlocks.
-        foreach (var child in element.Children.ToList())
+        // DomBridge.ResolvePositionAreaValues). Same defensive snapshot idiom
+        // (SnapshotChildren) as BuildAnchorRegistry / ResolveAnchorCenter /
+        // InlineContainingBlocks.
+        foreach (var child in SnapshotChildren(element))
             ResolvePositionAreaValues(child, anchorRegistry, scrollContainersNeedingRelative,
                 deferredDomMoves);
     }
@@ -585,7 +586,7 @@ public sealed partial class DomBridge
     private double FindScrollContentWidth(DomElement scrollContainer, double containerWidth)
     {
         double maxWidth = containerWidth;
-        foreach (var child in scrollContainer.Children)
+        foreach (var child in SnapshotChildren(scrollContainer))
         {
             if (child.IsTextNode) continue;
             var childProps = GetComputedProps(child);
@@ -612,7 +613,7 @@ public sealed partial class DomBridge
     private double FindScrollContentHeight(DomElement scrollContainer, double containerHeight)
     {
         double stackedHeight = 0;
-        foreach (var child in scrollContainer.Children)
+        foreach (var child in SnapshotChildren(scrollContainer))
         {
             if (child.IsTextNode) continue;
             var childProps = GetComputedProps(child);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
@@ -35,7 +35,7 @@ public sealed partial class DomBridge
     {
         if (string.Equals(el.TagName, "style", StringComparison.OrdinalIgnoreCase))
         {
-            foreach (var child in el.Children)
+            foreach (var child in SnapshotChildren(el))
             {
                 if (child.IsTextNode && !string.IsNullOrEmpty(child.TextContent))
                 {
@@ -64,7 +64,7 @@ public sealed partial class DomBridge
             }
         }
 
-        foreach (var child in el.Children.ToList())
+        foreach (var child in SnapshotChildren(el))
             CollectPositionTryRulesFromTree(child, result);
     }
     /// <summary>
@@ -104,7 +104,7 @@ public sealed partial class DomBridge
         // Snapshot: TryApplyFallback resolves anchor geometry, which can lazily
         // reflect style into the DOM and mutate a Children collection an enclosing
         // recursion frame is still walking ("Collection was modified", issue #1143).
-        foreach (var child in element.Children.ToList())
+        foreach (var child in SnapshotChildren(element))
             ResolvePositionTryFallbacksTree(child, anchorRegistry, positionTryRules);
     }
     private void TryApplyFallback(
@@ -284,7 +284,7 @@ public sealed partial class DomBridge
     private double EstimateMinContentWidth(DomElement element)
     {
         double maxWidth = 0;
-        foreach (var child in element.Children)
+        foreach (var child in SnapshotChildren(element))
         {
             if (child.IsTextNode) continue;
             var childProps = CollectMatchedRuleProperties(child);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
@@ -67,7 +67,7 @@ public sealed partial class DomBridge
                         wrapper.Style["left"] =
                             $"{(-scrollLeft).ToString(CultureInfo.InvariantCulture)}px";
 
-                    var originalChildren = el.Children.ToList();
+                    var originalChildren = SnapshotChildren(el);
                     el.Children.Clear();
                     el.Children.Add(wrapper);
                     foreach (var child in originalChildren)
@@ -105,7 +105,7 @@ public sealed partial class DomBridge
                     if (scrollTop > 0 && !isDocScrollingElement)
                     {
                         double childOffset = 0;
-                        foreach (var child in wrapper.Children)
+                        foreach (var child in SnapshotChildren(wrapper))
                         {
                             if (child.IsTextNode) continue;
                             var cp = GetComputedProps(child);
@@ -143,7 +143,7 @@ public sealed partial class DomBridge
     /// </summary>
     private void CollectFixedDescendants(DomElement parent, List<DomElement> results)
     {
-        foreach (var child in parent.Children)
+        foreach (var child in SnapshotChildren(parent))
         {
             if (child.IsTextNode) continue;
             var cp = GetComputedProps(child);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Visibility.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Visibility.cs
@@ -95,7 +95,10 @@ public sealed partial class DomBridge
             }
         }
 
-        foreach (var child in el.Children)
+        // Snapshot before recursing: the live child list can be mutated mid-walk
+        // (concurrent/lazy DOM edit) and throw, aborting resolution. SnapshotChildren
+        // tolerates that — same idiom as the other anchor-resolver tree walks.
+        foreach (var child in SnapshotChildren(el))
             ResolvePositionVisibilityTree(child, anchorRegistry);
     }
     /// <summary>

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -7992,6 +7992,40 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
     }
 
     [Fact]
+    public void Wpt_ResolveAnchorPositions_AbsPosChildOfInlineContainingBlock_PromotedWithoutThrow()
+    {
+        // Regression for issue #1195 (top WPT crash, signature
+        // "DomBridge.CollectInlineCBPromotions — Destination array was not long
+        // enough"). CollectInlineCBPromotions walked the live child list with a raw
+        // element.Children.ToList(): Enumerable.ToList reads Count, allocates a
+        // destination of that size, then CopyTo materialises the current (possibly
+        // larger) child array, so a mid-walk mutation overflows the copy. The walk
+        // now goes through the tolerant SnapshotChildren helper (same fix already
+        // used by CollectStyleElementsInTree). This drives the promotion path: an
+        // absolutely-positioned box inside an inline (position:relative <span>)
+        // containing block must be moved out to its nearest block-level ancestor.
+        const string html = @"<!DOCTYPE html>
+<div id=""block""><span id=""ic"" style=""position:relative"">ab<span id=""abs"" style=""position:absolute; left:10px; top:20px; width:5px; height:5px; background:red""></span></span></div>";
+
+        using var ctx = new Broiler.JavaScript.Engine.JSContext();
+        var bridge = new Broiler.HtmlBridge.DomBridge();
+        bridge.Attach(ctx, html, "file:///test.html");
+
+        // Must not throw (previously crashed with "Destination array was not long enough").
+        bridge.ResolveAnchorPositions();
+
+        Broiler.HtmlBridge.DomElement? abs = null;
+        FindDomElement(bridge.DocumentElement, "abs", ref abs);
+        Assert.NotNull(abs);
+
+        // The abspos child is promoted out of the inline containing block (#ic) to
+        // its nearest block-level ancestor (#block), since Broiler's renderer cannot
+        // place an abspos box inside an inline box.
+        Assert.NotNull(abs!.Parent);
+        Assert.Equal("block", abs!.Parent!.Id);
+    }
+
+    [Fact]
     public void Wpt_CssomView_ElementScroll_Alias_And_Object_Arguments_Work()
     {
         const string html = @"<!DOCTYPE html>


### PR DESCRIPTION
## Summary

Addresses the top problems from the WPT run in #1195:

- **Fixes the #1 crash** — `DomBridge.CollectInlineCBPromotions — Destination array was not long enough` (gated `css/css-transforms/animation/transform-interpolation-rotate-slerp.html`).
- **Hardens the whole anchor-resolver** against the same crash class so it can't resurface under a different signature.
- **Bumps the `Broiler.CSS` submodule** to fix unknown pseudo-classes matching every element — the dominant failure of problem #2 (`css/CSS2/cascade/at-import-010`) and a common WPT idiom across the suite.

## 1. The crash (root cause)

`CollectInlineCBPromotions` walked the live child list with a raw `element.Children.ToList()`. `LegacyChildList` projects the live `ChildNodes` collection, so `Enumerable.ToList` reads `Count`, allocates a destination of that size, then `CopyTo` materialises the *current* (possibly larger) child array — a mutation between those two steps overflows the copy and throws `ArgumentException`. `LegacyChildList.CopyTo` is a one-liner that inlines away in Release, so the top non-framework frame surfaces as `CollectInlineCBPromotions`.

This is a **known, already-diagnosed failure class**: the tolerant `SnapshotChildren` helper (`DomBridge/Css.cs`) was written for the identical exception on the sibling walk `CollectStyleElementsInTree`. The anchor-resolver walks simply never adopted it.

**Fix:** route the crash site — and every other raw `element.Children.ToList()` / live `foreach (var x in Y.Children)` walk across the `AnchorResolver/` directory (24 sites in 12 files) — through `SnapshotChildren`. It retries, then falls back to a bounds-checked index walk. Behaviour is **identical on the happy path** (`SnapshotChildren` returns `Children.ToList()` on its first try), so this only changes what happens under the racing mutation that used to crash. The intentional index-loop in `ScrollSimulation` (re-reads `Count` each step) was left as-is — it is already crash-safe.

## 2. Broiler.CSS: unknown pseudo-classes no longer match everything

`CssSelectorMatcher.ProcessPseudoClasses` ended its switch in `_ => true`, so a selector with an unrecognized pseudo-class (e.g. `:unknownpseudo`) matched **every element**. That made the standard WPT "an invalid selector is ignored" idiom — `:bogus { background: red }` — paint red on the whole page.

Per the Selectors spec an unknown pseudo-class is an invalid selector and its rule must be dropped. The fix replaces the blanket default with an allowlist: recognized pseudo-class names (plus the legacy single-colon pseudo-elements) and vendor-prefixed names stay lenient — matching exactly as before — while genuinely unknown names no longer match. This is a **strict narrowing**: recognized-but-unmodeled pseudos (`:read-only`, `:defined`, form-state) are unaffected, so no valid selector changes behaviour.

The submodule change is pushed to `Broiler.CSS` on branch `claude/wpt-1195-invalid-pseudo-class` (commit `596ebdc`) and this PR bumps the gitlink to it. It should get its own submodule PR merged; the pointer already references the pushed commit so CI can clone it by SHA.

## Verification

- Builds clean (`Broiler.HtmlBridge.Dom`, `Broiler.Wpt.Tests`, `Broiler.CSS.Dom`) — 0 warnings, 0 errors.
- New regression tests: `Wpt_ResolveAnchorPositions_AbsPosChildOfInlineContainingBlock_PromotedWithoutThrow` (crash path) and a `CssSelectorMatcherTests` case (unknown → no match; recognized/vendor → still match). Both pass.
- **Crash sweep:** the local anchor-resolver test set was baselined (stash → rebuild → rerun); the failure set is byte-for-byte identical before/after — zero regressions. The remaining anchor `*_MatchesReference` failures are the pre-existing environmental (font/reference) ones flagged in `CLAUDE.md`.
- **Selector fix:** rendered repro shows `:unknownpseudo{background:red}` going red → white; the full 147-test local WPT subset is identical before/after (102 pass / 38 fail) — zero regressions.

## Not included (triaged, see #1195)

The other layout mismatches (#3 abspos-containing-block, #5–#9 `color-scheme: dark` canvas, #10 container-query `::backdrop`, and #2's second half — `@import` following invalid rules) are **not** reproducible against Chromium references in a local checkout (the failing test files aren't in the committed subset, and #4 `document-canvas-remove-body` even passes locally). They are genuine gaps — notably `color-scheme` as a rendering property is unimplemented (a `:root{color-scheme:dark}` page renders a white canvas) — but need the CI reference environment to verify, so they're left for follow-up rather than shipped blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
