### PR TITLE
HtmlBridge Phase 5 (P5.8d.2b): native position-area used-value expansions

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/AnchorRegistryTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/AnchorRegistryTests.cs
@@ -75,6 +75,34 @@ public sealed class AnchorRegistryTests
     }
 
     [Fact]
+    public void ScopedResolve_BindsToLastInScopeCandidate_ElseLastWins()
+    {
+        var scopeA = new object();
+        var scopeB = new object();
+        var r = new AnchorRegistry();
+        r.Register("--a", new AnchorRect(0, 0, 10, 10), scopeA); // width 10
+        r.Register("--a", new AnchorRect(0, 0, 20, 20), scopeB); // width 20 (last)
+
+        // In scopeA → binds the first candidate; in scopeB → the second.
+        Assert.Equal(10, r.ResolveAnchorSize("--a", AnchorSizeDimension.Width, s => s == scopeA));
+        Assert.Equal(20, r.ResolveAnchorSize("--a", AnchorSizeDimension.Width, s => s == scopeB));
+        // None in scope → last-wins.
+        Assert.Equal(20, r.ResolveAnchorSize("--a", AnchorSizeDimension.Width, _ => false));
+        // No predicate → last-wins.
+        Assert.Equal(20, r.ResolveAnchorSize("--a", AnchorSizeDimension.Width));
+    }
+
+    [Fact]
+    public void ScopedResolve_SingleCandidate_IgnoresScopePredicate()
+    {
+        var r = new AnchorRegistry();
+        r.Register("--a", new AnchorRect(0, 0, 10, 10), new object());
+        // A single candidate always resolves, even when the predicate excludes it
+        // (only duplicate names consult scope — matching the bridge).
+        Assert.Equal(10, r.ResolveAnchorSize("--a", AnchorSizeDimension.Width, _ => false));
+    }
+
+    [Fact]
     public void UnknownAnchor_ReturnsNull()
     {
         var r = WithAnchor();

--- a/Broiler.Layout/Broiler.Layout.Tests/LayoutArchitectureTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/LayoutArchitectureTests.cs
@@ -51,6 +51,9 @@ public sealed class LayoutArchitectureTests
                 "Broiler.HTML.Dom",
                 "Broiler.HTML.Orchestration",
                 "Broiler.Layout.Tests",
+                // The WPT runner toggles NativeAnchorPlacement.Enabled around the final
+                // render for the Phase 5 native anchor-placement cutover (P5.8d.2b).
+                "Broiler.Wpt",
             ],
             friends);
     }

--- a/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
@@ -177,10 +177,16 @@ public sealed class NativeAnchorPlacementTests
     }
 
     [Fact]
-    public void Pass_KeepsLaidOutSize_ForBorderBoxSizing()
+    public void Pass_BorderBox_TreatsResolvedSizeAsBorderBox()
     {
         var (root, _) = FillCellFixture(out var target);
-        target.BoxSizing = "border-box"; // out of the sizing slice → reposition-only
+        // With box-sizing: border-box the authored width IS the border box, so padding
+        // and border are NOT added on top (content-box would give 50 + 10+10 = 70).
+        target.BoxSizing = "border-box";
+        target.Width = "50px";
+        target.Height = "50px";
+        target.PaddingLeft = "10px";
+        target.PaddingRight = "10px";
         try
         {
             NativeAnchorPlacement.Enabled = true;
@@ -188,8 +194,28 @@ public sealed class NativeAnchorPlacementTests
         }
         finally { NativeAnchorPlacement.Enabled = false; }
 
-        Assert.Equal(30, target.Size.Width, 3);
-        Assert.Equal(30, target.Size.Height, 3);
+        Assert.Equal(50, target.Size.Width, 3);   // border box = authored 50px
+        Assert.Equal(50, target.Size.Height, 3);
+    }
+
+    [Fact]
+    public void Pass_BorderBox_FillsCell_AsBorderBox()
+    {
+        var (root, _) = FillCellFixture(out var target);
+        // Auto width + border-box → the border box fills the cell (140), padding/border
+        // eat into the content box rather than extending beyond the cell.
+        target.BoxSizing = "border-box";
+        target.PaddingLeft = "10px";
+        target.PaddingRight = "10px";
+        try
+        {
+            NativeAnchorPlacement.Enabled = true;
+            CssBox.RunNativeAnchorPlacement(root);
+        }
+        finally { NativeAnchorPlacement.Enabled = false; }
+
+        Assert.Equal(140, target.Size.Width, 3);
+        Assert.Equal(140, target.Size.Height, 3);
     }
 
     // Shared fixture: CB 200×200 at origin, anchor --a (20×20 at (40,40)), and a

--- a/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
@@ -261,6 +261,40 @@ public sealed class NativeAnchorPlacementTests
     }
 
     [Fact]
+    public void Pass_PercentBoxProps_ResolveAgainstCellHeight_ForVerticalContainingBlock()
+    {
+        // A non-square cell in a vertical-writing-mode CB: percentage margins/padding must
+        // resolve against the cell's INLINE size, which is the cell HEIGHT here (CSS
+        // Writing Modes §7.4) — not the width the bridge always used.
+        var root = Box(null, new PointF(0, 0), new SizeF(1000, 1000));
+        var cb = Box(root, new PointF(0, 0), new SizeF(200, 100));
+        cb.Position = "relative";
+        cb.Display = "block";
+        cb.WritingMode = "vertical-rl";
+        var anchor = Box(cb, new PointF(40, 40), new SizeF(20, 20));
+        anchor.AnchorName = "--a";
+        var target = Box(cb, new PointF(0, 0), new SizeF(30, 30));
+        target.Position = "absolute";
+        target.Display = "block";
+        target.PositionArea = "bottom right"; // cell = (60,60,140,40): cellW 140, cellH 40
+        target.PositionAnchor = "--a";
+        target.MarginLeft = "10%"; // 10% of cell HEIGHT 40 = 4 (NOT 14 = 10% of width)
+
+        try
+        {
+            NativeAnchorPlacement.Enabled = true;
+            CssBox.RunNativeAnchorPlacement(root);
+        }
+        finally { NativeAnchorPlacement.Enabled = false; }
+
+        // border box width = imcb 140 - margin 4 = 136; positioned at imcbLeft 60 + margin 4.
+        Assert.Equal(136, target.Size.Width, 3);
+        Assert.Equal(40, target.Size.Height, 3);
+        Assert.Equal(64, target.Location.X, 3);
+        Assert.Equal("4px", target.MarginLeft);
+    }
+
+    [Fact]
     public void Pass_SharedAnchorName_BindsWithinOwnContainingBlockScope()
     {
         // Two sibling relative containers each declare anchor-name --a and hold a

--- a/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
@@ -218,6 +218,48 @@ public sealed class NativeAnchorPlacementTests
         Assert.Equal(140, target.Size.Height, 3);
     }
 
+    [Fact]
+    public void Pass_PercentMargin_StretchesMarginBoxToImcb()
+    {
+        var (root, _) = FillCellFixture(out var target);
+        // Auto width (stretch) + percentage margin-left → the margin box fills the cell
+        // (IMCB = cell 140), so the border box shrinks by the resolved margin and shifts.
+        target.MarginLeft = "10%"; // 10% of cell 140 = 14
+        try
+        {
+            NativeAnchorPlacement.Enabled = true;
+            CssBox.RunNativeAnchorPlacement(root);
+        }
+        finally { NativeAnchorPlacement.Enabled = false; }
+
+        Assert.Equal(126, target.Size.Width, 3);   // 140 - 14
+        Assert.Equal(140, target.Size.Height, 3);
+        Assert.Equal(74, target.Location.X, 3);     // imcbLeft 60 + margin 14
+        Assert.Equal(60, target.Location.Y, 3);
+        Assert.Equal("14px", target.MarginLeft);    // resolved px written back
+    }
+
+    [Fact]
+    public void Pass_PercentPadding_ResolvedAgainstCell_FillsImcb()
+    {
+        var (root, _) = FillCellFixture(out var target);
+        // Auto width + percentage padding → the border box still fills the IMCB (140);
+        // padding eats the content box, and is written back resolved against the cell.
+        target.PaddingLeft = "10%"; target.PaddingRight = "10%"; // 14 each of cell 140
+        try
+        {
+            NativeAnchorPlacement.Enabled = true;
+            CssBox.RunNativeAnchorPlacement(root);
+        }
+        finally { NativeAnchorPlacement.Enabled = false; }
+
+        Assert.Equal(140, target.Size.Width, 3);   // content 112 + padding 14+14
+        Assert.Equal(140, target.Size.Height, 3);
+        Assert.Equal(60, target.Location.X, 3);
+        Assert.Equal("14px", target.PaddingLeft);   // % resolved against cell width, not own width
+        Assert.Equal("14px", target.PaddingRight);
+    }
+
     // Shared fixture: CB 200×200 at origin, anchor --a (20×20 at (40,40)), and a
     // childless absolutely-positioned "bottom right" target (30×30 at origin).
     private static (CssBox root, CssBox cb) FillCellFixture(out CssBox target)

--- a/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
@@ -19,6 +19,11 @@ public sealed class NativeAnchorPlacementTests
     private static CssBox Box(CssBox parent, PointF location, SizeF size)
     {
         var b = new CssBox(parent, null, BaseUrl) { Location = location, Size = size };
+        // Root boxes get a minimal layout environment so the containing-block resolution
+        // (which reads Actual border widths → the box's em/font) works on these synthetic
+        // trees; children inherit it. Sizes are irrelevant — the test boxes carry no text.
+        if (parent == null)
+            b.LayoutEnvironment = new FakeLayoutEnvironment();
         return b;
     }
 
@@ -60,16 +65,20 @@ public sealed class NativeAnchorPlacementTests
         var root = Box(null, new PointF(0, 0), new SizeF(1000, 1000));
         var cb = Box(root, new PointF(0, 0), new SizeF(200, 200));
         cb.Position = "relative";
+        cb.Display = "block"; // a real (non-inline) containing block
 
         // Anchor: 20×20 border box at (40,40) → right/bottom = 60.
         var anchor = Box(cb, new PointF(40, 40), new SizeF(20, 20));
         anchor.AnchorName = "--a";
 
-        // Target: absolutely positioned, position-area "bottom right", 30×30, at origin.
+        // Target: absolutely positioned, position-area "bottom right", explicit 30×30
+        // (definite content size), at origin.
         var target = Box(cb, new PointF(0, 0), new SizeF(30, 30));
         target.Position = "absolute";
         target.PositionArea = "bottom right";
         target.PositionAnchor = "--a";
+        target.Width = "30px";
+        target.Height = "30px";
 
         // "bottom right" cell = [anchorRight..gridRight] × [anchorBottom..gridBottom]
         //   = [60..200] × [60..200]; End alignment puts the box at the cell start → (60,60).
@@ -85,9 +94,133 @@ public sealed class NativeAnchorPlacementTests
 
         Assert.Equal(60, target.Location.X, 3);
         Assert.Equal(60, target.Location.Y, 3);
-        // Size is unchanged (reposition-only MVP).
+        // Explicit content size, no padding/border → border box stays 30×30.
         Assert.Equal(30, target.Size.Width, 3);
         Assert.Equal(30, target.Size.Height, 3);
+    }
+
+    [Fact]
+    public void Pass_FillsCell_WhenAutoWidthChildlessBox()
+    {
+        var (root, cb) = FillCellFixture(out var target);
+        // Auto width/height (default) + childless + content-box → fills the cell.
+        try
+        {
+            NativeAnchorPlacement.Enabled = true;
+            CssBox.RunNativeAnchorPlacement(root);
+        }
+        finally { NativeAnchorPlacement.Enabled = false; }
+        _ = cb;
+
+        // Cell = [60..200] × [60..200] = 140×140; no insets → fills 140×140 at (60,60).
+        Assert.Equal(60, target.Location.X, 3);
+        Assert.Equal(60, target.Location.Y, 3);
+        Assert.Equal(140, target.Size.Width, 3);
+        Assert.Equal(140, target.Size.Height, 3);
+    }
+
+    [Fact]
+    public void Pass_ResolvesPercentSize_AgainstCell()
+    {
+        var (root, _) = FillCellFixture(out var target);
+        target.Width = "25%";   // 25% of cellW 140 = 35
+        target.Height = "50%";  // 50% of cellH 140 = 70
+        try
+        {
+            NativeAnchorPlacement.Enabled = true;
+            CssBox.RunNativeAnchorPlacement(root);
+        }
+        finally { NativeAnchorPlacement.Enabled = false; }
+
+        Assert.Equal(35, target.Size.Width, 3);
+        Assert.Equal(70, target.Size.Height, 3);
+    }
+
+    [Fact]
+    public void Pass_AddsPaddingAndBorder_ToContentSize_ForBorderBox()
+    {
+        var (root, _) = FillCellFixture(out var target);
+        target.Width = "20px";
+        target.Height = "20px";
+        target.PaddingLeft = "5px";
+        target.PaddingRight = "5px";
+        try
+        {
+            NativeAnchorPlacement.Enabled = true;
+            CssBox.RunNativeAnchorPlacement(root);
+        }
+        finally { NativeAnchorPlacement.Enabled = false; }
+
+        // content-box 20 + padding 5+5 → border-box width 30; height unaffected (20).
+        Assert.Equal(30, target.Size.Width, 3);
+        Assert.Equal(20, target.Size.Height, 3);
+    }
+
+    [Fact]
+    public void Pass_KeepsLaidOutSize_WhenBoxHasChildren()
+    {
+        var (root, _) = FillCellFixture(out var target);
+        // A childful box cannot be resized without re-flow → reposition-only.
+        _ = Box(target, new PointF(0, 0), new SizeF(10, 10));
+        try
+        {
+            NativeAnchorPlacement.Enabled = true;
+            CssBox.RunNativeAnchorPlacement(root);
+        }
+        finally { NativeAnchorPlacement.Enabled = false; }
+
+        Assert.Equal(60, target.Location.X, 3);
+        Assert.Equal(60, target.Location.Y, 3);
+        // Size preserved (auto width would otherwise fill the cell).
+        Assert.Equal(30, target.Size.Width, 3);
+        Assert.Equal(30, target.Size.Height, 3);
+    }
+
+    [Fact]
+    public void Pass_KeepsLaidOutSize_ForBorderBoxSizing()
+    {
+        var (root, _) = FillCellFixture(out var target);
+        target.BoxSizing = "border-box"; // out of the sizing slice → reposition-only
+        try
+        {
+            NativeAnchorPlacement.Enabled = true;
+            CssBox.RunNativeAnchorPlacement(root);
+        }
+        finally { NativeAnchorPlacement.Enabled = false; }
+
+        Assert.Equal(30, target.Size.Width, 3);
+        Assert.Equal(30, target.Size.Height, 3);
+    }
+
+    // Shared fixture: CB 200×200 at origin, anchor --a (20×20 at (40,40)), and a
+    // childless absolutely-positioned "bottom right" target (30×30 at origin).
+    private static (CssBox root, CssBox cb) FillCellFixture(out CssBox target)
+    {
+        var root = Box(null, new PointF(0, 0), new SizeF(1000, 1000));
+        var cb = Box(root, new PointF(0, 0), new SizeF(200, 200));
+        cb.Position = "relative";
+        cb.Display = "block"; // a real (non-inline) containing block
+        var anchor = Box(cb, new PointF(40, 40), new SizeF(20, 20));
+        anchor.AnchorName = "--a";
+        target = Box(cb, new PointF(0, 0), new SizeF(30, 30));
+        target.Position = "absolute";
+        target.PositionArea = "bottom right";
+        target.PositionAnchor = "--a";
+        return (root, cb);
+    }
+
+    [Theory]
+    [InlineData("30px", 30.0, null)]
+    [InlineData("50%", null, 50.0)]
+    [InlineData("42", 42.0, null)]
+    [InlineData("auto", null, null)]
+    [InlineData("", null, null)]
+    [InlineData("1em", null, null)]
+    public void ParseSizeComponent_MatchesBridgeSemantics(string value, double? px, double? pct)
+    {
+        var (ep, p) = CssBox.ParseSizeComponent(value);
+        Assert.Equal(px, ep);
+        Assert.Equal(pct, p);
     }
 
     [Fact]
@@ -96,6 +229,7 @@ public sealed class NativeAnchorPlacementTests
         var root = Box(null, new PointF(0, 0), new SizeF(1000, 1000));
         var cb = Box(root, new PointF(0, 0), new SizeF(200, 200));
         cb.Position = "relative";
+        cb.Display = "block"; // a real (non-inline) containing block
         var target = Box(cb, new PointF(7, 9), new SizeF(30, 30));
         target.Position = "absolute";
         target.PositionArea = "bottom right";
@@ -113,5 +247,41 @@ public sealed class NativeAnchorPlacementTests
 
         Assert.Equal(7, target.Location.X, 3);
         Assert.Equal(9, target.Location.Y, 3);
+    }
+
+    // Minimal layout environment for the synthetic box trees: resolves a fixed-size
+    // font (so em-based Actual border/padding widths compute) and returns benign
+    // defaults for everything else. The test boxes carry no text or replaced content,
+    // so the measurement/image/colour members are never exercised.
+    private sealed class FakeLayoutEnvironment : Broiler.Layout.ILayoutEnvironment
+    {
+        private static readonly Broiler.Graphics.ILayoutFont TheFont = new FakeFont();
+        public Broiler.Graphics.ILayoutFont GetFont(string family, double size, LayoutFontStyle style, string? fontFeatures = null) => TheFont;
+        public SizeF MeasureText(Broiler.Graphics.ILayoutFont font, string text) => SizeF.Empty;
+        public void MeasureText(Broiler.Graphics.ILayoutFont font, string text, double maxWidth, out int charFit, out double charFitWidth) { charFit = 0; charFitWidth = 0; }
+        public double GetWhitespaceWidth(Broiler.Graphics.ILayoutFont font) => 0;
+        public Broiler.Layout.ImageIntrinsics GetImageIntrinsics(object imageHandle) => default;
+        public Broiler.Graphics.BColor ParseColor(string value) => default;
+        public void RequestRefresh(bool relayout) { }
+        public SizeF ViewportSize => new(1000, 1000);
+        public PointF RootLocation => PointF.Empty;
+        public SizeF ActualSize { get; set; }
+        public bool AvoidGeometryAntialias => false;
+        public SizeF PageSize => new(1000, 1000);
+        public int MarginTop => 0;
+        public void ReportLayoutError(string message, Exception? exception = null) { }
+        public bool AvoidAsyncImagesLoading => true;
+        public bool AvoidImagesLateLoading => true;
+        public Broiler.Layout.ILayoutImageLoader CreateImageLoader(Action<object?, RectangleF, bool> onComplete) => null!;
+        public string FormatListMarker(int number, string style) => string.Empty;
+    }
+
+    private sealed class FakeFont : Broiler.Graphics.ILayoutFont
+    {
+        public double Size => 16;
+        public double Height => 16;
+        public double UnderlineOffset => 0;
+        public double LeftPadding => 0;
+        public string? FontFeatures => null;
     }
 }

--- a/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
@@ -260,6 +260,50 @@ public sealed class NativeAnchorPlacementTests
         Assert.Equal("14px", target.PaddingRight);
     }
 
+    [Fact]
+    public void Pass_SharedAnchorName_BindsWithinOwnContainingBlockScope()
+    {
+        // Two sibling relative containers each declare anchor-name --a and hold a
+        // "bottom right" target. With scope-aware resolution each target must bind to the
+        // anchor in ITS OWN container — not the global last-registered --a.
+        var root = Box(null, new PointF(0, 0), new SizeF(1000, 1000));
+
+        CssBox MakeContainer(float x, out CssBox target)
+        {
+            var cb = Box(root, new PointF(x, 0), new SizeF(200, 200));
+            cb.Position = "relative";
+            cb.Display = "block";
+            var anchor = Box(cb, new PointF(x + 40, 40), new SizeF(20, 20));
+            anchor.AnchorName = "--a";
+            target = Box(cb, new PointF(0, 0), new SizeF(30, 30));
+            target.Position = "absolute";
+            target.Display = "block";
+            target.PositionArea = "bottom right";
+            target.PositionAnchor = "--a";
+            target.Width = "30px";
+            target.Height = "30px";
+            return cb;
+        }
+
+        MakeContainer(0, out var targetA);
+        MakeContainer(300, out var targetB);
+
+        try
+        {
+            NativeAnchorPlacement.Enabled = true;
+            CssBox.RunNativeAnchorPlacement(root);
+        }
+        finally { NativeAnchorPlacement.Enabled = false; }
+
+        // targetA binds anchorA (right/bottom = 60) in container A → (60,60).
+        Assert.Equal(60, targetA.Location.X, 3);
+        Assert.Equal(60, targetA.Location.Y, 3);
+        // targetB binds anchorB (at x=340 → right 360, bottom 60) in container B → (360,60).
+        // A flat last-wins registry would bind BOTH to anchorB, collapsing targetA's cell.
+        Assert.Equal(360, targetB.Location.X, 3);
+        Assert.Equal(60, targetB.Location.Y, 3);
+    }
+
     // Shared fixture: CB 200×200 at origin, anchor --a (20×20 at (40,40)), and a
     // childless absolutely-positioned "bottom right" target (30×30 at origin).
     private static (CssBox root, CssBox cb) FillCellFixture(out CssBox target)

--- a/Broiler.Layout/Broiler.Layout/AnchorRegistry.cs
+++ b/Broiler.Layout/Broiler.Layout/AnchorRegistry.cs
@@ -32,50 +32,102 @@ public readonly record struct AnchorRect(double Left, double Top, double Width, 
 /// </remarks>
 public sealed class AnchorRegistry
 {
-    // Anchor names are custom idents — case-sensitive (ordinal), last registration wins.
-    private readonly Dictionary<string, AnchorRect> _anchors = new(StringComparer.Ordinal);
+    // Anchor names are custom idents — case-sensitive (ordinal). Each name keeps ALL
+    // registered candidates in registration (tree/document) order so a query can bind to
+    // the acceptable anchor in its own scope when several elements share a name; a
+    // scope-free lookup uses the last one (last-wins). Each candidate carries an opaque
+    // caller-supplied scope token (e.g. the source box) the caller's scope predicate
+    // interprets — the registry stays free of any box-tree/DOM knowledge.
+    private readonly Dictionary<string, List<(AnchorRect Rect, object? Scope)>> _anchors =
+        new(StringComparer.Ordinal);
 
-    /// <summary>Number of registered anchors.</summary>
+    /// <summary>Number of distinct registered anchor names.</summary>
     public int Count => _anchors.Count;
 
     /// <summary>
-    /// Registers (or replaces) the border-box rectangle of the anchor named
-    /// <paramref name="anchorName"/>.
+    /// Registers the border-box rectangle of an anchor named <paramref name="anchorName"/>,
+    /// with an optional opaque <paramref name="scope"/> token (interpreted only by the
+    /// scope predicate a caller passes to the resolve methods). Multiple registrations for
+    /// one name are all kept, in order; a scope-free query uses the last.
     /// </summary>
-    public void Register(string anchorName, AnchorRect rect)
+    public void Register(string anchorName, AnchorRect rect, object? scope = null)
     {
         ArgumentNullException.ThrowIfNull(anchorName);
-        _anchors[anchorName] = rect;
+        if (!_anchors.TryGetValue(anchorName, out var list))
+            _anchors[anchorName] = list = [];
+        list.Add((rect, scope));
     }
 
-    /// <summary>Looks up a registered anchor's rectangle.</summary>
-    public bool TryGet(string anchorName, out AnchorRect rect) => _anchors.TryGetValue(anchorName, out rect);
+    /// <summary>Looks up a registered anchor's rectangle (last registration wins).</summary>
+    public bool TryGet(string anchorName, out AnchorRect rect)
+    {
+        if (_anchors.TryGetValue(anchorName, out var list) && list.Count > 0)
+        {
+            rect = list[^1].Rect;
+            return true;
+        }
+        rect = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves the acceptable anchor rectangle for a query. When several elements share
+    /// the name and <paramref name="inScope"/> is supplied, binds to the LAST candidate
+    /// (registration order) whose scope token satisfies the predicate — the query's own
+    /// scope; otherwise (no predicate, single candidate, or none in scope) the last
+    /// registration wins. Mirrors the bridge's <c>ResolveAnchorForElement</c>.
+    /// </summary>
+    private bool TryResolve(string anchorName, Func<object?, bool>? inScope, out AnchorRect rect)
+    {
+        if (!_anchors.TryGetValue(anchorName, out var list) || list.Count == 0)
+        {
+            rect = default;
+            return false;
+        }
+        if (inScope != null && list.Count > 1)
+        {
+            AnchorRect? scoped = null;
+            foreach (var (r, s) in list)
+                if (inScope(s))
+                    scoped = r; // keep the last in-scope candidate
+            if (scoped is { } sr)
+            {
+                rect = sr;
+                return true;
+            }
+        }
+        rect = list[^1].Rect;
+        return true;
+    }
 
     /// <summary>
     /// Resolves the <c>position-area</c> grid cell for an anchored box against the
-    /// named anchor and the box's containing-block frame. Returns <c>null</c> when the
-    /// anchor is not registered (the caller falls back to normal positioning).
+    /// named anchor (in the query's scope, per <paramref name="inScope"/>) and the box's
+    /// containing-block frame. Returns <c>null</c> when the anchor is not registered (the
+    /// caller falls back to normal positioning).
     /// </summary>
     public PositionAreaCell? ResolvePositionAreaCell(
         string anchorName, PositionAreaValue area,
-        double cbX, double cbY, double cbWidth, double cbHeight)
+        double cbX, double cbY, double cbWidth, double cbHeight,
+        Func<object?, bool>? inScope = null)
     {
-        if (!_anchors.TryGetValue(anchorName, out var a))
+        if (!TryResolve(anchorName, inScope, out var a))
             return null;
         return PositionAreaGrid.ComputeCell(
             cbX, cbY, cbWidth, cbHeight, a.Left, a.Top, a.Right, a.Bottom, area);
     }
 
     /// <summary>
-    /// Resolves an <c>anchor(&lt;side&gt;)</c> reference against the named anchor.
-    /// Returns <c>null</c> when the anchor is not registered.
+    /// Resolves an <c>anchor(&lt;side&gt;)</c> reference against the named anchor (in the
+    /// query's scope). Returns <c>null</c> when the anchor is not registered.
     /// </summary>
     public double? ResolveAnchorEdge(
         string anchorName, AnchorSide side,
         double scrollAdjX, double scrollAdjY,
-        AnchorInsetProperty property, double cbWidth, double cbHeight)
+        AnchorInsetProperty property, double cbWidth, double cbHeight,
+        Func<object?, bool>? inScope = null)
     {
-        if (!_anchors.TryGetValue(anchorName, out var a))
+        if (!TryResolve(anchorName, inScope, out var a))
             return null;
         return AnchorGeometry.ResolveEdge(
             a.Left, a.Top, a.Right, a.Bottom, side, scrollAdjX, scrollAdjY, property, cbWidth, cbHeight);
@@ -83,11 +135,12 @@ public sealed class AnchorRegistry
 
     /// <summary>
     /// Resolves an <c>anchor-size(&lt;dimension&gt;)</c> reference against the named
-    /// anchor. Returns <c>null</c> when the anchor is not registered.
+    /// anchor (in the query's scope). Returns <c>null</c> when the anchor is not registered.
     /// </summary>
-    public double? ResolveAnchorSize(string anchorName, AnchorSizeDimension dimension)
+    public double? ResolveAnchorSize(string anchorName, AnchorSizeDimension dimension,
+        Func<object?, bool>? inScope = null)
     {
-        if (!_anchors.TryGetValue(anchorName, out var a))
+        if (!TryResolve(anchorName, inScope, out var a))
             return null;
         return AnchorGeometry.ResolveSize(dimension, a.Width, a.Height);
     }

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
@@ -172,15 +172,24 @@ partial class CssBox
     /// </summary>
     private void ApplyPercentBoxPropsPlacement(PositionAreaBox target, PositionAreaCell cell)
     {
-        double cellW = cell.Width;
+        // CSS Writing Modes §7.4: percentage margins and padding resolve against the
+        // INLINE size of the containing block. The containing block here is the
+        // position-area cell in the containing block's writing mode, so the inline size is
+        // the cell width for a horizontal CB and the cell HEIGHT for a vertical one.
+        // (Insets keep resolving against their own physical axis — done in ResolveInset.)
+        var cbBox = FindPositionedContainingBlock();
+        double inlineSize = cbBox != null && IsVerticalWritingMode(cbBox.WritingMode)
+            ? cell.Height
+            : cell.Width;
 
-        // Margins and padding: percentage against the cell inline size, else px (CSS
-        // %-margin/padding always resolve against the containing block's inline size,
-        // which is the cell here — matching the bridge's ResolvePctOrPx(..., cellW)).
-        double mT = ResolveEdgeAgainstCell(MarginTop, cellW), mR = ResolveEdgeAgainstCell(MarginRight, cellW);
-        double mB = ResolveEdgeAgainstCell(MarginBottom, cellW), mL = ResolveEdgeAgainstCell(MarginLeft, cellW);
-        double pT = ResolveEdgeAgainstCell(PaddingTop, cellW), pR = ResolveEdgeAgainstCell(PaddingRight, cellW);
-        double pB = ResolveEdgeAgainstCell(PaddingBottom, cellW), pL = ResolveEdgeAgainstCell(PaddingLeft, cellW);
+        // Margins and padding: percentage against the cell inline size, else px (matching
+        // the bridge's ResolvePctOrPx — but the bridge always used the width, so this
+        // diverges from the baked path only for a vertical containing block, which the
+        // bridge gets wrong).
+        double mT = ResolveEdgeAgainstCell(MarginTop, inlineSize), mR = ResolveEdgeAgainstCell(MarginRight, inlineSize);
+        double mB = ResolveEdgeAgainstCell(MarginBottom, inlineSize), mL = ResolveEdgeAgainstCell(MarginLeft, inlineSize);
+        double pT = ResolveEdgeAgainstCell(PaddingTop, inlineSize), pR = ResolveEdgeAgainstCell(PaddingRight, inlineSize);
+        double pB = ResolveEdgeAgainstCell(PaddingBottom, inlineSize), pL = ResolveEdgeAgainstCell(PaddingLeft, inlineSize);
         double bT = NativeBorderPx(BorderTopWidth, BorderTopStyle), bR = NativeBorderPx(BorderRightWidth, BorderRightStyle);
         double bB = NativeBorderPx(BorderBottomWidth, BorderBottomStyle), bL = NativeBorderPx(BorderLeftWidth, BorderLeftStyle);
 

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
@@ -63,32 +63,41 @@ partial class CssBox
     {
         if (box.PositionArea != "none" && box.TryResolvePositionAreaTarget(registry, out var target))
         {
-            // Apply the used SIZE first (P5.8d.2b sizing slice) for the boxes the engine
+            // Apply the used SIZE first (P5.8d.2b sizing slices) for the boxes the engine
             // can size without re-flowing a subtree: a childless box (no in-flow children
-            // or words), content-box sizing, and no percentage margin/padding/inset box
-            // properties (those resolve against the cell and need the bridge's explicit
-            // pre-bake for now). For such a box the grid-derived used width/height fills
-            // the cell / honours an explicit or percentage size exactly as the baked
-            // bridge path does; setting its border box repaints correctly with no
-            // children to re-flow. Every other box keeps the reposition-only MVP
-            // behaviour (its already-laid-out size is preserved).
+            // or words) with no percentage margin/padding/inset box properties (those
+            // resolve against the cell and need the bridge's explicit pre-bake for now).
+            // For such a box the grid-derived used size fills the cell / honours an explicit
+            // or percentage length exactly as the baked bridge path does; setting its border
+            // box repaints correctly with no children to re-flow. Every other box keeps the
+            // reposition-only behaviour (its already-laid-out size is preserved).
             if (box.CanApplyNativeAnchorSize())
             {
-                // target.Width/Height are the content-box used size. Add the box's own
-                // padding + border to form the border box (SizeF). Border/padding are read
-                // font-free (px + the CSS thin/medium/thick keyword map, style:none → 0) —
-                // matching the bridge's ResolveBorderWidth and avoiding the layout font the
-                // Actual* getters resolve (percentage padding is excluded by the gate).
-                double borderBoxW = target.Width
-                    + box.NativeBorderPx(box.BorderLeftWidth, box.BorderLeftStyle)
-                    + box.NativePaddingPx(box.PaddingLeft)
-                    + box.NativePaddingPx(box.PaddingRight)
+                // The box's own padding + border, read font-free (px + the CSS
+                // thin/medium/thick keyword map, style:none → 0 — matching the bridge's
+                // ResolveBorderWidth and avoiding the layout font the Actual* getters
+                // resolve; percentage padding is excluded by the gate).
+                double padBorderW =
+                    box.NativeBorderPx(box.BorderLeftWidth, box.BorderLeftStyle)
+                    + box.NativePaddingPx(box.PaddingLeft) + box.NativePaddingPx(box.PaddingRight)
                     + box.NativeBorderPx(box.BorderRightWidth, box.BorderRightStyle);
-                double borderBoxH = target.Height
-                    + box.NativeBorderPx(box.BorderTopWidth, box.BorderTopStyle)
-                    + box.NativePaddingPx(box.PaddingTop)
-                    + box.NativePaddingPx(box.PaddingBottom)
+                double padBorderH =
+                    box.NativeBorderPx(box.BorderTopWidth, box.BorderTopStyle)
+                    + box.NativePaddingPx(box.PaddingTop) + box.NativePaddingPx(box.PaddingBottom)
                     + box.NativeBorderPx(box.BorderBottomWidth, box.BorderBottomStyle);
+
+                // box-sizing: content-box (default) — target.Width/Height are the content
+                // size, so the border box adds padding+border. box-sizing: border-box —
+                // target.Width/Height already ARE the (cell-clamped/filled) border box, so
+                // use them directly, clamped to at least padding+border so the content box
+                // stays non-negative (mirrors the bridge's BorderBoxToContentSize + re-add).
+                bool borderBox = string.Equals(box.BoxSizing, "border-box", StringComparison.OrdinalIgnoreCase);
+                double borderBoxW = borderBox
+                    ? System.Math.Max(target.Width, padBorderW)
+                    : target.Width + padBorderW;
+                double borderBoxH = borderBox
+                    ? System.Math.Max(target.Height, padBorderH)
+                    : target.Height + padBorderH;
                 box.Size = new System.Drawing.SizeF((float)borderBoxW, (float)borderBoxH);
             }
 
@@ -105,17 +114,16 @@ partial class CssBox
     /// <summary>
     /// Whether the native placement post-pass may set this box's used size directly
     /// (rather than only repositioning). True only when doing so cannot mis-render:
-    /// the box has no in-flow children or words to re-flow, uses content-box sizing,
-    /// and has no percentage margin/padding/inset box properties (which resolve against
-    /// the position-area cell — a used-value computation still owned by the bridge's
-    /// pre-bake path until a later expansion). Matches the boxes for which the engine's
-    /// grid-derived size equals the baked bridge result.
+    /// the box has no in-flow children or words to re-flow, and has no percentage
+    /// margin/padding/inset box properties (which resolve against the position-area
+    /// cell — a used-value computation still owned by the bridge's pre-bake path until a
+    /// later expansion). Both <c>content-box</c> and <c>border-box</c> sizing are handled
+    /// (the caller forms the border box accordingly). Matches the boxes for which the
+    /// engine's grid-derived size equals the baked bridge result.
     /// </summary>
     private bool CanApplyNativeAnchorSize()
     {
         if (Boxes.Count != 0 || Words.Count != 0)
-            return false;
-        if (string.Equals(BoxSizing, "border-box", StringComparison.OrdinalIgnoreCase))
             return false;
         return !HasPercent(MarginTop) && !HasPercent(MarginRight)
             && !HasPercent(MarginBottom) && !HasPercent(MarginLeft)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
@@ -52,11 +52,27 @@ partial class CssBox
         if (!string.IsNullOrEmpty(name) && name != "none")
         {
             var b = box.Bounds;
-            registry.Register(name, new AnchorRect(b.X, b.Y, b.Width, b.Height));
+            // The anchor box itself is the scope token: a query binds to the candidate in
+            // its own containing block when several elements share a name (see
+            // ResolveScopedAnchorTarget). Registration order is tree/document order.
+            registry.Register(name, new AnchorRect(b.X, b.Y, b.Width, b.Height), box);
         }
 
         foreach (var child in box.Boxes)
             CollectAnchors(child, registry);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="descendant"/> is a strict box-tree descendant of
+    /// <paramref name="ancestor"/> (used as the anchor-name scope test: an anchor is in a
+    /// query's scope when its box is inside the query's containing block).
+    /// </summary>
+    private static bool IsBoxDescendantOf(CssBox descendant, CssBox ancestor)
+    {
+        for (var p = descendant.ParentBox; p != null; p = p.ParentBox)
+            if (p == ancestor)
+                return true;
+        return false;
     }
 
     private static void ApplyNativeAnchorPlacement(CssBox box, AnchorRegistry registry)
@@ -268,7 +284,11 @@ partial class CssBox
         GetAbsoluteContainingBlockPaddingBox(cb, out double cbX, out double cbY, out double cbW, out double cbH);
 
         var parsed = PositionAreaValue.Parse(area);
-        var resolved = registry.ResolvePositionAreaCell(anchorName, parsed, cbX, cbY, cbW, cbH);
+        // Scope resolution: when several elements share this anchor-name, bind to the
+        // candidate inside the query's own containing block (the anchor box a descendant of
+        // `cb`), mirroring the bridge's ResolveAnchorForElement; unique names are unaffected.
+        var resolved = registry.ResolvePositionAreaCell(anchorName, parsed, cbX, cbY, cbW, cbH,
+            inScope: scope => scope is CssBox src && IsBoxDescendantOf(src, cb));
         if (resolved is not { } c)
             return false; // Anchor not registered.
         cell = c;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
@@ -12,13 +12,14 @@ namespace Broiler.Layout.Engine;
 /// </summary>
 /// <remarks>
 /// Gated by <see cref="NativeAnchorPlacement.Enabled"/> (default off), so this is
-/// inert until the P5.8d cutover. The current pass handles the MVP subset:
-/// <c>position-area</c> with an explicit <c>position-anchor</c>, a registered anchor,
-/// and a box with a definite size — for which placement is a pure reposition (the
-/// grid cell + inset-modified containing block + within-cell alignment decide the
-/// box's origin; its already-laid-out size is kept). Auto/fill-the-cell sizing,
-/// box-sizing, inline-CB promotion, scrolling, <c>anchor()</c> insets and position-try
-/// are out of MVP and stay on the bridge path until later P5.8d expansions.
+/// inert until the P5.8d cutover. The pass handles <c>position-area</c> with an explicit
+/// <c>position-anchor</c> and a registered anchor. For a childless, content-box box with
+/// no percentage box properties it also applies the grid-derived used <b>size</b>
+/// (fill-the-cell / explicit / percentage width+height — the P5.8d.2b sizing expansion);
+/// every other box keeps the reposition-only behaviour (its already-laid-out size is
+/// kept). <c>box-sizing: border-box</c>, percentage margin/padding/inset box props,
+/// inline-CB promotion, scrolling, <c>anchor()</c> insets and position-try are still out
+/// of scope and stay on the bridge path until later P5.8d expansions.
 /// </remarks>
 partial class CssBox
 {
@@ -62,14 +63,104 @@ partial class CssBox
     {
         if (box.PositionArea != "none" && box.TryResolvePositionAreaTarget(registry, out var target))
         {
+            // Apply the used SIZE first (P5.8d.2b sizing slice) for the boxes the engine
+            // can size without re-flowing a subtree: a childless box (no in-flow children
+            // or words), content-box sizing, and no percentage margin/padding/inset box
+            // properties (those resolve against the cell and need the bridge's explicit
+            // pre-bake for now). For such a box the grid-derived used width/height fills
+            // the cell / honours an explicit or percentage size exactly as the baked
+            // bridge path does; setting its border box repaints correctly with no
+            // children to re-flow. Every other box keeps the reposition-only MVP
+            // behaviour (its already-laid-out size is preserved).
+            if (box.CanApplyNativeAnchorSize())
+            {
+                // target.Width/Height are the content-box used size. Add the box's own
+                // padding + border to form the border box (SizeF). Border/padding are read
+                // font-free (px + the CSS thin/medium/thick keyword map, style:none → 0) —
+                // matching the bridge's ResolveBorderWidth and avoiding the layout font the
+                // Actual* getters resolve (percentage padding is excluded by the gate).
+                double borderBoxW = target.Width
+                    + box.NativeBorderPx(box.BorderLeftWidth, box.BorderLeftStyle)
+                    + box.NativePaddingPx(box.PaddingLeft)
+                    + box.NativePaddingPx(box.PaddingRight)
+                    + box.NativeBorderPx(box.BorderRightWidth, box.BorderRightStyle);
+                double borderBoxH = target.Height
+                    + box.NativeBorderPx(box.BorderTopWidth, box.BorderTopStyle)
+                    + box.NativePaddingPx(box.PaddingTop)
+                    + box.NativePaddingPx(box.PaddingBottom)
+                    + box.NativeBorderPx(box.BorderBottomWidth, box.BorderBottomStyle);
+                box.Size = new System.Drawing.SizeF((float)borderBoxW, (float)borderBoxH);
+            }
+
             // Reposition the box (and its subtree) so its border-box origin lands at the
-            // grid-resolved position. Size is left as laid out (MVP: definite-size boxes).
+            // grid-resolved position.
             box.OffsetLeft(target.Left - box.Location.X);
             box.OffsetTop(target.Top - box.Location.Y);
         }
 
         foreach (var child in box.Boxes)
             ApplyNativeAnchorPlacement(child, registry);
+    }
+
+    /// <summary>
+    /// Whether the native placement post-pass may set this box's used size directly
+    /// (rather than only repositioning). True only when doing so cannot mis-render:
+    /// the box has no in-flow children or words to re-flow, uses content-box sizing,
+    /// and has no percentage margin/padding/inset box properties (which resolve against
+    /// the position-area cell — a used-value computation still owned by the bridge's
+    /// pre-bake path until a later expansion). Matches the boxes for which the engine's
+    /// grid-derived size equals the baked bridge result.
+    /// </summary>
+    private bool CanApplyNativeAnchorSize()
+    {
+        if (Boxes.Count != 0 || Words.Count != 0)
+            return false;
+        if (string.Equals(BoxSizing, "border-box", StringComparison.OrdinalIgnoreCase))
+            return false;
+        return !HasPercent(MarginTop) && !HasPercent(MarginRight)
+            && !HasPercent(MarginBottom) && !HasPercent(MarginLeft)
+            && !HasPercent(PaddingTop) && !HasPercent(PaddingRight)
+            && !HasPercent(PaddingBottom) && !HasPercent(PaddingLeft)
+            && !HasPercent(Top) && !HasPercent(Right)
+            && !HasPercent(Bottom) && !HasPercent(Left);
+    }
+
+    private static bool HasPercent(string? value) => value != null && value.Contains('%');
+
+    /// <summary>
+    /// Font-free used border width for one side: <c>0</c> when the border style is
+    /// absent/<c>none</c>; otherwise the CSS <c>thin</c>/<c>medium</c>/<c>thick</c>
+    /// keywords map to <c>1</c>/<c>3</c>/<c>4</c> px (default <c>medium</c>) and a
+    /// pixel length is taken as-is. Mirrors the bridge's <c>ResolveBorderWidth</c> and
+    /// <c>CssLengthParser.GetActualBorderWidth</c> so the native and baked paths agree.
+    /// </summary>
+    private double NativeBorderPx(string? width, string? style)
+    {
+        if (string.IsNullOrEmpty(style) || string.Equals(style, "none", StringComparison.OrdinalIgnoreCase))
+            return 0;
+        var w = width?.Trim();
+        if (string.IsNullOrEmpty(w) || string.Equals(w, "medium", StringComparison.OrdinalIgnoreCase))
+            return 3;
+        if (string.Equals(w, "thin", StringComparison.OrdinalIgnoreCase)) return 1;
+        if (string.Equals(w, "thick", StringComparison.OrdinalIgnoreCase)) return 4;
+        return ParsePxOnly(w) ?? 3;
+    }
+
+    /// <summary>Font-free used padding for one side: a pixel length (or bare number),
+    /// else <c>0</c>. Percentage padding is excluded upstream by the size gate.</summary>
+    private double NativePaddingPx(string? value) => ParsePxOnly(value) ?? 0;
+
+    private static double? ParsePxOnly(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        var v = value!.Trim();
+        if (v.Contains('%')) return null;
+        if (v.EndsWith("px", StringComparison.OrdinalIgnoreCase))
+            v = v[..^2];
+        return double.TryParse(v, System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture, out var px)
+            ? px
+            : null;
     }
 
     /// <summary>
@@ -98,16 +189,59 @@ partial class CssBox
         if (cell is not { } c)
             return false; // Anchor not registered.
 
-        // Reposition-only MVP: keep the box's already-laid-out border-box size, resolve
-        // insets against the cell, and align the box within the cell.
+        // Width/height inputs to the grid resolution. For a size-apply box (childless,
+        // content-box, no percentage box props — see CanApplyNativeAnchorSize) feed the
+        // box's authored CSS width/height so the used size fills the cell / honours an
+        // explicit or percentage length exactly as the baked bridge path does. For every
+        // other box keep the reposition-only MVP inputs (the already-laid-out border-box
+        // size), so its alignment position is byte-identical to the shipped behaviour.
+        double? explicitW, percentW, explicitH, percentH;
+        if (CanApplyNativeAnchorSize())
+        {
+            (explicitW, percentW) = ParseSizeComponent(Width);
+            (explicitH, percentH) = ParseSizeComponent(Height);
+        }
+        else
+        {
+            (explicitW, percentW) = (Size.Width, null);
+            (explicitH, percentH) = (Size.Height, null);
+        }
+
         target = PositionAreaGrid.ResolveElementBox(
             c,
             ResolveInset(Top, c.Height), ResolveInset(Right, c.Width),
             ResolveInset(Bottom, c.Height), ResolveInset(Left, c.Width),
-            explicitWidth: Size.Width, percentWidth: null,
-            explicitHeight: Size.Height, percentHeight: null,
+            explicitWidth: explicitW, percentWidth: percentW,
+            explicitHeight: explicitH, percentHeight: percentH,
             parsed);
         return true;
+    }
+
+    /// <summary>
+    /// Parses a CSS <c>width</c>/<c>height</c> component into the (explicit-px, percent)
+    /// pair <see cref="PositionAreaGrid.ResolveElementBox"/> expects: a pixel length (or
+    /// bare number) → <c>(px, null)</c>; a percentage like <c>50%</c> → <c>(null, 50)</c>;
+    /// <c>auto</c>/unparseable/other units → <c>(null, null)</c> (fill the cell). Mirrors
+    /// the bridge's <c>TryParsePx</c>/<c>TryParsePercent</c> exactly for parity.
+    /// </summary>
+    internal static (double? explicitPx, double? percent) ParseSizeComponent(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return (null, null);
+        var v = value!.Trim();
+        if (v.EndsWith('%'))
+        {
+            return double.TryParse(v[..^1], System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var pct)
+                ? (null, pct)
+                : (null, null);
+        }
+        if (v.EndsWith("px", StringComparison.OrdinalIgnoreCase))
+            v = v[..^2];
+        return double.TryParse(v, System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture, out var px)
+            ? (px, null)
+            : (null, null);
     }
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
@@ -61,16 +61,27 @@ partial class CssBox
 
     private static void ApplyNativeAnchorPlacement(CssBox box, AnchorRegistry registry)
     {
-        if (box.PositionArea != "none" && box.TryResolvePositionAreaTarget(registry, out var target))
+        if (box.PositionArea != "none" && box.TryResolvePositionAreaTarget(registry, out var target, out var cell))
         {
+            // Percentage box props (margin/padding/inset resolved against the cell): the
+            // box's margin box stretches to fill the inset-modified containing block, so
+            // its geometry is derived differently — handle it in its own path (which also
+            // writes the resolved px padding so the content-box background paints right).
+            if (box.CanApplyNativeAnchorSize() && box.HasPercentBoxProps())
+            {
+                box.ApplyPercentBoxPropsPlacement(target, cell);
+                foreach (var pchild in box.Boxes)
+                    ApplyNativeAnchorPlacement(pchild, registry);
+                return;
+            }
+
             // Apply the used SIZE first (P5.8d.2b sizing slices) for the boxes the engine
             // can size without re-flowing a subtree: a childless box (no in-flow children
-            // or words) with no percentage margin/padding/inset box properties (those
-            // resolve against the cell and need the bridge's explicit pre-bake for now).
-            // For such a box the grid-derived used size fills the cell / honours an explicit
-            // or percentage length exactly as the baked bridge path does; setting its border
-            // box repaints correctly with no children to re-flow. Every other box keeps the
-            // reposition-only behaviour (its already-laid-out size is preserved).
+            // or words). For such a box the grid-derived used size fills the cell / honours
+            // an explicit or percentage length exactly as the baked bridge path does;
+            // setting its border box repaints correctly with no children to re-flow. Every
+            // other box keeps the reposition-only behaviour (its already-laid-out size is
+            // preserved).
             if (box.CanApplyNativeAnchorSize())
             {
                 // The box's own padding + border, read font-free (px + the CSS
@@ -113,24 +124,87 @@ partial class CssBox
 
     /// <summary>
     /// Whether the native placement post-pass may set this box's used size directly
-    /// (rather than only repositioning). True only when doing so cannot mis-render:
-    /// the box has no in-flow children or words to re-flow, and has no percentage
-    /// margin/padding/inset box properties (which resolve against the position-area
-    /// cell — a used-value computation still owned by the bridge's pre-bake path until a
-    /// later expansion). Both <c>content-box</c> and <c>border-box</c> sizing are handled
-    /// (the caller forms the border box accordingly). Matches the boxes for which the
-    /// engine's grid-derived size equals the baked bridge result.
+    /// (rather than only repositioning). True when doing so cannot mis-render: the box has
+    /// no in-flow children or words to re-flow. Both <c>content-box</c> and
+    /// <c>border-box</c> sizing and percentage margin/padding/inset box props are handled
+    /// (the caller forms the border box / margin-box-fills-IMCB geometry accordingly).
+    /// Matches the boxes for which the engine's grid-derived size equals the baked bridge
+    /// result.
     /// </summary>
-    private bool CanApplyNativeAnchorSize()
+    private bool CanApplyNativeAnchorSize() => Boxes.Count == 0 && Words.Count == 0;
+
+    /// <summary>
+    /// Whether the box carries a percentage margin, padding, or inset — the CSS that
+    /// resolves against the position-area cell and drives the <c>place-self: stretch</c>
+    /// margin-box-fills-IMCB path (mirrors the bridge's <c>hasPercentBoxProps</c>).
+    /// </summary>
+    private bool HasPercentBoxProps() =>
+        HasPercent(MarginTop) || HasPercent(MarginRight) || HasPercent(MarginBottom) || HasPercent(MarginLeft)
+        || HasPercent(PaddingTop) || HasPercent(PaddingRight) || HasPercent(PaddingBottom) || HasPercent(PaddingLeft)
+        || HasPercent(Top) || HasPercent(Right) || HasPercent(Bottom) || HasPercent(Left);
+
+    /// <summary>
+    /// Places a childless <c>position-area</c> box whose margin/padding/inset carry
+    /// percentages (<see cref="HasPercentBoxProps"/>). Mirrors the bridge's
+    /// <c>hasPercentBoxProps</c> branch: percentage margins and padding resolve against the
+    /// cell inline size, the element's margin box stretches to fill the inset-modified
+    /// containing block (IMCB), and the content size is the IMCB minus margin+border+padding
+    /// (<see cref="PositionAreaGrid.ContentSizeFillingImcb"/>). The resolved padding is
+    /// written back as px so the content-box background paints at the right place; the
+    /// border box is set from the content size + padding + border, positioned so the margin
+    /// box's origin sits at the IMCB origin.
+    /// </summary>
+    private void ApplyPercentBoxPropsPlacement(PositionAreaBox target, PositionAreaCell cell)
     {
-        if (Boxes.Count != 0 || Words.Count != 0)
-            return false;
-        return !HasPercent(MarginTop) && !HasPercent(MarginRight)
-            && !HasPercent(MarginBottom) && !HasPercent(MarginLeft)
-            && !HasPercent(PaddingTop) && !HasPercent(PaddingRight)
-            && !HasPercent(PaddingBottom) && !HasPercent(PaddingLeft)
-            && !HasPercent(Top) && !HasPercent(Right)
-            && !HasPercent(Bottom) && !HasPercent(Left);
+        double cellW = cell.Width;
+
+        // Margins and padding: percentage against the cell inline size, else px (CSS
+        // %-margin/padding always resolve against the containing block's inline size,
+        // which is the cell here — matching the bridge's ResolvePctOrPx(..., cellW)).
+        double mT = ResolveEdgeAgainstCell(MarginTop, cellW), mR = ResolveEdgeAgainstCell(MarginRight, cellW);
+        double mB = ResolveEdgeAgainstCell(MarginBottom, cellW), mL = ResolveEdgeAgainstCell(MarginLeft, cellW);
+        double pT = ResolveEdgeAgainstCell(PaddingTop, cellW), pR = ResolveEdgeAgainstCell(PaddingRight, cellW);
+        double pB = ResolveEdgeAgainstCell(PaddingBottom, cellW), pL = ResolveEdgeAgainstCell(PaddingLeft, cellW);
+        double bT = NativeBorderPx(BorderTopWidth, BorderTopStyle), bR = NativeBorderPx(BorderRightWidth, BorderRightStyle);
+        double bB = NativeBorderPx(BorderBottomWidth, BorderBottomStyle), bL = NativeBorderPx(BorderLeftWidth, BorderLeftStyle);
+
+        var (contentW, contentH) = PositionAreaGrid.ContentSizeFillingImcb(
+            target.ImcbWidth, target.ImcbHeight,
+            new PositionAreaEdges(mT, mR, mB, mL),
+            new PositionAreaEdges(bT, bR, bB, bL),
+            new PositionAreaEdges(pT, pR, pB, pL));
+
+        // Write the resolved margins/padding as px (the bridge writes these inline too) so
+        // the box's own box-model reads the cell-resolved used values, not percentages
+        // re-resolved against the box's own width. Padding is what the content-box
+        // background/ClientRectangle depend on.
+        var px = System.Globalization.CultureInfo.InvariantCulture;
+        MarginTop = mT.ToString(px) + "px"; MarginRight = mR.ToString(px) + "px";
+        MarginBottom = mB.ToString(px) + "px"; MarginLeft = mL.ToString(px) + "px";
+        PaddingTop = pT.ToString(px) + "px"; PaddingRight = pR.ToString(px) + "px";
+        PaddingBottom = pB.ToString(px) + "px"; PaddingLeft = pL.ToString(px) + "px";
+
+        // Border box = content + padding + border; margin box origin sits at the IMCB origin.
+        double borderBoxW = contentW + pL + pR + bL + bR;
+        double borderBoxH = contentH + pT + pB + bT + bB;
+        Size = new System.Drawing.SizeF((float)borderBoxW, (float)borderBoxH);
+
+        double borderBoxLeft = target.ImcbLeft + mL;
+        double borderBoxTop = target.ImcbTop + mT;
+        OffsetLeft(borderBoxLeft - Location.X);
+        OffsetTop(borderBoxTop - Location.Y);
+    }
+
+    /// <summary>Resolves a margin/padding component against the cell inline size:
+    /// a percentage → that fraction of <paramref name="cellW"/>, a px length (or bare
+    /// number) → itself, anything else → 0. Mirrors the bridge's <c>ResolvePctOrPx</c>.</summary>
+    private static double ResolveEdgeAgainstCell(string? value, double cellW)
+    {
+        if (!string.IsNullOrWhiteSpace(value) && value!.TrimEnd().EndsWith('%')
+            && double.TryParse(value.Trim().TrimEnd('%'), System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var pct))
+            return cellW * pct / 100.0;
+        return ParsePxOnly(value) ?? 0;
     }
 
     private static bool HasPercent(string? value) => value != null && value.Contains('%');
@@ -176,9 +250,10 @@ partial class CssBox
     /// named anchor. Returns <c>false</c> (leave the box where it is) when the box is
     /// not an MVP anchor-positioned box or its anchor is not registered.
     /// </summary>
-    internal bool TryResolvePositionAreaTarget(AnchorRegistry registry, out PositionAreaBox target)
+    internal bool TryResolvePositionAreaTarget(AnchorRegistry registry, out PositionAreaBox target, out PositionAreaCell cell)
     {
         target = default;
+        cell = default;
 
         var area = PositionArea;
         if (string.IsNullOrEmpty(area) || area == "none")
@@ -193,9 +268,10 @@ partial class CssBox
         GetAbsoluteContainingBlockPaddingBox(cb, out double cbX, out double cbY, out double cbW, out double cbH);
 
         var parsed = PositionAreaValue.Parse(area);
-        var cell = registry.ResolvePositionAreaCell(anchorName, parsed, cbX, cbY, cbW, cbH);
-        if (cell is not { } c)
+        var resolved = registry.ResolvePositionAreaCell(anchorName, parsed, cbX, cbY, cbW, cbH);
+        if (resolved is not { } c)
             return false; // Anchor not registered.
+        cell = c;
 
         // Width/height inputs to the grid resolution. For a size-apply box (childless,
         // content-box, no percentage box props — see CanApplyNativeAnchorSize) feed the

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1783,13 +1783,33 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   green in isolation; the css-anchor-position **pixel** subset stays **byte-identical default-off (8-fail /
   31-pass)**, and **lever-on improves to 7-fail / 32-pass** — `position-area-scrolling-002` flips to
   passing (its border-box box now sizes to match the reference) with **zero regressions**.
+- **P5.8d.2b — native percentage box props (third expansion) — COMPLETED** 2026-07-14
+  (Broiler.Layout only, additive, default-off). `CanApplyNativeAnchorSize` now admits percentage
+  margin/padding/inset boxes (it is just childless-and-no-words); a new `ApplyPercentBoxPropsPlacement`
+  mirrors the bridge's `hasPercentBoxProps` branch — percentage margins/padding resolve against the cell
+  inline size (`ResolveEdgeAgainstCell`, the bridge's `ResolvePctOrPx`), the margin box stretches to fill
+  the IMCB, content size = `PositionAreaGrid.ContentSizeFillingImcb(imcb, margin, border, padding)`, the
+  resolved padding is written back as px so the content-box background paints right, and the border box is
+  positioned with its margin-box origin at the IMCB origin. `TryResolvePositionAreaTarget` now also outs
+  the `PositionAreaCell` (the percent resolution needs the cell inline size). Tests:
+  `NativeAnchorPlacementTests.cs` → 22 (percent margin shrinks+shifts the border box; percent padding
+  resolves against the cell — not the box's own width — and fills the IMCB). Regression check: full
+  `Broiler.Layout.Tests` (130) green; native e2e (2) green in isolation; the css-anchor-position **pixel**
+  subset stays **byte-identical default-off (8-fail / 31-pass)** and **lever-on unchanged (7-fail /
+  32-pass)** — zero regressions. **No corpus pixel test exercises this path:** the only percentage-box-props
+  test, `position-area-percents-001`, shares `anchor-name: --foo` across four anchors, so the bridge's
+  **uniqueness gate keeps it baked** (and it also needs writing-mode support neither path has). Validation
+  is therefore unit-test geometry (pinned to the promoted `ContentSizeFillingImcb`) plus no-regression. The
+  **uniqueness / `anchor-scope`** gate is the more impactful next blocker — it is what actually excludes
+  `percents-001` and any multi-anchor scenario, so the engine's flat last-wins `AnchorRegistry` needs
+  scope awareness before those boxes can go native.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
-  inline-CB promotion (DOM moves) → scroll simulation → `position-visibility` → dialog/backdrop →
-  `anchor()` insets → position-try. (Childless auto/explicit/percentage sizing AND `box-sizing:border-box`
-  now land natively — see the two size expansions above; percentage *box props* — margin/padding/inset
-  resolved against the cell — are still bridge-baked.) Each remaining feature is currently excluded by
-  `IsMvpNativeAnchorBox` (or `CanApplyNativeAnchorSize`) and stays on the bridge path (baked +
+  anchor-name scope/uniqueness (engine `AnchorRegistry` is flat last-wins) → inline-CB promotion (DOM
+  moves) → scroll simulation → `position-visibility` → dialog/backdrop → `anchor()` insets → position-try.
+  (Childless auto/explicit/percentage sizing, `box-sizing:border-box`, AND percentage margin/padding/inset
+  box props now land natively — see the three size expansions above.) Each remaining feature is currently
+  excluded by `IsMvpNativeAnchorBox` (or `CanApplyNativeAnchorSize`) and stays on the bridge path (baked +
   `position-area: none`), so enabling the lever globally is already safe (proven above); the expansions
   widen the gate one feature at a time as the engine grows to reproduce them.
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1823,16 +1823,34 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   writing-mode containers still fail). **`AnchorNameScopeTests`** — which regressed when the uniqueness
   gate was first added — now passes **both** default-off and lever-on in isolation. This is the first
   expansion with observable pixel-test movement (the size expansions had none, being gate-masked).
+- **P5.8d.2b — writing-mode percentage box props (fifth expansion) — COMPLETED** 2026-07-14
+  (Broiler.Layout only, additive, default-off). CSS Writing Modes §7.4: percentage margins/padding resolve
+  against the **inline** size of the containing block. `ApplyPercentBoxPropsPlacement` now resolves them
+  against the cell width for a horizontal CB and the cell **height** for a vertical one (the CB's writing
+  mode via `FindPositionedContainingBlock` + `IsVerticalWritingMode`), instead of always the width; insets
+  keep resolving against their own physical axis. This is the first expansion that deliberately **exceeds**
+  the bridge (which always used the width, so it gets vertical CBs wrong), so native diverges from the
+  baked path only for a vertical CB — a strictly-more-correct divergence. Tests: `NativeAnchorPlacementTests`
+  +1 (non-square cell in a `vertical-rl` CB: percent margin resolves against the cell height). Regression
+  check: full `Broiler.Layout.Tests` (134) green; **default-off byte-identical (8-fail / 31-pass)**;
+  **lever-on unchanged (7-fail / 32-pass)** with `position-area-percents-001` improving 98.7 %→98.8 % (its
+  vertical-CB containers 3&4 now geometrically correct). **Finding — `percents-001` is capped by rendering
+  fidelity, not geometry:** the native render matches Broiler's own `-ref` render to **0.05 %** (400 px of
+  sub-pixel border rounding), and differs from the committed Chromium **golden** by **1.25 %** — but
+  Broiler's render of the plain `-ref` markup (no anchor positioning at all) itself differs from the golden
+  by **1.26 %**. So the residual is Broiler-vs-Chromium anti-aliasing/border fidelity (a separate,
+  pre-existing rendering concern), and the anchor geometry is exact. `percents-001` will not cross the 99 %
+  pixel threshold from anchor work alone.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
-  ~~anchor-name scope/uniqueness~~ → inline-CB promotion (DOM moves) → scroll simulation →
-  `position-visibility` → dialog/backdrop → `anchor()` insets → position-try (and **writing-mode**
-  position-area, which blocks `percents-001` fully passing). (Childless auto/explicit/percentage sizing,
-  `box-sizing:border-box`, percentage margin/padding/inset box props, AND shared-name scope resolution now
-  land natively — see the four expansions above.) Each remaining feature is currently excluded by
-  `IsMvpNativeAnchorBox` (or `CanApplyNativeAnchorSize`) and stays on the bridge path (baked +
-  `position-area: none`), so enabling the lever globally is already safe (proven above); the expansions
-  widen the gate one feature at a time as the engine grows to reproduce them.
+  ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → inline-CB promotion (DOM moves) →
+  scroll simulation → `position-visibility` → dialog/backdrop → `anchor()` insets → position-try.
+  (Childless auto/explicit/percentage sizing, `box-sizing:border-box`, percentage margin/padding/inset box
+  props, shared-name scope resolution, AND writing-mode percentage basis now land natively — see the five
+  expansions above.) Each remaining feature is currently excluded by `IsMvpNativeAnchorBox` (or
+  `CanApplyNativeAnchorSize`) and stays on the bridge path (baked + `position-area: none`), so enabling the
+  lever globally is already safe (proven above); the expansions widen the gate one feature at a time as the
+  engine grows to reproduce them.
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4
   item-2 unblock** — once every feature is on the engine path.
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1742,12 +1742,42 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
     `RenderHtmlFileBitmapPublic` pipeline (bridge in native mode does **not** bake — see
     `NativeAnchorBridgeModeTests` — so the correct placement is the engine's), and that the baked and
     native paths agree pixel-wise. Cli `~NativeAnchor` (3) and `~Anchor|~PositionArea` (13) green.
+- **P5.8d.2b — native used-SIZE (first expansion) — COMPLETED** 2026-07-14 (Broiler.Layout only,
+  additive, behind the default-OFF flag). The P5.8c pass was reposition-only (the box's already-laid-out
+  border-box size was kept). It now also applies the grid-derived used **size** — fill-the-cell (the
+  `place-self: stretch` default), an explicit length, or a percentage of the cell — to the boxes the
+  engine can size without re-flowing a subtree: a **childless**, **content-box**, no-percentage-box-props
+  `position-area` box (`CanApplyNativeAnchorSize` in `Engine/CssBox.Anchor.cs`). For such a box
+  `TryResolvePositionAreaTarget` feeds the box's authored CSS width/height into
+  `PositionAreaGrid.ResolveElementBox` (bridge-matching `ParseSizeComponent`, so px/`%`/`auto` map exactly
+  as the bridge's `TryParsePx`/`TryParsePercent`), and `ApplyNativeAnchorPlacement` sets the border box =
+  content size + font-free padding/border (`NativeBorderPx`/`NativePaddingPx` mirror the bridge's
+  `ResolveBorderWidth` thin/medium/thick→1/3/4 map, avoiding the layout font the `Actual*` getters
+  resolve). Every other box (childful, `box-sizing:border-box`, percentage margin/padding/inset) keeps the
+  reposition-only behaviour and stays on the bridge bake path. Same box *set* flows to the engine as
+  before (the bridge's `IsMvpNativeAnchorBox` gate is unchanged); the engine just sizes the childless ones
+  to match the baked path instead of keeping their flow size. Tests: `Broiler.Layout.Tests/
+  NativeAnchorPlacementTests.cs` grows to 19 (fill-cell, percentage-of-cell, content+padding border box,
+  childful/border-box reposition-only fallbacks, `ParseSizeComponent` parity theory) — needing a minimal
+  fake `ILayoutEnvironment`/`ILayoutFont` so the synthetic block CBs can resolve Actual border widths.
+  Regression check: full `Broiler.Layout.Tests` (127) green; the css-anchor-position **pixel** subset
+  reproduces the identical **8-fail / 31-pass** set both default-off (byte-identical) and lever-on (no
+  passing test regresses); `NativeAnchorPlacementWptTests` (bridge/engine paths agree pixel-wise) green in
+  isolation. Also fixed a pre-existing arch-guard fail from the P5.8d.2b IVT addition
+  (`LayoutArchitectureTests.Internal_Consumers_Are_Explicit_And_Minimal` did not list `Broiler.Wpt`). One
+  observed non-blocker: lever-on `position-area-scrolling-002` (already failing) drops 97.7 %→68.5 % —
+  native sizing amplifies the deferred scrolled-anchor placement divergence on an admitted box; it does
+  not change the fail *set* and production is default-off. The scroll case is excluded from correctness
+  until the scroll-simulation expansion.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
-  default-off until each feature is on the engine path — percentage box props → box-sizing → inline-CB
+  default-off until each feature is on the engine path — ~~percentage box props~~ → box-sizing → inline-CB
   promotion (DOM moves) → scroll simulation → `position-visibility` → dialog/backdrop → `anchor()` insets
-  → position-try. Each is currently excluded by `IsMvpNativeAnchorBox` and stays on the bridge path
-  (baked + `position-area: none`), so enabling the lever globally is already safe (proven above); the
-  expansions widen the MVP gate one feature at a time as the engine grows to reproduce them.
+  → position-try. (Childless auto/explicit/percentage sizing now lands natively — see the size expansion
+  above; percentage *box props* — margin/padding/inset resolved against the cell — and `box-sizing` are
+  still bridge-baked.) Each remaining feature is currently excluded by `IsMvpNativeAnchorBox` (or
+  `CanApplyNativeAnchorSize`) and stays on the bridge path (baked + `position-area: none`), so enabling the
+  lever globally is already safe (proven above); the expansions widen the gate one feature at a time as
+  the engine grows to reproduce them.
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4
   item-2 unblock** — once every feature is on the engine path.
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1765,19 +1765,33 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   passing test regresses); `NativeAnchorPlacementWptTests` (bridge/engine paths agree pixel-wise) green in
   isolation. Also fixed a pre-existing arch-guard fail from the P5.8d.2b IVT addition
   (`LayoutArchitectureTests.Internal_Consumers_Are_Explicit_And_Minimal` did not list `Broiler.Wpt`). One
-  observed non-blocker: lever-on `position-area-scrolling-002` (already failing) drops 97.7 %→68.5 % —
-  native sizing amplifies the deferred scrolled-anchor placement divergence on an admitted box; it does
-  not change the fail *set* and production is default-off. The scroll case is excluded from correctness
-  until the scroll-simulation expansion.
+  observed non-blocker at this slice: lever-on `position-area-scrolling-002` (already failing) dropped
+  97.7 %→68.5 % (native sizing amplified a `box-sizing:border-box` box the size slice left on a partial
+  path); it did not change the fail *set* and production is default-off. **The box-sizing expansion below
+  fixes it** (scrolling-002 now passes lever-on).
+- **P5.8d.2b — native `box-sizing: border-box` (second expansion) — COMPLETED** 2026-07-14
+  (Broiler.Layout only, additive, default-off). `CanApplyNativeAnchorSize` no longer excludes
+  `box-sizing: border-box`; the caller forms the border box per box-sizing. The engine paints `Size` as
+  the border box regardless of box-sizing, so for a border-box box the grid-resolved used size (which the
+  bridge feeds as the border-box value and clamps to the cell) IS the border box — `ApplyNativeAnchorPlacement`
+  now uses `borderBox ? max(target.Size, padding+border) : target.Size + padding+border`, the
+  `max(…, padding+border)` mirroring the bridge's `BorderBoxToContentSize` clamp (content ≥ 0). No new
+  parsing — the same `PositionAreaGrid.ResolveElementBox` inputs, just a different border-box assembly.
+  Tests: `NativeAnchorPlacementTests.cs` → 20 (replaced the border-box reposition-only fallback with two
+  border-box sizing cases: explicit width used as the border box — padding/border NOT added — and
+  border-box fill-the-cell). Regression check: full `Broiler.Layout.Tests` (128) green; native e2e (2)
+  green in isolation; the css-anchor-position **pixel** subset stays **byte-identical default-off (8-fail /
+  31-pass)**, and **lever-on improves to 7-fail / 32-pass** — `position-area-scrolling-002` flips to
+  passing (its border-box box now sizes to match the reference) with **zero regressions**.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
-  default-off until each feature is on the engine path — ~~percentage box props~~ → box-sizing → inline-CB
-  promotion (DOM moves) → scroll simulation → `position-visibility` → dialog/backdrop → `anchor()` insets
-  → position-try. (Childless auto/explicit/percentage sizing now lands natively — see the size expansion
-  above; percentage *box props* — margin/padding/inset resolved against the cell — and `box-sizing` are
-  still bridge-baked.) Each remaining feature is currently excluded by `IsMvpNativeAnchorBox` (or
-  `CanApplyNativeAnchorSize`) and stays on the bridge path (baked + `position-area: none`), so enabling the
-  lever globally is already safe (proven above); the expansions widen the gate one feature at a time as
-  the engine grows to reproduce them.
+  default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
+  inline-CB promotion (DOM moves) → scroll simulation → `position-visibility` → dialog/backdrop →
+  `anchor()` insets → position-try. (Childless auto/explicit/percentage sizing AND `box-sizing:border-box`
+  now land natively — see the two size expansions above; percentage *box props* — margin/padding/inset
+  resolved against the cell — are still bridge-baked.) Each remaining feature is currently excluded by
+  `IsMvpNativeAnchorBox` (or `CanApplyNativeAnchorSize`) and stays on the bridge path (baked +
+  `position-area: none`), so enabling the lever globally is already safe (proven above); the expansions
+  widen the gate one feature at a time as the engine grows to reproduce them.
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4
   item-2 unblock** — once every feature is on the engine path.
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1803,13 +1803,34 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   **uniqueness / `anchor-scope`** gate is the more impactful next blocker — it is what actually excludes
   `percents-001` and any multi-anchor scenario, so the engine's flat last-wins `AnchorRegistry` needs
   scope awareness before those boxes can go native.
+- **P5.8d.2b — anchor-name scope / uniqueness (fourth expansion) — COMPLETED** 2026-07-14
+  (Broiler.Layout + bridge, both parent-repo, additive, default-off). The engine's flat last-wins
+  `AnchorRegistry` gains **scope awareness**: each name keeps *all* candidates in tree order, each with an
+  opaque caller-supplied scope token, and the resolve methods take an optional `inScope` predicate —
+  binding a query to the LAST candidate in its own scope, else last-wins (mirrors the bridge's
+  `ResolveAnchorForElement`). The registry stays box-tree/DOM-free (the token is `object?`; the caller
+  interprets it). The engine pass registers each anchor with its **source box** as the token and resolves
+  with "anchor box is a descendant of the query's positioned containing block" (`IsBoxDescendantOf`);
+  `TryResolvePositionAreaTarget` now threads that predicate. The bridge's `IsMvpNativeAnchorBox`
+  **uniqueness gate is relaxed** — shared anchor-names may now go native (only "name is registered"
+  remains). Backward-compatible: scope-free `Register`/`Resolve` keep last-wins, so the 7 existing
+  `AnchorRegistry` tests are unchanged. Tests: `AnchorRegistryTests` +2 (scoped last-in-scope /
+  single-candidate ignores scope); `NativeAnchorPlacementTests` +1 (two sibling containers sharing `--a`
+  bind within their own CB — a flat registry would collapse the first's cell). Regression check: full
+  `Broiler.Layout.Tests` (133) green; **default-off byte-identical (8-fail / 31-pass)**; **lever-on
+  unchanged (7-fail / 32-pass)** with `position-area-percents-001` improving 98.3 %→98.7 % (its shared-`--foo`
+  boxes now go native, scope-resolved per container, via the percentage-box-props path; only the
+  writing-mode containers still fail). **`AnchorNameScopeTests`** — which regressed when the uniqueness
+  gate was first added — now passes **both** default-off and lever-on in isolation. This is the first
+  expansion with observable pixel-test movement (the size expansions had none, being gate-masked).
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
-  anchor-name scope/uniqueness (engine `AnchorRegistry` is flat last-wins) → inline-CB promotion (DOM
-  moves) → scroll simulation → `position-visibility` → dialog/backdrop → `anchor()` insets → position-try.
-  (Childless auto/explicit/percentage sizing, `box-sizing:border-box`, AND percentage margin/padding/inset
-  box props now land natively — see the three size expansions above.) Each remaining feature is currently
-  excluded by `IsMvpNativeAnchorBox` (or `CanApplyNativeAnchorSize`) and stays on the bridge path (baked +
+  ~~anchor-name scope/uniqueness~~ → inline-CB promotion (DOM moves) → scroll simulation →
+  `position-visibility` → dialog/backdrop → `anchor()` insets → position-try (and **writing-mode**
+  position-area, which blocks `percents-001` fully passing). (Childless auto/explicit/percentage sizing,
+  `box-sizing:border-box`, percentage margin/padding/inset box props, AND shared-name scope resolution now
+  land natively — see the four expansions above.) Each remaining feature is currently excluded by
+  `IsMvpNativeAnchorBox` (or `CanApplyNativeAnchorSize`) and stays on the bridge path (baked +
   `position-area: none`), so enabling the lever globally is already safe (proven above); the expansions
   widen the gate one feature at a time as the engine grows to reproduce them.
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
@@ -400,9 +400,9 @@ public sealed partial class DomBridge
     /// Decides whether a <c>position-area</c> box belongs to the native-placement MVP
     /// subset (P5.8d.2b) — the boxes the Broiler.Layout engine's placement post-pass
     /// currently reproduces exactly, so the bridge can hand them off instead of
-    /// pre-baking. Requires: an explicit dashed-ident <c>position-anchor</c>, a
-    /// non-inline containing block, no intervening scroll container, and no
-    /// <c>position-try</c> or <c>anchor()</c>/<c>anchor-size()</c> on the element
+    /// pre-baking. Requires: an explicit dashed-ident <c>position-anchor</c> that names a
+    /// registered anchor, a non-inline containing block, no intervening scroll container,
+    /// and no <c>position-try</c> or <c>anchor()</c>/<c>anchor-size()</c> on the element
     /// (those entangled features stay on the bridge path until later expansions).
     /// </summary>
     private bool IsMvpNativeAnchorBox(
@@ -419,15 +419,11 @@ public sealed partial class DomBridge
         if (!anchorName.StartsWith("--", StringComparison.Ordinal))
             return false;
 
-        // A *uniquely*-named anchor. The engine's AnchorRegistry is a flat,
-        // ordinal last-wins name→rect map with no scope awareness, so when several
-        // elements share an anchor-name the box must stay on the bridge's scoped
-        // resolution path (ResolveAnchorForElement binds within the query's own
-        // containing block). _anchorCandidates is built (BuildAnchorRegistry) before
-        // this pass, so its per-name candidate count is available here.
-        if (_anchorCandidates == null ||
-            !_anchorCandidates.TryGetValue(anchorName, out var candidates) ||
-            candidates.Count != 1)
+        // The anchor-name must be registered. Shared names are now allowed: the engine's
+        // AnchorRegistry keeps every candidate and binds a query to the one in its own
+        // containing-block scope (matching the bridge's ResolveAnchorForElement), so a
+        // duplicate name no longer forces the bridge path.
+        if (_anchorCandidates == null || !_anchorCandidates.ContainsKey(anchorName))
             return false;
 
         // A non-inline containing block (the engine cannot yet promote abs-pos boxes


### PR DESCRIPTION
## Overview

Continues **Phase 5** of the HtmlBridge complexity-reduction roadmap (`docs/roadmap/htmlbridge-complexity-reduction-roadmap.md`), widening the Broiler.Layout engine's native CSS anchor-placement post-pass so more `position-area` boxes render natively instead of being pre-baked by the bridge's `AnchorResolver`. This is the path toward deleting the bridge's ~122 inline-style-dict writes — the **Phase 4 item-2 unblock**.

All work is behind the existing **default-off** `NativeAnchorPlacement.Enabled` flag: the production render path is **byte-identical** (proven each slice), and the lever-on native path is parity-gated against the css-anchor-position WPT pixel subset.

## Five expansions (each independently parity-gated)

The P5.8c pass was reposition-only (kept a box's flow-laid-out size). These slices grow it to reproduce — and in one case exceed — the bridge's baked used-value geometry, reusing the already-promoted `PositionAreaGrid` / `AnchorGeometry` / `AnchorRegistry` primitives:

1. **Used size** — applies the grid-derived used size (fill-the-cell / explicit / percentage width+height) to childless `position-area` boxes, not just repositioning them. Inputs match the bridge exactly (`ParseSizeComponent` mirrors `TryParsePx`/`TryParsePercent`; border/padding read font-free via `NativeBorderPx`/`NativePaddingPx`).
2. **`box-sizing: border-box`** — forms the border box per box-sizing (`borderBox ? max(size, padding+border) : size + padding+border`, mirroring the bridge's `BorderBoxToContentSize` clamp).
3. **Percentage box props** — new `ApplyPercentBoxPropsPlacement` mirrors the bridge's `hasPercentBoxProps` branch: percentage margins/padding resolve against the cell, the margin box stretches to fill the IMCB, content = `ContentSizeFillingImcb`, resolved padding written back as px.
4. **Anchor-name scope / uniqueness** — `AnchorRegistry` gains scope awareness (keeps all candidates per name with an opaque scope token + optional `inScope` predicate → last-in-scope, else last-wins, mirroring the bridge's `ResolveAnchorForElement`; the registry stays box-tree/DOM-free). The engine registers each anchor with its source box and resolves within the query's containing-block scope; the bridge's `IsMvpNativeAnchorBox` **uniqueness gate is relaxed** so shared anchor-names may go native.
5. **Writing-mode percentage basis** — CSS Writing Modes §7.4: percentage margins/padding resolve against the CB's **inline** size (cell width for a horizontal CB, cell **height** for a vertical one). First slice that deliberately **exceeds** the bridge (which always used the width and gets vertical CBs wrong).

## Scope

- **Broiler.Layout** (`AnchorRegistry.cs`, `Engine/CssBox.Anchor.cs`) and **Broiler.HtmlBridge.Dom** (`AnchorResolver/PositionArea.cs`, gate relaxation only) — both parent-repo, no submodule changes.
- Additive and backward-compatible: scope-free `Register`/`Resolve` keep last-wins semantics, so the 7 existing `AnchorRegistry` tests are unchanged.

## Verification

- **`Broiler.Layout.Tests`: 134/134** (added sizing, box-sizing, percent-box-props, scope, and vertical-CB cases; plus a fake `ILayoutEnvironment`/`ILayoutFont` so synthetic block CBs resolve Actual border widths). Also fixed a **pre-existing** arch-guard failure on `main` — `LayoutArchitectureTests` didn't list the `Broiler.Wpt` IVT that PR #1388 added.
- **Default-off**: css-anchor-position pixel subset stays **byte-identical (8-fail / 31-pass)**.
- **Lever-on**: improved to **7-fail / 32-pass** — `position-area-scrolling-002` flips to passing (box-sizing slice), and `position-area-percents-001` improves 98.3% → 98.8% (scope + writing-mode). Zero regressions across the five slices.
- **`NativeAnchorPlacementWptTests`** (baked/native paths agree) and **`AnchorNameScopeTests`** (which regressed when the uniqueness gate was first added) pass **both** default-off and lever-on in isolation.

## Reviewer notes

- **`position-area-percents-001` does not cross the 99% threshold, and that is a rendering-fidelity limit, not an anchor-geometry bug.** The native render matches Broiler's own `-ref` render to 0.05% (sub-pixel border rounding); against the committed Chromium golden, native = 1.25% while Broiler's render of the plain `-ref` markup (no anchor positioning at all) = 1.26%. The residual is Broiler-vs-Chromium anti-aliasing/border fidelity — a separate, pre-existing concern. Anchor geometry is exact.
- The lever stays default-off; remaining expansions toward the full `AnchorResolver` deletion (inline-CB promotion, scroll simulation, `position-visibility`, dialog/backdrop, `anchor()` insets, position-try) each widen the gate one feature at a time, as documented in the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)