### PR TITLE
HtmlBridge Phase 4: eliminate parallel DOM state (P4.1–P4.4a)

### DIFF
--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -812,8 +812,29 @@ Behaviour-preserving; no public-API change. Tests:
 nodeType 9 with a canonical documentElement + doctype child; element creation/lookup/query work).
 Regression check vs the P4.3 baseline: a 1073-test wide sweep has the change-side failure set as a
 strict subset of baseline (no new failures); the Acid+Range set-diff's one apparent delta passes in
-isolation (known parallel-load render flakiness) → zero regressions. **Next: P4.4b** severs the
-regime-A iframe tree link and rewires the ~15 consumer sites; **P4.4c** eliminates `OwnerDocRoot`.
+isolation (known parallel-load render flakiness) → zero regressions.
+
+**P4.4b (regime-A iframe sever) is BLOCKED below the bridge — it requires a `Broiler.Layout` submodule
+change, not a bridge-only slice.** A full bridge-side implementation was written and reverted; the
+approach (documented here for the eventual cross-layer PR) added `_contentDocuments`/
+`_documentContainers` container↔document maps, made the four `BuildSubDocument*` paths mint a canonical
+`DomDocument` referenced by the container (not a `#subdoc-root` tree child), and rewired the
+lookup/reverse consumers
+(`GetOrCreateSubDocument`, `InvalidateCachedSubDocument`, `GetSubDocumentScrollingElement`,
+`TrySerializeCurrentSrcDoc`, `GetOuterFrameElement`). It built cleanly and passed the DOM/script
+sub-document suites, but produced **four deterministic iframe-geometry regressions**
+(`Todo28_Iframe_ZeroSize_No_Visual_Box`, the two script-assigned-iframe-position `ScrollIntoView`
+tests, and `SubframeElement_GetBoundingClientRect_Is_Composed_Into_Main_Frame`). Root cause:
+`Broiler.Layout/Broiler.Layout/Engine/CssBox.cs` `LayoutNestedBrowsingContexts` composes each
+subframe's geometry into the main coordinate frame by **walking the `#subdoc-root` subtree that is
+present in the main box tree** — i.e. the `#subdoc-root` tree child is load-bearing for *layout*, not
+only script DOM. The shared-layout-geometry snapshot lays out `_document` (which contained the
+`#subdoc-root` subtree), so `getBoundingClientRect` of a sub-document element found its box; severing
+removes the sub-document from `_document`, so the layout engine composes nothing. The clean fix is to
+make `Broiler.Layout` lay out the referenced content-documents (via the container↔document map)
+instead of the `#subdoc-root` subtree — a cross-layer change that overlaps Phase 5 (used-value/Layout
+work). Until then, regime-A stays on the `#subdoc-root` element path. **P4.4c** (eliminate
+`OwnerDocRoot`) and the remaining `#document` sentinel are independent of this blocker.
 
 Status: **P4.3 completed** 2026-07-13 (same branch) — work item 1, second of four sentinels. The
 `#document-fragment` sentinel element is replaced by the canonical `Broiler.Dom.DomDocumentFragment`.

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -778,6 +778,43 @@ Exit criteria:
 
 ### Phase 4 - eliminate parallel DOM state
 
+Status: **P4.4a completed** 2026-07-13 (same branch) — work item 1, third sentinel (`#subdoc-root`),
+**stage a of a multi-stage remodel**. `#subdoc-root` cannot become a canonical `DomDocument` in place
+because the iframe/object/frame roots (regime A) are live *tree children* of their container, which a
+`DomDocument` forbids; the full remodel severs that link and follows a container↔document reference.
+P4.4a does the safe, self-contained first stage: the **detached** `createDocument`/`createHTMLDocument`
+roots (regime B) — which are already parentless — become real canonical `DomDocument`s
+(`CreateBrowsingContextDocument`), and their doctype/documentElement are appended as true canonical
+document children (a `DomDocumentType` is finally a legitimate child of a `DomDocument`). Regime A
+(iframe) stays on the `#subdoc-root` element path until P4.4b.
+
+Foundation (behavior-preserving `DomElement`→`DomNode` widenings so a `DomDocument` root flows through
+the shared sub-document infrastructure): `ElementRuntimeState.OwnerDocRoot`, the `_documentWrappers`
+map + `SetDocument`/`TryGetDocument`, `AdoptSubtreeIntoDocument`, `BuildSubDocument` + its 24
+sub-document callbacks, and the shared descendant helpers `GetDocumentElement`/`CollectByTagName`/
+`FindInSubTree`/`CollectMatching`/`CollectStyleElements`/`HitTestDocumentPoint`/`BuildStyleSheetsCollection`/
+`BuildRange`. `GetDocumentElement` became honestly nullable (an empty `DomDocument` has no
+documentElement, per DOM — was the `#subdoc-root` self-fallback), with null-guards added to the six
+callers.
+
+**Two regressions found and fixed during the stage** (both from the doctype/document now being a
+canonical non-element the surrounding element-typed code didn't expect): (1) `createDocument` with an
+empty qualifiedName produced an empty `DomDocument`, so `doc.documentElement` returned null and the
+facade getter crashed on `ToJSObject(null)` — fixed by returning `null` per DOM; (2) the `Range`
+`setStart/EndBefore/After` boundary setters used `ParentEl` (`ParentNode as DomElement`, which nulls a
+`DomDocument` parent) and so threw `InvalidNodeTypeError` when a node's parent was a regime-B document
+root — fixed to use the raw `ParentNode` (a Document is a valid boundary container). Both are guarded
+by pre-existing tests (`DomImplementationTests.Implementation_CreateDocument_Without_QualifiedName`,
+`Acid3Phase4RangeTests.Test8_MovingBoundaryPoints`).
+
+Behaviour-preserving; no public-API change. Tests:
+`Broiler.Cli.Tests/BrowsingContextRootMigrationTests.cs` (createDocument/createHTMLDocument report
+nodeType 9 with a canonical documentElement + doctype child; element creation/lookup/query work).
+Regression check vs the P4.3 baseline: a 1073-test wide sweep has the change-side failure set as a
+strict subset of baseline (no new failures); the Acid+Range set-diff's one apparent delta passes in
+isolation (known parallel-load render flakiness) → zero regressions. **Next: P4.4b** severs the
+regime-A iframe tree link and rewires the ~15 consumer sites; **P4.4c** eliminates `OwnerDocRoot`.
+
 Status: **P4.3 completed** 2026-07-13 (same branch) — work item 1, second of four sentinels. The
 `#document-fragment` sentinel element is replaced by the canonical `Broiler.Dom.DomDocumentFragment`.
 Unlike the doctype leaf, a fragment is a *container*, so it gets a dedicated

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -778,6 +778,41 @@ Exit criteria:
 
 ### Phase 4 - eliminate parallel DOM state
 
+Status: **P4.1 completed** 2026-07-13 (branch `htmlbridge-phase4-remove-knownnodes`) — work item 6.
+The `_knownNodes` parallel node set is deleted. It was a process-instance
+`HashSet<DomNode>` populated on **every** node-construction path (`createElement`, `cloneNode`,
+`createComment`/`createTextNode`, `createDocumentFragment`, doctype/subdoc-root creation, HTML/XHTML
+parse, `document.write`, `innerHTML`/`outerHTML` replace, `insertAdjacent*`, `attachShadow`, the
+XML-fallback builders) — ~70 write sites across 10 files — but had **no behaviour-affecting reader
+left**: its last real consumer (`document.links`/collection ordering) was already replaced by
+tree-order traversal, and its only surviving lookup was a redundant `if (!Contains) Add` guard on a
+`HashSet` (idempotent by definition). It was pure parallel state shadowing canonical tree membership,
+so the canonical Broiler.Dom tree is now the single authority. Removed with it: the now-dead
+`AddElementsRecursive` register-subtree helper (its `RemoveElementsRecursive` counterpart stays — it
+still evicts `_jsObjects`/`_styleSheetCache` on sub-document teardown) and the orphaned
+`CollectAllDescendantsFlat` document.write helper. `ParseHtml`/`Dispose` no longer `Clear()` a set
+that is gone. Behaviour-preserving; no public-API change (`_knownNodes` was `private`). Tests:
+`Broiler.Cli.Tests/KnownNodesRemovalTests.cs` (guard: the field is gone + it must not be
+reintroduced; characterizations: element create/insert, `cloneNode`/comment/fragment construction,
+and `innerHTML` parse-replace all still round-trip through the canonical tree). Regression check vs
+the P3.12 baseline: the DOM / traversal / namespace / HTML-DOM-interface / serializer / cross-document
+(SVG) / attributes / MutationObserver / lifetime / public-API-snapshot / architecture-guard / Acid3
+suites pass unchanged; the pre-existing environmental headless-geometry failure
+(`DomTraversalAndRangeTests.Range_GetBoundingClientRect_Includes_DisplayContents_Descendants`) fails
+identically with the change stashed → zero regressions.
+
+This is the first Phase 4 slice and the safest opener: it removes a genuine parallel authority (not a
+convenience wrapper) and declutters the `SubDocuments`/`Registration` node-construction paths that the
+still-pending Phase 3 Frames/browsing-context and Window/Document feature modules must extract — every
+construction site lost its `_knownNodes.Add(...)` bookkeeping line. The heavier parallel-state items
+(1 sentinel `#document`-family elements, 2 inline-style single authority, 3 parallel `InnerHtml`
+string) remain; item 5 "delete bridge copies" is a **separate judgement**, not a blanket sweep: the
+Phase-3-widened neutral shims (`IsText`/`ParentEl`/`ChildAt`/attribute scans, etc.) read the canonical
+tree rather than holding state, so they are wrappers to consolidate opportunistically, and the bridge's
+`Normalize`/`isEqualNode`/`cloneNode` reimplementations are **not** straight swaps for the canonical
+ones — they fire the bridge's MutationObserver / NodeIterator side effects the canonical algorithms do
+not.
+
 Goal: make Broiler.Dom and Broiler.Dom.Html the only authorities for document
 tree/content state.
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -778,6 +778,46 @@ Exit criteria:
 
 ### Phase 4 - eliminate parallel DOM state
 
+Status: **P4.3 completed** 2026-07-13 (same branch) — work item 1, second of four sentinels. The
+`#document-fragment` sentinel element is replaced by the canonical `Broiler.Dom.DomDocumentFragment`.
+Unlike the doctype leaf, a fragment is a *container*, so it gets a dedicated
+`PopulateDocumentFragmentJSObject` wrapper in `ToJSObject` (Node base + ParentNode mixin +
+child-manipulation: childNodes/children/first-last-child/-ElementChild, appendChild/insertBefore/
+removeChild/replaceChild/append/prepend, querySelector(-All), textContent, cloneNode) — deliberately
+NOT the element surface (attributes/style/tagName) it inherited as a sentinel element, and (preserving
+today's behaviour) NOT `getElementById`. Node-generic members reuse the existing DomNode handlers;
+the container members are focused fragment lambdas over the neutral tree helpers plus two shared
+helpers widened `DomElement`→`DomNode`: `InsertNodeAt` (guarding the element-only style-scope
+invalidation / child-added notification with `is DomElement`; a fragment parent has neither) and
+`FindInDescendants`/`SearchDescendants` (read-only descendant walk; scope is null for a fragment
+root). Fragment construction funnels through a new `CreateBridgeDocumentFragment()` at all three sites
+(`createDocumentFragment`, Range clone/extract result, the internal HTML fragment-parse container);
+the parse-container carriers (`BuildFragmentTree` return, `TryBuildInnerHtmlFragmentContainer` out
+param, the `parsedContainer` local) became `DomDocumentFragment`. `CloneDomElement`, `NodesAreEqual`,
+`GetNodeType`×2, `GetNodeName`, the serialization `GetKind` and the `append`-family child-spread
+(`BuildChildNodeArgumentNodes`) all gained a `DomDocumentFragment` branch and shed their
+`#document-fragment` TagName checks (the child-spread was the "silently stops matching" hazard the
+audit flagged). `appendChild(fragment)` now also unpacks natively (via the DomNode-widened
+`InsertNodeAt`), matching `append(fragment)`.
+
+**Regression fixed in this slice (introduced by P4.2, missed because that PR's wide-sweep log was
+tail-truncated to 8 of 10 failures):** `document.implementation.createDocument(ns, qname, doctype)`
+resolved the passed doctype with `_jsObjects.Entries … kvp.Key is DomElement`, which silently skipped
+the now-non-element `DomDocumentType` — so the doctype's `OwnerDocRoot` was never set and
+`doctype.ownerDocument` wrongly returned the main document. Fixed by matching `is DomNode` in both
+`createDocument` paths (main + sub-document) and, for the same class of hazard, in the sub-document
+`appendChild` node-lookup. Guarded by the pre-existing
+`DomEdgeCasePhase4Tests.CreateDocument_XHTML_With_DocType_Sets_OwnerDocument` (confirmed pass@P4.1 →
+fail@P4.2 → pass now).
+
+Behaviour-preserving; no public-API change. Tests:
+`Broiler.Cli.Tests/DocumentFragmentSentinelMigrationTests.cs` (create, append-unpack, query/children,
+cloneNode, Range extractContents). Regression check vs the P4.1 baseline (predating both P4.2 and
+P4.3): a 1005-test sweep has the change-side failure set as a strict subset of baseline (one flaky
+`:root` test even flipped to passing) with **no new failures**; the 21 apparent Acid deltas all pass
+in isolation (known parallel-load render flakiness — the Acid count varied 7/8/28 across runs) → zero
+regressions.
+
 Status: **P4.2 completed** 2026-07-13 (same branch) — work item 1, first of four sentinels. The
 `#doctype` sentinel element is replaced by the canonical `Broiler.Dom.DomDocumentType`. The doctype
 was a fake-tag `DomElement` (null namespace, `TagName == "#doctype"`) whose name/publicId/systemId

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -778,6 +778,41 @@ Exit criteria:
 
 ### Phase 4 - eliminate parallel DOM state
 
+Status: **P4.2 completed** 2026-07-13 (same branch) — work item 1, first of four sentinels. The
+`#doctype` sentinel element is replaced by the canonical `Broiler.Dom.DomDocumentType`. The doctype
+was a fake-tag `DomElement` (null namespace, `TagName == "#doctype"`) whose name/publicId/systemId
+lived in a parallel `ElementRuntimeState.DocumentType` state class (`DocumentTypeRuntimeState`); it
+now IS a canonical DocumentType node that carries those natively — so `DocumentTypeRuntimeState` and
+its `CopyRuntimeValuesTo` copy are deleted. Construction funnels through a new
+`CreateBridgeDocumentType(name, publicId, systemId)` over the existing `DomDocument.CreateDocumentType`
+factory (name lowercased once at construction to preserve the old read-time `GetDocTypeName`
+lowercasing; the always-`null` `internalSubset` is dropped — canonical has no such field and the JS
+getter already returned `null`). All five creation sites (main-parse `ParseDocType`, `document.write`,
+`createDocumentType` × main+sub, `createHTMLDocument` × main+sub) use the funnel. The reads move to the
+canonical node: a dedicated `PopulateDocumentTypeJSObject` wrapper gives the doctype the correct
+minimal DocumentType surface (Node base + ChildNode mixin + EventTarget + name/publicId/systemId,
+**not** the element surface it used to inherit); `GetNodeType`/`GetNodeName`, the serialization adapter
+(`GetKind`/`GetName`), `NodesAreEqual` (isEqualNode) and `CloneDomElement` all gained a
+`DomDocumentType` branch and shed their `#doctype` TagName special-cases. The canonical
+`HtmlSerializer`/`HtmlDocumentParser` already speak `DomDocumentType`, so no submodule change was
+needed. **One regression found and fixed during the slice:** the sub-document `childNodes` handler
+used `ChildElements` (element-only), which silently dropped the now-non-element doctype — switched to
+raw `ChildNodes` (matching `firstChild` and DOM `childNodes` semantics). Behaviour-preserving; no
+public-API change. Tests: `Broiler.Cli.Tests/DoctypeSentinelMigrationTests.cs` (parsed doctype,
+`createDocumentType`, `createHTMLDocument`, `cloneNode`, serialization). Regression check vs the P4.1
+baseline: the DOM / sub-document / cross-document / HTML-DOM-interface / serializer / namespace /
+traversal / lifetime / guard suites pass unchanged (595 in the wide sweep); the Acid pixel/layout
+suite fails the same **count** (8) on baseline and change with the differing test passing in isolation
+(known container flakiness), plus the standing headless-geometry failure → zero regressions.
+
+The remaining three sentinels — `#document-fragment` → `DomDocumentFragment`, `#subdoc-root` →
+browsing-context root, and `#document` → `DomDocument` — are separate sub-slices (P4.3+). They are
+harder than doctype: a fragment/subdoc-root/document is a **container** whose JS surface (appendChild,
+querySelector, children) the element wrapper currently supplies, and a canonical `DomDocumentType` may
+only be a child of a canonical `DomDocument` — so once the document/subdoc roots also become canonical,
+the doctype's `SetParent`/`AppendChild` will run under canonical pre-insert validity (today it is
+allowed because the parent is still an element).
+
 Status: **P4.1 completed** 2026-07-13 (branch `htmlbridge-phase4-remove-knownnodes`) — work item 6.
 The `_knownNodes` parallel node set is deleted. It was a process-instance
 `HashSet<DomNode>` populated on **every** node-construction path (`createElement`, `cloneNode`,

--- a/src/Broiler.Cli.Tests/BrowsingContextRootMigrationTests.cs
+++ b/src/Broiler.Cli.Tests/BrowsingContextRootMigrationTests.cs
@@ -1,0 +1,81 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Guards the HtmlBridge complexity-reduction roadmap Phase 4 item 1, stage P4.4a: the DETACHED
+/// browsing-context roots produced by <c>document.implementation.createDocument</c> and
+/// <c>createHTMLDocument</c> are now backed by a canonical <see cref="Broiler.Dom.DomDocument"/>
+/// instead of a <c>#subdoc-root</c> sentinel element. (The materialized iframe/object/frame roots
+/// — regime A — remain on the sentinel path until a later stage, because they are tree children of
+/// their container, which a DomDocument cannot be.) These characterizations exercise the
+/// script-visible surface of a regime-B document end-to-end.
+/// </summary>
+public sealed class BrowsingContextRootMigrationTests
+{
+    private static DomBridge Attach(out JSContext context)
+    {
+        context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, "<!DOCTYPE html><html><body></body></html>", "https://example.com/index.html");
+        return bridge;
+    }
+
+    [Fact]
+    public void CreateDocument_Is_A_Document_With_DocumentElement_And_Doctype()
+    {
+        using var bridge = Attach(out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var dt = document.implementation.createDocumentType('html', 'pub', 'sys');
+                var doc = document.implementation.createDocument('http://www.w3.org/1999/xhtml', 'html', dt);
+                return doc.nodeType + '|' + doc.documentElement.tagName.toLowerCase() + '|' +
+                       (dt.ownerDocument === doc) + '|' + doc.firstChild.nodeType + '|' + doc.firstChild.name;
+            })()
+            """);
+
+        // nodeType 9 (Document), <html> documentElement, doctype.ownerDocument === doc, first child is
+        // the DocumentType (nodeType 10) named "html".
+        Assert.Equal("9|html|true|10|html", result.ToString());
+    }
+
+    [Fact]
+    public void CreateHtmlDocument_Has_Structure_And_Title()
+    {
+        using var bridge = Attach(out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var doc = document.implementation.createHTMLDocument('Hello');
+                return doc.nodeType + '|' + doc.documentElement.tagName.toLowerCase() + '|' +
+                       doc.body.tagName.toLowerCase() + '|' + doc.head.tagName.toLowerCase() + '|' +
+                       doc.title + '|' + doc.firstChild.nodeType;
+            })()
+            """);
+
+        Assert.Equal("9|html|body|head|Hello|10", result.ToString());
+    }
+
+    [Fact]
+    public void CreateHtmlDocument_Supports_Element_Creation_And_Lookup()
+    {
+        using var bridge = Attach(out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var doc = document.implementation.createHTMLDocument('t');
+                var p = doc.createElement('p');
+                p.id = 'x';
+                p.textContent = 'hi';
+                doc.body.appendChild(p);
+                var found = doc.getElementById('x');
+                return (found === p) + '|' + found.textContent + '|' + (found.ownerDocument === doc) + '|' +
+                       doc.querySelector('#x').tagName.toLowerCase();
+            })()
+            """);
+
+        Assert.Equal("true|hi|true|p", result.ToString());
+    }
+}

--- a/src/Broiler.Cli.Tests/DoctypeSentinelMigrationTests.cs
+++ b/src/Broiler.Cli.Tests/DoctypeSentinelMigrationTests.cs
@@ -1,0 +1,97 @@
+using System.Reflection;
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Guards the HtmlBridge complexity-reduction roadmap Phase 4 second slice (P4.2, part of work item 1):
+/// the <c>#doctype</c> sentinel element is replaced by the canonical <see cref="Broiler.Dom.DomDocumentType"/>.
+/// The doctype was a fake-tag <c>DomElement</c> whose name/publicId/systemId lived in a parallel
+/// <c>ElementRuntimeState.DocumentType</c> state class; it now IS a canonical DocumentType node that
+/// carries those natively. These characterizations exercise every reachable doctype path through the
+/// bridge — the parsed <c>&lt;!DOCTYPE&gt;</c>, <c>createDocumentType</c>, <c>createHTMLDocument</c>,
+/// <c>cloneNode</c>, and serialization — and pin the observable behaviour across the migration.
+/// </summary>
+public sealed class DoctypeSentinelMigrationTests
+{
+    private static DomBridge Attach(string html, out JSContext context)
+    {
+        context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "https://example.com/index.html");
+        return bridge;
+    }
+
+    [Fact]
+    public void Parsed_Doctype_Reports_DocumentType_Node()
+    {
+        using var bridge = Attach("<!DOCTYPE html><html><body>x</body></html>", out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var dt = document.firstChild;
+                return dt.nodeType + '|' + dt.nodeName + '|' + (dt.parentNode === document) + '|' + (dt.ownerDocument === document);
+            })()
+            """);
+
+        Assert.Equal("10|html|true|true", result.ToString());
+    }
+
+    [Fact]
+    public void CreateDocumentType_Carries_Name_PublicId_SystemId()
+    {
+        using var bridge = Attach("<!DOCTYPE html><html><body></body></html>", out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var dt = document.implementation.createDocumentType('html', 'pubX', 'sysY');
+                return dt.nodeType + '|' + dt.name + '|' + dt.nodeName + '|' + dt.publicId + '|' + dt.systemId + '|' + (dt.internalSubset === null);
+            })()
+            """);
+
+        Assert.Equal("10|html|html|pubX|sysY|true", result.ToString());
+    }
+
+    [Fact]
+    public void CreateHtmlDocument_Has_Html_Doctype()
+    {
+        using var bridge = Attach("<!DOCTYPE html><html><body></body></html>", out var context);
+
+        // createHTMLDocument must not throw and its doctype must be a DocumentType node named "html".
+        var result = context.Eval("""
+            (() => {
+                var doc = document.implementation.createHTMLDocument('Title');
+                var dt = doc.firstChild;
+                return dt.nodeType + '|' + dt.nodeName;
+            })()
+            """);
+
+        Assert.Equal("10|html", result.ToString());
+    }
+
+    [Fact]
+    public void Doctype_CloneNode_Preserves_DocumentType_Fields()
+    {
+        using var bridge = Attach("<!DOCTYPE html><html><body></body></html>", out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var dt = document.implementation.createDocumentType('svg', 'p1', 's1');
+                var c = dt.cloneNode(false);
+                return c.nodeType + '|' + c.name + '|' + c.publicId + '|' + c.systemId + '|' + c.isEqualNode(dt);
+            })()
+            """);
+
+        Assert.Equal("10|svg|p1|s1|true", result.ToString());
+    }
+
+    [Fact]
+    public void Serialized_Document_Starts_With_Doctype()
+    {
+        using var bridge = Attach("<!DOCTYPE html><html><head></head><body>hi</body></html>", out _);
+
+        var html = bridge.SerializeToHtml();
+        Assert.StartsWith("<!DOCTYPE html>", html.TrimStart());
+    }
+}

--- a/src/Broiler.Cli.Tests/DocumentFragmentSentinelMigrationTests.cs
+++ b/src/Broiler.Cli.Tests/DocumentFragmentSentinelMigrationTests.cs
@@ -1,0 +1,121 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Guards the HtmlBridge complexity-reduction roadmap Phase 4 third slice (P4.3, part of work item 1):
+/// the <c>#document-fragment</c> sentinel element is replaced by the canonical
+/// <see cref="Broiler.Dom.DomDocumentFragment"/>. The fragment was a fake-tag <c>DomElement</c>
+/// (TagName "#document-fragment"); it now IS a canonical DocumentFragment node with a dedicated
+/// container JS wrapper. These characterizations exercise the reachable fragment paths — creation,
+/// child manipulation, unpack-on-insert, querying, cloneNode, and Range-produced fragments — and pin
+/// the observable behaviour across the migration.
+/// </summary>
+public sealed class DocumentFragmentSentinelMigrationTests
+{
+    private static DomBridge Attach(string html, out JSContext context)
+    {
+        context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "https://example.com/index.html");
+        return bridge;
+    }
+
+    [Fact]
+    public void CreateDocumentFragment_Reports_Fragment_Node()
+    {
+        using var bridge = Attach("<!DOCTYPE html><html><body></body></html>", out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var f = document.createDocumentFragment();
+                return f.nodeType + '|' + f.nodeName + '|' + (f.ownerDocument === document) + '|' + f.childNodes.length;
+            })()
+            """);
+
+        Assert.Equal("11|#document-fragment|true|0", result.ToString());
+    }
+
+    [Fact]
+    public void Append_Unpacks_Fragment_Children_Into_Host()
+    {
+        using var bridge = Attach("<!DOCTYPE html><html><body><div id=\"host\"></div></body></html>", out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var host = document.getElementById('host');
+                var f = document.createDocumentFragment();
+                var a = document.createElement('span'); a.textContent = 'one';
+                var b = document.createElement('span'); b.textContent = 'two';
+                f.appendChild(a);
+                f.appendChild(b);
+                host.append(f);
+                return host.childNodes.length + '|' + f.childNodes.length + '|' +
+                       host.firstChild.textContent + '|' + host.lastChild.textContent;
+            })()
+            """);
+
+        Assert.Equal("2|0|one|two", result.ToString());
+    }
+
+    [Fact]
+    public void Fragment_Query_And_Children_Work()
+    {
+        using var bridge = Attach("<!DOCTYPE html><html><body></body></html>", out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var f = document.createDocumentFragment();
+                var p = document.createElement('p'); p.className = 'x'; p.id = 'pp';
+                f.appendChild(p);
+                f.appendChild(document.createElement('b'));
+                var q = f.querySelector('.x');
+                // getElementById is intentionally NOT on the bridge's fragment surface (behaviour
+                // preserved across the migration) — assert its absence so the guard stays honest.
+                return f.children.length + '|' + (q === p) + '|' + (f.getElementById ? 'has-gebid' : 'no-gebid');
+            })()
+            """);
+
+        Assert.Equal("2|true|no-gebid", result.ToString());
+    }
+
+    [Fact]
+    public void Fragment_CloneNode_Deep_Copies_Children()
+    {
+        using var bridge = Attach("<!DOCTYPE html><html><body></body></html>", out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var f = document.createDocumentFragment();
+                var s = document.createElement('span'); s.textContent = 'hi';
+                f.appendChild(s);
+                var c = f.cloneNode(true);
+                return c.nodeType + '|' + c.childNodes.length + '|' + c.firstChild.textContent + '|' + (c.firstChild !== s);
+            })()
+            """);
+
+        Assert.Equal("11|1|hi|true", result.ToString());
+    }
+
+    [Fact]
+    public void Range_ExtractContents_Returns_Fragment()
+    {
+        using var bridge = Attach(
+            "<!DOCTYPE html><html><body><div id=\"t\"><span>a</span><span>b</span></div></body></html>",
+            out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var t = document.getElementById('t');
+                var range = document.createRange();
+                range.selectNodeContents(t);
+                var frag = range.extractContents();
+                return frag.nodeType + '|' + frag.childNodes.length + '|' + t.childNodes.length +
+                       '|' + frag.childNodes[0].textContent + frag.childNodes[1].textContent;
+            })()
+            """);
+
+        Assert.Equal("11|2|0|ab", result.ToString());
+    }
+}

--- a/src/Broiler.Cli.Tests/KnownNodesRemovalTests.cs
+++ b/src/Broiler.Cli.Tests/KnownNodesRemovalTests.cs
@@ -1,0 +1,109 @@
+using System.Reflection;
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Guards the HtmlBridge complexity-reduction roadmap Phase 4 first slice (P4.1): the
+/// <c>_knownNodes</c> parallel node set is removed. It was a tree-derived <see cref="HashSet{T}"/>
+/// populated on every node construction (createElement / cloneNode / createComment / parse /
+/// sub-document build) but had no behaviour-affecting reader left — its last real consumer was
+/// already replaced by tree-order traversal, and its only surviving lookup was a redundant
+/// idempotent-<c>Add</c> guard on a <c>HashSet</c>. Phase 4 makes the canonical Broiler.Dom tree the
+/// only authority for tree membership, so the parallel set is deleted. These characterizations
+/// exercise every construction path that used to feed the set and assert the DOM still behaves; the
+/// guard test asserts the field is gone.
+/// </summary>
+public sealed class KnownNodesRemovalTests
+{
+    [Fact]
+    public void DomBridge_Has_No_KnownNodes_Parallel_Set()
+    {
+        // The parallel node-tracking set must not be reintroduced: the canonical tree is the single
+        // authority for node membership.
+        var field = typeof(DomBridge).GetField("_knownNodes", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.Null(field);
+    }
+
+    [Fact]
+    public void Element_Creation_And_Insertion_Round_Trip()
+    {
+        const string html = "<!DOCTYPE html><html><body><div id=\"host\"></div></body></html>";
+
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "https://example.com/index.html");
+
+        var result = context.Eval("""
+            (() => {
+                var host = document.getElementById('host');
+                var span = document.createElement('span');
+                span.id = 'child';
+                span.textContent = 'hi';
+                host.appendChild(span);
+                var found = document.getElementById('child');
+                return found.textContent + '|' + (found.parentNode === host) + '|' + host.children.length;
+            })()
+            """);
+
+        Assert.Equal("hi|true|1", result.ToString());
+    }
+
+    [Fact]
+    public void CloneNode_Comment_And_Fragment_Construction_Round_Trip()
+    {
+        const string html = "<!DOCTYPE html><html><body><ul id=\"list\"><li class=\"row\">a</li></ul></body></html>";
+
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "https://example.com/index.html");
+
+        var result = context.Eval("""
+            (() => {
+                var list = document.getElementById('list');
+                var row = list.querySelector('.row');
+                var clone = row.cloneNode(true);
+                clone.textContent = 'b';
+                list.appendChild(clone);
+
+                var frag = document.createDocumentFragment();
+                var extra = document.createElement('li');
+                extra.textContent = 'c';
+                frag.appendChild(extra);
+                list.appendChild(frag);
+
+                var comment = document.createComment('note');
+                list.appendChild(comment);
+
+                var texts = [];
+                for (var i = 0; i < list.children.length; i++) texts.push(list.children[i].textContent);
+                return texts.join(',') + '|' + list.childNodes.length + '|' + comment.nodeType;
+            })()
+            """);
+
+        // 3 <li> children (a, b, c); childNodes count includes the trailing comment (4).
+        Assert.Equal("a,b,c|4|8", result.ToString());
+    }
+
+    [Fact]
+    public void InnerHtml_Parse_Replace_Round_Trip()
+    {
+        const string html = "<!DOCTYPE html><html><body><div id=\"box\"></div></body></html>";
+
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "https://example.com/index.html");
+
+        var result = context.Eval("""
+            (() => {
+                var box = document.getElementById('box');
+                box.innerHTML = '<p class="p">one</p><p class="p">two</p>';
+                var ps = box.querySelectorAll('.p');
+                return ps.length + '|' + ps[0].textContent + '|' + ps[1].textContent;
+            })()
+            """);
+
+        Assert.Equal("2|one|two", result.ToString());
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Lifetime.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Lifetime.cs
@@ -60,7 +60,6 @@ public sealed partial class DomBridge : IDisposable
         // The bridge borrows the JS context; only drop the reference.
         _jsContext = null;
 
-        _knownNodes.Clear();
 
         // Drain anything later PRs registered (currently the layout view is released directly
         // above; the registry is the seam future document services release through).

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -840,10 +840,10 @@ public sealed partial class DomBridge
             IsText(node) ? HtmlSerializationNodeKind.Text
             : IsComment(node) ? HtmlSerializationNodeKind.Comment
             : node is DomDocumentType ? HtmlSerializationNodeKind.DocumentType
+            : node is DomDocumentFragment ? HtmlSerializationNodeKind.Fragment
             : node is DomElement element
                 ? element.TagName.ToLowerInvariant() switch
                 {
-                    "#document-fragment" => HtmlSerializationNodeKind.Fragment,
                     "#subdoc-root" => HtmlSerializationNodeKind.DocumentRoot,
                     _ => HtmlSerializationNodeKind.Element
                 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -839,16 +839,17 @@ public sealed partial class DomBridge
         GetKind: static node =>
             IsText(node) ? HtmlSerializationNodeKind.Text
             : IsComment(node) ? HtmlSerializationNodeKind.Comment
+            : node is DomDocumentType ? HtmlSerializationNodeKind.DocumentType
             : node is DomElement element
                 ? element.TagName.ToLowerInvariant() switch
                 {
                     "#document-fragment" => HtmlSerializationNodeKind.Fragment,
                     "#subdoc-root" => HtmlSerializationNodeKind.DocumentRoot,
-                    "#doctype" => HtmlSerializationNodeKind.DocumentType,
                     _ => HtmlSerializationNodeKind.Element
                 }
                 : HtmlSerializationNodeKind.Element,
-        GetName: static node => node is DomElement element ? element.TagName : string.Empty,
+        GetName: static node => node is DomDocumentType docType ? docType.Name
+            : node is DomElement element ? element.TagName : string.Empty,
         // Never serialise a materialised nested-browsing-context (#subdoc-root) into
         // its container.  A sub-document is fetched and attached to its <iframe>/
         // <object>/<frame> so scripts can reach contentDocument and onload can fire,

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.TableHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.TableHost.cs
@@ -17,7 +17,6 @@ public sealed partial class DomBridge : ITableHost
     DomElement ITableHost.CreateElement(string tag)
     {
         var element = CreateBridgeElement(tag);
-        _knownNodes.Add(element);
         return element;
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.TraversalHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.TraversalHost.cs
@@ -38,28 +38,24 @@ public sealed partial class DomBridge : ITraversalHost
     JSObject ITraversalHost.CreateCommentNode(string data)
     {
         var comment = CreateBridgeCommentNode(data);
-        _knownNodes.Add(comment);
         return ToJSObject(comment);
     }
 
     DomNode ITraversalHost.CreateRangeResultFragment()
     {
         var fragment = CreateBridgeElement("#document-fragment");
-        _knownNodes.Add(fragment);
         return fragment;
     }
 
     DomNode ITraversalHost.CloneRangeNode(DomNode node, bool deep)
     {
         var clone = CloneDomElement(node, deep);
-        _knownNodes.Add(clone);
         return clone;
     }
 
     DomText ITraversalHost.CreateRangeTextNode(string data)
     {
         var text = CreateBridgeTextNode(data);
-        _knownNodes.Add(text);
         return text;
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.TraversalHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.TraversalHost.cs
@@ -41,11 +41,7 @@ public sealed partial class DomBridge : ITraversalHost
         return ToJSObject(comment);
     }
 
-    DomNode ITraversalHost.CreateRangeResultFragment()
-    {
-        var fragment = CreateBridgeElement("#document-fragment");
-        return fragment;
-    }
+    DomNode ITraversalHost.CreateRangeResultFragment() => CreateBridgeDocumentFragment();
 
     DomNode ITraversalHost.CloneRangeNode(DomNode node, bool deep)
     {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -356,6 +356,12 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     private DomDocumentType CreateBridgeDocumentType(string name, string publicId, string systemId) =>
         _document.CreateDocumentType(name.ToLowerInvariant(), publicId, systemId);
 
+    /// <summary>Mints a canonical <see cref="DomDocumentFragment"/> (Phase 4 item 1 — the former
+    /// <c>#document-fragment</c> sentinel element). The single funnel for fragment construction over
+    /// the canonical document factory (used by <c>createDocumentFragment</c>, Range clone/extract
+    /// results, and the internal HTML fragment-parse container).</summary>
+    private DomDocumentFragment CreateBridgeDocumentFragment() => _document.CreateDocumentFragment();
+
     /// <summary>Sets an element's <c>textContent</c> per DOM (RF-BRIDGE-1c Phase F, F3c part 2d):
     /// replaces all children with a single canonical <see cref="DomText"/> (or none when
     /// <paramref name="value"/> is null/empty). Replaces the former element-store

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -40,12 +40,6 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     private static readonly string[] InlineEventNames = ["click", "load", "change", "input", "submit", "mousedown",
         "mouseup", "mouseover", "mouseout", "keydown", "keyup", "keypress", "focus", "blur", "error", "scroll",
         "scrollend"];
-    // RF-BRIDGE-1c Phase F (F3b): the registration set is keyed by canonical DomNode so
-    // it can hold text/comment nodes once they flip to canonical DomText/DomComment (which
-    // are not Broiler.Dom.DomElement). A facade node IS-A DomNode, so this is a behaviour-preserving
-    // widen on the current homogeneous tree.
-    private readonly HashSet<DomNode> _knownNodes =
-        new(ReferenceEqualityComparer.Instance);
     // Phase 3 (P3.2): the whole MutationObserver feature — the observer registry (P2.5
     // MutationObserverHub), the observe()/disconnect() registration and childList/attribute/
     // characterData record delivery — lives in the MutationObserverBinding module, reached through
@@ -364,7 +358,6 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         if (!string.IsNullOrEmpty(value))
         {
             var textNode = CreateBridgeTextNode(value);
-            _knownNodes.Add(textNode);
             element.AppendChild(textNode);
         }
     }
@@ -682,9 +675,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         //    listeners registered on the body element.
         // Find the <body> element by traversing the document tree.
         // The body is a child of <html> (documentElement), which is a
-        // child of the document node. It may not appear in the flat
-        // _knownNodes list because html/head/body are structural elements
-        // pre-created by HtmlTreeBuilder.
+        // child of the document node.
         DomElement? body = null;
         if (htmlEl != null)
         {
@@ -814,7 +805,6 @@ public sealed partial class DomBridge : IDomBridgeRuntime
 
     private void ParseHtml(string html)
     {
-        _knownNodes.Clear();
         // P2.2: one call clears both wrapper maps. Re-parse now also releases stale sub-document
         // wrappers (keyed by detached roots that no lookup can reach again) — observably
         // equivalent to before, but it stops them lingering until disposal.
@@ -836,7 +826,6 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         {
             SetParent(doctype, _documentNode);
             _documentNode.AppendChild(doctype);
-            _knownNodes.Add(doctype);
         }
 
         // Publish the document's quirks mode for the render that follows on this
@@ -872,7 +861,6 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         foreach (var kv in InlineStyle(docElement))
             InlineStyle(DocumentElement)[kv.Key] = kv.Value;
 
-        _knownNodes.UnionWith(allElements);
 
         // Connect DocumentElement to _documentNode so that document.firstChild works
         // and structural pseudo-classes correctly detect the document root boundary
@@ -880,7 +868,6 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         if (!_documentNode.ChildNodes.Contains(DocumentElement))
             _documentNode.AppendChild(DocumentElement);
 
-        _knownNodes.Add(DocumentElement);
 
         // Stylesheet discovery is document-scoped and lazy through the shared
         // CssStyleEngine. A rebuilt document must not retain the prior engines.

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -362,6 +362,18 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// results, and the internal HTML fragment-parse container).</summary>
     private DomDocumentFragment CreateBridgeDocumentFragment() => _document.CreateDocumentFragment();
 
+    /// <summary>Mints a canonical <see cref="DomDocument"/> for a detached browsing context (Phase 4
+    /// item 1, P4.4a — the former <c>#subdoc-root</c> sentinel for <c>createDocument</c>/
+    /// <c>createHTMLDocument</c>). It is its own document (not the main <c>_document</c>) and, being a
+    /// programmatic non-rendered document, is marked viewport-less so hit-testing skips it. Its
+    /// children (doctype/documentElement) are appended as true canonical document children.</summary>
+    private DomDocument CreateBrowsingContextDocument()
+    {
+        var document = new DomDocument();
+        GetElementRuntimeState(document).Document.HasViewport.Set(false);
+        return document;
+    }
+
     /// <summary>Sets an element's <c>textContent</c> per DOM (RF-BRIDGE-1c Phase F, F3c part 2d):
     /// replaces all children with a single canonical <see cref="DomText"/> (or none when
     /// <paramref name="value"/> is null/empty). Replaces the former element-store

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -348,6 +348,14 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         return element;
     }
 
+    /// <summary>Mints a canonical <see cref="DomDocumentType"/> (Phase 4 item 1 — the former
+    /// <c>#doctype</c> sentinel element). The doctype name is lowercased to preserve the historical
+    /// bridge behaviour (doctype name was always surfaced lowercase via the old <c>GetDocTypeName</c>);
+    /// publicId/systemId keep their case. The single funnel for doctype construction over the
+    /// canonical document factory.</summary>
+    private DomDocumentType CreateBridgeDocumentType(string name, string publicId, string systemId) =>
+        _document.CreateDocumentType(name.ToLowerInvariant(), publicId, systemId);
+
     /// <summary>Sets an element's <c>textContent</c> per DOM (RF-BRIDGE-1c Phase F, F3c part 2d):
     /// replaces all children with a single canonical <see cref="DomText"/> (or none when
     /// <paramref name="value"/> is null/empty). Replaces the former element-store

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Attributes.cs
@@ -134,7 +134,7 @@ public sealed partial class DomBridge
             SetAttr(element, kv.Key, kv.Value);
     }
 
-    private void CollectByTagName(DomElement root, string tag, List<JSValue> results)
+    private void CollectByTagName(DomNode root, string tag, List<JSValue> results)
     {
         foreach (var child in ChildElements(root))
         {
@@ -164,7 +164,7 @@ public sealed partial class DomBridge
     }
 
     /// <summary>Collects all elements matching a predicate in a sub-tree.</summary>
-    private void CollectMatching(DomElement root, Func<DomElement, bool> predicate, List<JSValue> results)
+    private void CollectMatching(DomNode root, Func<DomElement, bool> predicate, List<JSValue> results)
     {
         foreach (var child in ChildElements(root))
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
@@ -25,12 +25,15 @@ internal sealed class ElementRuntimeState
     public HashSet<string> JsSetStyleProps { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// The document-root element that owns this node's (sub)document — iframe / nested
+    /// The browsing-context root that owns this node's (sub)document — iframe / nested
     /// browsing-context bookkeeping. Relocated off the <c>Broiler.Dom.DomElement</c> facade
     /// (RF-BRIDGE-1c Phase A). Not carried across <c>cloneNode</c> (matching the prior
-    /// facade behaviour: a clone re-derives its owner on adoption).
+    /// facade behaviour: a clone re-derives its owner on adoption). Phase 4 item 1 (P4.4a): widened
+    /// <c>DomElement?</c>→<c>DomNode?</c> so a canonical <c>DomDocument</c> browsing-context root
+    /// (createDocument/createHTMLDocument) can own its descendants, alongside the legacy
+    /// <c>#subdoc-root</c> element roots that regime-A (iframe) still uses.
     /// </summary>
-    public DomElement? OwnerDocRoot { get; set; }
+    public DomNode? OwnerDocRoot { get; set; }
 
     /// <summary>
     /// The element's raw inner-HTML/inner-text string — the source text for raw-text

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
@@ -73,8 +73,6 @@ internal sealed class ElementRuntimeState
 
     public AnimationRuntimeState Animation { get; } = new();
 
-    public DocumentTypeRuntimeState DocumentType { get; } = new();
-
     public void CopyRuntimeValuesTo(ElementRuntimeState target)
     {
         FormControl.Value.CopyTo(target.FormControl.Value);
@@ -96,10 +94,6 @@ internal sealed class ElementRuntimeState
         target.StyleSheet.RulesMutated = StyleSheet.RulesMutated;
         Document.HasViewport.CopyTo(target.Document.HasViewport);
         Animation.CurrentTimeMilliseconds.CopyTo(target.Animation.CurrentTimeMilliseconds);
-        DocumentType.Name.CopyTo(target.DocumentType.Name);
-        DocumentType.PublicId.CopyTo(target.DocumentType.PublicId);
-        DocumentType.SystemId.CopyTo(target.DocumentType.SystemId);
-        DocumentType.InternalSubset.CopyTo(target.DocumentType.InternalSubset);
     }
 }
 
@@ -175,14 +169,6 @@ internal sealed class DocumentRuntimeState
 internal sealed class AnimationRuntimeState
 {
     public RuntimeValue<double> CurrentTimeMilliseconds { get; } = new();
-}
-
-internal sealed class DocumentTypeRuntimeState
-{
-    public RuntimeValue<string> Name { get; } = new();
-    public RuntimeValue<string> PublicId { get; } = new();
-    public RuntimeValue<string> SystemId { get; } = new();
-    public RuntimeValue<object> InternalSubset { get; } = new();
 }
 
 internal sealed class RuntimeValue<T>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
@@ -10,13 +10,15 @@ public sealed partial class DomBridge
             ? args[index].DoubleValue
             : double.NaN;
 
-    private IReadOnlyList<DomElement> HitTestDocumentPoint(DomElement docRoot, double x, double y)
+    private IReadOnlyList<DomElement> HitTestDocumentPoint(DomNode docRoot, double x, double y)
     {
         if (!double.IsFinite(x) || !double.IsFinite(y))
             return [];
 
-        var documentElement = IsDocumentElement(docRoot)
-            ? docRoot
+        // Phase 4 item 1 (P4.4a): docRoot may be a canonical DomDocument (regime-B) — resolve the
+        // documentElement from its element children; only an element docRoot can itself be one.
+        var documentElement = docRoot is DomElement docRootElement && IsDocumentElement(docRootElement)
+            ? docRootElement
             : ChildElements(docRoot).FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith('#'));
 
         if (documentElement == null)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/HtmlTreeBuilding.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/HtmlTreeBuilding.cs
@@ -31,12 +31,13 @@ public sealed partial class DomBridge
 
     /// <summary>
     /// Parses an HTML fragment in <paramref name="contextTagName"/>'s context and wraps its children
-    /// in a bridge <c>#document-fragment</c> sentinel element. Replaces <c>HtmlTreeBuilder.BuildFragment</c>.
+    /// in a canonical <see cref="DomDocumentFragment"/> (Phase 4 item 1 — was a <c>#document-fragment</c>
+    /// sentinel element). Replaces <c>HtmlTreeBuilder.BuildFragment</c>.
     /// </summary>
-    private (DomElement Fragment, List<DomNode> AllElements) BuildFragmentTree(string html, string contextTagName)
+    private (DomDocumentFragment Fragment, List<DomNode> AllElements) BuildFragmentTree(string html, string contextTagName)
     {
         var parsed = new HtmlDocumentParser().ParseFragment(html, contextTagName);
-        var fragment = CreateBridgeElement("#document-fragment");
+        var fragment = CreateBridgeDocumentFragment();
         var allElements = new List<DomNode>();
 
         // AppendChild adopts each parsed child subtree into _document (fragment is _document-owned).

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
@@ -42,7 +42,13 @@ public sealed partial class DomBridge
     // MutationObserver option parsing and observe()/disconnect() registration moved to the Phase 3
     // MutationObserverBinding feature module (Broiler.HtmlBridge.Dom.Features).
 
-    private static DomElement GetDocumentElement(DomElement docRoot) => ChildElements(docRoot).FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith('#')) ?? docRoot;
+    // Phase 4 item 1 (P4.4a): docRoot may be a legacy #subdoc-root element OR a canonical
+    // DomDocument browsing-context root; ChildElements works over both. Returns the documentElement,
+    // or — for an element root with none — the root itself (the prior `?? docRoot` fallback). A
+    // canonical DomDocument with no documentElement yields null (per DOM; e.g. createDocument with an
+    // empty qualifiedName), so callers must null-check.
+    private static DomElement? GetDocumentElement(DomNode docRoot) =>
+        ChildElements(docRoot).FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith('#')) ?? docRoot as DomElement;
 
 
     private bool IsPositionAfter(DomNode docRoot, DomNode containerA, int offsetA, DomNode containerB, int offsetB)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -412,7 +412,6 @@ public sealed partial class DomBridge
         var remainingText = text[offset..];
         SetBridgeText(node, text[..offset]);
         var newNode = CreateBridgeTextNode(remainingText);
-        _knownNodes.Add(newNode);
         // Insert new node as next sibling
         if (ParentEl(node) != null)
         {
@@ -767,7 +766,6 @@ public sealed partial class DomBridge
     {
         var deep = a.Length > 0 && a[0].BooleanValue;
         var clone = CloneDomElement(node, deep);
-        _knownNodes.Add(clone);
         return ToJSObject(clone);
     }
 
@@ -886,7 +884,6 @@ public sealed partial class DomBridge
         GetElementRuntimeState(shadowRoot).Shadow.Mode.Set(mode);
         GetElementRuntimeState(element).Shadow.Root.Set(shadowRoot);
         GetElementRuntimeState(element).Shadow.Mode.Set(mode);
-        _knownNodes.Add(shadowRoot);
         return ToJSObject(shadowRoot);
     }
 
@@ -1507,7 +1504,6 @@ public sealed partial class DomBridge
         var text = a.Length > 1 ? a[1].ToString() : string.Empty;
         var (parent, index) = GetInsertAdjacentTarget(element, position);
         var textNode = CreateBridgeTextNode(text);
-        _knownNodes.Add(textNode);
         InsertNodeAt(parent, textNode, index);
         return JSUndefined.Value;
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -287,12 +287,12 @@ public sealed partial class DomBridge
             return new JSNumber(8); // COMMENT_NODE
         if (node is DomDocumentType)
             return new JSNumber(10); // DOCUMENT_TYPE_NODE (canonical DomDocumentType)
+        if (node is DomDocumentFragment)
+            return new JSNumber(11); // DOCUMENT_FRAGMENT_NODE (canonical DomDocumentFragment)
         if (node is not DomElement element)
             return new JSNumber(1); // canonical non-element char-data already handled above
         if (string.Equals(element.TagName, "#document", StringComparison.OrdinalIgnoreCase))
             return new JSNumber(9); // DOCUMENT_NODE
-        if (string.Equals(element.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase))
-            return new JSNumber(11); // DOCUMENT_FRAGMENT_NODE
         return new JSNumber(1); // ELEMENT_NODE
     }
 
@@ -305,12 +305,12 @@ public sealed partial class DomBridge
             return new JSString("#comment");
         if (node is DomDocumentType docType)
             return new JSString(docType.Name); // doctype nodeName is its (already lowercased) name
+        if (node is DomDocumentFragment)
+            return new JSString("#document-fragment");
         if (node is not DomElement element)
             return JSNull.Value;
         if (string.Equals(element.TagName, "#document", StringComparison.OrdinalIgnoreCase))
             return new JSString("#document");
-        if (string.Equals(element.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase))
-            return new JSString("#document-fragment");
 
         // Non-HTML namespace elements preserve original case (per DOM spec)
         if (!string.IsNullOrEmpty(element.NamespaceUri) && !string.Equals(element.NamespaceUri, "http://www.w3.org/1999/xhtml", StringComparison.OrdinalIgnoreCase))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -285,14 +285,14 @@ public sealed partial class DomBridge
             return new JSNumber(3); // TEXT_NODE
         if (IsComment(node))
             return new JSNumber(8); // COMMENT_NODE
+        if (node is DomDocumentType)
+            return new JSNumber(10); // DOCUMENT_TYPE_NODE (canonical DomDocumentType)
         if (node is not DomElement element)
             return new JSNumber(1); // canonical non-element char-data already handled above
         if (string.Equals(element.TagName, "#document", StringComparison.OrdinalIgnoreCase))
             return new JSNumber(9); // DOCUMENT_NODE
         if (string.Equals(element.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase))
             return new JSNumber(11); // DOCUMENT_FRAGMENT_NODE
-        if (string.Equals(element.TagName, "#doctype", StringComparison.OrdinalIgnoreCase))
-            return new JSNumber(10); // DOCUMENT_TYPE_NODE
         return new JSNumber(1); // ELEMENT_NODE
     }
 
@@ -303,16 +303,14 @@ public sealed partial class DomBridge
             return new JSString("#text");
         if (IsComment(node))
             return new JSString("#comment");
+        if (node is DomDocumentType docType)
+            return new JSString(docType.Name); // doctype nodeName is its (already lowercased) name
         if (node is not DomElement element)
             return JSNull.Value;
         if (string.Equals(element.TagName, "#document", StringComparison.OrdinalIgnoreCase))
             return new JSString("#document");
         if (string.Equals(element.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase))
             return new JSString("#document-fragment");
-        if (string.Equals(element.TagName, "#doctype", StringComparison.OrdinalIgnoreCase))
-        {
-            return new JSString(GetDocTypeName(element));
-        }
 
         // Non-HTML namespace elements preserve original case (per DOM spec)
         if (!string.IsNullOrEmpty(element.NamespaceUri) && !string.Equals(element.NamespaceUri, "http://www.w3.org/1999/xhtml", StringComparison.OrdinalIgnoreCase))
@@ -485,18 +483,12 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsJsObjectsGetPublicId055Core(DomElement element, in Arguments _)
-    {
-        var pubId = GetElementRuntimeState(element).DocumentType.PublicId.TryGet(out var p) ? p?.ToString() ?? string.Empty : string.Empty;
-        return new JSString(pubId);
-    }
+    private static JSValue JsJsObjectsGetPublicId055Core(DomNode node, in Arguments _) =>
+        new JSString(node is DomDocumentType dt ? dt.PublicId : string.Empty);
 
 
-    private JSValue JsJsObjectsGetSystemId056Core(DomElement element, in Arguments _)
-    {
-        var sysId = GetElementRuntimeState(element).DocumentType.SystemId.TryGet(out var s) ? s?.ToString() ?? string.Empty : string.Empty;
-        return new JSString(sysId);
-    }
+    private static JSValue JsJsObjectsGetSystemId056Core(DomNode node, in Arguments _) =>
+        new JSString(node is DomDocumentType dt ? dt.SystemId : string.Empty);
 
 
     private JSValue JsJsObjectsGetOwnerDocument057Core(DomNode node, in Arguments a)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
@@ -778,36 +778,31 @@ public sealed partial class DomBridge
         var doctypeArg = a.Length > 2 ? a[2] : null;
         if (!string.IsNullOrEmpty(qName))
             ValidateQualifiedName(qName, ns, context);
-        // Build a new document root
-        var docRoot = CreateBridgeElement("#subdoc-root");
-        GetElementRuntimeState(docRoot).Document.HasViewport.Set(false);
-        // Append doctype if provided
+        // Phase 4 item 1 (P4.4a): a createDocument root is a canonical DomDocument (was a #subdoc-root
+        // sentinel element).
+        var docRoot = CreateBrowsingContextDocument();
+        // Append doctype if provided — a DocumentType is a legitimate canonical child of a DomDocument.
         if (doctypeArg is JSObject dtObj)
         {
-            // Find the canonical node for the doctype JSObject. Phase 4 item 1: the doctype is a
-            // DomDocumentType (not a DomElement), so match any DomNode — the former `is DomElement`
-            // guard silently skipped the canonical doctype, leaving its ownerDocument unassociated.
             foreach (var kvp in _jsObjects.Entries)
             {
                 if (kvp.Value == dtObj && kvp.Key is DomNode dtNode)
                 {
-                    SetParent(dtNode, docRoot);
-                    GetElementRuntimeState(dtNode).OwnerDocRoot = docRoot;
                     docRoot.AppendChild(dtNode);
+                    GetElementRuntimeState(dtNode).OwnerDocRoot = docRoot;
                     break;
                 }
             }
         }
 
-        // Create document element if qualifiedName is provided
+        // Create document element if qualifiedName is provided (appended after the doctype, per DOM).
         if (!string.IsNullOrEmpty(qName))
         {
             var docEl = string.IsNullOrEmpty(ns)
                 ? CreateBridgeElement(qName)
                 : CreateBridgeElementNS(ns, qName);
-            SetParent(docEl, docRoot);
-            GetElementRuntimeState(docEl).OwnerDocRoot = docRoot;
             docRoot.AppendChild(docEl);
+            GetElementRuntimeState(docEl).OwnerDocRoot = docRoot;
         }
 
         return BuildSubDocument(docRoot);
@@ -817,19 +812,16 @@ public sealed partial class DomBridge
     private JSValue JsRegistrationCreateHTMLDocument059Core(in Arguments a)
     {
         var title = a.Length > 0 && !a[0].IsNull && !a[0].IsUndefined ? a[0].ToString() : null;
-        // Build a new HTML document root with html/head/body
-        var docRoot = CreateBridgeElement("#subdoc-root");
-        GetElementRuntimeState(docRoot).Document.HasViewport.Set(false);
-        // Add DOCTYPE
+        // Phase 4 item 1 (P4.4a): a createHTMLDocument root is a canonical DomDocument (was a
+        // #subdoc-root sentinel element); doctype + <html> are appended as canonical document children.
+        var docRoot = CreateBrowsingContextDocument();
         var doctype = CreateBridgeDocumentType("html", string.Empty, string.Empty);
-        SetParent(doctype, docRoot);
-        GetElementRuntimeState(doctype).OwnerDocRoot = docRoot;
         docRoot.AppendChild(doctype);
+        GetElementRuntimeState(doctype).OwnerDocRoot = docRoot;
         // "http://www.w3.org/1999/xhtml" is the default HTML namespace the funnel applies.
         var htmlEl = CreateBridgeElement("html");
-        SetParent(htmlEl, docRoot);
-        GetElementRuntimeState(htmlEl).OwnerDocRoot = docRoot;
         docRoot.AppendChild(htmlEl);
+        GetElementRuntimeState(htmlEl).OwnerDocRoot = docRoot;
         var headEl = CreateBridgeElement("head");
         SetParent(headEl, htmlEl);
         GetElementRuntimeState(headEl).OwnerDocRoot = docRoot;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
@@ -766,11 +766,7 @@ public sealed partial class DomBridge
             ValidateQualifiedName(qualifiedName, null, context);
         else
             ValidateElementName(qualifiedName, context);
-        var doctype = CreateBridgeElement("#doctype");
-        GetElementRuntimeState(doctype).DocumentType.Name.Set(qualifiedName);
-        GetElementRuntimeState(doctype).DocumentType.PublicId.Set(publicId);
-        GetElementRuntimeState(doctype).DocumentType.SystemId.Set(systemId);
-        GetElementRuntimeState(doctype).DocumentType.InternalSubset.Set(null);
+        var doctype = CreateBridgeDocumentType(qualifiedName, publicId, systemId);
         return ToJSObject(doctype);
     }
 
@@ -823,11 +819,7 @@ public sealed partial class DomBridge
         var docRoot = CreateBridgeElement("#subdoc-root");
         GetElementRuntimeState(docRoot).Document.HasViewport.Set(false);
         // Add DOCTYPE
-        var doctype = CreateBridgeElement("#doctype");
-        GetElementRuntimeState(doctype).DocumentType.Name.Set("html");
-        GetElementRuntimeState(doctype).DocumentType.PublicId.Set(string.Empty);
-        GetElementRuntimeState(doctype).DocumentType.SystemId.Set(string.Empty);
-        GetElementRuntimeState(doctype).DocumentType.InternalSubset.Set(null);
+        var doctype = CreateBridgeDocumentType("html", string.Empty, string.Empty);
         SetParent(doctype, docRoot);
         GetElementRuntimeState(doctype).OwnerDocRoot = docRoot;
         docRoot.AppendChild(doctype);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
@@ -135,7 +135,6 @@ public sealed partial class DomBridge
         ValidateElementName(tag, context);
         tag = AsciiToLower(tag);
         var el = CreateBridgeElement(tag);
-        _knownNodes.Add(el);
         return ToJSObject(el);
     }
 
@@ -144,7 +143,6 @@ public sealed partial class DomBridge
     {
         var text = a.Length > 0 ? a[0].ToString() : string.Empty;
         var el = CreateBridgeTextNode(text);
-        _knownNodes.Add(el);
         return ToJSObject(el);
     }
 
@@ -162,7 +160,6 @@ public sealed partial class DomBridge
     private JSValue JsRegistrationCreateDocumentFragment017Core(in Arguments a)
     {
         var fragment = CreateBridgeElement("#document-fragment");
-        _knownNodes.Add(fragment);
         return ToJSObject(fragment);
     }
 
@@ -542,20 +539,6 @@ public sealed partial class DomBridge
                             mainBody.AppendChild(child);
                         }
                     }
-
-                    // Register the content elements (excluding wrapper html/body
-                    // from the fragment parse) in document order so that
-                    // getElementsByTagName, document.links, etc. return
-                    // elements in the correct order relative to the rest of
-                    // the document.
-                    var contentEls = new List<DomNode>();
-                    foreach (var tc in writtenChildren)
-                    {
-                        contentEls.Add(tc);
-                        CollectAllDescendantsFlat(tc, contentEls);
-                    }
-
-                    _knownNodes.UnionWith(contentEls);
                 }
             }
 
@@ -719,7 +702,6 @@ public sealed partial class DomBridge
         var el = string.IsNullOrEmpty(ns)
             ? CreateBridgeElement(localName)
             : CreateBridgeElementNS(ns, localName);
-        _knownNodes.Add(el);
         return ToJSObject(el);
     }
 
@@ -789,7 +771,6 @@ public sealed partial class DomBridge
         GetElementRuntimeState(doctype).DocumentType.PublicId.Set(publicId);
         GetElementRuntimeState(doctype).DocumentType.SystemId.Set(systemId);
         GetElementRuntimeState(doctype).DocumentType.InternalSubset.Set(null);
-        _knownNodes.Add(doctype);
         return ToJSObject(doctype);
     }
 
@@ -804,7 +785,6 @@ public sealed partial class DomBridge
         // Build a new document root
         var docRoot = CreateBridgeElement("#subdoc-root");
         GetElementRuntimeState(docRoot).Document.HasViewport.Set(false);
-        _knownNodes.Add(docRoot);
         // Append doctype if provided
         if (doctypeArg is JSObject dtObj)
         {
@@ -830,7 +810,6 @@ public sealed partial class DomBridge
             SetParent(docEl, docRoot);
             GetElementRuntimeState(docEl).OwnerDocRoot = docRoot;
             docRoot.AppendChild(docEl);
-            _knownNodes.Add(docEl);
         }
 
         return BuildSubDocument(docRoot);
@@ -843,7 +822,6 @@ public sealed partial class DomBridge
         // Build a new HTML document root with html/head/body
         var docRoot = CreateBridgeElement("#subdoc-root");
         GetElementRuntimeState(docRoot).Document.HasViewport.Set(false);
-        _knownNodes.Add(docRoot);
         // Add DOCTYPE
         var doctype = CreateBridgeElement("#doctype");
         GetElementRuntimeState(doctype).DocumentType.Name.Set("html");
@@ -853,18 +831,15 @@ public sealed partial class DomBridge
         SetParent(doctype, docRoot);
         GetElementRuntimeState(doctype).OwnerDocRoot = docRoot;
         docRoot.AppendChild(doctype);
-        _knownNodes.Add(doctype);
         // "http://www.w3.org/1999/xhtml" is the default HTML namespace the funnel applies.
         var htmlEl = CreateBridgeElement("html");
         SetParent(htmlEl, docRoot);
         GetElementRuntimeState(htmlEl).OwnerDocRoot = docRoot;
         docRoot.AppendChild(htmlEl);
-        _knownNodes.Add(htmlEl);
         var headEl = CreateBridgeElement("head");
         SetParent(headEl, htmlEl);
         GetElementRuntimeState(headEl).OwnerDocRoot = docRoot;
         htmlEl.AppendChild(headEl);
-        _knownNodes.Add(headEl);
         // Add <title> element if title argument is provided
         if (title != null)
         {
@@ -872,19 +847,16 @@ public sealed partial class DomBridge
             SetParent(titleEl, headEl);
             GetElementRuntimeState(titleEl).OwnerDocRoot = docRoot;
             headEl.AppendChild(titleEl);
-            _knownNodes.Add(titleEl);
             var titleText = CreateBridgeTextNode(title);
             SetParent(titleText, titleEl);
             GetElementRuntimeState(titleText).OwnerDocRoot = docRoot;
             titleEl.AppendChild(titleText);
-            _knownNodes.Add(titleText);
         }
 
         var bodyEl = CreateBridgeElement("body");
         SetParent(bodyEl, htmlEl);
         GetElementRuntimeState(bodyEl).OwnerDocRoot = docRoot;
         htmlEl.AppendChild(bodyEl);
-        _knownNodes.Add(bodyEl);
         return BuildSubDocument(docRoot);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
@@ -159,7 +159,7 @@ public sealed partial class DomBridge
 
     private JSValue JsRegistrationCreateDocumentFragment017Core(in Arguments a)
     {
-        var fragment = CreateBridgeElement("#document-fragment");
+        var fragment = CreateBridgeDocumentFragment();
         return ToJSObject(fragment);
     }
 
@@ -784,14 +784,16 @@ public sealed partial class DomBridge
         // Append doctype if provided
         if (doctypeArg is JSObject dtObj)
         {
-            // Find the Broiler.Dom.DomElement for the doctype JSObject
+            // Find the canonical node for the doctype JSObject. Phase 4 item 1: the doctype is a
+            // DomDocumentType (not a DomElement), so match any DomNode — the former `is DomElement`
+            // guard silently skipped the canonical doctype, leaving its ownerDocument unassociated.
             foreach (var kvp in _jsObjects.Entries)
             {
-                if (kvp.Value == dtObj && kvp.Key is DomElement dtEl)
+                if (kvp.Value == dtObj && kvp.Key is DomNode dtNode)
                 {
-                    SetParent(dtEl, docRoot);
-                    GetElementRuntimeState(dtEl).OwnerDocRoot = docRoot;
-                    docRoot.AppendChild(dtEl);
+                    SetParent(dtNode, docRoot);
+                    GetElementRuntimeState(dtNode).OwnerDocRoot = docRoot;
+                    docRoot.AppendChild(dtNode);
                     break;
                 }
             }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
@@ -117,7 +117,6 @@ public sealed partial class DomBridge
         tagName = AsciiToLower(tagName);
         var el = CreateBridgeElement(tagName);
         GetElementRuntimeState(el).OwnerDocRoot = docRoot;
-        _knownNodes.Add(el);
         return ToJSObject(el);
     }
 
@@ -127,7 +126,6 @@ public sealed partial class DomBridge
         var text = a.Length > 0 ? a[0].ToString() : string.Empty;
         var el = CreateBridgeTextNode(text);
         GetElementRuntimeState(el).OwnerDocRoot = docRoot;
-        _knownNodes.Add(el);
         return ToJSObject(el);
     }
 
@@ -137,7 +135,6 @@ public sealed partial class DomBridge
         var data = a.Length > 0 ? a[0].ToString() : string.Empty;
         var el = CreateBridgeCommentNode(data);
         GetElementRuntimeState(el).OwnerDocRoot = docRoot;
-        _knownNodes.Add(el);
         return ToJSObject(el);
     }
 
@@ -151,7 +148,6 @@ public sealed partial class DomBridge
             ? CreateBridgeElement(localName)
             : CreateBridgeElementNS(ns, localName);
         GetElementRuntimeState(el).OwnerDocRoot = docRoot;
-        _knownNodes.Add(el);
         return ToJSObject(el);
     }
 
@@ -501,26 +497,19 @@ public sealed partial class DomBridge
         var fragment = a[0].ToString();
         // Parse DOCTYPE if present
         var doctype = bridge.ParseDocType(fragment);
-        var (parsedDoc, allEls, _) = BuildDocumentTree(fragment);
+        var (parsedDoc, _, _) = BuildDocumentTree(fragment);
         if (docRoot.ChildNodes.Count == 0)
         {
             if (doctype != null)
             {
                 SetParent(doctype, docRoot);
                 docRoot.AppendChild(doctype);
-                bridge._knownNodes.Add(doctype);
             }
 
             // parsedDoc is the <html> element from HtmlTreeBuilder.
             // Add it directly to docRoot (not its children).
             SetParent(parsedDoc, docRoot);
             docRoot.AppendChild(parsedDoc);
-            if (!bridge._knownNodes.Contains(parsedDoc))
-                bridge._knownNodes.Add(parsedDoc);
-            foreach (var el in allEls)
-            {
-                bridge._knownNodes.Add(el);
-            }
         }
         else
         {
@@ -536,11 +525,6 @@ public sealed partial class DomBridge
                         bodyEl.AppendChild(child);
                     }
                 }
-            }
-
-            foreach (var el in allEls)
-            {
-                bridge._knownNodes.Add(el);
             }
         }
 
@@ -651,7 +635,6 @@ public sealed partial class DomBridge
         GetElementRuntimeState(dt).DocumentType.PublicId.Set(publicId);
         GetElementRuntimeState(dt).DocumentType.SystemId.Set(systemId);
         GetElementRuntimeState(dt).DocumentType.InternalSubset.Set(null);
-        _knownNodes.Add(dt);
         return ToJSObject(dt);
     }
 
@@ -665,7 +648,6 @@ public sealed partial class DomBridge
             ValidateQualifiedName(qName, ns, _jsContext!);
         var subDocRoot = CreateBridgeElement("#subdoc-root");
         GetElementRuntimeState(subDocRoot).Document.HasViewport.Set(false);
-        _knownNodes.Add(subDocRoot);
         if (doctypeArg is JSObject dtObj)
         {
             foreach (var kvp in _jsObjects.Entries)
@@ -688,7 +670,6 @@ public sealed partial class DomBridge
             SetParent(docEl, subDocRoot);
             GetElementRuntimeState(docEl).OwnerDocRoot = subDocRoot;
             subDocRoot.AppendChild(docEl);
-            _knownNodes.Add(docEl);
         }
 
         return BuildSubDocument(subDocRoot);
@@ -700,7 +681,6 @@ public sealed partial class DomBridge
         var subTitle = a.Length > 0 && !a[0].IsNull && !a[0].IsUndefined ? a[0].ToString() : null;
         var subDocRoot = CreateBridgeElement("#subdoc-root");
         GetElementRuntimeState(subDocRoot).Document.HasViewport.Set(false);
-        _knownNodes.Add(subDocRoot);
         var dt = CreateBridgeElement("#doctype");
         GetElementRuntimeState(dt).DocumentType.Name.Set("html");
         GetElementRuntimeState(dt).DocumentType.PublicId.Set(string.Empty);
@@ -709,37 +689,31 @@ public sealed partial class DomBridge
         SetParent(dt, subDocRoot);
         GetElementRuntimeState(dt).OwnerDocRoot = subDocRoot;
         subDocRoot.AppendChild(dt);
-        _knownNodes.Add(dt);
         // "http://www.w3.org/1999/xhtml" is the default HTML namespace the funnel applies.
         var subHtml = CreateBridgeElement("html");
         SetParent(subHtml, subDocRoot);
         GetElementRuntimeState(subHtml).OwnerDocRoot = subDocRoot;
         subDocRoot.AppendChild(subHtml);
-        _knownNodes.Add(subHtml);
         var subHead = CreateBridgeElement("head");
         SetParent(subHead, subHtml);
         GetElementRuntimeState(subHead).OwnerDocRoot = subDocRoot;
         subHtml.AppendChild(subHead);
-        _knownNodes.Add(subHead);
         if (subTitle != null)
         {
             var subTitleEl = CreateBridgeElement("title");
             SetParent(subTitleEl, subHead);
             GetElementRuntimeState(subTitleEl).OwnerDocRoot = subDocRoot;
             subHead.AppendChild(subTitleEl);
-            _knownNodes.Add(subTitleEl);
             var subTitleText = CreateBridgeTextNode(subTitle);
             SetParent(subTitleText, subTitleEl);
             GetElementRuntimeState(subTitleText).OwnerDocRoot = subDocRoot;
             subTitleEl.AppendChild(subTitleText);
-            _knownNodes.Add(subTitleText);
         }
 
         var subBody = CreateBridgeElement("body");
         SetParent(subBody, subHtml);
         GetElementRuntimeState(subBody).OwnerDocRoot = subDocRoot;
         subHtml.AppendChild(subBody);
-        _knownNodes.Add(subBody);
         return BuildSubDocument(subDocRoot);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
@@ -84,8 +84,11 @@ public sealed partial class DomBridge
 
     private JSValue JsSubDocumentObjectsGetChildNodes008Core(DomElement docRoot, in Arguments _)
     {
+        // childNodes includes ALL node types (per DOM), notably the canonical DomDocumentType — which
+        // is no longer a DomElement after Phase 4 item 1, so ChildElements would wrongly drop it. This
+        // matches the sub-document's firstChild (raw first child) and the document childNodes semantics.
         var arr = new JSArray();
-        foreach (var child in ChildElements(docRoot))
+        foreach (var child in docRoot.ChildNodes)
             arr.Add(ToJSObject(child));
         return arr;
     }
@@ -630,11 +633,7 @@ public sealed partial class DomBridge
         var publicId = a[1].ToString();
         var systemId = a[2].ToString();
         ValidateElementName(qualifiedName, _jsContext!);
-        var dt = CreateBridgeElement("#doctype");
-        GetElementRuntimeState(dt).DocumentType.Name.Set(qualifiedName);
-        GetElementRuntimeState(dt).DocumentType.PublicId.Set(publicId);
-        GetElementRuntimeState(dt).DocumentType.SystemId.Set(systemId);
-        GetElementRuntimeState(dt).DocumentType.InternalSubset.Set(null);
+        var dt = CreateBridgeDocumentType(qualifiedName, publicId, systemId);
         return ToJSObject(dt);
     }
 
@@ -681,11 +680,7 @@ public sealed partial class DomBridge
         var subTitle = a.Length > 0 && !a[0].IsNull && !a[0].IsUndefined ? a[0].ToString() : null;
         var subDocRoot = CreateBridgeElement("#subdoc-root");
         GetElementRuntimeState(subDocRoot).Document.HasViewport.Set(false);
-        var dt = CreateBridgeElement("#doctype");
-        GetElementRuntimeState(dt).DocumentType.Name.Set("html");
-        GetElementRuntimeState(dt).DocumentType.PublicId.Set(string.Empty);
-        GetElementRuntimeState(dt).DocumentType.SystemId.Set(string.Empty);
-        GetElementRuntimeState(dt).DocumentType.InternalSubset.Set(null);
+        var dt = CreateBridgeDocumentType("html", string.Empty, string.Empty);
         SetParent(dt, subDocRoot);
         GetElementRuntimeState(dt).OwnerDocRoot = subDocRoot;
         subDocRoot.AppendChild(dt);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
@@ -586,7 +586,9 @@ public sealed partial class DomBridge
             return a.Length > 0 ? a[0] : JSNull.Value;
         foreach (var kvp in bridge._jsObjects.Entries)
         {
-            if (kvp.Value == childObj && kvp.Key is DomElement child)
+            // Phase 4 item 1: match any DomNode so a canonical DomDocumentType / DomDocumentFragment
+            // can be appended to a sub-document root (was `is DomElement`, which skipped them).
+            if (kvp.Value == childObj && kvp.Key is DomNode child)
             {
                 if (ParentEl(child) != null)
                     child.Remove();
@@ -649,13 +651,15 @@ public sealed partial class DomBridge
         GetElementRuntimeState(subDocRoot).Document.HasViewport.Set(false);
         if (doctypeArg is JSObject dtObj)
         {
+            // Phase 4 item 1: the doctype is a canonical DomDocumentType (not a DomElement); match any
+            // DomNode so its ownerDocument is associated with this sub-document.
             foreach (var kvp in _jsObjects.Entries)
             {
-                if (kvp.Value == dtObj && kvp.Key is DomElement dtEl)
+                if (kvp.Value == dtObj && kvp.Key is DomNode dtNode)
                 {
-                    SetParent(dtEl, subDocRoot);
-                    GetElementRuntimeState(dtEl).OwnerDocRoot = subDocRoot;
-                    subDocRoot.AppendChild(dtEl);
+                    SetParent(dtNode, subDocRoot);
+                    GetElementRuntimeState(dtNode).OwnerDocRoot = subDocRoot;
+                    subDocRoot.AppendChild(dtNode);
                     break;
                 }
             }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/SubDocumentObjects.cs
@@ -14,9 +14,11 @@ namespace Broiler.HtmlBridge;
 public sealed partial class DomBridge
 {
 
-    private JSValue JsSubDocumentObjectsGetBody003Core(DomElement docRoot, in Arguments _)
+    private JSValue JsSubDocumentObjectsGetBody003Core(DomNode docRoot, in Arguments _)
     {
         var htmlEl = GetDocumentElement(docRoot);
+        if (htmlEl == null)
+            return JSNull.Value;
         foreach (var child in ChildElements(htmlEl))
         {
             if (string.Equals(child.TagName, "body", StringComparison.OrdinalIgnoreCase))
@@ -27,9 +29,11 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsGetHead004Core(DomElement docRoot, in Arguments _)
+    private JSValue JsSubDocumentObjectsGetHead004Core(DomNode docRoot, in Arguments _)
     {
         var htmlEl = GetDocumentElement(docRoot);
+        if (htmlEl == null)
+            return JSNull.Value;
         foreach (var child in ChildElements(htmlEl))
         {
             if (string.Equals(child.TagName, "head", StringComparison.OrdinalIgnoreCase))
@@ -40,9 +44,11 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsGetTitle005Core(DomElement docRoot, in Arguments _)
+    private JSValue JsSubDocumentObjectsGetTitle005Core(DomNode docRoot, in Arguments _)
     {
         var htmlEl = GetDocumentElement(docRoot);
+        if (htmlEl == null)
+            return new JSString(string.Empty);
         var head = ChildElements(htmlEl).FirstOrDefault(c => string.Equals(c.TagName, "head", StringComparison.OrdinalIgnoreCase));
         if (head != null)
         {
@@ -59,9 +65,11 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsSetTitle006Core(DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsSetTitle006Core(DomNode docRoot, in Arguments a)
     {
         var htmlEl = GetDocumentElement(docRoot);
+        if (htmlEl == null)
+            return JSUndefined.Value;
         var head = ChildElements(htmlEl).FirstOrDefault(c => string.Equals(c.TagName, "head", StringComparison.OrdinalIgnoreCase));
         if (head != null)
         {
@@ -74,7 +82,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsGetForms007Core(DomElement docRoot, in Arguments _)
+    private JSValue JsSubDocumentObjectsGetForms007Core(DomNode docRoot, in Arguments _)
     {
         var results = new List<JSValue>();
         CollectByTagName(docRoot, "form", results);
@@ -82,7 +90,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsGetChildNodes008Core(DomElement docRoot, in Arguments _)
+    private JSValue JsSubDocumentObjectsGetChildNodes008Core(DomNode docRoot, in Arguments _)
     {
         // childNodes includes ALL node types (per DOM), notably the canonical DomDocumentType — which
         // is no longer a DomElement after Phase 4 item 1, so ChildElements would wrongly drop it. This
@@ -94,7 +102,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsGetElementById014Core(DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsGetElementById014Core(DomNode docRoot, in Arguments a)
     {
         var id = a.Length > 0 ? a[0].ToString() : string.Empty;
         var found = FindInSubTree(docRoot, el => el.Id == id);
@@ -102,7 +110,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsGetElementsByTagName015Core(DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsGetElementsByTagName015Core(DomNode docRoot, in Arguments a)
     {
         var tagName = a.Length > 0 ? a[0].ToString().ToLowerInvariant() : string.Empty;
         var results = new List<JSValue>();
@@ -111,7 +119,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsCreateElement016Core(DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsCreateElement016Core(DomNode docRoot, in Arguments a)
     {
         if (a.Length == 0)
             throw new JSException("Failed to execute 'createElement': 1 argument required.");
@@ -124,7 +132,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsCreateTextNode017Core(DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsCreateTextNode017Core(DomNode docRoot, in Arguments a)
     {
         var text = a.Length > 0 ? a[0].ToString() : string.Empty;
         var el = CreateBridgeTextNode(text);
@@ -133,7 +141,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsCreateComment018Core(DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsCreateComment018Core(DomNode docRoot, in Arguments a)
     {
         var data = a.Length > 0 ? a[0].ToString() : string.Empty;
         var el = CreateBridgeCommentNode(data);
@@ -142,7 +150,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsCreateElementNS019Core(DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsCreateElementNS019Core(DomNode docRoot, in Arguments a)
     {
         var ns = a.Length > 0 && !a[0].IsNull && !a[0].IsUndefined ? a[0].ToString() : null;
         var localName = a.Length > 1 ? a[1].ToString() : (a.Length > 0 ? a[0].ToString() : "div");
@@ -455,7 +463,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsQuerySelector035Core(DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsQuerySelector035Core(DomNode docRoot, in Arguments a)
     {
         var selector = a.Length > 0 ? a[0].ToString() : string.Empty;
         var found = FindInSubTree(docRoot, el => MatchesSelector(el, selector));
@@ -463,7 +471,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsQuerySelectorAll036Core(DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsQuerySelectorAll036Core(DomNode docRoot, in Arguments a)
     {
         var selector = a.Length > 0 ? a[0].ToString() : string.Empty;
         var results = new List<JSValue>();
@@ -472,28 +480,28 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsElementFromPoint037Core(DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsElementFromPoint037Core(DomNode docRoot, in Arguments a)
     {
         var hit = HitTestDocumentPoint(docRoot, GetCoordinateArgument(a, 0), GetCoordinateArgument(a, 1)).FirstOrDefault();
         return hit != null ? ToJSObject(hit) : JSNull.Value;
     }
 
 
-    private JSValue JsSubDocumentObjectsElementsFromPoint038Core(DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsElementsFromPoint038Core(DomNode docRoot, in Arguments a)
     {
         var hits = HitTestDocumentPoint(docRoot, GetCoordinateArgument(a, 0), GetCoordinateArgument(a, 1));
         return new JSArray(hits.Select(ToJSObject).ToArray());
     }
 
 
-    private JSValue JsSubDocumentObjectsOpen039Core(JSObject? doc, DomElement docRoot, in Arguments _)
+    private JSValue JsSubDocumentObjectsOpen039Core(JSObject? doc, DomNode docRoot, in Arguments _)
     {
         ClearChildren(docRoot);
         return doc;
     }
 
 
-    private JSValue JsSubDocumentObjectsWrite040Core(DomBridge? bridge, DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsWrite040Core(DomBridge? bridge, DomNode docRoot, in Arguments a)
     {
         if (a.Length == 0)
             return JSUndefined.Value;
@@ -535,7 +543,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsGetImages041Core(DomElement docRoot, in Arguments _)
+    private JSValue JsSubDocumentObjectsGetImages041Core(DomNode docRoot, in Arguments _)
     {
         var results = new List<JSValue>();
         CollectByTagName(docRoot, "img", results);
@@ -543,7 +551,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsGetLinks042Core(DomElement docRoot, in Arguments _)
+    private JSValue JsSubDocumentObjectsGetLinks042Core(DomNode docRoot, in Arguments _)
     {
         var results = new List<JSValue>();
         CollectMatching(docRoot, el => (string.Equals(el.TagName, "a", StringComparison.OrdinalIgnoreCase) || string.Equals(el.TagName, "area", StringComparison.OrdinalIgnoreCase)) && HasAttr(el, "href"), results);
@@ -551,7 +559,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsRemoveChild044Core(DomBridge? bridge, DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsRemoveChild044Core(DomBridge? bridge, DomNode docRoot, in Arguments a)
     {
         if (a.Length == 0)
             return JSNull.Value;
@@ -567,7 +575,10 @@ public sealed partial class DomBridge
                     bridge.NotifyNodeIteratorPreRemoval(child);
                     RemoveNthChild(docRoot, idx);
                     SetParent(child, null);
-                    bridge.NotifyChildRemoved(docRoot, child, idx);
+                    // Phase 4 item 1 (P4.4a): child-list mutation-observer notification is element-only;
+                    // a canonical DomDocument browsing-context root (regime-B) has no such observers.
+                    if (docRoot is DomElement docRootElement)
+                        bridge.NotifyChildRemoved(docRootElement, child, idx);
                 }
 
                 return childObj;
@@ -578,7 +589,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsAppendChild045Core(DomBridge? bridge, DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsAppendChild045Core(DomBridge? bridge, DomNode docRoot, in Arguments a)
     {
         if (a.Length == 0)
             return JSNull.Value;
@@ -603,7 +614,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsAppend046Core(DomBridge? bridge, DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsAppend046Core(DomBridge? bridge, DomNode docRoot, in Arguments a)
     {
         if (a.Length == 0)
             return JSUndefined.Value;
@@ -615,7 +626,7 @@ public sealed partial class DomBridge
     }
 
 
-    private JSValue JsSubDocumentObjectsPrepend047Core(DomBridge? bridge, DomElement docRoot, in Arguments a)
+    private JSValue JsSubDocumentObjectsPrepend047Core(DomBridge? bridge, DomNode docRoot, in Arguments a)
     {
         if (a.Length == 0)
             return JSUndefined.Value;
@@ -647,19 +658,16 @@ public sealed partial class DomBridge
         var doctypeArg = a.Length > 2 ? a[2] : null;
         if (!string.IsNullOrEmpty(qName))
             ValidateQualifiedName(qName, ns, _jsContext!);
-        var subDocRoot = CreateBridgeElement("#subdoc-root");
-        GetElementRuntimeState(subDocRoot).Document.HasViewport.Set(false);
+        // Phase 4 item 1 (P4.4a): a createDocument root is a canonical DomDocument (was a #subdoc-root).
+        var subDocRoot = CreateBrowsingContextDocument();
         if (doctypeArg is JSObject dtObj)
         {
-            // Phase 4 item 1: the doctype is a canonical DomDocumentType (not a DomElement); match any
-            // DomNode so its ownerDocument is associated with this sub-document.
             foreach (var kvp in _jsObjects.Entries)
             {
                 if (kvp.Value == dtObj && kvp.Key is DomNode dtNode)
                 {
-                    SetParent(dtNode, subDocRoot);
-                    GetElementRuntimeState(dtNode).OwnerDocRoot = subDocRoot;
                     subDocRoot.AppendChild(dtNode);
+                    GetElementRuntimeState(dtNode).OwnerDocRoot = subDocRoot;
                     break;
                 }
             }
@@ -670,9 +678,8 @@ public sealed partial class DomBridge
             var docEl = string.IsNullOrEmpty(ns)
                 ? CreateBridgeElement(qName)
                 : CreateBridgeElementNS(ns, qName);
-            SetParent(docEl, subDocRoot);
-            GetElementRuntimeState(docEl).OwnerDocRoot = subDocRoot;
             subDocRoot.AppendChild(docEl);
+            GetElementRuntimeState(docEl).OwnerDocRoot = subDocRoot;
         }
 
         return BuildSubDocument(subDocRoot);
@@ -682,17 +689,16 @@ public sealed partial class DomBridge
     private JSValue JsSubDocumentObjectsCreateHTMLDocument050Core(in Arguments a)
     {
         var subTitle = a.Length > 0 && !a[0].IsNull && !a[0].IsUndefined ? a[0].ToString() : null;
-        var subDocRoot = CreateBridgeElement("#subdoc-root");
-        GetElementRuntimeState(subDocRoot).Document.HasViewport.Set(false);
+        // Phase 4 item 1 (P4.4a): a createHTMLDocument root is a canonical DomDocument (was a
+        // #subdoc-root); doctype + <html> are appended as canonical document children.
+        var subDocRoot = CreateBrowsingContextDocument();
         var dt = CreateBridgeDocumentType("html", string.Empty, string.Empty);
-        SetParent(dt, subDocRoot);
-        GetElementRuntimeState(dt).OwnerDocRoot = subDocRoot;
         subDocRoot.AppendChild(dt);
+        GetElementRuntimeState(dt).OwnerDocRoot = subDocRoot;
         // "http://www.w3.org/1999/xhtml" is the default HTML namespace the funnel applies.
         var subHtml = CreateBridgeElement("html");
-        SetParent(subHtml, subDocRoot);
-        GetElementRuntimeState(subHtml).OwnerDocRoot = subDocRoot;
         subDocRoot.AppendChild(subHtml);
+        GetElementRuntimeState(subHtml).OwnerDocRoot = subDocRoot;
         var subHead = CreateBridgeElement("head");
         SetParent(subHead, subHtml);
         GetElementRuntimeState(subHead).OwnerDocRoot = subDocRoot;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -43,6 +43,14 @@ public sealed partial class DomBridge
         // text/comment nodes are Broiler.Dom.DomElement and fall through to the element wrapper, preserving
         // behaviour — and goes live once text/comment construction flips to canonical
         // DomText/DomComment (F3c construction cutover).
+        if (node is DomDocumentType docType)
+        {
+            // Phase 4 item 1: the doctype is a canonical DomDocumentType (was a #doctype sentinel
+            // element). It gets the minimal DocumentType surface, not the full element wrapper.
+            PopulateDocumentTypeJSObject(obj, docType);
+            return obj;
+        }
+
         if (node is not DomElement element)
         {
             PopulateCharacterDataJSObject(obj, node);
@@ -275,26 +283,6 @@ public sealed partial class DomBridge
             obj.FastAddValue((KeyString)"replaceData",
                 new JSFunction((in a) => JsJsObjectsReplaceData053Core(bridge, element, in a), "replaceData", 3),
                 JSPropertyAttributes.EnumerableConfigurableValue);
-        }
-
-        // DOCTYPE-specific properties
-        if (string.Equals(element.TagName, "#doctype", StringComparison.OrdinalIgnoreCase))
-        {
-            obj.FastAddProperty((KeyString)"name",
-                new JSFunction((in _) => new JSString(GetDocTypeName(element)), "get name"),
-                null, JSPropertyAttributes.EnumerableConfigurableProperty);
-
-            obj.FastAddProperty((KeyString)"publicId",
-                new JSFunction((in _) => JsJsObjectsGetPublicId055Core(element, in _), "get publicId"),
-                null, JSPropertyAttributes.EnumerableConfigurableProperty);
-
-            obj.FastAddProperty((KeyString)"systemId",
-                new JSFunction((in _) => JsJsObjectsGetSystemId056Core(element, in _), "get systemId"),
-                null, JSPropertyAttributes.EnumerableConfigurableProperty);
-
-            obj.FastAddProperty((KeyString)"internalSubset",
-                NullFunction("get internalSubset"),
-                null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
         // ownerDocument (read-only) — returns the Document node (nodeType=9)
@@ -560,14 +548,10 @@ public sealed partial class DomBridge
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // name (read/write) — for form elements; syncs with content attribute
-        // Skip for DOCTYPE nodes which have their own name property (doctype name)
-        if (!string.Equals(element.TagName, "#doctype", StringComparison.OrdinalIgnoreCase))
-        {
-            obj.FastAddProperty((KeyString)"name",
-                new JSFunction((in a) => JsJsObjectsGetName112Core(element, in a), "get name"),
-                new JSFunction((in a) => JsJsObjectsSetName113Core(element, in a), "set name"),
-                JSPropertyAttributes.EnumerableConfigurableProperty);
-        }
+        obj.FastAddProperty((KeyString)"name",
+            new JSFunction((in a) => JsJsObjectsGetName112Core(element, in a), "get name"),
+            new JSFunction((in a) => JsJsObjectsSetName113Core(element, in a), "set name"),
+            JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // disabled (read/write) — for form controls
         obj.FastAddProperty((KeyString)"disabled",
@@ -850,6 +834,148 @@ public sealed partial class DomBridge
 
         obj.FastAddValue((KeyString)"normalize",
             new JSFunction((in a) => JsJsObjectsNormalize076Core(node, in a), "normalize", 0),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // -- ChildNode mixin --
+        obj.FastAddValue((KeyString)"remove",
+            new JSFunction((in a) => JsJsObjectsRemove093Core(node, in a), "remove", 0),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        obj.FastAddValue((KeyString)"before",
+            new JSFunction((in a) => JsJsObjectsBefore094Core(node, in a), "before", 0),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        obj.FastAddValue((KeyString)"after",
+            new JSFunction((in a) => JsJsObjectsAfter095Core(node, in a), "after", 0),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        obj.FastAddValue((KeyString)"replaceWith",
+            new JSFunction((in a) => JsJsObjectsReplaceWith096Core(node, in a), "replaceWith", 0),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // -- EventTarget --
+        obj.FastAddValue((KeyString)"addEventListener",
+            new JSFunction((in a) => JsJsObjectsAddEventListener097Core(node, in a), "addEventListener", 3),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        obj.FastAddValue((KeyString)"removeEventListener",
+            new JSFunction((in a) => JsJsObjectsRemoveEventListener098Core(node, in a), "removeEventListener", 3),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        obj.FastAddValue((KeyString)"dispatchEvent",
+            new JSFunction((in a) => JsJsObjectsDispatchEvent099Core(bridge, node, in a), "dispatchEvent", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // Node type constants (exist on all Node objects).
+        obj.FastAddValue((KeyString)"ELEMENT_NODE", new JSNumber(1), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"ATTRIBUTE_NODE", new JSNumber(2), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"TEXT_NODE", new JSNumber(3), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"CDATA_SECTION_NODE", new JSNumber(4), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"COMMENT_NODE", new JSNumber(8), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"DOCUMENT_NODE", new JSNumber(9), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"DOCUMENT_TYPE_NODE", new JSNumber(10), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"DOCUMENT_FRAGMENT_NODE", new JSNumber(11), JSPropertyAttributes.EnumerableConfigurableValue);
+    }
+
+    /// <summary>
+    /// Builds the JS wrapper for a canonical <see cref="DomDocumentType"/> node (Phase 4 item 1).
+    /// A DocumentType is a leaf Node with the ChildNode mixin and DocumentType-specific
+    /// <c>name</c>/<c>publicId</c>/<c>systemId</c>/<c>internalSubset</c> — it deliberately does NOT get
+    /// the element surface (attributes/style/children) it inherited while it was a <c>#doctype</c>
+    /// sentinel element, nor the CharacterData mutation methods. The node-generic handlers are the
+    /// same ones the character-data wrapper uses.
+    /// </summary>
+    private void PopulateDocumentTypeJSObject(JSObject obj, DomDocumentType doctype)
+    {
+        var bridge = this;
+        DomNode node = doctype;
+
+        // -- Node identity --
+        obj.FastAddProperty((KeyString)"nodeType",
+            new JSFunction((in a) => JsJsObjectsGetNodeType038Core(node, in a), "get nodeType"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        obj.FastAddProperty((KeyString)"nodeName",
+            new JSFunction((in a) => JsJsObjectsGetNodeName039Core(node, in a), "get nodeName"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        obj.FastAddProperty((KeyString)"nodeValue",
+            new JSFunction((in _) => JSNull.Value, "get nodeValue"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        obj.FastAddProperty((KeyString)"textContent",
+            new JSFunction((in _) => JSNull.Value, "get textContent"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        // -- DocumentType interface --
+        obj.FastAddProperty((KeyString)"name",
+            new JSFunction((in _) => new JSString(doctype.Name), "get name"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        obj.FastAddProperty((KeyString)"publicId",
+            new JSFunction((in _) => JsJsObjectsGetPublicId055Core(node, in _), "get publicId"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        obj.FastAddProperty((KeyString)"systemId",
+            new JSFunction((in _) => JsJsObjectsGetSystemId056Core(node, in _), "get systemId"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        obj.FastAddProperty((KeyString)"internalSubset",
+            NullFunction("get internalSubset"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        // -- Tree navigation --
+        obj.FastAddProperty((KeyString)"parentNode",
+            new JSFunction((in a) => ParentEl(node) != null ? ToJSObject(ParentEl(node)!) : JSNull.Value, "get parentNode"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        obj.FastAddProperty((KeyString)"parentElement",
+            new JSFunction((in a) => JsJsObjectsGetParentElement058Core(node, in a), "get parentElement"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        obj.FastAddProperty((KeyString)"previousSibling",
+            new JSFunction((in a) => JsJsObjectsGetPreviousSibling037Core(node, in a), "get previousSibling"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        obj.FastAddProperty((KeyString)"nextSibling",
+            new JSFunction((in a) => JsJsObjectsGetNextSibling036Core(node, in a), "get nextSibling"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        obj.FastAddProperty((KeyString)"ownerDocument",
+            new JSFunction((in a) => JsJsObjectsGetOwnerDocument057Core(node, in a), "get ownerDocument"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        obj.FastAddProperty((KeyString)"isConnected",
+            new JSFunction((in a) => JsJsObjectsGetIsConnected032Core(node, in a), "get isConnected"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        obj.FastAddValue((KeyString)"hasChildNodes",
+            new JSFunction((in a) => JSBoolean.False, "hasChildNodes", 0),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // -- Node methods --
+        obj.FastAddValue((KeyString)"cloneNode",
+            new JSFunction((in a) => JsJsObjectsCloneNode079Core(node, in a), "cloneNode", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        obj.FastAddValue((KeyString)"isEqualNode",
+            new JSFunction((in a) => JsJsObjectsIsEqualNode077Core(node, in a), "isEqualNode", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        obj.FastAddValue((KeyString)"isSameNode",
+            new JSFunction((in a) => JsJsObjectsIsSameNode075Core(node, in a), "isSameNode", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        obj.FastAddValue((KeyString)"contains",
+            new JSFunction((in a) => JsJsObjectsContains073Core(node, in a), "contains", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        obj.FastAddValue((KeyString)"compareDocumentPosition",
+            new JSFunction((in a) => JsJsObjectsCompareDocumentPosition074Core(node, in a), "compareDocumentPosition", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        obj.FastAddValue((KeyString)"getRootNode",
+            new JSFunction((in a) => JsJsObjectsGetRootNode078Core(node, in a), "getRootNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- ChildNode mixin --

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -51,6 +51,15 @@ public sealed partial class DomBridge
             return obj;
         }
 
+        if (node is DomDocumentFragment fragment)
+        {
+            // Phase 4 item 1: the fragment is a canonical DomDocumentFragment (was a
+            // #document-fragment sentinel element). It gets the DocumentFragment container surface
+            // (Node base + ParentNode mixin + child manipulation), not the full element wrapper.
+            PopulateDocumentFragmentJSObject(obj, fragment);
+            return obj;
+        }
+
         if (node is not DomElement element)
         {
             PopulateCharacterDataJSObject(obj, node);
@@ -1004,6 +1013,246 @@ public sealed partial class DomBridge
             new JSFunction((in a) => JsJsObjectsRemoveEventListener098Core(node, in a), "removeEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
+        obj.FastAddValue((KeyString)"dispatchEvent",
+            new JSFunction((in a) => JsJsObjectsDispatchEvent099Core(bridge, node, in a), "dispatchEvent", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // Node type constants (exist on all Node objects).
+        obj.FastAddValue((KeyString)"ELEMENT_NODE", new JSNumber(1), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"ATTRIBUTE_NODE", new JSNumber(2), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"TEXT_NODE", new JSNumber(3), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"CDATA_SECTION_NODE", new JSNumber(4), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"COMMENT_NODE", new JSNumber(8), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"DOCUMENT_NODE", new JSNumber(9), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"DOCUMENT_TYPE_NODE", new JSNumber(10), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"DOCUMENT_FRAGMENT_NODE", new JSNumber(11), JSPropertyAttributes.EnumerableConfigurableValue);
+    }
+
+    /// <summary>
+    /// Builds the JS wrapper for a canonical <see cref="DomDocumentFragment"/> (Phase 4 item 1). A
+    /// fragment is a non-element container: it gets the Node base + ParentNode mixin + child-
+    /// manipulation surface, but NOT the element-only surface (attributes/style/tagName) it inherited
+    /// while it was a <c>#document-fragment</c> sentinel element. Node-generic members reuse the same
+    /// handlers the character-data wrapper uses; the container members are focused fragment lambdas
+    /// over the neutral tree helpers and the (DomNode-widened) <see cref="InsertNodeAt"/> — a fragment
+    /// parent has no style scope, sub-document onload or child-mutation-observer side effects.
+    /// </summary>
+    private void PopulateDocumentFragmentJSObject(JSObject obj, DomDocumentFragment fragment)
+    {
+        var bridge = this;
+        DomNode node = fragment;
+
+        // -- Node identity --
+        obj.FastAddProperty((KeyString)"nodeType",
+            new JSFunction((in a) => JsJsObjectsGetNodeType038Core(node, in a), "get nodeType"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddProperty((KeyString)"nodeName",
+            new JSFunction((in a) => JsJsObjectsGetNodeName039Core(node, in a), "get nodeName"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddProperty((KeyString)"nodeValue",
+            new JSFunction((in _) => JSNull.Value, "get nodeValue"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddProperty((KeyString)"ownerDocument",
+            new JSFunction((in a) => JsJsObjectsGetOwnerDocument057Core(node, in a), "get ownerDocument"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        // -- Tree navigation --
+        obj.FastAddProperty((KeyString)"parentNode",
+            new JSFunction((in _) => ParentEl(node) != null ? ToJSObject(ParentEl(node)!) : JSNull.Value, "get parentNode"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddProperty((KeyString)"parentElement",
+            new JSFunction((in a) => JsJsObjectsGetParentElement058Core(node, in a), "get parentElement"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddProperty((KeyString)"childNodes",
+            new JSFunction((in a) => JsJsObjectsGetChildNodes033Core(node, in a), "get childNodes"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddProperty((KeyString)"firstChild",
+            new JSFunction((in a) => JsJsObjectsGetFirstChild034Core(node, in a), "get firstChild"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddProperty((KeyString)"lastChild",
+            new JSFunction((in a) => JsJsObjectsGetLastChild035Core(node, in a), "get lastChild"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddProperty((KeyString)"isConnected",
+            new JSFunction((in a) => JsJsObjectsGetIsConnected032Core(node, in a), "get isConnected"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddValue((KeyString)"hasChildNodes",
+            new JSFunction((in a) => fragment.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasChildNodes", 0),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // -- ParentNode mixin (element views) --
+        obj.FastAddProperty((KeyString)"children",
+            new JSFunction((in _) => new JSArray([.. ChildElements(fragment).Where(c => !IsText(c) && !IsSubDocRoot(c)).Select(c => (JSValue)ToJSObject(c))]), "get children"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddProperty((KeyString)"childElementCount",
+            new JSFunction((in _) => new JSNumber(ChildElements(fragment).Count(c => !IsText(c) && !IsSubDocRoot(c))), "get childElementCount"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddProperty((KeyString)"firstElementChild",
+            new JSFunction((in _) =>
+            {
+                var first = ChildElements(fragment).FirstOrDefault(c => !IsText(c) && !IsSubDocRoot(c));
+                return first != null ? ToJSObject(first) : JSNull.Value;
+            }, "get firstElementChild"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddProperty((KeyString)"lastElementChild",
+            new JSFunction((in _) =>
+            {
+                var last = ChildElements(fragment).LastOrDefault(c => !IsText(c) && !IsSubDocRoot(c));
+                return last != null ? ToJSObject(last) : JSNull.Value;
+            }, "get lastElementChild"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        // -- textContent (get/set) --
+        obj.FastAddProperty((KeyString)"textContent",
+            new JSFunction((in _) => GetNodeTextValue(node), "get textContent"),
+            new JSFunction((in a) =>
+            {
+                ClearChildren(fragment);
+                var value = a.Length > 0 ? a[0].ToString() : string.Empty;
+                if (!string.IsNullOrEmpty(value))
+                    fragment.AppendChild(CreateBridgeTextNode(value));
+                return JSUndefined.Value;
+            }, "set textContent"),
+            JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        // -- Child manipulation --
+        obj.FastAddValue((KeyString)"appendChild",
+            new JSFunction((in a) =>
+            {
+                if (a.Length == 0 || a[0] is not JSObject childObj)
+                    return JSUndefined.Value;
+                var childEl = FindDomNodeByJSObject(childObj);
+                if (childEl == null)
+                    return a[0];
+                if (ReferenceEquals(childEl, fragment) || IsDescendant(childEl, fragment))
+                    ThrowDOMException(_jsContext!, "The new child element contains the parent.", "HierarchyRequestError");
+                InsertNodeAt(fragment, childEl, fragment.ChildNodes.Count);
+                return a[0];
+            }, "appendChild", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"insertBefore",
+            new JSFunction((in a) =>
+            {
+                if (a.Length == 0 || a[0] is not JSObject newChildObj)
+                    return JSUndefined.Value;
+                var newEl = FindDomNodeByJSObject(newChildObj);
+                if (newEl == null)
+                    return a[0];
+                if (ReferenceEquals(newEl, fragment) || IsDescendant(newEl, fragment))
+                    ThrowDOMException(_jsContext!, "The new child element contains the parent.", "HierarchyRequestError");
+                if (a.Length < 2 || a[1].IsNull || a[1].IsUndefined)
+                {
+                    InsertNodeAt(fragment, newEl, fragment.ChildNodes.Count);
+                    return a[0];
+                }
+                if (a[1] is not JSObject refChildObj)
+                    return a[0];
+                var refEl = FindDomNodeByJSObject(refChildObj);
+                if (refEl == null || ReferenceEquals(newEl, refEl))
+                    return a[0];
+                var idx = ChildIndexOf(fragment, refEl);
+                if (idx < 0)
+                    throw new JSException("NotFoundError: The node before which the new node is to be inserted is not a child of this node.");
+                InsertNodeAt(fragment, newEl, idx);
+                return a[0];
+            }, "insertBefore", 2),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"removeChild",
+            new JSFunction((in a) =>
+            {
+                if (a.Length == 0 || a[0] is not JSObject childObj)
+                    return JSUndefined.Value;
+                var childEl = FindDomNodeByJSObject(childObj);
+                if (childEl == null)
+                    return a[0];
+                var idx = ChildIndexOf(fragment, childEl);
+                if (idx < 0)
+                    return a[0];
+                NotifyNodeIteratorPreRemoval(childEl);
+                RemoveNthChild(fragment, idx);
+                SetParent(childEl, null);
+                return a[0];
+            }, "removeChild", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"replaceChild",
+            new JSFunction((in a) =>
+            {
+                if (a.Length < 2 || a[0] is not JSObject newObj || a[1] is not JSObject oldObj)
+                    return JSUndefined.Value;
+                var newEl = FindDomNodeByJSObject(newObj);
+                var oldEl = FindDomNodeByJSObject(oldObj);
+                if (newEl == null || oldEl == null)
+                    return a[1];
+                var idx = ChildIndexOf(fragment, oldEl);
+                if (idx < 0)
+                    return a[1];
+                SetParent(oldEl, null);
+                InsertNodeAt(fragment, newEl, Math.Min(idx, fragment.ChildNodes.Count));
+                return a[1];
+            }, "replaceChild", 2),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"append",
+            new JSFunction((in a) =>
+            {
+                if (a.Length == 0)
+                    return JSUndefined.Value;
+                var nodes = BuildChildNodeArgumentNodes(a);
+                var insertIndex = fragment.ChildNodes.Count;
+                foreach (var child in nodes)
+                    InsertNodeAt(fragment, child, insertIndex++);
+                return JSUndefined.Value;
+            }, "append", 0),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"prepend",
+            new JSFunction((in a) =>
+            {
+                if (a.Length == 0)
+                    return JSUndefined.Value;
+                var nodes = BuildChildNodeArgumentNodes(a);
+                var insertIndex = 0;
+                foreach (var child in nodes)
+                    InsertNodeAt(fragment, child, insertIndex++);
+                return JSUndefined.Value;
+            }, "prepend", 0),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // -- Query --
+        obj.FastAddValue((KeyString)"querySelector",
+            new JSFunction((in a) => FindInDescendants(fragment, a.Length > 0 ? a[0].ToString() : string.Empty, false, bridge), "querySelector", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"querySelectorAll",
+            new JSFunction((in a) => FindInDescendants(fragment, a.Length > 0 ? a[0].ToString() : string.Empty, true, bridge), "querySelectorAll", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // -- Node methods --
+        obj.FastAddValue((KeyString)"cloneNode",
+            new JSFunction((in a) => JsJsObjectsCloneNode079Core(node, in a), "cloneNode", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"isEqualNode",
+            new JSFunction((in a) => JsJsObjectsIsEqualNode077Core(node, in a), "isEqualNode", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"isSameNode",
+            new JSFunction((in a) => JsJsObjectsIsSameNode075Core(node, in a), "isSameNode", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"contains",
+            new JSFunction((in a) => JsJsObjectsContains073Core(node, in a), "contains", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"compareDocumentPosition",
+            new JSFunction((in a) => JsJsObjectsCompareDocumentPosition074Core(node, in a), "compareDocumentPosition", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"getRootNode",
+            new JSFunction((in a) => JsJsObjectsGetRootNode078Core(node, in a), "getRootNode", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"normalize",
+            new JSFunction((in a) => JsJsObjectsNormalize076Core(node, in a), "normalize", 0),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // -- EventTarget --
+        obj.FastAddValue((KeyString)"addEventListener",
+            new JSFunction((in a) => JsJsObjectsAddEventListener097Core(node, in a), "addEventListener", 3),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"removeEventListener",
+            new JSFunction((in a) => JsJsObjectsRemoveEventListener098Core(node, in a), "removeEventListener", 3),
+            JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"dispatchEvent",
             new JSFunction((in a) => JsJsObjectsDispatchEvent099Core(bridge, node, in a), "dispatchEvent", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Document.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Document.cs
@@ -123,8 +123,7 @@ public sealed partial class DomBridge
         document.FastAddProperty((KeyString)"images", new JSFunction(JsRegistrationGetImages053Core, "get images"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.links — collection of all <a> and <area> elements with href
-        // Uses tree-order traversal instead of _knownNodes insertion order
-        // to correctly reflect dynamically appended elements.
+        // Uses tree-order traversal so dynamically appended elements are reflected.
         document.FastAddProperty((KeyString)"links", new JSFunction(JsRegistrationGetLinks054Core, "get links"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.styleSheets — collection of stylesheet objects for main document

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
@@ -21,7 +21,7 @@ public sealed partial class DomBridge
     /// <summary>Cache for stylesheet objects, keyed by the owning style element.</summary>
     private readonly Dictionary<DomElement, JSObject> _styleSheetCache = [];
 
-    private JSArray BuildStyleSheetsCollection(DomElement docRoot)
+    private JSArray BuildStyleSheetsCollection(DomNode docRoot)
     {
         var styleEls = new List<DomElement>();
         CollectStyleElements(docRoot, styleEls);
@@ -37,7 +37,7 @@ public sealed partial class DomBridge
     }
 
     /// <summary>Collects all style elements in the sub-tree.</summary>
-    private static void CollectStyleElements(DomElement root, List<DomElement> results)
+    private static void CollectStyleElements(DomNode root, List<DomElement> results)
     {
         foreach (var child in ChildElements(root))
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocumentObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocumentObjects.cs
@@ -11,7 +11,7 @@ namespace Broiler.HtmlBridge;
 
 public sealed partial class DomBridge
 {
-    private JSObject BuildSubDocument(DomElement docRoot)
+    private JSObject BuildSubDocument(DomNode docRoot)
     {
         var doc = new JSObject();
         _jsObjects.SetDocument(docRoot, doc);
@@ -21,11 +21,11 @@ public sealed partial class DomBridge
         var bridge = this;
 
         doc.FastAddProperty((KeyString)"documentElement",
-            new JSFunction((in _) => ToJSObject(GetDocumentElement(docRoot)), "get documentElement"),
+            new JSFunction((in _) => GetDocumentElement(docRoot) is { } de ? ToJSObject(de) : JSNull.Value, "get documentElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         doc.FastAddProperty((KeyString)"scrollingElement",
-            new JSFunction((in _) => ToJSObject(GetDocumentElement(docRoot)), "get scrollingElement"),
+            new JSFunction((in _) => GetDocumentElement(docRoot) is { } se ? ToJSObject(se) : JSNull.Value, "get scrollingElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // body
@@ -235,7 +235,7 @@ public sealed partial class DomBridge
     }
 
     /// <summary>Finds the first element in a sub-tree matching a predicate.</summary>
-    private DomElement? FindInSubTree(DomElement root, Func<DomElement, bool> predicate)
+    private DomElement? FindInSubTree(DomNode root, Func<DomElement, bool> predicate)
     {
         foreach (var child in ChildElements(root))
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -916,6 +916,20 @@ public sealed partial class DomBridge
                    string.Equals(firstDocType.PublicId, secondDocType.PublicId, StringComparison.Ordinal) &&
                    string.Equals(firstDocType.SystemId, secondDocType.SystemId, StringComparison.Ordinal);
 
+        // Phase 4 item 1: two DocumentFragment nodes (no attributes/tag) are equal iff their children
+        // are equal — fall through to the child-count + per-child comparison below, which operates on
+        // the raw ChildNodes and needs no element cast.
+        if (first is DomDocumentFragment || second is DomDocumentFragment)
+        {
+            if (first is not DomDocumentFragment || second is not DomDocumentFragment ||
+                first.ChildNodes.Count != second.ChildNodes.Count)
+                return false;
+            for (var index = 0; index < first.ChildNodes.Count; index++)
+                if (!NodesAreEqual(ChildAt(first, index), ChildAt(second, index)))
+                    return false;
+            return true;
+        }
+
         var firstEl = (DomElement)first;
         var secondEl = (DomElement)second;
         if (!string.Equals(firstEl.TagName, secondEl.TagName, StringComparison.Ordinal) ||
@@ -998,7 +1012,11 @@ public sealed partial class DomBridge
         }
     }
 
-    private void InsertNodeAt(DomElement parent, DomNode node, int index)
+    // Phase 4 item 1: parent widened DomElement -> DomNode so a canonical DomDocumentFragment can be
+    // an insertion parent (fragment.appendChild/append/...). The style-scope invalidation and
+    // child-added mutation notification are element-only concerns, guarded accordingly; the onload
+    // firing below already guards on `node is DomElement`. Behaviour for element parents is identical.
+    private void InsertNodeAt(DomNode parent, DomNode node, int index)
     {
         if (ReferenceEquals(node, parent) || IsDescendant(node, parent))
             ThrowDOMException(_jsContext!, "The new child element contains the parent.", "HierarchyRequestError");
@@ -1026,8 +1044,11 @@ public sealed partial class DomBridge
         SetParent(node, parent);
         AdoptSubtreeIntoDocument(node, GetElementRuntimeState(parent).OwnerDocRoot);
         InsertChildAt(parent, index, node);
-        InvalidateStyleScope(parent);
-        NotifyChildAdded(parent, node, index);
+        if (parent is DomElement parentElement)
+        {
+            InvalidateStyleScope(parentElement);
+            NotifyChildAdded(parentElement, node, index);
+        }
 
         // RF-BRIDGE-1c Phase F (F3c part 2b): only elements carry a TagName / fire onloads; a
         // canonical char-data node inserts with no sub-document side effects.
@@ -1075,10 +1096,12 @@ public sealed partial class DomBridge
                 var candidateNode = FindDomNodeByJSObject(candidateObject);
                 if (candidateNode != null)
                 {
-                    if (candidateNode is DomElement candidateElement &&
-                        string.Equals(candidateElement.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase))
+                    // Phase 4 item 1: a canonical DomDocumentFragment argument inserts its children
+                    // (per DOM), not the fragment itself. (Was a "#document-fragment" TagName check on
+                    // the former sentinel element — a non-element fragment no longer matches that.)
+                    if (candidateNode is DomDocumentFragment candidateFragment)
                     {
-                        foreach (var fragmentChild in candidateElement.ChildNodes.ToArray())
+                        foreach (var fragmentChild in candidateFragment.ChildNodes.ToArray())
                             nodes.Add(fragmentChild);
                         continue;
                     }
@@ -1136,7 +1159,7 @@ public sealed partial class DomBridge
         var previousSibling = index > 0 ? ChildAt(parent, index - 1) : null;
         var nextSibling = index + 1 < parent.ChildNodes.Count ? ChildAt(parent, index + 1) : null;
 
-        DomElement? parsedContainer = null;
+        DomDocumentFragment? parsedContainer = null;
         if (!string.IsNullOrEmpty(html))
         {
             var parsingContext = parent.TagName.StartsWith('#')
@@ -1168,7 +1191,7 @@ public sealed partial class DomBridge
         InvalidateStyleScope(parent);
     }
 
-    private bool TryBuildInnerHtmlFragmentContainer(DomElement contextElement, string html, out DomElement container)
+    private bool TryBuildInnerHtmlFragmentContainer(DomElement contextElement, string html, out DomDocumentFragment container)
     {
         container = null!;
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -551,10 +551,6 @@ public sealed partial class DomBridge
         htmlEl.AppendChild(bodyEl);
 
         InsertChildAt(containerElement, 0, docRoot);
-        _knownNodes.Add(docRoot);
-        _knownNodes.Add(htmlEl);
-        _knownNodes.Add(headEl);
-        _knownNodes.Add(bodyEl);
 
         return docRoot;
     }
@@ -590,12 +586,6 @@ public sealed partial class DomBridge
         preEl.AppendChild(textNode);
 
         InsertChildAt(containerElement, 0, docRoot);
-        _knownNodes.Add(docRoot);
-        _knownNodes.Add(htmlEl);
-        _knownNodes.Add(headEl);
-        _knownNodes.Add(bodyEl);
-        _knownNodes.Add(preEl);
-        _knownNodes.Add(textNode);
 
         return docRoot;
     }
@@ -839,38 +829,16 @@ public sealed partial class DomBridge
         docRoot.AppendChild(parsedRoot);
 
         InsertChildAt(containerElement, 0, docRoot);
-        _knownNodes.Add(docRoot);
-        _knownNodes.Add(parsedRoot);
-        // Add structural children (head, body) that HtmlTreeBuilder does not include in allElements
-        foreach (var child in ChildElements(parsedRoot))
-            AddElementsRecursive(child);
-        // Add non-structural elements from the builder (skip any already registered)
-        foreach (var el in allElements)
-        {
-            _knownNodes.Add(el);
-        }
 
         return docRoot;
     }
 
-    /// <summary>
-    /// Recursively adds a Broiler.Dom.DomElement and all its descendants to the element tracking list.
-    /// Used by <see cref="BuildSubDocumentFromHtml"/> to register structural elements
-    /// (html, head, body) that <see cref="HtmlTreeBuilder"/> does not include in its allElements list.
-    /// </summary>
-    // RF-BRIDGE-1c Phase F (F3c part 2d): register/unregister the whole node subtree (raw
-    // ChildNodes) so canonical text/comment nodes round-trip through _knownNodes too. No-op on the
-    // old homogeneous tree where every child was an element.
-    private void AddElementsRecursive(DomNode node)
-    {
-        _knownNodes.Add(node);
-        foreach (var child in node.ChildNodes)
-            AddElementsRecursive(child);
-    }
-
+    // RF-BRIDGE-1c Phase F (F3c part 2d): unregister the whole node subtree from the bridge's
+    // per-node caches when a sub-document root is torn down (raw ChildNodes so canonical
+    // text/comment nodes are released too). The former AddElementsRecursive counterpart is gone —
+    // node membership is now read from the canonical tree, so there is nothing to register on build.
     private void RemoveElementsRecursive(DomNode node)
     {
-        _knownNodes.Remove(node);
         _jsObjects.Remove(node);
 
         if (node is DomElement element)
@@ -1081,7 +1049,6 @@ public sealed partial class DomBridge
         {
             RemoveChildFrom(fragmentContainer, child);
             SetParent(child, null);
-            AddElementsRecursive(child);
             nodes.Add(child);
         }
 
@@ -1115,7 +1082,6 @@ public sealed partial class DomBridge
             }
 
             var textNode = CreateBridgeTextNode(value.ToString());
-            _knownNodes.Add(textNode);
             nodes.Add(textNode);
         }
 
@@ -1141,7 +1107,6 @@ public sealed partial class DomBridge
                 SetParent(child, element);
                 AdoptSubtreeIntoDocument(child, GetElementRuntimeState(element).OwnerDocRoot);
                 element.AppendChild(child);
-                AddElementsRecursive(child);
             }
         }
 
@@ -1187,7 +1152,6 @@ public sealed partial class DomBridge
                 SetParent(child, parent);
                 AdoptSubtreeIntoDocument(child, GetElementRuntimeState(parent).OwnerDocRoot);
                 InsertChildAt(parent, insertIndex, child);
-                AddElementsRecursive(child);
                 NotifyChildAdded(parent, child, insertIndex);
                 insertIndex++;
             }
@@ -1254,7 +1218,6 @@ public sealed partial class DomBridge
             if (xdoc.Root == null)
             {
                 InsertChildAt(containerElement, 0, docRoot);
-                _knownNodes.Add(docRoot);
                 return docRoot;
             }
 
@@ -1277,8 +1240,6 @@ public sealed partial class DomBridge
             docRoot.AppendChild(rootEl);
 
             InsertChildAt(containerElement, 0, docRoot);
-            _knownNodes.Add(docRoot);
-            _knownNodes.Add(rootEl);
 
             // Execute scripts in XHTML documents with correct namespace
             if (isXhtml && hasCorrectXhtmlNs)
@@ -1290,7 +1251,6 @@ public sealed partial class DomBridge
         {
             // XML well-formedness error — return empty document, don't execute scripts
             InsertChildAt(containerElement, 0, docRoot);
-            _knownNodes.Add(docRoot);
         }
 
         return docRoot;
@@ -1317,14 +1277,12 @@ public sealed partial class DomBridge
                 var childEl = BuildDomElementFromXElement(childXe);
                 SetParent(childEl, el);
                 el.AppendChild(childEl);
-                _knownNodes.Add(childEl);
             }
             else if (child is XText childText)
             {
                 var textNode = CreateBridgeTextNode(childText.Value);
                 SetParent(textNode, el);
                 el.AppendChild(textNode);
-                _knownNodes.Add(textNode);
             }
         }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -909,6 +909,13 @@ public sealed partial class DomBridge
         if (first is DomCharacterData || second is DomCharacterData)
             return string.Equals(BridgeText(first), BridgeText(second), StringComparison.Ordinal);
 
+        // Phase 4 item 1: two DocumentType nodes are equal iff their name/publicId/systemId match
+        // (per DOM isEqualNode). Both have NodeType == DocumentType by the check above.
+        if (first is DomDocumentType firstDocType && second is DomDocumentType secondDocType)
+            return string.Equals(firstDocType.Name, secondDocType.Name, StringComparison.Ordinal) &&
+                   string.Equals(firstDocType.PublicId, secondDocType.PublicId, StringComparison.Ordinal) &&
+                   string.Equals(firstDocType.SystemId, secondDocType.SystemId, StringComparison.Ordinal);
+
         var firstEl = (DomElement)first;
         var secondEl = (DomElement)second;
         if (!string.Equals(firstEl.TagName, secondEl.TagName, StringComparison.Ordinal) ||

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
@@ -24,7 +24,7 @@ public sealed partial class DomBridge
     private JSObject BuildNodeIterator(DomElement root, int whatToShow, JSFunction? filterFn) =>
         _traversal.BuildNodeIterator(root, whatToShow, filterFn);
 
-    private JSObject BuildRange(DomElement? documentRoot = null) =>
+    private JSObject BuildRange(DomNode? documentRoot = null) =>
         _traversal.BuildRange(documentRoot);
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -312,7 +312,7 @@ public sealed partial class DomBridge
     /// Nested sub-document roots remain isolated browsing contexts and are not
     /// re-owned by the outer document.
     /// </summary>
-    private static void AdoptSubtreeIntoDocument(DomNode node, DomElement? ownerDocRoot)
+    private static void AdoptSubtreeIntoDocument(DomNode node, DomNode? ownerDocRoot)
     {
         GetElementRuntimeState(node).OwnerDocRoot = ownerDocRoot;
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -400,7 +400,6 @@ public sealed partial class DomBridge
                 var childClone = CloneDomElement(child, true);
                 SetParent(childClone, clone);
                 clone.AppendChild(childClone);
-                _knownNodes.Add(childClone);
             }
         }
         return clone;
@@ -512,21 +511,6 @@ public sealed partial class DomBridge
         }
     }
 
-    /// <summary>
-    /// Collects all descendants of <paramref name="parent"/> into <paramref name="result"/>
-    /// in depth-first pre-order (without skipping sub-document roots).
-    /// Used by <c>document.write()</c> to register parsed elements.
-    /// </summary>
-    // RF-BRIDGE-1c Phase F (F3c part 2d): flatten the whole subtree (raw ChildNodes) so text/comment
-    // descendants are collected for registration too.
-    private static void CollectAllDescendantsFlat(DomNode parent, List<DomNode> result)
-    {
-        foreach (var child in parent.ChildNodes)
-        {
-            result.Add(child);
-            CollectAllDescendantsFlat(child, result);
-        }
-    }
 
     /// <summary>
     /// Collects descendant elements matching a tag name in tree order (depth-first).

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -46,23 +46,27 @@ public sealed partial class DomBridge
     /// <summary>
     /// Searches descendants of an element using a CSS selector.
     /// </summary>
-    private static JSValue FindInDescendants(DomElement root, string selector, bool all, DomBridge bridge)
+    // Phase 4 item 1: root widened DomElement -> DomNode so querySelector/querySelectorAll work over a
+    // canonical DomDocumentFragment. A fragment cannot itself match a selector, so the :scope-root
+    // self-match is guarded to element roots and the descendant scope is null for a fragment root.
+    private static JSValue FindInDescendants(DomNode root, string selector, bool all, DomBridge bridge)
     {
         var results = new List<JSValue>();
-        if (selector.Contains(":scope") &&
-            MatchesSelector(root, selector, root))
+        var scope = root as DomElement;
+        if (scope is not null && selector.Contains(":scope") &&
+            MatchesSelector(scope, selector, scope))
         {
-            results.Add(bridge.ToJSObject(root));
+            results.Add(bridge.ToJSObject(scope));
             if (!all)
                 return results[0];
         }
 
-        SearchDescendants(root, selector, results, bridge, all, root);
+        SearchDescendants(root, selector, results, bridge, all, scope);
         if (all) return new JSArray(results);
         return results.Count > 0 ? results[0] : JSNull.Value;
     }
 
-    private static void SearchDescendants(DomElement parent, string selector, List<JSValue> results, DomBridge bridge, bool all, DomElement scope)
+    private static void SearchDescendants(DomNode parent, string selector, List<JSValue> results, DomBridge bridge, bool all, DomElement? scope)
     {
         foreach (var child in ChildElements(parent))
         {
@@ -344,6 +348,17 @@ public sealed partial class DomBridge
         if (source is DomDocumentType sourceDocType)
             return _document.CreateDocumentType(sourceDocType.Name, sourceDocType.PublicId, sourceDocType.SystemId);
 
+        // Phase 4 item 1: a canonical DomDocumentFragment clones to an empty fragment; a deep clone
+        // copies its children (a shallow clone is empty, per DOM).
+        if (source is DomDocumentFragment sourceFragment)
+        {
+            var fragmentClone = CreateBridgeDocumentFragment();
+            if (deep)
+                foreach (var child in sourceFragment.ChildNodes.ToArray())
+                    fragmentClone.AppendChild(CloneDomElement(child, true));
+            return fragmentClone;
+        }
+
         var element = (DomElement)source;
         // Preserve the source element's exact namespace (folds the old post-construction
         // `clone.NamespaceURI = element.NamespaceURI` — see below); SVG/foreign clones keep
@@ -534,9 +549,10 @@ public sealed partial class DomBridge
     {
         if (IsText(node)) return 3; // TEXT_NODE
         if (IsComment(node)) return 8;
+        if (node is DomDocumentType) return 10; // DOCUMENT_TYPE_NODE (canonical)
+        if (node is DomDocumentFragment) return 11; // DOCUMENT_FRAGMENT_NODE (canonical)
         if (node is not DomElement element) return 1;
         if (string.Equals(element.TagName, "#document", StringComparison.OrdinalIgnoreCase)) return 9;
-        if (string.Equals(element.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase)) return 11;
         return 1; // ELEMENT_NODE
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -29,9 +29,9 @@ public sealed partial class DomBridge
     };
 
     /// <summary>
-    /// Parses a DOCTYPE declaration and creates a Broiler.Dom.DomElement representing the DocumentType node.
+    /// Parses a DOCTYPE declaration and creates the canonical <see cref="DomDocumentType"/> node.
     /// </summary>
-    private DomElement? ParseDocType(string html)
+    private DomDocumentType? ParseDocType(string html)
     {
         var match = DocTypePattern.Match(html);
         if (!match.Success) return null;
@@ -40,20 +40,7 @@ public sealed partial class DomBridge
         var publicId = match.Groups[2].Success ? match.Groups[2].Value : string.Empty;
         var systemId = match.Groups[3].Success ? match.Groups[3].Value : string.Empty;
 
-        var doctype = CreateBridgeElement("#doctype");
-        GetElementRuntimeState(doctype).DocumentType.Name.Set(name);
-        GetElementRuntimeState(doctype).DocumentType.PublicId.Set(publicId);
-        GetElementRuntimeState(doctype).DocumentType.SystemId.Set(systemId);
-        GetElementRuntimeState(doctype).DocumentType.InternalSubset.Set(null);
-
-        return doctype;
-    }
-
-    /// <summary>Gets the lowercase name from a DOCTYPE Broiler.Dom.DomElement.</summary>
-    private static string GetDocTypeName(DomElement element)
-    {
-        var dtName = GetElementRuntimeState(element).DocumentType.Name.TryGet(out var n) ? n?.ToString() ?? "html" : "html";
-        return dtName.ToLowerInvariant();
+        return CreateBridgeDocumentType(name, publicId, systemId);
     }
 
     /// <summary>
@@ -352,6 +339,10 @@ public sealed partial class DomBridge
                 ? _document.CreateComment(sourceCharData.Data)
                 : _document.CreateTextNode(sourceCharData.Data);
         }
+
+        // Phase 4 item 1: a canonical DomDocumentType clones its immutable name/publicId/systemId.
+        if (source is DomDocumentType sourceDocType)
+            return _document.CreateDocumentType(sourceDocType.Name, sourceDocType.PublicId, sourceDocType.SystemId);
 
         var element = (DomElement)source;
         // Preserve the source element's exact namespace (folds the old post-construction

--- a/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.Range.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.Range.cs
@@ -234,7 +234,10 @@ internal sealed partial class TraversalBinding
             var nodes = DomBridge.GetNodesInRange(state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset);
             var elemCount = DomBridge.ChildElements(startContainerElement).Count(c => !DomBridge.IsText(c) && !DomBridge.IsComment(c));
             var removedElems = nodes.Count(n => !DomBridge.IsText(n) && !DomBridge.IsComment(n));
-            if (elemCount - removedElems + 1 > 1 || (!string.Equals(newParent.TagName, "#document-fragment", StringComparison.OrdinalIgnoreCase) && !DomBridge.IsComment(newParent)))
+            // newParent is always a real element here (a canonical DomDocumentFragment / DomComment
+            // is not a DomElement, so FindDomElementByJSObject returned null and we returned above) —
+            // the former "#document-fragment" sentinel-tag exclusion is dead.
+            if (elemCount - removedElems + 1 > 1 || !DomBridge.IsComment(newParent))
             {
                 DomBridge.ThrowDOMException(_host.JsContext, "Hierarchy request error", "HierarchyRequestError");
                 return JSUndefined.Value;

--- a/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.Range.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.Range.cs
@@ -85,13 +85,16 @@ internal sealed partial class TraversalBinding
         if (a[0] is not JSObject nodeObj)
             return JSUndefined.Value;
         var el = _host.FindDomNodeByJSObject(nodeObj);
-        if (el is null || DomBridge.ParentEl(el) == null)
+        // Phase 4 item 1 (P4.4a): a boundary node's parent may be a canonical DomDocument (a regime-B
+        // createDocument root) — a valid boundary container that is not a DomElement, so use the raw
+        // ParentNode (ParentEl nulled out a non-element parent and wrongly threw here).
+        if (el is null || el.ParentNode == null)
         {
             DomBridge.ThrowDOMException(_host.JsContext, "Invalid node type", "InvalidNodeTypeError");
             return JSUndefined.Value;
         }
 
-        state.SetStart(DomBridge.ParentEl(el), DomBridge.ChildIndexOf(DomBridge.ParentEl(el)!, el));
+        state.SetStart(el.ParentNode, DomBridge.ChildIndexOf(el.ParentNode, el));
         return JSUndefined.Value;
     }
 
@@ -102,13 +105,16 @@ internal sealed partial class TraversalBinding
         if (a[0] is not JSObject nodeObj)
             return JSUndefined.Value;
         var el = _host.FindDomNodeByJSObject(nodeObj);
-        if (el is null || DomBridge.ParentEl(el) == null)
+        // Phase 4 item 1 (P4.4a): a boundary node's parent may be a canonical DomDocument (a regime-B
+        // createDocument root) — a valid boundary container that is not a DomElement, so use the raw
+        // ParentNode (ParentEl nulled out a non-element parent and wrongly threw here).
+        if (el is null || el.ParentNode == null)
         {
             DomBridge.ThrowDOMException(_host.JsContext, "Invalid node type", "InvalidNodeTypeError");
             return JSUndefined.Value;
         }
 
-        state.SetStart(DomBridge.ParentEl(el), DomBridge.ChildIndexOf(DomBridge.ParentEl(el)!, el) + 1);
+        state.SetStart(el.ParentNode, DomBridge.ChildIndexOf(el.ParentNode, el) + 1);
         return JSUndefined.Value;
     }
 
@@ -119,14 +125,15 @@ internal sealed partial class TraversalBinding
         if (a[0] is not JSObject nodeObj)
             return JSUndefined.Value;
         var el = _host.FindDomNodeByJSObject(nodeObj);
-        if (el is null || DomBridge.ParentEl(el) == null)
+        // INVALID_NODE_TYPE_ERR — node has no parent. Phase 4 item 1 (P4.4a): use the raw ParentNode so
+        // a canonical DomDocument parent (regime-B createDocument root) is accepted as a container.
+        if (el is null || el.ParentNode == null)
         {
-            // INVALID_NODE_TYPE_ERR — node has no parent
             DomBridge.ThrowDOMException(_host.JsContext, "Invalid node type", "InvalidNodeTypeError");
             return JSUndefined.Value;
         }
 
-        state.SetEnd(DomBridge.ParentEl(el), DomBridge.ChildIndexOf(DomBridge.ParentEl(el)!, el));
+        state.SetEnd(el.ParentNode, DomBridge.ChildIndexOf(el.ParentNode, el));
         return JSUndefined.Value;
     }
 
@@ -137,13 +144,16 @@ internal sealed partial class TraversalBinding
         if (a[0] is not JSObject nodeObj)
             return JSUndefined.Value;
         var el = _host.FindDomNodeByJSObject(nodeObj);
-        if (el is null || DomBridge.ParentEl(el) == null)
+        // Phase 4 item 1 (P4.4a): a boundary node's parent may be a canonical DomDocument (a regime-B
+        // createDocument root) — a valid boundary container that is not a DomElement, so use the raw
+        // ParentNode (ParentEl nulled out a non-element parent and wrongly threw here).
+        if (el is null || el.ParentNode == null)
         {
             DomBridge.ThrowDOMException(_host.JsContext, "Invalid node type", "InvalidNodeTypeError");
             return JSUndefined.Value;
         }
 
-        state.SetEnd(DomBridge.ParentEl(el), DomBridge.ChildIndexOf(DomBridge.ParentEl(el)!, el) + 1);
+        state.SetEnd(el.ParentNode, DomBridge.ChildIndexOf(el.ParentNode, el) + 1);
         return JSUndefined.Value;
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.cs
@@ -260,7 +260,7 @@ internal sealed partial class TraversalBinding(ITraversalHost host)
     /// Builds a DOM <c>Range</c> object. The <paramref name="documentRoot"/> is the document node
     /// that owns this range (main or sub-document); defaults to the main document root.
     /// </summary>
-    internal JSObject BuildRange(DomElement? documentRoot = null)
+    internal JSObject BuildRange(DomNode? documentRoot = null)
     {
         var range = new JSObject();
         var docRoot = documentRoot ?? _host.DocumentNode;

--- a/src/Broiler.HtmlBridge.Dom/Runtime/JsObjectRegistry.cs
+++ b/src/Broiler.HtmlBridge.Dom/Runtime/JsObjectRegistry.cs
@@ -20,7 +20,9 @@ namespace Broiler.HtmlBridge.Dom.Runtime;
 internal sealed class JsObjectRegistry
 {
     private readonly Dictionary<DomNode, JSObject> _nodeWrappers = new(ReferenceEqualityComparer.Instance);
-    private readonly Dictionary<DomElement, JSObject> _documentWrappers = new(ReferenceEqualityComparer.Instance);
+    // Phase 4 item 1 (P4.4a): keyed by DomNode so a canonical DomDocument browsing-context root maps
+    // to its document wrapper, alongside the legacy #subdoc-root element roots.
+    private readonly Dictionary<DomNode, JSObject> _documentWrappers = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>Gets the wrapper already registered for <paramref name="node"/>, if any.</summary>
     public bool TryGet(DomNode node, out JSObject wrapper) => _nodeWrappers.TryGetValue(node, out wrapper!);
@@ -62,10 +64,10 @@ internal sealed class JsObjectRegistry
     /// element itself is also registered as a normal node wrapper by the caller; this second map
     /// answers "the document object owning this root".
     /// </summary>
-    public void SetDocument(DomElement documentRoot, JSObject document) => _documentWrappers[documentRoot] = document;
+    public void SetDocument(DomNode documentRoot, JSObject document) => _documentWrappers[documentRoot] = document;
 
     /// <summary>Gets the <c>document</c> wrapper registered for a sub-document root, if any.</summary>
-    public bool TryGetDocument(DomElement documentRoot, out JSObject document) =>
+    public bool TryGetDocument(DomNode documentRoot, out JSObject document) =>
         _documentWrappers.TryGetValue(documentRoot, out document!);
 
     /// <summary>Drops every wrapper identity — both node and sub-document maps. Called on re-parse and disposal.</summary>


### PR DESCRIPTION
## Summary

Kicks off **Phase 4 (eliminate parallel DOM state)** of the HtmlBridge complexity-reduction roadmap. Phase 4's goal is to make the canonical `Broiler.Dom`/`Broiler.Dom.Html` types the single authority for document tree/content state, replacing the bridge's parallel structures and `#`-sentinel fake-tag elements.

This branch lands **four independent, behaviour-preserving slices** plus a documented cross-layer blocker. Each slice was gated with characterization tests and a full-log **set-diff against a pre-change baseline** (change-side failures must be a strict subset of baseline) — no public-API change in any of them.

## Commits

| Commit | Slice | What it eliminates |
|---|---|---|
| `b7947d6f` | **P4.1** | the dead `_knownNodes` parallel node set (roadmap item 6) |
| `0b4216a4` | **P4.2** | `#doctype` sentinel → canonical `DomDocumentType` (item 1) |
| `24429467` | **P4.3** | `#document-fragment` sentinel → canonical `DomDocumentFragment` (item 1) |
| `75e987ce` | **P4.4a** | regime-B `createDocument`/`createHTMLDocument` roots → canonical `DomDocument` (item 1) |
| `0cea1127` | **docs** | records the P4.4b iframe-sever layout-engine blocker |

## What changed & why

- **P4.1 — remove `_knownNodes`.** A per-session `HashSet<DomNode>` written on ~70 node-construction sites but with no behaviour-affecting reader left (its last consumer was already on tree-order traversal; the only surviving lookup was a redundant idempotent-`Add` guard). Pure parallel state shadowing canonical tree membership — deleted, along with the now-dead `AddElementsRecursive`/`CollectAllDescendantsFlat` helpers.
- **P4.2 — `#doctype` → `DomDocumentType`.** The doctype was a fake-tag `DomElement` whose name/publicId/systemId lived in a parallel `DocumentTypeRuntimeState`; it now IS a canonical `DomDocumentType` carrying those natively (that state class is deleted). New `PopulateDocumentTypeJSObject` gives it the correct minimal DocumentType JS surface; node-dispatch/serialization/`isEqualNode`/`cloneNode` gained a `DomDocumentType` branch and shed their `#doctype` TagName cases.
- **P4.3 — `#document-fragment` → `DomDocumentFragment`.** A container, so it gets a dedicated `PopulateDocumentFragmentJSObject` wrapper (Node + ParentNode mixin + child manipulation). Reuses node-generic handlers plus two shared helpers widened `DomElement`→`DomNode` (`InsertNodeAt`, `FindInDescendants`, guarded for element-only concerns). Fixed a P4.2 regression discovered here (`createDocument` skipped the non-element doctype in a `is DomElement` lookup).
- **P4.4a — regime-B browsing-context roots → `DomDocument`.** The detached `createDocument`/`createHTMLDocument` roots (already parentless) become real canonical `DomDocument`s, so a `DomDocumentType` is finally a legitimate document child. Includes behaviour-preserving `DomElement`→`DomNode` widenings across the shared sub-document infrastructure (`OwnerDocRoot`, `_documentWrappers`, `BuildSubDocument` + its 24 callbacks, and shared descendant helpers). Fixed two regressions found here (empty-document `documentElement` null-crash; a Range boundary setter that threw on a `DomDocument` parent).

## Reviewer notes

- **The recurring hazard across these slices:** once a sentinel becomes a canonical *non-element* node, element-typed code trips on it — `ParentEl` (= `ParentNode as DomElement`, null for a Document), `is DomElement` guards, `ChildElements` (`OfType<DomElement>`), `FindDomElementByJSObject`, and `(DomElement)` casts. Each slice's fixes address these; worth a look at the `DomDocumentType`/`DomDocumentFragment` branches added to `CloneDomElement`, `NodesAreEqual`, the serialization adapter, and the Range boundary setters.
- **P4.4b (regime-A iframe `#subdoc-root` sever) is intentionally NOT here — it is blocked below the bridge.** A full bridge-side implementation was written and reverted; `Broiler.Layout`'s `CssBox.LayoutNestedBrowsingContexts` composes subframe geometry by walking the `#subdoc-root` subtree in the main box tree, so that tree child is load-bearing for *layout*, not only script DOM. Severing it needs a cross-layer `Broiler.Layout` change (Phase-5 adjacent). Root cause + approach are documented in `docs/roadmap/htmlbridge-complexity-reduction-roadmap.md` (P4.4b entry). `P4.4c` (eliminate `OwnerDocRoot`) depends on the same rework.
- **Verification.** New test files: `KnownNodesRemovalTests`, `DoctypeSentinelMigrationTests`, `DocumentFragmentSentinelMigrationTests`, `BrowsingContextRootMigrationTests`. Wide sweeps (up to ~1073 tests) plus Acid set-diffs were clean; the only deltas are known parallel-load render flakiness (pass in isolation) and pre-existing environmental failures (real HTTP, headless geometry, fonts).
- **Not merged/rebased with any layout changes** — this is bridge-only. The regime-A sever should be sequenced with Phase 5.
