### PR TITLE
HtmlBridge promotion backlog: triage docs + B1/B3 cleanups

### DIFF
--- a/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
+++ b/docs/roadmap/htmlbridge-dom-css-promotion-roadmap.md
@@ -1,8 +1,11 @@
 # HtmlBridge DOM/CSS Promotion Roadmap
 
 Status: **active** — Phases 0–5 are done; Phase 5's adapter removal merged to `main` (PR #1359,
-2026-07-12). Remaining promotion candidates are tracked in
-[`htmlbridge-remaining-work-roadmap.md`](htmlbridge-remaining-work-roadmap.md).
+2026-07-12). The in-scope promotion slices that followed (computed-style, Range, scope builder, CSS
+helpers) all merged as PRs #1362–#1367 — see the closed
+[`htmlbridge-remaining-work-roadmap.md`](htmlbridge-remaining-work-roadmap.md). The residual open-ended
+promotion candidates are tracked in
+[`htmlbridge-promotion-backlog-roadmap.md`](htmlbridge-promotion-backlog-roadmap.md).
 Date: 2026-07-09 (last updated 2026-07-12)
 
 ## Purpose
@@ -52,9 +55,17 @@ The important consequence is that `Broiler.HtmlBridge.Dom.DomElement` and `HtmlT
 | P3 | HTML serialization policies | `Broiler.Dom.Html` | Move only standard serialization policy helpers | Render-specific or Acid-test compatibility transforms should stay bridge-owned unless they are standard DOM/HTML behavior. |
 | Deferred | Image decoder, SVG parser/renderer, canvas helpers | `Broiler.Media`, `Broiler.Graphics`, or existing media roadmap | Do not move to DOM/CSS | These are shared engine capabilities, but not DOM or CSS component responsibilities. Align with the media/graphics roadmap. |
 
+**Status (2026-07-12).** Both **P0** rows are done (Phase 1 + §2.1/§2.3, PRs #1362/#1365/#1367); both **P1**
+rows are done (Phase 3 CSSOM projection, Phase 4 `DomTokenList`); all three **P2** rows are done (Phase 4
+mutation filtering, §2.2 Range PR #1364, §2.4 scope builder PR #1365). The only promotion candidate not yet
+started is **P3 HTML serialization policies**; the **Deferred** media/graphics row is out of DOM/CSS scope.
+The residue is carried into [`htmlbridge-promotion-backlog-roadmap.md`](htmlbridge-promotion-backlog-roadmap.md).
+
 ## Non-candidates
 
-Do not move these into `Broiler.DOM` or `Broiler.CSS`:
+Do not move these into `Broiler.DOM` or `Broiler.CSS`. Their destinations (media/graphics roadmaps,
+`Broiler.Layout`, or permanent bridge ownership) are routed in
+[`htmlbridge-out-of-scope-routing-roadmap.md`](htmlbridge-out-of-scope-routing-roadmap.md):
 
 - `Broiler.HtmlBridge.Dom.DomElement`: compatibility facade over canonical DOM; remove at the public v2 boundary instead of promoting.
 - `HtmlTreeBuilder`: compatibility adapter over `Broiler.Dom.Html.HtmlDocumentParser`; remove when callers parse into canonical DOM directly.
@@ -505,8 +516,18 @@ Add architecture checks where practical:
 
 ## Open Questions
 
-- Should the CSSOM projection live directly in `Broiler.CSS`, or should it be isolated under a `Broiler.CSS.Cssom` namespace to make the browser-API mapping explicit?
-- Should `DomTokenList` be a public DOM type or an internal helper consumed by bridge and future DOM APIs?
-- Should stylesheet scope assembly include host-provided external stylesheet text in CSS.Dom, or should it remain entirely bridge-owned until more non-bridge consumers exist?
-- How much of current bridge serialization behavior is standard HTML serialization versus compatibility transforms for rendering tests?
-- When is the project ready to declare `htmlbridge-public-surface/v2` and remove the v1 compatibility adapters?
+Four of the five original questions were answered in practice by the completed phases; the serialization
+question is the one still genuinely open and is carried into
+[`htmlbridge-promotion-backlog-roadmap.md`](htmlbridge-promotion-backlog-roadmap.md).
+
+- **Answered (Phase 3):** the CSSOM projection lives isolated under a dedicated `Broiler.CSS.Cssom`
+  namespace (`CssomRuleMetadata`), making the browser-API mapping explicit.
+- **Answered (Phase 4):** `DomTokenList` is a public canonical `Broiler.Dom.DomTokenList` type (the bridge
+  `classList` wrappers delegate to it).
+- **Answered (§2.4, PR #1365):** stylesheet scope assembly *does* take host-supplied external stylesheet
+  text in CSS.Dom — `CssStyleScopeBuilder` owns media-gated, order-preserving engine sync while the host
+  keeps discovery + fetching.
+- **Still open:** how much of current bridge serialization behavior is standard HTML serialization versus
+  compatibility transforms for rendering tests? (Gates the P3 HTML-serialization-policy promotion.)
+- **Answered (2026-07-10):** `htmlbridge-public-surface/v2` was declared and the v1 compatibility adapters
+  removed (Milestones 1.0–1.3, PR #1359).

--- a/docs/roadmap/htmlbridge-out-of-scope-routing-roadmap.md
+++ b/docs/roadmap/htmlbridge-out-of-scope-routing-roadmap.md
@@ -1,0 +1,120 @@
+# HtmlBridge Out-of-Scope Routing Roadmap
+
+Status: **reference / routing map** — the disposition of every `Broiler.HtmlBridge.*` surface the DOM/CSS
+promotion program explicitly declared **out of scope** for promotion into `Broiler.DOM` / `Broiler.CSS`.
+Nothing here is DOM/CSS-promotion work; this doc records *where each concern belongs instead* (another
+component's roadmap, or "permanently bridge-owned") so the boundary is not re-litigated and no item is lost
+between roadmaps.
+Date: 2026-07-12
+
+## Why this doc exists
+
+The promotion program ([`htmlbridge-dom-css-promotion-roadmap.md`](htmlbridge-dom-css-promotion-roadmap.md))
+has two exclusion lists — the **Deferred** row of its promotion-candidate table and its **Non-candidates**
+list. Those items are correctly *not* in the promotion backlog
+([`htmlbridge-promotion-backlog-roadmap.md`](htmlbridge-promotion-backlog-roadmap.md)), but "don't promote to
+DOM/CSS" is a decision, not a destination. This roadmap gives each excluded surface a destination and a
+status, in three buckets:
+
+1. **Route to the media/graphics roadmaps** — shared engine capabilities that belong to `Broiler.Media` /
+   `Broiler.Graphics`, not DOM/CSS.
+2. **Route to `Broiler.Layout`** — layout/paint/geometry that belongs to the layout engine; the bridge keeps
+   only the JS-facing wrappers.
+3. **Permanent bridge residents** — JS object identity, runtime state, and host/resource integration that are
+   *definitionally* bridge responsibilities and never move.
+
+The routing rule is the inverse of the promotion rule: a surface is out of scope for DOM/CSS precisely when it
+needs JavaScript object identity, callbacks, **layout geometry, paint, resource loading, or media/graphics
+capability** — each of which has its own owning component.
+
+---
+
+## Bucket 1 — Media & graphics capabilities → `Broiler.Media` / `Broiler.Graphics`
+
+**Promotion-roadmap origin:** the **Deferred** candidate row — *image decoder, SVG parser/renderer, canvas
+helpers → do not move to DOM/CSS; align with the media/graphics roadmap.*
+
+**Bridge surface today.** `Broiler.HtmlBridge.Rendering/ImagePipeline.cs` (the `<img>`/image decode + view-box
+pipeline); SVG and canvas rasterization paths reached through the bridge's rendering/graphics adapters.
+
+**Destination & owning roadmaps.**
+
+| Concern | Destination | Owning roadmap | Status |
+| --- | --- | --- | --- |
+| Image decode (PNG/APNG/JPEG/BMP) | `Broiler.Media.Image.Managed` | [`broiler-media-component.md`](broiler-media-component.md) | **Proposed** — the plan explicitly moves the existing managed image codecs out of `Broiler.Graphics` into `Broiler.Media.Image.Managed`. |
+| Audio / video decode | `Broiler.Media.Audio` / `Broiler.Media.Video.MediaFoundation` | [`broiler-media-component.md`](broiler-media-component.md) | **Proposed** (decode-first; `IMFMediaEngine` is the fixed first video provider). |
+| SVG parse / render, canvas rasterization | `Broiler.Graphics` (+ `Broiler.Graphics.Windows` surface) | media/graphics + [`skia-replacement-roadmap.md`](skia-replacement-roadmap.md) | Graphics-owned; not DOM/CSS. |
+
+**HtmlBridge's stake.** The bridge keeps the **DOM/JS element behavior** (`HTMLImageElement`,
+`HTMLCanvasElement`, `<svg>` element wiring, `viewBox` IDL, network/loading policy) and hands pixels/decoding
+to Media/Graphics through their host seams. When `Broiler.Media` lands, `ImagePipeline` should consume the
+`Broiler.Media.Image` codec contract instead of `Broiler.Graphics` image types — tracked **there**, gated on
+the media roadmap leaving "Proposed."
+
+**Action for this program:** none. Do not promote to DOM/CSS. Revisit `ImagePipeline`'s codec dependency when
+`broiler-media-component.md` starts implementation.
+
+---
+
+## Bucket 2 — Layout, paint & geometry → `Broiler.Layout`
+
+**Promotion-roadmap origin:** the **Non-candidates** entry — *layout metrics, hit-testing, scroll geometry,
+paint staging, and rendering logs should follow `Broiler.Layout` or rendering roadmaps, not DOM/CSS
+extraction* — plus the RF-BRIDGE-1a dead-rendering types.
+
+**Bridge surface today.** `DomBridge/LayoutMetrics.cs`, `HitTesting.cs`, `AnchorResolver/ScrollSimulation.cs`,
+`SharedLayoutGeometry.cs`, `CheckLayoutAssertions.cs`, and `Rendering/SharedLayoutGeometryProvider.cs`.
+
+**Disposition.**
+
+- **Geometry read-model — already unified (RF-BRIDGE-1b, done).** The bridge no longer owns a parallel box
+  model: the ~2950-LOC recursive `LayoutMetrics` estimators and `LayoutRuntimeState` are **deleted**, and the
+  bridge now reads real geometry from `Broiler.Layout` through `SharedLayoutGeometryProvider`. See
+  [`htmlbridge-blocked-items-completion-roadmap.md`](htmlbridge-blocked-items-completion-roadmap.md) Track 2
+  and [`rf-bridge-1b-layout-unification.md`](rf-bridge-1b-layout-unification.md). The layout engine itself is
+  [`broiler-layout-component.md`](broiler-layout-component.md) (**Complete**).
+- **RF-BRIDGE-1a dead paint types — deleted.** `CssBoxModel`, `CssTextProperties`, `RenderingStages` (~29
+  types) were removed at the Phase 5 public-surface boundary (promotion roadmap Phase 5). Closed.
+- **What stays bridge-owned (correctly).** The remaining files are the **JS-facing geometry wrappers**
+  (`getBoundingClientRect`/`client*`/`offset*`/`scroll*`, `elementFromPoint` hit-testing, `scrollIntoView` /
+  scroll simulation) and the provider seam. These marshal canonical layout geometry into JS/CSSOM object
+  behavior — a bridge responsibility by definition. They are **not** candidates for DOM/CSS or for further
+  extraction into `Broiler.Layout` (the engine supplies geometry; it does not own the DOM/JS API surface).
+
+**Action for this program:** none. The only future layout-side movement is whatever the `Broiler.Layout`
+roadmap itself schedules; the bridge↔layout seam (`SharedLayoutGeometryProvider`) is the established boundary.
+
+---
+
+## Bucket 3 — Permanent bridge residents (never promote)
+
+**Promotion-roadmap origin:** the **Non-candidates** list. These are definitionally bridge responsibilities —
+they carry JavaScript object identity, host integration, or runtime state, so no canonical DOM/CSS home is
+even meaningful.
+
+| Surface | Bridge location (representative) | Why it stays |
+| --- | --- | --- |
+| JS object wrappers — DOM, CSSOM, events, ranges, iterators, style declarations, collections | `DomBridge/JsFunctionCallbacks/*`, `JsObjects.cs`, `StyleSheets.cs` | Live object identity + JS callback marshaling; DOM/CSS own the *algorithms*, the bridge owns the *wrappers* over them. |
+| `ElementRuntimeState` (as a whole) | `ElementRuntimeState.cs` | Aggregates JS identity, listeners, form/scroll/dialog/shadow state, stylesheet runtime state, animations — bridge runtime, not a DOM node concern. |
+| Resource loading — `fetch`, `XMLHttpRequest`, external stylesheet fetching | `DomBridge/Registration/Fetch.cs`, `XmlHttpRequest.cs` | Networking + host policy; the CSS scope builder (§2.4) deliberately takes host-supplied text so fetching stays here. |
+| Timers, host callbacks, browser-app integration | bridge registration/host surfaces | Host-runtime integration, no canonical component. |
+
+**Action for this program:** none, ever. Recorded here only so a future "what else can we promote?" pass does
+not re-open them. If a *neutral algorithm* is ever found hiding inside one of these wrappers (as happened with
+`classList` → `DomTokenList` and mutation-observer filtering in Phase 4), that algorithm is a promotion
+candidate for the backlog doc — the *wrapper* around it still stays here.
+
+---
+
+## Summary
+
+| Bucket | Items | Destination | Actionable here? |
+| --- | --- | --- | --- |
+| 1 | image/audio/video decode, SVG, canvas | `Broiler.Media` / `Broiler.Graphics` | No — tracked in the media/graphics roadmaps (Media is *Proposed*). |
+| 2 | layout metrics, hit-testing, scroll/paint geometry | `Broiler.Layout` (via the provider seam) | No — geometry read-model already unified (RF-BRIDGE-1b done); JS wrappers stay bridge-owned. |
+| 3 | JS wrappers, `ElementRuntimeState`, resource loading, host integration | none — permanent bridge residents | No — never promote (extract only a neutral algorithm if one surfaces). |
+
+**Net:** there is **no open DOM/CSS-promotion work in any of these buckets.** Bucket 1's only future move is
+gated on the `Broiler.Media` roadmap starting implementation; Buckets 2 and 3 are settled boundaries. The only
+open *promotion* item across the whole HtmlBridge program remains **P3 HTML-serialization policy**, tracked in
+[`htmlbridge-promotion-backlog-roadmap.md`](htmlbridge-promotion-backlog-roadmap.md).

--- a/docs/roadmap/htmlbridge-promotion-backlog-roadmap.md
+++ b/docs/roadmap/htmlbridge-promotion-backlog-roadmap.md
@@ -1,0 +1,198 @@
+# HtmlBridge Promotion Backlog Roadmap
+
+Status: **active (low-priority backlog)** — the residual "what else could move from `Broiler.HtmlBridge.*`
+into the canonical `Broiler.DOM` / `Broiler.CSS` components" list, after the large HtmlBridge efforts and
+the in-scope promotion slices all landed. Nothing here is blocked or urgent; items are picked up
+opportunistically. **B1 (P3 serialization) is effectively complete** — the classification audit is done and
+the one remaining standard helper (the raw-text element set) was promoted (2026-07-12); B4 is answered by that
+audit. **B2 (stylesheet-mutation paths) is audited and confirmed no-promotion** (2026-07-12). **B3's
+duplication sweep is done** (2026-07-12) — it deleted three dead duplicated bridge helpers and assessed the one
+byte-identical remainder as not cleanly promotable. In short: the backlog is fully triaged — no open promotion
+work remains beyond the optional, explicitly-low-value items.
+Date: 2026-07-12
+
+## Why this doc exists
+
+Three big HtmlBridge workstreams are **complete and merged to `main`**:
+
+- **v1 public-surface removal** (`DomElement` facade + `HtmlTreeBuilder` deleted) — PR #1359. See
+  [`htmlbridge-facade-removal-current-state.md`](htmlbridge-facade-removal-current-state.md).
+- **RF-BRIDGE-1b geometry unification** (recursive estimators + `LayoutRuntimeState` deleted) — see
+  [`htmlbridge-blocked-items-completion-roadmap.md`](htmlbridge-blocked-items-completion-roadmap.md).
+- **The in-scope DOM/CSS promotion slices** (computed-style cutover, canonical `DomRange`, `CssStyleScopeBuilder`,
+  CSS helpers) — PRs #1362–#1367. See the now-closed
+  [`htmlbridge-remaining-work-roadmap.md`](htmlbridge-remaining-work-roadmap.md).
+
+What is left is the *open-ended* tail of the promotion program: the promotion-candidate rows in
+[`htmlbridge-dom-css-promotion-roadmap.md`](htmlbridge-dom-css-promotion-roadmap.md) that were never started
+(only P3), a handful of neutral micro-promotions already assessed as low value, and the one design question
+still genuinely open. This doc collects them in one place so the completed roadmaps read as "done" and the
+residue does not get lost.
+
+## Guiding rule (unchanged from the promotion roadmap)
+
+Move a bridge algorithm into `Broiler.DOM` / `Broiler.CSS` only when it is **neutral** — no JavaScript object
+identity, callbacks, layout geometry, resource loading, or bridge runtime state. Keep JS wrappers, live CSSOM
+object identity, host/resource integration, and layout/paint code in the bridge. Every promotion must be
+output-preserving and gated on the same before/after `Broiler.Cli.Tests` name-diff (plus the dispatch-only
+WPT/Acid/pixel corpus when it changes observed behavior). Submodule changes (`Broiler.CSS`, `Broiler.DOM`)
+follow the push-or-patch workflow in `CLAUDE.md`.
+
+---
+
+## Backlog items
+
+### B1 — P3: HTML serialization policy helpers → `Broiler.Dom.Html`
+
+**What.** Move only the *standard* HTML-serialization policy helpers into `Broiler.Dom.Html`, leaving
+render-specific / Acid-test compatibility transforms bridge-owned.
+
+**Status: B1 effectively complete — audit done, last standard helper promoted (2026-07-12).** After the
+promotion below there is **no standard HTML-serialization policy left duplicated in the bridge**; everything
+remaining in `DomBridge.Serialization.cs` is either a render-compat transform or a bridge-runtime-state adapter
+projection, both correctly bridge-owned.
+
+**Classification audit — DONE (2026-07-12).** The bridge's serialization path (`DomBridge.Serialization.cs`)
+was audited rule-by-rule. **Key finding: the standard serialization core was already promoted** —
+`Broiler.Dom.Html.HtmlSerializer` already owns the spec 13.3 machinery (the iterative depth-bounded traversal,
+`VoidElements`, doctype emission, comment emission, attribute + text HTML-escaping via `Encode`, and
+shorthand-first style ordering via `IsShorthandProperty`). The bridge only supplies a thin
+`HtmlSerializationAdapter<DomNode>` plus a set of pre-serialization transforms. Every rule classifies cleanly:
+
+| Serializer rule | Class | Disposition |
+| --- | --- | --- |
+| Iterative traversal, `VoidElements`, doctype/comment emission, attribute + text `Encode` escaping, shorthand ordering | **Standard 13.3** | Already in `HtmlSerializer` (owned by `Broiler.Dom.Html`). |
+| **Raw-text element set** (`script`/`style`/`xmp`/`iframe`/`noembed`/`noframes`/`noscript`/`plaintext` serialize text literally) | **Standard 13.3** | **Promoted (this change)** — see below. Was a bridge-private list *and* an incomplete `"script" or "style"` duplicate inside the serializer. |
+| `GetKind` text/comment discrimination by `NodeType` | Standard | In the adapter, keyed off canonical `NodeType` — trivial, stays. |
+| `GetKind` `#document-fragment`/`#subdoc-root`/`#doctype` sentinel tag-names | Bridge model | Bridge sentinel node model — stays. |
+| `GetStyles` from the ERS inline-style map; `GetAttributes` id/class-first ordering, `style` skip | Bridge runtime | Reads bridge `ElementRuntimeState`; deterministic ordering is a bridge policy — stays. |
+| `#subdoc-root` skip; `srcdoc` re-serialization; `input` value reflection from the FormControl IDL | Bridge runtime | Nested-browsing-context + form-control runtime state — stays. |
+| Zoom baking (`ApplyZoomSerializationStyles`, SVG attr scaling, pseudo overrides); `RemoveRenderCommentNodes`; `progress`/`meter` placeholders; `ReflectRenderState` | **Render-compat transform** | Pixel/reftest fidelity, needs computed style + zoom model — stays bridge-owned (answers **B4**). |
+
+**Promotion landed (2026-07-12) — the raw-text element set.** The one standard-serialization helper still
+duplicated in the bridge is now the single source of truth in `Broiler.Dom.Html`:
+- Added `HtmlSerializer.RawTextElements` (the standard 13.3 raw-text / escapable-raw-text / legacy set) and
+  `HtmlSerializer.IsRawTextElement(tagName)`, as a sibling of `VoidElements`.
+- The bridge's private `IsRawTextSerializationParent` list is deleted; it now delegates to
+  `HtmlSerializer.IsRawTextElement` (behaviour-identical — same set, same case-insensitive match).
+- Reconciled the serializer's own leaf-text branch from the incomplete `tagName is "script" or "style"` to
+  `IsRawTextElement(tagName)`, closing a latent gap where `<xmp>`/`<noembed>`/... leaf text would have been
+  HTML-escaped against the spec (a no-op for the canonical adapter, whose element nodes return no leaf text).
+- **Delivery:** `HtmlSerializer.cs` + `HtmlSerializerTests.cs` are in the `Broiler.DOM` **submodule** — push +
+  pointer bump (or `patches/` fallback if the push 403s); the one-line bridge delegation is main-repo.
+
+**Verified regression-free (2026-07-12).** New `HtmlSerializerTests` (13 cases: the raw-text set incl.
+case-insensitivity + literal-vs-escape round-trip) green; full `Broiler.Dom.Html.Tests` 18/18; bridge
+`innerHTML`/`outerHTML`/DOM-interfaces sweep 50/50; the serialization suite's 8 non-environmental tests green.
+The 3 failing `ScriptEngineExecuteTests` zoom/SVG/iframe-srcdoc serialization tests are **pre-existing** —
+confirmed failing identically at clean HEAD (stash A/B), environmental per `CLAUDE.md`. Still wants the
+dispatch-only WPT `domparsing`/`html/syntax/serializing` + Acid gate at merge (it changes serializer output
+only for the rare literal-leaf-text `<xmp>`/`<noembed>` case).
+
+**Exit criteria — MET.** The standard serialization policy lives in `Broiler.Dom.Html` with its own unit tests;
+the bridge serializer calls it and retains only render-compatibility transforms and runtime-state projections.
+
+### B2 — Live stylesheet-mutation paths — **audit done; confirmed no promotion needed (2026-07-12)**
+
+**What.** The live CSSOM stylesheet-**mutation** entry points (`insertRule` / `deleteRule` / `cssText`).
+
+**Audit — DONE (2026-07-12).** Traced every stylesheet-mutation entry point in
+`DomBridge/JsFunctionCallbacks/StyleSheets.cs` + `DomBridge/StyleSheets.cs`. **All CSS parsing already routes
+through the canonical `Broiler.CSS`; no parser or validator is duplicated in the bridge** (a grep for ad-hoc
+`;`/`:`/`{` splitting in these files finds nothing):
+
+| Path | Where | Parsing |
+| --- | --- | --- |
+| `insertRule` (model-backed live `CSSRuleList`) | `JsStyleSheetsInsertRule005Core` | `new Broiler.CSS.CssParser().ParseStyleSheet(ruleText)` → inserts the canonical `CssRule` into the shared model. |
+| `insertRule` (nested JS-object rule list) | `JsStyleSheetsInsertRule009Core` → `ruleFactory` → `BuildCssRuleObject(string)` → `ParseCssRuleStrings` | Same `CssParser().ParseStyleSheet`. |
+| `deleteRule` (both live and nested) | `JsStyleSheets{DeleteRule006,DeleteRule010}Core` | **No parsing** — `RemoveAt(index)` + index re-sync + `markRulesMutated`. |
+| Rule `cssText` **getters** (`GetCssText013…028`) | serialize the live JS CSSOM object graph | Read-only per spec (no rule-level `cssText` setter to duplicate); assembled from live JS wrapper properties, and `BuildCssRuleObject(CssRule)` keys off the canonical `CssomRuleMetadata.GetRuleType` projection (Phase 3) with a serialize→reparse fallback only for `Unknown` at-rule types. |
+
+**Conclusion — nothing to promote.** The only bridge-owned code on these paths is (a) live JS object identity
++ index synchronization (`syncLiveCssRulesIndices`/`SyncIndices`), (b) parent rule/sheet wiring
+(`parentStyleSheet`/`parentRule`), (c) mutation dispatch (`markRulesMutated`), and (d) `cssText` serialization
+of the *live JS wrapper graph* — all correctly bridge responsibilities per the promotion roadmap Non-candidates
+list and the Phase-3 "cssText/callback surfaces stay bridge-owned" decision. The `cssText` getters do
+hand-assemble at-rule wrappers by string interpolation, but they read the *live* (independently-mutable) JS
+object graph rather than a canonical `CssRule`, so they cannot call `CssSerializer.Serialize(rule)` — the same
+"different input shape" reason B3 gives for not consolidating `ParseDeclarations`. **Assessed low value; do not
+pursue.**
+
+**Verified (2026-07-12):** the CSSOM `insertRule`/`deleteRule`/stylesheet suite is green (29/30; the lone
+failure, `HttpClientMigrationTests.StylesheetLoadHandler_Uses_HttpClient`, is a pre-existing reflection/
+assembly-load environmental failure per `CLAUDE.md`, confirmed failing at clean HEAD). No code change; this
+entry records the "route stylesheet mutation through shared APIs" Phase-1 task as **verified resolved**.
+
+### B3 — Neutral micro-promotions — **duplication sweep done (2026-07-12)**
+
+**Duplication sweep — DONE (2026-07-12).** Swept the bridge's pure static string/CSS helpers
+(`DomBridge/Css.cs`, `DomBridge.cs`, `DomBridge/Utilities.cs`, `LayoutMetrics.cs`) against `Broiler.CSS` for
+`StripVendorPrefix`-style byte-identical duplication. Findings:
+
+- **Dead duplicated helpers — DELETED (main-repo only, this change).** Three bridge private helpers had **zero
+  callers** anywhere in the `DomBridge` partial class (each duplicated logic that already lives canonically):
+  `FindMatchingClosingParen` and `FindTopLevelChar` (`DomBridge/Css.cs`, twins of the private helpers in
+  `CssStyleEngine.Values.cs`) and `IsLengthOrPercentage` (`DomBridge.cs`, twin of the `CssStyleEngine.Values.cs`
+  length check). Deleting them is behaviour-neutral (private + uncalled — the bridge builds clean, 0 errors; CSS
+  computed-style/length suite 53/53). Not a promotion — pure dead-code removal surfaced by the sweep.
+- **Byte-identical length-normalize trio — found, NOT promoted (assessed low value).** `NormalizeSingleValueLengthFunction`
+  + `TryUnwrapSingleValueFunction` + `HasBalancedParens` in `DomBridge/Css.cs` are **byte-identical** to the
+  private helpers of the same name in `Broiler.CSS/CssLengthParser.cs`. Promoting them the `StripVendorPrefix`
+  way is *not* a one-line reroute: `CssLengthParser` keeps them **deliberately private**, and the bridge uses
+  `HasBalancedParens` independently at three `LayoutMetrics.cs` sites — so promotion means exposing two of
+  `CssLengthParser`'s internal paren-helpers as public API and rerouting four call sites across two bridge
+  files, to dedup ~40 lines of trivial paren-balancing. Public-surface expansion outweighs the benefit.
+  **Recommendation: do not pursue** unless `CssLengthParser` gains a public value-normalization surface for
+  another reason. (`ParseCssLengthToPixels` — 26 bridge call sites, canonical twin in `CssStyleEngine.Computed.cs`
+  — is likewise not a clean/safe consolidation.)
+
+**Previously recorded (still stands):**
+
+- **`CssInlineStyleParser.ParseDeclarations` consolidation — assessed marginal (2026-07-12).** Both
+  `DomBridge.ParseStyle` and the engine's inline loop already use canonical `CssParser().ParseDeclarations()`
+  + `CssDeclarationValidator`; the only unshared code is a ~4-line orchestration loop with *different output
+  shapes* (bridge: dict with `!important` suffix + vendor-prefix mapping; engine: cascade winners). The named
+  "third copy" `HtmlCss.ParseDeclarations` (`Broiler.Documents.Html`) is a different naive parser serving
+  document conversion — forcing it onto the canonical parser would change Documents behavior (out of scope).
+  **Recommendation: do not pursue** unless the output shapes converge.
+- Any *further* `StripVendorPrefix`-style byte-identical string helpers that surface later are cheap, safe wins
+  (promote to `Broiler.CSS.CssPropertyNames`, the pattern set by PR #1366). The 2026-07-12 sweep above found no
+  such clean case still open — the only byte-identical duplicate (the length-normalize trio) is not cleanly
+  promotable, and the dead duplicates were deleted.
+
+### B4 — design question (carried from the promotion roadmap) — **ANSWERED (2026-07-12)**
+
+> How much of current bridge serialization behavior is standard HTML serialization versus compatibility
+> transforms for rendering tests?
+
+**Answered by the B1 classification audit.** The standard §13.3 serialization (traversal, void elements,
+raw-text elements, doctype/comment emission, attribute/text escaping, shorthand ordering) is all in
+`Broiler.Dom.Html.HtmlSerializer`. The bridge-owned remainder is exactly two kinds: (1) **render-compat
+transforms** — zoom baking + SVG-attr scaling + zoom pseudo overrides, `RemoveRenderCommentNodes`,
+`progress`/`meter` shadow-DOM placeholders, and `ReflectRenderState` (all need computed style / the zoom model
+and exist for pixel/reftest fidelity); and (2) **bridge-runtime adapter projections** — ERS inline style,
+`#subdoc-root` handling, `srcdoc` re-serialization, form-control value reflection, and the sentinel-tag node
+model. See the B1 classification table for the per-rule split.
+
+### Out of scope (do not promote to DOM/CSS)
+
+Per the promotion roadmap's Non-candidates list and the **Deferred** table row: image decoder, SVG
+parser/renderer, and canvas helpers are shared engine capabilities that belong to `Broiler.Media` /
+`Broiler.Graphics` and the media/graphics roadmap — **not** DOM or CSS component responsibilities. Likewise JS
+object wrappers, `ElementRuntimeState`, resource loading, and layout/paint/hit-testing/scroll geometry stay in
+the bridge (or route to `Broiler.Layout`).
+
+The disposition of every out-of-scope surface — destination component, owning roadmap, and status — is
+tracked in its own routing map:
+[`htmlbridge-out-of-scope-routing-roadmap.md`](htmlbridge-out-of-scope-routing-roadmap.md). None of it is open
+DOM/CSS-promotion work.
+
+---
+
+## Validation plan
+
+Same as the promotion roadmap: `Broiler.CSS.Tests`, `Broiler.CSS.Dom.Tests`, `Broiler.Dom.Tests`,
+`Broiler.Dom.Html.Tests`, the bridge CSSOM/inline-style/serialization suites, and the targeted WPT/Acid cases
+already tracked — baseline first (some fail environmentally per `CLAUDE.md`), then require zero
+baseline-passing regressions via a before/after TRX name-diff. Keep the architecture guards green:
+`Broiler.DOM` references no JS-engine/bridge types; `Broiler.CSS`/`Broiler.CSS.Dom` reference no bridge types.

--- a/docs/roadmap/htmlbridge-remaining-work-roadmap.md
+++ b/docs/roadmap/htmlbridge-remaining-work-roadmap.md
@@ -1,13 +1,25 @@
 # HtmlBridge — Remaining Work Roadmap (post-facade-removal)
 
-Status: **active** — the consolidated "what's left" list now that the `DomElement` facade removal has landed.
-Date: 2026-07-11 (Section 1 gate closed 2026-07-12).
+Status: **closed** — every in-scope item in this roadmap has merged to `main`. Section 1 (facade-removal
+blockers) and Section 2 (§2.1–2.4 DOM/CSS promotion slices) are all done and merged (PRs #1359, #1362–#1367).
+The residual open-ended promotion-candidate backlog (former §2.5) is tracked forward in
+[`htmlbridge-promotion-backlog-roadmap.md`](htmlbridge-promotion-backlog-roadmap.md).
+Date: 2026-07-11 (all sections closed 2026-07-12).
 
-> **Update (2026-07-12): all of Section 1 has landed on `main`.** The F3c/F4 merge gate (1.1) passed
-> and merged as PR #1359; the CSS-helper promotion (2.1 shorthand + 2.3 casing/`CssPriority`) merged as
-> PR #1362; and the `@position-try` twin follow-up from 1.2 — animation/`@keyframes` collection from
-> InnerHtml-backed `<style>` elements — merged as PR #1363. The remaining open work is entirely in
-> Section 2 (DOM/CSS promotion backlog).
+> **Update (2026-07-12): everything in this roadmap has merged to `main`.**
+> - **Section 1** (facade-removal blockers): the F3c/F4 merge gate (1.1) merged as PR #1359; the
+>   `Broiler.Wpt.Tests` resurrection + `DomElement`-alias retirement + `@position-try` fix + CSS-helper
+>   promotion (1.2/1.3 tail, 2.1 shorthand, 2.3 casing/`CssPriority`) merged as PR #1362; the
+>   animation/`@keyframes` InnerHtml-`<style>` twin follow-up (1.2) merged as PR #1363.
+> - **Section 2** (DOM/CSS promotion slices): §2.2 canonical `DomRange` content operations + the bridge
+>   `Range`/`RangeState` rewire merged as PR #1364; §2.1 sparse computed-style projection + §2.4
+>   `CssStyleScopeBuilder` + §2.3 live-setter validation merged as PR #1365; §2.3 `StripVendorPrefix`
+>   promotion merged as PR #1366; the §2.1 `GetComputedProps` cutover + the dead form-control/logical
+>   helper sweep merged as PR #1367.
+>
+> The section entries below are retained as the record of what each slice did. The only work that remains
+> is the open-ended, low-priority promotion-candidate backlog (former §2.5), now tracked in
+> [`htmlbridge-promotion-backlog-roadmap.md`](htmlbridge-promotion-backlog-roadmap.md).
 
 ## Purpose
 
@@ -104,12 +116,12 @@ were **deliberately not** part of deleting the facade type. They continue the br
 responsibilities into the canonical `Broiler.Dom`/`Broiler.CSS` components. None are blocked by anything;
 they are prioritized independently.
 
-### 2.1 Promotion Phase 2 — computed style (partially delivered)
+### 2.1 Promotion Phase 2 — computed style — **DONE (merged PRs #1362 / #1365 / #1367)**
 
 - The literal `GetComputedProps → GetComputedStyle` cutover (route the bridge's computed-property reads
-  through the canonical CSSOM computed-style path). **The cutover of the ~98 call sites is still deferred,
-  but the canonical projection it needs now exists and the swap is scoped by a measured parity delta
-  (2026-07-12).**
+  through the canonical CSSOM computed-style path). **DONE and merged (PR #1367).** The subsections below
+  are retained as the record of the enabling projection (PR #1365), the measured parity delta, the final
+  cutover, and the dead-helper sweep.
   - **Additive canonical projection landed.** `Broiler.CSS.Dom.CssStyleEngine.GetSparseComputedStyle`
     (Broiler.CSS submodule) runs the full computed-style pipeline (cascade + inline, custom-property/`var()`,
     CSS-wide keywords, shorthand + `attr()`, relative font-weight, inheritance backfill, form-control size
@@ -193,10 +205,10 @@ they are prioritized independently.
   **Delivery note:** the public `ExpandShorthands` wrapper is in the `Broiler.CSS` submodule — push +
   pointer bump (or patch fallback) at commit time.
 
-### 2.2 Promotion Phase 4 / slice 8 — Range content operations (canonical API landed; bridge rewire remains)
+### 2.2 Promotion Phase 4 / slice 8 — Range content operations — **DONE (merged PR #1364)**
 
-The token-list + mutation-filtering work landed earlier; the content operations are now split into two
-slices — **the canonical algorithms first (done), the bridge rewire second (remaining, higher-risk).**
+The token-list + mutation-filtering work landed earlier; the content operations were split into two
+slices — the canonical algorithms first, the bridge rewire second — **and both merged in PR #1364.**
 
 - **Done (2026-07-12) — canonical `DomRange` content operations.** `Broiler.Dom.DomRange` gains the full
   DOM Standard §4.5 content-operation surface, implemented against canonical `DomNode`/`DomCharacterData`
@@ -239,7 +251,7 @@ slices — **the canonical algorithms first (done), the bridge rewire second (re
   already in the committed failed baseline, so adopting spec behavior can only hold or improve, never add a
   new failure. Like the F3c/F4 cutovers this still wants the full WPT range/selection corpus at merge.
 
-### 2.3 Promotion Phase 1 slice-2 — deferred helpers (casing + `CssPriority` **DONE**; live-setter routing remains)
+### 2.3 Promotion Phase 1 slice-2 — deferred helpers — **DONE (merged PRs #1362 / #1365 / #1366)**
 
 Phase 1's exit criteria were already met; slice-2 left deferred items: casing helpers, `CssPriority`, and
 live-setter routing.
@@ -314,7 +326,7 @@ live-setter routing.
   tests are in the `Broiler.CSS` **submodule** — push + pointer bump (or `patches/` fallback if the push
   403s); the bridge one-line reroute is main-repo.
 
-### 2.4 Promotion Phase 2 slice-2 — stylesheet scope assembly (P2 `CssStyleScopeBuilder`) — **DONE (2026-07-12)**
+### 2.4 Promotion Phase 2 slice-2 — stylesheet scope assembly (P2 `CssStyleScopeBuilder`) — **DONE (merged PR #1365)**
 
 The P2 candidate "stylesheet scope assembly without fetching" — previously **never built** (a whole-repo
 search found only the roadmap mention) — is delivered.
@@ -344,16 +356,17 @@ search found only the roadmap mention) — is delivered.
   fetching, and CSS-text extraction (`GetStyleElementCssText`, InnerHtml/CSSOM/runtime-state) — they need the
   DOM and resource loading, matching the roadmap's "fetching remains bridge/host code" boundary.
 
-### 2.5 Promotion-candidate backlog (P0–P3) + Open Questions
+### 2.5 Promotion-candidate backlog (P0–P3) + Open Questions — **moved to its own roadmap**
 
-- The remaining P0–P3 promotion-candidate rows in the promotion roadmap not covered above (the broader
-  "what else could move to the canonical components" backlog). The two higher-risk behavior changes that were
-  open here — the `GetComputedProps` **cutover** (§2.1) and the live `CSSStyleDeclaration` **setter routing**
-  (§2.3) — are now **both done** (each verified regression-free locally and wanting the dispatch-only WPT/Acid
-  gate at merge). The residual backlog is small: the optional `StripVendorPrefix`-style neutral promotions and
-  a tracked sweep of the now-dead form-control/logical bridge helpers left by the §2.1 cutover.
-- The promotion roadmap's **Open Questions** (Open Question #5 — "declare v2" — is now answered; the rest
-  remain).
+Everything higher-risk that was open here has since merged: the `GetComputedProps` **cutover** (§2.1, PR
+#1367, including the now-dead form-control/logical helper sweep — commits `283fbf58`/`2473a453`), the live
+`CSSStyleDeclaration` **setter routing** (§2.3, PR #1365), and the `StripVendorPrefix` promotion (§2.3, PR
+#1366). What remains is the open-ended, low-priority promotion-candidate backlog (the P0–P3 rows in the
+promotion roadmap not covered above — principally **P3 HTML-serialization policy**) plus the promotion
+roadmap's still-open Open Questions.
+
+Because none of it is urgent or blocked and it no longer belongs to the facade-removal effort, it is tracked
+forward in its own doc: [`htmlbridge-promotion-backlog-roadmap.md`](htmlbridge-promotion-backlog-roadmap.md).
 
 ---
 
@@ -364,3 +377,8 @@ As of 2026-07-11 the four previously-stale roadmap docs are updated to reflect F
 (Milestones 1.2/1.3 → done, Track 1 complete), `htmlbridge-dom-css-promotion-roadmap.md` (Phase 5
 adapter-removal → done), and `rf-bridge-1b-layout-unification.md` (header + increment 6/7 BLOCKED labels
 cleared). This roadmap is the forward-looking companion.
+
+**Update (2026-07-12):** with §2.1–2.4 all merged (PRs #1364–#1367), this roadmap is **closed**; the
+open-ended promotion residue (former §2.5) was split into
+[`htmlbridge-promotion-backlog-roadmap.md`](htmlbridge-promotion-backlog-roadmap.md), and the promotion
+roadmap's Open Questions section was updated to mark the four now-answered questions.

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -897,12 +897,12 @@ public sealed partial class DomBridge
         GetRawInnerHtml: static node => GetElementRuntimeState(node).InnerHtml);
 
     /// <summary>Whether <paramref name="node"/>'s parent is an HTML raw-text element whose text
-    /// content is serialized literally (not HTML-escaped) — <c>script</c>, <c>style</c>, and the
-    /// other raw-text elements. (RF-BRIDGE-1c Phase F, F3c part 2d.)</summary>
+    /// content is serialized literally (not HTML-escaped). The standard raw-text element set is
+    /// owned by <see cref="SharedHtmlSerializer.RawTextElements"/> (§13.3); this bridge predicate
+    /// only applies it to the node's parent. (RF-BRIDGE-1c Phase F, F3c part 2d.)</summary>
     private static bool IsRawTextSerializationParent(Broiler.Dom.DomNode node) =>
         node.ParentNode is Broiler.Dom.DomElement parent &&
-        parent.TagName.ToLowerInvariant() is "script" or "style" or "xmp" or "iframe"
-            or "noembed" or "noframes" or "noscript" or "plaintext";
+        SharedHtmlSerializer.IsRawTextElement(parent.TagName);
 
     private IEnumerable<KeyValuePair<string, string>> GetSerializableAttributes(Broiler.Dom.DomElement element)
     {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -1108,28 +1108,6 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         CSS.Dom.CssDeclarationValidator.IsAcceptableDeclarationValue(
             property, Broiler.CSS.CssPriority.Strip(value));
 
-    /// <summary>Checks whether <paramref name="v"/> looks like a CSS length or percentage.</summary>
-    private static bool IsLengthOrPercentage(string v)
-    {
-        if (v == "0") return true;
-
-        // Known CSS length/percentage units and their suffix lengths
-        ReadOnlySpan<string> units = ["vmin", "vmax", "rem", "px", "em", "vh", "vw", "pt", "cm", "mm", "in", "ex", "ch", "%"];
-
-        foreach (var unit in units)
-        {
-            if (v.EndsWith(unit, StringComparison.Ordinal) && v.Length > unit.Length)
-            {
-                var numPart = v[..^unit.Length];
-                if (double.TryParse(numPart, System.Globalization.NumberStyles.Float,
-                    System.Globalization.CultureInfo.InvariantCulture, out _))
-                    return true;
-            }
-        }
-
-        return false;
-    }
-
     [GeneratedRegex(@"<title[^>]*>(?<content>[\s\S]*?)</title>", RegexOptions.IgnoreCase | RegexOptions.Compiled, "de-DE")]
     private static partial Regex TitlePatternRegex();
     [GeneratedRegex(@"<(?<tag>[a-zA-Z][a-zA-Z0-9]*)\b(?<attrs>[^>]*)\/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled, "de-DE")]

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -519,40 +519,6 @@ public sealed partial class DomBridge
             computed["display"] = display;
     }
 
-    private static int FindMatchingClosingParen(string value, int openParenIndex)
-    {
-        int depth = 0;
-        for (int i = openParenIndex; i < value.Length; i++)
-        {
-            if (value[i] == '(')
-                depth++;
-            else if (value[i] == ')')
-            {
-                depth--;
-                if (depth == 0)
-                    return i;
-            }
-        }
-
-        return -1;
-    }
-
-    private static int FindTopLevelChar(string value, char target)
-    {
-        int depth = 0;
-        for (int i = 0; i < value.Length; i++)
-        {
-            if (value[i] == '(')
-                depth++;
-            else if (value[i] == ')')
-                depth--;
-            else if (value[i] == target && depth == 0)
-                return i;
-        }
-
-        return -1;
-    }
-
     /// <summary>
     /// Expands CSS shorthand properties into individual longhand properties (e.g.
     /// <c>margin: 10px 5px</c> → <c>margin-top/right/bottom/left</c>), only setting longhands


### PR DESCRIPTION
## Overview

Triages the residual HtmlBridge DOM/CSS **promotion backlog** and executes the actionable items. Follows the earlier work (facade removal #1359, and the promotion slices #1362–#1367) by splitting what's left into dedicated roadmaps and clearing the low-hanging items.

Depends on **Broiler-Platform/Broiler.DOM#8** (the canonical `HtmlSerializer` raw-text helper) — the submodule pointer is bumped to that commit (`7c2d7b5`).

## Documentation

- **Close** `htmlbridge-remaining-work-roadmap.md`: §2.1–2.4 all merged (PRs #1364–#1367). Corrects the stale "still deferred / rewire remains / cutover deferred" headings that contradicted their own bodies, and records the merge PR per slice.
- **New** `htmlbridge-promotion-backlog-roadmap.md` — the open, low-priority promotion residue (items B1–B4).
- **New** `htmlbridge-out-of-scope-routing-roadmap.md` — routing map for the non-promotion surfaces (media/graphics → `Broiler.Media`/`Broiler.Graphics`, layout → `Broiler.Layout` via the provider seam, permanent bridge residents).
- Update the promotion roadmap's forward pointers, promotion-candidate status table, and Open Questions (4 of 5 now answered in practice).

## Code

**B1 — serialization policy (P3).** The standard raw-text element set (`script`/`style`/`xmp`/`iframe`/`noembed`/`noframes`/`noscript`/`plaintext`, HTML Standard §13.3) is promoted to the canonical `HtmlSerializer` (submodule PR #8). Here the bridge's private `IsRawTextSerializationParent` list is deleted and delegates to `HtmlSerializer.IsRawTextElement`. A rule-by-rule audit confirmed the standard serialization core was already canonical; everything else in `DomBridge.Serialization.cs` is render-compat transforms + runtime-state adapter projections that correctly stay bridge-owned (this also answers open question **B4**).

**B2 — stylesheet mutation.** Audit only, no code change. `insertRule`/`deleteRule`/`cssText` already route through canonical `CssParser`/`CssomRuleMetadata`; no parser/validator is duplicated. Recorded as verified-resolved.

**B3 — duplication sweep.** Deletes three **dead** duplicated bridge helpers with zero callers in the `DomBridge` partial class: `FindMatchingClosingParen` + `FindTopLevelChar` (`DomBridge/Css.cs`) and `IsLengthOrPercentage` (`DomBridge.cs`). The one remaining byte-identical duplicate (the length-normalize trio vs `CssLengthParser`'s deliberately-private helpers, with independent `LayoutMetrics` uses) is assessed low-value and left in place.

## Verification

- Bridge builds clean (0 errors).
- `Broiler.Dom.Html.Tests` 18/18; bridge `innerHTML`/`outerHTML`/DOM-interfaces 50/50; CSSOM `insertRule`/`deleteRule` 29/30; CSS computed-style/length 53/53.
- All residual failures are pre-existing/environmental (zoom/SVG serialization, `HttpClientMigration` reflection), each confirmed failing identically at clean HEAD via stash A/B.

## Reviewer notes

- Merge the submodule PR (Broiler-Platform/Broiler.DOM#8) alongside this; the pointer bump references its commit.
- B2 is documentation-only; B1's bridge change is a one-line delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)