### PR TITLE
RF-BRIDGE-1b 2.5: retire LayoutRuntimeState (Item 2 complete)

### DIFF
--- a/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
+++ b/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
@@ -68,20 +68,18 @@ Track 2 (geometry)                         Track 1 (public surface)
 
 ## Track 2 — RF-BRIDGE-1b geometry unification
 
-Current state (updated 2026-07-10): `UseSharedLayoutGeometry = true` and
-**`UseSharedGeometryExclusively = true` (increment-6 cutover flipped ON,
-regression-free)**. Exclusive-shared is now the default: geometry entry points answer
-from the shared snapshot, and a *genuinely* boxless element (display:none/contents,
-text/comment) reports zero; a box-generating element merely absent from the current
-snapshot still falls back to the estimator via `ShouldReturnExclusiveSharedZero`'s
-`!HasAssociatedLayoutBox` guard (added 2026-07-10 — this is what makes the flip
-regression-free; see Milestone 2.4 Task 1). Verified zero delta on the full
-`Broiler.Cli.Tests` (1680) and `Broiler.Wpt.Tests` (545) corpora, gate families 20/20,
-`Broiler.Layout.Tests` 40/40. The estimator body (`LayoutMetrics.cs`, ~2952 LOC) is
-therefore **not yet deleted** — it stays load-bearing as the shared-unavailable fallback
-(see the DELETION analysis under Milestone 2.4: the only remaining snapshot gap is a WPT
-test-harness artifact, not real bridge usage). `LayoutRuntimeState` still stores resolved
-position-area geometry (Milestone 2.5, opens after the deletion).
+Current state (updated 2026-07-10): **Track 2 / Item 2 is COMPLETE.** `UseSharedLayoutGeometry = true`,
+`UseSharedGeometryExclusively = true`, the ~2950-LOC recursive estimator body is **deleted** (Milestone 2.4,
+PR #1354 — gated on and unblocked by the §9.2.1.1 inline-block layout fix, PR #1353), and
+**`LayoutRuntimeState` is retired** (Milestone 2.5 — the resolved position-area memo relocated to the
+bridge-level `PositionAreaResolutions` CWT). Geometry entry points answer from the shared snapshot; a
+*genuinely* boxless element (display:none/contents, text/comment) reports zero, and the residual estimator
+survives only as a shared-*unavailable* fallback for cross-origin / non-materialised frames. All three
+renderer prerequisites (Track 3: 3.1 abspos-in-inline-CB, 3.2 cross-frame/sub-viewport geometry, 3.3
+fixed-target scrollIntoView) landed regression-free. Verified across the full `Broiler.Cli.Tests`,
+`Broiler.Wpt.Tests`, `Broiler.Layout.Tests`, and the parity gate. **The two-box-model duplication that
+RF-BRIDGE-1b existed to remove is gone.** Nothing in Track 2 remains open; the next roadmap work is Track 1
+(DomElement facade removal, Milestones 1.2/1.3), now unblocked.
 
 ### Milestone 2.1 — Zoom-correct shared snapshot (the gating prerequisite)
 
@@ -458,23 +456,39 @@ the element's own, which mis-scales a self-zoomed target). Validated regression-
 
 **Depends on:** 2.3 (position-area resolution no longer stores into it).
 
-**Status (2026-07-10): ATTEMPTED + REVERTED — needs a re-entrancy-safe cache replacement.** `.Layout` is
-a per-element memo of the resolved position-area rect AND a re-entrancy guard: `ResolvePositionAreaForElement`
-is reachable from the geometry entry points, so removing the cache and re-resolving on-the-fly (rebuilding
-the anchor registry per call) recurses / corrupts shared state — it broke ~200 WPT tests (host abort) and
-was reverted. Retiring the type requires a re-entrancy-safe replacement first: a pass-scoped bridge-level
-`Dictionary<DomElement,rect>` (keyed off the `WithLayoutGeometryCache` pass), or sourcing position-area
-geometry from the shared snapshot in the entry points (the resolver already reflects the result into inline
-`left/top/width/height`). A focused follow-up.
+**Status (2026-07-10): DONE — `LayoutRuntimeState` deleted; RF-BRIDGE-1b "definition of done" met.**
+The earlier attempt failed because it *removed* the cache and re-resolved on-the-fly per call — rebuilding
+the anchor registry inside a geometry query re-enters `ResolvePositionAreaForElement` and corrupts shared
+state (~200 WPT host aborts). The re-entrancy safety comes from the memo *existing*, not from where it
+lives, so the fix keeps the memo and merely **relocates** it out of the typed runtime-state object: the four
+`.Layout` `RuntimeValue<double>` slots are replaced by a bridge-level
+`ConditionalWeakTable<DomElement, PositionAreaResolution>` (`PositionAreaResolutions`, in
+`PositionAreaQueries.cs`) with helpers `TryGetPositionAreaResolution` / `SetPositionAreaResolution` /
+`ClearPositionAreaResolution` / `CopyPositionAreaResolution`. This is a *pure storage relocation* — same
+static-CWT lifetime as `ElementRuntimeStates` (a detached element's memo is collected with it), same
+read/write/invalidate/clone semantics — so it is behaviour-identical by construction rather than by
+recomputation. (The doc's pass-scoped `Dictionary` and shared-snapshot options were both rejected: the
+main-pass write stores adjusted `borderBoxW`/`borderBoxH` that the on-the-fly `ComputePositionAreaRect`
+does not reproduce, so recompute-per-pass would diverge.) All five call sites migrated: the two writers
+(`PositionArea.cs`, `PositionAreaQueries.cs`), the invalidation (`Utilities.cs`, on
+`position-area`/`position-anchor` mutation), the clone-copy (`CloneDomElement`), and the internal
+`DomBridge.TryGetResolvedLayout` reader (the WPT harness's `TryGetResolvedLayout` consumer). Verified
+regression-free: a HEAD stash-comparison shows the WPT anchor/position-area cluster **identical** (37 pass /
+same 5 pre-existing fails `PositionAreaAnchorPartiallyOutside`, `PositionAreaScrolling00{2,3}`,
+`PositionVisibilityRemoveAnchorsVisible`, `PositionTryGrid001`), Cli offset/position 5/5, parity + clone +
+anchor + sticky 45/45, and the **full `Broiler.Cli.Tests` (1699, slot crasher excluded) shows ZERO new
+failures by name** vs the flag-on baseline (81 fails, all pre-existing environmental/known — PDF/Skia/font/
+network/grid; the 5-name delta is documented parallel-run flakiness). `LayoutRuntimeState` no longer exists.
 
-**Tasks.** Remove the `.Layout` slots and the `LayoutRuntimeState` type; confirm
-no reader remains (`PositionAreaQueries.cs`, any offset-property path).
+**Tasks — DONE.** Removed the `.Layout` slots and the `LayoutRuntimeState` type; confirmed
+no reader remains (`PositionAreaQueries.cs`, `DomBridge.TryGetResolvedLayout`, any offset-property path).
 
 **Verification.** Full anchor/position-area suite; `DomBridge` builds without the
 type.
 
-**Exit criteria.** `LayoutRuntimeState` deleted; RF-BRIDGE-1b "definition of
-done" met — the two-box-model duplication is gone.
+**Exit criteria — MET (2026-07-10).** `LayoutRuntimeState` deleted; RF-BRIDGE-1b "definition of
+done" met — the recursive-estimator box model (2.4) and its resolved-geometry runtime store (2.5) are
+both gone. **Track 2 / Item 2 complete.**
 
 ---
 

--- a/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
+++ b/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
@@ -351,21 +351,24 @@ other two are gated on prerequisites that are not yet met (documented below).
     declared; only the two test callers of `CssRules` need routing to the shared
     `Broiler.CSS` stylesheet API.
 
-- **PARTIALLY DONE — finish RF-BRIDGE-1b geometry unification** (delete the ~2950-LOC
-  `LayoutMetrics` estimators, increment 6, and retire `LayoutRuntimeState`,
-  increment 7). The `UseSharedLayoutGeometry` flag is **on** (increment 5 landed).
-  **Update (2026-07-10): the increment-6 CUTOVER is now landed** —
-  `UseSharedGeometryExclusively` is flipped **on**, regression-free (guarded by
-  `ShouldReturnExclusiveSharedZero`'s `!HasAssociatedLayoutBox` check; verified zero delta
-  on the full Cli 1680 + WPT 545 corpora). The estimator *body* is not yet deleted, and (**corrected
-  2026-07-10, session 95a4149e**) its remaining consumer is a **real `Broiler.Layout` bug, NOT a
-  WPT-harness artifact** as previously believed: a `display:inline-block` element containing a
-  block-level child, when it has any sibling (even a `display:none` `<script>`), has its principal box
-  dropped by the CSS 2.1 §9.2.1.1 block-inside-inline correction (the correction splits the inline-block
-  instead of leaving it atomic). That drops it from the shared snapshot; the `!HasAssociatedLayoutBox`
-  guard masks it via the estimator. Deleting the estimator is gated on fixing that engine bug. See
+- **DONE — RF-BRIDGE-1b geometry unification (Item 2) is COMPLETE.** All of increments 5–7 have landed:
+  `UseSharedLayoutGeometry` on (5), `UseSharedGeometryExclusively` on and the ~2950-LOC `LayoutMetrics`
+  recursive estimator body **deleted** (increment 6, PR #1354), and `LayoutRuntimeState` **retired**
+  (increment 7). The increment-6 deletion was gated on a real `Broiler.Layout` bug — a
+  `display:inline-block` containing a block-level child with any sibling (even a `display:none` `<script>`)
+  had its principal box dropped by the CSS 2.1 §9.2.1.1 block-inside-inline correction splitting the
+  inline-block instead of keeping it atomic — which was **fixed** in the `Broiler.HTML` submodule (PR #1353,
+  the atomic-inline fold in `DomParser.cs`) and, with the box then present in the snapshot, let the
+  estimator be removed. Increment 7 retired `LayoutRuntimeState` by relocating its resolved-position-area
+  memo to the bridge-level `PositionAreaResolutions` `ConditionalWeakTable` (a pure, behaviour-identical
+  storage relocation — the previous "remove the cache and recompute" attempt recursed and was reverted).
+  Both changes verified regression-free against full-corpus HEAD baselines (zero new failures by name). The
+  three renderer prerequisites (Track 3: abspos-in-inline-CB placement, cross-frame/sub-viewport geometry,
+  fixed-target scrollIntoView) all landed. The two-box-model duplication is gone; the only residual
+  estimator caller is the shared-*unavailable* fallback (cross-origin / non-materialised frames). See
   [`htmlbridge-blocked-items-completion-roadmap.md`](htmlbridge-blocked-items-completion-roadmap.md)
-  Milestone 2.4 for the full root-cause analysis and fix region.
+  Track 2 for the full history. **This unblocks the `DomElement`/`HtmlTreeBuilder` facade removal
+  (Milestones 1.2/1.3), the remaining Item 1 work.**
 
   **Correction (2026-07-09): the previously-documented blocker was stale.** The
   renderer *does* now size `@position-try` elements correctly on the shared path —

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -212,24 +212,18 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         out double width,
         out double height)
     {
-        var layout = GetElementRuntimeState(element).Layout;
-        var hasLeft = TryRead(layout.Left, out left);
-        var hasTop = TryRead(layout.Top, out top);
-        var hasWidth = TryRead(layout.Width, out width);
-        var hasHeight = TryRead(layout.Height, out height);
-        return hasLeft && hasTop && hasWidth && hasHeight;
-
-        static bool TryRead(RuntimeValue<double> slot, out double result)
+        // RF-BRIDGE-1b (Milestone 2.5): reads the memoized position-area resolution,
+        // relocated from ElementRuntimeState.Layout to the bridge-level
+        // PositionAreaResolutions cache. The four values are always set (and cleared)
+        // together, so a cached entry is equivalent to the old "all four slots present".
+        if (TryGetPositionAreaResolution(element, out var rect))
         {
-            if (slot.TryGet(out var value) && value is double number)
-            {
-                result = number;
-                return true;
-            }
-
-            result = 0;
-            return false;
+            (left, top, width, height) = rect;
+            return true;
         }
+
+        (left, top, width, height) = (0, 0, 0, 0);
+        return false;
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
@@ -380,10 +380,7 @@ public sealed partial class DomBridge
 
                     // Store resolved offsets for JS offset property queries.
                     // Use border-box dimensions (matching offsetWidth/offsetHeight).
-                    GetElementRuntimeState(element).Layout.Left.Set(finalLeft);
-                    GetElementRuntimeState(element).Layout.Top.Set(finalTop);
-                    GetElementRuntimeState(element).Layout.Width.Set(borderBoxW);
-                    GetElementRuntimeState(element).Layout.Height.Set(borderBoxH);
+                    SetPositionAreaResolution(element, finalLeft, finalTop, borderBoxW, borderBoxH);
                 }
             }
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionAreaQueries.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionAreaQueries.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace Broiler.HtmlBridge;
 
 public sealed partial class DomBridge
@@ -5,6 +7,65 @@ public sealed partial class DomBridge
     // -----------------------------------------------------------------
     // position-area resolution for JS offset queries
     // -----------------------------------------------------------------
+
+    // RF-BRIDGE-1b (Milestone 2.5): the resolved position-area rect is memoized here
+    // instead of in the retired ElementRuntimeState.Layout (LayoutRuntimeState). It is
+    // both a perf cache — avoids rebuilding the anchor registry on every offset query —
+    // and a re-entrancy guard: ResolvePositionAreaForElement is reachable from the
+    // geometry entry points, so an already-resolved element short-circuits here before
+    // re-entering resolution (rebuilding the registry per call recurses / corrupts shared
+    // state — the failure mode that reverted the naive cache removal). A static CWT keyed
+    // by element identity mirrors ElementRuntimeStates' lifetime, so a detached element's
+    // memo is collected with it, and the invalidation (position-area / position-anchor
+    // mutation) and clone-copy semantics are unchanged from the old .Layout slots.
+    private static readonly ConditionalWeakTable<DomElement, PositionAreaResolution>
+        PositionAreaResolutions = [];
+
+    private sealed class PositionAreaResolution
+    {
+        public double Left;
+        public double Top;
+        public double Width;
+        public double Height;
+    }
+
+    private static bool TryGetPositionAreaResolution(
+        DomElement element, out (double left, double top, double width, double height) rect)
+    {
+        if (PositionAreaResolutions.TryGetValue(element, out var r))
+        {
+            rect = (r.Left, r.Top, r.Width, r.Height);
+            return true;
+        }
+
+        rect = default;
+        return false;
+    }
+
+    private static void SetPositionAreaResolution(
+        DomElement element, double left, double top, double width, double height) =>
+        PositionAreaResolutions.AddOrUpdate(element, new PositionAreaResolution
+        {
+            Left = left,
+            Top = top,
+            Width = width,
+            Height = height,
+        });
+
+    private static void ClearPositionAreaResolution(DomElement element) =>
+        PositionAreaResolutions.Remove(element);
+
+    private static void CopyPositionAreaResolution(DomElement source, DomElement target)
+    {
+        if (PositionAreaResolutions.TryGetValue(source, out var r))
+            PositionAreaResolutions.AddOrUpdate(target, new PositionAreaResolution
+            {
+                Left = r.Left,
+                Top = r.Top,
+                Width = r.Width,
+                Height = r.Height,
+            });
+    }
 
     /// <summary>
     /// Resolves position-area for a specific element during JS execution,
@@ -15,11 +76,8 @@ public sealed partial class DomBridge
         ResolvePositionAreaForElement(DomElement element)
     {
         // Check for pre-resolved values first.
-        if (GetElementRuntimeState(element).Layout.Left.TryGet(out var rl) && rl is double resolvedLeft &&
-            GetElementRuntimeState(element).Layout.Top.TryGet(out var rt) && rt is double resolvedTop &&
-            GetElementRuntimeState(element).Layout.Width.TryGet(out var rw) && rw is double resolvedWidth &&
-            GetElementRuntimeState(element).Layout.Height.TryGet(out var rh) && rh is double resolvedHeight)
-            return (resolvedLeft, resolvedTop, resolvedWidth, resolvedHeight);
+        if (TryGetPositionAreaResolution(element, out var cached))
+            return cached;
 
         // Resolve on-the-fly from CSS properties and inline styles.
         var cssProps = CollectMatchedRuleProperties(element);
@@ -46,10 +104,7 @@ public sealed partial class DomBridge
         if (rect == null) return null;
 
         // Cache the resolved values.
-        GetElementRuntimeState(element).Layout.Left.Set(rect.Value.Left);
-        GetElementRuntimeState(element).Layout.Top.Set(rect.Value.Top);
-        GetElementRuntimeState(element).Layout.Width.Set(rect.Value.Width);
-        GetElementRuntimeState(element).Layout.Height.Set(rect.Value.Height);
+        SetPositionAreaResolution(element, rect.Value.Left, rect.Value.Top, rect.Value.Width, rect.Value.Height);
 
         return (rect.Value.Left, rect.Value.Top, rect.Value.Width, rect.Value.Height);
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
@@ -24,8 +24,6 @@ internal sealed class ElementRuntimeState
 
     public ScrollRuntimeState Scroll { get; } = new();
 
-    public LayoutRuntimeState Layout { get; } = new();
-
     public DialogRuntimeState Dialog { get; } = new();
 
     public ShadowRuntimeState Shadow { get; } = new();
@@ -47,10 +45,6 @@ internal sealed class ElementRuntimeState
         FormControl.ReturnValue.CopyTo(target.FormControl.ReturnValue);
         Scroll.Left.CopyTo(target.Scroll.Left);
         Scroll.Top.CopyTo(target.Scroll.Top);
-        Layout.Left.CopyTo(target.Layout.Left);
-        Layout.Top.CopyTo(target.Layout.Top);
-        Layout.Width.CopyTo(target.Layout.Width);
-        Layout.Height.CopyTo(target.Layout.Height);
         Dialog.Modal.CopyTo(target.Dialog.Modal);
         Dialog.TopLayerOrder.CopyTo(target.Dialog.TopLayerOrder);
         Dialog.PopoverOpen.CopyTo(target.Dialog.PopoverOpen);
@@ -83,14 +77,6 @@ internal sealed class ScrollRuntimeState
 {
     public RuntimeValue<double> Left { get; } = new();
     public RuntimeValue<double> Top { get; } = new();
-}
-
-internal sealed class LayoutRuntimeState
-{
-    public RuntimeValue<double> Left { get; } = new();
-    public RuntimeValue<double> Top { get; } = new();
-    public RuntimeValue<double> Width { get; } = new();
-    public RuntimeValue<double> Height { get; } = new();
 }
 
 internal sealed class DialogRuntimeState

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -405,6 +405,9 @@ public sealed partial class DomBridge
             clone.NsAttrMap[kv.Key] = kv.Value;
         // Copy browser-runtime values (e.g., checked state for inputs).
         GetElementRuntimeState(source).CopyRuntimeValuesTo(GetElementRuntimeState(clone));
+        // Carry the memoized position-area resolution too (was ElementRuntimeState.Layout,
+        // now the bridge-level PositionAreaResolutions cache — see PositionAreaQueries.cs).
+        CopyPositionAreaResolution(source, clone);
 
         if (deep)
         {
@@ -708,12 +711,7 @@ public sealed partial class DomBridge
                 // Invalidate cached position-area resolution when relevant
                 // properties change so offset queries recompute.
                 if (kebab is "position-area" or "position-anchor")
-                {
-                    GetElementRuntimeState(_element).Layout.Left.Remove();
-                    GetElementRuntimeState(_element).Layout.Top.Remove();
-                    GetElementRuntimeState(_element).Layout.Width.Remove();
-                    GetElementRuntimeState(_element).Layout.Height.Remove();
-                }
+                    ClearPositionAreaResolution(_element);
 
                 _onMutation?.Invoke();
             }


### PR DESCRIPTION
## What

Deletes the `LayoutRuntimeState` type — the four `.Layout` `RuntimeValue<double>` slots on `ElementRuntimeState` that memoized the resolved `position-area` rect. This is the last remnant of the RF-BRIDGE-1b bridge-side box model, now that the recursive geometry estimators are gone (Milestone 2.4, #1354). **Completes Track 2 / Item 2** of the promotion roadmap — the two-box-model duplication is fully removed.

## Why the previous attempt failed, and how this differs

The earlier 2.5 attempt *removed* the memo and re-resolved `position-area` on-the-fly per call. Because `ResolvePositionAreaForElement` is reachable from the geometry entry points, rebuilding the anchor registry inside a geometry query re-entered resolution and corrupted shared state (~200 WPT host aborts) — and was reverted.

The insight: **re-entrancy safety comes from the memo *existing*, not from where it lives.** So this change keeps the memo and merely **relocates** it out of the typed runtime-state object into a bridge-level `ConditionalWeakTable<DomElement, PositionAreaResolution>` (`PositionAreaResolutions`) with `Try/Set/Clear/Copy` helpers. Same static-CWT lifetime as `ElementRuntimeStates`, identical read/write/invalidate/clone semantics → **behaviour-identical by construction**, not by recomputation. (The roadmap's pass-scoped `Dictionary` and shared-snapshot options were rejected: the main-pass writer stores adjusted `borderBoxW/H` that the on-the-fly `ComputePositionAreaRect` does not reproduce, so recompute-per-pass would diverge.)

## Call sites migrated

- writers: `PositionArea.cs`, `PositionAreaQueries.cs`
- invalidation on `position-area`/`position-anchor` mutation: `Utilities.cs`
- clone-copy: `CloneDomElement` (`Utilities.cs`)
- internal reader: `DomBridge.TryGetResolvedLayout`
- type deleted: `ElementRuntimeState.cs`

## Verification (regression-free, HEAD stash comparison)

- WPT anchor/position-area cluster: **identical** to baseline — 37 pass / same 5 pre-existing fails (`PositionAreaAnchorPartiallyOutside`, `PositionAreaScrolling00{2,3}`, `PositionVisibilityRemoveAnchorsVisible`, `PositionTryGrid001`).
- Cli offset/position: 5/5 · parity + clone + anchor + sticky: 45/45.
- **Full `Broiler.Cli.Tests` (1699, slot-scroll crasher excluded): zero new failures by name** vs the flag-on baseline (81 pre-existing environmental fails; the 5-name delta is documented parallel-run flakiness).

Roadmap docs updated (blocked-items Milestone 2.5 → done; promotion roadmap Phase 5 Item 2 → complete). Next: Track 1 (DomElement/HtmlTreeBuilder facade removal, Milestones 1.2/1.3), now unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)