### PR TITLE
Fix grid item over-paint and reference generator root-relative resource serving

### DIFF
--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -58,7 +58,7 @@ permissions:
 
 env:
   # Bump to invalidate the cached WPT checkout + references.
-  CACHE_EPOCH: '3' # JavaScript-enabled Chromium references
+  CACHE_EPOCH: '4' # reference generator now serves root-relative /css/support, /resources, … from the WPT root
   SHARD_COUNT: '8'
   WPT_CHECKOUT_DIR: tests/wpt/checkout
   REFERENCE_DIR: tests/wpt/references

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -129,8 +129,14 @@ internal partial class CssBox
             PlaceItemInArea(p.Item, areaLeft, areaTop, areaRight - areaLeft, areaBottom - areaTop);
         }
 
-        // The grid's implicit height is the block-end edge of the last row track.
-        double gridHeight = maxRowEnd > 0 ? rowEndEdge[maxRowEnd - 1] : 0;
+        // The grid's block size is the block-end edge of its last row track.
+        // That last track is the greater of the explicit template (every
+        // grid-template-rows track contributes to the container's size even when
+        // no item occupies it) and any implicit rows placement created past it —
+        // so a 4-track template with items in only the first 3 rows still sizes
+        // the container to all four tracks, matching Chromium.
+        int rowLineCount = Math.Max(maxRowEnd, rowTracks.Count);
+        double gridHeight = rowLineCount > 0 ? rowEndEdge[rowLineCount - 1] : 0;
         double borderBoxHeight = ActualPaddingTop + ActualPaddingBottom
             + ActualBorderTopWidth + ActualBorderBottomWidth + gridHeight;
         ActualBottom = Location.Y + borderBoxHeight;
@@ -346,6 +352,18 @@ internal partial class CssBox
         item.Size = new SizeF((float)newWidth, (float)newHeight);
         item.ActualRight = item.Location.X + newWidth;
         item.ActualBottom = item.Location.Y + newHeight;
+
+        // When the grid container was laid out through the inline path
+        // (ContainsInlinesOnly → CreateLineBoxes), each item div acquired a
+        // per-line-box entry in its Rectangles map sized to the inline-block it
+        // was measured as (typically the full container width/height). That map
+        // is what the paint walker uses for the item's own background/border
+        // (Fragment.InlineRects), so leaving it in place would paint the item at
+        // its pre-grid inline size even though we just resized the border box.
+        // Grid items are blockified (CSS Grid §4), so their background is always a
+        // single border box — clear the stale inline rects and let paint fall
+        // back to Location+Size.
+        item.RectanglesReset();
     }
 
     /// <summary>

--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -41,6 +41,7 @@ Status snapshot and next steps for the Web Platform Tests (WPT) effort tracked i
 | 23 | `css-anchor-position` full-suite run (#1163, 227 fails) — triaged tail; scroll-offset tracking for `anchor()` across scrollers implemented | 🟡 partial | Broiler.HtmlBridge.Dom |
 | 24 | `position-area` grid collapses when the anchor is an abspos box inside an **inline** containing block (#1175) | ✅ fixed | Broiler.HtmlBridge.Dom |
 | 25 | Shared `anchor-name` not scoped — every element bound to one global (last-wins) anchor instead of the one in its own scope (#1175) | ✅ fixed | Broiler.HtmlBridge.Dom |
+| 26 | Definite-track grid items over-painted at stale inline-block size + grid collapsed to occupied rows; Chromium references rendered blank because the generator only served `/fonts/` (#1209) | ✅ fixed | Broiler.Layout + scripts/generate-wpt-references.js |
 
 Cluster 13 (issue [#1140](https://github.com/MaiRat/Broiler/issues/1140), the dominant new
 `css-backgrounds` directory — 30 failures, with `background-clip-root` at the worst-case **0 %
@@ -583,6 +584,41 @@ container's anchor, so it vanishes without the fix. *Note:* this alone does **no
 mis-places its later `float:left` containers) and #3 (writing-mode-aware margin/padding %), both still
 open (see the deferred entry). But the scope fix is correct for the whole class of shared-`anchor-name`
 tests independent of those.
+
+Cluster 26 (issue [#1209](https://github.com/Broiler-Platform/Broiler/issues/1209), the
+"biggest problems" CSS Grid list — the `css-grid/placement` and `grid-definition` fixed-track
+tests at 0–6 % match) turned out to be **two independent bugs, one on each side of the pixel
+comparison**, both surfacing as `MissingContent`:
+
+1. **Broiler over-painted grid items at their pre-grid inline size.** The definite-track pass
+   (`CssBoxGrid.TryApplyGridTrackLayout`) places and sizes items correctly — `getBoundingClientRect`
+   already returned the right geometry, so the geometry-only `GridTrackLayoutTests` passed — but a
+   block-level grid container reaches that pass through the inline layout path
+   (`ContainsInlinesOnly` → `CreateLineBoxes`), which first lays each item out as an inline-block and
+   records a per-line-box entry in the item's `Rectangles` map sized to the full container. The paint
+   walker uses that map (`Fragment.InlineRects`) for the item's own background/border, so a correctly
+   placed 50×50 item was still *painted* at ~1000×1000 — the render was pure over-paint, not
+   mis-placement. Grid items are blockified (CSS Grid §4) so their background is always a single
+   border box; `PlaceItemInArea` now calls `item.RectanglesReset()` after positioning, letting paint
+   fall back to `Location`+`Size`. The grid's block size also now spans **all** `grid-template-rows`
+   tracks (`Math.Max(maxRowEnd, rowTracks.Count)`), not just occupied rows, matching Chromium.
+   Pixel regression guard: `GridTrackPaintTests` samples the rendered bitmap (both bugs make an empty
+   cell / unoccupied row show the item colour or the white canvas instead of the container background).
+2. **The Chromium references for these tests were blank.** `scripts/generate-wpt-references.js`
+   loads each test over `file://` but only remapped root-relative `/fonts/…` requests to the WPT
+   root; `/css/support/grid.css` (which carries `display:grid` and the item colours) resolved to
+   `file:///css/support/grid.css`, 404'd, and the reference screenshot came out unstyled/blank —
+   while Broiler's own runner *does* resolve `/css/support/` (`TryResolveWptRootRelativePath`), so the
+   two sides rendered different documents and every such test failed on a spurious mismatch. The
+   generator now serves **any** root-relative resource from the WPT root
+   (`resolveRootRelativeResource`), exactly like a real WPT server and like the runner. Verified
+   byte-identical output on the full `css-backgrounds` reference set (those tests use relative paths,
+   so nothing changes) and confirmed `grid-auto-flow-sparse-001` flips 1.8 % → **100 %** with both
+   fixes. `CACHE_EPOCH` bumped to `4` so CI regenerates references. The remaining #1209 entries stay
+   open for deeper reasons unrelated to grid layout: the `grid-container-change-*` /
+   `grid-template-*-changes` tests set their grid up in a `document.fonts.ready.then(…)` callback and
+   render the testharness results summary table on-screen (Broiler runs neither), and the six
+   `grid-lanes/subgrid` tests need `subgrid` support.
 
 Cluster 11 (issue [#1119](https://github.com/MaiRat/Broiler/issues/1119), the dominant
 `PixelMismatch / MissingContent` family, 328 failures) was a render-serialization bug that

--- a/scripts/generate-wpt-references.js
+++ b/scripts/generate-wpt-references.js
@@ -96,6 +96,71 @@ function createBrowserContextOptions(nonJsOnly) {
     };
 }
 
+/** Content-type for a filename extension, for route.fulfill(). */
+function contentTypeForExtension(ext) {
+    switch (ext.toLowerCase()) {
+        case '.css':   return 'text/css; charset=utf-8';
+        case '.js':    return 'text/javascript; charset=utf-8';
+        case '.html':
+        case '.htm':
+        case '.xht':
+        case '.xhtml': return 'text/html; charset=utf-8';
+        case '.svg':   return 'image/svg+xml';
+        case '.png':   return 'image/png';
+        case '.jpg':
+        case '.jpeg':  return 'image/jpeg';
+        case '.gif':   return 'image/gif';
+        case '.webp':  return 'image/webp';
+        case '.ttf':   return 'font/truetype';
+        case '.otf':   return 'font/opentype';
+        case '.woff':  return 'font/woff';
+        case '.woff2': return 'font/woff2';
+        default:       return 'application/octet-stream';
+    }
+}
+
+/**
+ * Resolve a file:// request URL to the on-disk resource the reference generator
+ * should serve for it, or `null` when Chromium should be left to load (or 404)
+ * the request itself.
+ *
+ * WPT tests reference shared support resources — fonts, stylesheets, images,
+ * harness scripts — with *root-relative* URLs (/fonts/ahem.css,
+ * /css/support/grid.css, /resources/testharness.js). A real WPT server resolves
+ * those against the WPT root; loaded over file://, Chromium resolves them
+ * against the filesystem root (file:///css/support/grid.css) where nothing
+ * exists, so the resource 404s and the reference renders unstyled. This mirrors
+ * a real server (and Broiler.Wpt's own runner, TryResolveWptRootRelativePath):
+ *   - a path that resolves on disk as-is (the test document, a relative
+ *     sub-resource) → `null` (Chromium loads it directly);
+ *   - a root-relative path that resolves under `baseDir` → that path (served),
+ *     contained within `baseDir` to reject `../` escapes;
+ *   - anything else → `null` (Chromium 404s it, as before).
+ */
+function resolveRootRelativeResource(baseDir, requestUrl) {
+    if (!/^file:\/\//i.test(requestUrl)) {
+        return null;
+    }
+    const rawPath = decodeURIComponent(requestUrl.replace(/^file:\/\//i, '').split(/[?#]/)[0]);
+    try {
+        if (fs.existsSync(rawPath) && fs.statSync(rawPath).isFile()) {
+            return null;
+        }
+    } catch { /* fall through to the base-dir remap */ }
+
+    const resolvedBaseDir = path.resolve(baseDir);
+    const rel = rawPath.startsWith('/') ? '.' + rawPath : './' + rawPath;
+    const candidate = path.resolve(resolvedBaseDir, rel);
+    const contained =
+        candidate === resolvedBaseDir || candidate.startsWith(resolvedBaseDir + path.sep);
+    try {
+        if (contained && fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+            return candidate;
+        }
+    } catch { /* fall through — leave it for Chromium to 404 */ }
+    return null;
+}
+
 /** Recursively discover test files (excluding WPT crashtests). */
 function discoverTests(dir) {
     const results = [];
@@ -218,55 +283,47 @@ async function main(args = process.argv.slice(2)) {
         args: ['--allow-file-access-from-files'],
     });
 
-    // Determine if there is a local fonts/ directory to serve.
-    // WPT tests import fonts via root-relative URLs such as /fonts/ahem.css.
-    // When loaded from file://, these become file:///fonts/... which do not
-    // exist on the filesystem.  We intercept those requests and serve them
-    // from {baseDir}/fonts/ so Chromium uses the correct test fonts.
-    const localFontsDir = path.join(baseDir, 'fonts');
-    const hasFontsDir = fs.existsSync(localFontsDir);
-    if (hasFontsDir) {
-        console.log(`Serving WPT fonts from: ${localFontsDir}`);
-    }
+    // WPT tests reference their support resources — fonts, shared stylesheets,
+    // images, harness scripts — via *root-relative* URLs such as /fonts/ahem.css,
+    // /css/support/grid.css, or /resources/testharness.js.  A real WPT server
+    // resolves those against the WPT root.  When a test is loaded over file://,
+    // Chromium instead resolves them against the filesystem root
+    // (file:///css/support/grid.css), where nothing exists — so the resource
+    // silently 404s and the reference renders *unstyled* (e.g. a grid test whose
+    // display:grid + track colours live in /css/support/grid.css screenshots
+    // blank).  Broiler.Wpt's own runner already remaps these to the WPT root
+    // (TryResolveWptRootRelativePath); the reference generator must do the same
+    // or the two sides render different documents and every such test fails on a
+    // spurious pixel mismatch.  Intercept file:// requests: paths that resolve on
+    // disk as-is (the test document and its relative sub-resources) load
+    // directly; a root-relative path that does not resolve is served from
+    // {baseDir}, contained within it to guard against ../ escapes.
+    const resolvedBaseDir = path.resolve(baseDir);
+    console.log(`Serving root-relative WPT resources from: ${resolvedBaseDir}`);
 
     let completed = 0;
     let errors = 0;
     const total = testFiles.length;
 
-    // Intercept root-relative /fonts/ requests and serve them from the
-    // local fonts directory.  WPT tests use paths like /fonts/ahem.css
-    // which a real WPT server resolves relative to the WPT root.  When
-    // loading via file://, Chrome resolves them as file:///fonts/... which
-    // does not exist on disk.  Playwright can intercept these requests via
-    // context.route() for both http:// and file:// origin requests.
-    async function fontRouteHandler(route) {
-        const url = route.request().url();
-        // Strip the file:///fonts/ prefix to get the filename/subpath.
-        const subpath = decodeURIComponent(url.replace(/^file:\/\/\/fonts\//i, ''));
-        const localPath = path.join(localFontsDir, subpath);
-        if (fs.existsSync(localPath)) {
-            const body = fs.readFileSync(localPath);
-            const ext = path.extname(localPath).toLowerCase();
-            const contentType =
-                ext === '.css'  ? 'text/css; charset=utf-8' :
-                ext === '.ttf'  ? 'font/truetype' :
-                ext === '.otf'  ? 'font/opentype' :
-                ext === '.woff' ? 'font/woff' :
-                ext === '.woff2'? 'font/woff2' :
-                'application/octet-stream';
-            await route.fulfill({ status: 200, contentType, body });
-        } else {
-            await route.abort('failed');
+    async function fileRouteHandler(route) {
+        const served = resolveRootRelativeResource(resolvedBaseDir, route.request().url());
+        if (served === null) {
+            // The test document, a resolvable relative sub-resource, or an
+            // unmappable path — let Chromium load (or 404) it directly.
+            return route.continue();
         }
+        await route.fulfill({
+            status: 200,
+            contentType: contentTypeForExtension(path.extname(served)),
+            body: fs.readFileSync(served),
+        });
     }
 
-    // Create a fresh context + page, registering the font route.  Used both
+    // Create a fresh context + page, registering the resource route.  Used both
     // for a worker's initial page and to recover after a renderer crash.
     async function newRenderTarget() {
         const context = await browser.newContext(createBrowserContextOptions(nonJsOnly));
-        if (hasFontsDir) {
-            await context.route(/file:\/\/\/fonts\//i, fontRouteHandler);
-        }
+        await context.route(/^file:\/\//i, fileRouteHandler);
         const page = await context.newPage();
         return { context, page };
     }
@@ -347,11 +404,13 @@ async function main(args = process.argv.slice(2)) {
 }
 
 module.exports = {
+    contentTypeForExtension,
     createBrowserContextOptions,
     discoverTests,
     isNonTestFile,
     main,
     requiresJavaScript,
+    resolveRootRelativeResource,
     shardIndexForPath,
 };
 

--- a/scripts/tests/generate-wpt-references.test.js
+++ b/scripts/tests/generate-wpt-references.test.js
@@ -7,10 +7,12 @@ const path = require('node:path');
 const test = require('node:test');
 
 const {
+    contentTypeForExtension,
     createBrowserContextOptions,
     discoverTests,
     isNonTestFile,
     requiresJavaScript,
+    resolveRootRelativeResource,
     shardIndexForPath,
 } = require('../generate-wpt-references.js');
 
@@ -54,4 +56,51 @@ test('discovery includes xht and excludes WPT references and resources', () => {
 
 test('shard hash stays in lock-step with the C# runner', () => {
     assert.equal(shardIndexForPath('css/CSS2/foo.html', 8), 0x418AB4DC % 8);
+});
+
+test('root-relative resources resolve against the WPT root, like a real server', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'broiler-wpt-serve-'));
+    try {
+        fs.mkdirSync(path.join(root, 'css', 'support'), { recursive: true });
+        fs.mkdirSync(path.join(root, 'css', 'css-grid'), { recursive: true });
+        fs.mkdirSync(path.join(root, 'fonts'), { recursive: true });
+        const gridCss = path.join(root, 'css', 'support', 'grid.css');
+        const ahem = path.join(root, 'fonts', 'ahem.css');
+        const testDoc = path.join(root, 'css', 'css-grid', 'test.html');
+        const relResource = path.join(root, 'css', 'css-grid', 'ref.png');
+        fs.writeFileSync(gridCss, '.grid{display:grid}');
+        fs.writeFileSync(ahem, '@font-face{}');
+        fs.writeFileSync(testDoc, '<html></html>');
+        fs.writeFileSync(relResource, 'x');
+
+        // Root-relative support stylesheet / font → remapped under the WPT root.
+        assert.equal(
+            resolveRootRelativeResource(root, 'file:///css/support/grid.css'),
+            gridCss);
+        assert.equal(
+            resolveRootRelativeResource(root, 'file:///fonts/ahem.css?v=2'),
+            ahem);
+
+        // The test document and any path that resolves on disk as-is → null,
+        // so Chromium loads it directly rather than being re-served.
+        assert.equal(resolveRootRelativeResource(root, 'file://' + testDoc), null);
+        assert.equal(resolveRootRelativeResource(root, 'file://' + relResource), null);
+
+        // Missing resources and ../ escapes → null (Chromium 404s them).
+        assert.equal(resolveRootRelativeResource(root, 'file:///css/support/missing.css'), null);
+        assert.equal(resolveRootRelativeResource(root, 'file:///../../etc/passwd'), null);
+
+        // Non-file schemes are never intercepted.
+        assert.equal(resolveRootRelativeResource(root, 'https://example.test/x.css'), null);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('content type is inferred from the file extension', () => {
+    assert.equal(contentTypeForExtension('.css'), 'text/css; charset=utf-8');
+    assert.equal(contentTypeForExtension('.js'), 'text/javascript; charset=utf-8');
+    assert.equal(contentTypeForExtension('.ttf'), 'font/truetype');
+    assert.equal(contentTypeForExtension('.png'), 'image/png');
+    assert.equal(contentTypeForExtension('.unknown'), 'application/octet-stream');
 });

--- a/src/Broiler.Cli.Tests/GridTrackPaintTests.cs
+++ b/src/Broiler.Cli.Tests/GridTrackPaintTests.cs
@@ -1,0 +1,94 @@
+using Broiler.HTML.Image;
+using BColor = Broiler.Graphics.BColor;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Pixel-level regression tests for the definite-track CSS Grid pass
+/// (Broiler.Layout <c>CssBoxGrid</c>). The geometry-only checks in
+/// <see cref="GridTrackLayoutTests"/> read each item's box
+/// (<c>getBoundingClientRect</c>), which already reflected the correct grid
+/// placement — but the <em>paint</em> did not: when a grid container is laid out
+/// through the inline path (<c>ContainsInlinesOnly</c> → <c>CreateLineBoxes</c>),
+/// each item div keeps a per-line-box entry in its <c>Rectangles</c> map sized to
+/// the inline-block it was first measured as (typically the full container width
+/// and height). The paint walker uses that map for the item's background/border
+/// (<c>Fragment.InlineRects</c>), so a correctly-placed 50×50 item was still
+/// painted at ~1000×1000 — the WPT css-grid failures were pure over-paint, not
+/// mis-placement. These tests sample the rendered bitmap so that regression is
+/// caught directly.
+/// </summary>
+public sealed class GridTrackPaintTests
+{
+    private static bool Near(BColor c, int r, int g, int b) =>
+        System.Math.Abs(c.R - r) <= 6 && System.Math.Abs(c.G - g) <= 6 && System.Math.Abs(c.B - b) <= 6;
+
+    private static string Describe(BColor c) => $"rgb({c.R},{c.G},{c.B})";
+
+    /// <summary>
+    /// A single item placed in the first cell of a 2×2 fixed-track grid must paint
+    /// only its own 50×50 cell — the other three cells show the container's silver
+    /// background. Before the fix the item's stale full-size inline rect painted
+    /// red across the whole container.
+    /// </summary>
+    [Fact]
+    public void GridItem_PaintsOnlyItsCell_NotStaleInlineSize()
+    {
+        const string html =
+            "<!DOCTYPE html><html><head></head>"
+            + "<body style=\"margin:0\">"
+            + "<div style=\"display:grid;width:100px;background:#c0c0c0;"
+            + "grid-template-columns:50px 50px;grid-template-rows:50px 50px;\">"
+            + "<div style=\"grid-column:1;grid-row:1;width:100%;height:100%;background:#ff0000;\"></div>"
+            + "</div></body></html>";
+
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(html, 200, 200);
+
+        // Cell (0,0) is the red item.
+        var inItem = bitmap.GetPixel(25, 25);
+        Assert.True(Near(inItem, 255, 0, 0), $"item cell should be red, got {Describe(inItem)}");
+
+        // The three empty cells must show the silver container background, not the
+        // over-painted item colour.
+        var rightCell = bitmap.GetPixel(75, 25);
+        Assert.True(Near(rightCell, 192, 192, 192), $"cell (0,1) should be silver, got {Describe(rightCell)}");
+        var belowCell = bitmap.GetPixel(25, 75);
+        Assert.True(Near(belowCell, 192, 192, 192), $"cell (1,0) should be silver, got {Describe(belowCell)}");
+        var diagCell = bitmap.GetPixel(75, 75);
+        Assert.True(Near(diagCell, 192, 192, 192), $"cell (1,1) should be silver, got {Describe(diagCell)}");
+    }
+
+    /// <summary>
+    /// The grid container's block size spans every <c>grid-template-rows</c> track,
+    /// even rows no item occupies. A one-item grid with three 50px rows is 150px
+    /// tall (silver), so a point in the empty third row is inside the container —
+    /// before the fix the container collapsed to the single occupied row (50px) and
+    /// that point fell through to the white canvas.
+    /// </summary>
+    [Fact]
+    public void GridContainer_SpansAllExplicitRowTracks()
+    {
+        const string html =
+            "<!DOCTYPE html><html><head></head>"
+            + "<body style=\"margin:0\">"
+            + "<div style=\"display:grid;width:50px;background:#c0c0c0;"
+            + "grid-template-columns:50px;grid-template-rows:50px 50px 50px;\">"
+            + "<div style=\"grid-column:1;grid-row:1;width:100%;height:100%;background:#ff0000;\"></div>"
+            + "</div></body></html>";
+
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(html, 200, 200);
+
+        var row0 = bitmap.GetPixel(25, 25);
+        Assert.True(Near(row0, 255, 0, 0), $"row 0 should be the red item, got {Describe(row0)}");
+
+        // Rows 1 and 2 carry no item but are inside the grid — silver background.
+        var row1 = bitmap.GetPixel(25, 75);
+        Assert.True(Near(row1, 192, 192, 192), $"row 1 should be silver, got {Describe(row1)}");
+        var row2 = bitmap.GetPixel(25, 125);
+        Assert.True(Near(row2, 192, 192, 192), $"row 2 (last explicit track) should be silver, got {Describe(row2)}");
+
+        // Just past the third track the grid ends — the white canvas shows through.
+        var belowGrid = bitmap.GetPixel(25, 165);
+        Assert.True(Near(belowGrid, 255, 255, 255), $"below the grid should be white canvas, got {Describe(belowGrid)}");
+    }
+}


### PR DESCRIPTION
Fixes two independent bugs surfacing as `MissingContent` failures in CSS Grid tests (#1209):

## Summary

1. **Broiler grid item over-paint:** Grid items placed by the definite-track pass were painted at their pre-grid inline-block size instead of their final positioned size, causing massive over-paint in grid tests.

2. **Reference generator blank references:** The WPT reference generator only remapped `/fonts/` requests to the WPT root; other root-relative resources like `/css/support/grid.css` resolved to `file:///css/support/grid.css`, 404'd, and rendered unstyled. Meanwhile Broiler's own runner remaps all root-relative paths, so the two sides rendered different documents and every such test failed on spurious pixel mismatches.

## Changes

### Broiler.Layout/Engine/CssBoxGrid.cs
- **Grid item paint fix:** After `PlaceItemInArea` positions and sizes an item, call `item.RectanglesReset()` to clear stale inline-block `Rectangles` entries. Grid items are blockified (CSS Grid §4), so their background is always a single border box; paint now falls back to `Location`+`Size` instead of using the pre-grid inline rects.
- **Grid container height fix:** Grid block size now spans all explicit `grid-template-rows` tracks, not just occupied rows. Changed from `maxRowEnd` to `Math.Max(maxRowEnd, rowTracks.Count)` to match Chromium behavior.

### scripts/generate-wpt-references.js
- **New `contentTypeForExtension()` function:** Maps file extensions to proper MIME types for `route.fulfill()`.
- **New `resolveRootRelativeResource()` function:** Resolves `file://` request URLs to on-disk resources. Returns the path if it's a root-relative resource under `baseDir`, `null` if it's a direct filesystem path or unmappable (guards against `../` escapes).
- **Generalized route handler:** Replaced font-specific `fontRouteHandler` with `fileRouteHandler` that intercepts all `file://` requests and serves any root-relative resource from the WPT root, matching the behavior of a real WPT server and Broiler's own runner.
- **Removed fonts-directory check:** No longer conditionally registers the route; always intercept `file://` requests.

### scripts/tests/generate-wpt-references.test.js
- Added tests for `resolveRootRelativeResource()` covering root-relative paths, direct filesystem paths, missing resources, `../` escapes, and non-file schemes.
- Added tests for `contentTypeForExtension()` covering common file types.

### Broiler.Cli.Tests/GridTrackPaintTests.cs (new file)
- Pixel-level regression tests sampling the rendered bitmap to catch over-paint and container-sizing bugs directly.
- `GridItem_PaintsOnlyItsCell_NotStaleInlineSize`: Verifies a 50×50 grid item paints only its cell, not the full container.
- `GridContainer_SpansAllExplicitRowTracks`: Verifies the grid container spans all explicit row tracks even when unoccupied.

### .github/workflows/wpt-tests.yml
- Bumped `CACHE_EPOCH` from `3` to `4` to invalidate cached references and regenerate with the fixed generator.

### docs/roadmap/wpt-triage-and-diagnostics.md
- Added cluster 26 entry documenting both bugs, their fixes, and verification approach.

## Verification

- Byte-identical output on full `css-backgrounds` reference set (uses relative paths, unaffected).
- `grid-auto-flow-sparse-001` flips from 1.8% to **100%** match with both fixes applied.
- New pixel regression tests guard against future regressions in grid paint and sizing.

https://claude.ai/code/session_012Xxe6jDTa8bC8aQ4Hw7MiC