### PR TITLE
Fix broiler-preview-package build failures on Windows and Linux

### DIFF
--- a/Broiler.Writer/Broiler.Writer.csproj
+++ b/Broiler.Writer/Broiler.Writer.csproj
@@ -22,7 +22,6 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug-Windows' Or '$(Configuration)' == 'Release-Windows'">
     <TargetFramework>net10.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <PublishAot>true</PublishAot>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">

--- a/src/Broiler.App.Graphics/Broiler.App.Graphics.csproj
+++ b/src/Broiler.App.Graphics/Broiler.App.Graphics.csproj
@@ -15,6 +15,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug-Linux' Or '$(Configuration)' == 'Release-Linux'">
+    <!-- Collapse the multi-targeting list to the single Linux TFM. Without this,
+         restore fans out over the default TargetFrameworks (the Windows TFMs) and
+         never restores net10.0, so a later no-restore framework net10.0 build
+         fails with NETSDK1005. -->
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

The **Prepare Broiler Preview Package** workflow (`broiler-preview-package.yml`) fails on both jobs. The workflow commands are correct — the failures come from two project-configuration bugs it surfaces. Both fixes are at the correct layer (main-repo projects, no submodules involved).

## Fixes

### Linux — `NETSDK1005` (`Broiler.App.Graphics`)
```
error NETSDK1005: Assets file '.../Broiler.App.Graphics/obj/project.assets.json'
doesn't have a target for 'net10.0'. [...::TargetFramework=net10.0]
```
The project's default `TargetFrameworks` is `net10.0-windows;net10.0-windows7.0`. `dotnet restore` fans out over that *plural* list and ignores the singular `TargetFramework=net10.0` that the `Release-Linux` config sets, so the assets file never contains `net10.0`. The later `dotnet build --no-restore --framework net10.0` then fails.

**Fix:** collapse `TargetFrameworks` to `net10.0` inside the `Release-Linux`/`Debug-Linux` config group. The change is scoped to the Linux configs only; plain `Debug`/`Release` and the Windows configs are unaffected.

### Windows — `NETSDK1102` (`Broiler.Writer`)
```
error NETSDK1102: Optimizing assemblies for size is not supported for the
selected publish configuration. Please ensure that you are publishing a
self-contained app. [...::TargetFramework=net10.0-windows]
```
`Release-Windows` set `PublishAot=true`. A framework-dependent publish (`--self-contained false`) can't AOT size-optimize, so ILLink errors. AOT was added incidentally (commit `97032eb1`) and nothing depends on it — no workflow AOT-publishes the Writer, and it contradicts the self-contained single-file publish the release workflows use.

**Fix:** remove the `PublishAot` line.

## Verification
- Linux restore for `Release-Linux` now produces `net10.0` / `net10.0/linux-x64` targets (was only the two Windows TFMs before).
- Windows Writer publishes both succeed with no `NETSDK1102`: framework-dependent (produces `Broiler.Writer.exe` + `.dll`) and self-contained (exe + bundled runtime).

## Reviewer notes
- I could only verify the Linux restore/assets resolution on a Windows host; a full Linux-native build/publish on an ubuntu runner wasn't exercised. The `NETSDK1005` cause is fully addressed.
- The `PublishAot` removal also fixes the identical latent failure in `writer-draft-release.yml`, which publishes the Writer the same way.