### PR TITLE
HtmlBridge DOM/CSS promotion: Phases 0-4

### DIFF
--- a/Broiler.UI/samples/Linux/Broiler.UI.Linux.Demo/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Broiler.UI/samples/Linux/Broiler.UI.Linux.Demo/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net10.0\publish\linux-x64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net10.0</TargetFramework>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/Broiler.UI/samples/Win32/Broiler.UI.Win32.Demo/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Broiler.UI/samples/Win32/Broiler.UI.Win32.Demo/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net10.0-windows\publish\win-x64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+  </PropertyGroup>
+</Project>

--- a/Broiler.slnx
+++ b/Broiler.slnx
@@ -1,4 +1,4 @@
-﻿<Solution>
+<Solution>
   <Configurations>
     <BuildType Name="Debug" />
     <BuildType Name="Release" />
@@ -323,6 +323,8 @@
       <BuildType Project="Release" Solution="Release-Windows|*" />
     </Project>
   </Folder>
+  <Folder Name="/Dependencies/UI/src/" />
+  <Folder Name="/Dependencies/UI/src/Abstractions/" />
   <Folder Name="/Dependencies/UI/src/Abstractions/Commands/">
     <Project Path="Broiler.UI/src/Abstractions/Commands/Broiler.UI.Button/Broiler.UI.Button.csproj">
       <BuildType Project="Debug" Solution="Debug-Linux|*" />
@@ -467,6 +469,8 @@
       <BuildType Project="Release" Solution="Release-Windows|*" />
     </Project>
   </Folder>
+  <Folder Name="/Dependencies/UI/src/Implementations/" />
+  <Folder Name="/Dependencies/UI/src/Implementations/Standard/" />
   <Folder Name="/Dependencies/UI/src/Implementations/Standard/Commands/">
     <Project Path="Broiler.UI/src/Implementations/Standard/Commands/Broiler.UI.Button.Standard/Broiler.UI.Button.Standard.csproj">
       <BuildType Project="Debug" Solution="Debug-Linux|*" />
@@ -539,6 +543,7 @@
       <BuildType Project="Release" Solution="Release-Windows|*" />
     </Project>
   </Folder>
+  <Folder Name="/Dependencies/UI/src/Integrations/" />
   <Folder Name="/Dependencies/UI/src/Integrations/RichEdit/">
     <Project Path="Broiler.UI/src/Integrations/RichEdit/Broiler.UI.RichEdit.Rtf/Broiler.UI.RichEdit.Rtf.csproj">
       <BuildType Project="Debug" Solution="Debug-Linux|*" />
@@ -557,6 +562,8 @@
       <Build Project="false" Solution="Release-Linux|*" />
     </Project>
   </Folder>
+  <Folder Name="/Dependencies/UI/" />
+  <Folder Name="/Dependencies/UI/samples/" />
   <Folder Name="/Dependencies/UI/samples/Linux/">
     <Project Path="Broiler.UI/samples/Linux/Broiler.UI.Linux.Demo/Broiler.UI.Linux.Demo.csproj">
       <BuildType Project="Debug" Solution="Debug-Windows|*" />
@@ -591,6 +598,7 @@
       <BuildType Project="Release" Solution="Release-Windows|*" />
     </Project>
   </Folder>
+  <Folder Name="/Dependencies/UI/tests/" />
   <Folder Name="/Dependencies/UI/tests/Commands/">
     <Project Path="Broiler.UI/tests/Commands/Broiler.UI.Toolbar.Tests/Broiler.UI.Toolbar.Tests.csproj">
       <BuildType Project="Debug" Solution="Debug-Linux|*" />
@@ -936,31 +944,31 @@
       <Build Project="false" Solution="Debug|*" />
       <Build Project="false" Solution="Release|*" />
     </Project>
-  </Folder>
-  <Folder Name="/src/">
     <Project Path="src/Broiler.App.Graphics/Broiler.App.Graphics.csproj">
-      <Build Project="false" Solution="Debug|*" />
-      <Build Project="false" Solution="Release|*" />
+      <Build Solution="Debug|*" Project="false" />
+      <Build Solution="Release|*" Project="false" />
     </Project>
     <Project Path="src/Broiler.App.Tests/Broiler.App.Tests.csproj">
+      <BuildType Solution="Debug-Linux|*" Project="Debug" />
+      <BuildType Solution="Debug-Windows|*" Project="Debug" />
+      <BuildType Solution="Release-Linux|*" Project="Release" />
+      <BuildType Solution="Release-Windows|*" Project="Release" />
       <Build Solution="Debug|*" Project="false" />
-      <BuildType Project="Debug" Solution="Debug-Linux|*" />
-      <BuildType Project="Release" Solution="Release-Linux|*" />
-      <BuildType Project="Debug" Solution="Debug-Windows|*" />
-      <BuildType Project="Release" Solution="Release-Windows|*" />
     </Project>
     <Project Path="src/Broiler.Cli.Tests/Broiler.Cli.Tests.csproj">
-      <BuildType Project="Debug" Solution="Debug-Linux|*" />
-      <BuildType Project="Release" Solution="Release-Linux|*" />
-      <BuildType Project="Debug" Solution="Debug-Windows|*" />
-      <BuildType Project="Release" Solution="Release-Windows|*" />
+      <BuildType Solution="Debug-Linux|*" Project="Debug" />
+      <BuildType Solution="Debug-Windows|*" Project="Debug" />
+      <BuildType Solution="Release-Linux|*" Project="Release" />
+      <BuildType Solution="Release-Windows|*" Project="Release" />
     </Project>
     <Project Path="src/Broiler.Cli/Broiler.Cli.csproj">
-      <BuildType Project="Debug" Solution="Debug-Linux|*" />
-      <BuildType Project="Release" Solution="Release-Linux|*" />
-      <BuildType Project="Debug" Solution="Debug-Windows|*" />
-      <BuildType Project="Release" Solution="Release-Windows|*" />
+      <BuildType Solution="Debug-Linux|*" Project="Debug" />
+      <BuildType Solution="Debug-Windows|*" Project="Debug" />
+      <BuildType Solution="Release-Linux|*" Project="Release" />
+      <BuildType Solution="Release-Windows|*" Project="Release" />
     </Project>
+  </Folder>
+  <Folder Name="/src/">
     <Project Path="src/Broiler.DevConsole.Tests/Broiler.DevConsole.Tests.csproj">
       <BuildType Project="Debug" Solution="Debug-Linux|*" />
       <BuildType Project="Release" Solution="Release-Linux|*" />

--- a/docs/architecture/htmlbridge-engine-boundaries.md
+++ b/docs/architecture/htmlbridge-engine-boundaries.md
@@ -108,6 +108,75 @@ it consumes computed style and renderer geometry; its `display: contents`
 descendant behavior is covered by a dedicated regression gate. Content operations
 and JavaScript wrappers likewise remain outside the dependency-free kernel.
 
+Mutation-observer semantics are **not** yet fully canonical. The bridge still
+owns `MutationObserver` registration, observer-option matching, and mutation
+record filtering (`DomBridge/Registration/Events.cs` and the surrounding
+`__broilerRegisterMutationObserver` plumbing); it adapts filtered records into
+JavaScript callback objects. Several `DomRange` content operations are likewise
+still implemented in bridge rather than the kernel. Promoting the neutral parts
+of these paths — option matching/record filtering into `Broiler.DOM` and range
+content operations into canonical `DomRange` — is scoped as Phase 4 of the
+[DOM/CSS promotion roadmap](../roadmap/htmlbridge-dom-css-promotion-roadmap.md),
+not something already delivered here.
+
+## DOM/CSS promotion — Phase 0 baseline (2026-07-09)
+
+Phase 0 of the
+[HtmlBridge DOM/CSS promotion roadmap](../roadmap/htmlbridge-dom-css-promotion-roadmap.md)
+locks the boundary before any promotion PR slice moves code out of the bridge.
+The roadmap's later phases move neutral CSS/DOM algorithms into `Broiler.CSS`,
+`Broiler.CSS.Dom`, and `Broiler.DOM`. This section is the frozen inventory of
+what stays in the bridge and why, so those moves cannot silently re-package
+compatibility code as canonical engine code.
+
+### Allowed HtmlBridge compatibility seams
+
+Each seam is an intentional bridge-owned shim. Its removal boundary is
+`htmlbridge-public-surface/v2`; do not delete or promote it earlier. Adding a new
+seam to this list must be a deliberate, reviewed decision.
+
+| Seam | Kind | Ownership rationale | Promotion disposition |
+|---|---|---|---|
+| `Broiler.HtmlBridge.DomElement` | Versioned DOM adapter (`htmlbridge-dom-adapter/v1`) | Source-compatibility facade over `Broiler.Dom.DomElement`; delegates tree/attribute state to the canonical node | Non-candidate — remove at v2, do not promote |
+| `Broiler.HtmlBridge.HtmlTreeBuilder` | Versioned DOM adapter (`htmlbridge-dom-adapter/v1`) | Compatibility materializer over `Broiler.Dom.Html.HtmlDocumentParser` | Non-candidate — remove at v2, do not promote |
+| `DomBridge.CssRules` | Obsolete CSSOM compatibility view | Historical `(selector, specificity, declarations)` tuple projection; not a cascade store or render input | Remove at v2; consumers move to shared `Broiler.CSS` stylesheet/style-engine APIs |
+| `DomBridge.CalculateSpecificity(string)` | Static selector-specificity helper | Thin delegation to `Broiler.CSS.CssSelectorParser.CalculateSpecificity` | Remove at v2; public replacement is the CSS parser API |
+| CSSOM JavaScript wrappers (`DomBridge/StyleSheets.cs`) | Live JS object identity | Build `CSSStyleSheet`/`CSSRule` JS objects with parent-rule/sheet wiring and mutation events | Keep in bridge; Phase 3 thins them over a neutral CSS rule projection |
+| `ElementRuntimeState` | Bridge runtime state | JS identity, listeners, mutation-observer options, form/scroll/layout cache, dialog/shadow/animation state | Non-candidate — stays bridge-owned |
+| Host / resource loading (external stylesheet + subresource fetch) | Host integration | Fetching and base-path resolution are host concerns, not DOM/CSS | Keep in bridge; only host-supplied *text* assembly may move to CSS.Dom (Phase 2 open question) |
+
+The `MutationObserver` registration/option-matching/record-filtering paths and
+several `DomRange` content operations are also still bridge-owned; see the
+"Versioned DOM adapter policy" note above for their Phase 4 disposition.
+
+### Caller catalog (pre-v2 surface audit)
+
+Callers of the four named public seams, as of the Phase 0 baseline. This is the
+migration checklist that must reach zero non-test in-repo callers before the
+seam can be removed at v2.
+
+| Seam | In-repo production callers | Test callers |
+|---|---|---|
+| `DomElement` | Bridge-wide (`Broiler.HtmlBridge.Dom`); public entry points are `DomBridge.DocumentElement` / `DomBridge.Elements` | DOM/CSS/WPT compatibility tests via those entry points |
+| `HtmlTreeBuilder` | Bridge-internal only (`DomBridge.cs`, `DomBridge/SubDocuments.cs`, `DomBridge/JsFunctionCallbacks/*`) | `DomExtractionPhaseZeroTests` |
+| `DomBridge.CssRules` | **None** outside the bridge (already `[Obsolete]`) | `CssExtractionPhaseTwoTests`, `SelectorsLevel4SpecificityTests` |
+| `DomBridge.CalculateSpecificity` | **None** — no in-repo callers; tests call `Broiler.CSS.CssSelectorParser.CalculateSpecificity` directly | (specificity behavior covered against the CSS parser, not the bridge shim) |
+
+### Phase 0 guard tests
+
+The baseline is enforced from the main-repo test project so the guards run in
+main-repo CI without depending on submodule test runs:
+
+- `Broiler.Cli.Tests.HtmlBridgePromotionPhaseZeroTests` — freezes the seam
+  versions/shape above and guards that `Broiler.Dom` does not reference or expose
+  JavaScript-engine types and that `Broiler.CSS.Dom` does not reference
+  `Broiler.HtmlBridge.*`.
+
+The canonical components additionally self-guard inside their own submodules
+(`Broiler.Dom.Tests.DomArchitectureTests` forbids all non-framework dependencies;
+`Broiler.CSS.Dom.Tests.CssDomArchitectureTests` pins CSS.Dom's project references
+to `Broiler.CSS` + `Broiler.Dom` only).
+
 ## PR dashboard surfaces tied to this boundary
 
 - JavaScript conformance baseline:

--- a/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
+++ b/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
@@ -1,0 +1,352 @@
+# HtmlBridge DOM/CSS Promotion Roadmap
+
+Status: proposed
+Date: 2026-07-09
+
+## Purpose
+
+Investigate what remains in `Broiler.HtmlBridge.*` that can move into `Broiler.DOM.*`, `Broiler.CSS.*`, or a nearby shared component, and define a staged roadmap that avoids re-packaging compatibility code as if it were canonical engine code.
+
+## Executive verdict
+
+Yes, there are still candidates to promote out of `Broiler.HtmlBridge.*`, but most of them are small neutral algorithms, public helper APIs, or state projections. The large canonical moves have already happened:
+
+- `Broiler.DOM` owns the canonical DOM tree, mutations, ranges, traversal primitives, parsing hooks, and serialization direction.
+- `Broiler.Dom.Html` owns the HTML parser facade used by bridge compatibility code.
+- `Broiler.CSS` owns CSS syntax, selectors, declarations, values, diagnostics, parsing, serialization, and the stylesheet rule model.
+- `Broiler.CSS.Dom` owns selector matching, cascade, and computed style over canonical DOM nodes.
+
+The remaining `HtmlBridge` code should split into four buckets:
+
+1. Move neutral CSS helpers and duplicated computed-style algorithms into `Broiler.CSS` or `Broiler.CSS.Dom`.
+2. Move neutral DOM algorithms into `Broiler.DOM` when they do not require JavaScript object identity, callbacks, layout geometry, or bridge runtime state.
+3. Keep JavaScript wrappers, live CSSOM object identity, resource loading, events, timers, host integration, and layout/paint bridge code in `HtmlBridge` or route them to `Broiler.Layout` and media/graphics roadmaps.
+4. Delete compatibility adapters and dead rendering code at the next public-surface boundary instead of promoting them.
+
+## Current boundary facts
+
+The repository already documents the intended split in:
+
+- `Broiler.DOM/README.md`
+- `Broiler.CSS/README.md`
+- `docs/architecture/htmlbridge-engine-boundaries.md`
+- `docs/roadmap/broiler-css-component.md`
+- `docs/roadmap/refactor-gap.md`
+- `docs/roadmap/rf-bridge-1b-layout-unification.md`
+
+The important consequence is that `Broiler.HtmlBridge.Dom.DomElement` and `HtmlTreeBuilder` are compatibility adapters, not desirable destination APIs. They should stay as bridge shims until `htmlbridge-public-surface/v2`, then be removed once callers have migrated to canonical DOM APIs.
+
+## Promotion Candidates
+
+| Priority | Current area | Candidate owner | Move | Why |
+| --- | --- | --- | --- | --- |
+| P0 | `DomBridge.ParseStyle`, `IsAcceptableCssValue`, CSS priority helpers, property name casing helpers | `Broiler.CSS` or `Broiler.CSS.Dom` | Expose a shared inline declaration/parser utility and declaration validator | Bridge duplicates CSS value validation and inline-style handling that should be one canonical CSS behavior. |
+| P0 | `AnchorRegistry.GetComputedProps`, bridge CSS initial/inherited/default tables, shorthand expansion, attr/length helpers | `Broiler.CSS.Dom` | Replace bridge local computed-style projection with shared computed/cascaded style APIs | Anchor/layout consumers still rebuild a CSS engine subset in bridge, including tables and helper logic that already exist in `CssStyleEngine`. |
+| P1 | CSSOM rule metadata in `StyleSheets.cs` | `Broiler.CSS` or new `Broiler.CSS.Cssom` namespace | Add engine-neutral rule projection APIs for rule kind, descriptors, nested rules, namespace URI, and property rule metadata | Bridge should build JavaScript objects, but it should not serialize and re-parse shared rule model details to discover neutral metadata. |
+| P1 | `classList` token parsing and mutation behavior | `Broiler.DOM` | Add a DOMTokenList-style ordered-token helper over attributes | The ordered-set token rules are DOM semantics; the JavaScript wrapper and callback plumbing stay in bridge. |
+| P2 | Mutation observer option matching and record filtering | `Broiler.DOM` | Add neutral filtering over `DomMutationRecord` | Canonical DOM already emits mutation records. Bridge should convert filtered records to JS callbacks, not own the filtering algorithm. |
+| P2 | Range content operations and traversal state | `Broiler.DOM` | Expand canonical `DomRange` and route TreeWalker/NodeIterator wrappers through canonical traversal | `DomRange`, `DomTreeWalker`, and `DomNodeIterator` exist in DOM, but bridge still owns several content/traversal algorithms. Geometry APIs such as `getClientRects()` stay bridge/layout-owned. |
+| P2 | Stylesheet scope assembly without fetching | `Broiler.CSS.Dom` | Add a `CssStyleScopeBuilder` or similar host-driven builder | CSS.Dom can own style/link collection, ordering, media/supports evaluation, and engine synchronization if the host supplies resource text. Fetching remains bridge/host code. |
+| P3 | HTML serialization policies | `Broiler.Dom.Html` | Move only standard serialization policy helpers | Render-specific or Acid-test compatibility transforms should stay bridge-owned unless they are standard DOM/HTML behavior. |
+| Deferred | Image decoder, SVG parser/renderer, canvas helpers | `Broiler.Media`, `Broiler.Graphics`, or existing media roadmap | Do not move to DOM/CSS | These are shared engine capabilities, but not DOM or CSS component responsibilities. Align with the media/graphics roadmap. |
+
+## Non-candidates
+
+Do not move these into `Broiler.DOM` or `Broiler.CSS`:
+
+- `Broiler.HtmlBridge.Dom.DomElement`: compatibility facade over canonical DOM; remove at the public v2 boundary instead of promoting.
+- `HtmlTreeBuilder`: compatibility adapter over `Broiler.Dom.Html.HtmlDocumentParser`; remove when callers parse into canonical DOM directly.
+- JavaScript object wrappers for DOM, CSSOM, events, ranges, iterators, style declarations, and collections.
+- `ElementRuntimeState` as a whole. It holds JavaScript identity, listeners, form state, scroll state, layout cache, dialog/shadow state, stylesheet runtime state, animations, and document-type runtime state.
+- Resource loading, including external stylesheet fetching.
+- Layout metrics, hit-testing, scroll geometry, paint staging, and rendering logs. These should follow `Broiler.Layout` or rendering roadmaps, not DOM/CSS extraction.
+- `CssBoxModel`, `CssTextProperties`, and `RenderingStages`. Existing roadmap notes mark these as obsolete/dead compatibility surface for RF-BRIDGE-1a. They should be retired or deleted at the public-surface boundary, not promoted.
+
+## Roadmap
+
+### Phase 0: Lock the boundary and baseline
+
+Status: **done** (2026-07-09). The compatibility-seam inventory, caller catalog,
+and doc reconciliation live in
+[`docs/architecture/htmlbridge-engine-boundaries.md`](../architecture/htmlbridge-engine-boundaries.md)
+("DOM/CSS promotion — Phase 0 baseline"); the guard/inventory tests are
+`Broiler.Cli.Tests.HtmlBridgePromotionPhaseZeroTests`.
+
+Goal: make the extraction safe and prevent new bridge duplication.
+
+Tasks:
+
+- Add an inventory test or architecture note listing the remaining allowed `HtmlBridge` compatibility seams: `DomElement`, `HtmlTreeBuilder`, `CssRules`, `CalculateSpecificity`, CSSOM JS wrappers, runtime state, and host loading.
+- Reconcile `docs/architecture/htmlbridge-engine-boundaries.md` with current code. The doc says traversal and range state are canonical DOM algorithms, but bridge still owns range/traversal state and mutation observer conversion paths.
+- Catalog public callers of `DomElement`, `HtmlTreeBuilder`, `CssRules`, and `CalculateSpecificity` before any public-surface changes.
+- Add guard tests that `Broiler.DOM` does not reference JavaScript engine types and `Broiler.CSS.Dom` does not reference `Broiler.HtmlBridge.*`.
+
+Exit criteria:
+
+- The intended compatibility surface is documented with removal boundaries.
+- New work has a visible rule for whether it belongs in DOM/CSS, bridge, layout, or media/graphics.
+
+### Phase 1: Promote CSS declaration utilities
+
+Status: **exit criteria met** (2026-07-09). `Broiler.CSS.Dom.CssDeclarationValidator`
+now exposes the cascade engine's `IsAcceptableDeclarationValue` (single source of
+truth); `DomBridge.ParseStyle` routes through it and the bridge's
+`IsAcceptableCssValue` / `IsWhiteSpaceValue` / `IsTextTransformValue` duplicates
+are deleted. Covered by `Broiler.CSS.Dom.Tests.CssDeclarationValidatorTests`
+plus the existing bridge inline-style/Acid3 compatibility tests (verified
+regression-free against a no-change baseline). Deferred to PR slice 2 (does not
+gate the exit criteria): the illustrative `CssPropertyNames.To*PropertyName`
+casing helpers, `CssPriority.Parse/Apply/Strip`, and routing the live
+`CSSStyleDeclaration` setters / stylesheet-mutation paths through shared APIs.
+
+Goal: remove bridge-owned CSS parsing and validation duplicates.
+
+Tasks:
+
+- Add a shared API in `Broiler.CSS` or `Broiler.CSS.Dom`, for example:
+  - `CssInlineStyleParser.ParseDeclarations(...)`
+  - `CssDeclarationValidator.IsAcceptableDeclarationValue(...)`
+  - `CssPropertyNames.ToCssPropertyName(...)`
+  - `CssPropertyNames.ToDomPropertyName(...)`
+  - `CssPriority.Parse/Apply/Strip(...)`
+- Move or expose the newer validation logic currently private in `CssStyleEngine.Values.cs` instead of preserving the narrower bridge version.
+- Route `DomBridge.ParseStyle`, style attribute parsing, `CSSStyleDeclaration` setters, and stylesheet mutation paths through the shared API.
+- Preserve bridge diagnostics by passing a callback or diagnostic sink into the shared parser/validator.
+- Keep JavaScript wrapper behavior in bridge.
+
+Exit criteria:
+
+- Bridge no longer owns `IsAcceptableCssValue` or duplicate inline declaration validation.
+- Inline style behavior is covered by CSS unit tests and bridge compatibility tests.
+
+### Phase 2: Promote computed-style projections used by anchor/layout code
+
+Status: **partially delivered** (2026-07-09). The two computed-style *tables*
+that the bridge duplicated verbatim from `CssStyleEngine` — CSS initial values
+and the inherited-property set — are promoted into the shared public
+`Broiler.CSS.Dom.CssComputedDefaults`; the engine and the bridge's
+`GetComputedProps`/`ApplyInheritedProperties` now consume that single source, and
+the bridge's private copies are deleted (they had already drifted — the bridge's
+initial-value table carried `text-align-last: auto` the engine's lacked; the
+shared table reconciles to the superset). Covered by
+`Broiler.CSS.Dom.Tests.CssComputedDefaultsTests`; verified regression-free against
+a no-change baseline on the computed-style-sensitive suite.
+
+**Deliberately not done — the literal `GetComputedProps` → `GetComputedStyle`
+cutover.** Investigation showed it is not safely achievable as written:
+
+- `GetComputedProps` is the bridge's *central* computed-style accessor (~200 call
+  sites across `LayoutMetrics`, `HitTesting`, serialization, traversal, and the
+  anchor resolver), and consumers rely on its **sparse-map** contract (an
+  undeclared property reads back `null`). `GetComputedStyle` returns a
+  full-initials map, so a blind swap would silently shift every consumer (e.g.
+  `content` reads `"normal"` instead of `null`).
+- The bridge's `ApplyApproximateFormControlComputedSizes` uses rendered-text and
+  select-listbox metrics that need layout/text access `Broiler.CSS.Dom` must not
+  take on ("Keep layout used-value resolution and box geometry outside CSS.Dom").
+  Moving it would either lose that behavior or violate the component boundary.
+
+Two of the remaining neutral helpers are now also shared, output-preserving:
+
+- **`attr()` length substitution** — the engine's `ResolveLengthAttrFunctions`
+  is exposed as a public static (the bridge's identical copy, plus its regex and
+  `IsRecognizedLengthValue`, are deleted and routed to it).
+- **User-agent `display` defaults** — the tag→`display` table moves into the
+  public `Broiler.CSS.Dom.CssUserAgentDefaults.DisplayValues`; the bridge's
+  private table is deleted and its `ApplyUserAgentDisplayDefaults` reads the
+  shared table.
+
+Both verified regression-free (`CssComputedDefaultsTests`, the `attr()` and
+form-control display paths, geometry-parity tests, computed-style subset diff).
+**Shorthand expansion is deliberately still bridge-owned**: the engine's
+`ExpandCssShorthands` has drifted to a superset (it expands `outline`, which the
+bridge's does not and which the bridge *does* serialize), so sharing it is not
+output-preserving without a reconciliation pass. Form-control sizing and the
+sparse-map orchestration also stay bridge-owned per the layout boundary.
+
+Goal: stop rebuilding computed style in bridge for anchor positioning and layout-adjacent consumers.
+
+Tasks:
+
+- Add any missing public projection needed by bridge consumers to `CssStyleEngine`, such as a stable computed-style map view, cascaded declaration view with inline style included, or an anchor/layout style projection.
+- Replace `AnchorRegistry.GetComputedProps` with `GetSyncedScopedEngine(...).GetComputedStyle(...)` or a new shared projection.
+- Remove bridge-local copies of CSS initial values, inherited property sets, user-agent display defaults, shorthand expansion, attr substitution, approximate form-control sizing, and CSS length parsing where shared CSS.Dom APIs cover the behavior.
+- Keep layout used-value resolution and box geometry outside CSS.Dom.
+
+Exit criteria:
+
+- Anchor positioning and layout-adjacent callers consume shared CSS.Dom computed/cascaded style behavior.
+- The bridge has no private computed-style table that can drift from `CssStyleEngine`.
+
+### Phase 3: Split neutral CSSOM rule projection from JS wrappers
+
+Status: **done** (2026-07-09). `Broiler.CSS.Cssom.CssomRuleMetadata` is the neutral
+projection over `CssRule`: rule kind + CSSOM numeric type, style-rule selector
+text, `@import` href/media, `@namespace` prefix/URI, `@keyframes` name, and
+`@charset` encoding — computed from the parsed model, no serialize→reparse. The
+`@media`/`@supports`/`@layer`/`@page` preludes and `@property`/`@counter-style`
+descriptors are read from `CssAtRule.Prelude`/`Declarations` directly.
+`StyleSheets.cs`'s model-path `BuildCssRuleObject`/`BuildCssKeyframeRuleObject`
+now build the JS CSSOM objects from that projection instead of
+`CssSerializer.Serialize(rule)` + `Substring` re-parsing (declaration blocks still
+feed the JS `CSSStyleDeclaration` via `ParseStyle` on the serialized block, which
+is unchanged). Live object identity, parent wiring, mutation, and the cssText/
+callback surfaces stay bridge-owned. Verified by
+`Broiler.CSS.Tests.Cssom.CssomRuleMetadataTests` (23) plus ~350 CSSOM CLI tests
+with no new failures. The **string-input path** (nested `insertRule`, where JS
+supplies raw text with no model rule yet) still parses that text and is the
+one remaining substring path; unrecognized at-rules (`@container`,
+`@-webkit-keyframes`) fall back to it to preserve current behavior. The
+open-question answer: the projection lives under a dedicated `Broiler.CSS.Cssom`
+namespace (the CSS architecture guard now permits the component's own
+sub-namespaces).
+
+Goal: keep CSS rule semantics in CSS while retaining bridge-owned live JavaScript wrappers.
+
+Tasks:
+
+- Add a neutral projection API around `Broiler.CSS.CssRule` for:
+  - rule kind and CSSOM numeric type
+  - selector text and media/supports/layer metadata
+  - nested rule access
+  - property rule descriptors
+  - namespace prefix and URI
+  - keyframe selector and declaration access
+- Update `StyleSheets.cs` to build JavaScript CSSOM objects from the projection instead of string serialization and local metadata parsing.
+- Keep live object identity, parent rule/sheet wiring, mutation events, and JS callback surfaces in bridge.
+
+Exit criteria:
+
+- CSSOM JS wrappers are thin adapters over shared rule metadata.
+- No bridge code needs to parse serialized CSS text to discover model metadata that `Broiler.CSS` already knows.
+
+### Phase 4: Promote DOM token, mutation, range, and traversal algorithms
+
+Status: **token list + mutation filtering done; slice 8 partially done**
+(2026-07-09; PR slices 6–7, part of 8).
+
+Slice 8 findings/work:
+- **`TreeWalker`/`NodeIterator` routing is already canonical** — the bridge's
+  `BuildTreeWalker`/`BuildNodeIterator` already construct
+  `Broiler.Dom.DomTreeWalker`/`DomNodeIterator` and only wrap them with JS
+  filters/object identity (no bridge-owned traversal state to promote).
+- **Canonical `DomRange` boundary foundation added.** The stub gains the standard
+  boundary-point surface — `SetStart`/`SetEnd`, `StartContainer`/`StartOffset`/
+  `EndContainer`/`EndOffset`, `Collapsed` — over the range's already-present live
+  "removing steps" adjustment (`OnMutation`). Covered by `DomRangeTests` (5). This
+  also resolves the Range portion of the pre-existing `DomKernelTests` break.
+- **Still bridge-owned (not yet promoted):** the JS `Range` object's *content*
+  operations (`deleteContents`/`extractContents`/`cloneContents`/`insertNode`/
+  `surroundContents`) and the bridge's `RangeState` — the bridge does not yet route
+  its ranges through canonical `DomRange`. That routing plus content-op promotion
+  is the larger, higher-risk remainder of slice 8, entangled with the bridge's
+  range geometry/client-rect APIs (which stay bridge-owned).
+
+`Broiler.Dom.DomTokenList` is the canonical ordered-set token algorithm
+(ASCII-whitespace parse/serialize, unique-ordered, contains/add/remove/toggle/
+replace, empty/whitespace validation, attribute synchronization), covered by
+`Broiler.Dom.Tests.DomTokenListTests` (18). The bridge's `classList`
+`add`/`remove`/`toggle`/`contains` callbacks now delegate to it (and gain
+`classList.replace`), keeping only JS argument marshaling, the lenient empty-token
+skip, and the style-scope invalidation callback. Behavior-preserving: `ClassName`
+is exactly `get/setAttribute("class")`, which the token list uses, so mutation
+records and style invalidation are unchanged. Verified regression-free across the
+Acid3 `classList`, DOM, and mutation-observer CLI tests (232/233; the one failure
+is the pre-existing `Border_Shorthand` baseline case).
+
+**Mutation-observer filtering (slice 7):** `Broiler.Dom.DomMutationObserverFilter`
++ `DomMutationObserverOptions` own the option-matching gate (type flags,
+target/subtree scope via `DomNode.IsDescendantOf`, `attributeFilter`, and
+`CapturesOldValue`), covered by `DomMutationObserverFilterTests` (8). The bridge's
+three `Notify*MutationObservers` paths now build a canonical `DomMutationRecord`
+and delegate the delivery decision to `DomMutationObserverFilter.Matches`; the
+bridge's private `MutationObserverOptions` struct and `ShouldNotifyMutationObserver`
+are deleted (it uses the canonical options type). Behavior-preserving — the bridge
+sets no `attributeFilter`, so matching is identical to before; the filter's
+`attributeFilter` support is spec-complete and tested for a future wiring.
+Verified by the 10 `MutationObserver` CLI tests (childList, attributes with/without
+old value, characterData) plus the DOM/mutation subset (no new failures).
+
+Note: the `Broiler.DOM` test project previously had a **pre-existing** compile
+break in `DomKernelTests.cs` (stale references to `DomRange` boundary members,
+`DomException.Name`, `DomElement.Prefix`, `DomDocument.GetElementsByTagName`). This
+is now **fixed** — the missing members were legitimate standard DOM API and have
+been added to the canonical model, so the whole DOM test project compiles and runs
+(**51 tests pass**, including `DomKernelTests`, `DomTokenListTests`,
+`DomMutationObserverFilterTests`, and `DomRangeTests`).
+
+Goal: move DOM-standard behavior out of JavaScript bridge code while keeping host callbacks and layout geometry in bridge.
+
+Tasks:
+
+- Add a `DomTokenList` or ordered-token helper in `Broiler.DOM` for `classList`-style validation, add/remove/toggle/replace, and attribute synchronization.
+- Add mutation observer option matching/filtering over `DomMutationRecord`. Bridge should only adapt filtered records into JavaScript callback objects.
+- Expand canonical `DomRange` with neutral content operations currently implemented in bridge where they do not require JS wrappers or layout.
+- Route bridge `TreeWalker` and `NodeIterator` objects through canonical DOM traversal implementations, with bridge handling JavaScript filters and object identity.
+- Keep range geometry APIs, client rect generation, and visual selection behavior in bridge/layout.
+
+Exit criteria:
+
+- DOM-standard algorithms are covered in `Broiler.DOM` tests.
+- Bridge traversal/range files mostly contain JS object construction, callback adaptation, and layout-specific APIs.
+
+### Phase 5: Public-surface cleanup
+
+Goal: remove compatibility adapters once consumers are on canonical APIs.
+
+Tasks:
+
+- At `htmlbridge-public-surface/v2`, remove or hide:
+  - `Broiler.HtmlBridge.Dom.DomElement`
+  - `HtmlTreeBuilder`
+  - obsolete `CssRules` tuple view
+  - bridge-only specificity compatibility method if shared CSS parser APIs are the public replacement
+- Delete RF-BRIDGE-1a obsolete rendering pipeline types instead of moving them.
+- Finish RF-BRIDGE-1b layout unification by replacing bridge recursive geometry estimators with `Broiler.Layout` read-model access.
+
+Exit criteria:
+
+- `HtmlBridge` contains bridge responsibilities only: JS integration, compatibility surface, host/resource integration, CSSOM/DOM wrapper identity, and handoff to layout/rendering/media.
+- DOM and CSS components own canonical algorithms and data models without bridge dependencies.
+
+## Suggested PR Slices
+
+| PR | Scope | Risk |
+| --- | --- | --- |
+| 1 | Add CSS declaration utility APIs plus tests, no bridge call-site changes | Low |
+| 2 | Route inline style parsing and `CSSStyleDeclaration` setters through shared CSS APIs | Medium |
+| 3 | Add CSS.Dom computed-style projection for anchor/layout callers | Medium |
+| 4 | Replace `AnchorRegistry.GetComputedProps` and delete bridge CSS tables/helpers | High |
+| 5 | Add CSS rule projection API and migrate CSSOM object builders | Medium |
+| 6 | Add DOM token helper and migrate `classList` wrappers | Low |
+| 7 | Add DOM mutation observer filtering and migrate bridge callback preparation | Medium |
+| 8 | Expand canonical `DomRange`/traversal use and thin the bridge wrappers | High |
+| 9 | Public v2 compatibility cleanup and RF-BRIDGE-1a dead rendering deletions | High |
+
+## Validation Plan
+
+Run focused tests after each phase:
+
+- `Broiler.CSS.Tests`
+- `Broiler.CSS.Dom.Tests`
+- `Broiler.Dom.Tests`
+- `Broiler.Dom.Html.Tests`
+- bridge CSSOM and inline-style tests
+- selector and specificity compatibility tests
+- anchor positioning and layout-adjacent tests
+- mutation observer, range, TreeWalker, and NodeIterator tests
+- targeted WPT/Acid cases already tracked by the existing roadmaps
+
+Add architecture checks where practical:
+
+- `Broiler.DOM` must not reference JavaScript engine or bridge assemblies.
+- `Broiler.CSS` and `Broiler.CSS.Dom` must not reference bridge assemblies.
+- `Broiler.HtmlBridge.Dom` should not contain private CSS parser, validator, shorthand, initial-value, or inherited-property duplicates after Phase 2.
+
+## Open Questions
+
+- Should the CSSOM projection live directly in `Broiler.CSS`, or should it be isolated under a `Broiler.CSS.Cssom` namespace to make the browser-API mapping explicit?
+- Should `DomTokenList` be a public DOM type or an internal helper consumed by bridge and future DOM APIs?
+- Should stylesheet scope assembly include host-provided external stylesheet text in CSS.Dom, or should it remain entirely bridge-owned until more non-bridge consumers exist?
+- How much of current bridge serialization behavior is standard HTML serialization versus compatibility transforms for rendering tests?
+- When is the project ready to declare `htmlbridge-public-surface/v2` and remove the v1 compatibility adapters?

--- a/src/Broiler.Cli.Tests/HtmlBridgePromotionPhaseZeroTests.cs
+++ b/src/Broiler.Cli.Tests/HtmlBridgePromotionPhaseZeroTests.cs
@@ -1,0 +1,145 @@
+using System.Reflection;
+using Broiler.HtmlBridge;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Phase 0 ("Lock the boundary and baseline") of the HtmlBridge DOM/CSS
+/// promotion roadmap
+/// (<c>docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md</c>).
+///
+/// These tests freeze the remaining allowed <c>Broiler.HtmlBridge</c>
+/// compatibility seams and guard the canonical DOM/CSS components against
+/// re-acquiring bridge or JavaScript-engine dependencies. They make new bridge
+/// duplication visible at review time instead of allowing silent drift before
+/// the promotion PR slices land.
+///
+/// The intended removal boundary for every seam below is
+/// <c>htmlbridge-public-surface/v2</c>; see the architecture note
+/// <c>docs/architecture/htmlbridge-engine-boundaries.md</c> for the seam
+/// inventory, caller catalog, and ownership rationale.
+/// </summary>
+public sealed class HtmlBridgePromotionPhaseZeroTests
+{
+    /// <summary>
+    /// The canonical DOM/CSS/JS assembly names. Guard tests reflect over the
+    /// live assemblies so a new project reference cannot re-introduce a forbidden
+    /// dependency without tripping a test.
+    /// </summary>
+    private const string JavaScriptEnginePrefix = "Broiler.JavaScript";
+
+    private const string HtmlBridgePrefix = "Broiler.HtmlBridge";
+
+    [Fact]
+    public void DomElement_And_HtmlTreeBuilder_Adapter_Seam_Is_Versioned_And_Frozen()
+    {
+        // htmlbridge-dom-adapter/v1: the DomElement facade + HtmlTreeBuilder
+        // materializer. Both delegate to the canonical node model / Broiler.Dom.Html
+        // and may only be removed at the published removal boundary.
+        Assert.Equal("htmlbridge-dom-adapter/v1", DomElement.CompatibilitySurfaceVersion);
+        Assert.Equal("htmlbridge-public-surface/v2", DomElement.RemovalBoundaryVersion);
+        Assert.Equal("htmlbridge-dom-adapter/v1", HtmlTreeBuilder.CompatibilitySurfaceVersion);
+        Assert.Equal("htmlbridge-public-surface/v2", HtmlTreeBuilder.RemovalBoundaryVersion);
+    }
+
+    [Fact]
+    public void CssRules_Compatibility_Tuple_View_Remains_An_Obsolete_Bridge_Seam()
+    {
+        // CssRules is the historical (selector, specificity, declarations) tuple
+        // projection. It is bridge-owned and obsolete-marked; canonical consumers
+        // use the shared Broiler.CSS stylesheet/style-engine APIs. It must remain
+        // discoverable so its removal at v2 is a deliberate change.
+        var cssRules = typeof(DomBridge).GetProperty(
+            nameof(DomBridge.CssRules),
+            BindingFlags.Public | BindingFlags.Instance);
+
+        Assert.NotNull(cssRules);
+        Assert.NotNull(cssRules!.GetCustomAttribute<ObsoleteAttribute>());
+    }
+
+    [Fact]
+    public void CalculateSpecificity_Remains_A_Static_Delegation_Shim_Over_The_Css_Parser()
+    {
+        // CalculateSpecificity is a static compatibility helper that delegates to
+        // Broiler.CSS.CssSelectorParser.CalculateSpecificity. It has no in-repo
+        // callers today; the public replacement is the CSS parser API. Freezing
+        // its shape prevents the bridge from re-growing a private specificity
+        // algorithm.
+        var calculate = typeof(DomBridge).GetMethod(
+            nameof(DomBridge.CalculateSpecificity),
+            BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(calculate);
+        Assert.Equal(typeof(int), calculate!.ReturnType);
+        Assert.Equal([typeof(string)], calculate.GetParameters().Select(static p => p.ParameterType));
+    }
+
+    [Fact]
+    public void Bridge_Runtime_State_Remains_A_Bridge_Owned_Seam()
+    {
+        // ElementRuntimeState holds JavaScript identity, listeners, mutation
+        // observer options, form/scroll/layout cache, and other host state. The
+        // roadmap explicitly marks it a non-candidate for promotion; it stays in
+        // the bridge assembly.
+        var runtimeState = typeof(DomBridge).Assembly.GetType("Broiler.HtmlBridge.ElementRuntimeState");
+
+        Assert.NotNull(runtimeState);
+        Assert.Equal("Broiler.HtmlBridge.Dom", runtimeState!.Assembly.GetName().Name);
+    }
+
+    [Fact]
+    public void Canonical_Dom_Does_Not_Reference_The_JavaScript_Engine()
+    {
+        // Phase 0 guard: Broiler.Dom must not reference JavaScript-engine
+        // assemblies. The DOM kernel owns engine-neutral tree/algorithm code only.
+        var javaScriptReferences = typeof(Broiler.Dom.DomDocument).Assembly
+            .GetReferencedAssemblies()
+            .Select(static reference => reference.Name)
+            .Where(static name => name?.StartsWith(JavaScriptEnginePrefix, StringComparison.Ordinal) == true)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Empty(javaScriptReferences);
+    }
+
+    [Fact]
+    public void Canonical_Dom_Public_Surface_Does_Not_Expose_JavaScript_Types()
+    {
+        var leaks = typeof(Broiler.Dom.DomDocument).Assembly
+            .GetExportedTypes()
+            .SelectMany(static type => type.GetMembers(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+            .SelectMany(GetMemberTypes)
+            .Where(static type => type.Namespace?.StartsWith(JavaScriptEnginePrefix, StringComparison.Ordinal) == true)
+            .Select(static type => type.FullName)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Empty(leaks);
+    }
+
+    [Fact]
+    public void Canonical_CssDom_Does_Not_Reference_HtmlBridge()
+    {
+        // Phase 0 guard: Broiler.CSS.Dom owns selector matching, cascade, and
+        // computed style over canonical DOM nodes. It must not depend on the
+        // bridge, so bridge duplicates cannot leak back through a shared type.
+        var bridgeReferences = typeof(Broiler.CSS.Dom.CssStyleEngine).Assembly
+            .GetReferencedAssemblies()
+            .Select(static reference => reference.Name)
+            .Where(static name => name?.StartsWith(HtmlBridgePrefix, StringComparison.Ordinal) == true)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Empty(bridgeReferences);
+    }
+
+    private static IEnumerable<Type> GetMemberTypes(MemberInfo member) => member switch
+    {
+        MethodInfo method => [method.ReturnType, .. method.GetParameters().Select(static parameter => parameter.ParameterType)],
+        PropertyInfo property => [property.PropertyType],
+        FieldInfo field => [field.FieldType],
+        EventInfo eventInfo when eventInfo.EventHandlerType is not null => [eventInfo.EventHandlerType],
+        _ => [],
+    };
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Selectors.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Selectors.cs
@@ -5,7 +5,7 @@ namespace Broiler.HtmlBridge;
 /// </summary>
 public sealed partial class DomBridge
 {
-    private static readonly Broiler.CSS.Dom.CssSelectorMatcher SharedSelectorMatcher =
+    private static readonly CSS.Dom.CssSelectorMatcher SharedSelectorMatcher =
         new(new BridgeSelectorStateProvider());
 
     private static bool MatchesSelector(
@@ -14,7 +14,7 @@ public sealed partial class DomBridge
         DomElement? scope = null) =>
         SharedSelectorMatcher.Matches(element, selector, scope);
 
-    private sealed class BridgeSelectorStateProvider : Broiler.CSS.Dom.ICssSelectorStateProvider
+    private sealed class BridgeSelectorStateProvider : CSS.Dom.ICssSelectorStateProvider
     {
         public bool? IsChecked(Broiler.Dom.DomElement element)
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -53,12 +53,11 @@ public sealed partial class DomBridge
 
     private void ReflectRenderState(DomElement element)
     {
-        if (!element.IsTextNode && !element.TagName.StartsWith("#", StringComparison.Ordinal))
+        if (!element.IsTextNode && !element.TagName.StartsWith('#'))
         {
             if (element.Style.Count == 0)
             {
-                if (element.Attributes.ContainsKey("style"))
-                    element.Attributes.Remove("style");
+                element.Attributes.Remove("style");
             }
             else
             {
@@ -93,8 +92,7 @@ public sealed partial class DomBridge
             CreateSerializationAdapter(),
             new HtmlSerializationOptions(MaximumDepth: MaxSerializationDepth, EncodeTextNodes: false));
 
-    private string SerializeChildrenToHtml(DomElement element) =>
-        string.Concat(element.Children.Select(SerializeElementToHtml));
+    private string SerializeChildrenToHtml(DomElement element) => string.Concat(element.Children.Select(SerializeElementToHtml));
 
     private void ApplySerializationTransforms()
     {
@@ -146,8 +144,10 @@ public sealed partial class DomBridge
         if (rules.Count == 0)
             return;
 
-        var styleElement = new DomElement("style", null, null, string.Empty);
-        styleElement.TextContent = string.Join(Environment.NewLine, rules);
+        var styleElement = new DomElement("style", null, null, string.Empty)
+        {
+            TextContent = string.Join(Environment.NewLine, rules)
+        };
 
         var head = FindFirstElementByTagName(DocumentElement, "head");
         if (head != null)
@@ -272,8 +272,7 @@ public sealed partial class DomBridge
         element.InnerHtml = string.Empty;
         element.TextContent = null;
 
-        var fill = new DomElement("div", null, null, string.Empty);
-        fill.Parent = element;
+        var fill = new DomElement("div", null, null, string.Empty) { Parent = element };
         fill.Style["position"] = "absolute";
         fill.Style["background-color"] = tag == "meter" ? "#4caf50" : "#0a84ff";
 
@@ -540,10 +539,7 @@ public sealed partial class DomBridge
         if (!element.Attributes.TryGetValue(attributeName, out var value) || string.IsNullOrWhiteSpace(value))
             return;
 
-        element.Attributes[attributeName] = Regex.Replace(
-            value,
-            @"-?\d*\.?\d+(?:[eE][+-]?\d+)?",
-            match => ScaleSvgNumericMatch(match, usedZoom));
+        element.Attributes[attributeName] = ScaleSvgPointRegex().Replace(value, match => ScaleSvgNumericMatch(match, usedZoom));
     }
 
     private void ScaleSvgPathDataAttribute(DomElement element, string attributeName, double usedZoom)
@@ -551,10 +547,7 @@ public sealed partial class DomBridge
         if (!element.Attributes.TryGetValue(attributeName, out var value) || string.IsNullOrWhiteSpace(value))
             return;
 
-        element.Attributes[attributeName] = Regex.Replace(
-            value,
-            @"-?\d*\.?\d+(?:[eE][+-]?\d+)?",
-            match => ScaleSvgNumericMatch(match, usedZoom));
+        element.Attributes[attributeName] = ScaleSvgPathRegex().Replace(value, match => ScaleSvgNumericMatch(match, usedZoom));
     }
 
     private static string ScaleSvgNumericMatch(Match match, double factor)
@@ -655,7 +648,7 @@ public sealed partial class DomBridge
         if (!specified.TryGetValue("font", out var fontShorthand) || string.IsNullOrWhiteSpace(fontShorthand))
             return false;
 
-        var sizeMatch = Regex.Match(fontShorthand, @"(?<![\w.-])(-?\d*\.?\d+)px(?:\s*/|(?=\s|$))", RegexOptions.IgnoreCase);
+        var sizeMatch = FontShortHandRegex().Match(fontShorthand);
         if (!sizeMatch.Success ||
             !double.TryParse(sizeMatch.Groups[1].Value,
                 System.Globalization.NumberStyles.Float,
@@ -872,4 +865,13 @@ public sealed partial class DomBridge
 
         return string.Concat(subDocumentRoot.Children.Select(SerializeElementToHtml));
     }
+
+    [GeneratedRegex(@"-?\d*\.?\d+(?:[eE][+-]?\d+)?")]
+    private static partial Regex ScaleSvgPointRegex();
+    
+    [GeneratedRegex(@"-?\d*\.?\d+(?:[eE][+-]?\d+)?")]
+    private static partial Regex ScaleSvgPathRegex();
+
+    [GeneratedRegex(@"(?<![\w.-])(-?\d*\.?\d+)px(?:\s*/|(?=\s|$))", RegexOptions.IgnoreCase)]
+    private static partial Regex FontShortHandRegex();
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -47,7 +47,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         "scrollend"];
     private readonly HashSet<DomElement> _knownNodes =
         new(ReferenceEqualityComparer.Instance);
-    private readonly List<(JSObject Observer, DomElement Target, MutationObserverOptions Options)> _mutationObservers = [];
+    private readonly List<(JSObject Observer, DomElement Target, Broiler.Dom.DomMutationObserverOptions Options)> _mutationObservers = [];
     private readonly List<WeakReference<RangeState>> _activeRanges = [];
     private readonly List<WeakReference<Broiler.Dom.DomNodeIterator>> _activeNodeIterators = [];
     private readonly CanonicalDocument _document;
@@ -173,11 +173,10 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// All elements parsed from the HTML source.
     /// </summary>
     public IReadOnlyList<DomElement> Elements =>
-        _documentNode
+        [.. _documentNode
             .InclusiveDescendants()
             .OfType<DomElement>()
-            .Where(element => !ReferenceEquals(element, _documentNode))
-            .ToArray();
+            .Where(element => !ReferenceEquals(element, _documentNode))];
 
     private static ElementRuntimeState GetElementRuntimeState(DomElement element) =>
         ElementRuntimeStates.GetValue(element, static _ => new ElementRuntimeState());
@@ -368,8 +367,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// <c>setInterval</c>, or <c>requestAnimationFrame</c> callbacks
     /// waiting to execute.
     /// </summary>
-    public bool HasPendingTimers =>
-        _timeoutCallbacks.Count > 0 || _intervalCallbacks.Count > 0 || _rafCallbacks.Count > 0 || _frameActions.Count > 0;
+    public bool HasPendingTimers => !_timeoutCallbacks.IsEmpty || !_intervalCallbacks.IsEmpty || !_rafCallbacks.IsEmpty || !_frameActions.IsEmpty;
 
     /// <summary>
     /// Executes one batch of pending timer and animation-frame callbacks.
@@ -550,8 +548,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         // and addEventListener registrations using the same event path.
         try
         {
-            var evt = _jsContext.Eval("(function() { var e = document.createEvent('Event'); e.initEvent('load', false, false); return e; })()") as JSObject;
-            if (evt != null)
+            if (_jsContext.Eval("(function() { var e = document.createEvent('Event'); e.initEvent('load', false, false); return e; })()") is JSObject evt)
                 DispatchEventOnElement(body, evt);
         }
         catch (Exception ex)
@@ -587,26 +584,26 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         var legacyCancelBubble = false;
         evt[(KeyString)"defaultPrevented"] = prevented ? JSBoolean.True : JSBoolean.False;
         evt.FastAddValue((KeyString)"stopPropagation",
-            new JSFunction((in Arguments _) => JsCallbackStopPropagation001Core(ref legacyCancelBubble, in _), "stopPropagation", 0),
+            new JSFunction((in _) => JsCallbackStopPropagation001Core(ref legacyCancelBubble, in _), "stopPropagation", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         evt.FastAddValue((KeyString)"stopImmediatePropagation",
-            new JSFunction((in Arguments _) => JsCallbackStopImmediatePropagation002Core(ref immediateStopped, ref legacyCancelBubble, in _), "stopImmediatePropagation", 0),
+            new JSFunction((in _) => JsCallbackStopImmediatePropagation002Core(ref immediateStopped, ref legacyCancelBubble, in _), "stopImmediatePropagation", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         evt.FastAddValue((KeyString)"preventDefault",
-            new JSFunction((in Arguments _) => JsCallbackPreventDefault003Core(currentListenerPassive, evt, ref prevented, in _), "preventDefault", 0),
+            new JSFunction((in _) => JsCallbackPreventDefault003Core(currentListenerPassive, evt, ref prevented, in _), "preventDefault", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         evt.FastAddProperty(
             (KeyString)"cancelBubble",
-            new JSFunction((in Arguments _) => legacyCancelBubble ? JSBoolean.True : JSBoolean.False, "get cancelBubble"),
-            new JSFunction((in Arguments setArgs) => JsCallbackSetCancelBubble005Core(ref legacyCancelBubble, in setArgs), "set cancelBubble"),
+            new JSFunction((in _) => legacyCancelBubble ? JSBoolean.True : JSBoolean.False, "get cancelBubble"),
+            new JSFunction((in setArgs) => JsCallbackSetCancelBubble005Core(ref legacyCancelBubble, in setArgs), "set cancelBubble"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
         evt.FastAddProperty(
             (KeyString)"returnValue",
-            new JSFunction((in Arguments _) => prevented ? JSBoolean.False : JSBoolean.True, "get returnValue"),
-            new JSFunction((in Arguments setArgs) => JsCallbackSetReturnValue007Core(currentListenerPassive, evt, ref prevented, in setArgs), "set returnValue"),
+            new JSFunction((in _) => prevented ? JSBoolean.False : JSBoolean.True, "get returnValue"),
+            new JSFunction((in setArgs) => JsCallbackSetReturnValue007Core(currentListenerPassive, evt, ref prevented, in setArgs), "set returnValue"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
         evt.FastAddValue((KeyString)"composedPath",
-            new JSFunction((in Arguments _) => new JSArray(_windowJSObject), "composedPath", 0),
+            new JSFunction((in _) => new JSArray(_windowJSObject), "composedPath", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         if (_windowEventListeners.TryGetValue(eventType, out var listeners))
@@ -634,7 +631,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     {
         var frames = new List<JSValue>();
         CollectWindowFrames(DocumentElement, frames);
-        return new JSArray(frames.ToArray());
+        return new JSArray([.. frames]);
     }
 
     private void CollectWindowFrames(DomElement element, List<JSValue> frames)
@@ -660,13 +657,9 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     //  HTML parsing helpers
     // ------------------------------------------------------------------
 
-    private static readonly System.Text.RegularExpressions.Regex TitlePattern = new(
-        @"<title[^>]*>(?<content>[\s\S]*?)</title>",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex TitlePattern = TitlePatternRegex();
 
-    private static readonly System.Text.RegularExpressions.Regex OpenTagPattern = new(
-        @"<(?<tag>[a-zA-Z][a-zA-Z0-9]*)\b(?<attrs>[^>]*)\/?>",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex OpenTagPattern = OpenTagPatternRegex();
 
     private static readonly HashSet<string> SkippedTags = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -679,21 +672,13 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         "link", "meta", "param", "source", "track", "wbr"
     };
 
-    private static readonly System.Text.RegularExpressions.Regex IdPattern = new(
-        @"\bid\s*=\s*[""'](?<id>[^""']+)[""']",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex IdPattern = IdPatternRegex();
 
-    private static readonly System.Text.RegularExpressions.Regex ClassPattern = new(
-        @"\bclass\s*=\s*[""'](?<cls>[^""']+)[""']",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex ClassPattern = ClassPatternRegex();
 
-    private static readonly System.Text.RegularExpressions.Regex AttributeSelectorPattern = new(
-        @"\[(?<name>[a-zA-Z][a-zA-Z0-9_:-]*)(?:(?<op>[~|^$*]?=)(?<value>[""'][^""']*[""']|[^\]]*))?\]",
-        RegexOptions.Compiled);
+    private static readonly Regex AttributeSelectorPattern = AttributeSelectorPatternRegex();
 
-    private static readonly System.Text.RegularExpressions.Regex DocTypePattern = new(
-        @"<!DOCTYPE\s+(\w+)(?:\s+PUBLIC\s+""([^""]*)""(?:\s+""([^""]*)"")?)?\s*>",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex DocTypePattern = DocTypePatternRegex();
 
     private void ParseHtml(string html)
     {
@@ -820,9 +805,10 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// the last <em>valid</em> value wins (per CSS 2.1 §4.2 / CSS Syntax §5).
     /// </summary>
     /// <param name="reportDrops">
-    /// When <c>true</c>, declarations rejected by <see cref="IsAcceptableCssValue"/>
+    /// When <c>true</c>, declarations rejected by
+    /// <see cref="CSS.Dom.CssDeclarationValidator.IsAcceptableDeclarationValue"/>
     /// are surfaced through
-    /// <see cref="Broiler.CSS.Dom.CssEngineDiagnostics.DeclarationRejected"/>
+    /// <see cref="CSS.Dom.CssEngineDiagnostics.DeclarationRejected"/>
     /// (diagnostic #1b). The bridge rewrites the serialized <c>style</c> attribute
     /// from the survivors of this filter (see <c>PrepareCanonicalDocumentForRendering</c>),
     /// so a dropped inline declaration vanishes before the renderer's own style engine
@@ -834,16 +820,19 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     private static Dictionary<string, string> ParseStyle(string styleValue, bool reportDrops = false)
     {
         var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        var declarations = new Broiler.CSS.CssParser().ParseDeclarations(styleValue);
+        var declarations = new CSS.CssParser().ParseDeclarations(styleValue);
         foreach (var declaration in declarations.Declarations)
         {
             var prop = declaration.Name;
-            var val = declaration.Value.Text;
-            if (declaration.Important)
-                val += " !important";
+            // Validate the importance-stripped value against the shared CSS.Dom
+            // declaration table (the same closed-keyword error-recovery the cascade
+            // uses), then re-attach the "!important" suffix the bridge-owned
+            // declaration map carries as part of the string value.
+            var rawValue = declaration.Value.Text;
 
-            if (IsAcceptableCssValue(prop, val))
+            if (CSS.Dom.CssDeclarationValidator.IsAcceptableDeclarationValue(prop, rawValue))
             {
+                var val = declaration.Important ? rawValue + " !important" : rawValue;
                 result[prop] = val;
                 // Map vendor-prefixed property to unprefixed equivalent (TODO-G9)
                 var unprefixed = StripVendorPrefix(prop);
@@ -852,9 +841,9 @@ public sealed partial class DomBridge : IDomBridgeRuntime
             }
             else if (reportDrops)
             {
-                // Report the raw value (without the synthetic " !important" suffix) so
+                // Report the raw value (without any synthetic " !important" suffix) so
                 // inline drops aggregate identically to the engine's stylesheet drops.
-                CSS.Dom.CssEngineDiagnostics.DeclarationRejected?.Invoke(prop, declaration.Value.Text);
+                CSS.Dom.CssEngineDiagnostics.DeclarationRejected?.Invoke(prop, rawValue);
             }
         }
         return result;
@@ -878,222 +867,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         return property;
     }
 
-    /// <summary>
-    /// CSS error recovery: returns <c>false</c> for values that are clearly
-    /// invalid for the given property.  Only properties with a closed set of
-    /// keyword values are validated; all other properties accept any non-empty value.
-    /// </summary>
-    private static bool IsAcceptableCssValue(string property, string value)
-    {
-        if (string.IsNullOrWhiteSpace(value)) return false;
-
-        // CSS-wide keywords are always valid
-        var v = value.ToLowerInvariant();
-        if (v is "inherit" or "initial" or "unset" or "revert") return true;
-
-        // Custom-property references are validated after cascade, not during
-        // raw declaration parsing. Keep them so the later resolution step can
-        // substitute them into closed-keyword properties too.
-        if (v.IndexOf("var(", StringComparison.OrdinalIgnoreCase) >= 0) return true;
-
-        switch (property.ToLowerInvariant())
-        {
-            case "white-space":
-                return IsWhiteSpaceValue(v);
-
-            case "display":
-                return v is "block" or "inline" or "inline-block" or "none"
-                    or "flex" or "inline-flex" or "grid" or "inline-grid"
-                    or "table" or "table-row" or "table-cell" or "table-column"
-                    or "table-row-group" or "table-header-group"
-                    or "table-footer-group" or "table-column-group"
-                    or "table-caption" or "list-item" or "contents"
-                    or "run-in" or "flow-root";
-
-            case "position":
-                return v is "static" or "relative" or "absolute" or "fixed" or "sticky";
-
-            case "float":
-            case "css-float":
-                return v is "none" or "left" or "right" or "inline-start" or "inline-end";
-
-            case "clear":
-                return v is "none" or "left" or "right" or "both" or "inline-start" or "inline-end";
-
-            case "visibility":
-                return v is "visible" or "hidden" or "collapse";
-
-            case "overflow":
-            case "overflow-x":
-            case "overflow-y":
-                // CSS Overflow Level 3: overflow can be one or two keywords
-                // (e.g. "hidden scroll" sets overflow-x:hidden and overflow-y:scroll).
-                foreach (var part in v.Split(' ', StringSplitOptions.RemoveEmptyEntries))
-                {
-                    if (part is not ("visible" or "hidden" or "scroll" or "auto" or "clip"))
-                        return false;
-                }
-                return true;
-
-            case "text-align":
-                // CSS Text 4: text-align is a shorthand; 'justify-all' additionally
-                // justifies the last line.  The -webkit-{left,right,center} legacy
-                // keywords are non-standard but widely supported.
-                return v is "left" or "right" or "center" or "justify"
-                    or "start" or "end" or "justify-all" or "match-parent"
-                    or "-webkit-left" or "-webkit-right" or "-webkit-center";
-
-            case "text-align-last":
-                return v is "auto" or "start" or "end" or "left" or "right"
-                    or "center" or "justify" or "match-parent";
-
-            case "text-decoration-style":
-                return v is "solid" or "double" or "dotted" or "dashed" or "wavy";
-
-            case "text-transform":
-                return IsTextTransformValue(v);
-
-            case "vertical-align":
-                // Also accepts lengths/percentages, which won't match these keywords
-                return v is "baseline" or "sub" or "super" or "text-top"
-                    or "text-bottom" or "middle" or "top" or "bottom"
-                    || IsLengthOrPercentage(v);
-
-            case "box-sizing":
-                return v is "content-box" or "border-box";
-
-            case "cursor":
-                return v is "auto" or "default" or "none" or "context-menu"
-                    or "help" or "pointer" or "progress" or "wait"
-                    or "cell" or "crosshair" or "text" or "vertical-text"
-                    or "alias" or "copy" or "move" or "no-drop"
-                    or "not-allowed" or "grab" or "grabbing"
-                    or "e-resize" or "n-resize" or "ne-resize" or "nw-resize"
-                    or "s-resize" or "se-resize" or "sw-resize" or "w-resize"
-                    or "ew-resize" or "ns-resize" or "nesw-resize" or "nwse-resize"
-                    or "col-resize" or "row-resize" or "all-scroll" or "zoom-in" or "zoom-out"
-                    || v.StartsWith("url(", StringComparison.Ordinal);
-
-            case "list-style-type":
-                return v is "disc" or "circle" or "square" or "decimal"
-                    or "decimal-leading-zero" or "lower-roman" or "upper-roman"
-                    or "lower-greek" or "lower-latin" or "upper-latin"
-                    or "armenian" or "georgian" or "lower-alpha" or "upper-alpha"
-                    or "none";
-
-            case "border-style":
-            case "border-top-style":
-            case "border-right-style":
-            case "border-bottom-style":
-            case "border-left-style":
-            case "outline-style":
-                return v is "none" or "hidden" or "dotted" or "dashed"
-                    or "solid" or "double" or "groove" or "ridge"
-                    or "inset" or "outset";
-
-            case "font-style":
-                return v is "normal" or "italic" or "oblique";
-
-            case "font-weight":
-                return v is "normal" or "bold" or "bolder" or "lighter"
-                    || (int.TryParse(v, out var w) && w >= 1 && w <= 1000);
-
-            case "color":
-            case "background-color":
-            case "border-color":
-            case "border-top-color":
-            case "border-right-color":
-            case "border-bottom-color":
-            case "border-left-color":
-            case "outline-color":
-                // CSS color values: named colors, #hex, rgb(), rgba(),
-                // hsl(), hsla(), transparent, currentcolor.
-                // Reject unknown vendor-prefixed values (e.g. -acid3-bogus).
-                return !v.StartsWith('-')
-                    || v.StartsWith("-webkit-", StringComparison.Ordinal)
-                    || v.StartsWith("-moz-", StringComparison.Ordinal)
-                    || v.StartsWith("-ms-", StringComparison.Ordinal)
-                    || v.StartsWith("-o-", StringComparison.Ordinal);
-
-            default:
-                // For all other properties accept any non-empty value
-                return true;
-        }
-    }
-
     /// <summary>Checks whether <paramref name="v"/> looks like a CSS length or percentage.</summary>
-    // CSS Text 3 §2.1: none | [ [capitalize | uppercase | lowercase] || full-width
-    // || full-size-kana ] | math-auto. The case keywords are mutually exclusive; a
-    // valid multi-token value combines at most one case keyword with full-width
-    // and/or full-size-kana (in any order), each at most once.
-    // CSS Text 4 §3: white-space is a shorthand for white-space-collapse and
-    // text-wrap-mode. Accepts a legacy single keyword or the two-longhand form
-    // <'white-space-collapse'> || <'text-wrap-mode'> (at most one collapse keyword
-    // combined with at most one wrap keyword, in either order), so modern values
-    // like "preserve-breaks" and "break-spaces nowrap" are not dropped.
-    private static bool IsWhiteSpaceValue(string v)
-    {
-        if (v is "normal" or "nowrap" or "pre" or "pre-wrap" or "pre-line")
-            return true;
-
-        bool collapseSeen = false, wrapSeen = false;
-        foreach (var token in v.Split(' ', StringSplitOptions.RemoveEmptyEntries))
-        {
-            switch (token)
-            {
-                case "collapse":
-                case "preserve":
-                case "preserve-breaks":
-                case "preserve-spaces":
-                case "break-spaces":
-                    if (collapseSeen) return false;
-                    collapseSeen = true;
-                    break;
-                case "wrap":
-                case "nowrap":
-                    if (wrapSeen) return false;
-                    wrapSeen = true;
-                    break;
-                default:
-                    return false;
-            }
-        }
-
-        return collapseSeen || wrapSeen;
-    }
-
-    private static bool IsTextTransformValue(string v)
-    {
-        if (v is "none" or "math-auto")
-            return true;
-
-        bool caseSeen = false, fullWidth = false, fullSizeKana = false;
-        foreach (var token in v.Split(' ', StringSplitOptions.RemoveEmptyEntries))
-        {
-            switch (token)
-            {
-                case "capitalize":
-                case "uppercase":
-                case "lowercase":
-                    if (caseSeen) return false;
-                    caseSeen = true;
-                    break;
-                case "full-width":
-                    if (fullWidth) return false;
-                    fullWidth = true;
-                    break;
-                case "full-size-kana":
-                    if (fullSizeKana) return false;
-                    fullSizeKana = true;
-                    break;
-                default:
-                    return false;
-            }
-        }
-
-        return caseSeen || fullWidth || fullSizeKana;
-    }
-
     private static bool IsLengthOrPercentage(string v)
     {
         if (v == "0") return true;
@@ -1115,23 +889,26 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         return false;
     }
 
+    [GeneratedRegex(@"<title[^>]*>(?<content>[\s\S]*?)</title>", RegexOptions.IgnoreCase | RegexOptions.Compiled, "de-DE")]
+    private static partial Regex TitlePatternRegex();
+    [GeneratedRegex(@"<(?<tag>[a-zA-Z][a-zA-Z0-9]*)\b(?<attrs>[^>]*)\/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled, "de-DE")]
+    private static partial Regex OpenTagPatternRegex();
+    [GeneratedRegex(@"\bid\s*=\s*[""'](?<id>[^""']+)[""']", RegexOptions.IgnoreCase | RegexOptions.Compiled, "de-DE")]
+    private static partial Regex IdPatternRegex();
+    [GeneratedRegex(@"\bclass\s*=\s*[""'](?<cls>[^""']+)[""']", RegexOptions.IgnoreCase | RegexOptions.Compiled, "de-DE")]
+    private static partial Regex ClassPatternRegex();
+    [GeneratedRegex(@"\[(?<name>[a-zA-Z][a-zA-Z0-9_:-]*)(?:(?<op>[~|^$*]?=)(?<value>[""'][^""']*[""']|[^\]]*))?\]", RegexOptions.Compiled)]
+    private static partial Regex AttributeSelectorPatternRegex();
+    [GeneratedRegex(@"<!DOCTYPE\s+(\w+)(?:\s+PUBLIC\s+""([^""]*)""(?:\s+""([^""]*)"")?)?\s*>", RegexOptions.IgnoreCase | RegexOptions.Compiled, "de-DE")]
+    private static partial Regex DocTypePatternRegex();
 }
 
 /// <summary>
 /// Custom JSObject subclass for HTMLFormControlsCollection that returns null
 /// (not undefined) for named property lookups that don't match any control.
 /// </summary>
-internal sealed class FormElementsCollection : JSObject
+internal sealed class FormElementsCollection(DomElement form, DomBridge bridge) : JSObject()
 {
-    private readonly DomElement _form;
-    private readonly DomBridge _bridge;
-
-    public FormElementsCollection(DomElement form, DomBridge bridge) : base()
-    {
-        _form = form;
-        _bridge = bridge;
-    }
-
     protected override JSValue GetValue(KeyString key, JSValue receiver, bool throwError = true)
     {
         // First check own properties (length, numeric indices, known names)
@@ -1143,12 +920,12 @@ internal sealed class FormElementsCollection : JSObject
         var prop = key.Value.ToString();
         if (!string.IsNullOrEmpty(prop))
         {
-            var controls = DomBridge.CollectFormControls(_form);
+            var controls = DomBridge.CollectFormControls(form);
             foreach (var ctrl in controls)
             {
                 if (ctrl.Attributes.TryGetValue("name", out var name) &&
                     string.Equals(name, prop, StringComparison.Ordinal))
-                    return _bridge.ToJSObject(ctrl);
+                    return bridge.ToJSObject(ctrl);
             }
         }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
@@ -330,7 +330,7 @@ public sealed partial class DomBridge
                 props[kv.Key] = kv.Value;
 
             ExpandCssShorthands(props);
-            ResolveLengthAttrFunctions(props, element);
+            CSS.Dom.CssStyleEngine.ResolveLengthAttrFunctions(props, element);
             ResolveExplicitInheritedValues(props, element);
             ApplyInheritedProperties(props, element);
 
@@ -385,7 +385,7 @@ public sealed partial class DomBridge
                 }
             }
 
-            if (CssInitialValues.TryGetValue(key, out var initialValue))
+            if (CSS.Dom.CssComputedDefaults.InitialValues.TryGetValue(key, out var initialValue))
                 props[key] = initialValue;
             else
                 props.Remove(key);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -39,188 +39,6 @@ public sealed partial class DomBridge
     //  CSS specificity (Level 3) and <style> / <link> cascading
     // ------------------------------------------------------------------
 
-    /// <summary>
-    /// CSS initial values for commonly queried properties.
-    /// <c>getComputedStyle()</c> returns these when no CSS rule sets the property.
-    /// </summary>
-    private static readonly Dictionary<string, string> CssInitialValues = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["display"] = "inline",
-        ["position"] = "static",
-        ["float"] = "none",
-        ["visibility"] = "visible",
-        ["overflow"] = "visible",
-        ["overflow-x"] = "visible",
-        ["overflow-y"] = "visible",
-        ["text-transform"] = "none",
-        ["text-decoration"] = "none",
-        ["text-align"] = "start",
-        ["text-align-last"] = "auto",
-        ["text-indent"] = "0px",
-        ["text-shadow"] = "none",
-        ["white-space"] = "normal",
-        ["cursor"] = "auto",
-        ["font-style"] = "normal",
-        ["font-variant"] = "normal",
-        ["font-weight"] = "normal",
-        ["font-size"] = "16px",
-        ["font-family"] = "serif",
-        ["line-height"] = "normal",
-        ["letter-spacing"] = "normal",
-        ["word-spacing"] = "normal",
-        ["color"] = "rgb(0, 0, 0)",
-        ["background-color"] = "rgba(0, 0, 0, 0)",
-        ["background-image"] = "none",
-        ["background-position"] = "0% 0%",
-        ["background-repeat"] = "repeat",
-        ["margin"] = "0px",
-        ["margin-top"] = "0px",
-        ["margin-right"] = "0px",
-        ["margin-bottom"] = "0px",
-        ["margin-left"] = "0px",
-        ["padding"] = "0px",
-        ["padding-top"] = "0px",
-        ["padding-right"] = "0px",
-        ["padding-bottom"] = "0px",
-        ["padding-left"] = "0px",
-        ["border-style"] = "none",
-        ["border-width"] = "0px",
-        ["border-color"] = "rgb(0, 0, 0)",
-        ["border-top-width"] = "0px",
-        ["border-right-width"] = "0px",
-        ["border-bottom-width"] = "0px",
-        ["border-left-width"] = "0px",
-        ["border-top-style"] = "none",
-        ["border-right-style"] = "none",
-        ["border-bottom-style"] = "none",
-        ["border-left-style"] = "none",
-        ["border-top-color"] = "rgb(0, 0, 0)",
-        ["border-right-color"] = "rgb(0, 0, 0)",
-        ["border-bottom-color"] = "rgb(0, 0, 0)",
-        ["border-left-color"] = "rgb(0, 0, 0)",
-        ["border-collapse"] = "separate",
-        ["border-spacing"] = "0px",
-        ["opacity"] = "1",
-        ["vertical-align"] = "baseline",
-        ["clear"] = "none",
-        ["z-index"] = "auto",
-        ["top"] = "auto",
-        ["right"] = "auto",
-        ["bottom"] = "auto",
-        ["left"] = "auto",
-        ["width"] = "auto",
-        ["height"] = "auto",
-        ["min-width"] = "0px",
-        ["min-height"] = "0px",
-        ["max-width"] = "none",
-        ["max-height"] = "none",
-        ["box-sizing"] = "content-box",
-        ["list-style-type"] = "disc",
-        ["list-style-position"] = "outside",
-        ["content"] = "normal",
-        ["transform"] = "none",
-        ["mix-blend-mode"] = "normal",
-        ["background-blend-mode"] = "normal",
-        ["isolation"] = "auto",
-        ["filter"] = "none",
-        ["writing-mode"] = "horizontal-tb",
-        ["zoom"] = "1",
-    };
-
-    private static readonly HashSet<string> CssInheritedProperties = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "color",
-        "cursor",
-        "font-family",
-        "font-size",
-        "font-style",
-        "font-variant",
-        "font-weight",
-        "letter-spacing",
-        "line-height",
-        "text-align",
-        "text-align-last",
-        "text-indent",
-        "text-shadow",
-        "text-transform",
-        "visibility",
-        "white-space",
-        "word-spacing",
-        "writing-mode",
-    };
-
-    private static readonly Dictionary<string, string> UserAgentDefaultDisplayValues = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["html"] = "block",
-        ["address"] = "block",
-        ["blockquote"] = "block",
-        ["body"] = "block",
-        ["dd"] = "block",
-        ["div"] = "block",
-        ["dl"] = "block",
-        ["dt"] = "block",
-        ["fieldset"] = "block",
-        ["form"] = "block",
-        ["frame"] = "block",
-        ["frameset"] = "block",
-        ["h1"] = "block",
-        ["h2"] = "block",
-        ["h3"] = "block",
-        ["h4"] = "block",
-        ["h5"] = "block",
-        ["h6"] = "block",
-        ["noframes"] = "block",
-        ["ol"] = "block",
-        ["p"] = "block",
-        ["ul"] = "block",
-        ["center"] = "block",
-        ["dir"] = "block",
-        ["menu"] = "block",
-        ["pre"] = "block",
-        ["section"] = "block",
-        ["article"] = "block",
-        ["nav"] = "block",
-        ["aside"] = "block",
-        ["header"] = "block",
-        ["footer"] = "block",
-        ["main"] = "block",
-        ["figure"] = "block",
-        ["figcaption"] = "block",
-        ["details"] = "block",
-        ["li"] = "list-item",
-        ["summary"] = "list-item",
-        ["table"] = "table",
-        ["tr"] = "table-row",
-        ["thead"] = "table-header-group",
-        ["tbody"] = "table-row-group",
-        ["tfoot"] = "table-footer-group",
-        ["col"] = "table-column",
-        ["colgroup"] = "table-column-group",
-        ["td"] = "table-cell",
-        ["th"] = "table-cell",
-        ["caption"] = "table-caption",
-        ["button"] = "inline-block",
-        ["textarea"] = "inline-block",
-        ["input"] = "inline-block",
-        ["select"] = "inline-block",
-        ["iframe"] = "inline-block",
-        ["object"] = "inline-block",
-        ["head"] = "none",
-        ["style"] = "none",
-        ["title"] = "none",
-        ["script"] = "none",
-        ["link"] = "none",
-        ["meta"] = "none",
-        ["area"] = "none",
-        ["base"] = "none",
-        ["param"] = "none",
-        ["template"] = "none",
-        ["dialog"] = "none",
-    };
-
-    private static readonly System.Text.RegularExpressions.Regex LengthAttrFunctionPattern = new(
-        @"attr\(\s*(?<name>[A-Za-z_][A-Za-z0-9_-]*)\s+type\(\s*<length>\s*\)\s*(?:,\s*(?<fallback>[^)]+?))?\s*\)",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     /// <summary>
     /// Compatibility view of the main document's shared stylesheet model as the
@@ -276,57 +94,6 @@ public sealed partial class DomBridge
             {
                 MaterializeLegacyCssRules(atRule.Rules, target);
             }
-        }
-    }
-
-    private static bool IsRecognizedLengthValue(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            return false;
-
-        var trimmed = value.Trim();
-        return trimmed == "0" || !double.IsNaN(ParseCssLengthToPixels(trimmed));
-    }
-
-    private static void ResolveLengthAttrFunctions(
-        Dictionary<string, string> computed,
-        DomElement element)
-    {
-        foreach (var key in computed.Keys.ToList())
-        {
-            var value = computed[key];
-            if (string.IsNullOrWhiteSpace(value) ||
-                value.IndexOf("attr(", StringComparison.OrdinalIgnoreCase) < 0)
-            {
-                continue;
-            }
-
-            computed[key] = LengthAttrFunctionPattern.Replace(
-                value,
-                match =>
-                {
-                    var attrName = match.Groups["name"].Value;
-                    var fallback = match.Groups["fallback"].Success
-                        ? match.Groups["fallback"].Value.Trim()
-                        : string.Empty;
-                    var attributeValue = element.Attributes.TryGetValue(attrName, out var raw)
-                        ? raw.Trim()
-                        : string.Empty;
-
-                    if (!string.IsNullOrEmpty(attributeValue) &&
-                        IsRecognizedLengthValue(attributeValue))
-                    {
-                        return attributeValue;
-                    }
-
-                    if (!string.IsNullOrEmpty(fallback) &&
-                        IsRecognizedLengthValue(fallback))
-                    {
-                        return fallback;
-                    }
-
-                    return string.Empty;
-                });
         }
     }
 
@@ -623,7 +390,7 @@ public sealed partial class DomBridge
             return;
 
         var parentProps = GetComputedProps(element.Parent);
-        foreach (var property in CssInheritedProperties)
+        foreach (var property in CSS.Dom.CssComputedDefaults.InheritedProperties)
         {
             if (computed.ContainsKey(property))
                 continue;
@@ -1001,7 +768,7 @@ public sealed partial class DomBridge
             return;
         }
 
-        if (UserAgentDefaultDisplayValues.TryGetValue(element.TagName, out var display))
+        if (CSS.Dom.CssUserAgentDefaults.DisplayValues.TryGetValue(element.TagName, out var display))
             computed["display"] = display;
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
@@ -8,21 +8,6 @@ internal readonly record struct EventListenerRegistration(
     bool Once = false,
     bool Passive = false);
 
-internal sealed class MutationObserverOptions
-{
-    public bool ChildList { get; set; }
-
-    public bool Attributes { get; set; }
-
-    public bool AttributeOldValue { get; set; }
-
-    public bool CharacterData { get; set; }
-
-    public bool CharacterDataOldValue { get; set; }
-
-    public bool Subtree { get; set; }
-}
-
 /// <summary>
 /// JavaScript and browser-runtime state associated with a legacy DOM node.
 /// The node model deliberately does not own this state.

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
@@ -65,12 +65,12 @@ public sealed partial class DomBridge
     }
 
 
-    private static MutationObserverOptions CreateMutationObserverOptions(JSValue? value)
+    private static Broiler.Dom.DomMutationObserverOptions CreateMutationObserverOptions(JSValue? value)
     {
         if (value is not JSObject optionsObject)
-            return new MutationObserverOptions();
+            return new Broiler.Dom.DomMutationObserverOptions();
 
-        return new MutationObserverOptions
+        return new Broiler.Dom.DomMutationObserverOptions
         {
             ChildList = GetMutationObserverOption(optionsObject, "childList"),
             Attributes = GetMutationObserverOption(optionsObject, "attributes"),
@@ -82,7 +82,7 @@ public sealed partial class DomBridge
     }
 
 
-    private void RegisterMutationObserver(JSObject observerObject, DomElement target, MutationObserverOptions options)
+    private void RegisterMutationObserver(JSObject observerObject, DomElement target, Broiler.Dom.DomMutationObserverOptions options)
     {
         _mutationObservers.RemoveAll(entry =>
             ReferenceEquals(entry.Observer, observerObject) &&

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Utilities.cs
@@ -252,28 +252,32 @@ public sealed partial class DomBridge
     }
 
 
+    // classList operations delegate to the canonical Broiler.Dom.DomTokenList
+    // ordered-set algorithm (parse/serialize on ASCII whitespace, unique-ordered,
+    // attribute-synchronized). The bridge keeps only the JavaScript argument
+    // marshaling, the lenient empty-token skip these methods have always applied,
+    // and the style-scope invalidation callback.
     private static JSValue JsUtilitiesContains025Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
         if (a.Length == 0)
             return JSBoolean.False;
-        var cls = a[0].ToString();
-        var classes = new HashSet<string>((element.ClassName ?? string.Empty).Split(' ').Where(s => s.Length > 0), StringComparer.Ordinal);
-        return classes.Contains(cls) ? JSBoolean.True : JSBoolean.False;
+        return new global::Broiler.Dom.DomTokenList(element, "class").Contains(a[0].ToString())
+            ? JSBoolean.True
+            : JSBoolean.False;
     }
 
 
     private static JSValue JsUtilitiesAdd026Core(global::Broiler.HtmlBridge.DomElement element, global::System.Action<global::Broiler.HtmlBridge.DomElement>? onClassChanged, in Arguments a)
     {
-        var classes = (element.ClassName ?? string.Empty).Split(' ').Where(s => s.Length > 0).ToList();
-        var classSet = new HashSet<string>(classes, StringComparer.Ordinal);
+        var tokens = new List<string>();
         for (var i = 0; i < a.Length; i++)
         {
             var cls = a[i].ToString();
-            if (!string.IsNullOrEmpty(cls) && classSet.Add(cls))
-                classes.Add(cls);
+            if (!string.IsNullOrEmpty(cls))
+                tokens.Add(cls);
         }
 
-        element.ClassName = string.Join(" ", classes);
+        new global::Broiler.Dom.DomTokenList(element, "class").Add(tokens.ToArray());
         onClassChanged?.Invoke(element);
         return JSUndefined.Value;
     }
@@ -281,11 +285,15 @@ public sealed partial class DomBridge
 
     private static JSValue JsUtilitiesRemove027Core(global::Broiler.HtmlBridge.DomElement element, global::System.Action<global::Broiler.HtmlBridge.DomElement>? onClassChanged, in Arguments a)
     {
-        var toRemove = new HashSet<string>(StringComparer.Ordinal);
+        var tokens = new List<string>();
         for (var i = 0; i < a.Length; i++)
-            toRemove.Add(a[i].ToString());
-        var classes = (element.ClassName ?? string.Empty).Split(' ').Where(s => s.Length > 0 && !toRemove.Contains(s)).ToList();
-        element.ClassName = string.Join(" ", classes);
+        {
+            var cls = a[i].ToString();
+            if (!string.IsNullOrEmpty(cls))
+                tokens.Add(cls);
+        }
+
+        new global::Broiler.Dom.DomTokenList(element, "class").Remove(tokens.ToArray());
         onClassChanged?.Invoke(element);
         return JSUndefined.Value;
     }
@@ -296,24 +304,21 @@ public sealed partial class DomBridge
         if (a.Length == 0)
             return JSBoolean.False;
         var cls = a[0].ToString();
-        var classes = (element.ClassName ?? string.Empty).Split(' ').Where(s => s.Length > 0).ToList();
-        var classSet = new HashSet<string>(classes, StringComparer.Ordinal);
-        bool shouldAdd = a.Length >= 2 && a[1] is not JSUndefined ? a[1].BooleanValue : !classSet.Contains(cls);
-        if (shouldAdd)
-        {
-            if (classSet.Add(cls))
-                classes.Add(cls);
-            element.ClassName = string.Join(" ", classes);
-            onClassChanged?.Invoke(element);
-            return JSBoolean.True;
-        }
-        else
-        {
-            classes.Remove(cls);
-            element.ClassName = string.Join(" ", classes);
-            onClassChanged?.Invoke(element);
+        bool? force = a.Length >= 2 && a[1] is not JSUndefined ? a[1].BooleanValue : null;
+        var present = new global::Broiler.Dom.DomTokenList(element, "class").Toggle(cls, force);
+        onClassChanged?.Invoke(element);
+        return present ? JSBoolean.True : JSBoolean.False;
+    }
+
+
+    private static JSValue JsUtilitiesReplaceClassToken(global::Broiler.HtmlBridge.DomElement element, global::System.Action<global::Broiler.HtmlBridge.DomElement>? onClassChanged, in Arguments a)
+    {
+        if (a.Length < 2)
             return JSBoolean.False;
-        }
+        var replaced = new global::Broiler.Dom.DomTokenList(element, "class").Replace(a[0].ToString(), a[1].ToString());
+        if (replaced)
+            onClassChanged?.Invoke(element);
+        return replaced ? JSBoolean.True : JSBoolean.False;
     }
 
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsNative.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsNative.cs
@@ -13,43 +13,19 @@ public sealed partial class DomBridge
     private static readonly JSFunctionDelegate ReturnTrueDelegate = ReturnTrue;
     private static readonly JSFunctionDelegate ReturnZeroDelegate = ReturnZero;
 
-    private static JSFunction UndefinedFunction(string name, int length = 0)
-    {
-        return new JSFunction(ReturnUndefinedDelegate, name, length);
-    }
+    private static JSFunction UndefinedFunction(string name, int length = 0) => new(ReturnUndefinedDelegate, name, length);
 
-    private static JSFunction NullFunction(string name, int length = 0)
-    {
-        return new JSFunction(ReturnNullDelegate, name, length);
-    }
+    private static JSFunction NullFunction(string name, int length = 0) => new(ReturnNullDelegate, name, length);
 
-    private static JSFunction TrueFunction(string name, int length = 0)
-    {
-        return new JSFunction(ReturnTrueDelegate, name, length);
-    }
+    private static JSFunction TrueFunction(string name, int length = 0) => new(ReturnTrueDelegate, name, length);
 
-    private static JSFunction ZeroFunction(string name, int length = 0)
-    {
-        return new JSFunction(ReturnZeroDelegate, name, length);
-    }
+    private static JSFunction ZeroFunction(string name, int length = 0) => new(ReturnZeroDelegate, name, length);
 
-    private static JSValue ReturnUndefined(in Arguments _)
-    {
-        return JSUndefined.Value;
-    }
+    private static JSValue ReturnUndefined(in Arguments _) => JSUndefined.Value;
 
-    private static JSValue ReturnNull(in Arguments _)
-    {
-        return JSNull.Value;
-    }
+    private static JSValue ReturnNull(in Arguments _) => JSNull.Value;
 
-    private static JSValue ReturnTrue(in Arguments _)
-    {
-        return JSBoolean.True;
-    }
+    private static JSValue ReturnTrue(in Arguments _) => JSBoolean.True;
 
-    private static JSValue ReturnZero(in Arguments _)
-    {
-        return new JSNumber(0);
-    }
+    private static JSValue ReturnZero(in Arguments _) => new JSNumber(0);
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
@@ -228,8 +228,41 @@ public sealed partial class DomBridge
             : ParseCssRuleStrings(nestedCss).Select(rule => BuildCssKeyframeRuleObject(rule, parentStyleSheet, parentRule)))
         .ToList();
 
-    private static JSObject BuildCssKeyframeRuleObject(Broiler.CSS.CssRule rule, JSObject parentStyleSheet, JSObject parentRule) =>
-        BuildCssKeyframeRuleObject(CSS.CssSerializer.Serialize(rule), parentStyleSheet, parentRule);
+    private static JSObject BuildCssKeyframeRuleObject(Broiler.CSS.CssRule rule, JSObject parentStyleSheet, JSObject parentRule)
+    {
+        // A keyframe block is a style rule whose selector is the key text
+        // (e.g. "0%, 50%"). Read the key + declarations from the model instead of
+        // serializing and re-parsing; unexpected shapes fall back to the text path.
+        if (rule is not Broiler.CSS.CssStyleRule styleRule)
+            return BuildCssKeyframeRuleObject(CSS.CssSerializer.Serialize(rule), parentStyleSheet, parentRule);
+
+        var ruleObj = new JSObject();
+        ruleObj.FastAddProperty(
+            (KeyString)"parentStyleSheet",
+            new JSFunction((in Arguments _) => parentStyleSheet, "get parentStyleSheet"),
+            null,
+            JSPropertyAttributes.EnumerableConfigurableProperty);
+        ruleObj.FastAddProperty(
+            (KeyString)"parentRule",
+            new JSFunction((in Arguments _) => parentRule, "get parentRule"),
+            null,
+            JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        ruleObj.FastAddValue((KeyString)"type", new JSNumber(8), JSPropertyAttributes.EnumerableConfigurableValue);
+
+        var keyText = CSS.Cssom.CssomRuleMetadata.GetSelectorText(styleRule);
+        ruleObj.FastAddValue((KeyString)"keyText", new JSString(keyText), JSPropertyAttributes.EnumerableConfigurableValue);
+        ruleObj.FastAddProperty(
+            (KeyString)"cssText",
+            new JSFunction((in Arguments _) => JsStyleSheetsGetCssText013Core(keyText, ruleObj, in _), "get cssText"),
+            null,
+            JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        var styleObj = BuildStyleObject(ParseStyle(CSS.CssSerializer.Serialize(styleRule.Declarations)), ruleObj);
+        ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
+
+        return ruleObj;
+    }
 
     private static JSObject BuildCssKeyframeRuleObject(string ruleText, JSObject parentStyleSheet, JSObject parentRule)
     {
@@ -286,22 +319,296 @@ public sealed partial class DomBridge
     /// </summary>
     /// <summary>
     /// Builds a CSSRule JSObject from a shared <see cref="Broiler.CSS.CssRule"/>
-    /// model object (Phase 6). Rule detail extraction is shared with the
-    /// string-based builder via deterministic serialization, so behaviour is
-    /// identical while the CSSOM's rule storage is the model, not strings.
+    /// model object. Rule kind and metadata (selector text, prelude-derived
+    /// media/condition/name/href/prefix values, keyframe keys, and descriptors)
+    /// are read from the neutral <see cref="Broiler.CSS.Cssom.CssomRuleMetadata"/>
+    /// projection and the declaration model rather than by serializing the rule and
+    /// re-parsing the text. Declaration blocks still feed the JavaScript
+    /// <c>CSSStyleDeclaration</c> wrapper through <see cref="ParseStyle"/> on the
+    /// serialized block, which is unchanged. Unrecognized at-rules (for example
+    /// <c>@container</c> or a vendor-prefixed <c>@-webkit-keyframes</c>) fall back to
+    /// the legacy string builder, preserving their current behavior.
     /// </summary>
-    private static JSObject BuildCssRuleObject(Broiler.CSS.CssRule rule, JSObject parentStyleSheet, JSObject? parentRule = null) =>
-        BuildCssRuleObject(
-            CSS.CssSerializer.Serialize(rule),
-            parentStyleSheet,
-            parentRule,
-            // Drive the nested @media/@keyframes/@supports/@layer rule objects from the
-            // model (CssAtRule.Rules) instead of re-parsing serialized text, when the
-            // rule actually has nested rules. Gating on Count > 0 keeps declaration-bodied
-            // at-rules and empty blocks on the string path (Phase 6 tail).
-            rule is Broiler.CSS.CssAtRule { Declarations: null, HasBlock: true, Rules.Count: > 0 } atRule
-                ? atRule.Rules
-                : null);
+    private static JSObject BuildCssRuleObject(Broiler.CSS.CssRule rule, JSObject parentStyleSheet, JSObject? parentRule = null)
+    {
+        var kind = CSS.Cssom.CssomRuleMetadata.GetRuleType(rule);
+        if (kind == CSS.Cssom.CssomRuleType.Unknown)
+            return BuildCssRuleObject(CSS.CssSerializer.Serialize(rule), parentStyleSheet, parentRule);
+
+        var ruleObj = new JSObject();
+        ruleObj.FastAddProperty(
+            (KeyString)"parentStyleSheet",
+            new JSFunction((in Arguments _) => parentStyleSheet, "get parentStyleSheet"),
+            null,
+            JSPropertyAttributes.EnumerableConfigurableProperty);
+        ruleObj.FastAddProperty(
+            (KeyString)"parentRule",
+            new JSFunction((in Arguments _) => parentRule ?? JSNull.Value, "get parentRule"),
+            null,
+            JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        ruleObj.FastAddValue((KeyString)"type", new JSNumber((int)kind), JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // Builds the JS CSSStyleDeclaration for a declaration-bodied rule from the
+        // model's declaration block — identical to the legacy substring path because
+        // ParseStyle sees the same declarations, just serialized from the block.
+        JSObject StyleFromBlock(Broiler.CSS.CssDeclarationBlock? block)
+        {
+            var map = block is null
+                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                : ParseStyle(CSS.CssSerializer.Serialize(block));
+            return BuildStyleObject(map, ruleObj);
+        }
+
+        switch (kind)
+        {
+            case CSS.Cssom.CssomRuleType.Charset:
+            {
+                var encoding = CSS.Cssom.CssomRuleMetadata.GetCharsetEncoding((Broiler.CSS.CssAtRule)rule);
+                ruleObj.FastAddValue((KeyString)"encoding", new JSString(encoding), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty(
+                    (KeyString)"cssText",
+                    new JSFunction((in Arguments _) => new JSString($"@charset \"{encoding}\";"), "get cssText"),
+                    null,
+                    JSPropertyAttributes.EnumerableConfigurableProperty);
+                break;
+            }
+
+            case CSS.Cssom.CssomRuleType.Import:
+            {
+                var import = CSS.Cssom.CssomRuleMetadata.GetImport((Broiler.CSS.CssAtRule)rule);
+                ruleObj.FastAddValue((KeyString)"href", new JSString(import.Href), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue((KeyString)"media", new JSString(import.Media), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty(
+                    (KeyString)"cssText",
+                    new JSFunction((in Arguments _) => JsStyleSheetsGetCssText017Core(import.Href, import.Media, in _), "get cssText"),
+                    null,
+                    JSPropertyAttributes.EnumerableConfigurableProperty);
+                break;
+            }
+
+            case CSS.Cssom.CssomRuleType.Media:
+            {
+                var atRule = (Broiler.CSS.CssAtRule)rule;
+                var mediaText = atRule.Prelude;
+                var nestedRuleObjects = BuildNestedRuleObjects(string.Empty, atRule.Rules, parentStyleSheet, ruleObj);
+                var nestedCssRules = BuildCssRuleListObject(
+                    nestedRuleObjects,
+                    text => BuildCssRuleObject(text, parentStyleSheet, ruleObj));
+
+                ruleObj.FastAddValue((KeyString)"media", new JSString(mediaText), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty(
+                    (KeyString)"cssText",
+                    new JSFunction((in Arguments _) => JsStyleSheetsGetCssText018Core(mediaText, nestedRuleObjects, in _), "get cssText"),
+                    null,
+                    JSPropertyAttributes.EnumerableConfigurableProperty);
+                break;
+            }
+
+            case CSS.Cssom.CssomRuleType.FontFace:
+            {
+                var styleObj = StyleFromBlock(((Broiler.CSS.CssAtRule)rule).Declarations);
+                ruleObj.FastAddProperty(
+                    (KeyString)"cssText",
+                    new JSFunction((in Arguments _) => JsStyleSheetsGetCssText019Core(styleObj, in _), "get cssText"),
+                    null,
+                    JSPropertyAttributes.EnumerableConfigurableProperty);
+                ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
+                break;
+            }
+
+            case CSS.Cssom.CssomRuleType.Keyframes:
+            {
+                var atRule = (Broiler.CSS.CssAtRule)rule;
+                var name = CSS.Cssom.CssomRuleMetadata.GetKeyframesName(atRule);
+                var nestedRuleObjects = BuildNestedKeyframeObjects(string.Empty, atRule.Rules, parentStyleSheet, ruleObj);
+                var nestedCssRules = BuildCssRuleListObject(
+                    nestedRuleObjects,
+                    text => BuildCssKeyframeRuleObject(text, parentStyleSheet, ruleObj));
+
+                ruleObj.FastAddValue((KeyString)"name", new JSString(name), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty(
+                    (KeyString)"cssText",
+                    new JSFunction((in Arguments _) => JsStyleSheetsGetCssText020Core(name, nestedRuleObjects, in _), "get cssText"),
+                    null,
+                    JSPropertyAttributes.EnumerableConfigurableProperty);
+                break;
+            }
+
+            case CSS.Cssom.CssomRuleType.Property:
+            {
+                var descriptors = ParseStyle(CSS.CssSerializer.Serialize(((Broiler.CSS.CssAtRule)rule).Declarations ?? new Broiler.CSS.CssDeclarationBlock([])));
+                var propertyName = ((Broiler.CSS.CssAtRule)rule).Prelude;
+                var syntax = descriptors.TryGetValue("syntax", out var syntaxValue)
+                    ? UnquoteCssPropertyRuleDescriptor(syntaxValue)
+                    : "*";
+                var inherits = !descriptors.TryGetValue("inherits", out var inheritsValue)
+                    || !string.Equals(inheritsValue, "false", StringComparison.OrdinalIgnoreCase);
+                var initialValue = descriptors.GetValueOrDefault("initial-value");
+
+                ruleObj.FastAddValue((KeyString)"name", new JSString(propertyName), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue((KeyString)"syntax", new JSString(syntax), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue((KeyString)"inherits", inherits ? JSBoolean.True : JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue(
+                    (KeyString)"initialValue",
+                    string.IsNullOrEmpty(initialValue) ? JSNull.Value : new JSString(initialValue),
+                    JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty(
+                    (KeyString)"cssText",
+                    new JSFunction((in Arguments _) => JsStyleSheetsGetCssText021Core(inherits, initialValue, propertyName, syntax, in _), "get cssText"),
+                    null,
+                    JSPropertyAttributes.EnumerableConfigurableProperty);
+                break;
+            }
+
+            case CSS.Cssom.CssomRuleType.CounterStyle:
+            {
+                var atRule = (Broiler.CSS.CssAtRule)rule;
+                var ruleName = atRule.Prelude;
+                var descriptors = ParseStyle(CSS.CssSerializer.Serialize(atRule.Declarations ?? new Broiler.CSS.CssDeclarationBlock([])));
+
+                ruleObj.FastAddValue((KeyString)"name", new JSString(ruleName), JSPropertyAttributes.EnumerableConfigurableValue);
+
+                var descriptorMap = new (string CssName, string JsName)[]
+                {
+                    ("system", "system"),
+                    ("symbols", "symbols"),
+                    ("additive-symbols", "additiveSymbols"),
+                    ("negative", "negative"),
+                    ("prefix", "prefix"),
+                    ("suffix", "suffix"),
+                    ("range", "range"),
+                    ("pad", "pad"),
+                    ("fallback", "fallback"),
+                    ("speak-as", "speakAs")
+                };
+
+                foreach (var (cssName, jsName) in descriptorMap)
+                {
+                    ruleObj.FastAddValue(
+                        (KeyString)jsName,
+                        descriptors.TryGetValue(cssName, out var value) ? new JSString(value) : JSUndefined.Value,
+                        JSPropertyAttributes.EnumerableConfigurableValue);
+                }
+
+                ruleObj.FastAddProperty(
+                    (KeyString)"cssText",
+                    new JSFunction((in Arguments _) => JsStyleSheetsGetCssText022Core(descriptorMap, ruleName, ruleObj, in _), "get cssText"),
+                    null,
+                    JSPropertyAttributes.EnumerableConfigurableProperty);
+                break;
+            }
+
+            case CSS.Cssom.CssomRuleType.Supports:
+            {
+                var atRule = (Broiler.CSS.CssAtRule)rule;
+                var conditionText = atRule.Prelude;
+                var nestedRuleObjects = BuildNestedRuleObjects(string.Empty, atRule.Rules, parentStyleSheet, ruleObj);
+                var nestedCssRules = BuildCssRuleListObject(
+                    nestedRuleObjects,
+                    text => BuildCssRuleObject(text, parentStyleSheet, ruleObj));
+
+                ruleObj.FastAddValue((KeyString)"conditionText", new JSString(conditionText), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty(
+                    (KeyString)"cssText",
+                    new JSFunction((in Arguments _) => JsStyleSheetsGetCssText023Core(conditionText, nestedRuleObjects, in _), "get cssText"),
+                    null,
+                    JSPropertyAttributes.EnumerableConfigurableProperty);
+                break;
+            }
+
+            case CSS.Cssom.CssomRuleType.Layer:
+            {
+                var atRule = (Broiler.CSS.CssAtRule)rule;
+                var nameText = atRule.Prelude;
+                if (atRule.HasBlock)
+                {
+                    var nestedRuleObjects = BuildNestedRuleObjects(string.Empty, atRule.Rules, parentStyleSheet, ruleObj);
+                    var nestedCssRules = BuildCssRuleListObject(
+                        nestedRuleObjects,
+                        text => BuildCssRuleObject(text, parentStyleSheet, ruleObj));
+
+                    ruleObj.FastAddValue(
+                        (KeyString)"name",
+                        string.IsNullOrEmpty(nameText) ? JSNull.Value : new JSString(nameText),
+                        JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddProperty(
+                        (KeyString)"cssText",
+                        new JSFunction((in Arguments _) => JsStyleSheetsGetCssText024Core(nameText, nestedRuleObjects, in _), "get cssText"),
+                        null,
+                        JSPropertyAttributes.EnumerableConfigurableProperty);
+                }
+                else
+                {
+                    // Statement form: `@layer a, b;` — no block, empty cssRules.
+                    ruleObj.FastAddValue(
+                        (KeyString)"name",
+                        string.IsNullOrEmpty(nameText) ? JSNull.Value : new JSString(nameText),
+                        JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddValue((KeyString)"cssRules", BuildCssRuleListObject([]), JSPropertyAttributes.EnumerableConfigurableValue);
+                    ruleObj.FastAddProperty(
+                        (KeyString)"cssText",
+                        new JSFunction((in Arguments _) => JsStyleSheetsGetCssText025Core(nameText, in _), "get cssText"),
+                        null,
+                        JSPropertyAttributes.EnumerableConfigurableProperty);
+                }
+                break;
+            }
+
+            case CSS.Cssom.CssomRuleType.Namespace:
+            {
+                var ns = CSS.Cssom.CssomRuleMetadata.GetNamespace((Broiler.CSS.CssAtRule)rule);
+                ruleObj.FastAddValue((KeyString)"namespaceURI", new JSString(ns.Uri), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue(
+                    (KeyString)"prefix",
+                    string.IsNullOrEmpty(ns.Prefix) ? JSUndefined.Value : new JSString(ns.Prefix),
+                    JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty(
+                    (KeyString)"cssText",
+                    new JSFunction((in Arguments _) => JsStyleSheetsGetCssText026Core(ns.Uri, ns.Prefix, in _), "get cssText"),
+                    null,
+                    JSPropertyAttributes.EnumerableConfigurableProperty);
+                break;
+            }
+
+            case CSS.Cssom.CssomRuleType.Page:
+            {
+                var atRule = (Broiler.CSS.CssAtRule)rule;
+                var selectorText = atRule.Prelude;
+                var styleObj = StyleFromBlock(atRule.Declarations);
+                ruleObj.FastAddValue((KeyString)"selectorText", new JSString(selectorText), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty(
+                    (KeyString)"cssText",
+                    new JSFunction((in Arguments _) => JsStyleSheetsGetCssText027Core(selectorText, styleObj, in _), "get cssText"),
+                    null,
+                    JSPropertyAttributes.EnumerableConfigurableProperty);
+                break;
+            }
+
+            default:
+            {
+                // CSSStyleRule — type 1
+                var styleRule = (Broiler.CSS.CssStyleRule)rule;
+                var selectorText = CSS.Cssom.CssomRuleMetadata.GetSelectorText(styleRule);
+                ruleObj.FastAddValue((KeyString)"selectorText", new JSString(selectorText), JSPropertyAttributes.EnumerableConfigurableValue);
+                ruleObj.FastAddProperty(
+                    (KeyString)"cssText",
+                    new JSFunction((in Arguments _) => JsStyleSheetsGetCssText028Core(ruleObj, selectorText, in _), "get cssText"),
+                    null,
+                    JSPropertyAttributes.EnumerableConfigurableProperty);
+                var styleObj = StyleFromBlock(styleRule.Declarations);
+                ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
+                break;
+            }
+        }
+
+        return ruleObj;
+    }
 
     private static JSObject BuildCssRuleObject(string ruleText, JSObject parentStyleSheet, JSObject? parentRule = null, IReadOnlyList<Broiler.CSS.CssRule>? nestedModelRules = null)
     {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
@@ -1042,16 +1042,11 @@ public sealed partial class DomBridge
         if (_mutationObservers.Count == 0)
             return;
 
+        var mutation = new Broiler.Dom.DomMutationRecord(Broiler.Dom.DomMutationType.ChildList, target);
         foreach (var (observer, observedTarget, options) in _mutationObservers.ToArray())
         {
-            if (!options.ChildList)
+            if (!Broiler.Dom.DomMutationObserverFilter.Matches(mutation, observedTarget, options))
                 continue;
-
-            if (!ReferenceEquals(target, observedTarget) &&
-                !(options.Subtree && IsDescendant(observedTarget, target)))
-            {
-                continue;
-            }
 
             if (observer[(KeyString)"_notify"] is not JSFunction notifyFunction)
                 continue;
@@ -1081,9 +1076,10 @@ public sealed partial class DomBridge
         if (_mutationObservers.Count == 0)
             return;
 
+        var mutation = new Broiler.Dom.DomMutationRecord(Broiler.Dom.DomMutationType.Attributes, target, AttributeName: attributeName);
         foreach (var (observer, observedTarget, options) in _mutationObservers.ToArray())
         {
-            if (!options.Attributes || !ShouldNotifyMutationObserver(target, observedTarget, options))
+            if (!Broiler.Dom.DomMutationObserverFilter.Matches(mutation, observedTarget, options))
                 continue;
 
             if (observer[(KeyString)"_notify"] is not JSFunction notifyFunction)
@@ -1106,9 +1102,10 @@ public sealed partial class DomBridge
         if (_mutationObservers.Count == 0)
             return;
 
+        var mutation = new Broiler.Dom.DomMutationRecord(Broiler.Dom.DomMutationType.CharacterData, target);
         foreach (var (observer, observedTarget, options) in _mutationObservers.ToArray())
         {
-            if (!options.CharacterData || !ShouldNotifyMutationObserver(target, observedTarget, options))
+            if (!Broiler.Dom.DomMutationObserverFilter.Matches(mutation, observedTarget, options))
                 continue;
 
             if (observer[(KeyString)"_notify"] is not JSFunction notifyFunction)
@@ -1136,12 +1133,6 @@ public sealed partial class DomBridge
         UpdateCharacterData(target, newValue);
         if (!string.Equals(previousValue, target.TextContent, StringComparison.Ordinal))
             NotifyCharacterDataMutationObservers(target, previousValue);
-    }
-
-    private bool ShouldNotifyMutationObserver(DomElement target, DomElement observedTarget, MutationObserverOptions options)
-    {
-        return ReferenceEquals(target, observedTarget) ||
-               (options.Subtree && IsDescendant(observedTarget, target));
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -1024,6 +1024,12 @@ public sealed partial class DomBridge
             new JSFunction((in Arguments a) => JsUtilitiesToggle028Core(element, onClassChanged, in a), "toggle", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
+        // classList.replace(oldToken, newToken)
+        classList.FastAddValue(
+            (KeyString)"replace",
+            new JSFunction((in Arguments a) => JsUtilitiesReplaceClassToken(element, onClassChanged, in a), "replace", 2),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
         return classList;
     }
 


### PR DESCRIPTION
## Summary

Promotes neutral DOM/CSS algorithms out of `Broiler.HtmlBridge` into the canonical `Broiler.CSS` / `Broiler.DOM` components, per [`docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md`](docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md). The bridge is routed through the shared APIs; behavior is preserved (verified against no-change baselines and the DOM/CSS test suites).

Requires the paired submodule PRs to merge first (pointers are bumped to already-pushed commits):
- `Broiler.CSS` → branch `phase1-css-declaration-validator` (`e019c95`)
- `Broiler.DOM` → branch `dom-promotion-phase4` (`22c732b`)

## What changed, by phase

- **Phase 0** — Boundary lock: `HtmlBridgePromotionPhaseZeroTests` (seam inventory + guards that `Broiler.Dom` has no JS-engine deps and `Broiler.CSS.Dom` no bridge deps) and architecture-note reconciliation.
- **Phase 1** — Shared `CssDeclarationValidator` (single source for closed-keyword value validation); `DomBridge.ParseStyle` routes through it; bridge `IsAcceptableCssValue` + helpers deleted.
- **Phase 2** — Shared public `CssComputedDefaults` (initial values + inherited set), `CssUserAgentDefaults` (tag→display), and `CssStyleEngine.ResolveLengthAttrFunctions`; the bridge's private computed-style tables/`attr()` copy are deleted (fixes a drifted `text-align-last` initial). The full `GetComputedProps`→`GetComputedStyle` cutover is deliberately **not** done (sparse-map contract across ~200 consumers + layout-specific form-control sizing) — see the roadmap note.
- **Phase 3** — `Broiler.CSS.Cssom.CssomRuleMetadata` (neutral CSSOM projection over `CssRule`); `StyleSheets.cs` builds CSSOM objects from the model instead of `Serialize(rule)` + substring re-parse.
- **Phase 4** — `DomTokenList` (classList ordered set), `DomMutationObserverFilter` (observer option matching), and `DomRange` boundary API; the bridge delegates to each (TreeWalker/NodeIterator were already canonical). Also completes standard DOM members (`DomException.Name`, `DomElement.Prefix`, `DomDocument.GetElementsByTagName`), fixing the previously-broken DOM test suite.

## Testing

- `Broiler.CSS.Tests` 86, `Broiler.CSS.Dom.Tests` 193, `Broiler.Dom.Tests` 51 — all pass.
- Bridge CLI subsets (inline-style, CSSOM, classList, mutation-observer, DOM, geometry) show **no new failures** vs. baseline; the 10 `MutationObserver` and 102 DOM bridge tests pass. Pre-existing baseline failures (e.g. `Border_Shorthand_Expands_Color_To_Individual_Sides`) are unchanged.

## Reviewer notes

- **Bundled pre-existing changes (disclosure):** this branch also carries uncommitted working-tree changes that predated the session and were intermingled — notably in `DomBridge.cs` (could not be split non-interactively), plus `DomBridge.Selectors.cs`, `DomBridge.Serialization.cs`, `JsNative.cs`, `Broiler.slnx`, and two sample `PublishProfiles`. They are included so the commit matches the tested working tree; they are not part of the promotion work and should be reviewed on their own merits (or split out if preferred).
- Deferred within the roadmap: Phase 2 anchor cutover, Phase 4 slice-8 bridge range-content-ops routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)