### PR TITLE
Implement CSS Grid subgrid and absolutely-positioned grid items

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -363,6 +363,20 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         out double cbPadWidth,
         out double cbPadHeight)
     {
+        // CSS Grid §9: an absolutely-positioned grid item's containing block is
+        // the grid area the grid container's track-sizing pass resolved for it,
+        // not the container's padding box. All abspos size/offset resolution
+        // routes through here, so returning the area makes width/height/inset
+        // percentages and the static position use it uniformly.
+        if (GridAreaContainingBlock is { } gridArea)
+        {
+            cbPadLeft = gridArea.Left;
+            cbPadTop = gridArea.Top;
+            cbPadWidth = gridArea.Width;
+            cbPadHeight = gridArea.Height;
+            return;
+        }
+
         if (IsInlineContainingBlock(cb))
         {
             var bbox = GetInlineBoundingBox(cb);

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -107,14 +107,25 @@ internal partial class CssBox
         GridTrackSpec implicitCol = ParseSingleImplicitSpec(GridAutoColumns, em);
         GridTrackSpec implicitRow = ParseSingleImplicitSpec(GridAutoRows, em);
 
-        // Collect in-flow grid items in document order.
+        // Collect in-flow grid items in document order. Absolutely-positioned
+        // children are gathered separately: they take no part in track sizing or
+        // auto-placement, but when the grid container is their containing block
+        // (i.e. it is positioned) their grid area forms their containing block
+        // (CSS Grid §9), which the abspos pass below resolves once tracks exist.
+        bool gridIsAbsposContainingBlock =
+            Position is CssConstants.Relative or CssConstants.Absolute or CssConstants.Fixed;
         var placements = new List<GridPlacement>();
+        List<CssBox> absposItems = null;
         foreach (var child in Boxes)
         {
-            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
-                continue;
             if (child.Display == CssConstants.None)
                 continue;
+            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+            {
+                if (gridIsAbsposContainingBlock)
+                    (absposItems ??= new List<CssBox>()).Add(child);
+                continue;
+            }
 
             var (rowStart, rowSpan) = ParseGridLine(child.GridRow);
             var (colStart, colSpan) = ParseGridLine(child.GridColumn);
@@ -225,6 +236,13 @@ internal partial class CssBox
         ActualBottom = Location.Y + borderBoxHeight;
         ActualRight = CalculateActualRight();
         Size = new SizeF(Size.Width, (float)borderBoxHeight);
+
+        // Now that the grid has its final size and track edges, position any
+        // absolutely-positioned grid items within their resolved grid areas.
+        if (absposItems != null)
+            PlaceAbsposGridItems(absposItems, colStartEdge, colEndEdge, rowStartEdge, rowEndEdge,
+                colSizes.Length, rowSizes.Length, contentLeft, contentTop);
+
         _gridTrackLayoutApplied = true;
         return true;
     }
@@ -477,6 +495,139 @@ internal partial class CssBox
         // single border box — clear the stale inline rects and let paint fall
         // back to Location+Size.
         item.RectanglesReset();
+    }
+
+    /// <summary>
+    /// CSS Grid §9 (Absolute Positioning): resolve each absolutely-positioned
+    /// grid item's grid area from the sized tracks and position the item within
+    /// it. The area — not the grid container's padding box — is the item's
+    /// containing block, so an <c>auto</c> grid line resolves to the container's
+    /// padding edge and specified lines resolve to grid line positions.
+    /// </summary>
+    private void PlaceAbsposGridItems(List<CssBox> items,
+        double[] colStartEdge, double[] colEndEdge,
+        double[] rowStartEdge, double[] rowEndEdge,
+        int colCount, int rowCount, double contentLeft, double contentTop)
+    {
+        double padLeft = Location.X + ActualBorderLeftWidth;
+        double padRight = Location.X + Size.Width - ActualBorderRightWidth;
+        double padTop = Location.Y + ActualBorderTopWidth;
+        double padBottom = ActualBottom - ActualBorderBottomWidth;
+
+        foreach (var item in items)
+        {
+            var (rowStart, rowSpan) = ParseGridLine(item.GridRow);
+            var (colStart, colSpan) = ParseGridLine(item.GridColumn);
+            var (left, right) = ResolveAbsposAxis(colStart, colSpan, colStartEdge, colEndEdge,
+                colCount, contentLeft, padLeft, padRight);
+            var (top, bottom) = ResolveAbsposAxis(rowStart, rowSpan, rowStartEdge, rowEndEdge,
+                rowCount, contentTop, padTop, padBottom);
+            PlaceAbsposItemInArea(item, left, top, right - left, bottom - top);
+        }
+    }
+
+    /// <summary>
+    /// Resolve the [start, end] extent (absolute px) of an abspos grid item's
+    /// grid area along one axis. <paramref name="start"/> is a 0-indexed track
+    /// (null for an <c>auto</c> line, which resolves to the container's padding
+    /// edges per CSS Grid §9.2); lines are clamped into the grid's line range.
+    /// </summary>
+    private static (double start, double end) ResolveAbsposAxis(int? start, int span,
+        double[] startEdge, double[] endEdge, int trackCount, double contentOrigin,
+        double padStart, double padEnd)
+    {
+        if (start == null || trackCount == 0)
+            return (padStart, padEnd);
+        int a = Math.Clamp(start.Value, 0, trackCount);
+        int b = Math.Clamp(start.Value + Math.Max(1, span), 0, trackCount);
+        if (b <= a) b = Math.Min(a + 1, trackCount);
+        double s = a < trackCount ? contentOrigin + startEdge[a] : contentOrigin + endEdge[trackCount - 1];
+        double e = contentOrigin + endEdge[b - 1];
+        return e < s ? (s, s) : (s, e);
+    }
+
+    /// <summary>
+    /// CSS Grid §9: position an absolutely-positioned grid item within its
+    /// resolved grid area, which forms the item's containing block. Insets
+    /// (top/left/right/bottom) offset from the area edges; a percentage or fixed
+    /// width/height resolves against the area, while an <c>auto</c> size keeps
+    /// the item's shrink-to-fit measurement (grid abspos items align to
+    /// <c>start</c>, not <c>stretch</c>, by default) unless both insets pin it.
+    /// The area is recorded on the item so any later abspos re-resolution
+    /// (<see cref="GetAbsoluteContainingBlockPaddingBox"/>) uses it too.
+    /// </summary>
+    private static void PlaceAbsposItemInArea(CssBox item,
+        double areaLeft, double areaTop, double areaWidth, double areaHeight)
+    {
+        item.GridAreaContainingBlock =
+            new RectangleF((float)areaLeft, (float)areaTop, (float)areaWidth, (float)areaHeight);
+        double em = item.GetEmHeight();
+
+        double marginL = item.ActualMarginLeft, marginR = item.ActualMarginRight;
+        double? left = ParseAbsposInset(item.Left, areaWidth, em);
+        double? right = ParseAbsposInset(item.Right, areaWidth, em);
+        double width = ResolveAbsposSize(item.Width, areaWidth, em, item.Size.Width,
+            left, right, marginL, marginR, out bool widthAuto);
+        if (!widthAuto) width = item.ResolveSpecifiedWidthToBorderBox(width);
+        double x;
+        if (left.HasValue) x = areaLeft + left.Value + marginL;
+        else if (right.HasValue) x = areaLeft + areaWidth - right.Value - marginR - width;
+        else x = areaLeft + marginL;
+
+        double marginT = item.ActualMarginTop, marginB = item.ActualMarginBottom;
+        double? top = ParseAbsposInset(item.Top, areaHeight, em);
+        double? bottom = ParseAbsposInset(item.Bottom, areaHeight, em);
+        double height = ResolveAbsposSize(item.Height, areaHeight, em, item.Size.Height,
+            top, bottom, marginT, marginB, out bool heightAuto);
+        if (!heightAuto) height = item.ResolveSpecifiedHeightToBorderBox(height);
+        double y;
+        if (top.HasValue) y = areaTop + top.Value + marginT;
+        else if (bottom.HasValue) y = areaTop + areaHeight - bottom.Value - marginB - height;
+        else y = areaTop + marginT;
+
+        double dx = x - item.Location.X;
+        double dy = y - item.Location.Y;
+        if (Math.Abs(dx) > 0.01) item.OffsetLeft(dx);
+        if (Math.Abs(dy) > 0.01) item.OffsetTop(dy);
+        item.Size = new SizeF((float)Math.Max(0, width), (float)Math.Max(0, height));
+        item.ActualRight = item.Location.X + item.Size.Width;
+        item.ActualBottom = item.Location.Y + item.Size.Height;
+        item.AbsposLocationFinalized = true;
+        item.RectanglesReset();
+    }
+
+    /// <summary>An inset (top/left/right/bottom): null for <c>auto</c>, else px
+    /// resolved against the grid area extent <paramref name="basis"/>.</summary>
+    private static double? ParseAbsposInset(string value, double basis, double em)
+    {
+        if (string.IsNullOrEmpty(value) || value == CssConstants.Auto)
+            return null;
+        return CssValueParser.ParseLength(value, basis, em);
+    }
+
+    /// <summary>
+    /// Used inline/block size of an abspos grid item along one axis. A fixed or
+    /// percentage size resolves against the area; <c>auto</c> (or an intrinsic
+    /// keyword) keeps the shrink-to-fit measurement, except when both insets are
+    /// specified (CSS2.1 §10.3.7/§10.6.4), where the size fills the remaining gap.
+    /// </summary>
+    private static double ResolveAbsposSize(string size, double areaSize, double em,
+        double measured, double? startInset, double? endInset,
+        double marginStart, double marginEnd, out bool wasAuto)
+    {
+        if (!string.IsNullOrEmpty(size) && size != CssConstants.Auto
+            && !IsIntrinsicWidthKeyword(size))
+        {
+            wasAuto = false;
+            return CssValueParser.ParseLength(size, areaSize, em);
+        }
+        wasAuto = true;
+        if (startInset.HasValue && endInset.HasValue)
+        {
+            double gap = areaSize - startInset.Value - endInset.Value - marginStart - marginEnd;
+            return gap > 0 ? gap : 0;
+        }
+        return measured;
     }
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -94,11 +94,36 @@ internal partial class CssBox
         if (contentWidth <= 0)
             return false;
 
+        // CSS Grid Level 2 §7.3 (subgrid): an axis whose template is `subgrid`
+        // takes its tracks from the parent grid over the item's spanned area. The
+        // parent's track pass resolves and records those sizes (SubgridColumn/RowSizes)
+        // and re-runs this layout; until then (or with no grid parent) the axis is
+        // unresolved and the pass declines, falling back to the approximation.
+        bool colSubgrid = SubgridColumnSizes != null && StartsWithSubgrid(GridTemplateColumns);
+        bool rowSubgrid = SubgridRowSizes != null && StartsWithSubgrid(GridTemplateRows);
+        bool anySubgrid = colSubgrid || rowSubgrid;
+
         // Parse both axes' explicit track lists into sizing functions. A null list
         // (none/empty or an out-of-scope token) declines the whole pass.
-        List<GridTrackSpec> colSpecs = ParseTrackList(GridTemplateColumns, em);
-        List<GridTrackSpec> rowSpecs = ParseTrackList(GridTemplateRows, em);
-        if (colSpecs == null || rowSpecs == null || colSpecs.Count == 0 || rowSpecs.Count == 0)
+        List<GridTrackSpec> colSpecs = colSubgrid ? FixedTrackSpecs(SubgridColumnSizes) : ParseTrackList(GridTemplateColumns, em);
+        List<GridTrackSpec> rowSpecs = rowSubgrid ? FixedTrackSpecs(SubgridRowSizes) : ParseTrackList(GridTemplateRows, em);
+
+        // When one axis is a resolved subgrid, the other axis may legitimately be
+        // implicit-only (e.g. a column subgrid with `grid-auto-rows`): treat a
+        // none/empty track list there as zero explicit tracks so the placed items
+        // generate implicit tracks, rather than declining. The general (non-subgrid)
+        // path keeps requiring both axes to have explicit tracks.
+        if (anySubgrid)
+        {
+            if (colSpecs == null && IsNoneOrEmptyTemplate(GridTemplateColumns)) colSpecs = new List<GridTrackSpec>();
+            if (rowSpecs == null && IsNoneOrEmptyTemplate(GridTemplateRows)) rowSpecs = new List<GridTrackSpec>();
+        }
+
+        if (colSpecs == null || rowSpecs == null)
+            return false;
+        if (colSpecs.Count == 0 && rowSpecs.Count == 0)
+            return false;
+        if (!anySubgrid && (colSpecs.Count == 0 || rowSpecs.Count == 0))
             return false;
         if (colSpecs.Count > MaxGridLine || rowSpecs.Count > MaxGridLine)
             return false;
@@ -162,7 +187,10 @@ internal partial class CssBox
         int colCount = Math.Max(maxColEnd, colSpecs.Count);
         int rowCount = Math.Max(maxRowEnd, rowSpecs.Count);
 
-        double colGap = ResolveGridGap(ColumnGap, contentWidth, em);
+        // A subgridded axis adopts the parent grid's gutter (CSS Grid L2 §7.3).
+        double colGap = colSubgrid && SubgridColumnGap.HasValue
+            ? SubgridColumnGap.Value
+            : ResolveGridGap(ColumnGap, contentWidth, em);
 
         // ── Column axis (inline) ── content contributions are layout-independent.
         var colItems = new List<AxisItem>(placements.Count);
@@ -185,9 +213,11 @@ internal partial class CssBox
         // the definite content-box height straight from the declaration — Size.Height
         // at this point may be a measurement, not the specified height — so it can
         // drive fr/percentage rows. An indefinite height must not.
-        bool rowDefinite = TryGetDefiniteContentHeight(em, out double definiteHeight);
+        bool rowDefinite = TryGetDefiniteContentHeight(em, out double definiteHeight) || rowSubgrid;
         double rowBasis = rowDefinite ? definiteHeight : 0;
-        double rowGap = ResolveGridGap(RowGap, rowBasis, em);
+        double rowGap = rowSubgrid && SubgridRowGap.HasValue
+            ? SubgridRowGap.Value
+            : ResolveGridGap(RowGap, rowBasis, em);
 
         var rowItems = new List<AxisItem>(placements.Count);
         foreach (var p in placements)
@@ -225,6 +255,11 @@ internal partial class CssBox
             double areaTop = contentTop + rowStartEdge[p.PlacedRow];
             double areaBottom = contentTop + rowEndEdge[p.PlacedRow + p.RowSpan - 1];
             PlaceItemInArea(p.Item, areaLeft, areaTop, areaRight - areaLeft, areaBottom - areaTop);
+
+            // CSS Grid L2 §7.3: a subgrid item, now sized to its grid area, takes
+            // its tracks in the subgridded axis from this grid's tracks over the
+            // spanned range and lays its own items into them.
+            LayoutSubgridItem(p, colSizes, rowSizes, colGap, rowGap);
         }
 
         // The grid's block size is the block-end edge of its last row track. Every
@@ -628,6 +663,78 @@ internal partial class CssBox
             return gap > 0 ? gap : 0;
         }
         return measured;
+    }
+
+    // ─────────────────────────────── Subgrid ────────────────────────────────
+
+    /// <summary>
+    /// CSS Grid Level 2 §7.3: resolve a subgrid item's inherited tracks from this
+    /// grid's sized tracks over the item's spanned area, then re-run the item's
+    /// own grid layout so its children flow into those tracks. A no-op unless the
+    /// item is itself a grid container declaring <c>subgrid</c> on an axis.
+    /// </summary>
+    private void LayoutSubgridItem(GridPlacement p, double[] colSizes, double[] rowSizes,
+        double colGap, double rowGap)
+    {
+        var item = p.Item;
+        if (item.Display is not ("grid" or "inline-grid"))
+            return;
+        bool colSub = StartsWithSubgrid(item.GridTemplateColumns);
+        bool rowSub = StartsWithSubgrid(item.GridTemplateRows);
+        if (!colSub && !rowSub)
+            return;
+
+        if (colSub)
+        {
+            item.SubgridColumnSizes = SliceTrackSizes(colSizes, p.PlacedCol, p.ColSpan);
+            item.SubgridColumnGap = colGap;
+        }
+        if (rowSub)
+        {
+            item.SubgridRowSizes = SliceTrackSizes(rowSizes, p.PlacedRow, p.RowSpan);
+            item.SubgridRowGap = rowGap;
+        }
+        item.TryApplyGridTrackLayout();
+    }
+
+    /// <summary>The <paramref name="span"/> track sizes starting at <paramref name="start"/>
+    /// (clamped to the available tracks).</summary>
+    private static double[] SliceTrackSizes(double[] sizes, int start, int span)
+    {
+        int n = Math.Max(0, Math.Min(span, sizes.Length - start));
+        var slice = new double[n];
+        for (int i = 0; i < n; i++)
+            slice[i] = sizes[start + i];
+        return slice;
+    }
+
+    /// <summary>True when a track template's first token is the <c>subgrid</c> keyword.</summary>
+    private static bool StartsWithSubgrid(string template)
+    {
+        if (string.IsNullOrWhiteSpace(template))
+            return false;
+        string t = template.TrimStart();
+        return t.StartsWith("subgrid", StringComparison.OrdinalIgnoreCase)
+            && (t.Length == 7 || (!char.IsLetterOrDigit(t[7]) && t[7] != '-'));
+    }
+
+    /// <summary>True for a <c>none</c>/empty track template (no explicit tracks).</summary>
+    private static bool IsNoneOrEmptyTemplate(string template)
+        => string.IsNullOrWhiteSpace(template)
+            || template.Trim().Equals("none", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Build fixed (px) track-sizing functions from inherited subgrid sizes.</summary>
+    private static List<GridTrackSpec> FixedTrackSpecs(double[] sizes)
+    {
+        if (sizes == null)
+            return null;
+        var specs = new List<GridTrackSpec>(sizes.Length);
+        foreach (var s in sizes)
+        {
+            var g = new GridSize(GridSizeKind.Fixed, s);
+            specs.Add(new GridTrackSpec(g, g));
+        }
+        return specs;
     }
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -429,6 +429,21 @@ internal abstract class CssBoxProperties
     /// returns it when set. Null for every other box.
     /// </summary>
     internal RectangleF? GridAreaContainingBlock { get; set; }
+
+    /// <summary>
+    /// CSS Grid Level 2 §7.3 (subgrid): when this box is a grid item whose
+    /// <c>grid-template-columns</c> is <c>subgrid</c>, the parent grid's
+    /// track-sizing pass records here the sizes (px) of the parent tracks this
+    /// item's grid area spans, so the subgrid lays its own items out into the
+    /// inherited tracks instead of parsing a template. Null when not a
+    /// column-subgrid or not yet resolved by the parent. <see cref="SubgridRowSizes"/>
+    /// is the analogous row-axis inheritance; the gaps carry the parent's gutters,
+    /// which a subgridded axis adopts (CSS Grid L2 §7.3).
+    /// </summary>
+    internal double[] SubgridColumnSizes { get; set; }
+    internal double[] SubgridRowSizes { get; set; }
+    internal double? SubgridColumnGap { get; set; }
+    internal double? SubgridRowGap { get; set; }
     public string Height
     {
         get => ResolvePhysicalSize(_height, isWidth: false);

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -419,6 +419,16 @@ internal abstract class CssBoxProperties
     /// rely on <c>AdjustAbsolutePosition</c>.
     /// </summary>
     internal bool AbsposLocationFinalized { get; set; }
+
+    /// <summary>
+    /// When this box is an absolutely-positioned grid item, the grid container's
+    /// track-sizing pass records the item's resolved grid area here in absolute
+    /// coordinates (X/Y = area origin, Width/Height = area size). CSS Grid §9
+    /// makes that area — not the grid container's padding box — the box's
+    /// containing block, so <see cref="CssBox.GetAbsoluteContainingBlockPaddingBox"/>
+    /// returns it when set. Null for every other box.
+    /// </summary>
+    internal RectangleF? GridAreaContainingBlock { get; set; }
     public string Height
     {
         get => ResolvePhysicalSize(_height, isWidth: false);

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -525,7 +525,7 @@ internal static class CssUtils
                 cssBox.Content = value;
                 break;
             case "display":
-                cssBox.Display = value;
+                cssBox.Display = NormalizeDisplayValue(value);
                 break;
             case "direction":
                 cssBox.Direction = value;
@@ -691,6 +691,45 @@ internal static class CssUtils
         cssBox.GridAutoFlow = "row";
         cssBox.GridAutoRows = "auto";
         cssBox.GridAutoColumns = "auto";
+    }
+
+    private static readonly string[] DisplayOutsideKeywords = ["block", "inline", "run-in"];
+
+    /// <summary>
+    /// Normalize a <c>display</c> value the layout engine consumes: collapse the
+    /// CSS Display 3 two-value syntax (<c>inline grid</c>, <c>block flow-root</c>,
+    /// …) to its legacy single keyword, and map the experimental CSS Grid Level 3
+    /// <c>grid-lanes</c> &lt;display-inside&gt; to a grid formatting context
+    /// (<c>grid</c>/<c>inline-grid</c>). Single-keyword values pass through
+    /// unchanged apart from a bare <c>grid-lanes</c>.
+    /// </summary>
+    internal static string NormalizeDisplayValue(string value)
+    {
+        string v = value.Trim();
+        var parts = v.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 1)
+            return parts[0].Equals("grid-lanes", StringComparison.OrdinalIgnoreCase) ? "grid" : v;
+        if (parts.Length != 2)
+            return v;
+
+        string a = parts[0].ToLowerInvariant(), b = parts[1].ToLowerInvariant();
+        string outside, inside;
+        if (Array.IndexOf(DisplayOutsideKeywords, a) >= 0) { outside = a; inside = b; }
+        else if (Array.IndexOf(DisplayOutsideKeywords, b) >= 0) { outside = b; inside = a; }
+        else return v; // not a recognized two-value form; leave for the caller
+
+        // grid-lanes behaves as grid for our engine (experimental CSS Grid L3).
+        if (inside == "grid-lanes") inside = "grid";
+        bool isInline = outside == "inline";
+        return inside switch
+        {
+            "grid" => isInline ? "inline-grid" : "grid",
+            "flex" => isInline ? "inline-flex" : "flex",
+            "table" => isInline ? "inline-table" : "table",
+            "flow-root" => isInline ? "inline-block" : "flow-root",
+            "flow" => isInline ? "inline" : "block",
+            _ => v,
+        };
     }
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -346,6 +346,12 @@ internal static class CssUtils
             case "grid-auto-columns":
                 cssBox.GridAutoColumns = value;
                 break;
+            case "grid":
+                ApplyGridShorthand(cssBox, value, resetAutoTracks: true);
+                break;
+            case "grid-template":
+                ApplyGridShorthand(cssBox, value, resetAutoTracks: false);
+                break;
             case "contain":
                 cssBox.Contain = value;
                 break;
@@ -636,6 +642,76 @@ internal static class CssUtils
                 cssBox.AnimationPlayState = value;
                 break;
         }
+    }
+
+    /// <summary>
+    /// CSS Grid §7.4/§7.8: expand the <c>grid</c> and <c>grid-template</c>
+    /// shorthands into <c>grid-template-rows</c>/<c>grid-template-columns</c>.
+    /// Only the <c>none</c> and <c>&lt;rows&gt; / &lt;columns&gt;</c> forms are
+    /// expanded (they cover the common author usage, e.g.
+    /// <c>grid: 50px 50px / 50px 50px</c>); the <c>auto-flow</c> and
+    /// template-areas <c>&lt;string&gt;</c> forms are left untouched — their
+    /// longhands keep their cascaded/initial values — rather than risk
+    /// mis-parsing them. The full <c>grid</c> shorthand additionally resets the
+    /// implicit-track longhands to their initial values when it applies, per the
+    /// spec's reset semantics.
+    /// </summary>
+    private static void ApplyGridShorthand(CssBox cssBox, string value, bool resetAutoTracks)
+    {
+        string v = value.Trim();
+        if (v.Equals("none", StringComparison.OrdinalIgnoreCase))
+        {
+            cssBox.GridTemplateRows = "none";
+            cssBox.GridTemplateColumns = "none";
+            if (resetAutoTracks) ResetGridAutoTracks(cssBox);
+            return;
+        }
+
+        // The auto-flow and template-areas (<string>) forms are out of scope:
+        // leave every longhand as the cascade already set it.
+        if (v.IndexOf("auto-flow", StringComparison.OrdinalIgnoreCase) >= 0
+            || v.Contains('"') || v.Contains('\''))
+            return;
+
+        int slash = TopLevelSlashIndex(v);
+        if (slash < 0)
+            return;
+        string rows = v.Substring(0, slash).Trim();
+        string cols = v.Substring(slash + 1).Trim();
+        if (rows.Length == 0 || cols.Length == 0)
+            return;
+
+        cssBox.GridTemplateRows = rows;
+        cssBox.GridTemplateColumns = cols;
+        if (resetAutoTracks) ResetGridAutoTracks(cssBox);
+    }
+
+    private static void ResetGridAutoTracks(CssBox cssBox)
+    {
+        cssBox.GridAutoFlow = "row";
+        cssBox.GridAutoRows = "auto";
+        cssBox.GridAutoColumns = "auto";
+    }
+
+    /// <summary>
+    /// Index of the row/column separator slash in a <c>grid</c>/<c>grid-template</c>
+    /// value, ignoring any slash nested inside <c>()</c> or <c>[]</c> (a track list
+    /// itself never contains a top-level slash). Returns -1 when there is none.
+    /// </summary>
+    private static int TopLevelSlashIndex(string v)
+    {
+        int paren = 0, bracket = 0;
+        for (int i = 0; i < v.Length; i++)
+        {
+            char c = v[i];
+            if (c == '(') paren++;
+            else if (c == ')') { if (paren > 0) paren--; }
+            else if (c == '[') bracket++;
+            else if (c == ']') { if (bracket > 0) bracket--; }
+            else if (c == '/' && paren == 0 && bracket == 0)
+                return i;
+        }
+        return -1;
     }
 
     private static void ApplyLogicalBorderShorthand(CssBox cssBox, string value, bool inlineAxis)

--- a/patches/0002-css-two-value-display-grid-lanes.patch
+++ b/patches/0002-css-two-value-display-grid-lanes.patch
@@ -1,0 +1,79 @@
+From f20ed77da62b035d1b8ade5293ac8b1077f71027 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sat, 4 Jul 2026 09:06:53 +0000
+Subject: [PATCH] Accept CSS Display 3 two-value display syntax and grid-lanes
+
+IsAcceptableDeclarationValue rejected the two-value display syntax
+(<display-outside> <display-inside>, e.g. "inline grid", "block flow-root")
+and the experimental grid-lanes <display-inside>, dropping those declarations
+so the element fell back to its default display. Accept both forms (via a new
+IsTwoValueDisplay helper) so the layout engine can normalize them to a legacy
+single keyword.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+---
+ Broiler.CSS.Dom/CssStyleEngine.Values.cs | 34 ++++++++++++++++++++++--
+ 1 file changed, 32 insertions(+), 2 deletions(-)
+
+diff --git a/Broiler.CSS.Dom/CssStyleEngine.Values.cs b/Broiler.CSS.Dom/CssStyleEngine.Values.cs
+index 542e0fc..0cfc59d 100644
+--- a/Broiler.CSS.Dom/CssStyleEngine.Values.cs
++++ b/Broiler.CSS.Dom/CssStyleEngine.Values.cs
+@@ -307,7 +307,7 @@ public sealed partial class CssStyleEngine
+                     or "pre-line" or "break-spaces";
+ 
+             case "display":
+-                return v is "block" or "inline" or "inline-block" or "none"
++                if (v is "block" or "inline" or "inline-block" or "none"
+                     or "flex" or "inline-flex" or "grid" or "inline-grid"
+                     or "table" or "inline-table" or "table-row" or "table-cell"
+                     or "table-column" or "table-row-group" or "table-header-group"
+@@ -320,7 +320,16 @@ public sealed partial class CssStyleEngine
+                     // valid declaration and falling back to a stale cascade value.
+                     or "ruby" or "ruby-base" or "ruby-text"
+                     or "ruby-base-container" or "ruby-text-container"
+-                    or "math";
++                    or "math"
++                    // Experimental CSS Grid Level 3 <display-inside> keyword; the
++                    // layout engine maps it to a grid formatting context.
++                    or "grid-lanes")
++                    return true;
++                // CSS Display 3 two-value syntax: <display-outside> <display-inside>
++                // (e.g. "inline grid", "block flow-root"). Accept a valid pair in
++                // either order so the layout engine can normalize it to a legacy
++                // single keyword.
++                return IsTwoValueDisplay(v);
+ 
+             case "position":
+                 return v is "static" or "relative" or "absolute" or "fixed" or "sticky";
+@@ -426,6 +435,27 @@ public sealed partial class CssStyleEngine
+         }
+     }
+ 
++    /// <summary>
++    /// CSS Display 3 §2.1: validate the two-value <c>display</c> syntax
++    /// (<c>&lt;display-outside&gt; &amp;&amp; &lt;display-inside&gt;</c>), e.g.
++    /// <c>inline grid</c> or <c>block flow-root</c>. The two keywords may appear
++    /// in either order. <c>grid-lanes</c> is accepted as an experimental
++    /// &lt;display-inside&gt; (the layout engine maps it to grid).
++    /// </summary>
++    private static bool IsTwoValueDisplay(string value)
++    {
++        var parts = value.Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
++        if (parts.Length != 2)
++            return false;
++
++        static bool IsOutside(string k) => k is "block" or "inline" or "run-in";
++        static bool IsInside(string k) => k is "flow" or "flow-root" or "table"
++            or "flex" or "grid" or "grid-lanes" or "ruby";
++
++        return (IsOutside(parts[0]) && IsInside(parts[1]))
++            || (IsInside(parts[0]) && IsOutside(parts[1]));
++    }
++
+     private static bool IsBorderStyleList(string value)
+     {
+         var parts = SplitCssValues(value);
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -21,7 +21,19 @@ cd .. && git add <Submodule> && git commit -m "Bump <Submodule>: <summary>"
 
 ## Index
 
-_(none currently pending)_
+- **0002-css-two-value-display-grid-lanes.patch** → `Broiler.CSS`
+  (`Broiler.CSS.Dom/CssStyleEngine.Values.cs`) — makes `IsAcceptableDeclarationValue`
+  accept the CSS Display 3 two-value `display` syntax (`<display-outside>
+  <display-inside>`, e.g. `inline grid`, `block flow-root`) and the experimental
+  CSS Grid Level 3 `grid-lanes` `<display-inside>`, instead of dropping them.
+  The parent repo's `CssUtils.NormalizeDisplayValue` then collapses those to a
+  legacy single keyword (`inline grid` → `inline-grid`, `grid-lanes` → `grid`).
+  Until this patch is applied, the submodule still drops the two-value/grid-lanes
+  declarations at validation, so `NormalizeDisplayValue` never sees them and the
+  parent-repo change is an inert no-op (single-keyword values pass through
+  unchanged) — no CI fallback is needed. The companion **subgrid** support
+  (`Broiler.Layout` `CssBoxGrid.TryApplyGridTrackLayout`) is entirely in the
+  parent repo and is live on CI without this patch.
 
 ## Applied / obsolete
 


### PR DESCRIPTION
## Summary

Adds support for CSS Grid Level 2 subgrid (`grid-template-columns: subgrid` / `grid-template-rows: subgrid`) and CSS Grid §9 absolutely-positioned grid items. Also expands the `grid` and `grid-template` shorthands and normalizes the CSS Display 3 two-value `display` syntax.

## Key Changes

**Grid track layout (`CssBoxGrid.cs`)**
- Detect and handle subgridded axes: when a grid item declares `subgrid` on an axis, inherit the parent grid's track sizes over the item's spanned area instead of parsing a template
- Support absolutely-positioned grid items: collect them separately during placement, then resolve their grid areas and position them within those areas (which form their containing block per CSS Grid §9)
- Adopt parent grid's gutter for subgridded axes; treat a subgridded axis with implicit-only tracks (e.g. `grid-auto-rows`) as valid
- Recursively lay out subgrid items once the parent grid's tracks are sized

**Absolutely-positioned grid item placement**
- `PlaceAbsposGridItems`: resolve each abspos item's grid area from sized tracks; auto lines resolve to container padding edges, specified lines to grid line positions
- `PlaceAbsposItemInArea`: position the item within its grid area (the containing block), resolving insets and sizes against the area rather than the container's padding box
- Record the grid area on the item so later abspos re-resolution uses it uniformly

**Subgrid support**
- `LayoutSubgridItem`: after sizing a subgrid item, pass inherited track sizes and gaps to it and re-run its grid layout
- `SliceTrackSizes`: extract the parent's track sizes over the item's spanned range
- `StartsWithSubgrid` / `IsNoneOrEmptyTemplate`: helpers to detect subgrid declarations and implicit-only templates
- `FixedTrackSpecs`: convert inherited subgrid sizes to fixed (px) track specs

**Grid shorthand expansion (`CssUtils.cs`)**
- `ApplyGridShorthand`: expand `grid` and `grid-template` shorthands to `grid-template-rows` / `grid-template-columns` for the common `<rows> / <columns>` form; reset implicit-track longhands for the full `grid` shorthand
- `TopLevelSlashIndex`: find the row/column separator slash, ignoring nesting in `()` or `[]`

**Display value normalization (`CssUtils.cs`)**
- `NormalizeDisplayValue`: collapse CSS Display 3 two-value syntax (`inline grid`, `block flow-root`, etc.) to legacy single keywords; map experimental `grid-lanes` to `grid`

**Box properties (`CssBoxProperties.cs`)**
- `GridAreaContainingBlock`: record an abspos grid item's resolved grid area (the containing block)
- `SubgridColumnSizes` / `SubgridRowSizes` / `SubgridColumnGap` / `SubgridRowGap`: inherit parent grid's track sizes and gaps for subgridded axes

**Containing block resolution (`CssBox.cs`)**
- When `GridAreaContainingBlock` is set, use it as the containing block for abspos size/offset resolution instead of the grid container's padding box

## Patch

A companion patch (`0002-css-two-value-display-grid-lanes.patch`) updates `Broiler.CSS` to accept the two-value `display` syntax and `grid-lanes` at validation so they reach the layout engine's normalizer. Until applied, single-keyword values still work (the normalizer is inert for them); subgrid support in the layout engine is live without the patch.

https://claude.ai/code/session_013ncuJrCTkkd6RCbvkVdcFD