### PR TITLE
RF-BRIDGE-1c: incremental DomElement facade removal (7 members, Milestone 1.2)

### DIFF
--- a/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
+++ b/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
@@ -827,6 +827,14 @@ selectors suites green.
 
 ### Milestone 1.2 — Migrate `DomElement` callers off the facade
 
+> **Detailed implementation plan (2026-07-10):**
+> [`htmlbridge-domelement-facade-removal-plan.md`](htmlbridge-domelement-facade-removal-plan.md)
+> stages Milestones 1.2 + 1.3 into ~13–16 PRs (Phases A–F) using a strangler /
+> transitional-helper approach. It measures the real scope (~800+ facade refs, 76
+> construction sites, `.Style`-on-node and text-as-element as the two architectural
+> couplings) and resolves the design questions (where `.Style` lives; text/comment →
+> canonical `DomText`/`DomComment`). Read it before starting 1.2.
+
 **Goal.** Reduce the ~58 non-submodule source references to `DomElement` to zero
 by moving callers onto canonical `Broiler.Dom.DomNode`/`DomElement`.
 

--- a/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
+++ b/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
@@ -323,14 +323,21 @@ other two are gated on prerequisites that are not yet met (documented below).
   RF-BRIDGE-1b geometry unification — now unblocked (Item 2 complete) and detailed in a
   dedicated staged plan:
   [`htmlbridge-domelement-facade-removal-plan.md`](htmlbridge-domelement-facade-removal-plan.md)
-  (Phases A–F, ~13–16 PRs, strangler via transitional bridge helpers). `DomElement`
-  alone is referenced by **58
-  non-submodule source files** (`grep -rlE '\bDomElement\b' --include=*.cs src/`)
-  and is entangled with RF-BRIDGE-1b geometry keying (boxes
-  key by bridge instances — see rf-bridge-1b §5a), so it cannot be ripped out
-  behind a single verifiable change; it is a staged migration, not a deletion.
+  (Phases A–F, strangler via transitional bridge helpers). `DomElement`
+  alone was referenced by **58 non-submodule source files** and is entangled with
+  RF-BRIDGE-1b geometry keying, so it cannot be ripped out behind a single verifiable
+  change; it is a staged migration, not a deletion.
   `HtmlTreeBuilder`/`CssRules`/`CalculateSpecificity` removal follows once callers
   no longer need the facade node type.
+  **Progress (2026-07-11):** Milestone 1.2 is well under way on branch
+  `claude/rf-bridge-1c-domelement-facade-migration` — **7 facade members deleted**
+  (`JsSetStyleProps`, `OwnerDocRoot`, `Style`, `Attributes`+`LegacyAttributeDictionary`,
+  `Parent`, `IsTextNode`, `Children`+`LegacyChildList`; Phases A/B/C/E1/D1/E2), each a
+  behaviour-preserving relocation to `ElementRuntimeState` or canonical DOM, verified
+  regression-free (empty-diff vs the full-`Broiler.Cli.Tests` baseline). Facade remnants
+  `InnerHtml`/`TextContent`/`NamespaceURI`/`NsAttrMap` + the text→`DomText` construction
+  flip and cache/`RangeState` re-keying are the Phase C2/F remainder (see the plan's
+  "Status at a glance").
 
   **Sharpened dependency analysis (2026-07-09).** The four adapters split into two
   independent gates, not one:

--- a/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
+++ b/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
@@ -320,7 +320,11 @@ other two are gated on prerequisites that are not yet met (documented below).
   (Milestone 1.1): the two `CssRules` test consumers were rerouted to the shared
   `Broiler.CSS` parser and the phase-zero guards flipped to assert removal. The
   `DomElement`/`HtmlTreeBuilder` facade removal (Milestones 1.2/1.3) still follows the
-  RF-BRIDGE-1b geometry unification. `DomElement` alone is referenced by **58
+  RF-BRIDGE-1b geometry unification — now unblocked (Item 2 complete) and detailed in a
+  dedicated staged plan:
+  [`htmlbridge-domelement-facade-removal-plan.md`](htmlbridge-domelement-facade-removal-plan.md)
+  (Phases A–F, ~13–16 PRs, strangler via transitional bridge helpers). `DomElement`
+  alone is referenced by **58
   non-submodule source files** (`grep -rlE '\bDomElement\b' --include=*.cs src/`)
   and is entangled with RF-BRIDGE-1b geometry keying (boxes
   key by bridge instances — see rf-bridge-1b §5a), so it cannot be ripped out

--- a/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
+++ b/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
@@ -21,6 +21,29 @@ Track 3 renderer prerequisites in `Broiler.Layout`. Governance Milestone 1.0
 (`htmlbridge-public-surface/v2` declared) and Milestone 1.1 (zero-caller shim removal)
 are done. The facade removal is unblocked.
 
+## Status at a glance (2026-07-11)
+
+Branch `claude/rf-bridge-1c-domelement-facade-migration`. Each row is its own commit, every one
+regression-free against the full `Broiler.Cli.Tests` (1699, slot-scroll crasher excluded) 78-failure
+environmental baseline.
+
+| Facade member removed | Phase | Moved to | Sites |
+| --- | --- | --- | --- |
+| `JsSetStyleProps`, `OwnerDocRoot` | A | `ElementRuntimeState` | 42 |
+| `Style` | B | `ElementRuntimeState` via `InlineStyle(node)` | ~200 |
+| `Attributes` (+ `LegacyAttributeDictionary`) | C | canonical attributes via `TryGetAttribute`/`SetAttr`/… | ~195 |
+| `Parent` | E1 | canonical `ParentNode` via `ParentEl`/`SetParent` | ~450 |
+| `IsTextNode` | D1 | canonical `NodeType` via `IsText(node)` | 119 |
+| `Children` (+ `LegacyChildList`) | E2 | canonical `ChildNodes` via `ChildElements`/… | 421 |
+
+**Facade `DomElement` still carries:** `InnerHtml`, `TextContent`, `NamespaceURI`, `NsAttrMap`.
+
+**Not yet started:** **Phase C2** (`NsAttrMap` → canonical namespaced attributes) and the **Phase F
+cutover** — flip text/comment construction to canonical `DomText`/`DomComment` (removing `TextContent`),
+which cascades into re-typing `RangeState`, `_knownNodes`, and the JS-object cache, then re-key the
+remaining per-node caches, remove `HtmlTreeBuilder`, and delete the `DomElement` type. `InnerHtml` and
+`NamespaceURI` (ctor-coupled; `SetName` is `protected`) fold into Phase F.
+
 ## The facade in one paragraph
 
 `Broiler.HtmlBridge.DomElement` (`src/Broiler.HtmlBridge.Core/Dom/DomElement.cs`) is

--- a/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
+++ b/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
@@ -1,0 +1,307 @@
+# HtmlBridge `DomElement` Facade Removal — Implementation Plan
+
+Status: proposed
+Date: 2026-07-10
+
+## Purpose
+
+Give **Milestones 1.2 and 1.3** of
+[`htmlbridge-blocked-items-completion-roadmap.md`](htmlbridge-blocked-items-completion-roadmap.md)
+Track 1 — the removal of the `Broiler.HtmlBridge.DomElement` compatibility facade
+and its `HtmlTreeBuilder` materializer — a concrete, staged, build-green-at-every-
+commit implementation plan. This is the "detailed design" the roadmap defers; it
+does not restate *why* the facade is removed (see the promotion roadmap Phase 5 and
+the blocked-items Track 1) — it defines *how*.
+
+**Prerequisite status: MET.** RF-BRIDGE-1b geometry unification (Item 2, Milestones
+2.1–2.5) is complete and verified (2026-07-10): estimators deleted (PR #1354),
+`LayoutRuntimeState` retired (PR #1355), `UseSharedLayoutGeometry` /
+`UseSharedGeometryExclusively` both on, §9.2.1.1 fix landed (`Broiler.HTML` PR #205),
+Track 3 renderer prerequisites in `Broiler.Layout`. Governance Milestone 1.0
+(`htmlbridge-public-surface/v2` declared) and Milestone 1.1 (zero-caller shim removal)
+are done. The facade removal is unblocked.
+
+## The facade in one paragraph
+
+`Broiler.HtmlBridge.DomElement` (`src/Broiler.HtmlBridge.Core/Dom/DomElement.cs`) is
+`public sealed class DomElement : Broiler.Dom.DomElement`. The bridge's **entire node
+tree is built from facade instances**, including text and comment nodes, which the
+facade models as `DomElement` with `IsTextNode` set (not canonical `DomText`/
+`DomComment`). `HtmlTreeBuilder.ConvertNode` re-materializes the canonically-parsed
+tree back into facade nodes. The facade adds a surface of members over canonical
+`DomElement` that callers depend on pervasively; removing the type means giving every
+one of those members a canonical or bridge-runtime-state home, then flipping
+construction to canonical factories.
+
+## Measured scope (2026-07-10)
+
+Established by a full sweep of the non-submodule bridge source (three cluster analyses
+plus direct measurement):
+
+- **~800+ facade references across ~24+ non-test files** (52 files reference the name
+  `DomElement`, of which the bulk are the facade).
+- **76 `new DomElement(...)` construction sites across 14 files.**
+- **Zero fully-canonical "type-only" files** in the hot clusters — every anchor-resolver
+  and JS-callback file touches at least `.Style` or `IsTextNode`.
+- Two couplings are **architectural**, not mechanical:
+  1. **`.Style`** — a mutable `Dictionary<string,string>` attached *to the node*
+     (~200 read/write sites). Canonical DOM has no node-attached style dictionary.
+  2. **text/comment-as-element** — `IsTextNode` (119 sites) + `TextContent` (90 sites);
+     canonical uses `DomText`/`DomComment : DomCharacterData` with `.Data`, which are
+     **not** `DomElement`.
+
+The facade surface is frozen by the characterization test
+`Broiler.Cli.Tests.DomExtractionPhaseZeroTests.Legacy_DomElement_Compatibility_Surface_Is_Explicitly_Frozen`;
+each member removal updates that frozen list.
+
+## Facade member inventory → canonical target
+
+| Facade member | Kind | Sites¹ | Canonical / relocation target |
+| --- | --- | --- | --- |
+| `Style` | `Dictionary<string,string>` on node | ~200 | **ElementRuntimeState-backed** inline-style dict via a bridge accessor `InlineStyle(node)`. |
+| `IsTextNode` | `bool` | 119 | `node.NodeType == DomNodeType.Text` (via bridge helper during transition). |
+| `TextContent` | `string?` get/set | 90 | `DomText`/`DomComment`.`Data` (via bridge helper during transition). |
+| `Attributes` (`LegacyAttributeDictionary`) | string-keyed `IDictionary` | ~120 | canonical `GetAttribute`/`SetAttribute`/`HasAttribute`/`RemoveAttribute` + `Attributes.Values`. |
+| `Parent` | typed `DomElement?` get/set | facade subset of 336 | `ParentNode` (get, `as DomElement` where needed); set → `parent.AppendChild`/`InsertBefore`. |
+| `Children` | `LegacyChildList : IList<DomElement>` | facade subset of 424 | `ChildNodes` (read); `AppendChild`/`InsertBefore`/`RemoveChild` (mutate); helper for `IndexOf`/typed-children. |
+| `NamespaceURI` | `string?` get/set | ~10 | construct via `CreateElementNS`; read `NamespaceUri`. |
+| `OwnerDocRoot` | `DomElement?` get/set | 30 | **ElementRuntimeState** (facade-only, no canonical equivalent). |
+| `NsAttrMap` | `Dictionary<(ns,local),string>` | 18 | canonical namespaced attributes (`SetAttributeNS`/`GetAttributeNS`); relocate to ERS only if a residue remains. |
+| `JsSetStyleProps` | `HashSet<string>` | 11 | **ElementRuntimeState** (facade-only). |
+| `InnerHtml` | `string` get/set | 14 | **ElementRuntimeState** (facade-only bridge state). |
+| constructors | `new DomElement(...)` | 76 | `document.CreateElement`/`CreateElementNS`/`CreateTextNode`/`CreateComment`. |
+
+¹ "Sites" mixes facade-only counts (exact) with member-name greps that overcount
+shared names (`.Parent`/`.Children`/`.Style` also occur on `CssBox`, canonical nodes,
+JS objects); treat the tree-shape numbers as upper bounds.
+
+## Canonical API the plan relies on (verified present)
+
+- `DomNode`: `NodeType`, `ParentNode`, `ChildNodes` (`IReadOnlyList<DomNode>`),
+  `AppendChild`, `InsertBefore(node, ref)`, `RemoveChild`, `Remove()`, `NodeValue`.
+- `DomElement`: `LocalName`, `TagName`, `NamespaceUri`, `Id`, `ClassName`,
+  `GetAttribute`/`GetAttributeNS`/`SetAttribute`/`SetAttributeNS`/`HasAttribute`/
+  `RemoveAttribute`/`RemoveAttributeNS`, `Attributes` (namespace-keyed).
+- `DomText`/`DomComment : DomCharacterData` with settable `Data` (publishes a
+  `CharacterData` mutation record); **`internal` constructors** — the bridge must mint
+  them via `document.CreateTextNode`/`CreateComment`.
+- `DomDocument`: `CreateElement`, `CreateElementNS`, `CreateTextNode`, `CreateComment`,
+  `DocumentElement`/`Head`/`Body`, `GetElementById`, `GetElementsByTagName`.
+
+**Note (`ChildNodes` is read-only `IReadOnlyList<DomNode>`):** every `Children.Add/
+Insert/IndexOf/Remove/Clear` call migrates to parent-side mutation
+(`AppendChild`/`InsertBefore`/`RemoveChild`) or a bridge `ChildIndexOf` helper — there
+is no in-place list surface on canonical nodes.
+
+## Core strategy — strangler via transitional bridge helpers
+
+The build must stay green at **every commit**, and no single commit can flip the tree
+type. The technique is a strangler:
+
+1. **Introduce a bridge helper** that expresses a facade member's behaviour over the
+   canonical *base* type (`DomNode`), working on facade instances today and on
+   canonical instances after the flip. Examples:
+   - `static bool IsBridgeText(DomNode n) => n.NodeType == DomNodeType.Text;`
+   - `static string BridgeText(DomNode n)` / `SetBridgeText(DomNode n, string)` —
+     reads/writes `DomText.Data` (falls back to facade `TextContent` while facade
+     nodes still exist).
+   - `Dictionary<string,string> InlineStyle(DomNode n)` — ERS-backed.
+   - `static DomElement? TypedParent(DomNode n) => n.ParentNode as DomElement;`
+   - `static int ChildIndexOf(DomNode parent, DomNode child)`.
+2. **Migrate call sites** from `element.<facadeMember>` to the helper. Safe while nodes
+   are still facade (helper accepts `DomNode`, facade IS-A `DomNode`).
+3. **Remove the facade member** once no site references it; update the frozen guard.
+4. **Flip construction** to canonical factories *last*, after every member is helper-
+   routed — the helpers already work on canonical nodes, so the flip is behaviour-
+   preserving.
+
+The critical ordering constraint this produces: **the tree-shape surface
+(`Parent`/`Children`/traversal) must be widened from facade `DomElement` to canonical
+`DomNode` BEFORE text/comment construction is flipped to `DomText`/`DomComment`** —
+because `DomText` is not a `DomElement`, so any code holding children as
+`IList<DomElement>` or casting `(DomElement)child` breaks the moment a real `DomText`
+enters the tree. Widening traversal to `DomNode` (with facade nodes still in place) is
+safe and is the true prerequisite for canonical text.
+
+## Staged plan
+
+Each phase is one or more PRs, each independently building + green. Gate every phase on
+the **full** validation set (see "Validation" below), baselined first per `CLAUDE.md`.
+
+### Phase A — Relocate facade-only bridge state into `ElementRuntimeState`
+
+Independent, low-risk, no canonical-model change. Proves the relocation pattern and
+thins the facade immediately. `GetElementRuntimeState` is `private static`, so even the
+nested `CssStyleDeclaration`/`CssStyleMap` JS-object classes can reach it.
+
+- **A1 — `JsSetStyleProps`** (11 sites). Add `HashSet<string> JsSetStyleProps` to
+  `ElementRuntimeState`; rewrite `x.JsSetStyleProps` → `GetElementRuntimeState(x).JsSetStyleProps`;
+  delete the facade member; drop `"JsSetStyleProps"` from the frozen list.
+- **A2 — `OwnerDocRoot`** (30 sites). `DomElement? OwnerDocRoot` → ERS (type stays
+  facade-typed for now; re-typed to canonical in Phase F).
+- **A3 — `InnerHtml`** (14 sites). Relocate to ERS (or recompute where it is only a
+  style-source fallback, e.g. `Css.cs:575`).
+
+**Risk.** Low. **Exit.** Facade loses 3 members; frozen guard updated; all suites green.
+
+### Phase B — Canonicalize `.Style` (node-attached inline style)
+
+- Add an ERS-backed accessor `Dictionary<string,string> InlineStyle(DomNode)`.
+- Populate it wherever the facade `Style` is populated today: `HtmlTreeBuilder`
+  construction (`ParseStyle`), the `style=` attribute setter (`Attributes.cs`), and JS
+  `element.style` writes (`Utilities.cs` `CssStyleDeclaration`).
+- Migrate the ~200 `.Style` read/write/remove/enumerate sites to `InlineStyle(node)`.
+- Delete facade `Style`; drop `"Style"` from the frozen list.
+
+**Risk.** High (breadth, ~200 sites), but mechanical and locally verifiable. Split into
+sub-PRs by cluster (anchor-resolver, JS-callbacks, serialization/computed-style).
+**Exit.** No `.Style` on the node; inline style lives in ERS; computed-style, anchor,
+animation, serialization suites green.
+
+### Phase C — Canonicalize attribute access (`Attributes` + `NsAttrMap`)
+
+- Migrate string-keyed `element.Attributes[...]`/`.TryGetValue`/`.ContainsKey`/`.Keys`/
+  `.Remove` to canonical `GetAttribute`/`SetAttribute`/`HasAttribute`/`RemoveAttribute`
+  and `Attributes.Values` (namespace-keyed). Add thin bridge helpers
+  (`GetAttr(node,name)`, `AttrNames(node)`) only where they reduce churn.
+- Fold `NsAttrMap` bookkeeping into canonical namespaced attributes
+  (`SetAttributeNS`/`GetAttributeNS`); relocate any irreducible residue to ERS.
+- Remove the facade `Attributes` hide and `NsAttrMap`; drop `"NsAttrMap"` from the
+  frozen list.
+
+**Risk.** Medium-High. Heaviest in `ElementInterfaces.cs`, `JsObjects.cs`,
+`Attributes.cs`, `Registration.cs`. **Exit.** Attribute access is canonical; XHTML/NS
+attribute WPT + Acid cases green.
+
+### Phase E — Widen tree-shape traversal to `DomNode` (prerequisite for D)
+
+*(Runs before D despite the label; kept as "E" to match the member table.)*
+
+- Introduce `TypedParent(DomNode)`, `ChildIndexOf(parent, child)`,
+  `ChildElements(node)` (canonical `ChildNodes.OfType<DomElement>()`), and reparent
+  helpers wrapping `AppendChild`/`InsertBefore`/`RemoveChild`.
+- Migrate `el.Parent` (get) → `ParentNode`/`TypedParent`; `el.Parent = p` (set) →
+  `p.AppendChild(el)`/`InsertBefore`; `el.Children.Add/Insert/Remove/Clear` → parent-
+  side mutation; `el.Children[i]`/`.Count`/`.IndexOf` → `ChildNodes`/`ChildIndexOf`.
+- Re-type internal tree fields and walkers (`_documentNode`, `Elements`,
+  `LayoutMetrics` parent-chain walks, `HitTesting`, `Traversal`) from facade
+  `DomElement` to canonical `DomNode`/`DomElement` as appropriate. **Do not** flip
+  construction yet — facade instances still populate the tree.
+- Remove facade `Parent`/`Children`/`NamespaceURI`; drop `"Parent"`/`"NamespaceURI"`
+  from the frozen list.
+
+**Risk.** High (largest single surface; `LayoutMetrics.cs` alone is ~119 facade-typed
+lines dominated by `.Parent` walks). Split by file cluster. **Exit.** All tree traversal
+is `DomNode`-based; the tree can safely contain non-`DomElement` nodes.
+
+### Phase D — Canonicalize text/comment nodes
+
+Now safe because traversal is `DomNode`-based (Phase E).
+
+- Route all `IsTextNode`/`TextContent` sites through `IsBridgeText`/`BridgeText`/
+  `SetBridgeText` (introduced in the strategy section, reading `DomText.Data`).
+- Flip text/comment **construction**: the ~20 `new DomElement("#text"/"#comment", …,
+  isTextNode:true)` sites → `document.CreateTextNode`/`CreateComment`; `HtmlTreeBuilder`
+  and `Registration`/`SubDocumentObjects`/`Traversal` text splitting produce canonical
+  character-data nodes.
+- Rework text-dependent algorithms confirmed by the sweep: `LayoutMetrics`
+  `GetDirectTextContent`/select-option text, `Css` style-source/rendered-text,
+  `AnchorResolver` `CssCleanup`/`PositionTry` `<style>` text rewrite,
+  `InlineContainingBlocks` inline-width estimation, `Traversal` range extraction,
+  `JsObjects` `splitText`/CharacterData.
+- Remove facade `IsTextNode`/`TextContent`; drop `"TextContent"` from the frozen list.
+
+**Risk.** Highest — the text-as-element model is load-bearing in range/selection,
+serialization, and inline layout. Gate hard on WPT text/range/selection + Acid.
+**Exit.** Text/comment are canonical `DomText`/`DomComment`; no `IsTextNode` on the node.
+
+### Phase F — Flip element construction, re-key caches, delete the facade (Milestone 1.3)
+
+- Route the remaining element `new DomElement(...)` sites to
+  `document.CreateElement`/`CreateElementNS`.
+- Rewrite/retire `HtmlTreeBuilder`: its callers (`DomBridge.cs`, `SubDocuments.cs`,
+  `Registration.cs`, `SubDocumentObjects.cs`) parse into canonical nodes via
+  `Broiler.Dom.Html.HtmlDocumentParser` directly (the parser already produces canonical
+  nodes; the adapter's only job was re-materializing facade nodes).
+- Re-key the 14 per-node caches (`ElementRuntimeStates`, `_jsObjectCache`,
+  `_computedStyleEngines`, `_computedPropsCache`/`_computedPropsInProgress`,
+  `_docRootToDocJSObject`, `_smoothScrollTokens`, `_styleSheetCache`,
+  `_subDocument*Cache`, `_zoomSpecifiedStyleCache`, `PositionAreaResolutions`) from
+  `DomElement` to canonical `DomNode` — now cast-free because
+  `FindDomElementByJSObject` and the Registration reverse-lookups return canonical
+  nodes. Re-type `OwnerDocRoot`/shadow `RuntimeValue<DomElement>` to canonical.
+- Widen the public seam `IDomBridgeRuntime.Elements` (`IReadOnlyList<DomElement>`) and
+  `DomBridge.DocumentElement` to canonical `Broiler.Dom.DomElement` (text/comment drop
+  out naturally via `OfType<DomElement>()`).
+- Delete `DomElement.cs` and `HtmlTreeBuilder.cs`.
+- Update/remove the frozen seam assertions in `HtmlBridgePromotionPhaseZeroTests`
+  (`DomElement_And_HtmlTreeBuilder_Adapter_Seam_Is_Versioned_And_Frozen`) and
+  `DomExtractionPhaseZeroTests` (now asserting removal, not the frozen surface).
+
+**Risk.** High — final cutover. **Exit.** `DomElement`/`HtmlTreeBuilder` gone; promotion
+roadmap Phase 5 exit criteria met ("HtmlBridge contains bridge responsibilities only").
+
+## Dependency graph
+
+```
+A (facade-only state)  ─┐
+B (.Style → ERS)        ─┼─► E (widen traversal to DomNode) ─► D (text→DomText) ─► F (construct+cache+delete)
+C (attributes canonical)─┘
+```
+
+A, B, C are mutually independent and can land in any order (A first is the cheapest
+proof). E gates D (canonical text needs `DomNode` traversal). D gates F (element
+construction flips last, once no facade instances are required). F is the only
+irreversible step.
+
+## Validation (every phase)
+
+Baseline first (some fail environmentally per `CLAUDE.md`), then require zero new
+failures by name:
+
+- Full `Broiler.Cli.Tests` (bridge DOM/CSSOM/anchor/scroll/serialization) — the primary
+  gate; the `ScrollIntoView_Treats_Assigned_Slot` slot-scroll crasher stays excluded.
+- Full `Broiler.Wpt.Tests` + WPT check-layout + pixel + Acid baselines.
+- `Broiler.Dom.Tests`, `Broiler.CSS.Dom.Tests` (canonical algorithms unaffected).
+- Guard tests `HtmlBridgePromotionPhaseZeroTests` + `DomExtractionPhaseZeroTests`
+  (updated per phase as members are removed).
+- `SharedLayoutGeometryParityTests` parity gate + shared-geometry families (the node
+  identity underneath geometry caches must stay stable).
+- `bridge.mutation` + a geometry-query benchmark for no perf regression (the ERS-backed
+  `InlineStyle`/text helpers add an indirection on hot paths — measure).
+
+## Risks & mitigations
+
+- **`.Style` and text helpers on hot paths** (computed style, inline layout, range).
+  Mitigate: keep helpers allocation-free; ERS lookup is a `ConditionalWeakTable` hit
+  already paid elsewhere; benchmark Phase B and D.
+- **Text-as-element is load-bearing in serialization/range** — a wrong `DomText`
+  boundary silently corrupts `outerHTML`/selection. Mitigate: Phase D lands behind the
+  full WPT range/selection + serialization corpus, cluster by cluster.
+- **Giant unreviewable PRs.** Mitigate: every phase splits by file cluster; caller-count
+  guard (`grep -rlE '\bDomElement\b' --include=*.cs src/`) trends strictly down and is
+  reported per PR.
+- **Cache identity drift.** Re-keying (Phase F) must preserve reference identity;
+  canonical nodes use reference equality (no `Equals` override), so declared key type
+  does not change runtime behaviour — but verify the parity gate after re-key.
+
+## Effort estimate
+
+A: ~1 small PR. B: 2–3 PRs. C: 2 PRs. E: 3–4 PRs (LayoutMetrics/HitTesting/Traversal are
+large). D: 3–4 PRs (hardest). F: 2 PRs (construction flip; then delete + guard flip).
+**Order of ~13–16 PRs total.** This matches the roadmap's "High risk, staged, 58 files"
+framing; it is not a single-session cutover.
+
+## Design decisions (resolved 2026-07-10)
+
+1. **`.Style` home — ERS-backed `Dictionary<string,string>`.** The inline-style dict
+   moves into `ElementRuntimeState` behind a bridge `InlineStyle(node)` accessor,
+   matching "the node model deliberately does not own this state." (Not backed by
+   canonical CSSOM — that would be a larger CSS.Dom change with its own drift surface.)
+2. **Text — transition helpers.** Introduce `IsBridgeText`/`BridgeText`/`SetBridgeText`
+   over `DomNode`; migrate sites, then flip construction. Keeps every commit green (no
+   long red-build window from a single text-model flip).
+3. **`HtmlTreeBuilder` — retire entirely in Phase F.** Callers use
+   `Broiler.Dom.Html.HtmlDocumentParser` directly (the promotion roadmap's end state).
+4. **Cadence — incremental, PR-per-phase-cluster (~13–16 PRs).** Caller-count guard
+   trends strictly down and is reported per PR.

--- a/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
+++ b/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
@@ -170,20 +170,28 @@ scrollIntoView-% parallel flake, which passes in isolation).
   `Children`/text cutover builds on. (Sed over-captured `state.StartContainer/EndContainer` member
   chains; corrected + hand-migrated the `ParentEl(...)`/`siblings[i]`/`Children[i]` receivers.)
 
-**Remaining D+E2 cluster (one coordinated cutover — the hardest piece):**
-`Children` (`LegacyChildList : IList<DomElement>`, ~350 sites), `TextContent`→
-`DomText`/`DomComment`.`Data` (90 sites), and flipping text/comment **construction** to
-`document.CreateTextNode`/`CreateComment`. These cannot be sub-sliced: a `DomText` cannot enter an
-`IList<DomElement>`, and text-data storage flips *with* construction. Plan: introduce
-`ChildElements`/`ChildIndexOf`/child-mutation helpers + `TextData`/`SetTextData` (route reads via
-`NodeValue`/`DomCharacterData.Data`), migrate the `Children` reads/mutations and the loop-body
-`TagName`/`#comment` checks (`IsComment(node)`), flip the ~20 text/comment construction sites, then
-delete `Children` + `TextContent` in one commit. Gate on the full WPT range/selection + serialization
-corpus (text boundaries silently corrupt `outerHTML`/selection).
+- **Phase E2 (`Children`) — DONE.** Facade `Children` (`LegacyChildList : IList<DomElement>`) removed;
+  **421 sites** migrated to canonical `ChildNodes` + helpers (`ChildElements`/`ChildAt`/`ChildIndexOf`/
+  `InsertChildAt`/`RemoveNthChild`/`ClearChildren`), each mirroring the old primitive. The tree stays
+  homogeneous `DomElement`, so the `Cast`/`ChildAt` casts are safe today and narrow to `OfType` +
+  `IsText` handling at the text flip. Notable snags handled: `ParentEl(y)?.Children.Remove(y)` →
+  `y.Remove()`; the `state.StartContainer/EndContainer.Children` member chains and a `Children[^1]`
+  from-end index; the one indexer-set → `ReplaceChild`; and a **name collision** with a pre-existing
+  *notifying* `RemoveChildAt` (raw primitive renamed `RemoveNthChild`; self-recursion fixed). Full
+  `Broiler.Cli.Tests` empty-diff vs baseline, before and after removing the member.
 
-Facade now retains: `InnerHtml` (Phase F), `NsAttrMap` (Phase C2), `TextContent` + `Children`
-(D+E2 cluster above), `NamespaceURI` (Phase F).
-Next: the **D+E2 `Children`/construction cutover** (largest remaining), or **Phase C2** (`NsAttrMap`).
+**What remains of D+E2 — the text→canonical construction flip (Phase F territory):** `TextContent`
+(90 sites) → `DomText`/`DomComment`.`Data`, and flipping the ~20 text/comment **construction** sites to
+`document.CreateTextNode`/`CreateComment`. This is deferred because it **cascades beyond the facade**: a
+`DomText` is not a `DomElement`, so it forces re-typing `RangeState.StartContainer`/`EndContainer`, the
+`_knownNodes` set, and the JS-object cache (text nodes have JS wrappers) — i.e. it belongs with the
+Phase F cache/RangeState cutover. At that point `ChildElements` narrows to `OfType<DomElement>()` and the
+tree-walk bodies gain `IsText`/`is DomElement` handling. Gate on the WPT range/selection + serialization
+corpus.
+
+Facade now retains: `InnerHtml` (Phase F), `NsAttrMap` (Phase C2), `TextContent` (Phase F text flip),
+`NamespaceURI` (Phase F). Next: **Phase C2** (`NsAttrMap`) or the **Phase F cutover** (text→`DomText`,
+construction flip, cache/`RangeState` re-keying, delete the facade type).
 
 ### Phase A — Relocate facade-only bridge state into `ElementRuntimeState`
 

--- a/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
+++ b/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
@@ -147,9 +147,26 @@ scrollIntoView-% parallel flake, which passes in isolation).
   `GetAttribute`/`SetAttribute` are no-namespace + lowercasing, so raw canonical methods are **not**
   a drop-in for the legacy scan — the helpers are the faithful translation.
 
-Facade now retains: `InnerHtml` (deferred, ctor-coupled → Phase F), `NsAttrMap` (Phase C2),
-`IsTextNode`/`TextContent` (Phase D), `Parent`/`Children`/`NamespaceURI` (Phase E).
-Next: **Phase E** (widen tree traversal to `DomNode`) or **Phase C2** (`NsAttrMap`).
+- **Phase E (part 1 — `Parent`)** — facade `Parent` getter/setter removed; ~450 sites → bridge
+  helpers `ParentEl(element)` (= `ParentNode as DomElement`) and `SetParent(child, parent)`
+  (mirrors the old setter). Phase-D-safe (a node's parent is always an element, so `ParentEl`
+  survives text→`DomText`). `.Parent` is **not** universally facade-owned — the receiver-scoped
+  sed over-matched `DirectoryInfo.Parent`, a member chain, `?.Parent` guards, an object
+  initializer, and an indexer receiver; all reverted by hand.
+
+**Phase E remainder (`Children`, `NamespaceURI`):**
+- **`Children`** is the true Phase-D blocker — a `LegacyChildList : IList<DomElement>` can't hold
+  a future `DomText`. Its ~350 sites (Add/Insert/Remove/IndexOf/Count/indexer/LINQ) and the
+  loop-body `IsTextNode`/`TagName` checks are intertwined with the text-node model, so **do
+  `Children` together with Phase D** (introduce `IsBridgeText`/`ChildElements`/`ChildIndexOf`
+  helpers, migrate, flip text construction, then delete `Children` + `IsTextNode`/`TextContent`).
+- **`NamespaceURI`** is constructor-coupled (8 sets right after `new DomElement`; canonical
+  `SetName` is `protected`, unreachable from `DomBridge`) — fold into **Phase F** with the
+  construction flip.
+
+Facade now retains: `InnerHtml` (Phase F), `NsAttrMap` (Phase C2), `IsTextNode`/`TextContent` +
+`Children` (Phase D/E2 combined), `NamespaceURI` (Phase F).
+Next: **Phase D+E2** (text-node canonicalization + `Children`) or **Phase C2** (`NsAttrMap`).
 
 ### Phase A — Relocate facade-only bridge state into `ElementRuntimeState`
 

--- a/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
+++ b/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
@@ -128,6 +128,12 @@ safe and is the true prerequisite for canonical text.
 Each phase is one or more PRs, each independently building + green. Gate every phase on
 the **full** validation set (see "Validation" below), baselined first per `CLAUDE.md`.
 
+**Progress (2026-07-10):** Phase A **DONE** — `JsSetStyleProps` + `OwnerDocRoot` relocated
+to `ElementRuntimeState` (42 sites), facade members deleted, frozen guard updated; full
+`Broiler.Cli.Tests` (1699, crasher excluded) zero new failures by name vs HEAD. `InnerHtml`
+deferred out of Phase A (constructor-coupled; fold in near Phase F). Next: Phase B
+(`.Style` → ERS). Branch: `claude/rf-bridge-1c-domelement-facade-migration`.
+
 ### Phase A — Relocate facade-only bridge state into `ElementRuntimeState`
 
 Independent, low-risk, no canonical-model change. Proves the relocation pattern and
@@ -146,17 +152,39 @@ nested `CssStyleDeclaration`/`CssStyleMap` JS-object classes can reach it.
 
 ### Phase B — Canonicalize `.Style` (node-attached inline style)
 
-- Add an ERS-backed accessor `Dictionary<string,string> InlineStyle(DomNode)`.
-- Populate it wherever the facade `Style` is populated today: `HtmlTreeBuilder`
-  construction (`ParseStyle`), the `style=` attribute setter (`Attributes.cs`), and JS
-  `element.style` writes (`Utilities.cs` `CssStyleDeclaration`).
-- Migrate the ~200 `.Style` read/write/remove/enumerate sites to `InlineStyle(node)`.
-- Delete facade `Style`; drop `"Style"` from the frozen list.
+- Add an **eager** ERS field `Dictionary<string,string> Style` (init empty,
+  `OrdinalIgnoreCase`) and a bridge accessor `Dictionary<string,string> InlineStyle(DomNode)`
+  → `GetElementRuntimeState(node).Style`.
+- Migrate the ~207 element `.Style` sites (136 writes) to `InlineStyle(node)`.
+- Seed at construction where the facade seeds today:
+  - `CloneDomElement` (in `DomBridge` partial — copy `InlineStyle(source)` into
+    `InlineStyle(clone)`; drop the `style` constructor arg).
+  - `HtmlTreeBuilder` element case — parses `style` at construction, but the builder is a
+    **separate class** and cannot reach the private static `GetElementRuntimeState`. Seed
+    in `DomBridge` after `Build`/`ParseFragment` returns (walk the returned elements, parse
+    each node's `style` attribute into `InlineStyle`), or expose an internal seeding hook.
+- Delete facade `Style` (and its constructor param); drop `"Style"` from the frozen list.
 
-**Risk.** High (breadth, ~200 sites), but mechanical and locally verifiable. Split into
-sub-PRs by cluster (anchor-resolver, JS-callbacks, serialization/computed-style).
-**Exit.** No `.Style` on the node; inline style lives in ERS; computed-style, anchor,
-animation, serialization suites green.
+**Findings that shape this phase (2026-07-10):**
+- **The `Style` dict is the authoritative in-memory inline style, not the `style`
+  attribute.** It is seeded from `style=` at parse/set time (`Attributes.cs` clears +
+  reparses the dict on a `style=` write), mutated directly by JS `element.style`
+  (`Utilities.cs` `CssStyleDeclaration`), the anchor resolver, and synthetic form-control
+  styling (`DomBridge.Serialization.cs`), and only written **back** to the `style`
+  attribute at serialization. Therefore `InlineStyle` must be an **eager persistent** ERS
+  dict seeded once — a lazy "parse the `style` attribute on first access" design would
+  silently drop unsynced JS mutations (notably on `cloneNode`, whose clone must copy the
+  live dict, not re-parse the possibly-stale attribute).
+- **`.Style` is NOT a facade-unique member name** — it also occurs on tuples
+  (`_zoomSerializationRevertLog`'s `(Element, Style, Attributes)`), computed-props maps,
+  etc. So **no blind `sed`** (unlike Phase A's facade-unique `OwnerDocRoot`/
+  `JsSetStyleProps`): each `.Style` site needs confirmation it is on a `DomElement` value.
+  Migrate file-by-file with review.
+
+**Risk.** High (breadth ~207 sites + construction seeding + non-unique name → per-site
+judgment). Split into sub-PRs by cluster (anchor-resolver, JS-callbacks,
+serialization/computed-style). **Exit.** No `.Style` on the node; inline style lives in
+ERS; computed-style, anchor, animation, serialization suites green.
 
 ### Phase C — Canonicalize attribute access (`Attributes` + `NsAttrMap`)
 

--- a/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
+++ b/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
@@ -128,11 +128,19 @@ safe and is the true prerequisite for canonical text.
 Each phase is one or more PRs, each independently building + green. Gate every phase on
 the **full** validation set (see "Validation" below), baselined first per `CLAUDE.md`.
 
-**Progress (2026-07-10):** Phase A **DONE** — `JsSetStyleProps` + `OwnerDocRoot` relocated
-to `ElementRuntimeState` (42 sites), facade members deleted, frozen guard updated; full
-`Broiler.Cli.Tests` (1699, crasher excluded) zero new failures by name vs HEAD. `InnerHtml`
-deferred out of Phase A (constructor-coupled; fold in near Phase F). Next: Phase B
-(`.Style` → ERS). Branch: `claude/rf-bridge-1c-domelement-facade-migration`.
+**Progress (2026-07-10):** Phases A + B **DONE** on branch
+`claude/rf-bridge-1c-domelement-facade-migration`, each full-`Broiler.Cli.Tests` regression-free
+(78-failure baseline, empty diff).
+- **Phase A** — `JsSetStyleProps` + `OwnerDocRoot` → `ElementRuntimeState` (42 sites).
+- **Phase B** — inline `.Style` → ERS via `DomBridge.InlineStyle(element)` (lazy-seeds from the
+  `style=` attribute on first access; ~200 sites; clone + dialog-backdrop seed explicitly; facade
+  `Style` deleted, ignored `style` ctor param retained until Phase F). Perf note: `InlineStyle`
+  adds a CWT lookup per style access on hot paths — candidate for a per-pass cache if benchmarks
+  regress.
+
+Facade now retains: `InnerHtml` (deferred, ctor-coupled → Phase F), `Attributes`/`NsAttrMap`
+(Phase C), `IsTextNode`/`TextContent` (Phase D), `Parent`/`Children`/`NamespaceURI` (Phase E).
+Next: **Phase C** (canonicalize attribute access).
 
 ### Phase A — Relocate facade-only bridge state into `ElementRuntimeState`
 

--- a/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
+++ b/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
@@ -164,9 +164,26 @@ scrollIntoView-% parallel flake, which passes in isolation).
   `SetName` is `protected`, unreachable from `DomBridge`) — fold into **Phase F** with the
   construction flip.
 
-Facade now retains: `InnerHtml` (Phase F), `NsAttrMap` (Phase C2), `IsTextNode`/`TextContent` +
-`Children` (Phase D/E2 combined), `NamespaceURI` (Phase F).
-Next: **Phase D+E2** (text-node canonicalization + `Children`) or **Phase C2** (`NsAttrMap`).
+- **Phase D (part 1 — `IsTextNode`)** — facade `IsTextNode` removed; 119 sites → `IsText(node)`
+  (`node.NodeType == DomNodeType.Text`). NodeType-based, so forward-compatible with canonical
+  `DomText`; the facade `NodeValue` now keys off `NodeType`. This is the discrimination step the
+  `Children`/text cutover builds on. (Sed over-captured `state.StartContainer/EndContainer` member
+  chains; corrected + hand-migrated the `ParentEl(...)`/`siblings[i]`/`Children[i]` receivers.)
+
+**Remaining D+E2 cluster (one coordinated cutover — the hardest piece):**
+`Children` (`LegacyChildList : IList<DomElement>`, ~350 sites), `TextContent`→
+`DomText`/`DomComment`.`Data` (90 sites), and flipping text/comment **construction** to
+`document.CreateTextNode`/`CreateComment`. These cannot be sub-sliced: a `DomText` cannot enter an
+`IList<DomElement>`, and text-data storage flips *with* construction. Plan: introduce
+`ChildElements`/`ChildIndexOf`/child-mutation helpers + `TextData`/`SetTextData` (route reads via
+`NodeValue`/`DomCharacterData.Data`), migrate the `Children` reads/mutations and the loop-body
+`TagName`/`#comment` checks (`IsComment(node)`), flip the ~20 text/comment construction sites, then
+delete `Children` + `TextContent` in one commit. Gate on the full WPT range/selection + serialization
+corpus (text boundaries silently corrupt `outerHTML`/selection).
+
+Facade now retains: `InnerHtml` (Phase F), `NsAttrMap` (Phase C2), `TextContent` + `Children`
+(D+E2 cluster above), `NamespaceURI` (Phase F).
+Next: the **D+E2 `Children`/construction cutover** (largest remaining), or **Phase C2** (`NsAttrMap`).
 
 ### Phase A — Relocate facade-only bridge state into `ElementRuntimeState`
 

--- a/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
+++ b/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
@@ -128,19 +128,28 @@ safe and is the true prerequisite for canonical text.
 Each phase is one or more PRs, each independently building + green. Gate every phase on
 the **full** validation set (see "Validation" below), baselined first per `CLAUDE.md`.
 
-**Progress (2026-07-10):** Phases A + B **DONE** on branch
+**Progress (2026-07-10/11):** Phases A + B + C **DONE** on branch
 `claude/rf-bridge-1c-domelement-facade-migration`, each full-`Broiler.Cli.Tests` regression-free
-(78-failure baseline, empty diff).
+(78-failure baseline; the only diff is the documented `GoogleSearchPolyfillTests`
+scrollIntoView-% parallel flake, which passes in isolation).
 - **Phase A** — `JsSetStyleProps` + `OwnerDocRoot` → `ElementRuntimeState` (42 sites).
 - **Phase B** — inline `.Style` → ERS via `DomBridge.InlineStyle(element)` (lazy-seeds from the
   `style=` attribute on first access; ~200 sites; clone + dialog-backdrop seed explicitly; facade
   `Style` deleted, ignored `style` ctor param retained until Phase F). Perf note: `InlineStyle`
   adds a CWT lookup per style access on hot paths — candidate for a per-pass cache if benchmarks
   regress.
+- **Phase C** — `Attributes` (`LegacyAttributeDictionary`) shim removed; ~195 sites moved to
+  bridge helpers over the canonical namespace-keyed attribute set (`TryGetAttribute`/`GetAttr`/
+  `HasAttr`/`SetAttr`/`RemoveAttr`/`AttributeNames`/`AttributeSnapshot`/`RestoreAttributes`, each
+  mirroring the legacy dict's case-insensitive scan-by-qualified-name exactly). `element.Attributes`
+  now resolves to the canonical read-only map. **`NsAttrMap` deferred** — its NS-handler rewrite has
+  namespace-normalization subtleties; isolate as its own follow-up (Phase C2). Note: canonical
+  `GetAttribute`/`SetAttribute` are no-namespace + lowercasing, so raw canonical methods are **not**
+  a drop-in for the legacy scan — the helpers are the faithful translation.
 
-Facade now retains: `InnerHtml` (deferred, ctor-coupled → Phase F), `Attributes`/`NsAttrMap`
-(Phase C), `IsTextNode`/`TextContent` (Phase D), `Parent`/`Children`/`NamespaceURI` (Phase E).
-Next: **Phase C** (canonicalize attribute access).
+Facade now retains: `InnerHtml` (deferred, ctor-coupled → Phase F), `NsAttrMap` (Phase C2),
+`IsTextNode`/`TextContent` (Phase D), `Parent`/`Children`/`NamespaceURI` (Phase E).
+Next: **Phase E** (widen tree traversal to `DomNode`) or **Phase C2** (`NsAttrMap`).
 
 ### Phase A — Relocate facade-only bridge state into `ElementRuntimeState`
 

--- a/src/Broiler.Cli.Tests/DomExtractionPhaseZeroTests.cs
+++ b/src/Broiler.Cli.Tests/DomExtractionPhaseZeroTests.cs
@@ -103,15 +103,15 @@ public sealed class DomExtractionPhaseZeroTests
         Assert.Equal("html", documentElement.TagName);
         Assert.Equal("Phase Zero", title);
 
-        var head = Assert.Single(documentElement.Children, static child => child.TagName == "head");
-        var body = Assert.Single(documentElement.Children, static child => child.TagName == "body");
+        var head = Assert.Single(documentElement.ChildNodes.OfType<Broiler.Dom.DomElement>(), static child => child.TagName == "head");
+        var body = Assert.Single(documentElement.ChildNodes.OfType<Broiler.Dom.DomElement>(), static child => child.TagName == "body");
         Assert.Same(documentElement, head.ParentNode);
         Assert.Same(documentElement, body.ParentNode);
 
         var host = Assert.Single(elements, static element => element.Id == "host");
         Assert.Same(body, host.ParentNode);
-        Assert.Equal(["span", "span"], host.Children.Select(static child => child.TagName));
-        Assert.All(host.Children, child => Assert.Same(host, child.ParentNode));
+        Assert.Equal(["span", "span"], host.ChildNodes.OfType<Broiler.Dom.DomElement>().Select(static child => child.TagName));
+        Assert.All(host.ChildNodes, child => Assert.Same(host, child.ParentNode));
     }
 
     [Fact]
@@ -161,7 +161,7 @@ public sealed class DomExtractionPhaseZeroTests
         var created = Assert.Single(bridge.Elements, static element => element.Id == "created");
 
         Assert.Same(host, created.ParentNode);
-        Assert.Contains(created, host.Children);
+        Assert.Contains(created, host.ChildNodes);
         Assert.Contains("<section id=\"created\"></section>", bridge.SerializeToHtml(), StringComparison.Ordinal);
     }
 }

--- a/src/Broiler.Cli.Tests/DomExtractionPhaseZeroTests.cs
+++ b/src/Broiler.Cli.Tests/DomExtractionPhaseZeroTests.cs
@@ -11,13 +11,14 @@ namespace Broiler.Cli.Tests;
 /// </summary>
 public sealed class DomExtractionPhaseZeroTests
 {
-    // RF-BRIDGE-1c Phase A relocated JsSetStyleProps and OwnerDocRoot off the facade
-    // into ElementRuntimeState (bridge runtime state the node model must not own), so
-    // they no longer appear on the DomElement surface below.
+    // RF-BRIDGE-1c relocated bridge runtime state off the facade into
+    // ElementRuntimeState (the node model must not own it): Phase A moved
+    // JsSetStyleProps + OwnerDocRoot; Phase B moved the inline Style dictionary
+    // (now reached via DomBridge.InlineStyle). They no longer appear on the
+    // DomElement surface below.
     private static readonly string[] LegacyMutableCollectionProperties =
     [
         "NsAttrMap",
-        "Style",
     ];
 
     private static readonly string[] LegacySettableScalarProperties =

--- a/src/Broiler.Cli.Tests/DomExtractionPhaseZeroTests.cs
+++ b/src/Broiler.Cli.Tests/DomExtractionPhaseZeroTests.cs
@@ -21,13 +21,15 @@ public sealed class DomExtractionPhaseZeroTests
         "NsAttrMap",
     ];
 
+    // RF-BRIDGE-1c Phase E relocated the facade Parent getter/setter to
+    // DomBridge.ParentEl / SetParent over canonical ParentNode, so Parent is no
+    // longer a settable scalar on the DomElement surface below.
     private static readonly string[] LegacySettableScalarProperties =
     [
         "ClassName",
         "Id",
         "InnerHtml",
         "NamespaceURI",
-        "Parent",
         "TextContent",
     ];
 
@@ -103,13 +105,13 @@ public sealed class DomExtractionPhaseZeroTests
 
         var head = Assert.Single(documentElement.Children, static child => child.TagName == "head");
         var body = Assert.Single(documentElement.Children, static child => child.TagName == "body");
-        Assert.Same(documentElement, head.Parent);
-        Assert.Same(documentElement, body.Parent);
+        Assert.Same(documentElement, head.ParentNode);
+        Assert.Same(documentElement, body.ParentNode);
 
         var host = Assert.Single(elements, static element => element.Id == "host");
-        Assert.Same(body, host.Parent);
+        Assert.Same(body, host.ParentNode);
         Assert.Equal(["span", "span"], host.Children.Select(static child => child.TagName));
-        Assert.All(host.Children, child => Assert.Same(host, child.Parent));
+        Assert.All(host.Children, child => Assert.Same(host, child.ParentNode));
     }
 
     [Fact]
@@ -158,7 +160,7 @@ public sealed class DomExtractionPhaseZeroTests
         var host = Assert.Single(bridge.Elements, static element => element.Id == "host");
         var created = Assert.Single(bridge.Elements, static element => element.Id == "created");
 
-        Assert.Same(host, created.Parent);
+        Assert.Same(host, created.ParentNode);
         Assert.Contains(created, host.Children);
         Assert.Contains("<section id=\"created\"></section>", bridge.SerializeToHtml(), StringComparison.Ordinal);
     }

--- a/src/Broiler.Cli.Tests/DomExtractionPhaseZeroTests.cs
+++ b/src/Broiler.Cli.Tests/DomExtractionPhaseZeroTests.cs
@@ -11,9 +11,11 @@ namespace Broiler.Cli.Tests;
 /// </summary>
 public sealed class DomExtractionPhaseZeroTests
 {
+    // RF-BRIDGE-1c Phase A relocated JsSetStyleProps and OwnerDocRoot off the facade
+    // into ElementRuntimeState (bridge runtime state the node model must not own), so
+    // they no longer appear on the DomElement surface below.
     private static readonly string[] LegacyMutableCollectionProperties =
     [
-        "JsSetStyleProps",
         "NsAttrMap",
         "Style",
     ];
@@ -24,7 +26,6 @@ public sealed class DomExtractionPhaseZeroTests
         "Id",
         "InnerHtml",
         "NamespaceURI",
-        "OwnerDocRoot",
         "Parent",
         "TextContent",
     ];

--- a/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
+++ b/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
@@ -56,7 +56,12 @@ public sealed class DomElement : CanonicalElement
         _children = new LegacyChildList(this);
         _attributes = new LegacyAttributeDictionary(this);
         InnerHtml = innerHtml;
-        Style = style ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        // RF-BRIDGE-1c Phase B: inline style is no longer stored on the node. It lives in
+        // ElementRuntimeState and is reached via DomBridge.InlineStyle(element), which lazily
+        // seeds it from the `style=` attribute (already applied from `attributes` below). The
+        // `style` parameter is retained only for call-site compatibility until construction
+        // flips to canonical factories (Phase F); it is intentionally not read here.
+        _ = style;
         IsTextNode = isTextNode || string.Equals(tagName, "#text", StringComparison.Ordinal);
 
         if (attributes is not null)
@@ -84,8 +89,6 @@ public sealed class DomElement : CanonicalElement
     }
 
     public string InnerHtml { get; set; }
-
-    public Dictionary<string, string> Style { get; }
 
     public new LegacyAttributeDictionary Attributes => _attributes;
 

--- a/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
+++ b/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
@@ -22,7 +22,6 @@ public sealed class DomElement : CanonicalElement
     public const string RemovalBoundaryVersion = "htmlbridge-public-surface/v2";
 
     private readonly LegacyChildList _children;
-    private readonly LegacyAttributeDictionary _attributes;
     private string? _textContent;
 
     public DomElement(
@@ -54,7 +53,6 @@ public sealed class DomElement : CanonicalElement
             ResolveNodeType(tagName, isTextNode))
     {
         _children = new LegacyChildList(this);
-        _attributes = new LegacyAttributeDictionary(this);
         InnerHtml = innerHtml;
         // RF-BRIDGE-1c Phase B: inline style is no longer stored on the node. It lives in
         // ElementRuntimeState and is reached via DomBridge.InlineStyle(element), which lazily
@@ -66,8 +64,11 @@ public sealed class DomElement : CanonicalElement
 
         if (attributes is not null)
         {
+            // Fresh node: no existing attributes to update in place, so a plain
+            // canonical SetAttribute (no-namespace) matches the old legacy-dictionary
+            // seeding exactly.
             foreach (var (name, value) in attributes)
-                _attributes[name] = value;
+                SetAttribute(name, value);
         }
 
         if (id is not null)
@@ -89,8 +90,6 @@ public sealed class DomElement : CanonicalElement
     }
 
     public string InnerHtml { get; set; }
-
-    public new LegacyAttributeDictionary Attributes => _attributes;
 
     public DomElement? Parent
     {
@@ -199,89 +198,4 @@ public sealed class DomElement : CanonicalElement
         public DomElement? Find(Predicate<DomElement> match) => owner.ChildNodes.Cast<DomElement>().FirstOrDefault(item => match(item));
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
-
-    public sealed class LegacyAttributeDictionary(DomElement owner) :
-        IDictionary<string, string>,
-        IReadOnlyDictionary<string, string>
-    {
-        public string this[string key]
-        {
-            get => Find(key)?.Value ?? throw new KeyNotFoundException(key);
-            set
-            {
-                var existing = Find(key);
-                if (existing is { } attribute)
-                    owner.SetAttributeNS(attribute.NamespaceUri, attribute.QualifiedName, value);
-                else
-                    owner.SetAttribute(key, value);
-            }
-        }
-
-        public ICollection<string> Keys => Snapshot().Keys;
-        public ICollection<string> Values => Snapshot().Values;
-        IEnumerable<string> IReadOnlyDictionary<string, string>.Keys => Keys;
-        IEnumerable<string> IReadOnlyDictionary<string, string>.Values => Values;
-        public int Count => owner.baseAttributes().Count;
-        public bool IsReadOnly => false;
-
-        public void Add(string key, string value) => this[key] = value;
-        public void Add(KeyValuePair<string, string> item) => Add(item.Key, item.Value);
-        public void Clear()
-        {
-            foreach (var key in Keys.ToArray())
-                owner.RemoveAttribute(key);
-        }
-
-        public bool Contains(KeyValuePair<string, string> item) =>
-            TryGetValue(item.Key, out var value) && string.Equals(value, item.Value, StringComparison.Ordinal);
-        public bool ContainsKey(string key) => Find(key) is not null;
-        public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex) =>
-            Snapshot().ToArray().CopyTo(array, arrayIndex);
-        public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => Snapshot().GetEnumerator();
-        public bool Remove(string key)
-        {
-            var existing = Find(key);
-            return existing is { } attribute &&
-                owner.RemoveAttributeNS(attribute.NamespaceUri, attribute.LocalName);
-        }
-        public bool Remove(KeyValuePair<string, string> item) => Contains(item) && Remove(item.Key);
-        public bool TryGetValue(string key, out string value)
-        {
-            var found = Find(key);
-            value = found?.Value ?? string.Empty;
-            return found is not null;
-        }
-
-        public string? GetValueOrDefault(string key) => Find(key)?.Value;
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        private Dictionary<string, string> Snapshot()
-        {
-            // Two attributes can collapse to the same key under case-insensitive
-            // comparison (e.g. an element carrying both `xml:lang` and `XML:LANG`,
-            // common in XHTML/XML fixtures). ToDictionary throws "An item with the
-            // same key has already been added" in that case, which aborts the whole
-            // snapshot (signature LegacyAttributeDictionary.Snapshot). Build the map
-            // defensively with last-wins semantics instead.
-            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var attribute in owner.baseAttributes().Values)
-                result[attribute.QualifiedName] = attribute.Value;
-            return result;
-        }
-
-        private Broiler.Dom.DomAttribute? Find(string qualifiedName)
-        {
-            foreach (var attribute in owner.baseAttributes().Values)
-            {
-                if (string.Equals(attribute.QualifiedName, qualifiedName, StringComparison.OrdinalIgnoreCase))
-                    return attribute;
-            }
-
-            return null;
-        }
-    }
-
-    private IReadOnlyDictionary<(string? NamespaceUri, string LocalName), Broiler.Dom.DomAttribute> baseAttributes() =>
-        base.Attributes;
 }

--- a/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
+++ b/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
@@ -21,7 +21,6 @@ public sealed class DomElement : CanonicalElement
     public const string CompatibilitySurfaceVersion = "htmlbridge-dom-adapter/v1";
     public const string RemovalBoundaryVersion = "htmlbridge-public-surface/v2";
 
-    private readonly LegacyChildList _children;
     private string? _textContent;
 
     public DomElement(
@@ -52,7 +51,6 @@ public sealed class DomElement : CanonicalElement
                 tagName),
             ResolveNodeType(tagName, isTextNode))
     {
-        _children = new LegacyChildList(this);
         InnerHtml = innerHtml;
         // RF-BRIDGE-1c Phase B: inline style is no longer stored on the node. It lives in
         // ElementRuntimeState and is reached via DomBridge.InlineStyle(element), which lazily
@@ -93,8 +91,6 @@ public sealed class DomElement : CanonicalElement
     }
 
     public string InnerHtml { get; set; }
-
-    public LegacyChildList Children => _children;
 
     public string? TextContent
     {
@@ -137,54 +133,4 @@ public sealed class DomElement : CanonicalElement
                     ? CanonicalNodeType.DocumentType
                     : CanonicalNodeType.Element;
 
-    public sealed class LegacyChildList(DomElement owner) : IList<DomElement>
-    {
-        public DomElement this[int index]
-        {
-            get => (DomElement)owner.ChildNodes[index];
-            set => owner.ReplaceChild(value, owner.ChildNodes[index]);
-        }
-
-        public int Count => owner.ChildNodes.Count;
-        public bool IsReadOnly => false;
-
-        public void Add(DomElement item) => owner.AppendChild(item);
-        public void Clear()
-        {
-            foreach (var child in owner.ChildNodes.ToArray())
-                owner.RemoveChild(child);
-        }
-
-        public bool Contains(DomElement item) => owner.ChildNodes.Contains(item);
-        public void CopyTo(DomElement[] array, int arrayIndex) =>
-            owner.ChildNodes.Cast<DomElement>().ToArray().CopyTo(array, arrayIndex);
-        public IEnumerator<DomElement> GetEnumerator() => owner.ChildNodes.Cast<DomElement>().GetEnumerator();
-        public int IndexOf(DomElement item)
-        {
-            for (var index = 0; index < owner.ChildNodes.Count; index++)
-            {
-                if (ReferenceEquals(owner.ChildNodes[index], item))
-                    return index;
-            }
-
-            return -1;
-        }
-        public void Insert(int index, DomElement item)
-        {
-            var reference = index < Count ? owner.ChildNodes[index] : null;
-            owner.InsertBefore(item, reference);
-        }
-
-        public bool Remove(DomElement item)
-        {
-            if (!ReferenceEquals(item.ParentNode, owner))
-                return false;
-            owner.RemoveChild(item);
-            return true;
-        }
-
-        public void RemoveAt(int index) => owner.RemoveChild(owner.ChildNodes[index]);
-        public DomElement? Find(Predicate<DomElement> match) => owner.ChildNodes.Cast<DomElement>().FirstOrDefault(item => match(item));
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-    }
 }

--- a/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
+++ b/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
@@ -127,15 +127,11 @@ public sealed class DomElement : CanonicalElement
     /// </summary>
     public override string? NodeValue => IsTextNode ? _textContent : base.NodeValue;
 
-    public HashSet<string> JsSetStyleProps { get; } = new(StringComparer.OrdinalIgnoreCase);
-
     public string? NamespaceURI
     {
         get => NamespaceUri;
         set => SetName(new CanonicalName(value, TagName));
     }
-
-    public DomElement? OwnerDocRoot { get; set; }
 
     public Dictionary<(string? Namespace, string LocalName), string> NsAttrMap { get; } = [];
 

--- a/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
+++ b/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
@@ -60,7 +60,10 @@ public sealed class DomElement : CanonicalElement
         // `style` parameter is retained only for call-site compatibility until construction
         // flips to canonical factories (Phase F); it is intentionally not read here.
         _ = style;
-        IsTextNode = isTextNode || string.Equals(tagName, "#text", StringComparison.Ordinal);
+        // RF-BRIDGE-1c Phase D: text-node identity is the canonical NodeType (set from
+        // ResolveNodeType in the base call above), reached via DomBridge.IsText(node). The
+        // `isTextNode` parameter still drives ResolveNodeType; there is no separate flag.
+        _ = isTextNode;
 
         if (attributes is not null)
         {
@@ -93,8 +96,6 @@ public sealed class DomElement : CanonicalElement
 
     public LegacyChildList Children => _children;
 
-    public bool IsTextNode { get; }
-
     public string? TextContent
     {
         get => _textContent;
@@ -112,10 +113,10 @@ public sealed class DomElement : CanonicalElement
     /// Exposes a text node's content through the canonical <see cref="CanonicalElement.NodeValue"/>
     /// so engine-neutral consumers (notably the renderer's typed DOM-to-box builder) can read
     /// bridge text without depending on this facade type. The bridge models text nodes as a
-    /// <see cref="DomElement"/> with <see cref="IsTextNode"/> set rather than a canonical
+    /// <see cref="DomElement"/> with a text <see cref="CanonicalNodeType"/> rather than a canonical
     /// <c>DomText</c>, so <c>NodeValue</c> is the only canonical bridge for that text.
     /// </summary>
-    public override string? NodeValue => IsTextNode ? _textContent : base.NodeValue;
+    public override string? NodeValue => NodeType == CanonicalNodeType.Text ? _textContent : base.NodeValue;
 
     public string? NamespaceURI
     {

--- a/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
+++ b/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
@@ -91,18 +91,6 @@ public sealed class DomElement : CanonicalElement
 
     public string InnerHtml { get; set; }
 
-    public DomElement? Parent
-    {
-        get => ParentNode as DomElement;
-        set
-        {
-            if (value is null)
-                Remove();
-            else if (!ReferenceEquals(ParentNode, value))
-                value.AppendChild(this);
-        }
-    }
-
     public LegacyChildList Children => _children;
 
     public bool IsTextNode { get; }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ComputedStyleEngine.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ComputedStyleEngine.cs
@@ -98,7 +98,7 @@ public sealed partial class DomBridge
     /// <paramref name="element"/> from matching stylesheet rules (no inline styles,
     /// inheritance, or initial-value backfill), via the shared style engine. This
     /// replaces the legacy <c>foreach (… in CssRules) if (MatchesSelector(…))</c>
-    /// collection loops; callers still merge <c>element.Style</c> on top as before.
+    /// collection loops; callers still merge <c>InlineStyle(element)</c> on top as before.
     /// </summary>
     private Dictionary<string, string> CollectMatchedRuleProperties(DomElement element) =>
         new(GetSyncedScopedEngine(element).GetCascadedDeclaredValues(element), StringComparer.OrdinalIgnoreCase);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -83,7 +83,7 @@ public sealed partial class DomBridge
         for (var i = log.Count - 1; i >= 0; i--)
         {
             var (element, style, attributes) = log[i];
-            RestoreStringMap(element.Style, style);
+            RestoreStringMap(InlineStyle(element), style);
             RestoreStringMap(element.Attributes, attributes);
         }
 
@@ -102,7 +102,7 @@ public sealed partial class DomBridge
     {
         if (!element.IsTextNode && !element.TagName.StartsWith('#'))
         {
-            if (element.Style.Count == 0)
+            if (InlineStyle(element).Count == 0)
             {
                 element.Attributes.Remove("style");
             }
@@ -110,7 +110,7 @@ public sealed partial class DomBridge
             {
                 var styleText = string.Join(
                     "; ",
-                    element.Style
+                    InlineStyle(element)
                         .OrderBy(kv => SharedHtmlSerializer.IsShorthandProperty(kv.Key) ? 0 : 1)
                         .Select(static kv => $"{kv.Key}: {kv.Value}"));
                 if (!element.Attributes.TryGetValue("style", out var currentStyle) ||
@@ -304,26 +304,26 @@ public sealed partial class DomBridge
         var reverseInline = string.Equals(direction, "rtl", StringComparison.OrdinalIgnoreCase);
         var ratio = ResolveProgressLikeValueRatio(element, tag);
 
-        element.Style["display"] = "inline-block";
-        element.Style["box-sizing"] = "border-box";
-        element.Style["position"] = "relative";
-        element.Style["overflow"] = "hidden";
-        element.Style["padding"] = "0";
-        element.Style["border"] = "1px solid #767676";
-        element.Style["background-color"] = tag == "meter" ? "#e6e6e6" : "#f0f0f0";
-        element.Style["vertical-align"] = "middle";
+        InlineStyle(element)["display"] = "inline-block";
+        InlineStyle(element)["box-sizing"] = "border-box";
+        InlineStyle(element)["position"] = "relative";
+        InlineStyle(element)["overflow"] = "hidden";
+        InlineStyle(element)["padding"] = "0";
+        InlineStyle(element)["border"] = "1px solid #767676";
+        InlineStyle(element)["background-color"] = tag == "meter" ? "#e6e6e6" : "#f0f0f0";
+        InlineStyle(element)["vertical-align"] = "middle";
         if (!string.IsNullOrWhiteSpace(width) && !string.Equals(width, "auto", StringComparison.OrdinalIgnoreCase))
-            element.Style["width"] = width;
+            InlineStyle(element)["width"] = width;
         if (!string.IsNullOrWhiteSpace(height) && !string.Equals(height, "auto", StringComparison.OrdinalIgnoreCase))
-            element.Style["height"] = height;
+            InlineStyle(element)["height"] = height;
 
         element.Children.Clear();
         element.InnerHtml = string.Empty;
         element.TextContent = null;
 
         var fill = new DomElement("div", null, null, string.Empty) { Parent = element };
-        fill.Style["position"] = "absolute";
-        fill.Style["background-color"] = tag == "meter" ? "#4caf50" : "#0a84ff";
+        InlineStyle(fill)["position"] = "absolute";
+        InlineStyle(fill)["background-color"] = tag == "meter" ? "#4caf50" : "#0a84ff";
 
         var fillExtent = vertical
             ? ReadPixelLength(height, DefaultProgressLikeTrackLengthPx) * ratio
@@ -331,17 +331,17 @@ public sealed partial class DomBridge
         var fillExtentPx = $"{fillExtent.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)}px";
         if (vertical)
         {
-            fill.Style["left"] = "0";
-            fill.Style["right"] = "0";
-            fill.Style[reverseInline ? "bottom" : "top"] = "0";
-            fill.Style["height"] = fillExtentPx;
+            InlineStyle(fill)["left"] = "0";
+            InlineStyle(fill)["right"] = "0";
+            InlineStyle(fill)[reverseInline ? "bottom" : "top"] = "0";
+            InlineStyle(fill)["height"] = fillExtentPx;
         }
         else
         {
-            fill.Style["top"] = "0";
-            fill.Style["bottom"] = "0";
-            fill.Style[reverseInline ? "right" : "left"] = "0";
-            fill.Style["width"] = fillExtentPx;
+            InlineStyle(fill)["top"] = "0";
+            InlineStyle(fill)["bottom"] = "0";
+            InlineStyle(fill)[reverseInline ? "right" : "left"] = "0";
+            InlineStyle(fill)["width"] = fillExtentPx;
         }
 
         element.Children.Add(fill);
@@ -403,10 +403,10 @@ public sealed partial class DomBridge
         var willSvg = ShouldApplySvgSerializationAttributes(element);
         // Record the pre-bake state for the geometry-snapshot revert (only when this element
         // is actually mutated — scaled, SVG-adjusted, or carrying a `zoom` to strip).
-        if (_zoomSerializationRevertLog != null && (willScale || willSvg || element.Style.ContainsKey("zoom")))
+        if (_zoomSerializationRevertLog != null && (willScale || willSvg || InlineStyle(element).ContainsKey("zoom")))
             _zoomSerializationRevertLog.Add((
                 element,
-                new Dictionary<string, string>(element.Style),
+                new Dictionary<string, string>(InlineStyle(element)),
                 new Dictionary<string, string>(element.Attributes)));
 
         if (willScale)
@@ -417,7 +417,7 @@ public sealed partial class DomBridge
                     continue;
 
                 if (TryScaleSerializableCssValue(value, usedZoom, out var scaled))
-                    element.Style[property] = scaled;
+                    InlineStyle(element)[property] = scaled;
             }
 
         }
@@ -425,7 +425,7 @@ public sealed partial class DomBridge
         if (willSvg)
             ApplyZoomSerializationSvgAttributes(element, usedZoom);
 
-        element.Style.Remove("zoom");
+        InlineStyle(element).Remove("zoom");
 
         foreach (var child in element.Children)
             ApplyZoomSerializationStyles(child, usedZoom);
@@ -458,7 +458,7 @@ public sealed partial class DomBridge
         if (props.TryGetValue(property, out value) && !string.IsNullOrWhiteSpace(value))
             return true;
 
-        if (!element.Style.TryGetValue(property, out var specified) ||
+        if (!InlineStyle(element).TryGetValue(property, out var specified) ||
             !string.Equals(specified?.Trim(), "inherit", StringComparison.OrdinalIgnoreCase) ||
             element.Parent == null)
         {
@@ -469,7 +469,7 @@ public sealed partial class DomBridge
         if (parentProps.TryGetValue(property, out value) && !string.IsNullOrWhiteSpace(value))
             return true;
 
-        if (element.Parent.Style.TryGetValue(property, out value) && !string.IsNullOrWhiteSpace(value))
+        if (InlineStyle(element.Parent!).TryGetValue(property, out value) && !string.IsNullOrWhiteSpace(value))
             return true;
 
         return false;
@@ -569,7 +569,7 @@ public sealed partial class DomBridge
             return;
 
         string? value = null;
-        if (preferInlineStyle && element.Style.TryGetValue(propertyName, out var inlineValue) && !string.IsNullOrWhiteSpace(inlineValue))
+        if (preferInlineStyle && InlineStyle(element).TryGetValue(propertyName, out var inlineValue) && !string.IsNullOrWhiteSpace(inlineValue))
             value = inlineValue;
         else if (props.TryGetValue(propertyName, out var propValue) && !string.IsNullOrWhiteSpace(propValue))
             value = propValue;
@@ -872,7 +872,7 @@ public sealed partial class DomBridge
             !string.Equals(child.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase)),
         GetAttributes: GetSerializableAttributes,
         GetStyles: static element =>
-            element.Style.OrderBy(kv => SharedHtmlSerializer.IsShorthandProperty(kv.Key) ? 0 : 1),
+            InlineStyle(element).OrderBy(kv => SharedHtmlSerializer.IsShorthandProperty(kv.Key) ? 0 : 1),
         GetText: static element => element.TextContent,
         GetRawInnerHtml: static element => element.InnerHtml);
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -129,7 +129,7 @@ public sealed partial class DomBridge
             }
         }
 
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
             ReflectRenderState(child);
     }
 
@@ -139,7 +139,7 @@ public sealed partial class DomBridge
             CreateSerializationAdapter(),
             new HtmlSerializationOptions(MaximumDepth: MaxSerializationDepth, EncodeTextNodes: false));
 
-    private string SerializeChildrenToHtml(DomElement element) => string.Concat(element.Children.Select(SerializeElementToHtml));
+    private string SerializeChildrenToHtml(DomElement element) => string.Concat(ChildElements(element).Select(SerializeElementToHtml));
 
     private void ApplySerializationTransforms()
     {
@@ -172,12 +172,12 @@ public sealed partial class DomBridge
     /// </summary>
     private static void RemoveRenderCommentNodes(DomElement element)
     {
-        for (int i = element.Children.Count - 1; i >= 0; i--)
+        for (int i = element.ChildNodes.Count - 1; i >= 0; i--)
         {
-            var child = element.Children[i];
+            var child = ChildAt(element, i);
             if (string.Equals(child.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
             {
-                element.Children.RemoveAt(i);
+                RemoveNthChild(element, i);
                 continue;
             }
 
@@ -202,12 +202,12 @@ public sealed partial class DomBridge
         if (head != null)
         {
             SetParent(styleElement, head);
-            head.Children.Add(styleElement);
+            head.AppendChild(styleElement);
             return;
         }
 
         SetParent(styleElement, DocumentElement);
-        DocumentElement.Children.Insert(0, styleElement);
+        InsertChildAt(DocumentElement, 0, styleElement);
     }
 
     private void CollectZoomPseudoSerializationOverrides(
@@ -229,7 +229,7 @@ public sealed partial class DomBridge
             AppendZoomPseudoSerializationOverride(element, "::after", usedZoom, rules, ref pseudoIndex);
         }
 
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
             CollectZoomPseudoSerializationOverrides(child, usedZoom, rules, ref pseudoIndex);
     }
 
@@ -273,7 +273,7 @@ public sealed partial class DomBridge
         if (string.Equals(root.TagName, tagName, StringComparison.OrdinalIgnoreCase))
             return root;
 
-        foreach (var child in root.Children)
+        foreach (var child in ChildElements(root))
         {
             var match = FindFirstElementByTagName(child, tagName);
             if (match != null)
@@ -288,7 +288,7 @@ public sealed partial class DomBridge
         if (IsText(element))
             return;
 
-        foreach (var child in element.Children.ToList())
+        foreach (var child in ChildElements(element).ToList())
             ApplyProgressLikeSerializationPlaceholders(child);
 
         var tag = element.TagName.ToLowerInvariant();
@@ -317,7 +317,7 @@ public sealed partial class DomBridge
         if (!string.IsNullOrWhiteSpace(height) && !string.Equals(height, "auto", StringComparison.OrdinalIgnoreCase))
             InlineStyle(element)["height"] = height;
 
-        element.Children.Clear();
+        ClearChildren(element);
         element.InnerHtml = string.Empty;
         element.TextContent = null;
 
@@ -345,7 +345,7 @@ public sealed partial class DomBridge
             InlineStyle(fill)["width"] = fillExtentPx;
         }
 
-        element.Children.Add(fill);
+        element.AppendChild(fill);
     }
 
     private static double ResolveProgressLikeValueRatio(DomElement element, string tag)
@@ -428,7 +428,7 @@ public sealed partial class DomBridge
 
         InlineStyle(element).Remove("zoom");
 
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
             ApplyZoomSerializationStyles(child, usedZoom);
     }
 
@@ -869,7 +869,7 @@ public sealed partial class DomBridge
         // embedded p{background:green;height:100%} painted the whole parent green).
         // The renderer rasterises each embedded document in isolation instead
         // (srcdoc content is round-tripped via the srcdoc attribute).
-        GetChildren: static element => element.Children.Where(static child =>
+        GetChildren: static element => ChildElements(element).Where(static child =>
             !string.Equals(child.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase)),
         GetAttributes: GetSerializableAttributes,
         GetStyles: static element =>
@@ -920,12 +920,12 @@ public sealed partial class DomBridge
             return null;
         }
 
-        var subDocumentRoot = element.Children.FirstOrDefault(child =>
+        var subDocumentRoot = ChildElements(element).FirstOrDefault(child =>
             string.Equals(child.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase));
-        if (subDocumentRoot == null || subDocumentRoot.Children.Count == 0)
+        if (subDocumentRoot == null || subDocumentRoot.ChildNodes.Count == 0)
             return null;
 
-        return string.Concat(subDocumentRoot.Children.Select(SerializeElementToHtml));
+        return string.Concat(ChildElements(subDocumentRoot).Select(SerializeElementToHtml));
     }
 
     [GeneratedRegex(@"-?\d*\.?\d+(?:[eE][+-]?\d+)?")]

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -201,12 +201,12 @@ public sealed partial class DomBridge
         var head = FindFirstElementByTagName(DocumentElement, "head");
         if (head != null)
         {
-            styleElement.Parent = head;
+            SetParent(styleElement, head);
             head.Children.Add(styleElement);
             return;
         }
 
-        styleElement.Parent = DocumentElement;
+        SetParent(styleElement, DocumentElement);
         DocumentElement.Children.Insert(0, styleElement);
     }
 
@@ -321,7 +321,8 @@ public sealed partial class DomBridge
         element.InnerHtml = string.Empty;
         element.TextContent = null;
 
-        var fill = new DomElement("div", null, null, string.Empty) { Parent = element };
+        var fill = new DomElement("div", null, null, string.Empty);
+        SetParent(fill, element);
         InlineStyle(fill)["position"] = "absolute";
         InlineStyle(fill)["background-color"] = tag == "meter" ? "#4caf50" : "#0a84ff";
 
@@ -460,16 +461,16 @@ public sealed partial class DomBridge
 
         if (!InlineStyle(element).TryGetValue(property, out var specified) ||
             !string.Equals(specified?.Trim(), "inherit", StringComparison.OrdinalIgnoreCase) ||
-            element.Parent == null)
+            ParentEl(element) == null)
         {
             return false;
         }
 
-        var parentProps = GetComputedProps(element.Parent);
+        var parentProps = GetComputedProps(ParentEl(element));
         if (parentProps.TryGetValue(property, out value) && !string.IsNullOrWhiteSpace(value))
             return true;
 
-        if (InlineStyle(element.Parent!).TryGetValue(property, out value) && !string.IsNullOrWhiteSpace(value))
+        if (InlineStyle(ParentEl(element)!).TryGetValue(property, out value) && !string.IsNullOrWhiteSpace(value))
             return true;
 
         return false;
@@ -682,7 +683,7 @@ public sealed partial class DomBridge
 
     private double ResolveOriginalNearestSpecifiedFontSizePx(DomElement element)
     {
-        for (DomElement? current = element; current != null; current = current.Parent)
+        for (DomElement? current = element; current != null; current = ParentEl(current))
         {
             if (TryGetSpecifiedFontSizePx(current, out var fontSize))
                 return fontSize;
@@ -745,7 +746,7 @@ public sealed partial class DomBridge
 
     private double GetNearestExplicitFontSizeOwnerZoom(DomElement element)
     {
-        for (DomElement? current = element; current != null; current = current.Parent)
+        for (DomElement? current = element; current != null; current = ParentEl(current))
         {
             var props = GetComputedProps(current);
             if (props.TryGetValue("font-size", out var fontSize) && !string.IsNullOrWhiteSpace(fontSize))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -100,7 +100,7 @@ public sealed partial class DomBridge
 
     private void ReflectRenderState(DomElement element)
     {
-        if (!element.IsTextNode && !element.TagName.StartsWith('#'))
+        if (!IsText(element) && !element.TagName.StartsWith('#'))
         {
             if (InlineStyle(element).Count == 0)
             {
@@ -216,7 +216,7 @@ public sealed partial class DomBridge
         List<string> rules,
         ref int pseudoIndex)
     {
-        if (element.IsTextNode)
+        if (IsText(element))
             return;
 
         var props = GetComputedProps(element);
@@ -285,7 +285,7 @@ public sealed partial class DomBridge
 
     private void ApplyProgressLikeSerializationPlaceholders(DomElement element)
     {
-        if (element.IsTextNode)
+        if (IsText(element))
             return;
 
         foreach (var child in element.Children.ToList())
@@ -393,7 +393,7 @@ public sealed partial class DomBridge
 
     private void ApplyZoomSerializationStyles(DomElement element, double parentZoom)
     {
-        if (element.IsTextNode)
+        if (IsText(element))
             return;
 
         var props = GetComputedProps(element);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -84,7 +84,7 @@ public sealed partial class DomBridge
         {
             var (element, style, attributes) = log[i];
             RestoreStringMap(InlineStyle(element), style);
-            RestoreStringMap(element.Attributes, attributes);
+            RestoreAttributes(element, attributes);
         }
 
         // Reverted styles must not read back the baked values from the computed cache.
@@ -104,7 +104,7 @@ public sealed partial class DomBridge
         {
             if (InlineStyle(element).Count == 0)
             {
-                element.Attributes.Remove("style");
+                RemoveAttr(element, "style");
             }
             else
             {
@@ -113,19 +113,19 @@ public sealed partial class DomBridge
                     InlineStyle(element)
                         .OrderBy(kv => SharedHtmlSerializer.IsShorthandProperty(kv.Key) ? 0 : 1)
                         .Select(static kv => $"{kv.Key}: {kv.Value}"));
-                if (!element.Attributes.TryGetValue("style", out var currentStyle) ||
+                if (!TryGetAttribute(element, "style", out var currentStyle) ||
                     !string.Equals(currentStyle, styleText, StringComparison.Ordinal))
                 {
-                    element.Attributes["style"] = styleText;
+                    SetAttr(element, "style", styleText);
                 }
             }
 
             if (element.TagName.Equals("input", StringComparison.OrdinalIgnoreCase) &&
-                !element.Attributes.ContainsKey("value") &&
+                !HasAttr(element, "value") &&
                 GetElementRuntimeState(element).FormControl.Value.TryGet(out var idlValue) &&
                 idlValue is string { Length: > 0 } idlString)
             {
-                element.Attributes["value"] = idlString;
+                SetAttr(element, "value", idlString);
             }
         }
 
@@ -360,7 +360,7 @@ public sealed partial class DomBridge
 
     private static double ReadNumericAttribute(DomElement element, string attributeName, double fallback)
     {
-        if (!element.Attributes.TryGetValue(attributeName, out var rawValue) || string.IsNullOrWhiteSpace(rawValue))
+        if (!TryGetAttribute(element, attributeName, out var rawValue) || string.IsNullOrWhiteSpace(rawValue))
             return fallback;
 
         return double.TryParse(
@@ -407,7 +407,7 @@ public sealed partial class DomBridge
             _zoomSerializationRevertLog.Add((
                 element,
                 new Dictionary<string, string>(InlineStyle(element)),
-                new Dictionary<string, string>(element.Attributes)));
+                AttributeSnapshot(element)));
 
         if (willScale)
         {
@@ -565,7 +565,7 @@ public sealed partial class DomBridge
         string propertyName,
         bool preferInlineStyle = false)
     {
-        if (element.Attributes.ContainsKey(propertyName))
+        if (HasAttr(element, propertyName))
             return;
 
         string? value = null;
@@ -579,34 +579,34 @@ public sealed partial class DomBridge
         if (string.IsNullOrWhiteSpace(value))
             return;
 
-        element.Attributes[propertyName] = value.Trim();
+        SetAttr(element, propertyName, value.Trim());
     }
 
     private void ScaleSvgLengthAttribute(DomElement element, string attributeName, double usedZoom)
     {
-        if (!element.Attributes.TryGetValue(attributeName, out var value) ||
+        if (!TryGetAttribute(element, attributeName, out var value) ||
             !TryScaleSvgLengthToken(element, value, usedZoom, out var scaled))
         {
             return;
         }
 
-        element.Attributes[attributeName] = scaled;
+        SetAttr(element, attributeName, scaled);
     }
 
     private void ScaleSvgPointListAttribute(DomElement element, string attributeName, double usedZoom)
     {
-        if (!element.Attributes.TryGetValue(attributeName, out var value) || string.IsNullOrWhiteSpace(value))
+        if (!TryGetAttribute(element, attributeName, out var value) || string.IsNullOrWhiteSpace(value))
             return;
 
-        element.Attributes[attributeName] = ScaleSvgPointRegex().Replace(value, match => ScaleSvgNumericMatch(match, usedZoom));
+        SetAttr(element, attributeName, ScaleSvgPointRegex().Replace(value, match => ScaleSvgNumericMatch(match, usedZoom)));
     }
 
     private void ScaleSvgPathDataAttribute(DomElement element, string attributeName, double usedZoom)
     {
-        if (!element.Attributes.TryGetValue(attributeName, out var value) || string.IsNullOrWhiteSpace(value))
+        if (!TryGetAttribute(element, attributeName, out var value) || string.IsNullOrWhiteSpace(value))
             return;
 
-        element.Attributes[attributeName] = ScaleSvgPathRegex().Replace(value, match => ScaleSvgNumericMatch(match, usedZoom));
+        SetAttr(element, attributeName, ScaleSvgPathRegex().Replace(value, match => ScaleSvgNumericMatch(match, usedZoom)));
     }
 
     private static string ScaleSvgNumericMatch(Match match, double factor)
@@ -884,8 +884,10 @@ public sealed partial class DomBridge
             yield return new("class", element.ClassName);
 
         var serializedSrcDoc = TrySerializeCurrentSrcDoc(element);
-        foreach (var (name, value) in element.Attributes)
+        foreach (var attribute in element.Attributes.Values)
         {
+            var name = attribute.QualifiedName;
+            var value = attribute.Value;
             if (name.Equals("id", StringComparison.OrdinalIgnoreCase) ||
                 name.Equals("class", StringComparison.OrdinalIgnoreCase) ||
                 name.Equals("style", StringComparison.OrdinalIgnoreCase))
@@ -901,7 +903,7 @@ public sealed partial class DomBridge
         }
 
         if (element.TagName.Equals("input", StringComparison.OrdinalIgnoreCase) &&
-            !element.Attributes.ContainsKey("value") &&
+            !HasAttr(element, "value") &&
             GetElementRuntimeState(element).FormControl.Value.TryGet(out var idlValue) &&
             idlValue is string { Length: > 0 } idlString)
         {
@@ -912,7 +914,7 @@ public sealed partial class DomBridge
     private string? TrySerializeCurrentSrcDoc(DomElement element)
     {
         if (!string.Equals(element.TagName, "iframe", StringComparison.OrdinalIgnoreCase) ||
-            !element.Attributes.ContainsKey("srcdoc"))
+            !HasAttr(element, "srcdoc"))
         {
             return null;
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -156,7 +156,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         _documentNode = new DomElement(_document, "#document", null, null, string.Empty);
         DocumentElement = new DomElement(_document, "html", null, null, string.Empty);
         _document.AppendChild(_documentNode);
-        _documentNode.Children.Add(DocumentElement);
+        _documentNode.AppendChild(DocumentElement);
     }
 
     /// <summary>
@@ -188,6 +188,70 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// attribute; thereafter it is the source of truth (JS <c>element.style</c> writes,
     /// anchor/form-control styling), synced back to the attribute at serialization.
     /// </summary>
+    // -----------------------------------------------------------------
+    // RF-BRIDGE-1c Phase E2: child-node access over canonical ChildNodes,
+    // replacing the facade DomElement.Children (LegacyChildList). The bridge
+    // tree is homogeneous DomElement today, so ChildElements is a drop-in for
+    // the old enumeration; the Cast/ChildAt casts are safe until text/comment
+    // flip to canonical DomText/DomComment (Phase F), when ChildElements narrows
+    // to OfType and callers gain IsText handling.
+    // -----------------------------------------------------------------
+
+    /// <summary>The element's child nodes as <see cref="DomElement"/> (drop-in for the old
+    /// <c>element.Children</c> enumeration).</summary>
+    private static IEnumerable<DomElement> ChildElements(DomElement element) =>
+        element.ChildNodes.Cast<DomElement>();
+
+    /// <summary>The child at <paramref name="index"/> (old <c>Children[index]</c>).</summary>
+    private static DomElement ChildAt(DomElement element, int index) => (DomElement)element.ChildNodes[index];
+
+    /// <summary>The child at <paramref name="index"/>, supporting from-end indices like <c>^1</c>
+    /// (old <c>Children[^1]</c>); canonical <c>ChildNodes</c> is an <c>IReadOnlyList</c> with no
+    /// from-end indexer.</summary>
+    private static DomElement ChildAt(DomElement element, System.Index index) =>
+        (DomElement)element.ChildNodes[index.GetOffset(element.ChildNodes.Count)];
+
+    /// <summary>Index of <paramref name="child"/> among the element's children, or -1
+    /// (old <c>Children.IndexOf</c>, reference equality).</summary>
+    private static int ChildIndexOf(DomElement element, Broiler.Dom.DomNode child)
+    {
+        for (var i = 0; i < element.ChildNodes.Count; i++)
+        {
+            if (ReferenceEquals(element.ChildNodes[i], child))
+                return i;
+        }
+
+        return -1;
+    }
+
+    /// <summary>Old <c>Children.Insert(index, child)</c>.</summary>
+    private static void InsertChildAt(DomElement parent, int index, Broiler.Dom.DomNode child)
+    {
+        var reference = index < parent.ChildNodes.Count ? parent.ChildNodes[index] : null;
+        parent.InsertBefore(child, reference);
+    }
+
+    /// <summary>Old <c>Children.Remove(child)</c> — removes only if actually a child; returns success.</summary>
+    private static bool RemoveChildFrom(DomElement parent, Broiler.Dom.DomNode child)
+    {
+        if (!ReferenceEquals(child.ParentNode, parent))
+            return false;
+
+        parent.RemoveChild(child);
+        return true;
+    }
+
+    /// <summary>Old raw <c>Children.RemoveAt(index)</c> (no mutation notifications — matches the
+    /// LegacyChildList primitive; distinct from the notifying <c>RemoveChildAt</c> helper).</summary>
+    private static void RemoveNthChild(DomElement parent, int index) => parent.RemoveChild(parent.ChildNodes[index]);
+
+    /// <summary>Old <c>Children.Clear()</c>.</summary>
+    private static void ClearChildren(DomElement parent)
+    {
+        foreach (var child in parent.ChildNodes.ToArray())
+            parent.RemoveChild(child);
+    }
+
     /// <summary>Whether <paramref name="node"/> is a text node (RF-BRIDGE-1c Phase D: replaces
     /// the facade <c>IsText(DomElement)</c>). NodeType-based, so it holds for the current
     /// facade text nodes and for canonical <c>DomText</c> once construction flips in the
@@ -575,7 +639,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         DomElement? body = null;
         if (htmlEl != null)
         {
-            body = htmlEl.Children.FirstOrDefault(c =>
+            body = ChildElements(htmlEl).FirstOrDefault(c =>
                 string.Equals(c.TagName, "body", StringComparison.OrdinalIgnoreCase));
         }
         if (body == null) return;
@@ -676,7 +740,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
 
     private void CollectWindowFrames(DomElement element, List<JSValue> frames)
     {
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
         {
             if (IsText(child))
                 continue;
@@ -725,7 +789,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         _knownNodes.Clear();
         _jsObjectCache.Clear();
         _computedPropsCache.Clear();
-        _documentNode.Children.Clear();
+        ClearChildren(_documentNode);
         _serializationTransformsApplied = false;
 
         // Parse DOCTYPE from the HTML and add it as first child of _documentNode
@@ -733,7 +797,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         if (doctype != null)
         {
             SetParent(doctype, _documentNode);
-            _documentNode.Children.Add(doctype);
+            _documentNode.AppendChild(doctype);
             _knownNodes.Add(doctype);
         }
 
@@ -749,11 +813,11 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         var builder = new HtmlTreeBuilder();
         var (docElement, allElements, title) = builder.Build(html, _document);
         Title = title;
-        DocumentElement.Children.Clear();
-        foreach (var child in docElement.Children.ToArray())
+        ClearChildren(DocumentElement);
+        foreach (var child in ChildElements(docElement).ToArray())
         {
             SetParent(child, DocumentElement);
-            DocumentElement.Children.Add(child);
+            DocumentElement.AppendChild(child);
         }
 
         // Copy attributes from the parsed <html> element to DocumentElement
@@ -773,8 +837,8 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         // Connect DocumentElement to _documentNode so that document.firstChild works
         // and structural pseudo-classes correctly detect the document root boundary
         SetParent(DocumentElement, _documentNode);
-        if (!_documentNode.Children.Contains(DocumentElement))
-            _documentNode.Children.Add(DocumentElement);
+        if (!_documentNode.ChildNodes.Contains(DocumentElement))
+            _documentNode.AppendChild(DocumentElement);
 
         _knownNodes.Add(DocumentElement);
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -181,6 +181,29 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     private static ElementRuntimeState GetElementRuntimeState(DomElement element) =>
         ElementRuntimeStates.GetValue(element, static _ => new ElementRuntimeState());
 
+    /// <summary>
+    /// The element's authoritative in-memory inline style dictionary (CSS kebab-case),
+    /// relocated off the <c>DomElement</c> facade into <see cref="ElementRuntimeState"/>
+    /// (RF-BRIDGE-1c Phase B). Lazily seeded once from the element's <c>style=</c>
+    /// attribute; thereafter it is the source of truth (JS <c>element.style</c> writes,
+    /// anchor/form-control styling), synced back to the attribute at serialization.
+    /// </summary>
+    private static Dictionary<string, string> InlineStyle(DomElement element)
+    {
+        var state = GetElementRuntimeState(element);
+        if (!state.StyleSeeded)
+        {
+            state.StyleSeeded = true;
+            var styleAttr = element.GetAttribute("style");
+            if (!string.IsNullOrEmpty(styleAttr))
+            {
+                foreach (var kv in ParseStyle(styleAttr))
+                    state.Style[kv.Key] = kv.Value;
+            }
+        }
+        return state.Style;
+    }
+
     private static Dictionary<string, List<EventListenerRegistration>> GetEventListeners(DomElement element) =>
         GetElementRuntimeState(element).EventListeners;
 
@@ -719,8 +742,8 @@ public sealed partial class DomBridge : IDomBridgeRuntime
             DocumentElement.ClassName = docElement.ClassName;
         foreach (var kv in docElement.Attributes)
             DocumentElement.Attributes[kv.Key] = kv.Value;
-        foreach (var kv in docElement.Style)
-            DocumentElement.Style[kv.Key] = kv.Value;
+        foreach (var kv in InlineStyle(docElement))
+            InlineStyle(DocumentElement)[kv.Key] = kv.Value;
 
         _knownNodes.UnionWith(allElements);
 
@@ -807,7 +830,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// from the survivors of this filter (see <c>PrepareCanonicalDocumentForRendering</c>),
     /// so a dropped inline declaration vanishes before the renderer's own style engine
     /// can report it — this is the only place such drops are observable. Set it only at
-    /// inline-style <em>ingestion</em> sites that write <c>element.Style</c> (so the drop
+    /// inline-style <em>ingestion</em> sites that write <c>InlineStyle(element)</c> (so the drop
     /// reaches the rendered output); leave it off for query/bookkeeping re-parses and for
     /// stylesheet-rule / descriptor parsing (cascade drops the style engine already reports).
     /// </param>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -188,6 +188,23 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// attribute; thereafter it is the source of truth (JS <c>element.style</c> writes,
     /// anchor/form-control styling), synced back to the attribute at serialization.
     /// </summary>
+    /// <summary>The element's parent as a <see cref="DomElement"/> (RF-BRIDGE-1c Phase E:
+    /// replaces the facade <c>ParentEl(DomElement)</c> getter — <c>ParentNode as DomElement</c>).
+    /// A node's parent is always an element, so this is stable when text/comment nodes become
+    /// canonical <c>DomText</c>/<c>DomComment</c> in Phase D.</summary>
+    private static DomElement? ParentEl(DomElement element) => element.ParentNode as DomElement;
+
+    /// <summary>Reparents <paramref name="child"/> under <paramref name="parent"/> (RF-BRIDGE-1c
+    /// Phase E: replaces the facade <c>ParentEl(DomElement)</c> setter). A null parent detaches;
+    /// otherwise the child is appended if not already there — matching the old setter exactly.</summary>
+    private static void SetParent(DomElement child, DomElement? parent)
+    {
+        if (parent is null)
+            child.Remove();
+        else if (!ReferenceEquals(child.ParentNode, parent))
+            parent.AppendChild(child);
+    }
+
     private static Dictionary<string, string> InlineStyle(DomElement element)
     {
         var state = GetElementRuntimeState(element);
@@ -709,7 +726,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         var doctype = ParseDocType(html);
         if (doctype != null)
         {
-            doctype.Parent = _documentNode;
+            SetParent(doctype, _documentNode);
             _documentNode.Children.Add(doctype);
             _knownNodes.Add(doctype);
         }
@@ -729,7 +746,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         DocumentElement.Children.Clear();
         foreach (var child in docElement.Children.ToArray())
         {
-            child.Parent = DocumentElement;
+            SetParent(child, DocumentElement);
             DocumentElement.Children.Add(child);
         }
 
@@ -749,7 +766,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
 
         // Connect DocumentElement to _documentNode so that document.firstChild works
         // and structural pseudo-classes correctly detect the document root boundary
-        DocumentElement.Parent = _documentNode;
+        SetParent(DocumentElement, _documentNode);
         if (!_documentNode.Children.Contains(DocumentElement))
             _documentNode.Children.Add(DocumentElement);
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -188,6 +188,12 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// attribute; thereafter it is the source of truth (JS <c>element.style</c> writes,
     /// anchor/form-control styling), synced back to the attribute at serialization.
     /// </summary>
+    /// <summary>Whether <paramref name="node"/> is a text node (RF-BRIDGE-1c Phase D: replaces
+    /// the facade <c>IsText(DomElement)</c>). NodeType-based, so it holds for the current
+    /// facade text nodes and for canonical <c>DomText</c> once construction flips in the
+    /// <c>Children</c>/text cutover.</summary>
+    private static bool IsText(Broiler.Dom.DomNode node) => node.NodeType == Broiler.Dom.DomNodeType.Text;
+
     /// <summary>The element's parent as a <see cref="DomElement"/> (RF-BRIDGE-1c Phase E:
     /// replaces the facade <c>ParentEl(DomElement)</c> getter — <c>ParentNode as DomElement</c>).
     /// A node's parent is always an element, so this is stable when text/comment nodes become
@@ -311,7 +317,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     {
         foreach (var el in Elements)
         {
-            if (el.IsTextNode || string.IsNullOrEmpty(el.Id))
+            if (IsText(el) || string.IsNullOrEmpty(el.Id))
                 continue;
             // Only register if the global doesn't already exist
             // (user-defined globals take precedence — a `var`/`function` or a
@@ -672,7 +678,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     {
         foreach (var child in element.Children)
         {
-            if (child.IsTextNode)
+            if (IsText(child))
                 continue;
 
             if (string.Equals(child.TagName, "iframe", StringComparison.OrdinalIgnoreCase))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -660,7 +660,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
 
             if (string.Equals(child.TagName, "iframe", StringComparison.OrdinalIgnoreCase))
             {
-                var src = child.Attributes.TryGetValue("src", out var srcValue) ? srcValue : string.Empty;
+                var src = TryGetAttribute(child, "src", out var srcValue) ? srcValue : string.Empty;
                 if (!IsCrossOrigin(src, _pageUrl))
                     frames.Add(GetOrCreateSubWindow(child));
             }
@@ -740,8 +740,8 @@ public sealed partial class DomBridge : IDomBridgeRuntime
             DocumentElement.Id = docElement.Id;
         if (!string.IsNullOrEmpty(docElement.ClassName))
             DocumentElement.ClassName = docElement.ClassName;
-        foreach (var kv in docElement.Attributes)
-            DocumentElement.Attributes[kv.Key] = kv.Value;
+        foreach (var attribute in docElement.Attributes.Values)
+            SetAttr(DocumentElement, attribute.QualifiedName, attribute.Value);
         foreach (var kv in InlineStyle(docElement))
             InlineStyle(DocumentElement)[kv.Key] = kv.Value;
 
@@ -940,7 +940,7 @@ internal sealed class FormElementsCollection(DomElement form, DomBridge bridge) 
             var controls = DomBridge.CollectFormControls(form);
             foreach (var ctrl in controls)
             {
-                if (ctrl.Attributes.TryGetValue("name", out var name) &&
+                if (ctrl.GetAttribute("name") is { } name &&
                     string.Equals(name, prop, StringComparison.Ordinal))
                     return bridge.ToJSObject(ctrl);
             }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorCenter.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorCenter.cs
@@ -14,7 +14,7 @@ public sealed partial class DomBridge
         DomElement element,
         Dictionary<string, AnchorInfo> anchorRegistry)
     {
-        if (!element.IsTextNode)
+        if (!IsText(element))
         {
             var cssProps = GetComputedProps(element);
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorCenter.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorCenter.cs
@@ -33,9 +33,9 @@ public sealed partial class DomBridge
                 ResolveAnchorForElement(positionAnchor, element, anchorRegistry) is { } anchor)
             {
                 double elWidth = TryParsePx(cssProps.GetValueOrDefault("width")) ??
-                                 TryParsePx(element.Style.GetValueOrDefault("width")) ?? 0;
+                                 TryParsePx(InlineStyle(element).GetValueOrDefault("width")) ?? 0;
                 double elHeight = TryParsePx(cssProps.GetValueOrDefault("height")) ??
-                                  TryParsePx(element.Style.GetValueOrDefault("height")) ?? 0;
+                                  TryParsePx(InlineStyle(element).GetValueOrDefault("height")) ?? 0;
 
                 // align-self: anchor-center → center vertically on anchor
                 if (alignSelf != null &&
@@ -43,7 +43,7 @@ public sealed partial class DomBridge
                 {
                     double anchorCenterY = anchor.Top + anchor.Height / 2.0;
                     double top = anchorCenterY - elHeight / 2.0;
-                    element.Style["top"] = $"{top.ToString(CultureInfo.InvariantCulture)}px";
+                    InlineStyle(element)["top"] = $"{top.ToString(CultureInfo.InvariantCulture)}px";
                 }
 
                 // justify-self: anchor-center → center horizontally on anchor
@@ -52,14 +52,14 @@ public sealed partial class DomBridge
                 {
                     double anchorCenterX = anchor.Left + anchor.Width / 2.0;
                     double left = anchorCenterX - elWidth / 2.0;
-                    element.Style["left"] = $"{left.ToString(CultureInfo.InvariantCulture)}px";
+                    InlineStyle(element)["left"] = $"{left.ToString(CultureInfo.InvariantCulture)}px";
                 }
 
                 // Ensure the element has position:absolute.
                 if (!cssProps.TryGetValue("position", out var pos) ||
                     pos == "static")
                 {
-                    element.Style["position"] = "absolute";
+                    InlineStyle(element)["position"] = "absolute";
                 }
             }
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
@@ -192,7 +192,7 @@ public sealed partial class DomBridge
         // the anchored box off-screen (css-anchor-position anchor-scroll-to-sticky-004).
         bool stickyToNextScroller = IsSticky(GetComputedProps(anchorEl));
 
-        for (var el = anchorEl.Parent; el != null; el = el.Parent)
+        for (var el = ParentEl(anchorEl); el != null; el = ParentEl(el))
         {
             var props = GetComputedProps(el);
             if (!HasOverflowClipping(props))
@@ -236,7 +236,7 @@ public sealed partial class DomBridge
     /// </summary>
     private static bool IsDescendantOrSelf(DomElement node, DomElement ancestor)
     {
-        for (var cur = node; cur != null; cur = cur.Parent)
+        for (var cur = node; cur != null; cur = ParentEl(cur))
             if (cur == ancestor)
                 return true;
         return false;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
@@ -31,7 +31,7 @@ public sealed partial class DomBridge
                 hasAnchorSizeRef = true;
         }
         // Also check inline styles for anchor-size()
-        foreach (var kv in element.Style)
+        foreach (var kv in InlineStyle(element))
         {
             if (kv.Value.Contains("anchor-size(", StringComparison.OrdinalIgnoreCase))
                 hasAnchorSizeRef = true;
@@ -45,14 +45,14 @@ public sealed partial class DomBridge
 
             // Get the implicit anchor name from position-anchor.
             string? implicitAnchor = cssProps.GetValueOrDefault("position-anchor") ??
-                                     element.Style.GetValueOrDefault("position-anchor");
+                                     InlineStyle(element).GetValueOrDefault("position-anchor");
 
             // When the target element is fixed-positioned (e.g. top-layer dialog)
             // and the anchor is NOT fixed-positioned, anchor positions must be
             // adjusted by the document scroll offset so the anchor's viewport
             // position is used instead of its document position.
             bool targetIsFixed =
-                (cssProps.GetValueOrDefault("position") ?? element.Style.GetValueOrDefault("position")) == "fixed" ||
+                (cssProps.GetValueOrDefault("position") ?? InlineStyle(element).GetValueOrDefault("position")) == "fixed" ||
                 (GetElementRuntimeState(element).Dialog.Modal.TryGet(out var tModal) && tModal is true);
             double scrollAdjY = 0, scrollAdjX = 0;
             if (targetIsFixed)
@@ -134,7 +134,7 @@ public sealed partial class DomBridge
                 });
 
                 if (resolved != kv.Value)
-                    element.Style[kv.Key] = resolved;
+                    InlineStyle(element)[kv.Key] = resolved;
             }
 
             // Apply non-anchor CSS properties (e.g. position, margin).
@@ -142,15 +142,15 @@ public sealed partial class DomBridge
             {
                 if (!kv.Value.Contains("anchor(", StringComparison.OrdinalIgnoreCase) &&
                     !kv.Value.Contains("anchor-size(", StringComparison.OrdinalIgnoreCase) &&
-                    !element.Style.ContainsKey(kv.Key) &&
+                    !InlineStyle(element).ContainsKey(kv.Key) &&
                     IsLayoutProperty(kv.Key))
                 {
-                    element.Style[kv.Key] = kv.Value;
+                    InlineStyle(element)[kv.Key] = kv.Value;
                 }
             }
 
             // Remove 'inset' shorthand.
-            element.Style.Remove("inset");
+            InlineStyle(element).Remove("inset");
         }
 
         // Resolve anchor-size() function calls in both CSS and inline styles.
@@ -261,7 +261,7 @@ public sealed partial class DomBridge
     {
         // Get implicit anchor name from position-anchor.
         string? implicitAnchor = cssProps.GetValueOrDefault("position-anchor") ??
-                                 element.Style.GetValueOrDefault("position-anchor");
+                                 InlineStyle(element).GetValueOrDefault("position-anchor");
 
         string ResolveValue(string value)
         {
@@ -291,17 +291,17 @@ public sealed partial class DomBridge
         {
             if (kv.Value.Contains("anchor-size(", StringComparison.OrdinalIgnoreCase))
             {
-                element.Style[kv.Key] = ResolveValue(kv.Value);
+                InlineStyle(element)[kv.Key] = ResolveValue(kv.Value);
             }
         }
 
         // Resolve in existing inline styles.
-        var inlineKeys = new List<string>(element.Style.Keys);
+        var inlineKeys = new List<string>(InlineStyle(element).Keys);
         foreach (var key in inlineKeys)
         {
-            if (element.Style[key].Contains("anchor-size(", StringComparison.OrdinalIgnoreCase))
+            if (InlineStyle(element)[key].Contains("anchor-size(", StringComparison.OrdinalIgnoreCase))
             {
-                element.Style[key] = ResolveValue(element.Style[key]);
+                InlineStyle(element)[key] = ResolveValue(InlineStyle(element)[key]);
             }
         }
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
@@ -161,7 +161,7 @@ public sealed partial class DomBridge
         accTop += ComputePrecedingSiblingHeights(element);
 
         // Walk up ancestors to accumulate margins, padding, and borders.
-        var ancestor = element.Parent;
+        var ancestor = ParentEl(element);
         while (ancestor != null)
         {
             var ancProps = GetComputedProps(ancestor);
@@ -202,7 +202,7 @@ public sealed partial class DomBridge
             accTop += TryParsePx(ancProps.GetValueOrDefault("border-top-width")) ?? 0;
             accTop += ComputePrecedingSiblingHeights(ancestor);
 
-            ancestor = ancestor.Parent;
+            ancestor = ParentEl(ancestor);
         }
 
         // For block-level elements without explicit width, compute width
@@ -268,7 +268,7 @@ public sealed partial class DomBridge
     /// </summary>
     private DomElement? FindGeometryContainingBlockAncestor(DomElement element)
     {
-        for (var ancestor = element.Parent; ancestor != null; ancestor = ancestor.Parent)
+        for (var ancestor = ParentEl(element); ancestor != null; ancestor = ParentEl(ancestor))
             if (EstablishesContainingBlock(GetComputedProps(ancestor)))
                 return ancestor;
         return null;
@@ -366,9 +366,9 @@ public sealed partial class DomBridge
             if (!string.Equals(value?.Trim(), "inherit", StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            if (element.Parent != null)
+            if (ParentEl(element) != null)
             {
-                parentProps ??= GetComputedProps(element.Parent);
+                parentProps ??= GetComputedProps(ParentEl(element));
                 if (parentProps.TryGetValue(key, out var parentValue) && !string.IsNullOrWhiteSpace(parentValue))
                 {
                     props[key] = parentValue;
@@ -387,10 +387,10 @@ public sealed partial class DomBridge
     /// </summary>
     private double ComputePrecedingSiblingHeights(DomElement element)
     {
-        if (element.Parent == null) return 0;
+        if (ParentEl(element) == null) return 0;
 
         double totalHeight = 0;
-        // Snapshot the sibling list before walking it: element.Parent.Children
+        // Snapshot the sibling list before walking it: ParentEl(element).Children
         // enumerates the live ChildNodes list, so any mutation of it during the
         // walk (e.g. an anchor-driven DOM move on a node sharing this parent, or
         // a lazy offset query that re-enters anchor resolution) throws
@@ -398,7 +398,7 @@ public sealed partial class DomBridge
         // for the whole document (WPT issue #1131, signature
         // DomBridge.BuildAnchorRegistry). Same defensive snapshot (SnapshotChildren)
         // idiom as ResolveAnchorCenter and InlineContainingBlocks.
-        foreach (var sibling in SnapshotChildren(element.Parent))
+        foreach (var sibling in SnapshotChildren(ParentEl(element)))
         {
             if (sibling == element) break;
             if (sibling.IsTextNode) continue;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
@@ -26,7 +26,7 @@ public sealed partial class DomBridge
         var candidates = new Dictionary<string, List<AnchorInfo>>(StringComparer.Ordinal);
         foreach (var el in Elements)
         {
-            if (el.IsTextNode)
+            if (IsText(el))
                 continue;
 
             var declarations = CollectMatchedRuleProperties(el);
@@ -401,7 +401,7 @@ public sealed partial class DomBridge
         foreach (var sibling in SnapshotChildren(ParentEl(element)))
         {
             if (sibling == element) break;
-            if (sibling.IsTextNode) continue;
+            if (IsText(sibling)) continue;
 
             var sibProps = GetComputedProps(sibling);
             string? sibPos = sibProps.GetValueOrDefault("position");

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
@@ -317,7 +317,7 @@ public sealed partial class DomBridge
 
             foreach (var kv in CollectMatchedRuleProperties(element))
                 props[kv.Key] = kv.Value;
-            foreach (var kv in element.Style)
+            foreach (var kv in InlineStyle(element))
                 props[kv.Key] = kv.Value;
 
             ExpandCssShorthands(props);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -95,7 +95,7 @@ public sealed partial class DomBridge
                 (scPos == "relative" || scPos == "absolute" ||
                  scPos == "fixed" || scPos == "sticky");
             if (!alreadyPositioned)
-                sc.Style["position"] = "relative";
+                InlineStyle(sc)["position"] = "relative";
         }
 
         // 4. Insert backdrop elements for modal dialogs.
@@ -170,12 +170,12 @@ public sealed partial class DomBridge
 
         // The replaced root paints only the image; neither the root nor the
         // (box-less) body background reaches the canvas.
-        html.Style["background"] = "none";
-        html.Style["background-color"] = "transparent";
-        body.Style["margin"] = "0";
-        body.Style["padding"] = "0";
-        body.Style["background"] = "none";
-        body.Style["background-color"] = "transparent";
+        InlineStyle(html)["background"] = "none";
+        InlineStyle(html)["background-color"] = "transparent";
+        InlineStyle(body)["margin"] = "0";
+        InlineStyle(body)["padding"] = "0";
+        InlineStyle(body)["background"] = "none";
+        InlineStyle(body)["background-color"] = "transparent";
 
         body.Children.Clear();
 
@@ -212,7 +212,7 @@ public sealed partial class DomBridge
             return;
 
         var combinedZoom = GetUsedZoomForElement(DocumentElement) * scale;
-        DocumentElement.Style["zoom"] = combinedZoom.ToString("0.###", CultureInfo.InvariantCulture);
+        InlineStyle(DocumentElement)["zoom"] = combinedZoom.ToString("0.###", CultureInfo.InvariantCulture);
         GetElementRuntimeState(DocumentElement).Scroll.Left.Set(GetVisualViewportPageOffset(vertical: false));
         GetElementRuntimeState(DocumentElement).Scroll.Top.Set(GetVisualViewportPageOffset(vertical: true));
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -75,8 +75,8 @@ public sealed partial class DomBridge
         //     to avoid collection modification during traversal.
         foreach (var (el, oldParent, newParent) in deferredDomMoves)
         {
-            oldParent.Children.Remove(el);
-            newParent.Children.Add(el);
+            RemoveChildFrom(oldParent, el);
+            newParent.AppendChild(el);
         }
 
         // 3d2. Promote any remaining absolutely positioned children of
@@ -177,7 +177,7 @@ public sealed partial class DomBridge
         InlineStyle(body)["background"] = "none";
         InlineStyle(body)["background-color"] = "transparent";
 
-        body.Children.Clear();
+        ClearChildren(body);
 
         var img = new DomElement(
             _document, "img", null, null, string.Empty, null,
@@ -186,7 +186,7 @@ public sealed partial class DomBridge
                 ["src"] = url,
             });
         SetParent(img, body);
-        body.Children.Add(img);
+        body.AppendChild(img);
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -185,7 +185,7 @@ public sealed partial class DomBridge
             {
                 ["src"] = url,
             });
-        img.Parent = body;
+        SetParent(img, body);
         body.Children.Add(img);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ContainingBlocks.cs
@@ -19,7 +19,7 @@ public sealed partial class DomBridge
     }
     private void EnsureContainingBlockPositioningTree(DomElement el)
     {
-        if (!el.IsTextNode && !string.Equals(el.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (!IsText(el) && !string.Equals(el.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
         {
             var props = CollectMatchedRuleProperties(el);
             foreach (var kv in InlineStyle(el))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ContainingBlocks.cs
@@ -22,7 +22,7 @@ public sealed partial class DomBridge
         if (!el.IsTextNode && !string.Equals(el.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
         {
             var props = CollectMatchedRuleProperties(el);
-            foreach (var kv in el.Style)
+            foreach (var kv in InlineStyle(el))
                 props[kv.Key] = kv.Value;
 
             // If the element already has explicit positioning, no change needed.
@@ -31,7 +31,7 @@ public sealed partial class DomBridge
 
             if (!alreadyPositioned && EstablishesContainingBlock(props))
             {
-                el.Style["position"] = "relative";
+                InlineStyle(el)["position"] = "relative";
             }
         }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/CssCleanup.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/CssCleanup.cs
@@ -24,7 +24,7 @@ public sealed partial class DomBridge
             // copy overflow ("Destination array…"), same idiom as AnchorRegistry.
             foreach (var child in SnapshotChildren(root))
             {
-                if (child.IsTextNode && !string.IsNullOrEmpty(child.TextContent))
+                if (IsText(child) && !string.IsNullOrEmpty(child.TextContent))
                     child.TextContent = RemoveUnsupportedCssRules(child.TextContent);
             }
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
@@ -131,9 +131,9 @@ public sealed partial class DomBridge
                 InlineStyle(backdrop)[kv.Key] = kv.Value;
             SetParent(backdrop, parent);
 
-            int idx = parent.Children.IndexOf(dialog);
+            int idx = ChildIndexOf(parent, dialog);
             if (idx >= 0)
-                parent.Children.Insert(idx, backdrop);
+                InsertChildAt(parent, idx, backdrop);
 
             // If the ::backdrop declares position-try-fallbacks and its base
             // geometry overflows the containing block, resolve the fallback

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
@@ -34,7 +34,7 @@ public sealed partial class DomBridge
 
             // Set position:fixed as UA default for modal dialogs that have
             // no explicit position, matching Chromium's top-layer behaviour.
-            el.Style["position"] = "fixed";
+            InlineStyle(el)["position"] = "fixed";
         }
     }
 
@@ -67,18 +67,18 @@ public sealed partial class DomBridge
 
             if (!alreadyPositioned)
             {
-                el.Style["position"] = "fixed";
-                if (!el.Style.ContainsKey("top") && !props.ContainsKey("top"))
-                    el.Style["top"] = "0";
-                if (!el.Style.ContainsKey("left") && !props.ContainsKey("left"))
-                    el.Style["left"] = "0";
+                InlineStyle(el)["position"] = "fixed";
+                if (!InlineStyle(el).ContainsKey("top") && !props.ContainsKey("top"))
+                    InlineStyle(el)["top"] = "0";
+                if (!InlineStyle(el).ContainsKey("left") && !props.ContainsKey("left"))
+                    InlineStyle(el)["left"] = "0";
             }
 
             // Elevate into the synthetic top layer, ordered by show order, so the
             // popover paints above non-top-layer content (e.g. a plain
             // position:fixed sibling) and later popovers paint over earlier ones.
             int order = GetElementRuntimeState(el).Dialog.TopLayerOrder.TryGet(out var o) && o is int oi ? oi : 0;
-            el.Style["z-index"] = (TopLayerZIndexBase + order).ToString(System.Globalization.CultureInfo.InvariantCulture);
+            InlineStyle(el)["z-index"] = (TopLayerZIndexBase + order).ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
     }
     // -----------------------------------------------------------------
@@ -126,9 +126,9 @@ public sealed partial class DomBridge
                 .GetCascadedDeclaredValues(dialog, "::backdrop");
             OverlayBackdropAuthorGeometry(backdropDecls, backdropStyle);
 
-            var backdrop = new DomElement(
-                "div", null, null, string.Empty,
-                style: backdropStyle);
+            var backdrop = new DomElement("div", null, null, string.Empty);
+            foreach (var kv in backdropStyle)
+                InlineStyle(backdrop)[kv.Key] = kv.Value;
             backdrop.Parent = parent;
 
             int idx = parent.Children.IndexOf(dialog);
@@ -156,24 +156,24 @@ public sealed partial class DomBridge
             // Ensure the dialog has UA default styles.
             // Check both inline styles and CSS rules before applying defaults.
             var dialogProps = GetComputedProps(dialog);
-            if (!dialog.Style.ContainsKey("display"))
-                dialog.Style["display"] = "block";
-            if (!dialog.Style.ContainsKey("border") &&
+            if (!InlineStyle(dialog).ContainsKey("display"))
+                InlineStyle(dialog)["display"] = "block";
+            if (!InlineStyle(dialog).ContainsKey("border") &&
                 !dialogProps.ContainsKey("border") &&
                 !dialogProps.ContainsKey("border-width"))
             {
-                dialog.Style["border-width"] = "1px";
-                dialog.Style["border-style"] = "solid";
-                dialog.Style["border-color"] = "black";
+                InlineStyle(dialog)["border-width"] = "1px";
+                InlineStyle(dialog)["border-style"] = "solid";
+                InlineStyle(dialog)["border-color"] = "black";
             }
-            if (!dialog.Style.ContainsKey("padding") &&
+            if (!InlineStyle(dialog).ContainsKey("padding") &&
                 !dialogProps.ContainsKey("padding"))
-                dialog.Style["padding"] = "1em";
-            if (!dialog.Style.ContainsKey("background") &&
-                !dialog.Style.ContainsKey("background-color") &&
+                InlineStyle(dialog)["padding"] = "1em";
+            if (!InlineStyle(dialog).ContainsKey("background") &&
+                !InlineStyle(dialog).ContainsKey("background-color") &&
                 !dialogProps.ContainsKey("background") &&
                 !dialogProps.ContainsKey("background-color"))
-                dialog.Style["background-color"] = "white";
+                InlineStyle(dialog)["background-color"] = "white";
         }
     }
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
@@ -129,7 +129,7 @@ public sealed partial class DomBridge
             var backdrop = new DomElement("div", null, null, string.Empty);
             foreach (var kv in backdropStyle)
                 InlineStyle(backdrop)[kv.Key] = kv.Value;
-            backdrop.Parent = parent;
+            SetParent(backdrop, parent);
 
             int idx = parent.Children.IndexOf(dialog);
             if (idx >= 0)
@@ -286,9 +286,9 @@ public sealed partial class DomBridge
             HasAttr(element, "open") &&
             GetElementRuntimeState(element).Dialog.Modal.TryGet(out var isModal) &&
             isModal is bool modal && modal &&
-            element.Parent != null)
+            ParentEl(element) != null)
         {
-            results.Add((element, element.Parent, false));
+            results.Add((element, ParentEl(element), false));
         }
 
         // Snapshot before recursing: the live child list can be mutated mid-walk
@@ -303,11 +303,11 @@ public sealed partial class DomBridge
     // the top layer and generates a ::backdrop, just like a modal dialog.
     private static void FindOpenPopovers(DomElement element, List<(DomElement, DomElement, bool)> results)
     {
-        if (element.Parent != null &&
+        if (ParentEl(element) != null &&
             GetElementRuntimeState(element).Dialog.PopoverOpen.TryGet(out var open) &&
             open is true)
         {
-            results.Add((element, element.Parent, true));
+            results.Add((element, ParentEl(element), true));
         }
 
         foreach (var child in SnapshotChildren(element))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
@@ -19,7 +19,7 @@ public sealed partial class DomBridge
         {
             if (!string.Equals(el.TagName, "dialog", StringComparison.OrdinalIgnoreCase))
                 continue;
-            if (!el.Attributes.ContainsKey("open"))
+            if (!HasAttr(el, "open"))
                 continue;
             if (!(GetElementRuntimeState(el).Dialog.Modal.TryGet(out var m) && m is true))
                 continue;
@@ -283,7 +283,7 @@ public sealed partial class DomBridge
     private static void FindModalDialogs(DomElement element, List<(DomElement, DomElement, bool)> results)
     {
         if (string.Equals(element.TagName, "dialog", StringComparison.OrdinalIgnoreCase) &&
-            element.Attributes.ContainsKey("open") &&
+            HasAttr(element, "open") &&
             GetElementRuntimeState(element).Dialog.Modal.TryGet(out var isModal) &&
             isModal is bool modal && modal &&
             element.Parent != null)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/FixedPosition.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/FixedPosition.cs
@@ -24,14 +24,14 @@ public sealed partial class DomBridge
             // Collect cascaded CSS properties for this element.
             var cssProps = CollectMatchedRuleProperties(el);
             // Merge inline styles (higher priority).
-            foreach (var kv in el.Style)
+            foreach (var kv in InlineStyle(el))
                 cssProps[kv.Key] = kv.Value;
 
             if (cssProps.TryGetValue("position", out var pos) &&
                 string.Equals(pos, "fixed", StringComparison.OrdinalIgnoreCase))
             {
                 // Ensure position: fixed is set as inline style.
-                el.Style["position"] = "fixed";
+                InlineStyle(el)["position"] = "fixed";
 
                 // Expand the 'inset' shorthand into top/right/bottom/left.
                 if (cssProps.TryGetValue("inset", out var insetVal) &&
@@ -42,38 +42,38 @@ public sealed partial class DomBridge
                     string r = parts.Length > 1 ? parts[1] : parts[0];
                     string b = parts.Length > 2 ? parts[2] : parts[0];
                     string l = parts.Length > 3 ? parts[3] : r;
-                    if (!el.Style.ContainsKey("top")) el.Style["top"] = t;
-                    if (!el.Style.ContainsKey("right")) el.Style["right"] = r;
-                    if (!el.Style.ContainsKey("bottom")) el.Style["bottom"] = b;
-                    if (!el.Style.ContainsKey("left")) el.Style["left"] = l;
+                    if (!InlineStyle(el).ContainsKey("top")) InlineStyle(el)["top"] = t;
+                    if (!InlineStyle(el).ContainsKey("right")) InlineStyle(el)["right"] = r;
+                    if (!InlineStyle(el).ContainsKey("bottom")) InlineStyle(el)["bottom"] = b;
+                    if (!InlineStyle(el).ContainsKey("left")) InlineStyle(el)["left"] = l;
                 }
 
                 // Copy top/left/right/bottom/width/height from CSS if not already inline.
                 foreach (var prop in new[] { "top", "left", "right", "bottom", "width", "height" })
                 {
-                    if (!el.Style.ContainsKey(prop) && cssProps.TryGetValue(prop, out var v))
+                    if (!InlineStyle(el).ContainsKey(prop) && cssProps.TryGetValue(prop, out var v))
                     {
                         if (!v.Contains("anchor(", StringComparison.OrdinalIgnoreCase))
-                            el.Style[prop] = v;
+                            InlineStyle(el)[prop] = v;
                     }
                 }
 
                 // Resolve width from opposing left/right insets when no explicit width.
-                if (!el.Style.ContainsKey("width") || el.Style["width"] == "auto")
+                if (!InlineStyle(el).ContainsKey("width") || InlineStyle(el)["width"] == "auto")
                 {
-                    var leftPx = TryParsePx(el.Style.GetValueOrDefault("left"));
-                    var rightPx = TryParsePx(el.Style.GetValueOrDefault("right"));
+                    var leftPx = TryParsePx(InlineStyle(el).GetValueOrDefault("left"));
+                    var rightPx = TryParsePx(InlineStyle(el).GetValueOrDefault("right"));
                     if (leftPx.HasValue && rightPx.HasValue)
-                        el.Style["width"] = $"{vpW - leftPx.Value - rightPx.Value}px";
+                        InlineStyle(el)["width"] = $"{vpW - leftPx.Value - rightPx.Value}px";
                 }
 
                 // Resolve height from opposing top/bottom insets when no explicit height.
-                if (!el.Style.ContainsKey("height") || el.Style["height"] == "auto")
+                if (!InlineStyle(el).ContainsKey("height") || InlineStyle(el)["height"] == "auto")
                 {
-                    var topPx = TryParsePx(el.Style.GetValueOrDefault("top"));
-                    var bottomPx = TryParsePx(el.Style.GetValueOrDefault("bottom"));
+                    var topPx = TryParsePx(InlineStyle(el).GetValueOrDefault("top"));
+                    var bottomPx = TryParsePx(InlineStyle(el).GetValueOrDefault("bottom"));
                     if (topPx.HasValue && bottomPx.HasValue)
-                        el.Style["height"] = $"{vpH - topPx.Value - bottomPx.Value}px";
+                        InlineStyle(el)["height"] = $"{vpH - topPx.Value - bottomPx.Value}px";
                 }
             }
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/FixedPosition.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/FixedPosition.cs
@@ -19,7 +19,7 @@ public sealed partial class DomBridge
     }
     private void ResolveFixedPositionSizingInTree(DomElement el, int vpW, int vpH)
     {
-        if (!el.IsTextNode)
+        if (!IsText(el))
         {
             // Collect cascaded CSS properties for this element.
             var cssProps = CollectMatchedRuleProperties(el);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
@@ -12,7 +12,7 @@ public sealed partial class DomBridge
     {
         foreach (var el in Elements)
         {
-            if (el.Style.TryGetValue("anchor-name", out var anchorName) &&
+            if (InlineStyle(el).TryGetValue("anchor-name", out var anchorName) &&
                 !string.IsNullOrWhiteSpace(anchorName))
             {
                 var box = ComputeElementBoxWithContainer(el);
@@ -330,24 +330,24 @@ public sealed partial class DomBridge
             double curTop = TryParsePx(childCss.GetValueOrDefault("top")) ?? 0;
             double curWidth = TryParsePx(childCss.GetValueOrDefault("width")) ?? 0;
             double curHeight = TryParsePx(childCss.GetValueOrDefault("height")) ?? 0;
-            child.Style["position"] = childCss.GetValueOrDefault("position") ?? "absolute";
+            InlineStyle(child)["position"] = childCss.GetValueOrDefault("position") ?? "absolute";
             // Ensure inline elements (like <span>) are treated as block-level
             // after absolute positioning, so the renderer paints backgrounds.
             string? childDisplay = childCss.GetValueOrDefault("display");
             if (IsInlineElement(child.TagName, childDisplay))
-                child.Style["display"] = "block";
-            child.Style["left"] = $"{(curLeft + offX).ToString(CultureInfo.InvariantCulture)}px";
-            child.Style["top"] = $"{(curTop + offY).ToString(CultureInfo.InvariantCulture)}px";
+                InlineStyle(child)["display"] = "block";
+            InlineStyle(child)["left"] = $"{(curLeft + offX).ToString(CultureInfo.InvariantCulture)}px";
+            InlineStyle(child)["top"] = $"{(curTop + offY).ToString(CultureInfo.InvariantCulture)}px";
             // Ensure width and height are preserved as inline styles.
             if (curWidth > 0)
-                child.Style["width"] = $"{curWidth.ToString(CultureInfo.InvariantCulture)}px";
+                InlineStyle(child)["width"] = $"{curWidth.ToString(CultureInfo.InvariantCulture)}px";
             if (curHeight > 0)
-                child.Style["height"] = $"{curHeight.ToString(CultureInfo.InvariantCulture)}px";
+                InlineStyle(child)["height"] = $"{curHeight.ToString(CultureInfo.InvariantCulture)}px";
             // Preserve background-color if specified in CSS rules.
             string? bg = childCss.GetValueOrDefault("background-color")
                       ?? childCss.GetValueOrDefault("background");
             if (!string.IsNullOrWhiteSpace(bg) && bg != "transparent" && bg != "initial")
-                child.Style["background-color"] = bg;
+                InlineStyle(child)["background-color"] = bg;
 
             // Move from inline CB to block ancestor.
             inlineCB.Children.Remove(child);
@@ -357,7 +357,7 @@ public sealed partial class DomBridge
             var blockProps = GetComputedProps(blockAncestor);
             string? blockPos = blockProps.GetValueOrDefault("position");
             if (blockPos == null || blockPos == "static")
-                blockAncestor.Style["position"] = "relative";
+                InlineStyle(blockAncestor)["position"] = "relative";
         }
     }
     private void CollectInlineCBPromotions(

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
@@ -350,8 +350,8 @@ public sealed partial class DomBridge
                 InlineStyle(child)["background-color"] = bg;
 
             // Move from inline CB to block ancestor.
-            inlineCB.Children.Remove(child);
-            blockAncestor.Children.Add(child);
+            RemoveChildFrom(inlineCB, child);
+            blockAncestor.AppendChild(child);
 
             // Ensure the block ancestor has position:relative.
             var blockProps = GetComputedProps(blockAncestor);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
@@ -96,7 +96,7 @@ public sealed partial class DomBridge
     /// </summary>
     private double? ResolveBlockUsedWidthFromAncestors(DomElement blockEl)
     {
-        for (var a = ParentEl(blockEl); a != null && !a.IsTextNode; a = ParentEl(a))
+        for (var a = ParentEl(blockEl); a != null && !IsText(a); a = ParentEl(a))
         {
             var ap = GetComputedProps(a);
             double? w = TryParsePx(ap.GetValueOrDefault("width"));
@@ -172,7 +172,7 @@ public sealed partial class DomBridge
     {
         foreach (var el in Elements)
         {
-            if (!el.IsTextNode &&
+            if (!IsText(el) &&
                 string.Equals(el.TagName, "body", StringComparison.OrdinalIgnoreCase))
                 return el;
         }
@@ -208,7 +208,7 @@ public sealed partial class DomBridge
         // enough"). SnapshotChildren tolerates both, matching the other walks here.
         foreach (var child in SnapshotChildren(element))
         {
-            if (child.IsTextNode)
+            if (IsText(child))
             {
                 // Estimate text width from font-size (Ahem font: 1ch = font-size).
                 int charCount = (child.TextContent ?? "").Length;
@@ -365,7 +365,7 @@ public sealed partial class DomBridge
         List<(DomElement child, DomElement inlineCB, DomElement blockAncestor,
             double offX, double offY)> promotions)
     {
-        if (!element.IsTextNode && IsInlineContainingBlock(element))
+        if (!IsText(element) && IsInlineContainingBlock(element))
         {
             var (offX, offY, blockAncestor) = ComputeInlineCBOffset(element);
             if (blockAncestor != null)
@@ -373,7 +373,7 @@ public sealed partial class DomBridge
                 // Collect absolutely positioned children.
                 foreach (var child in SnapshotChildren(element))
                 {
-                    if (child.IsTextNode) continue;
+                    if (IsText(child)) continue;
                     var childProps = GetComputedProps(child);
                     string? childPos = childProps.GetValueOrDefault("position");
                     if (childPos == "absolute" || childPos == "fixed")
@@ -408,7 +408,7 @@ public sealed partial class DomBridge
         // Find nearest block-level ancestor.
         while (parent != null)
         {
-            if (!parent.IsTextNode)
+            if (!IsText(parent))
             {
                 var parentProps = GetComputedProps(parent);
                 string? parentDisplay = parentProps.GetValueOrDefault("display");
@@ -496,7 +496,7 @@ public sealed partial class DomBridge
         foreach (var sibling in SnapshotChildren(parent))
         {
             if (sibling == element) break;
-            if (sibling.IsTextNode)
+            if (IsText(sibling))
             {
                 // Count line breaks in text content.
                 var text = sibling.TextContent ?? "";
@@ -568,7 +568,7 @@ public sealed partial class DomBridge
         {
             if (sibling == element) break;
 
-            if (sibling.IsTextNode)
+            if (IsText(sibling))
             {
                 // Decode HTML entities (e.g. &nbsp; → \u00A0) before counting.
                 var text = System.Net.WebUtility.HtmlDecode(sibling.TextContent ?? "");

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
@@ -47,7 +47,7 @@ public sealed partial class DomBridge
     /// </summary>
     private double FindContainingBlockWidth(DomElement element)
     {
-        var parent = element.Parent;
+        var parent = ParentEl(element);
         while (parent != null)
         {
             var parentProps = GetComputedProps(parent);
@@ -78,7 +78,7 @@ public sealed partial class DomBridge
                 w -= TryParsePx(parentProps.GetValueOrDefault("padding-right")) ?? 0;
                 return w;
             }
-            parent = parent.Parent;
+            parent = ParentEl(parent);
         }
         // No positioned ancestor found; use viewport width minus default body
         // margin (8px each side) as the effective content width for block layout.
@@ -96,7 +96,7 @@ public sealed partial class DomBridge
     /// </summary>
     private double? ResolveBlockUsedWidthFromAncestors(DomElement blockEl)
     {
-        for (var a = blockEl.Parent; a != null && !a.IsTextNode; a = a.Parent)
+        for (var a = ParentEl(blockEl); a != null && !a.IsTextNode; a = ParentEl(a))
         {
             var ap = GetComputedProps(a);
             double? w = TryParsePx(ap.GetValueOrDefault("width"));
@@ -118,7 +118,7 @@ public sealed partial class DomBridge
     /// </summary>
     private double FindContainingBlockHeight(DomElement element)
     {
-        var parent = element.Parent;
+        var parent = ParentEl(element);
         while (parent != null)
         {
             var parentProps = GetComputedProps(parent);
@@ -136,7 +136,7 @@ public sealed partial class DomBridge
                 h -= TryParsePx(parentProps.GetValueOrDefault("padding-bottom")) ?? 0;
                 return h;
             }
-            parent = parent.Parent;
+            parent = ParentEl(parent);
         }
         return _viewportHeight;
     }
@@ -194,9 +194,9 @@ public sealed partial class DomBridge
         double fontSize = TryParsePx(elProps.GetValueOrDefault("font-size")) ?? 16;
 
         // Check parent font-size as well (inline elements inherit).
-        if (element.Parent != null)
+        if (ParentEl(element) != null)
         {
-            var parentProps = GetComputedProps(element.Parent);
+            var parentProps = GetComputedProps(ParentEl(element));
             double parentFs = TryParsePx(parentProps.GetValueOrDefault("font-size")) ?? 16;
             if (parentFs > 0) fontSize = parentFs;
         }
@@ -242,9 +242,9 @@ public sealed partial class DomBridge
         double fontSize = TryParsePx(props.GetValueOrDefault("font-size")) ?? 16;
 
         // Check parent for font-size and line-height (inline elements inherit).
-        if (element.Parent != null)
+        if (ParentEl(element) != null)
         {
-            var parentProps = GetComputedProps(element.Parent);
+            var parentProps = GetComputedProps(ParentEl(element));
             double parentFs = TryParsePx(parentProps.GetValueOrDefault("font-size")) ?? 16;
             if (parentFs > 0) fontSize = parentFs;
 
@@ -402,7 +402,7 @@ public sealed partial class DomBridge
         // - Preceding inline siblings
         // - Line breaks
         // We estimate this from the layout context.
-        var parent = inlineCB.Parent;
+        var parent = ParentEl(inlineCB);
         DomElement? blockAncestor = null;
 
         // Find nearest block-level ancestor.
@@ -418,7 +418,7 @@ public sealed partial class DomBridge
                     break;
                 }
             }
-            parent = parent.Parent;
+            parent = ParentEl(parent);
         }
 
         if (blockAncestor == null) return (0, 0, null);
@@ -444,13 +444,13 @@ public sealed partial class DomBridge
     private double EstimateInlineOffsetX(DomElement inlineEl, DomElement blockAncestor)
     {
         double offset = 0;
-        var parent = inlineEl.Parent;
+        var parent = ParentEl(inlineEl);
         while (parent != null && parent != blockAncestor)
         {
             // Accumulate horizontal position from parent's preceding content
             offset += EstimatePrecedingInlineWidth(inlineEl, parent);
             inlineEl = parent;
-            parent = parent.Parent;
+            parent = ParentEl(parent);
         }
         // Final level: position within the block ancestor
         if (parent == blockAncestor)
@@ -466,12 +466,12 @@ public sealed partial class DomBridge
     private double EstimateInlineOffsetY(DomElement inlineEl, DomElement blockAncestor)
     {
         double offset = 0;
-        var parent = inlineEl.Parent;
+        var parent = ParentEl(inlineEl);
         while (parent != null && parent != blockAncestor)
         {
             offset += EstimatePrecedingBlockHeight(inlineEl, parent);
             inlineEl = parent;
-            parent = parent.Parent;
+            parent = ParentEl(parent);
         }
         if (parent == blockAncestor)
             offset += EstimatePrecedingBlockHeight(inlineEl, blockAncestor);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
@@ -23,7 +23,7 @@ public sealed partial class DomBridge
         if (!element.IsTextNode)
         {
             var cssProps = CollectMatchedRuleProperties(element);
-            foreach (var kv in element.Style)
+            foreach (var kv in InlineStyle(element))
                 cssProps[kv.Key] = kv.Value;
 
             string? positionArea = cssProps.GetValueOrDefault("position-area");
@@ -61,11 +61,11 @@ public sealed partial class DomBridge
                     if (!cssProps.TryGetValue("position", out var origPos) ||
                         !origPos.Equals("fixed", StringComparison.OrdinalIgnoreCase))
                     {
-                        element.Style["position"] = "absolute";
+                        InlineStyle(element)["position"] = "absolute";
                     }
                     else
                     {
-                        element.Style["position"] = "fixed";
+                        InlineStyle(element)["position"] = "fixed";
                     }
 
                     double cellW = rect.Value.Width;
@@ -239,7 +239,7 @@ public sealed partial class DomBridge
                                 var blockProps = GetComputedProps(blockAncestor);
                                 string? blockPos = blockProps.GetValueOrDefault("position");
                                 if (blockPos == null || blockPos == "static")
-                                    blockAncestor.Style["position"] = "relative";
+                                    InlineStyle(blockAncestor)["position"] = "relative";
                             }
 
                             // Defer the move to avoid collection modification
@@ -317,17 +317,17 @@ public sealed partial class DomBridge
 
                         // Set resolved pixel values for margins and padding
                         // to override the percentage values from CSS.
-                        element.Style["margin-top"] = $"{marginTop2.ToString(CultureInfo.InvariantCulture)}px";
-                        element.Style["margin-right"] = $"{marginRight2.ToString(CultureInfo.InvariantCulture)}px";
-                        element.Style["margin-bottom"] = $"{marginBottom2.ToString(CultureInfo.InvariantCulture)}px";
-                        element.Style["margin-left"] = $"{marginLeft2.ToString(CultureInfo.InvariantCulture)}px";
-                        element.Style["padding-top"] = $"{padTop.ToString(CultureInfo.InvariantCulture)}px";
-                        element.Style["padding-right"] = $"{padRight.ToString(CultureInfo.InvariantCulture)}px";
-                        element.Style["padding-bottom"] = $"{padBottom.ToString(CultureInfo.InvariantCulture)}px";
-                        element.Style["padding-left"] = $"{padLeft.ToString(CultureInfo.InvariantCulture)}px";
-                        element.Style.Remove("margin");
-                        element.Style.Remove("padding");
-                        element.Style.Remove("inset");
+                        InlineStyle(element)["margin-top"] = $"{marginTop2.ToString(CultureInfo.InvariantCulture)}px";
+                        InlineStyle(element)["margin-right"] = $"{marginRight2.ToString(CultureInfo.InvariantCulture)}px";
+                        InlineStyle(element)["margin-bottom"] = $"{marginBottom2.ToString(CultureInfo.InvariantCulture)}px";
+                        InlineStyle(element)["margin-left"] = $"{marginLeft2.ToString(CultureInfo.InvariantCulture)}px";
+                        InlineStyle(element)["padding-top"] = $"{padTop.ToString(CultureInfo.InvariantCulture)}px";
+                        InlineStyle(element)["padding-right"] = $"{padRight.ToString(CultureInfo.InvariantCulture)}px";
+                        InlineStyle(element)["padding-bottom"] = $"{padBottom.ToString(CultureInfo.InvariantCulture)}px";
+                        InlineStyle(element)["padding-left"] = $"{padLeft.ToString(CultureInfo.InvariantCulture)}px";
+                        InlineStyle(element).Remove("margin");
+                        InlineStyle(element).Remove("padding");
+                        InlineStyle(element).Remove("inset");
 
                         resolvedW = contentW;
                         resolvedH = contentH;
@@ -363,16 +363,16 @@ public sealed partial class DomBridge
                         // (which maps medium→2px instead of the spec's 3px).
                         // Always set the value (even 0px) to ensure the
                         // renderer doesn't fall back to its keyword defaults.
-                        element.Style["border-top-width"] = $"{bdrT.ToString(CultureInfo.InvariantCulture)}px";
-                        element.Style["border-right-width"] = $"{bdrR.ToString(CultureInfo.InvariantCulture)}px";
-                        element.Style["border-bottom-width"] = $"{bdrB.ToString(CultureInfo.InvariantCulture)}px";
-                        element.Style["border-left-width"] = $"{bdrL.ToString(CultureInfo.InvariantCulture)}px";
+                        InlineStyle(element)["border-top-width"] = $"{bdrT.ToString(CultureInfo.InvariantCulture)}px";
+                        InlineStyle(element)["border-right-width"] = $"{bdrR.ToString(CultureInfo.InvariantCulture)}px";
+                        InlineStyle(element)["border-bottom-width"] = $"{bdrB.ToString(CultureInfo.InvariantCulture)}px";
+                        InlineStyle(element)["border-left-width"] = $"{bdrL.ToString(CultureInfo.InvariantCulture)}px";
                     }
 
-                    element.Style["left"] = $"{finalLeft.ToString(CultureInfo.InvariantCulture)}px";
-                    element.Style["top"] = $"{finalTop.ToString(CultureInfo.InvariantCulture)}px";
-                    element.Style["width"] = $"{resolvedW.ToString(CultureInfo.InvariantCulture)}px";
-                    element.Style["height"] = $"{resolvedH.ToString(CultureInfo.InvariantCulture)}px";
+                    InlineStyle(element)["left"] = $"{finalLeft.ToString(CultureInfo.InvariantCulture)}px";
+                    InlineStyle(element)["top"] = $"{finalTop.ToString(CultureInfo.InvariantCulture)}px";
+                    InlineStyle(element)["width"] = $"{resolvedW.ToString(CultureInfo.InvariantCulture)}px";
+                    InlineStyle(element)["height"] = $"{resolvedH.ToString(CultureInfo.InvariantCulture)}px";
 
                     // Record the scroll container for deferred position:relative.
                     if (scrollContainer != null)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
@@ -20,7 +20,7 @@ public sealed partial class DomBridge
         HashSet<DomElement> scrollContainersNeedingRelative,
         List<(DomElement element, DomElement oldParent, DomElement newParent)> deferredDomMoves)
     {
-        if (!element.IsTextNode)
+        if (!IsText(element))
         {
             var cssProps = CollectMatchedRuleProperties(element);
             foreach (var kv in InlineStyle(element))
@@ -581,7 +581,7 @@ public sealed partial class DomBridge
         double maxWidth = containerWidth;
         foreach (var child in SnapshotChildren(scrollContainer))
         {
-            if (child.IsTextNode) continue;
+            if (IsText(child)) continue;
             var childProps = GetComputedProps(child);
             double? childW = TryParsePx(childProps.GetValueOrDefault("width"));
             if (childW.HasValue)
@@ -608,7 +608,7 @@ public sealed partial class DomBridge
         double stackedHeight = 0;
         foreach (var child in SnapshotChildren(scrollContainer))
         {
-            if (child.IsTextNode) continue;
+            if (IsText(child)) continue;
             var childProps = GetComputedProps(child);
             var pos = childProps.GetValueOrDefault("position");
             if (pos == "absolute" || pos == "fixed")
@@ -651,7 +651,7 @@ public sealed partial class DomBridge
         var parent = ParentEl(el);
         while (parent != null)
         {
-            if (!parent.IsTextNode)
+            if (!IsText(parent))
             {
                 var props = GetComputedProps(parent);
                 if (HasOverflowClipping(props))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
@@ -244,10 +244,10 @@ public sealed partial class DomBridge
 
                             // Defer the move to avoid collection modification
                             // during tree traversal.
-                            if (blockAncestor != null && element.Parent != blockAncestor
-                                && element.Parent != null)
+                            if (blockAncestor != null && ParentEl(element) != blockAncestor
+                                && ParentEl(element) != null)
                             {
-                                deferredDomMoves.Add((element, element.Parent, blockAncestor));
+                                deferredDomMoves.Add((element, ParentEl(element), blockAncestor));
                             }
                         }
                     }
@@ -648,7 +648,7 @@ public sealed partial class DomBridge
     /// </summary>
     private DomElement? FindNearestScrollContainer(DomElement el)
     {
-        var parent = el.Parent;
+        var parent = ParentEl(el);
         while (parent != null)
         {
             if (!parent.IsTextNode)
@@ -657,7 +657,7 @@ public sealed partial class DomBridge
                 if (HasOverflowClipping(props))
                     return parent;
             }
-            parent = parent.Parent;
+            parent = ParentEl(parent);
         }
         return null;
     }
@@ -667,11 +667,11 @@ public sealed partial class DomBridge
     /// </summary>
     private static bool IsDescendantOfElement(DomElement el, DomElement potentialAncestor)
     {
-        var current = el.Parent;
+        var current = ParentEl(el);
         while (current != null)
         {
             if (ReferenceEquals(current, potentialAncestor)) return true;
-            current = current.Parent;
+            current = ParentEl(current);
         }
         return false;
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionAreaQueries.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionAreaQueries.cs
@@ -81,7 +81,7 @@ public sealed partial class DomBridge
 
         // Resolve on-the-fly from CSS properties and inline styles.
         var cssProps = CollectMatchedRuleProperties(element);
-        foreach (var kv in element.Style)
+        foreach (var kv in InlineStyle(element))
             cssProps[kv.Key] = kv.Value;
 
         string? positionArea = cssProps.GetValueOrDefault("position-area");

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
@@ -34,7 +34,7 @@ public sealed partial class DomBridge
         {
             foreach (var child in SnapshotChildren(el))
             {
-                if (child.IsTextNode && !string.IsNullOrEmpty(child.TextContent))
+                if (IsText(child) && !string.IsNullOrEmpty(child.TextContent))
                 {
                     // Strip CSS comments first: a comment inside a @position-try
                     // body (common in WPT, e.g. "/* 2: position right */") contains
@@ -81,7 +81,7 @@ public sealed partial class DomBridge
         Dictionary<string, AnchorInfo> anchorRegistry,
         Dictionary<string, Dictionary<string, string>> positionTryRules)
     {
-        if (!element.IsTextNode &&
+        if (!IsText(element) &&
             !string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
         {
             // Collect all CSS + inline properties to find position-try-fallbacks.
@@ -283,7 +283,7 @@ public sealed partial class DomBridge
         double maxWidth = 0;
         foreach (var child in SnapshotChildren(element))
         {
-            if (child.IsTextNode) continue;
+            if (IsText(child)) continue;
             var childProps = CollectMatchedRuleProperties(child);
             foreach (var kv in InlineStyle(child))
                 childProps[kv.Key] = kv.Value;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
@@ -86,7 +86,7 @@ public sealed partial class DomBridge
         {
             // Collect all CSS + inline properties to find position-try-fallbacks.
             var cssProps = CollectMatchedRuleProperties(element);
-            foreach (var kv in element.Style)
+            foreach (var kv in InlineStyle(element))
                 cssProps[kv.Key] = kv.Value;
 
             string? fallbacks = cssProps.GetValueOrDefault("position-try-fallbacks") ??
@@ -116,15 +116,15 @@ public sealed partial class DomBridge
         double cbHeight = FindContainingBlockHeight(element);
 
         // Check if the base style overflows the IMCB.
-        double baseLeft = TryParsePx(element.Style.GetValueOrDefault("left")) ?? 0;
-        double baseTop = TryParsePx(element.Style.GetValueOrDefault("top")) ?? 0;
-        double baseRight = TryParsePx(element.Style.GetValueOrDefault("right")) ??
+        double baseLeft = TryParsePx(InlineStyle(element).GetValueOrDefault("left")) ?? 0;
+        double baseTop = TryParsePx(InlineStyle(element).GetValueOrDefault("top")) ?? 0;
+        double baseRight = TryParsePx(InlineStyle(element).GetValueOrDefault("right")) ??
                            TryParsePx(baseProps.GetValueOrDefault("right")) ?? 0;
-        double baseBottom = TryParsePx(element.Style.GetValueOrDefault("bottom")) ??
+        double baseBottom = TryParsePx(InlineStyle(element).GetValueOrDefault("bottom")) ??
                             TryParsePx(baseProps.GetValueOrDefault("bottom")) ?? 0;
-        double baseWidth = TryParsePx(element.Style.GetValueOrDefault("width")) ??
+        double baseWidth = TryParsePx(InlineStyle(element).GetValueOrDefault("width")) ??
                            TryParsePx(baseProps.GetValueOrDefault("width")) ?? 0;
-        double baseHeight = TryParsePx(element.Style.GetValueOrDefault("height")) ??
+        double baseHeight = TryParsePx(InlineStyle(element).GetValueOrDefault("height")) ??
                             TryParsePx(baseProps.GetValueOrDefault("height")) ?? 0;
 
         // Compute IMCB (inset-modified containing block) dimensions.
@@ -262,13 +262,13 @@ public sealed partial class DomBridge
             if (fits)
             {
                 // Apply the fallback: set resolved values as inline styles.
-                element.Style["left"] = $"{tryLeft.ToString(CultureInfo.InvariantCulture)}px";
-                element.Style["top"] = $"{tryTop.ToString(CultureInfo.InvariantCulture)}px";
-                element.Style["width"] = $"{tryWidth.ToString(CultureInfo.InvariantCulture)}px";
-                element.Style["height"] = $"{tryHeight.ToString(CultureInfo.InvariantCulture)}px";
-                element.Style.Remove("right");
-                element.Style.Remove("bottom");
-                element.Style.Remove("inset");
+                InlineStyle(element)["left"] = $"{tryLeft.ToString(CultureInfo.InvariantCulture)}px";
+                InlineStyle(element)["top"] = $"{tryTop.ToString(CultureInfo.InvariantCulture)}px";
+                InlineStyle(element)["width"] = $"{tryWidth.ToString(CultureInfo.InvariantCulture)}px";
+                InlineStyle(element)["height"] = $"{tryHeight.ToString(CultureInfo.InvariantCulture)}px";
+                InlineStyle(element).Remove("right");
+                InlineStyle(element).Remove("bottom");
+                InlineStyle(element).Remove("inset");
                 return;
             }
         }
@@ -285,7 +285,7 @@ public sealed partial class DomBridge
         {
             if (child.IsTextNode) continue;
             var childProps = CollectMatchedRuleProperties(child);
-            foreach (var kv in child.Style)
+            foreach (var kv in InlineStyle(child))
                 childProps[kv.Key] = kv.Value;
 
             double childWidth = TryParsePx(childProps.GetValueOrDefault("width")) ?? 0;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
@@ -20,7 +20,7 @@ public sealed partial class DomBridge
     }
     private void ApplyScrollSimulationTree(DomElement el)
     {
-        if (!el.IsTextNode)
+        if (!IsText(el))
         {
             double scrollTop = 0;
             double scrollLeft = 0;
@@ -103,7 +103,7 @@ public sealed partial class DomBridge
                         double childOffset = 0;
                         foreach (var child in SnapshotChildren(wrapper))
                         {
-                            if (child.IsTextNode) continue;
+                            if (IsText(child)) continue;
                             var cp = GetComputedProps(child);
                             var childPos = cp.GetValueOrDefault("position");
                             if (childPos == "absolute" || childPos == "fixed")
@@ -141,7 +141,7 @@ public sealed partial class DomBridge
     {
         foreach (var child in SnapshotChildren(parent))
         {
-            if (child.IsTextNode) continue;
+            if (IsText(child)) continue;
             var cp = GetComputedProps(child);
             var pos = cp.GetValueOrDefault("position");
             if (pos == "fixed")

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
@@ -68,7 +68,7 @@ public sealed partial class DomBridge
                     el.Children.Add(wrapper);
                     foreach (var child in originalChildren)
                     {
-                        child.Parent = wrapper;
+                        SetParent(child, wrapper);
                         wrapper.Children.Add(child);
                     }
 
@@ -84,8 +84,8 @@ public sealed partial class DomBridge
                         CollectFixedDescendants(wrapper, fixedDescendants);
                         foreach (var fixedEl in fixedDescendants)
                         {
-                            fixedEl.Parent?.Children.Remove(fixedEl);
-                            fixedEl.Parent = el;
+                            ParentEl(fixedEl)?.Children.Remove(fixedEl);
+                            SetParent(fixedEl, el);
                             el.Children.Add(fixedEl);
                         }
                     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
@@ -55,12 +55,12 @@ public sealed partial class DomBridge
                     // avoiding the rendering artefact where negative-margin
                     // spacers can leak above the container's top edge.
                     var wrapper = new DomElement(_document, "div", null, null, "");
-                    wrapper.Style["position"] = "relative";
+                    InlineStyle(wrapper)["position"] = "relative";
                     if (scrollTop != 0)
-                        wrapper.Style["top"] =
+                        InlineStyle(wrapper)["top"] =
                             $"{(-scrollTop).ToString(CultureInfo.InvariantCulture)}px";
                     if (scrollLeft != 0)
-                        wrapper.Style["left"] =
+                        InlineStyle(wrapper)["left"] =
                             $"{(-scrollLeft).ToString(CultureInfo.InvariantCulture)}px";
 
                     var originalChildren = SnapshotChildren(el);
@@ -115,7 +115,7 @@ public sealed partial class DomBridge
                             childOffset += childMT;
                             if (childOffset + childH <= scrollTop)
                             {
-                                child.Style["visibility"] = "hidden";
+                                InlineStyle(child)["visibility"] = "hidden";
                                 childOffset += childH;
                             }
                             else

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
@@ -46,7 +46,7 @@ public sealed partial class DomBridge
                 bool isDocScrollingElement =
                     string.Equals(el.TagName, "html", StringComparison.OrdinalIgnoreCase);
 
-                if ((clips || isDocScrollingElement) && el.Children.Count > 0)
+                if ((clips || isDocScrollingElement) && el.ChildNodes.Count > 0)
                 {
                     // Wrap all children in a positioned div that shifts content
                     // upward / leftward.  Using position:relative + top/left
@@ -64,12 +64,12 @@ public sealed partial class DomBridge
                             $"{(-scrollLeft).ToString(CultureInfo.InvariantCulture)}px";
 
                     var originalChildren = SnapshotChildren(el);
-                    el.Children.Clear();
-                    el.Children.Add(wrapper);
+                    ClearChildren(el);
+                    el.AppendChild(wrapper);
                     foreach (var child in originalChildren)
                     {
                         SetParent(child, wrapper);
-                        wrapper.Children.Add(child);
+                        wrapper.AppendChild(child);
                     }
 
                     // For the document scrolling element, extract ALL
@@ -84,9 +84,9 @@ public sealed partial class DomBridge
                         CollectFixedDescendants(wrapper, fixedDescendants);
                         foreach (var fixedEl in fixedDescendants)
                         {
-                            ParentEl(fixedEl)?.Children.Remove(fixedEl);
+                            fixedEl.Remove();
                             SetParent(fixedEl, el);
-                            el.Children.Add(fixedEl);
+                            el.AppendChild(fixedEl);
                         }
                     }
 
@@ -130,8 +130,8 @@ public sealed partial class DomBridge
 
         // Use index-based loop because the list may grow during iteration
         // (wrapper insertion above).
-        for (int i = 0; i < el.Children.Count; i++)
-            ApplyScrollSimulationTree(el.Children[i]);
+        for (int i = 0; i < el.ChildNodes.Count; i++)
+            ApplyScrollSimulationTree(ChildAt(el, i));
     }
     /// <summary>
     /// Recursively collects all descendants with <c>position: fixed</c>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/StickyPositioning.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/StickyPositioning.cs
@@ -33,8 +33,8 @@ public sealed partial class DomBridge
 
         // Index-based: ApplyStickyOffset only mutates el's own style, not the
         // child list, but stay defensive.
-        for (int i = 0; i < el.Children.Count; i++)
-            ResolveStickyPositioningTree(el.Children[i]);
+        for (int i = 0; i < el.ChildNodes.Count; i++)
+            ResolveStickyPositioningTree(ChildAt(el, i));
     }
 
     private void ApplyStickyOffset(DomElement el)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/StickyPositioning.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/StickyPositioning.cs
@@ -53,17 +53,17 @@ public sealed partial class DomBridge
         // position as `relative` + offset reproduces it.  Relative and sticky
         // both establish a containing block / stacking context, so this is
         // behaviour-preserving for descendants.
-        el.Style["position"] = "relative";
+        InlineStyle(el)["position"] = "relative";
 
         if (dy != 0)
         {
-            el.Style["top"] = dy.ToString("0.###", CultureInfo.InvariantCulture) + "px";
-            el.Style.Remove("bottom");
+            InlineStyle(el)["top"] = dy.ToString("0.###", CultureInfo.InvariantCulture) + "px";
+            InlineStyle(el).Remove("bottom");
         }
         if (dx != 0)
         {
-            el.Style["left"] = dx.ToString("0.###", CultureInfo.InvariantCulture) + "px";
-            el.Style.Remove("right");
+            InlineStyle(el)["left"] = dx.ToString("0.###", CultureInfo.InvariantCulture) + "px";
+            InlineStyle(el).Remove("right");
         }
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/StickyPositioning.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/StickyPositioning.cs
@@ -28,7 +28,7 @@ public sealed partial class DomBridge
 
     private void ResolveStickyPositioningTree(DomElement el)
     {
-        if (!el.IsTextNode && IsSticky(GetComputedProps(el)))
+        if (!IsText(el) && IsSticky(GetComputedProps(el)))
             ApplyStickyOffset(el);
 
         // Index-based: ApplyStickyOffset only mutates el's own style, not the
@@ -155,7 +155,7 @@ public sealed partial class DomBridge
     {
         for (var current = GetScrollTraversalParent(el); current != null; current = GetScrollTraversalParent(current))
         {
-            if (current.IsTextNode)
+            if (IsText(current))
                 continue;
             var display = GetComputedProps(current).GetValueOrDefault("display") ?? "block";
             bool inlineLevel = display is "inline" or "inline-block" or "inline-table"

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Visibility.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Visibility.cs
@@ -52,7 +52,7 @@ public sealed partial class DomBridge
                         var anchorEl = FindElementByAnchorName(posAnchor);
                         if (anchorEl != null && !IsAnchorVisibleForTarget(anchorEl, el))
                         {
-                            el.Style["display"] = "none";
+                            InlineStyle(el)["display"] = "none";
                         }
                     }
                 }
@@ -84,7 +84,7 @@ public sealed partial class DomBridge
                     }
 
                     if (!hasValidAnchor)
-                        el.Style["display"] = "none";
+                        InlineStyle(el)["display"] = "none";
                 }
             }
         }
@@ -105,7 +105,7 @@ public sealed partial class DomBridge
         {
             if (el.IsTextNode) continue;
             // Check inline styles first.
-            if (el.Style.TryGetValue("anchor-name", out var n) &&
+            if (InlineStyle(el).TryGetValue("anchor-name", out var n) &&
                 string.Equals(n.Trim(), anchorName, StringComparison.Ordinal))
                 return el;
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Visibility.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Visibility.cs
@@ -139,7 +139,7 @@ public sealed partial class DomBridge
         var targetCB = FindContainingBlockElement(target);
 
         // Walk from the anchor upward looking for scroll containers.
-        var el = anchor.Parent;
+        var el = ParentEl(anchor);
         while (el != null)
         {
             var props = GetComputedProps(el);
@@ -172,7 +172,7 @@ public sealed partial class DomBridge
                 }
             }
 
-            el = el.Parent;
+            el = ParentEl(el);
         }
 
         return true;
@@ -189,7 +189,7 @@ public sealed partial class DomBridge
             if (props.TryGetValue("visibility", out var v) &&
                 v.Equals("hidden", StringComparison.OrdinalIgnoreCase))
                 return true;
-            current = current.Parent;
+            current = ParentEl(current);
         }
         return false;
     }
@@ -207,7 +207,7 @@ public sealed partial class DomBridge
             offset += ComputePrecedingSiblingHeights(current);
             var props = GetComputedProps(current);
             offset += TryParsePx(props.GetValueOrDefault("margin-top")) ?? 0;
-            current = current.Parent;
+            current = ParentEl(current);
             if (current != null && current != container)
             {
                 var cProps = GetComputedProps(current);
@@ -223,13 +223,13 @@ public sealed partial class DomBridge
     /// </summary>
     private DomElement? FindContainingBlockElement(DomElement el)
     {
-        var parent = el.Parent;
+        var parent = ParentEl(el);
         while (parent != null)
         {
             var pProps = GetComputedProps(parent);
             if (EstablishesContainingBlock(pProps))
                 return parent;
-            parent = parent.Parent;
+            parent = ParentEl(parent);
         }
         return null;
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Visibility.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Visibility.cs
@@ -21,7 +21,7 @@ public sealed partial class DomBridge
         DomElement el,
         Dictionary<string, AnchorInfo> anchorRegistry)
     {
-        if (!el.IsTextNode)
+        if (!IsText(el))
         {
             var props = GetComputedProps(el);
             string? posVis = props.GetValueOrDefault("position-visibility");
@@ -103,7 +103,7 @@ public sealed partial class DomBridge
     {
         foreach (var el in Elements)
         {
-            if (el.IsTextNode) continue;
+            if (IsText(el)) continue;
             // Check inline styles first.
             if (InlineStyle(el).TryGetValue("anchor-name", out var n) &&
                 string.Equals(n.Trim(), anchorName, StringComparison.Ordinal))
@@ -113,7 +113,7 @@ public sealed partial class DomBridge
         // Fall back to the shared cascade.
         foreach (var el in Elements)
         {
-            if (el.IsTextNode) continue;
+            if (IsText(el)) continue;
             var declarations = CollectMatchedRuleProperties(el);
             if (declarations.TryGetValue("anchor-name", out var name) &&
                 string.Equals(name.Trim(), anchorName, StringComparison.Ordinal))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
@@ -171,7 +171,7 @@ public sealed partial class DomBridge
     {
         // Walk up to find <style> elements.
         var root = element;
-        while (root.Parent != null) root = root.Parent;
+        while (ParentEl(root) != null) root = ParentEl(root);
 
         Dictionary<string, string>? result = null;
         CollectAnimPropsFromStyleElements(root, element, ref result);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
@@ -45,7 +45,7 @@ public sealed partial class DomBridge
             if (string.IsNullOrEmpty(css))
             {
                 css = string.Concat(root.Children
-                    .Where(c => c.IsTextNode)
+                    .Where(c => IsText(c))
                     .Select(c => c.TextContent ?? string.Empty));
             }
             var styleSheet = new Broiler.CSS.CssParser().ParseStyleSheet(css);
@@ -187,7 +187,7 @@ public sealed partial class DomBridge
             if (string.IsNullOrEmpty(css))
             {
                 css = string.Concat(node.Children
-                    .Where(c => c.IsTextNode)
+                    .Where(c => IsText(c))
                     .Select(c => c.TextContent ?? string.Empty));
             }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
@@ -120,11 +120,11 @@ public sealed partial class DomBridge
         string? animValue = null, delayValue = null, nameValue = null;
         bool hasAnimation = false, hasDelay = false, hasName = false;
 
-        if (element.Style.Count > 0)
+        if (InlineStyle(element).Count > 0)
         {
-            hasAnimation = element.Style.TryGetValue("animation", out animValue);
-            hasDelay = element.Style.TryGetValue("animation-delay", out delayValue);
-            hasName = element.Style.TryGetValue("animation-name", out nameValue);
+            hasAnimation = InlineStyle(element).TryGetValue("animation", out animValue);
+            hasDelay = InlineStyle(element).TryGetValue("animation-delay", out delayValue);
+            hasName = InlineStyle(element).TryGetValue("animation-name", out nameValue);
         }
 
         // Also check stylesheet rules that may apply to this element.
@@ -320,7 +320,7 @@ public sealed partial class DomBridge
                     if (fillMode is "backwards" or "both")
                     {
                         foreach (var kv in keyframes[0].Properties)
-                            element.Style[kv.Key] = kv.Value;
+                            InlineStyle(element)[kv.Key] = kv.Value;
                     }
                     return;
                 }
@@ -353,13 +353,13 @@ public sealed partial class DomBridge
 
         // Apply resolved values as inline styles and remove animation properties.
         foreach (var kv in resolvedProps)
-            element.Style[kv.Key] = kv.Value;
+            InlineStyle(element)[kv.Key] = kv.Value;
 
-        element.Style.Remove("animation");
-        element.Style.Remove("animation-delay");
-        element.Style.Remove("animation-name");
-        element.Style.Remove("animation-duration");
-        element.Style.Remove("animation-timing-function");
+        InlineStyle(element).Remove("animation");
+        InlineStyle(element).Remove("animation-delay");
+        InlineStyle(element).Remove("animation-name");
+        InlineStyle(element).Remove("animation-duration");
+        InlineStyle(element).Remove("animation-timing-function");
     }
 
     private Dictionary<string, string> ResolveKeyframeProperties(

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
@@ -44,7 +44,7 @@ public sealed partial class DomBridge
             // Fall back to concatenating child text nodes when TextContent is not set.
             if (string.IsNullOrEmpty(css))
             {
-                css = string.Concat(root.Children
+                css = string.Concat(ChildElements(root)
                     .Where(c => IsText(c))
                     .Select(c => c.TextContent ?? string.Empty));
             }
@@ -61,7 +61,7 @@ public sealed partial class DomBridge
             }
         }
 
-        foreach (var child in root.Children)
+        foreach (var child in ChildElements(root))
             CollectKeyframes(child, map);
     }
 
@@ -186,7 +186,7 @@ public sealed partial class DomBridge
             var css = node.TextContent;
             if (string.IsNullOrEmpty(css))
             {
-                css = string.Concat(node.Children
+                css = string.Concat(ChildElements(node)
                     .Where(c => IsText(c))
                     .Select(c => c.TextContent ?? string.Empty));
             }
@@ -213,7 +213,7 @@ public sealed partial class DomBridge
             }
         }
 
-        foreach (var child in node.Children)
+        foreach (var child in ChildElements(node))
             CollectAnimPropsFromStyleElements(child, target, ref result);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
@@ -229,9 +229,9 @@ public sealed partial class DomBridge
             element.ClassName = attrVal;
         else if (string.Equals(attrName, "style", StringComparison.OrdinalIgnoreCase))
         {
-            element.Style.Clear();
+            InlineStyle(element).Clear();
             foreach (var kv in ParseStyle(attrVal, reportDrops: true))
-                element.Style[kv.Key] = kv.Value;
+                InlineStyle(element)[kv.Key] = kv.Value;
             InvalidateStyleScope(element);
         }
         else if (attrName.Length > 2 && attrName.StartsWith("on", StringComparison.OrdinalIgnoreCase))
@@ -284,9 +284,9 @@ public sealed partial class DomBridge
             element.ClassName = attrVal;
         else if (string.Equals(attrName, "style", StringComparison.OrdinalIgnoreCase))
         {
-            element.Style.Clear();
+            InlineStyle(element).Clear();
             foreach (var kv in ParseStyle(attrVal, reportDrops: true))
-                element.Style[kv.Key] = kv.Value;
+                InlineStyle(element)[kv.Key] = kv.Value;
             InvalidateStyleScope(element);
         }
         else if (attrName.Length > 2 && attrName.StartsWith("on", StringComparison.OrdinalIgnoreCase))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
@@ -10,6 +10,105 @@ namespace Broiler.HtmlBridge;
 
 public sealed partial class DomBridge
 {
+    // -----------------------------------------------------------------
+    // RF-BRIDGE-1c Phase C: string-keyed attribute access over canonical
+    // Broiler.Dom attributes, replacing the removed DomElement.Attributes
+    // (LegacyAttributeDictionary) facade. Each helper mirrors the legacy
+    // dictionary's semantics exactly — a case-insensitive scan by qualified
+    // name over the canonical (namespace-keyed) attribute set — so the
+    // migration is behaviour-preserving (same O(n) scan the shim did).
+    // -----------------------------------------------------------------
+
+    /// <summary>Legacy <c>Attributes.TryGetValue</c>: case-insensitive lookup by
+    /// qualified name; <paramref name="value"/> is <c>""</c> when absent.</summary>
+    private static bool TryGetAttribute(DomElement element, string qualifiedName, out string value)
+    {
+        foreach (var attribute in element.Attributes.Values)
+        {
+            if (string.Equals(attribute.QualifiedName, qualifiedName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = attribute.Value;
+                return true;
+            }
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    /// <summary>Legacy <c>Attributes.GetValueOrDefault</c> / null-returning indexer get.</summary>
+    private static string? GetAttr(DomElement element, string qualifiedName) =>
+        TryGetAttribute(element, qualifiedName, out var value) ? value : null;
+
+    /// <summary>Legacy <c>Attributes.ContainsKey</c>.</summary>
+    private static bool HasAttr(DomElement element, string qualifiedName) =>
+        TryGetAttribute(element, qualifiedName, out _);
+
+    /// <summary>Legacy string-keyed <c>Attributes[name] = value</c> setter: updates an
+    /// existing attribute in place (preserving its namespace) or creates a no-namespace one.</summary>
+    private static void SetAttr(DomElement element, string qualifiedName, string value)
+    {
+        Broiler.Dom.DomAttribute? existing = null;
+        foreach (var attribute in element.Attributes.Values)
+        {
+            if (string.Equals(attribute.QualifiedName, qualifiedName, StringComparison.OrdinalIgnoreCase))
+            {
+                existing = attribute;
+                break;
+            }
+        }
+
+        if (existing is { } found)
+            element.SetAttributeNS(found.NamespaceUri, found.QualifiedName, value);
+        else
+            element.SetAttribute(qualifiedName, value);
+    }
+
+    /// <summary>Legacy <c>Attributes.Remove</c>: removes the attribute matched by qualified name.</summary>
+    private static bool RemoveAttr(DomElement element, string qualifiedName)
+    {
+        Broiler.Dom.DomAttribute? existing = null;
+        foreach (var attribute in element.Attributes.Values)
+        {
+            if (string.Equals(attribute.QualifiedName, qualifiedName, StringComparison.OrdinalIgnoreCase))
+            {
+                existing = attribute;
+                break;
+            }
+        }
+
+        return existing is { } found && element.RemoveAttributeNS(found.NamespaceUri, found.LocalName);
+    }
+
+    /// <summary>Legacy <c>Attributes.Keys</c>: the qualified names of the element's attributes.</summary>
+    private static IEnumerable<string> AttributeNames(DomElement element) =>
+        element.Attributes.Values.Select(static attribute => attribute.QualifiedName);
+
+    /// <summary>Legacy enumeration/snapshot of the string-keyed attribute map (qualified
+    /// name → value, case-insensitive, last-wins on collision — matching the old
+    /// <c>LegacyAttributeDictionary.Snapshot</c>).</summary>
+    private static Dictionary<string, string> AttributeSnapshot(DomElement element)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var attribute in element.Attributes.Values)
+            result[attribute.QualifiedName] = attribute.Value;
+        return result;
+    }
+
+    /// <summary>Restores the element's attribute set to <paramref name="saved"/> — the
+    /// attribute-map equivalent of <c>RestoreStringMap</c> (remove extras, then set saved).</summary>
+    private static void RestoreAttributes(DomElement element, Dictionary<string, string> saved)
+    {
+        foreach (var name in AttributeNames(element).ToList())
+        {
+            if (!saved.ContainsKey(name))
+                RemoveAttr(element, name);
+        }
+
+        foreach (var kv in saved)
+            SetAttr(element, kv.Key, kv.Value);
+    }
+
     private void CollectByTagName(DomElement root, string tag, List<JSValue> results)
     {
         foreach (var child in root.Children)
@@ -31,7 +130,7 @@ public sealed partial class DomBridge
             if (!child.IsTextNode &&
                 (string.Equals(child.TagName, "a", StringComparison.OrdinalIgnoreCase) ||
                  string.Equals(child.TagName, "area", StringComparison.OrdinalIgnoreCase)) &&
-                child.Attributes.ContainsKey("href"))
+                HasAttr(child, "href"))
             {
                 results.Add(ToJSObject(child));
             }
@@ -119,7 +218,7 @@ public sealed partial class DomBridge
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Numeric index access — expose each attribute by index
-        var attrKeys = element.Attributes.Keys.ToList();
+        var attrKeys = AttributeNames(element).ToList();
         for (var i = 0; i < attrKeys.Count; i++)
         {
             var idx = i;
@@ -221,8 +320,8 @@ public sealed partial class DomBridge
 
     private void SetAttributeLikeSetAttribute(DomElement element, string attrName, string attrVal)
     {
-        element.Attributes.TryGetValue(attrName, out var previousAttrVal);
-        element.Attributes[attrName] = attrVal;
+        TryGetAttribute(element, attrName, out var previousAttrVal);
+        SetAttr(element, attrName, attrVal);
         if (string.Equals(attrName, "id", StringComparison.OrdinalIgnoreCase))
             element.Id = attrVal;
         else if (string.Equals(attrName, "class", StringComparison.OrdinalIgnoreCase))
@@ -248,8 +347,8 @@ public sealed partial class DomBridge
 
     private void RemoveAttributeLikeRemoveAttribute(DomElement element, string attrName)
     {
-        element.Attributes.TryGetValue(attrName, out var previousAttrVal);
-        var removed = element.Attributes.Remove(attrName);
+        TryGetAttribute(element, attrName, out var previousAttrVal);
+        var removed = RemoveAttr(element, attrName);
         foreach (var key in element.NsAttrMap.Where(kv => string.Equals(kv.Value, attrName, StringComparison.OrdinalIgnoreCase)).Select(kv => kv.Key).ToList())
             element.NsAttrMap.Remove(key);
         if (string.Equals(attrName, "id", StringComparison.OrdinalIgnoreCase))
@@ -267,13 +366,13 @@ public sealed partial class DomBridge
         string? previousAttrVal = null;
         if (element.NsAttrMap.TryGetValue((namespaceUri, localName), out var previousQualifiedName))
         {
-            element.Attributes.TryGetValue(previousQualifiedName, out previousAttrVal);
+            TryGetAttribute(element, previousQualifiedName, out previousAttrVal);
             if (!string.Equals(previousQualifiedName, attrName, StringComparison.OrdinalIgnoreCase))
-                element.Attributes.Remove(previousQualifiedName);
+                RemoveAttr(element, previousQualifiedName);
         }
         else
         {
-            element.Attributes.TryGetValue(attrName, out previousAttrVal);
+            TryGetAttribute(element, attrName, out previousAttrVal);
         }
 
         element.SetAttributeNS(namespaceUri, attrName, attrVal);
@@ -306,8 +405,8 @@ public sealed partial class DomBridge
         if (!element.NsAttrMap.TryGetValue((namespaceUri, localName), out var attrName))
             return;
 
-        element.Attributes.TryGetValue(attrName, out var previousAttrVal);
-        var removed = element.Attributes.Remove(attrName);
+        TryGetAttribute(element, attrName, out var previousAttrVal);
+        var removed = RemoveAttr(element, attrName);
         element.NsAttrMap.Remove((namespaceUri, localName));
         if (string.Equals(attrName, "id", StringComparison.OrdinalIgnoreCase))
             element.Id = null;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
@@ -111,7 +111,7 @@ public sealed partial class DomBridge
 
     private void CollectByTagName(DomElement root, string tag, List<JSValue> results)
     {
-        foreach (var child in root.Children)
+        foreach (var child in ChildElements(root))
         {
             if (!IsText(child) && (tag == "*" || string.Equals(child.TagName, tag, StringComparison.OrdinalIgnoreCase)))
                 results.Add(ToJSObject(child));
@@ -125,7 +125,7 @@ public sealed partial class DomBridge
     /// </summary>
     private void CollectLinksInTreeOrder(DomElement root, List<JSValue> results)
     {
-        foreach (var child in root.Children)
+        foreach (var child in ChildElements(root))
         {
             if (!IsText(child) &&
                 (string.Equals(child.TagName, "a", StringComparison.OrdinalIgnoreCase) ||
@@ -141,7 +141,7 @@ public sealed partial class DomBridge
     /// <summary>Collects all elements matching a predicate in a sub-tree.</summary>
     private void CollectMatching(DomElement root, Func<DomElement, bool> predicate, List<JSValue> results)
     {
-        foreach (var child in root.Children)
+        foreach (var child in ChildElements(root))
         {
             if (!IsText(child) && predicate(child))
                 results.Add(ToJSObject(child));
@@ -153,7 +153,7 @@ public sealed partial class DomBridge
     private static void CollectSubDocElements(DomElement root, List<DomElement> list)
     {
         list.Add(root);
-        foreach (var child in root.Children)
+        foreach (var child in ChildElements(root))
             CollectSubDocElements(child, list);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
@@ -113,7 +113,7 @@ public sealed partial class DomBridge
     {
         foreach (var child in root.Children)
         {
-            if (!child.IsTextNode && (tag == "*" || string.Equals(child.TagName, tag, StringComparison.OrdinalIgnoreCase)))
+            if (!IsText(child) && (tag == "*" || string.Equals(child.TagName, tag, StringComparison.OrdinalIgnoreCase)))
                 results.Add(ToJSObject(child));
             CollectByTagName(child, tag, results);
         }
@@ -127,7 +127,7 @@ public sealed partial class DomBridge
     {
         foreach (var child in root.Children)
         {
-            if (!child.IsTextNode &&
+            if (!IsText(child) &&
                 (string.Equals(child.TagName, "a", StringComparison.OrdinalIgnoreCase) ||
                  string.Equals(child.TagName, "area", StringComparison.OrdinalIgnoreCase)) &&
                 HasAttr(child, "href"))
@@ -143,7 +143,7 @@ public sealed partial class DomBridge
     {
         foreach (var child in root.Children)
         {
-            if (!child.IsTextNode && predicate(child))
+            if (!IsText(child) && predicate(child))
                 results.Add(ToJSObject(child));
             CollectMatching(child, predicate, results);
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/CheckLayoutAssertions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/CheckLayoutAssertions.cs
@@ -69,7 +69,7 @@ public sealed partial class DomBridge
             }
         }
 
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
             CollectCheckLayoutAssertions(child, results);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/CheckLayoutAssertions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/CheckLayoutAssertions.cs
@@ -61,7 +61,7 @@ public sealed partial class DomBridge
     {
         foreach (var (attribute, property) in CheckLayoutAttributeMap)
         {
-            if (element.Attributes.TryGetValue(attribute, out var raw) &&
+            if (TryGetAttribute(element, attribute, out var raw) &&
                 double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var expected))
             {
                 results.Add(new CheckLayoutAssertion(
@@ -108,7 +108,7 @@ public sealed partial class DomBridge
                 builder.Append('.').Append(firstClass);
         }
 
-        if (element.Attributes.TryGetValue("title", out var title) && !string.IsNullOrEmpty(title))
+        if (TryGetAttribute(element, "title", out var title) && !string.IsNullOrEmpty(title))
             builder.Append("[title=").Append(title).Append(']');
 
         return builder.ToString();

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -138,12 +138,12 @@ public sealed partial class DomBridge
     private static DomElement GetDocumentRootFor(DomElement el)
     {
         var root = el;
-        while (root.Parent != null)
+        while (ParentEl(root) != null)
         {
             // If we've reached a document root, stop here
             if (root.TagName.StartsWith("#", StringComparison.Ordinal))
                 return root;
-            root = root.Parent;
+            root = ParentEl(root);
         }
         return root;
     }
@@ -325,10 +325,10 @@ public sealed partial class DomBridge
 
     private void ApplyInheritedProperties(Dictionary<string, string> computed, DomElement element)
     {
-        if (element.Parent == null)
+        if (ParentEl(element) == null)
             return;
 
-        var parentProps = GetComputedProps(element.Parent);
+        var parentProps = GetComputedProps(ParentEl(element));
         foreach (var property in CSS.Dom.CssComputedDefaults.InheritedProperties)
         {
             if (computed.ContainsKey(property))
@@ -1455,7 +1455,7 @@ public sealed partial class DomBridge
 
         // Walk up from docRoot to find the containing iframe/object element
         // The docRoot is typically a #subdoc-root child of the iframe element
-        var parent = docRoot.Parent;
+        var parent = ParentEl(docRoot);
         if (parent != null && !parent.TagName.StartsWith("#", StringComparison.Ordinal))
         {
             // parent is the iframe/object element — check its style for dimensions

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -66,7 +66,7 @@ public sealed partial class DomBridge
 
         // Remove all CSS-derived properties (keep inline ones AND JS-set ones).
         var keysToRemove = element.Style.Keys
-            .Where(k => !inlineStyleProps.Contains(k) && !element.JsSetStyleProps.Contains(k))
+            .Where(k => !inlineStyleProps.Contains(k) && !GetElementRuntimeState(element).JsSetStyleProps.Contains(k))
             .ToList();
         foreach (var key in keysToRemove)
             element.Style.Remove(key);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -58,7 +58,7 @@ public sealed partial class DomBridge
         // 1. Collect property names that come from the inline style attribute.
         //    These must never be cleared or overwritten by the cascade.
         var inlineStyleProps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (element.Attributes.TryGetValue("style", out var inlineStyle) &&
+        if (TryGetAttribute(element, "style", out var inlineStyle) &&
             !string.IsNullOrEmpty(inlineStyle))
         {
             foreach (var kv in ParseStyle(inlineStyle))
@@ -313,7 +313,7 @@ public sealed partial class DomBridge
             StringComparer.OrdinalIgnoreCase);
 
         if (pseudoElement == null &&
-            element.Attributes.TryGetValue("style", out var inlineStyleAttr) &&
+            TryGetAttribute(element, "style", out var inlineStyleAttr) &&
             !string.IsNullOrEmpty(inlineStyleAttr))
         {
             foreach (var kv in ParseStyle(inlineStyleAttr))
@@ -381,7 +381,7 @@ public sealed partial class DomBridge
         switch (tag)
         {
             case "input":
-                string type = element.Attributes.GetValueOrDefault("type")?.ToLowerInvariant() ?? "text";
+                string type = GetAttr(element, "type")?.ToLowerInvariant() ?? "text";
                 switch (type)
                 {
                     case "hidden":
@@ -398,7 +398,7 @@ public sealed partial class DomBridge
                     case "reset":
                         logicalInlineSize = 72;
                         logicalBlockSize = 20;
-                        ApplyButtonLikeMultilineSizing(ref logicalInlineSize, ref logicalBlockSize, element.Attributes.GetValueOrDefault("value"));
+                        ApplyButtonLikeMultilineSizing(ref logicalInlineSize, ref logicalBlockSize, GetAttr(element, "value"));
                         break;
                     default:
                         logicalInlineSize = 173;
@@ -487,8 +487,8 @@ public sealed partial class DomBridge
 
     private static int GetSelectVisibleRowCount(DomElement element)
     {
-        bool isMultiple = element.Attributes.ContainsKey("multiple");
-        if (element.Attributes.TryGetValue("size", out var rawSize) &&
+        bool isMultiple = HasAttr(element, "multiple");
+        if (TryGetAttribute(element, "size", out var rawSize) &&
             int.TryParse(rawSize, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedSize) &&
             parsedSize > 0)
         {
@@ -578,7 +578,7 @@ public sealed partial class DomBridge
 
         if (string.Equals(styleEl.TagName, "link", StringComparison.OrdinalIgnoreCase) &&
             cssText.Length == 0 &&
-            styleEl.Attributes.TryGetValue("href", out var href) &&
+            TryGetAttribute(styleEl, "href", out var href) &&
             !string.IsNullOrEmpty(href))
         {
             if (GetElementRuntimeState(styleEl).StyleSheet.FetchedCss.TryGet(out var cachedCss) && cachedCss is string cachedStr)
@@ -661,7 +661,7 @@ public sealed partial class DomBridge
         {
             if (element.TagName.Equals("style", StringComparison.OrdinalIgnoreCase))
             {
-                var nonce = element.Attributes.TryGetValue("nonce", out var n) ? n : null;
+                var nonce = TryGetAttribute(element, "nonce", out var n) ? n : null;
                 if (!csp.AllowsInlineStyleElement(nonce, GetStyleElementCssText(element)))
                 {
                     element.Remove();
@@ -669,9 +669,9 @@ public sealed partial class DomBridge
                 }
             }
 
-            if (blockStyleAttribute && element.Attributes.ContainsKey("style"))
+            if (blockStyleAttribute && HasAttr(element, "style"))
             {
-                element.Attributes.Remove("style");
+                RemoveAttr(element, "style");
                 InlineStyle(element).Clear();
                 InvalidateStyleScope(element);
             }
@@ -701,7 +701,7 @@ public sealed partial class DomBridge
         if (computed.ContainsKey("display"))
             return;
 
-        if (element.Attributes.ContainsKey("hidden"))
+        if (HasAttr(element, "hidden"))
         {
             computed["display"] = "none";
             return;
@@ -1459,7 +1459,7 @@ public sealed partial class DomBridge
         if (parent != null && !parent.TagName.StartsWith("#", StringComparison.Ordinal))
         {
             // parent is the iframe/object element — check its style for dimensions
-            if (parent.Attributes.TryGetValue("style", out var style) && !string.IsNullOrEmpty(style))
+            if (TryGetAttribute(parent, "style", out var style) && !string.IsNullOrEmpty(style))
             {
                 var w = ExtractCssDimension(style, "width");
                 var h = ExtractCssDimension(style, "height");
@@ -1467,8 +1467,8 @@ public sealed partial class DomBridge
                     return (w, h);
             }
 
-            var attributeWidth = ParseViewportDimensionAttribute(parent.Attributes.GetValueOrDefault("width"));
-            var attributeHeight = ParseViewportDimensionAttribute(parent.Attributes.GetValueOrDefault("height"));
+            var attributeWidth = ParseViewportDimensionAttribute(GetAttr(parent, "width"));
+            var attributeHeight = ParseViewportDimensionAttribute(GetAttr(parent, "height"));
             if (attributeWidth > 0 || attributeHeight > 0)
                 return (attributeWidth, attributeHeight);
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -123,7 +123,7 @@ public sealed partial class DomBridge
         if (!IsText(element) && !element.TagName.StartsWith("#", StringComparison.Ordinal))
             InvalidateElementStyles(element);
 
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
         {
             if (!IsText(child) && !child.TagName.StartsWith("#subdoc", StringComparison.OrdinalIgnoreCase))
                 InvalidateStyleScopeRecursive(child);
@@ -176,7 +176,7 @@ public sealed partial class DomBridge
     /// sub-document root materialising during the walk).
     /// </summary>
     /// <remarks>
-    /// A plain <c>root.Children.ToList()</c> is NOT thread-safe here.
+    /// A plain <c>ChildElements(root).ToList()</c> is NOT thread-safe here.
     /// <see cref="DomElement.LegacyChildList"/> projects the live
     /// <c>ChildNodes</c> collection: <see cref="Enumerable.ToList{T}"/> reads
     /// <c>Count</c>, allocates a destination array of that size, then calls
@@ -196,7 +196,7 @@ public sealed partial class DomBridge
         {
             try
             {
-                return root.Children.ToList();
+                return ChildElements(root).ToList();
             }
             catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
             {
@@ -214,9 +214,9 @@ public sealed partial class DomBridge
             DomElement child;
             try
             {
-                if (i >= root.Children.Count)
+                if (i >= root.ChildNodes.Count)
                     break;
-                child = root.Children[i];
+                child = ChildAt(root, i);
             }
             catch (Exception ex) when (ex is ArgumentOutOfRangeException or InvalidOperationException)
             {
@@ -519,7 +519,7 @@ public sealed partial class DomBridge
 
     private static void AppendRenderedText(DomElement element, StringBuilder builder)
     {
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
         {
             if (IsText(child))
             {
@@ -564,7 +564,7 @@ public sealed partial class DomBridge
     private string GetStyleElementSourceText(DomElement styleEl)
     {
         var cssText = new StringBuilder();
-        foreach (var child in styleEl.Children)
+        foreach (var child in ChildElements(styleEl))
         {
             if (IsText(child) && child.TextContent != null)
                 cssText.Append(child.TextContent);
@@ -678,7 +678,7 @@ public sealed partial class DomBridge
         }
 
         // Snapshot: a blocked <style> child removes itself from this collection.
-        foreach (var child in element.Children.ToArray())
+        foreach (var child in ChildElements(element).ToArray())
             ApplyStyleCsp(child, csp, blockStyleAttribute);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -47,7 +47,8 @@ public sealed partial class DomBridge
     // directly. See docs/architecture/htmlbridge-engine-boundaries.md.
 
     /// <summary>
-    /// Clears any CSS-derived compatibility values left in <see cref="DomElement.Style"/>
+    /// Clears any CSS-derived compatibility values left in the element's inline style
+    /// (<see cref="ElementRuntimeState.Style"/>, reached via <c>InlineStyle</c>)
     /// after a selector-affecting mutation. Stylesheet declarations are resolved lazily
     /// by the shared style engine; only inline declarations and JavaScript-set values
     /// remain in the bridge-owned declaration map.
@@ -65,11 +66,11 @@ public sealed partial class DomBridge
         }
 
         // Remove all CSS-derived properties (keep inline ones AND JS-set ones).
-        var keysToRemove = element.Style.Keys
+        var keysToRemove = InlineStyle(element).Keys
             .Where(k => !inlineStyleProps.Contains(k) && !GetElementRuntimeState(element).JsSetStyleProps.Contains(k))
             .ToList();
         foreach (var key in keysToRemove)
-            element.Style.Remove(key);
+            InlineStyle(element).Remove(key);
     }
 
     /// <summary>
@@ -671,7 +672,7 @@ public sealed partial class DomBridge
             if (blockStyleAttribute && element.Attributes.ContainsKey("style"))
             {
                 element.Attributes.Remove("style");
-                element.Style.Clear();
+                InlineStyle(element).Clear();
                 InvalidateStyleScope(element);
             }
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -120,12 +120,12 @@ public sealed partial class DomBridge
 
     private void InvalidateStyleScopeRecursive(DomElement element)
     {
-        if (!element.IsTextNode && !element.TagName.StartsWith("#", StringComparison.Ordinal))
+        if (!IsText(element) && !element.TagName.StartsWith("#", StringComparison.Ordinal))
             InvalidateElementStyles(element);
 
         foreach (var child in element.Children)
         {
-            if (!child.IsTextNode && !child.TagName.StartsWith("#subdoc", StringComparison.OrdinalIgnoreCase))
+            if (!IsText(child) && !child.TagName.StartsWith("#subdoc", StringComparison.OrdinalIgnoreCase))
                 InvalidateStyleScopeRecursive(child);
         }
     }
@@ -156,7 +156,7 @@ public sealed partial class DomBridge
     {
         foreach (var child in SnapshotChildren(root))
         {
-            if (!child.IsTextNode)
+            if (!IsText(child))
             {
                 if (string.Equals(child.TagName, "style", StringComparison.OrdinalIgnoreCase))
                     styleElements.Add(child);
@@ -521,7 +521,7 @@ public sealed partial class DomBridge
     {
         foreach (var child in element.Children)
         {
-            if (child.IsTextNode)
+            if (IsText(child))
             {
                 if (!string.IsNullOrEmpty(child.TextContent))
                     builder.Append(child.TextContent);
@@ -566,7 +566,7 @@ public sealed partial class DomBridge
         var cssText = new StringBuilder();
         foreach (var child in styleEl.Children)
         {
-            if (child.IsTextNode && child.TextContent != null)
+            if (IsText(child) && child.TextContent != null)
                 cssText.Append(child.TextContent);
         }
 
@@ -657,7 +657,7 @@ public sealed partial class DomBridge
 
     private void ApplyStyleCsp(DomElement element, ContentSecurityPolicy csp, bool blockStyleAttribute)
     {
-        if (!element.IsTextNode)
+        if (!IsText(element))
         {
             if (element.TagName.Equals("style", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementInterfaces.cs
@@ -176,7 +176,7 @@ public sealed partial class DomBridge
             // action (read/write)
             obj.FastAddProperty(
                 (KeyString)"action",
-                new JSFunction((in Arguments _) => element.Attributes.TryGetValue("action", out var act) ? new JSString(act) : new JSString(string.Empty),
+                new JSFunction((in Arguments _) => TryGetAttribute(element, "action", out var act) ? new JSString(act) : new JSString(string.Empty),
                     "get action"),
                 new JSFunction((in Arguments a) => JsElementInterfacesSetAction027Core(element, in a), "set action"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -186,7 +186,7 @@ public sealed partial class DomBridge
         {
             obj.FastAddProperty(
                 (KeyString)"open",
-                new JSFunction((in Arguments _) => element.Attributes.ContainsKey("open") ? JSBoolean.True : JSBoolean.False,
+                new JSFunction((in Arguments _) => HasAttr(element, "open") ? JSBoolean.True : JSBoolean.False,
                     "get open"),
                 new JSFunction((in Arguments a) => JsElementInterfacesSetOpen029Core(bridge, element, in a), "set open"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -216,7 +216,7 @@ public sealed partial class DomBridge
             // open (getter/setter)
             obj.FastAddProperty(
                 (KeyString)"open",
-                new JSFunction((in Arguments _) => element.Attributes.ContainsKey("open") ? JSBoolean.True : JSBoolean.False,
+                new JSFunction((in Arguments _) => HasAttr(element, "open") ? JSBoolean.True : JSBoolean.False,
                     "get open"),
                 new JSFunction((in Arguments a) => JsElementInterfacesSetOpen034Core(bridge, element, in a), "set open"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -232,7 +232,7 @@ public sealed partial class DomBridge
 
         // Popover API (HTML §popover) — showPopover()/hidePopover() are exposed on
         // any element carrying the global `popover` attribute, not tied to a tag.
-        if (element.Attributes.ContainsKey("popover"))
+        if (HasAttr(element, "popover"))
         {
             obj.FastAddValue(
                 (KeyString)"showPopover",
@@ -293,7 +293,7 @@ public sealed partial class DomBridge
         {
             obj.FastAddProperty(
                 (KeyString)"htmlFor",
-                new JSFunction((in Arguments _) => element.Attributes.TryGetValue("for", out var f) ? new JSString(f) : new JSString(string.Empty),
+                new JSFunction((in Arguments _) => TryGetAttribute(element, "for", out var f) ? new JSString(f) : new JSString(string.Empty),
                     "get htmlFor"),
                 new JSFunction((in Arguments a) => JsElementInterfacesSetHtmlFor047Core(element, in a), "set htmlFor"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -304,7 +304,7 @@ public sealed partial class DomBridge
         {
             obj.FastAddProperty(
                 (KeyString)"httpEquiv",
-                new JSFunction((in Arguments _) => element.Attributes.TryGetValue("http-equiv", out var he) ? new JSString(he) : new JSString(string.Empty),
+                new JSFunction((in Arguments _) => TryGetAttribute(element, "http-equiv", out var he) ? new JSString(he) : new JSString(string.Empty),
                     "get httpEquiv"),
                 new JSFunction((in Arguments a) => JsElementInterfacesSetHttpEquiv049Core(element, in a), "set httpEquiv"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -322,7 +322,7 @@ public sealed partial class DomBridge
             // type property (MIME type of the resource)
             obj.FastAddProperty(
                 (KeyString)"type",
-                new JSFunction((in Arguments _) => element.Attributes.TryGetValue("type", out var t) ? new JSString(t) : new JSString(string.Empty),
+                new JSFunction((in Arguments _) => TryGetAttribute(element, "type", out var t) ? new JSString(t) : new JSString(string.Empty),
                     "get type"),
                 new JSFunction((in Arguments a) => JsElementInterfacesSetType053Core(element, in a), "set type"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -362,7 +362,7 @@ public sealed partial class DomBridge
                 var captured = attrName; // capture for closure
                 obj.FastAddProperty(
                     (KeyString)captured,
-                    new JSFunction((in Arguments _) => element.Attributes.TryGetValue(captured, out var v) ? new JSString(v) : new JSString(string.Empty),
+                    new JSFunction((in Arguments _) => TryGetAttribute(element, captured, out var v) ? new JSString(v) : new JSString(string.Empty),
                         "get " + captured),
                     new JSFunction((in Arguments a) => JsElementInterfacesCallback059Core(captured, element, in a), "set " + captured),
                     JSPropertyAttributes.EnumerableConfigurableProperty);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
@@ -36,6 +36,23 @@ internal sealed class ElementRuntimeState
     /// </summary>
     public DomElement? OwnerDocRoot { get; set; }
 
+    /// <summary>
+    /// The node's inline style in CSS kebab-case — the authoritative in-memory inline
+    /// style (mutated by JS <c>element.style</c>, the anchor resolver, and synthetic
+    /// form-control styling; synced back to the <c>style=</c> attribute at serialization).
+    /// Relocated off the <c>DomElement</c> facade (RF-BRIDGE-1c Phase B); reached through
+    /// <c>DomBridge.InlineStyle(element)</c>, which lazily seeds it from the <c>style=</c>
+    /// attribute on first access (see <see cref="StyleSeeded"/>).
+    /// </summary>
+    public Dictionary<string, string> Style { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Whether <see cref="Style"/> has been seeded from the element's <c>style=</c>
+    /// attribute yet. The lazy seed runs once on first <c>InlineStyle</c> access; the
+    /// <c>style=</c> attribute setter and <c>cloneNode</c> set this explicitly.
+    /// </summary>
+    public bool StyleSeeded { get; set; }
+
     public FormControlRuntimeState FormControl { get; } = new();
 
     public ScrollRuntimeState Scroll { get; } = new();

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
@@ -20,6 +20,22 @@ internal sealed class ElementRuntimeState
     public Dictionary<string, JSValue> InlineEventHandlers { get; } =
         new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Inline-style property names last written through the JS <c>element.style</c> /
+    /// <c>setAttribute("style", …)</c> path, tracked so serialization and computed-style
+    /// invalidation preserve author-set intent. Relocated off the <c>DomElement</c> facade
+    /// (RF-BRIDGE-1c Phase A — the node model does not own this bridge state).
+    /// </summary>
+    public HashSet<string> JsSetStyleProps { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The document-root element that owns this node's (sub)document — iframe / nested
+    /// browsing-context bookkeeping. Relocated off the <c>DomElement</c> facade
+    /// (RF-BRIDGE-1c Phase A). Not carried across <c>cloneNode</c> (matching the prior
+    /// facade behaviour: a clone re-derives its owner on adoption).
+    /// </summary>
+    public DomElement? OwnerDocRoot { get; set; }
+
     public FormControlRuntimeState FormControl { get; } = new();
 
     public ScrollRuntimeState Scroll { get; } = new();

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Events.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Events.cs
@@ -94,14 +94,14 @@ public sealed partial class DomBridge
         }
 
         // Individual element validation
-        if (!element.Attributes.ContainsKey("required")) return true;
+        if (!HasAttr(element, "required")) return true;
 
         var tag = element.TagName;
         if (string.Equals(tag, "input", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(tag, "textarea", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(tag, "select", StringComparison.OrdinalIgnoreCase))
         {
-            element.Attributes.TryGetValue("value", out var val);
+            TryGetAttribute(element, "value", out var val);
             return !string.IsNullOrEmpty(val);
         }
         return true;
@@ -267,7 +267,7 @@ public sealed partial class DomBridge
         foreach (var eventName in InlineEventNames)
         {
             var attrName = $"on{eventName}";
-            if (element.Attributes.TryGetValue(attrName, out var code) &&
+            if (TryGetAttribute(element, attrName, out var code) &&
                 !string.IsNullOrEmpty(code) &&
                 !GetInlineEventHandlers(element).ContainsKey(eventName))
             {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Events.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Events.cs
@@ -129,8 +129,8 @@ public sealed partial class DomBridge
         // Build the path from the root to the target
         var path = new List<DomElement>();
         var visited = new HashSet<DomElement>();
-        var node = target.Parent;
-        while (node != null && visited.Add(node)) { path.Add(node); node = node.Parent; }
+        var node = ParentEl(target);
+        while (node != null && visited.Add(node)) { path.Add(node); node = ParentEl(node); }
         path.Reverse();
 
         // Include the document node at the very beginning of the path

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Events.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Events.cs
@@ -111,7 +111,7 @@ public sealed partial class DomBridge
     {
         foreach (var child in form.Children)
         {
-            if (!child.IsTextNode && !CheckElementValidity(child)) return false;
+            if (!IsText(child) && !CheckElementValidity(child)) return false;
             if (!ValidateFormChildren(child)) return false;
         }
         return true;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Events.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Events.cs
@@ -109,7 +109,7 @@ public sealed partial class DomBridge
 
     private static bool ValidateFormChildren(DomElement form)
     {
-        foreach (var child in form.Children)
+        foreach (var child in ChildElements(form))
         {
             if (!IsText(child) && !CheckElementValidity(child)) return false;
             if (!ValidateFormChildren(child)) return false;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
@@ -200,17 +200,17 @@ public sealed partial class DomBridge
         out (double Left, double Top, double Width, double Height) rect)
     {
         rect = default;
-        var row = element.Parent;
+        var row = ParentEl(element);
         if (row == null || !string.Equals(row.TagName, "tr", StringComparison.OrdinalIgnoreCase))
             return false;
 
-        var table = row.Parent;
+        var table = ParentEl(row);
         if (table != null &&
             (string.Equals(table.TagName, "thead", StringComparison.OrdinalIgnoreCase) ||
              string.Equals(table.TagName, "tbody", StringComparison.OrdinalIgnoreCase) ||
              string.Equals(table.TagName, "tfoot", StringComparison.OrdinalIgnoreCase)))
         {
-            table = table.Parent;
+            table = ParentEl(table);
         }
 
         if (table == null || !string.Equals(table.TagName, "table", StringComparison.OrdinalIgnoreCase))
@@ -309,7 +309,7 @@ public sealed partial class DomBridge
 
     private DomElement? FindAssociatedImageMapImage(DomElement area)
     {
-        var map = area.Parent;
+        var map = ParentEl(area);
         if (map == null || !string.Equals(map.TagName, "map", StringComparison.OrdinalIgnoreCase))
             return null;
 
@@ -506,7 +506,7 @@ public sealed partial class DomBridge
 
     private bool IsElementRenderedForHitTesting(DomElement element)
     {
-        for (var current = element; current != null; current = current.Parent)
+        for (var current = element; current != null; current = ParentEl(current))
         {
             if (current.IsTextNode)
                 return false;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
@@ -313,9 +313,9 @@ public sealed partial class DomBridge
         if (map == null || !string.Equals(map.TagName, "map", StringComparison.OrdinalIgnoreCase))
             return null;
 
-        var mapName = map.Attributes.GetValueOrDefault("name");
+        var mapName = GetAttr(map, "name");
         if (string.IsNullOrWhiteSpace(mapName))
-            mapName = map.Attributes.GetValueOrDefault("id");
+            mapName = GetAttr(map, "id");
         if (string.IsNullOrWhiteSpace(mapName))
             return null;
 
@@ -325,7 +325,7 @@ public sealed partial class DomBridge
             if (!string.Equals(candidate.TagName, "img", StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            var useMap = candidate.Attributes.GetValueOrDefault("usemap")?.Trim();
+            var useMap = GetAttr(candidate, "usemap")?.Trim();
             if (string.Equals(useMap, expectedUseMap, StringComparison.OrdinalIgnoreCase))
                 return candidate;
         }
@@ -350,8 +350,8 @@ public sealed partial class DomBridge
         DomElement image,
         (double Left, double Top, double Width, double Height) imageRect)
     {
-        var widthBasis = ParsePositiveDouble(image.Attributes.GetValueOrDefault("width"));
-        var heightBasis = ParsePositiveDouble(image.Attributes.GetValueOrDefault("height"));
+        var widthBasis = ParsePositiveDouble(GetAttr(image, "width"));
+        var heightBasis = ParsePositiveDouble(GetAttr(image, "height"));
 
         return (
             widthBasis > 0 ? imageRect.Width / widthBasis : 1,
@@ -360,11 +360,11 @@ public sealed partial class DomBridge
 
     private bool IsPointInsideAreaShape(DomElement area, double x, double y)
     {
-        var shape = area.Attributes.GetValueOrDefault("shape")?.Trim().ToLowerInvariant();
+        var shape = GetAttr(area, "shape")?.Trim().ToLowerInvariant();
         if (string.IsNullOrEmpty(shape))
             shape = "rect";
 
-        var coords = ParseAreaCoords(area.Attributes.GetValueOrDefault("coords"));
+        var coords = ParseAreaCoords(GetAttr(area, "coords"));
         return shape switch
         {
             "default" => true,

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
@@ -532,7 +532,7 @@ public sealed partial class DomBridge
 
     private static bool DocumentHasViewport(DomElement documentElement)
     {
-        var docRoot = documentElement.OwnerDocRoot;
+        var docRoot = GetElementRuntimeState(documentElement).OwnerDocRoot;
         if (docRoot == null)
             return true;
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
@@ -16,7 +16,7 @@ public sealed partial class DomBridge
 
         var documentElement = IsDocumentElement(docRoot)
             ? docRoot
-            : docRoot.Children.FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith("#"));
+            : ChildElements(docRoot).FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith("#"));
         if (documentElement == null)
             return Array.Empty<DomElement>();
 
@@ -35,9 +35,9 @@ public sealed partial class DomBridge
 
     private void CollectHitTestMatches(DomElement element, double x, double y, List<DomElement> hits)
     {
-        for (var i = element.Children.Count - 1; i >= 0; i--)
+        for (var i = element.ChildNodes.Count - 1; i >= 0; i--)
         {
-            var child = element.Children[i];
+            var child = ChildAt(element, i);
             if (!IsText(child) && !child.TagName.StartsWith("#", StringComparison.Ordinal))
                 CollectHitTestMatches(child, x, y, hits);
         }
@@ -221,7 +221,7 @@ public sealed partial class DomBridge
         if (rowIndex < 0)
             return false;
 
-        var cells = row.Children
+        var cells = ChildElements(row)
             .Where(child => !IsText(child) && IsTableCellElement(child))
             .ToList();
         var cellIndex = cells.FindIndex(candidate => ReferenceEquals(candidate, element));
@@ -229,7 +229,7 @@ public sealed partial class DomBridge
             return false;
 
         var columnCount = rows
-            .Select(candidate => candidate.Children.Count(child => !IsText(child) && IsTableCellElement(child)))
+            .Select(candidate => ChildElements(candidate).Count(child => !IsText(child) && IsTableCellElement(child)))
             .DefaultIfEmpty(0)
             .Max();
         if (columnCount <= 0 || rows.Count <= 0)
@@ -335,7 +335,7 @@ public sealed partial class DomBridge
 
     private IEnumerable<DomElement> EnumerateDomDescendants(DomElement root)
     {
-        foreach (var child in root.Children)
+        foreach (var child in ChildElements(root))
         {
             if (IsText(child) || child.TagName.StartsWith("#", StringComparison.Ordinal))
                 continue;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
@@ -16,7 +16,7 @@ public sealed partial class DomBridge
 
         var documentElement = IsDocumentElement(docRoot)
             ? docRoot
-            : docRoot.Children.FirstOrDefault(c => !c.IsTextNode && !c.TagName.StartsWith("#"));
+            : docRoot.Children.FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith("#"));
         if (documentElement == null)
             return Array.Empty<DomElement>();
 
@@ -38,7 +38,7 @@ public sealed partial class DomBridge
         for (var i = element.Children.Count - 1; i >= 0; i--)
         {
             var child = element.Children[i];
-            if (!child.IsTextNode && !child.TagName.StartsWith("#", StringComparison.Ordinal))
+            if (!IsText(child) && !child.TagName.StartsWith("#", StringComparison.Ordinal))
                 CollectHitTestMatches(child, x, y, hits);
         }
 
@@ -222,14 +222,14 @@ public sealed partial class DomBridge
             return false;
 
         var cells = row.Children
-            .Where(child => !child.IsTextNode && IsTableCellElement(child))
+            .Where(child => !IsText(child) && IsTableCellElement(child))
             .ToList();
         var cellIndex = cells.FindIndex(candidate => ReferenceEquals(candidate, element));
         if (cellIndex < 0)
             return false;
 
         var columnCount = rows
-            .Select(candidate => candidate.Children.Count(child => !child.IsTextNode && IsTableCellElement(child)))
+            .Select(candidate => candidate.Children.Count(child => !IsText(child) && IsTableCellElement(child)))
             .DefaultIfEmpty(0)
             .Max();
         if (columnCount <= 0 || rows.Count <= 0)
@@ -337,7 +337,7 @@ public sealed partial class DomBridge
     {
         foreach (var child in root.Children)
         {
-            if (child.IsTextNode || child.TagName.StartsWith("#", StringComparison.Ordinal))
+            if (IsText(child) || child.TagName.StartsWith("#", StringComparison.Ordinal))
                 continue;
 
             yield return child;
@@ -508,7 +508,7 @@ public sealed partial class DomBridge
     {
         for (var current = element; current != null; current = ParentEl(current))
         {
-            if (current.IsTextNode)
+            if (IsText(current))
                 return false;
 
             if (current.TagName.StartsWith("#", StringComparison.Ordinal))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Attributes.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Attributes.cs
@@ -12,7 +12,7 @@ public sealed partial class DomBridge
         if (a.Length == 0)
             return JSNull.Value;
         var name = a[0].ToString();
-        if (!element.Attributes.TryGetValue(name, out var val))
+        if (!TryGetAttribute(element, name, out var val))
             return JSNull.Value;
         return BuildAttrNode(name, val, element, ownerObj);
     }
@@ -24,7 +24,7 @@ public sealed partial class DomBridge
             return JSNull.Value;
         var ns = a[0].IsNull || a[0].IsUndefined ? null : a[0].ToString();
         var localName = a[1].ToString();
-        if (!element.NsAttrMap.TryGetValue((ns, localName), out var qName) || !element.Attributes.TryGetValue(qName, out var val))
+        if (!element.NsAttrMap.TryGetValue((ns, localName), out var qName) || !TryGetAttribute(element, qName, out var val))
             return JSNull.Value;
         return BuildAttrNode(qName, val, element, ownerObj);
     }
@@ -42,7 +42,7 @@ public sealed partial class DomBridge
             return JSNull.Value;
         var value = attrObj[(KeyString)"value"].ToString();
         JSValue old = JSNull.Value;
-        if (element.Attributes.TryGetValue(name, out var oldVal))
+        if (TryGetAttribute(element, name, out var oldVal))
             old = BuildAttrNode(name, oldVal, element, ownerObj);
         SetAttributeLikeSetAttribute(element, name, value);
         return old;
@@ -60,7 +60,7 @@ public sealed partial class DomBridge
         var ns = GetAttrNodeNamespace(attrObj);
         var value = attrObj[(KeyString)"value"].ToString();
         JSValue old = JSNull.Value;
-        if (element.NsAttrMap.TryGetValue((ns, localName), out var oldQName) && element.Attributes.TryGetValue(oldQName, out var oldVal))
+        if (element.NsAttrMap.TryGetValue((ns, localName), out var oldQName) && TryGetAttribute(element, oldQName, out var oldVal))
             old = BuildAttrNode(oldQName, oldVal, element, ownerObj);
         SetAttributeLikeSetAttributeNS(element, ns, name, localName, value);
         return old;
@@ -72,7 +72,7 @@ public sealed partial class DomBridge
         if (a.Length == 0)
             return JSNull.Value;
         var name = a[0].ToString();
-        if (!element.Attributes.TryGetValue(name, out var val))
+        if (!TryGetAttribute(element, name, out var val))
             return JSNull.Value;
         var removed = BuildAttrNode(name, val, element, ownerObj);
         RemoveAttributeLikeRemoveAttribute(element, name);
@@ -86,7 +86,7 @@ public sealed partial class DomBridge
             return JSNull.Value;
         var ns = a[0].IsNull || a[0].IsUndefined ? null : a[0].ToString();
         var localName = a[1].ToString();
-        if (!element.NsAttrMap.TryGetValue((ns, localName), out var qName) || !element.Attributes.TryGetValue(qName, out var val))
+        if (!element.NsAttrMap.TryGetValue((ns, localName), out var qName) || !TryGetAttribute(element, qName, out var val))
             return JSNull.Value;
         var removed = BuildAttrNode(qName, val, element, ownerObj);
         RemoveAttributeLikeRemoveAttributeNS(element, ns, localName);
@@ -99,21 +99,21 @@ public sealed partial class DomBridge
         if (a.Length == 0)
             return JSNull.Value;
         var idx = (int)a[0].DoubleValue;
-        var keys = element.Attributes.Keys.ToList();
+        var keys = AttributeNames(element).ToList();
         if (idx < 0 || idx >= keys.Count)
             return JSNull.Value;
         var name = keys[idx];
-        return BuildAttrNode(name, element.Attributes[name], element, ownerObj);
+        return BuildAttrNode(name, GetAttr(element, name) ?? string.Empty, element, ownerObj);
     }
 
 
     private JSValue JsAttributesCallback009Core(global::Broiler.HtmlBridge.DomElement element, global::System.Int32 idx, global::Broiler.JavaScript.Runtime.JSObject ownerObj, in Arguments _)
     {
-        var keys = element.Attributes.Keys.ToList();
+        var keys = AttributeNames(element).ToList();
         if (idx >= keys.Count)
             return JSUndefined.Value;
         var n = keys[idx];
-        return BuildAttrNode(n, element.Attributes[n], element, ownerObj);
+        return BuildAttrNode(n, GetAttr(element, n) ?? string.Empty, element, ownerObj);
     }
 
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
@@ -31,10 +31,10 @@ public sealed partial class DomBridge
         if (IsText(element))
             return element.TextContent != null ? new JSString(element.TextContent) : new JSString(string.Empty);
 
-        if (element.TextContent != null && element.Children.Count == 0)
+        if (element.TextContent != null && element.ChildNodes.Count == 0)
             return new JSString(element.TextContent);
 
-        if (element.Children.Count > 0)
+        if (element.ChildNodes.Count > 0)
         {
             var sb = new StringBuilder();
             CollectTextContent(element, sb);
@@ -99,7 +99,7 @@ public sealed partial class DomBridge
 
     private static DomElement GetDocumentElement(DomElement docRoot)
     {
-        return docRoot.Children.FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith("#"))
+        return ChildElements(docRoot).FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith("#"))
             ?? docRoot;
     }
 
@@ -116,7 +116,7 @@ public sealed partial class DomBridge
                 node = ParentEl(node);
             if (ParentEl(node) != null)
             {
-                var childIdx = containerA.Children.IndexOf(node);
+                var childIdx = ChildIndexOf(containerA, node);
                 return offsetA > childIdx;
             }
 
@@ -130,7 +130,7 @@ public sealed partial class DomBridge
                 node = ParentEl(node);
             if (ParentEl(node) != null)
             {
-                var childIdx = containerB.Children.IndexOf(node);
+                var childIdx = ChildIndexOf(containerB, node);
                 return childIdx >= offsetB;
             }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
@@ -112,9 +112,9 @@ public sealed partial class DomBridge
         if (IsDescendant(containerA, containerB))
         {
             var node = containerB;
-            while (node.Parent != null && !ReferenceEquals(node.Parent, containerA))
-                node = node.Parent;
-            if (node.Parent != null)
+            while (ParentEl(node) != null && !ReferenceEquals(ParentEl(node), containerA))
+                node = ParentEl(node);
+            if (ParentEl(node) != null)
             {
                 var childIdx = containerA.Children.IndexOf(node);
                 return offsetA > childIdx;
@@ -126,9 +126,9 @@ public sealed partial class DomBridge
         if (IsDescendant(containerB, containerA))
         {
             var node = containerA;
-            while (node.Parent != null && !ReferenceEquals(node.Parent, containerB))
-                node = node.Parent;
-            if (node.Parent != null)
+            while (ParentEl(node) != null && !ReferenceEquals(ParentEl(node), containerB))
+                node = ParentEl(node);
+            if (ParentEl(node) != null)
             {
                 var childIdx = containerB.Children.IndexOf(node);
                 return childIdx >= offsetB;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
@@ -47,10 +47,10 @@ public sealed partial class DomBridge
 
     private bool IsCurrentIframeCrossOrigin(DomElement element)
     {
-        if (element.Attributes.ContainsKey("srcdoc"))
+        if (HasAttr(element, "srcdoc"))
             return false;
 
-        var iframeSrcValue = element.Attributes.TryGetValue("src", out var srcVal) ? srcVal : string.Empty;
+        var iframeSrcValue = TryGetAttribute(element, "src", out var srcVal) ? srcVal : string.Empty;
         return IsCrossOrigin(iframeSrcValue, _pageUrl);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
@@ -28,7 +28,7 @@ public sealed partial class DomBridge
 
     private JSValue GetNodeTextValue(DomElement element)
     {
-        if (element.IsTextNode)
+        if (IsText(element))
             return element.TextContent != null ? new JSString(element.TextContent) : new JSString(string.Empty);
 
         if (element.TextContent != null && element.Children.Count == 0)
@@ -99,7 +99,7 @@ public sealed partial class DomBridge
 
     private static DomElement GetDocumentElement(DomElement docRoot)
     {
-        return docRoot.Children.FirstOrDefault(c => !c.IsTextNode && !c.TagName.StartsWith("#"))
+        return docRoot.Children.FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith("#"))
             ?? docRoot;
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/ElementInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/ElementInterfaces.cs
@@ -245,7 +245,7 @@ public sealed partial class DomBridge
         var td = new DomElement(_document, "td", null, null, string.Empty);
         bridge._knownNodes.Add(td);
         SetParent(td, element);
-        var cells = element.Children.Where(c => !c.IsTextNode && IsTableCellElement(c)).ToList();
+        var cells = element.Children.Where(c => !IsText(c) && IsTableCellElement(c)).ToList();
         if (index < 0 || index >= cells.Count)
         {
             element.Children.Add(td);
@@ -269,7 +269,7 @@ public sealed partial class DomBridge
         if (a.Length == 0)
             throw new JSException("Failed to execute 'deleteCell' on 'HTMLTableRowElement': 1 argument required, but only 0 present.");
         var index = (int)Math.Truncate(a[0].DoubleValue);
-        var cells = element.Children.Where(c => !c.IsTextNode && IsTableCellElement(c)).ToList();
+        var cells = element.Children.Where(c => !IsText(c) && IsTableCellElement(c)).ToList();
         if (index < 0)
             index = cells.Count + index;
         if (index < 0 || index >= cells.Count)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/ElementInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/ElementInterfaces.cs
@@ -14,21 +14,21 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesGetCaption001Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        var cap = element.Children.Find(c => string.Equals(c.TagName, "caption", StringComparison.OrdinalIgnoreCase));
+        var cap = ChildElements(element).FirstOrDefault(c => string.Equals(c.TagName, "caption", StringComparison.OrdinalIgnoreCase));
         return cap != null ? ToJSObject(cap) : JSNull.Value;
     }
 
 
     private JSValue JsElementInterfacesGetTHead002Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        var th = element.Children.Find(c => string.Equals(c.TagName, "thead", StringComparison.OrdinalIgnoreCase));
+        var th = ChildElements(element).FirstOrDefault(c => string.Equals(c.TagName, "thead", StringComparison.OrdinalIgnoreCase));
         return th != null ? ToJSObject(th) : JSNull.Value;
     }
 
 
     private JSValue JsElementInterfacesGetTFoot003Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        var tf = element.Children.Find(c => string.Equals(c.TagName, "tfoot", StringComparison.OrdinalIgnoreCase));
+        var tf = ChildElements(element).FirstOrDefault(c => string.Equals(c.TagName, "tfoot", StringComparison.OrdinalIgnoreCase));
         return tf != null ? ToJSObject(tf) : JSNull.Value;
     }
 
@@ -36,7 +36,7 @@ public sealed partial class DomBridge
     private JSValue JsElementInterfacesGetTBodies005Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
         var bodies = new List<JSValue>();
-        foreach (var c in element.Children)
+        foreach (var c in ChildElements(element))
             if (string.Equals(c.TagName, "tbody", StringComparison.OrdinalIgnoreCase))
                 bodies.Add(ToJSObject(c));
         var arr = new JSArray(bodies);
@@ -52,50 +52,50 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesCreateCaption007Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        var cap = element.Children.Find(c => string.Equals(c.TagName, "caption", StringComparison.OrdinalIgnoreCase));
+        var cap = ChildElements(element).FirstOrDefault(c => string.Equals(c.TagName, "caption", StringComparison.OrdinalIgnoreCase));
         if (cap != null)
             return ToJSObject(cap);
         cap = new DomElement(_document, "caption", null, null, string.Empty);
         bridge._knownNodes.Add(cap);
         SetParent(cap, element);
-        element.Children.Insert(0, cap);
+        InsertChildAt(element, 0, cap);
         return ToJSObject(cap);
     }
 
 
     private JSValue JsElementInterfacesCreateTHead008Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        var th = element.Children.Find(c => string.Equals(c.TagName, "thead", StringComparison.OrdinalIgnoreCase));
+        var th = ChildElements(element).FirstOrDefault(c => string.Equals(c.TagName, "thead", StringComparison.OrdinalIgnoreCase));
         if (th != null)
             return ToJSObject(th);
         th = new DomElement(_document, "thead", null, null, string.Empty);
         bridge._knownNodes.Add(th);
         SetParent(th, element);
-        element.Children.Add(th);
+        element.AppendChild(th);
         return ToJSObject(th);
     }
 
 
     private JSValue JsElementInterfacesCreateTFoot009Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        var tf = element.Children.Find(c => string.Equals(c.TagName, "tfoot", StringComparison.OrdinalIgnoreCase));
+        var tf = ChildElements(element).FirstOrDefault(c => string.Equals(c.TagName, "tfoot", StringComparison.OrdinalIgnoreCase));
         if (tf != null)
             return ToJSObject(tf);
         tf = new DomElement(_document, "tfoot", null, null, string.Empty);
         bridge._knownNodes.Add(tf);
         SetParent(tf, element);
-        element.Children.Add(tf);
+        element.AppendChild(tf);
         return ToJSObject(tf);
     }
 
 
     private JSValue JsElementInterfacesDeleteCaption010Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        var cap = element.Children.Find(c => string.Equals(c.TagName, "caption", StringComparison.OrdinalIgnoreCase));
+        var cap = ChildElements(element).FirstOrDefault(c => string.Equals(c.TagName, "caption", StringComparison.OrdinalIgnoreCase));
         if (cap != null)
         {
             SetParent(cap, null);
-            element.Children.Remove(cap);
+            RemoveChildFrom(element, cap);
         }
 
         return JSUndefined.Value;
@@ -104,11 +104,11 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesDeleteTHead011Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        var th = element.Children.Find(c => string.Equals(c.TagName, "thead", StringComparison.OrdinalIgnoreCase));
+        var th = ChildElements(element).FirstOrDefault(c => string.Equals(c.TagName, "thead", StringComparison.OrdinalIgnoreCase));
         if (th != null)
         {
             SetParent(th, null);
-            element.Children.Remove(th);
+            RemoveChildFrom(element, th);
         }
 
         return JSUndefined.Value;
@@ -117,11 +117,11 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesDeleteTFoot012Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        var tf = element.Children.Find(c => string.Equals(c.TagName, "tfoot", StringComparison.OrdinalIgnoreCase));
+        var tf = ChildElements(element).FirstOrDefault(c => string.Equals(c.TagName, "tfoot", StringComparison.OrdinalIgnoreCase));
         if (tf != null)
         {
             SetParent(tf, null);
-            element.Children.Remove(tf);
+            RemoveChildFrom(element, tf);
         }
 
         return JSUndefined.Value;
@@ -146,7 +146,7 @@ public sealed partial class DomBridge
         if (index >= 0 && index < rows.Count)
         {
             var row = rows[index];
-            ParentEl(row)?.Children.Remove(row);
+            row.Remove();
             SetParent(row, null);
         }
 
@@ -157,7 +157,7 @@ public sealed partial class DomBridge
     private JSValue JsElementInterfacesGetRows016Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
         var rows = new List<JSValue>();
-        foreach (var c in element.Children)
+        foreach (var c in ChildElements(element))
             if (string.Equals(c.TagName, "tr", StringComparison.OrdinalIgnoreCase))
                 rows.Add(ToJSObject(c));
         var arr = new JSArray(rows);
@@ -177,14 +177,14 @@ public sealed partial class DomBridge
         var tr = new DomElement(_document, "tr", null, null, string.Empty);
         bridge._knownNodes.Add(tr);
         SetParent(tr, element);
-        var trRows = element.Children.Where(c => string.Equals(c.TagName, "tr", StringComparison.OrdinalIgnoreCase)).ToList();
+        var trRows = ChildElements(element).Where(c => string.Equals(c.TagName, "tr", StringComparison.OrdinalIgnoreCase)).ToList();
         if (index < 0 || index >= trRows.Count)
-            element.Children.Add(tr);
+            element.AppendChild(tr);
         else
         {
             var refRow = trRows[index];
-            var idx = element.Children.IndexOf(refRow);
-            element.Children.Insert(idx, tr);
+            var idx = ChildIndexOf(element, refRow);
+            InsertChildAt(element, idx, tr);
         }
 
         return ToJSObject(tr);
@@ -210,7 +210,7 @@ public sealed partial class DomBridge
         if (section == null)
             return new JSNumber(-1);
         var idx = 0;
-        foreach (var c in section.Children)
+        foreach (var c in ChildElements(section))
         {
             if (ReferenceEquals(c, element))
                 return new JSNumber(idx);
@@ -225,7 +225,7 @@ public sealed partial class DomBridge
     private JSValue JsElementInterfacesGetCells021Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
         var cells = new List<JSValue>();
-        foreach (var c in element.Children)
+        foreach (var c in ChildElements(element))
             if (string.Equals(c.TagName, "td", StringComparison.OrdinalIgnoreCase) || string.Equals(c.TagName, "th", StringComparison.OrdinalIgnoreCase))
                 cells.Add(ToJSObject(c));
         var arr = new JSArray(cells);
@@ -245,19 +245,19 @@ public sealed partial class DomBridge
         var td = new DomElement(_document, "td", null, null, string.Empty);
         bridge._knownNodes.Add(td);
         SetParent(td, element);
-        var cells = element.Children.Where(c => !IsText(c) && IsTableCellElement(c)).ToList();
+        var cells = ChildElements(element).Where(c => !IsText(c) && IsTableCellElement(c)).ToList();
         if (index < 0 || index >= cells.Count)
         {
-            element.Children.Add(td);
+            element.AppendChild(td);
         }
         else
         {
             var referenceCell = cells[index];
-            var childIndex = element.Children.IndexOf(referenceCell);
+            var childIndex = ChildIndexOf(element, referenceCell);
             if (childIndex < 0)
-                element.Children.Add(td);
+                element.AppendChild(td);
             else
-                element.Children.Insert(childIndex, td);
+                InsertChildAt(element, childIndex, td);
         }
 
         return ToJSObject(td);
@@ -269,14 +269,14 @@ public sealed partial class DomBridge
         if (a.Length == 0)
             throw new JSException("Failed to execute 'deleteCell' on 'HTMLTableRowElement': 1 argument required, but only 0 present.");
         var index = (int)Math.Truncate(a[0].DoubleValue);
-        var cells = element.Children.Where(c => !IsText(c) && IsTableCellElement(c)).ToList();
+        var cells = ChildElements(element).Where(c => !IsText(c) && IsTableCellElement(c)).ToList();
         if (index < 0)
             index = cells.Count + index;
         if (index < 0 || index >= cells.Count)
             throw new JSException("INDEX_SIZE_ERR");
         var cell = cells[index];
         SetParent(cell, null);
-        element.Children.Remove(cell);
+        RemoveChildFrom(element, cell);
         return JSUndefined.Value;
     }
 
@@ -397,18 +397,18 @@ public sealed partial class DomBridge
                 refEl = FindDomElementByJSObject(refObj);
         }
 
-        ParentEl(optEl)?.Children.Remove(optEl);
+        optEl.Remove();
         SetParent(optEl, element);
         if (refEl != null)
         {
-            var idx = element.Children.IndexOf(refEl);
+            var idx = ChildIndexOf(element, refEl);
             if (idx >= 0)
-                element.Children.Insert(idx, optEl);
+                InsertChildAt(element, idx, optEl);
             else
-                element.Children.Add(optEl);
+                element.AppendChild(optEl);
         }
         else
-            element.Children.Add(optEl);
+            element.AppendChild(optEl);
         return JSUndefined.Value;
     }
 
@@ -416,7 +416,7 @@ public sealed partial class DomBridge
     private JSValue JsElementInterfacesGetOptions039Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
         var opts = new List<JSValue>();
-        foreach (var c in element.Children)
+        foreach (var c in ChildElements(element))
             if (string.Equals(c.TagName, "option", StringComparison.OrdinalIgnoreCase))
                 opts.Add(ToJSObject(c));
         var arr = new JSArray(opts);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/ElementInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/ElementInterfaces.cs
@@ -290,7 +290,7 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesSetAction027Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["action"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "action", a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
 
@@ -298,9 +298,9 @@ public sealed partial class DomBridge
     private JSValue JsElementInterfacesSetOpen029Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
         if (a.Length > 0 && a[0].BooleanValue)
-            element.Attributes["open"] = "";
+            SetAttr(element, "open", "");
         else
-            element.Attributes.Remove("open");
+            RemoveAttr(element, "open");
         bridge.InvalidateStyleScope(element);
         return JSUndefined.Value;
     }
@@ -308,7 +308,7 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesShowModal030Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        element.Attributes["open"] = "";
+        SetAttr(element, "open", "");
         GetElementRuntimeState(element).Dialog.Modal.Set(true);
         GetElementRuntimeState(element).Dialog.TopLayerOrder.Set(++bridge._topLayerCounter);
         bridge.InvalidateStyleScope(element);
@@ -318,7 +318,7 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesShow031Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        element.Attributes["open"] = "";
+        SetAttr(element, "open", "");
         bridge.InvalidateStyleScope(element);
         return JSUndefined.Value;
     }
@@ -352,7 +352,7 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesClose032Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes.Remove("open");
+        RemoveAttr(element, "open");
         GetElementRuntimeState(element).Dialog.Modal.Remove();
         if (a.Length > 0)
             GetElementRuntimeState(element).FormControl.ReturnValue.Set(a[0].ToString());
@@ -364,9 +364,9 @@ public sealed partial class DomBridge
     private JSValue JsElementInterfacesSetOpen034Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
         if (a.Length > 0 && a[0].BooleanValue)
-            element.Attributes["open"] = "";
+            SetAttr(element, "open", "");
         else
-            element.Attributes.Remove("open");
+            RemoveAttr(element, "open");
         bridge.InvalidateStyleScope(element);
         return JSUndefined.Value;
     }
@@ -440,7 +440,7 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesGetSize042Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        if (element.Attributes.TryGetValue("size", out var rawSize) && int.TryParse(rawSize, out var parsedSize) && parsedSize > 0)
+        if (TryGetAttribute(element, "size", out var rawSize) && int.TryParse(rawSize, out var parsedSize) && parsedSize > 0)
         {
             return new JSNumber(parsedSize);
         }
@@ -455,9 +455,9 @@ public sealed partial class DomBridge
             return JSUndefined.Value;
         var size = (int)Math.Truncate(a[0].DoubleValue);
         if (size > 0)
-            element.Attributes["size"] = size.ToString();
+            SetAttr(element, "size", size.ToString());
         else
-            element.Attributes.Remove("size");
+            RemoveAttr(element, "size");
         return JSUndefined.Value;
     }
 
@@ -471,21 +471,21 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesSetHtmlFor047Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["for"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "for", a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
 
 
     private JSValue JsElementInterfacesSetHttpEquiv049Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["http-equiv"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "http-equiv", a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
 
 
     private JSValue JsElementInterfacesGetData050Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        if (!element.Attributes.TryGetValue("data", out var d))
+        if (!TryGetAttribute(element, "data", out var d))
             return new JSString(string.Empty);
         // Resolve relative URI against base URL
         if (Uri.TryCreate(bridge._pageUrl, UriKind.Absolute, out var baseUri) && Uri.TryCreate(baseUri, d, out var resolved))
@@ -496,7 +496,7 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesSetData051Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["data"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "data", a.Length > 0 ? a[0].ToString() : string.Empty);
         // Invalidate cached sub-document when data changes
         bridge.InvalidateCachedSubDocument(element);
         return JSUndefined.Value;
@@ -505,14 +505,14 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesSetType053Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["type"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "type", a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
 
 
     private JSValue JsElementInterfacesGetContentDocument054Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        var dataUrl = element.Attributes.TryGetValue("data", out var d) ? d : string.Empty;
+        var dataUrl = TryGetAttribute(element, "data", out var d) ? d : string.Empty;
         if (IsCrossOrigin(dataUrl, bridge._pageUrl))
             return JSNull.Value;
         // Check if the resource actually loaded successfully
@@ -524,7 +524,7 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesGetSVGDocument055Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        var dataUrl = element.Attributes.TryGetValue("data", out var d) ? d : string.Empty;
+        var dataUrl = TryGetAttribute(element, "data", out var d) ? d : string.Empty;
         if (IsCrossOrigin(dataUrl, bridge._pageUrl))
             return JSNull.Value;
         return bridge.GetOrCreateSubDocument(element);
@@ -533,7 +533,7 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesGetHref056Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        if (!element.Attributes.TryGetValue("href", out var h))
+        if (!TryGetAttribute(element, "href", out var h))
             return new JSString(string.Empty);
         if (Uri.TryCreate(bridge._pageUrl, UriKind.Absolute, out var baseUri) && Uri.TryCreate(baseUri, h, out var resolved))
             return new JSString(resolved.AbsoluteUri);
@@ -543,21 +543,21 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesSetHref057Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["href"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "href", a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
 
 
     private JSValue JsElementInterfacesCallback059Core(global::System.String? captured, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes[captured] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, captured, a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
 
 
     private JSValue JsElementInterfacesGetHref060Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        if (!element.Attributes.TryGetValue("href", out var h))
+        if (!TryGetAttribute(element, "href", out var h))
             return new JSString(string.Empty);
         if (Uri.TryCreate(bridge._pageUrl, UriKind.Absolute, out var baseUri) && Uri.TryCreate(baseUri, h, out var resolved))
             return new JSString(resolved.AbsoluteUri);
@@ -567,7 +567,7 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesSetHref061Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["href"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "href", a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
 
@@ -589,7 +589,7 @@ public sealed partial class DomBridge
         }
 
         // Fallback: HTML attribute
-        if (element.Attributes.TryGetValue(dimName, out var attrVal) && double.TryParse(attrVal, out var attrNum))
+        if (TryGetAttribute(element, dimName, out var attrVal) && double.TryParse(attrVal, out var attrNum))
             return new JSNumber(attrNum);
         return new JSNumber(0);
     }
@@ -597,7 +597,7 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesCallback063Core(global::System.String? dimName, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes[dimName] = a.Length > 0 ? a[0].ToString() : "0";
+        SetAttr(element, dimName, a.Length > 0 ? a[0].ToString() : "0");
         return JSUndefined.Value;
     }
 
@@ -715,7 +715,7 @@ public sealed partial class DomBridge
     private JSValue JsElementInterfacesCallback086Core(global::System.String? attrName, global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
         var animLength = new JSObject();
-        var valueStr = element.Attributes.TryGetValue(attrName, out var v) ? v : "0";
+        var valueStr = TryGetAttribute(element, attrName, out var v) ? v : "0";
         double.TryParse(valueStr, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var numVal);
         var baseVal = CreateSvgLengthValue(numVal);
         var animVal = CreateSvgLengthValue(numVal);
@@ -730,7 +730,7 @@ public sealed partial class DomBridge
         var animRect = new JSObject();
         var baseRect = new JSObject();
         double vbX = 0, vbY = 0, vbW = 0, vbH = 0;
-        if (element.Attributes.TryGetValue("viewBox", out var vb) && !string.IsNullOrWhiteSpace(vb))
+        if (TryGetAttribute(element, "viewBox", out var vb) && !string.IsNullOrWhiteSpace(vb))
         {
             var parts = vb.Split([' ', ','], StringSplitOptions.RemoveEmptyEntries);
             if (parts.Length >= 4)
@@ -766,7 +766,7 @@ public sealed partial class DomBridge
         CollectTextContent(element, sb);
         // Stub: estimate using font-size * character count * 0.6 average advance ratio
         double fontSize = 16;
-        if (element.Attributes.TryGetValue("font-size", out var fs))
+        if (TryGetAttribute(element, "font-size", out var fs))
         {
             var fsClean = fs.Replace("px", "").Replace("pt", "").Trim();
             double.TryParse(fsClean, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out fontSize);
@@ -787,7 +787,7 @@ public sealed partial class DomBridge
         if (nchars == 0)
             return new JSNumber(0);
         double fontSize = 16;
-        if (element.Attributes.TryGetValue("font-size", out var fs))
+        if (TryGetAttribute(element, "font-size", out var fs))
         {
             var fsClean = fs.Replace("px", "").Replace("pt", "").Trim();
             double.TryParse(fsClean, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out fontSize);
@@ -805,7 +805,7 @@ public sealed partial class DomBridge
         if (charnum < 0 || charnum >= sb.Length)
             throw new JSException("INDEX_SIZE_ERR");
         double fontSize = 16;
-        if (element.Attributes.TryGetValue("font-size", out var fs))
+        if (TryGetAttribute(element, "font-size", out var fs))
         {
             var fsClean = fs.Replace("px", "").Replace("pt", "").Trim();
             double.TryParse(fsClean, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out fontSize);
@@ -826,7 +826,7 @@ public sealed partial class DomBridge
         if (charnum < 0 || charnum >= sb.Length)
             throw new JSException("INDEX_SIZE_ERR");
         double fontSize = 16;
-        if (element.Attributes.TryGetValue("font-size", out var fs))
+        if (TryGetAttribute(element, "font-size", out var fs))
         {
             var fsClean = fs.Replace("px", "").Replace("pt", "").Trim();
             double.TryParse(fsClean, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out fontSize);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/ElementInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/ElementInterfaces.cs
@@ -57,7 +57,7 @@ public sealed partial class DomBridge
             return ToJSObject(cap);
         cap = new DomElement(_document, "caption", null, null, string.Empty);
         bridge._knownNodes.Add(cap);
-        cap.Parent = element;
+        SetParent(cap, element);
         element.Children.Insert(0, cap);
         return ToJSObject(cap);
     }
@@ -70,7 +70,7 @@ public sealed partial class DomBridge
             return ToJSObject(th);
         th = new DomElement(_document, "thead", null, null, string.Empty);
         bridge._knownNodes.Add(th);
-        th.Parent = element;
+        SetParent(th, element);
         element.Children.Add(th);
         return ToJSObject(th);
     }
@@ -83,7 +83,7 @@ public sealed partial class DomBridge
             return ToJSObject(tf);
         tf = new DomElement(_document, "tfoot", null, null, string.Empty);
         bridge._knownNodes.Add(tf);
-        tf.Parent = element;
+        SetParent(tf, element);
         element.Children.Add(tf);
         return ToJSObject(tf);
     }
@@ -94,7 +94,7 @@ public sealed partial class DomBridge
         var cap = element.Children.Find(c => string.Equals(c.TagName, "caption", StringComparison.OrdinalIgnoreCase));
         if (cap != null)
         {
-            cap.Parent = null;
+            SetParent(cap, null);
             element.Children.Remove(cap);
         }
 
@@ -107,7 +107,7 @@ public sealed partial class DomBridge
         var th = element.Children.Find(c => string.Equals(c.TagName, "thead", StringComparison.OrdinalIgnoreCase));
         if (th != null)
         {
-            th.Parent = null;
+            SetParent(th, null);
             element.Children.Remove(th);
         }
 
@@ -120,7 +120,7 @@ public sealed partial class DomBridge
         var tf = element.Children.Find(c => string.Equals(c.TagName, "tfoot", StringComparison.OrdinalIgnoreCase));
         if (tf != null)
         {
-            tf.Parent = null;
+            SetParent(tf, null);
             element.Children.Remove(tf);
         }
 
@@ -146,8 +146,8 @@ public sealed partial class DomBridge
         if (index >= 0 && index < rows.Count)
         {
             var row = rows[index];
-            row.Parent?.Children.Remove(row);
-            row.Parent = null;
+            ParentEl(row)?.Children.Remove(row);
+            SetParent(row, null);
         }
 
         return JSUndefined.Value;
@@ -176,7 +176,7 @@ public sealed partial class DomBridge
         var index = a.Length > 0 ? (int)a[0].DoubleValue : -1;
         var tr = new DomElement(_document, "tr", null, null, string.Empty);
         bridge._knownNodes.Add(tr);
-        tr.Parent = element;
+        SetParent(tr, element);
         var trRows = element.Children.Where(c => string.Equals(c.TagName, "tr", StringComparison.OrdinalIgnoreCase)).ToList();
         if (index < 0 || index >= trRows.Count)
             element.Children.Add(tr);
@@ -194,9 +194,9 @@ public sealed partial class DomBridge
     private JSValue JsElementInterfacesGetRowIndex018Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
         // Find parent table
-        var tableEl = element.Parent;
+        var tableEl = ParentEl(element);
         if (tableEl != null && (string.Equals(tableEl.TagName, "thead", StringComparison.OrdinalIgnoreCase) || string.Equals(tableEl.TagName, "tbody", StringComparison.OrdinalIgnoreCase) || string.Equals(tableEl.TagName, "tfoot", StringComparison.OrdinalIgnoreCase)))
-            tableEl = tableEl.Parent;
+            tableEl = ParentEl(tableEl);
         if (tableEl == null || !string.Equals(tableEl.TagName, "table", StringComparison.OrdinalIgnoreCase))
             return new JSNumber(-1);
         var rows = CollectTableRows(tableEl);
@@ -206,7 +206,7 @@ public sealed partial class DomBridge
 
     private JSValue JsElementInterfacesGetSectionRowIndex019Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        var section = element.Parent;
+        var section = ParentEl(element);
         if (section == null)
             return new JSNumber(-1);
         var idx = 0;
@@ -244,7 +244,7 @@ public sealed partial class DomBridge
         var index = a.Length > 0 ? (int)Math.Truncate(a[0].DoubleValue) : -1;
         var td = new DomElement(_document, "td", null, null, string.Empty);
         bridge._knownNodes.Add(td);
-        td.Parent = element;
+        SetParent(td, element);
         var cells = element.Children.Where(c => !c.IsTextNode && IsTableCellElement(c)).ToList();
         if (index < 0 || index >= cells.Count)
         {
@@ -275,7 +275,7 @@ public sealed partial class DomBridge
         if (index < 0 || index >= cells.Count)
             throw new JSException("INDEX_SIZE_ERR");
         var cell = cells[index];
-        cell.Parent = null;
+        SetParent(cell, null);
         element.Children.Remove(cell);
         return JSUndefined.Value;
     }
@@ -397,8 +397,8 @@ public sealed partial class DomBridge
                 refEl = FindDomElementByJSObject(refObj);
         }
 
-        optEl.Parent?.Children.Remove(optEl);
-        optEl.Parent = element;
+        ParentEl(optEl)?.Children.Remove(optEl);
+        SetParent(optEl, element);
         if (refEl != null)
         {
             var idx = element.Children.IndexOf(refEl);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -250,9 +250,9 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetNextSibling036Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.Parent == null)
+        if (ParentEl(element) == null)
             return JSNull.Value;
-        var siblings = element.Parent.Children;
+        var siblings = ParentEl(element).Children;
         var idx = siblings.IndexOf(element);
         for (var i = idx + 1; i < siblings.Count; i++)
         {
@@ -266,9 +266,9 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetPreviousSibling037Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.Parent == null)
+        if (ParentEl(element) == null)
             return JSNull.Value;
-        var siblings = element.Parent.Children;
+        var siblings = ParentEl(element).Children;
         var idx = siblings.IndexOf(element);
         for (var i = idx - 1; i >= 0; i--)
         {
@@ -406,11 +406,11 @@ public sealed partial class DomBridge
         newNode.TextContent = remainingText;
         _knownNodes.Add(newNode);
         // Insert new node as next sibling
-        if (element.Parent != null)
+        if (ParentEl(element) != null)
         {
-            var idx = element.Parent.Children.IndexOf(element);
-            newNode.Parent = element.Parent;
-            element.Parent.Children.Insert(idx + 1, newNode);
+            var idx = ParentEl(element).Children.IndexOf(element);
+            SetParent(newNode, ParentEl(element));
+            ParentEl(element).Children.Insert(idx + 1, newNode);
         }
 
         // Invalidate cached JSObject so length/data properties reflect the update
@@ -504,11 +504,11 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetParentElement058Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.Parent == null)
+        if (ParentEl(element) == null)
             return JSNull.Value;
-        if (element.Parent.IsTextNode)
+        if (ParentEl(element).IsTextNode)
             return JSNull.Value;
-        return ToJSObject(element.Parent);
+        return ToJSObject(ParentEl(element));
     }
 
 
@@ -827,9 +827,9 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetNextElementSibling085Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.Parent == null)
+        if (ParentEl(element) == null)
             return JSNull.Value;
-        var siblings = element.Parent.Children;
+        var siblings = ParentEl(element).Children;
         var idx = siblings.IndexOf(element);
         for (var i = idx + 1; i < siblings.Count; i++)
         {
@@ -843,9 +843,9 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetPreviousElementSibling086Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.Parent == null)
+        if (ParentEl(element) == null)
             return JSNull.Value;
-        var siblings = element.Parent.Children;
+        var siblings = ParentEl(element).Children;
         var idx = siblings.IndexOf(element);
         for (var i = idx - 1; i >= 0; i--)
         {
@@ -873,7 +873,7 @@ public sealed partial class DomBridge
 
         mode = string.Equals(mode, "closed", StringComparison.OrdinalIgnoreCase) ? "closed" : "open";
         var shadowRoot = new DomElement(_document, "#shadow-root", null, null, string.Empty);
-        shadowRoot.Parent = element;
+        SetParent(shadowRoot, element);
         GetElementRuntimeState(shadowRoot).OwnerDocRoot = GetElementRuntimeState(element).OwnerDocRoot;
         GetElementRuntimeState(shadowRoot).Shadow.Host.Set(element);
         GetElementRuntimeState(shadowRoot).Shadow.Mode.Set(mode);
@@ -942,7 +942,7 @@ public sealed partial class DomBridge
             return a[0];
         NotifyNodeIteratorPreRemoval(childEl);
         element.Children.RemoveAt(idx);
-        childEl.Parent = null;
+        SetParent(childEl, null);
         bridgeForAppend.InvalidateStyleScope(element);
         NotifyChildRemoved(element, childEl, idx);
         return a[0];
@@ -970,7 +970,7 @@ public sealed partial class DomBridge
         var previousSibling = idx > 0 ? element.Children[idx - 1] : null;
         var nextSibling = idx + 1 < element.Children.Count ? element.Children[idx + 1] : null;
         // If newChild is already in this parent, remove it first and re-find idx
-        if (ReferenceEquals(newEl.Parent, element))
+        if (ReferenceEquals(ParentEl(newEl), element))
         {
             element.Children.Remove(newEl);
             idx = element.Children.IndexOf(oldEl);
@@ -979,9 +979,9 @@ public sealed partial class DomBridge
         }
         else
         {
-            if (newEl.Parent != null)
+            if (ParentEl(newEl) != null)
             {
-                var oldParent = newEl.Parent;
+                var oldParent = ParentEl(newEl);
                 var oldIndex = oldParent.Children.IndexOf(newEl);
                 if (oldIndex >= 0)
                 {
@@ -992,8 +992,8 @@ public sealed partial class DomBridge
             }
         }
 
-        oldEl.Parent = null;
-        newEl.Parent = element;
+        SetParent(oldEl, null);
+        SetParent(newEl, element);
         AdoptSubtreeIntoDocument(newEl, GetElementRuntimeState(element).OwnerDocRoot);
         element.Children[idx] = newEl;
         bridgeForAppend.InvalidateStyleScope(element);
@@ -1005,11 +1005,11 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsRemove093Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        // Capture the parent up front: DomElement.Parent is computed from the canonical
-        // ParentNode, and Children.RemoveAt detaches it — so reading element.Parent after
+        // Capture the parent up front: ParentEl(DomElement) is computed from the canonical
+        // ParentNode, and Children.RemoveAt detaches it — so reading ParentEl(element) after
         // the removal would return null (→ NRE in InvalidateStyleScope). Mirrors the
         // working removeChild path, which holds the parent reference independently.
-        var parent = element.Parent;
+        var parent = ParentEl(element);
         if (parent != null)
         {
             var idx = parent.Children.IndexOf(element);
@@ -1017,7 +1017,7 @@ public sealed partial class DomBridge
             {
                 NotifyNodeIteratorPreRemoval(element);
                 parent.Children.RemoveAt(idx);
-                element.Parent = null;
+                SetParent(element, null);
                 InvalidateStyleScope(parent);
                 NotifyChildRemoved(parent, element, idx);
             }
@@ -1029,45 +1029,45 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsBefore094Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.Parent == null || a.Length == 0)
+        if (ParentEl(element) == null || a.Length == 0)
             return JSUndefined.Value;
         var nodes = BuildChildNodeArgumentNodes(a);
-        var insertIndex = element.Parent.Children.IndexOf(element);
+        var insertIndex = ParentEl(element).Children.IndexOf(element);
         if (insertIndex < 0)
             return JSUndefined.Value;
         foreach (var node in nodes)
-            InsertNodeAt(element.Parent, node, insertIndex++);
+            InsertNodeAt(ParentEl(element), node, insertIndex++);
         return JSUndefined.Value;
     }
 
 
     private JSValue JsJsObjectsAfter095Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.Parent == null || a.Length == 0)
+        if (ParentEl(element) == null || a.Length == 0)
             return JSUndefined.Value;
         var nodes = BuildChildNodeArgumentNodes(a);
-        var insertIndex = element.Parent.Children.IndexOf(element);
+        var insertIndex = ParentEl(element).Children.IndexOf(element);
         if (insertIndex < 0)
             return JSUndefined.Value;
         insertIndex++;
         foreach (var node in nodes)
-            InsertNodeAt(element.Parent, node, insertIndex++);
+            InsertNodeAt(ParentEl(element), node, insertIndex++);
         return JSUndefined.Value;
     }
 
 
     private JSValue JsJsObjectsReplaceWith096Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.Parent == null)
+        if (ParentEl(element) == null)
             return JSUndefined.Value;
-        var parent = element.Parent;
+        var parent = ParentEl(element);
         var replacementIndex = parent.Children.IndexOf(element);
         if (replacementIndex < 0)
             return JSUndefined.Value;
         var nodes = BuildChildNodeArgumentNodes(a);
         NotifyNodeIteratorPreRemoval(element);
         parent.Children.RemoveAt(replacementIndex);
-        element.Parent = null;
+        SetParent(element, null);
         InvalidateStyleScope(parent);
         NotifyChildRemoved(parent, element, replacementIndex);
         foreach (var node in nodes)
@@ -1147,8 +1147,8 @@ public sealed partial class DomBridge
                 if (TryGetAttribute(element, "name", out var radioName) && !string.IsNullOrEmpty(radioName))
                 {
                     var scope = element;
-                    while (scope.Parent != null)
-                        scope = scope.Parent;
+                    while (ParentEl(scope) != null)
+                        scope = ParentEl(scope);
                     UncheckRadioSiblings(scope, element, radioName);
                 }
             }
@@ -1178,9 +1178,9 @@ public sealed partial class DomBridge
             if (btnType == "submit")
             {
                 // Walk up the DOM tree to find the parent <form>
-                var form = element.Parent;
+                var form = ParentEl(element);
                 while (form != null && !string.Equals(form.TagName, "form", StringComparison.OrdinalIgnoreCase))
-                    form = form.Parent;
+                    form = ParentEl(form);
                 if (form != null)
                 {
                     // Dispatch a submit event on the form
@@ -1315,14 +1315,14 @@ public sealed partial class DomBridge
             if (TryGetAttribute(element, "type", out var tp) && string.Equals(tp, "radio", StringComparison.OrdinalIgnoreCase) && TryGetAttribute(element, "name", out var radioName) && !string.IsNullOrEmpty(radioName))
             {
                 // Find the scope for radio group — form parent, or document root if not in a form
-                var scope = element.Parent;
+                var scope = ParentEl(element);
                 while (scope != null && !string.Equals(scope.TagName, "form", StringComparison.OrdinalIgnoreCase))
-                    scope = scope.Parent;
+                    scope = ParentEl(scope);
                 if (scope == null)
                 {
                     scope = element;
-                    while (scope.Parent != null)
-                        scope = scope.Parent;
+                    while (ParentEl(scope) != null)
+                        scope = ParentEl(scope);
                 }
 
                 UncheckRadioSiblings(scope, element, radioName);
@@ -1485,7 +1485,7 @@ public sealed partial class DomBridge
     private JSValue JsJsObjectsClosest129Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
         var sel = a.Length > 0 ? a[0].ToString() : string.Empty;
-        for (DomElement? current = element; current != null && !current.TagName.StartsWith("#", StringComparison.Ordinal); current = current.Parent)
+        for (DomElement? current = element; current != null && !current.TagName.StartsWith("#", StringComparison.Ordinal); current = ParentEl(current))
         {
             if (MatchesSelector(current, sel, element))
                 return bridge.ToJSObject(current);
@@ -1542,9 +1542,9 @@ public sealed partial class DomBridge
         {
             case "beforebegin":
             case "afterend":
-                if (element.Parent == null)
+                if (ParentEl(element) == null)
                     ThrowDOMException(_jsContext!, "Cannot insert adjacent HTML without a parent node.", "NoModificationAllowedError");
-                parsingContext = element.Parent!;
+                parsingContext = ParentEl(element)!;
                 break;
             default:
                 parsingContext = element;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -115,7 +115,7 @@ public sealed partial class DomBridge
     private JSValue JsJsObjectsSetTextContent021Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
         var text = a.Length > 0 ? a[0].ToString() : string.Empty;
-        if (element.IsTextNode || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
         {
             bridge.SetCharacterData(element, text);
             return JSUndefined.Value;
@@ -282,7 +282,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetNodeType038Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.IsTextNode)
+        if (IsText(element))
             return new JSNumber(3); // TEXT_NODE
         if (string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
             return new JSNumber(8); // COMMENT_NODE
@@ -298,7 +298,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetNodeName039Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.IsTextNode)
+        if (IsText(element))
             return new JSString("#text");
         if (string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
             return new JSString("#comment");
@@ -320,7 +320,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetLocalName040Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.IsTextNode)
+        if (IsText(element))
             return JSNull.Value;
         if (element.TagName.StartsWith("#"))
             return JSNull.Value; // #comment, #document, etc.
@@ -346,7 +346,7 @@ public sealed partial class DomBridge
         if (element.NamespaceURI != null)
             return new JSString(element.NamespaceURI);
         // Default namespace for HTML elements
-        if (!element.IsTextNode && !element.TagName.StartsWith("#"))
+        if (!IsText(element) && !element.TagName.StartsWith("#"))
             return new JSString("http://www.w3.org/1999/xhtml");
         return JSNull.Value;
     }
@@ -354,7 +354,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetNodeValue043Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.IsTextNode || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
             return element.TextContent != null ? new JSString(element.TextContent) : JSNull.Value;
         return JSNull.Value;
     }
@@ -362,7 +362,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsSetNodeValue044Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.IsTextNode || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
             bridge.SetCharacterData(element, a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
@@ -370,7 +370,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetData045Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.IsTextNode || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
             return element.TextContent != null ? new JSString(element.TextContent) : new JSString(string.Empty);
         return JSUndefined.Value;
     }
@@ -378,7 +378,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsSetData046Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.IsTextNode || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
             bridge.SetCharacterData(element, a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
@@ -386,7 +386,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetLength047Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.IsTextNode || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
             return new JSNumber((element.TextContent ?? string.Empty).Length);
         return new JSNumber(element.Children.Count);
     }
@@ -506,7 +506,7 @@ public sealed partial class DomBridge
     {
         if (ParentEl(element) == null)
             return JSNull.Value;
-        if (ParentEl(element).IsTextNode)
+        if (IsText(ParentEl(element)))
             return JSNull.Value;
         return ToJSObject(ParentEl(element));
     }
@@ -803,7 +803,7 @@ public sealed partial class DomBridge
         var result = new List<JSValue>();
         foreach (var child in element.Children)
         {
-            if (!child.IsTextNode && !IsSubDocRoot(child))
+            if (!IsText(child) && !IsSubDocRoot(child))
                 result.Add(ToJSObject(child));
         }
 
@@ -813,14 +813,14 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetFirstElementChild083Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        var first = element.Children.FirstOrDefault(c => !c.IsTextNode && !IsSubDocRoot(c));
+        var first = element.Children.FirstOrDefault(c => !IsText(c) && !IsSubDocRoot(c));
         return first != null ? ToJSObject(first) : JSNull.Value;
     }
 
 
     private JSValue JsJsObjectsGetLastElementChild084Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        var last = element.Children.LastOrDefault(c => !c.IsTextNode && !IsSubDocRoot(c));
+        var last = element.Children.LastOrDefault(c => !IsText(c) && !IsSubDocRoot(c));
         return last != null ? ToJSObject(last) : JSNull.Value;
     }
 
@@ -833,7 +833,7 @@ public sealed partial class DomBridge
         var idx = siblings.IndexOf(element);
         for (var i = idx + 1; i < siblings.Count; i++)
         {
-            if (!siblings[i].IsTextNode && !IsSubDocRoot(siblings[i]))
+            if (!IsText(siblings[i]) && !IsSubDocRoot(siblings[i]))
                 return ToJSObject(siblings[i]);
         }
 
@@ -849,7 +849,7 @@ public sealed partial class DomBridge
         var idx = siblings.IndexOf(element);
         for (var i = idx - 1; i >= 0; i--)
         {
-            if (!siblings[i].IsTextNode && !IsSubDocRoot(siblings[i]))
+            if (!IsText(siblings[i]) && !IsSubDocRoot(siblings[i]))
                 return ToJSObject(siblings[i]);
         }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -134,11 +134,11 @@ public sealed partial class DomBridge
         {
             // Setting element.style = "prop: val; ..." parses as cssText
             element.Style.Clear();
-            element.JsSetStyleProps.Clear();
+            GetElementRuntimeState(element).JsSetStyleProps.Clear();
             foreach (var kv in ParseStyle(s.ToString(), reportDrops: true))
             {
                 element.Style[kv.Key] = kv.Value;
-                element.JsSetStyleProps.Add(kv.Key);
+                GetElementRuntimeState(element).JsSetStyleProps.Add(kv.Key);
             }
 
             bridge.InvalidateStyleScope(element);
@@ -495,7 +495,7 @@ public sealed partial class DomBridge
     private JSValue JsJsObjectsGetOwnerDocument057Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
         // For elements in sub-documents, return the sub-document JSObject
-        if (element.OwnerDocRoot != null && _docRootToDocJSObject.TryGetValue(element.OwnerDocRoot, out var subDoc))
+        if (GetElementRuntimeState(element).OwnerDocRoot != null && _docRootToDocJSObject.TryGetValue(GetElementRuntimeState(element).OwnerDocRoot, out var subDoc))
             return subDoc;
         // For main document elements, return the main document JSObject
         return _documentJSObject ?? JSNull.Value;
@@ -874,7 +874,7 @@ public sealed partial class DomBridge
         mode = string.Equals(mode, "closed", StringComparison.OrdinalIgnoreCase) ? "closed" : "open";
         var shadowRoot = new DomElement(_document, "#shadow-root", null, null, string.Empty);
         shadowRoot.Parent = element;
-        shadowRoot.OwnerDocRoot = element.OwnerDocRoot;
+        GetElementRuntimeState(shadowRoot).OwnerDocRoot = GetElementRuntimeState(element).OwnerDocRoot;
         GetElementRuntimeState(shadowRoot).Shadow.Host.Set(element);
         GetElementRuntimeState(shadowRoot).Shadow.Mode.Set(mode);
         GetElementRuntimeState(element).Shadow.Root.Set(shadowRoot);
@@ -994,7 +994,7 @@ public sealed partial class DomBridge
 
         oldEl.Parent = null;
         newEl.Parent = element;
-        AdoptSubtreeIntoDocument(newEl, element.OwnerDocRoot);
+        AdoptSubtreeIntoDocument(newEl, GetElementRuntimeState(element).OwnerDocRoot);
         element.Children[idx] = newEl;
         bridgeForAppend.InvalidateStyleScope(element);
         NotifyChildRemoved(element, oldEl, idx, previousSibling, nextSibling);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -17,7 +17,7 @@ public sealed partial class DomBridge
     {
         var val = a.Length > 0 ? a[0].ToString() : string.Empty;
         element.Id = val;
-        element.Attributes["id"] = val;
+        SetAttr(element, "id", val);
         bridge.InvalidateStyleScope(element);
         return JSUndefined.Value;
     }
@@ -28,7 +28,7 @@ public sealed partial class DomBridge
         // Prefer Attributes['class'] (synced by setAttribute and className setter).
         // Fall back to element.ClassName for elements created with a class in the constructor
         // but not yet synced to Attributes (e.g. parsed HTML elements).
-        if (element.Attributes.TryGetValue("class", out var cls))
+        if (TryGetAttribute(element, "class", out var cls))
             return new JSString(cls);
         return element.ClassName != null ? new JSString(element.ClassName) : new JSString(string.Empty);
     }
@@ -38,7 +38,7 @@ public sealed partial class DomBridge
     {
         var val = a.Length > 0 ? a[0].ToString() : string.Empty;
         element.ClassName = val;
-        element.Attributes["class"] = val;
+        SetAttr(element, "class", val);
         bridge.InvalidateStyleScope(element);
         return JSUndefined.Value;
     }
@@ -46,28 +46,28 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsSetTitle006Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["title"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "title", a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
 
 
     private JSValue JsJsObjectsSetLang008Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["lang"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "lang", a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
 
 
     private JSValue JsJsObjectsSetAccessKey010Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["accesskey"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "accesskey", a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
 
 
     private JSValue JsJsObjectsSetDir012Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["dir"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "dir", a.Length > 0 ? a[0].ToString() : string.Empty);
         bridge.InvalidateStyleScope(element);
         return JSUndefined.Value;
     }
@@ -75,7 +75,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetDraggable013Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        if (element.Attributes.TryGetValue("draggable", out var draggable))
+        if (TryGetAttribute(element, "draggable", out var draggable))
             return string.Equals(draggable, "true", StringComparison.OrdinalIgnoreCase) ? JSBoolean.True : JSBoolean.False;
         return JSBoolean.False;
     }
@@ -83,7 +83,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsSetDraggable014Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["draggable"] = a.Length > 0 && a[0].BooleanValue ? "true" : "false";
+        SetAttr(element, "draggable", a.Length > 0 && a[0].BooleanValue ? "true" : "false");
         return JSUndefined.Value;
     }
 
@@ -154,8 +154,8 @@ public sealed partial class DomBridge
         {
             var attrName = a[0].ToString();
             var attrVal = a[1].ToString();
-            element.Attributes.TryGetValue(attrName, out var previousAttrVal);
-            element.Attributes[attrName] = attrVal;
+            TryGetAttribute(element, attrName, out var previousAttrVal);
+            SetAttr(element, attrName, attrVal);
             // Sync special properties
             if (string.Equals(attrName, "id", StringComparison.OrdinalIgnoreCase))
                 element.Id = attrVal;
@@ -189,7 +189,7 @@ public sealed partial class DomBridge
         if (a.Length == 0)
             return JSNull.Value;
         var name = a[0].ToString();
-        return element.Attributes.TryGetValue(name, out var val) ? new JSString(val) : JSNull.Value;
+        return TryGetAttribute(element, name, out var val) ? new JSString(val) : JSNull.Value;
     }
 
 
@@ -198,7 +198,7 @@ public sealed partial class DomBridge
         if (a.Length == 0)
             return JSNull.Value;
         var name = a[0].ToString();
-        return element.Attributes.TryGetValue(name, out var val) ? BuildAttrNode(name, val, element, obj) : JSNull.Value;
+        return TryGetAttribute(element, name, out var val) ? BuildAttrNode(name, val, element, obj) : JSNull.Value;
     }
 
 
@@ -208,7 +208,7 @@ public sealed partial class DomBridge
             return JSNull.Value;
         var ns = a[0].IsNull || a[0].IsUndefined ? null : a[0].ToString();
         var localName = a[1].ToString();
-        if (!element.NsAttrMap.TryGetValue((ns, localName), out var qName) || !element.Attributes.TryGetValue(qName, out var val))
+        if (!element.NsAttrMap.TryGetValue((ns, localName), out var qName) || !TryGetAttribute(element, qName, out var val))
             return JSNull.Value;
         return BuildAttrNode(qName, val, element, obj);
     }
@@ -516,7 +516,7 @@ public sealed partial class DomBridge
     {
         if (a.Length == 0)
             return JSBoolean.False;
-        return element.Attributes.ContainsKey(a[0].ToString()) ? JSBoolean.True : JSBoolean.False;
+        return HasAttr(element, a[0].ToString()) ? JSBoolean.True : JSBoolean.False;
     }
 
 
@@ -525,8 +525,8 @@ public sealed partial class DomBridge
         if (a.Length > 0)
         {
             var attrName = a[0].ToString();
-            element.Attributes.TryGetValue(attrName, out var previousAttrVal);
-            var removed = element.Attributes.Remove(attrName);
+            TryGetAttribute(element, attrName, out var previousAttrVal);
+            var removed = RemoveAttr(element, attrName);
             // Sync special properties
             if (string.Equals(attrName, "id", StringComparison.OrdinalIgnoreCase))
                 element.Id = null;
@@ -546,7 +546,7 @@ public sealed partial class DomBridge
         if (a.Length == 0)
             return JSBoolean.False;
         var attrName = a[0].ToString();
-        var hasAttribute = element.Attributes.ContainsKey(attrName);
+        var hasAttribute = HasAttr(element, attrName);
         var forceSpecified = a.Length > 1 && !a[1].IsUndefined;
         var shouldHaveAttribute = forceSpecified ? a[1].BooleanValue : !hasAttribute;
         if (shouldHaveAttribute)
@@ -569,7 +569,7 @@ public sealed partial class DomBridge
         var name = GetAttrNodeName(attrObj);
         if (string.IsNullOrEmpty(name))
             return JSNull.Value;
-        var old = element.Attributes.TryGetValue(name, out var oldVal) ? BuildAttrNode(name, oldVal, element, obj) : JSNull.Value;
+        var old = TryGetAttribute(element, name, out var oldVal) ? BuildAttrNode(name, oldVal, element, obj) : JSNull.Value;
         SetAttributeLikeSetAttribute(element, name, attrObj[(KeyString)"value"].ToString());
         return old;
     }
@@ -585,7 +585,7 @@ public sealed partial class DomBridge
             return JSNull.Value;
         var ns = GetAttrNodeNamespace(attrObj);
         JSValue old = JSNull.Value;
-        if (element.NsAttrMap.TryGetValue((ns, localName), out var oldQName) && element.Attributes.TryGetValue(oldQName, out var oldVal))
+        if (element.NsAttrMap.TryGetValue((ns, localName), out var oldQName) && TryGetAttribute(element, oldQName, out var oldVal))
             old = BuildAttrNode(oldQName, oldVal, element, obj);
         SetAttributeLikeSetAttributeNS(element, ns, name, localName, attrObj[(KeyString)"value"].ToString());
         return old;
@@ -597,7 +597,7 @@ public sealed partial class DomBridge
         if (a.Length == 0 || a[0] is not JSObject attrObj)
             return JSNull.Value;
         var name = GetAttrNodeName(attrObj);
-        if (string.IsNullOrEmpty(name) || !element.Attributes.TryGetValue(name, out var val))
+        if (string.IsNullOrEmpty(name) || !TryGetAttribute(element, name, out var val))
             return JSNull.Value;
         var removed = BuildAttrNode(name, val, element, obj);
         RemoveAttributeLikeRemoveAttribute(element, name);
@@ -613,7 +613,7 @@ public sealed partial class DomBridge
         if (string.IsNullOrEmpty(localName))
             return JSNull.Value;
         var ns = GetAttrNodeNamespace(attrObj);
-        if (!element.NsAttrMap.TryGetValue((ns, localName), out var qName) || !element.Attributes.TryGetValue(qName, out var val))
+        if (!element.NsAttrMap.TryGetValue((ns, localName), out var qName) || !TryGetAttribute(element, qName, out var val))
             return JSNull.Value;
         var removed = BuildAttrNode(qName, val, element, obj);
         RemoveAttributeLikeRemoveAttributeNS(element, ns, localName);
@@ -642,7 +642,7 @@ public sealed partial class DomBridge
             return JSNull.Value;
         var ns = a[0].IsNull || a[0].IsUndefined ? null : a[0].ToString();
         var localName = a[1].ToString();
-        if (element.NsAttrMap.TryGetValue((ns, localName), out var qName) && element.Attributes.TryGetValue(qName, out var val))
+        if (element.NsAttrMap.TryGetValue((ns, localName), out var qName) && TryGetAttribute(element, qName, out var val))
             return new JSString(val);
         return JSNull.Value;
     }
@@ -1134,17 +1134,17 @@ public sealed partial class DomBridge
         // Toggle checked state for checkboxes/radio buttons (per HTML spec)
         if (string.Equals(element.TagName, "input", StringComparison.OrdinalIgnoreCase))
         {
-            var inputType = element.Attributes.TryGetValue("type", out var t) ? t.ToLowerInvariant() : "text";
+            var inputType = TryGetAttribute(element, "type", out var t) ? t.ToLowerInvariant() : "text";
             if (inputType == "checkbox")
             {
-                bool wasChecked = GetElementRuntimeState(element).FormControl.Checked.TryGet(out var cv) && cv is true || (!GetElementRuntimeState(element).FormControl.Checked.IsSet && element.Attributes.ContainsKey("checked"));
+                bool wasChecked = GetElementRuntimeState(element).FormControl.Checked.TryGet(out var cv) && cv is true || (!GetElementRuntimeState(element).FormControl.Checked.IsSet && HasAttr(element, "checked"));
                 GetElementRuntimeState(element).FormControl.Checked.Set(!wasChecked);
             }
             else if (inputType == "radio")
             {
                 GetElementRuntimeState(element).FormControl.Checked.Set(true);
                 // Radio mutual exclusion
-                if (element.Attributes.TryGetValue("name", out var radioName) && !string.IsNullOrEmpty(radioName))
+                if (TryGetAttribute(element, "name", out var radioName) && !string.IsNullOrEmpty(radioName))
                 {
                     var scope = element;
                     while (scope.Parent != null)
@@ -1171,7 +1171,7 @@ public sealed partial class DomBridge
         if (string.Equals(element.TagName, "input", StringComparison.OrdinalIgnoreCase) || string.Equals(element.TagName, "button", StringComparison.OrdinalIgnoreCase))
         {
             var btnType = "text";
-            if (element.Attributes.TryGetValue("type", out var bt))
+            if (TryGetAttribute(element, "type", out var bt))
                 btnType = bt.ToLowerInvariant();
             else if (string.Equals(element.TagName, "button", StringComparison.OrdinalIgnoreCase))
                 btnType = "submit"; // <button> defaults to type="submit" per HTML spec
@@ -1276,7 +1276,7 @@ public sealed partial class DomBridge
             return new JSString(GetSelectValue(element));
         if (GetElementRuntimeState(element).FormControl.Value.TryGet(out var domVal) && domVal is string sv)
             return new JSString(sv);
-        if (element.Attributes.TryGetValue("value", out var val))
+        if (TryGetAttribute(element, "value", out var val))
             return new JSString(val);
         return new JSString(string.Empty);
     }
@@ -1291,7 +1291,7 @@ public sealed partial class DomBridge
         else if (tag == "select")
             SetSelectValue(element, v);
         else
-            element.Attributes["value"] = v;
+            SetAttr(element, "value", v);
         return JSUndefined.Value;
     }
 
@@ -1301,7 +1301,7 @@ public sealed partial class DomBridge
         // IDL property takes precedence over content attribute
         if (GetElementRuntimeState(element).FormControl.Checked.TryGet(out var v))
             return v is true ? JSBoolean.True : JSBoolean.False;
-        return element.Attributes.ContainsKey("checked") ? JSBoolean.True : JSBoolean.False;
+        return HasAttr(element, "checked") ? JSBoolean.True : JSBoolean.False;
     }
 
 
@@ -1312,7 +1312,7 @@ public sealed partial class DomBridge
         if (newVal)
         {
             // Radio button mutual exclusion: uncheck others in same group
-            if (element.Attributes.TryGetValue("type", out var tp) && string.Equals(tp, "radio", StringComparison.OrdinalIgnoreCase) && element.Attributes.TryGetValue("name", out var radioName) && !string.IsNullOrEmpty(radioName))
+            if (TryGetAttribute(element, "type", out var tp) && string.Equals(tp, "radio", StringComparison.OrdinalIgnoreCase) && TryGetAttribute(element, "name", out var radioName) && !string.IsNullOrEmpty(radioName))
             {
                 // Find the scope for radio group — form parent, or document root if not in a form
                 var scope = element.Parent;
@@ -1335,7 +1335,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetType110Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.Attributes.TryGetValue("type", out var t))
+        if (TryGetAttribute(element, "type", out var t))
             return new JSString(t.ToLowerInvariant());
         // Default type values per HTML spec
         var tag = element.TagName.ToLowerInvariant();
@@ -1347,14 +1347,14 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsSetType111Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["type"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "type", a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
 
 
     private JSValue JsJsObjectsGetName112Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.Attributes.TryGetValue("name", out var n))
+        if (TryGetAttribute(element, "name", out var n))
             return new JSString(n);
         return new JSString(string.Empty);
     }
@@ -1362,7 +1362,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsSetName113Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["name"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "name", a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
 
@@ -1370,9 +1370,9 @@ public sealed partial class DomBridge
     private JSValue JsJsObjectsSetDisabled115Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
         if (a.Length > 0 && a[0].BooleanValue)
-            element.Attributes["disabled"] = "disabled";
+            SetAttr(element, "disabled", "disabled");
         else
-            element.Attributes.Remove("disabled");
+            RemoveAttr(element, "disabled");
         bridge.InvalidateStyleScope(element);
         return JSUndefined.Value;
     }
@@ -1381,9 +1381,9 @@ public sealed partial class DomBridge
     private JSValue JsJsObjectsSetHidden117Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
         if (a.Length > 0 && a[0].BooleanValue)
-            element.Attributes["hidden"] = string.Empty;
+            SetAttr(element, "hidden", string.Empty);
         else
-            element.Attributes.Remove("hidden");
+            RemoveAttr(element, "hidden");
         bridge.InvalidateStyleScope(element);
         return JSUndefined.Value;
     }
@@ -1391,7 +1391,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetTabIndex118Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
     {
-        if (element.Attributes.TryGetValue("tabindex", out var rawTabIndex) && int.TryParse(rawTabIndex, out var parsedTabIndex))
+        if (TryGetAttribute(element, "tabindex", out var rawTabIndex) && int.TryParse(rawTabIndex, out var parsedTabIndex))
         {
             return new JSNumber(parsedTabIndex);
         }
@@ -1405,7 +1405,7 @@ public sealed partial class DomBridge
         if (a.Length == 0)
             return JSUndefined.Value;
         var tabIndex = (int)Math.Truncate(a[0].DoubleValue);
-        element.Attributes["tabindex"] = tabIndex.ToString();
+        SetAttr(element, "tabindex", tabIndex.ToString());
         return JSUndefined.Value;
     }
 
@@ -1413,9 +1413,9 @@ public sealed partial class DomBridge
     private JSValue JsJsObjectsSetRequired121Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
         if (a.Length > 0 && a[0].BooleanValue)
-            element.Attributes["required"] = "required";
+            SetAttr(element, "required", "required");
         else
-            element.Attributes.Remove("required");
+            RemoveAttr(element, "required");
         bridge.InvalidateStyleScope(element);
         return JSUndefined.Value;
     }
@@ -1614,7 +1614,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsSetSrc139Core(global::Broiler.HtmlBridge.DomBridge? bridgeForSrc, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["src"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "src", a.Length > 0 ? a[0].ToString() : string.Empty);
         // Invalidate cached sub-document when src changes
         InvalidateCachedSubDocument(element);
         _onloadFired.Remove(element);
@@ -1626,7 +1626,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsSetSrcdoc141Core(global::Broiler.HtmlBridge.DomBridge? bridgeForSrc, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        element.Attributes["srcdoc"] = a.Length > 0 ? a[0].ToString() : string.Empty;
+        SetAttr(element, "srcdoc", a.Length > 0 ? a[0].ToString() : string.Empty);
         InvalidateCachedSubDocument(element);
         _onloadFired.Remove(element);
         bridgeForSrc.FireSubDocumentOnload(element);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -133,11 +133,11 @@ public sealed partial class DomBridge
         if (a.Length > 0 && a[0] is JSString s)
         {
             // Setting element.style = "prop: val; ..." parses as cssText
-            element.Style.Clear();
+            InlineStyle(element).Clear();
             GetElementRuntimeState(element).JsSetStyleProps.Clear();
             foreach (var kv in ParseStyle(s.ToString(), reportDrops: true))
             {
-                element.Style[kv.Key] = kv.Value;
+                InlineStyle(element)[kv.Key] = kv.Value;
                 GetElementRuntimeState(element).JsSetStyleProps.Add(kv.Key);
             }
 
@@ -163,9 +163,9 @@ public sealed partial class DomBridge
                 element.ClassName = attrVal;
             else if (string.Equals(attrName, "style", StringComparison.OrdinalIgnoreCase))
             {
-                element.Style.Clear();
+                InlineStyle(element).Clear();
                 foreach (var kv in ParseStyle(attrVal, reportDrops: true))
-                    element.Style[kv.Key] = kv.Value;
+                    InlineStyle(element)[kv.Key] = kv.Value;
                 bridgeForSet.InvalidateStyleScope(element);
             }
             // Compile on* event handler attributes into functions

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -123,7 +123,7 @@ public sealed partial class DomBridge
 
         element.TextContent = text;
         // Setting textContent clears all children per DOM spec
-        element.Children.Clear();
+        ClearChildren(element);
         return JSUndefined.Value;
     }
 
@@ -224,7 +224,7 @@ public sealed partial class DomBridge
     private JSValue JsJsObjectsGetChildNodes033Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
         var children = new List<JSValue>();
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
         {
             if (!IsSubDocRoot(child))
                 children.Add(ToJSObject(child));
@@ -236,14 +236,14 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetFirstChild034Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        var first = element.Children.FirstOrDefault(c => !IsSubDocRoot(c));
+        var first = ChildElements(element).FirstOrDefault(c => !IsSubDocRoot(c));
         return first != null ? ToJSObject(first) : JSNull.Value;
     }
 
 
     private JSValue JsJsObjectsGetLastChild035Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        var last = element.Children.LastOrDefault(c => !IsSubDocRoot(c));
+        var last = ChildElements(element).LastOrDefault(c => !IsSubDocRoot(c));
         return last != null ? ToJSObject(last) : JSNull.Value;
     }
 
@@ -252,7 +252,7 @@ public sealed partial class DomBridge
     {
         if (ParentEl(element) == null)
             return JSNull.Value;
-        var siblings = ParentEl(element).Children;
+        var siblings = ChildElements(ParentEl(element)).ToList();
         var idx = siblings.IndexOf(element);
         for (var i = idx + 1; i < siblings.Count; i++)
         {
@@ -268,7 +268,7 @@ public sealed partial class DomBridge
     {
         if (ParentEl(element) == null)
             return JSNull.Value;
-        var siblings = ParentEl(element).Children;
+        var siblings = ChildElements(ParentEl(element)).ToList();
         var idx = siblings.IndexOf(element);
         for (var i = idx - 1; i >= 0; i--)
         {
@@ -388,7 +388,7 @@ public sealed partial class DomBridge
     {
         if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
             return new JSNumber((element.TextContent ?? string.Empty).Length);
-        return new JSNumber(element.Children.Count);
+        return new JSNumber(element.ChildNodes.Count);
     }
 
 
@@ -408,9 +408,9 @@ public sealed partial class DomBridge
         // Insert new node as next sibling
         if (ParentEl(element) != null)
         {
-            var idx = ParentEl(element).Children.IndexOf(element);
+            var idx = ChildIndexOf(ParentEl(element), element);
             SetParent(newNode, ParentEl(element));
-            ParentEl(element).Children.Insert(idx + 1, newNode);
+            InsertChildAt(ParentEl(element), idx + 1, newNode);
         }
 
         // Invalidate cached JSObject so length/data properties reflect the update
@@ -778,7 +778,7 @@ public sealed partial class DomBridge
             ThrowDOMException(_jsContext!, "The new child element contains the parent.", "HierarchyRequestError");
         if (a.Length < 2 || a[1].IsNull || a[1].IsUndefined)
         {
-            bridgeForInsert.InsertNodeAt(element, newEl, element.Children.Count);
+            bridgeForInsert.InsertNodeAt(element, newEl, element.ChildNodes.Count);
             return a[0];
         }
 
@@ -790,7 +790,7 @@ public sealed partial class DomBridge
             return a[0];
         if (ReferenceEquals(newEl, refEl))
             return a[0];
-        var idx = element.Children.IndexOf(refEl);
+        var idx = ChildIndexOf(element, refEl);
         if (idx < 0)
             throw new JSException("NotFoundError: The node before which the new node is to be inserted is not a child of this node.");
         bridgeForInsert.InsertNodeAt(element, newEl, idx);
@@ -801,7 +801,7 @@ public sealed partial class DomBridge
     private JSValue JsJsObjectsGetChildren081Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
         var result = new List<JSValue>();
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
         {
             if (!IsText(child) && !IsSubDocRoot(child))
                 result.Add(ToJSObject(child));
@@ -813,14 +813,14 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetFirstElementChild083Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        var first = element.Children.FirstOrDefault(c => !IsText(c) && !IsSubDocRoot(c));
+        var first = ChildElements(element).FirstOrDefault(c => !IsText(c) && !IsSubDocRoot(c));
         return first != null ? ToJSObject(first) : JSNull.Value;
     }
 
 
     private JSValue JsJsObjectsGetLastElementChild084Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        var last = element.Children.LastOrDefault(c => !IsText(c) && !IsSubDocRoot(c));
+        var last = ChildElements(element).LastOrDefault(c => !IsText(c) && !IsSubDocRoot(c));
         return last != null ? ToJSObject(last) : JSNull.Value;
     }
 
@@ -829,7 +829,7 @@ public sealed partial class DomBridge
     {
         if (ParentEl(element) == null)
             return JSNull.Value;
-        var siblings = ParentEl(element).Children;
+        var siblings = ChildElements(ParentEl(element)).ToList();
         var idx = siblings.IndexOf(element);
         for (var i = idx + 1; i < siblings.Count; i++)
         {
@@ -845,7 +845,7 @@ public sealed partial class DomBridge
     {
         if (ParentEl(element) == null)
             return JSNull.Value;
-        var siblings = ParentEl(element).Children;
+        var siblings = ChildElements(ParentEl(element)).ToList();
         var idx = siblings.IndexOf(element);
         for (var i = idx - 1; i >= 0; i--)
         {
@@ -898,7 +898,7 @@ public sealed partial class DomBridge
         // Prevent circular references (HierarchyRequestError per DOM spec)
         if (ReferenceEquals(childEl, element) || IsDescendant(childEl, element))
             ThrowDOMException(_jsContext!, "The new child element contains the parent.", "HierarchyRequestError");
-        bridgeForAppend.InsertNodeAt(element, childEl, element.Children.Count);
+        bridgeForAppend.InsertNodeAt(element, childEl, element.ChildNodes.Count);
         return a[0];
     }
 
@@ -908,7 +908,7 @@ public sealed partial class DomBridge
         if (a.Length == 0)
             return JSUndefined.Value;
         var nodes = BuildChildNodeArgumentNodes(a);
-        var insertIndex = element.Children.Count;
+        var insertIndex = element.ChildNodes.Count;
         foreach (var node in nodes)
             InsertNodeAt(element, node, insertIndex++);
         return JSUndefined.Value;
@@ -937,11 +937,11 @@ public sealed partial class DomBridge
         var childEl = FindDomElementByJSObject(childObj);
         if (childEl == null)
             return a[0];
-        var idx = element.Children.IndexOf(childEl);
+        var idx = ChildIndexOf(element, childEl);
         if (idx < 0)
             return a[0];
         NotifyNodeIteratorPreRemoval(childEl);
-        element.Children.RemoveAt(idx);
+        RemoveNthChild(element, idx);
         SetParent(childEl, null);
         bridgeForAppend.InvalidateStyleScope(element);
         NotifyChildRemoved(element, childEl, idx);
@@ -964,16 +964,16 @@ public sealed partial class DomBridge
         // Prevent circular references (HierarchyRequestError per DOM spec)
         if (ReferenceEquals(newEl, element) || IsDescendant(newEl, element))
             ThrowDOMException(_jsContext!, "The new child element contains the parent.", "HierarchyRequestError");
-        var idx = element.Children.IndexOf(oldEl);
+        var idx = ChildIndexOf(element, oldEl);
         if (idx < 0)
             return a[1];
-        var previousSibling = idx > 0 ? element.Children[idx - 1] : null;
-        var nextSibling = idx + 1 < element.Children.Count ? element.Children[idx + 1] : null;
+        var previousSibling = idx > 0 ? ChildAt(element, idx - 1) : null;
+        var nextSibling = idx + 1 < element.ChildNodes.Count ? ChildAt(element, idx + 1) : null;
         // If newChild is already in this parent, remove it first and re-find idx
         if (ReferenceEquals(ParentEl(newEl), element))
         {
-            element.Children.Remove(newEl);
-            idx = element.Children.IndexOf(oldEl);
+            RemoveChildFrom(element, newEl);
+            idx = ChildIndexOf(element, oldEl);
             if (idx < 0)
                 return a[1];
         }
@@ -982,11 +982,11 @@ public sealed partial class DomBridge
             if (ParentEl(newEl) != null)
             {
                 var oldParent = ParentEl(newEl);
-                var oldIndex = oldParent.Children.IndexOf(newEl);
+                var oldIndex = ChildIndexOf(oldParent, newEl);
                 if (oldIndex >= 0)
                 {
                     NotifyNodeIteratorPreRemoval(newEl);
-                    oldParent.Children.RemoveAt(oldIndex);
+                    RemoveNthChild(oldParent, oldIndex);
                     NotifyChildRemoved(oldParent, newEl, oldIndex);
                 }
             }
@@ -995,7 +995,7 @@ public sealed partial class DomBridge
         SetParent(oldEl, null);
         SetParent(newEl, element);
         AdoptSubtreeIntoDocument(newEl, GetElementRuntimeState(element).OwnerDocRoot);
-        element.Children[idx] = newEl;
+        element.ReplaceChild(newEl, element.ChildNodes[idx]);
         bridgeForAppend.InvalidateStyleScope(element);
         NotifyChildRemoved(element, oldEl, idx, previousSibling, nextSibling);
         NotifyChildAdded(element, newEl, idx);
@@ -1012,11 +1012,11 @@ public sealed partial class DomBridge
         var parent = ParentEl(element);
         if (parent != null)
         {
-            var idx = parent.Children.IndexOf(element);
+            var idx = ChildIndexOf(parent, element);
             if (idx >= 0)
             {
                 NotifyNodeIteratorPreRemoval(element);
-                parent.Children.RemoveAt(idx);
+                RemoveNthChild(parent, idx);
                 SetParent(element, null);
                 InvalidateStyleScope(parent);
                 NotifyChildRemoved(parent, element, idx);
@@ -1032,7 +1032,7 @@ public sealed partial class DomBridge
         if (ParentEl(element) == null || a.Length == 0)
             return JSUndefined.Value;
         var nodes = BuildChildNodeArgumentNodes(a);
-        var insertIndex = ParentEl(element).Children.IndexOf(element);
+        var insertIndex = ChildIndexOf(ParentEl(element), element);
         if (insertIndex < 0)
             return JSUndefined.Value;
         foreach (var node in nodes)
@@ -1046,7 +1046,7 @@ public sealed partial class DomBridge
         if (ParentEl(element) == null || a.Length == 0)
             return JSUndefined.Value;
         var nodes = BuildChildNodeArgumentNodes(a);
-        var insertIndex = ParentEl(element).Children.IndexOf(element);
+        var insertIndex = ChildIndexOf(ParentEl(element), element);
         if (insertIndex < 0)
             return JSUndefined.Value;
         insertIndex++;
@@ -1061,12 +1061,12 @@ public sealed partial class DomBridge
         if (ParentEl(element) == null)
             return JSUndefined.Value;
         var parent = ParentEl(element);
-        var replacementIndex = parent.Children.IndexOf(element);
+        var replacementIndex = ChildIndexOf(parent, element);
         if (replacementIndex < 0)
             return JSUndefined.Value;
         var nodes = BuildChildNodeArgumentNodes(a);
         NotifyNodeIteratorPreRemoval(element);
-        parent.Children.RemoveAt(replacementIndex);
+        RemoveNthChild(parent, replacementIndex);
         SetParent(element, null);
         InvalidateStyleScope(parent);
         NotifyChildRemoved(parent, element, replacementIndex);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
@@ -533,7 +533,7 @@ public sealed partial class DomBridge
                     {
                         currentScript = documentElements[CurrentScriptIndex];
                         // Verify it's a <script> in mainBody
-                        if (currentScript.Parent != mainBody)
+                        if (ParentEl(currentScript) != mainBody)
                             currentScript = null;
                     }
 
@@ -543,7 +543,7 @@ public sealed partial class DomBridge
                         var insertIdx = mainBody.Children.IndexOf(currentScript) + 1;
                         for (int ci = 0; ci < writtenChildren.Length; ci++)
                         {
-                            writtenChildren[ci].Parent = mainBody;
+                            SetParent(writtenChildren[ci], mainBody);
                             mainBody.Children.Insert(insertIdx + ci, writtenChildren[ci]);
                         }
                     }
@@ -552,7 +552,7 @@ public sealed partial class DomBridge
                         // Fallback: append to end
                         foreach (var child in writtenChildren)
                         {
-                            child.Parent = mainBody;
+                            SetParent(child, mainBody);
                             mainBody.Children.Add(child);
                         }
                     }
@@ -656,7 +656,7 @@ public sealed partial class DomBridge
             {
                 NotifyNodeIteratorPreRemoval(childEl);
                 docNodeForMutation.Children.RemoveAt(idx);
-                childEl.Parent = null;
+                SetParent(childEl, null);
                 NotifyChildRemoved(docNodeForMutation, childEl, idx);
             }
         }
@@ -675,9 +675,9 @@ public sealed partial class DomBridge
         var childEl = FindDomElementByJSObject(childObj);
         if (childEl != null)
         {
-            if (childEl.Parent != null)
+            if (ParentEl(childEl) != null)
             {
-                var oldParent = childEl.Parent;
+                var oldParent = ParentEl(childEl);
                 var oldIndex = oldParent.Children.IndexOf(childEl);
                 if (oldIndex >= 0)
                 {
@@ -687,7 +687,7 @@ public sealed partial class DomBridge
                 }
             }
 
-            childEl.Parent = docNodeForMutation;
+            SetParent(childEl, docNodeForMutation);
             docNodeForMutation.Children.Add(childEl);
             NotifyChildAdded(docNodeForMutation, childEl, docNodeForMutation.Children.Count - 1);
         }
@@ -706,9 +706,9 @@ public sealed partial class DomBridge
         var newEl = FindDomElementByJSObject(newObj);
         if (newEl == null)
             return a[0];
-        if (newEl.Parent != null)
+        if (ParentEl(newEl) != null)
         {
-            var oldParent = newEl.Parent;
+            var oldParent = ParentEl(newEl);
             var oldIndex = oldParent.Children.IndexOf(newEl);
             if (oldIndex >= 0)
             {
@@ -726,7 +726,7 @@ public sealed partial class DomBridge
                 var idx = docNodeForMutation.Children.IndexOf(refEl);
                 if (idx >= 0)
                 {
-                    newEl.Parent = docNodeForMutation;
+                    SetParent(newEl, docNodeForMutation);
                     docNodeForMutation.Children.Insert(idx, newEl);
                     NotifyChildAdded(docNodeForMutation, newEl, idx);
                     return a[0];
@@ -735,7 +735,7 @@ public sealed partial class DomBridge
         }
 
         // If refChild is null or not found, append
-        newEl.Parent = docNodeForMutation;
+        SetParent(newEl, docNodeForMutation);
         docNodeForMutation.Children.Add(newEl);
         NotifyChildAdded(docNodeForMutation, newEl, docNodeForMutation.Children.Count - 1);
         return a[0];
@@ -870,7 +870,7 @@ public sealed partial class DomBridge
                 if (kvp.Value == dtObj)
                 {
                     var dtEl = kvp.Key;
-                    dtEl.Parent = docRoot;
+                    SetParent(dtEl, docRoot);
                     GetElementRuntimeState(dtEl).OwnerDocRoot = docRoot;
                     docRoot.Children.Add(dtEl);
                     break;
@@ -884,7 +884,7 @@ public sealed partial class DomBridge
             var docEl = new DomElement(_document, qName, null, null, string.Empty);
             if (!string.IsNullOrEmpty(ns))
                 docEl.NamespaceURI = ns;
-            docEl.Parent = docRoot;
+            SetParent(docEl, docRoot);
             GetElementRuntimeState(docEl).OwnerDocRoot = docRoot;
             docRoot.Children.Add(docEl);
             _knownNodes.Add(docEl);
@@ -907,18 +907,18 @@ public sealed partial class DomBridge
         GetElementRuntimeState(doctype).DocumentType.PublicId.Set(string.Empty);
         GetElementRuntimeState(doctype).DocumentType.SystemId.Set(string.Empty);
         GetElementRuntimeState(doctype).DocumentType.InternalSubset.Set(null);
-        doctype.Parent = docRoot;
+        SetParent(doctype, docRoot);
         GetElementRuntimeState(doctype).OwnerDocRoot = docRoot;
         docRoot.Children.Add(doctype);
         _knownNodes.Add(doctype);
         var htmlEl = new DomElement(_document, "html", null, null, string.Empty);
         htmlEl.NamespaceURI = "http://www.w3.org/1999/xhtml";
-        htmlEl.Parent = docRoot;
+        SetParent(htmlEl, docRoot);
         GetElementRuntimeState(htmlEl).OwnerDocRoot = docRoot;
         docRoot.Children.Add(htmlEl);
         _knownNodes.Add(htmlEl);
         var headEl = new DomElement(_document, "head", null, null, string.Empty);
-        headEl.Parent = htmlEl;
+        SetParent(headEl, htmlEl);
         GetElementRuntimeState(headEl).OwnerDocRoot = docRoot;
         htmlEl.Children.Add(headEl);
         _knownNodes.Add(headEl);
@@ -926,20 +926,20 @@ public sealed partial class DomBridge
         if (title != null)
         {
             var titleEl = new DomElement(_document, "title", null, null, string.Empty);
-            titleEl.Parent = headEl;
+            SetParent(titleEl, headEl);
             GetElementRuntimeState(titleEl).OwnerDocRoot = docRoot;
             headEl.Children.Add(titleEl);
             _knownNodes.Add(titleEl);
             var titleText = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
             titleText.TextContent = title;
-            titleText.Parent = titleEl;
+            SetParent(titleText, titleEl);
             GetElementRuntimeState(titleText).OwnerDocRoot = docRoot;
             titleEl.Children.Add(titleText);
             _knownNodes.Add(titleText);
         }
 
         var bodyEl = new DomElement(_document, "body", null, null, string.Empty);
-        bodyEl.Parent = htmlEl;
+        SetParent(bodyEl, htmlEl);
         GetElementRuntimeState(bodyEl).OwnerDocRoot = docRoot;
         htmlEl.Children.Add(bodyEl);
         _knownNodes.Add(bodyEl);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
@@ -17,7 +17,7 @@ public sealed partial class DomBridge
 
     private JSValue JsRegistrationGetBody002Core(in Arguments a)
     {
-        foreach (var child in DocumentElement.Children)
+        foreach (var child in ChildElements(DocumentElement))
         {
             if (string.Equals(child.TagName, "body", StringComparison.OrdinalIgnoreCase))
                 return ToJSObject(child);
@@ -29,7 +29,7 @@ public sealed partial class DomBridge
 
     private JSValue JsRegistrationGetHead003Core(in Arguments a)
     {
-        foreach (var child in DocumentElement.Children)
+        foreach (var child in ChildElements(DocumentElement))
         {
             if (string.Equals(child.TagName, "head", StringComparison.OrdinalIgnoreCase))
                 return ToJSObject(child);
@@ -517,10 +517,10 @@ public sealed partial class DomBridge
             var fragment = a[0].ToString();
             var builder = new HtmlTreeBuilder();
             var (fragmentRoot, allEls) = builder.BuildFragment(fragment, "body", _document);
-            if (fragmentRoot.Children.Count > 0)
+            if (fragmentRoot.ChildNodes.Count > 0)
             {
                 // Find the <body> element in the main tree
-                var mainBody = DocumentElement.Children.FirstOrDefault(c => string.Equals(c.TagName, "body", StringComparison.OrdinalIgnoreCase));
+                var mainBody = ChildElements(DocumentElement).FirstOrDefault(c => string.Equals(c.TagName, "body", StringComparison.OrdinalIgnoreCase));
                 if (mainBody != null)
                 {
                     // Find the currently executing <script> element so we can
@@ -537,14 +537,14 @@ public sealed partial class DomBridge
                             currentScript = null;
                     }
 
-                    var writtenChildren = fragmentRoot.Children.ToArray();
+                    var writtenChildren = ChildElements(fragmentRoot).ToArray();
                     if (currentScript != null)
                     {
-                        var insertIdx = mainBody.Children.IndexOf(currentScript) + 1;
+                        var insertIdx = ChildIndexOf(mainBody, currentScript) + 1;
                         for (int ci = 0; ci < writtenChildren.Length; ci++)
                         {
                             SetParent(writtenChildren[ci], mainBody);
-                            mainBody.Children.Insert(insertIdx + ci, writtenChildren[ci]);
+                            InsertChildAt(mainBody, insertIdx + ci, writtenChildren[ci]);
                         }
                     }
                     else
@@ -553,7 +553,7 @@ public sealed partial class DomBridge
                         foreach (var child in writtenChildren)
                         {
                             SetParent(child, mainBody);
-                            mainBody.Children.Add(child);
+                            mainBody.AppendChild(child);
                         }
                     }
 
@@ -635,7 +635,7 @@ public sealed partial class DomBridge
     private JSValue JsRegistrationGetChildNodes046Core(in Arguments _)
     {
         var nodes = new List<JSValue>();
-        foreach (var child in _documentNode.Children)
+        foreach (var child in ChildElements(_documentNode))
             nodes.Add(ToJSObject(child));
         return new JSArray(nodes);
     }
@@ -651,11 +651,11 @@ public sealed partial class DomBridge
         var childEl = FindDomElementByJSObject(childObj);
         if (childEl != null)
         {
-            var idx = docNodeForMutation.Children.IndexOf(childEl);
+            var idx = ChildIndexOf(docNodeForMutation, childEl);
             if (idx >= 0)
             {
                 NotifyNodeIteratorPreRemoval(childEl);
-                docNodeForMutation.Children.RemoveAt(idx);
+                RemoveNthChild(docNodeForMutation, idx);
                 SetParent(childEl, null);
                 NotifyChildRemoved(docNodeForMutation, childEl, idx);
             }
@@ -678,18 +678,18 @@ public sealed partial class DomBridge
             if (ParentEl(childEl) != null)
             {
                 var oldParent = ParentEl(childEl);
-                var oldIndex = oldParent.Children.IndexOf(childEl);
+                var oldIndex = ChildIndexOf(oldParent, childEl);
                 if (oldIndex >= 0)
                 {
                     NotifyNodeIteratorPreRemoval(childEl);
-                    oldParent.Children.RemoveAt(oldIndex);
+                    RemoveNthChild(oldParent, oldIndex);
                     NotifyChildRemoved(oldParent, childEl, oldIndex);
                 }
             }
 
             SetParent(childEl, docNodeForMutation);
-            docNodeForMutation.Children.Add(childEl);
-            NotifyChildAdded(docNodeForMutation, childEl, docNodeForMutation.Children.Count - 1);
+            docNodeForMutation.AppendChild(childEl);
+            NotifyChildAdded(docNodeForMutation, childEl, docNodeForMutation.ChildNodes.Count - 1);
         }
 
         return a[0];
@@ -709,11 +709,11 @@ public sealed partial class DomBridge
         if (ParentEl(newEl) != null)
         {
             var oldParent = ParentEl(newEl);
-            var oldIndex = oldParent.Children.IndexOf(newEl);
+            var oldIndex = ChildIndexOf(oldParent, newEl);
             if (oldIndex >= 0)
             {
                 NotifyNodeIteratorPreRemoval(newEl);
-                oldParent.Children.RemoveAt(oldIndex);
+                RemoveNthChild(oldParent, oldIndex);
                 NotifyChildRemoved(oldParent, newEl, oldIndex);
             }
         }
@@ -723,11 +723,11 @@ public sealed partial class DomBridge
             var refEl = FindDomElementByJSObject(refObj);
             if (refEl != null)
             {
-                var idx = docNodeForMutation.Children.IndexOf(refEl);
+                var idx = ChildIndexOf(docNodeForMutation, refEl);
                 if (idx >= 0)
                 {
                     SetParent(newEl, docNodeForMutation);
-                    docNodeForMutation.Children.Insert(idx, newEl);
+                    InsertChildAt(docNodeForMutation, idx, newEl);
                     NotifyChildAdded(docNodeForMutation, newEl, idx);
                     return a[0];
                 }
@@ -736,8 +736,8 @@ public sealed partial class DomBridge
 
         // If refChild is null or not found, append
         SetParent(newEl, docNodeForMutation);
-        docNodeForMutation.Children.Add(newEl);
-        NotifyChildAdded(docNodeForMutation, newEl, docNodeForMutation.Children.Count - 1);
+        docNodeForMutation.AppendChild(newEl);
+        NotifyChildAdded(docNodeForMutation, newEl, docNodeForMutation.ChildNodes.Count - 1);
         return a[0];
     }
 
@@ -872,7 +872,7 @@ public sealed partial class DomBridge
                     var dtEl = kvp.Key;
                     SetParent(dtEl, docRoot);
                     GetElementRuntimeState(dtEl).OwnerDocRoot = docRoot;
-                    docRoot.Children.Add(dtEl);
+                    docRoot.AppendChild(dtEl);
                     break;
                 }
             }
@@ -886,7 +886,7 @@ public sealed partial class DomBridge
                 docEl.NamespaceURI = ns;
             SetParent(docEl, docRoot);
             GetElementRuntimeState(docEl).OwnerDocRoot = docRoot;
-            docRoot.Children.Add(docEl);
+            docRoot.AppendChild(docEl);
             _knownNodes.Add(docEl);
         }
 
@@ -909,18 +909,18 @@ public sealed partial class DomBridge
         GetElementRuntimeState(doctype).DocumentType.InternalSubset.Set(null);
         SetParent(doctype, docRoot);
         GetElementRuntimeState(doctype).OwnerDocRoot = docRoot;
-        docRoot.Children.Add(doctype);
+        docRoot.AppendChild(doctype);
         _knownNodes.Add(doctype);
         var htmlEl = new DomElement(_document, "html", null, null, string.Empty);
         htmlEl.NamespaceURI = "http://www.w3.org/1999/xhtml";
         SetParent(htmlEl, docRoot);
         GetElementRuntimeState(htmlEl).OwnerDocRoot = docRoot;
-        docRoot.Children.Add(htmlEl);
+        docRoot.AppendChild(htmlEl);
         _knownNodes.Add(htmlEl);
         var headEl = new DomElement(_document, "head", null, null, string.Empty);
         SetParent(headEl, htmlEl);
         GetElementRuntimeState(headEl).OwnerDocRoot = docRoot;
-        htmlEl.Children.Add(headEl);
+        htmlEl.AppendChild(headEl);
         _knownNodes.Add(headEl);
         // Add <title> element if title argument is provided
         if (title != null)
@@ -928,20 +928,20 @@ public sealed partial class DomBridge
             var titleEl = new DomElement(_document, "title", null, null, string.Empty);
             SetParent(titleEl, headEl);
             GetElementRuntimeState(titleEl).OwnerDocRoot = docRoot;
-            headEl.Children.Add(titleEl);
+            headEl.AppendChild(titleEl);
             _knownNodes.Add(titleEl);
             var titleText = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
             titleText.TextContent = title;
             SetParent(titleText, titleEl);
             GetElementRuntimeState(titleText).OwnerDocRoot = docRoot;
-            titleEl.Children.Add(titleText);
+            titleEl.AppendChild(titleText);
             _knownNodes.Add(titleText);
         }
 
         var bodyEl = new DomElement(_document, "body", null, null, string.Empty);
         SetParent(bodyEl, htmlEl);
         GetElementRuntimeState(bodyEl).OwnerDocRoot = docRoot;
-        htmlEl.Children.Add(bodyEl);
+        htmlEl.AppendChild(bodyEl);
         _knownNodes.Add(bodyEl);
         return BuildSubDocument(docRoot);
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
@@ -871,7 +871,7 @@ public sealed partial class DomBridge
                 {
                     var dtEl = kvp.Key;
                     dtEl.Parent = docRoot;
-                    dtEl.OwnerDocRoot = docRoot;
+                    GetElementRuntimeState(dtEl).OwnerDocRoot = docRoot;
                     docRoot.Children.Add(dtEl);
                     break;
                 }
@@ -885,7 +885,7 @@ public sealed partial class DomBridge
             if (!string.IsNullOrEmpty(ns))
                 docEl.NamespaceURI = ns;
             docEl.Parent = docRoot;
-            docEl.OwnerDocRoot = docRoot;
+            GetElementRuntimeState(docEl).OwnerDocRoot = docRoot;
             docRoot.Children.Add(docEl);
             _knownNodes.Add(docEl);
         }
@@ -908,18 +908,18 @@ public sealed partial class DomBridge
         GetElementRuntimeState(doctype).DocumentType.SystemId.Set(string.Empty);
         GetElementRuntimeState(doctype).DocumentType.InternalSubset.Set(null);
         doctype.Parent = docRoot;
-        doctype.OwnerDocRoot = docRoot;
+        GetElementRuntimeState(doctype).OwnerDocRoot = docRoot;
         docRoot.Children.Add(doctype);
         _knownNodes.Add(doctype);
         var htmlEl = new DomElement(_document, "html", null, null, string.Empty);
         htmlEl.NamespaceURI = "http://www.w3.org/1999/xhtml";
         htmlEl.Parent = docRoot;
-        htmlEl.OwnerDocRoot = docRoot;
+        GetElementRuntimeState(htmlEl).OwnerDocRoot = docRoot;
         docRoot.Children.Add(htmlEl);
         _knownNodes.Add(htmlEl);
         var headEl = new DomElement(_document, "head", null, null, string.Empty);
         headEl.Parent = htmlEl;
-        headEl.OwnerDocRoot = docRoot;
+        GetElementRuntimeState(headEl).OwnerDocRoot = docRoot;
         htmlEl.Children.Add(headEl);
         _knownNodes.Add(headEl);
         // Add <title> element if title argument is provided
@@ -927,20 +927,20 @@ public sealed partial class DomBridge
         {
             var titleEl = new DomElement(_document, "title", null, null, string.Empty);
             titleEl.Parent = headEl;
-            titleEl.OwnerDocRoot = docRoot;
+            GetElementRuntimeState(titleEl).OwnerDocRoot = docRoot;
             headEl.Children.Add(titleEl);
             _knownNodes.Add(titleEl);
             var titleText = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
             titleText.TextContent = title;
             titleText.Parent = titleEl;
-            titleText.OwnerDocRoot = docRoot;
+            GetElementRuntimeState(titleText).OwnerDocRoot = docRoot;
             titleEl.Children.Add(titleText);
             _knownNodes.Add(titleText);
         }
 
         var bodyEl = new DomElement(_document, "body", null, null, string.Empty);
         bodyEl.Parent = htmlEl;
-        bodyEl.OwnerDocRoot = docRoot;
+        GetElementRuntimeState(bodyEl).OwnerDocRoot = docRoot;
         htmlEl.Children.Add(bodyEl);
         _knownNodes.Add(bodyEl);
         return BuildSubDocument(docRoot);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
@@ -758,7 +758,7 @@ public sealed partial class DomBridge
         {
             if (string.Equals(el.TagName, "form", StringComparison.OrdinalIgnoreCase))
             {
-                if (el.Attributes.TryGetValue("name", out var formName) && !string.IsNullOrEmpty(formName))
+                if (TryGetAttribute(el, "name", out var formName) && !string.IsNullOrEmpty(formName))
                     arr.FastAddValue((KeyString)formName, ToJSObject(el), JSPropertyAttributes.EnumerableConfigurableValue);
             }
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
@@ -16,7 +16,7 @@ public sealed partial class DomBridge
     private JSValue JsSubDocumentObjectsGetBody003Core(global::Broiler.HtmlBridge.DomElement docRoot, in Arguments _)
     {
         var htmlEl = GetDocumentElement(docRoot);
-        foreach (var child in htmlEl.Children)
+        foreach (var child in ChildElements(htmlEl))
         {
             if (string.Equals(child.TagName, "body", StringComparison.OrdinalIgnoreCase))
                 return ToJSObject(child);
@@ -29,7 +29,7 @@ public sealed partial class DomBridge
     private JSValue JsSubDocumentObjectsGetHead004Core(global::Broiler.HtmlBridge.DomElement docRoot, in Arguments _)
     {
         var htmlEl = GetDocumentElement(docRoot);
-        foreach (var child in htmlEl.Children)
+        foreach (var child in ChildElements(htmlEl))
         {
             if (string.Equals(child.TagName, "head", StringComparison.OrdinalIgnoreCase))
                 return ToJSObject(child);
@@ -42,15 +42,15 @@ public sealed partial class DomBridge
     private JSValue JsSubDocumentObjectsGetTitle005Core(global::Broiler.HtmlBridge.DomElement docRoot, in Arguments _)
     {
         var htmlEl = GetDocumentElement(docRoot);
-        var head = htmlEl.Children.FirstOrDefault(c => string.Equals(c.TagName, "head", StringComparison.OrdinalIgnoreCase));
+        var head = ChildElements(htmlEl).FirstOrDefault(c => string.Equals(c.TagName, "head", StringComparison.OrdinalIgnoreCase));
         if (head != null)
         {
-            var titleEl = head.Children.FirstOrDefault(c => string.Equals(c.TagName, "title", StringComparison.OrdinalIgnoreCase));
+            var titleEl = ChildElements(head).FirstOrDefault(c => string.Equals(c.TagName, "title", StringComparison.OrdinalIgnoreCase));
             if (titleEl != null)
             {
                 // Two paths: (1) textContent setter clears children and stores text directly
                 // in TextContent, (2) text set via child text nodes (e.g. createTextNode + appendChild).
-                if (titleEl.TextContent != null && titleEl.Children.Count == 0)
+                if (titleEl.TextContent != null && titleEl.ChildNodes.Count == 0)
                     return new JSString(titleEl.TextContent);
                 var sb = new StringBuilder();
                 CollectTextContent(titleEl, sb);
@@ -65,14 +65,14 @@ public sealed partial class DomBridge
     private JSValue JsSubDocumentObjectsSetTitle006Core(global::Broiler.HtmlBridge.DomElement docRoot, in Arguments a)
     {
         var htmlEl = GetDocumentElement(docRoot);
-        var head = htmlEl.Children.FirstOrDefault(c => string.Equals(c.TagName, "head", StringComparison.OrdinalIgnoreCase));
+        var head = ChildElements(htmlEl).FirstOrDefault(c => string.Equals(c.TagName, "head", StringComparison.OrdinalIgnoreCase));
         if (head != null)
         {
-            var titleEl = head.Children.FirstOrDefault(c => string.Equals(c.TagName, "title", StringComparison.OrdinalIgnoreCase));
+            var titleEl = ChildElements(head).FirstOrDefault(c => string.Equals(c.TagName, "title", StringComparison.OrdinalIgnoreCase));
             if (titleEl != null)
             {
                 titleEl.TextContent = a.Length > 0 ? a[0].ToString() : string.Empty;
-                titleEl.Children.Clear();
+                ClearChildren(titleEl);
             }
         }
 
@@ -91,7 +91,7 @@ public sealed partial class DomBridge
     private JSValue JsSubDocumentObjectsGetChildNodes008Core(global::Broiler.HtmlBridge.DomElement docRoot, in Arguments _)
     {
         var arr = new JSArray();
-        foreach (var child in docRoot.Children)
+        foreach (var child in ChildElements(docRoot))
             arr.Add(ToJSObject(child));
         return arr;
     }
@@ -497,7 +497,7 @@ public sealed partial class DomBridge
 
     private JSValue JsSubDocumentObjectsOpen039Core(global::Broiler.JavaScript.Runtime.JSObject? doc, global::Broiler.HtmlBridge.DomElement docRoot, in Arguments _)
     {
-        docRoot.Children.Clear();
+        ClearChildren(docRoot);
         return doc;
     }
 
@@ -511,19 +511,19 @@ public sealed partial class DomBridge
         var doctype = bridge.ParseDocType(fragment);
         var treeBuilder = new HtmlTreeBuilder();
         var (parsedDoc, allEls, _) = treeBuilder.Build(fragment);
-        if (docRoot.Children.Count == 0)
+        if (docRoot.ChildNodes.Count == 0)
         {
             if (doctype != null)
             {
                 SetParent(doctype, docRoot);
-                docRoot.Children.Add(doctype);
+                docRoot.AppendChild(doctype);
                 bridge._knownNodes.Add(doctype);
             }
 
             // parsedDoc is the <html> element from HtmlTreeBuilder.
             // Add it directly to docRoot (not its children).
             SetParent(parsedDoc, docRoot);
-            docRoot.Children.Add(parsedDoc);
+            docRoot.AppendChild(parsedDoc);
             if (!bridge._knownNodes.Contains(parsedDoc))
                 bridge._knownNodes.Add(parsedDoc);
             foreach (var el in allEls)
@@ -540,10 +540,10 @@ public sealed partial class DomBridge
                 var parsedBody = FindInTree(parsedDoc, el => string.Equals(el.TagName, "body", StringComparison.OrdinalIgnoreCase));
                 if (parsedBody != null)
                 {
-                    foreach (var child in parsedBody.Children)
+                    foreach (var child in ChildElements(parsedBody))
                     {
                         SetParent(child, bodyEl);
-                        bodyEl.Children.Add(child);
+                        bodyEl.AppendChild(child);
                     }
                 }
             }
@@ -582,15 +582,15 @@ public sealed partial class DomBridge
         var childObj = a[0] as JSObject;
         if (childObj == null)
             return JSNull.Value;
-        foreach (var child in docRoot.Children.ToList())
+        foreach (var child in ChildElements(docRoot).ToList())
         {
             if (bridge._jsObjectCache.TryGetValue(child, out var cached) && cached == childObj)
             {
-                var idx = docRoot.Children.IndexOf(child);
+                var idx = ChildIndexOf(docRoot, child);
                 if (idx >= 0)
                 {
                     bridge.NotifyNodeIteratorPreRemoval(child);
-                    docRoot.Children.RemoveAt(idx);
+                    RemoveNthChild(docRoot, idx);
                     SetParent(child, null);
                     bridge.NotifyChildRemoved(docRoot, child, idx);
                 }
@@ -616,10 +616,10 @@ public sealed partial class DomBridge
             {
                 var child = kvp.Key;
                 if (ParentEl(child) != null)
-                    ParentEl(child).Children.Remove(child);
+                    child.Remove();
                 SetParent(child, docRoot);
                 AdoptSubtreeIntoDocument(child, docRoot);
-                docRoot.Children.Add(child);
+                docRoot.AppendChild(child);
                 return childObj;
             }
         }
@@ -633,7 +633,7 @@ public sealed partial class DomBridge
         if (a.Length == 0)
             return JSUndefined.Value;
         var nodes = bridge.BuildChildNodeArgumentNodes(a);
-        var insertIndex = docRoot.Children.Count;
+        var insertIndex = docRoot.ChildNodes.Count;
         foreach (var node in nodes)
             bridge.InsertNodeAt(docRoot, node, insertIndex++);
         return JSUndefined.Value;
@@ -689,7 +689,7 @@ public sealed partial class DomBridge
                     var dtEl = kvp.Key;
                     SetParent(dtEl, subDocRoot);
                     GetElementRuntimeState(dtEl).OwnerDocRoot = subDocRoot;
-                    subDocRoot.Children.Add(dtEl);
+                    subDocRoot.AppendChild(dtEl);
                     break;
                 }
             }
@@ -702,7 +702,7 @@ public sealed partial class DomBridge
                 docEl.NamespaceURI = ns;
             SetParent(docEl, subDocRoot);
             GetElementRuntimeState(docEl).OwnerDocRoot = subDocRoot;
-            subDocRoot.Children.Add(docEl);
+            subDocRoot.AppendChild(docEl);
             _knownNodes.Add(docEl);
         }
 
@@ -723,38 +723,38 @@ public sealed partial class DomBridge
         GetElementRuntimeState(dt).DocumentType.InternalSubset.Set(null);
         SetParent(dt, subDocRoot);
         GetElementRuntimeState(dt).OwnerDocRoot = subDocRoot;
-        subDocRoot.Children.Add(dt);
+        subDocRoot.AppendChild(dt);
         _knownNodes.Add(dt);
         var subHtml = new DomElement(_document, "html", null, null, string.Empty);
         subHtml.NamespaceURI = "http://www.w3.org/1999/xhtml";
         SetParent(subHtml, subDocRoot);
         GetElementRuntimeState(subHtml).OwnerDocRoot = subDocRoot;
-        subDocRoot.Children.Add(subHtml);
+        subDocRoot.AppendChild(subHtml);
         _knownNodes.Add(subHtml);
         var subHead = new DomElement(_document, "head", null, null, string.Empty);
         SetParent(subHead, subHtml);
         GetElementRuntimeState(subHead).OwnerDocRoot = subDocRoot;
-        subHtml.Children.Add(subHead);
+        subHtml.AppendChild(subHead);
         _knownNodes.Add(subHead);
         if (subTitle != null)
         {
             var subTitleEl = new DomElement(_document, "title", null, null, string.Empty);
             SetParent(subTitleEl, subHead);
             GetElementRuntimeState(subTitleEl).OwnerDocRoot = subDocRoot;
-            subHead.Children.Add(subTitleEl);
+            subHead.AppendChild(subTitleEl);
             _knownNodes.Add(subTitleEl);
             var subTitleText = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
             subTitleText.TextContent = subTitle;
             SetParent(subTitleText, subTitleEl);
             GetElementRuntimeState(subTitleText).OwnerDocRoot = subDocRoot;
-            subTitleEl.Children.Add(subTitleText);
+            subTitleEl.AppendChild(subTitleText);
             _knownNodes.Add(subTitleText);
         }
 
         var subBody = new DomElement(_document, "body", null, null, string.Empty);
         SetParent(subBody, subHtml);
         GetElementRuntimeState(subBody).OwnerDocRoot = subDocRoot;
-        subHtml.Children.Add(subBody);
+        subHtml.AppendChild(subBody);
         _knownNodes.Add(subBody);
         return BuildSubDocument(subDocRoot);
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
@@ -570,7 +570,7 @@ public sealed partial class DomBridge
     private JSValue JsSubDocumentObjectsGetLinks042Core(global::Broiler.HtmlBridge.DomElement docRoot, in Arguments _)
     {
         var results = new List<JSValue>();
-        CollectMatching(docRoot, el => (string.Equals(el.TagName, "a", StringComparison.OrdinalIgnoreCase) || string.Equals(el.TagName, "area", StringComparison.OrdinalIgnoreCase)) && el.Attributes.ContainsKey("href"), results);
+        CollectMatching(docRoot, el => (string.Equals(el.TagName, "a", StringComparison.OrdinalIgnoreCase) || string.Equals(el.TagName, "area", StringComparison.OrdinalIgnoreCase)) && HasAttr(el, "href"), results);
         return new JSArray(results);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
@@ -515,14 +515,14 @@ public sealed partial class DomBridge
         {
             if (doctype != null)
             {
-                doctype.Parent = docRoot;
+                SetParent(doctype, docRoot);
                 docRoot.Children.Add(doctype);
                 bridge._knownNodes.Add(doctype);
             }
 
             // parsedDoc is the <html> element from HtmlTreeBuilder.
             // Add it directly to docRoot (not its children).
-            parsedDoc.Parent = docRoot;
+            SetParent(parsedDoc, docRoot);
             docRoot.Children.Add(parsedDoc);
             if (!bridge._knownNodes.Contains(parsedDoc))
                 bridge._knownNodes.Add(parsedDoc);
@@ -542,7 +542,7 @@ public sealed partial class DomBridge
                 {
                     foreach (var child in parsedBody.Children)
                     {
-                        child.Parent = bodyEl;
+                        SetParent(child, bodyEl);
                         bodyEl.Children.Add(child);
                     }
                 }
@@ -591,7 +591,7 @@ public sealed partial class DomBridge
                 {
                     bridge.NotifyNodeIteratorPreRemoval(child);
                     docRoot.Children.RemoveAt(idx);
-                    child.Parent = null;
+                    SetParent(child, null);
                     bridge.NotifyChildRemoved(docRoot, child, idx);
                 }
 
@@ -615,9 +615,9 @@ public sealed partial class DomBridge
             if (kvp.Value == childObj)
             {
                 var child = kvp.Key;
-                if (child.Parent != null)
-                    child.Parent.Children.Remove(child);
-                child.Parent = docRoot;
+                if (ParentEl(child) != null)
+                    ParentEl(child).Children.Remove(child);
+                SetParent(child, docRoot);
                 AdoptSubtreeIntoDocument(child, docRoot);
                 docRoot.Children.Add(child);
                 return childObj;
@@ -687,7 +687,7 @@ public sealed partial class DomBridge
                 if (kvp.Value == dtObj)
                 {
                     var dtEl = kvp.Key;
-                    dtEl.Parent = subDocRoot;
+                    SetParent(dtEl, subDocRoot);
                     GetElementRuntimeState(dtEl).OwnerDocRoot = subDocRoot;
                     subDocRoot.Children.Add(dtEl);
                     break;
@@ -700,7 +700,7 @@ public sealed partial class DomBridge
             var docEl = new DomElement(_document, qName, null, null, string.Empty);
             if (!string.IsNullOrEmpty(ns))
                 docEl.NamespaceURI = ns;
-            docEl.Parent = subDocRoot;
+            SetParent(docEl, subDocRoot);
             GetElementRuntimeState(docEl).OwnerDocRoot = subDocRoot;
             subDocRoot.Children.Add(docEl);
             _knownNodes.Add(docEl);
@@ -721,38 +721,38 @@ public sealed partial class DomBridge
         GetElementRuntimeState(dt).DocumentType.PublicId.Set(string.Empty);
         GetElementRuntimeState(dt).DocumentType.SystemId.Set(string.Empty);
         GetElementRuntimeState(dt).DocumentType.InternalSubset.Set(null);
-        dt.Parent = subDocRoot;
+        SetParent(dt, subDocRoot);
         GetElementRuntimeState(dt).OwnerDocRoot = subDocRoot;
         subDocRoot.Children.Add(dt);
         _knownNodes.Add(dt);
         var subHtml = new DomElement(_document, "html", null, null, string.Empty);
         subHtml.NamespaceURI = "http://www.w3.org/1999/xhtml";
-        subHtml.Parent = subDocRoot;
+        SetParent(subHtml, subDocRoot);
         GetElementRuntimeState(subHtml).OwnerDocRoot = subDocRoot;
         subDocRoot.Children.Add(subHtml);
         _knownNodes.Add(subHtml);
         var subHead = new DomElement(_document, "head", null, null, string.Empty);
-        subHead.Parent = subHtml;
+        SetParent(subHead, subHtml);
         GetElementRuntimeState(subHead).OwnerDocRoot = subDocRoot;
         subHtml.Children.Add(subHead);
         _knownNodes.Add(subHead);
         if (subTitle != null)
         {
             var subTitleEl = new DomElement(_document, "title", null, null, string.Empty);
-            subTitleEl.Parent = subHead;
+            SetParent(subTitleEl, subHead);
             GetElementRuntimeState(subTitleEl).OwnerDocRoot = subDocRoot;
             subHead.Children.Add(subTitleEl);
             _knownNodes.Add(subTitleEl);
             var subTitleText = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
             subTitleText.TextContent = subTitle;
-            subTitleText.Parent = subTitleEl;
+            SetParent(subTitleText, subTitleEl);
             GetElementRuntimeState(subTitleText).OwnerDocRoot = subDocRoot;
             subTitleEl.Children.Add(subTitleText);
             _knownNodes.Add(subTitleText);
         }
 
         var subBody = new DomElement(_document, "body", null, null, string.Empty);
-        subBody.Parent = subHtml;
+        SetParent(subBody, subHtml);
         GetElementRuntimeState(subBody).OwnerDocRoot = subDocRoot;
         subHtml.Children.Add(subBody);
         _knownNodes.Add(subBody);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
@@ -122,7 +122,7 @@ public sealed partial class DomBridge
         ValidateElementName(tagName, _jsContext!);
         tagName = AsciiToLower(tagName);
         var el = new DomElement(_document, tagName, null, null, string.Empty);
-        el.OwnerDocRoot = docRoot;
+        GetElementRuntimeState(el).OwnerDocRoot = docRoot;
         _knownNodes.Add(el);
         return ToJSObject(el);
     }
@@ -133,7 +133,7 @@ public sealed partial class DomBridge
         var text = a.Length > 0 ? a[0].ToString() : string.Empty;
         var el = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
         el.TextContent = text;
-        el.OwnerDocRoot = docRoot;
+        GetElementRuntimeState(el).OwnerDocRoot = docRoot;
         _knownNodes.Add(el);
         return ToJSObject(el);
     }
@@ -144,7 +144,7 @@ public sealed partial class DomBridge
         var data = a.Length > 0 ? a[0].ToString() : string.Empty;
         var el = new DomElement(_document, "#comment", null, null, string.Empty);
         el.TextContent = data;
-        el.OwnerDocRoot = docRoot;
+        GetElementRuntimeState(el).OwnerDocRoot = docRoot;
         _knownNodes.Add(el);
         return ToJSObject(el);
     }
@@ -158,7 +158,7 @@ public sealed partial class DomBridge
         var el = new DomElement(_document, localName, null, null, string.Empty);
         if (!string.IsNullOrEmpty(ns))
             el.NamespaceURI = ns;
-        el.OwnerDocRoot = docRoot;
+        GetElementRuntimeState(el).OwnerDocRoot = docRoot;
         _knownNodes.Add(el);
         return ToJSObject(el);
     }
@@ -688,7 +688,7 @@ public sealed partial class DomBridge
                 {
                     var dtEl = kvp.Key;
                     dtEl.Parent = subDocRoot;
-                    dtEl.OwnerDocRoot = subDocRoot;
+                    GetElementRuntimeState(dtEl).OwnerDocRoot = subDocRoot;
                     subDocRoot.Children.Add(dtEl);
                     break;
                 }
@@ -701,7 +701,7 @@ public sealed partial class DomBridge
             if (!string.IsNullOrEmpty(ns))
                 docEl.NamespaceURI = ns;
             docEl.Parent = subDocRoot;
-            docEl.OwnerDocRoot = subDocRoot;
+            GetElementRuntimeState(docEl).OwnerDocRoot = subDocRoot;
             subDocRoot.Children.Add(docEl);
             _knownNodes.Add(docEl);
         }
@@ -722,38 +722,38 @@ public sealed partial class DomBridge
         GetElementRuntimeState(dt).DocumentType.SystemId.Set(string.Empty);
         GetElementRuntimeState(dt).DocumentType.InternalSubset.Set(null);
         dt.Parent = subDocRoot;
-        dt.OwnerDocRoot = subDocRoot;
+        GetElementRuntimeState(dt).OwnerDocRoot = subDocRoot;
         subDocRoot.Children.Add(dt);
         _knownNodes.Add(dt);
         var subHtml = new DomElement(_document, "html", null, null, string.Empty);
         subHtml.NamespaceURI = "http://www.w3.org/1999/xhtml";
         subHtml.Parent = subDocRoot;
-        subHtml.OwnerDocRoot = subDocRoot;
+        GetElementRuntimeState(subHtml).OwnerDocRoot = subDocRoot;
         subDocRoot.Children.Add(subHtml);
         _knownNodes.Add(subHtml);
         var subHead = new DomElement(_document, "head", null, null, string.Empty);
         subHead.Parent = subHtml;
-        subHead.OwnerDocRoot = subDocRoot;
+        GetElementRuntimeState(subHead).OwnerDocRoot = subDocRoot;
         subHtml.Children.Add(subHead);
         _knownNodes.Add(subHead);
         if (subTitle != null)
         {
             var subTitleEl = new DomElement(_document, "title", null, null, string.Empty);
             subTitleEl.Parent = subHead;
-            subTitleEl.OwnerDocRoot = subDocRoot;
+            GetElementRuntimeState(subTitleEl).OwnerDocRoot = subDocRoot;
             subHead.Children.Add(subTitleEl);
             _knownNodes.Add(subTitleEl);
             var subTitleText = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
             subTitleText.TextContent = subTitle;
             subTitleText.Parent = subTitleEl;
-            subTitleText.OwnerDocRoot = subDocRoot;
+            GetElementRuntimeState(subTitleText).OwnerDocRoot = subDocRoot;
             subTitleEl.Children.Add(subTitleText);
             _knownNodes.Add(subTitleText);
         }
 
         var subBody = new DomElement(_document, "body", null, null, string.Empty);
         subBody.Parent = subHtml;
-        subBody.OwnerDocRoot = subDocRoot;
+        GetElementRuntimeState(subBody).OwnerDocRoot = subDocRoot;
         subHtml.Children.Add(subBody);
         _knownNodes.Add(subBody);
         return BuildSubDocument(subDocRoot);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Traversal.cs
@@ -51,9 +51,9 @@ public sealed partial class DomBridge
         // Try children first
         while (true)
         {
-            if (node.Children.Count > 0)
+            if (node.ChildNodes.Count > 0)
             {
-                node = node.Children[0];
+                node = ChildAt(node, 0);
                 var result = ApplyFilter(node, whatToShow, filterFn);
                 if (result == 1)
                 {
@@ -119,14 +119,14 @@ public sealed partial class DomBridge
             // Try previous sibling's deepest descendant
             if (ParentEl(node) != null && !ReferenceEquals(node, root))
             {
-                var siblings = ParentEl(node).Children;
+                var siblings = ChildElements(ParentEl(node)).ToList();
                 var idx = siblings.IndexOf(node);
                 if (idx > 0)
                 {
                     node = siblings[idx - 1];
                     // Go to deepest last child
-                    while (node.Children.Count > 0)
-                        node = node.Children[^1];
+                    while (node.ChildNodes.Count > 0)
+                        node = ChildAt(node, ^1);
                     var result = ApplyFilter(node, whatToShow, filterFn);
                     if (result == 1)
                     {
@@ -341,7 +341,7 @@ public sealed partial class DomBridge
         }
 
         state.StartContainer = ParentEl(el);
-        state.StartOffset = ParentEl(el).Children.IndexOf(el);
+        state.StartOffset = ChildIndexOf(ParentEl(el), el);
         // Per spec: if start is after end, collapse to start
         if (IsPositionAfter(state.Root, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset))
         {
@@ -369,7 +369,7 @@ public sealed partial class DomBridge
         }
 
         state.StartContainer = ParentEl(el);
-        state.StartOffset = ParentEl(el).Children.IndexOf(el) + 1;
+        state.StartOffset = ChildIndexOf(ParentEl(el), el) + 1;
         // Per spec: if start is after end, collapse to start
         if (IsPositionAfter(state.Root, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset))
         {
@@ -398,7 +398,7 @@ public sealed partial class DomBridge
         }
 
         state.EndContainer = ParentEl(el);
-        state.EndOffset = ParentEl(el).Children.IndexOf(el);
+        state.EndOffset = ChildIndexOf(ParentEl(el), el);
         // Per spec: if end is before start, collapse to end
         if (IsPositionAfter(state.Root, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset))
         {
@@ -426,7 +426,7 @@ public sealed partial class DomBridge
         }
 
         state.EndContainer = ParentEl(el);
-        state.EndOffset = ParentEl(el).Children.IndexOf(el) + 1;
+        state.EndOffset = ChildIndexOf(ParentEl(el), el) + 1;
         // Per spec: if end is before start, collapse to end
         if (IsPositionAfter(state.Root, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset))
         {
@@ -469,7 +469,7 @@ public sealed partial class DomBridge
         if (el is null || ParentEl(el) == null)
             return JSUndefined.Value;
         state.StartContainer = ParentEl(el);
-        state.StartOffset = ParentEl(el).Children.IndexOf(el);
+        state.StartOffset = ChildIndexOf(ParentEl(el), el);
         state.EndContainer = ParentEl(el);
         state.EndOffset = state.StartOffset + 1;
         state.UpdateCollapsed();
@@ -494,7 +494,7 @@ public sealed partial class DomBridge
         if (IsText(el) || string.Equals(el.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
             state.EndOffset = (el.TextContent ?? string.Empty).Length;
         else
-            state.EndOffset = el.Children.Count;
+            state.EndOffset = el.ChildNodes.Count;
         state.UpdateCollapsed();
         return JSUndefined.Value;
     }
@@ -509,7 +509,7 @@ public sealed partial class DomBridge
         {
             var clone = bridge.CloneDomElement(node, true);
             SetParent(clone, fragment);
-            fragment.Children.Add(clone);
+            fragment.AppendChild(clone);
             bridge._knownNodes.Add(clone);
         }
 
@@ -532,7 +532,7 @@ public sealed partial class DomBridge
             var textNode = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
             textNode.TextContent = extractedText;
             SetParent(textNode, fragment);
-            fragment.Children.Add(textNode);
+            fragment.AppendChild(textNode);
             bridge._knownNodes.Add(textNode);
             state.EndContainer = state.StartContainer;
             state.EndOffset = state.StartOffset;
@@ -543,13 +543,13 @@ public sealed partial class DomBridge
         // Handle same-container element case (simple child extraction)
         if (ReferenceEquals(state.StartContainer, state.EndContainer))
         {
-            var count = Math.Min(state.EndOffset, state.StartContainer.Children.Count) - state.StartOffset;
+            var count = Math.Min(state.EndOffset, state.StartContainer.ChildNodes.Count) - state.StartOffset;
             for (var i = 0; i < count; i++)
             {
-                var child = state.StartContainer.Children[state.StartOffset];
-                state.StartContainer.Children.RemoveAt(state.StartOffset);
+                var child = ChildAt(state.StartContainer, state.StartOffset);
+                RemoveNthChild(state.StartContainer, state.StartOffset);
                 SetParent(child, fragment);
-                fragment.Children.Add(child);
+                fragment.AppendChild(child);
             }
 
             state.EndContainer = state.StartContainer;
@@ -589,8 +589,8 @@ public sealed partial class DomBridge
             endAncestorChild = node;
         }
 
-        var startIdx2 = startAncestorChild != null ? ancestor.Children.IndexOf(startAncestorChild) : -1;
-        var endIdx2 = endAncestorChild != null ? ancestor.Children.IndexOf(endAncestorChild) : -1;
+        var startIdx2 = startAncestorChild != null ? ChildIndexOf(ancestor, startAncestorChild) : -1;
+        var endIdx2 = endAncestorChild != null ? ChildIndexOf(ancestor, endAncestorChild) : -1;
         // Clone start-side path (first partially contained child)
         if (startAncestorChild != null && startIdx2 >= 0)
         {
@@ -607,23 +607,23 @@ public sealed partial class DomBridge
                     extractedNode.TextContent = extractedPart;
                     bridge._knownNodes.Add(extractedNode);
                     SetParent(extractedNode, fragment);
-                    fragment.Children.Add(extractedNode);
+                    fragment.AppendChild(extractedNode);
                 }
                 else
                 {
                     // Element: clone and extract children from startOffset
                     var clone = CloneDomElement(state.StartContainer, false);
                     bridge._knownNodes.Add(clone);
-                    for (var ci = state.StartOffset; ci < state.StartContainer.Children.Count;)
+                    for (var ci = state.StartOffset; ci < state.StartContainer.ChildNodes.Count;)
                     {
-                        var child = state.StartContainer.Children[ci];
-                        state.StartContainer.Children.RemoveAt(ci);
+                        var child = ChildAt(state.StartContainer, ci);
+                        RemoveNthChild(state.StartContainer, ci);
                         SetParent(child, clone);
-                        clone.Children.Add(child);
+                        clone.AppendChild(child);
                     }
 
                     SetParent(clone, fragment);
-                    fragment.Children.Add(clone);
+                    fragment.AppendChild(clone);
                 }
             }
             else
@@ -633,7 +633,7 @@ public sealed partial class DomBridge
                 if (clone != null)
                 {
                     SetParent(clone, fragment);
-                    fragment.Children.Add(clone);
+                    fragment.AppendChild(clone);
                 }
             }
         }
@@ -643,11 +643,11 @@ public sealed partial class DomBridge
         {
             for (var ci = startIdx2 + 1; ci < endIdx2;)
             {
-                var child = ancestor.Children[ci];
-                ancestor.Children.RemoveAt(ci);
+                var child = ChildAt(ancestor, ci);
+                RemoveNthChild(ancestor, ci);
                 endIdx2--;
                 SetParent(child, fragment);
-                fragment.Children.Add(child);
+                fragment.AppendChild(child);
             }
         }
 
@@ -665,22 +665,22 @@ public sealed partial class DomBridge
                     extractedNode.TextContent = extractedPart;
                     bridge._knownNodes.Add(extractedNode);
                     SetParent(extractedNode, fragment);
-                    fragment.Children.Add(extractedNode);
+                    fragment.AppendChild(extractedNode);
                 }
                 else
                 {
                     var clone = CloneDomElement(state.EndContainer, false);
                     bridge._knownNodes.Add(clone);
-                    for (var ci = 0; ci < state.EndOffset && state.EndContainer.Children.Count > 0; ci++)
+                    for (var ci = 0; ci < state.EndOffset && state.EndContainer.ChildNodes.Count > 0; ci++)
                     {
-                        var child = state.EndContainer.Children[0];
-                        state.EndContainer.Children.RemoveAt(0);
+                        var child = ChildAt(state.EndContainer, 0);
+                        RemoveNthChild(state.EndContainer, 0);
                         SetParent(child, clone);
-                        clone.Children.Add(child);
+                        clone.AppendChild(child);
                     }
 
                     SetParent(clone, fragment);
-                    fragment.Children.Add(clone);
+                    fragment.AppendChild(clone);
                 }
             }
             else
@@ -689,7 +689,7 @@ public sealed partial class DomBridge
                 if (clone != null)
                 {
                     SetParent(clone, fragment);
-                    fragment.Children.Add(clone);
+                    fragment.AppendChild(clone);
                 }
             }
         }
@@ -707,7 +707,7 @@ public sealed partial class DomBridge
         var nodes = GetNodesInRange(state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset);
         foreach (var node in nodes)
         {
-            ParentEl(node)?.Children.Remove(node);
+            node.Remove();
             SetParent(node, null);
         }
 
@@ -729,7 +729,7 @@ public sealed partial class DomBridge
         if (el == null)
             return JSUndefined.Value;
         // Remove from old parent if needed
-        ParentEl(el)?.Children.Remove(el);
+        el.Remove();
         // If start container is a text node, split it
         if (IsText(state.StartContainer))
         {
@@ -751,11 +751,11 @@ public sealed partial class DomBridge
             remainder.TextContent = afterText;
             bridge._knownNodes.Add(remainder);
             // Insert: [before] [insertedNode] [after]
-            var textIdx = parent.Children.IndexOf(state.StartContainer);
+            var textIdx = ChildIndexOf(parent, state.StartContainer);
             SetParent(el, parent);
-            parent.Children.Insert(textIdx + 1, el);
+            InsertChildAt(parent, textIdx + 1, el);
             SetParent(remainder, parent);
-            parent.Children.Insert(textIdx + 2, remainder);
+            InsertChildAt(parent, textIdx + 2, remainder);
             // Per spec: update range boundary points after text split
             state.StartContainer = parent;
             state.StartOffset = textIdx + 1; // index of inserted node
@@ -771,8 +771,8 @@ public sealed partial class DomBridge
         else
         {
             SetParent(el, state.StartContainer);
-            var insertIdx = Math.Min(state.StartOffset, state.StartContainer.Children.Count);
-            state.StartContainer.Children.Insert(insertIdx, el);
+            var insertIdx = Math.Min(state.StartOffset, state.StartContainer.ChildNodes.Count);
+            InsertChildAt(state.StartContainer, insertIdx, el);
         }
 
         return JSUndefined.Value;
@@ -836,7 +836,7 @@ public sealed partial class DomBridge
         {
             // Count existing element children (minus any that will be moved into newParent)
             var nodes = GetNodesInRange(state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset);
-            var elemCount = state.StartContainer.Children.Count(c => !IsText(c) && !string.Equals(c.TagName, "#comment", StringComparison.OrdinalIgnoreCase));
+            var elemCount = ChildElements(state.StartContainer).Count(c => !IsText(c) && !string.Equals(c.TagName, "#comment", StringComparison.OrdinalIgnoreCase));
             var removedElems = nodes.Count(n => !IsText(n) && !string.Equals(n.TagName, "#comment", StringComparison.OrdinalIgnoreCase));
             // After removal + adding newParent, there would be (elemCount - removedElems + 1) element children
             if (elemCount - removedElems + 1 > 1 || (!string.Equals(newParent.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase) && !string.Equals(newParent.TagName, "#comment", StringComparison.OrdinalIgnoreCase)))
@@ -849,15 +849,15 @@ public sealed partial class DomBridge
         var rangeNodes = GetNodesInRange(state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset);
         foreach (var node in rangeNodes)
         {
-            ParentEl(node)?.Children.Remove(node);
+            node.Remove();
             SetParent(node, newParent);
-            newParent.Children.Add(node);
+            newParent.AppendChild(node);
         }
 
-        ParentEl(newParent)?.Children.Remove(newParent);
+        newParent.Remove();
         SetParent(newParent, state.StartContainer);
-        var idx = Math.Min(state.StartOffset, state.StartContainer.Children.Count);
-        state.StartContainer.Children.Insert(idx, newParent);
+        var idx = Math.Min(state.StartOffset, state.StartContainer.ChildNodes.Count);
+        InsertChildAt(state.StartContainer, idx, newParent);
         return JSUndefined.Value;
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Traversal.cs
@@ -491,7 +491,7 @@ public sealed partial class DomBridge
         state.StartOffset = 0;
         state.EndContainer = el;
         // For text/comment nodes, endOffset is the character length
-        if (el.IsTextNode || string.Equals(el.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsText(el) || string.Equals(el.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
             state.EndOffset = (el.TextContent ?? string.Empty).Length;
         else
             state.EndOffset = el.Children.Count;
@@ -522,7 +522,7 @@ public sealed partial class DomBridge
         var fragment = new DomElement(_document, "#document-fragment", null, null, string.Empty);
         bridge._knownNodes.Add(fragment);
         // Handle same-container text node case
-        if (ReferenceEquals(state.StartContainer, state.EndContainer) && (state.StartContainer.IsTextNode || string.Equals(state.StartContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)))
+        if (ReferenceEquals(state.StartContainer, state.EndContainer) && (IsText(state.StartContainer) || string.Equals(state.StartContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)))
         {
             var text = state.StartContainer.TextContent ?? string.Empty;
             var s = Math.Max(0, Math.Min(state.StartOffset, text.Length));
@@ -597,7 +597,7 @@ public sealed partial class DomBridge
             if (ReferenceEquals(startAncestorChild, state.StartContainer))
             {
                 // Start container IS the direct child of ancestor
-                if (state.StartContainer.IsTextNode)
+                if (IsText(state.StartContainer))
                 {
                     // Text node: split at startOffset
                     var text = state.StartContainer.TextContent ?? string.Empty;
@@ -656,7 +656,7 @@ public sealed partial class DomBridge
         {
             if (ReferenceEquals(endAncestorChild, state.EndContainer))
             {
-                if (state.EndContainer.IsTextNode)
+                if (IsText(state.EndContainer))
                 {
                     var text = state.EndContainer.TextContent ?? string.Empty;
                     var extractedPart = text.Substring(0, state.EndOffset);
@@ -731,7 +731,7 @@ public sealed partial class DomBridge
         // Remove from old parent if needed
         ParentEl(el)?.Children.Remove(el);
         // If start container is a text node, split it
-        if (state.StartContainer.IsTextNode)
+        if (IsText(state.StartContainer))
         {
             var parent = ParentEl(state.StartContainer);
             if (parent == null)
@@ -795,8 +795,8 @@ public sealed partial class DomBridge
         if (!ReferenceEquals(state.StartContainer, state.EndContainer))
         {
             // Check if start container is partially selected (text/comment node with offset in middle)
-            bool startPartial = (state.StartContainer.IsTextNode || string.Equals(state.StartContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)) && state.StartOffset > 0;
-            bool endPartial = (state.EndContainer.IsTextNode || string.Equals(state.EndContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)) && state.EndOffset < (state.EndContainer.TextContent ?? "").Length;
+            bool startPartial = (IsText(state.StartContainer) || string.Equals(state.StartContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)) && state.StartOffset > 0;
+            bool endPartial = (IsText(state.EndContainer) || string.Equals(state.EndContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)) && state.EndOffset < (state.EndContainer.TextContent ?? "").Length;
             // Per spec: if any non-Text node is partially contained, throw HIERARCHY_REQUEST_ERR
             var ancestor = FindCommonAncestor(state.StartContainer, state.EndContainer);
             if (ancestor != null)
@@ -805,7 +805,7 @@ public sealed partial class DomBridge
                 var node = state.StartContainer;
                 while (node != null && !ReferenceEquals(node, ancestor))
                 {
-                    if (!node.IsTextNode && !string.Equals(node.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+                    if (!IsText(node) && !string.Equals(node.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
                     {
                         // Non-text node between start/end — check if partially selected
                         if (!ReferenceEquals(node, state.StartContainer) || !ReferenceEquals(node, state.EndContainer))
@@ -822,7 +822,7 @@ public sealed partial class DomBridge
 
             // If both are comment/text nodes but different, the range spans partially across non-text nodes
             // In Acid3 test 11, both are comment nodes partially selected — per spec this raises an exception
-            if ((state.StartContainer.IsTextNode || string.Equals(state.StartContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)) && (state.EndContainer.IsTextNode || string.Equals(state.EndContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)) && startPartial && endPartial)
+            if ((IsText(state.StartContainer) || string.Equals(state.StartContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)) && (IsText(state.EndContainer) || string.Equals(state.EndContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)) && startPartial && endPartial)
             {
                 // BAD_BOUNDARYPOINTS_ERR / INVALID_STATE_ERR
                 ThrowDOMException(bridge._jsContext!, "Invalid state", "InvalidStateError");
@@ -836,8 +836,8 @@ public sealed partial class DomBridge
         {
             // Count existing element children (minus any that will be moved into newParent)
             var nodes = GetNodesInRange(state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset);
-            var elemCount = state.StartContainer.Children.Count(c => !c.IsTextNode && !string.Equals(c.TagName, "#comment", StringComparison.OrdinalIgnoreCase));
-            var removedElems = nodes.Count(n => !n.IsTextNode && !string.Equals(n.TagName, "#comment", StringComparison.OrdinalIgnoreCase));
+            var elemCount = state.StartContainer.Children.Count(c => !IsText(c) && !string.Equals(c.TagName, "#comment", StringComparison.OrdinalIgnoreCase));
+            var removedElems = nodes.Count(n => !IsText(n) && !string.Equals(n.TagName, "#comment", StringComparison.OrdinalIgnoreCase));
             // After removal + adding newParent, there would be (elemCount - removedElems + 1) element children
             if (elemCount - removedElems + 1 > 1 || (!string.Equals(newParent.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase) && !string.Equals(newParent.TagName, "#comment", StringComparison.OrdinalIgnoreCase)))
             {
@@ -906,7 +906,7 @@ public sealed partial class DomBridge
     {
         var sb = new StringBuilder();
         // Handle case where range is within a single text/comment node
-        if (ReferenceEquals(state.StartContainer, state.EndContainer) && (state.StartContainer.IsTextNode || string.Equals(state.StartContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)))
+        if (ReferenceEquals(state.StartContainer, state.EndContainer) && (IsText(state.StartContainer) || string.Equals(state.StartContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)))
         {
             var text = state.StartContainer.TextContent ?? string.Empty;
             var s = Math.Max(0, Math.Min(state.StartOffset, text.Length));

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Traversal.cs
@@ -30,7 +30,7 @@ public sealed partial class DomBridge
         var node = currentNode;
         while (node != null && !ReferenceEquals(node, root))
         {
-            node = node.Parent;
+            node = ParentEl(node);
             if (node == null)
                 break;
             var result = ApplyFilter(node, whatToShow, filterFn);
@@ -117,9 +117,9 @@ public sealed partial class DomBridge
         while (true)
         {
             // Try previous sibling's deepest descendant
-            if (node.Parent != null && !ReferenceEquals(node, root))
+            if (ParentEl(node) != null && !ReferenceEquals(node, root))
             {
-                var siblings = node.Parent.Children;
+                var siblings = ParentEl(node).Children;
                 var idx = siblings.IndexOf(node);
                 if (idx > 0)
                 {
@@ -138,7 +138,7 @@ public sealed partial class DomBridge
                 }
 
                 // Move to parent
-                node = node.Parent;
+                node = ParentEl(node);
                 var r = ApplyFilter(node, whatToShow, filterFn);
                 if (r == 1)
                 {
@@ -334,14 +334,14 @@ public sealed partial class DomBridge
         if (nodeObj == null)
             return JSUndefined.Value;
         var el = bridge.FindDomElementByJSObject(nodeObj);
-        if (el?.Parent == null)
+        if (el is null || ParentEl(el) == null)
         {
             ThrowDOMException(bridge._jsContext!, "Invalid node type", "InvalidNodeTypeError");
             return JSUndefined.Value;
         }
 
-        state.StartContainer = el.Parent;
-        state.StartOffset = el.Parent.Children.IndexOf(el);
+        state.StartContainer = ParentEl(el);
+        state.StartOffset = ParentEl(el).Children.IndexOf(el);
         // Per spec: if start is after end, collapse to start
         if (IsPositionAfter(state.Root, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset))
         {
@@ -362,14 +362,14 @@ public sealed partial class DomBridge
         if (nodeObj == null)
             return JSUndefined.Value;
         var el = bridge.FindDomElementByJSObject(nodeObj);
-        if (el?.Parent == null)
+        if (el is null || ParentEl(el) == null)
         {
             ThrowDOMException(bridge._jsContext!, "Invalid node type", "InvalidNodeTypeError");
             return JSUndefined.Value;
         }
 
-        state.StartContainer = el.Parent;
-        state.StartOffset = el.Parent.Children.IndexOf(el) + 1;
+        state.StartContainer = ParentEl(el);
+        state.StartOffset = ParentEl(el).Children.IndexOf(el) + 1;
         // Per spec: if start is after end, collapse to start
         if (IsPositionAfter(state.Root, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset))
         {
@@ -390,15 +390,15 @@ public sealed partial class DomBridge
         if (nodeObj == null)
             return JSUndefined.Value;
         var el = bridge.FindDomElementByJSObject(nodeObj);
-        if (el?.Parent == null)
+        if (el is null || ParentEl(el) == null)
         {
             // INVALID_NODE_TYPE_ERR — node has no parent
             ThrowDOMException(bridge._jsContext!, "Invalid node type", "InvalidNodeTypeError");
             return JSUndefined.Value;
         }
 
-        state.EndContainer = el.Parent;
-        state.EndOffset = el.Parent.Children.IndexOf(el);
+        state.EndContainer = ParentEl(el);
+        state.EndOffset = ParentEl(el).Children.IndexOf(el);
         // Per spec: if end is before start, collapse to end
         if (IsPositionAfter(state.Root, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset))
         {
@@ -419,14 +419,14 @@ public sealed partial class DomBridge
         if (nodeObj == null)
             return JSUndefined.Value;
         var el = bridge.FindDomElementByJSObject(nodeObj);
-        if (el?.Parent == null)
+        if (el is null || ParentEl(el) == null)
         {
             ThrowDOMException(bridge._jsContext!, "Invalid node type", "InvalidNodeTypeError");
             return JSUndefined.Value;
         }
 
-        state.EndContainer = el.Parent;
-        state.EndOffset = el.Parent.Children.IndexOf(el) + 1;
+        state.EndContainer = ParentEl(el);
+        state.EndOffset = ParentEl(el).Children.IndexOf(el) + 1;
         // Per spec: if end is before start, collapse to end
         if (IsPositionAfter(state.Root, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset))
         {
@@ -466,11 +466,11 @@ public sealed partial class DomBridge
         if (nodeObj == null)
             return JSUndefined.Value;
         var el = bridge.FindDomElementByJSObject(nodeObj);
-        if (el?.Parent == null)
+        if (el is null || ParentEl(el) == null)
             return JSUndefined.Value;
-        state.StartContainer = el.Parent;
-        state.StartOffset = el.Parent.Children.IndexOf(el);
-        state.EndContainer = el.Parent;
+        state.StartContainer = ParentEl(el);
+        state.StartOffset = ParentEl(el).Children.IndexOf(el);
+        state.EndContainer = ParentEl(el);
         state.EndOffset = state.StartOffset + 1;
         state.UpdateCollapsed();
         return JSUndefined.Value;
@@ -508,7 +508,7 @@ public sealed partial class DomBridge
         foreach (var node in nodes)
         {
             var clone = bridge.CloneDomElement(node, true);
-            clone.Parent = fragment;
+            SetParent(clone, fragment);
             fragment.Children.Add(clone);
             bridge._knownNodes.Add(clone);
         }
@@ -531,7 +531,7 @@ public sealed partial class DomBridge
             state.StartContainer.TextContent = text.Substring(0, s) + text.Substring(e2);
             var textNode = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
             textNode.TextContent = extractedText;
-            textNode.Parent = fragment;
+            SetParent(textNode, fragment);
             fragment.Children.Add(textNode);
             bridge._knownNodes.Add(textNode);
             state.EndContainer = state.StartContainer;
@@ -548,7 +548,7 @@ public sealed partial class DomBridge
             {
                 var child = state.StartContainer.Children[state.StartOffset];
                 state.StartContainer.Children.RemoveAt(state.StartOffset);
-                child.Parent = fragment;
+                SetParent(child, fragment);
                 fragment.Children.Add(child);
             }
 
@@ -575,8 +575,8 @@ public sealed partial class DomBridge
         DomElement? startAncestorChild = null;
         {
             var node = state.StartContainer;
-            while (node != null && !ReferenceEquals(node.Parent, ancestor))
-                node = node.Parent;
+            while (node != null && !ReferenceEquals(ParentEl(node), ancestor))
+                node = ParentEl(node);
             startAncestorChild = node;
         }
 
@@ -584,8 +584,8 @@ public sealed partial class DomBridge
         DomElement? endAncestorChild = null;
         {
             var node = state.EndContainer;
-            while (node != null && !ReferenceEquals(node.Parent, ancestor))
-                node = node.Parent;
+            while (node != null && !ReferenceEquals(ParentEl(node), ancestor))
+                node = ParentEl(node);
             endAncestorChild = node;
         }
 
@@ -606,7 +606,7 @@ public sealed partial class DomBridge
                     var extractedNode = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
                     extractedNode.TextContent = extractedPart;
                     bridge._knownNodes.Add(extractedNode);
-                    extractedNode.Parent = fragment;
+                    SetParent(extractedNode, fragment);
                     fragment.Children.Add(extractedNode);
                 }
                 else
@@ -618,11 +618,11 @@ public sealed partial class DomBridge
                     {
                         var child = state.StartContainer.Children[ci];
                         state.StartContainer.Children.RemoveAt(ci);
-                        child.Parent = clone;
+                        SetParent(child, clone);
                         clone.Children.Add(child);
                     }
 
-                    clone.Parent = fragment;
+                    SetParent(clone, fragment);
                     fragment.Children.Add(clone);
                 }
             }
@@ -632,7 +632,7 @@ public sealed partial class DomBridge
                 var clone = ExtractStartPath(startAncestorChild, state.StartContainer, state.StartOffset, bridge);
                 if (clone != null)
                 {
-                    clone.Parent = fragment;
+                    SetParent(clone, fragment);
                     fragment.Children.Add(clone);
                 }
             }
@@ -646,7 +646,7 @@ public sealed partial class DomBridge
                 var child = ancestor.Children[ci];
                 ancestor.Children.RemoveAt(ci);
                 endIdx2--;
-                child.Parent = fragment;
+                SetParent(child, fragment);
                 fragment.Children.Add(child);
             }
         }
@@ -664,7 +664,7 @@ public sealed partial class DomBridge
                     var extractedNode = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
                     extractedNode.TextContent = extractedPart;
                     bridge._knownNodes.Add(extractedNode);
-                    extractedNode.Parent = fragment;
+                    SetParent(extractedNode, fragment);
                     fragment.Children.Add(extractedNode);
                 }
                 else
@@ -675,11 +675,11 @@ public sealed partial class DomBridge
                     {
                         var child = state.EndContainer.Children[0];
                         state.EndContainer.Children.RemoveAt(0);
-                        child.Parent = clone;
+                        SetParent(child, clone);
                         clone.Children.Add(child);
                     }
 
-                    clone.Parent = fragment;
+                    SetParent(clone, fragment);
                     fragment.Children.Add(clone);
                 }
             }
@@ -688,7 +688,7 @@ public sealed partial class DomBridge
                 var clone = ExtractEndPath(endAncestorChild, state.EndContainer, state.EndOffset, bridge);
                 if (clone != null)
                 {
-                    clone.Parent = fragment;
+                    SetParent(clone, fragment);
                     fragment.Children.Add(clone);
                 }
             }
@@ -707,8 +707,8 @@ public sealed partial class DomBridge
         var nodes = GetNodesInRange(state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset);
         foreach (var node in nodes)
         {
-            node.Parent?.Children.Remove(node);
-            node.Parent = null;
+            ParentEl(node)?.Children.Remove(node);
+            SetParent(node, null);
         }
 
         state.EndContainer = state.StartContainer;
@@ -729,11 +729,11 @@ public sealed partial class DomBridge
         if (el == null)
             return JSUndefined.Value;
         // Remove from old parent if needed
-        el.Parent?.Children.Remove(el);
+        ParentEl(el)?.Children.Remove(el);
         // If start container is a text node, split it
         if (state.StartContainer.IsTextNode)
         {
-            var parent = state.StartContainer.Parent;
+            var parent = ParentEl(state.StartContainer);
             if (parent == null)
                 return JSUndefined.Value;
             var text = state.StartContainer.TextContent ?? string.Empty;
@@ -752,9 +752,9 @@ public sealed partial class DomBridge
             bridge._knownNodes.Add(remainder);
             // Insert: [before] [insertedNode] [after]
             var textIdx = parent.Children.IndexOf(state.StartContainer);
-            el.Parent = parent;
+            SetParent(el, parent);
             parent.Children.Insert(textIdx + 1, el);
-            remainder.Parent = parent;
+            SetParent(remainder, parent);
             parent.Children.Insert(textIdx + 2, remainder);
             // Per spec: update range boundary points after text split
             state.StartContainer = parent;
@@ -770,7 +770,7 @@ public sealed partial class DomBridge
         }
         else
         {
-            el.Parent = state.StartContainer;
+            SetParent(el, state.StartContainer);
             var insertIdx = Math.Min(state.StartOffset, state.StartContainer.Children.Count);
             state.StartContainer.Children.Insert(insertIdx, el);
         }
@@ -816,7 +816,7 @@ public sealed partial class DomBridge
                         }
                     }
 
-                    node = node.Parent;
+                    node = ParentEl(node);
                 }
             }
 
@@ -849,13 +849,13 @@ public sealed partial class DomBridge
         var rangeNodes = GetNodesInRange(state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset);
         foreach (var node in rangeNodes)
         {
-            node.Parent?.Children.Remove(node);
-            node.Parent = newParent;
+            ParentEl(node)?.Children.Remove(node);
+            SetParent(node, newParent);
             newParent.Children.Add(node);
         }
 
-        newParent.Parent?.Children.Remove(newParent);
-        newParent.Parent = state.StartContainer;
+        ParentEl(newParent)?.Children.Remove(newParent);
+        SetParent(newParent, state.StartContainer);
         var idx = Math.Min(state.StartOffset, state.StartContainer.Children.Count);
         state.StartContainer.Children.Insert(idx, newParent);
         return JSUndefined.Value;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Utilities.cs
@@ -28,13 +28,13 @@ public sealed partial class DomBridge
     private static JSValue JsUtilitiesSetCssText004Core(global::Broiler.HtmlBridge.DomElement element, global::System.Action? onMutation, in Arguments a)
     {
         element.Style.Clear();
-        element.JsSetStyleProps.Clear();
+        GetElementRuntimeState(element).JsSetStyleProps.Clear();
         if (a.Length > 0)
         {
             foreach (var kv in ParseStyle(a[0].ToString(), reportDrops: true))
             {
                 element.Style[kv.Key] = kv.Value;
-                element.JsSetStyleProps.Add(kv.Key);
+                GetElementRuntimeState(element).JsSetStyleProps.Add(kv.Key);
             }
         }
 
@@ -52,12 +52,12 @@ public sealed partial class DomBridge
             if (string.IsNullOrEmpty(value))
             {
                 element.Style.Remove(prop);
-                element.JsSetStyleProps.Remove(prop);
+                GetElementRuntimeState(element).JsSetStyleProps.Remove(prop);
             }
             else
             {
                 element.Style[prop] = value;
-                element.JsSetStyleProps.Add(prop);
+                GetElementRuntimeState(element).JsSetStyleProps.Add(prop);
             }
 
             onMutation?.Invoke();
@@ -96,7 +96,7 @@ public sealed partial class DomBridge
             var prop = a[0].ToString();
             var removed = element.Style.TryGetValue(prop, out var val) ? val : string.Empty;
             element.Style.Remove(prop);
-            element.JsSetStyleProps.Remove(prop);
+            GetElementRuntimeState(element).JsSetStyleProps.Remove(prop);
             onMutation?.Invoke();
             return new JSString(removed);
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Utilities.cs
@@ -19,7 +19,7 @@ public sealed partial class DomBridge
 
     private static JSValue JsUtilitiesGetCssText003Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        var parts = element.Style.Select(kv => $"{kv.Key}: {kv.Value}");
+        var parts = InlineStyle(element).Select(kv => $"{kv.Key}: {kv.Value}");
         var text = string.Join("; ", parts);
         return new JSString(text.Length > 0 ? text + ";" : text);
     }
@@ -27,13 +27,13 @@ public sealed partial class DomBridge
 
     private static JSValue JsUtilitiesSetCssText004Core(global::Broiler.HtmlBridge.DomElement element, global::System.Action? onMutation, in Arguments a)
     {
-        element.Style.Clear();
+        InlineStyle(element).Clear();
         GetElementRuntimeState(element).JsSetStyleProps.Clear();
         if (a.Length > 0)
         {
             foreach (var kv in ParseStyle(a[0].ToString(), reportDrops: true))
             {
-                element.Style[kv.Key] = kv.Value;
+                InlineStyle(element)[kv.Key] = kv.Value;
                 GetElementRuntimeState(element).JsSetStyleProps.Add(kv.Key);
             }
         }
@@ -51,12 +51,12 @@ public sealed partial class DomBridge
             var value = ApplyCssPriority(a[1].ToString(), a.Length >= 3 ? a[2].ToString() : string.Empty);
             if (string.IsNullOrEmpty(value))
             {
-                element.Style.Remove(prop);
+                InlineStyle(element).Remove(prop);
                 GetElementRuntimeState(element).JsSetStyleProps.Remove(prop);
             }
             else
             {
-                element.Style[prop] = value;
+                InlineStyle(element)[prop] = value;
                 GetElementRuntimeState(element).JsSetStyleProps.Add(prop);
             }
 
@@ -94,8 +94,8 @@ public sealed partial class DomBridge
         if (a.Length > 0)
         {
             var prop = a[0].ToString();
-            var removed = element.Style.TryGetValue(prop, out var val) ? val : string.Empty;
-            element.Style.Remove(prop);
+            var removed = InlineStyle(element).TryGetValue(prop, out var val) ? val : string.Empty;
+            InlineStyle(element).Remove(prop);
             GetElementRuntimeState(element).JsSetStyleProps.Remove(prop);
             onMutation?.Invoke();
             return new JSString(removed);
@@ -107,7 +107,7 @@ public sealed partial class DomBridge
 
     private static JSValue JsUtilitiesGetCssFloat008Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (element.Style.TryGetValue("float", out var val))
+        if (InlineStyle(element).TryGetValue("float", out var val))
             return new JSString(val);
         return new JSString(string.Empty);
     }
@@ -116,7 +116,7 @@ public sealed partial class DomBridge
     private static JSValue JsUtilitiesSetCssFloat009Core(global::Broiler.HtmlBridge.DomElement element, global::System.Action? onMutation, in Arguments a)
     {
         if (a.Length > 0)
-            element.Style["float"] = a[0].ToString();
+            InlineStyle(element)["float"] = a[0].ToString();
         onMutation?.Invoke();
         return JSUndefined.Value;
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -288,7 +288,7 @@ public sealed partial class DomBridge
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // splitText(offset) — splits a text node at the given character offset
-        if (element.IsTextNode)
+        if (IsText(element))
         {
             obj.FastAddValue(
                 (KeyString)"splitText",
@@ -297,7 +297,7 @@ public sealed partial class DomBridge
         }
 
         // substringData(offset, count) — for text/comment CharacterData nodes
-        if (element.IsTextNode || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
         {
             obj.FastAddValue(
                 (KeyString)"substringData",
@@ -508,7 +508,7 @@ public sealed partial class DomBridge
         // childElementCount (read-only)
         obj.FastAddProperty(
             (KeyString)"childElementCount",
-            new JSFunction((in Arguments a) => new JSNumber(element.Children.Count(c => !c.IsTextNode && !IsSubDocRoot(c))),
+            new JSFunction((in Arguments a) => new JSNumber(element.Children.Count(c => !IsText(c) && !IsSubDocRoot(c))),
                 "get childElementCount"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -185,7 +185,7 @@ public sealed partial class DomBridge
         // parentNode (read-only, dynamic)
         obj.FastAddProperty(
             (KeyString)"parentNode",
-            new JSFunction((in Arguments a) => element.Parent != null ? ToJSObject(element.Parent) : JSNull.Value,
+            new JSFunction((in Arguments a) => ParentEl(element) != null ? ToJSObject(ParentEl(element)) : JSNull.Value,
                 "get parentNode"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -370,7 +370,7 @@ public sealed partial class DomBridge
         // hasChildNodes()
         obj.FastAddValue(
             (KeyString)"hasChildNodes",
-            new JSFunction((in Arguments a) => element.Children.Count > 0 ? JSBoolean.True : JSBoolean.False,
+            new JSFunction((in Arguments a) => element.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False,
                 "hasChildNodes", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -508,7 +508,7 @@ public sealed partial class DomBridge
         // childElementCount (read-only)
         obj.FastAddProperty(
             (KeyString)"childElementCount",
-            new JSFunction((in Arguments a) => new JSNumber(element.Children.Count(c => !IsText(c) && !IsSubDocRoot(c))),
+            new JSFunction((in Arguments a) => new JSNumber(ChildElements(element).Count(c => !IsText(c) && !IsSubDocRoot(c))),
                 "get childElementCount"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -58,7 +58,7 @@ public sealed partial class DomBridge
         // title (read/write) — synced with attributes["title"]
         obj.FastAddProperty(
             (KeyString)"title",
-            new JSFunction((in Arguments a) => element.Attributes.TryGetValue("title", out var t) ? new JSString(t) : new JSString(string.Empty),
+            new JSFunction((in Arguments a) => TryGetAttribute(element, "title", out var t) ? new JSString(t) : new JSString(string.Empty),
                 "get title"),
             new JSFunction((in Arguments a) => JsJsObjectsSetTitle006Core(element, in a), "set title"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -66,7 +66,7 @@ public sealed partial class DomBridge
         // lang (read/write) — synced with attributes["lang"]
         obj.FastAddProperty(
             (KeyString)"lang",
-            new JSFunction((in Arguments a) => element.Attributes.TryGetValue("lang", out var lang) ? new JSString(lang) : new JSString(string.Empty),
+            new JSFunction((in Arguments a) => TryGetAttribute(element, "lang", out var lang) ? new JSString(lang) : new JSString(string.Empty),
                 "get lang"),
             new JSFunction((in Arguments a) => JsJsObjectsSetLang008Core(element, in a), "set lang"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -74,7 +74,7 @@ public sealed partial class DomBridge
         // accessKey (read/write) — synced with attributes["accesskey"]
         obj.FastAddProperty(
             (KeyString)"accessKey",
-            new JSFunction((in Arguments a) => element.Attributes.TryGetValue("accesskey", out var accessKey) ? new JSString(accessKey) : new JSString(string.Empty),
+            new JSFunction((in Arguments a) => TryGetAttribute(element, "accesskey", out var accessKey) ? new JSString(accessKey) : new JSString(string.Empty),
                 "get accessKey"),
             new JSFunction((in Arguments a) => JsJsObjectsSetAccessKey010Core(element, in a), "set accessKey"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -82,7 +82,7 @@ public sealed partial class DomBridge
         // dir (read/write) — synced with attributes["dir"]
         obj.FastAddProperty(
             (KeyString)"dir",
-            new JSFunction((in Arguments a) => element.Attributes.TryGetValue("dir", out var dir) ? new JSString(dir) : new JSString(string.Empty),
+            new JSFunction((in Arguments a) => TryGetAttribute(element, "dir", out var dir) ? new JSString(dir) : new JSString(string.Empty),
                 "get dir"),
             new JSFunction((in Arguments a) => JsJsObjectsSetDir012Core(bridge, element, in a), "set dir"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -390,7 +390,7 @@ public sealed partial class DomBridge
         // getAttributeNames()
         obj.FastAddValue(
             (KeyString)"getAttributeNames",
-            new JSFunction((in Arguments _) => new JSArray(element.Attributes.Keys.Select(static name => (JSValue)new JSString(name)).ToArray()),
+            new JSFunction((in Arguments _) => new JSArray(AttributeNames(element).Select(static name => (JSValue)new JSString(name)).ToArray()),
                 "getAttributeNames", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -691,7 +691,7 @@ public sealed partial class DomBridge
         // disabled (read/write) — for form controls
         obj.FastAddProperty(
             (KeyString)"disabled",
-            new JSFunction((in Arguments a) => element.Attributes.ContainsKey("disabled") ? JSBoolean.True : JSBoolean.False,
+            new JSFunction((in Arguments a) => HasAttr(element, "disabled") ? JSBoolean.True : JSBoolean.False,
                 "get disabled"),
             new JSFunction((in Arguments a) => JsJsObjectsSetDisabled115Core(bridge, element, in a), "set disabled"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -699,7 +699,7 @@ public sealed partial class DomBridge
         // hidden (read/write) — global reflected boolean attribute
         obj.FastAddProperty(
             (KeyString)"hidden",
-            new JSFunction((in Arguments a) => element.Attributes.ContainsKey("hidden") ? JSBoolean.True : JSBoolean.False,
+            new JSFunction((in Arguments a) => HasAttr(element, "hidden") ? JSBoolean.True : JSBoolean.False,
                 "get hidden"),
             new JSFunction((in Arguments a) => JsJsObjectsSetHidden117Core(bridge, element, in a), "set hidden"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -714,7 +714,7 @@ public sealed partial class DomBridge
         // required (read/write) — form validation
         obj.FastAddProperty(
             (KeyString)"required",
-            new JSFunction((in Arguments a) => element.Attributes.ContainsKey("required") ? JSBoolean.True : JSBoolean.False,
+            new JSFunction((in Arguments a) => HasAttr(element, "required") ? JSBoolean.True : JSBoolean.False,
                 "get required"),
             new JSFunction((in Arguments a) => JsJsObjectsSetRequired121Core(bridge, element, in a), "set required"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
@@ -811,20 +811,20 @@ public sealed partial class DomBridge
             var bridgeForSrc = this;
             obj.FastAddProperty(
                 (KeyString)"src",
-                new JSFunction((in Arguments _) => element.Attributes.TryGetValue("src", out var s) ? new JSString(s) : new JSString(string.Empty), "get src"),
+                new JSFunction((in Arguments _) => TryGetAttribute(element, "src", out var s) ? new JSString(s) : new JSString(string.Empty), "get src"),
                 new JSFunction((in Arguments a) => JsJsObjectsSetSrc139Core(bridgeForSrc, element, in a), "set src"),
                  JSPropertyAttributes.EnumerableConfigurableProperty);
 
             obj.FastAddProperty(
                 (KeyString)"srcdoc",
-                new JSFunction((in Arguments _) => element.Attributes.TryGetValue("srcdoc", out var s) ? new JSString(s) : new JSString(string.Empty), "get srcdoc"),
+                new JSFunction((in Arguments _) => TryGetAttribute(element, "srcdoc", out var s) ? new JSString(s) : new JSString(string.Empty), "get srcdoc"),
                 new JSFunction((in Arguments a) => JsJsObjectsSetSrcdoc141Core(bridgeForSrc, element, in a), "set srcdoc"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
 
             // sandbox attribute access
             obj.FastAddProperty(
                 (KeyString)"sandbox",
-                new JSFunction((in Arguments _) => element.Attributes.TryGetValue("sandbox", out var sandbox) ? new JSString(sandbox) : new JSString(string.Empty), "get sandbox"),
+                new JSFunction((in Arguments _) => TryGetAttribute(element, "sandbox", out var sandbox) ? new JSString(sandbox) : new JSString(string.Empty), "get sandbox"),
                 null,
                 JSPropertyAttributes.EnumerableConfigurableProperty);
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -217,7 +217,7 @@ public sealed partial class DomBridge
 
     private DomElement? GetOffsetParentForDomElement(DomElement element)
     {
-        if (element.Parent == null ||
+        if (ParentEl(element) == null ||
             ReferenceEquals(element, DocumentElement) ||
             string.Equals(element.TagName, "html", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(element.TagName, "body", StringComparison.OrdinalIgnoreCase))
@@ -231,7 +231,7 @@ public sealed partial class DomBridge
 
         var documentElement = GetOwningDocumentElement(element);
         var fallbackBody = FindBodyElement(documentElement);
-        for (var current = element.Parent; current != null; current = current.Parent)
+        for (var current = ParentEl(element); current != null; current = ParentEl(current))
         {
             if (string.Equals(current.TagName, "body", StringComparison.OrdinalIgnoreCase))
                 return current;
@@ -283,14 +283,14 @@ public sealed partial class DomBridge
             return FindNearestScrollParent(containingBlock, documentElement);
         }
 
-        return FindNearestScrollParent(element.Parent, documentElement);
+        return FindNearestScrollParent(ParentEl(element), documentElement);
     }
 
     private DomElement GetDocumentScrollingElement(DomElement documentElement) => documentElement;
 
     private DomElement FindNearestScrollParent(DomElement? start, DomElement documentElement)
     {
-        for (var current = start; current != null; current = current.Parent)
+        for (var current = start; current != null; current = ParentEl(current))
         {
             if (ReferenceEquals(current, documentElement))
                 return GetDocumentScrollingElement(documentElement);
@@ -307,7 +307,7 @@ public sealed partial class DomBridge
 
     private DomElement? FindFixedPositionContainingBlock(DomElement element, DomElement documentElement)
     {
-        for (var current = element.Parent; current != null; current = current.Parent)
+        for (var current = ParentEl(element); current != null; current = ParentEl(current))
         {
             if (ReferenceEquals(current, documentElement))
                 break;
@@ -541,7 +541,7 @@ public sealed partial class DomBridge
     {
         var props = GetComputedProps(element);
         var specifiedZoom = props.GetValueOrDefault("zoom");
-        var parentZoom = element.Parent != null ? GetUsedZoomForElement(element.Parent) : 1.0;
+        var parentZoom = ParentEl(element) != null ? GetUsedZoomForElement(ParentEl(element)) : 1.0;
         return ResolveSpecifiedZoom(specifiedZoom, parentZoom);
     }
 
@@ -720,7 +720,7 @@ public sealed partial class DomBridge
 
     private double ResolveSvgTextCoordinate(DomElement element, string attributeName)
     {
-        for (var current = element; current != null; current = current.Parent)
+        for (var current = element; current != null; current = ParentEl(current))
         {
             if (!IsSvgTextContentElement(current))
                 continue;
@@ -813,7 +813,7 @@ public sealed partial class DomBridge
 
     private static DomElement? FindNearestSvgViewportAncestor(DomElement element)
     {
-        for (var current = element.Parent; current != null; current = current.Parent)
+        for (var current = ParentEl(element); current != null; current = ParentEl(current))
         {
             if (IsSvgViewportElement(current))
                 return current;
@@ -1621,11 +1621,11 @@ public sealed partial class DomBridge
 
     private static bool IsViewportBodyElement(DomElement element, DomElement documentElement) =>
         string.Equals(element.TagName, "body", StringComparison.OrdinalIgnoreCase) &&
-        ReferenceEquals(element.Parent, documentElement);
+        ReferenceEquals(ParentEl(element), documentElement);
 
     private DomElement GetOwningDocumentElement(DomElement element)
     {
-        for (var current = element; current != null; current = current.Parent!)
+        for (var current = element; current != null; current = ParentEl(current)!)
         {
             if (string.Equals(current.TagName, "html", StringComparison.OrdinalIgnoreCase))
                 return current;
@@ -1650,10 +1650,10 @@ public sealed partial class DomBridge
 
     private static DomElement? GetOuterFrameElement(DomElement documentElement)
     {
-        var docRoot = documentElement.Parent;
+        var docRoot = ParentEl(documentElement);
         return docRoot != null &&
                string.Equals(docRoot.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase)
-            ? docRoot.Parent
+            ? ParentEl(docRoot)
             : null;
     }
 
@@ -1744,7 +1744,7 @@ public sealed partial class DomBridge
     /// </summary>
     private DomElement? FindNearestFixedAncestorOrSelf(DomElement element)
     {
-        for (var current = element; current != null; current = current.Parent)
+        for (var current = element; current != null; current = ParentEl(current))
         {
             if (IsFixedPositionElement(current))
                 return current;
@@ -1754,7 +1754,7 @@ public sealed partial class DomBridge
 
     private static bool IsDomDescendantOrSelf(DomElement node, DomElement potentialAncestor)
     {
-        for (var current = node; current != null; current = current.Parent)
+        for (var current = node; current != null; current = ParentEl(current))
         {
             if (ReferenceEquals(current, potentialAncestor))
                 return true;
@@ -1906,8 +1906,8 @@ public sealed partial class DomBridge
     {
         var props = GetComputedProps(element);
         var value = props.GetValueOrDefault(propertyName);
-        if (string.Equals(value, "inherit", StringComparison.OrdinalIgnoreCase) && element.Parent != null)
-            return ResolveScrollIntoViewInset(element.Parent, propertyName);
+        if (string.Equals(value, "inherit", StringComparison.OrdinalIgnoreCase) && ParentEl(element) != null)
+            return ResolveScrollIntoViewInset(ParentEl(element), propertyName);
 
         return (ParseCssLengthToPixelsWithViewport(value, element), element);
     }
@@ -2024,7 +2024,7 @@ public sealed partial class DomBridge
             double emBasis;
             if (forFontSize)
             {
-                var parent = referenceElement.Parent;
+                var parent = ParentEl(referenceElement);
                 emBasis = parent != null ? ResolveFontSizeForElement(parent) : 16;
             }
             else
@@ -2190,16 +2190,16 @@ public sealed partial class DomBridge
 
     private double ResolveContainingBlockReferenceLength(DomElement element, bool vertical)
     {
-        if (element.Parent == null ||
+        if (ParentEl(element) == null ||
             string.Equals(element.TagName, "html", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(element.TagName, "body", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(element.Parent.TagName, "html", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(element.Parent.TagName, "body", StringComparison.OrdinalIgnoreCase))
+            string.Equals(ParentEl(element).TagName, "html", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(ParentEl(element).TagName, "body", StringComparison.OrdinalIgnoreCase))
         {
             return GetViewportReferenceLength(element, vertical);
         }
 
-        var parentRect = ComputeUnzoomedLayoutRect(element.Parent);
+        var parentRect = ComputeUnzoomedLayoutRect(ParentEl(element));
         var reference = vertical ? parentRect.Height : parentRect.Width;
         return reference > 0 ? reference : GetViewportReferenceLength(element, vertical);
     }
@@ -2240,7 +2240,7 @@ public sealed partial class DomBridge
 
     private double ResolveLineHeightForLength(DomElement element, bool rootRelative, bool forLineHeight = false)
     {
-        var target = rootRelative ? GetRootElement(element) : (forLineHeight ? element.Parent ?? element : element);
+        var target = rootRelative ? GetRootElement(element) : (forLineHeight ? ParentEl(element) ?? element : element);
         return ResolveLineHeightForElement(target);
     }
 
@@ -2254,9 +2254,9 @@ public sealed partial class DomBridge
     {
         DomElement? htmlElement = null;
         var current = element;
-        while (current.Parent != null)
+        while (ParentEl(current) != null)
         {
-            current = current.Parent;
+            current = ParentEl(current);
             if (string.Equals(current.TagName, "html", StringComparison.OrdinalIgnoreCase))
                 htmlElement = current;
         }
@@ -2292,7 +2292,7 @@ public sealed partial class DomBridge
         if (fontSize > 0)
             return fontSize;
 
-        for (var current = element; current != null; current = current.Parent)
+        for (var current = element; current != null; current = ParentEl(current))
         {
             if (!TryGetAttribute(current, "font-size", out var attributeValue) ||
                 string.IsNullOrWhiteSpace(attributeValue))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -621,7 +621,7 @@ public sealed partial class DomBridge
         var maxRight = 0d;
         var maxBottom = 0d;
 
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
         {
             if (IsText(child) || child.TagName.StartsWith("#", StringComparison.Ordinal))
                 continue;
@@ -709,7 +709,7 @@ public sealed partial class DomBridge
         if (!string.IsNullOrWhiteSpace(element.TextContent))
             sb.Append(element.TextContent);
 
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
         {
             if (IsText(child) && !string.IsNullOrWhiteSpace(child.TextContent))
                 sb.Append(child.TextContent);
@@ -1415,7 +1415,7 @@ public sealed partial class DomBridge
     private static int CountSelectOptions(DomElement element)
     {
         int count = 0;
-        foreach (var child in element.Children.Where(c => !IsText(c)))
+        foreach (var child in ChildElements(element).Where(c => !IsText(c)))
         {
             if (string.Equals(child.TagName, "option", StringComparison.OrdinalIgnoreCase))
             {
@@ -1452,7 +1452,7 @@ public sealed partial class DomBridge
     private static List<DomElement> CollectSelectOptions(DomElement element)
     {
         var options = new List<DomElement>();
-        foreach (var child in element.Children.Where(c => !IsText(c)))
+        foreach (var child in ChildElements(element).Where(c => !IsText(c)))
         {
             if (string.Equals(child.TagName, "option", StringComparison.OrdinalIgnoreCase))
             {
@@ -1561,7 +1561,7 @@ public sealed partial class DomBridge
             if (host == null)
                 yield break;
 
-            foreach (var child in host.Children)
+            foreach (var child in ChildElements(host))
             {
                 if (!IsText(child) && SlotAcceptsNode(element, child))
                     yield return child;
@@ -1570,7 +1570,7 @@ public sealed partial class DomBridge
             yield break;
         }
 
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
         {
             if (!IsText(child))
                 yield return child;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -588,7 +588,7 @@ public sealed partial class DomBridge
             return transform;
         }
 
-        return element.Attributes.TryGetValue("transform", out var attributeTransform)
+        return TryGetAttribute(element, "transform", out var attributeTransform)
             ? attributeTransform
             : null;
     }
@@ -725,7 +725,7 @@ public sealed partial class DomBridge
             if (!IsSvgTextContentElement(current))
                 continue;
 
-            if (current.Attributes.TryGetValue(attributeName, out var rawValue))
+            if (TryGetAttribute(current, attributeName, out var rawValue))
             {
                 var percentageBasis = ResolveContainingBlockReferenceLength(
                     current,
@@ -760,14 +760,14 @@ public sealed partial class DomBridge
     }
 
     private static bool HasOwnSvgCoordinate(DomElement element, string attributeName) =>
-        element.Attributes.TryGetValue(attributeName, out var rawValue) &&
+        TryGetAttribute(element, attributeName, out var rawValue) &&
         !string.IsNullOrWhiteSpace(rawValue);
 
     private bool TryResolveSvgTextPathStart(DomElement element, out (double X, double Y) point)
     {
         point = default;
-        if (!element.Attributes.TryGetValue("href", out var href) &&
-            !element.Attributes.TryGetValue("xlink:href", out href))
+        if (!TryGetAttribute(element, "href", out var href) &&
+            !TryGetAttribute(element, "xlink:href", out href))
         {
             return false;
         }
@@ -781,7 +781,7 @@ public sealed partial class DomBridge
             ? FindInTree(documentElement, candidate => string.Equals(candidate.Id, href[1..], StringComparison.Ordinal))
             : null;
         if (referencedPath == null ||
-            !referencedPath.Attributes.TryGetValue("d", out var pathData) ||
+            !TryGetAttribute(referencedPath, "d", out var pathData) ||
             string.IsNullOrWhiteSpace(pathData))
         {
             return false;
@@ -1481,7 +1481,7 @@ public sealed partial class DomBridge
         for (var index = 0; index < options.Count; index++)
         {
             var option = options[index];
-            if (option.Attributes.ContainsKey("selected") ||
+            if (HasAttr(option, "selected") ||
                 (GetElementRuntimeState(option).FormControl.DefaultSelected.TryGet(out var defaultSelected) && defaultSelected is true))
             {
                 return index;
@@ -1517,7 +1517,7 @@ public sealed partial class DomBridge
         if (GetElementRuntimeState(option).FormControl.Value.TryGet(out var domValue) && domValue is string stringValue)
             return stringValue;
 
-        if (option.Attributes.TryGetValue("value", out var attrValue))
+        if (TryGetAttribute(option, "value", out var attrValue))
             return attrValue;
 
         return option.TextContent;
@@ -1529,7 +1529,7 @@ public sealed partial class DomBridge
         for (var index = 0; index < options.Count; index++)
         {
             var option = options[index];
-            var optionValue = option.Attributes.TryGetValue("value", out var attrValue)
+            var optionValue = TryGetAttribute(option, "value", out var attrValue)
                 ? attrValue
                 : option.TextContent;
             if (string.Equals(optionValue, value, StringComparison.Ordinal))
@@ -2219,7 +2219,7 @@ public sealed partial class DomBridge
                 if (frameLength > 0)
                     return frameLength;
 
-                if (frameElement.Attributes.TryGetValue(vertical ? "height" : "width", out var frameAttribute) &&
+                if (TryGetAttribute(frameElement, vertical ? "height" : "width", out var frameAttribute) &&
                     double.TryParse(frameAttribute, System.Globalization.NumberStyles.Float,
                         System.Globalization.CultureInfo.InvariantCulture, out frameLength) &&
                     frameLength > 0)
@@ -2294,7 +2294,7 @@ public sealed partial class DomBridge
 
         for (var current = element; current != null; current = current.Parent)
         {
-            if (!current.Attributes.TryGetValue("font-size", out var attributeValue) ||
+            if (!TryGetAttribute(current, "font-size", out var attributeValue) ||
                 string.IsNullOrWhiteSpace(attributeValue))
             {
                 continue;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -342,7 +342,7 @@ public sealed partial class DomBridge
 
     private bool HasAssociatedLayoutBox(DomElement element)
     {
-        if (element.IsTextNode)
+        if (IsText(element))
             return false;
 
         if (element.TagName.StartsWith("#", StringComparison.Ordinal))
@@ -623,7 +623,7 @@ public sealed partial class DomBridge
 
         foreach (var child in element.Children)
         {
-            if (child.IsTextNode || child.TagName.StartsWith("#", StringComparison.Ordinal))
+            if (IsText(child) || child.TagName.StartsWith("#", StringComparison.Ordinal))
                 continue;
 
             var childRect = GetHitTestRectForElement(child);
@@ -711,7 +711,7 @@ public sealed partial class DomBridge
 
         foreach (var child in element.Children)
         {
-            if (child.IsTextNode && !string.IsNullOrWhiteSpace(child.TextContent))
+            if (IsText(child) && !string.IsNullOrWhiteSpace(child.TextContent))
                 sb.Append(child.TextContent);
         }
 
@@ -1415,7 +1415,7 @@ public sealed partial class DomBridge
     private static int CountSelectOptions(DomElement element)
     {
         int count = 0;
-        foreach (var child in element.Children.Where(c => !c.IsTextNode))
+        foreach (var child in element.Children.Where(c => !IsText(c)))
         {
             if (string.Equals(child.TagName, "option", StringComparison.OrdinalIgnoreCase))
             {
@@ -1452,7 +1452,7 @@ public sealed partial class DomBridge
     private static List<DomElement> CollectSelectOptions(DomElement element)
     {
         var options = new List<DomElement>();
-        foreach (var child in element.Children.Where(c => !c.IsTextNode))
+        foreach (var child in element.Children.Where(c => !IsText(c)))
         {
             if (string.Equals(child.TagName, "option", StringComparison.OrdinalIgnoreCase))
             {
@@ -1563,7 +1563,7 @@ public sealed partial class DomBridge
 
             foreach (var child in host.Children)
             {
-                if (!child.IsTextNode && SlotAcceptsNode(element, child))
+                if (!IsText(child) && SlotAcceptsNode(element, child))
                     yield return child;
             }
 
@@ -1572,7 +1572,7 @@ public sealed partial class DomBridge
 
         foreach (var child in element.Children)
         {
-            if (!child.IsTextNode)
+            if (!IsText(child))
                 yield return child;
         }
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Animations.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Animations.cs
@@ -35,9 +35,9 @@ public sealed partial class DomBridge
         animationShorthand = null;
         animationDelay = null;
 
-        if (element.Style.TryGetValue("animation", out animationShorthand))
+        if (InlineStyle(element).TryGetValue("animation", out animationShorthand))
         {
-            element.Style.TryGetValue("animation-delay", out animationDelay);
+            InlineStyle(element).TryGetValue("animation-delay", out animationDelay);
             return true;
         }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Animations.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Animations.cs
@@ -12,7 +12,7 @@ public sealed partial class DomBridge
         var animations = new List<JSValue>();
         foreach (var element in Elements)
         {
-            if (element.IsTextNode || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+            if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
                 continue;
             if (target != null && !ReferenceEquals(element, target))
                 continue;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Document.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Document.cs
@@ -147,13 +147,13 @@ public sealed partial class DomBridge
         // document.firstChild (getter — returns first child of document: DOCTYPE if present, else documentElement)
         document.FastAddProperty(
             (KeyString)"firstChild",
-            new JSFunction((in Arguments _) => _documentNode.Children.Count > 0 ? ToJSObject(_documentNode.Children[0]) : JSNull.Value, "get firstChild"),
+            new JSFunction((in Arguments _) => _documentNode.ChildNodes.Count > 0 ? ToJSObject(ChildAt(_documentNode, 0)) : JSNull.Value, "get firstChild"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);
         // document.lastChild (getter — returns last child of document, typically documentElement)
         document.FastAddProperty(
             (KeyString)"lastChild",
-            new JSFunction((in Arguments _) => _documentNode.Children.Count > 0 ? ToJSObject(_documentNode.Children[^1]) : JSNull.Value, "get lastChild"),
+            new JSFunction((in Arguments _) => _documentNode.ChildNodes.Count > 0 ? ToJSObject(ChildAt(_documentNode, ^1)) : JSNull.Value, "get lastChild"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);
         // document.childNodes (getter — returns children of document node: [DOCTYPE, documentElement])

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
@@ -63,8 +63,8 @@ public sealed partial class DomBridge
 
     private static bool SlotAcceptsNode(DomElement slot, DomElement node)
     {
-        var slotName = slot.Attributes.GetValueOrDefault("name");
-        var nodeSlot = node.Attributes.GetValueOrDefault("slot");
+        var slotName = GetAttr(slot, "name");
+        var nodeSlot = GetAttr(node, "slot");
         return string.IsNullOrEmpty(slotName)
             ? string.IsNullOrEmpty(nodeSlot)
             : string.Equals(slotName, nodeSlot, StringComparison.OrdinalIgnoreCase);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
@@ -72,7 +72,7 @@ public sealed partial class DomBridge
 
     private DomElement? FindAssignedSlot(DomElement root, DomElement node)
     {
-        foreach (var child in root.Children)
+        foreach (var child in ChildElements(root))
         {
             if (IsText(child))
                 continue;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
@@ -74,7 +74,7 @@ public sealed partial class DomBridge
     {
         foreach (var child in root.Children)
         {
-            if (child.IsTextNode)
+            if (IsText(child))
                 continue;
 
             if (string.Equals(child.TagName, "slot", StringComparison.OrdinalIgnoreCase) &&
@@ -93,7 +93,7 @@ public sealed partial class DomBridge
 
     private DomElement? GetAssignedSlot(DomElement element)
     {
-        if (element.IsTextNode || ParentEl(element) == null)
+        if (IsText(element) || ParentEl(element) == null)
             return null;
 
         var shadowRoot = GetShadowRoot(ParentEl(element));

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
@@ -31,7 +31,7 @@ public sealed partial class DomBridge
 
     private static DomElement? FindContainingShadowRoot(DomElement? element)
     {
-        for (var current = element; current != null; current = current.Parent)
+        for (var current = element; current != null; current = ParentEl(current))
         {
             if (string.Equals(current.TagName, "#shadow-root", StringComparison.Ordinal))
                 return current;
@@ -43,8 +43,8 @@ public sealed partial class DomBridge
     private DomElement GetTreeRoot(DomElement element)
     {
         var current = element;
-        while (current.Parent != null)
-            current = current.Parent;
+        while (ParentEl(current) != null)
+            current = ParentEl(current);
         return current;
     }
 
@@ -93,10 +93,10 @@ public sealed partial class DomBridge
 
     private DomElement? GetAssignedSlot(DomElement element)
     {
-        if (element.IsTextNode || element.Parent == null)
+        if (element.IsTextNode || ParentEl(element) == null)
             return null;
 
-        var shadowRoot = GetShadowRoot(element.Parent);
+        var shadowRoot = GetShadowRoot(ParentEl(element));
         return shadowRoot != null ? FindAssignedSlot(shadowRoot, element) : null;
     }
 
@@ -106,7 +106,7 @@ public sealed partial class DomBridge
         if (assignedSlot != null)
             return assignedSlot;
 
-        var parent = element.Parent;
+        var parent = ParentEl(element);
         return GetShadowHost(parent) ?? parent;
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
@@ -53,10 +53,10 @@ public sealed partial class DomBridge
     {
         if (!string.Equals(element.TagName, "link", StringComparison.OrdinalIgnoreCase))
             return false;
-        if (!element.Attributes.TryGetValue("rel", out var rel) ||
+        if (!TryGetAttribute(element, "rel", out var rel) ||
             !rel.Contains("stylesheet", StringComparison.OrdinalIgnoreCase))
             return false;
-        return element.Attributes.ContainsKey("href");
+        return HasAttr(element, "href");
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
@@ -36,7 +36,7 @@ public sealed partial class DomBridge
     /// <summary>Collects all style elements in the sub-tree.</summary>
     private static void CollectStyleElements(DomElement root, List<DomElement> results)
     {
-        foreach (var child in root.Children)
+        foreach (var child in ChildElements(root))
         {
             if (string.Equals(child.TagName, "style", StringComparison.OrdinalIgnoreCase))
                 results.Add(child);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocumentObjects.cs
@@ -298,7 +298,7 @@ public sealed partial class DomBridge
     {
         foreach (var child in root.Children)
         {
-            if (!child.IsTextNode && !child.TagName.StartsWith("#") && predicate(child))
+            if (!IsText(child) && !child.TagName.StartsWith("#") && predicate(child))
                 return child;
             var found = FindInSubTree(child, predicate);
             if (found != null) return found;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocumentObjects.cs
@@ -69,21 +69,21 @@ public sealed partial class DomBridge
         // firstChild
         doc.FastAddProperty(
             (KeyString)"firstChild",
-            new JSFunction((in Arguments _) => docRoot.Children.Count > 0 ? ToJSObject(docRoot.Children[0]) : JSNull.Value, "get firstChild"),
+            new JSFunction((in Arguments _) => docRoot.ChildNodes.Count > 0 ? ToJSObject(ChildAt(docRoot, 0)) : JSNull.Value, "get firstChild"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // lastChild
         doc.FastAddProperty(
             (KeyString)"lastChild",
-            new JSFunction((in Arguments _) => docRoot.Children.Count > 0 ? ToJSObject(docRoot.Children[^1]) : JSNull.Value, "get lastChild"),
+            new JSFunction((in Arguments _) => docRoot.ChildNodes.Count > 0 ? ToJSObject(ChildAt(docRoot, ^1)) : JSNull.Value, "get lastChild"),
             null,
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // hasChildNodes()
         doc.FastAddValue(
             (KeyString)"hasChildNodes",
-            new JSFunction((in Arguments _) => docRoot.Children.Count > 0 ? JSBoolean.True : JSBoolean.False,
+            new JSFunction((in Arguments _) => docRoot.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False,
                 "hasChildNodes", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
@@ -296,7 +296,7 @@ public sealed partial class DomBridge
     /// <summary>Finds the first element in a sub-tree matching a predicate.</summary>
     private DomElement? FindInSubTree(DomElement root, Func<DomElement, bool> predicate)
     {
-        foreach (var child in root.Children)
+        foreach (var child in ChildElements(root))
         {
             if (!IsText(child) && !child.TagName.StartsWith("#") && predicate(child))
                 return child;
@@ -310,7 +310,7 @@ public sealed partial class DomBridge
     private static DomElement? FindInTree(DomElement root, Func<DomElement, bool> predicate)
     {
         if (predicate(root)) return root;
-        foreach (var child in root.Children)
+        foreach (var child in ChildElements(root))
         {
             var found = FindInTree(child, predicate);
             if (found != null) return found;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -21,12 +21,12 @@ public sealed partial class DomBridge
 
     private void InvalidateCachedSubDocument(DomElement containerElement)
     {
-        var existingDocRoot = containerElement.Children.FirstOrDefault(child =>
+        var existingDocRoot = ChildElements(containerElement).FirstOrDefault(child =>
             string.Equals(child.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase));
         if (existingDocRoot != null)
         {
             RemoveElementsRecursive(existingDocRoot);
-            containerElement.Children.Remove(existingDocRoot);
+            RemoveChildFrom(containerElement, existingDocRoot);
         }
 
         _subDocumentCache.Remove(containerElement);
@@ -134,7 +134,7 @@ public sealed partial class DomBridge
 
         var executeHtmlScripts = false;
         string? htmlToExecute = null;
-        var docRoot = containerElement.Children.FirstOrDefault(c =>
+        var docRoot = ChildElements(containerElement).FirstOrDefault(c =>
             string.Equals(c.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase));
         if (docRoot == null)
         {
@@ -363,16 +363,16 @@ public sealed partial class DomBridge
 
     private static DomElement? GetSubDocumentScrollingElement(DomElement containerElement)
     {
-        var docRoot = containerElement.Children.FirstOrDefault(c =>
+        var docRoot = ChildElements(containerElement).FirstOrDefault(c =>
             string.Equals(c.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase));
         if (docRoot == null)
             return null;
 
-        return docRoot.Children.FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith("#"));
+        return ChildElements(docRoot).FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith("#"));
     }
 
     private static DomElement? FindBodyElement(DomElement documentElement) =>
-        documentElement.Children.FirstOrDefault(c =>
+        ChildElements(documentElement).FirstOrDefault(c =>
             !IsText(c) &&
             string.Equals(c.TagName, "body", StringComparison.OrdinalIgnoreCase));
 
@@ -577,17 +577,17 @@ public sealed partial class DomBridge
 
         var htmlEl = new DomElement("html", null, null, string.Empty);
         SetParent(htmlEl, docRoot);
-        docRoot.Children.Add(htmlEl);
+        docRoot.AppendChild(htmlEl);
 
         var headEl = new DomElement("head", null, null, string.Empty);
         SetParent(headEl, htmlEl);
-        htmlEl.Children.Add(headEl);
+        htmlEl.AppendChild(headEl);
 
         var bodyEl = new DomElement("body", null, null, string.Empty);
         SetParent(bodyEl, htmlEl);
-        htmlEl.Children.Add(bodyEl);
+        htmlEl.AppendChild(bodyEl);
 
-        containerElement.Children.Insert(0, docRoot);
+        InsertChildAt(containerElement, 0, docRoot);
         _knownNodes.Add(docRoot);
         _knownNodes.Add(htmlEl);
         _knownNodes.Add(headEl);
@@ -607,27 +607,27 @@ public sealed partial class DomBridge
 
         var htmlEl = new DomElement("html", null, null, string.Empty);
         SetParent(htmlEl, docRoot);
-        docRoot.Children.Add(htmlEl);
+        docRoot.AppendChild(htmlEl);
 
         var headEl = new DomElement("head", null, null, string.Empty);
         SetParent(headEl, htmlEl);
-        htmlEl.Children.Add(headEl);
+        htmlEl.AppendChild(headEl);
 
         var bodyEl = new DomElement("body", null, null, string.Empty);
         SetParent(bodyEl, htmlEl);
-        htmlEl.Children.Add(bodyEl);
+        htmlEl.AppendChild(bodyEl);
 
         // Wrap text content in <pre> element
         var preEl = new DomElement("pre", null, null, string.Empty);
         SetParent(preEl, bodyEl);
-        bodyEl.Children.Add(preEl);
+        bodyEl.AppendChild(preEl);
 
         var textNode = new DomElement("#text", null, null, string.Empty, isTextNode: true);
         textNode.TextContent = textContent;
         SetParent(textNode, preEl);
-        preEl.Children.Add(textNode);
+        preEl.AppendChild(textNode);
 
-        containerElement.Children.Insert(0, docRoot);
+        InsertChildAt(containerElement, 0, docRoot);
         _knownNodes.Add(docRoot);
         _knownNodes.Add(htmlEl);
         _knownNodes.Add(headEl);
@@ -875,13 +875,13 @@ public sealed partial class DomBridge
         // parsedRoot is the <html> element itself (HtmlTreeBuilder returns it directly).
         // Move it under #subdoc-root as the documentElement.
         SetParent(parsedRoot, docRoot);
-        docRoot.Children.Add(parsedRoot);
+        docRoot.AppendChild(parsedRoot);
 
-        containerElement.Children.Insert(0, docRoot);
+        InsertChildAt(containerElement, 0, docRoot);
         _knownNodes.Add(docRoot);
         _knownNodes.Add(parsedRoot);
         // Add structural children (head, body) that HtmlTreeBuilder does not include in allElements
-        foreach (var child in parsedRoot.Children)
+        foreach (var child in ChildElements(parsedRoot))
             AddElementsRecursive(child);
         // Add non-structural elements from the builder (skip any already registered)
         foreach (var el in allElements)
@@ -902,7 +902,7 @@ public sealed partial class DomBridge
     {
         if (!_knownNodes.Contains(element))
             _knownNodes.Add(element);
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
             AddElementsRecursive(child);
     }
 
@@ -912,15 +912,15 @@ public sealed partial class DomBridge
         _jsObjectCache.Remove(element);
         _styleSheetCache.Remove(element);
 
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
             RemoveElementsRecursive(child);
     }
 
     private void NormalizeNode(DomElement node)
     {
-        for (var index = 0; index < node.Children.Count;)
+        for (var index = 0; index < node.ChildNodes.Count;)
         {
-            var child = node.Children[index];
+            var child = ChildAt(node, index);
             if (!IsText(child))
             {
                 NormalizeNode(child);
@@ -930,9 +930,9 @@ public sealed partial class DomBridge
 
             var mergedText = child.TextContent ?? string.Empty;
             var nextIndex = index + 1;
-            while (nextIndex < node.Children.Count && IsText(node.Children[nextIndex]))
+            while (nextIndex < node.ChildNodes.Count && IsText(ChildAt(node, nextIndex)))
             {
-                mergedText += node.Children[nextIndex].TextContent ?? string.Empty;
+                mergedText += ChildAt(node, nextIndex).TextContent ?? string.Empty;
                 RemoveChildAt(node, nextIndex);
             }
 
@@ -949,12 +949,12 @@ public sealed partial class DomBridge
 
     private void RemoveChildAt(DomElement parent, int index)
     {
-        if (index < 0 || index >= parent.Children.Count)
+        if (index < 0 || index >= parent.ChildNodes.Count)
             return;
 
-        var child = parent.Children[index];
+        var child = ChildAt(parent, index);
         NotifyNodeIteratorPreRemoval(child);
-        parent.Children.RemoveAt(index);
+        RemoveNthChild(parent, index);
         SetParent(child, null);
         InvalidateStyleScope(parent);
         NotifyChildRemoved(parent, child, index);
@@ -975,14 +975,14 @@ public sealed partial class DomBridge
 
         if (!AttributeMapsAreEqual(AttributeSnapshot(first), AttributeSnapshot(second)) ||
             !NamespaceAttributeMapsAreEqual(first.NsAttrMap, second.NsAttrMap) ||
-            first.Children.Count != second.Children.Count)
+            first.ChildNodes.Count != second.ChildNodes.Count)
         {
             return false;
         }
 
-        for (var index = 0; index < first.Children.Count; index++)
+        for (var index = 0; index < first.ChildNodes.Count; index++)
         {
-            if (!NodesAreEqual(first.Children[index], second.Children[index]))
+            if (!NodesAreEqual(ChildAt(first, index), ChildAt(second, index)))
                 return false;
         }
 
@@ -1044,18 +1044,18 @@ public sealed partial class DomBridge
             case "beforebegin":
                 if (ParentEl(element) == null)
                     ThrowDOMException(_jsContext!, "Cannot insert adjacent content without a parent node.", "NoModificationAllowedError");
-                return (ParentEl(element)!, ParentEl(element)!.Children.IndexOf(element));
+                return (ParentEl(element)!, ChildIndexOf(ParentEl(element)!, element));
             case "afterbegin":
                 return (element, 0);
             case "beforeend":
-                return (element, element.Children.Count);
+                return (element, element.ChildNodes.Count);
             case "afterend":
                 if (ParentEl(element) == null)
                     ThrowDOMException(_jsContext!, "Cannot insert adjacent content without a parent node.", "NoModificationAllowedError");
-                return (ParentEl(element)!, ParentEl(element)!.Children.IndexOf(element) + 1);
+                return (ParentEl(element)!, ChildIndexOf(ParentEl(element)!, element) + 1);
             default:
                 ThrowDOMException(_jsContext!, $"'{position}' is not a valid insertion position.", "SyntaxError");
-                return (element, element.Children.Count);
+                return (element, element.ChildNodes.Count);
         }
     }
 
@@ -1066,27 +1066,27 @@ public sealed partial class DomBridge
 
         if (index < 0)
             index = 0;
-        if (index > parent.Children.Count)
-            index = parent.Children.Count;
+        if (index > parent.ChildNodes.Count)
+            index = parent.ChildNodes.Count;
 
         if (ParentEl(node) != null)
         {
             var oldParent = ParentEl(node);
-            var oldIndex = oldParent.Children.IndexOf(node);
+            var oldIndex = ChildIndexOf(oldParent, node);
             if (oldIndex >= 0)
             {
                 if (ReferenceEquals(oldParent, parent) && oldIndex < index)
                     index--;
 
                 NotifyNodeIteratorPreRemoval(node);
-                oldParent.Children.RemoveAt(oldIndex);
+                RemoveNthChild(oldParent, oldIndex);
                 NotifyChildRemoved(oldParent, node, oldIndex);
             }
         }
 
         SetParent(node, parent);
         AdoptSubtreeIntoDocument(node, GetElementRuntimeState(parent).OwnerDocRoot);
-        parent.Children.Insert(index, node);
+        InsertChildAt(parent, index, node);
         InvalidateStyleScope(parent);
         NotifyChildAdded(parent, node, index);
 
@@ -1106,9 +1106,9 @@ public sealed partial class DomBridge
         if (!TryBuildInnerHtmlFragmentContainer(contextElement, html, out var fragmentContainer))
             return nodes;
 
-        foreach (var child in fragmentContainer.Children.ToArray())
+        foreach (var child in ChildElements(fragmentContainer).ToArray())
         {
-            fragmentContainer.Children.Remove(child);
+            RemoveChildFrom(fragmentContainer, child);
             SetParent(child, null);
             AddElementsRecursive(child);
             nodes.Add(child);
@@ -1130,7 +1130,7 @@ public sealed partial class DomBridge
                 {
                     if (string.Equals(candidateNode.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase))
                     {
-                        foreach (var fragmentChild in candidateNode.Children.ToArray())
+                        foreach (var fragmentChild in ChildElements(candidateNode).ToArray())
                             nodes.Add(fragmentChild);
                         continue;
                     }
@@ -1163,19 +1163,19 @@ public sealed partial class DomBridge
             return;
         }
 
-        foreach (var child in element.Children.ToArray())
+        foreach (var child in ChildElements(element).ToArray())
             RemoveElementsRecursive(child);
 
-        element.Children.Clear();
+        ClearChildren(element);
 
         if (!string.IsNullOrEmpty(html) &&
             TryBuildInnerHtmlFragmentContainer(element, html, out var fragmentContainer))
         {
-            foreach (var child in fragmentContainer.Children.ToArray())
+            foreach (var child in ChildElements(fragmentContainer).ToArray())
             {
                 SetParent(child, element);
                 AdoptSubtreeIntoDocument(child, GetElementRuntimeState(element).OwnerDocRoot);
-                element.Children.Add(child);
+                element.AppendChild(child);
                 AddElementsRecursive(child);
             }
         }
@@ -1192,12 +1192,12 @@ public sealed partial class DomBridge
         if (parent == null)
             return;
 
-        var index = parent.Children.IndexOf(element);
+        var index = ChildIndexOf(parent, element);
         if (index < 0)
             return;
 
-        var previousSibling = index > 0 ? parent.Children[index - 1] : null;
-        var nextSibling = index + 1 < parent.Children.Count ? parent.Children[index + 1] : null;
+        var previousSibling = index > 0 ? ChildAt(parent, index - 1) : null;
+        var nextSibling = index + 1 < parent.ChildNodes.Count ? ChildAt(parent, index + 1) : null;
 
         DomElement? parsedContainer = null;
         if (!string.IsNullOrEmpty(html))
@@ -1210,18 +1210,18 @@ public sealed partial class DomBridge
         }
 
         NotifyNodeIteratorPreRemoval(element);
-        parent.Children.RemoveAt(index);
+        RemoveNthChild(parent, index);
         SetParent(element, null);
         NotifyChildRemoved(parent, element, index, previousSibling, nextSibling);
 
         if (parsedContainer != null)
         {
             var insertIndex = index;
-            foreach (var child in parsedContainer.Children.ToArray())
+            foreach (var child in ChildElements(parsedContainer).ToArray())
             {
                 SetParent(child, parent);
                 AdoptSubtreeIntoDocument(child, GetElementRuntimeState(parent).OwnerDocRoot);
-                parent.Children.Insert(insertIndex, child);
+                InsertChildAt(parent, insertIndex, child);
                 AddElementsRecursive(child);
                 NotifyChildAdded(parent, child, insertIndex);
                 insertIndex++;
@@ -1248,7 +1248,7 @@ public sealed partial class DomBridge
 
     private static DomElement? FindFirstElementByTag(DomElement root, string tag)
     {
-        foreach (var child in root.Children)
+        foreach (var child in ChildElements(root))
         {
             if (!IsText(child) && string.Equals(child.TagName, tag, StringComparison.OrdinalIgnoreCase))
                 return child;
@@ -1289,7 +1289,7 @@ public sealed partial class DomBridge
             var xdoc = System.Xml.Linq.XDocument.Parse(cleanXml);
             if (xdoc.Root == null)
             {
-                containerElement.Children.Insert(0, docRoot);
+                InsertChildAt(containerElement, 0, docRoot);
                 _knownNodes.Add(docRoot);
                 return docRoot;
             }
@@ -1310,9 +1310,9 @@ public sealed partial class DomBridge
             // Build DOM tree from XML
             var rootEl = BuildDomElementFromXElement(xdoc.Root);
             SetParent(rootEl, docRoot);
-            docRoot.Children.Add(rootEl);
+            docRoot.AppendChild(rootEl);
 
-            containerElement.Children.Insert(0, docRoot);
+            InsertChildAt(containerElement, 0, docRoot);
             _knownNodes.Add(docRoot);
             _knownNodes.Add(rootEl);
 
@@ -1325,7 +1325,7 @@ public sealed partial class DomBridge
         catch (System.Xml.XmlException)
         {
             // XML well-formedness error — return empty document, don't execute scripts
-            containerElement.Children.Insert(0, docRoot);
+            InsertChildAt(containerElement, 0, docRoot);
             _knownNodes.Add(docRoot);
         }
 
@@ -1352,7 +1352,7 @@ public sealed partial class DomBridge
             {
                 var childEl = BuildDomElementFromXElement(childXe);
                 SetParent(childEl, el);
-                el.Children.Add(childEl);
+                el.AppendChild(childEl);
                 _knownNodes.Add(childEl);
             }
             else if (child is System.Xml.Linq.XText childText)
@@ -1360,7 +1360,7 @@ public sealed partial class DomBridge
                 var textNode = new DomElement("#text", null, null, string.Empty, isTextNode: true);
                 textNode.TextContent = childText.Value;
                 SetParent(textNode, el);
-                el.Children.Add(textNode);
+                el.AppendChild(textNode);
                 _knownNodes.Add(textNode);
             }
         }
@@ -1406,7 +1406,7 @@ public sealed partial class DomBridge
             return;
         }
 
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
             CollectScriptContent(child, scripts);
     }
 
@@ -1419,7 +1419,7 @@ public sealed partial class DomBridge
             return element.TextContent ?? string.Empty;
 
         var sb = new StringBuilder();
-        foreach (var child in element.Children)
+        foreach (var child in ChildElements(element))
             sb.Append(GetTextContentRecursive(child));
         return sb.ToString();
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -379,8 +379,8 @@ public sealed partial class DomBridge
     private JSObject? GetParentWindowForSubDocument(DomElement containerElement)
     {
         var ownerDocRoot = GetElementRuntimeState(containerElement).OwnerDocRoot;
-        if (ownerDocRoot?.Parent != null && !ownerDocRoot.Parent.TagName.StartsWith("#", StringComparison.Ordinal))
-            return GetOrCreateSubWindow(ownerDocRoot.Parent);
+        if (ownerDocRoot != null && ParentEl(ownerDocRoot) != null && !ParentEl(ownerDocRoot).TagName.StartsWith("#", StringComparison.Ordinal))
+            return GetOrCreateSubWindow(ParentEl(ownerDocRoot));
 
         return _windowJSObject;
     }
@@ -388,9 +388,9 @@ public sealed partial class DomBridge
     private string GetInheritedSubDocumentBaseUrl(DomElement containerElement)
     {
         var ownerDocRoot = GetElementRuntimeState(containerElement).OwnerDocRoot;
-        if (ownerDocRoot?.Parent != null &&
-            !ownerDocRoot.Parent.TagName.StartsWith("#", StringComparison.Ordinal) &&
-            _subDocumentBaseUrlCache.TryGetValue(ownerDocRoot.Parent, out var parentBaseUrl) &&
+        if (ownerDocRoot != null && ParentEl(ownerDocRoot) != null &&
+            !ParentEl(ownerDocRoot).TagName.StartsWith("#", StringComparison.Ordinal) &&
+            _subDocumentBaseUrlCache.TryGetValue(ParentEl(ownerDocRoot), out var parentBaseUrl) &&
             !string.IsNullOrWhiteSpace(parentBaseUrl))
         {
             return parentBaseUrl;
@@ -573,18 +573,18 @@ public sealed partial class DomBridge
     private DomElement BuildEmptySubDocument(DomElement containerElement)
     {
         var docRoot = new DomElement("#subdoc-root", null, null, string.Empty);
-        docRoot.Parent = containerElement;
+        SetParent(docRoot, containerElement);
 
         var htmlEl = new DomElement("html", null, null, string.Empty);
-        htmlEl.Parent = docRoot;
+        SetParent(htmlEl, docRoot);
         docRoot.Children.Add(htmlEl);
 
         var headEl = new DomElement("head", null, null, string.Empty);
-        headEl.Parent = htmlEl;
+        SetParent(headEl, htmlEl);
         htmlEl.Children.Add(headEl);
 
         var bodyEl = new DomElement("body", null, null, string.Empty);
-        bodyEl.Parent = htmlEl;
+        SetParent(bodyEl, htmlEl);
         htmlEl.Children.Add(bodyEl);
 
         containerElement.Children.Insert(0, docRoot);
@@ -603,28 +603,28 @@ public sealed partial class DomBridge
     private DomElement BuildSubDocumentWithText(string textContent, DomElement containerElement)
     {
         var docRoot = new DomElement("#subdoc-root", null, null, string.Empty);
-        docRoot.Parent = containerElement;
+        SetParent(docRoot, containerElement);
 
         var htmlEl = new DomElement("html", null, null, string.Empty);
-        htmlEl.Parent = docRoot;
+        SetParent(htmlEl, docRoot);
         docRoot.Children.Add(htmlEl);
 
         var headEl = new DomElement("head", null, null, string.Empty);
-        headEl.Parent = htmlEl;
+        SetParent(headEl, htmlEl);
         htmlEl.Children.Add(headEl);
 
         var bodyEl = new DomElement("body", null, null, string.Empty);
-        bodyEl.Parent = htmlEl;
+        SetParent(bodyEl, htmlEl);
         htmlEl.Children.Add(bodyEl);
 
         // Wrap text content in <pre> element
         var preEl = new DomElement("pre", null, null, string.Empty);
-        preEl.Parent = bodyEl;
+        SetParent(preEl, bodyEl);
         bodyEl.Children.Add(preEl);
 
         var textNode = new DomElement("#text", null, null, string.Empty, isTextNode: true);
         textNode.TextContent = textContent;
-        textNode.Parent = preEl;
+        SetParent(textNode, preEl);
         preEl.Children.Add(textNode);
 
         containerElement.Children.Insert(0, docRoot);
@@ -867,14 +867,14 @@ public sealed partial class DomBridge
     private DomElement BuildSubDocumentFromHtml(string html, DomElement containerElement)
     {
         var docRoot = new DomElement("#subdoc-root", null, null, string.Empty);
-        docRoot.Parent = containerElement;
+        SetParent(docRoot, containerElement);
 
         var builder = new HtmlTreeBuilder();
         var (parsedRoot, allElements, _) = builder.Build(html, _document);
 
         // parsedRoot is the <html> element itself (HtmlTreeBuilder returns it directly).
         // Move it under #subdoc-root as the documentElement.
-        parsedRoot.Parent = docRoot;
+        SetParent(parsedRoot, docRoot);
         docRoot.Children.Add(parsedRoot);
 
         containerElement.Children.Insert(0, docRoot);
@@ -955,7 +955,7 @@ public sealed partial class DomBridge
         var child = parent.Children[index];
         NotifyNodeIteratorPreRemoval(child);
         parent.Children.RemoveAt(index);
-        child.Parent = null;
+        SetParent(child, null);
         InvalidateStyleScope(parent);
         NotifyChildRemoved(parent, child, index);
     }
@@ -1042,17 +1042,17 @@ public sealed partial class DomBridge
         switch (position)
         {
             case "beforebegin":
-                if (element.Parent == null)
+                if (ParentEl(element) == null)
                     ThrowDOMException(_jsContext!, "Cannot insert adjacent content without a parent node.", "NoModificationAllowedError");
-                return (element.Parent!, element.Parent!.Children.IndexOf(element));
+                return (ParentEl(element)!, ParentEl(element)!.Children.IndexOf(element));
             case "afterbegin":
                 return (element, 0);
             case "beforeend":
                 return (element, element.Children.Count);
             case "afterend":
-                if (element.Parent == null)
+                if (ParentEl(element) == null)
                     ThrowDOMException(_jsContext!, "Cannot insert adjacent content without a parent node.", "NoModificationAllowedError");
-                return (element.Parent!, element.Parent!.Children.IndexOf(element) + 1);
+                return (ParentEl(element)!, ParentEl(element)!.Children.IndexOf(element) + 1);
             default:
                 ThrowDOMException(_jsContext!, $"'{position}' is not a valid insertion position.", "SyntaxError");
                 return (element, element.Children.Count);
@@ -1069,9 +1069,9 @@ public sealed partial class DomBridge
         if (index > parent.Children.Count)
             index = parent.Children.Count;
 
-        if (node.Parent != null)
+        if (ParentEl(node) != null)
         {
-            var oldParent = node.Parent;
+            var oldParent = ParentEl(node);
             var oldIndex = oldParent.Children.IndexOf(node);
             if (oldIndex >= 0)
             {
@@ -1084,7 +1084,7 @@ public sealed partial class DomBridge
             }
         }
 
-        node.Parent = parent;
+        SetParent(node, parent);
         AdoptSubtreeIntoDocument(node, GetElementRuntimeState(parent).OwnerDocRoot);
         parent.Children.Insert(index, node);
         InvalidateStyleScope(parent);
@@ -1109,7 +1109,7 @@ public sealed partial class DomBridge
         foreach (var child in fragmentContainer.Children.ToArray())
         {
             fragmentContainer.Children.Remove(child);
-            child.Parent = null;
+            SetParent(child, null);
             AddElementsRecursive(child);
             nodes.Add(child);
         }
@@ -1173,7 +1173,7 @@ public sealed partial class DomBridge
         {
             foreach (var child in fragmentContainer.Children.ToArray())
             {
-                child.Parent = element;
+                SetParent(child, element);
                 AdoptSubtreeIntoDocument(child, GetElementRuntimeState(element).OwnerDocRoot);
                 element.Children.Add(child);
                 AddElementsRecursive(child);
@@ -1188,7 +1188,7 @@ public sealed partial class DomBridge
     {
         html ??= string.Empty;
 
-        var parent = element.Parent;
+        var parent = ParentEl(element);
         if (parent == null)
             return;
 
@@ -1211,7 +1211,7 @@ public sealed partial class DomBridge
 
         NotifyNodeIteratorPreRemoval(element);
         parent.Children.RemoveAt(index);
-        element.Parent = null;
+        SetParent(element, null);
         NotifyChildRemoved(parent, element, index, previousSibling, nextSibling);
 
         if (parsedContainer != null)
@@ -1219,7 +1219,7 @@ public sealed partial class DomBridge
             var insertIndex = index;
             foreach (var child in parsedContainer.Children.ToArray())
             {
-                child.Parent = parent;
+                SetParent(child, parent);
                 AdoptSubtreeIntoDocument(child, GetElementRuntimeState(parent).OwnerDocRoot);
                 parent.Children.Insert(insertIndex, child);
                 AddElementsRecursive(child);
@@ -1273,7 +1273,7 @@ public sealed partial class DomBridge
     private DomElement BuildSubDocumentFromXml(string xmlContent, string contentType, DomElement containerElement)
     {
         var docRoot = new DomElement("#subdoc-root", null, null, string.Empty);
-        docRoot.Parent = containerElement;
+        SetParent(docRoot, containerElement);
 
         try
         {
@@ -1309,7 +1309,7 @@ public sealed partial class DomBridge
 
             // Build DOM tree from XML
             var rootEl = BuildDomElementFromXElement(xdoc.Root);
-            rootEl.Parent = docRoot;
+            SetParent(rootEl, docRoot);
             docRoot.Children.Add(rootEl);
 
             containerElement.Children.Insert(0, docRoot);
@@ -1351,7 +1351,7 @@ public sealed partial class DomBridge
             if (child is System.Xml.Linq.XElement childXe)
             {
                 var childEl = BuildDomElementFromXElement(childXe);
-                childEl.Parent = el;
+                SetParent(childEl, el);
                 el.Children.Add(childEl);
                 _knownNodes.Add(childEl);
             }
@@ -1359,7 +1359,7 @@ public sealed partial class DomBridge
             {
                 var textNode = new DomElement("#text", null, null, string.Empty, isTextNode: true);
                 textNode.TextContent = childText.Value;
-                textNode.Parent = el;
+                SetParent(textNode, el);
                 el.Children.Add(textNode);
                 _knownNodes.Add(textNode);
             }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -378,7 +378,7 @@ public sealed partial class DomBridge
 
     private JSObject? GetParentWindowForSubDocument(DomElement containerElement)
     {
-        var ownerDocRoot = containerElement.OwnerDocRoot;
+        var ownerDocRoot = GetElementRuntimeState(containerElement).OwnerDocRoot;
         if (ownerDocRoot?.Parent != null && !ownerDocRoot.Parent.TagName.StartsWith("#", StringComparison.Ordinal))
             return GetOrCreateSubWindow(ownerDocRoot.Parent);
 
@@ -387,7 +387,7 @@ public sealed partial class DomBridge
 
     private string GetInheritedSubDocumentBaseUrl(DomElement containerElement)
     {
-        var ownerDocRoot = containerElement.OwnerDocRoot;
+        var ownerDocRoot = GetElementRuntimeState(containerElement).OwnerDocRoot;
         if (ownerDocRoot?.Parent != null &&
             !ownerDocRoot.Parent.TagName.StartsWith("#", StringComparison.Ordinal) &&
             _subDocumentBaseUrlCache.TryGetValue(ownerDocRoot.Parent, out var parentBaseUrl) &&
@@ -1085,7 +1085,7 @@ public sealed partial class DomBridge
         }
 
         node.Parent = parent;
-        AdoptSubtreeIntoDocument(node, parent.OwnerDocRoot);
+        AdoptSubtreeIntoDocument(node, GetElementRuntimeState(parent).OwnerDocRoot);
         parent.Children.Insert(index, node);
         InvalidateStyleScope(parent);
         NotifyChildAdded(parent, node, index);
@@ -1174,7 +1174,7 @@ public sealed partial class DomBridge
             foreach (var child in fragmentContainer.Children.ToArray())
             {
                 child.Parent = element;
-                AdoptSubtreeIntoDocument(child, element.OwnerDocRoot);
+                AdoptSubtreeIntoDocument(child, GetElementRuntimeState(element).OwnerDocRoot);
                 element.Children.Add(child);
                 AddElementsRecursive(child);
             }
@@ -1220,7 +1220,7 @@ public sealed partial class DomBridge
             foreach (var child in parsedContainer.Children.ToArray())
             {
                 child.Parent = parent;
-                AdoptSubtreeIntoDocument(child, parent.OwnerDocRoot);
+                AdoptSubtreeIntoDocument(child, GetElementRuntimeState(parent).OwnerDocRoot);
                 parent.Children.Insert(insertIndex, child);
                 AddElementsRecursive(child);
                 NotifyChildAdded(parent, child, insertIndex);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -368,12 +368,12 @@ public sealed partial class DomBridge
         if (docRoot == null)
             return null;
 
-        return docRoot.Children.FirstOrDefault(c => !c.IsTextNode && !c.TagName.StartsWith("#"));
+        return docRoot.Children.FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith("#"));
     }
 
     private static DomElement? FindBodyElement(DomElement documentElement) =>
         documentElement.Children.FirstOrDefault(c =>
-            !c.IsTextNode &&
+            !IsText(c) &&
             string.Equals(c.TagName, "body", StringComparison.OrdinalIgnoreCase));
 
     private JSObject? GetParentWindowForSubDocument(DomElement containerElement)
@@ -921,7 +921,7 @@ public sealed partial class DomBridge
         for (var index = 0; index < node.Children.Count;)
         {
             var child = node.Children[index];
-            if (!child.IsTextNode)
+            if (!IsText(child))
             {
                 NormalizeNode(child);
                 index++;
@@ -930,7 +930,7 @@ public sealed partial class DomBridge
 
             var mergedText = child.TextContent ?? string.Empty;
             var nextIndex = index + 1;
-            while (nextIndex < node.Children.Count && node.Children[nextIndex].IsTextNode)
+            while (nextIndex < node.Children.Count && IsText(node.Children[nextIndex]))
             {
                 mergedText += node.Children[nextIndex].TextContent ?? string.Empty;
                 RemoveChildAt(node, nextIndex);
@@ -965,7 +965,7 @@ public sealed partial class DomBridge
         if (ReferenceEquals(first, second))
             return true;
 
-        if (first.IsTextNode != second.IsTextNode ||
+        if (IsText(first) != IsText(second) ||
             !string.Equals(first.TagName, second.TagName, StringComparison.Ordinal) ||
             !string.Equals(first.NamespaceURI, second.NamespaceURI, StringComparison.Ordinal) ||
             !string.Equals(first.TextContent ?? string.Empty, second.TextContent ?? string.Empty, StringComparison.Ordinal))
@@ -1157,7 +1157,7 @@ public sealed partial class DomBridge
         element.InnerHtml = html;
         element.TextContent = null;
 
-        if (element.IsTextNode)
+        if (IsText(element))
         {
             element.TextContent = html;
             return;
@@ -1250,7 +1250,7 @@ public sealed partial class DomBridge
     {
         foreach (var child in root.Children)
         {
-            if (!child.IsTextNode && string.Equals(child.TagName, tag, StringComparison.OrdinalIgnoreCase))
+            if (!IsText(child) && string.Equals(child.TagName, tag, StringComparison.OrdinalIgnoreCase))
                 return child;
 
             var match = FindFirstElementByTag(child, tag);
@@ -1415,7 +1415,7 @@ public sealed partial class DomBridge
     /// </summary>
     private static string GetTextContentRecursive(DomElement element)
     {
-        if (element.IsTextNode)
+        if (IsText(element))
             return element.TextContent ?? string.Empty;
 
         var sb = new StringBuilder();

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -49,7 +49,7 @@ public sealed partial class DomBridge
         var tag = element.TagName?.ToLowerInvariant();
         if (tag != "iframe" && tag != "object") return;
 
-        var hasSrcDoc = tag == "iframe" && element.Attributes.ContainsKey("srcdoc");
+        var hasSrcDoc = tag == "iframe" && HasAttr(element, "srcdoc");
         var resourceUrl = hasSrcDoc ? "about:srcdoc" : GetSubResourceUrl(element);
         if (string.IsNullOrWhiteSpace(resourceUrl) && !hasSrcDoc) return;
 
@@ -139,7 +139,7 @@ public sealed partial class DomBridge
         if (docRoot == null)
         {
             if (string.Equals(containerElement.TagName, "iframe", StringComparison.OrdinalIgnoreCase) &&
-                containerElement.Attributes.TryGetValue("srcdoc", out var srcDoc))
+                TryGetAttribute(containerElement, "srcdoc", out var srcDoc))
             {
                 _subDocumentLocationCache[containerElement] = "about:srcdoc";
                 _subDocumentBaseUrlCache[containerElement] = GetInheritedSubDocumentBaseUrl(containerElement);
@@ -339,7 +339,7 @@ public sealed partial class DomBridge
         }
 
         if (string.Equals(containerElement.TagName, "iframe", StringComparison.OrdinalIgnoreCase) &&
-            containerElement.Attributes.ContainsKey("srcdoc"))
+            HasAttr(containerElement, "srcdoc"))
             return "about:srcdoc";
 
         var resolvedUrl = ResolveSubResourceUrl(GetSubResourceUrl(containerElement), GetInheritedSubDocumentBaseUrl(containerElement));
@@ -645,9 +645,9 @@ public sealed partial class DomBridge
     {
         var tag = containerElement.TagName?.ToLowerInvariant();
         if (tag == "iframe")
-            return containerElement.Attributes.TryGetValue("src", out var src) ? src : string.Empty;
+            return TryGetAttribute(containerElement, "src", out var src) ? src : string.Empty;
         if (tag == "object")
-            return containerElement.Attributes.TryGetValue("data", out var data) ? data : string.Empty;
+            return TryGetAttribute(containerElement, "data", out var data) ? data : string.Empty;
         return string.Empty;
     }
 
@@ -973,7 +973,7 @@ public sealed partial class DomBridge
             return false;
         }
 
-        if (!AttributeMapsAreEqual(first.Attributes, second.Attributes) ||
+        if (!AttributeMapsAreEqual(AttributeSnapshot(first), AttributeSnapshot(second)) ||
             !NamespaceAttributeMapsAreEqual(first.NsAttrMap, second.NsAttrMap) ||
             first.Children.Count != second.Children.Count)
         {
@@ -1343,7 +1343,7 @@ public sealed partial class DomBridge
         foreach (var attr in xe.Attributes())
         {
             if (!attr.IsNamespaceDeclaration)
-                el.Attributes[attr.Name.LocalName] = attr.Value;
+                SetAttr(el, attr.Name.LocalName, attr.Value);
         }
 
         foreach (var child in xe.Nodes())

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
@@ -523,7 +523,7 @@ public sealed partial class DomBridge
         if (ReferenceEquals(startContainer, endContainer))
         {
             // Same container
-            if (startContainer.IsTextNode)
+            if (IsText(startContainer))
             {
                 var text = startContainer.TextContent ?? string.Empty;
                 var s = Math.Max(0, Math.Min(startOffset, text.Length));
@@ -540,7 +540,7 @@ public sealed partial class DomBridge
         }
 
         // Start container: collect from startOffset to end
-        if (startContainer.IsTextNode)
+        if (IsText(startContainer))
         {
             var text = startContainer.TextContent ?? string.Empty;
             if (startOffset < text.Length)
@@ -568,7 +568,7 @@ public sealed partial class DomBridge
                     if (IsDescendant(startContainer, node) || IsDescendant(endContainer, node))
                         continue;
                     // Only collect from top-level nodes
-                    if (node.IsTextNode)
+                    if (IsText(node))
                         sb.Append(node.TextContent ?? string.Empty);
                     else if (node.Children.Count == 0)
                         continue; // element with no text children
@@ -578,7 +578,7 @@ public sealed partial class DomBridge
         }
 
         // End container: collect from 0 to endOffset
-        if (endContainer.IsTextNode)
+        if (IsText(endContainer))
         {
             // Don't include end container text for Range.toString()
             // (end boundary is exclusive for text)
@@ -722,7 +722,7 @@ public sealed partial class DomBridge
         DomElement node,
         List<(double Left, double Top, double Width, double Height)> rects)
     {
-        if (node.IsTextNode || string.Equals(node.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsText(node) || string.Equals(node.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
             return;
 
         var display = GetComputedProps(node).GetValueOrDefault("display");
@@ -806,7 +806,7 @@ public sealed partial class DomBridge
             if (i == 0)
             {
                 // This is the startContainer level
-                if (original.IsTextNode)
+                if (IsText(original))
                 {
                     var text = original.TextContent ?? string.Empty;
                     var extractedPart = text.Substring(startOffset);
@@ -889,7 +889,7 @@ public sealed partial class DomBridge
             if (i == 0)
             {
                 // This is the endContainer level
-                if (original.IsTextNode)
+                if (IsText(original))
                 {
                     var text = original.TextContent ?? string.Empty;
                     var extractedPart = text.Substring(0, endOffset);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
@@ -138,15 +138,15 @@ public sealed partial class DomBridge
     {
         while (node != null && !ReferenceEquals(node, root))
         {
-            if (node.Parent != null)
+            if (ParentEl(node) != null)
             {
-                var siblings = node.Parent.Children;
+                var siblings = ParentEl(node).Children;
                 var idx = siblings.IndexOf(node);
                 if (idx >= 0 && idx + 1 < siblings.Count)
                     return siblings[idx + 1];
             }
-            if (node.Parent != null)
-                node = node.Parent;
+            if (ParentEl(node) != null)
+                node = ParentEl(node);
             else
                 return null;
         }
@@ -183,8 +183,8 @@ public sealed partial class DomBridge
         var sibling = node;
         while (true)
         {
-            if (sibling.Parent == null || ReferenceEquals(sibling, root)) return JSNull.Value;
-            var siblings = sibling.Parent.Children;
+            if (ParentEl(sibling) == null || ReferenceEquals(sibling, root)) return JSNull.Value;
+            var siblings = ParentEl(sibling).Children;
             var idx = siblings.IndexOf(sibling);
             var target = next ? (idx + 1 < siblings.Count ? siblings[idx + 1] : null) : (idx > 0 ? siblings[idx - 1] : null);
             if (target != null)
@@ -200,7 +200,7 @@ public sealed partial class DomBridge
                 continue;
             }
             // No more siblings — move up (DOM spec steps 3.3-3.5)
-            sibling = sibling.Parent;
+            sibling = ParentEl(sibling);
             if (sibling == null || ReferenceEquals(sibling, root)) return JSNull.Value;
             // Per spec: if filter accepts parent, return null
             // (the parent is a "real" node, so don't skip over it)
@@ -212,8 +212,8 @@ public sealed partial class DomBridge
     /// <summary>Helper: get next/previous sibling, or null if past boundaries.</summary>
     private static DomElement? GetSiblingInDirection(DomElement node, bool forward, DomElement boundary)
     {
-        if (node.Parent == null || ReferenceEquals(node, boundary)) return null;
-        var siblings = node.Parent.Children;
+        if (ParentEl(node) == null || ReferenceEquals(node, boundary)) return null;
+        var siblings = ParentEl(node).Children;
         var idx = siblings.IndexOf(node);
         if (forward && idx + 1 < siblings.Count) return siblings[idx + 1];
         if (!forward && idx > 0) return siblings[idx - 1];
@@ -468,13 +468,13 @@ public sealed partial class DomBridge
         while (current != null)
         {
             ancestors.Add(current);
-            current = current.Parent;
+            current = ParentEl(current);
         }
         current = b;
         while (current != null)
         {
             if (ancestors.Contains(current)) return current;
-            current = current.Parent;
+            current = ParentEl(current);
         }
         return null;
     }
@@ -602,7 +602,7 @@ public sealed partial class DomBridge
         while (node != null && !ReferenceEquals(node, commonAncestor))
         {
             chain.Add(node);
-            node = node.Parent;
+            node = ParentEl(node);
         }
         if (chain.Count == 0) return null;
 
@@ -629,7 +629,7 @@ public sealed partial class DomBridge
             if (topClone == null) topClone = clone;
             if (currentParent != null)
             {
-                clone.Parent = currentParent;
+                SetParent(clone, currentParent);
                 currentParent.Children.Add(clone);
             }
 
@@ -641,14 +641,14 @@ public sealed partial class DomBridge
                 if (isStart)
                 {
                     // Include the extracted text + remaining siblings
-                    extractedTextNode.Parent = clone;
+                    SetParent(extractedTextNode, clone);
                     clone.Children.Add(extractedTextNode);
                     // Move siblings after the text node into the clone
                     for (var j = childIdx + 1; j < original.Children.Count; )
                     {
                         var sibling = original.Children[j];
                         original.Children.RemoveAt(j);
-                        sibling.Parent = clone;
+                        SetParent(sibling, clone);
                         clone.Children.Add(sibling);
                     }
                 }
@@ -660,10 +660,10 @@ public sealed partial class DomBridge
                         var sibling = original.Children[0];
                         original.Children.RemoveAt(0);
                         childIdx--;
-                        sibling.Parent = clone;
+                        SetParent(sibling, clone);
                         clone.Children.Add(sibling);
                     }
-                    extractedTextNode.Parent = clone;
+                    SetParent(extractedTextNode, clone);
                     clone.Children.Add(extractedTextNode);
                 }
             }
@@ -776,7 +776,7 @@ public sealed partial class DomBridge
         {
             chain.Add(node);
             if (ReferenceEquals(node, topNode)) break;
-            node = node.Parent;
+            node = ParentEl(node);
         }
 
         // Pass 1: Clone the ancestor chain from top to bottom, creating
@@ -790,7 +790,7 @@ public sealed partial class DomBridge
             clones[i] = clone;
             if (i < chain.Count - 1)
             {
-                clone.Parent = clones[i + 1];
+                SetParent(clone, clones[i + 1]);
                 // Will position correctly in Pass 2
             }
         }
@@ -819,7 +819,7 @@ public sealed partial class DomBridge
                     {
                         var child = original.Children[ci];
                         original.Children.RemoveAt(ci);
-                        child.Parent = clone;
+                        SetParent(child, clone);
                         clone.Children.Add(child);
                     }
                 }
@@ -830,7 +830,7 @@ public sealed partial class DomBridge
                 var childClone = clones[i - 1]; // next-in-chain clone
 
                 // First add the deeper clone (already populated from previous iterations)
-                childClone.Parent = parentClone;
+                SetParent(childClone, parentClone);
                 parentClone.Children.Add(childClone);
 
                 // Then move siblings after the chain child in the original
@@ -842,7 +842,7 @@ public sealed partial class DomBridge
                     {
                         var child = original.Children[ci];
                         original.Children.RemoveAt(ci);
-                        child.Parent = parentClone;
+                        SetParent(child, parentClone);
                         parentClone.Children.Add(child);
                     }
                 }
@@ -866,7 +866,7 @@ public sealed partial class DomBridge
         {
             chain.Add(node);
             if (ReferenceEquals(node, topNode)) break;
-            node = node.Parent;
+            node = ParentEl(node);
         }
 
         // Pass 1: Create clones for the chain
@@ -902,7 +902,7 @@ public sealed partial class DomBridge
                     {
                         var child = original.Children[0];
                         original.Children.RemoveAt(0);
-                        child.Parent = clone;
+                        SetParent(child, clone);
                         clone.Children.Add(child);
                     }
                 }
@@ -922,13 +922,13 @@ public sealed partial class DomBridge
                         var child = original.Children[0];
                         original.Children.RemoveAt(0);
                         childIdx--;
-                        child.Parent = parentClone;
+                        SetParent(child, parentClone);
                         parentClone.Children.Add(child);
                     }
                 }
 
                 // Then add the deeper clone (already populated)
-                childClone.Parent = parentClone;
+                SetParent(childClone, parentClone);
                 parentClone.Children.Add(childClone);
             }
         }
@@ -996,11 +996,11 @@ public sealed partial class DomBridge
 
         private static bool IsDescendantOf(DomElement node, DomElement potentialAncestor)
         {
-            var current = node.Parent;
+            var current = ParentEl(node);
             while (current != null)
             {
                 if (ReferenceEquals(current, potentialAncestor)) return true;
-                current = current.Parent;
+                current = ParentEl(current);
             }
             return false;
         }
@@ -1242,14 +1242,14 @@ public sealed partial class DomBridge
             var current = node;
             while (current != null && !ReferenceEquals(current, root))
             {
-                if (current.Parent != null)
+                if (ParentEl(current) != null)
                 {
-                    var siblings = current.Parent.Children;
+                    var siblings = ParentEl(current).Children;
                     var idx = siblings.IndexOf(current);
                     if (idx >= 0 && idx + 1 < siblings.Count)
                         return siblings[idx + 1];
                 }
-                current = current.Parent;
+                current = ParentEl(current);
             }
             return null;
         }
@@ -1260,8 +1260,8 @@ public sealed partial class DomBridge
         /// </summary>
         private static DomElement? GetPreviousNodeBefore(DomElement node, DomElement root)
         {
-            if (node.Parent == null) return null;
-            var siblings = node.Parent.Children;
+            if (ParentEl(node) == null) return null;
+            var siblings = ParentEl(node).Children;
             var idx = siblings.IndexOf(node);
             if (idx > 0)
             {
@@ -1272,18 +1272,18 @@ public sealed partial class DomBridge
                 return prev;
             }
             // No previous sibling — parent is the previous node (unless it's root)
-            if (!ReferenceEquals(node.Parent, root))
-                return node.Parent;
+            if (!ReferenceEquals(ParentEl(node), root))
+                return ParentEl(node);
             return null;
         }
 
         private static bool IsDescendantOf(DomElement node, DomElement potentialAncestor)
         {
-            var current = node.Parent;
+            var current = ParentEl(node);
             while (current != null)
             {
                 if (ReferenceEquals(current, potentialAncestor)) return true;
-                current = current.Parent;
+                current = ParentEl(current);
             }
             return false;
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
@@ -140,7 +140,7 @@ public sealed partial class DomBridge
         {
             if (ParentEl(node) != null)
             {
-                var siblings = ParentEl(node).Children;
+                var siblings = ChildElements(ParentEl(node)).ToList();
                 var idx = siblings.IndexOf(node);
                 if (idx >= 0 && idx + 1 < siblings.Count)
                     return siblings[idx + 1];
@@ -158,15 +158,15 @@ public sealed partial class DomBridge
     /// </summary>
     private JSValue TreeWalkerTraverseChildren(DomElement node, bool first, DomElement root, int whatToShow, JSFunction? filterFn, ref DomElement currentNode)
     {
-        if (node.Children.Count == 0) return JSNull.Value;
-        var child = first ? node.Children[0] : node.Children[^1];
+        if (node.ChildNodes.Count == 0) return JSNull.Value;
+        var child = first ? ChildAt(node, 0) : ChildAt(node, ^1);
         while (child != null)
         {
             var result = ApplyFilter(child, whatToShow, filterFn);
             if (result == 1) { currentNode = child; return ToJSObject(child); }
-            if (result == 3 && child.Children.Count > 0) // SKIP — descend
+            if (result == 3 && child.ChildNodes.Count > 0) // SKIP — descend
             {
-                child = first ? child.Children[0] : child.Children[^1];
+                child = first ? ChildAt(child, 0) : ChildAt(child, ^1);
                 continue;
             }
             // REJECT or SKIP with no children — next/previous sibling
@@ -184,14 +184,14 @@ public sealed partial class DomBridge
         while (true)
         {
             if (ParentEl(sibling) == null || ReferenceEquals(sibling, root)) return JSNull.Value;
-            var siblings = ParentEl(sibling).Children;
+            var siblings = ChildElements(ParentEl(sibling)).ToList();
             var idx = siblings.IndexOf(sibling);
             var target = next ? (idx + 1 < siblings.Count ? siblings[idx + 1] : null) : (idx > 0 ? siblings[idx - 1] : null);
             if (target != null)
             {
                 var result = ApplyFilter(target, whatToShow, filterFn);
                 if (result == 1) { currentNode = target; return ToJSObject(target); }
-                if (result == 3 && target.Children.Count > 0) // SKIP — try children
+                if (result == 3 && target.ChildNodes.Count > 0) // SKIP — try children
                 {
                     var child = TreeWalkerTraverseChildren(target, next, root, whatToShow, filterFn, ref currentNode);
                     if (!child.IsNull) return child;
@@ -213,7 +213,7 @@ public sealed partial class DomBridge
     private static DomElement? GetSiblingInDirection(DomElement node, bool forward, DomElement boundary)
     {
         if (ParentEl(node) == null || ReferenceEquals(node, boundary)) return null;
-        var siblings = ParentEl(node).Children;
+        var siblings = ChildElements(ParentEl(node)).ToList();
         var idx = siblings.IndexOf(node);
         if (forward && idx + 1 < siblings.Count) return siblings[idx + 1];
         if (!forward && idx > 0) return siblings[idx - 1];
@@ -489,8 +489,8 @@ public sealed partial class DomBridge
         if (ReferenceEquals(startContainer, endContainer))
         {
             // Same container — return children between offsets
-            for (var i = startOffset; i < Math.Min(endOffset, startContainer.Children.Count); i++)
-                result.Add(startContainer.Children[i]);
+            for (var i = startOffset; i < Math.Min(endOffset, startContainer.ChildNodes.Count); i++)
+                result.Add(ChildAt(startContainer, i));
             return result;
         }
 
@@ -533,8 +533,8 @@ public sealed partial class DomBridge
             else
             {
                 // Element container — collect text from children between offsets
-                for (var i = startOffset; i < Math.Min(endOffset, startContainer.Children.Count); i++)
-                    CollectTextContent(startContainer.Children[i], sb);
+                for (var i = startOffset; i < Math.Min(endOffset, startContainer.ChildNodes.Count); i++)
+                    CollectTextContent(ChildAt(startContainer, i), sb);
             }
             return;
         }
@@ -548,8 +548,8 @@ public sealed partial class DomBridge
         }
         else
         {
-            for (var i = startOffset; i < startContainer.Children.Count; i++)
-                CollectTextContent(startContainer.Children[i], sb);
+            for (var i = startOffset; i < startContainer.ChildNodes.Count; i++)
+                CollectTextContent(ChildAt(startContainer, i), sb);
         }
 
         // Middle nodes: collect all text from nodes between start and end paths
@@ -570,7 +570,7 @@ public sealed partial class DomBridge
                     // Only collect from top-level nodes
                     if (IsText(node))
                         sb.Append(node.TextContent ?? string.Empty);
-                    else if (node.Children.Count == 0)
+                    else if (node.ChildNodes.Count == 0)
                         continue; // element with no text children
                     // Don't double-collect descendants
                 }
@@ -585,8 +585,8 @@ public sealed partial class DomBridge
         }
         else
         {
-            for (var i = 0; i < Math.Min(endOffset, endContainer.Children.Count); i++)
-                CollectTextContent(endContainer.Children[i], sb);
+            for (var i = 0; i < Math.Min(endOffset, endContainer.ChildNodes.Count); i++)
+                CollectTextContent(ChildAt(endContainer, i), sb);
         }
     }
 
@@ -630,26 +630,26 @@ public sealed partial class DomBridge
             if (currentParent != null)
             {
                 SetParent(clone, currentParent);
-                currentParent.Children.Add(clone);
+                currentParent.AppendChild(clone);
             }
 
             // For start boundary: include siblings after the text node within this element
             // For end boundary: include siblings before the text node within this element
             if (i == 1) // direct parent of text node
             {
-                var childIdx = original.Children.IndexOf(chain[0]);
+                var childIdx = ChildIndexOf(original, chain[0]);
                 if (isStart)
                 {
                     // Include the extracted text + remaining siblings
                     SetParent(extractedTextNode, clone);
-                    clone.Children.Add(extractedTextNode);
+                    clone.AppendChild(extractedTextNode);
                     // Move siblings after the text node into the clone
-                    for (var j = childIdx + 1; j < original.Children.Count; )
+                    for (var j = childIdx + 1; j < original.ChildNodes.Count; )
                     {
-                        var sibling = original.Children[j];
-                        original.Children.RemoveAt(j);
+                        var sibling = ChildAt(original, j);
+                        RemoveNthChild(original, j);
                         SetParent(sibling, clone);
-                        clone.Children.Add(sibling);
+                        clone.AppendChild(sibling);
                     }
                 }
                 else
@@ -657,14 +657,14 @@ public sealed partial class DomBridge
                     // Move siblings before the text node into the clone
                     for (var j = 0; j < childIdx; )
                     {
-                        var sibling = original.Children[0];
-                        original.Children.RemoveAt(0);
+                        var sibling = ChildAt(original, 0);
+                        RemoveNthChild(original, 0);
                         childIdx--;
                         SetParent(sibling, clone);
-                        clone.Children.Add(sibling);
+                        clone.AppendChild(sibling);
                     }
                     SetParent(extractedTextNode, clone);
-                    clone.Children.Add(extractedTextNode);
+                    clone.AppendChild(extractedTextNode);
                 }
             }
             currentParent = clone;
@@ -728,7 +728,7 @@ public sealed partial class DomBridge
         var display = GetComputedProps(node).GetValueOrDefault("display");
         if (string.Equals(display, "contents", StringComparison.OrdinalIgnoreCase))
         {
-            foreach (var child in node.Children)
+            foreach (var child in ChildElements(node))
                 CollectClientRectsForRangeNode(child, rects);
 
             return;
@@ -815,12 +815,12 @@ public sealed partial class DomBridge
                 }
                 else
                 {
-                    for (var ci = startOffset; ci < original.Children.Count; )
+                    for (var ci = startOffset; ci < original.ChildNodes.Count; )
                     {
-                        var child = original.Children[ci];
-                        original.Children.RemoveAt(ci);
+                        var child = ChildAt(original, ci);
+                        RemoveNthChild(original, ci);
                         SetParent(child, clone);
-                        clone.Children.Add(child);
+                        clone.AppendChild(child);
                     }
                 }
             }
@@ -831,19 +831,19 @@ public sealed partial class DomBridge
 
                 // First add the deeper clone (already populated from previous iterations)
                 SetParent(childClone, parentClone);
-                parentClone.Children.Add(childClone);
+                parentClone.AppendChild(childClone);
 
                 // Then move siblings after the chain child in the original
                 var nextInChain = chain[i - 1];
-                var childIdx = original.Children.IndexOf(nextInChain);
+                var childIdx = ChildIndexOf(original, nextInChain);
                 if (childIdx >= 0)
                 {
-                    for (var ci = childIdx + 1; ci < original.Children.Count; )
+                    for (var ci = childIdx + 1; ci < original.ChildNodes.Count; )
                     {
-                        var child = original.Children[ci];
-                        original.Children.RemoveAt(ci);
+                        var child = ChildAt(original, ci);
+                        RemoveNthChild(original, ci);
                         SetParent(child, parentClone);
-                        parentClone.Children.Add(child);
+                        parentClone.AppendChild(child);
                     }
                 }
             }
@@ -898,12 +898,12 @@ public sealed partial class DomBridge
                 }
                 else
                 {
-                    for (var ci = 0; ci < endOffset && original.Children.Count > 0; ci++)
+                    for (var ci = 0; ci < endOffset && original.ChildNodes.Count > 0; ci++)
                     {
-                        var child = original.Children[0];
-                        original.Children.RemoveAt(0);
+                        var child = ChildAt(original, 0);
+                        RemoveNthChild(original, 0);
                         SetParent(child, clone);
-                        clone.Children.Add(child);
+                        clone.AppendChild(child);
                     }
                 }
             }
@@ -914,22 +914,22 @@ public sealed partial class DomBridge
 
                 // First move siblings before the chain child in the original
                 var nextInChain = chain[i - 1];
-                var childIdx = original.Children.IndexOf(nextInChain);
+                var childIdx = ChildIndexOf(original, nextInChain);
                 if (childIdx >= 0)
                 {
                     for (var ci = 0; ci < childIdx; )
                     {
-                        var child = original.Children[0];
-                        original.Children.RemoveAt(0);
+                        var child = ChildAt(original, 0);
+                        RemoveNthChild(original, 0);
                         childIdx--;
                         SetParent(child, parentClone);
-                        parentClone.Children.Add(child);
+                        parentClone.AppendChild(child);
                     }
                 }
 
                 // Then add the deeper clone (already populated)
                 SetParent(childClone, parentClone);
-                parentClone.Children.Add(childClone);
+                parentClone.AppendChild(childClone);
             }
         }
 
@@ -1012,8 +1012,8 @@ public sealed partial class DomBridge
     /// </summary>
     private void NotifyChildAdded(DomElement parent, DomElement addedChild, int index)
     {
-        var previousSibling = index > 0 ? parent.Children[index - 1] : null;
-        var nextSibling = index + 1 < parent.Children.Count ? parent.Children[index + 1] : null;
+        var previousSibling = index > 0 ? ChildAt(parent, index - 1) : null;
+        var nextSibling = index + 1 < parent.ChildNodes.Count ? ChildAt(parent, index + 1) : null;
         NotifyMutationObservers(parent, addedChild, null, previousSibling, nextSibling);
     }
 
@@ -1027,8 +1027,8 @@ public sealed partial class DomBridge
                 _activeRanges.RemoveAt(i); // GC'd — prune
         }
 
-        previousSibling ??= index > 0 ? parent.Children[index - 1] : null;
-        nextSibling ??= index < parent.Children.Count ? parent.Children[index] : null;
+        previousSibling ??= index > 0 ? ChildAt(parent, index - 1) : null;
+        nextSibling ??= index < parent.ChildNodes.Count ? ChildAt(parent, index) : null;
         NotifyMutationObservers(parent, null, removedChild, previousSibling, nextSibling);
     }
 
@@ -1244,7 +1244,7 @@ public sealed partial class DomBridge
             {
                 if (ParentEl(current) != null)
                 {
-                    var siblings = ParentEl(current).Children;
+                    var siblings = ChildElements(ParentEl(current)).ToList();
                     var idx = siblings.IndexOf(current);
                     if (idx >= 0 && idx + 1 < siblings.Count)
                         return siblings[idx + 1];
@@ -1261,14 +1261,14 @@ public sealed partial class DomBridge
         private static DomElement? GetPreviousNodeBefore(DomElement node, DomElement root)
         {
             if (ParentEl(node) == null) return null;
-            var siblings = ParentEl(node).Children;
+            var siblings = ChildElements(ParentEl(node)).ToList();
             var idx = siblings.IndexOf(node);
             if (idx > 0)
             {
                 // Go to the deepest last descendant of the previous sibling
                 var prev = siblings[idx - 1];
-                while (prev.Children.Count > 0)
-                    prev = prev.Children[^1];
+                while (prev.ChildNodes.Count > 0)
+                    prev = ChildAt(prev, ^1);
                 return prev;
             }
             // No previous sibling — parent is the previous node (unless it's root)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -315,11 +315,11 @@ public sealed partial class DomBridge
     /// </summary>
     private static bool IsDescendant(DomElement ancestor, DomElement candidate)
     {
-        var current = candidate.Parent;
+        var current = ParentEl(candidate);
         while (current != null)
         {
             if (ReferenceEquals(current, ancestor)) return true;
-            current = current.Parent;
+            current = ParentEl(current);
         }
         return false;
     }
@@ -335,12 +335,12 @@ public sealed partial class DomBridge
             return 0;
 
         var firstAncestors = new List<DomElement>();
-        for (var current = first; current != null; current = current.Parent)
+        for (var current = first; current != null; current = ParentEl(current))
             firstAncestors.Add(current);
         firstAncestors.Reverse();
 
         var secondAncestors = new List<DomElement>();
-        for (var current = second; current != null; current = current.Parent)
+        for (var current = second; current != null; current = ParentEl(current))
             secondAncestors.Add(current);
         secondAncestors.Reverse();
 
@@ -420,7 +420,7 @@ public sealed partial class DomBridge
             foreach (var child in source.Children)
             {
                 var childClone = CloneDomElement(child, true);
-                childClone.Parent = clone;
+                SetParent(childClone, clone);
                 clone.Children.Add(childClone);
                 _knownNodes.Add(childClone);
             }
@@ -509,26 +509,26 @@ public sealed partial class DomBridge
                 // No sections and no rows at all: create a new tbody per spec
                 var tbody = new DomElement("tbody", null, null, string.Empty);
                 bridge._knownNodes.Add(tbody);
-                tbody.Parent = table;
+                SetParent(tbody, table);
                 table.Children.Add(tbody);
                 lastSection = tbody;
             }
             if (lastSection != null)
             {
-                tr.Parent = lastSection;
+                SetParent(tr, lastSection);
                 lastSection.Children.Add(tr);
             }
             else
             {
-                tr.Parent = table;
+                SetParent(tr, table);
                 table.Children.Add(tr);
             }
         }
         else if (index >= 0 && index < allRows.Count)
         {
             var refRow = allRows[index];
-            var parent = refRow.Parent ?? table;
-            tr.Parent = parent;
+            var parent = ParentEl(refRow) ?? table;
+            SetParent(tr, parent);
             var idx = parent.Children.IndexOf(refRow);
             parent.Children.Insert(idx >= 0 ? idx : parent.Children.Count, tr);
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -397,8 +397,14 @@ public sealed partial class DomBridge
     private DomElement CloneDomElement(DomElement source, bool deep)
     {
         var attrs = new Dictionary<string, string>(source.Attributes, StringComparer.OrdinalIgnoreCase);
-        var style = new Dictionary<string, string>(source.Style, StringComparer.OrdinalIgnoreCase);
-        var clone = new DomElement(source.TagName, source.Id, source.ClassName, source.InnerHtml, style, attrs, source.IsTextNode);
+        var clone = new DomElement(source.TagName, source.Id, source.ClassName, source.InnerHtml, null, attrs, source.IsTextNode);
+        // RF-BRIDGE-1c Phase B: inline style lives in ElementRuntimeState now. Copy the
+        // source's live style dict (which may hold JS mutations not yet synced to the
+        // `style=` attribute), replacing the clone's lazily-seeded attribute values.
+        var cloneStyle = InlineStyle(clone);
+        cloneStyle.Clear();
+        foreach (var kv in InlineStyle(source))
+            cloneStyle[kv.Key] = kv.Value;
         clone.TextContent = source.TextContent;
         clone.NamespaceURI = source.NamespaceURI;
         foreach (var kv in source.NsAttrMap)
@@ -672,8 +678,8 @@ public sealed partial class DomBridge
     /// A JSObject subclass that intercepts property get/set to sync
     /// JavaScript camelCase style property assignments (e.g.
     /// <c>style.animationDelay = '-100s'</c>) with the DOM element's
-    /// <see cref="DomElement.Style"/> dictionary in CSS kebab-case
-    /// (<c>animation-delay: -100s</c>).
+    /// inline style (<see cref="ElementRuntimeState.Style"/>, reached via
+    /// <c>InlineStyle</c>) in CSS kebab-case (<c>animation-delay: -100s</c>).
     /// </summary>
     private sealed class CssStyleDeclaration : JSObject
     {
@@ -699,12 +705,12 @@ public sealed partial class DomBridge
                 var val = value?.ToString() ?? string.Empty;
                 if (string.IsNullOrEmpty(val))
                 {
-                    _element.Style.Remove(kebab);
+                    InlineStyle(_element).Remove(kebab);
                     GetElementRuntimeState(_element).JsSetStyleProps.Remove(kebab);
                 }
                 else
                 {
-                    _element.Style[kebab] = val;
+                    InlineStyle(_element)[kebab] = val;
                     GetElementRuntimeState(_element).JsSetStyleProps.Add(kebab);
                 }
 
@@ -727,7 +733,7 @@ public sealed partial class DomBridge
             if (result != null && !result.IsUndefined)
                 return result;
 
-            // Fall back to element.Style lookup (kebab-case)
+            // Fall back to InlineStyle(element) lookup (kebab-case)
             var nameStr = key.ToString();
             if (!NonCssNames.Contains(nameStr))
             {
@@ -795,7 +801,7 @@ public sealed partial class DomBridge
         => style.Keys.ToList();
 
     private static List<string> GetStylePropertyNames(DomElement element)
-        => GetStylePropertyNames((IReadOnlyDictionary<string, string>)element.Style);
+        => GetStylePropertyNames((IReadOnlyDictionary<string, string>)InlineStyle(element));
 
     private static Dictionary<string, string> BuildDeclaredInlineStyleMap(DomElement element)
     {
@@ -810,7 +816,7 @@ public sealed partial class DomBridge
 
         foreach (var property in GetElementRuntimeState(element).JsSetStyleProps)
         {
-            if (element.Style.TryGetValue(property, out var value))
+            if (InlineStyle(element).TryGetValue(property, out var value))
                 declared[property] = value;
         }
 
@@ -862,7 +868,7 @@ public sealed partial class DomBridge
 
     private static bool TryGetStylePropertyRawValue(DomElement element, string property, out string value)
     {
-        if (TryGetStylePropertyRawValue((IReadOnlyDictionary<string, string>)element.Style, property, out value!))
+        if (TryGetStylePropertyRawValue((IReadOnlyDictionary<string, string>)InlineStyle(element), property, out value!))
             return true;
 
         return TryGetExpandedInlineStyleRawValue(element, property, out value!);
@@ -885,7 +891,7 @@ public sealed partial class DomBridge
             new JSFunction((in Arguments a) => JsUtilitiesSetProperty005Core(element, onMutation, in a), "setProperty", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        // style.getPropertyValue(property) — checks element.Style dict first, then
+        // style.getPropertyValue(property) — checks InlineStyle(element) dict first, then
         // tries camelCase conversion for kebab-case input (or vice versa),
         // and also checks JSObject properties (set via el.style.camelCase = value).
         style.FastAddValue(

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -111,7 +111,7 @@ public sealed partial class DomBridge
     {
         foreach (var child in parent.Children)
         {
-            if (!child.IsTextNode && MatchesSelector(child, selector, scope))
+            if (!IsText(child) && MatchesSelector(child, selector, scope))
             {
                 results.Add(bridge.ToJSObject(child));
                 if (!all) return;
@@ -126,7 +126,7 @@ public sealed partial class DomBridge
     /// </summary>
     private static void CollectTextContent(DomElement node, StringBuilder sb)
     {
-        if (node.IsTextNode)
+        if (IsText(node))
         {
             sb.Append(node.TextContent ?? string.Empty);
             return;
@@ -397,7 +397,7 @@ public sealed partial class DomBridge
     private DomElement CloneDomElement(DomElement source, bool deep)
     {
         var attrs = AttributeSnapshot(source);
-        var clone = new DomElement(source.TagName, source.Id, source.ClassName, source.InnerHtml, null, attrs, source.IsTextNode);
+        var clone = new DomElement(source.TagName, source.Id, source.ClassName, source.InnerHtml, null, attrs, IsText(source));
         // RF-BRIDGE-1c Phase B: inline style lives in ElementRuntimeState now. Copy the
         // source's live style dict (which may hold JS mutations not yet synced to the
         // `style=` attribute), replacing the clone's lazily-seeded attribute values.
@@ -564,7 +564,7 @@ public sealed partial class DomBridge
     {
         foreach (var child in scope.Children)
         {
-            if (!child.IsTextNode && !ReferenceEquals(child, except))
+            if (!IsText(child) && !ReferenceEquals(child, except))
             {
                 if (string.Equals(child.TagName, "input", StringComparison.OrdinalIgnoreCase) &&
                     TryGetAttribute(child, "type", out var st) &&
@@ -661,7 +661,7 @@ public sealed partial class DomBridge
     /// </summary>
     private static int GetNodeType(DomElement element)
     {
-        if (element.IsTextNode) return 3; // TEXT_NODE
+        if (IsText(element)) return 3; // TEXT_NODE
         if (string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase)) return 8;
         if (string.Equals(element.TagName, "#document", StringComparison.OrdinalIgnoreCase)) return 9;
         if (string.Equals(element.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase)) return 11;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -379,7 +379,7 @@ public sealed partial class DomBridge
     /// </summary>
     private static void AdoptSubtreeIntoDocument(DomElement node, DomElement? ownerDocRoot)
     {
-        node.OwnerDocRoot = ownerDocRoot;
+        GetElementRuntimeState(node).OwnerDocRoot = ownerDocRoot;
 
         foreach (var child in node.Children)
         {
@@ -700,12 +700,12 @@ public sealed partial class DomBridge
                 if (string.IsNullOrEmpty(val))
                 {
                     _element.Style.Remove(kebab);
-                    _element.JsSetStyleProps.Remove(kebab);
+                    GetElementRuntimeState(_element).JsSetStyleProps.Remove(kebab);
                 }
                 else
                 {
                     _element.Style[kebab] = val;
-                    _element.JsSetStyleProps.Add(kebab);
+                    GetElementRuntimeState(_element).JsSetStyleProps.Add(kebab);
                 }
 
                 // Invalidate cached position-area resolution when relevant
@@ -808,7 +808,7 @@ public sealed partial class DomBridge
                 declared[kv.Key] = kv.Value;
         }
 
-        foreach (var property in element.JsSetStyleProps)
+        foreach (var property in GetElementRuntimeState(element).JsSetStyleProps)
         {
             if (element.Style.TryGetValue(property, out var value))
                 declared[property] = value;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -109,7 +109,7 @@ public sealed partial class DomBridge
 
     private static void SearchDescendants(DomElement parent, string selector, List<JSValue> results, DomBridge bridge, bool all, DomElement scope)
     {
-        foreach (var child in parent.Children)
+        foreach (var child in ChildElements(parent))
         {
             if (!IsText(child) && MatchesSelector(child, selector, scope))
             {
@@ -131,7 +131,7 @@ public sealed partial class DomBridge
             sb.Append(node.TextContent ?? string.Empty);
             return;
         }
-        foreach (var child in node.Children)
+        foreach (var child in ChildElements(node))
             CollectTextContent(child, sb);
     }
 
@@ -362,8 +362,8 @@ public sealed partial class DomBridge
         var commonAncestor = firstAncestors[divergenceIndex - 1];
         var firstChild = firstAncestors[divergenceIndex];
         var secondChild = secondAncestors[divergenceIndex];
-        var firstIndex = commonAncestor.Children.IndexOf(firstChild);
-        var secondIndex = commonAncestor.Children.IndexOf(secondChild);
+        var firstIndex = ChildIndexOf(commonAncestor, firstChild);
+        var secondIndex = ChildIndexOf(commonAncestor, secondChild);
 
         if (firstIndex == secondIndex)
             return 0;
@@ -381,7 +381,7 @@ public sealed partial class DomBridge
     {
         GetElementRuntimeState(node).OwnerDocRoot = ownerDocRoot;
 
-        foreach (var child in node.Children)
+        foreach (var child in ChildElements(node))
         {
             if (IsSubDocRoot(child))
                 continue;
@@ -417,11 +417,11 @@ public sealed partial class DomBridge
 
         if (deep)
         {
-            foreach (var child in source.Children)
+            foreach (var child in ChildElements(source))
             {
                 var childClone = CloneDomElement(child, true);
                 SetParent(childClone, clone);
-                clone.Children.Add(childClone);
+                clone.AppendChild(childClone);
                 _knownNodes.Add(childClone);
             }
         }
@@ -436,29 +436,29 @@ public sealed partial class DomBridge
     {
         var rows = new List<DomElement>();
         // 1. All tr children of thead elements (in tree order)
-        foreach (var child in table.Children)
+        foreach (var child in ChildElements(table))
         {
             if (string.Equals(child.TagName, "thead", StringComparison.OrdinalIgnoreCase))
-                foreach (var c in child.Children)
+                foreach (var c in ChildElements(child))
                     if (string.Equals(c.TagName, "tr", StringComparison.OrdinalIgnoreCase))
                         rows.Add(c);
         }
         // 2. All tr children that are direct children of table, or children of tbody elements (in tree order)
-        foreach (var child in table.Children)
+        foreach (var child in ChildElements(table))
         {
             var ctag = child.TagName.ToLowerInvariant();
             if (ctag == "tr")
                 rows.Add(child);
             else if (ctag == "tbody")
-                foreach (var c in child.Children)
+                foreach (var c in ChildElements(child))
                     if (string.Equals(c.TagName, "tr", StringComparison.OrdinalIgnoreCase))
                         rows.Add(c);
         }
         // 3. All tr children of tfoot elements (in tree order)
-        foreach (var child in table.Children)
+        foreach (var child in ChildElements(table))
         {
             if (string.Equals(child.TagName, "tfoot", StringComparison.OrdinalIgnoreCase))
-                foreach (var c in child.Children)
+                foreach (var c in ChildElements(child))
                     if (string.Equals(c.TagName, "tr", StringComparison.OrdinalIgnoreCase))
                         rows.Add(c);
         }
@@ -495,12 +495,12 @@ public sealed partial class DomBridge
         {
             // Find the last section to append to, or create a tbody
             DomElement? lastSection = null;
-            for (int i = table.Children.Count - 1; i >= 0; i--)
+            for (int i = table.ChildNodes.Count - 1; i >= 0; i--)
             {
-                var ctag = table.Children[i].TagName.ToLowerInvariant();
+                var ctag = ChildAt(table, i).TagName.ToLowerInvariant();
                 if (ctag == "thead" || ctag == "tbody" || ctag == "tfoot")
                 {
-                    lastSection = table.Children[i];
+                    lastSection = ChildAt(table, i);
                     break;
                 }
             }
@@ -510,18 +510,18 @@ public sealed partial class DomBridge
                 var tbody = new DomElement("tbody", null, null, string.Empty);
                 bridge._knownNodes.Add(tbody);
                 SetParent(tbody, table);
-                table.Children.Add(tbody);
+                table.AppendChild(tbody);
                 lastSection = tbody;
             }
             if (lastSection != null)
             {
                 SetParent(tr, lastSection);
-                lastSection.Children.Add(tr);
+                lastSection.AppendChild(tr);
             }
             else
             {
                 SetParent(tr, table);
-                table.Children.Add(tr);
+                table.AppendChild(tr);
             }
         }
         else if (index >= 0 && index < allRows.Count)
@@ -529,8 +529,8 @@ public sealed partial class DomBridge
             var refRow = allRows[index];
             var parent = ParentEl(refRow) ?? table;
             SetParent(tr, parent);
-            var idx = parent.Children.IndexOf(refRow);
-            parent.Children.Insert(idx >= 0 ? idx : parent.Children.Count, tr);
+            var idx = ChildIndexOf(parent, refRow);
+            InsertChildAt(parent, idx >= 0 ? idx : parent.ChildNodes.Count, tr);
         }
         return ToJSObject(tr);
     }
@@ -547,7 +547,7 @@ public sealed partial class DomBridge
 
     private static void CollectFormControlsRecursive(DomElement parent, List<DomElement> controls)
     {
-        foreach (var child in parent.Children)
+        foreach (var child in ChildElements(parent))
         {
             var ctag = child.TagName.ToLowerInvariant();
             if (ctag == "input" || ctag == "select" || ctag == "textarea" || ctag == "button")
@@ -562,7 +562,7 @@ public sealed partial class DomBridge
     /// </summary>
     private static void UncheckRadioSiblings(DomElement scope, DomElement except, string radioName)
     {
-        foreach (var child in scope.Children)
+        foreach (var child in ChildElements(scope))
         {
             if (!IsText(child) && !ReferenceEquals(child, except))
             {
@@ -607,7 +607,7 @@ public sealed partial class DomBridge
     /// </summary>
     private static void CollectDescendants(DomElement root, List<DomElement> result)
     {
-        foreach (var child in root.Children)
+        foreach (var child in ChildElements(root))
         {
             // Skip sub-document roots — they are separate document trees
             // and must not be traversed as part of the parent document.
@@ -625,7 +625,7 @@ public sealed partial class DomBridge
     /// </summary>
     private static void CollectAllDescendantsFlat(DomElement parent, List<DomElement> result)
     {
-        foreach (var child in parent.Children)
+        foreach (var child in ChildElements(parent))
         {
             result.Add(child);
             CollectAllDescendantsFlat(child, result);
@@ -637,7 +637,7 @@ public sealed partial class DomBridge
     /// </summary>
     private static void CollectDescendantsByTag(DomElement root, string tagName, List<JSValue> results, DomBridge bridge)
     {
-        foreach (var child in root.Children)
+        foreach (var child in ChildElements(root))
         {
             if (tagName == "*" || string.Equals(child.TagName, tagName, StringComparison.OrdinalIgnoreCase))
                 results.Add(bridge.ToJSObject(child));

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -396,7 +396,7 @@ public sealed partial class DomBridge
     /// </summary>
     private DomElement CloneDomElement(DomElement source, bool deep)
     {
-        var attrs = new Dictionary<string, string>(source.Attributes, StringComparer.OrdinalIgnoreCase);
+        var attrs = AttributeSnapshot(source);
         var clone = new DomElement(source.TagName, source.Id, source.ClassName, source.InnerHtml, null, attrs, source.IsTextNode);
         // RF-BRIDGE-1c Phase B: inline style lives in ElementRuntimeState now. Copy the
         // source's live style dict (which may hold JS mutations not yet synced to the
@@ -567,9 +567,9 @@ public sealed partial class DomBridge
             if (!child.IsTextNode && !ReferenceEquals(child, except))
             {
                 if (string.Equals(child.TagName, "input", StringComparison.OrdinalIgnoreCase) &&
-                    child.Attributes.TryGetValue("type", out var st) &&
+                    TryGetAttribute(child, "type", out var st) &&
                     string.Equals(st, "radio", StringComparison.OrdinalIgnoreCase) &&
-                    child.Attributes.TryGetValue("name", out var sn) &&
+                    TryGetAttribute(child, "name", out var sn) &&
                     string.Equals(sn, radioName, StringComparison.Ordinal))
                 {
                     GetElementRuntimeState(child).FormControl.Checked.Set(false);
@@ -807,7 +807,7 @@ public sealed partial class DomBridge
     {
         var declared = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        if (element.Attributes.TryGetValue("style", out var inlineStyle) &&
+        if (TryGetAttribute(element, "style", out var inlineStyle) &&
             !string.IsNullOrEmpty(inlineStyle))
         {
             foreach (var kv in ParseStyle(inlineStyle))
@@ -1085,8 +1085,8 @@ public sealed partial class DomBridge
     {
         var ctx = new JSObject();
         int width = 300, height = 150;
-        if (canvas.Attributes.TryGetValue("width", out var w) && int.TryParse(w, out var pw)) width = pw;
-        if (canvas.Attributes.TryGetValue("height", out var h) && int.TryParse(h, out var ph)) height = ph;
+        if (TryGetAttribute(canvas, "width", out var w) && int.TryParse(w, out var pw)) width = pw;
+        if (TryGetAttribute(canvas, "height", out var h) && int.TryParse(h, out var ph)) height = ph;
 
         var context2d = new CanvasRenderingContext2D(width, height);
 

--- a/src/Broiler.HtmlBridge.Dom/HtmlTreeBuilder.cs
+++ b/src/Broiler.HtmlBridge.Dom/HtmlTreeBuilder.cs
@@ -37,7 +37,7 @@ public sealed class HtmlTreeBuilder
         var allElements = new List<DomElement>();
         var fragment = new DomElement(document, "#document-fragment", null, null, string.Empty);
         foreach (var child in parsed.Fragment.ChildNodes)
-            fragment.Children.Add(ConvertNode(child, document, allElements));
+            fragment.AppendChild(ConvertNode(child, document, allElements));
         return (fragment, allElements);
     }
 
@@ -98,7 +98,7 @@ public sealed class HtmlTreeBuilder
                 structural &&
                 child is Broiler.Dom.DomElement childElement &&
                 childElement.LocalName is "head" or "body";
-            target.Children.Add(ConvertNode(child, targetDocument, allElements, childIsStructural));
+            target.AppendChild(ConvertNode(child, targetDocument, allElements, childIsStructural));
         }
 
         return target;

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -10099,7 +10099,7 @@ iframe {
     {
         if (found != null) return;
         if (el.Id == id) { found = el; return; }
-        foreach (var c in el.Children)
+        foreach (var c in el.ChildNodes.OfType<Broiler.HtmlBridge.DomElement>())
             FindDomElement(c, id, ref found);
     }
 


### PR DESCRIPTION
## RF-BRIDGE-1c: incremental `DomElement` facade removal (promotion roadmap Milestone 1.2)

Executes the first two-thirds of the `Broiler.HtmlBridge.DomElement` facade removal — Milestone 1.2 of
[`htmlbridge-dom-css-promotion-roadmap.md`](docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md) Phase 5,
following the staged design in
[`htmlbridge-domelement-facade-removal-plan.md`](docs/roadmap/htmlbridge-domelement-facade-removal-plan.md).

This is a **staged migration, not a big-bang deletion**: `DomElement` (a compatibility facade over
canonical `Broiler.Dom.DomElement`) is the bridge's fundamental node type, so each of its added members is
relocated to `ElementRuntimeState` or to canonical DOM APIs in its own behaviour-preserving, independently
verified commit.

### Prerequisite (verified, not changed here)
RF-BRIDGE-1b geometry unification (Item 2) — the estimator deletion, `LayoutRuntimeState` retirement,
`UseSharedGeometryExclusively`, the §9.2.1.1 inline-block fix, and the Track 3 renderer prerequisites —
was re-verified complete at the code + build + test level before this work began; it unblocks the facade
removal.

### What's in this PR — 7 facade members removed

| Facade member removed | Phase | Relocated to | Sites |
| --- | --- | --- | --- |
| `JsSetStyleProps`, `OwnerDocRoot` | A | `ElementRuntimeState` | 42 |
| `Style` | B | `ElementRuntimeState` via `InlineStyle(node)` (lazy-seeds from the `style=` attribute) | ~200 |
| `Attributes` (+ nested `LegacyAttributeDictionary`) | C | canonical namespace-keyed attributes via `TryGetAttribute`/`GetAttr`/`HasAttr`/`SetAttr`/`RemoveAttr`/… | ~195 |
| `Parent` | E1 | canonical `ParentNode` via `ParentEl`/`SetParent` | ~450 |
| `IsTextNode` | D1 | canonical `NodeType` via `IsText(node)` | 119 |
| `Children` (+ nested `LegacyChildList`) | E2 | canonical `ChildNodes` via `ChildElements`/`ChildAt`/`ChildIndexOf`/`InsertChildAt`/`RemoveNthChild`/`ClearChildren` | 421 |

Each helper mirrors the old facade member's exact semantics (e.g. the attribute helpers reproduce the
legacy dictionary's case-insensitive scan-by-qualified-name, since canonical `GetAttribute`/`SetAttribute`
are no-namespace + lowercasing and are *not* a behaviour-preserving drop-in). Design decisions locked with
the maintainer: `.Style` → `ElementRuntimeState`; text discrimination → NodeType helpers; `HtmlTreeBuilder`
retired in Phase F.

### Verification
Every phase was gated on the **full `Broiler.Cli.Tests`** suite (1699 tests, the known slot-scroll
`ScrollIntoView_Treats_Assigned_Slot` crasher excluded) diffed **by test name** against the pre-existing
78-failure environmental baseline (Skia/PDF/network/font/WPT-pixel/layout, per `CLAUDE.md`). Every phase is
**regression-free** — an empty by-name diff (the occasional `GoogleSearchPolyfill`/`Acid3` delta is
documented parallel-run flakiness that passes in isolation). The largest change (E2, `Children`, 421 sites)
was verified empty-diff both before and after deleting the facade member.

### What remains (follow-ups, not in this PR)
The facade still carries `InnerHtml`, `TextContent`, `NamespaceURI`, `NsAttrMap`. Remaining work:
- **Phase C2** — `NsAttrMap` → canonical namespaced attributes (small, self-contained).
- **Phase F cutover** — flip text/comment **construction** to canonical `DomText`/`DomComment` (removing
  `TextContent`), which cascades into re-typing `RangeState`, `_knownNodes`, and the JS-object cache (text
  nodes carry JS wrappers); then re-key the remaining per-node caches, remove `HtmlTreeBuilder`, and delete
  the `DomElement` type + `IsTextNode`-in-frozen-guard. `InnerHtml`/`NamespaceURI` (ctor-coupled;
  `SetName` is `protected`) fold in here.

The bridge tree is deliberately kept homogeneous `DomElement` throughout this PR, so the `Cast`/`ChildAt`
casts in the `Children`/`Parent` helpers are safe; they narrow to `OfType<DomElement>()` + `IsText`
handling at the Phase F text flip.

### Notes for review
- **No submodule changes** — all edits are in the main repo (`src/`, `docs/`).
- The characterization guard `DomExtractionPhaseZeroTests` is updated each phase as members leave the frozen
  facade surface.
- Working files are CRLF with `core.autocrlf=true`; some mechanical transforms were scripted, so git may
  report line-ending normalization warnings, but the committed diffs are content-only.
- 13 commits, each building green and independently reviewable (code + a paired roadmap-doc update per
  phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
