### PR TITLE
Phase 5 P5.8d.2b: native transform/contain/will-change CB & scroll

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
@@ -646,17 +646,20 @@ public sealed class NativeAnchorPlacementTests
     }
 
     [Theory]
-    [InlineData("translateX(10px)", "none")]
-    [InlineData("rotate(5deg)", "none")]
-    [InlineData("none", "layout")]
-    [InlineData("none", "paint")]
-    [InlineData("none", "strict")]
-    [InlineData("none", "content")]
-    public void Pass_TransformOrContainCb_IsResolvedNatively_WhenFlagOn(string transform, string contain)
+    [InlineData("translateX(10px)", "none", "auto")]
+    [InlineData("rotate(5deg)", "none", "auto")]
+    [InlineData("none", "layout", "auto")]
+    [InlineData("none", "paint", "auto")]
+    [InlineData("none", "strict", "auto")]
+    [InlineData("none", "content", "auto")]
+    [InlineData("none", "none", "transform")]          // will-change: transform
+    [InlineData("none", "none", "opacity, transform")] // will-change list containing transform
+    public void Pass_TransformOrContainCb_IsResolvedNatively_WhenFlagOn(string transform, string contain, string willChange)
     {
         var (root, cb) = NonPositionCbFixture(out var target);
         cb.Transform = transform;
         cb.Contain = contain;
+        cb.WillChange = willChange;
 
         try
         {
@@ -697,23 +700,27 @@ public sealed class NativeAnchorPlacementTests
     }
 
     [Theory]
-    [InlineData("none", "none", false)]
-    [InlineData("translateX(1px)", "none", true)]
-    [InlineData("rotate(1deg)", "none", true)]
-    [InlineData("", "none", false)]
-    [InlineData("none", "layout", true)]
-    [InlineData("none", "paint", true)]
-    [InlineData("none", "strict", true)]
-    [InlineData("none", "content", true)]
-    [InlineData("none", "size", false)]       // size containment alone does not establish a CB
-    [InlineData("none", "", false)]
+    [InlineData("none", "none", "auto", false)]
+    [InlineData("translateX(1px)", "none", "auto", true)]
+    [InlineData("rotate(1deg)", "none", "auto", true)]
+    [InlineData("", "none", "auto", false)]
+    [InlineData("none", "layout", "auto", true)]
+    [InlineData("none", "paint", "auto", true)]
+    [InlineData("none", "strict", "auto", true)]
+    [InlineData("none", "content", "auto", true)]
+    [InlineData("none", "size", "auto", false)]       // size containment alone does not establish a CB
+    [InlineData("none", "", "auto", false)]
+    [InlineData("none", "none", "transform", true)]           // will-change: transform
+    [InlineData("none", "none", "opacity, transform", true)]  // will-change list containing transform
+    [InlineData("none", "none", "opacity", false)]            // will-change without transform
     public void EstablishesNonPositionAbsPosContainingBlock_MirrorsBridgePredicate(
-        string transform, string contain, bool expected)
+        string transform, string contain, string willChange, bool expected)
     {
         var root = Box(null, new PointF(0, 0), new SizeF(100, 100));
         var b = Box(root, new PointF(0, 0), new SizeF(10, 10));
         b.Transform = transform;
         b.Contain = contain;
+        b.WillChange = willChange;
         Assert.Equal(expected, b.EstablishesNonPositionAbsPosContainingBlock());
     }
 

--- a/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/NativeAnchorPlacementTests.cs
@@ -619,6 +619,105 @@ public sealed class NativeAnchorPlacementTests
     }
 
     // ------------------------------------------------------------------
+    // transform / contain containing block (P5.8d.2b transform/contain CB expansion)
+    // ------------------------------------------------------------------
+
+    // CB 200×200 at (100,100) that establishes an abspos containing block through a
+    // NON-position property (the caller sets Transform or Contain); it is NOT
+    // position:relative. Anchor --a is a 20×20 box at (140,140) → right/bottom (160,160).
+    // Returns a childless auto-size (fill-the-cell) bottom-right target at the origin: when
+    // the CB is recognised, the box fills the [160..300]×[160..300] cell (140×140 at
+    // (160,160)); when it is NOT, the containing block climbs to the 1000×1000 root and the
+    // box fills the far larger [160..1000]² cell — so the used SIZE discriminates the two.
+    private static (CssBox root, CssBox cb) NonPositionCbFixture(out CssBox target)
+    {
+        var root = Box(null, new PointF(0, 0), new SizeF(1000, 1000));
+        root.Display = "block"; // so an abspos box climbing to the root resolves the viewport
+                                //  (not the root's inline bounding box), discriminating the two paths
+        var cb = Box(root, new PointF(100, 100), new SizeF(200, 200));
+        cb.Display = "block"; // a real (non-inline) block, but NOT positioned
+        var anchor = Box(cb, new PointF(140, 140), new SizeF(20, 20));
+        anchor.AnchorName = "--a";
+        target = Box(cb, new PointF(0, 0), new SizeF(0, 0));
+        target.Position = "absolute";
+        target.PositionArea = "bottom right";
+        target.PositionAnchor = "--a";
+        return (root, cb);
+    }
+
+    [Theory]
+    [InlineData("translateX(10px)", "none")]
+    [InlineData("rotate(5deg)", "none")]
+    [InlineData("none", "layout")]
+    [InlineData("none", "paint")]
+    [InlineData("none", "strict")]
+    [InlineData("none", "content")]
+    public void Pass_TransformOrContainCb_IsResolvedNatively_WhenFlagOn(string transform, string contain)
+    {
+        var (root, cb) = NonPositionCbFixture(out var target);
+        cb.Transform = transform;
+        cb.Contain = contain;
+
+        try
+        {
+            NativeAnchorPlacement.Enabled = true;
+            CssBox.RunNativeAnchorPlacement(root);
+        }
+        finally { NativeAnchorPlacement.Enabled = false; }
+
+        // The CB is the 200×200 box at (100,100), so the bottom-right cell is
+        // [160..300]×[160..300] = 140×140 at (160,160) — not the root-based cell.
+        Assert.Equal(160, target.Location.X, 3);
+        Assert.Equal(160, target.Location.Y, 3);
+        Assert.Equal(140, target.Size.Width, 3);
+        Assert.Equal(140, target.Size.Height, 3);
+    }
+
+    [Fact]
+    public void Pass_PlainStaticCb_ClimbsToRoot_NotRecognizedAsContainingBlock()
+    {
+        // Control: a plain static block (no transform, no containment) does NOT establish an
+        // abspos containing block, so the target resolves against the 1000×1000 root and
+        // fills the far larger [160..1000]² cell — proving the transform/contain recognition
+        // above is what binds the box to the inner block.
+        var (root, cb) = NonPositionCbFixture(out var target);
+        _ = cb;
+
+        try
+        {
+            NativeAnchorPlacement.Enabled = true;
+            CssBox.RunNativeAnchorPlacement(root);
+        }
+        finally { NativeAnchorPlacement.Enabled = false; }
+
+        Assert.Equal(160, target.Location.X, 3);
+        Assert.Equal(160, target.Location.Y, 3);
+        Assert.Equal(840, target.Size.Width, 3);
+        Assert.Equal(840, target.Size.Height, 3);
+    }
+
+    [Theory]
+    [InlineData("none", "none", false)]
+    [InlineData("translateX(1px)", "none", true)]
+    [InlineData("rotate(1deg)", "none", true)]
+    [InlineData("", "none", false)]
+    [InlineData("none", "layout", true)]
+    [InlineData("none", "paint", true)]
+    [InlineData("none", "strict", true)]
+    [InlineData("none", "content", true)]
+    [InlineData("none", "size", false)]       // size containment alone does not establish a CB
+    [InlineData("none", "", false)]
+    public void EstablishesNonPositionAbsPosContainingBlock_MirrorsBridgePredicate(
+        string transform, string contain, bool expected)
+    {
+        var root = Box(null, new PointF(0, 0), new SizeF(100, 100));
+        var b = Box(root, new PointF(0, 0), new SizeF(10, 10));
+        b.Transform = transform;
+        b.Contain = contain;
+        Assert.Equal(expected, b.EstablishesNonPositionAbsPosContainingBlock());
+    }
+
+    // ------------------------------------------------------------------
     // @position-try fallback (P5.8d.2b position-try expansion)
     // ------------------------------------------------------------------
 

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
@@ -67,6 +67,17 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             if (box.Position is CssConstants.Relative or CssConstants.Absolute or CssConstants.Fixed || box.ParentBox == null)
                 return box;
 
+            // Native anchor mode (P5.8d.2b transform/contain CB expansion): a box that
+            // establishes a containing block for absolutely-positioned descendants through a
+            // non-position property — a non-none transform (CSS Transforms 1 §4) or
+            // contain: layout/paint/strict/content (CSS Containment §2) — is that containing
+            // block. On the baked path the bridge's EnsureContainingBlockPositioning pre-bakes
+            // position:relative onto the same boxes, so the position check above already
+            // returns them; recognising them here lets native mode drop that pre-bake. Gated
+            // by the native-anchor lever so default-off layout is byte-identical.
+            if (NativeAnchorPlacement.Enabled && box.EstablishesNonPositionAbsPosContainingBlock())
+                return box;
+
             // RF-BRIDGE-1b Track 3.2: a nested browsing context's sub-viewport
             // (#subdoc-root) is the initial containing block for its subtree, so an
             // absolutely-positioned descendant with no positioned ancestor resolves
@@ -88,6 +99,32 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     }
 
     private bool IsInitialContainingBlock(CssBox cb) => cb.ParentBox == null && LayoutEnvironment != null;
+
+    /// <summary>
+    /// Whether this box establishes a containing block for absolutely-positioned
+    /// descendants through a property other than <c>position</c> — a non-<c>none</c>
+    /// <c>transform</c> (CSS Transforms 1 §4) or a <c>contain</c> value of
+    /// <c>layout</c>/<c>paint</c>/<c>strict</c>/<c>content</c> (CSS Containment §2).
+    /// Mirrors the subset of the bridge's <c>EstablishesContainingBlock</c> that the engine
+    /// models natively; <c>will-change</c> is not projected onto the box, so a
+    /// will-change-only containing block stays on the bridge path. Consulted by
+    /// <see cref="FindPositionedContainingBlock"/> only under the native-anchor lever.
+    /// </summary>
+    internal bool EstablishesNonPositionAbsPosContainingBlock()
+    {
+        if (!string.IsNullOrWhiteSpace(Transform)
+            && !string.Equals(Transform, "none", System.StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (!string.IsNullOrWhiteSpace(Contain))
+        {
+            var c = Contain.ToLowerInvariant();
+            if (c.Contains("layout") || c.Contains("paint") || c.Contains("strict") || c.Contains("content"))
+                return true;
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// RF-BRIDGE-1b Track 3.2: the viewport a <c>position:fixed</c> descendant of this

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
@@ -103,11 +103,12 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     /// <summary>
     /// Whether this box establishes a containing block for absolutely-positioned
     /// descendants through a property other than <c>position</c> — a non-<c>none</c>
-    /// <c>transform</c> (CSS Transforms 1 §4) or a <c>contain</c> value of
-    /// <c>layout</c>/<c>paint</c>/<c>strict</c>/<c>content</c> (CSS Containment §2).
-    /// Mirrors the subset of the bridge's <c>EstablishesContainingBlock</c> that the engine
-    /// models natively; <c>will-change</c> is not projected onto the box, so a
-    /// will-change-only containing block stays on the bridge path. Consulted by
+    /// <c>transform</c> (CSS Transforms 1 §4), a <c>contain</c> value of
+    /// <c>layout</c>/<c>paint</c>/<c>strict</c>/<c>content</c> (CSS Containment §2), or
+    /// <c>will-change: transform</c> (CSS Will Change 1 §3 — a will-change hint for a
+    /// property that would itself create one). Mirrors the bridge's
+    /// <c>EstablishesContainingBlock</c> exactly (minus the <c>position</c> branch handled
+    /// by the caller), so the two paths agree. Consulted by
     /// <see cref="FindPositionedContainingBlock"/> only under the native-anchor lever.
     /// </summary>
     internal bool EstablishesNonPositionAbsPosContainingBlock()
@@ -122,6 +123,10 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             if (c.Contains("layout") || c.Contains("paint") || c.Contains("strict") || c.Contains("content"))
                 return true;
         }
+
+        if (!string.IsNullOrWhiteSpace(WillChange)
+            && WillChange.Contains("transform", System.StringComparison.OrdinalIgnoreCase))
+            return true;
 
         return false;
     }

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Scroll.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Scroll.cs
@@ -1,0 +1,67 @@
+using System.Globalization;
+using Broiler.CSS;
+
+namespace Broiler.Layout.Engine;
+
+/// <summary>
+/// Native scroll-offset placement (HtmlBridge complexity-reduction roadmap Phase 5,
+/// P5.8d.2b scroll expansion). A root post-pass — run after the main single-pass
+/// layout, before <see cref="CssBox.RunNativeAnchorPlacement"/> — that shifts the
+/// content of each scroll container the bridge marked with
+/// <see cref="ScrollTopAttr"/>/<see cref="ScrollLeftAttr"/> by the negative scroll
+/// offset, so a script-set <c>scrollTop</c>/<c>scrollLeft</c> renders natively instead
+/// of via the bridge's DOM-shift wrapper. The container's own <c>overflow</c> clip
+/// (applied at paint) clips the shifted content.
+/// </summary>
+/// <remarks>
+/// Gated by <see cref="NativeAnchorPlacement.Enabled"/> (default off), so this is inert
+/// until the cutover. The bridge marks a container only when the document has no anchor
+/// content (see <c>DomBridge.ApplyScrollSimulationTree</c>), so this pass never
+/// interacts with the anchor-scroll-container / position-visibility machinery, which
+/// keeps the bridge's DOM-shift.
+/// </remarks>
+partial class CssBox
+{
+    internal const string ScrollTopAttr = "data-broiler-scroll-top";
+    internal const string ScrollLeftAttr = "data-broiler-scroll-left";
+
+    /// <summary>
+    /// Entry point for the scroll post-pass, invoked from <c>PerformLayout</c> at the
+    /// document root when the flag is on.
+    /// </summary>
+    internal static void RunScrollSimulation(CssBox root) => ApplyScrollSimulation(root);
+
+    private static void ApplyScrollSimulation(CssBox box)
+    {
+        double top = ParseScrollOffset(box.GetAttribute(ScrollTopAttr));
+        double left = ParseScrollOffset(box.GetAttribute(ScrollLeftAttr));
+
+        if (top != 0 || left != 0)
+        {
+            // Shift the container's in-flow content up/left by the scroll offset. OffsetTop/
+            // OffsetLeft translate a box and its whole subtree and already skip position:fixed
+            // descendants (CSS2.1 §9.6.1), matching the bridge's fixed handling; the container
+            // box itself stays put, so its overflow box clips the shifted content.
+            foreach (var child in box.Boxes)
+            {
+                if (child.Position == CssConstants.Fixed)
+                    continue;
+                if (top != 0)
+                    child.OffsetTop(-top);
+                if (left != 0)
+                    child.OffsetLeft(-left);
+            }
+        }
+
+        // Recurse so nested scroll containers compose (each shifts its own content, on top
+        // of any shift an ancestor already applied to it).
+        foreach (var child in box.Boxes)
+            ApplyScrollSimulation(child);
+    }
+
+    private static double ParseScrollOffset(string? value) =>
+        !string.IsNullOrEmpty(value)
+        && double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var v)
+            ? v
+            : 0;
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -387,7 +387,12 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             // post-pass — every anchor now has final geometry — gated off by default.
             // Runs before the fragment tree is built (that happens after PerformLayout).
             if (ParentBox == null && NativeAnchorPlacement.Enabled)
+            {
+                // Native scroll offsets first (P5.8d.2b scroll expansion), so anchor geometry
+                // (and everything downstream) sees the scrolled content.
+                RunScrollSimulation(this);
                 RunNativeAnchorPlacement(this);
+            }
         }
         catch (Exception ex)
         {

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -811,6 +811,18 @@ internal abstract partial class CssBoxProperties
     /// </summary>
     public string ContentVisibility { get; set; } = "visible";
     public string Transform { get; set; } = "none";
+
+    /// <summary>
+    /// CSS Will Change Module Level 1: the <c>will-change</c> property. A
+    /// comma-separated hint list (<c>auto</c> by default). Consumed only by the
+    /// native anchor-placement containing-block resolution: <c>will-change: transform</c>
+    /// (and other values that would create one) establishes a containing block for
+    /// absolutely-positioned descendants — see
+    /// <see cref="CssBox.EstablishesNonPositionAbsPosContainingBlock"/>. No other layout
+    /// or paint behaviour reads it today.
+    /// </summary>
+    public string WillChange { get; set; } = "auto";
+
     public string FlexDirection { get; set; } = "row";
     public string FlexGrow { get; set; } = "0";
     public string FlexShrink { get; set; } = "1";

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -126,6 +126,7 @@ internal static partial class CssUtils
             "box-sizing" => cssBox.BoxSizing,
             "clip-path" => cssBox.ClipPath,
             "transform" => cssBox.Transform,
+            "will-change" => cssBox.WillChange,
             "align-content" => cssBox.AlignContent,
             "justify-self" => cssBox.JustifySelf,
             "align-self" => cssBox.AlignSelf,
@@ -250,6 +251,9 @@ internal static partial class CssUtils
                 break;
             case "transform":
                 cssBox.Transform = value;
+                break;
+            case "will-change":
+                cssBox.WillChange = value;
                 break;
             case "box-shadow":
                 cssBox.BoxShadow = value;

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2196,6 +2196,22 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   stay green. Two pre-existing environmental `DomBridge_SerializeToHtml_*` (iframe-scroll / viewport-zoom)
   Cli failures confirmed identical on the stashed baseline. Zero regressions. Groundwork for the full scroll
   model (which would also unblock sticky); the entangled cases and sticky itself remain on the bridge.
+
+  **Finding — the document scrolling element and fixed-descendant cases are NOT positively validatable here
+  (2026-07-15 investigation; the native handoff was extended to them and reverted).** Extending the native
+  handoff to the `<html>` document scrolling element is *safe* (baked-vs-native parity holds), but its
+  positive path cannot be exercised in a synthetic fixture: `documentElement.scrollTop = N` resolves to `0`
+  through `SetElementScrollOffsetsWithBehavior` → `ResolveElementScrollOffsets` (the `clamp` /
+  `CanProgrammaticallyScroll` / `GetScrollBounds` machinery, entangled with visual-viewport tracking since
+  `trackVisualViewport = ReferenceEquals(element, DocumentElement)`), so page scroll never actually applies
+  — baked and native both render unscrolled, making the extension an unvalidated no-op. The
+  fixed-descendant case is separately un-validatable: a `position:fixed` child of an `overflow:hidden` scroll
+  container paints in **neither** path (a renderer limitation clips fixed descendants of clipping ancestors),
+  so there is no visible fixed box to assert parity on. The engine translate already handles fixed correctly
+  in principle (`OffsetTop`/`OffsetLeft` skip `position:fixed` at every depth, so no reparenting is needed —
+  the bridge's `CollectFixedDescendants` reparenting only undoes the DOM-shift wrapper's renderer bug), but
+  that correctness can't be *demonstrated* here. Both cases were therefore left on the bridge path; they need
+  an environment where page scroll and fixed-in-scroll actually render.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
   ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → ~~inline-CB promotion (relative inline

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2233,8 +2233,11 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   lacks it, so a port is engine-layout work, not a bridge extraction, and it affects *all* pages (not just
   anchor pages) so the eventual production flip carries broad risk. Verified engine gaps:
   `ResolveStickyPositioning` (no `position:sticky` in the engine), `ApplyVisualViewportSerializationState`
-  (no pinch-zoom / `zoom`), and `InsertDialogBackdrops`/`ApplyDialogUAPositioning` (no top-layer painting).
-  Each is its own engine feature + broad-corpus parity effort, larger than a lever-gated slice.
+  (no pinch-zoom / `zoom`), and `InsertDialogBackdrops`/`ApplyDialogUAPositioning` (whose 7 validation tests
+  turn out to be a **scroll-dependent, anchor-entangled modal-dialog path** — a transparent backdrop, modal
+  UA positioning, `anchor()` insets, `IsAnchorAccessible`, and a document-scroll adjustment — NOT the
+  standalone renderer feature first assumed; see the corrected finding below). Each is its own engine feature +
+  broad-corpus parity effort, larger than a lever-gated slice.
   **`ApplyScrollSimulation` now has a native FIRST INCREMENT (seventeenth expansion below): the engine has a
   scroll-offset post-pass (`CssBox.RunScrollSimulation`), and the bridge hands off non-document scroll
   containers on no-anchor pages to it — so that case renders with no DOM-shift wrapper / inline writes. The
@@ -2264,8 +2267,38 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   position-visibility interaction that reproduces the flow-vs-paint hiding bug) are unbuilt.** Left on the
   bridge path.
 
-  **Finding — dialog/backdrop is a renderer-submodule feature, not a parent-repo post-pass slice (2026-07-15
-  investigation).** It *is* validatable — 7 `anchor-position-top-layer-*` corpus tests, all passing — and has
+  **Finding — dialog/backdrop is scroll-dependent and anchor-entangled, NOT a standalone renderer feature
+  (2026-07-15 deep investigation; corrects the earlier "renderer-submodule feature, no scroll dependency"
+  assessment below).** The only validation is 7 `anchor-position-top-layer-*` corpus tests, and reading them
+  overturns the earlier framing:
+  - **The `::backdrop` scrim is pixel-irrelevant here.** Every one of the 7 tests declares
+    `dialog::backdrop { background: transparent; }`, so the backdrop paints nothing — the assertion is the
+    anchored dialog's *position* (a lime box). So `::backdrop` box-generation, while genuinely absent from the
+    renderer, is **not what these tests validate**, and there is **no standalone dialog/backdrop corpus** in
+    this checkout to validate the visible-scrim path against. (The renderer *does* already generate
+    pseudo-element boxes — `ApplyPseudoElementBoxes`/`CreatePseudoElementBox` for `::before`/`::after`,
+    `DomParser.cs:363` — so `::backdrop` box-gen would *extend* that machinery, not build it from scratch;
+    but it is unneeded for parity here.)
+  - **What the tests actually exercise is a modal-dialog native-anchor path.** They `showModal()` a
+    `<dialog>` and anchor it with `anchor()` insets (`top: anchor(top); left: anchor(right)`), then
+    `document.scrollingElement.scrollTop = 100` with `body { height: 300vh }`. The pixel-relevant behaviour is
+    (a) modal-dialog UA positioning (`position:fixed`, `ApplyDialogUAPositioning`), (b) `anchor()`-inset
+    placement, (c) **anchor accessibility** (`IsAnchorAccessible` — a top-layer-order rule deciding whether a
+    target may see a given anchor; this is the actual subject of tests 003–006), and (d) a **document-scroll
+    adjustment** for the fixed/modal target.
+  - **It is therefore blocked behind the scroll model, like sticky — not independent of it.** Modal dialogs
+    are deliberately **excluded** from the native `anchor()`-inset handoff (`IsMvpNativeAnchorInsetBox`,
+    `AnchorFunctions.cs:204`) precisely because *"fixed / modal-dialog targets get a document-scroll adjustment
+    the engine MVP does not do"* (`AnchorFunctions.cs:199`), and the tests page-scroll. So a native port needs
+    the engine scroll model (the seventeenth expansion's first increment, not yet the document-scroll case)
+    **plus** a modality/top-layer runtime-state channel **plus** `IsAnchorAccessible` promoted into the
+    engine's `AnchorRegistry`. It is a coordinated anchor-machinery + scroll effort, not a renderer-submodule
+    box-gen slice — and all-or-nothing for the 7 tests. Left on the bridge path; correct sequence is scroll
+    model first, then the modal-dialog anchor path (which also delivers dialog/backdrop's pixel-relevant part).
+  The original (now-superseded) renderer-submodule framing is kept below for context.
+
+  **(Superseded) Finding — dialog/backdrop as a renderer-submodule feature (2026-07-15).** It *is*
+  validatable — 7 `anchor-position-top-layer-*` corpus tests, all passing — and has
   no scroll dependency, so unlike sticky it is not blocked; but it is the largest category-2 item and is
   structurally different from the anchor slices, which were pure post-layout *repositioning* in the parent-repo
   engine. The bridge's `ApplyDialogUAPositioning`/`ApplyPopoverUAPositioning`/`InsertDialogBackdrops` do four

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2163,6 +2163,39 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   with no corpus gain (like `position-visibility`), but it **removes `EnsureContainingBlockPositioning`
   entirely from the bridge's native render path** — one full AnchorResolver pass off the Phase 4 item-2
   inline-write list.
+- **P5.8d.2b — native scroll offset (seventeenth expansion, FIRST INCREMENT) — COMPLETED** 2026-07-15
+  (branch `claude/htmlbridge-phase-5-sk540t`; Broiler.Layout + bridge, both parent-repo, additive,
+  default-off). The **first native scroll geometry in the engine** — the beginning of the
+  `ApplyScrollSimulation` port the sticky/scroll findings named as the prerequisite. The bridge's
+  `ApplyScrollSimulation` simulates a script-set `scrollTop`/`scrollLeft` by DOM-wrapping a scroll
+  container's children in a `position:relative` div shifted by the negative offset (plus a
+  `visibility:hidden` top-clip hack). This increment moves the **plain non-document, no-anchor-page** case
+  to the engine:
+  - **Engine.** New `Engine/CssBox.Scroll.cs` — `RunScrollSimulation`, a root post-pass run (gated by
+    `NativeAnchorPlacement.Enabled`) **before** `RunNativeAnchorPlacement` so downstream geometry sees the
+    scrolled content. For each box carrying `data-broiler-scroll-top`/`-left` it translates the container's
+    child boxes by the negative offset via the existing `OffsetTop`/`OffsetLeft` (which recurse the subtree
+    and already skip `position:fixed`, CSS2.1 §9.6.1); the container's own `overflow` box clips the shifted
+    content at paint. Notably the direct box translation clips the top edge correctly **without** the
+    bridge's `visibility:hidden` workaround (that hack existed because the bridge's `position:relative`
+    wrapper confused the renderer's top clip).
+  - **Bridge.** In native mode, for a non-document scroll container on a page with **no anchor content**
+    (`DocumentHasAnchorContent()` — no registered `anchor-name`), `ApplyScrollSimulation` writes the offset
+    as `data-broiler-scroll-top`/`-left` and skips the wrapper-div DOM mutation entirely (no inline
+    `position`/`top`/`left`/`visibility` writes reach the render). Scoped to no-anchor documents so it never
+    crosses the anchor-scroll-container / position-visibility machinery (the eleventh/thirteenth expansions),
+    which keeps the bridge's DOM-shift; every other case (the `<html>` document scrolling element, fixed
+    descendant reparenting, and any anchor page) stays on the bridge path.
+  Tests: `Broiler.Wpt.Tests/NativeScrollParityWptTests.cs` (full render: a JS-`scrollTop` `overflow:hidden`
+  container — the scrolled marker lands in the same rectangle baked vs native, AND content scrolled entirely
+  above the top edge is clipped away in both, proving the native overflow clip matches). Regression check:
+  full `Broiler.Layout.Tests` (177; pre-existing arch-guard fail identical on baseline) green;
+  css-anchor-position **default-off byte-identical (31/8)** and **lever-on unchanged (6 fails, identical
+  set)** — anchor pages keep the bridge scroll path via the no-anchor scoping, so the whole anchor corpus is
+  unaffected; the `ScrollContainerAnchorParity` (eleventh) and `NativePositionVisibility` (thirteenth) suites
+  stay green. Two pre-existing environmental `DomBridge_SerializeToHtml_*` (iframe-scroll / viewport-zoom)
+  Cli failures confirmed identical on the stashed baseline. Zero regressions. Groundwork for the full scroll
+  model (which would also unblock sticky); the entangled cases and sticky itself remain on the bridge.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
   ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → ~~inline-CB promotion (relative inline
@@ -2183,10 +2216,15 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   (`ResolveFixedPositionSizing`, done above); (b) **needs a new engine feature** — the engine genuinely
   lacks it, so a port is engine-layout work, not a bridge extraction, and it affects *all* pages (not just
   anchor pages) so the eventual production flip carries broad risk. Verified engine gaps:
-  `ResolveStickyPositioning` (no `position:sticky` in the engine), `ApplyScrollSimulation` (no scroll-offset
-  model — scroll is only the bridge's DOM-shift), `ApplyVisualViewportSerializationState` (no pinch-zoom /
-  `zoom`), and `InsertDialogBackdrops`/`ApplyDialogUAPositioning` (no top-layer painting). Each is its own
-  engine feature + broad-corpus parity effort, larger than a lever-gated slice. **`EnsureContainingBlockPositioning`
+  `ResolveStickyPositioning` (no `position:sticky` in the engine), `ApplyVisualViewportSerializationState`
+  (no pinch-zoom / `zoom`), and `InsertDialogBackdrops`/`ApplyDialogUAPositioning` (no top-layer painting).
+  Each is its own engine feature + broad-corpus parity effort, larger than a lever-gated slice.
+  **`ApplyScrollSimulation` now has a native FIRST INCREMENT (seventeenth expansion below): the engine has a
+  scroll-offset post-pass (`CssBox.RunScrollSimulation`), and the bridge hands off non-document scroll
+  containers on no-anchor pages to it — so that case renders with no DOM-shift wrapper / inline writes. The
+  entangled remainder (the document scrolling element, fixed-descendant reparenting, and anchor-scroll
+  containers) stays on the bridge's DOM-shift, and the full model that would also unblock sticky is still to
+  come.** **`EnsureContainingBlockPositioning`
   — the engine's `FindPositionedContainingBlock` gap for `transform`/`contain`/`will-change` containing
   blocks — is now RESOLVED (sixteenth expansion above): the engine recognises all three natively under the
   lever (with `will-change` projected onto the box), so the pass is skipped **entirely** in native mode — no
@@ -2200,10 +2238,15 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   using its *flow* position (y=0) rather than its pinned *paint* position (probe: the box pins correctly to
   `Y=10` but serialises with `visibility:hidden`+`data-broiler-scroll-hidden`). Matching the bridge would
   reproduce that bug. (3) **Scroll-model dependency** — sticky is inherently scroll-dependent and the engine
-  has no scroll-offset model; it is coupled to `ApplyScrollSimulation` (itself an unported bridge pass whose
-  DOM-shift is the only scroll representation). The correct sequence is to give the engine a real scroll
-  model first (port `ApplyScrollSimulation`), which unblocks both scroll and sticky and fixes the
-  flow-vs-paint hiding bug, and to do it in an environment with a sticky corpus. Left on the bridge path.
+  has no scroll-offset model; it is coupled to `ApplyScrollSimulation` (whose DOM-shift is the only scroll
+  representation). The correct sequence is to give the engine a real scroll model first (port
+  `ApplyScrollSimulation`), which unblocks both scroll and sticky and fixes the flow-vs-paint hiding bug, and
+  to do it in an environment with a sticky corpus. **Update (seventeenth expansion below): the engine now has
+  a scroll-offset post-pass, and the plain non-anchor scroll-container case is native — the first step of
+  that model. But sticky stays blocked here: it still has no corpus, and the remaining scroll cases the
+  full model needs (the document scrolling element, fixed reparenting, and the anchor-scroll-container /
+  position-visibility interaction that reproduces the flow-vs-paint hiding bug) are unbuilt.** Left on the
+  bridge path.
 
   **Finding — dialog/backdrop is a renderer-submodule feature, not a parent-repo post-pass slice (2026-07-15
   investigation).** It *is* validatable — 7 `anchor-position-top-layer-*` corpus tests, all passing — and has
@@ -2222,9 +2265,11 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   renderer effort, and all-or-nothing for parity (a partial port breaks the 7 passing tests). Best done as its
   own submodule feature, not folded into the lever-gated anchor cutover. Left on the bridge path.
 
-  Still bridge-only: dialog/backdrop, sticky, scroll simulation, visual-viewport (the engine-feature set
-  above; transform/contain CBs are now native — sixteenth expansion), and the opposing-inset /
-  auto-min-content-sized position-try bases (the engine's
+  Still bridge-only: dialog/backdrop, sticky, the entangled scroll cases (document scrolling element, fixed
+  reparenting, anchor-scroll containers — the plain non-anchor case is native as of the seventeenth
+  expansion), visual-viewport (the engine-feature set above; transform/contain/will-change CBs are now
+  native — sixteenth expansion), and the opposing-inset / auto-min-content-sized position-try bases (the
+  engine's
   `TryApplyPositionTryFallback` supports these geometries but the bridge gate keeps them baked pending per-case
   parity). **A position-area base was investigated and deliberately NOT handed off (2026-07-15):** Broiler
   clamps an explicit position-area size to the grid cell (P5.5 `PositionAreaGrid.ResolveElementBox`) and a

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2123,53 +2123,58 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   default-off byte-identical; **lever-on the css-anchor-position subset is unchanged (6 fails, identical
   set)** — the `position-fixed` anchor tests still pass. (This WPT checkout has no non-anchor fixed-element
   corpus; the redundancy is proven by the engine-vs-bridge agreement.) Zero regressions.
-- **P5.8d.2b — transform/contain containing block (sixteenth expansion) — COMPLETED** 2026-07-15
+- **P5.8d.2b — transform/contain/will-change containing block (sixteenth expansion) — COMPLETED** 2026-07-15
   (branch `claude/htmlbridge-phase-5-sk540t`; Broiler.Layout + bridge, both parent-repo, additive,
   default-off). The bridge's **`EnsureContainingBlockPositioning`** pass — which pre-bakes inline
   `position:relative` onto every element that establishes an abspos containing block through a
   non-position property (`transform`, `contain: layout/paint/strict/content`, `will-change: transform`)
-  so the renderer's `position`-only CB resolution treats it as a containing block — is now, for its
-  transform/contain cases, resolved **natively by the engine** instead of pre-baked. This is the last of
-  the *general* (non-anchor) AnchorResolver passes' geometry to move, and the resolution of the "engine
-  gap" the triage below recorded. Landed:
+  so the renderer's `position`-only CB resolution treats it as a containing block — is now resolved
+  **natively by the engine** and **skipped entirely in native mode**. This is the last of the *general*
+  (non-anchor) AnchorResolver passes' geometry to move, and the resolution of the "engine gap" the triage
+  below recorded. Landed in two steps (transform/contain first, then the will-change completion):
   - **Engine.** `CssBox.FindPositionedContainingBlock` (the abspos CB walk) now, **under the native-anchor
     lever**, also returns a box that establishes a containing block via a non-`none` `transform`
-    (CSS Transforms 1 §4) or `contain: layout/paint/strict/content` (CSS Containment §2) — a new
-    `EstablishesNonPositionAbsPosContainingBlock` predicate mirroring the bridge's
-    `EstablishesContainingBlock` (minus `will-change`, which is not projected onto the box). Gated by
-    `NativeAnchorPlacement.Enabled`, so default-off layout is byte-identical. On the baked path the box is
-    already `position:relative` (from the pass), so the pre-existing `position` check returned it — the
-    native recognition returns the *same* box, which is why baked and native agree.
-  - **Bridge.** `EnsureContainingBlockPositioning` skips the `position:relative` write in native mode for
-    a transform/contain-established CB (a new `EstablishesContainingBlockViaWillChangeOnly` keeps only the
-    will-change-only case on the bridge, since the engine does not model `will-change`) — removing those
-    inline writes from the native render path. Default-off writes exactly as before.
-  Tests: `Broiler.Layout.Tests/NativeAnchorPlacementTests.cs` +9 (a `contain:layout`/`transform` CB is
-  resolved natively and the target fills the inner cell, a plain **static** block control climbs to the
-  root — proving the recognition binds it — and the predicate mirror-table); `Broiler.Wpt.Tests/
+    (CSS Transforms 1 §4), `contain: layout/paint/strict/content` (CSS Containment §2), or
+    `will-change: transform` (CSS Will Change 1 §3) — a new `EstablishesNonPositionAbsPosContainingBlock`
+    predicate mirroring the bridge's `EstablishesContainingBlock` exactly. `will-change` is now projected
+    onto the box (`CssBoxProperties.WillChange` + the `CssUtils` get/set arms — a parent-repo-only add; the
+    cascade already emits the declared property to the ignored-name sink, so no submodule/CSS-engine change
+    was needed). Gated by `NativeAnchorPlacement.Enabled`, so default-off layout is byte-identical. On the
+    baked path the box is already `position:relative` (from the pass), so the pre-existing `position` check
+    returned it — the native recognition returns the *same* box, which is why baked and native agree.
+  - **Bridge.** `ResolveAnchorPositions` now **skips `EnsureContainingBlockPositioning` entirely in native
+    mode** (`if (!NativeAnchorPlacement)`), so **no `position:relative` write from this pass reaches the
+    native render path**. Default mode bakes exactly as before.
+  Tests: `Broiler.Layout.Tests/NativeAnchorPlacementTests.cs` +12 (a `contain:layout`/`transform`/
+  `will-change:transform` CB is resolved natively and the target fills the inner cell, a plain **static**
+  block control climbs to the root — proving the recognition binds it — and the predicate mirror-table);
+  `Broiler.Cli.Tests/NativeAnchorWillChangeCbPipelineTests.cs` (REAL parse → cascade → layout: a
+  `will-change: transform` box, NOT pre-baked to relative by this harness, is resolved as the CB by the
+  engine and the auto-sized target fills the 140×140 inner cell — proving both that the cascade projects
+  `will-change` onto the box and that the engine recognises it); `Broiler.Wpt.Tests/
   NativeAnchorContainCbWptTests.cs` (full render: a `contain:layout` CB anchored box, the corpus
   `transform-010/015/016` pattern, placed by the engine and pixel-agreeing baked vs native — an auto-sized
   fill that would fill the 340-wide viewport cell if the CB weren't recognised, so the fill size proves the
-  `contain` box is the CB). Regression check: full `Broiler.Layout.Tests` (172, the pre-existing
+  `contain` box is the CB). Regression check: full `Broiler.Layout.Tests` (177, the pre-existing
   environmental arch-guard fail identical on baseline) green; **default-off byte-identical (31 pass / 8
   fail)**; **lever-on the css-anchor-position subset is unchanged (6 fails, identical set — verified against
   the stashed baseline), with transform/contain match% pixel-identical** (`transform-010/016` 100 %,
   `transform-015` 100 %, `abs-inline-container`/`inline-container` 95.81 %). Zero regressions. A parity move
-  with no corpus gain (like `position-visibility`), but it drains the transform/contain `position:relative`
-  writes from the bridge's native render path — leaving `EnsureContainingBlockPositioning` writing only for
-  will-change-only CBs.
+  with no corpus gain (like `position-visibility`), but it **removes `EnsureContainingBlockPositioning`
+  entirely from the bridge's native render path** — one full AnchorResolver pass off the Phase 4 item-2
+  inline-write list.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
   ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → ~~inline-CB promotion (relative inline
   CB)~~ → ~~`anchor()` insets~~ → ~~`anchor-size()`~~ → ~~opposing-inset sizing~~ → ~~abspos-inline CB~~ →
   ~~scroll simulation~~ → ~~`position-visibility`~~ → dialog/backdrop → ~~position-try (anchor()-inset handoff
-  subset)~~ → ~~transform/contain containing blocks~~. (Childless auto/explicit/percentage sizing,
+  subset)~~ → ~~transform/contain/will-change containing blocks~~. (Childless auto/explicit/percentage sizing,
   `box-sizing:border-box`, percentage margin/padding/inset box props, shared-name scope resolution,
   writing-mode percentage basis, relatively-positioned inline containing blocks, `anchor()` physical insets,
   `anchor-size()` sizing, opposing-inset sizing, abspos-inline containing blocks, intervening scroll
   containers, the anchor()-inset `@position-try` fallback subset, `position-visibility`, `anchor-center`,
-  redundant fixed-position sizing, AND transform/contain containing blocks now land natively — see the
-  sixteen expansions above.)
+  redundant fixed-position sizing, AND transform/contain/will-change containing blocks now land natively —
+  see the sixteen expansions above.)
 
   **Triage of the remaining AnchorResolver passes (2026-07-15):** the anchor-specific, lever-gated passes
   are now on the engine (placement MVPs, `position-visibility`, `anchor-center`). The rest are *general*
@@ -2182,10 +2187,10 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   model — scroll is only the bridge's DOM-shift), `ApplyVisualViewportSerializationState` (no pinch-zoom /
   `zoom`), and `InsertDialogBackdrops`/`ApplyDialogUAPositioning` (no top-layer painting). Each is its own
   engine feature + broad-corpus parity effort, larger than a lever-gated slice. **`EnsureContainingBlockPositioning`
-  — the engine's `FindPositionedContainingBlock` gap for `transform`/`contain` containing blocks — is now
-  RESOLVED (sixteenth expansion above): the engine recognises them natively under the lever, so the
-  transform/contain `position:relative` pre-bake is dropped in native mode (only the will-change-only case,
-  which the engine does not model, stays on the bridge).**
+  — the engine's `FindPositionedContainingBlock` gap for `transform`/`contain`/`will-change` containing
+  blocks — is now RESOLVED (sixteenth expansion above): the engine recognises all three natively under the
+  lever (with `will-change` projected onto the box), so the pass is skipped **entirely** in native mode — no
+  `position:relative` pre-bake reaches the native render path.**
 
   **Finding — `position:sticky` is blocked here (2026-07-15 investigation).** Three compounding blockers make
   a responsible port infeasible in this environment: (1) **no corpus** — this WPT checkout has zero sticky

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -2123,17 +2123,53 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   default-off byte-identical; **lever-on the css-anchor-position subset is unchanged (6 fails, identical
   set)** — the `position-fixed` anchor tests still pass. (This WPT checkout has no non-anchor fixed-element
   corpus; the redundancy is proven by the engine-vs-bridge agreement.) Zero regressions.
+- **P5.8d.2b — transform/contain containing block (sixteenth expansion) — COMPLETED** 2026-07-15
+  (branch `claude/htmlbridge-phase-5-sk540t`; Broiler.Layout + bridge, both parent-repo, additive,
+  default-off). The bridge's **`EnsureContainingBlockPositioning`** pass — which pre-bakes inline
+  `position:relative` onto every element that establishes an abspos containing block through a
+  non-position property (`transform`, `contain: layout/paint/strict/content`, `will-change: transform`)
+  so the renderer's `position`-only CB resolution treats it as a containing block — is now, for its
+  transform/contain cases, resolved **natively by the engine** instead of pre-baked. This is the last of
+  the *general* (non-anchor) AnchorResolver passes' geometry to move, and the resolution of the "engine
+  gap" the triage below recorded. Landed:
+  - **Engine.** `CssBox.FindPositionedContainingBlock` (the abspos CB walk) now, **under the native-anchor
+    lever**, also returns a box that establishes a containing block via a non-`none` `transform`
+    (CSS Transforms 1 §4) or `contain: layout/paint/strict/content` (CSS Containment §2) — a new
+    `EstablishesNonPositionAbsPosContainingBlock` predicate mirroring the bridge's
+    `EstablishesContainingBlock` (minus `will-change`, which is not projected onto the box). Gated by
+    `NativeAnchorPlacement.Enabled`, so default-off layout is byte-identical. On the baked path the box is
+    already `position:relative` (from the pass), so the pre-existing `position` check returned it — the
+    native recognition returns the *same* box, which is why baked and native agree.
+  - **Bridge.** `EnsureContainingBlockPositioning` skips the `position:relative` write in native mode for
+    a transform/contain-established CB (a new `EstablishesContainingBlockViaWillChangeOnly` keeps only the
+    will-change-only case on the bridge, since the engine does not model `will-change`) — removing those
+    inline writes from the native render path. Default-off writes exactly as before.
+  Tests: `Broiler.Layout.Tests/NativeAnchorPlacementTests.cs` +9 (a `contain:layout`/`transform` CB is
+  resolved natively and the target fills the inner cell, a plain **static** block control climbs to the
+  root — proving the recognition binds it — and the predicate mirror-table); `Broiler.Wpt.Tests/
+  NativeAnchorContainCbWptTests.cs` (full render: a `contain:layout` CB anchored box, the corpus
+  `transform-010/015/016` pattern, placed by the engine and pixel-agreeing baked vs native — an auto-sized
+  fill that would fill the 340-wide viewport cell if the CB weren't recognised, so the fill size proves the
+  `contain` box is the CB). Regression check: full `Broiler.Layout.Tests` (172, the pre-existing
+  environmental arch-guard fail identical on baseline) green; **default-off byte-identical (31 pass / 8
+  fail)**; **lever-on the css-anchor-position subset is unchanged (6 fails, identical set — verified against
+  the stashed baseline), with transform/contain match% pixel-identical** (`transform-010/016` 100 %,
+  `transform-015` 100 %, `abs-inline-container`/`inline-container` 95.81 %). Zero regressions. A parity move
+  with no corpus gain (like `position-visibility`), but it drains the transform/contain `position:relative`
+  writes from the bridge's native render path — leaving `EnsureContainingBlockPositioning` writing only for
+  will-change-only CBs.
 - **Remaining P5.8d.2b (the entangled expansions, each its own PR + parity gate):** the lever stays
   default-off until each feature is on the engine path — ~~percentage box props~~ → ~~box-sizing~~ →
   ~~anchor-name scope/uniqueness~~ → ~~writing-mode % box props~~ → ~~inline-CB promotion (relative inline
   CB)~~ → ~~`anchor()` insets~~ → ~~`anchor-size()`~~ → ~~opposing-inset sizing~~ → ~~abspos-inline CB~~ →
   ~~scroll simulation~~ → ~~`position-visibility`~~ → dialog/backdrop → ~~position-try (anchor()-inset handoff
-  subset)~~. (Childless auto/explicit/percentage sizing, `box-sizing:border-box`, percentage
-  margin/padding/inset box props, shared-name scope resolution, writing-mode percentage basis,
-  relatively-positioned inline containing blocks, `anchor()` physical insets, `anchor-size()` sizing,
-  opposing-inset sizing, abspos-inline containing blocks, intervening scroll containers, the
-  anchor()-inset `@position-try` fallback subset, `position-visibility`, `anchor-center`, AND redundant
-  fixed-position sizing now land natively — see the fifteen expansions above.)
+  subset)~~ → ~~transform/contain containing blocks~~. (Childless auto/explicit/percentage sizing,
+  `box-sizing:border-box`, percentage margin/padding/inset box props, shared-name scope resolution,
+  writing-mode percentage basis, relatively-positioned inline containing blocks, `anchor()` physical insets,
+  `anchor-size()` sizing, opposing-inset sizing, abspos-inline containing blocks, intervening scroll
+  containers, the anchor()-inset `@position-try` fallback subset, `position-visibility`, `anchor-center`,
+  redundant fixed-position sizing, AND transform/contain containing blocks now land natively — see the
+  sixteen expansions above.)
 
   **Triage of the remaining AnchorResolver passes (2026-07-15):** the anchor-specific, lever-gated passes
   are now on the engine (placement MVPs, `position-visibility`, `anchor-center`). The rest are *general*
@@ -2144,10 +2180,12 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   anchor pages) so the eventual production flip carries broad risk. Verified engine gaps:
   `ResolveStickyPositioning` (no `position:sticky` in the engine), `ApplyScrollSimulation` (no scroll-offset
   model — scroll is only the bridge's DOM-shift), `ApplyVisualViewportSerializationState` (no pinch-zoom /
-  `zoom`), `InsertDialogBackdrops`/`ApplyDialogUAPositioning` (no top-layer painting), and
-  `EnsureContainingBlockPositioning` (the engine's `FindPositionedContainingBlock` considers only
-  `position`, not `transform`/`contain` containing blocks). Each is its own engine feature + broad-corpus
-  parity effort, larger than a lever-gated slice.
+  `zoom`), and `InsertDialogBackdrops`/`ApplyDialogUAPositioning` (no top-layer painting). Each is its own
+  engine feature + broad-corpus parity effort, larger than a lever-gated slice. **`EnsureContainingBlockPositioning`
+  — the engine's `FindPositionedContainingBlock` gap for `transform`/`contain` containing blocks — is now
+  RESOLVED (sixteenth expansion above): the engine recognises them natively under the lever, so the
+  transform/contain `position:relative` pre-bake is dropped in native mode (only the will-change-only case,
+  which the engine does not model, stays on the bridge).**
 
   **Finding — `position:sticky` is blocked here (2026-07-15 investigation).** Three compounding blockers make
   a responsible port infeasible in this environment: (1) **no corpus** — this WPT checkout has zero sticky
@@ -2179,8 +2217,9 @@ extraction (higher risk). Detailed design below (P5.8b–d).** Two grounding cor
   renderer effort, and all-or-nothing for parity (a partial port breaks the 7 passing tests). Best done as its
   own submodule feature, not folded into the lever-gated anchor cutover. Left on the bridge path.
 
-  Still bridge-only: dialog/backdrop, sticky, scroll simulation, visual-viewport, transform/contain CBs
-  (the engine-feature set above), and the opposing-inset / auto-min-content-sized position-try bases (the engine's
+  Still bridge-only: dialog/backdrop, sticky, scroll simulation, visual-viewport (the engine-feature set
+  above; transform/contain CBs are now native — sixteenth expansion), and the opposing-inset /
+  auto-min-content-sized position-try bases (the engine's
   `TryApplyPositionTryFallback` supports these geometries but the bridge gate keeps them baked pending per-case
   parity). **A position-area base was investigated and deliberately NOT handed off (2026-07-15):** Broiler
   clamps an explicit position-area size to the grid cell (P5.5 `PositionAreaGrid.ResolveElementBox`) and a

--- a/src/Broiler.Cli.Tests/NativeAnchorWillChangeCbPipelineTests.cs
+++ b/src/Broiler.Cli.Tests/NativeAnchorWillChangeCbPipelineTests.cs
@@ -1,0 +1,88 @@
+using System.Drawing;
+using Broiler.HtmlBridge;
+using Broiler.HTML.Image;
+using Broiler.JavaScript.Engine;
+using Broiler.Layout;
+using Broiler.Layout.Engine;
+using DomDocument = Broiler.Dom.DomDocument;
+using DomElement = Broiler.Dom.DomElement;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// End-to-end proof that <c>will-change: transform</c> establishes a native anchor
+/// containing block (Phase 5 P5.8d.2b transform/contain CB expansion, will-change
+/// completion) through the REAL parse → cascade → layout pipeline. This also verifies
+/// the cascade actually projects <c>will-change</c> onto the box (the new
+/// <c>CssBoxProperties.WillChange</c> + <c>CssUtils</c> arm) — the box could not be
+/// recognised otherwise.
+///
+/// The harness renders through <see cref="HtmlContainer.GetLayoutGeometry"/>, which does
+/// NOT run the bridge's <c>ResolveAnchorPositions</c> — so the <c>will-change</c> box is
+/// NOT pre-baked to <c>position: relative</c>; the engine must resolve the containing
+/// block from <c>will-change</c> alone. The target is auto-sized, so if the box were not
+/// recognised its containing block would climb to the viewport and the fill size would be
+/// far larger — the 140×140 fill pins that the <c>will-change</c> box is the CB.
+/// </summary>
+[Xunit.Collection("SharedGeometryStatics")]
+public sealed class NativeAnchorWillChangeCbPipelineTests
+{
+    private const string Url = "file:///native-anchor-willchange.html";
+
+    // #cb is a 200×200 box at the origin whose ONLY containing-block-establishing property
+    // is will-change: transform (it is NOT position:relative). #anchor is 20×20 at (40,40)
+    // → right/bottom = 60. #target is an auto-sized abspos box, position-area "bottom right".
+    private const string Html =
+        "<!DOCTYPE html><html><head><style>" +
+        "body { margin: 0; }" +
+        "#cb { will-change: transform; width: 200px; height: 200px; }" +
+        "#anchor { position: absolute; left: 40px; top: 40px; width: 20px; height: 20px; anchor-name: --a; }" +
+        "#target { position: absolute; position-anchor: --a; position-area: bottom right; }" +
+        "</style></head><body><div id='cb'><div id='anchor'></div><div id='target'></div></div></body></html>";
+
+    private static BoxGeometry LayoutTarget(bool nativeAnchor)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, Html, Url);
+        DomDocument document = bridge.GetRenderDocument();
+
+        using var container = new HtmlContainer
+        {
+            Location = new PointF(0, 0),
+            AvoidAsyncImagesLoading = true,
+            AvoidImagesLateLoading = true,
+        };
+        container.SetDocumentWithStyleSet(document, baseUrl: Url);
+
+        IReadOnlyDictionary<DomElement, BoxGeometry> geometry;
+        try
+        {
+            NativeAnchorPlacement.Enabled = nativeAnchor;
+            geometry = container.GetLayoutGeometry(new SizeF(800, 600));
+        }
+        finally
+        {
+            NativeAnchorPlacement.Enabled = false;
+        }
+
+        var target = document.GetElementById("target");
+        Assert.NotNull(target);
+        Assert.True(geometry.ContainsKey(target!), "target box has no geometry");
+        return geometry[target!];
+    }
+
+    [Fact]
+    public void NativeFlagOn_ResolvesWillChangeCb_AndFillsInnerCell()
+    {
+        var box = LayoutTarget(nativeAnchor: true);
+
+        // "bottom right" cell against the 200×200 will-change box = [60..200]×[60..200] =
+        // 140×140 at (60,60). A viewport-resolved CB would give a ~740×540 fill instead, so
+        // the 140×140 fill proves the will-change box is the containing block.
+        Assert.Equal(60f, box.BorderBox.Left, 1);
+        Assert.Equal(60f, box.BorderBox.Top, 1);
+        Assert.Equal(140f, box.BorderBox.Width, 1);
+        Assert.Equal(140f, box.BorderBox.Height, 1);
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -154,14 +154,15 @@ public sealed partial class DomBridge
             ResolveFixedPositionSizing(viewportWidth, viewportHeight);
 
         // 6. Ensure elements that establish containing blocks via non-position
-        //    properties (contain:layout, transform) get position:relative so the
-        //    Broiler renderer treats them as containing blocks for abspos children.
-        //    Native mode (P5.8d.2b transform/contain CB expansion): the Broiler.Layout
-        //    engine now resolves transform/contain containing blocks natively
-        //    (CssBox.FindPositionedContainingBlock under the lever), so the transform/contain
-        //    position:relative pre-bake is dropped; only a will-change-only containing block
-        //    still needs it (the engine does not model will-change).
-        EnsureContainingBlockPositioning(DocumentElement);
+        //    properties (contain:layout, transform, will-change:transform) get
+        //    position:relative so the Broiler renderer treats them as containing blocks for
+        //    abspos children. Native mode (P5.8d.2b transform/contain CB expansion): the
+        //    Broiler.Layout engine now resolves all of these natively
+        //    (CssBox.FindPositionedContainingBlock + EstablishesNonPositionAbsPosContainingBlock
+        //    under the lever), so this pre-bake is skipped entirely — no inline position:relative
+        //    write reaches the native render path.
+        if (!NativeAnchorPlacement)
+            EnsureContainingBlockPositioning(DocumentElement);
 
         // 7. Strip CSS rules with unsupported properties (anchor(), inset,
         //    anchor-name) from the stylesheet so the renderer doesn't

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -156,6 +156,11 @@ public sealed partial class DomBridge
         // 6. Ensure elements that establish containing blocks via non-position
         //    properties (contain:layout, transform) get position:relative so the
         //    Broiler renderer treats them as containing blocks for abspos children.
+        //    Native mode (P5.8d.2b transform/contain CB expansion): the Broiler.Layout
+        //    engine now resolves transform/contain containing blocks natively
+        //    (CssBox.FindPositionedContainingBlock under the lever), so the transform/contain
+        //    position:relative pre-bake is dropped; only a will-change-only containing block
+        //    still needs it (the engine does not model will-change).
         EnsureContainingBlockPositioning(DocumentElement);
 
         // 7. Strip CSS rules with unsupported properties (anchor(), inset,

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ContainingBlocks.cs
@@ -31,7 +31,15 @@ public sealed partial class DomBridge
 
             if (!alreadyPositioned && EstablishesContainingBlock(props))
             {
-                InlineStyle(el)["position"] = "relative";
+                // Native mode (P5.8d.2b transform/contain CB expansion): the Broiler.Layout
+                // engine now resolves transform/contain containing blocks natively
+                // (CssBox.FindPositionedContainingBlock under the lever), so the bridge no
+                // longer pre-bakes position:relative for them — removing that inline write
+                // from the native render path. A containing block established ONLY by
+                // will-change:transform stays on the bridge path (the engine does not project
+                // will-change onto the box).
+                if (!NativeAnchorPlacement || EstablishesContainingBlockViaWillChangeOnly(props))
+                    InlineStyle(el)["position"] = "relative";
             }
         }
 
@@ -77,5 +85,36 @@ public sealed partial class DomBridge
             return true;
 
         return false;
+    }
+
+    /// <summary>
+    /// Whether the element (already known to <see cref="EstablishesContainingBlock"/>)
+    /// does so <em>only</em> through <c>will-change: transform</c> — it has no
+    /// <c>transform</c> and no containment (<c>contain: layout/paint/strict/content</c>).
+    /// The Broiler.Layout engine recognises transform/contain containing blocks natively
+    /// under the native-anchor lever but does not model <c>will-change</c>, so in native
+    /// mode only these will-change-only boxes still need the bridge's
+    /// <c>position:relative</c> pre-bake.
+    /// </summary>
+    private static bool EstablishesContainingBlockViaWillChangeOnly(Dictionary<string, string> props)
+    {
+        // Transform and containment are both resolved by the engine under the lever.
+        if (props.TryGetValue("transform", out var transform) &&
+            !string.IsNullOrWhiteSpace(transform) &&
+            !string.Equals(transform, "none", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (props.TryGetValue("contain", out var contain) && !string.IsNullOrWhiteSpace(contain))
+        {
+            var containLower = contain.ToLowerInvariant();
+            if (containLower.Contains("layout") || containLower.Contains("paint") ||
+                containLower.Contains("strict") || containLower.Contains("content"))
+                return false;
+        }
+
+        // Reaches here only when EstablishesContainingBlock was already true and the reason
+        // is neither transform nor containment — i.e. will-change:transform.
+        return props.TryGetValue("will-change", out var willChange) &&
+               willChange.Contains("transform", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ContainingBlocks.cs
@@ -11,9 +11,13 @@ public sealed partial class DomBridge
     /// <summary>
     /// For elements that establish containing blocks via CSS properties that
     /// Broiler's renderer does not understand (e.g. <c>contain:layout</c>,
-    /// <c>transform</c>), adds <c>position:relative</c> to their inline
-    /// styles so the renderer treats them as containing blocks for absolutely
-    /// positioned descendants.
+    /// <c>transform</c>, <c>will-change:transform</c>), adds <c>position:relative</c> to
+    /// their inline styles so the renderer treats them as containing blocks for absolutely
+    /// positioned descendants. Called only on the default (baked) path — in native mode the
+    /// Broiler.Layout engine resolves these containing blocks itself
+    /// (<see cref="EstablishesContainingBlock"/>'s engine mirror,
+    /// <c>CssBox.EstablishesNonPositionAbsPosContainingBlock</c>), so
+    /// <see cref="ResolveAnchorPositions"/> skips this pass entirely.
     /// </summary>
     private void EnsureContainingBlockPositioning(DomElement root) => EnsureContainingBlockPositioningTree(root);
 
@@ -31,15 +35,7 @@ public sealed partial class DomBridge
 
             if (!alreadyPositioned && EstablishesContainingBlock(props))
             {
-                // Native mode (P5.8d.2b transform/contain CB expansion): the Broiler.Layout
-                // engine now resolves transform/contain containing blocks natively
-                // (CssBox.FindPositionedContainingBlock under the lever), so the bridge no
-                // longer pre-bakes position:relative for them — removing that inline write
-                // from the native render path. A containing block established ONLY by
-                // will-change:transform stays on the bridge path (the engine does not project
-                // will-change onto the box).
-                if (!NativeAnchorPlacement || EstablishesContainingBlockViaWillChangeOnly(props))
-                    InlineStyle(el)["position"] = "relative";
+                InlineStyle(el)["position"] = "relative";
             }
         }
 
@@ -85,36 +81,5 @@ public sealed partial class DomBridge
             return true;
 
         return false;
-    }
-
-    /// <summary>
-    /// Whether the element (already known to <see cref="EstablishesContainingBlock"/>)
-    /// does so <em>only</em> through <c>will-change: transform</c> — it has no
-    /// <c>transform</c> and no containment (<c>contain: layout/paint/strict/content</c>).
-    /// The Broiler.Layout engine recognises transform/contain containing blocks natively
-    /// under the native-anchor lever but does not model <c>will-change</c>, so in native
-    /// mode only these will-change-only boxes still need the bridge's
-    /// <c>position:relative</c> pre-bake.
-    /// </summary>
-    private static bool EstablishesContainingBlockViaWillChangeOnly(Dictionary<string, string> props)
-    {
-        // Transform and containment are both resolved by the engine under the lever.
-        if (props.TryGetValue("transform", out var transform) &&
-            !string.IsNullOrWhiteSpace(transform) &&
-            !string.Equals(transform, "none", StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        if (props.TryGetValue("contain", out var contain) && !string.IsNullOrWhiteSpace(contain))
-        {
-            var containLower = contain.ToLowerInvariant();
-            if (containLower.Contains("layout") || containLower.Contains("paint") ||
-                containLower.Contains("strict") || containLower.Contains("content"))
-                return false;
-        }
-
-        // Reaches here only when EstablishesContainingBlock was already true and the reason
-        // is neither transform nor containment — i.e. will-change:transform.
-        return props.TryGetValue("will-change", out var willChange) &&
-               willChange.Contains("transform", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/ScrollSimulation.cs
@@ -47,6 +47,30 @@ public sealed partial class DomBridge
 
                 if ((clips || isDocScrollingElement) && el.ChildNodes.Count > 0)
                 {
+                    // Native mode (P5.8d.2b scroll expansion): for a non-document scroll
+                    // container on a page with no anchor content, hand the scroll offset to the
+                    // Broiler.Layout engine via data attributes instead of DOM-shifting the
+                    // content. The engine's scroll post-pass (CssBox.RunScrollSimulation)
+                    // translates the container's content and its overflow box clips it — no
+                    // wrapper div, no inline position/top/left/visibility writes reach the render.
+                    // Scoped to no-anchor documents so this never crosses the anchor-scroll-
+                    // container / position-visibility machinery, which keeps the DOM-shift below.
+                    if (NativeAnchorPlacement && !isDocScrollingElement && !DocumentHasAnchorContent())
+                    {
+                        if (scrollTop != 0)
+                            SetAttr(el, "data-broiler-scroll-top",
+                                scrollTop.ToString(CultureInfo.InvariantCulture));
+                        if (scrollLeft != 0)
+                            SetAttr(el, "data-broiler-scroll-left",
+                                scrollLeft.ToString(CultureInfo.InvariantCulture));
+
+                        // Recurse into children (nested scroll containers) and skip the DOM-shift.
+                        for (int i = 0; i < el.ChildNodes.Count; i++)
+                            if (ChildAt(el, i) is DomElement scrolledChild)
+                                ApplyScrollSimulationTree(scrolledChild);
+                        return;
+                    }
+
                     // Wrap all children in a positioned div that shifts content
                     // upward / leftward.  Using position:relative + top/left
                     // ensures the shifted content is clipped correctly by the
@@ -172,6 +196,16 @@ public sealed partial class DomBridge
     }
     
     private double GetScrollSimulationScaleFactor() => HasActiveVisualViewport() ? GetVisualViewportScale() : 1;
+
+    /// <summary>
+    /// Whether the document has any registered anchor (a named <c>anchor-name</c>) — i.e.
+    /// CSS anchor positioning could be active. Used to scope the native scroll handoff: when
+    /// there are no anchors, none of the anchor-scroll-container / position-visibility
+    /// machinery runs, so a scroll container can be handed to the engine's scroll post-pass
+    /// without any interaction with it. <c>_anchorCandidates</c> is populated by
+    /// <c>BuildAnchorRegistry</c> (step 1), well before scroll simulation (step 8).
+    /// </summary>
+    private bool DocumentHasAnchorContent() => _anchorCandidates is { Count: > 0 };
 
     private static bool HasOverflowClipping(Dictionary<string, string> props)
     {

--- a/src/Broiler.Wpt.Tests/NativeAnchorContainCbWptTests.cs
+++ b/src/Broiler.Wpt.Tests/NativeAnchorContainCbWptTests.cs
@@ -1,0 +1,118 @@
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// End-to-end proof of the Phase 5 transform/contain containing-block expansion
+/// (P5.8d.2b) through the full WPT render pipeline
+/// (<see cref="WptTestRunner.RenderHtmlFileBitmapPublic"/>).
+///
+/// The anchored target's containing block is established by <c>contain: layout</c> —
+/// a NON-position property (the css-anchor-position <c>transform-010/015/016</c>
+/// corpus pattern) — not by <c>position: relative</c>. On the baked path the bridge's
+/// <c>EnsureContainingBlockPositioning</c> pre-bakes <c>position: relative</c> onto the
+/// <c>contain: layout</c> box so the renderer treats it as the containing block; with
+/// the native lever on the bridge drops that write and the Broiler.Layout engine
+/// resolves the <c>contain</c> containing block natively
+/// (<c>CssBox.FindPositionedContainingBlock</c> +
+/// <c>EstablishesNonPositionAbsPosContainingBlock</c>). Both paths must place the box
+/// against the inner 200×200 box, not the viewport — so the auto-sized (fill-the-cell)
+/// target's SIZE, which would differ if the containing block climbed to the viewport,
+/// pins that the engine binds it to the <c>contain</c> box.
+///
+/// Fixture: a 200×200 <c>contain: layout</c> box at the origin; a uniquely named anchor
+/// <c>--a</c> (20×20 at (40,40), right/bottom (60,60)); and an auto-sized red
+/// <c>position-area: bottom right</c> target anchored to <c>--a</c>. The bottom-right cell
+/// is [60..200]×[60..200] (the box's right/bottom is 200) so the filled target occupies
+/// (60,60)–(199,199) — 140×140. Were the containing block NOT resolved to the
+/// <c>contain</c> box, it would climb to the 400×400 viewport and the auto-sized target
+/// would fill a 340×340 cell — so the fill size proves the <c>contain</c> box is the CB.
+/// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
+public class NativeAnchorContainCbWptTests : IDisposable
+{
+    private readonly bool _previousLever = WptTestRunner.NativeAnchorPlacement;
+
+    public void Dispose()
+    {
+        WptTestRunner.NativeAnchorPlacement = _previousLever;
+        Program.ResetTestHooks();
+    }
+
+    private const string Html = @"<!DOCTYPE html><meta charset=""utf-8"">
+<style>
+  body { margin: 0; }
+  #cb { contain: layout; width: 200px; height: 200px; }
+  #anchor { position: absolute; left: 40px; top: 40px; width: 20px; height: 20px; anchor-name: --a; }
+  #target { position: absolute; position-anchor: --a; position-area: bottom right; background: #ff0000; }
+</style>
+<div id=""cb""><div id=""anchor""></div><div id=""target""></div></div>";
+
+    private static (int x0, int y0, int x1, int y1, int count) RedBox(BBitmap bmp, int w, int h)
+    {
+        int x0 = int.MaxValue, y0 = int.MaxValue, x1 = -1, y1 = -1, count = 0;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                var p = bmp.GetPixel(x, y);
+                if (p.R > 200 && p.G < 80 && p.B < 80)
+                {
+                    count++;
+                    if (x < x0) x0 = x;
+                    if (y < y0) y0 = y;
+                    if (x > x1) x1 = x;
+                    if (y > y1) y1 = y;
+                }
+            }
+        return (x0, y0, x1, y1, count);
+    }
+
+    private static (int x0, int y0, int x1, int y1, int count) Render(bool nativeAnchor)
+    {
+        WptTestRunner.NativeAnchorPlacement = nativeAnchor;
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-contain-cb-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "contain-cb.html");
+            File.WriteAllText(file, Html);
+
+            var runner = new WptTestRunner(400, 400);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+            return RedBox(bmp, 400, 400);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void NativeLeverOn_EngineResolvesContainCb_AndFillsCell()
+    {
+        var red = Render(nativeAnchor: true);
+
+        Assert.True(red.count > 0, "red target box not painted under the native lever.");
+        Assert.True(System.Math.Abs(red.x0 - 60) <= 2, $"red left={red.x0}, expected ~60.");
+        Assert.True(System.Math.Abs(red.y0 - 60) <= 2, $"red top={red.y0}, expected ~60.");
+        Assert.True(System.Math.Abs(red.x1 - 199) <= 2, $"red right={red.x1}, expected ~199 (fills the 140-wide cell, not the 340-wide viewport cell).");
+        Assert.True(System.Math.Abs(red.y1 - 199) <= 2, $"red bottom={red.y1}, expected ~199 (fills the 140-tall cell).");
+    }
+
+    [Fact]
+    public void BridgeAndEnginePaths_Agree_OnContainCb()
+    {
+        // Lever off → the bridge pre-bakes position:relative on the contain:layout box;
+        // lever on → the engine resolves the contain containing block natively. Both must
+        // bind the target to the inner box (same fill cell).
+        var baked = Render(nativeAnchor: false);
+        var native = Render(nativeAnchor: true);
+
+        Assert.True(baked.count > 0 && native.count > 0, "target box missing in one of the paths.");
+        Assert.True(System.Math.Abs(baked.x0 - native.x0) <= 2, $"left differs: baked={baked.x0}, native={native.x0}.");
+        Assert.True(System.Math.Abs(baked.y0 - native.y0) <= 2, $"top differs: baked={baked.y0}, native={native.y0}.");
+        Assert.True(System.Math.Abs(baked.x1 - native.x1) <= 2, $"right differs: baked={baked.x1}, native={native.x1}.");
+        Assert.True(System.Math.Abs(baked.y1 - native.y1) <= 2, $"bottom differs: baked={baked.y1}, native={native.y1}.");
+    }
+}

--- a/src/Broiler.Wpt.Tests/NativeScrollParityWptTests.cs
+++ b/src/Broiler.Wpt.Tests/NativeScrollParityWptTests.cs
@@ -1,0 +1,150 @@
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// End-to-end proof of the Phase 5 native scroll-offset expansion (P5.8d.2b) through the
+/// full WPT render pipeline (<see cref="WptTestRunner.RenderHtmlFileBitmapPublic"/>).
+///
+/// A JS-set <c>scrollTop</c> on an <c>overflow: hidden</c> container is rendered two ways:
+/// the bridge's DOM-shift (lever off — a <c>position:relative</c> wrapper offsets the
+/// content) and the Broiler.Layout engine's scroll post-pass (lever on — the bridge marks
+/// the container with <c>data-broiler-scroll-top</c> and the engine translates the content,
+/// clipped by the container's overflow box). Both must place the scrolled marker in the
+/// same spot.
+///
+/// Fixture: a 100×100 <c>overflow:hidden</c> container at (20,20); inside it a 50px spacer,
+/// a 20px red marker (content-y 50–70), and a tall tail. With <c>scrollTop = 30</c> the
+/// marker shifts up 30px, so it paints at container-y 20 → absolute y 40 (rows 40–59),
+/// x 20–119. Without the scroll it would sit at y 70 — so the marker's y position pins that
+/// the scroll offset was applied.
+/// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
+public class NativeScrollParityWptTests : IDisposable
+{
+    private readonly bool _previousLever = WptTestRunner.NativeAnchorPlacement;
+
+    public void Dispose()
+    {
+        WptTestRunner.NativeAnchorPlacement = _previousLever;
+        Program.ResetTestHooks();
+    }
+
+    private const string Html = @"<!DOCTYPE html><meta charset=""utf-8"">
+<style>
+  body { margin: 0; }
+  #sc { position: absolute; left: 20px; top: 20px; width: 100px; height: 100px; overflow: hidden; }
+  #spacer { height: 50px; }
+  #marker { height: 20px; background: #ff0000; }
+  #tail { height: 200px; }
+</style>
+<div id=""sc""><div id=""spacer""></div><div id=""marker""></div><div id=""tail""></div></div>
+<script>document.getElementById('sc').scrollTop = 30;</script>";
+
+    // A marker scrolled ENTIRELY above the container's top edge: content-y 10–30 with
+    // scrollTop 40 → container-y -30..-10, so it must be clipped away (this is the top-edge
+    // clip the bridge worked around with visibility:hidden; the engine's overflow box must
+    // clip it too). A second visible green marker pins that the container still paints.
+    private const string HtmlScrolledAbove = @"<!DOCTYPE html><meta charset=""utf-8"">
+<style>
+  body { margin: 0; }
+  #sc { position: absolute; left: 20px; top: 20px; width: 100px; height: 100px; overflow: hidden; }
+  #top { height: 10px; }
+  #marker { height: 20px; background: #ff0000; }
+  #gap { height: 60px; }
+  #visible { height: 20px; background: #ff0000; }
+  #tail { height: 200px; }
+</style>
+<div id=""sc""><div id=""top""></div><div id=""marker""></div><div id=""gap""></div><div id=""visible""></div><div id=""tail""></div></div>
+<script>document.getElementById('sc').scrollTop = 40;</script>";
+
+    private static (int x0, int y0, int x1, int y1, int count) RedBox(BBitmap bmp, int w, int h)
+    {
+        int x0 = int.MaxValue, y0 = int.MaxValue, x1 = -1, y1 = -1, count = 0;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                var p = bmp.GetPixel(x, y);
+                if (p.R > 200 && p.G < 80 && p.B < 80)
+                {
+                    count++;
+                    if (x < x0) x0 = x;
+                    if (y < y0) y0 = y;
+                    if (x > x1) x1 = x;
+                    if (y > y1) y1 = y;
+                }
+            }
+        return (x0, y0, x1, y1, count);
+    }
+
+    private static (int x0, int y0, int x1, int y1, int count) Render(bool nativeAnchor, string html = Html)
+    {
+        WptTestRunner.NativeAnchorPlacement = nativeAnchor;
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-native-scroll-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "scroll.html");
+            File.WriteAllText(file, html);
+
+            var runner = new WptTestRunner(200, 200);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+            return RedBox(bmp, 200, 200);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void NativeLeverOn_EngineAppliesScrollOffset()
+    {
+        var red = Render(nativeAnchor: true);
+
+        Assert.True(red.count > 0, "red marker not painted under the native lever.");
+        // Scrolled up 30px: marker at container-y 20 → absolute y 40 (not y 70 unscrolled).
+        Assert.True(System.Math.Abs(red.y0 - 40) <= 2, $"marker top={red.y0}, expected ~40 (scrolled).");
+        Assert.True(System.Math.Abs(red.y1 - 59) <= 2, $"marker bottom={red.y1}, expected ~59.");
+        Assert.True(System.Math.Abs(red.x0 - 20) <= 2, $"marker left={red.x0}, expected ~20.");
+        Assert.True(System.Math.Abs(red.x1 - 119) <= 2, $"marker right={red.x1}, expected ~119.");
+    }
+
+    [Fact]
+    public void BridgeAndEnginePaths_Agree_OnScrollOffset()
+    {
+        // Lever off → the bridge DOM-shifts; lever on → the engine translates. Both must
+        // place the scrolled marker in the same rectangle (native scroll parity).
+        var baked = Render(nativeAnchor: false);
+        var native = Render(nativeAnchor: true);
+
+        Assert.True(baked.count > 0 && native.count > 0, "marker missing in one of the paths.");
+        Assert.True(System.Math.Abs(baked.x0 - native.x0) <= 2, $"left differs: baked={baked.x0}, native={native.x0}.");
+        Assert.True(System.Math.Abs(baked.y0 - native.y0) <= 2, $"top differs: baked={baked.y0}, native={native.y0}.");
+        Assert.True(System.Math.Abs(baked.x1 - native.x1) <= 2, $"right differs: baked={baked.x1}, native={native.x1}.");
+        Assert.True(System.Math.Abs(baked.y1 - native.y1) <= 2, $"bottom differs: baked={baked.y1}, native={native.y1}.");
+    }
+
+    [Fact]
+    public void NativeLeverOn_ClipsContentScrolledAboveTheTopEdge()
+    {
+        var red = Render(nativeAnchor: true, html: HtmlScrolledAbove);
+
+        // The container top is y=20. Nothing red may paint above it: the scrolled-above
+        // marker (content-y 10–30, scrollTop 40 → container-y -30..-10) must be clipped.
+        Assert.True(red.count > 0, "no red painted at all — the visible marker should show.");
+        Assert.True(red.y0 >= 20 - 1, $"red leaked above the container top edge (y0={red.y0}, container top=20).");
+    }
+
+    [Fact]
+    public void BridgeAndEnginePaths_Agree_WhenContentScrolledAboveTop()
+    {
+        var baked = Render(nativeAnchor: false, html: HtmlScrolledAbove);
+        var native = Render(nativeAnchor: true, html: HtmlScrolledAbove);
+
+        Assert.True(baked.count > 0 && native.count > 0, "visible marker missing in one of the paths.");
+        Assert.True(System.Math.Abs(baked.y0 - native.y0) <= 2, $"top differs: baked={baked.y0}, native={native.y0}.");
+        Assert.True(System.Math.Abs(baked.y1 - native.y1) <= 2, $"bottom differs: baked={baked.y1}, native={native.y1}.");
+    }
+}


### PR DESCRIPTION
## Summary

Completes two Phase 5 complexity-reduction expansions (P5.8d.2b) by moving geometry resolution from the bridge to the Broiler.Layout engine:

1. **Transform/contain/will-change containing blocks** — the engine now natively recognizes boxes that establish absolutely-positioned containing blocks via `transform`, `contain: layout/paint/strict/content`, or `will-change: transform`, eliminating the bridge's `EnsureContainingBlockPositioning` pre-bake of `position:relative` in native mode.

2. **Native scroll offset (first increment)** — the engine now simulates script-set `scrollTop`/`scrollLeft` for non-document scroll containers on pages without anchor content, translating child boxes and clipping via the container's overflow box, eliminating the bridge's DOM-shift wrapper in that case.

Both features are gated by `NativeAnchorPlacement.Enabled` (default off), so default-off layout remains byte-identical. Baked vs. native paths achieve pixel-identical parity on all test fixtures.

## Key Changes

### Transform/contain/will-change containing blocks

- **Engine (`CssBox.ContainingBlock.cs`):** `FindPositionedContainingBlock` now recognizes boxes establishing a containing block via non-`none` `transform`, `contain: layout/paint/strict/content`, or `will-change: transform` under the native-anchor lever. New `EstablishesNonPositionAbsPosContainingBlock()` predicate mirrors the bridge's `EstablishesContainingBlock` exactly.

- **Engine (`CssBoxProperties.cs`):** Added `WillChange` property to track the CSS Will Change Module Level 1 hint list; the cascade projects declared `will-change` onto the box.

- **Engine (`CssUtils.cs`):** Added getter/setter arms for `will-change` property access.

- **Bridge (`AnchorResolver.cs`):** `ResolveAnchorPositions` now skips `EnsureContainingBlockPositioning` entirely in native mode, so no `position:relative` write from this pass reaches the native render path.

- **Tests:** 
  - `NativeAnchorPlacementTests.cs` +12 tests: transform/contain/will-change CB resolution, static-block control, and predicate mirror-table.
  - `NativeAnchorWillChangeCbPipelineTests.cs` (new): full parse → cascade → layout pipeline proof that `will-change: transform` establishes a CB natively.
  - `NativeAnchorContainCbWptTests.cs` (new): full WPT render proof that `contain: layout` CB is resolved natively and pixel-agrees with baked path.

### Native scroll offset (first increment)

- **Engine (`CssBox.Scroll.cs`, new):** `RunScrollSimulation` post-pass (gated by `NativeAnchorPlacement.Enabled`, runs before `RunNativeAnchorPlacement`) translates child boxes of scroll containers marked with `data-broiler-scroll-top`/`-left` by the negative offset via existing `OffsetTop`/`OffsetLeft` (which already skip `position:fixed`). The container's overflow box clips the shifted content at paint.

- **Bridge (`ScrollSimulation.cs`):** In native mode, for non-document scroll containers on pages with no anchor content (`!DocumentHasAnchorContent()`), writes the offset as `data-broiler-scroll-top`/`-left` attributes and skips the wrapper-div DOM mutation entirely. Scoped to no-anchor documents so it never crosses anchor-scroll-container / position-visibility machinery.

- **Tests:**
  - `NativeScrollParityWptTests.cs` (new): full WPT render proof that JS-`scrollTop` on an `overflow:hidden` container places the scrolled marker in the same rectangle baked vs. native, and clips content scrolled above the top edge.

## Notable Implementation Details

- The transform/contain/will-change expansion is a **parity move with no corpus gain** (like `position-visibility`

https://claude.ai/code/session_01YKTbBcsv5FwMpyzGVC84Qd