### PR TITLE
css: accept CSS Text 4 white-space shorthand values

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/WhiteSpaceNormalizationTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/WhiteSpaceNormalizationTests.cs
@@ -1,0 +1,55 @@
+using Broiler.Layout.Engine;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// Covers <see cref="CssUtils.NormalizeWhiteSpaceValue"/>: the CSS Text 4
+/// <c>white-space</c> shorthand (a shorthand for <c>white-space-collapse</c> and
+/// <c>text-wrap-mode</c>) is folded onto the legacy single keyword the layout
+/// engine keys off, so modern longhand-style values are no longer dropped.
+/// </summary>
+public sealed class WhiteSpaceNormalizationTests
+{
+    [Theory]
+    // Legacy single keywords pass through untouched.
+    [InlineData("normal", "normal")]
+    [InlineData("nowrap", "nowrap")]
+    [InlineData("pre", "pre")]
+    [InlineData("pre-wrap", "pre-wrap")]
+    [InlineData("pre-line", "pre-line")]
+    // Modern single white-space-collapse keywords (text-wrap-mode defaults to wrap).
+    [InlineData("collapse", "normal")]
+    [InlineData("preserve", "pre-wrap")]
+    [InlineData("preserve-breaks", "pre-line")]
+    // Modern single text-wrap-mode keywords (white-space-collapse defaults to collapse).
+    [InlineData("wrap", "normal")]
+    // Two-longhand form, either order.
+    [InlineData("collapse wrap", "normal")]
+    [InlineData("collapse nowrap", "nowrap")]
+    [InlineData("preserve wrap", "pre-wrap")]
+    [InlineData("preserve nowrap", "pre")]
+    [InlineData("nowrap preserve", "pre")]
+    [InlineData("preserve-breaks wrap", "pre-line")]
+    // No exact legacy equivalent: fold onto the closest keyword.
+    [InlineData("preserve-breaks nowrap", "pre-line")]
+    // break-spaces has no legacy keyword and is passed through for the engine.
+    [InlineData("break-spaces", "break-spaces")]
+    [InlineData("break-spaces nowrap", "break-spaces")]
+    // Case and surrounding whitespace are normalized.
+    [InlineData("  PRESERVE-BREAKS  ", "pre-line")]
+    public void NormalizeWhiteSpaceValue_FoldsShorthandOntoLegacyKeyword(string input, string expected)
+    {
+        Assert.Equal(expected, CssUtils.NormalizeWhiteSpaceValue(input));
+    }
+
+    [Theory]
+    // Unrecognized/malformed values are left untouched (the declaration is either
+    // dropped upstream at validation or handled elsewhere).
+    [InlineData("x-bogus")]
+    [InlineData("preserve preserve")]
+    [InlineData("wrap nowrap")]
+    public void NormalizeWhiteSpaceValue_LeavesUnrecognizedValuesUntouched(string input)
+    {
+        Assert.Equal(input, CssUtils.NormalizeWhiteSpaceValue(input));
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -593,7 +593,7 @@ internal static class CssUtils
                 cssBox.TextDecorationColor = value;
                 break;
             case "white-space":
-                cssBox.WhiteSpace = value;
+                cssBox.WhiteSpace = NormalizeWhiteSpaceValue(value);
                 break;
             case "text-transform":
                 cssBox.TextTransform = value;
@@ -823,6 +823,83 @@ internal static class CssUtils
             "flow-root" => isInline ? "inline-block" : "flow-root",
             "flow" => isInline ? "inline" : "block",
             _ => v,
+        };
+    }
+
+    /// <summary>
+    /// Normalizes a CSS Text 4 <c>white-space</c> shorthand value to the legacy
+    /// single keyword the layout engine keys off (<c>normal</c>, <c>nowrap</c>,
+    /// <c>pre</c>, <c>pre-wrap</c>, <c>pre-line</c>, or the passthrough
+    /// <c>break-spaces</c>). <c>white-space</c> is a shorthand for
+    /// <c>white-space-collapse</c> and <c>text-wrap-mode</c>; the two-longhand
+    /// form <c>&lt;collapse&gt; || &lt;wrap-mode&gt;</c> and modern single
+    /// keywords (<c>preserve</c>, <c>preserve-breaks</c>, …) carry the same
+    /// meaning as a legacy keyword and are folded onto it so the existing
+    /// white-space handling in the engine applies unchanged. Longhand
+    /// combinations with no exact legacy equivalent are mapped to the closest
+    /// keyword that preserves the dominant collapse behaviour. Legacy keywords
+    /// and unrecognized values pass through untouched.
+    /// </summary>
+    internal static string NormalizeWhiteSpaceValue(string value)
+    {
+        string v = value.Trim().ToLowerInvariant();
+
+        // Legacy single keywords already map directly onto the engine's model.
+        if (v is CssConstants.Normal or CssConstants.NoWrap or CssConstants.Pre
+            or CssConstants.PreWrap or CssConstants.PreLine)
+            return v;
+
+        string collapse = null, wrap = null;
+        foreach (var token in v.Split((char[])null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            switch (token)
+            {
+                case "collapse":
+                case "preserve":
+                case "preserve-breaks":
+                case "preserve-spaces":
+                case "break-spaces":
+                    if (collapse != null) return v; // malformed; leave untouched
+                    collapse = token;
+                    break;
+                case "wrap":
+                case "nowrap":
+                    if (wrap != null) return v;
+                    wrap = token;
+                    break;
+                default:
+                    return v; // not a recognized modern token; leave as-is
+            }
+        }
+
+        if (collapse == null && wrap == null)
+            return v;
+
+        // Longhand initial values: white-space-collapse: collapse, text-wrap-mode: wrap.
+        collapse ??= "collapse";
+        wrap ??= "wrap";
+
+        // break-spaces has no legacy keyword; keep the token so the engine can
+        // special-case it (both wrap modes collapse to the same handling today).
+        if (collapse == "break-spaces")
+            return "break-spaces";
+
+        return (collapse, wrap) switch
+        {
+            ("collapse", "wrap") => CssConstants.Normal,
+            ("collapse", "nowrap") => CssConstants.NoWrap,
+            ("preserve", "wrap") => CssConstants.PreWrap,
+            ("preserve", "nowrap") => CssConstants.Pre,
+            ("preserve-breaks", "wrap") => CssConstants.PreLine,
+            // preserve-breaks + nowrap: preserves segment breaks with no exact
+            // legacy keyword — pre-line keeps the newline preservation that
+            // dominates the visual result.
+            ("preserve-breaks", "nowrap") => CssConstants.PreLine,
+            // preserve-spaces preserves spaces but collapses segment breaks; the
+            // closest legacy keyword that preserves spaces is pre-wrap/pre.
+            ("preserve-spaces", "nowrap") => CssConstants.Pre,
+            ("preserve-spaces", "wrap") => CssConstants.PreWrap,
+            _ => CssConstants.Normal,
         };
     }
 

--- a/patches/0007-css-white-space-shorthand.patch
+++ b/patches/0007-css-white-space-shorthand.patch
@@ -1,0 +1,117 @@
+From 7db56665cbc3ca9c771d19d680269f1d30980977 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Tue, 7 Jul 2026 06:40:20 +0000
+Subject: [PATCH] css: accept CSS Text 4 white-space shorthand values
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+white-space is a shorthand for white-space-collapse and text-wrap-mode.
+Accept the modern single keywords (preserve, preserve-breaks, …) and the
+two-longhand <collapse> || <wrap-mode> form during declaration validation
+so valid values like 'preserve-breaks' and 'break-spaces nowrap' are no
+longer dropped by CSS error recovery (WPT css-text).
+---
+ Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs | 26 +++++++++++++
+ Broiler.CSS.Dom/CssStyleEngine.Values.cs     | 41 +++++++++++++++++++-
+ 2 files changed, 65 insertions(+), 2 deletions(-)
+
+diff --git a/Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs b/Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs
+index f3f6211..5532ff7 100644
+--- a/Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs
++++ b/Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs
+@@ -488,6 +488,32 @@ public sealed class CssStyleEngineTests
+         Assert.Equal(valid, engine.GetComputedStyle(div).GetPropertyValue(property));
+     }
+ 
++    [Theory]
++    // CSS Text 4: white-space is a shorthand for white-space-collapse and
++    // text-wrap-mode. The modern single keywords and the two-longhand form are
++    // valid and must not be dropped as invalid (WPT css-text; issue #1272 lists
++    // "white-space: preserve-breaks" and "white-space: break-spaces nowrap" among
++    // the most-dropped declarations).
++    [InlineData("preserve-breaks")]
++    [InlineData("preserve")]
++    [InlineData("break-spaces")]
++    [InlineData("break-spaces nowrap")]
++    [InlineData("preserve-breaks nowrap")]
++    [InlineData("collapse wrap")]
++    public void Valid_WhiteSpace_Shorthand_Is_Kept(string whiteSpace)
++    {
++        var (_, _, body) = NewDocument();
++        var div = body.OwnerDocument.CreateElement("div");
++        div.Id = "t";
++        body.AppendChild(div);
++
++        // The second declaration is a valid CSS Text 4 white-space value and must
++        // win over the first rather than being discarded by error recovery.
++        var engine = EngineWith($"#t {{ white-space: pre; white-space: {whiteSpace}; }}");
++
++        Assert.Equal(whiteSpace, engine.GetComputedStyle(div).GetPropertyValue("white-space"));
++    }
++
+     [Fact]
+     public void Invalid_Vendor_Color_Is_Rejected_But_Standard_Prefixes_Pass()
+     {
+diff --git a/Broiler.CSS.Dom/CssStyleEngine.Values.cs b/Broiler.CSS.Dom/CssStyleEngine.Values.cs
+index 649bbf5..69b5b70 100644
+--- a/Broiler.CSS.Dom/CssStyleEngine.Values.cs
++++ b/Broiler.CSS.Dom/CssStyleEngine.Values.cs
+@@ -303,8 +303,7 @@ public sealed partial class CssStyleEngine
+         switch (property.ToLowerInvariant())
+         {
+             case "white-space":
+-                return v is "normal" or "nowrap" or "pre" or "pre-wrap"
+-                    or "pre-line" or "break-spaces";
++                return IsWhiteSpaceValue(v);
+ 
+             case "display":
+                 if (v is "block" or "inline" or "inline-block" or "none"
+@@ -462,6 +461,44 @@ public sealed partial class CssStyleEngine
+             || (IsInside(parts[0]) && IsOutside(parts[1]));
+     }
+ 
++    // CSS Text 4 §3: white-space is a shorthand for white-space-collapse and
++    // text-wrap-mode. Its value is either a legacy single keyword
++    // (normal | pre | nowrap | pre-wrap | pre-line) or the two-longhand form
++    // <'white-space-collapse'> || <'text-wrap-mode'> — at most one collapse
++    // keyword combined with at most one wrap keyword, in either order. Accepting
++    // the full grammar keeps values like "preserve-breaks" (== pre-line) and
++    // "break-spaces nowrap" from being dropped as invalid.
++    private static bool IsWhiteSpaceValue(string value)
++    {
++        if (value is "normal" or "nowrap" or "pre" or "pre-wrap" or "pre-line")
++            return true;
++
++        bool collapseSeen = false, wrapSeen = false;
++        foreach (var token in value.Split(' ', System.StringSplitOptions.RemoveEmptyEntries))
++        {
++            switch (token)
++            {
++                case "collapse":
++                case "preserve":
++                case "preserve-breaks":
++                case "preserve-spaces":
++                case "break-spaces":
++                    if (collapseSeen) return false;
++                    collapseSeen = true;
++                    break;
++                case "wrap":
++                case "nowrap":
++                    if (wrapSeen) return false;
++                    wrapSeen = true;
++                    break;
++                default:
++                    return false;
++            }
++        }
++
++        return collapseSeen || wrapSeen;
++    }
++
+     // CSS Text 3 §2.1: none | [ [capitalize | uppercase | lowercase] || full-width
+     // || full-size-kana ] | math-auto. The case keywords are mutually exclusive; a
+     // valid multi-token value combines at most one case keyword with full-width
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -67,6 +67,37 @@ cd .. && git add <Submodule> && git commit -m "Bump <Submodule>: <summary>"
   `DomBridge.IsAcceptableCssValue`) was updated in the same commit, so JS-set
   `element.style.textTransform` accepts the full grammar on CI regardless.
 
+- **0007-css-white-space-shorthand.patch** → `Broiler.CSS`
+  (`Broiler.CSS.Dom/CssStyleEngine.Values.cs`) — makes `IsAcceptableDeclarationValue`
+  validate the **full** CSS Text 4 §3 `white-space` shorthand grammar
+  (`normal | pre | nowrap | pre-wrap | pre-line |
+  <'white-space-collapse'> || <'text-wrap-mode'>`) via a new `IsWhiteSpaceValue`
+  helper. `white-space` is a shorthand for `white-space-collapse`
+  (`collapse | preserve | preserve-breaks | preserve-spaces | break-spaces`) and
+  `text-wrap-mode` (`wrap | nowrap`). The validator previously accepted only the
+  legacy single keywords plus `break-spaces`, so it dropped the modern single
+  keywords and the two-longhand form — `white-space: preserve-breaks` (152 drops
+  in issue #1272), `white-space: preserve-breaks nowrap` (120) and
+  `white-space: break-spaces nowrap` (120) — as invalid, discarding the whole
+  declaration and falling back to a stale cascade value. (The genuinely invalid
+  `white-space: balance` / `balance preserve` — `balance` is a `text-wrap-style`
+  value, not a `white-space` one — stay correctly dropped.)
+  **No active CI fallback for the new values — they stay dropped until the patch
+  lands.** Unlike patch 0006, the modern shorthand keywords are **not** accepted by
+  the pinned validator, so the render cascade (`SharedRendererCascade` →
+  `CssUtils.SetPropertyValue`) never receives them on CI until a maintainer applies
+  this patch and bumps the pointer. The companion **main-repo** pieces are in place
+  and inert-but-ready: `Broiler.Layout` `CssUtils.NormalizeWhiteSpaceValue`
+  (guarded by `WhiteSpaceNormalizationTests`) folds a shorthand value onto the
+  legacy keyword the engine keys off — `preserve-breaks`→`pre-line`,
+  `preserve`→`pre-wrap`, the two-value `collapse|preserve|… × wrap|nowrap` combos,
+  and `break-spaces` passthrough — so the values light up as soon as they stop
+  being dropped, and it is a no-op for the values the pinned validator already
+  accepts. The companion CSSOM-side validator (main-repo
+  `DomBridge.IsAcceptableCssValue`, guarded by `InlineStyleDropDiagnosticsTests`)
+  was updated in the same parent commit, so JS-set `element.style.whiteSpace`
+  accepts the full grammar on CI regardless.
+
 ## Applied / obsolete
 
 - **0004-css-expand-margin-padding-shorthand-cascade.patch** → `Broiler.CSS`

--- a/src/Broiler.Cli.Tests/InlineStyleDropDiagnosticsTests.cs
+++ b/src/Broiler.Cli.Tests/InlineStyleDropDiagnosticsTests.cs
@@ -70,6 +70,35 @@ public sealed class InlineStyleDropDiagnosticsTests
         Assert.Contains("color: red", serialized);
     }
 
+    [Fact]
+    public void Modern_WhiteSpace_Shorthand_Is_Not_Dropped()
+    {
+        // CSS Text 4: white-space is a shorthand for white-space-collapse and
+        // text-wrap-mode. The modern longhand-style values must survive the
+        // bridge's IsAcceptableCssValue filter (issue #1272), while a truly
+        // bogus keyword is still dropped and reported.
+        var rejected = RunWithDiagnostics(
+            "document.getElementById('t').setAttribute('style', "
+            + "'white-space: break-spaces nowrap; --x: 1; white-space: x-bogus');");
+
+        Assert.DoesNotContain(rejected, e => e.Property == "white-space" && e.Value == "break-spaces nowrap");
+        Assert.Contains(("white-space", "x-bogus"), rejected);
+    }
+
+    [Fact]
+    public void Modern_WhiteSpace_Value_Survives_Serialization()
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, Html, "file:///inline-drop.html");
+        context.Eval(
+            "document.getElementById('t').setAttribute('style', 'white-space: preserve-breaks');");
+
+        var serialized = bridge.SerializeToHtml();
+
+        Assert.Contains("preserve-breaks", serialized);
+    }
+
     private static List<(string Property, string Value)> RunWithDiagnostics(string script)
     {
         using var context = new JSContext();

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -883,8 +883,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         switch (property.ToLowerInvariant())
         {
             case "white-space":
-                return v is "normal" or "nowrap" or "pre" or "pre-wrap"
-                    or "pre-line" or "break-spaces";
+                return IsWhiteSpaceValue(v);
 
             case "display":
                 return v is "block" or "inline" or "inline-block" or "none"
@@ -1003,6 +1002,42 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     // || full-size-kana ] | math-auto. The case keywords are mutually exclusive; a
     // valid multi-token value combines at most one case keyword with full-width
     // and/or full-size-kana (in any order), each at most once.
+    // CSS Text 4 §3: white-space is a shorthand for white-space-collapse and
+    // text-wrap-mode. Accepts a legacy single keyword or the two-longhand form
+    // <'white-space-collapse'> || <'text-wrap-mode'> (at most one collapse keyword
+    // combined with at most one wrap keyword, in either order), so modern values
+    // like "preserve-breaks" and "break-spaces nowrap" are not dropped.
+    private static bool IsWhiteSpaceValue(string v)
+    {
+        if (v is "normal" or "nowrap" or "pre" or "pre-wrap" or "pre-line")
+            return true;
+
+        bool collapseSeen = false, wrapSeen = false;
+        foreach (var token in v.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            switch (token)
+            {
+                case "collapse":
+                case "preserve":
+                case "preserve-breaks":
+                case "preserve-spaces":
+                case "break-spaces":
+                    if (collapseSeen) return false;
+                    collapseSeen = true;
+                    break;
+                case "wrap":
+                case "nowrap":
+                    if (wrapSeen) return false;
+                    wrapSeen = true;
+                    break;
+                default:
+                    return false;
+            }
+        }
+
+        return collapseSeen || wrapSeen;
+    }
+
     private static bool IsTextTransformValue(string v)
     {
         if (v is "none" or "math-auto")


### PR DESCRIPTION
Implements support for the CSS Text 4 `white-space` shorthand grammar, which combines `white-space-collapse` and `text-wrap-mode` longhand properties. This prevents valid modern values from being dropped as invalid during CSS declaration validation.

## Summary

The `white-space` property is a shorthand for two longhand properties:
- `white-space-collapse`: `collapse | preserve | preserve-breaks | preserve-spaces | break-spaces`
- `text-wrap-mode`: `wrap | nowrap`

Valid values include:
- Legacy single keywords: `normal`, `pre`, `nowrap`, `pre-wrap`, `pre-line`
- Modern single keywords: `preserve`, `preserve-breaks`, `preserve-spaces`, `break-spaces`
- Two-longhand form: any collapse keyword combined with any wrap keyword (e.g., `preserve-breaks nowrap`, `break-spaces nowrap`)

Previously, only legacy keywords and `break-spaces` were accepted, causing modern values like `preserve-breaks` (152 drops in issue #1272) and `break-spaces nowrap` (120 drops) to be discarded as invalid.

## Changes

**Broiler.CSS submodule patch** (`patches/0007-css-white-space-shorthand.patch`):
- Updated `CssStyleEngine.Values.IsAcceptableDeclarationValue` to validate the full CSS Text 4 grammar via new `IsWhiteSpaceValue` helper
- Added comprehensive test coverage in `CssStyleEngineTests.Valid_WhiteSpace_Shorthand_Is_Kept`

**Main repo — layout normalization** (`Broiler.Layout/CssUtils.cs`):
- Added `NormalizeWhiteSpaceValue` to fold shorthand values onto legacy keywords the layout engine keys off:
  - `preserve` → `pre-wrap`
  - `preserve-breaks` → `pre-line`
  - `collapse` → `normal`
  - Two-value combos mapped to closest equivalent (e.g., `preserve-breaks nowrap` → `pre-line`)
  - `break-spaces` passed through unchanged
- Integrated into `SetPropertyValue` white-space handling
- Added `WhiteSpaceNormalizationTests` with 15 test cases covering all mappings

**Main repo — CSSOM validator** (`DomBridge.cs`):
- Updated `IsAcceptableCssValue` to accept the full grammar via matching `IsWhiteSpaceValue` helper
- Ensures JS-set `element.style.whiteSpace` accepts modern values on CI

**Test coverage** (`InlineStyleDropDiagnosticsTests.cs`):
- Added `Modern_WhiteSpace_Shorthand_Is_Not_Dropped` to verify modern values survive the bridge filter
- Added `Modern_WhiteSpace_Value_Survives_Serialization` to verify serialization round-trip

The patch is ready for application; the main-repo pieces are inert but active once the patch lands and the submodule pointer is bumped.

https://claude.ai/code/session_019ikSkLyJPHhZ88Ck8dX4yQ