### PR TITLE
RF-BRIDGE-1b: shared-geometry scroll overflow, zoom correctness & Element.remove() fix

### DIFF
--- a/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
+++ b/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
@@ -323,12 +323,49 @@ other two are gated on prerequisites that are not yet met (documented below).
 
 - **BLOCKED — finish RF-BRIDGE-1b geometry unification** (delete the ~2700-LOC
   `LayoutMetrics` estimators, increment 6, and retire `LayoutRuntimeState`,
-  increment 7). The `UseSharedLayoutGeometry` flag is now **on** (increment 5
-  landed), but the estimators remain the necessary fallback: the parity gate still
-  carries `KnownRendererGapRegressions = 3` because the **renderer has no
-  `position-try` (and anchor/grid) layout**, so those elements lay out 0×0 on the
-  shared path. Deleting the estimators today regresses geometry. Unblocks only when
-  the renderer implements that layout and the parity shortfall drops to 0.
+  increment 7). The `UseSharedLayoutGeometry` flag is **on** (increment 5 landed).
+
+  **Correction (2026-07-09): the previously-documented blocker was stale.** The
+  renderer *does* now size `@position-try` elements correctly on the shared path —
+  `position-try-002` width+height and `position-try-grid-001` height all match. The
+  parity gate now reads **shared 345 / estimator 72 of 484** (the shared path beats
+  the estimators by 273 assertions), so `KnownRendererGapRegressions` has been
+  lowered from 3 to **0**. Position-try *fallback offsets* are still wrong on the
+  shared path, but they are wrong on the estimator path too, so they are not a
+  shared-vs-estimator regression and do not gate the deletion.
+
+  **The actual blocker for increments 6–7 is a shared-provider capability gap, not
+  position-try sizing.** `SharedLayoutGeometryProvider` only supplies static box
+  geometry (border/padding/content boxes for laid-out elements). The estimators —
+  and `LayoutRuntimeState` — remain load-bearing for four things the provider does
+  **not** supply, so deleting them today regresses real, tested behavior:
+  1. **Scroll overflow extents** (`scrollWidth/Height`) — *partially migrated
+     (2026-07-09)*: `GetScrollWidth/HeightForDomElement` now answer **non-root,
+     unzoomed** elements from the shared snapshot (`TryGetSharedScrollExtent`),
+     regression-free. Zoomed subtrees and the root/viewport still use the estimator.
+     **Zoom (2026-07-09):** all shared geometry branches gate on
+     `IsUnzoomedForSharedGeometry`; zoomed elements use the estimator (path-independent).
+     A snapshot-side divide-by-zoom was tried and reverted (double-counts in the render
+     pipeline, which bakes zoom into serialized sizes). Correct zoom values locked in by
+     `SharedGeometryZoomSizeTests`. Separately fixed an `Element.remove()` NRE (read
+     computed `Parent` after detach) that was the real blocker for 4 zoom pixel tests —
+     flipped `ScrollMetricsIncludeChildZoomOverflow`, `ClientAndScrollMetricsIncludePadding`,
+     `ZoomGeometryApis`, `ZoomIcUnit` green. Then implemented the **render-doc/live-doc
+     separation for zoom** (extract zoom baking from the guarded transforms + revert after
+     the geometry snapshot so the live/CSSOM doc stays pristine) — flipped
+     `ZoomScrollAndOffsetApis`, `ZoomScrollPadding`, `ZoomScrollIntoViewAbsolutePosition`
+     green (Zoom suite 7→1; only unrelated `PinchZoom` remains). Zero regressions. See
+     rf-bridge-1b §5 incr 6.
+  2. **Sticky positioning** (`AnchorResolver/StickyPositioning.cs`) — uses
+     `ComputeOffsetWithinAncestor` and the border/content-box estimators.
+  3. **`scrollIntoView`** alignment geometry.
+  4. **Position-area / anchor resolved geometry** — the anchor resolver
+     (`PositionArea.cs`, `PositionAreaQueries.cs`) stores results in
+     `LayoutRuntimeState`.
+
+  Increments 6–7 unblock only once the provider/renderer covers scroll-overflow,
+  sticky, `scrollIntoView`, and position-area geometry (the deferred "later
+  increments" in rf-bridge-1b §5). Until then the estimators stay.
 
 Goal: remove compatibility adapters once consumers are on canonical APIs.
 

--- a/docs/roadmap/rf-bridge-1b-layout-unification.md
+++ b/docs/roadmap/rf-bridge-1b-layout-unification.md
@@ -161,18 +161,163 @@ natural fit for the existing per-pass `WithLayoutGeometryCache` lifetime. Benchm
    **DONE.** `DomBridge.UseSharedLayoutGeometry` now defaults to **true**
    ([`SharedLayoutGeometry.cs`](../../src/Broiler.HtmlBridge.Dom/DomBridge/SharedLayoutGeometry.cs));
    the live geometry entry points read the shared renderer layout, with the
-   estimators kept as the per-element fallback. The parity gate holds with a
-   documented `KnownRendererGapRegressions = 3` budget (the renderer's missing
-   `position-try`/anchor/grid layout — those elements fall back to the estimator).
-   Increments 6–7 (delete the estimators, retire `LayoutRuntimeState`) stay blocked
-   until the renderer closes that layout gap and the shortfall reaches 0.
+   estimators kept as the per-element fallback.
+
+   **Update (2026-07-09): parity budget lowered 3 → 0.** The renderer now sizes
+   `@position-try` elements correctly on the shared path (`position-try-002`
+   width+height, `position-try-grid-001` height all match), so the earlier
+   3-assertion budget was retired. The gate now reads **shared 345 / estimator 72
+   of 484** — the shared path beats the estimators by 273 assertions —
+   and holds at `KnownRendererGapRegressions = 0`. Position-try fallback *offsets*
+   are still wrong on the shared path, but the estimator gets them wrong too, so
+   they are not a shared-vs-estimator regression.
 6. **Delete the estimators.** Remove the ~2700-line estimator body from
    `LayoutMetrics.cs`, keeping only the thin JS-facing wrappers that now call the
    provider. Retire `WithLayoutGeometryCache` (the provider's snapshot cache replaces
    its purpose).
+   **BLOCKED (2026-07-09) — not on position-try sizing (that works now), but on a
+   provider capability gap.** `SharedLayoutGeometryProvider` only supplies static
+   box geometry (border/padding/content boxes for laid-out elements). The estimator
+   graph is still load-bearing for geometry the provider does **not** supply, so a
+   deletion regresses real behavior:
+   - **Scroll overflow extents** (`scrollWidth/Height`) — *partially migrated
+     (2026-07-09)*. `GetScrollWidth/HeightForDomElement` now answer **non-root,
+     unzoomed** elements from the shared snapshot via `TryGetSharedScrollExtent`
+     (union of the element's padding box + descendant border boxes from the snapshot;
+     `SharedScrollOverflowTests`), regression-free across the full scroll test family
+     (identical pass/fail set vs HEAD). Still on the estimator: (a) **zoomed
+     subtrees** (see the zoom note below); (b) the **root/viewport** scroll area.
+   - **Sticky positioning** (`AnchorResolver/StickyPositioning.cs`) — uses
+     `ComputeOffsetWithinAncestor` + border/content-box estimators.
+   - **`scrollIntoView`** alignment geometry.
+
+   **Zoom handling (2026-07-09).** The shared snapshot is in the renderer's *zoomed*
+   document space, so the raw shared branches returned zoomed values (`clientWidth` of a
+   `zoom:2` element read 120 not 60). **All shared geometry branches gate on
+   `IsUnzoomedForSharedGeometry`; zoomed elements route to the estimator**, which
+   resolves zoom from CSS directly and is path-independent.
+
+   A snapshot-side "divide by cumulative zoom" fix was tried and **reverted** — it is
+   correct for a plain `DomBridge` but double-counts in the render pipeline, because
+   `GetRenderDocument`'s `ApplyZoomSerializationStyles` bakes `zoom` into the serialized
+   box *size* while leaving the `zoom` property readable, so the snapshot box is already
+   partly unzoomed and dividing again halves it (`clientWidth` 60 → 30 in the pipeline).
+   The estimator avoids this entirely. Correct zoom size values are locked in
+   (path-independently) by `SharedGeometryZoomSizeTests`.
+
+   **`Element.remove()` bug fixed (2026-07-09) — this was the real blocker for the zoom
+   pixel tests.** `element.remove()` read `element.Parent` (computed from `ParentNode`)
+   *after* `Children.RemoveAt` had detached it → captured `null` →
+   `InvalidateStyleScope(null)` threw an NRE (surfaced to JS as a `ReferenceError`).
+   Any script calling `el.remove()` broke — including the CSSOM zoom tests' `measure()`
+   cleanup, which is why they were red (the pre-existing red `#pass` box never turned
+   green). Fixed by capturing the parent before removal, mirroring `removeChild`
+   (`ElementRemoveTests`). This flipped **4** previously-red tests:
+   `ScrollMetricsIncludeChildZoomOverflow`, `ClientAndScrollMetricsIncludePadding`,
+   `ZoomGeometryApis`, and `ZoomIcUnit`. Zero regressions (scroll family, mutation
+   observers, parity all unchanged/green). Remaining zoom failures
+   (`ZoomScrollAndOffsetApis`, `ZoomScrollPadding`, `ZoomScrollIntoViewAbsolutePosition`,
+   `PinchZoom`) are pre-existing and use `removeChild`/other paths — separate issues.
+
+   **`ZoomScrollAndOffsetApis` root cause (found 2026-07-09) — deep, pre-existing.**
+   Probing its values through the render pipeline shows only the *container-zoom* element
+   is wrong: `withZoom` (`zoom:4`) reports `clientWidth`/`scrollWidth` = 400/1000 instead
+   of 100/250 (exactly ×4); everything else (child-zoom overflow, scroll offsets, offsets)
+   is correct. Cause: `ApplyZoomSerializationStyles` (in `GetRenderDocument`)
+   **permanently mutates the live document** — it bakes zoom into the element's size
+   (`width:100`→`width:400`) and removes the `zoom` property (DomBridge.Serialization.cs
+   §ApplyZoomSerializationStyles). It runs once per pass when the shared snapshot is
+   built (triggered by any earlier *unzoomed* geometry query). Afterward the unzoomed
+   CSSOM metrics (`clientWidth`/`offsetWidth`) can't recover the original size — the zoom
+   info is gone. `getBoundingClientRect` passes precisely because it *wants* the zoomed
+   value (baked-size × zoom(now 1) = correct). This is an architectural conflict: one
+   document serves both rendering (needs baked zoom) and CSSOM (needs original zoom).
+   A proper fix separates the render document from the live/CSSOM document (don't mutate
+   the live DOM in `GetRenderDocument`), or preserves the used-zoom so unzoomed metrics
+   can divide it back out — both larger, higher-risk changes, deferred.
+
+   **Render-doc/live-doc separation — IMPLEMENTED for the zoom transform (2026-07-09).**
+   `GetRenderDocument` and `SerializeToHtml` share one guarded `ApplySerializationTransforms`
+   (`_serializationTransformsApplied`, runs once) that mutates the live document:
+   `RemoveRenderCommentNodes` (tree), `ApplyZoomSerializationStyles` (per-element style,
+   destructive), `ApplyZoomPseudoSerializationOverrides` (injects a `<style>` into `<head>`),
+   `ApplyProgressLikeSerializationPlaceholders` (injects child placeholders). This one path
+   serves three consumers with conflicting needs: JS-facing `outerHTML`/render (want baked)
+   and the geometry snapshot (wants baked for layout, then the live doc pristine for
+   subsequent CSSOM).
+
+   The full guard reset can't be reused per pass because the pseudo/progress transforms are
+   *non-idempotent* (re-running duplicates the injected nodes). The implemented fix isolates
+   the one *destructive, revertible* transform — zoom baking:
+   - `ApplyZoomSerializationStyles` is **extracted from the guarded set** and called by
+     `GetRenderDocument`/`SerializeToHtml` directly (before the guarded pseudo/progress,
+     preserving their zoom-baked-size dependency; idempotent once the `zoom` property is
+     stripped).
+   - When a `_zoomSerializationRevertLog` is installed, it records each mutated element's
+     pre-bake `Style`+`Attributes`; `RevertZoomSerialization` restores them (and clears the
+     computed-props cache).
+   - `BuildSharedGeometrySnapshot` installs the log, builds the (baked) snapshot for correct
+     rendered geometry, then reverts — leaving the live/CSSOM document pristine. The render
+     and `SerializeToHtml` paths install no log, so their baking stays permanent (unchanged).
+
+   Result: `ZoomScrollAndOffsetApis`, `ZoomScrollPadding`, and `ZoomScrollIntoViewAbsolutePosition`
+   flip green (full Zoom suite 7→1 fail across the session; only the unrelated
+   `PinchZoom` visual-viewport case remains). **Zero regressions** — scroll family (5 fixed,
+   none broken), Acid (13/328 == HEAD), serialization/outerHTML (== HEAD), mutation
+   observers (10/10), parity (345/72), all shared-geometry Cli tests. Regression test:
+   `SharedGeometryZoomSizeTests.Zoomed_Client_Stays_Unzoomed_After_A_Snapshot_Build`.
+
+   The remaining transforms (comment removal, pseudo/progress injection) still mutate the
+   live doc once via the guard — a smaller, separate residual; the same revert-log pattern
+   (or a full clone-with-identity-mapping keyed by `CssBox.SourceElement`) would extend the
+   separation to them if a JS-facing need arises.
+
+   Unblocks once the provider/renderer path also covers zoomed + root scroll, sticky,
+   and `scrollIntoView` geometry (the deferred "later increments" in §5). Then the
+   estimator helpers used only by the offset/client/bounding-rect entry points can
+   be removed and the fallback set to zeros (detached/`display:none` semantics).
+
+   **Deletion sequence (found 2026-07-09) — the remaining increments are ORDERED, and
+   intermediate migrations have no deletion payoff.** Every geometry entry point keeps
+   the estimator as a *fallback* for: `isRoot`/viewport, zoomed subtrees (the zoom
+   gate), position-area resolution, and boxless elements. The estimator body cannot be
+   deleted until *all* those fallbacks are covered without it. Concretely:
+   1. **Zoom-correct shared snapshot** (in progress, separate session). Until zoomed
+      elements are answered from shared, the zoom gate routes them to the estimator, so
+      the estimator can't go.
+   2. **A pre-layout geometry source for the resolvers.** Sticky/position-area run
+      *inside* `ResolveAnchorPositions` and mutate the DOM. They *can* read shared
+      geometry without recursion (`GetRenderDocument` does NOT run the resolvers — the
+      anchor resolver already does this via `TryGetAnchorLayoutBox`), **but a piecemeal
+      migration is unsafe**: `ComputeOffsetWithinAncestor` subtracts intermediate
+      **scroll offsets** (`GetElementScrollOffset`) and sticky runs *before* scroll
+      simulation, whereas the shared snapshot carries no JS-set scroll state — so a
+      shared-geometry sticky offset would diverge from the estimator exactly in the
+      scroll cases sticky exists to handle. Migrate these only at the final cutover with
+      a scroll-aware pre-layout geometry source, not as an intermediate step.
+   3. **Flip the fallback to zeros** (detached/`display:none` semantics) and delete the
+      estimator body — the actual deletion, possible only after 1 and 2.
+      **STAGED (2026-07-09).** The fallback→zeros is implemented behind the default-OFF
+      `DomBridge.UseSharedGeometryExclusively` flag: when on, every geometry entry point
+      (client/offset W/H, `getBoundingClientRect`, `scrollWidth/Height`, `offsetTop/Left`)
+      returns zero for an unzoomed element with no shared box instead of consulting the
+      estimator (`ShouldReturnExclusiveSharedZero`). Default off ⇒ zero behavior change
+      (verified: scroll family identical to HEAD); flipping it on is verified to read
+      real geometry for boxed elements and zero for `display:none`
+      (`SharedGeometryExclusiveCutoverTests`). It can be turned on — and the estimator
+      bodies deleted — once steps 1 and 2 land.
+
+   Net: no migration between here and step 3 deletes an estimator or flips a test; the
+   fallback mechanism is now staged (default off). The next *payoff-bearing* prerequisite
+   is the zoom-correct shared snapshot (step 1).
 7. **Move `LayoutRuntimeState`** (`ElementRuntimeState.cs:102`, four
    `RuntimeValue<double>` slots) out last — most of it becomes obsolete once geometry
    comes from the shared snapshot.
+   **BLOCKED (2026-07-09) — still load-bearing.** `LayoutRuntimeState` is not yet
+   obsolete: the anchor resolver stores resolved position-area geometry in it
+   (`AnchorResolver/PositionArea.cs` writes `.Layout.{Left,Top,Width,Height}`,
+   `PositionAreaQueries.cs` reads them). Retiring it requires routing position-area
+   anchor resolution through shared geometry first.
 
 ## 5a. Blocker found (2026-06-29) — the typed render path drops author `<style>` CSS
 

--- a/src/Broiler.Cli.Tests/ElementRemoveTests.cs
+++ b/src/Broiler.Cli.Tests/ElementRemoveTests.cs
@@ -1,0 +1,44 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Regression test for the <c>Element.remove()</c> bridge bug: the callback read
+/// <c>element.Parent</c> (computed from the canonical <c>ParentNode</c>) *after*
+/// <c>Children.RemoveAt</c> had already detached it, so the captured parent was null →
+/// <c>InvalidateStyleScope(null)</c> threw a <c>NullReferenceException</c> (surfaced to
+/// JS as a <c>ReferenceError</c>). This broke any script calling <c>el.remove()</c> —
+/// e.g. the CSSOM zoom tests' <c>measure()</c> cleanup. Fixed by capturing the parent
+/// before removal, mirroring the working <c>removeChild</c> path.
+/// </summary>
+[Xunit.Collection("SharedGeometryStatics")]
+public sealed class ElementRemoveTests
+{
+    private static string Eval(string script)
+    {
+        const string html = "<!DOCTYPE html><html><head></head><body></body></html>";
+        using var ctx = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(ctx, html, "file:///remove.html");
+        return ctx.Eval(script).ToString();
+    }
+
+    [Fact]
+    public void Remove_Detaches_Element_Without_Throwing()
+    {
+        Assert.Equal("true|0|ok", Eval(
+            "(function(){" +
+            "var y=document.createElement('div'); document.body.appendChild(y);" +
+            "y.remove();" +
+            "return (y.parentNode===null) + '|' + document.body.children.length + '|ok';" +
+            "})()"));
+    }
+
+    [Fact]
+    public void Remove_On_Detached_Element_Is_A_Noop()
+    {
+        Assert.Equal("ok", Eval(
+            "(function(){var y=document.createElement('div'); y.remove(); return 'ok';})()"));
+    }
+}

--- a/src/Broiler.Cli.Tests/SharedGeometryExclusiveCutoverTests.cs
+++ b/src/Broiler.Cli.Tests/SharedGeometryExclusiveCutoverTests.cs
@@ -1,0 +1,60 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// RF-BRIDGE-1b increment 6 (staged cutover): verifies the default-OFF
+/// <see cref="DomBridge.UseSharedGeometryExclusively"/> flag. When flipped on, unzoomed
+/// geometry queries answer exclusively from the shared snapshot — a boxed element reads
+/// its real geometry and a boxless (detached / <c>display:none</c>) element reads zero,
+/// with no estimator consultation. This locks in the deletion-enabling behavior so the
+/// final estimator removal is a small step once the zoom-correct snapshot lands.
+/// </summary>
+[Xunit.Collection("SharedGeometryStatics")]
+public sealed class SharedGeometryExclusiveCutoverTests
+{
+    private static string Measure(string html, string id, bool exclusive)
+    {
+        var prev = DomBridge.UseSharedGeometryExclusively;
+        DomBridge.UseSharedGeometryExclusively = exclusive;
+        try
+        {
+            using var ctx = new JSContext();
+            var bridge = new DomBridge();
+            bridge.Attach(ctx, html, "file:///cutover.html");
+            return ctx.Eval(
+                $"(function(){{var e=document.getElementById('{id}');" +
+                "return [e.offsetWidth,e.offsetHeight,e.clientWidth,e.scrollWidth].join(',');})()").ToString();
+        }
+        finally { DomBridge.UseSharedGeometryExclusively = prev; }
+    }
+
+    [Fact]
+    public void DefaultsOff()
+    {
+        // The staged cutover must stay off by default so the estimator fallback is intact.
+        Assert.False(DomBridge.UseSharedGeometryExclusively);
+    }
+
+    [Fact]
+    public void Exclusive_Boxed_Element_Reads_Real_Shared_Geometry()
+    {
+        const string html = "<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0}</style></head>" +
+            "<body><div id='b' style='width:120px;height:40px'></div></body></html>";
+
+        // offsetWidth, offsetHeight, clientWidth, scrollWidth (empty box → scrollWidth == width)
+        Assert.Equal("120,40,120,120", Measure(html, "b", exclusive: true));
+    }
+
+    [Fact]
+    public void Exclusive_DisplayNone_Element_Reads_Zero_Not_Estimator()
+    {
+        // display:none produces no box; exclusive-shared reports zero geometry (correct),
+        // rather than the estimator's declared-size guess.
+        const string html = "<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0}</style></head>" +
+            "<body><div id='n' style='display:none;width:100px;height:50px'></div></body></html>";
+
+        Assert.Equal("0,0,0,0", Measure(html, "n", exclusive: true));
+    }
+}

--- a/src/Broiler.Cli.Tests/SharedGeometryTestCollection.cs
+++ b/src/Broiler.Cli.Tests/SharedGeometryTestCollection.cs
@@ -1,0 +1,13 @@
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Serializes the RF-BRIDGE-1b shared-geometry tests. Several of them mutate process-wide
+/// static flags (<c>DomBridge.UseSharedLayoutGeometry</c>,
+/// <c>DomBridge.UseSharedGeometryExclusively</c>) via try/finally, while others assert
+/// geometry values that depend on those flags' defaults. xUnit runs test classes in
+/// parallel by default, so without a shared collection a concurrent flag toggle can bleed
+/// into a reader and cause spurious failures. Membership in one collection makes them run
+/// sequentially.
+/// </summary>
+[Xunit.CollectionDefinition("SharedGeometryStatics", DisableParallelization = true)]
+public sealed class SharedGeometryTestCollection;

--- a/src/Broiler.Cli.Tests/SharedGeometryZoomSizeTests.cs
+++ b/src/Broiler.Cli.Tests/SharedGeometryZoomSizeTests.cs
@@ -1,0 +1,87 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// RF-BRIDGE-1b: the CSS size metrics (<c>clientWidth/Height</c>,
+/// <c>offsetWidth/Height</c>, <c>scrollWidth/Height</c>) must report the element's own
+/// unzoomed CSS pixels, and a zoomed descendant's larger extent counts as scroll
+/// overflow. Zoomed elements are answered by the estimator (via the
+/// <c>IsUnzoomedForSharedGeometry</c> gate) because the render pipeline bakes zoom into
+/// the serialized box sizes, which would make a snapshot-side zoom division
+/// double-count. These direct-API assertions lock in the correct values regardless of
+/// which path serves them.
+/// </summary>
+[Xunit.Collection("SharedGeometryStatics")]
+public sealed class SharedGeometryZoomSizeTests
+{
+    private static string Eval(string bodyHtml, string expr)
+    {
+        var html = "<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0}</style></head><body>" +
+                   bodyHtml + "</body></html>";
+        using var ctx = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(ctx, html, "file:///zoomsize.html");
+        return ctx.Eval(expr).ToString();
+    }
+
+    [Fact]
+    public void Client_Metrics_Are_Unzoomed_By_Own_Zoom()
+    {
+        // zoom:2 container, width 20 + padding 10px 20px → clientWidth 60, clientHeight 40
+        // in the element's own CSS pixels (not 120/80).
+        const string body = "<div id='c' style='zoom:2;width:20px;height:20px;padding:10px 20px'></div>";
+        Assert.Equal("60,40", Eval(body,
+            "(function(){var c=document.getElementById('c');return [c.clientWidth,c.clientHeight].join(',');})()"));
+    }
+
+    [Fact]
+    public void Offset_Metrics_Are_Unzoomed_By_Own_Zoom()
+    {
+        const string body = "<div id='c' style='zoom:2;width:100px;height:40px'></div>";
+        Assert.Equal("100,40", Eval(body,
+            "(function(){var c=document.getElementById('c');return [c.offsetWidth,c.offsetHeight].join(',');})()"));
+    }
+
+    [Fact]
+    public void Scroll_Overflow_Counts_Child_Zoom_In_Unzoomed_Container_Pixels()
+    {
+        // Container (no zoom) 20×20 + padding 10px 20px; child 20×20 with zoom:2 renders
+        // 40×40, overflowing → scrollWidth 80 (20+40+20), scrollHeight 60 (10+40+10).
+        const string body =
+            "<div id='c' style='width:20px;height:20px;padding:10px 20px;overflow:auto'>" +
+            "<div style='width:20px;height:20px;zoom:2'></div></div>";
+        Assert.Equal("60,40,80,60", Eval(body,
+            "(function(){var c=document.getElementById('c');" +
+            "return [c.clientWidth,c.clientHeight,c.scrollWidth,c.scrollHeight].join(',');})()"));
+    }
+
+    [Fact]
+    public void Zoomed_Client_Stays_Unzoomed_After_A_Snapshot_Build()
+    {
+        // RF-BRIDGE-1b render-doc/live-doc separation regression: an unzoomed query (u)
+        // builds the shared geometry snapshot, whose GetRenderDocument bakes zoom into the
+        // live document. Without the post-snapshot revert, a later query on the zoomed
+        // element (z) would read the baked size (400). With the separation the live doc is
+        // restored, so z.clientWidth stays the unzoomed 100.
+        const string body =
+            "<div id='u' style='width:50px;height:50px'></div>" +
+            "<div id='z' style='zoom:4;width:100px;height:100px'></div>";
+        Assert.Equal("50|100", Eval(body,
+            "(function(){var u=document.getElementById('u');var first=u.clientWidth;" +
+            "var z=document.getElementById('z');return first+'|'+z.clientWidth;})()"));
+    }
+
+    [Fact]
+    public void Container_Own_Zoom_Divides_Out_Of_Scroll_Overflow()
+    {
+        // Container zoom:2, child 20×20 (no own zoom) → scrollWidth 60 in container pixels.
+        const string body =
+            "<div id='c' style='zoom:2;width:20px;height:20px;padding:10px 20px;overflow:auto'>" +
+            "<div style='width:20px;height:20px'></div></div>";
+        Assert.Equal("60,40,60,40", Eval(body,
+            "(function(){var c=document.getElementById('c');" +
+            "return [c.clientWidth,c.clientHeight,c.scrollWidth,c.scrollHeight].join(',');})()"));
+    }
+}

--- a/src/Broiler.Cli.Tests/SharedLayoutGeometryParityTests.cs
+++ b/src/Broiler.Cli.Tests/SharedLayoutGeometryParityTests.cs
@@ -17,6 +17,7 @@ namespace Broiler.Cli.Tests;
 /// now is to establish the harness and the estimator baseline. Once ③ lands, the gate
 /// fails if the shared path answers fewer assertions correctly than the estimator did.
 /// </summary>
+[Xunit.Collection("SharedGeometryStatics")]
 public sealed class SharedLayoutGeometryParityTests
 {
     private readonly Xunit.Abstractions.ITestOutputHelper _output;
@@ -152,16 +153,16 @@ public sealed class SharedLayoutGeometryParityTests
             $"(±{TolerancePx}px)");
         Assert.Equal(estimator.Total, shared.Total); // same assertions evaluated both ways
 
-        // Known renderer gap: elements using @position-try lay out to 0×0 because the
-        // layout engine does not yet implement position-try fallback, so the shared
-        // path answers 3 fewer check-layout assertions than the estimator on this
-        // corpus (position-try-002 width+height, position-try-grid-001 height). The
-        // estimator "wins" there only by reading the declared width/height it never
-        // laid out. This budget keeps the gate active — it still fails on ANY further
-        // regression — and drops to 0 once the renderer lays out position-try (at which
-        // point the flag can flip). These cases are already in the WPT pixel-failing
-        // baseline, so the renderer does not render them correctly either.
-        const int KnownRendererGapRegressions = 3;
+        // The renderer now sizes @position-try elements correctly on the shared path
+        // (position-try-002 width+height and position-try-grid-001 height all match the
+        // estimator), so the historical 3-assertion budget is retired. Empirically the
+        // shared path now answers far MORE check-layout assertions than the estimator
+        // (≈345 vs ≈72 of 484 on this corpus), so the gate holds at a zero budget: the
+        // shared renderer-layout path must never answer fewer assertions than the coarse
+        // estimator. The remaining shared-path gaps are position-try fallback OFFSETS
+        // (anchor() inset resolution), which the estimator also gets wrong, so they are
+        // not a shared-vs-estimator regression.
+        const int KnownRendererGapRegressions = 0;
 
         // THE GATE: the shared renderer-layout path must answer at least as many
         // assertions correctly as the estimator, minus the documented renderer gap.

--- a/src/Broiler.Cli.Tests/SharedScrollOverflowTests.cs
+++ b/src/Broiler.Cli.Tests/SharedScrollOverflowTests.cs
@@ -1,0 +1,52 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// RF-BRIDGE-1b: locks in the shared-geometry scroll-overflow path
+/// (<see cref="DomBridge"/> <c>scrollWidth</c>/<c>scrollHeight</c> answered from the
+/// renderer-layout snapshot for non-root, unzoomed elements). Guards against a
+/// regression in <c>TryGetSharedScrollExtent</c>; zoomed subtrees deliberately stay
+/// on the estimator and are covered by the CSSOM zoom-scroll tests.
+/// </summary>
+[Xunit.Collection("SharedGeometryStatics")]
+public sealed class SharedScrollOverflowTests
+{
+    private static string EvalScroll(string html, string id)
+    {
+        using var ctx = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(ctx, html, "file:///scroll.html");
+        return ctx.Eval(
+            $"(function(){{var e=document.getElementById('{id}');" +
+            "return [e.clientWidth,e.clientHeight,e.scrollWidth,e.scrollHeight].join(',');})()").ToString();
+    }
+
+    [Fact]
+    public void ScrollExtent_Reflects_Overflowing_Child_From_Shared_Geometry()
+    {
+        // Default flag state (UseSharedLayoutGeometry = true). A 100×100 overflow:auto
+        // container with a larger in-flow child: clientWidth/Height are the padding box
+        // (100×100) and scrollWidth/Height cover the child's border box (250×300).
+        Assert.True(DomBridge.UseSharedLayoutGeometry);
+
+        const string html = "<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0}</style></head><body>" +
+            "<div id='c' style='width:100px;height:100px;overflow:auto'>" +
+            "<div style='width:250px;height:300px'></div></div></body></html>";
+
+        Assert.Equal("100,100,250,300", EvalScroll(html, "c"));
+    }
+
+    [Fact]
+    public void ScrollExtent_Includes_Container_End_Padding()
+    {
+        // padding:10px 20px → clientWidth 100+40=140, clientHeight 100+20=120. A child
+        // that fills the content box does not overflow, so scroll == client.
+        const string html = "<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0}</style></head><body>" +
+            "<div id='c' style='width:100px;height:100px;padding:10px 20px;overflow:auto'>" +
+            "<div style='width:100px;height:100px'></div></div></body></html>";
+
+        Assert.Equal("140,120,140,120", EvalScroll(html, "c"));
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -20,6 +20,14 @@ public sealed partial class DomBridge
     private const double DefaultProgressLikeTrackLengthPx = 120;
     private readonly Dictionary<DomElement, Dictionary<string, string>> _zoomSpecifiedStyleCache = [];
 
+    // RF-BRIDGE-1b render-doc/live-doc separation: when non-null, ApplyZoomSerializationStyles
+    // records each mutated element's pre-bake Style + Attributes here so the geometry-snapshot
+    // path can restore the live document afterward (zoom baking is destructive — it scales
+    // sizes and drops the `zoom` property — which would otherwise corrupt subsequent unzoomed
+    // CSSOM queries, e.g. clientWidth of a zoomed element). The render/serialize paths leave
+    // this null so their baking stays permanent.
+    private List<(DomElement Element, Dictionary<string, string> Style, Dictionary<string, string> Attributes)>? _zoomSerializationRevertLog;
+
     /// <summary>
     /// Serialises the current DOM tree back to an HTML string.
     /// Call this after JavaScript execution to obtain the modified page
@@ -27,6 +35,7 @@ public sealed partial class DomBridge
     /// </summary>
     public string SerializeToHtml()
     {
+        ApplyZoomSerializationStyles(DocumentElement, 1.0);
         ApplySerializationTransforms();
         return SharedHtmlSerializer.Serialize(
             DocumentElement,
@@ -46,9 +55,47 @@ public sealed partial class DomBridge
     /// </summary>
     public Broiler.Dom.DomDocument GetRenderDocument()
     {
+        // Zoom baking runs per call (not part of the run-once guarded transforms) so the
+        // geometry-snapshot path can revert it afterward via _zoomSerializationRevertLog;
+        // it is idempotent once baked (the `zoom` property is stripped), so repeat calls on
+        // the render path are no-ops. Must run before the guarded pseudo/progress transforms,
+        // which depend on the baked sizes.
+        ApplyZoomSerializationStyles(DocumentElement, 1.0);
         ApplySerializationTransforms();
         ReflectRenderState(DocumentElement);
         return _document;
+    }
+
+    /// <summary>
+    /// RF-BRIDGE-1b render-doc/live-doc separation: restores the live document's zoom-baked
+    /// elements to their pre-bake Style/Attributes (captured in
+    /// <see cref="_zoomSerializationRevertLog"/>). Called by the geometry-snapshot path after
+    /// the layout is captured, so subsequent CSSOM/estimator queries see pristine (unzoomed)
+    /// styles rather than the render-oriented baked sizes.
+    /// </summary>
+    private void RevertZoomSerialization()
+    {
+        var log = _zoomSerializationRevertLog;
+        _zoomSerializationRevertLog = null;
+        if (log == null)
+            return;
+
+        for (var i = log.Count - 1; i >= 0; i--)
+        {
+            var (element, style, attributes) = log[i];
+            RestoreStringMap(element.Style, style);
+            RestoreStringMap(element.Attributes, attributes);
+        }
+
+        // Reverted styles must not read back the baked values from the computed cache.
+        _computedPropsCache.Clear();
+    }
+
+    private static void RestoreStringMap(IDictionary<string, string> target, Dictionary<string, string> saved)
+    {
+        target.Clear();
+        foreach (var kv in saved)
+            target[kv.Key] = kv.Value;
     }
 
     private void ReflectRenderState(DomElement element)
@@ -101,7 +148,9 @@ public sealed partial class DomBridge
 
         _serializationTransformsApplied = true;
         RemoveRenderCommentNodes(DocumentElement);
-        ApplyZoomSerializationStyles(DocumentElement, 1.0);
+        // Zoom baking is applied by the callers (GetRenderDocument/SerializeToHtml) before this,
+        // so it can be reverted on the geometry-snapshot path; pseudo/progress below depend on
+        // the baked sizes and must run after it.
         ApplyZoomPseudoSerializationOverrides();
         ApplyProgressLikeSerializationPlaceholders(DocumentElement);
     }
@@ -350,7 +399,17 @@ public sealed partial class DomBridge
         var specifiedZoom = props.GetValueOrDefault("zoom");
         var usedZoom = ResolveSpecifiedZoom(specifiedZoom, parentZoom);
 
-        if (Math.Abs(usedZoom - 1.0) > ZoomSerializationEpsilon)
+        var willScale = Math.Abs(usedZoom - 1.0) > ZoomSerializationEpsilon;
+        var willSvg = ShouldApplySvgSerializationAttributes(element);
+        // Record the pre-bake state for the geometry-snapshot revert (only when this element
+        // is actually mutated — scaled, SVG-adjusted, or carrying a `zoom` to strip).
+        if (_zoomSerializationRevertLog != null && (willScale || willSvg || element.Style.ContainsKey("zoom")))
+            _zoomSerializationRevertLog.Add((
+                element,
+                new Dictionary<string, string>(element.Style),
+                new Dictionary<string, string>(element.Attributes)));
+
+        if (willScale)
         {
             foreach (var property in ZoomScaledSerializationProperties)
             {
@@ -363,7 +422,7 @@ public sealed partial class DomBridge
 
         }
 
-        if (ShouldApplySvgSerializationAttributes(element))
+        if (willSvg)
             ApplyZoomSerializationSvgAttributes(element, usedZoom);
 
         element.Style.Remove("zoom");

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -1005,14 +1005,18 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsRemove093Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.Parent != null)
+        // Capture the parent up front: DomElement.Parent is computed from the canonical
+        // ParentNode, and Children.RemoveAt detaches it — so reading element.Parent after
+        // the removal would return null (→ NRE in InvalidateStyleScope). Mirrors the
+        // working removeChild path, which holds the parent reference independently.
+        var parent = element.Parent;
+        if (parent != null)
         {
-            var idx = element.Parent.Children.IndexOf(element);
+            var idx = parent.Children.IndexOf(element);
             if (idx >= 0)
             {
                 NotifyNodeIteratorPreRemoval(element);
-                element.Parent.Children.RemoveAt(idx);
-                var parent = element.Parent;
+                parent.Children.RemoveAt(idx);
                 element.Parent = null;
                 InvalidateStyleScope(parent);
                 NotifyChildRemoved(parent, element, idx);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -80,8 +80,10 @@ public sealed partial class DomBridge
                 return GetViewportReferenceLength(element, vertical: false);
 
             // RF-BRIDGE-1b: clientWidth is the padding-box width (content + padding).
-            if (UseSharedLayoutGeometry && TryGetSharedLayoutGeometry(element, out var shared))
+            if (UseSharedLayoutGeometry && IsUnzoomedForSharedGeometry(element) && TryGetSharedLayoutGeometry(element, out var shared))
                 return shared.PaddingBox.Width;
+            if (ShouldReturnExclusiveSharedZero(element))
+                return 0;
 
             var props = GetComputedProps(element);
             var containingBlockWidth = ResolveContainingBlockReferenceLength(element, vertical: false);
@@ -99,8 +101,10 @@ public sealed partial class DomBridge
                 return GetViewportReferenceLength(element, vertical: true);
 
             // RF-BRIDGE-1b: clientHeight is the padding-box height (content + padding).
-            if (UseSharedLayoutGeometry && TryGetSharedLayoutGeometry(element, out var shared))
+            if (UseSharedLayoutGeometry && IsUnzoomedForSharedGeometry(element) && TryGetSharedLayoutGeometry(element, out var shared))
                 return shared.PaddingBox.Height;
+            if (ShouldReturnExclusiveSharedZero(element))
+                return 0;
 
             var props = GetComputedProps(element);
             var containingBlockWidth = ResolveContainingBlockReferenceLength(element, vertical: false);
@@ -132,12 +136,14 @@ public sealed partial class DomBridge
             if (ShouldReportZeroOffsetMetrics(element))
                 return 0;
 
-            if (UseSharedLayoutGeometry && TryGetSharedLayoutGeometry(element, out var shared))
+            if (UseSharedLayoutGeometry && IsUnzoomedForSharedGeometry(element) && TryGetSharedLayoutGeometry(element, out var shared))
                 return shared.BorderBox.Width;
 
             var resolved = ResolvePositionAreaForElement(element);
             if (resolved != null)
                 return resolved.Value.width;
+            if (ShouldReturnExclusiveSharedZero(element))
+                return 0;
 
             var props = GetComputedProps(element);
             var width = GetBorderBoxWidth(props, element);
@@ -156,12 +162,14 @@ public sealed partial class DomBridge
             if (ShouldReportZeroOffsetMetrics(element))
                 return 0;
 
-            if (UseSharedLayoutGeometry && TryGetSharedLayoutGeometry(element, out var shared))
+            if (UseSharedLayoutGeometry && IsUnzoomedForSharedGeometry(element) && TryGetSharedLayoutGeometry(element, out var shared))
                 return shared.BorderBox.Height;
 
             var resolved = ResolvePositionAreaForElement(element);
             if (resolved != null)
                 return resolved.Value.height;
+            if (ShouldReturnExclusiveSharedZero(element))
+                return 0;
 
             var props = GetComputedProps(element);
             var height = GetBorderBoxHeight(props, element);
@@ -340,6 +348,8 @@ public sealed partial class DomBridge
             var offsetParent = GetOffsetParentForDomElement(element);
             if (TryGetSharedOffset(element, offsetParent, vertical: true, out var sharedTop))
                 return sharedTop;
+            if (ShouldReturnExclusiveSharedZero(element))
+                return 0;
             if (offsetParent != null)
                 return ComputeOffsetRelativeToAncestor(element, offsetParent, vertical: true);
 
@@ -357,6 +367,8 @@ public sealed partial class DomBridge
             var offsetParent = GetOffsetParentForDomElement(element);
             if (TryGetSharedOffset(element, offsetParent, vertical: false, out var sharedLeft))
                 return sharedLeft;
+            if (ShouldReturnExclusiveSharedZero(element))
+                return 0;
             if (offsetParent != null)
                 return ComputeOffsetRelativeToAncestor(element, offsetParent, vertical: false);
 
@@ -377,7 +389,11 @@ public sealed partial class DomBridge
     private bool TryGetSharedOffset(DomElement element, DomElement offsetParent, bool vertical, out double offset)
     {
         offset = 0;
-        if (!UseSharedLayoutGeometry || !TryGetSharedLayoutGeometry(element, out var elementGeometry))
+        // Zoom is not reconciled against the shared snapshot's coordinate space (a
+        // zoomed offsetParent/element makes the raw doc-coord delta the wrong scale),
+        // so a zoomed subtree falls back to the estimator's explicit zoom handling.
+        if (!UseSharedLayoutGeometry || !IsUnzoomedForSharedGeometry(element) ||
+            !TryGetSharedLayoutGeometry(element, out var elementGeometry))
             return false;
 
         double elementEdge = vertical ? elementGeometry.BorderBox.Top : elementGeometry.BorderBox.Left;
@@ -531,11 +547,93 @@ public sealed partial class DomBridge
                !string.Equals(display, "contents", StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// RF-BRIDGE-1b: computes an element's scrollable overflow extent
+    /// (<c>scrollWidth</c>/<c>scrollHeight</c>) from the shared renderer-layout
+    /// snapshot — the union of the element's own padding-box (client) extent and the
+    /// end edges of its rendered descendants' border boxes, expressed in the element's
+    /// padding-box coordinate space and including the element's end padding. This
+    /// mirrors the coarse estimator's element-descendant semantics but reads real box
+    /// geometry from the provider instead of re-deriving it. Returns <c>false</c> when
+    /// the element has no shared box (detached / <c>display:none</c>) so the caller
+    /// falls back to the estimator.
+    ///
+    /// <para>Zoom stays on the estimator (via <see cref="IsUnzoomedForSharedGeometry"/>):
+    /// the render pipeline bakes CSS <c>zoom</c> into the serialized box sizes
+    /// (<c>ApplyZoomSerializationStyles</c>) while the <c>zoom</c> property remains
+    /// readable, so a snapshot-side zoom division would double-count. The estimator
+    /// resolves zoom from CSS directly and is path-independent.</para>
+    /// </summary>
+    private bool TryGetSharedScrollExtent(DomElement element, bool vertical, out double extent)
+    {
+        extent = 0;
+        if (!TryGetSharedLayoutGeometry(element, out var box))
+            return false;
+        if (!IsUnzoomedForSharedGeometry(element))
+            return false;
+
+        var paddingBox = box.PaddingBox;
+        var contentBox = box.ContentBox;
+        var origin = vertical ? paddingBox.Top : paddingBox.Left;
+        // The scrolling area is at least the padding-box (client) extent, and the
+        // scrollable overflow region includes the container's end padding.
+        var max = vertical ? (double)paddingBox.Height : paddingBox.Width;
+        var endPadding = vertical
+            ? Math.Max(0, paddingBox.Bottom - contentBox.Bottom)
+            : Math.Max(0, paddingBox.Right - contentBox.Right);
+
+        foreach (var descendant in EnumerateRenderedDescendants(element))
+        {
+            if (!IsUnzoomedForSharedGeometry(descendant))
+                return false; // a zoomed descendant → let the estimator answer the query
+            if (!TryGetSharedLayoutGeometry(descendant, out var childBox))
+                continue;
+            var childEnd = vertical ? childBox.BorderBox.Bottom : childBox.BorderBox.Right;
+            max = Math.Max(max, (childEnd - origin) + endPadding);
+        }
+
+        extent = max;
+        return true;
+    }
+
+    /// <summary>
+    /// RF-BRIDGE-1b: whether <paramref name="element"/> is free of CSS <c>zoom</c>
+    /// (cumulative used zoom == 1). The shared snapshot is in the renderer's zoomed
+    /// document space and the render pipeline additionally bakes <c>zoom</c> into the
+    /// serialized box sizes while leaving the <c>zoom</c> property readable, so the
+    /// bridge cannot reconcile zoom against the snapshot on either the size or the
+    /// position path without double-counting. Zoomed elements therefore route to the
+    /// estimator, which resolves zoom from CSS directly and is path-independent. Every
+    /// shared geometry branch gates on this. See the CSSOM/CSS-viewport zoom tests.
+    /// </summary>
+    private bool IsUnzoomedForSharedGeometry(DomElement element) =>
+        Math.Abs(GetUsedZoomForElement(element) - 1.0) < 0.0001;
+
+    /// <summary>
+    /// RF-BRIDGE-1b increment 6 (staged cutover, default OFF). Under
+    /// <see cref="UseSharedGeometryExclusively"/>, an unzoomed element that produced no
+    /// shared box is treated as detached / <c>display:none</c> (zero geometry) rather
+    /// than consulting the coarse estimators — the entry points call this right after
+    /// their shared-snapshot branch. When the flag is off (the default) this is always
+    /// false, so the estimator fallback runs exactly as before. Zoomed subtrees are not
+    /// short-circuited (they still legitimately need the estimator until the shared
+    /// snapshot is zoom-correct).
+    /// </summary>
+    private bool ShouldReturnExclusiveSharedZero(DomElement element) =>
+        UseSharedGeometryExclusively && UseSharedLayoutGeometry && IsUnzoomedForSharedGeometry(element);
+
     private double GetScrollWidthForDomElement(DomElement element, bool isRoot) =>
         WithLayoutGeometryCache(() =>
         {
         if (TryGetSelectListBoxScrollExtent(element, verticalAxis: false, out var selectScrollWidth))
             return selectScrollWidth;
+
+        // RF-BRIDGE-1b: answer non-root scroll overflow from the shared renderer layout
+        // when available; the viewport/root scroll area stays on the estimator path.
+        if (!isRoot && UseSharedLayoutGeometry && TryGetSharedScrollExtent(element, vertical: false, out var sharedScrollWidth))
+            return sharedScrollWidth;
+        if (!isRoot && ShouldReturnExclusiveSharedZero(element))
+            return 0;
 
         var props = GetComputedProps(element);
         var ownWidth = GetClientWidthForDomElement(element, isRoot: false);
@@ -564,6 +662,13 @@ public sealed partial class DomBridge
         {
         if (TryGetSelectListBoxScrollExtent(element, verticalAxis: true, out var selectScrollHeight))
             return selectScrollHeight;
+
+        // RF-BRIDGE-1b: answer non-root scroll overflow from the shared renderer layout
+        // when available; the viewport/root scroll area stays on the estimator path.
+        if (!isRoot && UseSharedLayoutGeometry && TryGetSharedScrollExtent(element, vertical: true, out var sharedScrollHeight))
+            return sharedScrollHeight;
+        if (!isRoot && ShouldReturnExclusiveSharedZero(element))
+            return 0;
 
         var props = GetComputedProps(element);
         var ownHeight = GetClientHeightForDomElement(element, isRoot: false);
@@ -729,8 +834,11 @@ public sealed partial class DomBridge
 
         // RF-BRIDGE-1b: prefer the renderer's real layout (border box, document coords)
         // for the element's rect, which powers getBoundingClientRect and offset top/left.
-        // Falls back to the estimator when the element has no box (detached/display:none).
-        if (UseSharedLayoutGeometry && TryGetSharedLayoutGeometry(element, out var sharedGeometry))
+        // Falls back to the estimator when the element has no box (detached/display:none)
+        // or when zoom is in play (the shared snapshot is not zoom-reconciled, and
+        // ComputeRenderedRect below re-applies zoom — using the zoomed shared box here
+        // would double-count it).
+        if (UseSharedLayoutGeometry && IsUnzoomedForSharedGeometry(element) && TryGetSharedLayoutGeometry(element, out var sharedGeometry))
         {
             var sharedRect = (
                 (double)sharedGeometry.BorderBox.Left,
@@ -740,6 +848,15 @@ public sealed partial class DomBridge
             if (_layoutRectCache != null)
                 _layoutRectCache[element] = sharedRect;
             return sharedRect;
+        }
+
+        // RF-BRIDGE-1b increment 6 (staged): under exclusive-shared, an unzoomed element
+        // with no box is detached/display:none → zero rect, no estimator.
+        if (ShouldReturnExclusiveSharedZero(element))
+        {
+            if (_layoutRectCache != null)
+                _layoutRectCache[element] = (0, 0, 0, 0);
+            return (0, 0, 0, 0);
         }
 
         // Cache unconditionally: re-entrant computations (an auto content-extent

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SharedLayoutGeometry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SharedLayoutGeometry.cs
@@ -16,6 +16,19 @@ public sealed partial class DomBridge
     // Mirrors the LayoutGeometryCacheEnabled test seam.
     internal static bool UseSharedLayoutGeometry = true;
 
+    // RF-BRIDGE-1b increment 6 (staged cutover — default OFF). When true, the geometry
+    // entry points answer *exclusively* from the shared snapshot for unzoomed elements:
+    // an unzoomed element with no shared box returns zero (detached / display:none
+    // semantics) instead of falling back to the coarse LayoutMetrics estimators. This
+    // stages the estimator deletion — flipping it on makes the estimator bodies dead
+    // for the unzoomed path. It stays OFF until (a) the zoom-correct shared snapshot
+    // lands (so zoomed subtrees no longer need the estimator — they are still routed to
+    // it by IsUnzoomedForSharedGeometry) and (b) the pre-layout resolvers (sticky/
+    // position-area, which depend on scroll-offset accounting the snapshot lacks) have a
+    // shared-geometry source. Only then can the estimator bodies actually be removed.
+    // See docs/roadmap/rf-bridge-1b-layout-unification.md §5 incr 6 "Deletion sequence".
+    internal static bool UseSharedGeometryExclusively = false;
+
     private SharedLayoutGeometryProvider _sharedLayoutGeometry;
 
     private SharedLayoutGeometryProvider SharedLayoutGeometry =>
@@ -45,6 +58,12 @@ public sealed partial class DomBridge
 
     private System.Collections.Generic.IReadOnlyDictionary<Broiler.Dom.DomElement, BoxGeometry> BuildSharedGeometrySnapshot()
     {
+        // RF-BRIDGE-1b render-doc/live-doc separation: install a revert log so the zoom
+        // baking GetRenderDocument applies (needed for correct RENDERED geometry, incl. a
+        // zoomed descendant's overflow) is undone on the live document afterward. That keeps
+        // the live/CSSOM document pristine, so unzoomed CSSOM queries on zoomed elements
+        // (routed to the estimator) read original styles instead of baked ones.
+        _zoomSerializationRevertLog = [];
         try
         {
             var document = GetRenderDocument();
@@ -57,6 +76,10 @@ public sealed partial class DomBridge
             // etc.) degrades the whole pass to the estimator — a geometry query must
             // never throw because the renderer choked on the document.
             return EmptySharedGeometry;
+        }
+        finally
+        {
+            RevertZoomSerialization();
         }
     }
 


### PR DESCRIPTION
## What & why

Advances **Phase 5** of the HtmlBridge DOM/CSS promotion roadmap (RF-BRIDGE-1b geometry unification): moves more element-geometry queries onto the renderer's real layout, fixes a live-DOM corruption that broke zoomed CSSOM metrics, and fixes a broadly-impactful `Element.remove()` bug. Net **7 previously-failing zoom/scroll WPT tests now pass, with zero regressions.**

## Changes

- **Scroll overflow via shared layout** — `GetScrollWidth/HeightForDomElement` answer non-root, unzoomed elements from the renderer's real layout snapshot (`TryGetSharedScrollExtent`) instead of the coarse estimators.
- **`Element.remove()` fix** — the callback read the computed `Parent` *after* `Children.RemoveAt` had already detached it → `NullReferenceException` (surfaced to JS as a `ReferenceError`), breaking every `el.remove()` caller. Now captures the parent before removal, mirroring `removeChild`. (Fixed 4 zoom tests whose `measure()` cleanup called `.remove()`.)
- **Render-doc/live-doc separation for zoom** — `GetRenderDocument`'s zoom baking (scales sizes, strips `zoom`) permanently mutated the live document, corrupting later unzoomed CSSOM reads on zoomed elements. Zoom baking is now extracted from the run-once serialization guard and **reverted after the geometry snapshot**, so the live/CSSOM document stays pristine. Render/serialize paths keep baking permanently. (Fixed 3 more zoom tests.)
- **Zoom gating** — all shared geometry branches gate on `IsUnzoomedForSharedGeometry`; zoomed elements resolve via the estimator (path-independent). A snapshot-side divide-by-zoom was tried and reverted (it double-counts in the render pipeline).
- **Cutover staging** — default-off `UseSharedGeometryExclusively` stages the eventual estimator deletion (boxless unzoomed elements → zero geometry).
- **Parity gate** — budget lowered `3 → 0` (the renderer now sizes `position-try` correctly).

## Verification

Zero regressions, diffed against baselines:
- **Acid**: 13/328 == HEAD (the 13 are pre-existing/environmental).
- **Scroll family**: no new failures, 5 fixed.
- **Serialization / outerHTML / rendering-pipeline**: no new failures vs HEAD.
- **Mutation observers** 10/10; **parity gate** 345/72; shared-geometry Cli tests all green.
- Full **Zoom suite**: 7 → 1 failing (only the unrelated `PinchZoom` visual-viewport case remains).

New tests: `ElementRemoveTests`, `SharedGeometryZoomSizeTests`, `SharedScrollOverflowTests`, `SharedGeometryExclusiveCutoverTests`, plus a `SharedGeometryStatics` xunit collection that serializes the static-flag geometry tests (fixes pre-existing parallel flakiness).

## Reviewer notes

- No submodule changes — parent repo only.
- Design + rationale documented in `docs/roadmap/rf-bridge-1b-layout-unification.md` §5 incr 6 and `docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md`.
- Residual (out of scope): comment-removal and pseudo/progress injection still mutate the live doc once via the guard — smaller, separate concern; the same revert-log pattern extends to them if a JS-facing need arises. Remaining zoom failure `PinchZoom` is a separate visual-viewport mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)