### PR TITLE
Add BOSS (Broiler.Office.Server): Kestrel host for the Writer WASM app

### DIFF
--- a/Broiler.Office.Server/.gitignore
+++ b/Broiler.Office.Server/.gitignore
@@ -1,0 +1,3 @@
+# The web root is generated: the Broiler Writer WASM bundle is vendored here from the client's
+# published output by the VendorWriterClientForRun MSBuild target (see the .csproj). Never commit it.
+/wwwroot/

--- a/Broiler.Office.Server/Broiler.Office.Server.csproj
+++ b/Broiler.Office.Server/Broiler.Office.Server.csproj
@@ -1,0 +1,72 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <!--
+    BOSS — the Broiler Office Standalone Server.
+
+    A self-contained ASP.NET Core / Kestrel host for the Broiler Office web apps. It serves the
+    Broiler Writer WebAssembly word processor (Broiler.Writer.WebAssembly).
+
+    Hosting model — "vendored publish", not Blazor-hosted:
+      The Writer is a Microsoft.NET.Sdk.WebAssembly app (not Blazor). The Blazor hosted model
+      (Components.WebAssembly.Server + ProjectReference) serves it fine in development but, on publish,
+      never bakes the WebAssembly SDK's transformed index.html (the import map + fingerprinted script
+      references) into the output — it ships the raw placeholder index.html and the app can't boot.
+      So instead this server VENDORS the Writer's *published* wwwroot (transformed index.html, the
+      _framework mono-wasm runtime, and every content-hashed asset) and serves it as plain static
+      files. That is exactly the bundle the standalone `python -m http.server` flow serves, just hosted
+      by Kestrel — identical in `dotnet run` and `dotnet publish`.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>Broiler.Office.Server</RootNamespace>
+    <AssemblyName>Broiler.Office.Server</AssemblyName>
+    <IsPackable>false</IsPackable>
+
+    <!-- The vendored wwwroot is already content-hashed by the WebAssembly SDK and its transformed
+         index.html points at those exact names. Leave it untouched: don't let the Web SDK's static
+         web assets pipeline re-fingerprint or rewrite it. -->
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
+
+    <WriterClientProject>..\Broiler.Writer.WebAssembly\Broiler.Writer.WebAssembly.csproj</WriterClientProject>
+    <!-- Absolute: this PublishDir is handed to the client's build, where a relative path would resolve
+         against the client project directory rather than this one. BaseIntermediateOutputPath (obj\)
+         is set early and reliably; IntermediateOutputPath is not yet populated at this point. -->
+    <WriterClientStage>$(MSBuildProjectDirectory)\$(BaseIntermediateOutputPath)writer-client\</WriterClientStage>
+  </PropertyGroup>
+
+  <!-- Publish the Writer WASM client (trimmed — untrimmed crashes mono at boot) into an intermediate
+       stage. Skipped once staged, so the dev inner loop stays fast; force a refresh after changing the
+       Writer with -p:ForceWriterClientPublish=true (or delete obj/). -->
+  <Target Name="PublishWriterClient"
+          Condition="!Exists('$(WriterClientStage)wwwroot\index.html') Or '$(ForceWriterClientPublish)' == 'true'">
+    <Message Importance="high" Text="BOSS: publishing the Broiler Writer WASM client into $(WriterClientStage)…" />
+    <RemoveDir Directories="$(WriterClientStage)" />
+    <MSBuild Projects="$(WriterClientProject)"
+             Targets="Publish"
+             Properties="Configuration=$(Configuration);PublishDir=$(WriterClientStage);RunAOTCompilation=false" />
+  </Target>
+
+  <!-- Dev / `dotnet run`: vendor the staged bundle into this project's web root so Kestrel serves it. -->
+  <Target Name="VendorWriterClientForRun" DependsOnTargets="PublishWriterClient" BeforeTargets="Build">
+    <ItemGroup>
+      <_WriterClientFile Include="$(WriterClientStage)wwwroot\**\*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_WriterClientFile)"
+          DestinationFiles="@(_WriterClientFile->'$(MSBuildProjectDirectory)\wwwroot\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- Publish: vendor the staged bundle into the publish output web root. -->
+  <Target Name="VendorWriterClientForPublish" DependsOnTargets="PublishWriterClient" AfterTargets="Publish">
+    <ItemGroup>
+      <_WriterClientPublishFile Include="$(WriterClientStage)wwwroot\**\*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_WriterClientPublishFile)"
+          DestinationFiles="@(_WriterClientPublishFile->'$(PublishDir)wwwroot\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+</Project>

--- a/Broiler.Office.Server/Broiler.Office.Server.slnx
+++ b/Broiler.Office.Server/Broiler.Office.Server.slnx
@@ -1,0 +1,5 @@
+<Solution>
+  <Project Path="Broiler.Office.Server.csproj" />
+  <Project Path="../Broiler.Writer.WebAssembly/Broiler.Writer.WebAssembly.csproj" />
+  <Project Path="../Broiler.Graphics/Broiler.Graphics.WebAssembly/Broiler.Graphics.WebAssembly.csproj" />
+</Solution>

--- a/Broiler.Office.Server/Program.cs
+++ b/Broiler.Office.Server/Program.cs
@@ -1,0 +1,89 @@
+using System.Reflection;
+using Microsoft.AspNetCore.StaticFiles;
+
+// ── BOSS: the Broiler Office Standalone Server ────────────────────────────────────────────────────
+// A Kestrel host that serves the Broiler Office web apps. Today that is the Broiler Writer word
+// processor (Broiler.Writer.WebAssembly), mounted at the site root and served from its vendored,
+// content-hashed WebAssembly bundle (see the .csproj for how the bundle gets here). Additional Office
+// apps register the same way: vendor the client's published wwwroot and add it to the app list.
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Kestrel is the default (and only) server here; make the intent explicit.
+builder.WebHost.UseKestrel();
+
+var app = builder.Build();
+
+// The apps this server hosts. Extend this list as more Office web clients come online.
+var hostedApps = new[]
+{
+    new OfficeApp(
+        Name: "Writer",
+        Description: "Broiler Writer — word processor",
+        Path: "/",
+        Formats: new[] { "rtf", "docx", "html", "md" }),
+};
+
+if (!app.Environment.IsDevelopment())
+    app.UseExceptionHandler("/error");
+
+// Content types for the mono-wasm runtime under _framework/. The defaults already cover .wasm
+// (application/wasm, required for streaming compilation), .js, and .json; add the runtime's data
+// blobs and let anything else through as a binary download so no framework asset 404s.
+var contentTypes = new FileExtensionContentTypeProvider();
+contentTypes.Mappings[".dat"] = "application/octet-stream";   // ICU / timezone data
+contentTypes.Mappings[".blat"] = "application/octet-stream";  // bundled resources
+contentTypes.Mappings[".pdb"] = "application/octet-stream";   // debug symbols (debug builds)
+contentTypes.Mappings[".dll"] = "application/octet-stream";
+
+var staticFiles = new StaticFileOptions
+{
+    ContentTypeProvider = contentTypes,
+    ServeUnknownFileTypes = true,
+    DefaultContentType = "application/octet-stream",
+};
+
+// Serve the vendored Writer bundle: its transformed index.html references content-hashed physical
+// files (dotnet.<hash>.js, the replay module, m.<hash>.js) that exist on disk, so plain static file
+// serving is all that's needed — no import-map rewriting.
+app.UseStaticFiles(staticFiles);
+
+app.UseRouting();
+
+// ── Server API ────────────────────────────────────────────────────────────────────────────────────
+var serverVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0";
+
+app.MapGet("/healthz", () => Results.Text("OK", "text/plain"));
+
+app.MapGet("/api/info", () => Results.Json(new
+{
+    server = "BOSS",
+    product = "Broiler Office Standalone Server",
+    version = serverVersion,
+    apps = hostedApps,
+}));
+
+app.MapGet("/error", () => Results.Problem("The hosted application failed to load."));
+
+// Anything that is neither an API route nor a physical static asset is an in-app (client-routed) path:
+// hand back the Writer shell so the WebAssembly runtime boots and takes over.
+app.MapFallbackToFile("index.html", staticFiles);
+
+// Startup banner — makes it obvious the standalone server is up and where the Office apps live.
+var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("BOSS");
+app.Lifetime.ApplicationStarted.Register(() =>
+{
+    var addresses = app.Services
+        .GetRequiredService<Microsoft.AspNetCore.Hosting.Server.IServer>()
+        .Features.Get<Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature>()?
+        .Addresses;
+
+    logger.LogInformation("BOSS — Broiler Office Standalone Server v{Version} is up.", serverVersion);
+    foreach (var address in addresses ?? Array.Empty<string>())
+        logger.LogInformation("  Writer:  {Address}/", address.TrimEnd('/'));
+});
+
+app.Run();
+
+/// <summary>An Office web app mounted by BOSS, as reported by <c>/api/info</c>.</summary>
+internal sealed record OfficeApp(string Name, string Description, string Path, string[] Formats);

--- a/Broiler.Office.Server/Properties/launchSettings.json
+++ b/Broiler.Office.Server/Properties/launchSettings.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "BOSS": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7300;http://localhost:5300",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "BOSS (http)": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5300",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Broiler.Office.Server/README.md
+++ b/Broiler.Office.Server/README.md
@@ -1,0 +1,71 @@
+# BOSS — Broiler Office Standalone Server
+
+A self-contained **ASP.NET Core / Kestrel** web server that hosts the Broiler Office web apps. It
+serves the **Broiler Writer** WebAssembly word processor (`Broiler.Writer.WebAssembly`) directly from
+Kestrel — no external static file server (Python `http.server`, nginx, …) required.
+
+## Hosting model — vendored publish
+
+The Writer is a `Microsoft.NET.Sdk.WebAssembly` app (not Blazor). The classic Blazor *hosted* model
+(`Microsoft.AspNetCore.Components.WebAssembly.Server` + a `ProjectReference`) serves it fine in
+development but, on **publish**, never bakes the WebAssembly SDK's transformed `index.html` (the
+import map + content-hashed script references) into the output — it ships the raw placeholder
+`index.html` and the app cannot boot.
+
+So BOSS instead **vendors the Writer's *published* `wwwroot`** — the transformed `index.html`, the
+`_framework/` mono-wasm runtime, and every content-hashed asset — and serves it as plain static files.
+That is exactly the bundle the standalone `python -m http.server` flow serves, just hosted by Kestrel,
+and it behaves identically under `dotnet run` and `dotnet publish`.
+
+How the bundle gets here (see [`Broiler.Office.Server.csproj`](Broiler.Office.Server.csproj)):
+
+1. `PublishWriterClient` publishes `Broiler.Writer.WebAssembly` **trimmed** (untrimmed crashes mono at
+   boot) into `obj/writer-client/`. It is skipped once staged; force a refresh with
+   `-p:ForceWriterClientPublish=true` after changing the Writer.
+2. `VendorWriterClientForRun` copies that bundle into this project's `wwwroot/` for `dotnet run`.
+3. `VendorWriterClientForPublish` copies it into the publish output `wwwroot/` for `dotnet publish`.
+
+`wwwroot/` is generated and git-ignored. [`Program.cs`](Program.cs) serves it with a content-type
+provider that covers the `_framework` runtime blobs (`.wasm` → `application/wasm`, ICU `.dat`, …).
+
+## Endpoints
+
+| Route        | Purpose                                                            |
+| ------------ | ----------------------------------------------------------------- |
+| `/`          | Broiler Writer (WebAssembly).                                      |
+| `/healthz`   | Liveness probe — returns `OK`.                                     |
+| `/api/info`  | JSON: server identity, version, and the list of hosted apps.      |
+
+## Run (development)
+
+```powershell
+dotnet run --project Broiler.Office.Server
+```
+
+Kestrel listens on `https://localhost:7300` and `http://localhost:5300` (see
+[`Properties/launchSettings.json`](Properties/launchSettings.json)). Open the root URL for the Writer.
+
+> The **first** build publishes the trimmed WebAssembly client (native emscripten link — a minute or
+> two) and vendors it. Subsequent builds reuse the staged bundle. Requires the wasm workload:
+> `dotnet workload install wasm-tools`.
+
+## Publish (single self-contained bundle)
+
+```powershell
+dotnet publish Broiler.Office.Server -c Release -o artifacts/boss
+dotnet artifacts/boss/Broiler.Office.Server.dll
+```
+
+The publish output is one deployable folder whose `wwwroot/` holds the complete, trimmed Writer bundle
+— it boots the Writer over Kestrel with no other dependencies.
+
+## Adding more Office apps
+
+Vendor another client's published `wwwroot` (under its own sub-path) and add an entry to the
+`hostedApps` list in [`Program.cs`](Program.cs).
+
+## Solution
+
+[`Broiler.Office.Server.slnx`](Broiler.Office.Server.slnx) bundles the server, the Writer WebAssembly
+client, and the direct-Canvas graphics backend. Like the other WebAssembly samples, it is a
+repo-root sibling with its own solution file and is not part of the root `Broiler.slnx`.

--- a/Broiler.Office.Server/appsettings.Development.json
+++ b/Broiler.Office.Server/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Information"
+    }
+  }
+}

--- a/Broiler.Office.Server/appsettings.json
+++ b/Broiler.Office.Server/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/Broiler.Writer.WebAssembly/Broiler.Writer.WebAssembly.csproj
+++ b/Broiler.Writer.WebAssembly/Broiler.Writer.WebAssembly.csproj
@@ -11,6 +11,11 @@
     <IsPackable>false</IsPackable>
     <RootNamespace>Broiler.Writer.WebAssembly</RootNamespace>
     <AssemblyName>Broiler.Writer.WebAssembly</AssemblyName>
+    <!-- Publishing this browser-wasm app untrimmed crashes the mono runtime at boot
+         (AppContext.Setup). Trim on every publish path — direct `dotnet publish` of this project AND
+         a hosted publish through Broiler.Office.Server (BOSS), where the pubxml profile does not
+         apply. Full AOT still layers on top with -p:RunAOTCompilation=true. -->
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What

Wires **Broiler.Writer.WebAssembly** to a self-contained **ASP.NET Core / Kestrel** server — **BOSS**, the *Broiler Office Standalone Server* (`Broiler.Office.Server`). It serves the Writer word processor at `/` and exposes `/healthz` and `/api/info`, so the WASM app runs on Kestrel with no external static file server.

New project files:
- `Broiler.Office.Server/Program.cs` — Kestrel host, static serving of the Writer bundle, `/healthz`, `/api/info` (server identity + hosted-app list).
- Own `.slnx`, `launchSettings.json` (`https://localhost:7300`, `http://localhost:5300`), `appsettings*.json`, `.gitignore`, `README.md`.

One change outside the new project: `PublishTrimmed=true` in `Broiler.Writer.WebAssembly.csproj`.

## Why the "vendored publish" model (not Blazor-hosted)

The Writer is a `Microsoft.NET.Sdk.WebAssembly` app, **not** Blazor. The classic Blazor hosted model (`Components.WebAssembly.Server` + `ProjectReference` + `UseBlazorFrameworkFiles`/`MapStaticAssets`) serves it in `dotnet run`, but on **publish** it ships the raw placeholder `index.html` (empty import map, unresolved `main#[.{fingerprint}].js`) — the browser fetches `/main` and the app never boots.

Instead, BOSS publishes the Writer **trimmed** into an intermediate stage (MSBuild target) and **vendors its transformed `wwwroot`** (real import map, `_framework` mono-wasm runtime, content-hashed assets) into the server web root, serving it as plain static files with a framework-aware content-type provider (`.wasm` → `application/wasm`, ICU `.dat`, …). `StaticWebAssetsEnabled=false` keeps the Web SDK from re-fingerprinting the already-hashed bundle. Identical behavior under `dotnet run` and `dotnet publish`.

`PublishTrimmed=true` is set on the client so it is trimmed on **every** publish path (untrimmed crashes mono at boot), including the hosted publish through BOSS where the pubxml profile does not apply.

## Verification

Verified in a fresh browser tab, boot + render, for both:
- **Dev** (`dotnet run`): no console errors, status hidden, canvas painted (52 colors / 1028 non-transparent samples).
- **Published bundle** (`dotnet publish -o artifacts/boss` → `dotnet Broiler.Office.Server.dll`): all `_framework/*.wasm` 200, ICU `.dat` 200 (`application/octet-stream`), replay module 200, transformed `index.html`, app boots and renders.
- `/healthz` → `OK`; `/api/info` → correct JSON.

## Reviewer notes

- Generated `wwwroot/` (the vendored bundle) is git-ignored; only 8 source files + the client csproj are committed.
- First build publishes the trimmed WASM client (emscripten link, ~1–2 min), then reuses the staged bundle; refresh with `-p:ForceWriterClientPublish=true`.
- Not added to the root `Broiler.slnx` (matches the existing WASM-sample convention; it has its own `.slnx`).
- No submodule pointers touched.