### PR TITLE
Fix WPT #1203 biggest problems: font shorthand, floats, replaced margins, overflow

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -3802,6 +3802,11 @@ internal class CssBox : CssBoxProperties, IDisposable
     private double ComputeShrinkToFitWidth()
     {
         double maxLineWidth = 0;
+        // Running width of a horizontal run of adjacent floated children. At
+        // max-content the container is under no width constraint, so a run of
+        // float:left/right children lays out side by side and their widths ADD;
+        // a non-floated (block) child ends the run and starts its own line.
+        double floatRunWidth = 0;
 
         foreach (var child in Boxes)
         {
@@ -3825,8 +3830,26 @@ internal class CssBox : CssBoxProperties, IDisposable
             }
 
             childWidth += child.ActualMarginLeft + child.ActualMarginRight;
-            if (!double.IsNaN(childWidth))
+            if (double.IsNaN(childWidth))
+                continue;
+
+            // CSS Sizing 3 §5: the max-content width of a container whose
+            // children float must accumulate a run of adjacent floats rather
+            // than take only the widest single child — otherwise a container of
+            // two float:left children (WPT floats-143: a <ul> of two float:left
+            // <li>) shrinks to one child's width, wrapping the second below the
+            // first. Non-floated (block-level) children each start their own
+            // line, so they reset the run and contribute independently.
+            if (child.Float != CssConstants.None)
+            {
+                floatRunWidth += childWidth;
+                maxLineWidth = Math.Max(maxLineWidth, floatRunWidth);
+            }
+            else
+            {
+                floatRunWidth = 0;
                 maxLineWidth = Math.Max(maxLineWidth, childWidth);
+            }
         }
 
         return maxLineWidth;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -638,9 +638,21 @@ internal static class CssLayoutEngine
                             maxbottom += strutHeight - (maxbottom - cury);
                     }
 
+                    // CSS Text §5.1: a line box may not be broken before its
+                    // first inline content. An unbreakable word wider than the
+                    // line stays on the (otherwise empty) line and overflows;
+                    // it must not be pushed to a phantom second line, which
+                    // would double the block's height (WPT max-height-109: a
+                    // 3000px Ahem word in a 200px line was wrapping to a second
+                    // line, so #red-parent grew to ~400px and red showed above
+                    // the green). Words are added to the line via
+                    // ReportExistanceOf below, so Words.Count == 0 means this
+                    // word is the first on the current line.
+                    bool lineHasContent = line.Words.Count > 0;
                     if ((b.WhiteSpace != CssConstants.NoWrap && b.WhiteSpace != CssConstants.Pre && curx + word.Width + rightspacing > limitRight
                          && (b.WhiteSpace != CssConstants.PreWrap || !word.IsSpaces)
-                         && (b.WhiteSpace != CssConstants.PreLine || !word.IsSpaces)) || word.IsLineBreak || wrapNoWrapBox)
+                         && (b.WhiteSpace != CssConstants.PreLine || !word.IsSpaces)
+                         && lineHasContent) || word.IsLineBreak || wrapNoWrapBox)
                     {
                         wrapNoWrapBox = false;
                         curx = startx;


### PR DESCRIPTION
@
Resolves the five lowest-pixel-match tests flagged in the WPT run (issue #1203). All five were reproduced locally via `--render` against the live engine; before/after images confirmed.

## Root causes & fixes

### 1. `font` shorthand ate the numeric weight as the font-size  → 3 tests
`ExpandFontShorthand` parsed each token as a font-size **before** checking the leading style/variant/weight keywords, and `IsFontSizeToken` accepts a bare unitless number as a length. So a numeric font-weight was consumed as the size:

- `font: 900 1.75em Verdana` → `font-size:900` (gigantic text)
- `font: italic small-caps 100 150%/300% sans-serif` → `font-size:100`, `font-family:"150%/300% sans-serif"`

Per the CSS Fonts `font` grammar the style/variant/weight keywords always precede the size, and a unitless number before the size can only be a weight. Fix classifies those keywords first (**Broiler.CSS** submodule, `CssStyleEngine.Values.cs`).

Fixes **css1/c527-font-10** (32→18px text), **backgrounds/background-root-006** (body now shrink-wraps; navy canvas + white-tile box), and the giant-glyph cause in **floats-clear/floats-143**.

### 2. Nested float shrink-to-fit took max instead of sum → floats-143
A shrink-to-fit container of two `float:left` `<li>` used `max(child)` rather than summing adjacent floats, so the second `<li>` wrapped below the first. `ComputeShrinkToFitWidth` now accumulates a run of adjacent floats (**Broiler.Layout**, `CssBox.cs`). Combined with the font fix, floats-143 renders a single-line green **PASS**.

### 3. Line break before the first (over-wide) word → max-height-109
An unbreakable word wider than the line was wrapped before the first word of an empty line, spawning a phantom second line box that doubled the block height (red showed above the green). `FlowBox` now suppresses the width-overflow break when the current line is empty, per CSS Text §5.1 (**Broiler.Layout**, `CssLayoutEngine.cs`). **normal-flow/max-height-109** now renders a single wide green rectangle, no red.

### 4. Block-level replaced `<img>` lost its auto horizontal margins → c43-rpl-bbx-001
`CorrectImgBoxes` wraps a `display:block` image in an anonymous block and flips the image to `display:inline`; auto side-margins on an inline replaced box compute to 0, so `width:50%; margin-left:auto` was stuck flush-left. Fix hands the block width + horizontal margins to the anonymous wrapper when the replaced element has a definite width and an auto side-margin (**Broiler.HTML** submodule, `DomParser.cs`). **css1/c43-rpl-bbx-001** now renders flush-right; also enables `margin:auto` centering of fixed-width block images.

## Submodules
- **Broiler.CSS** — `CssStyleEngine.Values.cs`; commit pushed to its remote, pointer bumped.
- **Broiler.HTML** — `DomParser.cs`; commit pushed to its remote, pointer bumped.
- **Broiler.Layout** is a normal directory in this repo (not a submodule); both layout fixes are in-tree.

## Testing
- `Broiler.CSS.Dom.Tests`: 86/86 pass.
- `Broiler.Wpt.Tests`: 142 failures both before and after (identical failing set — the 142 are pre-existing environmental font-diff failures per CLAUDE.md); zero regressions from any of the four fixes.

## Known residuals (out of scope, follow-ups)
- **c527-font-10**: `font-variant: small-caps` is unimplemented (no small-caps synthesis) and percentage `line-height` / synthetic italic are approximate. The font-size fix removes it from the < 50%-match "biggest problems", but pixel-perfection needs small-caps support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@