### PR TITLE
HtmlBridge Phase 5 (P5.8d.2b): native inline-CB / anchor() / anchor-size / opposing-inset placement + &nbsp; entity-decode fix

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
@@ -338,6 +338,97 @@ public sealed class NativeAnchorPlacementTests
         Assert.Equal(60, targetB.Location.Y, 3);
     }
 
+    // ------------------------------------------------------------------
+    // anchor() inset placement (P5.8d.2b anchor()-insets expansion)
+    // ------------------------------------------------------------------
+
+    // CB 200×200 at origin; anchor --a is a 20×20 box at (40,40) → right/bottom 60,
+    // left/top 40. Returns a childless 30×30 abspos target at the origin for the caller
+    // to give anchor() insets.
+    private static (CssBox root, CssBox cb) AnchorInsetFixture(out CssBox target)
+    {
+        var root = Box(null, new PointF(0, 0), new SizeF(1000, 1000));
+        var cb = Box(root, new PointF(0, 0), new SizeF(200, 200));
+        cb.Position = "relative";
+        cb.Display = "block";
+        var anchor = Box(cb, new PointF(40, 40), new SizeF(20, 20));
+        anchor.AnchorName = "--a";
+        target = Box(cb, new PointF(0, 0), new SizeF(30, 30));
+        target.Position = "absolute";
+        return (root, cb);
+    }
+
+    private static void RunPass(CssBox root)
+    {
+        try
+        {
+            NativeAnchorPlacement.Enabled = true;
+            CssBox.RunNativeAnchorPlacement(root);
+        }
+        finally { NativeAnchorPlacement.Enabled = false; }
+    }
+
+    [Fact]
+    public void AnchorInset_LeftTop_PlacesMarginEdgeAtAnchorEdges()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);
+        target.Left = "anchor(--a right)";  // box left edge = anchor right = 60
+        target.Top = "anchor(--a bottom)";  // box top edge  = anchor bottom = 60
+        RunPass(root);
+        Assert.Equal(60, target.Location.X, 3);
+        Assert.Equal(60, target.Location.Y, 3);
+        Assert.Equal(30, target.Size.Width, 3);  // reposition-only: size kept
+        Assert.Equal(30, target.Size.Height, 3);
+    }
+
+    [Fact]
+    public void AnchorInset_RightBottom_PlacesFarMarginEdgeAtAnchorEdges()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);
+        // right: anchor(--a left) → box RIGHT edge lands on the anchor's left edge (40),
+        // so with a 30-wide box the left edge is at 10. Likewise bottom → box bottom at 40.
+        target.Right = "anchor(--a left)";
+        target.Bottom = "anchor(--a top)";
+        RunPass(root);
+        Assert.Equal(10, target.Location.X, 3);   // 40 - 30
+        Assert.Equal(10, target.Location.Y, 3);
+    }
+
+    [Fact]
+    public void AnchorInset_MixedAnchorAndPlainLength_ResolvesEach()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);
+        target.Left = "anchor(--a right)";  // 60
+        target.Top = "15px";                // plain length → box top edge at 15
+        RunPass(root);
+        Assert.Equal(60, target.Location.X, 3);
+        Assert.Equal(15, target.Location.Y, 3);
+    }
+
+    [Fact]
+    public void AnchorInset_ImplicitAnchor_UsesPositionAnchor()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);
+        target.PositionAnchor = "--a";
+        target.Left = "anchor(right)";   // no name in the function → position-anchor --a
+        target.Top = "anchor(bottom)";
+        RunPass(root);
+        Assert.Equal(60, target.Location.X, 3);
+        Assert.Equal(60, target.Location.Y, 3);
+    }
+
+    [Fact]
+    public void AnchorInset_UnregisteredAnchor_LeavesBoxPut()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);
+        target.Left = "anchor(--missing right)";
+        target.Top = "anchor(--missing bottom)";
+        RunPass(root);
+        // Fallback 0px → box left/top margin edge at the CB origin (0,0), not the anchor.
+        Assert.Equal(0, target.Location.X, 3);
+        Assert.Equal(0, target.Location.Y, 3);
+    }
+
     // Shared fixture: CB 200×200 at origin, anchor --a (20×20 at (40,40)), and a
     // childless absolutely-positioned "bottom right" target (30×30 at origin).
     private static (CssBox root, CssBox cb) FillCellFixture(out CssBox target)

--- a/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
@@ -429,6 +429,74 @@ public sealed class NativeAnchorPlacementTests
         Assert.Equal(0, target.Location.Y, 3);
     }
 
+    // ------------------------------------------------------------------
+    // anchor-size() sizing (P5.8d.2b anchor-size() expansion)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void AnchorSize_WidthAndHeight_SizeBoxToAnchorDimensions()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);  // anchor --a is 20×20
+        target.Width = "anchor-size(--a width)";
+        target.Height = "anchor-size(--a height)";
+        RunPass(root);
+        Assert.Equal(20, target.Size.Width, 3);
+        Assert.Equal(20, target.Size.Height, 3);
+    }
+
+    [Fact]
+    public void AnchorSize_OnlyWidth_KeepsLaidOutHeight()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);  // laid-out 30×30
+        target.Width = "anchor-size(--a width)"; // 20
+        RunPass(root);
+        Assert.Equal(20, target.Size.Width, 3);
+        Assert.Equal(30, target.Size.Height, 3);  // height untouched
+    }
+
+    [Fact]
+    public void AnchorSize_ContentBox_AddsPaddingAndBorder()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);
+        target.Width = "anchor-size(--a width)"; // content 20
+        target.PaddingLeft = "5px";
+        target.PaddingRight = "5px";
+        RunPass(root);
+        Assert.Equal(30, target.Size.Width, 3);   // 20 + 5 + 5 border box
+    }
+
+    [Fact]
+    public void AnchorSize_BorderBox_UsesResolvedAsBorderBox()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);
+        target.Width = "anchor-size(--a width)"; // 20
+        target.BoxSizing = "border-box";
+        target.PaddingLeft = "5px";
+        target.PaddingRight = "5px";
+        RunPass(root);
+        Assert.Equal(20, target.Size.Width, 3);   // border box = resolved 20 (padding not added)
+    }
+
+    [Fact]
+    public void AnchorSize_ImplicitAnchor_UsesPositionAnchor()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);
+        target.PositionAnchor = "--a";
+        target.Width = "anchor-size(width)";   // no name → position-anchor --a
+        RunPass(root);
+        Assert.Equal(20, target.Size.Width, 3);
+    }
+
+    [Fact]
+    public void AnchorSize_ChildfulBox_KeepsLaidOutSize()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);
+        target.Width = "anchor-size(--a width)";
+        _ = Box(target, new PointF(0, 0), new SizeF(10, 10));  // has a child → excluded
+        RunPass(root);
+        Assert.Equal(30, target.Size.Width, 3);  // unchanged (reposition/resize needs a re-flow)
+    }
+
     // Shared fixture: CB 200×200 at origin, anchor --a (20×20 at (40,40)), and a
     // childless absolutely-positioned "bottom right" target (30×30 at origin).
     private static (CssBox root, CssBox cb) FillCellFixture(out CssBox target)

--- a/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
@@ -430,6 +430,70 @@ public sealed class NativeAnchorPlacementTests
     }
 
     // ------------------------------------------------------------------
+    // opposing-inset sizing (P5.8d.2b)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void AnchorInset_OpposingLeftRight_SizesBoxBetweenInsets()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);  // anchor --a: left 40, right 60
+        target.Left = "anchor(--a left)";    // box left edge at 40
+        target.Right = "anchor(--a right)";  // box right edge at 60
+        // Width auto (default) → the two insets size it: 60 - 40 = 20.
+        RunPass(root);
+        Assert.Equal(40, target.Location.X, 3);
+        Assert.Equal(20, target.Size.Width, 3);
+    }
+
+    [Fact]
+    public void AnchorInset_OpposingTopBottom_SizesBoxBetweenInsets()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);  // anchor --a: top 40, bottom 60
+        target.Top = "anchor(--a top)";
+        target.Bottom = "anchor(--a bottom)";
+        RunPass(root);
+        Assert.Equal(40, target.Location.Y, 3);
+        Assert.Equal(20, target.Size.Height, 3);
+    }
+
+    [Fact]
+    public void AnchorInset_OpposingWithMargins_ShrinksBorderBox()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);
+        target.Left = "anchor(--a left)";    // 40
+        target.Right = "anchor(--a right)";  // right inset resolves so margin box spans 40..60
+        target.MarginLeft = "3px";
+        target.MarginRight = "5px";
+        RunPass(root);
+        // border box = (60-40) - 3 - 5 = 12; positioned at 40 + marginLeft 3 = 43.
+        Assert.Equal(43, target.Location.X, 3);
+        Assert.Equal(12, target.Size.Width, 3);
+    }
+
+    [Fact]
+    public void AnchorInset_OpposingButExplicitWidth_KeepsWidth()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);
+        target.Left = "anchor(--a left)";
+        target.Right = "anchor(--a right)";
+        target.Width = "30px";  // explicit → over-constrained; reposition-only by left.
+        RunPass(root);
+        Assert.Equal(40, target.Location.X, 3);
+        Assert.Equal(30, target.Size.Width, 3);  // size kept
+    }
+
+    [Fact]
+    public void AnchorInset_OpposingButChildful_KeepsSize()
+    {
+        var (root, _) = AnchorInsetFixture(out var target);
+        target.Left = "anchor(--a left)";
+        target.Right = "anchor(--a right)";
+        _ = Box(target, new PointF(0, 0), new SizeF(10, 10));  // childful → no resize
+        RunPass(root);
+        Assert.Equal(30, target.Size.Width, 3);  // laid-out 30 kept (a re-flow would be needed)
+    }
+
+    // ------------------------------------------------------------------
     // anchor-size() sizing (P5.8d.2b anchor-size() expansion)
     // ------------------------------------------------------------------
 

--- a/Broiler.Layout/Broiler.Layout/AnchorRegistry.cs
+++ b/Broiler.Layout/Broiler.Layout/AnchorRegistry.cs
@@ -101,6 +101,16 @@ public sealed class AnchorRegistry
     }
 
     /// <summary>
+    /// Resolves the acceptable anchor rectangle for a query in its own scope (per
+    /// <paramref name="inScope"/>, else last-wins). Public wrapper over the scope
+    /// resolution for callers that need the raw rect (e.g. resolving <c>anchor()</c>
+    /// insets against a caller-computed containing-block frame). Returns <c>false</c>
+    /// when the anchor is not registered.
+    /// </summary>
+    public bool TryResolveRect(string anchorName, Func<object?, bool>? inScope, out AnchorRect rect)
+        => TryResolve(anchorName, inScope, out rect);
+
+    /// <summary>
     /// Resolves the <c>position-area</c> grid cell for an anchored box against the
     /// named anchor (in the query's scope, per <paramref name="inScope"/>) and the box's
     /// containing-block frame. Returns <c>null</c> when the anchor is not registered (the

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
@@ -133,6 +133,13 @@ partial class CssBox
             box.OffsetLeft(target.Left - box.Location.X);
             box.OffsetTop(target.Top - box.Location.Y);
         }
+        else if (box.PositionArea == "none")
+        {
+            // anchor()/anchor-size() inset placement (P5.8d.2b anchor()-insets expansion):
+            // a box positioned by anchor() functions in its left/right/top/bottom rather
+            // than position-area.
+            box.TryApplyAnchorInsetPlacement(registry);
+        }
 
         foreach (var child in box.Boxes)
             ApplyNativeAnchorPlacement(child, registry);
@@ -373,5 +380,119 @@ partial class CssBox
         if (len.IsPercentage)
             return basis * len.Number;
         return len.Unit == CssUnit.Px ? len.Number : 0;
+    }
+
+    /// <summary>Whether a raw CSS inset value carries an <c>anchor()</c> function.</summary>
+    private static bool InsetHasAnchor(string? value) =>
+        value != null && value.Contains("anchor(", System.StringComparison.OrdinalIgnoreCase)
+        && !value.Contains("anchor-size(", System.StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Places a box positioned by <c>anchor()</c> functions in its physical insets
+    /// (<c>left</c>/<c>right</c>/<c>top</c>/<c>bottom</c>) — the engine equivalent of the
+    /// bridge's <c>ResolveAnchorFunctions</c> pre-bake (P5.8d.2b anchor()-insets expansion).
+    /// MVP: reposition-only (the box's already-laid-out size is kept), at most one inset per
+    /// axis (opposing-inset sizing stays on the bridge path). For each present inset it
+    /// resolves the anchor() reference to a CB-frame inset value via the promoted
+    /// <see cref="AnchorGeometry.ResolveEdge"/> (mirroring the bridge exactly), converts it to
+    /// the box's document-absolute margin edge, and offsets the border box there. Returns
+    /// <c>false</c> (leaves the box put) when it is not an anchor()-inset box or its anchor is
+    /// unregistered.
+    /// </summary>
+    internal bool TryApplyAnchorInsetPlacement(AnchorRegistry registry)
+    {
+        if (Position != CssConstants.Absolute && Position != CssConstants.Fixed)
+            return false;
+        bool anchorLeft = InsetHasAnchor(Left), anchorRight = InsetHasAnchor(Right);
+        bool anchorTop = InsetHasAnchor(Top), anchorBottom = InsetHasAnchor(Bottom);
+        if (!anchorLeft && !anchorRight && !anchorTop && !anchorBottom)
+            return false;
+
+        var cb = FindPositionedContainingBlock();
+        GetAbsoluteContainingBlockPaddingBox(cb, out double cbX, out double cbY, out double cbW, out double cbH);
+        // Scope resolution mirrors the position-area path: bind a shared anchor-name to the
+        // candidate inside the query's own containing block.
+        Func<object?, bool> inScope = scope => scope is CssBox src && IsBoxDescendantOf(src, cb);
+
+        double? leftInset = ResolveInsetMaybeAnchor(Left, AnchorInsetProperty.Left, registry, inScope, cbX, cbY, cbW, cbH);
+        double? rightInset = ResolveInsetMaybeAnchor(Right, AnchorInsetProperty.Right, registry, inScope, cbX, cbY, cbW, cbH);
+        double? topInset = ResolveInsetMaybeAnchor(Top, AnchorInsetProperty.Top, registry, inScope, cbX, cbY, cbW, cbH);
+        double? bottomInset = ResolveInsetMaybeAnchor(Bottom, AnchorInsetProperty.Bottom, registry, inScope, cbX, cbY, cbW, cbH);
+
+        // MVP requires an anchor-resolved inset to have succeeded on the anchored axis.
+        if (anchorLeft && leftInset is null) return false;
+        if (anchorRight && rightInset is null) return false;
+        if (anchorTop && topInset is null) return false;
+        if (anchorBottom && bottomInset is null) return false;
+
+        double bw = Size.Width, bh = Size.Height;
+
+        // Horizontal: the inset is measured from the CB padding edge to the box's MARGIN
+        // edge; add/subtract the used margin to reach the border box (reposition-only, so
+        // the laid-out width is kept). Prefer left; else right.
+        double? borderLeft = null;
+        if (leftInset is double L)
+            borderLeft = cbX + L + ActualMarginLeft;
+        else if (rightInset is double R)
+            borderLeft = cbX + cbW - R - ActualMarginRight - bw;
+
+        double? borderTop = null;
+        if (topInset is double T)
+            borderTop = cbY + T + ActualMarginTop;
+        else if (bottomInset is double B)
+            borderTop = cbY + cbH - B - ActualMarginBottom - bh;
+
+        if (borderLeft is double bl)
+            OffsetLeft((float)(bl - Location.X));
+        if (borderTop is double bt)
+            OffsetTop((float)(bt - Location.Y));
+        return borderLeft != null || borderTop != null;
+    }
+
+    /// <summary>
+    /// Resolves one physical inset that may contain an <c>anchor()</c> function to a CB-frame
+    /// length (px). A plain length/percentage resolves normally; an <c>anchor()</c> reference
+    /// resolves against the named anchor's document-absolute rect (converted to the CB frame)
+    /// via <see cref="AnchorGeometry.ResolveEdge"/> — the same math the bridge bakes. Returns
+    /// <c>null</c> for <c>auto</c>/absent/unparseable/unregistered, or a value the reposition
+    /// MVP does not model (e.g. a <c>calc()</c> the rewrite leaves non-numeric).
+    /// </summary>
+    private double? ResolveInsetMaybeAnchor(
+        string? value, AnchorInsetProperty property, AnchorRegistry registry,
+        Func<object?, bool> inScope, double cbX, double cbY, double cbW, double cbH)
+    {
+        if (string.IsNullOrEmpty(value) || value == CssConstants.Auto)
+            return null;
+
+        double basis = property is AnchorInsetProperty.Left or AnchorInsetProperty.Right ? cbW : cbH;
+
+        if (!InsetHasAnchor(value))
+        {
+            var plain = new CssLength(value);
+            if (plain.HasError) return null;
+            if (plain.IsPercentage) return basis * plain.Number;
+            return plain.Unit == CssUnit.Px ? plain.Number : null;
+        }
+
+        // Rewrite each anchor() reference to a px string against the resolved anchor rect,
+        // then parse the (now numeric) result. The default anchor is the box's
+        // position-anchor when the function names none.
+        string rewritten = AnchorFunction.Rewrite(value, r =>
+        {
+            string name = string.IsNullOrEmpty(r.Name) ? (PositionAnchor ?? string.Empty) : r.Name!;
+            if (string.IsNullOrEmpty(name) || name == "auto" ||
+                !registry.TryResolveRect(name, inScope, out var a))
+                return r.Fallback ?? "0px";
+
+            double v = AnchorGeometry.ResolveEdge(
+                a.Left - cbX, a.Top - cbY, a.Right - cbX, a.Bottom - cbY,
+                r.Side, 0, 0, property, cbW, cbH);
+            return v.ToString(System.Globalization.CultureInfo.InvariantCulture) + "px";
+        });
+
+        var len = new CssLength(rewritten);
+        if (len.HasError) return null;
+        if (len.IsPercentage) return basis * len.Number;
+        return len.Unit == CssUnit.Px ? len.Number : null;
     }
 }

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
@@ -135,6 +135,10 @@ partial class CssBox
         }
         else if (box.PositionArea == "none")
         {
+            // anchor-size() sizing (P5.8d.2b anchor-size() expansion): size a childless box
+            // to the anchor's width/height first, so any anchor()-inset placement that
+            // follows repositions against the resolved size.
+            box.TryApplyNativeAnchorSizing(registry);
             // anchor()/anchor-size() inset placement (P5.8d.2b anchor()-insets expansion):
             // a box positioned by anchor() functions in its left/right/top/bottom rather
             // than position-area.
@@ -380,6 +384,83 @@ partial class CssBox
         if (len.IsPercentage)
             return basis * len.Number;
         return len.Unit == CssUnit.Px ? len.Number : 0;
+    }
+
+    /// <summary>Whether a raw CSS value carries an <c>anchor-size()</c> function.</summary>
+    private static bool HasAnchorSize(string? value) =>
+        value != null && value.Contains("anchor-size(", System.StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Sizes a childless box whose <c>width</c>/<c>height</c> use <c>anchor-size()</c> to the
+    /// named anchor's dimension (P5.8d.2b anchor-size() expansion) — the engine equivalent of
+    /// the bridge's <c>ResolveAnchorSizeFunctions</c> pre-bake. The resolved value is the used
+    /// content or border size per <c>box-sizing</c> (mirroring how the bridge writes the
+    /// property and the renderer applies it); the box is grown in place from its current
+    /// origin, so any following <c>anchor()</c>-inset placement repositions against the new
+    /// size. Returns <c>false</c> (size unchanged) when it is not an MVP anchor-size box or the
+    /// anchor is unregistered.
+    /// </summary>
+    internal bool TryApplyNativeAnchorSizing(AnchorRegistry registry)
+    {
+        if (Boxes.Count != 0 || Words.Count != 0)
+            return false; // childless only (a re-flow would be needed otherwise)
+        if (Position != CssConstants.Absolute && Position != CssConstants.Fixed)
+            return false;
+        bool wAnchor = HasAnchorSize(Width), hAnchor = HasAnchorSize(Height);
+        if (!wAnchor && !hAnchor)
+            return false;
+
+        var cb = FindPositionedContainingBlock();
+        Func<object?, bool> inScope = scope => scope is CssBox src && IsBoxDescendantOf(src, cb);
+
+        double? contentW = wAnchor ? ResolveAnchorSizeComponent(Width, registry, inScope) : null;
+        double? contentH = hAnchor ? ResolveAnchorSizeComponent(Height, registry, inScope) : null;
+        if (wAnchor && contentW is null) return false;
+        if (hAnchor && contentH is null) return false;
+
+        // box-sizing: content-box (default) — the resolved value is the content size, so add
+        // padding+border for the border box. border-box — it already is the border box (clamp
+        // to at least padding+border so the content stays non-negative). Font-free px, matching
+        // the bridge and the position-area sizing path.
+        bool borderBox = string.Equals(BoxSizing, "border-box", StringComparison.OrdinalIgnoreCase);
+        double padBorderW =
+            NativeBorderPx(BorderLeftWidth, BorderLeftStyle) + NativePaddingPx(PaddingLeft)
+            + NativePaddingPx(PaddingRight) + NativeBorderPx(BorderRightWidth, BorderRightStyle);
+        double padBorderH =
+            NativeBorderPx(BorderTopWidth, BorderTopStyle) + NativePaddingPx(PaddingTop)
+            + NativePaddingPx(PaddingBottom) + NativeBorderPx(BorderBottomWidth, BorderBottomStyle);
+
+        float newW = Size.Width, newH = Size.Height;
+        if (contentW is double cw)
+            newW = (float)(borderBox ? System.Math.Max(cw, padBorderW) : cw + padBorderW);
+        if (contentH is double ch)
+            newH = (float)(borderBox ? System.Math.Max(ch, padBorderH) : ch + padBorderH);
+        Size = new System.Drawing.SizeF(newW, newH);
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves a <c>width</c>/<c>height</c> value that uses <c>anchor-size()</c> to the
+    /// anchor's dimension (px). The default anchor is the box's <c>position-anchor</c> when the
+    /// function names none. Returns <c>null</c> for an unregistered anchor / non-numeric result.
+    /// </summary>
+    private double? ResolveAnchorSizeComponent(
+        string? value, AnchorRegistry registry, Func<object?, bool> inScope)
+    {
+        if (string.IsNullOrEmpty(value))
+            return null;
+        string rewritten = AnchorFunction.RewriteSize(value, r =>
+        {
+            string name = string.IsNullOrEmpty(r.Name) ? (PositionAnchor ?? string.Empty) : r.Name!;
+            if (string.IsNullOrEmpty(name) || name == "auto")
+                return "0px";
+            var size = registry.ResolveAnchorSize(name, r.Dimension, inScope);
+            return size is double s ? s.ToString(System.Globalization.CultureInfo.InvariantCulture) + "px" : "0px";
+        });
+        var len = new CssLength(rewritten);
+        if (len.HasError || len.IsPercentage)
+            return null;
+        return len.Unit == CssUnit.Px ? len.Number : null;
     }
 
     /// <summary>Whether a raw CSS inset value carries an <c>anchor()</c> function.</summary>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
@@ -463,6 +463,11 @@ partial class CssBox
         return len.Unit == CssUnit.Px ? len.Number : null;
     }
 
+    /// <summary>Whether a CSS <c>width</c>/<c>height</c> value is <c>auto</c> (or unset), so an
+    /// opposing pair of insets determines the used size.</summary>
+    private static bool IsAutoLength(string? value) =>
+        string.IsNullOrEmpty(value) || value == CssConstants.Auto;
+
     /// <summary>Whether a raw CSS inset value carries an <c>anchor()</c> function.</summary>
     private static bool InsetHasAnchor(string? value) =>
         value != null && value.Contains("anchor(", System.StringComparison.OrdinalIgnoreCase)
@@ -508,9 +513,23 @@ partial class CssBox
 
         double bw = Size.Width, bh = Size.Height;
 
+        // Opposing-inset sizing (P5.8d.2b): both insets present on an axis + an auto length +
+        // a childless box → the used size is determined by the two insets (CSS 2.1 §10.3.7 /
+        // §10.6.4: the border box fills the inset-modified containing block minus margins).
+        // Childless-only so no subtree needs a re-flow; an explicit length keeps its size
+        // (the reposition-only branch below positions by the start inset). Grow from the
+        // resolved size before positioning.
+        bool childless = Boxes.Count == 0 && Words.Count == 0;
+        if (childless && leftInset is double li && rightInset is double ri && IsAutoLength(Width))
+            bw = System.Math.Max(0, cbW - li - ri - ActualMarginLeft - ActualMarginRight);
+        if (childless && topInset is double ti && bottomInset is double bi && IsAutoLength(Height))
+            bh = System.Math.Max(0, cbH - ti - bi - ActualMarginTop - ActualMarginBottom);
+        if (bw != Size.Width || bh != Size.Height)
+            Size = new System.Drawing.SizeF((float)bw, (float)bh);
+
         // Horizontal: the inset is measured from the CB padding edge to the box's MARGIN
-        // edge; add/subtract the used margin to reach the border box (reposition-only, so
-        // the laid-out width is kept). Prefer left; else right.
+        // edge; add/subtract the used margin to reach the border box. When only one inset is
+        // present the laid-out (or opposing-inset-resolved) size is kept. Prefer left; else right.
         double? borderLeft = null;
         if (leftInset is double L)
             borderLeft = cbX + L + ActualMarginLeft;

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1867,13 +1867,26 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   the baked `AnchorInlineContainingBlockTests` corner; a flag-off control pins the placement to the
   post-pass). Regression check: **default-off byte-identical (8-fail / 31-pass)**; **lever-on unchanged
   (7-fail / 32-pass)**, the only corpus movement being `position-area-inline-container` 83.30 %→83.10 %
-  (−0.2 %, run noise — that test is corrupted by a **pre-existing, unrelated `&nbsp;`-not-decoded rendering
-  bug** that renders the entity as literal text, so it fails ~83 % on *both* paths and cannot pass from
-  anchor work). `position-area-abs-inline-container` is unchanged (kept baked by the abspos-inline
-  exception). No passing test regresses on either path; the baked-path `AnchorInlineContainingBlockTests`
-  (26) and native WPT/scope suites stay green. Validation is therefore the exact-geometry pipeline test plus
-  no-regression (the percentage-box-props precedent). The `abs-inline-container` bridge/engine
-  blockification disagreement is the follow-up before that test can also go native.
+  (−0.2 %, run noise — that test was corrupted by a then-unrelated `&nbsp;`-not-decoded rendering bug that
+  rendered the entity as literal text). `position-area-abs-inline-container` is unchanged (kept baked by the
+  abspos-inline exception). No passing test regresses on either path; the baked-path
+  `AnchorInlineContainingBlockTests` (26) and native WPT/scope suites stay green. Validation is therefore the
+  exact-geometry pipeline test plus no-regression (the percentage-box-props precedent). The
+  `abs-inline-container` bridge/engine blockification disagreement is the follow-up before that test can also
+  go native.
+  - **Follow-up — the `&nbsp;`-not-decoded rendering bug is now FIXED** (2026-07-14; `Broiler.DOM`
+    submodule, `HtmlTokenizer`). Root cause: the shared WHATWG tokenizer emitted character data verbatim, so
+    named/decimal/hex character references (`&nbsp;`, `&#160;`, `&#xA0;`) stayed literal in the DOM; the
+    serializer then HTML-encoded them, so the bridge→serialize→reparse render path double-encoded to
+    `&amp;nbsp;` and painted the literal entity. The tokenizer now decodes references in Data-state character
+    tokens (raw-text `<script>`/`<style>` stay verbatim; attribute decoding left to the downstream
+    `Broiler.HTML` `HtmlParser` to avoid a double-decode). Impact on the inline-container family:
+    `position-area-inline-container` 83 %→**95.8 %** (lever-on) / 91.9 % (default-off),
+    `position-area-abs-inline-container` 88 %→92 % — both substantially improved (the residual gap is inline-CB
+    position-area geometry precision, not the entity bug). Zero regressions: full `Broiler.Cli.Tests` diffed
+    stash-vs-change is **0 new failures, +1 fixed** (`Acid3_Score_Position_With_Negative_Margin`); the
+    css-anchor-position subset passing set is unchanged both modes. Regression test:
+    `Broiler.Cli.Tests/HtmlEntityDecodingTests.cs`.
 - **P5.8d.2b — `anchor()` inset placement (seventh expansion) — COMPLETED** 2026-07-14
   (branch `htmlbridge-phase5-native-anchor-inline-cb`; Broiler.Layout + bridge, both parent-repo, additive,
   default-off). A box positioned by `anchor()` functions in its physical insets (`left`/`right`/`top`/

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1841,24 +1841,59 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   by **1.26 %**. So the residual is Broiler-vs-Chromium anti-aliasing/border fidelity (a separate,
   pre-existing rendering concern), and the anchor geometry is exact. `percents-001` will not cross the 99 %
   pixel threshold from anchor work alone.
+- **P5.8d.2b — inline containing-block promotion (sixth expansion) — COMPLETED** 2026-07-14
+  (branch `htmlbridge-phase5-native-anchor-inline-cb`; bridge only, additive, default-off). A
+  `position-area` box whose containing block is a **relatively-positioned inline element** (a
+  `position:relative` `<span>`) now goes native. The engine already resolves this case correctly: an abspos
+  box inside an inline CB is placed against the inline element's real line-box bounding box
+  (`CssBox.GetInlineBoundingBox`, CSS2.1 §10.1) — the very thing the bridge's estimator could **not** do,
+  which is why the bridge's `PromoteAbsPosFromInlineCBs` DOM-moves abspos children out of inline CBs (~250
+  lines of inline-flow-offset estimation) on the baked path. So this expansion is bridge-gate-only, no
+  Broiler.Layout change:
+  - **Gate.** `IsMvpNativeAnchorBox` no longer excludes an inline CB. It still excludes an inline CB that is
+    **itself** `position:absolute`/`fixed`: the engine blockifies such an element (CSS2.1 §9.7 forces
+    `display:block`) so it treats that CB as a *block*, while the bridge's `IsInlineElement` still treats it
+    as inline — the two disagree on the CB extent, so that case stays baked until reconciled (this is exactly
+    `position-area-abs-inline-container`, kept on the bridge path).
+  - **Promotion skip.** In native mode `CollectInlineCBPromotions` skips the **whole** inline CB when it
+    directly holds a native-MVP `position-area` box (`InlineCbHasNativeAnchorBox` →
+    `IsNativeMvpPositionAreaBox`, a reusable "would native mode hand this off?" predicate): the engine lays
+    out the intact anchor+target subtree, so DOM-moving any of that inline CB's abspos children would tear
+    the anchor out of the target's containing block and break the native placement. Other inline CBs still
+    promote as before.
+  Tests: `Broiler.Cli.Tests/NativeAnchorInlineCbPipelineTests.cs` (real parse→cascade→layout pipeline: the
+  engine places the abspos anchor at its inset position inside a `position:relative` inline CB — `(100,25)`,
+  not the inline-flow position — and the `bottom right` cell at the grid corner `(300,75)` 100×25, matching
+  the baked `AnchorInlineContainingBlockTests` corner; a flag-off control pins the placement to the
+  post-pass). Regression check: **default-off byte-identical (8-fail / 31-pass)**; **lever-on unchanged
+  (7-fail / 32-pass)**, the only corpus movement being `position-area-inline-container` 83.30 %→83.10 %
+  (−0.2 %, run noise — that test is corrupted by a **pre-existing, unrelated `&nbsp;`-not-decoded rendering
+  bug** that renders the entity as literal text, so it fails ~83 % on *both* paths and cannot pass from
+  anchor work). `position-area-abs-inline-container` is unchanged (kept baked by the abspos-inline
+  exception). No passing test regresses on either path; the baked-path `AnchorInlineContainingBlockTests`
+  (26) and native WPT/scope suites stay green. Validation is therefore the exact-geometry pipeline test plus
+  no-regression (the percentage-box-props precedent). The `abs-inline-container` bridge/engine
+  blockification disagreement is the follow-up before that test can also go native.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
-  ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → inline-CB promotion (DOM moves) →
-  scroll simulation → `position-visibility` → dialog/backdrop → `anchor()` insets → position-try.
+  ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → ~~inline-CB promotion (relative inline
+  CB)~~ → abspos-inline CB (blockification reconciliation) → scroll simulation → `position-visibility` →
+  dialog/backdrop → `anchor()` insets → position-try.
   (Childless auto/explicit/percentage sizing, `box-sizing:border-box`, percentage margin/padding/inset box
-  props, shared-name scope resolution, AND writing-mode percentage basis now land natively — see the five
-  expansions above.) Each remaining feature is currently excluded by `IsMvpNativeAnchorBox` (or
-  `CanApplyNativeAnchorSize`) and stays on the bridge path (baked + `position-area: none`), so enabling the
-  lever globally is already safe (proven above); the expansions widen the gate one feature at a time as the
-  engine grows to reproduce them.
+  props, shared-name scope resolution, writing-mode percentage basis, AND relatively-positioned inline
+  containing blocks now land natively — see the six expansions above.) Each remaining feature is currently
+  excluded by `IsMvpNativeAnchorBox` (or `CanApplyNativeAnchorSize`) and stays on the bridge path (baked +
+  `position-area: none`), so enabling the lever globally is already safe (proven above); the expansions
+  widen the gate one feature at a time as the engine grows to reproduce them.
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4
   item-2 unblock** — once every feature is on the engine path.
 
-The DOM-entangled bridge concerns (anchor registry *building* now trivial on the box tree; but
-inline-CB promotion with DOM moves, scroll simulation, `position-visibility`, dialog/backdrop,
-`anchor-scope`/scoping) are the hard part of the later cutover expansions: the engine operates on boxes,
-not the DOM, so these are re-implementations, not moves — which is why the MVP subset deliberately
-excludes them.
+The DOM-entangled bridge concerns (anchor registry *building* now trivial on the box tree, and the
+relatively-positioned inline-CB case now handled by the engine's real §10.1 inline-box geometry rather
+than the bridge's DOM-move estimator; but abspos-inline blockification reconciliation, scroll simulation,
+`position-visibility`, dialog/backdrop, `anchor-scope`/scoping) are the hard part of the later cutover
+expansions: the engine operates on boxes, not the DOM, so these are re-implementations, not moves — which
+is why the MVP subset deliberately excludes them.
 
 Goal: turn LayoutMetrics and AnchorResolver into a thin API adapter over a
 single layout snapshot.

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1874,15 +1874,45 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   (26) and native WPT/scope suites stay green. Validation is therefore the exact-geometry pipeline test plus
   no-regression (the percentage-box-props precedent). The `abs-inline-container` bridge/engine
   blockification disagreement is the follow-up before that test can also go native.
+- **P5.8d.2b — `anchor()` inset placement (seventh expansion) — COMPLETED** 2026-07-14
+  (branch `htmlbridge-phase5-native-anchor-inline-cb`; Broiler.Layout + bridge, both parent-repo, additive,
+  default-off). A box positioned by `anchor()` functions in its physical insets (`left`/`right`/`top`/
+  `bottom`) rather than `position-area` now goes native — the engine equivalent of the bridge's
+  `ResolveAnchorFunctions` pre-bake, and the first native path that is **not** driven by `position-area`.
+  The raw `anchor()` inset survives the cascade onto `CssBox.Left`/`Top`/`Right`/`Bottom` (verified by probe),
+  so:
+  - **Engine.** `CssBox.TryApplyAnchorInsetPlacement` (in `CssBox.Anchor.cs`, run from the root post-pass
+    when `PositionArea == "none"`) resolves each anchor() inset against the named anchor's document-absolute
+    rect converted to the CB frame, via the already-promoted `AnchorGeometry.ResolveEdge` (mirroring the
+    bridge's bake exactly), then places the box's document-absolute margin edge at the resolved inset and
+    offsets the border box there. MVP: reposition-only (laid-out size kept), at most one inset per axis
+    (opposing-inset sizing needs a re-flow and stays baked); a plain length or a percentage on the other axis
+    resolves normally. `AnchorRegistry` gains a public `TryResolveRect` (scoped rect getter) so the caller can
+    build the CB-frame inset itself. Scope binding reuses the position-area predicate.
+  - **Bridge.** `ResolveAnchorFunctions` skips baking (`hasAnchorRef = false`) for a native-MVP anchor()-inset
+    box (`IsMvpNativeAnchorInsetBox`: every anchor() is in a physical inset naming a registered accessible
+    anchor; no `anchor-size()`; single inset per axis; not fixed/modal; no intervening scroll offset — the
+    engine uses no scroll adjustment; no `position-try`), leaving the `anchor()` CSS to survive to the engine.
+  Tests: `Broiler.Layout.Tests/NativeAnchorPlacementTests.cs` +5 (left/top, right/bottom far-edge, mixed
+  anchor+length, implicit `position-anchor`, unregistered→fallback); `Broiler.Cli.Tests/
+  NativeAnchorInsetPipelineTests.cs` (real pipeline: a `left/top: anchor(--a right/bottom)` box lands at the
+  anchor's right/bottom edge); `Broiler.Wpt.Tests/NativeAnchorInsetWptTests.cs` (full render pipeline: engine
+  places it, baked & native paths agree pixel-wise). Regression check: full `Broiler.Layout.Tests` (139)
+  green; **default-off byte-identical (8-fail / 31-pass)**; **lever-on unchanged (7-fail / 32-pass) with zero
+  per-test movement.** As with the percentage-box-props expansion, **no corpus pixel test exercises the
+  anchor()-inset MVP path** (the corpus's anchor() tests are testharness/JS — unaffected by the render-only
+  lever — or gate-excluded), so validation is the exact-geometry unit + pipeline + full-render tests plus
+  no-regression.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
   ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → ~~inline-CB promotion (relative inline
-  CB)~~ → abspos-inline CB (blockification reconciliation) → scroll simulation → `position-visibility` →
-  dialog/backdrop → `anchor()` insets → position-try.
+  CB)~~ → ~~`anchor()` insets~~ → abspos-inline CB (blockification reconciliation) → `anchor-size()` →
+  opposing-inset sizing → scroll simulation → `position-visibility` → dialog/backdrop → position-try.
   (Childless auto/explicit/percentage sizing, `box-sizing:border-box`, percentage margin/padding/inset box
-  props, shared-name scope resolution, writing-mode percentage basis, AND relatively-positioned inline
-  containing blocks now land natively — see the six expansions above.) Each remaining feature is currently
-  excluded by `IsMvpNativeAnchorBox` (or `CanApplyNativeAnchorSize`) and stays on the bridge path (baked +
+  props, shared-name scope resolution, writing-mode percentage basis, relatively-positioned inline
+  containing blocks, AND `anchor()` physical insets now land natively — see the seven expansions above.) Each
+  remaining feature is currently excluded by `IsMvpNativeAnchorBox`/`IsMvpNativeAnchorInsetBox` (or
+  `CanApplyNativeAnchorSize`) and stays on the bridge path (baked +
   `position-area: none`), so enabling the lever globally is already safe (proven above); the expansions
   widen the gate one feature at a time as the engine grows to reproduce them.
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1930,18 +1930,36 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   the three native-anchor WPT render test classes into one `[Collection("NativeAnchorWpt")]`: they toggle the
   process-wide `WptTestRunner.NativeAnchorPlacement` static around a render, so running them in parallel let
   one class's baked render stomp another's native render — a shared-static test race, not a product bug.)
+- **P5.8d.2b — opposing-inset sizing (ninth expansion) — COMPLETED** 2026-07-14
+  (branch `htmlbridge-phase5-native-anchor-inline-cb`; Broiler.Layout + bridge, additive, default-off). Directly
+  completes the `anchor()`-insets feature: when both physical insets of an axis are present (at least one an
+  `anchor()`), a **childless** box with an **auto** length on that axis is now *sized* to span between the two
+  resolved insets, not just repositioned (CSS 2.1 §10.3.7/§10.6.4: the border box fills the inset-modified
+  containing block minus margins). `CssBox.TryApplyAnchorInsetPlacement` grows the box from the resolved size
+  before positioning at the start inset; a childful box (needs a re-flow) or an explicit length
+  (over-constrained) keeps the reposition-only behaviour. The bridge's `IsMvpNativeAnchorInsetBox` opposing-inset
+  exclusion is relaxed to admit exactly that childless-and-auto case (via `ChildElements`/`GetElementTextContent`
+  + `IsAutoLength`); every other opposing-inset box stays baked. Tests: `Broiler.Layout.Tests/
+  NativeAnchorPlacementTests.cs` +5 (span left/right, span top/bottom, margins shrink the border box, explicit
+  width keeps size, childful keeps size); `Broiler.Cli.Tests/NativeAnchorOpposingInsetPipelineTests.cs` (real
+  pipeline: a four-inset box spans the anchor); `Broiler.Wpt.Tests/NativeAnchorOpposingInsetWptTests.cs` (full
+  render). Regression check: full `Broiler.Layout.Tests` (150) green; **default-off byte-identical (8-fail /
+  31-pass)**; **lever-on 7-fail / 32-pass, passing set unchanged, with the FIRST corpus pixel improvement of
+  the anchor()-function expansions:** `anchor-position-borders-002` (a testharness test whose `.target` boxes are
+  auto-size, four-inset `anchor()` spanners) improves **99.38 %→99.99 %** — those targets now size natively
+  (more precisely than the bridge estimator) — with no other test moving and no regression.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
   ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → ~~inline-CB promotion (relative inline
-  CB)~~ → ~~`anchor()` insets~~ → ~~`anchor-size()`~~ → abspos-inline CB (blockification reconciliation) →
-  opposing-inset sizing → scroll simulation → `position-visibility` → dialog/backdrop → position-try.
+  CB)~~ → ~~`anchor()` insets~~ → ~~`anchor-size()`~~ → ~~opposing-inset sizing~~ → abspos-inline CB
+  (blockification reconciliation) → scroll simulation → `position-visibility` → dialog/backdrop → position-try.
   (Childless auto/explicit/percentage sizing, `box-sizing:border-box`, percentage margin/padding/inset box
   props, shared-name scope resolution, writing-mode percentage basis, relatively-positioned inline
-  containing blocks, `anchor()` physical insets, AND `anchor-size()` sizing now land natively — see the eight
-  expansions above.) Each remaining feature is currently excluded by `IsMvpNativeAnchorBox`/
-  `IsMvpNativeAnchorInsetBox`/`IsMvpNativeAnchorSizeBox` (or `CanApplyNativeAnchorSize`) and stays on the
-  bridge path (baked + `position-area: none`), so enabling the lever globally is already safe (proven above);
-  the expansions widen the gate one feature at a time as the engine grows to reproduce them.
+  containing blocks, `anchor()` physical insets, `anchor-size()` sizing, AND opposing-inset sizing now land
+  natively — see the nine expansions above.) Each remaining feature is currently excluded by
+  `IsMvpNativeAnchorBox`/`IsMvpNativeAnchorInsetBox`/`IsMvpNativeAnchorSizeBox` (or `CanApplyNativeAnchorSize`)
+  and stays on the bridge path (baked + `position-area: none`), so enabling the lever globally is already safe
+  (proven above); the expansions widen the gate one feature at a time as the engine grows to reproduce them.
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4
   item-2 unblock** — once every feature is on the engine path.
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1903,18 +1903,45 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   anchor()-inset MVP path** (the corpus's anchor() tests are testharness/JS — unaffected by the render-only
   lever — or gate-excluded), so validation is the exact-geometry unit + pipeline + full-render tests plus
   no-regression.
+- **P5.8d.2b — `anchor-size()` sizing (eighth expansion) — COMPLETED** 2026-07-14
+  (branch `htmlbridge-phase5-native-anchor-inline-cb`; Broiler.Layout + bridge, both parent-repo, additive,
+  default-off). Completes the `anchor()` function family (insets + sizing). A **childless** box whose
+  `width`/`height` use `anchor-size()` is now sized natively by the engine (the equivalent of the bridge's
+  `ResolveAnchorSizeFunctions`). The raw `anchor-size()` value survives onto `CssBox.Width`/`Height`, so:
+  - **Engine.** `CssBox.TryApplyNativeAnchorSizing` (run from the post-pass when `PositionArea == "none"`,
+    *before* the anchor()-inset placement so a repositioning uses the resolved size) resolves each
+    `anchor-size()` to the named anchor's dimension via `AnchorRegistry.ResolveAnchorSize` (dimensions are
+    frame-independent, so no CB conversion), then sets the used border box per `box-sizing` (content+pad/border,
+    or border-box clamped) with the font-free `NativeBorderPx`/`NativePaddingPx` helpers, growing the box in
+    place from its laid-out origin. Childless only (a re-flow would be needed otherwise).
+  - **Bridge.** `ResolveAnchorFunctions` skips baking the `anchor-size()` (`IsMvpNativeAnchorSizeBox`: an
+    absolutely-positioned childless box; `anchor-size()` only in `width`/`height` naming a registered
+    accessible anchor; no `anchor()` inset — the combined case stays baked; no `position-area`; no right/bottom
+    inset; **no CSS `zoom`**; not modal; no `position-try`), leaving the CSS for the engine.
+  Tests: `Broiler.Layout.Tests/NativeAnchorPlacementTests.cs` +6 (width+height, width-only, content-box
+  pad/border, border-box, implicit `position-anchor`, childful fallback); `Broiler.Cli.Tests/
+  NativeAnchorSizePipelineTests.cs` (real pipeline sizes the box to the anchor's 50×70);
+  `Broiler.Wpt.Tests/NativeAnchorSizeWptTests.cs` (full render; baked & native agree). Regression check: full
+  `Broiler.Layout.Tests` (145) green; **default-off byte-identical (8-fail / 31-pass)**; **lever-on unchanged
+  (7-fail / 32-pass) with zero per-test movement.** The two corpus `anchor-size()` pixel tests stay baked and
+  **pass** as before — `anchor-size-css-zoom` (excluded by the `zoom` gate) and `transform-005` (excluded by
+  the `position-area` gate; it combines `anchor-size()` with `position-area` and 3D transforms) — so the clean
+  `anchor-size()` path is unit + pipeline + full-render validated with no corpus movement. (Also serialized
+  the three native-anchor WPT render test classes into one `[Collection("NativeAnchorWpt")]`: they toggle the
+  process-wide `WptTestRunner.NativeAnchorPlacement` static around a render, so running them in parallel let
+  one class's baked render stomp another's native render — a shared-static test race, not a product bug.)
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
   ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → ~~inline-CB promotion (relative inline
-  CB)~~ → ~~`anchor()` insets~~ → abspos-inline CB (blockification reconciliation) → `anchor-size()` →
+  CB)~~ → ~~`anchor()` insets~~ → ~~`anchor-size()`~~ → abspos-inline CB (blockification reconciliation) →
   opposing-inset sizing → scroll simulation → `position-visibility` → dialog/backdrop → position-try.
   (Childless auto/explicit/percentage sizing, `box-sizing:border-box`, percentage margin/padding/inset box
   props, shared-name scope resolution, writing-mode percentage basis, relatively-positioned inline
-  containing blocks, AND `anchor()` physical insets now land natively — see the seven expansions above.) Each
-  remaining feature is currently excluded by `IsMvpNativeAnchorBox`/`IsMvpNativeAnchorInsetBox` (or
-  `CanApplyNativeAnchorSize`) and stays on the bridge path (baked +
-  `position-area: none`), so enabling the lever globally is already safe (proven above); the expansions
-  widen the gate one feature at a time as the engine grows to reproduce them.
+  containing blocks, `anchor()` physical insets, AND `anchor-size()` sizing now land natively — see the eight
+  expansions above.) Each remaining feature is currently excluded by `IsMvpNativeAnchorBox`/
+  `IsMvpNativeAnchorInsetBox`/`IsMvpNativeAnchorSizeBox` (or `CanApplyNativeAnchorSize`) and stays on the
+  bridge path (baked + `position-area: none`), so enabling the lever globally is already safe (proven above);
+  the expansions widen the gate one feature at a time as the engine grows to reproduce them.
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4
   item-2 unblock** — once every feature is on the engine path.
 

--- a/src/Broiler.Cli.Tests/HtmlEntityDecodingTests.cs
+++ b/src/Broiler.Cli.Tests/HtmlEntityDecodingTests.cs
@@ -1,0 +1,73 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Regression tests for HTML character-reference decoding in text content. The shared
+/// <c>Broiler.Dom.Html.HtmlTokenizer</c> previously emitted character data verbatim, so
+/// <c>&amp;nbsp;</c> etc. stayed as the literal text "&amp;nbsp;" in the DOM — and, because
+/// the serializer HTML-encodes text on the way out, the WPT bridge→serialize→reparse render
+/// path then double-encoded it to <c>&amp;amp;nbsp;</c> and painted the literal entity
+/// (css-anchor-position position-area-inline-container). The tokenizer now decodes named,
+/// decimal, and hex references in ordinary character data (but not in raw-text
+/// <c>&lt;script&gt;</c>/<c>&lt;style&gt;</c> content).
+/// </summary>
+public sealed class HtmlEntityDecodingTests
+{
+    private const string Url = "file:///entities.html";
+
+    private static string TextContent(string bodyHtml, string id)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, $"<!DOCTYPE html><html><body>{bodyHtml}</body></html>", Url);
+        return context.Eval($"document.getElementById('{id}').textContent")?.ToString() ?? "";
+    }
+
+    [Theory]
+    [InlineData("<div id='t'>&nbsp;</div>", " ")]      // named
+    [InlineData("<div id='t'>&#160;</div>", " ")]      // decimal numeric
+    [InlineData("<div id='t'>&#xA0;</div>", " ")]      // hex numeric
+    [InlineData("<div id='t'>&amp;</div>", "&")]
+    [InlineData("<div id='t'>&lt;&gt;</div>", "<>")]
+    [InlineData("<div id='t'>&copy;</div>", "©")]
+    [InlineData("<div id='t'>a &amp; b</div>", "a & b")]     // entity amid text
+    [InlineData("<div id='t'>Tom & Jerry</div>", "Tom & Jerry")] // bare ampersand is literal
+    public void DecodesCharacterReferencesInText(string html, string expected)
+    {
+        Assert.Equal(expected, TextContent(html, "t"));
+    }
+
+    [Fact]
+    public void NbspSurvivesSerializeRoundTrip_NotDoubleEncoded()
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, "<!DOCTYPE html><html><body><div id='t'>&nbsp;&nbsp;X</div></body></html>", Url);
+        var serialized = bridge.SerializeToHtml();
+
+        // The bug produced "&amp;nbsp;". The fix serializes the decoded U+00A0 as a raw
+        // char or a numeric reference — never the literal named entity re-escaped.
+        Assert.DoesNotContain("&amp;nbsp;", serialized);
+
+        // Re-parsing the serialized HTML must still yield the two non-breaking spaces.
+        using var context2 = new JSContext();
+        var bridge2 = new DomBridge();
+        bridge2.Attach(context2, serialized, Url);
+        var text = context2.Eval("document.getElementById('t').textContent")?.ToString() ?? "";
+        Assert.Equal("  X", text);
+    }
+
+    [Fact]
+    public void ScriptContentIsNotEntityDecoded()
+    {
+        // Raw-text element content must stay verbatim: a "&amp;&amp;" in JS must not become "&&".
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context,
+            "<!DOCTYPE html><html><body><script id='s' type='text/plain'>a &amp;&amp; b</script></body></html>", Url);
+        var text = context.Eval("document.getElementById('s').textContent")?.ToString() ?? "";
+        Assert.Equal("a &amp;&amp; b", text);
+    }
+}

--- a/src/Broiler.Cli.Tests/NativeAnchorInlineCbPipelineTests.cs
+++ b/src/Broiler.Cli.Tests/NativeAnchorInlineCbPipelineTests.cs
@@ -1,0 +1,107 @@
+using System.Drawing;
+using Broiler.HtmlBridge;
+using Broiler.HTML.Image;
+using Broiler.JavaScript.Engine;
+using Broiler.Layout;
+using Broiler.Layout.Engine;
+using DomDocument = Broiler.Dom.DomDocument;
+using DomElement = Broiler.Dom.DomElement;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// End-to-end validation that the Broiler.Layout engine's native anchor post-pass
+/// (Phase 5, P5.8d.2b inline-CB expansion) places a <c>position-area</c> box whose
+/// containing block is an <em>inline</em> element (a <c>position:relative</c>
+/// &lt;span&gt;) against the real inline-CB geometry
+/// (<c>CssBox.GetInlineBoundingBox</c>, CSS2.1 §10.1) — the case the bridge's
+/// estimator could not do, which is why <c>PromoteAbsPosFromInlineCBs</c> DOM-moves
+/// abspos children out of inline CBs on the baked path. Mirrors the
+/// css-anchor-position <c>position-area-inline-container</c> family: the anchor is an
+/// abspos box inside the inline CB, so its rect comes from real layout, not inline flow.
+/// </summary>
+[Xunit.Collection("SharedGeometryStatics")]
+public sealed class NativeAnchorInlineCbPipelineTests
+{
+    private const string Url = "file:///native-anchor-inlinecb.html";
+
+    // #ic is an inline position:relative span; #spacer (inline-block 400x100) gives it a
+    // definite 400x100 extent. #anchor is a 200x50 abspos box at (100,25) inside #ic.
+    // #br is a position-area "bottom right" box anchored to --a.
+    private const string Html =
+        "<!DOCTYPE html><html><head><style>" +
+        "body { margin: 0; }" +
+        "#outer { position: relative; font-size: 100px; line-height: 1; }" +
+        "#ic { position: relative; }" +
+        "#spacer { display: inline-block; width: 400px; height: 100px; }" +
+        "#anchor { position: absolute; left: 100px; top: 25px; width: 200px; height: 50px; anchor-name: --a; }" +
+        "#br { position: absolute; align-self: stretch; justify-self: stretch;" +
+        " position-anchor: --a; position-area: bottom right; }" +
+        "</style></head><body><div id='outer'><span id='ic'><span id='spacer'></span>" +
+        "<span id='anchor'></span><div id='br'></div></span></div></body></html>";
+
+    private static (BoxGeometry anchor, BoxGeometry br) LayoutBoxes(bool nativeAnchor)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, Html, Url);
+        DomDocument document = bridge.GetRenderDocument();
+
+        using var container = new HtmlContainer
+        {
+            Location = new PointF(0, 0),
+            AvoidAsyncImagesLoading = true,
+            AvoidImagesLateLoading = true,
+        };
+        container.SetDocumentWithStyleSet(document, baseUrl: Url);
+
+        IReadOnlyDictionary<DomElement, BoxGeometry> geometry;
+        try
+        {
+            NativeAnchorPlacement.Enabled = nativeAnchor;
+            geometry = container.GetLayoutGeometry(new SizeF(800, 600));
+        }
+        finally
+        {
+            NativeAnchorPlacement.Enabled = false;
+        }
+
+        var anchor = document.GetElementById("anchor");
+        var br = document.GetElementById("br");
+        Assert.NotNull(anchor);
+        Assert.NotNull(br);
+        Assert.True(geometry.ContainsKey(anchor!), "anchor box has no geometry");
+        Assert.True(geometry.ContainsKey(br!), "br box has no geometry");
+        return (geometry[anchor!], geometry[br!]);
+    }
+
+    [Fact]
+    public void NativeFlagOn_PlacesInlineCbPositionAreaBox_AtGridCorner()
+    {
+        var (anchor, br) = LayoutBoxes(nativeAnchor: true);
+
+        // The engine lays out the abspos anchor at its inset position relative to the
+        // inline CB's bounding box: (100,25) 200x50 (NOT the inline-flow position).
+        Assert.Equal(100f, anchor.BorderBox.Left, 1);
+        Assert.Equal(25f, anchor.BorderBox.Top, 1);
+
+        // "bottom right" cell = [anchorRight=300..gridRight=400] x [anchorBottom=75..
+        // gridBottom=100] → the 100x25 corner cell at (300,75), matching the bridge's
+        // baked AnchorInlineContainingBlockTests corner.
+        Assert.Equal(300f, br.BorderBox.Left, 1);
+        Assert.Equal(75f, br.BorderBox.Top, 1);
+        Assert.Equal(100f, br.BorderBox.Width, 1);
+        Assert.Equal(25f, br.BorderBox.Height, 1);
+    }
+
+    [Fact]
+    public void NativeFlagOff_LeavesInlineCbPositionAreaBoxUnplaced()
+    {
+        // Flag off → the engine ignores position-area, so #br sits at its ordinary abspos
+        // position, not the (300,75) anchor cell. Pins the placement to the post-pass.
+        var (_, br) = LayoutBoxes(nativeAnchor: false);
+        Assert.False(
+            System.Math.Abs(br.BorderBox.Left - 300f) < 1 && System.Math.Abs(br.BorderBox.Top - 75f) < 1,
+            $"br was unexpectedly at the anchor cell without the native flag: {br.BorderBox}");
+    }
+}

--- a/src/Broiler.Cli.Tests/NativeAnchorInsetPipelineTests.cs
+++ b/src/Broiler.Cli.Tests/NativeAnchorInsetPipelineTests.cs
@@ -1,0 +1,91 @@
+using System.Drawing;
+using Broiler.HtmlBridge;
+using Broiler.HTML.Image;
+using Broiler.JavaScript.Engine;
+using Broiler.Layout;
+using Broiler.Layout.Engine;
+using DomDocument = Broiler.Dom.DomDocument;
+using DomElement = Broiler.Dom.DomElement;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// End-to-end validation that the Broiler.Layout engine's native anchor post-pass
+/// (Phase 5, P5.8d.2b anchor()-insets expansion) places a box positioned by
+/// <c>anchor()</c> functions in its physical insets (<c>left</c>/<c>right</c>/
+/// <c>top</c>/<c>bottom</c>) — the engine equivalent of the bridge's
+/// <c>ResolveAnchorFunctions</c> pre-bake — through the real parse → cascade → layout
+/// pipeline.
+/// </summary>
+[Xunit.Collection("SharedGeometryStatics")]
+public sealed class NativeAnchorInsetPipelineTests
+{
+    private const string Url = "file:///native-anchor-inset.html";
+
+    // #cb is the containing block (relative, 200x200 at the origin). #anchor is a 20x20 box
+    // at (40,40) → right/bottom = 60. #target is a 30x30 abspos box whose left/top are
+    // anchor(--a right)/anchor(--a bottom), so its margin (== border, no margins) left/top
+    // land on the anchor's right/bottom edge → border box at (60,60).
+    private const string Html =
+        "<!DOCTYPE html><html><head><style>" +
+        "body { margin: 0; }" +
+        "#cb { position: relative; width: 200px; height: 200px; }" +
+        "#anchor { position: absolute; left: 40px; top: 40px; width: 20px; height: 20px; anchor-name: --a; }" +
+        "#target { position: absolute; width: 30px; height: 30px;" +
+        " left: anchor(--a right); top: anchor(--a bottom); }" +
+        "</style></head><body><div id='cb'><div id='anchor'></div><div id='target'></div></div></body></html>";
+
+    private static BoxGeometry LayoutTarget(bool nativeAnchor)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, Html, Url);
+        DomDocument document = bridge.GetRenderDocument();
+
+        using var container = new HtmlContainer
+        {
+            Location = new PointF(0, 0),
+            AvoidAsyncImagesLoading = true,
+            AvoidImagesLateLoading = true,
+        };
+        container.SetDocumentWithStyleSet(document, baseUrl: Url);
+
+        IReadOnlyDictionary<DomElement, BoxGeometry> geometry;
+        try
+        {
+            NativeAnchorPlacement.Enabled = nativeAnchor;
+            geometry = container.GetLayoutGeometry(new SizeF(800, 600));
+        }
+        finally
+        {
+            NativeAnchorPlacement.Enabled = false;
+        }
+
+        var target = document.GetElementById("target");
+        Assert.NotNull(target);
+        Assert.True(geometry.ContainsKey(target!), "target box has no geometry");
+        return geometry[target!];
+    }
+
+    [Fact]
+    public void NativeFlagOn_PlacesAnchorInsetBox_AtAnchorEdges()
+    {
+        var box = LayoutTarget(nativeAnchor: true);
+        Assert.Equal(60f, box.BorderBox.Left, 1);
+        Assert.Equal(60f, box.BorderBox.Top, 1);
+        Assert.Equal(30f, box.BorderBox.Width, 1);
+        Assert.Equal(30f, box.BorderBox.Height, 1);
+    }
+
+    [Fact]
+    public void NativeFlagOff_LeavesAnchorInsetBoxUnplaced()
+    {
+        // Flag off → the engine cannot parse anchor() as a length, so #target sits at its
+        // static/zero-inset position, not the (60,60) anchor edges. Pins the placement to
+        // the post-pass.
+        var box = LayoutTarget(nativeAnchor: false);
+        Assert.False(
+            System.Math.Abs(box.BorderBox.Left - 60f) < 1 && System.Math.Abs(box.BorderBox.Top - 60f) < 1,
+            $"box was unexpectedly at the anchor edges without the native flag: {box.BorderBox}");
+    }
+}

--- a/src/Broiler.Cli.Tests/NativeAnchorOpposingInsetPipelineTests.cs
+++ b/src/Broiler.Cli.Tests/NativeAnchorOpposingInsetPipelineTests.cs
@@ -1,0 +1,86 @@
+using System.Drawing;
+using Broiler.HtmlBridge;
+using Broiler.HTML.Image;
+using Broiler.JavaScript.Engine;
+using Broiler.Layout;
+using Broiler.Layout.Engine;
+using DomDocument = Broiler.Dom.DomDocument;
+using DomElement = Broiler.Dom.DomElement;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// End-to-end validation of native opposing-inset sizing (Phase 5, P5.8d.2b): a childless
+/// box with <c>anchor()</c> on both insets of an axis and an auto length is sized to span
+/// between the two resolved insets by the Broiler.Layout engine post-pass, through the real
+/// parse → cascade → layout pipeline.
+/// </summary>
+[Xunit.Collection("SharedGeometryStatics")]
+public sealed class NativeAnchorOpposingInsetPipelineTests
+{
+    private const string Url = "file:///native-anchor-opposing.html";
+
+    // #anchor is 50×30 at (60,50) → left 60, right 110, top 50, bottom 80. #target spans it
+    // via anchor() on all four insets with auto width/height → border box (60,50) 50×30.
+    private const string Html =
+        "<!DOCTYPE html><html><head><style>" +
+        "body { margin: 0; }" +
+        "#cb { position: relative; width: 200px; height: 200px; }" +
+        "#anchor { position: absolute; left: 60px; top: 50px; width: 50px; height: 30px; anchor-name: --a; }" +
+        "#target { position: absolute;" +
+        " left: anchor(--a left); right: anchor(--a right);" +
+        " top: anchor(--a top); bottom: anchor(--a bottom); }" +
+        "</style></head><body><div id='cb'><div id='anchor'></div><div id='target'></div></div></body></html>";
+
+    private static BoxGeometry LayoutTarget(bool nativeAnchor)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, Html, Url);
+        DomDocument document = bridge.GetRenderDocument();
+
+        using var container = new HtmlContainer
+        {
+            Location = new PointF(0, 0),
+            AvoidAsyncImagesLoading = true,
+            AvoidImagesLateLoading = true,
+        };
+        container.SetDocumentWithStyleSet(document, baseUrl: Url);
+
+        IReadOnlyDictionary<DomElement, BoxGeometry> geometry;
+        try
+        {
+            NativeAnchorPlacement.Enabled = nativeAnchor;
+            geometry = container.GetLayoutGeometry(new SizeF(800, 600));
+        }
+        finally
+        {
+            NativeAnchorPlacement.Enabled = false;
+        }
+
+        var target = document.GetElementById("target");
+        Assert.NotNull(target);
+        Assert.True(geometry.ContainsKey(target!), "target box has no geometry");
+        return geometry[target!];
+    }
+
+    [Fact]
+    public void NativeFlagOn_SizesBoxToSpanBetweenOpposingInsets()
+    {
+        var box = LayoutTarget(nativeAnchor: true);
+        Assert.Equal(60f, box.BorderBox.Left, 1);
+        Assert.Equal(50f, box.BorderBox.Top, 1);
+        Assert.Equal(50f, box.BorderBox.Width, 1);
+        Assert.Equal(30f, box.BorderBox.Height, 1);
+    }
+
+    [Fact]
+    public void NativeFlagOff_DoesNotSpanAnchor()
+    {
+        var box = LayoutTarget(nativeAnchor: false);
+        Assert.False(
+            System.Math.Abs(box.BorderBox.Width - 50f) < 1 && System.Math.Abs(box.BorderBox.Height - 30f) < 1
+            && System.Math.Abs(box.BorderBox.Left - 60f) < 1,
+            $"box unexpectedly spanned the anchor without the native flag: {box.BorderBox}");
+    }
+}

--- a/src/Broiler.Cli.Tests/NativeAnchorSizePipelineTests.cs
+++ b/src/Broiler.Cli.Tests/NativeAnchorSizePipelineTests.cs
@@ -1,0 +1,84 @@
+using System.Drawing;
+using Broiler.HtmlBridge;
+using Broiler.HTML.Image;
+using Broiler.JavaScript.Engine;
+using Broiler.Layout;
+using Broiler.Layout.Engine;
+using DomDocument = Broiler.Dom.DomDocument;
+using DomElement = Broiler.Dom.DomElement;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// End-to-end validation that the Broiler.Layout engine's native anchor post-pass
+/// (Phase 5, P5.8d.2b anchor-size() expansion) sizes a childless box whose
+/// <c>width</c>/<c>height</c> use <c>anchor-size()</c> to the named anchor's dimension —
+/// the engine equivalent of the bridge's <c>ResolveAnchorSizeFunctions</c> pre-bake —
+/// through the real parse → cascade → layout pipeline.
+/// </summary>
+[Xunit.Collection("SharedGeometryStatics")]
+public sealed class NativeAnchorSizePipelineTests
+{
+    private const string Url = "file:///native-anchor-size.html";
+
+    // #anchor is 50×70. #target sizes to anchor-size(--a width/height) → 50×70.
+    private const string Html =
+        "<!DOCTYPE html><html><head><style>" +
+        "body { margin: 0; }" +
+        "#cb { position: relative; width: 200px; height: 200px; }" +
+        "#anchor { position: absolute; left: 40px; top: 40px; width: 50px; height: 70px; anchor-name: --a; }" +
+        "#target { position: absolute; left: 0; top: 0;" +
+        " width: anchor-size(--a width); height: anchor-size(--a height); }" +
+        "</style></head><body><div id='cb'><div id='anchor'></div><div id='target'></div></div></body></html>";
+
+    private static BoxGeometry LayoutTarget(bool nativeAnchor)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, Html, Url);
+        DomDocument document = bridge.GetRenderDocument();
+
+        using var container = new HtmlContainer
+        {
+            Location = new PointF(0, 0),
+            AvoidAsyncImagesLoading = true,
+            AvoidImagesLateLoading = true,
+        };
+        container.SetDocumentWithStyleSet(document, baseUrl: Url);
+
+        IReadOnlyDictionary<DomElement, BoxGeometry> geometry;
+        try
+        {
+            NativeAnchorPlacement.Enabled = nativeAnchor;
+            geometry = container.GetLayoutGeometry(new SizeF(800, 600));
+        }
+        finally
+        {
+            NativeAnchorPlacement.Enabled = false;
+        }
+
+        var target = document.GetElementById("target");
+        Assert.NotNull(target);
+        Assert.True(geometry.ContainsKey(target!), "target box has no geometry");
+        return geometry[target!];
+    }
+
+    [Fact]
+    public void NativeFlagOn_SizesBoxToAnchorDimensions()
+    {
+        var box = LayoutTarget(nativeAnchor: true);
+        Assert.Equal(50f, box.BorderBox.Width, 1);
+        Assert.Equal(70f, box.BorderBox.Height, 1);
+    }
+
+    [Fact]
+    public void NativeFlagOff_LeavesBoxUnsizedByAnchor()
+    {
+        // Flag off → the engine cannot parse anchor-size() as a length, so the box does not
+        // take the anchor's 50×70 size. Pins the sizing to the post-pass.
+        var box = LayoutTarget(nativeAnchor: false);
+        Assert.False(
+            System.Math.Abs(box.BorderBox.Width - 50f) < 1 && System.Math.Abs(box.BorderBox.Height - 70f) < 1,
+            $"box was unexpectedly anchor-sized without the native flag: {box.BorderBox}");
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
@@ -35,6 +35,15 @@ public sealed partial class DomBridge
                 hasAnchorSizeRef = true;
         }
 
+        // Native mode (P5.8d.2b anchor()-insets expansion): for the MVP subset, skip
+        // baking the anchor() insets entirely so the box's `left/right/top/bottom:
+        // anchor(...)` CSS survives to the render and the Broiler.Layout engine's placement
+        // post-pass resolves it natively (see CssBox.TryApplyAnchorInsetPlacement). Every
+        // other anchor() box is baked below.
+        if (hasAnchorRef && NativeAnchorPlacement &&
+            IsMvpNativeAnchorInsetBox(element, cssProps, anchorRegistry))
+            hasAnchorRef = false;
+
         if (hasAnchorRef)
         {
             // Need CB dimensions for resolving anchor positions in right/bottom contexts.
@@ -150,6 +159,101 @@ public sealed partial class DomBridge
         foreach (var child in SnapshotChildren(element))
             ResolveAnchorFunctions(child, anchorRegistry);
     }
+
+    /// <summary>
+    /// Whether an element's <c>anchor()</c> insets are the MVP subset the engine's native
+    /// placement post-pass reproduces (P5.8d.2b), so the bridge can hand them off instead of
+    /// pre-baking (see <see cref="CssBox"/>'s <c>TryApplyAnchorInsetPlacement</c>). Requires:
+    /// every <c>anchor()</c> reference is in a physical inset (<c>left</c>/<c>right</c>/
+    /// <c>top</c>/<c>bottom</c>) and names a registered, accessible anchor; no
+    /// <c>anchor-size()</c>; at most one inset per axis (opposing-inset sizing needs a re-flow
+    /// the reposition-only pass can't do); the box is not fixed/modal and has no intervening
+    /// scroll offset (the engine uses no scroll adjustment); and no <c>position-try</c>.
+    /// </summary>
+    private bool IsMvpNativeAnchorInsetBox(
+        DomElement element, Dictionary<string, string> cssProps,
+        Dictionary<string, AnchorInfo> anchorRegistry)
+    {
+        // Merge inline styles over matched-rule props (inline wins), matching what the
+        // engine cascade projects onto the box.
+        var merged = new Dictionary<string, string>(cssProps, StringComparer.OrdinalIgnoreCase);
+        foreach (var kv in InlineStyle(element))
+            merged[kv.Key] = kv.Value;
+
+        // No position-try (out of the MVP subset).
+        if (merged.ContainsKey("position-try-fallbacks") || merged.ContainsKey("position-try"))
+            return false;
+
+        // Fixed / modal-dialog targets get a document-scroll adjustment the engine MVP
+        // does not apply — keep them baked.
+        var position = merged.GetValueOrDefault("position");
+        if (position == "fixed")
+            return false;
+        if (GetElementRuntimeState(element).Dialog.Modal.TryGet(out var modal) && modal is true)
+            return false;
+
+        // Every anchor()/anchor-size() must be an anchor() in a physical inset; any
+        // anchor-size(), or an anchor() outside left/right/top/bottom, stays baked.
+        bool anyAnchorInset = false;
+        foreach (var (key, value) in merged)
+        {
+            if (value.Contains("anchor-size(", StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (!value.Contains("anchor(", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (key is not ("left" or "right" or "top" or "bottom"))
+                return false;
+            anyAnchorInset = true;
+        }
+        if (!anyAnchorInset)
+            return false;
+
+        // Reposition-only: opposing insets on an axis would size the box (needs a re-flow).
+        if (HasInset(merged, "left") && HasInset(merged, "right"))
+            return false;
+        if (HasInset(merged, "top") && HasInset(merged, "bottom"))
+            return false;
+
+        // Every referenced anchor must be registered, accessible, and moved by no scroll
+        // relative to the target (the engine resolves with a zero scroll adjustment).
+        string? implicitAnchor = merged.GetValueOrDefault("position-anchor");
+        foreach (var key in new[] { "left", "right", "top", "bottom" })
+        {
+            if (!merged.TryGetValue(key, out var value) ||
+                !value.Contains("anchor(", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (!AnchorFunction.TryGetFirst(value, out var reference))
+                return false;
+            var name = string.IsNullOrEmpty(reference.Name)
+                ? (implicitAnchor ?? string.Empty)
+                : reference.Name!;
+            if (string.IsNullOrEmpty(name) || name == "auto")
+                return false;
+            if (!anchorRegistry.TryGetValue(name, out var anchor) ||
+                !IsAnchorAccessible(anchor.SourceElement, element))
+                return false;
+            // A non-fixed anchor separated from the target by a scroll container shifts by
+            // that scroller's offset (the bridge subtracts it); the engine MVP does not.
+            if (anchor.SourceElement != null)
+            {
+                bool anchorIsFixed =
+                    GetComputedProps(anchor.SourceElement).GetValueOrDefault("position") == "fixed";
+                if (!anchorIsFixed)
+                {
+                    ComputeInterveningScrollOffset(anchor.SourceElement, element, out var sx, out var sy);
+                    if (sx != 0 || sy != 0)
+                        return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>Whether a physical inset in <paramref name="props"/> is present and not
+    /// <c>auto</c>.</summary>
+    private static bool HasInset(Dictionary<string, string> props, string name) =>
+        props.TryGetValue(name, out var v) && !string.IsNullOrWhiteSpace(v) && v.Trim() != "auto";
     /// <summary>
     /// Accumulates the scroll offset of scroll containers that lie between the
     /// anchor and the target — i.e. that are ancestors of <paramref name="anchorEl"/>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Linq;
 using Broiler.CSS;
 using Broiler.Dom;
 using Broiler.Layout;
@@ -146,7 +147,11 @@ public sealed partial class DomBridge
         }
 
         // Resolve anchor-size() function calls in both CSS and inline styles.
-        if (hasAnchorSizeRef)
+        // Native mode (P5.8d.2b anchor-size() expansion): skip baking for the MVP subset so
+        // the box's `width/height: anchor-size(...)` survives to the engine's sizing pass
+        // (CssBox.TryApplyNativeAnchorSizing).
+        if (hasAnchorSizeRef &&
+            !(NativeAnchorPlacement && IsMvpNativeAnchorSizeBox(element, cssProps, anchorRegistry)))
         {
             ResolveAnchorSizeFunctions(element, cssProps, anchorRegistry);
         }
@@ -254,6 +259,92 @@ public sealed partial class DomBridge
     /// <c>auto</c>.</summary>
     private static bool HasInset(Dictionary<string, string> props, string name) =>
         props.TryGetValue(name, out var v) && !string.IsNullOrWhiteSpace(v) && v.Trim() != "auto";
+
+    /// <summary>
+    /// Whether an element's <c>anchor-size()</c> sizing is the MVP subset the engine's native
+    /// sizing pass reproduces (P5.8d.2b), so the bridge can hand it off instead of pre-baking
+    /// (see <see cref="CssBox"/>'s <c>TryApplyNativeAnchorSizing</c>). Requires: an absolutely
+    /// positioned, <b>childless</b> box (the engine only sizes childless boxes without a
+    /// re-flow); <c>anchor-size()</c> only in <c>width</c>/<c>height</c>, each naming a
+    /// registered accessible anchor; no <c>anchor()</c> inset (the combined case stays baked);
+    /// no <c>position-area</c>; no right/bottom inset (the engine grows the box from its
+    /// laid-out origin); no CSS <c>zoom</c>; not a modal dialog; and no <c>position-try</c>.
+    /// </summary>
+    private bool IsMvpNativeAnchorSizeBox(
+        DomElement element, Dictionary<string, string> cssProps,
+        Dictionary<string, AnchorInfo> anchorRegistry)
+    {
+        var merged = new Dictionary<string, string>(cssProps, StringComparer.OrdinalIgnoreCase);
+        foreach (var kv in InlineStyle(element))
+            merged[kv.Key] = kv.Value;
+
+        // Absolutely positioned only (fixed gets a scroll adjustment the engine MVP omits).
+        if (merged.GetValueOrDefault("position") != "absolute")
+            return false;
+        if (merged.ContainsKey("position-try-fallbacks") || merged.ContainsKey("position-try"))
+            return false;
+        // position-area boxes are placed+sized by the position-area path, not here.
+        var area = merged.GetValueOrDefault("position-area");
+        if (!string.IsNullOrWhiteSpace(area) && area != "none")
+            return false;
+        if (GetElementRuntimeState(element).Dialog.Modal.TryGet(out var modal) && modal is true)
+            return false;
+        // The engine sizes already-laid-out (already-zoomed) box geometry; a CSS zoom scale
+        // would double-count, so keep zoomed boxes baked.
+        if (Math.Abs(GetUsedZoomForElement(element) - 1.0) > 0.0001)
+            return false;
+        // Childless: the engine only resizes a box with no in-flow children/words.
+        if (ChildElements(element).Any())
+            return false;
+        if (!string.IsNullOrWhiteSpace(GetElementTextContent(element)))
+            return false;
+        // The engine grows the box from its laid-out left/top origin, so a right/bottom inset
+        // (which the baked path resolves via a re-layout) stays baked.
+        if (HasInset(merged, "right") || HasInset(merged, "bottom"))
+            return false;
+
+        // anchor-size() only in width/height; any anchor() inset means the combined case,
+        // which stays baked (the anchor()-inset gate already excludes anchor-size boxes).
+        bool anySize = false;
+        foreach (var (key, value) in merged)
+        {
+            if (value.Contains("anchor(", StringComparison.OrdinalIgnoreCase) &&
+                !value.Contains("anchor-size(", StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (!value.Contains("anchor-size(", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (key is not ("width" or "height"))
+                return false;
+            anySize = true;
+        }
+        if (!anySize)
+            return false;
+
+        // Every referenced anchor must be registered and accessible.
+        string? implicitAnchor = merged.GetValueOrDefault("position-anchor");
+        foreach (var key in new[] { "width", "height" })
+        {
+            if (!merged.TryGetValue(key, out var value) ||
+                !value.Contains("anchor-size(", StringComparison.OrdinalIgnoreCase))
+                continue;
+            bool ok = true;
+            AnchorFunction.RewriteSize(value, r =>
+            {
+                var name = string.IsNullOrEmpty(r.Name)
+                    ? (implicitAnchor ?? string.Empty)
+                    : r.Name!;
+                if (string.IsNullOrEmpty(name) || name == "auto" ||
+                    !anchorRegistry.TryGetValue(name, out var anchor) ||
+                    !IsAnchorAccessible(anchor.SourceElement, element))
+                    ok = false;
+                return "0px";
+            });
+            if (!ok)
+                return false;
+        }
+
+        return true;
+    }
     /// <summary>
     /// Accumulates the scroll offset of scroll containers that lie between the
     /// anchor and the target — i.e. that are ancestors of <paramref name="anchorEl"/>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
@@ -213,10 +213,17 @@ public sealed partial class DomBridge
         if (!anyAnchorInset)
             return false;
 
-        // Reposition-only: opposing insets on an axis would size the box (needs a re-flow).
-        if (HasInset(merged, "left") && HasInset(merged, "right"))
+        // Opposing insets on an axis size the box. The engine resolves that size (border box
+        // fills the inset-modified CB minus margins) only for a childless box with an auto
+        // length on that axis; a childful box (needs a re-flow) or an explicit length
+        // (over-constrained) stays baked.
+        bool childless = !ChildElements(element).Any()
+            && string.IsNullOrWhiteSpace(GetElementTextContent(element));
+        if (HasInset(merged, "left") && HasInset(merged, "right")
+            && !(childless && IsAutoLength(merged.GetValueOrDefault("width"))))
             return false;
-        if (HasInset(merged, "top") && HasInset(merged, "bottom"))
+        if (HasInset(merged, "top") && HasInset(merged, "bottom")
+            && !(childless && IsAutoLength(merged.GetValueOrDefault("height"))))
             return false;
 
         // Every referenced anchor must be registered, accessible, and moved by no scroll
@@ -259,6 +266,11 @@ public sealed partial class DomBridge
     /// <c>auto</c>.</summary>
     private static bool HasInset(Dictionary<string, string> props, string name) =>
         props.TryGetValue(name, out var v) && !string.IsNullOrWhiteSpace(v) && v.Trim() != "auto";
+
+    /// <summary>Whether a <c>width</c>/<c>height</c> value is <c>auto</c> (or unset), so an
+    /// opposing pair of insets determines the used size.</summary>
+    private static bool IsAutoLength(string? value) =>
+        string.IsNullOrWhiteSpace(value) || value!.Trim() == "auto";
 
     /// <summary>
     /// Whether an element's <c>anchor-size()</c> sizing is the MVP subset the engine's native

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
@@ -361,12 +361,37 @@ public sealed partial class DomBridge
                 InlineStyle(blockAncestor)["position"] = "relative";
         }
     }
+    /// <summary>
+    /// Whether the inline containing block <paramref name="inlineCB"/> directly holds an
+    /// absolutely-positioned <c>position-area</c> box that native mode routes to the
+    /// engine (<see cref="IsNativeMvpPositionAreaBox"/>). When it does, the whole inline
+    /// CB is left un-promoted so the engine can lay out the intact anchor + target subtree
+    /// (P5.8d.2b inline-CB expansion).
+    /// </summary>
+    private bool InlineCbHasNativeAnchorBox(DomElement inlineCB)
+    {
+        foreach (var child in SnapshotChildren(inlineCB))
+        {
+            if (IsText(child)) continue;
+            if (IsNativeMvpPositionAreaBox(child))
+                return true;
+        }
+        return false;
+    }
+
     private void CollectInlineCBPromotions(
         DomElement element,
         List<(DomElement child, DomElement inlineCB, DomElement blockAncestor,
             double offX, double offY)> promotions)
     {
-        if (!IsText(element) && IsInlineContainingBlock(element))
+        // Native mode (P5.8d.2b inline-CB expansion): when an inline containing block holds
+        // a native-MVP position-area box, the engine lays out the whole inline subtree
+        // (anchor + positioned boxes) against the real inline-box geometry, so this bridge
+        // promotion must NOT DOM-move any of that inline CB's abspos children — doing so
+        // would tear the anchor out of the target's containing block and break the native
+        // placement. Skip collecting from such an inline CB (still recurse for nested ones).
+        if (!IsText(element) && IsInlineContainingBlock(element) &&
+            !(NativeAnchorPlacement && InlineCbHasNativeAnchorBox(element)))
         {
             var (offX, offY, blockAncestor) = ComputeInlineCBOffset(element);
             if (blockAncestor != null)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
@@ -426,11 +426,27 @@ public sealed partial class DomBridge
         if (_anchorCandidates == null || !_anchorCandidates.ContainsKey(anchorName))
             return false;
 
-        // A non-inline containing block (the engine cannot yet promote abs-pos boxes
-        // out of inline containing blocks the way the bridge does).
+        // A non-abspos inline containing block is now IN the MVP subset (P5.8d.2b
+        // inline-CB expansion): the engine's abspos layout places a box inside an inline
+        // element against the real inline-box bounding box (CssBox.GetInlineBoundingBox,
+        // CSS2.1 §10.1), which the bridge's estimator could not — so, unlike every other
+        // gate, a relatively-positioned inline CB no longer forces the bridge path. The box
+        // stays inside the inline CB (PromoteAbsPosFromInlineCBs skips the whole inline CB
+        // in native mode — see InlineCbHasNativeAnchorBox) so the engine lays out the
+        // intact subtree.
+        //
+        // Exception: an inline element that is ITSELF absolutely/fixed positioned is
+        // blockified by the engine (CSS2.1 §9.7: position:absolute forces display:block),
+        // so the engine treats it as a block containing block while the bridge's
+        // IsInlineElement still treats it as inline — the two disagree on the CB's extent.
+        // Keep such a box on the bridge bake path until that is reconciled.
         var cb = FindContainingBlockElement(element);
         if (cb != null && IsInlineContainingBlock(cb))
-            return false;
+        {
+            var cbPos = GetComputedProps(cb).GetValueOrDefault("position");
+            if (cbPos is "absolute" or "fixed")
+                return false;
+        }
 
         // position-try and anchor()/anchor-size() are out of the MVP subset.
         if (cssProps.ContainsKey("position-try-fallbacks") || cssProps.ContainsKey("position-try"))
@@ -443,6 +459,43 @@ public sealed partial class DomBridge
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Whether native mode would hand this element's <c>position-area</c> off to the
+    /// engine's placement post-pass instead of pre-baking it — i.e. it satisfies
+    /// <see cref="IsMvpNativeAnchorBox"/> under the same computed-property, anchor and
+    /// scroll-container resolution <see cref="ResolvePositionAreaValues"/> uses. Used by
+    /// the inline-CB promotion pass to leave such a box (and its inline containing block's
+    /// subtree) intact for the engine rather than DOM-moving it out. Returns
+    /// <c>false</c> when the element has no resolvable <c>position-area</c>/anchor.
+    /// </summary>
+    private bool IsNativeMvpPositionAreaBox(DomElement element)
+    {
+        if (IsText(element))
+            return false;
+
+        var cssProps = CollectMatchedRuleProperties(element);
+        foreach (var kv in InlineStyle(element))
+            cssProps[kv.Key] = kv.Value;
+
+        string? positionArea = cssProps.GetValueOrDefault("position-area");
+        string? positionAnchor = cssProps.GetValueOrDefault("position-anchor");
+        if (string.IsNullOrWhiteSpace(positionArea) || positionArea == "none" ||
+            string.IsNullOrWhiteSpace(positionAnchor))
+            return false;
+
+        // The registration check lives in IsMvpNativeAnchorBox (via _anchorCandidates,
+        // which is populated alongside the full anchor registry), so an unregistered
+        // anchor already yields false there — no separate anchor lookup needed.
+        var anchorEl = FindElementByAnchorName(positionAnchor);
+        var rawScrollContainer = anchorEl != null ? FindNearestScrollContainer(anchorEl) : null;
+        var scrollContainer = rawScrollContainer != null &&
+            IsDescendantOfElement(element, rawScrollContainer)
+                ? rawScrollContainer
+                : null;
+
+        return IsMvpNativeAnchorBox(element, positionAnchor, cssProps, scrollContainer);
     }
 
     /// <summary>

--- a/src/Broiler.Wpt.Tests/NativeAnchorInsetWptTests.cs
+++ b/src/Broiler.Wpt.Tests/NativeAnchorInsetWptTests.cs
@@ -1,0 +1,108 @@
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// End-to-end proof of the Phase 5 native <c>anchor()</c>-insets cutover (P5.8d.2b) through
+/// the full WPT render pipeline (<see cref="WptTestRunner.RenderHtmlFileBitmapPublic"/>:
+/// parse → DomBridge script/anchor resolution → serialize → engine layout → raster).
+///
+/// With the runner's <see cref="WptTestRunner.NativeAnchorPlacement"/> lever on, the bridge
+/// does <em>not</em> pre-bake a box positioned by <c>anchor()</c> functions in its physical
+/// insets (the MVP subset — <c>ResolveAnchorFunctions</c> skips it, so the
+/// <c>left/top: anchor(...)</c> CSS survives serialization); the box is instead placed by the
+/// Broiler.Layout engine's post-pass (<c>CssBox.TryApplyAnchorInsetPlacement</c>). The same
+/// fixture with the lever off (the bridge pre-bakes) lands the box in the same place, so the
+/// two paths agree.
+///
+/// Fixture: a 200×200 <c>position:relative</c> containing block; a uniquely-named anchor
+/// <c>--a</c> (20×20 at (40,40), so its right/bottom edge is (60,60)); and a 30×30 red target
+/// whose <c>left</c>/<c>top</c> are <c>anchor(--a right)</c>/<c>anchor(--a bottom)</c>, so its
+/// left/top edge lands on the anchor's right/bottom edge — the red box occupies (60,60)–(89,89).
+/// This is strict MVP: a registered anchor, a single inset per axis, no scroll container, not
+/// fixed, no <c>position-try</c>/<c>anchor-size()</c>.
+/// </summary>
+public class NativeAnchorInsetWptTests : IDisposable
+{
+    private readonly bool _previousLever = WptTestRunner.NativeAnchorPlacement;
+
+    public void Dispose()
+    {
+        WptTestRunner.NativeAnchorPlacement = _previousLever;
+        Program.ResetTestHooks();
+    }
+
+    private const string Html = @"<!DOCTYPE html><meta charset=""utf-8"">
+<style>
+  body { margin: 0; }
+  #cb { position: relative; width: 200px; height: 200px; }
+  #anchor { position: absolute; left: 40px; top: 40px; width: 20px; height: 20px; anchor-name: --a; }
+  #target { position: absolute; width: 30px; height: 30px; left: anchor(--a right); top: anchor(--a bottom); background: #ff0000; }
+</style>
+<div id=""cb""><div id=""anchor""></div><div id=""target""></div></div>";
+
+    private static (int x0, int y0, int x1, int y1, int count) RedBox(BBitmap bmp, int w, int h)
+    {
+        int x0 = int.MaxValue, y0 = int.MaxValue, x1 = -1, y1 = -1, count = 0;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                var p = bmp.GetPixel(x, y);
+                if (p.R > 200 && p.G < 80 && p.B < 80)
+                {
+                    count++;
+                    if (x < x0) x0 = x;
+                    if (y < y0) y0 = y;
+                    if (x > x1) x1 = x;
+                    if (y > y1) y1 = y;
+                }
+            }
+        return (x0, y0, x1, y1, count);
+    }
+
+    private static (int x0, int y0, int x1, int y1, int count) Render(bool nativeAnchor)
+    {
+        WptTestRunner.NativeAnchorPlacement = nativeAnchor;
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-native-anchor-inset-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "mvp.html");
+            File.WriteAllText(file, Html);
+
+            var runner = new WptTestRunner(400, 400);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+            return RedBox(bmp, 400, 400);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void NativeLeverOn_EnginePlacesAnchorInsetBox_AtAnchorEdges()
+    {
+        var red = Render(nativeAnchor: true);
+
+        Assert.True(red.count > 0, "red target box not painted under the native lever.");
+        Assert.True(System.Math.Abs(red.x0 - 60) <= 2, $"red left={red.x0}, expected ~60.");
+        Assert.True(System.Math.Abs(red.y0 - 60) <= 2, $"red top={red.y0}, expected ~60.");
+        Assert.True(System.Math.Abs(red.x1 - 89) <= 2, $"red right={red.x1}, expected ~89.");
+        Assert.True(System.Math.Abs(red.y1 - 89) <= 2, $"red bottom={red.y1}, expected ~89.");
+    }
+
+    [Fact]
+    public void BridgeAndEnginePaths_Agree_OnAnchorInsetBox()
+    {
+        var baked = Render(nativeAnchor: false);
+        var native = Render(nativeAnchor: true);
+
+        Assert.True(baked.count > 0 && native.count > 0, "target box missing in one of the paths.");
+        Assert.True(System.Math.Abs(baked.x0 - native.x0) <= 2, $"left differs: baked={baked.x0}, native={native.x0}.");
+        Assert.True(System.Math.Abs(baked.y0 - native.y0) <= 2, $"top differs: baked={baked.y0}, native={native.y0}.");
+        Assert.True(System.Math.Abs(baked.x1 - native.x1) <= 2, $"right differs: baked={baked.x1}, native={native.x1}.");
+        Assert.True(System.Math.Abs(baked.y1 - native.y1) <= 2, $"bottom differs: baked={baked.y1}, native={native.y1}.");
+    }
+}

--- a/src/Broiler.Wpt.Tests/NativeAnchorOpposingInsetWptTests.cs
+++ b/src/Broiler.Wpt.Tests/NativeAnchorOpposingInsetWptTests.cs
@@ -1,0 +1,99 @@
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// End-to-end proof of native opposing-inset sizing (P5.8d.2b) through the full WPT render
+/// pipeline. With the lever on, the bridge does not pre-bake a childless box that has
+/// <c>anchor()</c> on both insets of an axis (auto length); the Broiler.Layout engine sizes
+/// it to span between the resolved insets. The lever-off (baked) path lands the same box.
+///
+/// Fixture: a 200×200 <c>position:relative</c> containing block; a transparent anchor
+/// <c>--a</c> (50×30 at (60,50)); and a red target that anchors all four insets to it with
+/// auto width/height → the red box occupies (60,50)–(109,79).
+/// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
+public class NativeAnchorOpposingInsetWptTests : IDisposable
+{
+    private readonly bool _previousLever = WptTestRunner.NativeAnchorPlacement;
+
+    public void Dispose()
+    {
+        WptTestRunner.NativeAnchorPlacement = _previousLever;
+        Program.ResetTestHooks();
+    }
+
+    private const string Html = @"<!DOCTYPE html><meta charset=""utf-8"">
+<style>
+  body { margin: 0; }
+  #cb { position: relative; width: 200px; height: 200px; }
+  #anchor { position: absolute; left: 60px; top: 50px; width: 50px; height: 30px; anchor-name: --a; }
+  #target { position: absolute; left: anchor(--a left); right: anchor(--a right); top: anchor(--a top); bottom: anchor(--a bottom); background: #ff0000; }
+</style>
+<div id=""cb""><div id=""anchor""></div><div id=""target""></div></div>";
+
+    private static (int x0, int y0, int x1, int y1, int count) RedBox(BBitmap bmp, int w, int h)
+    {
+        int x0 = int.MaxValue, y0 = int.MaxValue, x1 = -1, y1 = -1, count = 0;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                var p = bmp.GetPixel(x, y);
+                if (p.R > 200 && p.G < 80 && p.B < 80)
+                {
+                    count++;
+                    if (x < x0) x0 = x;
+                    if (y < y0) y0 = y;
+                    if (x > x1) x1 = x;
+                    if (y > y1) y1 = y;
+                }
+            }
+        return (x0, y0, x1, y1, count);
+    }
+
+    private static (int x0, int y0, int x1, int y1, int count) Render(bool nativeAnchor)
+    {
+        WptTestRunner.NativeAnchorPlacement = nativeAnchor;
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-native-anchor-opp-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "mvp.html");
+            File.WriteAllText(file, Html);
+
+            var runner = new WptTestRunner(400, 400);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+            return RedBox(bmp, 400, 400);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void NativeLeverOn_EngineSizesBoxToSpanAnchor()
+    {
+        var red = Render(nativeAnchor: true);
+
+        Assert.True(red.count > 0, "red target box not painted under the native lever.");
+        Assert.True(System.Math.Abs(red.x0 - 60) <= 2, $"red left={red.x0}, expected ~60.");
+        Assert.True(System.Math.Abs(red.y0 - 50) <= 2, $"red top={red.y0}, expected ~50.");
+        Assert.True(System.Math.Abs(red.x1 - 109) <= 2, $"red right={red.x1}, expected ~109 (width 50).");
+        Assert.True(System.Math.Abs(red.y1 - 79) <= 2, $"red bottom={red.y1}, expected ~79 (height 30).");
+    }
+
+    [Fact]
+    public void BridgeAndEnginePaths_Agree_OnOpposingInsetBox()
+    {
+        var baked = Render(nativeAnchor: false);
+        var native = Render(nativeAnchor: true);
+
+        Assert.True(baked.count > 0 && native.count > 0, "target box missing in one of the paths.");
+        Assert.True(System.Math.Abs(baked.x0 - native.x0) <= 2, $"left differs: baked={baked.x0}, native={native.x0}.");
+        Assert.True(System.Math.Abs(baked.y0 - native.y0) <= 2, $"top differs: baked={baked.y0}, native={native.y0}.");
+        Assert.True(System.Math.Abs(baked.x1 - native.x1) <= 2, $"right differs: baked={baked.x1}, native={native.x1}.");
+        Assert.True(System.Math.Abs(baked.y1 - native.y1) <= 2, $"bottom differs: baked={baked.y1}, native={native.y1}.");
+    }
+}

--- a/src/Broiler.Wpt.Tests/NativeAnchorPlacementWptTests.cs
+++ b/src/Broiler.Wpt.Tests/NativeAnchorPlacementWptTests.cs
@@ -24,6 +24,7 @@ namespace Broiler.Wpt.Tests;
 /// anchor, a non-inline containing block, no scroll container, and no
 /// <c>position-try</c>/<c>anchor()</c>.
 /// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
 public class NativeAnchorPlacementWptTests : IDisposable
 {
     private readonly bool _previousLever = WptTestRunner.NativeAnchorPlacement;

--- a/src/Broiler.Wpt.Tests/NativeAnchorSizeWptTests.cs
+++ b/src/Broiler.Wpt.Tests/NativeAnchorSizeWptTests.cs
@@ -4,27 +4,24 @@ using Broiler.HTML.Image;
 namespace Broiler.Wpt.Tests;
 
 /// <summary>
-/// End-to-end proof of the Phase 5 native <c>anchor()</c>-insets cutover (P5.8d.2b) through
-/// the full WPT render pipeline (<see cref="WptTestRunner.RenderHtmlFileBitmapPublic"/>:
-/// parse → DomBridge script/anchor resolution → serialize → engine layout → raster).
+/// End-to-end proof of the Phase 5 native <c>anchor-size()</c> cutover (P5.8d.2b) through
+/// the full WPT render pipeline (parse → DomBridge anchor resolution → serialize →
+/// HtmlPostProcessor → reparse → engine layout → raster).
 ///
 /// With the runner's <see cref="WptTestRunner.NativeAnchorPlacement"/> lever on, the bridge
-/// does <em>not</em> pre-bake a box positioned by <c>anchor()</c> functions in its physical
-/// insets (the MVP subset — <c>ResolveAnchorFunctions</c> skips it, so the
-/// <c>left/top: anchor(...)</c> CSS survives serialization); the box is instead placed by the
-/// Broiler.Layout engine's post-pass (<c>CssBox.TryApplyAnchorInsetPlacement</c>). The same
-/// fixture with the lever off (the bridge pre-bakes) lands the box in the same place, so the
-/// two paths agree.
+/// does <em>not</em> pre-bake a childless box whose <c>width</c>/<c>height</c> use
+/// <c>anchor-size()</c>; the box is instead sized by the Broiler.Layout engine's post-pass
+/// (<c>CssBox.TryApplyNativeAnchorSizing</c>). The same fixture with the lever off (the bridge
+/// pre-bakes) produces the same box, so the two paths agree.
 ///
 /// Fixture: a 200×200 <c>position:relative</c> containing block; a uniquely-named anchor
-/// <c>--a</c> (20×20 at (40,40), so its right/bottom edge is (60,60)); and a 30×30 red target
-/// whose <c>left</c>/<c>top</c> are <c>anchor(--a right)</c>/<c>anchor(--a bottom)</c>, so its
-/// left/top edge lands on the anchor's right/bottom edge — the red box occupies (60,60)–(89,89).
-/// This is strict MVP: a registered anchor, a single inset per axis, no scroll container, not
-/// fixed, no <c>position-try</c>/<c>anchor-size()</c>.
+/// <c>--a</c> (50×70, transparent); and a red target at (100,100) sized to
+/// <c>anchor-size(--a width)</c> × <c>anchor-size(--a height)</c> — so the red box occupies
+/// (100,100)–(149,169). Strict MVP: childless, absolutely positioned, no <c>position-area</c>,
+/// no zoom, no right/bottom inset, no <c>position-try</c>.
 /// </summary>
 [Xunit.Collection("NativeAnchorWpt")]
-public class NativeAnchorInsetWptTests : IDisposable
+public class NativeAnchorSizeWptTests : IDisposable
 {
     private readonly bool _previousLever = WptTestRunner.NativeAnchorPlacement;
 
@@ -38,8 +35,8 @@ public class NativeAnchorInsetWptTests : IDisposable
 <style>
   body { margin: 0; }
   #cb { position: relative; width: 200px; height: 200px; }
-  #anchor { position: absolute; left: 40px; top: 40px; width: 20px; height: 20px; anchor-name: --a; }
-  #target { position: absolute; width: 30px; height: 30px; left: anchor(--a right); top: anchor(--a bottom); background: #ff0000; }
+  #anchor { position: absolute; left: 40px; top: 40px; width: 50px; height: 70px; anchor-name: --a; }
+  #target { position: absolute; left: 100px; top: 100px; width: anchor-size(--a width); height: anchor-size(--a height); background: #ff0000; }
 </style>
 <div id=""cb""><div id=""anchor""></div><div id=""target""></div></div>";
 
@@ -65,7 +62,7 @@ public class NativeAnchorInsetWptTests : IDisposable
     private static (int x0, int y0, int x1, int y1, int count) Render(bool nativeAnchor)
     {
         WptTestRunner.NativeAnchorPlacement = nativeAnchor;
-        string dir = Path.Combine(Path.GetTempPath(), "broiler-native-anchor-inset-" + System.Guid.NewGuid().ToString("N"));
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-native-anchor-size-" + System.Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         try
         {
@@ -83,19 +80,19 @@ public class NativeAnchorInsetWptTests : IDisposable
     }
 
     [Fact]
-    public void NativeLeverOn_EnginePlacesAnchorInsetBox_AtAnchorEdges()
+    public void NativeLeverOn_EngineSizesAnchorSizeBox_ToAnchorDimensions()
     {
         var red = Render(nativeAnchor: true);
 
         Assert.True(red.count > 0, "red target box not painted under the native lever.");
-        Assert.True(System.Math.Abs(red.x0 - 60) <= 2, $"red left={red.x0}, expected ~60.");
-        Assert.True(System.Math.Abs(red.y0 - 60) <= 2, $"red top={red.y0}, expected ~60.");
-        Assert.True(System.Math.Abs(red.x1 - 89) <= 2, $"red right={red.x1}, expected ~89.");
-        Assert.True(System.Math.Abs(red.y1 - 89) <= 2, $"red bottom={red.y1}, expected ~89.");
+        Assert.True(System.Math.Abs(red.x0 - 100) <= 2, $"red left={red.x0}, expected ~100.");
+        Assert.True(System.Math.Abs(red.y0 - 100) <= 2, $"red top={red.y0}, expected ~100.");
+        Assert.True(System.Math.Abs(red.x1 - 149) <= 2, $"red right={red.x1}, expected ~149 (width 50).");
+        Assert.True(System.Math.Abs(red.y1 - 169) <= 2, $"red bottom={red.y1}, expected ~169 (height 70).");
     }
 
     [Fact]
-    public void BridgeAndEnginePaths_Agree_OnAnchorInsetBox()
+    public void BridgeAndEnginePaths_Agree_OnAnchorSizeBox()
     {
         var baked = Render(nativeAnchor: false);
         var native = Render(nativeAnchor: true);

--- a/src/Broiler.Wpt.Tests/NativeAnchorWptCollection.cs
+++ b/src/Broiler.Wpt.Tests/NativeAnchorWptCollection.cs
@@ -1,0 +1,11 @@
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Serializes the native anchor-placement WPT render tests. They all toggle the
+/// process-wide <see cref="WptTestRunner.NativeAnchorPlacement"/> static (and the
+/// <c>[ThreadStatic]</c> engine lever) around a render, so running the classes in parallel
+/// lets one class's baked (lever-off) render stomp another's native render — a shared-static
+/// race, not a product bug. Membership in this collection makes xUnit run them sequentially.
+/// </summary>
+[Xunit.CollectionDefinition("NativeAnchorWpt", DisableParallelization = true)]
+public sealed class NativeAnchorWptCollection { }


### PR DESCRIPTION
## Summary

Continues the HtmlBridge complexity-reduction roadmap **Phase 5 (P5.8d.2b)** native anchor-placement cutover — widening the Broiler.Layout engine's native anchor path four features at a time so the bridge's `AnchorResolver` pre-baking writes can eventually be deleted (the Phase 4 item-2 unblock) — plus a foundational HTML entity-decoding bug fix surfaced along the way.

All engine work is behind the default-off `NativeAnchorPlacement` lever, so **production rendering is unchanged**; each expansion is gated per-box in the bridge and validated with unit + real-pipeline + full-render tests.

## Commits

1. **Native anchor placement for relative inline containing blocks** — a `position-area` box whose CB is a `position:relative` inline `<span>` now places against the engine's real §10.1 inline-box geometry (`GetInlineBoundingBox`), instead of the bridge's ~250-line inline-flow estimator. Bridge-gate-only (no Layout change); abspos-inline CBs stay baked (bridge/engine disagree on §9.7 blockification).
2. **Native `anchor()` inset placement** — first native path *not* driven by `position-area`: a box positioned by `anchor()` functions in `left`/`right`/`top`/`bottom`, resolved via the promoted `AnchorGeometry.ResolveEdge`. MVP reposition-only, one inset per axis.
3. **Native `anchor-size()` sizing** — a childless box sized to the anchor's `width`/`height` via `AnchorRegistry.ResolveAnchorSize`. Conservative gate keeps the two corpus `anchor-size()` pixel tests (zoom / position-area + 3D transforms) baked and passing.
4. **Native opposing-inset sizing** — both insets on an axis + auto length + childless → the box spans between the resolved insets (border box fills the inset-modified CB minus margins).
5. **Fix `&nbsp;` / character-reference rendering** — bumps the `Broiler.DOM` submodule pointer + adds a regression test (see below).

## The entity-decoding fix (submodule change)

**Root cause:** the shared `Broiler.Dom.Html.HtmlTokenizer` emitted character data verbatim — it had *no* character-reference decoding. So `&nbsp;`, `&amp;`, `&#160;`, etc. stayed as literal text in the DOM. Because the serializer HTML-*encodes* text on output, the WPT `Attach → SerializeToHtml → reparse` render path double-encoded `&nbsp;` → `&amp;nbsp;` and painted the literal entity.

**Fix:** the tokenizer now decodes named/decimal/hex references in Data-state character tokens (raw-text `<script>`/`<style>` stays verbatim; attribute decoding is left to the downstream `Broiler.HTML` `HtmlParser` to avoid a double-decode).

- Submodule commit: `MaiRat/Broiler.DOM` branch `htmlbridge-nbsp-entity-decode` (`335e137e`), pushed; **companion submodule PR should be opened against `Broiler-Platform/Broiler.DOM`**. This parent PR bumps the gitlink to that commit.

## Validation

- **Default-off byte-identical** for every expansion (css-anchor-position pixel subset 8-fail / 31-pass).
- **Lever-on 7-fail / 32-pass, passing set unchanged** across all expansions. Opposing-inset sizing produced the first corpus pixel *improvement* (`anchor-position-borders-002` 99.38% → 99.99%).
- Entity fix: full `Broiler.Cli.Tests` diffed **stash-vs-change = 0 new failures, +1 fixed** (`Acid3_Score_Position_With_Negative_Margin`); `position-area-inline-container` 83% → 95.8% (lever-on), `abs-inline-container` 88% → 92%.
- New tests: `NativeAnchorInlineCbPipelineTests`, `NativeAnchorInsetPipelineTests` / `…WptTests`, `NativeAnchorSizePipelineTests` / `…WptTests`, `NativeAnchorOpposingInsetPipelineTests` / `…WptTests`, `HtmlEntityDecodingTests`, plus Layout unit tests (`NativeAnchorPlacementTests` → 150). The three native-anchor WPT render classes share `[Collection("NativeAnchorWpt")]` (they toggle a process-wide static — parallel runs raced).

## Reviewer notes

- The residual gap keeping the inline-container tests below 99% is inline-CB position-area geometry precision (a separate concern), not the entity bug.
- Remaining Phase 5 features (abspos-inline CB reconciliation, scroll simulation, position-visibility, dialog/backdrop, position-try) are DOM/scroll-entangled re-implementations with no corpus pixel upside; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
