### PR TITLE
HtmlBridge P4.4b: sever regime-A iframe #subdoc-root via a content-document resolver

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -61,6 +61,18 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     internal bool IsNestedViewportRoot { get; set; }
 
     /// <summary>
+    /// RF-BRIDGE-1b / HtmlBridge Phase 4 (P4.4b): marks the box that roots a nested
+    /// browsing context (the sub-viewport of an <c>&lt;iframe&gt;</c>/<c>&lt;object&gt;</c>/
+    /// <c>&lt;frame&gt;</c> sub-document). <see cref="LayoutNestedBrowsingContexts"/> keys off
+    /// this flag — set by the DOM→box builder — instead of a <c>#subdoc-root</c> fake tag name,
+    /// so the sub-document can be projected either from an in-tree materialised subtree (legacy)
+    /// or synthesised from a referenced content <see cref="Dom.DomDocument"/> (Phase 4 sever).
+    /// The box is placed and sized to its frame's content box by <see cref="LayoutSubdocument"/>,
+    /// which also promotes it to an <see cref="IsNestedViewportRoot"/> sub-viewport.
+    /// </summary>
+    internal bool IsNestedBrowsingContextRoot { get; set; }
+
+    /// <summary>
     /// When the block-inside-inline correction splits a positioned inline
     /// element, the original box loses its children to anonymous "left" and
     /// "right" copies.  This list tracks those copies so that
@@ -381,8 +393,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     {
         foreach (var child in box.Boxes)
         {
-            if (child.SourceElement is { } source
-                && string.Equals(source.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase))
+            if (child.IsNestedBrowsingContextRoot)
             {
                 LayoutSubdocument(box, child, g);
             }

--- a/Broiler.Layout/Broiler.Layout/ILayoutView.cs
+++ b/Broiler.Layout/Broiler.Layout/ILayoutView.cs
@@ -29,6 +29,14 @@ public interface ILayoutView : IDisposable
     /// <param name="document">The canonical document to lay out.</param>
     /// <param name="viewport">The viewport size to lay out against.</param>
     /// <param name="baseUrl">The document base URL used for resource resolution.</param>
+    /// <param name="contentDocumentResolver">
+    /// Optional host callback (HtmlBridge Phase 4 P4.4b) mapping a nested-browsing-context
+    /// container element (<c>&lt;iframe&gt;</c>/<c>&lt;object&gt;</c>/<c>&lt;frame&gt;</c>) to its
+    /// referenced content <see cref="DomDocument"/>. When supplied, a sub-document that is no
+    /// longer an in-tree child is projected into the box tree (and its geometry composed into the
+    /// main frame). Null preserves the legacy in-tree-materialisation behaviour.
+    /// </param>
     IReadOnlyDictionary<DomElement, BoxGeometry> GetGeometry(
-        DomDocument document, SizeF viewport, string baseUrl);
+        DomDocument document, SizeF viewport, string baseUrl,
+        Func<DomElement, DomDocument?>? contentDocumentResolver = null);
 }

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1018,27 +1018,58 @@ Regression check vs the P4.3 baseline: a 1073-test wide sweep has the change-sid
 strict subset of baseline (no new failures); the Acid+Range set-diff's one apparent delta passes in
 isolation (known parallel-load render flakiness) → zero regressions.
 
-**P4.4b (regime-A iframe sever) is BLOCKED below the bridge — it requires a `Broiler.Layout` submodule
-change, not a bridge-only slice.** A full bridge-side implementation was written and reverted; the
-approach (documented here for the eventual cross-layer PR) added `_contentDocuments`/
-`_documentContainers` container↔document maps, made the four `BuildSubDocument*` paths mint a canonical
-`DomDocument` referenced by the container (not a `#subdoc-root` tree child), and rewired the
-lookup/reverse consumers
-(`GetOrCreateSubDocument`, `InvalidateCachedSubDocument`, `GetSubDocumentScrollingElement`,
-`TrySerializeCurrentSrcDoc`, `GetOuterFrameElement`). It built cleanly and passed the DOM/script
-sub-document suites, but produced **four deterministic iframe-geometry regressions**
-(`Todo28_Iframe_ZeroSize_No_Visual_Box`, the two script-assigned-iframe-position `ScrollIntoView`
-tests, and `SubframeElement_GetBoundingClientRect_Is_Composed_Into_Main_Frame`). Root cause:
-`Broiler.Layout/Broiler.Layout/Engine/CssBox.cs` `LayoutNestedBrowsingContexts` composes each
-subframe's geometry into the main coordinate frame by **walking the `#subdoc-root` subtree that is
-present in the main box tree** — i.e. the `#subdoc-root` tree child is load-bearing for *layout*, not
-only script DOM. The shared-layout-geometry snapshot lays out `_document` (which contained the
-`#subdoc-root` subtree), so `getBoundingClientRect` of a sub-document element found its box; severing
-removes the sub-document from `_document`, so the layout engine composes nothing. The clean fix is to
-make `Broiler.Layout` lay out the referenced content-documents (via the container↔document map)
-instead of the `#subdoc-root` subtree — a cross-layer change that overlaps Phase 5 (used-value/Layout
-work). Until then, regime-A stays on the `#subdoc-root` element path. **P4.4c** (eliminate
-`OwnerDocRoot`) and the remaining `#document` sentinel are independent of this blocker.
+Status: **P4.4b completed** 2026-07-14 (branch `htmlbridge-phase4-p44b-iframe-sever`) — **the regime-A
+iframe/object/frame sever, delivered as the cross-layer fix the earlier blocker called for.** The
+materialized sub-document of an `<iframe>`/`<object>`/`<frame>` is no longer an in-tree `#subdoc-root`
+child of the container; the four `BuildSubDocument*` paths now mint a canonical `Broiler.Dom.DomDocument`
+(via the P4.4a `CreateBrowsingContextDocument` funnel) referenced through container↔document maps
+(`_contentDocuments`/`_documentContainers`, with `GetContentDocument`/`GetFrameForContentDocument`/
+`LinkContentDocument`). The tree-child lookups were rewired to the forward map (`GetOrCreateSubDocument`,
+`InvalidateCachedSubDocument`, `GetSubDocumentScrollingElement`, `TrySerializeCurrentSrcDoc`) and the
+three `ParentEl(#subdoc-root)` reverse lookups to the reverse map (`GetOuterFrameElement`,
+`GetParentWindowForSubDocument`/`GetInheritedSubDocumentBaseUrl`, and `GetViewportForDocRoot` — the last
+because `GetDocumentRootFor` now returns the sub-document `<html>` instead of the `#subdoc-root` element).
+
+**The cross-layer half that unblocked it** (the reason the prior bridge-only attempt was reverted): the
+renderer now lays out the *referenced* content document instead of a `#subdoc-root` subtree.
+`Broiler.Layout` gained a neutral `CssBox.IsNestedBrowsingContextRoot` flag; `LayoutNestedBrowsingContexts`
+keys off that flag rather than `SourceElement.TagName == "#subdoc-root"`. A `Func<DomElement,DomDocument?>`
+content-document resolver is threaded from the bridge through `ILayoutView.GetGeometry` →
+`HeadlessLayoutView` → `HtmlContainer`/`HtmlContainerInt.ContentDocumentResolver` →
+`DomParser.GenerateCssTree` → `HtmlParser.ParseDocument`/`AppendCanonicalNode`, which — for an element the
+resolver maps to a content document — synthesises the sub-viewport box (flag set, no `SourceElement`) and
+projects the referenced document's tree into it. So a subframe element still reports real
+`getBoundingClientRect` composed into the main frame, from a document that is no longer in `_document`.
+`HeadlessLayoutView` bypasses its `(document,version,viewport,baseUrl)` snapshot cache when a resolver is
+present, because a severed sub-document has its own `DomDocument.Version` invisible to the main document's.
+
+`Broiler.Layout` and `Broiler.HTML` are the parent-repo / submodule this touched; the cascade is
+unaffected because `SharedRendererCascade.BuildEngine` uses the document only for a null-check (rules come
+from the globally-collected `styleSet` + each element's own inline/ancestor chain), and
+`CascadeParseStyles`/`CascadeApplyStyles` walk `box.Boxes`, so a separate content `DomDocument` cascades
+identically. `OwnerDocRoot` was left exactly as before (regime-A parsed nodes still unadopted) to preserve
+behaviour — the reverse-map lookups tolerate the resulting nulls, giving parity.
+
+Behaviour-preserving; no public-API change to the bridge (the maps/resolver are internal; the widened
+`ILayoutView`/`HtmlContainer` members are renderer-side). Tests:
+`Broiler.Cli.Tests/SubDocumentSeverMigrationTests.cs` (sentinel absent from the serialized tree,
+`contentDocument` DOM intact, subframe geometry composed, `srcdoc` serialization round-trip, `srcdoc`
+reassignment rebuild). Regression check vs the merge-base: the **four oracle tests the prior attempt
+regressed now pass** (`Todo28_Iframe_ZeroSize_No_Visual_Box`, the two script-assigned-iframe-position
+`ScrollIntoView` tests, `SubframeElement_GetBoundingClientRect_Is_Composed_Into_Main_Frame`); the
+sub-document/iframe/frames/messaging (138), HtmlDomInterface/serialization/geometry/anchor (134), and
+Acid3/DOM/traversal/shadow/migration (506) suites show **zero regressions** — every failure
+(HttpSubResource real-HTTP iframe, zoom/iframe-srcdoc serialization, Acid3 score/border/cascade/NodeIterator
+pixel, the standing `Range_GetBoundingClientRect` headless-geometry) reproduces identically with all
+changes stashed.
+
+**Residual follow-up (not blocking):** the `#subdoc-root` *element* is fully eliminated (zero creation
+sites), but a handful of now-inert defensive `#subdoc-root` tag guards remain (`Utilities.IsSubDocRoot`
+and its two exclusion call sites, the `Css.cs` style-scope/collect guards, `DomBridge.CollectWindowFrames`,
+and the `DomBridge.Serialization` `GetKind`/skip arms). They can never fire (no such element is ever
+built) and are left as a trivial dead-code removal so this change stays a focused, behaviour-preserving
+sever. **P4.4c** (eliminate `OwnerDocRoot`) is now unblocked (regime-A roots are canonical
+`DomDocument`s); the remaining `#document` sentinel work is independent.
 
 Status: **P4.3 completed** 2026-07-13 (same branch) — work item 1, second of four sentinels. The
 `#document-fragment` sentinel element is replaced by the canonical `Broiler.Dom.DomDocumentFragment`.

--- a/src/Broiler.Cli.Tests/DomBridgeSessionLifetimeTests.cs
+++ b/src/Broiler.Cli.Tests/DomBridgeSessionLifetimeTests.cs
@@ -220,7 +220,8 @@ public sealed class DomBridgeSessionLifetimeTests
         public int DisposeCount { get; private set; }
 
         public IReadOnlyDictionary<DomElement, BoxGeometry> GetGeometry(
-            DomDocument document, SizeF viewport, string baseUrl)
+            DomDocument document, SizeF viewport, string baseUrl,
+            Func<DomElement, DomDocument?>? contentDocumentResolver = null)
         {
             GetGeometryCount++;
             return Empty;

--- a/src/Broiler.Cli.Tests/SubDocumentSeverMigrationTests.cs
+++ b/src/Broiler.Cli.Tests/SubDocumentSeverMigrationTests.cs
@@ -1,0 +1,137 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Guards the HtmlBridge complexity-reduction roadmap Phase 4 item 1, stage P4.4b: the MATERIALIZED
+/// nested browsing contexts (regime A — an <c>&lt;iframe&gt;</c>/<c>&lt;object&gt;</c>/<c>&lt;frame&gt;</c>
+/// sub-document) are severed from the script-visible <c>_document</c> tree. The sub-document is now a
+/// canonical <see cref="Broiler.Dom.DomDocument"/> referenced through a container↔document map, no longer
+/// an in-tree <c>#subdoc-root</c> sentinel child of the container. The box builder projects the referenced
+/// document into the render box tree via a content-document resolver so subframe geometry still composes
+/// into the main coordinate frame (the cross-layer fix that unblocked this sever). These characterizations
+/// pin: the sentinel is gone from the tree; <c>contentDocument</c> still works; subframe geometry still
+/// composes; and <c>srcdoc</c> serialization + reassignment still round-trip through the map.
+/// </summary>
+public sealed class SubDocumentSeverMigrationTests
+{
+    private const string FrameHost = """
+<!DOCTYPE html>
+<html><body style="margin:0; width:2000px; height:2000px;">
+  <iframe id="fr"></iframe>
+</body></html>
+""";
+
+    private static DomBridge AttachFrameHost(out JSContext context)
+    {
+        context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, FrameHost, "file:///test.html");
+        bridge.FireWindowLoadEvent();
+        return bridge;
+    }
+
+    [Fact]
+    public void Materialized_SubDocument_Is_Not_A_SubdocRoot_Child_In_The_Serialized_Tree()
+    {
+        using var bridge = AttachFrameHost(out var context);
+
+        // Build the sub-document by accessing contentDocument, then serialize the main document.
+        context.Eval("""
+            (() => {
+                var f = document.getElementById('fr');
+                f.srcdoc = '<!DOCTYPE html><html><body><p id="p">hi</p></body></html>';
+                return f.contentDocument.getElementById('p').textContent;
+            })()
+            """);
+
+        var html = bridge.SerializeToHtml();
+
+        // The severed sub-document must not appear as a #subdoc-root element inside the main tree,
+        // and the iframe's own sub-document content (the <p>) must not leak into the main document.
+        Assert.DoesNotContain("#subdoc-root", html);
+        Assert.DoesNotContain("subdoc", html);
+    }
+
+    [Fact]
+    public void ContentDocument_Still_Exposes_The_SubDocument_Dom()
+    {
+        using var bridge = AttachFrameHost(out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var f = document.getElementById('fr');
+                f.srcdoc = '<!DOCTYPE html><html><body><p id="p">hi</p></body></html>';
+                var doc = f.contentDocument;
+                return doc.nodeType + '|' + doc.getElementById('p').textContent + '|' +
+                       doc.body.tagName.toLowerCase();
+            })()
+            """);
+
+        // nodeType 9 (Document), the <p> is found, and body resolves.
+        Assert.Equal("9|hi|body", result.ToString());
+    }
+
+    [Fact]
+    public void Subframe_Element_Geometry_Composes_Into_The_Main_Frame_After_Sever()
+    {
+        using var bridge = AttachFrameHost(out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var iframe = document.getElementById('fr');
+                iframe.style.cssText = 'position:absolute; left:100px; top:300px; width:400px; height:300px; border:0';
+                iframe.srcdoc = '<!DOCTYPE html><html><body style="margin:0"><div id="target" style="position:absolute; left:30px; top:40px; width:50px; height:50px;"></div></body></html>';
+                var r = iframe.contentDocument.getElementById('target').getBoundingClientRect();
+                return r.left + ',' + r.top + ',' + r.width + ',' + r.height;
+            })()
+            """);
+
+        // iframe content origin (100,300) + target inset (30,40) = (130,340), size 50x50 — the geometry
+        // is composed from the referenced content document, not an in-tree #subdoc-root subtree.
+        Assert.Equal("130,340,50,50", result.ToString());
+    }
+
+    [Fact]
+    public void SrcDoc_Serialization_RoundTrips_Through_The_Map()
+    {
+        using var bridge = AttachFrameHost(out var context);
+
+        context.Eval("""
+            (() => {
+                var f = document.getElementById('fr');
+                f.srcdoc = '<!DOCTYPE html><html><body><p id="p">hello</p></body></html>';
+                // Mutate the sub-document so the serialized srcdoc reflects live content, not the raw attribute.
+                f.contentDocument.getElementById('p').textContent = 'mutated';
+                return 0;
+            })()
+            """);
+
+        var html = bridge.SerializeToHtml();
+
+        // The iframe carries a srcdoc attribute serialized from the live (severed) sub-document.
+        Assert.Contains("srcdoc", html);
+        Assert.Contains("mutated", html);
+    }
+
+    [Fact]
+    public void Reassigning_SrcDoc_Rebuilds_The_Content_Document()
+    {
+        using var bridge = AttachFrameHost(out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var f = document.getElementById('fr');
+                f.srcdoc = '<!DOCTYPE html><html><body><p id="a">first</p></body></html>';
+                var first = f.contentDocument.getElementById('a').textContent;
+                f.srcdoc = '<!DOCTYPE html><html><body><p id="b">second</p></body></html>';
+                var oldGone = (f.contentDocument.getElementById('a') === null);
+                var second = f.contentDocument.getElementById('b').textContent;
+                return first + '|' + oldGone + '|' + second;
+            })()
+            """);
+
+        Assert.Equal("first|true|second", result.ToString());
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -944,8 +944,7 @@ public sealed partial class DomBridge
             return null;
         }
 
-        var subDocumentRoot = ChildElements(element).FirstOrDefault(child =>
-            string.Equals(child.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase));
+        var subDocumentRoot = GetContentDocument(element);
         if (subDocumentRoot == null || subDocumentRoot.ChildNodes.Count == 0)
             return null;
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -678,9 +678,10 @@ public sealed partial class DomBridge
             string.Equals(docRoot.TagName, "#document", StringComparison.OrdinalIgnoreCase))
             return (_viewportWidth, _viewportHeight);
 
-        // Walk up from docRoot to find the containing iframe/object element
-        // The docRoot is typically a #subdoc-root child of the iframe element
-        var parent = ParentEl(docRoot);
+        // docRoot is a severed sub-document's documentElement (<html>, post-P4.4b); its parent is
+        // the content DomDocument. Recover the containing iframe/object via the reverse map to read
+        // its CSS dimensions as the sub-viewport size (was ParentEl(#subdoc-root)).
+        var parent = GetFrameForContentDocument(docRoot?.ParentNode);
         if (parent != null && !parent.TagName.StartsWith("#", StringComparison.Ordinal))
         {
             // parent is the iframe/object element — check its style for dimensions

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -1524,13 +1524,12 @@ public sealed partial class DomBridge
         return string.Equals(props.GetValueOrDefault("position"), "fixed", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static DomElement? GetOuterFrameElement(DomElement documentElement)
+    private DomElement? GetOuterFrameElement(DomElement documentElement)
     {
-        var docRoot = ParentEl(documentElement);
-        return docRoot != null &&
-               string.Equals(docRoot.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase)
-            ? ParentEl(docRoot)
-            : null;
+        // A sub-document's documentElement (<html>) now hangs off its canonical DomDocument
+        // (the severed content document, P4.4b); recover the owning frame via the reverse map
+        // (was ParentEl(ParentEl(<html>)) through the #subdoc-root element).
+        return GetFrameForContentDocument(documentElement?.ParentNode);
     }
 
     private DomElement? GetOuterScrollContinuationElement(DomElement scrollContainer)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SharedLayoutGeometry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SharedLayoutGeometry.cs
@@ -87,7 +87,10 @@ public sealed partial class DomBridge
         {
             var document = GetRenderDocument();
             var viewport = new SizeF(_viewportWidth, _viewportHeight);
-            return LayoutView.GetGeometry(document, viewport, _pageUrl);
+            // P4.4b: a materialised iframe/object sub-document is no longer an in-tree
+            // #subdoc-root child — hand the layout view the resolver so it projects each
+            // referenced content document as a sub-viewport and composes its geometry.
+            return LayoutView.GetGeometry(document, viewport, _pageUrl, ResolveContentDocumentForRender);
         }
         catch
         {
@@ -113,7 +116,8 @@ public sealed partial class DomBridge
     {
         public static readonly NullLayoutView Instance = new();
         public IReadOnlyDictionary<DomElement, BoxGeometry> GetGeometry(
-            DomDocument document, SizeF viewport, string baseUrl) => EmptySharedGeometry;
+            DomDocument document, SizeF viewport, string baseUrl,
+            Func<DomElement, DomDocument?>? contentDocumentResolver = null) => EmptySharedGeometry;
         public void Dispose() { }
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -21,14 +21,44 @@ public sealed partial class DomBridge
     private readonly HashSet<DomElement> _objectLoadFailures = [];
     private readonly HashSet<DomElement> _onloadFired = [];
 
+    // ── Phase 4 (P4.4b): regime-A nested-browsing-context sever ──────────────
+    // The materialised sub-document of an <iframe>/<object>/<frame> is no longer an in-tree
+    // #subdoc-root child of the container; it is a canonical DomDocument referenced through
+    // these maps. The render path projects it into the box tree via the content-document
+    // resolver (see ResolveContentDocumentForRender), and the reverse map recovers a
+    // sub-document's owning frame where the old code walked ParentEl(#subdoc-root).
+    private readonly Dictionary<DomElement, DomDocument> _contentDocuments = [];
+    private readonly Dictionary<DomDocument, DomElement> _documentContainers = [];
+
+    private DomDocument? GetContentDocument(DomElement containerElement) =>
+        _contentDocuments.TryGetValue(containerElement, out var document) ? document : null;
+
+    /// <summary>The frame element a severed sub-document belongs to, or null for the main /
+    /// a detached (createDocument) document. Replaces <c>ParentEl(#subdoc-root)</c>.</summary>
+    private DomElement? GetFrameForContentDocument(DomNode? docRoot) =>
+        docRoot is DomDocument document && _documentContainers.TryGetValue(document, out var frame)
+            ? frame
+            : null;
+
+    private void LinkContentDocument(DomElement containerElement, DomDocument document)
+    {
+        _contentDocuments[containerElement] = document;
+        _documentContainers[document] = containerElement;
+    }
+
+    /// <summary>The content-document resolver handed to the layout view (P4.4b): maps a
+    /// nested-browsing-context container to its severed sub-document so the box builder
+    /// projects it as a sub-viewport and composes its geometry into the main frame.</summary>
+    private DomDocument? ResolveContentDocumentForRender(DomElement containerElement) =>
+        GetContentDocument(containerElement);
+
     private void InvalidateCachedSubDocument(DomElement containerElement)
     {
-        var existingDocRoot = ChildElements(containerElement).FirstOrDefault(child =>
-            string.Equals(child.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase));
-        if (existingDocRoot != null)
+        if (_contentDocuments.TryGetValue(containerElement, out var existingDocument))
         {
-            RemoveElementsRecursive(existingDocRoot);
-            RemoveChildFrom(containerElement, existingDocRoot);
+            RemoveElementsRecursive(existingDocument);
+            _documentContainers.Remove(existingDocument);
+            _contentDocuments.Remove(containerElement);
         }
 
         _subDocumentCache.Remove(containerElement);
@@ -136,8 +166,7 @@ public sealed partial class DomBridge
 
         var executeHtmlScripts = false;
         string? htmlToExecute = null;
-        var docRoot = ChildElements(containerElement).FirstOrDefault(c =>
-            string.Equals(c.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase));
+        DomDocument? docRoot = GetContentDocument(containerElement);
         if (docRoot == null)
         {
             if (string.Equals(containerElement.TagName, "iframe", StringComparison.OrdinalIgnoreCase) &&
@@ -324,14 +353,10 @@ public sealed partial class DomBridge
         SetElementScrollOffsetsWithBehavior(scrollingElement, left, top, relative: relative, clamp: false, behavior: behavior);
     }
 
-    private static DomElement? GetSubDocumentScrollingElement(DomElement containerElement)
+    private DomElement? GetSubDocumentScrollingElement(DomElement containerElement)
     {
-        var docRoot = ChildElements(containerElement).FirstOrDefault(c =>
-            string.Equals(c.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase));
-        if (docRoot == null)
-            return null;
-
-        return ChildElements(docRoot).FirstOrDefault(c => !IsText(c) && !c.TagName.StartsWith('#'));
+        var document = GetContentDocument(containerElement);
+        return document == null ? null : GetDocumentElement(document);
     }
 
     private static DomElement? FindBodyElement(DomElement documentElement) =>
@@ -341,19 +366,21 @@ public sealed partial class DomBridge
 
     private JSObject? GetParentWindowForSubDocument(DomElement containerElement)
     {
-        var ownerDocRoot = GetElementRuntimeState(containerElement).OwnerDocRoot;
-        if (ownerDocRoot != null && ParentEl(ownerDocRoot) != null && !ParentEl(ownerDocRoot).TagName.StartsWith('#'))
-            return GetOrCreateSubWindow(ParentEl(ownerDocRoot));
+        // The container's owning document root is a severed sub-document DomDocument when the
+        // container is itself nested in another frame; recover that frame via the reverse map
+        // (was ParentEl(#subdoc-root)).
+        var parentFrame = GetFrameForContentDocument(GetElementRuntimeState(containerElement).OwnerDocRoot);
+        if (parentFrame != null)
+            return GetOrCreateSubWindow(parentFrame);
 
         return _windowJSObject;
     }
 
     private string GetInheritedSubDocumentBaseUrl(DomElement containerElement)
     {
-        var ownerDocRoot = GetElementRuntimeState(containerElement).OwnerDocRoot;
-        if (ownerDocRoot != null && ParentEl(ownerDocRoot) != null &&
-            !ParentEl(ownerDocRoot).TagName.StartsWith('#') &&
-            _subDocumentBaseUrlCache.TryGetValue(ParentEl(ownerDocRoot), out var parentBaseUrl) &&
+        var parentFrame = GetFrameForContentDocument(GetElementRuntimeState(containerElement).OwnerDocRoot);
+        if (parentFrame != null &&
+            _subDocumentBaseUrlCache.TryGetValue(parentFrame, out var parentBaseUrl) &&
             !string.IsNullOrWhiteSpace(parentBaseUrl))
         {
             return parentBaseUrl;
@@ -533,14 +560,12 @@ public sealed partial class DomBridge
     /// <summary>
     /// Creates a minimal empty sub-document structure (html > head + body).
     /// </summary>
-    private DomElement BuildEmptySubDocument(DomElement containerElement)
+    private DomDocument BuildEmptySubDocument(DomElement containerElement)
     {
-        var docRoot = CreateBridgeElement("#subdoc-root");
-        SetParent(docRoot, containerElement);
+        var document = CreateBrowsingContextDocument();
 
         var htmlEl = CreateBridgeElement("html");
-        SetParent(htmlEl, docRoot);
-        docRoot.AppendChild(htmlEl);
+        document.AppendChild(htmlEl);
 
         var headEl = CreateBridgeElement("head");
         SetParent(headEl, htmlEl);
@@ -550,23 +575,21 @@ public sealed partial class DomBridge
         SetParent(bodyEl, htmlEl);
         htmlEl.AppendChild(bodyEl);
 
-        InsertChildAt(containerElement, 0, docRoot);
+        LinkContentDocument(containerElement, document);
 
-        return docRoot;
+        return document;
     }
 
     /// <summary>
     /// Creates a sub-document with plain text content wrapped in a <c>&lt;pre&gt;</c> element.
     /// Used for <c>text/plain</c> resources.
     /// </summary>
-    private DomElement BuildSubDocumentWithText(string textContent, DomElement containerElement)
+    private DomDocument BuildSubDocumentWithText(string textContent, DomElement containerElement)
     {
-        var docRoot = CreateBridgeElement("#subdoc-root");
-        SetParent(docRoot, containerElement);
+        var document = CreateBrowsingContextDocument();
 
         var htmlEl = CreateBridgeElement("html");
-        SetParent(htmlEl, docRoot);
-        docRoot.AppendChild(htmlEl);
+        document.AppendChild(htmlEl);
 
         var headEl = CreateBridgeElement("head");
         SetParent(headEl, htmlEl);
@@ -585,9 +608,9 @@ public sealed partial class DomBridge
         SetParent(textNode, preEl);
         preEl.AppendChild(textNode);
 
-        InsertChildAt(containerElement, 0, docRoot);
+        LinkContentDocument(containerElement, document);
 
-        return docRoot;
+        return document;
     }
 
     /// <summary>
@@ -816,21 +839,19 @@ public sealed partial class DomBridge
     /// <summary>
     /// Builds a sub-document tree from fetched HTML content.
     /// </summary>
-    private DomElement BuildSubDocumentFromHtml(string html, DomElement containerElement)
+    private DomDocument BuildSubDocumentFromHtml(string html, DomElement containerElement)
     {
-        var docRoot = CreateBridgeElement("#subdoc-root");
-        SetParent(docRoot, containerElement);
+        var document = CreateBrowsingContextDocument();
 
         var (parsedRoot, allElements, _) = BuildDocumentTree(html);
 
         // parsedRoot is the <html> element itself (HtmlTreeBuilder returns it directly).
-        // Move it under #subdoc-root as the documentElement.
-        SetParent(parsedRoot, docRoot);
-        docRoot.AppendChild(parsedRoot);
+        // Append it as the sub-document's documentElement (a canonical DomDocument child).
+        document.AppendChild(parsedRoot);
 
-        InsertChildAt(containerElement, 0, docRoot);
+        LinkContentDocument(containerElement, document);
 
-        return docRoot;
+        return document;
     }
 
     // RF-BRIDGE-1c Phase F (F3c part 2d): unregister the whole node subtree from the bridge's
@@ -1227,10 +1248,9 @@ public sealed partial class DomBridge
     /// For XHTML with valid namespace, also executes embedded scripts.
     /// XML well-formedness errors result in an empty document.
     /// </summary>
-    private DomElement BuildSubDocumentFromXml(string xmlContent, string contentType, DomElement containerElement)
+    private DomDocument BuildSubDocumentFromXml(string xmlContent, string contentType, DomElement containerElement)
     {
-        var docRoot = CreateBridgeElement("#subdoc-root");
-        SetParent(docRoot, containerElement);
+        var document = CreateBrowsingContextDocument();
 
         try
         {
@@ -1246,8 +1266,8 @@ public sealed partial class DomBridge
             var xdoc = XDocument.Parse(cleanXml);
             if (xdoc.Root == null)
             {
-                InsertChildAt(containerElement, 0, docRoot);
-                return docRoot;
+                LinkContentDocument(containerElement, document);
+                return document;
             }
 
             // Check XHTML namespace validity
@@ -1257,32 +1277,30 @@ public sealed partial class DomBridge
 
             if (isXhtml && !hasCorrectXhtmlNs)
             {
-                // Wrong XHTML namespace — create empty doc, don't execute scripts
-                var emptyDoc = BuildEmptySubDocument(containerElement);
-                // Remove the docRoot we already created since BuildEmptySubDocument creates its own
-                return emptyDoc;
+                // Wrong XHTML namespace — create empty doc, don't execute scripts. It links
+                // the container to its own document.
+                return BuildEmptySubDocument(containerElement);
             }
 
             // Build DOM tree from XML
             var rootEl = BuildDomElementFromXElement(xdoc.Root);
-            SetParent(rootEl, docRoot);
-            docRoot.AppendChild(rootEl);
+            document.AppendChild(rootEl);
 
-            InsertChildAt(containerElement, 0, docRoot);
+            LinkContentDocument(containerElement, document);
 
             // Execute scripts in XHTML documents with correct namespace
             if (isXhtml && hasCorrectXhtmlNs)
             {
-                ExecuteSubDocumentScripts(docRoot);
+                ExecuteSubDocumentScripts(rootEl);
             }
         }
         catch (System.Xml.XmlException)
         {
             // XML well-formedness error — return empty document, don't execute scripts
-            InsertChildAt(containerElement, 0, docRoot);
+            LinkContentDocument(containerElement, document);
         }
 
-        return docRoot;
+        return document;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Completes **P4.4b** of the [HtmlBridge complexity-reduction roadmap](docs/roadmap/htmlbridge-complexity-reduction-roadmap.md) — the regime-A `<iframe>`/`<object>`/`<frame>` sever that was previously *"blocked below the bridge"*. This unblocks the Phase-3 SubDocuments/Frames feature module (its script-visible tree is now sentinel-free) and unblocks **P4.4c** (regime-A roots are now canonical `DomDocument`s).

A materialized sub-document is no longer an in-tree `#subdoc-root` sentinel child of the container. It is a canonical `Broiler.Dom.DomDocument` referenced through container↔document maps, and the renderer lays out that **referenced** document so subframe geometry still composes into the main coordinate frame. This is the cross-layer fix the earlier blocker called for — the prior bridge-only attempt was reverted because `#subdoc-root` was load-bearing for layout.

## Changes

**`Broiler.Layout`**
- New neutral `CssBox.IsNestedBrowsingContextRoot` flag; `LayoutNestedBrowsingContexts` keys off it instead of `SourceElement.TagName == "#subdoc-root"`.
- `ILayoutView.GetGeometry` gains an optional content-document resolver.

**`Broiler.HTML` submodule** (pointer bumped to `3c4345f`; see Broiler-Platform/Broiler.HTML#207)
- Box builder projects a referenced content document as a sub-viewport box; resolver threaded through `HeadlessLayoutView` / `HtmlContainer(Int)` / `DomParser` / `HtmlParser`.

**Bridge**
- The 4 `BuildSubDocument*` methods mint a canonical `DomDocument` in `_contentDocuments`/`_documentContainers` instead of a `#subdoc-root` tree child.
- Forward-map lookups (`GetOrCreateSubDocument`, `InvalidateCachedSubDocument`, `GetSubDocumentScrollingElement`, `TrySerializeCurrentSrcDoc`) and the three `ParentEl(#subdoc-root)` reverse-lookups (`GetOuterFrameElement`, `GetParentWindowForSubDocument`/`GetInheritedSubDocumentBaseUrl`, `GetViewportForDocRoot`) rewired to the maps.
- `BuildSharedGeometrySnapshot` hands the resolver to the layout view.

## Behaviour / design notes

- `OwnerDocRoot` is left exactly as before (regime-A parsed nodes stay unadopted); the reverse-map lookups tolerate the resulting nulls, giving parity.
- The `#subdoc-root` **element** has zero creation sites left; a handful of now-inert `#subdoc-root` tag guards remain and are flagged in the roadmap as a trivial dead-code follow-up.
- `HeadlessLayoutView` bypasses its `(document, version, viewport, baseUrl)` snapshot cache when a resolver is present, because a severed sub-document has its own `DomDocument.Version` invisible to the main document's.

## Testing

- New pins: `Broiler.Cli.Tests/SubDocumentSeverMigrationTests.cs` (5) — sentinel absent from the serialized tree, `contentDocument` intact, subframe geometry composed, `srcdoc` round-trip + reassignment rebuild.
- The **four oracle tests the prior attempt regressed now pass** (`SubframeElement_GetBoundingClientRect_Is_Composed_Into_Main_Frame`, the two script-assigned-iframe `ScrollIntoView` tests, `Todo28_Iframe_ZeroSize`).
- **Zero regressions** across ~880 tests (sub-document/iframe/frames, DOM-interface/serialization/geometry/anchor, Acid3/DOM/traversal/shadow, scroll/hit-test/CSSOM/dialog/position/selectors); every failure reproduces identically with all changes stashed (real-HTTP iframe, zoom/srcdoc serialization, Acid3 pixel/score, and the standing `Range_GetBoundingClientRect` headless-geometry failure).

> [!NOTE]
> Requires the `Broiler.HTML` submodule PR (Broiler-Platform/Broiler.HTML#207) — the pointer bump in this PR references its commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)