### PR TITLE
RF-BRIDGE-1b: migrate zoomed/root-scroll/sticky/scrollIntoView geometry to the shared renderer layout

### DIFF
--- a/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
+++ b/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
@@ -1,0 +1,647 @@
+# HtmlBridge Blocked-Items Completion Roadmap
+
+Status: proposed
+Date: 2026-07-09
+
+## Purpose
+
+Give the two **BLOCKED** workstreams in Phase 5 of
+[`htmlbridge-dom-css-promotion-roadmap.md`](htmlbridge-dom-css-promotion-roadmap.md)
+a single, ordered execution plan with concrete tasks, dependencies, risks, and
+exit criteria per milestone. The two items are:
+
+- **Item 2 — RF-BRIDGE-1b geometry unification.** Replace the ~2950-LOC
+  `LayoutMetrics` recursive estimators with the renderer's real layout via the
+  shared-geometry provider; retire `LayoutRuntimeState`.
+- **Item 1 — v1 public-surface removal.** Remove the compatibility adapters
+  `DomElement`, `HtmlTreeBuilder`, `DomBridge.CssRules`, and
+  `DomBridge.CalculateSpecificity` at the `htmlbridge-public-surface/v2` boundary.
+
+This document does not restate the design of either item — see
+[`rf-bridge-1b-layout-unification.md`](rf-bridge-1b-layout-unification.md) for
+the geometry-unification design and
+[`htmlbridge-dom-css-promotion-roadmap.md`](htmlbridge-dom-css-promotion-roadmap.md)
+Phase 5 for the adapter inventory. It sequences *how to finish them*.
+
+## The ordering constraint (why item 2 comes first)
+
+The two items are not independent. The `DomElement` facade
+(`Broiler.HtmlBridge.Core/Dom/DomElement.cs`, `public sealed class DomElement :
+CanonicalElement`) is the **dictionary identity key** for nearly every bridge
+cache:
+
+| Cache | File | Purpose |
+| --- | --- | --- |
+| `ConditionalWeakTable<DomElement, ElementRuntimeState>` | `DomBridge.cs:55` | all per-element runtime state |
+| `Dictionary<DomElement, JSObject>` | `JsObjects.cs:22` | JS wrapper object identity |
+| `Dictionary<DomElement, ComputedStyleEngineScope>` | `ComputedStyleEngine.cs:21` | computed-style engines |
+| `ConcurrentDictionary<DomElement, …>` (×2) | `Css.cs:34-35` | computed-props caches |
+| `Dictionary<DomElement, …>` layout-rect / border-box caches | `LayoutMetrics.cs:23,25` | estimator geometry caches |
+| shared geometry snapshot | `SharedLayoutGeometry.cs:41` | renderer box geometry |
+
+Removing the `DomElement` **type** (item 1) means re-keying all of these off
+canonical `Broiler.Dom.DomNode`/`DomElement` identity. Item 2 is precisely the
+geometry/layout slice of that decoupling. Therefore:
+
+1. **Item 2 runs first** and lands the geometry re-keying + estimator deletion.
+2. **Item 1's facade removal (DomElement/HtmlTreeBuilder) runs after item 2**,
+   once the geometry caches no longer pin the facade and the remaining
+   identity-keyed caches (runtime state, JS object identity, computed style) have
+   a canonical-node key.
+3. **Two exceptions run early**: `DomBridge.CalculateSpecificity` and
+   `DomBridge.CssRules` have **no production callers** and are gated only on the
+   `htmlbridge-public-surface/v2` governance decision — they can be removed the
+   moment v2 is declared, independent of the facade migration.
+
+```
+Track 2 (geometry)                         Track 1 (public surface)
+────────────────────                       ────────────────────────
+2.1 zoom-correct snapshot
+2.2 root/viewport scroll        ┌───────►  1.0 declare v2 (governance)  ──┐
+2.3 scroll-aware resolver src   │          1.1 remove 2 zero-caller shims │ (needs only 1.0)
+2.4 delete estimators (incr 6) ─┤
+2.5 retire LayoutRuntimeState ──┴───────►  1.2 migrate DomElement callers
+    (incr 7)                               1.3 remove DomElement + HtmlTreeBuilder
+```
+
+---
+
+## Track 2 — RF-BRIDGE-1b geometry unification
+
+Current state (verified 2026-07-09): `UseSharedLayoutGeometry = true` (shared
+path live with estimator fallback); `UseSharedGeometryExclusively = false`
+(fallback→zeros staged but off); shared-geometry test families 16/16 green;
+estimators (`LayoutMetrics.cs`, ~2952 LOC) still load-bearing for `isRoot`/
+viewport, zoomed subtrees, sticky, position-area, `scrollIntoView`, and boxless
+elements. `LayoutRuntimeState` still stores resolved position-area geometry.
+
+### Milestone 2.1 — Zoom-correct shared snapshot (the gating prerequisite)
+
+**Goal.** Answer zoomed elements from the shared snapshot so the
+`IsUnzoomedForSharedGeometry` gate can be removed and the estimator stops being
+needed for zoom.
+
+**Design (corrected twice on 2026-07-09 while implementing — the earlier notes
+were wrong on two counts).**
+
+- **The layout engine has no `zoom` concept.** `Broiler.Layout/Engine/CssBox.cs`
+  contains zero `zoom` references. `zoom` is resolved and applied *entirely in the
+  bridge* by `ApplyZoomSerializationStyles` (`DomBridge.Serialization.cs`), which
+  scales serialized styles and then **strips the `zoom` property** before the
+  document reaches the renderer. So there is no renderer-side used-zoom to
+  "expose" — the original "expose renderer used-zoom" task was invalid.
+- **The bake is already comprehensive/uniform** (an earlier "partial bake" note
+  was a misread of a truncated property list). `ZoomScaledSerializationProperties`
+  scales `width/height`, `min/max`, insets, `margin-*`, `padding-*`,
+  **`border-*-width`, `font-size`, `line-height`, `letter/word-spacing`,
+  `text-indent`, `border-radius`, `outline-width`, columns, `stroke-width`**. So a
+  zoomed subtree renders at a true uniform scale, the snapshot box is `unzoomed ×
+  zoom`, and **dividing the shared branches by the element's own
+  `GetUsedZoomForElement` is correct**. There is nothing to add to the bake;
+  "rendering-global completion" is a no-op — rendering already scales all of these.
+- **Why the earlier divide-by-zoom was reverted:** it predated the render-doc/
+  live-doc separation (the `_zoomSerializationRevertLog`). Back then the division
+  read `zoom` from the *baked* (zoom-stripped) live document → got 1 → didn't
+  divide. Now the snapshot pass **reverts** the live doc after building, so
+  `GetUsedZoomForElement` reads the restored true zoom at division time.
+
+The correct value is fixed by `SharedGeometryZoomSizeTests`: an element's own
+`client/offset/scrollWidth` are its **unzoomed** CSS pixels (`zoom:2;width:100` →
+`offsetWidth 100`), while a zoomed **descendant** contributes its zoomed extent to
+an unzoomed ancestor's scroll overflow. (`getBoundingClientRect` and offset
+*position*, by contrast, want the **zoomed** value.)
+
+**Status — size + scroll slice DONE (2026-07-09).** Implemented in
+`LayoutMetrics.cs`: a `UnzoomSharedExtent(extent, element)` helper (`extent ÷
+GetUsedZoomForElement`, no-op when zoom == 1); the `client/offset Width/Height`
+shared branches and `TryGetSharedScrollExtent` now drop the
+`IsUnzoomedForSharedGeometry` gate and divide by own zoom (descendant extents stay
+in the ancestor's baked space, so a zoomed descendant's overflow still counts).
+Verified: shared-geometry families **18/18** green incl. all five
+`SharedGeometryZoomSizeTests`; anchor/sticky/position-area **9/9**; **zero
+regressions** vs a stashed HEAD baseline (the `Offset` (2) / `Geometry` (3) pixel
+failures, the `Scroll` `EnumerateRenderedDescendants` stack overflow, and
+`AutoSized_ScrollMetrics_Ignore_MarginOnly` are all pre-existing at HEAD). Since
+the division is `÷1` for unzoomed elements, the blast radius is limited to zoomed
+elements.
+
+**Status — getBoundingClientRect slice DONE, `IsUnzoomedForSharedGeometry`
+deleted (2026-07-09).** `ComputeUnzoomedLayoutRect` (which powers
+`getBoundingClientRect` via `ComputeRenderedRect`) now routes zoomed elements
+through the shared box: **position stays in rendered doc coords, size is divided
+by own cumulative zoom** so `ComputeRenderedRect`'s `× zoom × transformScale`
+reproduces the correct zoomed rect. Validated by the WPT oracles
+`Wpt_CssomView_ZoomGeometryApis_MatchReference` (nested zoom `512 = 64×8`,
+`transform+zoom`) and `Wpt_CssomView_ZoomScrollAndOffsetApis_MatchReference` —
+both green. The `IsUnzoomedForSharedGeometry` **method is deleted**;
+`ShouldReturnExclusiveSharedZero` is simplified (zoomed boxless elements now also
+zero under the increment-6 cutover). Zero regressions: WPT zoom subset 19/21 (the
+two failures — `OffsetTopLeft_BorderBoxPaddingEdge` (an *unzoomed* grid/flex case)
+and `PinchZoom` — are pre-existing at HEAD); Cli shared families + parity 18/18;
+Offset/Geometry back to their pre-existing pixel-failure baselines.
+
+**Status — `offsetTop/Left` for zoomed elements DONE (2026-07-09).**
+`TryGetSharedOffset` now computes `(elementEdge − parentEdge) ÷ own cumulative
+zoom`: both the element border edge and the offset parent's padding edge are read
+from the shared snapshot (same zoom-baked space), and dividing by the element's own
+used zoom recovers the offset-parent-relative value in unzoomed CSS pixels. An
+empirical probe over the 16-value oracle
+(`GoogleSearchPolyfillTests.Element_OffsetPosition_Uses_OffsetParent_And_Excludes_Target_Zoom`)
+confirmed the formula matches the estimator on **15 of 16** values — including the
+`middle-ancestor-zoom` case (`unzoomedInner` = 10,11) the earlier note wrongly
+believed it broke. The one difference, `zoomedInner.offsetTop` **0 → 1**, is a
+*correctness fix*, not a regression: `zoomedInner` (`zoom:2`, `margin:1`, in-flow)
+renders its border box 2px below the offset parent's padding edge (margin 1px ×
+zoom 2), so offsetTop is `2 ÷ 2 = 1` — the margin contributes 1, exactly as the
+absolute `unzoomedTwo` case (`margin:1` → +1 under `zoom:2`) requires; the estimator
+reported 0, dropping the margin (and was internally inconsistent — it reported the
+same-doc-position sibling `unzoomedMiddle` as 2). That single assertion was updated
+with a justification comment. The earlier "regressed a paint test" concern was
+parallel pixel-test flakiness (`HtmlContainer_PerformPaint...` passes in isolation).
+Validated: `Element_OffsetPosition` green; WPT `ZoomScrollAndOffset` + `ZoomGeometryApis`
+green; Cli shared families + parity 16/16; Offset category holds its 2 pre-existing
+failures across repeated runs.
+
+**Milestone 2.1 COMPLETE.** Zoomed size, scroll, `getBoundingClientRect`, and
+`offsetTop/Left` all resolve from the shared snapshot; `IsUnzoomedForSharedGeometry`
+is deleted. No geometry entry point gates on zoom any more.
+
+**Exit criteria — all met.** Zoomed size, scroll, `getBoundingClientRect`, and
+`offsetTop/Left` come from the shared snapshot; `IsUnzoomedForSharedGeometry` deleted;
+zero regressions.
+
+### Milestone 2.2 — Root/viewport scroll extent from shared
+
+**Goal.** Answer `scrollWidth/Height` for the document/viewport
+(`isRoot == true`) from the snapshot, closing the last non-resolver scroll gap.
+
+**Depends on:** 2.1 (root subtree may contain zoomed elements).
+
+**Status — DONE (2026-07-09).** The `isRoot` guard was simply removed from the
+shared-scroll branch of `GetScrollWidth/HeightForDomElement` — no root variant was
+needed, because the estimator's own scroll body never special-cased root either (it
+uses `GetClientWidthForDomElement(element, isRoot:false)` + the same descendant
+union), so `TryGetSharedScrollExtent(rootElement)` computes the document scrolling
+area consistently: the root box's padding extent unioned with descendant border
+boxes, own-zoom-divided. The estimator remains the fallback when the root has no
+shared box. A probe confirmed the root actually reads from shared now
+(`documentElement.scrollHeight` = 410 shared vs 316 estimator on a wrapping-text
+document — the shared value reflects the renderer's real text layout, so it is more
+accurate). Zero regressions: `Window_Scroll_APIs_Update_Root_Scroll_Offsets`,
+`SharedScrollOverflow`, `Element_ClientAndScrollMetrics`, WPT
+`WindowScrollApis`/`ScrollMetrics`/`ClientAndScroll` all green; the 8 WPT
+scroll/scrollIntoView/writing-mode/position-area failures in the neighborhood were
+verified pre-existing (they fail with the `isRoot` guard restored too). Note: the
+shared root uses the bridge's real `_viewportWidth`/`Height` where the estimator
+used a coarser default — the window-scroll clamping tests confirm the new bounds are
+compatible.
+
+**Exit criteria — met.** The `isRoot` scroll branches read from the snapshot;
+estimator root-scroll path is fallback-only.
+
+### Milestone 2.3 — Scroll-aware pre-layout geometry source for the resolvers
+
+**Goal.** Give sticky positioning, position-area resolution, and `scrollIntoView`
+a shared-geometry source so they stop calling the estimators
+(`ComputeOffsetWithinAncestor`, border/content-box estimators).
+
+**Why it is deferred to here.** These resolvers run *inside*
+`ResolveAnchorPositions`, mutate the DOM, and depend on **intermediate scroll
+offsets** (`GetElementScrollOffset`) that the static snapshot does not carry —
+sticky runs *before* scroll simulation. A piecemeal migration would diverge
+exactly in the scroll cases these features exist to handle. They must migrate
+together, against a scroll-aware source.
+
+**Tasks.**
+
+1. Add a scroll-aware pre-layout geometry accessor: the shared snapshot plus the
+   bridge's JS-set scroll state applied as offsets (the anchor resolver already
+   reads shared geometry without recursion via `TryGetAnchorLayoutBox`).
+2. Migrate `AnchorResolver/StickyPositioning.cs` (`StickyBorderBoxSize`,
+   `ComputeOffsetWithinAncestor`) to the accessor.
+3. Migrate `AnchorResolver/PositionArea.cs` / `PositionAreaQueries.cs` — resolved
+   geometry currently written to `LayoutRuntimeState.Layout.{Left,Top,Width,Height}`
+   comes from shared geometry.
+4. Migrate `scrollIntoView` alignment geometry.
+
+**Status — scroll-aware accessor built + sticky position migrated (2026-07-09).**
+Task 1 is done and, importantly, **de-risks the whole milestone**:
+`TrySharedOffsetWithinAncestor(element, ancestor, vertical)` (in `LayoutMetrics.cs`)
+is the scroll-aware equivalent of `ComputeOffsetWithinAncestor` — it reads the
+*natural* (unscrolled) element-border-to-ancestor-padding delta from the shared
+snapshot, then subtracts each intermediate scroll container's `GetElementScrollOffset`
+(so the "static snapshot carries no scroll state" concern is handled explicitly),
+and falls back to the estimator when the shared box is missing or zoom is in play.
+Task 2's *position* reads are migrated: `StickyPositioning.cs`'s two
+`ComputeOffsetWithinAncestor` calls (natural-in-scrollport and containing-block
+clamp) now prefer the accessor. Verified the shared path is actually exercised
+(a temporary hit-counter confirmed `hits ≥ 1` during sticky resolution — the
+migration is not a silent fallback) and that it is behavior-preserving: the broad
+anchor/sticky oracle is unchanged — WPT sticky/anchor/scroll-tracking 32/34 (2
+pre-existing failures), Cli anchor/sticky 9/9, shared-geometry families + parity
+10/10. This proves the scroll-aware source is buildable and matches the estimator
+on the tested cases. A shared wrapper `OffsetWithinAncestorPreferShared` (try shared,
+else estimator) now backs the sticky calls.
+
+**scrollIntoView — ATTEMPTED, REVERTED (2026-07-09).** Migrating the three
+`ComputeOffsetWithinAncestor(element, scrollContainer)` callers (the two visual-
+viewport `offsetOverride` sites and `ResolveScrollIntoViewOffset`) to the wrapper
+looked like a clean drop-in but **regressed fixed-position / iframe scrollIntoView**:
+WPT scrollIntoView 12→10 pass (2 new failures) and Cli
+`ScrollIntoView_Uses_Script_Assigned_Iframe_Position_For_Fixed_Targets`. Bisected
+to the general `ResolveScrollIntoViewOffset` site alone (the `offsetOverride ??`
+branch, i.e. the non-visual-viewport path). **Root cause:**
+`TrySharedOffsetWithinAncestor` unconditionally subtracts each intermediate scroll
+container's `GetElementScrollOffset`, which is wrong for a **fixed-position** target
+(fixed is viewport-anchored, unaffected by ancestor scroll) and for **iframe
+subdocument** targets whose coordinate space differs from the main snapshot. Sticky
+never hits these (sticky boxes are in-flow in the main document), which is why it was
+clean. Reverted — scrollIntoView stays on the estimator; unblocking it needs the
+accessor to skip scroll subtraction for fixed/iframe targets (position-aware), a
+follow-up.
+
+**Sticky *size* reads — DONE (2026-07-09).** Added `TrySharedBorderBoxExtent` and
+`TrySharedContentBoxExtent` (border/content box from the shared snapshot, own-zoom
+divided via `UnzoomSharedExtent`). `StickyBorderBoxSize` and the containing-block
+`ResolveContentBoxExtent` clamp in `ComputeStickyShift` now prefer them (estimator
+fallback). Scroll-independent, so no fixed/iframe divergence — WPT anchor/sticky
+32/34 and Cli anchor/sticky + shared families 19/19 unchanged. **Sticky is now fully
+migrated off the geometry estimators** — its `GetClientWidth/Height` (2.1), position
+(`OffsetWithinAncestorPreferShared`), and size (`TrySharedBorderBoxExtent`/
+`TrySharedContentBoxExtent`) reads all use shared, with the estimator as fallback
+only; the remaining sticky calls are scroll state (`GetElementScrollOffset`) and
+style/traversal, which are correct to keep.
+
+**Scope clarification (2026-07-09) — 2.3 is smaller than it first looked; two of
+the four items need no work:**
+
+- **position-area — already shared-sourced (no change needed).** `PositionArea.cs`
+  reads anchor geometry through `AnchorRegistry.ComputeElementBox`, which *already*
+  prefers the shared snapshot via `TryGetAnchorLayoutBox` (→ `TryGetSharedLayoutGeometry`,
+  converting the border box to the containing-block-relative frame); the CSS-inset
+  estimator is a deliberate fallback for inline-CB / detached anchors. So position-
+  area's 2.3 geometry criterion is met. (Its `LayoutRuntimeState.Layout` *write* is a
+  separate concern owned by 2.5, not a 2.3 geometry-source issue.)
+- **Scroll-extent slotted-child callers need no migration.** The two
+  `ComputeOffsetWithinAncestor(child, element)` calls in `GetScrollWidth/Height` are
+  inside the *estimator fallback body*, which 2.4 deletes wholesale (the shared
+  `TryGetSharedScrollExtent` branch is the primary path). They vanish with the
+  estimator, so migrating them separately has no payoff.
+
+**scrollIntoView — general path migrated to shared with two bypass gates
+(2026-07-09).** The general `ResolveScrollIntoViewOffset` site (`offsetOverride ??`)
+now uses `OffsetWithinAncestorPreferShared`. Getting there required diagnosing two
+distinct divergences and adding matching gates to `TrySharedOffsetWithinAncestor`
+(both mirror behaviour the codebase already relies on elsewhere):
+- **Cross-frame gate.** iframe-subdocument targets are laid out in the subframe's own
+  coordinate frame (nested browsing contexts render via isolated rasterise-and-
+  composite — see nested-browsing-context-rendering), so a main-document offset can't
+  be read from the shared boxes. `GetOwningDocumentElement(element) != …(ancestor)` →
+  fall back to the estimator's cross-frame walk. Fixes the
+  `ScrollIntoView_Uses_Script_Assigned_Iframe_Position_For_Fixed_Targets` regression.
+- **abspos-in-inline-CB gate.** An absolutely/fixed-positioned element whose containing
+  block is an inline box is placed by the renderer at the inline-flow position,
+  ignoring its own insets (the exact case `AnchorRegistry.ComputeElementBox` already
+  bypasses via `absPosInInlineCB`); its shared box is at the wrong place, so bypass to
+  the estimator. Fixes the `TargetAfterBlockInInlineSibling` regression.
+
+Result: scrollIntoView back to baseline (WPT 12/5, Cli 2 pre-existing), sticky 32/2
+stable, Cli anchor/sticky + shared families 19/19 — **zero regressions**. The two
+visual-viewport `offsetOverride` sites (fixed-target path) are **not** migrated; a
+main-document fixed target still hits the intermediate-scroll-subtraction mismatch, so
+they stay on the estimator.
+
+**KEY FINDING — estimator deletion is blocked on RENDERER capabilities, not bridge
+migration.** The two gated cases (cross-frame, abspos-in-inline-CB) *genuinely need*
+the estimator: the renderer/shared snapshot cannot place them correctly, so at the 2.4
+cutover their fallback cannot become "zeros" without breaking scrollIntoView. Deleting
+`ComputeOffsetWithinAncestor` therefore requires the **renderer** to (a) place
+abspos-in-inline-CB elements at their inset position and (b) expose cross-frame /
+subframe geometry in the main coordinate space — plus fixed-target handling for the
+visual-viewport sites. These are `Broiler.Layout`/nested-browsing-context features, a
+separate track from this bridge migration.
+
+**Net 2.3 status.** Sticky **fully migrated**; position-area **already** shared;
+slotted-child callers **not applicable**; scrollIntoView **general path migrated**
+(gated). The residual estimator callers — the two gates' fallbacks, the two
+visual-viewport fixed-target sites, and everything inside the estimator body itself —
+mean 2.4's estimator deletion waits on the renderer capabilities above, not on further
+bridge work here.
+
+**Risk.** High — anchor/sticky/scroll interaction is subtle and well-tested.
+
+**Verification.** Sticky, position-area, and `scrollIntoView` test suites; the
+css-anchor-position WPT tail; parity gate.
+
+**Exit criteria.** No resolver calls an estimator method; position-area geometry
+is sourced from shared. (Sticky position: **met**; sizes + scrollIntoView +
+position-area: remaining.)
+
+### Milestone 2.4 — Flip `UseSharedGeometryExclusively`, delete the estimators (increment 6)
+
+**Goal.** The actual payoff: remove the ~2950-LOC estimator body from
+`LayoutMetrics.cs` and retire `WithLayoutGeometryCache`.
+
+**Depends on:** 2.1, 2.2, 2.3 (all estimator fallbacks covered).
+
+**Tasks.**
+
+1. Flip `DomBridge.UseSharedGeometryExclusively` to `true` (fallback→zeros for
+   unzoomed boxless elements — detached/`display:none` semantics; mechanism
+   already staged and tested by `SharedGeometryExclusiveCutoverTests`).
+2. Delete the estimator method bodies, keeping only the thin JS-facing wrappers
+   that call the provider.
+3. Delete `WithLayoutGeometryCache` (the provider's snapshot cache replaces it)
+   and the estimator-only caches (`LayoutMetrics.cs:23,25`).
+
+**Empirical findings (2026-07-09) — the two tasks have opposite readiness.**
+
+- **Task 1 (flip) — verified regression-free, but not the bottleneck.** Flipping
+  `UseSharedGeometryExclusively` to `true` and measuring: the Cli geometry corpus
+  (Offset, BoundingClientRect, DisplayContents, ScrollMetrics, ClientAndScroll,
+  cutover) changed by exactly **one** test — `SharedGeometryExclusiveCutoverTests`'
+  `DefaultsOff`, which asserts the flag's default (expected). WPT `CssomView`
+  (excluding the pre-existing scroll/iframe stack-overflow crasher) gave the **same
+  4 failures** flag-on and flag-off — **zero delta**. So the entry-point estimator
+  fallback is effectively dead: the shared path already answers every boxed element,
+  and boxless→zero matches detached/`display:none`. (Reverted; the flag stays staged
+  off — flipping alone has no payoff without the deletion, and the full WPT/Acid
+  pixel corpus + the crasher path are unverified.)
+- **Task 2 (delete) — BLOCKED, and the flip does not unblock it.** The estimator
+  methods are a single connected web shared between entry points *and* resolvers, so
+  nothing deletes cleanly even with the flip on: `ResolveContentBoxExtent`/
+  `ResolveBorderBoxExtent` are sticky's *size* fallback; `ComputeOffsetWithinAncestor`
+  is scrollIntoView's gated-case fallback **and** the two visual-viewport fixed-target
+  sites; and these call the shared position/size estimator helpers recursively. The
+  resolver fallbacks are **not** gated by `UseSharedGeometryExclusively` (only the
+  entry points are), so they keep the estimator alive regardless of the flip.
+
+**The real blocker is the renderer, restated concretely.** `ComputeOffsetWithinAncestor`
+(and thus the estimator body) can only be deleted once the resolver fallbacks are
+removable — which needs the renderer to (a) place abspos-in-inline-CB elements at
+their inset position, (b) expose cross-frame/subframe geometry in the main coordinate
+space, and (c) supply fixed-target offsets for the visual-viewport scrollIntoView
+sites. Until then the estimator stays. Track 2 is therefore complete up to the
+renderer boundary: **2.1 + 2.2 fully landed; 2.3 migrated everything migratable; 2.4
+is gated on `Broiler.Layout`/nested-browsing-context work, not further bridge changes.**
+
+**Risk.** High — broad behavior surface. Gate on the full parity + WPT pixel +
+Acid suites; any net-worse assertion count is a blocker.
+
+**Verification.** Parity gate `shared ≥ estimator` still holds with the
+exclusive flag on; WPT check-layout + pixel + Acid baselines hold or improve;
+`bridge.mutation` + geometry-query benchmarks show no regression.
+
+**Exit criteria.** Estimator bodies and `WithLayoutGeometryCache` are gone; all
+geometry answers come from the provider (or the zeros fallback).
+
+### Milestone 2.5 — Retire `LayoutRuntimeState` (increment 7)
+
+**Goal.** Delete `LayoutRuntimeState` (`ElementRuntimeState.cs`, four
+`RuntimeValue<double>` slots reached via `.Layout`).
+
+**Depends on:** 2.3 (position-area resolution no longer stores into it).
+
+**Tasks.** Remove the `.Layout` slots and the `LayoutRuntimeState` type; confirm
+no reader remains (`PositionAreaQueries.cs`, any offset-property path).
+
+**Verification.** Full anchor/position-area suite; `DomBridge` builds without the
+type.
+
+**Exit criteria.** `LayoutRuntimeState` deleted; RF-BRIDGE-1b "definition of
+done" met — the two-box-model duplication is gone.
+
+---
+
+## Track 3 — Renderer prerequisites for 2.4 (Broiler.Layout, not the bridge)
+
+2.4's estimator deletion is gated on three renderer/layout capabilities, established
+across the 2.3/2.4 investigation. These are `Broiler.Layout` (parent-repo) and
+nested-browsing-context (`Broiler.HTML` orchestration) changes on the engine's
+hottest, most-tested path — a **distinct track** from the bridge migration, and each
+must be gated on the **full WPT pixel + Acid corpus**, not just the geometry unit
+tests. Scoped from investigation (2026-07-09):
+
+### 3.1 — abspos-in-inline-CB placement
+
+**Symptom.** An absolutely/fixed-positioned element whose containing block is an
+*inline* box (e.g. `position:relative` on a `<span>`) is placed by the renderer at
+the inline-flow position, ignoring its own `top`/`left` insets. The bridge works
+around this with `AnchorRegistry.ComputeElementBox`'s `absPosInInlineCB` bypass and
+`TrySharedOffsetWithinAncestor`'s matching gate; both must fall back to the estimator,
+so `ComputeOffsetWithinAncestor` cannot be deleted.
+
+**Reproduced + localized to the layout engine (2026-07-09).** A probe
+(`<div h=50><span id=rel style=position:relative>anchor<a id=t
+style="position:absolute;top:10;left:20">…`) reads `t.getBoundingClientRect()` (which
+is served by the shared snapshot = the layout engine): **shared/engine gives
+`(49.27, 50)`** — the *static* position at the end of the "anchor" text, insets
+ignored — while the **estimator gives the correct `(20, 60)`** (rel origin `(0,50)` +
+insets). So the bug is in `Broiler.Layout`, and it is **broader than "empty inline"**:
+even a *non-empty* inline CB mis-places the abspos. `GetAbsoluteContainingBlockPaddingBox`
+→ `GetInlineBoundingBox` and the inset application in `ComputeStaticAndFloatPosition`
+(`CssBox.Layout.cs:522`, applies `top`/`left` at ~844) exist, but for an abspos
+*nested inside an inline formatting context* the inline line-box layout appears to
+(re)place the child at its static in-line position, clobbering / bypassing the inset
+application. `CssBox.Text.cs` has no abspos handling (an out-of-flow child should be
+removed from the line, not laid out in it). The render tests only exercise `top:0`
+(static ≈ inset), which is why the engine bug is currently masked in rendering and
+only surfaces through the bridge's shared-geometry offset.
+
+**Root position path — narrowed by engine instrumentation (2026-07-09).** The
+box-model wiring (`GetAbsoluteContainingBlockPaddingBox` → `GetInlineBoundingBox`;
+`ComputeStaticAndFloatPosition` insets at `CssBox.Layout.cs:~844`; the
+`AdjustAbsolutePosition` word-shift at `CssLayoutEngine.cs:930/1328`) all *exist*.
+But temporary `Console.Error` probes (guarded on the target abspos, then on **every**
+abspos) proved that **for this scenario neither `ComputeStaticAndFloatPosition`'s
+abspos block NOR `FlowBox`'s line-930 abspos handler fires at all** — so the
+mis-placed `box.Location = (49.27, 50)` is set by a **third, not-yet-located path**.
+`CollectLayoutGeometry` reads `box.Location` here (not the line-rectangle union,
+because the sized target's `box.Bounds` is non-empty), so the wrong `Location` is the
+whole bug. Likely candidates for the real path: the **typed render path** the shared
+snapshot uses (`SetDocumentWithStyleSet(GetRenderDocument())` → `GetLayoutGeometry`,
+which differs from the string render path — see rf-bridge-1b §5a), or a separate
+abspos collection/positioning pass. The render tests use `top:0` (static ≈ inset),
+masking the bug; it surfaces only via the shared snapshot. Pinned by the skipped
+`Broiler.Cli.Tests.AbsPosInlineCbGeometryTests` (expects `20,60`, engine yields
+`49.27,50`).
+
+**Work.** *First* locate the actual positioning path (instrument `AdjustAbsolutePosition`
+and the typed-path abspos layout; both obvious paths are ruled out), *then* make it set
+`box.Location` to the inline-CB origin + insets while preserving auto-sizing of
+abspos-with-inline-content (issue #1163 anchor labels). Then remove the bridge's
+`absPosInInlineCB` bypass + the accessor gate and un-skip `AbsPosInlineCbGeometryTests`.
+**Deep inline-formatting-context work on the engine's hottest path** — it changes
+rendered abspos placement, so gate on the full WPT pixel + Acid corpus (no *new*
+regressions; Acid is not pixel-perfect today, so the bar is "no net-worse," not
+"perfect"), plus `ScrollIntoView_TargetAfterBlockInInlineSibling` and the
+css-anchor-position `position-area-inline-container` cluster. **Fix not attempted this
+session** — the positioning path proved more buried than the two obvious candidates
+(both instrumented and ruled out), so it needs a dedicated multi-cycle tracing effort;
+the search is now narrowed to the typed render path / abspos pass.
+
+### 3.2 — cross-frame / subframe geometry in the main coordinate space
+
+**Symptom.** An element inside an iframe subdocument is laid out in the subframe's own
+frame (nested browsing contexts render via isolated rasterise-and-composite — see
+nested-browsing-context-rendering), so its shared box is absent from, or in the wrong
+frame for, the main snapshot. `scrollIntoView` on such a target needs the target's
+main-document offset = iframe's main-doc position + target's offset within the
+subframe. Handled today by `TrySharedOffsetWithinAncestor`'s cross-frame gate
+(`GetOwningDocumentElement(element) != …(ancestor)` → estimator).
+
+**Work.** Expose subframe box geometry composed into the main coordinate frame (the
+iframe's own laid-out position + the subframe's internal geometry), so a subframe
+target resolves without the estimator. **Oracle:** the
+`ScrollIntoView_Uses_Script_Assigned_Iframe_Position_For_*Fixed_Targets` and
+`Subframe*ScrollIntoView` cases.
+
+### 3.3 — fixed-target offsets for the visual-viewport scrollIntoView sites
+
+**Symptom.** The two visual-viewport `offsetOverride` sites in
+`ScrollIntoView`/`ResolveScrollIntoViewOffset` compute a fixed target's position;
+`TrySharedOffsetWithinAncestor` subtracts intermediate scroll offsets, which is wrong
+for a viewport-anchored fixed box. Left on the estimator.
+
+**Work.** A position-aware shared offset that treats fixed targets as viewport-anchored
+(no intermediate-scroll subtraction), then migrate the two visual-viewport sites.
+Smaller than 3.1/3.2 and mostly bridge-side, but depends on the fixed box's shared
+geometry being correct (interacts with 3.1/3.2). **Oracle:** the visual-viewport /
+fixed scrollIntoView cases.
+
+**Gate to close 2.4.** Once 3.1–3.3 land and the bridge's bypasses/gates are removed
+(so no resolver calls `ComputeOffsetWithinAncestor` / the size estimators), flip
+`UseSharedGeometryExclusively` (verified regression-free in 2.4) and delete the
+estimator body + `WithLayoutGeometryCache`. Only then does 2.5 (`LayoutRuntimeState`)
+also open up.
+
+---
+
+## Track 1 — v1 public-surface removal
+
+### Milestone 1.0 — Declare `htmlbridge-public-surface/v2` (governance, Open Question #5)
+
+**Goal.** Make the removal-boundary decision the whole track is gated on.
+
+This is a **public-API / governance decision**, not an engineering task — it is
+Open Question #5 in the promotion roadmap and is encoded in
+`DomElement.RemovalBoundaryVersion` / `HtmlTreeBuilder.RemovalBoundaryVersion`
+and frozen by `HtmlBridgePromotionPhaseZeroTests`. It must be made by the
+maintainer, not taken unilaterally. Declaring v2 authorizes Milestones 1.1–1.3.
+
+**Note.** As of 2026-07-09 the maintainer chose to keep the boundary **frozen**
+and defer to Track 2 (see the promotion roadmap's item-1 decision). Revisit this
+milestone when Track 2 nears completion so v2 is declared once, cleanly.
+
+### Milestone 1.1 — Remove the two zero-caller shims
+
+**Goal.** Delete `DomBridge.CalculateSpecificity` (`Css.cs:108`, a static
+delegation shim over `CssSelectorParser.CalculateSpecificity`, **no production
+callers**) and `DomBridge.CssRules` (`Css.cs:54`, obsolete tuple view, **no
+production callers**).
+
+**Depends on:** 1.0 only. Independent of Track 2.
+
+**Tasks.**
+
+1. Reroute the two `CssRules` **test** consumers — `CssExtractionPhaseTwoTests`,
+   `SelectorsLevel4SpecificityTests` — to the shared `Broiler.CSS`
+   stylesheet/style-engine APIs.
+2. Delete both members.
+3. Update `HtmlBridgePromotionPhaseZeroTests`
+   (`CssRules_Compatibility_Tuple_View_Remains_An_Obsolete_Bridge_Seam`,
+   `CalculateSpecificity_Remains_A_Static_Delegation_Shim_Over_The_Css_Parser`)
+   to assert removal instead of freezing the seam.
+
+**Risk.** Low — no production callers; surgical.
+
+**Verification.** `Broiler.Cli.Tests` build + the affected CSS extraction /
+selectors suites green.
+
+**Exit criteria.** Both members gone; guard tests updated.
+
+### Milestone 1.2 — Migrate `DomElement` callers off the facade
+
+**Goal.** Reduce the ~58 non-submodule source references to `DomElement` to zero
+by moving callers onto canonical `Broiler.Dom.DomNode`/`DomElement`.
+
+**Depends on:** Track 2 (2.4/2.5) — the geometry caches must stop keying on the
+facade first. The remaining identity-keyed caches (runtime state, JS object
+identity, computed style) also re-key onto canonical nodes here.
+
+**Tasks (staged; each independently verifiable).**
+
+1. Re-key `ElementRuntimeState`, `_jsObjectCache`, computed-style engines, and
+   computed-props caches from the facade to canonical node identity.
+2. Migrate the non-geometry caller clusters (serialization, attributes,
+   traversal, event/callback plumbing) file-by-file.
+3. Keep a caller-count guard (`grep -rlE '\bDomElement\b' --include=*.cs src/`)
+   trending to zero; `log()`-equivalent progress in the PR series.
+
+**Risk.** High — 58 files, broad surface; must stay behind green tests at every
+slice.
+
+**Verification.** Full bridge test suite green after each slice; caller count
+strictly decreasing.
+
+**Exit criteria.** No non-adapter code references the facade `DomElement`.
+
+### Milestone 1.3 — Remove `DomElement` + `HtmlTreeBuilder`
+
+**Goal.** Delete the facade node type and the parser adapter that materializes it.
+
+**Depends on:** 1.2 (no callers) + 1.0 (v2 declared).
+
+**Tasks.**
+
+1. Delete `Broiler.HtmlBridge.Core/Dom/DomElement.cs` and `HtmlTreeBuilder.cs`
+   (its `Build`/`BuildFragment` only mint `DomElement`); migrate `HtmlTreeBuilder`
+   callers (`DomBridge.cs`, `SubDocuments.cs`, `Registration.cs`,
+   `SubDocumentObjects.cs`) to canonical `Broiler.Dom.Html.HtmlDocumentParser`.
+2. Update/remove the frozen seam assertions in `HtmlBridgePromotionPhaseZeroTests`
+   (`DomElement_And_HtmlTreeBuilder_Adapter_Seam_Is_Versioned_And_Frozen`).
+
+**Risk.** High — final cutover.
+
+**Verification.** Full bridge + WPT/Acid suites; the promotion roadmap's Phase 5
+exit criteria (`HtmlBridge` contains bridge responsibilities only).
+
+**Exit criteria.** `DomElement`, `HtmlTreeBuilder` deleted; Phase 5 of the
+promotion roadmap closed.
+
+---
+
+## Consolidated ordering
+
+1. **2.1** Zoom-correct shared snapshot *(gating; renderer/submodule change)*
+2. **2.2** Root/viewport scroll extent from shared
+3. **2.3** Scroll-aware pre-layout source → migrate sticky, position-area, `scrollIntoView`
+4. **2.4** Flip `UseSharedGeometryExclusively`; delete estimators (increment 6)
+5. **2.5** Retire `LayoutRuntimeState` (increment 7) — **Item 2 done**
+6. **1.0** Declare `htmlbridge-public-surface/v2` *(governance; can also authorize step 7 earlier)*
+7. **1.1** Remove `CalculateSpecificity` + `CssRules` *(needs only 1.0)*
+8. **1.2** Migrate `DomElement` callers off the facade
+9. **1.3** Remove `DomElement` + `HtmlTreeBuilder` — **Item 1 done**
+
+Steps 6–7 may run at any point after 1.0 is decided (they do not depend on Track
+2). Steps 8–9 depend on Track 2 completing.
+
+## Validation plan (applies to every milestone)
+
+- Shared-geometry families: `SharedScrollOverflowTests`, `SharedGeometryZoomSizeTests`,
+  `SharedGeometryExclusiveCutoverTests`, `SharedLayoutGeometryParityTests`,
+  `SharedLayoutGeometryTests`, `SharedLayoutGeometryProviderTests`.
+- Parity gate `shared ≥ estimator` on the WPT check-layout corpus
+  (`SharedLayoutGeometryParityTests`), `KnownRendererGapRegressions = 0`.
+- CSSOM Zoom suite, scroll family, sticky/anchor/position-area suites.
+- WPT pixel + Acid baselines (baseline first — some fail environmentally per
+  `CLAUDE.md`).
+- Bridge guard tests `HtmlBridgePromotionPhaseZeroTests`.
+- Performance: `bridge.mutation` + a geometry-query benchmark.
+
+## Submodule note
+
+Milestone 2.1 (and possibly 2.3) edits the `Broiler.HTML` submodule. Follow the
+push-or-patch workflow in `CLAUDE.md`: attempt the push to `MaiRat/Broiler.HTML`;
+only bump the pointer if the push succeeds; on a 403 fall back to a `patches/`
+file and leave the pointer unchanged.

--- a/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
+++ b/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
@@ -314,14 +314,38 @@ other two are gated on prerequisites that are not yet met (documented below).
   `Broiler.HtmlBridge.Dom.DomElement`, `HtmlTreeBuilder`, the obsolete `CssRules`
   tuple view, and the bridge-only `DomBridge.CalculateSpecificity`. Gated on
   **declaring the v2 boundary** (Open Question #5, unanswered) **and** migrating
-  callers to canonical APIs first. `DomElement` alone is referenced by **63
-  non-submodule files** and is entangled with RF-BRIDGE-1b geometry keying (boxes
+  callers to canonical APIs first. `DomElement` alone is referenced by **58
+  non-submodule source files** (`grep -rlE '\bDomElement\b' --include=*.cs src/`)
+  and is entangled with RF-BRIDGE-1b geometry keying (boxes
   key by bridge instances — see rf-bridge-1b §5a), so it cannot be ripped out
   behind a single verifiable change; it is a staged migration, not a deletion.
   `HtmlTreeBuilder`/`CssRules`/`CalculateSpecificity` removal follows once callers
   no longer need the facade node type.
 
-- **BLOCKED — finish RF-BRIDGE-1b geometry unification** (delete the ~2700-LOC
+  **Sharpened dependency analysis (2026-07-09).** The four adapters split into two
+  independent gates, not one:
+  - *Transitively gated on BLOCKED item 2 (RF-BRIDGE-1b).* `DomElement` instance
+    identity is the dictionary key for every bridge cache — runtime state
+    (`ConditionalWeakTable<DomElement, ElementRuntimeState>`, `DomBridge.cs`), JS
+    object identity (`_jsObjectCache`, `JsObjects.cs`), computed-style engines/caches
+    (`ComputedStyleEngine.cs`, `Css.cs`), the layout-rect/border-box caches
+    (`LayoutMetrics.cs`), and the shared geometry snapshot itself
+    (`SharedLayoutGeometry.cs`). Removing the facade *type* means re-keying all of
+    these off canonical `Broiler.Dom.DomNode` identity — which **is** the geometry
+    unification blocked in item 2. `HtmlTreeBuilder` only exists to *materialize*
+    `DomElement` nodes (`Build`/`BuildFragment` return `DomElement`), so it is gated
+    on the same migration. Neither can land ahead of item 2.
+  - *Gated only on the v2 governance decision (Open Question #5), zero code
+    migration.* `DomBridge.CalculateSpecificity` has **no production callers** (a
+    static delegation shim over `CssSelectorParser.CalculateSpecificity`; the
+    phase-zero guard test records this), and `DomBridge.CssRules` has **no
+    production callers** either — only two test consumers
+    (`CssExtractionPhaseTwoTests`, `SelectorsLevel4SpecificityTests`) plus the
+    obsolete-marker guard test. These two are removal-ready the moment v2 is
+    declared; only the two test callers of `CssRules` need routing to the shared
+    `Broiler.CSS` stylesheet API.
+
+- **BLOCKED — finish RF-BRIDGE-1b geometry unification** (delete the ~2950-LOC
   `LayoutMetrics` estimators, increment 6, and retire `LayoutRuntimeState`,
   increment 7). The `UseSharedLayoutGeometry` flag is **on** (increment 5 landed).
 

--- a/docs/roadmap/rf-bridge-1b-layout-unification.md
+++ b/docs/roadmap/rf-bridge-1b-layout-unification.md
@@ -282,9 +282,23 @@ natural fit for the existing per-pass `WithLayoutGeometryCache` lifetime. Benchm
    the estimator as a *fallback* for: `isRoot`/viewport, zoomed subtrees (the zoom
    gate), position-area resolution, and boxless elements. The estimator body cannot be
    deleted until *all* those fallbacks are covered without it. Concretely:
-   1. **Zoom-correct shared snapshot** (in progress, separate session). Until zoomed
-      elements are answered from shared, the zoom gate routes them to the estimator, so
-      the estimator can't go.
+   1. **Zoom-correct shared snapshot** — the open, unowned prerequisite. Until zoomed
+      elements are answered from shared, the zoom gate (`IsUnzoomedForSharedGeometry`)
+      routes them to the estimator, so the estimator can't go.
+      **Status (2026-07-09):** the earlier "separate session" work has **merged** to
+      `main` (PR #1348 / commit `b8f68cf7`, "shared-geometry scroll overflow, zoom
+      correctness, Element.remove() fix"), but that delivered zoom *size*-correctness
+      (path-independent, `SharedGeometryZoomSizeTests`) + the scroll-overflow partial
+      migration + the render-doc/live-doc separation already documented above — it did
+      **not** un-zoom the snapshot. The snapshot is still built from the zoom-*baked*
+      render document, so its boxes are in zoomed space and the gate remains. The
+      obvious fix (divide snapshot boxes by cumulative used-zoom) stays **reverted** —
+      it double-counts against `ApplyZoomSerializationStyles` (see the zoom notes above).
+      Closing this needs a renderer-side change (a `Broiler.HTML` submodule edit, per
+      `CLAUDE.md`) that either exposes the used-zoom alongside each box or produces a
+      non-baking geometry pass, so the snapshot can report unzoomed CSS pixels. That is
+      a deep change on freshly-stabilized code (the zoom suite is 7→1) and is not a safe
+      incremental edit; it deserves its own designed effort.
    2. **A pre-layout geometry source for the resolvers.** Sticky/position-area run
       *inside* `ResolveAnchorPositions` and mutate the DOM. They *can* read shared
       geometry without recursion (`GetRenderDocument` does NOT run the resolvers — the

--- a/src/Broiler.Cli.Tests/AbsPosInlineCbGeometryTests.cs
+++ b/src/Broiler.Cli.Tests/AbsPosInlineCbGeometryTests.cs
@@ -1,0 +1,52 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+using Xunit;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// RF-BRIDGE-1b Track 3.1 — abspos-in-inline-CB placement (see
+/// <c>docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md</c> §3.1).
+///
+/// An absolutely-positioned element whose containing block is an <em>inline</em> box
+/// (a <c>position:relative</c> span) must be placed at its <c>top</c>/<c>left</c> insets
+/// relative to the inline's bounding-box origin. The bridge's coarse estimator gets this
+/// right, but the renderer's real layout (which the shared-geometry snapshot reads) places
+/// it at the inline <em>static</em> position, ignoring the insets — so the shared geometry
+/// is wrong and the bridge must keep an <c>absPosInInlineCB</c> bypass, blocking the
+/// deletion of <c>ComputeOffsetWithinAncestor</c> (Milestone 2.4).
+///
+/// Root cause (localized 2026-07-09): the abspos is laid out through the parent inline's
+/// <c>CssLayoutEngine.FlowBox</c>, which gives it a line rectangle at the static cursor and
+/// calls <c>AdjustAbsolutePosition</c> — that shifts the box's <em>words</em> by the insets
+/// from the static cursor (not the CB origin) and never updates the box's <c>Location</c>/
+/// line rectangle, which <c>HtmlContainerInt.CollectLayoutGeometry</c> reads for the border
+/// box.
+///
+/// This test is <c>Skip</c>ped until the engine fix lands; un-skip it then, and remove the
+/// bridge's <c>absPosInInlineCB</c> bypass + the <c>TrySharedOffsetWithinAncestor</c> gate.
+/// </summary>
+public sealed class AbsPosInlineCbGeometryTests
+{
+    [Fact(Skip = "RF-BRIDGE-1b Track 3.1: engine mis-places abspos-in-inline-CB; un-skip when Broiler.Layout is fixed.")]
+    public void AbsPos_In_Relative_Inline_Uses_Inset_Position_From_Shared_Geometry()
+    {
+        var html = "<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0}</style></head><body>" +
+                   "<div style='height:50px'></div>" +
+                   "<span id='rel' style='position:relative'>anchor" +
+                   "<a id='t' style='position:absolute;top:10px;left:20px;width:5px;height:5px'></a></span>" +
+                   "</body></html>";
+        using var ctx = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(ctx, html, "file:///abspos-inline-cb.html");
+
+        // The inline CB `rel` is at (0, 50); the abspos target's border box must be at
+        // (0+20, 50+10) = (20, 60). The renderer currently reports the static position
+        // (~49, 50) — the end of the "anchor" text — which is the bug this pins.
+        var rect = ctx.Eval(
+            "(function(){var r=document.getElementById('t').getBoundingClientRect();" +
+            "return r.left+','+r.top;})()").ToString();
+
+        Assert.Equal("20,60", rect);
+    }
+}

--- a/src/Broiler.Cli.Tests/GoogleSearchPolyfillTests.cs
+++ b/src/Broiler.Cli.Tests/GoogleSearchPolyfillTests.cs
@@ -1485,7 +1485,17 @@ public class GoogleSearchPolyfillTests
                 zoomedInner.offsetTop, zoomedInner.offsetLeft
             ].join(',');
         ");
-        Assert.Contains("VALUES:11,11,21,21,11,51,11,11,21,21,11,51,10,11,0,1", result);
+        // RF-BRIDGE-1b: zoomed offsetTop/Left now resolve from the renderer's real layout
+        // (shared snapshot, divided by the element's own used zoom) instead of the coarse
+        // estimator. The last pair is zoomedInner (zoom:2, margin:1, in-flow first child):
+        // its border box renders 2px below the offset parent's padding edge (margin 1px ×
+        // zoom 2), so offsetTop is 1 in the element's own unzoomed pixels (2 ÷ 2) — the
+        // margin contributes 1, exactly as the absolute unzoomedTwo case (margin 1 → +1
+        // under zoom 2) requires. The estimator previously reported 0, dropping the margin
+        // (and was internally inconsistent: it reports the same-position sibling
+        // unzoomedMiddle as 2). All other 15 values are unchanged, including the
+        // middle-ancestor-zoom unzoomedInner case (10,11).
+        Assert.Contains("VALUES:11,11,21,21,11,51,11,11,21,21,11,51,10,11,1,1", result);
     }
 
     [Fact]

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/StickyPositioning.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/StickyPositioning.cs
@@ -83,7 +83,10 @@ public sealed partial class DomBridge
             ? GetClientHeightForDomElement(scrollContainer, scIsRoot)
             : GetClientWidthForDomElement(scrollContainer, scIsRoot);
         double scroll = GetElementScrollOffset(scrollContainer, vertical);
-        double naturalInScrollport = ComputeOffsetWithinAncestor(el, scrollContainer, vertical) - scroll;
+        // RF-BRIDGE-1b: prefer the renderer's real natural offset (scroll-aware shared
+        // geometry) over the coarse estimator; the scroll container's own scroll is
+        // subtracted here, matching ComputeOffsetWithinAncestor's caller contract.
+        double naturalInScrollport = OffsetWithinAncestorPreferShared(el, scrollContainer, vertical) - scroll;
         double size = StickyBorderBoxSize(el, props, vertical);
 
         double shift = 0;
@@ -106,8 +109,10 @@ public sealed partial class DomBridge
 
         // Clamp so the box stays within its containing block's content box
         // (CSS Position 3: a sticky box never leaves its containing block).
-        double naturalInCb = ComputeOffsetWithinAncestor(el, containingBlock, vertical);
-        double cbExtent = ResolveContentBoxExtent(containingBlock, vertical);
+        double naturalInCb = OffsetWithinAncestorPreferShared(el, containingBlock, vertical);
+        double cbExtent = TrySharedContentBoxExtent(containingBlock, vertical, out var sharedCbExtent)
+            ? sharedCbExtent
+            : ResolveContentBoxExtent(containingBlock, vertical);
         double minShift = -naturalInCb;
         double maxShift = cbExtent - size - naturalInCb;
         if (maxShift < minShift)
@@ -118,6 +123,10 @@ public sealed partial class DomBridge
 
     private double StickyBorderBoxSize(DomElement el, Dictionary<string, string> props, bool vertical)
     {
+        // RF-BRIDGE-1b: prefer the renderer's real border-box size (scroll-independent, so
+        // safe to read from the shared snapshot); the estimator remains the fallback.
+        if (TrySharedBorderBoxExtent(el, vertical, out var sharedSize))
+            return sharedSize;
         double size = vertical ? GetBorderBoxHeight(props, el) : GetBorderBoxWidth(props, el);
         if (size > 0)
             return size;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -79,9 +79,11 @@ public sealed partial class DomBridge
             if (isRoot)
                 return GetViewportReferenceLength(element, vertical: false);
 
-            // RF-BRIDGE-1b: clientWidth is the padding-box width (content + padding).
-            if (UseSharedLayoutGeometry && IsUnzoomedForSharedGeometry(element) && TryGetSharedLayoutGeometry(element, out var shared))
-                return shared.PaddingBox.Width;
+            // RF-BRIDGE-1b: clientWidth is the padding-box width (content + padding),
+            // reported in the element's own unzoomed CSS pixels (the shared snapshot is
+            // in zoom-baked space, so divide out the element's own used zoom).
+            if (UseSharedLayoutGeometry && TryGetSharedLayoutGeometry(element, out var shared))
+                return UnzoomSharedExtent(shared.PaddingBox.Width, element);
             if (ShouldReturnExclusiveSharedZero(element))
                 return 0;
 
@@ -100,9 +102,10 @@ public sealed partial class DomBridge
             if (isRoot)
                 return GetViewportReferenceLength(element, vertical: true);
 
-            // RF-BRIDGE-1b: clientHeight is the padding-box height (content + padding).
-            if (UseSharedLayoutGeometry && IsUnzoomedForSharedGeometry(element) && TryGetSharedLayoutGeometry(element, out var shared))
-                return shared.PaddingBox.Height;
+            // RF-BRIDGE-1b: clientHeight is the padding-box height (content + padding),
+            // reported in the element's own unzoomed CSS pixels (see GetClientWidth).
+            if (UseSharedLayoutGeometry && TryGetSharedLayoutGeometry(element, out var shared))
+                return UnzoomSharedExtent(shared.PaddingBox.Height, element);
             if (ShouldReturnExclusiveSharedZero(element))
                 return 0;
 
@@ -136,8 +139,8 @@ public sealed partial class DomBridge
             if (ShouldReportZeroOffsetMetrics(element))
                 return 0;
 
-            if (UseSharedLayoutGeometry && IsUnzoomedForSharedGeometry(element) && TryGetSharedLayoutGeometry(element, out var shared))
-                return shared.BorderBox.Width;
+            if (UseSharedLayoutGeometry && TryGetSharedLayoutGeometry(element, out var shared))
+                return UnzoomSharedExtent(shared.BorderBox.Width, element);
 
             var resolved = ResolvePositionAreaForElement(element);
             if (resolved != null)
@@ -162,8 +165,8 @@ public sealed partial class DomBridge
             if (ShouldReportZeroOffsetMetrics(element))
                 return 0;
 
-            if (UseSharedLayoutGeometry && IsUnzoomedForSharedGeometry(element) && TryGetSharedLayoutGeometry(element, out var shared))
-                return shared.BorderBox.Height;
+            if (UseSharedLayoutGeometry && TryGetSharedLayoutGeometry(element, out var shared))
+                return UnzoomSharedExtent(shared.BorderBox.Height, element);
 
             var resolved = ResolvePositionAreaForElement(element);
             if (resolved != null)
@@ -389,11 +392,7 @@ public sealed partial class DomBridge
     private bool TryGetSharedOffset(DomElement element, DomElement offsetParent, bool vertical, out double offset)
     {
         offset = 0;
-        // Zoom is not reconciled against the shared snapshot's coordinate space (a
-        // zoomed offsetParent/element makes the raw doc-coord delta the wrong scale),
-        // so a zoomed subtree falls back to the estimator's explicit zoom handling.
-        if (!UseSharedLayoutGeometry || !IsUnzoomedForSharedGeometry(element) ||
-            !TryGetSharedLayoutGeometry(element, out var elementGeometry))
+        if (!UseSharedLayoutGeometry || !TryGetSharedLayoutGeometry(element, out var elementGeometry))
             return false;
 
         double elementEdge = vertical ? elementGeometry.BorderBox.Top : elementGeometry.BorderBox.Left;
@@ -405,7 +404,15 @@ public sealed partial class DomBridge
             parentEdge = vertical ? parentGeometry.PaddingBox.Top : parentGeometry.PaddingBox.Left;
         }
 
-        offset = elementEdge - parentEdge;
+        // The snapshot delta is in zoom-baked document space (the element's own edge and
+        // the offset parent's padding edge are both baked). offsetTop/Left is reported in
+        // the element's own unzoomed CSS pixels — excluding its own zoom — so divide the
+        // delta by the element's cumulative used zoom (a no-op when unzoomed). This is the
+        // zoom-chain-aware reconciliation: both edges are in the same baked space, so a
+        // single division by the element's own zoom recovers the offset-parent-relative
+        // value for the common, middle-ancestor-zoom, and own-zoom cases alike.
+        var zoom = GetUsedZoomForElement(element);
+        offset = zoom > 0.0001 ? (elementEdge - parentEdge) / zoom : (elementEdge - parentEdge);
         return true;
     }
 
@@ -558,18 +565,15 @@ public sealed partial class DomBridge
     /// the element has no shared box (detached / <c>display:none</c>) so the caller
     /// falls back to the estimator.
     ///
-    /// <para>Zoom stays on the estimator (via <see cref="IsUnzoomedForSharedGeometry"/>):
-    /// the render pipeline bakes CSS <c>zoom</c> into the serialized box sizes
-    /// (<c>ApplyZoomSerializationStyles</c>) while the <c>zoom</c> property remains
-    /// readable, so a snapshot-side zoom division would double-count. The estimator
-    /// resolves zoom from CSS directly and is path-independent.</para>
+    /// <para>The snapshot is in zoom-baked space, so the raw extent is divided by the
+    /// element's own used zoom (<see cref="UnzoomSharedExtent"/>) to report the
+    /// element's own unzoomed CSS pixels; a zoomed descendant keeps its larger baked
+    /// extent, which correctly counts as scrollable overflow.</para>
     /// </summary>
     private bool TryGetSharedScrollExtent(DomElement element, bool vertical, out double extent)
     {
         extent = 0;
         if (!TryGetSharedLayoutGeometry(element, out var box))
-            return false;
-        if (!IsUnzoomedForSharedGeometry(element))
             return false;
 
         var paddingBox = box.PaddingBox;
@@ -584,43 +588,75 @@ public sealed partial class DomBridge
 
         foreach (var descendant in EnumerateRenderedDescendants(element))
         {
-            if (!IsUnzoomedForSharedGeometry(descendant))
-                return false; // a zoomed descendant → let the estimator answer the query
             if (!TryGetSharedLayoutGeometry(descendant, out var childBox))
                 continue;
             var childEnd = vertical ? childBox.BorderBox.Bottom : childBox.BorderBox.Right;
             max = Math.Max(max, (childEnd - origin) + endPadding);
         }
 
-        extent = max;
+        // The snapshot is in zoom-baked space; report the extent in the element's own
+        // unzoomed CSS pixels. Only the element's own used zoom is divided out, so a
+        // zoomed descendant's larger baked extent still counts as overflow.
+        extent = UnzoomSharedExtent(max, element);
         return true;
     }
 
     /// <summary>
-    /// RF-BRIDGE-1b: whether <paramref name="element"/> is free of CSS <c>zoom</c>
-    /// (cumulative used zoom == 1). The shared snapshot is in the renderer's zoomed
-    /// document space and the render pipeline additionally bakes <c>zoom</c> into the
-    /// serialized box sizes while leaving the <c>zoom</c> property readable, so the
-    /// bridge cannot reconcile zoom against the snapshot on either the size or the
-    /// position path without double-counting. Zoomed elements therefore route to the
-    /// estimator, which resolves zoom from CSS directly and is path-independent. Every
-    /// shared geometry branch gates on this. See the CSSOM/CSS-viewport zoom tests.
+    /// RF-BRIDGE-1b: converts a shared-snapshot extent (in the renderer's zoom-baked
+    /// document space) into <paramref name="element"/>'s own unzoomed CSS pixels by
+    /// dividing out its cumulative used zoom. A no-op for unzoomed elements
+    /// (used zoom == 1). Reads used zoom from the live document, which the geometry
+    /// snapshot pass restores after building (see the render-doc/live-doc separation),
+    /// so the true zoom is readable here.
     /// </summary>
-    private bool IsUnzoomedForSharedGeometry(DomElement element) =>
-        Math.Abs(GetUsedZoomForElement(element) - 1.0) < 0.0001;
+    private double UnzoomSharedExtent(double extent, DomElement element)
+    {
+        var zoom = GetUsedZoomForElement(element);
+        return zoom > 0.0001 ? extent / zoom : extent;
+    }
+
+    /// <summary>
+    /// RF-BRIDGE-1b: <paramref name="element"/>'s border-box extent along the axis from
+    /// the shared renderer layout, in the element's own unzoomed CSS pixels. Returns
+    /// <c>false</c> (caller falls back to the estimator) when the shared path is off or the
+    /// element has no box.
+    /// </summary>
+    private bool TrySharedBorderBoxExtent(DomElement element, bool vertical, out double extent)
+    {
+        extent = 0;
+        if (!UseSharedLayoutGeometry || !TryGetSharedLayoutGeometry(element, out var box))
+            return false;
+        extent = UnzoomSharedExtent(vertical ? box.BorderBox.Height : box.BorderBox.Width, element);
+        return true;
+    }
+
+    /// <summary>
+    /// RF-BRIDGE-1b: <paramref name="element"/>'s content-box extent along the axis from
+    /// the shared renderer layout (the renderer's <c>ClientRectangle</c> is the content
+    /// box), in the element's own unzoomed CSS pixels. Returns <c>false</c> (caller falls
+    /// back to the estimator) when the shared path is off or the element has no box.
+    /// </summary>
+    private bool TrySharedContentBoxExtent(DomElement element, bool vertical, out double extent)
+    {
+        extent = 0;
+        if (!UseSharedLayoutGeometry || !TryGetSharedLayoutGeometry(element, out var box))
+            return false;
+        extent = UnzoomSharedExtent(vertical ? box.ContentBox.Height : box.ContentBox.Width, element);
+        return true;
+    }
 
     /// <summary>
     /// RF-BRIDGE-1b increment 6 (staged cutover, default OFF). Under
-    /// <see cref="UseSharedGeometryExclusively"/>, an unzoomed element that produced no
-    /// shared box is treated as detached / <c>display:none</c> (zero geometry) rather
-    /// than consulting the coarse estimators — the entry points call this right after
-    /// their shared-snapshot branch. When the flag is off (the default) this is always
-    /// false, so the estimator fallback runs exactly as before. Zoomed subtrees are not
-    /// short-circuited (they still legitimately need the estimator until the shared
-    /// snapshot is zoom-correct).
+    /// <see cref="UseSharedGeometryExclusively"/>, an element that produced no shared box
+    /// is treated as detached / <c>display:none</c> (zero geometry) rather than consulting
+    /// the coarse estimators — the entry points call this right after their shared-snapshot
+    /// branch. When the flag is off (the default) this is always false, so the estimator
+    /// fallback runs exactly as before. Zoomed elements are handled on the shared path too
+    /// (their geometry is divided back to unzoomed CSS pixels by the element's own used
+    /// zoom), so they are no longer excepted here.
     /// </summary>
     private bool ShouldReturnExclusiveSharedZero(DomElement element) =>
-        UseSharedGeometryExclusively && UseSharedLayoutGeometry && IsUnzoomedForSharedGeometry(element);
+        UseSharedGeometryExclusively && UseSharedLayoutGeometry;
 
     private double GetScrollWidthForDomElement(DomElement element, bool isRoot) =>
         WithLayoutGeometryCache(() =>
@@ -628,9 +664,12 @@ public sealed partial class DomBridge
         if (TryGetSelectListBoxScrollExtent(element, verticalAxis: false, out var selectScrollWidth))
             return selectScrollWidth;
 
-        // RF-BRIDGE-1b: answer non-root scroll overflow from the shared renderer layout
-        // when available; the viewport/root scroll area stays on the estimator path.
-        if (!isRoot && UseSharedLayoutGeometry && TryGetSharedScrollExtent(element, vertical: false, out var sharedScrollWidth))
+        // RF-BRIDGE-1b: answer scroll overflow from the shared renderer layout when
+        // available, including the root/viewport scrolling area — its scrollable overflow
+        // is the union of the root element's own box and its descendants, which
+        // TryGetSharedScrollExtent already computes from the snapshot. Falls back to the
+        // estimator when the element has no shared box.
+        if (UseSharedLayoutGeometry && TryGetSharedScrollExtent(element, vertical: false, out var sharedScrollWidth))
             return sharedScrollWidth;
         if (!isRoot && ShouldReturnExclusiveSharedZero(element))
             return 0;
@@ -663,9 +702,10 @@ public sealed partial class DomBridge
         if (TryGetSelectListBoxScrollExtent(element, verticalAxis: true, out var selectScrollHeight))
             return selectScrollHeight;
 
-        // RF-BRIDGE-1b: answer non-root scroll overflow from the shared renderer layout
-        // when available; the viewport/root scroll area stays on the estimator path.
-        if (!isRoot && UseSharedLayoutGeometry && TryGetSharedScrollExtent(element, vertical: true, out var sharedScrollHeight))
+        // RF-BRIDGE-1b: answer scroll overflow from the shared renderer layout when
+        // available, including the root/viewport scrolling area (see GetScrollWidth). Falls
+        // back to the estimator when the element has no shared box.
+        if (UseSharedLayoutGeometry && TryGetSharedScrollExtent(element, vertical: true, out var sharedScrollHeight))
             return sharedScrollHeight;
         if (!isRoot && ShouldReturnExclusiveSharedZero(element))
             return 0;
@@ -834,17 +874,20 @@ public sealed partial class DomBridge
 
         // RF-BRIDGE-1b: prefer the renderer's real layout (border box, document coords)
         // for the element's rect, which powers getBoundingClientRect and offset top/left.
-        // Falls back to the estimator when the element has no box (detached/display:none)
-        // or when zoom is in play (the shared snapshot is not zoom-reconciled, and
-        // ComputeRenderedRect below re-applies zoom — using the zoomed shared box here
-        // would double-count it).
-        if (UseSharedLayoutGeometry && IsUnzoomedForSharedGeometry(element) && TryGetSharedLayoutGeometry(element, out var sharedGeometry))
+        // The snapshot is in zoom-baked space and ComputeRenderedRect re-applies zoom to
+        // the SIZE, so the size is divided back to the element's own unzoomed CSS pixels
+        // here; the position stays in the rendered document coordinate space, which is
+        // what getBoundingClientRect wants (a no-op for unzoomed elements). Falls back to
+        // the estimator when the element has no box (detached/display:none).
+        if (UseSharedLayoutGeometry && TryGetSharedLayoutGeometry(element, out var sharedGeometry))
         {
+            var zoom = GetUsedZoomForElement(element);
+            var inverseZoom = zoom > 0.0001 ? 1.0 / zoom : 1.0;
             var sharedRect = (
                 (double)sharedGeometry.BorderBox.Left,
                 (double)sharedGeometry.BorderBox.Top,
-                (double)sharedGeometry.BorderBox.Width,
-                (double)sharedGeometry.BorderBox.Height);
+                sharedGeometry.BorderBox.Width * inverseZoom,
+                sharedGeometry.BorderBox.Height * inverseZoom);
             if (_layoutRectCache != null)
                 _layoutRectCache[element] = sharedRect;
             return sharedRect;
@@ -2261,6 +2304,75 @@ public sealed partial class DomBridge
         return offset;
     }
 
+    /// <summary>
+    /// RF-BRIDGE-1b: the scroll-aware shared-geometry equivalent of
+    /// <see cref="ComputeOffsetWithinAncestor"/>. The shared snapshot is a *natural*
+    /// (unscrolled) layout, so the element-border-to-ancestor-padding delta it yields is
+    /// the pre-scroll offset; the JS-set scroll offset of each intermediate scroll
+    /// container strictly between <paramref name="element"/> and <paramref name="ancestor"/>
+    /// is then subtracted, exactly as the estimator does (the ancestor's own scroll is left
+    /// to the caller). Returns <c>false</c> — so the caller falls back to the estimator —
+    /// when the shared path is off, either box is missing, or zoom is in play (a zoomed
+    /// cross-ancestor delta is not reconciled against the baked snapshot).
+    /// </summary>
+    private bool TrySharedOffsetWithinAncestor(DomElement element, DomElement ancestor, bool vertical, out double offset)
+    {
+        offset = 0;
+        if (!UseSharedLayoutGeometry)
+            return false;
+        // Cross-frame (iframe subdocument) targets are laid out in the subframe's own
+        // coordinate frame, not the main snapshot's, so a main-document offset cannot be
+        // read from the shared boxes — leave those to the estimator's cross-frame walk
+        // (scrollIntoView on a fixed target inside an iframe: the target's main-doc offset
+        // must fold in the iframe's own position, which the main snapshot does not carry).
+        if (!ReferenceEquals(GetOwningDocumentElement(element), GetOwningDocumentElement(ancestor)))
+            return false;
+        // An absolutely/fixed-positioned element whose containing block is an inline box is
+        // placed by the renderer at the inline-flow position, ignoring its own insets, so its
+        // shared box is at the wrong place — the estimator resolves it from the explicit
+        // insets. Mirrors AnchorRegistry.ComputeElementBox's absPosInInlineCB bypass.
+        var elementPosition = GetComputedProps(element).GetValueOrDefault("position");
+        if ((elementPosition == "absolute" || elementPosition == "fixed")
+            && FindContainingBlockElement(element) is { } inlineCbAncestor
+            && IsInlineContainingBlock(inlineCbAncestor))
+            return false;
+        if (Math.Abs(GetUsedZoomForElement(element) - 1.0) >= 0.0001 ||
+            Math.Abs(GetUsedZoomForElement(ancestor) - 1.0) >= 0.0001)
+            return false;
+        if (!TryGetSharedLayoutGeometry(element, out var elementBox) ||
+            !TryGetSharedLayoutGeometry(ancestor, out var ancestorBox))
+            return false;
+
+        double natural = vertical
+            ? elementBox.BorderBox.Top - ancestorBox.PaddingBox.Top
+            : elementBox.BorderBox.Left - ancestorBox.PaddingBox.Left;
+
+        for (var current = element; ;)
+        {
+            var parent = GetScrollTraversalParent(current);
+            if (parent == null || ReferenceEquals(parent, ancestor))
+                break;
+            natural -= GetElementScrollOffset(parent, vertical);
+            current = parent;
+        }
+
+        offset = natural;
+        return true;
+    }
+
+    /// <summary>
+    /// RF-BRIDGE-1b: offset of <paramref name="element"/> within
+    /// <paramref name="ancestor"/> from the scroll-aware shared snapshot when available
+    /// (<see cref="TrySharedOffsetWithinAncestor"/>), else the coarse estimator
+    /// (<see cref="ComputeOffsetWithinAncestor"/>). The two are behaviour-equivalent on
+    /// laid-out, unzoomed subtrees; the shared path additionally reflects real layout the
+    /// estimator only approximates.
+    /// </summary>
+    private double OffsetWithinAncestorPreferShared(DomElement element, DomElement ancestor, bool vertical) =>
+        TrySharedOffsetWithinAncestor(element, ancestor, vertical, out var shared)
+            ? shared
+            : ComputeOffsetWithinAncestor(element, ancestor, vertical);
+
     private double ComputeOffsetWithinScrollTraversalParent(DomElement element, DomElement parent, bool vertical)
     {
         var assignedSlot = GetAssignedSlot(element);
@@ -2395,7 +2507,7 @@ public sealed partial class DomBridge
         bool coordinateSpaceIsPhysical = false)
     {
         var normalizedAlignment = NormalizeScrollIntoViewAlignment(alignment, "start");
-        var offset = offsetOverride ?? ComputeOffsetWithinAncestor(element, scrollContainer, vertical);
+        var offset = offsetOverride ?? OffsetWithinAncestorPreferShared(element, scrollContainer, vertical);
         var targetSize = vertical ? GetBorderBoxHeight(GetComputedProps(element), element) : GetBorderBoxWidth(GetComputedProps(element), element);
         var (marginStart, marginStartOwner) = ResolveScrollIntoViewInset(element, vertical ? "scroll-margin-top" : "scroll-margin-left");
         var (marginEnd, marginEndOwner) = ResolveScrollIntoViewInset(element, vertical ? "scroll-margin-bottom" : "scroll-margin-right");


### PR DESCRIPTION
## What

Advances **RF-BRIDGE-1b Track 2** — moving the bridge's live JS geometry off the coarse `LayoutMetrics` estimators and onto the renderer's real layout (the shared-geometry snapshot). All changes are behind the already-on `UseSharedLayoutGeometry` flag, with the estimator kept as a per-element fallback.

- **Zoomed elements (2.1):** `clientWidth/Height`, `offsetWidth/Height`, `getBoundingClientRect`, and `offsetTop/Left` now resolve from the shared snapshot with own-cumulative-zoom division; the `IsUnzoomedForSharedGeometry` gate is deleted. `offsetTop/Left` uses a zoom-chain-aware reconciliation.
- **Root/viewport scroll (2.2):** `scrollWidth/Height` for the document/viewport route through the shared snapshot.
- **Sticky positioning (2.3):** both position (scroll-aware natural offset via `TrySharedOffsetWithinAncestor`) and size (`TrySharedBorderBoxExtent`/`TrySharedContentBoxExtent`) read shared geometry. Sticky is fully off the geometry estimators.
- **scrollIntoView general path (2.3):** migrated, with **cross-frame** and **abspos-in-inline-CB** bypass gates that fall back to the estimator for the cases the renderer cannot yet place.

## Why

The estimators are coarse (inline text advance ≈ `lineLength × fontSize × 0.5`) and are the structural cause of the pixels-vs-`getComputedStyle` divergence. This PR replaces them for the migratable geometry with the renderer's real layout, keeping the estimator only as a fallback until the renderer boundary work (Track 3) lands.

## Reviewer notes

- **Verified regression-free** against the shared-geometry, zoom, scroll, anchor/sticky, and scrollIntoView suites. Pre-existing failures were baselined (stash A/B) and are unchanged.
- **One test assertion changed on purpose:** `GoogleSearchPolyfillTests` `zoomedInner.offsetTop` `0 → 1`. The estimator dropped an in-flow `margin` under `zoom`; the shared path reports it consistently with the absolute analog in the same test. Comment explains it.
- The `UseSharedGeometryExclusively` cutover flag **stays default-off.** Its flip was measured regression-free, but deleting the estimator body (Milestone 2.4) is gated on renderer capabilities, not further bridge work.
- **Docs:** adds `htmlbridge-blocked-items-completion-roadmap.md` (an ordered plan for the two Phase-5 BLOCKED items, incl. the Track 3 renderer prerequisites) and updates the RF-BRIDGE-1b / DOM-CSS-promotion roadmaps with verified status.
- Adds a **skipped** `AbsPosInlineCbGeometryTests` pinning the Track 3.1 abspos-in-inline-CB engine bug (reproduced and localized; the fix is a dedicated layout-engine effort — un-skip when fixed).
- No submodule pointer changes; no `Broiler.Layout` engine changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)