### PR TITLE
Route bridge GetComputedProps through the canonical engine (§2.1 cutover)

### DIFF
--- a/docs/roadmap/htmlbridge-remaining-work-roadmap.md
+++ b/docs/roadmap/htmlbridge-remaining-work-roadmap.md
@@ -139,24 +139,40 @@ they are prioritized independently.
        the bridge leaves raw; conversely the engine's `ComputeStyle` has no inherit-fold, so it emits a raw
        `inherit` the bridge resolves. (Mostly improvements; audit at swap.)
     4. **Custom properties** — the engine surfaces `--*`; the bridge omits them. (Benign.)
-  - **What remains (the actual cutover, still deferred) — attempt made 2026-07-12, confirmed not a
-    drop-in, reverted.** The swap was tried directly: `GetComputedProps` (`AnchorRegistry.cs`) rewritten to
-    delegate to `GetSyncedScopedEngine(el).GetSparseComputedStyle(el)` + `ApplyUserAgentDisplayDefaults`
-    (reconciling class 1), keeping the physical-inset backfill. Against a same-state baseline (3 pre-existing
-    fails) the anchor/geometry/serialization/scrollIntoView consumer clusters showed **4 new regressions**,
-    exactly the class-2/3 impact the parity delta predicted:
-    `GoogleSearchPolyfillTests.ScrollIntoView_Clamps_Fixed_Scrollers_To_Their_Scroll_Bounds` and
-    `…ScrollIntoView_Legacy_False_Aligns_To_Block_End`, plus the zoom-serialization pair
-    `ScriptEngineExecuteTests.DomBridge_SerializeToHtml_Scales_ExplicitInherited_Zoom_Properties` and
-    `…Scales_Zoomed_ScrollPadding_And_ScrollMargin_Properties`. The zoom-serialization path scales specific
-    computed properties, and the canonical projection's fuller inheritance + resolved values change *which*
-    properties are present and their form — so the swap is genuinely observable, not a no-op. **Reverted**
-    (`git checkout AnchorRegistry.cs`); clusters returned to the 3-fail baseline. **Conclusion:** the cutover
-    needs the inheritance model reconciled (sparse-inheritance projection, or a per-site audit of the
-    zoom-serialization + scrollIntoView readers) and must run behind the full WPT/Acid/pixel gate — it is not
-    a safe local-only slice. The additive projection + parity test remain the foundation for it. **Delivery
-    note:** the `GetSparseComputedStyle` API is in the `Broiler.CSS` submodule — push + pointer bump (or
-    `patches/` fallback) at commit time; the parity test + accessors are main-repo.
+  - **The cutover — DONE (2026-07-12) via the engine inline-provider approach.** `GetComputedProps`
+    (`AnchorRegistry.cs`) now routes through `GetSyncedScopedEngine(el).GetSparseComputedStyle(el,
+    sparseInheritance: true)` + the two thin reconciliations (`ResolveExplicitInheritedValues` for the
+    class-3c inherit-fold, `ApplyUserAgentDisplayDefaults` for class 1). The bridge's private
+    `ApplyInheritedProperties` (class-2 inheritance duplication) is **deleted**; the inset/form-control/logical
+    tail steps are gone from the path (the engine's `ComputeStyle` already does them). Two enabling changes
+    made it work where the earlier blind swap failed:
+    1. **Sparse-inheritance projection** (`Broiler.CSS` submodule): `GetSparseComputedStyle` gains a
+       `sparseInheritance` flag that sources inheritance from the parent's *sparse* projection (via a cached
+       `GetSparseComputedStyleInternal` recursion) instead of the parent's full computed style — reconciling
+       class 2 (nowhere-declared inherited props stay absent).
+    2. **Inline-style provider** (`CssStyleEngine.SetInlineStyleSource`, submodule): the earlier attempt
+       failed because the engine reads inline from the DOM `style` **attribute**, but the bridge's
+       authoritative inline is its live **ElementRuntimeState** map — JS `el.style.X=` and the anchor
+       resolver write ERS and *never* the attribute (verified: `getAttribute("style")` stays null,
+       `getComputedStyle` returned defaults). The bridge now feeds the engine the ERS map as the cascade's
+       inline source (`SerializeInlineStyleForEngine`), so the engine sees JS-set and resolver-written inline
+       for both the element's cascade and its inheritance recursion. Cache coordination: the per-document
+       engines' caches are invalidated together with `_computedPropsCache` (new `ClearComputedPropsCache`
+       routing the three clear sites through `InvalidateScopedEngineComputedCaches`), since an ERS mutation is
+       not a DOM mutation.
+    - **Side effect (a fix):** `getComputedStyle` now also reflects JS-set/resolver-written inline (it
+      previously did not), since it shares the same provider-fed engine.
+    - **Verified regression-free + pixel-neutral (2026-07-12):** the 4 previously-regressing tests pass; the
+      full `Broiler.Cli.Tests` suite has **0 new deterministic failures** vs a same-state baseline (the two
+      apparent deltas — `FixedChild_DoesNot_Inflate_Parent_AutoHeight` and a `NetworkAndHttpTests` fetch case —
+      are pre-existing parallel-flaky / order-dependent, confirmed at clean HEAD); the full local WPT corpus
+      (171 tests: CSS2, css-align, css-anchor-position, css-animations, css-backgrounds) is **pixel-identical**
+      (same 38 failures, **zero** matchPercent drift across every test); engine unit tests + the parity test
+      pass. Still wants the dispatch-only full WPT/Acid gate at merge. **Follow-up:** the now-dead
+      form-control/logical bridge helpers (`ApplyApproximateFormControlComputedSizes`, `ApplyLogicalSizeAliases`
+      + orphaned helpers) are left for a separate sweep (tracked). **Delivery:** the engine changes
+      (`sparseInheritance`, `SetInlineStyleSource`, cache) are in the `Broiler.CSS` submodule — push + pointer
+      bump; the bridge rewire + parity-accessor repoint are main-repo.
 - **Shorthand expansion — DONE (2026-07-12).** The bridge's `ExpandCssShorthands` (+ its private
   `ExpandFontShorthand` / `ExpandBoxShorthand` / `ExpandBorderShorthand` / `ExpandBorderSideShorthand` /
   `ExpandBackgroundShorthand` / `SplitCssValues` helpers, ~500 lines in `DomBridge/Css.cs`) is deleted and
@@ -329,9 +345,11 @@ search found only the roadmap mention) — is delivered.
 ### 2.5 Promotion-candidate backlog (P0–P3) + Open Questions
 
 - The remaining P0–P3 promotion-candidate rows in the promotion roadmap not covered above (the broader
-  "what else could move to the canonical components" backlog). After §2.1–2.4, the notable open ones are the
-  literal `GetComputedProps`→`GetComputedStyle` **cutover** (§2.1 Slice 4, scoped by the measured delta) and
-  the live `CSSStyleDeclaration` **setter routing** (§2.3), both higher-risk behavior changes wanting the WPT gate.
+  "what else could move to the canonical components" backlog). The two higher-risk behavior changes that were
+  open here — the `GetComputedProps` **cutover** (§2.1) and the live `CSSStyleDeclaration` **setter routing**
+  (§2.3) — are now **both done** (each verified regression-free locally and wanting the dispatch-only WPT/Acid
+  gate at merge). The residual backlog is small: the optional `StripVendorPrefix`-style neutral promotions and
+  a tracked sweep of the now-dead form-control/logical bridge helpers left by the §2.1 cutover.
 - The promotion roadmap's **Open Questions** (Open Question #5 — "declare v2" — is now answered; the rest
   remain).
 

--- a/docs/roadmap/htmlbridge-remaining-work-roadmap.md
+++ b/docs/roadmap/htmlbridge-remaining-work-roadmap.md
@@ -168,9 +168,11 @@ they are prioritized independently.
       are pre-existing parallel-flaky / order-dependent, confirmed at clean HEAD); the full local WPT corpus
       (171 tests: CSS2, css-align, css-anchor-position, css-animations, css-backgrounds) is **pixel-identical**
       (same 38 failures, **zero** matchPercent drift across every test); engine unit tests + the parity test
-      pass. Still wants the dispatch-only full WPT/Acid gate at merge. **Follow-up:** the now-dead
-      form-control/logical bridge helpers (`ApplyApproximateFormControlComputedSizes`, `ApplyLogicalSizeAliases`
-      + orphaned helpers) are left for a separate sweep (tracked). **Delivery:** the engine changes
+      pass. Still wants the dispatch-only full WPT/Acid gate at merge. The now-dead form-control/logical
+      bridge helpers this cutover orphaned (`ApplyApproximateFormControlComputedSizes`, `ApplyLogicalSizeAliases`,
+      + 9 transitive helpers, 176 lines — the engine's `ComputeStyle` performs that work now) are **swept in the
+      same PR** (each verified 0-caller; the shared `IsVerticalWritingMode`/`IsSelectListBox`/
+      `GetSelectVisibleRowCount` kept). **Delivery:** the engine changes
       (`sparseInheritance`, `SetInlineStyleSource`, cache) are in the `Broiler.CSS` submodule — push + pointer
       bump; the bridge rewire + parity-accessor repoint are main-repo.
 - **Shorthand expansion — DONE (2026-07-12).** The bridge's `ExpandCssShorthands` (+ its private

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ComputedStyleEngine.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ComputedStyleEngine.cs
@@ -21,6 +21,44 @@ public sealed partial class DomBridge
     private sealed class ComputedStyleEngineScope
     {
         public required Broiler.CSS.Dom.CssStyleScopeBuilder ScopeBuilder { get; init; }
+        // The wrapped engine, held directly so ERS-inline mutations (which the engine's
+        // DOM-mutation subscription does not observe) can invalidate its computed caches.
+        public required Broiler.CSS.Dom.CssStyleEngine Engine { get; init; }
+    }
+
+    /// <summary>
+    /// Invalidates every per-document engine's cascade/computed-style caches. Called
+    /// alongside clearing <c>_computedPropsCache</c> because those engines now read inline
+    /// style from the bridge's live ElementRuntimeState map (via
+    /// <see cref="Broiler.CSS.Dom.CssStyleEngine.SetInlineStyleSource"/>), whose mutations
+    /// are not DOM mutations and so do not trigger the engine's own invalidation.
+    /// </summary>
+    private void InvalidateScopedEngineComputedCaches()
+    {
+        foreach (var scope in _computedStyleEngines.Values)
+            scope.Engine.InvalidateComputedStyleCaches();
+    }
+
+    /// <summary>
+    /// Serializes an element's live inline-style map (ElementRuntimeState) to a CSS
+    /// declaration string for the canonical engine's cascade — the bridge's authoritative
+    /// inline source, which includes JS <c>el.style.X=</c> writes and anchor-resolver-written
+    /// geometry that never reach the DOM <c>style</c> attribute the engine would otherwise read.
+    /// Returns <c>null</c> when there is no inline style.
+    /// </summary>
+    private static string? SerializeInlineStyleForEngine(Broiler.Dom.DomElement element)
+    {
+        var inline = InlineStyle(element);
+        if (inline.Count == 0)
+            return null;
+        var sb = new System.Text.StringBuilder();
+        foreach (var kv in inline)
+        {
+            if (sb.Length > 0)
+                sb.Append(';');
+            sb.Append(kv.Key).Append(':').Append(kv.Value);
+        }
+        return sb.ToString();
     }
 
     /// <summary>
@@ -40,10 +78,15 @@ public sealed partial class DomBridge
         var docRoot = GetDocumentRootFor(element);
         if (!_computedStyleEngines.TryGetValue(docRoot, out var scope))
         {
+            var engine = new Broiler.CSS.Dom.CssStyleEngine(new BridgeSelectorStateProvider());
+            // Feed the bridge's live ElementRuntimeState inline map as the cascade's inline
+            // source (see SerializeInlineStyleForEngine) so the engine sees JS-set and
+            // anchor-resolver-written inline that never reaches the DOM style attribute.
+            engine.SetInlineStyleSource(SerializeInlineStyleForEngine);
             scope = new ComputedStyleEngineScope
             {
-                ScopeBuilder = new Broiler.CSS.Dom.CssStyleScopeBuilder(
-                    new Broiler.CSS.Dom.CssStyleEngine(new BridgeSelectorStateProvider())),
+                ScopeBuilder = new Broiler.CSS.Dom.CssStyleScopeBuilder(engine),
+                Engine = engine,
             };
             _computedStyleEngines[docRoot] = scope;
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -88,7 +88,7 @@ public sealed partial class DomBridge
         }
 
         // Reverted styles must not read back the baked values from the computed cache.
-        _computedPropsCache.Clear();
+        ClearComputedPropsCache();
     }
 
     private static void RestoreStringMap(IDictionary<string, string> target, Dictionary<string, string> saved)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -427,7 +427,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// <c>CssStyleEngine.GetSparseComputedStyle</c> over the element's synced scoped engine —
     /// the candidate replacement for <see cref="GetComputedPropsForParity"/>.</summary>
     internal IReadOnlyDictionary<string, string> GetSparseComputedStyleForParity(Broiler.Dom.DomElement element) =>
-        GetSyncedScopedEngine(element).GetSparseComputedStyle(element);
+        GetSyncedScopedEngine(element).GetSparseComputedStyle(element, sparseInheritance: true);
 
     private static Dictionary<string, List<EventListenerRegistration>> GetEventListeners(Broiler.Dom.DomNode element) =>
         GetElementRuntimeState(element).EventListeners;
@@ -926,7 +926,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     {
         _knownNodes.Clear();
         _jsObjectCache.Clear();
-        _computedPropsCache.Clear();
+        ClearComputedPropsCache();
         ClearChildren(_documentNode);
         _serializationTransformsApplied = false;
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorRegistry.cs
@@ -309,45 +309,30 @@ public sealed partial class DomBridge
         if (_computedPropsInProgress.TryGetValue(element, out var inProgress))
             return inProgress;
 
-        var props = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        // Route the whole computed-style pipeline — cascade + inline, custom-property/
+        // var() and CSS-wide-keyword resolution, shorthand expansion (incl. inset →
+        // top/right/bottom/left), attr() length substitution, relative font-weight,
+        // form-control size synthesis, and logical-size aliases — through the canonical
+        // engine's sparse projection. The engine reads inline style from the bridge's live
+        // ElementRuntimeState map (SetInlineStyleSource in GetSyncedScopedEngine), so it
+        // sees JS-set and anchor-resolver-written inline that never reaches the DOM style
+        // attribute. `sparseInheritance: true` reproduces the bridge's inheritance model:
+        // inherited properties propagate only from explicitly-declared ancestor values, so
+        // a nowhere-declared inherited property stays absent — the null-for-undeclared
+        // contract the ~90 layout/anchor/serialization/scroll consumers of this map depend on.
+        var props = new Dictionary<string, string>(
+            GetSyncedScopedEngine(element).GetSparseComputedStyle(element, sparseInheritance: true),
+            StringComparer.OrdinalIgnoreCase);
         _computedPropsInProgress[element] = props;
         try
         {
-            ApplyUserAgentDisplayDefaults(props, element);
-
-            foreach (var kv in CollectMatchedRuleProperties(element))
-                props[kv.Key] = kv.Value;
-            foreach (var kv in InlineStyle(element))
-                props[kv.Key] = kv.Value;
-
-            ExpandCssShorthands(props);
-            CSS.Dom.CssStyleEngine.ResolveLengthAttrFunctions(props, element);
+            // Two reconciliations the engine's sparse projection deliberately does not do:
+            // fold the explicit `inherit` keyword to the parent's value (ComputeStyle keeps
+            // it raw), and seed the user-agent `display` default (a renderer policy). Both
+            // are non-clobbering, so applying them after the projection preserves the prior
+            // seed-first ordering (an author `display` still wins).
             ResolveExplicitInheritedValues(props, element);
-            ApplyInheritedProperties(props, element);
-
-            // Expand the inset shorthand → top, right, bottom, left so that
-            // downstream code (ComputeElementBox, TryApplyFallback, etc.) can
-            // read the individual inset properties directly.
-            if (props.TryGetValue("inset", out var insetVal2))
-            {
-                var parts = insetVal2.Split([' ', '\t'],
-                    StringSplitOptions.RemoveEmptyEntries);
-                if (parts.Length > 0)
-                {
-                    string iTop = parts[0];
-                    string iRight = parts.Length > 1 ? parts[1] : iTop;
-                    string iBottom = parts.Length > 2 ? parts[2] : iTop;
-                    string iLeft = parts.Length > 3 ? parts[3] : iRight;
-
-                    if (!props.ContainsKey("top")) props["top"] = iTop;
-                    if (!props.ContainsKey("right")) props["right"] = iRight;
-                    if (!props.ContainsKey("bottom")) props["bottom"] = iBottom;
-                    if (!props.ContainsKey("left")) props["left"] = iLeft;
-                }
-            }
-
-            ApplyApproximateFormControlComputedSizes(props, element);
-            ApplyLogicalSizeAliases(props);
+            ApplyUserAgentDisplayDefaults(props, element);
 
             _computedPropsCache[element] = props;
             return props;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -345,125 +345,6 @@ public sealed partial class DomBridge
         return null;
     }
 
-    private static void ApplyApproximateFormControlComputedSizes(
-        Dictionary<string, string> computed,
-        Broiler.Dom.DomElement element)
-    {
-        string tag = element.TagName.ToLowerInvariant();
-        if (tag is not ("input" or "button" or "select" or "textarea" or "progress" or "meter"))
-            return;
-
-        string writingMode = computed.GetValueOrDefault("writing-mode") ?? "horizontal-tb";
-        bool vertical = IsVerticalWritingMode(writingMode);
-
-        double logicalInlineSize = 60;
-        double logicalBlockSize = 20;
-
-        switch (tag)
-        {
-            case "input":
-                string type = GetAttr(element, "type")?.ToLowerInvariant() ?? "text";
-                switch (type)
-                {
-                    case "hidden":
-                        logicalInlineSize = 0;
-                        logicalBlockSize = 0;
-                        break;
-                    case "checkbox":
-                    case "radio":
-                        logicalInlineSize = 13;
-                        logicalBlockSize = 13;
-                        break;
-                    case "submit":
-                    case "button":
-                    case "reset":
-                        logicalInlineSize = 72;
-                        logicalBlockSize = 20;
-                        ApplyButtonLikeMultilineSizing(ref logicalInlineSize, ref logicalBlockSize, GetAttr(element, "value"));
-                        break;
-                    default:
-                        logicalInlineSize = 173;
-                        logicalBlockSize = 16;
-                        break;
-                }
-                break;
-            case "button":
-                logicalInlineSize = 72;
-                logicalBlockSize = 20;
-                ApplyButtonLikeMultilineSizing(ref logicalInlineSize, ref logicalBlockSize, GetElementRenderedText(element));
-                break;
-            case "select":
-                logicalInlineSize = 60;
-                logicalBlockSize = 19;
-                ApplySelectListBoxSizing(ref logicalInlineSize, ref logicalBlockSize, element);
-                break;
-            case "textarea":
-                logicalInlineSize = 170;
-                logicalBlockSize = 40;
-                break;
-            case "progress":
-            case "meter":
-                logicalInlineSize = 120;
-                logicalBlockSize = 16;
-                break;
-        }
-
-        double physicalWidth = vertical ? logicalBlockSize : logicalInlineSize;
-        double physicalHeight = vertical ? logicalInlineSize : logicalBlockSize;
-
-        if (!HasExplicitPhysicalOrLogicalSize(computed, "width", vertical ? "block-size" : "inline-size") && physicalWidth > 0)
-            computed["width"] = FormatPx(physicalWidth);
-        if (!HasExplicitPhysicalOrLogicalSize(computed, "height", vertical ? "inline-size" : "block-size") && physicalHeight > 0)
-            computed["height"] = FormatPx(physicalHeight);
-    }
-
-    private static void ApplyLogicalSizeAliases(Dictionary<string, string> computed)
-    {
-        string writingMode = computed.GetValueOrDefault("writing-mode") ?? "horizontal-tb";
-        bool vertical = IsVerticalWritingMode(writingMode);
-
-        string width = computed.GetValueOrDefault("width") ?? "auto";
-        string height = computed.GetValueOrDefault("height") ?? "auto";
-        string inlineSize = computed.GetValueOrDefault("inline-size") ?? "auto";
-        string blockSize = computed.GetValueOrDefault("block-size") ?? "auto";
-
-        if (!HasExplicitSpecifiedSize(width))
-            width = ResolveLogicalPhysicalFallback(width, vertical ? blockSize : inlineSize);
-
-        if (!HasExplicitSpecifiedSize(height))
-            height = ResolveLogicalPhysicalFallback(height, vertical ? inlineSize : blockSize);
-
-        computed["width"] = width;
-        computed["height"] = height;
-        computed["block-size"] = HasExplicitSpecifiedSize(blockSize) ? blockSize : (vertical ? width : height);
-        computed["inline-size"] = HasExplicitSpecifiedSize(inlineSize) ? inlineSize : (vertical ? height : width);
-    }
-
-    private static bool HasExplicitPhysicalOrLogicalSize(Dictionary<string, string> computed, string physicalProperty, string logicalProperty) =>
-        HasExplicitSpecifiedSize(computed.GetValueOrDefault(physicalProperty)) ||
-        HasExplicitSpecifiedSize(computed.GetValueOrDefault(logicalProperty));
-
-    private static void ApplyButtonLikeMultilineSizing(ref double logicalInlineSize, ref double logicalBlockSize, string? rawText)
-    {
-        int lineCount = CountRenderedLines(rawText);
-        if (lineCount <= 1)
-            return;
-
-        logicalBlockSize = 20 * lineCount;
-    }
-
-    private static void ApplySelectListBoxSizing(ref double logicalInlineSize, ref double logicalBlockSize, Broiler.Dom.DomElement element)
-    {
-        int visibleRows = GetSelectVisibleRowCount(element);
-        if (visibleRows <= 1)
-            return;
-
-        const double rowBlockSize = 16;
-        const double chromeBlockSize = 4;
-        logicalInlineSize = Math.Max(logicalInlineSize, 72);
-        logicalBlockSize = (visibleRows * rowBlockSize) + chromeBlockSize;
-    }
-
     private static bool IsSelectListBox(Broiler.Dom.DomElement element) => GetSelectVisibleRowCount(element) > 1;
 
     private static int GetSelectVisibleRowCount(Broiler.Dom.DomElement element)
@@ -479,64 +360,10 @@ public sealed partial class DomBridge
         return isMultiple ? 4 : 1;
     }
 
-    private static int CountRenderedLines(string? rawText)
-    {
-        if (string.IsNullOrEmpty(rawText))
-            return 1;
-
-        return WebUtility.HtmlDecode(rawText)
-            .Replace("\r\n", "\n", StringComparison.Ordinal)
-            .Replace('\r', '\n')
-            .Split('\n')
-            .Length;
-    }
-
-    private static string GetElementRenderedText(Broiler.Dom.DomElement element)
-    {
-        var builder = new StringBuilder();
-        AppendRenderedText(element, builder);
-        return builder.ToString();
-    }
-
-    private static void AppendRenderedText(Broiler.Dom.DomElement element, StringBuilder builder)
-    {
-        // RF-BRIDGE-1c Phase F (F3c part 2d): iterate raw ChildNodes to read canonical DomText.
-        foreach (var child in element.ChildNodes)
-        {
-            if (IsText(child))
-            {
-                if (BridgeText(child).Length > 0)
-                    builder.Append(BridgeText(child));
-                continue;
-            }
-
-            if (child is not Broiler.Dom.DomElement childElement)
-                continue;
-
-            if (string.Equals(childElement.TagName, "br", StringComparison.OrdinalIgnoreCase))
-            {
-                builder.Append('\n');
-                continue;
-            }
-
-            AppendRenderedText(childElement, builder);
-        }
-    }
-
-    private static string ResolveLogicalPhysicalFallback(string currentPhysicalValue, string mappedLogicalValue) =>
-        HasExplicitSpecifiedSize(mappedLogicalValue) ? mappedLogicalValue : currentPhysicalValue;
-
     private static bool IsVerticalWritingMode(string? writingMode)
     {
         var normalized = writingMode?.Trim().ToLowerInvariant();
         return normalized is "vertical-rl" or "vertical-lr" or "sideways-rl" or "sideways-lr";
-    }
-
-    private static bool HasExplicitSpecifiedSize(string? value)
-    {
-        value = value?.Trim() ?? string.Empty;
-        return value.Length > 0 &&
-               !string.Equals(value, "auto", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -674,9 +501,6 @@ public sealed partial class DomBridge
             ? string.Join("\n", rules.Select(CSS.CssSerializer.Serialize))
             : state.RulesSourceText ?? string.Empty;
     }
-
-    private static string FormatPx(double value) =>
-        $"{Math.Round(value).ToString(CultureInfo.InvariantCulture)}px";
 
     private static void ApplyUserAgentDisplayDefaults(
         Dictionary<string, string> computed,

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -34,6 +34,19 @@ public sealed partial class DomBridge
     private readonly System.Collections.Concurrent.ConcurrentDictionary<Broiler.Dom.DomElement, Dictionary<string, string>> _computedPropsCache = new();
     private readonly System.Collections.Concurrent.ConcurrentDictionary<Broiler.Dom.DomElement, Dictionary<string, string>> _computedPropsInProgress = new();
 
+    /// <summary>
+    /// Clears the bridge's <c>GetComputedProps</c> memo <em>and</em> the per-document engines'
+    /// cascade/computed-style caches together. The two must invalidate as one now that
+    /// <c>GetComputedProps</c> routes through the engine's sparse projection, which reads inline
+    /// style from the live ElementRuntimeState map (an ERS mutation is invisible to the engine's
+    /// own DOM-mutation subscription).
+    /// </summary>
+    private void ClearComputedPropsCache()
+    {
+        _computedPropsCache.Clear();
+        InvalidateScopedEngineComputedCaches();
+    }
+
     // ------------------------------------------------------------------
     //  CSS specificity (Level 3) and <style> / <link> cascading
     // ------------------------------------------------------------------
@@ -95,7 +108,7 @@ public sealed partial class DomBridge
 
     internal void InvalidateStyleScope(Broiler.Dom.DomElement anchor)
     {
-        _computedPropsCache.Clear();
+        ClearComputedPropsCache();
         var docRoot = GetDocumentRootFor(anchor);
         if (_styleInvalidationBatchDepth > 0)
         {
@@ -308,25 +321,6 @@ public sealed partial class DomBridge
         }
 
         return specified;
-    }
-
-    private void ApplyInheritedProperties(Dictionary<string, string> computed, Broiler.Dom.DomElement element)
-    {
-        if (ParentEl(element) == null)
-            return;
-
-        var parentProps = GetComputedProps(ParentEl(element));
-        foreach (var property in CSS.Dom.CssComputedDefaults.InheritedProperties)
-        {
-            if (computed.ContainsKey(property))
-                continue;
-
-            if (parentProps.TryGetValue(property, out var inheritedValue) &&
-                !string.IsNullOrWhiteSpace(inheritedValue))
-            {
-                computed[property] = inheritedValue;
-            }
-        }
     }
 
     private static string? NormalizePseudoElement(string? pseudoElement)


### PR DESCRIPTION
Completes the last non-trivial item in the HtmlBridge DOM/CSS promotion backlog (§2.1 in `docs/roadmap/htmlbridge-remaining-work-roadmap.md`): the bridge's central internal computed-style accessor `GetComputedProps` (~90 call sites) now routes through the canonical `CssStyleEngine` sparse projection instead of a parallel private pipeline.

Depends on **Broiler-Platform/Broiler.CSS#23** (the engine's `sparseInheritance` flag + `SetInlineStyleSource`); this PR bumps the submodule pointer to it.

## What changed
```
GetComputedProps(el) =
  GetSyncedScopedEngine(el).GetSparseComputedStyle(el, sparseInheritance: true)
  + ResolveExplicitInheritedValues(el)   // fold explicit `inherit` (engine keeps it raw)
  + ApplyUserAgentDisplayDefaults(el)     // UA display default (non-clobbering)
```
- Deletes the bridge's private `ApplyInheritedProperties` (class-2 inheritance duplication); drops the inset/form-control/logical-alias tail steps from this path (the engine's `ComputeStyle` already does them).
- Feeds the engine the bridge's live **ElementRuntimeState** inline map as the cascade's inline source (`SetInlineStyleSource` / `SerializeInlineStyleForEngine`).
- Coordinates cache invalidation: `ClearComputedPropsCache` routes the three `_computedPropsCache` clear sites through `InvalidateScopedEngineComputedCaches`, since ERS mutations aren't DOM mutations.

## Why the earlier blind swap failed (and this doesn't)
The bridge's *authoritative* inline is its ERS map — JS `el.style.X=` and the anchor resolver write it but **never** the DOM `style` attribute (verified: `getAttribute("style")` stays null, `getComputedStyle` returned defaults). The canonical engine reads only the attribute, so a naive swap lost all JS-set/resolver-written inline and regressed scrollIntoView geometry. The inline provider closes that gap; the `sparseInheritance` flag reconciles the inheritance-model divergence.

**Side effect (a fix):** `getComputedStyle` now also reflects JS-set/resolver-written inline (it previously did not), since it shares the same provider-fed engine.

## Verification — regression-free and pixel-neutral
- The 4 tests the earlier revert broke now **pass**.
- Full `Broiler.Cli.Tests`: **0 new deterministic failures** vs a same-state baseline (the two apparent deltas — `FixedChild_DoesNot_Inflate_Parent_AutoHeight`, a `NetworkAndHttpTests` fetch case — are pre-existing parallel-flaky / order-dependent, confirmed at clean HEAD).
- Full **local WPT corpus** (171 tests: CSS2, css-align, css-anchor-position, css-animations, css-backgrounds): **pixel-identical** — same 38 failures, **zero** matchPercent drift across every test.
- Engine unit tests + `SparseComputedStyleParityTests` pass.
- Still wants the **dispatch-only full WPT/Acid gate** at merge (this changes observable behavior — inheritance model + `getComputedStyle` now seeing ERS).

## Follow-up
The now-dead form-control/logical bridge helpers (`ApplyApproximateFormControlComputedSizes`, `ApplyLogicalSizeAliases` + orphaned helpers) are left for a separate tracked sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)