### PR TITLE
HtmlBridge Phase 5 (P5.8d.2b): native anchor-placement runner lever + per-element MVP gating

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Broiler.Layout.csproj
+++ b/Broiler.Layout/Broiler.Layout/Broiler.Layout.csproj
@@ -25,6 +25,9 @@
     <InternalsVisibleTo Include="Broiler.DevConsole" />
     <InternalsVisibleTo Include="Broiler.DevConsole.Tests" />
     <InternalsVisibleTo Include="Broiler.Layout.Tests" />
+    <!-- The WPT runner sets NativeAnchorPlacement.Enabled around only the final
+         render during the Phase 5 native anchor-placement cutover (P5.8d.2b). -->
+    <InternalsVisibleTo Include="Broiler.Wpt" />
   </ItemGroup>
 
 </Project>

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1709,24 +1709,45 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   identical 9 deterministic anchor-tail fails. Zero regressions. (A default-mode strip assertion was
   dropped as unreliable in the raw-string `Attach` harness — the `<style>` InnerHtml-vs-DomText nuance +
   no real layout make it diverge from the full WPT pipeline; default-off safety is proven by the WPT run.)
-- **P5.8d.2b — runner lever + full render parity (NOT started, the concentrated risk):** add
-  `<InternalsVisibleTo Include="Broiler.Wpt" />` to `Broiler.Layout.csproj` (the runner can already set the
-  bridge flag via bridge IVT; this lets it also set `NativeAnchorPlacement.Enabled` around **only** the
-  final `RenderToImageWithStyleSet` — not the earlier geometry snapshots). Gate both behind a default-off
-  runner lever (env var, like `UseSharedLayoutGeometry`). Then prove pixel parity on the **MVP subset**
-  (position-area + explicit `position-anchor` + uniquely-named anchor + non-inline CB + no scroll
-  container); for mixed MVP/non-MVP rules, add per-element suppression (write `position-area: none` inline
-  on bridge-baked boxes so the engine skips them). Expand feature-by-feature (percentage box props →
-  box-sizing → inline-CB promotion → scroll simulation → `position-visibility` → dialog/backdrop →
-  `anchor()` insets → position-try), each its own PR + parity gate. Start with the **MVP subset**:
-  `position-area` with an explicit `position-anchor`, a uniquely-named anchor, a non-inline containing
-  block, and no intervening scroll container (`scrollContainer == null` and `!IsInlineContainingBlock`).
-  For those boxes the bridge's `ResolvePositionAreaValues` returns early (leaving the CSS intact) and the
-  engine places them; everything else stays on the bridge path. Prove parity per-test in isolation
-  against the css-anchor-position baseline, then expand coverage one entangled feature at a time
-  (percentage box props → box-sizing → inline-CB promotion → scroll simulation → `position-visibility` →
-  dialog/backdrop → `anchor()` insets → position-try). Each expansion is its own PR with its own parity
-  gate.
+- **P5.8d.2b — runner lever + MVP-subset render parity — FIRST SLICE COMPLETED** 2026-07-14 (branch
+  `htmlbridge-phase5-native-anchor-cutover`). The production-flip *infrastructure* is in and proven on the
+  strict MVP subset; the lever is default-off and expansion to the entangled features is still to come.
+  Landed:
+  - **Engine reach.** `<InternalsVisibleTo Include="Broiler.Wpt" />` on `Broiler.Layout.csproj` plus a
+    direct `Broiler.Wpt`→`Broiler.Layout` `ProjectReference` (it only reached Layout transitively before),
+    so the runner can name and set the `[ThreadStatic]` `Broiler.Layout.Engine.NativeAnchorPlacement.Enabled`.
+  - **Bridge: whole-function skip → per-element MVP gating.** P5.8d.2a's all-or-nothing
+    `if (!NativeAnchorPlacement)` around `ResolvePositionAreaValues` is replaced by a per-box decision
+    inside it: `rect = NativeAnchorPlacement && IsMvpNativeAnchorBox(...) ? null : ComputePositionAreaRect(...)`
+    (null rect ⇒ the whole baking block is skipped, leaving the box's `position-area`/`position-anchor`/
+    `anchor-name` CSS intact for the engine). `IsMvpNativeAnchorBox` requires: an explicit dashed-ident
+    `position-anchor`, a **uniquely-named** anchor (`_anchorCandidates[name].Count == 1` — the engine's
+    `AnchorRegistry` is a flat ordinal last-wins map with no scope awareness), a non-inline containing
+    block, no intervening scroll container, and no `position-try`/`anchor()`/`anchor-size()` on the box.
+    Every **non-MVP** box under native mode is still baked as before **and** gets `position-area: none`
+    written inline so the engine post-pass skips the already-placed box (the mixed-doc suppression the
+    plan called for). `NeutralizeStyleElementsForAnchorRules` stays skipped in native mode (MVP boxes need
+    their stylesheet `position-area`/`anchor-name` to survive; baked non-MVP boxes are inline-overridden).
+  - **Runner lever.** `BROILER_WPT_NATIVE_ANCHOR` (default off, static like `DeferPromiseTests`) sets
+    `bridge.NativeAnchorPlacement` on both `DomBridge` instances in `ExecuteScriptsWithDom`, and a
+    `RenderWithNativeAnchor(...)` wrapper enables the engine flag around **only** the two final
+    `RenderToImageWithStyleSet` calls (`[ThreadStatic]`, restored in `finally`).
+  - **Validation.** Default-off is byte-identical (the gates are all `if (NativeAnchorPlacement)`): the
+    `~Anchor|~Position|~Sticky` WPT suite is the same **9 anchor-tail fails / 54 pass** as baseline.
+    **Lever-on across the whole suite reproduces the identical 9/54 set** — MVP boxes route through the
+    engine, everything else stays baked, zero regressions. (An initial lever-on run regressed
+    `AnchorNameScopeTests` — a shared `--a` across two scopes — which is exactly what the *uniqueness* gate
+    now excludes.) New `Broiler.Wpt.Tests/NativeAnchorPlacementWptTests.cs` proves the engine places a
+    strict-MVP `position-area: bottom right` box at the grid-derived (60,60)–(89,89) through the **full**
+    `RenderHtmlFileBitmapPublic` pipeline (bridge in native mode does **not** bake — see
+    `NativeAnchorBridgeModeTests` — so the correct placement is the engine's), and that the baked and
+    native paths agree pixel-wise. Cli `~NativeAnchor` (3) and `~Anchor|~PositionArea` (13) green.
+- **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
+  default-off until each feature is on the engine path — percentage box props → box-sizing → inline-CB
+  promotion (DOM moves) → scroll simulation → `position-visibility` → dialog/backdrop → `anchor()` insets
+  → position-try. Each is currently excluded by `IsMvpNativeAnchorBox` and stays on the bridge path
+  (baked + `position-area: none`), so enabling the lever globally is already safe (proven above); the
+  expansions widen the MVP gate one feature at a time as the engine grows to reproduce them.
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4
   item-2 unblock** — once every feature is on the engine path.
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -18,12 +18,18 @@ public sealed partial class DomBridge
     /// <summary>
     /// Native anchor-placement mode (HtmlBridge complexity-reduction roadmap Phase 5
     /// item 3, P5.8d). Default off. When on, the bridge stops pre-baking
-    /// <c>position-area</c> into inline pixel styles and leaves the
-    /// <c>position-area</c>/<c>anchor-name</c>/<c>position-anchor</c> CSS intact, so the
+    /// <c>position-area</c> into inline pixel styles <em>for the MVP subset</em> —
+    /// a box with <c>position-area</c>, an explicit dashed-ident <c>position-anchor</c>,
+    /// a non-inline containing block, no intervening scroll container, and no
+    /// <c>position-try</c>/<c>anchor()</c> — leaving that box's
+    /// <c>position-area</c>/<c>anchor-name</c>/<c>position-anchor</c> CSS intact so the
     /// Broiler.Layout engine's anchor-placement post-pass (gated by
-    /// <c>Broiler.Layout.Engine.NativeAnchorPlacement.Enabled</c>) can place the boxes
-    /// natively during the final render. Internal: driven by the WPT runner lever and
-    /// tests; off in production until the cutover is complete.
+    /// <c>Broiler.Layout.Engine.NativeAnchorPlacement.Enabled</c>) places it during the
+    /// final render. Boxes outside the MVP subset stay on the bridge path: they are
+    /// baked as usual and marked <c>position-area: none</c> inline so the engine
+    /// post-pass skips them. When off, every box is baked exactly as today.
+    /// Internal: driven by the WPT runner lever and tests; off in production until the
+    /// cutover is complete.
     /// </summary>
     internal bool NativeAnchorPlacement { get; set; }
 
@@ -68,12 +74,12 @@ public sealed partial class DomBridge
         //    so IsAnchorVisibleForTarget is not affected by the new CB.
         var scrollContainersNeedingRelative = new HashSet<DomElement>();
         var deferredDomMoves = new List<(DomElement element, DomElement oldParent, DomElement newParent)>();
-        // Native mode (P5.8d): skip position-area pre-baking so the value survives to
-        // the render and the Broiler.Layout engine places the box natively.
-        if (!NativeAnchorPlacement)
-            ResolvePositionAreaValues(
-                DocumentElement, anchorRegistry, scrollContainersNeedingRelative,
-                deferredDomMoves);
+        // Native mode (P5.8d) makes this a per-element decision: MVP-subset boxes are
+        // left un-baked (their CSS survives for the engine post-pass) while every other
+        // box is baked as usual — see ResolvePositionAreaValues.
+        ResolvePositionAreaValues(
+            DocumentElement, anchorRegistry, scrollContainersNeedingRelative,
+            deferredDomMoves);
 
         // 3a2. Resolve align-self/justify-self: anchor-center on elements
         //      that have position-anchor but no position-area.

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
@@ -53,8 +53,17 @@ public sealed partial class DomBridge
 
                 // Compute the grid cell using the anchor's scroll container
                 // (or the element's own CB) as the containing block.
-                var rect = ComputePositionAreaRect(
-                    element, anchor, positionArea, scrollContainer);
+                //
+                // Native mode (P5.8d): for the MVP subset, skip pre-baking entirely
+                // (rect stays null) so the box's position-area/position-anchor CSS
+                // survives to the render and the Broiler.Layout engine's placement
+                // post-pass positions it natively. Every other box is baked below.
+                var rect =
+                    NativeAnchorPlacement &&
+                    IsMvpNativeAnchorBox(element, positionAnchor, cssProps, scrollContainer)
+                        ? null
+                        : ComputePositionAreaRect(
+                            element, anchor, positionArea, scrollContainer);
                 if (rect != null)
                 {
                     // Preserve position:fixed when the element already has it;
@@ -361,6 +370,13 @@ public sealed partial class DomBridge
                     // Store resolved offsets for JS offset property queries.
                     // Use border-box dimensions (matching offsetWidth/offsetHeight).
                     SetPositionAreaResolution(element, finalLeft, finalTop, borderBoxW, borderBoxH);
+
+                    // Native mode (P5.8d), non-MVP box: this box was just baked into
+                    // explicit inline pixel values, so neutralize position-area on it
+                    // (inline wins the cascade) to stop the engine's placement post-pass
+                    // from repositioning an already-placed box.
+                    if (NativeAnchorPlacement)
+                        InlineStyle(element)["position-area"] = "none";
                 }
             }
         }
@@ -378,6 +394,59 @@ public sealed partial class DomBridge
         foreach (var child in SnapshotChildren(element))
             ResolvePositionAreaValues(child, anchorRegistry, scrollContainersNeedingRelative,
                 deferredDomMoves);
+    }
+
+    /// <summary>
+    /// Decides whether a <c>position-area</c> box belongs to the native-placement MVP
+    /// subset (P5.8d.2b) — the boxes the Broiler.Layout engine's placement post-pass
+    /// currently reproduces exactly, so the bridge can hand them off instead of
+    /// pre-baking. Requires: an explicit dashed-ident <c>position-anchor</c>, a
+    /// non-inline containing block, no intervening scroll container, and no
+    /// <c>position-try</c> or <c>anchor()</c>/<c>anchor-size()</c> on the element
+    /// (those entangled features stay on the bridge path until later expansions).
+    /// </summary>
+    private bool IsMvpNativeAnchorBox(
+        DomElement element, string positionAnchor, Dictionary<string, string> cssProps,
+        DomElement? scrollContainer)
+    {
+        // No intervening scroll container (the anchor's scroll container is not this
+        // box's containing block).
+        if (scrollContainer != null)
+            return false;
+
+        // An explicit, named anchor — a dashed-ident like `--a`, not the default `auto`.
+        var anchorName = positionAnchor.Trim();
+        if (!anchorName.StartsWith("--", StringComparison.Ordinal))
+            return false;
+
+        // A *uniquely*-named anchor. The engine's AnchorRegistry is a flat,
+        // ordinal last-wins name→rect map with no scope awareness, so when several
+        // elements share an anchor-name the box must stay on the bridge's scoped
+        // resolution path (ResolveAnchorForElement binds within the query's own
+        // containing block). _anchorCandidates is built (BuildAnchorRegistry) before
+        // this pass, so its per-name candidate count is available here.
+        if (_anchorCandidates == null ||
+            !_anchorCandidates.TryGetValue(anchorName, out var candidates) ||
+            candidates.Count != 1)
+            return false;
+
+        // A non-inline containing block (the engine cannot yet promote abs-pos boxes
+        // out of inline containing blocks the way the bridge does).
+        var cb = FindContainingBlockElement(element);
+        if (cb != null && IsInlineContainingBlock(cb))
+            return false;
+
+        // position-try and anchor()/anchor-size() are out of the MVP subset.
+        if (cssProps.ContainsKey("position-try-fallbacks") || cssProps.ContainsKey("position-try"))
+            return false;
+        foreach (var value in cssProps.Values)
+        {
+            if (value.Contains("anchor(", StringComparison.OrdinalIgnoreCase) ||
+                value.Contains("anchor-size(", StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Broiler.Wpt.Tests/NativeAnchorPlacementWptTests.cs
+++ b/src/Broiler.Wpt.Tests/NativeAnchorPlacementWptTests.cs
@@ -1,0 +1,111 @@
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// End-to-end proof of the Phase 5 native anchor-placement cutover (P5.8d.2b) through
+/// the full WPT render pipeline (<see cref="WptTestRunner.RenderHtmlFileBitmapPublic"/>:
+/// parse → DomBridge script/anchor resolution → serialize → engine layout → raster).
+///
+/// With the runner's <see cref="WptTestRunner.NativeAnchorPlacement"/> lever on, the
+/// bridge does <em>not</em> pre-bake an MVP-subset <c>position-area</c> box (proven at
+/// the bridge level by <c>NativeAnchorBridgeModeTests</c> — the CSS survives
+/// serialization), yet the box is still positioned in the correct grid cell: that
+/// placement is the Broiler.Layout engine's post-pass. The same fixture with the lever
+/// off (the bridge pre-bakes) lands in the same cell, so the two paths agree.
+///
+/// Fixture (mirrors the P5.8d.1 pipeline test): a 200×200 <c>position:relative</c>
+/// containing block; a uniquely-named anchor <c>--a</c> (20×20 at (40,40), so its
+/// right/bottom edge is (60,60)); and a 30×30 red target with
+/// <c>position-area: bottom right</c> anchored to <c>--a</c>. The bottom-right cell is
+/// [60..200]×[60..200] and End alignment puts the 30×30 box at the cell start — so the
+/// red box occupies (60,60)–(89,89). This is strict MVP: an explicit uniquely-named
+/// anchor, a non-inline containing block, no scroll container, and no
+/// <c>position-try</c>/<c>anchor()</c>.
+/// </summary>
+public class NativeAnchorPlacementWptTests : IDisposable
+{
+    private readonly bool _previousLever = WptTestRunner.NativeAnchorPlacement;
+
+    public void Dispose()
+    {
+        WptTestRunner.NativeAnchorPlacement = _previousLever;
+        Program.ResetTestHooks();
+    }
+
+    private const string Html = @"<!DOCTYPE html><meta charset=""utf-8"">
+<style>
+  body { margin: 0; }
+  #cb { position: relative; width: 200px; height: 200px; }
+  #anchor { position: absolute; left: 40px; top: 40px; width: 20px; height: 20px; anchor-name: --a; }
+  #target { position: absolute; width: 30px; height: 30px; position-anchor: --a; position-area: bottom right; background: #ff0000; }
+</style>
+<div id=""cb""><div id=""anchor""></div><div id=""target""></div></div>";
+
+    private static (int x0, int y0, int x1, int y1, int count) RedBox(BBitmap bmp, int w, int h)
+    {
+        int x0 = int.MaxValue, y0 = int.MaxValue, x1 = -1, y1 = -1, count = 0;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                var p = bmp.GetPixel(x, y);
+                if (p.R > 200 && p.G < 80 && p.B < 80)
+                {
+                    count++;
+                    if (x < x0) x0 = x;
+                    if (y < y0) y0 = y;
+                    if (x > x1) x1 = x;
+                    if (y > y1) y1 = y;
+                }
+            }
+        return (x0, y0, x1, y1, count);
+    }
+
+    private static (int x0, int y0, int x1, int y1, int count) Render(bool nativeAnchor)
+    {
+        WptTestRunner.NativeAnchorPlacement = nativeAnchor;
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-native-anchor-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "mvp.html");
+            File.WriteAllText(file, Html);
+
+            var runner = new WptTestRunner(400, 400);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+            return RedBox(bmp, 400, 400);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void NativeLeverOn_EnginePlacesMvpPositionAreaBox_InBottomRightCell()
+    {
+        var red = Render(nativeAnchor: true);
+
+        Assert.True(red.count > 0, "red target box not painted under the native lever.");
+        Assert.True(System.Math.Abs(red.x0 - 60) <= 2, $"red left={red.x0}, expected ~60.");
+        Assert.True(System.Math.Abs(red.y0 - 60) <= 2, $"red top={red.y0}, expected ~60.");
+        Assert.True(System.Math.Abs(red.x1 - 89) <= 2, $"red right={red.x1}, expected ~89.");
+        Assert.True(System.Math.Abs(red.y1 - 89) <= 2, $"red bottom={red.y1}, expected ~89.");
+    }
+
+    [Fact]
+    public void BridgeAndEnginePaths_Agree_OnMvpPositionAreaBox()
+    {
+        // Lever off → the bridge pre-bakes; lever on → the engine post-pass places.
+        // Both must land the box in the same cell (native placement parity).
+        var baked = Render(nativeAnchor: false);
+        var native = Render(nativeAnchor: true);
+
+        Assert.True(baked.count > 0 && native.count > 0, "target box missing in one of the paths.");
+        Assert.True(System.Math.Abs(baked.x0 - native.x0) <= 2, $"left differs: baked={baked.x0}, native={native.x0}.");
+        Assert.True(System.Math.Abs(baked.y0 - native.y0) <= 2, $"top differs: baked={baked.y0}, native={native.y0}.");
+        Assert.True(System.Math.Abs(baked.x1 - native.x1) <= 2, $"right differs: baked={baked.x1}, native={native.x1}.");
+        Assert.True(System.Math.Abs(baked.y1 - native.y1) <= 2, $"bottom differs: baked={baked.y1}, native={native.y1}.");
+    }
+}

--- a/src/Broiler.Wpt/Broiler.Wpt.csproj
+++ b/src/Broiler.Wpt/Broiler.Wpt.csproj
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Direct reference so the runner can set the engine's native anchor-placement
+         flag (Broiler.Layout.Engine.NativeAnchorPlacement) around the final render;
+         Broiler.Layout grants Broiler.Wpt InternalsVisibleTo for P5.8d.2b. -->
+    <ProjectReference Include="..\..\Broiler.Layout\Broiler.Layout\Broiler.Layout.csproj" />
     <ProjectReference Include="..\..\Broiler.Graphics\Broiler.Graphics\Broiler.Graphics.csproj" />
     <ProjectReference Include="..\Broiler.HtmlBridge.Core\Broiler.HtmlBridge.Core.csproj" />
     <ProjectReference Include="..\Broiler.HtmlBridge.Dom\Broiler.HtmlBridge.Dom.csproj" />

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -324,6 +324,19 @@ internal sealed class WptTestRunner
         Environment.GetEnvironmentVariable("BROILER_WPT_DEFER_PROMISE_TESTS") is "1" or "true" or "TRUE";
 
     /// <summary>
+    /// Native anchor-placement cutover lever (HtmlBridge complexity-reduction roadmap
+    /// Phase 5, P5.8d.2b). Default <c>false</c>. When on, the runner puts the DomBridge
+    /// into native anchor mode (so MVP-subset <c>position-area</c> boxes keep their CSS
+    /// instead of being pre-baked) and enables the Broiler.Layout engine's placement
+    /// post-pass (<c>NativeAnchorPlacement.Enabled</c>) around only the final render, so
+    /// the engine — not the bridge — positions those boxes. Overridden by the
+    /// <c>BROILER_WPT_NATIVE_ANCHOR</c> environment variable. Kept default-off until
+    /// pixel parity is proven feature-by-feature across the css-anchor-position suite.
+    /// </summary>
+    internal static bool NativeAnchorPlacement { get; set; } =
+        Environment.GetEnvironmentVariable("BROILER_WPT_NATIVE_ANCHOR") is "1" or "true" or "TRUE";
+
+    /// <summary>
     /// File extensions treated as test files.
     /// </summary>
     private static readonly HashSet<string> TestExtensions = new(StringComparer.OrdinalIgnoreCase)
@@ -1474,9 +1487,9 @@ internal sealed class WptTestRunner
         HTML.Image.BBitmap rendered;
         try
         {
-            rendered = HtmlRender.RenderToImageWithStyleSet(html, _width, _height,
+            rendered = RenderWithNativeAnchor(() => HtmlRender.RenderToImageWithStyleSet(html, _width, _height,
                 backgroundColor: BColor.White,
-                stylesheetLoad: stylesheetHandler, imageLoad: imageHandler, baseUrl: testBaseUrl);
+                stylesheetLoad: stylesheetHandler, imageLoad: imageHandler, baseUrl: testBaseUrl));
         }
         catch (Exception ex)
         {
@@ -1761,9 +1774,32 @@ internal sealed class WptTestRunner
             };
         }
 
-        return HtmlRender.RenderToImageWithStyleSet(html, _width, _height,
+        return RenderWithNativeAnchor(() => HtmlRender.RenderToImageWithStyleSet(html, _width, _height,
             backgroundColor: BColor.White,
-            stylesheetLoad: stylesheetHandler, imageLoad: imageHandler, baseUrl: testBaseUrl);
+            stylesheetLoad: stylesheetHandler, imageLoad: imageHandler, baseUrl: testBaseUrl));
+    }
+
+    /// <summary>
+    /// Runs <paramref name="render"/> with the Broiler.Layout engine's native
+    /// anchor-placement post-pass enabled iff the runner lever is on (P5.8d.2b). The
+    /// engine flag is <c>[ThreadStatic]</c>, so enabling it here scopes it to this one
+    /// render on this thread — the earlier bridge geometry snapshots are unaffected.
+    /// </summary>
+    private static HTML.Image.BBitmap RenderWithNativeAnchor(Func<HTML.Image.BBitmap> render)
+    {
+        if (!NativeAnchorPlacement)
+            return render();
+
+        var previous = Broiler.Layout.Engine.NativeAnchorPlacement.Enabled;
+        Broiler.Layout.Engine.NativeAnchorPlacement.Enabled = true;
+        try
+        {
+            return render();
+        }
+        finally
+        {
+            Broiler.Layout.Engine.NativeAnchorPlacement.Enabled = previous;
+        }
     }
 
     internal HTML.Image.BBitmap RenderHtmlFileBitmapPublic(string htmlPath, string? wptRoot)
@@ -1988,7 +2024,7 @@ internal sealed class WptTestRunner
             // Even with no inline scripts, we still need to process anchor
             // positioning, animation snapshots, etc. via the DomBridge.
             using var context2 = new JSContext();
-            var bridge2 = new DomBridge();
+            var bridge2 = new DomBridge { NativeAnchorPlacement = NativeAnchorPlacement };
             bridge2.Attach(context2, html, url);
             // Inject browser API stubs so onload handlers etc. can reference them.
             try { context2.Eval(BrowserApiStubs); } catch { /* best-effort */ }
@@ -2001,7 +2037,7 @@ internal sealed class WptTestRunner
         }
 
         using var context = new JSContext();
-        var bridge = new DomBridge();
+        var bridge = new DomBridge { NativeAnchorPlacement = NativeAnchorPlacement };
         bridge.TaskCheckpointCallback = () => microTasks.Drain();
         context["queueMicrotask"] = new JSFunction((in Arguments a) =>
         {


### PR DESCRIPTION
## Summary

First slice of the Phase 5 **native anchor-positioning production flip** (roadmap `docs/roadmap/htmlbridge-complexity-reduction-roadmap.md`, P5.8d.2b — the "concentrated risk" cutover). The Broiler.Layout engine's anchor-placement post-pass (shipped default-off in #1387) can now position an **MVP-subset** `position-area` box during the final WPT render instead of the bridge pre-baking it into inline pixels — proven pixel-identical across the css-anchor-position suite, with the lever **default-off**.

This is the infrastructure + strict-MVP proof; the entangled features (percentage box props, box-sizing, inline-CB promotion, scroll, position-visibility, dialog/backdrop, `anchor()` insets, position-try) remain on the bridge path and are widened in one at a time later.

## What changed

- **`Broiler.Layout.csproj`** — `InternalsVisibleTo Broiler.Wpt` + a direct `Broiler.Wpt`→`Broiler.Layout` `ProjectReference` (it only reached Layout transitively before), so the runner can name and set the `[ThreadStatic]` `NativeAnchorPlacement.Enabled` flag.
- **Bridge `AnchorResolver` (`AnchorResolver.cs`, `PositionArea.cs`)** — replace P5.8d.2a's whole-function skip with **per-element MVP gating** inside `ResolvePositionAreaValues`. `IsMvpNativeAnchorBox` hands a box to the engine only when it has an explicit dashed-ident, **uniquely-named** `position-anchor` (via `_anchorCandidates` count — the engine registry is ordinal last-wins with no scope awareness), a non-inline containing block, no intervening scroll container, and no `position-try`/`anchor()`/`anchor-size()`. Non-MVP boxes stay baked and get `position-area: none` written inline so the engine post-pass skips them.
- **`WptTestRunner.cs`** — `BROILER_WPT_NATIVE_ANCHOR` env-var lever (default off) puts the bridge in native mode during script execution (both `DomBridge` instances) and enables the engine flag around **only** the two final `RenderToImageWithStyleSet` calls, restored in `finally`.
- **`NativeAnchorPlacementWptTests.cs`** (new) — proves the engine places an MVP `position-area: bottom right` box at the grid-derived (60,60)–(89,89) through the full `RenderHtmlFileBitmapPublic` pipeline, and that the baked and native paths agree.

## Why the uniqueness gate

The first lever-on run regressed `AnchorNameScopeTests` (two elements sharing `--a` across scopes): the engine's flat last-wins registry bound to the wrong anchor. Enforcing the roadmap's "uniquely-named anchor" MVP criterion via `_anchorCandidates` fixes it — shared-name boxes stay on the bridge's scoped resolution path.

## Validation

- **Default-off is byte-identical** (all gates are `if (NativeAnchorPlacement)`): `~Anchor|~Position|~Sticky` = 9 anchor-tail fails / 54 pass, matching baseline.
- **Lever-on across the whole suite reproduces the identical 9-pixel-fail set** — MVP boxes route through the engine, everything else stays baked. Zero regressions.
- Cli.Tests `~NativeAnchor` (3) and `~Anchor|~PositionArea` (13) green.

## Reviewer notes

- No submodule pointers touched — all changes are parent-repo (Broiler.Layout is parent-repo, not a submodule).
- The lever stays **default-off**; nothing changes in production until each entangled feature is proven on the engine path in its own follow-up PR. Enabling the lever globally is already safe (proven above) because non-MVP boxes are still baked.
- Roadmap + baseline memory updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)