### PR TITLE
Fix animation/@keyframes collection from InnerHtml-backed <style> elements

### DIFF
--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/CssCleanup.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/CssCleanup.cs
@@ -22,10 +22,27 @@ public sealed partial class DomBridge
             // text node, mutating root.Children mid-enumeration ("Collection was
             // modified", WPT issue #1143). SnapshotChildren also guards the ToList()
             // copy overflow ("Destination array…"), same idiom as AnchorRegistry.
+            bool hadTextChild = false;
             foreach (var child in SnapshotChildren(root))
             {
                 if (IsText(child) && !string.IsNullOrEmpty(BridgeText(child)))
+                {
                     SetBridgeText(child, RemoveUnsupportedCssRules(BridgeText(child)));
+                    hadTextChild = true;
+                }
+            }
+
+            // RF-BRIDGE-1c Phase F (F3c) follow-up: a <style> element's CSS can live in its
+            // InnerHtml runtime state with no DomText child (the same InnerHtml-backed state the
+            // animation/@position-try collectors handle). Neutralize that source too, so the
+            // renderer — which reads it back through GetStyleElementSourceText — does not re-apply
+            // anchor rules the resolver has already resolved into inline styles. Changing the
+            // source re-parses the sheet on next read (EnsureStyleSheetRulesCurrent).
+            if (!hadTextChild)
+            {
+                var state = GetElementRuntimeState(root);
+                if (!string.IsNullOrEmpty(state.InnerHtml))
+                    state.InnerHtml = RemoveUnsupportedCssRules(state.InnerHtml);
             }
         }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
@@ -36,13 +36,16 @@ public sealed partial class DomBridge
 
     private sealed record KeyframeEntry(float Position, Dictionary<string, string> Properties);
 
-    private static void CollectKeyframes(Broiler.Dom.DomElement root, Dictionary<string, List<KeyframeEntry>> map)
+    // Instance (not static): reads <style> source through the canonical
+    // GetStyleElementSourceText accessor rather than hand-walking child text nodes, so
+    // @keyframes are still collected when the CSS lives in the element's InnerHtml runtime
+    // state with no DomText child (RF-BRIDGE-1c Phase F / F3c — same fix as @position-try and
+    // CollectAnimPropsFromStyleElements).
+    private void CollectKeyframes(Broiler.Dom.DomElement root, Dictionary<string, List<KeyframeEntry>> map)
     {
         if (string.Equals(root.TagName, "style", StringComparison.OrdinalIgnoreCase))
         {
-            var css = string.Concat(root.ChildNodes
-                .Where(c => IsText(c))
-                .Select(c => BridgeText(c)));
+            var css = GetStyleElementSourceText(root);
             var styleSheet = new Broiler.CSS.CssParser().ParseStyleSheet(css);
             foreach (var atRule in styleSheet.Rules.OfType<Broiler.CSS.CssAtRule>())
             {
@@ -162,7 +165,9 @@ public sealed partial class DomBridge
     /// whose selectors match the given element.  This is a simplified matcher
     /// that handles tag selectors (e.g. <c>body</c>, <c>html</c>).
     /// </summary>
-    private static Dictionary<string, string>? CollectStylesheetAnimationProperties(Broiler.Dom.DomElement element)
+    // Instance (not static) so it can read <style> source through the canonical
+    // GetStyleElementSourceText accessor — see CollectAnimPropsFromStyleElements.
+    private Dictionary<string, string>? CollectStylesheetAnimationProperties(Broiler.Dom.DomElement element)
     {
         // Walk up to find <style> elements.
         var root = element;
@@ -173,14 +178,20 @@ public sealed partial class DomBridge
         return result;
     }
 
-    private static void CollectAnimPropsFromStyleElements(
+    private void CollectAnimPropsFromStyleElements(
         Broiler.Dom.DomElement node, Broiler.Dom.DomElement target, ref Dictionary<string, string>? result)
     {
         if (string.Equals(node.TagName, "style", StringComparison.OrdinalIgnoreCase))
         {
-            var css = string.Concat(node.ChildNodes
-                .Where(c => IsText(c))
-                .Select(c => BridgeText(c)));
+            // RF-BRIDGE-1c Phase F (F3c) follow-up: read the <style> source through the canonical
+            // GetStyleElementSourceText accessor rather than hand-walking child text nodes. After
+            // Attach, a <style> element's CSS can live in its InnerHtml runtime state with no DomText
+            // child (childCount == 0) in some parse paths — the raw child walk then saw nothing, so
+            // stylesheet-declared animation / @keyframes properties were silently missed (the same
+            // failure mode that broke @position-try; fixed in AnchorResolver/PositionTry.cs).
+            // GetStyleElementSourceText covers the DomText-child, InnerHtml-fallback, and linked-href
+            // stylesheet cases uniformly.
+            var css = GetStyleElementSourceText(node);
 
             var styleSheet = new Broiler.CSS.CssParser().ParseStyleSheet(css);
             foreach (var styleRule in styleSheet.Rules.OfType<Broiler.CSS.CssStyleRule>())

--- a/src/Broiler.Wpt.Tests/AnimationInnerHtmlStyleTests.cs
+++ b/src/Broiler.Wpt.Tests/AnimationInnerHtmlStyleTests.cs
@@ -1,0 +1,98 @@
+using System.Linq;
+using System.Reflection;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression guard for the RF-BRIDGE-1c Phase F (F3c) follow-up in
+/// <c>AnimationResolver</c>. After Attach, a <c>&lt;style&gt;</c> element's CSS can live in its
+/// InnerHtml runtime state with no <c>DomText</c> child (childCount == 0) — the state the
+/// full render/anchor pipeline can leave a style in after re-serialising it. The animation
+/// collectors used to read the CSS by hand-walking child text nodes, which returns empty in
+/// that state, so stylesheet <c>@keyframes</c> and stylesheet-declared <c>animation</c>
+/// properties were silently missed (the same failure mode that broke <c>@position-try</c>).
+/// The collectors now read through the canonical <c>GetStyleElementSourceText</c> accessor,
+/// which covers the InnerHtml case.
+///
+/// The InnerHtml-only state is constructed directly (via the same reflection idiom the bridge
+/// boundary-guard tests use) because it is the specific runtime state the fix targets and is
+/// awkward to trigger through the public API in isolation.
+/// </summary>
+public sealed class AnimationInnerHtmlStyleTests
+{
+    // Sets an element's InnerHtml runtime state without adding a DomText child, reproducing the
+    // childCount == 0 / InnerHtml-backed <style> state.
+    private static void SetInnerHtmlRuntimeState(Broiler.HtmlBridge.DomBridge bridge, Broiler.Dom.DomElement el, string css)
+    {
+        var state = typeof(Broiler.HtmlBridge.DomBridge)
+            .GetMethod("GetElementRuntimeState", BindingFlags.NonPublic | BindingFlags.Static)!
+            .Invoke(null, new object[] { el })!;
+        state.GetType().GetProperty("InnerHtml")!.SetValue(state, css);
+    }
+
+    private static Broiler.Dom.DomElement? FindById(Broiler.Dom.DomElement el, string id)
+    {
+        if (el.Id == id) return el;
+        foreach (var c in el.ChildNodes.OfType<Broiler.Dom.DomElement>())
+            if (FindById(c, id) is { } found) return found;
+        return null;
+    }
+
+    [Fact]
+    public void Keyframes_AreCollected_When_StyleContent_Lives_In_InnerHtml()
+    {
+        // Inline animation on the target; @keyframes only reachable via the InnerHtml-backed <style>.
+        const string html = @"<!DOCTYPE html>
+<div id=""box"" style=""animation: slide 10s linear -10s;""></div>
+<style id=""sheet""></style>";
+        using var ctx = new Broiler.JavaScript.Engine.JSContext();
+        var bridge = new Broiler.HtmlBridge.DomBridge();
+        bridge.Attach(ctx, html, "file:///test.html");
+
+        var sheet = FindById(bridge.DocumentElement, "sheet");
+        var box = FindById(bridge.DocumentElement, "box");
+        Assert.NotNull(sheet);
+        Assert.NotNull(box);
+
+        SetInnerHtmlRuntimeState(bridge, sheet!,
+            "@keyframes slide { from { margin-left: 0px; } to { margin-left: 200px; } }");
+        Assert.Empty(sheet!.ChildNodes); // no DomText child — the state the fix targets
+
+        bridge.ResolveAnimationSnapshots();
+
+        // animation-delay:-10s over a 10s duration snapshots at t=0 to the 100% ("to") keyframe.
+        var style = Broiler.HtmlBridge.DomBridge.GetInlineStyleView(box!);
+        Assert.True(style.TryGetValue("margin-left", out var ml) && ml == "200px",
+            $"Expected margin-left:200px from @keyframes in InnerHtml <style>, got [{string.Join(", ", style.Select(kv => $"{kv.Key}:{kv.Value}"))}]");
+    }
+
+    [Fact]
+    public void StylesheetAnimationProperty_IsCollected_When_StyleContent_Lives_In_InnerHtml()
+    {
+        // Animation declared by a stylesheet RULE (not inline) plus @keyframes — both only
+        // reachable via the InnerHtml-backed <style>. Exercises CollectAnimPropsFromStyleElements
+        // and CollectKeyframes together.
+        const string html = @"<!DOCTYPE html>
+<div id=""box""></div>
+<style id=""sheet""></style>";
+        using var ctx = new Broiler.JavaScript.Engine.JSContext();
+        var bridge = new Broiler.HtmlBridge.DomBridge();
+        bridge.Attach(ctx, html, "file:///test.html");
+
+        var sheet = FindById(bridge.DocumentElement, "sheet");
+        var box = FindById(bridge.DocumentElement, "box");
+        Assert.NotNull(sheet);
+        Assert.NotNull(box);
+
+        SetInnerHtmlRuntimeState(bridge, sheet!,
+            "#box { animation: slide 10s linear -10s; } " +
+            "@keyframes slide { from { margin-left: 0px; } to { margin-left: 200px; } }");
+        Assert.Empty(sheet!.ChildNodes);
+
+        bridge.ResolveAnimationSnapshots();
+
+        var style = Broiler.HtmlBridge.DomBridge.GetInlineStyleView(box!);
+        Assert.True(style.TryGetValue("margin-left", out var ml) && ml == "200px",
+            $"Expected margin-left:200px from stylesheet animation in InnerHtml <style>, got [{string.Join(", ", style.Select(kv => $"{kv.Key}:{kv.Value}"))}]");
+    }
+}


### PR DESCRIPTION
## What & why

Fixes a latent twin of the `@position-try` fallback regression (merged in #1362). Same RF-BRIDGE-1c Phase F (F3c) blind spot: after a re-serialize step (e.g. `SetElementInnerHtml` / `ReplaceRootWithReplacedContent`), a `<style>` element's CSS can live in its **InnerHtml runtime state with no `DomText` child** (`childCount == 0`). `AnimationResolver` read the CSS by hand-walking child text nodes, which returns empty in that state — so stylesheet `@keyframes` and stylesheet-declared `animation` properties were silently missed.

## Changes

- **`AnimationResolver.cs`** — `CollectKeyframes`, `CollectAnimPropsFromStyleElements`, and `CollectStylesheetAnimationProperties` are now **instance** methods (both callers — `ResolveAnimationSnapshots`, `TryGetAnimationProperties` — are instance) and read `<style>` source through the canonical `GetStyleElementSourceText` accessor, which covers the DomText-child, InnerHtml-fallback, and linked-`href` cases uniformly. (Chose the instance route over a static InnerHtml fallback precisely so the `href` case is covered too.)
- **`CssCleanup.NeutralizeStyleElementsForAnchorRules`** — the **write-path** variant of the same pattern. It strips unsupported anchor rules by rewriting `<style>` text and previously did nothing for InnerHtml-backed styles. It now neutralizes the `InnerHtml` source in place when there is no `DomText` child, so the renderer (which reads it back via `GetStyleElementSourceText`) does not re-apply anchor rules the resolver already resolved into inline styles. The reparse is picked up by `EnsureStyleSheetRulesCurrent`.

Behaviour-preserving for the common `DomText`-backed case: `GetStyleElementSourceText` reads the DomText children first, and the new `CssCleanup` branch only runs at `childCount == 0`.

## Tests

- **`AnimationInnerHtmlStyleTests`** (2) — one for `@keyframes` collection, one for a stylesheet-declared `animation` rule, both against a deterministically-constructed InnerHtml-only `<style>`. **Fail-before / pass-after verified** (with the child-walk reverted, the target isn't resolved).
  - The InnerHtml-only state is built by reflect-setting `ElementRuntimeState.InnerHtml` on a childless `<style>` — the same reflection idiom the bridge boundary-guard tests use. (JS `element.innerHTML = …` on a `<style>` does *not* populate that runtime state, and a static `<style>` keeps its DomText child even with a script present, so neither reproduces the state through the public API.)

## Verification

- Whole solution builds (0 errors).
- 21/21 anchor / position / animation `Broiler.Cli.Tests` pass; `HtmlBridgeBoundaryGuardTests` 12/12; `@position-try` regression test still green.

## Reviewer note

The `CssCleanup` change is renderer-facing, so the full **WPT / Acid / pixel** corpus (dispatch-only in this environment) is the ultimate gate for it — same as the rest of the F3c/F4 line of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
