### PR TITLE
Enable implicit-only grid track layout for template-less grids

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -161,8 +161,7 @@ internal partial class CssBox
         // none), the other axis may legitimately be implicit-only (e.g. a column
         // subgrid with `grid-auto-rows`): treat a none/empty track list there as
         // zero explicit tracks so the placed items generate implicit tracks, rather
-        // than declining. The general (non-subgrid) path keeps requiring both axes
-        // to have explicit tracks.
+        // than declining.
         if (anySubgrid || anyOrphanSubgrid)
         {
             if (colSpecs == null && IsNoneOrEmptyTemplate(GridTemplateColumns)) colSpecs = new List<GridTrackSpec>();
@@ -180,15 +179,46 @@ internal partial class CssBox
                 rowSpecs = new List<GridTrackSpec> { AutoTrackSpec };
         }
 
+        // An axis with no explicit template (`none`/empty) but a `grid-auto-*`
+        // sizing function is implicit-only: its tracks come entirely from
+        // auto-placement (§7.5). Treat the empty template as zero explicit tracks
+        // so the placed items generate implicit tracks, rather than declining the
+        // whole pass — this is the common `display:grid` + `grid-auto-columns/rows`
+        // shape (the css-grid alignment suite, whose grids omit templates), which
+        // the approximation renders collapsed. An *unsupported* token (subgrid,
+        // fit-content, …) still parses to null and declines below.
+        bool colImplicitOnly = colSpecs == null && IsNoneOrEmptyTemplate(GridTemplateColumns);
+        bool rowImplicitOnly = rowSpecs == null && IsNoneOrEmptyTemplate(GridTemplateRows);
+        if (colImplicitOnly) colSpecs = new List<GridTrackSpec>();
+        if (rowImplicitOnly) rowSpecs = new List<GridTrackSpec>();
+
         if (colSpecs == null || rowSpecs == null)
             return false;
-        // A standalone orphan-subgrid grid can have zero explicit tracks in both
-        // axes (subgrid→none on one, `none` on the other) yet still be sized from
-        // its implicit tracks and auto-placed items, so it is allowed through where
-        // the general both-empty case declines.
-        if (colSpecs.Count == 0 && rowSpecs.Count == 0 && !anyOrphanSubgrid)
+        // The implicit-only (`none` template + grid-auto-*) path is a newly enabled
+        // takeover from the baseline-aware cross-axis approximation, so it declines
+        // for the two shapes this bounded pass sizes worse than that approximation:
+        //   • baseline self-alignment (`align-self: baseline`, `justify-items: last
+        //     baseline`, …) synthesizes a shared baseline across a column/row
+        //     (CSS Align §9) this pass does not compute — it would fall to start;
+        //   • an item whose used block size the pass cannot trust from a single
+        //     measurement — a nested flex/grid/table container, a replaced or
+        //     form-control item, or a scroll container — where sizing an auto row
+        //     from the measured height collapses or mis-stretches the item.
+        // Grids with an explicit template on the affected axis keep going through
+        // this pass exactly as before; only the implicit-only takeover is gated.
+        if ((colImplicitOnly || rowImplicitOnly)
+            && (GridUsesBaselineSelfAlignment() || !GridImplicitPathItemsAreSimple()))
             return false;
-        if (!anySubgrid && !anyOrphanSubgrid && (colSpecs.Count == 0 || rowSpecs.Count == 0))
+        // Implicit tracks are allowed to carry the whole axis for a subgrid, an
+        // orphan subgrid, or an implicit-only (`none` template + grid-auto-*) axis;
+        // the placed items below generate them. Any other empty axis is degenerate
+        // and declines to the approximation.
+        bool implicitTracksAllowed =
+            anySubgrid || anyOrphanSubgrid || colImplicitOnly || rowImplicitOnly;
+        if (colSpecs.Count == 0 && rowSpecs.Count == 0
+            && !anyOrphanSubgrid && !(colImplicitOnly && rowImplicitOnly))
+            return false;
+        if (!implicitTracksAllowed && (colSpecs.Count == 0 || rowSpecs.Count == 0))
             return false;
         if (colSpecs.Count > MaxGridLine || rowSpecs.Count > MaxGridLine)
             return false;
@@ -832,6 +862,76 @@ internal partial class CssBox
         if (string.IsNullOrEmpty(size) || size == CssConstants.Auto)
             return true;
         return size.EndsWith("%", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// True when this grid or any of its in-flow items requests baseline
+    /// self-alignment on either axis (<c>align-items</c>/<c>justify-items</c> on
+    /// the container, or <c>align-self</c>/<c>justify-self</c> on an item). Baseline
+    /// alignment needs a synthesized shared baseline the bounded track pass does not
+    /// compute, so callers use this to decline to the baseline-aware approximation.
+    /// </summary>
+    private bool GridUsesBaselineSelfAlignment()
+    {
+        if (MentionsBaseline(AlignItems) || MentionsBaseline(JustifyItems))
+            return true;
+        foreach (var child in Boxes)
+        {
+            if (child.Display == CssConstants.None)
+                continue;
+            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+                continue;
+            if (MentionsBaseline(child.AlignSelf) || MentionsBaseline(child.JustifySelf))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>True when an alignment value is (or ends with) the
+    /// <c>baseline</c> keyword — covering <c>baseline</c>, <c>first baseline</c>,
+    /// and <c>last baseline</c>.</summary>
+    private static bool MentionsBaseline(string value)
+        => !string.IsNullOrEmpty(value)
+            && value.IndexOf("baseline", StringComparison.OrdinalIgnoreCase) >= 0;
+
+    /// <summary>
+    /// True when every in-flow item of this grid is a plain box whose used block
+    /// size the bounded track pass can trust from a single measurement — used to
+    /// gate the implicit-only takeover away from item shapes the pass sizes worse
+    /// than the approximation it replaces (see the caller). An item is *not* simple
+    /// when it establishes a nested flex/grid/table formatting context (whose
+    /// intrinsic block size the single measurement can under-size — collapsing an
+    /// auto row), is a replaced element or form control (whose stretch/aspect-ratio
+    /// sizing differs from a plain box), or is a scroll container. A plain block
+    /// item with <c>height:100%</c> is simple: that just stretches it to the row.
+    /// </summary>
+    private bool GridImplicitPathItemsAreSimple()
+    {
+        foreach (var child in Boxes)
+        {
+            if (child.Display == CssConstants.None)
+                continue;
+            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+                continue;
+            if (child.Display is "flex" or "inline-flex" or "grid" or "inline-grid"
+                or CssConstants.Table or CssConstants.InlineTable)
+                return false;
+            if (child.IsImage)
+                return false;
+            if (child.HtmlTag != null)
+            {
+                string tag = child.HtmlTag.Name;
+                if (tag.Equals("button", StringComparison.OrdinalIgnoreCase)
+                    || tag.Equals("input", StringComparison.OrdinalIgnoreCase)
+                    || tag.Equals("select", StringComparison.OrdinalIgnoreCase)
+                    || tag.Equals("textarea", StringComparison.OrdinalIgnoreCase)
+                    || tag.Equals("img", StringComparison.OrdinalIgnoreCase))
+                    return false;
+            }
+            if (!string.IsNullOrEmpty(child.Overflow) && child.Overflow != CssConstants.Visible)
+                return false;
+        }
+        return true;
     }
 
     private static double GridAxisAlignmentOffset(string self, string items, double free, bool rtl)

--- a/src/Broiler.Cli.Tests/GridTrackLayoutTests.cs
+++ b/src/Broiler.Cli.Tests/GridTrackLayoutTests.cs
@@ -377,4 +377,37 @@ public sealed class GridTrackLayoutTests
             ("grid-column:2;grid-row:1;", 100, 0, 100, 40));
         AssertCheckLayout(html, "file:///grid-linename-auto-fill.html");
     }
+
+    [Fact]
+    public void GridImplicitOnlyTracks_WithAlignContent_DistributeRowsInDefiniteHeight()
+    {
+        // A template-less grid (no grid-template-columns/rows) sized purely by
+        // grid-auto-columns/-rows: 20px columns, 40px rows, in a 200x300 box.
+        // Before the implicit-only fix this whole shape declined the §11 pass and
+        // collapsed under the approximation; now the placed items generate the two
+        // implicit rows and `align-content:space-between` pushes row 2 to the
+        // block end (300 - 40 = 260). Mirrors the css-grid alignment suite
+        // (grid-align-content-distribution.html), whose grids omit templates.
+        string html = GridDoc(
+            "width:200px;height:300px;grid-auto-columns:20px;grid-auto-rows:40px;align-content:space-between;",
+            ("grid-column:1;grid-row:1;", 0, 0, 20, 40),
+            ("grid-column:2;grid-row:1;", 20, 0, 20, 40),
+            ("grid-column:1;grid-row:2;", 0, 260, 20, 40),
+            ("grid-column:2;grid-row:2;", 20, 260, 20, 40));
+        AssertCheckLayout(html, "file:///grid-implicit-align-content.html");
+    }
+
+    [Fact]
+    public void GridImplicitOnlyRows_WithExplicitColumns_SizeFromGridAutoRows()
+    {
+        // Explicit columns but a template-less row axis fed by grid-auto-rows:50px.
+        // The row axis is implicit-only; the two placed rows must each size to
+        // 50px rather than declining the pass.
+        string html = GridDoc(
+            "grid-template-columns:60px 60px;grid-auto-rows:50px;",
+            ("grid-column:1;grid-row:1;", 0, 0, 60, 50),
+            ("grid-column:2;grid-row:1;", 60, 0, 60, 50),
+            ("grid-column:1;grid-row:2;", 0, 50, 60, 50));
+        AssertCheckLayout(html, "file:///grid-implicit-rows.html");
+    }
 }


### PR DESCRIPTION
## Summary

Extend the bounded grid track layout pass to handle implicit-only grids — grids with no explicit template (`none`/empty) but a `grid-auto-columns` or `grid-auto-rows` sizing function. This enables proper layout of the common `display:grid` + `grid-auto-*` pattern used in the CSS Grid alignment test suite, which previously declined the pass and fell back to the baseline-aware approximation.

## Key Changes

- **Implicit-only axis detection**: Added logic to identify axes with empty templates but active `grid-auto-*` functions, treating them as zero explicit tracks so placed items can generate implicit tracks.

- **Gating conditions for implicit-only takeover**: The implicit-only path is only enabled when:
  - The grid does not use baseline self-alignment (`align-items: baseline`, `justify-self: baseline`, etc.), which requires a synthesized shared baseline the pass does not compute.
  - All in-flow items are "simple" boxes whose block size can be trusted from a single measurement — excluding nested flex/grid/table containers, replaced elements, form controls, and scroll containers.

- **New helper methods**:
  - `GridUsesBaselineSelfAlignment()`: Checks if the grid or any in-flow item requests baseline alignment on either axis.
  - `MentionsBaseline(string value)`: Utility to detect baseline keywords in alignment values.
  - `GridImplicitPathItemsAreSimple()`: Validates that all in-flow items are plain boxes suitable for the implicit-only path.

- **Updated validation logic**: Refined the empty-axis checks to allow implicit tracks for subgrids, orphan subgrids, and implicit-only axes, while declining degenerate cases and unsupported token shapes.

- **Test coverage**: Added two test cases:
  - `GridImplicitOnlyTracks_WithAlignContent_DistributeRowsInDefiniteHeight`: Verifies that a template-less grid with `grid-auto-rows` and `align-content:space-between` correctly distributes rows in a definite height container.
  - `GridImplicitOnlyRows_WithExplicitColumns_SizeFromGridAutoRows`: Confirms that an implicit-only row axis with explicit columns sizes rows from `grid-auto-rows`.

## Implementation Details

The change preserves backward compatibility: grids with explicit templates on either axis continue through the pass exactly as before. Only the newly enabled implicit-only takeover is gated by the baseline and item-simplicity checks, ensuring the pass only handles cases where it produces better results than the approximation it replaces.

https://claude.ai/code/session_01FQt7HKinsAPdzeUWxgbudi