### PR TITLE
Fix grid item percentage height resolving against width

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -1007,7 +1007,30 @@ internal static class CssLayoutEngine
 
         // --- Compute height ---
         double ibHeight;
-        if (b.Height != CssConstants.Auto && !string.IsNullOrEmpty(b.Height))
+        bool heightIsPercent = !string.IsNullOrEmpty(b.Height) && b.Height.Contains('%');
+        // A grid item's percentage block size resolves against its grid *area*
+        // (the track), which is not known here — the track pass / PlaceItemInArea
+        // sizes percentage/auto grid items to their area later. So measure an
+        // in-flow grid item at its content height for now instead of resolving
+        // the percentage against the container *width* (the wrong basis in the
+        // branch below): that basis made an auto-height grid item with
+        // height:100% balloon to ~100% of the grid width and, clipped to the
+        // viewport, paint a full-viewport box (WPT
+        // css-grid/grid-items/whitespace-in-grid-item-001); it also handed the
+        // §11 track pass an inflated block size that tripped its "did a narrowed
+        // column reflow this?" guard into declining to the stacking
+        // approximation. Restricted to in-flow grid items — every other box
+        // (inline-block, flex item, replaced inline SVG/img, out-of-flow static
+        // positions) keeps its existing sizing untouched.
+        bool isInFlowGridItem =
+            b.Position is not (CssConstants.Absolute or CssConstants.Fixed)
+            && b.ParentBox != null
+            && b.ParentBox.Display is "grid" or "inline-grid";
+        if (heightIsPercent && isInFlowGridItem)
+        {
+            ibHeight = Math.Max(0, b.ActualBottom - b.Location.Y);
+        }
+        else if (b.Height != CssConstants.Auto && !string.IsNullOrEmpty(b.Height))
         {
             double cssHeight = CssValueParser.ParseLength(b.Height, containerWidth, b.GetEmHeight());
             ibHeight = b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase)

--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -45,6 +45,7 @@ Status snapshot and next steps for the Web Platform Tests (WPT) effort tracked i
 | 27 | #1209's reference generator over-corrected: serving **every** root-relative resource pulled in the real `/resources/testharness.js` + `check-layout-th.js`, so ~206 harness-driven `css-grid` tests regressed to `MissingContent` (Chromium painted a results table Broiler's harness stubs never render) (#1212) | ✅ fixed | scripts/generate-wpt-references.js |
 | 28 | Grid pass only did fixed tracks; `fr`/`auto`/`min-content`/`max-content`/`minmax()` declined to the single-column approximation, and subgrid needs real parent track sizing first (#1212) | 🟡 partial | Broiler.Layout/CssBoxGrid |
 | 29 | `grid-lanes/subgrid` reftests at 0–1 %: empty **orthogonal-flow** (`vertical-rl`) box filled its container and rotated into a viewport-tall strip instead of collapsing to fit-content (§7.3) — whole `row-subgrid-auto-fill-*` cluster now matches; `column-subgrid-auto-fill-*` still needs multi-column named-line subgrid layout (#1221) | 🟡 partial | Broiler.Layout |
+| 30 | Grid-item `height:100%` ballooned to fill the viewport: the inline-block fallback resolved a percentage height against the container **width** and skipped the §10.5 indefinite-CB→`auto` rule (`whitespace-in-grid-item-001` 9 %→98.5 %) (#1227) | ✅ fixed | Broiler.Layout |
 
 Cluster 13 (issue [#1140](https://github.com/MaiRat/Broiler/issues/1140), the dominant new
 `css-backgrounds` directory — 30 failures, with `background-clip-root` at the worst-case **0 %
@@ -710,6 +711,44 @@ element's default display):
    subgrids collapse to a thin strip. Matching these needs the deferred **multi-column named-line
    subgrid** track layout (cluster 28's tail); a `grid-auto-rows`-only shortcut would stack the children
    full-width and over-paint the grey, so it is not attempted here.
+
+Cluster 30 (issue [#1227](https://github.com/Broiler-Platform/Broiler/issues/1227), the "biggest
+problems" CSS Grid list — the `grid-items` tests at ~9 % match) was a **grid-item percentage-height**
+bug in the inline-block fallback. `css-grid/grid-items/whitespace-in-grid-item-001`'s `.item`
+(`height:100%; width:30px`) rendered the grey `.grid` container filling the **whole viewport** instead
+of collapsing. Root cause was `CssLayoutEngine.FlowInlineBlock` — the path every flex/grid item and
+inline-block takes in Broiler's approximation — resolving a percentage `height` with
+`ParseLength(b.Height, containerWidth, …)`, i.e. against the container **width**. A grid item's
+percentage block size resolves against its grid *area* (the track), which is not known at this point —
+the §11 track pass / `PlaceItemInArea` sizes percentage/auto grid items to their area *later*. So the
+empty `height:100%` item was sized to 100 % of the grid *width* and, clipped to the viewport, painted a
+full-viewport grey box (the reference collapses to nothing). Fixed **narrowly**: an in-flow grid item
+(`b.ParentBox` is `grid`/`inline-grid`, not abspos/fixed) with a percentage height is measured at its
+**content height** here, and `PlaceItemInArea` then sizes it to the resolved track. Every other box —
+plain inline-block, flex item, replaced inline SVG/img, out-of-flow static positions — keeps the exact
+original width-basis path, so the change is byte-neutral outside grid items. The grid-item case had a
+subtlety: the old width basis coincidentally sized `GridDoc`'s `.i{height:100%}` items right only when
+the grid width equalled the track height, and against a definite-height `fr` grid an over-broad first
+cut (measuring the item at the full container *height*) made the track pass's "would a narrowed column
+have reflowed this?" guard **decline** and drop to the stacking approximation — measuring at content
+height avoids that. (A broader variant that also applied §10.5 indefinite-CB→`auto` to *all*
+inline-blocks was reverted: it regressed `inline-svg-100-percent-in-body` — a replaced inline SVG with
+`height:100%` that must fill the body — so the fix is deliberately scoped to grid items only.) Verified:
+`whitespace-in-grid-item-001` **9.1 % → 98.5 %** against a locally-generated Chromium screenshot (the
+residual is the instruction-paragraph font/anti-aliasing tail, not the grid); minimal repros — a
+`display:grid` with an empty `height:100%` child now **collapses** (was viewport-filling), while a plain
+block, a flex container, and the replaced inline SVG were already correct and stay so;
+`GridTrackLayoutTests`/`GridTrackPaintTests` (16) all green including the fr-row split guard
+`GridFrRows_SplitDefiniteHeight` (caught the over-broad first cut); the inline-block/positioning-heavy
+local reftest subset (`css-align` + `CSS2/{abspos,normal-flow,visudet,positioning}`, 36 tests) has a
+**byte-identical** failure set before/after, and the two curated grid tests
+(`Wpt_PositionTryGrid001` 97.1 %, unchanged; `RunTestWithTimeout_GridTemplateColumnsCrash`) are
+unchanged. Main-repo (`Broiler.Layout`), active on CI. Guard:
+`GridTrackPaintTests.GridItem_PercentHeight_InAutoHeightGrid_CollapsesInsteadOfFillingViewport`.
+**Still open** in the #1227 list: `grid-size-with-orthogonal-child-001` (needs single-explicit-axis
+grid track sizing + orthogonal-flow intrinsic sizing), the `grid-lanes` auto-repeat / subgrid tail
+(feature work), and the JS-driven `grid-container-change-*` / `grid-template-*-changes` tests
+(`document.fonts.ready` + testharness results table).
 
 Cluster 11 (issue [#1119](https://github.com/MaiRat/Broiler/issues/1119), the dominant
 `PixelMismatch / MissingContent` family, 328 failures) was a render-serialization bug that

--- a/src/Broiler.Cli.Tests/GridTrackPaintTests.cs
+++ b/src/Broiler.Cli.Tests/GridTrackPaintTests.cs
@@ -91,4 +91,39 @@ public sealed class GridTrackPaintTests
         var belowGrid = bitmap.GetPixel(25, 165);
         Assert.True(Near(belowGrid, 255, 255, 255), $"below the grid should be white canvas, got {Describe(belowGrid)}");
     }
+
+    /// <summary>
+    /// A grid item's <c>height:100%</c> resolves against its grid <em>area</em>;
+    /// in an auto-height grid with no row template the area is itself content-sized,
+    /// so the percentage computes to <c>auto</c> and the empty item collapses to
+    /// zero height (CSS 2.1 §10.5). Before the fix the inline-block fallback
+    /// (<c>CssLayoutEngine.FlowInlineBlock</c>) resolved a percentage height against
+    /// the container <em>width</em> and never checked the containing block's height,
+    /// so an empty <c>height:100%</c> item ballooned to ~100% of the grid width and
+    /// the grey grid filled the entire viewport
+    /// (WPT css-grid/grid-items/whitespace-in-grid-item-001). The grid must instead
+    /// collapse, leaving the canvas below its top edge white.
+    /// </summary>
+    [Fact]
+    public void GridItem_PercentHeight_InAutoHeightGrid_CollapsesInsteadOfFillingViewport()
+    {
+        const string html =
+            "<!DOCTYPE html><html><head></head>"
+            + "<body style=\"margin:0\">"
+            + "<div style=\"display:grid;background:#808080;\">"
+            + "<div style=\"width:30px;height:100%;background:salmon;\"></div>"
+            + "</div></body></html>";
+
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(html, 200, 200);
+
+        // The empty height:100% item collapses to content (0), so the auto-height
+        // grid has no block extent: points below its top edge are the white canvas,
+        // not the grey grid background (which filled the viewport before the fix).
+        var mid = bitmap.GetPixel(10, 100);
+        Assert.True(Near(mid, 255, 255, 255),
+            $"grid must collapse (auto height), so y=100 is white canvas, got {Describe(mid)}");
+        var low = bitmap.GetPixel(120, 180);
+        Assert.True(Near(low, 255, 255, 255),
+            $"y=180 must be white canvas (grid collapsed), got {Describe(low)}");
+    }
 }


### PR DESCRIPTION
## Summary

Fixed a bug where grid items with `height:100%` in auto-height grids resolved their percentage against the container **width** instead of their grid area, causing empty items to balloon to fill the viewport. The fix narrows the percentage-height resolution path in `FlowInlineBlock` to measure in-flow grid items at their content height, deferring the actual track-based sizing to the track layout pass.

## Changes

- **Broiler.Layout/Engine/CssLayoutEngine.cs**: Modified `FlowInlineBlock` to detect in-flow grid items with percentage heights and measure them at their content height instead of resolving the percentage against container width. This prevents the incorrect sizing that caused `whitespace-in-grid-item-001` to fail (9% → 98.5% after fix). The change is scoped to grid items only; all other boxes (inline-block, flex items, replaced inline SVG/img, out-of-flow static positions) retain their original sizing behavior.

- **Broiler.Cli.Tests/GridTrackPaintTests.cs**: Added `GridItem_PercentHeight_InAutoHeightGrid_CollapsesInsteadOfFillingViewport` test to verify that an empty grid item with `height:100%` in an auto-height grid collapses to zero height (per CSS 2.1 §10.5) instead of filling the viewport.

- **docs/roadmap/wpt-triage-and-diagnostics.md**: Documented cluster 30 (issue #1227) in the WPT triage status, including root cause analysis, the fix scope, verification results, and remaining open items in the grid-items test cluster.

## Implementation Details

The root cause was that `CssLayoutEngine.FlowInlineBlock` — the path taken by every flex/grid item and inline-block in Broiler's approximation — resolved percentage `height` using `ParseLength(b.Height, containerWidth, …)`, treating the container **width** as the basis. For grid items, percentage block size should resolve against the grid *area* (track), which is not known at this point; the §11 track pass (`PlaceItemInArea`) sizes percentage/auto grid items to their area later.

The fix detects in-flow grid items (position is not absolute/fixed, parent display is grid/inline-grid) with percentage heights and measures them at their **content height** instead. This allows the track pass to then size them correctly to the resolved track. A subtlety: the old width-basis path coincidentally sized items correctly only when grid width equalled track height; measuring at content height avoids tripping the track pass's "would a narrowed column reflow this?" guard, which was declining to the stacking approximation on over-broad first cuts.

Verified: `whitespace-in-grid-item-001` improved from 9.1% to 98.5% match; minimal repros confirm the fix (empty `height:100%` child now collapses), and existing grid/inline-block/positioning tests remain unchanged. Guard test added: `GridItem_PercentHeight_InAutoHeightGrid_CollapsesInsteadOfFillingViewport`.

https://claude.ai/code/session_01AscS6it5BQVp4CRKnJJyKi