### PR TITLE
Fix deep DOM serialization and frameset overflow crashes

### DIFF
--- a/patches/0011-broiler-html-frameset-track-overflow.patch
+++ b/patches/0011-broiler-html-frameset-track-overflow.patch
@@ -1,0 +1,79 @@
+From ce111c12b85e834dcc3f4820e278c47def54e22d Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Wed, 8 Jul 2026 10:23:02 +0000
+Subject: [PATCH] Fix frameset track overflow crash on oversized rows/cols
+
+A frameset track expressed as a giant fixed or percentage length
+(e.g. rows="4294967227%,*") was fed straight through as the frame's
+width/height percentage. The resulting frame resolved to billions of
+pixels, and rasterising that embedded document overflowed the Int32
+RGBA buffer size in the BBitmap allocation, throwing
+"Arithmetic operation resulted in an overflow" and crashing the whole
+page render.
+
+ParseFramesetSpec now scales all tracks down proportionally when they
+would exceed the frameset's area, matching the HTML frameset algorithm
+(oversized fixed/percentage tracks are shrunk to fit, never overflow).
+For rows="4294967227%,*" the huge track becomes 100% and the star track
+0%, so the first frame fills the viewport and the second is squeezed to
+nothing - matching the WPT green-ref.html reference.
+
+Also hardened CompositeEmbeddedDocuments to skip any embedded box whose
+RGBA allocation would still overflow Int32, so a pathological size can
+never crash the entire render.
+
+Fixes the crash gating html/rendering/.../the-frameset-and-frame-elements/
+large-rows-percentage.html and large-rows-abssize.html.
+---
+ Source/Broiler.HTML.Image/HtmlRender.cs           |  8 +++++++-
+ .../Broiler.HTML.Orchestration/Parse/DomParser.cs | 15 +++++++++++++++
+ 2 files changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/Source/Broiler.HTML.Image/HtmlRender.cs b/Source/Broiler.HTML.Image/HtmlRender.cs
+index 7c1d60a..6029638 100644
+--- a/Source/Broiler.HTML.Image/HtmlRender.cs
++++ b/Source/Broiler.HTML.Image/HtmlRender.cs
+@@ -328,7 +328,13 @@ public static class HtmlRender
+             int dh = (int)Math.Round(fragment.Size.Height
+                 - (float)(border.Top + border.Bottom + padding.Top + padding.Bottom));
+ 
+-            if (dw > 0 && dh > 0)
++            // Guard against a pathologically large embedded box (e.g. a frameset
++            // track that still resolves to billions of pixels): allocating its
++            // RGBA buffer would overflow Int32 and throw, crashing the whole page
++            // render.  Anything that large is off-screen anyway, so skip it.
++            bool fitsAllocation = (long)dw * dh * 4 <= int.MaxValue;
++
++            if (dw > 0 && dh > 0 && fitsAllocation)
+             {
+                 using var sub = RenderToImageCore(
+                     fragment.EmbeddedDocumentHtml, dw, dh,
+diff --git a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+index 182d12d..fc5bb82 100644
+--- a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
++++ b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+@@ -978,6 +978,21 @@ internal sealed class DomParser
+             result.Add(frac * 100.0);
+         }
+ 
++        // Fixed/percentage tracks can request more than the frameset's area
++        // (e.g. rows="4294967227%,*"): the HTML frameset algorithm scales the
++        // tracks down proportionally so they fit exactly, never overflowing the
++        // frameset.  Without this a single giant track produces a frame sized in
++        // billions of pixels, overflowing the embedded-document bitmap allocation.
++        double total = 0;
++        foreach (var p in result)
++            total += p;
++        if (total > 100.0)
++        {
++            double scale = 100.0 / total;
++            for (int i = 0; i < result.Count; i++)
++                result[i] *= scale;
++        }
++
+         return result;
+     }
+ 
+-- 
+2.43.0
+

--- a/patches/0012-broiler-dom-iterative-html-serializer.patch
+++ b/patches/0012-broiler-dom-iterative-html-serializer.patch
@@ -1,0 +1,227 @@
+From 8f2b2742ceec063bd97b15965e4bee3148b35c3d Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Wed, 8 Jul 2026 11:05:12 +0000
+Subject: [PATCH] Serialize HTML iteratively so deep DOM trees don't crash
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+HtmlSerializer.Append recursed once per DOM level and threw
+"Maximum HTML serialization depth (1024) exceeded" past its depth cap —
+a legitimately deep tree (e.g. WPT shadow-dom/build-deep-detached-shadow-
+then-append-text.html, ~999 nested shadow hosts -> ~2000 serialized
+levels) crashed the whole render. The cap existed only to stop the
+recursion overflowing the .NET call stack.
+
+Rewrite Append to walk an explicit heap stack instead of recursing:
+each element pushes a deferred close-tag marker then its children (in
+reverse, so they emit in document order). Output is byte-for-byte
+identical for ordinary trees. Depth is still tracked and bounded by
+MaximumDepth (raised to 100000 now that it guards heap growth / cycles
+rather than stack frames), so a runaway structure is still bounded but
+real content no longer hits the cap.
+---
+ Broiler.Dom.Html/HtmlSerializer.cs | 161 ++++++++++++++++++-----------
+ 1 file changed, 103 insertions(+), 58 deletions(-)
+
+diff --git a/Broiler.Dom.Html/HtmlSerializer.cs b/Broiler.Dom.Html/HtmlSerializer.cs
+index 0e538dd..121b7cd 100644
+--- a/Broiler.Dom.Html/HtmlSerializer.cs
++++ b/Broiler.Dom.Html/HtmlSerializer.cs
+@@ -24,7 +24,7 @@ public sealed record HtmlSerializationAdapter<TNode>(
+ 
+ public sealed record HtmlSerializationOptions(
+     bool IncludeHtmlDoctype = false,
+-    int MaximumDepth = 1024,
++    int MaximumDepth = 100_000,
+     bool EncodeTextNodes = true,
+     bool NewLineAfterDoctype = false);
+ 
+@@ -74,82 +74,127 @@ public static class HtmlSerializer
+ 
+     public static string Encode(string? value) => WebUtility.HtmlEncode(value ?? string.Empty);
+ 
++    // A pending unit of serialization work. Either a node to open (Closing is
++    // null) or a literal close-tag string to append once a node's children have
++    // all been written. Kept on an explicit heap stack so serialization does not
++    // recurse on the .NET call stack: a legitimately deep DOM (e.g. hundreds of
++    // nested shadow hosts, WPT shadow-dom/build-deep-detached-shadow-then-append-
++    // text.html) would otherwise overflow the stack. Depth is still tracked so a
++    // runaway/cyclic structure is bounded by MaximumDepth instead of exhausting
++    // memory.
++    private readonly struct PendingNode<TNode>(TNode node, string? closing, int depth)
++    {
++        public readonly TNode Node = node;
++        public readonly string? Closing = closing;
++        public readonly int Depth = depth;
++    }
++
+     private static void Append<TNode>(
+-        TNode node,
++        TNode root,
+         HtmlSerializationAdapter<TNode> adapter,
+         HtmlSerializationOptions options,
+         StringBuilder builder,
+         int depth)
+     {
+-        if (depth > options.MaximumDepth)
+-            throw new InvalidOperationException($"Maximum HTML serialization depth ({options.MaximumDepth}) exceeded.");
++        var stack = new Stack<PendingNode<TNode>>();
++        stack.Push(new PendingNode<TNode>(root, null, depth));
+ 
+-        var kind = adapter.GetKind(node);
+-        if (kind == HtmlSerializationNodeKind.Text)
++        while (stack.Count > 0)
+         {
+-            var text = adapter.GetText(node) ?? string.Empty;
+-            builder.Append(options.EncodeTextNodes ? Encode(text) : text);
+-            return;
+-        }
++            var pending = stack.Pop();
++            if (pending.Closing is not null)
++            {
++                builder.Append(pending.Closing);
++                continue;
++            }
+ 
+-        if (kind == HtmlSerializationNodeKind.Comment)
+-        {
+-            builder.Append("<!--").Append(adapter.GetText(node) ?? string.Empty).Append("-->");
+-            return;
+-        }
++            var node = pending.Node;
++            var nodeDepth = pending.Depth;
++            if (nodeDepth > options.MaximumDepth)
++                throw new InvalidOperationException($"Maximum HTML serialization depth ({options.MaximumDepth}) exceeded.");
+ 
+-        if (kind is HtmlSerializationNodeKind.Fragment or HtmlSerializationNodeKind.DocumentRoot)
+-        {
+-            foreach (var child in adapter.GetChildren(node))
+-                Append(child, adapter, options, builder, depth + 1);
+-            return;
+-        }
++            var kind = adapter.GetKind(node);
++            if (kind == HtmlSerializationNodeKind.Text)
++            {
++                var textData = adapter.GetText(node) ?? string.Empty;
++                builder.Append(options.EncodeTextNodes ? Encode(textData) : textData);
++                continue;
++            }
+ 
+-        if (kind == HtmlSerializationNodeKind.DocumentType)
+-        {
+-            var name = adapter.GetName(node);
+-            builder.Append("<!DOCTYPE ").Append(string.IsNullOrWhiteSpace(name) ? "html" : name).Append('>');
+-            return;
+-        }
++            if (kind == HtmlSerializationNodeKind.Comment)
++            {
++                builder.Append("<!--").Append(adapter.GetText(node) ?? string.Empty).Append("-->");
++                continue;
++            }
+ 
+-        var tagName = adapter.GetName(node).ToLowerInvariant();
+-        builder.Append('<').Append(tagName);
+-        foreach (var (name, value) in adapter.GetAttributes(node))
+-            builder.Append(' ').Append(name).Append("=\"").Append(Encode(value)).Append('"');
++            if (kind is HtmlSerializationNodeKind.Fragment or HtmlSerializationNodeKind.DocumentRoot)
++            {
++                PushChildren(stack, adapter.GetChildren(node), nodeDepth + 1);
++                continue;
++            }
+ 
+-        var styles = adapter.GetStyles(node).ToArray();
+-        if (styles.Length > 0)
+-        {
+-            builder.Append(" style=\"");
+-            for (var index = 0; index < styles.Length; index++)
++            if (kind == HtmlSerializationNodeKind.DocumentType)
+             {
+-                if (index > 0)
+-                    builder.Append("; ");
+-                builder.Append(styles[index].Key).Append(": ").Append(Encode(styles[index].Value));
++                var name = adapter.GetName(node);
++                builder.Append("<!DOCTYPE ").Append(string.IsNullOrWhiteSpace(name) ? "html" : name).Append('>');
++                continue;
+             }
+-            builder.Append('"');
+-        }
+ 
+-        builder.Append('>');
+-        if (VoidElements.Contains(tagName))
+-            return;
++            var tagName = adapter.GetName(node).ToLowerInvariant();
++            builder.Append('<').Append(tagName);
++            foreach (var (name, value) in adapter.GetAttributes(node))
++                builder.Append(' ').Append(name).Append("=\"").Append(Encode(value)).Append('"');
+ 
+-        var children = adapter.GetChildren(node).ToArray();
+-        if (children.Length > 0)
+-        {
+-            foreach (var child in children)
+-                Append(child, adapter, options, builder, depth + 1);
+-        }
+-        else if (adapter.GetText(node) is { Length: > 0 } text)
+-        {
+-            builder.Append(tagName is "script" or "style" ? text : Encode(text));
+-        }
+-        else if (adapter.GetRawInnerHtml(node) is { Length: > 0 } rawInnerHtml)
+-        {
+-            builder.Append(rawInnerHtml);
++            var styles = adapter.GetStyles(node).ToArray();
++            if (styles.Length > 0)
++            {
++                builder.Append(" style=\"");
++                for (var index = 0; index < styles.Length; index++)
++                {
++                    if (index > 0)
++                        builder.Append("; ");
++                    builder.Append(styles[index].Key).Append(": ").Append(Encode(styles[index].Value));
++                }
++                builder.Append('"');
++            }
++
++            builder.Append('>');
++            if (VoidElements.Contains(tagName))
++                continue;
++
++            var children = adapter.GetChildren(node).ToArray();
++            if (children.Length > 0)
++            {
++                // Defer the close tag until after every child is written, then
++                // push the children so they pop (and serialize) in document order.
++                stack.Push(new PendingNode<TNode>(default!, $"</{tagName}>", nodeDepth));
++                for (var index = children.Length - 1; index >= 0; index--)
++                    stack.Push(new PendingNode<TNode>(children[index], null, nodeDepth + 1));
++                continue;
++            }
++
++            if (adapter.GetText(node) is { Length: > 0 } text)
++            {
++                builder.Append(tagName is "script" or "style" ? text : Encode(text));
++            }
++            else if (adapter.GetRawInnerHtml(node) is { Length: > 0 } rawInnerHtml)
++            {
++                builder.Append(rawInnerHtml);
++            }
++
++            builder.Append("</").Append(tagName).Append('>');
+         }
++    }
+ 
+-        builder.Append("</").Append(tagName).Append('>');
++    private static void PushChildren<TNode>(
++        Stack<PendingNode<TNode>> stack,
++        IEnumerable<TNode> children,
++        int depth)
++    {
++        // Reverse so the first child pops first (document order).
++        var buffer = children as IReadOnlyList<TNode> ?? children.ToArray();
++        for (var index = buffer.Count - 1; index >= 0; index--)
++            stack.Push(new PendingNode<TNode>(buffer[index], null, depth));
+     }
+ 
+     private static readonly HtmlSerializationAdapter<DomNode> CanonicalAdapter = new(
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -21,6 +21,32 @@ cd .. && git add <Submodule> && git commit -m "Bump <Submodule>: <summary>"
 
 ## Index
 
+- **0012-broiler-dom-iterative-html-serializer.patch** → `Broiler.DOM`
+  (`Broiler.Dom.Html/HtmlSerializer.cs`) — fixes the crash gating
+  `shadow-dom/build-deep-detached-shadow-then-append-text.html` (issue #1302,
+  `HtmlSerializer.Append[TNode] — Maximum HTML serialization depth (1024)
+  exceeded`). `Append` recursed once per DOM level, so a legitimately deep tree
+  (the test builds ~999 nested shadow hosts → ~2000 serialized levels) blew past
+  the 1024 cap and threw, crashing the whole render. The cap existed only to
+  stop the recursion overflowing the .NET call stack. The patch rewrites `Append`
+  to walk an explicit heap stack (each element pushes a deferred close-tag marker
+  then its children in reverse, emitting in document order) — byte-for-byte
+  identical output for ordinary trees, verified by
+  `HtmlSerializerIterativeTests.Serialize_ProducesCorrectlyNestedAndOrderedOutput`
+  — and raises the default `MaximumDepth` to 100000 now that the bound guards
+  heap growth / cycles rather than stack frames.
+  **Active CI fallback — yes.** The renderer serializes through the **main-repo**
+  `DomBridge` (`SerializeToHtml` / the render-document adapter), which passes its
+  own `MaxSerializationDepth`; that constant was raised 1024 → 100000 in the same
+  parent commit, so the test renders on CI **now** without waiting on this patch.
+  It is safe with the still-recursive pinned serializer because ~2000 recursive
+  frames stay well within the 1MB stack (verified: the test renders, and deeper
+  script-built chains hit the 30 s WPT timeout — a graceful failure — long before
+  any overflow). Once a maintainer applies this patch and bumps the pointer, the
+  recursion (and any residual stack-overflow risk at extreme depths) is gone
+  entirely. Guards: `HtmlSerializerIterativeTests` (exact-output equivalence +
+  a 2000-level chain serializing without throwing).
+
 - **0011-broiler-html-frameset-track-overflow.patch** → `Broiler.HTML`
   (`Source/Broiler.HTML.Orchestration/Parse/DomParser.cs` +
   `Source/Broiler.HTML.Image/HtmlRender.cs`) — fixes the crash gating

--- a/patches/README.md
+++ b/patches/README.md
@@ -21,6 +21,32 @@ cd .. && git add <Submodule> && git commit -m "Bump <Submodule>: <summary>"
 
 ## Index
 
+- **0011-broiler-html-frameset-track-overflow.patch** → `Broiler.HTML`
+  (`Source/Broiler.HTML.Orchestration/Parse/DomParser.cs` +
+  `Source/Broiler.HTML.Image/HtmlRender.cs`) — fixes the crash gating
+  `html/rendering/non-replaced-elements/the-frameset-and-frame-elements/`
+  `large-rows-percentage.html` and `large-rows-abssize.html` (issue #1302,
+  `HtmlRender.RenderToImageCore — Arithmetic operation resulted in an
+  overflow`). A frameset track given as a giant fixed or percentage length
+  (both tests use `rows="4294967227%,*"`) was passed straight through as the
+  frame's height percentage, so the frame resolved to billions of pixels;
+  rasterising that embedded document overflowed the Int32 RGBA buffer-size
+  multiply in `BBitmap`'s constructor (`checked(width * height * 4)`), throwing
+  and crashing the whole page render. `ParseFramesetSpec` now scales all tracks
+  down proportionally whenever they would exceed the frameset's area (the HTML
+  frameset algorithm shrinks oversized fixed/percentage tracks to fit, never
+  overflowing): for `rows="4294967227%,*"` the huge track becomes 100 % and the
+  `*` track 0 %, so the first frame fills the viewport and the second is
+  squeezed to nothing — the rendered 1024×768 output is uniformly green,
+  matching the WPT `reference/green-ref.html`. `CompositeEmbeddedDocuments` is
+  also hardened to skip any embedded box whose RGBA allocation would still
+  overflow Int32, so no pathological size can crash the render.
+  **No active CI fallback:** both the frameset track math (`DomParser`) and the
+  embedded-document rasterisation (`HtmlRender`) live entirely in the
+  `Broiler.HTML` submodule — there is no parent-repo layer to mirror them into —
+  so these two tests stay crashed until a maintainer applies this patch and
+  bumps the pointer.
+
 - **0010-css-backgrounds-root-gradient-propagation.patch** → `Broiler.HTML`
   (`Source/Broiler.HTML.Orchestration/IR/PaintWalker.Gradients.cs` +
   `Source/Broiler.HTML.Image/BCanvas.cs`) — fixes a root `<html>` background

--- a/src/Broiler.Cli.Tests/ContentSecurityPolicyTests.cs
+++ b/src/Broiler.Cli.Tests/ContentSecurityPolicyTests.cs
@@ -346,4 +346,95 @@ public class ContentSecurityPolicyTests
         Assert.Contains("data-csp=\"blocked\"", result);
         Assert.DoesNotContain(">after<", result);
     }
+
+    // --- style-src family (issue #1302 CSP style-src* WPT tests) ----------
+
+    [Fact]
+    public void StyleSrcAttr_None_Strips_Inline_Style_Attribute()
+    {
+        const string html = """
+            <!DOCTYPE html>
+            <html>
+            <head><meta http-equiv="Content-Security-Policy"
+                content="style-src-attr 'none'; style-src 'unsafe-inline';"></head>
+            <body style="background: green"></body>
+            </html>
+            """;
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///t.html");
+
+        Assert.DoesNotContain("background: green", result);
+        Assert.DoesNotContain("style=", result);
+    }
+
+    [Fact]
+    public void StyleSrcElem_None_Removes_Style_Element()
+    {
+        const string html = """
+            <!DOCTYPE html>
+            <html>
+            <head><meta http-equiv="Content-Security-Policy"
+                content="style-src-elem 'none'; style-src 'unsafe-inline';"></head>
+            <body><style>body {background: green;}</style></body>
+            </html>
+            """;
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///t.html");
+
+        Assert.DoesNotContain("background: green", result);
+        Assert.DoesNotContain("<style", result);
+    }
+
+    [Fact]
+    public void StyleSrcElem_Allowed_Attr_Blocked_Keeps_Element_Strips_Attribute()
+    {
+        const string html = """
+            <!DOCTYPE html>
+            <html>
+            <head><meta http-equiv="Content-Security-Policy"
+                content="style-src-elem 'unsafe-inline'; style-src-attr 'none';"></head>
+            <body style="background: green"><style>body {background: blue;}</style></body>
+            </html>
+            """;
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///t.html");
+
+        // The style attribute is blocked; the <style> element survives.
+        Assert.DoesNotContain("background: green", result);
+        Assert.Contains("background: blue", result);
+        Assert.Contains("<style", result);
+    }
+
+    [Fact]
+    public void StyleSrc_UnsafeInline_Keeps_Inline_Style_Attribute()
+    {
+        const string html = """
+            <!DOCTYPE html>
+            <html>
+            <head><meta http-equiv="Content-Security-Policy"
+                content="style-src 'unsafe-inline';"></head>
+            <body style="background: green"></body>
+            </html>
+            """;
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///t.html");
+
+        Assert.Contains("background: green", result);
+    }
+
+    [Fact]
+    public void No_Csp_Keeps_Inline_Styles()
+    {
+        const string html = """
+            <!DOCTYPE html>
+            <html>
+            <body style="background: green"><style>p {color: red;}</style></body>
+            </html>
+            """;
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///t.html");
+
+        Assert.Contains("background: green", result);
+        Assert.Contains("<style", result);
+    }
 }

--- a/src/Broiler.Cli.Tests/HtmlSerializerIterativeTests.cs
+++ b/src/Broiler.Cli.Tests/HtmlSerializerIterativeTests.cs
@@ -1,0 +1,72 @@
+using Broiler.Dom;
+using Broiler.Dom.Html;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Guards the iterative (explicit-stack) rewrite of
+/// <see cref="HtmlSerializer.Append{TNode}"/> — issue #1302's
+/// shadow-dom/build-deep-detached-shadow-then-append-text.html crashed the
+/// render with "Maximum HTML serialization depth (1024) exceeded" because the
+/// serializer recursed once per DOM level. The rewrite must (a) produce exactly
+/// the same output as before for ordinary trees, including correctly ordered
+/// close tags, and (b) serialize a very deep chain without throwing or
+/// overflowing the stack.
+/// </summary>
+public sealed class HtmlSerializerIterativeTests
+{
+    [Fact]
+    public void Serialize_ProducesCorrectlyNestedAndOrderedOutput()
+    {
+        var doc = new DomDocument();
+        var root = doc.CreateElement("div");
+        root.SetAttribute("id", "a");
+        var p = doc.CreateElement("p");
+        p.AppendChild(doc.CreateTextNode("Hello "));
+        var b = doc.CreateElement("b");
+        b.AppendChild(doc.CreateTextNode("bold"));
+        p.AppendChild(b);
+        root.AppendChild(p);
+        var img = doc.CreateElement("img");
+        img.SetAttribute("src", "p.png");
+        root.AppendChild(img);
+        root.AppendChild(doc.CreateElement("span"));
+
+        var html = HtmlSerializer.Serialize(root);
+
+        Assert.Equal(
+            "<div id=\"a\"><p>Hello <b>bold</b></p><img src=\"p.png\"><span></span></div>",
+            html);
+    }
+
+    [Fact]
+    public void Serialize_DeepChain_DoesNotThrowOrOverflow()
+    {
+        var doc = new DomDocument();
+        var root = doc.CreateElement("div");
+        var current = root;
+        // ~2000 levels: past the old 1024 recursion cap and comparable to the WPT
+        // shadow-dom deep-detached test that triggered the crash.
+        for (var i = 0; i < 2000; i++)
+        {
+            var child = doc.CreateElement("div");
+            current.AppendChild(child);
+            current = child;
+        }
+        current.AppendChild(doc.CreateTextNode("deep"));
+
+        // Explicit high cap so the assertion holds against both the recursive
+        // baseline (pre-patch pointer) and the iterative rewrite: the point is
+        // that ~2000 levels serialize without throwing or overflowing.
+        var html = HtmlSerializer.Serialize(
+            root,
+            new HtmlSerializationOptions(MaximumDepth: 100_000));
+
+        Assert.StartsWith("<div><div>", html);
+        Assert.EndsWith("</div></div>", html);
+        Assert.Contains("deep", html);
+        // Balanced: one open and one close per level plus the root.
+        Assert.Equal(2001, System.Text.RegularExpressions.Regex.Matches(html, "<div>").Count);
+        Assert.Equal(2001, System.Text.RegularExpressions.Regex.Matches(html, "</div>").Count);
+    }
+}

--- a/src/Broiler.Cli.Tests/NamedElementGlobalCollisionTests.cs
+++ b/src/Broiler.Cli.Tests/NamedElementGlobalCollisionTests.cs
@@ -1,0 +1,63 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Regression guards for the crash that gated several WPT tests (issue #1302,
+/// signature "Initialize — Cannot assign to read only variable"): a document
+/// whose script declares a global lexical <c>const</c>/<c>let</c>/<c>class</c>
+/// with the same name as an element's <c>id</c> (e.g. the WPT
+/// <c>&lt;img id="img"&gt;</c> + <c>const img = …</c> and
+/// <c>&lt;iframe id="current"&gt;</c> + <c>const current = …</c> helpers) crashed
+/// the whole render. <see cref="DomBridge.RegisterNamedElementGlobals"/> assigned
+/// the element to the same-named global via the context indexer, which wrote
+/// through the read-only lexical binding and threw. The "skip if already defined"
+/// guard compared the engine's <c>JSBoolean</c> against C#'s "True" and so never
+/// fired.
+/// </summary>
+public sealed class NamedElementGlobalCollisionTests
+{
+    [Fact]
+    public void RegisterNamedElementGlobals_DoesNotThrow_WhenIdCollidesWithConst()
+    {
+        using var ctx = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(ctx, "<!doctype html><body><img id=img></body>", "file:///c.html");
+        // The user's script runs first and publishes a read-only global lexical.
+        ctx.Eval("const img = 42;");
+
+        // Registering the same-named element must not crash (previously threw
+        // "Cannot assign to read only variable").
+        var ex = Record.Exception(() => bridge.RegisterNamedElementGlobals(ctx));
+        Assert.Null(ex);
+
+        // The user's const binding wins over named-element access.
+        Assert.Equal("42", ctx.Eval("String(img)").ToString());
+    }
+
+    [Fact]
+    public void RegisterNamedElementGlobals_DoesNotThrow_WhenIdCollidesWithClass()
+    {
+        using var ctx = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(ctx, "<!doctype html><body><div id=Widget></div></body>", "file:///c.html");
+        ctx.Eval("class Widget {}");
+
+        var ex = Record.Exception(() => bridge.RegisterNamedElementGlobals(ctx));
+        Assert.Null(ex);
+        Assert.Equal("function", ctx.Eval("typeof Widget").ToString());
+    }
+
+    [Fact]
+    public void RegisterNamedElementGlobals_StillExposesUndeclaredIdAsGlobal()
+    {
+        using var ctx = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(ctx, "<!doctype html><body><div id=host></div></body>", "file:///c.html");
+
+        // No user binding named `host` — named access on the window must still work.
+        bridge.RegisterNamedElementGlobals(ctx);
+        Assert.Equal("object", ctx.Eval("typeof host").ToString());
+    }
+}

--- a/src/Broiler.Cli/CaptureService.cs
+++ b/src/Broiler.Cli/CaptureService.cs
@@ -487,7 +487,10 @@ public class CaptureService
                 scripts.Add(scriptContent);
         }
 
-        if (scripts.Count == 0 && deferredScripts.Count == 0)
+        // No scripts to run: normally the raw HTML passes through untouched, but
+        // a CSP style-src policy that blocks inline styles still has to be applied
+        // to the rendered output, so fall through to build and re-serialize the DOM.
+        if (scripts.Count == 0 && deferredScripts.Count == 0 && (csp == null || !csp.AffectsStyles()))
             return html;
 
         var microTasks = new MicroTaskQueue();
@@ -497,6 +500,10 @@ public class CaptureService
         bridge.Csp = csp;
         bridge.TaskCheckpointCallback = () => microTasks.Drain();
         bridge.Attach(context, html, url);
+
+        // Enforce the CSP style-src family on the parsed DOM so blocked inline
+        // style attributes / <style> elements neither apply nor render.
+        bridge.ApplyStyleContentSecurityPolicy(csp);
 
         // Set local base path for sub-resource resolution (e.g. iframe src)
         if (!string.IsNullOrEmpty(localResourceBasePath))

--- a/src/Broiler.HtmlBridge.Core/Scripting/ContentSecurityPolicy.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/ContentSecurityPolicy.cs
@@ -11,7 +11,9 @@ namespace Broiler.HtmlBridge.Scripting;
 /// pipeline. The currently honored directives are <c>default-src</c>,
 /// <c>script-src</c>, <c>script-src-elem</c>, and <c>script-src-attr</c>
 /// for inline-script, external-script, inline event-handler, and
-/// <c>eval()</c> gating. The currently honored source expressions are
+/// <c>eval()</c> gating, plus <c>style-src</c>, <c>style-src-elem</c>, and
+/// <c>style-src-attr</c> for gating inline <c>&lt;style&gt;</c> elements and
+/// inline <c>style="…"</c> attributes. The currently honored source expressions are
 /// <c>'none'</c>, <c>'self'</c>, <c>'unsafe-inline'</c>,
 /// <c>'unsafe-eval'</c>, <c>'strict-dynamic'</c>, nonce sources, hash
 /// sources, wildcard <c>*</c>, scheme sources such as <c>https:</c>, and
@@ -30,6 +32,9 @@ public sealed class ContentSecurityPolicy
     private readonly HashSet<string> _scriptSrcTokens = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _scriptSrcElemTokens = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _scriptSrcAttrTokens = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _styleSrcTokens = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _styleSrcElemTokens = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _styleSrcAttrTokens = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Whether <c>eval()</c> and similar dynamic code execution is allowed.
@@ -52,6 +57,9 @@ public sealed class ContentSecurityPolicy
         _scriptSrcTokens.Clear();
         _scriptSrcElemTokens.Clear();
         _scriptSrcAttrTokens.Clear();
+        _styleSrcTokens.Clear();
+        _styleSrcElemTokens.Clear();
+        _styleSrcAttrTokens.Clear();
         AllowsEval = true;
         StrictDynamic = false;
 
@@ -74,6 +82,12 @@ public sealed class ContentSecurityPolicy
                 target = _scriptSrcElemTokens;
             else if (string.Equals(tokens[0], "script-src-attr", StringComparison.OrdinalIgnoreCase))
                 target = _scriptSrcAttrTokens;
+            else if (string.Equals(tokens[0], "style-src", StringComparison.OrdinalIgnoreCase))
+                target = _styleSrcTokens;
+            else if (string.Equals(tokens[0], "style-src-elem", StringComparison.OrdinalIgnoreCase))
+                target = _styleSrcElemTokens;
+            else if (string.Equals(tokens[0], "style-src-attr", StringComparison.OrdinalIgnoreCase))
+                target = _styleSrcAttrTokens;
 
             if (target == null)
                 continue;
@@ -136,6 +150,69 @@ public sealed class ContentSecurityPolicy
             return true;
 
         return false;
+    }
+
+    /// <summary>
+    /// Returns whether an inline <c>style="…"</c> attribute is allowed under the
+    /// effective style-attribute directive (<c>style-src-attr</c>, falling back
+    /// to <c>style-src</c> then <c>default-src</c>). Style attributes cannot carry
+    /// a nonce, so only <c>'unsafe-inline'</c> (or the absence of any applicable
+    /// directive) permits them.
+    /// </summary>
+    public bool AllowsInlineStyleAttribute()
+    {
+        var sources = GetEffectiveStyleAttributeSources();
+        if (sources.Count == 0)
+            return true;
+
+        if (IsNoneOnly(sources))
+            return false;
+
+        return sources.Contains("'unsafe-inline'");
+    }
+
+    /// <summary>
+    /// Returns whether an inline <c>&lt;style&gt;</c> element is allowed under the
+    /// effective style-element directive (<c>style-src-elem</c>, falling back to
+    /// <c>style-src</c> then <c>default-src</c>). Honors <c>'unsafe-inline'</c>,
+    /// nonce sources, and hash sources.
+    /// </summary>
+    public bool AllowsInlineStyleElement(string? nonce = null, string? styleText = null)
+    {
+        var sources = GetEffectiveStyleElementSources();
+        if (sources.Count == 0)
+            return true;
+
+        if (IsNoneOnly(sources))
+            return false;
+
+        if (!string.IsNullOrEmpty(nonce) && MatchesNonce(sources, nonce))
+            return true;
+
+        if (!string.IsNullOrEmpty(styleText) && MatchesHash(sources, styleText))
+            return true;
+
+        return sources.Contains("'unsafe-inline'");
+    }
+
+    /// <summary>
+    /// Returns whether this policy could block some inline style — a style
+    /// attribute or a plain (nonce-less/hash-less) <c>&lt;style&gt;</c> element.
+    /// Lets a caller skip building a DOM purely to enforce styles when the policy
+    /// permits them all.
+    /// </summary>
+    public bool AffectsStyles()
+    {
+        if (!AllowsInlineStyleAttribute())
+            return true;
+
+        var elementSources = GetEffectiveStyleElementSources();
+        if (elementSources.Count == 0)
+            return false;
+        if (IsNoneOnly(elementSources))
+            return true;
+
+        return !elementSources.Contains("'unsafe-inline'");
     }
 
     /// <summary>
@@ -247,6 +324,24 @@ public sealed class ContentSecurityPolicy
             return _scriptSrcAttrTokens;
         if (_scriptSrcTokens.Count > 0)
             return _scriptSrcTokens;
+        return _defaultSrcTokens;
+    }
+
+    private HashSet<string> GetEffectiveStyleElementSources()
+    {
+        if (_styleSrcElemTokens.Count > 0)
+            return _styleSrcElemTokens;
+        if (_styleSrcTokens.Count > 0)
+            return _styleSrcTokens;
+        return _defaultSrcTokens;
+    }
+
+    private HashSet<string> GetEffectiveStyleAttributeSources()
+    {
+        if (_styleSrcAttrTokens.Count > 0)
+            return _styleSrcAttrTokens;
+        if (_styleSrcTokens.Count > 0)
+            return _styleSrcTokens;
         return _defaultSrcTokens;
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -15,7 +15,7 @@ public sealed partial class DomBridge
     //  DOM → HTML serialisation
     // ------------------------------------------------------------------
 
-    private const int MaxSerializationDepth = 1024;
+    private const int MaxSerializationDepth = 100_000;
     private const double ZoomSerializationEpsilon = 0.0001;
     private const double DefaultProgressLikeTrackLengthPx = 120;
     private readonly Dictionary<DomElement, Dictionary<string, string>> _zoomSpecifiedStyleCache = [];

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -281,22 +281,42 @@ public sealed partial class DomBridge : IDomBridgeRuntime
             if (el.IsTextNode || string.IsNullOrEmpty(el.Id))
                 continue;
             // Only register if the global doesn't already exist
-            // (user-defined globals take precedence).
+            // (user-defined globals take precedence — a `var`/`function` or a
+            // lexical `const`/`let`/`class` with the same name shadows the named
+            // element, per HTML "named access on the Window object"). The JS
+            // engine reports the result as a JSBoolean whose ToString() is the
+            // lowercase "true"/"false"; comparing against C#'s "True" never
+            // matched, so this skip was a no-op and a same-named read-only
+            // global lexical made the assignment below throw
+            // "Cannot assign to read only variable", crashing the whole render.
             try
             {
                 var existing = context.Eval(
                     $"typeof {el.Id} !== 'undefined'");
-                if (existing?.ToString() == "True")
+                if (existing != null && existing.BooleanValue)
                     continue;
             }
             catch
             {
-                // If the id isn't a valid JS identifier, skip it.
+                // If the id isn't a valid JS identifier, or resolving it throws
+                // (e.g. a lexical binding still in its temporal dead zone), leave
+                // the existing binding untouched.
                 continue;
             }
 
-            var jsObj = ToJSObject(el);
-            context[el.Id] = jsObj;
+            // Defensive: even past the guard, assigning could hit a read-only
+            // binding in an edge case; a named-element convenience global must
+            // never crash script execution.
+            try
+            {
+                var jsObj = ToJSObject(el);
+                context[el.Id] = jsObj;
+            }
+            catch (Exception ex)
+            {
+                RenderLogger.LogWarning(LogCategory.JavaScript, "DomBridge.RegisterNamedElementGlobals",
+                    $"Could not register named element global '{el.Id}': {ex.Message}", ex);
+            }
         }
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -8,6 +8,7 @@ using Broiler.JavaScript.BuiltIns.String;
 using Broiler.JavaScript.Runtime;
 using Broiler.JavaScript.BuiltIns.Function;
 using Broiler.HtmlBridge.Logging;
+using Broiler.HtmlBridge.Scripting;
 
 namespace Broiler.HtmlBridge;
 
@@ -931,6 +932,50 @@ public sealed partial class DomBridge
     /// pre-Phase-6), and the serialized live model once <c>insertRule</c>/<c>deleteRule</c>
     /// has mutated it — so script CSSOM mutations are observed downstream.
     /// </summary>
+    /// <summary>
+    /// Enforces the Content Security Policy <c>style-src</c> family on the parsed
+    /// DOM so blocked inline styles do not render: an inline <c>style="…"</c>
+    /// attribute blocked by <c>style-src-attr</c> (→ <c>style-src</c> →
+    /// <c>default-src</c>) is stripped, and a <c>&lt;style&gt;</c> element blocked
+    /// by <c>style-src-elem</c> (same fallback chain) is removed. Only the style
+    /// directives are consulted — script/event-handler enforcement is intentionally
+    /// left to the script pipeline — so this is safe to call on any parsed document.
+    /// </summary>
+    public void ApplyStyleContentSecurityPolicy(ContentSecurityPolicy? csp)
+    {
+        if (csp == null || DocumentElement == null)
+            return;
+
+        ApplyStyleCsp(DocumentElement, csp, blockStyleAttribute: !csp.AllowsInlineStyleAttribute());
+    }
+
+    private void ApplyStyleCsp(DomElement element, ContentSecurityPolicy csp, bool blockStyleAttribute)
+    {
+        if (!element.IsTextNode)
+        {
+            if (element.TagName.Equals("style", StringComparison.OrdinalIgnoreCase))
+            {
+                var nonce = element.Attributes.TryGetValue("nonce", out var n) ? n : null;
+                if (!csp.AllowsInlineStyleElement(nonce, GetStyleElementCssText(element)))
+                {
+                    element.Remove();
+                    return;
+                }
+            }
+
+            if (blockStyleAttribute && element.Attributes.ContainsKey("style"))
+            {
+                element.Attributes.Remove("style");
+                element.Style.Clear();
+                InvalidateStyleScope(element);
+            }
+        }
+
+        // Snapshot: a blocked <style> child removes itself from this collection.
+        foreach (var child in element.Children.ToArray())
+            ApplyStyleCsp(child, csp, blockStyleAttribute);
+    }
+
     private string GetStyleElementCssText(DomElement styleEl)
     {
         var rules = EnsureStyleSheetRulesCurrent(styleEl);

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -2014,6 +2014,14 @@ internal sealed class WptTestRunner
             return JSUndefined.Value;
         }, "queueMicrotask", 1);
         bridge.Attach(context, html, url);
+
+        // Enforce the CSP style-src family (style-src / -elem / -attr) on the
+        // parsed DOM before scripts run, so an inline style attribute or <style>
+        // element blocked by the page's policy neither applies nor renders
+        // (WPT content-security-policy/style-src*). Only style directives are
+        // consulted, so this does not change script/event-handler behaviour.
+        bridge.ApplyStyleContentSecurityPolicy(ContentSecurityPolicy.FromHtml(html));
+
         try { context.Eval("window.queueMicrotask = queueMicrotask;"); } catch { /* best-effort */ }
 
         // Register DOM elements with IDs as globals (HTML5 named access).


### PR DESCRIPTION
Fixes two crashes that gate WPT tests in issue #1302:

## Summary

This PR addresses crashes in HTML serialization and frameset rendering by rewriting the serializer to use an explicit stack instead of recursion, and by scaling oversized frameset tracks to prevent integer overflow in bitmap allocation. It also adds CSP `style-src*` enforcement to block inline styles per policy.

## Changes

### 1. Iterative HTML Serialization (Patch 0012)
**File:** `Broiler.Dom.Html/HtmlSerializer.cs`

The `HtmlSerializer.Append` method recursed once per DOM level, causing a stack overflow on legitimately deep trees (e.g., WPT `shadow-dom/build-deep-detached-shadow-then-append-text.html` with ~2000 serialized levels). The 1024-depth cap existed only to prevent call-stack exhaustion.

- Rewrites `Append` to walk an explicit heap stack instead of recursing
- Each element pushes a deferred close-tag marker, then its children in reverse (for document-order emission)
- Output is byte-for-byte identical for ordinary trees
- Raises `MaximumDepth` default from 1024 to 100,000 (now guards heap growth/cycles, not stack frames)
- Adds `PendingNode<TNode>` struct to track work units on the heap stack

**Tests:** `HtmlSerializerIterativeTests` verifies exact output equivalence and successful serialization of 2000-level chains.

### 2. Frameset Track Overflow Prevention (Patch 0011)
**Files:** `Source/Broiler.HTML.Orchestration/Parse/DomParser.cs`, `Source/Broiler.HTML.Image/HtmlRender.cs`

A frameset track with a giant fixed or percentage length (e.g., `rows="4294967227%,*"`) was passed directly as the frame's height percentage, resolving to billions of pixels. Rasterizing the embedded document overflowed the Int32 RGBA buffer multiply in `BBitmap` allocation, crashing the entire page render.

- `ParseFramesetSpec` now scales all tracks proportionally when they exceed the frameset's area (per HTML frameset algorithm)
- Oversized fixed/percentage tracks are shrunk to fit, never overflow
- `HtmlRender.CompositeEmbeddedDocuments` guards against pathologically large embedded boxes by skipping any whose RGBA allocation would overflow Int32

### 3. CSP Style-Source Enforcement
**Files:** `src/Broiler.HtmlBridge.Core/Scripting/ContentSecurityPolicy.cs`, `src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs`, `src/Broiler.HtmlBridge.Dom/DomBridge.cs`, `src/Broiler.Cli/CaptureService.cs`, `src/Broiler.Wpt/WptTestRunner.cs`

Adds support for CSP `style-src`, `style-src-elem`, and `style-src-attr` directives to block inline styles before rendering.

- `ContentSecurityPolicy` now parses and enforces the style-source family (with fallback chain: `-elem`/`-attr` → `-src` → `default-src`)
- `AllowsInlineStyleAttribute()` and `AllowsInlineStyleElement()` methods check nonce, hash, and `'unsafe-inline'` sources
- `DomBridge.ApplyStyleContentSecurityPolicy()` strips blocked `style` attributes and removes blocked `<style>` elements from the parsed DOM
- `CaptureService` and `WptTestRunner` apply style CSP before script execution

**Tests:** `ContentSecurityPolicyTests` adds five new test cases covering `style-src-attr 'none'`, `style-src-elem 'none'`, mixed policies, and fallback behavior.

### 4. Named Element Global Collision Fix
**File:** `src/Broiler.HtmlBridge.Dom/DomBridge.cs`

Fixes a crash when a document declares a global lexical `const`/`let`/

https://claude.ai/code/session_017dKqy1wdQXANsk9S8iianU