### PR TITLE
Fix orthogonal-flow auto inline-size to collapse instead of fill

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -1275,6 +1275,53 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
                     Size = new SizeF((float)stfWidth, Size.Height);
                 }
+                else if ((Width == CssConstants.Auto || string.IsNullOrEmpty(Width))
+                    && Float == CssConstants.None
+                    && Position != CssConstants.Absolute && Position != CssConstants.Fixed
+                    && VerticalFlowPrototype.Enabled
+                    && IsVerticalWritingMode(WritingMode)
+                    && (ParentBox == null || !IsVerticalWritingMode(ParentBox.WritingMode))
+                    && ContainingBlock is { ParentBox: not null } orthoCb
+                    && (string.IsNullOrEmpty(orthoCb.Height) || orthoCb.Height == CssConstants.Auto))
+                {
+                    // CSS Writing Modes 4 §7.3 (auto-sizing in orthogonal flows):
+                    // a box establishing an orthogonal flow — here a vertical
+                    // writing-mode box inside a non-vertical containing block — with
+                    // an auto inline size is sized to fit-content, NOT stretched to
+                    // the containing block's (perpendicular) inline size. In the
+                    // vertical-flow prototype this box is laid out in a logical
+                    // horizontal frame where its logical width IS its inline size, so
+                    // compute that width as shrink-to-fit; the post-layout rotation
+                    // (ApplyVerticalWritingModeFlow) then maps it onto physical height.
+                    // Gated on an indefinite containing-block block size (an auto-height
+                    // in-flow ancestor) so a definite orthogonal size — a root box
+                    // filling the viewport, or an explicit-height container — keeps the
+                    // existing fill behaviour. Without this, an empty (or short)
+                    // vertical box fills the container width and rotates into a
+                    // viewport-tall strip instead of collapsing to its content
+                    // (WPT css-grid/grid-lanes row-subgrid-auto-fill-007).
+                    EnsureDescendantWordsMeasured(g);
+
+                    double preferred = ComputeShrinkToFitWidth();
+                    // Indefinite orthogonal available inline size falls back to the
+                    // initial containing block (viewport) block size — here the
+                    // viewport height, the vertical inline axis's extent.
+                    double available = LayoutEnvironment?.ViewportSize.Height ?? width;
+
+                    GetMinMaxWidth(out double prefMin, out _);
+                    if (double.IsNaN(prefMin)) prefMin = 0;
+                    if (double.IsNaN(preferred)) preferred = 0;
+                    double stfWidth = Math.Min(Math.Max(prefMin, available), preferred);
+
+                    // Border/padding added for the border-box width Size.Width holds
+                    // (shrink-to-fit yields a content width). max-width/min-width are
+                    // physical-width (block-size) constraints and do not clamp the
+                    // inline size resolved here.
+                    stfWidth += ActualBorderLeftWidth + ActualBorderRightWidth
+                              + ActualPaddingLeft + ActualPaddingRight;
+
+                    Size = new SizeF((float)stfWidth, Size.Height);
+                }
                 else if (Width == CssConstants.Auto || string.IsNullOrEmpty(Width))
                 {
                     // Margins reduce the box width only for auto-width elements.

--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -44,6 +44,7 @@ Status snapshot and next steps for the Web Platform Tests (WPT) effort tracked i
 | 26 | Definite-track grid items over-painted at stale inline-block size + grid collapsed to occupied rows; Chromium references rendered blank because the generator only served `/fonts/` (#1209) | ✅ fixed | Broiler.Layout + scripts/generate-wpt-references.js |
 | 27 | #1209's reference generator over-corrected: serving **every** root-relative resource pulled in the real `/resources/testharness.js` + `check-layout-th.js`, so ~206 harness-driven `css-grid` tests regressed to `MissingContent` (Chromium painted a results table Broiler's harness stubs never render) (#1212) | ✅ fixed | scripts/generate-wpt-references.js |
 | 28 | Grid pass only did fixed tracks; `fr`/`auto`/`min-content`/`max-content`/`minmax()` declined to the single-column approximation, and subgrid needs real parent track sizing first (#1212) | 🟡 partial | Broiler.Layout/CssBoxGrid |
+| 29 | `grid-lanes/subgrid` reftests at 0–1 %: empty **orthogonal-flow** (`vertical-rl`) box filled its container and rotated into a viewport-tall strip instead of collapsing to fit-content (§7.3) — whole `row-subgrid-auto-fill-*` cluster now matches; `column-subgrid-auto-fill-*` still needs multi-column named-line subgrid layout (#1221) | 🟡 partial | Broiler.Layout |
 
 Cluster 13 (issue [#1140](https://github.com/MaiRat/Broiler/issues/1140), the dominant new
 `css-backgrounds` directory — 30 failures, with `background-clip-root` at the worst-case **0 %
@@ -620,7 +621,9 @@ comparison**, both surfacing as `MissingContent`:
    open for deeper reasons unrelated to grid layout: the `grid-container-change-*` /
    `grid-template-*-changes` tests set their grid up in a `document.fonts.ready.then(…)` callback and
    render the testharness results summary table on-screen (Broiler runs neither), and the six
-   `grid-lanes/subgrid` tests need `subgrid` support.
+   `grid-lanes/subgrid` tests need `subgrid` support. (Update: the `row-subgrid-auto-fill-*` half of
+   those was fixed in cluster 29 — it was an orthogonal-flow sizing bug, not missing subgrid support;
+   the `column-subgrid-auto-fill-*` half still needs multi-column named-line subgrid layout.)
 
 Cluster 27 (issue [#1212](https://github.com/Broiler-Platform/Broiler/issues/1212), "about 100
 more failures since the last change") was a **regression introduced by cluster 26's own fix**. Point 2
@@ -674,6 +677,39 @@ approximation already handles. Verified by `GridTrackLayoutTests` (fr split, fix
 `position-try-grid-001` improves 87.7 % → 97.1 %). Still deferred, and the actual gate for the subgrid
 cluster: **subgrid track adoption** (a subgrid item inheriting its parent's spanned tracks), `fit-content()`,
 `repeat(auto-fill/auto-fit)`, and named lines.
+
+Cluster 29 (issue [#1221](https://github.com/Broiler-Platform/Broiler/issues/1221), the
+`css-grid/grid-lanes/subgrid` reftests at 0–1 % match) split into two independent causes, both
+downstream of `grid-lanes` dropping to a block (#1218 — no browser ships the experimental Grid Level 3
+`grid-lanes` keyword unflagged, so the reference generator's Chromium and Broiler alike drop it to the
+element's default display):
+
+1. **`row-subgrid-auto-fill-*` (the 0 % worst case, `row-subgrid-auto-fill-007`) — fixed.** Each
+   test's `.subgrid` is an empty `writing-mode: vertical-rl` grid inside the auto-height block the
+   `grid-lanes` container became — a box **establishing an orthogonal flow**. The vertical-flow
+   prototype lays such a box out in a logical horizontal frame and rotates it into physical space; with
+   an auto inline size it filled its containing block's *width* in that frame, so the rotation mapped
+   that width onto the box's physical **height** and the empty box became a viewport-tall light-grey
+   strip where Chromium collapses to blank (0 % / `MissingContent`). Fixed in `CssBox.PerformLayoutImp`
+   per CSS Writing Modes 4 §7.3 (auto-sizing in orthogonal flows): an in-flow vertical rotation root
+   with an auto inline size and an **indefinite** orthogonal available size (an auto-height containing
+   block) is sized to fit-content instead of stretched — so it collapses to its content, matching
+   Chromium. Gated on the indefinite case so a definite orthogonal size (a root box filling the
+   viewport, an explicit-height container) keeps the existing fill behaviour. The whole
+   `row-subgrid-auto-fill-*` cluster (8 tests) now matches its Chromium reference (`-007` 0 % → 100 %,
+   the rest ≥ 88 %), verified by re-rendering each test file against a locally-generated Playwright
+   Chromium screenshot (grid-lanes drops identically in every Chromium version, so the local shot
+   reproduces the CI reference — confirmed by the `-007`/`column-001` matches reproducing the issue's
+   0.0 %/0.5 % exactly); the full local `css` subset (147 tests) has an identical pass set before/after
+   (zero regressions). Guard: `OrthogonalFlowCollapseTests` (`Broiler.Wpt.Tests`).
+2. **`column-subgrid-auto-fill-*` — still open (larger feature).** Here `.subgrid` is a *horizontal*
+   block-level grid with `grid-auto-rows: 8px` and many named-line-placed children
+   (`grid-column: y N`); Chromium renders a grey multi-column grid (≈ 89 % of the reference is the grey
+   `.subgrid` background). Broiler's single-column grid approximation ignores `grid-auto-rows` and
+   cannot resolve the `subgrid` / `repeat(auto-fill, [line-names])` / named-line columns, so the
+   subgrids collapse to a thin strip. Matching these needs the deferred **multi-column named-line
+   subgrid** track layout (cluster 28's tail); a `grid-auto-rows`-only shortcut would stack the children
+   full-width and over-paint the grey, so it is not attempted here.
 
 Cluster 11 (issue [#1119](https://github.com/MaiRat/Broiler/issues/1119), the dominant
 `PixelMismatch / MissingContent` family, 328 failures) was a render-serialization bug that

--- a/src/Broiler.Wpt.Tests/OrthogonalFlowCollapseTests.cs
+++ b/src/Broiler.Wpt.Tests/OrthogonalFlowCollapseTests.cs
@@ -1,0 +1,107 @@
+using System.IO;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression test for CSS Writing Modes 4 §7.3 (auto-sizing in orthogonal
+/// flows): a box establishing an orthogonal flow — a vertical writing-mode box
+/// inside a non-vertical containing block — with an auto inline size is sized to
+/// <em>fit-content</em>, not stretched to the containing block's perpendicular
+/// inline size.
+///
+/// <para>Before the fix, the vertical-flow prototype laid such a box out in a
+/// logical horizontal frame where it filled the containing block's width; the
+/// post-layout rotation then mapped that width onto the box's physical height, so
+/// an empty <c>writing-mode: vertical-rl</c> box rotated into a viewport-tall
+/// strip instead of collapsing. This surfaced in the WPT
+/// <c>css-grid/grid-lanes/subgrid/…/row-subgrid-auto-fill-*</c> reftests: the
+/// <c>grid-lanes</c> container drops to a block (no browser ships grid-lanes
+/// unflagged) and its child is an empty <c>vertical-rl</c> grid, which Chromium
+/// collapses to blank but Broiler painted as a full-viewport light-grey block — a
+/// 0% pixel match. The orthogonal box must collapse to its content instead.</para>
+/// </summary>
+public class OrthogonalFlowCollapseTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public OrthogonalFlowCollapseTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "broiler-ortho-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        Program.ResetTestHooks();
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // Renders the body on a white canvas and returns the fraction of non-white
+    // pixels — i.e. how much of the viewport the content covers.
+    private double NonWhiteFraction(string body, int width, int height)
+    {
+        var html = $@"<!DOCTYPE html>
+<style> html, body {{ margin: 0; background: white; }} </style>
+<body>{body}</body>";
+        var file = Path.Combine(_tempDir, "t-" + Guid.NewGuid().ToString("N")[..6] + ".html");
+        File.WriteAllText(file, html);
+
+        var runner = new WptTestRunner(width, height);
+        using var bmp = runner.RenderHtmlFileBitmapPublic(file, _tempDir);
+
+        int nonWhite = 0;
+        for (int y = 0; y < height; y++)
+        for (int x = 0; x < width; x++)
+        {
+            var p = bmp.GetPixel(x, y);
+            if (p.R < 245 || p.G < 245 || p.B < 245)
+                nonWhite++;
+        }
+        return (double)nonWhite / (width * height);
+    }
+
+    [Fact]
+    public void EmptyVerticalRlBox_InAutoHeightBlock_CollapsesInsteadOfFillingViewport()
+    {
+        // .g is an auto-height block (a light-grey background makes any spurious
+        // fill visible); its child is an empty vertical-rl grid whose only item is
+        // an empty 10px box — the row-subgrid-auto-fill-007 shape once grid-lanes
+        // has dropped to a block. Chromium collapses this to blank.
+        var body =
+            "<div style=\"background:lightgrey\">" +
+              "<div style=\"display:grid;writing-mode:vertical-rl;background:black\">" +
+                "<div style=\"min-width:10px;min-height:0;background:grey\"></div>" +
+              "</div>" +
+            "</div>";
+
+        double frac = NonWhiteFraction(body, 400, 300);
+
+        // Before the fix the vertical box filled the container width and rotated
+        // into a viewport-tall strip (~100% of the canvas non-white). After it
+        // collapses to its content — at most a tiny sliver.
+        Assert.True(frac < 0.05,
+            $"empty vertical-rl box did not collapse: {frac:P1} of the canvas is non-white " +
+            "(orthogonal-flow auto inline-size regressed to filling the containing block).");
+    }
+
+    [Fact]
+    public void VerticalRlBox_WithDefiniteHeightContainingBlock_IsUnaffected()
+    {
+        // A definite containing-block block size (an explicit-height parent) keeps
+        // the existing behaviour: the guard only engages for an indefinite (auto)
+        // orthogonal available size, so this box still paints. Locks the fix's
+        // scope so it cannot silently start collapsing definite-size vertical boxes.
+        var body =
+            "<div style=\"height:100px;background:lightgrey\">" +
+              "<div style=\"display:grid;writing-mode:vertical-rl;background:black\">" +
+                "<div style=\"width:20px;height:20px;background:grey\"></div>" +
+              "</div>" +
+            "</div>";
+
+        double frac = NonWhiteFraction(body, 400, 300);
+
+        Assert.True(frac > 0.01,
+            $"definite-height vertical container unexpectedly collapsed: only {frac:P2} non-white.");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes CSS Writing Modes 4 §7.3 auto-sizing in orthogonal flows: a vertical writing-mode box with an auto inline size inside a non-vertical containing block now sizes to fit-content instead of stretching to fill the containing block's width. This resolves the `row-subgrid-auto-fill-*` WPT cluster (8 tests, previously 0–1 % match) where empty `vertical-rl` grids were incorrectly rendering as viewport-tall strips.

## Changes

- **`CssBox.PerformLayoutImp`**: Added orthogonal-flow auto inline-size handling that computes shrink-to-fit width for a vertical writing-mode box inside a non-vertical containing block with an indefinite (auto-height) block size. The fix is gated on the indefinite case to preserve existing fill behaviour for definite orthogonal sizes (root boxes, explicit-height containers).

- **`OrthogonalFlowCollapseTests`**: New regression test suite verifying that empty `vertical-rl` boxes collapse to their content instead of filling the viewport, and that definite-height containers remain unaffected.

- **`docs/roadmap/wpt-triage-and-diagnostics.md`**: Updated cluster 29 entry documenting the fix and its scope; noted that `column-subgrid-auto-fill-*` tests remain open pending multi-column named-line subgrid layout.

## Implementation Details

The vertical-flow prototype lays orthogonal boxes in a logical horizontal frame and rotates them into physical space post-layout. With an auto inline size, such a box was filling its containing block's width in that frame, causing the rotation to map that width onto the box's physical height — making empty boxes appear as viewport-tall strips.

The fix detects this case (vertical writing-mode, auto inline-size, non-vertical parent, indefinite orthogonal available size) and applies shrink-to-fit sizing before layout, ensuring the box collapses to its content. The indefinite-size guard prevents the fix from affecting definite orthogonal scenarios where fill behaviour is correct.

**Result**: The `row-subgrid-auto-fill-*` cluster now matches Chromium references (row-subgrid-auto-fill-007: 0 % → 100 %; others ≥ 88 %). Zero regressions in the full local `css` subset (147 tests).

https://claude.ai/code/session_01JWfZij5gNrL9JXjKVCvuH5