### PR TITLE
RF-BRIDGE-1b 1.2 slice 1: re-key per-element runtime-state caches off canonical identity

### DIFF
--- a/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
+++ b/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
@@ -830,18 +830,44 @@ selectors suites green.
 **Goal.** Reduce the ~58 non-submodule source references to `DomElement` to zero
 by moving callers onto canonical `Broiler.Dom.DomNode`/`DomElement`.
 
-**Depends on:** Track 2 (2.4/2.5) — the geometry caches must stop keying on the
-facade first. The remaining identity-keyed caches (runtime state, JS object
-identity, computed style) also re-key onto canonical nodes here.
+**Depends on:** Track 2 (2.4/2.5) — MET (both complete). The geometry caches no
+longer key on the facade (2.4 deleted them); the remaining identity-keyed caches
+(runtime state, JS object identity, computed style) re-key onto canonical nodes here.
+
+**Key structural finding (2026-07-10, from slice 1).** The facade
+`DomElement : Broiler.Dom.DomElement` — it *inherits from* the canonical element,
+so re-keying a cache is a **type-widening** (facade→canonical base) that preserves
+reference identity, not a lookup rewrite. But the facade is **not just an identity
+key**: it carries real per-element bridge state read pervasively — `Style` (everywhere),
+`IsTextNode` (**121** sites), `OwnerDocRoot` (32), `NsAttrMap` (19), `JsSetStyleProps`
+(11), `InnerHtml` (7), plus the `Children`/`Attributes` legacy views and `TextContent`.
+So a cache can be cleanly re-keyed **only if its key is used as a pure identity token**
+(no facade members read); caches whose *accessors* read facade state are gated on
+**relocating that state** (side tables keyed by canonical node, or onto canonical nodes),
+which is the bulk of the work and overlaps Task 2.
 
 **Tasks (staged; each independently verifiable).**
 
-1. Re-key `ElementRuntimeState`, `_jsObjectCache`, computed-style engines, and
-   computed-props caches from the facade to canonical node identity.
+1. Re-key the identity caches from the facade to canonical node identity.
+   - **Slice 1 — DONE (2026-07-10).** `ElementRuntimeStates` (all per-element runtime
+     state) and `PositionAreaResolutions` (the 2.5 position-area memo) re-keyed to
+     `Broiler.Dom.DomElement`; accessors `GetElementRuntimeState` /
+     `TryGet/Set/Clear/CopyPositionAreaResolution` widened. Both are pure-identity
+     `ConditionalWeakTable`s (no facade-member key access, no iteration), so the widening
+     is behaviour-preserving. Verified: bridge + Cli + Wpt build clean; focused
+     Anchor/Sticky/Clone/Offset/MutationObserver 50/50; WPT anchor/position-area cluster
+     identical to baseline (37/42, same 5 pre-existing fails).
+   - **Deferred to later slices.** `_jsObjectCache` — iterated by `FindDomElementByJSObject`
+     (returns facade `DomElement?`) and the sub-document adoption loops, which read facade
+     members off the key; re-keying needs those consumers migrated first.
+     `_computedPropsCache` / `_computedStyleEngines` — their accessors (`GetComputedProps`,
+     computed-style) read facade `Style` off the element, so they are gated on relocating
+     the facade's per-element state (Task 2), not just the key type.
 2. Migrate the non-geometry caller clusters (serialization, attributes,
    traversal, event/callback plumbing) file-by-file.
 3. Keep a caller-count guard (`grep -rlE '\bDomElement\b' --include=*.cs src/`)
-   trending to zero; `log()`-equivalent progress in the PR series.
+   trending to zero (57 non-facade-defining files at slice-1 time); `log()`-equivalent
+   progress in the PR series.
 
 **Risk.** High — 58 files, broad surface; must stay behind green tests at every
 slice.

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -52,7 +52,13 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     private readonly List<WeakReference<Broiler.Dom.DomNodeIterator>> _activeNodeIterators = [];
     private readonly CanonicalDocument _document;
     private readonly DomElement _documentNode;
-    private static readonly ConditionalWeakTable<DomElement, ElementRuntimeState> ElementRuntimeStates = [];
+    // Milestone 1.2 (DomElement facade removal): keyed off canonical
+    // Broiler.Dom.DomElement identity, not the v1 facade type. The facade IS a
+    // canonical element (DomElement : Broiler.Dom.DomElement), so every current key
+    // is unchanged by reference; widening the key type decouples the per-element
+    // runtime-state layer from the facade ahead of its deletion. The key is used
+    // purely as an identity token here (no facade members read), so this is safe.
+    private static readonly ConditionalWeakTable<Broiler.Dom.DomElement, ElementRuntimeState> ElementRuntimeStates = [];
     private JSObject? _documentJSObject;
     private JSObject? _windowJSObject;
     private JSObject? _visualViewportJSObject;
@@ -178,7 +184,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
             .OfType<DomElement>()
             .Where(element => !ReferenceEquals(element, _documentNode))];
 
-    private static ElementRuntimeState GetElementRuntimeState(DomElement element) =>
+    private static ElementRuntimeState GetElementRuntimeState(Broiler.Dom.DomElement element) =>
         ElementRuntimeStates.GetValue(element, static _ => new ElementRuntimeState());
 
     private static Dictionary<string, List<EventListenerRegistration>> GetEventListeners(DomElement element) =>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionAreaQueries.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionAreaQueries.cs
@@ -18,7 +18,10 @@ public sealed partial class DomBridge
     // by element identity mirrors ElementRuntimeStates' lifetime, so a detached element's
     // memo is collected with it, and the invalidation (position-area / position-anchor
     // mutation) and clone-copy semantics are unchanged from the old .Layout slots.
-    private static readonly ConditionalWeakTable<DomElement, PositionAreaResolution>
+    // Milestone 1.2 (DomElement facade removal): keyed off canonical
+    // Broiler.Dom.DomElement identity, not the v1 facade type — the key is a pure
+    // identity token (no facade members read), matching ElementRuntimeStates.
+    private static readonly ConditionalWeakTable<Broiler.Dom.DomElement, PositionAreaResolution>
         PositionAreaResolutions = [];
 
     private sealed class PositionAreaResolution
@@ -30,7 +33,7 @@ public sealed partial class DomBridge
     }
 
     private static bool TryGetPositionAreaResolution(
-        DomElement element, out (double left, double top, double width, double height) rect)
+        Broiler.Dom.DomElement element, out (double left, double top, double width, double height) rect)
     {
         if (PositionAreaResolutions.TryGetValue(element, out var r))
         {
@@ -43,7 +46,7 @@ public sealed partial class DomBridge
     }
 
     private static void SetPositionAreaResolution(
-        DomElement element, double left, double top, double width, double height) =>
+        Broiler.Dom.DomElement element, double left, double top, double width, double height) =>
         PositionAreaResolutions.AddOrUpdate(element, new PositionAreaResolution
         {
             Left = left,
@@ -52,10 +55,10 @@ public sealed partial class DomBridge
             Height = height,
         });
 
-    private static void ClearPositionAreaResolution(DomElement element) =>
+    private static void ClearPositionAreaResolution(Broiler.Dom.DomElement element) =>
         PositionAreaResolutions.Remove(element);
 
-    private static void CopyPositionAreaResolution(DomElement source, DomElement target)
+    private static void CopyPositionAreaResolution(Broiler.Dom.DomElement source, Broiler.Dom.DomElement target)
     {
         if (PositionAreaResolutions.TryGetValue(source, out var r))
             PositionAreaResolutions.AddOrUpdate(target, new PositionAreaResolution


### PR DESCRIPTION
> Stacked on #1355 (2.5 / LayoutRuntimeState retirement). Review/merge #1355 first; this PR's base will retarget to `main` once #1355 lands.

## What

First slice of the `DomElement` facade removal (Milestone 1.2). Re-keys the two per-element runtime-state `ConditionalWeakTable`s off canonical `Broiler.Dom.DomElement` identity instead of the v1 facade `DomElement` type:

- `ElementRuntimeStates` — all per-element bridge runtime state
- `PositionAreaResolutions` — the position-area memo relocated here in 2.5

## Why it's safe

The facade **is** a canonical element (`DomElement : Broiler.Dom.DomElement`), so widening the key type from the facade to its canonical base preserves reference identity — every current key is the same object. Both caches use the key as a **pure identity token** (no facade members read off the key, no iteration), and the accessors don't touch facade state, so `GetElementRuntimeState` / `TryGet`/`Set`/`Clear`/`CopyPositionAreaResolution` widen to `Broiler.Dom.DomElement` with all existing callers passing facade instances that upcast cleanly.

## Deliberately deferred

The other identity caches named in the milestone are **not** cleanly re-keyable yet:
- `_jsObjectCache` is iterated by `FindDomElementByJSObject` (returns facade `DomElement?`) and the sub-document adoption loops, which read facade members (`Parent`/`Children`) off the key.
- `_computedPropsCache` / `_computedStyleEngines` accessors (`GetComputedProps`, computed-style) read facade `Style` off the element.

Both are gated on **relocating the facade's per-element state** (`IsTextNode` × 121, `Style`, `OwnerDocRoot` × 32, `NsAttrMap` × 19, `JsSetStyleProps` × 11, `InnerHtml` × 7, legacy child/attribute views), which is the bulk of Milestone 1.2/1.3 across ~57 files — a later slice. The roadmap doc is updated with this structural finding and the slice sequencing.

## Verification

Bridge + `Broiler.Cli.Tests` + `Broiler.Wpt.Tests` build clean; focused Anchor/Sticky/Clone/Offset/MutationObserver suite **50/50**; WPT anchor/position-area cluster **identical to baseline** (37 pass / same 5 pre-existing fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)