### PR TITLE
Promote StripVendorPrefix to canonical CssPropertyNames

### DIFF
--- a/docs/roadmap/htmlbridge-remaining-work-roadmap.md
+++ b/docs/roadmap/htmlbridge-remaining-work-roadmap.md
@@ -280,9 +280,21 @@ live-setter routing.
   with a `!important` string suffix + vendor-prefix mapping; the engine adds cascade winners). The named
   "third copy" `HtmlCss.ParseDeclarations` (`Broiler.Documents.Html`) is a **different, naive parser**
   (HtmlDecode + split on `;`/`:`, no CssParser, no validation, no `!important`) serving document conversion —
-  forcing it onto the canonical parser would change Documents behavior, out of scope. The one genuinely-clean
-  remaining duplicate is the **byte-identical `StripVendorPrefix`** in `DomBridge.cs:1101` and
-  `CssStyleEngine.cs:682` (promote to `Broiler.CSS.CssPropertyNames`) — a small, optional follow-up.
+  forcing it onto the canonical parser would change Documents behavior, out of scope.
+- **Done (2026-07-12) — `StripVendorPrefix` promoted.** The one genuinely-clean remaining duplicate — the
+  **byte-identical `StripVendorPrefix`** that lived privately in both `DomBridge.cs` (bridge `ParseStyle`
+  vendor→unprefixed inline-style aliasing) and `CssStyleEngine.cs` (cascade-slot vendor→unprefixed alias) —
+  is promoted to the canonical `Broiler.CSS.CssPropertyNames.StripVendorPrefix` (its natural home alongside
+  the kebab↔camel `To*PropertyName` mapping). Both private copies are deleted and route through the shared
+  static; the move is a compile-time identity (a pure, dependency-free string function called identically),
+  so behaviour is provably unchanged. Covered by 9 new `CssPropertyNamesTests` cases (known prefixes,
+  case-insensitive prefix match with verbatim remainder, `--custom`/unprefixed pass-through, empty). Verified
+  regression-free: `Broiler.CSS.Tests` `CssPropertyNames` 26/26; `Broiler.CSS.Dom.Tests` 213/214 (the 1 =
+  the pre-existing `Public_Surface_Does_Not_Expose_Mutable_Collections` arch guard, baseline per §2.4); the
+  bridge end-to-end `GoogleSearchPolyfillTests.Webkit_Prefixed_Property_Mapped_To_Unprefixed` + the
+  style-declaration-validation / inline-style cluster 16/16. **Delivery note:** `CssPropertyNames.cs` + its
+  tests are in the `Broiler.CSS` **submodule** — push + pointer bump (or `patches/` fallback if the push
+  403s); the bridge one-line reroute is main-repo.
 
 ### 2.4 Promotion Phase 2 slice-2 — stylesheet scope assembly (P2 `CssStyleScopeBuilder`) — **DONE (2026-07-12)**
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -1079,7 +1079,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
                 var val = declaration.Important ? rawValue + " !important" : rawValue;
                 result[prop] = val;
                 // Map vendor-prefixed property to unprefixed equivalent (TODO-G9)
-                var unprefixed = StripVendorPrefix(prop);
+                var unprefixed = Broiler.CSS.CssPropertyNames.StripVendorPrefix(prop);
                 if (unprefixed != prop && !result.ContainsKey(unprefixed))
                     result[unprefixed] = val;
             }
@@ -1107,24 +1107,6 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     private static bool IsAcceptableInlineValue(string property, string value) =>
         CSS.Dom.CssDeclarationValidator.IsAcceptableDeclarationValue(
             property, Broiler.CSS.CssPriority.Strip(value));
-
-    /// <summary>
-    /// Strips vendor prefixes (<c>-webkit-</c>, <c>-moz-</c>, <c>-ms-</c>, <c>-o-</c>)
-    /// from a CSS property name, returning the unprefixed equivalent.
-    /// Returns the original name unchanged if it has no vendor prefix.
-    /// </summary>
-    private static string StripVendorPrefix(string property)
-    {
-        if (property.StartsWith("-webkit-", StringComparison.OrdinalIgnoreCase))
-            return property[8..];
-        if (property.StartsWith("-moz-", StringComparison.OrdinalIgnoreCase))
-            return property[5..];
-        if (property.StartsWith("-ms-", StringComparison.OrdinalIgnoreCase))
-            return property[4..];
-        if (property.StartsWith("-o-", StringComparison.OrdinalIgnoreCase))
-            return property[3..];
-        return property;
-    }
 
     /// <summary>Checks whether <paramref name="v"/> looks like a CSS length or percentage.</summary>
     private static bool IsLengthOrPercentage(string v)


### PR DESCRIPTION
Continues the HtmlBridge DOM/CSS promotion backlog (§2.3 follow-up in `docs/roadmap/htmlbridge-remaining-work-roadmap.md`): promotes the one genuinely-clean remaining duplicate — the **byte-identical `StripVendorPrefix`** that lived privately in both the bridge (`DomBridge.ParseStyle` inline-style vendor→unprefixed aliasing) and the cascade engine (`CssStyleEngine` slot aliasing) — into the canonical `Broiler.CSS.CssPropertyNames`, alongside the kebab↔camel property-name mapping.

## Changes
- **Parent (this PR):** `DomBridge.ParseStyle` routes through `Broiler.CSS.CssPropertyNames.StripVendorPrefix`; the bridge's private copy is deleted. Bumps the `Broiler.CSS` submodule pointer.
- **Submodule (Broiler-Platform/Broiler.CSS#22):** adds the canonical `CssPropertyNames.StripVendorPrefix` + 9 tests; the cascade engine's private copy is deleted and rerouted.

It is a pure compile-time identity (a dependency-free string function called identically), so inline-style and cascade behaviour are unchanged.

## Verification
- `Broiler.CSS.Tests` CssPropertyNames 26/26 (9 new cases).
- `Broiler.CSS.Dom.Tests` 213/214 (the 1 = pre-existing `Public_Surface_Does_Not_Expose_Mutable_Collections` arch-guard baseline).
- Bridge end-to-end `GoogleSearchPolyfillTests.Webkit_Prefixed_Property_Mapped_To_Unprefixed` 1/1; style-declaration-validation / inline-style cluster 16/16.

## Merge note
Depends on Broiler-Platform/Broiler.CSS#22 — the submodule pointer here targets that branch's HEAD; once #22 merges, the pointer should land on (or be re-bumped to) its merge commit so CI clones a reachable SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)