### PR TITLE
Support CSS env() substitution and dark color-scheme canvas

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -755,6 +755,16 @@ internal abstract partial class CssBoxProperties
     public string Contain { get; set; } = "none";
 
     /// <summary>
+    /// CSS Color Adjust Module Level 1: the <c>color-scheme</c> property.
+    /// A space-separated list of the color schemes the element can render in
+    /// (<c>normal</c>, <c>light</c>, <c>dark</c>, optionally prefixed by
+    /// <c>only</c>). Used by canvas background painting (CSS Color Adjust
+    /// §2.3): when the root's used color scheme is <c>dark</c>, the canvas is
+    /// painted the UA dark backdrop colour rather than white.
+    /// </summary>
+    public string ColorScheme { get; set; } = "normal";
+
+    /// <summary>
     /// CSS Containment Module Level 2: the <c>content-visibility</c> property.
     /// Values: <c>visible</c> (default), <c>hidden</c>, <c>auto</c>.
     /// <c>hidden</c> skips the element's contents (they are not painted and are

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -141,6 +141,7 @@ internal static partial class CssUtils
             "grid-auto-columns" => cssBox.GridAutoColumns,
             "contain" => cssBox.Contain,
             "content-visibility" => cssBox.ContentVisibility,
+            "color-scheme" => cssBox.ColorScheme,
             _ => null,
         };
     }
@@ -377,6 +378,9 @@ internal static partial class CssUtils
                 break;
             case "content-visibility":
                 cssBox.ContentVisibility = value;
+                break;
+            case "color-scheme":
+                cssBox.ColorScheme = value;
                 break;
             case "columns":
                 // CSS Multi-column §3: 'columns' is a shorthand for

--- a/Broiler.Layout/Broiler.Layout/IR/ComputedStyle.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/ComputedStyle.cs
@@ -151,6 +151,14 @@ public sealed class ComputedStyle
     public string Contain { get; init; } = "none";
 
     /// <summary>
+    /// CSS Color Adjust Module Level 1: the <c>color-scheme</c> property.
+    /// Used by canvas background painting (CSS Color Adjust §2.3): when the
+    /// root's used color scheme is <c>dark</c>, the canvas is painted the UA
+    /// dark backdrop colour instead of white.
+    /// </summary>
+    public string ColorScheme { get; init; } = "normal";
+
+    /// <summary>
     /// CSS Containment Module Level 2: the <c>content-visibility</c> property.
     /// <c>hidden</c> makes the fragment builder skip the element's contents so
     /// they are not painted, while the element's own box still renders.

--- a/Broiler.Layout/Broiler.Layout/IR/ComputedStyleBuilder.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/ComputedStyleBuilder.cs
@@ -140,6 +140,7 @@ internal static class ComputedStyleBuilder
             ClipPath = box.ClipPath,
             Contain = box.Contain,
             ContentVisibility = box.ContentVisibility,
+            ColorScheme = box.ColorScheme,
             Transform = box.Transform,
 
             // Flex

--- a/patches/0015-css-env-substitution-function.patch
+++ b/patches/0015-css-env-substitution-function.patch
@@ -1,0 +1,322 @@
+From ee9cd3538b2ce088f6142eca31e243038da3dbcc Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Wed, 8 Jul 2026 15:50:16 +0000
+Subject: [PATCH] Support the CSS env() substitution function
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+env() references were never resolved: the substitution phase only
+scanned for var(), so an env() left as a literal function token reached
+the renderer (which painted background-color: env(unknown) as black) and
+@supports (background-color: env(test)) evaluated false because env(test)
+is not a valid <color>.
+
+Resolve env() alongside var() at computed-value time. A UA-defined name
+(the safe-area insets, 0px in a headless desktop context) substitutes its
+value; any other name substitutes its comma-separated fallback when one is
+present (which may itself contain var()/env()), and is otherwise invalid
+at computed-value time — the guaranteed-invalid value, which resets the
+referencing property to its initial value rather than reviving an earlier
+cascaded declaration. env() is also reported as supported declaration
+syntax by @supports.
+
+Fixes WPT css-env/at-supports, css-env/fallback-nested-var, and
+css-env/unknown-env-names-override-previous (all 0.0% pixel match).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_015HGrNqhEnwW8Q5RLGyuHiB
+---
+ Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs |  65 +++++++++
+ Broiler.CSS.Dom/CssStyleEngine.Supports.cs   |   5 +-
+ Broiler.CSS.Dom/CssStyleEngine.Values.cs     | 134 ++++++++++++++++---
+ 3 files changed, 183 insertions(+), 21 deletions(-)
+
+diff --git a/Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs b/Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs
+index 224b930..6b68d54 100644
+--- a/Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs
++++ b/Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs
+@@ -254,6 +254,71 @@ public sealed class CssStyleEngineTests
+         Assert.Equal("crimson", engine.GetComputedStyle(div).GetPropertyValue("color"));
+     }
+ 
++    [Fact]
++    public void Env_Unknown_Name_Falls_Back_To_Provided_Default()
++    {
++        var (_, _, body) = NewDocument();
++        var div = body.OwnerDocument.CreateElement("div");
++        body.AppendChild(div);
++
++        // env(test) is not a UA-defined variable, so the comma-separated fallback
++        // is substituted (WPT css-env/fallback-nested-var, with the fallback here
++        // a plain value rather than a nested var()).
++        var engine = EngineWith("div { color: env(test, crimson); }");
++
++        Assert.Equal("crimson", engine.GetComputedStyle(div).GetPropertyValue("color"));
++    }
++
++    [Fact]
++    public void Env_Unknown_Name_Resolves_Nested_Var_Fallback()
++    {
++        var (_, _, body) = NewDocument();
++        var div = body.OwnerDocument.CreateElement("div");
++        body.AppendChild(div);
++
++        // The env() fallback may itself contain a var() reference, which must be
++        // resolved (WPT css-env/fallback-nested-var).
++        var engine = EngineWith(
++            "div { --main: rgb(0, 128, 0); color: env(test, var(--main)); }");
++
++        Assert.Equal("rgb(0, 128, 0)", engine.GetComputedStyle(div).GetPropertyValue("color"));
++    }
++
++    [Fact]
++    public void Env_Unknown_Name_Without_Fallback_Is_Invalid_And_Overrides_Previous()
++    {
++        var (_, _, body) = NewDocument();
++        var div = body.OwnerDocument.CreateElement("div");
++        body.AppendChild(div);
++
++        // An unknown env() with no fallback is invalid at computed-value time. The
++        // second declaration still wins the cascade over `green`, so the property
++        // resets to its initial value rather than reviving the earlier declaration
++        // (WPT css-env/unknown-env-names-override-previous).
++        var engine = EngineWith(
++            "div { background-color: green; background-color: env(unknown); }");
++
++        var bg = engine.GetComputedStyle(div).GetPropertyValue("background-color");
++        Assert.DoesNotContain("green", bg);
++        Assert.DoesNotContain("env(", bg);
++    }
++
++    [Fact]
++    public void Env_Reference_Is_A_Supported_Feature_Query()
++    {
++        var (_, _, body) = NewDocument();
++        var div = body.OwnerDocument.CreateElement("div");
++        body.AppendChild(div);
++
++        // @supports (property: env(name)) is true: env() is valid declaration
++        // syntax regardless of whether the name resolves, so the guarded rule
++        // applies (WPT css-env/at-supports).
++        var engine = EngineWith(
++            "@supports (background-color: env(test)) { div { color: rgb(0, 128, 0); } }");
++
++        Assert.Equal("rgb(0, 128, 0)", engine.GetComputedStyle(div).GetPropertyValue("color"));
++    }
++
+     [Fact]
+     public void Cyclic_Custom_Properties_Resolve_To_Invalid_Without_Exhausting_Memory()
+     {
+diff --git a/Broiler.CSS.Dom/CssStyleEngine.Supports.cs b/Broiler.CSS.Dom/CssStyleEngine.Supports.cs
+index 7945470..98ab77e 100644
+--- a/Broiler.CSS.Dom/CssStyleEngine.Supports.cs
++++ b/Broiler.CSS.Dom/CssStyleEngine.Supports.cs
+@@ -42,7 +42,10 @@ public sealed partial class CssStyleEngine
+         // supported declaration per CSS Properties & Values.
+         if (property.StartsWith("--", StringComparison.Ordinal))
+             return true;
+-        if (value.Contains("var(", StringComparison.OrdinalIgnoreCase))
++        // var()/env() substitution functions are always valid declaration syntax;
++        // whether they resolve is a computed-value-time question @supports does not ask.
++        if (value.Contains("var(", StringComparison.OrdinalIgnoreCase)
++            || value.Contains("env(", StringComparison.OrdinalIgnoreCase))
+             return true;
+ 
+         if (!IsKnownCssProperty(property))
+diff --git a/Broiler.CSS.Dom/CssStyleEngine.Values.cs b/Broiler.CSS.Dom/CssStyleEngine.Values.cs
+index 5aca0d0..7bde368 100644
+--- a/Broiler.CSS.Dom/CssStyleEngine.Values.cs
++++ b/Broiler.CSS.Dom/CssStyleEngine.Values.cs
+@@ -91,7 +91,7 @@ public sealed partial class CssStyleEngine
+ 
+             if (!computed.TryGetValue(key, out var value)
+                 || string.IsNullOrEmpty(value)
+-                || value.IndexOf("var(", StringComparison.OrdinalIgnoreCase) < 0)
++                || !ContainsSubstitutionFunction(value))
+             {
+                 continue;
+             }
+@@ -112,7 +112,7 @@ public sealed partial class CssStyleEngine
+     {
+         if (string.IsNullOrEmpty(value)
+             || depth >= 8
+-            || value.IndexOf("var(", StringComparison.OrdinalIgnoreCase) < 0)
++            || !ContainsSubstitutionFunction(value))
+         {
+             return value;
+         }
+@@ -123,24 +123,31 @@ public sealed partial class CssStyleEngine
+ 
+         while (position < value.Length)
+         {
+-            int varIndex = value.IndexOf("var(", position, StringComparison.OrdinalIgnoreCase);
+-            if (varIndex < 0)
++            int fnIndex = FindNextSubstitutionFunction(value, position, out bool isEnv);
++            if (fnIndex < 0)
+             {
+                 sb.Append(value, position, value.Length - position);
+                 break;
+             }
+ 
+-            sb.Append(value, position, varIndex - position);
++            sb.Append(value, position, fnIndex - position);
+ 
+-            int openParenIndex = varIndex + 3;
++            // Both "var(" and "env(" carry a 3-character name before the '('.
++            int openParenIndex = fnIndex + 3;
+             int closeParenIndex = FindMatchingClosingParen(value, openParenIndex);
+             if (closeParenIndex < 0)
+             {
+                 string inner = value[(openParenIndex + 1)..];
+-                string recovered = ResolveVarFunction(inner, computed, depth + 1, visiting);
+-                if (recovered == $"var({inner})")
++                string recovered = isEnv
++                    ? ResolveEnvFunction(inner, computed, depth + 1, visiting)
++                    : ResolveVarFunction(inner, computed, depth + 1, visiting);
++                if (recovered == $"{(isEnv ? "env" : "var")}({inner})")
+                 {
+-                    sb.Append(value, varIndex, value.Length - varIndex);
++                    sb.Append(value, fnIndex, value.Length - fnIndex);
++                }
++                else if (recovered == CustomPropertyInvalidMarker)
++                {
++                    return CustomPropertyInvalidMarker;
+                 }
+                 else
+                 {
+@@ -150,16 +157,16 @@ public sealed partial class CssStyleEngine
+                 break;
+             }
+ 
+-            string varFunction = value.Substring(varIndex, closeParenIndex - varIndex + 1);
+-            string replacement = ResolveVarFunction(
+-                value.Substring(openParenIndex + 1, closeParenIndex - openParenIndex - 1),
+-                computed,
+-                depth + 1,
+-                visiting);
++            string function = value.Substring(fnIndex, closeParenIndex - fnIndex + 1);
++            string functionInner =
++                value.Substring(openParenIndex + 1, closeParenIndex - openParenIndex - 1);
++            string replacement = isEnv
++                ? ResolveEnvFunction(functionInner, computed, depth + 1, visiting)
++                : ResolveVarFunction(functionInner, computed, depth + 1, visiting);
+ 
+-            if (replacement == varFunction)
++            if (replacement == function)
+             {
+-                sb.Append(varFunction);
++                sb.Append(function);
+             }
+             else if (replacement == CustomPropertyInvalidMarker)
+             {
+@@ -240,6 +247,93 @@ public sealed partial class CssStyleEngine
+         return $"var({inner})";
+     }
+ 
++    // ---- env() resolution --------------------------------------------------
++
++    // True when the value contains a var() or env() substitution function whose
++    // resolution has been deferred to computed-value time.
++    private static bool ContainsSubstitutionFunction(string value) =>
++        value.IndexOf("var(", StringComparison.OrdinalIgnoreCase) >= 0
++        || value.IndexOf("env(", StringComparison.OrdinalIgnoreCase) >= 0;
++
++    // Index of the earliest var()/env() function at or after <paramref name="start"/>,
++    // or -1 if neither occurs. <paramref name="isEnv"/> reports which one won.
++    private static int FindNextSubstitutionFunction(string value, int start, out bool isEnv)
++    {
++        int varIndex = value.IndexOf("var(", start, StringComparison.OrdinalIgnoreCase);
++        int envIndex = value.IndexOf("env(", start, StringComparison.OrdinalIgnoreCase);
++
++        if (envIndex >= 0 && (varIndex < 0 || envIndex < varIndex))
++        {
++            isEnv = true;
++            return envIndex;
++        }
++
++        isEnv = false;
++        return varIndex;
++    }
++
++    // Resolves an env() reference (CSS Environment Variables §env). Broiler models
++    // the UA-defined variables that have a fixed value in a headless desktop
++    // context (the safe-area insets, which are 0px with no notch); any other name
++    // is unknown. An unknown env() substitutes its comma-separated fallback when
++    // one is present (which may itself contain var()/env()), and is otherwise
++    // invalid at computed-value time — the guaranteed-invalid value, which resets
++    // the referencing property to its initial value rather than reviving an
++    // earlier cascaded declaration.
++    private static string ResolveEnvFunction(
++        string inner,
++        Dictionary<string, string> computed,
++        int depth,
++        HashSet<string>? visiting = null)
++    {
++        string nameSpec = inner.Trim();
++        string fallback = string.Empty;
++        bool hasFallback = false;
++
++        int commaIndex = FindTopLevelChar(inner, ',');
++        if (commaIndex >= 0)
++        {
++            nameSpec = inner[..commaIndex].Trim();
++            fallback = inner[(commaIndex + 1)..].Trim();
++            hasFallback = true;
++        }
++
++        // A dimensional env() name may carry integer indices
++        // (e.g. env(viewport-segment-width 0 0)); the leading identifier names it.
++        string name = nameSpec;
++        int firstWhitespace = nameSpec.IndexOfAny(new[] { ' ', '\t', '\n', '\r', '\f' });
++        if (firstWhitespace >= 0)
++            name = nameSpec[..firstWhitespace];
++
++        if (TryGetUaEnvironmentValue(name, out var uaValue))
++            return uaValue;
++
++        if (hasFallback)
++            return ResolveKnownCustomProperties(fallback, computed, depth, visiting);
++
++        return CustomPropertyInvalidMarker;
++    }
++
++    private static bool TryGetUaEnvironmentValue(string name, out string value)
++    {
++        switch (name.ToLowerInvariant())
++        {
++            case "safe-area-inset-top":
++            case "safe-area-inset-right":
++            case "safe-area-inset-bottom":
++            case "safe-area-inset-left":
++            case "safe-area-max-inset-top":
++            case "safe-area-max-inset-right":
++            case "safe-area-max-inset-bottom":
++            case "safe-area-max-inset-left":
++                value = "0px";
++                return true;
++            default:
++                value = string.Empty;
++                return false;
++        }
++    }
++
+     private static int FindMatchingClosingParen(string value, int openParenIndex)
+     {
+         int depth = 0;
+@@ -295,9 +389,9 @@ public sealed partial class CssStyleEngine
+         if (v is "inherit" or "initial" or "unset" or "revert")
+             return true;
+ 
+-        // Custom-property references are validated after substitution, not during
+-        // raw cascade, so keep them for the later var() resolution step.
+-        if (v.Contains("var(", StringComparison.OrdinalIgnoreCase))
++        // Custom-property references and env() are validated after substitution,
++        // not during raw cascade, so keep them for the later resolution step.
++        if (ContainsSubstitutionFunction(v))
+             return true;
+ 
+         switch (property.ToLowerInvariant())
+-- 
+2.43.0
+

--- a/patches/0016-css-color-scheme-dark-canvas.patch
+++ b/patches/0016-css-color-scheme-dark-canvas.patch
@@ -1,0 +1,153 @@
+From 648dd8fbfd47c1382df11013a14aedd453305425 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Wed, 8 Jul 2026 16:30:59 +0000
+Subject: [PATCH] Paint the canvas dark for a dark used color-scheme
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CSS Color Adjust §2.3: when the document root element's used color scheme
+is dark, the UA paints the canvas backdrop the dark colour (rgb(18,18,18))
+instead of white. Broiler ignored color-scheme, so a page with
+:root { color-scheme: dark } and no background rendered a white canvas
+where Chromium renders dark.
+
+Both canvas-background code paths now emit the dark backdrop when the
+root's used color scheme is dark (the color-scheme list offers dark but
+not light, against the reference environment's light preference):
+- PaintWalker.EmitCanvasBackground (Fragment/IR paint path) adds a dark
+  FillRect as the bottom layer.
+- HtmlContainerInt.GetRootBackgroundColor (HtmlContainer paint path)
+  returns the dark colour when nothing else propagates.
+A propagated root/body background still paints over it, so an explicit
+background wins; a fully-transparent root and body leave the dark backdrop
+showing.
+
+Reads ComputedStyle.ColorScheme / CssBox.ColorScheme, plumbed through
+Broiler.Layout.
+
+Fixes WPT css-color-adjust/rendering/dark-color-scheme
+color-scheme-root-background and
+color-scheme-color-initial-affected-by-color-scheme-property (0.0% match).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_015HGrNqhEnwW8Q5RLGyuHiB
+---
+ .../HtmlContainerInt.cs                       | 33 +++++++++++++
+ .../IR/PaintWalker.CanvasBackground.cs        | 46 +++++++++++++++++++
+ 2 files changed, 79 insertions(+)
+
+diff --git a/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs b/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
+index 6c5a19f..2e61375 100644
+--- a/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
++++ b/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
+@@ -195,9 +195,42 @@ public sealed class HtmlContainerInt : IHtmlContainerInt, IDisposable
+             }
+         }
+ 
++        // CSS Color Adjust §2.3: when the root's used color scheme is dark and no
++        // background propagated, the default canvas backdrop is the UA dark colour
++        // (rgb(18,18,18)) instead of white. Mirrors PaintWalker.EmitCanvasBackground.
++        if (htmlBox != null && UsesDarkColorScheme(htmlBox.ColorScheme))
++            return CanvasDarkBackdrop;
++
+         return BColor.Empty;
+     }
+ 
++    // CSS Color Adjust §2.3: the UA dark canvas backdrop colour Chromium paints
++    // for a dark used color scheme.
++    private static readonly BColor CanvasDarkBackdrop = BColor.FromArgb(255, 18, 18, 18);
++
++    /// <summary>
++    /// CSS Color Adjust §2.2–2.3: whether a <c>color-scheme</c> value resolves to
++    /// a dark used scheme against the reference environment's light preference —
++    /// i.e. the list offers <c>dark</c> but not <c>light</c> (a matching preferred
++    /// scheme, when present, wins). The <c>only</c> keyword does not change this.
++    /// </summary>
++    private static bool UsesDarkColorScheme(string? colorScheme)
++    {
++        if (string.IsNullOrWhiteSpace(colorScheme))
++            return false;
++
++        bool hasDark = false, hasLight = false;
++        foreach (var token in colorScheme.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
++        {
++            if (token.Equals("dark", StringComparison.OrdinalIgnoreCase))
++                hasDark = true;
++            else if (token.Equals("light", StringComparison.OrdinalIgnoreCase))
++                hasLight = true;
++        }
++
++        return hasDark && !hasLight;
++    }
++
+     private static CssBox? FindBodyBox(CssBox parent, int depth = 0)
+     {
+         if (depth > 3)
+diff --git a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs
+index 7ad7de5..a236057 100644
+--- a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs
++++ b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs
+@@ -44,6 +44,14 @@ internal static partial class PaintWalker
+     /// </summary>
+     private static Fragment? EmitCanvasBackground(Fragment root, RectangleF viewport, List<DisplayItem> items)
+     {
++        // CSS Color Adjust §2.3: when the document root's used color scheme is
++        // dark, the canvas is painted the UA dark backdrop colour instead of
++        // white. Emit it as the bottom layer so a propagated root/body
++        // background (found below) paints over it; a fully-transparent root and
++        // body leave the dark backdrop showing.
++        if (RootUsesDarkColorScheme(root))
++            items.Add(new FillRectItem { Bounds = viewport, Color = DarkCanvasColor });
++
+         // Find which element supplies the canvas background (color + image
+         // as a unit, per CSS2.1 §14.2).
+         var (canvasBg, colorSource, imgSource) = FindCanvasBackgroundAndImage(root);
+@@ -257,6 +265,44 @@ internal static partial class PaintWalker
+         return (BColor.Empty, null, null);
+     }
+ 
++    // CSS Color Adjust §2.3: the UA-defined dark canvas backdrop colour that
++    // Chromium paints for a dark used color scheme (rgb(18, 18, 18)).
++    private static readonly BColor DarkCanvasColor = BColor.FromArgb(255, 18, 18, 18);
++
++    /// <summary>
++    /// CSS Color Adjust §2.2–2.3: whether the document root element's used
++    /// color scheme is <c>dark</c>, which makes the canvas backdrop dark.
++    /// <para>
++    /// The reference environment prefers a <em>light</em> color scheme
++    /// (Playwright's default). The used scheme is the preferred one when the
++    /// element's <c>color-scheme</c> list includes it; otherwise the first
++    /// supported scheme in the list is used. So the canvas is dark exactly when
++    /// the list offers <c>dark</c> but not <c>light</c>. The <c>only</c> keyword
++    /// does not change this here (it forbids a UA override we do not perform).
++    /// </para>
++    /// </summary>
++    private static bool RootUsesDarkColorScheme(Fragment root)
++    {
++        // color-scheme governing the canvas is the document root element's
++        // (html). `root` may be the html fragment itself or a synthetic parent.
++        var html = FindFragmentByTag(root, "html") ?? FindFirstBlockChild(root) ?? root;
++
++        var scheme = html.Style.ColorScheme;
++        if (string.IsNullOrWhiteSpace(scheme))
++            return false;
++
++        bool hasDark = false, hasLight = false;
++        foreach (var token in scheme.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
++        {
++            if (token.Equals("dark", StringComparison.OrdinalIgnoreCase))
++                hasDark = true;
++            else if (token.Equals("light", StringComparison.OrdinalIgnoreCase))
++                hasLight = true;
++        }
++
++        return hasDark && !hasLight;
++    }
++
+     /// <summary>
+     /// Returns <see langword="true"/> when the given fragment's CSS properties
+     /// suppress background propagation to the canvas.  Per the CSS
+-- 
+2.43.0
+

--- a/patches/0017-css-bare-pseudo-element-universal.patch
+++ b/patches/0017-css-bare-pseudo-element-universal.patch
@@ -1,0 +1,93 @@
+From fcab2d46a3999b69117689234265025d42a10736 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Wed, 8 Jul 2026 17:07:54 +0000
+Subject: [PATCH] Match a bare ::backdrop (and other bare pseudo-elements) as
+ universal
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+TryStripPseudoElementSelector rejected a pseudo-element selector whose base
+compound was empty — a bare `::backdrop { … }` (equivalently `*::backdrop`)
+returned false and its declarations were dropped. Only qualified forms
+(`dialog::backdrop`, `.foo::backdrop`) matched, so an author bare
+`::backdrop { background: green }` fell back to the UA default.
+
+Treat an empty base selector as the universal `*` in both the `::` and the
+legacy single-colon branch, matching the pseudo-element of any originating
+element.
+
+Fixes bare ::backdrop rules used by WPT css-position tests; guarded by
+GetCascadedStyle_Matches_Bare_Pseudo_Element_As_Universal.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_015HGrNqhEnwW8Q5RLGyuHiB
+---
+ Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs | 20 ++++++++++++++++++++
+ Broiler.CSS.Dom/CssStyleEngine.cs            | 12 ++++++++++--
+ 2 files changed, 30 insertions(+), 2 deletions(-)
+
+diff --git a/Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs b/Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs
+index 224b930..e46dc76 100644
+--- a/Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs
++++ b/Broiler.CSS.Dom.Tests/CssStyleEngineTests.cs
+@@ -710,6 +710,26 @@ public sealed class CssStyleEngineTests
+         Assert.Equal("blue", cascaded["color"]);
+     }
+ 
++    [Theory]
++    [InlineData("::backdrop")]
++    [InlineData("::before")]
++    [InlineData("::marker")]
++    public void GetCascadedStyle_Matches_Bare_Pseudo_Element_As_Universal(string pseudoElement)
++    {
++        // A bare pseudo-element selector (e.g. `::backdrop { … }`) is equivalent
++        // to `*::backdrop` and must match the pseudo-element of any element. The
++        // empty base selector was previously rejected, so author `::backdrop`
++        // rules (WPT css-position replaced-object-backdrop) were dropped.
++        var (_, _, body) = NewDocument();
++        var div = body.OwnerDocument.CreateElement("div");
++        body.AppendChild(div);
++
++        var engine = EngineWith($"{pseudoElement} {{ color: blue; }}");
++        var cascaded = engine.GetCascadedStyle(div, pseudoElement);
++
++        Assert.Equal("blue", cascaded["color"]);
++    }
++
+     [Fact]
+     public void GetCascadedStyle_Expands_MultiValue_Pseudo_Element_Borders()
+     {
+diff --git a/Broiler.CSS.Dom/CssStyleEngine.cs b/Broiler.CSS.Dom/CssStyleEngine.cs
+index fef4833..f747153 100644
+--- a/Broiler.CSS.Dom/CssStyleEngine.cs
++++ b/Broiler.CSS.Dom/CssStyleEngine.cs
+@@ -685,7 +685,13 @@ public sealed partial class CssStyleEngine
+                 return false;
+ 
+             baseSelector = selector[..doubleColonIndex].TrimEnd();
+-            return baseSelector.Length > 0;
++            // A bare pseudo-element selector (e.g. `::backdrop`) has an empty base
++            // and is equivalent to `*::backdrop`: it targets the pseudo-element of
++            // any originating element. Match it as the universal selector rather
++            // than rejecting it (which dropped author `::backdrop { … }` rules).
++            if (baseSelector.Length == 0)
++                baseSelector = "*";
++            return true;
+         }
+ 
+         var singleColonSuffix = ":" + normalized;
+@@ -693,7 +699,9 @@ public sealed partial class CssStyleEngine
+             return false;
+ 
+         baseSelector = selector[..^singleColonSuffix.Length].TrimEnd();
+-        return baseSelector.Length > 0;
++        if (baseSelector.Length == 0)
++            baseSelector = "*";
++        return true;
+     }
+ 
+     private static bool IsPropertyAllowedForPseudoElement(string? pseudoElement, string propertyName) =>
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -21,6 +21,53 @@ cd .. && git add <Submodule> && git commit -m "Bump <Submodule>: <summary>"
 
 ## Index
 
+- **0016-css-color-scheme-dark-canvas.patch** → `Broiler.HTML`
+  (`Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs` and
+  `Broiler.HTML.Orchestration/HtmlContainerInt.cs`) — fixes two of the
+  `css-color-adjust` dark-color-scheme "biggest problems" (issue #1311:
+  `color-scheme-root-background` and
+  `color-scheme-color-initial-affected-by-color-scheme-property`, both 0% match).
+  CSS Color Adjust §2.3: when the document root element's used color scheme is
+  dark, the UA paints the canvas backdrop the dark colour (rgb(18, 18, 18))
+  rather than white. Broiler ignored `color-scheme`, so `:root { color-scheme:
+  dark }` with no background rendered a white canvas where Chromium renders dark.
+  Both canvas-background paths now emit the dark backdrop when the root's used
+  scheme is dark (the `color-scheme` list offers `dark` but not `light`, against
+  the reference environment's light preference): `PaintWalker.EmitCanvasBackground`
+  (the Fragment/IR paint path, which the WPT runner uses) adds a dark bottom
+  layer, and `HtmlContainerInt.GetRootBackgroundColor` (the HtmlContainer paint
+  path, which `HtmlRender.RenderToImageWithStyleSet` uses) returns the dark
+  colour when nothing else propagates. A propagated root/body background still
+  paints over it, and a fully-transparent root/body leaves the dark backdrop
+  showing. This consumes the new `ComputedStyle.ColorScheme`, plumbed through
+  `Broiler.Layout` (main repo: `CssBoxProperties`, `CssUtils`, `ComputedStyle`,
+  `ComputedStyleBuilder`). The second test also needed a main-repo WPT-runner
+  alignment (committed to the main repo, active immediately): the `test()`
+  testharness stub no longer runs its body — the reference generator never loads
+  testharness, so `test` is undefined there and the bodies (one of which toggles
+  a class that flips `color-scheme`) never run before the screenshot; running
+  them advanced Broiler's captured DOM past the reference point.
+  **Active CI fallback — none.** Canvas painting lives in the `Broiler.HTML`
+  orchestration layer, consumed by the parent as compiled submodule source with
+  no interception point (like patches 0008–0015). It activates on CI when this
+  patch is applied and the `Broiler.HTML` pointer is bumped; the pointer is
+  intentionally left unbumped (the change is committed to the submodule locally
+  only, unpushed because `MaiRat/Broiler.HTML` is outside session scope). The
+  `Broiler.Layout` plumbing and the runner stub change are in the main repo and
+  active immediately. Pixel-guard tests
+  (`Root_Color_Scheme_Dark_Paints_Dark_Canvas`,
+  `Root_Color_Scheme_Light_Keeps_White_Canvas`,
+  `Root_Color_Scheme_Dark_With_Background_Uses_Background`, written against
+  `HtmlRender.RenderToImageWithStyleSet` in `RootBackgroundTests`) are held back
+  from the main repo until the pointer is bumped — they assert the dark canvas,
+  which the pinned (unpatched) submodule does not yet paint, so committing them
+  now would red the main-repo suite on CI; apply them alongside the patch.
+  Verified end-to-end via `--render`: both tests render the dark canvas
+  rgb(18, 18, 18), matching the Chromium references generated with a light OS
+  preference; they were white before. A full run of the committed WPT suite
+  showed an identical 35-test failure set before and after the whole change (no
+  regressions).
+
 - **0015-css-env-substitution-function.patch** → `Broiler.CSS`
   (`Broiler.CSS.Dom/CssStyleEngine.Values.cs`,
   `Broiler.CSS.Dom/CssStyleEngine.Supports.cs`, plus tests) — fixes the

--- a/patches/README.md
+++ b/patches/README.md
@@ -21,6 +21,27 @@ cd .. && git add <Submodule> && git commit -m "Bump <Submodule>: <summary>"
 
 ## Index
 
+- **0017-css-bare-pseudo-element-universal.patch** → `Broiler.CSS`
+  (`Broiler.CSS.Dom/CssStyleEngine.cs`, plus a test) — a correctness fix that
+  accompanies the popover/`::backdrop` work for the css-position overlay cluster
+  (issue #1311). `TryStripPseudoElementSelector` rejected a pseudo-element
+  selector whose base compound was empty: a bare `::backdrop { … }` (equivalently
+  `*::backdrop`) returned false and its declarations were dropped, so only
+  qualified forms (`dialog::backdrop`, `.foo::backdrop`) matched. The patch
+  treats an empty base as the universal `*`, so a bare `::backdrop`/`::before`/…
+  rule matches the pseudo-element of any element. Guard:
+  `GetCascadedStyle_Matches_Bare_Pseudo_Element_As_Universal` in
+  `CssStyleEngineTests`. **Not required for the four overlay tests that are fixed
+  now** — `overlay-transition-backdrop`, `overlay-transition-finished`,
+  `overlay-transition-out-rendering`, and `replaced-object-backdrop` all use
+  *qualified* `::backdrop` selectors, which the pinned `Broiler.CSS` already
+  matches, so they render green on CI from the main-repo popover support alone.
+  This patch additionally makes bare `::backdrop` (and other bare pseudo-element)
+  rules work once applied and the `Broiler.CSS` pointer is bumped; the pointer is
+  intentionally left unbumped (unpushed — `MaiRat/Broiler.CSS` is outside session
+  scope, 403). **Active CI fallback — none needed** (the qualified-selector path
+  the overlay tests use already works).
+
 - **0016-css-color-scheme-dark-canvas.patch** → `Broiler.HTML`
   (`Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs` and
   `Broiler.HTML.Orchestration/HtmlContainerInt.cs`) — fixes two of the

--- a/patches/README.md
+++ b/patches/README.md
@@ -21,6 +21,38 @@ cd .. && git add <Submodule> && git commit -m "Bump <Submodule>: <summary>"
 
 ## Index
 
+- **0015-css-env-substitution-function.patch** → `Broiler.CSS`
+  (`Broiler.CSS.Dom/CssStyleEngine.Values.cs`,
+  `Broiler.CSS.Dom/CssStyleEngine.Supports.cs`, plus tests) — fixes the
+  `css-env/*` "biggest problems" cluster (issue #1311: `at-supports.tentative`,
+  `fallback-nested-var.tentative`, `unknown-env-names-override-previous.tentative`,
+  all at 0% match). The `env()` substitution function was never resolved: the
+  computed-value substitution phase scanned only for `var(`, so an `env()` left
+  as a literal function token reached the renderer (which painted
+  `background-color: env(unknown)` as black instead of leaving it invalid), and
+  `@supports (background-color: env(test))` evaluated false because `env(test)`
+  is not a valid `<color>`. The patch resolves `env()` alongside `var()` (CSS
+  Environment Variables §env): a UA-defined name (the safe-area insets, `0px` in
+  a headless desktop context) substitutes its value; any other name substitutes
+  its comma-separated fallback when present (which may itself contain
+  `var()`/`env()`), and is otherwise invalid at computed-value time — the
+  guaranteed-invalid value, which resets the referencing property to its initial
+  value rather than reviving an earlier cascaded declaration. `env()` is also
+  reported as supported declaration syntax by `@supports`. Guards:
+  `Env_Unknown_Name_Falls_Back_To_Provided_Default`,
+  `Env_Unknown_Name_Resolves_Nested_Var_Fallback`,
+  `Env_Unknown_Name_Without_Fallback_Is_Invalid_And_Overrides_Previous`, and
+  `Env_Reference_Is_A_Supported_Feature_Query` in `CssStyleEngineTests`.
+  **Active CI fallback — none.** `env()`/`var()` substitution lives entirely in
+  the `Broiler.CSS` computed-value layer, which the parent repo consumes as
+  compiled submodule source with no main-repo interception point (like patches
+  0008–0014). It activates on CI when this patch is applied and the `Broiler.CSS`
+  pointer is bumped; the pointer is intentionally left unbumped (the change is
+  committed to the submodule locally only, unpushed because `MaiRat/Broiler.CSS`
+  is outside session scope). Verified end-to-end via `--render`: the three tests
+  render green, green, and white (transparent → white canvas) respectively,
+  matching the Chromium references; they were white, black, and black before.
+
 - **0014-broiler-html-display-contents-root-canvas-background.patch** →
   `Broiler.HTML` (`Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs`,
   `Broiler.HTML.Orchestration/HtmlContainerInt.cs`) — fixes the

--- a/src/Broiler.Cli.Tests/ScriptEngineExecuteTests.cs
+++ b/src/Broiler.Cli.Tests/ScriptEngineExecuteTests.cs
@@ -1186,6 +1186,84 @@ document.getElementById('out').appendChild(p);
     }
 
     [Fact]
+    public void DomBridge_Popover_ShowPopover_Promotes_To_Top_Layer_With_Backdrop()
+    {
+        // HTML §popover: showPopover() puts the element in the top layer, so it
+        // is elevated above ordinary content (synthetic z-index) and generates a
+        // ::backdrop honouring the author `background-color` (WPT css-position
+        // overlay-transition-backdrop / replaced-object-backdrop).
+        const string html = """
+<!DOCTYPE html>
+<html><head><style>
+  [popover]::backdrop { background-color: rgb(1, 200, 3); }
+</style></head>
+<body><div id="pop" popover></div></body></html>
+""";
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///test.html");
+        context.Eval("document.getElementById('pop').showPopover();");
+        bridge.ResolveAnchorPositions();
+
+        var result = bridge.SerializeToHtml();
+
+        // The popover is elevated into the synthetic top layer.
+        Assert.Contains("z-index: 2000000", result);
+        // A ::backdrop div was synthesized carrying the author background.
+        Assert.Contains("background-color: rgb(1, 200, 3)", result);
+    }
+
+    [Fact]
+    public void DomBridge_Popover_HidePopover_Removes_Top_Layer_Promotion()
+    {
+        const string html = """
+<!DOCTYPE html>
+<html><head><style>
+  [popover]::backdrop { background-color: rgb(1, 200, 3); }
+</style></head>
+<body><div id="pop" popover></div></body></html>
+""";
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///test.html");
+        // Shown then hidden with no overlay transition → leaves the top layer.
+        context.Eval("var p = document.getElementById('pop'); p.showPopover(); p.hidePopover();");
+        bridge.ResolveAnchorPositions();
+
+        var result = bridge.SerializeToHtml();
+
+        Assert.DoesNotContain("z-index: 2000000", result);
+    }
+
+    [Fact]
+    public void DomBridge_Popover_HidePopover_With_Overlay_Transition_Stays_In_Top_Layer()
+    {
+        // CSS Position §overlay: hiding while `overlay` transitions out with
+        // transition-behavior: allow-discrete keeps the popover in the top layer
+        // as it animates. A static snapshot is taken mid-transition, so it must
+        // still render (WPT overlay-transition-backdrop / -out-rendering).
+        const string html = """
+<!DOCTYPE html>
+<html><head><style>
+  [popover] {
+    transition: overlay 60s step-end;
+    transition-behavior: allow-discrete;
+  }
+</style></head>
+<body><div id="pop" popover></div></body></html>
+""";
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///test.html");
+        context.Eval("var p = document.getElementById('pop'); p.showPopover(); p.hidePopover();");
+        bridge.ResolveAnchorPositions();
+
+        var result = bridge.SerializeToHtml();
+
+        Assert.Contains("z-index: 2000000", result);
+    }
+
+    [Fact]
     public void DomBridge_SerializeToHtml_Preserves_Mutated_Iframe_Scroll_State_In_SrcDoc()
     {
         const string html = """

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -25,6 +25,7 @@ public sealed partial class DomBridge
         // 0. Apply UA default position:fixed to modal dialogs before anchor
         //    resolution, since browsers treat top-layer elements as fixed.
         ApplyDialogUAPositioning(DocumentElement);
+        ApplyPopoverUAPositioning(DocumentElement);
 
         // 1. Build an anchor registry from CSS rules with anchor-name.
         var anchorRegistry = new Dictionary<string, AnchorInfo>(StringComparer.Ordinal);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
@@ -37,6 +37,50 @@ public sealed partial class DomBridge
             el.Style["position"] = "fixed";
         }
     }
+
+    /// <summary>
+    /// Applies UA top-layer positioning to open popovers (HTML §popover): a
+    /// popover is laid out in the top layer as a fixed-position box, so give one
+    /// with no explicit position <c>position: fixed</c> anchored at the viewport
+    /// origin. Later-shown popovers keep their source order, so they paint over
+    /// earlier ones — matching the top-layer stacking these overlay tests probe.
+    /// </summary>
+    // Base z-index for the synthetic top layer. The real top layer sits above
+    // every painted stacking context (CSS Position §top-layer); Broiler has no
+    // dedicated top-layer paint pass, so approximate it with a very large
+    // z-index offset by each element's top-layer order, keeping open popovers
+    // above ordinary positioned content and correctly ordered amongst themselves
+    // (a later-shown popover paints over an earlier one). Kept below int.MaxValue
+    // so the counter has headroom.
+    private const int TopLayerZIndexBase = 2_000_000_000;
+
+    private void ApplyPopoverUAPositioning(DomElement root)
+    {
+        foreach (var el in Elements)
+        {
+            if (!(GetElementRuntimeState(el).Dialog.PopoverOpen.TryGet(out var open) && open is true))
+                continue;
+
+            var props = GetComputedProps(el);
+            bool alreadyPositioned = props.TryGetValue("position", out var pos) &&
+                (pos == "fixed" || pos == "absolute");
+
+            if (!alreadyPositioned)
+            {
+                el.Style["position"] = "fixed";
+                if (!el.Style.ContainsKey("top") && !props.ContainsKey("top"))
+                    el.Style["top"] = "0";
+                if (!el.Style.ContainsKey("left") && !props.ContainsKey("left"))
+                    el.Style["left"] = "0";
+            }
+
+            // Elevate into the synthetic top layer, ordered by show order, so the
+            // popover paints above non-top-layer content (e.g. a plain
+            // position:fixed sibling) and later popovers paint over earlier ones.
+            int order = GetElementRuntimeState(el).Dialog.TopLayerOrder.TryGet(out var o) && o is int oi ? oi : 0;
+            el.Style["z-index"] = (TopLayerZIndexBase + order).ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+    }
     // -----------------------------------------------------------------
     // Dialog backdrop insertion
     // -----------------------------------------------------------------
@@ -46,15 +90,20 @@ public sealed partial class DomBridge
         Dictionary<string, AnchorInfo> anchorRegistry,
         Dictionary<string, Dictionary<string, string>> positionTryRules)
     {
-        var modals = new List<(DomElement dialog, DomElement parent)>();
+        var modals = new List<(DomElement dialog, DomElement parent, bool isPopover)>();
         FindModalDialogs(root, modals);
+        FindOpenPopovers(root, modals);
 
-        foreach (var (dialog, parent) in modals)
+        foreach (var (dialog, parent, isPopover) in modals)
         {
-            // Collect ::backdrop CSS properties for this dialog element.
-            // Look for selectors ending with "::backdrop" that would match
-            // the dialog (e.g. "dialog::backdrop", "#target::backdrop").
-            var backdropBg = GetBackdropBackground(dialog);
+            // Collect ::backdrop CSS properties for this element. Look for
+            // selectors ending with "::backdrop" that would match it (e.g.
+            // "dialog::backdrop", "[popover]::backdrop", "#target::backdrop").
+            // A modal dialog's ::backdrop defaults to the UA dimming scrim; a
+            // popover's ::backdrop defaults to transparent (no scrim) — either
+            // is overridden by an author `background`/`background-color`.
+            var backdropBg = GetBackdropBackground(
+                dialog, isPopover ? "transparent" : "rgb(229, 229, 229)");
 
             // Insert a backdrop div BEFORE the dialog.
             // Use 'position: fixed' with explicit pixel viewport dimensions
@@ -95,6 +144,14 @@ public sealed partial class DomBridge
             {
                 ResolvePositionTryFallbacksTree(backdrop, anchorRegistry, positionTryRules);
             }
+
+            // The white-box UA defaults below (display:block, border, padding,
+            // white background) are the modal <dialog> appearance. Popovers do
+            // not share them — their box styling comes entirely from author CSS —
+            // so skip this block for popovers (their ::backdrop was still emitted
+            // above).
+            if (isPopover)
+                continue;
 
             // Ensure the dialog has UA default styles.
             // Check both inline styles and CSS rules before applying defaults.
@@ -164,11 +221,11 @@ public sealed partial class DomBridge
     /// pseudo-element by checking CSS rules for <c>::backdrop</c> selectors
     /// that match the given dialog element.
     /// </summary>
-    private string GetBackdropBackground(DomElement dialog)
+    private string GetBackdropBackground(DomElement dialog, string defaultBg = "rgb(229, 229, 229)")
     {
-        // Default backdrop color: pre-composited rgba(0,0,0,0.1) over white.
-        // Alpha-blending: 255*(1-0.1) + 0*0.1 = 229.5 ≈ 229.
-        const string defaultBg = "rgb(229, 229, 229)";
+        // Default modal-dialog backdrop color: pre-composited rgba(0,0,0,0.1) over
+        // white (255*(1-0.1) + 0*0.1 = 229.5 ≈ 229). Callers pass "transparent"
+        // for popovers, whose ::backdrop has no UA scrim.
 
         var declarations = GetSyncedScopedEngine(dialog)
             .GetCascadedDeclaredValues(dialog, "::backdrop");
@@ -223,7 +280,7 @@ public sealed partial class DomBridge
 
         return anchorOrder < targetOrder;
     }
-    private static void FindModalDialogs(DomElement element, List<(DomElement, DomElement)> results)
+    private static void FindModalDialogs(DomElement element, List<(DomElement, DomElement, bool)> results)
     {
         if (string.Equals(element.TagName, "dialog", StringComparison.OrdinalIgnoreCase) &&
             element.Attributes.ContainsKey("open") &&
@@ -231,7 +288,7 @@ public sealed partial class DomBridge
             isModal is bool modal && modal &&
             element.Parent != null)
         {
-            results.Add((element, element.Parent));
+            results.Add((element, element.Parent, false));
         }
 
         // Snapshot before recursing: the live child list can be mutated mid-walk
@@ -239,5 +296,52 @@ public sealed partial class DomBridge
         // tolerates that — same idiom as the other anchor-resolver tree walks.
         foreach (var child in SnapshotChildren(element))
             FindModalDialogs(child, results);
+    }
+
+    // Popover API (HTML §popover): an element whose showPopover() ran (and whose
+    // hidePopover() did not tear it down — see PopoverKeepsOverlayOnHide) is in
+    // the top layer and generates a ::backdrop, just like a modal dialog.
+    private static void FindOpenPopovers(DomElement element, List<(DomElement, DomElement, bool)> results)
+    {
+        if (element.Parent != null &&
+            GetElementRuntimeState(element).Dialog.PopoverOpen.TryGet(out var open) &&
+            open is true)
+        {
+            results.Add((element, element.Parent, true));
+        }
+
+        foreach (var child in SnapshotChildren(element))
+            FindOpenPopovers(child, results);
+    }
+
+    // CSS Position §overlay: whether hiding this popover leaves it in the top
+    // layer because its `overlay` is being transitioned out with
+    // `transition-behavior: allow-discrete`. A static render snapshots
+    // mid-transition, so such a popover (and its ::backdrop) stays rendered.
+    private bool PopoverKeepsOverlayOnHide(DomElement element)
+    {
+        var props = GetComputedProps(element);
+
+        // allow-discrete is required for a discrete property like `overlay` to
+        // participate in a transition at all. It lives on transition-behavior;
+        // tolerate it also appearing folded into a `transition` shorthand.
+        string behavior =
+            props.GetValueOrDefault("transition-behavior", string.Empty) + " " +
+            props.GetValueOrDefault("transition", string.Empty);
+        if (behavior.IndexOf("allow-discrete", StringComparison.OrdinalIgnoreCase) < 0)
+            return false;
+
+        // The transitioned property list must include `overlay` (or `all`).
+        string transitioned =
+            props.GetValueOrDefault("transition-property", string.Empty) + " " +
+            props.GetValueOrDefault("transition", string.Empty);
+        foreach (var token in transitioned.Split(new[] { ' ', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (token.Equals("overlay", StringComparison.OrdinalIgnoreCase) ||
+                token.Equals("all", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementInterfaces.cs
@@ -230,6 +230,21 @@ public sealed partial class DomBridge
                 JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
+        // Popover API (HTML §popover) — showPopover()/hidePopover() are exposed on
+        // any element carrying the global `popover` attribute, not tied to a tag.
+        if (element.Attributes.ContainsKey("popover"))
+        {
+            obj.FastAddValue(
+                (KeyString)"showPopover",
+                new JSFunction((in Arguments _) => JsElementInterfacesShowPopoverCore(bridge, element, in _), "showPopover", 0),
+                JSPropertyAttributes.EnumerableConfigurableValue);
+
+            obj.FastAddValue(
+                (KeyString)"hidePopover",
+                new JSFunction((in Arguments _) => JsElementInterfacesHidePopoverCore(bridge, element, in _), "hidePopover", 0),
+                JSPropertyAttributes.EnumerableConfigurableValue);
+        }
+
         // HTMLSelectElement interface
         if (tag == "select")
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
@@ -68,6 +68,7 @@ internal sealed class ElementRuntimeState
         Layout.Height.CopyTo(target.Layout.Height);
         Dialog.Modal.CopyTo(target.Dialog.Modal);
         Dialog.TopLayerOrder.CopyTo(target.Dialog.TopLayerOrder);
+        Dialog.PopoverOpen.CopyTo(target.Dialog.PopoverOpen);
         Shadow.Root.CopyTo(target.Shadow.Root);
         Shadow.Host.CopyTo(target.Shadow.Host);
         Shadow.Mode.CopyTo(target.Shadow.Mode);
@@ -111,6 +112,12 @@ internal sealed class DialogRuntimeState
 {
     public RuntimeValue<bool> Modal { get; } = new();
     public RuntimeValue<int> TopLayerOrder { get; } = new();
+
+    // Popover API (HTML §popover): set by showPopover(), cleared by
+    // hidePopover() — except when an `overlay` allow-discrete transition keeps
+    // the element in the top layer as it animates out, in which case it stays
+    // set so its ::backdrop still renders for the snapshot.
+    public RuntimeValue<bool> PopoverOpen { get; } = new();
 }
 
 internal sealed class ShadowRuntimeState

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/ElementInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/ElementInterfaces.cs
@@ -324,6 +324,32 @@ public sealed partial class DomBridge
     }
 
 
+    // Popover API (HTML §popover): showPopover() promotes the element to the top
+    // layer (so its ::backdrop renders). Modeled with the same runtime flag +
+    // top-layer order the modal-dialog path uses.
+    private JSValue JsElementInterfacesShowPopoverCore(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments _)
+    {
+        GetElementRuntimeState(element).Dialog.PopoverOpen.Set(true);
+        GetElementRuntimeState(element).Dialog.TopLayerOrder.Set(++bridge._topLayerCounter);
+        bridge.InvalidateStyleScope(element);
+        return JSUndefined.Value;
+    }
+
+
+    private JSValue JsElementInterfacesHidePopoverCore(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments _)
+    {
+        // CSS Position §overlay: hiding a popover whose `overlay` is transitioned
+        // with `transition-behavior: allow-discrete` keeps it in the top layer for
+        // the duration of the transition. A static render snapshots mid-transition,
+        // so the popover (and its ::backdrop) must stay rendered — leave the flag
+        // set. Without such a transition, hidePopover() removes it immediately.
+        if (!bridge.PopoverKeepsOverlayOnHide(element))
+            GetElementRuntimeState(element).Dialog.PopoverOpen.Remove();
+        bridge.InvalidateStyleScope(element);
+        return JSUndefined.Value;
+    }
+
+
     private JSValue JsElementInterfacesClose032Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
         element.Attributes.Remove("open");

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -378,7 +378,13 @@ internal sealed class WptTestRunner
   var __broilerPromiseTests = [];
   var __broilerWindowLoaded = false;
   if (typeof test === 'undefined') {
-    window.test = function(func, name) { try { func(); } catch(e) {} };
+    // Chromium-matching mode: the reference generator does not load
+    // testharness.js, so `test` is undefined there and the test body never
+    // runs before the screenshot. Some bodies mutate the DOM (e.g. toggling a
+    // class that changes color-scheme), which would advance our captured DOM
+    // past the reference point. Leave them un-run so the snapshot reflects the
+    // initial post-load state (mirrors the promise_test stub below).
+    window.test = function(func, name) {};
   }
   if (typeof async_test === 'undefined') {
     window.async_test = function(func, name) {


### PR DESCRIPTION
## Summary

This PR adds support for the CSS `env()` substitution function and implements dark canvas background painting for elements with `color-scheme: dark`. It also includes a correctness fix for bare pseudo-element selectors and popover API support with top-layer positioning.

## Changes

### CSS env() Substitution Function (Patch 0015)
- **File:** `Broiler.CSS.Dom/CssStyleEngine.Values.cs`
- Resolves `env()` references alongside `var()` at computed-value time
- Implements UA-defined environment variables (safe-area insets, all 0px in headless desktop context)
- Unknown `env()` names substitute their comma-separated fallback (which may contain nested `var()`/`env()`)
- Unknown `env()` without fallback becomes the guaranteed-invalid value, resetting the property to initial rather than reviving earlier cascaded declarations
- `env()` is now reported as supported declaration syntax by `@supports`
- **Tests:** `Env_Unknown_Name_Falls_Back_To_Provided_Default`, `Env_Unknown_Name_Resolves_Nested_Var_Fallback`, `Env_Unknown_Name_Without_Fallback_Is_Invalid_And_Overrides_Previous`, `Env_Reference_Is_A_Supported_Feature_Query`
- **Fixes WPT:** `css-env/at-supports`, `css-env/fallback-nested-var`, `css-env/unknown-env-names-override-previous`

### Dark Color-Scheme Canvas Background (Patch 0016)
- **Files:** `Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs`, `Broiler.HTML.Orchestration/HtmlContainerInt.cs`
- Implements CSS Color Adjust §2.3: when the document root's used `color-scheme` is dark, the canvas backdrop is painted dark (rgb(18, 18, 18)) instead of white
- Detects dark color scheme when the `color-scheme` list offers `dark` but not `light` (against the reference environment's light preference)
- Both canvas-background code paths emit the dark backdrop: `PaintWalker.EmitCanvasBackground` (Fragment/IR path) and `HtmlContainerInt.GetRootBackgroundColor` (HtmlContainer path)
- Propagated root/body backgrounds still paint over the dark backdrop; fully-transparent root/body leaves it showing
- Plumbs `ComputedStyle.ColorScheme` through `Broiler.Layout` (`CssBoxProperties`, `CssUtils`, `ComputedStyle`, `ComputedStyleBuilder`)
- **Fixes WPT:** `css-color-adjust/rendering/dark-color-scheme` tests (`color-scheme-root-background`, `color-scheme-color-initial-affected-by-color-scheme-property`)

### Bare Pseudo-Element Selector Fix (Patch 0017)
- **File:** `Broiler.CSS.Dom/CssStyleEngine.cs`
- Fixes `TryStripPseudoElementSelector` to treat empty base selectors as universal (`*`)
- Bare `::backdrop`, `::before`, etc. now match the pseudo-element of any element (equivalent to `*::backdrop`)
- Previously rejected bare pseudo-element rules, so only qualified forms (`dialog::backdrop`) matched
- **Test:** `GetCascadedStyle_Matches_Bare_Pseudo_Element_As_Universal`

### Popover API Support
- **Files:** `DomBridge/AnchorResolver/Dialogs.cs`, `DomBridge/ElementInterfaces.cs`, `DomBridge/JsFunctionCallbacks/ElementInterfaces.cs`, `ElementRuntimeState.cs`
- Implements `showPopover()` and `hidePopover()` methods on elements with the `popover` attribute
- Promotes open popovers to a synthetic top layer with z-index elevation (base 2,000,000,000 + top-layer order)
- Generates `::backdrop` pseudo-element with UA default transparent (no scrim, unlike modal

https://claude.ai/code/session_015HGrNqhEnwW8Q5RLGyuHiB