### PR TITLE
CSS Grid: implement content distribution and row track layout

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -2520,6 +2520,9 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         // falls back to start when content overflows, but for blocks this
         // is handled implicitly (shift is clamped to ≥ 0).
         if (AlignContent != null && AlignContent != "normal"
+            // The definite-track grid pass distributes align-content across its
+            // row tracks itself; this block-level shift would double it.
+            && !_gridTrackLayoutApplied
             && (IsBlock || Display == CssConstants.ListItem || Display == CssConstants.InlineBlock
                 || Display == CssConstants.TableCell)
             && Boxes.Count > 0

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -4761,6 +4761,8 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
         double cellLeft = Location.X + ActualPaddingLeft + ActualBorderLeftWidth;
         double cellTop = Location.Y + ActualPaddingTop + ActualBorderTopWidth;
+        double columnWidth = Size.Width - ActualPaddingLeft - ActualPaddingRight
+            - ActualBorderLeftWidth - ActualBorderRightWidth;
         double maxBottom = cellTop;
         foreach (var child in Boxes)
         {
@@ -4768,6 +4770,12 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 continue;
             if (child.Display == CssConstants.None)
                 continue;
+            // CSS Grid Level 1 §6.1: an auto-width grid item with the default
+            // (stretch) justify-self fills its column — the same rule the
+            // multi-row auto-placement path applies. Same-cell items are still
+            // stretched to the container's content width so they paint as the
+            // full-width blue bars the check-layout grid reftests expect.
+            StretchGridItemToColumnWidth(child, columnWidth);
             double dx = cellLeft + child.ActualMarginLeft - child.Location.X;
             double dy = cellTop + child.ActualMarginTop - child.Location.Y;
             if (Math.Abs(dx) > 0.1)
@@ -4778,8 +4786,157 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             if (childBottom > maxBottom)
                 maxBottom = childBottom;
         }
+
+        // If the grid declares explicit rows, size those tracks and place the
+        // items in them (heights, block-axis alignment, container height). This
+        // runs at the container's final width — unlike the definite-track pass,
+        // which the shrink-to-fit measurement invokes at content width — so a
+        // stretched-column grid sizes its percentage/fixed rows correctly here.
+        // Declines (keeping the plain content-height stacking below) for a
+        // none/auto or out-of-scope rows template.
+        if (TryApplyStackingRowTracks(cellLeft, cellTop, columnWidth))
+            return true;
+
         ActualBottom = maxBottom + ActualPaddingBottom + ActualBorderBottomWidth;
         return true;
+    }
+
+    /// <summary>
+    /// Sizes an explicit <c>grid-template-rows</c> for the same-cell stacking
+    /// path and re-places every in-flow item within its resolved row track (via
+    /// <see cref="PlaceItemInArea"/>, so heights, block-axis alignment and the
+    /// stale-inline-rect reset all match the definite-track pass). All items share
+    /// one grid line here (the stacking precondition), so a single row band
+    /// serves them. Sets the container's block size from the sized tracks and
+    /// returns <c>true</c>; returns <c>false</c> to leave plain content-height
+    /// stacking in place when the rows template is none/auto or out of scope.
+    /// </summary>
+    private bool TryApplyStackingRowTracks(double cellLeft, double cellTop, double columnWidth)
+    {
+        double em = GetEmHeight();
+        List<GridTrackSpec> rowSpecs = ParseTrackList(GridTemplateRows, em);
+        if (rowSpecs == null || rowSpecs.Count == 0 || rowSpecs.Count > MaxGridLine)
+            return false;
+
+        var (rowStartN, rowSpan) = ParseGridLine(GridRowOfFirstInFlowItem(), rowSpecs.Count);
+        int rowStart = rowStartN ?? 0;
+        if (rowStart < 0 || rowSpan < 1 || rowStart + rowSpan > MaxGridLine)
+            return false;
+
+        // Tallest same-cell item's margin-box height feeds the occupied track's
+        // content contribution.
+        double contentH = 0;
+        foreach (var child in Boxes)
+        {
+            if (child.Position is CssConstants.Absolute or CssConstants.Fixed
+                || child.Display == CssConstants.None)
+                continue;
+            double h = (child.ActualBottom - child.Location.Y)
+                + child.ActualMarginTop + child.ActualMarginBottom;
+            if (h > contentH) contentH = h;
+        }
+
+        int rowCount = Math.Max(rowSpecs.Count, rowStart + rowSpan);
+        GridTrackSpec implicitRow = ParseSingleImplicitSpec(GridAutoRows, em);
+        bool rowDefinite = TryGetDefiniteContentHeight(em, out double definiteHeight);
+        double rowBasis = rowDefinite ? definiteHeight : 0;
+        double rowGap = ResolveGridGap(RowGap, rowBasis, em);
+
+        var rowItems = new List<AxisItem> { new AxisItem(rowStart, rowSpan, contentH, contentH) };
+        double[] rowSizes = ResolveTrackSizes(rowSpecs, implicitRow, rowCount,
+            rowBasis, rowDefinite, rowGap, rowBasis, em, rowItems);
+        if (rowSizes == null)
+            return false;
+
+        // CSS Grid §7.2.1: percentage rows against an indefinite block size are
+        // sized as 'auto' for the intrinsic height above, then resolved against
+        // that intrinsic height for layout while the container keeps it.
+        double intrinsic = SumTrackSizes(rowSizes, rowGap);
+        if (!rowDefinite)
+            ResolvePercentRowTracksAgainstIntrinsic(rowSpecs, implicitRow, rowSizes, intrinsic);
+
+        double[] rowStartEdge = BuildTrackEdges(rowSizes, rowGap, out double[] rowEndEdge);
+        double areaTop = cellTop + rowStartEdge[rowStart];
+        double areaBottom = cellTop + rowEndEdge[rowStart + rowSpan - 1];
+        double areaHeight = areaBottom - areaTop;
+
+        foreach (var child in Boxes)
+        {
+            if (child.Position is CssConstants.Absolute or CssConstants.Fixed
+                || child.Display == CssConstants.None)
+                continue;
+            PlaceItemInArea(child, cellLeft, areaTop, columnWidth, areaHeight);
+        }
+
+        // A definite-height grid keeps its specified content height (rows may
+        // overflow it or leave trailing space); an indefinite one sizes to the
+        // intrinsic (pass-1) row height.
+        double gridContentHeight = rowDefinite ? definiteHeight : intrinsic;
+        ActualBottom = Location.Y + ActualBorderTopWidth + ActualPaddingTop
+            + gridContentHeight + ActualPaddingBottom + ActualBorderBottomWidth;
+        return true;
+    }
+
+    /// <summary>The <c>grid-row</c> of the first in-flow grid item (all in-flow
+    /// items share it on the stacking path, so any one is representative).</summary>
+    private string GridRowOfFirstInFlowItem()
+    {
+        foreach (var child in Boxes)
+        {
+            if (child.Position is CssConstants.Absolute or CssConstants.Fixed
+                || child.Display == CssConstants.None)
+                continue;
+            return child.GridRow;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// CSS Grid Level 1 §6.1 / CSS Box Alignment §6.2: stretch a grid item to
+    /// its column's content width when it has an <c>auto</c> used width under the
+    /// default (<c>normal</c>/<c>stretch</c>) justify-self. Shared by the
+    /// same-cell stacking path and the multi-row auto-placement path so both
+    /// fill the column the same way. Returns whether the item's justify-self
+    /// resolved to stretch (so the caller can skip a redundant justify offset).
+    /// </summary>
+    private bool StretchGridItemToColumnWidth(CssBox child, double columnWidth)
+        => StretchGridItemToColumnWidth(child, columnWidth, out _);
+
+    private bool StretchGridItemToColumnWidth(CssBox child, double columnWidth, out string resolvedJustify)
+    {
+        bool isAutoWidth = child.Width == CssConstants.Auto
+            || string.IsNullOrEmpty(child.Width);
+        string js = child.JustifySelf?.Trim().ToLowerInvariant();
+        // CSS Box Alignment §6.2: 'justify-self: auto' resolves to the grid
+        // container's 'justify-items' (the intermediate display: contents
+        // ancestor, having no box, does not contribute).
+        if (string.IsNullOrEmpty(js) || js == "auto")
+        {
+            string ji = JustifyItems?.Trim().ToLowerInvariant();
+            js = string.IsNullOrEmpty(ji) || ji == "auto" || ji == "legacy"
+                ? "normal"
+                : ji;
+        }
+        bool isStretch = js == "normal" || js == "stretch";
+
+        if (isStretch && isAutoWidth)
+        {
+            double targetWidth = columnWidth
+                - child.ActualMarginLeft - child.ActualMarginRight;
+            if (targetWidth > 0 && Math.Abs(child.Size.Width - targetWidth) > 0.5)
+            {
+                child.Size = new SizeF((float)targetWidth, child.Size.Height);
+                child.ActualRight = child.Location.X + targetWidth;
+                // The inline layout path (CreateLineBoxes) recorded per-line-box
+                // rectangles the paint walker uses for the item's own
+                // background/border; leaving them would paint the item at its
+                // pre-stretch inline width. Grid items are blockified, so clear
+                // the stale inline rects and let paint fall back to Location+Size.
+                child.RectanglesReset();
+            }
+        }
+        resolvedJustify = js;
+        return isStretch;
     }
 
     /// <summary>
@@ -4823,28 +4980,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
             // CSS Grid Level 1 §6.1: Grid items with auto/normal/stretch
             // justify-self and auto width should stretch to fill the column.
-            bool isAutoWidth = child.Width == CssConstants.Auto
-                || string.IsNullOrEmpty(child.Width);
-            string js = child.JustifySelf?.Trim().ToLowerInvariant();
-            // CSS Box Alignment §6.2: 'justify-self: auto' resolves to the
-            // grid container's 'justify-items' (the intermediate display:
-            // contents ancestor, having no box, does not contribute).
-            if (string.IsNullOrEmpty(js) || js == "auto")
-            {
-                string ji = JustifyItems?.Trim().ToLowerInvariant();
-                js = string.IsNullOrEmpty(ji) || ji == "auto" || ji == "legacy"
-                    ? "normal"
-                    : ji;
-            }
-            bool isStretch = js == "normal" || js == "stretch";
-
-            if (isStretch && isAutoWidth)
-            {
-                double targetWidth = columnWidth
-                    - child.ActualMarginLeft - child.ActualMarginRight;
-                if (targetWidth > 0 && Math.Abs(child.Size.Width - targetWidth) > 0.5)
-                    child.Size = new SizeF((float)targetWidth, child.Size.Height);
-            }
+            bool isStretch = StretchGridItemToColumnWidth(child, columnWidth, out string js);
 
             // Move child to the start of the current row.
             double dx = cellLeft + child.ActualMarginLeft - child.Location.X;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -265,8 +265,12 @@ internal partial class CssBox
             double marginX = p.Item.ActualMarginLeft + p.Item.ActualMarginRight;
             colItems.Add(new AxisItem(p.PlacedCol, p.ColSpan, minW + marginX, maxW + marginX));
         }
+        // CSS Grid §11.7: the default (normal) / explicit stretch content
+        // distribution grows auto tracks to fill the container; a packing/spacing
+        // justify-content leaves them at content size and positions them instead.
+        bool stretchCols = IsStretchContentDistribution(JustifyContent);
         double[] colSizes = ResolveTrackSizes(colSpecs, implicitCol, colCount,
-            contentWidth, definite: true, colGap, contentWidth, em, colItems);
+            contentWidth, definite: true, colGap, contentWidth, em, colItems, stretchCols);
         if (colSizes == null)
             return false;
 
@@ -302,13 +306,21 @@ internal partial class CssBox
             if (h < 0) h = 0;
             rowItems.Add(new AxisItem(p.PlacedRow, p.RowSpan, h, h));
         }
+        bool stretchRows = IsStretchContentDistribution(AlignContent);
         double[] rowSizes = ResolveTrackSizes(rowSpecs, implicitRow, rowCount,
-            rowBasis, rowDefinite, rowGap, rowBasis, em, rowItems);
+            rowBasis, rowDefinite, rowGap, rowBasis, em, rowItems, stretchRows);
         if (rowSizes == null)
             return false;
 
-        double[] colStartEdge = BuildTrackEdges(colSizes, colGap, out double[] colEndEdge);
-        double[] rowStartEdge = BuildTrackEdges(rowSizes, rowGap, out double[] rowEndEdge);
+        // CSS Box Alignment §5 (content distribution): when the tracks do not
+        // fill the container along an axis, justify-content (inline) / align-content
+        // (block) positions or spaces them within the leftover room. The block axis
+        // only has leftover room when the container's block size is definite.
+        double rowContainerSize = rowDefinite ? definiteHeight : SumTrackSizes(rowSizes, rowGap);
+        double[] colStartEdge = BuildTrackEdgesAligned(colSizes, colGap, contentWidth,
+            JustifyContent, out double[] colEndEdge);
+        double[] rowStartEdge = BuildTrackEdgesAligned(rowSizes, rowGap, rowContainerSize,
+            AlignContent, out double[] rowEndEdge);
 
         double contentLeft = Location.X + ActualBorderLeftWidth + ActualPaddingLeft;
         double contentTop = Location.Y + ActualBorderTopWidth + ActualPaddingTop;
@@ -1340,7 +1352,7 @@ internal partial class CssBox
     /// </summary>
     private double[] ResolveTrackSizes(List<GridTrackSpec> explicitSpecs, GridTrackSpec implicitSpec,
         int count, double containerSize, bool definite, double gap, double percentBasis, double em,
-        List<AxisItem> items)
+        List<AxisItem> items, bool stretchAutoTracks = false)
     {
         if (count < 1) return null;
 
@@ -1441,6 +1453,28 @@ internal partial class CssBox
                 if (isFr[t]) sizes[t] = Math.Max(sizes[t], frFactor[t] * frUnit);
         }
 
+        // CSS Grid §11.7 "Stretch auto Tracks": under the default (normal) content
+        // distribution, leftover space in a definite container is shared equally
+        // among the tracks with an 'auto' max sizing function. fr tracks already
+        // absorbed free space, so skip when any is present.
+        if (stretchAutoTracks && definite && containerSize > 0 && sumFr == 0)
+        {
+            double used = 0;
+            for (int t = 0; t < count; t++) used += sizes[t];
+            double free = containerSize - used - (count - 1) * gap;
+            if (free > 0.5)
+            {
+                int autoCount = 0;
+                for (int t = 0; t < count; t++) if (maxKind[t] == GridSizeKind.Auto) autoCount++;
+                if (autoCount > 0)
+                {
+                    double share = free / autoCount;
+                    for (int t = 0; t < count; t++)
+                        if (maxKind[t] == GridSizeKind.Auto) sizes[t] += share;
+                }
+            }
+        }
+
         for (int t = 0; t < count; t++)
         {
             if (double.IsNaN(sizes[t]) || double.IsInfinity(sizes[t]) || sizes[t] < 0)
@@ -1512,6 +1546,106 @@ internal partial class CssBox
             cursor += size + gap;
         }
         return startEdge;
+    }
+
+    /// <summary>
+    /// Builds cumulative track-edge arrays, positioning the whole track set within
+    /// <paramref name="containerSize"/> according to the axis's content-distribution
+    /// value (<c>justify-content</c> for columns, <c>align-content</c> for rows) when
+    /// the tracks leave free space. Positional values (start/center/end) offset the
+    /// set; distribution values (space-between/around/evenly) also widen the spacing
+    /// between tracks. With no free space this matches <see cref="BuildTrackEdges"/>.
+    /// </summary>
+    private static double[] BuildTrackEdgesAligned(double[] sizes, double gap,
+        double containerSize, string contentAlign, out double[] endEdge)
+    {
+        int count = Math.Max(sizes.Length, 1);
+        var startEdge = new double[count];
+        endEdge = new double[count];
+
+        double sum = 0;
+        for (int i = 0; i < sizes.Length; i++) sum += sizes[i];
+        double free = containerSize - sum - (count - 1) * gap;
+
+        double leading = 0, between = gap;
+        if (free > 0.5)
+            ResolveContentDistribution(contentAlign, free, count, gap, out leading, out between);
+
+        double cursor = leading;
+        for (int i = 0; i < count; i++)
+        {
+            double size = i < sizes.Length ? sizes[i] : 0;
+            startEdge[i] = cursor;
+            endEdge[i] = cursor + size;
+            cursor += size + between;
+        }
+        return startEdge;
+    }
+
+    /// <summary>
+    /// True when a <c>justify-content</c>/<c>align-content</c> value leaves auto
+    /// tracks stretching to fill the container — the initial <c>normal</c> (and the
+    /// explicit <c>stretch</c>). Any packing/spacing keyword (start/center/end/
+    /// space-*) suppresses the stretch and instead positions the tracks.
+    /// </summary>
+    private static bool IsStretchContentDistribution(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return true;
+        string v = value.Trim().ToLowerInvariant();
+        return v == "normal" || v == "stretch";
+    }
+
+    /// <summary>
+    /// CSS Box Alignment §5: resolves a content-distribution value into a leading
+    /// offset for the first track and the spacing to insert between adjacent tracks
+    /// (the base <paramref name="gap"/> plus any distributed free space). Only the
+    /// physical (LTR / top-to-bottom) mapping is handled; <c>normal</c>/<c>stretch</c>
+    /// and unrecognised values pack at the start (track growth for stretch is done
+    /// during sizing, not here).
+    /// </summary>
+    private static void ResolveContentDistribution(string value, double free, int count,
+        double gap, out double leading, out double between)
+    {
+        leading = 0;
+        between = gap;
+        string v = (value ?? "").Trim().ToLowerInvariant();
+        if (v.StartsWith("safe ")) v = v.Substring(5).Trim();
+        else if (v.StartsWith("unsafe ")) v = v.Substring(7).Trim();
+        switch (v)
+        {
+            case "center":
+                leading = free / 2;
+                break;
+            case "end":
+            case "flex-end":
+            case "right":
+                leading = free;
+                break;
+            case "space-between":
+                // ≥2 tracks share the free space between them; a single track packs
+                // at the start.
+                if (count > 1) between = gap + free / (count - 1);
+                break;
+            case "space-around":
+                // Free space as equal gaps around every track (half at each end).
+                {
+                    double unit = free / count;
+                    between = gap + unit;
+                    leading = unit / 2;
+                }
+                break;
+            case "space-evenly":
+                // Free space as equal gaps between and outside every track.
+                {
+                    double unit = free / (count + 1);
+                    between = gap + unit;
+                    leading = unit;
+                }
+                break;
+            default:
+                // start / flex-start / left / normal / stretch / baseline → pack start.
+                break;
+        }
     }
 
     // ─────────────────────────── Grid line parsing ───────────────────────────

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -1293,6 +1293,41 @@ internal partial class CssBox
         return true;
     }
 
+    /// <summary>Total pixel extent of all <paramref name="sizes"/> plus the gaps
+    /// between them — the grid's content-box size along that axis.</summary>
+    private static double SumTrackSizes(double[] sizes, double gap)
+    {
+        if (sizes == null || sizes.Length == 0) return 0;
+        double total = 0;
+        foreach (double s in sizes) total += s;
+        total += (sizes.Length - 1) * gap;
+        return total > 0 ? total : 0;
+    }
+
+    /// <summary>
+    /// CSS Grid §7.2.1: re-resolve pure-percentage row tracks against the grid's
+    /// computed intrinsic block size after the indefinite-height pass sized them as
+    /// 'auto'. Only a track sized purely by percentage (min and max the same
+    /// percentage — i.e. <c>grid-template-rows: 60%</c>) becomes definite here;
+    /// mixed intrinsic/percentage tracks keep their auto-derived size.
+    /// </summary>
+    private static void ResolvePercentRowTracksAgainstIntrinsic(List<GridTrackSpec> specs,
+        GridTrackSpec implicitSpec, double[] sizes, double intrinsicHeight)
+    {
+        if (sizes == null || intrinsicHeight < 0) return;
+        for (int t = 0; t < sizes.Length; t++)
+        {
+            GridTrackSpec spec = t < specs.Count ? specs[t] : implicitSpec;
+            if (spec.Min.Kind == GridSizeKind.Percent && spec.Max.Kind == GridSizeKind.Percent
+                && spec.Min.Value == spec.Max.Value)
+            {
+                double px = spec.Max.Value / 100.0 * intrinsicHeight;
+                if (!double.IsNaN(px) && !double.IsInfinity(px) && px >= 0)
+                    sizes[t] = px;
+            }
+        }
+    }
+
     // ─────────────────────────── Track sizing (§11) ───────────────────────────
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxHelper.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxHelper.cs
@@ -568,6 +568,16 @@ internal static class CssBoxHelper
     /// </summary>
     internal static bool IsEmptyCollapsible(CssBox box)
     {
+        // CSS2.1 §8.3.1: a box that establishes a new block formatting context
+        // (float, inline-block, grid/flex, overflow≠visible, abspos, table-cell)
+        // does not collapse its top and bottom margins through itself — even with
+        // no content — so an empty such box still separates its neighbours by both
+        // its margins. Chromium keeps an empty overflow:hidden / grid container's
+        // top and bottom margins distinct; only a plain in-flow block collapses
+        // through. (Floats/abspos are already excluded from flow collapsing, but
+        // covering them here keeps the predicate self-consistent.)
+        if (EstablishesBfc(box))
+            return false;
         if (box.ActualBorderTopWidth > 0.1 || box.ActualBorderBottomWidth > 0.1)
             return false;
         if (box.ActualPaddingTop > 0.1 || box.ActualPaddingBottom > 0.1)


### PR DESCRIPTION
## Summary

Implements CSS Grid content distribution (justify-content / align-content) and explicit row track sizing for the same-cell stacking path. Adds support for stretching auto-width grid items to their column width, and resolves percentage row tracks against the grid's intrinsic height.

## Key Changes

- **Content distribution alignment**: Adds `BuildTrackEdgesAligned()` to position track sets within free space according to justify-content (columns) and align-content (rows). Implements positional (start/center/end) and distribution (space-between/around/evenly) keywords per CSS Box Alignment §5.

- **Row track layout for stacking path**: Implements `TryApplyStackingRowTracks()` to size explicit `grid-template-rows` and place same-cell items within their resolved row tracks, matching the definite-track pass behavior for heights and block-axis alignment.

- **Grid item column stretching**: Extracts `StretchGridItemToColumnWidth()` as a shared utility for both the same-cell stacking and multi-row auto-placement paths. Implements CSS Grid Level 1 §6.1 stretch behavior for auto-width items under default justify-self.

- **Percentage row resolution**: Adds `ResolvePercentRowTracksAgainstIntrinsic()` to re-resolve pure-percentage row tracks against the grid's computed intrinsic block size after the indefinite-height pass (CSS Grid §7.2.1).

- **Track sizing refinements**: 
  - Passes `stretchAutoTracks` flag to `ResolveTrackSizes()` to implement "Stretch auto Tracks" (§11.7) — distributing leftover space among auto-max tracks under normal content distribution.
  - Adds `SumTrackSizes()` helper to compute grid content-box size along an axis.
  - Prevents double-application of align-content by checking `_gridTrackLayoutApplied` flag in block-level shift logic.

- **BFC margin-collapse fix**: Updates `IsEmptyCollapsible()` to recognize that boxes establishing a new block formatting context (grid, flex, overflow≠visible, etc.) do not collapse margins through themselves, even when empty.

## Implementation Details

- The stacking path now computes column width once and reuses it for both item stretching and row track layout, ensuring consistent sizing.
- Row track sizing respects the container's definite vs. indefinite block size, sizing percentage tracks as 'auto' during intrinsic measurement and re-resolving them afterward.
- Content distribution is applied only when tracks leave free space; with no free space, positioning matches the original `BuildTrackEdges()` behavior.
- Grid item stretching clears stale inline rectangles (`RectanglesReset()`) to prevent paint walker from using pre-stretch widths.

https://claude.ai/code/session_01D3Bsgnw7JrgkUqWf8fYJW1