### PR TITLE
RF-BRIDGE-1b Track 3.1–3.3: abspos-in-inline-CB, subframe geometry, fixed-target visual-viewport

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
@@ -181,6 +181,15 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             // laid-out positions and sizes.
             foreach (var child in box.Boxes)
             {
+                // CSS2.1 §10.1: the inline containing block's extent is the box
+                // around the inline's own (in-flow) line boxes. An out-of-flow
+                // (absolutely/fixed positioned) descendant is not part of that
+                // extent — and while it is being positioned its transient static
+                // Location would otherwise pollute the bounds it is measured
+                // against (e.g. drag the CB top to 0), corrupting its own inset.
+                if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+                    continue;
+
                 if (child.Size.Width <= 0 && child.Size.Height <= 0)
                     continue;
 

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
@@ -64,7 +64,16 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         // are laid out, so the trimmed margins collapse to nothing.
         ApplyMarginTrim();
 
-        if (IsBlock || Display == CssConstants.ListItem || Display == CssConstants.Table || Display == CssConstants.InlineTable || Display == CssConstants.TableCell || Display == CssConstants.TableCaption)
+        // CSS2.1 §9.7: an out-of-flow (absolutely/fixed positioned) box has its
+        // computed 'display' blockified — an inline-level abspos element (e.g. a
+        // positioned <a> or <span>) is laid out as a block. Route it through the
+        // block path so it resolves its own used width (shrink-to-fit per §10.3.7)
+        // and its inset position (ComputeStaticAndFloatPosition), rather than the
+        // inline else-branch which would leave its Size/Location uncomputed and let
+        // it report the static line-box rectangle instead of its inset box.
+        bool isOutOfFlow = Position == CssConstants.Absolute || Position == CssConstants.Fixed;
+
+        if (IsBlock || isOutOfFlow || Display == CssConstants.ListItem || Display == CssConstants.Table || Display == CssConstants.InlineTable || Display == CssConstants.TableCell || Display == CssConstants.TableCaption)
         {
             // Because their width and height are set by CssTable
             if (Display != CssConstants.TableCell && Display != CssConstants.Table)
@@ -554,6 +563,21 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             // reading ParentBox.ClientTop.
             double marginCollapse = MarginTopCollapse(flowPrev);
             double top = (flowPrev == null && ParentBox != null ? ParentBox.ClientTop : ParentBox == null ? Location.Y : 0) + marginCollapse + flowPrevBottom;
+
+            // CSS2.1 §10.3.7 / §10.6.4: an out-of-flow box that was flowed
+            // through an inline formatting context takes its *static* position
+            // from the inline cursor recorded at flow time, not from the block
+            // stacking computed above (which does not model inline placement).
+            // An axis with auto insets keeps this static position; an explicit
+            // inset overrides it below. Without this an abspos with auto insets
+            // inside inline content would re-flow its own content from the top
+            // of its containing block instead of its in-flow line position.
+            if ((Position == CssConstants.Absolute || Position == CssConstants.Fixed)
+                && InlineStaticPosition is { } inlineStatic)
+            {
+                left = inlineStatic.X + ActualMarginLeft;
+                top = inlineStatic.Y + ActualMarginTop;
+            }
 
             // --- Float positioning ---
             if (Float != CssConstants.None)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -332,11 +332,110 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             {
                 ApplyVerticalWritingModeFlow();
             }
+
+            // RF-BRIDGE-1b Track 3.2: after the main document is laid out, lay out any
+            // materialised nested browsing contexts (an <iframe>/<object>/<frame> whose
+            // sub-document DOM is present as a #subdoc-root subtree, as it is on the
+            // shared-geometry render document). Each subtree is placed at its frame's
+            // content-box origin and sized to the content box, so a subframe element
+            // reports real geometry composed into the main coordinate frame. This runs
+            // only at the document root and only touches #subdoc-root subtrees, which are
+            // absent from the paint document (that serialises the sub-document into the
+            // frame's srcdoc and rasterises it separately), so it cannot affect painting.
+            if (ParentBox == null)
+                LayoutNestedBrowsingContexts(this, g);
         }
         catch (Exception ex)
         {
             LayoutEnvironment.ReportLayoutError("Exception in box layout", ex);
         }
+    }
+
+    private static void LayoutNestedBrowsingContexts(CssBox box, ILayoutEnvironment g)
+    {
+        foreach (var child in box.Boxes)
+        {
+            if (child.SourceElement is { } source
+                && string.Equals(source.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase))
+            {
+                LayoutSubdocument(box, child, g);
+            }
+
+            // Descend either way so nested frames (a subframe that itself embeds a frame)
+            // are laid out relative to their now-positioned parent subdocument.
+            LayoutNestedBrowsingContexts(child, g);
+        }
+    }
+
+    /// <summary>
+    /// Lays out a materialised sub-document subtree (<paramref name="subdocRoot"/>, a
+    /// <c>#subdoc-root</c> box) inside its containing frame (<paramref name="frame"/>):
+    /// positions it at the frame's content-box origin, sizes it to the content box (the
+    /// sub-viewport), and runs the normal block layout so its descendants report geometry
+    /// in the main coordinate frame. The static (unscrolled) sub-document position is
+    /// used — the bridge applies each frame's own scroll offset separately, exactly as it
+    /// does for the main document.
+    /// </summary>
+    private static void LayoutSubdocument(CssBox frame, CssBox subdocRoot, ILayoutEnvironment g)
+    {
+        double contentLeft = frame.Location.X + frame.ActualBorderLeftWidth + frame.ActualPaddingLeft;
+        double contentTop = frame.Location.Y + frame.ActualBorderTopWidth + frame.ActualPaddingTop;
+        double contentWidth = frame.Size.Width
+            - frame.ActualBorderLeftWidth - frame.ActualBorderRightWidth
+            - frame.ActualPaddingLeft - frame.ActualPaddingRight;
+        double contentHeight = frame.Size.Height
+            - frame.ActualBorderTopWidth - frame.ActualBorderBottomWidth
+            - frame.ActualPaddingTop - frame.ActualPaddingBottom;
+
+        if (contentWidth <= 0 || contentHeight <= 0)
+            return;
+
+        // The #subdoc-root box acts as the sub-viewport: a block filling the frame's
+        // content box, against which the sub-document's root element resolves.
+        subdocRoot.Display = CssConstants.Block;
+        subdocRoot.Size = new SizeF((float)contentWidth, (float)contentHeight);
+        subdocRoot.Location = new PointF((float)contentLeft, (float)contentTop);
+        subdocRoot.ActualBottom = contentTop;
+
+        subdocRoot.PerformLayoutImp(g);
+
+        // PerformLayoutImp resolves the subtree relative to the containing block's flow,
+        // which need not coincide with the frame content-box origin set above. Translate
+        // the whole subtree so its origin lands exactly at the content box.
+        double dx = contentLeft - subdocRoot.Location.X;
+        double dy = contentTop - subdocRoot.Location.Y;
+        if (dx != 0 || dy != 0)
+            TranslateSubtree(subdocRoot, dx, dy);
+    }
+
+    private static void TranslateSubtree(CssBox box, double dx, double dy)
+    {
+        box.Location = new PointF((float)(box.Location.X + dx), (float)(box.Location.Y + dy));
+        box.ActualBottom += dy;
+
+        foreach (var line in box.LineBoxes)
+        {
+            var keys = new List<CssBox>(line.Rectangles.Keys);
+            foreach (var key in keys)
+            {
+                var r = line.Rectangles[key];
+                line.Rectangles[key] = new RectangleF((float)(r.X + dx), (float)(r.Y + dy), r.Width, r.Height);
+            }
+            foreach (var word in line.Words)
+            {
+                word.Left += dx;
+                word.Top += dy;
+            }
+        }
+
+        foreach (var word in box.Words)
+        {
+            word.Left += dx;
+            word.Top += dy;
+        }
+
+        foreach (var child in box.Boxes)
+            TranslateSubtree(child, dx, dy);
     }
 
     public void SetBeforeBox(CssBox before)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -510,6 +510,17 @@ internal abstract partial class CssBoxProperties
     internal bool AbsposLocationFinalized { get; set; }
 
     /// <summary>
+    /// The static position (CSS2.1 §10.3.7 / §10.6.4) an out-of-flow box would
+    /// occupy in its inline formatting context — the inline cursor where FlowBox
+    /// encountered it. Recorded by the inline layout so that when the box's block
+    /// layout resolves its used position, an axis with <c>auto</c> insets falls
+    /// back to this inline static position instead of the block-flow static
+    /// (top of the containing block), which does not model inline placement.
+    /// Null when the box was not flowed through an inline formatting context.
+    /// </summary>
+    internal PointF? InlineStaticPosition { get; set; }
+
+    /// <summary>
     /// When this box is an absolutely-positioned grid item, the grid container's
     /// track-sizing pass records the item's resolved grid area here in absolute
     /// coordinates (X/Y = area origin, Width/Height = area size). CSS Grid §9

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -549,6 +549,62 @@ internal static class CssLayoutEngine
             && blockBox.Overflow is CssConstants.Hidden or CssConstants.Auto or CssConstants.Scroll
             && blockBox.ActualBottom - blockBox.Location.Y > blockBox.ActualHeight)
             blockBox.ActualBottom = blockBox.Location.Y + blockBox.ActualHeight;
+
+        // CSS2.1 §9.6.1 / §10.3.7: An out-of-flow (absolutely/fixed positioned)
+        // descendant of this inline formatting context was flowed by FlowBox only
+        // to establish its static line-box rectangle; it never received its own
+        // PerformLayout, so its used size and inset-based position are unresolved.
+        // Now that the context's line rectangles are assigned (so an inline
+        // containing block such as a position:relative <span> has real geometry),
+        // lay those boxes out. Without this an abspos inside an inline CB reports
+        // its static line position instead of its top/left inset box.
+        LayoutOutOfFlowInlineDescendants(g, blockBox);
+    }
+
+    /// <summary>
+    /// Lays out the absolutely/fixed positioned boxes that hang off an inline
+    /// formatting context established by <paramref name="ifcRoot"/>. FlowBox
+    /// descends the inline subtree to establish each out-of-flow box's static
+    /// position but does not run its block layout (size + inset position); this
+    /// walk does, mirroring how the block path lays out its out-of-flow children
+    /// via <see cref="CssBox.PerformLayout"/>. It descends only through in-flow,
+    /// non-atomic inline boxes — the boxes FlowBox itself entered — because
+    /// floats, atomic inlines (inline-block/-flex/-grid/-table), and block-level
+    /// boxes run their own layout, which already resolves their out-of-flow
+    /// descendants.
+    /// </summary>
+    private static void LayoutOutOfFlowInlineDescendants(ILayoutEnvironment g, CssBox ifcRoot)
+    {
+        foreach (var child in ifcRoot.Boxes)
+            LayoutOutOfFlowInlineDescendantsCore(g, child);
+    }
+
+    private static void LayoutOutOfFlowInlineDescendantsCore(ILayoutEnvironment g, CssBox box)
+    {
+        if (box.Display == CssConstants.None)
+            return;
+
+        if (box.Position == CssConstants.Absolute || box.Position == CssConstants.Fixed)
+        {
+            // PerformLayout resolves the box's own size + inset position and
+            // recurses into its subtree, so do not descend past it here.
+            box.PerformLayout(g);
+            return;
+        }
+
+        // Only plain inline (and anonymous inline) boxes are part of this inline
+        // formatting context. Floats and atomic/block boxes establish their own
+        // layout and must not be re-entered here. Anonymous *block* wrappers (from
+        // a block-in-inline split) run their own CreateLineBoxes, so excluding
+        // IsBlock avoids laying their out-of-flow descendants out twice.
+        if (box.Float != CssConstants.None || box.IsBlock)
+            return;
+
+        if (box.Display == CssConstants.Inline || box.Kind == BoxKind.Anonymous)
+        {
+            foreach (var child in box.Boxes)
+                LayoutOutOfFlowInlineDescendantsCore(g, child);
+        }
     }
 
     public static void ApplyCellVerticalAlignment(ILayoutEnvironment g, CssBox cell)
@@ -669,6 +725,14 @@ internal static class CssLayoutEngine
             // height.
             bool isAbsposChild = b.Position == CssConstants.Absolute
                 || b.Position == CssConstants.Fixed;
+
+            // CSS2.1 §10.3.7 / §10.6.4: record the out-of-flow child's static
+            // position — the inline cursor it would occupy in this formatting
+            // context — so its own block layout can honour it for auto-inset
+            // axes (see CssBoxProperties.InlineStaticPosition).
+            if (isAbsposChild)
+                b.InlineStaticPosition = new PointF((float)curx, (float)cury);
+
             double childSaveCurx = curx;
             double childSaveCury = cury;
             double childSaveMaxRight = maxRight;

--- a/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
+++ b/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
@@ -422,6 +422,10 @@ hottest, most-tested path — a **distinct track** from the bridge migration, an
 must be gated on the **full WPT pixel + Acid corpus**, not just the geometry unit
 tests. Scoped from investigation (2026-07-09):
 
+**Status: 3.1 LANDED (2026-07-09), engine-side, regression-free; 3.2 and 3.3 remain.**
+Once the bridge's `absPosInInlineCB` bypass/gate are also retired (a follow-up), 3.1
+stops blocking `ComputeOffsetWithinAncestor`; 2.4 still waits on 3.2 + 3.3.
+
 ### 3.1 — abspos-in-inline-CB placement
 
 **Symptom.** An absolutely/fixed-positioned element whose containing block is an
@@ -448,37 +452,59 @@ removed from the line, not laid out in it). The render tests only exercise `top:
 (static ≈ inset), which is why the engine bug is currently masked in rendering and
 only surfaces through the bridge's shared-geometry offset.
 
-**Root position path — narrowed by engine instrumentation (2026-07-09).** The
-box-model wiring (`GetAbsoluteContainingBlockPaddingBox` → `GetInlineBoundingBox`;
-`ComputeStaticAndFloatPosition` insets at `CssBox.Layout.cs:~844`; the
-`AdjustAbsolutePosition` word-shift at `CssLayoutEngine.cs:930/1328`) all *exist*.
-But temporary `Console.Error` probes (guarded on the target abspos, then on **every**
-abspos) proved that **for this scenario neither `ComputeStaticAndFloatPosition`'s
-abspos block NOR `FlowBox`'s line-930 abspos handler fires at all** — so the
-mis-placed `box.Location = (49.27, 50)` is set by a **third, not-yet-located path**.
-`CollectLayoutGeometry` reads `box.Location` here (not the line-rectangle union,
-because the sized target's `box.Bounds` is non-empty), so the wrong `Location` is the
-whole bug. Likely candidates for the real path: the **typed render path** the shared
-snapshot uses (`SetDocumentWithStyleSet(GetRenderDocument())` → `GetLayoutGeometry`,
-which differs from the string render path — see rf-bridge-1b §5a), or a separate
-abspos collection/positioning pass. The render tests use `top:0` (static ≈ inset),
-masking the bug; it surfaces only via the shared snapshot. Pinned by the skipped
-`Broiler.Cli.Tests.AbsPosInlineCbGeometryTests` (expects `20,60`, engine yields
-`49.27,50`).
+**Root cause — FOUND, and the earlier "third path" note was itself wrong
+(2026-07-09).** Instrumenting the `Location` setter proved the abspos target's
+`box.Location` is **never set at all** (only static boxes get Location sets); the
+mis-placed `(49.27, 50)` therefore does *not* come from `box.Location`. It comes from
+`CollectLayoutGeometry`'s **line-rectangle-union fallback**: because the target is
+never given a real `PerformLayout`, its used `Size` stays `(0,0)`, so `box.Bounds` is
+empty and the collector falls back to `UnionLineRectangles` — the static line rectangle
+`FlowBox` parked at the end of the "anchor" text. The deeper reason it is never laid
+out: `LayoutBlockChildren`'s **inlines-only branch** (`CssBox.Layout.cs`, the
+`ContainsInlinesOnly → CreateLineBoxes` path) lays out *floated* children after the
+line pass but has **no equivalent for out-of-flow abspos/fixed children**, so an abspos
+whose ancestor chain up to the block is all-inline (the `position:relative <span>`
+case) is flowed by `FlowBox` for its static rectangle only and never sized/positioned.
+Two further gaps compounded it: (a) the engine never **blockifies** an abspos per
+CSS 2.1 §9.7, so an inline-display abspos (`<a>`/`<span>`) skips `PerformLayoutImp`'s
+block path (`IsBlock == false`) that resolves width + inset position; and (b)
+`GetInlineBoundingBox` measured the inline CB's extent including its *own* out-of-flow
+child, whose transient static `Location` dragged the CB origin to `(0,0)`.
 
-**Work.** *First* locate the actual positioning path (instrument `AdjustAbsolutePosition`
-and the typed-path abspos layout; both obvious paths are ruled out), *then* make it set
-`box.Location` to the inline-CB origin + insets while preserving auto-sizing of
-abspos-with-inline-content (issue #1163 anchor labels). Then remove the bridge's
-`absPosInInlineCB` bypass + the accessor gate and un-skip `AbsPosInlineCbGeometryTests`.
-**Deep inline-formatting-context work on the engine's hottest path** — it changes
-rendered abspos placement, so gate on the full WPT pixel + Acid corpus (no *new*
-regressions; Acid is not pixel-perfect today, so the bar is "no net-worse," not
-"perfect"), plus `ScrollIntoView_TargetAfterBlockInInlineSibling` and the
-css-anchor-position `position-area-inline-container` cluster. **Fix not attempted this
-session** — the positioning path proved more buried than the two obvious candidates
-(both instrumented and ruled out), so it needs a dedicated multi-cycle tracing effort;
-the search is now narrowed to the typed render path / abspos pass.
+**Fix — LANDED in `Broiler.Layout` (2026-07-09), entirely engine-side.** Three
+coordinated changes, all CSS-spec-grounded:
+1. **`CreateLineBoxes` → `LayoutOutOfFlowInlineDescendants`** (`CssLayoutEngine.cs`):
+   after an inline formatting context is flowed, walk its in-flow inline subtree and
+   `PerformLayout` each out-of-flow abspos/fixed descendant (mirroring how the block
+   path lays out its out-of-flow children; floats/atomic-inlines/blocks run their own
+   layout and are skipped).
+2. **§9.7 blockification** (`CssBox.Layout.cs`, `PerformLayoutImp`): route out-of-flow
+   boxes through the block layout path regardless of computed display, so an
+   inline-level abspos resolves its shrink-to-fit width (§10.3.7) and inset position.
+3. **Inline static position preserved** (`CssBoxProperties.InlineStaticPosition` +
+   `FlowBox` records it + `ComputeStaticAndFloatPosition` honours it): an *auto*-inset
+   abspos keeps the inline cursor position `FlowBox` gave it, so it does not re-flow its
+   content from the top of its containing block (fixed a 7.6% pixel regression in
+   `position-area-abs-inline-container` where the `#inline-container` text jumped to the
+   origin); an *explicit* inset still overrides. Plus `GetInlineBoundingBox`
+   (`CssBox.ContainingBlock.cs`) now excludes out-of-flow children from the inline CB's
+   extent (§10.1).
+
+`AbsPosInlineCbGeometryTests` **un-skipped and green** (`20,60`). Verified
+regression-free vs a stashed HEAD baseline: `Broiler.Layout.Tests` 39/40 (the 1 is the
+pre-existing project-reference-path architecture test), Cli geometry/anchor/shared +
+`SharedLayoutGeometryParity` families green, and the WPT anchor/position-area/sticky +
+abspos/cssom-view clusters show **zero new failures** (every failure — e.g.
+`PositionAreaScrolling00{2,3}`, `OffsetTopLeft_BorderBoxPaddingEdge`,
+`AbsposInBlockInInlineInRelposInline` — also fails at HEAD). Notably
+`position-area-abs-inline-container` (which passed at HEAD) still passes.
+
+**Follow-up now unblocked (not done here).** With the engine placing abspos-in-inline-CB
+correctly, the bridge's `AnchorRegistry` `absPosInInlineCB` bypass + the
+`TrySharedOffsetWithinAncestor` gate (and, eventually, the `PromoteAbsPosFromInlineCBs`
+DOM-mutation workaround) can be retired — a separate bridge change to validate against
+the full anchor WPT cluster, and still one of the three renderer prerequisites (with
+3.2/3.3) that 2.4's estimator deletion waits on.
 
 ### 3.2 — cross-frame / subframe geometry in the main coordinate space
 
@@ -509,9 +535,10 @@ Smaller than 3.1/3.2 and mostly bridge-side, but depends on the fixed box's shar
 geometry being correct (interacts with 3.1/3.2). **Oracle:** the visual-viewport /
 fixed scrollIntoView cases.
 
-**Gate to close 2.4.** Once 3.1–3.3 land and the bridge's bypasses/gates are removed
-(so no resolver calls `ComputeOffsetWithinAncestor` / the size estimators), flip
-`UseSharedGeometryExclusively` (verified regression-free in 2.4) and delete the
+**Gate to close 2.4.** **3.1 has landed** (engine now places abspos-in-inline-CB
+correctly); 3.2 and 3.3 remain. Once all three land *and* the bridge's bypasses/gates
+are removed (so no resolver calls `ComputeOffsetWithinAncestor` / the size estimators),
+flip `UseSharedGeometryExclusively` (verified regression-free in 2.4) and delete the
 estimator body + `WithLayoutGeometryCache`. Only then does 2.5 (`LayoutRuntimeState`)
 also open up.
 

--- a/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
+++ b/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
@@ -422,9 +422,12 @@ hottest, most-tested path — a **distinct track** from the bridge migration, an
 must be gated on the **full WPT pixel + Acid corpus**, not just the geometry unit
 tests. Scoped from investigation (2026-07-09):
 
-**Status: 3.1 COMPLETE (engine fix 2026-07-09 + bridge bypass/gate removal 2026-07-10),
-regression-free; 3.2 and 3.3 remain.** 3.1 no longer blocks
-`ComputeOffsetWithinAncestor`; 2.4's estimator deletion still waits on 3.2 + 3.3.
+**Status: 3.1 COMPLETE (engine fix 2026-07-09 + bridge bypass/gate removal 2026-07-10)
+and 3.3 COMPLETE (split-subtraction migration 2026-07-10), both regression-free; only
+3.2 remains.** The two fixed-target visual-viewport `scrollIntoView` sites and the
+abspos-in-inline-CB paths no longer call `ComputeOffsetWithinAncestor`; 2.4's estimator
+deletion now waits on 3.2 (cross-frame geometry) alone — plus dropping the remaining
+cross-frame gate once 3.2 lands.
 
 ### 3.1 — abspos-in-inline-CB placement
 
@@ -562,32 +565,51 @@ Smaller than 3.1/3.2 and mostly bridge-side, but depends on the fixed box's shar
 geometry being correct (interacts with 3.1/3.2). **Oracle:** the visual-viewport /
 fixed scrollIntoView cases.
 
-**Attempted + reverted (2026-07-10) — a blanket "viewport-anchored" flag is too coarse.**
-Added a `viewportAnchored` mode to `TrySharedOffsetWithinAncestor` that skips the whole
-intermediate-scroll-subtraction loop, and pointed the two `ScrollFixedElementIntoVisualViewport`
-`offsetOverride` sites at it. Both direct oracles (`VisualViewport_ScrollIntoView_Fixed_Target_Uses_Visual_Page_Offset`,
-`VisualViewport_ScrollIntoView_FixedTarget_Adjusts_PageTop`) stayed green — but a hit
-probe showed that was **luck, not correctness**: for the `Adjusts_PageTop` case the shared
-value (1268) and estimator (744) disagree by exactly the intermediate scroll, and both
-clamp to the same max visual-viewport extra offset, so the test can't tell them apart.
-The disagreement is because that fixture's target is an `<input>` *inside* a
-`position:fixed; overflow:auto` box — i.e. the fixed element is **itself a scroll
-container**, and the target genuinely scrolls within it. So the subtraction must be split:
-skip it for scroll containers **above** the fixed element (between the fixed box and the
-document — those don't move a viewport-anchored box), but **keep** it for scroll containers
-**at or below** the fixed element in the subtree (the fixed box's own `overflow` scroll,
-which the target rides). A single flag can't express that; the correct fix walks the chain
-and stops subtracting only once it passes the nearest fixed ancestor's document-anchor —
-which needs that fixed box's shared geometry to be reliable (the 3.2/fixed-geometry
-dependency). Reverted; the two sites stay on the estimator until this split is implemented
-and validated against a fixture whose result is *not* clamp-saturated.
+**DONE — split-subtraction landed (2026-07-10).** The correct rule is a *split*, not a
+blanket skip. A first attempt with a `viewportAnchored` mode that skipped the whole
+intermediate-scroll-subtraction loop looked green but was clamp-luck: for the
+`Adjusts_PageTop` fixture (target is an `<input>` inside a `position:fixed; overflow:auto`
+box — the fixed element is **itself a scroll container** the target rides) it gave 1268 vs
+the estimator's 744, and both saturate the same max visual-viewport offset. So the loop now
+subtracts scroll only for containers **at or below** the target's nearest `position:fixed`
+ancestor F (the fixed box's own overflow + any scroller nested inside it, which the target
+rides) and **stops** once the walk climbs past F (containers above F don't move a
+viewport-anchored box). Implemented in `TrySharedOffsetWithinAncestor(..., viewportAnchored)`
+via `FindNearestFixedAncestorOrSelf` + a DOM ancestor check; the two
+`ScrollFixedElementIntoVisualViewport` `offsetOverride` sites now call
+`OffsetWithinAncestorForFixedPreferShared` instead of `ComputeOffsetWithinAncestor`.
 
-**Gate to close 2.4.** **3.1 is complete** — the engine places abspos-in-inline-CB
-correctly and the bridge's `absPosInInlineCB` bypass + gate are removed; 3.2 and 3.3
-remain. Once those land *and* their bypasses/gates are removed (so no resolver calls
-`ComputeOffsetWithinAncestor` / the size estimators), flip `UseSharedGeometryExclusively`
-(verified regression-free in 2.4) and delete the estimator body + `WithLayoutGeometryCache`.
-Only then does 2.5 (`LayoutRuntimeState`) also open up.
+Validated against a **non-clamp-saturated** fixture
+(`VisualViewport_ScrollIntoView_Target_In_TopFixed_Scroller_Uses_Unclamped_Offset`, added):
+a top-anchored fixed scroller with the target 150px down, scrolled into a 384px visual
+viewport, lands `pageTop` at 650 (= 500 layout + 150) — well under the 884 clamp. Probes
+confirmed the migration is behaviour-identical to the estimator wherever the fixed box's
+geometry is well-defined: for a **top-anchored** fixed element the shared offset equals the
+estimator *exactly* (36 = 36). The default (non-anchored) path — sticky, general
+scrollIntoView, position-area — is byte-for-byte unchanged (the split only engages under
+`viewportAnchored`). Zero new failures across the fixed / visual-viewport / scrollIntoView
+clusters; the residual pre-existing failures (`VisualScrollIntoView_002`,
+`SubframeRootScrollIntoView_Uses_SmoothScrollBehavior`, `ScrollIntoView_Maps_WritingMode…`)
+fail identically at HEAD.
+
+**Known separate bug it exposed (not 3.3).** A `bottom`/`right`-anchored fixed box is
+mis-placed in the shared geometry by its own extent — `getBoundingClientRect()` on a
+`position:fixed; bottom:0; height:60` box reports `top = innerHeight` (should be
+`innerHeight − 60`), i.e. it is anchored by its top edge to the viewport bottom instead of
+its bottom edge. This affects `getBoundingClientRect` and the estimator alike (both differ
+from each other only because they mis-handle it differently), is masked in every current
+test by the visual-viewport clamp, and is orthogonal to the scroll-accounting 3.3 fixes.
+File/fix it at the fixed-box layout layer separately; after the 3.3 migration scrollIntoView
+at least reads the *same* (shared) geometry as `getBoundingClientRect`, so the two are now
+mutually consistent.
+
+**Gate to close 2.4.** **3.1 and 3.3 are complete** — the engine places abspos-in-inline-CB
+correctly (bypass + gate removed) and the two fixed-target visual-viewport scrollIntoView
+sites read the shared snapshot; only **3.2** (cross-frame geometry) remains. Once it lands
+*and* the cross-frame gate is dropped (so no resolver calls `ComputeOffsetWithinAncestor` /
+the size estimators), flip `UseSharedGeometryExclusively` (verified regression-free in 2.4)
+and delete the estimator body + `WithLayoutGeometryCache`. Only then does 2.5
+(`LayoutRuntimeState`) also open up.
 
 ---
 

--- a/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
+++ b/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
@@ -422,12 +422,14 @@ hottest, most-tested path — a **distinct track** from the bridge migration, an
 must be gated on the **full WPT pixel + Acid corpus**, not just the geometry unit
 tests. Scoped from investigation (2026-07-09):
 
-**Status: 3.1 COMPLETE (engine fix 2026-07-09 + bridge bypass/gate removal 2026-07-10)
-and 3.3 COMPLETE (split-subtraction migration 2026-07-10), both regression-free; only
-3.2 remains.** The two fixed-target visual-viewport `scrollIntoView` sites and the
-abspos-in-inline-CB paths no longer call `ComputeOffsetWithinAncestor`; 2.4's estimator
-deletion now waits on 3.2 (cross-frame geometry) alone — plus dropping the remaining
-cross-frame gate once 3.2 lands.
+**Status: 3.1 and 3.3 COMPLETE (2026-07-10), regression-free; 3.2 partially landed.**
+The two fixed-target visual-viewport `scrollIntoView` sites and the abspos-in-inline-CB
+paths no longer call `ComputeOffsetWithinAncestor`. 3.2's **geometry composition is done**
+— a subframe element now reports real `getBoundingClientRect` in the main coordinate frame
+(`CssBox.LayoutNestedBrowsingContexts`) — but its **offset migration is still gated**: a
+`position:fixed` element inside a subframe resolves against the main viewport, so the
+cross-frame `scrollIntoView` gate stays on the estimator until the subframe lays out under
+its own sub-viewport. 2.4's estimator deletion waits on that final 3.2 piece.
 
 ### 3.1 — abspos-in-inline-CB placement
 
@@ -540,17 +542,35 @@ target resolves without the estimator. **Oracle:** the
 `ScrollIntoView_Uses_Script_Assigned_Iframe_Position_For_*Fixed_Targets` and
 `Subframe*ScrollIntoView` cases.
 
-**Scope confirmed (2026-07-10).** The shared snapshot (`BuildSharedGeometrySnapshot` →
-`GetRenderDocument()` → `CollectLayoutGeometry`) is a single `Dictionary<DomElement,
-BoxGeometry>` for the **main** document only — subframe elements are not keyed in it at
-all, so `TryGetSharedLayoutGeometry(subframeTarget)` already returns false and the
-cross-frame gate is a fast short-circuit over a box that is simply absent. Closing 3.2
-therefore means teaching `CollectLayoutGeometry` (Broiler.HTML orchestration) to recurse
-into each iframe's laid-out subdocument, translate its internal box geometry by the
-iframe element's own main-frame border-box origin, and add those entries to the snapshot —
-i.e. nested-browsing-context composition on the renderer side, not a bridge-only change.
-This is the largest of the three prerequisites and must gate on the full iframe/subframe
-scrollIntoView + `Subframe*` corpus (several of which currently fail pre-existing).
+**Geometry composition LANDED (2026-07-10); offset migration still gated on subframe
+fixed-positioning.** Investigation corrected the earlier scope note: the render document
+(`GetRenderDocument()` = the live `_document`) *does* carry each iframe's sub-document as a
+`#subdoc-root` subtree, and `CollectLayoutGeometry` *does* key boxes for the subframe
+elements — but the layout leaves that subtree unpositioned (the iframe is a replaced leaf),
+so every subframe box came back at `(0,0,0,0)`. Fixed in `Broiler.Layout` (**main repo**,
+not the submodule) with `CssBox.LayoutNestedBrowsingContexts`: a root-only post-layout pass
+that finds each `#subdoc-root` box, places it at its frame's content-box origin, sizes it to
+the content box (the sub-viewport), runs the normal block layout, and translates the subtree
+onto the content origin. A subframe element now reports real `getBoundingClientRect` in the
+main coordinate frame (pinned by
+`DomBridge_SubframeElement_GetBoundingClientRect_Is_Composed_Into_Main_Frame`: an abspos
+target at `(30,40)` in an iframe at `(100,300)` → `130,340,50,50`, was `0,0,0,0`). The pass
+is additive and touches only `#subdoc-root` subtrees — absent from the paint document (which
+serialises the sub-document into the frame's `srcdoc` and rasterises it separately), so paint
+is unaffected; regression-free across the layout, shared-geometry, anchor, and iframe/cssom
+clusters.
+
+**What still blocks dropping the cross-frame gate.** A `position:fixed` element *inside* a
+subframe resolves against the layout env's **global** `ViewportSize` (the main viewport),
+not the subframe's content box, so its composed box is wrong — dropping the gate regressed
+`ScrollIntoView_Uses_Script_Assigned_Iframe_Position_For_Fixed_Targets` (its target is fixed
+within the subframe). The gate therefore stays: `scrollIntoView` cross-frame offsets remain
+on the estimator's frame-aware walk. Closing that needs the subframe to lay out under its
+**own sub-viewport** — a delegating `ILayoutEnvironment` whose `ViewportSize` is the frame
+content box (and fixed positioning honouring a per-context origin so a fixed subframe box
+lands at `contentOrigin + inset`, not `(0,0) + inset`). That is the remaining 3.2 work; once
+it lands, drop the cross-frame gate and validate against the full iframe/subframe
+scrollIntoView + `Subframe*` corpus (several currently fail pre-existing).
 
 ### 3.3 — fixed-target offsets for the visual-viewport scrollIntoView sites
 
@@ -605,11 +625,12 @@ mutually consistent.
 
 **Gate to close 2.4.** **3.1 and 3.3 are complete** — the engine places abspos-in-inline-CB
 correctly (bypass + gate removed) and the two fixed-target visual-viewport scrollIntoView
-sites read the shared snapshot; only **3.2** (cross-frame geometry) remains. Once it lands
-*and* the cross-frame gate is dropped (so no resolver calls `ComputeOffsetWithinAncestor` /
-the size estimators), flip `UseSharedGeometryExclusively` (verified regression-free in 2.4)
-and delete the estimator body + `WithLayoutGeometryCache`. Only then does 2.5
-(`LayoutRuntimeState`) also open up.
+sites read the shared snapshot. **3.2's geometry composition has landed** (subframe boxes are
+now in the main-frame snapshot); the one remaining piece is the subframe sub-viewport so the
+cross-frame `scrollIntoView` gate can be dropped. Once that lands (so no resolver calls
+`ComputeOffsetWithinAncestor` / the size estimators), flip `UseSharedGeometryExclusively`
+(verified regression-free in 2.4) and delete the estimator body + `WithLayoutGeometryCache`.
+Only then does 2.5 (`LayoutRuntimeState`) also open up.
 
 ---
 

--- a/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
+++ b/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
@@ -422,9 +422,9 @@ hottest, most-tested path — a **distinct track** from the bridge migration, an
 must be gated on the **full WPT pixel + Acid corpus**, not just the geometry unit
 tests. Scoped from investigation (2026-07-09):
 
-**Status: 3.1 LANDED (2026-07-09), engine-side, regression-free; 3.2 and 3.3 remain.**
-Once the bridge's `absPosInInlineCB` bypass/gate are also retired (a follow-up), 3.1
-stops blocking `ComputeOffsetWithinAncestor`; 2.4 still waits on 3.2 + 3.3.
+**Status: 3.1 COMPLETE (engine fix 2026-07-09 + bridge bypass/gate removal 2026-07-10),
+regression-free; 3.2 and 3.3 remain.** 3.1 no longer blocks
+`ComputeOffsetWithinAncestor`; 2.4's estimator deletion still waits on 3.2 + 3.3.
 
 ### 3.1 — abspos-in-inline-CB placement
 
@@ -499,12 +499,27 @@ abspos/cssom-view clusters show **zero new failures** (every failure — e.g.
 `AbsposInBlockInInlineInRelposInline` — also fails at HEAD). Notably
 `position-area-abs-inline-container` (which passed at HEAD) still passes.
 
-**Follow-up now unblocked (not done here).** With the engine placing abspos-in-inline-CB
-correctly, the bridge's `AnchorRegistry` `absPosInInlineCB` bypass + the
-`TrySharedOffsetWithinAncestor` gate (and, eventually, the `PromoteAbsPosFromInlineCBs`
-DOM-mutation workaround) can be retired — a separate bridge change to validate against
-the full anchor WPT cluster, and still one of the three renderer prerequisites (with
-3.2/3.3) that 2.4's estimator deletion waits on.
+**Bridge bypasses retired (2026-07-10).** With the engine placing abspos-in-inline-CB
+correctly, the two bridge fallbacks that mirrored the old renderer gap are **removed**:
+`AnchorRegistry.ComputeElementBox`'s `absPosInInlineCB` bypass (so an abspos anchor in
+an inline CB now registers from the real shared box) and
+`TrySharedOffsetWithinAncestor`'s matching abspos-in-inline-CB gate (so `scrollIntoView`
+on such a target reads the shared offset instead of the estimator). The cross-frame
+(3.2) and zoom gates in `TrySharedOffsetWithinAncestor` are **kept**. Verified
+regression-free: the WPT abspos-in-inline-CB cluster (`position-area-inline-container`,
+`-abs-inline-container`, `AnchorInlineContainingBlock`, `AbsPos*InInlineContainingBlock`)
+green; the anchor/position-area/sticky/anchor-scroll/position-try clusters show only the
+same pre-existing failures as HEAD (`PositionAreaScrolling00{2,3}`,
+`PositionAreaAnchorPartiallyOutside`, `PositionVisibilityRemoveAnchorsVisible`,
+`PositionTryGrid001`); Cli oracle + scrollIntoView-abspos + anchor + shared families
+green. (`position-area-percents-001` flakes under parallel load — passes 3/3 in
+isolation on both HEAD and this change.)
+
+The `PromoteAbsPosFromInlineCBs` DOM-mutation workaround in the anchor resolver is left
+in place — it is now redundant for geometry but is a larger, separate anchor-subsystem
+change with its own paint/registration coupling; retiring it is a follow-up. 3.1 no
+longer blocks `ComputeOffsetWithinAncestor`; 2.4's estimator deletion still waits on
+3.2 + 3.3.
 
 ### 3.2 — cross-frame / subframe geometry in the main coordinate space
 
@@ -535,12 +550,12 @@ Smaller than 3.1/3.2 and mostly bridge-side, but depends on the fixed box's shar
 geometry being correct (interacts with 3.1/3.2). **Oracle:** the visual-viewport /
 fixed scrollIntoView cases.
 
-**Gate to close 2.4.** **3.1 has landed** (engine now places abspos-in-inline-CB
-correctly); 3.2 and 3.3 remain. Once all three land *and* the bridge's bypasses/gates
-are removed (so no resolver calls `ComputeOffsetWithinAncestor` / the size estimators),
-flip `UseSharedGeometryExclusively` (verified regression-free in 2.4) and delete the
-estimator body + `WithLayoutGeometryCache`. Only then does 2.5 (`LayoutRuntimeState`)
-also open up.
+**Gate to close 2.4.** **3.1 is complete** — the engine places abspos-in-inline-CB
+correctly and the bridge's `absPosInInlineCB` bypass + gate are removed; 3.2 and 3.3
+remain. Once those land *and* their bypasses/gates are removed (so no resolver calls
+`ComputeOffsetWithinAncestor` / the size estimators), flip `UseSharedGeometryExclusively`
+(verified regression-free in 2.4) and delete the estimator body + `WithLayoutGeometryCache`.
+Only then does 2.5 (`LayoutRuntimeState`) also open up.
 
 ---
 

--- a/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
+++ b/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
@@ -537,6 +537,18 @@ target resolves without the estimator. **Oracle:** the
 `ScrollIntoView_Uses_Script_Assigned_Iframe_Position_For_*Fixed_Targets` and
 `Subframe*ScrollIntoView` cases.
 
+**Scope confirmed (2026-07-10).** The shared snapshot (`BuildSharedGeometrySnapshot` →
+`GetRenderDocument()` → `CollectLayoutGeometry`) is a single `Dictionary<DomElement,
+BoxGeometry>` for the **main** document only — subframe elements are not keyed in it at
+all, so `TryGetSharedLayoutGeometry(subframeTarget)` already returns false and the
+cross-frame gate is a fast short-circuit over a box that is simply absent. Closing 3.2
+therefore means teaching `CollectLayoutGeometry` (Broiler.HTML orchestration) to recurse
+into each iframe's laid-out subdocument, translate its internal box geometry by the
+iframe element's own main-frame border-box origin, and add those entries to the snapshot —
+i.e. nested-browsing-context composition on the renderer side, not a bridge-only change.
+This is the largest of the three prerequisites and must gate on the full iframe/subframe
+scrollIntoView + `Subframe*` corpus (several of which currently fail pre-existing).
+
 ### 3.3 — fixed-target offsets for the visual-viewport scrollIntoView sites
 
 **Symptom.** The two visual-viewport `offsetOverride` sites in
@@ -549,6 +561,26 @@ for a viewport-anchored fixed box. Left on the estimator.
 Smaller than 3.1/3.2 and mostly bridge-side, but depends on the fixed box's shared
 geometry being correct (interacts with 3.1/3.2). **Oracle:** the visual-viewport /
 fixed scrollIntoView cases.
+
+**Attempted + reverted (2026-07-10) — a blanket "viewport-anchored" flag is too coarse.**
+Added a `viewportAnchored` mode to `TrySharedOffsetWithinAncestor` that skips the whole
+intermediate-scroll-subtraction loop, and pointed the two `ScrollFixedElementIntoVisualViewport`
+`offsetOverride` sites at it. Both direct oracles (`VisualViewport_ScrollIntoView_Fixed_Target_Uses_Visual_Page_Offset`,
+`VisualViewport_ScrollIntoView_FixedTarget_Adjusts_PageTop`) stayed green — but a hit
+probe showed that was **luck, not correctness**: for the `Adjusts_PageTop` case the shared
+value (1268) and estimator (744) disagree by exactly the intermediate scroll, and both
+clamp to the same max visual-viewport extra offset, so the test can't tell them apart.
+The disagreement is because that fixture's target is an `<input>` *inside* a
+`position:fixed; overflow:auto` box — i.e. the fixed element is **itself a scroll
+container**, and the target genuinely scrolls within it. So the subtraction must be split:
+skip it for scroll containers **above** the fixed element (between the fixed box and the
+document — those don't move a viewport-anchored box), but **keep** it for scroll containers
+**at or below** the fixed element in the subtree (the fixed box's own `overflow` scroll,
+which the target rides). A single flag can't express that; the correct fix walks the chain
+and stops subtracting only once it passes the nearest fixed ancestor's document-anchor —
+which needs that fixed box's shared geometry to be reliable (the 3.2/fixed-geometry
+dependency). Reverted; the two sites stay on the estimator until this split is implemented
+and validated against a fixture whose result is *not* clamp-saturated.
 
 **Gate to close 2.4.** **3.1 is complete** — the engine places abspos-in-inline-CB
 correctly and the bridge's `absPosInInlineCB` bypass + gate are removed; 3.2 and 3.3

--- a/src/Broiler.Cli.Tests/AbsPosInlineCbGeometryTests.cs
+++ b/src/Broiler.Cli.Tests/AbsPosInlineCbGeometryTests.cs
@@ -28,7 +28,7 @@ namespace Broiler.Cli.Tests;
 /// </summary>
 public sealed class AbsPosInlineCbGeometryTests
 {
-    [Fact(Skip = "RF-BRIDGE-1b Track 3.1: engine mis-places abspos-in-inline-CB; un-skip when Broiler.Layout is fixed.")]
+    [Fact]
     public void AbsPos_In_Relative_Inline_Uses_Inset_Position_From_Shared_Geometry()
     {
         var html = "<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0}</style></head><body>" +

--- a/src/Broiler.Cli.Tests/GoogleSearchPolyfillTests.cs
+++ b/src/Broiler.Cli.Tests/GoogleSearchPolyfillTests.cs
@@ -2167,6 +2167,62 @@ document.getElementById('result').textContent =
         Assert.Contains("1000|1000|1384|1000|true|2|384", result);
     }
 
+    // RF-BRIDGE-1b Track 3.3: a fixed element that is itself a scroll container, with the
+    // target part-way down its overflow, scrolled into a scale-2 visual viewport. Unlike the
+    // bottom:0 sibling above (which clamp-saturates the visual page offset and so can't tell a
+    // correct offset from a wrong one), this top:0 case needs a *modest* extra offset: the
+    // target sits 150px into the fixed scroller, the visual viewport is 384px tall (max extra
+    // = 768 - 384 = 384), so pageTop lands at 500 (layout scroll) + 150 = 650 — well under the
+    // 884 clamp. This pins the shared-geometry offset (ScrollFixedElementIntoVisualViewport →
+    // OffsetWithinAncestorForFixedPreferShared) to the correct, non-saturated value, so a
+    // regression in the fixed-subtree scroll accounting is caught here rather than hidden by
+    // the clamp.
+    [Fact]
+    public void VisualViewport_ScrollIntoView_Target_In_TopFixed_Scroller_Uses_Unclamped_Offset()
+    {
+        var result = ExecJs(@"
+            document.body.style.margin = '0';
+            document.body.style.height = '4000px';
+            visualViewport.scale = 2;
+            window.scrollTo(0, 500);
+
+            var fixed = document.createElement('div');
+            fixed.style.position = 'fixed';
+            fixed.style.top = '0';
+            fixed.style.left = '0';
+            fixed.style.width = '100px';
+            fixed.style.height = '300px';
+            fixed.style.overflow = 'auto';
+
+            var spacer = document.createElement('div');
+            spacer.style.height = '150px';
+
+            var target = document.createElement('input');
+            target.style.display = 'block';
+            target.style.height = '20px';
+
+            fixed.appendChild(spacer);
+            fixed.appendChild(target);
+            document.body.appendChild(fixed);
+
+            var fired = false;
+            visualViewport.addEventListener('scroll', function() { fired = true; });
+            target.scrollIntoView({ behavior: 'instant' });
+
+            document.getElementById('result').textContent = [
+                window.scrollY,
+                visualViewport.pageTop,
+                fired,
+                visualViewport.scale,
+                visualViewport.height
+            ].join('|');
+        ");
+
+        // Non-saturated: pageTop = layout scroll (500) + target's 150px offset within the
+        // fixed scroller = 650 (clamp ceiling is 884).
+        Assert.Contains("500|650|true|2|384", result);
+    }
+
     [Fact]
     public void ScrollIntoView_Does_Not_Scroll_Root_For_Targets_Inside_Unscrollable_Fixed_Containers()
     {

--- a/src/Broiler.Cli.Tests/ScriptEngineExecuteTests.cs
+++ b/src/Broiler.Cli.Tests/ScriptEngineExecuteTests.cs
@@ -210,6 +210,42 @@ function run() {
         Assert.Equal("old|true|new", result.ToString());
     }
 
+    // RF-BRIDGE-1b Track 3.2: a normal/absolutely-positioned element inside an iframe
+    // subdocument reports getBoundingClientRect in the *main* coordinate frame — the
+    // iframe's content-box origin plus the element's offset within the subframe. The
+    // shared-geometry snapshot lays out each materialised #subdoc-root subtree at its
+    // frame's content box (CssBox.LayoutNestedBrowsingContexts); before this the subframe
+    // boxes were left unpositioned (0,0,0,0). (position:fixed inside a subframe still
+    // resolves against the main viewport — a separate sub-viewport follow-up — so it is
+    // not exercised here.)
+    [Fact]
+    public void DomBridge_SubframeElement_GetBoundingClientRect_Is_Composed_Into_Main_Frame()
+    {
+        const string html = """
+<!DOCTYPE html>
+<html><body style="margin:0; width:2000px; height:2000px;">
+  <iframe id="fr"></iframe>
+</body></html>
+""";
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///test.html");
+        bridge.FireWindowLoadEvent();
+
+        var result = context.Eval("""
+            (() => {
+                var iframe = document.getElementById('fr');
+                iframe.style.cssText = 'position:absolute; left:100px; top:300px; width:400px; height:300px; border:0';
+                iframe.srcdoc = '<!DOCTYPE html><html><body style="margin:0"><div id="target" style="position:absolute; left:30px; top:40px; width:50px; height:50px;"></div></body></html>';
+                var r = iframe.contentDocument.getElementById('target').getBoundingClientRect();
+                return r.left + ',' + r.top + ',' + r.width + ',' + r.height;
+            })()
+            """);
+
+        // Iframe content origin (100,300) + target inset (30,40) = (130,340), size 50x50.
+        Assert.Equal("130,340,50,50", result.ToString());
+    }
+
     [Fact]
     public void DomBridge_ScrollIntoView_Uses_Script_Assigned_Iframe_Position_For_Fixed_Targets()
     {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
@@ -81,20 +81,6 @@ public sealed partial class DomBridge
         string? position = props.GetValueOrDefault("position");
         bool isPositioned = position == "absolute" || position == "fixed";
 
-        // An absolutely/fixed-positioned anchor whose containing block is an
-        // *inline* element (e.g. a `position:relative` <span>) cannot be placed by
-        // Broiler's renderer inside that inline box (see PromoteAbsPosFromInlineCBs)
-        // — its real layout lands at the inline-flow position, ignoring the box's own
-        // left/top insets. The shared-geometry path would therefore register the
-        // anchor at the wrong rect (css-anchor-position position-area-inline-container:
-        // an abspos anchor at left:100/top:25 in a <span> came back at the end of the
-        // preceding text, collapsing all four position-area cells). The CSS-inset
-        // estimator below resolves this case exactly from the explicit insets, so
-        // bypass the shared path for it.
-        bool absPosInInlineCB = isPositioned
-            && FindContainingBlockElement(element) is { } inlineCbAncestor
-            && IsInlineContainingBlock(inlineCbAncestor);
-
         // Prefer the renderer's real layout for the anchor rect when the shared
         // geometry path is active (RF-BRIDGE-1b). The CSS-property estimator below
         // cannot model inline flow — an inline anchor after an inline-block, or with
@@ -105,7 +91,12 @@ public sealed partial class DomBridge
         // anchor() resolution is unchanged. Falls through to the estimator whenever
         // the geometry is unavailable (flag off, detached, no box) — so this is a
         // no-op unless UseSharedLayoutGeometry is enabled.
-        if (!absPosInInlineCB && TryGetAnchorLayoutBox(element, out var layoutBox))
+        //
+        // (RF-BRIDGE-1b Track 3.1) The former absPosInInlineCB bypass is gone: the
+        // layout engine now places an abspos anchor whose containing block is an
+        // inline box at its inset position, so its shared box is correct — verified
+        // by the css-anchor-position position-area-inline-container cluster.
+        if (TryGetAnchorLayoutBox(element, out var layoutBox))
             return layoutBox;
 
         double width = TryParsePx(props.GetValueOrDefault("width")) ?? 0;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -2321,11 +2321,13 @@ public sealed partial class DomBridge
         offset = 0;
         if (!UseSharedLayoutGeometry)
             return false;
-        // Cross-frame (iframe subdocument) targets are laid out in the subframe's own
-        // coordinate frame, not the main snapshot's, so a main-document offset cannot be
-        // read from the shared boxes — leave those to the estimator's cross-frame walk
-        // (scrollIntoView on a fixed target inside an iframe: the target's main-doc offset
-        // must fold in the iframe's own position, which the main snapshot does not carry).
+        // Cross-frame (iframe subdocument) targets: the shared snapshot now composes each
+        // subframe's normal/absolute geometry into the main coordinate frame
+        // (CssBox.LayoutNestedBrowsingContexts, RF-BRIDGE-1b Track 3.2), but a
+        // position:fixed element inside a subframe still resolves against the *main*
+        // viewport rather than the subframe's (the layout env's ViewportSize is global),
+        // so its composed box is wrong. Until the subframe lays out under its own
+        // sub-viewport, keep the cross-frame offset on the estimator's frame-aware walk.
         if (!ReferenceEquals(GetOwningDocumentElement(element), GetOwningDocumentElement(ancestor)))
             return false;
         // (RF-BRIDGE-1b Track 3.1) The former abspos-in-inline-CB bypass is gone: the

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -1810,7 +1810,7 @@ public sealed partial class DomBridge
             viewportSizeOverride: GetVisualViewportHeight(),
             currentScrollOverride: GetVisualViewportPageOffset(vertical: true),
             offsetOverride: GetElementScrollOffset(scrollContainer, vertical: true) +
-                ComputeOffsetWithinAncestor(element, scrollContainer, vertical: true),
+                OffsetWithinAncestorForFixedPreferShared(element, scrollContainer, vertical: true),
             coordinateSpaceIsPhysical: true);
         var targetLeft = ResolveScrollIntoViewOffset(
             element,
@@ -1820,7 +1820,7 @@ public sealed partial class DomBridge
             viewportSizeOverride: GetVisualViewportWidth(),
             currentScrollOverride: GetVisualViewportPageOffset(vertical: false),
             offsetOverride: GetElementScrollOffset(scrollContainer, vertical: false) +
-                ComputeOffsetWithinAncestor(element, scrollContainer, vertical: false),
+                OffsetWithinAncestorForFixedPreferShared(element, scrollContainer, vertical: false),
             coordinateSpaceIsPhysical: true);
         SetVisualViewportPageOffsets(left: targetLeft, top: targetTop);
     }
@@ -2315,7 +2315,8 @@ public sealed partial class DomBridge
     /// when the shared path is off, either box is missing, or zoom is in play (a zoomed
     /// cross-ancestor delta is not reconciled against the baked snapshot).
     /// </summary>
-    private bool TrySharedOffsetWithinAncestor(DomElement element, DomElement ancestor, bool vertical, out double offset)
+    private bool TrySharedOffsetWithinAncestor(DomElement element, DomElement ancestor, bool vertical, out double offset,
+        bool viewportAnchored = false)
     {
         offset = 0;
         if (!UseSharedLayoutGeometry)
@@ -2342,10 +2343,21 @@ public sealed partial class DomBridge
             ? elementBox.BorderBox.Top - ancestorBox.PaddingBox.Top
             : elementBox.BorderBox.Left - ancestorBox.PaddingBox.Left;
 
+        // (RF-BRIDGE-1b Track 3.3) For a viewport-anchored target — one being scrolled
+        // into the *visual* viewport whose containing chain includes a position:fixed
+        // ancestor F — only the scroll containers at or below F move the target: the
+        // target rides F's own overflow scroll (and any scroller nested inside F), but
+        // F itself is pinned to the viewport, so scroll containers *above* F do not
+        // shift it. Stop subtracting once the walk climbs past F. (A normal, non-anchored
+        // target subtracts every intermediate scroll container up to the ancestor.)
+        var fixedAnchor = viewportAnchored ? FindNearestFixedAncestorOrSelf(element) : null;
+
         for (var current = element; ;)
         {
             var parent = GetScrollTraversalParent(current);
             if (parent == null || ReferenceEquals(parent, ancestor))
+                break;
+            if (fixedAnchor != null && !IsDomDescendantOrSelf(parent, fixedAnchor))
                 break;
             natural -= GetElementScrollOffset(parent, vertical);
             current = parent;
@@ -2354,6 +2366,45 @@ public sealed partial class DomBridge
         offset = natural;
         return true;
     }
+
+    /// <summary>
+    /// Walks the DOM ancestry from <paramref name="element"/> (inclusive) and returns the
+    /// nearest <c>position:fixed</c> box, or null if none. Used to bound the scroll
+    /// subtraction for a viewport-anchored scrollIntoView target
+    /// (<see cref="TrySharedOffsetWithinAncestor"/>).
+    /// </summary>
+    private DomElement? FindNearestFixedAncestorOrSelf(DomElement element)
+    {
+        for (var current = element; current != null; current = current.Parent)
+        {
+            if (IsFixedPositionElement(current))
+                return current;
+        }
+        return null;
+    }
+
+    private static bool IsDomDescendantOrSelf(DomElement node, DomElement potentialAncestor)
+    {
+        for (var current = node; current != null; current = current.Parent)
+        {
+            if (ReferenceEquals(current, potentialAncestor))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// RF-BRIDGE-1b Track 3.3: offset of a viewport-anchored (fixed-subtree) target
+    /// within <paramref name="ancestor"/> from the shared snapshot, subtracting only the
+    /// scroll of containers at or below the target's nearest fixed ancestor
+    /// (<see cref="TrySharedOffsetWithinAncestor"/> with <c>viewportAnchored</c>), else
+    /// the estimator. Used by the visual-viewport fixed-element scrollIntoView sites so
+    /// they no longer call the estimator directly.
+    /// </summary>
+    private double OffsetWithinAncestorForFixedPreferShared(DomElement element, DomElement ancestor, bool vertical) =>
+        TrySharedOffsetWithinAncestor(element, ancestor, vertical, out var shared, viewportAnchored: true)
+            ? shared
+            : ComputeOffsetWithinAncestor(element, ancestor, vertical);
 
     /// <summary>
     /// RF-BRIDGE-1b: offset of <paramref name="element"/> within

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -2327,15 +2327,10 @@ public sealed partial class DomBridge
         // must fold in the iframe's own position, which the main snapshot does not carry).
         if (!ReferenceEquals(GetOwningDocumentElement(element), GetOwningDocumentElement(ancestor)))
             return false;
-        // An absolutely/fixed-positioned element whose containing block is an inline box is
-        // placed by the renderer at the inline-flow position, ignoring its own insets, so its
-        // shared box is at the wrong place — the estimator resolves it from the explicit
-        // insets. Mirrors AnchorRegistry.ComputeElementBox's absPosInInlineCB bypass.
-        var elementPosition = GetComputedProps(element).GetValueOrDefault("position");
-        if ((elementPosition == "absolute" || elementPosition == "fixed")
-            && FindContainingBlockElement(element) is { } inlineCbAncestor
-            && IsInlineContainingBlock(inlineCbAncestor))
-            return false;
+        // (RF-BRIDGE-1b Track 3.1) The former abspos-in-inline-CB bypass is gone: the
+        // layout engine now places an absolutely/fixed-positioned element whose
+        // containing block is an inline box at its inset position, so its shared box is
+        // correct and the estimator fallback is no longer needed here.
         if (Math.Abs(GetUsedZoomForElement(element) - 1.0) >= 0.0001 ||
             Math.Abs(GetUsedZoomForElement(ancestor) - 1.0) >= 0.0001)
             return false;


### PR DESCRIPTION
Completes three major tracks toward retiring the `ComputeOffsetWithinAncestor` estimator (RF-BRIDGE-1b §2.4):

## Summary

**Track 3.1 — abspos-in-inline-CB placement (COMPLETE).** The layout engine now correctly places an absolutely/fixed-positioned element whose containing block is an inline box (e.g. a `position:relative <span>`). The root cause was that such elements were never laid out — they were flowed by the inline formatter only to establish a static line-box rectangle, then left with `Size=(0,0)`, causing `CollectLayoutGeometry` to fall back to the line-rectangle union. Fixed with three coordinated engine changes: (a) `LayoutOutOfFlowInlineDescendants` walks the inline subtree after line layout and `PerformLayout`s each out-of-flow descendant; (b) blockification (CSS 2.1 §9.7) routes out-of-flow boxes through the block layout path regardless of computed display, so an inline-level abspos resolves its shrink-to-fit width and inset position; (c) inline static position is preserved so an auto-inset abspos keeps the inline cursor position rather than re-flowing from the block top. Bridge bypasses (`absPosInInlineCB` in `AnchorRegistry` and `TrySharedOffsetWithinAncestor`) are removed; `AbsPosInlineCbGeometryTests` un-skipped and green.

**Track 3.2 — subframe geometry composition (GEOMETRY COMPLETE; offset migration gated on sub-viewport).** The shared-geometry snapshot now lays out each materialised `#subdoc-root` subtree at its frame's content-box origin via `CssBox.LayoutNestedBrowsingContexts`, so a subframe element reports real `getBoundingClientRect` in the main coordinate frame. A `position:fixed` element *inside* a subframe still resolves against the main viewport (not the subframe's), so the cross-frame `scrollIntoView` gate remains until the subframe lays out under its own sub-viewport — a follow-up requiring a delegating `ILayoutEnvironment` with per-context `ViewportSize`.

**Track 3.3 — fixed-target visual-viewport scrollIntoView (COMPLETE).** The two `ScrollFixedElementIntoVisualViewport` sites now use shared geometry via `OffsetWithinAncestorForFixedPreferShared`, which applies a split-subtraction rule: scroll containers at or below the target's nearest `position:fixed` ancestor are subtracted (the target rides that fixed box's overflow), but containers above it are skipped (the fixed box is pinned to the viewport). Validated against a non-clamp-saturated fixture to ensure correctness independent of visual-viewport clamping.

## Key Changes

- **`CssBox.PerformLayout` + `LayoutNestedBrowsingContexts`**: Post-layout pass that positions each `#subdoc-root` subtree at its frame's content box and runs block layout, composing subframe geometry into the main frame.
- **`CssLayoutEngine.CreateLineBoxes` + `LayoutOutOfFlowInlineDescendants`**: After inline layout, walk the inline subtree and `PerformLayout` each out-of-flow abspos/fixed descendant.
- **`CssBox.Layout.PerformLayoutImp` blockification**: Route out-of-flow boxes through the block path regardless of computed display (CSS 2.1 §9.7).
- **Inline static position (`CssBoxProperties.InlineStaticPosition`)**: Record the inline cursor position during flow; `ComputeStaticAndFloatPosition` honours it for auto-inset axes.
- **`CssBox.ContainingBlock.GetInlineBoundingBox`**: Exclude out-of-flow children from the inline CB's extent (CSS 2.1 §10.1).
- **`LayoutMetrics.TrySharedOffsetWithinAncestor`**: Split-

https://claude.ai/code/session_01KiiySbxe5MVYCZG7P3h3Xt