### PR TITLE
RF-BRIDGE-1b: fix inline-block §9.2.1.1 box drop (unblocks estimator deletion) + declare htmlbridge-public-surface/v2

### DIFF
--- a/docs/architecture/htmlbridge-engine-boundaries.md
+++ b/docs/architecture/htmlbridge-engine-boundaries.md
@@ -7,8 +7,16 @@ expanding the cross-engine contract.
 
 ## Boundary version
 
-- **Boundary version:** `htmlbridge-public-surface/v1`
-- **Status:** frozen for M1 follow-on work
+- **Boundary version:** `htmlbridge-public-surface/v2` **(declared 2026-07-10)**
+- **Prior boundary:** `htmlbridge-public-surface/v1` (M1 frozen surface)
+- **Status:** v2 declared by the maintainer, authorizing removal of the v1
+  compatibility adapters catalogued below. Removal proceeds per the
+  [HtmlBridge blocked-items completion roadmap](../roadmap/htmlbridge-blocked-items-completion-roadmap.md)
+  Track 1: the two zero-caller shims (`DomBridge.CalculateSpecificity`,
+  `DomBridge.CssRules`) are removed at v2 immediately (Milestone 1.1); the
+  `DomElement` / `HtmlTreeBuilder` facade removal (Milestones 1.2/1.3) additionally
+  waits on the RF-BRIDGE-1b geometry unification so the identity-keyed caches stop
+  keying on the facade.
 - **Change policy:** additive or behavioral changes inside this boundary require
   spec citations, targeted tests, and an explicit roadmap note; any breaking
   surface change requires a boundary-version bump.

--- a/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
+++ b/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
@@ -346,9 +346,19 @@ estimator remains only as a shared-unavailable fallback, to be dropped/degraded 
 
 ### Milestone 2.4 — Flip `UseSharedGeometryExclusively` (DONE), delete the estimators (increment 6, pending)
 
-**Status (2026-07-10): the FLIP is DONE and regression-free; the estimator DELETION is not
-yet done** — its only remaining blocker is a WPT test-harness snapshot artifact (see Task 1
-and the DELETION analysis below), which the `!HasAssociatedLayoutBox` guard mitigates safely.
+**Status (2026-07-10): the FLIP is DONE and regression-free; the estimator DELETION's blocker is
+now FIXED (session 95a4149e).** The blocker was previously mis-described as a WPT-harness snapshot
+artifact; investigation proved it a real `Broiler.Layout` bug (see the corrected DELETION analysis
+below) and it is now fixed at source in `Broiler.HTML/Source/Broiler.HTML.Orchestration/Parse/
+DomParser.cs`: the block-inside-inline correction's leading-run fold now folds atomic inlines
+(`IsAtomicInlineLevel(box.Boxes[0]) || ContainsInlinesOnlyDeep(box.Boxes[0])`), so an `inline-block`
+containing a block child is no longer mis-selected as the "block to split around" and dissolved.
+Validated regression-free across the full corpus: `LayoutGeometryCompletenessTests` 19/19 (with two new
+`<script>`/`display:none`-sibling fixtures), `Broiler.Layout.Tests` 40/40, full `Broiler.Wpt.Tests`
+(136 fails = exact baseline, 0 new by name) and full `Broiler.Cli.Tests` (76 unique fails = exact
+baseline, 0 new by name). With the box now present in the snapshot for these elements, the
+`!HasAssociatedLayoutBox` guard no longer masks a real gap here — the estimator deletion (Task 2) can
+proceed once the parity harness is retired.
 
 **Goal.** The actual payoff: remove the ~2950-LOC estimator body from
 `LayoutMetrics.cs` and retire `WithLayoutGeometryCache`.
@@ -699,40 +709,45 @@ root-caused to the snapshot missing the `scrollIntoView` scroll container and fi
 `ShouldReturnExclusiveSharedZero` to genuinely-boxless elements (Milestone 2.4 Task 1). Verified
 zero delta on the full Cli (1680) and WPT (545) corpora.
 
-**What blocks the estimator DELETION — sharpened twice (2026-07-10). The gap is DYNAMIC (bridge
-snapshot build), NOT a static layout box-construction gap.** Testing *pure* exclusive (zero any
-snapshot-missing element, no estimator fallback) surfaced regressions from ≥2 elements missing from
-the snapshot: the 4 css-viewport zoom scroll-into-view WPT tests (a `display:inline-block;
-overflow:hidden` container that is a direct child of `<body>`) and `GoogleLikeDiagTest.
-GridChild_UsesContentSizing` (a grid child). The first hypothesis — a static `Broiler.Layout`
-box-construction/attachment gap — was **disproven** by a completeness assertion
-(`Broiler.Cli.Tests.LayoutGeometryCompletenessTests`): a static `HtmlContainer.GetLayoutGeometry`
-call **collects every one of these elements** across 16 layout-mode fixtures, including the exact
-ZoomScrollPadding structure (two inline-block containers, second `zoom:2`) at 320/800/1024 viewports.
-So the layout engine DOES produce the boxes. (An earlier `CollectLayoutGeometry` line-box-traversal
-fix was also tried and proven ineffective — reverted.)
+**What blocks the estimator DELETION — CORRECTED 2026-07-10 (session 95a4149e): it is a REAL
+`Broiler.Layout` bug, NOT a WPT-test-harness artifact.** The earlier "harness artifact / normal bridge
+usage never misses" conclusion (retained below struck through for provenance) was **wrong** — it was an
+artifact of the *variant matrix's own fixtures* omitting a `display:none` sibling. Re-reproduced via
+**plain `Attach` + `ctx.Eval`** (no `WptTestRunner`) with a temporary
+`DomBridge.SharedGeometryMissDiagnostic` hook plus a `HtmlContainerInt.CollectLayoutGeometry` box-tree +
+render-doc DOM dump:
 
-The regression is therefore **dynamic** — and (sharpened 2026-07-10 via `BuildSharedGeometrySnapshot`
-instrumentation + a variant matrix) it is a **WPT-test-harness artifact of `WptTestRunner.
-ExecuteScriptsWithDom`, NOT a real bridge geometry gap.** Findings:
-- The first `.container` is missing from the snapshot on the **first** snapshot build (`call#1`), at
-  the bridge's default `1024×768` geometry viewport — so it is not cumulative bake/revert drift and
-  not a viewport mismatch (a static layout at 1024×768 collects it).
-- **Normal bridge usage does NOT miss.** A variant matrix (single vs two containers, with/without a
-  `zoom:2` sibling, direct `scrollHeight` vs `scrollIntoView` vs the exact loop-both-targets script,
-  ± `FireWindowLoadEvent` + `ResolveAnimationSnapshots`, ± a style-invalidation batch) via plain
-  `Attach` + `ctx.Eval` is **`present=True` in every case**. Only the full `ExecuteScriptsWithDom`
-  path (which injects `BrowserApiStubs`/testharness stubs and runs scripts through a microtask-draining
-  execution mechanism + a temp-file round-trip) produces `present=False`.
+- The queried `.container` is `inDoc=True` (present in the live DocumentElement tree) and the render-doc
+  DOM is **structurally perfect**, yet the element has **no box** in the layout tree — its block children
+  are promoted to become direct block children of `<body>`. So it is a pure layout-engine bug, not a
+  bridge / render-doc-transform / snapshot-identity gap.
+- **Minimal trigger (isolated by matrix):** a `display:inline-block` element that (1) contains ≥1
+  **block-level child** and (2) has **any sibling** in its parent — even a `display:none` one
+  (`<script>`, a hidden `<div>`; before *or* after). Then the inline-block's principal box is dropped.
+  NOT required: overflow, zoom, scroll, scrollIntoView, or the WPT harness (all irrelevant). NOT
+  triggered by: a lone inline-block (no sibling → correct), an inline-block with only text children, or a
+  plain `display:block` element.
+- **Root cause:** `LayoutBoxUtils.ContainsInlinesOnly` skips `display:none` children and treats the
+  inline-block as inline-compatible → routes the parent (`<body>`) onto the line-box path
+  (`CssBox.Layout.cs:1074` → `CreateLineBoxes`). The **block-inside-inline correction (CSS 2.1 §9.2.1.1)**
+  then splits the inline-block as though it were a bare inline box, hoisting its block children into the
+  parent and dropping the inline-block's own box. An inline-block establishes a BFC and must **not** be
+  split. **Fix region:** the §9.2.1.1 correction (referenced at `CssLayoutEngine.cs:1767-1769`,
+  `CssBox.cs:40-76`) must exclude atomic inlines (inline-block / -flex / -grid / -table, replaced
+  elements) from the split.
 
-So the estimator's entry-point fallback is exercised only by the WPT harness flow, not by real
-geometry queries. The `!HasAssociatedLayoutBox` guard safely mitigates (fall back to estimator), so
-the flip is regression-free. **To unblock the deletion, either (a) fix the specific
-`ExecuteScriptsWithDom` step that leaves the harness snapshot incomplete (remaining bisection: the
-stub injection / microtask-drain execution mechanism / file round-trip — `FireWindowLoadEvent`,
-`ResolveAnimationSnapshots`, and style batching are already excluded), or (b) treat the 4 zoom WPT
-cases as harness artifacts and keep the guard.** `LayoutGeometryCompletenessTests` (static, 18/18)
-guards the real-usage side. Gate any deletion on the full parity + WPT pixel + Acid corpus.
+Impact: `getBoundingClientRect` / `client*` / `offset*` / `scroll*` return nothing from the shared
+snapshot for such inline-blocks; the `!HasAssociatedLayoutBox` guard masks it by falling back to the
+estimator. **Deleting the estimator is therefore gated on FIXING this §9.2.1.1 layout bug** (hottest
+`Broiler.Layout` path — `Broiler.HTML` submodule — needs full WPT + Acid gating). `LayoutGeometry­
+CompletenessTests` does **not** catch it (its fixtures have no `display:none` sibling); add a
+`<script>`-sibling inline-block fixture as the regression guard. Gate any deletion on the full parity +
+WPT pixel + Acid corpus.
+
+> ~~Superseded (2026-07-10, earlier same day): the gap was believed DYNAMIC and a WPT-test-harness
+> artifact of `WptTestRunner.ExecuteScriptsWithDom` — "normal bridge usage does not miss." That was a
+> false negative: the variant matrix's fixtures had no `display:none` sibling, so they never hit the
+> §9.2.1.1 trigger.~~
 
 ---
 

--- a/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
+++ b/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
@@ -310,11 +310,17 @@ other two are gated on prerequisites that are not yet met (documented below).
   `CssExtractionPhaseZeroTests.Phase7_*` failures are **pre-existing at HEAD**
   (legacy `Broiler.HTML.CSS`/`CssData` environmental state), baselined as unrelated.
 
-- **BLOCKED — remove the v1 compatibility adapters** (`htmlbridge-public-surface/v2`):
+- **IN PROGRESS — remove the v1 compatibility adapters** (`htmlbridge-public-surface/v2`):
   `Broiler.HtmlBridge.Dom.DomElement`, `HtmlTreeBuilder`, the obsolete `CssRules`
-  tuple view, and the bridge-only `DomBridge.CalculateSpecificity`. Gated on
-  **declaring the v2 boundary** (Open Question #5, unanswered) **and** migrating
-  callers to canonical APIs first. `DomElement` alone is referenced by **58
+  tuple view, and the bridge-only `DomBridge.CalculateSpecificity`.
+  **Update (2026-07-10, session 95a4149e): the v2 boundary is DECLARED** (Open
+  Question #5 answered by the maintainer; see
+  `docs/architecture/htmlbridge-engine-boundaries.md`), and the two zero-caller shims
+  — `DomBridge.CssRules` and `DomBridge.CalculateSpecificity` — are **REMOVED**
+  (Milestone 1.1): the two `CssRules` test consumers were rerouted to the shared
+  `Broiler.CSS` parser and the phase-zero guards flipped to assert removal. The
+  `DomElement`/`HtmlTreeBuilder` facade removal (Milestones 1.2/1.3) still follows the
+  RF-BRIDGE-1b geometry unification. `DomElement` alone is referenced by **58
   non-submodule source files** (`grep -rlE '\bDomElement\b' --include=*.cs src/`)
   and is entangled with RF-BRIDGE-1b geometry keying (boxes
   key by bridge instances — see rf-bridge-1b §5a), so it cannot be ripped out
@@ -351,11 +357,15 @@ other two are gated on prerequisites that are not yet met (documented below).
   **Update (2026-07-10): the increment-6 CUTOVER is now landed** —
   `UseSharedGeometryExclusively` is flipped **on**, regression-free (guarded by
   `ShouldReturnExclusiveSharedZero`'s `!HasAssociatedLayoutBox` check; verified zero delta
-  on the full Cli 1680 + WPT 545 corpora). The estimator *body* is not yet deleted: its only
-  remaining consumer is a WPT test-harness snapshot artifact (real bridge usage produces a
-  complete snapshot), mitigated by the guard. See
+  on the full Cli 1680 + WPT 545 corpora). The estimator *body* is not yet deleted, and (**corrected
+  2026-07-10, session 95a4149e**) its remaining consumer is a **real `Broiler.Layout` bug, NOT a
+  WPT-harness artifact** as previously believed: a `display:inline-block` element containing a
+  block-level child, when it has any sibling (even a `display:none` `<script>`), has its principal box
+  dropped by the CSS 2.1 §9.2.1.1 block-inside-inline correction (the correction splits the inline-block
+  instead of leaving it atomic). That drops it from the shared snapshot; the `!HasAssociatedLayoutBox`
+  guard masks it via the estimator. Deleting the estimator is gated on fixing that engine bug. See
   [`htmlbridge-blocked-items-completion-roadmap.md`](htmlbridge-blocked-items-completion-roadmap.md)
-  Milestone 2.4 for the full flip/deletion analysis and the two paths to complete the deletion.
+  Milestone 2.4 for the full root-cause analysis and fix region.
 
   **Correction (2026-07-09): the previously-documented blocker was stale.** The
   renderer *does* now size `@position-try` elements correctly on the shared path —

--- a/src/Broiler.Cli.Tests/CssExtractionPhaseTwoTests.cs
+++ b/src/Broiler.Cli.Tests/CssExtractionPhaseTwoTests.cs
@@ -42,24 +42,25 @@ public sealed class CssExtractionPhaseTwoTests
             }
             """;
 
-        using var context = new JSContext();
-        var bridge = new DomBridge();
-        bridge.Attach(
-            context,
-            $"<!doctype html><html><head><style>{css}</style></head><body><div class=\"asset\"></div></body></html>",
-            "https://example.test/css-phase-two");
+        // Was a characterization test over the obsolete DomBridge.CssRules tuple
+        // view; rerouted to the shared Broiler.CSS parser (the single source of
+        // truth) when that seam was removed at htmlbridge-public-surface/v2. The
+        // shared parser must keep complex declaration values intact — a data-URI
+        // with commas, a string with a semicolon, a custom property with a colon,
+        // and a calc() inside an @media block.
+        var sheet = new Broiler.CSS.CssParser().ParseStyleSheet(css);
 
-        var assetRules = bridge.CssRules
-            .Where(static rule => rule.Selector == ".asset")
-            .ToArray();
+        var baseAsset = sheet.Rules.OfType<Broiler.CSS.CssStyleRule>()
+            .Single(static r => r.Selectors.Selectors.Any(static s => s.Text.Trim() == ".asset"));
+        Assert.Equal("url(data:image/png;base64,AAAA)", baseAsset.Declarations.GetPropertyValue("background-image"));
+        Assert.Equal("\"alpha;beta\"", baseAsset.Declarations.GetPropertyValue("content"));
+        Assert.Equal("alpha:beta", baseAsset.Declarations.GetPropertyValue("--Payload"));
 
-        Assert.Equal(2, assetRules.Length);
-        Assert.Equal(
-            "url(data:image/png;base64,AAAA)",
-            assetRules[0].Declarations["background-image"]);
-        Assert.Equal("\"alpha;beta\"", assetRules[0].Declarations["content"]);
-        Assert.Equal("alpha:beta", assetRules[0].Declarations["--Payload"]);
-        Assert.Equal("calc(10px + 5px)", assetRules[1].Declarations["width"]);
+        var mediaRule = sheet.Rules.OfType<Broiler.CSS.CssAtRule>()
+            .Single(static r => r.Name.Equals("media", System.StringComparison.OrdinalIgnoreCase));
+        var mediaAsset = mediaRule.Rules.OfType<Broiler.CSS.CssStyleRule>()
+            .Single(static r => r.Selectors.Selectors.Any(static s => s.Text.Trim() == ".asset"));
+        Assert.Equal("calc(10px + 5px)", mediaAsset.Declarations.GetPropertyValue("width"));
     }
 
     [Fact]

--- a/src/Broiler.Cli.Tests/HtmlBridgePromotionPhaseZeroTests.cs
+++ b/src/Broiler.Cli.Tests/HtmlBridgePromotionPhaseZeroTests.cs
@@ -43,35 +43,33 @@ public sealed class HtmlBridgePromotionPhaseZeroTests
     }
 
     [Fact]
-    public void CssRules_Compatibility_Tuple_View_Remains_An_Obsolete_Bridge_Seam()
+    public void CssRules_Compatibility_Tuple_View_Is_Removed_At_V2()
     {
-        // CssRules is the historical (selector, specificity, declarations) tuple
-        // projection. It is bridge-owned and obsolete-marked; canonical consumers
-        // use the shared Broiler.CSS stylesheet/style-engine APIs. It must remain
-        // discoverable so its removal at v2 is a deliberate change.
+        // htmlbridge-public-surface/v2 (Milestone 1.1): the obsolete CssRules tuple
+        // view had no production callers and is removed. Consumers use the shared
+        // Broiler.CSS parser (CssParser / CssStyleRule / CssDeclarationBlock)
+        // directly. This guard asserts the seam is gone so it cannot silently
+        // reappear.
         var cssRules = typeof(DomBridge).GetProperty(
-            nameof(DomBridge.CssRules),
+            "CssRules",
             BindingFlags.Public | BindingFlags.Instance);
 
-        Assert.NotNull(cssRules);
-        Assert.NotNull(cssRules!.GetCustomAttribute<ObsoleteAttribute>());
+        Assert.Null(cssRules);
     }
 
     [Fact]
-    public void CalculateSpecificity_Remains_A_Static_Delegation_Shim_Over_The_Css_Parser()
+    public void CalculateSpecificity_Static_Shim_Is_Removed_At_V2()
     {
-        // CalculateSpecificity is a static compatibility helper that delegates to
-        // Broiler.CSS.CssSelectorParser.CalculateSpecificity. It has no in-repo
-        // callers today; the public replacement is the CSS parser API. Freezing
-        // its shape prevents the bridge from re-growing a private specificity
-        // algorithm.
+        // htmlbridge-public-surface/v2 (Milestone 1.1): the bridge-only
+        // CalculateSpecificity static delegation shim had no production callers and
+        // is removed. The public replacement is
+        // Broiler.CSS.CssSelectorParser.CalculateSpecificity, which stays. This
+        // guard asserts the bridge shim is gone.
         var calculate = typeof(DomBridge).GetMethod(
-            nameof(DomBridge.CalculateSpecificity),
+            "CalculateSpecificity",
             BindingFlags.Public | BindingFlags.Static);
 
-        Assert.NotNull(calculate);
-        Assert.Equal(typeof(int), calculate!.ReturnType);
-        Assert.Equal([typeof(string)], calculate.GetParameters().Select(static p => p.ParameterType));
+        Assert.Null(calculate);
     }
 
     [Fact]

--- a/src/Broiler.Cli.Tests/LayoutGeometryCompletenessTests.cs
+++ b/src/Broiler.Cli.Tests/LayoutGeometryCompletenessTests.cs
@@ -68,6 +68,13 @@ public sealed class LayoutGeometryCompletenessTests
             "  <div id='target' class='container'>\n    <div class='buffer'></div>\n    <div class='buffer'></div>\n  </div>\n" +
             "  <div style='display:inline-block'>\n    <div class='container' style='zoom:2'>\n      <div class='buffer'></div>\n      <div class='buffer'></div>\n    </div>\n  </div>\n</body></html>" },
         new object[] { "inline-block-nested-in-block", 800, 600, Wrap("<div><div id='target' style='display:inline-block;overflow:hidden;width:100px;height:50px'>x</div></div>") },
+        // RF-BRIDGE-1b §9.2.1.1 regression (session 95a4149e): an inline-block containing a BLOCK
+        // child, when it has a display:none sibling (a <script>, or any hidden element), had its
+        // principal box dropped — ContainsInlinesOnlyDeep did not skip display:none children, so the
+        // block-inside-inline correction fired on <body> and mis-split the inline-block. The estimator
+        // fallback masked it; this fixture guards the layout fix directly.
+        new object[] { "inline-block-blockchild-with-script-sibling", 800, 600, Wrap("<div id='target' style='display:inline-block'><div style='height:50px'></div></div><script></script>") },
+        new object[] { "inline-block-blockchild-with-hidden-sibling", 800, 600, Wrap("<div id='target' style='display:inline-block'><div style='height:50px'></div></div><div style='display:none'></div>") },
         new object[] { "flex-item", 800, 600, Wrap("<div style='display:flex'><div id='target' style='width:50px;height:20px'>x</div></div>") },
         new object[] { "grid-item-fixed", 800, 600, Wrap("<div style='display:grid;grid-template-columns:100px'><div id='target'>x</div></div>") },
         new object[] { "grid-item-content-sized", 800, 600, Wrap("<div style='display:grid'><div id='target'>content</div></div>") },

--- a/src/Broiler.Cli.Tests/SelectorsLevel4SpecificityTests.cs
+++ b/src/Broiler.Cli.Tests/SelectorsLevel4SpecificityTests.cs
@@ -105,22 +105,16 @@ document.getElementById('result').textContent =
     }
 
     [Fact]
-    public void DomBridge_CssRules_DoNotSplit_Commas_Inside_Is()
+    public void CssParser_DoesNotSplit_Commas_Inside_Is()
     {
-        const string html = """
-<!DOCTYPE html>
-<html><head>
-<style>
-:is(.alpha, .beta) { color: red; }
-</style>
-</head><body><div class="alpha"></div></body></html>
-""";
+        // Was a characterization test over the obsolete DomBridge.CssRules tuple
+        // view; rerouted to the shared Broiler.CSS parser (the single source of
+        // truth) when that seam was removed at htmlbridge-public-surface/v2. The
+        // comma inside :is(...) must not split the rule into two selectors.
+        var sheet = new Broiler.CSS.CssParser().ParseStyleSheet(":is(.alpha, .beta) { color: red; }");
 
-        using var context = new JSContext();
-        var bridge = new DomBridge();
-        bridge.Attach(context, html, "file:///test.html");
-
-        var rule = Assert.Single(bridge.CssRules);
-        Assert.Equal(":is(.alpha, .beta)", rule.Selector);
+        var styleRule = Assert.IsType<Broiler.CSS.CssStyleRule>(Assert.Single(sheet.Rules));
+        var selector = Assert.Single(styleRule.Selectors.Selectors);
+        Assert.Equal(":is(.alpha, .beta)", selector.Text.Trim());
     }
 }

--- a/src/Broiler.Cli.Tests/SharedLayoutGeometryProviderTests.cs
+++ b/src/Broiler.Cli.Tests/SharedLayoutGeometryProviderTests.cs
@@ -11,6 +11,7 @@ namespace Broiler.Cli.Tests;
 /// provider in isolation; the live <c>LayoutMetrics</c> routing (behind
 /// <c>UseSharedLayoutGeometry</c>) lands in increment ③.
 /// </summary>
+[Xunit.Collection("SharedGeometryStatics")]
 public sealed class SharedLayoutGeometryProviderTests
 {
     [Fact]

--- a/src/Broiler.Cli.Tests/SharedLayoutGeometryTests.cs
+++ b/src/Broiler.Cli.Tests/SharedLayoutGeometryTests.cs
@@ -15,6 +15,7 @@ namespace Broiler.Cli.Tests;
 /// tree. These tests pin the box-model arithmetic the bridge will later consume in
 /// place of its coarse estimators.
 /// </summary>
+[Xunit.Collection("SharedGeometryStatics")]
 public sealed class SharedLayoutGeometryTests
 {
     private static IReadOnlyDictionary<DomElement, BoxGeometry> LayoutGeometry(

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -40,73 +40,12 @@ public sealed partial class DomBridge
     // ------------------------------------------------------------------
 
 
-    /// <summary>
-    /// Compatibility view of the main document's shared stylesheet model as the
-    /// historical (selector, specificity, declarations) tuples.
-    /// </summary>
-    /// <remarks>
-    /// New bridge code must consume <see cref="Broiler.CSS.Dom.CssStyleEngine"/>.
-    /// This projection remains for the frozen public surface and characterization
-    /// tests during the one-release Phase 7 compatibility window; it is not a
-    /// cascade store or an input to rendering, invalidation, or anchor layout.
-    /// </remarks>
-    [Obsolete("Use the shared Broiler.CSS stylesheet/style-engine APIs. This compatibility view will be removed after the Phase 7 transition window.")]
-    public IReadOnlyList<(string Selector, int Specificity, Dictionary<string, string> Declarations)> CssRules =>
-        BuildLegacyCssRuleView(DocumentElement);
-
-    private IReadOnlyList<(string Selector, int Specificity, Dictionary<string, string> Declarations)> BuildLegacyCssRuleView(
-        DomElement scope)
-    {
-        var result = new List<(string Selector, int Specificity, Dictionary<string, string> Declarations)>();
-        var styleElements = new List<DomElement>();
-        CollectStyleElementsInTree(GetDocumentRootFor(scope), styleElements);
-        foreach (var styleEl in styleElements)
-        {
-            var sheet = new Broiler.CSS.CssParser().ParseStyleSheet(GetStyleElementCssText(styleEl));
-            MaterializeLegacyCssRules(sheet.Rules, result);
-        }
-
-        result.Sort((x, y) => x.Specificity.CompareTo(y.Specificity));
-        return result;
-    }
-
-    private void MaterializeLegacyCssRules(
-        IReadOnlyList<Broiler.CSS.CssRule> rules,
-        List<(string Selector, int Specificity, Dictionary<string, string> Declarations)> target)
-    {
-        foreach (var rule in rules)
-        {
-            if (rule is Broiler.CSS.CssStyleRule styleRule)
-            {
-                var declarations = ParseStyle(CSS.CssSerializer.Serialize(styleRule.Declarations));
-                foreach (var selector in styleRule.Selectors.Selectors)
-                {
-                    if (!string.IsNullOrWhiteSpace(selector.Text))
-                        target.Add((selector.Text.Trim(), selector.Specificity.Encoded, declarations));
-                }
-
-                continue;
-            }
-
-            if (rule is Broiler.CSS.CssAtRule atRule &&
-                atRule.Name.Equals("media", StringComparison.OrdinalIgnoreCase) &&
-                EvaluateMediaQuery(atRule.Prelude, _viewportWidth, _viewportHeight))
-            {
-                MaterializeLegacyCssRules(atRule.Rules, target);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Calculates CSS specificity for a selector, including Selectors L4
-    /// pseudo-class functions such as <c>:is()</c>, <c>:where()</c>,
-    /// <c>:has()</c>, and <c>:nth-child(... of ...)</c>.
-    /// Returns a sortable integer encoding of (a, b, c) where a = ID selectors,
-    /// b = class / attribute / pseudo-class selectors, and c = type selectors /
-    /// pseudo-elements. Inline styles are handled separately.
-    /// </summary>
-    public static int CalculateSpecificity(string selector) =>
-        CSS.CssSelectorParser.CalculateSpecificity(selector).Encoded;
+    // htmlbridge-public-surface/v2 (declared 2026-07-10): the compatibility
+    // `CssRules` tuple view and the `CalculateSpecificity` static delegation shim
+    // were removed here (Milestone 1.1). They had no production callers; consumers
+    // use the shared Broiler.CSS parser (`CssParser` / `CssStyleRule` /
+    // `CssDeclarationBlock.GetPropertyValue`) and `CssSelectorParser.CalculateSpecificity`
+    // directly. See docs/architecture/htmlbridge-engine-boundaries.md.
 
     /// <summary>
     /// Clears any CSS-derived compatibility values left in <see cref="DomElement.Style"/>


### PR DESCRIPTION
## Summary

Verified the HtmlBridge blocked-items roadmap and found its headline was wrong, then fixed the real blocker and advanced Track 1.

### 1. The estimator-deletion blocker is a real `Broiler.Layout` bug — now fixed
The roadmap claimed the RF-BRIDGE-1b increment-6 estimator-deletion blocker was a WPT-harness snapshot artifact ("normal usage never misses"). Reproduced via plain `Attach`+`Eval` (no harness) and reduced to a minimal trigger: a `display:inline-block` element with a **block-level child** and **any sibling** (even a `display:none` `<script>`) has its principal box dropped — the CSS 2.1 §9.2.1.1 block-inside-inline correction's fold loop mis-selects the inline-block as the "block to split around" and dissolves it, hoisting its block children into the parent.

**Fix** (`Broiler.HTML` submodule, `DomParser.cs`, 6 lines): fold atomic inlines (`inline-block`/`-flex`/`-grid`) into the correction's leading run — they are inline-level content establishing their own BFC and must not be split. The existing "everything-folded → restore → bail" path then makes the correction a no-op for the bug cases.

Impact: `getBoundingClientRect`/`client*`/`offset*`/`scroll*` returned nothing from the shared snapshot for such inline-blocks (masked by the estimator fallback). This unblocks the increment-6 estimator deletion.

### 2. Test-flakiness fix
`SharedLayoutGeometryTests` + `SharedLayoutGeometryProviderTests` were missing from the no-parallel `SharedGeometryStatics` collection → spurious `ContentBox.Width = -30` under the default parallel run. Added them.

### 3. Track 1 — declare `htmlbridge-public-surface/v2` + remove the two zero-caller shims
Maintainer declared v2. Removed `DomBridge.CssRules` and `DomBridge.CalculateSpecificity` (no production callers), rerouted the two `CssRules` test consumers to the shared `Broiler.CSS` parser, and flipped the phase-zero guards to assert removal. The `DomElement`/`HtmlTreeBuilder` facade removal (1.2/1.3) still follows the geometry unification.

## Validation (regression-free, diffed by test name)
- `LayoutGeometryCompletenessTests` 19/19 (incl. 2 new fixtures pinning the bug) · `Broiler.Layout.Tests` 40/40
- Full `Broiler.Wpt.Tests`: 136 fails = **exact baseline**, 0 new, 0 collateral
- Full `Broiler.Cli.Tests`: 76 unique fails = **exact baseline**, 0 new

## Submodule
The `Broiler.HTML` change is pushed to `claude/rf-bridge-1b-inline-block-9211-fix` on the submodule remote; the pointer is bumped here. It should be merged on the submodule repo separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)