### PR TITLE
Repoint submodules from MaiRat to Broiler-Platform

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,20 +1,20 @@
 [submodule "Broiler.Graphics"]
 	path = Broiler.Graphics
-	url = https://github.com/MaiRat/Broiler.Graphics.git
+	url = https://github.com/Broiler-Platform/Broiler.Graphics.git
 	branch = main
 [submodule "Broiler.JS"]
 	path = Broiler.JS
-	url = https://github.com/MaiRat/Broiler.JS.git
+	url = https://github.com/Broiler-Platform/Broiler.JS.git
 	branch = main
 [submodule "Broiler.HTML"]
 	path = Broiler.HTML
-	url = https://github.com/MaiRat/Broiler.HTML.git
+	url = https://github.com/Broiler-Platform/Broiler.HTML.git
 	branch = main
 [submodule "Broiler.CSS"]
 	path = Broiler.CSS
-	url = https://github.com/MaiRat/Broiler.CSS.git
+	url = https://github.com/Broiler-Platform/Broiler.CSS.git
 	branch = main
 [submodule "Broiler.DOM"]
 	path = Broiler.DOM
-	url = https://github.com/MaiRat/Broiler.DOM.git
+	url = https://github.com/Broiler-Platform/Broiler.DOM.git
 	branch = main


### PR DESCRIPTION
## What

Repoints all five git submodules from `github.com/MaiRat/Broiler.*` to `github.com/Broiler-Platform/Broiler.*` in `.gitmodules`:

- `Broiler.Graphics`
- `Broiler.JS`
- `Broiler.HTML`
- `Broiler.CSS`
- `Broiler.DOM`

## Why

These submodule repos moved to the `Broiler-Platform` org. The main repo already originates there (`Broiler-Platform/Broiler`); this aligns the submodules with the same canonical org so fresh clones and CI fetch from the right place.

## Safety checks performed

- ✅ All five repos confirmed reachable under `Broiler-Platform`.
- ✅ Every currently-pinned submodule commit already exists on its new `Broiler-Platform` remote, so clone-by-pointer and `git submodule update` are unaffected.
- ✅ No submodule pointers (gitlinks) were moved — this is a URL-only change.

## Reviewer notes

- Only `.gitmodules` is tracked here. Existing local checkouts also need `git submodule sync` to update their local `.git/config` and each submodule's own `origin` (already done in the working environment; other contributors should run it after pulling).
- Push-workflow caveat: submodule pushes previously succeeded via an in-scope redirect from the old `MaiRat` remotes. With origins now at `Broiler-Platform` directly, a first submodule push may hit the 403 egress-scope path (patch fallback per `CLAUDE.md`) unless `Broiler-Platform/Broiler.*` is in the session's GitHub scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)