### PR TITLE
refactor(htmlbridge): RF-BRIDGE-1c — remove the DomElement facade (through Phase F3c part 1)

### DIFF
--- a/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
+++ b/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
@@ -329,14 +329,15 @@ other two are gated on prerequisites that are not yet met (documented below).
   change; it is a staged migration, not a deletion.
   `HtmlTreeBuilder`/`CssRules`/`CalculateSpecificity` removal follows once callers
   no longer need the facade node type.
-  **Progress (2026-07-11):** Milestone 1.2 is well under way on branch
-  `claude/rf-bridge-1c-domelement-facade-migration` — **7 facade members deleted**
+  **Progress (2026-07-11):** Milestone 1.2 is well under way — **8 facade members deleted**
   (`JsSetStyleProps`, `OwnerDocRoot`, `Style`, `Attributes`+`LegacyAttributeDictionary`,
-  `Parent`, `IsTextNode`, `Children`+`LegacyChildList`; Phases A/B/C/E1/D1/E2), each a
+  `Parent`, `IsTextNode`, `Children`+`LegacyChildList` on branch
+  `claude/rf-bridge-1c-domelement-facade-migration`; `NsAttrMap` on branch
+  `claude/htmlbridge-domelement-removal-ucyw5j`; Phases A/B/C/E1/D1/E2/C2), each a
   behaviour-preserving relocation to `ElementRuntimeState` or canonical DOM, verified
-  regression-free (empty-diff vs the full-`Broiler.Cli.Tests` baseline). Facade remnants
-  `InnerHtml`/`TextContent`/`NamespaceURI`/`NsAttrMap` + the text→`DomText` construction
-  flip and cache/`RangeState` re-keying are the Phase C2/F remainder (see the plan's
+  regression-free vs the full-`Broiler.Cli.Tests` baseline. Facade remnants
+  `InnerHtml`/`TextContent`/`NamespaceURI` + the text→`DomText` construction
+  flip and cache/`RangeState` re-keying are the Phase F remainder (see the plan's
   "Status at a glance").
 
   **Sharpened dependency analysis (2026-07-09).** The four adapters split into two

--- a/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
+++ b/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
@@ -23,7 +23,7 @@ are done. The facade removal is unblocked.
 
 ## Status at a glance (2026-07-11)
 
-Phases A–E2 on branch `claude/rf-bridge-1c-domelement-facade-migration`; Phases C2 + F1 + F3a + F3b on branch
+Phases A–E2 on branch `claude/rf-bridge-1c-domelement-facade-migration`; Phases C2 + F1 + F3a + F3b + F3c-part1 on branch
 `claude/htmlbridge-domelement-removal-ucyw5j`. Each row is its own commit, every one regression-free
 against the full `Broiler.Cli.Tests` (1699, slot-scroll crasher excluded) environmental baseline —
 Phase C2 verified 0 baseline-passing tests regressed (before/after trx diff; the sole delta is the
@@ -63,8 +63,18 @@ pre-change tree too).
   `as DomElement`). Full `Broiler.Cli.Tests` regression-free. `RangeState` + the ~10 range helpers it
   feeds stay `DomElement`-typed — that widen cascades and lands with the flip in F3c.
 
+- **F3c part 1 — node-level `DomNode` widening (safe, green). DONE.** Widened
+  `ElementRuntimeStates`(CWT)/`GetElementRuntimeState`, `_mutationObservers` targets, `ChildIndexOf`,
+  `ParentEl`, `SetParent`, `GetTreeRoot`/`ToJSRootNode`, and the Node-navigation callbacks
+  (`childNodes`/`firstChild`/`lastChild`/`nextSibling`/`previousSibling`/`isConnected`, now walking raw
+  `ChildNodes`) + `nodeType`/`nodeName` to canonical `DomNode`. Full `Broiler.Cli.Tests` regression-free
+  (caught + fixed a `GetTreeRoot` over-walk that mis-rooted isConnected/getRootNode/compareDocumentPosition).
+
 **Phase F remaining (staged):**
-- **F3c — the flip (higher risk).** **The `ToJSObject` blocker:** today `ToJSObject` gives every node
+- **F3c part 2 — the atomic flip (big-bang; not cleanly green-steppable).** Widening `ChildAt` to return
+  `DomNode` opens the full tree-heterogeneity cascade (~68 range/tree-walker/normalize/serialization
+  sites that must handle non-element children) — coupled with the construction flip, so it lands
+  atomically. **The `ToJSObject` blocker:** today `ToJSObject` gives every node
   — text/comment included — the full element wrapper; a canonical `DomText`/`DomComment` (not a
   `DomElement`) needs its own minimal Node/CharacterData wrapper (replacing the `(DomElement)node` cast
   F3b left in place). Then: widen `RangeState.StartContainer`/`EndContainer`/`Root` + the ~10 range

--- a/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
+++ b/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
@@ -39,14 +39,33 @@ pre-change tree too).
 | `IsTextNode` | D1 | canonical `NodeType` via `IsText(node)` | 119 |
 | `Children` (+ `LegacyChildList`) | E2 | canonical `ChildNodes` via `ChildElements`/… | 421 |
 | `NsAttrMap` | C2 | canonical namespaced attributes via `TryGetNsAttribute`/`GetAttributeNS` | 18 |
+| `InnerHtml` | F1 | `ElementRuntimeState` via `GetElementRuntimeState(el).InnerHtml` | ~7 |
 
-**Facade `DomElement` still carries:** `InnerHtml`, `TextContent`, `NamespaceURI`.
+**Facade `DomElement` still carries:** `TextContent`, `NamespaceURI`.
 
-**Not yet started:** the **Phase F cutover** — flip text/comment construction to canonical
-`DomText`/`DomComment` (removing `TextContent`), which cascades into re-typing `RangeState`,
-`_knownNodes`, and the JS-object cache, then re-key the remaining per-node caches, remove
-`HtmlTreeBuilder`, and delete the `DomElement` type. `InnerHtml` and `NamespaceURI` (ctor-coupled;
-`SetName` is `protected`) fold into Phase F.
+**Phase F remaining (staged):**
+- **F3 — canonical text/comment flip (highest risk):** re-type `_knownNodes`, `_jsObjectCache`,
+  `RangeState.StartContainer`/`EndContainer`, `_docRootToDocJSObject`, mutation-observer targets, and
+  `RuntimeValue<DomElement>` (shadow root/host) to canonical `DomNode`; flip the ~23 text/comment
+  construction sites to `document.CreateTextNode`/`CreateComment`; split `TextContent`'s double duty
+  (text/comment character-data → `DomText`/`DomComment`.`Data`; element `textContent` aggregation →
+  compute over child `DomText`); add an `IsComment(node)` helper (a `DomComment` has no `TagName`);
+  narrow `ChildElements` to `OfType<DomElement>()` and route the text-needing callers (serialization
+  `GetChildren`, JS `childNodes`, `CollectTextContent`, the Range routines) to raw `ChildNodes`; fix the
+  three `Traversal.cs` tree-node casts (`:62`, `:71`, `:232`) + `ToTraversalJsValue`; switch
+  serialization `GetKind` to a `NodeType` switch; remove facade `TextContent`. Gate on WPT
+  range/selection/serialization + Acid.
+- **F4 — construction flip + cache re-key + delete facade:** flip the ~40 real-element
+  `new DomElement(...)` sites to `document.CreateElement`/`CreateElementNS` (removes the `NamespaceURI`
+  ctor-coupling — `SetName` is `protected`, so the namespace must be set at construction); retire
+  `HtmlTreeBuilder` (callers parse via `HtmlDocumentParser.ParseDocument(html, _document)` directly);
+  re-key the ~14 remaining per-node caches to canonical `DomElement`; widen the public seams
+  `DomBridge.Elements`/`DocumentElement` + `IDomBridgeRuntime.Elements` to canonical (update the
+  `WptTestRunnerTests` helper); remove facade `NamespaceURI`; delete `DomElement.cs` +
+  `HtmlTreeBuilder.cs`; update/remove the frozen seam guard tests.
+
+Dependency: F1 (done) is independent; **F3 gates F4** (element construction flips last, once no facade
+instances or facade-only members remain). F4 is the only irreversible step.
 
 ## The facade in one paragraph
 
@@ -156,10 +175,11 @@ Each phase is one or more PRs, each independently building + green. Gate every p
 the **full** validation set (see "Validation" below), baselined first per `CLAUDE.md`.
 
 **Progress (2026-07-10/11):** Phases A + B + C + E1 + D1 + E2 **DONE** on branch
-`claude/rf-bridge-1c-domelement-facade-migration`; **Phase C2 DONE** on branch
+`claude/rf-bridge-1c-domelement-facade-migration`; **Phases C2 + F1 (`InnerHtml`) DONE** on branch
 `claude/htmlbridge-domelement-removal-ucyw5j`. Each is full-`Broiler.Cli.Tests` regression-free
 (the only diff is the documented `GoogleSearchPolyfillTests` render/scroll environmental failures,
-confirmed pre-existing on the pre-change tree).
+confirmed pre-existing on the pre-change tree). Phase A's deferred **A3 (`InnerHtml` → ERS)** landed
+here as **F1**.
 - **Phase A** — `JsSetStyleProps` + `OwnerDocRoot` → `ElementRuntimeState` (42 sites).
 - **Phase B** — inline `.Style` → ERS via `DomBridge.InlineStyle(element)` (lazy-seeds from the
   `style=` attribute on first access; ~200 sites; clone + dialog-backdrop seed explicitly; facade

--- a/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
+++ b/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
@@ -23,7 +23,7 @@ are done. The facade removal is unblocked.
 
 ## Status at a glance (2026-07-11)
 
-Phases A–E2 on branch `claude/rf-bridge-1c-domelement-facade-migration`; Phase C2 on branch
+Phases A–E2 on branch `claude/rf-bridge-1c-domelement-facade-migration`; Phases C2 + F1 + F3a on branch
 `claude/htmlbridge-domelement-removal-ucyw5j`. Each row is its own commit, every one regression-free
 against the full `Broiler.Cli.Tests` (1699, slot-scroll crasher excluded) environmental baseline —
 Phase C2 verified 0 baseline-passing tests regressed (before/after trx diff; the sole delta is the
@@ -43,18 +43,39 @@ pre-change tree too).
 
 **Facade `DomElement` still carries:** `TextContent`, `NamespaceURI`.
 
+**Phase F progress:**
+- **F1 — `InnerHtml` → ERS.** Done (see table).
+- **F3a — character-data indirection (strangler prep for the text flip). DONE.** Introduced
+  `IsComment(DomNode)` (NodeType-based, since a canonical `DomComment` has no `TagName`) and
+  `BridgeText`/`SetBridgeText` (read/write character data over `DomCharacterData.Data`, with a facade
+  `TextContent` fallback during transition). Migrated ~80 character-data + comment-discrimination sites
+  (CharacterData JS callbacks, `SetCharacterData`, Range extract/clone/toString splits, `normalize`,
+  `createTextNode`/`createComment`/title seeding, `<style>`/CSS source gatherers, anchor-resolver CSS
+  rewrites, inline-width estimation, layout `GetDirectTextContent`, `isEqualNode`, serialization
+  `GetText`, and the `#comment` `TagName` checks) to the helpers. Behaviour-preserving on the
+  homogeneous facade tree; full `Broiler.Cli.Tests` regression-free. Element-level `textContent`
+  aggregation and text/comment construction are intentionally left for F3c.
+
 **Phase F remaining (staged):**
-- **F3 — canonical text/comment flip (highest risk):** re-type `_knownNodes`, `_jsObjectCache`,
-  `RangeState.StartContainer`/`EndContainer`, `_docRootToDocJSObject`, mutation-observer targets, and
-  `RuntimeValue<DomElement>` (shadow root/host) to canonical `DomNode`; flip the ~23 text/comment
-  construction sites to `document.CreateTextNode`/`CreateComment`; split `TextContent`'s double duty
-  (text/comment character-data → `DomText`/`DomComment`.`Data`; element `textContent` aggregation →
-  compute over child `DomText`); add an `IsComment(node)` helper (a `DomComment` has no `TagName`);
-  narrow `ChildElements` to `OfType<DomElement>()` and route the text-needing callers (serialization
-  `GetChildren`, JS `childNodes`, `CollectTextContent`, the Range routines) to raw `ChildNodes`; fix the
-  three `Traversal.cs` tree-node casts (`:62`, `:71`, `:232`) + `ToTraversalJsValue`; switch
-  serialization `GetKind` to a `NodeType` switch; remove facade `TextContent`. Gate on WPT
-  range/selection/serialization + Acid.
+- **F3b — widen the node-identity surface to `DomNode` (safe, no behaviour change):** re-type
+  `_knownNodes`, `_jsObjectCache`, `RangeState.StartContainer`/`EndContainer`, `_docRootToDocJSObject`,
+  mutation-observer targets, and `RuntimeValue<DomElement>` (shadow root/host) from the facade to
+  canonical `DomNode` (a facade node IS-A `DomNode`, so this compiles and behaves identically on the
+  current tree). Rework `ToJSObject(DomNode)` to build a minimal Node/CharacterData wrapper for
+  non-element nodes while the element body stays cast-guarded; add `FindDomNodeByJSObject`.
+  **The blocker for F3c:** today `ToJSObject` gives every node — text/comment included — the full
+  element wrapper; a canonical `DomText`/`DomComment` (not a `DomElement`) needs its own wrapper.
+- **F3c — the flip (higher risk):** flip the ~23 text/comment construction sites to
+  `document.CreateTextNode`/`CreateComment` (incl. `HtmlTreeBuilder.ConvertNode`, whose `allElements`
+  list widens to `DomNode`); split `TextContent`'s remaining element-aggregation double duty (element
+  `textContent` set → child `DomText`; get → compute over child `DomText`); narrow `ChildElements` to
+  `OfType<DomElement>()` and route the text-needing callers (serialization `GetChildren`, JS
+  `childNodes`, `CollectTextContent`, the Range routines) to raw `ChildNodes`; fix the three
+  `Traversal.cs` tree-node casts (`:62`, `:71`, `:232`) + `ToTraversalJsValue`; make `CloneDomElement`
+  clone canonical char-data via the document factories; switch serialization `GetKind` to a `NodeType`
+  switch; remove facade `TextContent` + the `NodeValue` override. Gate on WPT
+  range/selection/serialization + Acid. (`IsComment`/`BridgeText`/`SetBridgeText` and the ~80
+  character-data sites are already done in F3a.)
 - **F4 — construction flip + cache re-key + delete facade:** flip the ~40 real-element
   `new DomElement(...)` sites to `document.CreateElement`/`CreateElementNS` (removes the `NamespaceURI`
   ctor-coupling — `SetName` is `protected`, so the namespace must be set at construction); retire

--- a/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
+++ b/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
@@ -23,9 +23,12 @@ are done. The facade removal is unblocked.
 
 ## Status at a glance (2026-07-11)
 
-Branch `claude/rf-bridge-1c-domelement-facade-migration`. Each row is its own commit, every one
-regression-free against the full `Broiler.Cli.Tests` (1699, slot-scroll crasher excluded) 78-failure
-environmental baseline.
+Phases A–E2 on branch `claude/rf-bridge-1c-domelement-facade-migration`; Phase C2 on branch
+`claude/htmlbridge-domelement-removal-ucyw5j`. Each row is its own commit, every one regression-free
+against the full `Broiler.Cli.Tests` (1699, slot-scroll crasher excluded) environmental baseline —
+Phase C2 verified 0 baseline-passing tests regressed (before/after trx diff; the sole delta is the
+pre-existing `GoogleSearchPolyfillTests` render/scroll environmental failures, confirmed failing on the
+pre-change tree too).
 
 | Facade member removed | Phase | Moved to | Sites |
 | --- | --- | --- | --- |
@@ -35,14 +38,15 @@ environmental baseline.
 | `Parent` | E1 | canonical `ParentNode` via `ParentEl`/`SetParent` | ~450 |
 | `IsTextNode` | D1 | canonical `NodeType` via `IsText(node)` | 119 |
 | `Children` (+ `LegacyChildList`) | E2 | canonical `ChildNodes` via `ChildElements`/… | 421 |
+| `NsAttrMap` | C2 | canonical namespaced attributes via `TryGetNsAttribute`/`GetAttributeNS` | 18 |
 
-**Facade `DomElement` still carries:** `InnerHtml`, `TextContent`, `NamespaceURI`, `NsAttrMap`.
+**Facade `DomElement` still carries:** `InnerHtml`, `TextContent`, `NamespaceURI`.
 
-**Not yet started:** **Phase C2** (`NsAttrMap` → canonical namespaced attributes) and the **Phase F
-cutover** — flip text/comment construction to canonical `DomText`/`DomComment` (removing `TextContent`),
-which cascades into re-typing `RangeState`, `_knownNodes`, and the JS-object cache, then re-key the
-remaining per-node caches, remove `HtmlTreeBuilder`, and delete the `DomElement` type. `InnerHtml` and
-`NamespaceURI` (ctor-coupled; `SetName` is `protected`) fold into Phase F.
+**Not yet started:** the **Phase F cutover** — flip text/comment construction to canonical
+`DomText`/`DomComment` (removing `TextContent`), which cascades into re-typing `RangeState`,
+`_knownNodes`, and the JS-object cache, then re-key the remaining per-node caches, remove
+`HtmlTreeBuilder`, and delete the `DomElement` type. `InnerHtml` and `NamespaceURI` (ctor-coupled;
+`SetName` is `protected`) fold into Phase F.
 
 ## The facade in one paragraph
 
@@ -151,10 +155,11 @@ safe and is the true prerequisite for canonical text.
 Each phase is one or more PRs, each independently building + green. Gate every phase on
 the **full** validation set (see "Validation" below), baselined first per `CLAUDE.md`.
 
-**Progress (2026-07-10/11):** Phases A + B + C **DONE** on branch
-`claude/rf-bridge-1c-domelement-facade-migration`, each full-`Broiler.Cli.Tests` regression-free
-(78-failure baseline; the only diff is the documented `GoogleSearchPolyfillTests`
-scrollIntoView-% parallel flake, which passes in isolation).
+**Progress (2026-07-10/11):** Phases A + B + C + E1 + D1 + E2 **DONE** on branch
+`claude/rf-bridge-1c-domelement-facade-migration`; **Phase C2 DONE** on branch
+`claude/htmlbridge-domelement-removal-ucyw5j`. Each is full-`Broiler.Cli.Tests` regression-free
+(the only diff is the documented `GoogleSearchPolyfillTests` render/scroll environmental failures,
+confirmed pre-existing on the pre-change tree).
 - **Phase A** — `JsSetStyleProps` + `OwnerDocRoot` → `ElementRuntimeState` (42 sites).
 - **Phase B** — inline `.Style` → ERS via `DomBridge.InlineStyle(element)` (lazy-seeds from the
   `style=` attribute on first access; ~200 sites; clone + dialog-backdrop seed explicitly; facade
@@ -203,6 +208,21 @@ scrollIntoView-% parallel flake, which passes in isolation).
   *notifying* `RemoveChildAt` (raw primitive renamed `RemoveNthChild`; self-recursion fixed). Full
   `Broiler.Cli.Tests` empty-diff vs baseline, before and after removing the member.
 
+- **Phase C2 (`NsAttrMap`) — DONE.** Facade `NsAttrMap` (the `(namespace, localName) → qualifiedName`
+  shadow map) removed; **18 sites** migrated to the canonical namespace-keyed attribute set, which
+  already encodes namespace + local + qualified name + value. A bridge helper
+  `TryGetNsAttribute(element, ns, localName, out qName, out value)` does the direct canonical
+  `Attributes.TryGetValue((ns, localName))` lookup (normalizing `""`→`null` like `SetAttributeNS`/
+  `GetAttributeNS`); the plain `getAttributeNS`/`hasAttributeNS` callbacks route straight through
+  canonical `GetAttributeNS`. `TryGetAttachedAttrNamespace` scans canonical attributes (skipping the
+  no-namespace ones, so the colon-split fallback still governs them); `isEqualNode`'s attribute check
+  collapses to a single `CanonicalAttributesAreEqual`; `cloneNode` copies attributes straight from the
+  canonical set (via `SetAttribute`/`SetAttributeNS`), restoring the namespace fidelity that used to
+  ride on the shadow map. The behaviour change is limited to spec corrections that were previously
+  latent (`getAttributeNS(null, htmlAttr)`/`hasAttributeNS(null, htmlAttr)` now find no-namespace
+  attributes); every existing NS-attribute characterization test still passes and serialization output
+  is byte-identical (it reads `QualifiedName`). Full `Broiler.Cli.Tests` regression-free.
+
 **What remains of D+E2 — the text→canonical construction flip (Phase F territory):** `TextContent`
 (90 sites) → `DomText`/`DomComment`.`Data`, and flipping the ~20 text/comment **construction** sites to
 `document.CreateTextNode`/`CreateComment`. This is deferred because it **cascades beyond the facade**: a
@@ -212,8 +232,8 @@ Phase F cache/RangeState cutover. At that point `ChildElements` narrows to `OfTy
 tree-walk bodies gain `IsText`/`is DomElement` handling. Gate on the WPT range/selection + serialization
 corpus.
 
-Facade now retains: `InnerHtml` (Phase F), `NsAttrMap` (Phase C2), `TextContent` (Phase F text flip),
-`NamespaceURI` (Phase F). Next: **Phase C2** (`NsAttrMap`) or the **Phase F cutover** (text→`DomText`,
+Facade now retains: `InnerHtml` (Phase F), `TextContent` (Phase F text flip),
+`NamespaceURI` (Phase F). Next: the **Phase F cutover** (text→`DomText`,
 construction flip, cache/`RangeState` re-keying, delete the facade type).
 
 ### Phase A — Relocate facade-only bridge state into `ElementRuntimeState`
@@ -282,6 +302,14 @@ ERS; computed-style, anchor, animation, serialization suites green.
 **Risk.** Medium-High. Heaviest in `ElementInterfaces.cs`, `JsObjects.cs`,
 `Attributes.cs`, `Registration.cs`. **Exit.** Attribute access is canonical; XHTML/NS
 attribute WPT + Acid cases green.
+
+**Done (2026-07-11).** Phase C landed the string-keyed side; **Phase C2** then removed
+`NsAttrMap` outright. No residue needed relocating to ERS — the canonical namespace-keyed
+attribute set (`(namespace, localName) → DomAttribute` with `QualifiedName`/`Value`) is a
+strict superset of what the shadow map carried, so every lookup became a direct
+`Attributes.TryGetValue((ns, localName))` (helper `TryGetNsAttribute`) or a canonical
+`GetAttributeNS`, and `cloneNode`/`isEqualNode` read the same canonical set. The frozen
+`"NsAttrMap"` entry is gone; `LegacyMutableCollectionProperties` is now empty.
 
 ### Phase E — Widen tree-shape traversal to `DomNode` (prerequisite for D)
 

--- a/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
+++ b/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
@@ -23,7 +23,7 @@ are done. The facade removal is unblocked.
 
 ## Status at a glance (2026-07-11)
 
-Phases A–E2 on branch `claude/rf-bridge-1c-domelement-facade-migration`; Phases C2 + F1 + F3a on branch
+Phases A–E2 on branch `claude/rf-bridge-1c-domelement-facade-migration`; Phases C2 + F1 + F3a + F3b on branch
 `claude/htmlbridge-domelement-removal-ucyw5j`. Each row is its own commit, every one regression-free
 against the full `Broiler.Cli.Tests` (1699, slot-scroll crasher excluded) environmental baseline —
 Phase C2 verified 0 baseline-passing tests regressed (before/after trx diff; the sole delta is the
@@ -56,26 +56,29 @@ pre-change tree too).
   homogeneous facade tree; full `Broiler.Cli.Tests` regression-free. Element-level `textContent`
   aggregation and text/comment construction are intentionally left for F3c.
 
+- **F3b — widen the node-identity surface to `DomNode` (safe, no behaviour change). DONE.** Re-typed
+  `_knownNodes` and `_jsObjectCache` to canonical `DomNode`, widened `ToJSObject(DomNode)` (body keeps a
+  `(DomElement)node` cast that always succeeds on today's homogeneous tree), and added
+  `FindDomNodeByJSObject` (the raw reverse lookup; `FindDomElementByJSObject` now narrows with
+  `as DomElement`). Full `Broiler.Cli.Tests` regression-free. `RangeState` + the ~10 range helpers it
+  feeds stay `DomElement`-typed — that widen cascades and lands with the flip in F3c.
+
 **Phase F remaining (staged):**
-- **F3b — widen the node-identity surface to `DomNode` (safe, no behaviour change):** re-type
-  `_knownNodes`, `_jsObjectCache`, `RangeState.StartContainer`/`EndContainer`, `_docRootToDocJSObject`,
-  mutation-observer targets, and `RuntimeValue<DomElement>` (shadow root/host) from the facade to
-  canonical `DomNode` (a facade node IS-A `DomNode`, so this compiles and behaves identically on the
-  current tree). Rework `ToJSObject(DomNode)` to build a minimal Node/CharacterData wrapper for
-  non-element nodes while the element body stays cast-guarded; add `FindDomNodeByJSObject`.
-  **The blocker for F3c:** today `ToJSObject` gives every node — text/comment included — the full
-  element wrapper; a canonical `DomText`/`DomComment` (not a `DomElement`) needs its own wrapper.
-- **F3c — the flip (higher risk):** flip the ~23 text/comment construction sites to
-  `document.CreateTextNode`/`CreateComment` (incl. `HtmlTreeBuilder.ConvertNode`, whose `allElements`
-  list widens to `DomNode`); split `TextContent`'s remaining element-aggregation double duty (element
-  `textContent` set → child `DomText`; get → compute over child `DomText`); narrow `ChildElements` to
-  `OfType<DomElement>()` and route the text-needing callers (serialization `GetChildren`, JS
-  `childNodes`, `CollectTextContent`, the Range routines) to raw `ChildNodes`; fix the three
-  `Traversal.cs` tree-node casts (`:62`, `:71`, `:232`) + `ToTraversalJsValue`; make `CloneDomElement`
-  clone canonical char-data via the document factories; switch serialization `GetKind` to a `NodeType`
-  switch; remove facade `TextContent` + the `NodeValue` override. Gate on WPT
-  range/selection/serialization + Acid. (`IsComment`/`BridgeText`/`SetBridgeText` and the ~80
-  character-data sites are already done in F3a.)
+- **F3c — the flip (higher risk).** **The `ToJSObject` blocker:** today `ToJSObject` gives every node
+  — text/comment included — the full element wrapper; a canonical `DomText`/`DomComment` (not a
+  `DomElement`) needs its own minimal Node/CharacterData wrapper (replacing the `(DomElement)node` cast
+  F3b left in place). Then: widen `RangeState.StartContainer`/`EndContainer`/`Root` + the ~10 range
+  helpers they feed to `DomNode` (and `_mutationObservers` targets for characterData observers); flip
+  the ~23 text/comment construction sites to `document.CreateTextNode`/`CreateComment` (incl.
+  `HtmlTreeBuilder.ConvertNode`, whose `allElements` list widens to `DomNode`); split `TextContent`'s
+  remaining element-aggregation double duty (element `textContent` set → child `DomText`; get → compute
+  over child `DomText`); narrow `ChildElements` to `OfType<DomElement>()` and route the text-needing
+  callers (serialization `GetChildren`, JS `childNodes`, `CollectTextContent`, the Range routines) to
+  raw `ChildNodes`; fix the three `Traversal.cs` tree-node casts (`:62`, `:71`, `:232`) +
+  `ToTraversalJsValue`; make `CloneDomElement` clone canonical char-data via the document factories;
+  switch serialization `GetKind` to a `NodeType` switch; remove facade `TextContent` + the `NodeValue`
+  override. Gate on WPT range/selection/serialization + Acid. (`IsComment`/`BridgeText`/`SetBridgeText`,
+  the ~80 character-data sites, and the `DomNode` node-identity widening are already done in F3a+F3b.)
 - **F4 — construction flip + cache re-key + delete facade:** flip the ~40 real-element
   `new DomElement(...)` sites to `document.CreateElement`/`CreateElementNS` (removes the `NamespaceURI`
   ctor-coupling — `SetName` is `protected`, so the namespace must be set at construction); retire

--- a/docs/roadmap/htmlbridge-facade-removal-current-state.md
+++ b/docs/roadmap/htmlbridge-facade-removal-current-state.md
@@ -1,0 +1,130 @@
+# HtmlBridge `DomElement` Facade Removal — Current State & Handoff
+
+Status: **in progress** — facade thinned to 2 remaining members; the irreversible
+text-node flip (F3c part 2) is teed up but not yet applied.
+Last updated: 2026-07-11.
+
+This is the standalone "where things stand" snapshot for the RF-BRIDGE-1c effort
+(Milestones 1.2/1.3 of the blocked-items roadmap). The *design* lives in
+[`htmlbridge-domelement-facade-removal-plan.md`](htmlbridge-domelement-facade-removal-plan.md);
+this file is the current-state summary a reviewer or the next implementer can read
+on its own.
+
+## 1. What this effort does
+
+`Broiler.HtmlBridge.DomElement` (`src/Broiler.HtmlBridge.Core/Dom/DomElement.cs`) is a
+`public sealed class DomElement : Broiler.Dom.DomElement` — a compatibility facade the
+bridge builds its **entire node tree** from, including text/comment nodes (modeled as a
+facade `DomElement` with a text/comment `NodeType`, not canonical `DomText`/`DomComment`).
+`HtmlTreeBuilder.ConvertNode` re-materializes the canonically-parsed tree back into facade
+instances. The goal is to delete both types so the bridge holds only canonical
+`Broiler.Dom` nodes and bridge-runtime state, by giving every facade member a canonical or
+`ElementRuntimeState` (ERS) home, then flipping construction to canonical factories.
+
+## 2. Facade surface: removed vs remaining
+
+| Facade member | Status | Relocated to |
+| --- | --- | --- |
+| `JsSetStyleProps`, `OwnerDocRoot` | ✅ removed (A) | `ElementRuntimeState` |
+| `Style` | ✅ removed (B) | ERS via `InlineStyle(node)` |
+| `Attributes` (+`LegacyAttributeDictionary`) | ✅ removed (C) | canonical attributes |
+| `Parent` | ✅ removed (E1) | canonical `ParentNode` via `ParentEl`/`SetParent` |
+| `IsTextNode` | ✅ removed (D1) | canonical `NodeType` via `IsText(node)` |
+| `Children` (+`LegacyChildList`) | ✅ removed (E2) | canonical `ChildNodes` |
+| `NsAttrMap` | ✅ removed (C2) | canonical namespaced attributes |
+| `InnerHtml` | ✅ removed (F1) | ERS |
+| **`TextContent`** | ⏳ **remains** | → canonical `DomText`/`DomComment`.`Data` (F3c part 2) |
+| **`NamespaceURI`** | ⏳ **remains** | → canonical read + `CreateElementNS` at construction (F4) |
+
+`DomElement` and `HtmlTreeBuilder` themselves are deleted in **F4**.
+
+## 3. Transitional machinery currently in place
+
+Introduced by the in-progress phases; the next implementer builds on these:
+
+- **Character data:** `BridgeText(DomNode)` / `SetBridgeText(DomNode, string)` read/write a
+  text/comment node's data over canonical `DomCharacterData.Data`, with a facade
+  `TextContent` fallback while the tree is still facade. `IsText(DomNode)` /
+  `IsComment(DomNode)` discriminate by `NodeType`. **All ~80 character-data + comment sites
+  already route through these** (F3a) — so the flip only has to change *construction*.
+- **Attributes:** `TryGetAttribute`/`GetAttr`/`HasAttr`/`SetAttr`/`RemoveAttr`/`AttributeNames`/
+  `AttributeSnapshot`/`RestoreAttributes` (Phase C) and `TryGetNsAttribute` (C2) express the
+  old string-keyed + namespaced surface over the canonical namespace-keyed attribute set.
+- **Inline style:** ERS-backed `InlineStyle(node)` (Phase B).
+- **Node identity (F3b + F3c-part1):** `_knownNodes`, `_jsObjectCache`, `ElementRuntimeStates`
+  (CWT) / `GetElementRuntimeState`, `_mutationObservers` targets, `ChildIndexOf`, `ParentEl`,
+  `SetParent`, `GetTreeRoot`/`ToJSRootNode`, and the JS Node-navigation callbacks
+  (`childNodes`/`firstChild`/`lastChild`/`nextSibling`/`previousSibling`/`isConnected`,
+  `nodeType`/`nodeName`) are all typed on canonical **`DomNode`**. `FindDomNodeByJSObject`
+  resolves any node from its JS wrapper (`FindDomElementByJSObject` narrows with `as DomElement`).
+  `ToJSObject(DomNode)` currently keeps a `(DomElement)node` cast that always succeeds on
+  today's homogeneous tree — F3c part 2 replaces it with the char-data branch.
+
+Everything above is **behaviour-preserving on the current homogeneous facade tree** and
+verified regression-free against the full `Broiler.Cli.Tests` (1699 tests).
+
+## 4. What remains — F3c part 2 (the atomic flip)
+
+This is the one irreversible, **big-bang** step: the moment a canonical `DomText` enters the
+tree, every site below must already handle a non-`DomElement` child, so it cannot be
+decomposed into more build-green commits. Concrete work, roughly in order:
+
+1. **`ChildAt` → `DomNode`** and fix the resulting **~68 tree-heterogeneity sites** (range
+   extraction in `Traversal.cs`/`JsFunctionCallbacks/Traversal.cs`, TreeWalker/NodeIterator,
+   `normalize`, `SubDocuments.cs`, `Utilities.cs`, `HitTesting.cs`, `Css.cs`,
+   `AnchorResolver/*`) so they handle/skip non-element children correctly. *(Measured: 68
+   compile errors across 9 files when `ChildAt` returns `DomNode`.)*
+2. **`ToJSObject` split** — the blocker. `ToJSObject` is an 823-line method (~110 properties)
+   whose Node-level/CharacterData callbacks are all typed `DomElement`. Split it into
+   node-level (all nodes) + element-only (`if (node is DomElement element)`), giving canonical
+   `DomText`/`DomComment` a proper minimal wrapper (replacing the `(DomElement)node` cast).
+   F3c-part1 already widened the navigation/`nodeType`/`nodeName` callbacks; the CharacterData
+   (`data`/`length`/`splitText`/`substring`/`append`/`delete`/`insert`/`replaceData`),
+   `cloneNode`, `remove`, `before`/`after`/`replaceWith`, EventTarget, `contains`,
+   `compareDocumentPosition`, `isSameNode`, `normalize`, `isEqualNode`, `getRootNode`,
+   `ownerDocument`, `parentElement` callbacks still need widening to `DomNode`.
+3. **`RangeState` cascade** — widen `StartContainer`/`EndContainer`/`Root` and the ~10 range
+   helpers they feed (`GetNodesInRange`, `CollectRangeText`, `CreatePartialCloneForExtract`,
+   `ExtractStartPath`/`EndPath`, `FindCommonAncestor`, `GetDocumentOrderNodes`, …) to `DomNode`.
+4. **Construction flip** — the ~23 `new DomElement("#text"/"#comment", …)` sites →
+   `document.CreateTextNode`/`CreateComment`, including `HtmlTreeBuilder.ConvertNode` (whose
+   `allElements: List<DomElement>` widens to `List<DomNode>`; update its 5 callers).
+5. **Split `TextContent`'s element-aggregation duty** — element `textContent` *set* → clear +
+   append a child `DomText`; *get* → aggregate over child `DomText`. Remove the element-store
+   shortcut (`Common.cs:34`, `SubDocumentObjects.cs:53/74`, `LayoutMetrics.cs:709/1523/1534`,
+   `Css.cs:573`, `SubDocuments.cs:1145/1406`, `AnimationResolver.cs:43/186`,
+   `Serialization.cs:322`, `Utilities.cs` clone).
+6. **`ChildElements` → `OfType<DomElement>()`** and route the text-needing callers
+   (serialization `GetChildren`, JS `childNodes`, `CollectTextContent`, the Range routines) to
+   raw `ChildNodes`.
+7. **`CloneDomElement`** clone canonical char-data via the document factories; fix the three
+   raw casts in `Traversal.cs` (`:62`, `:71`, `:232`) + `ToTraversalJsValue`; switch
+   serialization `GetKind` to a `NodeType` switch; widen the serialization adapter off
+   `<DomElement>`.
+8. **Remove facade `TextContent` + the `NodeValue` override**; update the frozen scalar guard.
+
+**Gate:** the plan requires the WPT range/selection/serialization + Acid corpus in addition to
+`Broiler.Cli.Tests` for this step (silent `outerHTML`/selection corruption is the failure mode).
+
+## 5. What remains — F4 (final cutover, irreversible)
+
+Flip the ~40 real-element `new DomElement(...)` sites to `document.CreateElement`/
+`CreateElementNS` (this removes the `NamespaceURI` ctor-coupling — canonical `SetName` is
+`protected`, so namespace must be set at construction); retire `HtmlTreeBuilder` (callers use
+`Broiler.Dom.Html.HtmlDocumentParser.ParseDocument(html, _document)` directly); re-key the ~14
+remaining per-node caches to canonical `DomElement`; widen the public seams `DomBridge.Elements`/
+`DocumentElement` + `IDomBridgeRuntime.Elements` to canonical `Broiler.Dom.DomElement` (only
+external consumer needing a touch: `Broiler.Wpt.Tests/WptTestRunnerTests.cs`); remove facade
+`NamespaceURI`; delete `DomElement.cs` + `HtmlTreeBuilder.cs`; update/remove the frozen seam
+guard tests (`DomExtractionPhaseZeroTests`, `HtmlBridgePromotionPhaseZeroTests`,
+`HtmlBridgeBoundaryGuardTests`).
+
+## 6. Verification methodology (used for every landed commit)
+
+Baseline the full `Broiler.Cli.Tests` first (per `CLAUDE.md`), then require **zero
+baseline-passing tests to regress** via a before/after TRX name diff. The
+`ScrollIntoView_Treats_Assigned_Slot_As_Scroll_Container` slot-scroll crasher is excluded (it
+stack-overflows and aborts the host). The steady-state environmental baseline is **81 failures /
+1618 passes / 1699 total** — all pre-existing (graphics/Skia, PDF, HTTP, WPT-render,
+flex/grid, `GoogleSearchPolyfillTests` scroll/render), each confirmed failing on the pre-change
+tree. One F3a run aborted mid-suite on a parallel-load OOM flake that cleared on rerun.

--- a/src/Broiler.Cli.Tests/DomExtractionPhaseZeroTests.cs
+++ b/src/Broiler.Cli.Tests/DomExtractionPhaseZeroTests.cs
@@ -14,12 +14,11 @@ public sealed class DomExtractionPhaseZeroTests
     // RF-BRIDGE-1c relocated bridge runtime state off the facade into
     // ElementRuntimeState (the node model must not own it): Phase A moved
     // JsSetStyleProps + OwnerDocRoot; Phase B moved the inline Style dictionary
-    // (now reached via DomBridge.InlineStyle). They no longer appear on the
-    // DomElement surface below.
-    private static readonly string[] LegacyMutableCollectionProperties =
-    [
-        "NsAttrMap",
-    ];
+    // (now reached via DomBridge.InlineStyle). Phase C2 removed NsAttrMap, whose
+    // (namespace, local name) → qualified-name bookkeeping is now derived from the
+    // canonical namespace-keyed attribute set. No mutable-collection property remains
+    // on the DomElement surface below.
+    private static readonly string[] LegacyMutableCollectionProperties = [];
 
     // RF-BRIDGE-1c Phase E relocated the facade Parent getter/setter to
     // DomBridge.ParentEl / SetParent over canonical ParentNode, so Parent is no

--- a/src/Broiler.Cli.Tests/DomExtractionPhaseZeroTests.cs
+++ b/src/Broiler.Cli.Tests/DomExtractionPhaseZeroTests.cs
@@ -22,12 +22,12 @@ public sealed class DomExtractionPhaseZeroTests
 
     // RF-BRIDGE-1c Phase E relocated the facade Parent getter/setter to
     // DomBridge.ParentEl / SetParent over canonical ParentNode, so Parent is no
-    // longer a settable scalar on the DomElement surface below.
+    // longer a settable scalar on the DomElement surface below. Phase F relocated
+    // InnerHtml into ElementRuntimeState, so it is no longer a settable scalar either.
     private static readonly string[] LegacySettableScalarProperties =
     [
         "ClassName",
         "Id",
-        "InnerHtml",
         "NamespaceURI",
         "TextContent",
     ];

--- a/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
+++ b/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
@@ -51,7 +51,12 @@ public sealed class DomElement : CanonicalElement
                 tagName),
             ResolveNodeType(tagName, isTextNode))
     {
-        InnerHtml = innerHtml;
+        // RF-BRIDGE-1c Phase F: raw inner-HTML is no longer stored on the node. It lives in
+        // ElementRuntimeState and is reached via DomBridge.GetElementRuntimeState(element).InnerHtml,
+        // seeded by the innerHTML setter and copied across cloneNode. The `innerHtml` parameter is
+        // retained only for call-site compatibility until construction flips to canonical factories
+        // (Phase F); it is intentionally not read here.
+        _ = innerHtml;
         // RF-BRIDGE-1c Phase B: inline style is no longer stored on the node. It lives in
         // ElementRuntimeState and is reached via DomBridge.InlineStyle(element), which lazily
         // seeds it from the `style=` attribute (already applied from `attributes` below). The
@@ -89,8 +94,6 @@ public sealed class DomElement : CanonicalElement
         get => base.ClassName;
         set => base.ClassName = value;
     }
-
-    public string InnerHtml { get; set; }
 
     public string? TextContent
     {

--- a/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
+++ b/src/Broiler.HtmlBridge.Core/Dom/DomElement.cs
@@ -120,8 +120,6 @@ public sealed class DomElement : CanonicalElement
         set => SetName(new CanonicalName(value, TagName));
     }
 
-    public Dictionary<(string? Namespace, string LocalName), string> NsAttrMap { get; } = [];
-
     private static bool IsSpecialNode(string tagName) => tagName.StartsWith('#');
 
     private static CanonicalNodeType ResolveNodeType(string tagName, bool isTextNode) =>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -174,14 +174,15 @@ public sealed partial class DomBridge
     {
         for (int i = element.ChildNodes.Count - 1; i >= 0; i--)
         {
-            var child = ChildAt(element, i);
-            if (string.Equals(child.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+            var child = element.ChildNodes[i];
+            if (IsComment(child))
             {
                 RemoveNthChild(element, i);
                 continue;
             }
 
-            RemoveRenderCommentNodes(child);
+            if (child is DomElement childElement)
+                RemoveRenderCommentNodes(childElement);
         }
     }
 
@@ -874,7 +875,7 @@ public sealed partial class DomBridge
         GetAttributes: GetSerializableAttributes,
         GetStyles: static element =>
             InlineStyle(element).OrderBy(kv => SharedHtmlSerializer.IsShorthandProperty(kv.Key) ? 0 : 1),
-        GetText: static element => element.TextContent,
+        GetText: static element => BridgeText(element),
         GetRawInnerHtml: static element => GetElementRuntimeState(element).InnerHtml);
 
     private IEnumerable<KeyValuePair<string, string>> GetSerializableAttributes(DomElement element)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -318,7 +318,7 @@ public sealed partial class DomBridge
             InlineStyle(element)["height"] = height;
 
         ClearChildren(element);
-        element.InnerHtml = string.Empty;
+        GetElementRuntimeState(element).InnerHtml = string.Empty;
         element.TextContent = null;
 
         var fill = new DomElement("div", null, null, string.Empty);
@@ -875,7 +875,7 @@ public sealed partial class DomBridge
         GetStyles: static element =>
             InlineStyle(element).OrderBy(kv => SharedHtmlSerializer.IsShorthandProperty(kv.Key) ? 0 : 1),
         GetText: static element => element.TextContent,
-        GetRawInnerHtml: static element => element.InnerHtml);
+        GetRawInnerHtml: static element => GetElementRuntimeState(element).InnerHtml);
 
     private IEnumerable<KeyValuePair<string, string>> GetSerializableAttributes(DomElement element)
     {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -51,12 +51,12 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     // widen on the current homogeneous tree.
     private readonly HashSet<Broiler.Dom.DomNode> _knownNodes =
         new(ReferenceEqualityComparer.Instance);
-    private readonly List<(JSObject Observer, DomElement Target, Broiler.Dom.DomMutationObserverOptions Options)> _mutationObservers = [];
+    private readonly List<(JSObject Observer, Broiler.Dom.DomNode Target, Broiler.Dom.DomMutationObserverOptions Options)> _mutationObservers = [];
     private readonly List<WeakReference<RangeState>> _activeRanges = [];
     private readonly List<WeakReference<Broiler.Dom.DomNodeIterator>> _activeNodeIterators = [];
     private readonly CanonicalDocument _document;
     private readonly DomElement _documentNode;
-    private static readonly ConditionalWeakTable<DomElement, ElementRuntimeState> ElementRuntimeStates = [];
+    private static readonly ConditionalWeakTable<Broiler.Dom.DomNode, ElementRuntimeState> ElementRuntimeStates = [];
     private JSObject? _documentJSObject;
     private JSObject? _windowJSObject;
     private JSObject? _visualViewportJSObject;
@@ -182,8 +182,8 @@ public sealed partial class DomBridge : IDomBridgeRuntime
             .OfType<DomElement>()
             .Where(element => !ReferenceEquals(element, _documentNode))];
 
-    private static ElementRuntimeState GetElementRuntimeState(DomElement element) =>
-        ElementRuntimeStates.GetValue(element, static _ => new ElementRuntimeState());
+    private static ElementRuntimeState GetElementRuntimeState(Broiler.Dom.DomNode node) =>
+        ElementRuntimeStates.GetValue(node, static _ => new ElementRuntimeState());
 
     /// <summary>
     /// The element's authoritative in-memory inline style dictionary (CSS kebab-case),
@@ -217,7 +217,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
 
     /// <summary>Index of <paramref name="child"/> among the element's children, or -1
     /// (old <c>Children.IndexOf</c>, reference equality).</summary>
-    private static int ChildIndexOf(DomElement element, Broiler.Dom.DomNode child)
+    private static int ChildIndexOf(Broiler.Dom.DomNode element, Broiler.Dom.DomNode child)
     {
         for (var i = 0; i < element.ChildNodes.Count; i++)
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -258,6 +258,33 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// <c>Children</c>/text cutover.</summary>
     private static bool IsText(Broiler.Dom.DomNode node) => node.NodeType == Broiler.Dom.DomNodeType.Text;
 
+    /// <summary>Whether <paramref name="node"/> is a comment node (RF-BRIDGE-1c Phase F).
+    /// NodeType-based, so it holds for the current facade comment nodes and for canonical
+    /// <c>DomComment</c> once construction flips — the replacement for the many
+    /// <c>TagName == "#comment"</c> checks, since a canonical <c>DomComment</c> has no
+    /// <c>TagName</c>.</summary>
+    private static bool IsComment(Broiler.Dom.DomNode node) => node.NodeType == Broiler.Dom.DomNodeType.Comment;
+
+    /// <summary>Reads a text/comment node's character data (RF-BRIDGE-1c Phase F). Canonical
+    /// <c>DomText</c>/<c>DomComment</c> expose it as <c>Data</c>; the facade text/comment nodes
+    /// (pre-flip) expose it as <c>TextContent</c>. The single accessor both models funnel through
+    /// during the text cutover; returns <c>""</c> (never null) for character-data nodes.</summary>
+    private static string BridgeText(Broiler.Dom.DomNode node) => node switch
+    {
+        Broiler.Dom.DomCharacterData characterData => characterData.Data,
+        DomElement facade => facade.TextContent ?? string.Empty,
+        _ => node.NodeValue ?? string.Empty,
+    };
+
+    /// <summary>Writes a text/comment node's character data (see <see cref="BridgeText"/>).</summary>
+    private static void SetBridgeText(Broiler.Dom.DomNode node, string value)
+    {
+        if (node is Broiler.Dom.DomCharacterData characterData)
+            characterData.Data = value;
+        else if (node is DomElement facade)
+            facade.TextContent = value;
+    }
+
     /// <summary>The element's parent as a <see cref="DomElement"/> (RF-BRIDGE-1c Phase E:
     /// replaces the facade <c>ParentEl(DomElement)</c> getter — <c>ParentNode as DomElement</c>).
     /// A node's parent is always an element, so this is stable when text/comment nodes become

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -293,12 +293,12 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// replaces the facade <c>ParentEl(DomElement)</c> getter — <c>ParentNode as DomElement</c>).
     /// A node's parent is always an element, so this is stable when text/comment nodes become
     /// canonical <c>DomText</c>/<c>DomComment</c> in Phase D.</summary>
-    private static DomElement? ParentEl(DomElement element) => element.ParentNode as DomElement;
+    private static DomElement? ParentEl(Broiler.Dom.DomNode node) => node.ParentNode as DomElement;
 
     /// <summary>Reparents <paramref name="child"/> under <paramref name="parent"/> (RF-BRIDGE-1c
     /// Phase E: replaces the facade <c>ParentEl(DomElement)</c> setter). A null parent detaches;
     /// otherwise the child is appended if not already there — matching the old setter exactly.</summary>
-    private static void SetParent(DomElement child, DomElement? parent)
+    private static void SetParent(Broiler.Dom.DomNode child, DomElement? parent)
     {
         if (parent is null)
             child.Remove();

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -45,7 +45,11 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     private static readonly string[] InlineEventNames = ["click", "load", "change", "input", "submit", "mousedown",
         "mouseup", "mouseover", "mouseout", "keydown", "keyup", "keypress", "focus", "blur", "error", "scroll",
         "scrollend"];
-    private readonly HashSet<DomElement> _knownNodes =
+    // RF-BRIDGE-1c Phase F (F3b): the registration set is keyed by canonical DomNode so
+    // it can hold text/comment nodes once they flip to canonical DomText/DomComment (which
+    // are not DomElement). A facade node IS-A DomNode, so this is a behaviour-preserving
+    // widen on the current homogeneous tree.
+    private readonly HashSet<Broiler.Dom.DomNode> _knownNodes =
         new(ReferenceEqualityComparer.Instance);
     private readonly List<(JSObject Observer, DomElement Target, Broiler.Dom.DomMutationObserverOptions Options)> _mutationObservers = [];
     private readonly List<WeakReference<RangeState>> _activeRanges = [];

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ContainingBlocks.cs
@@ -19,7 +19,7 @@ public sealed partial class DomBridge
     }
     private void EnsureContainingBlockPositioningTree(DomElement el)
     {
-        if (!IsText(el) && !string.Equals(el.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (!IsText(el) && !IsComment(el))
         {
             var props = CollectMatchedRuleProperties(el);
             foreach (var kv in InlineStyle(el))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/CssCleanup.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/CssCleanup.cs
@@ -24,8 +24,8 @@ public sealed partial class DomBridge
             // copy overflow ("Destination array…"), same idiom as AnchorRegistry.
             foreach (var child in SnapshotChildren(root))
             {
-                if (IsText(child) && !string.IsNullOrEmpty(child.TextContent))
-                    child.TextContent = RemoveUnsupportedCssRules(child.TextContent);
+                if (IsText(child) && !string.IsNullOrEmpty(BridgeText(child)))
+                    SetBridgeText(child, RemoveUnsupportedCssRules(BridgeText(child)));
             }
         }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
@@ -211,7 +211,7 @@ public sealed partial class DomBridge
             if (IsText(child))
             {
                 // Estimate text width from font-size (Ahem font: 1ch = font-size).
-                int charCount = (child.TextContent ?? "").Length;
+                int charCount = BridgeText(child).Length;
                 totalWidth += charCount * fontSize;
             }
             else
@@ -499,7 +499,7 @@ public sealed partial class DomBridge
             if (IsText(sibling))
             {
                 // Count line breaks in text content.
-                var text = sibling.TextContent ?? "";
+                var text = BridgeText(sibling);
                 int lineBreaks = text.Count(c => c == '\n');
                 // Don't count text node line breaks as they're usually
                 // just whitespace in the HTML source.
@@ -571,7 +571,7 @@ public sealed partial class DomBridge
             if (IsText(sibling))
             {
                 // Decode HTML entities (e.g. &nbsp; → \u00A0) before counting.
-                var text = System.Net.WebUtility.HtmlDecode(sibling.TextContent ?? "");
+                var text = System.Net.WebUtility.HtmlDecode(BridgeText(sibling));
                 int charCount = 0;
                 foreach (char c in text)
                 {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
@@ -34,12 +34,12 @@ public sealed partial class DomBridge
         {
             foreach (var child in SnapshotChildren(el))
             {
-                if (IsText(child) && !string.IsNullOrEmpty(child.TextContent))
+                if (IsText(child) && !string.IsNullOrEmpty(BridgeText(child)))
                 {
                     // Strip CSS comments first: a comment inside a @position-try
                     // body (common in WPT, e.g. "/* 2: position right */") contains
                     // ':' and ';' that would otherwise corrupt declaration parsing.
-                    var styleText = CssCommentPattern.Replace(child.TextContent, " ");
+                    var styleText = CssCommentPattern.Replace(BridgeText(child), " ");
                     foreach (Match m in PositionTryParsePattern.Matches(styleText))
                     {
                         var name = m.Groups["name"].Value;
@@ -81,8 +81,7 @@ public sealed partial class DomBridge
         Dictionary<string, AnchorInfo> anchorRegistry,
         Dictionary<string, Dictionary<string, string>> positionTryRules)
     {
-        if (!IsText(element) &&
-            !string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (!IsText(element) && !IsComment(element))
         {
             // Collect all CSS + inline properties to find position-try-fallbacks.
             var cssProps = CollectMatchedRuleProperties(element);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
@@ -46,7 +46,7 @@ public sealed partial class DomBridge
             {
                 css = string.Concat(ChildElements(root)
                     .Where(c => IsText(c))
-                    .Select(c => c.TextContent ?? string.Empty));
+                    .Select(c => BridgeText(c)));
             }
             var styleSheet = new Broiler.CSS.CssParser().ParseStyleSheet(css);
             foreach (var atRule in styleSheet.Rules.OfType<Broiler.CSS.CssAtRule>())
@@ -188,7 +188,7 @@ public sealed partial class DomBridge
             {
                 css = string.Concat(ChildElements(node)
                     .Where(c => IsText(c))
-                    .Select(c => c.TextContent ?? string.Empty));
+                    .Select(c => BridgeText(c)));
             }
 
             var styleSheet = new Broiler.CSS.CssParser().ParseStyleSheet(css);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
@@ -80,6 +80,30 @@ public sealed partial class DomBridge
         return existing is { } found && element.RemoveAttributeNS(found.NamespaceUri, found.LocalName);
     }
 
+    /// <summary>
+    /// RF-BRIDGE-1c Phase C2: canonical replacement for the removed
+    /// <c>DomElement.NsAttrMap</c> shadow map. Looks up the attribute identified by
+    /// (<paramref name="namespaceUri"/>, <paramref name="localName"/>) directly in the
+    /// canonical namespace-keyed attribute set and yields its qualified (possibly
+    /// prefixed) name plus value — the exact pair <c>NsAttrMap</c> used to carry. The
+    /// namespace is normalized (empty string ≡ null) to match canonical attribute keying,
+    /// the same normalization <c>SetAttributeNS</c>/<c>GetAttributeNS</c> apply.
+    /// </summary>
+    private static bool TryGetNsAttribute(DomElement element, string? namespaceUri, string localName, out string qualifiedName, out string value)
+    {
+        var ns = string.IsNullOrEmpty(namespaceUri) ? null : namespaceUri;
+        if (element.Attributes.TryGetValue((ns, localName), out var attribute))
+        {
+            qualifiedName = attribute.QualifiedName;
+            value = attribute.Value;
+            return true;
+        }
+
+        qualifiedName = string.Empty;
+        value = string.Empty;
+        return false;
+    }
+
     /// <summary>Legacy <c>Attributes.Keys</c>: the qualified names of the element's attributes.</summary>
     private static IEnumerable<string> AttributeNames(DomElement element) =>
         element.Attributes.Values.Select(static attribute => attribute.QualifiedName);
@@ -268,13 +292,20 @@ public sealed partial class DomBridge
 
     private static bool TryGetAttachedAttrNamespace(DomElement element, string qualifiedName, out string? namespaceUri, out string localName)
     {
-        foreach (var kv in element.NsAttrMap)
+        // Match a genuinely namespaced attribute (non-null namespace) by qualified name —
+        // the set NsAttrMap used to track. No-namespace attributes are skipped so the
+        // colon-split fallback below governs their local name, exactly as before: a
+        // prefixed qualified name can only carry a namespace, so this never drops one.
+        foreach (var attribute in element.Attributes.Values)
         {
-            if (!string.Equals(kv.Value, qualifiedName, StringComparison.OrdinalIgnoreCase))
+            if (attribute.NamespaceUri is null ||
+                !string.Equals(attribute.QualifiedName, qualifiedName, StringComparison.OrdinalIgnoreCase))
+            {
                 continue;
+            }
 
-            namespaceUri = kv.Key.Namespace;
-            localName = kv.Key.LocalName;
+            namespaceUri = attribute.NamespaceUri;
+            localName = attribute.LocalName;
             return true;
         }
 
@@ -349,8 +380,6 @@ public sealed partial class DomBridge
     {
         TryGetAttribute(element, attrName, out var previousAttrVal);
         var removed = RemoveAttr(element, attrName);
-        foreach (var key in element.NsAttrMap.Where(kv => string.Equals(kv.Value, attrName, StringComparison.OrdinalIgnoreCase)).Select(kv => kv.Key).ToList())
-            element.NsAttrMap.Remove(key);
         if (string.Equals(attrName, "id", StringComparison.OrdinalIgnoreCase))
             element.Id = null;
         else if (string.Equals(attrName, "class", StringComparison.OrdinalIgnoreCase))
@@ -364,9 +393,12 @@ public sealed partial class DomBridge
     private void SetAttributeLikeSetAttributeNS(DomElement element, string? namespaceUri, string attrName, string localName, string attrVal)
     {
         string? previousAttrVal = null;
-        if (element.NsAttrMap.TryGetValue((namespaceUri, localName), out var previousQualifiedName))
+        if (TryGetNsAttribute(element, namespaceUri, localName, out var previousQualifiedName, out var existingAttrVal))
         {
-            TryGetAttribute(element, previousQualifiedName, out previousAttrVal);
+            previousAttrVal = existingAttrVal;
+            // A prefix change keeps the same (namespace, localName) canonical key, so the
+            // SetAttributeNS below replaces the old-prefix attribute in place. The explicit
+            // remove keeps the canonical mutation-record sequence identical to the shadow-map era.
             if (!string.Equals(previousQualifiedName, attrName, StringComparison.OrdinalIgnoreCase))
                 RemoveAttr(element, previousQualifiedName);
         }
@@ -376,7 +408,6 @@ public sealed partial class DomBridge
         }
 
         element.SetAttributeNS(namespaceUri, attrName, attrVal);
-        element.NsAttrMap[(namespaceUri, localName)] = attrName;
         if (string.Equals(attrName, "id", StringComparison.OrdinalIgnoreCase))
             element.Id = attrVal;
         else if (string.Equals(attrName, "class", StringComparison.OrdinalIgnoreCase))
@@ -402,12 +433,10 @@ public sealed partial class DomBridge
 
     private void RemoveAttributeLikeRemoveAttributeNS(DomElement element, string? namespaceUri, string localName)
     {
-        if (!element.NsAttrMap.TryGetValue((namespaceUri, localName), out var attrName))
+        if (!TryGetNsAttribute(element, namespaceUri, localName, out var attrName, out var previousAttrVal))
             return;
 
-        TryGetAttribute(element, attrName, out var previousAttrVal);
         var removed = RemoveAttr(element, attrName);
-        element.NsAttrMap.Remove((namespaceUri, localName));
         if (string.Equals(attrName, "id", StringComparison.OrdinalIgnoreCase))
             element.Id = null;
         else if (string.Equals(attrName, "class", StringComparison.OrdinalIgnoreCase))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -573,8 +573,8 @@ public sealed partial class DomBridge
         if (cssText.Length == 0 && styleEl.TextContent != null)
             cssText.Append(styleEl.TextContent);
 
-        if (cssText.Length == 0 && !string.IsNullOrEmpty(styleEl.InnerHtml))
-            cssText.Append(styleEl.InnerHtml);
+        if (cssText.Length == 0 && !string.IsNullOrEmpty(GetElementRuntimeState(styleEl).InnerHtml))
+            cssText.Append(GetElementRuntimeState(styleEl).InnerHtml);
 
         if (string.Equals(styleEl.TagName, "link", StringComparison.OrdinalIgnoreCase) &&
             cssText.Length == 0 &&

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -523,8 +523,8 @@ public sealed partial class DomBridge
         {
             if (IsText(child))
             {
-                if (!string.IsNullOrEmpty(child.TextContent))
-                    builder.Append(child.TextContent);
+                if (BridgeText(child).Length > 0)
+                    builder.Append(BridgeText(child));
                 continue;
             }
 
@@ -566,8 +566,8 @@ public sealed partial class DomBridge
         var cssText = new StringBuilder();
         foreach (var child in ChildElements(styleEl))
         {
-            if (IsText(child) && child.TextContent != null)
-                cssText.Append(child.TextContent);
+            if (IsText(child))
+                cssText.Append(BridgeText(child));
         }
 
         if (cssText.Length == 0 && styleEl.TextContent != null)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
@@ -37,6 +37,16 @@ internal sealed class ElementRuntimeState
     public DomElement? OwnerDocRoot { get; set; }
 
     /// <summary>
+    /// The element's raw inner-HTML/inner-text string — the source text for raw-text
+    /// elements (<c>&lt;style&gt;</c>/<c>&lt;script&gt;</c>/<c>&lt;textarea&gt;</c>), an
+    /// <c>innerHTML</c>-getter fallback, and the value round-tripped by serialization.
+    /// Relocated off the <c>DomElement</c> facade (RF-BRIDGE-1c Phase F — the node model
+    /// does not own this bridge state). Empty by default; seeded by the <c>innerHTML</c>
+    /// setter and copied across <c>cloneNode</c>.
+    /// </summary>
+    public string InnerHtml { get; set; } = string.Empty;
+
+    /// <summary>
     /// The node's inline style in CSS kebab-case — the authoritative in-memory inline
     /// style (mutated by JS <c>element.style</c>, the anchor resolver, and synthetic
     /// form-control styling; synced back to the <c>style=</c> attribute at serialization).

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Attributes.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Attributes.cs
@@ -24,7 +24,7 @@ public sealed partial class DomBridge
             return JSNull.Value;
         var ns = a[0].IsNull || a[0].IsUndefined ? null : a[0].ToString();
         var localName = a[1].ToString();
-        if (!element.NsAttrMap.TryGetValue((ns, localName), out var qName) || !TryGetAttribute(element, qName, out var val))
+        if (!TryGetNsAttribute(element, ns, localName, out var qName, out var val))
             return JSNull.Value;
         return BuildAttrNode(qName, val, element, ownerObj);
     }
@@ -60,7 +60,7 @@ public sealed partial class DomBridge
         var ns = GetAttrNodeNamespace(attrObj);
         var value = attrObj[(KeyString)"value"].ToString();
         JSValue old = JSNull.Value;
-        if (element.NsAttrMap.TryGetValue((ns, localName), out var oldQName) && TryGetAttribute(element, oldQName, out var oldVal))
+        if (TryGetNsAttribute(element, ns, localName, out var oldQName, out var oldVal))
             old = BuildAttrNode(oldQName, oldVal, element, ownerObj);
         SetAttributeLikeSetAttributeNS(element, ns, name, localName, value);
         return old;
@@ -86,7 +86,7 @@ public sealed partial class DomBridge
             return JSNull.Value;
         var ns = a[0].IsNull || a[0].IsUndefined ? null : a[0].ToString();
         var localName = a[1].ToString();
-        if (!element.NsAttrMap.TryGetValue((ns, localName), out var qName) || !TryGetAttribute(element, qName, out var val))
+        if (!TryGetNsAttribute(element, ns, localName, out var qName, out var val))
             return JSNull.Value;
         var removed = BuildAttrNode(qName, val, element, ownerObj);
         RemoveAttributeLikeRemoveAttributeNS(element, ns, localName);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
@@ -29,7 +29,7 @@ public sealed partial class DomBridge
     private JSValue GetNodeTextValue(DomElement element)
     {
         if (IsText(element))
-            return element.TextContent != null ? new JSString(element.TextContent) : new JSString(string.Empty);
+            return new JSString(BridgeText(element));
 
         if (element.TextContent != null && element.ChildNodes.Count == 0)
             return new JSString(element.TextContent);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
@@ -41,7 +41,7 @@ public sealed partial class DomBridge
             return new JSString(sb.ToString());
         }
 
-        return new JSString(element.InnerHtml);
+        return new JSString(GetElementRuntimeState(element).InnerHtml);
     }
 
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -115,7 +115,7 @@ public sealed partial class DomBridge
     private JSValue JsJsObjectsSetTextContent021Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
         var text = a.Length > 0 ? a[0].ToString() : string.Empty;
-        if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsText(element) || IsComment(element))
         {
             bridge.SetCharacterData(element, text);
             return JSUndefined.Value;
@@ -284,7 +284,7 @@ public sealed partial class DomBridge
     {
         if (IsText(element))
             return new JSNumber(3); // TEXT_NODE
-        if (string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsComment(element))
             return new JSNumber(8); // COMMENT_NODE
         if (string.Equals(element.TagName, "#document", StringComparison.OrdinalIgnoreCase))
             return new JSNumber(9); // DOCUMENT_NODE
@@ -300,7 +300,7 @@ public sealed partial class DomBridge
     {
         if (IsText(element))
             return new JSString("#text");
-        if (string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsComment(element))
             return new JSString("#comment");
         if (string.Equals(element.TagName, "#document", StringComparison.OrdinalIgnoreCase))
             return new JSString("#document");
@@ -354,15 +354,15 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetNodeValue043Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
-            return element.TextContent != null ? new JSString(element.TextContent) : JSNull.Value;
+        if (IsText(element) || IsComment(element))
+            return new JSString(BridgeText(element));
         return JSNull.Value;
     }
 
 
     private JSValue JsJsObjectsSetNodeValue044Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsText(element) || IsComment(element))
             bridge.SetCharacterData(element, a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
@@ -370,15 +370,15 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetData045Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
-            return element.TextContent != null ? new JSString(element.TextContent) : new JSString(string.Empty);
+        if (IsText(element) || IsComment(element))
+            return new JSString(BridgeText(element));
         return JSUndefined.Value;
     }
 
 
     private JSValue JsJsObjectsSetData046Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsText(element) || IsComment(element))
             bridge.SetCharacterData(element, a.Length > 0 ? a[0].ToString() : string.Empty);
         return JSUndefined.Value;
     }
@@ -386,8 +386,8 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetLength047Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
-        if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
-            return new JSNumber((element.TextContent ?? string.Empty).Length);
+        if (IsText(element) || IsComment(element))
+            return new JSNumber(BridgeText(element).Length);
         return new JSNumber(element.ChildNodes.Count);
     }
 
@@ -397,13 +397,13 @@ public sealed partial class DomBridge
         if (a.Length == 0)
             throw new JSException("Failed to execute 'splitText' on 'Text': 1 argument required, but only 0 present.");
         var offset = (int)a[0].DoubleValue;
-        var text = element.TextContent ?? string.Empty;
+        var text = BridgeText(element);
         if (offset < 0 || offset > text.Length)
             throw new JSException("Failed to execute 'splitText' on 'Text': The offset " + offset + " is larger than the node's length " + text.Length + ".");
         var remainingText = text.Substring(offset);
-        element.TextContent = text.Substring(0, offset);
+        SetBridgeText(element, text.Substring(0, offset));
         var newNode = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
-        newNode.TextContent = remainingText;
+        SetBridgeText(newNode, remainingText);
         _knownNodes.Add(newNode);
         // Insert new node as next sibling
         if (ParentEl(element) != null)
@@ -423,7 +423,7 @@ public sealed partial class DomBridge
     {
         var offset = a.Length > 0 ? (int)a[0].DoubleValue : 0;
         var count = a.Length > 1 ? Math.Max(0, (int)a[1].DoubleValue) : 0;
-        var text = element.TextContent ?? string.Empty;
+        var text = BridgeText(element);
         if (offset < 0 || offset > text.Length)
             throw new JSException("INDEX_SIZE_ERR");
         var end = (int)Math.Min((long)offset + count, text.Length);
@@ -434,7 +434,7 @@ public sealed partial class DomBridge
     private JSValue JsJsObjectsAppendData050Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomElement element, in Arguments a)
     {
         var data = a.Length > 0 ? a[0].ToString() : string.Empty;
-        bridge.SetCharacterData(element, (element.TextContent ?? string.Empty) + data);
+        bridge.SetCharacterData(element, BridgeText(element) + data);
         return JSUndefined.Value;
     }
 
@@ -443,7 +443,7 @@ public sealed partial class DomBridge
     {
         var offset = a.Length > 0 ? (int)a[0].DoubleValue : 0;
         var count = a.Length > 1 ? Math.Max(0, (int)a[1].DoubleValue) : 0;
-        var text = element.TextContent ?? string.Empty;
+        var text = BridgeText(element);
         if (offset < 0 || offset > text.Length)
             throw new JSException("INDEX_SIZE_ERR");
         var end = (int)Math.Min((long)offset + count, text.Length);
@@ -456,7 +456,7 @@ public sealed partial class DomBridge
     {
         var offset = a.Length > 0 ? (int)a[0].DoubleValue : 0;
         var data = a.Length > 1 ? a[1].ToString() : string.Empty;
-        var text = element.TextContent ?? string.Empty;
+        var text = BridgeText(element);
         if (offset < 0 || offset > text.Length)
             throw new JSException("INDEX_SIZE_ERR");
         bridge.SetCharacterData(element, text.Insert(offset, data));
@@ -469,7 +469,7 @@ public sealed partial class DomBridge
         var offset = a.Length > 0 ? (int)a[0].DoubleValue : 0;
         var count = a.Length > 1 ? Math.Max(0, (int)a[1].DoubleValue) : 0;
         var data = a.Length > 2 ? a[2].ToString() : string.Empty;
-        var text = element.TextContent ?? string.Empty;
+        var text = BridgeText(element);
         if (offset < 0 || offset > text.Length)
             throw new JSException("INDEX_SIZE_ERR");
         var end = (int)Math.Min((long)offset + count, text.Length);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -208,7 +208,7 @@ public sealed partial class DomBridge
             return JSNull.Value;
         var ns = a[0].IsNull || a[0].IsUndefined ? null : a[0].ToString();
         var localName = a[1].ToString();
-        if (!element.NsAttrMap.TryGetValue((ns, localName), out var qName) || !TryGetAttribute(element, qName, out var val))
+        if (!TryGetNsAttribute(element, ns, localName, out var qName, out var val))
             return JSNull.Value;
         return BuildAttrNode(qName, val, element, obj);
     }
@@ -585,7 +585,7 @@ public sealed partial class DomBridge
             return JSNull.Value;
         var ns = GetAttrNodeNamespace(attrObj);
         JSValue old = JSNull.Value;
-        if (element.NsAttrMap.TryGetValue((ns, localName), out var oldQName) && TryGetAttribute(element, oldQName, out var oldVal))
+        if (TryGetNsAttribute(element, ns, localName, out var oldQName, out var oldVal))
             old = BuildAttrNode(oldQName, oldVal, element, obj);
         SetAttributeLikeSetAttributeNS(element, ns, name, localName, attrObj[(KeyString)"value"].ToString());
         return old;
@@ -613,7 +613,7 @@ public sealed partial class DomBridge
         if (string.IsNullOrEmpty(localName))
             return JSNull.Value;
         var ns = GetAttrNodeNamespace(attrObj);
-        if (!element.NsAttrMap.TryGetValue((ns, localName), out var qName) || !TryGetAttribute(element, qName, out var val))
+        if (!TryGetNsAttribute(element, ns, localName, out var qName, out var val))
             return JSNull.Value;
         var removed = BuildAttrNode(qName, val, element, obj);
         RemoveAttributeLikeRemoveAttributeNS(element, ns, localName);
@@ -642,9 +642,8 @@ public sealed partial class DomBridge
             return JSNull.Value;
         var ns = a[0].IsNull || a[0].IsUndefined ? null : a[0].ToString();
         var localName = a[1].ToString();
-        if (element.NsAttrMap.TryGetValue((ns, localName), out var qName) && TryGetAttribute(element, qName, out var val))
-            return new JSString(val);
-        return JSNull.Value;
+        var val = element.GetAttributeNS(ns, localName);
+        return val is not null ? new JSString(val) : JSNull.Value;
     }
 
 
@@ -667,7 +666,7 @@ public sealed partial class DomBridge
             return JSBoolean.False;
         var ns = a[0].IsNull || a[0].IsUndefined ? null : a[0].ToString();
         var localName = a[1].ToString();
-        return element.NsAttrMap.ContainsKey((ns, localName)) ? JSBoolean.True : JSBoolean.False;
+        return element.GetAttributeNS(ns, localName) is not null ? JSBoolean.True : JSBoolean.False;
     }
 
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -214,19 +214,22 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsJsObjectsGetIsConnected032Core(global::Broiler.HtmlBridge.DomElement element, in Arguments _)
+    private JSValue JsJsObjectsGetIsConnected032Core(global::Broiler.Dom.DomNode node, in Arguments _)
     {
-        var root = GetTreeRoot(element);
+        var root = GetTreeRoot(node);
         return ReferenceEquals(root, _documentNode) ? JSBoolean.True : JSBoolean.False;
     }
 
+    /// <summary>Whether <paramref name="node"/> is a sub-document root element (only elements can be).</summary>
+    private static bool IsSubDocRootNode(global::Broiler.Dom.DomNode node) =>
+        node is DomElement element && IsSubDocRoot(element);
 
-    private JSValue JsJsObjectsGetChildNodes033Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
+    private JSValue JsJsObjectsGetChildNodes033Core(global::Broiler.Dom.DomNode node, in Arguments a)
     {
         var children = new List<JSValue>();
-        foreach (var child in ChildElements(element))
+        foreach (var child in node.ChildNodes)
         {
-            if (!IsSubDocRoot(child))
+            if (!IsSubDocRootNode(child))
                 children.Add(ToJSObject(child));
         }
 
@@ -234,29 +237,30 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsJsObjectsGetFirstChild034Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
+    private JSValue JsJsObjectsGetFirstChild034Core(global::Broiler.Dom.DomNode node, in Arguments a)
     {
-        var first = ChildElements(element).FirstOrDefault(c => !IsSubDocRoot(c));
+        var first = node.ChildNodes.FirstOrDefault(c => !IsSubDocRootNode(c));
         return first != null ? ToJSObject(first) : JSNull.Value;
     }
 
 
-    private JSValue JsJsObjectsGetLastChild035Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
+    private JSValue JsJsObjectsGetLastChild035Core(global::Broiler.Dom.DomNode node, in Arguments a)
     {
-        var last = ChildElements(element).LastOrDefault(c => !IsSubDocRoot(c));
+        var last = node.ChildNodes.LastOrDefault(c => !IsSubDocRootNode(c));
         return last != null ? ToJSObject(last) : JSNull.Value;
     }
 
 
-    private JSValue JsJsObjectsGetNextSibling036Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
+    private JSValue JsJsObjectsGetNextSibling036Core(global::Broiler.Dom.DomNode node, in Arguments a)
     {
-        if (ParentEl(element) == null)
+        var parent = node.ParentNode;
+        if (parent == null)
             return JSNull.Value;
-        var siblings = ChildElements(ParentEl(element)).ToList();
-        var idx = siblings.IndexOf(element);
+        var siblings = parent.ChildNodes;
+        var idx = ChildIndexOf(parent, node);
         for (var i = idx + 1; i < siblings.Count; i++)
         {
-            if (!IsSubDocRoot(siblings[i]))
+            if (!IsSubDocRootNode(siblings[i]))
                 return ToJSObject(siblings[i]);
         }
 
@@ -264,15 +268,16 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsJsObjectsGetPreviousSibling037Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
+    private JSValue JsJsObjectsGetPreviousSibling037Core(global::Broiler.Dom.DomNode node, in Arguments a)
     {
-        if (ParentEl(element) == null)
+        var parent = node.ParentNode;
+        if (parent == null)
             return JSNull.Value;
-        var siblings = ChildElements(ParentEl(element)).ToList();
-        var idx = siblings.IndexOf(element);
+        var siblings = parent.ChildNodes;
+        var idx = ChildIndexOf(parent, node);
         for (var i = idx - 1; i >= 0; i--)
         {
-            if (!IsSubDocRoot(siblings[i]))
+            if (!IsSubDocRootNode(siblings[i]))
                 return ToJSObject(siblings[i]);
         }
 
@@ -280,12 +285,14 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsJsObjectsGetNodeType038Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
+    private JSValue JsJsObjectsGetNodeType038Core(global::Broiler.Dom.DomNode node, in Arguments a)
     {
-        if (IsText(element))
+        if (IsText(node))
             return new JSNumber(3); // TEXT_NODE
-        if (IsComment(element))
+        if (IsComment(node))
             return new JSNumber(8); // COMMENT_NODE
+        if (node is not DomElement element)
+            return new JSNumber(1); // canonical non-element char-data already handled above
         if (string.Equals(element.TagName, "#document", StringComparison.OrdinalIgnoreCase))
             return new JSNumber(9); // DOCUMENT_NODE
         if (string.Equals(element.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase))
@@ -296,12 +303,14 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsJsObjectsGetNodeName039Core(global::Broiler.HtmlBridge.DomElement element, in Arguments a)
+    private JSValue JsJsObjectsGetNodeName039Core(global::Broiler.Dom.DomNode node, in Arguments a)
     {
-        if (IsText(element))
+        if (IsText(node))
             return new JSString("#text");
-        if (IsComment(element))
+        if (IsComment(node))
             return new JSString("#comment");
+        if (node is not DomElement element)
+            return JSNull.Value;
         if (string.Equals(element.TagName, "#document", StringComparison.OrdinalIgnoreCase))
             return new JSString("#document");
         if (string.Equals(element.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
@@ -141,7 +141,7 @@ public sealed partial class DomBridge
     {
         var text = a.Length > 0 ? a[0].ToString() : string.Empty;
         var el = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
-        el.TextContent = text;
+        SetBridgeText(el, text);
         _knownNodes.Add(el);
         return ToJSObject(el);
     }
@@ -626,7 +626,7 @@ public sealed partial class DomBridge
     {
         var data = a.Length > 0 ? a[0].ToString() : string.Empty;
         var el = new DomElement(_document, "#comment", null, null, string.Empty, isTextNode: false);
-        el.TextContent = data;
+        SetBridgeText(el, data);
         _knownNodes.Add(el);
         return ToJSObject(el);
     }
@@ -931,7 +931,7 @@ public sealed partial class DomBridge
             headEl.AppendChild(titleEl);
             _knownNodes.Add(titleEl);
             var titleText = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
-            titleText.TextContent = title;
+            SetBridgeText(titleText, title);
             SetParent(titleText, titleEl);
             GetElementRuntimeState(titleText).OwnerDocRoot = docRoot;
             titleEl.AppendChild(titleText);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
@@ -867,9 +867,8 @@ public sealed partial class DomBridge
             // Find the DomElement for the doctype JSObject
             foreach (var kvp in _jsObjectCache)
             {
-                if (kvp.Value == dtObj)
+                if (kvp.Value == dtObj && kvp.Key is DomElement dtEl)
                 {
-                    var dtEl = kvp.Key;
                     SetParent(dtEl, docRoot);
                     GetElementRuntimeState(dtEl).OwnerDocRoot = docRoot;
                     docRoot.AppendChild(dtEl);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
@@ -612,9 +612,8 @@ public sealed partial class DomBridge
             return a.Length > 0 ? a[0] : JSNull.Value;
         foreach (var kvp in bridge._jsObjectCache)
         {
-            if (kvp.Value == childObj)
+            if (kvp.Value == childObj && kvp.Key is DomElement child)
             {
-                var child = kvp.Key;
                 if (ParentEl(child) != null)
                     child.Remove();
                 SetParent(child, docRoot);
@@ -684,9 +683,8 @@ public sealed partial class DomBridge
         {
             foreach (var kvp in _jsObjectCache)
             {
-                if (kvp.Value == dtObj)
+                if (kvp.Value == dtObj && kvp.Key is DomElement dtEl)
                 {
-                    var dtEl = kvp.Key;
                     SetParent(dtEl, subDocRoot);
                     GetElementRuntimeState(dtEl).OwnerDocRoot = subDocRoot;
                     subDocRoot.AppendChild(dtEl);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
@@ -132,7 +132,7 @@ public sealed partial class DomBridge
     {
         var text = a.Length > 0 ? a[0].ToString() : string.Empty;
         var el = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
-        el.TextContent = text;
+        SetBridgeText(el, text);
         GetElementRuntimeState(el).OwnerDocRoot = docRoot;
         _knownNodes.Add(el);
         return ToJSObject(el);
@@ -143,7 +143,7 @@ public sealed partial class DomBridge
     {
         var data = a.Length > 0 ? a[0].ToString() : string.Empty;
         var el = new DomElement(_document, "#comment", null, null, string.Empty);
-        el.TextContent = data;
+        SetBridgeText(el, data);
         GetElementRuntimeState(el).OwnerDocRoot = docRoot;
         _knownNodes.Add(el);
         return ToJSObject(el);
@@ -744,7 +744,7 @@ public sealed partial class DomBridge
             subHead.AppendChild(subTitleEl);
             _knownNodes.Add(subTitleEl);
             var subTitleText = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
-            subTitleText.TextContent = subTitle;
+            SetBridgeText(subTitleText, subTitle);
             SetParent(subTitleText, subTitleEl);
             GetElementRuntimeState(subTitleText).OwnerDocRoot = subDocRoot;
             subTitleEl.AppendChild(subTitleText);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Traversal.cs
@@ -491,8 +491,8 @@ public sealed partial class DomBridge
         state.StartOffset = 0;
         state.EndContainer = el;
         // For text/comment nodes, endOffset is the character length
-        if (IsText(el) || string.Equals(el.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
-            state.EndOffset = (el.TextContent ?? string.Empty).Length;
+        if (IsText(el) || IsComment(el))
+            state.EndOffset = BridgeText(el).Length;
         else
             state.EndOffset = el.ChildNodes.Count;
         state.UpdateCollapsed();
@@ -522,15 +522,15 @@ public sealed partial class DomBridge
         var fragment = new DomElement(_document, "#document-fragment", null, null, string.Empty);
         bridge._knownNodes.Add(fragment);
         // Handle same-container text node case
-        if (ReferenceEquals(state.StartContainer, state.EndContainer) && (IsText(state.StartContainer) || string.Equals(state.StartContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)))
+        if (ReferenceEquals(state.StartContainer, state.EndContainer) && (IsText(state.StartContainer) || IsComment(state.StartContainer)))
         {
-            var text = state.StartContainer.TextContent ?? string.Empty;
+            var text = BridgeText(state.StartContainer);
             var s = Math.Max(0, Math.Min(state.StartOffset, text.Length));
             var e2 = Math.Max(s, Math.Min(state.EndOffset, text.Length));
             var extractedText = text.Substring(s, e2 - s);
-            state.StartContainer.TextContent = text.Substring(0, s) + text.Substring(e2);
+            SetBridgeText(state.StartContainer, text.Substring(0, s) + text.Substring(e2));
             var textNode = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
-            textNode.TextContent = extractedText;
+            SetBridgeText(textNode, extractedText);
             SetParent(textNode, fragment);
             fragment.AppendChild(textNode);
             bridge._knownNodes.Add(textNode);
@@ -600,11 +600,11 @@ public sealed partial class DomBridge
                 if (IsText(state.StartContainer))
                 {
                     // Text node: split at startOffset
-                    var text = state.StartContainer.TextContent ?? string.Empty;
+                    var text = BridgeText(state.StartContainer);
                     var extractedPart = text.Substring(state.StartOffset);
-                    state.StartContainer.TextContent = text.Substring(0, state.StartOffset);
+                    SetBridgeText(state.StartContainer, text.Substring(0, state.StartOffset));
                     var extractedNode = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
-                    extractedNode.TextContent = extractedPart;
+                    SetBridgeText(extractedNode, extractedPart);
                     bridge._knownNodes.Add(extractedNode);
                     SetParent(extractedNode, fragment);
                     fragment.AppendChild(extractedNode);
@@ -658,11 +658,11 @@ public sealed partial class DomBridge
             {
                 if (IsText(state.EndContainer))
                 {
-                    var text = state.EndContainer.TextContent ?? string.Empty;
+                    var text = BridgeText(state.EndContainer);
                     var extractedPart = text.Substring(0, state.EndOffset);
-                    state.EndContainer.TextContent = text.Substring(state.EndOffset);
+                    SetBridgeText(state.EndContainer, text.Substring(state.EndOffset));
                     var extractedNode = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
-                    extractedNode.TextContent = extractedPart;
+                    SetBridgeText(extractedNode, extractedPart);
                     bridge._knownNodes.Add(extractedNode);
                     SetParent(extractedNode, fragment);
                     fragment.AppendChild(extractedNode);
@@ -736,7 +736,7 @@ public sealed partial class DomBridge
             var parent = ParentEl(state.StartContainer);
             if (parent == null)
                 return JSUndefined.Value;
-            var text = state.StartContainer.TextContent ?? string.Empty;
+            var text = BridgeText(state.StartContainer);
             var splitOffset = Math.Min(state.StartOffset, text.Length);
             var beforeText = text.Substring(0, splitOffset);
             var afterText = text.Substring(splitOffset);
@@ -745,10 +745,10 @@ public sealed partial class DomBridge
             var originalEndIsSame = ReferenceEquals(state.EndContainer, originalTextNode);
             var originalEndOffset = state.EndOffset;
             // Update original text node
-            state.StartContainer.TextContent = beforeText;
+            SetBridgeText(state.StartContainer, beforeText);
             // Create remainder text node
             var remainder = new DomElement(_document, "#text", null, null, string.Empty, isTextNode: true);
-            remainder.TextContent = afterText;
+            SetBridgeText(remainder, afterText);
             bridge._knownNodes.Add(remainder);
             // Insert: [before] [insertedNode] [after]
             var textIdx = ChildIndexOf(parent, state.StartContainer);
@@ -795,8 +795,8 @@ public sealed partial class DomBridge
         if (!ReferenceEquals(state.StartContainer, state.EndContainer))
         {
             // Check if start container is partially selected (text/comment node with offset in middle)
-            bool startPartial = (IsText(state.StartContainer) || string.Equals(state.StartContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)) && state.StartOffset > 0;
-            bool endPartial = (IsText(state.EndContainer) || string.Equals(state.EndContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)) && state.EndOffset < (state.EndContainer.TextContent ?? "").Length;
+            bool startPartial = (IsText(state.StartContainer) || IsComment(state.StartContainer)) && state.StartOffset > 0;
+            bool endPartial = (IsText(state.EndContainer) || IsComment(state.EndContainer)) && state.EndOffset < BridgeText(state.EndContainer).Length;
             // Per spec: if any non-Text node is partially contained, throw HIERARCHY_REQUEST_ERR
             var ancestor = FindCommonAncestor(state.StartContainer, state.EndContainer);
             if (ancestor != null)
@@ -805,7 +805,7 @@ public sealed partial class DomBridge
                 var node = state.StartContainer;
                 while (node != null && !ReferenceEquals(node, ancestor))
                 {
-                    if (!IsText(node) && !string.Equals(node.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+                    if (!IsText(node) && !IsComment(node))
                     {
                         // Non-text node between start/end — check if partially selected
                         if (!ReferenceEquals(node, state.StartContainer) || !ReferenceEquals(node, state.EndContainer))
@@ -822,7 +822,7 @@ public sealed partial class DomBridge
 
             // If both are comment/text nodes but different, the range spans partially across non-text nodes
             // In Acid3 test 11, both are comment nodes partially selected — per spec this raises an exception
-            if ((IsText(state.StartContainer) || string.Equals(state.StartContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)) && (IsText(state.EndContainer) || string.Equals(state.EndContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)) && startPartial && endPartial)
+            if ((IsText(state.StartContainer) || IsComment(state.StartContainer)) && (IsText(state.EndContainer) || IsComment(state.EndContainer)) && startPartial && endPartial)
             {
                 // BAD_BOUNDARYPOINTS_ERR / INVALID_STATE_ERR
                 ThrowDOMException(bridge._jsContext!, "Invalid state", "InvalidStateError");
@@ -836,10 +836,10 @@ public sealed partial class DomBridge
         {
             // Count existing element children (minus any that will be moved into newParent)
             var nodes = GetNodesInRange(state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset);
-            var elemCount = ChildElements(state.StartContainer).Count(c => !IsText(c) && !string.Equals(c.TagName, "#comment", StringComparison.OrdinalIgnoreCase));
-            var removedElems = nodes.Count(n => !IsText(n) && !string.Equals(n.TagName, "#comment", StringComparison.OrdinalIgnoreCase));
+            var elemCount = ChildElements(state.StartContainer).Count(c => !IsText(c) && !IsComment(c));
+            var removedElems = nodes.Count(n => !IsText(n) && !IsComment(n));
             // After removal + adding newParent, there would be (elemCount - removedElems + 1) element children
-            if (elemCount - removedElems + 1 > 1 || (!string.Equals(newParent.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase) && !string.Equals(newParent.TagName, "#comment", StringComparison.OrdinalIgnoreCase)))
+            if (elemCount - removedElems + 1 > 1 || (!string.Equals(newParent.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase) && !IsComment(newParent)))
             {
                 ThrowDOMException(bridge._jsContext!, "Hierarchy request error", "HierarchyRequestError");
                 return JSUndefined.Value;
@@ -906,9 +906,9 @@ public sealed partial class DomBridge
     {
         var sb = new StringBuilder();
         // Handle case where range is within a single text/comment node
-        if (ReferenceEquals(state.StartContainer, state.EndContainer) && (IsText(state.StartContainer) || string.Equals(state.StartContainer.TagName, "#comment", StringComparison.OrdinalIgnoreCase)))
+        if (ReferenceEquals(state.StartContainer, state.EndContainer) && (IsText(state.StartContainer) || IsComment(state.StartContainer)))
         {
-            var text = state.StartContainer.TextContent ?? string.Empty;
+            var text = BridgeText(state.StartContainer);
             var s = Math.Max(0, Math.Min(state.StartOffset, text.Length));
             var e = Math.Max(s, Math.Min(state.EndOffset, text.Length));
             sb.Append(text, s, e - s);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -297,7 +297,7 @@ public sealed partial class DomBridge
         }
 
         // substringData(offset, count) — for text/comment CharacterData nodes
-        if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsText(element) || IsComment(element))
         {
             obj.FastAddValue(
                 (KeyString)"substringData",

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -19,18 +19,25 @@ public sealed partial class DomBridge
     private const double DefaultBodyMarginPixels = 8;
     private const int MaxScrollContinuationDepth = 16;
 
-    private readonly Dictionary<DomElement, JSObject> _jsObjectCache = [];
+    // RF-BRIDGE-1c Phase F (F3b): the JS-object cache is keyed by canonical DomNode so
+    // text/comment nodes (which get JS wrappers) can round-trip once they flip to canonical
+    // DomText/DomComment. A facade node IS-A DomNode, so this is a behaviour-preserving widen.
+    private readonly Dictionary<Broiler.Dom.DomNode, JSObject> _jsObjectCache = [];
     /// <summary>Counter for tracking top-layer insertion order via showModal().</summary>
     private int _topLayerCounter;
 
-    internal JSObject ToJSObject(DomElement element)
+    internal JSObject ToJSObject(Broiler.Dom.DomNode node)
     {
-        if (_jsObjectCache.TryGetValue(element, out var cached))
+        if (_jsObjectCache.TryGetValue(node, out var cached))
             return cached;
 
+        // RF-BRIDGE-1c Phase F (F3b): the tree is still homogeneous facade DomElement, so this
+        // cast always succeeds. F3c replaces it with a `node is not DomElement` branch that builds
+        // a minimal Node/CharacterData wrapper for canonical DomText/DomComment.
+        var element = (DomElement)node;
         var obj = new JSObject();
         var bridge = this;
-        _jsObjectCache[element] = obj;
+        _jsObjectCache[node] = obj;
 
         obj.FastAddValue(
             (KeyString)"tagName",

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -711,8 +711,8 @@ public sealed partial class DomBridge
 
         foreach (var child in ChildElements(element))
         {
-            if (IsText(child) && !string.IsNullOrWhiteSpace(child.TextContent))
-                sb.Append(child.TextContent);
+            if (IsText(child) && !string.IsNullOrWhiteSpace(BridgeText(child)))
+                sb.Append(BridgeText(child));
         }
 
         return sb.ToString();

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Animations.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Animations.cs
@@ -12,7 +12,7 @@ public sealed partial class DomBridge
         var animations = new List<JSValue>();
         foreach (var element in Elements)
         {
-            if (IsText(element) || string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+            if (IsText(element) || IsComment(element))
                 continue;
             if (target != null && !ReferenceEquals(element, target))
                 continue;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
@@ -40,20 +40,23 @@ public sealed partial class DomBridge
         return null;
     }
 
-    private DomElement GetTreeRoot(DomElement element)
+    private Broiler.Dom.DomNode GetTreeRoot(Broiler.Dom.DomNode node)
     {
-        var current = element;
-        while (ParentEl(current) != null)
-            current = ParentEl(current);
+        Broiler.Dom.DomNode current = node;
+        // Stop at the topmost element: the facade #document's ParentNode is the canonical
+        // DomDocument (not a DomElement), which is the same stop point the old ParentEl walk had.
+        // A detached text node roots to itself (returned as a DomNode).
+        while (current.ParentNode is DomElement parent)
+            current = parent;
         return current;
     }
 
-    private JSValue ToJSRootNode(DomElement root)
+    private JSValue ToJSRootNode(Broiler.Dom.DomNode root)
     {
         if (ReferenceEquals(root, _documentNode))
             return _documentJSObject ?? JSNull.Value;
 
-        if (IsSubDocRoot(root) && _docRootToDocJSObject.TryGetValue(root, out var subDocument))
+        if (root is DomElement rootEl && IsSubDocRoot(rootEl) && _docRootToDocJSObject.TryGetValue(rootEl, out var subDocument))
             return subDocument;
 
         return ToJSObject(root);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -1141,7 +1141,7 @@ public sealed partial class DomBridge
     private void SetElementInnerHtml(DomElement element, string html)
     {
         html ??= string.Empty;
-        element.InnerHtml = html;
+        GetElementRuntimeState(element).InnerHtml = html;
         element.TextContent = null;
 
         if (IsText(element))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -973,8 +973,7 @@ public sealed partial class DomBridge
             return false;
         }
 
-        if (!AttributeMapsAreEqual(AttributeSnapshot(first), AttributeSnapshot(second)) ||
-            !NamespaceAttributeMapsAreEqual(first.NsAttrMap, second.NsAttrMap) ||
+        if (!CanonicalAttributesAreEqual(first, second) ||
             first.ChildNodes.Count != second.ChildNodes.Count)
         {
             return false;
@@ -989,36 +988,24 @@ public sealed partial class DomBridge
         return true;
     }
 
-    private static bool AttributeMapsAreEqual(
-        IReadOnlyDictionary<string, string> first,
-        IReadOnlyDictionary<string, string> second)
+    /// <summary>
+    /// RF-BRIDGE-1c Phase C2: isEqualNode attribute comparison over the canonical
+    /// namespace-keyed attribute set — which encodes namespace, local name, qualified
+    /// name, and value in one place, replacing the former flat-snapshot + NsAttrMap pair.
+    /// Two attribute sets are equal when they have the same count and each (namespace,
+    /// local name) key maps to the same value and qualified name (the qualified-name
+    /// check preserves the prefix sensitivity the snapshot comparison had).
+    /// </summary>
+    private static bool CanonicalAttributesAreEqual(DomElement first, DomElement second)
     {
-        if (first.Count != second.Count)
+        if (first.Attributes.Count != second.Attributes.Count)
             return false;
 
-        foreach (var (name, value) in first)
+        foreach (var (key, attribute) in first.Attributes)
         {
-            if (!second.TryGetValue(name, out var otherValue) ||
-                !string.Equals(value, otherValue, StringComparison.Ordinal))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static bool NamespaceAttributeMapsAreEqual(
-        Dictionary<(string? Namespace, string LocalName), string> first,
-        Dictionary<(string? Namespace, string LocalName), string> second)
-    {
-        if (first.Count != second.Count)
-            return false;
-
-        foreach (var (key, value) in first)
-        {
-            if (!second.TryGetValue(key, out var otherValue) ||
-                !string.Equals(value, otherValue, StringComparison.Ordinal))
+            if (!second.Attributes.TryGetValue(key, out var other) ||
+                !string.Equals(attribute.Value, other.Value, StringComparison.Ordinal) ||
+                !string.Equals(attribute.QualifiedName, other.QualifiedName, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -623,7 +623,7 @@ public sealed partial class DomBridge
         bodyEl.AppendChild(preEl);
 
         var textNode = new DomElement("#text", null, null, string.Empty, isTextNode: true);
-        textNode.TextContent = textContent;
+        SetBridgeText(textNode, textContent);
         SetParent(textNode, preEl);
         preEl.AppendChild(textNode);
 
@@ -928,11 +928,11 @@ public sealed partial class DomBridge
                 continue;
             }
 
-            var mergedText = child.TextContent ?? string.Empty;
+            var mergedText = BridgeText(child);
             var nextIndex = index + 1;
             while (nextIndex < node.ChildNodes.Count && IsText(ChildAt(node, nextIndex)))
             {
-                mergedText += ChildAt(node, nextIndex).TextContent ?? string.Empty;
+                mergedText += BridgeText(ChildAt(node, nextIndex));
                 RemoveChildAt(node, nextIndex);
             }
 
@@ -968,7 +968,7 @@ public sealed partial class DomBridge
         if (IsText(first) != IsText(second) ||
             !string.Equals(first.TagName, second.TagName, StringComparison.Ordinal) ||
             !string.Equals(first.NamespaceURI, second.NamespaceURI, StringComparison.Ordinal) ||
-            !string.Equals(first.TextContent ?? string.Empty, second.TextContent ?? string.Empty, StringComparison.Ordinal))
+            !string.Equals(BridgeText(first), BridgeText(second), StringComparison.Ordinal))
         {
             return false;
         }
@@ -1345,7 +1345,7 @@ public sealed partial class DomBridge
             else if (child is System.Xml.Linq.XText childText)
             {
                 var textNode = new DomElement("#text", null, null, string.Empty, isTextNode: true);
-                textNode.TextContent = childText.Value;
+                SetBridgeText(textNode, childText.Value);
                 SetParent(textNode, el);
                 el.AppendChild(textNode);
                 _knownNodes.Add(textNode);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
@@ -525,7 +525,7 @@ public sealed partial class DomBridge
             // Same container
             if (IsText(startContainer))
             {
-                var text = startContainer.TextContent ?? string.Empty;
+                var text = BridgeText(startContainer);
                 var s = Math.Max(0, Math.Min(startOffset, text.Length));
                 var e = Math.Max(s, Math.Min(endOffset, text.Length));
                 sb.Append(text, s, e - s);
@@ -542,7 +542,7 @@ public sealed partial class DomBridge
         // Start container: collect from startOffset to end
         if (IsText(startContainer))
         {
-            var text = startContainer.TextContent ?? string.Empty;
+            var text = BridgeText(startContainer);
             if (startOffset < text.Length)
                 sb.Append(text.Substring(startOffset));
         }
@@ -569,7 +569,7 @@ public sealed partial class DomBridge
                         continue;
                     // Only collect from top-level nodes
                     if (IsText(node))
-                        sb.Append(node.TextContent ?? string.Empty);
+                        sb.Append(BridgeText(node));
                     else if (node.ChildNodes.Count == 0)
                         continue; // element with no text children
                     // Don't double-collect descendants
@@ -608,7 +608,7 @@ public sealed partial class DomBridge
 
         // Create text node with extracted content
         var extractedTextNode = new DomElement("#text", null, null, string.Empty, isTextNode: true);
-        extractedTextNode.TextContent = extractedText;
+        SetBridgeText(extractedTextNode, extractedText);
         bridge._knownNodes.Add(extractedTextNode);
 
         if (chain.Count == 1)
@@ -722,7 +722,7 @@ public sealed partial class DomBridge
         DomElement node,
         List<(double Left, double Top, double Width, double Height)> rects)
     {
-        if (IsText(node) || string.Equals(node.TagName, "#comment", StringComparison.OrdinalIgnoreCase))
+        if (IsText(node) || IsComment(node))
             return;
 
         var display = GetComputedProps(node).GetValueOrDefault("display");
@@ -808,10 +808,10 @@ public sealed partial class DomBridge
                 // This is the startContainer level
                 if (IsText(original))
                 {
-                    var text = original.TextContent ?? string.Empty;
+                    var text = BridgeText(original);
                     var extractedPart = text.Substring(startOffset);
-                    original.TextContent = text.Substring(0, startOffset);
-                    clone.TextContent = extractedPart;
+                    SetBridgeText(original, text.Substring(0, startOffset));
+                    SetBridgeText(clone, extractedPart);
                 }
                 else
                 {
@@ -891,10 +891,10 @@ public sealed partial class DomBridge
                 // This is the endContainer level
                 if (IsText(original))
                 {
-                    var text = original.TextContent ?? string.Empty;
+                    var text = BridgeText(original);
                     var extractedPart = text.Substring(0, endOffset);
-                    original.TextContent = text.Substring(endOffset);
-                    clone.TextContent = extractedPart;
+                    SetBridgeText(original, text.Substring(endOffset));
+                    SetBridgeText(clone, extractedPart);
                 }
                 else
                 {
@@ -1124,14 +1124,14 @@ public sealed partial class DomBridge
 
     private static void UpdateCharacterData(DomElement target, string? newValue)
     {
-        target.TextContent = newValue ?? string.Empty;
+        SetBridgeText(target, newValue ?? string.Empty);
     }
 
     private void SetCharacterData(DomElement target, string? newValue)
     {
-        var previousValue = target.TextContent;
+        var previousValue = BridgeText(target);
         UpdateCharacterData(target, newValue);
-        if (!string.Equals(previousValue, target.TextContent, StringComparison.Ordinal))
+        if (!string.Equals(previousValue, BridgeText(target), StringComparison.Ordinal))
             NotifyCharacterDataMutationObservers(target, previousValue);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -396,7 +396,10 @@ public sealed partial class DomBridge
     /// </summary>
     private DomElement CloneDomElement(DomElement source, bool deep)
     {
-        var clone = new DomElement(source.TagName, source.Id, source.ClassName, source.InnerHtml, null, null, IsText(source));
+        var clone = new DomElement(source.TagName, source.Id, source.ClassName, string.Empty, null, null, IsText(source));
+        // RF-BRIDGE-1c Phase F: raw inner-HTML lives in ElementRuntimeState now; copy it across
+        // the clone (matching the prior facade behaviour of seeding InnerHtml at construction).
+        GetElementRuntimeState(clone).InnerHtml = GetElementRuntimeState(source).InnerHtml;
         // RF-BRIDGE-1c Phase C2: copy attributes straight from the canonical namespace-keyed
         // set so namespaced attributes (namespace, prefix, local name) survive the clone —
         // that fidelity used to depend on the separate NsAttrMap shadow. No-namespace

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -128,7 +128,7 @@ public sealed partial class DomBridge
     {
         if (IsText(node))
         {
-            sb.Append(node.TextContent ?? string.Empty);
+            sb.Append(BridgeText(node));
             return;
         }
         foreach (var child in ChildElements(node))
@@ -675,7 +675,7 @@ public sealed partial class DomBridge
     private static int GetNodeType(DomElement element)
     {
         if (IsText(element)) return 3; // TEXT_NODE
-        if (string.Equals(element.TagName, "#comment", StringComparison.OrdinalIgnoreCase)) return 8;
+        if (IsComment(element)) return 8;
         if (string.Equals(element.TagName, "#document", StringComparison.OrdinalIgnoreCase)) return 9;
         if (string.Equals(element.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase)) return 11;
         return 1; // ELEMENT_NODE

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -296,7 +296,16 @@ public sealed partial class DomBridge
     /// Finds the <see cref="DomElement"/> corresponding to a given <see cref="JSObject"/>
     /// by looking up the JS object cache.
     /// </summary>
-    private DomElement? FindDomElementByJSObject(JSObject jsObj)
+    private DomElement? FindDomElementByJSObject(JSObject jsObj) =>
+        FindDomNodeByJSObject(jsObj) as DomElement;
+
+    /// <summary>
+    /// Finds the canonical <see cref="Broiler.Dom.DomNode"/> corresponding to a given
+    /// <see cref="JSObject"/> by reverse-scanning the JS-object cache. Unlike
+    /// <see cref="FindDomElementByJSObject"/> this also resolves text/comment nodes
+    /// (RF-BRIDGE-1c Phase F — needed once ranges/selection carry canonical char-data nodes).
+    /// </summary>
+    private Broiler.Dom.DomNode? FindDomNodeByJSObject(JSObject jsObj)
     {
         foreach (var kvp in _jsObjectCache)
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -396,8 +396,20 @@ public sealed partial class DomBridge
     /// </summary>
     private DomElement CloneDomElement(DomElement source, bool deep)
     {
-        var attrs = AttributeSnapshot(source);
-        var clone = new DomElement(source.TagName, source.Id, source.ClassName, source.InnerHtml, null, attrs, IsText(source));
+        var clone = new DomElement(source.TagName, source.Id, source.ClassName, source.InnerHtml, null, null, IsText(source));
+        // RF-BRIDGE-1c Phase C2: copy attributes straight from the canonical namespace-keyed
+        // set so namespaced attributes (namespace, prefix, local name) survive the clone —
+        // that fidelity used to depend on the separate NsAttrMap shadow. No-namespace
+        // attributes go through SetAttribute (which lowercases, matching the prior snapshot
+        // path); a prefixed qualified name can only exist with a namespace, so it never
+        // reaches the SetAttribute branch (which would throw on the ':').
+        foreach (var attribute in source.Attributes.Values)
+        {
+            if (attribute.NamespaceUri is null)
+                clone.SetAttribute(attribute.QualifiedName, attribute.Value);
+            else
+                clone.SetAttributeNS(attribute.NamespaceUri, attribute.QualifiedName, attribute.Value);
+        }
         // RF-BRIDGE-1c Phase B: inline style lives in ElementRuntimeState now. Copy the
         // source's live style dict (which may hold JS mutations not yet synced to the
         // `style=` attribute), replacing the clone's lazily-seeded attribute values.
@@ -407,8 +419,6 @@ public sealed partial class DomBridge
             cloneStyle[kv.Key] = kv.Value;
         clone.TextContent = source.TextContent;
         clone.NamespaceURI = source.NamespaceURI;
-        foreach (var kv in source.NsAttrMap)
-            clone.NsAttrMap[kv.Key] = kv.Value;
         // Copy browser-runtime values (e.g., checked state for inputs).
         GetElementRuntimeState(source).CopyRuntimeValuesTo(GetElementRuntimeState(clone));
         // Carry the memoized position-area resolution too (was ElementRuntimeState.Layout,


### PR DESCRIPTION
## Summary

Strangler removal of the `Broiler.HtmlBridge.DomElement` compatibility facade and its
`HtmlTreeBuilder` materializer (RF-BRIDGE-1c, Milestones 1.2/1.3), so the bridge holds only
canonical `Broiler.Dom` nodes + bridge-runtime state. **This is the in-progress state** — the
facade has been thinned from 8 members to **2 remaining** (`TextContent`, `NamespaceURI`); the
final irreversible text-node flip (F3c part 2) and cutover (F4) are scoped but **not yet
applied**. Every commit builds and is regression-free.

Design: [`docs/roadmap/htmlbridge-domelement-facade-removal-plan.md`](docs/roadmap/htmlbridge-domelement-facade-removal-plan.md).
Standalone snapshot: [`docs/roadmap/htmlbridge-facade-removal-current-state.md`](docs/roadmap/htmlbridge-facade-removal-current-state.md).

## Facade members removed

| Member | Phase | Relocated to |
| --- | --- | --- |
| `JsSetStyleProps`, `OwnerDocRoot` | A | `ElementRuntimeState` |
| `Style` | B | ERS via `InlineStyle(node)` |
| `Attributes` (+ `LegacyAttributeDictionary`) | C | canonical attributes |
| `Parent` | E1 | canonical `ParentNode` via `ParentEl`/`SetParent` |
| `IsTextNode` | D1 | canonical `NodeType` via `IsText(node)` |
| `Children` (+ `LegacyChildList`) | E2 | canonical `ChildNodes` |
| `NsAttrMap` | C2 | canonical namespaced attributes |
| `InnerHtml` | F1 | ERS |

**Still on the facade:** `TextContent` (→ canonical `DomText`/`DomComment`.`Data`, F3c part 2)
and `NamespaceURI` (→ `CreateElementNS` at construction, F4).

## What this branch adds since the last integration point (this session)

- **C2** — remove `NsAttrMap`; namespaced attributes derived from the canonical namespace-keyed
  set (`TryGetNsAttribute` / `GetAttributeNS`); latent spec fixes (`getAttributeNS(null, …)` now
  finds no-namespace attributes).
- **F1** — relocate `InnerHtml` to `ElementRuntimeState`.
- **F3a** — route all ~80 text/comment **character-data** + comment-discrimination sites through
  `BridgeText`/`SetBridgeText`/`IsComment` (strangler prep; canonical `DomText.Data` becomes a
  one-line swap).
- **F3b + F3c-part1** — widen the node-identity + node-navigation surface to canonical `DomNode`
  (`_knownNodes`, `_jsObjectCache`, `ToJSObject`, ERS/CWT, `_mutationObservers` targets,
  `ChildIndexOf`, `ParentEl`, `SetParent`, `GetTreeRoot`, and the `childNodes`/`nextSibling`/…
  callbacks now walking raw `ChildNodes`); add `FindDomNodeByJSObject`. Caught + fixed a subtle
  `GetTreeRoot` over-walk regression.

Everything is **behaviour-preserving on the current homogeneous facade tree**.

## Remaining (not in this PR)

- **F3c part 2** — the atomic flip: `ChildAt`→`DomNode` (~68 tree-heterogeneity sites), split
  `ToJSObject` into node-level + a canonical char-data wrapper, cascade `RangeState`, flip the ~23
  text/comment construction sites + `HtmlTreeBuilder.ConvertNode`, split `TextContent`'s
  element-aggregation duty, narrow `ChildElements`, remove facade `TextContent`. Must land
  atomically; gate on the WPT range/selection/serialization + Acid corpus.
- **F4** — flip element construction, retire `HtmlTreeBuilder`, re-key caches, widen public seams,
  remove `NamespaceURI`, delete `DomElement.cs` + `HtmlTreeBuilder.cs`.

Both are fully enumerated (with site counts) in the current-state doc.

## Testing

Baselined the full `Broiler.Cli.Tests` (1699) first, then required **zero baseline-passing tests
to regress** for every commit via a before/after TRX name diff. Steady-state environmental
baseline: **81 failed / 1618 passed** — all pre-existing (graphics/Skia, PDF, HTTP, WPT-render,
flex/grid, `GoogleSearchPolyfillTests` scroll/render), each confirmed failing on the pre-change
tree. The `ScrollIntoView_Treats_Assigned_Slot_As_Scroll_Container` slot-scroll crasher is
excluded (stack-overflows the host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6Ww1b94iKQLhUFLTQiu6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6Ww1b94iKQLhUFLTQiu6f)_