### PR TITLE
Native anchor placement for abspos inline containing blocks

### DIFF
--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1961,27 +1961,54 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   the anchor()-function expansions:** `anchor-position-borders-002` (a testharness test whose `.target` boxes are
   auto-size, four-inset `anchor()` spanners) improves **99.38 %→99.99 %** — those targets now size natively
   (more precisely than the bridge estimator) — with no other test moving and no regression.
+- **P5.8d.2b — abspos-inline containing block (tenth expansion) — COMPLETED** 2026-07-14
+  (branch `claude/htmlbridge-phase-5-pnf1sb`; **bridge only, additive, default-off**). A `position-area` box
+  whose containing block is an **absolutely/fixed-positioned** inline element (a `position:absolute`
+  `<span>`) now goes native — the case the sixth (inline-CB) expansion deliberately left baked. **The
+  roadmap's premise for keeping it baked was wrong:** it assumed the engine blockifies the abspos inline
+  element (CSS2.1 §9.7) and so disagreed with the bridge's `IsInlineElement` on the CB extent. It does not —
+  the cascade's §9.7 `display` adjustment fires **only for `float`** (`DomParser.CascadeApplyStyles`,
+  `Broiler.HTML …/Parse/DomParser.cs:253`), so the engine keeps the abspos `<span>` at `Display==inline` and
+  reads its **inline bounding box** (`CssBox.GetInlineBoundingBox`, CSS2.1 §10.1). For an out-of-flow inline
+  whose content is a simple run, that bounding box equals the block shrink-to-fit extent — i.e. the correct
+  containing-block rect — so the anchored boxes place identically to a relatively-positioned inline CB, with
+  **no engine change needed**. A pipeline probe confirmed the four corner boxes land at the grid-derived
+  corners (`tl(0,0)`/`tr(300,0)`/`bl(0,75)`/`br(300,75)` for a 400×100 CB with a (100,25)200×50 anchor),
+  while the bridge's baked estimator collapses them to 0×0 (it cannot place a box inside an abspos inline CB).
+  - **Change.** The single `IsMvpNativeAnchorBox` abspos/fixed inline-CB exclusion is removed (the last
+    inline-CB carve-out); the promotion-skip already handles it (`IsNativeMvpPositionAreaBox` → the relaxed
+    gate → `CollectInlineCBPromotions` leaves the inline CB's subtree intact for the engine).
+  Tests: `Broiler.Cli.Tests/NativeAnchorAbsInlineCbPipelineTests.cs` (real parse→cascade→layout pipeline:
+  the four corner boxes at the grid corners with the flag on; a flag-off control pins the placement to the
+  post-pass). Regression check: full Cli `~NativeAnchor` (13) and Wpt `~NativeAnchor|~AnchorInlineContainingBlock|
+  ~AnchorNameScope` (10) green; **default-off byte-identical (8-fail / 31-pass)**; **lever-on unchanged fail
+  set (7-fail / 32-pass) with `position-area-abs-inline-container` improving 92.1 %→95.8 %** — the same
+  residual as its sibling `position-area-inline-container` (also 95.8 %), i.e. inline-CB rendering fidelity,
+  not geometry. Zero regressions. (True §9.7 abspos blockification of computed `display` remains a separate,
+  broader engine concern; it is not needed for the abs-inline-container placement and no corpus test requires
+  it here.)
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
   ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → ~~inline-CB promotion (relative inline
-  CB)~~ → ~~`anchor()` insets~~ → ~~`anchor-size()`~~ → ~~opposing-inset sizing~~ → abspos-inline CB
-  (blockification reconciliation) → scroll simulation → `position-visibility` → dialog/backdrop → position-try.
+  CB)~~ → ~~`anchor()` insets~~ → ~~`anchor-size()`~~ → ~~opposing-inset sizing~~ → ~~abspos-inline CB~~ →
+  scroll simulation → `position-visibility` → dialog/backdrop → position-try.
   (Childless auto/explicit/percentage sizing, `box-sizing:border-box`, percentage margin/padding/inset box
   props, shared-name scope resolution, writing-mode percentage basis, relatively-positioned inline
-  containing blocks, `anchor()` physical insets, `anchor-size()` sizing, AND opposing-inset sizing now land
-  natively — see the nine expansions above.) Each remaining feature is currently excluded by
+  containing blocks, `anchor()` physical insets, `anchor-size()` sizing, opposing-inset sizing, AND
+  abspos-inline containing blocks now land natively — see the ten expansions above.) Each remaining feature
+  is currently excluded by
   `IsMvpNativeAnchorBox`/`IsMvpNativeAnchorInsetBox`/`IsMvpNativeAnchorSizeBox` (or `CanApplyNativeAnchorSize`)
   and stays on the bridge path (baked + `position-area: none`), so enabling the lever globally is already safe
   (proven above); the expansions widen the gate one feature at a time as the engine grows to reproduce them.
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4
   item-2 unblock** — once every feature is on the engine path.
 
-The DOM-entangled bridge concerns (anchor registry *building* now trivial on the box tree, and the
-relatively-positioned inline-CB case now handled by the engine's real §10.1 inline-box geometry rather
-than the bridge's DOM-move estimator; but abspos-inline blockification reconciliation, scroll simulation,
-`position-visibility`, dialog/backdrop, `anchor-scope`/scoping) are the hard part of the later cutover
-expansions: the engine operates on boxes, not the DOM, so these are re-implementations, not moves — which
-is why the MVP subset deliberately excludes them.
+The DOM-entangled bridge concerns (anchor registry *building* now trivial on the box tree, and both the
+relatively- and absolutely-positioned inline-CB cases now handled by the engine's real §10.1 inline-box
+geometry rather than the bridge's DOM-move estimator; but scroll simulation, `position-visibility`,
+dialog/backdrop, `anchor-scope`/scoping) are the hard part of the later cutover expansions: the engine
+operates on boxes, not the DOM, so these are re-implementations, not moves — which is why the MVP subset
+deliberately excludes them.
 
 Goal: turn LayoutMetrics and AnchorResolver into a thin API adapter over a
 single layout snapshot.

--- a/src/Broiler.Cli.Tests/NativeAnchorAbsInlineCbPipelineTests.cs
+++ b/src/Broiler.Cli.Tests/NativeAnchorAbsInlineCbPipelineTests.cs
@@ -1,0 +1,132 @@
+using System.Drawing;
+using Broiler.HtmlBridge;
+using Broiler.HTML.Image;
+using Broiler.JavaScript.Engine;
+using Broiler.Layout;
+using Broiler.Layout.Engine;
+using DomDocument = Broiler.Dom.DomDocument;
+using DomElement = Broiler.Dom.DomElement;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// End-to-end validation that the Broiler.Layout engine's native anchor post-pass
+/// (Phase 5, P5.8d.2b abspos-inline-CB expansion) places <c>position-area</c> boxes
+/// whose containing block is an <em>absolutely positioned</em> inline element (an
+/// <c>position:absolute</c> &lt;span&gt;) against the real inline-CB geometry
+/// (<c>CssBox.GetInlineBoundingBox</c>, CSS2.1 §10.1).
+/// </summary>
+/// <remarks>
+/// This is the case the previous inline-CB expansion deliberately left on the bridge
+/// bake path (the roadmap assumed the engine blockified the abspos inline element and
+/// disagreed on the CB extent). It does not: the cascade's §9.7 display adjustment fires
+/// only for <c>float</c> (<c>DomParser.CascadeApplyStyles</c>), so the engine treats the
+/// abspos <c>&lt;span&gt;</c> as inline and reads its inline bounding box — which, for a
+/// simple content run, equals the block shrink-to-fit extent, i.e. the correct containing
+/// block. So the anchored boxes place identically to a relatively-positioned inline CB.
+/// Mirrors css-anchor-position <c>position-area-abs-inline-container</c> (the anchor is an
+/// abspos box inside the abspos inline CB, so its rect comes from real layout).
+/// </remarks>
+[Xunit.Collection("SharedGeometryStatics")]
+public sealed class NativeAnchorAbsInlineCbPipelineTests
+{
+    private const string Url = "file:///native-anchor-abs-inlinecb.html";
+
+    // #ic is an inline position:ABSOLUTE span; #spacer (inline-block 400x100) gives its
+    // inline bounding box a definite 400x100 extent (as the abs-inline-container test's
+    // Ahem "XXXX" text does). #anchor is a 200x50 abspos box at (100,25) inside #ic.
+    // #tl/#tr/#bl/#br are the four position-area corner boxes anchored to --a.
+    private const string Html =
+        "<!DOCTYPE html><html><head><style>" +
+        "body { margin: 0; }" +
+        "#outer { position: relative; font-size: 100px; line-height: 1; }" +
+        "#ic { position: absolute; }" +
+        "#spacer { display: inline-block; width: 400px; height: 100px; }" +
+        "#anchor { position: absolute; left: 100px; top: 25px; width: 200px; height: 50px; anchor-name: --a; }" +
+        ".a { position: absolute; align-self: stretch; justify-self: stretch; position-anchor: --a; }" +
+        "#tl { position-area: top left; } #tr { position-area: top right; }" +
+        "#bl { position-area: bottom left; } #br { position-area: bottom right; }" +
+        "</style></head><body><div id='outer'><span id='ic'><span id='spacer'></span>" +
+        "<span id='anchor'></span><div id='tl' class='a'></div><div id='tr' class='a'></div>" +
+        "<div id='bl' class='a'></div><div id='br' class='a'></div></span></div></body></html>";
+
+    private static IReadOnlyDictionary<DomElement, BoxGeometry> Layout(bool nativeAnchor, out DomDocument document)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        if (nativeAnchor) bridge.NativeAnchorPlacement = true;
+        bridge.Attach(context, Html, Url);
+        document = bridge.GetRenderDocument();
+
+        using var container = new HtmlContainer
+        {
+            Location = new PointF(0, 0),
+            AvoidAsyncImagesLoading = true,
+            AvoidImagesLateLoading = true,
+        };
+        container.SetDocumentWithStyleSet(document, baseUrl: Url);
+
+        try
+        {
+            NativeAnchorPlacement.Enabled = nativeAnchor;
+            return container.GetLayoutGeometry(new SizeF(800, 600));
+        }
+        finally
+        {
+            NativeAnchorPlacement.Enabled = false;
+        }
+    }
+
+    private static BoxGeometry Box(IReadOnlyDictionary<DomElement, BoxGeometry> g, DomDocument doc, string id)
+    {
+        var el = doc.GetElementById(id);
+        Assert.NotNull(el);
+        Assert.True(g.ContainsKey(el!), $"{id} box has no geometry");
+        return g[el!];
+    }
+
+    [Fact]
+    public void NativeFlagOn_PlacesAbsInlineCbPositionAreaBoxes_AtGridCorners()
+    {
+        var g = Layout(nativeAnchor: true, out var doc);
+
+        // The abspos anchor lays out at its inset position inside the abspos inline CB's
+        // bounding box: (100,25) 200x50. So the anchor edges are left=100, right=300,
+        // top=25, bottom=75, and the CB (inline bounding box) is (0,0) 400x100.
+        var anchor = Box(g, doc, "anchor");
+        Assert.Equal(100f, anchor.BorderBox.Left, 1);
+        Assert.Equal(25f, anchor.BorderBox.Top, 1);
+
+        // 3x3 grid corner cells, each 100x25:
+        //   top left     [0..100]   x [0..25]
+        //   top right    [300..400] x [0..25]
+        //   bottom left  [0..100]   x [75..100]
+        //   bottom right [300..400] x [75..100]
+        void AssertCorner(string id, float x, float y)
+        {
+            var b = Box(g, doc, id).BorderBox;
+            Assert.Equal(x, b.Left, 1);
+            Assert.Equal(y, b.Top, 1);
+            Assert.Equal(100f, b.Width, 1);
+            Assert.Equal(25f, b.Height, 1);
+        }
+
+        AssertCorner("tl", 0f, 0f);
+        AssertCorner("tr", 300f, 0f);
+        AssertCorner("bl", 0f, 75f);
+        AssertCorner("br", 300f, 75f);
+    }
+
+    [Fact]
+    public void NativeFlagOff_DoesNotPlaceBoxesAtAnchorCorners()
+    {
+        // Flag off → the engine ignores position-area (and the bridge's baked estimator
+        // cannot place a box inside an abspos inline CB), so the boxes are NOT at the grid
+        // corners. Pins the correct placement to the native post-pass.
+        var g = Layout(nativeAnchor: false, out var doc);
+        var br = Box(g, doc, "br").BorderBox;
+        Assert.False(
+            System.Math.Abs(br.Left - 300f) < 1 && System.Math.Abs(br.Top - 75f) < 1,
+            $"br was unexpectedly at the anchor grid corner without the native flag: {br}");
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
@@ -401,9 +401,11 @@ public sealed partial class DomBridge
     /// subset (P5.8d.2b) — the boxes the Broiler.Layout engine's placement post-pass
     /// currently reproduces exactly, so the bridge can hand them off instead of
     /// pre-baking. Requires: an explicit dashed-ident <c>position-anchor</c> that names a
-    /// registered anchor, a non-inline containing block, no intervening scroll container,
-    /// and no <c>position-try</c> or <c>anchor()</c>/<c>anchor-size()</c> on the element
-    /// (those entangled features stay on the bridge path until later expansions).
+    /// registered anchor, no intervening scroll container, and no <c>position-try</c> or
+    /// <c>anchor()</c>/<c>anchor-size()</c> on the element (those entangled features stay on
+    /// the bridge path until later expansions). Both block and inline containing blocks
+    /// (relative or abspos/fixed) are in the subset — the engine places against the real
+    /// inline-box geometry the bridge estimator could not.
     /// </summary>
     private bool IsMvpNativeAnchorBox(
         DomElement element, string positionAnchor, Dictionary<string, string> cssProps,
@@ -426,27 +428,23 @@ public sealed partial class DomBridge
         if (_anchorCandidates == null || !_anchorCandidates.ContainsKey(anchorName))
             return false;
 
-        // A non-abspos inline containing block is now IN the MVP subset (P5.8d.2b
-        // inline-CB expansion): the engine's abspos layout places a box inside an inline
-        // element against the real inline-box bounding box (CssBox.GetInlineBoundingBox,
-        // CSS2.1 §10.1), which the bridge's estimator could not — so, unlike every other
-        // gate, a relatively-positioned inline CB no longer forces the bridge path. The box
-        // stays inside the inline CB (PromoteAbsPosFromInlineCBs skips the whole inline CB
-        // in native mode — see InlineCbHasNativeAnchorBox) so the engine lays out the
-        // intact subtree.
+        // An inline containing block — whether relatively or absolutely/fixed positioned —
+        // is now IN the MVP subset (P5.8d.2b inline-CB and abspos-inline-CB expansions): the
+        // engine's abspos layout places a box inside an inline element against the real
+        // inline-box bounding box (CssBox.GetInlineBoundingBox, CSS2.1 §10.1), which the
+        // bridge's estimator could not. The box stays inside the inline CB
+        // (PromoteAbsPosFromInlineCBs skips the whole inline CB in native mode — see
+        // InlineCbHasNativeAnchorBox) so the engine lays out the intact anchor + target
+        // subtree.
         //
-        // Exception: an inline element that is ITSELF absolutely/fixed positioned is
-        // blockified by the engine (CSS2.1 §9.7: position:absolute forces display:block),
-        // so the engine treats it as a block containing block while the bridge's
-        // IsInlineElement still treats it as inline — the two disagree on the CB's extent.
-        // Keep such a box on the bridge bake path until that is reconciled.
-        var cb = FindContainingBlockElement(element);
-        if (cb != null && IsInlineContainingBlock(cb))
-        {
-            var cbPos = GetComputedProps(cb).GetValueOrDefault("position");
-            if (cbPos is "absolute" or "fixed")
-                return false;
-        }
+        // The engine does not blockify an abspos inline element (the cascade's CSS2.1 §9.7
+        // adjustment fires only for float — see DomParser.CascadeApplyStyles), so it treats
+        // an abspos <span> containing block as inline and reads its inline bounding box. For
+        // an out-of-flow inline whose content is a simple run that equals the block
+        // shrink-to-fit extent (the css-anchor-position abs-inline-container case), that is
+        // the correct containing-block rect, so the anchored boxes place identically to a
+        // relative inline CB. No bridge/engine disagreement remains; both inline-CB cases go
+        // native.
 
         // position-try and anchor()/anchor-size() are out of the MVP subset.
         if (cssProps.ContainsKey("position-try-fallbacks") || cssProps.ContainsKey("position-try"))


### PR DESCRIPTION
## Summary

Completes the tenth expansion of the native anchor placement MVP subset (P5.8d.2b) by enabling `position-area` boxes whose containing block is an **absolutely or fixed-positioned inline element** to be placed natively by the Broiler.Layout engine, rather than falling back to the bridge's baked estimator.

## Key Changes

- **Removed abspos/fixed inline-CB exclusion** from `IsMvpNativeAnchorBox` in `PositionArea.cs`. The roadmap's premise for keeping this case baked was incorrect: the engine does not blockify abspos inline elements (CSS2.1 §9.7 `display` adjustment fires only for `float`), so it correctly reads the inline bounding box via `CssBox.GetInlineBoundingBox`. For simple content runs, this equals the block shrink-to-fit extent — the correct containing-block rect — making placement identical to relatively-positioned inline CBs.

- **Updated documentation** in `htmlbridge-complexity-reduction-roadmap.md` to reflect completion of the abspos-inline-CB expansion and clarify that both relative and abspos/fixed inline containing blocks now go native.

- **Added pipeline test** `NativeAnchorAbsInlineCbPipelineTests.cs` validating end-to-end behavior:
  - Confirms four corner `position-area` boxes land at grid-derived corners (0,0 / 300,0 / 0,75 / 300,75) with the native flag enabled
  - Control test verifies the bridge's baked estimator cannot place boxes inside abspos inline CBs (they collapse to 0×0)
  - Tests the real parse→cascade→layout pipeline with a 400×100 inline CB and (100,25) 200×50 anchor

## Implementation Details

The change is minimal and additive: the promotion-skip mechanism (`IsNativeMvpPositionAreaBox` → `CollectInlineCBPromotions`) already preserves the inline CB's subtree for the engine, so no additional gating logic is needed. The engine's existing abspos layout correctly handles the case once the exclusion is removed.

**Test results:**
- Full Cli `~NativeAnchor` (13 tests) and Wpt `~NativeAnchor|~AnchorInlineContainingBlock|~AnchorNameScope` (10 tests) pass
- Default-off: byte-identical (8-fail / 31-pass)
- Lever-on: unchanged fail set (7-fail / 32-pass) with `position-area-abs-inline-container` improving 92.1 %→95.8 %
- Zero regressions

This completes the inline-CB geometry handling; both relative and abspos inline containing blocks now use the engine's real §10.1 inline-box geometry rather than the bridge's DOM-move estimator.

https://claude.ai/code/session_011yPyYQEUE9as11y6GV5bcy