### PR TITLE
HtmlBridge P4.12: promote Range stringifier to canonical DomRange.ToString; reuse InclusiveDescendants

### DIFF
--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -860,6 +860,44 @@ Exit criteria:
 
 ### Phase 4 - eliminate parallel DOM state
 
+Status: **P4.12 completed** 2026-07-14 (branch `htmlbridge-phase4-range-stringifier`) — **work items 4/5: the
+Range stringifier is promoted to a spec-correct canonical `Broiler.Dom.DomRange.ToString()`, and the bridge's
+`GetDocumentOrderNodes` document-order flatten is deleted in favour of canonical `DomNode.InclusiveDescendants`.**
+Two separable pieces:
+
+- **Range stringifier → canonical (promotion + bug fix).** The bridge's `CollectRangeText` (`TraversalBinding.Range.cs`)
+  reimplemented the DOM §4.5 `Range` stringifier and did so with a non-spec bug: it *omitted the end-container
+  Text node's head* (treated the end boundary as exclusive for text). A new `public override string DomRange.ToString()`
+  implements the spec algorithm properly — start-Text tail + every fully-contained Text node in tree order + end-Text
+  head — reusing canonical's existing `IsContained` / `InclusiveDescendants`. `RangeToString` now delegates to it and
+  `CollectRangeText` is deleted. The one deliberate deviation retained in the bridge wrapper: a range within a **single
+  Comment node** still stringifies to the selected substring (Acid3 Test 11 pins `'DEFG'`; the spec, being Text-only,
+  would yield `""`). Observable change: a range spanning distinct Text nodes now includes the end node's head (spec-correct;
+  no unit test pinned the old omission). Canonical tests: 5 new in `Broiler.Dom.Tests/DomRangeTests.cs`; bridge
+  characterization: `DomTraversalAndRangeTests.Range_ToString_Across_Text_Nodes_Includes_End_Container_Text` (plus the
+  existing `Range_ToString` / comment / single-text cases still green).
+- **`GetDocumentOrderNodes` → `InclusiveDescendants` (item-5 reuse).** The bridge helper
+  (`[root] + preorder(ChildNodes)`, `Utilities.cs`) exactly equalled canonical `DomNode.InclusiveDescendants()`, so its
+  three callers (`GetNodesInRange` in `Traversal.cs`, `IsPositionAfter`/`compareBoundaryPoints` in `Common.cs`, and the
+  now-deleted `CollectRangeText`) call `node.InclusiveDescendants().ToList()`, and `GetDocumentOrderNodes` plus its
+  now-orphaned `CollectDescendants` recursion are deleted. `GetNodesInRange` itself **stays bridge-owned** — it is a
+  non-spec client-rect geometry heuristic (it includes partially-overlapping elements, unlike canonical `IsContained`),
+  so it is the wrong shape for canonical `Broiler.Dom`. Its old regime-A `#subdoc-root` exclusion blocker is gone
+  (P4.4b/P4.11), which is what let its document-order source be reused.
+
+The canonical `DomRange.ToString()` addition shipped as `Broiler.DOM` submodule commit `f7f0d4f` (branch
+`claude/domrange-stringifier`) — the push **succeeded** (the `MaiRat/` remote redirects in-scope to
+`Broiler-Platform/Broiler.DOM`), so the submodule pointer is bumped (no patch fallback). Behaviour-preserving except the
+end-Text bug fix; no public-API change in the bridge (all deleted members were `private`/`internal`). Regression check
+vs the merge-base with the same filter: the DomTraversalAndRange / TraversalBindingModule / Acid3 suites reproduce an
+**identical** 7-test failure set with the change stashed (the standing headless `Range_GetBoundingClientRect` geometry
+test and the flaky Acid3 score/border/cascade/NodeIterator/image set), and DomEdgeCase / CrossDocument / Serialization /
+DomEvents (98) pass → zero regressions.
+
+**This exhausts the clean item-4/5 promotions.** Remaining Phase 4 residue is unchanged: item 2's full inline-style dict
+elimination (P4.7 shipped the write-through slice; the ~200-site rewrite is Phase-5-entangled via the anchor resolver),
+and the item 5 `Normalize` / `CloneDomElement` swaps still blocked by side-effect / runtime-state coupling.
+
 Status: **P4.9/P4.10 delegation landed** 2026-07-14 — **work items 4/5, post-patch follow-up: the bridge
 equality/common-ancestor copies are now deleted and delegate to canonical `Broiler.Dom.DomNode`.** The
 maintainer applied `patches/0001` (`IsEqualNode`) and `patches/0002` (`CommonAncestorWith`) and bumped the

--- a/src/Broiler.Cli.Tests/DomTraversalAndRangeTests.cs
+++ b/src/Broiler.Cli.Tests/DomTraversalAndRangeTests.cs
@@ -778,6 +778,37 @@ document.body.appendChild(out);
         Assert.Contains("helloworld", result);
     }
 
+    /// <summary>
+    /// A range spanning two Text nodes stringifies to the start node's selected tail, the fully
+    /// contained middle text, and the end node's selected head — the DOM §4.5 stringifier (now
+    /// delegated to canonical <c>Broiler.Dom.DomRange.ToString</c>). The former bridge copy
+    /// omitted the end node's head, a non-spec bug this pins as fixed.
+    /// </summary>
+    [Fact]
+    public void Range_ToString_Across_Text_Nodes_Includes_End_Container_Text()
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<div id=""t""><p id=""a"">hello</p><b id=""m"">MID</b><p id=""z"">world</p></div>
+<script>
+var a = document.getElementById('a').firstChild;  // 'hello'
+var z = document.getElementById('z').firstChild;  // 'world'
+var range = document.createRange();
+range.setStart(a, 2);   // 'he|llo' -> tail 'llo'
+range.setEnd(z, 3);     // 'wor|ld' -> head 'wor'
+var out = document.createElement('div');
+out.id = 'result';
+out.textContent = 'toString=[' + range.toString() + ']';
+document.body.appendChild(out);
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+
+        // 'llo' (start tail) + 'MID' (contained) + 'wor' (end head, previously dropped).
+        Assert.Contains("toString=[lloMIDwor]", result);
+    }
+
     // ──────────────────────── Document API additions ────────────────────────
 
     [Fact]

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
@@ -87,7 +87,7 @@ public sealed partial class DomBridge
         }
 
         var commonRoot = containerA.CommonAncestorWith(containerB) ?? docRoot;
-        var allNodes = GetDocumentOrderNodes(commonRoot);
+        var allNodes = commonRoot.InclusiveDescendants().ToList();
         var idxA = allNodes.IndexOf(containerA);
         var idxB = allNodes.IndexOf(containerB);
         if (idxA < 0 || idxB < 0)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Traversal.cs
@@ -80,10 +80,14 @@ public sealed partial class DomBridge
     }
 
     /// <summary>
-    /// Returns the list of top-level nodes fully contained within the specified range boundaries.
-    /// For element containers, this returns children between the start and end offsets. Neutral
-    /// tree helper shared by the bridge's range client-rect geometry and the
-    /// <c>TraversalBinding</c> feature module (a Phase 4 promotion candidate to Broiler.Dom).
+    /// Returns the top-level nodes overlapping the given range boundaries, for the range
+    /// client-rect geometry. For a single container this is the children between the offsets;
+    /// across containers it is the document-order nodes strictly between start and end, keeping
+    /// only those not already covered by an included ancestor. This is a client-rect geometry
+    /// heuristic — it includes partially-overlapping elements, unlike the spec-strict
+    /// <c>DomRange.IsContained</c> set — so it stays bridge-owned rather than promoting to
+    /// canonical Broiler.Dom. It reuses canonical <see cref="DomNode.InclusiveDescendants"/> for
+    /// the document-order walk.
     /// </summary>
     internal static List<DomNode> GetNodesInRange(DomNode startContainer, int startOffset, DomNode endContainer, int endOffset)
     {
@@ -100,7 +104,7 @@ public sealed partial class DomBridge
         var ancestor = startContainer.CommonAncestorWith(endContainer);
         if (ancestor == null) return result;
 
-        var allNodes = GetDocumentOrderNodes(ancestor);
+        var allNodes = ancestor.InclusiveDescendants().ToList();
         var startIdx = allNodes.IndexOf(startContainer);
         var endIdx = allNodes.IndexOf(endContainer);
         if (startIdx < 0 || endIdx < 0) return result;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -470,25 +470,6 @@ public sealed partial class DomBridge
     // form.elements collection (indexed + named access) moved to the Phase 3 FormBinding feature
     // module (Broiler.HtmlBridge.Dom.Features).
 
-    /// <summary>
-    /// Collects all descendants of <paramref name="root"/> in document order
-    /// (depth-first pre-order).
-    /// </summary>
-    private static void CollectDescendants(DomNode root, List<DomNode> result)
-    {
-        // RF-BRIDGE-1c Phase F (F3c part 2b): walk raw ChildNodes so document-order traversal
-        // includes text/comment nodes (range boundary indexing needs them). Behaviour-preserving
-        // on today's homogeneous tree where every child is an element.
-        // Sub-documents are separate document trees, but since P4.4b severed the #subdoc-root
-        // element they are no longer in-tree children here, so document-order traversal never
-        // crosses a sub-document boundary.
-        foreach (var child in root.ChildNodes)
-        {
-            result.Add(child);
-            CollectDescendants(child, result);
-        }
-    }
-
 
     /// <summary>
     /// Collects descendant elements matching a tag name in tree order (depth-first).
@@ -501,17 +482,6 @@ public sealed partial class DomBridge
                 results.Add(bridge.ToJSObject(child));
             CollectDescendantsByTag(child, tagName, results, bridge);
         }
-    }
-
-    /// <summary>
-    /// Returns a flat list of all nodes in the subtree rooted at
-    /// <paramref name="root"/> in document order (including the root).
-    /// </summary>
-    internal static List<DomNode> GetDocumentOrderNodes(DomNode root)
-    {
-        var list = new List<DomNode> { root };
-        CollectDescendants(root, list);
-        return list;
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.Range.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.Range.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Broiler.JavaScript.BuiltIns.Null;
 using Broiler.JavaScript.BuiltIns.Number;
 using Broiler.JavaScript.BuiltIns.Array;
@@ -293,100 +292,20 @@ internal sealed partial class TraversalBinding
 
     private static JSValue RangeToString(DomRange state, in Arguments a)
     {
-        var sb = new StringBuilder();
-        // Handle case where range is within a single text/comment node
-        if (ReferenceEquals(state.StartContainer, state.EndContainer) && (DomBridge.IsText(state.StartContainer) || DomBridge.IsComment(state.StartContainer)))
+        // A range within a single Comment node stringifies to the selected substring — a deliberate
+        // deviation from the DOM §4.5 stringifier, which is Text-only (a Comment range would yield
+        // ""), retained for Acid3 Test 11. Every other case delegates to the canonical spec-correct
+        // Range stringifier (Broiler.Dom.DomRange.ToString), which the bridge's former CollectRangeText
+        // copy shadowed — and shadowed with a bug: it omitted the end-container Text node's head.
+        if (ReferenceEquals(state.StartContainer, state.EndContainer) && DomBridge.IsComment(state.StartContainer))
         {
             var text = DomBridge.BridgeText(state.StartContainer);
             var s = Math.Max(0, Math.Min(state.StartOffset, text.Length));
             var e = Math.Max(s, Math.Min(state.EndOffset, text.Length));
-            sb.Append(text, s, e - s);
-        }
-        else
-        {
-            // Cross-node range: collect text with proper offset handling
-            CollectRangeText(sb, state.StartContainer, state.StartOffset, state.EndContainer, state.EndOffset);
+            return new JSString(text.Substring(s, e - s));
         }
 
-        return new JSString(sb.ToString());
-    }
-
-    // -------- Range content helpers --------
-
-    /// <summary>
-    /// Collects text content from a range that spans across nodes.
-    /// Handles start/end offset boundaries properly for text nodes.
-    /// </summary>
-    private static void CollectRangeText(StringBuilder sb, DomNode startContainer, int startOffset, DomNode endContainer, int endOffset)
-    {
-        if (ReferenceEquals(startContainer, endContainer))
-        {
-            // Same container
-            if (DomBridge.IsText(startContainer))
-            {
-                var text = DomBridge.BridgeText(startContainer);
-                var s = Math.Max(0, Math.Min(startOffset, text.Length));
-                var e = Math.Max(s, Math.Min(endOffset, text.Length));
-                sb.Append(text, s, e - s);
-            }
-            else
-            {
-                // Element container — collect text from children between offsets
-                for (var i = startOffset; i < Math.Min(endOffset, startContainer.ChildNodes.Count); i++)
-                    DomBridge.CollectTextContent(DomBridge.ChildAt(startContainer, i), sb);
-            }
-            return;
-        }
-
-        // Start container: collect from startOffset to end
-        if (DomBridge.IsText(startContainer))
-        {
-            var text = DomBridge.BridgeText(startContainer);
-            if (startOffset < text.Length)
-                sb.Append(text.AsSpan(startOffset));
-        }
-        else
-        {
-            for (var i = startOffset; i < startContainer.ChildNodes.Count; i++)
-                DomBridge.CollectTextContent(DomBridge.ChildAt(startContainer, i), sb);
-        }
-
-        // Middle nodes: collect all text from nodes between start and end paths
-        var ancestor = startContainer.CommonAncestorWith(endContainer);
-        if (ancestor != null)
-        {
-            var allNodes = DomBridge.GetDocumentOrderNodes(ancestor);
-            var startIdx = allNodes.IndexOf(startContainer);
-            var endIdx = allNodes.IndexOf(endContainer);
-            if (startIdx >= 0 && endIdx >= 0)
-            {
-                for (var i = startIdx + 1; i < endIdx; i++)
-                {
-                    var node = allNodes[i];
-                    // Skip descendants of start/end containers (already handled)
-                    if (node.IsDescendantOf(startContainer) || node.IsDescendantOf(endContainer))
-                        continue;
-                    // Only collect from top-level nodes
-                    if (DomBridge.IsText(node))
-                        sb.Append(DomBridge.BridgeText(node));
-                    else if (node.ChildNodes.Count == 0)
-                        continue; // element with no text children
-                    // Don't double-collect descendants
-                }
-            }
-        }
-
-        // End container: collect from 0 to endOffset
-        if (DomBridge.IsText(endContainer))
-        {
-            // Don't include end container text for Range.toString()
-            // (end boundary is exclusive for text)
-        }
-        else
-        {
-            for (var i = 0; i < Math.Min(endOffset, endContainer.ChildNodes.Count); i++)
-                DomBridge.CollectTextContent(DomBridge.ChildAt(endContainer, i), sb);
-        }
+        return new JSString(state.ToString());
     }
 
     private static (double Left, double Top, double Width, double Height) UnionClientRects(


### PR DESCRIPTION
Phase 4 (eliminate parallel DOM state), work items 4/5. Two separable pieces.

## 1. Range stringifier → canonical, spec-corrected

The bridge's `CollectRangeText` (`TraversalBinding.Range.cs`) reimplemented the DOM §4.5 `Range.toString()` stringifier — with a non-spec bug: it **omitted the end-container Text node's head**. This PR:

- adds a spec-correct `DomRange.ToString()` to canonical `Broiler.Dom` (reusing `IsContained`/`InclusiveDescendants`),
- delegates the bridge's `RangeToString` to it and **deletes** `CollectRangeText`,
- keeps the one deliberate deviation in the bridge wrapper: a range within a **single Comment node** stringifies to the selected substring (Acid3 Test 11 pins `'DEFG'`; the Text-only spec would yield `""`).

Observable change: a range spanning distinct Text nodes now includes the end node's head (spec-correct; no unit test pinned the old omission).

## 2. `GetDocumentOrderNodes` → `InclusiveDescendants` (item-5 reuse)

The bridge helper (`[root] + preorder(ChildNodes)`) exactly equalled canonical `DomNode.InclusiveDescendants()`, so its three callers (`GetNodesInRange`, `IsPositionAfter`/`compareBoundaryPoints`, the deleted `CollectRangeText`) reuse the canonical walk; `GetDocumentOrderNodes` and its now-orphaned `CollectDescendants` recursion are **deleted**. `GetNodesInRange` stays bridge-owned — it is a client-rect geometry heuristic (includes partially-overlapping elements), not a spec-strict contained-node set.

## Submodule

The canonical `DomRange.ToString()` addition is **Broiler-Platform/Broiler.DOM#9** (commit `f7f0d4f`); the push succeeded, so the submodule pointer is bumped here (no patch fallback). **Merge the submodule PR before this one** — the pointer pins that commit.

## Verification

- Canonical: 28/28 `DomRangeTests` (5 new stringifier tests).
- Bridge: behaviour-preserving except the end-Text bug fix; no public-API change (deleted members were `private`/`internal`). The range/traversal/Acid3 filter reproduces an **identical** 7-test failure set with the change stashed (standing headless `Range_GetBoundingClientRect` + flaky Acid3 score/border/cascade/NodeIterator/image); DomEdgeCase/CrossDocument/Serialization/DomEvents (98) pass → zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)