### PR TITLE
Phase F4 final: complete DomElement → Broiler.Dom.DomElement cutover

### DIFF
--- a/docs/roadmap/htmlbridge-remaining-work-roadmap.md
+++ b/docs/roadmap/htmlbridge-remaining-work-roadmap.md
@@ -43,27 +43,56 @@ not catch. WPT is **dispatch-only** in this environment (the `WPT Tests` GitHub 
   and range/selection/serialization regressions.
 - **Status:** WPT run dispatched 2026-07-11; awaiting results + baseline diff.
 
-### 1.2 Resurrect `Broiler.Wpt.Tests` (pre-existing, out of `Cli.Tests` scope)
+### 1.2 Resurrect `Broiler.Wpt.Tests` (pre-existing, out of `Cli.Tests` scope) — **DONE**
 
-`Broiler.Wpt.Tests` (`WptTestRunnerTests.cs`) has been **non-compiling since phases B/E1** — it references
+`Broiler.Wpt.Tests` (`WptTestRunnerTests.cs`) had been **non-compiling since phases B/E1** — it referenced
 the facade's `.Style` / `.Parent` compatibility members that those phases removed. F4 applied the item-5
 seam type-swap (`Broiler.HtmlBridge.DomElement` → `Broiler.Dom.DomElement`) there, but the `.Style`/
-`.Parent` references remain broken. This test project is outside the `Broiler.Cli.Tests` verification
-harness (WPT runs via the dispatch workflow, not these unit tests), so it does not block the gate — but
-the whole solution won't build until it's fixed.
+`.Parent` references remained broken. This test project is outside the `Broiler.Cli.Tests` verification
+harness (WPT runs via the dispatch workflow, not these unit tests), so it did not block the gate — but
+the whole solution would not build until it was fixed.
 
-- **Action:** rewrite the ~24 `.Style`/`.Parent` call sites against a supported surface (the bridge no
-  longer exposes inline style / parent as public facade members; these assertions likely need canonical
-  bridge accessors or should be deleted if the tests are stale). Do **not** re-add a public facade seam —
-  the boundary guards freeze the public leak surface.
+- **Done (2026-07-11):** the 12 broken call sites (across 5 test methods) were rewritten against a
+  supported surface. `.Parent`/`.Parent.Id` → canonical `DomNode.ParentNode` (cast to `Broiler.Dom.DomElement`);
+  the `.Style` inline-style reads → a new **internal** read-only accessor `DomBridge.GetInlineStyleView(DomElement)`
+  (wraps the private `InlineStyle` map, visible only via `InternalsVisibleTo` — **not** a public facade seam;
+  `HtmlBridgeBoundaryGuardTests` still green, 12/12). The stale `..\Broiler.HtmlBridge\` project reference
+  (the pre-split project, gone since the Core/Dom/Rendering/Scripting split) was repointed to
+  `..\Broiler.HtmlBridge.Dom\`, clearing the MSB9008 warning. **The whole solution now builds (0 errors).**
+- **Surfaced pre-existing failures (NOT caused by this fix, NOT part of the facade work):** with the project
+  dark for months, resurrecting it exposed failing tests. Across the full `WptTestRunnerTests` class: 334/472
+  pass, 138 fail — ~118 are `*_MatchesReference` pixel reftests that fail in a bare container for the
+  documented environmental (font) reasons, the remaining ~20 are script/subframe/harness tests (deferred-promise,
+  PDF app, viewport features). Independent of both the merge gate (1.1) and the facade removal.
+- **Position-try regression fixed (2026-07-11):** the resurrection also exposed a genuine **`@position-try`
+  fallback regression** (not test staleness): `Wpt_PositionTryCascade_FallbackApplies` and the pixel-accurate
+  `PositionTryFallbackTests.PositionTry002_…` both failed (box never moved). Root cause: after `Attach`, a
+  `<style>` element's CSS can live in its `InnerHtml` runtime state with no `DomText` child (childCount == 0),
+  but `CollectPositionTryRulesFromTree` read the CSS by hand-walking child text nodes → it collected **zero**
+  `@position-try` rules, so every fallback silently no-op'd (both resolve-only and full-render paths). Fix:
+  read via the canonical `GetStyleElementSourceText(el)` accessor (the same source the cascade uses; covers the
+  InnerHtml-fallback case). Both tests now pass; the 7 nearby `PositionArea*`/`PositionTryGrid*` pixel reftests
+  fail **identically with and without the fix** (baseline-verified environmental, 0 regressions). A latent
+  twin of the same bug in `AnimationResolver.CollectAnimPropsFromStyleElements` (static, so needs its own
+  InnerHtml fallback + a reproducing test) is tracked as a separate follow-up.
 - **Priority:** low; independent of the merge gate.
 
-### 1.3 Optional cleanup — retire the `DomElement` alias
+### 1.3 Optional cleanup — retire the `DomElement` alias — **DONE**
 
-F4 added `global using DomElement = Broiler.Dom.DomElement;` in `Broiler.HtmlBridge.Dom` so the ~900
-unqualified element-handling sites resolve canonical without per-site edits. This is behaviourally exact
-but leaves an alias shadowing a deleted type name. Optionally, rename those refs to the canonical name and
-drop the alias. Pure cosmetics — no behaviour change, no urgency.
+F4 added `global using DomElement = Broiler.Dom.DomElement;` in `Broiler.HtmlBridge.Dom` so the
+unqualified element-handling sites resolved canonical without per-site edits. This was behaviourally exact
+but left an alias shadowing a deleted type name.
+
+- **Done (2026-07-11):** the 659 bare `DomElement` tokens across 46 files were fully-qualified to
+  `Broiler.Dom.DomElement` (matching this assembly's existing convention — it already fully-qualifies
+  every other `Broiler.Dom.*` type, e.g. `Broiler.Dom.DomNode` 216×, and has no `using Broiler.Dom;`),
+  and `GlobalUsings.cs` (which held only the alias) was deleted. The rename used a dot- and
+  word-boundary-guarded substitution so it skipped already-qualified refs and method-name substrings
+  (`GetClientWidthForDomElement`, `FindDomElementByJSObject`, `CloneDomElement`, …). Qualifying a type name
+  is a compile-time identity, so runtime behaviour is provably unchanged: whole solution builds (0 errors),
+  `HtmlBridgeBoundaryGuardTests` 12/12 green, bridge smoke tests pass. (The unrelated file-scoped
+  `using DomElement = …` in `Broiler.Cli.Tests/SharedLayoutGeometryTests.cs` is a separate test-local
+  convenience, not the F4 alias, and was left as-is.)
 
 ---
 
@@ -77,8 +106,26 @@ they are prioritized independently.
 ### 2.1 Promotion Phase 2 — computed style (partially delivered)
 
 - The literal `GetComputedProps → GetComputedStyle` cutover (route the bridge's computed-property reads
-  through the canonical CSSOM computed-style path).
-- **Shorthand expansion is still deliberately bridge-owned** — promote it to the shared CSS component.
+  through the canonical CSSOM computed-style path). **Still deliberately deferred** — the sparse-map vs
+  full-initials contract mismatch and the layout-dependent form-control sizing make it unsafe as a blind
+  swap (see the promotion roadmap Phase 2 for the analysis).
+- **Shorthand expansion — DONE (2026-07-12).** The bridge's `ExpandCssShorthands` (+ its private
+  `ExpandFontShorthand` / `ExpandBoxShorthand` / `ExpandBorderShorthand` / `ExpandBorderSideShorthand` /
+  `ExpandBackgroundShorthand` / `SplitCssValues` helpers, ~500 lines in `DomBridge/Css.cs`) is deleted and
+  now delegates to the single canonical `Broiler.CSS.Dom.CssStyleEngine.ExpandShorthands` (a new public
+  wrapper over the engine's existing private pass). The bridge copy had **drifted to a narrower subset**
+  than the roadmap's earlier "only expands `outline`" note suggested — beyond `outline` it also lacked the
+  engine's `font` slash line-height handling (`NormalizeFontSlashTokens`) and its multi-layer
+  `background` parser (size/origin/clip). Adopting the engine (a strict, additive, more-spec-correct
+  superset — never removes a shorthand, never overwrites an existing longhand) was verified
+  **regression-neutral**: exact baseline set-diff over the computed-style / getComputedStyle / font /
+  background / border Cli.Tests subset shows **0 new failures** (the ~16 pre-existing failures are
+  environmental Skia-font / zoom / `*LikeChromium` rendering + Acid cases; the two that wobbled between
+  parallel runs — `Root_Selector_Overrides_Html_Border_Top`, `FixedChild_DoesNot_Inflate_Parent_AutoHeight`
+  — both pass in isolation = known Cli.Tests parallel flakiness). This closes the Phase 2 exit criterion
+  "the bridge has no private computed-style table that can drift from `CssStyleEngine`" for shorthands.
+  **Delivery note:** the public `ExpandShorthands` wrapper is in the `Broiler.CSS` submodule — push +
+  pointer bump (or patch fallback) at commit time.
 
 ### 2.2 Promotion Phase 4 / slice 8 — Range content operations (partially done)
 
@@ -89,10 +136,31 @@ The token-list + mutation-filtering work landed; the higher-risk remainder is st
   `Broiler.Dom.DomRange` instead of the bridge's own range machinery. (F3c already widened `RangeState` to
   canonical `DomNode`, which de-risks this.)
 
-### 2.3 Promotion Phase 1 slice-2 — deferred helpers
+### 2.3 Promotion Phase 1 slice-2 — deferred helpers (casing + `CssPriority` **DONE**; live-setter routing remains)
 
-Phase 1's exit criteria are met, but slice-2 left deferred items: casing helpers, `CssPriority`, and
+Phase 1's exit criteria were already met; slice-2 left deferred items: casing helpers, `CssPriority`, and
 live-setter routing.
+
+- **Done (2026-07-12):** the two pure-string helpers are promoted to the canonical `Broiler.CSS` kernel:
+  - `Broiler.CSS.CssPropertyNames.ToCssPropertyName` / `ToDomPropertyName` — the CSS-kebab ↔ DOM-camelCase
+    property-name mapping (including the vendor-prefix leading-hyphen round-trip). The bridge's three
+    private copies (`Css.cs` local `ToCamelCase`, `Utilities.cs` `ToCamelCaseStatic` / `ToKebabCase`) are
+    deleted and all ~15 call sites route through it.
+  - `Broiler.CSS.CssPriority.Strip` / `Parse` / `Apply` — the CSSOM string-level `!important` handling
+    (lenient trailing-suffix contract preserved byte-for-byte). The bridge's `StripCssPriority` /
+    `GetCssPriority` / `ApplyCssPriority` + `ImportantSuffixPattern` regex are deleted and all call sites
+    route through it.
+  - Both are neutral, dependency-free static utilities; the CSS architecture guard (`CssArchitectureTests`)
+    stays green. Covered by new `CssPropertyNamesTests` + `CssPriorityTests` (36 cases, exact-parity).
+    Verified regression-free: whole solution builds (0 errors); the bridge CSSOM / inline-style /
+    style-declaration subset is unchanged (the only 2 failures — `SelectorsAndCssomTests.Root_Matches_…`
+    and `…Lang_Matches_XmlLang_Ancestor` — are **pre-existing at clean HEAD**, baseline-confirmed, and
+    exercise `:root`/`:lang` selector matching untouched by this change).
+  - **Delivery note:** the new files live in the `Broiler.CSS` **submodule** — the submodule commit must be
+    pushed and the parent pointer bumped (or a `patches/` fallback if the push 403s) as part of committing
+    this work.
+- **Still deferred:** routing the live `CSSStyleDeclaration` setters / stylesheet-mutation paths through
+  shared CSS APIs (higher-risk, entangled with live CSSOM object identity — a separate slice).
 
 ### 2.4 Promotion-candidate backlog (P0–P3) + Open Questions
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ComputedStyleEngine.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ComputedStyleEngine.cs
@@ -18,7 +18,7 @@ public sealed partial class DomBridge
     // across calls, instead of leaking a subscription per getComputedStyle() call.
     // The scoped stylesheet set is re-synced only when the collected
     // <style>/<link>/inserted-rule text actually changes.
-    private readonly Dictionary<DomElement, ComputedStyleEngineScope> _computedStyleEngines = [];
+    private readonly Dictionary<Broiler.Dom.DomElement, ComputedStyleEngineScope> _computedStyleEngines = [];
 
     private sealed class ComputedStyleEngineScope
     {
@@ -39,7 +39,7 @@ public sealed partial class DomBridge
     /// re-syncing its scoped stylesheet set (the same <c>&lt;style&gt;</c>/<c>&lt;link&gt;</c>/
     /// inserted-CSSOM text the legacy cascade saw) whenever that text changes.
     /// </summary>
-    private Broiler.CSS.Dom.CssStyleEngine GetSyncedScopedEngine(DomElement element)
+    private Broiler.CSS.Dom.CssStyleEngine GetSyncedScopedEngine(Broiler.Dom.DomElement element)
     {
         var docRoot = GetDocumentRootFor(element);
         if (!_computedStyleEngines.TryGetValue(docRoot, out var scope))
@@ -51,7 +51,7 @@ public sealed partial class DomBridge
             _computedStyleEngines[docRoot] = scope;
         }
 
-        var styleElements = new List<DomElement>();
+        var styleElements = new List<Broiler.Dom.DomElement>();
         CollectStyleElementsInTree(docRoot, styleElements);
 
         var combined = new StringBuilder();
@@ -82,7 +82,7 @@ public sealed partial class DomBridge
     /// shared <see cref="Broiler.CSS.Dom.CssStyleEngine"/>, scoped to the
     /// element's document root.
     /// </summary>
-    private Dictionary<string, string> BuildComputedStyleMapViaEngine(DomElement element, string? pseudoElement)
+    private Dictionary<string, string> BuildComputedStyleMapViaEngine(Broiler.Dom.DomElement element, string? pseudoElement)
     {
         var computed = GetSyncedScopedEngine(element).GetComputedStyle(element, pseudoElement: pseudoElement);
 
@@ -100,6 +100,6 @@ public sealed partial class DomBridge
     /// replaces the legacy <c>foreach (… in CssRules) if (MatchesSelector(…))</c>
     /// collection loops; callers still merge <c>InlineStyle(element)</c> on top as before.
     /// </summary>
-    private Dictionary<string, string> CollectMatchedRuleProperties(DomElement element) =>
+    private Dictionary<string, string> CollectMatchedRuleProperties(Broiler.Dom.DomElement element) =>
         new(GetSyncedScopedEngine(element).GetCascadedDeclaredValues(element), StringComparer.OrdinalIgnoreCase);
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Selectors.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Selectors.cs
@@ -9,16 +9,16 @@ public sealed partial class DomBridge
         new(new BridgeSelectorStateProvider());
 
     private static bool MatchesSelector(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         string selector,
-        DomElement? scope = null) =>
+        Broiler.Dom.DomElement? scope = null) =>
         SharedSelectorMatcher.Matches(element, selector, scope);
 
     private sealed class BridgeSelectorStateProvider : CSS.Dom.ICssSelectorStateProvider
     {
         public bool? IsChecked(Broiler.Dom.DomElement element)
         {
-            if (element is not DomElement bridgeElement)
+            if (element is not Broiler.Dom.DomElement bridgeElement)
                 return null;
 
             return GetElementRuntimeState(bridgeElement).FormControl.Checked.TryGet(out var value)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -18,7 +18,7 @@ public sealed partial class DomBridge
     private const int MaxSerializationDepth = 100_000;
     private const double ZoomSerializationEpsilon = 0.0001;
     private const double DefaultProgressLikeTrackLengthPx = 120;
-    private readonly Dictionary<DomElement, Dictionary<string, string>> _zoomSpecifiedStyleCache = [];
+    private readonly Dictionary<Broiler.Dom.DomElement, Dictionary<string, string>> _zoomSpecifiedStyleCache = [];
 
     // RF-BRIDGE-1b render-doc/live-doc separation: when non-null, ApplyZoomSerializationStyles
     // records each mutated element's pre-bake Style + Attributes here so the geometry-snapshot
@@ -26,7 +26,7 @@ public sealed partial class DomBridge
     // sizes and drops the `zoom` property — which would otherwise corrupt subsequent unzoomed
     // CSSOM queries, e.g. clientWidth of a zoomed element). The render/serialize paths leave
     // this null so their baking stays permanent.
-    private List<(DomElement Element, Dictionary<string, string> Style, Dictionary<string, string> Attributes)>? _zoomSerializationRevertLog;
+    private List<(Broiler.Dom.DomElement Element, Dictionary<string, string> Style, Dictionary<string, string> Attributes)>? _zoomSerializationRevertLog;
 
     /// <summary>
     /// Serialises the current DOM tree back to an HTML string.
@@ -98,7 +98,7 @@ public sealed partial class DomBridge
             target[kv.Key] = kv.Value;
     }
 
-    private void ReflectRenderState(DomElement element)
+    private void ReflectRenderState(Broiler.Dom.DomElement element)
     {
         if (!IsText(element) && !element.TagName.StartsWith('#'))
         {
@@ -133,13 +133,13 @@ public sealed partial class DomBridge
             ReflectRenderState(child);
     }
 
-    private string SerializeElementToHtml(DomElement element) =>
+    private string SerializeElementToHtml(Broiler.Dom.DomElement element) =>
         SharedHtmlSerializer.Serialize(
             element,
             CreateSerializationAdapter(),
             new HtmlSerializationOptions(MaximumDepth: MaxSerializationDepth, EncodeTextNodes: false));
 
-    private string SerializeChildrenToHtml(DomElement element) => string.Concat(ChildElements(element).Select(SerializeElementToHtml));
+    private string SerializeChildrenToHtml(Broiler.Dom.DomElement element) => string.Concat(ChildElements(element).Select(SerializeElementToHtml));
 
     private void ApplySerializationTransforms()
     {
@@ -170,7 +170,7 @@ public sealed partial class DomBridge
     /// so JS-visible <c>innerHTML</c>/<c>outerHTML</c> (which serialize without it)
     /// still expose the comments.
     /// </summary>
-    private static void RemoveRenderCommentNodes(DomElement element)
+    private static void RemoveRenderCommentNodes(Broiler.Dom.DomElement element)
     {
         for (int i = element.ChildNodes.Count - 1; i >= 0; i--)
         {
@@ -181,7 +181,7 @@ public sealed partial class DomBridge
                 continue;
             }
 
-            if (child is DomElement childElement)
+            if (child is Broiler.Dom.DomElement childElement)
                 RemoveRenderCommentNodes(childElement);
         }
     }
@@ -210,7 +210,7 @@ public sealed partial class DomBridge
     }
 
     private void CollectZoomPseudoSerializationOverrides(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         double parentZoom,
         List<string> rules,
         ref int pseudoIndex)
@@ -233,7 +233,7 @@ public sealed partial class DomBridge
     }
 
     private void AppendZoomPseudoSerializationOverride(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         string pseudoElement,
         double usedZoom,
         List<string> rules,
@@ -267,7 +267,7 @@ public sealed partial class DomBridge
         rules.Add($"#{element.Id}{pseudoElement} {{ {string.Join("; ", declarations)}; }}");
     }
 
-    private static DomElement? FindFirstElementByTagName(DomElement root, string tagName)
+    private static Broiler.Dom.DomElement? FindFirstElementByTagName(Broiler.Dom.DomElement root, string tagName)
     {
         if (string.Equals(root.TagName, tagName, StringComparison.OrdinalIgnoreCase))
             return root;
@@ -282,7 +282,7 @@ public sealed partial class DomBridge
         return null;
     }
 
-    private void ApplyProgressLikeSerializationPlaceholders(DomElement element)
+    private void ApplyProgressLikeSerializationPlaceholders(Broiler.Dom.DomElement element)
     {
         if (IsText(element))
             return;
@@ -346,7 +346,7 @@ public sealed partial class DomBridge
         element.AppendChild(fill);
     }
 
-    private static double ResolveProgressLikeValueRatio(DomElement element, string tag)
+    private static double ResolveProgressLikeValueRatio(Broiler.Dom.DomElement element, string tag)
     {
         var min = tag == "meter" ? ReadNumericAttribute(element, "min", 0) : 0;
         var max = ReadNumericAttribute(element, "max", 1);
@@ -357,7 +357,7 @@ public sealed partial class DomBridge
         return Math.Clamp((value - min) / (max - min), 0, 1);
     }
 
-    private static double ReadNumericAttribute(DomElement element, string attributeName, double fallback)
+    private static double ReadNumericAttribute(Broiler.Dom.DomElement element, string attributeName, double fallback)
     {
         if (!TryGetAttribute(element, attributeName, out var rawValue) || string.IsNullOrWhiteSpace(rawValue))
             return fallback;
@@ -389,7 +389,7 @@ public sealed partial class DomBridge
             : fallback;
     }
 
-    private void ApplyZoomSerializationStyles(DomElement element, double parentZoom)
+    private void ApplyZoomSerializationStyles(Broiler.Dom.DomElement element, double parentZoom)
     {
         if (IsText(element))
             return;
@@ -430,14 +430,14 @@ public sealed partial class DomBridge
             ApplyZoomSerializationStyles(child, usedZoom);
     }
 
-    private static bool ShouldApplySvgSerializationAttributes(DomElement element)
+    private static bool ShouldApplySvgSerializationAttributes(Broiler.Dom.DomElement element)
     {
         var tag = element.TagName.ToLowerInvariant();
         return tag is "svg" or "defs" or "path" or "rect" or "line" or "text" or "textpath" or "polygon" or "polyline";
     }
 
     private bool TryGetZoomSerializableValue(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         Dictionary<string, string> props,
         string property,
         out string value)
@@ -474,7 +474,7 @@ public sealed partial class DomBridge
         return false;
     }
 
-    private Dictionary<string, string> GetZoomSpecifiedStyleMap(DomElement element)
+    private Dictionary<string, string> GetZoomSpecifiedStyleMap(Broiler.Dom.DomElement element)
     {
         if (!_zoomSpecifiedStyleCache.TryGetValue(element, out var specified))
         {
@@ -511,7 +511,7 @@ public sealed partial class DomBridge
         "column-width", "column-height", "column-gap"
     ];
 
-    private void ApplyZoomSerializationSvgAttributes(DomElement element, double usedZoom)
+    private void ApplyZoomSerializationSvgAttributes(Broiler.Dom.DomElement element, double usedZoom)
     {
         var tag = element.TagName.ToLowerInvariant();
         var props = GetComputedProps(element);
@@ -559,7 +559,7 @@ public sealed partial class DomBridge
     }
 
     private void ApplySvgPresentationAttribute(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         Dictionary<string, string> props,
         string propertyName,
         bool preferInlineStyle = false)
@@ -581,7 +581,7 @@ public sealed partial class DomBridge
         SetAttr(element, propertyName, value.Trim());
     }
 
-    private void ScaleSvgLengthAttribute(DomElement element, string attributeName, double usedZoom)
+    private void ScaleSvgLengthAttribute(Broiler.Dom.DomElement element, string attributeName, double usedZoom)
     {
         if (!TryGetAttribute(element, attributeName, out var value) ||
             !TryScaleSvgLengthToken(element, value, usedZoom, out var scaled))
@@ -592,7 +592,7 @@ public sealed partial class DomBridge
         SetAttr(element, attributeName, scaled);
     }
 
-    private void ScaleSvgPointListAttribute(DomElement element, string attributeName, double usedZoom)
+    private void ScaleSvgPointListAttribute(Broiler.Dom.DomElement element, string attributeName, double usedZoom)
     {
         if (!TryGetAttribute(element, attributeName, out var value) || string.IsNullOrWhiteSpace(value))
             return;
@@ -600,7 +600,7 @@ public sealed partial class DomBridge
         SetAttr(element, attributeName, ScaleSvgPointRegex().Replace(value, match => ScaleSvgNumericMatch(match, usedZoom)));
     }
 
-    private void ScaleSvgPathDataAttribute(DomElement element, string attributeName, double usedZoom)
+    private void ScaleSvgPathDataAttribute(Broiler.Dom.DomElement element, string attributeName, double usedZoom)
     {
         if (!TryGetAttribute(element, attributeName, out var value) || string.IsNullOrWhiteSpace(value))
             return;
@@ -619,7 +619,7 @@ public sealed partial class DomBridge
         return (number * factor).ToString("0.###", System.Globalization.CultureInfo.InvariantCulture);
     }
 
-    private bool TryScaleSvgLengthToken(DomElement element, string value, double usedZoom, out string scaled)
+    private bool TryScaleSvgLengthToken(Broiler.Dom.DomElement element, string value, double usedZoom, out string scaled)
     {
         scaled = string.Empty;
         var trimmed = value.Trim();
@@ -663,7 +663,7 @@ public sealed partial class DomBridge
         return false;
     }
 
-    private bool TryResolveSvgFontRelativeUnitPixels(DomElement element, string unit, out double pixels)
+    private bool TryResolveSvgFontRelativeUnitPixels(Broiler.Dom.DomElement element, string unit, out double pixels)
     {
         pixels = 0;
         if (SvgRootFontRelativeUnits.Contains(unit))
@@ -679,9 +679,9 @@ public sealed partial class DomBridge
         return pixels > 0;
     }
 
-    private double ResolveOriginalNearestSpecifiedFontSizePx(DomElement element)
+    private double ResolveOriginalNearestSpecifiedFontSizePx(Broiler.Dom.DomElement element)
     {
-        for (DomElement? current = element; current != null; current = ParentEl(current))
+        for (Broiler.Dom.DomElement? current = element; current != null; current = ParentEl(current))
         {
             if (TryGetSpecifiedFontSizePx(current, out var fontSize))
                 return fontSize;
@@ -693,7 +693,7 @@ public sealed partial class DomBridge
     private double ResolveOriginalRootSpecifiedFontSizePx() =>
         TryGetSpecifiedFontSizePx(DocumentElement, out var fontSize) ? fontSize : 16;
 
-    private bool TryGetSpecifiedFontSizePx(DomElement element, out double fontSize)
+    private bool TryGetSpecifiedFontSizePx(Broiler.Dom.DomElement element, out double fontSize)
     {
         fontSize = 0;
         var specified = BuildSpecifiedStyleMap(element);
@@ -728,7 +728,7 @@ public sealed partial class DomBridge
         _ => 1.0
     };
 
-    private double ResolveSvgLengthZoomFactor(DomElement element, string unit, double usedZoom)
+    private double ResolveSvgLengthZoomFactor(Broiler.Dom.DomElement element, string unit, double usedZoom)
     {
         if (SvgAbsoluteOrViewportUnits.Contains(unit))
             return usedZoom;
@@ -742,9 +742,9 @@ public sealed partial class DomBridge
         return usedZoom;
     }
 
-    private double GetNearestExplicitFontSizeOwnerZoom(DomElement element)
+    private double GetNearestExplicitFontSizeOwnerZoom(Broiler.Dom.DomElement element)
     {
-        for (DomElement? current = element; current != null; current = ParentEl(current))
+        for (Broiler.Dom.DomElement? current = element; current != null; current = ParentEl(current))
         {
             var props = GetComputedProps(current);
             if (props.TryGetValue("font-size", out var fontSize) && !string.IsNullOrWhiteSpace(fontSize))
@@ -853,12 +853,12 @@ public sealed partial class DomBridge
     // text/comment off NodeType (holds for facade and canonical char-data), and the remaining
     // special kinds off the facade #document-fragment/#subdoc-root/#doctype TagNames (still facade
     // elements). GetName/GetAttributes/GetStyles/GetRawInnerHtml are only invoked for element/doctype
-    // nodes (see HtmlSerializer.Append), so their DomElement narrowing is always satisfied.
+    // nodes (see HtmlSerializer.Append), so their Broiler.Dom.DomElement narrowing is always satisfied.
     private HtmlSerializationAdapter<Broiler.Dom.DomNode> CreateSerializationAdapter() => new(
         GetKind: static node =>
             IsText(node) ? HtmlSerializationNodeKind.Text
             : IsComment(node) ? HtmlSerializationNodeKind.Comment
-            : node is DomElement element
+            : node is Broiler.Dom.DomElement element
                 ? element.TagName.ToLowerInvariant() switch
                 {
                     "#document-fragment" => HtmlSerializationNodeKind.Fragment,
@@ -867,7 +867,7 @@ public sealed partial class DomBridge
                     _ => HtmlSerializationNodeKind.Element
                 }
                 : HtmlSerializationNodeKind.Element,
-        GetName: static node => node is DomElement element ? element.TagName : string.Empty,
+        GetName: static node => node is Broiler.Dom.DomElement element ? element.TagName : string.Empty,
         // Never serialise a materialised nested-browsing-context (#subdoc-root) into
         // its container.  A sub-document is fetched and attached to its <iframe>/
         // <object>/<frame> so scripts can reach contentDocument and onload can fire,
@@ -877,9 +877,9 @@ public sealed partial class DomBridge
         // The renderer rasterises each embedded document in isolation instead
         // (srcdoc content is round-tripped via the srcdoc attribute).
         GetChildren: static node => node.ChildNodes.Where(static child =>
-            !(child is DomElement childElement && string.Equals(childElement.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase))),
-        GetAttributes: node => node is DomElement element ? GetSerializableAttributes(element) : [],
-        GetStyles: static node => node is DomElement element
+            !(child is Broiler.Dom.DomElement childElement && string.Equals(childElement.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase))),
+        GetAttributes: node => node is Broiler.Dom.DomElement element ? GetSerializableAttributes(element) : [],
+        GetStyles: static node => node is Broiler.Dom.DomElement element
             ? InlineStyle(element).OrderBy(kv => SharedHtmlSerializer.IsShorthandProperty(kv.Key) ? 0 : 1)
             : [],
         // RF-BRIDGE-1c Phase F (F3c part 2d): text nodes serialize with the same HTML escaping the
@@ -900,11 +900,11 @@ public sealed partial class DomBridge
     /// content is serialized literally (not HTML-escaped) — <c>script</c>, <c>style</c>, and the
     /// other raw-text elements. (RF-BRIDGE-1c Phase F, F3c part 2d.)</summary>
     private static bool IsRawTextSerializationParent(Broiler.Dom.DomNode node) =>
-        node.ParentNode is DomElement parent &&
+        node.ParentNode is Broiler.Dom.DomElement parent &&
         parent.TagName.ToLowerInvariant() is "script" or "style" or "xmp" or "iframe"
             or "noembed" or "noframes" or "noscript" or "plaintext";
 
-    private IEnumerable<KeyValuePair<string, string>> GetSerializableAttributes(DomElement element)
+    private IEnumerable<KeyValuePair<string, string>> GetSerializableAttributes(Broiler.Dom.DomElement element)
     {
         if (!string.IsNullOrEmpty(element.Id))
             yield return new("id", element.Id);
@@ -939,7 +939,7 @@ public sealed partial class DomBridge
         }
     }
 
-    private string? TrySerializeCurrentSrcDoc(DomElement element)
+    private string? TrySerializeCurrentSrcDoc(Broiler.Dom.DomElement element)
     {
         if (!string.Equals(element.TagName, "iframe", StringComparison.OrdinalIgnoreCase) ||
             !HasAttr(element, "srcdoc"))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -47,7 +47,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         "scrollend"];
     // RF-BRIDGE-1c Phase F (F3b): the registration set is keyed by canonical DomNode so
     // it can hold text/comment nodes once they flip to canonical DomText/DomComment (which
-    // are not DomElement). A facade node IS-A DomNode, so this is a behaviour-preserving
+    // are not Broiler.Dom.DomElement). A facade node IS-A DomNode, so this is a behaviour-preserving
     // widen on the current homogeneous tree.
     private readonly HashSet<Broiler.Dom.DomNode> _knownNodes =
         new(ReferenceEqualityComparer.Instance);
@@ -55,12 +55,12 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     private readonly List<WeakReference<RangeState>> _activeRanges = [];
     private readonly List<WeakReference<Broiler.Dom.DomNodeIterator>> _activeNodeIterators = [];
     private readonly CanonicalDocument _document;
-    private readonly DomElement _documentNode;
+    private readonly Broiler.Dom.DomElement _documentNode;
     private static readonly ConditionalWeakTable<Broiler.Dom.DomNode, ElementRuntimeState> ElementRuntimeStates = [];
     private JSObject? _documentJSObject;
     private JSObject? _windowJSObject;
     private JSObject? _visualViewportJSObject;
-    private readonly Dictionary<DomElement, JSObject> _docRootToDocJSObject = [];
+    private readonly Dictionary<Broiler.Dom.DomElement, JSObject> _docRootToDocJSObject = [];
     private JSContext? _jsContext;
 
     // Timer & async execution queues.
@@ -83,7 +83,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     private readonly System.Collections.Concurrent.ConcurrentDictionary<int, Action> _frameActions = new();
     // Touched by the same scroll/frame-action callbacks that can run on
     // ThreadPool threads (see the timer-map note above), so keep it concurrent.
-    private readonly System.Collections.Concurrent.ConcurrentDictionary<DomElement, int> _smoothScrollTokens = new();
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<Broiler.Dom.DomElement, int> _smoothScrollTokens = new();
     private readonly List<JSFunction> _visualViewportScrollListeners = [];
     private readonly Dictionary<string, List<EventListenerRegistration>> _windowEventListeners =
         new(StringComparer.OrdinalIgnoreCase);
@@ -91,7 +91,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<JSObject, JSObject> _eventTargetOwnerWindows =
         new(ReferenceEqualityComparer.Instance);
-    private readonly Dictionary<JSObject, DomElement> _subWindowContainers =
+    private readonly Dictionary<JSObject, Broiler.Dom.DomElement> _subWindowContainers =
         new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<JSObject, JSObject> _messagePortPeers =
         new(ReferenceEqualityComparer.Instance);
@@ -176,10 +176,10 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// <summary>
     /// All elements parsed from the HTML source.
     /// </summary>
-    public IReadOnlyList<DomElement> Elements =>
+    public IReadOnlyList<Broiler.Dom.DomElement> Elements =>
         [.. _documentNode
             .InclusiveDescendants()
-            .OfType<DomElement>()
+            .OfType<Broiler.Dom.DomElement>()
             .Where(element => !ReferenceEquals(element, _documentNode))];
 
     private static ElementRuntimeState GetElementRuntimeState(Broiler.Dom.DomNode node) =>
@@ -187,31 +187,31 @@ public sealed partial class DomBridge : IDomBridgeRuntime
 
     /// <summary>
     /// The element's authoritative in-memory inline style dictionary (CSS kebab-case),
-    /// relocated off the <c>DomElement</c> facade into <see cref="ElementRuntimeState"/>
+    /// relocated off the <c>Broiler.Dom.DomElement</c> facade into <see cref="ElementRuntimeState"/>
     /// (RF-BRIDGE-1c Phase B). Lazily seeded once from the element's <c>style=</c>
     /// attribute; thereafter it is the source of truth (JS <c>element.style</c> writes,
     /// anchor/form-control styling), synced back to the attribute at serialization.
     /// </summary>
     // -----------------------------------------------------------------
     // RF-BRIDGE-1c Phase E2: child-node access over canonical ChildNodes,
-    // replacing the facade DomElement.Children (LegacyChildList). The bridge
-    // tree is homogeneous DomElement today, so ChildElements is a drop-in for
+    // replacing the facade Broiler.Dom.DomElement.Children (LegacyChildList). The bridge
+    // tree is homogeneous Broiler.Dom.DomElement today, so ChildElements is a drop-in for
     // the old enumeration; the Cast/ChildAt casts are safe until text/comment
     // flip to canonical DomText/DomComment (Phase F), when ChildElements narrows
     // to OfType and callers gain IsText handling.
     // -----------------------------------------------------------------
 
-    /// <summary>The element's <see cref="DomElement"/> children. RF-BRIDGE-1c Phase F (F3c part 2c):
-    /// narrowed from <c>Cast</c> to <c>OfType&lt;DomElement&gt;()</c> so it skips canonical
+    /// <summary>The element's <see cref="Broiler.Dom.DomElement"/> children. RF-BRIDGE-1c Phase F (F3c part 2c):
+    /// narrowed from <c>Cast</c> to <c>OfType&lt;Broiler.Dom.DomElement&gt;()</c> so it skips canonical
     /// <c>DomText</c>/<c>DomComment</c> children once construction flips; a no-op on today's
     /// homogeneous tree. Callers that need text/comment children walk raw <c>ChildNodes</c> instead.</summary>
-    private static IEnumerable<DomElement> ChildElements(Broiler.Dom.DomNode element) =>
-        element.ChildNodes.OfType<DomElement>();
+    private static IEnumerable<Broiler.Dom.DomElement> ChildElements(Broiler.Dom.DomNode element) =>
+        element.ChildNodes.OfType<Broiler.Dom.DomElement>();
 
     /// <summary>The child node at <paramref name="index"/> (old <c>Children[index]</c>). RF-BRIDGE-1c
     /// Phase F (F3c part 2c): returns canonical <see cref="Broiler.Dom.DomNode"/> — a child may be a
     /// <c>DomText</c>/<c>DomComment</c> once construction flips. Element-only callers narrow with
-    /// <c>as DomElement</c>/<c>is DomElement</c>; on today's homogeneous tree every child is an element.</summary>
+    /// <c>as Broiler.Dom.DomElement</c>/<c>is Broiler.Dom.DomElement</c>; on today's homogeneous tree every child is an element.</summary>
     private static Broiler.Dom.DomNode ChildAt(Broiler.Dom.DomNode element, int index) => element.ChildNodes[index];
 
     /// <summary>The child node at <paramref name="index"/>, supporting from-end indices like <c>^1</c>
@@ -267,7 +267,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     }
 
     /// <summary>Whether <paramref name="node"/> is a text node (RF-BRIDGE-1c Phase D: replaces
-    /// the facade <c>IsText(DomElement)</c>). NodeType-based, so it holds for the current
+    /// the facade <c>IsText(Broiler.Dom.DomElement)</c>). NodeType-based, so it holds for the current
     /// facade text nodes and for canonical <c>DomText</c> once construction flips in the
     /// <c>Children</c>/text cutover.</summary>
     private static bool IsText(Broiler.Dom.DomNode node) => node.NodeType == Broiler.Dom.DomNodeType.Text;
@@ -307,13 +307,13 @@ public sealed partial class DomBridge : IDomBridgeRuntime
 
     /// <summary>
     /// The single construction funnel for bridge element nodes (RF-BRIDGE-1c Phase F, F4). Every
-    /// former <c>new DomElement(...)</c> site routes through here (or <see cref="CreateBridgeElementNS"/>)
+    /// former <c>new Broiler.Dom.DomElement(...)</c> site routes through here (or <see cref="CreateBridgeElementNS"/>)
     /// so element construction lives in exactly one place over the canonical <c>Broiler.Dom</c>
     /// document factories. The tag name may be an HTML element literal (HTML namespace) or a
     /// <c>#</c>-sentinel (<c>#document</c>, <c>#subdoc-root</c>, …), which keeps a null namespace and
     /// its preserved name — the bridge-internal document/fragment/shadow model over canonical types.
     /// </summary>
-    private DomElement CreateBridgeElement(
+    private Broiler.Dom.DomElement CreateBridgeElement(
         string tagName,
         string? id = null,
         string? className = null,
@@ -328,7 +328,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// <c>createElementNS</c> handlers, sub-document roots, and clones (which preserve the source
     /// element's namespace). See <see cref="CreateBridgeElement"/>.
     /// </summary>
-    private DomElement CreateBridgeElementNS(
+    private Broiler.Dom.DomElement CreateBridgeElementNS(
         string? namespaceUri,
         string tagName,
         string? id = null,
@@ -349,8 +349,8 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// <summary>Sets an element's <c>textContent</c> per DOM (RF-BRIDGE-1c Phase F, F3c part 2d):
     /// replaces all children with a single canonical <see cref="Broiler.Dom.DomText"/> (or none when
     /// <paramref name="value"/> is null/empty). Replaces the former element-store
-    /// <c>DomElement.TextContent</c> scalar.</summary>
-    private void SetElementTextContent(DomElement element, string? value)
+    /// <c>Broiler.Dom.DomElement.TextContent</c> scalar.</summary>
+    private void SetElementTextContent(Broiler.Dom.DomElement element, string? value)
     {
         ClearChildren(element);
         if (!string.IsNullOrEmpty(value))
@@ -362,22 +362,22 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     }
 
     /// <summary>An element's <c>textContent</c> — the concatenation of its descendant text (RF-BRIDGE-1c
-    /// Phase F, F3c part 2d). Replaces reads of the former element-store <c>DomElement.TextContent</c>.</summary>
-    private static string GetElementTextContent(DomElement element)
+    /// Phase F, F3c part 2d). Replaces reads of the former element-store <c>Broiler.Dom.DomElement.TextContent</c>.</summary>
+    private static string GetElementTextContent(Broiler.Dom.DomElement element)
     {
         var sb = new System.Text.StringBuilder();
         CollectTextContent(element, sb);
         return sb.ToString();
     }
 
-    /// <summary>The element's parent as a <see cref="DomElement"/> (RF-BRIDGE-1c Phase E:
-    /// replaces the facade <c>ParentEl(DomElement)</c> getter — <c>ParentNode as DomElement</c>).
+    /// <summary>The element's parent as a <see cref="Broiler.Dom.DomElement"/> (RF-BRIDGE-1c Phase E:
+    /// replaces the facade <c>ParentEl(Broiler.Dom.DomElement)</c> getter — <c>ParentNode as Broiler.Dom.DomElement</c>).
     /// A node's parent is always an element, so this is stable when text/comment nodes become
     /// canonical <c>DomText</c>/<c>DomComment</c> in Phase D.</summary>
-    private static DomElement? ParentEl(Broiler.Dom.DomNode node) => node.ParentNode as DomElement;
+    private static Broiler.Dom.DomElement? ParentEl(Broiler.Dom.DomNode node) => node.ParentNode as Broiler.Dom.DomElement;
 
     /// <summary>Reparents <paramref name="child"/> under <paramref name="parent"/> (RF-BRIDGE-1c
-    /// Phase E: replaces the facade <c>ParentEl(DomElement)</c> setter). A null parent detaches;
+    /// Phase E: replaces the facade <c>ParentEl(Broiler.Dom.DomElement)</c> setter). A null parent detaches;
     /// otherwise the child is appended if not already there — matching the old setter exactly.
     /// RF-BRIDGE-1c Phase F (F3c part 2b): the parent widened to <c>DomNode?</c> so range-extract
     /// code can pass DomNode-typed ancestor-chain clones (always elements at runtime).</summary>
@@ -389,7 +389,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
             parent.AppendChild(child);
     }
 
-    private static Dictionary<string, string> InlineStyle(DomElement element)
+    private static Dictionary<string, string> InlineStyle(Broiler.Dom.DomElement element)
     {
         var state = GetElementRuntimeState(element);
         if (!state.StyleSeeded)
@@ -405,13 +405,22 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         return state.Style;
     }
 
+    /// <summary>Read-only diagnostic view of an element's resolved inline-style map — the same
+    /// dictionary the anchor resolver reads and writes (display:none, resolved left/top/width/height,
+    /// …). RF-BRIDGE-1c Phase F4 removed the <c>Broiler.Dom.DomElement.Style</c> facade member; internal test and
+    /// tooling callers that need to inspect post-resolution inline styles route through this accessor
+    /// instead. Visible only to <c>InternalsVisibleTo</c> assemblies — not part of the public surface,
+    /// so it does not re-open a public facade seam.</summary>
+    internal static IReadOnlyDictionary<string, string> GetInlineStyleView(Broiler.Dom.DomElement element) =>
+        InlineStyle(element);
+
     private static Dictionary<string, List<EventListenerRegistration>> GetEventListeners(Broiler.Dom.DomNode element) =>
         GetElementRuntimeState(element).EventListeners;
 
     private static Dictionary<string, JSValue> GetInlineEventHandlers(Broiler.Dom.DomNode element) =>
         GetElementRuntimeState(element).InlineEventHandlers;
 
-    internal bool TryGetStoredScrollOffset(DomElement element, bool vertical, out double offset)
+    internal bool TryGetStoredScrollOffset(Broiler.Dom.DomElement element, bool vertical, out double offset)
     {
         var slot = vertical
             ? GetElementRuntimeState(element).Scroll.Top
@@ -426,11 +435,11 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         return false;
     }
 
-    internal double? GetStoredScrollOffsetOrDefault(DomElement element, bool vertical) =>
+    internal double? GetStoredScrollOffsetOrDefault(Broiler.Dom.DomElement element, bool vertical) =>
         TryGetStoredScrollOffset(element, vertical, out var offset) ? offset : null;
 
     internal bool TryGetResolvedLayout(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         out double left,
         out double top,
         out double width,
@@ -750,7 +759,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         // child of the document node. It may not appear in the flat
         // _knownNodes list because html/head/body are structural elements
         // pre-created by HtmlTreeBuilder.
-        DomElement? body = null;
+        Broiler.Dom.DomElement? body = null;
         if (htmlEl != null)
         {
             body = ChildElements(htmlEl).FirstOrDefault(c =>
@@ -852,7 +861,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         return new JSArray([.. frames]);
     }
 
-    private void CollectWindowFrames(DomElement element, List<JSValue> frames)
+    private void CollectWindowFrames(Broiler.Dom.DomElement element, List<JSValue> frames)
     {
         foreach (var child in ChildElements(element))
         {
@@ -1127,7 +1136,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
 /// Custom JSObject subclass for HTMLFormControlsCollection that returns null
 /// (not undefined) for named property lookups that don't match any control.
 /// </summary>
-internal sealed class FormElementsCollection(DomElement form, DomBridge bridge) : JSObject()
+internal sealed class FormElementsCollection(Broiler.Dom.DomElement form, DomBridge bridge) : JSObject()
 {
     protected override JSValue GetValue(KeyString key, JSValue receiver, bool throwError = true)
     {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorCenter.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorCenter.cs
@@ -11,7 +11,7 @@ public sealed partial class DomBridge
     /// Centers the element on the anchor in the appropriate axis.
     /// </summary>
     private void ResolveAnchorCenter(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         Dictionary<string, AnchorInfo> anchorRegistry)
     {
         if (!IsText(element))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
@@ -16,7 +16,7 @@ public sealed partial class DomBridge
         @"anchor-size\(\s*(?:(?<name>--[a-zA-Z0-9_-]+)\s+)?(?<dim>width|height|block|inline|self-block|self-inline)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private void ResolveAnchorFunctions(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         Dictionary<string, AnchorInfo> anchorRegistry)
     {
         var cssProps = CollectMatchedRuleProperties(element);
@@ -178,7 +178,7 @@ public sealed partial class DomBridge
     /// is scaled to match <c>ApplyScrollSimulation</c> under an active visual viewport.
     /// </summary>
     private void ComputeInterveningScrollOffset(
-        DomElement anchorEl, DomElement targetEl, out double offX, out double offY)
+        Broiler.Dom.DomElement anchorEl, Broiler.Dom.DomElement targetEl, out double offX, out double offY)
     {
         offX = 0;
         offY = 0;
@@ -234,7 +234,7 @@ public sealed partial class DomBridge
     /// True when <paramref name="node"/> is <paramref name="ancestor"/> or a
     /// descendant of it.
     /// </summary>
-    private static bool IsDescendantOrSelf(DomElement node, DomElement ancestor)
+    private static bool IsDescendantOrSelf(Broiler.Dom.DomElement node, Broiler.Dom.DomElement ancestor)
     {
         for (var cur = node; cur != null; cur = ParentEl(cur))
             if (cur == ancestor)
@@ -255,7 +255,7 @@ public sealed partial class DomBridge
     /// dimensions.
     /// </summary>
     private static void ResolveAnchorSizeFunctions(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         Dictionary<string, string> cssProps,
         Dictionary<string, AnchorInfo> anchorRegistry)
     {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
@@ -8,7 +8,7 @@ public sealed partial class DomBridge
 
     private sealed record AnchorInfo(
         double Top, double Left, double Width, double Height,
-        DomElement? SourceElement = null)
+        Broiler.Dom.DomElement? SourceElement = null)
     {
         public double Right => Left + Width;
         public double Bottom => Top + Height;
@@ -55,7 +55,7 @@ public sealed partial class DomBridge
     /// is found, so unique-name lookups (the overwhelming majority) are unchanged.
     /// </summary>
     private AnchorInfo? ResolveAnchorForElement(
-        string name, DomElement queryEl, Dictionary<string, AnchorInfo> registry)
+        string name, Broiler.Dom.DomElement queryEl, Dictionary<string, AnchorInfo> registry)
     {
         if (_anchorCandidates != null &&
             _anchorCandidates.TryGetValue(name, out var list) && list.Count > 1)
@@ -74,7 +74,7 @@ public sealed partial class DomBridge
         }
         return registry.TryGetValue(name, out var global) ? global : (AnchorInfo?)null;
     }
-    private AnchorInfo? ComputeElementBox(DomElement element)
+    private AnchorInfo? ComputeElementBox(Broiler.Dom.DomElement element)
     {
         var props = GetComputedProps(element);
 
@@ -234,7 +234,7 @@ public sealed partial class DomBridge
     /// or the element produced no usable box, keeping this a no-op until the parity
     /// gate enables real-layout geometry.
     /// </summary>
-    private bool TryGetAnchorLayoutBox(DomElement element, out AnchorInfo box)
+    private bool TryGetAnchorLayoutBox(Broiler.Dom.DomElement element, out AnchorInfo box)
     {
         box = default!;
         if (!UseSharedLayoutGeometry)
@@ -266,7 +266,7 @@ public sealed partial class DomBridge
     /// Walks up from <paramref name="element"/> to the nearest ancestor that
     /// establishes a containing block (the frame the estimator measures against).
     /// </summary>
-    private DomElement? FindGeometryContainingBlockAncestor(DomElement element)
+    private Broiler.Dom.DomElement? FindGeometryContainingBlockAncestor(Broiler.Dom.DomElement element)
     {
         for (var ancestor = ParentEl(element); ancestor != null; ancestor = ParentEl(ancestor))
             if (EstablishesContainingBlock(GetComputedProps(ancestor)))
@@ -301,7 +301,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Gets computed CSS properties for an element (CSS rules + inline styles).
     /// </summary>
-    private Dictionary<string, string> GetComputedProps(DomElement element)
+    private Dictionary<string, string> GetComputedProps(Broiler.Dom.DomElement element)
     {
         if (_computedPropsCache.TryGetValue(element, out var cached))
             return cached;
@@ -357,7 +357,7 @@ public sealed partial class DomBridge
             _computedPropsInProgress.TryRemove(element, out _);
         }
     }
-    private void ResolveExplicitInheritedValues(Dictionary<string, string> props, DomElement element)
+    private void ResolveExplicitInheritedValues(Dictionary<string, string> props, Broiler.Dom.DomElement element)
     {
         Dictionary<string, string>? parentProps = null;
         foreach (var key in props.Keys.ToList())
@@ -385,7 +385,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Computes the total height of preceding siblings in normal flow.
     /// </summary>
-    private double ComputePrecedingSiblingHeights(DomElement element)
+    private double ComputePrecedingSiblingHeights(Broiler.Dom.DomElement element)
     {
         if (ParentEl(element) == null) return 0;
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -52,8 +52,8 @@ public sealed partial class DomBridge
         //    Collects scroll containers that need position:relative but
         //    defers adding it until after position-visibility resolution,
         //    so IsAnchorVisibleForTarget is not affected by the new CB.
-        var scrollContainersNeedingRelative = new HashSet<DomElement>();
-        var deferredDomMoves = new List<(DomElement element, DomElement oldParent, DomElement newParent)>();
+        var scrollContainersNeedingRelative = new HashSet<Broiler.Dom.DomElement>();
+        var deferredDomMoves = new List<(Broiler.Dom.DomElement element, Broiler.Dom.DomElement oldParent, Broiler.Dom.DomElement newParent)>();
         ResolvePositionAreaValues(
             DocumentElement, anchorRegistry, scrollContainersNeedingRelative,
             deferredDomMoves);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ContainingBlocks.cs
@@ -13,11 +13,11 @@ public sealed partial class DomBridge
     /// styles so the renderer treats them as containing blocks for absolutely
     /// positioned descendants.
     /// </summary>
-    private void EnsureContainingBlockPositioning(DomElement root)
+    private void EnsureContainingBlockPositioning(Broiler.Dom.DomElement root)
     {
         EnsureContainingBlockPositioningTree(root);
     }
-    private void EnsureContainingBlockPositioningTree(DomElement el)
+    private void EnsureContainingBlockPositioningTree(Broiler.Dom.DomElement el)
     {
         if (!IsText(el) && !IsComment(el))
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/CssCleanup.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/CssCleanup.cs
@@ -14,7 +14,7 @@ public sealed partial class DomBridge
     /// properties.  This prevents the renderer from applying unsupported CSS
     /// that would conflict with the resolved inline styles.
     /// </summary>
-    private static void NeutralizeStyleElementsForAnchorRules(DomElement root)
+    private static void NeutralizeStyleElementsForAnchorRules(Broiler.Dom.DomElement root)
     {
         if (string.Equals(root.TagName, "style", StringComparison.OrdinalIgnoreCase))
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
@@ -13,7 +13,7 @@ public sealed partial class DomBridge
     /// Must be called <em>before</em> anchor resolution so that anchor()
     /// function values are resolved with the correct positioning context.
     /// </summary>
-    private void ApplyDialogUAPositioning(DomElement root)
+    private void ApplyDialogUAPositioning(Broiler.Dom.DomElement root)
     {
         foreach (var el in Elements)
         {
@@ -54,7 +54,7 @@ public sealed partial class DomBridge
     // so the counter has headroom.
     private const int TopLayerZIndexBase = 2_000_000_000;
 
-    private void ApplyPopoverUAPositioning(DomElement root)
+    private void ApplyPopoverUAPositioning(Broiler.Dom.DomElement root)
     {
         foreach (var el in Elements)
         {
@@ -86,11 +86,11 @@ public sealed partial class DomBridge
     // -----------------------------------------------------------------
 
     private void InsertDialogBackdrops(
-        DomElement root, int vpW, int vpH,
+        Broiler.Dom.DomElement root, int vpW, int vpH,
         Dictionary<string, AnchorInfo> anchorRegistry,
         Dictionary<string, Dictionary<string, string>> positionTryRules)
     {
-        var modals = new List<(DomElement dialog, DomElement parent, bool isPopover)>();
+        var modals = new List<(Broiler.Dom.DomElement dialog, Broiler.Dom.DomElement parent, bool isPopover)>();
         FindModalDialogs(root, modals);
         FindOpenPopovers(root, modals);
 
@@ -221,7 +221,7 @@ public sealed partial class DomBridge
     /// pseudo-element by checking CSS rules for <c>::backdrop</c> selectors
     /// that match the given dialog element.
     /// </summary>
-    private string GetBackdropBackground(DomElement dialog, string defaultBg = "rgb(229, 229, 229)")
+    private string GetBackdropBackground(Broiler.Dom.DomElement dialog, string defaultBg = "rgb(229, 229, 229)")
     {
         // Default modal-dialog backdrop color: pre-composited rgba(0,0,0,0.1) over
         // white (255*(1-0.1) + 0*0.1 = 229.5 ≈ 229). Callers pass "transparent"
@@ -259,7 +259,7 @@ public sealed partial class DomBridge
     /// <item>Non-top-layer anchors are always accessible.</item>
     /// </list>
     /// </remarks>
-    private static bool IsAnchorAccessible(DomElement? anchorElement, DomElement targetElement)
+    private static bool IsAnchorAccessible(Broiler.Dom.DomElement? anchorElement, Broiler.Dom.DomElement targetElement)
     {
         if (anchorElement == null) return true;
 
@@ -280,7 +280,7 @@ public sealed partial class DomBridge
 
         return anchorOrder < targetOrder;
     }
-    private static void FindModalDialogs(DomElement element, List<(DomElement, DomElement, bool)> results)
+    private static void FindModalDialogs(Broiler.Dom.DomElement element, List<(Broiler.Dom.DomElement, Broiler.Dom.DomElement, bool)> results)
     {
         if (string.Equals(element.TagName, "dialog", StringComparison.OrdinalIgnoreCase) &&
             HasAttr(element, "open") &&
@@ -301,7 +301,7 @@ public sealed partial class DomBridge
     // Popover API (HTML §popover): an element whose showPopover() ran (and whose
     // hidePopover() did not tear it down — see PopoverKeepsOverlayOnHide) is in
     // the top layer and generates a ::backdrop, just like a modal dialog.
-    private static void FindOpenPopovers(DomElement element, List<(DomElement, DomElement, bool)> results)
+    private static void FindOpenPopovers(Broiler.Dom.DomElement element, List<(Broiler.Dom.DomElement, Broiler.Dom.DomElement, bool)> results)
     {
         if (ParentEl(element) != null &&
             GetElementRuntimeState(element).Dialog.PopoverOpen.TryGet(out var open) &&
@@ -318,7 +318,7 @@ public sealed partial class DomBridge
     // layer because its `overlay` is being transitioned out with
     // `transition-behavior: allow-discrete`. A static render snapshots
     // mid-transition, so such a popover (and its ::backdrop) stays rendered.
-    private bool PopoverKeepsOverlayOnHide(DomElement element)
+    private bool PopoverKeepsOverlayOnHide(Broiler.Dom.DomElement element)
     {
         var props = GetComputedProps(element);
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/FixedPosition.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/FixedPosition.cs
@@ -17,7 +17,7 @@ public sealed partial class DomBridge
     {
         ResolveFixedPositionSizingInTree(DocumentElement, vpW, vpH);
     }
-    private void ResolveFixedPositionSizingInTree(DomElement el, int vpW, int vpH)
+    private void ResolveFixedPositionSizingInTree(Broiler.Dom.DomElement el, int vpW, int vpH)
     {
         if (!IsText(el))
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
@@ -34,7 +34,7 @@ public sealed partial class DomBridge
     /// Computes an element's box position relative to its positioned
     /// containing block, resolving <c>right</c> to <c>left</c> when needed.
     /// </summary>
-    private AnchorInfo? ComputeElementBoxWithContainer(DomElement element)
+    private AnchorInfo? ComputeElementBoxWithContainer(Broiler.Dom.DomElement element)
     {
         // Delegate to the main ComputeElementBox which already handles
         // both positioned and normal-flow elements with ancestor offset
@@ -45,7 +45,7 @@ public sealed partial class DomBridge
     /// Finds the width of the nearest positioned ancestor (containing block)
     /// for an absolutely positioned element.
     /// </summary>
-    private double FindContainingBlockWidth(DomElement element)
+    private double FindContainingBlockWidth(Broiler.Dom.DomElement element)
     {
         var parent = ParentEl(element);
         while (parent != null)
@@ -94,7 +94,7 @@ public sealed partial class DomBridge
     /// than defaulting to the viewport. Returns <c>null</c> when no sized
     /// ancestor is found (caller falls back to the viewport width).
     /// </summary>
-    private double? ResolveBlockUsedWidthFromAncestors(DomElement blockEl)
+    private double? ResolveBlockUsedWidthFromAncestors(Broiler.Dom.DomElement blockEl)
     {
         for (var a = ParentEl(blockEl); a != null && !IsText(a); a = ParentEl(a))
         {
@@ -116,7 +116,7 @@ public sealed partial class DomBridge
     /// Finds the height of the nearest positioned ancestor (containing block)
     /// for an absolutely positioned element.
     /// </summary>
-    private double FindContainingBlockHeight(DomElement element)
+    private double FindContainingBlockHeight(Broiler.Dom.DomElement element)
     {
         var parent = ParentEl(element);
         while (parent != null)
@@ -168,7 +168,7 @@ public sealed partial class DomBridge
         }
         return 8;
     }
-    private DomElement? FindBodyElement()
+    private Broiler.Dom.DomElement? FindBodyElement()
     {
         foreach (var el in Elements)
         {
@@ -183,7 +183,7 @@ public sealed partial class DomBridge
     /// <c>&lt;span&gt;</c>) by examining its text content and child element widths.
     /// Returns <c>null</c> if the element is not an inline element.
     /// </summary>
-    private double? EstimateInlineContentWidth(DomElement element)
+    private double? EstimateInlineContentWidth(Broiler.Dom.DomElement element)
     {
         string? display = GetComputedProps(element).GetValueOrDefault("display");
         bool isInline = IsInlineElement(element.TagName, display);
@@ -232,7 +232,7 @@ public sealed partial class DomBridge
     /// line-height or font-size.
     /// Returns <c>null</c> if the element is not an inline element.
     /// </summary>
-    private double? EstimateInlineContentHeight(DomElement element)
+    private double? EstimateInlineContentHeight(Broiler.Dom.DomElement element)
     {
         string? display = GetComputedProps(element).GetValueOrDefault("display");
         bool isInline = IsInlineElement(element.TagName, display);
@@ -297,7 +297,7 @@ public sealed partial class DomBridge
     /// <c>position: relative</c>).  Broiler's renderer cannot correctly
     /// place absolutely positioned children inside such elements.
     /// </summary>
-    private bool IsInlineContainingBlock(DomElement element)
+    private bool IsInlineContainingBlock(Broiler.Dom.DomElement element)
     {
         var props = GetComputedProps(element);
         string? display = props.GetValueOrDefault("display");
@@ -313,10 +313,10 @@ public sealed partial class DomBridge
     /// not support positioning absolutely positioned elements inside
     /// inline boxes (like <c>&lt;span&gt;</c>).
     /// </summary>
-    private void PromoteAbsPosFromInlineCBs(DomElement root)
+    private void PromoteAbsPosFromInlineCBs(Broiler.Dom.DomElement root)
     {
         // Collect all promotions first (to avoid mutating during traversal).
-        var promotions = new List<(DomElement child, DomElement inlineCB, DomElement blockAncestor,
+        var promotions = new List<(Broiler.Dom.DomElement child, Broiler.Dom.DomElement inlineCB, Broiler.Dom.DomElement blockAncestor,
             double offX, double offY)>();
         CollectInlineCBPromotions(root, promotions);
 
@@ -361,8 +361,8 @@ public sealed partial class DomBridge
         }
     }
     private void CollectInlineCBPromotions(
-        DomElement element,
-        List<(DomElement child, DomElement inlineCB, DomElement blockAncestor,
+        Broiler.Dom.DomElement element,
+        List<(Broiler.Dom.DomElement child, Broiler.Dom.DomElement inlineCB, Broiler.Dom.DomElement blockAncestor,
             double offX, double offY)> promotions)
     {
         if (!IsText(element) && IsInlineContainingBlock(element))
@@ -393,8 +393,8 @@ public sealed partial class DomBridge
     /// coordinates when promoting position-area elements out of an inline CB.
     /// Returns (offsetX, offsetY, blockAncestor).
     /// </summary>
-    private (double offsetX, double offsetY, DomElement? blockAncestor)
-        ComputeInlineCBOffset(DomElement inlineCB)
+    private (double offsetX, double offsetY, Broiler.Dom.DomElement? blockAncestor)
+        ComputeInlineCBOffset(Broiler.Dom.DomElement inlineCB)
     {
         // Walk up from the inline CB to find the nearest block-level ancestor.
         // The inline CB's position within its parent block is determined by:
@@ -403,7 +403,7 @@ public sealed partial class DomBridge
         // - Line breaks
         // We estimate this from the layout context.
         var parent = ParentEl(inlineCB);
-        DomElement? blockAncestor = null;
+        Broiler.Dom.DomElement? blockAncestor = null;
 
         // Find nearest block-level ancestor.
         while (parent != null)
@@ -441,7 +441,7 @@ public sealed partial class DomBridge
     /// its nearest block ancestor, accounting for preceding text and
     /// inline content.
     /// </summary>
-    private double EstimateInlineOffsetX(DomElement inlineEl, DomElement blockAncestor)
+    private double EstimateInlineOffsetX(Broiler.Dom.DomElement inlineEl, Broiler.Dom.DomElement blockAncestor)
     {
         double offset = 0;
         var parent = ParentEl(inlineEl);
@@ -463,7 +463,7 @@ public sealed partial class DomBridge
     /// siblings, line breaks (<c>&lt;br&gt;</c>), and text nodes that
     /// contain only line breaks.
     /// </summary>
-    private double EstimateInlineOffsetY(DomElement inlineEl, DomElement blockAncestor)
+    private double EstimateInlineOffsetY(Broiler.Dom.DomElement inlineEl, Broiler.Dom.DomElement blockAncestor)
     {
         double offset = 0;
         var parent = ParentEl(inlineEl);
@@ -482,7 +482,7 @@ public sealed partial class DomBridge
     /// handling <c>&lt;br&gt;</c> elements (which contribute the parent's
     /// line-height) and text nodes with line breaks.
     /// </summary>
-    private double EstimatePrecedingBlockHeight(DomElement element, DomElement parent)
+    private double EstimatePrecedingBlockHeight(Broiler.Dom.DomElement element, Broiler.Dom.DomElement parent)
     {
         double totalHeight = 0;
         var parentProps = GetComputedProps(parent);
@@ -558,7 +558,7 @@ public sealed partial class DomBridge
     /// Estimates the total width of inline content preceding <paramref name="element"/>
     /// within <paramref name="parent"/>.  This includes text nodes and inline elements.
     /// </summary>
-    private double EstimatePrecedingInlineWidth(DomElement element, DomElement parent)
+    private double EstimatePrecedingInlineWidth(Broiler.Dom.DomElement element, Broiler.Dom.DomElement parent)
     {
         double width = 0;
         var props = GetComputedProps(parent);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
@@ -15,10 +15,10 @@ public sealed partial class DomBridge
     /// region specified by position-area and sets explicit inline styles.
     /// </summary>
     private void ResolvePositionAreaValues(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         Dictionary<string, AnchorInfo> anchorRegistry,
-        HashSet<DomElement> scrollContainersNeedingRelative,
-        List<(DomElement element, DomElement oldParent, DomElement newParent)> deferredDomMoves)
+        HashSet<Broiler.Dom.DomElement> scrollContainersNeedingRelative,
+        List<(Broiler.Dom.DomElement element, Broiler.Dom.DomElement oldParent, Broiler.Dom.DomElement newParent)> deferredDomMoves)
     {
         if (!IsText(element))
         {
@@ -409,8 +409,8 @@ public sealed partial class DomBridge
     /// rather than the target element's normal containing block.
     /// </summary>
     private PositionAreaRect? ComputePositionAreaRect(
-        DomElement element, AnchorInfo anchor, string positionArea,
-        DomElement? scrollContainer = null)
+        Broiler.Dom.DomElement element, AnchorInfo anchor, string positionArea,
+        Broiler.Dom.DomElement? scrollContainer = null)
     {
         double cbWidth, cbHeight;
         double anchorLeft, anchorRight, anchorTop, anchorBottom;
@@ -576,7 +576,7 @@ public sealed partial class DomBridge
     /// Falls back to the container's own width if no explicit child widths
     /// are found.
     /// </summary>
-    private double FindScrollContentWidth(DomElement scrollContainer, double containerWidth)
+    private double FindScrollContentWidth(Broiler.Dom.DomElement scrollContainer, double containerWidth)
     {
         double maxWidth = containerWidth;
         foreach (var child in SnapshotChildren(scrollContainer))
@@ -603,7 +603,7 @@ public sealed partial class DomBridge
     /// the block-axis scroll extent.  The result is clamped to at least the
     /// container's own height (scrollHeight ≥ clientHeight).
     /// </summary>
-    private double FindScrollContentHeight(DomElement scrollContainer, double containerHeight)
+    private double FindScrollContentHeight(Broiler.Dom.DomElement scrollContainer, double containerHeight)
     {
         double stackedHeight = 0;
         foreach (var child in SnapshotChildren(scrollContainer))
@@ -628,7 +628,7 @@ public sealed partial class DomBridge
     /// Otherwise, both are in document coordinates and we subtract.
     /// </summary>
     private (double Left, double Top) ComputeAnchorRelativeToContainer(
-        AnchorInfo anchor, DomElement container)
+        AnchorInfo anchor, Broiler.Dom.DomElement container)
     {
         // Check if the container establishes a CB. If it does, the anchor's
         // ComputeElementBox walk will have stopped at the container, and
@@ -646,7 +646,7 @@ public sealed partial class DomBridge
     /// Finds the nearest ancestor of <paramref name="el"/> that is a scroll
     /// container (has <c>overflow: hidden/scroll/auto/clip</c>).
     /// </summary>
-    private DomElement? FindNearestScrollContainer(DomElement el)
+    private Broiler.Dom.DomElement? FindNearestScrollContainer(Broiler.Dom.DomElement el)
     {
         var parent = ParentEl(el);
         while (parent != null)
@@ -665,7 +665,7 @@ public sealed partial class DomBridge
     /// Returns <c>true</c> when <paramref name="el"/> is a descendant of
     /// <paramref name="potentialAncestor"/> in the DOM tree.
     /// </summary>
-    private static bool IsDescendantOfElement(DomElement el, DomElement potentialAncestor)
+    private static bool IsDescendantOfElement(Broiler.Dom.DomElement el, Broiler.Dom.DomElement potentialAncestor)
     {
         var current = ParentEl(el);
         while (current != null)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionAreaQueries.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionAreaQueries.cs
@@ -18,7 +18,7 @@ public sealed partial class DomBridge
     // by element identity mirrors ElementRuntimeStates' lifetime, so a detached element's
     // memo is collected with it, and the invalidation (position-area / position-anchor
     // mutation) and clone-copy semantics are unchanged from the old .Layout slots.
-    private static readonly ConditionalWeakTable<DomElement, PositionAreaResolution>
+    private static readonly ConditionalWeakTable<Broiler.Dom.DomElement, PositionAreaResolution>
         PositionAreaResolutions = [];
 
     private sealed class PositionAreaResolution
@@ -30,7 +30,7 @@ public sealed partial class DomBridge
     }
 
     private static bool TryGetPositionAreaResolution(
-        DomElement element, out (double left, double top, double width, double height) rect)
+        Broiler.Dom.DomElement element, out (double left, double top, double width, double height) rect)
     {
         if (PositionAreaResolutions.TryGetValue(element, out var r))
         {
@@ -43,7 +43,7 @@ public sealed partial class DomBridge
     }
 
     private static void SetPositionAreaResolution(
-        DomElement element, double left, double top, double width, double height) =>
+        Broiler.Dom.DomElement element, double left, double top, double width, double height) =>
         PositionAreaResolutions.AddOrUpdate(element, new PositionAreaResolution
         {
             Left = left,
@@ -52,10 +52,10 @@ public sealed partial class DomBridge
             Height = height,
         });
 
-    private static void ClearPositionAreaResolution(DomElement element) =>
+    private static void ClearPositionAreaResolution(Broiler.Dom.DomElement element) =>
         PositionAreaResolutions.Remove(element);
 
-    private static void CopyPositionAreaResolution(DomElement source, DomElement target)
+    private static void CopyPositionAreaResolution(Broiler.Dom.DomElement source, Broiler.Dom.DomElement target)
     {
         if (PositionAreaResolutions.TryGetValue(source, out var r))
             PositionAreaResolutions.AddOrUpdate(target, new PositionAreaResolution
@@ -73,7 +73,7 @@ public sealed partial class DomBridge
     /// Called lazily when offsetLeft/offsetTop/etc. are queried.
     /// </summary>
     internal (double left, double top, double width, double height)?
-        ResolvePositionAreaForElement(DomElement element)
+        ResolvePositionAreaForElement(Broiler.Dom.DomElement element)
     {
         // Check for pre-resolved values first.
         if (TryGetPositionAreaResolution(element, out var cached))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
@@ -27,36 +27,44 @@ public sealed partial class DomBridge
         return result;
     }
     private void CollectPositionTryRulesFromTree(
-        DomElement el,
+        Broiler.Dom.DomElement el,
         Dictionary<string, Dictionary<string, string>> result)
     {
         if (string.Equals(el.TagName, "style", StringComparison.OrdinalIgnoreCase))
         {
-            foreach (var child in SnapshotChildren(el))
+            // RF-BRIDGE-1c Phase F (F3c) follow-up: read the <style> source through the
+            // canonical GetStyleElementSourceText accessor rather than hand-walking child
+            // text nodes. After Attach, a <style> element's CSS can live in its InnerHtml
+            // runtime state with no DomText child at all (childCount == 0) — the raw child
+            // walk then saw nothing, so @position-try rules were never collected and every
+            // fallback silently failed to apply (in both the resolve-only and full-render
+            // paths). GetStyleElementSourceText is the same source the cascade reads and
+            // covers both the DomText-child and InnerHtml-fallback cases. Use the raw source
+            // (not the serialized rule model): the CSS rule serializer does not round-trip
+            // the @position-try at-rule.
+            var raw = GetStyleElementSourceText(el);
+            if (!string.IsNullOrEmpty(raw))
             {
-                if (IsText(child) && !string.IsNullOrEmpty(BridgeText(child)))
+                // Strip CSS comments first: a comment inside a @position-try
+                // body (common in WPT, e.g. "/* 2: position right */") contains
+                // ':' and ';' that would otherwise corrupt declaration parsing.
+                var styleText = CssCommentPattern.Replace(raw, " ");
+                foreach (Match m in PositionTryParsePattern.Matches(styleText))
                 {
-                    // Strip CSS comments first: a comment inside a @position-try
-                    // body (common in WPT, e.g. "/* 2: position right */") contains
-                    // ':' and ';' that would otherwise corrupt declaration parsing.
-                    var styleText = CssCommentPattern.Replace(BridgeText(child), " ");
-                    foreach (Match m in PositionTryParsePattern.Matches(styleText))
+                    var name = m.Groups["name"].Value;
+                    var body = m.Groups["body"].Value;
+                    var props = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var decl in body.Split(';'))
                     {
-                        var name = m.Groups["name"].Value;
-                        var body = m.Groups["body"].Value;
-                        var props = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                        foreach (var decl in body.Split(';'))
-                        {
-                            var trimmed = decl.Trim();
-                            if (string.IsNullOrEmpty(trimmed)) continue;
-                            var colonIdx = trimmed.IndexOf(':');
-                            if (colonIdx < 0) continue;
-                            var propName = trimmed[..colonIdx].Trim();
-                            var propValue = trimmed[(colonIdx + 1)..].Trim();
-                            props[propName] = propValue;
-                        }
-                        result[name] = props;
+                        var trimmed = decl.Trim();
+                        if (string.IsNullOrEmpty(trimmed)) continue;
+                        var colonIdx = trimmed.IndexOf(':');
+                        if (colonIdx < 0) continue;
+                        var propName = trimmed[..colonIdx].Trim();
+                        var propValue = trimmed[(colonIdx + 1)..].Trim();
+                        props[propName] = propValue;
                     }
+                    result[name] = props;
                 }
             }
         }
@@ -70,14 +78,14 @@ public sealed partial class DomBridge
     /// non-overflowing fallback from the <c>@position-try</c> rules.
     /// </summary>
     private void ResolvePositionTryFallbacks(
-        DomElement root,
+        Broiler.Dom.DomElement root,
         Dictionary<string, AnchorInfo> anchorRegistry,
         Dictionary<string, Dictionary<string, string>> positionTryRules)
     {
         ResolvePositionTryFallbacksTree(root, anchorRegistry, positionTryRules);
     }
     private void ResolvePositionTryFallbacksTree(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         Dictionary<string, AnchorInfo> anchorRegistry,
         Dictionary<string, Dictionary<string, string>> positionTryRules)
     {
@@ -104,7 +112,7 @@ public sealed partial class DomBridge
             ResolvePositionTryFallbacksTree(child, anchorRegistry, positionTryRules);
     }
     private void TryApplyFallback(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         Dictionary<string, string> baseProps,
         Dictionary<string, AnchorInfo> anchorRegistry,
         Dictionary<string, Dictionary<string, string>> positionTryRules,
@@ -277,7 +285,7 @@ public sealed partial class DomBridge
     /// children's explicit widths. This is a heuristic for elements
     /// with <c>width: min-content</c>.
     /// </summary>
-    private double EstimateMinContentWidth(DomElement element)
+    private double EstimateMinContentWidth(Broiler.Dom.DomElement element)
     {
         double maxWidth = 0;
         foreach (var child in SnapshotChildren(element))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
@@ -14,11 +14,11 @@ public sealed partial class DomBridge
     /// with negative margins.  Combined with <c>overflow: hidden</c>, this
     /// produces the same visual output as a real browser scroll.
     /// </summary>
-    private void ApplyScrollSimulation(DomElement root)
+    private void ApplyScrollSimulation(Broiler.Dom.DomElement root)
     {
         ApplyScrollSimulationTree(root);
     }
-    private void ApplyScrollSimulationTree(DomElement el)
+    private void ApplyScrollSimulationTree(Broiler.Dom.DomElement el)
     {
         if (!IsText(el))
         {
@@ -80,7 +80,7 @@ public sealed partial class DomBridge
                     // offset applied to the wrapper.
                     if (isDocScrollingElement)
                     {
-                        var fixedDescendants = new List<DomElement>();
+                        var fixedDescendants = new List<Broiler.Dom.DomElement>();
                         CollectFixedDescendants(wrapper, fixedDescendants);
                         foreach (var fixedEl in fixedDescendants)
                         {
@@ -131,14 +131,14 @@ public sealed partial class DomBridge
         // Use index-based loop because the list may grow during iteration
         // (wrapper insertion above).
         for (int i = 0; i < el.ChildNodes.Count; i++)
-            if (ChildAt(el, i) is DomElement child)
+            if (ChildAt(el, i) is Broiler.Dom.DomElement child)
                 ApplyScrollSimulationTree(child);
     }
     /// <summary>
     /// Recursively collects all descendants with <c>position: fixed</c>
     /// (including generated backdrop divs) from the given subtree.
     /// </summary>
-    private void CollectFixedDescendants(DomElement parent, List<DomElement> results)
+    private void CollectFixedDescendants(Broiler.Dom.DomElement parent, List<Broiler.Dom.DomElement> results)
     {
         foreach (var child in SnapshotChildren(parent))
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/StickyPositioning.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/StickyPositioning.cs
@@ -21,12 +21,12 @@ namespace Broiler.HtmlBridge;
 /// </summary>
 public sealed partial class DomBridge
 {
-    private void ResolveStickyPositioning(DomElement root)
+    private void ResolveStickyPositioning(Broiler.Dom.DomElement root)
     {
         ResolveStickyPositioningTree(root);
     }
 
-    private void ResolveStickyPositioningTree(DomElement el)
+    private void ResolveStickyPositioningTree(Broiler.Dom.DomElement el)
     {
         if (!IsText(el) && IsSticky(GetComputedProps(el)))
             ApplyStickyOffset(el);
@@ -34,11 +34,11 @@ public sealed partial class DomBridge
         // Index-based: ApplyStickyOffset only mutates el's own style, not the
         // child list, but stay defensive.
         for (int i = 0; i < el.ChildNodes.Count; i++)
-            if (ChildAt(el, i) is DomElement child)
+            if (ChildAt(el, i) is Broiler.Dom.DomElement child)
                 ResolveStickyPositioningTree(child);
     }
 
-    private void ApplyStickyOffset(DomElement el)
+    private void ApplyStickyOffset(Broiler.Dom.DomElement el)
     {
         var props = GetComputedProps(el);
 
@@ -69,8 +69,8 @@ public sealed partial class DomBridge
     }
 
     private double ComputeStickyShift(
-        DomElement el, Dictionary<string, string> props,
-        DomElement scrollContainer, DomElement containingBlock, bool vertical)
+        Broiler.Dom.DomElement el, Dictionary<string, string> props,
+        Broiler.Dom.DomElement scrollContainer, Broiler.Dom.DomElement containingBlock, bool vertical)
     {
         string startInset = vertical ? "top" : "left";
         string endInset = vertical ? "bottom" : "right";
@@ -122,7 +122,7 @@ public sealed partial class DomBridge
         return Math.Clamp(shift, minShift, maxShift);
     }
 
-    private double StickyBorderBoxSize(DomElement el, Dictionary<string, string> props, bool vertical)
+    private double StickyBorderBoxSize(Broiler.Dom.DomElement el, Dictionary<string, string> props, bool vertical)
     {
         // RF-BRIDGE-1b: the renderer's real border-box size from the shared snapshot
         // (scroll-independent). With the estimators deleted, an explicit CSS border-box from
@@ -138,7 +138,7 @@ public sealed partial class DomBridge
         !string.IsNullOrWhiteSpace(value) &&
         !string.Equals(value, "auto", StringComparison.OrdinalIgnoreCase);
 
-    private double ParseStickyInset(string? value, DomElement el, DomElement scrollContainer, bool vertical)
+    private double ParseStickyInset(string? value, Broiler.Dom.DomElement el, Broiler.Dom.DomElement scrollContainer, bool vertical)
     {
         // Percentage insets on a sticky box resolve against the scroll
         // container's content-box size along the axis.
@@ -152,7 +152,7 @@ public sealed partial class DomBridge
     /// The containing block used to clamp a sticky box: its nearest ancestor
     /// that establishes a block-level box (skips inline/anonymous wrappers).
     /// </summary>
-    private DomElement? GetStickyContainingBlock(DomElement el)
+    private Broiler.Dom.DomElement? GetStickyContainingBlock(Broiler.Dom.DomElement el)
     {
         for (var current = GetScrollTraversalParent(el); current != null; current = GetScrollTraversalParent(current))
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Visibility.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Visibility.cs
@@ -12,13 +12,13 @@ public sealed partial class DomBridge
     /// CSS <c>visibility: hidden</c>) or does not exist.
     /// </summary>
     private void ResolvePositionVisibility(
-        DomElement root,
+        Broiler.Dom.DomElement root,
         Dictionary<string, AnchorInfo> anchorRegistry)
     {
         ResolvePositionVisibilityTree(root, anchorRegistry);
     }
     private void ResolvePositionVisibilityTree(
-        DomElement el,
+        Broiler.Dom.DomElement el,
         Dictionary<string, AnchorInfo> anchorRegistry)
     {
         if (!IsText(el))
@@ -96,10 +96,10 @@ public sealed partial class DomBridge
             ResolvePositionVisibilityTree(child, anchorRegistry);
     }
     /// <summary>
-    /// Finds the <see cref="DomElement"/> that has the given
+    /// Finds the <see cref="Broiler.Dom.DomElement"/> that has the given
     /// <c>anchor-name</c> (from CSS rules or inline styles).
     /// </summary>
-    private DomElement? FindElementByAnchorName(string anchorName)
+    private Broiler.Dom.DomElement? FindElementByAnchorName(string anchorName)
     {
         foreach (var el in Elements)
         {
@@ -129,7 +129,7 @@ public sealed partial class DomBridge
     /// the scroll container is the containing block for the target element,
     /// the anchor is considered visible (per spec § position-visibility).
     /// </summary>
-    private bool IsAnchorVisibleForTarget(DomElement anchor, DomElement target)
+    private bool IsAnchorVisibleForTarget(Broiler.Dom.DomElement anchor, Broiler.Dom.DomElement target)
     {
         // Check CSS visibility on the anchor and its ancestors.
         if (HasInheritedVisibilityHidden(anchor))
@@ -180,7 +180,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Checks whether the element or any ancestor has <c>visibility: hidden</c>.
     /// </summary>
-    private bool HasInheritedVisibilityHidden(DomElement el)
+    private bool HasInheritedVisibilityHidden(Broiler.Dom.DomElement el)
     {
         var current = el;
         while (current != null)
@@ -198,7 +198,7 @@ public sealed partial class DomBridge
     /// <paramref name="container"/> by summing heights of preceding siblings
     /// and ancestor margins/padding up to the container.
     /// </summary>
-    private double ComputeNaturalOffsetInContainer(DomElement el, DomElement container)
+    private double ComputeNaturalOffsetInContainer(Broiler.Dom.DomElement el, Broiler.Dom.DomElement container)
     {
         double offset = 0;
         var current = el;
@@ -221,7 +221,7 @@ public sealed partial class DomBridge
     /// Finds the nearest positioned ancestor that serves as the containing
     /// block for an absolutely positioned element.
     /// </summary>
-    private DomElement? FindContainingBlockElement(DomElement el)
+    private Broiler.Dom.DomElement? FindContainingBlockElement(Broiler.Dom.DomElement el)
     {
         var parent = ParentEl(el);
         while (parent != null)
@@ -238,7 +238,7 @@ public sealed partial class DomBridge
     /// The anchor's CB is typically the same as the target's CB when both are
     /// inside the same positioned ancestor.
     /// </summary>
-    private DomElement? FindAnchorContainingBlock(DomElement target, DomElement targetCB)
+    private Broiler.Dom.DomElement? FindAnchorContainingBlock(Broiler.Dom.DomElement target, Broiler.Dom.DomElement targetCB)
     {
         // Find the anchor element by looking at the target's position-anchor.
         var cssProps = GetComputedProps(target);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
@@ -36,7 +36,7 @@ public sealed partial class DomBridge
 
     private sealed record KeyframeEntry(float Position, Dictionary<string, string> Properties);
 
-    private static void CollectKeyframes(DomElement root, Dictionary<string, List<KeyframeEntry>> map)
+    private static void CollectKeyframes(Broiler.Dom.DomElement root, Dictionary<string, List<KeyframeEntry>> map)
     {
         if (string.Equals(root.TagName, "style", StringComparison.OrdinalIgnoreCase))
         {
@@ -108,7 +108,7 @@ public sealed partial class DomBridge
     // -----------------------------------------------------------------
 
     private void ResolveAnimationsOnTree(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         Dictionary<string, List<KeyframeEntry>> keyframesMap)
     {
         // Check if this element has animation properties set (inline styles).
@@ -162,7 +162,7 @@ public sealed partial class DomBridge
     /// whose selectors match the given element.  This is a simplified matcher
     /// that handles tag selectors (e.g. <c>body</c>, <c>html</c>).
     /// </summary>
-    private static Dictionary<string, string>? CollectStylesheetAnimationProperties(DomElement element)
+    private static Dictionary<string, string>? CollectStylesheetAnimationProperties(Broiler.Dom.DomElement element)
     {
         // Walk up to find <style> elements.
         var root = element;
@@ -174,7 +174,7 @@ public sealed partial class DomBridge
     }
 
     private static void CollectAnimPropsFromStyleElements(
-        DomElement node, DomElement target, ref Dictionary<string, string>? result)
+        Broiler.Dom.DomElement node, Broiler.Dom.DomElement target, ref Dictionary<string, string>? result)
     {
         if (string.Equals(node.TagName, "style", StringComparison.OrdinalIgnoreCase))
         {
@@ -212,7 +212,7 @@ public sealed partial class DomBridge
     /// Very simple CSS selector matcher — handles tag names, classes, IDs,
     /// and <c>:root</c> pseudo-class.  Sufficient for WPT body/html selectors.
     /// </summary>
-    private static bool SimpleMatchesElement(string selector, DomElement element)
+    private static bool SimpleMatchesElement(string selector, Broiler.Dom.DomElement element)
     {
         var selTrimmed = selector.Trim().ToLowerInvariant();
 
@@ -244,7 +244,7 @@ public sealed partial class DomBridge
     }
 
     private void TryResolveAnimation(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         Dictionary<string, List<KeyframeEntry>> keyframesMap,
         string? animationShorthand,
         string? animationDelay,
@@ -354,7 +354,7 @@ public sealed partial class DomBridge
     }
 
     private Dictionary<string, string> ResolveKeyframeProperties(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         List<KeyframeEntry> keyframes, float progress, string timingFunction)
     {
         var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -631,7 +631,7 @@ public sealed partial class DomBridge
     /// Supports color values (rgb, rgba, named colors) and numeric values.
     /// Falls back to discrete stepping for unsupported value types.
     /// </summary>
-    private string TryInterpolateValue(DomElement element, string prop, string fromValue, string toValue, float progress)
+    private string TryInterpolateValue(Broiler.Dom.DomElement element, string prop, string fromValue, string toValue, float progress)
     {
         // Try color interpolation for color-related properties.
         if (IsColorProperty(prop))
@@ -662,7 +662,7 @@ public sealed partial class DomBridge
     }
 
     private bool TryInterpolateLengthValue(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         string prop,
         string fromValue,
         string toValue,
@@ -685,7 +685,7 @@ public sealed partial class DomBridge
         return true;
     }
 
-    private double? GetInterpolationPercentageBasis(DomElement element, string prop)
+    private double? GetInterpolationPercentageBasis(Broiler.Dom.DomElement element, string prop)
     {
         return prop switch
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
@@ -12,7 +12,7 @@ public sealed partial class DomBridge
 {
     // -----------------------------------------------------------------
     // RF-BRIDGE-1c Phase C: string-keyed attribute access over canonical
-    // Broiler.Dom attributes, replacing the removed DomElement.Attributes
+    // Broiler.Dom attributes, replacing the removed Broiler.Dom.DomElement.Attributes
     // (LegacyAttributeDictionary) facade. Each helper mirrors the legacy
     // dictionary's semantics exactly — a case-insensitive scan by qualified
     // name over the canonical (namespace-keyed) attribute set — so the
@@ -21,7 +21,7 @@ public sealed partial class DomBridge
 
     /// <summary>Legacy <c>Attributes.TryGetValue</c>: case-insensitive lookup by
     /// qualified name; <paramref name="value"/> is <c>""</c> when absent.</summary>
-    private static bool TryGetAttribute(DomElement element, string qualifiedName, out string value)
+    private static bool TryGetAttribute(Broiler.Dom.DomElement element, string qualifiedName, out string value)
     {
         foreach (var attribute in element.Attributes.Values)
         {
@@ -37,16 +37,16 @@ public sealed partial class DomBridge
     }
 
     /// <summary>Legacy <c>Attributes.GetValueOrDefault</c> / null-returning indexer get.</summary>
-    private static string? GetAttr(DomElement element, string qualifiedName) =>
+    private static string? GetAttr(Broiler.Dom.DomElement element, string qualifiedName) =>
         TryGetAttribute(element, qualifiedName, out var value) ? value : null;
 
     /// <summary>Legacy <c>Attributes.ContainsKey</c>.</summary>
-    private static bool HasAttr(DomElement element, string qualifiedName) =>
+    private static bool HasAttr(Broiler.Dom.DomElement element, string qualifiedName) =>
         TryGetAttribute(element, qualifiedName, out _);
 
     /// <summary>Legacy string-keyed <c>Attributes[name] = value</c> setter: updates an
     /// existing attribute in place (preserving its namespace) or creates a no-namespace one.</summary>
-    private static void SetAttr(DomElement element, string qualifiedName, string value)
+    private static void SetAttr(Broiler.Dom.DomElement element, string qualifiedName, string value)
     {
         Broiler.Dom.DomAttribute? existing = null;
         foreach (var attribute in element.Attributes.Values)
@@ -65,7 +65,7 @@ public sealed partial class DomBridge
     }
 
     /// <summary>Legacy <c>Attributes.Remove</c>: removes the attribute matched by qualified name.</summary>
-    private static bool RemoveAttr(DomElement element, string qualifiedName)
+    private static bool RemoveAttr(Broiler.Dom.DomElement element, string qualifiedName)
     {
         Broiler.Dom.DomAttribute? existing = null;
         foreach (var attribute in element.Attributes.Values)
@@ -82,14 +82,14 @@ public sealed partial class DomBridge
 
     /// <summary>
     /// RF-BRIDGE-1c Phase C2: canonical replacement for the removed
-    /// <c>DomElement.NsAttrMap</c> shadow map. Looks up the attribute identified by
+    /// <c>Broiler.Dom.DomElement.NsAttrMap</c> shadow map. Looks up the attribute identified by
     /// (<paramref name="namespaceUri"/>, <paramref name="localName"/>) directly in the
     /// canonical namespace-keyed attribute set and yields its qualified (possibly
     /// prefixed) name plus value — the exact pair <c>NsAttrMap</c> used to carry. The
     /// namespace is normalized (empty string ≡ null) to match canonical attribute keying,
     /// the same normalization <c>SetAttributeNS</c>/<c>GetAttributeNS</c> apply.
     /// </summary>
-    private static bool TryGetNsAttribute(DomElement element, string? namespaceUri, string localName, out string qualifiedName, out string value)
+    private static bool TryGetNsAttribute(Broiler.Dom.DomElement element, string? namespaceUri, string localName, out string qualifiedName, out string value)
     {
         var ns = string.IsNullOrEmpty(namespaceUri) ? null : namespaceUri;
         if (element.Attributes.TryGetValue((ns, localName), out var attribute))
@@ -105,13 +105,13 @@ public sealed partial class DomBridge
     }
 
     /// <summary>Legacy <c>Attributes.Keys</c>: the qualified names of the element's attributes.</summary>
-    private static IEnumerable<string> AttributeNames(DomElement element) =>
+    private static IEnumerable<string> AttributeNames(Broiler.Dom.DomElement element) =>
         element.Attributes.Values.Select(static attribute => attribute.QualifiedName);
 
     /// <summary>Legacy enumeration/snapshot of the string-keyed attribute map (qualified
     /// name → value, case-insensitive, last-wins on collision — matching the old
     /// <c>LegacyAttributeDictionary.Snapshot</c>).</summary>
-    private static Dictionary<string, string> AttributeSnapshot(DomElement element)
+    private static Dictionary<string, string> AttributeSnapshot(Broiler.Dom.DomElement element)
     {
         var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var attribute in element.Attributes.Values)
@@ -121,7 +121,7 @@ public sealed partial class DomBridge
 
     /// <summary>Restores the element's attribute set to <paramref name="saved"/> — the
     /// attribute-map equivalent of <c>RestoreStringMap</c> (remove extras, then set saved).</summary>
-    private static void RestoreAttributes(DomElement element, Dictionary<string, string> saved)
+    private static void RestoreAttributes(Broiler.Dom.DomElement element, Dictionary<string, string> saved)
     {
         foreach (var name in AttributeNames(element).ToList())
         {
@@ -133,7 +133,7 @@ public sealed partial class DomBridge
             SetAttr(element, kv.Key, kv.Value);
     }
 
-    private void CollectByTagName(DomElement root, string tag, List<JSValue> results)
+    private void CollectByTagName(Broiler.Dom.DomElement root, string tag, List<JSValue> results)
     {
         foreach (var child in ChildElements(root))
         {
@@ -147,7 +147,7 @@ public sealed partial class DomBridge
     /// Collects all <c>&lt;a&gt;</c> and <c>&lt;area&gt;</c> elements with an
     /// <c>href</c> attribute in document tree order.
     /// </summary>
-    private void CollectLinksInTreeOrder(DomElement root, List<JSValue> results)
+    private void CollectLinksInTreeOrder(Broiler.Dom.DomElement root, List<JSValue> results)
     {
         foreach (var child in ChildElements(root))
         {
@@ -163,7 +163,7 @@ public sealed partial class DomBridge
     }
 
     /// <summary>Collects all elements matching a predicate in a sub-tree.</summary>
-    private void CollectMatching(DomElement root, Func<DomElement, bool> predicate, List<JSValue> results)
+    private void CollectMatching(Broiler.Dom.DomElement root, Func<Broiler.Dom.DomElement, bool> predicate, List<JSValue> results)
     {
         foreach (var child in ChildElements(root))
         {
@@ -173,8 +173,8 @@ public sealed partial class DomBridge
         }
     }
 
-    /// <summary>Collects all DomElement nodes in a sub-tree for tracking.</summary>
-    private static void CollectSubDocElements(DomElement root, List<DomElement> list)
+    /// <summary>Collects all Broiler.Dom.DomElement nodes in a sub-tree for tracking.</summary>
+    private static void CollectSubDocElements(Broiler.Dom.DomElement root, List<Broiler.Dom.DomElement> list)
     {
         list.Add(root);
         foreach (var child in ChildElements(root))
@@ -191,7 +191,7 @@ public sealed partial class DomBridge
     /// Builds a NamedNodeMap-like JSObject for element.attributes, with
     /// getNamedItem, setNamedItem, removeNamedItem, item, and length.
     /// </summary>
-    private JSObject BuildNamedNodeMapObject(DomElement element, JSObject ownerObj)
+    private JSObject BuildNamedNodeMapObject(Broiler.Dom.DomElement element, JSObject ownerObj)
     {
         var map = new JSObject();
 
@@ -259,7 +259,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Builds an Attr-like JSObject with name, value, specified, ownerElement, nodeType, nodeName.
     /// </summary>
-    private static JSObject BuildAttrNode(string name, string value, DomElement element, JSObject ownerObj)
+    private static JSObject BuildAttrNode(string name, string value, Broiler.Dom.DomElement element, JSObject ownerObj)
     {
         var namespaceUri = TryGetAttachedAttrNamespace(element, name, out var ns, out var localName)
             ? ns
@@ -290,7 +290,7 @@ public sealed partial class DomBridge
         return attr;
     }
 
-    private static bool TryGetAttachedAttrNamespace(DomElement element, string qualifiedName, out string? namespaceUri, out string localName)
+    private static bool TryGetAttachedAttrNamespace(Broiler.Dom.DomElement element, string qualifiedName, out string? namespaceUri, out string localName)
     {
         // Match a genuinely namespaced attribute (non-null namespace) by qualified name —
         // the set NsAttrMap used to track. No-namespace attributes are skipped so the
@@ -349,7 +349,7 @@ public sealed partial class DomBridge
             : null;
     }
 
-    private void SetAttributeLikeSetAttribute(DomElement element, string attrName, string attrVal)
+    private void SetAttributeLikeSetAttribute(Broiler.Dom.DomElement element, string attrName, string attrVal)
     {
         TryGetAttribute(element, attrName, out var previousAttrVal);
         SetAttr(element, attrName, attrVal);
@@ -376,7 +376,7 @@ public sealed partial class DomBridge
             NotifyAttributeMutationObservers(element, attrName, previousAttrVal);
     }
 
-    private void RemoveAttributeLikeRemoveAttribute(DomElement element, string attrName)
+    private void RemoveAttributeLikeRemoveAttribute(Broiler.Dom.DomElement element, string attrName)
     {
         TryGetAttribute(element, attrName, out var previousAttrVal);
         var removed = RemoveAttr(element, attrName);
@@ -390,7 +390,7 @@ public sealed partial class DomBridge
             NotifyAttributeMutationObservers(element, attrName, previousAttrVal);
     }
 
-    private void SetAttributeLikeSetAttributeNS(DomElement element, string? namespaceUri, string attrName, string localName, string attrVal)
+    private void SetAttributeLikeSetAttributeNS(Broiler.Dom.DomElement element, string? namespaceUri, string attrName, string localName, string attrVal)
     {
         string? previousAttrVal = null;
         if (TryGetNsAttribute(element, namespaceUri, localName, out var previousQualifiedName, out var existingAttrVal))
@@ -431,7 +431,7 @@ public sealed partial class DomBridge
             NotifyAttributeMutationObservers(element, attrName, previousAttrVal);
     }
 
-    private void RemoveAttributeLikeRemoveAttributeNS(DomElement element, string? namespaceUri, string localName)
+    private void RemoveAttributeLikeRemoveAttributeNS(Broiler.Dom.DomElement element, string? namespaceUri, string localName)
     {
         if (!TryGetNsAttribute(element, namespaceUri, localName, out var attrName, out var previousAttrVal))
             return;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/CheckLayoutAssertions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/CheckLayoutAssertions.cs
@@ -57,7 +57,7 @@ public sealed partial class DomBridge
         });
     }
 
-    private void CollectCheckLayoutAssertions(DomElement element, List<CheckLayoutAssertion> results)
+    private void CollectCheckLayoutAssertions(Broiler.Dom.DomElement element, List<CheckLayoutAssertion> results)
     {
         foreach (var (attribute, property) in CheckLayoutAttributeMap)
         {
@@ -73,7 +73,7 @@ public sealed partial class DomBridge
             CollectCheckLayoutAssertions(child, results);
     }
 
-    private double ComputeCheckLayoutMetric(DomElement element, string property)
+    private double ComputeCheckLayoutMetric(Broiler.Dom.DomElement element, string property)
     {
         var isRoot = IsViewportElementForMetrics(element);
         return property switch
@@ -92,7 +92,7 @@ public sealed partial class DomBridge
     }
 
     /// <summary>Concise CSS-ish descriptor for reporting (tag + id/first-class + title).</summary>
-    private static string DescribeElement(DomElement element)
+    private static string DescribeElement(Broiler.Dom.DomElement element)
     {
         var builder = new StringBuilder(element.TagName.ToLowerInvariant());
         if (!string.IsNullOrEmpty(element.Id))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -19,7 +19,7 @@ namespace Broiler.HtmlBridge;
 public sealed partial class DomBridge
 {
     private int _styleInvalidationBatchDepth;
-    private HashSet<DomElement>? _pendingStyleInvalidationRoots;
+    private HashSet<Broiler.Dom.DomElement>? _pendingStyleInvalidationRoots;
     // These caches/reentrancy guards are read and written while computing
     // getComputedStyle / element geometry. That work is re-entered from JS
     // Promise/async/generator and scroll/timer continuations that the JS engine
@@ -31,8 +31,8 @@ public sealed partial class DomBridge
     // the whole process (SIGABRT/exit 134), taking out an entire WPT shard
     // (issue #1143). Use concurrent collections, the same defensive idiom as the
     // timer/raf maps.
-    private readonly System.Collections.Concurrent.ConcurrentDictionary<DomElement, Dictionary<string, string>> _computedPropsCache = new();
-    private readonly System.Collections.Concurrent.ConcurrentDictionary<DomElement, Dictionary<string, string>> _computedPropsInProgress = new();
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<Broiler.Dom.DomElement, Dictionary<string, string>> _computedPropsCache = new();
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<Broiler.Dom.DomElement, Dictionary<string, string>> _computedPropsInProgress = new();
 
     // ------------------------------------------------------------------
     //  CSS specificity (Level 3) and <style> / <link> cascading
@@ -53,7 +53,7 @@ public sealed partial class DomBridge
     /// by the shared style engine; only inline declarations and JavaScript-set values
     /// remain in the bridge-owned declaration map.
     /// </summary>
-    internal void InvalidateElementStyles(DomElement element)
+    internal void InvalidateElementStyles(Broiler.Dom.DomElement element)
     {
         // 1. Collect property names that come from the inline style attribute.
         //    These must never be cleared or overwritten by the cascade.
@@ -93,7 +93,7 @@ public sealed partial class DomBridge
             FlushPendingStyleInvalidations();
     }
 
-    internal void InvalidateStyleScope(DomElement anchor)
+    internal void InvalidateStyleScope(Broiler.Dom.DomElement anchor)
     {
         _computedPropsCache.Clear();
         var docRoot = GetDocumentRootFor(anchor);
@@ -118,7 +118,7 @@ public sealed partial class DomBridge
         _pendingStyleInvalidationRoots.Clear();
     }
 
-    private void InvalidateStyleScopeRecursive(DomElement element)
+    private void InvalidateStyleScopeRecursive(Broiler.Dom.DomElement element)
     {
         if (!IsText(element) && !element.TagName.StartsWith("#", StringComparison.Ordinal))
             InvalidateElementStyles(element);
@@ -135,7 +135,7 @@ public sealed partial class DomBridge
     /// parent chain. Stops at <c>#subdoc-root</c> or <c>#document</c> boundaries.
     /// Returns the topmost node within the element's document scope.
     /// </summary>
-    private static DomElement GetDocumentRootFor(DomElement el)
+    private static Broiler.Dom.DomElement GetDocumentRootFor(Broiler.Dom.DomElement el)
     {
         var root = el;
         while (ParentEl(root) != null)
@@ -152,7 +152,7 @@ public sealed partial class DomBridge
     /// Recursively collects all <c>&lt;style&gt;</c> elements from a document tree.
     /// Does not descend into sub-document boundaries (<c>#subdoc-root</c>).
     /// </summary>
-    private static void CollectStyleElementsInTree(DomElement root, List<DomElement> styleElements)
+    private static void CollectStyleElementsInTree(Broiler.Dom.DomElement root, List<Broiler.Dom.DomElement> styleElements)
     {
         foreach (var child in SnapshotChildren(root))
         {
@@ -177,7 +177,7 @@ public sealed partial class DomBridge
     /// </summary>
     /// <remarks>
     /// A plain <c>ChildElements(root).ToList()</c> is NOT thread-safe here.
-    /// <see cref="DomElement.LegacyChildList"/> projects the live
+    /// <see cref="Broiler.Dom.DomElement.LegacyChildList"/> projects the live
     /// <c>ChildNodes</c> collection: <see cref="Enumerable.ToList{T}"/> reads
     /// <c>Count</c>, allocates a destination array of that size, then calls
     /// <c>CopyTo</c>, which materialises the <em>current</em> (possibly larger)
@@ -190,7 +190,7 @@ public sealed partial class DomBridge
     /// for the whole tree, leaving the document unstyled. Retry a bounded number
     /// of times, then fall back to a tolerant index walk.
     /// </remarks>
-    private static List<DomElement> SnapshotChildren(DomElement root)
+    private static List<Broiler.Dom.DomElement> SnapshotChildren(Broiler.Dom.DomElement root)
     {
         for (var attempt = 0; attempt < 4; attempt++)
         {
@@ -208,16 +208,16 @@ public sealed partial class DomBridge
 
         // Sustained contention: copy element-by-element, re-checking bounds each
         // step so a shrinking list can only truncate the snapshot, never throw.
-        var snapshot = new List<DomElement>();
+        var snapshot = new List<Broiler.Dom.DomElement>();
         for (var i = 0; ; i++)
         {
-            DomElement? child;
+            Broiler.Dom.DomElement? child;
             try
             {
                 if (i >= root.ChildNodes.Count)
                     break;
                 // Element snapshot: a char-data child (post-flip) is skipped (null).
-                child = ChildAt(root, i) as DomElement;
+                child = ChildAt(root, i) as Broiler.Dom.DomElement;
             }
             catch (Exception ex) when (ex is ArgumentOutOfRangeException or InvalidOperationException)
             {
@@ -231,31 +231,17 @@ public sealed partial class DomBridge
         return snapshot;
     }
 
-    private JSObject BuildComputedStyleObject(DomElement? element, string? pseudoElement = null)
+    private JSObject BuildComputedStyleObject(Broiler.Dom.DomElement? element, string? pseudoElement = null)
     {
         var computed = BuildComputedStyleMap(element, pseudoElement);
         var propertyNames = computed.Keys.ToList();
         var obj = new JSObject();
 
-        // Helper to convert CSS property name to JS camelCase (e.g., "z-index" -> "zIndex")
-        static string ToCamelCase(string cssName)
-        {
-            var sb = new StringBuilder();
-            bool upper = false;
-            foreach (char c in cssName)
-            {
-                if (c == '-') { upper = true; continue; }
-                sb.Append(upper ? char.ToUpperInvariant(c) : c);
-                upper = false;
-            }
-            return sb.ToString();
-        }
-
         // Expose all computed properties as both camelCase and kebab-case
         foreach (var kv in computed)
         {
-            var camel = ToCamelCase(kv.Key);
-            var normalized = StripCssPriority(kv.Value);
+            var camel = Broiler.CSS.CssPropertyNames.ToDomPropertyName(kv.Key);
+            var normalized = Broiler.CSS.CssPriority.Strip(kv.Value);
             obj.FastAddValue((KeyString)kv.Key, new JSString(normalized), JSPropertyAttributes.EnumerableConfigurableValue);
             if (camel != kv.Key)
                 obj.FastAddValue((KeyString)camel, new JSString(normalized), JSPropertyAttributes.EnumerableConfigurableValue);
@@ -292,7 +278,7 @@ public sealed partial class DomBridge
         return obj;
     }
 
-    private Dictionary<string, string> BuildComputedStyleMap(DomElement? element, string? pseudoElement = null)
+    private Dictionary<string, string> BuildComputedStyleMap(Broiler.Dom.DomElement? element, string? pseudoElement = null)
     {
         // getComputedStyle() resolves through the shared Broiler.CSS.Dom.CssStyleEngine
         // (BuildComputedStyleMapViaEngine, see DomBridge.ComputedStyleEngine.cs). The legacy
@@ -306,7 +292,7 @@ public sealed partial class DomBridge
         return BuildComputedStyleMapViaEngine(element, pseudoElement);
     }
 
-    private Dictionary<string, string> BuildSpecifiedStyleMap(DomElement element, string? pseudoElement = null)
+    private Dictionary<string, string> BuildSpecifiedStyleMap(Broiler.Dom.DomElement element, string? pseudoElement = null)
     {
         pseudoElement = NormalizePseudoElement(pseudoElement);
         var specified = new Dictionary<string, string>(
@@ -324,7 +310,7 @@ public sealed partial class DomBridge
         return specified;
     }
 
-    private void ApplyInheritedProperties(Dictionary<string, string> computed, DomElement element)
+    private void ApplyInheritedProperties(Dictionary<string, string> computed, Broiler.Dom.DomElement element)
     {
         if (ParentEl(element) == null)
             return;
@@ -367,7 +353,7 @@ public sealed partial class DomBridge
 
     private static void ApplyApproximateFormControlComputedSizes(
         Dictionary<string, string> computed,
-        DomElement element)
+        Broiler.Dom.DomElement element)
     {
         string tag = element.TagName.ToLowerInvariant();
         if (tag is not ("input" or "button" or "select" or "textarea" or "progress" or "meter"))
@@ -472,7 +458,7 @@ public sealed partial class DomBridge
         logicalBlockSize = 20 * lineCount;
     }
 
-    private static void ApplySelectListBoxSizing(ref double logicalInlineSize, ref double logicalBlockSize, DomElement element)
+    private static void ApplySelectListBoxSizing(ref double logicalInlineSize, ref double logicalBlockSize, Broiler.Dom.DomElement element)
     {
         int visibleRows = GetSelectVisibleRowCount(element);
         if (visibleRows <= 1)
@@ -484,9 +470,9 @@ public sealed partial class DomBridge
         logicalBlockSize = (visibleRows * rowBlockSize) + chromeBlockSize;
     }
 
-    private static bool IsSelectListBox(DomElement element) => GetSelectVisibleRowCount(element) > 1;
+    private static bool IsSelectListBox(Broiler.Dom.DomElement element) => GetSelectVisibleRowCount(element) > 1;
 
-    private static int GetSelectVisibleRowCount(DomElement element)
+    private static int GetSelectVisibleRowCount(Broiler.Dom.DomElement element)
     {
         bool isMultiple = HasAttr(element, "multiple");
         if (TryGetAttribute(element, "size", out var rawSize) &&
@@ -511,14 +497,14 @@ public sealed partial class DomBridge
             .Length;
     }
 
-    private static string GetElementRenderedText(DomElement element)
+    private static string GetElementRenderedText(Broiler.Dom.DomElement element)
     {
         var builder = new StringBuilder();
         AppendRenderedText(element, builder);
         return builder.ToString();
     }
 
-    private static void AppendRenderedText(DomElement element, StringBuilder builder)
+    private static void AppendRenderedText(Broiler.Dom.DomElement element, StringBuilder builder)
     {
         // RF-BRIDGE-1c Phase F (F3c part 2d): iterate raw ChildNodes to read canonical DomText.
         foreach (var child in element.ChildNodes)
@@ -530,7 +516,7 @@ public sealed partial class DomBridge
                 continue;
             }
 
-            if (child is not DomElement childElement)
+            if (child is not Broiler.Dom.DomElement childElement)
                 continue;
 
             if (string.Equals(childElement.TagName, "br", StringComparison.OrdinalIgnoreCase))
@@ -566,7 +552,7 @@ public sealed partial class DomBridge
     /// mutations applied. This is the input from which the shared rule model is
     /// (re)parsed; <see cref="GetStyleElementCssText"/> applies mutations on top.
     /// </summary>
-    private string GetStyleElementSourceText(DomElement styleEl)
+    private string GetStyleElementSourceText(Broiler.Dom.DomElement styleEl)
     {
         var cssText = new StringBuilder();
         // RF-BRIDGE-1c Phase F (F3c part 2d): iterate raw ChildNodes — the <style> text is a
@@ -620,7 +606,7 @@ public sealed partial class DomBridge
     /// the source text and thus discards prior <c>insertRule</c>/<c>deleteRule</c>
     /// mutations, matching CSSOM semantics.
     /// </summary>
-    private List<Broiler.CSS.CssRule> EnsureStyleSheetRulesCurrent(DomElement styleEl)
+    private List<Broiler.CSS.CssRule> EnsureStyleSheetRulesCurrent(Broiler.Dom.DomElement styleEl)
     {
         var state = GetElementRuntimeState(styleEl).StyleSheet;
         var sourceText = GetStyleElementSourceText(styleEl);
@@ -659,7 +645,7 @@ public sealed partial class DomBridge
         ApplyStyleCsp(DocumentElement, csp, blockStyleAttribute: !csp.AllowsInlineStyleAttribute());
     }
 
-    private void ApplyStyleCsp(DomElement element, ContentSecurityPolicy csp, bool blockStyleAttribute)
+    private void ApplyStyleCsp(Broiler.Dom.DomElement element, ContentSecurityPolicy csp, bool blockStyleAttribute)
     {
         if (!IsText(element))
         {
@@ -686,7 +672,7 @@ public sealed partial class DomBridge
             ApplyStyleCsp(child, csp, blockStyleAttribute);
     }
 
-    private string GetStyleElementCssText(DomElement styleEl)
+    private string GetStyleElementCssText(Broiler.Dom.DomElement styleEl)
     {
         var rules = EnsureStyleSheetRulesCurrent(styleEl);
         var state = GetElementRuntimeState(styleEl).StyleSheet;
@@ -700,7 +686,7 @@ public sealed partial class DomBridge
 
     private static void ApplyUserAgentDisplayDefaults(
         Dictionary<string, string> computed,
-        DomElement element)
+        Broiler.Dom.DomElement element)
     {
         if (computed.ContainsKey("display"))
             return;
@@ -750,510 +736,15 @@ public sealed partial class DomBridge
     }
 
     /// <summary>
-    /// Expands CSS shorthand properties into individual longhand properties.
-    /// For example, <c>margin: 10px 5px</c> expands to <c>margin-top: 10px</c>,
-    /// <c>margin-right: 5px</c>, <c>margin-bottom: 10px</c>, <c>margin-left: 5px</c>.
-    /// Only sets longhands that are not already explicitly set.
+    /// Expands CSS shorthand properties into individual longhand properties (e.g.
+    /// <c>margin: 10px 5px</c> → <c>margin-top/right/bottom/left</c>), only setting longhands
+    /// not already present. DOM/CSS promotion Phase 2: this now delegates to the single canonical
+    /// <see cref="Broiler.CSS.Dom.CssStyleEngine.ExpandShorthands"/> — the bridge's own copy (which
+    /// had drifted to a narrower subset: no <c>outline</c>, no <c>font</c> slash line-height, and a
+    /// single-layer <c>background</c> parser) is deleted so it can no longer drift from the engine.
     /// </summary>
     private static void ExpandCssShorthands(Dictionary<string, string> computed)
-    {
-        if (computed.TryGetValue("font", out var fontVal))
-            ExpandFontShorthand(computed, fontVal);
-
-        // Expand margin shorthand → margin-top, margin-right, margin-bottom, margin-left
-        if (computed.TryGetValue("margin", out var marginVal))
-            ExpandBoxShorthand(computed, marginVal, "margin-top", "margin-right", "margin-bottom", "margin-left");
-
-        // Expand padding shorthand → padding-top, padding-right, padding-bottom, padding-left
-        if (computed.TryGetValue("padding", out var paddingVal))
-            ExpandBoxShorthand(computed, paddingVal, "padding-top", "padding-right", "padding-bottom", "padding-left");
-
-        // Expand border-width shorthand → individual sides
-        if (computed.TryGetValue("border-width", out var bwVal))
-            ExpandBoxShorthand(computed, bwVal, "border-top-width", "border-right-width", "border-bottom-width", "border-left-width");
-
-        // Expand border-style shorthand → individual sides
-        if (computed.TryGetValue("border-style", out var bsVal))
-            ExpandBoxShorthand(computed, bsVal, "border-top-style", "border-right-style", "border-bottom-style", "border-left-style");
-
-        // Expand border-color shorthand → individual sides
-        if (computed.TryGetValue("border-color", out var bcVal))
-            ExpandBoxShorthand(computed, bcVal, "border-top-color", "border-right-color", "border-bottom-color", "border-left-color");
-
-        // Expand border shorthand (e.g. "2cm solid gray") → border-width, border-style, border-color
-        if (computed.TryGetValue("border", out var borderVal))
-            ExpandBorderShorthand(computed, borderVal);
-
-        if (computed.TryGetValue("border-left", out var borderLeftVal))
-            ExpandBorderSideShorthand(computed, borderLeftVal, "left");
-        if (computed.TryGetValue("border-top", out var borderTopVal))
-            ExpandBorderSideShorthand(computed, borderTopVal, "top");
-        if (computed.TryGetValue("border-right", out var borderRightVal))
-            ExpandBorderSideShorthand(computed, borderRightVal, "right");
-        if (computed.TryGetValue("border-bottom", out var borderBottomVal))
-            ExpandBorderSideShorthand(computed, borderBottomVal, "bottom");
-
-        // Expand border-inline shorthand → border-left and border-right
-        // CSS Logical Properties §5.1: border-inline applies to both
-        // inline-start and inline-end (left and right in LTR).
-        if (computed.TryGetValue("border-inline", out var biVal))
-        {
-            if (!computed.ContainsKey("border-left")) computed["border-left"] = biVal;
-            if (!computed.ContainsKey("border-right")) computed["border-right"] = biVal;
-            ExpandBorderSideShorthand(computed, biVal, "left");
-            ExpandBorderSideShorthand(computed, biVal, "right");
-        }
-
-        // Expand border-block shorthand → border-top and border-bottom
-        if (computed.TryGetValue("border-block", out var bbVal))
-        {
-            if (!computed.ContainsKey("border-top")) computed["border-top"] = bbVal;
-            if (!computed.ContainsKey("border-bottom")) computed["border-bottom"] = bbVal;
-            ExpandBorderSideShorthand(computed, bbVal, "top");
-            ExpandBorderSideShorthand(computed, bbVal, "bottom");
-        }
-
-        // Expand margin-block shorthand → margin-top and margin-bottom
-        if (computed.TryGetValue("margin-block", out var mbVal))
-        {
-            var parts = SplitCssValues(mbVal);
-            if (parts.Length >= 1)
-            {
-                if (!computed.ContainsKey("margin-top")) computed["margin-top"] = parts[0];
-                if (!computed.ContainsKey("margin-bottom")) computed["margin-bottom"] = parts.Length > 1 ? parts[1] : parts[0];
-            }
-        }
-
-        // Expand margin-inline shorthand → margin-left and margin-right
-        if (computed.TryGetValue("margin-inline", out var miVal))
-        {
-            var parts = SplitCssValues(miVal);
-            if (parts.Length >= 1)
-            {
-                if (!computed.ContainsKey("margin-left")) computed["margin-left"] = parts[0];
-                if (!computed.ContainsKey("margin-right")) computed["margin-right"] = parts.Length > 1 ? parts[1] : parts[0];
-            }
-        }
-
-        // Expand padding-block shorthand → padding-top and padding-bottom
-        if (computed.TryGetValue("padding-block", out var pbVal))
-        {
-            var parts = SplitCssValues(pbVal);
-            if (parts.Length >= 1)
-            {
-                if (!computed.ContainsKey("padding-top")) computed["padding-top"] = parts[0];
-                if (!computed.ContainsKey("padding-bottom")) computed["padding-bottom"] = parts.Length > 1 ? parts[1] : parts[0];
-            }
-        }
-
-        // Expand padding-inline shorthand → padding-left and padding-right
-        if (computed.TryGetValue("padding-inline", out var piVal))
-        {
-            var parts = SplitCssValues(piVal);
-            if (parts.Length >= 1)
-            {
-                if (!computed.ContainsKey("padding-left")) computed["padding-left"] = parts[0];
-                if (!computed.ContainsKey("padding-right")) computed["padding-right"] = parts.Length > 1 ? parts[1] : parts[0];
-            }
-        }
-
-        // Expand inset shorthand → top, right, bottom, left (CSS Logical Properties)
-        if (computed.TryGetValue("inset", out var insetVal))
-        {
-            // inset is a shorthand that maps to top, right, bottom, left using
-            // the same 1-4 value pattern as margin/padding.  Only set longhands
-            // that are not already explicitly specified to avoid clobbering
-            // author-provided overrides.
-            var insetParts = SplitCssValues(insetVal);
-            if (insetParts.Length > 0)
-            {
-                string iTop = insetParts[0];
-                string iRight = insetParts.Length > 1 ? insetParts[1] : iTop;
-                string iBottom = insetParts.Length > 2 ? insetParts[2] : iTop;
-                string iLeft = insetParts.Length > 3 ? insetParts[3] : iRight;
-
-                if (!computed.ContainsKey("top")) computed["top"] = iTop;
-                if (!computed.ContainsKey("right")) computed["right"] = iRight;
-                if (!computed.ContainsKey("bottom")) computed["bottom"] = iBottom;
-                if (!computed.ContainsKey("left")) computed["left"] = iLeft;
-            }
-        }
-
-        // Expand background shorthand → background-color, background-image, background-repeat,
-        // background-attachment, background-position (CSS2.1 §14.2.1)
-        if (computed.TryGetValue("background", out var bgVal))
-            ExpandBackgroundShorthand(computed, bgVal);
-    }
-
-    private static void ExpandFontShorthand(Dictionary<string, string> computed, string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            return;
-
-        if (value.Trim().Equals("inherit", StringComparison.OrdinalIgnoreCase))
-        {
-            // Keep any longhands that were already assigned by more specific
-            // declarations; only use the inherited font shorthand to backfill
-            // missing longhands in the computed map.
-            if (!computed.ContainsKey("font-style")) computed["font-style"] = "inherit";
-            if (!computed.ContainsKey("font-variant")) computed["font-variant"] = "inherit";
-            if (!computed.ContainsKey("font-weight")) computed["font-weight"] = "inherit";
-            if (!computed.ContainsKey("font-size")) computed["font-size"] = "inherit";
-            if (!computed.ContainsKey("line-height")) computed["line-height"] = "inherit";
-            if (!computed.ContainsKey("font-family")) computed["font-family"] = "inherit";
-            return;
-        }
-
-        var tokens = SplitCssValues(value);
-        if (tokens.Length == 0)
-            return;
-
-        string fontStyle = "normal";
-        string fontVariant = "normal";
-        string fontWeight = "normal";
-        string? fontSize = null;
-        string? lineHeight = null;
-        int fontSizeIndex = -1;
-
-        for (int i = 0; i < tokens.Length; i++)
-        {
-            var token = tokens[i];
-            var lower = token.ToLowerInvariant();
-
-            if (TryParseFontSizeAndLineHeight(lower, token, out var parsedFontSize, out var parsedLineHeight))
-            {
-                fontSize = parsedFontSize;
-                lineHeight = parsedLineHeight;
-                fontSizeIndex = i;
-                break;
-            }
-
-            if (lower is "normal" or "italic" or "oblique")
-                fontStyle = lower;
-            else if (lower == "small-caps")
-                fontVariant = lower;
-            else if (lower is "bold" or "bolder" or "lighter" or "100" or "200" or "300" or "400" or "500" or "600" or "700" or "800" or "900")
-                fontWeight = lower;
-        }
-
-        if (fontSizeIndex < 0 || fontSizeIndex >= tokens.Length - 1 || string.IsNullOrWhiteSpace(fontSize))
-            return;
-
-        var fontFamily = string.Join(" ", tokens[(fontSizeIndex + 1)..]).Trim();
-        if (string.IsNullOrWhiteSpace(fontFamily))
-            return;
-
-        bool hasNonEmptyFamily = fontFamily
-            .Split(',', StringSplitOptions.TrimEntries)
-            .Any(part => !string.IsNullOrWhiteSpace(part.Trim('"', '\'', ' ')));
-        if (!hasNonEmptyFamily)
-            return;
-
-        // Respect longhands that already won in the cascade; the shorthand only
-        // populates values that are still absent from the computed map.
-        if (!computed.ContainsKey("font-style")) computed["font-style"] = fontStyle;
-        if (!computed.ContainsKey("font-variant")) computed["font-variant"] = fontVariant;
-        if (!computed.ContainsKey("font-weight")) computed["font-weight"] = fontWeight;
-        if (!computed.ContainsKey("font-size")) computed["font-size"] = fontSize;
-        var resolvedLineHeight = !string.IsNullOrWhiteSpace(lineHeight) ? lineHeight : "normal";
-        if (!computed.ContainsKey("line-height")) computed["line-height"] = resolvedLineHeight;
-        if (!computed.ContainsKey("font-family")) computed["font-family"] = fontFamily;
-    }
-
-    private static bool TryParseFontSizeAndLineHeight(string lowerToken, string originalToken, out string fontSize, out string lineHeight)
-    {
-        fontSize = string.Empty;
-        lineHeight = string.Empty;
-
-        string sizeToken = lowerToken;
-        string? lineHeightToken = null;
-        int slashIndex = lowerToken.IndexOf('/', StringComparison.Ordinal);
-        if (slashIndex >= 0)
-        {
-            sizeToken = lowerToken[..slashIndex];
-            lineHeightToken = originalToken[(slashIndex + 1)..];
-        }
-
-        if (!IsFontSizeToken(sizeToken))
-            return false;
-
-        if (lineHeightToken != null)
-        {
-            var trimmedLineHeight = lineHeightToken.Trim();
-            if (!IsFontLineHeightToken(trimmedLineHeight))
-                return false;
-            lineHeight = trimmedLineHeight;
-        }
-
-        fontSize = originalToken;
-        if (slashIndex >= 0)
-            fontSize = originalToken[..slashIndex];
-
-        return true;
-    }
-
-    private static bool IsFontSizeToken(string token) =>
-        token is "xx-small" or "x-small" or "small" or "medium" or "large" or "x-large" or "xx-large" or "larger" or "smaller"
-        || IsLengthOrPercentage(token);
-
-    private static bool IsFontLineHeightToken(string token) =>
-        token.Equals("normal", StringComparison.OrdinalIgnoreCase)
-        || IsLengthOrPercentage(token)
-        || double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out _);
-
-    /// <summary>
-    /// Expands a 1–4 value CSS box shorthand (margin, padding, border-width, etc.)
-    /// into four individual properties using CSS box-model order: top, right, bottom, left.
-    /// </summary>
-    private static void ExpandBoxShorthand(Dictionary<string, string> computed, string value,
-        string topProp, string rightProp, string bottomProp, string leftProp)
-    {
-        var parts = SplitCssValues(value);
-        if (parts.Length == 0) return;
-
-        string top, right, bottom, left;
-        switch (parts.Length)
-        {
-            case 1:
-                top = right = bottom = left = parts[0];
-                break;
-            case 2:
-                top = bottom = parts[0];
-                right = left = parts[1];
-                break;
-            case 3:
-                top = parts[0];
-                right = left = parts[1];
-                bottom = parts[2];
-                break;
-            default: // 4+
-                top = parts[0];
-                right = parts[1];
-                bottom = parts[2];
-                left = parts[3];
-                break;
-        }
-
-        if (!computed.ContainsKey(topProp)) computed[topProp] = top;
-        if (!computed.ContainsKey(rightProp)) computed[rightProp] = right;
-        if (!computed.ContainsKey(bottomProp)) computed[bottomProp] = bottom;
-        if (!computed.ContainsKey(leftProp)) computed[leftProp] = left;
-    }
-
-    /// <summary>
-    /// Expands the <c>border</c> shorthand (e.g. "2cm solid gray") into
-    /// <c>border-width</c>, <c>border-style</c>, and <c>border-color</c>.
-    /// </summary>
-    private static void ExpandBorderShorthand(Dictionary<string, string> computed, string value)
-    {
-        var parts = SplitCssValues(value);
-
-        string? width = null, style = null, color = null;
-
-        foreach (var part in parts)
-        {
-            var lower = part.ToLowerInvariant();
-            if (lower is "none" or "hidden" or "dotted" or "dashed" or "solid"
-                or "double" or "groove" or "ridge" or "inset" or "outset")
-            {
-                style ??= part;
-            }
-            else if (lower is "thin" or "medium" or "thick" || IsLengthOrPercentage(lower))
-            {
-                width ??= part;
-            }
-            else
-            {
-                color ??= part;
-            }
-        }
-
-        if (width != null && !computed.ContainsKey("border-width")) computed["border-width"] = width;
-        if (style != null && !computed.ContainsKey("border-style")) computed["border-style"] = style;
-        if (color != null && !computed.ContainsKey("border-color")) computed["border-color"] = color;
-
-        // Further expand border-width, border-style, and border-color into individual sides
-        if (width != null)
-            ExpandBoxShorthand(computed, width, "border-top-width", "border-right-width", "border-bottom-width", "border-left-width");
-        if (style != null)
-            ExpandBoxShorthand(computed, style, "border-top-style", "border-right-style", "border-bottom-style", "border-left-style");
-        if (color != null)
-            ExpandBoxShorthand(computed, color, "border-top-color", "border-right-color", "border-bottom-color", "border-left-color");
-    }
-
-    /// <summary>
-    /// Expands a border shorthand value (e.g. "solid black 1em") into
-    /// individual longhands for a specific side (top, right, bottom, left).
-    /// </summary>
-    private static void ExpandBorderSideShorthand(
-        Dictionary<string, string> computed, string value, string side)
-    {
-        var parts = SplitCssValues(value);
-        string? width = null, style = null, color = null;
-        foreach (var part in parts)
-        {
-            var lower = part.ToLowerInvariant();
-            if (lower is "none" or "hidden" or "dotted" or "dashed" or "solid"
-                or "double" or "groove" or "ridge" or "inset" or "outset")
-                style ??= part;
-            else if (lower is "thin" or "medium" or "thick" || IsLengthOrPercentage(lower))
-                width ??= part;
-            else
-                color ??= part;
-        }
-
-        if (width != null && !computed.ContainsKey($"border-{side}-width"))
-            computed[$"border-{side}-width"] = width;
-        if (style != null && !computed.ContainsKey($"border-{side}-style"))
-            computed[$"border-{side}-style"] = style;
-        if (color != null && !computed.ContainsKey($"border-{side}-color"))
-            computed[$"border-{side}-color"] = color;
-    }
-
-    /// <summary>
-    /// Expands the CSS <c>background</c> shorthand into its five longhand properties:
-    /// <c>background-color</c>, <c>background-image</c>, <c>background-repeat</c>,
-    /// <c>background-attachment</c>, and <c>background-position</c>.
-    /// CSS2.1 §14.2.1: tokens can appear in any order; unspecified longhands
-    /// receive their initial values.
-    /// </summary>
-    /// <remarks>
-    /// Implements TODO-24 (acid3-compliance.md §11.5): correctly handles data-URI
-    /// images with percent-encoded characters, non-integer percentage positions
-    /// (e.g. <c>99.8392283%</c>), and trailing color keywords (e.g. <c>white</c>).
-    /// See also: <c>CssParser.ParseBackgroundShorthand()</c> for the rendering-path
-    /// counterpart.  Tests: <c>Acid3Todo24_28Tests.cs</c>.
-    /// </remarks>
-    private static void ExpandBackgroundShorthand(Dictionary<string, string> computed, string value)
-    {
-        var tokens = SplitCssValues(value);
-
-        string? color = null;
-        string? image = null;
-        string? repeat = null;
-        string? attachment = null;
-        var positionParts = new List<string>();
-
-        foreach (var token in tokens)
-        {
-            var lower = token.ToLowerInvariant();
-
-            // background-image: url(...) or none
-            if (lower.StartsWith("url("))
-            {
-                image ??= token;
-                continue;
-            }
-
-            // CSS gradient functions (linear-gradient, radial-gradient, etc.)
-            if (lower.StartsWith("linear-gradient(") ||
-                lower.StartsWith("radial-gradient(") ||
-                lower.StartsWith("conic-gradient(") ||
-                lower.StartsWith("repeating-linear-gradient(") ||
-                lower.StartsWith("repeating-radial-gradient(") ||
-                lower.StartsWith("repeating-conic-gradient("))
-            {
-                image ??= token;
-                continue;
-            }
-
-            if (lower == "none")
-            {
-                image ??= "none";
-                continue;
-            }
-
-            // background-attachment (CSS3 adds 'local')
-            if (lower is "scroll" or "fixed" or "local")
-            {
-                attachment ??= lower;
-                continue;
-            }
-
-            // CSS3 background-origin / background-clip box values —
-            // accept but don't change rendering (not yet implemented).
-            if (lower is "content-box" or "padding-box" or "border-box" or "border-area")
-            {
-                continue;
-            }
-
-            // CSS3 background-size separator — skip '/' and size tokens
-            if (lower == "/")
-                continue;
-
-            // background-repeat (CSS3 adds 'space' and 'round')
-            if (lower is "repeat" or "repeat-x" or "repeat-y" or "no-repeat" or "space" or "round")
-            {
-                repeat ??= lower;
-                continue;
-            }
-
-            // background-position keywords
-            if (lower is "left" or "right" or "top" or "bottom" or "center")
-            {
-                positionParts.Add(lower);
-                continue;
-            }
-
-            // Length or percentage values → position
-            if (IsLengthOrPercentage(lower))
-            {
-                positionParts.Add(token);
-                continue;
-            }
-
-            // inherit — skip
-            if (lower == "inherit")
-                continue;
-
-            // CSS3 background-size keywords — accept but don't render
-            if (lower is "auto" or "cover" or "contain")
-                continue;
-
-            // Remaining token → treat as color (named color, hex, rgb(), etc.)
-            color ??= token;
-        }
-
-        if (!computed.ContainsKey("background-color"))
-            computed["background-color"] = color ?? "transparent";
-        if (!computed.ContainsKey("background-image"))
-            computed["background-image"] = image ?? "none";
-        if (!computed.ContainsKey("background-repeat"))
-            computed["background-repeat"] = repeat ?? "repeat";
-        if (!computed.ContainsKey("background-attachment"))
-            computed["background-attachment"] = attachment ?? "scroll";
-        if (!computed.ContainsKey("background-position"))
-            computed["background-position"] = positionParts.Count > 0
-                ? string.Join(" ", positionParts) : "0% 0%";
-    }
-
-    /// <summary>
-    /// Splits a CSS value into whitespace-separated tokens, respecting
-    /// parenthesised groups (e.g. <c>rgba(0, 0, 0, 0.5)</c>).
-    /// </summary>
-    private static string[] SplitCssValues(string value)
-    {
-        var parts = new List<string>();
-        var sb = new StringBuilder();
-        int depth = 0;
-        foreach (char c in value)
-        {
-            if (c == '(') depth++;
-            else if (c == ')' && depth > 0) depth--;
-
-            if (char.IsWhiteSpace(c) && depth == 0 && sb.Length > 0)
-            {
-                parts.Add(sb.ToString());
-                sb.Clear();
-            }
-            else if (!char.IsWhiteSpace(c) || depth > 0)
-            {
-                sb.Append(c);
-            }
-        }
-        if (sb.Length > 0) parts.Add(sb.ToString());
-        return parts.ToArray();
-    }
+        => Broiler.CSS.Dom.CssStyleEngine.ExpandShorthands(computed);
 
     /// <summary>
     /// Evaluates a media query string. Supports basic queries needed for Acid3.
@@ -1451,7 +942,7 @@ public sealed partial class DomBridge
     /// the viewport is the iframe container's CSS dimensions. For the main
     /// document, the viewport is 0×0 (headless).
     /// </summary>
-    private (int Width, int Height) GetViewportForDocRoot(DomElement docRoot)
+    private (int Width, int Height) GetViewportForDocRoot(Broiler.Dom.DomElement docRoot)
     {
         if (ReferenceEquals(docRoot, DocumentElement) ||
             string.Equals(docRoot.TagName, "#document", StringComparison.OrdinalIgnoreCase))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementInterfaces.cs
@@ -9,7 +9,7 @@ namespace Broiler.HtmlBridge;
 
 public sealed partial class DomBridge
 {
-    private void AddElementSpecificMembers(JSObject obj, DomElement element)
+    private void AddElementSpecificMembers(JSObject obj, Broiler.Dom.DomElement element)
     {
         var bridge = this;
         // -- Phase 5: HTML DOM Interfaces --

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
@@ -23,24 +23,24 @@ internal sealed class ElementRuntimeState
     /// <summary>
     /// Inline-style property names last written through the JS <c>element.style</c> /
     /// <c>setAttribute("style", …)</c> path, tracked so serialization and computed-style
-    /// invalidation preserve author-set intent. Relocated off the <c>DomElement</c> facade
+    /// invalidation preserve author-set intent. Relocated off the <c>Broiler.Dom.DomElement</c> facade
     /// (RF-BRIDGE-1c Phase A — the node model does not own this bridge state).
     /// </summary>
     public HashSet<string> JsSetStyleProps { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// The document-root element that owns this node's (sub)document — iframe / nested
-    /// browsing-context bookkeeping. Relocated off the <c>DomElement</c> facade
+    /// browsing-context bookkeeping. Relocated off the <c>Broiler.Dom.DomElement</c> facade
     /// (RF-BRIDGE-1c Phase A). Not carried across <c>cloneNode</c> (matching the prior
     /// facade behaviour: a clone re-derives its owner on adoption).
     /// </summary>
-    public DomElement? OwnerDocRoot { get; set; }
+    public Broiler.Dom.DomElement? OwnerDocRoot { get; set; }
 
     /// <summary>
     /// The element's raw inner-HTML/inner-text string — the source text for raw-text
     /// elements (<c>&lt;style&gt;</c>/<c>&lt;script&gt;</c>/<c>&lt;textarea&gt;</c>), an
     /// <c>innerHTML</c>-getter fallback, and the value round-tripped by serialization.
-    /// Relocated off the <c>DomElement</c> facade (RF-BRIDGE-1c Phase F — the node model
+    /// Relocated off the <c>Broiler.Dom.DomElement</c> facade (RF-BRIDGE-1c Phase F — the node model
     /// does not own this bridge state). Empty by default; seeded by the <c>innerHTML</c>
     /// setter and copied across <c>cloneNode</c>.
     /// </summary>
@@ -50,7 +50,7 @@ internal sealed class ElementRuntimeState
     /// The node's inline style in CSS kebab-case — the authoritative in-memory inline
     /// style (mutated by JS <c>element.style</c>, the anchor resolver, and synthetic
     /// form-control styling; synced back to the <c>style=</c> attribute at serialization).
-    /// Relocated off the <c>DomElement</c> facade (RF-BRIDGE-1c Phase B); reached through
+    /// Relocated off the <c>Broiler.Dom.DomElement</c> facade (RF-BRIDGE-1c Phase B); reached through
     /// <c>DomBridge.InlineStyle(element)</c>, which lazily seeds it from the <c>style=</c>
     /// attribute on first access (see <see cref="StyleSeeded"/>).
     /// </summary>
@@ -136,8 +136,8 @@ internal sealed class DialogRuntimeState
 
 internal sealed class ShadowRuntimeState
 {
-    public RuntimeValue<DomElement> Root { get; } = new();
-    public RuntimeValue<DomElement> Host { get; } = new();
+    public RuntimeValue<Broiler.Dom.DomElement> Root { get; } = new();
+    public RuntimeValue<Broiler.Dom.DomElement> Host { get; } = new();
     public RuntimeValue<string> Mode { get; } = new();
 }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Events.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Events.cs
@@ -70,7 +70,7 @@ public sealed partial class DomBridge
         }
     }
 
-    private JSValue BuildComposedPathValue(Broiler.Dom.DomNode target, IReadOnlyList<DomElement> path)
+    private JSValue BuildComposedPathValue(Broiler.Dom.DomNode target, IReadOnlyList<Broiler.Dom.DomElement> path)
     {
         JSValue ToEventPathObject(Broiler.Dom.DomNode node)
             => node == _documentNode ? (_documentJSObject ?? JSNull.Value) : ToJSObject(node);
@@ -86,7 +86,7 @@ public sealed partial class DomBridge
         return new JSArray(values.ToArray());
     }
 
-    private static bool CheckElementValidity(DomElement element)
+    private static bool CheckElementValidity(Broiler.Dom.DomElement element)
     {
         if (string.Equals(element.TagName, "form", StringComparison.OrdinalIgnoreCase))
         {
@@ -107,7 +107,7 @@ public sealed partial class DomBridge
         return true;
     }
 
-    private static bool ValidateFormChildren(DomElement form)
+    private static bool ValidateFormChildren(Broiler.Dom.DomElement form)
     {
         foreach (var child in ChildElements(form))
         {
@@ -127,8 +127,8 @@ public sealed partial class DomBridge
         var eventType = typeVal != null && typeVal is JSString ? typeVal.ToString() : "unknown";
 
         // Build the path from the root to the target
-        var path = new List<DomElement>();
-        var visited = new HashSet<DomElement>();
+        var path = new List<Broiler.Dom.DomElement>();
+        var visited = new HashSet<Broiler.Dom.DomElement>();
         var node = ParentEl(target);
         while (node != null && visited.Add(node)) { path.Add(node); node = ParentEl(node); }
         path.Reverse();
@@ -262,7 +262,7 @@ public sealed partial class DomBridge
     /// element into <see cref="JSFunction"/> instances stored in <see cref="bridge-owned inline event handler state"/>.
     /// Only compiles attributes that have not already been compiled.
     /// </summary>
-    private void CompileInlineEventAttributes(DomElement element)
+    private void CompileInlineEventAttributes(Broiler.Dom.DomElement element)
     {
         foreach (var eventName in InlineEventNames)
         {
@@ -280,7 +280,7 @@ public sealed partial class DomBridge
     /// Compiles a single <c>on*</c> attribute value into a <see cref="JSFunction"/>
     /// and stores it in <see cref="bridge-owned inline event handler state"/>.
     /// </summary>
-    internal void CompileInlineEventAttribute(DomElement element, string attrName, string code)
+    internal void CompileInlineEventAttribute(Broiler.Dom.DomElement element, string attrName, string code)
     {
         if (_jsContext == null || string.IsNullOrEmpty(code) || attrName.Length <= 2) return;
         var eventName = attrName[2..].ToLowerInvariant();

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
@@ -9,36 +9,36 @@ public sealed partial class DomBridge
             ? args[index].DoubleValue
             : double.NaN;
 
-    private IReadOnlyList<DomElement> HitTestDocumentPoint(DomElement docRoot, double x, double y)
+    private IReadOnlyList<Broiler.Dom.DomElement> HitTestDocumentPoint(Broiler.Dom.DomElement docRoot, double x, double y)
     {
         if (!double.IsFinite(x) || !double.IsFinite(y))
-            return Array.Empty<DomElement>();
+            return Array.Empty<Broiler.Dom.DomElement>();
 
         var documentElement = IsDocumentElement(docRoot)
             ? docRoot
             : ChildElements(docRoot).FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith("#"));
         if (documentElement == null)
-            return Array.Empty<DomElement>();
+            return Array.Empty<Broiler.Dom.DomElement>();
 
         if (!DocumentHasViewport(documentElement))
-            return Array.Empty<DomElement>();
+            return Array.Empty<Broiler.Dom.DomElement>();
 
         var viewportWidth = GetViewportReferenceLength(documentElement, vertical: false);
         var viewportHeight = GetViewportReferenceLength(documentElement, vertical: true);
         if (viewportWidth <= 0 || viewportHeight <= 0 || x < 0 || y < 0 || x >= viewportWidth || y >= viewportHeight)
-            return Array.Empty<DomElement>();
+            return Array.Empty<Broiler.Dom.DomElement>();
 
-        var hits = new List<DomElement>();
+        var hits = new List<Broiler.Dom.DomElement>();
         CollectHitTestMatches(documentElement, x, y, hits);
         return hits;
     }
 
-    private void CollectHitTestMatches(DomElement element, double x, double y, List<DomElement> hits)
+    private void CollectHitTestMatches(Broiler.Dom.DomElement element, double x, double y, List<Broiler.Dom.DomElement> hits)
     {
         for (var i = element.ChildNodes.Count - 1; i >= 0; i--)
         {
             // Only element children are hit-test candidates (skip text/comment).
-            if (ChildAt(element, i) is DomElement child && !child.TagName.StartsWith("#", StringComparison.Ordinal))
+            if (ChildAt(element, i) is Broiler.Dom.DomElement child && !child.TagName.StartsWith("#", StringComparison.Ordinal))
                 CollectHitTestMatches(child, x, y, hits);
         }
 
@@ -47,7 +47,7 @@ public sealed partial class DomBridge
     }
 
 
-    private bool IsElementHitTestCandidate(DomElement element, double x, double y)
+    private bool IsElementHitTestCandidate(Broiler.Dom.DomElement element, double x, double y)
     {
         if (IsAreaElement(element))
             return IsImageMapAreaHit(element, x, y);
@@ -73,7 +73,7 @@ public sealed partial class DomBridge
                y >= rect.Top && y < rect.Top + rect.Height;
     }
 
-    private (double Left, double Top, double Width, double Height) GetHitTestRectForElement(DomElement element)
+    private (double Left, double Top, double Width, double Height) GetHitTestRectForElement(Broiler.Dom.DomElement element)
     {
         if (IsDocumentElement(element))
             return GetBoundingClientRectForDomElement(element, isRoot: true);
@@ -109,18 +109,18 @@ public sealed partial class DomBridge
         return rect;
     }
 
-    private static bool IsTableCellElement(DomElement element)
+    private static bool IsTableCellElement(Broiler.Dom.DomElement element)
     {
         var tag = element.TagName;
         return string.Equals(tag, "td", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(tag, "th", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool IsAreaElement(DomElement element) =>
+    private static bool IsAreaElement(Broiler.Dom.DomElement element) =>
         string.Equals(element.TagName, "area", StringComparison.OrdinalIgnoreCase);
 
     private bool TryGetListItemMarkerHitTestRect(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         out (double Left, double Top, double Width, double Height) rect)
     {
         rect = default;
@@ -151,7 +151,7 @@ public sealed partial class DomBridge
     }
 
     private static bool IsOutsideListItemMarkerCandidate(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         IReadOnlyDictionary<string, string> props)
     {
         var isListItem = string.Equals(element.TagName, "li", StringComparison.OrdinalIgnoreCase) ||
@@ -169,7 +169,7 @@ public sealed partial class DomBridge
                 !string.Equals(listStyleImage, "none", StringComparison.OrdinalIgnoreCase));
     }
 
-    private double EstimateOutsideListMarkerExtent(DomElement element, IReadOnlyDictionary<string, string> props)
+    private double EstimateOutsideListMarkerExtent(Broiler.Dom.DomElement element, IReadOnlyDictionary<string, string> props)
     {
         var fontSize = Math.Max(8, ResolveFontSizeForElement(element));
         var listStyleType = props.GetValueOrDefault("list-style-type");
@@ -184,7 +184,7 @@ public sealed partial class DomBridge
         return Math.Min(40, markerCore + 8);
     }
 
-    private static bool IsTableStructuralHitTestOnlyElement(DomElement element)
+    private static bool IsTableStructuralHitTestOnlyElement(Broiler.Dom.DomElement element)
     {
         var tag = element.TagName;
         return string.Equals(tag, "tr", StringComparison.OrdinalIgnoreCase) ||
@@ -196,7 +196,7 @@ public sealed partial class DomBridge
     }
 
     private bool TryGetSimpleTableCellHitTestRect(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         out (double Left, double Top, double Width, double Height) rect)
     {
         rect = default;
@@ -264,7 +264,7 @@ public sealed partial class DomBridge
         return true;
     }
 
-    private (double Horizontal, double Vertical) GetEffectiveTableBorderSpacing(DomElement table)
+    private (double Horizontal, double Vertical) GetEffectiveTableBorderSpacing(Broiler.Dom.DomElement table)
     {
         var rawValue = GetComputedProps(table).GetValueOrDefault("border-spacing");
         if (string.IsNullOrWhiteSpace(rawValue))
@@ -286,7 +286,7 @@ public sealed partial class DomBridge
         return (horizontal, vertical);
     }
 
-    private bool IsImageMapAreaHit(DomElement area, double x, double y)
+    private bool IsImageMapAreaHit(Broiler.Dom.DomElement area, double x, double y)
     {
         var image = FindAssociatedImageMapImage(area);
         if (image == null)
@@ -307,7 +307,7 @@ public sealed partial class DomBridge
         return IsPointInsideAreaShape(area, scaledX, scaledY);
     }
 
-    private DomElement? FindAssociatedImageMapImage(DomElement area)
+    private Broiler.Dom.DomElement? FindAssociatedImageMapImage(Broiler.Dom.DomElement area)
     {
         var map = ParentEl(area);
         if (map == null || !string.Equals(map.TagName, "map", StringComparison.OrdinalIgnoreCase))
@@ -333,7 +333,7 @@ public sealed partial class DomBridge
         return null;
     }
 
-    private IEnumerable<DomElement> EnumerateDomDescendants(DomElement root)
+    private IEnumerable<Broiler.Dom.DomElement> EnumerateDomDescendants(Broiler.Dom.DomElement root)
     {
         foreach (var child in ChildElements(root))
         {
@@ -347,7 +347,7 @@ public sealed partial class DomBridge
     }
 
     private (double ScaleX, double ScaleY) GetImageMapCoordinateScale(
-        DomElement image,
+        Broiler.Dom.DomElement image,
         (double Left, double Top, double Width, double Height) imageRect)
     {
         var widthBasis = ParsePositiveDouble(GetAttr(image, "width"));
@@ -358,7 +358,7 @@ public sealed partial class DomBridge
             heightBasis > 0 ? imageRect.Height / heightBasis : 1);
     }
 
-    private bool IsPointInsideAreaShape(DomElement area, double x, double y)
+    private bool IsPointInsideAreaShape(Broiler.Dom.DomElement area, double x, double y)
     {
         var shape = GetAttr(area, "shape")?.Trim().ToLowerInvariant();
         if (string.IsNullOrEmpty(shape))
@@ -375,7 +375,7 @@ public sealed partial class DomBridge
     }
 
     private bool IsPointInsideRoundedHitRect(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         (double Left, double Top, double Width, double Height) rect,
         double x,
         double y)
@@ -422,7 +422,7 @@ public sealed partial class DomBridge
         return normalizedX * normalizedX + normalizedY * normalizedY > 1;
     }
 
-    private double GetUniformHitTestBorderRadius(DomElement element, double width, double height)
+    private double GetUniformHitTestBorderRadius(Broiler.Dom.DomElement element, double width, double height)
     {
         var rawRadius = GetComputedProps(element).GetValueOrDefault("border-radius");
         if (string.IsNullOrWhiteSpace(rawRadius) || string.Equals(rawRadius, "0", StringComparison.Ordinal))
@@ -504,7 +504,7 @@ public sealed partial class DomBridge
             : 0;
     }
 
-    private bool IsElementRenderedForHitTesting(DomElement element)
+    private bool IsElementRenderedForHitTesting(Broiler.Dom.DomElement element)
     {
         for (var current = element; current != null; current = ParentEl(current))
         {
@@ -530,7 +530,7 @@ public sealed partial class DomBridge
         return true;
     }
 
-    private static bool DocumentHasViewport(DomElement documentElement)
+    private static bool DocumentHasViewport(Broiler.Dom.DomElement documentElement)
     {
         var docRoot = GetElementRuntimeState(documentElement).OwnerDocRoot;
         if (docRoot == null)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/HtmlTreeBuilding.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/HtmlTreeBuilding.cs
@@ -5,7 +5,7 @@ namespace Broiler.HtmlBridge;
 public sealed partial class DomBridge
 {
     // RF-BRIDGE-1c Phase F4: HtmlTreeBuilder is retired. It used to re-materialize the shared
-    // HtmlDocumentParser's canonical tree into facade DomElement nodes; with the facade gone the
+    // HtmlDocumentParser's canonical tree into facade Broiler.Dom.DomElement nodes; with the facade gone the
     // parser already produces the canonical nodes the bridge holds, so these helpers parse and hand
     // the tree straight back. Callers reparent the returned root/fragment children into the
     // _document-owned tree, and canonical AppendChild auto-adopts the subtree into _document (see
@@ -17,7 +17,7 @@ public sealed partial class DomBridge
     /// canonical <c>&lt;html&gt;</c> root, the non-structural node registration list, and the title.
     /// Replaces the retired <c>HtmlTreeBuilder.Build</c>.
     /// </summary>
-    private static (DomElement DocumentElement, List<Broiler.Dom.DomNode> AllElements, string Title) BuildDocumentTree(string html)
+    private static (Broiler.Dom.DomElement DocumentElement, List<Broiler.Dom.DomNode> AllElements, string Title) BuildDocumentTree(string html)
     {
         var parsed = new HtmlDocumentParser().ParseDocument(html);
         var root = parsed.Document.DocumentElement ??
@@ -32,7 +32,7 @@ public sealed partial class DomBridge
     /// Parses an HTML fragment in <paramref name="contextTagName"/>'s context and wraps its children
     /// in a bridge <c>#document-fragment</c> sentinel element. Replaces <c>HtmlTreeBuilder.BuildFragment</c>.
     /// </summary>
-    private (DomElement Fragment, List<Broiler.Dom.DomNode> AllElements) BuildFragmentTree(string html, string contextTagName)
+    private (Broiler.Dom.DomElement Fragment, List<Broiler.Dom.DomNode> AllElements) BuildFragmentTree(string html, string contextTagName)
     {
         var parsed = new HtmlDocumentParser().ParseFragment(html, contextTagName);
         var fragment = CreateBridgeElement("#document-fragment");

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
@@ -33,7 +33,7 @@ public sealed partial class DomBridge
         if (node is Broiler.Dom.DomCharacterData characterData)
             return new JSString(characterData.Data);
 
-        if (node is not DomElement element)
+        if (node is not Broiler.Dom.DomElement element)
             return new JSString(string.Empty);
 
         if (element.ChildNodes.Count > 0)
@@ -47,7 +47,7 @@ public sealed partial class DomBridge
     }
 
 
-    private bool IsCurrentIframeCrossOrigin(DomElement element)
+    private bool IsCurrentIframeCrossOrigin(Broiler.Dom.DomElement element)
     {
         if (HasAttr(element, "srcdoc"))
             return false;
@@ -99,7 +99,7 @@ public sealed partial class DomBridge
     }
 
 
-    private static DomElement GetDocumentElement(DomElement docRoot)
+    private static Broiler.Dom.DomElement GetDocumentElement(Broiler.Dom.DomElement docRoot)
     {
         return ChildElements(docRoot).FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith("#"))
             ?? docRoot;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Css.cs
@@ -12,15 +12,15 @@ public sealed partial class DomBridge
         {
             var name = a[0].ToString();
             if (computed.TryGetValue(name, out var val))
-                return new JSString(StripCssPriority(val));
+                return new JSString(Broiler.CSS.CssPriority.Strip(val));
             // Try kebab-case conversion for camelCase input
-            var kebab = ToKebabCase(name);
+            var kebab = Broiler.CSS.CssPropertyNames.ToCssPropertyName(name);
             if (kebab != name && computed.TryGetValue(kebab, out val))
-                return new JSString(StripCssPriority(val));
+                return new JSString(Broiler.CSS.CssPriority.Strip(val));
             // Try camelCase conversion for kebab-case input
-            var camel = ToCamelCaseStatic(name);
+            var camel = Broiler.CSS.CssPropertyNames.ToDomPropertyName(name);
             if (camel != name && computed.TryGetValue(camel, out val))
-                return new JSString(StripCssPriority(val));
+                return new JSString(Broiler.CSS.CssPriority.Strip(val));
         }
 
         return new JSString(string.Empty);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/ElementInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/ElementInterfaces.cs
@@ -389,7 +389,7 @@ public sealed partial class DomBridge
         var optEl = FindDomElementByJSObject(optObj);
         if (optEl == null)
             return JSUndefined.Value;
-        DomElement? refEl = null;
+        Broiler.Dom.DomElement? refEl = null;
         if (a.Length > 1 && !a[1].IsNull && !a[1].IsUndefined)
         {
             var refObj = a[1] as JSObject;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -215,7 +215,7 @@ public sealed partial class DomBridge
 
     /// <summary>Whether <paramref name="node"/> is a sub-document root element (only elements can be).</summary>
     private static bool IsSubDocRootNode(global::Broiler.Dom.DomNode node) =>
-        node is DomElement element && IsSubDocRoot(element);
+        node is Broiler.Dom.DomElement element && IsSubDocRoot(element);
 
     private JSValue JsJsObjectsGetChildNodes033Core(global::Broiler.Dom.DomNode node, in Arguments a)
     {
@@ -284,7 +284,7 @@ public sealed partial class DomBridge
             return new JSNumber(3); // TEXT_NODE
         if (IsComment(node))
             return new JSNumber(8); // COMMENT_NODE
-        if (node is not DomElement element)
+        if (node is not Broiler.Dom.DomElement element)
             return new JSNumber(1); // canonical non-element char-data already handled above
         if (string.Equals(element.TagName, "#document", StringComparison.OrdinalIgnoreCase))
             return new JSNumber(9); // DOCUMENT_NODE
@@ -302,7 +302,7 @@ public sealed partial class DomBridge
             return new JSString("#text");
         if (IsComment(node))
             return new JSString("#comment");
-        if (node is not DomElement element)
+        if (node is not Broiler.Dom.DomElement element)
             return JSNull.Value;
         if (string.Equals(element.TagName, "#document", StringComparison.OrdinalIgnoreCase))
             return new JSString("#document");
@@ -323,7 +323,7 @@ public sealed partial class DomBridge
     private JSValue JsJsObjectsGetLocalName040Core(global::Broiler.Dom.DomNode node, in Arguments a)
     {
         // localName is null for non-element nodes (text/comment/document).
-        if (node is not DomElement element)
+        if (node is not Broiler.Dom.DomElement element)
             return JSNull.Value;
         if (element.TagName.StartsWith("#"))
             return JSNull.Value; // #comment, #document, etc.
@@ -337,7 +337,7 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetPrefix041Core(global::Broiler.Dom.DomNode node, in Arguments a)
     {
-        if (node is not DomElement element)
+        if (node is not Broiler.Dom.DomElement element)
             return JSNull.Value;
         var colonIdx = element.TagName.IndexOf(':');
         if (colonIdx >= 0)
@@ -349,7 +349,7 @@ public sealed partial class DomBridge
     private JSValue JsJsObjectsGetNamespaceURI042Core(global::Broiler.Dom.DomNode node, in Arguments a)
     {
         // namespaceURI is null for non-element nodes (text/comment/document).
-        if (node is not DomElement element)
+        if (node is not Broiler.Dom.DomElement element)
             return JSNull.Value;
         if (element.NamespaceUri != null)
             return new JSString(element.NamespaceUri);
@@ -728,7 +728,7 @@ public sealed partial class DomBridge
     private JSValue JsJsObjectsNormalize076Core(global::Broiler.Dom.DomNode node, in Arguments _)
     {
         // normalize() on a character-data node is a no-op (it has no text children to merge).
-        if (node is DomElement element)
+        if (node is Broiler.Dom.DomElement element)
             NormalizeNode(element);
         return JSUndefined.Value;
     }
@@ -900,7 +900,7 @@ public sealed partial class DomBridge
         var childObj = a[0] as JSObject;
         if (childObj == null)
             return JSUndefined.Value;
-        // Find the DomElement for this child JSObject
+        // Find the Broiler.Dom.DomElement for this child JSObject
         var childEl = FindDomNodeByJSObject(childObj);
         if (childEl == null)
             return a[0];
@@ -1494,7 +1494,7 @@ public sealed partial class DomBridge
     private JSValue JsJsObjectsClosest129Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomElement element, in Arguments a)
     {
         var sel = a.Length > 0 ? a[0].ToString() : string.Empty;
-        for (DomElement? current = element; current != null && !current.TagName.StartsWith("#", StringComparison.Ordinal); current = ParentEl(current))
+        for (Broiler.Dom.DomElement? current = element; current != null && !current.TagName.StartsWith("#", StringComparison.Ordinal); current = ParentEl(current))
         {
             if (MatchesSelector(current, sel, element))
                 return bridge.ToJSObject(current);
@@ -1543,7 +1543,7 @@ public sealed partial class DomBridge
         var html = a.Length > 1 ? a[1].ToString() : string.Empty;
         if (string.IsNullOrEmpty(html))
             return JSUndefined.Value;
-        DomElement parsingContext;
+        Broiler.Dom.DomElement parsingContext;
         switch (position)
         {
             case "beforebegin":

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
@@ -526,7 +526,7 @@ public sealed partial class DomBridge
                     // insert the new nodes right after it (matching real browser
                     // behaviour where document.write() inserts at the parser
                     // insertion point).
-                    DomElement? currentScript = null;
+                    Broiler.Dom.DomElement? currentScript = null;
                     var documentElements = Elements;
                     if (CurrentScriptIndex >= 0 && CurrentScriptIndex < documentElements.Count)
                     {
@@ -812,7 +812,7 @@ public sealed partial class DomBridge
 
     private JSValue JsRegistrationGetStyleSheets055Core(in Arguments _)
     {
-        var styleEls = new List<DomElement>();
+        var styleEls = new List<Broiler.Dom.DomElement>();
         foreach (var el in Elements)
         {
             if (string.Equals(el.TagName, "style", StringComparison.OrdinalIgnoreCase))
@@ -862,10 +862,10 @@ public sealed partial class DomBridge
         // Append doctype if provided
         if (doctypeArg is JSObject dtObj)
         {
-            // Find the DomElement for the doctype JSObject
+            // Find the Broiler.Dom.DomElement for the doctype JSObject
             foreach (var kvp in _jsObjectCache)
             {
-                if (kvp.Value == dtObj && kvp.Key is DomElement dtEl)
+                if (kvp.Value == dtObj && kvp.Key is Broiler.Dom.DomElement dtEl)
                 {
                     SetParent(dtEl, docRoot);
                     GetElementRuntimeState(dtEl).OwnerDocRoot = docRoot;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
@@ -602,7 +602,7 @@ public sealed partial class DomBridge
             return a.Length > 0 ? a[0] : JSNull.Value;
         foreach (var kvp in bridge._jsObjectCache)
         {
-            if (kvp.Value == childObj && kvp.Key is DomElement child)
+            if (kvp.Value == childObj && kvp.Key is Broiler.Dom.DomElement child)
             {
                 if (ParentEl(child) != null)
                     child.Remove();
@@ -673,7 +673,7 @@ public sealed partial class DomBridge
         {
             foreach (var kvp in _jsObjectCache)
             {
-                if (kvp.Value == dtObj && kvp.Key is DomElement dtEl)
+                if (kvp.Value == dtObj && kvp.Key is Broiler.Dom.DomElement dtEl)
                 {
                     SetParent(dtEl, subDocRoot);
                     GetElementRuntimeState(dtEl).OwnerDocRoot = subDocRoot;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Traversal.cs
@@ -832,7 +832,7 @@ public sealed partial class DomBridge
         // Document node can only have one element child. RF-BRIDGE-1c Phase F (F3c part 2b):
         // only an element container carries #document/#subdoc-root TagName; a text container
         // never enters this branch.
-        if (state.StartContainer is DomElement startContainerElement &&
+        if (state.StartContainer is Broiler.Dom.DomElement startContainerElement &&
             (string.Equals(startContainerElement.TagName, "#document", StringComparison.OrdinalIgnoreCase) || string.Equals(startContainerElement.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase)))
         {
             // Count existing element children (minus any that will be moved into newParent)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Utilities.cs
@@ -48,7 +48,7 @@ public sealed partial class DomBridge
         if (a.Length >= 2)
         {
             var prop = a[0].ToString();
-            var value = ApplyCssPriority(a[1].ToString(), a.Length >= 3 ? a[2].ToString() : string.Empty);
+            var value = Broiler.CSS.CssPriority.Apply(a[1].ToString(), a.Length >= 3 ? a[2].ToString() : string.Empty);
             if (string.IsNullOrEmpty(value))
             {
                 InlineStyle(element).Remove(prop);
@@ -73,9 +73,9 @@ public sealed partial class DomBridge
         {
             var prop = a[0].ToString();
             if (TryGetStylePropertyRawValue(element, prop, out var val))
-                return new JSString(StripCssPriority(val));
+                return new JSString(Broiler.CSS.CssPriority.Strip(val));
             // Try camelCase version of kebab-case input
-            var camel = ToCamelCaseStatic(prop);
+            var camel = Broiler.CSS.CssPropertyNames.ToDomPropertyName(prop);
             // Check JSObject properties (set via el.style.propertyName = value)
             var jsVal = a.This?[(KeyString)camel];
             if (jsVal != null && !jsVal.IsUndefined && !jsVal.IsNull)
@@ -138,7 +138,7 @@ public sealed partial class DomBridge
     private static JSValue JsUtilitiesGetPropertyPriority012Core(global::Broiler.Dom.DomElement element, in Arguments a)
     {
         if (a.Length > 0 && TryGetStylePropertyRawValue(element, a[0].ToString(), out var value))
-            return new JSString(GetCssPriority(value));
+            return new JSString(Broiler.CSS.CssPriority.Parse(value));
         return new JSString(string.Empty);
     }
 
@@ -169,7 +169,7 @@ public sealed partial class DomBridge
         if (a.Length >= 2)
         {
             var prop = a[0].ToString();
-            var value = ApplyCssPriority(a[1].ToString(), a.Length >= 3 ? a[2].ToString() : string.Empty);
+            var value = Broiler.CSS.CssPriority.Apply(a[1].ToString(), a.Length >= 3 ? a[2].ToString() : string.Empty);
             if (string.IsNullOrEmpty(value))
                 styleMap.Remove(prop);
             else
@@ -186,8 +186,8 @@ public sealed partial class DomBridge
         {
             var prop = a[0].ToString();
             if (TryGetStylePropertyRawValue(styleMap, prop, out var val))
-                return new JSString(StripCssPriority(val));
-            var camel = ToCamelCaseStatic(prop);
+                return new JSString(Broiler.CSS.CssPriority.Strip(val));
+            var camel = Broiler.CSS.CssPropertyNames.ToDomPropertyName(prop);
             var jsVal = a.This?[(KeyString)camel];
             if (jsVal != null && !jsVal.IsUndefined && !jsVal.IsNull)
                 return jsVal;
@@ -205,9 +205,9 @@ public sealed partial class DomBridge
         if (a.Length > 0)
         {
             var prop = a[0].ToString();
-            var removed = TryGetStylePropertyRawValue(styleMap, prop, out var val) ? StripCssPriority(val) : string.Empty;
+            var removed = TryGetStylePropertyRawValue(styleMap, prop, out var val) ? Broiler.CSS.CssPriority.Strip(val) : string.Empty;
             styleMap.Remove(prop);
-            styleMap.Remove(ToKebabCase(prop));
+            styleMap.Remove(Broiler.CSS.CssPropertyNames.ToCssPropertyName(prop));
             return new JSString(removed);
         }
 
@@ -247,7 +247,7 @@ public sealed partial class DomBridge
     private static JSValue JsUtilitiesGetPropertyPriority023Core(global::System.Collections.Generic.Dictionary<global::System.String, global::System.String> styleMap, in Arguments a)
     {
         if (a.Length > 0 && TryGetStylePropertyRawValue(styleMap, a[0].ToString(), out var value))
-            return new JSString(GetCssPriority(value));
+            return new JSString(Broiler.CSS.CssPriority.Parse(value));
         return new JSString(string.Empty);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -10,7 +10,7 @@ using Broiler.JavaScript.BuiltIns.Function;
 namespace Broiler.HtmlBridge;
 
 /// <summary>
-/// Conversion of <see cref="DomElement"/> instances to YantraJS
+/// Conversion of <see cref="Broiler.Dom.DomElement"/> instances to YantraJS
 /// <see cref="JSObject"/> representations, including sub-document
 /// construction and tree-search helpers.
 /// </summary>
@@ -35,12 +35,12 @@ public sealed partial class DomBridge
         _jsObjectCache[node] = obj;
 
         // RF-BRIDGE-1c Phase F (F3c): canonical character-data nodes (DomText/DomComment) are not
-        // DomElement, so they receive a minimal Node/CharacterData wrapper instead of the full
+        // Broiler.Dom.DomElement, so they receive a minimal Node/CharacterData wrapper instead of the full
         // element surface below. This branch is dead on today's homogeneous facade tree — facade
-        // text/comment nodes are DomElement and fall through to the element wrapper, preserving
+        // text/comment nodes are Broiler.Dom.DomElement and fall through to the element wrapper, preserving
         // behaviour — and goes live once text/comment construction flips to canonical
         // DomText/DomComment (F3c construction cutover).
-        if (node is not DomElement element)
+        if (node is not Broiler.Dom.DomElement element)
         {
             PopulateCharacterDataJSObject(obj, node);
             return obj;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -66,7 +66,7 @@ public sealed partial class DomBridge
         }
     }
 
-    private double GetClientWidthForDomElement(DomElement element, bool isRoot) =>
+    private double GetClientWidthForDomElement(Broiler.Dom.DomElement element, bool isRoot) =>
         WithLayoutGeometryCache(() =>
         {
             if (isRoot)
@@ -82,7 +82,7 @@ public sealed partial class DomBridge
             return 0;
         });
 
-    private double GetClientHeightForDomElement(DomElement element, bool isRoot) =>
+    private double GetClientHeightForDomElement(Broiler.Dom.DomElement element, bool isRoot) =>
         WithLayoutGeometryCache(() =>
         {
             if (isRoot)
@@ -97,19 +97,19 @@ public sealed partial class DomBridge
             return 0;
         });
 
-    private double GetClientTopForDomElement(DomElement element)
+    private double GetClientTopForDomElement(Broiler.Dom.DomElement element)
     {
         var props = GetComputedProps(element);
         return ParseCssLengthToPixelsWithViewport(props.GetValueOrDefault("border-top-width"), element);
     }
 
-    private double GetClientLeftForDomElement(DomElement element)
+    private double GetClientLeftForDomElement(Broiler.Dom.DomElement element)
     {
         var props = GetComputedProps(element);
         return ParseCssLengthToPixelsWithViewport(props.GetValueOrDefault("border-left-width"), element);
     }
 
-    private double GetOffsetWidthForDomElement(DomElement element, bool isRoot) =>
+    private double GetOffsetWidthForDomElement(Broiler.Dom.DomElement element, bool isRoot) =>
         WithLayoutGeometryCache(() =>
         {
             if (isRoot)
@@ -128,7 +128,7 @@ public sealed partial class DomBridge
             return 0;
         });
 
-    private double GetOffsetHeightForDomElement(DomElement element, bool isRoot) =>
+    private double GetOffsetHeightForDomElement(Broiler.Dom.DomElement element, bool isRoot) =>
         WithLayoutGeometryCache(() =>
         {
             if (isRoot)
@@ -147,10 +147,10 @@ public sealed partial class DomBridge
             return 0;
         });
 
-    private static bool ShouldReportZeroOffsetMetrics(DomElement element) =>
+    private static bool ShouldReportZeroOffsetMetrics(Broiler.Dom.DomElement element) =>
         string.Equals(element.TagName, "map", StringComparison.OrdinalIgnoreCase);
 
-    private double GetOffsetTopForDomElement(DomElement element) =>
+    private double GetOffsetTopForDomElement(Broiler.Dom.DomElement element) =>
         WithLayoutGeometryCache(() =>
         {
             var resolved = ResolvePositionAreaForElement(element);
@@ -164,7 +164,7 @@ public sealed partial class DomBridge
             return 0;
         });
 
-    private double GetOffsetLeftForDomElement(DomElement element) =>
+    private double GetOffsetLeftForDomElement(Broiler.Dom.DomElement element) =>
         WithLayoutGeometryCache(() =>
         {
             var resolved = ResolvePositionAreaForElement(element);
@@ -188,7 +188,7 @@ public sealed partial class DomBridge
     /// (<c>align-self</c>/<c>justify-self</c>) in vertical writing modes. Returns
     /// <c>false</c> (fall back to the estimator) when either box is missing from the snapshot.
     /// </summary>
-    private bool TryGetSharedOffset(DomElement element, DomElement offsetParent, bool vertical, out double offset)
+    private bool TryGetSharedOffset(Broiler.Dom.DomElement element, Broiler.Dom.DomElement offsetParent, bool vertical, out double offset)
     {
         offset = 0;
         if (!UseSharedLayoutGeometry || !TryGetSharedLayoutGeometry(element, out var elementGeometry))
@@ -215,7 +215,7 @@ public sealed partial class DomBridge
         return true;
     }
 
-    private DomElement? GetOffsetParentForDomElement(DomElement element)
+    private Broiler.Dom.DomElement? GetOffsetParentForDomElement(Broiler.Dom.DomElement element)
     {
         if (ParentEl(element) == null ||
             ReferenceEquals(element, DocumentElement) ||
@@ -251,7 +251,7 @@ public sealed partial class DomBridge
         return fallbackBody ?? documentElement;
     }
 
-    private DomElement? GetScrollParentForDomElement(DomElement element)
+    private Broiler.Dom.DomElement? GetScrollParentForDomElement(Broiler.Dom.DomElement element)
     {
         var documentElement = GetOwningDocumentElement(element);
         if (!HasAssociatedLayoutBox(element))
@@ -286,9 +286,9 @@ public sealed partial class DomBridge
         return FindNearestScrollParent(ParentEl(element), documentElement);
     }
 
-    private DomElement GetDocumentScrollingElement(DomElement documentElement) => documentElement;
+    private Broiler.Dom.DomElement GetDocumentScrollingElement(Broiler.Dom.DomElement documentElement) => documentElement;
 
-    private DomElement FindNearestScrollParent(DomElement? start, DomElement documentElement)
+    private Broiler.Dom.DomElement FindNearestScrollParent(Broiler.Dom.DomElement? start, Broiler.Dom.DomElement documentElement)
     {
         for (var current = start; current != null; current = ParentEl(current))
         {
@@ -305,7 +305,7 @@ public sealed partial class DomBridge
         return GetDocumentScrollingElement(documentElement);
     }
 
-    private DomElement? FindFixedPositionContainingBlock(DomElement element, DomElement documentElement)
+    private Broiler.Dom.DomElement? FindFixedPositionContainingBlock(Broiler.Dom.DomElement element, Broiler.Dom.DomElement documentElement)
     {
         for (var current = ParentEl(element); current != null; current = ParentEl(current))
         {
@@ -319,7 +319,7 @@ public sealed partial class DomBridge
         return null;
     }
 
-    private bool EstablishesFixedPositionContainingBlock(DomElement element)
+    private bool EstablishesFixedPositionContainingBlock(Broiler.Dom.DomElement element)
     {
         var props = GetComputedProps(element);
         var transform = props.GetValueOrDefault("transform");
@@ -340,7 +340,7 @@ public sealed partial class DomBridge
                normalized.Contains("content");
     }
 
-    private bool HasAssociatedLayoutBox(DomElement element)
+    private bool HasAssociatedLayoutBox(Broiler.Dom.DomElement element)
     {
         if (IsText(element))
             return false;
@@ -369,7 +369,7 @@ public sealed partial class DomBridge
     /// element's own unzoomed CSS pixels; a zoomed descendant keeps its larger baked
     /// extent, which correctly counts as scrollable overflow.</para>
     /// </summary>
-    private bool TryGetSharedScrollExtent(DomElement element, bool vertical, out double extent)
+    private bool TryGetSharedScrollExtent(Broiler.Dom.DomElement element, bool vertical, out double extent)
     {
         extent = 0;
         if (!TryGetSharedLayoutGeometry(element, out var box))
@@ -408,7 +408,7 @@ public sealed partial class DomBridge
     /// snapshot pass restores after building (see the render-doc/live-doc separation),
     /// so the true zoom is readable here.
     /// </summary>
-    private double UnzoomSharedExtent(double extent, DomElement element)
+    private double UnzoomSharedExtent(double extent, Broiler.Dom.DomElement element)
     {
         var zoom = GetUsedZoomForElement(element);
         return zoom > 0.0001 ? extent / zoom : extent;
@@ -420,7 +420,7 @@ public sealed partial class DomBridge
     /// <c>false</c> (caller falls back to the estimator) when the shared path is off or the
     /// element has no box.
     /// </summary>
-    private bool TrySharedBorderBoxExtent(DomElement element, bool vertical, out double extent)
+    private bool TrySharedBorderBoxExtent(Broiler.Dom.DomElement element, bool vertical, out double extent)
     {
         extent = 0;
         if (!UseSharedLayoutGeometry || !TryGetSharedLayoutGeometry(element, out var box))
@@ -435,7 +435,7 @@ public sealed partial class DomBridge
     /// box), in the element's own unzoomed CSS pixels. Returns <c>false</c> (caller falls
     /// back to the estimator) when the shared path is off or the element has no box.
     /// </summary>
-    private bool TrySharedContentBoxExtent(DomElement element, bool vertical, out double extent)
+    private bool TrySharedContentBoxExtent(Broiler.Dom.DomElement element, bool vertical, out double extent)
     {
         extent = 0;
         if (!UseSharedLayoutGeometry || !TryGetSharedLayoutGeometry(element, out var box))
@@ -444,7 +444,7 @@ public sealed partial class DomBridge
         return true;
     }
 
-    private double GetScrollWidthForDomElement(DomElement element, bool isRoot) =>
+    private double GetScrollWidthForDomElement(Broiler.Dom.DomElement element, bool isRoot) =>
         WithLayoutGeometryCache(() =>
         {
             if (TryGetSelectListBoxScrollExtent(element, verticalAxis: false, out var selectScrollWidth))
@@ -460,7 +460,7 @@ public sealed partial class DomBridge
             return 0;
         });
 
-    private double GetScrollHeightForDomElement(DomElement element, bool isRoot) =>
+    private double GetScrollHeightForDomElement(Broiler.Dom.DomElement element, bool isRoot) =>
         WithLayoutGeometryCache(() =>
         {
             if (TryGetSelectListBoxScrollExtent(element, verticalAxis: true, out var selectScrollHeight))
@@ -474,7 +474,7 @@ public sealed partial class DomBridge
             return 0;
         });
 
-    private (double Left, double Top, double Width, double Height) GetBoundingClientRectForDomElement(DomElement element, bool isRoot) =>
+    private (double Left, double Top, double Width, double Height) GetBoundingClientRectForDomElement(Broiler.Dom.DomElement element, bool isRoot) =>
         WithLayoutGeometryCache(() =>
         {
             if (isRoot)
@@ -483,7 +483,7 @@ public sealed partial class DomBridge
             return ComputeRenderedRect(element);
         });
 
-    private (double Left, double Top, double Width, double Height) ComputeRenderedRect(DomElement element)
+    private (double Left, double Top, double Width, double Height) ComputeRenderedRect(Broiler.Dom.DomElement element)
     {
         var layoutRect = ComputeUnzoomedLayoutRect(element);
         var zoom = GetUsedZoomForElement(element);
@@ -491,7 +491,7 @@ public sealed partial class DomBridge
         return (layoutRect.Left, layoutRect.Top, layoutRect.Width * zoom * transformScale, layoutRect.Height * zoom * transformScale);
     }
 
-    private (double Left, double Top, double Width, double Height) ComputeUnzoomedLayoutRect(DomElement element)
+    private (double Left, double Top, double Width, double Height) ComputeUnzoomedLayoutRect(Broiler.Dom.DomElement element)
     {
         // RF-BRIDGE-1b: the element's rect comes from the renderer's real layout (border
         // box, document coords), which powers getBoundingClientRect and offset top/left.
@@ -514,7 +514,7 @@ public sealed partial class DomBridge
         return (0, 0, 0, 0);
     }
 
-    private static bool IsSvgShapeElement(DomElement element)
+    private static bool IsSvgShapeElement(Broiler.Dom.DomElement element)
     {
         var tag = element.TagName;
         return string.Equals(tag, "rect", StringComparison.OrdinalIgnoreCase) ||
@@ -525,19 +525,19 @@ public sealed partial class DomBridge
                string.Equals(tag, "svg:foreignobject", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool IsSvgViewportElement(DomElement element)
+    private static bool IsSvgViewportElement(Broiler.Dom.DomElement element)
     {
         var tag = element.TagName;
         return string.Equals(tag, "svg", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(tag, "svg:svg", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool IsSvgElement(DomElement element) =>
+    private static bool IsSvgElement(Broiler.Dom.DomElement element) =>
         string.Equals(element.NamespaceUri, "http://www.w3.org/2000/svg", StringComparison.OrdinalIgnoreCase) ||
         IsSvgViewportElement(element) ||
         IsSvgShapeElement(element);
 
-    private double GetUsedZoomForElement(DomElement element)
+    private double GetUsedZoomForElement(Broiler.Dom.DomElement element)
     {
         var props = GetComputedProps(element);
         var specifiedZoom = props.GetValueOrDefault("zoom");
@@ -561,7 +561,7 @@ public sealed partial class DomBridge
         return parentZoom;
     }
 
-    private double GetTransformScale(DomElement element)
+    private double GetTransformScale(Broiler.Dom.DomElement element)
     {
         var transform = GetElementTransformValue(element);
         if (string.IsNullOrWhiteSpace(transform))
@@ -578,7 +578,7 @@ public sealed partial class DomBridge
         return 1;
     }
 
-    private string? GetElementTransformValue(DomElement element)
+    private string? GetElementTransformValue(Broiler.Dom.DomElement element)
     {
         var props = GetComputedProps(element);
         var transform = props.GetValueOrDefault("transform");
@@ -593,14 +593,14 @@ public sealed partial class DomBridge
             : null;
     }
 
-    private static bool IsSvgGroupElement(DomElement element)
+    private static bool IsSvgGroupElement(Broiler.Dom.DomElement element)
     {
         var tag = element.TagName;
         return string.Equals(tag, "g", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(tag, "svg:g", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool IsSvgTextContentElement(DomElement element)
+    private static bool IsSvgTextContentElement(Broiler.Dom.DomElement element)
     {
         var tag = element.TagName;
         return string.Equals(tag, "text", StringComparison.OrdinalIgnoreCase) ||
@@ -612,7 +612,7 @@ public sealed partial class DomBridge
     }
 
     private bool TryGetSvgChildrenUnionRect(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         out (double Left, double Top, double Width, double Height) rect)
     {
         var found = false;
@@ -653,7 +653,7 @@ public sealed partial class DomBridge
     }
 
     private bool TryGetSvgTextHitTestRect(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         out (double Left, double Top, double Width, double Height) rect)
     {
         var text = GetDirectTextContent(element);
@@ -703,7 +703,7 @@ public sealed partial class DomBridge
         return true;
     }
 
-    private static string GetDirectTextContent(DomElement element)
+    private static string GetDirectTextContent(Broiler.Dom.DomElement element)
     {
         // RF-BRIDGE-1c Phase F (F3c part 2d): a node's direct text is its text-node children.
         var sb = new StringBuilder();
@@ -716,7 +716,7 @@ public sealed partial class DomBridge
         return sb.ToString();
     }
 
-    private double ResolveSvgTextCoordinate(DomElement element, string attributeName)
+    private double ResolveSvgTextCoordinate(Broiler.Dom.DomElement element, string attributeName)
     {
         for (var current = element; current != null; current = ParentEl(current))
         {
@@ -757,11 +757,11 @@ public sealed partial class DomBridge
         return 0;
     }
 
-    private static bool HasOwnSvgCoordinate(DomElement element, string attributeName) =>
+    private static bool HasOwnSvgCoordinate(Broiler.Dom.DomElement element, string attributeName) =>
         TryGetAttribute(element, attributeName, out var rawValue) &&
         !string.IsNullOrWhiteSpace(rawValue);
 
-    private bool TryResolveSvgTextPathStart(DomElement element, out (double X, double Y) point)
+    private bool TryResolveSvgTextPathStart(Broiler.Dom.DomElement element, out (double X, double Y) point)
     {
         point = default;
         if (!TryGetAttribute(element, "href", out var href) &&
@@ -802,14 +802,14 @@ public sealed partial class DomBridge
         return true;
     }
 
-    private static bool IsSvgTextPathElement(DomElement element)
+    private static bool IsSvgTextPathElement(Broiler.Dom.DomElement element)
     {
         var tag = element.TagName;
         return string.Equals(tag, "textpath", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(tag, "svg:textpath", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static DomElement? FindNearestSvgViewportAncestor(DomElement element)
+    private static Broiler.Dom.DomElement? FindNearestSvgViewportAncestor(Broiler.Dom.DomElement element)
     {
         for (var current = ParentEl(element); current != null; current = ParentEl(current))
         {
@@ -820,7 +820,7 @@ public sealed partial class DomBridge
         return null;
     }
 
-    private double GetBorderBoxWidth(Dictionary<string, string> props, DomElement? element = null)
+    private double GetBorderBoxWidth(Dictionary<string, string> props, Broiler.Dom.DomElement? element = null)
     {
         var containingBlockWidth = element != null ? ResolveContainingBlockReferenceLength(element, vertical: false) : (double?)null;
         return ParseCssLengthToPixelsWithViewport(props.GetValueOrDefault("width"), element, percentageBasis: containingBlockWidth)
@@ -830,7 +830,7 @@ public sealed partial class DomBridge
              + ParseCssLengthToPixelsWithViewport(props.GetValueOrDefault("border-right-width"), element);
     }
 
-    private double GetBorderBoxHeight(Dictionary<string, string> props, DomElement? element = null)
+    private double GetBorderBoxHeight(Dictionary<string, string> props, Broiler.Dom.DomElement? element = null)
     {
         var containingBlockWidth = element != null ? ResolveContainingBlockReferenceLength(element, vertical: false) : (double?)null;
         var containingBlockHeight = element != null ? ResolveContainingBlockReferenceLength(element, vertical: true) : (double?)null;
@@ -842,7 +842,7 @@ public sealed partial class DomBridge
     }
 
     private void ScrollElementIntoView(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         string? block = null,
         string? inline = null,
         string? behavior = null)
@@ -965,7 +965,7 @@ public sealed partial class DomBridge
     }
 
     private (string Horizontal, string Vertical) ResolvePhysicalScrollIntoViewAlignments(
-        DomElement scrollContainer,
+        Broiler.Dom.DomElement scrollContainer,
         string? block,
         string? inline)
     {
@@ -1004,7 +1004,7 @@ public sealed partial class DomBridge
         };
     }
 
-    private double GetElementScrollOffset(DomElement element, bool vertical)
+    private double GetElementScrollOffset(Broiler.Dom.DomElement element, bool vertical)
     {
         if (!CanProgrammaticallyScroll(element, vertical))
             return 0;
@@ -1014,14 +1014,14 @@ public sealed partial class DomBridge
             : 0;
     }
 
-    private void SetElementScrollOffsets(DomElement element, double? left = null, double? top = null, bool relative = false, bool clamp = true)
+    private void SetElementScrollOffsets(Broiler.Dom.DomElement element, double? left = null, double? top = null, bool relative = false, bool clamp = true)
     {
         var (nextLeft, nextTop) = ResolveElementScrollOffsets(element, left, top, relative, clamp);
         GetElementRuntimeState(element).Scroll.Left.Set(nextLeft);
         GetElementRuntimeState(element).Scroll.Top.Set(nextTop);
     }
 
-    private (double Left, double Top) ResolveElementScrollOffsets(DomElement element, double? left = null, double? top = null, bool relative = false, bool clamp = true)
+    private (double Left, double Top) ResolveElementScrollOffsets(Broiler.Dom.DomElement element, double? left = null, double? top = null, bool relative = false, bool clamp = true)
     {
         var currentLeft = GetElementScrollOffset(element, vertical: false);
         var currentTop = GetElementScrollOffset(element, vertical: true);
@@ -1045,7 +1045,7 @@ public sealed partial class DomBridge
     }
 
     private void SetElementScrollOffsetsWithBehavior(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         double? left = null,
         double? top = null,
         bool relative = false,
@@ -1106,12 +1106,12 @@ public sealed partial class DomBridge
         _frameActions[Interlocked.Increment(ref _frameActionIdCounter)] = callback;
     }
 
-    private void CancelSmoothScroll(DomElement element)
+    private void CancelSmoothScroll(Broiler.Dom.DomElement element)
     {
         _smoothScrollTokens.TryRemove(element, out _);
     }
 
-    private void DispatchScrollEventIfNeeded(DomElement element, double previousLeft, double previousTop)
+    private void DispatchScrollEventIfNeeded(Broiler.Dom.DomElement element, double previousLeft, double previousTop)
     {
         if (AreClose(previousLeft, GetElementScrollOffset(element, vertical: false)) &&
             AreClose(previousTop, GetElementScrollOffset(element, vertical: true)))
@@ -1120,7 +1120,7 @@ public sealed partial class DomBridge
         DispatchElementEvent(element, "scroll");
     }
 
-    private void DispatchScrollEndEventIfNeeded(DomElement element, double previousLeft, double previousTop)
+    private void DispatchScrollEndEventIfNeeded(Broiler.Dom.DomElement element, double previousLeft, double previousTop)
     {
         if (AreClose(previousLeft, GetElementScrollOffset(element, vertical: false)) &&
             AreClose(previousTop, GetElementScrollOffset(element, vertical: true)))
@@ -1129,7 +1129,7 @@ public sealed partial class DomBridge
         DispatchElementEvent(element, "scrollend");
     }
 
-    private void DispatchElementEvent(DomElement element, string eventType)
+    private void DispatchElementEvent(Broiler.Dom.DomElement element, string eventType)
     {
         var evt = new JSObject();
         evt.FastAddValue((KeyString)"type", new JSString(eventType), JSPropertyAttributes.EnumerableConfigurableValue);
@@ -1137,7 +1137,7 @@ public sealed partial class DomBridge
         DispatchEventOnElement(element, evt);
     }
 
-    private string ResolveScrollBehavior(DomElement element, string? requestedBehavior)
+    private string ResolveScrollBehavior(Broiler.Dom.DomElement element, string? requestedBehavior)
     {
         var normalizedRequested = NormalizeScrollBehavior(requestedBehavior);
         if (normalizedRequested == "instant" || normalizedRequested == "smooth")
@@ -1179,8 +1179,8 @@ public sealed partial class DomBridge
     }
 
     private void ScrollFixedElementIntoVisualViewport(
-        DomElement element,
-        DomElement scrollContainer,
+        Broiler.Dom.DomElement element,
+        Broiler.Dom.DomElement scrollContainer,
         string? block,
         string? inline)
     {
@@ -1293,7 +1293,7 @@ public sealed partial class DomBridge
         }
     }
 
-    private bool CanProgrammaticallyScroll(DomElement element, bool vertical)
+    private bool CanProgrammaticallyScroll(Broiler.Dom.DomElement element, bool vertical)
     {
         if (IsDocumentElement(element) ||
             IsViewportBodyElement(element, GetOwningDocumentElement(element)))
@@ -1310,7 +1310,7 @@ public sealed partial class DomBridge
         return EnablesScrollingBox(axisValue);
     }
 
-    private bool CanProgrammaticallyScrollRoot(DomElement rootElement, bool vertical)
+    private bool CanProgrammaticallyScrollRoot(Broiler.Dom.DomElement rootElement, bool vertical)
     {
         var documentElement = GetOwningDocumentElement(rootElement);
         var htmlOverflow = GetOverflowAxisValue(GetComputedProps(documentElement), vertical);
@@ -1349,7 +1349,7 @@ public sealed partial class DomBridge
         return value.Contains("hidden") || value.Contains("scroll") || value.Contains("auto") || value.Contains("clip");
     }
 
-    private (double MinLeft, double MaxLeft, double MinTop, double MaxTop) GetScrollBounds(DomElement element)
+    private (double MinLeft, double MaxLeft, double MinTop, double MaxTop) GetScrollBounds(Broiler.Dom.DomElement element)
     {
         var isRoot = IsViewportElementForMetrics(element);
         var maxLeft = Math.Max(0, GetScrollWidthForDomElement(element, isRoot) - GetClientWidthForDomElement(element, isRoot));
@@ -1371,7 +1371,7 @@ public sealed partial class DomBridge
         return (minLeft, boundedMaxLeft, minTop, boundedMaxTop);
     }
 
-    private bool CanProgrammaticallyScrollSelectListBox(DomElement element, bool vertical)
+    private bool CanProgrammaticallyScrollSelectListBox(Broiler.Dom.DomElement element, bool vertical)
     {
         var props = GetComputedProps(element);
         bool verticalWritingMode = IsVerticalWritingMode(props.GetValueOrDefault("writing-mode"));
@@ -1384,7 +1384,7 @@ public sealed partial class DomBridge
         return scrollExtent > clientExtent + 0.5;
     }
 
-    private bool TryGetSelectListBoxScrollExtent(DomElement element, bool verticalAxis, out double extent)
+    private bool TryGetSelectListBoxScrollExtent(Broiler.Dom.DomElement element, bool verticalAxis, out double extent)
     {
         if (!IsSelectListBox(element))
         {
@@ -1410,7 +1410,7 @@ public sealed partial class DomBridge
         return true;
     }
 
-    private static int CountSelectOptions(DomElement element)
+    private static int CountSelectOptions(Broiler.Dom.DomElement element)
     {
         int count = 0;
         foreach (var child in ChildElements(element).Where(c => !IsText(c)))
@@ -1447,9 +1447,9 @@ public sealed partial class DomBridge
         return svgLength;
     }
 
-    private static List<DomElement> CollectSelectOptions(DomElement element)
+    private static List<Broiler.Dom.DomElement> CollectSelectOptions(Broiler.Dom.DomElement element)
     {
-        var options = new List<DomElement>();
+        var options = new List<Broiler.Dom.DomElement>();
         foreach (var child in ChildElements(element).Where(c => !IsText(c)))
         {
             if (string.Equals(child.TagName, "option", StringComparison.OrdinalIgnoreCase))
@@ -1464,7 +1464,7 @@ public sealed partial class DomBridge
         return options;
     }
 
-    private static int GetSelectSelectedIndex(DomElement element)
+    private static int GetSelectSelectedIndex(Broiler.Dom.DomElement element)
     {
         var options = CollectSelectOptions(element);
         if (options.Count == 0)
@@ -1489,7 +1489,7 @@ public sealed partial class DomBridge
         return 0;
     }
 
-    private static void SetSelectSelectedIndex(DomElement element, int index)
+    private static void SetSelectSelectedIndex(Broiler.Dom.DomElement element, int index)
     {
         var options = CollectSelectOptions(element);
         if (options.Count == 0)
@@ -1504,7 +1504,7 @@ public sealed partial class DomBridge
         GetElementRuntimeState(element).FormControl.SelectedIndex.Set(index);
     }
 
-    private static string GetSelectValue(DomElement element)
+    private static string GetSelectValue(Broiler.Dom.DomElement element)
     {
         var options = CollectSelectOptions(element);
         var selectedIndex = GetSelectSelectedIndex(element);
@@ -1521,7 +1521,7 @@ public sealed partial class DomBridge
         return GetElementTextContent(option);
     }
 
-    private static void SetSelectValue(DomElement element, string value)
+    private static void SetSelectValue(Broiler.Dom.DomElement element, string value)
     {
         var options = CollectSelectOptions(element);
         for (var index = 0; index < options.Count; index++)
@@ -1540,7 +1540,7 @@ public sealed partial class DomBridge
         GetElementRuntimeState(element).FormControl.SelectedIndex.Set(-1);
     }
 
-    private IEnumerable<DomElement> EnumerateRenderedDescendants(DomElement element)
+    private IEnumerable<Broiler.Dom.DomElement> EnumerateRenderedDescendants(Broiler.Dom.DomElement element)
     {
         foreach (var child in EnumerateRenderedChildren(element))
         {
@@ -1551,7 +1551,7 @@ public sealed partial class DomBridge
         }
     }
 
-    private IEnumerable<DomElement> EnumerateRenderedChildren(DomElement element)
+    private IEnumerable<Broiler.Dom.DomElement> EnumerateRenderedChildren(Broiler.Dom.DomElement element)
     {
         if (string.Equals(element.TagName, "slot", StringComparison.OrdinalIgnoreCase))
         {
@@ -1575,7 +1575,7 @@ public sealed partial class DomBridge
         }
     }
 
-    private DomElement? FindScrollContainer(DomElement element)
+    private Broiler.Dom.DomElement? FindScrollContainer(Broiler.Dom.DomElement element)
     {
         var documentElement = GetOwningDocumentElement(element);
         for (var current = GetScrollTraversalParent(element); current != null; current = GetScrollTraversalParent(current))
@@ -1594,7 +1594,7 @@ public sealed partial class DomBridge
         return documentElement;
     }
 
-    private bool HasFixedPositionAncestorBefore(DomElement element, DomElement ancestor)
+    private bool HasFixedPositionAncestorBefore(Broiler.Dom.DomElement element, Broiler.Dom.DomElement ancestor)
     {
         for (var current = GetScrollTraversalParent(element);
              current != null && !ReferenceEquals(current, ancestor);
@@ -1608,20 +1608,20 @@ public sealed partial class DomBridge
         return false;
     }
 
-    private static bool IsDocumentElement(DomElement element) =>
+    private static bool IsDocumentElement(Broiler.Dom.DomElement element) =>
         string.Equals(element.TagName, "html", StringComparison.OrdinalIgnoreCase);
 
-    private bool IsViewportElementForMetrics(DomElement element)
+    private bool IsViewportElementForMetrics(Broiler.Dom.DomElement element)
     {
         var documentElement = GetOwningDocumentElement(element);
         return IsDocumentElement(element) || IsViewportBodyElement(element, documentElement);
     }
 
-    private static bool IsViewportBodyElement(DomElement element, DomElement documentElement) =>
+    private static bool IsViewportBodyElement(Broiler.Dom.DomElement element, Broiler.Dom.DomElement documentElement) =>
         string.Equals(element.TagName, "body", StringComparison.OrdinalIgnoreCase) &&
         ReferenceEquals(ParentEl(element), documentElement);
 
-    private DomElement GetOwningDocumentElement(DomElement element)
+    private Broiler.Dom.DomElement GetOwningDocumentElement(Broiler.Dom.DomElement element)
     {
         for (var current = element; current != null; current = ParentEl(current)!)
         {
@@ -1632,7 +1632,7 @@ public sealed partial class DomBridge
         return DocumentElement;
     }
 
-    private bool HasFixedPositionInDocument(DomElement element, DomElement documentElement)
+    private bool HasFixedPositionInDocument(Broiler.Dom.DomElement element, Broiler.Dom.DomElement documentElement)
     {
         if (IsFixedPositionElement(element))
             return true;
@@ -1640,13 +1640,13 @@ public sealed partial class DomBridge
         return HasFixedPositionAncestorBefore(element, documentElement);
     }
 
-    private bool IsFixedPositionElement(DomElement element)
+    private bool IsFixedPositionElement(Broiler.Dom.DomElement element)
     {
         var props = GetComputedProps(element);
         return string.Equals(props.GetValueOrDefault("position"), "fixed", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static DomElement? GetOuterFrameElement(DomElement documentElement)
+    private static Broiler.Dom.DomElement? GetOuterFrameElement(Broiler.Dom.DomElement documentElement)
     {
         var docRoot = ParentEl(documentElement);
         return docRoot != null &&
@@ -1655,7 +1655,7 @@ public sealed partial class DomBridge
             : null;
     }
 
-    private DomElement? GetOuterScrollContinuationElement(DomElement scrollContainer)
+    private Broiler.Dom.DomElement? GetOuterScrollContinuationElement(Broiler.Dom.DomElement scrollContainer)
     {
         if (IsDocumentElement(scrollContainer))
             return GetOuterFrameElement(scrollContainer);
@@ -1673,7 +1673,7 @@ public sealed partial class DomBridge
     /// <c>false</c> — so the caller reports zero — when either box is missing, or zoom is in
     /// play (a zoomed cross-ancestor delta is not reconciled against the baked snapshot).
     /// </summary>
-    private bool TrySharedOffsetWithinAncestor(DomElement element, DomElement ancestor, bool vertical, out double offset,
+    private bool TrySharedOffsetWithinAncestor(Broiler.Dom.DomElement element, Broiler.Dom.DomElement ancestor, bool vertical, out double offset,
         bool viewportAnchored = false)
     {
         offset = 0;
@@ -1740,7 +1740,7 @@ public sealed partial class DomBridge
     /// subtraction for a viewport-anchored scrollIntoView target
     /// (<see cref="TrySharedOffsetWithinAncestor"/>).
     /// </summary>
-    private DomElement? FindNearestFixedAncestorOrSelf(DomElement element)
+    private Broiler.Dom.DomElement? FindNearestFixedAncestorOrSelf(Broiler.Dom.DomElement element)
     {
         for (var current = element; current != null; current = ParentEl(current))
         {
@@ -1750,7 +1750,7 @@ public sealed partial class DomBridge
         return null;
     }
 
-    private static bool IsDomDescendantOrSelf(DomElement node, DomElement potentialAncestor)
+    private static bool IsDomDescendantOrSelf(Broiler.Dom.DomElement node, Broiler.Dom.DomElement potentialAncestor)
     {
         for (var current = node; current != null; current = ParentEl(current))
         {
@@ -1768,7 +1768,7 @@ public sealed partial class DomBridge
     /// the estimator. Used by the visual-viewport fixed-element scrollIntoView sites so
     /// they no longer call the estimator directly.
     /// </summary>
-    private double OffsetWithinAncestorForFixedPreferShared(DomElement element, DomElement ancestor, bool vertical) =>
+    private double OffsetWithinAncestorForFixedPreferShared(Broiler.Dom.DomElement element, Broiler.Dom.DomElement ancestor, bool vertical) =>
         TrySharedOffsetWithinAncestor(element, ancestor, vertical, out var shared, viewportAnchored: true)
             ? shared
             : 0;
@@ -1780,14 +1780,14 @@ public sealed partial class DomBridge
     /// shared-unavailable element (cross-origin / non-materialised frame) reports 0 — real
     /// in-flow sticky/scrollIntoView targets are always present in the snapshot.
     /// </summary>
-    private double OffsetWithinAncestorPreferShared(DomElement element, DomElement ancestor, bool vertical) =>
+    private double OffsetWithinAncestorPreferShared(Broiler.Dom.DomElement element, Broiler.Dom.DomElement ancestor, bool vertical) =>
         TrySharedOffsetWithinAncestor(element, ancestor, vertical, out var shared)
             ? shared
             : 0;
 
     private double ResolveScrollIntoViewOffset(
-        DomElement element,
-        DomElement scrollContainer,
+        Broiler.Dom.DomElement element,
+        Broiler.Dom.DomElement scrollContainer,
         bool vertical,
         string? alignment,
         double? viewportSizeOverride = null,
@@ -1862,7 +1862,7 @@ public sealed partial class DomBridge
     }
 
     private double ConvertPhysicalScrollPosition(
-        DomElement scrollContainer,
+        Broiler.Dom.DomElement scrollContainer,
         bool vertical,
         double physicalPosition,
         bool coordinateSpaceIsPhysical)
@@ -1870,7 +1870,7 @@ public sealed partial class DomBridge
             ? physicalPosition
             : ConvertPhysicalPositionToScrollCoordinate(scrollContainer, vertical, physicalPosition);
 
-    private double ConvertScrollCoordinateToPhysicalPosition(DomElement scrollContainer, bool vertical, double coordinate)
+    private double ConvertScrollCoordinateToPhysicalPosition(Broiler.Dom.DomElement scrollContainer, bool vertical, double coordinate)
     {
         if (!UsesNegativeScrollCoordinates(scrollContainer, vertical))
             return coordinate;
@@ -1878,7 +1878,7 @@ public sealed partial class DomBridge
         return coordinate + GetPositiveScrollExtent(scrollContainer, vertical);
     }
 
-    private double ConvertPhysicalPositionToScrollCoordinate(DomElement scrollContainer, bool vertical, double physicalPosition)
+    private double ConvertPhysicalPositionToScrollCoordinate(Broiler.Dom.DomElement scrollContainer, bool vertical, double physicalPosition)
     {
         if (!UsesNegativeScrollCoordinates(scrollContainer, vertical))
             return physicalPosition;
@@ -1886,13 +1886,13 @@ public sealed partial class DomBridge
         return physicalPosition - GetPositiveScrollExtent(scrollContainer, vertical);
     }
 
-    private bool UsesNegativeScrollCoordinates(DomElement scrollContainer, bool vertical)
+    private bool UsesNegativeScrollCoordinates(Broiler.Dom.DomElement scrollContainer, bool vertical)
     {
         var (minLeft, _, minTop, _) = GetScrollBounds(scrollContainer);
         return vertical ? minTop < 0 : minLeft < 0;
     }
 
-    private double GetPositiveScrollExtent(DomElement scrollContainer, bool vertical)
+    private double GetPositiveScrollExtent(Broiler.Dom.DomElement scrollContainer, bool vertical)
     {
         var (minLeft, maxLeft, minTop, maxTop) = GetScrollBounds(scrollContainer);
         return vertical
@@ -1900,7 +1900,7 @@ public sealed partial class DomBridge
             : (minLeft < 0 ? maxLeft - minLeft : maxLeft);
     }
 
-    private (double Value, DomElement Owner) ResolveScrollIntoViewInset(DomElement element, string propertyName)
+    private (double Value, Broiler.Dom.DomElement Owner) ResolveScrollIntoViewInset(Broiler.Dom.DomElement element, string propertyName)
     {
         var props = GetComputedProps(element);
         var value = props.GetValueOrDefault(propertyName);
@@ -1910,7 +1910,7 @@ public sealed partial class DomBridge
         return (ParseCssLengthToPixelsWithViewport(value, element), element);
     }
 
-    private double ConvertInsetToScrollContainerCoordinates(double inset, DomElement insetOwner, DomElement scrollContainer)
+    private double ConvertInsetToScrollContainerCoordinates(double inset, Broiler.Dom.DomElement insetOwner, Broiler.Dom.DomElement scrollContainer)
     {
         if (!double.IsFinite(inset) || AreClose(inset, 0))
             return 0;
@@ -1928,7 +1928,7 @@ public sealed partial class DomBridge
 
     private double ParseCssLengthToPixelsWithViewport(
         string? value,
-        DomElement? referenceElement = null,
+        Broiler.Dom.DomElement? referenceElement = null,
         bool forLineHeight = false,
         double? percentageBasis = null,
         bool forFontSize = false)
@@ -1943,7 +1943,7 @@ public sealed partial class DomBridge
 
     private bool TryEvaluateCssLengthWithViewport(
         string value,
-        DomElement? referenceElement,
+        Broiler.Dom.DomElement? referenceElement,
         bool forLineHeight,
         double? percentageBasis,
         out double result,
@@ -2062,7 +2062,7 @@ public sealed partial class DomBridge
 
     private bool TryEvaluateMathLengthFunction(
         string value,
-        DomElement? referenceElement,
+        Broiler.Dom.DomElement? referenceElement,
         bool forLineHeight,
         double? percentageBasis,
         out double result,
@@ -2186,7 +2186,7 @@ public sealed partial class DomBridge
         return parts;
     }
 
-    private double ResolveContainingBlockReferenceLength(DomElement element, bool vertical)
+    private double ResolveContainingBlockReferenceLength(Broiler.Dom.DomElement element, bool vertical)
     {
         if (ParentEl(element) == null ||
             string.Equals(element.TagName, "html", StringComparison.OrdinalIgnoreCase) ||
@@ -2202,7 +2202,7 @@ public sealed partial class DomBridge
         return reference > 0 ? reference : GetViewportReferenceLength(element, vertical);
     }
 
-    private double GetViewportReferenceLength(DomElement? element, bool vertical)
+    private double GetViewportReferenceLength(Broiler.Dom.DomElement? element, bool vertical)
     {
         if (element != null)
         {
@@ -2236,21 +2236,21 @@ public sealed partial class DomBridge
                !string.Equals(value, "auto", StringComparison.OrdinalIgnoreCase);
     }
 
-    private double ResolveLineHeightForLength(DomElement element, bool rootRelative, bool forLineHeight = false)
+    private double ResolveLineHeightForLength(Broiler.Dom.DomElement element, bool rootRelative, bool forLineHeight = false)
     {
         var target = rootRelative ? GetRootElement(element) : (forLineHeight ? ParentEl(element) ?? element : element);
         return ResolveLineHeightForElement(target);
     }
 
-    private double ResolveFontSizeForLength(DomElement element, bool rootRelative)
+    private double ResolveFontSizeForLength(Broiler.Dom.DomElement element, bool rootRelative)
     {
         var target = rootRelative ? GetRootElement(element) : element;
         return ResolveFontSizeForElement(target);
     }
 
-    private DomElement GetRootElement(DomElement element)
+    private Broiler.Dom.DomElement GetRootElement(Broiler.Dom.DomElement element)
     {
-        DomElement? htmlElement = null;
+        Broiler.Dom.DomElement? htmlElement = null;
         var current = element;
         while (ParentEl(current) != null)
         {
@@ -2262,7 +2262,7 @@ public sealed partial class DomBridge
         return htmlElement ?? current;
     }
 
-    private double ResolveLineHeightForElement(DomElement element)
+    private double ResolveLineHeightForElement(Broiler.Dom.DomElement element)
     {
         var props = GetComputedProps(element);
         var fontSize = ResolveFontSizeForElement(element);
@@ -2283,7 +2283,7 @@ public sealed partial class DomBridge
         return ParseCssLengthToPixelsWithViewport(lineHeight, element, forLineHeight: true);
     }
 
-    private double ResolveFontSizeForElement(DomElement element)
+    private double ResolveFontSizeForElement(Broiler.Dom.DomElement element)
     {
         var props = GetComputedProps(element);
         var fontSize = ParseCssLengthToPixelsWithViewport(props.GetValueOrDefault("font-size"), element, forFontSize: true);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Animations.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Animations.cs
@@ -7,7 +7,7 @@ namespace Broiler.HtmlBridge;
 
 public sealed partial class DomBridge
 {
-    private JSArray BuildAnimationList(DomElement? target)
+    private JSArray BuildAnimationList(Broiler.Dom.DomElement? target)
     {
         var animations = new List<JSValue>();
         foreach (var element in Elements)
@@ -28,7 +28,7 @@ public sealed partial class DomBridge
     }
 
     private bool TryGetAnimationProperties(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         out string? animationShorthand,
         out string? animationDelay)
     {
@@ -51,7 +51,7 @@ public sealed partial class DomBridge
     }
 
     private void EnsureAnimationCurrentTime(
-        DomElement element,
+        Broiler.Dom.DomElement element,
         string? animationShorthand,
         string? animationDelay)
     {
@@ -81,7 +81,7 @@ public sealed partial class DomBridge
         GetElementRuntimeState(element).Animation.CurrentTimeMilliseconds.Set(currentTimeMs);
     }
 
-    private static JSObject BuildAnimationObject(DomElement element)
+    private static JSObject BuildAnimationObject(Broiler.Dom.DomElement element)
     {
         var animation = new JSObject();
         animation.FastAddProperty(

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Registration.cs
@@ -18,7 +18,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// The element backing <c>document.documentElement</c> (the &lt;html&gt; element).
     /// </summary>
-    public DomElement DocumentElement { get; }
+    public Broiler.Dom.DomElement DocumentElement { get; }
 
     private void RegisterDocument(JSContext context)
     {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
@@ -5,10 +5,10 @@ namespace Broiler.HtmlBridge;
 
 public sealed partial class DomBridge
 {
-    private static DomElement? GetShadowRoot(DomElement element)
+    private static Broiler.Dom.DomElement? GetShadowRoot(Broiler.Dom.DomElement element)
     {
         if (GetElementRuntimeState(element).Shadow.Root.TryGet(out var rawShadowRoot) &&
-            rawShadowRoot is DomElement root)
+            rawShadowRoot is Broiler.Dom.DomElement root)
         {
             return root;
         }
@@ -16,12 +16,12 @@ public sealed partial class DomBridge
         return null;
     }
 
-    private static DomElement? GetShadowHost(DomElement? shadowRoot)
+    private static Broiler.Dom.DomElement? GetShadowHost(Broiler.Dom.DomElement? shadowRoot)
     {
         if (shadowRoot != null &&
             string.Equals(shadowRoot.TagName, "#shadow-root", StringComparison.Ordinal) &&
             GetElementRuntimeState(shadowRoot).Shadow.Host.TryGet(out var rawHost) &&
-            rawHost is DomElement host)
+            rawHost is Broiler.Dom.DomElement host)
         {
             return host;
         }
@@ -29,11 +29,11 @@ public sealed partial class DomBridge
         return null;
     }
 
-    private static DomElement? FindContainingShadowRoot(Broiler.Dom.DomNode? node)
+    private static Broiler.Dom.DomElement? FindContainingShadowRoot(Broiler.Dom.DomNode? node)
     {
         for (var current = node; current != null; current = current.ParentNode)
         {
-            if (current is DomElement element && string.Equals(element.TagName, "#shadow-root", StringComparison.Ordinal))
+            if (current is Broiler.Dom.DomElement element && string.Equals(element.TagName, "#shadow-root", StringComparison.Ordinal))
                 return element;
         }
 
@@ -44,9 +44,9 @@ public sealed partial class DomBridge
     {
         Broiler.Dom.DomNode current = node;
         // Stop at the topmost element: the facade #document's ParentNode is the canonical
-        // DomDocument (not a DomElement), which is the same stop point the old ParentEl walk had.
+        // DomDocument (not a Broiler.Dom.DomElement), which is the same stop point the old ParentEl walk had.
         // A detached text node roots to itself (returned as a DomNode).
-        while (current.ParentNode is DomElement parent)
+        while (current.ParentNode is Broiler.Dom.DomElement parent)
             current = parent;
         return current;
     }
@@ -56,15 +56,15 @@ public sealed partial class DomBridge
         if (ReferenceEquals(root, _documentNode))
             return _documentJSObject ?? JSNull.Value;
 
-        if (root is DomElement rootEl && IsSubDocRoot(rootEl) && _docRootToDocJSObject.TryGetValue(rootEl, out var subDocument))
+        if (root is Broiler.Dom.DomElement rootEl && IsSubDocRoot(rootEl) && _docRootToDocJSObject.TryGetValue(rootEl, out var subDocument))
             return subDocument;
 
         return ToJSObject(root);
     }
 
-    private DomElement? GetSlotHost(DomElement slot) => GetShadowHost(FindContainingShadowRoot(slot));
+    private Broiler.Dom.DomElement? GetSlotHost(Broiler.Dom.DomElement slot) => GetShadowHost(FindContainingShadowRoot(slot));
 
-    private static bool SlotAcceptsNode(DomElement slot, DomElement node)
+    private static bool SlotAcceptsNode(Broiler.Dom.DomElement slot, Broiler.Dom.DomElement node)
     {
         var slotName = GetAttr(slot, "name");
         var nodeSlot = GetAttr(node, "slot");
@@ -73,7 +73,7 @@ public sealed partial class DomBridge
             : string.Equals(slotName, nodeSlot, StringComparison.OrdinalIgnoreCase);
     }
 
-    private DomElement? FindAssignedSlot(DomElement root, DomElement node)
+    private Broiler.Dom.DomElement? FindAssignedSlot(Broiler.Dom.DomElement root, Broiler.Dom.DomElement node)
     {
         foreach (var child in ChildElements(root))
         {
@@ -94,7 +94,7 @@ public sealed partial class DomBridge
         return null;
     }
 
-    private DomElement? GetAssignedSlot(DomElement element)
+    private Broiler.Dom.DomElement? GetAssignedSlot(Broiler.Dom.DomElement element)
     {
         if (IsText(element) || ParentEl(element) == null)
             return null;
@@ -103,7 +103,7 @@ public sealed partial class DomBridge
         return shadowRoot != null ? FindAssignedSlot(shadowRoot, element) : null;
     }
 
-    private DomElement? GetScrollTraversalParent(DomElement element)
+    private Broiler.Dom.DomElement? GetScrollTraversalParent(Broiler.Dom.DomElement element)
     {
         var assignedSlot = GetAssignedSlot(element);
         if (assignedSlot != null)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SharedLayoutGeometry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SharedLayoutGeometry.cs
@@ -44,7 +44,7 @@ public sealed partial class DomBridge
     /// the caller falls back to the estimator. Active only when
     /// <see cref="UseSharedLayoutGeometry"/> is set; the live entry points gate on that.
     /// </summary>
-    private bool TryGetSharedLayoutGeometry(DomElement element, out BoxGeometry geometry)
+    private bool TryGetSharedLayoutGeometry(Broiler.Dom.DomElement element, out BoxGeometry geometry)
     {
         var snapshot = _sharedGeometrySnapshot ??= BuildSharedGeometrySnapshot();
         return snapshot.TryGetValue(element, out geometry);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
@@ -16,11 +16,11 @@ namespace Broiler.HtmlBridge;
 public sealed partial class DomBridge
 {
     /// <summary>Cache for stylesheet objects, keyed by the owning style element.</summary>
-    private readonly Dictionary<DomElement, JSObject> _styleSheetCache = [];
+    private readonly Dictionary<Broiler.Dom.DomElement, JSObject> _styleSheetCache = [];
 
-    private JSArray BuildStyleSheetsCollection(DomElement docRoot)
+    private JSArray BuildStyleSheetsCollection(Broiler.Dom.DomElement docRoot)
     {
-        var styleEls = new List<DomElement>();
+        var styleEls = new List<Broiler.Dom.DomElement>();
         CollectStyleElements(docRoot, styleEls);
 
         var arr = new JSArray();
@@ -34,7 +34,7 @@ public sealed partial class DomBridge
     }
 
     /// <summary>Collects all style elements in the sub-tree.</summary>
-    private static void CollectStyleElements(DomElement root, List<DomElement> results)
+    private static void CollectStyleElements(Broiler.Dom.DomElement root, List<Broiler.Dom.DomElement> results)
     {
         foreach (var child in ChildElements(root))
         {
@@ -49,7 +49,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Returns <c>true</c> if the element is a <c>&lt;link rel="stylesheet" href="..."&gt;</c>.
     /// </summary>
-    private static bool IsExternalStylesheet(DomElement element)
+    private static bool IsExternalStylesheet(Broiler.Dom.DomElement element)
     {
         if (!string.Equals(element.TagName, "link", StringComparison.OrdinalIgnoreCase))
             return false;
@@ -64,7 +64,7 @@ public sealed partial class DomBridge
     /// Cached per style element to ensure identity (the same object is returned
     /// each time, making cssRules a live collection per the CSSOM spec).
     /// </summary>
-    private JSObject BuildStyleSheetObject(DomElement styleElement)
+    private JSObject BuildStyleSheetObject(Broiler.Dom.DomElement styleElement)
     {
         if (_styleSheetCache.TryGetValue(styleElement, out var cached))
             return cached;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocumentObjects.cs
@@ -10,7 +10,7 @@ namespace Broiler.HtmlBridge;
 
 public sealed partial class DomBridge
 {
-    private JSObject BuildSubDocument(DomElement docRoot)
+    private JSObject BuildSubDocument(Broiler.Dom.DomElement docRoot)
     {
         var doc = new JSObject();
         _docRootToDocJSObject[docRoot] = doc;
@@ -294,7 +294,7 @@ public sealed partial class DomBridge
     }
 
     /// <summary>Finds the first element in a sub-tree matching a predicate.</summary>
-    private DomElement? FindInSubTree(DomElement root, Func<DomElement, bool> predicate)
+    private Broiler.Dom.DomElement? FindInSubTree(Broiler.Dom.DomElement root, Func<Broiler.Dom.DomElement, bool> predicate)
     {
         foreach (var child in ChildElements(root))
         {
@@ -307,7 +307,7 @@ public sealed partial class DomBridge
     }
 
     /// <summary>Finds the first element in a tree matching a predicate (includes the root).</summary>
-    private static DomElement? FindInTree(DomElement root, Func<DomElement, bool> predicate)
+    private static Broiler.Dom.DomElement? FindInTree(Broiler.Dom.DomElement root, Func<Broiler.Dom.DomElement, bool> predicate)
     {
         if (predicate(root)) return root;
         foreach (var child in ChildElements(root))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -12,14 +12,14 @@ namespace Broiler.HtmlBridge;
 public sealed partial class DomBridge
 {
     // ── Phase 6: Sub-document cache ──────────────────────────────────────────
-    private readonly Dictionary<DomElement, JSObject> _subDocumentCache = [];
-    private readonly Dictionary<DomElement, JSObject> _subWindowCache = [];
-    private readonly Dictionary<DomElement, string> _subDocumentLocationCache = [];
-    private readonly Dictionary<DomElement, string> _subDocumentBaseUrlCache = [];
-    private readonly HashSet<DomElement> _objectLoadFailures = [];
-    private readonly HashSet<DomElement> _onloadFired = [];
+    private readonly Dictionary<Broiler.Dom.DomElement, JSObject> _subDocumentCache = [];
+    private readonly Dictionary<Broiler.Dom.DomElement, JSObject> _subWindowCache = [];
+    private readonly Dictionary<Broiler.Dom.DomElement, string> _subDocumentLocationCache = [];
+    private readonly Dictionary<Broiler.Dom.DomElement, string> _subDocumentBaseUrlCache = [];
+    private readonly HashSet<Broiler.Dom.DomElement> _objectLoadFailures = [];
+    private readonly HashSet<Broiler.Dom.DomElement> _onloadFired = [];
 
-    private void InvalidateCachedSubDocument(DomElement containerElement)
+    private void InvalidateCachedSubDocument(Broiler.Dom.DomElement containerElement)
     {
         var existingDocRoot = ChildElements(containerElement).FirstOrDefault(child =>
             string.Equals(child.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase));
@@ -41,7 +41,7 @@ public sealed partial class DomBridge
     /// Handles both property-based handlers (element.onload = function) and
     /// attribute-based handlers (setAttribute("onload", code)).
     /// </summary>
-    private void FireSubDocumentOnload(DomElement element)
+    private void FireSubDocumentOnload(Broiler.Dom.DomElement element)
     {
         if (_jsContext == null) return;
         if (_onloadFired.Contains(element)) return;
@@ -77,7 +77,7 @@ public sealed partial class DomBridge
     /// Recursively fires onload for all iframe/object descendants of an element.
     /// Called when a subtree containing iframes/objects is added to the document.
     /// </summary>
-    private void FireDescendantOnloads(DomElement element)
+    private void FireDescendantOnloads(Broiler.Dom.DomElement element)
     {
         // Snapshot before iterating: FireSubDocumentOnload runs a sub-document's
         // onload handler, whose script can structurally mutate element.Children
@@ -101,7 +101,7 @@ public sealed partial class DomBridge
     /// failed to load (HTTP 404, file not found, etc.), meaning fallback content
     /// should be visible and contentDocument should return null.
     /// </summary>
-    private bool IsObjectLoadFailed(DomElement objectElement)
+    private bool IsObjectLoadFailed(Broiler.Dom.DomElement objectElement)
     {
         if (_objectLoadFailures.Contains(objectElement))
             return true;
@@ -127,7 +127,7 @@ public sealed partial class DomBridge
     /// For same-origin HTTP/HTTPS resources, attempts to fetch and parse the content.
     /// Non-HTML resources (by extension or Content-Type) get a minimal empty document.
     /// </summary>
-    internal JSObject GetOrCreateSubDocument(DomElement containerElement)
+    internal JSObject GetOrCreateSubDocument(Broiler.Dom.DomElement containerElement)
     {
         if (_subDocumentCache.TryGetValue(containerElement, out var cached))
             return cached;
@@ -197,7 +197,7 @@ public sealed partial class DomBridge
         return doc;
     }
 
-    private JSObject GetOrCreateSubWindow(DomElement containerElement)
+    private JSObject GetOrCreateSubWindow(Broiler.Dom.DomElement containerElement)
     {
         if (_subWindowCache.TryGetValue(containerElement, out var cached))
             return cached;
@@ -330,7 +330,7 @@ public sealed partial class DomBridge
         return subWindow;
     }
 
-    private string GetSubWindowLocationHref(DomElement containerElement)
+    private string GetSubWindowLocationHref(Broiler.Dom.DomElement containerElement)
     {
         if (_subDocumentLocationCache.TryGetValue(containerElement, out var cachedLocation) &&
             !string.IsNullOrWhiteSpace(cachedLocation))
@@ -346,13 +346,13 @@ public sealed partial class DomBridge
         return !string.IsNullOrWhiteSpace(resolvedUrl) ? resolvedUrl : "about:blank";
     }
 
-    private double GetSubWindowScrollOffset(DomElement containerElement, bool vertical)
+    private double GetSubWindowScrollOffset(Broiler.Dom.DomElement containerElement, bool vertical)
     {
         var scrollingElement = GetSubDocumentScrollingElement(containerElement);
         return scrollingElement == null ? 0 : GetElementScrollOffset(scrollingElement, vertical);
     }
 
-    private void SetSubWindowScrollOffsets(DomElement containerElement, double? left = null, double? top = null, bool relative = false, string? behavior = null)
+    private void SetSubWindowScrollOffsets(Broiler.Dom.DomElement containerElement, double? left = null, double? top = null, bool relative = false, string? behavior = null)
     {
         var scrollingElement = GetSubDocumentScrollingElement(containerElement);
         if (scrollingElement == null)
@@ -361,7 +361,7 @@ public sealed partial class DomBridge
         SetElementScrollOffsetsWithBehavior(scrollingElement, left, top, relative: relative, clamp: false, behavior: behavior);
     }
 
-    private static DomElement? GetSubDocumentScrollingElement(DomElement containerElement)
+    private static Broiler.Dom.DomElement? GetSubDocumentScrollingElement(Broiler.Dom.DomElement containerElement)
     {
         var docRoot = ChildElements(containerElement).FirstOrDefault(c =>
             string.Equals(c.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase));
@@ -371,12 +371,12 @@ public sealed partial class DomBridge
         return ChildElements(docRoot).FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith("#"));
     }
 
-    private static DomElement? FindBodyElement(DomElement documentElement) =>
+    private static Broiler.Dom.DomElement? FindBodyElement(Broiler.Dom.DomElement documentElement) =>
         ChildElements(documentElement).FirstOrDefault(c =>
             !IsText(c) &&
             string.Equals(c.TagName, "body", StringComparison.OrdinalIgnoreCase));
 
-    private JSObject? GetParentWindowForSubDocument(DomElement containerElement)
+    private JSObject? GetParentWindowForSubDocument(Broiler.Dom.DomElement containerElement)
     {
         var ownerDocRoot = GetElementRuntimeState(containerElement).OwnerDocRoot;
         if (ownerDocRoot != null && ParentEl(ownerDocRoot) != null && !ParentEl(ownerDocRoot).TagName.StartsWith("#", StringComparison.Ordinal))
@@ -385,7 +385,7 @@ public sealed partial class DomBridge
         return _windowJSObject;
     }
 
-    private string GetInheritedSubDocumentBaseUrl(DomElement containerElement)
+    private string GetInheritedSubDocumentBaseUrl(Broiler.Dom.DomElement containerElement)
     {
         var ownerDocRoot = GetElementRuntimeState(containerElement).OwnerDocRoot;
         if (ownerDocRoot != null && ParentEl(ownerDocRoot) != null &&
@@ -399,7 +399,7 @@ public sealed partial class DomBridge
         return _pageUrl;
     }
 
-    private string GetSubDocumentBaseUrl(DomElement containerElement)
+    private string GetSubDocumentBaseUrl(Broiler.Dom.DomElement containerElement)
     {
         return _subDocumentBaseUrlCache.TryGetValue(containerElement, out var baseUrl) &&
                !string.IsNullOrWhiteSpace(baseUrl)
@@ -501,7 +501,7 @@ public sealed partial class DomBridge
         return File.Exists(localPath) ? localPath : null;
     }
 
-    private void ExecuteSubDocumentScripts(DomElement containerElement, string html)
+    private void ExecuteSubDocumentScripts(Broiler.Dom.DomElement containerElement, string html)
     {
         if (_jsContext == null || string.IsNullOrWhiteSpace(html))
             return;
@@ -570,7 +570,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Creates a minimal empty sub-document structure (html > head + body).
     /// </summary>
-    private DomElement BuildEmptySubDocument(DomElement containerElement)
+    private Broiler.Dom.DomElement BuildEmptySubDocument(Broiler.Dom.DomElement containerElement)
     {
         var docRoot = CreateBridgeElement("#subdoc-root");
         SetParent(docRoot, containerElement);
@@ -600,7 +600,7 @@ public sealed partial class DomBridge
     /// Creates a sub-document with plain text content wrapped in a <c>&lt;pre&gt;</c> element.
     /// Used for <c>text/plain</c> resources.
     /// </summary>
-    private DomElement BuildSubDocumentWithText(string textContent, DomElement containerElement)
+    private Broiler.Dom.DomElement BuildSubDocumentWithText(string textContent, Broiler.Dom.DomElement containerElement)
     {
         var docRoot = CreateBridgeElement("#subdoc-root");
         SetParent(docRoot, containerElement);
@@ -640,7 +640,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Gets the resource URL for a container element (iframe src or object data).
     /// </summary>
-    private static string GetSubResourceUrl(DomElement containerElement)
+    private static string GetSubResourceUrl(Broiler.Dom.DomElement containerElement)
     {
         var tag = containerElement.TagName?.ToLowerInvariant();
         if (tag == "iframe")
@@ -863,7 +863,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Builds a sub-document tree from fetched HTML content.
     /// </summary>
-    private DomElement BuildSubDocumentFromHtml(string html, DomElement containerElement)
+    private Broiler.Dom.DomElement BuildSubDocumentFromHtml(string html, Broiler.Dom.DomElement containerElement)
     {
         var docRoot = CreateBridgeElement("#subdoc-root");
         SetParent(docRoot, containerElement);
@@ -892,7 +892,7 @@ public sealed partial class DomBridge
     }
 
     /// <summary>
-    /// Recursively adds a DomElement and all its descendants to the element tracking list.
+    /// Recursively adds a Broiler.Dom.DomElement and all its descendants to the element tracking list.
     /// Used by <see cref="BuildSubDocumentFromHtml"/> to register structural elements
     /// (html, head, body) that <see cref="HtmlTreeBuilder"/> does not include in its allElements list.
     /// </summary>
@@ -911,14 +911,14 @@ public sealed partial class DomBridge
     {
         _knownNodes.Remove(node);
         _jsObjectCache.Remove(node);
-        if (node is DomElement element)
+        if (node is Broiler.Dom.DomElement element)
             _styleSheetCache.Remove(element);
 
         foreach (var child in node.ChildNodes)
             RemoveElementsRecursive(child);
     }
 
-    private void NormalizeNode(DomElement node)
+    private void NormalizeNode(Broiler.Dom.DomElement node)
     {
         for (var index = 0; index < node.ChildNodes.Count;)
         {
@@ -926,7 +926,7 @@ public sealed partial class DomBridge
             if (!IsText(child))
             {
                 // Recurse into element children (a comment has no text children to merge).
-                if (child is DomElement childElement)
+                if (child is Broiler.Dom.DomElement childElement)
                     NormalizeNode(childElement);
                 index++;
                 continue;
@@ -951,7 +951,7 @@ public sealed partial class DomBridge
         }
     }
 
-    private void RemoveChildAt(DomElement parent, int index)
+    private void RemoveChildAt(Broiler.Dom.DomElement parent, int index)
     {
         if (index < 0 || index >= parent.ChildNodes.Count)
             return;
@@ -974,13 +974,13 @@ public sealed partial class DomBridge
 
         // RF-BRIDGE-1c Phase F (F3c): canonical character-data nodes (text/comment) have no
         // TagName/attributes — they are equal iff their data matches. Dead on today's homogeneous
-        // facade tree (facade text/comment are DomElement and take the element path below); live
+        // facade tree (facade text/comment are Broiler.Dom.DomElement and take the element path below); live
         // once construction flips to canonical DomText/DomComment.
         if (first is Broiler.Dom.DomCharacterData || second is Broiler.Dom.DomCharacterData)
             return string.Equals(BridgeText(first), BridgeText(second), StringComparison.Ordinal);
 
-        var firstEl = (DomElement)first;
-        var secondEl = (DomElement)second;
+        var firstEl = (Broiler.Dom.DomElement)first;
+        var secondEl = (Broiler.Dom.DomElement)second;
         if (!string.Equals(firstEl.TagName, secondEl.TagName, StringComparison.Ordinal) ||
             !string.Equals(firstEl.NamespaceUri, secondEl.NamespaceUri, StringComparison.Ordinal) ||
             !string.Equals(BridgeText(firstEl), BridgeText(secondEl), StringComparison.Ordinal))
@@ -1011,7 +1011,7 @@ public sealed partial class DomBridge
     /// local name) key maps to the same value and qualified name (the qualified-name
     /// check preserves the prefix sensitivity the snapshot comparison had).
     /// </summary>
-    private static bool CanonicalAttributesAreEqual(DomElement first, DomElement second)
+    private static bool CanonicalAttributesAreEqual(Broiler.Dom.DomElement first, Broiler.Dom.DomElement second)
     {
         if (first.Attributes.Count != second.Attributes.Count)
             return false;
@@ -1039,7 +1039,7 @@ public sealed partial class DomBridge
         return string.Empty;
     }
 
-    private (DomElement Parent, int Index) GetInsertAdjacentTarget(DomElement element, string position)
+    private (Broiler.Dom.DomElement Parent, int Index) GetInsertAdjacentTarget(Broiler.Dom.DomElement element, string position)
     {
         switch (position)
         {
@@ -1061,7 +1061,7 @@ public sealed partial class DomBridge
         }
     }
 
-    private void InsertNodeAt(DomElement parent, Broiler.Dom.DomNode node, int index)
+    private void InsertNodeAt(Broiler.Dom.DomElement parent, Broiler.Dom.DomNode node, int index)
     {
         if (ReferenceEquals(node, parent) || IsDescendant(node, parent))
             ThrowDOMException(_jsContext!, "The new child element contains the parent.", "HierarchyRequestError");
@@ -1094,7 +1094,7 @@ public sealed partial class DomBridge
 
         // RF-BRIDGE-1c Phase F (F3c part 2b): only elements carry a TagName / fire onloads; a
         // canonical char-data node inserts with no sub-document side effects.
-        if (node is DomElement insertedElement)
+        if (node is Broiler.Dom.DomElement insertedElement)
         {
             var insertedTag = insertedElement.TagName?.ToLowerInvariant();
             if (insertedTag == "iframe" || insertedTag == "object")
@@ -1104,7 +1104,7 @@ public sealed partial class DomBridge
         }
     }
 
-    private List<Broiler.Dom.DomNode> BuildAdjacentHtmlNodes(DomElement contextElement, string html)
+    private List<Broiler.Dom.DomNode> BuildAdjacentHtmlNodes(Broiler.Dom.DomElement contextElement, string html)
     {
         var nodes = new List<Broiler.Dom.DomNode>();
         if (string.IsNullOrEmpty(html))
@@ -1139,7 +1139,7 @@ public sealed partial class DomBridge
                 var candidateNode = FindDomNodeByJSObject(candidateObject);
                 if (candidateNode != null)
                 {
-                    if (candidateNode is DomElement candidateElement &&
+                    if (candidateNode is Broiler.Dom.DomElement candidateElement &&
                         string.Equals(candidateElement.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase))
                     {
                         foreach (var fragmentChild in candidateElement.ChildNodes.ToArray())
@@ -1160,7 +1160,7 @@ public sealed partial class DomBridge
         return nodes;
     }
 
-    private void SetElementInnerHtml(DomElement element, string html)
+    private void SetElementInnerHtml(Broiler.Dom.DomElement element, string html)
     {
         html ??= string.Empty;
         GetElementRuntimeState(element).InnerHtml = html;
@@ -1187,7 +1187,7 @@ public sealed partial class DomBridge
         InvalidateStyleScope(element);
     }
 
-    private void SetElementOuterHtml(DomElement element, string html)
+    private void SetElementOuterHtml(Broiler.Dom.DomElement element, string html)
     {
         html ??= string.Empty;
 
@@ -1202,7 +1202,7 @@ public sealed partial class DomBridge
         var previousSibling = index > 0 ? ChildAt(parent, index - 1) : null;
         var nextSibling = index + 1 < parent.ChildNodes.Count ? ChildAt(parent, index + 1) : null;
 
-        DomElement? parsedContainer = null;
+        Broiler.Dom.DomElement? parsedContainer = null;
         if (!string.IsNullOrEmpty(html))
         {
             var parsingContext = parent.TagName.StartsWith("#", StringComparison.Ordinal)
@@ -1235,7 +1235,7 @@ public sealed partial class DomBridge
         InvalidateStyleScope(parent);
     }
 
-    private bool TryBuildInnerHtmlFragmentContainer(DomElement contextElement, string html, out DomElement container)
+    private bool TryBuildInnerHtmlFragmentContainer(Broiler.Dom.DomElement contextElement, string html, out Broiler.Dom.DomElement container)
     {
         container = null!;
 
@@ -1248,7 +1248,7 @@ public sealed partial class DomBridge
         return true;
     }
 
-    private static DomElement? FindFirstElementByTag(DomElement root, string tag)
+    private static Broiler.Dom.DomElement? FindFirstElementByTag(Broiler.Dom.DomElement root, string tag)
     {
         foreach (var child in ChildElements(root))
         {
@@ -1272,7 +1272,7 @@ public sealed partial class DomBridge
     /// For XHTML with valid namespace, also executes embedded scripts.
     /// XML well-formedness errors result in an empty document.
     /// </summary>
-    private DomElement BuildSubDocumentFromXml(string xmlContent, string contentType, DomElement containerElement)
+    private Broiler.Dom.DomElement BuildSubDocumentFromXml(string xmlContent, string contentType, Broiler.Dom.DomElement containerElement)
     {
         var docRoot = CreateBridgeElement("#subdoc-root");
         SetParent(docRoot, containerElement);
@@ -1335,9 +1335,9 @@ public sealed partial class DomBridge
     }
 
     /// <summary>
-    /// Recursively builds a DomElement tree from an XElement.
+    /// Recursively builds a Broiler.Dom.DomElement tree from an XElement.
     /// </summary>
-    private DomElement BuildDomElementFromXElement(System.Xml.Linq.XElement xe)
+    private Broiler.Dom.DomElement BuildDomElementFromXElement(System.Xml.Linq.XElement xe)
     {
         var tagName = xe.Name.LocalName.ToLowerInvariant();
         var el = CreateBridgeElement(tagName);
@@ -1373,7 +1373,7 @@ public sealed partial class DomBridge
     /// Finds and executes script elements within a sub-document tree.
     /// Scripts call parent.notify() etc. in the main JS context.
     /// </summary>
-    private void ExecuteSubDocumentScripts(DomElement docRoot)
+    private void ExecuteSubDocumentScripts(Broiler.Dom.DomElement docRoot)
     {
         if (_jsContext == null) return;
 
@@ -1397,7 +1397,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Recursively collects text content from script elements.
     /// </summary>
-    private static void CollectScriptContent(DomElement element, List<string> scripts)
+    private static void CollectScriptContent(Broiler.Dom.DomElement element, List<string> scripts)
     {
         if (string.Equals(element.TagName, "script", StringComparison.OrdinalIgnoreCase))
         {
@@ -1414,7 +1414,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Gets the concatenated text content of an element and all its descendants.
     /// </summary>
-    private static string GetTextContentRecursive(DomElement element)
+    private static string GetTextContentRecursive(Broiler.Dom.DomElement element)
     {
         // RF-BRIDGE-1c Phase F (F3c part 2d): aggregate descendant text over raw ChildNodes.
         var sb = new StringBuilder();

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
@@ -53,7 +53,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Builds a DOM <c>TreeWalker</c> object.
     /// </summary>
-    private JSObject BuildTreeWalker(DomElement root, int whatToShow, JSFunction? filterFn)
+    private JSObject BuildTreeWalker(Broiler.Dom.DomElement root, int whatToShow, JSFunction? filterFn)
     {
         var tw = new JSObject();
         var walker = new Broiler.Dom.DomTreeWalker(
@@ -133,7 +133,7 @@ public sealed partial class DomBridge
     // RF-BRIDGE-1c Phase F (F3c part 2c): a TreeWalker/NodeIterator result may be a text/comment
     // node (SHOW_TEXT/SHOW_COMMENT), so convert any non-null node — not just elements — to its JS
     // wrapper. Behaviour-preserving today: walker results over the homogeneous facade tree are all
-    // DomElement (text/comment are facade elements); forward-correct once they flip to canonical.
+    // Broiler.Dom.DomElement (text/comment are facade elements); forward-correct once they flip to canonical.
     private JSValue ToTraversalJsValue(Broiler.Dom.DomNode? node) =>
         node is not null ? ToJSObject(node) : JSNull.Value;
 
@@ -227,7 +227,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Builds a DOM <c>NodeIterator</c> object.
     /// </summary>
-    private JSObject BuildNodeIterator(DomElement root, int whatToShow, JSFunction? filterFn)
+    private JSObject BuildNodeIterator(Broiler.Dom.DomElement root, int whatToShow, JSFunction? filterFn)
     {
         var iter = new JSObject();
         var iterator = new Broiler.Dom.DomNodeIterator(
@@ -287,7 +287,7 @@ public sealed partial class DomBridge
     /// Builds a DOM <c>Range</c> object. The <paramref name="documentRoot"/>
     /// is the document node that owns this range (main or sub-document).
     /// </summary>
-    private JSObject BuildRange(DomElement? documentRoot = null)
+    private JSObject BuildRange(Broiler.Dom.DomElement? documentRoot = null)
     {
         var range = new JSObject();
         var docRoot = documentRoot ?? _documentNode;
@@ -598,7 +598,7 @@ public sealed partial class DomBridge
     /// Creates a partial clone for extractContents when a boundary is in a text node.
     /// Clones the ancestor chain from the text node up to (but not including) the common ancestor.
     /// </summary>
-    private static Broiler.Dom.DomNode? CreatePartialCloneForExtract(Broiler.Dom.DomNode textNode, DomElement commonAncestor, string extractedText, bool isStart, DomBridge bridge)
+    private static Broiler.Dom.DomNode? CreatePartialCloneForExtract(Broiler.Dom.DomNode textNode, Broiler.Dom.DomElement commonAncestor, string extractedText, bool isStart, DomBridge bridge)
     {
         // Build the chain: textNode → parent → ... → child-of-commonAncestor. chain[0] is the
         // boundary text node; chain[1..] are ancestor elements (RF-BRIDGE-1c Phase F, F3c part 2d).
@@ -622,12 +622,12 @@ public sealed partial class DomBridge
         }
 
         // Clone the chain (from top to bottom)
-        DomElement? topClone = null;
-        DomElement? currentParent = null;
+        Broiler.Dom.DomElement? topClone = null;
+        Broiler.Dom.DomElement? currentParent = null;
         for (var i = chain.Count - 1; i >= 1; i--)
         {
             // chain[i] for i >= 1 is an ancestor element.
-            var original = (DomElement)chain[i];
+            var original = (Broiler.Dom.DomElement)chain[i];
             var clone = bridge.CreateBridgeElement(original.TagName);
             bridge._knownNodes.Add(clone);
 
@@ -681,7 +681,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Checks if a node is fully contained between start and end containers in the range.
     /// </summary>
-    private static bool IsContainedInRange(DomElement node, DomElement ancestor, DomElement startContainer, DomElement endContainer, List<DomElement> allNodes)
+    private static bool IsContainedInRange(Broiler.Dom.DomElement node, Broiler.Dom.DomElement ancestor, Broiler.Dom.DomElement startContainer, Broiler.Dom.DomElement endContainer, List<Broiler.Dom.DomElement> allNodes)
     {
         // A node is fully contained if it and all its descendants are between start and end
         var nodeIdx = allNodes.IndexOf(node);
@@ -729,7 +729,7 @@ public sealed partial class DomBridge
     {
         // Character-data nodes contribute no client rect here (their text runs are measured
         // elsewhere); after this guard the node is an element.
-        if (IsText(node) || IsComment(node) || node is not DomElement element)
+        if (IsText(node) || IsComment(node) || node is not Broiler.Dom.DomElement element)
             return;
 
         var display = GetComputedProps(element).GetValueOrDefault("display");
@@ -954,7 +954,7 @@ public sealed partial class DomBridge
     {
         // RF-BRIDGE-1c Phase F (F3c part 2b): range boundary points are canonical DomNode —
         // a range commonly starts/ends inside a text node. Behaviour-preserving on today's
-        // homogeneous facade tree (facade text nodes are DomElement, so the DomNode fields hold
+        // homogeneous facade tree (facade text nodes are Broiler.Dom.DomElement, so the DomNode fields hold
         // the same values); forward-correct once text/comment flip to canonical DomText/DomComment.
         public Broiler.Dom.DomNode StartContainer;
         public int StartOffset;
@@ -1024,14 +1024,14 @@ public sealed partial class DomBridge
     /// Notifies all active ranges that a child was removed from <paramref name="parent"/>
     /// at the given <paramref name="index"/>.
     /// </summary>
-    private void NotifyChildAdded(DomElement parent, Broiler.Dom.DomNode addedChild, int index)
+    private void NotifyChildAdded(Broiler.Dom.DomElement parent, Broiler.Dom.DomNode addedChild, int index)
     {
         var previousSibling = index > 0 ? ChildAt(parent, index - 1) : null;
         var nextSibling = index + 1 < parent.ChildNodes.Count ? ChildAt(parent, index + 1) : null;
         NotifyMutationObservers(parent, addedChild, null, previousSibling, nextSibling);
     }
 
-    private void NotifyChildRemoved(DomElement parent, Broiler.Dom.DomNode removedChild, int index, Broiler.Dom.DomNode? previousSibling = null, Broiler.Dom.DomNode? nextSibling = null)
+    private void NotifyChildRemoved(Broiler.Dom.DomElement parent, Broiler.Dom.DomNode removedChild, int index, Broiler.Dom.DomNode? previousSibling = null, Broiler.Dom.DomNode? nextSibling = null)
     {
         for (var i = _activeRanges.Count - 1; i >= 0; i--)
         {
@@ -1047,7 +1047,7 @@ public sealed partial class DomBridge
     }
 
     private void NotifyMutationObservers(
-        DomElement target,
+        Broiler.Dom.DomElement target,
         Broiler.Dom.DomNode? addedChild,
         Broiler.Dom.DomNode? removedChild,
         Broiler.Dom.DomNode? previousSibling,
@@ -1085,7 +1085,7 @@ public sealed partial class DomBridge
         }
     }
 
-    private void NotifyAttributeMutationObservers(DomElement target, string attributeName, string? oldValue)
+    private void NotifyAttributeMutationObservers(Broiler.Dom.DomElement target, string attributeName, string? oldValue)
     {
         if (_mutationObservers.Count == 0)
             return;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -19,8 +19,6 @@ namespace Broiler.HtmlBridge;
 /// </summary>
 public sealed partial class DomBridge
 {
-    private static readonly System.Text.RegularExpressions.Regex ImportantSuffixPattern = new(@"\s*!\s*important\s*$",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly HashSet<string> CssStyleDeclarationNonCssNames = new(StringComparer.Ordinal)
     {
         "setProperty", "getPropertyValue", "removeProperty",
@@ -28,42 +26,10 @@ public sealed partial class DomBridge
         "item", "getPropertyPriority",
     };
 
-    private static string ToCamelCaseStatic(string cssName)
-    {
-        var sb = new StringBuilder();
-        bool upper = false;
-        foreach (char c in cssName)
-        {
-            if (c == '-') { upper = true; continue; }
-            sb.Append(upper ? char.ToUpperInvariant(c) : c);
-            upper = false;
-        }
-        return sb.ToString();
-    }
-
-    /// <summary>Converts JS camelCase property names to CSS kebab-case.</summary>
-    private static string ToKebabCase(string camelName)
-    {
-        var sb = new StringBuilder();
-        foreach (char c in camelName)
-        {
-            if (char.IsUpper(c))
-            {
-                sb.Append('-');
-                sb.Append(char.ToLowerInvariant(c));
-            }
-            else
-            {
-                sb.Append(c);
-            }
-        }
-        return sb.ToString();
-    }
-
     /// <summary>
-    /// Parses a DOCTYPE declaration and creates a DomElement representing the DocumentType node.
+    /// Parses a DOCTYPE declaration and creates a Broiler.Dom.DomElement representing the DocumentType node.
     /// </summary>
-    private DomElement? ParseDocType(string html)
+    private Broiler.Dom.DomElement? ParseDocType(string html)
     {
         var match = DocTypePattern.Match(html);
         if (!match.Success) return null;
@@ -81,8 +47,8 @@ public sealed partial class DomBridge
         return doctype;
     }
 
-    /// <summary>Gets the lowercase name from a DOCTYPE DomElement.</summary>
-    private static string GetDocTypeName(DomElement element)
+    /// <summary>Gets the lowercase name from a DOCTYPE Broiler.Dom.DomElement.</summary>
+    private static string GetDocTypeName(Broiler.Dom.DomElement element)
     {
         var dtName = GetElementRuntimeState(element).DocumentType.Name.TryGet(out var n) ? n?.ToString() ?? "html" : "html";
         return dtName.ToLowerInvariant();
@@ -91,7 +57,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Searches descendants of an element using a CSS selector.
     /// </summary>
-    private static JSValue FindInDescendants(DomElement root, string selector, bool all, DomBridge bridge)
+    private static JSValue FindInDescendants(Broiler.Dom.DomElement root, string selector, bool all, DomBridge bridge)
     {
         var results = new List<JSValue>();
         if (selector.IndexOf(":scope", StringComparison.Ordinal) >= 0 &&
@@ -107,7 +73,7 @@ public sealed partial class DomBridge
         return results.Count > 0 ? results[0] : JSNull.Value;
     }
 
-    private static void SearchDescendants(DomElement parent, string selector, List<JSValue> results, DomBridge bridge, bool all, DomElement scope)
+    private static void SearchDescendants(Broiler.Dom.DomElement parent, string selector, List<JSValue> results, DomBridge bridge, bool all, Broiler.Dom.DomElement scope)
     {
         foreach (var child in ChildElements(parent))
         {
@@ -296,11 +262,11 @@ public sealed partial class DomBridge
     }
 
     /// <summary>
-    /// Finds the <see cref="DomElement"/> corresponding to a given <see cref="JSObject"/>
+    /// Finds the <see cref="Broiler.Dom.DomElement"/> corresponding to a given <see cref="JSObject"/>
     /// by looking up the JS object cache.
     /// </summary>
-    private DomElement? FindDomElementByJSObject(JSObject jsObj) =>
-        FindDomNodeByJSObject(jsObj) as DomElement;
+    private Broiler.Dom.DomElement? FindDomElementByJSObject(JSObject jsObj) =>
+        FindDomNodeByJSObject(jsObj) as Broiler.Dom.DomElement;
 
     /// <summary>
     /// Finds the canonical <see cref="Broiler.Dom.DomNode"/> corresponding to a given
@@ -318,7 +284,7 @@ public sealed partial class DomBridge
         return null;
     }
 
-    private static bool IsSubDocRoot(DomElement element) =>
+    private static bool IsSubDocRoot(Broiler.Dom.DomElement element) =>
         string.Equals(element.TagName, "#subdoc-root", StringComparison.Ordinal);
 
     /// <summary>
@@ -389,7 +355,7 @@ public sealed partial class DomBridge
     /// Nested sub-document roots remain isolated browsing contexts and are not
     /// re-owned by the outer document.
     /// </summary>
-    private static void AdoptSubtreeIntoDocument(Broiler.Dom.DomNode node, DomElement? ownerDocRoot)
+    private static void AdoptSubtreeIntoDocument(Broiler.Dom.DomNode node, Broiler.Dom.DomElement? ownerDocRoot)
     {
         GetElementRuntimeState(node).OwnerDocRoot = ownerDocRoot;
 
@@ -397,7 +363,7 @@ public sealed partial class DomBridge
         // too. Behaviour-preserving on today's homogeneous tree (every child is an element).
         foreach (var child in node.ChildNodes)
         {
-            if (child is DomElement childElement && IsSubDocRoot(childElement))
+            if (child is Broiler.Dom.DomElement childElement && IsSubDocRoot(childElement))
                 continue;
 
             AdoptSubtreeIntoDocument(child, ownerDocRoot);
@@ -405,14 +371,14 @@ public sealed partial class DomBridge
     }
 
     /// <summary>
-    /// Clones a <see cref="DomElement"/>. When <paramref name="deep"/> is true,
+    /// Clones a <see cref="Broiler.Dom.DomElement"/>. When <paramref name="deep"/> is true,
     /// all descendants are recursively cloned.
     /// </summary>
     private Broiler.Dom.DomNode CloneDomElement(Broiler.Dom.DomNode source, bool deep)
     {
         // RF-BRIDGE-1c Phase F (F3c): canonical character-data nodes clone via the document
         // factories (DomText/DomComment ctors are internal). Dead on today's homogeneous facade
-        // tree — facade text/comment nodes are DomElement and take the element path below; live
+        // tree — facade text/comment nodes are Broiler.Dom.DomElement and take the element path below; live
         // once text/comment construction flips to canonical DomText/DomComment.
         if (source is Broiler.Dom.DomCharacterData sourceCharData)
         {
@@ -421,7 +387,7 @@ public sealed partial class DomBridge
                 : _document.CreateTextNode(sourceCharData.Data);
         }
 
-        var element = (DomElement)source;
+        var element = (Broiler.Dom.DomElement)source;
         // Preserve the source element's exact namespace (folds the old post-construction
         // `clone.NamespaceURI = element.NamespaceURI` — see below); SVG/foreign clones keep
         // their namespace rather than defaulting to HTML.
@@ -478,9 +444,9 @@ public sealed partial class DomBridge
     /// Collects all &lt;tr&gt; elements in a table in HTML spec order:
     /// 1. thead rows, 2. tbody rows + direct tr children (in tree order), 3. tfoot rows.
     /// </summary>
-    private static List<DomElement> CollectTableRows(DomElement table)
+    private static List<Broiler.Dom.DomElement> CollectTableRows(Broiler.Dom.DomElement table)
     {
-        var rows = new List<DomElement>();
+        var rows = new List<Broiler.Dom.DomElement>();
         // 1. All tr children of thead elements (in tree order)
         foreach (var child in ChildElements(table))
         {
@@ -514,7 +480,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Builds a JSArray of table rows for the 'rows' property.
     /// </summary>
-    private JSArray BuildTableRows(DomElement table)
+    private JSArray BuildTableRows(Broiler.Dom.DomElement table)
     {
         var rows = CollectTableRows(table);
         var jsRows = new List<JSValue>();
@@ -531,7 +497,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Inserts a row into a table at the given index, per HTMLTableElement.insertRow() spec.
     /// </summary>
-    private JSValue InsertTableRow(DomElement table, int index, DomBridge bridge)
+    private JSValue InsertTableRow(Broiler.Dom.DomElement table, int index, DomBridge bridge)
     {
         var tr = CreateBridgeElement("tr");
         bridge._knownNodes.Add(tr);
@@ -540,10 +506,10 @@ public sealed partial class DomBridge
         if (allRows.Count == 0 || index == -1 || index == allRows.Count)
         {
             // Find the last section to append to, or create a tbody
-            DomElement? lastSection = null;
+            Broiler.Dom.DomElement? lastSection = null;
             for (int i = table.ChildNodes.Count - 1; i >= 0; i--)
             {
-                if (ChildAt(table, i) is not DomElement childElement)
+                if (ChildAt(table, i) is not Broiler.Dom.DomElement childElement)
                     continue;
                 var ctag = childElement.TagName.ToLowerInvariant();
                 if (ctag == "thead" || ctag == "tbody" || ctag == "tfoot")
@@ -586,14 +552,14 @@ public sealed partial class DomBridge
     /// <summary>
     /// Collects form control elements (input, select, textarea, button) from a form.
     /// </summary>
-    internal static List<DomElement> CollectFormControls(DomElement form)
+    internal static List<Broiler.Dom.DomElement> CollectFormControls(Broiler.Dom.DomElement form)
     {
-        var controls = new List<DomElement>();
+        var controls = new List<Broiler.Dom.DomElement>();
         CollectFormControlsRecursive(form, controls);
         return controls;
     }
 
-    private static void CollectFormControlsRecursive(DomElement parent, List<DomElement> controls)
+    private static void CollectFormControlsRecursive(Broiler.Dom.DomElement parent, List<Broiler.Dom.DomElement> controls)
     {
         foreach (var child in ChildElements(parent))
         {
@@ -608,7 +574,7 @@ public sealed partial class DomBridge
     /// Recursively unchecks all radio inputs with the given name within the scope,
     /// except for the specified element. Used for radio button mutual exclusion.
     /// </summary>
-    private static void UncheckRadioSiblings(DomElement scope, DomElement except, string radioName)
+    private static void UncheckRadioSiblings(Broiler.Dom.DomElement scope, Broiler.Dom.DomElement except, string radioName)
     {
         foreach (var child in ChildElements(scope))
         {
@@ -630,7 +596,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Builds a form.elements collection (JSObject with indexed + named access).
     /// </summary>
-    private JSValue BuildFormElementsCollection(DomElement form, DomBridge bridge)
+    private JSValue BuildFormElementsCollection(Broiler.Dom.DomElement form, DomBridge bridge)
     {
         var controls = CollectFormControls(form);
 
@@ -662,7 +628,7 @@ public sealed partial class DomBridge
         {
             // Skip sub-document roots — they are separate document trees
             // and must not be traversed as part of the parent document.
-            if (child is DomElement childElement && IsSubDocRoot(childElement))
+            if (child is Broiler.Dom.DomElement childElement && IsSubDocRoot(childElement))
                 continue;
             result.Add(child);
             CollectDescendants(child, result);
@@ -688,7 +654,7 @@ public sealed partial class DomBridge
     /// <summary>
     /// Collects descendant elements matching a tag name in tree order (depth-first).
     /// </summary>
-    private static void CollectDescendantsByTag(DomElement root, string tagName, List<JSValue> results, DomBridge bridge)
+    private static void CollectDescendantsByTag(Broiler.Dom.DomElement root, string tagName, List<JSValue> results, DomBridge bridge)
     {
         foreach (var child in ChildElements(root))
         {
@@ -710,13 +676,13 @@ public sealed partial class DomBridge
     }
 
     /// <summary>
-    /// Returns the node type constant for a <see cref="DomElement"/>.
+    /// Returns the node type constant for a <see cref="Broiler.Dom.DomElement"/>.
     /// </summary>
     private static int GetNodeType(Broiler.Dom.DomNode node)
     {
         if (IsText(node)) return 3; // TEXT_NODE
         if (IsComment(node)) return 8;
-        if (node is not DomElement element) return 1;
+        if (node is not Broiler.Dom.DomElement element) return 1;
         if (string.Equals(element.TagName, "#document", StringComparison.OrdinalIgnoreCase)) return 9;
         if (string.Equals(element.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase)) return 11;
         return 1; // ELEMENT_NODE
@@ -737,13 +703,13 @@ public sealed partial class DomBridge
     /// </summary>
     private sealed class CssStyleDeclaration : JSObject
     {
-        private readonly DomElement _element;
+        private readonly Broiler.Dom.DomElement _element;
         private readonly Action? _onMutation;
 
         // Names that are JS methods / special properties, not CSS properties.
         private static HashSet<string> NonCssNames => CssStyleDeclarationNonCssNames;
 
-        public CssStyleDeclaration(DomElement element, Action? onMutation = null)
+        public CssStyleDeclaration(Broiler.Dom.DomElement element, Action? onMutation = null)
         {
             _element = element;
             _onMutation = onMutation;
@@ -755,7 +721,7 @@ public sealed partial class DomBridge
             var nameStr = name.ToString();
             if (!NonCssNames.Contains(nameStr))
             {
-                var kebab = ToKebabCase(nameStr);
+                var kebab = Broiler.CSS.CssPropertyNames.ToCssPropertyName(nameStr);
                 var val = value?.ToString() ?? string.Empty;
                 if (string.IsNullOrEmpty(val))
                 {
@@ -792,7 +758,7 @@ public sealed partial class DomBridge
             if (!NonCssNames.Contains(nameStr))
             {
                 if (TryGetStylePropertyRawValue(_element, nameStr, out var val))
-                    return new JSString(StripCssPriority(val));
+                    return new JSString(Broiler.CSS.CssPriority.Strip(val));
             }
 
             return new JSString(string.Empty);
@@ -811,7 +777,7 @@ public sealed partial class DomBridge
             var nameStr = name.ToString();
             if (!CssStyleDeclarationNonCssNames.Contains(nameStr))
             {
-                var kebab = ToKebabCase(nameStr);
+                var kebab = Broiler.CSS.CssPropertyNames.ToCssPropertyName(nameStr);
                 var val = value?.ToString() ?? string.Empty;
                 if (string.IsNullOrEmpty(val))
                     _style.Remove(kebab);
@@ -833,31 +799,20 @@ public sealed partial class DomBridge
             if (!CssStyleDeclarationNonCssNames.Contains(nameStr) &&
                 TryGetStylePropertyRawValue(_style, nameStr, out var val))
             {
-                return new JSString(StripCssPriority(val));
+                return new JSString(Broiler.CSS.CssPriority.Strip(val));
             }
 
             return new JSString(string.Empty);
         }
     }
 
-    private static string StripCssPriority(string? value)
-        => string.IsNullOrEmpty(value) ? string.Empty : ImportantSuffixPattern.Replace(value, string.Empty).Trim();
-
-    private static string GetCssPriority(string? value)
-        => !string.IsNullOrEmpty(value) && ImportantSuffixPattern.IsMatch(value) ? "important" : string.Empty;
-
-    private static string ApplyCssPriority(string value, string priority)
-        => string.Equals(priority?.Trim(), "important", StringComparison.OrdinalIgnoreCase)
-            ? $"{StripCssPriority(value)} !important".Trim()
-            : StripCssPriority(value);
-
     private static List<string> GetStylePropertyNames(IReadOnlyDictionary<string, string> style)
         => style.Keys.ToList();
 
-    private static List<string> GetStylePropertyNames(DomElement element)
+    private static List<string> GetStylePropertyNames(Broiler.Dom.DomElement element)
         => GetStylePropertyNames((IReadOnlyDictionary<string, string>)InlineStyle(element));
 
-    private static Dictionary<string, string> BuildDeclaredInlineStyleMap(DomElement element)
+    private static Dictionary<string, string> BuildDeclaredInlineStyleMap(Broiler.Dom.DomElement element)
     {
         var declared = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -877,7 +832,7 @@ public sealed partial class DomBridge
         return declared;
     }
 
-    private static bool TryGetExpandedInlineStyleRawValue(DomElement element, string property, out string value)
+    private static bool TryGetExpandedInlineStyleRawValue(Broiler.Dom.DomElement element, string property, out string value)
     {
         var declared = BuildDeclaredInlineStyleMap(element);
         if (declared.Count == 0)
@@ -891,11 +846,11 @@ public sealed partial class DomBridge
         if (declared.TryGetValue(property, out value!))
             return true;
 
-        var camel = ToCamelCaseStatic(property);
+        var camel = Broiler.CSS.CssPropertyNames.ToDomPropertyName(property);
         if (camel != property && declared.TryGetValue(camel, out value!))
             return true;
 
-        var kebab = ToKebabCase(property);
+        var kebab = Broiler.CSS.CssPropertyNames.ToCssPropertyName(property);
         if (kebab != property && declared.TryGetValue(kebab, out value!))
             return true;
 
@@ -908,11 +863,11 @@ public sealed partial class DomBridge
         if (style.TryGetValue(property, out value!))
             return true;
 
-        var camel = ToCamelCaseStatic(property);
+        var camel = Broiler.CSS.CssPropertyNames.ToDomPropertyName(property);
         if (camel != property && style.TryGetValue(camel, out value!))
             return true;
 
-        var kebab = ToKebabCase(property);
+        var kebab = Broiler.CSS.CssPropertyNames.ToCssPropertyName(property);
         if (kebab != property && style.TryGetValue(kebab, out value!))
             return true;
 
@@ -920,7 +875,7 @@ public sealed partial class DomBridge
         return false;
     }
 
-    private static bool TryGetStylePropertyRawValue(DomElement element, string property, out string value)
+    private static bool TryGetStylePropertyRawValue(Broiler.Dom.DomElement element, string property, out string value)
     {
         if (TryGetStylePropertyRawValue((IReadOnlyDictionary<string, string>)InlineStyle(element), property, out value!))
             return true;
@@ -928,7 +883,7 @@ public sealed partial class DomBridge
         return TryGetExpandedInlineStyleRawValue(element, property, out value!);
     }
 
-    private static JSObject BuildStyleObject(DomElement element, Action? onMutation = null, JSValue? parentRule = null)
+    private static JSObject BuildStyleObject(Broiler.Dom.DomElement element, Action? onMutation = null, JSValue? parentRule = null)
     {
         var style = new CssStyleDeclaration(element, onMutation);
 
@@ -1054,7 +1009,7 @@ public sealed partial class DomBridge
     /// Builds a <c>classList</c> object exposing <c>add</c>, <c>remove</c>,
     /// <c>toggle</c>, and <c>contains</c>.
     /// </summary>
-    private static JSObject BuildClassListObject(DomElement element, Action<DomElement>? onClassChanged = null)
+    private static JSObject BuildClassListObject(Broiler.Dom.DomElement element, Action<Broiler.Dom.DomElement>? onClassChanged = null)
     {
         var classList = new JSObject();
 
@@ -1135,7 +1090,7 @@ public sealed partial class DomBridge
     /// operations as defined in the HTML Canvas 2D Context specification.
     /// Drawing commands are recorded but not rasterised in the current implementation.
     /// </summary>
-    private static JSObject BuildCanvas2DContext(DomElement canvas)
+    private static JSObject BuildCanvas2DContext(Broiler.Dom.DomElement canvas)
     {
         var ctx = new JSObject();
         int width = 300, height = 150;

--- a/src/Broiler.HtmlBridge.Dom/GlobalUsings.cs
+++ b/src/Broiler.HtmlBridge.Dom/GlobalUsings.cs
@@ -1,8 +1,0 @@
-// RF-BRIDGE-1c Phase F4 (final cutover): the compatibility facade
-// Broiler.HtmlBridge.DomElement has been deleted. The bridge builds its entire tree
-// from canonical Broiler.Dom nodes now; this alias re-points every unqualified
-// `DomElement` in this assembly at the canonical type so the ~900 element-handling
-// sites resolve to Broiler.Dom.DomElement without per-site edits. Element construction
-// funnels through DomBridge.CreateBridgeElement / CreateBridgeElementNS over the
-// document factories (CreateElement / CreateElementNS).
-global using DomElement = Broiler.Dom.DomElement;

--- a/src/Broiler.Wpt.Tests/Broiler.Wpt.Tests.csproj
+++ b/src/Broiler.Wpt.Tests/Broiler.Wpt.Tests.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Broiler.Wpt\Broiler.Wpt.csproj" />
-    <ProjectReference Include="..\Broiler.HtmlBridge\Broiler.HtmlBridge.csproj" />
+    <ProjectReference Include="..\Broiler.HtmlBridge.Dom\Broiler.HtmlBridge.Dom.csproj" />
     <ProjectReference Include="..\..\Broiler.JS\Broiler.JS\Broiler.JavaScript.Engine\Broiler.JavaScript.Engine.csproj" />
   </ItemGroup>
 

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -8166,9 +8166,10 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
         Assert.NotNull(targetEl);
 
         // Target should be hidden because anchor is scrolled out
+        var targetStyle = Broiler.HtmlBridge.DomBridge.GetInlineStyleView(targetEl!);
         Assert.True(
-            targetEl!.Style.TryGetValue("display", out var d) && d == "none",
-            $"Expected target display:none but styles = [{string.Join(", ", targetEl.Style.Select(kv => $"{kv.Key}:{kv.Value}"))}]");
+            targetStyle.TryGetValue("display", out var d) && d == "none",
+            $"Expected target display:none but styles = [{string.Join(", ", targetStyle.Select(kv => $"{kv.Key}:{kv.Value}"))}]");
     }
 
     [Fact]
@@ -8201,8 +8202,9 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
         // The abspos child is promoted out of the inline containing block (#ic) to
         // its nearest block-level ancestor (#block), since Broiler's renderer cannot
         // place an abspos box inside an inline box.
-        Assert.NotNull(abs!.Parent);
-        Assert.Equal("block", abs!.Parent!.Id);
+        var absParent = abs!.ParentNode as Broiler.Dom.DomElement;
+        Assert.NotNull(absParent);
+        Assert.Equal("block", absParent!.Id);
     }
 
     [Fact]
@@ -9981,10 +9983,11 @@ iframe {
         if (bridge.TryGetResolvedLayout(el, out var left, out var top, out var width, out var height))
             return (left, top, width, height);
 
-        left = el.Style.TryGetValue("left", out var ls) && double.TryParse(ls.Replace("px", ""), out var lv) ? lv : 0;
-        top = el.Style.TryGetValue("top", out var ts) && double.TryParse(ts.Replace("px", ""), out var tv) ? tv : 0;
-        width = el.Style.TryGetValue("width", out var ws) && double.TryParse(ws.Replace("px", ""), out var wv) ? wv : 0;
-        height = el.Style.TryGetValue("height", out var hs) && double.TryParse(hs.Replace("px", ""), out var hv) ? hv : 0;
+        var style = Broiler.HtmlBridge.DomBridge.GetInlineStyleView(el);
+        left = style.TryGetValue("left", out var ls) && double.TryParse(ls.Replace("px", ""), out var lv) ? lv : 0;
+        top = style.TryGetValue("top", out var ts) && double.TryParse(ts.Replace("px", ""), out var tv) ? tv : 0;
+        width = style.TryGetValue("width", out var ws) && double.TryParse(ws.Replace("px", ""), out var wv) ? wv : 0;
+        height = style.TryGetValue("height", out var hs) && double.TryParse(hs.Replace("px", ""), out var hv) ? hv : 0;
 
         return (left, top, width, height);
     }
@@ -10049,7 +10052,7 @@ iframe {
         // The anchor has right:-50px, top:-50px, width:100, height:100
         // in a 400x400 container → left = 400 - (-50) - 100 = 350, top = -50
         var anchorProps = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var kv in anchor!.Style)
+        foreach (var kv in Broiler.HtmlBridge.DomBridge.GetInlineStyleView(anchor!))
             anchorProps[kv.Key] = kv.Value;
 
         // Debug: show the anchor's resolved styles
@@ -10062,7 +10065,7 @@ iframe {
         FindDomElement(bridge.DocumentElement, "anchored", ref anchored);
 
         var anchoredStyleStr = anchored != null
-            ? string.Join(", ", anchored.Style.Select(kv => $"{kv.Key}:{kv.Value}"))
+            ? string.Join(", ", Broiler.HtmlBridge.DomBridge.GetInlineStyleView(anchored).Select(kv => $"{kv.Key}:{kv.Value}"))
             : "not found";
 
         // Since the test uses JS to set position-area dynamically, the
@@ -10087,8 +10090,9 @@ iframe {
         // The fallback should set left:50, top:50
         if (absTry != null)
         {
-            var left = absTry.Style.GetValueOrDefault("left") ?? "0px";
-            var top = absTry.Style.GetValueOrDefault("top") ?? "0px";
+            var absTryStyle = Broiler.HtmlBridge.DomBridge.GetInlineStyleView(absTry);
+            var left = absTryStyle.GetValueOrDefault("left") ?? "0px";
+            var top = absTryStyle.GetValueOrDefault("top") ?? "0px";
             // Accept test pass if the fallback was applied
             Assert.True(left.Contains("50") || top.Contains("50"),
                 $"Expected position-try fallback to apply. left={left} top={top}");


### PR DESCRIPTION
## Summary

Completes the Phase F4 final cutover from the facade `DomElement` type to the canonical `Broiler.Dom.DomElement`. All remaining unqualified `DomElement` references in the bridge have been replaced with their fully-qualified canonical form. The `GlobalUsings.cs` compatibility alias has been removed, and helper utilities have been consolidated into the `Broiler.CSS` namespace.

## Key Changes

- **Type qualification:** All `DomElement` references across `DomBridge` and related files now use `Broiler.Dom.DomElement` (or `Broiler.Dom.DomElement?` for nullable cases). Affected files include:
  - `Css.cs` — field declarations, method parameters, local variables, and type casts
  - `LayoutMetrics.cs` — geometry calculation methods
  - `SubDocuments.cs` — sub-document cache dictionaries and handlers
  - `Serialization.cs` — zoom serialization state tracking
  - `DomBridge.cs` — core document node and cache declarations
  - All `AnchorResolver/` sub-modules (PositionTry, PositionArea, Dialogs, StickyPositioning, Visibility, etc.)
  - Event handling, traversal, shadow DOM, attributes, and other bridge subsystems

- **Helper consolidation:** Removed local implementations of CSS utility functions:
  - `ToCamelCase()` → delegated to `Broiler.CSS.CssPropertyNames.ToDomPropertyName()`
  - `StripCssPriority()` → delegated to `Broiler.CSS.CssPriority.Strip()`
  - `ApplyCssPriority()` → delegated to `Broiler.CSS.CssPriority.Apply()`
  - Removed `ToCamelCaseStatic()` and `ToKebabCase()` from `Utilities.cs`

- **GlobalUsings cleanup:** Deleted `GlobalUsings.cs` (which provided the `DomElement` alias); all code now uses explicit qualification.

- **Test fix:** Updated `Broiler.Wpt.Tests` to use the new internal accessor `DomBridge.GetInlineStyleView(DomElement)` for inline-style assertions (replacing the removed `.Style` facade property). This accessor is internal-only, visible via `InternalsVisibleTo`, and does not re-expose a public facade seam.

- **Project reference correction:** Fixed `Broiler.Wpt.Tests.csproj` to reference `..\Broiler.HtmlBridge.Dom\` instead of the pre-split `..\Broiler.HtmlBridge\` project.

- **Submodule bump:** `Broiler.CSS` updated to commit `e555934` (provides the consolidated CSS utility functions).

- **Documentation:** Updated `htmlbridge-remaining-work-roadmap.md` to mark task 1.2 (Resurrect `Broiler.Wpt.Tests`) as **DONE**, with details on the 12 broken call sites fixed and the internal accessor pattern used.

## Implementation Details

- All type changes are mechanical (no logic changes); the bridge continues to operate on canonical `Broiler.Dom.DomElement` instances as it has since Phase F.
- The `GetInlineStyleView()` internal accessor wraps the private `InlineStyle` map and is only visible to test code via `InternalsVisibleTo` — it does not widen the public API surface (verified by `HtmlBridgeBoundaryGuardTests`).
- CSS utility functions are now sourced from `Broiler.CSS` (a shared, well-tested layer) rather than duplicated in the bridge, improving maintainability.
- The solution now builds cleanly with no MSB9008 warnings or unresolved references.

https://claude.ai/code/session_01ER2oZCEmwviM7J8jQiW3E6