### PR TITLE
Implement CSS Text 3 text-transform property

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -1004,6 +1004,11 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         bool preserveSpaces = WhiteSpace == CssConstants.Pre || WhiteSpace == CssConstants.PreWrap;
         bool respoctNewline = preserveSpaces || WhiteSpace == CssConstants.PreLine;
 
+        // CSS Text 3 §2.1: apply text-transform (case mapping / full-width /
+        // full-size-kana) as each word's text is materialized.  Null when the
+        // computed value produces no glyph change (none / math-auto / unset).
+        var transform = TextTransformer.For(TextTransform);
+
         textSpan = _text.Span;
         while (startIdx < textSpan.Length)
         {
@@ -1020,6 +1025,10 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
             if (endIdx > startIdx)
             {
+                // A collapsible/preserved white-space run is a word boundary for
+                // the `capitalize` transform regardless of whether it is emitted.
+                transform?.Break();
+
                 if (preserveSpaces)
                 {
                     // CSS2.1 §16.6: For pre-wrap, emit each space as a
@@ -1065,7 +1074,11 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                     var hasSpaceBefore = !preserveSpaces && startIdx > 0 && Words.Count == 0 && char.IsWhiteSpace(textSpan[startIdx - 1]);
                     var hasSpaceAfter = !preserveSpaces && endIdx < textSpan.Length && char.IsWhiteSpace(textSpan[endIdx]);
 
-                    Words.Add(new CssRectWord(this, WebUtility.HtmlDecode(_text.Slice(startIdx, endIdx - startIdx).ToString()), hasSpaceBefore, hasSpaceAfter));
+                    var wordText = WebUtility.HtmlDecode(_text.Slice(startIdx, endIdx - startIdx).ToString());
+                    if (transform != null)
+                        wordText = transform.Transform(wordText);
+
+                    Words.Add(new CssRectWord(this, wordText, hasSpaceBefore, hasSpaceAfter));
                 }
             }
 
@@ -1074,12 +1087,170 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             {
                 endIdx++;
 
+                // A forced line break is also a word boundary for `capitalize`.
+                transform?.Break();
+
                 if (respoctNewline)
                     Words.Add(new CssRectWord(this, "\n", false, false));
             }
 
             startIdx = endIdx;
         }
+    }
+
+    /// <summary>
+    /// Applies CSS Text 3 §2.1 <c>text-transform</c> to successive words of a box.
+    /// Case transforms (<c>uppercase</c>/<c>lowercase</c>/<c>capitalize</c>) and the
+    /// width transforms (<c>full-width</c>, <c>full-size-kana</c>) can combine. The
+    /// <c>capitalize</c> transform titlecases the first letter of each word, so the
+    /// instance carries the "at a word boundary" state across the box's words;
+    /// <see cref="Break"/> marks an intervening white-space run or forced break.
+    /// </summary>
+    private sealed class TextTransformer
+    {
+        private readonly bool _capitalize;
+        private readonly bool _upper;
+        private readonly bool _lower;
+        private readonly bool _fullWidth;
+        private readonly bool _fullSizeKana;
+        private bool _atWordStart = true;
+
+        private TextTransformer(bool capitalize, bool upper, bool lower, bool fullWidth, bool fullSizeKana)
+        {
+            _capitalize = capitalize;
+            _upper = upper;
+            _lower = lower;
+            _fullWidth = fullWidth;
+            _fullSizeKana = fullSizeKana;
+        }
+
+        /// <summary>
+        /// Builds a transformer for the computed <c>text-transform</c> value, or
+        /// returns <c>null</c> when no keyword changes glyphs (<c>none</c>,
+        /// <c>math-auto</c> — element-scoped MathML italicization not modelled here —
+        /// or the CSS-wide keywords).
+        /// </summary>
+        public static TextTransformer For(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return null;
+
+            bool capitalize = false, upper = false, lower = false, fullWidth = false, fullSizeKana = false;
+            foreach (var token in value.Split((char[])null, StringSplitOptions.RemoveEmptyEntries))
+            {
+                switch (token.ToLowerInvariant())
+                {
+                    case "capitalize": capitalize = true; break;
+                    case "uppercase": upper = true; break;
+                    case "lowercase": lower = true; break;
+                    case "full-width": fullWidth = true; break;
+                    case "full-size-kana": fullSizeKana = true; break;
+                    // none / math-auto / inherit / initial / unrecognized: no glyph change.
+                }
+            }
+
+            if (!capitalize && !upper && !lower && !fullWidth && !fullSizeKana)
+                return null;
+
+            return new TextTransformer(capitalize, upper, lower, fullWidth, fullSizeKana);
+        }
+
+        /// <summary>Marks a word boundary between two transformed words.</summary>
+        public void Break() => _atWordStart = true;
+
+        public string Transform(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return text;
+
+            // Case mapping first (uppercase/lowercase/capitalize are exclusive per
+            // spec; guard order here defensively). String-based Upper/Lower handles
+            // one-to-many mappings such as ß → SS.
+            string s = text;
+            if (_upper)
+                s = s.ToUpperInvariant();
+            else if (_lower)
+                s = s.ToLowerInvariant();
+            else if (_capitalize)
+                s = Capitalize(s);
+
+            if (_fullWidth || _fullSizeKana)
+                s = MapWidth(s);
+
+            return s;
+        }
+
+        private string Capitalize(string s)
+        {
+            var sb = new System.Text.StringBuilder(s.Length);
+            foreach (char c in s)
+            {
+                if (IsMidWord(c))
+                {
+                    // Apostrophes and combining marks stay inside the word (so
+                    // "can't" → "Can't", not "Can'T") without changing the state.
+                    sb.Append(c);
+                }
+                else if (char.IsLetterOrDigit(c))
+                {
+                    sb.Append(_atWordStart && char.IsLetter(c) ? char.ToUpperInvariant(c) : c);
+                    _atWordStart = false;
+                }
+                else
+                {
+                    // White space, hyphens and other punctuation start a new word.
+                    sb.Append(c);
+                    _atWordStart = true;
+                }
+            }
+            return sb.ToString();
+        }
+
+        private static bool IsMidWord(char c)
+        {
+            if (c == '\'' || c == '’')
+                return true;
+            var cat = System.Globalization.CharUnicodeInfo.GetUnicodeCategory(c);
+            return cat is System.Globalization.UnicodeCategory.NonSpacingMark
+                or System.Globalization.UnicodeCategory.SpacingCombiningMark
+                or System.Globalization.UnicodeCategory.EnclosingMark;
+        }
+
+        private string MapWidth(string s)
+        {
+            var sb = new System.Text.StringBuilder(s.Length);
+            foreach (char c in s)
+            {
+                char m = c;
+                if (_fullSizeKana)
+                    m = ToFullSizeKana(m);
+                if (_fullWidth)
+                    m = ToFullWidth(m);
+                sb.Append(m);
+            }
+            return sb.ToString();
+        }
+
+        // U+0021..U+007E → the fullwidth forms U+FF01..U+FF5E. The ASCII space is
+        // left as U+0020 so white-space processing is unaffected.
+        private static char ToFullWidth(char c)
+            => c >= '!' && c <= '~' ? (char)(c - 0x0021 + 0xFF01) : c;
+
+        // Small (sutegana) kana → their full-size equivalents (CSS Text 3 §2.1.1).
+        private static char ToFullSizeKana(char c) => c switch
+        {
+            // Hiragana
+            'ぁ' => 'あ', 'ぃ' => 'い', 'ぅ' => 'う',
+            'ぇ' => 'え', 'ぉ' => 'お', 'っ' => 'つ',
+            'ゃ' => 'や', 'ゅ' => 'ゆ', 'ょ' => 'よ',
+            'ゎ' => 'わ', 'ゕ' => 'か', 'ゖ' => 'け',
+            // Katakana
+            'ァ' => 'ア', 'ィ' => 'イ', 'ゥ' => 'ウ',
+            'ェ' => 'エ', 'ォ' => 'オ', 'ッ' => 'ツ',
+            'ャ' => 'ヤ', 'ュ' => 'ユ', 'ョ' => 'ヨ',
+            'ヮ' => 'ワ', 'ヵ' => 'カ', 'ヶ' => 'ケ',
+            _ => c,
+        };
     }
 
     public virtual void Dispose()

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -593,6 +593,14 @@ internal abstract class CssBoxProperties
         }
     }
     public string WhiteSpace { get; set; } = "normal";
+
+    /// <summary>
+    /// CSS Text 3 §2.1 <c>text-transform</c>. An inherited property applied to a
+    /// box's text when its words are parsed (see <see cref="CssBox.ParseToWords"/>).
+    /// The default <c>none</c> leaves text unchanged.
+    /// </summary>
+    public string TextTransform { get; set; } = "none";
+
     public string Visibility { get; set; } = "visible";
 
     public string WordSpacing
@@ -1768,6 +1776,7 @@ internal abstract class CssBoxProperties
         EmptyCells = p.EmptyCells;
         CaptionSide = p.CaptionSide;
         WhiteSpace = p.WhiteSpace;
+        TextTransform = p.TextTransform;
         Visibility = p.Visibility;
         _textIndent = p._textIndent;
         TextAlign = p.TextAlign;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -595,6 +595,9 @@ internal static class CssUtils
             case "white-space":
                 cssBox.WhiteSpace = value;
                 break;
+            case "text-transform":
+                cssBox.TextTransform = value;
+                break;
             case "word-break":
                 cssBox.WordBreak = value;
                 break;

--- a/patches/0006-css-text-transform-grammar.patch
+++ b/patches/0006-css-text-transform-grammar.patch
@@ -1,0 +1,170 @@
+From 7a0e00656dc99ab9d3409514f60695ff6cd9e4b9 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Tue, 7 Jul 2026 06:10:37 +0000
+Subject: [PATCH] Accept the full CSS Text 3 text-transform grammar in the
+ value validator
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+text-transform is none | [ [capitalize | uppercase | lowercase] || full-width
+|| full-size-kana ] | math-auto. The validator previously accepted only the
+single keywords none/capitalize/uppercase/lowercase/full-width, so it dropped
+valid combinations (e.g. "capitalize full-width") and the standalone
+full-size-kana / math-auto values as invalid — discarding the whole declaration
+and falling back to a stale cascade value. Validate the real grammar instead.
+---
+ Broiler.CSS.Dom/CssStyleEngine.Values.cs | 116 +++++++++++++++--------
+ 1 file changed, 77 insertions(+), 39 deletions(-)
+
+diff --git a/Broiler.CSS.Dom/CssStyleEngine.Values.cs b/Broiler.CSS.Dom/CssStyleEngine.Values.cs
+index 900fbab..649bbf5 100644
+--- a/Broiler.CSS.Dom/CssStyleEngine.Values.cs
++++ b/Broiler.CSS.Dom/CssStyleEngine.Values.cs
+@@ -307,7 +307,7 @@ public sealed partial class CssStyleEngine
+                     or "pre-line" or "break-spaces";
+ 
+             case "display":
+-                if (v is "block" or "inline" or "inline-block" or "none"
++                if (v is "block" or "inline" or "inline-block" or "none"
+                     or "flex" or "inline-flex" or "grid" or "inline-grid"
+                     or "table" or "inline-table" or "table-row" or "table-cell"
+                     or "table-column" or "table-row-group" or "table-header-group"
+@@ -320,21 +320,21 @@ public sealed partial class CssStyleEngine
+                     // valid declaration and falling back to a stale cascade value.
+                     or "ruby" or "ruby-base" or "ruby-text"
+                     or "ruby-base-container" or "ruby-text-container"
+-                    or "math")
+-                    return true;
+-                // The experimental CSS Grid Level 3 <display-inside> keyword
+-                // grid-lanes is intentionally NOT accepted: no stable browser
+-                // ships it unflagged, so treating display:grid-lanes (or the
+-                // two-value inline grid-lanes) as invalid — dropping the
+-                // declaration so the element keeps its default display — matches
+-                // reference browsers. Accepting it and mapping it to a grid
+-                // formatting context instead diverged from every reference on the
+-                // css-grid/grid-lanes WPT suite.
+-                // CSS Display 3 two-value syntax: <display-outside> <display-inside>
+-                // (e.g. "inline grid", "block flow-root"). Accept a valid pair in
+-                // either order so the layout engine can normalize it to a legacy
+-                // single keyword.
+-                return IsTwoValueDisplay(v);
++                    or "math")
++                    return true;
++                // The experimental CSS Grid Level 3 <display-inside> keyword
++                // grid-lanes is intentionally NOT accepted: no stable browser
++                // ships it unflagged, so treating display:grid-lanes (or the
++                // two-value inline grid-lanes) as invalid — dropping the
++                // declaration so the element keeps its default display — matches
++                // reference browsers. Accepting it and mapping it to a grid
++                // formatting context instead diverged from every reference on the
++                // css-grid/grid-lanes WPT suite.
++                // CSS Display 3 two-value syntax: <display-outside> <display-inside>
++                // (e.g. "inline grid", "block flow-root"). Accept a valid pair in
++                // either order so the layout engine can normalize it to a legacy
++                // single keyword.
++                return IsTwoValueDisplay(v);
+ 
+             case "position":
+                 return v is "static" or "relative" or "absolute" or "fixed" or "sticky";
+@@ -373,7 +373,7 @@ public sealed partial class CssStyleEngine
+                 return v is "solid" or "double" or "dotted" or "dashed" or "wavy";
+ 
+             case "text-transform":
+-                return v is "none" or "capitalize" or "uppercase" or "lowercase" or "full-width";
++                return IsTextTransformValue(v);
+ 
+             case "vertical-align":
+                 return v is "baseline" or "sub" or "super" or "text-top"
+@@ -440,28 +440,66 @@ public sealed partial class CssStyleEngine
+         }
+     }
+ 
+-    /// <summary>
+-    /// CSS Display 3 §2.1: validate the two-value <c>display</c> syntax
+-    /// (<c>&lt;display-outside&gt; &amp;&amp; &lt;display-inside&gt;</c>), e.g.
+-    /// <c>inline grid</c> or <c>block flow-root</c>. The two keywords may appear
+-    /// in either order. The experimental <c>grid-lanes</c> &lt;display-inside&gt;
+-    /// is deliberately excluded so <c>inline grid-lanes</c> is rejected as invalid
+-    /// (matching reference browsers, which do not ship grid-lanes unflagged).
+-    /// </summary>
+-    private static bool IsTwoValueDisplay(string value)
+-    {
+-        var parts = value.Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
+-        if (parts.Length != 2)
+-            return false;
+-
+-        static bool IsOutside(string k) => k is "block" or "inline" or "run-in";
+-        static bool IsInside(string k) => k is "flow" or "flow-root" or "table"
+-            or "flex" or "grid" or "ruby";
+-
+-        return (IsOutside(parts[0]) && IsInside(parts[1]))
+-            || (IsInside(parts[0]) && IsOutside(parts[1]));
+-    }
+-
++    /// <summary>
++    /// CSS Display 3 §2.1: validate the two-value <c>display</c> syntax
++    /// (<c>&lt;display-outside&gt; &amp;&amp; &lt;display-inside&gt;</c>), e.g.
++    /// <c>inline grid</c> or <c>block flow-root</c>. The two keywords may appear
++    /// in either order. The experimental <c>grid-lanes</c> &lt;display-inside&gt;
++    /// is deliberately excluded so <c>inline grid-lanes</c> is rejected as invalid
++    /// (matching reference browsers, which do not ship grid-lanes unflagged).
++    /// </summary>
++    private static bool IsTwoValueDisplay(string value)
++    {
++        var parts = value.Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
++        if (parts.Length != 2)
++            return false;
++
++        static bool IsOutside(string k) => k is "block" or "inline" or "run-in";
++        static bool IsInside(string k) => k is "flow" or "flow-root" or "table"
++            or "flex" or "grid" or "ruby";
++
++        return (IsOutside(parts[0]) && IsInside(parts[1]))
++            || (IsInside(parts[0]) && IsOutside(parts[1]));
++    }
++
++    // CSS Text 3 §2.1: none | [ [capitalize | uppercase | lowercase] || full-width
++    // || full-size-kana ] | math-auto. The case keywords are mutually exclusive; a
++    // valid multi-token value combines at most one case keyword with full-width
++    // and/or full-size-kana (in any order), each at most once. Accepting the full
++    // grammar keeps combinations like "capitalize full-width" and the standalone
++    // "full-size-kana"/"math-auto" from being dropped as invalid.
++    private static bool IsTextTransformValue(string value)
++    {
++        if (value is "none" or "math-auto")
++            return true;
++
++        bool caseSeen = false, fullWidth = false, fullSizeKana = false;
++        foreach (var token in value.Split(' ', System.StringSplitOptions.RemoveEmptyEntries))
++        {
++            switch (token)
++            {
++                case "capitalize":
++                case "uppercase":
++                case "lowercase":
++                    if (caseSeen) return false;
++                    caseSeen = true;
++                    break;
++                case "full-width":
++                    if (fullWidth) return false;
++                    fullWidth = true;
++                    break;
++                case "full-size-kana":
++                    if (fullSizeKana) return false;
++                    fullSizeKana = true;
++                    break;
++                default:
++                    return false;
++            }
++        }
++
++        return caseSeen || fullWidth || fullSizeKana;
++    }
++
+     private static bool IsBorderStyleList(string value)
+     {
+         var parts = SplitCssValues(value);
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -44,6 +44,29 @@ cd .. && git add <Submodule> && git commit -m "Bump <Submodule>: <summary>"
   caught-and-logged behaviour (correction abandoned for the affected box) until a
   maintainer applies this patch and bumps the pointer; nothing crashes the run.
 
+- **0006-css-text-transform-grammar.patch** → `Broiler.CSS`
+  (`Broiler.CSS.Dom/CssStyleEngine.Values.cs`) — makes `IsAcceptableDeclarationValue`
+  validate the **full** CSS Text 3 §2.1 `text-transform` grammar
+  (`none | [ [capitalize | uppercase | lowercase] || full-width || full-size-kana ]
+  | math-auto`) via a new `IsTextTransformValue` helper. The validator previously
+  accepted only the single keywords `none`/`capitalize`/`uppercase`/`lowercase`/
+  `full-width`, so it dropped valid **combinations** (`capitalize full-width`,
+  `full-width full-size-kana lowercase`) and the standalone `full-size-kana`
+  (1295 drops in issue #1270) / `math-auto` (235) values as invalid — discarding
+  the whole declaration and falling back to a stale cascade value.
+  **Active CI fallback for the primary win — none needed.** The single-keyword
+  values (`uppercase`/`lowercase`/`capitalize`/`full-width`) are **already** accepted
+  by the pinned validator, and the new main-repo `Broiler.Layout` implementation
+  (`CssBox.ParseToWords` → `TextTransformer`, guarded by `TextTransformTests`) applies
+  them on CI **now** — that covers the `text-transform-upperlower-*` and
+  `text-transform-capitalize-*` families directly. Only the multi-keyword
+  combinations and the standalone `full-size-kana`/`math-auto` remain dropped until
+  a maintainer applies this patch and bumps the pointer; the `TextTransformer` already
+  implements those transforms, so they light up as soon as the value stops being
+  dropped. The companion CSSOM-side validator (main-repo
+  `DomBridge.IsAcceptableCssValue`) was updated in the same commit, so JS-set
+  `element.style.textTransform` accepts the full grammar on CI regardless.
+
 ## Applied / obsolete
 
 - **0004-css-expand-margin-padding-shorthand-cascade.patch** → `Broiler.CSS`

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -928,7 +928,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
                 return v is "solid" or "double" or "dotted" or "dashed" or "wavy";
 
             case "text-transform":
-                return v is "none" or "capitalize" or "uppercase" or "lowercase" or "full-width";
+                return IsTextTransformValue(v);
 
             case "vertical-align":
                 // Also accepts lengths/percentages, which won't match these keywords
@@ -999,6 +999,42 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     }
 
     /// <summary>Checks whether <paramref name="v"/> looks like a CSS length or percentage.</summary>
+    // CSS Text 3 §2.1: none | [ [capitalize | uppercase | lowercase] || full-width
+    // || full-size-kana ] | math-auto. The case keywords are mutually exclusive; a
+    // valid multi-token value combines at most one case keyword with full-width
+    // and/or full-size-kana (in any order), each at most once.
+    private static bool IsTextTransformValue(string v)
+    {
+        if (v is "none" or "math-auto")
+            return true;
+
+        bool caseSeen = false, fullWidth = false, fullSizeKana = false;
+        foreach (var token in v.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            switch (token)
+            {
+                case "capitalize":
+                case "uppercase":
+                case "lowercase":
+                    if (caseSeen) return false;
+                    caseSeen = true;
+                    break;
+                case "full-width":
+                    if (fullWidth) return false;
+                    fullWidth = true;
+                    break;
+                case "full-size-kana":
+                    if (fullSizeKana) return false;
+                    fullSizeKana = true;
+                    break;
+                default:
+                    return false;
+            }
+        }
+
+        return caseSeen || fullWidth || fullSizeKana;
+    }
+
     private static bool IsLengthOrPercentage(string v)
     {
         if (v == "0") return true;

--- a/src/Broiler.Wpt.Tests/TextTransformTests.cs
+++ b/src/Broiler.Wpt.Tests/TextTransformTests.cs
@@ -1,0 +1,124 @@
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression tests for the CSS Text 3 §2.1 <c>text-transform</c> implementation
+/// in <c>CssBox.ParseToWords</c> (main-repo <c>Broiler.Layout</c>).
+///
+/// The computed value already reached each box (the CSS value validator accepts
+/// <c>uppercase</c>/<c>lowercase</c>/<c>capitalize</c>/<c>full-width</c>), but the
+/// layout engine never applied it, so the whole <c>css-text/text-transform</c>
+/// suite rendered untransformed glyphs. These tests pin the transform by rendering
+/// transformed text and asserting it is pixel-identical to the same text authored
+/// in the target case — a font-independent oracle that fails without the fix
+/// (untransformed text does not match the pre-cased reference).
+/// </summary>
+public class TextTransformTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public TextTransformTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "broiler-text-transform-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        Program.ResetTestHooks();
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private BBitmap Render(string transform, string text)
+    {
+        var html = $@"<!DOCTYPE html>
+<style>
+  body {{ margin: 0; font: 20px monospace; color: black; }}
+  #t {{ text-transform: {transform}; }}
+</style>
+<body><div id='t'>{text}</div></body>";
+        var file = Path.Combine(_tempDir, $"tt-{Guid.NewGuid().ToString("N")[..8]}.html");
+        File.WriteAllText(file, html);
+        var runner = new WptTestRunner(400, 80);
+        return runner.RenderHtmlFileBitmapPublic(file, _tempDir);
+    }
+
+    // Number of "inked" (non-near-white) pixels — a cheap glyph presence measure.
+    private static int InkCount(BBitmap bmp)
+    {
+        int n = 0;
+        for (int y = 0; y < bmp.Height; y++)
+        for (int x = 0; x < bmp.Width; x++)
+        {
+            var p = bmp.GetPixel(x, y);
+            if (p.R < 200 || p.G < 200 || p.B < 200)
+                n++;
+        }
+        return n;
+    }
+
+    private static bool PixelIdentical(BBitmap a, BBitmap b)
+    {
+        if (a.Width != b.Width || a.Height != b.Height)
+            return false;
+        for (int y = 0; y < a.Height; y++)
+        for (int x = 0; x < a.Width; x++)
+        {
+            var pa = a.GetPixel(x, y);
+            var pb = b.GetPixel(x, y);
+            if (pa.R != pb.R || pa.G != pb.G || pa.B != pb.B || pa.A != pb.A)
+                return false;
+        }
+        return true;
+    }
+
+    private void AssertTransformMatchesLiteral(string transform, string source, string expected)
+    {
+        using var transformed = Render(transform, source);
+        using var literal = Render("none", expected);
+
+        Assert.True(InkCount(literal) > 0, "reference text painted nothing.");
+        Assert.True(
+            PixelIdentical(transformed, literal),
+            $"text-transform:{transform} of \"{source}\" did not render identically to \"{expected}\".");
+    }
+
+    [Fact]
+    public void Uppercase_RendersAsUppercasedText()
+        => AssertTransformMatchesLiteral("uppercase", "hello world", "HELLO WORLD");
+
+    [Fact]
+    public void Lowercase_RendersAsLowercasedText()
+        => AssertTransformMatchesLiteral("lowercase", "HELLO WORLD", "hello world");
+
+    [Fact]
+    public void Capitalize_TitlecasesEachWord()
+        => AssertTransformMatchesLiteral("capitalize", "hello world", "Hello World");
+
+    [Fact]
+    public void Capitalize_KeepsApostropheInsideWord()
+        => AssertTransformMatchesLiteral("capitalize", "can't stop", "Can't Stop");
+
+    [Fact]
+    public void Capitalize_TreatsHyphenAsWordBoundary()
+        => AssertTransformMatchesLiteral("capitalize", "well-being", "Well-Being");
+
+    [Fact]
+    public void None_LeavesTextUnchanged()
+        => AssertTransformMatchesLiteral("none", "Mixed Case", "Mixed Case");
+
+    [Fact]
+    public void Uppercase_ChangesRenderingFromSource()
+    {
+        // Guards the oracle itself: transformed output must differ from the
+        // untransformed source (otherwise the identity test above is vacuous).
+        using var transformed = Render("uppercase", "hello world");
+        using var untransformed = Render("none", "hello world");
+        Assert.False(
+            PixelIdentical(transformed, untransformed),
+            "text-transform:uppercase did not change the rendering.");
+    }
+}


### PR DESCRIPTION
## Summary

Implements the CSS Text 3 §2.1 `text-transform` property in the layout engine, applying case mapping (`uppercase`, `lowercase`, `capitalize`) and width transforms (`full-width`, `full-size-kana`) to text as words are parsed. Also updates CSS value validators to accept the full grammar (combinations like `capitalize full-width` and standalone `full-size-kana`/`math-auto`).

## Changes

### Main repo (`Broiler.Layout`)

- **`CssBox.ParseToWords`**: Added `TextTransformer` helper class that applies text-transform to each word as it is materialized. The transformer:
  - Handles case mapping (uppercase/lowercase/capitalize are mutually exclusive per spec)
  - Implements width transforms (full-width ASCII → fullwidth forms; full-size-kana small kana → full-size equivalents)
  - Tracks word boundaries for `capitalize` (titlecases first letter of each word; apostrophes and combining marks stay inside words; hyphens and punctuation start new words)
  - Calls `Break()` at whitespace runs and forced line breaks to reset word-start state
  
- **`CssBoxProperties`**: Added `TextTransform` property (inherited, default `"none"`) and wired it into property inheritance and CSS value setting.

- **`CssUtils.SetPropertyValue`**: Added case for `"text-transform"` to apply parsed values to boxes.

- **`TextTransformTests`**: New regression test suite (7 tests) that renders transformed text and asserts pixel-identity with pre-cased reference text — a font-independent oracle that fails without the fix.

### Submodule patches

- **`0006-css-text-transform-grammar.patch`** → `Broiler.CSS` (`CssStyleEngine.Values.cs`):
  - Replaces single-keyword validation with `IsTextTransformValue` helper that accepts the full grammar: `none | [ [capitalize | uppercase | lowercase] || full-width || full-size-kana ] | math-auto`
  - Enforces mutual exclusivity of case keywords and prevents duplicate width keywords
  - Fixes 1295 drops of `full-size-kana` and 235 drops of `math-auto` (issue #1270)

- **Main repo fallback** (`DomBridge.IsAcceptableCssValue`): Identical `IsTextTransformValue` implementation so JS-set `element.style.textTransform` accepts the full grammar on CI regardless of patch status.

## Implementation notes

- The `TextTransformer` is instantiated once per box during `ParseToWords` and reused across all words, carrying `_atWordStart` state across word boundaries.
- Case mapping uses `ToUpperInvariant`/`ToLowerInvariant` to handle one-to-many mappings (e.g. ß → SS).
- Width transforms are applied after case mapping (per spec order).
- Full-size kana mappings cover both hiragana and katakana small forms per CSS Text 3 §2.1.1.
- The single-keyword values (`uppercase`/`lowercase`/`capitalize`/`full-width`) are already accepted by the pinned validator, so the main-repo implementation lights up on CI now. Multi-keyword combinations and standalone `full-size-kana`/`math-auto` remain dropped until the patch is applied and the pointer bumped.

https://claude.ai/code/session_017YgPBjXkywJJpCmKqpeYQ7