### PR TITLE
P5.8d.2b: Native anchor placement for scroll-container targets

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/AnchorPropertyProjectionTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/AnchorPropertyProjectionTests.cs
@@ -27,6 +27,7 @@ public sealed class AnchorPropertyProjectionTests
         Assert.Equal("auto", box.PositionAnchor);
         Assert.Equal("none", box.PositionArea);
         Assert.Equal("normal", box.PositionTry);
+        Assert.Equal("none", box.PositionTryFallbacks);
     }
 
     [Theory]
@@ -34,6 +35,7 @@ public sealed class AnchorPropertyProjectionTests
     [InlineData("position-anchor", "--foo")]
     [InlineData("position-area", "top left")]
     [InlineData("position-try", "flip-block")]
+    [InlineData("position-try-fallbacks", "--f1, --f2, --f3")]
     public void SetPropertyValue_ProjectsOntoBox_AndRoundTrips(string property, string value)
     {
         var box = NewBox();
@@ -49,10 +51,12 @@ public sealed class AnchorPropertyProjectionTests
         CssUtils.SetPropertyValue(box, "position-anchor", "--a");
         CssUtils.SetPropertyValue(box, "position-area", "bottom right");
         CssUtils.SetPropertyValue(box, "position-try", "--fallback-1");
+        CssUtils.SetPropertyValue(box, "position-try-fallbacks", "--f1, --f2");
 
         Assert.Equal("--a", box.AnchorName);
         Assert.Equal("--a", box.PositionAnchor);
         Assert.Equal("bottom right", box.PositionArea);
         Assert.Equal("--fallback-1", box.PositionTry);
+        Assert.Equal("--f1, --f2", box.PositionTryFallbacks);
     }
 }

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -647,6 +647,7 @@ internal abstract partial class CssBoxProperties
     public string PositionAnchor { get; set; } = "auto";
     public string PositionArea { get; set; } = "none";
     public string PositionTry { get; set; } = "normal";
+    public string PositionTryFallbacks { get; set; } = "none";
 
     public string LineHeight
     {

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -95,6 +95,7 @@ internal static partial class CssUtils
             "position-anchor" => cssBox.PositionAnchor,
             "position-area" => cssBox.PositionArea,
             "position-try" => cssBox.PositionTry,
+            "position-try-fallbacks" => cssBox.PositionTryFallbacks,
             "line-height" => cssBox.LineHeight,
             "vertical-align" => cssBox.VerticalAlign,
             "text-indent" => cssBox.TextIndent,
@@ -590,6 +591,9 @@ internal static partial class CssUtils
                 break;
             case "position-try":
                 cssBox.PositionTry = value;
+                break;
+            case "position-try-fallbacks":
+                cssBox.PositionTryFallbacks = value;
                 break;
             case "line-height":
                 cssBox.LineHeight = value;

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2064,8 +2064,20 @@ project onto the box via `SharedRendererCascade` — its rule *bodies* never rea
 engine consumes cascaded box properties only, never the stylesheet). A native `position-try` therefore
 needs a new data path: the parsed `@position-try` name→declarations map (already modelled canonically as
 `Broiler.CSS.PositionTryRule`, P5.3) must be handed to the engine's post-pass, and the fallback
-apply/re-place/re-test loop reimplemented on the box tree. Until that infrastructure lands,
-`position-try` boxes stay gate-excluded and baked (`IsMvpNativeAnchorBox` excludes `position-try`); this
+apply/re-place/re-test loop reimplemented on the box tree.
+
+**Groundwork landed (2026-07-14):** the per-box half of that input is now in place — `position-try-fallbacks`
+is projected onto `CssBox` (`CssBoxProperties.PositionTryFallbacks`, plus the `CssUtils` get/set arms), the
+P5.8b pattern applied to the fallback list. It is **inert** (nothing reads it yet — no behaviour change; the
+css-anchor-position subset is byte-identical, 31/8 default-off and 32/7 lever-on), so the box now carries the
+ordered fallback names the post-pass will consume. Test: `Broiler.Layout.Tests/AnchorPropertyProjectionTests.cs`
+(+1 theory row + round-trip). Still to build: (a) the `@position-try` **rule-body** channel from the
+bridge/runner into the post-pass (the parsed `PositionTryRule` map), (b) the base placement of a
+position-try box made native (its `position-area`/`anchor()` base must be on the engine so the fallback loop
+has a base to overflow-test), and (c) the fallback apply/re-place/re-test loop itself (reusing the promoted
+`AnchorGeometry.Overflows`/`Fits` and the engine's existing `anchor()`-inset / position-area placement).
+Until (a)–(c) land, `position-try` boxes stay gate-excluded and baked (`IsMvpNativeAnchorBox` excludes
+`position-try`); this
 is why `position-try-grid-001` — which also combines `anchor()` insets and grid abspos — fails identically
 on both the baked and native paths and is not a native-gate regression.
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1987,28 +1987,59 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   not geometry. Zero regressions. (True §9.7 abspos blockification of computed `display` remains a separate,
   broader engine concern; it is not needed for the abs-inline-container placement and no corpus test requires
   it here.)
+- **P5.8d.2b — intervening scroll container (eleventh expansion) — COMPLETED** 2026-07-14
+  (branch `claude/htmlbridge-phase-5-sy7bkr`; **bridge only, additive, default-off**). A `position-area` box
+  whose containing block is the **anchor's scroll container** (an *intervening scroll container* — the target
+  is a descendant of the scroll container the anchor lives in) now goes native — the case the MVP subset
+  excluded from the start via the `IsMvpNativeAnchorBox` `scrollContainer != null` gate. **No engine change
+  needed:** the bridge's `ApplyScrollSimulation` pre-pass already DOM-shifts a scrolled container's content
+  (wrapping it in a `position:relative` offset div with `top:-scrollTop`/`left:-scrollLeft`) *before* the
+  final render, so the engine's box tree already carries the scrolled anchor's border-box geometry; the
+  native post-pass reads that shifted anchor rect (`box.Bounds`) and places the target against it, exactly as
+  for any other anchor. The two bridge changes:
+  - **Gate.** The `scrollContainer != null` early-return in `IsMvpNativeAnchorBox` is removed (position-try
+    and `anchor()`/`anchor-size()` remain the only position-area exclusions).
+  - **CB parity.** The baked path registers the scroll container in `scrollContainersNeedingRelative` (so it
+    gets `position:relative` and becomes the target's containing block) *inside* the `rect != null` bake
+    block; native (un-baked) boxes now register it too, so the CB frame the engine resolves is identical to
+    the baked path whether or not the scroll container was already positioned.
+  Validation (this expansion is the render-parity model — the corpus `position-area-scrolling-001/003`
+  cannot exercise it because their targets **vanish in both the baked and native paths** due to a separate
+  pre-existing rendering bug, so they fail identically default-off and lever-on; `scrolling-002`, whose
+  target is *outside* the scroll container, already went native): `Broiler.Wpt.Tests/
+  ScrollContainerAnchorParityTests.cs` (full render pipeline: a scroll-container `position-area: bottom
+  right` target renders **pixel-identically** baked vs native — positioned and static scroll containers, with
+  and without a JS scroll offset; a `scrollTop:50`/`scrollLeft:30` offset shifts the native placement to the
+  scrolled anchor's edge exactly as baked) plus `Broiler.Cli.Tests/NativeAnchorScrollContainerModeTests.cs`
+  (bridge half: native mode leaves the scroll-container target un-baked — no inline `left`/`top`/
+  `position-area: none` — while default mode bakes it, so the parity above is genuinely the engine's doing).
+  Regression check: full Cli `~NativeAnchor` (15) and the anchor Wpt suites (`~AnchorScrollTracking`/
+  `~AnchorNameScope`/`~AnchorInlineContainingBlock`/`~PositionTryFallback`/`~NativeAnchor`/`~ScrollContainer`,
+  18) green; **default-off byte-identical (8-fail / 31-pass)**; **lever-on unchanged (7-fail / 32-pass)** with
+  the identical pre-existing anchor-tail fail *set* — zero regressions.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
   ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → ~~inline-CB promotion (relative inline
   CB)~~ → ~~`anchor()` insets~~ → ~~`anchor-size()`~~ → ~~opposing-inset sizing~~ → ~~abspos-inline CB~~ →
-  scroll simulation → `position-visibility` → dialog/backdrop → position-try.
+  ~~scroll simulation~~ → `position-visibility` → dialog/backdrop → position-try.
   (Childless auto/explicit/percentage sizing, `box-sizing:border-box`, percentage margin/padding/inset box
   props, shared-name scope resolution, writing-mode percentage basis, relatively-positioned inline
-  containing blocks, `anchor()` physical insets, `anchor-size()` sizing, opposing-inset sizing, AND
-  abspos-inline containing blocks now land natively — see the ten expansions above.) Each remaining feature
-  is currently excluded by
+  containing blocks, `anchor()` physical insets, `anchor-size()` sizing, opposing-inset sizing, abspos-inline
+  containing blocks, AND intervening scroll containers now land natively — see the eleven expansions above.)
+  Each remaining feature is currently excluded by
   `IsMvpNativeAnchorBox`/`IsMvpNativeAnchorInsetBox`/`IsMvpNativeAnchorSizeBox` (or `CanApplyNativeAnchorSize`)
   and stays on the bridge path (baked + `position-area: none`), so enabling the lever globally is already safe
   (proven above); the expansions widen the gate one feature at a time as the engine grows to reproduce them.
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4
   item-2 unblock** — once every feature is on the engine path.
 
-The DOM-entangled bridge concerns (anchor registry *building* now trivial on the box tree, and both the
+The DOM-entangled bridge concerns (anchor registry *building* now trivial on the box tree; both the
 relatively- and absolutely-positioned inline-CB cases now handled by the engine's real §10.1 inline-box
-geometry rather than the bridge's DOM-move estimator; but scroll simulation, `position-visibility`,
-dialog/backdrop, `anchor-scope`/scoping) are the hard part of the later cutover expansions: the engine
-operates on boxes, not the DOM, so these are re-implementations, not moves — which is why the MVP subset
-deliberately excludes them.
+geometry rather than the bridge's DOM-move estimator; and an intervening scroll container now handled by
+reading the anchor's already-`ApplyScrollSimulation`-shifted box geometry rather than re-simulating scroll
+in the engine; but `position-visibility`, dialog/backdrop, `anchor-scope`/scoping) are the hard part of the
+later cutover expansions: the engine operates on boxes, not the DOM, so these are re-implementations, not
+moves — which is why the MVP subset deliberately excludes them.
 
 Goal: turn LayoutMetrics and AnchorResolver into a thin API adapter over a
 single layout snapshot.

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2033,6 +2033,42 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4
   item-2 unblock** — once every feature is on the engine path.
 
+**Finding — `position-visibility` is entangled with the scroll-container CB decision (2026-07-14
+investigation; the naive engine port was tried and reverted after two lever-on regressions).** A native
+engine port (project `position-visibility` onto the box, and in the placement post-pass set
+`display:none` when the anchor is `visibility:hidden` or scrolled out of an intervening clip container)
+is straightforward *except* for one ordering subtlety the bridge relies on: the bridge runs
+`ResolvePositionVisibility` **before** it applies `position:relative` to scroll containers used as a
+position-area CB (`ResolveAnchorPositions` steps 3c vs 3e — the deferral is deliberate, see the
+`scrollContainersNeedingRelative` comment), so during the bridge's visibility check the scroll container
+is **not yet** the target's containing block and its `IsAnchorVisibleForTarget` "the clip container *is*
+the target's CB → no intervening clip → visible" exception does not fire; the scrolled-out anchor
+therefore hides the target. The engine only sees the **final** serialized DOM, where that scroll
+container *is* already `position:relative` (the scroll-simulation expansion above adds it for native
+boxes too), so the engine's equivalent exception fires and the target is (incorrectly) kept visible —
+and, symmetrically, the naive geometry check hid two boxes it should not have
+(`position-visibility-anchors-visible-with-position`, `position-visibility-remove-anchors-visible` both
+regressed to 98.7 % MissingContent lever-on). Because every `position-visibility` corpus test already
+passes via the bridge (this is a parity move with no corpus gain), the port must reproduce the bridge's
+pre-`position:relative` CB view exactly — e.g. compute the anchor-visibility CB from the box's *original*
+(pre-native) positioning, or drive the whole hiding decision from a snapshot the bridge hands to the
+engine — before the bridge's `ResolvePositionVisibility` can be skipped. Left on the bridge path for now.
+
+**Finding — `position-try` needs the `@position-try` rules plumbed into the engine first (2026-07-14
+assessment).** The bridge's `TryApplyFallback` (`PositionTry.cs`) selects a fallback by (1) reading the
+box's already-**baked** base `left`/`top`/`width`/`height` inline styles, (2) testing overflow, then (3)
+overlaying each named `@position-try` rule's declarations, resolving its `anchor()` insets, and testing
+fit. The blocker for a native port is step (3): `@position-try` is a stylesheet **at-rule**, not a
+per-element cascaded property, so — unlike `position-area`/`anchor-name`/`position-try` longhands, which
+project onto the box via `SharedRendererCascade` — its rule *bodies* never reach `Broiler.Layout` (the
+engine consumes cascaded box properties only, never the stylesheet). A native `position-try` therefore
+needs a new data path: the parsed `@position-try` name→declarations map (already modelled canonically as
+`Broiler.CSS.PositionTryRule`, P5.3) must be handed to the engine's post-pass, and the fallback
+apply/re-place/re-test loop reimplemented on the box tree. Until that infrastructure lands,
+`position-try` boxes stay gate-excluded and baked (`IsMvpNativeAnchorBox` excludes `position-try`); this
+is why `position-try-grid-001` — which also combines `anchor()` insets and grid abspos — fails identically
+on both the baked and native paths and is not a native-gate regression.
+
 The DOM-entangled bridge concerns (anchor registry *building* now trivial on the box tree; both the
 relatively- and absolutely-positioned inline-CB cases now handled by the engine's real §10.1 inline-box
 geometry rather than the bridge's DOM-move estimator; and an intervening scroll container now handled by

--- a/src/Broiler.Cli.Tests/NativeAnchorScrollContainerModeTests.cs
+++ b/src/Broiler.Cli.Tests/NativeAnchorScrollContainerModeTests.cs
@@ -1,0 +1,75 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Bridge half of the Phase 5 scroll-simulation expansion (P5.8d.2b): a
+/// <c>position-area</c> box whose containing block is the anchor's scroll container is
+/// now in the native MVP subset, so with <c>DomBridge.NativeAnchorPlacement</c> on the
+/// bridge stops pre-baking it — the box keeps its <c>position-area</c> and gets no
+/// baked inline <c>left</c>/<c>top</c> or <c>position-area: none</c> override, leaving
+/// the placement to the engine's post-pass (validated to render identically to the
+/// baked path by <c>ScrollContainerAnchorParityTests</c>). Default off pre-bakes as
+/// before.
+/// </summary>
+public sealed class NativeAnchorScrollContainerModeTests
+{
+    private const string Url = "file:///native-anchor-scroll-mode.html";
+
+    // #sc is the target's containing block AND the anchor's scroll container; the target
+    // is inside it (an intervening scroll container) — the case previously excluded.
+    private const string Html =
+        "<!DOCTYPE html><html><head><style>" +
+        "body { margin: 0; }" +
+        "#sc { position: relative; overflow: hidden; width: 300px; height: 300px; }" +
+        "#content { width: 600px; height: 600px; }" +
+        "#anchor { position: absolute; left: 100px; top: 100px; width: 40px; height: 40px; anchor-name: --a; }" +
+        "#target { position: absolute; width: 30px; height: 30px; position-anchor: --a; position-area: bottom right; }" +
+        "</style></head><body><div id='sc'><div id='content'><div id='anchor'></div>" +
+        "<div id='target'></div></div></div></body></html>";
+
+    private static string ResolveAndSerialize(bool nativeMode)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge { NativeAnchorPlacement = nativeMode };
+        bridge.Attach(context, Html, Url);
+        bridge.ResolveAnchorPositions();
+        return bridge.SerializeToHtml();
+    }
+
+    /// <summary>Extracts the serialized <c>#target</c> element's opening tag.</summary>
+    private static string TargetTag(string html)
+    {
+        int i = html.IndexOf("id=\"target\"", System.StringComparison.Ordinal);
+        if (i < 0) i = html.IndexOf("id='target'", System.StringComparison.Ordinal);
+        Assert.True(i >= 0, "no #target element in serialized output");
+        int open = html.LastIndexOf('<', i);
+        int close = html.IndexOf('>', i);
+        return html.Substring(open, close - open + 1);
+    }
+
+    [Fact]
+    public void NativeMode_DoesNotBakeScrollContainerBox()
+    {
+        var tag = TargetTag(ResolveAndSerialize(nativeMode: true));
+
+        // Went native: no baked inline pixel placement and no neutralizing override —
+        // the engine post-pass places it from the surviving position-area CSS.
+        Assert.DoesNotContain("position-area: none", tag);
+        Assert.DoesNotContain("position-area:none", tag);
+        Assert.DoesNotContain("left:", tag.Replace(" ", ""));
+        Assert.DoesNotContain("top:", tag.Replace(" ", ""));
+    }
+
+    [Fact]
+    public void DefaultMode_BakesScrollContainerBox()
+    {
+        var tag = TargetTag(ResolveAndSerialize(nativeMode: false));
+
+        // Default (production) path pre-bakes explicit inline pixel placement.
+        var compact = tag.Replace(" ", "");
+        Assert.Contains("left:", compact);
+        Assert.Contains("top:", compact);
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
@@ -64,6 +64,15 @@ public sealed partial class DomBridge
                         ? null
                         : ComputePositionAreaRect(
                             element, anchor, positionArea, scrollContainer);
+
+                // A native (un-baked) box whose containing block is the anchor's scroll
+                // container still needs that scroll container to establish the CB the
+                // engine resolves — the baked path adds position:relative below (inside
+                // the rect!=null block); do the same here so the native CB frame matches.
+                // (P5.8d.2b scroll-simulation expansion.)
+                if (rect == null && scrollContainer != null)
+                    scrollContainersNeedingRelative.Add(scrollContainer);
+
                 if (rect != null)
                 {
                     // Preserve position:fixed when the element already has it;
@@ -401,20 +410,30 @@ public sealed partial class DomBridge
     /// subset (P5.8d.2b) — the boxes the Broiler.Layout engine's placement post-pass
     /// currently reproduces exactly, so the bridge can hand them off instead of
     /// pre-baking. Requires: an explicit dashed-ident <c>position-anchor</c> that names a
-    /// registered anchor, no intervening scroll container, and no <c>position-try</c> or
-    /// <c>anchor()</c>/<c>anchor-size()</c> on the element (those entangled features stay on
-    /// the bridge path until later expansions). Both block and inline containing blocks
-    /// (relative or abspos/fixed) are in the subset — the engine places against the real
-    /// inline-box geometry the bridge estimator could not.
+    /// registered anchor, and no <c>position-try</c> or <c>anchor()</c>/<c>anchor-size()</c>
+    /// on the element (those entangled features stay on the bridge path until later
+    /// expansions). Both block and inline containing blocks (relative or abspos/fixed) are
+    /// in the subset — the engine places against the real inline-box geometry the bridge
+    /// estimator could not. An intervening scroll container (the anchor's scroll container
+    /// is the box's containing block) is also in the subset (P5.8d.2b scroll-simulation
+    /// expansion): the bridge's <c>ApplyScrollSimulation</c> DOM-shifts the scrolled
+    /// content before render, so the engine reads the already-scrolled anchor geometry.
     /// </summary>
     private bool IsMvpNativeAnchorBox(
         DomElement element, string positionAnchor, Dictionary<string, string> cssProps,
         DomElement? scrollContainer)
     {
-        // No intervening scroll container (the anchor's scroll container is not this
-        // box's containing block).
-        if (scrollContainer != null)
-            return false;
+        // An intervening scroll container (the anchor's scroll container is this box's
+        // containing block) is now IN the MVP subset (P5.8d.2b scroll-simulation
+        // expansion). The bridge's ApplyScrollSimulation pre-pass DOM-shifts the scroll
+        // container's content (wrapping it in a position:relative offset div) before the
+        // final render, so the engine's box tree already carries the scrolled anchor
+        // geometry; the native post-pass reads the shifted anchor border box and places
+        // the target against it. The scroll container is still registered as the box's
+        // containing block below (scrollContainersNeedingRelative) in native mode too, so
+        // the CB frame the engine resolves is identical to the baked path — verified
+        // baked-vs-native pixel-identical by ScrollContainerAnchorParityTests (with and
+        // without a scroll offset, positioned and static scroll containers).
 
         // An explicit, named anchor — a dashed-ident like `--a`, not the default `auto`.
         var anchorName = positionAnchor.Trim();

--- a/src/Broiler.Wpt.Tests/ScrollContainerAnchorParityTests.cs
+++ b/src/Broiler.Wpt.Tests/ScrollContainerAnchorParityTests.cs
@@ -1,0 +1,100 @@
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Render parity for the Phase 5 scroll-simulation expansion (P5.8d.2b): a
+/// <c>position-area</c> box whose containing block is the anchor's <em>scroll
+/// container</em> now goes native (the bridge no longer pre-bakes it). The bridge's
+/// <c>ApplyScrollSimulation</c> pre-pass DOM-shifts the scrolled content before the
+/// final render, so the engine's box tree already carries the scrolled anchor
+/// geometry and its placement post-pass reads the shifted anchor border box. These
+/// tests prove the native (lever-on) render lands the box in the same cell as the
+/// baked (lever-off) render — with and without a JS scroll offset, and for both a
+/// positioned and a static scroll container.
+/// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
+public class ScrollContainerAnchorParityTests : IDisposable
+{
+    private readonly bool _previousLever = WptTestRunner.NativeAnchorPlacement;
+    public void Dispose() { WptTestRunner.NativeAnchorPlacement = _previousLever; Program.ResetTestHooks(); }
+
+    // A scroll container that IS the target's containing block, holding an anchor and a
+    // `position-area: bottom right` target. `{SC_POS}` toggles position:relative on the
+    // scroll container; `{SCRIPT}` optionally applies a JS scroll offset.
+    private const string HtmlTemplate = @"<!DOCTYPE html><meta charset=""utf-8"">
+<style>
+  body { margin: 0; }
+  #sc { {SC_POS}overflow: hidden; width: 300px; height: 300px; }
+  #content { width: 600px; height: 600px; }
+  #anchor { position: absolute; left: 100px; top: 100px; width: 40px; height: 40px; anchor-name: --a; background: gray; }
+  #target { position: absolute; width: 30px; height: 30px; position-anchor: --a; position-area: bottom right; background: #ff0000; }
+</style>
+<div id=""sc""><div id=""content""><div id=""anchor""></div><div id=""target""></div></div></div>
+{SCRIPT}";
+
+    private static (int x0, int y0, int x1, int y1, int count) RedBox(BBitmap bmp, int w, int h)
+    {
+        int x0 = int.MaxValue, y0 = int.MaxValue, x1 = -1, y1 = -1, count = 0;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                var p = bmp.GetPixel(x, y);
+                if (p.R > 200 && p.G < 80 && p.B < 80)
+                { count++; if (x < x0) x0 = x; if (y < y0) y0 = y; if (x > x1) x1 = x; if (y > y1) y1 = y; }
+            }
+        return (x0, y0, x1, y1, count);
+    }
+
+    private static (int x0, int y0, int x1, int y1, int count) Render(string html, bool nativeAnchor)
+    {
+        WptTestRunner.NativeAnchorPlacement = nativeAnchor;
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-sc-anchor-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "sc.html");
+            File.WriteAllText(file, html);
+            var runner = new WptTestRunner(400, 400);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+            return RedBox(bmp, 400, 400);
+        }
+        finally { try { Directory.Delete(dir, true); } catch { } }
+    }
+
+    private static string Html(bool positioned, string script) => HtmlTemplate
+        .Replace("{SC_POS}", positioned ? "position: relative; " : "")
+        .Replace("{SCRIPT}", script);
+
+    [Theory]
+    [InlineData(true, "")]                                                                          // positioned CB, no scroll
+    [InlineData(false, "")]                                                                         // static CB, no scroll
+    [InlineData(true, "<script>sc.scrollTop = 50; sc.scrollLeft = 30;</script>")]                   // positioned CB, scrolled
+    public void ScrollContainerCB_BakedAndNativePaths_Agree(bool positioned, string script)
+    {
+        string html = Html(positioned, script);
+        var baked = Render(html, nativeAnchor: false);
+        var native = Render(html, nativeAnchor: true);
+
+        Assert.True(baked.count > 0, "baked path painted no target.");
+        Assert.True(native.count > 0, "native path painted no target.");
+        Assert.True(System.Math.Abs(baked.x0 - native.x0) <= 2, $"left differs: baked={baked.x0}, native={native.x0}.");
+        Assert.True(System.Math.Abs(baked.y0 - native.y0) <= 2, $"top differs: baked={baked.y0}, native={native.y0}.");
+        Assert.True(System.Math.Abs(baked.x1 - native.x1) <= 2, $"right differs: baked={baked.x1}, native={native.x1}.");
+        Assert.True(System.Math.Abs(baked.y1 - native.y1) <= 2, $"bottom differs: baked={baked.y1}, native={native.y1}.");
+    }
+
+    [Fact]
+    public void ScrollOffset_ShiftsNativePlacement_LikeBaked()
+    {
+        // Anchor at content (100,100) 40x40; scrollLeft=30, scrollTop=50 shift it to
+        // (70,50), so its right/bottom edge is (110,90) and the bottom-right 30x30 target
+        // occupies (110,90)-(139,119). The native path must reproduce that exactly.
+        string html = Html(positioned: true, "<script>sc.scrollTop = 50; sc.scrollLeft = 30;</script>");
+        var native = Render(html, nativeAnchor: true);
+        Assert.True(native.count > 0, "native path painted no target.");
+        Assert.True(System.Math.Abs(native.x0 - 110) <= 2, $"native left={native.x0}, expected ~110.");
+        Assert.True(System.Math.Abs(native.y0 - 90) <= 2, $"native top={native.y0}, expected ~90.");
+    }
+}


### PR DESCRIPTION
## Summary

Expands the native anchor placement MVP subset to include `position-area` boxes whose containing block is the anchor's scroll container (an intervening scroll container). The bridge no longer pre-bakes these boxes; instead, the engine's post-pass reads the anchor geometry that the bridge's `ApplyScrollSimulation` pre-pass has already shifted via DOM wrapping, placing the target identically to the baked path.

## Changes

**Bridge (`DomBridge`)**
- Remove the `scrollContainer != null` early-return gate in `IsMvpNativeAnchorBox` that excluded intervening scroll containers from the native subset.
- Register the scroll container in `scrollContainersNeedingRelative` for native (un-baked) boxes too, ensuring the containing-block frame the engine resolves matches the baked path whether or not the scroll container was already positioned.
- Update docstring to reflect that intervening scroll containers are now in the MVP subset (P5.8d.2b scroll-simulation expansion).

**Engine (`Broiler.Layout`)**
- Project `position-try-fallbacks` onto `CssBox` as a new property (`CssBoxProperties.PositionTryFallbacks`), with getter/setter arms in `CssUtils` — groundwork for the later `position-try` native port. Currently inert (no behaviour change).
- Add test row to `AnchorPropertyProjectionTests` to validate round-trip of the new property.

**Tests**
- `ScrollContainerAnchorParityTests.cs` (new): Full render-pipeline validation that a scroll-container `position-area: bottom right` target renders pixel-identically (≤2px tolerance) in baked vs native modes — positioned and static scroll containers, with and without JS scroll offsets. Includes a specific test for `scrollTop:50`/`scrollLeft:30` offset correctness.
- `NativeAnchorScrollContainerModeTests.cs` (new): Bridge-layer validation that native mode leaves the scroll-container target un-baked (no inline `left`/`top`/`position-area: none` override), while default mode pre-bakes it.

**Documentation**
- Update roadmap to mark P5.8d.2b as COMPLETED (2026-07-14).
- Document the two bridge changes (gate removal and CB parity registration).
- Add findings on `position-visibility` entanglement with the scroll-container CB decision and why it remains on the bridge path.
- Add findings on `position-try` needing `@position-try` rule-body plumbing into the engine before a native port is possible.
- Note that `position-try-fallbacks` groundwork is now in place (inert, no behaviour change).

## Validation

- Full Cli `~NativeAnchor` (15 tests) and anchor Wpt suites (`~AnchorScrollTracking`, `~AnchorNameScope`, `~AnchorInlineContainingBlock`, `~PositionTryFallback`, `~NativeAnchor`, `~ScrollContainer`, 18 tests) green.
- Default-off: byte-identical (8-fail / 31-pass).
- Lever-on: unchanged (7-fail / 32-pass) with identical pre-existing anchor-tail fail set — zero regressions.

## Notes

- Default-off (production path pre-bakes as before).
- No engine changes required; the bridge's existing `ApplyScrollSimulation` pre-pass already DOM-shifts scrolled content before render.
- `position-try-fallbacks` projection is groundwork only; the feature remains gate-excluded and baked until the `@position-try` rule-body channel and fallback loop are implemented.

https://claude.ai/code/session_01WM3PffqzVzkoy9cMFgGFjf