### PR TITLE
Phase 5 native anchor positioning: position-try, anchor-center, position-visibility

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
@@ -618,6 +618,140 @@ public sealed class NativeAnchorPlacementTests
         Assert.Equal(9, target.Location.Y, 3);
     }
 
+    // ------------------------------------------------------------------
+    // @position-try fallback (P5.8d.2b position-try expansion)
+    // ------------------------------------------------------------------
+
+    // CB 100×100 at origin (relative, block); anchor --a is a 20×20 box at (70,70)
+    // → left/top 70, right/bottom 90. Returns a childless 30×30 abspos target at the
+    // origin for the caller to give a (usually overflowing) base placement + position-try.
+    private static (CssBox root, CssBox cb) PositionTryFixture(out CssBox target)
+    {
+        var root = Box(null, new PointF(0, 0), new SizeF(1000, 1000));
+        var cb = Box(root, new PointF(0, 0), new SizeF(100, 100));
+        cb.Position = "relative";
+        cb.Display = "block";
+        var anchor = Box(cb, new PointF(70, 70), new SizeF(20, 20));
+        anchor.AnchorName = "--a";
+        target = Box(cb, new PointF(0, 0), new SizeF(30, 30));
+        target.Position = "absolute";
+        return (root, cb);
+    }
+
+    private static IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> Rules(
+        params (string name, (string, string)[] decls)[] rules)
+    {
+        var map = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal);
+        foreach (var (name, decls) in rules)
+        {
+            var d = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (k, v) in decls) d[k] = v;
+            map[name] = d;
+        }
+        return map;
+    }
+
+    private static void RunPassWithRules(
+        CssBox root, IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>? rules)
+    {
+        try
+        {
+            NativeAnchorPlacement.Enabled = true;
+            NativeAnchorPlacement.PositionTryRules = rules;
+            CssBox.RunNativeAnchorPlacement(root);
+        }
+        finally
+        {
+            NativeAnchorPlacement.Enabled = false;
+            NativeAnchorPlacement.PositionTryRules = null;
+        }
+    }
+
+    [Fact]
+    public void PositionTry_BaseOverflows_AppliesFirstFittingFallback()
+    {
+        var (root, _) = PositionTryFixture(out var target);
+        // Base: box left/top margin edge at the anchor's right/bottom (90,90); a 30-wide box
+        // then overflows the 100-wide CB (90+30 = 120).
+        target.Left = "anchor(--a right)";
+        target.Top = "anchor(--a bottom)";
+        target.PositionTryFallbacks = "--flip";
+        // Fallback flips to the anchor's opposite edges: right/bottom at the anchor's
+        // left/top (70), so a 30-wide box lands at (40,40) and fits.
+        RunPassWithRules(root, Rules(("--flip", new[]
+        {
+            ("left", "auto"), ("right", "anchor(--a left)"),
+            ("top", "auto"), ("bottom", "anchor(--a top)"),
+        })));
+        Assert.Equal(40, target.Location.X, 3);
+        Assert.Equal(40, target.Location.Y, 3);
+        Assert.Equal(30, target.Size.Width, 3);
+        Assert.Equal(30, target.Size.Height, 3);
+    }
+
+    [Fact]
+    public void PositionTry_BaseFits_NoFallbackApplied()
+    {
+        var (root, _) = PositionTryFixture(out var target);
+        // Base at the anchor's left/top (70,70); a 30-wide box ends exactly at the CB edge
+        // (70+30 = 100) → does not overflow, so the fallback must NOT be applied.
+        target.Left = "anchor(--a left)";
+        target.Top = "anchor(--a top)";
+        target.PositionTryFallbacks = "--flip";
+        RunPassWithRules(root, Rules(("--flip", new[]
+        {
+            ("left", "auto"), ("right", "anchor(--a left)"),
+            ("top", "auto"), ("bottom", "anchor(--a top)"),
+        })));
+        Assert.Equal(70, target.Location.X, 3);
+        Assert.Equal(70, target.Location.Y, 3);
+    }
+
+    [Fact]
+    public void PositionTry_NoRules_LeavesBaseInPlace()
+    {
+        var (root, _) = PositionTryFixture(out var target);
+        target.Left = "anchor(--a right)";  // base overflows
+        target.Top = "anchor(--a bottom)";
+        target.PositionTryFallbacks = "--flip";
+        RunPassWithRules(root, rules: null); // channel empty → the overflowing base is kept
+        Assert.Equal(90, target.Location.X, 3);
+        Assert.Equal(90, target.Location.Y, 3);
+    }
+
+    [Fact]
+    public void PositionTry_InsetAuto_ResetsBaseInsetsNotSetByFallback()
+    {
+        var (root, _) = PositionTryFixture(out var target);
+        target.Left = "anchor(--a right)"; // 90 → overflows
+        target.Top = "10px";               // base top 10
+        target.PositionTryFallbacks = "--flip";
+        // inset:auto resets left/top/bottom; only right is set by the fallback → the base
+        // top (10px) must NOT leak, so tryTop resolves to 0.
+        RunPassWithRules(root, Rules(("--flip", new[]
+        {
+            ("right", "anchor(--a left)"), ("inset", "auto"),
+        })));
+        Assert.Equal(40, target.Location.X, 3); // 100 - 30(rightInset) - 30(width)
+        Assert.Equal(0, target.Location.Y, 3);  // top reset to auto → 0, not 10
+    }
+
+    [Fact]
+    public void PositionTry_PicksFirstFittingFallback_SkippingOverflowing()
+    {
+        var (root, _) = PositionTryFixture(out var target);
+        target.Left = "anchor(--a right)"; // base left 90 → overflows
+        target.Top = "10px";               // base top 10 (fits)
+        target.PositionTryFallbacks = "--stay, --flip";
+        RunPassWithRules(root, Rules(
+            // First fallback still overflows (left stays at the anchor's right edge, 90).
+            ("--stay", new[] { ("left", "anchor(--a right)") }),
+            // Second fits: right at the anchor's left edge → left 40.
+            ("--flip", new[] { ("left", "auto"), ("right", "anchor(--a left)") })));
+        Assert.Equal(40, target.Location.X, 3); // the second fallback won
+        Assert.Equal(10, target.Location.Y, 3); // base top preserved (no inset:auto here)
+    }
+
     // Minimal layout environment for the synthetic box trees: resolves a fixed-size
     // font (so em-based Actual border/padding widths compute) and returns benign
     // defaults for everything else. The test boxes carry no text or replaced content,

--- a/Broiler.Layout/Broiler.Layout/AnchorRegistry.cs
+++ b/Broiler.Layout/Broiler.Layout/AnchorRegistry.cs
@@ -110,6 +110,29 @@ public sealed class AnchorRegistry
     public bool TryResolveRect(string anchorName, Func<object?, bool>? inScope, out AnchorRect rect)
         => TryResolve(anchorName, inScope, out rect);
 
+    /// <summary>Whether the name has at least one registered candidate.</summary>
+    public bool Contains(string anchorName) => _anchors.ContainsKey(anchorName);
+
+    /// <summary>
+    /// Resolves the acceptable anchor's registered <b>scope token</b> for a query (the source
+    /// box the caller passed to <see cref="Register"/>), using the same scope binding as the rect
+    /// resolution. Lets the position-visibility pass reach the anchor's own box (to test whether
+    /// it is scrolled out / <c>visibility:hidden</c>). Returns <c>null</c> when unregistered or
+    /// the token is not of type <typeparamref name="T"/>.
+    /// </summary>
+    public T? ResolveScope<T>(string anchorName, Func<object?, bool>? inScope) where T : class
+    {
+        if (!_anchors.TryGetValue(anchorName, out var list) || list.Count == 0)
+            return null;
+        (AnchorRect Rect, object? Scope)? chosen = null;
+        if (inScope != null && list.Count > 1)
+            foreach (var c in list)
+                if (inScope(c.Scope))
+                    chosen = c;
+        chosen ??= list[^1];
+        return chosen.Value.Scope as T;
+    }
+
     /// <summary>
     /// Resolves the <c>position-area</c> grid cell for an anchored box against the
     /// named anchor (in the query's scope, per <paramref name="inScope"/>) and the box's

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
@@ -33,6 +33,9 @@ partial class CssBox
         if (registry.Count == 0)
             return;
         ApplyNativeAnchorPlacement(root, registry);
+        // position-visibility (P5.8d.2b): hide anchor-positioned targets whose anchor is not
+        // visible. Runs after placement so the anchor's final (scroll-shifted) geometry is known.
+        ResolvePositionVisibility(root, registry);
     }
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
@@ -146,6 +146,10 @@ partial class CssBox
             // a box positioned by anchor() functions in its left/right/top/bottom rather
             // than position-area.
             box.TryApplyAnchorInsetPlacement(registry);
+            // align-self/justify-self: anchor-center (P5.8d.2b anchor-center expansion): centre
+            // the box on its anchor in the block/inline axis (a box with position-anchor but no
+            // position-area).
+            box.TryApplyAnchorCenter(registry);
         }
 
         // position-try fallback (P5.8d.2b position-try expansion): after the base placement
@@ -604,6 +608,51 @@ partial class CssBox
         if (len.HasError) return null;
         if (len.IsPercentage) return basis * len.Number;
         return len.Unit == CssUnit.Px ? len.Number : null;
+    }
+
+    /// <summary>
+    /// Centres a box on its anchor per <c>align-self: anchor-center</c> (block axis) /
+    /// <c>justify-self: anchor-center</c> (inline axis) — the engine equivalent of the bridge's
+    /// <c>ResolveAnchorCenter</c> (P5.8d.2b anchor-center expansion). Applies only to an
+    /// absolutely/fixed-positioned box with <c>position-anchor</c> and no <c>position-area</c>
+    /// (position-area does its own alignment). Repositions the centred axis so the box's centre
+    /// aligns with the anchor's centre; the other axis keeps its laid-out position. The anchor rect
+    /// is the same registered (scroll-shifted) geometry the placement passes use, so the centring is
+    /// scroll-correct. Returns <c>false</c> when it is not an anchor-center box or the anchor is
+    /// unregistered.
+    /// </summary>
+    internal bool TryApplyAnchorCenter(AnchorRegistry registry)
+    {
+        if (Position != CssConstants.Absolute && Position != CssConstants.Fixed)
+            return false;
+        if (PositionArea != "none")
+            return false;
+        var anchorName = PositionAnchor;
+        if (string.IsNullOrEmpty(anchorName) || anchorName == "auto")
+            return false;
+        bool alignCenter = string.Equals(AlignSelf, "anchor-center", StringComparison.OrdinalIgnoreCase);
+        bool justifyCenter = string.Equals(JustifySelf, "anchor-center", StringComparison.OrdinalIgnoreCase);
+        if (!alignCenter && !justifyCenter)
+            return false;
+
+        var cb = FindPositionedContainingBlock();
+        Func<object?, bool> inScope = scope => scope is CssBox src && IsBoxDescendantOf(src, cb);
+        if (!registry.TryResolveRect(anchorName, inScope, out var a))
+            return false;
+
+        // align-self centres in the block axis (Y for horizontal writing modes), justify-self in
+        // the inline axis (X). The non-centred axis keeps its laid-out position.
+        if (alignCenter)
+        {
+            double centredTop = (a.Top + a.Bottom) / 2 - Size.Height / 2.0;
+            OffsetTop((float)(centredTop - Location.Y));
+        }
+        if (justifyCenter)
+        {
+            double centredLeft = (a.Left + a.Right) / 2 - Size.Width / 2.0;
+            OffsetLeft((float)(centredLeft - Location.X));
+        }
+        return true;
     }
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Anchor.cs
@@ -145,6 +145,13 @@ partial class CssBox
             box.TryApplyAnchorInsetPlacement(registry);
         }
 
+        // position-try fallback (P5.8d.2b position-try expansion): after the base placement
+        // above, if the box's base overflows its containing block, replace it with the first
+        // @position-try fallback that fits. Reads the rule bodies from the out-of-band channel
+        // (NativeAnchorPlacement.PositionTryRules); a no-op when the box has no position-try or
+        // no rules are available.
+        box.TryApplyPositionTryFallback(registry);
+
         foreach (var child in box.Boxes)
             ApplyNativeAnchorPlacement(child, registry);
     }
@@ -584,6 +591,184 @@ partial class CssBox
                 !registry.TryResolveRect(name, inScope, out var a))
                 return r.Fallback ?? "0px";
 
+            double v = AnchorGeometry.ResolveEdge(
+                a.Left - cbX, a.Top - cbY, a.Right - cbX, a.Bottom - cbY,
+                r.Side, 0, 0, property, cbW, cbH);
+            return v.ToString(System.Globalization.CultureInfo.InvariantCulture) + "px";
+        });
+
+        var len = new CssLength(rewritten);
+        if (len.HasError) return null;
+        if (len.IsPercentage) return basis * len.Number;
+        return len.Unit == CssUnit.Px ? len.Number : null;
+    }
+
+    /// <summary>
+    /// The fallback-name list a position-try box carries — <c>position-try-fallbacks</c>
+    /// when set, else the <c>position-try</c> shorthand (mirrors the bridge's
+    /// <c>position-try-fallbacks ?? position-try</c>). <c>null</c> when neither is set
+    /// (the projected defaults are <c>none</c>/<c>normal</c>).
+    /// </summary>
+    private string? PositionTryFallbackList()
+    {
+        if (!string.IsNullOrWhiteSpace(PositionTryFallbacks) && PositionTryFallbacks != "none")
+            return PositionTryFallbacks;
+        if (!string.IsNullOrWhiteSpace(PositionTry) && PositionTry != "normal")
+            return PositionTry;
+        return null;
+    }
+
+    /// <summary>
+    /// Native <c>@position-try</c> fallback selection (P5.8d.2b position-try expansion) — the
+    /// engine equivalent of the bridge's <c>TryApplyFallback</c>. Runs after the base
+    /// placement: if the box's base overflows its containing block, it walks the box's
+    /// <c>position-try-fallbacks</c> list and applies the first <c>@position-try</c> rule
+    /// whose resolved position/size fits the containing block. The rule bodies come from the
+    /// out-of-band <see cref="NativeAnchorPlacement.PositionTryRules"/> channel (a stylesheet
+    /// at-rule never reaches the cascaded box properties). Reposition + (childless) resize,
+    /// matching the bridge; a no-op when the box has no position-try, no rules are available,
+    /// or the base already fits. Returns <c>false</c> in those no-op cases, <c>true</c> when a
+    /// fallback was applied.
+    /// </summary>
+    internal bool TryApplyPositionTryFallback(AnchorRegistry registry)
+    {
+        if (Position != CssConstants.Absolute && Position != CssConstants.Fixed)
+            return false;
+        var fallbackList = PositionTryFallbackList();
+        if (fallbackList is null)
+            return false;
+        var rules = NativeAnchorPlacement.PositionTryRules;
+        if (rules is null || rules.Count == 0)
+            return false;
+
+        var cb = FindPositionedContainingBlock();
+        GetAbsoluteContainingBlockPaddingBox(cb, out double cbX, out double cbY, out double cbW, out double cbH);
+        Func<object?, bool> inScope = scope => scope is CssBox src && IsBoxDescendantOf(src, cb);
+
+        // Base placement geometry, in the containing-block frame. baseLeft/baseTop are the
+        // already-placed used position; baseRight/baseBottom are the box's numeric right/bottom
+        // insets (px only, else 0 — an anchor()/auto inset is already reflected in the used
+        // position). Mirrors the bridge's IMCB computation (cb − left − right per axis).
+        double baseLeft = Bounds.X - cbX;
+        double baseTop = Bounds.Y - cbY;
+        double baseWidth = Bounds.Width;
+        double baseHeight = Bounds.Height;
+        double baseRight = ParsePxOnly(Right) ?? 0;
+        double baseBottom = ParsePxOnly(Bottom) ?? 0;
+        double imcbWidth = cbW - baseLeft - baseRight;
+        double imcbHeight = cbH - baseTop - baseBottom;
+
+        if (!AnchorGeometry.Overflows(baseLeft, baseTop, baseWidth, baseHeight, cbW, cbH, imcbWidth, imcbHeight))
+            return false; // Base fits — no fallback needed.
+
+        foreach (var name in PositionTryRule.ParseFallbackList(fallbackList))
+        {
+            if (!rules.TryGetValue(name, out var tryProps))
+                continue;
+
+            // Overlay the fallback's declarations on the box's own position/size CSS.
+            var merged = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["left"] = Left ?? "auto",
+                ["right"] = Right ?? "auto",
+                ["top"] = Top ?? "auto",
+                ["bottom"] = Bottom ?? "auto",
+                ["width"] = Width ?? "auto",
+                ["height"] = Height ?? "auto",
+            };
+            foreach (var kv in tryProps)
+                merged[kv.Key] = kv.Value;
+
+            // inset: auto resets any inset the fallback didn't itself set, so the base
+            // insets don't leak through (mirrors the bridge).
+            if (merged.TryGetValue("inset", out var insetVal) && insetVal.Trim() == "auto")
+            {
+                foreach (var side in new[] { "left", "right", "top", "bottom" })
+                    if (!tryProps.ContainsKey(side))
+                        merged[side] = "auto";
+            }
+
+            // Resolve explicit width/height first so left-from-right / top-from-bottom use the
+            // right element size; else keep the base used size.
+            double tryWidth = baseWidth, tryHeight = baseHeight;
+            if (merged.TryGetValue("width", out var wv) && ParsePxOnly(wv) is double pw) tryWidth = pw;
+            if (merged.TryGetValue("height", out var hv) && ParsePxOnly(hv) is double ph) tryHeight = ph;
+
+            double tryLeft = 0, tryTop = 0;
+            if (IsPresentInset(merged, "left", out var lv))
+                tryLeft = ResolveTryEdge(lv, AnchorInsetProperty.Left, registry, inScope, cbX, cbY, cbW, cbH) ?? 0;
+            if (IsPresentInset(merged, "right", out var rv) &&
+                ResolveTryEdge(rv, AnchorInsetProperty.Right, registry, inScope, cbX, cbY, cbW, cbH) is double rightPx)
+            {
+                if (!IsPresentInset(merged, "left", out _))
+                    tryLeft = cbW - rightPx - tryWidth;   // no left → left from right + width
+                else
+                    tryWidth = cbW - tryLeft - rightPx;   // both → width from the two insets
+            }
+            if (IsPresentInset(merged, "top", out var tv))
+                tryTop = ResolveTryEdge(tv, AnchorInsetProperty.Top, registry, inScope, cbX, cbY, cbW, cbH) ?? 0;
+            if (IsPresentInset(merged, "bottom", out var bv) &&
+                ResolveTryEdge(bv, AnchorInsetProperty.Bottom, registry, inScope, cbX, cbY, cbW, cbH) is double bottomPx)
+            {
+                if (!IsPresentInset(merged, "top", out _))
+                    tryTop = cbH - bottomPx - tryHeight;
+                else
+                    tryHeight = cbH - tryTop - bottomPx;
+            }
+
+            if (!AnchorGeometry.Fits(tryLeft, tryTop, tryWidth, tryHeight, cbW, cbH))
+                continue;
+
+            // Apply: reposition to the CB-frame candidate, and resize a childless box (a
+            // childful box keeps its laid-out size — a re-flow would be needed).
+            if (Boxes.Count == 0 && Words.Count == 0 &&
+                (tryWidth != Size.Width || tryHeight != Size.Height))
+                Size = new System.Drawing.SizeF((float)tryWidth, (float)tryHeight);
+            OffsetLeft((float)(cbX + tryLeft - Location.X));
+            OffsetTop((float)(cbY + tryTop - Location.Y));
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Whether a merged inset entry is present and not <c>auto</c>.</summary>
+    private static bool IsPresentInset(Dictionary<string, string> merged, string key, out string value)
+    {
+        value = merged.GetValueOrDefault(key) ?? "auto";
+        return !string.IsNullOrWhiteSpace(value) && value.Trim() != "auto";
+    }
+
+    /// <summary>
+    /// Resolves one <c>@position-try</c> inset declaration (a plain length/percentage or an
+    /// <c>anchor()</c> reference) to a containing-block-frame length (px). Mirrors the base
+    /// anchor()-inset resolution (<see cref="ResolveInsetMaybeAnchor"/>): the anchor rect is
+    /// taken document-absolute and converted to the CB frame, with no scroll adjustment (the
+    /// fallback path, like the bridge's, uses none). Returns <c>null</c> for
+    /// unparseable/unregistered.
+    /// </summary>
+    private double? ResolveTryEdge(
+        string? value, AnchorInsetProperty property, AnchorRegistry registry,
+        Func<object?, bool> inScope, double cbX, double cbY, double cbW, double cbH)
+    {
+        if (string.IsNullOrEmpty(value) || value == CssConstants.Auto)
+            return null;
+        double basis = property is AnchorInsetProperty.Left or AnchorInsetProperty.Right ? cbW : cbH;
+
+        if (!value.Contains("anchor(", System.StringComparison.OrdinalIgnoreCase))
+        {
+            var plain = new CssLength(value);
+            if (plain.HasError) return null;
+            if (plain.IsPercentage) return basis * plain.Number;
+            return plain.Unit == CssUnit.Px ? plain.Number : null;
+        }
+
+        string rewritten = AnchorFunction.Rewrite(value, r =>
+        {
+            string name = string.IsNullOrEmpty(r.Name) ? (PositionAnchor ?? string.Empty) : r.Name!;
+            if (string.IsNullOrEmpty(name) || name == "auto" ||
+                !registry.TryResolveRect(name, inScope, out var a))
+                return r.Fallback ?? "0px";
             double v = AnchorGeometry.ResolveEdge(
                 a.Left - cbX, a.Top - cbY, a.Right - cbX, a.Bottom - cbY,
                 r.Side, 0, 0, property, cbW, cbH);

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Visibility.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Visibility.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Drawing;
+using Broiler.CSS;
+
+namespace Broiler.Layout.Engine;
+
+/// <summary>
+/// Native <c>position-visibility</c> resolution (Phase 5, P5.8d.2b) — the engine equivalent of
+/// the bridge's <c>ResolvePositionVisibility</c>/<c>IsAnchorVisibleForTarget</c>. A root post-pass
+/// (run after native anchor placement, so every box has final geometry) that hides an
+/// anchor-positioned target whose anchor is not visible: <c>visibility:hidden</c>, missing
+/// (<c>anchors-valid</c>), or scrolled out of an <em>intervening</em> clip container
+/// (<c>anchors-visible</c>). Hiding is applied via <see cref="CssBox.PositionHidden"/> after
+/// layout (the fragment builder skips the box), replacing the bridge's <c>display:none</c> write.
+/// </summary>
+/// <remarks>
+/// The intervening-clip decision needs the target's containing block computed as if the bridge's
+/// anchor-induced <c>position:relative</c> on a scroll container were absent (the bridge decides
+/// visibility <em>before</em> it applies that relative — see the roadmap finding). The bridge
+/// stamps those scrollers with <c>data-broiler-anchor-cb</c>; this pass treats a stamped scroller
+/// as still-intervening (not the target's CB), so a static scroller (stamped) hides its scrolled-out
+/// anchor's target while an authored <c>position:relative</c> scroller (not stamped, = the CB) does
+/// not. Uses real box geometry (the anchor's scroll-shifted <see cref="Bounds"/> vs the clip rect)
+/// rather than the bridge's offset estimator.
+/// </remarks>
+partial class CssBox
+{
+    private const string AnchorInducedCbAttr = "data-broiler-anchor-cb";
+
+    internal static void ResolvePositionVisibility(CssBox root, AnchorRegistry registry)
+        => ResolvePositionVisibilityTree(root, registry);
+
+    private static void ResolvePositionVisibilityTree(CssBox box, AnchorRegistry registry)
+    {
+        box.ApplyPositionVisibility(registry);
+        foreach (var child in box.Boxes)
+            ResolvePositionVisibilityTree(child, registry);
+    }
+
+    private void ApplyPositionVisibility(AnchorRegistry registry)
+    {
+        var posAnchor = PositionAnchor;
+        bool hasAnchor = !string.IsNullOrEmpty(posAnchor) && posAnchor != "auto";
+        bool hasArea = !string.IsNullOrEmpty(PositionArea) && PositionArea != "none";
+
+        // "normal" is the unset sentinel; an unset position-visibility on a position-area +
+        // position-anchor target takes the implicit anchors-visible (position-visibility-initial),
+        // while an explicit "always" never hides (position-visibility-remove-anchors-visible).
+        string posVis = PositionVisibility;
+        if (posVis == "normal" && hasAnchor && hasArea)
+            posVis = "anchors-visible";
+
+        if (string.Equals(posVis, "anchors-visible", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!hasAnchor)
+                return;
+            var cb = FindPositionedContainingBlock();
+            Func<object?, bool> inScope = scope => scope is CssBox src && IsBoxDescendantOf(src, cb);
+            var anchorBox = registry.ResolveScope<CssBox>(posAnchor, inScope);
+            if (anchorBox == null || !IsAnchorVisibleFor(anchorBox))
+                PositionHidden = true;
+        }
+        else if (string.Equals(posVis, "anchors-valid", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!HasValidAnchor(registry, posAnchor, hasAnchor))
+                PositionHidden = true;
+        }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="anchorBox"/> is "visible" for this target's
+    /// <c>anchors-visible</c>: not <c>visibility:hidden</c>, not inside a hidden subtree, and not
+    /// scrolled out of a clip container that clips the anchor but is not this target's (visibility)
+    /// containing block.
+    /// </summary>
+    private bool IsAnchorVisibleFor(CssBox anchorBox)
+    {
+        // Authored visibility:hidden on the anchor or an ancestor. A visibility:hidden that the
+        // bridge's scroll simulation injected to clip scrolled-out content (data-broiler-scroll-hidden)
+        // is NOT authored — it means "scrolled out", which is subject to the intervening-clip / CB
+        // exception below, so it is ignored here (matching the bridge, which decides visibility before
+        // scroll simulation runs).
+        for (var p = anchorBox; p != null; p = p.ParentBox)
+            if (string.Equals(p.Visibility, "hidden", StringComparison.OrdinalIgnoreCase)
+                && string.IsNullOrEmpty(p.GetAttribute("data-broiler-scroll-hidden")))
+                return false;
+
+        // An anchor inside an already-hidden subtree (a chained anchor whose host was hidden) is
+        // not visible.
+        for (var p = anchorBox; p != null; p = p.ParentBox)
+            if (p.PositionHidden)
+                return false;
+
+        // A fixed anchor is positioned against the viewport and is not clipped by ancestor
+        // scroll containers, so it is never scrolled out.
+        if (anchorBox.Position == CssConstants.Fixed)
+            return true;
+
+        // The target's containing block computed as if anchor-induced-relative scrollers were
+        // static (the bridge's pre-position:relative view).
+        var targetCb = FindVisibilityContainingBlock();
+
+        // Whether the bridge's scroll simulation clipped the anchor out of its scroll container
+        // (the authoritative "scrolled out" signal — the relative offset the sim applies is not
+        // reflected in a box's Bounds, so this marker is more reliable than a geometry read).
+        bool anchorScrollClipped = AnchorIsScrollClipped(anchorBox);
+
+        for (var el = anchorBox.ParentBox; el != null; el = el.ParentBox)
+        {
+            if (!el.IsScrollClipContainer())
+                continue;
+            bool anchorInduced = el.IsAnchorInducedCb();
+            // The clip container IS the target's CB (and is a genuine, authored CB) → there is no
+            // intervening clip between anchor and target → visible.
+            if (el == targetCb && !anchorInduced)
+                return true;
+            // Otherwise it is intervening (or an anchor-induced CB the bridge treats as static):
+            // the anchor is hidden if it is scrolled entirely out of this container.
+            if (anchorScrollClipped || AnchorScrolledOutOf(anchorBox, el))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// This target's containing block for visibility purposes: the nearest positioned ancestor that
+    /// is not an anchor-induced <c>position:relative</c> scroll container (which the bridge applied
+    /// only after deciding visibility, so it must not count as the CB here).
+    /// </summary>
+    private CssBox FindVisibilityContainingBlock()
+    {
+        for (var b = ParentBox; b != null; b = b.ParentBox)
+        {
+            if (b.ParentBox == null)
+                return b;
+            bool positioned = b.Position is CssConstants.Relative or CssConstants.Absolute or CssConstants.Fixed;
+            if (positioned && !b.IsAnchorInducedCb())
+                return b;
+        }
+        return ContainingBlock;
+    }
+
+    /// <summary>Whether the anchor's border box lies entirely outside the clip container's padding
+    /// box on any axis (scrolled out). The anchor's <see cref="Bounds"/> already reflect scroll via
+    /// the bridge's DOM-shift simulation.</summary>
+    private static bool AnchorScrolledOutOf(CssBox anchor, CssBox scroller)
+    {
+        var clip = RectangleF.FromLTRB(
+            (float)(scroller.Location.X + scroller.ActualBorderLeftWidth),
+            (float)(scroller.Location.Y + scroller.ActualBorderTopWidth),
+            (float)(scroller.ActualRight - scroller.ActualBorderRightWidth),
+            (float)(scroller.ActualBottom - scroller.ActualBorderBottomWidth));
+        var a = anchor.Bounds;
+        const float eps = 0.5f;
+        return a.Bottom <= clip.Top + eps || a.Top >= clip.Bottom - eps
+            || a.Right <= clip.Left + eps || a.Left >= clip.Right - eps;
+    }
+
+    /// <summary>Whether this box clips its content (a scroll/clip container). Recognises the
+    /// two-value <c>overflow</c> shorthand (e.g. <c>hidden scroll</c>, which the cascade stores
+    /// un-normalised) by matching any token, so it is not limited to the single-value forms the
+    /// paint clip check handles.</summary>
+    private bool IsScrollClipContainer()
+    {
+        if (string.IsNullOrEmpty(Overflow) || Overflow == "visible")
+            return false;
+        return Overflow.Contains("hidden", StringComparison.Ordinal)
+            || Overflow.Contains("scroll", StringComparison.Ordinal)
+            || Overflow.Contains("auto", StringComparison.Ordinal)
+            || Overflow.Contains("clip", StringComparison.Ordinal);
+    }
+
+    /// <summary>Whether the anchor (or an ancestor between it and its scroll container) was
+    /// clipped out of view by the bridge's scroll simulation (marked
+    /// <c>data-broiler-scroll-hidden</c>) — i.e. scrolled entirely out of its scroll container.</summary>
+    private static bool AnchorIsScrollClipped(CssBox anchorBox)
+    {
+        for (var p = anchorBox; p != null; p = p.ParentBox)
+            if (!string.IsNullOrEmpty(p.GetAttribute("data-broiler-scroll-hidden")))
+                return true;
+        return false;
+    }
+
+    private bool IsAnchorInducedCb()
+        => !string.IsNullOrEmpty(GetAttribute(AnchorInducedCbAttr));
+
+    /// <summary>
+    /// <c>anchors-valid</c> validity: the target has at least one anchor reference that resolves to
+    /// a registered anchor — an explicit <c>position-anchor</c>, or an <c>anchor()</c> function in a
+    /// physical inset / size naming a registered anchor.
+    /// </summary>
+    private bool HasValidAnchor(AnchorRegistry registry, string posAnchor, bool hasAnchor)
+    {
+        if (hasAnchor && registry.Contains(posAnchor))
+            return true;
+        foreach (var value in new[] { Left, Right, Top, Bottom, Width, Height })
+        {
+            if (string.IsNullOrEmpty(value) || value.IndexOf("anchor(", StringComparison.OrdinalIgnoreCase) < 0)
+                continue;
+            if (AnchorFunction.TryGetFirst(value, out var reference))
+            {
+                string name = string.IsNullOrEmpty(reference.Name) ? posAnchor : reference.Name!;
+                if (!string.IsNullOrEmpty(name) && name != "auto" && registry.Contains(name))
+                    return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -648,6 +648,22 @@ internal abstract partial class CssBoxProperties
     public string PositionArea { get; set; } = "none";
     public string PositionTry { get; set; } = "normal";
     public string PositionTryFallbacks { get; set; } = "none";
+    // Default "normal" is a sentinel for UNSET (the cascade only emits position-visibility
+    // when authored, since it is not in CssComputedDefaults). It lets the visibility pass
+    // distinguish an unset target — which, when it has position-area + position-anchor, takes
+    // an implicit "anchors-visible" (the position-visibility-initial reftest) — from an
+    // explicit "always" (position-visibility-remove-anchors-visible), which must never hide.
+    public string PositionVisibility { get; set; } = "normal";
+
+    /// <summary>
+    /// Runtime flag set by the native anchor post-pass' <c>position-visibility</c> resolution
+    /// (P5.8d.2b) to suppress an anchor-positioned box whose anchor is not visible (scrolled out
+    /// of an intervening clip container, <c>visibility:hidden</c>, or — for <c>anchors-valid</c> —
+    /// missing). Unlike <c>display:none</c> it is applied <em>after</em> layout, so the box keeps
+    /// its geometry but <see cref="Broiler.Layout.IR.FragmentTreeBuilder"/> excludes it (and its
+    /// subtree) from the paint fragment tree. Not a CSS property — never cascaded or copied.
+    /// </summary>
+    public bool PositionHidden { get; set; }
 
     public string LineHeight
     {

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -96,6 +96,7 @@ internal static partial class CssUtils
             "position-area" => cssBox.PositionArea,
             "position-try" => cssBox.PositionTry,
             "position-try-fallbacks" => cssBox.PositionTryFallbacks,
+            "position-visibility" => cssBox.PositionVisibility,
             "line-height" => cssBox.LineHeight,
             "vertical-align" => cssBox.VerticalAlign,
             "text-indent" => cssBox.TextIndent,
@@ -594,6 +595,9 @@ internal static partial class CssUtils
                 break;
             case "position-try-fallbacks":
                 cssBox.PositionTryFallbacks = value;
+                break;
+            case "position-visibility":
+                cssBox.PositionVisibility = value;
                 break;
             case "line-height":
                 cssBox.LineHeight = value;

--- a/Broiler.Layout/Broiler.Layout/Engine/NativeAnchorPlacement.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/NativeAnchorPlacement.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Broiler.Layout.Engine;
 
 /// <summary>
@@ -15,4 +17,17 @@ internal static class NativeAnchorPlacement
 {
     [System.ThreadStatic]
     public static bool Enabled;
+
+    /// <summary>
+    /// The document's parsed <c>@position-try</c> at-rules — a name → declaration map —
+    /// for the native position-try fallback pass (P5.8d.2b position-try expansion). The
+    /// engine consumes cascaded box properties, never the stylesheet, so the
+    /// rule <em>bodies</em> (a stylesheet at-rule, not a per-element cascaded property)
+    /// must be handed in out-of-band. The caller that enables <see cref="Enabled"/> for a
+    /// layout also sets this (parsed via the canonical <c>Broiler.CSS.PositionTryRule</c>
+    /// model) and restores it afterward; <c>null</c>/empty means no fallback rules are
+    /// available, so a position-try box keeps its base placement.
+    /// </summary>
+    [System.ThreadStatic]
+    public static IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>? PositionTryRules;
 }

--- a/Broiler.Layout/Broiler.Layout/IR/FragmentTreeBuilder.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/FragmentTreeBuilder.cs
@@ -38,7 +38,15 @@ internal static class FragmentTreeBuilder
         if (!contentHidden)
         {
             foreach (var child in box.Boxes)
+            {
+                // position-visibility (P5.8d.2b): the native anchor post-pass sets
+                // PositionHidden on an anchor-positioned box whose anchor is not visible.
+                // Exclude it (and its subtree) from the paint tree after layout — the
+                // engine equivalent of the bridge writing display:none.
+                if (child.PositionHidden)
+                    continue;
                 children.Add(BuildFragment(child, hasTransformAncestor));
+            }
         }
 
         List<LineFragment>? lines = null;

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2071,9 +2071,16 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   opposing-inset sizing, abspos-inline containing blocks, intervening scroll containers, AND the
   anchor()-inset `@position-try` fallback subset now land natively — see the twelve expansions above.)
   Still bridge-only: `position-visibility` (blocked by the scroll-container CB ordering, see the finding
-  below), dialog/backdrop, and the non-anchor()-inset position-try bases (position-area base, opposing-inset
-  base, auto/min-content sizing — the engine's `TryApplyPositionTryFallback` supports these geometries but
-  the bridge gate keeps them baked pending per-case parity). Each remaining feature is currently excluded by
+  below), dialog/backdrop, and the opposing-inset / auto-min-content-sized position-try bases (the engine's
+  `TryApplyPositionTryFallback` supports these geometries but the bridge gate keeps them baked pending per-case
+  parity). **A position-area base was investigated and deliberately NOT handed off (2026-07-15):** Broiler
+  clamps an explicit position-area size to the grid cell (P5.5 `PositionAreaGrid.ResolveElementBox`) and a
+  cell is always inside the containing block, so a position-area base **never overflows** — its
+  `@position-try` fallback is therefore **inert**, and no corpus test combines the two (all four `position-try`
+  corpus tests are anchor()-inset). Extending the gate to it would move zero corpus boxes while adding
+  cross-step gate/threading complexity for a fallback that never fires; the speculative extension was written,
+  proven inert by a full-pipeline parity test (base placed at the cell, fallback never applied), and reverted.
+  Each remaining feature is currently excluded by
   `IsMvpNativeAnchorBox`/`IsMvpNativeAnchorInsetBox`/`IsMvpNativeAnchorSizeBox` (or `CanApplyNativeAnchorSize`)
   and stays on the bridge path (baked + `position-area: none` / `position-try-fallbacks: none`), so enabling
   the lever globally is already safe (proven above); the expansions widen the gate one feature at a time as

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2017,19 +2017,67 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   `~AnchorNameScope`/`~AnchorInlineContainingBlock`/`~PositionTryFallback`/`~NativeAnchor`/`~ScrollContainer`,
   18) green; **default-off byte-identical (8-fail / 31-pass)**; **lever-on unchanged (7-fail / 32-pass)** with
   the identical pre-existing anchor-tail fail *set* — zero regressions.
+- **P5.8d.2b — `@position-try` fallback (twelfth expansion) — COMPLETED** 2026-07-15
+  (branch `claude/htmlbridge-phase-5-9m00kh`; Broiler.Layout + bridge + Wpt runner, all parent-repo,
+  additive, default-off). A box in the **anchor()-inset position-try handoff subset** now selects and
+  applies its `@position-try` fallback natively — the engine equivalent of the bridge's
+  `TryApplyFallback` pre-bake, and the first non-placement feature moved off the bridge. Two grounding
+  facts from the investigation corrected the earlier "needs a new data path" assessment:
+  - **The engine already receives the parsed stylesheet.** `CssAnimationResolver.ResolveAnimations(box,
+    styleSet.AuthorStyleSheet)` (`DomParser.cs:253` call site) threads the `CssStyleSheet` (with at-rules
+    as `CssAtRule`) into layout for `@keyframes` — so at-rules *do* reach Broiler.Layout, just at the
+    per-box cascade site, not the root post-pass. This slice therefore uses a **parent-repo-only**
+    thread-static channel (mirroring the `NativeAnchorPlacement.Enabled` lever) rather than a submodule
+    edit: `NativeAnchorPlacement.PositionTryRules` (a name→declarations map), parsed via the canonical
+    `Broiler.CSS.PositionTryRule` model.
+  - **The base placement is already native.** An anchor()-inset base is placed by the P5.8d.2b
+    anchor()-insets pass, so the fallback loop just runs after it.
+  Landed:
+  - **Engine.** `CssBox.TryApplyPositionTryFallback` (`Engine/CssBox.Anchor.cs`, run from the post-pass
+    after base placement): reads the box's post-placement geometry in the CB frame, overflow-tests it via
+    the promoted `AnchorGeometry.Overflows`, and — if it overflows — walks `position-try-fallbacks`,
+    overlaying each `@position-try` rule's `left`/`right`/`top`/`bottom`/`width`/`height`/`inset:auto`
+    declarations (resolving embedded `anchor()` via the scoped `AnchorRegistry` + `AnchorGeometry.ResolveEdge`,
+    exactly as the base pass) and applying the first candidate that `AnchorGeometry.Fits` — a faithful port
+    of the bridge's `TryApplyFallback`. Reposition + (childless) resize.
+  - **Bridge.** `IsMvpNativeAnchorInsetBox` now admits position-try when `NativePositionTryHandoffSupported`
+    holds (its `@position-try` rules are available to the engine, a definite pixel `width`+`height`, single
+    inset per axis) — threaded the parsed rules into `ResolveAnchorFunctions` for the gate. In native mode
+    a handoff box is left un-baked (base + fallback owned by the engine); every other position-try box is
+    baked as today **and** neutralized inline (`position-try-fallbacks: none`) so the engine's fallback pass
+    skips the already-baked box. Both the base (step 2) and the fallback (step 3b) use the *same* predicate,
+    so the handoff/bake decision cannot disagree.
+  - **Runner.** `RenderWithNativeAnchor` parses the `@position-try` rules from the (serialised) HTML's
+    `<style>` blocks and sets the channel around the render.
+  Tests: `Broiler.Layout.Tests/NativeAnchorPlacementTests.cs` +5 (base-fits no-op, base-overflows applies
+  first fitting fallback, no-rules keeps base, `inset:auto` reset, first-fitting skips overflowing);
+  `Broiler.Cli.Tests/NativePositionTryPipelineTests.cs` (real parse→cascade→layout: fallback applied via
+  the channel; a no-rules control keeps the overflowing base) + `NativePositionTryBridgeModeTests.cs`
+  (native mode leaves the handoff box un-baked); `Broiler.Wpt.Tests/NativePositionTryWptTests.cs` (full
+  render; baked & native agree pixel-wise). Regression check: full `Broiler.Layout.Tests` (161, incl. the
+  pre-existing environmental arch-guard fail identical on baseline) green; **default-off byte-identical**
+  (the css-anchor-position subset is the same 8-fail / 31-pass, and all bridge changes are gated behind
+  `NativeAnchorPlacement`); **lever-on improves 7-fail → 6-fail** — `position-try-grid-001` (an anchor()-inset
+  + position-try test) now goes native and **passes**, with **zero regressions** (JSON failure-set diff:
+  `{+position-try-grid-001}`, nothing removed). This is the **first corpus position-try test to go native**.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
   ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → ~~inline-CB promotion (relative inline
   CB)~~ → ~~`anchor()` insets~~ → ~~`anchor-size()`~~ → ~~opposing-inset sizing~~ → ~~abspos-inline CB~~ →
-  ~~scroll simulation~~ → `position-visibility` → dialog/backdrop → position-try.
-  (Childless auto/explicit/percentage sizing, `box-sizing:border-box`, percentage margin/padding/inset box
-  props, shared-name scope resolution, writing-mode percentage basis, relatively-positioned inline
-  containing blocks, `anchor()` physical insets, `anchor-size()` sizing, opposing-inset sizing, abspos-inline
-  containing blocks, AND intervening scroll containers now land natively — see the eleven expansions above.)
-  Each remaining feature is currently excluded by
+  ~~scroll simulation~~ → `position-visibility` → dialog/backdrop → ~~position-try (anchor()-inset handoff
+  subset)~~. (Childless auto/explicit/percentage sizing, `box-sizing:border-box`, percentage
+  margin/padding/inset box props, shared-name scope resolution, writing-mode percentage basis,
+  relatively-positioned inline containing blocks, `anchor()` physical insets, `anchor-size()` sizing,
+  opposing-inset sizing, abspos-inline containing blocks, intervening scroll containers, AND the
+  anchor()-inset `@position-try` fallback subset now land natively — see the twelve expansions above.)
+  Still bridge-only: `position-visibility` (blocked by the scroll-container CB ordering, see the finding
+  below), dialog/backdrop, and the non-anchor()-inset position-try bases (position-area base, opposing-inset
+  base, auto/min-content sizing — the engine's `TryApplyPositionTryFallback` supports these geometries but
+  the bridge gate keeps them baked pending per-case parity). Each remaining feature is currently excluded by
   `IsMvpNativeAnchorBox`/`IsMvpNativeAnchorInsetBox`/`IsMvpNativeAnchorSizeBox` (or `CanApplyNativeAnchorSize`)
-  and stays on the bridge path (baked + `position-area: none`), so enabling the lever globally is already safe
-  (proven above); the expansions widen the gate one feature at a time as the engine grows to reproduce them.
+  and stays on the bridge path (baked + `position-area: none` / `position-try-fallbacks: none`), so enabling
+  the lever globally is already safe (proven above); the expansions widen the gate one feature at a time as
+  the engine grows to reproduce them.
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4
   item-2 unblock** — once every feature is on the engine path.
 
@@ -2066,20 +2114,24 @@ needs a new data path: the parsed `@position-try` name→declarations map (alrea
 `Broiler.CSS.PositionTryRule`, P5.3) must be handed to the engine's post-pass, and the fallback
 apply/re-place/re-test loop reimplemented on the box tree.
 
+**Resolved (2026-07-15) — the twelfth expansion above landed (a) + (c), grounding-corrected.** The
+"never reaches Broiler.Layout" premise was imprecise: `CssAnimationResolver.ResolveAnimations` already
+threads `styleSet.AuthorStyleSheet` (at-rules included) into layout for `@keyframes` — so the channel is a
+**parent-repo-only** thread-static (`NativeAnchorPlacement.PositionTryRules`, parsed via the canonical
+`PositionTryRule` model), no submodule edit needed. Both the per-box groundwork (below) and the rule-body
+channel (a) plus the fallback apply/re-test loop (c, `CssBox.TryApplyPositionTryFallback`) are now in place;
+(b) the native base is reused from the anchor()-inset pass. `position-try-grid-001` now goes native and
+**passes lever-on** (it was the failing example this finding cited). Remaining: the loop supports
+position-area / opposing-inset / auto-sized bases geometrically, but the bridge gate
+(`NativePositionTryHandoffSupported`) hands off only the anchor()-inset + definite-size + single-inset
+subset pending per-case parity for the other bases.
+
 **Groundwork landed (2026-07-14):** the per-box half of that input is now in place — `position-try-fallbacks`
 is projected onto `CssBox` (`CssBoxProperties.PositionTryFallbacks`, plus the `CssUtils` get/set arms), the
 P5.8b pattern applied to the fallback list. It is **inert** (nothing reads it yet — no behaviour change; the
 css-anchor-position subset is byte-identical, 31/8 default-off and 32/7 lever-on), so the box now carries the
 ordered fallback names the post-pass will consume. Test: `Broiler.Layout.Tests/AnchorPropertyProjectionTests.cs`
-(+1 theory row + round-trip). Still to build: (a) the `@position-try` **rule-body** channel from the
-bridge/runner into the post-pass (the parsed `PositionTryRule` map), (b) the base placement of a
-position-try box made native (its `position-area`/`anchor()` base must be on the engine so the fallback loop
-has a base to overflow-test), and (c) the fallback apply/re-place/re-test loop itself (reusing the promoted
-`AnchorGeometry.Overflows`/`Fits` and the engine's existing `anchor()`-inset / position-area placement).
-Until (a)–(c) land, `position-try` boxes stay gate-excluded and baked (`IsMvpNativeAnchorBox` excludes
-`position-try`); this
-is why `position-try-grid-001` — which also combines `anchor()` insets and grid abspos — fails identically
-on both the baked and native paths and is not a native-gate regression.
+(+1 theory row + round-trip). **Now consumed** by the twelfth expansion's `TryApplyPositionTryFallback`.
 
 The DOM-entangled bridge concerns (anchor registry *building* now trivial on the box tree; both the
 relatively- and absolutely-positioned inline-CB cases now handled by the engine's real §10.1 inline-box

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2110,6 +2110,19 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   Regression check: default-off byte-identical; **lever-on the css-anchor-position subset is unchanged (6 fails,
   identical set)** and `anchor-center-scroll-001` (its one corpus render test) improves **99.4 %→100 %** — the
   native centring is exact where the bridge estimator was a hair off. Zero regressions.
+- **P5.8d.2b — fixed-position sizing (fifteenth expansion) — COMPLETED** 2026-07-15
+  (branch `claude/htmlbridge-phase-5-9m00kh`; bridge only, additive, default-off). The bridge's
+  `ResolveFixedPositionSizing` pass — which pre-baked inline `width`/`height` on `position:fixed` boxes
+  from opposing insets (`top:0;bottom:0` → full height) — is now **redundant** and skipped in native mode:
+  the Broiler.Layout engine already resolves it natively (CSS2.1 §10.3.7, including the fixed→viewport
+  containing block via `FixedPositioningViewport()` and the `inset` shorthand), producing the identical
+  size, so gating the pass cannot visually regress. This is the first *general* (non-anchor) AnchorResolver
+  pass shown redundant and removed, not re-implemented. Tests: `Broiler.Cli.Tests/NativeFixedSizingTests.cs`
+  (the engine sizes a fixed opposing-inset box and the `inset` shorthand to 740×560 in an 800×600 viewport;
+  native mode leaves the box un-baked while default mode bakes inline width/height). Regression check:
+  default-off byte-identical; **lever-on the css-anchor-position subset is unchanged (6 fails, identical
+  set)** — the `position-fixed` anchor tests still pass. (This WPT checkout has no non-anchor fixed-element
+  corpus; the redundancy is proven by the engine-vs-bridge agreement.) Zero regressions.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
   ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → ~~inline-CB promotion (relative inline

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2162,6 +2162,23 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   model first (port `ApplyScrollSimulation`), which unblocks both scroll and sticky and fixes the
   flow-vs-paint hiding bug, and to do it in an environment with a sticky corpus. Left on the bridge path.
 
+  **Finding — dialog/backdrop is a renderer-submodule feature, not a parent-repo post-pass slice (2026-07-15
+  investigation).** It *is* validatable — 7 `anchor-position-top-layer-*` corpus tests, all passing — and has
+  no scroll dependency, so unlike sticky it is not blocked; but it is the largest category-2 item and is
+  structurally different from the anchor slices, which were pure post-layout *repositioning* in the parent-repo
+  engine. The bridge's `ApplyDialogUAPositioning`/`ApplyPopoverUAPositioning`/`InsertDialogBackdrops` do four
+  things a native port must reproduce: (1) **runtime state** — modality (`showModal()`), popover-open
+  (`showPopover()`), and top-layer order are bridge `ElementRuntimeState`; the engine cannot tell a modal
+  dialog from a merely-`open` one from the serialised DOM, so a native port needs a runtime-state channel /
+  markers; (2) **`::backdrop` pseudo-element generation** — a *new* box (viewport-covering scrim), which is
+  box-generation work in `Broiler.HTML`'s `DomParser` (submodule), not post-layout repositioning; (3) **a
+  top-layer paint pass** — none exists in the renderer's `PaintWalker` (submodule); the bridge fakes it with a
+  2-billion z-index; (4) **dialog UA box styles** (border/padding/background — a submodule UA-stylesheet
+  concern). So the bulk of the work is in the `Broiler.HTML` renderer submodule (box-gen + paint + UA styles),
+  delivered as patches under `patches/`, plus a parent-repo runtime-state channel — a dedicated multi-part
+  renderer effort, and all-or-nothing for parity (a partial port breaks the 7 passing tests). Best done as its
+  own submodule feature, not folded into the lever-gated anchor cutover. Left on the bridge path.
+
   Still bridge-only: dialog/backdrop, sticky, scroll simulation, visual-viewport, transform/contain CBs
   (the engine-feature set above), and the opposing-inset / auto-min-content-sized position-try bases (the engine's
   `TryApplyPositionTryFallback` supports these geometries but the bridge gate keeps them baked pending per-case

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2097,6 +2097,19 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   set — zero regressions)**. Full `Broiler.Layout.Tests` (156, the pre-existing environmental arch-guard fail
   identical on baseline) and the Cli/Wpt anchor suites green. Zero corpus gain (a parity move), but it removes the
   position-visibility `display:none` DOM write from the bridge's render path.
+- **P5.8d.2b — `anchor-center` (fourteenth expansion) — COMPLETED** 2026-07-15
+  (branch `claude/htmlbridge-phase-5-9m00kh`; Broiler.Layout + bridge, additive, default-off). The bridge's
+  `ResolveAnchorCenter` pass is now on the engine: `CssBox.TryApplyAnchorCenter` centres an
+  absolutely/fixed-positioned box with `position-anchor` and no `position-area` on its anchor —
+  `align-self: anchor-center` in the block axis, `justify-self: anchor-center` in the inline axis — using the
+  registered (scroll-shifted) anchor rect the placement passes use, so it is scroll-correct. Run from the
+  `PositionArea == "none"` branch of the post-pass after the `anchor()`-inset placement. The bridge skips
+  `ResolveAnchorCenter` in native mode (deleting its `InlineStyle["top"/"left"]` writes), leaving the
+  `align-self`/`position-anchor` CSS to survive to the engine. Tests:
+  `Broiler.Wpt.Tests/NativeAnchorCenterWptTests.cs` (full render; centred on the anchor, baked & native agree).
+  Regression check: default-off byte-identical; **lever-on the css-anchor-position subset is unchanged (6 fails,
+  identical set)** and `anchor-center-scroll-001` (its one corpus render test) improves **99.4 %→100 %** — the
+  native centring is exact where the bridge estimator was a hair off. Zero regressions.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
   ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → ~~inline-CB promotion (relative inline

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2132,9 +2132,25 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   margin/padding/inset box props, shared-name scope resolution, writing-mode percentage basis,
   relatively-positioned inline containing blocks, `anchor()` physical insets, `anchor-size()` sizing,
   opposing-inset sizing, abspos-inline containing blocks, intervening scroll containers, the
-  anchor()-inset `@position-try` fallback subset, AND `position-visibility` now land natively — see the
-  thirteen expansions above.)
-  Still bridge-only: dialog/backdrop and the opposing-inset / auto-min-content-sized position-try bases (the engine's
+  anchor()-inset `@position-try` fallback subset, `position-visibility`, `anchor-center`, AND redundant
+  fixed-position sizing now land natively — see the fifteen expansions above.)
+
+  **Triage of the remaining AnchorResolver passes (2026-07-15):** the anchor-specific, lever-gated passes
+  are now on the engine (placement MVPs, `position-visibility`, `anchor-center`). The rest are *general*
+  (non-anchor) rendering passes the bridge pre-bakes for the static renderer, and they split two ways:
+  (a) **redundant** — the engine already handles it, so the pass is just skipped in native mode
+  (`ResolveFixedPositionSizing`, done above); (b) **needs a new engine feature** — the engine genuinely
+  lacks it, so a port is engine-layout work, not a bridge extraction, and it affects *all* pages (not just
+  anchor pages) so the eventual production flip carries broad risk. Verified engine gaps:
+  `ResolveStickyPositioning` (no `position:sticky` in the engine), `ApplyScrollSimulation` (no scroll-offset
+  model — scroll is only the bridge's DOM-shift), `ApplyVisualViewportSerializationState` (no pinch-zoom /
+  `zoom`), `InsertDialogBackdrops`/`ApplyDialogUAPositioning` (no top-layer painting), and
+  `EnsureContainingBlockPositioning` (the engine's `FindPositionedContainingBlock` considers only
+  `position`, not `transform`/`contain` containing blocks). Each is its own engine feature + broad-corpus
+  parity effort, larger than a lever-gated slice.
+
+  Still bridge-only: dialog/backdrop, sticky, scroll simulation, visual-viewport, transform/contain CBs
+  (the engine-feature set above), and the opposing-inset / auto-min-content-sized position-try bases (the engine's
   `TryApplyPositionTryFallback` supports these geometries but the bridge gate keeps them baked pending per-case
   parity). **A position-area base was investigated and deliberately NOT handed off (2026-07-15):** Broiler
   clamps an explicit position-area size to the grid cell (P5.5 `PositionAreaGrid.ResolveElementBox`) and a

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2109,6 +2109,41 @@ pre-`position:relative` CB view exactly — e.g. compute the anchor-visibility C
 (pre-native) positioning, or drive the whole hiding decision from a snapshot the bridge hands to the
 engine — before the bridge's `ResolvePositionVisibility` can be skipped. Left on the bridge path for now.
 
+**Root cause proven (2026-07-15) — the two cases are indistinguishable in the final DOM the engine sees.**
+Empirically: `position-visibility-anchors-visible.html` (a **static** scroll container that becomes the
+target's position-area CB) references a render where the target is **hidden**; `-with-position.html` (an
+**authored `position:relative`** scroll container) references one where the target is **shown**. The *only*
+difference is the scroller's authored `position`. In native mode the bridge injects inline `position:relative`
+on the static scroller (for placement + the scroll-simulation expansion), so **both** documents reach the
+engine with the scroller `position:relative` — the box tree, the CB chain, and the box-tree ancestry are then
+identical for the two, yet they require opposite visibility results. No amount of engine-side geometry can
+separate them from the final DOM alone; the authored distinction has been erased. (The engine also has **no
+scroll-offset property** — scroll is modelled only by the bridge's `ApplyScrollSimulation` DOM-shift — so the
+visibility geometry must be read from shifted box positions + `overflow` clip rects, not a scroll value.)
+
+**Actionable design for the port (so a future focused effort can execute it):**
+1. **Signal the anchor-induced CB.** When the bridge applies deferred `position:relative` to a *previously
+   unpositioned* scroll container (`scrollContainersNeedingRelative`, step 3e), in native mode also stamp a
+   benign metadata attribute (e.g. `data-broiler-anchor-cb`) on it. This is the one bit the engine cannot
+   re-derive; an authored-`relative` scroller (`-with-position`) is *not* stamped, so the two cases separate.
+2. **Engine visibility pass.** Project `position-visibility` onto `CssBox`; in the anchor post-pass, for each
+   anchor-positioned target compute anchor visibility over the box tree — `visibility:hidden` inheritance, and
+   whether the anchor's (scroll-shifted) border box lies within the visible clip rect of each `overflow`-clipping
+   ancestor that is an ancestor of the anchor but **not** of the target's CB — where a `data-broiler-anchor-cb`
+   scroller is treated as **not** the CB (i.e. still intervening), reproducing the bridge's pre-`position:relative`
+   view. Hide by suppressing the box (`Display = "none"` is honoured at `CssBox.cs:655`, but verify a post-layout
+   set actually removes it from paint; otherwise add a paint-skip flag).
+3. **Skip the bridge pass in native mode**, deleting the `InlineStyle(el)["display"]="none"` write (the Phase 4
+   item-2 concern). Default-off keeps `ResolvePositionVisibility` byte-identical.
+4. **Parity bar:** all **14** `position-visibility` corpus tests pass default-off today, so the port must keep
+   14/14 lever-on (chained-001/002/003, both/position-fixed, css-visibility, stacked-child, after-scroll-out,
+   anchors-valid, initial, and the static/relative/JS-override scroller trio). This is the hard part — the
+   bridge uses *estimated* offsets (`ComputeNaturalOffsetInContainer`) while the engine has real geometry, so
+   each case must be re-validated, not assumed.
+This is a coordinated re-architecture (a new bridge→engine metadata channel + a geometric visibility pass +
+14-test parity), not a behaviour-preserving extraction — larger than one slice, and still zero corpus gain.
+Left on the bridge path.
+
 **Finding — `position-try` needs the `@position-try` rules plumbed into the engine first (2026-07-14
 assessment).** The bridge's `TryApplyFallback` (`PositionTry.cs`) selects a fallback by (1) reading the
 box's already-**baked** base `left`/`top`/`width`/`height` inline styles, (2) testing overflow, then (3)

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2149,6 +2149,19 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   `position`, not `transform`/`contain` containing blocks). Each is its own engine feature + broad-corpus
   parity effort, larger than a lever-gated slice.
 
+  **Finding — `position:sticky` is blocked here (2026-07-15 investigation).** Three compounding blockers make
+  a responsible port infeasible in this environment: (1) **no corpus** — this WPT checkout has zero sticky
+  render tests, so there is nothing to validate parity against (position-visibility had 14). (2) **The
+  native-vs-baked parity model is unusable because the reference is buggy** — a sticky box inside a scrolled
+  container is wrongly hidden by `ApplyScrollSimulation`'s clip loop, which marks it `visibility:hidden`
+  using its *flow* position (y=0) rather than its pinned *paint* position (probe: the box pins correctly to
+  `Y=10` but serialises with `visibility:hidden`+`data-broiler-scroll-hidden`). Matching the bridge would
+  reproduce that bug. (3) **Scroll-model dependency** — sticky is inherently scroll-dependent and the engine
+  has no scroll-offset model; it is coupled to `ApplyScrollSimulation` (itself an unported bridge pass whose
+  DOM-shift is the only scroll representation). The correct sequence is to give the engine a real scroll
+  model first (port `ApplyScrollSimulation`), which unblocks both scroll and sticky and fixes the
+  flow-vs-paint hiding bug, and to do it in an environment with a sticky corpus. Left on the bridge path.
+
   Still bridge-only: dialog/backdrop, sticky, scroll simulation, visual-viewport, transform/contain CBs
   (the engine-feature set above), and the opposing-inset / auto-min-content-sized position-try bases (the engine's
   `TryApplyPositionTryFallback` supports these geometries but the bridge gate keeps them baked pending per-case

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2060,18 +2060,55 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   `NativeAnchorPlacement`); **lever-on improves 7-fail → 6-fail** — `position-try-grid-001` (an anchor()-inset
   + position-try test) now goes native and **passes**, with **zero regressions** (JSON failure-set diff:
   `{+position-try-grid-001}`, nothing removed). This is the **first corpus position-try test to go native**.
+- **P5.8d.2b — `position-visibility` (thirteenth expansion) — COMPLETED** 2026-07-15
+  (branch `claude/htmlbridge-phase-5-9m00kh`; Broiler.Layout + bridge, both parent-repo, additive,
+  default-off). The **first non-placement, non-position-try bridge pass moved to the engine**, and the
+  resolution of the finding below (which had said "left on the bridge path"). An anchor-positioned target
+  whose anchor is not visible is now hidden by the Broiler.Layout engine's post-pass
+  (`CssBox.ResolvePositionVisibility`) instead of the bridge writing `display:none` — the roadmap's target
+  behaviour for the Phase 4 item-2 unblock. Landed:
+  - **Engine.** `position-visibility` is projected onto `CssBox` (default sentinel **`"normal"`** = unset, so
+    an unset position-area target takes the implicit anchors-visible — `position-visibility-initial` — while an
+    explicit `always` never hides — `-remove-anchors-visible`). A new `CssBox.Visibility.cs` pass walks each
+    target: authored `visibility:hidden` inheritance, a hidden (`PositionHidden`) subtree (chained anchors), a
+    fixed anchor (never clipped), and otherwise whether the anchor is scrolled out of an **intervening** clip
+    container — a clip ancestor of the anchor that is not the target's (visibility) containing block.
+    `anchors-valid` hides when no `position-anchor`/`anchor()` names a registered anchor. Hiding uses a new
+    post-layout `CssBox.PositionHidden` flag that `FragmentTreeBuilder` excludes from the paint tree (no
+    `display:none` — `display:none` is only honoured *during* layout).
+  - **The CB-ordering fix (the reverted-attempt blocker).** The bridge decides visibility *before* it applies
+    anchor-induced `position:relative` to a scroll-container CB, so a **static** scroller's scrolled-out anchor
+    hides its target while an authored **`position:relative`** scroller's does not — but both reach the engine
+    with the scroller `position:relative`. The bridge now stamps `data-broiler-anchor-cb` on scrollers it makes
+    relative (step 3e) **and** on the scroll-simulation offset wrapper; the engine's visibility CB skips stamped
+    boxes, so a stamped (anchor-induced) scroller stays intervening while an authored-relative scroller is the CB
+    → the two cases separate. A second marker, `data-broiler-scroll-hidden`, tags the `visibility:hidden` the
+    scroll simulation injects to clip scrolled-out content, so the engine treats it as "scrolled out" (subject to
+    the CB exception) rather than authored `visibility:hidden`. (Also: the engine's clip-container test now
+    recognises the two-value `overflow: hidden scroll` shorthand the cascade stores un-normalised.)
+  - **Bridge.** `ResolvePositionVisibility` is skipped in native mode (deleting the `InlineStyle["display"]="none"`
+    write); the two markers are stamped only in native mode.
+  Tests: `Broiler.Wpt.Tests/NativePositionVisibilityWptTests.cs` (full render: static scroller hides the target,
+  authored-relative scroller shows it, baked & native agree). Regression check: **all 14 `position-visibility`
+  corpus tests pass lever-on** (they passed via the bridge before; now via the engine — chained-001/002/003,
+  both/position-fixed, css-visibility, stacked-child ×2, after-scroll-out, anchors-valid, initial, and the
+  static/relative/JS-override scroller trio) and **default-off (14/14, byte-identical)**; the full
+  css-anchor-position subset is **byte-identical default-off (31/8)** and **lever-on unchanged (6 fails, identical
+  set — zero regressions)**. Full `Broiler.Layout.Tests` (156, the pre-existing environmental arch-guard fail
+  identical on baseline) and the Cli/Wpt anchor suites green. Zero corpus gain (a parity move), but it removes the
+  position-visibility `display:none` DOM write from the bridge's render path.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
   ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → ~~inline-CB promotion (relative inline
   CB)~~ → ~~`anchor()` insets~~ → ~~`anchor-size()`~~ → ~~opposing-inset sizing~~ → ~~abspos-inline CB~~ →
-  ~~scroll simulation~~ → `position-visibility` → dialog/backdrop → ~~position-try (anchor()-inset handoff
+  ~~scroll simulation~~ → ~~`position-visibility`~~ → dialog/backdrop → ~~position-try (anchor()-inset handoff
   subset)~~. (Childless auto/explicit/percentage sizing, `box-sizing:border-box`, percentage
   margin/padding/inset box props, shared-name scope resolution, writing-mode percentage basis,
   relatively-positioned inline containing blocks, `anchor()` physical insets, `anchor-size()` sizing,
-  opposing-inset sizing, abspos-inline containing blocks, intervening scroll containers, AND the
-  anchor()-inset `@position-try` fallback subset now land natively — see the twelve expansions above.)
-  Still bridge-only: `position-visibility` (blocked by the scroll-container CB ordering, see the finding
-  below), dialog/backdrop, and the opposing-inset / auto-min-content-sized position-try bases (the engine's
+  opposing-inset sizing, abspos-inline containing blocks, intervening scroll containers, the
+  anchor()-inset `@position-try` fallback subset, AND `position-visibility` now land natively — see the
+  thirteen expansions above.)
+  Still bridge-only: dialog/backdrop and the opposing-inset / auto-min-content-sized position-try bases (the engine's
   `TryApplyPositionTryFallback` supports these geometries but the bridge gate keeps them baked pending per-case
   parity). **A position-area base was investigated and deliberately NOT handed off (2026-07-15):** Broiler
   clamps an explicit position-area size to the grid cell (P5.5 `PositionAreaGrid.ResolveElementBox`) and a
@@ -2087,6 +2124,12 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   the engine grows to reproduce them.
 - **Then** thin/delete the now-unreached bridge `AnchorResolver` inline-dict writes — the **Phase 4
   item-2 unblock** — once every feature is on the engine path.
+
+**Finding — `position-visibility` is entangled with the scroll-container CB decision — RESOLVED 2026-07-15
+(see the thirteenth expansion above; the design below was executed and all 14 corpus tests pass lever-on).**
+The `data-broiler-anchor-cb` marker (on both the anchor-induced-relative scroller and the scroll-sim wrapper)
+plus a `data-broiler-scroll-hidden` marker for the sim's injected `visibility:hidden` gave the engine exactly
+the pre-`position:relative` CB view the decision needs. The original analysis is kept below for context.
 
 **Finding — `position-visibility` is entangled with the scroll-container CB decision (2026-07-14
 investigation; the naive engine port was tried and reverted after two lever-on regressions).** A native

--- a/src/Broiler.Cli.Tests/NativeFixedSizingTests.cs
+++ b/src/Broiler.Cli.Tests/NativeFixedSizingTests.cs
@@ -1,0 +1,88 @@
+using System.Drawing;
+using Broiler.HtmlBridge;
+using Broiler.HTML.Image;
+using Broiler.JavaScript.Engine;
+using Broiler.Layout;
+using DomDocument = Broiler.Dom.DomDocument;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Verifies the Phase 5 native fixed-position sizing cutover (P5.8d.2b): the bridge's
+/// <c>ResolveFixedPositionSizing</c> pre-bake (inline width/height from opposing insets) is
+/// redundant because the Broiler.Layout engine resolves it natively (CSS2.1 §10.3.7, including the
+/// fixed→viewport containing block and the <c>inset</c> shorthand). In native mode the bridge skips
+/// the pass and leaves the CSS for the engine; the two paths agree.
+/// </summary>
+[Xunit.Collection("SharedGeometryStatics")]
+public sealed class NativeFixedSizingTests
+{
+    private const string Url = "file:///fixed.html";
+
+    // A fixed box sized purely by opposing insets (no explicit width/height).
+    private const string OpposingInsetHtml =
+        "<!DOCTYPE html><html><head><style>body{margin:0}" +
+        "#f{position:fixed;top:20px;bottom:20px;left:30px;right:30px;background:red}" +
+        "</style></head><body><div id='f'></div></body></html>";
+
+    private const string InsetShorthandHtml =
+        "<!DOCTYPE html><html><head><style>body{margin:0}" +
+        "#f{position:fixed;inset:20px 30px;background:red}" +
+        "</style></head><body><div id='f'></div></body></html>";
+
+    private static BoxGeometry EngineLayout(string html)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, Url);
+        DomDocument document = bridge.GetRenderDocument();
+        using var container = new HtmlContainer
+        {
+            Location = new PointF(0, 0),
+            AvoidAsyncImagesLoading = true,
+            AvoidImagesLateLoading = true,
+        };
+        container.SetDocumentWithStyleSet(document, baseUrl: Url);
+        var geometry = container.GetLayoutGeometry(new SizeF(800, 600));
+        return geometry[document.GetElementById("f")!];
+    }
+
+    [Fact]
+    public void EngineSizesFixedBox_FromOpposingInsets()
+    {
+        // 800x600 viewport, insets top/bottom 20, left/right 30 → 740x560 at (30,20).
+        var box = EngineLayout(OpposingInsetHtml);
+        Assert.Equal(740f, box.BorderBox.Width, 1);
+        Assert.Equal(560f, box.BorderBox.Height, 1);
+        Assert.Equal(30f, box.BorderBox.Left, 1);
+        Assert.Equal(20f, box.BorderBox.Top, 1);
+    }
+
+    [Fact]
+    public void EngineSizesFixedBox_FromInsetShorthand()
+    {
+        var box = EngineLayout(InsetShorthandHtml);
+        Assert.Equal(740f, box.BorderBox.Width, 1);
+        Assert.Equal(560f, box.BorderBox.Height, 1);
+    }
+
+    [Fact]
+    public void NativeMode_DoesNotBakeFixedSize_ButDefaultModeDoes()
+    {
+        static string ResolveAndSerialize(bool native)
+        {
+            using var context = new JSContext();
+            var bridge = new DomBridge { NativeAnchorPlacement = native };
+            bridge.Attach(context, OpposingInsetHtml, Url);
+            bridge.ResolveAnchorPositions();
+            return bridge.SerializeToHtml();
+        }
+
+        // Default mode pre-bakes explicit width/height inline; native mode leaves the box to the
+        // engine (no baked width/height), so its inset CSS drives the engine's §10.3.7 sizing.
+        Assert.Contains("width", ResolveAndSerialize(native: false));
+        var native = ResolveAndSerialize(native: true);
+        Assert.DoesNotContain("width:", native);
+        Assert.DoesNotContain("height:", native);
+    }
+}

--- a/src/Broiler.Cli.Tests/NativePositionTryBridgeModeTests.cs
+++ b/src/Broiler.Cli.Tests/NativePositionTryBridgeModeTests.cs
@@ -1,0 +1,50 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Verifies the bridge half of the native <c>@position-try</c> cutover (Phase 5,
+/// P5.8d.2b position-try expansion): with <c>DomBridge.NativeAnchorPlacement</c> on, a
+/// box in the anchor()-inset position-try handoff subset (definite size, single inset per
+/// axis, its <c>@position-try</c> rules available) keeps its <c>anchor()</c> base and
+/// <c>position-try-fallbacks</c> CSS through serialization — the engine's post-pass owns
+/// both the base placement and the fallback. Default off reproduces today's behaviour
+/// (the box is pre-baked and the anchor CSS neutralized), keeping production unchanged.
+/// </summary>
+public sealed class NativePositionTryBridgeModeTests
+{
+    private const string Url = "file:///native-position-try-mode.html";
+
+    private const string Html =
+        "<!DOCTYPE html><html><head><style>" +
+        "body { margin: 0; }" +
+        "#cb { position: relative; width: 100px; height: 100px; }" +
+        "#anchor { position: absolute; left: 70px; top: 70px; width: 20px; height: 20px; anchor-name: --a; }" +
+        "#target { position: absolute; width: 30px; height: 30px;" +
+        " left: anchor(--a right); top: anchor(--a bottom); position-try-fallbacks: --flip; }" +
+        "@position-try --flip { left: auto; right: anchor(--a left); top: auto; bottom: anchor(--a top); }" +
+        "</style></head><body><div id='cb'><div id='anchor'></div><div id='target'></div></div></body></html>";
+
+    private static string ResolveAndSerialize(bool nativeMode)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge { NativeAnchorPlacement = nativeMode };
+        bridge.Attach(context, Html, Url);
+        bridge.ResolveAnchorPositions();
+        return bridge.SerializeToHtml();
+    }
+
+    [Fact]
+    public void NativeMode_PreservesAnchorAndPositionTryCss()
+    {
+        var html = ResolveAndSerialize(nativeMode: true);
+        // Un-baked: the engine post-pass needs the base anchor() and the @position-try rule
+        // to survive to the render.
+        Assert.Contains("anchor(", html);
+        Assert.Contains("@position-try", html);
+        // The handoff box's position-try was NOT neutralized (that suppression is only for
+        // baked, non-handoff boxes).
+        Assert.DoesNotContain("position-try-fallbacks: none", html);
+    }
+}

--- a/src/Broiler.Cli.Tests/NativePositionTryPipelineTests.cs
+++ b/src/Broiler.Cli.Tests/NativePositionTryPipelineTests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using System.Drawing;
+using Broiler.HtmlBridge;
+using Broiler.HTML.Image;
+using Broiler.JavaScript.Engine;
+using Broiler.Layout;
+using Broiler.Layout.Engine;
+using DomDocument = Broiler.Dom.DomDocument;
+using DomElement = Broiler.Dom.DomElement;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// End-to-end validation that the Broiler.Layout engine's native <c>@position-try</c>
+/// fallback pass (Phase 5, P5.8d.2b position-try expansion) selects and applies a
+/// fallback through the real parse → cascade → layout pipeline — the engine equivalent
+/// of the bridge's <c>TryApplyFallback</c> pre-bake. The <c>@position-try</c> rule bodies
+/// reach the engine via the out-of-band <see cref="NativeAnchorPlacement.PositionTryRules"/>
+/// channel (a stylesheet at-rule never reaches the cascaded box properties).
+/// </summary>
+[Xunit.Collection("SharedGeometryStatics")]
+public sealed class NativePositionTryPipelineTests
+{
+    private const string Url = "file:///native-position-try.html";
+
+    // #cb is the containing block (relative, 100x100 at the origin). #anchor is a 20x20 box
+    // at (70,70) → left/top 70, right/bottom 90. #target is a 30x30 abspos box whose base
+    // left/top are anchor(--a right)/anchor(--a bottom) → base border box at (90,90), which
+    // overflows the 100-wide CB. The @position-try fallback flips it to the anchor's
+    // opposite edges → (40,40), which fits.
+    private const string Html =
+        "<!DOCTYPE html><html><head><style>" +
+        "body { margin: 0; }" +
+        "#cb { position: relative; width: 100px; height: 100px; }" +
+        "#anchor { position: absolute; left: 70px; top: 70px; width: 20px; height: 20px; anchor-name: --a; }" +
+        "#target { position: absolute; width: 30px; height: 30px;" +
+        " left: anchor(--a right); top: anchor(--a bottom); position-try-fallbacks: --flip; }" +
+        "@position-try --flip { left: auto; right: anchor(--a left); top: auto; bottom: anchor(--a top); }" +
+        "</style></head><body><div id='cb'><div id='anchor'></div><div id='target'></div></div></body></html>";
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> FlipRule =
+        new Dictionary<string, IReadOnlyDictionary<string, string>>
+        {
+            ["--flip"] = new Dictionary<string, string>
+            {
+                ["left"] = "auto",
+                ["right"] = "anchor(--a left)",
+                ["top"] = "auto",
+                ["bottom"] = "anchor(--a top)",
+            },
+        };
+
+    private static BoxGeometry LayoutTarget(
+        bool nativeAnchor,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>? rules)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, Html, Url);
+        DomDocument document = bridge.GetRenderDocument();
+
+        using var container = new HtmlContainer
+        {
+            Location = new PointF(0, 0),
+            AvoidAsyncImagesLoading = true,
+            AvoidImagesLateLoading = true,
+        };
+        container.SetDocumentWithStyleSet(document, baseUrl: Url);
+
+        IReadOnlyDictionary<DomElement, BoxGeometry> geometry;
+        try
+        {
+            NativeAnchorPlacement.Enabled = nativeAnchor;
+            NativeAnchorPlacement.PositionTryRules = rules;
+            geometry = container.GetLayoutGeometry(new SizeF(800, 600));
+        }
+        finally
+        {
+            NativeAnchorPlacement.Enabled = false;
+            NativeAnchorPlacement.PositionTryRules = null;
+        }
+
+        var target = document.GetElementById("target");
+        Assert.NotNull(target);
+        Assert.True(geometry.ContainsKey(target!), "target box has no geometry");
+        return geometry[target!];
+    }
+
+    [Fact]
+    public void NativeFlagOn_WithRules_AppliesFallback_ToFittingPosition()
+    {
+        var box = LayoutTarget(nativeAnchor: true, rules: FlipRule);
+        Assert.Equal(40f, box.BorderBox.Left, 1);
+        Assert.Equal(40f, box.BorderBox.Top, 1);
+        Assert.Equal(30f, box.BorderBox.Width, 1);
+        Assert.Equal(30f, box.BorderBox.Height, 1);
+    }
+
+    [Fact]
+    public void NativeFlagOn_WithoutRules_KeepsOverflowingBase()
+    {
+        // No @position-try rule bodies handed to the engine → the overflowing base placement
+        // (90,90) is kept, proving the fallback move is the channel-fed pass's doing.
+        var box = LayoutTarget(nativeAnchor: true, rules: null);
+        Assert.Equal(90f, box.BorderBox.Left, 1);
+        Assert.Equal(90f, box.BorderBox.Top, 1);
+    }
+
+    [Fact]
+    public void NativeFlagOff_LeavesBoxUnplaced()
+    {
+        // Flag off → the engine cannot parse anchor() as a length, so #target sits at its
+        // static/zero-inset position, not the fallback (40,40) or base (90,90).
+        var box = LayoutTarget(nativeAnchor: false, rules: FlipRule);
+        Assert.False(
+            System.Math.Abs(box.BorderBox.Left - 40f) < 1 && System.Math.Abs(box.BorderBox.Top - 40f) < 1,
+            $"box was unexpectedly at the fallback position without the native flag: {box.BorderBox}");
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
@@ -16,7 +16,8 @@ public sealed partial class DomBridge
     // canonical Broiler.CSS.AnchorFunction model (Phase 5 item 4). These callbacks
     // keep only the used-value geometry; AnchorFunction.Rewrite/RewriteSize supply
     // the parsed AnchorFunctionRef/AnchorSizeFunctionRef.
-    private void ResolveAnchorFunctions(DomElement element, Dictionary<string, AnchorInfo> anchorRegistry)
+    private void ResolveAnchorFunctions(DomElement element, Dictionary<string, AnchorInfo> anchorRegistry,
+        Dictionary<string, Dictionary<string, string>>? positionTryRules = null)
     {
         var cssProps = CollectMatchedRuleProperties(element);
 
@@ -42,7 +43,7 @@ public sealed partial class DomBridge
         // post-pass resolves it natively (see CssBox.TryApplyAnchorInsetPlacement). Every
         // other anchor() box is baked below.
         if (hasAnchorRef && NativeAnchorPlacement &&
-            IsMvpNativeAnchorInsetBox(element, cssProps, anchorRegistry))
+            IsMvpNativeAnchorInsetBox(element, cssProps, anchorRegistry, positionTryRules))
             hasAnchorRef = false;
 
         if (hasAnchorRef)
@@ -162,7 +163,7 @@ public sealed partial class DomBridge
         // throws "Collection was modified" (WPT content-visibility-anchor-positioning)
         // or overflows the ToList() copy. SnapshotChildren tolerates both.
         foreach (var child in SnapshotChildren(element))
-            ResolveAnchorFunctions(child, anchorRegistry);
+            ResolveAnchorFunctions(child, anchorRegistry, positionTryRules);
     }
 
     /// <summary>
@@ -177,7 +178,8 @@ public sealed partial class DomBridge
     /// </summary>
     private bool IsMvpNativeAnchorInsetBox(
         DomElement element, Dictionary<string, string> cssProps,
-        Dictionary<string, AnchorInfo> anchorRegistry)
+        Dictionary<string, AnchorInfo> anchorRegistry,
+        Dictionary<string, Dictionary<string, string>>? positionTryRules = null)
     {
         // Merge inline styles over matched-rule props (inline wins), matching what the
         // engine cascade projects onto the box.
@@ -185,8 +187,13 @@ public sealed partial class DomBridge
         foreach (var kv in InlineStyle(element))
             merged[kv.Key] = kv.Value;
 
-        // No position-try (out of the MVP subset).
-        if (merged.ContainsKey("position-try-fallbacks") || merged.ContainsKey("position-try"))
+        // position-try is admitted only for the tight subset the engine's native fallback
+        // pass reproduces (P5.8d.2b position-try expansion): the @position-try rule bodies
+        // must be available to the engine (the channel) and the box's base must be a
+        // definite-size, single-inset-per-axis reposition. Otherwise the box (base +
+        // fallback) stays fully baked on the bridge path.
+        if ((merged.ContainsKey("position-try-fallbacks") || merged.ContainsKey("position-try"))
+            && !NativePositionTryHandoffSupported(merged, positionTryRules))
             return false;
 
         // Fixed / modal-dialog targets get a document-scroll adjustment the engine MVP
@@ -271,6 +278,50 @@ public sealed partial class DomBridge
     /// opposing pair of insets determines the used size.</summary>
     private static bool IsAutoLength(string? value) =>
         string.IsNullOrWhiteSpace(value) || value!.Trim() == "auto";
+
+    /// <summary>
+    /// Whether an anchor()-inset box's <c>position-try</c> is the tight subset the engine's
+    /// native fallback pass (<c>CssBox.TryApplyPositionTryFallback</c>) reproduces exactly,
+    /// so the bridge can hand off the box (base + fallback) instead of pre-baking it. Requires:
+    /// the parsed <c>@position-try</c> rules are available to the engine and every referenced
+    /// fallback name resolves to one; a definite pixel <c>width</c> AND <c>height</c> (the
+    /// engine overflow-tests the laid-out size, which for an <c>auto</c>/<c>min-content</c>
+    /// width would need the bridge's min-content estimator the engine has no equivalent for);
+    /// and no opposing insets on the base (single inset per axis — the base is a
+    /// reposition-only anchor()-inset placement). Every other position-try box stays baked.
+    /// </summary>
+    private bool NativePositionTryHandoffSupported(
+        Dictionary<string, string> merged,
+        Dictionary<string, Dictionary<string, string>>? positionTryRules)
+    {
+        if (positionTryRules == null || positionTryRules.Count == 0)
+            return false;
+
+        string? fallbacks = merged.GetValueOrDefault("position-try-fallbacks")
+            ?? merged.GetValueOrDefault("position-try");
+        if (string.IsNullOrWhiteSpace(fallbacks))
+            return false;
+        var names = PositionTryRule.ParseFallbackList(fallbacks);
+        if (names.Length == 0)
+            return false;
+        foreach (var name in names)
+            if (!positionTryRules.ContainsKey(name))
+                return false;
+
+        // Definite pixel width AND height (the engine reads the laid-out size for its overflow
+        // test; a non-px width has no bridge-matching engine size).
+        if (!TryParsePx(merged.GetValueOrDefault("width")).HasValue ||
+            !TryParsePx(merged.GetValueOrDefault("height")).HasValue)
+            return false;
+
+        // No opposing insets — the base is a single-inset-per-axis reposition.
+        if (HasInset(merged, "left") && HasInset(merged, "right"))
+            return false;
+        if (HasInset(merged, "top") && HasInset(merged, "bottom"))
+            return false;
+
+        return true;
+    }
 
     /// <summary>
     /// Whether an element's <c>anchor-size()</c> sizing is the MVP subset the engine's native

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -65,8 +65,11 @@ public sealed partial class DomBridge
         // 1b. Parse @position-try at-rules from stylesheets.
         var positionTryRules = ParsePositionTryRules();
 
-        // 2. Resolve anchor() function values on elements.
-        ResolveAnchorFunctions(DocumentElement, anchorRegistry);
+        // 2. Resolve anchor() function values on elements. Native mode passes the
+        //    parsed @position-try rules so the anchor()-inset MVP gate can hand off a
+        //    position-try box only when the engine has its fallback rules (via the
+        //    NativeAnchorPlacement.PositionTryRules channel).
+        ResolveAnchorFunctions(DocumentElement, anchorRegistry, positionTryRules);
 
         // 3. Resolve position-area values on anchored elements.
         //    Collects scroll containers that need position:relative but

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -85,8 +85,11 @@ public sealed partial class DomBridge
             deferredDomMoves);
 
         // 3a2. Resolve align-self/justify-self: anchor-center on elements
-        //      that have position-anchor but no position-area.
-        ResolveAnchorCenter(DocumentElement, anchorRegistry);
+        //      that have position-anchor but no position-area. Native mode (P5.8d.2b) centres
+        //      these in the engine post-pass (CssBox.TryApplyAnchorCenter) instead, so the
+        //      align-self/justify-self + position-anchor CSS survives to the render un-baked.
+        if (!NativeAnchorPlacement)
+            ResolveAnchorCenter(DocumentElement, anchorRegistry);
 
         // 3b. Resolve position-try-fallbacks for elements whose base
         //     style overflows the containing block.

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -145,9 +145,13 @@ public sealed partial class DomBridge
             anchorRegistry, positionTryRules);
 
         // 5. Ensure fixed-position elements from CSS have explicit pixel
-        //    dimensions (the Broiler renderer does not resolve width/height
-        //    from opposing inset values).
-        ResolveFixedPositionSizing(viewportWidth, viewportHeight);
+        //    dimensions from opposing inset values (e.g. top:0;bottom:0). Native mode (P5.8d.2b)
+        //    relies on the Broiler.Layout engine, which resolves this natively (CSS2.1 §10.3.7,
+        //    incl. the fixed→viewport containing block and the `inset` shorthand — verified to
+        //    agree with this pre-bake), so the bridge pass is redundant and skipped, removing its
+        //    inline width/height/inset writes.
+        if (!NativeAnchorPlacement)
+            ResolveFixedPositionSizing(viewportWidth, viewportHeight);
 
         // 6. Ensure elements that establish containing blocks via non-position
         //    properties (contain:layout, transform) get position:relative so the

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -93,8 +93,12 @@ public sealed partial class DomBridge
         ResolvePositionTryFallbacks(DocumentElement, anchorRegistry, positionTryRules);
 
         // 3c. Resolve position-visibility: hide anchor-positioned elements
-        //     whose anchor is not visible or does not exist.
-        ResolvePositionVisibility(DocumentElement, anchorRegistry);
+        //     whose anchor is not visible or does not exist. Native mode (P5.8d.2b) resolves
+        //     this in the Broiler.Layout engine post-pass instead (CssBox.ResolvePositionVisibility),
+        //     so the bridge stops writing display:none; the scroll-container marker stamped in
+        //     step 3e gives the engine the pre-position:relative CB view the decision needs.
+        if (!NativeAnchorPlacement)
+            ResolvePositionVisibility(DocumentElement, anchorRegistry);
 
         // 3d. Apply deferred DOM moves (inline CB → block ancestor promotion).
         //     Must be done after all position-area resolution is complete
@@ -121,7 +125,15 @@ public sealed partial class DomBridge
                 (scPos == "relative" || scPos == "absolute" ||
                  scPos == "fixed" || scPos == "sticky");
             if (!alreadyPositioned)
+            {
                 InlineStyle(sc)["position"] = "relative";
+                // Native mode: mark this scroller so the engine's position-visibility pass knows
+                // its position:relative is anchor-induced (not authored) and must still count as an
+                // intervening clip container — reproducing the bridge's pre-position:relative CB
+                // view without which a static-scroller target would be wrongly kept visible.
+                if (NativeAnchorPlacement)
+                    SetAttr(sc, "data-broiler-anchor-cb", "1");
+            }
         }
 
         // 4. Insert backdrop elements for modal dialogs.

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
@@ -69,7 +69,27 @@ public sealed partial class DomBridge
 
             if (!string.IsNullOrWhiteSpace(fallbacks) && positionTryRules.Count > 0)
             {
-                TryApplyFallback(element, cssProps, anchorRegistry, positionTryRules, fallbacks!);
+                // Native mode (P5.8d.2b position-try expansion): a box in the anchor()-inset
+                // position-try handoff subset had its base left un-baked in
+                // ResolveAnchorFunctions (same IsMvpNativeAnchorInsetBox predicate); the
+                // engine's post-pass applies the fallback from the PositionTryRules channel,
+                // so skip baking and leave the position-try + anchor() CSS intact. Every other
+                // position-try box is baked here and, in native mode, has its position-try
+                // neutralized inline so the engine's fallback pass skips the already-baked box.
+                if (NativeAnchorPlacement &&
+                    IsMvpNativeAnchorInsetBox(element, cssProps, anchorRegistry, positionTryRules))
+                {
+                    // handed off to the engine — the bridge does not touch this box
+                }
+                else
+                {
+                    TryApplyFallback(element, cssProps, anchorRegistry, positionTryRules, fallbacks!);
+                    if (NativeAnchorPlacement)
+                    {
+                        InlineStyle(element)["position-try-fallbacks"] = "none";
+                        InlineStyle(element)["position-try"] = "normal";
+                    }
+                }
             }
         }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
@@ -55,6 +55,13 @@ public sealed partial class DomBridge
                     // spacers can leak above the container's top edge.
                     var wrapper = CreateBridgeElement("div");
                     InlineStyle(wrapper)["position"] = "relative";
+                    // Native mode: this scroll-offset wrapper is a rendering hack, not an authored
+                    // containing block, so mark it (like an anchor-induced-relative scroller) — the
+                    // engine's position-visibility pass must resolve a target's CB to the real
+                    // authored scroll container, not this wrapper (else an authored position:relative
+                    // scroller's target is wrongly hidden — position-visibility-anchors-visible-with-position).
+                    if (NativeAnchorPlacement)
+                        SetAttr(wrapper, "data-broiler-anchor-cb", "1");
                     if (scrollTop != 0)
                         InlineStyle(wrapper)["top"] =
                             $"{(-scrollTop).ToString(CultureInfo.InvariantCulture)}px";
@@ -115,6 +122,13 @@ public sealed partial class DomBridge
                             if (childOffset + childH <= scrollTop)
                             {
                                 InlineStyle(child)["visibility"] = "hidden";
+                                // Native mode: this visibility:hidden is a scroll-clip hack, not an
+                                // authored value — mark it so the engine's position-visibility pass
+                                // does not mistake a scrolled-out anchor for an authored
+                                // visibility:hidden anchor (which would hide the target even when its
+                                // CB is the scroller — position-visibility-anchors-visible-with-position).
+                                if (NativeAnchorPlacement)
+                                    SetAttr(child, "data-broiler-scroll-hidden", "1");
                                 childOffset += childH;
                             }
                             else

--- a/src/Broiler.Wpt.Tests/NativeAnchorCenterWptTests.cs
+++ b/src/Broiler.Wpt.Tests/NativeAnchorCenterWptTests.cs
@@ -1,0 +1,98 @@
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// End-to-end proof of the Phase 5 native <c>anchor-center</c> cutover (P5.8d.2b) through the full
+/// WPT render pipeline. With the runner lever on, the bridge stops baking
+/// <c>align-self</c>/<c>justify-self: anchor-center</c> and the Broiler.Layout engine's post-pass
+/// (<c>CssBox.TryApplyAnchorCenter</c>) centres the box on its anchor. Baked (lever-off) and native
+/// (lever-on) paths agree.
+///
+/// Fixture: a 40×40 anchor at (100,100) → centre (120,120); a 20×20 red target with both
+/// <c>align-self</c> and <c>justify-self: anchor-center</c> → centred at (120,120), i.e. the box
+/// occupies (110,110)–(129,129).
+/// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
+public class NativeAnchorCenterWptTests : IDisposable
+{
+    private readonly bool _previousLever = WptTestRunner.NativeAnchorPlacement;
+
+    public void Dispose()
+    {
+        WptTestRunner.NativeAnchorPlacement = _previousLever;
+        Program.ResetTestHooks();
+    }
+
+    private const string Html = @"<!DOCTYPE html><meta charset=""utf-8"">
+<style>
+  body { margin: 0; }
+  #cb { position: relative; width: 300px; height: 300px; }
+  #anchor { position: absolute; left: 100px; top: 100px; width: 40px; height: 40px; anchor-name: --a; }
+  #target { position: absolute; position-anchor: --a; align-self: anchor-center; justify-self: anchor-center;
+            left: 0; top: 0; width: 20px; height: 20px; background: #ff0000; }
+</style>
+<div id=""cb""><div id=""anchor""></div><div id=""target""></div></div>";
+
+    private static (int x0, int y0, int x1, int y1, int count) RedBox(BBitmap bmp, int w, int h)
+    {
+        int x0 = int.MaxValue, y0 = int.MaxValue, x1 = -1, y1 = -1, count = 0;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                var p = bmp.GetPixel(x, y);
+                if (p.R > 200 && p.G < 80 && p.B < 80)
+                {
+                    count++;
+                    if (x < x0) x0 = x;
+                    if (y < y0) y0 = y;
+                    if (x > x1) x1 = x;
+                    if (y > y1) y1 = y;
+                }
+            }
+        return (x0, y0, x1, y1, count);
+    }
+
+    private static (int x0, int y0, int x1, int y1, int count) Render(bool nativeAnchor)
+    {
+        WptTestRunner.NativeAnchorPlacement = nativeAnchor;
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-native-anchor-center-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "mvp.html");
+            File.WriteAllText(file, Html);
+            var runner = new WptTestRunner(400, 400);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+            return RedBox(bmp, 400, 400);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void NativeLeverOn_CentresBoxOnAnchor()
+    {
+        var red = Render(nativeAnchor: true);
+        Assert.True(red.count > 0, "red target box not painted under the native lever.");
+        Assert.True(System.Math.Abs(red.x0 - 110) <= 2, $"red left={red.x0}, expected ~110.");
+        Assert.True(System.Math.Abs(red.y0 - 110) <= 2, $"red top={red.y0}, expected ~110.");
+        Assert.True(System.Math.Abs(red.x1 - 129) <= 2, $"red right={red.x1}, expected ~129.");
+        Assert.True(System.Math.Abs(red.y1 - 129) <= 2, $"red bottom={red.y1}, expected ~129.");
+    }
+
+    [Fact]
+    public void BridgeAndEnginePaths_Agree_OnAnchorCenter()
+    {
+        var baked = Render(nativeAnchor: false);
+        var native = Render(nativeAnchor: true);
+        Assert.True(baked.count > 0 && native.count > 0, "target box missing in one of the paths.");
+        Assert.True(System.Math.Abs(baked.x0 - native.x0) <= 2, $"left differs: baked={baked.x0}, native={native.x0}.");
+        Assert.True(System.Math.Abs(baked.y0 - native.y0) <= 2, $"top differs: baked={baked.y0}, native={native.y0}.");
+        Assert.True(System.Math.Abs(baked.x1 - native.x1) <= 2, $"right differs: baked={baked.x1}, native={native.x1}.");
+        Assert.True(System.Math.Abs(baked.y1 - native.y1) <= 2, $"bottom differs: baked={baked.y1}, native={native.y1}.");
+    }
+}

--- a/src/Broiler.Wpt.Tests/NativePositionTryWptTests.cs
+++ b/src/Broiler.Wpt.Tests/NativePositionTryWptTests.cs
@@ -1,0 +1,110 @@
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// End-to-end proof of the Phase 5 native <c>@position-try</c> cutover (P5.8d.2b) through the
+/// full WPT render pipeline (<see cref="WptTestRunner.RenderHtmlFileBitmapPublic"/>: parse →
+/// DomBridge anchor resolution → serialize → engine layout → raster).
+///
+/// With the runner lever on, the bridge does <em>not</em> pre-bake a box in the anchor()-inset
+/// position-try handoff subset (its <c>anchor()</c> base and <c>position-try-fallbacks</c>
+/// survive serialization); the box is placed by the Broiler.Layout engine's post-pass, which
+/// fed the parsed <c>@position-try</c> rule bodies via the
+/// <c>NativeAnchorPlacement.PositionTryRules</c> channel selects and applies the first fitting
+/// fallback (<c>CssBox.TryApplyPositionTryFallback</c>). The same fixture with the lever off
+/// (the bridge's <c>TryApplyFallback</c> pre-bakes) lands the box in the same place, so the two
+/// paths agree.
+///
+/// Fixture: a 100×100 <c>position:relative</c> CB; a uniquely-named anchor <c>--a</c> (20×20 at
+/// (70,70)); a 30×30 red target whose base <c>left/top</c> are <c>anchor(--a right)</c>/
+/// <c>anchor(--a bottom)</c> → base at (90,90), which overflows the CB. The <c>@position-try
+/// --flip</c> rule flips to the anchor's opposite edges → the red box lands at (40,40)–(69,69).
+/// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
+public class NativePositionTryWptTests : IDisposable
+{
+    private readonly bool _previousLever = WptTestRunner.NativeAnchorPlacement;
+
+    public void Dispose()
+    {
+        WptTestRunner.NativeAnchorPlacement = _previousLever;
+        Program.ResetTestHooks();
+    }
+
+    private const string Html = @"<!DOCTYPE html><meta charset=""utf-8"">
+<style>
+  body { margin: 0; }
+  #cb { position: relative; width: 100px; height: 100px; }
+  #anchor { position: absolute; left: 70px; top: 70px; width: 20px; height: 20px; anchor-name: --a; }
+  #target { position: absolute; width: 30px; height: 30px; left: anchor(--a right); top: anchor(--a bottom);
+            position-try-fallbacks: --flip; background: #ff0000; }
+  @position-try --flip { left: auto; right: anchor(--a left); top: auto; bottom: anchor(--a top); }
+</style>
+<div id=""cb""><div id=""anchor""></div><div id=""target""></div></div>";
+
+    private static (int x0, int y0, int x1, int y1, int count) RedBox(BBitmap bmp, int w, int h)
+    {
+        int x0 = int.MaxValue, y0 = int.MaxValue, x1 = -1, y1 = -1, count = 0;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                var p = bmp.GetPixel(x, y);
+                if (p.R > 200 && p.G < 80 && p.B < 80)
+                {
+                    count++;
+                    if (x < x0) x0 = x;
+                    if (y < y0) y0 = y;
+                    if (x > x1) x1 = x;
+                    if (y > y1) y1 = y;
+                }
+            }
+        return (x0, y0, x1, y1, count);
+    }
+
+    private static (int x0, int y0, int x1, int y1, int count) Render(bool nativeAnchor)
+    {
+        WptTestRunner.NativeAnchorPlacement = nativeAnchor;
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-native-position-try-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "mvp.html");
+            File.WriteAllText(file, Html);
+
+            var runner = new WptTestRunner(400, 400);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+            return RedBox(bmp, 400, 400);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void NativeLeverOn_EngineAppliesFallback_ToFittingPosition()
+    {
+        var red = Render(nativeAnchor: true);
+
+        Assert.True(red.count > 0, "red target box not painted under the native lever.");
+        Assert.True(System.Math.Abs(red.x0 - 40) <= 2, $"red left={red.x0}, expected ~40 (fallback).");
+        Assert.True(System.Math.Abs(red.y0 - 40) <= 2, $"red top={red.y0}, expected ~40 (fallback).");
+        Assert.True(System.Math.Abs(red.x1 - 69) <= 2, $"red right={red.x1}, expected ~69.");
+        Assert.True(System.Math.Abs(red.y1 - 69) <= 2, $"red bottom={red.y1}, expected ~69.");
+    }
+
+    [Fact]
+    public void BridgeAndEnginePaths_Agree_OnPositionTryFallback()
+    {
+        var baked = Render(nativeAnchor: false);
+        var native = Render(nativeAnchor: true);
+
+        Assert.True(baked.count > 0 && native.count > 0, "target box missing in one of the paths.");
+        Assert.True(System.Math.Abs(baked.x0 - native.x0) <= 2, $"left differs: baked={baked.x0}, native={native.x0}.");
+        Assert.True(System.Math.Abs(baked.y0 - native.y0) <= 2, $"top differs: baked={baked.y0}, native={native.y0}.");
+        Assert.True(System.Math.Abs(baked.x1 - native.x1) <= 2, $"right differs: baked={baked.x1}, native={native.x1}.");
+        Assert.True(System.Math.Abs(baked.y1 - native.y1) <= 2, $"bottom differs: baked={baked.y1}, native={native.y1}.");
+    }
+}

--- a/src/Broiler.Wpt.Tests/NativePositionVisibilityWptTests.cs
+++ b/src/Broiler.Wpt.Tests/NativePositionVisibilityWptTests.cs
@@ -1,0 +1,98 @@
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// End-to-end proof of the Phase 5 native <c>position-visibility</c> cutover (P5.8d.2b) through the
+/// full WPT render pipeline. With the runner lever on, the bridge stops resolving
+/// <c>position-visibility</c> (no <c>display:none</c> write) and the Broiler.Layout engine's
+/// post-pass (<c>CssBox.ResolvePositionVisibility</c>) hides an anchor-positioned target whose
+/// anchor is scrolled out of an <em>intervening</em> clip container.
+///
+/// The two fixtures differ only in the scroll container's authored <c>position</c> — the exact case
+/// the bridge's pre-<c>position:relative</c> ordering distinguishes and the engine reproduces via the
+/// <c>data-broiler-anchor-cb</c> marker:
+/// - a <b>static</b> scroll container is not the target's CB, so its scrolled-out anchor is an
+///   intervening clip → the target is <b>hidden</b>;
+/// - an authored <b>position:relative</b> scroll container IS the target's CB → no intervening clip →
+///   the target is <b>shown</b>, even though the anchor is scrolled out.
+/// Both the baked (lever-off) and native (lever-on) paths agree.
+/// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
+public class NativePositionVisibilityWptTests : IDisposable
+{
+    private readonly bool _previousLever = WptTestRunner.NativeAnchorPlacement;
+
+    public void Dispose()
+    {
+        WptTestRunner.NativeAnchorPlacement = _previousLever;
+        Program.ResetTestHooks();
+    }
+
+    // A 100x100 red target anchored (position-area: bottom right) to a 100x100 anchor at the top of a
+    // 300x100 scroll container, scrolled down 100px so the anchor is scrolled out. {0} is the scroll
+    // container's position.
+    private const string Template = @"<!DOCTYPE html><meta charset=""utf-8"">
+<style>
+  body {{ margin: 0; }}
+  #sc {{ overflow: hidden scroll; width: 300px; height: 100px; {0} }}
+  #anchor {{ anchor-name: --a1; width: 100px; height: 100px; background: orange; }}
+  #spacer {{ height: 100px; }}
+  #target {{ position-anchor: --a1; position-visibility: anchors-visible; position-area: bottom right;
+             width: 100px; height: 100px; background: #ff0000; position: absolute; top: 0; left: 0; }}
+</style>
+<div id=""sc""><div id=""anchor"">anchor</div><div id=""spacer""></div><div id=""target"">target</div></div>
+<script>document.getElementById('sc').scrollTop = 100;</script>";
+
+    private static int RedCount(BBitmap bmp, int w, int h)
+    {
+        int count = 0;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                var p = bmp.GetPixel(x, y);
+                if (p.R > 200 && p.G < 80 && p.B < 80)
+                    count++;
+            }
+        return count;
+    }
+
+    private static int RenderRedCount(bool nativeAnchor, string scrollContainerPosition)
+    {
+        WptTestRunner.NativeAnchorPlacement = nativeAnchor;
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-native-posvis-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "mvp.html");
+            File.WriteAllText(file, string.Format(Template, scrollContainerPosition));
+            var runner = new WptTestRunner(400, 400);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+            return RedCount(bmp, 400, 400);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void NativeLeverOn_StaticScroller_HidesTarget()
+    {
+        // Intervening clip → hidden. Baked path hides it too, so both agree on "no red".
+        Assert.Equal(0, RenderRedCount(nativeAnchor: true, ""));
+        Assert.Equal(0, RenderRedCount(nativeAnchor: false, ""));
+    }
+
+    [Fact]
+    public void NativeLeverOn_RelativeScroller_ShowsTarget()
+    {
+        // The scroller IS the target's CB → no intervening clip → shown (red present) under both
+        // the native and baked paths.
+        Assert.True(RenderRedCount(nativeAnchor: true, "position: relative;") > 0,
+            "target should be visible under the native lever with a position:relative scroller.");
+        Assert.True(RenderRedCount(nativeAnchor: false, "position: relative;") > 0,
+            "target should be visible under the baked path with a position:relative scroller.");
+    }
+}

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -307,7 +307,7 @@ internal sealed class WptTestResult
 /// through the Broiler HTML/JavaScript stack and comparing the output to
 /// a Chromium/Playwright reference image.
 /// </summary>
-internal sealed class WptTestRunner
+internal sealed partial class WptTestRunner
 {
     /// <summary>
     /// When set, the stub <c>promise_test</c> does NOT run its bodies before the
@@ -1487,7 +1487,7 @@ internal sealed class WptTestRunner
         HTML.Image.BBitmap rendered;
         try
         {
-            rendered = RenderWithNativeAnchor(() => HtmlRender.RenderToImageWithStyleSet(html, _width, _height,
+            rendered = RenderWithNativeAnchor(html, () => HtmlRender.RenderToImageWithStyleSet(html, _width, _height,
                 backgroundColor: BColor.White,
                 stylesheetLoad: stylesheetHandler, imageLoad: imageHandler, baseUrl: testBaseUrl));
         }
@@ -1774,7 +1774,7 @@ internal sealed class WptTestRunner
             };
         }
 
-        return RenderWithNativeAnchor(() => HtmlRender.RenderToImageWithStyleSet(html, _width, _height,
+        return RenderWithNativeAnchor(html, () => HtmlRender.RenderToImageWithStyleSet(html, _width, _height,
             backgroundColor: BColor.White,
             stylesheetLoad: stylesheetHandler, imageLoad: imageHandler, baseUrl: testBaseUrl));
     }
@@ -1784,23 +1784,56 @@ internal sealed class WptTestRunner
     /// anchor-placement post-pass enabled iff the runner lever is on (P5.8d.2b). The
     /// engine flag is <c>[ThreadStatic]</c>, so enabling it here scopes it to this one
     /// render on this thread — the earlier bridge geometry snapshots are unaffected.
+    /// The document's <c>@position-try</c> rule bodies (parsed from <paramref name="html"/>)
+    /// are handed to the engine's post-pass via the same thread-static channel, since a
+    /// stylesheet at-rule never reaches the cascaded box properties the engine reads
+    /// (P5.8d.2b position-try expansion).
     /// </summary>
-    private static HTML.Image.BBitmap RenderWithNativeAnchor(Func<HTML.Image.BBitmap> render)
+    private static HTML.Image.BBitmap RenderWithNativeAnchor(string html, Func<HTML.Image.BBitmap> render)
     {
         if (!NativeAnchorPlacement)
             return render();
 
-        var previous = Broiler.Layout.Engine.NativeAnchorPlacement.Enabled;
+        var previousEnabled = Broiler.Layout.Engine.NativeAnchorPlacement.Enabled;
+        var previousRules = Broiler.Layout.Engine.NativeAnchorPlacement.PositionTryRules;
         Broiler.Layout.Engine.NativeAnchorPlacement.Enabled = true;
+        Broiler.Layout.Engine.NativeAnchorPlacement.PositionTryRules = ParsePositionTryRulesFromHtml(html);
         try
         {
             return render();
         }
         finally
         {
-            Broiler.Layout.Engine.NativeAnchorPlacement.Enabled = previous;
+            Broiler.Layout.Engine.NativeAnchorPlacement.Enabled = previousEnabled;
+            Broiler.Layout.Engine.NativeAnchorPlacement.PositionTryRules = previousRules;
         }
     }
+
+    /// <summary>
+    /// Extracts the document's <c>@position-try</c> rules (name → declarations) from the
+    /// serialised HTML's <c>&lt;style&gt;</c> blocks, using the canonical
+    /// <c>Broiler.CSS.PositionTryRule</c> parser (the same model the bridge uses). Later
+    /// duplicates win, in document order — matching the bridge's accumulator.
+    /// </summary>
+    private static IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>? ParsePositionTryRulesFromHtml(string html)
+    {
+        if (string.IsNullOrEmpty(html) || html.IndexOf("@position-try", StringComparison.OrdinalIgnoreCase) < 0)
+            return null;
+
+        var result = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal);
+        foreach (Match m in StyleBlockRegex().Matches(html))
+        {
+            var css = m.Groups["css"].Value;
+            if (css.IndexOf("@position-try", StringComparison.OrdinalIgnoreCase) < 0)
+                continue;
+            foreach (var rule in Broiler.CSS.PositionTryRule.Parse(css))
+                result[rule.Key] = rule.Value;
+        }
+        return result.Count > 0 ? result : null;
+    }
+
+    [GeneratedRegex(@"<style[^>]*>(?<css>.*?)</style>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex StyleBlockRegex();
 
     internal HTML.Image.BBitmap RenderHtmlFileBitmapPublic(string htmlPath, string? wptRoot)
     {


### PR DESCRIPTION
## Summary

Completes three Phase 5 anchor positioning features by moving them from the bridge's pre-bake to the Broiler.Layout engine's post-pass: `@position-try` fallback selection, `align-self`/`justify-self: anchor-center` centering, and `position-visibility` anchor-hiding. These are the first non-placement anchor features moved off the bridge, reducing bridge complexity and improving correctness through native CSS resolution.

## Key Changes

### Engine (Broiler.Layout)

- **`@position-try` fallback selection** (`CssBox.TryApplyPositionTryFallback`): After base anchor placement, if the box overflows its containing block, walks the `position-try-fallbacks` list and applies the first `@position-try` rule that fits. Rule bodies arrive via the out-of-band `NativeAnchorPlacement.PositionTryRules` channel (a stylesheet at-rule never reaches cascaded box properties). Resolves embedded `anchor()` functions using the scoped `AnchorRegistry`, matching the bridge's `TryApplyFallback` pre-bake.

- **`anchor-center` alignment** (`CssBox.TryApplyAnchorCenter`): Centres an absolutely/fixed-positioned box on its anchor per `align-self: anchor-center` (block axis) / `justify-self: anchor-center` (inline axis). Applies only to boxes with `position-anchor` and no `position-area`. Uses the registered (scroll-shifted) anchor geometry for scroll-correct centering.

- **`position-visibility` resolution** (`CssBox.ResolvePositionVisibility`, new `CssBox.Visibility.cs`): Hides an anchor-positioned target whose anchor is not visible — either `visibility:hidden`, missing (`anchors-valid`), or scrolled out of an *intervening* clip container (`anchors-visible`). Hiding uses a new post-layout `CssBox.PositionHidden` flag that `FragmentTreeBuilder` excludes from the paint tree (no `display:none` write).

- **CB-ordering fix**: The bridge decides visibility before applying anchor-induced `position:relative` to scroll containers, so a static scroller's scrolled-out anchor hides its target while an authored `position:relative` scroller's does not. The bridge now stamps `data-broiler-anchor-cb` on scrollers it makes relative; the engine's visibility CB skips stamped boxes, reproducing the bridge's pre-relative ordering. A second marker, `data-broiler-scroll-hidden`, tags the scroll simulation's `visibility:hidden` so the engine treats it as "scrolled out" rather than authored hiding.

- **New `CssBox` properties**: `PositionVisibility` (default sentinel `"normal"` = unset), `PositionHidden` flag (post-layout hiding), `PositionTry`, `PositionTryFallbacks`.

- **`AnchorRegistry` extension**: `Contains()` and `ResolveScope<T>()` methods for anchor name lookup and scope resolution.

### Bridge (Broiler.HtmlBridge.Dom)

- **`IsMvpNativeAnchorInsetBox` gate expansion**: Now admits `position-try` when `NativePositionTryHandoffSupported` holds — the box has definite `width`+`height`, single inset per axis, and its `@position-try` rules are available to the engine (threaded via `ResolveAnchorFunctions`).

- **Handoff vs. bake decision**: In native mode, a handoff box is left un-baked (base + fallback owned by the engine); every other position-try box is baked as today and neutralized inline (`position-try-fallbacks: none`) so the engine's fallback pass skips it. Both base and fallback use the same predicate, preventing disagreement.

- **`@position-try` rule parsing**: `ParsePositionTryRules()` extracts at-rules from stylesheets and threads them to `ResolveAnchorFunctions` for the handoff gate. The runner (`WptTestRunner`) parses

https://claude.ai/code/session_01799YxTTwzuvPAeyw4bw7Pq