### PR TITLE
HtmlBridge Phase 4: complete item 1 — remove dead #subdoc-root guards (P4.11) and eliminate the OwnerDocRoot parallel field (P4.4c)

### DIFF
--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -860,6 +860,50 @@ Exit criteria:
 
 ### Phase 4 - eliminate parallel DOM state
 
+Status: **P4.4c completed** 2026-07-14 (branch `htmlbridge-phase4-remove-subdocroot-guards`) — **work item 1:
+eliminate the `OwnerDocRoot` parallel-state field.** `ElementRuntimeState.OwnerDocRoot` (a per-node
+back-reference to the owning browsing-context root — null for main-document nodes, the sub-document root
+for sub-document nodes) shadowed the canonical owner-document. It existed because every bridge node is
+minted from the main `_document` (the `CreateBridgeElement` funnel), so canonical `node.OwnerDocument` is
+uniformly the main document even for sub-document nodes. P4.4b unblocked its removal by making a
+(sub-)document root a canonical `Broiler.Dom.DomDocument`: a node's owning document is now **derived**, not
+stored —
+
+- **Connected nodes:** the new `DomBridge.GetOwningDocument(node)` returns the absolute canonical tree root
+  (a `DomDocument` after the sever). This makes the four readers (`ownerDocument` getter, hit-test viewport
+  check, and the two sub-window/base-URL frame recoveries) tree-derived, and lets the subtree-propagation
+  helper `AdoptSubtreeIntoDocument` (and its five insertion call sites + the recursive walk) be **deleted**
+  outright — connected nodes no longer need eager owner-root propagation.
+- **Detached `createElement` nodes:** a sub-document's `document.createElement`/`createTextNode`/… returns a
+  *detached* node whose owner a tree-walk can't see; those are now adopted into their content document via
+  the public `DomDocument.AdoptNode` (a no-op `RemoveChild` on the parentless node), so canonical
+  `node.OwnerDocument` — `GetOwningDocument`'s detached fallback — reports the sub-document. This replaces the
+  `ISubDocumentHost.SetOwnerDocRoot` seam with `AdoptDetachedNode`. **No submodule change** was needed (the
+  connected-node case is tree-derived; the detached case uses the existing public `AdoptNode`).
+- The ~28 write sites collapse: the `createDocument`/`createHTMLDocument` structural writers (Registration +
+  SubDocumentBinding.Implementation) and the shadow-root inheritance are simply dropped (those nodes are
+  connected via `AppendChild`/`SetParent`, so tree-walk covers them).
+
+**One regression found and fixed in-slice** (a genuine behaviour dependency, not a rename): the hit-test
+`DocumentHasViewport` check returned `true` for regime-A iframe content precisely *because* those nodes
+carried a null `OwnerDocRoot` (P4.4b left regime-A nodes unadopted), so the content document's
+`CreateBrowsingContextDocument` `HasViewport=false` marker — shared with detached programmatic documents —
+was never consulted. With ownership now tree-derived, that marker became live and suppressed iframe
+hit-testing (`GoogleSearchPolyfillTests.Document_HitTesting_Uses_Html_But_Not_Body_For_Iframe_Viewport_Fallback`).
+Fixed by distinguishing rendered nested browsing contexts (main document, or a content document reachable
+through a container frame in the `_documentContainers` map) from detached programmatic documents
+(`createDocument`/`createHTMLDocument`, which have no frame and keep `HasViewport=false`); `DocumentHasViewport`
+became an instance method to consult the frame map. Behaviour-preserving; no public-API change (the field,
+helper and host seam are all internal). Tests: `Broiler.Cli.Tests/OwnerDocRootRemovalTests.cs` (reflection
+guards that the field + `AdoptSubtreeIntoDocument` are gone and `GetOwningDocument` is present; `ownerDocument`
+characterizations across main / detached-main-created / sub-document connected / sub-document detached-created
+/ iframe-content regimes; and the iframe-content hit-test viewport guard). Regression check vs the P4.11
+baseline: the SubDocument / Iframe / Frame / ShadowDom / OwnerDocument / CrossDocument / HtmlDomInterface /
+DomImplementation / GoogleSearchPolyfill suites are an **identical** failure set with the change stashed
+(the standing real-HTTP `Iframe_*` and zoom/srcdoc serialization failures), and the wider DomEdgeCase /
+Namespace / Attributes / DomTraversal / Acid3Phase4 / DomEvents / sentinel-migration sweep shows only the
+standing headless `Range_GetBoundingClientRect` failure → zero regressions.
+
 Status: **P4.11 completed** 2026-07-14 (branch `htmlbridge-phase4-remove-subdocroot-guards`) — **work item 1,
 final cleanup: delete the now-inert `#subdoc-root` tag-name special cases.** P4.4b severed the materialized
 nested browsing context from the `_document` tree (a sub-document is a canonical `Broiler.Dom.DomDocument`
@@ -898,8 +942,8 @@ are now removed.** The remaining Phase 4 residue is unchanged and still blocked/
 item 2's full inline-style dict elimination (P4.7 shipped the script-observable write-through slice; the
 ~200-site dict rewrite is deferred), item 4/5's submodule-push-gated promotions (`IsEqualNode` P4.9,
 `CommonAncestorWith` P4.10) and the `GetNodesInRange` / `DomRange`-stringifier / `Normalize` / `CloneDomElement`
-swaps blocked by regime-A layout coupling or side-effect coupling, and P4.4c (`OwnerDocRoot`) which still needs
-regime-A content-node adoption.
+swaps blocked by regime-A layout coupling or side-effect coupling. (P4.4c `OwnerDocRoot` — the last independent
+in-repo residue — is now also done; see the P4.4c entry above.)
 
 Status: **P4.10 prepared as a submodule patch** 2026-07-14 (same branch) — **work items 4/5: promote the
 nearest-common-ancestor tree query to canonical `Broiler.Dom.DomNode.CommonAncestorWith`.** The bridge's

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -860,6 +860,47 @@ Exit criteria:
 
 ### Phase 4 - eliminate parallel DOM state
 
+Status: **P4.11 completed** 2026-07-14 (branch `htmlbridge-phase4-remove-subdocroot-guards`) — **work item 1,
+final cleanup: delete the now-inert `#subdoc-root` tag-name special cases.** P4.4b severed the materialized
+nested browsing context from the `_document` tree (a sub-document is a canonical `Broiler.Dom.DomDocument`
+referenced through a container↔document map, never an in-tree `#subdoc-root` sentinel child) and left the
+element with **zero creation sites**, so every remaining `IsSubDocRoot` guard and `"#subdoc-root"` TagName
+check across the bridge became dead code — provably unreachable, never firing. This removes them all: the
+`IsSubDocRoot(DomElement)` (`Utilities.cs`) and `IsSubDocRootNode(DomNode)` (`JsFunctionCallbacks/JsObjects.cs`)
+helpers plus their ~15 call sites — the node child/sibling navigation (`childNodes`/`firstChild`/`lastChild`/
+`nextSibling`/`previousSibling`), the element navigation (`children`/`childElementCount`/`firstElementChild`/
+`lastElementChild`/`nextElementSibling`/`previousElementSibling`), the fragment `children` view, `CollectDescendants`
+and `AdoptSubtreeIntoDocument`; the `CollectWindowFrames` recursion skip (`DomBridge.cs`); the serialization
+`GetKind` `DocumentRoot` arm and the `GetChildren` sub-document skip (`DomBridge.Serialization.cs`, which
+collapse to "always element" / "all children" now that a severed sub-document can never appear in `ChildNodes`);
+the `CollectStyleElementsInTree` and `InvalidateStyleScopeRecursive` `#subdoc` recursion guards (`Css.cs`); the
+`ToJSRootNode` `#subdoc-root` branch (`ShadowDom.cs`, whose fall-through `ToJSObject` already resolves a
+canonical `DomDocument` root to its document wrapper via the P4.6 branch); and the document-level
+`surroundContents` sentinel guard (`TraversalBinding.Range.cs`, whose `#document`/`#subdoc-root` element check
+is dead now that the document root is a canonical `DomDocument` — the canonical `SurroundContents` enforces the
+single-document-element hierarchy rule directly). The generic `#`-prefix stop in `GetDocumentRootFor` stays —
+it is still live for `#shadow-root` (the one remaining `#`-prefixed bridge element); only its stale doc comment
+was corrected. Behaviour-preserving (every removed guard was unreachable); no public-API change (all helpers
+were private). Tests: `Broiler.Cli.Tests/SubdocRootGuardRemovalTests.cs` (reflection guards that
+`IsSubDocRoot`/`IsSubDocRootNode` are gone and must not return, + node/element child-and-sibling navigation,
+`getRootNode()`, and iframe-host navigation/serialization/style-collection characterizations pinning that the
+severed sub-document neither appears in the main tree nor leaks its `<style>` into the parent cascade).
+Regression check vs the P4.10/merged baseline: the SubDocument / Range / Serialization / ShadowDom / sentinel-
+migration / KnownNodes / BrowsingContextRoot / HtmlDomInterface / DomTraversal / Acid3 / DomEvents / Attributes
+suites reproduce an **identical** failure set with the change stashed (the standing headless
+`Range_GetBoundingClientRect`, the real-HTTP `HttpSubResourceTests.Iframe_*`, the zoom/srcdoc
+`ScriptEngineExecuteTests.DomBridge_SerializeToHtml_*`, and the flaky Acid3 score/border/cascade/NodeIterator
+set) → zero regressions.
+
+**This closes the item-1 sentinel work: every `#document`/`#document-fragment`/`#doctype`/`#subdoc-root`
+fake-tag element is gone (P4.2/P4.3/P4.4a/P4.4b/P4.6) and the residual dead tag-name guards they left behind
+are now removed.** The remaining Phase 4 residue is unchanged and still blocked/gated as recorded below:
+item 2's full inline-style dict elimination (P4.7 shipped the script-observable write-through slice; the
+~200-site dict rewrite is deferred), item 4/5's submodule-push-gated promotions (`IsEqualNode` P4.9,
+`CommonAncestorWith` P4.10) and the `GetNodesInRange` / `DomRange`-stringifier / `Normalize` / `CloneDomElement`
+swaps blocked by regime-A layout coupling or side-effect coupling, and P4.4c (`OwnerDocRoot`) which still needs
+regime-A content-node adoption.
+
 Status: **P4.10 prepared as a submodule patch** 2026-07-14 (same branch) — **work items 4/5: promote the
 nearest-common-ancestor tree query to canonical `Broiler.Dom.DomNode.CommonAncestorWith`.** The bridge's
 `FindCommonAncestor(a, b)` (`Traversal.cs`) is a neutral tree walk — the deepest inclusive ancestor of

--- a/src/Broiler.Cli.Tests/OwnerDocRootRemovalTests.cs
+++ b/src/Broiler.Cli.Tests/OwnerDocRootRemovalTests.cs
@@ -1,0 +1,126 @@
+using System.Reflection;
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Guards the HtmlBridge complexity-reduction roadmap Phase 4 item 1, P4.4c: the
+/// <c>ElementRuntimeState.OwnerDocRoot</c> parallel-state field is eliminated. It shadowed the
+/// canonical owner-document (null for main-document nodes, the sub-document root for sub-document
+/// nodes). After P4.4b made a (sub-)document root a canonical <see cref="Broiler.Dom.DomDocument"/>,
+/// a node's owning document is derived from the canonical tree — a connected node's absolute root is
+/// its owning document (<c>DomBridge.GetOwningDocument</c>) — while a sub-document's detached
+/// <c>createElement</c> node is adopted into its content document (<c>DomDocument.AdoptNode</c>) so its
+/// canonical <c>ownerDocument</c> is correct without a parallel field. The subtree-propagation helper
+/// (<c>AdoptSubtreeIntoDocument</c>) is deleted with it.
+///
+/// The reflection guards assert the field and helper are gone (and must not return). The
+/// characterizations pin <c>ownerDocument</c> across every regime (main / detached-main-created /
+/// sub-document connected / sub-document detached-created / iframe content) plus iframe hit-testing,
+/// which relied on the old null-OwnerDocRoot heuristic.
+/// </summary>
+public sealed class OwnerDocRootRemovalTests
+{
+    [Fact]
+    public void ElementRuntimeState_Has_No_OwnerDocRoot_Field()
+    {
+        var ers = typeof(DomBridge).Assembly.GetType("Broiler.HtmlBridge.Dom.Runtime.ElementRuntimeState");
+        Assert.NotNull(ers);
+        Assert.Null(ers!.GetProperty("OwnerDocRoot", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
+        Assert.Null(ers.GetField("OwnerDocRoot", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
+    }
+
+    [Fact]
+    public void DomBridge_Has_No_AdoptSubtreeIntoDocument_Helper()
+    {
+        // Subtree owner-root propagation is gone: connected nodes derive their owning document from
+        // tree position. The tree-derivation helper must exist in its place.
+        Assert.Null(typeof(DomBridge).GetMethod("AdoptSubtreeIntoDocument", BindingFlags.NonPublic | BindingFlags.Static));
+        Assert.NotNull(typeof(DomBridge).GetMethod("GetOwningDocument", BindingFlags.NonPublic | BindingFlags.Static));
+    }
+
+    private static DomBridge Attach(string html, out JSContext context)
+    {
+        context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///test.html");
+        return bridge;
+    }
+
+    [Fact]
+    public void OwnerDocument_Of_Main_Document_Nodes_Is_The_Main_Document()
+    {
+        using var bridge = Attach(
+            "<!DOCTYPE html><html><body><div id=\"x\"></div></body></html>", out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var connected = document.getElementById('x').ownerDocument === document;
+                var detached = document.createElement('span').ownerDocument === document;
+                return connected + '|' + detached;
+            })()
+            """);
+
+        Assert.Equal("true|true", result.ToString());
+    }
+
+    [Fact]
+    public void OwnerDocument_Of_Programmatic_SubDocument_Nodes_Is_That_SubDocument()
+    {
+        using var bridge = Attach("<!DOCTYPE html><html><body></body></html>", out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var sub = document.implementation.createHTMLDocument('t');
+                var connected = sub.body.ownerDocument === sub;
+                var notMain = sub.body.ownerDocument !== document;
+                // A node created by (but not yet inserted into) the sub-document reports the sub-document.
+                var created = sub.createElement('div');
+                var detached = created.ownerDocument === sub;
+                return connected + '|' + notMain + '|' + detached;
+            })()
+            """);
+
+        Assert.Equal("true|true|true", result.ToString());
+    }
+
+    [Fact]
+    public void OwnerDocument_Of_Iframe_Content_Nodes_Is_The_Content_Document()
+    {
+        using var bridge = Attach(
+            "<!DOCTYPE html><html><body><iframe id=\"fr\"></iframe></body></html>", out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var f = document.getElementById('fr');
+                f.srcdoc = '<!DOCTYPE html><html><body><p id="p">hi</p></body></html>';
+                var doc = f.contentDocument;
+                var p = doc.getElementById('p');
+                return (p.ownerDocument === doc) + '|' + (p.ownerDocument !== document);
+            })()
+            """);
+
+        Assert.Equal("true|true", result.ToString());
+    }
+
+    [Fact]
+    public void Iframe_Content_HitTesting_Still_Resolves_A_Viewport()
+    {
+        // Regression guard for the old null-OwnerDocRoot heuristic: an iframe content document renders
+        // (has a viewport) and must return hits, unlike a detached programmatic document.
+        using var bridge = Attach(
+            "<!DOCTYPE html><html><body><iframe id=\"fr\"></iframe></body></html>", out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var f = document.getElementById('fr');
+                f.srcdoc = '<!DOCTYPE html><html><body><div style="height:20px"></div></body></html>';
+                var hits = f.contentDocument.elementsFromPoint(0, 5);
+                return hits.length > 0;
+            })()
+            """);
+
+        Assert.Equal("true", result.ToString());
+    }
+}

--- a/src/Broiler.Cli.Tests/SubdocRootGuardRemovalTests.cs
+++ b/src/Broiler.Cli.Tests/SubdocRootGuardRemovalTests.cs
@@ -1,0 +1,154 @@
+using System.Reflection;
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Guards the HtmlBridge complexity-reduction roadmap Phase 4 item 1 residual: the now-inert
+/// <c>#subdoc-root</c> tag-name special cases are removed. P4.4b severed the materialized nested
+/// browsing context from the <c>_document</c> tree (a sub-document is a canonical
+/// <see cref="Broiler.Dom.DomDocument"/> referenced through a container↔document map, never an in-tree
+/// <c>#subdoc-root</c> sentinel child), so every <c>IsSubDocRoot</c> guard and <c>"#subdoc-root"</c>
+/// TagName check across the bridge became dead code — the element is never built, so the checks never
+/// fire. This deletes them: the <c>IsSubDocRoot</c>/<c>IsSubDocRootNode</c> helpers, the child/sibling
+/// navigation filters, the <c>CollectWindowFrames</c> / serialization / style-scope / style-collection
+/// skips, and the document-level <c>surroundContents</c> sentinel guard.
+///
+/// The reflection guards assert the helpers are gone (and must not be reintroduced — the canonical tree,
+/// with sub-documents severed, is the single authority). The characterizations exercise the exact DOM
+/// navigation, style-collection, serialization and getRootNode paths whose <c>#subdoc-root</c> filters
+/// were removed, on both a normal tree and an iframe host, to pin behaviour-preservation.
+/// </summary>
+public sealed class SubdocRootGuardRemovalTests
+{
+    [Theory]
+    [InlineData("IsSubDocRoot")]
+    [InlineData("IsSubDocRootNode")]
+    public void DomBridge_Has_No_SubdocRoot_TagName_Helper(string methodName)
+    {
+        // The dead sentinel-tag guards must not be reintroduced: no #subdoc-root element is ever
+        // constructed (P4.4b), so any TagName check on it is unreachable.
+        var method = typeof(DomBridge).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.Null(method);
+    }
+
+    private static DomBridge Attach(string html, out JSContext context)
+    {
+        context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///test.html");
+        return bridge;
+    }
+
+    [Fact]
+    public void Node_Child_And_Sibling_Navigation_Round_Trips()
+    {
+        using var bridge = Attach(
+            "<!DOCTYPE html><html><body><ul id=\"l\"><li id=\"a\">a</li><li id=\"b\">b</li><li id=\"c\">c</li></ul></body></html>",
+            out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var l = document.getElementById('l');
+                var b = document.getElementById('b');
+                return [
+                    l.childNodes.length,            // 3 <li>
+                    l.firstChild.id,                // a
+                    l.lastChild.id,                 // c
+                    b.nextSibling.id,               // c
+                    b.previousSibling.id            // a
+                ].join('|');
+            })()
+            """);
+
+        Assert.Equal("3|a|c|c|a", result.ToString());
+    }
+
+    [Fact]
+    public void Element_Child_And_Sibling_Navigation_Round_Trips()
+    {
+        using var bridge = Attach(
+            "<!DOCTYPE html><html><body><ul id=\"l\"><li id=\"a\">a</li><li id=\"b\">b</li><li id=\"c\">c</li></ul></body></html>",
+            out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var l = document.getElementById('l');
+                var b = document.getElementById('b');
+                return [
+                    l.children.length,              // 3
+                    l.childElementCount,            // 3
+                    l.firstElementChild.id,         // a
+                    l.lastElementChild.id,          // c
+                    b.nextElementSibling.id,        // c
+                    b.previousElementSibling.id     // a
+                ].join('|');
+            })()
+            """);
+
+        Assert.Equal("3|3|a|c|c|a", result.ToString());
+    }
+
+    [Fact]
+    public void GetRootNode_Of_A_Connected_Element_Is_The_Document()
+    {
+        using var bridge = Attach(
+            "<!DOCTYPE html><html><body><div id=\"x\"></div></body></html>", out var context);
+
+        var result = context.Eval("(document.getElementById('x').getRootNode() === document)");
+
+        Assert.Equal("true", result.ToString());
+    }
+
+    [Fact]
+    public void Iframe_Host_Main_Document_Navigation_And_Serialization_Ignore_The_SubDocument()
+    {
+        using var bridge = Attach(
+            "<!DOCTYPE html><html><body><iframe id=\"fr\"></iframe><p id=\"tail\">tail</p></body></html>",
+            out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var f = document.getElementById('fr');
+                f.srcdoc = '<!DOCTYPE html><html><body><span id="inner">leak?</span></body></html>';
+                // Force the sub-document to materialize.
+                var inner = f.contentDocument.getElementById('inner').textContent;
+                var body = document.body;
+                // The severed sub-document must not appear as an extra child of <body>.
+                return [
+                    inner,                          // leak?
+                    body.childElementCount,         // 2: <iframe> + <p>
+                    body.lastElementChild.id        // tail
+                ].join('|');
+            })()
+            """);
+
+        Assert.Equal("leak?|2|tail", result.ToString());
+
+        var html = bridge.SerializeToHtml();
+        Assert.DoesNotContain("subdoc", html);
+    }
+
+    [Fact]
+    public void Style_Collection_Applies_Across_An_Iframe_Host_Without_Leaking_The_SubDocument()
+    {
+        using var bridge = Attach(
+            "<!DOCTYPE html><html><head><style>#t { color: rgb(1, 2, 3); }</style></head>" +
+            "<body><iframe id=\"fr\"></iframe><div id=\"t\">t</div></body></html>",
+            out var context);
+
+        var result = context.Eval("""
+            (() => {
+                var f = document.getElementById('fr');
+                f.srcdoc = '<!DOCTYPE html><html><head><style>#t { color: rgb(9, 9, 9); }</style></head><body></body></html>';
+                f.contentDocument; // materialize the sub-document
+                // The main document's own <style> must still resolve (style collection walks the main
+                // tree only — the sub-document's <style> must not leak into the parent cascade).
+                return window.getComputedStyle(document.getElementById('t')).color;
+            })()
+            """);
+
+        Assert.Equal("rgb(1, 2, 3)", result.ToString());
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -844,35 +844,24 @@ public sealed partial class DomBridge
 
     // RF-BRIDGE-1c Phase F (F3c part 2c): the serialization adapter is over canonical DomNode so
     // text/comment children serialize once construction flips to DomText/DomComment. GetKind keys
-    // text/comment off NodeType (holds for facade and canonical char-data), and the remaining
-    // special kinds off the facade #document-fragment/#subdoc-root/#doctype TagNames (still facade
-    // elements). GetName/GetAttributes/GetStyles are only invoked for element/doctype nodes (see
-    // HtmlSerializer.Append), so their Broiler.Dom.DomElement narrowing is always satisfied.
+    // text/comment off NodeType (holds for facade and canonical char-data) and the doctype/fragment
+    // kinds off the canonical node types; everything else is an element. GetName/GetAttributes/
+    // GetStyles are only invoked for element/doctype nodes (see HtmlSerializer.Append), so their
+    // Broiler.Dom.DomElement narrowing is always satisfied.
     private HtmlSerializationAdapter<DomNode> CreateSerializationAdapter() => new(
         GetKind: static node =>
             IsText(node) ? HtmlSerializationNodeKind.Text
             : IsComment(node) ? HtmlSerializationNodeKind.Comment
             : node is DomDocumentType ? HtmlSerializationNodeKind.DocumentType
             : node is DomDocumentFragment ? HtmlSerializationNodeKind.Fragment
-            : node is DomElement element
-                ? element.TagName.ToLowerInvariant() switch
-                {
-                    "#subdoc-root" => HtmlSerializationNodeKind.DocumentRoot,
-                    _ => HtmlSerializationNodeKind.Element
-                }
-                : HtmlSerializationNodeKind.Element,
+            : HtmlSerializationNodeKind.Element,
         GetName: static node => node is DomDocumentType docType ? docType.Name
             : node is DomElement element ? element.TagName : string.Empty,
-        // Never serialise a materialised nested-browsing-context (#subdoc-root) into
-        // its container.  A sub-document is fetched and attached to its <iframe>/
-        // <object>/<frame> so scripts can reach contentDocument and onload can fire,
-        // but it is a *separate* document — emitting it inline leaks its <style> into
-        // the parent's cascade (WPT css/CSS2/box-display/root-canvas-001, where the
-        // embedded p{background:green;height:100%} painted the whole parent green).
-        // The renderer rasterises each embedded document in isolation instead
-        // (srcdoc content is round-tripped via the srcdoc attribute).
-        GetChildren: static node => node.ChildNodes.Where(static child =>
-            !(child is DomElement childElement && string.Equals(childElement.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase))),
+        // A materialised nested-browsing-context document is no longer an in-tree child (P4.4b
+        // severed the #subdoc-root element); it is referenced off its <iframe>/<object>/<frame>
+        // container and rasterised in isolation (srcdoc content round-trips via the srcdoc
+        // attribute), so it can never appear in ChildNodes and needs no serialization skip.
+        GetChildren: static node => node.ChildNodes,
         GetAttributes: node => node is DomElement element ? GetSerializableAttributes(element) : [],
         GetStyles: static node => node is DomElement element
             ? InlineStyle(element).OrderBy(kv => HtmlSerializer.IsShorthandProperty(kv.Key) ? 0 : 1)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.SubDocumentHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.SubDocumentHost.cs
@@ -34,8 +34,15 @@ public sealed partial class DomBridge : ISubDocumentHost
 
     bool ISubDocumentHost.TryGetNodeWrapper(DomNode node, out JSObject wrapper) => _jsObjects.TryGet(node, out wrapper);
 
-    void ISubDocumentHost.SetOwnerDocRoot(DomNode node, DomNode docRoot) =>
-        GetElementRuntimeState(node).OwnerDocRoot = docRoot;
+    // Phase 4 item 1 (P4.4c): a sub-document createElement/… node is minted from the main _document
+    // and returned detached, so its canonical OwnerDocument would be the main document. Adopt it into
+    // the sub-document's content DomDocument (a no-op RemoveChild since it is parentless) so
+    // GetOwningDocument's detached fallback (node.OwnerDocument) reports the sub-document.
+    void ISubDocumentHost.AdoptDetachedNode(DomNode node, DomNode docRoot)
+    {
+        if (docRoot is DomDocument document)
+            document.AdoptNode(node);
+    }
 
     DomElement ISubDocumentHost.CreateElement(string tagName) => CreateBridgeElement(tagName);
     DomElement ISubDocumentHost.CreateElementNS(string ns, string localName) => CreateBridgeElementNS(ns, localName);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -843,8 +843,9 @@ public sealed partial class DomBridge : IDomBridgeRuntime
                     frames.Add(GetOrCreateSubWindow(child));
             }
 
-            if (!string.Equals(child.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase))
-                CollectWindowFrames(child, frames);
+            // Sub-documents are severed (P4.4b) — never in-tree children — so the walk always
+            // descends normal element children.
+            CollectWindowFrames(child, frames);
         }
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -108,24 +108,28 @@ public sealed partial class DomBridge
         if (!IsText(element) && !element.TagName.StartsWith('#'))
             InvalidateElementStyles(element);
 
+        // Sub-documents keep their own style scope, but since P4.4b severed the #subdoc-root element
+        // they are no longer in-tree children, so this walk never crosses a sub-document boundary.
         foreach (var child in ChildElements(element))
         {
-            if (!IsText(child) && !child.TagName.StartsWith("#subdoc", StringComparison.OrdinalIgnoreCase))
+            if (!IsText(child))
                 InvalidateStyleScopeRecursive(child);
         }
     }
 
     /// <summary>
-    /// Finds the document root ancestor for the given element by walking up the
-    /// parent chain. Stops at <c>#subdoc-root</c> or <c>#document</c> boundaries.
-    /// Returns the topmost node within the element's document scope.
+    /// Finds the style-scope root ancestor for the given element by walking up the
+    /// parent chain. Stops at a <c>#</c>-prefixed boundary element (a <c>#shadow-root</c>;
+    /// the document/sub-document sentinels are gone — the canonical <c>DomDocument</c> parent
+    /// is not a <c>DomElement</c>, so <see cref="ParentEl"/> already stops the walk there).
+    /// Returns the topmost element within the element's scope.
     /// </summary>
     private static DomElement GetDocumentRootFor(DomElement el)
     {
         var root = el;
         while (ParentEl(root) != null)
         {
-            // If we've reached a document root, stop here
+            // If we've reached a scope root (shadow root), stop here
             if (root.TagName.StartsWith('#'))
                 return root;
             root = ParentEl(root);
@@ -135,7 +139,9 @@ public sealed partial class DomBridge
 
     /// <summary>
     /// Recursively collects all <c>&lt;style&gt;</c> elements from a document tree.
-    /// Does not descend into sub-document boundaries (<c>#subdoc-root</c>).
+    /// Sub-documents keep their own style scope, but since P4.4b severed the
+    /// <c>#subdoc-root</c> element they are no longer in-tree children, so this walk
+    /// never crosses a sub-document boundary.
     /// </summary>
     private static void CollectStyleElementsInTree(DomElement root, List<DomElement> styleElements)
     {
@@ -148,9 +154,7 @@ public sealed partial class DomBridge
                 else if (IsExternalStylesheet(child))
                     styleElements.Add(child);
 
-                // Don't descend into sub-document roots (they have their own style scope)
-                if (!child.TagName.StartsWith("#subdoc", StringComparison.OrdinalIgnoreCase))
-                    CollectStyleElementsInTree(child, styleElements);
+                CollectStyleElementsInTree(child, styleElements);
             }
         }
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementRuntimeState.cs
@@ -24,16 +24,11 @@ internal sealed class ElementRuntimeState
     /// </summary>
     public HashSet<string> JsSetStyleProps { get; } = new(StringComparer.OrdinalIgnoreCase);
 
-    /// <summary>
-    /// The browsing-context root that owns this node's (sub)document — iframe / nested
-    /// browsing-context bookkeeping. Relocated off the <c>Broiler.Dom.DomElement</c> facade
-    /// (RF-BRIDGE-1c Phase A). Not carried across <c>cloneNode</c> (matching the prior
-    /// facade behaviour: a clone re-derives its owner on adoption). Phase 4 item 1 (P4.4a): widened
-    /// <c>DomElement?</c>→<c>DomNode?</c> so a canonical <c>DomDocument</c> browsing-context root
-    /// (createDocument/createHTMLDocument) can own its descendants, alongside the legacy
-    /// <c>#subdoc-root</c> element roots that regime-A (iframe) still uses.
-    /// </summary>
-    public DomNode? OwnerDocRoot { get; set; }
+    // Phase 4 item 1 (P4.4c): the OwnerDocRoot parallel-state field is deleted. A node's owning
+    // (sub-)document is now derived from the canonical tree (a connected node's absolute root is a
+    // Broiler.Dom.DomDocument after the P4.4b sever) or the node's canonical OwnerDocument when
+    // detached — see DomBridge.GetOwningDocument. Sub-document createElement nodes are adopted into
+    // their content document (DomDocument.AdoptNode) so their detached OwnerDocument is correct.
 
     /// <summary>
     /// The node's inline style in CSS kebab-case — the authoritative in-memory inline

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/HitTesting.cs
@@ -521,12 +521,19 @@ public sealed partial class DomBridge
         return true;
     }
 
-    private static bool DocumentHasViewport(DomElement documentElement)
+    private bool DocumentHasViewport(DomElement documentElement)
     {
-        var docRoot = GetElementRuntimeState(documentElement).OwnerDocRoot;
-        if (docRoot == null)
+        var docRoot = GetOwningDocument(documentElement);
+        // Phase 4 item 1 (P4.4c): the owning document comes from the canonical tree, not OwnerDocRoot.
+        // The main document and rendered nested browsing contexts (iframe/object/frame — reachable
+        // through a container frame in the content-document map) have a viewport. This replaces the
+        // former heuristic that relied on regime-A iframe nodes carrying a null OwnerDocRoot: those
+        // content documents share the CreateBrowsingContextDocument HasViewport=false marker with
+        // detached programmatic documents, so the frame-container test is what distinguishes them.
+        if (ReferenceEquals(docRoot, _document) || GetFrameForContentDocument(docRoot) != null)
             return true;
 
+        // A detached programmatic document (createDocument/createHTMLDocument) is viewport-less.
         return !GetElementRuntimeState(docRoot).Document.HasViewport.TryGet(out var value) ||
                value is not bool hasViewport ||
                hasViewport;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -476,10 +476,13 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetOwnerDocument057Core(DomNode node, in Arguments a)
     {
-        // For elements in sub-documents, return the sub-document JSObject
-        if (GetElementRuntimeState(node).OwnerDocRoot != null && _jsObjects.TryGetDocument(GetElementRuntimeState(node).OwnerDocRoot, out var subDoc))
+        // Phase 4 item 1 (P4.4c): the owning document is derived from the canonical tree (connected
+        // nodes) or the node's canonical OwnerDocument (detached), not a parallel OwnerDocRoot field.
+        var owner = GetOwningDocument(node);
+        // A sub-document maps to its JS document wrapper; the main document maps to the window
+        // document object.
+        if (!ReferenceEquals(owner, _document) && _jsObjects.TryGetDocument(owner, out var subDoc))
             return subDoc;
-        // For main document elements, return the main document JSObject
         return _documentJSObject ?? JSNull.Value;
     }
 
@@ -853,8 +856,9 @@ public sealed partial class DomBridge
 
         mode = string.Equals(mode, "closed", StringComparison.OrdinalIgnoreCase) ? "closed" : "open";
         var shadowRoot = CreateBridgeElement("#shadow-root");
+        // SetParent links the shadow root to its host, so GetOwningDocument derives the shadow root's
+        // owning document from the host's tree position — no OwnerDocRoot inheritance needed (P4.4c).
         SetParent(shadowRoot, element);
-        GetElementRuntimeState(shadowRoot).OwnerDocRoot = GetElementRuntimeState(element).OwnerDocRoot;
         GetElementRuntimeState(shadowRoot).Shadow.Host.Set(element);
         GetElementRuntimeState(shadowRoot).Shadow.Mode.Set(mode);
         GetElementRuntimeState(element).Shadow.Root.Set(shadowRoot);
@@ -969,7 +973,6 @@ public sealed partial class DomBridge
 
         SetParent(oldEl, null);
         SetParent(newEl, element);
-        AdoptSubtreeIntoDocument(newEl, GetElementRuntimeState(element).OwnerDocRoot);
         element.ReplaceChild(newEl, element.ChildNodes[idx]);
         bridgeForAppend.InvalidateStyleScope(element);
         NotifyChildRemoved(element, oldEl, idx, previousSibling, nextSibling);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -216,18 +216,11 @@ public sealed partial class DomBridge
         return ReferenceEquals(root, _document) ? JSBoolean.True : JSBoolean.False;
     }
 
-    /// <summary>Whether <paramref name="node"/> is a sub-document root element (only elements can be).</summary>
-    private static bool IsSubDocRootNode(DomNode node) =>
-        node is DomElement element && IsSubDocRoot(element);
-
     private JSValue JsJsObjectsGetChildNodes033Core(DomNode node, in Arguments a)
     {
         var children = new List<JSValue>();
         foreach (var child in node.ChildNodes)
-        {
-            if (!IsSubDocRootNode(child))
-                children.Add(ToJSObject(child));
-        }
+            children.Add(ToJSObject(child));
 
         return new JSArray(children);
     }
@@ -235,14 +228,14 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetFirstChild034Core(DomNode node, in Arguments a)
     {
-        var first = node.ChildNodes.FirstOrDefault(c => !IsSubDocRootNode(c));
+        var first = node.ChildNodes.FirstOrDefault();
         return first != null ? ToJSObject(first) : JSNull.Value;
     }
 
 
     private JSValue JsJsObjectsGetLastChild035Core(DomNode node, in Arguments a)
     {
-        var last = node.ChildNodes.LastOrDefault(c => !IsSubDocRootNode(c));
+        var last = node.ChildNodes.LastOrDefault();
         return last != null ? ToJSObject(last) : JSNull.Value;
     }
 
@@ -254,13 +247,7 @@ public sealed partial class DomBridge
             return JSNull.Value;
         var siblings = parent.ChildNodes;
         var idx = ChildIndexOf(parent, node);
-        for (var i = idx + 1; i < siblings.Count; i++)
-        {
-            if (!IsSubDocRootNode(siblings[i]))
-                return ToJSObject(siblings[i]);
-        }
-
-        return JSNull.Value;
+        return idx >= 0 && idx + 1 < siblings.Count ? ToJSObject(siblings[idx + 1]) : JSNull.Value;
     }
 
 
@@ -271,13 +258,7 @@ public sealed partial class DomBridge
             return JSNull.Value;
         var siblings = parent.ChildNodes;
         var idx = ChildIndexOf(parent, node);
-        for (var i = idx - 1; i >= 0; i--)
-        {
-            if (!IsSubDocRootNode(siblings[i]))
-                return ToJSObject(siblings[i]);
-        }
-
-        return JSNull.Value;
+        return idx - 1 >= 0 ? ToJSObject(siblings[idx - 1]) : JSNull.Value;
     }
 
 
@@ -802,7 +783,7 @@ public sealed partial class DomBridge
         var result = new List<JSValue>();
         foreach (var child in ChildElements(element))
         {
-            if (!IsText(child) && !IsSubDocRoot(child))
+            if (!IsText(child))
                 result.Add(ToJSObject(child));
         }
 
@@ -812,14 +793,14 @@ public sealed partial class DomBridge
 
     private JSValue JsJsObjectsGetFirstElementChild083Core(DomElement element, in Arguments a)
     {
-        var first = ChildElements(element).FirstOrDefault(c => !IsText(c) && !IsSubDocRoot(c));
+        var first = ChildElements(element).FirstOrDefault(c => !IsText(c));
         return first != null ? ToJSObject(first) : JSNull.Value;
     }
 
 
     private JSValue JsJsObjectsGetLastElementChild084Core(DomElement element, in Arguments a)
     {
-        var last = ChildElements(element).LastOrDefault(c => !IsText(c) && !IsSubDocRoot(c));
+        var last = ChildElements(element).LastOrDefault(c => !IsText(c));
         return last != null ? ToJSObject(last) : JSNull.Value;
     }
 
@@ -832,7 +813,7 @@ public sealed partial class DomBridge
         var idx = siblings.IndexOf(element);
         for (var i = idx + 1; i < siblings.Count; i++)
         {
-            if (!IsText(siblings[i]) && !IsSubDocRoot(siblings[i]))
+            if (!IsText(siblings[i]))
                 return ToJSObject(siblings[i]);
         }
 
@@ -848,7 +829,7 @@ public sealed partial class DomBridge
         var idx = siblings.IndexOf(element);
         for (var i = idx - 1; i >= 0; i--)
         {
-            if (!IsText(siblings[i]) && !IsSubDocRoot(siblings[i]))
+            if (!IsText(siblings[i]))
                 return ToJSObject(siblings[i]);
         }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Registration.cs
@@ -789,7 +789,6 @@ public sealed partial class DomBridge
                 if (kvp.Value == dtObj && kvp.Key is DomNode dtNode)
                 {
                     docRoot.AppendChild(dtNode);
-                    GetElementRuntimeState(dtNode).OwnerDocRoot = docRoot;
                     break;
                 }
             }
@@ -802,7 +801,6 @@ public sealed partial class DomBridge
                 ? CreateBridgeElement(qName)
                 : CreateBridgeElementNS(ns, qName);
             docRoot.AppendChild(docEl);
-            GetElementRuntimeState(docEl).OwnerDocRoot = docRoot;
         }
 
         return _subDocuments.BuildDocument(docRoot);
@@ -814,34 +812,30 @@ public sealed partial class DomBridge
         var title = a.Length > 0 && !a[0].IsNull && !a[0].IsUndefined ? a[0].ToString() : null;
         // Phase 4 item 1 (P4.4a): a createHTMLDocument root is a canonical DomDocument (was a
         // #subdoc-root sentinel element); doctype + <html> are appended as canonical document children.
+        // Phase 4 item 1 (P4.4c): structural nodes are appended under docRoot (a canonical
+        // DomDocument), so GetOwningDocument derives their owner from tree position — no OwnerDocRoot.
         var docRoot = CreateBrowsingContextDocument();
         var doctype = CreateBridgeDocumentType("html", string.Empty, string.Empty);
         docRoot.AppendChild(doctype);
-        GetElementRuntimeState(doctype).OwnerDocRoot = docRoot;
         // "http://www.w3.org/1999/xhtml" is the default HTML namespace the funnel applies.
         var htmlEl = CreateBridgeElement("html");
         docRoot.AppendChild(htmlEl);
-        GetElementRuntimeState(htmlEl).OwnerDocRoot = docRoot;
         var headEl = CreateBridgeElement("head");
         SetParent(headEl, htmlEl);
-        GetElementRuntimeState(headEl).OwnerDocRoot = docRoot;
         htmlEl.AppendChild(headEl);
         // Add <title> element if title argument is provided
         if (title != null)
         {
             var titleEl = CreateBridgeElement("title");
             SetParent(titleEl, headEl);
-            GetElementRuntimeState(titleEl).OwnerDocRoot = docRoot;
             headEl.AppendChild(titleEl);
             var titleText = CreateBridgeTextNode(title);
             SetParent(titleText, titleEl);
-            GetElementRuntimeState(titleText).OwnerDocRoot = docRoot;
             titleEl.AppendChild(titleText);
         }
 
         var bodyEl = CreateBridgeElement("body");
         SetParent(bodyEl, htmlEl);
-        GetElementRuntimeState(bodyEl).OwnerDocRoot = docRoot;
         htmlEl.AppendChild(bodyEl);
         return _subDocuments.BuildDocument(docRoot);
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -425,14 +425,14 @@ public sealed partial class DomBridge
             new JSFunction((in a) => JsJsObjectsInsertBefore080Core(bridgeForInsert, element, in a), "insertBefore", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        // children (read-only) — element children only (no text nodes, no #subdoc-root)
+        // children (read-only) — element children only (no text nodes)
         obj.FastAddProperty((KeyString)"children",
             new JSFunction((in a) => JsJsObjectsGetChildren081Core(element, in a), "get children"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // childElementCount (read-only)
         obj.FastAddProperty((KeyString)"childElementCount",
-            new JSFunction((in a) => new JSNumber(ChildElements(element).Count(c => !IsText(c) && !IsSubDocRoot(c))), "get childElementCount"),
+            new JSFunction((in a) => new JSNumber(ChildElements(element).Count(c => !IsText(c))), "get childElementCount"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // firstElementChild (read-only)
@@ -1096,22 +1096,22 @@ public sealed partial class DomBridge
 
         // -- ParentNode mixin (element views) --
         obj.FastAddProperty((KeyString)"children",
-            new JSFunction((in _) => new JSArray([.. ChildElements(fragment).Where(c => !IsText(c) && !IsSubDocRoot(c)).Select(c => (JSValue)ToJSObject(c))]), "get children"),
+            new JSFunction((in _) => new JSArray([.. ChildElements(fragment).Where(c => !IsText(c)).Select(c => (JSValue)ToJSObject(c))]), "get children"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddProperty((KeyString)"childElementCount",
-            new JSFunction((in _) => new JSNumber(ChildElements(fragment).Count(c => !IsText(c) && !IsSubDocRoot(c))), "get childElementCount"),
+            new JSFunction((in _) => new JSNumber(ChildElements(fragment).Count(c => !IsText(c))), "get childElementCount"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddProperty((KeyString)"firstElementChild",
             new JSFunction((in _) =>
             {
-                var first = ChildElements(fragment).FirstOrDefault(c => !IsText(c) && !IsSubDocRoot(c));
+                var first = ChildElements(fragment).FirstOrDefault(c => !IsText(c));
                 return first != null ? ToJSObject(first) : JSNull.Value;
             }, "get firstElementChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddProperty((KeyString)"lastElementChild",
             new JSFunction((in _) =>
             {
-                var last = ChildElements(fragment).LastOrDefault(c => !IsText(c) && !IsSubDocRoot(c));
+                var last = ChildElements(fragment).LastOrDefault(c => !IsText(c));
                 return last != null ? ToJSObject(last) : JSNull.Value;
             }, "get lastElementChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
@@ -57,9 +57,8 @@ public sealed partial class DomBridge
         if (ReferenceEquals(root, _document))
             return _documentJSObject ?? JSNull.Value;
 
-        if (root is DomElement rootEl && IsSubDocRoot(rootEl) && _jsObjects.TryGetDocument(rootEl, out var subDocument))
-            return subDocument;
-
+        // A severed sub-document root is a canonical DomDocument (P4.4b); ToJSObject resolves it to
+        // its document wrapper via the document-wrapper map, so no #subdoc-root special case remains.
         return ToJSObject(root);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -366,10 +366,10 @@ public sealed partial class DomBridge
 
     private JSObject? GetParentWindowForSubDocument(DomElement containerElement)
     {
-        // The container's owning document root is a severed sub-document DomDocument when the
-        // container is itself nested in another frame; recover that frame via the reverse map
-        // (was ParentEl(#subdoc-root)).
-        var parentFrame = GetFrameForContentDocument(GetElementRuntimeState(containerElement).OwnerDocRoot);
+        // The container's owning document is a severed sub-document DomDocument when the container is
+        // itself nested in another frame; recover that frame via the reverse map (P4.4c: the owning
+        // document comes from the canonical tree, was OwnerDocRoot / ParentEl(#subdoc-root)).
+        var parentFrame = GetFrameForContentDocument(GetOwningDocument(containerElement));
         if (parentFrame != null)
             return GetOrCreateSubWindow(parentFrame);
 
@@ -378,7 +378,7 @@ public sealed partial class DomBridge
 
     private string GetInheritedSubDocumentBaseUrl(DomElement containerElement)
     {
-        var parentFrame = GetFrameForContentDocument(GetElementRuntimeState(containerElement).OwnerDocRoot);
+        var parentFrame = GetFrameForContentDocument(GetOwningDocument(containerElement));
         if (parentFrame != null &&
             _subDocumentBaseUrlCache.TryGetValue(parentFrame, out var parentBaseUrl) &&
             !string.IsNullOrWhiteSpace(parentBaseUrl))
@@ -1063,7 +1063,6 @@ public sealed partial class DomBridge
         }
 
         SetParent(node, parent);
-        AdoptSubtreeIntoDocument(node, GetElementRuntimeState(parent).OwnerDocRoot);
         InsertChildAt(parent, index, node);
         if (parent is DomElement parentElement)
         {
@@ -1155,7 +1154,6 @@ public sealed partial class DomBridge
             foreach (var child in fragmentContainer.ChildNodes.ToArray())
             {
                 SetParent(child, element);
-                AdoptSubtreeIntoDocument(child, GetElementRuntimeState(element).OwnerDocRoot);
                 element.AppendChild(child);
             }
         }
@@ -1200,7 +1198,6 @@ public sealed partial class DomBridge
             foreach (var child in parsedContainer.ChildNodes.ToArray())
             {
                 SetParent(child, parent);
-                AdoptSubtreeIntoDocument(child, GetElementRuntimeState(parent).OwnerDocRoot);
                 InsertChildAt(parent, insertIndex, child);
                 NotifyChildAdded(parent, child, insertIndex);
                 insertIndex++;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -235,8 +235,6 @@ public sealed partial class DomBridge
     private DomNode? FindDomNodeByJSObject(JSObject jsObj) =>
         _jsObjects.TryGetNode(jsObj, out var node) ? node : null;
 
-    private static bool IsSubDocRoot(DomElement element) => string.Equals(element.TagName, "#subdoc-root", StringComparison.Ordinal);
-
     // Phase 4 item 5: the bridge's IsDescendant(ancestor, candidate) copy is deleted; call sites use
     // the canonical Broiler.Dom.DomNode.IsDescendantOf(ancestor) instance method (identical ancestor
     // walk; every bridge call site passes a non-null ancestor, so canonical's null-ancestor throw is
@@ -301,13 +299,10 @@ public sealed partial class DomBridge
 
         // RF-BRIDGE-1c Phase F (F3c part 2b): walk raw ChildNodes so char-data children are adopted
         // too. Behaviour-preserving on today's homogeneous tree (every child is an element).
+        // Nested browsing-context documents are no longer in-tree children (P4.4b severed the
+        // #subdoc-root element), so a subtree walk never crosses a sub-document boundary.
         foreach (var child in node.ChildNodes)
-        {
-            if (child is DomElement childElement && IsSubDocRoot(childElement))
-                continue;
-
             AdoptSubtreeIntoDocument(child, ownerDocRoot);
-        }
     }
 
     /// <summary>
@@ -486,12 +481,11 @@ public sealed partial class DomBridge
         // RF-BRIDGE-1c Phase F (F3c part 2b): walk raw ChildNodes so document-order traversal
         // includes text/comment nodes (range boundary indexing needs them). Behaviour-preserving
         // on today's homogeneous tree where every child is an element.
+        // Sub-documents are separate document trees, but since P4.4b severed the #subdoc-root
+        // element they are no longer in-tree children here, so document-order traversal never
+        // crosses a sub-document boundary.
         foreach (var child in root.ChildNodes)
         {
-            // Skip sub-document roots — they are separate document trees
-            // and must not be traversed as part of the parent document.
-            if (child is DomElement childElement && IsSubDocRoot(childElement))
-                continue;
             result.Add(child);
             CollectDescendants(child, result);
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -288,21 +288,19 @@ public sealed partial class DomBridge
     }
 
     /// <summary>
-    /// Updates the owning document root for <paramref name="node"/> and its
-    /// descendants when the subtree is inserted into another document.
-    /// Nested sub-document roots remain isolated browsing contexts and are not
-    /// re-owned by the outer document.
+    /// The canonical <see cref="DomDocument"/> that owns <paramref name="node"/> (Phase 4 item 1,
+    /// P4.4c). For a connected node this is the absolute tree root: after P4.4b a (sub-)document root
+    /// is a canonical <see cref="DomDocument"/>, so ownership is derived from tree position — no
+    /// parallel <c>OwnerDocRoot</c> field. A detached node falls back to the canonical owner-document
+    /// set at construction/adoption (a sub-document's <c>createElement</c> node was adopted into its
+    /// content document; every other node was minted from the main <c>_document</c>).
     /// </summary>
-    internal static void AdoptSubtreeIntoDocument(DomNode node, DomNode? ownerDocRoot)
+    internal static DomDocument GetOwningDocument(DomNode node)
     {
-        GetElementRuntimeState(node).OwnerDocRoot = ownerDocRoot;
-
-        // RF-BRIDGE-1c Phase F (F3c part 2b): walk raw ChildNodes so char-data children are adopted
-        // too. Behaviour-preserving on today's homogeneous tree (every child is an element).
-        // Nested browsing-context documents are no longer in-tree children (P4.4b severed the
-        // #subdoc-root element), so a subtree walk never crosses a sub-document boundary.
-        foreach (var child in node.ChildNodes)
-            AdoptSubtreeIntoDocument(child, ownerDocRoot);
+        DomNode root = node;
+        while (root.ParentNode is { } parent)
+            root = parent;
+        return root as DomDocument ?? node.OwnerDocument;
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/Features/ISubDocumentHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ISubDocumentHost.cs
@@ -41,9 +41,10 @@ internal interface ISubDocumentHost
     /// <summary>The JS wrapper already registered for <paramref name="node"/>, if any.</summary>
     bool TryGetNodeWrapper(DomNode node, out JSObject wrapper);
 
-    /// <summary>Records <paramref name="node"/>'s owning sub-document root (the runtime-state
-    /// <c>OwnerDocRoot</c> field the bridge keys sub-document membership on).</summary>
-    void SetOwnerDocRoot(DomNode node, DomNode docRoot);
+    /// <summary>Adopts a freshly-created, still-detached <paramref name="node"/> into the sub-document
+    /// <paramref name="docRoot"/> (a canonical <c>DomDocument</c>) so its canonical
+    /// <c>ownerDocument</c> is the sub-document, not the main document it was minted from (P4.4c).</summary>
+    void AdoptDetachedNode(DomNode node, DomNode docRoot);
 
     // -------- node construction funnels --------
     DomElement CreateElement(string tagName);

--- a/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.Implementation.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.Implementation.cs
@@ -34,12 +34,11 @@ internal sealed partial class SubDocumentBinding
         if (!string.IsNullOrEmpty(qName))
             DomBridge.ValidateQualifiedName(qName, ns, _host.JsContext);
         // Phase 4 item 1 (P4.4a): a createDocument root is a canonical DomDocument (was a #subdoc-root).
+        // Phase 4 item 1 (P4.4c): structural nodes are appended under subDocRoot (a canonical
+        // DomDocument), so GetOwningDocument derives their owner from tree position — no OwnerDocRoot.
         var subDocRoot = _host.CreateBrowsingContextDocument();
         if (doctypeArg is JSObject dtObj && _host.FindDomNodeByJSObject(dtObj) is { } dtNode)
-        {
             subDocRoot.AppendChild(dtNode);
-            _host.SetOwnerDocRoot(dtNode, subDocRoot);
-        }
 
         if (!string.IsNullOrEmpty(qName))
         {
@@ -47,7 +46,6 @@ internal sealed partial class SubDocumentBinding
                 ? _host.CreateElement(qName)
                 : _host.CreateElementNS(ns, qName);
             subDocRoot.AppendChild(docEl);
-            _host.SetOwnerDocRoot(docEl, subDocRoot);
         }
 
         return BuildDocument(subDocRoot);
@@ -58,33 +56,29 @@ internal sealed partial class SubDocumentBinding
         var subTitle = a.Length > 0 && !a[0].IsNull && !a[0].IsUndefined ? a[0].ToString() : null;
         // Phase 4 item 1 (P4.4a): a createHTMLDocument root is a canonical DomDocument (was a
         // #subdoc-root); doctype + <html> are appended as canonical document children.
+        // Phase 4 item 1 (P4.4c): structural nodes are appended under subDocRoot (a canonical
+        // DomDocument), so GetOwningDocument derives their owner from tree position — no OwnerDocRoot.
         var subDocRoot = _host.CreateBrowsingContextDocument();
         var dt = _host.CreateDocumentType("html", string.Empty, string.Empty);
         subDocRoot.AppendChild(dt);
-        _host.SetOwnerDocRoot(dt, subDocRoot);
         // "http://www.w3.org/1999/xhtml" is the default HTML namespace the funnel applies.
         var subHtml = _host.CreateElement("html");
         subDocRoot.AppendChild(subHtml);
-        _host.SetOwnerDocRoot(subHtml, subDocRoot);
         var subHead = _host.CreateElement("head");
         DomBridge.SetParent(subHead, subHtml);
-        _host.SetOwnerDocRoot(subHead, subDocRoot);
         subHtml.AppendChild(subHead);
         if (subTitle != null)
         {
             var subTitleEl = _host.CreateElement("title");
             DomBridge.SetParent(subTitleEl, subHead);
-            _host.SetOwnerDocRoot(subTitleEl, subDocRoot);
             subHead.AppendChild(subTitleEl);
             var subTitleText = _host.CreateTextNode(subTitle);
             DomBridge.SetParent(subTitleText, subTitleEl);
-            _host.SetOwnerDocRoot(subTitleText, subDocRoot);
             subTitleEl.AppendChild(subTitleText);
         }
 
         var subBody = _host.CreateElement("body");
         DomBridge.SetParent(subBody, subHtml);
-        _host.SetOwnerDocRoot(subBody, subDocRoot);
         subHtml.AppendChild(subBody);
         return BuildDocument(subDocRoot);
     }

--- a/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.Nodes.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.Nodes.cs
@@ -20,7 +20,7 @@ internal sealed partial class SubDocumentBinding
         DomBridge.ValidateElementName(tagName, _host.JsContext);
         tagName = DomBridge.AsciiToLower(tagName);
         var el = _host.CreateElement(tagName);
-        _host.SetOwnerDocRoot(el, docRoot);
+        _host.AdoptDetachedNode(el, docRoot);
         return _host.ToJSObject(el);
     }
 
@@ -28,7 +28,7 @@ internal sealed partial class SubDocumentBinding
     {
         var text = a.Length > 0 ? a[0].ToString() : string.Empty;
         var el = _host.CreateTextNode(text);
-        _host.SetOwnerDocRoot(el, docRoot);
+        _host.AdoptDetachedNode(el, docRoot);
         return _host.ToJSObject(el);
     }
 
@@ -36,7 +36,7 @@ internal sealed partial class SubDocumentBinding
     {
         var data = a.Length > 0 ? a[0].ToString() : string.Empty;
         var el = _host.CreateComment(data);
-        _host.SetOwnerDocRoot(el, docRoot);
+        _host.AdoptDetachedNode(el, docRoot);
         return _host.ToJSObject(el);
     }
 
@@ -48,7 +48,7 @@ internal sealed partial class SubDocumentBinding
         var el = string.IsNullOrEmpty(ns)
             ? _host.CreateElement(localName)
             : _host.CreateElementNS(ns, localName);
-        _host.SetOwnerDocRoot(el, docRoot);
+        _host.AdoptDetachedNode(el, docRoot);
         return _host.ToJSObject(el);
     }
 
@@ -141,7 +141,6 @@ internal sealed partial class SubDocumentBinding
             if (DomBridge.ParentEl(child) != null)
                 child.Remove();
             DomBridge.SetParent(child, docRoot);
-            DomBridge.AdoptSubtreeIntoDocument(child, docRoot);
             docRoot.AppendChild(child);
             return childObj;
         }

--- a/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.Range.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.Range.cs
@@ -234,25 +234,10 @@ internal sealed partial class TraversalBinding
         if (newParent == null)
             return JSUndefined.Value;
 
-        // Bridge-specific compatibility guard (not part of canonical surroundContents): the
-        // #document / #subdoc-root sentinels are plain elements to the canonical DOM, so its
-        // single-document-element hierarchy rule does not fire. Preserve the Acid3-era check that
-        // surrounding at the document level cannot introduce a second element child.
-        if (state.StartContainer is DomElement startContainerElement &&
-            (string.Equals(startContainerElement.TagName, "#document", StringComparison.OrdinalIgnoreCase) || string.Equals(startContainerElement.TagName, "#subdoc-root", StringComparison.OrdinalIgnoreCase)))
-        {
-            var nodes = DomBridge.GetNodesInRange(state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset);
-            var elemCount = DomBridge.ChildElements(startContainerElement).Count(c => !DomBridge.IsText(c) && !DomBridge.IsComment(c));
-            var removedElems = nodes.Count(n => !DomBridge.IsText(n) && !DomBridge.IsComment(n));
-            // newParent is always a real element here (a canonical DomDocumentFragment / DomComment
-            // is not a DomElement, so FindDomElementByJSObject returned null and we returned above) —
-            // the former "#document-fragment" sentinel-tag exclusion is dead.
-            if (elemCount - removedElems + 1 > 1 || !DomBridge.IsComment(newParent))
-            {
-                DomBridge.ThrowDOMException(_host.JsContext, "Hierarchy request error", "HierarchyRequestError");
-                return JSUndefined.Value;
-            }
-        }
+        // The document root is now a canonical DomDocument (P4.6) and sub-document roots are severed
+        // canonical DomDocuments (P4.4b) — neither is a DomElement — so the canonical
+        // SurroundContents below enforces the single-document-element hierarchy rule directly; the
+        // former #document / #subdoc-root sentinel guard here is dead and removed.
 
         // The canonical algorithm handles the partial-non-text (InvalidStateError, incl. comment
         // boundaries) and invalid-newParent (InvalidNodeTypeError) checks, the extract, and the wrap.


### PR DESCRIPTION
## Summary

Completes **work item 1** of the [HtmlBridge complexity-reduction roadmap](docs/roadmap/htmlbridge-complexity-reduction-roadmap.md) Phase 4 ("eliminate parallel DOM state"). Two stacked, behaviour-preserving slices that remove the last of the `#subdoc-root`/`#document`-family shadow state left behind after the P4.4b iframe sever and the P4.6 `#document` migration. With these, **Phase 4's exit criteria are met** (one tree, one owner-document authority, no `#document`-family fake-tag checks).

Both slices are internal-only — no public-API change, and no submodule change.

## P4.11 — remove the now-inert `#subdoc-root` tag-name special cases

P4.4b severed the materialized nested browsing context from the `_document` tree (a sub-document is now a canonical `DomDocument` referenced through a container↔document map) and left the `#subdoc-root` element with **zero creation sites**, so every remaining `IsSubDocRoot` guard and `"#subdoc-root"` TagName check was dead — provably unreachable.

Removed: the `IsSubDocRoot`/`IsSubDocRootNode` helpers and their ~15 call sites (node + element child/sibling navigation, fragment `children` view, `CollectDescendants`, `AdoptSubtreeIntoDocument`); the `CollectWindowFrames` recursion skip; the serialization `GetKind`/`GetChildren` arms; the `Css.cs` `CollectStyleElementsInTree`/`InvalidateStyleScopeRecursive` `#subdoc` guards; the `ShadowDom.ToJSRootNode` branch (the fall-through `ToJSObject` already resolves a canonical `DomDocument` root); and the document-level `surroundContents` sentinel guard (canonical `SurroundContents` now enforces the single-documentElement rule directly). **Kept** `GetDocumentRootFor`'s generic `#`-prefix stop — still live for `#shadow-root`.

## P4.4c — eliminate the `OwnerDocRoot` parallel-state field

`ElementRuntimeState.OwnerDocRoot` was a per-node back-reference to the owning browsing-context root (null for main-document nodes, the sub-document root otherwise) that shadowed the canonical owner-document. It existed because every bridge node is minted from the main `_document`, so canonical `node.OwnerDocument` is uniformly the main document even for sub-document nodes.

Ownership is now **derived, not stored**:

- **Connected nodes** → new `DomBridge.GetOwningDocument(node)` returns the absolute canonical tree root (a `DomDocument` after the P4.4b sever). This makes the four readers tree-derived and lets `AdoptSubtreeIntoDocument` + its five insertion call sites be deleted outright.
- **Detached `createElement` nodes** → adopted into their content document via the public `DomDocument.AdoptNode` (a no-op `RemoveChild` on the parentless node), so `GetOwningDocument`'s detached fallback (`node.OwnerDocument`) reports the sub-document. Replaces the `ISubDocumentHost.SetOwnerDocRoot` seam with `AdoptDetachedNode`. **No submodule change needed.**
- The `createDocument`/`createHTMLDocument` structural writers and the shadow-root inheritance are dropped (those nodes are connected via `AppendChild`/`SetParent`, so tree-walk covers them).

### Reviewer note — one regression found and fixed in-slice

The hit-test `DocumentHasViewport` check returned `true` for regime-A iframe content **precisely because** those nodes carried a null `OwnerDocRoot` (P4.4b left regime-A nodes unadopted), so the content document's `CreateBrowsingContextDocument` `HasViewport=false` marker — shared with detached programmatic documents — was never consulted. With ownership tree-derived, that marker became live and suppressed iframe hit-testing. Fixed by distinguishing rendered nested browsing contexts (main document, or a content document reachable through a container frame) from detached programmatic documents (`createDocument`/`createHTMLDocument`, no frame, `HasViewport=false`); `DocumentHasViewport` became an instance method to consult the frame map.

## Tests

- `SubdocRootGuardRemovalTests.cs` — reflection guards that `IsSubDocRoot`/`IsSubDocRootNode` are gone + node/element navigation, `getRootNode()`, and iframe-host navigation/serialization/style-no-leak characterizations.
- `OwnerDocRootRemovalTests.cs` — reflection guards that the field + `AdoptSubtreeIntoDocument` are gone and `GetOwningDocument` is present; `ownerDocument` across main / detached-main-created / sub-document connected / sub-document detached-created / iframe-content regimes; and the iframe-content hit-test viewport guard.

## Verification

Both slices verified by stash-comparing the failure set (identical on both sides → zero regressions) across the SubDocument / Iframe / Frame / ShadowDom / OwnerDocument / CrossDocument / HtmlDomInterface / DomImplementation / GoogleSearchPolyfill / sentinel-migration / KnownNodes suites, plus a wider DomEdgeCase / Namespace / Attributes / DomTraversal / Acid3 / DomEvents sweep. Remaining failures are the standing environmental set (headless `Range_GetBoundingClientRect` geometry, real-HTTP `Iframe_*`, zoom/srcdoc serialization, flaky Acid3 pixel/score).

🤖 Generated with [Claude Code](https://claude.com/claude-code)