### PR TITLE
HtmlBridge DOM/CSS promotion: sparse computed-style, scope builder, setter validation

### DIFF
--- a/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
+++ b/docs/roadmap/htmlbridge-blocked-items-completion-roadmap.md
@@ -1,13 +1,14 @@
 # HtmlBridge Blocked-Items Completion Roadmap
 
-Status: **COMPLETE (implementation)** — Track 2 / Item 2 (RF-BRIDGE-1b geometry, Milestones 2.1–2.5)
+Status: **COMPLETE and MERGED** — Track 2 / Item 2 (RF-BRIDGE-1b geometry, Milestones 2.1–2.5)
 and Track 1 / Item 1 (v1 public-surface removal, Milestones 1.0–1.3) are all implemented and
 `Broiler.Cli.Tests`-verified. The `DomElement` facade + `HtmlTreeBuilder` are deleted (Milestone 1.3,
-Phase F4). The F3c/F4 stack is **not yet merged** — it awaits the WPT + Acid + pixel gate (dispatch-only).
+Phase F4). The F3c/F4 stack passed the WPT + Acid + pixel gate and **merged to `main` as PR #1359
+(`ecbdf406`, 2026-07-12)**.
 See [`htmlbridge-facade-removal-current-state.md`](htmlbridge-facade-removal-current-state.md) for the
 facade-removal record and [`htmlbridge-remaining-work-roadmap.md`](htmlbridge-remaining-work-roadmap.md)
 for what remains after this roadmap closes.
-Date: 2026-07-09 (Track 1 completed 2026-07-11)
+Date: 2026-07-09 (Track 1 completed 2026-07-11; stack merged 2026-07-12)
 
 ## Purpose
 
@@ -890,12 +891,12 @@ canonical `AppendChild` auto-adopts the subtree); frozen guards rewritten to "fa
 
 **Risk.** High — final cutover (done; `Cli.Tests`-verified 0 new failures).
 
-**Verification.** Full bridge suite green; the WPT/Acid/pixel gate is the remaining merge blocker; the
-promotion roadmap's Phase 5 adapter-removal workstream is satisfied (`HtmlBridge` contains bridge
-responsibilities only).
+**Verification.** Full bridge suite green; the WPT/Acid/pixel gate passed and the stack merged (PR #1359,
+2026-07-12); the promotion roadmap's Phase 5 adapter-removal workstream is satisfied (`HtmlBridge` contains
+bridge responsibilities only).
 
-**Exit criteria — MET (pending merge gate).** `DomElement`, `HtmlTreeBuilder` deleted; promotion roadmap
-Phase 5 adapter-removal workstream closed.
+**Exit criteria — MET (merged).** `DomElement`, `HtmlTreeBuilder` deleted; promotion roadmap
+Phase 5 adapter-removal workstream closed; merged as PR #1359 (2026-07-12).
 
 ---
 
@@ -912,8 +913,8 @@ Phase 5 adapter-removal workstream closed.
 9. **1.3** Remove `DomElement` + `HtmlTreeBuilder` — **done (2026-07-11); Item 1 done → this roadmap is complete**
 
 Steps 6–7 may run at any point after 1.0 is decided (they do not depend on Track
-2). Steps 8–9 depend on Track 2 completing. **All nine steps are now done** — the only
-outstanding item is the WPT + Acid + pixel merge gate for the F3c/F4 commit stack.
+2). Steps 8–9 depend on Track 2 completing. **All nine steps are now done** — and the
+F3c/F4 commit stack passed the WPT + Acid + pixel merge gate and merged as PR #1359 (2026-07-12).
 
 ## Validation plan (applies to every milestone)
 

--- a/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
+++ b/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
@@ -1,7 +1,9 @@
 # HtmlBridge DOM/CSS Promotion Roadmap
 
-Status: proposed
-Date: 2026-07-09
+Status: **active** — Phases 0–5 are done; Phase 5's adapter removal merged to `main` (PR #1359,
+2026-07-12). Remaining promotion candidates are tracked in
+[`htmlbridge-remaining-work-roadmap.md`](htmlbridge-remaining-work-roadmap.md).
+Date: 2026-07-09 (last updated 2026-07-12)
 
 ## Purpose
 
@@ -46,7 +48,7 @@ The important consequence is that `Broiler.HtmlBridge.Dom.DomElement` and `HtmlT
 | P1 | `classList` token parsing and mutation behavior | `Broiler.DOM` | Add a DOMTokenList-style ordered-token helper over attributes | The ordered-set token rules are DOM semantics; the JavaScript wrapper and callback plumbing stay in bridge. |
 | P2 | Mutation observer option matching and record filtering | `Broiler.DOM` | Add neutral filtering over `DomMutationRecord` | Canonical DOM already emits mutation records. Bridge should convert filtered records to JS callbacks, not own the filtering algorithm. |
 | P2 | Range content operations and traversal state | `Broiler.DOM` | Expand canonical `DomRange` and route TreeWalker/NodeIterator wrappers through canonical traversal | `DomRange`, `DomTreeWalker`, and `DomNodeIterator` exist in DOM, but bridge still owns several content/traversal algorithms. Geometry APIs such as `getClientRects()` stay bridge/layout-owned. |
-| P2 | Stylesheet scope assembly without fetching | `Broiler.CSS.Dom` | Add a `CssStyleScopeBuilder` or similar host-driven builder | CSS.Dom can own style/link collection, ordering, media/supports evaluation, and engine synchronization if the host supplies resource text. Fetching remains bridge/host code. |
+| P2 | Stylesheet scope assembly without fetching **(DONE 2026-07-12)** | `Broiler.CSS.Dom` | `CssStyleScopeBuilder` — media-gated, origin/order-preserving, change-detected engine sync (host supplies text). See [`htmlbridge-remaining-work-roadmap.md`](htmlbridge-remaining-work-roadmap.md) §2.4. | CSS.Dom can own style/link collection, ordering, media/supports evaluation, and engine synchronization if the host supplies resource text. Fetching remains bridge/host code. |
 | P3 | HTML serialization policies | `Broiler.Dom.Html` | Move only standard serialization policy helpers | Render-specific or Acid-test compatibility transforms should stay bridge-owned unless they are standard DOM/HTML behavior. |
 | Deferred | Image decoder, SVG parser/renderer, canvas helpers | `Broiler.Media`, `Broiler.Graphics`, or existing media roadmap | Do not move to DOM/CSS | These are shared engine capabilities, but not DOM or CSS component responsibilities. Align with the media/graphics roadmap. |
 
@@ -120,6 +122,16 @@ Exit criteria:
 - Inline style behavior is covered by CSS unit tests and bridge compatibility tests.
 
 ### Phase 2: Promote computed-style projections used by anchor/layout code
+
+> **Update (2026-07-12):** two claims below are superseded — see
+> [`htmlbridge-remaining-work-roadmap.md`](htmlbridge-remaining-work-roadmap.md) §2.1 for current state.
+> (a) **Shorthand expansion is now shared** — the bridge's `ExpandCssShorthands` was deleted and delegates
+> to `CssStyleEngine.ExpandShorthands` (the "deliberately still bridge-owned" note below is stale).
+> (b) The **form-control-sizing "needs layout" blocker is stale** — `CssStyleEngine.Computed.cs` already
+> has a layout-free `ApplyApproximateFormControlComputedSizes` inside the CSS.Dom boundary. The additive
+> `CssStyleEngine.GetSparseComputedStyle` projection (the null-for-undeclared view the `GetComputedProps`
+> consumers need) has landed; a differential parity test scoped the remaining cutover to a four-class
+> delta (UA display defaults, full-vs-sparse inheritance, value resolution, custom properties).
 
 Status: **partially delivered** (2026-07-09). The two computed-style *tables*
 that the bridge duplicated verbatim from `CssStyleEngine` — CSS initial values
@@ -304,12 +316,12 @@ Exit criteria:
 
 ### Phase 5: Public-surface cleanup
 
-Status: **adapter-removal complete (implementation), pending merge gate** (2026-07-11). All three
+Status: **adapter-removal complete and MERGED** (2026-07-12). All three
 workstreams — RF-BRIDGE-1a dead-paint removal, RF-BRIDGE-1b geometry unification (Item 2), and the v1
 compatibility-adapter removal (`DomElement`/`HtmlTreeBuilder`/`CssRules`/`CalculateSpecificity`) — are
-done and `Broiler.Cli.Tests`-verified. Phase 5's exit criteria are met; the only outstanding item is the
-WPT + Acid + pixel merge gate for the F3c/F4 commit stack (dispatch-only). Remaining promotion candidates
-beyond this phase are tracked in
+done and `Broiler.Cli.Tests`-verified. Phase 5's exit criteria are met; the F4 facade-removal stack passed
+the WPT + Acid + pixel merge gate and **merged to `main` as PR #1359 (`ecbdf406`, 2026-07-12)**. Remaining
+promotion candidates beyond this phase are tracked in
 [`htmlbridge-remaining-work-roadmap.md`](htmlbridge-remaining-work-roadmap.md).
 
 - **DONE — delete the RF-BRIDGE-1a dead paint pipeline.** The bridge's parallel,
@@ -354,7 +366,7 @@ beyond this phase are tracked in
   `HtmlTreeBuilder` **deleted** (F4). Each step is behaviour-preserving and regression-free vs the full
   `Broiler.Cli.Tests` baseline (0 new failures). See
   [`htmlbridge-facade-removal-current-state.md`](htmlbridge-facade-removal-current-state.md) for the
-  authoritative record and the WPT/Acid/pixel merge gate.
+  authoritative record; the WPT/Acid/pixel merge gate passed and the stack merged as PR #1359 (2026-07-12).
 
   **Sharpened dependency analysis (2026-07-09).** The four adapters split into two
   independent gates, not one:
@@ -452,7 +464,7 @@ Tasks:
 - Delete RF-BRIDGE-1a obsolete rendering pipeline types instead of moving them. **(done)**
 - Finish RF-BRIDGE-1b layout unification by replacing bridge recursive geometry estimators with `Broiler.Layout` read-model access.
 
-Exit criteria — **MET** (implementation; pending the WPT/Acid/pixel merge gate):
+Exit criteria — **MET** (WPT/Acid/pixel merge gate passed; merged as PR #1359, 2026-07-12):
 
 - `HtmlBridge` contains bridge responsibilities only: JS integration, compatibility surface, host/resource integration, CSSOM/DOM wrapper identity, and handoff to layout/rendering/media. ✅ (the v1 `DomElement`/`HtmlTreeBuilder` adapters are deleted)
 - DOM and CSS components own canonical algorithms and data models without bridge dependencies. ✅ (bridge tree is canonical `Broiler.Dom` nodes)

--- a/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
+++ b/docs/roadmap/htmlbridge-domelement-facade-removal-plan.md
@@ -1,11 +1,12 @@
 # HtmlBridge `DomElement` Facade Removal — Implementation Plan
 
-Status: **implemented** — all phases (A–F4) landed and `Broiler.Cli.Tests`-verified on
-`claude/htmlbridge-domelement-f3c-flip`; the facade + `HtmlTreeBuilder` are deleted. NOT merged —
-awaits the WPT + Acid + pixel gate. The authoritative "where things stand" record is
+Status: **implemented and MERGED** — all phases (A–F4) landed, `Broiler.Cli.Tests`-verified on
+`claude/htmlbridge-domelement-f3c-flip`, and **merged to `main` as PR #1359 (`ecbdf406`, 2026-07-12)**
+after passing the WPT + Acid + pixel gate; the facade + `HtmlTreeBuilder` are deleted. The authoritative
+"where things stand" record is
 [`htmlbridge-facade-removal-current-state.md`](htmlbridge-facade-removal-current-state.md); this
 plan is retained as the "how it was staged" design history.
-Date: 2026-07-10 (implemented 2026-07-11)
+Date: 2026-07-10 (implemented 2026-07-11, merged 2026-07-12)
 
 ## Purpose
 
@@ -31,9 +32,10 @@ are done. The facade removal is unblocked.
 `claude/htmlbridge-domelement-f3c-flip` and `Broiler.Cli.Tests`-verified.** The `Broiler.HtmlBridge.DomElement`
 facade and `HtmlTreeBuilder` are **deleted**; the bridge holds only canonical `Broiler.Dom` nodes + bridge
 runtime state. Each phase is its own commit, every one regression-free against the full `Broiler.Cli.Tests`
-(slot-scroll crasher excluded) environmental baseline via before/after TRX **name**-diff. **NOT merged** —
-the F3c/F4 stack awaits the WPT range/selection/serialization + Acid + pixel gate (dispatch-only). The live
-record is the [current-state doc](htmlbridge-facade-removal-current-state.md) §4/§5.
+(slot-scroll crasher excluded) environmental baseline via before/after TRX **name**-diff. **Merged** to
+`main` as PR #1359 (`ecbdf406`, 2026-07-12) after the F3c/F4 stack passed the WPT range/selection/
+serialization + Acid + pixel gate (dispatch-only). The live record is the
+[current-state doc](htmlbridge-facade-removal-current-state.md) §4/§5.
 
 **F3c part 2 decomposition — ALL DONE + `Cli.Tests`-verified:** green type-widening commits
 (**2a `ToJSObject` split; 2b `RangeState`/NodeIterator/tree-mutation + char-data wrapper; 2c `ChildAt`
@@ -473,7 +475,7 @@ happened via the `global using DomElement = Broiler.Dom.DomElement` alias rather
 
 **Risk.** High — final cutover. **Exit — MET.** `DomElement`/`HtmlTreeBuilder` deleted; promotion
 roadmap Phase 5 adapter-removal workstream satisfied ("HtmlBridge contains bridge responsibilities
-only") — pending the WPT/Acid/pixel merge gate.
+only"); the WPT/Acid/pixel merge gate passed and the stack merged as PR #1359 (2026-07-12).
 
 ## Dependency graph
 

--- a/docs/roadmap/htmlbridge-facade-removal-current-state.md
+++ b/docs/roadmap/htmlbridge-facade-removal-current-state.md
@@ -1,11 +1,12 @@
 # HtmlBridge `DomElement` Facade Removal — Current State & Handoff
 
-Status: **facade removed — F4 implemented and `Broiler.Cli.Tests`-verified (0 regressions).**
+Status: **facade removed — F4 implemented, `Broiler.Cli.Tests`-verified (0 regressions), and MERGED.**
 The `DomElement` facade and `HtmlTreeBuilder` are **deleted**; the bridge holds only canonical
-`Broiler.Dom` nodes. F3c part 2 (2a–2d) and F4 are all committed on
-`claude/htmlbridge-domelement-f3c-flip` but **NOT merged** — the whole F3c/F4 stack awaits the
-WPT range/selection/serialization + Acid + pixel gate (WPT is dispatch-only here; see §4/§5 gates).
-Last updated: 2026-07-11.
+`Broiler.Dom` nodes. F3c part 2 (2a–2d) and F4 (all committed on `claude/htmlbridge-domelement-f3c-flip`)
+**merged to `main` as PR #1359 (`ecbdf406`, 2026-07-12)** after passing the WPT range/selection/serialization
++ Acid + pixel gate (the failing WPT set was confirmed a subset of the committed baseline; no new namespace
+or range/selection/serialization regressions). The merge-gate discussion below is retained as history.
+Last updated: 2026-07-12.
 
 ## Decomposition note (F3c part 2)
 
@@ -148,7 +149,7 @@ TreeWalker, cloning, adoption, event dispatch, and serialization all handle cano
 `DomComment` correctly. Everything behaviour-preserving is done; only the irreversible flip (2d) —
 which actually puts a canonical `DomText` into the tree — remains.
 
-- ✅ **2d — the atomic construction flip. DONE + Cli.Tests-verified; ⚠️ NOT MERGED (awaits WPT gate).**
+- ✅ **2d — the atomic construction flip. DONE + Cli.Tests-verified; MERGED (PR #1359, 2026-07-12).**
   Canonical `DomText`/`DomComment` now enter the tree. `CreateBridgeTextNode`/`CreateBridgeCommentNode`
   mint `_document.CreateTextNode`/`CreateComment`; all ~17 text/comment construction sites +
   `HtmlTreeBuilder.ConvertNode` (return + `AllElements` → `List<DomNode>`) route through them. `TextContent`
@@ -166,10 +167,11 @@ which actually puts a canonical `DomText` into the tree — remains.
   `:nth-child` invalidation on whitespace-text removal); 81 → 73 environmental failures. Commit `72634e02`
   on branch `claude/htmlbridge-domelement-f3c-flip`.
 
-**⚠️ MERGE GATE:** 2d is regression-free on `Broiler.Cli.Tests` (which includes the Acid3 corpus), but the
-roadmap requires the **WPT range/selection/serialization + Acid** corpus before this irreversible step
-merges (silent `outerHTML`/selection corruption is the failure mode). WPT is dispatch-only in this
-environment — run it and confirm green before merging `72634e02`.
+**✅ MERGE GATE PASSED:** 2d is regression-free on `Broiler.Cli.Tests` (which includes the Acid3 corpus),
+and the **WPT range/selection/serialization + Acid** corpus was run green (dispatch-only) before this
+irreversible step merged — the failing WPT set was a subset of the committed baseline, no new
+`outerHTML`/selection/serialization regressions. Merged as part of PR #1359 (`72634e02` → `ecbdf406`,
+2026-07-12).
 
 **Gate (2d):** the WPT range/selection/serialization + Acid corpus in addition to `Broiler.Cli.Tests`
 (silent `outerHTML`/selection corruption is the failure mode). The green steps 2a–2c gate on
@@ -238,7 +240,7 @@ NamespaceURI-into-construction + cache re-key + seam widen (green, incremental);
 to canonical, retire `HtmlTreeBuilder`, delete both files, update guards (the irreversible cutover).
 Spike the parser-document-ownership question (item 6) before starting.
 
-### F4 — DONE + `Broiler.Cli.Tests`-verified (0 regressions); ⚠️ NOT MERGED (awaits WPT/pixel gate)
+### F4 — DONE + `Broiler.Cli.Tests`-verified (0 regressions); MERGED (PR #1359, 2026-07-12)
 
 Landed on `claude/htmlbridge-domelement-f3c-flip` as the two commits the sketch predicted:
 
@@ -275,10 +277,10 @@ excluded): **0 new failures** — after-failures (73) are a strict subset of the
 lone dropped failure is a pre-existing flaky render test (`VerticalTextPositioningTests`). Same
 environmental baseline as post-2d.
 
-**⚠️ MERGE GATE (F4 + the whole F3c stack).** Regression-free on `Broiler.Cli.Tests` (incl. Acid3), but
-the irreversible cutover still requires the **full WPT + Acid + pixel** corpus before merge (silent
-`outerHTML`/selection/render corruption is the failure mode; watch SVG/foreign `createElementNS`). WPT is
-dispatch-only in this environment — run it green before merging `aa00ecf5`/`ddad4769`.
+**✅ MERGE GATE PASSED (F4 + the whole F3c stack).** Regression-free on `Broiler.Cli.Tests` (incl. Acid3),
+and the **full WPT + Acid + pixel** corpus was run green (dispatch-only) before the irreversible cutover
+merged — no new `outerHTML`/selection/render or SVG/foreign `createElementNS` regressions; the failing WPT
+set was a subset of the committed baseline. `aa00ecf5`/`ddad4769` merged in PR #1359 (`ecbdf406`, 2026-07-12).
 
 ## 6. Verification methodology (used for every landed commit)
 

--- a/docs/roadmap/htmlbridge-remaining-work-roadmap.md
+++ b/docs/roadmap/htmlbridge-remaining-work-roadmap.md
@@ -107,9 +107,56 @@ they are prioritized independently.
 ### 2.1 Promotion Phase 2 — computed style (partially delivered)
 
 - The literal `GetComputedProps → GetComputedStyle` cutover (route the bridge's computed-property reads
-  through the canonical CSSOM computed-style path). **Still deliberately deferred** — the sparse-map vs
-  full-initials contract mismatch and the layout-dependent form-control sizing make it unsafe as a blind
-  swap (see the promotion roadmap Phase 2 for the analysis).
+  through the canonical CSSOM computed-style path). **The cutover of the ~98 call sites is still deferred,
+  but the canonical projection it needs now exists and the swap is scoped by a measured parity delta
+  (2026-07-12).**
+  - **Additive canonical projection landed.** `Broiler.CSS.Dom.CssStyleEngine.GetSparseComputedStyle`
+    (Broiler.CSS submodule) runs the full computed-style pipeline (cascade + inline, custom-property/`var()`,
+    CSS-wide keywords, shorthand + `attr()`, relative font-weight, inheritance backfill, form-control size
+    synthesis, logical-size aliases) **without** the initial-value backfill, so an undeclared non-inherited
+    property reads back absent — the null-for-undeclared contract the ~98 `GetComputedProps` consumers rely
+    on. It is the `ComputeStyle` pass gated by a new `backfillInitials:false` flag; the full
+    `GetComputedStyle`/`GetCascadedStyle` paths are unchanged. Covered by 5 `CssStyleEngineTests`. This is
+    additive — **zero call-site changes**, so it cannot regress anything on its own.
+  - **Stale blocker corrected.** The roadmap's second blocker — "layout-dependent form-control sizing" —
+    is **not** a blocker: `ApplyApproximateFormControlComputedSizes` already has a layout-free copy inside
+    `CssStyleEngine.Computed.cs` (it counts `<br>`-split text lines and reads `size`/`rows` attributes, no
+    glyph/box measurement), living within the `CssDomArchitectureTests` boundary. The only real remaining
+    contract issue is sparse-vs-full, addressed by the flag above.
+  - **Parity measured, and it is bigger than "a short reconciliation list."** A differential characterization
+    test (`SparseComputedStyleParityTests` in `Broiler.Cli.Tests`, via two internal `*ForParity` bridge
+    accessors) compares the canonical projection against the bridge's `GetComputedProps` over a corpus and
+    pins the delta to **four structural classes** — everything else matches exactly, and the test fails on any
+    *uncategorised* drift:
+    1. **UA display defaults** — the bridge injects a UA `display` for block elements
+       (`ApplyUserAgentDisplayDefaults`); the canonical projection leaves `display` to the renderer, so it is
+       present-in-bridge / absent-in-sparse. (Real gap — a swap must reconcile it.)
+    2. **Inheritance model** — the canonical projection backfills inheritance from the parent's *full*
+       computed style (every inherited property materialises from the root's initials down); the bridge
+       propagates from the parent's *sparse* map (an inherited property never declared anywhere stays absent).
+       The whole inherited-property set therefore diverges on elements that declare none of it. (Real gap.)
+    3. **Value resolution (bidirectional)** — the engine resolves `var()`/`initial`/`unset`/`bold`→`700` that
+       the bridge leaves raw; conversely the engine's `ComputeStyle` has no inherit-fold, so it emits a raw
+       `inherit` the bridge resolves. (Mostly improvements; audit at swap.)
+    4. **Custom properties** — the engine surfaces `--*`; the bridge omits them. (Benign.)
+  - **What remains (the actual cutover, still deferred) — attempt made 2026-07-12, confirmed not a
+    drop-in, reverted.** The swap was tried directly: `GetComputedProps` (`AnchorRegistry.cs`) rewritten to
+    delegate to `GetSyncedScopedEngine(el).GetSparseComputedStyle(el)` + `ApplyUserAgentDisplayDefaults`
+    (reconciling class 1), keeping the physical-inset backfill. Against a same-state baseline (3 pre-existing
+    fails) the anchor/geometry/serialization/scrollIntoView consumer clusters showed **4 new regressions**,
+    exactly the class-2/3 impact the parity delta predicted:
+    `GoogleSearchPolyfillTests.ScrollIntoView_Clamps_Fixed_Scrollers_To_Their_Scroll_Bounds` and
+    `…ScrollIntoView_Legacy_False_Aligns_To_Block_End`, plus the zoom-serialization pair
+    `ScriptEngineExecuteTests.DomBridge_SerializeToHtml_Scales_ExplicitInherited_Zoom_Properties` and
+    `…Scales_Zoomed_ScrollPadding_And_ScrollMargin_Properties`. The zoom-serialization path scales specific
+    computed properties, and the canonical projection's fuller inheritance + resolved values change *which*
+    properties are present and their form — so the swap is genuinely observable, not a no-op. **Reverted**
+    (`git checkout AnchorRegistry.cs`); clusters returned to the 3-fail baseline. **Conclusion:** the cutover
+    needs the inheritance model reconciled (sparse-inheritance projection, or a per-site audit of the
+    zoom-serialization + scrollIntoView readers) and must run behind the full WPT/Acid/pixel gate — it is not
+    a safe local-only slice. The additive projection + parity test remain the foundation for it. **Delivery
+    note:** the `GetSparseComputedStyle` API is in the `Broiler.CSS` submodule — push + pointer bump (or
+    `patches/` fallback) at commit time; the parity test + accessors are main-repo.
 - **Shorthand expansion — DONE (2026-07-12).** The bridge's `ExpandCssShorthands` (+ its private
   `ExpandFontShorthand` / `ExpandBoxShorthand` / `ExpandBorderShorthand` / `ExpandBorderSideShorthand` /
   `ExpandBackgroundShorthand` / `SplitCssValues` helpers, ~500 lines in `DomBridge/Css.cs`) is deleted and
@@ -197,13 +244,82 @@ live-setter routing.
   - **Delivery note:** the new files live in the `Broiler.CSS` **submodule** — the submodule commit must be
     pushed and the parent pointer bumped (or a `patches/` fallback if the push 403s) as part of committing
     this work.
-- **Still deferred:** routing the live `CSSStyleDeclaration` setters / stylesheet-mutation paths through
-  shared CSS APIs (higher-risk, entangled with live CSSOM object identity — a separate slice).
+- **Done (2026-07-12) — live per-property setter validation.** The remaining "live-setter routing" gap:
+  the per-property `CSSStyleDeclaration` setters (`el.style.X = …`, `setProperty(…)`, the rule-side twins,
+  `cssFloat`) wrote their value **raw** into the inline-style map with **no validation**, while the
+  attribute/`cssText` path (`el.style = "color: bogus"`) already dropped invalid declarations via
+  `ParseStyle` → the shared `CssDeclarationValidator`. That asymmetry meant `el.style.color = "bogus"`
+  *stored* the invalid value. All six live setter sites now gate through a shared
+  `DomBridge.IsAcceptableInlineValue` helper (= `CssDeclarationValidator.IsAcceptableDeclarationValue` on the
+  `!important`-stripped value) — the same closed-keyword error-recovery the attribute path uses. An invalid
+  value is now ignored (prior value kept), matching CSSOM error handling; custom (`--*`) and unknown
+  properties still pass (the validator default), and `!important` is validated on the stripped value.
+  - **Nuance found (the "live CSSOM object identity" entanglement the roadmap warned about):** the IDL
+    `SetValue` path stores the value in **two** places — the ERS inline-style map *and*, via the trailing
+    `base.SetValue`, a plain JS property on the style object that the getter reads **first**. Gating only the
+    map was silently bypassed; the fix returns early on an invalid value so `base.SetValue` never stores it
+    either. Separately, `el.style.cssFloat = …` is a **pre-existing dead path** (`cssFloat` is in
+    `NonCssNames`, so `SetValue` delegates to `base.SetValue` and never reaches the `Set009`/`Set020`
+    accessor); the gate there is harmless defensive code, and `float` set via the reachable
+    `setProperty('float', …)` path is validated.
+  - **Verified regression-free (Cli-scope):** 10 `CssStyleDeclarationValidationTests`; the CSSOM /
+    inline-style / computed-style / Acid3 clusters show **0 new failures** — the 9 residual fails all
+    **pre-existing**, confirmed by stashing the whole change set and re-running at clean HEAD (`:root`/`:lang`,
+    `HttpClientMigration`, `Acid3CascadeDebug`, `Border_Shorthand`, and the environmental Acid3 render/score/
+    image-capture + `PhaseC_NodeIterator` tests fail identically without the change). Because it changes
+    observed CSSOM behavior (invalid values now rejected), it wants the full **WPT css/cssom + Acid** gate at merge.
+  - **Delivery:** entirely main-repo (bridge `DomBridge.cs` helper + the six setter sites in
+    `DomBridge/Utilities.cs` and `DomBridge/JsFunctionCallbacks/Utilities.cs`); no submodule change.
+- **Still deferred:** the live stylesheet-**mutation** paths are already largely shared (`insertRule`/
+  `deleteRule`/`cssText` parse through `CssParser`, per Phases 3/6).
+- **Assessed, low value (2026-07-12) — `CssInlineStyleParser.ParseDeclarations` consolidation.** The
+  Phase-1 "add a shared inline-declaration parser" idea turns out **marginal**: both `DomBridge.ParseStyle`
+  and the engine's inline loop (`CssStyleEngine.cs:482`, `Computed.cs:131`) *already* use the canonical
+  `CssParser().ParseDeclarations()` + `CssDeclarationValidator.IsAcceptableDeclarationValue`, so the only
+  shared code is a ~4-line orchestration loop with **different output shapes** (the bridge formats a dict
+  with a `!important` string suffix + vendor-prefix mapping; the engine adds cascade winners). The named
+  "third copy" `HtmlCss.ParseDeclarations` (`Broiler.Documents.Html`) is a **different, naive parser**
+  (HtmlDecode + split on `;`/`:`, no CssParser, no validation, no `!important`) serving document conversion —
+  forcing it onto the canonical parser would change Documents behavior, out of scope. The one genuinely-clean
+  remaining duplicate is the **byte-identical `StripVendorPrefix`** in `DomBridge.cs:1101` and
+  `CssStyleEngine.cs:682` (promote to `Broiler.CSS.CssPropertyNames`) — a small, optional follow-up.
 
-### 2.4 Promotion-candidate backlog (P0–P3) + Open Questions
+### 2.4 Promotion Phase 2 slice-2 — stylesheet scope assembly (P2 `CssStyleScopeBuilder`) — **DONE (2026-07-12)**
 
-- The P0–P3 promotion-candidate table in the promotion roadmap (the broader "what else could move to the
-  canonical components" backlog).
+The P2 candidate "stylesheet scope assembly without fetching" — previously **never built** (a whole-repo
+search found only the roadmap mention) — is delivered.
+
+- **Canonical `Broiler.CSS.Dom.CssStyleScopeBuilder`** (Broiler.CSS submodule) owns the neutral scope
+  assembly the bridge previously did ad-hoc in `DomBridge.GetSyncedScopedEngine`: given a host-supplied,
+  document-ordered list of `StyleSource(cssText, origin, media?)`, it evaluates each source's `media`
+  attribute against the environment, keeps only the matches (in cascade-origin/document order), parses each
+  as its own sheet, and re-syncs the `CssStyleEngine` only when the effective (media-filtered) set changes.
+  The host keeps the parts that need the DOM + resource loading — discovering `<style>`/`<link>` elements,
+  fetching external sheets, extracting each sheet's CSS text. 9 `CssStyleScopeBuilderTests`.
+- **Real correctness fix, not just a move.** The old bridge path concatenated every collected sheet into one
+  blob and applied it **unconditionally**, ignoring per-element `media` — so `<style media="print">` (and
+  any non-matching `<link media>`) wrongly took effect on screen. Routing `GetSyncedScopedEngine` through the
+  builder (extracting `GetAttr(styleEl, "media")` per source) fixes this; parsing each source separately also
+  isolates a malformed sheet from the next and scopes `@import`/`@namespace` per-sheet. Pinned by
+  `StyleScopeMediaTests` (a non-matching-media sheet is excluded; matching/no-media applies).
+- **Verified regression-free (Cli-scope):** full `Broiler.CSS.Dom.Tests` 213/214 (the 1 = the pre-existing
+  `Public_Surface_Does_Not_Expose_Mutable_Collections` arch guard, baseline-confirmed via stash); bridge
+  StyleSheet/Cssom/ComputedStyle/MediaQuery/Cascade clusters 140/144 — the 4 fails all **pre-existing**
+  (`:root`/`:lang` selector, `HttpClientMigration` reflection/assembly-load, `Acid3CascadeDebug` render-pixel
+  known-limitation; the latter two confirmed failing at HEAD with the bridge change reverted). Because it
+  changes observed behavior for media-gated sheets, it still wants the full **WPT/Acid/pixel** gate at merge.
+- **Delivery note:** `CssStyleScopeBuilder.cs` + its tests are in the `Broiler.CSS` **submodule** — push +
+  pointer bump (or `patches/` fallback) at commit time; the bridge rewire + `StyleScopeMediaTests` are main-repo.
+- **Not moved (correctly host-owned):** `<style>`/`<link>` discovery (`CollectStyleElementsInTree`), external
+  fetching, and CSS-text extraction (`GetStyleElementCssText`, InnerHtml/CSSOM/runtime-state) — they need the
+  DOM and resource loading, matching the roadmap's "fetching remains bridge/host code" boundary.
+
+### 2.5 Promotion-candidate backlog (P0–P3) + Open Questions
+
+- The remaining P0–P3 promotion-candidate rows in the promotion roadmap not covered above (the broader
+  "what else could move to the canonical components" backlog). After §2.1–2.4, the notable open ones are the
+  literal `GetComputedProps`→`GetComputedStyle` **cutover** (§2.1 Slice 4, scoped by the measured delta) and
+  the live `CSSStyleDeclaration` **setter routing** (§2.3), both higher-risk behavior changes wanting the WPT gate.
 - The promotion roadmap's **Open Questions** (Open Question #5 — "declare v2" — is now answered; the rest
   remain).
 

--- a/src/Broiler.Cli.Tests/CssStyleDeclarationValidationTests.cs
+++ b/src/Broiler.Cli.Tests/CssStyleDeclarationValidationTests.cs
@@ -1,0 +1,95 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+using Xunit;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// DOM/CSS promotion §2.3 — the live per-property <c>CSSStyleDeclaration</c> setters
+/// (<c>el.style.X = …</c>, <c>setProperty(…)</c>, <c>cssFloat = …</c>) route their value through
+/// the shared <c>Broiler.CSS.Dom.CssDeclarationValidator</c>, so an invalid value is ignored
+/// rather than stored — matching the inline-style <em>attribute</em> path (which already dropped
+/// invalid declarations) and CSSOM error handling. Only closed-keyword properties reject; custom
+/// and unknown properties still pass (the validator default).
+/// </summary>
+public sealed class CssStyleDeclarationValidationTests
+{
+    private static string Eval(string script)
+    {
+        using var ctx = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(ctx,
+            "<!DOCTYPE html><html><body><div id=\"t\"></div></body></html>", "file:///v.html");
+        return ctx.Eval("(function(){var s=document.getElementById('t').style;" + script + "})()").ToString();
+    }
+
+    [Fact]
+    public void Invalid_Keyword_On_Property_Setter_Is_Ignored()
+    {
+        // position:levitating is not a valid <position> keyword → the setter stores nothing.
+        Assert.Equal("", Eval("s.position='levitating';return s.position;"));
+    }
+
+    [Fact]
+    public void Invalid_Keyword_Via_SetProperty_Is_Ignored()
+    {
+        Assert.Equal("", Eval("s.setProperty('display','supergrid');return s.getPropertyValue('display');"));
+    }
+
+    [Fact]
+    public void Valid_Value_On_Property_Setter_Still_Applies()
+    {
+        Assert.Equal("relative", Eval("s.position='relative';return s.position;"));
+    }
+
+    [Fact]
+    public void Valid_Value_Via_SetProperty_Still_Applies()
+    {
+        Assert.Equal("block", Eval("s.setProperty('display','block');return s.getPropertyValue('display');"));
+    }
+
+    [Fact]
+    public void Invalid_Value_Keeps_The_Existing_Value()
+    {
+        // A rejected set must not clobber a previously-valid value.
+        Assert.Equal("relative", Eval("s.position='relative';s.position='levitating';return s.position;"));
+    }
+
+    [Fact]
+    public void Custom_Property_Via_SetProperty_Is_Accepted()
+    {
+        // Custom (--*) properties are not closed-keyword; the validator default accepts them.
+        Assert.Equal("anything", Eval("s.setProperty('--foo','anything');return s.getPropertyValue('--foo');"));
+    }
+
+    [Fact]
+    public void Unknown_Property_Value_Is_Accepted()
+    {
+        // Unknown properties fall through the validator default (accept), so setProperty stores them.
+        Assert.Equal("42", Eval("s.setProperty('--x','42');return s.getPropertyValue('--x');"));
+    }
+
+    [Fact]
+    public void Important_Value_Is_Validated_On_The_Stripped_Value()
+    {
+        // "red !important" validates the stripped "red" (valid) and is stored with priority.
+        Assert.Equal("important",
+            Eval("s.setProperty('color','red','important');return s.getPropertyPriority('color');"));
+    }
+
+    [Fact]
+    public void Invalid_Float_Via_SetProperty_Is_Ignored()
+    {
+        // `float` set through the general setProperty path (the reachable one) is gated.
+        Assert.Equal("", Eval("s.setProperty('float','banana');return s.getPropertyValue('float');"));
+        Assert.Equal("left", Eval("s.setProperty('float','left');return s.getPropertyValue('float');"));
+    }
+
+    [Fact]
+    public void Property_Path_Now_Matches_Attribute_Path_For_Invalid_Values()
+    {
+        // Both the attribute assignment and the per-property setter drop an invalid keyword.
+        Assert.Equal("", Eval("s.cssText='position: levitating';return s.position;"));
+        Assert.Equal("", Eval("s.position='levitating';return s.position;"));
+    }
+}

--- a/src/Broiler.Cli.Tests/SparseComputedStyleParityTests.cs
+++ b/src/Broiler.Cli.Tests/SparseComputedStyleParityTests.cs
@@ -1,0 +1,204 @@
+using System.Text;
+using Broiler.CSS.Dom;
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+using Xunit;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// DOM/CSS promotion §2.1 — differential parity between the bridge's sparse computed-style
+/// projection (<c>DomBridge.GetComputedProps</c>) and its candidate canonical replacement
+/// (<c>CssStyleEngine.GetSparseComputedStyle</c>, added in the Broiler.CSS submodule).
+///
+/// This does NOT swap any of the ~98 <c>GetComputedProps</c> call sites. It measures how
+/// faithfully the canonical projection reproduces the bridge's output over a representative
+/// corpus and pins the reconciliation surface, so the (higher-risk) swap can be scoped
+/// against a known delta — and so that delta cannot silently grow.
+///
+/// The measured delta falls into four documented classes (all others must match exactly):
+///  1. <b>UA display defaults</b> — the bridge injects a user-agent <c>display</c> for block
+///     elements (<c>ApplyUserAgentDisplayDefaults</c>); the canonical projection leaves
+///     <c>display</c> to the renderer, so it is present-in-bridge / absent-in-sparse.
+///  2. <b>Inheritance model</b> — the canonical projection backfills inherited properties from
+///     the parent's <em>full</em> computed style, so every inherited property is materialised
+///     from the root's initials down. The bridge propagates inheritance from the parent's
+///     <em>sparse</em> map, so an inherited property never declared anywhere stays absent.
+///     The whole inherited-property set is therefore present-in-sparse / absent-in-bridge on
+///     elements that declare none of it.
+///  3. <b>Value resolution</b> (bidirectional) — the two paths resolve <c>var()</c>, the
+///     CSS-wide keywords (<c>initial/inherit/unset/revert</c>) and relative font-weight
+///     keywords at different points, so one side may hold the resolved value while the other
+///     holds the raw token. The canonical projection resolves <c>var()</c>/<c>initial</c>/
+///     <c>unset</c> and <c>bold</c>→<c>700</c> that the bridge leaves raw; conversely its
+///     <c>ComputeStyle</c> path has no inherit-fold, so it emits a raw <c>inherit</c> that the
+///     bridge resolves. Same property, resolved-vs-raw value either way.
+///  4. <b>Custom properties</b> — the canonical projection surfaces <c>--*</c> custom
+///     properties; the bridge omits them.
+///
+/// A swap of the call sites must reconcile 1 and 2 (they change what undeclared reads back as)
+/// and audit 3/4; this test is the checklist and the drift guard, not a green-light on its own.
+/// </summary>
+public sealed class SparseComputedStyleParityTests
+{
+    private static readonly string[] Corpus =
+    [
+        @"<!DOCTYPE html><html><head><style>
+            #a { color: red; font: italic bold 20px Ahem; }
+            .p { color: purple; }
+            div { margin: 10px 20px; padding: 5px; }
+        </style></head><body>
+            <div id='a' class='p'>x<span>y</span></div>
+            <p class='p'>inherited<em>child</em></p>
+        </body></html>",
+
+        @"<!DOCTYPE html><html><head><style>
+            #rel { position: relative; }
+            #abs { position: absolute; top: 10px; left: 20px; width: 5px; height: 5px; }
+            #ov { overflow: hidden; display: inline-block; }
+        </style></head><body>
+            <div id='rel' style='border: 1px solid green; background: red no-repeat'>
+                <a id='abs'></a></div>
+            <section id='ov'>scroll</section>
+        </body></html>",
+
+        @"<!DOCTYPE html><html><head><style>
+            input { color: blue; } button { font-weight: bold; }
+        </style></head><body>
+            <form>
+                <input id='i' type='text' value='hi'>
+                <button id='b'>ok</button>
+                <select id='s' size='3'><option>1</option><option>2</option></select>
+                <textarea id='ta' rows='4'>text</textarea>
+            </form>
+        </body></html>",
+
+        @"<!DOCTYPE html><html><head><style>
+            :root { --accent: teal; }
+            #v { color: var(--accent); text-decoration: underline; }
+            #k { color: inherit; display: initial; margin: unset; }
+        </style></head><body>
+            <div id='v'>var</div>
+            <div class='p'><span id='k'>keywords</span></div>
+        </body></html>",
+    ];
+
+    private static readonly string[] CssWideKeywords = ["initial", "inherit", "unset", "revert"];
+    private static readonly HashSet<string> FontWeightKeywords =
+        new(["normal", "bold", "bolder", "lighter"], StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void CanonicalSparseProjection_Reproduces_Bridge_GetComputedProps_Modulo_Documented_Delta()
+    {
+        // Divergences that are NOT explained by one of the four documented classes — these are
+        // the regressions/drift the guard exists to catch.
+        var unexpectedOnlyInBridge = new SortedDictionary<string, (string el, string val)>();
+        var unexpectedMismatch = new SortedDictionary<string, (string el, string bridge, string sparse)>();
+        var unexpectedOnlyInSparse = new SortedDictionary<string, (string el, string val)>();
+
+        int elementsChecked = 0;
+
+        foreach (var html in Corpus)
+        {
+            using var ctx = new JSContext();
+            var bridge = new DomBridge();
+            bridge.Attach(ctx, html, "file:///parity.html");
+
+            foreach (var element in bridge.Elements)
+            {
+                var tag = element.TagName?.ToLowerInvariant() ?? "?";
+                if (tag is "html" or "head" or "meta" or "title" or "style" or "script"
+                    or "#document" or "#doctype" or "#comment" or "#text")
+                    continue;
+
+                elementsChecked++;
+                var desc = $"{tag}#{element.Id}";
+                var bridgeMap = bridge.GetComputedPropsForParity(element);
+                var sparseMap = bridge.GetSparseComputedStyleForParity(element);
+
+                foreach (var kv in bridgeMap)
+                {
+                    if (!sparseMap.TryGetValue(kv.Key, out var sparseVal))
+                    {
+                        // Class 1: UA display defaults are the only expected bridge-only key.
+                        if (!string.Equals(kv.Key, "display", StringComparison.OrdinalIgnoreCase))
+                            unexpectedOnlyInBridge.TryAdd(kv.Key, (desc, kv.Value));
+                    }
+                    else if (!string.Equals(sparseVal, kv.Value, StringComparison.Ordinal)
+                             && !IsExpectedValueResolution(kv.Key, kv.Value, sparseVal))
+                    {
+                        unexpectedMismatch.TryAdd(kv.Key, (desc, kv.Value, sparseVal));
+                    }
+                }
+
+                foreach (var kv in sparseMap)
+                {
+                    if (bridgeMap.ContainsKey(kv.Key))
+                        continue;
+                    // Class 2 (inherited-property materialisation) + class 4 (custom properties)
+                    // are the expected sparse-only keys.
+                    if (kv.Key.StartsWith("--", StringComparison.Ordinal)
+                        || CssComputedDefaults.InheritedProperties.Contains(kv.Key))
+                        continue;
+                    unexpectedOnlyInSparse.TryAdd(kv.Key, (desc, kv.Value));
+                }
+            }
+        }
+
+        Assert.True(elementsChecked >= 15, $"corpus regressed: only {elementsChecked} elements checked");
+
+        var report = new StringBuilder();
+        report.AppendLine(
+            $"Uncategorised divergences (should be 0): onlyInBridge={unexpectedOnlyInBridge.Count}, "
+            + $"valueMismatch={unexpectedMismatch.Count}, onlyInSparse={unexpectedOnlyInSparse.Count}");
+        AppendGroup(report, "UNEXPECTED PRESENT-IN-BRIDGE / ABSENT-IN-SPARSE", unexpectedOnlyInBridge);
+        AppendMismatch(report, "UNEXPECTED VALUE MISMATCH", unexpectedMismatch);
+        AppendGroup(report, "UNEXPECTED PRESENT-IN-SPARSE / ABSENT-IN-BRIDGE", unexpectedOnlyInSparse);
+
+        Assert.True(
+            unexpectedOnlyInBridge.Count == 0
+            && unexpectedMismatch.Count == 0
+            && unexpectedOnlyInSparse.Count == 0,
+            report.ToString());
+    }
+
+    // A value mismatch is EXPECTED when it is the value-resolution class: one side holds a raw
+    // var() / CSS-wide keyword / relative-font-weight token while the other holds the resolved
+    // value. This is bidirectional — the engine resolves var()/initial/unset/bold that the
+    // bridge leaves raw, and the bridge resolves the `inherit` the engine's ComputeStyle leaves raw.
+    private static bool IsExpectedValueResolution(string key, string bridgeValue, string sparseValue) =>
+        IsUnresolvedToken(key, bridgeValue) || IsUnresolvedToken(key, sparseValue);
+
+    private static bool IsUnresolvedToken(string key, string value)
+    {
+        var v = value.Trim();
+        if (v.Contains("var(", StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (CssWideKeywords.Contains(v.ToLowerInvariant()))
+            return true;
+        if (string.Equals(key, "font-weight", StringComparison.OrdinalIgnoreCase)
+            && FontWeightKeywords.Contains(v))
+            return true;
+        return false;
+    }
+
+    private static void AppendGroup(StringBuilder sb, string title,
+        SortedDictionary<string, (string el, string val)> group)
+    {
+        if (group.Count == 0)
+            return;
+        sb.AppendLine($"--- {title} ---");
+        foreach (var (key, (el, val)) in group)
+            sb.AppendLine($"  {key} = \"{val}\"  (e.g. {el})");
+    }
+
+    private static void AppendMismatch(StringBuilder sb, string title,
+        SortedDictionary<string, (string el, string bridge, string sparse)> group)
+    {
+        if (group.Count == 0)
+            return;
+        sb.AppendLine($"--- {title} ---");
+        foreach (var (key, (el, b, s)) in group)
+            sb.AppendLine($"  {key}: bridge=\"{b}\" sparse=\"{s}\"  (e.g. {el})");
+    }
+}

--- a/src/Broiler.Cli.Tests/StyleScopeMediaTests.cs
+++ b/src/Broiler.Cli.Tests/StyleScopeMediaTests.cs
@@ -1,0 +1,54 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+using Xunit;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// DOM/CSS promotion §2 (P2) — the bridge routes stylesheet-scope assembly through the
+/// canonical <c>Broiler.CSS.Dom.CssStyleScopeBuilder</c>, which evaluates each collected
+/// <c>&lt;style&gt;</c>/<c>&lt;link&gt;</c> element's <c>media</c> attribute against the viewport.
+/// Before that, the bridge concatenated every collected sheet into one blob and applied it
+/// unconditionally, so a non-matching-media sheet wrongly took effect.
+/// </summary>
+public sealed class StyleScopeMediaTests
+{
+    private static string ComputedColor(string html, string id)
+    {
+        using var ctx = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(ctx, html, "file:///media.html");
+        return ctx.Eval($"window.getComputedStyle(document.getElementById('{id}')).color").ToString();
+    }
+
+    [Fact]
+    public void NonMatching_Media_Stylesheet_Is_Excluded()
+    {
+        // A base sheet sets green; a later sheet gated on an impossible viewport width sets red.
+        // The gated sheet must be excluded, so green wins — before the CssStyleScopeBuilder fix
+        // the bridge concatenated both and the source-later red won.
+        var html = "<!DOCTYPE html><html><head>" +
+                   "<style>#t { color: rgb(0, 128, 0); }</style>" +
+                   "<style media=\"(min-width: 100000px)\">#t { color: rgb(255, 0, 0); }</style>" +
+                   "</head><body><div id=\"t\">x</div></body></html>";
+        Assert.Equal("rgb(0, 128, 0)", ComputedColor(html, "t"));
+    }
+
+    [Fact]
+    public void Matching_Media_Stylesheet_Is_Included()
+    {
+        var html = "<!DOCTYPE html><html><head>" +
+                   "<style media=\"(min-width: 1px)\">#t { color: rgb(0, 0, 255); }</style>" +
+                   "</head><body><div id=\"t\">x</div></body></html>";
+        Assert.Equal("rgb(0, 0, 255)", ComputedColor(html, "t"));
+    }
+
+    [Fact]
+    public void No_Media_Attribute_Applies_Unconditionally()
+    {
+        var html = "<!DOCTYPE html><html><head>" +
+                   "<style>#t { color: rgb(0, 0, 255); }</style>" +
+                   "</head><body><div id=\"t\">x</div></body></html>";
+        Assert.Equal("rgb(0, 0, 255)", ComputedColor(html, "t"));
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ComputedStyleEngine.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ComputedStyleEngine.cs
@@ -1,5 +1,3 @@
-using System.Text;
-
 namespace Broiler.HtmlBridge;
 
 /// <summary>
@@ -22,9 +20,7 @@ public sealed partial class DomBridge
 
     private sealed class ComputedStyleEngineScope
     {
-        public required Broiler.CSS.Dom.CssStyleEngine Engine { get; init; }
-
-        public int StyleSheetHash { get; set; } = -1;
+        public required Broiler.CSS.Dom.CssStyleScopeBuilder ScopeBuilder { get; init; }
     }
 
     /// <summary>
@@ -46,7 +42,8 @@ public sealed partial class DomBridge
         {
             scope = new ComputedStyleEngineScope
             {
-                Engine = new Broiler.CSS.Dom.CssStyleEngine(new BridgeSelectorStateProvider()),
+                ScopeBuilder = new Broiler.CSS.Dom.CssStyleScopeBuilder(
+                    new Broiler.CSS.Dom.CssStyleEngine(new BridgeSelectorStateProvider())),
             };
             _computedStyleEngines[docRoot] = scope;
         }
@@ -54,27 +51,19 @@ public sealed partial class DomBridge
         var styleElements = new List<Broiler.Dom.DomElement>();
         CollectStyleElementsInTree(docRoot, styleElements);
 
-        var combined = new StringBuilder();
+        // Hand the collected sheets to the canonical scope builder in document order; it
+        // gates each on the element's `media` attribute against the viewport and re-syncs the
+        // engine only when the effective set changes. Text extraction (InnerHtml / CSSOM rule
+        // text / external-sheet runtime state) stays here because it needs the DOM and loading.
+        var sources = new List<Broiler.CSS.Dom.CssStyleScopeBuilder.StyleSource>(styleElements.Count);
         foreach (var styleEl in styleElements)
-            combined.Append(GetStyleElementCssText(styleEl)).Append('\n');
-        var combinedText = combined.ToString();
-
-        var hash = combinedText.GetHashCode(StringComparison.Ordinal);
-        if (hash != scope.StyleSheetHash)
-        {
-            scope.Engine.ClearStyleSheets();
-            if (combinedText.Length > 0)
-            {
-                var sheet = new Broiler.CSS.CssParser().ParseStyleSheet(combinedText);
-                scope.Engine.AddStyleSheet(sheet, CSS.Dom.CssOrigin.Author);
-            }
-
-            scope.StyleSheetHash = hash;
-        }
+            sources.Add(new Broiler.CSS.Dom.CssStyleScopeBuilder.StyleSource(
+                GetStyleElementCssText(styleEl),
+                CSS.Dom.CssOrigin.Author,
+                GetAttr(styleEl, "media")));
 
         var (vpWidth, vpHeight) = GetViewportForDocRoot(docRoot);
-        scope.Engine.UpdateEnvironment(new Broiler.CSS.Dom.CssEnvironment(vpWidth, vpHeight));
-        return scope.Engine;
+        return scope.ScopeBuilder.Sync(sources, new Broiler.CSS.Dom.CssEnvironment(vpWidth, vpHeight));
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -414,6 +414,21 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     internal static IReadOnlyDictionary<string, string> GetInlineStyleView(Broiler.Dom.DomElement element) =>
         InlineStyle(element);
 
+    /// <summary>Parity-test hook (DOM/CSS promotion §2.1): the bridge's own sparse
+    /// computed-style projection. Paired with <see cref="GetSparseComputedStyleForParity"/>
+    /// (the canonical engine's candidate replacement over the SAME synced engine) so a
+    /// differential test can measure how close the canonical projection is before the
+    /// higher-risk swap of the ~98 <c>GetComputedProps</c> call sites. Visible only to
+    /// <c>InternalsVisibleTo</c> assemblies — not a public seam.</summary>
+    internal Dictionary<string, string> GetComputedPropsForParity(Broiler.Dom.DomElement element) =>
+        GetComputedProps(element);
+
+    /// <summary>Parity-test hook (DOM/CSS promotion §2.1): the canonical engine's
+    /// <c>CssStyleEngine.GetSparseComputedStyle</c> over the element's synced scoped engine —
+    /// the candidate replacement for <see cref="GetComputedPropsForParity"/>.</summary>
+    internal IReadOnlyDictionary<string, string> GetSparseComputedStyleForParity(Broiler.Dom.DomElement element) =>
+        GetSyncedScopedEngine(element).GetSparseComputedStyle(element);
+
     private static Dictionary<string, List<EventListenerRegistration>> GetEventListeners(Broiler.Dom.DomNode element) =>
         GetElementRuntimeState(element).EventListeners;
 
@@ -1077,6 +1092,21 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         }
         return result;
     }
+
+    /// <summary>
+    /// Whether <paramref name="value"/> is an acceptable declared value for
+    /// <paramref name="property"/> per the shared <see cref="CSS.Dom.CssDeclarationValidator"/> —
+    /// the same closed-keyword error-recovery the inline-style <em>attribute</em> path
+    /// (<see cref="ParseStyle"/>) applies. A live <c>CSSStyleDeclaration</c> per-property setter
+    /// (<c>el.style.color = …</c>, <c>setProperty(…)</c>, <c>cssFloat = …</c>) must <em>reject</em>
+    /// an invalid value rather than store it, matching the attribute path (where
+    /// <c>el.style = "color: bogus"</c> already drops the declaration) and CSSOM error handling.
+    /// The value may carry a trailing <c>!important</c>, which is stripped before validation;
+    /// unknown and custom (<c>--*</c>) properties are always accepted (the validator's default).
+    /// </summary>
+    private static bool IsAcceptableInlineValue(string property, string value) =>
+        CSS.Dom.CssDeclarationValidator.IsAcceptableDeclarationValue(
+            property, Broiler.CSS.CssPriority.Strip(value));
 
     /// <summary>
     /// Strips vendor prefixes (<c>-webkit-</c>, <c>-moz-</c>, <c>-ms-</c>, <c>-o-</c>)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Utilities.cs
@@ -54,11 +54,12 @@ public sealed partial class DomBridge
                 InlineStyle(element).Remove(prop);
                 GetElementRuntimeState(element).JsSetStyleProps.Remove(prop);
             }
-            else
+            else if (IsAcceptableInlineValue(prop, value))
             {
                 InlineStyle(element)[prop] = value;
                 GetElementRuntimeState(element).JsSetStyleProps.Add(prop);
             }
+            // setProperty with an invalid value is a no-op per CSSOM (the value is not set).
 
             onMutation?.Invoke();
         }
@@ -116,7 +117,11 @@ public sealed partial class DomBridge
     private static JSValue JsUtilitiesSetCssFloat009Core(global::Broiler.Dom.DomElement element, global::System.Action? onMutation, in Arguments a)
     {
         if (a.Length > 0)
-            InlineStyle(element)["float"] = a[0].ToString();
+        {
+            var val = a[0].ToString();
+            if (string.IsNullOrEmpty(val) || IsAcceptableInlineValue("float", val))
+                InlineStyle(element)["float"] = val;
+        }
         onMutation?.Invoke();
         return JSUndefined.Value;
     }
@@ -172,8 +177,9 @@ public sealed partial class DomBridge
             var value = Broiler.CSS.CssPriority.Apply(a[1].ToString(), a.Length >= 3 ? a[2].ToString() : string.Empty);
             if (string.IsNullOrEmpty(value))
                 styleMap.Remove(prop);
-            else
+            else if (IsAcceptableInlineValue(prop, value))
                 styleMap[prop] = value;
+            // setProperty with an invalid value is a no-op per CSSOM.
         }
 
         return JSUndefined.Value;
@@ -226,7 +232,11 @@ public sealed partial class DomBridge
     private static JSValue JsUtilitiesSetCssFloat020Core(global::System.Collections.Generic.Dictionary<global::System.String, global::System.String> styleMap, in Arguments a)
     {
         if (a.Length > 0)
-            styleMap["float"] = a[0].ToString();
+        {
+            var val = a[0].ToString();
+            if (string.IsNullOrEmpty(val) || IsAcceptableInlineValue("float", val))
+                styleMap["float"] = val;
+        }
         return JSUndefined.Value;
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -728,10 +728,18 @@ public sealed partial class DomBridge
                     InlineStyle(_element).Remove(kebab);
                     GetElementRuntimeState(_element).JsSetStyleProps.Remove(kebab);
                 }
-                else
+                else if (IsAcceptableInlineValue(kebab, val))
                 {
                     InlineStyle(_element)[kebab] = val;
                     GetElementRuntimeState(_element).JsSetStyleProps.Add(kebab);
+                }
+                else
+                {
+                    // Invalid value: ignore it completely (CSSOM error handling). Return
+                    // without falling through to base.SetValue — the getter reads the JS
+                    // property first, so letting the base object keep the value would
+                    // resurface the rejected value. Any existing valid value is left intact.
+                    return true;
                 }
 
                 // Invalidate cached position-area resolution when relevant
@@ -781,8 +789,10 @@ public sealed partial class DomBridge
                 var val = value?.ToString() ?? string.Empty;
                 if (string.IsNullOrEmpty(val))
                     _style.Remove(kebab);
-                else
+                else if (IsAcceptableInlineValue(kebab, val))
                     _style[kebab] = val;
+                else
+                    return true;   // invalid value ignored; don't store it as a JS property either
             }
 
             return base.SetValue(name, value, receiver, throwError);


### PR DESCRIPTION
Advances the DOM/CSS promotion backlog ([`htmlbridge-remaining-work-roadmap.md`](docs/roadmap/htmlbridge-remaining-work-roadmap.md) §2) with three independent, `Broiler.Cli.Tests`-verified slices, plus roadmap-accuracy fixes.

**Submodule:** bumps the `Broiler.CSS` pointer to Broiler-Platform/Broiler.CSS#21 (the `GetSparseComputedStyle` + `CssStyleScopeBuilder` commit). That PR must merge (or the pointer be re-bumped to its merged SHA) for CI to build — the bridge changes here consume those new APIs.

## What changed

### 2.1 — additive canonical sparse computed-style projection
The submodule adds `CssStyleEngine.GetSparseComputedStyle`: the computed-style pipeline **without** the initial-value backfill, so an undeclared non-inherited property reads back absent — the null-for-undeclared contract the bridge's `GetComputedProps` consumers rely on. Here (main-repo): two internal `*ForParity` accessors + a **differential parity test** that measures how faithfully the canonical projection reproduces `GetComputedProps` and pins the reconciliation delta to four documented classes. Purely additive — **no call-site changes**.

The literal ~98-site `GetComputedProps → GetSparseComputedStyle` cutover was **attempted and confirmed NOT a clean drop-in** — delegating produced 4 regressions (zoom-serialization of inherited/scroll-margin props + two `scrollIntoView` cases), exactly the predicted inheritance/value-resolution delta — so it was reverted and remains deferred behind the WPT gate (documented in §2.1).

### P2 — stylesheet scope assembly via `CssStyleScopeBuilder`
Routes `DomBridge.GetSyncedScopedEngine` through the new canonical `CssStyleScopeBuilder` (submodule). Beyond the promotion, this **fixes a real bug**: the old path concatenated every collected `<style>`/`<link>` sheet into one blob and applied it unconditionally, ignoring per-element `media` — so `<style media="print">` wrongly took effect on screen. The builder gates each source on its media attribute, preserves origin/document order, and parses each source as its own sheet. Pinned by `StyleScopeMediaTests`.

### 2.3 — live per-property `CSSStyleDeclaration` setter validation
The per-property setters (`el.style.X = …`, `setProperty(…)`, the rule-side twins) wrote raw values with **no validation**, while the attribute/`cssText` path already dropped invalid declarations via the shared `CssDeclarationValidator`. So `el.style.color = "bogus"` *stored* the invalid value. All six setter sites now gate through a shared `DomBridge.IsAcceptableInlineValue` helper: invalid values are ignored (prior value kept), matching the attribute path and CSSOM error handling; custom (`--*`) and unknown properties still pass; `!important` is validated on the stripped value. 10 `CssStyleDeclarationValidationTests`.

### Docs
Updates the five htmlbridge roadmap docs — records the three slices, and corrects stale "not merged" language in four docs now that the facade-removal stack (#1359) merged to `main`.

## Reviewer notes
- **Behavior changes** (P2 media gating, 2.3 invalid-value rejection) are spec-aligned but observable; they additionally want the **full WPT css/cssom + Acid + pixel** gate at merge.
- Nuance found in 2.3: the IDL `SetValue` stores the value in two places (ERS map + a JS property the getter reads first), so the gate returns early on invalid to skip `base.SetValue`; `el.style.cssFloat=` is a pre-existing dead path (defensive gate only).

## Verification
Regression-free across the CSS.Dom, CSSOM, computed-style, inline-style, scope, and Acid3 clusters; all residual failures confirmed **pre-existing at clean HEAD** (`:root`/`:lang`, HttpClient reflection, Acid3 render/score/image environmental, `Border_Shorthand`, the zoom-serialization environmental trio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)