### PR TITLE
HtmlBridge P4.9/P4.10 follow-up: delegate isEqualNode/FindCommonAncestor to canonical DomNode

### DIFF
--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -860,6 +860,36 @@ Exit criteria:
 
 ### Phase 4 - eliminate parallel DOM state
 
+Status: **P4.9/P4.10 delegation landed** 2026-07-14 — **work items 4/5, post-patch follow-up: the bridge
+equality/common-ancestor copies are now deleted and delegate to canonical `Broiler.Dom.DomNode`.** The
+maintainer applied `patches/0001` (`IsEqualNode`) and `patches/0002` (`CommonAncestorWith`) and bumped the
+`Broiler.DOM` pointer (parent commit `4be3faea`; submodule `8a48f1b`, with `DomNode.IsEqualNode` and
+`DomNode.CommonAncestorWith` now present), then removed the patch files. That un-gated the follow-up P4.9/P4.10
+explicitly deferred to "once the patch lands":
+
+- **`isEqualNode`:** the bridge's `NodesAreEqual` / `CanonicalAttributesAreEqual` (`SubDocuments.cs`) are
+  deleted; `JsJsObjectsIsEqualNode077Core` now delegates to `node.IsEqualNode(other)` (the canonical op is
+  null-tolerant, subsuming the old explicit null check; it drops the bridge copy's element-level `BridgeText`
+  comparison, a no-op on the canonical tree — so it is behaviour-equivalent). `IsEqualNodePromotionTests`
+  (which pinned the observable behaviour against the former bridge copy) stays green against the delegation.
+- **`FindCommonAncestor`:** the bridge helper (`Traversal.cs`) is deleted; its four call sites
+  (`compareDocumentPosition` boundary compare in `Common.cs`, `GetNodesInRange` in `Traversal.cs`, and the
+  Range `commonAncestorContainer` / stringifier paths in `TraversalBinding.Range.cs`) now call
+  `a.CommonAncestorWith(b)` — null-tolerant and null-returning for disjoint trees, matching the deleted helper;
+  every site already passes a non-null `a` and null-checks the result.
+
+Behaviour-preserving; no public-API change (all deleted members were `private`/`internal`). Build clean
+(0 warnings); the isEqualNode / range / compareDocumentPosition / DomTraversal / SubDocument / Acid3Phase4 /
+DomEdgeCase / CrossDocument suites pass (113 tests), with only the two standing environmental failures — the
+headless `Range_GetBoundingClientRect` geometry test and the real-HTTP `HttpSubResourceTests.Iframe_*` test —
+reproducing identically with the change stashed → zero regressions.
+
+**This exhausts the clean, in-repo item-4/5 promotion follow-ups.** What remains is unchanged: `Normalize` /
+`CloneDomElement` stay blocked by side-effect / runtime-state coupling; a *further* `GetNodesInRange` /
+`DomRange`-stringifier promotion to canonical would be a new submodule addition (its old `#subdoc-root`
+regime-A blocker is gone now that P4.4b/P4.11 eliminated the sentinel, but promoting it still needs the
+submodule push/patch workflow, and the stringifier additionally has non-spec quirks to resolve first).
+
 Status: **P4.4c completed** 2026-07-14 (branch `htmlbridge-phase4-remove-subdocroot-guards`) — **work item 1:
 eliminate the `OwnerDocRoot` parallel-state field.** `ElementRuntimeState.OwnerDocRoot` (a per-node
 back-reference to the owning browsing-context root — null for main-document nodes, the sub-document root
@@ -938,12 +968,15 @@ set) → zero regressions.
 
 **This closes the item-1 sentinel work: every `#document`/`#document-fragment`/`#doctype`/`#subdoc-root`
 fake-tag element is gone (P4.2/P4.3/P4.4a/P4.4b/P4.6) and the residual dead tag-name guards they left behind
-are now removed.** The remaining Phase 4 residue is unchanged and still blocked/gated as recorded below:
-item 2's full inline-style dict elimination (P4.7 shipped the script-observable write-through slice; the
-~200-site dict rewrite is deferred), item 4/5's submodule-push-gated promotions (`IsEqualNode` P4.9,
-`CommonAncestorWith` P4.10) and the `GetNodesInRange` / `DomRange`-stringifier / `Normalize` / `CloneDomElement`
-swaps blocked by regime-A layout coupling or side-effect coupling. (P4.4c `OwnerDocRoot` — the last independent
-in-repo residue — is now also done; see the P4.4c entry above.)
+are now removed.** The remaining Phase 4 residue: item 2's full inline-style dict elimination (P4.7 shipped
+the script-observable write-through slice; the ~200-site dict rewrite is deferred), and the item 4/5
+`Normalize` / `CloneDomElement` swaps blocked by side-effect / runtime-state coupling. The item 4/5
+`IsEqualNode` (P4.9) and `CommonAncestorWith` (P4.10) promotions are **no longer push-gated** — the patches
+were applied, the pointer bumped, and the bridge copies deleted in favour of canonical delegation (see the
+top-of-Phase-4 P4.9/P4.10 delegation entry). A further `GetNodesInRange` / `DomRange`-stringifier promotion
+remains a new submodule addition (its old regime-A blocker is gone, but the push/patch workflow and the
+stringifier's non-spec quirks remain). (P4.4c `OwnerDocRoot` — the last independent in-repo residue — is now
+also done; see the P4.4c entry above.)
 
 Status: **P4.10 prepared as a submodule patch** 2026-07-14 (same branch) — **work items 4/5: promote the
 nearest-common-ancestor tree query to canonical `Broiler.Dom.DomNode.CommonAncestorWith`.** The bridge's
@@ -960,7 +993,9 @@ Same submodule-scope outcome as P4.9: the `Broiler.DOM` push 403s, so it ships a
 `patches/0002-add-domnode-commonancestorwith.patch` (indexed in `patches/README.md`), the pointer is
 **unbumped**, and the bridge keeps `FindCommonAncestor` as the active fallback; the follow-up after the
 patch lands is to replace the helper body with `a.CommonAncestorWith(b)` (the four call sites already
-null-check). No main-repo behaviour change.
+null-check). No main-repo behaviour change. **(Follow-up since landed — see the P4.9/P4.10 delegation entry
+at the top of Phase 4: the patch was applied, the pointer bumped, and the bridge helper deleted in favour of
+`a.CommonAncestorWith(b)`.)**
 
 **With P4.9 (`IsEqualNode`) and P4.10 (`CommonAncestorWith`), the clean, quirk-free neutral-algorithm
 promotions are exhausted.** The other promotion candidates are *not* clean: `GetNodesInRange`
@@ -986,7 +1021,8 @@ GitHub scope — the documented egress caveat), so per `CLAUDE.md` this ships as
 instructions) and the **submodule pointer is left unbumped**. The bridge keeps its `NodesAreEqual`
 implementation as the **active fallback** so CI (which clones the submodule by pointer) still compiles;
 once a maintainer applies the patch and bumps the `Broiler.DOM` gitlink, the follow-up is to delete the
-bridge copy and delegate the binding to `node.IsEqualNode(other)`. Behaviour is pinned by
+bridge copy and delegate the binding to `node.IsEqualNode(other)`. **(Follow-up since landed — see the
+P4.9/P4.10 delegation entry at the top of Phase 4.)** Behaviour is pinned by
 `Broiler.Cli.Tests/IsEqualNodePromotionTests.cs` (equal/unequal element trees, attribute-order
 irrelevance, text-node data equality) — green today against the bridge copy and required to stay green
 after the canonical delegation. No main-repo behaviour change in this commit.

--- a/src/Broiler.Cli.Tests/IsEqualNodePromotionTests.cs
+++ b/src/Broiler.Cli.Tests/IsEqualNodePromotionTests.cs
@@ -1,16 +1,15 @@
 namespace Broiler.Cli.Tests;
 
 /// <summary>
-/// Phase 4 items 4/5: node equality (<c>Node.isEqualNode()</c>) is slated to move to the canonical
-/// <c>Broiler.Dom.DomNode.IsEqualNode</c> tree algorithm, with the bridge's <c>NodesAreEqual</c> copy
-/// deleted and its <c>isEqualNode</c> binding delegating. That promotion is a Broiler.DOM submodule
-/// change; the submodule push is outside this session's GitHub scope (403), so it ships as
-/// <c>patches/0001-add-domnode-isequalnode.patch</c> and the bridge keeps its <c>NodesAreEqual</c>
-/// implementation as the active fallback until the patch lands and the pointer is bumped.
+/// Phase 4 items 4/5: node equality (<c>Node.isEqualNode()</c>) was promoted to the canonical
+/// <c>Broiler.Dom.DomNode.IsEqualNode</c> tree algorithm (<c>patches/0001-add-domnode-isequalnode.patch</c>,
+/// since applied by the maintainer and pinned in the <c>Broiler.DOM</c> submodule). The bridge's
+/// <c>NodesAreEqual</c> / <c>CanonicalAttributesAreEqual</c> copies are now deleted and the
+/// <c>isEqualNode</c> binding delegates to <c>node.IsEqualNode(other)</c>.
 ///
-/// These end-to-end characterizations pin the observable <c>isEqualNode</c> behaviour so the
-/// eventual delegation is provably equivalent (they pass against the bridge copy today and must keep
-/// passing after the canonical delegation).
+/// These end-to-end characterizations pinned the observable <c>isEqualNode</c> behaviour so the
+/// delegation is provably equivalent — they passed against the former bridge copy and must keep
+/// passing against the canonical delegation.
 /// </summary>
 public sealed class IsEqualNodePromotionTests
 {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
@@ -86,7 +86,7 @@ public sealed partial class DomBridge
             return true;
         }
 
-        var commonRoot = FindCommonAncestor(containerA, containerB) ?? docRoot;
+        var commonRoot = containerA.CommonAncestorWith(containerB) ?? docRoot;
         var allNodes = GetDocumentOrderNodes(commonRoot);
         var idxA = allNodes.IndexOf(containerA);
         var idxB = allNodes.IndexOf(containerB);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/JsObjects.cs
@@ -716,7 +716,12 @@ public sealed partial class DomBridge
         if (a.Length == 0 || a[0] is not JSObject otherObj)
             return JSBoolean.False;
         var other = FindDomNodeByJSObject(otherObj);
-        return other != null && NodesAreEqual(node, other) ? JSBoolean.True : JSBoolean.False;
+        // Phase 4 items 4/5: delegate to the canonical Broiler.Dom.DomNode.IsEqualNode tree
+        // algorithm (promoted via patches/0001, now applied and pinned in the submodule). The
+        // canonical operation is null-tolerant (IsEqualNode(null) == false), so the former explicit
+        // null check is subsumed. The old bridge copy (NodesAreEqual/CanonicalAttributesAreEqual) is
+        // deleted; behaviour is pinned by IsEqualNodePromotionTests.
+        return node.IsEqualNode(other) ? JSBoolean.True : JSBoolean.False;
     }
 
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -915,91 +915,12 @@ public sealed partial class DomBridge
         NotifyChildRemoved(parent, child, index);
     }
 
-    private static bool NodesAreEqual(DomNode first, DomNode second)
-    {
-        if (ReferenceEquals(first, second))
-            return true;
-
-        if (first.NodeType != second.NodeType)
-            return false;
-
-        // RF-BRIDGE-1c Phase F (F3c): canonical character-data nodes (text/comment) have no
-        // TagName/attributes — they are equal iff their data matches. Dead on today's homogeneous
-        // facade tree (facade text/comment are Broiler.Dom.DomElement and take the element path below); live
-        // once construction flips to canonical DomText/DomComment.
-        if (first is DomCharacterData || second is DomCharacterData)
-            return string.Equals(BridgeText(first), BridgeText(second), StringComparison.Ordinal);
-
-        // Phase 4 item 1: two DocumentType nodes are equal iff their name/publicId/systemId match
-        // (per DOM isEqualNode). Both have NodeType == DocumentType by the check above.
-        if (first is DomDocumentType firstDocType && second is DomDocumentType secondDocType)
-            return string.Equals(firstDocType.Name, secondDocType.Name, StringComparison.Ordinal) &&
-                   string.Equals(firstDocType.PublicId, secondDocType.PublicId, StringComparison.Ordinal) &&
-                   string.Equals(firstDocType.SystemId, secondDocType.SystemId, StringComparison.Ordinal);
-
-        // Phase 4 item 1: two DocumentFragment nodes (no attributes/tag) are equal iff their children
-        // are equal — fall through to the child-count + per-child comparison below, which operates on
-        // the raw ChildNodes and needs no element cast.
-        if (first is DomDocumentFragment || second is DomDocumentFragment)
-        {
-            if (first is not DomDocumentFragment || second is not DomDocumentFragment ||
-                first.ChildNodes.Count != second.ChildNodes.Count)
-                return false;
-            for (var index = 0; index < first.ChildNodes.Count; index++)
-                if (!NodesAreEqual(ChildAt(first, index), ChildAt(second, index)))
-                    return false;
-            return true;
-        }
-
-        var firstEl = (DomElement)first;
-        var secondEl = (DomElement)second;
-        if (!string.Equals(firstEl.TagName, secondEl.TagName, StringComparison.Ordinal) ||
-            !string.Equals(firstEl.NamespaceUri, secondEl.NamespaceUri, StringComparison.Ordinal) ||
-            !string.Equals(BridgeText(firstEl), BridgeText(secondEl), StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        if (!CanonicalAttributesAreEqual(firstEl, secondEl) ||
-            firstEl.ChildNodes.Count != secondEl.ChildNodes.Count)
-        {
-            return false;
-        }
-
-        for (var index = 0; index < firstEl.ChildNodes.Count; index++)
-        {
-            if (!NodesAreEqual(ChildAt(firstEl, index), ChildAt(secondEl, index)))
-                return false;
-        }
-
-        return true;
-    }
-
-    /// <summary>
-    /// RF-BRIDGE-1c Phase C2: isEqualNode attribute comparison over the canonical
-    /// namespace-keyed attribute set — which encodes namespace, local name, qualified
-    /// name, and value in one place, replacing the former flat-snapshot + NsAttrMap pair.
-    /// Two attribute sets are equal when they have the same count and each (namespace,
-    /// local name) key maps to the same value and qualified name (the qualified-name
-    /// check preserves the prefix sensitivity the snapshot comparison had).
-    /// </summary>
-    private static bool CanonicalAttributesAreEqual(DomElement first, DomElement second)
-    {
-        if (first.Attributes.Count != second.Attributes.Count)
-            return false;
-
-        foreach (var (key, attribute) in first.Attributes)
-        {
-            if (!second.Attributes.TryGetValue(key, out var other) ||
-                !string.Equals(attribute.Value, other.Value, StringComparison.Ordinal) ||
-                !string.Equals(attribute.QualifiedName, other.QualifiedName, StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
+    // Phase 4 items 4/5 (P4.9 follow-up): the bridge's NodesAreEqual / CanonicalAttributesAreEqual
+    // copies were deleted after their promotion to canonical Broiler.Dom.DomNode.IsEqualNode landed
+    // in the pinned submodule (patches/0001, applied by the maintainer). The isEqualNode binding now
+    // delegates to node.IsEqualNode(other); behaviour is pinned by IsEqualNodePromotionTests. The
+    // canonical algorithm drops the bridge copy's element-level BridgeText comparison, which was a
+    // no-op on the canonical tree (an element's NodeValue is null) — so it is behaviour-equivalent.
 
     private string NormalizeInsertAdjacentPosition(JSValue? value)
     {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
@@ -27,26 +27,10 @@ public sealed partial class DomBridge
     private JSObject BuildRange(DomNode? documentRoot = null) =>
         _traversal.BuildRange(documentRoot);
 
-    /// <summary>
-    /// Finds the common ancestor of two nodes.
-    /// </summary>
-    internal static DomNode? FindCommonAncestor(DomNode a, DomNode b)
-    {
-        var ancestors = new HashSet<DomNode>(ReferenceEqualityComparer.Instance);
-        DomNode? current = a;
-        while (current != null)
-        {
-            ancestors.Add(current);
-            current = current.ParentNode;
-        }
-        current = b;
-        while (current != null)
-        {
-            if (ancestors.Contains(current)) return current;
-            current = current.ParentNode;
-        }
-        return null;
-    }
+    // Phase 4 items 4/5 (P4.10 follow-up): the bridge's FindCommonAncestor copy was deleted after its
+    // promotion to canonical Broiler.Dom.DomNode.CommonAncestorWith landed in the pinned submodule
+    // (patches/0002, applied by the maintainer). Call sites use a.CommonAncestorWith(b), which is
+    // null-tolerant and returns null for nodes in different trees — matching the deleted helper.
 
     private JSObject CreateDomRectObject((double Left, double Top, double Width, double Height) rectData)
     {
@@ -113,7 +97,7 @@ public sealed partial class DomBridge
         }
 
         // Different containers — collect nodes between start and end
-        var ancestor = FindCommonAncestor(startContainer, endContainer);
+        var ancestor = startContainer.CommonAncestorWith(endContainer);
         if (ancestor == null) return result;
 
         var allNodes = GetDocumentOrderNodes(ancestor);

--- a/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.Range.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.Range.cs
@@ -21,9 +21,9 @@ internal sealed partial class TraversalBinding
 
     private JSValue RangeGetCommonAncestorContainer(DomRange state, in Arguments a)
     {
-        // FindCommonAncestor returns null for boundaries in different trees, preserving the lenient
-        // JSNull result; the canonical CommonAncestorContainer would throw.
-        var ancestor = DomBridge.FindCommonAncestor(state.StartContainer, state.EndContainer);
+        // CommonAncestorWith returns null for boundaries in different trees, preserving the lenient
+        // JSNull result; the canonical DomRange.CommonAncestorContainer would throw.
+        var ancestor = state.StartContainer.CommonAncestorWith(state.EndContainer);
         return ancestor != null ? _host.ToJSObject(ancestor) : JSNull.Value;
     }
 
@@ -352,7 +352,7 @@ internal sealed partial class TraversalBinding
         }
 
         // Middle nodes: collect all text from nodes between start and end paths
-        var ancestor = DomBridge.FindCommonAncestor(startContainer, endContainer);
+        var ancestor = startContainer.CommonAncestorWith(endContainer);
         if (ancestor != null)
         {
             var allNodes = DomBridge.GetDocumentOrderNodes(ancestor);


### PR DESCRIPTION
## Summary

Phase 4 (eliminate parallel DOM state) work items 4/5 — **post-patch follow-up**. The bridge's node-equality and common-ancestor copies are now deleted and delegate to canonical `Broiler.Dom.DomNode`.

## Why now (the unblocking event)

P4.9 (`IsEqualNode`) and P4.10 (`CommonAncestorWith`) prepared these promotions as submodule patches (`patches/0001`, `patches/0002`) because the `Broiler.DOM` push returned 403 — leaving the bridge copies as the active fallback and the in-repo delegation deferred to "once the patch lands."

That has now happened: the maintainer applied both patches and bumped the `Broiler.DOM` pointer (parent commit `4be3faea` "Update submodules"; submodule now `8a48f1b`, with `DomNode.IsEqualNode` and `DomNode.CommonAncestorWith` present), then removed the patch files. So the canonical methods exist in the pinned submodule and the follow-up needs **no submodule change**.

## What changed

- **`isEqualNode`**: deleted `NodesAreEqual` / `CanonicalAttributesAreEqual` (`SubDocuments.cs`); `JsJsObjectsIsEqualNode077Core` now delegates to `node.IsEqualNode(other)`. The canonical op is null-tolerant (subsuming the old explicit null check) and drops the bridge copy's element-level `BridgeText` comparison — a no-op on the canonical tree (an element's `NodeValue` is null) — so it is behaviour-equivalent.
- **`FindCommonAncestor`**: deleted the bridge helper (`Traversal.cs`); its four call sites now call `a.CommonAncestorWith(b)`:
  - `compareDocumentPosition` boundary compare (`Common.cs`)
  - `GetNodesInRange` (`Traversal.cs`)
  - Range `commonAncestorContainer` + the range stringifier (`TraversalBinding.Range.cs`)
  
  The canonical op is null-tolerant and returns null for disjoint trees, matching the deleted helper; every site already passes a non-null `a` and null-checks the result.
- Updated the roadmap (top-of-Phase-4 delegation status entry + amended the now-stale "active fallback" notes in the P4.9/P4.10 entries) and the `IsEqualNodePromotionTests` doc comment.

## Testing

- Build clean (0 warnings, 0 errors).
- `isEqualNode` / range / `compareDocumentPosition` / `DomTraversal` / `SubDocument` / `Acid3Phase4` / `DomEdgeCase` / `CrossDocument` suites pass (113 tests).
- The only 2 failures — the standing headless `Range_GetBoundingClientRect` geometry test and the real-HTTP `HttpSubResourceTests.Iframe_*` test — reproduce **identically** with the change stashed → **zero regressions**.

## Reviewer notes

- Behaviour-preserving; no public-API change (all deleted members were `private`/`internal`).
- The `IsEqualNodePromotionTests` characterizations pinned the observable behaviour against the former bridge copy and stay green against the canonical delegation.
- This exhausts the clean, in-repo item-4/5 promotion follow-ups. Still blocked: `Normalize` / `CloneDomElement` (side-effect / runtime-state coupling); a *further* `GetNodesInRange` / `DomRange`-stringifier promotion would be a new submodule addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)