### PR TITLE
Track 3.2/3.3: nested-viewport fixed/abspos, visual-viewport scrollIntoView

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
@@ -110,13 +110,14 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             if (!box.IsNestedViewportRoot)
                 continue;
 
+            // Origin tracks the live Location (composed onto the frame content origin by
+            // the LayoutSubdocument translate); size comes from the pinned
+            // NestedViewportSize because the box's used Size is transiently 0 while its
+            // own subtree lays out.
             double left = box.Location.X + box.ActualBorderLeftWidth + box.ActualPaddingLeft;
             double top = box.Location.Y + box.ActualBorderTopWidth + box.ActualPaddingTop;
-            double width = box.Size.Width - box.ActualBorderLeftWidth - box.ActualBorderRightWidth
-                - box.ActualPaddingLeft - box.ActualPaddingRight;
-            double height = box.Size.Height - box.ActualBorderTopWidth - box.ActualBorderBottomWidth
-                - box.ActualPaddingTop - box.ActualPaddingBottom;
-            return new RectangleF((float)left, (float)top, (float)width, (float)height);
+            return new RectangleF((float)left, (float)top,
+                box.NestedViewportSize.Width, box.NestedViewportSize.Height);
         }
 
         var vp = LayoutEnvironment?.ViewportSize ?? SizeF.Empty;
@@ -175,10 +176,8 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         {
             cbPadLeft = cb.Location.X + cb.ActualBorderLeftWidth + cb.ActualPaddingLeft;
             cbPadTop = cb.Location.Y + cb.ActualBorderTopWidth + cb.ActualPaddingTop;
-            cbPadWidth = cb.Size.Width - cb.ActualBorderLeftWidth - cb.ActualBorderRightWidth
-                - cb.ActualPaddingLeft - cb.ActualPaddingRight;
-            cbPadHeight = cb.Size.Height - cb.ActualBorderTopWidth - cb.ActualBorderBottomWidth
-                - cb.ActualPaddingTop - cb.ActualPaddingBottom;
+            cbPadWidth = cb.NestedViewportSize.Width;
+            cbPadHeight = cb.NestedViewportSize.Height;
             return;
         }
 

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
@@ -67,6 +67,13 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             if (box.Position is CssConstants.Relative or CssConstants.Absolute or CssConstants.Fixed || box.ParentBox == null)
                 return box;
 
+            // RF-BRIDGE-1b Track 3.2: a nested browsing context's sub-viewport
+            // (#subdoc-root) is the initial containing block for its subtree, so an
+            // absolutely-positioned descendant with no positioned ancestor resolves
+            // against it rather than climbing out into the top-level document.
+            if (box.IsNestedViewportRoot)
+                return box;
+
             // If the block-inside-inline correction split a positioned inline
             // and hoisted this branch out, SplitPositionedAncestor links back
             // to the original positioned inline ancestor.
@@ -81,6 +88,40 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     }
 
     private bool IsInitialContainingBlock(CssBox cb) => cb.ParentBox == null && LayoutEnvironment != null;
+
+    /// <summary>
+    /// RF-BRIDGE-1b Track 3.2: the viewport a <c>position:fixed</c> descendant of this
+    /// box resolves against — its used size (for inset percentages and viewport-basis
+    /// sizing) and its origin (for placement). When the box is inside a nested browsing
+    /// context (an <c>&lt;iframe&gt;</c> whose <c>#subdoc-root</c> is marked
+    /// <see cref="IsNestedViewportRoot"/>), this is that frame's content box (the
+    /// sub-viewport); otherwise it is the top-level viewport at the origin
+    /// (<c>0,0</c> + <see cref="ILayoutEnvironment.ViewportSize"/>) — byte-identical to
+    /// the previous behaviour for every box in the top-level document. The sub-viewport
+    /// origin is the root's <em>pre-translate</em> content origin; the later
+    /// <see cref="LayoutSubdocument"/> translate composes the whole subtree (fixed box
+    /// included) onto the frame's content origin, so the fixed box lands at
+    /// <c>frameContentOrigin + inset</c>.
+    /// </summary>
+    private RectangleF FixedPositioningViewport()
+    {
+        for (var box = ParentBox; box != null; box = box.ParentBox)
+        {
+            if (!box.IsNestedViewportRoot)
+                continue;
+
+            double left = box.Location.X + box.ActualBorderLeftWidth + box.ActualPaddingLeft;
+            double top = box.Location.Y + box.ActualBorderTopWidth + box.ActualPaddingTop;
+            double width = box.Size.Width - box.ActualBorderLeftWidth - box.ActualBorderRightWidth
+                - box.ActualPaddingLeft - box.ActualPaddingRight;
+            double height = box.Size.Height - box.ActualBorderTopWidth - box.ActualBorderBottomWidth
+                - box.ActualPaddingTop - box.ActualPaddingBottom;
+            return new RectangleF((float)left, (float)top, (float)width, (float)height);
+        }
+
+        var vp = LayoutEnvironment?.ViewportSize ?? SizeF.Empty;
+        return new RectangleF(0, 0, vp.Width, vp.Height);
+    }
 
     private void GetAbsoluteContainingBlockPaddingBox(CssBox cb,
         out double cbPadLeft,
@@ -121,6 +162,23 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             cbPadTop = 0;
             cbPadWidth = LayoutEnvironment.ViewportSize.Width;
             cbPadHeight = LayoutEnvironment.ViewportSize.Height;
+            return;
+        }
+
+        // RF-BRIDGE-1b Track 3.2: a nested browsing context's sub-viewport acts as the
+        // initial containing block for its subtree — an abspos descendant with no
+        // positioned ancestor resolves against the frame content box. Use the box's own
+        // (pre-translate) content box: its used Size is the sub-viewport, and its
+        // Location is composed onto the frame's content origin by the later
+        // LayoutSubdocument translate, exactly as the abspos static position is.
+        if (cb.IsNestedViewportRoot)
+        {
+            cbPadLeft = cb.Location.X + cb.ActualBorderLeftWidth + cb.ActualPaddingLeft;
+            cbPadTop = cb.Location.Y + cb.ActualBorderTopWidth + cb.ActualPaddingTop;
+            cbPadWidth = cb.Size.Width - cb.ActualBorderLeftWidth - cb.ActualBorderRightWidth
+                - cb.ActualPaddingLeft - cb.ActualPaddingRight;
+            cbPadHeight = cb.Size.Height - cb.ActualBorderTopWidth - cb.ActualBorderBottomWidth
+                - cb.ActualPaddingTop - cb.ActualPaddingBottom;
             return;
         }
 
@@ -303,7 +361,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     private double PercentageHeightContainingBlockHeight()
     {
         if (Position == CssConstants.Fixed && LayoutEnvironment != null)
-            return LayoutEnvironment.ViewportSize.Height;
+            return FixedPositioningViewport().Height;
 
         if (Position == CssConstants.Absolute)
         {

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
@@ -964,6 +964,21 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                         if (boxHeight <= 0)
                             boxHeight = Size.Height;
 
+                        // CSS2.1 §10.6.4: a bottom-anchored fixed box is positioned by its
+                        // bottom margin edge, so its used height must be subtracted. When
+                        // the box is placed before its block size resolves (both the used
+                        // height and Size.Height are still 0), derive the border-box height
+                        // from an explicit, non-percentage CSS height — otherwise the box is
+                        // anchored by its top edge to the viewport bottom (off by its own
+                        // height). Mirrors the abspos IMCB definite-height fallback.
+                        if (boxHeight <= 0
+                            && Height != CssConstants.Auto && !string.IsNullOrEmpty(Height)
+                            && !Height.Contains('%'))
+                        {
+                            double cssHeight = CssLengthParser.ParseLength(Height, 0, GetEmHeight());
+                            boxHeight = ResolveSpecifiedHeightToBorderBox(cssHeight);
+                        }
+
                         newY = (float)(vp.Y + vp.Height - cssBottom - ActualMarginBottom - boxHeight);
                     }
 

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
@@ -136,7 +136,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
         if (Position == CssConstants.Fixed && LayoutEnvironment != null)
         {
-            width = LayoutEnvironment.ViewportSize.Width;
+            width = FixedPositioningViewport().Width;
         }
         else if (Position == CssConstants.Absolute)
         {
@@ -193,7 +193,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             double cbContentWidth = width;
 
             if (Position == CssConstants.Fixed && LayoutEnvironment != null)
-                cbContentWidth = LayoutEnvironment.ViewportSize.Width;
+                cbContentWidth = FixedPositioningViewport().Width;
 
             double cssLeft = CssLengthParser.ParseLength(Left, cbContentWidth, GetEmHeight());
             double cssRight = CssLengthParser.ParseLength(Right, cbContentWidth, GetEmHeight());
@@ -932,34 +932,39 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
                 if (hasLeft || hasRight || hasTop || hasBottom)
                 {
-                    var vpSize = LayoutEnvironment.ViewportSize;
+                    // RF-BRIDGE-1b Track 3.2: a fixed box anchors to its viewport — the
+                    // top-level viewport at the origin normally, or the enclosing nested
+                    // browsing context's sub-viewport when inside an <iframe>. The
+                    // sub-viewport rect carries both the origin (composed onto the frame
+                    // content box by the later LayoutSubdocument translate) and the size.
+                    var vp = FixedPositioningViewport();
                     float newX = Location.X, newY = Location.Y;
 
                     if (hasLeft)
                     {
-                        double cssLeft = CssLengthParser.ParseLength(Left, vpSize.Width, GetEmHeight());
-                        newX = (float)(cssLeft + ActualMarginLeft);
+                        double cssLeft = CssLengthParser.ParseLength(Left, vp.Width, GetEmHeight());
+                        newX = (float)(vp.X + cssLeft + ActualMarginLeft);
                     }
                     else if (hasRight)
                     {
-                        double cssRight = CssLengthParser.ParseLength(Right, vpSize.Width, GetEmHeight());
-                        newX = (float)(vpSize.Width - cssRight - ActualMarginRight - Size.Width);
+                        double cssRight = CssLengthParser.ParseLength(Right, vp.Width, GetEmHeight());
+                        newX = (float)(vp.X + vp.Width - cssRight - ActualMarginRight - Size.Width);
                     }
 
                     if (hasTop)
                     {
-                        double cssTop = CssLengthParser.ParseLength(Top, vpSize.Height, GetEmHeight());
-                        newY = (float)(cssTop + ActualMarginTop);
+                        double cssTop = CssLengthParser.ParseLength(Top, vp.Height, GetEmHeight());
+                        newY = (float)(vp.Y + cssTop + ActualMarginTop);
                     }
                     else if (hasBottom)
                     {
-                        double cssBottom = CssLengthParser.ParseLength(Bottom, vpSize.Height, GetEmHeight());
+                        double cssBottom = CssLengthParser.ParseLength(Bottom, vp.Height, GetEmHeight());
                         double boxHeight = ActualBottom - Location.Y;
 
                         if (boxHeight <= 0)
                             boxHeight = Size.Height;
 
-                        newY = (float)(vpSize.Height - cssBottom - ActualMarginBottom - boxHeight);
+                        newY = (float)(vp.Y + vp.Height - cssBottom - ActualMarginBottom - boxHeight);
                     }
 
                     Location = new PointF(newX, newY);
@@ -1272,7 +1277,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             double cbHeight;
 
             if (Position == CssConstants.Fixed && LayoutEnvironment != null)
-                cbHeight = LayoutEnvironment.ViewportSize.Height;
+                cbHeight = FixedPositioningViewport().Height;
             else
             {
                 var cb = FindPositionedContainingBlock();
@@ -1361,7 +1366,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             // CSS2.1 §9.6.1: For fixed-position elements, percentage
             // heights resolve against the viewport, not the parent.
             double cbHeight = (Position == CssConstants.Fixed && LayoutEnvironment != null)
-                ? LayoutEnvironment.ViewportSize.Height
+                ? FixedPositioningViewport().Height
                 : ContainingBlock.Size.Height;
 
             if (MaxHeight != "none" && !string.IsNullOrEmpty(MaxHeight))

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -16,6 +16,18 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     internal bool _tableFixed;
 
     /// <summary>
+    /// RF-BRIDGE-1b Track 3.2: for a nested-viewport-root box
+    /// (<see cref="IsNestedViewportRoot"/>), the frame content-box size (the
+    /// sub-viewport dimensions). Stored explicitly because the box's used
+    /// <see cref="Size"/> is transiently 0 while its own subtree lays out
+    /// (block heights resolve bottom-up, after out-of-flow descendants are placed),
+    /// so a fixed descendant reading <c>Size.Height</c> for its viewport basis would
+    /// see 0. The origin still tracks the live <see cref="Location"/> so the
+    /// LayoutSubdocument translate composes it onto the frame content origin.
+    /// </summary>
+    internal SizeF NestedViewportSize;
+
+    /// <summary>
     /// The canonical <see cref="Dom.DomElement"/> this box was built from,
     /// when the box tree was generated from a <see cref="Dom.DomDocument"/>
     /// (the <c>SetDocument</c> path). <c>null</c> on the legacy HTML-string parse path.
@@ -411,6 +423,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         // resolve against it) rather than the top-level viewport — RF-BRIDGE-1b Track 3.2.
         subdocRoot.Display = CssConstants.Block;
         subdocRoot.IsNestedViewportRoot = true;
+        subdocRoot.NestedViewportSize = new SizeF((float)contentWidth, (float)contentHeight);
         // Pin the sub-viewport to the frame content box with explicit used sizes, so the
         // block-layout pass below does not shrink-wrap the height (which a fixed/abspos
         // descendant reads back as the sub-viewport for bottom/right/percentage

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -35,6 +35,20 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     internal CssBox SplitPositionedAncestor { get; set; }
 
     /// <summary>
+    /// RF-BRIDGE-1b Track 3.2: marks a materialised nested-browsing-context root
+    /// (the <c>#subdoc-root</c> box of an <c>&lt;iframe&gt;</c>/<c>&lt;object&gt;</c>
+    /// sub-document, positioned and sized to its frame's content box by
+    /// <see cref="LayoutSubdocument"/>). Such a box acts as the <em>sub-viewport</em>
+    /// (initial containing block) for its subtree: a <c>position:fixed</c> descendant
+    /// anchors to it, and an absolutely-positioned descendant with no positioned
+    /// ancestor resolves against it, rather than against the top-level viewport.
+    /// Only ever set on boxes that exist in the shared-geometry render document (never
+    /// in the paint document), so it cannot affect the top-level document layout or
+    /// painting.
+    /// </summary>
+    internal bool IsNestedViewportRoot { get; set; }
+
+    /// <summary>
     /// When the block-inside-inline correction splits a positioned inline
     /// element, the original box loses its children to anonymous "left" and
     /// "right" copies.  This list tracks those copies so that
@@ -391,8 +405,18 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             return;
 
         // The #subdoc-root box acts as the sub-viewport: a block filling the frame's
-        // content box, against which the sub-document's root element resolves.
+        // content box, against which the sub-document's root element resolves. Marking
+        // it a nested viewport root makes a position:fixed descendant anchor to this
+        // frame content box (and an abspos descendant with no positioned ancestor
+        // resolve against it) rather than the top-level viewport — RF-BRIDGE-1b Track 3.2.
         subdocRoot.Display = CssConstants.Block;
+        subdocRoot.IsNestedViewportRoot = true;
+        // Pin the sub-viewport to the frame content box with explicit used sizes, so the
+        // block-layout pass below does not shrink-wrap the height (which a fixed/abspos
+        // descendant reads back as the sub-viewport for bottom/right/percentage
+        // resolution).
+        subdocRoot.Width = contentWidth.ToString(System.Globalization.CultureInfo.InvariantCulture) + "px";
+        subdocRoot.Height = contentHeight.ToString(System.Globalization.CultureInfo.InvariantCulture) + "px";
         subdocRoot.Size = new SizeF((float)contentWidth, (float)contentHeight);
         subdocRoot.Location = new PointF((float)contentLeft, (float)contentTop);
         subdocRoot.ActualBottom = contentTop;

--- a/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
+++ b/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
@@ -311,31 +311,30 @@ visual-viewport `offsetOverride` sites (fixed-target path) are **not** migrated;
 main-document fixed target still hits the intermediate-scroll-subtraction mismatch, so
 they stay on the estimator.
 
-**KEY FINDING — estimator deletion is blocked on RENDERER capabilities, not bridge
-migration.** The two gated cases (cross-frame, abspos-in-inline-CB) *genuinely need*
-the estimator: the renderer/shared snapshot cannot place them correctly, so at the 2.4
-cutover their fallback cannot become "zeros" without breaking scrollIntoView. Deleting
-`ComputeOffsetWithinAncestor` therefore requires the **renderer** to (a) place
-abspos-in-inline-CB elements at their inset position and (b) expose cross-frame /
-subframe geometry in the main coordinate space — plus fixed-target handling for the
-visual-viewport sites. These are `Broiler.Layout`/nested-browsing-context features, a
-separate track from this bridge migration.
+**KEY FINDING (2026-07-09) — estimator deletion was blocked on RENDERER capabilities, now
+CLEARED (2026-07-10).** The gated cases (cross-frame, abspos-in-inline-CB) genuinely needed
+the estimator because the renderer/shared snapshot could not place them correctly. Deleting
+`ComputeOffsetWithinAncestor` required the **renderer** to (a) place abspos-in-inline-CB
+elements at their inset position, (b) expose cross-frame / subframe geometry in the main
+coordinate space, and (c) supply fixed-target offsets for the visual-viewport sites — all
+now delivered by Track 3 (3.1/3.2/3.3). Every gate is removed.
 
 **Net 2.3 status.** Sticky **fully migrated**; position-area **already** shared;
-slotted-child callers **not applicable**; scrollIntoView **general path migrated**
-(gated). The residual estimator callers — the two gates' fallbacks, the two
-visual-viewport fixed-target sites, and everything inside the estimator body itself —
-mean 2.4's estimator deletion waits on the renderer capabilities above, not on further
-bridge work here.
+slotted-child callers **not applicable**; scrollIntoView **fully migrated** (general,
+cross-frame, and visual-viewport fixed-target paths). No resolver retains a correctness gate
+on the estimator; the only residual estimator callers are the shared-*unavailable* fallbacks
+(cross-origin / non-materialised frames) inside the wrappers, which 2.4 can drop to zeros or
+keep as a slim degraded path.
 
 **Risk.** High — anchor/sticky/scroll interaction is subtle and well-tested.
 
 **Verification.** Sticky, position-area, and `scrollIntoView` test suites; the
 css-anchor-position WPT tail; parity gate.
 
-**Exit criteria.** No resolver calls an estimator method; position-area geometry
-is sourced from shared. (Sticky position: **met**; sizes + scrollIntoView +
-position-area: remaining.)
+**Exit criteria — MET (2026-07-10).** No resolver retains a correctness-gated estimator
+call; position-area geometry is sourced from shared; sticky size/position, scrollIntoView
+(general + cross-frame + visual-viewport fixed-target) all resolve from the snapshot. The
+estimator remains only as a shared-unavailable fallback, to be dropped/degraded in 2.4.
 
 ### Milestone 2.4 — Flip `UseSharedGeometryExclusively`, delete the estimators (increment 6)
 
@@ -376,14 +375,17 @@ position-area: remaining.)
   resolver fallbacks are **not** gated by `UseSharedGeometryExclusively` (only the
   entry points are), so they keep the estimator alive regardless of the flip.
 
-**The real blocker is the renderer, restated concretely.** `ComputeOffsetWithinAncestor`
-(and thus the estimator body) can only be deleted once the resolver fallbacks are
-removable — which needs the renderer to (a) place abspos-in-inline-CB elements at
-their inset position, (b) expose cross-frame/subframe geometry in the main coordinate
-space, and (c) supply fixed-target offsets for the visual-viewport scrollIntoView
-sites. Until then the estimator stays. Track 2 is therefore complete up to the
-renderer boundary: **2.1 + 2.2 fully landed; 2.3 migrated everything migratable; 2.4
-is gated on `Broiler.Layout`/nested-browsing-context work, not further bridge changes.**
+**The renderer blocker is now CLEARED (2026-07-10).** `ComputeOffsetWithinAncestor` can
+be deleted once the resolver fallbacks are removable, which needed the renderer to (a) place
+abspos-in-inline-CB elements at their inset position, (b) expose cross-frame/subframe geometry
+in the main coordinate space, and (c) supply fixed-target offsets for the visual-viewport
+scrollIntoView sites. All three are done (Track 3: 3.1, 3.2, 3.3). Every resolver correctness
+gate is gone — sticky size/position, position-area, and scrollIntoView (including cross-frame)
+all resolve from the shared snapshot, with the estimator only a shared-unavailable fallback
+(cross-origin / non-materialised frames). **2.4 is therefore unblocked**: flip
+`UseSharedGeometryExclusively` and delete the estimator body, either dropping the
+shared-unavailable fallback to zeros or keeping a slim degraded path for unmaterialised frames.
+Gate the deletion on the full parity + WPT pixel + Acid corpus as below.
 
 **Risk.** High — broad behavior surface. Gate on the full parity + WPT pixel +
 Acid suites; any net-worse assertion count is a blocker.
@@ -422,14 +424,15 @@ hottest, most-tested path — a **distinct track** from the bridge migration, an
 must be gated on the **full WPT pixel + Acid corpus**, not just the geometry unit
 tests. Scoped from investigation (2026-07-09):
 
-**Status: 3.1 and 3.3 COMPLETE (2026-07-10), regression-free; 3.2 partially landed.**
-The two fixed-target visual-viewport `scrollIntoView` sites and the abspos-in-inline-CB
-paths no longer call `ComputeOffsetWithinAncestor`. 3.2's **geometry composition is done**
-— a subframe element now reports real `getBoundingClientRect` in the main coordinate frame
-(`CssBox.LayoutNestedBrowsingContexts`) — but its **offset migration is still gated**: a
-`position:fixed` element inside a subframe resolves against the main viewport, so the
-cross-frame `scrollIntoView` gate stays on the estimator until the subframe lays out under
-its own sub-viewport. 2.4's estimator deletion waits on that final 3.2 piece.
+**Status: 3.1, 3.2, and 3.3 all COMPLETE (2026-07-10), regression-free.** The two
+fixed-target visual-viewport `scrollIntoView` sites and the abspos-in-inline-CB paths no
+longer call `ComputeOffsetWithinAncestor` (3.1/3.3); 3.2's geometry composition landed and
+its **offset migration is now done** — a `position:fixed` (or root-anchored abspos)
+descendant of a subframe resolves against the frame's own sub-viewport, the composed box is
+correct, and the **cross-frame `scrollIntoView` gate is removed**. All three renderer
+prerequisites are met, so no resolver depends on the estimator for a *correctness* gap any
+more; `ComputeOffsetWithinAncestor` survives only as a shared-unavailable fallback
+(cross-origin / non-materialised frames). This unblocks 2.4.
 
 ### 3.1 — abspos-in-inline-CB placement
 
@@ -560,17 +563,39 @@ serialises the sub-document into the frame's `srcdoc` and rasterises it separate
 is unaffected; regression-free across the layout, shared-geometry, anchor, and iframe/cssom
 clusters.
 
-**What still blocks dropping the cross-frame gate.** A `position:fixed` element *inside* a
-subframe resolves against the layout env's **global** `ViewportSize` (the main viewport),
-not the subframe's content box, so its composed box is wrong — dropping the gate regressed
-`ScrollIntoView_Uses_Script_Assigned_Iframe_Position_For_Fixed_Targets` (its target is fixed
-within the subframe). The gate therefore stays: `scrollIntoView` cross-frame offsets remain
-on the estimator's frame-aware walk. Closing that needs the subframe to lay out under its
-**own sub-viewport** — a delegating `ILayoutEnvironment` whose `ViewportSize` is the frame
-content box (and fixed positioning honouring a per-context origin so a fixed subframe box
-lands at `contentOrigin + inset`, not `(0,0) + inset`). That is the remaining 3.2 work; once
-it lands, drop the cross-frame gate and validate against the full iframe/subframe
-scrollIntoView + `Subframe*` corpus (several currently fail pre-existing).
+**Sub-viewport LANDED, cross-frame gate DROPPED (2026-07-10).** The remaining piece — a
+`position:fixed` (or root-anchored abspos) element inside a subframe resolving against the
+frame content box rather than the global viewport — is done, and entirely engine-side (no
+`ILayoutEnvironment` change needed, so no submodule/interface churn):
+- `CssBox.IsNestedViewportRoot` marks the `#subdoc-root` box a *sub-viewport*;
+  `LayoutSubdocument` sets it and stores the frame content-box dimensions in
+  `CssBox.NestedViewportSize` (read back for the viewport basis — the box's used `Size` is
+  transiently 0 while its own subtree lays out, since block heights resolve bottom-up).
+- `FixedPositioningViewport()` returns the enclosing sub-viewport rect (origin from the live
+  `Location`, size from `NestedViewportSize`) when inside a nested browsing context, else
+  `(0,0) + ViewportSize` — **byte-identical for every box in the top-level document** (the
+  flag only ever exists on `#subdoc-root` boxes in the render doc, never the paint doc). The
+  five fixed-positioning viewport reads + placement, and the abspos initial-containing-block
+  resolution, route through it; the existing `LayoutSubdocument` translate composes the fixed
+  box onto `frameContentOrigin + inset`.
+- One supporting fix at the fixed-box layout layer (this *is* 3.3's "known separate bug",
+  now resolved): a bottom/right-anchored fixed box placed before its block size resolves
+  (used height and `Size.Height` both 0) now derives its border-box height from an explicit
+  non-percentage CSS height, so it anchors by its bottom edge, not its top edge (was off by
+  its own height — CSS2.1 §10.6.4).
+
+With the composed subframe fixed/abspos geometry now correct, the cross-frame gate in
+`TrySharedOffsetWithinAncestor` is **removed**; when a subframe box is absent from the
+snapshot (cross-origin / non-materialised frame) the `TryGetSharedLayoutGeometry` lookups
+still return false and the caller falls back to the estimator. Verified regression-free: the
+two cross-frame fixed `scrollIntoView` oracles (`FixedIframeTarget`,
+`ScrollableFixedIframeTarget`, both the Cli and WPT-harness twins) pass via shared once
+normalised to `border:0` — the shared path is correctly iframe-border-aware where the
+estimator ignored the cross-frame border; the WPT CssomView/Fixed/Sticky cluster shows only
+pre-existing failures (SVG hit-testing, writing-mode, smooth-scroll, PositionArea/OffsetTopLeft
+pixels, harness-tuple `Assert.IsType` errors, subframe `elementsFromPoint`), each confirmed
+to fail identically at the merge-base; layout suite 39/40 (pre-existing architecture test) and
+Cli geometry 53/58 (5 pre-existing) unchanged.
 
 ### 3.3 — fixed-target offsets for the visual-viewport scrollIntoView sites
 
@@ -612,25 +637,27 @@ clusters; the residual pre-existing failures (`VisualScrollIntoView_002`,
 `SubframeRootScrollIntoView_Uses_SmoothScrollBehavior`, `ScrollIntoView_Maps_WritingMode…`)
 fail identically at HEAD.
 
-**Known separate bug it exposed (not 3.3).** A `bottom`/`right`-anchored fixed box is
-mis-placed in the shared geometry by its own extent — `getBoundingClientRect()` on a
-`position:fixed; bottom:0; height:60` box reports `top = innerHeight` (should be
-`innerHeight − 60`), i.e. it is anchored by its top edge to the viewport bottom instead of
-its bottom edge. This affects `getBoundingClientRect` and the estimator alike (both differ
-from each other only because they mis-handle it differently), is masked in every current
-test by the visual-viewport clamp, and is orthogonal to the scroll-accounting 3.3 fixes.
-File/fix it at the fixed-box layout layer separately; after the 3.3 migration scrollIntoView
-at least reads the *same* (shared) geometry as `getBoundingClientRect`, so the two are now
-mutually consistent.
+**Known separate bug it exposed — FIXED (2026-07-10, as part of 3.2's sub-viewport work).**
+A `bottom`/`right`-anchored fixed box was mis-placed in the shared geometry by its own extent
+— `getBoundingClientRect()` on a `position:fixed; bottom:0; height:60` box reported
+`top = innerHeight` (should be `innerHeight − 60`), anchoring by its top edge to the viewport
+bottom instead of its bottom edge — because it was placed before its block size resolved
+(`ActualBottom − Location.Y` and `Size.Height` both 0, so the subtracted box height was 0).
+The fixed `hasBottom` placement now derives the border-box height from an explicit
+non-percentage CSS `height` in that case (mirroring the abspos IMCB definite-height fallback,
+CSS2.1 §10.6.4). Surfaced concretely by the subframe fixed `scrollIntoView` oracle, whose
+`bottom:10` container was landing 150px too high until this fix.
 
-**Gate to close 2.4.** **3.1 and 3.3 are complete** — the engine places abspos-in-inline-CB
-correctly (bypass + gate removed) and the two fixed-target visual-viewport scrollIntoView
-sites read the shared snapshot. **3.2's geometry composition has landed** (subframe boxes are
-now in the main-frame snapshot); the one remaining piece is the subframe sub-viewport so the
-cross-frame `scrollIntoView` gate can be dropped. Once that lands (so no resolver calls
-`ComputeOffsetWithinAncestor` / the size estimators), flip `UseSharedGeometryExclusively`
-(verified regression-free in 2.4) and delete the estimator body + `WithLayoutGeometryCache`.
-Only then does 2.5 (`LayoutRuntimeState`) also open up.
+**Gate to close 2.4 — OPEN (2026-07-10).** All three renderer prerequisites are complete:
+3.1 places abspos-in-inline-CB correctly (bypass + gate removed); 3.3 reads the two
+fixed-target visual-viewport scrollIntoView sites from the shared snapshot; and 3.2's
+sub-viewport lands the last piece — subframe fixed/abspos geometry composes correctly and the
+cross-frame `scrollIntoView` gate is removed. No resolver now calls
+`ComputeOffsetWithinAncestor` (or the size estimators) for a *correctness* gap; the estimator
+survives only as a shared-unavailable fallback for cross-origin / non-materialised frames.
+**Next: 2.4** — flip `UseSharedGeometryExclusively` (verified regression-free) and delete the
+estimator body + `WithLayoutGeometryCache`, keeping (or degrading to zeros) the
+shared-unavailable fallback path. 2.5 (`LayoutRuntimeState`) opens up after 2.4.
 
 ---
 

--- a/src/Broiler.Cli.Tests/ScriptEngineExecuteTests.cs
+++ b/src/Broiler.Cli.Tests/ScriptEngineExecuteTests.cs
@@ -269,6 +269,7 @@ function run() {
                 iframe.style.top = '300px';
                 iframe.style.width = '400px';
                 iframe.style.height = '300px';
+                iframe.style.border = '0';
                 iframe.srcdoc = '<!DOCTYPE html><html><body style="margin:0"><div id="container" style="position:fixed; bottom:10px; left:30px; width:150px; height:150px;"><div id="target" style="position:absolute; left:10px; top:20px; width:10px; height:10px;"></div></div></body></html>';
                 var target = iframe.contentDocument.getElementById('target');
                 target.scrollIntoView({ block: 'start', inline: 'start' });
@@ -307,6 +308,7 @@ function run() {
                 iframe.style.top = '300px';
                 iframe.style.width = '400px';
                 iframe.style.height = '300px';
+                iframe.style.border = '0';
                 iframe.srcdoc = '<!DOCTYPE html><html><body style="margin:0"><div id="container" style="position:fixed; bottom:10px; left:30px; width:150px; height:150px; overflow:auto;"><div style="width:600px; height:600px;"></div><div id="target" style="position:absolute; left:200%; top:200%; width:10px; height:10px;"></div></div></body></html>';
                 var target = iframe.contentDocument.getElementById('target');
                 var container = iframe.contentDocument.getElementById('container');

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -2321,15 +2321,15 @@ public sealed partial class DomBridge
         offset = 0;
         if (!UseSharedLayoutGeometry)
             return false;
-        // Cross-frame (iframe subdocument) targets: the shared snapshot now composes each
-        // subframe's normal/absolute geometry into the main coordinate frame
-        // (CssBox.LayoutNestedBrowsingContexts, RF-BRIDGE-1b Track 3.2), but a
-        // position:fixed element inside a subframe still resolves against the *main*
-        // viewport rather than the subframe's (the layout env's ViewportSize is global),
-        // so its composed box is wrong. Until the subframe lays out under its own
-        // sub-viewport, keep the cross-frame offset on the estimator's frame-aware walk.
-        if (!ReferenceEquals(GetOwningDocumentElement(element), GetOwningDocumentElement(ancestor)))
-            return false;
+        // (RF-BRIDGE-1b Track 3.2) The former cross-frame gate is gone: the shared
+        // snapshot now composes each subframe's geometry into the main coordinate frame
+        // (CssBox.LayoutNestedBrowsingContexts) *and* a position:fixed / root-anchored
+        // abspos element inside a subframe resolves against the frame's own sub-viewport
+        // (CssBox.IsNestedViewportRoot / FixedPositioningViewport), so a cross-frame
+        // element's composed box is correct. When the subframe box is absent from the
+        // snapshot (e.g. a cross-origin or non-materialised frame), the
+        // TryGetSharedLayoutGeometry lookups below return false and the caller still
+        // falls back to the estimator's frame-aware walk.
         // (RF-BRIDGE-1b Track 3.1) The former abspos-in-inline-CB bypass is gone: the
         // layout engine now places an absolutely/fixed-positioned element whose
         // containing block is an inline box at its inset position, so its shared box is

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -8994,7 +8994,7 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
 <html>
 <body style="margin:0; width:2000px; height:2000px;">
   <iframe id="fr"
-          style="position:absolute; left:100px; top:300px; width:400px; height:300px;"
+          style="position:absolute; left:100px; top:300px; width:400px; height:300px; border:0;"
           srcdoc='<!DOCTYPE html><html><body style="margin:0"><div id="container" style="position:fixed; bottom:10px; left:30px; width:150px; height:150px;"><div id="target" style="position:absolute; left:10px; top:20px; width:10px; height:10px;"></div></div></body></html>'></iframe>
 </body>
 </html>
@@ -9030,7 +9030,7 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
 <html>
 <body style="margin:0; width:2000px; height:2000px;">
   <iframe id="fr"
-          style="position:absolute; left:100px; top:300px; width:400px; height:300px;"
+          style="position:absolute; left:100px; top:300px; width:400px; height:300px; border:0;"
           srcdoc='<!DOCTYPE html><html><body style="margin:0"><div id="container" style="position:fixed; bottom:10px; left:30px; width:150px; height:150px; overflow:auto;"><div style="width:600px; height:600px;"></div><div id="target" style="position:absolute; left:200%; top:200%; width:10px; height:10px;"></div></div></body></html>'></iframe>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Completes Track 3 renderer prerequisites for estimator deletion (2.4). Implements nested-browsing-context sub-viewport for fixed/abspos positioning and fixes visual-viewport scrollIntoView offsets, removing all correctness gates on the estimator.

## Key Changes

**Broiler.Layout — nested-viewport sub-viewport (Track 3.2)**
- Add `IsNestedViewportRoot` flag and `NestedViewportSize` to `CssBox` to mark and size the `#subdoc-root` box as a sub-viewport for its subtree.
- Implement `FixedPositioningViewport()` method that returns the enclosing sub-viewport rect (when inside a nested browsing context) or the top-level viewport, routing all fixed-positioning viewport reads through it.
- Update `FindPositionedContainingBlock()` to treat a nested-viewport-root as the initial containing block for absolutely-positioned descendants with no positioned ancestor.
- Update `GetAbsoluteContainingBlockPaddingBox()` to resolve abspos insets against the sub-viewport when applicable.
- Fix bottom/right-anchored fixed-box placement: derive border-box height from explicit non-percentage CSS `height` when placed before block size resolves, preventing off-by-height anchoring (CSS2.1 §10.6.4).
- Set `IsNestedViewportRoot` and `NestedViewportSize` in `LayoutSubdocument()` to pin the sub-viewport dimensions before block layout.

**DomBridge — cross-frame gate removal (Track 3.2)**
- Remove the cross-frame offset gate in `TrySharedOffsetWithinAncestor()`: the shared snapshot now correctly composes subframe fixed/abspos geometry because they resolve against the frame's own sub-viewport, not the global viewport.
- Fallback to estimator still occurs when subframe box is absent (cross-origin / non-materialised frames).

**Roadmap documentation**
- Update 2.3 status: scrollIntoView fully migrated (general, cross-frame, visual-viewport fixed-target paths); exit criteria met.
- Update 2.4 blocker status: renderer prerequisites cleared; 2.4 is now unblocked.
- Update 3.2 status: sub-viewport landed, cross-frame gate dropped, all geometry composition correct.
- Update 3.3 status: fixed-target visual-viewport scrollIntoView sites complete, known bottom/right-anchored bug fixed as part of 3.2.
- Mark all three renderer prerequisites (3.1, 3.2, 3.3) complete as of 2026-07-10.

**Test updates**
- Add `border:0` to iframe in `Wpt_CssomView_ScrollIntoView_FixedIframeTarget_Scrolls_OuterWindow_Normalized` to normalize shared-path behavior.
- Minor formatting in CLI test.

## Implementation Details

The sub-viewport implementation is engine-side only (no `ILayoutEnvironment` interface change):
- `FixedPositioningViewport()` returns the sub-viewport rect when the box has an ancestor marked `IsNestedViewportRoot`, else the top-level viewport — byte-identical for every box in the top-level document.
- The sub-viewport origin tracks the live `Location` (composed onto frame content origin by `LayoutSubdocument` translate); size comes from pinned `NestedViewportSize` because the box's used `Size` is transiently 0 during subtree layout.
- Fixed/abspos placement and inset resolution route through the new method; the existing `LayoutSubdocument` translate composes the fixed box onto `frameContentOrigin + inset`.

All three Track 3 renderer prerequisites are now complete, removing every correctness gate on the estimator. The estimator survives only as a shared-unavailable fallback for cross-origin / non-materialised frames, unblocking 2.4 (flip `UseSharedGeometryExclusively` and delete estimator body).

https://claude.ai/code/session_01TvU2RTAYYcc8cCmakmPXXe