### PR TITLE
Implement CSS table captions and fix table grid items

### DIFF
--- a/Broiler.Layout/Broiler.Layout/DocumentModeContext.cs
+++ b/Broiler.Layout/Broiler.Layout/DocumentModeContext.cs
@@ -1,0 +1,45 @@
+namespace Broiler.Layout;
+
+/// <summary>
+/// Per-render (thread-local) document-mode state, mirroring the way
+/// <c>Broiler.CSS.CssLengthParser</c> exposes the current viewport size for the
+/// duration of a render. The host publishes the document's quirks-mode flag here
+/// when it parses the page, so layout — which on the HTML-string parse path holds
+/// no reference back to the source document — can consult it while sizing the
+/// root and body boxes (the quirks-mode body/html fill-viewport behaviour,
+/// https://quirks.spec.whatwg.org/).
+///
+/// Layout runs on the same thread immediately after the parse that set this, and
+/// each parse overwrites it, so a stale <c>true</c> never leaks into a later
+/// standards-mode render. <c>CssBox</c> additionally caches the value on the tree
+/// root the first time it reads it, so it survives a re-layout pass that may run
+/// on a different thread.
+/// </summary>
+public static class DocumentModeContext
+{
+    [System.ThreadStatic]
+    private static bool _quirksMode;
+
+    /// <summary>The quirks-mode flag of the document currently being laid out.</summary>
+    public static bool CurrentQuirksMode
+    {
+        get => _quirksMode;
+        set => _quirksMode = value;
+    }
+
+    /// <summary>
+    /// Lightweight quirks-mode determination from raw HTML. A document with no
+    /// doctype, or any doctype whose name is not a bare <c>html</c>, is in quirks
+    /// mode; a bare <c>&lt;!DOCTYPE html&gt;</c> selects standards mode.
+    /// </summary>
+    public static bool IsQuirksHtml(string html)
+    {
+        if (string.IsNullOrEmpty(html))
+            return true;
+        var match = System.Text.RegularExpressions.Regex.Match(
+            html, @"<!doctype\s+([^\s>]+)",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        return !(match.Success
+            && match.Groups[1].Value.Equals("html", System.StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -214,6 +214,28 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         set { _htmlContainer = value; }
     }
 
+    private bool? _documentQuirksMode;
+
+    /// <summary>
+    /// Whether the document being laid out is in quirks mode. Captured once —
+    /// from <see cref="Dom.DocumentModeContext"/>, which the HTML parser publishes
+    /// on the parse thread — onto the tree root the first time layout consults it,
+    /// then read from the root by every box. Caching on the root makes the value
+    /// survive re-layout passes (which may run on a different thread, where the
+    /// thread-local would have reset) without threading it through the box builder.
+    /// </summary>
+    internal bool DocumentQuirksMode
+    {
+        get
+        {
+            var root = this;
+            while (root._parentBox != null)
+                root = root._parentBox;
+            root._documentQuirksMode ??= DocumentModeContext.CurrentQuirksMode;
+            return root._documentQuirksMode.Value;
+        }
+    }
+
     /// <summary>
     /// Host-injected layout environment (see <see cref="ILayoutEnvironment"/>),
     /// resolved up the box tree like <see cref="ContainerInt"/>. Set on the root
@@ -2172,6 +2194,40 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             && TryResolveAspectRatioBlockHeight(out double aspectRatioBorderBoxHeight))
         {
             ActualBottom = Location.Y + aspectRatioBorderBoxHeight;
+        }
+
+        // Quirks-mode "the body element fills the html element" / "the html
+        // element fills the viewport" quirks (https://quirks.spec.whatwg.org/):
+        // in quirks mode an auto-height root <html> fills the viewport (minus its
+        // margins) and an auto-height <body> fills the html element's content box
+        // (minus its own margins), instead of shrink-wrapping to content. Acts as
+        // a floor (content taller than the fill still overflows/scrolls).
+        if ((Height == CssConstants.Auto || string.IsNullOrEmpty(Height))
+            && DocumentQuirksMode
+            && LayoutEnvironment != null
+            && Position is not (CssConstants.Absolute or CssConstants.Fixed)
+            && Float == CssConstants.None
+            && HtmlTag != null)
+        {
+            double? fillBorderBoxHeight = null;
+            if (HtmlTag.Name.Equals("html", StringComparison.OrdinalIgnoreCase))
+            {
+                fillBorderBoxHeight = LayoutEnvironment.ViewportSize.Height
+                    - ActualMarginTop - ActualMarginBottom;
+            }
+            else if (HtmlTag.Name.Equals("body", StringComparison.OrdinalIgnoreCase)
+                && ParentBox is { HtmlTag: { } parentTag }
+                && parentTag.Name.Equals("html", StringComparison.OrdinalIgnoreCase))
+            {
+                var html = ParentBox;
+                double htmlContentHeight = LayoutEnvironment.ViewportSize.Height
+                    - html.ActualMarginTop - html.ActualMarginBottom
+                    - html.ActualBorderTopWidth - html.ActualBorderBottomWidth
+                    - html.ActualPaddingTop - html.ActualPaddingBottom;
+                fillBorderBoxHeight = htmlContentHeight - ActualMarginTop - ActualMarginBottom;
+            }
+            if (fillBorderBoxHeight is { } fillH && fillH > ActualBottom - Location.Y)
+                ActualBottom = Location.Y + fillH;
         }
 
         // CSS2.1 §10.7: Apply min-height / max-height constraints.

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -1129,7 +1129,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         // are laid out, so the trimmed margins collapse to nothing.
         ApplyMarginTrim();
 
-        if (IsBlock || Display == CssConstants.ListItem || Display == CssConstants.Table || Display == CssConstants.InlineTable || Display == CssConstants.TableCell)
+        if (IsBlock || Display == CssConstants.ListItem || Display == CssConstants.Table || Display == CssConstants.InlineTable || Display == CssConstants.TableCell || Display == CssConstants.TableCaption)
         {
             // Because their width and height are set by CssTable
             if (Display != CssConstants.TableCell && Display != CssConstants.Table)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -5120,6 +5120,33 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 // pre-stretch inline width. Grid items are blockified, so clear
                 // the stale inline rects and let paint fall back to Location+Size.
                 child.RectanglesReset();
+
+                // A stretched table grid item is sized to the column width like
+                // any other stretched item, but — unlike a block — its cell grid
+                // was already shrink-wrapped to content by the table formatting
+                // algorithm and does not reflow from a bare Size change. Re-run
+                // that algorithm with the filled width made definite so the
+                // columns (and their centered cell content) span the column
+                // instead of hugging the content (WPT table-grid-item-dynamic-002).
+                if ((child.Display == CssConstants.Table || child.Display == CssConstants.InlineTable)
+                    && child.LayoutEnvironment != null)
+                {
+                    string savedWidth = child.Width;
+                    float savedX = child.Location.X, savedY = child.Location.Y;
+                    // Make the filled width definite and re-run the box's own
+                    // layout (not just the table algorithm) so the §10.7 min-height
+                    // clamp still applies — a bare table-engine call would drop the
+                    // table's min-height and collapse it to content height.
+                    child.Width = targetWidth.ToString("R", System.Globalization.CultureInfo.InvariantCulture) + "px";
+                    child.PerformLayout(child.LayoutEnvironment);
+                    child.Width = savedWidth;
+                    // PerformLayout may reposition the box; the caller offsets it
+                    // into its cell next, so restore the pre-relayout origin.
+                    child.OffsetLeft(savedX - child.Location.X);
+                    child.OffsetTop(savedY - child.Location.Y);
+                    child.Size = new SizeF((float)targetWidth, child.Size.Height);
+                    child.ActualRight = child.Location.X + targetWidth;
+                }
             }
         }
         resolvedJustify = js;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -248,6 +248,16 @@ internal partial class CssBox
         {
             if (child.Display == CssConstants.None)
                 continue;
+            // CSS Grid §4: every in-flow child becomes a grid item, EXCEPT a
+            // contiguous run of collapsible white space that is not contained in
+            // a non-anonymous box — such an anonymous box "is not rendered (just
+            // as if it were display:none)" and must not occupy a track. Broiler's
+            // box tree keeps the inter-item white space between block-level grid
+            // items as anonymous whitespace-only boxes; left in, each auto-places
+            // into its own phantom track and inflates the grid (e.g. the
+            // grid-lanes subgrid reftests gained spurious rows).
+            if (IsCollapsibleWhitespaceItem(child))
+                continue;
             if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
             {
                 if (gridIsAbsposContainingBlock)
@@ -977,6 +987,21 @@ internal partial class CssBox
             slice[i] = sizes[start + i];
         return slice;
     }
+
+    /// <summary>
+    /// CSS Grid §4: an anonymous box holding only collapsible white space is not
+    /// rendered and generates no grid item. True only for an anonymous box (no
+    /// element), with no child boxes, whose text is entirely white space and
+    /// whose <c>white-space</c> would collapse it (i.e. not a <c>pre*</c> value
+    /// that preserves it).
+    /// </summary>
+    private static bool IsCollapsibleWhitespaceItem(CssBox child)
+        => child.HtmlTag == null
+           && child.Boxes.Count == 0
+           && child.WhiteSpace != CssConstants.Pre
+           && child.WhiteSpace != CssConstants.PreWrap
+           && child.WhiteSpace != CssConstants.PreLine
+           && child.Text.Span.IsWhiteSpace();
 
     /// <summary>True when a track template's first token is the <c>subgrid</c> keyword.</summary>
     private static bool StartsWithSubgrid(string template)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -387,6 +387,29 @@ internal partial class CssBox
                 return false;
 
             double marginY = p.Item.ActualMarginTop + p.Item.ActualMarginBottom;
+
+            // CSS Grid L2 §7.3: a row-subgrid item spanning several of this grid's
+            // rows contributes its *own* per-track content sizes to those rows, not
+            // one lumped height distributed equally. Without this a subgrid over
+            // auto rows flattens differently-sized rows to the average (e.g. the
+            // row-subgrid-grid-gap reftest's 30/50/30 rows collapsed to
+            // 36.6/36.6/36.6). Expand into one AxisItem per spanned row when the
+            // subgrid's children resolve cleanly; otherwise fall through to the
+            // single lumped item below.
+            if (p.RowSpan > 1
+                && StartsWithSubgrid(p.Item.GridTemplateRows)
+                && TryGetSubgridRowContributions(p.Item, p.RowSpan) is { } perRow)
+            {
+                double perRowMargin = marginY / p.RowSpan;
+                for (int t = 0; t < p.RowSpan; t++)
+                {
+                    double th = perRow[t] + perRowMargin;
+                    if (th < 0) th = 0;
+                    rowItems.Add(new AxisItem(p.PlacedRow + t, 1, th, th));
+                }
+                continue;
+            }
+
             // A replaced item with a definite block-size records its height on its
             // image word (measured through the container line box), leaving the box
             // ActualBottom at 0; trust the definite block-size for the row instead
@@ -975,6 +998,44 @@ internal partial class CssBox
             item.SubgridRowGap = rowGap;
         }
         item.TryApplyGridTrackLayout();
+    }
+
+    /// <summary>
+    /// CSS Grid L2 §7.3: the per-track block-axis content contributions a
+    /// row-subgrid makes to the <paramref name="parentSpan"/> parent rows it
+    /// spans — the max content height of the subgrid's children placed in each
+    /// subgridded row. Returns <c>null</c> to decline (keeping the caller's lumped
+    /// single-item sizing) unless every in-flow child is explicitly placed on a
+    /// single, in-range row, so auto-placement and multi-row spans stay on the
+    /// existing conservative path. The subgrid's children have already been laid
+    /// out (its standalone/orphan pass), so their measured heights are available.
+    /// </summary>
+    private double[] TryGetSubgridRowContributions(CssBox subgrid, int parentSpan)
+    {
+        if (parentSpan <= 0)
+            return null;
+        var contrib = new double[parentSpan];
+        bool any = false;
+        foreach (var child in subgrid.Boxes)
+        {
+            if (child.Display == CssConstants.None || IsCollapsibleWhitespaceItem(child))
+                continue;
+            if (child.Position is CssConstants.Absolute or CssConstants.Fixed)
+                continue;
+            var (rowStart, rowSpan) = ParseGridLine(child.GridRow, parentSpan);
+            if (!rowStart.HasValue || rowSpan != 1)
+                return null;
+            int idx = rowStart.Value;
+            if (idx < 0 || idx >= parentSpan)
+                return null;
+            double marginY = child.ActualMarginTop + child.ActualMarginBottom;
+            double h = (child.ActualBottom - child.Location.Y) + marginY;
+            if (h < 0) h = 0;
+            if (h > contrib[idx])
+                contrib[idx] = h;
+            any = true;
+        }
+        return any ? contrib : null;
     }
 
     /// <summary>The <paramref name="span"/> track sizes starting at <paramref name="start"/>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -527,6 +527,7 @@ internal abstract class CssBoxProperties
     public string Display { get; set; } = "inline";
     public string Direction { get; set; } = "ltr";
     public string EmptyCells { get; set; } = "show";
+    public string CaptionSide { get; set; } = "top";
     public string Float { get; set; } = "none";
     public string Clear { get; set; } = "none";
     public string Position { get; set; } = "static";
@@ -1765,6 +1766,7 @@ internal abstract class CssBoxProperties
         BorderCollapse = p.BorderCollapse;
         _color = p._color;
         EmptyCells = p.EmptyCells;
+        CaptionSide = p.CaptionSide;
         WhiteSpace = p.WhiteSpace;
         Visibility = p.Visibility;
         _textIndent = p._textIndent;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -1098,6 +1098,18 @@ internal static class CssLayoutEngine
 
             b.ApplyGridLayoutAfterInline();
         }
+        else if (b.Display == CssConstants.Table || b.Display == CssConstants.InlineTable)
+        {
+            // A table laid out through this atomic-inline path (an `inline-table`,
+            // or a `display:table` blockified into a flex/grid item, which
+            // ContainsInlinesOnly routes here) must run the table formatting
+            // algorithm — its row/row-group/cell/caption boxes have no standalone
+            // block layout. Without this the table's children were laid out
+            // individually as blocks, so the rows and cells (and their text) were
+            // never positioned and a `<table>` grid item rendered empty. (WPT
+            // css-grid/table-grid-item-dynamic-002.)
+            CssLayoutEngineTable.PerformLayout(g, b, b.BaseUrl);
+        }
         else if (LayoutBoxUtils.ContainsInlinesOnly(b) || InlineContentWithBrsOnly(b))
         {
             // Inline-block content that is inline runs interrupted only by <br>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngineTable.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngineTable.cs
@@ -18,6 +18,12 @@ internal sealed class CssLayoutEngineTable
     private readonly List<CssBox> _columns = [];
     private readonly List<CssBox> _allRows = [];
 
+    // CSS2.1 §17.4.1: table-caption boxes are laid out as block boxes above
+    // (caption-side:top, the default) or below the table box, spanning the
+    // table's width. Broiler previously dropped them entirely, so caption text
+    // never rendered; collect them here to lay out in LayoutCells.
+    private readonly List<CssBox> _captions = [];
+
     private int _columnCount;
 
     private bool _widthSpecified;
@@ -123,6 +129,7 @@ internal sealed class CssLayoutEngineTable
             switch (box.Display)
             {
                 case CssConstants.TableCaption:
+                    _captions.Add(box);
                     break;
                 case CssConstants.TableRow:
                     _bodyrows.Add(box);
@@ -665,8 +672,15 @@ internal sealed class CssLayoutEngineTable
 
     private void LayoutCells(ILayoutEnvironment g)
     {
+        // CSS2.1 §17.4.1: lay out top-side captions above the cell grid. They
+        // span the table's used width and push the first row (and every later
+        // row) down by their combined height. Bottom-side captions are laid out
+        // after the rows (see below).
+        double captionWidth = GetWidthSum() + GetHorizontalSpacing() * (_columnCount + 1);
+        double topCaptionHeight = LayoutTopCaptions(g, captionWidth);
+
         double startx = Math.Max(_tableBox.ClientLeft + GetHorizontalSpacing(), 0);
-        double starty = Math.Max(_tableBox.ClientTop + GetVerticalSpacing(), 0);
+        double starty = Math.Max(_tableBox.ClientTop + topCaptionHeight + GetVerticalSpacing(), 0);
         double cury = starty;
         double maxRight = startx;
         double maxBottom = 0f;
@@ -805,6 +819,12 @@ internal sealed class CssLayoutEngineTable
         _tableBox.ActualRight = maxRight + GetHorizontalSpacing() + _tableBox.ActualBorderRightWidth;
         _tableBox.ActualBottom = Math.Max(maxBottom, starty) + GetVerticalSpacing() + _tableBox.ActualBorderBottomWidth;
 
+        // CSS2.1 §17.4.1: lay out bottom-side captions below the table box and
+        // extend the table's bottom to enclose them.
+        double bottomCaptionBottom = LayoutBottomCaptions(g, captionWidth, _tableBox.ActualBottom);
+        if (bottomCaptionBottom > _tableBox.ActualBottom)
+            _tableBox.ActualBottom = bottomCaptionBottom;
+
         // CSS2.1 §17.5.2: Update the table box's Size to match the
         // computed layout dimensions so background painting, overflow
         // clipping, and child containing-block queries use the correct
@@ -812,6 +832,99 @@ internal sealed class CssLayoutEngineTable
         _tableBox.Size = new SizeF(
             (float)(_tableBox.ActualRight - _tableBox.Location.X),
             (float)(_tableBox.ActualBottom - _tableBox.Location.Y));
+    }
+
+    /// <summary>
+    /// CSS2.1 §17.4.1: A caption's <c>caption-side</c> places it on the block
+    /// (top/bottom) side of the table. Broiler exposes it as a raw string
+    /// property (default <c>top</c>); only <c>bottom</c> moves it below.
+    /// </summary>
+    private static bool IsBottomCaption(CssBox caption) =>
+        string.Equals(caption.CaptionSide, CssConstants.Bottom, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Lay out a single caption as a block box of the table's used width and
+    /// return its outer (margin-box) height. The caption is positioned at
+    /// (<paramref name="x"/>, <paramref name="y"/>) at its content-box origin,
+    /// inside its own margins.
+    /// </summary>
+    private static double LayoutCaption(ILayoutEnvironment g, CssBox caption, double x, double y, double width)
+    {
+        double contentWidth = Math.Max(0,
+            width - caption.ActualMarginLeft - caption.ActualMarginRight
+                  - caption.ActualBorderLeftWidth - caption.ActualBorderRightWidth
+                  - caption.ActualPaddingLeft - caption.ActualPaddingRight);
+
+        // The caption is laid out as a block box whose width is the table's used
+        // width (CSS2.1 §17.4). PerformLayoutImp resolves a block's width from its
+        // containing block (the table box), whose Size.Width is not finalised
+        // until LayoutCells completes — so pin an explicit content-box width here
+        // (only when the author left it auto) to avoid the caption shrinking to a
+        // stale/zero container width and wrapping every word onto its own line.
+        string savedWidth = caption.Width;
+        bool pinWidth = string.IsNullOrEmpty(caption.Width) || caption.Width == CssConstants.Auto;
+        if (pinWidth)
+            caption.Width = contentWidth.ToString("R", System.Globalization.CultureInfo.InvariantCulture) + "px";
+
+        double targetX = x + caption.ActualMarginLeft;
+        double targetY = y + caption.ActualMarginTop;
+        caption.Location = new PointF((float)targetX, (float)targetY);
+        caption.Size = new SizeF((float)contentWidth, 0f);
+        caption.PerformLayout(g);
+
+        if (pinWidth)
+            caption.Width = savedWidth;
+
+        // PerformLayoutImp positions a block's content relative to a flow origin
+        // it recomputes, so the caption (and its line boxes) may not honour the
+        // provisional Location set above — snap the whole subtree to the target
+        // with OffsetLeft/OffsetTop, mirroring the grid item placement path.
+        double dx = targetX - caption.Location.X;
+        double dy = targetY - caption.Location.Y;
+        if (Math.Abs(dx) > 0.01)
+            caption.OffsetLeft(dx);
+        if (Math.Abs(dy) > 0.01)
+            caption.OffsetTop(dy);
+
+        return (caption.ActualBottom - caption.Location.Y)
+            + caption.ActualMarginTop + caption.ActualMarginBottom;
+    }
+
+    /// <summary>
+    /// CSS2.1 §17.4.1: lay out all top-side captions stacked from the table's
+    /// content-box top, returning their combined height so the cell grid can be
+    /// offset below them.
+    /// </summary>
+    private double LayoutTopCaptions(ILayoutEnvironment g, double width)
+    {
+        double total = 0;
+        double x = _tableBox.ClientLeft;
+        double top = _tableBox.ClientTop;
+        foreach (var caption in _captions)
+        {
+            if (IsBottomCaption(caption))
+                continue;
+            total += LayoutCaption(g, caption, x, top + total, width);
+        }
+        return total;
+    }
+
+    /// <summary>
+    /// CSS2.1 §17.4.1: lay out all bottom-side captions stacked below the table
+    /// box, returning the bottom edge of the last caption (or the incoming
+    /// <paramref name="tableBottom"/> when there are none).
+    /// </summary>
+    private double LayoutBottomCaptions(ILayoutEnvironment g, double width, double tableBottom)
+    {
+        double x = _tableBox.ClientLeft;
+        double y = tableBottom;
+        foreach (var caption in _captions)
+        {
+            if (!IsBottomCaption(caption))
+                continue;
+            y += LayoutCaption(g, caption, x, y, width);
+        }
+        return y;
     }
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngineTable.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngineTable.cs
@@ -813,7 +813,7 @@ internal sealed class CssLayoutEngineTable
 
         // CSS2.1 §17.5.3: when the table's specified height exceeds the height
         // the rows naturally occupy, distribute the surplus over the rows.
-        maxBottom = DistributeExtraTableHeight(g, rowBounds, maxBottom);
+        maxBottom = DistributeExtraTableHeight(g, rowBounds, maxBottom, starty);
 
         maxRight = Math.Max(maxRight, _tableBox.Location.X + _tableBox.ActualWidth);
         _tableBox.ActualRight = maxRight + GetHorizontalSpacing() + _tableBox.ActualBorderRightWidth;
@@ -940,26 +940,51 @@ internal sealed class CssLayoutEngineTable
     /// </summary>
     private double DistributeExtraTableHeight(
         ILayoutEnvironment g, List<(CssBox Row, double Top, double Bottom)> rowBounds,
-        double naturalBottom)
+        double naturalBottom, double rowAreaTop)
     {
         if (rowBounds.Count == 0)
             return naturalBottom;
-        if (string.IsNullOrEmpty(_tableBox.Height) || _tableBox.Height == CssConstants.Auto)
-            return naturalBottom;
 
-        // Resolve the specified height against the containing block (percentages
-        // need a definite basis; fall back to no-op when unavailable).
         double cbHeight = _tableBox.ContainingBlock?.ActualHeight ?? 0;
-        double specHeight = CssValueParser.ParseLength(_tableBox.Height, cbHeight, _tableBox.GetEmHeight());
-        if (double.IsNaN(specHeight) || specHeight <= 0)
-            return naturalBottom;
+        double em = _tableBox.GetEmHeight();
 
-        // Target bottom for the row area = table top + specified content height.
-        // ClientTop already includes the table's top border/padding; the bottom
-        // border/spacing is added by the caller, so target the row content box.
-        double specBottom = _tableBox.Location.Y + specHeight
-            - _tableBox.ActualBorderBottomWidth - _tableBox.ActualPaddingBottom - GetVerticalSpacing();
-        double surplus = specBottom - naturalBottom;
+        double target = naturalBottom;
+
+        // CSS2.1 §17.5.3: an explicit table 'height' greater than the content
+        // grows the rows. Target bottom for the row area = table top + specified
+        // content height (ClientTop already includes the top border/padding; the
+        // bottom border/spacing is added by the caller).
+        if (!string.IsNullOrEmpty(_tableBox.Height) && _tableBox.Height != CssConstants.Auto)
+        {
+            double specHeight = CssValueParser.ParseLength(_tableBox.Height, cbHeight, em);
+            if (!double.IsNaN(specHeight) && specHeight > 0)
+            {
+                double specBottom = _tableBox.Location.Y + specHeight
+                    - _tableBox.ActualBorderBottomWidth - _tableBox.ActualPaddingBottom - GetVerticalSpacing();
+                if (specBottom > target)
+                    target = specBottom;
+            }
+        }
+
+        // CSS2.1 §17.5.3 / §10.7: a 'min-height' greater than the content grows
+        // the rows the same way. In the table wrapper model min-height applies to
+        // the inner table box (the rows), *not* the caption, so measure it from
+        // the row-area top (below any top caption) rather than the table origin —
+        // this is what vertically centres a `vertical-align:middle` cell whose
+        // table has a tall min-height (WPT table-grid-item-dynamic-002).
+        if (!string.IsNullOrEmpty(_tableBox.MinHeight) && _tableBox.MinHeight != "0")
+        {
+            double minH = CssValueParser.ParseLength(_tableBox.MinHeight, cbHeight, em);
+            if (!double.IsNaN(minH) && minH > 0)
+            {
+                double minBottom = rowAreaTop + minH
+                    - _tableBox.ActualBorderTopWidth - _tableBox.ActualBorderBottomWidth;
+                if (minBottom > target)
+                    target = minBottom;
+            }
+        }
+
+        double surplus = target - naturalBottom;
         if (surplus <= 0.5)
             return naturalBottom;
 

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -90,6 +90,7 @@ internal static class CssUtils
             "display" => cssBox.Display,
             "direction" => cssBox.Direction,
             "empty-cells" => cssBox.EmptyCells,
+            "caption-side" => cssBox.CaptionSide,
             "float" => cssBox.Float,
             "clear" => cssBox.Clear,
             "position" => cssBox.Position,
@@ -554,6 +555,9 @@ internal static class CssUtils
                 break;
             case "empty-cells":
                 cssBox.EmptyCells = value;
+                break;
+            case "caption-side":
+                cssBox.CaptionSide = value;
                 break;
             case "float":
                 cssBox.Float = value;

--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -744,11 +744,18 @@ single fix flips them:
 - **#7 `alignment/grid-align-baseline-vertical`** — vertical-writing-mode grid **intrinsic (block-axis)
   width** + **baseline self-alignment** (Workstream A's open tail): the `writing-mode:vertical-rl` grids
   size their physical width to the viewport instead of shrink-wrapping their rows.
-- **#8 `table-grid-item-dynamic-002`** — three stacked gaps: (a) a `<table>` **grid item is declined as
-  "not simple"** (`GridImplicitPathItemsAreSimple`) and approximated *without laying its content out*, so
-  the `th` text vanishes; (b) **table `<caption>` boxes were dropped entirely** — fixed this session (see
-  below); (c) the `onload` **min-height 500→100 dynamic relayout** does not take effect. Passing needs
-  (a) grid non-simple-item content layout **and** (c) style-mutation reflow, both substantial.
+- **#8 `table-grid-item-dynamic-002` — ✅ layout fixed this session (49% → 98.7%).** Four stacked bugs,
+  each spec-grounded: (a) table `<caption>` boxes were dropped (fixed earlier this session); (b) a bare
+  `onload = fn` never fired because `window` ≠ the global object in the JS engine — a bare assignment
+  lands on `globalThis.onload`, so `FireWindowLoadEvent` now checks both (this made the `min-height`
+  500→100 dynamic relayout take effect); (c) a `<table>` laid out as a grid/inline item had its rows/cells
+  laid out as bare blocks (the table formatting algorithm never ran) so cell text vanished — `FlowInlineBlock`
+  now routes `display:table` through `CssLayoutEngineTable`; (d) a stretched table grid item filled the
+  column but its cells stayed shrink-wrapped and its `min-height` did not grow the row (so the
+  middle-aligned `th` was not vertically centred) — the stretch path re-runs the table at the filled width,
+  and `DistributeExtraTableHeight` now honours `min-height` (measured from the row-area top, below the
+  caption). The residual ~1.3% is glyph-level: the test's `monospace` renders narrower in Broiler than in
+  the reference Chromium (the grey box matches pixel-for-pixel). Guards `TableGridItemTests`.
 
 **Fixed this session — table `<caption>` layout (CSS2.1 §17.4.1).** While root-causing #8 the table
 engine was found to match `display:table-caption` with a bare `case …: break;` — captions were collected

--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -719,6 +719,45 @@ element's default display):
    subgrid** track layout (cluster 28's tail); a `grid-auto-rows`-only shortcut would stack the children
    full-width and over-paint the grey, so it is not attempted here.
 
+Cluster 38 (issue [#1266](https://github.com/Broiler-Platform/Broiler/issues/1266), the "top-8 biggest
+problems" run) was triaged end-to-end this session against a local Chromium-reference pixel loop (sparse
+`css/css-grid` checkout + Playwright references + `Broiler.Wpt` compare, reproducing the issue's percent
+matches within noise). All eight are the hard tail and each needs a distinct, roadmap-scale feature — no
+single fix flips them:
+
+- **#1/#3/#4 `column-subgrid-auto-fill-{003,001,008}` and #6 `row-subgrid-grid-gap-012`** — the deferred
+  **multi-column named-line subgrid track adoption** (cluster 28/29 tail): a subgrid item inheriting its
+  parent's spanned tracks, `repeat(auto-fill, [line-names])`, and `subgrid`-side gap. Broiler's
+  single-column approximation over/under-sizes the grey subgrid bands (gap-012 renders the right band
+  order at ~2× height).
+- **#2 `subgrid/orthogonal-writing-mode-006`** — same subgrid feature across an orthogonal flow; Broiler
+  blows the fit-content outer grid up to the viewport.
+- **#5 `grid-lanes-quirks-fill-viewport`** — the quirks-mode *body-fills-viewport* / *html-fills-viewport*
+  behaviour (quirks.spec §"the body element fills the html element quirk"). Broiler tracks **no**
+  quirks/standards mode in the DOM→layout path, so even the `display:grid` `-ref` renders the body at
+  content height. Needs doctype→quirks plumbing before the fill can be implemented.
+- **#7 `alignment/grid-align-baseline-vertical`** — vertical-writing-mode grid **intrinsic (block-axis)
+  width** + **baseline self-alignment** (Workstream A's open tail): the `writing-mode:vertical-rl` grids
+  size their physical width to the viewport instead of shrink-wrapping their rows.
+- **#8 `table-grid-item-dynamic-002`** — three stacked gaps: (a) a `<table>` **grid item is declined as
+  "not simple"** (`GridImplicitPathItemsAreSimple`) and approximated *without laying its content out*, so
+  the `th` text vanishes; (b) **table `<caption>` boxes were dropped entirely** — fixed this session (see
+  below); (c) the `onload` **min-height 500→100 dynamic relayout** does not take effect. Passing needs
+  (a) grid non-simple-item content layout **and** (c) style-mutation reflow, both substantial.
+
+**Fixed this session — table `<caption>` layout (CSS2.1 §17.4.1).** While root-causing #8 the table
+engine was found to match `display:table-caption` with a bare `case …: break;` — captions were collected
+nowhere and laid out never, so caption text/background rendered nowhere and the table height excluded
+them. `CssLayoutEngineTable` now collects captions and lays them out as block boxes of the table's used
+width: top-side captions (the default) stack above the cell grid and push the rows down; a
+`caption-side:bottom` caption stacks below (a new inherited `CaptionSide` property, wired through
+`CssUtils`). `display:table-caption` also gained a real block-layout path in `CssBox.PerformLayoutImp`
+(it fell through every branch and stayed 0-height). Guard `TableCaptionTests` (top pushes rows down by
+the caption height; bottom sits below without moving them); zero regressions across the vendored
+css-align/css-anchor-position/CSS2 subsets (102/38/13 byte-identical before/after) and the grid Cli.Tests.
+This is a general table-rendering correctness win but does **not** by itself flip #8, which still needs
+the grid non-simple-item and dynamic-reflow work above.
+
 Cluster 30 (issue [#1227](https://github.com/Broiler-Platform/Broiler/issues/1227), the "biggest
 problems" CSS Grid list — the `grid-items` tests at ~9 % match) was a **grid-item percentage-height**
 bug in the inline-block fallback. `css-grid/grid-items/whitespace-in-grid-item-001`'s `.item`

--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -737,10 +737,19 @@ single fix flips them:
   over/under-sizes the grey subgrid bands. Still open (the harder half of the cluster).
 - **#2 `subgrid/orthogonal-writing-mode-006`** — same subgrid feature across an orthogonal flow; Broiler
   blows the fit-content outer grid up to the viewport.
-- **#5 `grid-lanes-quirks-fill-viewport`** — the quirks-mode *body-fills-viewport* / *html-fills-viewport*
-  behaviour (quirks.spec §"the body element fills the html element quirk"). Broiler tracks **no**
-  quirks/standards mode in the DOM→layout path, so even the `display:grid` `-ref` renders the body at
-  content height. Needs doctype→quirks plumbing before the fill can be implemented.
+- **#5 `grid-lanes-quirks-fill-viewport` — ✅ mostly fixed this session (11.6% → 98.1%).** The quirks-mode
+  *body-fills-viewport* / *html-fills-viewport* behaviour (quirks.spec §"the body element fills the html
+  element quirk"). Broiler tracked no quirks/standards mode, so an auto-height body shrink-wrapped to
+  content. Added a **main-repo-only** quirks pipeline (no submodule change — `Broiler.DOM` is an unpushable
+  submodule and the main repo must compile against its pinned commit): a thread-local
+  `Broiler.Layout.DocumentModeContext` (mirroring `CssLengthParser`'s per-render viewport state) that
+  `DomBridge` sets from the doctype on parse — every WPT render parses through the bridge before laying
+  out — and which `CssBox` caches on the tree root and consults to grow an auto `<html>`/`<body>` to the
+  viewport / html content minus margins. The residual ~1.9% is the body's vertical position: Broiler adds
+  the child `<p>`'s top margin to the body position instead of collapsing it through (a general
+  parent/first-child margin-collapse behaviour, not the fill quirk). Guard `QuirksBodyFillTests`
+  (doctype→quirks detection; the fill itself is pixel-verified by the reftest — the check-layout harness
+  reports the body rect as the full viewport regardless of mode).
 - **#7 `alignment/grid-align-baseline-vertical`** — vertical-writing-mode grid **intrinsic (block-axis)
   width** + **baseline self-alignment** (Workstream A's open tail): the `writing-mode:vertical-rl` grids
   size their physical width to the viewport instead of shrink-wrapping their rows.

--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -725,11 +725,16 @@ problems" run) was triaged end-to-end this session against a local Chromium-refe
 matches within noise). All eight are the hard tail and each needs a distinct, roadmap-scale feature — no
 single fix flips them:
 
-- **#1/#3/#4 `column-subgrid-auto-fill-{003,001,008}` and #6 `row-subgrid-grid-gap-012`** — the deferred
-  **multi-column named-line subgrid track adoption** (cluster 28/29 tail): a subgrid item inheriting its
-  parent's spanned tracks, `repeat(auto-fill, [line-names])`, and `subgrid`-side gap. Broiler's
-  single-column approximation over/under-sizes the grey subgrid bands (gap-012 renders the right band
-  order at ~2× height).
+- **#6 `row-subgrid-grid-gap-012` — ✅ fixed this session (46% → 99.8%).** Two bugs: (1) the collapsible
+  white space between the `<span>`s was being turned into phantom grid items (two extra rows); dropping
+  anonymous whitespace-only items per §4 took it to ~96%. (2) The row-subgrid over the parent's auto rows
+  lumped its 30/50/30 content into one span and distributed it equally (36.6/36.6/36.6); giving the parent
+  per-track contributions from the subgrid's children (§7.3, `TryGetSubgridRowContributions`) sized the
+  rows correctly. Guards `GridWhitespaceItemTests`, `SubgridRowContributionTests`.
+- **#1/#3/#4 `column-subgrid-auto-fill-{003,001,008}`** — the deferred **multi-column named-line subgrid
+  track adoption** (cluster 28/29 tail): a subgrid item inheriting its parent's spanned tracks,
+  `repeat(auto-fill, [line-names])`, and `subgrid`-side gap. Broiler's single-column approximation
+  over/under-sizes the grey subgrid bands. Still open (the harder half of the cluster).
 - **#2 `subgrid/orthogonal-writing-mode-006`** — same subgrid feature across an orthogonal flow; Broiler
   blows the fit-content outer grid up to the viewport.
 - **#5 `grid-lanes-quirks-fill-viewport`** — the quirks-mode *body-fills-viewport* / *html-fills-viewport*

--- a/src/Broiler.Cli.Tests/GridWhitespaceItemTests.cs
+++ b/src/Broiler.Cli.Tests/GridWhitespaceItemTests.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+using Xunit;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Regression guard for CSS Grid §4: a contiguous run of collapsible white space
+/// that is not inside an element generates no grid item. Broiler's box tree keeps
+/// the inter-item white space between block-level grid items as anonymous
+/// whitespace-only boxes; the grid item collection previously turned each into a
+/// phantom item, auto-placing it into its own track and inflating the grid with
+/// spurious rows/columns (the grid-lanes subgrid reftests, e.g.
+/// row-subgrid-grid-gap-012, gained extra rows and jumped from ~46% to ~96% pixel
+/// match once these were dropped).
+///
+/// A three-row grid whose items carry newlines/indentation between them must size
+/// to exactly three rows — identical to the same markup with the white space
+/// removed.
+/// </summary>
+public sealed class GridWhitespaceItemTests
+{
+    private static double GridHeight(string bodyInner)
+    {
+        string html =
+            "<!DOCTYPE html><html><head><style>"
+            + "body{margin:0;font:20px/1 monospace}"
+            + ".g{display:grid;grid-template-columns:100px;grid-auto-rows:40px;position:relative}"
+            + ".g span{background:grey}"
+            + "</style></head><body>"
+            + "<div class=\"g\" id=\"g\" data-offset-x=\"0\" data-offset-y=\"0\" data-expected-height=\"0\">"
+            + bodyInner
+            + "</div></body></html>";
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///ws.html");
+        var by = bridge.EvaluateCheckLayoutAssertions()
+            .GroupBy(a => a.Element)
+            .ToDictionary(g => g.Key, g => g.ToDictionary(a => a.Property, a => a.Actual));
+        return by.TryGetValue("div#g", out var m) && m.TryGetValue("height", out var h) ? h : double.NaN;
+    }
+
+    [Fact]
+    public void WhitespaceBetweenGridItems_DoesNotAddPhantomTracks()
+    {
+        // Newlines + indentation between the three items (the natural authoring
+        // style, and exactly what the WPT subgrid tests use).
+        string spaced =
+            "\n      <span style=\"grid-row:1\">a</span>\n"
+            + "      <span style=\"grid-row:2\">b</span>\n"
+            + "      <span style=\"grid-row:3\">c</span>\n    ";
+        // The same three items with no inter-item white space.
+        string tight =
+            "<span style=\"grid-row:1\">a</span>"
+            + "<span style=\"grid-row:2\">b</span>"
+            + "<span style=\"grid-row:3\">c</span>";
+
+        double spacedH = GridHeight(spaced);
+        double tightH = GridHeight(tight);
+
+        // Three 40px auto rows → 120px, regardless of the inter-item white space.
+        Assert.Equal(120, tightH, 1);
+        Assert.Equal(tightH, spacedH, 1);
+    }
+}

--- a/src/Broiler.Cli.Tests/QuirksBodyFillTests.cs
+++ b/src/Broiler.Cli.Tests/QuirksBodyFillTests.cs
@@ -1,0 +1,33 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+using Xunit;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Regression guard for the quirks-mode "the body element fills the html element"
+/// / "the html element fills the viewport" quirks
+/// (https://quirks.spec.whatwg.org/), driving WPT
+/// css-grid/grid-lanes/grid-lanes-quirks-fill-viewport. In quirks mode an
+/// auto-height &lt;body&gt; fills the html element's content box *minus its own
+/// margins*; the quirks flag is derived from the doctype and published through
+/// <c>Broiler.Layout.DocumentModeContext</c> (set by <c>DomBridge</c> on parse).
+/// </summary>
+public sealed class QuirksBodyFillTests
+{
+    // Quirks-mode detection from the doctype — the fiddly half of the feature.
+    // The layout fill itself (an auto body/html growing to the viewport minus
+    // margins) is exercised by the WPT reftest grid-lanes-quirks-fill-viewport;
+    // Broiler's check-layout harness reports the body's client rect as the full
+    // viewport regardless of mode, so it cannot measure the fill here.
+    [Theory]
+    [InlineData("<!DOCTYPE html>", false)]
+    [InlineData("<!doctype html>", false)]
+    [InlineData("<!DOCTYPE HTML>", false)]
+    [InlineData("<!doctype quirks>", true)]
+    [InlineData("<!doctype html PUBLIC \"-//W3C//DTD HTML 4.01//EN\">", false)]
+    [InlineData("", true)]
+    [InlineData("<html><body></body></html>", true)]
+    public void IsQuirksHtml_MatchesDoctype(string html, bool expectedQuirks)
+        => Assert.Equal(expectedQuirks, Broiler.Layout.DocumentModeContext.IsQuirksHtml(html));
+}

--- a/src/Broiler.Cli.Tests/SubgridRowContributionTests.cs
+++ b/src/Broiler.Cli.Tests/SubgridRowContributionTests.cs
@@ -1,0 +1,53 @@
+using System.Linq;
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+using Xunit;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Regression guard for CSS Grid L2 §7.3 subgrid track sizing: a row-subgrid
+/// spanning several of its parent's auto rows contributes its own per-track
+/// content sizes to those rows, rather than a single lumped height distributed
+/// equally. Before this, differently-sized subgrid rows (30 / 50 / 30) collapsed
+/// to the average (36.6 / 36.6 / 36.6) — the residual error that kept WPT
+/// css-grid/grid-lanes/subgrid row-subgrid-grid-gap-012 at ~96% after the
+/// whitespace-item fix; with per-track contributions it matches (~99.8%).
+///
+/// A standalone outer grid with three auto rows wraps a subgrid spanning all
+/// three, whose items are 30 / 50 / 30 tall. The items must land at y = 0, 30, 80
+/// (rows sized to each item), not 0, 36.6, 73.3 (equal thirds).
+/// </summary>
+public sealed class SubgridRowContributionTests
+{
+    private static double OffsetY(string id, System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, double>> by)
+        => by.TryGetValue(id, out var m) && m.TryGetValue("offset-y", out var v) ? v : double.NaN;
+
+    [Fact]
+    public void RowSubgrid_SizesParentRowsPerTrack_NotAveraged()
+    {
+        string html =
+            "<!DOCTYPE html><html><head><style>"
+            + "body{margin:0;font:20px/1 monospace}"
+            + ".outer{display:grid;grid-template-rows:auto auto auto;position:relative;width:100px}"
+            + ".sub{display:grid;grid-template-rows:subgrid;grid-row:1 / span 3}"
+            + "</style></head><body>"
+            + "<div class=\"outer\">"
+            + "<div class=\"sub\">"
+            + "<div id=\"a\" style=\"height:30px;grid-row:1\" data-offset-x=\"0\" data-offset-y=\"0\" data-expected-height=\"30\"></div>"
+            + "<div id=\"b\" style=\"height:50px;grid-row:2\" data-offset-x=\"0\" data-offset-y=\"0\" data-expected-height=\"50\"></div>"
+            + "<div id=\"c\" style=\"height:30px;grid-row:3\" data-offset-x=\"0\" data-offset-y=\"0\" data-expected-height=\"30\"></div>"
+            + "</div></div></body></html>";
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///sub.html");
+        var by = bridge.EvaluateCheckLayoutAssertions()
+            .GroupBy(a => a.Element)
+            .ToDictionary(g => g.Key, g => g.ToDictionary(a => a.Property, a => a.Actual));
+
+        // Rows sized 30 / 50 / 30 → items stack at 0, 30, 80 (no gap).
+        Assert.Equal(0, OffsetY("div#a", by), 1);
+        Assert.Equal(30, OffsetY("div#b", by), 1);
+        Assert.Equal(80, OffsetY("div#c", by), 1);
+    }
+}

--- a/src/Broiler.Cli.Tests/TableCaptionTests.cs
+++ b/src/Broiler.Cli.Tests/TableCaptionTests.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+using Xunit;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Regression guard for CSS2.1 §17.4 table captions. The table layout engine
+/// previously matched <c>display:table-caption</c> boxes with a bare
+/// <c>case … : break;</c> — collecting them nowhere and laying them out never —
+/// so caption text (and background) rendered nowhere and the table box's height
+/// excluded the caption entirely (WPT css-grid/table-grid-item-dynamic-002's
+/// "Table caption" was one visible symptom).
+///
+/// Captions are now laid out as block boxes of the table's used width: a
+/// top-side caption (the default) sits above the cell grid and pushes the rows
+/// down by its height; a <c>caption-side:bottom</c> caption sits below the grid.
+/// In both cases the caption contributes to the table's height. Assertions read
+/// the check-layout actuals and compare relationships (the exact caption height
+/// depends on the test font) rather than hard-coding pixel values.
+/// </summary>
+public sealed class TableCaptionTests
+{
+    private static (double y, double h) Box(string id, System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, double>> by)
+    {
+        var key = $"{id}";
+        if (!by.TryGetValue(key, out var m))
+            return (double.NaN, double.NaN);
+        double g(string p) => m.TryGetValue(p, out var v) ? v : double.NaN;
+        return (g("offset-y"), g("height"));
+    }
+
+    private static System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, double>> Layout(bool withCaption, string captionStyle)
+    {
+        string caption = withCaption
+            ? $"<caption id=\"cap\" style=\"{captionStyle}\" data-offset-x=\"0\" data-offset-y=\"0\" data-expected-height=\"0\">Caption text</caption>"
+            : "";
+        string html =
+            "<!DOCTYPE html><html><head><style>"
+            + "body{margin:0;font:16px/1 monospace}"
+            + "table{border-collapse:collapse}"
+            + "td{padding:0;border:0}"
+            + "</style></head><body>"
+            + "<table>"
+            + caption
+            + "<tr><td id=\"cell\" data-offset-x=\"0\" data-offset-y=\"0\" data-expected-height=\"0\">RowCellContent</td></tr>"
+            + "</table></body></html>";
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///caption.html");
+        return bridge.EvaluateCheckLayoutAssertions()
+            .GroupBy(a => a.Element)
+            .ToDictionary(g => g.Key, g => g.ToDictionary(a => a.Property, a => a.Actual));
+    }
+
+    [Fact]
+    public void TopCaption_IsLaidOutAndPushesRowsDown()
+    {
+        var baseline = Layout(withCaption: false, captionStyle: "");
+        var withCap = Layout(withCaption: true, captionStyle: "");
+
+        var cap = Box("caption#cap", withCap);
+        double cellNoCap = Box("td#cell", baseline).y;
+        double cellTopCap = Box("td#cell", withCap).y;
+
+        // The caption laid out with a non-zero height (it was previously dropped).
+        Assert.True(cap.h > 0, $"caption height should be > 0 but was {cap.h}");
+        // A top caption pushes the first row down by roughly its own height,
+        // relative to the same table with no caption.
+        Assert.True(cellTopCap - cellNoCap >= cap.h - 2,
+            $"top caption should push the cell down by ~{cap.h} (was {cellNoCap}, now {cellTopCap})");
+    }
+
+    [Fact]
+    public void BottomCaption_IsLaidOutBelowRowsWithoutMovingThem()
+    {
+        var baseline = Layout(withCaption: false, captionStyle: "");
+        var withCap = Layout(withCaption: true, captionStyle: "caption-side:bottom");
+
+        var cap = Box("caption#cap", withCap);
+        double cellNoCap = Box("td#cell", baseline).y;
+        var cell = Box("td#cell", withCap);
+
+        Assert.True(cap.h > 0, $"caption height should be > 0 but was {cap.h}");
+        // A bottom caption does not move the rows...
+        Assert.True(System.Math.Abs(cell.y - cellNoCap) <= 2,
+            $"bottom caption should not move the cell (was {cellNoCap}, now {cell.y})");
+        // ...and sits at/below the cell's bottom edge.
+        Assert.True(cap.y >= cell.y + cell.h - 2,
+            $"bottom caption top ({cap.y}) should be at/below cell bottom ({cell.y + cell.h})");
+    }
+}

--- a/src/Broiler.Cli.Tests/TableGridItemTests.cs
+++ b/src/Broiler.Cli.Tests/TableGridItemTests.cs
@@ -1,0 +1,79 @@
+using System.Linq;
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+using Xunit;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Regression guards for the fixes that made WPT css-grid/table-grid-item-dynamic-002
+/// render correctly (49% → ~99% pixel match):
+///
+/// 1. A bare <c>onload = fn</c> global assignment fires on window load. In this
+///    engine <c>window</c> is not the global object, so a bare assignment lands on
+///    <c>globalThis.onload</c>; FireWindowLoadEvent now checks both, so the test's
+///    <c>onload</c> handler (which shrinks the table via <c>style.minHeight</c>)
+///    actually runs.
+/// 2. A <c>&lt;table&gt;</c> laid out as a grid/inline item runs the table
+///    formatting algorithm instead of having its rows/cells laid out as bare
+///    blocks — so its cell content is positioned and painted rather than dropped.
+/// 3. A table's <c>min-height</c> greater than its content grows the rows (and thus
+///    vertically centres a middle-aligned cell), like an explicit table height.
+/// </summary>
+public sealed class TableGridItemTests
+{
+    [Fact]
+    public void BareOnloadAssignment_FiresOnWindowLoad()
+    {
+        using var ctx = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(ctx, "<!doctype html><body><div id=d></div>", "file:///o.html");
+        bridge.RegisterNamedElementGlobals(ctx);
+        // Bare assignment (no `window.` / `var`), exactly as the WPT test writes it.
+        ctx.Eval("onload = function(){ document.getElementById('d').setAttribute('data-loaded','yes'); };");
+        bridge.FireWindowLoadEvent();
+        string html = bridge.SerializeToHtml();
+        int cut = html.IndexOf("<script", System.StringComparison.OrdinalIgnoreCase);
+        string body = cut >= 0 ? html.Substring(0, cut) : html;
+        Assert.Contains("data-loaded=\"yes\"", body);
+    }
+
+    private static System.Collections.Generic.Dictionary<string, double> Cell(string tableStyle)
+    {
+        string html =
+            "<!DOCTYPE html><html><head><style>body{margin:0;font:16px/1 monospace}"
+            + ".g{display:grid;position:relative;width:400px}</style></head><body>"
+            + "<div class=\"g\">"
+            + $"<table style=\"{tableStyle}\">"
+            + "<thead><tr><th id=\"cell\" data-offset-x=\"0\" data-offset-y=\"0\" data-expected-width=\"0\" data-expected-height=\"0\">Header text here</th></tr></thead>"
+            + "</table></div></body></html>";
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///t.html");
+        var by = bridge.EvaluateCheckLayoutAssertions()
+            .GroupBy(a => a.Element)
+            .ToDictionary(g => g.Key, g => g.ToDictionary(a => a.Property, a => a.Actual));
+        return by.TryGetValue("th#cell", out var m) ? m : new System.Collections.Generic.Dictionary<string, double>();
+    }
+
+    [Fact]
+    public void TableGridItem_LaysOutCellContent()
+    {
+        var cell = Cell("");
+        // The th cell must be laid out with real geometry — before the fix a
+        // <table> grid item's cells were 0×0 (the table engine never ran).
+        Assert.True(cell.TryGetValue("width", out var w) && w > 0, $"cell width should be > 0 but was {(cell.TryGetValue("width", out var x) ? x : double.NaN)}");
+        Assert.True(cell.TryGetValue("height", out var h) && h > 0, $"cell height should be > 0 but was {(cell.TryGetValue("height", out var y) ? y : double.NaN)}");
+    }
+
+    [Fact]
+    public void TableGridItem_MinHeightGrowsTheRow()
+    {
+        double hPlain = Cell("").TryGetValue("height", out var a) ? a : double.NaN;
+        double hMin = Cell("min-height:100px").TryGetValue("height", out var b) ? b : double.NaN;
+        // With min-height:100 the single row fills to ~100px (content ≈ 16px),
+        // so the cell is much taller than the plain (content-height) cell.
+        Assert.True(hMin >= 90, $"cell with min-height:100 should be ~100px tall but was {hMin}");
+        Assert.True(hMin > hPlain + 40, $"min-height should grow the row (plain {hPlain}, min {hMin})");
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -696,6 +696,14 @@ public sealed partial class DomBridge : IDomBridgeRuntime
             _knownNodes.Add(doctype);
         }
 
+        // Publish the document's quirks mode for the render that follows on this
+        // thread. Layout (which on the HTML-string path holds no back-reference to
+        // the document) reads it while sizing the root/body boxes for the
+        // quirks-mode fill-viewport behaviour. Every WPT render runs through this
+        // parse before laying out, so the flag is set for the render that matters.
+        Broiler.Layout.DocumentModeContext.CurrentQuirksMode =
+            Broiler.Layout.DocumentModeContext.IsQuirksHtml(html);
+
         // Use WHATWG-aligned tokeniser & tree builder
         var builder = new HtmlTreeBuilder();
         var (docElement, allElements, title) = builder.Build(html, _document);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -481,8 +481,17 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         {
             _jsContext.Eval(@"
 (function() {
-  if (typeof window.onload === 'function') {
-    try { window.onload(); } catch(e) {}
+  // A page may register the load handler either as `window.onload = fn`
+  // or as a bare `onload = fn` assignment. In a browser `window` IS the
+  // global object so both are the same property; in this engine the global
+  // object and `window` are distinct, so a bare `onload = fn` lands on the
+  // global (globalThis.onload) and never on window.onload. Check both, with
+  // window.onload winning when present.
+  var h = null;
+  if (typeof window.onload === 'function') h = window.onload;
+  else if (typeof onload === 'function') h = onload;
+  if (h) {
+    try { h(); } catch(e) {}
   }
 })();");
         }

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -1677,11 +1677,53 @@ internal sealed class WptTestRunner
     /// mechanism (which uses root-relative URLs that cannot be resolved for
     /// <c>file://</c> base URLs).
     /// </summary>
+    private static bool _genericFontsLoaded;
+
     private static void EnsureWptFontsLoaded(string wptRoot)
     {
         var ahemPath = Path.Combine(wptRoot, "fonts", "Ahem.ttf");
         if (File.Exists(ahemPath))
             HtmlRender.LoadFontFromFile(ahemPath, "Ahem");
+
+        EnsureGenericFontsLoaded();
+    }
+
+    // The reference generator's Chromium resolves the CSS generic families through
+    // fontconfig (monospace → DejaVu Sans Mono, serif → DejaVu Serif, sans-serif →
+    // DejaVu Sans). Broiler does not enumerate system fonts, so its generic-family
+    // fallback finds nothing and the backend renders a proportional default for
+    // `monospace` — text comes out far narrower than the reference (e.g. a
+    // monospace <th> at ~7px/char vs Chromium's ~9.6px). Register the same system
+    // fonts under the generic names so monospace text is actually fixed-width and
+    // matches the reference. First existing candidate wins; missing files are
+    // skipped so this is a no-op where the fonts are absent.
+    private static void EnsureGenericFontsLoaded()
+    {
+        if (_genericFontsLoaded)
+            return;
+        _genericFontsLoaded = true;
+
+        LoadFirstAvailableAs("monospace",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+            "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf");
+        LoadFirstAvailableAs("serif",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf",
+            "/usr/share/fonts/truetype/liberation/LiberationSerif-Regular.ttf");
+        LoadFirstAvailableAs("sans-serif",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf");
+    }
+
+    private static void LoadFirstAvailableAs(string cssName, params string[] candidatePaths)
+    {
+        foreach (var path in candidatePaths)
+        {
+            if (File.Exists(path))
+            {
+                HtmlRender.LoadFontFromFile(path, cssName);
+                return;
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

This PR implements CSS2.1 §17.4 table caption layout and fixes several related issues that prevented tables from rendering correctly when used as grid items or in quirks mode. The changes enable proper rendering of `<caption>` elements, fix table cell layout in grid contexts, and implement quirks-mode body/html fill-viewport behavior.

## Key Changes

### Table Caption Support
- **CssLayoutEngineTable.cs**: Collect `display:table-caption` boxes (previously dropped entirely) and lay them out as block boxes spanning the table's used width
  - Top-side captions (default `caption-side:top`) are positioned above the cell grid and push rows down by their height
  - Bottom-side captions (`caption-side:bottom`) are positioned below the grid
  - Both contribute to the table's final height
  - Captions are laid out with explicit width pinning to prevent shrinking to stale container widths

### Table Grid Item Fixes
- **CssLayoutEngine.cs**: Route `display:table` and `display:inline-table` boxes through the table formatting algorithm when laid out as atomic inline items (grid/flex children), instead of treating them as bare block containers
- **CssBox.cs**: Include `TableCaption` in the block-layout path so captions receive proper width/height resolution
- **CssBox.cs**: Add table grid item re-layout when stretched to a column width, since the table's cell grid was already shrink-wrapped and doesn't reflow from a bare Size change

### Quirks Mode Support
- **DocumentModeContext.cs** (new): Thread-local document-mode state mirroring the viewport-size pattern, allowing layout to consult quirks mode while sizing root/body boxes
- **CssBox.cs**: Implement quirks-mode body/html fill-viewport behavior per https://quirks.spec.whatwg.org/
  - Auto-height `<html>` fills the viewport minus its margins
  - Auto-height `<body>` (child of `<html>`) fills the html element's content box minus its own margins
  - Acts as a floor; content taller than the fill still overflows
- **DomBridge.cs**: Set `DocumentModeContext.CurrentQuirksMode` from doctype on parse; detect quirks mode from HTML (no doctype or non-`html` doctype name)

### Grid Layout Improvements
- **CssBoxGrid.cs**: Skip collapsible whitespace-only anonymous boxes when collecting grid items (CSS Grid §4), preventing phantom tracks from inter-item newlines/indentation
- **CssBoxGrid.cs**: Implement per-track row contributions for row-subgrids (CSS Grid L2 §7.3)
  - When a row-subgrid spans multiple parent auto rows, contribute each child's height to its respective row instead of lumping all height into one span and distributing equally
  - Fixes subgrid row sizing (e.g., 30/50/30 rows no longer collapse to 36.6/36.6/36.6)

### Window Load Event Fix
- **DomBridge.cs**: Check both `window.onload` and bare `onload` (global) when firing the load event, since bare assignments land on `globalThis` rather than `window` in this engine

### Test Infrastructure
- **WptTestRunner.cs**: Load generic fonts (monospace, serif, sans-serif) from system paths to match Chromium reference rendering, fixing text width mismatches in monospace content

## Tests Added

- `TableCaptionTests`: Verify top and bottom captions are laid out and contribute to table height
- `TableGridItemTests`: Verify tables as grid items run the table formatting algorithm and respect `min-height`
- `GridWhitespaceItemTests`: Verify whitespace between grid items doesn't create phantom tracks
- `SubgridRowContributionTests`: Verify row-subgrids size parent rows per-track, not averaged
- `QuirksBodyFillTests`: Verify quirks-mode detection from doctype

## Impact

These changes fix WPT test regressions:
- `css-grid/table-grid-item-dynamic-002`: Table grid items now render cell content (was 0×0)
- `

https://claude.ai/code/session_01U76vpGKwDAhc2qQtRSYAd9