### PR TITLE
Promote Range content ops to canonical DomRange + rewire the bridge onto it

### DIFF
--- a/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
+++ b/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
@@ -235,12 +235,20 @@ Slice 8 findings/work:
   `EndContainer`/`EndOffset`, `Collapsed` — over the range's already-present live
   "removing steps" adjustment (`OnMutation`). Covered by `DomRangeTests` (5). This
   also resolves the Range portion of the pre-existing `DomKernelTests` break.
-- **Still bridge-owned (not yet promoted):** the JS `Range` object's *content*
-  operations (`deleteContents`/`extractContents`/`cloneContents`/`insertNode`/
-  `surroundContents`) and the bridge's `RangeState` — the bridge does not yet route
-  its ranges through canonical `DomRange`. That routing plus content-op promotion
-  is the larger, higher-risk remainder of slice 8, entangled with the bridge's
-  range geometry/client-rect APIs (which stay bridge-owned).
+- **Canonical content operations added (2026-07-12).** `Broiler.Dom.DomRange` now
+  implements the DOM Standard §4.5 content operations directly —
+  `ExtractContents`/`CloneContents`/`DeleteContents`/`InsertNode`/`SurroundContents`,
+  plus `SelectNode`/`SelectNodeContents`/`Collapse` and `CommonAncestorContainer` —
+  over canonical `DomNode`/`DomCharacterData` (no JS-object or layout dependencies),
+  following the spec algorithms rather than the bridge's ad-hoc document-order
+  heuristics. Covered by 13 new `DomRangeTests` (project green 64/64). See
+  [`htmlbridge-remaining-work-roadmap.md`](htmlbridge-remaining-work-roadmap.md) §2.2.
+- **Still bridge-owned (the remaining, higher-risk slice):** routing the bridge's JS
+  `Range` object and its `RangeState` (`DomBridge/Traversal.cs`) through the new
+  canonical `DomRange`, so the bridge stops owning its own content-op machinery. This
+  is entangled with the bridge's range geometry/client-rect APIs (which stay
+  bridge-owned) and JS object identity, and — like the F3c/F4 cutovers — needs the WPT
+  range/selection corpus at merge (silent selection/serialization failure mode).
 
 `Broiler.Dom.DomTokenList` is the canonical ordered-set token algorithm
 (ASCII-whitespace parse/serialize, unique-ordered, contains/add/remove/toggle/

--- a/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
+++ b/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
@@ -243,12 +243,16 @@ Slice 8 findings/work:
   following the spec algorithms rather than the bridge's ad-hoc document-order
   heuristics. Covered by 13 new `DomRangeTests` (project green 64/64). See
   [`htmlbridge-remaining-work-roadmap.md`](htmlbridge-remaining-work-roadmap.md) §2.2.
-- **Still bridge-owned (the remaining, higher-risk slice):** routing the bridge's JS
-  `Range` object and its `RangeState` (`DomBridge/Traversal.cs`) through the new
-  canonical `DomRange`, so the bridge stops owning its own content-op machinery. This
-  is entangled with the bridge's range geometry/client-rect APIs (which stay
-  bridge-owned) and JS object identity, and — like the F3c/F4 cutovers — needs the WPT
-  range/selection corpus at merge (silent selection/serialization failure mode).
+- **Bridge rewire done (2026-07-12).** `RangeState` is deleted; the JS `Range` is backed
+  by a `BridgeDomRange : Broiler.Dom.DomRange` subclass (non-tracking) that overrides the
+  node-creation seams to mint bridge nodes (`#document-fragment` fragments + `CloneDomElement`
+  clones carrying host runtime state, registered in `_knownNodes`). All `Range` callbacks
+  delegate to the canonical boundary/selection/content methods; the bridge's ad-hoc extract
+  helpers and boundary math are removed; external-mutation adjustment still flows through the
+  weak `_activeRanges` registry via `DomRange.NotifyNodeRemoved`. Geometry/client-rects stay
+  bridge-owned. Regression-free vs the `Cli.Tests` range/mutation/Acid suites; still wants the
+  WPT range/selection corpus at merge. See
+  [`htmlbridge-remaining-work-roadmap.md`](htmlbridge-remaining-work-roadmap.md) §2.2.
 
 `Broiler.Dom.DomTokenList` is the canonical ordered-set token algorithm
 (ASCII-whitespace parse/serialize, unique-ordered, contains/add/remove/toggle/

--- a/docs/roadmap/htmlbridge-remaining-work-roadmap.md
+++ b/docs/roadmap/htmlbridge-remaining-work-roadmap.md
@@ -147,13 +147,32 @@ slices — **the canonical algorithms first (done), the bridge rewire second (re
   select/collapse); the whole `Broiler.Dom.Tests` project is green (64/64) and the bridge consumer builds
   clean. **Delivery note:** the new code is in the `Broiler.DOM` **submodule** — push + pointer bump (or
   `patches/` fallback if the push 403s) at commit time.
-- **Still bridge-owned (the remaining, higher-risk slice):** routing the bridge's JS `Range` object and
-  its `RangeState` (in `DomBridge/Traversal.cs`) through the new canonical `DomRange` so the bridge stops
-  owning its own content-operation machinery. This is entangled with the bridge's range geometry /
-  client-rect APIs (`GetClientRectsForRange`, which stay bridge-owned) and JS object identity, and — like
-  the F3c/F4 cutovers — its failure mode is silent selection/serialization corruption, so it needs the
-  WPT range/selection corpus at merge, not just `Cli.Tests`. F3c already widened `RangeState` to canonical
-  `DomNode`, which de-risks the boundary-point handoff.
+- **Done (2026-07-12) — the bridge `Range`/`RangeState` rewire.** The bridge's `RangeState` class is
+  **deleted**; the live JS `Range` is now backed by a `BridgeDomRange : Broiler.Dom.DomRange` (a private
+  bridge subclass constructed `trackMutations: false`) that overrides the four node-creation seams so the
+  canonical content operations mint bridge nodes — `#document-fragment` result fragments and
+  `CloneDomElement` clones that carry host runtime state (form-control value/checked, scroll, dialog/shadow,
+  live inline style), all registered in `_knownNodes`. Every `Range` JS callback in
+  `JsFunctionCallbacks/Traversal.cs` now delegates: the content ops (`extract`/`clone`/`delete`/`insert`/
+  `surround`) to the canonical methods; the boundary/selection ops (`setStart`/`setEnd`/`setStartBefore`…/
+  `collapse`/`selectNode`/`selectNodeContents`) to `SetStart`/`SetEnd`/`Collapse`/`SelectNode`. The bridge's
+  hand-rolled algorithms are removed: `RangeState.AdjustForRemoval`/`UpdateCollapsed`, the ad-hoc
+  `ExtractStartPath`/`ExtractEndPath`/`CreatePartialCloneForExtract`/`IsContainedInRange` extract helpers,
+  and the manual boundary collapse math. Boundary adjustment for external tree mutations still runs through
+  the bridge's weak `_activeRanges` registry (preserving the no-leak `WeakReference` design), which now calls
+  the canonical `DomRange.NotifyNodeRemoved`. Geometry stays bridge-owned: `GetClientRectsForRange` /
+  `getBoundingClientRect` / `getClientRects` and `toString`/`compareBoundaryPoints` read boundary points off
+  the `DomRange` but keep their bridge geometry/text helpers.
+  **Verification:** `Broiler.Cli.Tests` range/traversal suite 56/57 (the 1 failure —
+  `Range_GetBoundingClientRect_Includes_DisplayContents_Descendants` — is **pre-existing/environmental**,
+  baseline-confirmed: a `display:contents` layout that produces zero height in the bare container, fails
+  identically without this change); mutation-observer / boundary-guard / DOM-interface suites 90/90; Acid3 /
+  DOM-events / DOM-edge suites 120/120; canonical `Broiler.Dom.Tests` 69/69. The two `insertNode`
+  boundary-after-split tests were updated to the **spec-correct** result (the start boundary stays in the
+  truncated original text node rather than the pre-rewire bridge's non-spec normalization to the parent) —
+  gate-safe because `dom/ranges/Range-insertNode.html` (and all five `Range-*` content-op WPT tests) are
+  already in the committed failed baseline, so adopting spec behavior can only hold or improve, never add a
+  new failure. Like the F3c/F4 cutovers this still wants the full WPT range/selection corpus at merge.
 
 ### 2.3 Promotion Phase 1 slice-2 — deferred helpers (casing + `CssPriority` **DONE**; live-setter routing remains)
 

--- a/docs/roadmap/htmlbridge-remaining-work-roadmap.md
+++ b/docs/roadmap/htmlbridge-remaining-work-roadmap.md
@@ -1,7 +1,13 @@
 # HtmlBridge — Remaining Work Roadmap (post-facade-removal)
 
-Status: **active** — the consolidated "what's left" list once the `DomElement` facade removal lands.
-Date: 2026-07-11.
+Status: **active** — the consolidated "what's left" list now that the `DomElement` facade removal has landed.
+Date: 2026-07-11 (Section 1 gate closed 2026-07-12).
+
+> **Update (2026-07-12): all of Section 1 has landed on `main`.** The F3c/F4 merge gate (1.1) passed
+> and merged as PR #1359; the CSS-helper promotion (2.1 shorthand + 2.3 casing/`CssPriority`) merged as
+> PR #1362; and the `@position-try` twin follow-up from 1.2 — animation/`@keyframes` collection from
+> InnerHtml-backed `<style>` elements — merged as PR #1363. The remaining open work is entirely in
+> Section 2 (DOM/CSS promotion backlog).
 
 ## Purpose
 
@@ -27,21 +33,15 @@ Authoritative records referenced below:
 
 ## 1. Blockers to landing the facade removal (in-scope, do these to merge)
 
-### 1.1 WPT + Acid + pixel merge gate — **the one hard blocker**
+### 1.1 WPT + Acid + pixel merge gate — **DONE (merged)**
 
 The F3c/F4 stack (`72634e02`, `aa00ecf5`, `ddad4769` on `claude/htmlbridge-domelement-f3c-flip`, PR
-#1359) is **Cli.Tests-verified regression-free** (0 new failures; F3c added 8 fixes) but is **not merged**.
-Both irreversible cutovers — the text→`DomText` flip (2d) and the element-construction flip + facade
-delete (F4) — are gated on the **full WPT range/selection/serialization + Acid + pixel** corpus before
-merge, because the failure mode is *silent* `outerHTML`/selection/render corruption that `Cli.Tests` does
-not catch. WPT is **dispatch-only** in this environment (the `WPT Tests` GitHub Actions workflow,
-`workflow_dispatch`).
-
-- **Action:** dispatch the WPT workflow on the branch, confirm the failing set is a **subset** of the
-  committed WPT baseline (`tests/wpt-baseline/failed-tests.json`) — i.e. **0 new failures** — then mark
-  PR #1359 ready and merge. Watch specifically for SVG/foreign `createElementNS` namespace regressions
-  and range/selection/serialization regressions.
-- **Status:** WPT run dispatched 2026-07-11; awaiting results + baseline diff.
+#1359) — both irreversible cutovers, the text→`DomText` flip (2d) and the element-construction flip +
+facade delete (F4) — passed the **full WPT range/selection/serialization + Acid + pixel** gate and
+**merged (`ecbdf406`, 2026-07-12)**. The failing WPT set was confirmed a subset of the committed baseline
+(`tests/wpt-baseline/failed-tests.json`, updated `[skip ci]` in `2b9b1319`); no new SVG/foreign
+`createElementNS` namespace or range/selection/serialization regressions. The `DomElement` facade and
+`HtmlTreeBuilder` are gone from `main`; the bridge tree is canonical `Broiler.Dom` nodes.
 
 ### 1.2 Resurrect `Broiler.Wpt.Tests` (pre-existing, out of `Cli.Tests` scope) — **DONE**
 
@@ -72,9 +72,10 @@ the whole solution would not build until it was fixed.
   `@position-try` rules, so every fallback silently no-op'd (both resolve-only and full-render paths). Fix:
   read via the canonical `GetStyleElementSourceText(el)` accessor (the same source the cascade uses; covers the
   InnerHtml-fallback case). Both tests now pass; the 7 nearby `PositionArea*`/`PositionTryGrid*` pixel reftests
-  fail **identically with and without the fix** (baseline-verified environmental, 0 regressions). A latent
-  twin of the same bug in `AnimationResolver.CollectAnimPropsFromStyleElements` (static, so needs its own
-  InnerHtml fallback + a reproducing test) is tracked as a separate follow-up.
+  fail **identically with and without the fix** (baseline-verified environmental, 0 regressions). The latent
+  twin of the same bug in `AnimationResolver.CollectAnimPropsFromStyleElements` (static InnerHtml fallback)
+  is now **fixed and merged** (PR #1363, `d383b371`): animation/`@keyframes` collection reads
+  InnerHtml-backed `<style>` source via the same canonical accessor, with a reproducing test.
 - **Priority:** low; independent of the merge gate.
 
 ### 1.3 Optional cleanup — retire the `DomElement` alias — **DONE**
@@ -127,14 +128,32 @@ they are prioritized independently.
   **Delivery note:** the public `ExpandShorthands` wrapper is in the `Broiler.CSS` submodule — push +
   pointer bump (or patch fallback) at commit time.
 
-### 2.2 Promotion Phase 4 / slice 8 — Range content operations (partially done)
+### 2.2 Promotion Phase 4 / slice 8 — Range content operations (canonical API landed; bridge rewire remains)
 
-The token-list + mutation-filtering work landed; the higher-risk remainder is still bridge-owned:
+The token-list + mutation-filtering work landed earlier; the content operations are now split into two
+slices — **the canonical algorithms first (done), the bridge rewire second (remaining, higher-risk).**
 
-- The JS `Range` **content** operations — `deleteContents` / `extractContents` / `cloneContents` /
-  `insertNode` / `surroundContents` — and the bridge's `RangeState`, routed through the canonical
-  `Broiler.Dom.DomRange` instead of the bridge's own range machinery. (F3c already widened `RangeState` to
-  canonical `DomNode`, which de-risks this.)
+- **Done (2026-07-12) — canonical `DomRange` content operations.** `Broiler.Dom.DomRange` gains the full
+  DOM Standard §4.5 content-operation surface, implemented against canonical `DomNode`/`DomCharacterData`
+  (no JS-object or layout dependencies): `ExtractContents` / `CloneContents` / `DeleteContents` /
+  `InsertNode` / `SurroundContents`, plus the selection helpers `SelectNode` / `SelectNodeContents` /
+  `Collapse` and the `CommonAncestorContainer` accessor. These follow the spec algorithms literally
+  (partially-contained-child recursion via sub-ranges, `contained`/`partially contained` boundary-point
+  tests over the existing `CompareBoundaryPoints`, text-node split for `InsertNode`), rather than porting
+  the bridge's ad-hoc document-order-`IndexOf` heuristics. Two new `DomException` factories
+  (`InvalidStateError` / `InvalidNodeTypeError`) back `surroundContents`/`selectNode`. Covered by 13 new
+  `DomRangeTests` cases (extract/clone/delete within one text node and across nodes, insert at an element
+  offset + inside-text split + comment-container rejection, surround wrap + partial-non-text throw,
+  select/collapse); the whole `Broiler.Dom.Tests` project is green (64/64) and the bridge consumer builds
+  clean. **Delivery note:** the new code is in the `Broiler.DOM` **submodule** — push + pointer bump (or
+  `patches/` fallback if the push 403s) at commit time.
+- **Still bridge-owned (the remaining, higher-risk slice):** routing the bridge's JS `Range` object and
+  its `RangeState` (in `DomBridge/Traversal.cs`) through the new canonical `DomRange` so the bridge stops
+  owning its own content-operation machinery. This is entangled with the bridge's range geometry /
+  client-rect APIs (`GetClientRectsForRange`, which stay bridge-owned) and JS object identity, and — like
+  the F3c/F4 cutovers — its failure mode is silent selection/serialization corruption, so it needs the
+  WPT range/selection corpus at merge, not just `Cli.Tests`. F3c already widened `RangeState` to canonical
+  `DomNode`, which de-risks the boundary-point handoff.
 
 ### 2.3 Promotion Phase 1 slice-2 — deferred helpers (casing + `CssPriority` **DONE**; live-setter routing remains)
 

--- a/src/Broiler.Cli.Tests/DomTraversalAndRangeTests.cs
+++ b/src/Broiler.Cli.Tests/DomTraversalAndRangeTests.cs
@@ -1303,9 +1303,11 @@ r.push(p.childNodes[0].textContent);       // '12'
 r.push(p.childNodes[1].textContent);       // 'ABCDE'
 r.push(p.childNodes[2].textContent);       // '345'
 
-// Range boundaries should be updated to parent after text split
-r.push(range.startContainer === p);        // true (parent of split)
-r.push(range.startOffset);                 // 1 (index of inserted node)
+// Per the DOM Standard, insertNode splits the start text node but leaves the start
+// boundary in the (now truncated) original text node — it does NOT normalize to the
+// parent (the pre-rewire bridge's non-spec behaviour). t1 is now '12', offset 2.
+r.push(range.startContainer === t1);       // true (start stays in the original text node)
+r.push(range.startOffset);                 // 2 (end of '12')
 
 var out = document.createElement('div');
 out.id = 'result';
@@ -1316,7 +1318,7 @@ document.body.appendChild(out);
 
         var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
 
-        Assert.Contains("3|12|ABCDE|345|true|1", result);
+        Assert.Contains("3|12|ABCDE|345|true|2", result);
     }
 
     /// <summary>
@@ -1691,8 +1693,10 @@ r.push(p.childNodes.length);              // 3
 r.push(p.childNodes[0].textContent);      // 'A'
 r.push(p.childNodes[1].textContent);      // 'XYZ'
 r.push(p.childNodes[2].textContent);      // 'BCDE'
-r.push(range.startContainer === p);       // true
-r.push(range.startOffset);               // 1 (index of inserted node)
+// Per the DOM Standard the start boundary stays in the (now 'A') original text node,
+// not the parent (the pre-rewire bridge's non-spec normalization).
+r.push(range.startContainer === t);       // true (start stays in the original text node)
+r.push(range.startOffset);               // 1
 var out = document.createElement('div');
 out.id = 'result';
 out.textContent = r.join('|');

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -52,7 +52,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     private readonly HashSet<Broiler.Dom.DomNode> _knownNodes =
         new(ReferenceEqualityComparer.Instance);
     private readonly List<(JSObject Observer, Broiler.Dom.DomNode Target, Broiler.Dom.DomMutationObserverOptions Options)> _mutationObservers = [];
-    private readonly List<WeakReference<RangeState>> _activeRanges = [];
+    private readonly List<WeakReference<Broiler.Dom.DomRange>> _activeRanges = [];
     private readonly List<WeakReference<Broiler.Dom.DomNodeIterator>> _activeNodeIterators = [];
     private readonly CanonicalDocument _document;
     private readonly Broiler.Dom.DomElement _documentNode;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Traversal.cs
@@ -253,21 +253,23 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsTraversalGetCommonAncestorContainer020Core(global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalGetCommonAncestorContainer020Core(global::Broiler.Dom.DomRange state, in Arguments a)
     {
+        // FindCommonAncestor (bridge helper) returns null for boundaries in different trees,
+        // preserving the lenient JSNull result; the canonical CommonAncestorContainer would throw.
         var ancestor = FindCommonAncestor(state.StartContainer, state.EndContainer);
         return ancestor != null ? ToJSObject(ancestor) : JSNull.Value;
     }
 
 
-    private JSValue JsTraversalGetBoundingClientRect021Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments _)
+    private JSValue JsTraversalGetBoundingClientRect021Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments _)
     {
         var rects = bridge.GetClientRectsForRange(state);
         return bridge.CreateDomRectObject(UnionClientRects(rects));
     }
 
 
-    private JSValue JsTraversalGetClientRects022Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments _)
+    private JSValue JsTraversalGetClientRects022Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments _)
     {
         var rects = bridge.GetClientRectsForRange(state);
         if (rects.Count == 0)
@@ -276,7 +278,18 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsTraversalSetStart023Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    // Coerces a JS-supplied range offset to the node's valid [0, length] range, matching the
+    // pre-rewire bridge's lenient behaviour (it clamped in the content ops) so canonical
+    // Substring/child indexing never throws on an out-of-range offset.
+    private static int ClampRangeOffset(global::Broiler.Dom.DomNode node, int offset)
+    {
+        var length = node is global::Broiler.Dom.DomCharacterData characterData
+            ? characterData.Data.Length
+            : node.ChildNodes.Count;
+        return Math.Clamp(offset, 0, length);
+    }
+
+    private JSValue JsTraversalSetStart023Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments a)
     {
         if (a.Length < 2)
             throw new JSException("Failed to execute 'setStart': 2 arguments required.");
@@ -286,22 +299,12 @@ public sealed partial class DomBridge
         var el = bridge.FindDomNodeByJSObject(nodeObj);
         if (el == null)
             return JSUndefined.Value;
-        var newOffset = (int)a[1].DoubleValue;
-        state.StartContainer = el;
-        state.StartOffset = newOffset;
-        // Per spec: if start is after end, collapse range to start
-        if (IsPositionAfter(state.Root, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset))
-        {
-            state.EndContainer = state.StartContainer;
-            state.EndOffset = state.StartOffset;
-        }
-
-        state.UpdateCollapsed();
+        state.SetStart(el, ClampRangeOffset(el, (int)a[1].DoubleValue));
         return JSUndefined.Value;
     }
 
 
-    private JSValue JsTraversalSetEnd024Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalSetEnd024Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments a)
     {
         if (a.Length < 2)
             throw new JSException("Failed to execute 'setEnd': 2 arguments required.");
@@ -311,22 +314,12 @@ public sealed partial class DomBridge
         var el = bridge.FindDomNodeByJSObject(nodeObj);
         if (el == null)
             return JSUndefined.Value;
-        var newOffset = (int)a[1].DoubleValue;
-        state.EndContainer = el;
-        state.EndOffset = newOffset;
-        // Per spec: if end is before start, collapse range to end
-        if (IsPositionAfter(state.Root, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset))
-        {
-            state.StartContainer = state.EndContainer;
-            state.StartOffset = state.EndOffset;
-        }
-
-        state.UpdateCollapsed();
+        state.SetEnd(el, ClampRangeOffset(el, (int)a[1].DoubleValue));
         return JSUndefined.Value;
     }
 
 
-    private JSValue JsTraversalSetStartBefore025Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalSetStartBefore025Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments a)
     {
         if (a.Length == 0)
             throw new JSException("Failed to execute 'setStartBefore': 1 argument required.");
@@ -340,21 +333,12 @@ public sealed partial class DomBridge
             return JSUndefined.Value;
         }
 
-        state.StartContainer = ParentEl(el);
-        state.StartOffset = ChildIndexOf(ParentEl(el), el);
-        // Per spec: if start is after end, collapse to start
-        if (IsPositionAfter(state.Root, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset))
-        {
-            state.EndContainer = state.StartContainer;
-            state.EndOffset = state.StartOffset;
-        }
-
-        state.UpdateCollapsed();
+        state.SetStart(ParentEl(el), ChildIndexOf(ParentEl(el), el));
         return JSUndefined.Value;
     }
 
 
-    private JSValue JsTraversalSetStartAfter026Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalSetStartAfter026Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments a)
     {
         if (a.Length == 0)
             throw new JSException("Failed to execute 'setStartAfter': 1 argument required.");
@@ -368,21 +352,12 @@ public sealed partial class DomBridge
             return JSUndefined.Value;
         }
 
-        state.StartContainer = ParentEl(el);
-        state.StartOffset = ChildIndexOf(ParentEl(el), el) + 1;
-        // Per spec: if start is after end, collapse to start
-        if (IsPositionAfter(state.Root, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset))
-        {
-            state.EndContainer = state.StartContainer;
-            state.EndOffset = state.StartOffset;
-        }
-
-        state.UpdateCollapsed();
+        state.SetStart(ParentEl(el), ChildIndexOf(ParentEl(el), el) + 1);
         return JSUndefined.Value;
     }
 
 
-    private JSValue JsTraversalSetEndBefore027Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalSetEndBefore027Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments a)
     {
         if (a.Length == 0)
             throw new JSException("Failed to execute 'setEndBefore': 1 argument required.");
@@ -397,21 +372,12 @@ public sealed partial class DomBridge
             return JSUndefined.Value;
         }
 
-        state.EndContainer = ParentEl(el);
-        state.EndOffset = ChildIndexOf(ParentEl(el), el);
-        // Per spec: if end is before start, collapse to end
-        if (IsPositionAfter(state.Root, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset))
-        {
-            state.StartContainer = state.EndContainer;
-            state.StartOffset = state.EndOffset;
-        }
-
-        state.UpdateCollapsed();
+        state.SetEnd(ParentEl(el), ChildIndexOf(ParentEl(el), el));
         return JSUndefined.Value;
     }
 
 
-    private JSValue JsTraversalSetEndAfter028Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalSetEndAfter028Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments a)
     {
         if (a.Length == 0)
             throw new JSException("Failed to execute 'setEndAfter': 1 argument required.");
@@ -425,40 +391,19 @@ public sealed partial class DomBridge
             return JSUndefined.Value;
         }
 
-        state.EndContainer = ParentEl(el);
-        state.EndOffset = ChildIndexOf(ParentEl(el), el) + 1;
-        // Per spec: if end is before start, collapse to end
-        if (IsPositionAfter(state.Root, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset))
-        {
-            state.StartContainer = state.EndContainer;
-            state.StartOffset = state.EndOffset;
-        }
-
-        state.UpdateCollapsed();
+        state.SetEnd(ParentEl(el), ChildIndexOf(ParentEl(el), el) + 1);
         return JSUndefined.Value;
     }
 
 
-    private JSValue JsTraversalCollapse029Core(global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalCollapse029Core(global::Broiler.Dom.DomRange state, in Arguments a)
     {
-        var toStart = a.Length > 0 && a[0].BooleanValue;
-        if (toStart)
-        {
-            state.EndContainer = state.StartContainer;
-            state.EndOffset = state.StartOffset;
-        }
-        else
-        {
-            state.StartContainer = state.EndContainer;
-            state.StartOffset = state.EndOffset;
-        }
-
-        state.Collapsed = true;
+        state.Collapse(a.Length > 0 && a[0].BooleanValue);
         return JSUndefined.Value;
     }
 
 
-    private JSValue JsTraversalSelectNode030Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalSelectNode030Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments a)
     {
         if (a.Length == 0)
             throw new JSException("Failed to execute 'selectNode': 1 argument required.");
@@ -466,18 +411,16 @@ public sealed partial class DomBridge
         if (nodeObj == null)
             return JSUndefined.Value;
         var el = bridge.FindDomNodeByJSObject(nodeObj);
+        // Preserve the pre-rewire lenient behaviour: a parentless node is a no-op here rather
+        // than the canonical InvalidNodeTypeError throw.
         if (el is null || ParentEl(el) == null)
             return JSUndefined.Value;
-        state.StartContainer = ParentEl(el);
-        state.StartOffset = ChildIndexOf(ParentEl(el), el);
-        state.EndContainer = ParentEl(el);
-        state.EndOffset = state.StartOffset + 1;
-        state.UpdateCollapsed();
+        state.SelectNode(el);
         return JSUndefined.Value;
     }
 
 
-    private JSValue JsTraversalSelectNodeContents031Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalSelectNodeContents031Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments a)
     {
         if (a.Length == 0)
             throw new JSException("Failed to execute 'selectNodeContents': 1 argument required.");
@@ -487,237 +430,27 @@ public sealed partial class DomBridge
         var el = bridge.FindDomNodeByJSObject(nodeObj);
         if (el == null)
             return JSUndefined.Value;
-        state.StartContainer = el;
-        state.StartOffset = 0;
-        state.EndContainer = el;
-        // For text/comment nodes, endOffset is the character length
-        if (IsText(el) || IsComment(el))
-            state.EndOffset = BridgeText(el).Length;
-        else
-            state.EndOffset = el.ChildNodes.Count;
-        state.UpdateCollapsed();
+        state.SelectNodeContents(el);
         return JSUndefined.Value;
     }
 
 
-    private JSValue JsTraversalCloneContents032Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalCloneContents032Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments a) =>
+        bridge.ToJSObject(state.CloneContents());
+
+
+    private JSValue JsTraversalExtractContents033Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments a) =>
+        bridge.ToJSObject(state.ExtractContents());
+
+
+    private JSValue JsTraversalDeleteContents034Core(global::Broiler.Dom.DomRange state, in Arguments a)
     {
-        var fragment = CreateBridgeElement("#document-fragment");
-        bridge._knownNodes.Add(fragment);
-        var nodes = GetNodesInRange(state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset);
-        foreach (var node in nodes)
-        {
-            var clone = bridge.CloneDomElement(node, true);
-            SetParent(clone, fragment);
-            fragment.AppendChild(clone);
-            bridge._knownNodes.Add(clone);
-        }
-
-        return bridge.ToJSObject(fragment);
-    }
-
-
-    private JSValue JsTraversalExtractContents033Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
-    {
-        var fragment = CreateBridgeElement("#document-fragment");
-        bridge._knownNodes.Add(fragment);
-        // Handle same-container text node case
-        if (ReferenceEquals(state.StartContainer, state.EndContainer) && (IsText(state.StartContainer) || IsComment(state.StartContainer)))
-        {
-            var text = BridgeText(state.StartContainer);
-            var s = Math.Max(0, Math.Min(state.StartOffset, text.Length));
-            var e2 = Math.Max(s, Math.Min(state.EndOffset, text.Length));
-            var extractedText = text.Substring(s, e2 - s);
-            SetBridgeText(state.StartContainer, text.Substring(0, s) + text.Substring(e2));
-            var textNode = CreateBridgeTextNode(extractedText);
-            SetParent(textNode, fragment);
-            fragment.AppendChild(textNode);
-            bridge._knownNodes.Add(textNode);
-            state.EndContainer = state.StartContainer;
-            state.EndOffset = state.StartOffset;
-            state.Collapsed = true;
-            return bridge.ToJSObject(fragment);
-        }
-
-        // Handle same-container element case (simple child extraction)
-        if (ReferenceEquals(state.StartContainer, state.EndContainer))
-        {
-            var count = Math.Min(state.EndOffset, state.StartContainer.ChildNodes.Count) - state.StartOffset;
-            for (var i = 0; i < count; i++)
-            {
-                var child = ChildAt(state.StartContainer, state.StartOffset);
-                RemoveNthChild(state.StartContainer, state.StartOffset);
-                SetParent(child, fragment);
-                fragment.AppendChild(child);
-            }
-
-            state.EndContainer = state.StartContainer;
-            state.EndOffset = state.StartOffset;
-            state.Collapsed = true;
-            return bridge.ToJSObject(fragment);
-        }
-
-        // Handle cross-node extraction using the DOM spec algorithm:
-        // 1. Find common ancestor
-        // 2. Find first/last partially contained children
-        // 3. Clone start path, move fully contained, clone end path
-        var ancestor = FindCommonAncestor(state.StartContainer, state.EndContainer);
-        if (ancestor == null)
-        {
-            state.EndContainer = state.StartContainer;
-            state.EndOffset = state.StartOffset;
-            state.Collapsed = true;
-            return bridge.ToJSObject(fragment);
-        }
-
-        // Find the child of ancestor that is an ancestor of (or is) startContainer.
-        // RF-BRIDGE-1c Phase F (F3c part 2b): a boundary child can be a text node.
-        Broiler.Dom.DomNode? startAncestorChild = null;
-        {
-            Broiler.Dom.DomNode? node = state.StartContainer;
-            while (node != null && !ReferenceEquals(node.ParentNode, ancestor))
-                node = node.ParentNode;
-            startAncestorChild = node;
-        }
-
-        // Find the child of ancestor that is an ancestor of (or is) endContainer
-        Broiler.Dom.DomNode? endAncestorChild = null;
-        {
-            Broiler.Dom.DomNode? node = state.EndContainer;
-            while (node != null && !ReferenceEquals(node.ParentNode, ancestor))
-                node = node.ParentNode;
-            endAncestorChild = node;
-        }
-
-        var startIdx2 = startAncestorChild != null ? ChildIndexOf(ancestor, startAncestorChild) : -1;
-        var endIdx2 = endAncestorChild != null ? ChildIndexOf(ancestor, endAncestorChild) : -1;
-        // Clone start-side path (first partially contained child)
-        if (startAncestorChild != null && startIdx2 >= 0)
-        {
-            if (ReferenceEquals(startAncestorChild, state.StartContainer))
-            {
-                // Start container IS the direct child of ancestor
-                if (IsText(state.StartContainer))
-                {
-                    // Text node: split at startOffset
-                    var text = BridgeText(state.StartContainer);
-                    var extractedPart = text.Substring(state.StartOffset);
-                    SetBridgeText(state.StartContainer, text.Substring(0, state.StartOffset));
-                    var extractedNode = bridge.CreateBridgeTextNode(extractedPart);
-                    bridge._knownNodes.Add(extractedNode);
-                    SetParent(extractedNode, fragment);
-                    fragment.AppendChild(extractedNode);
-                }
-                else
-                {
-                    // Element container (text case handled above); clone and extract children.
-                    var clone = CloneDomElement(state.StartContainer, false);
-                    bridge._knownNodes.Add(clone);
-                    for (var ci = state.StartOffset; ci < state.StartContainer.ChildNodes.Count;)
-                    {
-                        var child = ChildAt(state.StartContainer, ci);
-                        RemoveNthChild(state.StartContainer, ci);
-                        SetParent(child, clone);
-                        clone.AppendChild(child);
-                    }
-
-                    SetParent(clone, fragment);
-                    fragment.AppendChild(clone);
-                }
-            }
-            else
-            {
-                // Start container is deeper — clone the path from startAncestorChild down
-                var clone = ExtractStartPath(startAncestorChild, state.StartContainer, state.StartOffset, bridge);
-                if (clone != null)
-                {
-                    SetParent(clone, fragment);
-                    fragment.AppendChild(clone);
-                }
-            }
-        }
-
-        // Move fully contained children between start and end paths
-        if (startIdx2 >= 0 && endIdx2 >= 0)
-        {
-            for (var ci = startIdx2 + 1; ci < endIdx2;)
-            {
-                var child = ChildAt(ancestor, ci);
-                RemoveNthChild(ancestor, ci);
-                endIdx2--;
-                SetParent(child, fragment);
-                fragment.AppendChild(child);
-            }
-        }
-
-        // Clone end-side path (last partially contained child)
-        if (endAncestorChild != null && endIdx2 >= 0 && !ReferenceEquals(startAncestorChild, endAncestorChild))
-        {
-            if (ReferenceEquals(endAncestorChild, state.EndContainer))
-            {
-                if (IsText(state.EndContainer))
-                {
-                    var text = BridgeText(state.EndContainer);
-                    var extractedPart = text.Substring(0, state.EndOffset);
-                    SetBridgeText(state.EndContainer, text.Substring(state.EndOffset));
-                    var extractedNode = bridge.CreateBridgeTextNode(extractedPart);
-                    bridge._knownNodes.Add(extractedNode);
-                    SetParent(extractedNode, fragment);
-                    fragment.AppendChild(extractedNode);
-                }
-                else
-                {
-                    // Element container (text case handled above); clone and extract children.
-                    var clone = CloneDomElement(state.EndContainer, false);
-                    bridge._knownNodes.Add(clone);
-                    for (var ci = 0; ci < state.EndOffset && state.EndContainer.ChildNodes.Count > 0; ci++)
-                    {
-                        var child = ChildAt(state.EndContainer, 0);
-                        RemoveNthChild(state.EndContainer, 0);
-                        SetParent(child, clone);
-                        clone.AppendChild(child);
-                    }
-
-                    SetParent(clone, fragment);
-                    fragment.AppendChild(clone);
-                }
-            }
-            else
-            {
-                var clone = ExtractEndPath(endAncestorChild, state.EndContainer, state.EndOffset, bridge);
-                if (clone != null)
-                {
-                    SetParent(clone, fragment);
-                    fragment.AppendChild(clone);
-                }
-            }
-        }
-
-        // Collapse range to start after extraction
-        state.EndContainer = state.StartContainer;
-        state.EndOffset = state.StartOffset;
-        state.Collapsed = true;
-        return bridge.ToJSObject(fragment);
-    }
-
-
-    private JSValue JsTraversalDeleteContents034Core(global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
-    {
-        var nodes = GetNodesInRange(state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset);
-        foreach (var node in nodes)
-        {
-            node.Remove();
-            SetParent(node, null);
-        }
-
-        state.EndContainer = state.StartContainer;
-        state.EndOffset = state.StartOffset;
-        state.Collapsed = true;
+        state.DeleteContents();
         return JSUndefined.Value;
     }
 
 
-    private JSValue JsTraversalInsertNode035Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalInsertNode035Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments a)
     {
         if (a.Length == 0)
             throw new JSException("Failed to execute 'insertNode': 1 argument required.");
@@ -727,57 +460,20 @@ public sealed partial class DomBridge
         var el = bridge.FindDomNodeByJSObject(nodeObj);
         if (el == null)
             return JSUndefined.Value;
-        // Remove from old parent if needed
-        el.Remove();
-        // If start container is a text node, split it
-        if (IsText(state.StartContainer))
+        try
         {
-            var parent = ParentEl(state.StartContainer);
-            if (parent == null)
-                return JSUndefined.Value;
-            var text = BridgeText(state.StartContainer);
-            var splitOffset = Math.Min(state.StartOffset, text.Length);
-            var beforeText = text.Substring(0, splitOffset);
-            var afterText = text.Substring(splitOffset);
-            // Remember original text node for endContainer adjustment
-            var originalTextNode = state.StartContainer;
-            var originalEndIsSame = ReferenceEquals(state.EndContainer, originalTextNode);
-            var originalEndOffset = state.EndOffset;
-            // Update original text node
-            SetBridgeText(state.StartContainer, beforeText);
-            // Create remainder text node
-            var remainder = bridge.CreateBridgeTextNode(afterText);
-            bridge._knownNodes.Add(remainder);
-            // Insert: [before] [insertedNode] [after]
-            var textIdx = ChildIndexOf(parent, state.StartContainer);
-            SetParent(el, parent);
-            InsertChildAt(parent, textIdx + 1, el);
-            SetParent(remainder, parent);
-            InsertChildAt(parent, textIdx + 2, remainder);
-            // Per spec: update range boundary points after text split
-            state.StartContainer = parent;
-            state.StartOffset = textIdx + 1; // index of inserted node
-            if (originalEndIsSame)
-            {
-                // End was in the same text node — adjust for the split
-                state.EndContainer = parent;
-                state.EndOffset = textIdx + 2; // after the inserted node
-            }
-
-            state.UpdateCollapsed();
+            state.InsertNode(el);
         }
-        else
+        catch (Broiler.Dom.DomException ex)
         {
-            SetParent(el, state.StartContainer);
-            var insertIdx = Math.Min(state.StartOffset, state.StartContainer.ChildNodes.Count);
-            InsertChildAt(state.StartContainer, insertIdx, el);
+            ThrowDOMException(bridge._jsContext!, ex.Message, ex.Name);
         }
 
         return JSUndefined.Value;
     }
 
 
-    private JSValue JsTraversalSurroundContents036Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalSurroundContents036Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments a)
     {
         if (a.Length == 0)
             throw new JSException("Failed to execute 'surroundContents': 1 argument required.");
@@ -787,59 +483,17 @@ public sealed partial class DomBridge
         var newParent = bridge.FindDomElementByJSObject(nodeObj);
         if (newParent == null)
             return JSUndefined.Value;
-        // Check if the range partially selects any non-Text node
-        // If start and end containers differ and either is not a text node,
-        // we need to check if the range partially selects a non-Text node
-        if (!ReferenceEquals(state.StartContainer, state.EndContainer))
-        {
-            // Check if start container is partially selected (text/comment node with offset in middle)
-            bool startPartial = (IsText(state.StartContainer) || IsComment(state.StartContainer)) && state.StartOffset > 0;
-            bool endPartial = (IsText(state.EndContainer) || IsComment(state.EndContainer)) && state.EndOffset < BridgeText(state.EndContainer).Length;
-            // Per spec: if any non-Text node is partially contained, throw HIERARCHY_REQUEST_ERR
-            var ancestor = FindCommonAncestor(state.StartContainer, state.EndContainer);
-            if (ancestor != null)
-            {
-                // Check if startContainer's ancestors up to common ancestor are partially selected
-                var node = state.StartContainer;
-                while (node != null && !ReferenceEquals(node, ancestor))
-                {
-                    if (!IsText(node) && !IsComment(node))
-                    {
-                        // Non-text node between start/end — check if partially selected
-                        if (!ReferenceEquals(node, state.StartContainer) || !ReferenceEquals(node, state.EndContainer))
-                        {
-                            // For the specific case test 11 tests: surround contents across two comments
-                            // Both startContainer and endContainer are comment nodes with middle offsets
-                            // This is a BAD_BOUNDARYPOINTS_ERR scenario
-                        }
-                    }
 
-                    node = ParentEl(node);
-                }
-            }
-
-            // If both are comment/text nodes but different, the range spans partially across non-text nodes
-            // In Acid3 test 11, both are comment nodes partially selected — per spec this raises an exception
-            if ((IsText(state.StartContainer) || IsComment(state.StartContainer)) && (IsText(state.EndContainer) || IsComment(state.EndContainer)) && startPartial && endPartial)
-            {
-                // BAD_BOUNDARYPOINTS_ERR / INVALID_STATE_ERR
-                ThrowDOMException(bridge._jsContext!, "Invalid state", "InvalidStateError");
-                return JSUndefined.Value;
-            }
-        }
-
-        // Check: inserting newParent into startContainer — must not violate hierarchy
-        // Document node can only have one element child. RF-BRIDGE-1c Phase F (F3c part 2b):
-        // only an element container carries #document/#subdoc-root TagName; a text container
-        // never enters this branch.
+        // Bridge-specific compatibility guard (not part of canonical surroundContents): the
+        // #document / #subdoc-root sentinels are plain elements to the canonical DOM, so its
+        // single-document-element hierarchy rule does not fire. Preserve the Acid3-era check that
+        // surrounding at the document level cannot introduce a second element child.
         if (state.StartContainer is Broiler.Dom.DomElement startContainerElement &&
             (string.Equals(startContainerElement.TagName, "#document", StringComparison.OrdinalIgnoreCase) || string.Equals(startContainerElement.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase)))
         {
-            // Count existing element children (minus any that will be moved into newParent)
             var nodes = GetNodesInRange(state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset);
             var elemCount = ChildElements(startContainerElement).Count(c => !IsText(c) && !IsComment(c));
             var removedElems = nodes.Count(n => !IsText(n) && !IsComment(n));
-            // After removal + adding newParent, there would be (elemCount - removedElems + 1) element children
             if (elemCount - removedElems + 1 > 1 || (!string.Equals(newParent.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase) && !IsComment(newParent)))
             {
                 ThrowDOMException(bridge._jsContext!, "Hierarchy request error", "HierarchyRequestError");
@@ -847,23 +501,22 @@ public sealed partial class DomBridge
             }
         }
 
-        var rangeNodes = GetNodesInRange(state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset);
-        foreach (var node in rangeNodes)
+        // The canonical algorithm handles the partial-non-text (InvalidStateError, incl. comment
+        // boundaries) and invalid-newParent (InvalidNodeTypeError) checks, the extract, and the wrap.
+        try
         {
-            node.Remove();
-            SetParent(node, newParent);
-            newParent.AppendChild(node);
+            state.SurroundContents(newParent);
+        }
+        catch (Broiler.Dom.DomException ex)
+        {
+            ThrowDOMException(bridge._jsContext!, ex.Message, ex.Name);
         }
 
-        newParent.Remove();
-        SetParent(newParent, state.StartContainer);
-        var idx = Math.Min(state.StartOffset, state.StartContainer.ChildNodes.Count);
-        InsertChildAt(state.StartContainer, idx, newParent);
         return JSUndefined.Value;
     }
 
 
-    private JSValue JsTraversalCloneRange037Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalCloneRange037Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments a)
     {
         var clone = bridge.BuildRange();
         // Set clone boundaries via internal approach
@@ -875,7 +528,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsTraversalCompareBoundaryPoints038Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalCompareBoundaryPoints038Core(global::Broiler.HtmlBridge.DomBridge? bridge, global::Broiler.Dom.DomRange state, in Arguments a)
     {
         if (a.Length < 2)
             throw new JSException("Failed to execute 'compareBoundaryPoints': 2 arguments required.");
@@ -903,7 +556,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsTraversalToString039Core(global::Broiler.HtmlBridge.DomBridge.RangeState? state, in Arguments a)
+    private JSValue JsTraversalToString039Core(global::Broiler.Dom.DomRange state, in Arguments a)
     {
         var sb = new StringBuilder();
         // Handle case where range is within a single text/comment node

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
@@ -291,11 +291,13 @@ public sealed partial class DomBridge
     {
         var range = new JSObject();
         var docRoot = documentRoot ?? _documentNode;
-        var state = new RangeState(docRoot);
+        var state = new BridgeDomRange(this, docRoot);
         var bridge = this;
 
-        // Register this range for mutation tracking
-        _activeRanges.Add(new WeakReference<RangeState>(state));
+        // Register this range for mutation tracking. The range is non-tracking (it does not
+        // subscribe to the document mutation event), so a script-abandoned range stays
+        // weakly held here and is GC-collectable; NotifyChildRemoved drives its adjustment.
+        _activeRanges.Add(new WeakReference<Broiler.Dom.DomRange>(state));
 
         // startContainer
         range.FastAddProperty(
@@ -594,109 +596,6 @@ public sealed partial class DomBridge
         }
     }
 
-    /// <summary>
-    /// Creates a partial clone for extractContents when a boundary is in a text node.
-    /// Clones the ancestor chain from the text node up to (but not including) the common ancestor.
-    /// </summary>
-    private static Broiler.Dom.DomNode? CreatePartialCloneForExtract(Broiler.Dom.DomNode textNode, Broiler.Dom.DomElement commonAncestor, string extractedText, bool isStart, DomBridge bridge)
-    {
-        // Build the chain: textNode → parent → ... → child-of-commonAncestor. chain[0] is the
-        // boundary text node; chain[1..] are ancestor elements (RF-BRIDGE-1c Phase F, F3c part 2d).
-        var chain = new List<Broiler.Dom.DomNode>();
-        Broiler.Dom.DomNode? node = textNode;
-        while (node != null && !ReferenceEquals(node, commonAncestor))
-        {
-            chain.Add(node);
-            node = node.ParentNode;
-        }
-        if (chain.Count == 0) return null;
-
-        // Create text node with extracted content
-        var extractedTextNode = bridge.CreateBridgeTextNode(extractedText);
-        bridge._knownNodes.Add(extractedTextNode);
-
-        if (chain.Count == 1)
-        {
-            // Text node is direct child of common ancestor
-            return extractedTextNode;
-        }
-
-        // Clone the chain (from top to bottom)
-        Broiler.Dom.DomElement? topClone = null;
-        Broiler.Dom.DomElement? currentParent = null;
-        for (var i = chain.Count - 1; i >= 1; i--)
-        {
-            // chain[i] for i >= 1 is an ancestor element.
-            var original = (Broiler.Dom.DomElement)chain[i];
-            var clone = bridge.CreateBridgeElement(original.TagName);
-            bridge._knownNodes.Add(clone);
-
-            if (topClone == null) topClone = clone;
-            if (currentParent != null)
-            {
-                SetParent(clone, currentParent);
-                currentParent.AppendChild(clone);
-            }
-
-            // For start boundary: include siblings after the text node within this element
-            // For end boundary: include siblings before the text node within this element
-            if (i == 1) // direct parent of text node
-            {
-                var childIdx = ChildIndexOf(original, chain[0]);
-                if (isStart)
-                {
-                    // Include the extracted text + remaining siblings
-                    SetParent(extractedTextNode, clone);
-                    clone.AppendChild(extractedTextNode);
-                    // Move siblings after the text node into the clone
-                    for (var j = childIdx + 1; j < original.ChildNodes.Count; )
-                    {
-                        var sibling = ChildAt(original, j);
-                        RemoveNthChild(original, j);
-                        SetParent(sibling, clone);
-                        clone.AppendChild(sibling);
-                    }
-                }
-                else
-                {
-                    // Move siblings before the text node into the clone
-                    for (var j = 0; j < childIdx; )
-                    {
-                        var sibling = ChildAt(original, 0);
-                        RemoveNthChild(original, 0);
-                        childIdx--;
-                        SetParent(sibling, clone);
-                        clone.AppendChild(sibling);
-                    }
-                    SetParent(extractedTextNode, clone);
-                    clone.AppendChild(extractedTextNode);
-                }
-            }
-            currentParent = clone;
-        }
-
-        return topClone;
-    }
-
-    /// <summary>
-    /// Checks if a node is fully contained between start and end containers in the range.
-    /// </summary>
-    private static bool IsContainedInRange(Broiler.Dom.DomElement node, Broiler.Dom.DomElement ancestor, Broiler.Dom.DomElement startContainer, Broiler.Dom.DomElement endContainer, List<Broiler.Dom.DomElement> allNodes)
-    {
-        // A node is fully contained if it and all its descendants are between start and end
-        var nodeIdx = allNodes.IndexOf(node);
-        var startIdx = allNodes.IndexOf(startContainer);
-        var endIdx = allNodes.IndexOf(endContainer);
-
-        if (nodeIdx <= startIdx || nodeIdx >= endIdx) return false;
-
-        // Check that the node is not an ancestor of start or end container
-        if (IsDescendant(node, startContainer) || IsDescendant(node, endContainer))
-            return false;
-
-        return true;
-    }
-
     private JSObject CreateDomRectObject((double Left, double Top, double Width, double Height) rectData)
     {
         var rect = new JSObject();
@@ -711,7 +610,7 @@ public sealed partial class DomBridge
         return rect;
     }
 
-    private List<(double Left, double Top, double Width, double Height)> GetClientRectsForRange(RangeState state)
+    private List<(double Left, double Top, double Width, double Height)> GetClientRectsForRange(Broiler.Dom.DomRange state)
     {
         var rects = new List<(double Left, double Top, double Width, double Height)>();
         if (state.Collapsed)
@@ -770,254 +669,43 @@ public sealed partial class DomBridge
     }
 
     /// <summary>
-    /// Extracts the start-side path for cross-node extractContents.
-    /// Clones ancestor chain from <paramref name="topNode"/> down to <paramref name="startContainer"/>,
-    /// moving content after the start boundary into the cloned structure.
+    /// The bridge's live <c>Range</c> boundary store and content-operation engine — the
+    /// canonical <see cref="Broiler.Dom.DomRange"/> with the node-creation seams overridden so
+    /// content operations mint bridge nodes: <c>#document-fragment</c> result fragments and
+    /// <see cref="DomBridge.CloneDomElement"/> clones that carry host runtime state (form-control
+    /// value/checked, scroll, dialog/shadow, live inline style), all registered in
+    /// <see cref="DomBridge._knownNodes"/> so <see cref="DomBridge.ToJSObject"/> can wrap them.
+    /// Constructed <c>trackMutations: false</c> — the bridge already drives boundary adjustment
+    /// from <see cref="DomBridge.NotifyChildRemoved"/> via its weak <see cref="DomBridge._activeRanges"/>
+    /// registry, so the range must not also self-subscribe to the document mutation event (which
+    /// would double-adjust and root the range for the document's lifetime).
     /// </summary>
-    private static Broiler.Dom.DomNode ExtractStartPath(Broiler.Dom.DomNode topNode, Broiler.Dom.DomNode startContainer, int startOffset, DomBridge bridge)
+    private sealed class BridgeDomRange(DomBridge bridge, Broiler.Dom.DomNode root)
+        : Broiler.Dom.DomRange(root, trackMutations: false)
     {
-        // Build chain: startContainer → parent → ... → topNode. RF-BRIDGE-1c Phase F (F3c
-        // part 2b): chain[0] (the boundary container) may be a text node; the rest are ancestor
-        // elements, so the chain is DomNode-typed.
-        var chain = new List<Broiler.Dom.DomNode>();
-        Broiler.Dom.DomNode? node = startContainer;
-        while (node != null)
+        protected override Broiler.Dom.DomNode CreateResultFragment()
         {
-            chain.Add(node);
-            if (ReferenceEquals(node, topNode)) break;
-            node = node.ParentNode;
+            var fragment = bridge.CreateBridgeElement("#document-fragment");
+            bridge._knownNodes.Add(fragment);
+            return fragment;
         }
 
-        // Pass 1: Clone the ancestor chain from top to bottom, creating
-        // the skeletal tree structure.  Map each chain index to its clone.
-        var clones = new Broiler.Dom.DomNode[chain.Count];
-        for (var i = chain.Count - 1; i >= 0; i--)
+        protected override Broiler.Dom.DomNode CloneForRange(Broiler.Dom.DomNode node, bool deep)
         {
-            var original = chain[i];
-            var clone = bridge.CloneDomElement(original, false);
+            var clone = bridge.CloneDomElement(node, deep);
             bridge._knownNodes.Add(clone);
-            clones[i] = clone;
-            if (i < chain.Count - 1)
-            {
-                SetParent(clone, clones[i + 1]);
-                // Will position correctly in Pass 2
-            }
+            return clone;
         }
 
-        // Pass 2: Process each level bottom-up so that each clone's
-        // child list is built in the correct order:
-        //   [next-in-chain clone, siblings moved from original]
-        for (var i = 0; i < chain.Count; i++)
+        protected override Broiler.Dom.DomText CreateTextForRange(string data)
         {
-            var original = chain[i];
-            var clone = clones[i];
-
-            if (i == 0)
-            {
-                // This is the startContainer level
-                if (IsText(original))
-                {
-                    var text = BridgeText(original);
-                    var extractedPart = text.Substring(startOffset);
-                    SetBridgeText(original, text.Substring(0, startOffset));
-                    SetBridgeText(clone, extractedPart);
-                }
-                else
-                {
-                    for (var ci = startOffset; ci < original.ChildNodes.Count; )
-                    {
-                        var child = ChildAt(original, ci);
-                        RemoveNthChild(original, ci);
-                        SetParent(child, clone);
-                        clone.AppendChild(child);
-                    }
-                }
-            }
-            else
-            {
-                var parentClone = clones[i];
-                var childClone = clones[i - 1]; // next-in-chain clone
-
-                // First add the deeper clone (already populated from previous iterations)
-                SetParent(childClone, parentClone);
-                parentClone.AppendChild(childClone);
-
-                // Then move siblings after the chain child in the original
-                var nextInChain = chain[i - 1];
-                var childIdx = ChildIndexOf(original, nextInChain);
-                if (childIdx >= 0)
-                {
-                    for (var ci = childIdx + 1; ci < original.ChildNodes.Count; )
-                    {
-                        var child = ChildAt(original, ci);
-                        RemoveNthChild(original, ci);
-                        SetParent(child, parentClone);
-                        parentClone.AppendChild(child);
-                    }
-                }
-            }
+            var text = (Broiler.Dom.DomText)bridge.CreateBridgeTextNode(data);
+            bridge._knownNodes.Add(text);
+            return text;
         }
 
-        return clones[chain.Count - 1];
-    }
-
-    /// <summary>
-    /// Extracts the end-side path for cross-node extractContents.
-    /// Clones ancestor chain from <paramref name="topNode"/> down to <paramref name="endContainer"/>,
-    /// moving content before the end boundary into the cloned structure.
-    /// </summary>
-    private static Broiler.Dom.DomNode ExtractEndPath(Broiler.Dom.DomNode topNode, Broiler.Dom.DomNode endContainer, int endOffset, DomBridge bridge)
-    {
-        // Build chain: endContainer → parent → ... → topNode (chain[0] may be a text node; see
-        // ExtractStartPath).
-        var chain = new List<Broiler.Dom.DomNode>();
-        Broiler.Dom.DomNode? node = endContainer;
-        while (node != null)
-        {
-            chain.Add(node);
-            if (ReferenceEquals(node, topNode)) break;
-            node = node.ParentNode;
-        }
-
-        // Pass 1: Create clones for the chain
-        var clones = new Broiler.Dom.DomNode[chain.Count];
-        for (var i = chain.Count - 1; i >= 0; i--)
-        {
-            var original = chain[i];
-            var clone = bridge.CloneDomElement(original, false);
-            bridge._knownNodes.Add(clone);
-            clones[i] = clone;
-        }
-
-        // Pass 2: Process bottom-up. For end-side, siblings before the
-        // chain child are moved, then the deeper clone is appended.
-        for (var i = 0; i < chain.Count; i++)
-        {
-            var original = chain[i];
-            var clone = clones[i];
-
-            if (i == 0)
-            {
-                // This is the endContainer level
-                if (IsText(original))
-                {
-                    var text = BridgeText(original);
-                    var extractedPart = text.Substring(0, endOffset);
-                    SetBridgeText(original, text.Substring(endOffset));
-                    SetBridgeText(clone, extractedPart);
-                }
-                else
-                {
-                    for (var ci = 0; ci < endOffset && original.ChildNodes.Count > 0; ci++)
-                    {
-                        var child = ChildAt(original, 0);
-                        RemoveNthChild(original, 0);
-                        SetParent(child, clone);
-                        clone.AppendChild(child);
-                    }
-                }
-            }
-            else
-            {
-                var parentClone = clones[i];
-                var childClone = clones[i - 1]; // next-in-chain clone
-
-                // First move siblings before the chain child in the original
-                var nextInChain = chain[i - 1];
-                var childIdx = ChildIndexOf(original, nextInChain);
-                if (childIdx >= 0)
-                {
-                    for (var ci = 0; ci < childIdx; )
-                    {
-                        var child = ChildAt(original, 0);
-                        RemoveNthChild(original, 0);
-                        childIdx--;
-                        SetParent(child, parentClone);
-                        parentClone.AppendChild(child);
-                    }
-                }
-
-                // Then add the deeper clone (already populated)
-                SetParent(childClone, parentClone);
-                parentClone.AppendChild(childClone);
-            }
-        }
-
-        return clones[chain.Count - 1];
-    }
-
-    /// <summary>
-    /// Tracks the boundary-point state of a live <c>Range</c> object so that
-    /// DOM mutations can adjust boundaries per the DOM Living Standard.
-    /// </summary>
-    private sealed class RangeState
-    {
-        // RF-BRIDGE-1c Phase F (F3c part 2b): range boundary points are canonical DomNode —
-        // a range commonly starts/ends inside a text node. Behaviour-preserving on today's
-        // homogeneous facade tree (facade text nodes are Broiler.Dom.DomElement, so the DomNode fields hold
-        // the same values); forward-correct once text/comment flip to canonical DomText/DomComment.
-        public Broiler.Dom.DomNode StartContainer;
-        public int StartOffset;
-        public Broiler.Dom.DomNode EndContainer;
-        public int EndOffset;
-        public bool Collapsed;
-        public Broiler.Dom.DomNode Root { get; }
-
-        public RangeState(Broiler.Dom.DomNode root)
-        {
-            Root = root;
-            StartContainer = root;
-            EndContainer = root;
-            Collapsed = true;
-        }
-
-        public void UpdateCollapsed()
-        {
-            Collapsed = ReferenceEquals(StartContainer, EndContainer) && StartOffset == EndOffset;
-        }
-
-        /// <summary>
-        /// Adjusts boundary points when a child is removed from <paramref name="parent"/>
-        /// at <paramref name="index"/>.  Per DOM spec §14.4 "Removing steps".
-        /// </summary>
-        public void AdjustForRemoval(Broiler.Dom.DomNode parent, Broiler.Dom.DomNode removedChild, int index)
-        {
-            // If startContainer is a descendant of removedChild (or IS removedChild),
-            // set start to (parent, index).
-            if (ReferenceEquals(StartContainer, removedChild) || IsDescendantOf(StartContainer, removedChild))
-            {
-                StartContainer = parent;
-                StartOffset = index;
-            }
-            else if (ReferenceEquals(StartContainer, parent) && StartOffset > index)
-            {
-                StartOffset--;
-            }
-
-            // Same for endContainer
-            if (ReferenceEquals(EndContainer, removedChild) || IsDescendantOf(EndContainer, removedChild))
-            {
-                EndContainer = parent;
-                EndOffset = index;
-            }
-            else if (ReferenceEquals(EndContainer, parent) && EndOffset > index)
-            {
-                EndOffset--;
-            }
-
-            UpdateCollapsed();
-        }
-
-        private static bool IsDescendantOf(Broiler.Dom.DomNode node, Broiler.Dom.DomNode potentialAncestor)
-        {
-            var current = node.ParentNode;
-            while (current != null)
-            {
-                if (ReferenceEquals(current, potentialAncestor)) return true;
-                current = current.ParentNode;
-            }
-            return false;
-        }
+        protected override Broiler.Dom.DomRange CreateSubRange(Broiler.Dom.DomNode root) =>
+            new BridgeDomRange(bridge, root);
     }
 
     /// <summary>
@@ -1036,7 +724,7 @@ public sealed partial class DomBridge
         for (var i = _activeRanges.Count - 1; i >= 0; i--)
         {
             if (_activeRanges[i].TryGetTarget(out var state))
-                state.AdjustForRemoval(parent, removedChild, index);
+                state.NotifyNodeRemoved(parent, removedChild, index);
             else
                 _activeRanges.RemoveAt(i); // GC'd — prune
         }


### PR DESCRIPTION
Moves the bridge's DOM `Range` off its own hand-rolled machinery and onto the canonical `Broiler.Dom.DomRange`. Two layers: the canonical content operations + host seams (submodule, **Broiler-Platform/Broiler.DOM#7**), and the bridge rewire that consumes them (this PR). Bumps the `Broiler.DOM` pointer to the submodule commit.

## Canonical (Broiler.DOM#7)
DOM §4.5 content operations (`extract`/`clone`/`delete`/`insert`/`surround` + selection helpers) on `DomRange`, plus four overridable node-creation seams and a non-tracking construction mode so a host can back the JS `Range` with it.

## Bridge rewire (this PR)
- Deletes `RangeState`; the live JS `Range` is backed by a `BridgeDomRange : Broiler.Dom.DomRange` (constructed `trackMutations: false`) that overrides the seams to mint bridge nodes — `#document-fragment` fragments and `CloneDomElement` clones carrying **host runtime state** (form-control value/checked, scroll, dialog/shadow, live inline style), registered in `_knownNodes`. This is why the rewire routes through seams rather than the plain canonical clone: canonical `CloneNode` can't reproduce that per-node state.
- Every `Range` JS callback delegates to the canonical `DomRange` (content ops + `setStart`/`setEnd`/`setStart|EndBefore|After`/`collapse`/`selectNode`/`selectNodeContents`).
- Removes the bridge's ad-hoc extract helpers (`ExtractStartPath`/`ExtractEndPath`/`CreatePartialCloneForExtract`/`IsContainedInRange`) and boundary math.
- External-mutation adjustment still flows through the weak `_activeRanges` registry (preserving the no-leak `WeakReference` design), now via `DomRange.NotifyNodeRemoved`. Geometry (`getClientRects`/`getBoundingClientRect`) and `toString`/`compareBoundaryPoints` stay bridge-owned, reading boundary points off the `DomRange`.

## Behaviour note (gate-safe)
Two `insertNode` boundary-after-split Cli.Tests were updated to the **spec-correct** result: the start boundary stays in the truncated original text node rather than the pre-rewire bridge's non-spec normalization to the parent. Safe for the merge gate's subset check because `dom/ranges/Range-insertNode.html` — and all five `Range-*` content-op WPT tests — are already in the committed failed baseline, so adopting spec behavior can only hold or improve, never add a new failure.

## Verification
- `Cli.Tests` range/traversal **56/57** — the 1 failure (`Range_GetBoundingClientRect...DisplayContents`) is **pre-existing/environmental** (a `display:contents` layout that yields zero height in the bare container; baseline-confirmed to fail identically without this change)
- mutation-observer / boundary-guard / DOM-interface **90/90**; Acid3 / DOM-events / DOM-edge **120/120**; canonical `Broiler.Dom.Tests` **69/69**

Also reconciles the HtmlBridge roadmaps (§2.2 / promotion Phase 4 slice 8 → done). Like the F3c/F4 cutovers this still wants the full WPT range/selection corpus at merge (silent selection/serialization failure mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)