### PR TITLE
CSS Grid baseline alignment and percentage row sizing

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -660,8 +660,19 @@ internal partial class CssBox
         double marginL = item.ActualMarginLeft, marginR = item.ActualMarginRight;
         double marginT = item.ActualMarginTop, marginB = item.ActualMarginBottom;
 
-        bool widthFills = FillsArea(item.Width);
-        bool heightFills = FillsArea(item.Height);
+        // CSS Box Alignment §4.3 / CSS Grid §6.1: an auto-sized grid item fills its
+        // area only under the (default) stretch self-alignment. A positional or
+        // baseline align-self/justify-self (self-start, center, baseline, …) keeps
+        // the item at its content size and positions it in the area instead — a
+        // percentage size always fills, resolving against the area regardless.
+        bool widthIsPercent = !string.IsNullOrEmpty(item.Width)
+            && item.Width.EndsWith("%", StringComparison.Ordinal);
+        bool heightIsPercent = !string.IsNullOrEmpty(item.Height)
+            && item.Height.EndsWith("%", StringComparison.Ordinal);
+        bool widthFills = FillsArea(item.Width)
+            && (widthIsPercent || SelfAlignmentStretches(item.JustifySelf, JustifyItems));
+        bool heightFills = FillsArea(item.Height)
+            && (heightIsPercent || SelfAlignmentStretches(item.AlignSelf, AlignItems));
 
         double targetLeft = areaLeft + marginL;
         double targetTop = areaTop + marginT;
@@ -1173,6 +1184,26 @@ internal partial class CssBox
             h += item.ActualPaddingTop + item.ActualPaddingBottom
                 + item.ActualBorderTopWidth + item.ActualBorderBottomWidth;
         return h > 0 ? h : 0;
+    }
+
+    /// <summary>
+    /// True when a grid item's used self-alignment on an axis is <c>stretch</c>
+    /// (so an auto-sized item fills the area). Resolves <c>align-self</c>/
+    /// <c>justify-self</c> of <c>auto</c>/<c>normal</c> to the container's
+    /// <c>align-items</c>/<c>justify-items</c>, whose own initial value
+    /// (<c>normal</c>) is stretch. Any positional or baseline value
+    /// (<c>start</c>, <c>center</c>, <c>self-end</c>, <c>baseline</c>, …) is not
+    /// stretch, so the item is content-sized and then positioned.
+    /// </summary>
+    private static bool SelfAlignmentStretches(string self, string items)
+    {
+        string v = self;
+        if (string.IsNullOrEmpty(v) || v == "auto" || v == "normal")
+            v = items;
+        v = (v ?? "").Trim().ToLowerInvariant();
+        if (v.StartsWith("safe ")) v = v.Substring(5).Trim();
+        else if (v.StartsWith("unsafe ")) v = v.Substring(7).Trim();
+        return string.IsNullOrEmpty(v) || v == "normal" || v == "stretch";
     }
 
     private static double GridAxisAlignmentOffset(string self, string items, double free, bool rtl)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -441,6 +441,11 @@ internal partial class CssBox
             LayoutSubgridItem(p, colSizes, rowSizes, colGap, rowGap);
         }
 
+        // CSS Box Alignment §9: baseline self-alignment. Items in a row that ask
+        // for align-self:baseline share a baseline — each is shifted in the block
+        // axis so its first baseline sits on the group's shared (max) baseline.
+        AlignGridRowBaselines(placements);
+
         // The grid's block size is the block-end edge of its last row track. Every
         // grid-template-rows track contributes even when unoccupied, so a 4-track
         // template with items in only the first 3 rows still sizes to all four.
@@ -1195,6 +1200,78 @@ internal partial class CssBox
     /// (<c>start</c>, <c>center</c>, <c>self-end</c>, <c>baseline</c>, …) is not
     /// stretch, so the item is content-sized and then positioned.
     /// </summary>
+    /// <summary>CSS Box Alignment §9.3 typical ascent fraction of the line box —
+    /// the baseline sits this far below the first line's top (matches the inline
+    /// layout's <c>TypicalAscentRatio</c>).</summary>
+    private const double BaselineAscentRatio = 0.8;
+
+    /// <summary>
+    /// CSS Box Alignment §9 (baseline self-alignment, block axis): within each
+    /// grid row, the items whose <c>align-self</c> resolves to (first) baseline
+    /// form a baseline-sharing group. Their shared baseline is the lowest of the
+    /// individual first baselines; every item is shifted down so its own first
+    /// baseline lands on it (the group's tallest-ascent item stays, shorter items
+    /// drop). A group of one needs no shift.
+    /// </summary>
+    private void AlignGridRowBaselines(List<GridPlacement> placements)
+    {
+        Dictionary<int, List<CssBox>> byRow = null;
+        foreach (var p in placements)
+        {
+            if (!ResolvesToFirstBaseline(p.Item.AlignSelf, AlignItems))
+                continue;
+            (byRow ??= new Dictionary<int, List<CssBox>>())
+                .TryGetValue(p.PlacedRow, out var list);
+            if (list == null) byRow[p.PlacedRow] = list = new List<CssBox>();
+            list.Add(p.Item);
+        }
+        if (byRow == null)
+            return;
+        foreach (var group in byRow.Values)
+        {
+            if (group.Count < 2)
+                continue;
+            double shared = double.MinValue;
+            var baselines = new double[group.Count];
+            for (int i = 0; i < group.Count; i++)
+            {
+                baselines[i] = GridItemFirstBaselineY(group[i]);
+                if (baselines[i] > shared) shared = baselines[i];
+            }
+            for (int i = 0; i < group.Count; i++)
+            {
+                double shift = shared - baselines[i];
+                if (shift > 0.5)
+                {
+                    group[i].OffsetTop(shift);
+                    group[i].ActualBottom += shift;
+                }
+            }
+        }
+    }
+
+    /// <summary>Absolute Y of a grid item's first baseline: its first line box's
+    /// baseline, approximated as the font ascent below the content-box top.</summary>
+    private static double GridItemFirstBaselineY(CssBox item)
+    {
+        double ascent = item.ActualFont.Height * BaselineAscentRatio;
+        return item.Location.Y + item.ActualBorderTopWidth + item.ActualPaddingTop + ascent;
+    }
+
+    /// <summary>True when a grid item's used <c>align-self</c>/<c>justify-self</c>
+    /// resolves to (first) <c>baseline</c> — resolving <c>auto</c>/<c>normal</c>
+    /// through the container's <c>align-items</c>/<c>justify-items</c>.</summary>
+    private static bool ResolvesToFirstBaseline(string self, string items)
+    {
+        string v = self;
+        if (string.IsNullOrEmpty(v) || v == "auto" || v == "normal")
+            v = items;
+        v = (v ?? "").Trim().ToLowerInvariant();
+        if (v.StartsWith("safe ")) v = v.Substring(5).Trim();
+        else if (v.StartsWith("unsafe ")) v = v.Substring(7).Trim();
+        return v == "baseline" || v == "first baseline" || v == "first-baseline";
+    }
+
     private static bool SelfAlignmentStretches(string self, string items)
     {
         string v = self;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -393,11 +393,25 @@ internal partial class CssBox
         if (rowSizes == null)
             return false;
 
+        // CSS Grid §7.2.1: percentage rows against an indefinite block size are
+        // sized as 'auto' above (definite=false), producing the grid's intrinsic
+        // block size; they are then resolved against that intrinsic height for
+        // layout while the container keeps the intrinsic height (so a shrunken
+        // percentage row leaves trailing space rather than collapsing the grid).
+        // Mirrors the same-cell stacking path (TryApplyStackingRowTracks). For a
+        // grid with no percentage rows this is a no-op and intrinsicRowHeight
+        // equals the plain track sum, so non-percentage grids are unaffected.
+        double intrinsicRowHeight = SumTrackSizes(rowSizes, rowGap);
+        if (!rowDefinite)
+            ResolvePercentRowTracksAgainstIntrinsic(rowSpecs, implicitRow, rowSizes, intrinsicRowHeight);
+
         // CSS Box Alignment §5 (content distribution): when the tracks do not
         // fill the container along an axis, justify-content (inline) / align-content
         // (block) positions or spaces them within the leftover room. The block axis
-        // only has leftover room when the container's block size is definite.
-        double rowContainerSize = rowDefinite ? definiteHeight : SumTrackSizes(rowSizes, rowGap);
+        // only has leftover room when the container's block size is definite — or,
+        // for an indefinite height, when a percentage row shrank below the locked
+        // intrinsic height above.
+        double rowContainerSize = rowDefinite ? definiteHeight : intrinsicRowHeight;
         double[] colStartEdge = BuildTrackEdgesAligned(colSizes, colGap, contentWidth,
             JustifyContent, out double[] colEndEdge);
         double[] rowStartEdge = BuildTrackEdgesAligned(rowSizes, rowGap, rowContainerSize,
@@ -431,6 +445,10 @@ internal partial class CssBox
         // grid-template-rows track contributes even when unoccupied, so a 4-track
         // template with items in only the first 3 rows still sizes to all four.
         double gridHeight = rowSizes.Length > 0 ? rowEndEdge[rowSizes.Length - 1] : 0;
+        // §7.2.1: an indefinite-height grid keeps its intrinsic block size even
+        // after percentage rows resolved (shrank) against it, leaving trailing space.
+        if (!rowDefinite && intrinsicRowHeight > gridHeight)
+            gridHeight = intrinsicRowHeight;
         double borderBoxHeight = ActualPaddingTop + ActualPaddingBottom
             + ActualBorderTopWidth + ActualBorderBottomWidth + gridHeight;
         ActualBottom = Location.Y + borderBoxHeight;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxHelper.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxHelper.cs
@@ -269,6 +269,20 @@ internal static class CssBoxHelper
             for (int i = 0; i < box.Boxes.Count; i++)
             {
                 CssBox childBox = box.Boxes[i];
+
+                // A <br> forces a line break, so max-content is the widest line:
+                // close the running line here and start a fresh one. Otherwise the
+                // recursion below (a <br> computes to a block box, which resets and
+                // then restores the running sum) leaves the following inline content
+                // accumulating on the same line — `A<br>B` would measure as A + B
+                // instead of max(A, B), doubling a multi-line item's width.
+                if (childBox.IsBrElement)
+                {
+                    oldSum = oldSum.HasValue ? Math.Max(oldSum.Value, maxSum) : maxSum;
+                    maxSum = marginSum;
+                    continue;
+                }
+
                 marginSum += childBox.ActualMarginLeft + childBox.ActualMarginRight;
 
                 //maxSum += childBox.ActualMarginLeft + childBox.ActualMarginRight;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -648,7 +648,12 @@ internal abstract class CssBoxProperties
     public string FlexShrink { get; set; } = "1";
     public string FlexBasis { get; set; } = "auto";
     public string FlexWrap { get; set; } = "nowrap";
-    public string JustifyContent { get; set; } = "flex-start";
+    // CSS Box Alignment §8: the initial value of justify-content is 'normal',
+    // not 'flex-start'. In a flex container 'normal' behaves as 'flex-start'
+    // (packed at the main-start edge), so flex layout is unchanged; in a grid
+    // container 'normal' triggers the default stretch of auto tracks, which
+    // 'flex-start' (a packing distribution) suppresses.
+    public string JustifyContent { get; set; } = "normal";
     public string JustifyItems { get; set; } = "normal";
     public string AlignItems { get; set; } = "stretch";
     public string AlignContent { get; set; } = "normal";

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -1098,8 +1098,17 @@ internal static class CssLayoutEngine
 
             b.ApplyGridLayoutAfterInline();
         }
-        else if (LayoutBoxUtils.ContainsInlinesOnly(b))
+        else if (LayoutBoxUtils.ContainsInlinesOnly(b) || InlineContentWithBrsOnly(b))
         {
+            // Inline-block content that is inline runs interrupted only by <br>
+            // line breaks is an inline formatting context: lay it out with line
+            // boxes so the breaks split it into lines. A <br> computes to a
+            // block-level box in Broiler, which would otherwise route this to the
+            // block-children branch below — that branch lays each anonymous inline
+            // child out via its own PerformLayout (which sets no block height for
+            // an inline box), collapsing the inline-block to zero height. This is
+            // the shape of a multi-line grid item (e.g. `X<br>X`), which the
+            // css-grid check-layout reference tests use throughout.
             CreateLineBoxes(g, b);
         }
         else if (b.Boxes.Count > 0)
@@ -1202,6 +1211,36 @@ internal static class CssLayoutEngine
 
         maxRight = Math.Max(maxRight, ibBorderLeft + physicalBoxWidth);
         maxbottom = Math.Max(maxbottom, b.ActualBottom + b.ActualMarginBottom);
+    }
+
+    /// <summary>
+    /// True when <paramref name="box"/>'s in-flow content is inline-level except
+    /// for <c>&lt;br&gt;</c> elements — which compute to block-level boxes in
+    /// Broiler but merely force a line break within an inline formatting context.
+    /// Such a box should be laid out with <see cref="CreateLineBoxes"/> (the
+    /// breaks split the inline content into lines) rather than the block-children
+    /// path, which never establishes line boxes for the anonymous inline runs and
+    /// so leaves the box zero-height. Requires at least one <c>&lt;br&gt;</c> so a
+    /// genuinely block-only box is unaffected (it is not inline content).
+    /// </summary>
+    private static bool InlineContentWithBrsOnly(CssBox box)
+    {
+        bool sawBr = false;
+        foreach (var child in box.Boxes)
+        {
+            if (child.Display == CssConstants.None)
+                continue;
+            if (child.Position is CssConstants.Absolute or CssConstants.Fixed)
+                continue;
+            if (child.IsBrElement)
+            {
+                sawBr = true;
+                continue;
+            }
+            if (!child.IsInline && child.Float == CssConstants.None)
+                return false;
+        }
+        return sawBr;
     }
 
     private static bool HasBlockLevelFlexItems(CssBox box)

--- a/Broiler.Layout/Broiler.Layout/IR/ComputedStyle.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/ComputedStyle.cs
@@ -160,7 +160,7 @@ public sealed class ComputedStyle
     public string FlexShrink { get; init; } = "1";
     public string FlexBasis { get; init; } = "auto";
     public string FlexWrap { get; init; } = "nowrap";
-    public string JustifyContent { get; init; } = "flex-start";
+    public string JustifyContent { get; init; } = "normal";
     public string AlignItems { get; init; } = "stretch";
 
     // --- Table ---


### PR DESCRIPTION
## Summary

Implements CSS Grid baseline self-alignment (block axis) and fixes percentage row sizing in grids with indefinite height. Also corrects inline-block layout for content interrupted by `<br>` elements and adjusts `justify-content` initial value to match CSS Box Alignment spec.

## Key Changes

- **Baseline alignment (block axis):** Items in a grid row with `align-self: baseline` now form a baseline-sharing group. Each item is shifted so its first baseline aligns with the group's shared (maximum) baseline, per CSS Box Alignment §9.

- **Percentage row sizing:** When a grid has indefinite block size, percentage rows are now sized as `auto` initially (producing the grid's intrinsic height), then resolved against that intrinsic height for layout. The container retains the intrinsic height even if percentage rows shrink, leaving trailing space rather than collapsing the grid (CSS Grid §7.2.1).

- **Self-alignment stretch resolution:** Grid item sizing now correctly distinguishes between stretch (fills area) and positional/baseline alignment (content-sized and positioned). Percentage-sized items always fill; auto-sized items fill only under stretch alignment.

- **Inline-block with `<br>` elements:** Fixed layout of inline-block content interrupted by `<br>` line breaks. Such content now routes through line-box creation instead of block-children layout, preventing zero-height collapse. Handles multi-line grid items like `X<br>X`.

- **Max-content width calculation:** `<br>` elements now correctly force line breaks in max-content measurement, so multi-line content measures as the widest line rather than summing all lines.

- **`justify-content` initial value:** Changed from `flex-start` to `normal` per CSS Box Alignment §8. In flex containers `normal` behaves as `flex-start` (unchanged); in grid containers `normal` enables default track stretching, which `flex-start` (a packing distribution) suppresses.

## Implementation Details

- `AlignGridRowBaselines()` groups items by row and resolves baseline conflicts by shifting items down to a shared baseline.
- `GridItemFirstBaselineY()` approximates first baseline as font ascent below content-box top using `BaselineAscentRatio` (0.8).
- `ResolvesToFirstBaseline()` and `SelfAlignmentStretches()` resolve `auto`/`normal` self-alignment values through container defaults, handling `safe`/`unsafe` modifiers.
- `InlineContentWithBrsOnly()` detects inline content with only `<br>` block-level interruptions to route to line-box layout.
- Intrinsic row height is computed once and reused for both percentage resolution and content distribution alignment.

https://claude.ai/code/session_01PGLdWDRx1PRCbCDFxR8qdv