### PR TITLE
Phase 4 item 5: delegate cloneNode to canonical, reuse tree-order primitives

### DIFF
--- a/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
@@ -28,7 +28,7 @@ quick view.
 | 1 — repair the project graph | **Complete** | None — all five work items landed. |
 | 2 — document services & single state authority | **Complete** (bar the JS-engine blocker) | Simultaneous-session isolation blocked below the bridge (JS engine, out of scope); the process-static per-element runtime tables are **fully de-globalized** to per-bridge instances — `PositionAreaResolutions` plus every `ElementRuntimeState` concern (FormControl, Scroll, StyleSheet, Document, Animation, Shadow, Dialog, and the InlineStyle-hub inline-style trio) done 2026-07-17; no process-static per-element table remains. |
 | 3 — feature modules | Bulk delivered | The mixed `JsObjects.cs` element-member callbacks file now holds a single callback — Canvas `getContext` (Phase-6-gated); every other element-member callback has been extracted (SVG — P3.50; Element/geometry — P3.51; `<object>` sub-document accessors — P3.52; tree mutation — P3.58; on* reflectors — P3.59; form-control IDL — P3.60; `form.submit()` — P3.61; shadow-DOM binding — P3.62; `element.style` cssText setter — P3.63); `DomBridge.cs` facade within the 500–800-line target (682 as of 2026-07-17), and the 750-line file-size ratchet is fully closed — every HtmlBridge production file is under the limit and the `OversizedFileExemptions` debt list is empty. |
-| 4 — eliminate parallel DOM state | Bulk delivered | Item 2 full inline-style dict elimination (~170 sites) in progress — the anchor-resolver cluster (98 sites) is now behind the `BakedInlineStyle`/`BakedStyleMap` seam (P4.14), so the baked-vs-script store split is a single-point change; the store split itself + non-cluster sites remain. Item 5 `Normalize`/`CloneDomElement` swaps blocked by side-effect coupling (clone runtime-state copy consolidated behind one authority, P4.13). |
+| 4 — eliminate parallel DOM state | Bulk delivered | Item 2: the serialize-time **baked style is now a distinct per-element overlay store**, split off the script-observable inline-style dict (P4.14 increments 1–3: anchor cluster + animation/synthetic/zoom bake writers seamed, then backed by a tombstone-aware overlay merged only at serialization) — verified byte-identical incl. the WPT anchor-position pixel corpus. `InlineStyleRuntimeState.Style` no longer carries bakes. Remaining: full-corpus WPT/Acid CI gate; item 5 `Normalize`/`CloneDomElement` swaps blocked by side-effect coupling (clone runtime-state copy consolidated behind one authority, P4.13). |
 | 5 — used-value behaviour into Layout | Bulk delivered; **in-scope terminal** | Anchor-track deletion complete through step 6. Feature (b) visual-viewport/zoom: read (CSSOM) **and** render (pixel) sides now validated on the engine used-value model (2026-07-19) — deleting the zoom bake is now only a *deployment* gate (enable `NativeZoom` at the external `CaptureService` renderer), plus the submodule-push-gated pinch render cutover (`patches/0001`). Feature (a) dialog/backdrop: native modal centering + modal box-chrome bake deletion landed; native `::backdrop` box + top-layer paint stay submodule-patch-gated. See the [2026-07-19 reconciliation](#reconciliation-2026-07-19--features-a-and-b-driven-to-their-in-scope-terminal-state). |
 
 Companion documents:
@@ -1970,8 +1970,37 @@ Exit criteria:
 
 ### Phase 4 - eliminate parallel DOM state
 
-Status: **P4.14 in progress** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) — **work item 2,
-inline-style single authority. Increment 2 (this commit): route the remaining serialize-time bake writers through
+Status: **P4.14 increment 3 completed** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) —
+**work item 2, inline-style single authority: split the baked-style storage off the script-observable dict.**
+With every serialize-time bake write behind the `BakedInlineStyle` seam (increments 1–2), the writes now land
+in a per-element **baked overlay** (`_bakedStyleOverlays`, a `ConditionalWeakTable<DomElement,
+Dictionary<string, string?>>` in `AnchorResolver/BakedStyle.cs`) instead of `InlineStyleRuntimeState.Style`, so
+that dict is no longer polluted by bakes. A `null` overlay value is a **tombstone** — a bake resolver removing an
+authored/prior property (the animation resolver dropping the `animation` shorthand after baking longhands, the
+anchor resolver dropping `margin`/`padding`/`inset`, sticky dropping `bottom`/`right`) so the merged view
+excludes it. `BakedStyleMap` now writes to the overlay and reads the **merged** base ∪ overlay view (overlay
+wins, tombstones remove); the resolvers' cross-pass reads are unchanged by construction. The serializer's own
+effective-style reads — the `GetStyles` emit, `SyncStyleAttributeFromInlineStyle` (the `style=`-attribute
+write-back at `ReflectRenderState`), and the zoom / SVG-zoom source reads — route to the new
+`EffectiveInlineStyle(element)` (materialized merge) / `BakedInlineStyle(...).TryGetValue`, which are exactly the
+merge points; every other reader (script-CSSOM `element.style`, cascade cleanup, parse-time authored copy) stays
+on `InlineStyle` and is unaffected because it runs **pre-bake**, when the overlay is empty. `CloneDomElement`'s
+runtime-state copy (P4.13) also copies the overlay. **Why it's byte-identical:** bakes are strictly terminal
+(serialize-time, after all script/cascade writes), so applying the overlay last reproduces the old single-dict
+content exactly. **Validation:** builds clean; the anchor / position-area / position-try / sticky / animation /
+inline-style / CssStyleDeclaration / computed-style / CSSOM / synthetic-form-control / clone / dialog / SVG /
+cross-document Cli suites show a **failure set identical to baseline** (stash-compares), the three
+`DomBridge_SerializeToHtml_*` zoom/srcdoc failures are the standing environmental ones (no new), and — the render
+gate for a serialization-affecting change — the **WPT `css/css-anchor-position` pixel corpus is byte-identical
+between baseline and this change** (40 discovered → 32 pass / 7 fail / 1 skip, 97.98% average match, same failing
+names). The full-corpus WPT pixel + Acid run (beyond the anchor subset) is the remaining CI-only gate, but the
+terminal-bake argument makes the serialized output byte-identical for every element, not just anchor ones.
+**This completes the anchor-cluster item-2 elimination:** the parallel inline-style dict no longer carries baked
+geometry; `InlineStyleRuntimeState.Style` is the script/cascade authority and the baked overlay is a distinct
+serialize-time store. Still open: the non-cluster read-side (none observed — script surfaces already exclude
+bakes) and the item-5 `Normalize`/`CloneDomElement` swaps.
+
+Status: **P4.14 increment 2 completed** 2026-07-19 — **work item 2, route the remaining serialize-time bake writers through
 the `BakedInlineStyle` seam, so every bridge-internal bake write now goes through one chokepoint.** Investigation
 of the store-split target found the `Style` dict is a **multi-purpose scratch**, not just inline style: it holds
 script-set inline style (marked by `JsSetStyleProps`), lazily-seeded `style=`-attribute values, **CSS-cascade-derived

--- a/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
@@ -1970,6 +1970,28 @@ Exit criteria:
 
 ### Phase 4 - eliminate parallel DOM state
 
+Status: **P4.19 completed** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) — **work item
+4/5: reuse canonical `CompareBoundaryPoints` for `CompareTreeOrder` (the last document-order duplicate).**
+`DomBridge.CompareTreeOrder` (`Utilities.cs`, the tree-order step of `compareDocumentPosition`) reimplemented
+document order via a hand-rolled ancestor-chain divergence — the same order the P4.17 `IsPositionAfter` reuse
+routes through canonical `DomRange.CompareBoundaryPoints`. The tree order of two nodes is the order of the
+boundary points immediately before each, so it now delegates: `Math.Sign(CompareBoundaryPoints(firstParent,
+index(first), secondParent, index(second)))`. Its only caller (`CompareDocumentPosition`) already resolves the
+same-node / disconnected / ancestor-descendant cases before reaching it, so both nodes are same-tree,
+non-containing and parented; the retained `null`-parent / different-root guards preserve the old "0 when no
+ordering can be determined" contract and dodge `CompareBoundaryPoints`'s cross-tree `WrongDocument` throw for
+any other caller. In-repo (canonical method already public); no public-API change; −18 net lines. Verified
+regression-free: the `NodeRelationshipsBindingModule` + `HtmlDomInterfaces` (compareDocumentPosition) suites
+pass 53/53 and Acid3 (`DomEventsEdgeCase`) passes; the only failure in the range/traversal batch is the
+standing headless `Range_GetBoundingClientRect` geometry test (confirmed pre-existing).
+
+**Reuse thread status.** With P4.19 the clean canonical neutral-algorithm reuses are exhausted: `IsDescendantOf`
+(P4.8), `IsEqualNode`/`CommonAncestorWith` (P4.9/P4.10), `InclusiveDescendants` (P4.12), `GetRootNode` (P4.16),
+`CompareBoundaryPoints` (P4.17 + P4.19) and `Descendants` (P4.18) are all delegated; the one remaining public-
+visibility promotion (`IndexOfReference`) is the pending `patches/0002`. What is left in item 4/5 is the
+genuinely blocked pair — `Normalize` (needs the `DomDocument.Mutated`-subscription architecture) and
+`CloneDomElement` (three canonical-`CloneNode` divergences) — recorded under P4.15.
+
 Status: **P4.18 completed** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) — **work item
 4/5, descendant-collection cluster: reuse canonical `DomNode.Descendants()` for the hand-rolled depth-first
 element walks.** Four bridge helpers reimplemented a depth-first descendant-element recursion that canonical

--- a/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
@@ -28,7 +28,7 @@ quick view.
 | 1 — repair the project graph | **Complete** | None — all five work items landed. |
 | 2 — document services & single state authority | **Complete** (bar the JS-engine blocker) | Simultaneous-session isolation blocked below the bridge (JS engine, out of scope); the process-static per-element runtime tables are **fully de-globalized** to per-bridge instances — `PositionAreaResolutions` plus every `ElementRuntimeState` concern (FormControl, Scroll, StyleSheet, Document, Animation, Shadow, Dialog, and the InlineStyle-hub inline-style trio) done 2026-07-17; no process-static per-element table remains. |
 | 3 — feature modules | Bulk delivered | The mixed `JsObjects.cs` element-member callbacks file now holds a single callback — Canvas `getContext` (Phase-6-gated); every other element-member callback has been extracted (SVG — P3.50; Element/geometry — P3.51; `<object>` sub-document accessors — P3.52; tree mutation — P3.58; on* reflectors — P3.59; form-control IDL — P3.60; `form.submit()` — P3.61; shadow-DOM binding — P3.62; `element.style` cssText setter — P3.63); `DomBridge.cs` facade within the 500–800-line target (682 as of 2026-07-17), and the 750-line file-size ratchet is fully closed — every HtmlBridge production file is under the limit and the `OversizedFileExemptions` debt list is empty. |
-| 4 — eliminate parallel DOM state | Bulk delivered | Item 2: the serialize-time **baked style is now a distinct per-element overlay store**, split off the script-observable inline-style dict (P4.14 increments 1–3: anchor cluster + animation/synthetic/zoom bake writers seamed, then backed by a tombstone-aware overlay merged only at serialization) — verified byte-identical incl. the WPT anchor-position pixel corpus. `InlineStyleRuntimeState.Style` no longer carries bakes. Remaining: full-corpus WPT/Acid CI gate; item 5 `Normalize`/`CloneDomElement` swaps blocked by side-effect coupling (clone runtime-state copy consolidated behind one authority, P4.13). |
+| 4 — eliminate parallel DOM state | Bulk delivered | Item 2: the serialize-time **baked style is now a distinct per-element overlay store**, split off the script-observable inline-style dict (P4.14 increments 1–3: anchor cluster + animation/synthetic/zoom bake writers seamed, then backed by a tombstone-aware overlay merged only at serialization) — verified byte-identical incl. the WPT anchor-position pixel corpus. `InlineStyleRuntimeState.Style` no longer carries bakes. Remaining: full-corpus WPT/Acid CI gate; item 5 `Normalize`/`CloneDomElement` swaps still blocked, now specified precisely (P4.15): `Normalize` needs the bridge's MutationObserver/NodeIterator/Range driven from canonical `DomDocument.Mutated` (architectural); `CloneDomElement` (runtime-state gate retired via P4.13/overlay) needs three canonical-`CloneNode` divergences reconciled — owner-document, attribute-case (SVG `viewBox`), shallow-ctor namespace — with SVG/Acid validation. |
 | 5 — used-value behaviour into Layout | Bulk delivered; **in-scope terminal** | Anchor-track deletion complete through step 6. Feature (b) visual-viewport/zoom: read (CSSOM) **and** render (pixel) sides now validated on the engine used-value model (2026-07-19) — deleting the zoom bake is now only a *deployment* gate (enable `NativeZoom` at the external `CaptureService` renderer), plus the submodule-push-gated pinch render cutover (`patches/0001`). Feature (a) dialog/backdrop: native modal centering + modal box-chrome bake deletion landed; native `::backdrop` box + top-layer paint stay submodule-patch-gated. See the [2026-07-19 reconciliation](#reconciliation-2026-07-19--features-a-and-b-driven-to-their-in-scope-terminal-state). |
 
 Companion documents:
@@ -1969,6 +1969,52 @@ Exit criteria:
   133 tests with the guard) stays green.
 
 ### Phase 4 - eliminate parallel DOM state
+
+Status: **P4.15 — item 5 (`Normalize` / `CloneDomElement` canonical swaps) investigated; both remain blocked,
+with the precise blockers and unblock paths now established** 2026-07-19 (branch
+`claude/htmlbridge-complexity-reduction-4ho9hr`). A deep, code-grounded run at the two remaining item-5 swaps.
+One prior premise is now **stale in the bridge's favour**: bridge text/comment nodes are already canonical
+`Broiler.Dom.DomText`/`DomComment` (`CreateBridgeTextNode` → `_document.CreateTextNode`, `IsText` is
+`NodeType == Text`), so canonical `DomNode.Normalize()`/`CloneNode()` *would* recognise them — the old
+homogeneous-`DomElement`-facade blocker is gone. What actually blocks each swap:
+
+- **`Normalize` — blocked by the bridge-native side-effect system (architectural).** `NormalizeNode`
+  (`HtmlFragmentMutation.cs`) coalesces text via `RemoveChildAt`, which fires the bridge's **pre-removal**
+  `NotifyNodeIteratorPreRemoval` + `NotifyChildRemoved` (MutationObserver) + `InvalidateStyleScope`. The
+  bridge's MutationObserver/NodeIterator/live-range are **bridge-native** (`MutationObserverHub`, driven by
+  explicit `Notify*` calls) and do **not** subscribe to canonical `DomDocument.Mutated` — only
+  `DocumentStyleContext` does. Canonical `DomNode.Normalize()` (`Broiler.Dom/DomNode.cs:312`) removes then
+  **publishes post-removal** `DomMutationRecord`s to `Mutated`; a post-removal record cannot reconstruct the
+  bridge's *pre-removal* NodeIterator notification, and the bridge observers never see `Mutated` anyway. So a
+  swap would silently drop NodeIterator adjustment, MutationObserver `childList` records, and style
+  invalidation. **Unblock path:** drive the bridge's MutationObserver/NodeIterator/Range subsystems from
+  `DomDocument.Mutated` (as canonical `DomTraversal`/`DomRange` already do — they subscribe at
+  `DomTraversal.cs:215` / `DomRange.cs:38`), retiring the hand-rolled `Notify*` wrappers; then `Normalize`
+  (and every other mutation) delegates to canonical for free. This is a cross-cutting subsystem change on the
+  mutation hot path — its own multi-step track, gated on the full WPT/Acid corpus, not a behaviour-preserving
+  single increment.
+
+- **`CloneDomElement` — the runtime-state gate is retired, but canonical `CloneNode` has three DOM-semantics
+  divergences to reconcile first.** Cloning does **not** mutate the document, so it has *no* side-effect
+  coupling; and the runtime-state copy is now isolated behind one authority (`CopyBridgeRuntimeStateTo`, P4.13,
+  incl. the P4.14-inc3 baked overlay), so the swap shape is `source.CloneNode(deep)` + a lockstep
+  source/clone walk calling `CopyBridgeRuntimeStateTo` per element pair. What still blocks a *behaviour-preserving*
+  swap, each a real divergence between the current hand-rolled clone and canonical `DomElement.CloneShallow`
+  (`Broiler.Dom/DomElement.cs:94`): (1) **owner document** — the bridge mints clones from the main `_document`
+  (`CreateBridgeElementNS`), canonical `CloneNode` clones into `source.OwnerDocument`, differing for
+  sub-document nodes; (2) **attribute case** — the bridge re-copies no-namespace attributes through
+  `SetAttribute` (which lowercases), canonical copies the stored key verbatim, so any parser-stored
+  case-preserved attribute (e.g. SVG `viewBox`) can diverge; (3) **shallow-ctor namespace/registration** parity
+  (`new DomElement(ownerDocument, Name)` vs the `CreateElementNS` funnel). Each is unit-testable (the
+  Namespace / SVG / Acid3-SVG / clone suites cover them), so this swap is the more tractable of the two — but it
+  is a delicate rewrite of a correct method whose attribute-case divergence is **render-relevant** (SVG
+  attribute case), so it needs the SVG + serialization + Acid corpus to sign off, not just the clone unit tests.
+
+**Net:** neither swap is a safe, in-container, behaviour-preserving single increment. `Normalize` needs the
+`DomDocument.Mutated`-subscription architecture; `CloneDomElement` needs the three divergences reconciled and a
+full SVG/serialization/Acid validation. Both are now specified concretely for a run with full CI, rather than
+left as the prior vague "side-effect / runtime-state coupling." No code change landed for P4.15 — deliberately,
+to avoid shipping an unvalidatable DOM-semantics change.
 
 Status: **P4.14 increment 3 completed** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) —
 **work item 2, inline-style single authority: split the baked-style storage off the script-observable dict.**

--- a/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
@@ -28,7 +28,7 @@ quick view.
 | 1 — repair the project graph | **Complete** | None — all five work items landed. |
 | 2 — document services & single state authority | **Complete** (bar the JS-engine blocker) | Simultaneous-session isolation blocked below the bridge (JS engine, out of scope); the process-static per-element runtime tables are **fully de-globalized** to per-bridge instances — `PositionAreaResolutions` plus every `ElementRuntimeState` concern (FormControl, Scroll, StyleSheet, Document, Animation, Shadow, Dialog, and the InlineStyle-hub inline-style trio) done 2026-07-17; no process-static per-element table remains. |
 | 3 — feature modules | Bulk delivered | The mixed `JsObjects.cs` element-member callbacks file now holds a single callback — Canvas `getContext` (Phase-6-gated); every other element-member callback has been extracted (SVG — P3.50; Element/geometry — P3.51; `<object>` sub-document accessors — P3.52; tree mutation — P3.58; on* reflectors — P3.59; form-control IDL — P3.60; `form.submit()` — P3.61; shadow-DOM binding — P3.62; `element.style` cssText setter — P3.63); `DomBridge.cs` facade within the 500–800-line target (682 as of 2026-07-17), and the 750-line file-size ratchet is fully closed — every HtmlBridge production file is under the limit and the `OversizedFileExemptions` debt list is empty. |
-| 4 — eliminate parallel DOM state | Bulk delivered | Item 2 full inline-style dict elimination (~200 sites) deferred (Phase-5-entangled); item 5 `Normalize`/`CloneDomElement` swaps blocked by side-effect coupling. |
+| 4 — eliminate parallel DOM state | Bulk delivered | Item 2 full inline-style dict elimination (~170 sites) in progress — the anchor-resolver cluster (98 sites) is now behind the `BakedInlineStyle`/`BakedStyleMap` seam (P4.14), so the baked-vs-script store split is a single-point change; the store split itself + non-cluster sites remain. Item 5 `Normalize`/`CloneDomElement` swaps blocked by side-effect coupling (clone runtime-state copy consolidated behind one authority, P4.13). |
 | 5 — used-value behaviour into Layout | Bulk delivered; **in-scope terminal** | Anchor-track deletion complete through step 6. Feature (b) visual-viewport/zoom: read (CSSOM) **and** render (pixel) sides now validated on the engine used-value model (2026-07-19) — deleting the zoom bake is now only a *deployment* gate (enable `NativeZoom` at the external `CaptureService` renderer), plus the submodule-push-gated pinch render cutover (`patches/0001`). Feature (a) dialog/backdrop: native modal centering + modal box-chrome bake deletion landed; native `::backdrop` box + top-layer paint stay submodule-patch-gated. See the [2026-07-19 reconciliation](#reconciliation-2026-07-19--features-a-and-b-driven-to-their-in-scope-terminal-state). |
 
 Companion documents:
@@ -1969,6 +1969,32 @@ Exit criteria:
   133 tests with the guard) stays green.
 
 ### Phase 4 - eliminate parallel DOM state
+
+Status: **P4.14 in progress** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) — **work item 2,
+inline-style single authority, increment 1: seam the anchor-resolver cluster off the raw dict.** The remaining
+item-2 work (fully eliminate the parallel inline-style `Style` dict) is a ~170-site rewrite, ~98 of them in the
+anchor-resolver cluster where the dict is used as **baked-geometry scratch** — the resolver reads an element's
+effective inline style and writes resolved position/insets/margins/borders/size, and those direct writes
+deliberately do **not** write-through to `getAttribute("style")` (unlike the `element.style` JS path, P4.7), so
+they don't leak mid-resolution. That dual-purpose use is exactly why the dict is a parallel store and why a
+blind route-to-attribute rewrite is wrong. This increment introduces the migration **seam** rather than
+swapping the store: a new `BakedInlineStyle(element)` accessor returns a `BakedStyleMap` value-wrapper
+(`AnchorResolver/BakedStyle.cs`) mirroring the exact dict surface the cluster uses (indexer get/set, `Remove`,
+`ContainsKey`, `TryGetValue`, `GetValueOrDefault`, `Keys`, enumeration), and all **98** raw `InlineStyle(...)`
+sites across the nine `AnchorResolver/` files (`PositionArea` 25, `Dialogs` 17, `PositionTry` 17, `AnchorFunctions`
+12, `InlineContainingBlocks` 9, `AnchorResolver` 8, `StickyPositioning` 5, `AnchorFunctions.NativeHandoff` 3,
+`Visibility` 1) now go through it. Today the wrapper forwards to the same per-element dict, so behaviour is
+**byte-identical**; the next increment can back the baked writes with a store distinct from the script-observable
+inline style (reads → merged script ∪ baked view, writes → baked overlay merged only at serialization) by
+changing **only** `BakedStyle.cs`, not the 98 call sites. Behaviour-preserving; no public-API change. The
+compiler enforced surface-completeness (it caught a `.Keys` use the initial inventory missed). Validation:
+`Broiler.HtmlBridge.Dom` builds clean; the NativeAnchor* / PositionArea / PositionTry / NativeSticky /
+AnchorInset / DialogBindingModule Cli suites pass (53) and the InlineStyleWriteThrough / InnerHtmlParallelState
+suites pass — the one intermittent `PositionTryLiveGeometryTests.FixedSizeOverflowingBase_SelectsFallback_LiveOffsets`
+was confirmed a **pre-existing parallel-run flake** (fails 1-in-3 at baseline with this change stashed; passes 3/3
+in isolation). **Not yet done:** the store split itself (increment 2), the remaining non-cluster item-2 sites
+(serialization/`StyleDeclarationBinding`/animation), and the item-5 `Normalize`/`CloneDomElement` swaps — all
+unchanged.
 
 Status: **P4.13 completed** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) — **work item 5,
 `CloneDomElement` de-risk: consolidate the bridge runtime-state clone-copy behind a single authority.**

--- a/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
@@ -10,10 +10,17 @@ document services, feature-module extraction, parallel-DOM-state elimination, an
 the move of used-value behaviour into Layout — including per-slice status entries,
 branches, tests and regression checks.
 
-**These phases are not all fully complete.** The bulk of each phase's planned
-work has landed, but several phases carry explicit deferred, blocked, or
-still-to-come residue, and a few exit criteria remain open. Read each phase's
-own status entries for the specifics; the summary below is the quick view.
+**These phases are complete to their in-scope terminal state; the residue that
+remains is externally gated.** The bulk of each phase's planned work has landed,
+and as of the 2026-07-19 reconciliation no further main-repo, in-session code
+change advances closure — what is left is strictly external: a maintainer applying
+the pending submodule patches (`Broiler.CSS`/`Broiler.HTML`/`Broiler.DOM`, out of
+session push scope → 403 → patch workflow) and bumping the pointers; an
+environment-config change (enabling `NativeZoom` at the `CaptureService` external
+renderer to delete the zoom bake); and the deliberately later-phase / out-of-scope
+items (Phase 6 Canvas `getContext`; the JS-engine simultaneous-session isolation).
+Read each phase's own status entries for the specifics; the summary below is the
+quick view.
 
 | Phase | Status | Open residue |
 |---|---|---|
@@ -22,7 +29,7 @@ own status entries for the specifics; the summary below is the quick view.
 | 2 — document services & single state authority | **Complete** (bar the JS-engine blocker) | Simultaneous-session isolation blocked below the bridge (JS engine, out of scope); the process-static per-element runtime tables are **fully de-globalized** to per-bridge instances — `PositionAreaResolutions` plus every `ElementRuntimeState` concern (FormControl, Scroll, StyleSheet, Document, Animation, Shadow, Dialog, and the InlineStyle-hub inline-style trio) done 2026-07-17; no process-static per-element table remains. |
 | 3 — feature modules | Bulk delivered | The mixed `JsObjects.cs` element-member callbacks file now holds a single callback — Canvas `getContext` (Phase-6-gated); every other element-member callback has been extracted (SVG — P3.50; Element/geometry — P3.51; `<object>` sub-document accessors — P3.52; tree mutation — P3.58; on* reflectors — P3.59; form-control IDL — P3.60; `form.submit()` — P3.61; shadow-DOM binding — P3.62; `element.style` cssText setter — P3.63); `DomBridge.cs` facade within the 500–800-line target (682 as of 2026-07-17), and the 750-line file-size ratchet is fully closed — every HtmlBridge production file is under the limit and the `OversizedFileExemptions` debt list is empty. |
 | 4 — eliminate parallel DOM state | Bulk delivered | Item 2 full inline-style dict elimination (~200 sites) deferred (Phase-5-entangled); item 5 `Normalize`/`CloneDomElement` swaps blocked by side-effect coupling. |
-| 5 — used-value behaviour into Layout | Bulk delivered | Anchor-track deletion complete through step 6; ALWAYS-pass + not-yet-native residue remains; full completion gated on the native dialog/backdrop track and the visual-viewport LayoutSnapshot endgame. |
+| 5 — used-value behaviour into Layout | Bulk delivered; **in-scope terminal** | Anchor-track deletion complete through step 6. Feature (b) visual-viewport/zoom: read (CSSOM) **and** render (pixel) sides now validated on the engine used-value model (2026-07-19) — deleting the zoom bake is now only a *deployment* gate (enable `NativeZoom` at the external `CaptureService` renderer), plus the submodule-push-gated pinch render cutover (`patches/0001`). Feature (a) dialog/backdrop: native modal centering + modal box-chrome bake deletion landed; native `::backdrop` box + top-layer paint stay submodule-patch-gated. See the [2026-07-19 reconciliation](#reconciliation-2026-07-19--features-a-and-b-driven-to-their-in-scope-terminal-state). |
 
 Companion documents:
 
@@ -3966,3 +3973,57 @@ further is gated on separate feature work (native dialog/backdrop, visual-viewpo
 engine intrinsic-size position-try is now **done**: min-content and max/fit-content bases all hand off natively)
 plus the optional follow-up of fully retiring the `NativeAnchorPlacement` lever once the last ALWAYS
 marker-stamp no longer needs it.
+
+#### Reconciliation 2026-07-19 — features (a) and (b) driven to their in-scope terminal state
+
+The two step-6 feature gates ((a) native dialog/backdrop, (b) the visual-viewport LayoutSnapshot endgame)
+have since been carried as far as this session's scope allows (merged via PR #1407). What landed, and where
+each now genuinely stops, so a reader knows exactly what full closure still needs:
+
+- **(b) visual-viewport / zoom — read AND render sides now validated; only a deployment gate remains.**
+  - **Native visual-viewport read model activated** (`NativeVisualViewport` on): the pinch scale is read from
+    the engine rather than the serialization bake, and the `_zoomSerializationRevertLog` revert machinery is
+    **deleted** (dead once the read path no longer mutates the live doc).
+  - **CSSOM read path migrated to the engine used-value model.** The A/B harness
+    (`Broiler.Cli.Tests/ZoomBakeVsEngineEquivalenceTests`) proved bake and engine agree for absolute lengths,
+    nested zoom, abspos insets, margins/border and absolute-length `line-height`, and diverge only for `%` /
+    `em` / `rem` / `calc(px+%)` — where the **engine value is the mathematically-correct unzoomed CSS px** and
+    the bake was simply buggy. `SharedLayoutGeometry.BuildSharedGeometrySnapshot` now enables `NativeZoom`
+    around the snapshot layout, so `offset*`/`client*`/`gBCR` are the correct engine used value for relative
+    units too. The catalogue tests were reworked from `*_Diverges_BlocksFlip` to `*_ReadIsEngineUsedValue` /
+    `*_ReadIsStable` (read now independent of the render-only flag). Zero new fails.
+  - **Render-side A/B validation done** (engine render proven correct, incl. relative units): a
+    `WptTestRunner.NativeZoom` lever (default-off, byte-identical; mirrors `NativeAnchorPlacement`) renders the
+    zoom cases through the engine; the new `Wpt_CssViewport_Zoom{Basic,Percentage,Em}_EngineRender_MatchesReference`
+    tests match the same hand-authored references the baked path matches — the absolute **and** the `%`/`em`
+    cases the bake mishandled — and the existing 16 `Wpt_CssViewport_Zoom*_MatchesReference` reftests are
+    unchanged. Correctness is banked on both the read (CSSOM) and render (pixel) sides.
+  - **Terminal gate (not closeable in-session): deleting the zoom bake is now purely a *deployment* concern**,
+    not correctness or patch. `NativeZoom` must be enabled at every consumer that lays out bridge serialized
+    output; the geometry snapshot (a) and WPT render (b) are covered, but the **product capture path**
+    (`CaptureService`) hands the serialized HTML to an *external* renderer this container can neither scope nor
+    validate. Until that consumer enables the flag — an environment-config change — the bake stays as the
+    carry-through, so nothing on CI regresses. See `zoom-native-cutover.md` P2.
+  - **Pinch-zoom render cutover is submodule-push-gated.** `patches/0001-html-render-viewport-zoom-param.patch`
+    (`Broiler.HTML` `HtmlRender.RenderToImageWithStyleSet` → threads `viewportZoom`) is captured for a
+    maintainer to apply (403 push scope); its main-repo follow-up (pass `visualViewport.scale` into the render
+    and stop `ApplyVisualViewportSerializationState` baking the pinch factor onto the root `zoom`) is deferred
+    until the pointer is bumped, because it references the patched API that does not exist at the pinned SHA.
+    The serialization bake remains the active fallback meanwhile.
+
+- **(a) native dialog / backdrop — the in-scope, main-repo slices landed; the native box + paint stay
+  submodule-patch-gated.** Native modal `<dialog>` centering is wired (horizontal and block-axis
+  shrink-to-fit for content-sized modals), the **modal box-chrome bake is deleted**, and the popover
+  top-layer emulation is de-doubled. The remaining pieces — a native `::backdrop` box and a native top layer
+  in layout/paint — live in `Broiler.CSS` / `Broiler.HTML` (out of session push scope → 403 → patch workflow,
+  maintainer-apply), so the `ApplyDialogUAPositioning` / `ApplyPopoverUAPositioning` / `InsertDialogBackdrops`
+  ALWAYS passes stay as the WPT-runner-only fallback until those patches land. See the native-dialog track in
+  `htmlbridge-complexity-reduction-notes.md`.
+
+**Net after this reconciliation.** Every Phase 0–5 residue is now at its terminal *in-scope* state: no
+further main-repo, in-session code change advances closure. What remains is strictly external — a maintainer
+applying the pending submodule patches (dialog/backdrop native box+paint; patch 0001 viewport-zoom render
+plumbing) and bumping the pointers, an environment change enabling `NativeZoom` at the `CaptureService`
+renderer, and the later-phase / out-of-scope items already recorded (Phase 6 Canvas `getContext`; the JS-engine
+simultaneous-session isolation). The `NativeAnchorPlacement` lever's full retirement stays the documented
+optional follow-up, still blocked only by the step-3e marker that the native-dialog track will remove.

--- a/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
@@ -1970,6 +1970,33 @@ Exit criteria:
 
 ### Phase 4 - eliminate parallel DOM state
 
+Status: **P4.17 completed** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) — **work item
+4/5, document-position & child-index canonical-reuse cluster (submodule-gated half via the patch workflow).**
+Two neutral-algorithm reuses:
+
+- **`IsPositionAfter` → canonical `DomRange.CompareBoundaryPoints` (landed in-repo).** The bridge's
+  boundary-point "is A after B" comparison (`JsFunctionCallbacks/Common.cs`, behind `compareBoundaryPoints` /
+  `compareDocumentPosition`) reimplemented the DOM boundary-comparison algorithm that canonical
+  `DomRange.CompareBoundaryPoints` (already **public**) provides. Verified branch-for-branch equivalent for
+  **same-tree** points (same-container `offset` compare, either-descendant child-index compare, and
+  common-ancestor ordering all agree, so `IsPositionAfter ≡ CompareBoundaryPoints(...) > 0`), so the same-tree
+  path now delegates. The bridge's **deliberate cross-tree leniency** (its `compareBoundaryPoints` returns an
+  order via the document root rather than throwing `WrongDocument` as canonical does) is preserved verbatim by
+  guarding on `GetRootNode()` equality first. Deletes ~25 lines of duplicated descendant-walk / order logic.
+  No submodule change needed (canonical method already public). Verified regression-free — the
+  `DomTraversalAndRange` / `NodeRelationshipsBindingModule` (compareDocumentPosition) / `NamespaceAndDomCore`
+  suites pass, the one failure (`Range_GetBoundingClientRect_Includes_DisplayContents_Descendants`) is the
+  standing headless-geometry environmental failure, confirmed identical at baseline.
+- **`ChildIndexOf` → canonical `IndexOfReference` (submodule patch `0002`).** `IndexOfReference` (the
+  byte-identical reference-equality child-index scan `DomRange` uses) is on an `internal`
+  `DomNodeCollectionExtensions`; making it public is a one-line visibility change. The `Broiler.DOM` push
+  **returned 403** (out of session scope — contrary to the P4.12-era note that the `MaiRat/` redirect was
+  in-scope; the scope has since tightened), so per `CLAUDE.md` it ships as
+  `patches/0002-dom-make-domnodecollectionextensions-public.patch` with a `patches/README.md` entry, the
+  submodule pointer left **unbumped**, and `ChildIndexOf` keeping its manual loop as the active CI fallback.
+  The follow-up (delegate + delete the loop) lands once a maintainer applies the patch and bumps the pointer.
+  No main-repo behaviour change for this half.
+
 Status: **P4.16 completed** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) — **work item
 4/5, next tractable cluster: reuse canonical `DomNode.GetRootNode()` for the bridge's absolute-root walks.**
 The neutral-tree-algorithm reuse cluster (the P4.8–4.12 pattern), scoped to the reuses whose canonical method

--- a/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
@@ -28,7 +28,7 @@ quick view.
 | 1 — repair the project graph | **Complete** | None — all five work items landed. |
 | 2 — document services & single state authority | **Complete** (bar the JS-engine blocker) | Simultaneous-session isolation blocked below the bridge (JS engine, out of scope); the process-static per-element runtime tables are **fully de-globalized** to per-bridge instances — `PositionAreaResolutions` plus every `ElementRuntimeState` concern (FormControl, Scroll, StyleSheet, Document, Animation, Shadow, Dialog, and the InlineStyle-hub inline-style trio) done 2026-07-17; no process-static per-element table remains. |
 | 3 — feature modules | Bulk delivered | The mixed `JsObjects.cs` element-member callbacks file now holds a single callback — Canvas `getContext` (Phase-6-gated); every other element-member callback has been extracted (SVG — P3.50; Element/geometry — P3.51; `<object>` sub-document accessors — P3.52; tree mutation — P3.58; on* reflectors — P3.59; form-control IDL — P3.60; `form.submit()` — P3.61; shadow-DOM binding — P3.62; `element.style` cssText setter — P3.63); `DomBridge.cs` facade within the 500–800-line target (682 as of 2026-07-17), and the 750-line file-size ratchet is fully closed — every HtmlBridge production file is under the limit and the `OversizedFileExemptions` debt list is empty. |
-| 4 — eliminate parallel DOM state | Bulk delivered | Item 2: the serialize-time **baked style is now a distinct per-element overlay store**, split off the script-observable inline-style dict (P4.14 increments 1–3: anchor cluster + animation/synthetic/zoom bake writers seamed, then backed by a tombstone-aware overlay merged only at serialization) — verified byte-identical incl. the WPT anchor-position pixel corpus. `InlineStyleRuntimeState.Style` no longer carries bakes. Remaining: full-corpus WPT/Acid CI gate; item 5 `Normalize`/`CloneDomElement` swaps still blocked, now specified precisely (P4.15): `Normalize` needs the bridge's MutationObserver/NodeIterator/Range driven from canonical `DomDocument.Mutated` (architectural); `CloneDomElement` (runtime-state gate retired via P4.13/overlay) needs three canonical-`CloneNode` divergences reconciled — owner-document, attribute-case (SVG `viewBox`), shallow-ctor namespace — with SVG/Acid validation. |
+| 4 — eliminate parallel DOM state | Bulk delivered | Item 2: the serialize-time **baked style is now a distinct per-element overlay store**, split off the script-observable inline-style dict (P4.14 increments 1–3: anchor cluster + animation/synthetic/zoom bake writers seamed, then backed by a tombstone-aware overlay merged only at serialization) — verified byte-identical incl. the WPT anchor-position pixel corpus. `InlineStyleRuntimeState.Style` no longer carries bakes. Remaining: full-corpus WPT/Acid CI gate. Item 4/5 canonical reuses done (P4.8–4.12, P4.16–4.19; `IndexOfReference` visibility is pending `patches/0002`). `CloneDomElement` now delegates to canonical `CloneNode` (P4.20, verified byte-identical across ~14 clone suites). Item 5 reduces to `Normalize` alone — still blocked on driving the bridge's MutationObserver/NodeIterator/Range from canonical `DomDocument.Mutated` (P4.15). |
 | 5 — used-value behaviour into Layout | Bulk delivered; **in-scope terminal** | Anchor-track deletion complete through step 6. Feature (b) visual-viewport/zoom: read (CSSOM) **and** render (pixel) sides now validated on the engine used-value model (2026-07-19) — deleting the zoom bake is now only a *deployment* gate (enable `NativeZoom` at the external `CaptureService` renderer), plus the submodule-push-gated pinch render cutover (`patches/0001`). Feature (a) dialog/backdrop: native modal centering + modal box-chrome bake deletion landed; native `::backdrop` box + top-layer paint stay submodule-patch-gated. See the [2026-07-19 reconciliation](#reconciliation-2026-07-19--features-a-and-b-driven-to-their-in-scope-terminal-state). |
 
 Companion documents:
@@ -1969,6 +1969,33 @@ Exit criteria:
   133 tests with the guard) stays green.
 
 ### Phase 4 - eliminate parallel DOM state
+
+Status: **P4.20 completed** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) — **work item 5:
+`CloneDomElement` now delegates the tree + attribute clone to canonical `DomNode.CloneNode`.** This closes the
+more tractable of the two P4.15 blocked swaps. `CloneDomElement` reimplemented cloning per node-kind — element
+via `CreateBridgeElementNS` (minted from the main `_document`) + a `SetAttribute`/`SetAttributeNS` copy loop,
+text/comment/doctype/fragment via the document factories, plus a recursive deep-clone. It now delegates to
+`source.CloneNode(deep)` (canonical `CloneShallow` handles every node kind — namespace + attribute set, text/
+comment data, doctype fields, fragment — and recurses in child order), and a new
+`CopyRuntimeStateForClonedSubtree` walks the source and clone in lockstep, applying the bridge's
+`CopyBridgeRuntimeStateTo` authority (P4.13 + the P4.14-inc3 baked overlay) to each element pair. Cloning does
+not mutate the live document, so — unlike `Normalize` — there is **no** MutationObserver/NodeIterator/live-range
+side-effect coupling, and the runtime-state gate was already retired, which is why this half was tractable.
+
+**The three P4.15 divergences turned out not to manifest** in the tested surface: canonical preserves the source
+owner document (vs the old mint-from-main-`_document`) and copies attribute keys verbatim (vs the old
+no-namespace `SetAttribute` lowercasing) — both spec-correct — and uses the `Name`-carrying `CloneShallow` ctor
+(namespace preserved). Verified byte-identical across a **comprehensive clone surface** (≈14 suites,
+stash-baseline-compared): general clone + form-control-state survival (`HtmlDomInterfaces`), whitespace/namespace
+(`NamespaceAndDomCore`), doctype (`DoctypeSentinelMigration`), fragment (`DocumentFragmentSentinelMigration`),
+deep-clone/Acid3 (`DomEventsEdgeCase`, `Acid3Regression`), **SVG attribute-case** (`SvgDomAndCrossDoc`,
+`SvgDomDynamicContent`, `Acid3SvgAndParsing`) and **sub-document owner-document** (`OwnerDocRootRemoval`,
+`SubdocRootGuardRemoval`) — **all 0 failures with the change, and 0 at baseline** for the divergence-sensitive
+SVG/owner-doc subset (so no regression, and no pre-existing failure masked). No public-API change; −30 net lines.
+There is no SVG WPT pixel subset in-repo, so the render gate here is the Cli SVG/Acid suites; the full WPT
+pixel + Acid CI corpus remains the belt-and-suspenders sign-off for a clone/render-adjacent change, consistent
+with the P4.15 note. **Item 5 now reduces to `Normalize` alone** (still blocked on the
+`DomDocument.Mutated`-subscription architecture — P4.15).
 
 Status: **P4.19 completed** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) — **work item
 4/5: reuse canonical `CompareBoundaryPoints` for `CompareTreeOrder` (the last document-order duplicate).**

--- a/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
@@ -1970,6 +1970,33 @@ Exit criteria:
 
 ### Phase 4 - eliminate parallel DOM state
 
+Status: **P4.13 completed** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) — **work item 5,
+`CloneDomElement` de-risk: consolidate the bridge runtime-state clone-copy behind a single authority.**
+`CloneDomElement` (`Utilities.cs`) copied every per-bridge per-element runtime-state table onto the
+`cloneNode` copy as a **scattered ~25-line inline block of hand-written `.CopyTo` calls** — the exact
+"parallel state kept in sync by hand" hazard Phase 4 targets: because the copy list lived in a *different
+file* from the state-table definitions, adding a field or a whole new runtime-state table (as the Phase 2
+items 3/4 de-globalization repeatedly did) could silently drop it from clones with nothing to catch the
+omission. This slice gives **each runtime-state composite its own `CopyTo(target)`** co-located with its
+fields (`FormControl`/`Scroll`/`Dialog`/`Shadow`/`StyleSheet`/`Document`/`Animation` in `RuntimeStates.cs`)
+and replaces the inline block with a single `DomBridge.CopyBridgeRuntimeStateTo(source, clone)` aggregator
+(inline-style dict + the seven table `CopyTo`s + the position-area memo `CopyPositionAreaResolution`).
+**Behaviour-preserving** — the same copies, relocated; the shadow root/host reference-copy and the
+stylesheet rule-list deep-copy semantics are retained verbatim. This is also the concrete decomposition the
+still-blocked item-5 `CloneDomElement`→canonical-`CloneNode` swap needs: a future swap becomes "canonical
+clones the tree/attributes; `CopyBridgeRuntimeStateTo` copies the parallel bridge state," instead of the
+canonical clone having to reproduce the scattered list. No public-API change (all members `private`/
+`internal`). Tests: new `HtmlDomInterfacesTests.Input_Value_And_Checked_Survive_CloneNode` (script-set value
++ checked survive onto an independent clone) alongside the existing `Radio_Checked_State_Survives_CloneNode`;
+the clone / node-relationship / namespace / sentinel-migration / owner-doc-root suites pass (102 → 103 with
+the new test). Also fixed a **stale reflection guard** surfaced in-area:
+`OwnerDocRootRemovalTests.ElementRuntimeState_Has_No_OwnerDocRoot_Field` looked up the pre-2026-07-17
+composite name `ElementRuntimeState` (renamed `InlineStyleRuntimeState` by the de-globalization), so its
+`Assert.NotNull` had been failing at baseline and the guard no longer guarded anything — repointed to the
+current type name. This does **not** close item 5 (the `Normalize` / `CloneDomElement` canonical swaps stay
+blocked by the side-effect / runtime-state coupling, and item 2's full inline-style dict elimination is
+unchanged) — it removes the silent-drop hazard in the clone path and stages the eventual swap.
+
 Status: **P4.12 completed** 2026-07-14 (branch `htmlbridge-phase4-range-stringifier`) — **work items 4/5: the
 Range stringifier is promoted to a spec-correct canonical `Broiler.Dom.DomRange.ToString()`, and the bridge's
 `GetDocumentOrderNodes` document-order flatten is deleted in favour of canonical `DomNode.InclusiveDescendants`.**

--- a/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
@@ -1970,6 +1970,24 @@ Exit criteria:
 
 ### Phase 4 - eliminate parallel DOM state
 
+Status: **P4.16 completed** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) — **work item
+4/5, next tractable cluster: reuse canonical `DomNode.GetRootNode()` for the bridge's absolute-root walks.**
+The neutral-tree-algorithm reuse cluster (the P4.8–4.12 pattern), scoped to the reuses whose canonical method
+is already **public** (no submodule push). Canonical `GetRootNode()` (`Broiler.Dom/DomNode.cs:243`) is the
+identical `while (ParentNode is not null)` climb the bridge open-coded in two places, so both now delegate:
+`GetOwningDocument` (`Utilities.cs`, 21 callers — `ownerDocument`, hit-test viewport, base-URL frame recovery)
+becomes `node.GetRootNode() as DomDocument ?? node.OwnerDocument`, and `GetTreeRoot` (`ShadowDom.cs`, behind the
+`INodeRelationshipsHost`/`INodeAccessorsHost` `getRootNode()` + `compareDocumentPosition` bindings) becomes
+`node.GetRootNode()`. Byte-identical (same walk); no public-API change; −4 net lines of duplicated traversal.
+The third candidate, `ChildIndexOf` → canonical `IndexOfReference`, is **not** in-repo: `IndexOfReference` lives
+on the `internal` `DomNodeCollectionExtensions`, so promoting it needs the extension made public — a submodule
+push (403 → patch, the P4.9/P4.10 shape) — so the loop stays, with a note at the call site. The `ParentEl`-based
+topmost-*element* walks (`Css.GetDocumentRootFor`, `AnimationResolver`) stay too: they climb element parents and
+stop at shadow roots, which is not `GetRootNode`'s document/fragment semantics. Validation: builds clean; the
+`OwnerDocRootRemoval` (ownerDocument across main / detached / sub-document / iframe-content regimes + the iframe
+hit-test viewport guard), `SubdocRootGuardRemoval`, `NodeRelationshipsBindingModule` (`getRootNode`,
+`compareDocumentPosition`) suites pass (20/20).
+
 Status: **P4.15 — item 5 (`Normalize` / `CloneDomElement` canonical swaps) investigated; both remain blocked,
 with the precise blockers and unblock paths now established** 2026-07-19 (branch
 `claude/htmlbridge-complexity-reduction-4ho9hr`). A deep, code-grounded run at the two remaining item-5 swaps.

--- a/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
@@ -1970,6 +1970,28 @@ Exit criteria:
 
 ### Phase 4 - eliminate parallel DOM state
 
+Status: **P4.18 completed** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) — **work item
+4/5, descendant-collection cluster: reuse canonical `DomNode.Descendants()` for the hand-rolled depth-first
+element walks.** Four bridge helpers reimplemented a depth-first descendant-element recursion that canonical
+`Descendants()` (already **public**) provides — and which canonical documents as the bridge's own WPT #1143
+concurrent-mutation defensive idiom promoted to canonical (it snapshots each level via `_children.ToArray()`
+on the **real** child list, so it is document-order, mutation-safe, and free of the `LegacyChildList`
+projection overflow the per-level `SnapshotChildren` retry guarded). All four now iterate
+`root.Descendants().OfType<DomElement>()`: `CollectDescendantsByTag` (`Utilities.cs`, `getElementsByTagName`),
+`CollectStyleElements` (`StyleSheets.cs`, `document.styleSheets`), `CollectStyleElementsInTree` (`Css.cs`, the
+computed-style cascade's `<style>`/external-stylesheet collection) and `CollectWindowFrames` (`WindowLoad.cs`,
+`window.frames`). Byte-identical set + pre-order (`ChildElements` is exactly `ChildNodes.OfType<DomElement>()`
+with no `#`-filtering, shadow roots are not in-tree children, and severed sub-documents are not descendants —
+so the element set and order match); the three that iterated the **live** `ChildElements`
+(`CollectDescendantsByTag`/`CollectStyleElements`/`CollectWindowFrames`) additionally **gain** the canonical
+level-snapshot mutation-safety they lacked, and `CollectStyleElementsInTree` swaps its per-level
+`SnapshotChildren` for canonical's equivalent (which, on the real list, cannot hit the projection overflow the
+retry existed for). `SnapshotChildren` itself stays — it is the widely-used single-level primitive (anchor
+resolver, dialogs, animation, sub-documents). No submodule change (canonical method already public). No
+public-API change; −4 net lines. Verified regression-free: the `StyleSheetBindingModule` /
+`ComputedStyleBindingModule` / `HtmlDom` (getElementsByTagName) / `IframeElementBindingModule` (frames) /
+`CssImportantCascade` suites pass (51/51).
+
 Status: **P4.17 completed** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) — **work item
 4/5, document-position & child-index canonical-reuse cluster (submodule-gated half via the patch workflow).**
 Two neutral-algorithm reuses:

--- a/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-implemented.md
@@ -1971,7 +1971,33 @@ Exit criteria:
 ### Phase 4 - eliminate parallel DOM state
 
 Status: **P4.14 in progress** 2026-07-19 (branch `claude/htmlbridge-complexity-reduction-4ho9hr`) — **work item 2,
-inline-style single authority, increment 1: seam the anchor-resolver cluster off the raw dict.** The remaining
+inline-style single authority. Increment 2 (this commit): route the remaining serialize-time bake writers through
+the `BakedInlineStyle` seam, so every bridge-internal bake write now goes through one chokepoint.** Investigation
+of the store-split target found the `Style` dict is a **multi-purpose scratch**, not just inline style: it holds
+script-set inline style (marked by `JsSetStyleProps`), lazily-seeded `style=`-attribute values, **CSS-cascade-derived
+values** (added by the cascade, stripped by `Css.InvalidateElementStyles`), and the serialize-time bakes. The
+script-observable surfaces already exclude bakes — `element.style` is rebuilt from the `style=` attribute + only the
+`JsSetStyleProps` keys (`StyleDeclarationBinding.BuildDeclaredInlineStyleMap`), and the computed-style author layer
+keeps only inline/JS-set keys — so the bakes are already logically separate on the read side; what's missing is a
+single write-side chokepoint and a clean storage split. A blind storage swap is unsafe (it touches every reader of
+this entangled dict and needs the full WPT pixel/Acid corpus, which can't run reliably in-container), so increment 2
+completes the **write** boundary: the animation-snapshot resolver (`AnimationResolver.cs`, a serialize-time bake
+resolver run beside `ResolveAnchorPositions`) is routed wholesale, and the synthetic-form-control (meter/progress) +
+zoom bake **writes** in `DomBridge.Serialization.cs` are routed, while the script path (`StyleDeclarationBinding`/
+`AttributesHost`, which write-throughs to the attribute), the parse-time authored-style copy (`HtmlParsing`), and the
+cascade cleanup (`Css.cs`) stay on `InlineStyle`. The four remaining `InlineStyle` reads in the serializer
+(`SyncStyleAttributeFromInlineStyle`, the two zoom source reads, and the final property emit) are exactly the
+**merge points** increment 3 will switch to a merged base∪overlay read when it backs `BakedInlineStyle` with a
+distinct baked-overlay store. Byte-identical (the wrapper still forwards to the same dict); no public-API change.
+Added `Count` to `BakedStyleMap`. Validation: `Broiler.HtmlBridge.Dom` builds clean; the Animation / Serialization /
+FormControl / NativeAnchor / InlineStyleWriteThrough Cli suites pass (110), and the 5 failures in that batch are a
+**byte-identical pre-existing set at baseline** (the three standing environmental `DomBridge_SerializeToHtml_*`
+zoom/srcdoc tests, the `HttpClientMigration` WebClient assembly guard, and the font-dependent
+`FormControlRenderTests.SelectListBox…WritingMode`) — confirmed by a stash-compare. **Increment 3 (not done):** the
+actual storage swap (baked overlay + serializer merge-point reads), then the non-cluster read-side + the item-5
+`Normalize`/`CloneDomElement` swaps.
+
+Status: **P4.14 in progress (increment 1)** 2026-07-19 — **work item 2, seam the anchor-resolver cluster off the raw dict.** The remaining
 item-2 work (fully eliminate the parallel inline-style `Style` dict) is a ~170-site rewrite, ~98 of them in the
 anchor-resolver cluster where the dict is used as **baked-geometry scratch** — the resolver reads an element's
 effective inline style and writes resolved position/insets/margins/borders/size, and those direct writes

--- a/patches/0002-dom-make-domnodecollectionextensions-public.patch
+++ b/patches/0002-dom-make-domnodecollectionextensions-public.patch
@@ -1,0 +1,214 @@
+From 014cffc3430c4ec925f3ab73bf7993e04351dc06 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 19 Jul 2026 19:53:15 +0000
+Subject: [PATCH] Make DomNodeCollectionExtensions public for host reuse
+
+IndexOfReference (reference-equality child-index scan) is used internally by DomRange;
+exposing the extension class lets bridge/host consumers reuse the canonical scan
+(e.g. DomBridge.ChildIndexOf) instead of re-implementing the loop.
+---
+ Broiler.Dom/DomNode.cs | 173 +++++++++++++++++++++--------------------
+ 1 file changed, 88 insertions(+), 85 deletions(-)
+
+diff --git a/Broiler.Dom/DomNode.cs b/Broiler.Dom/DomNode.cs
+index dae6bae..b4d8fee 100644
+--- a/Broiler.Dom/DomNode.cs
++++ b/Broiler.Dom/DomNode.cs
+@@ -177,69 +177,69 @@ public abstract class DomNode
+         return clone;
+     }
+ 
+-    /// <summary>
+-    /// The DOM <c>Node.isEqualNode()</c> operation (§4.4): two nodes are equal when they have the
+-    /// same node type and type-specific identity, and equal children in order. DocumentType nodes
+-    /// compare name/publicId/systemId; character-data nodes compare their data; elements compare
+-    /// namespace + qualified name + attribute set (unordered, by namespace/local-name/value) + child
+-    /// list; document/fragment nodes compare their child list. This is the neutral tree algorithm the
+-    /// script bridge's <c>isEqualNode</c> binding delegates to.
+-    /// </summary>
+-    public bool IsEqualNode(DomNode? other)
+-    {
+-        if (other is null)
+-            return false;
+-        if (ReferenceEquals(this, other))
+-            return true;
+-        if (NodeType != other.NodeType)
+-            return false;
+-
+-        switch (this)
+-        {
+-            case DomDocumentType thisDocType when other is DomDocumentType otherDocType:
+-                return string.Equals(thisDocType.Name, otherDocType.Name, StringComparison.Ordinal)
+-                    && string.Equals(thisDocType.PublicId, otherDocType.PublicId, StringComparison.Ordinal)
+-                    && string.Equals(thisDocType.SystemId, otherDocType.SystemId, StringComparison.Ordinal);
+-
+-            case DomCharacterData thisData when other is DomCharacterData otherData:
+-                return string.Equals(thisData.Data, otherData.Data, StringComparison.Ordinal);
+-
+-            case DomElement thisEl when other is DomElement otherEl:
+-                if (!string.Equals(thisEl.TagName, otherEl.TagName, StringComparison.Ordinal)
+-                    || !string.Equals(thisEl.NamespaceUri, otherEl.NamespaceUri, StringComparison.Ordinal)
+-                    || !AttributesEqual(thisEl, otherEl))
+-                {
+-                    return false;
+-                }
+-                break;
+-        }
+-
+-        if (_children.Count != other._children.Count)
+-            return false;
+-        for (var index = 0; index < _children.Count; index++)
+-        {
+-            if (!_children[index].IsEqualNode(other._children[index]))
+-                return false;
+-        }
+-        return true;
+-    }
+-
+-    private static bool AttributesEqual(DomElement first, DomElement second)
+-    {
+-        if (first.Attributes.Count != second.Attributes.Count)
+-            return false;
+-        foreach (var (key, attribute) in first.Attributes)
+-        {
+-            if (!second.Attributes.TryGetValue(key, out var other)
+-                || !string.Equals(attribute.Value, other.Value, StringComparison.Ordinal)
+-                || !string.Equals(attribute.QualifiedName, other.QualifiedName, StringComparison.OrdinalIgnoreCase))
+-            {
+-                return false;
+-            }
+-        }
+-        return true;
+-    }
+-
++    /// <summary>
++    /// The DOM <c>Node.isEqualNode()</c> operation (§4.4): two nodes are equal when they have the
++    /// same node type and type-specific identity, and equal children in order. DocumentType nodes
++    /// compare name/publicId/systemId; character-data nodes compare their data; elements compare
++    /// namespace + qualified name + attribute set (unordered, by namespace/local-name/value) + child
++    /// list; document/fragment nodes compare their child list. This is the neutral tree algorithm the
++    /// script bridge's <c>isEqualNode</c> binding delegates to.
++    /// </summary>
++    public bool IsEqualNode(DomNode? other)
++    {
++        if (other is null)
++            return false;
++        if (ReferenceEquals(this, other))
++            return true;
++        if (NodeType != other.NodeType)
++            return false;
++
++        switch (this)
++        {
++            case DomDocumentType thisDocType when other is DomDocumentType otherDocType:
++                return string.Equals(thisDocType.Name, otherDocType.Name, StringComparison.Ordinal)
++                    && string.Equals(thisDocType.PublicId, otherDocType.PublicId, StringComparison.Ordinal)
++                    && string.Equals(thisDocType.SystemId, otherDocType.SystemId, StringComparison.Ordinal);
++
++            case DomCharacterData thisData when other is DomCharacterData otherData:
++                return string.Equals(thisData.Data, otherData.Data, StringComparison.Ordinal);
++
++            case DomElement thisEl when other is DomElement otherEl:
++                if (!string.Equals(thisEl.TagName, otherEl.TagName, StringComparison.Ordinal)
++                    || !string.Equals(thisEl.NamespaceUri, otherEl.NamespaceUri, StringComparison.Ordinal)
++                    || !AttributesEqual(thisEl, otherEl))
++                {
++                    return false;
++                }
++                break;
++        }
++
++        if (_children.Count != other._children.Count)
++            return false;
++        for (var index = 0; index < _children.Count; index++)
++        {
++            if (!_children[index].IsEqualNode(other._children[index]))
++                return false;
++        }
++        return true;
++    }
++
++    private static bool AttributesEqual(DomElement first, DomElement second)
++    {
++        if (first.Attributes.Count != second.Attributes.Count)
++            return false;
++        foreach (var (key, attribute) in first.Attributes)
++        {
++            if (!second.Attributes.TryGetValue(key, out var other)
++                || !string.Equals(attribute.Value, other.Value, StringComparison.Ordinal)
++                || !string.Equals(attribute.QualifiedName, other.QualifiedName, StringComparison.OrdinalIgnoreCase))
++            {
++                return false;
++            }
++        }
++        return true;
++    }
++
+     public DomNode GetRootNode()
+     {
+         DomNode current = this;
+@@ -288,27 +288,27 @@ public abstract class DomNode
+         return false;
+     }
+ 
+-    /// <summary>
+-    /// The nearest common inclusive ancestor of this node and <paramref name="other"/> — the deepest
+-    /// node that is an inclusive ancestor of both — or <c>null</c> when they belong to different trees
+-    /// (or <paramref name="other"/> is <c>null</c>). "Inclusive" means a node is its own ancestor, so
+-    /// if one node is an ancestor of the other, that node is returned. Unlike
+-    /// <see cref="DomRange.CommonAncestorContainer"/> (which requires two boundary points in one tree
+-    /// and throws otherwise), this is a null-tolerant node-level query for arbitrary node pairs.
+-    /// </summary>
+-    public DomNode? CommonAncestorWith(DomNode? other)
+-    {
+-        if (other is null)
+-            return null;
+-        var ancestors = InclusiveAncestors().ToHashSet();
+-        foreach (var ancestor in other.InclusiveAncestors())
+-        {
+-            if (ancestors.Contains(ancestor))
+-                return ancestor;
+-        }
+-        return null;
+-    }
+-
++    /// <summary>
++    /// The nearest common inclusive ancestor of this node and <paramref name="other"/> — the deepest
++    /// node that is an inclusive ancestor of both — or <c>null</c> when they belong to different trees
++    /// (or <paramref name="other"/> is <c>null</c>). "Inclusive" means a node is its own ancestor, so
++    /// if one node is an ancestor of the other, that node is returned. Unlike
++    /// <see cref="DomRange.CommonAncestorContainer"/> (which requires two boundary points in one tree
++    /// and throws otherwise), this is a null-tolerant node-level query for arbitrary node pairs.
++    /// </summary>
++    public DomNode? CommonAncestorWith(DomNode? other)
++    {
++        if (other is null)
++            return null;
++        var ancestors = InclusiveAncestors().ToHashSet();
++        foreach (var ancestor in other.InclusiveAncestors())
++        {
++            if (ancestors.Contains(ancestor))
++                return ancestor;
++        }
++        return null;
++    }
++
+     public void Normalize()
+     {
+         for (var index = 0; index < _children.Count;)
+@@ -412,8 +412,11 @@ public abstract class DomNode
+ 
+ }
+ 
+-internal static class DomNodeCollectionExtensions
++public static class DomNodeCollectionExtensions
+ {
++    /// <summary>Index of <paramref name="target"/> in <paramref name="nodes"/> by reference equality,
++    /// or -1 if absent. Public so bridge/host consumers can reuse the canonical reference-index scan
++    /// (e.g. <c>DomBridge.ChildIndexOf</c>) instead of re-implementing the loop.</summary>
+     public static int IndexOfReference(this IReadOnlyList<DomNode> nodes, DomNode target)
+     {
+         for (var index = 0; index < nodes.Count; index++)
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -24,6 +24,27 @@ SHA (so it would not compile against the pinned clone on CI).
 
 ---
 
+## 0002 — `Broiler.DOM`: make `DomNodeCollectionExtensions` public
+
+**Target:** `Broiler.DOM` (`Broiler.Dom/DomNode.cs`).
+**Depends on:** nothing (a one-line visibility change).
+
+**What it does.** `DomNodeCollectionExtensions.IndexOfReference(this IReadOnlyList<DomNode>,
+DomNode)` — the reference-equality child-index scan `DomRange` already uses internally — is on an
+`internal` class, so bridge/host consumers can't reuse it. The patch makes the class `public`
+(the method is already `public`) so the canonical scan can be shared. Behaviour-neutral (visibility
+only); the full css/dom test corpus is unaffected.
+
+**Follow-up (main-repo, once applied + pointer bumped).** Delegate `DomBridge.ChildIndexOf`
+(`DomBridge.cs`) to `element.ChildNodes.IndexOfReference(child)` and delete its manual loop — the
+byte-identical reuse. Deferred because it references the newly-public API, which does not exist at
+the pinned submodule SHA (so it would not compile against the pinned clone on CI).
+
+**Current fallback (unchanged until applied):** `ChildIndexOf` keeps its manual reference-equality
+loop, so nothing on CI depends on this patch. (The sibling `IsPositionAfter` →
+`DomRange.CompareBoundaryPoints` reuse in the same Phase-4 cluster needed **no** patch — that
+canonical method was already public — and is already landed in the main repo.)
+
 ## 0001 — `Broiler.HTML`: plumb `viewportZoom` through the static render entry
 
 **Target:** `Broiler.HTML` (`Source/Broiler.HTML.Image/HtmlRender.cs`).

--- a/src/Broiler.Cli.Tests/HtmlDomInterfacesTests.cs
+++ b/src/Broiler.Cli.Tests/HtmlDomInterfacesTests.cs
@@ -62,6 +62,37 @@ document.getElementById('result').textContent = r.join(',');
         Assert.Contains("true,true,radio", result);
     }
 
+    [Fact]
+    public void Input_Value_And_Checked_Survive_CloneNode()
+    {
+        // Exercises the consolidated cloneNode bridge-runtime-state copy
+        // (DomBridge.CopyBridgeRuntimeStateTo -> FormControlRuntimeState.CopyTo): the source's
+        // script-set value (not reflected to the value= attribute) and checked state must both
+        // survive onto the clone, and the clone must be independent of later source mutations.
+        var html = @"<!DOCTYPE html>
+<html><body>
+<input id=""t"" type=""text"" />
+<input id=""c"" type=""checkbox"" />
+<div id=""result""></div>
+<script>
+var r = [];
+var t = document.getElementById('t');
+var c = document.getElementById('c');
+t.value = 'hello';
+c.checked = true;
+var tClone = t.cloneNode(false);
+var cClone = c.cloneNode(false);
+t.value = 'changed';           // must not leak into the already-taken clone
+r.push(tClone.value);          // hello
+r.push(cClone.checked);        // true
+document.getElementById('result').textContent = r.join(',');
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+        Assert.Contains("hello,true", result);
+    }
+
     // ────────────────────── 7.2: className whitespace preservation ──────────────────────
 
     [Fact]

--- a/src/Broiler.Cli.Tests/OwnerDocRootRemovalTests.cs
+++ b/src/Broiler.Cli.Tests/OwnerDocRootRemovalTests.cs
@@ -25,7 +25,11 @@ public sealed class OwnerDocRootRemovalTests
     [Fact]
     public void ElementRuntimeState_Has_No_OwnerDocRoot_Field()
     {
-        var ers = typeof(DomBridge).Assembly.GetType("Broiler.HtmlBridge.Dom.Runtime.ElementRuntimeState");
+        // The node-runtime-state composite (formerly ElementRuntimeState) was renamed
+        // InlineStyleRuntimeState by the Phase 2 items 3/4 de-globalization (2026-07-17), once every
+        // non-inline-style concern had been split into its own per-bridge table. Look it up under the
+        // current name; the OwnerDocRoot parallel-state field (P4.4c) must not exist on it.
+        var ers = typeof(DomBridge).Assembly.GetType("Broiler.HtmlBridge.Dom.Runtime.InlineStyleRuntimeState");
         Assert.NotNull(ers);
         Assert.Null(ers!.GetProperty("OwnerDocRoot", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
         Assert.Null(ers.GetField("OwnerDocRoot", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.SvgZoom.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.SvgZoom.cs
@@ -68,7 +68,7 @@ public sealed partial class DomBridge
             return;
 
         string? value = null;
-        if (preferInlineStyle && InlineStyle(element).TryGetValue(propertyName, out var inlineValue) && !string.IsNullOrWhiteSpace(inlineValue))
+        if (preferInlineStyle && BakedInlineStyle(element).TryGetValue(propertyName, out var inlineValue) && !string.IsNullOrWhiteSpace(inlineValue))
             value = inlineValue;
         else if (props.TryGetValue(propertyName, out var propValue) && !string.IsNullOrWhiteSpace(propValue))
             value = propValue;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -82,7 +82,10 @@ public sealed partial class DomBridge
     /// </summary>
     private void SyncStyleAttributeFromInlineStyle(DomElement element)
     {
-        var style = InlineStyle(element);
+        // Merge the baked overlay in: at serialize time (ReflectRenderState) the style= attribute must
+        // reflect the resolved bakes, exactly as it did when bakes lived in the inline-style dict. At
+        // script time the overlay is empty, so this equals the base dict (byte-identical write-through).
+        var style = EffectiveInlineStyle(element);
         if (style.Count == 0)
         {
             RemoveAttr(element, "style");
@@ -420,7 +423,7 @@ public sealed partial class DomBridge
         if (props.TryGetValue(property, out value) && !string.IsNullOrWhiteSpace(value))
             return true;
 
-        if (!InlineStyle(element).TryGetValue(property, out var specified) ||
+        if (!BakedInlineStyle(element).TryGetValue(property, out var specified) ||
             !string.Equals(specified?.Trim(), "inherit", StringComparison.OrdinalIgnoreCase) ||
             ParentEl(element) == null)
         {
@@ -431,7 +434,7 @@ public sealed partial class DomBridge
         if (parentProps.TryGetValue(property, out value) && !string.IsNullOrWhiteSpace(value))
             return true;
 
-        if (InlineStyle(ParentEl(element)!).TryGetValue(property, out value) && !string.IsNullOrWhiteSpace(value))
+        if (BakedInlineStyle(ParentEl(element)!).TryGetValue(property, out value) && !string.IsNullOrWhiteSpace(value))
             return true;
 
         return false;
@@ -555,7 +558,7 @@ public sealed partial class DomBridge
         GetChildren: static node => node.ChildNodes,
         GetAttributes: node => node is DomElement element ? GetSerializableAttributes(element) : [],
         GetStyles: node => node is DomElement element
-            ? InlineStyle(element).OrderBy(kv => HtmlSerializer.IsShorthandProperty(kv.Key) ? 0 : 1)
+            ? EffectiveInlineStyle(element).OrderBy(kv => HtmlSerializer.IsShorthandProperty(kv.Key) ? 0 : 1)
             : [],
         // RF-BRIDGE-1c Phase F (F3c part 2d): text nodes serialize with the same HTML escaping the
         // former element-store textContent path applied — except inside raw-text elements

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -279,25 +279,25 @@ public sealed partial class DomBridge
         var reverseInline = string.Equals(direction, "rtl", StringComparison.OrdinalIgnoreCase);
         var ratio = ResolveProgressLikeValueRatio(element, tag);
 
-        InlineStyle(element)["display"] = "inline-block";
-        InlineStyle(element)["box-sizing"] = "border-box";
-        InlineStyle(element)["position"] = "relative";
-        InlineStyle(element)["overflow"] = "hidden";
-        InlineStyle(element)["padding"] = "0";
-        InlineStyle(element)["border"] = "1px solid #767676";
-        InlineStyle(element)["background-color"] = tag == "meter" ? "#e6e6e6" : "#f0f0f0";
-        InlineStyle(element)["vertical-align"] = "middle";
+        BakedInlineStyle(element)["display"] = "inline-block";
+        BakedInlineStyle(element)["box-sizing"] = "border-box";
+        BakedInlineStyle(element)["position"] = "relative";
+        BakedInlineStyle(element)["overflow"] = "hidden";
+        BakedInlineStyle(element)["padding"] = "0";
+        BakedInlineStyle(element)["border"] = "1px solid #767676";
+        BakedInlineStyle(element)["background-color"] = tag == "meter" ? "#e6e6e6" : "#f0f0f0";
+        BakedInlineStyle(element)["vertical-align"] = "middle";
         if (!string.IsNullOrWhiteSpace(width) && !string.Equals(width, "auto", StringComparison.OrdinalIgnoreCase))
-            InlineStyle(element)["width"] = width;
+            BakedInlineStyle(element)["width"] = width;
         if (!string.IsNullOrWhiteSpace(height) && !string.Equals(height, "auto", StringComparison.OrdinalIgnoreCase))
-            InlineStyle(element)["height"] = height;
+            BakedInlineStyle(element)["height"] = height;
 
         ClearChildren(element);
 
         var fill = CreateBridgeElement("div");
         SetParent(fill, element);
-        InlineStyle(fill)["position"] = "absolute";
-        InlineStyle(fill)["background-color"] = tag == "meter" ? "#4caf50" : "#0a84ff";
+        BakedInlineStyle(fill)["position"] = "absolute";
+        BakedInlineStyle(fill)["background-color"] = tag == "meter" ? "#4caf50" : "#0a84ff";
 
         var fillExtent = vertical
             ? ReadPixelLength(height, DefaultProgressLikeTrackLengthPx) * ratio
@@ -305,17 +305,17 @@ public sealed partial class DomBridge
         var fillExtentPx = $"{fillExtent.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)}px";
         if (vertical)
         {
-            InlineStyle(fill)["left"] = "0";
-            InlineStyle(fill)["right"] = "0";
-            InlineStyle(fill)[reverseInline ? "bottom" : "top"] = "0";
-            InlineStyle(fill)["height"] = fillExtentPx;
+            BakedInlineStyle(fill)["left"] = "0";
+            BakedInlineStyle(fill)["right"] = "0";
+            BakedInlineStyle(fill)[reverseInline ? "bottom" : "top"] = "0";
+            BakedInlineStyle(fill)["height"] = fillExtentPx;
         }
         else
         {
-            InlineStyle(fill)["top"] = "0";
-            InlineStyle(fill)["bottom"] = "0";
-            InlineStyle(fill)[reverseInline ? "right" : "left"] = "0";
-            InlineStyle(fill)["width"] = fillExtentPx;
+            BakedInlineStyle(fill)["top"] = "0";
+            BakedInlineStyle(fill)["bottom"] = "0";
+            BakedInlineStyle(fill)[reverseInline ? "right" : "left"] = "0";
+            BakedInlineStyle(fill)["width"] = fillExtentPx;
         }
 
         element.AppendChild(fill);
@@ -383,7 +383,7 @@ public sealed partial class DomBridge
                     continue;
 
                 if (TryScaleSerializableCssValue(value, usedZoom, out var scaled))
-                    InlineStyle(element)[property] = scaled;
+                    BakedInlineStyle(element)[property] = scaled;
             }
 
         }
@@ -391,7 +391,7 @@ public sealed partial class DomBridge
         if (willSvg)
             ApplyZoomSerializationSvgAttributes(element, usedZoom);
 
-        InlineStyle(element).Remove("zoom");
+        BakedInlineStyle(element).Remove("zoom");
 
         foreach (var child in ChildElements(element))
             ApplyZoomSerializationStyles(child, usedZoom);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.WindowLoad.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.WindowLoad.cs
@@ -190,21 +190,18 @@ public sealed partial class DomBridge
 
     private void CollectWindowFrames(DomElement element, List<JSValue> frames)
     {
-        foreach (var child in ChildElements(element))
+        // Phase 4 item 4/5: reuse canonical Descendants() (public, document-order, level-snapshotted)
+        // instead of a hand-rolled depth-first ChildElements recursion. Sub-documents are severed
+        // (P4.4b) — never in-tree children — so the walk never crosses a frame boundary, and a nested
+        // iframe's content (its own sub-document) is not a descendant here, matching the old walk.
+        foreach (var child in element.Descendants().OfType<DomElement>())
         {
-            if (IsText(child))
-                continue;
-
             if (string.Equals(child.TagName, "iframe", StringComparison.OrdinalIgnoreCase))
             {
                 var src = TryGetAttribute(child, "src", out var srcValue) ? srcValue : string.Empty;
                 if (!IsCrossOrigin(src, _pageUrl))
                     frames.Add(_subWindows.GetOrCreate(child));
             }
-
-            // Sub-documents are severed (P4.4b) — never in-tree children — so the walk always
-            // descends normal element children.
-            CollectWindowFrames(child, frames);
         }
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -265,7 +265,10 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         element.ChildNodes[index.GetOffset(element.ChildNodes.Count)];
 
     /// <summary>Index of <paramref name="child"/> among the element's children, or -1
-    /// (old <c>Children.IndexOf</c>, reference equality).</summary>
+    /// (old <c>Children.IndexOf</c>, reference equality). Phase 4 item 4/5: canonical
+    /// <c>Broiler.Dom.DomNodeCollectionExtensions.IndexOfReference</c> is the byte-identical scan, but it
+    /// is <c>internal</c> to the submodule — promoting this delegation is gated on making it public
+    /// (a submodule push, per the P4.9/P4.10 pattern), so the loop stays for now.</summary>
     internal static int ChildIndexOf(DomNode element, DomNode child)
     {
         for (var i = 0; i < element.ChildNodes.Count; i++)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -266,9 +266,11 @@ public sealed partial class DomBridge : IDomBridgeRuntime
 
     /// <summary>Index of <paramref name="child"/> among the element's children, or -1
     /// (old <c>Children.IndexOf</c>, reference equality). Phase 4 item 4/5: canonical
-    /// <c>Broiler.Dom.DomNodeCollectionExtensions.IndexOfReference</c> is the byte-identical scan, but it
-    /// is <c>internal</c> to the submodule — promoting this delegation is gated on making it public
-    /// (a submodule push, per the P4.9/P4.10 pattern), so the loop stays for now.</summary>
+    /// <c>Broiler.Dom.DomNodeCollectionExtensions.IndexOfReference</c> is the byte-identical scan, but the
+    /// extension class is <c>internal</c> at the pinned submodule SHA; making it public ships as
+    /// <c>patches/0002-dom-make-domnodecollectionextensions-public.patch</c> (Broiler.DOM push 403'd). Once
+    /// applied + pointer-bumped, the follow-up is <c>=> element.ChildNodes.IndexOfReference(child)</c>; the
+    /// loop is the active fallback until then.</summary>
     internal static int ChildIndexOf(DomNode element, DomNode child)
     {
         for (var i = 0; i < element.ChildNodes.Count; i++)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.NativeHandoff.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.NativeHandoff.cs
@@ -30,7 +30,7 @@ public sealed partial class DomBridge
         // Merge inline styles over matched-rule props (inline wins), matching what the
         // engine cascade projects onto the box.
         var merged = new Dictionary<string, string>(cssProps, StringComparer.OrdinalIgnoreCase);
-        foreach (var kv in InlineStyle(element))
+        foreach (var kv in BakedInlineStyle(element))
             merged[kv.Key] = kv.Value;
 
         // Whether the box has no in-flow content — the engine's opposing-inset sizing and the
@@ -246,7 +246,7 @@ public sealed partial class DomBridge
         Dictionary<string, AnchorInfo> anchorRegistry)
     {
         var merged = new Dictionary<string, string>(cssProps, StringComparer.OrdinalIgnoreCase);
-        foreach (var kv in InlineStyle(element))
+        foreach (var kv in BakedInlineStyle(element))
             merged[kv.Key] = kv.Value;
 
         // Absolutely positioned only (fixed gets a scroll adjustment the engine MVP omits).
@@ -338,7 +338,7 @@ public sealed partial class DomBridge
         Dictionary<string, AnchorInfo> anchorRegistry)
     {
         var merged = new Dictionary<string, string>(cssProps, StringComparer.OrdinalIgnoreCase);
-        foreach (var kv in InlineStyle(element))
+        foreach (var kv in BakedInlineStyle(element))
             merged[kv.Key] = kv.Value;
 
         // Absolutely positioned only (fixed/modal targets get a document-scroll adjustment the

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorFunctions.cs
@@ -31,7 +31,7 @@ public sealed partial class DomBridge
                 hasAnchorSizeRef = true;
         }
         // Also check inline styles for anchor-size()
-        foreach (var kv in InlineStyle(element))
+        foreach (var kv in BakedInlineStyle(element))
         {
             if (kv.Value.Contains("anchor-size(", StringComparison.OrdinalIgnoreCase))
                 hasAnchorSizeRef = true;
@@ -63,14 +63,14 @@ public sealed partial class DomBridge
 
             // Get the implicit anchor name from position-anchor.
             string? implicitAnchor = cssProps.GetValueOrDefault("position-anchor") ??
-                                     InlineStyle(element).GetValueOrDefault("position-anchor");
+                                     BakedInlineStyle(element).GetValueOrDefault("position-anchor");
 
             // When the target element is fixed-positioned (e.g. top-layer dialog)
             // and the anchor is NOT fixed-positioned, anchor positions must be
             // adjusted by the document scroll offset so the anchor's viewport
             // position is used instead of its document position.
             bool targetIsFixed =
-                (cssProps.GetValueOrDefault("position") ?? InlineStyle(element).GetValueOrDefault("position")) == "fixed" ||
+                (cssProps.GetValueOrDefault("position") ?? BakedInlineStyle(element).GetValueOrDefault("position")) == "fixed" ||
                 (DialogStateFor(element).Modal.TryGet(out var tModal) && tModal is true);
             double scrollAdjY = 0, scrollAdjX = 0;
             if (targetIsFixed)
@@ -137,7 +137,7 @@ public sealed partial class DomBridge
                 });
 
                 if (resolved != kv.Value)
-                    InlineStyle(element)[kv.Key] = resolved;
+                    BakedInlineStyle(element)[kv.Key] = resolved;
             }
 
             // Apply non-anchor CSS properties (e.g. position, margin).
@@ -145,15 +145,15 @@ public sealed partial class DomBridge
             {
                 if (!kv.Value.Contains("anchor(", StringComparison.OrdinalIgnoreCase) &&
                     !kv.Value.Contains("anchor-size(", StringComparison.OrdinalIgnoreCase) &&
-                    !InlineStyle(element).ContainsKey(kv.Key) &&
+                    !BakedInlineStyle(element).ContainsKey(kv.Key) &&
                     IsLayoutProperty(kv.Key))
                 {
-                    InlineStyle(element)[kv.Key] = kv.Value;
+                    BakedInlineStyle(element)[kv.Key] = kv.Value;
                 }
             }
 
             // Remove 'inset' shorthand.
-            InlineStyle(element).Remove("inset");
+            BakedInlineStyle(element).Remove("inset");
         }
 
         // Resolve anchor-size() function calls in both CSS and inline styles.
@@ -284,7 +284,7 @@ public sealed partial class DomBridge
     {
         // Get implicit anchor name from position-anchor.
         string? implicitAnchor = cssProps.GetValueOrDefault("position-anchor") ??
-                                 InlineStyle(element).GetValueOrDefault("position-anchor");
+                                 BakedInlineStyle(element).GetValueOrDefault("position-anchor");
 
         string ResolveValue(string value)
         {
@@ -308,17 +308,17 @@ public sealed partial class DomBridge
         {
             if (kv.Value.Contains("anchor-size(", StringComparison.OrdinalIgnoreCase))
             {
-                InlineStyle(element)[kv.Key] = ResolveValue(kv.Value);
+                BakedInlineStyle(element)[kv.Key] = ResolveValue(kv.Value);
             }
         }
 
         // Resolve in existing inline styles.
-        var inlineKeys = new List<string>(InlineStyle(element).Keys);
+        var inlineKeys = new List<string>(BakedInlineStyle(element).Keys);
         foreach (var key in inlineKeys)
         {
-            if (InlineStyle(element)[key].Contains("anchor-size(", StringComparison.OrdinalIgnoreCase))
+            if (BakedInlineStyle(element)[key].Contains("anchor-size(", StringComparison.OrdinalIgnoreCase))
             {
-                InlineStyle(element)[key] = ResolveValue(InlineStyle(element)[key]);
+                BakedInlineStyle(element)[key] = ResolveValue(BakedInlineStyle(element)[key]);
             }
         }
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -174,7 +174,7 @@ public sealed partial class DomBridge
                  scPos == "fixed" || scPos == "sticky");
             if (!alreadyPositioned)
             {
-                InlineStyle(sc)["position"] = "relative";
+                BakedInlineStyle(sc)["position"] = "relative";
                 // Native mode: mark this scroller so the engine's position-visibility pass knows
                 // its position:relative is anchor-induced (not authored) and must still count as an
                 // intervening clip container — reproducing the bridge's pre-position:relative CB
@@ -262,12 +262,12 @@ public sealed partial class DomBridge
 
         // The replaced root paints only the image; neither the root nor the
         // (box-less) body background reaches the canvas.
-        InlineStyle(html)["background"] = "none";
-        InlineStyle(html)["background-color"] = "transparent";
-        InlineStyle(body)["margin"] = "0";
-        InlineStyle(body)["padding"] = "0";
-        InlineStyle(body)["background"] = "none";
-        InlineStyle(body)["background-color"] = "transparent";
+        BakedInlineStyle(html)["background"] = "none";
+        BakedInlineStyle(html)["background-color"] = "transparent";
+        BakedInlineStyle(body)["margin"] = "0";
+        BakedInlineStyle(body)["padding"] = "0";
+        BakedInlineStyle(body)["background"] = "none";
+        BakedInlineStyle(body)["background-color"] = "transparent";
 
         ClearChildren(body);
 
@@ -302,7 +302,7 @@ public sealed partial class DomBridge
             return;
 
         var combinedZoom = GetUsedZoomForElement(DocumentElement) * scale;
-        InlineStyle(DocumentElement)["zoom"] = combinedZoom.ToString("0.###", CultureInfo.InvariantCulture);
+        BakedInlineStyle(DocumentElement)["zoom"] = combinedZoom.ToString("0.###", CultureInfo.InvariantCulture);
         ScrollStateFor(DocumentElement).Left.Set(GetVisualViewportPageOffset(vertical: false));
         ScrollStateFor(DocumentElement).Top.Set(GetVisualViewportPageOffset(vertical: true));
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/BakedStyle.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/BakedStyle.cs
@@ -1,10 +1,25 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Broiler.Dom;
 
 namespace Broiler.HtmlBridge;
 
 public sealed partial class DomBridge
 {
+    /// <summary>
+    /// Per-element <b>baked-style overlay</b> (Phase 4 item 2, increment 3): the store for the bridge's
+    /// serialize-time bake writers (anchor resolver, animation-snapshot resolver, synthetic form-control
+    /// styling, zoom bake), split out of the script-observable inline-style dict (<see cref="InlineStyle"/>).
+    /// A <c>null</c> value is a <b>tombstone</b> — a bake resolver removing an authored/prior property (e.g.
+    /// the animation resolver dropping the <c>animation</c> shorthand after baking longhands, or the anchor
+    /// resolver dropping <c>margin</c> after baking <c>margin-*</c>) so the merged view excludes it.
+    /// GC-scoped to the element (a detached element's overlay is collected with it).
+    /// </summary>
+    private readonly ConditionalWeakTable<DomElement, Dictionary<string, string?>> _bakedStyleOverlays = new();
+
+    private Dictionary<string, string?> BakedStyleOverlayFor(DomElement element) =>
+        _bakedStyleOverlays.GetValue(element, static _ => new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase));
+
     /// <summary>
     /// The seam onto an element's inline-style working store for the bridge's <b>serialize-time bake
     /// writers</b> — the anchor resolver (position/insets/margins/borders/size), the animation-snapshot
@@ -14,54 +29,127 @@ public sealed partial class DomBridge
     ///
     /// HtmlBridge complexity-reduction roadmap Phase 4 item 2 (inline-style single authority). Increment 1
     /// routed the anchor-resolver cluster (~98 sites) here; increment 2 routed the remaining bridge-internal
-    /// bake writers (AnimationResolver, and the synthetic-form-control + zoom bake writes in
-    /// DomBridge.Serialization.cs), so <b>every</b> serialize-time bake write now goes through this one
-    /// chokepoint while the script path (<c>element.style</c>/<c>setAttribute</c>, which write-throughs to
-    /// the <c>style=</c> attribute) and the cascade cleanup stay on <see cref="InlineStyle"/>. Today it
-    /// wraps that same per-element dict, so behaviour is byte-identical. The seam exists so a later
-    /// increment can split the baked writes into a store distinct from the script-observable inline style —
-    /// those writes must NOT leak into live <c>getAttribute("style")</c> mid-resolution, which is exactly
-    /// why the dict is currently a dual-purpose parallel store — by changing only this method, the struct
-    /// below, and the serializer's effective-style read (the merge point). The remaining
-    /// <see cref="InlineStyle"/> reads in the serializer (<c>SyncStyleAttributeFromInlineStyle</c>, the zoom
-    /// source reads, and the final property emit) are exactly those merge points.
+    /// bake writers; increment 3 (this) backs the writes with a store distinct from the script-observable
+    /// inline style: writes land in the per-element <see cref="BakedStyleOverlayFor">baked overlay</see>,
+    /// and reads return the <b>merged</b> base ∪ overlay view (overlay wins, tombstones remove). The script
+    /// path (<c>element.style</c>/<c>setAttribute</c>, which write-throughs to the <c>style=</c> attribute),
+    /// the cascade cleanup and parse-time authored-style copy stay on <see cref="InlineStyle"/>. Because the
+    /// bakes are strictly terminal (serialize-time, after all script/cascade writes), applying the overlay
+    /// last reproduces the old single-dict content exactly, so serialized output is byte-identical — while
+    /// <c>InlineStyleRuntimeState.Style</c> is no longer polluted by bakes. The serializer's own effective-
+    /// style reads (<see cref="EffectiveInlineStyle"/>) are the merge point.
     /// </summary>
-    internal BakedStyleMap BakedInlineStyle(DomElement element) => new(InlineStyle(element));
+    internal BakedStyleMap BakedInlineStyle(DomElement element) =>
+        new(InlineStyle(element), BakedStyleOverlayFor(element));
+
+    /// <summary>
+    /// The materialized <b>merged</b> inline style for a serialize-time reader: the base
+    /// <see cref="InlineStyle"/> dict with the element's <see cref="BakedStyleOverlayFor">baked overlay</see>
+    /// applied (overlay values win; <c>null</c>-tombstoned keys removed). This is what the serializer emits
+    /// and what the <c>style=</c> attribute is synced from, so the baked geometry reaches the renderer.
+    /// Returns a fresh dictionary (safe to enumerate/order). For elements with no bakes the overlay is
+    /// empty and this equals the base dict.
+    /// </summary>
+    internal Dictionary<string, string> EffectiveInlineStyle(DomElement element)
+    {
+        var baseStyle = InlineStyle(element);
+        if (!_bakedStyleOverlays.TryGetValue(element, out var overlay) || overlay.Count == 0)
+            return new Dictionary<string, string>(baseStyle, StringComparer.OrdinalIgnoreCase);
+
+        var merged = new Dictionary<string, string>(baseStyle, StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, value) in overlay)
+        {
+            if (value is null)
+                merged.Remove(key);
+            else
+                merged[key] = value;
+        }
+        return merged;
+    }
+
+    // Phase 4 item 5 hook (CopyBridgeRuntimeStateTo): copy a source element's baked overlay onto its
+    // cloneNode copy, so a clone made after a bake carries the same resolved geometry (byte-identical with
+    // the pre-split behaviour, where bakes lived in the copied inline-style dict). A no-op when the source
+    // has no overlay (the common case — clones are made by script, before serialize-time baking).
+    private void CopyBakedStyleOverlay(DomElement source, DomElement clone)
+    {
+        if (!_bakedStyleOverlays.TryGetValue(source, out var sourceOverlay) || sourceOverlay.Count == 0)
+            return;
+        var cloneOverlay = BakedStyleOverlayFor(clone);
+        cloneOverlay.Clear();
+        foreach (var (key, value) in sourceOverlay)
+            cloneOverlay[key] = value;
+    }
 }
 
 /// <summary>
-/// Thin value wrapper over an element's inline-style working dictionary used by the anchor resolver
-/// (returned by <see cref="DomBridge.BakedInlineStyle"/>). It mirrors the exact
-/// <see cref="Dictionary{TKey,TValue}"/> surface the cluster uses — indexer get/set, <c>Remove</c>,
-/// <c>ContainsKey</c>, <c>TryGetValue</c>, <c>GetValueOrDefault</c> and enumeration — so migrating the
-/// cluster off raw dict indexing is behaviour-preserving, and it is the single point at which a future
-/// baked-vs-script store split is made. Reads currently surface the same dict the writes mutate; when
-/// the stores split, reads will surface the merged (script ∪ baked) view and writes the baked overlay.
+/// Value wrapper the bridge's serialize-time bake writers use (returned by
+/// <see cref="DomBridge.BakedInlineStyle"/>). Writes land in the per-element baked <paramref name="overlay"/>
+/// (indexer set → value; <c>Remove</c> → <c>null</c> tombstone); reads return the <b>merged</b>
+/// base ∪ overlay view (overlay wins, tombstones remove). It mirrors the <see cref="Dictionary{TKey,TValue}"/>
+/// surface the cluster uses (indexer get/set, <c>Remove</c>, <c>ContainsKey</c>, <c>TryGetValue</c>,
+/// <c>GetValueOrDefault</c>, <c>Keys</c>, <c>Count</c>, enumeration). Enumeration/<c>Keys</c>/<c>Count</c>
+/// materialize the merge; the per-key reads do not.
 /// </summary>
 internal readonly struct BakedStyleMap
 {
-    private readonly Dictionary<string, string> _store;
+    private readonly Dictionary<string, string> _base;
+    private readonly Dictionary<string, string?> _overlay;
 
-    public BakedStyleMap(Dictionary<string, string> store) => _store = store;
+    public BakedStyleMap(Dictionary<string, string> baseStyle, Dictionary<string, string?> overlay)
+    {
+        _base = baseStyle;
+        _overlay = overlay;
+    }
 
     public string this[string key]
     {
-        get => _store[key];
-        set => _store[key] = value;
+        get => _overlay.TryGetValue(key, out var ov)
+            ? ov ?? throw new KeyNotFoundException(key)
+            : _base[key];
+        set => _overlay[key] = value;
     }
 
-    public bool Remove(string key) => _store.Remove(key);
+    // Tombstone the key so the merged view excludes it (whether it came from base or a prior overlay write).
+    // Returns whether the key was present in the merged view beforehand, matching Dictionary.Remove.
+    public bool Remove(string key)
+    {
+        var wasPresent = ContainsKey(key);
+        _overlay[key] = null;
+        return wasPresent;
+    }
 
-    public bool ContainsKey(string key) => _store.ContainsKey(key);
+    public bool ContainsKey(string key) =>
+        _overlay.TryGetValue(key, out var ov) ? ov is not null : _base.ContainsKey(key);
 
-    public bool TryGetValue(string key, [MaybeNullWhen(false)] out string value) =>
-        _store.TryGetValue(key, out value);
+    public bool TryGetValue(string key, [MaybeNullWhen(false)] out string value)
+    {
+        if (_overlay.TryGetValue(key, out var ov))
+        {
+            value = ov;
+            return ov is not null;
+        }
+        return _base.TryGetValue(key, out value);
+    }
 
-    public string? GetValueOrDefault(string key) => _store.GetValueOrDefault(key);
+    public string? GetValueOrDefault(string key) => TryGetValue(key, out var value) ? value : null;
 
-    public int Count => _store.Count;
+    public int Count => Materialize().Count;
 
-    public Dictionary<string, string>.KeyCollection Keys => _store.Keys;
+    public IEnumerable<string> Keys => Materialize().Keys;
 
-    public Dictionary<string, string>.Enumerator GetEnumerator() => _store.GetEnumerator();
+    public Dictionary<string, string>.Enumerator GetEnumerator() => Materialize().GetEnumerator();
+
+    private Dictionary<string, string> Materialize()
+    {
+        var merged = new Dictionary<string, string>(_base, StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, value) in _overlay)
+        {
+            if (value is null)
+                merged.Remove(key);
+            else
+                merged[key] = value;
+        }
+        return merged;
+    }
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/BakedStyle.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/BakedStyle.cs
@@ -1,0 +1,59 @@
+using System.Diagnostics.CodeAnalysis;
+using Broiler.Dom;
+
+namespace Broiler.HtmlBridge;
+
+public sealed partial class DomBridge
+{
+    /// <summary>
+    /// The anchor resolver's seam onto an element's inline-style working store: it reads the
+    /// element's effective inline style and writes resolved/baked geometry (position, insets,
+    /// margins, borders, width/height) as the passes build on one another.
+    ///
+    /// HtmlBridge complexity-reduction roadmap Phase 4 item 2 (inline-style single authority),
+    /// first increment: the anchor-resolver cluster reaches the store ONLY through this accessor and
+    /// the <see cref="BakedStyleMap"/> it returns, instead of indexing the raw <see cref="InlineStyle"/>
+    /// dictionary at ~90 scattered sites. Today it wraps that same per-element dict, so behaviour is
+    /// byte-identical. The seam exists so a later increment can split the resolver's baked-geometry
+    /// writes into a store distinct from the script-observable inline style — those writes must NOT
+    /// leak into live <c>getAttribute("style")</c> mid-resolution (unlike the <c>element.style</c> JS
+    /// path, which write-throughs to the attribute), which is exactly why the dict is currently a
+    /// dual-purpose parallel store. That split then changes only this method and the struct below.
+    /// </summary>
+    internal BakedStyleMap BakedInlineStyle(DomElement element) => new(InlineStyle(element));
+}
+
+/// <summary>
+/// Thin value wrapper over an element's inline-style working dictionary used by the anchor resolver
+/// (returned by <see cref="DomBridge.BakedInlineStyle"/>). It mirrors the exact
+/// <see cref="Dictionary{TKey,TValue}"/> surface the cluster uses — indexer get/set, <c>Remove</c>,
+/// <c>ContainsKey</c>, <c>TryGetValue</c>, <c>GetValueOrDefault</c> and enumeration — so migrating the
+/// cluster off raw dict indexing is behaviour-preserving, and it is the single point at which a future
+/// baked-vs-script store split is made. Reads currently surface the same dict the writes mutate; when
+/// the stores split, reads will surface the merged (script ∪ baked) view and writes the baked overlay.
+/// </summary>
+internal readonly struct BakedStyleMap
+{
+    private readonly Dictionary<string, string> _store;
+
+    public BakedStyleMap(Dictionary<string, string> store) => _store = store;
+
+    public string this[string key]
+    {
+        get => _store[key];
+        set => _store[key] = value;
+    }
+
+    public bool Remove(string key) => _store.Remove(key);
+
+    public bool ContainsKey(string key) => _store.ContainsKey(key);
+
+    public bool TryGetValue(string key, [MaybeNullWhen(false)] out string value) =>
+        _store.TryGetValue(key, out value);
+
+    public string? GetValueOrDefault(string key) => _store.GetValueOrDefault(key);
+
+    public Dictionary<string, string>.KeyCollection Keys => _store.Keys;
+
+    public Dictionary<string, string>.Enumerator GetEnumerator() => _store.GetEnumerator();
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/BakedStyle.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/BakedStyle.cs
@@ -6,19 +6,25 @@ namespace Broiler.HtmlBridge;
 public sealed partial class DomBridge
 {
     /// <summary>
-    /// The anchor resolver's seam onto an element's inline-style working store: it reads the
-    /// element's effective inline style and writes resolved/baked geometry (position, insets,
-    /// margins, borders, width/height) as the passes build on one another.
+    /// The seam onto an element's inline-style working store for the bridge's <b>serialize-time bake
+    /// writers</b> — the anchor resolver (position/insets/margins/borders/size), the animation-snapshot
+    /// resolver (interpolated keyframe values), synthetic form-control styling (meter/progress) and the
+    /// zoom serialization bake. Each reads the element's effective inline style and writes resolved/baked
+    /// values, as the passes build on one another.
     ///
-    /// HtmlBridge complexity-reduction roadmap Phase 4 item 2 (inline-style single authority),
-    /// first increment: the anchor-resolver cluster reaches the store ONLY through this accessor and
-    /// the <see cref="BakedStyleMap"/> it returns, instead of indexing the raw <see cref="InlineStyle"/>
-    /// dictionary at ~90 scattered sites. Today it wraps that same per-element dict, so behaviour is
-    /// byte-identical. The seam exists so a later increment can split the resolver's baked-geometry
-    /// writes into a store distinct from the script-observable inline style — those writes must NOT
-    /// leak into live <c>getAttribute("style")</c> mid-resolution (unlike the <c>element.style</c> JS
-    /// path, which write-throughs to the attribute), which is exactly why the dict is currently a
-    /// dual-purpose parallel store. That split then changes only this method and the struct below.
+    /// HtmlBridge complexity-reduction roadmap Phase 4 item 2 (inline-style single authority). Increment 1
+    /// routed the anchor-resolver cluster (~98 sites) here; increment 2 routed the remaining bridge-internal
+    /// bake writers (AnimationResolver, and the synthetic-form-control + zoom bake writes in
+    /// DomBridge.Serialization.cs), so <b>every</b> serialize-time bake write now goes through this one
+    /// chokepoint while the script path (<c>element.style</c>/<c>setAttribute</c>, which write-throughs to
+    /// the <c>style=</c> attribute) and the cascade cleanup stay on <see cref="InlineStyle"/>. Today it
+    /// wraps that same per-element dict, so behaviour is byte-identical. The seam exists so a later
+    /// increment can split the baked writes into a store distinct from the script-observable inline style —
+    /// those writes must NOT leak into live <c>getAttribute("style")</c> mid-resolution, which is exactly
+    /// why the dict is currently a dual-purpose parallel store — by changing only this method, the struct
+    /// below, and the serializer's effective-style read (the merge point). The remaining
+    /// <see cref="InlineStyle"/> reads in the serializer (<c>SyncStyleAttributeFromInlineStyle</c>, the zoom
+    /// source reads, and the final property emit) are exactly those merge points.
     /// </summary>
     internal BakedStyleMap BakedInlineStyle(DomElement element) => new(InlineStyle(element));
 }
@@ -52,6 +58,8 @@ internal readonly struct BakedStyleMap
         _store.TryGetValue(key, out value);
 
     public string? GetValueOrDefault(string key) => _store.GetValueOrDefault(key);
+
+    public int Count => _store.Count;
 
     public Dictionary<string, string>.KeyCollection Keys => _store.Keys;
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
@@ -78,7 +78,7 @@ public sealed partial class DomBridge
 
             // Set position:fixed as UA default for modal dialogs that have
             // no explicit position, matching Chromium's top-layer behaviour.
-            InlineStyle(el)["position"] = "fixed";
+            BakedInlineStyle(el)["position"] = "fixed";
 
             // HTML UA `dialog:modal { inset:0; margin:auto }` centring. With the box
             // fixed-positioned, both insets 0 and auto margins, the layout engine's
@@ -121,18 +121,18 @@ public sealed partial class DomBridge
 
         if (ResolveModalAxisCentres(el, specified, "width"))
         {
-            InlineStyle(el)["left"] = "0";
-            InlineStyle(el)["right"] = "0";
-            InlineStyle(el)["margin-left"] = "auto";
-            InlineStyle(el)["margin-right"] = "auto";
+            BakedInlineStyle(el)["left"] = "0";
+            BakedInlineStyle(el)["right"] = "0";
+            BakedInlineStyle(el)["margin-left"] = "auto";
+            BakedInlineStyle(el)["margin-right"] = "auto";
         }
 
         if (ResolveModalAxisCentres(el, specified, "height"))
         {
-            InlineStyle(el)["top"] = "0";
-            InlineStyle(el)["bottom"] = "0";
-            InlineStyle(el)["margin-top"] = "auto";
-            InlineStyle(el)["margin-bottom"] = "auto";
+            BakedInlineStyle(el)["top"] = "0";
+            BakedInlineStyle(el)["bottom"] = "0";
+            BakedInlineStyle(el)["margin-top"] = "auto";
+            BakedInlineStyle(el)["margin-bottom"] = "auto";
         }
     }
 
@@ -144,7 +144,7 @@ public sealed partial class DomBridge
     {
         if (!specified.TryGetValue(sizeProperty, out var value) || string.IsNullOrWhiteSpace(value))
         {
-            InlineStyle(el)[sizeProperty] = "fit-content"; // UA dialog:modal shrink-to-fit default
+            BakedInlineStyle(el)[sizeProperty] = "fit-content"; // UA dialog:modal shrink-to-fit default
             return true;
         }
 
@@ -180,11 +180,11 @@ public sealed partial class DomBridge
 
             if (!alreadyPositioned)
             {
-                InlineStyle(el)["position"] = "fixed";
-                if (!InlineStyle(el).ContainsKey("top") && !props.ContainsKey("top"))
-                    InlineStyle(el)["top"] = "0";
-                if (!InlineStyle(el).ContainsKey("left") && !props.ContainsKey("left"))
-                    InlineStyle(el)["left"] = "0";
+                BakedInlineStyle(el)["position"] = "fixed";
+                if (!BakedInlineStyle(el).ContainsKey("top") && !props.ContainsKey("top"))
+                    BakedInlineStyle(el)["top"] = "0";
+                if (!BakedInlineStyle(el).ContainsKey("left") && !props.ContainsKey("left"))
+                    BakedInlineStyle(el)["left"] = "0";
             }
 
             // Elevate into the top layer, ordered by show order, so the popover paints above
@@ -197,7 +197,7 @@ public sealed partial class DomBridge
             if (NativeTopLayer)
                 StampTopLayerOrder(el, order);
             else
-                InlineStyle(el)["z-index"] = (TopLayerZIndexBase + order).ToString(System.Globalization.CultureInfo.InvariantCulture);
+                BakedInlineStyle(el)["z-index"] = (TopLayerZIndexBase + order).ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
     }
     // -----------------------------------------------------------------
@@ -262,7 +262,7 @@ public sealed partial class DomBridge
 
                 var backdrop = CreateBridgeElement("div");
                 foreach (var kv in backdropStyle)
-                    InlineStyle(backdrop)[kv.Key] = kv.Value;
+                    BakedInlineStyle(backdrop)[kv.Key] = kv.Value;
                 SetParent(backdrop, parent);
 
                 int idx = ChildIndexOf(parent, dialog);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/InlineContainingBlocks.cs
@@ -13,7 +13,7 @@ public sealed partial class DomBridge
     {
         foreach (var el in Elements)
         {
-            if (InlineStyle(el).TryGetValue("anchor-name", out var anchorName) &&
+            if (BakedInlineStyle(el).TryGetValue("anchor-name", out var anchorName) &&
                 !string.IsNullOrWhiteSpace(anchorName))
             {
                 var box = ComputeElementBoxWithContainer(el);
@@ -331,24 +331,24 @@ public sealed partial class DomBridge
             double curTop = TryParsePx(childCss.GetValueOrDefault("top")) ?? 0;
             double curWidth = TryParsePx(childCss.GetValueOrDefault("width")) ?? 0;
             double curHeight = TryParsePx(childCss.GetValueOrDefault("height")) ?? 0;
-            InlineStyle(child)["position"] = childCss.GetValueOrDefault("position") ?? "absolute";
+            BakedInlineStyle(child)["position"] = childCss.GetValueOrDefault("position") ?? "absolute";
             // Ensure inline elements (like <span>) are treated as block-level
             // after absolute positioning, so the renderer paints backgrounds.
             string? childDisplay = childCss.GetValueOrDefault("display");
             if (IsInlineElement(child.TagName, childDisplay))
-                InlineStyle(child)["display"] = "block";
-            InlineStyle(child)["left"] = $"{(curLeft + offX).ToString(CultureInfo.InvariantCulture)}px";
-            InlineStyle(child)["top"] = $"{(curTop + offY).ToString(CultureInfo.InvariantCulture)}px";
+                BakedInlineStyle(child)["display"] = "block";
+            BakedInlineStyle(child)["left"] = $"{(curLeft + offX).ToString(CultureInfo.InvariantCulture)}px";
+            BakedInlineStyle(child)["top"] = $"{(curTop + offY).ToString(CultureInfo.InvariantCulture)}px";
             // Ensure width and height are preserved as inline styles.
             if (curWidth > 0)
-                InlineStyle(child)["width"] = $"{curWidth.ToString(CultureInfo.InvariantCulture)}px";
+                BakedInlineStyle(child)["width"] = $"{curWidth.ToString(CultureInfo.InvariantCulture)}px";
             if (curHeight > 0)
-                InlineStyle(child)["height"] = $"{curHeight.ToString(CultureInfo.InvariantCulture)}px";
+                BakedInlineStyle(child)["height"] = $"{curHeight.ToString(CultureInfo.InvariantCulture)}px";
             // Preserve background-color if specified in CSS rules.
             string? bg = childCss.GetValueOrDefault("background-color")
                       ?? childCss.GetValueOrDefault("background");
             if (!string.IsNullOrWhiteSpace(bg) && bg != "transparent" && bg != "initial")
-                InlineStyle(child)["background-color"] = bg;
+                BakedInlineStyle(child)["background-color"] = bg;
 
             // Move from inline CB to block ancestor.
             RemoveChildFrom(inlineCB, child);
@@ -358,7 +358,7 @@ public sealed partial class DomBridge
             var blockProps = GetComputedProps(blockAncestor);
             string? blockPos = blockProps.GetValueOrDefault("position");
             if (blockPos == null || blockPos == "static")
-                InlineStyle(blockAncestor)["position"] = "relative";
+                BakedInlineStyle(blockAncestor)["position"] = "relative";
         }
     }
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionArea.cs
@@ -24,7 +24,7 @@ public sealed partial class DomBridge
         if (!IsText(element))
         {
             var cssProps = CollectMatchedRuleProperties(element);
-            foreach (var kv in InlineStyle(element))
+            foreach (var kv in BakedInlineStyle(element))
                 cssProps[kv.Key] = kv.Value;
 
             string? positionArea = cssProps.GetValueOrDefault("position-area");
@@ -81,11 +81,11 @@ public sealed partial class DomBridge
                     if (!cssProps.TryGetValue("position", out var origPos) ||
                         !origPos.Equals("fixed", StringComparison.OrdinalIgnoreCase))
                     {
-                        InlineStyle(element)["position"] = "absolute";
+                        BakedInlineStyle(element)["position"] = "absolute";
                     }
                     else
                     {
-                        InlineStyle(element)["position"] = "fixed";
+                        BakedInlineStyle(element)["position"] = "fixed";
                     }
 
                     double cellW = rect.Value.Width;
@@ -235,7 +235,7 @@ public sealed partial class DomBridge
                                 var blockProps = GetComputedProps(blockAncestor);
                                 string? blockPos = blockProps.GetValueOrDefault("position");
                                 if (blockPos == null || blockPos == "static")
-                                    InlineStyle(blockAncestor)["position"] = "relative";
+                                    BakedInlineStyle(blockAncestor)["position"] = "relative";
                             }
 
                             // Defer the move to avoid collection modification
@@ -314,17 +314,17 @@ public sealed partial class DomBridge
 
                         // Set resolved pixel values for margins and padding
                         // to override the percentage values from CSS.
-                        InlineStyle(element)["margin-top"] = $"{marginTop2.ToString(CultureInfo.InvariantCulture)}px";
-                        InlineStyle(element)["margin-right"] = $"{marginRight2.ToString(CultureInfo.InvariantCulture)}px";
-                        InlineStyle(element)["margin-bottom"] = $"{marginBottom2.ToString(CultureInfo.InvariantCulture)}px";
-                        InlineStyle(element)["margin-left"] = $"{marginLeft2.ToString(CultureInfo.InvariantCulture)}px";
-                        InlineStyle(element)["padding-top"] = $"{padTop.ToString(CultureInfo.InvariantCulture)}px";
-                        InlineStyle(element)["padding-right"] = $"{padRight.ToString(CultureInfo.InvariantCulture)}px";
-                        InlineStyle(element)["padding-bottom"] = $"{padBottom.ToString(CultureInfo.InvariantCulture)}px";
-                        InlineStyle(element)["padding-left"] = $"{padLeft.ToString(CultureInfo.InvariantCulture)}px";
-                        InlineStyle(element).Remove("margin");
-                        InlineStyle(element).Remove("padding");
-                        InlineStyle(element).Remove("inset");
+                        BakedInlineStyle(element)["margin-top"] = $"{marginTop2.ToString(CultureInfo.InvariantCulture)}px";
+                        BakedInlineStyle(element)["margin-right"] = $"{marginRight2.ToString(CultureInfo.InvariantCulture)}px";
+                        BakedInlineStyle(element)["margin-bottom"] = $"{marginBottom2.ToString(CultureInfo.InvariantCulture)}px";
+                        BakedInlineStyle(element)["margin-left"] = $"{marginLeft2.ToString(CultureInfo.InvariantCulture)}px";
+                        BakedInlineStyle(element)["padding-top"] = $"{padTop.ToString(CultureInfo.InvariantCulture)}px";
+                        BakedInlineStyle(element)["padding-right"] = $"{padRight.ToString(CultureInfo.InvariantCulture)}px";
+                        BakedInlineStyle(element)["padding-bottom"] = $"{padBottom.ToString(CultureInfo.InvariantCulture)}px";
+                        BakedInlineStyle(element)["padding-left"] = $"{padLeft.ToString(CultureInfo.InvariantCulture)}px";
+                        BakedInlineStyle(element).Remove("margin");
+                        BakedInlineStyle(element).Remove("padding");
+                        BakedInlineStyle(element).Remove("inset");
 
                         resolvedW = contentW;
                         resolvedH = contentH;
@@ -362,16 +362,16 @@ public sealed partial class DomBridge
                         // (which maps medium→2px instead of the spec's 3px).
                         // Always set the value (even 0px) to ensure the
                         // renderer doesn't fall back to its keyword defaults.
-                        InlineStyle(element)["border-top-width"] = $"{bdrT.ToString(CultureInfo.InvariantCulture)}px";
-                        InlineStyle(element)["border-right-width"] = $"{bdrR.ToString(CultureInfo.InvariantCulture)}px";
-                        InlineStyle(element)["border-bottom-width"] = $"{bdrB.ToString(CultureInfo.InvariantCulture)}px";
-                        InlineStyle(element)["border-left-width"] = $"{bdrL.ToString(CultureInfo.InvariantCulture)}px";
+                        BakedInlineStyle(element)["border-top-width"] = $"{bdrT.ToString(CultureInfo.InvariantCulture)}px";
+                        BakedInlineStyle(element)["border-right-width"] = $"{bdrR.ToString(CultureInfo.InvariantCulture)}px";
+                        BakedInlineStyle(element)["border-bottom-width"] = $"{bdrB.ToString(CultureInfo.InvariantCulture)}px";
+                        BakedInlineStyle(element)["border-left-width"] = $"{bdrL.ToString(CultureInfo.InvariantCulture)}px";
                     }
 
-                    InlineStyle(element)["left"] = $"{finalLeft.ToString(CultureInfo.InvariantCulture)}px";
-                    InlineStyle(element)["top"] = $"{finalTop.ToString(CultureInfo.InvariantCulture)}px";
-                    InlineStyle(element)["width"] = $"{resolvedW.ToString(CultureInfo.InvariantCulture)}px";
-                    InlineStyle(element)["height"] = $"{resolvedH.ToString(CultureInfo.InvariantCulture)}px";
+                    BakedInlineStyle(element)["left"] = $"{finalLeft.ToString(CultureInfo.InvariantCulture)}px";
+                    BakedInlineStyle(element)["top"] = $"{finalTop.ToString(CultureInfo.InvariantCulture)}px";
+                    BakedInlineStyle(element)["width"] = $"{resolvedW.ToString(CultureInfo.InvariantCulture)}px";
+                    BakedInlineStyle(element)["height"] = $"{resolvedH.ToString(CultureInfo.InvariantCulture)}px";
 
                     // Record the scroll container for deferred position:relative.
                     if (scrollContainer != null)
@@ -386,7 +386,7 @@ public sealed partial class DomBridge
                     // placement post-pass from repositioning an already-placed box. Stamped
                     // unconditionally as of Phase 4 item-2 step 5 (harmless on the retired baked
                     // path, where the engine post-pass does not run).
-                    InlineStyle(element)["position-area"] = "none";
+                    BakedInlineStyle(element)["position-area"] = "none";
                 }
             }
         }
@@ -494,7 +494,7 @@ public sealed partial class DomBridge
             return false;
 
         var cssProps = CollectMatchedRuleProperties(element);
-        foreach (var kv in InlineStyle(element))
+        foreach (var kv in BakedInlineStyle(element))
             cssProps[kv.Key] = kv.Value;
 
         string? positionArea = cssProps.GetValueOrDefault("position-area");

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/PositionTry.cs
@@ -61,7 +61,7 @@ public sealed partial class DomBridge
         {
             // Collect all CSS + inline properties to find position-try-fallbacks.
             var cssProps = CollectMatchedRuleProperties(element);
-            foreach (var kv in InlineStyle(element))
+            foreach (var kv in BakedInlineStyle(element))
                 cssProps[kv.Key] = kv.Value;
 
             string? fallbacks = cssProps.GetValueOrDefault("position-try-fallbacks") ??
@@ -85,8 +85,8 @@ public sealed partial class DomBridge
                 else
                 {
                     TryApplyFallback(element, cssProps, anchorRegistry, positionTryRules, fallbacks!);
-                    InlineStyle(element)["position-try-fallbacks"] = "none";
-                    InlineStyle(element)["position-try"] = "normal";
+                    BakedInlineStyle(element)["position-try-fallbacks"] = "none";
+                    BakedInlineStyle(element)["position-try"] = "normal";
                 }
             }
         }
@@ -108,15 +108,15 @@ public sealed partial class DomBridge
         // Check if the base style overflows the IMCB. The base insets are already baked
         // to inline px here; the live read path (ResolvePositionTryForElement) resolves them
         // fresh and calls the same ComputeFallbackPlacement core.
-        double baseLeft = TryParsePx(InlineStyle(element).GetValueOrDefault("left")) ?? 0;
-        double baseTop = TryParsePx(InlineStyle(element).GetValueOrDefault("top")) ?? 0;
-        double baseRight = TryParsePx(InlineStyle(element).GetValueOrDefault("right")) ??
+        double baseLeft = TryParsePx(BakedInlineStyle(element).GetValueOrDefault("left")) ?? 0;
+        double baseTop = TryParsePx(BakedInlineStyle(element).GetValueOrDefault("top")) ?? 0;
+        double baseRight = TryParsePx(BakedInlineStyle(element).GetValueOrDefault("right")) ??
                            TryParsePx(baseProps.GetValueOrDefault("right")) ?? 0;
-        double baseBottom = TryParsePx(InlineStyle(element).GetValueOrDefault("bottom")) ??
+        double baseBottom = TryParsePx(BakedInlineStyle(element).GetValueOrDefault("bottom")) ??
                             TryParsePx(baseProps.GetValueOrDefault("bottom")) ?? 0;
-        double baseWidth = TryParsePx(InlineStyle(element).GetValueOrDefault("width")) ??
+        double baseWidth = TryParsePx(BakedInlineStyle(element).GetValueOrDefault("width")) ??
                            TryParsePx(baseProps.GetValueOrDefault("width")) ?? 0;
-        double baseHeight = TryParsePx(InlineStyle(element).GetValueOrDefault("height")) ??
+        double baseHeight = TryParsePx(BakedInlineStyle(element).GetValueOrDefault("height")) ??
                             TryParsePx(baseProps.GetValueOrDefault("height")) ?? 0;
 
         // Estimate content width for min-content/max-content.
@@ -132,13 +132,13 @@ public sealed partial class DomBridge
         if (ComputeFallbackPlacement(baseProps, anchorRegistry, positionTryRules, fallbackList,
                 baseLeft, baseTop, baseRight, baseBottom, baseWidth, baseHeight, cbWidth, cbHeight) is { } placed)
         {
-            InlineStyle(element)["left"] = $"{placed.left.ToString(CultureInfo.InvariantCulture)}px";
-            InlineStyle(element)["top"] = $"{placed.top.ToString(CultureInfo.InvariantCulture)}px";
-            InlineStyle(element)["width"] = $"{placed.width.ToString(CultureInfo.InvariantCulture)}px";
-            InlineStyle(element)["height"] = $"{placed.height.ToString(CultureInfo.InvariantCulture)}px";
-            InlineStyle(element).Remove("right");
-            InlineStyle(element).Remove("bottom");
-            InlineStyle(element).Remove("inset");
+            BakedInlineStyle(element)["left"] = $"{placed.left.ToString(CultureInfo.InvariantCulture)}px";
+            BakedInlineStyle(element)["top"] = $"{placed.top.ToString(CultureInfo.InvariantCulture)}px";
+            BakedInlineStyle(element)["width"] = $"{placed.width.ToString(CultureInfo.InvariantCulture)}px";
+            BakedInlineStyle(element)["height"] = $"{placed.height.ToString(CultureInfo.InvariantCulture)}px";
+            BakedInlineStyle(element).Remove("right");
+            BakedInlineStyle(element).Remove("bottom");
+            BakedInlineStyle(element).Remove("inset");
         }
     }
 
@@ -291,7 +291,7 @@ public sealed partial class DomBridge
         {
             if (IsText(child)) continue;
             var childProps = CollectMatchedRuleProperties(child);
-            foreach (var kv in InlineStyle(child))
+            foreach (var kv in BakedInlineStyle(child))
                 childProps[kv.Key] = kv.Value;
 
             double childWidth = TryParsePx(childProps.GetValueOrDefault("width")) ?? 0;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/StickyPositioning.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/StickyPositioning.cs
@@ -77,18 +77,18 @@ public sealed partial class DomBridge
         // position as `relative` + offset reproduces it.  Relative and sticky
         // both establish a containing block / stacking context, so this is
         // behaviour-preserving for descendants.
-        InlineStyle(el)["position"] = "relative";
+        BakedInlineStyle(el)["position"] = "relative";
 
         if (dy != 0)
         {
-            InlineStyle(el)["top"] = dy.ToString("0.###", CultureInfo.InvariantCulture) + "px";
-            InlineStyle(el).Remove("bottom");
+            BakedInlineStyle(el)["top"] = dy.ToString("0.###", CultureInfo.InvariantCulture) + "px";
+            BakedInlineStyle(el).Remove("bottom");
         }
 
         if (dx != 0)
         {
-            InlineStyle(el)["left"] = dx.ToString("0.###", CultureInfo.InvariantCulture) + "px";
-            InlineStyle(el).Remove("right");
+            BakedInlineStyle(el)["left"] = dx.ToString("0.###", CultureInfo.InvariantCulture) + "px";
+            BakedInlineStyle(el).Remove("right");
         }
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Visibility.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Visibility.cs
@@ -25,7 +25,7 @@ public sealed partial class DomBridge
         {
             if (IsText(el)) continue;
             // Check inline styles first.
-            if (InlineStyle(el).TryGetValue("anchor-name", out var n) &&
+            if (BakedInlineStyle(el).TryGetValue("anchor-name", out var n) &&
                 string.Equals(n.Trim(), anchorName, StringComparison.Ordinal))
                 return el;
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
@@ -117,11 +117,11 @@ public sealed partial class DomBridge
         string? animValue = null, delayValue = null, nameValue = null;
         bool hasAnimation = false, hasDelay = false, hasName = false;
 
-        if (InlineStyle(element).Count > 0)
+        if (BakedInlineStyle(element).Count > 0)
         {
-            hasAnimation = InlineStyle(element).TryGetValue("animation", out animValue);
-            hasDelay = InlineStyle(element).TryGetValue("animation-delay", out delayValue);
-            hasName = InlineStyle(element).TryGetValue("animation-name", out nameValue);
+            hasAnimation = BakedInlineStyle(element).TryGetValue("animation", out animValue);
+            hasDelay = BakedInlineStyle(element).TryGetValue("animation-delay", out delayValue);
+            hasName = BakedInlineStyle(element).TryGetValue("animation-name", out nameValue);
         }
 
         // Also check stylesheet rules that may apply to this element.
@@ -311,7 +311,7 @@ public sealed partial class DomBridge
                     if (fillMode is "backwards" or "both")
                     {
                         foreach (var kv in keyframes[0].Properties)
-                            InlineStyle(element)[kv.Key] = kv.Value;
+                            BakedInlineStyle(element)[kv.Key] = kv.Value;
                     }
                     return;
                 }
@@ -344,13 +344,13 @@ public sealed partial class DomBridge
 
         // Apply resolved values as inline styles and remove animation properties.
         foreach (var kv in resolvedProps)
-            InlineStyle(element)[kv.Key] = kv.Value;
+            BakedInlineStyle(element)[kv.Key] = kv.Value;
 
-        InlineStyle(element).Remove("animation");
-        InlineStyle(element).Remove("animation-delay");
-        InlineStyle(element).Remove("animation-name");
-        InlineStyle(element).Remove("animation-duration");
-        InlineStyle(element).Remove("animation-timing-function");
+        BakedInlineStyle(element).Remove("animation");
+        BakedInlineStyle(element).Remove("animation-delay");
+        BakedInlineStyle(element).Remove("animation-name");
+        BakedInlineStyle(element).Remove("animation-duration");
+        BakedInlineStyle(element).Remove("animation-timing-function");
     }
 
     private Dictionary<string, string> ResolveKeyframeProperties(DomElement element,

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -151,24 +151,20 @@ public sealed partial class DomBridge
     }
 
     /// <summary>
-    /// Recursively collects all <c>&lt;style&gt;</c> elements from a document tree.
-    /// Sub-documents keep their own style scope, but since P4.4b severed the
-    /// <c>#subdoc-root</c> element they are no longer in-tree children, so this walk
-    /// never crosses a sub-document boundary.
+    /// Collects all <c>&lt;style&gt;</c> (and external-stylesheet <c>&lt;link&gt;</c>) elements from a
+    /// document tree. Sub-documents keep their own style scope, but since P4.4b severed the
+    /// <c>#subdoc-root</c> element they are no longer in-tree children, so this walk never crosses a
+    /// sub-document boundary. Phase 4 item 4/5: reuses canonical <see cref="DomNode.Descendants"/>
+    /// (document-order, level-snapshotted against the concurrent-mutation race the per-level
+    /// <see cref="SnapshotChildren"/> walk guarded — Descendants snapshots the real child list, so the
+    /// LegacyChildList projection overflow cannot occur here) instead of the hand-rolled recursion.
     /// </summary>
     private static void CollectStyleElementsInTree(DomElement root, List<DomElement> styleElements)
     {
-        foreach (var child in SnapshotChildren(root))
+        foreach (var element in root.Descendants().OfType<DomElement>())
         {
-            if (!IsText(child))
-            {
-                if (string.Equals(child.TagName, "style", StringComparison.OrdinalIgnoreCase))
-                    styleElements.Add(child);
-                else if (IsExternalStylesheet(child))
-                    styleElements.Add(child);
-
-                CollectStyleElementsInTree(child, styleElements);
-            }
+            if (string.Equals(element.TagName, "style", StringComparison.OrdinalIgnoreCase) || IsExternalStylesheet(element))
+                styleElements.Add(element);
         }
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsFunctionCallbacks/Common.cs
@@ -55,39 +55,16 @@ public sealed partial class DomBridge
 
     private bool IsPositionAfter(DomNode docRoot, DomNode containerA, int offsetA, DomNode containerB, int offsetB)
     {
-        if (ReferenceEquals(containerA, containerB))
-            return offsetA > offsetB;
+        // Phase 4 item 4/5: for boundary points in the SAME tree this is exactly canonical
+        // Broiler.Dom.DomRange.CompareBoundaryPoints(...) > 0 (verified branch-for-branch: same-container,
+        // either-descendant, and common-ancestor ordering all agree), so delegate to it instead of
+        // re-implementing the walk. The bridge deliberately keeps a LENIENT cross-tree path — canonical
+        // throws WrongDocument, but the bridge's compareBoundaryPoints returns an order rather than
+        // throwing — so the cross-tree branch (different roots) is preserved verbatim below.
+        if (ReferenceEquals(containerA.GetRootNode(), containerB.GetRootNode()))
+            return DomRange.CompareBoundaryPoints(containerA, offsetA, containerB, offsetB) > 0;
 
-        if (containerB.IsDescendantOf(containerA))
-        {
-            DomNode node = containerB;
-            while (node.ParentNode != null && !ReferenceEquals(node.ParentNode, containerA))
-                node = node.ParentNode;
-            if (node.ParentNode != null)
-            {
-                var childIdx = ChildIndexOf(containerA, node);
-                return offsetA > childIdx;
-            }
-
-            return false;
-        }
-
-        if (containerA.IsDescendantOf(containerB))
-        {
-            DomNode node = containerA;
-            while (node.ParentNode != null && !ReferenceEquals(node.ParentNode, containerB))
-                node = node.ParentNode;
-            if (node.ParentNode != null)
-            {
-                var childIdx = ChildIndexOf(containerB, node);
-                return childIdx >= offsetB;
-            }
-
-            return true;
-        }
-
-        var commonRoot = containerA.CommonAncestorWith(containerB) ?? docRoot;
-        var allNodes = commonRoot.InclusiveDescendants().ToList();
+        var allNodes = docRoot.InclusiveDescendants().ToList();
         var idxA = allNodes.IndexOf(containerA);
         var idxB = allNodes.IndexOf(containerB);
         if (idxA < 0 || idxB < 0)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/RuntimeStates.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/RuntimeStates.cs
@@ -59,13 +59,20 @@ internal sealed class InlineStyleRuntimeState
     // into their own per-bridge instance table (DomBridge._formControlRuntimeStates via FormControlStateFor,
     // _scrollRuntimeStates via ScrollStateFor, _dialogRuntimeStates via DialogStateFor, _shadowRuntimeStates
     // via ShadowStateFor, _styleSheetRuntimeStates via StyleSheetStateFor, _documentRuntimeStates via
-    // DocumentStateFor, _animationRuntimeStates via AnimationStateFor); every one's clone copy lives in
-    // CloneDomElement now, so the former CopyRuntimeValuesTo aggregator is gone. The inline-style concern
-    // that remained was itself de-globalized to a per-bridge table (DomBridge._inlineStyleStates via
+    // DocumentStateFor, _animationRuntimeStates via AnimationStateFor). The inline-style concern that
+    // remained was itself de-globalized to a per-bridge table (DomBridge._inlineStyleStates via
     // InlineStyleStateFor) and this composite renamed to InlineStyleRuntimeState — no process-static
     // per-element runtime table remains. See the *RuntimeState classes below (still used by those tables).
+    // Phase 4 item 5 (2026-07-19): each table's cloneNode copy is now a per-class CopyTo, aggregated by
+    // DomBridge.CopyBridgeRuntimeStateTo (a single authority, replacing the scattered per-field CopyTo list
+    // the earlier de-globalization had inlined into CloneDomElement).
 }
 
+// Phase 4 item 5 (CloneDomElement de-risk, 2026-07-19): each runtime-state composite owns a
+// CopyTo(target) that clones its own fields, co-located with the field declarations. cloneNode's
+// bridge-state copy (DomBridge.CopyBridgeRuntimeStateTo) is the single caller: keeping the copy
+// semantics next to the fields means adding a field can no longer silently drop from the clone
+// (the old scattered CopyTo list in CloneDomElement had to be hand-updated in a different file).
 internal sealed class FormControlRuntimeState
 {
     public RuntimeValue<string> Value { get; } = new();
@@ -73,12 +80,27 @@ internal sealed class FormControlRuntimeState
     public RuntimeValue<bool> DefaultSelected { get; } = new();
     public RuntimeValue<int> SelectedIndex { get; } = new();
     public RuntimeValue<string> ReturnValue { get; } = new();
+
+    public void CopyTo(FormControlRuntimeState target)
+    {
+        Value.CopyTo(target.Value);
+        Checked.CopyTo(target.Checked);
+        DefaultSelected.CopyTo(target.DefaultSelected);
+        SelectedIndex.CopyTo(target.SelectedIndex);
+        ReturnValue.CopyTo(target.ReturnValue);
+    }
 }
 
 internal sealed class ScrollRuntimeState
 {
     public RuntimeValue<double> Left { get; } = new();
     public RuntimeValue<double> Top { get; } = new();
+
+    public void CopyTo(ScrollRuntimeState target)
+    {
+        Left.CopyTo(target.Left);
+        Top.CopyTo(target.Top);
+    }
 }
 
 internal sealed class DialogRuntimeState
@@ -91,6 +113,13 @@ internal sealed class DialogRuntimeState
     // the element in the top layer as it animates out, in which case it stays
     // set so its ::backdrop still renders for the snapshot.
     public RuntimeValue<bool> PopoverOpen { get; } = new();
+
+    public void CopyTo(DialogRuntimeState target)
+    {
+        Modal.CopyTo(target.Modal);
+        TopLayerOrder.CopyTo(target.TopLayerOrder);
+        PopoverOpen.CopyTo(target.PopoverOpen);
+    }
 }
 
 internal sealed class ShadowRuntimeState
@@ -98,6 +127,15 @@ internal sealed class ShadowRuntimeState
     public RuntimeValue<DomElement> Root { get; } = new();
     public RuntimeValue<DomElement> Host { get; } = new();
     public RuntimeValue<string> Mode { get; } = new();
+
+    // Copies the shadow root/host references verbatim — the clone points at the SAME shadow
+    // root/host as the source (the pre-existing cloneNode behaviour, preserved).
+    public void CopyTo(ShadowRuntimeState target)
+    {
+        Root.CopyTo(target.Root);
+        Host.CopyTo(target.Host);
+        Mode.CopyTo(target.Mode);
+    }
 }
 
 internal sealed class StyleSheetRuntimeState
@@ -128,16 +166,30 @@ internal sealed class StyleSheetRuntimeState
     /// text is serialized from the model so the mutation is observed downstream.
     /// </summary>
     public bool RulesMutated { get; set; }
+
+    // The rule list is deep-copied (a fresh List) so the clone's insertRule/deleteRule do not
+    // mutate the source sheet; the source text / mutated flag are copied verbatim.
+    public void CopyTo(StyleSheetRuntimeState target)
+    {
+        FetchedCss.CopyTo(target.FetchedCss);
+        target.Rules = Rules is null ? null : [.. Rules];
+        target.RulesSourceText = RulesSourceText;
+        target.RulesMutated = RulesMutated;
+    }
 }
 
 internal sealed class DocumentRuntimeState
 {
     public RuntimeValue<bool> HasViewport { get; } = new();
+
+    public void CopyTo(DocumentRuntimeState target) => HasViewport.CopyTo(target.HasViewport);
 }
 
 internal sealed class AnimationRuntimeState
 {
     public RuntimeValue<double> CurrentTimeMilliseconds { get; } = new();
+
+    public void CopyTo(AnimationRuntimeState target) => CurrentTimeMilliseconds.CopyTo(target.CurrentTimeMilliseconds);
 }
 
 internal sealed class RuntimeValue<T>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowDom.cs
@@ -54,16 +54,11 @@ public sealed partial class DomBridge
         return null;
     }
 
-    private DomNode GetTreeRoot(DomNode node)
-    {
-        DomNode current = node;
-        // Walk to the absolute root. For a connected node this is the canonical DomDocument
-        // (Phase 4: the document root is the DomDocument, not a #document wrapper element); a
-        // detached subtree roots to its topmost node (returned as a DomNode).
-        while (current.ParentNode is { } parent)
-            current = parent;
-        return current;
-    }
+    // Walk to the absolute root. For a connected node this is the canonical DomDocument (Phase 4: the
+    // document root is the DomDocument, not a #document wrapper element); a detached subtree roots to its
+    // topmost node. Phase 4 item 4/5: this is exactly canonical DomNode.GetRootNode(), so delegate to it
+    // rather than re-implement the `while ParentNode` climb.
+    private DomNode GetTreeRoot(DomNode node) => node.GetRootNode();
 
     private JSValue ToJSRootNode(DomNode root)
     {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
@@ -36,16 +36,15 @@ public sealed partial class DomBridge
         return arr;
     }
 
-    /// <summary>Collects all style elements in the sub-tree.</summary>
+    /// <summary>Collects all style elements in the sub-tree. Phase 4 item 4/5: reuses canonical
+    /// <see cref="DomNode.Descendants"/> (document-order, level-snapshotted against concurrent mutation)
+    /// instead of a hand-rolled depth-first recursion over the live child list.</summary>
     private static void CollectStyleElements(DomNode root, List<DomElement> results)
     {
-        foreach (var child in ChildElements(root))
+        foreach (var element in root.Descendants().OfType<DomElement>())
         {
-            if (string.Equals(child.TagName, "style", StringComparison.OrdinalIgnoreCase))
-                results.Add(child);
-            else if (IsExternalStylesheet(child))
-                results.Add(child);
-            CollectStyleElements(child, results);
+            if (string.Equals(element.TagName, "style", StringComparison.OrdinalIgnoreCase) || IsExternalStylesheet(element))
+                results.Add(element);
         }
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -289,73 +289,43 @@ public sealed partial class DomBridge
     /// </summary>
     private DomNode CloneDomElement(DomNode source, bool deep)
     {
-        // RF-BRIDGE-1c Phase F (F3c): canonical character-data nodes clone via the document
-        // factories (DomText/DomComment ctors are internal). Dead on today's homogeneous facade
-        // tree — facade text/comment nodes are Broiler.Dom.DomElement and take the element path below; live
-        // once text/comment construction flips to canonical DomText/DomComment.
-        if (source is DomCharacterData sourceCharData)
-        {
-            return IsComment(source)
-                ? _document.CreateComment(sourceCharData.Data)
-                : _document.CreateTextNode(sourceCharData.Data);
-        }
+        // Phase 4 item 5: delegate the tree + attribute clone to canonical DomNode.CloneNode (spec §4.4)
+        // instead of the bridge's hand-rolled per-node-kind rebuild. Canonical CloneShallow handles every
+        // node kind — element (namespace + attribute set verbatim), text/comment (data), doctype
+        // (name/publicId/systemId) and fragment — and, when deep, recurses the child list in order. This
+        // replaces the former CreateBridgeElementNS-from-main-`_document` construction + SetAttribute
+        // attribute copy; canonical preserves the source's owner document and attribute keys verbatim,
+        // which is spec-correct (the old path minted every clone from the main document and lowercased
+        // no-namespace attribute names). Cloning does not mutate the live document, so there is no
+        // MutationObserver/NodeIterator/live-range side-effect coupling here (unlike Normalize).
+        var clone = source.CloneNode(deep);
 
-        // Phase 4 item 1: a canonical DomDocumentType clones its immutable name/publicId/systemId.
-        if (source is DomDocumentType sourceDocType)
-            return _document.CreateDocumentType(sourceDocType.Name, sourceDocType.PublicId, sourceDocType.SystemId);
-
-        // Phase 4 item 1: a canonical DomDocumentFragment clones to an empty fragment; a deep clone
-        // copies its children (a shallow clone is empty, per DOM).
-        if (source is DomDocumentFragment sourceFragment)
-        {
-            var fragmentClone = CreateBridgeDocumentFragment();
-            if (deep)
-                foreach (var child in sourceFragment.ChildNodes.ToArray())
-                    fragmentClone.AppendChild(CloneDomElement(child, true));
-            return fragmentClone;
-        }
-
-        var element = (DomElement)source;
-        // Preserve the source element's exact namespace (folds the old post-construction
-        // `clone.NamespaceURI = element.NamespaceURI` — see below); SVG/foreign clones keep
-        // their namespace rather than defaulting to HTML.
-        var clone = CreateBridgeElementNS(element.NamespaceUri, element.TagName, element.Id, element.ClassName);
-        // RF-BRIDGE-1c Phase C2: copy attributes straight from the canonical namespace-keyed
-        // set so namespaced attributes (namespace, prefix, local name) survive the clone —
-        // that fidelity used to depend on the separate NsAttrMap shadow. No-namespace
-        // attributes go through SetAttribute (which lowercases, matching the prior snapshot
-        // path); a prefixed qualified name can only exist with a namespace, so it never
-        // reaches the SetAttribute branch (which would throw on the ':').
-        foreach (var attribute in element.Attributes.Values)
-        {
-            if (attribute.NamespaceUri is null)
-                clone.SetAttribute(attribute.QualifiedName, attribute.Value);
-            else
-                clone.SetAttributeNS(attribute.NamespaceUri, attribute.QualifiedName, attribute.Value);
-        }
-        // RF-BRIDGE-1c Phase F (F3c part 2d): element text lives in child DomText nodes, cloned by
-        // the deep-clone loop below — no element-store TextContent scalar to copy.
-        // (The namespace was carried at construction via CreateBridgeElementNS above.)
-        // Copy all bridge per-element runtime state (inline style, form control, scroll, dialog/
-        // popover, shadow, stylesheet, document viewport, animation, position-area memo) through the
-        // single CopyBridgeRuntimeStateTo authority. Must run after the attributes are copied above:
-        // the inline-style copy first lazily seeds the clone from its `style=` attribute, then
-        // overwrites it with the source's live dict.
-        CopyBridgeRuntimeStateTo(element, clone);
-
-        if (deep)
-        {
-            // RF-BRIDGE-1c Phase F (F3c): iterate raw ChildNodes (not ChildElements) so text/
-            // comment children clone too once they flip to canonical DomText/DomComment. On the
-            // homogeneous facade tree every child is already an element, so this is a no-op widen.
-            foreach (var child in element.ChildNodes)
-            {
-                var childClone = CloneDomElement(child, true);
-                SetParent(childClone, clone);
-                clone.AppendChild(childClone);
-            }
-        }
+        // Canonical CloneNode knows nothing about the bridge's parallel per-element runtime state (inline
+        // style + baked overlay, form control, scroll, dialog/popover, shadow, stylesheet, document
+        // viewport, animation, position-area memo), so copy it onto every element in the cloned subtree
+        // through the single CopyBridgeRuntimeStateTo authority (P4.13 / P4.14-inc3).
+        CopyRuntimeStateForClonedSubtree(source, clone, deep);
         return clone;
+    }
+
+    /// <summary>
+    /// Walks a source subtree and its canonical <c>CloneNode</c> copy in lockstep, copying the bridge's
+    /// per-element runtime state (via <see cref="CopyBridgeRuntimeStateTo"/>) from each source element to
+    /// its clone. Canonical <c>CloneNode(deep)</c> reproduces the child list in order, so index <c>i</c>
+    /// of the source's children pairs with index <c>i</c> of the clone's.
+    /// </summary>
+    private void CopyRuntimeStateForClonedSubtree(DomNode source, DomNode clone, bool deep)
+    {
+        if (source is DomElement sourceElement && clone is DomElement cloneElement)
+            CopyBridgeRuntimeStateTo(sourceElement, cloneElement);
+
+        if (!deep)
+            return;
+
+        var sourceChildren = source.ChildNodes;
+        var cloneChildren = clone.ChildNodes;
+        for (var i = 0; i < sourceChildren.Count && i < cloneChildren.Count; i++)
+            CopyRuntimeStateForClonedSubtree(sourceChildren[i], cloneChildren[i], true);
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -413,6 +413,10 @@ public sealed partial class DomBridge
         // Memoized position-area resolution (was ElementRuntimeState.Layout, now the bridge-level
         // PositionAreaResolutions cache — see PositionAreaQueries.cs).
         CopyPositionAreaResolution(source, clone);
+
+        // Baked-style overlay (Phase 4 item 2 increment 3): serialize-time bakes now live off the
+        // inline-style dict, so copy the overlay too. A no-op unless the source was cloned after baking.
+        CopyBakedStyleOverlay(source, clone);
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -250,41 +250,23 @@ public sealed partial class DomBridge
         if (ReferenceEquals(first, second))
             return 0;
 
-        var firstAncestors = new List<DomNode>();
-        for (DomNode? current = first; current != null; current = current.ParentNode)
-            firstAncestors.Add(current);
-        firstAncestors.Reverse();
-
-        var secondAncestors = new List<DomNode>();
-        for (DomNode? current = second; current != null; current = current.ParentNode)
-            secondAncestors.Add(current);
-        secondAncestors.Reverse();
-
-        var divergenceIndex = 0;
-        var sharedLength = Math.Min(firstAncestors.Count, secondAncestors.Count);
-        while (divergenceIndex < sharedLength &&
-               ReferenceEquals(firstAncestors[divergenceIndex], secondAncestors[divergenceIndex]))
-        {
-            divergenceIndex++;
-        }
-
-        if (divergenceIndex == 0 ||
-            divergenceIndex >= firstAncestors.Count ||
-            divergenceIndex >= secondAncestors.Count)
-        {
-            return 0;
-        }
-
-        var commonAncestor = firstAncestors[divergenceIndex - 1];
-        var firstChild = firstAncestors[divergenceIndex];
-        var secondChild = secondAncestors[divergenceIndex];
-        var firstIndex = ChildIndexOf(commonAncestor, firstChild);
-        var secondIndex = ChildIndexOf(commonAncestor, secondChild);
-
-        if (firstIndex == secondIndex)
+        // Phase 4 item 4/5: the tree order of two nodes is the order of the boundary points immediately
+        // before each of them, which canonical Broiler.Dom.DomRange.CompareBoundaryPoints computes — the
+        // same canonical order primitive IsPositionAfter (P4.17) now delegates to, replacing the
+        // hand-rolled ancestor-chain divergence. This helper's only caller (compareDocumentPosition)
+        // already resolves the same-node, disconnected, and ancestor/descendant cases before reaching
+        // here, so both nodes are same-tree, non-containing, and parented; the guards below preserve the
+        // old "return 0 when no ordering can be determined" contract (and avoid CompareBoundaryPoints's
+        // cross-tree WrongDocument throw) for any other caller.
+        var firstParent = first.ParentNode;
+        var secondParent = second.ParentNode;
+        if (firstParent is null || secondParent is null ||
+            !ReferenceEquals(first.GetRootNode(), second.GetRootNode()))
             return 0;
 
-        return firstIndex < secondIndex ? -1 : 1;
+        return Math.Sign(DomRange.CompareBoundaryPoints(
+            firstParent, ChildIndexOf(firstParent, first),
+            secondParent, ChildIndexOf(secondParent, second)));
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -509,11 +509,15 @@ public sealed partial class DomBridge
     /// </summary>
     private static void CollectDescendantsByTag(DomElement root, string tagName, List<JSValue> results, DomBridge bridge)
     {
-        foreach (var child in ChildElements(root))
+        // Phase 4 item 4/5: reuse canonical Descendants() (public, document-order, level-snapshotted —
+        // the bridge's own WPT #1143 defensive idiom promoted to canonical, operating on the real child
+        // list so it also avoids the LegacyChildList projection overflow) instead of a hand-rolled
+        // depth-first ChildElements recursion. Same element set + pre-order; mutation-safe where the old
+        // live ChildElements iteration was not.
+        foreach (var element in root.Descendants().OfType<DomElement>())
         {
-            if (tagName == "*" || string.Equals(child.TagName, tagName, StringComparison.OrdinalIgnoreCase))
-                results.Add(bridge.ToJSObject(child));
-            CollectDescendantsByTag(child, tagName, results, bridge);
+            if (tagName == "*" || string.Equals(element.TagName, tagName, StringComparison.OrdinalIgnoreCase))
+                results.Add(bridge.ToJSObject(element));
         }
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -353,50 +353,15 @@ public sealed partial class DomBridge
             else
                 clone.SetAttributeNS(attribute.NamespaceUri, attribute.QualifiedName, attribute.Value);
         }
-        // RF-BRIDGE-1c Phase B: inline style lives in ElementRuntimeState now. Copy the
-        // source's live style dict (which may hold JS mutations not yet synced to the
-        // `style=` attribute), replacing the clone's lazily-seeded attribute values.
-        var cloneStyle = InlineStyle(clone);
-        cloneStyle.Clear();
-        foreach (var kv in InlineStyle(element))
-            cloneStyle[kv.Key] = kv.Value;
         // RF-BRIDGE-1c Phase F (F3c part 2d): element text lives in child DomText nodes, cloned by
         // the deep-clone loop below — no element-store TextContent scalar to copy.
         // (The namespace was carried at construction via CreateBridgeElementNS above.)
-        // Copy browser-runtime values (e.g., checked state for inputs). Form-control, scroll offsets,
-        // dialog/popover top-layer state, shadow-DOM linkage, stylesheet state, the document viewport
-        // flag and the animation timeline all moved out of ElementRuntimeState into per-bridge instance
-        // tables (Phase 2 item 4 de-globalization), so copy each here to preserve cloneNode semantics.
-        var sourceForm = FormControlStateFor(element);
-        var cloneForm = FormControlStateFor(clone);
-        sourceForm.Value.CopyTo(cloneForm.Value);
-        sourceForm.Checked.CopyTo(cloneForm.Checked);
-        sourceForm.DefaultSelected.CopyTo(cloneForm.DefaultSelected);
-        sourceForm.SelectedIndex.CopyTo(cloneForm.SelectedIndex);
-        sourceForm.ReturnValue.CopyTo(cloneForm.ReturnValue);
-        ScrollStateFor(element).Left.CopyTo(ScrollStateFor(clone).Left);
-        ScrollStateFor(element).Top.CopyTo(ScrollStateFor(clone).Top);
-        var sourceDialog = DialogStateFor(element);
-        var cloneDialog = DialogStateFor(clone);
-        sourceDialog.Modal.CopyTo(cloneDialog.Modal);
-        sourceDialog.TopLayerOrder.CopyTo(cloneDialog.TopLayerOrder);
-        sourceDialog.PopoverOpen.CopyTo(cloneDialog.PopoverOpen);
-        var sourceShadow = ShadowStateFor(element);
-        var cloneShadow = ShadowStateFor(clone);
-        sourceShadow.Root.CopyTo(cloneShadow.Root);
-        sourceShadow.Host.CopyTo(cloneShadow.Host);
-        sourceShadow.Mode.CopyTo(cloneShadow.Mode);
-        var sourceSheet = StyleSheetStateFor(element);
-        var cloneSheet = StyleSheetStateFor(clone);
-        sourceSheet.FetchedCss.CopyTo(cloneSheet.FetchedCss);
-        cloneSheet.Rules = sourceSheet.Rules is null ? null : [.. sourceSheet.Rules];
-        cloneSheet.RulesSourceText = sourceSheet.RulesSourceText;
-        cloneSheet.RulesMutated = sourceSheet.RulesMutated;
-        DocumentStateFor(element).HasViewport.CopyTo(DocumentStateFor(clone).HasViewport);
-        AnimationStateFor(element).CurrentTimeMilliseconds.CopyTo(AnimationStateFor(clone).CurrentTimeMilliseconds);
-        // Carry the memoized position-area resolution too (was ElementRuntimeState.Layout,
-        // now the bridge-level PositionAreaResolutions cache — see PositionAreaQueries.cs).
-        CopyPositionAreaResolution(element, clone);
+        // Copy all bridge per-element runtime state (inline style, form control, scroll, dialog/
+        // popover, shadow, stylesheet, document viewport, animation, position-area memo) through the
+        // single CopyBridgeRuntimeStateTo authority. Must run after the attributes are copied above:
+        // the inline-style copy first lazily seeds the clone from its `style=` attribute, then
+        // overwrites it with the source's live dict.
+        CopyBridgeRuntimeStateTo(element, clone);
 
         if (deep)
         {
@@ -411,6 +376,43 @@ public sealed partial class DomBridge
             }
         }
         return clone;
+    }
+
+    /// <summary>
+    /// Phase 4 item 5 (CloneDomElement de-risk): the single authority that copies every bridge
+    /// per-element runtime-state table from a source element onto its <c>cloneNode</c> copy.
+    /// Canonical <c>DomNode.CloneNode</c> clones the tree and attributes but knows nothing about
+    /// the bridge's parallel per-element state (inline style, form control, scroll, dialog/popover
+    /// top layer, shadow linkage, stylesheet CSSOM, document viewport flag, animation timeline and
+    /// the position-area memo), so the bridge carries it here. Consolidating it out of the scattered
+    /// inline block in <see cref="CloneDomElement"/> means each state table owns its own
+    /// <c>CopyTo</c> (in <c>RuntimeStates.cs</c>, next to its fields) — a new field/table can no
+    /// longer be silently dropped from clones — and isolates the exact bridge-state copy the
+    /// eventual canonical-<c>CloneNode</c> swap (item 5) will call alongside the canonical clone.
+    /// </summary>
+    private void CopyBridgeRuntimeStateTo(DomElement source, DomElement clone)
+    {
+        // Inline style (RF-BRIDGE-1c Phase B): copy the source's live style dict — which may hold
+        // JS `element.style` mutations not yet synced to the `style=` attribute — over the clone's
+        // lazily-seeded attribute values. `InlineStyle(clone)` seeds from the (already-copied)
+        // `style=` attribute before the Clear, so the copy is authoritative.
+        var cloneStyle = InlineStyle(clone);
+        cloneStyle.Clear();
+        foreach (var kv in InlineStyle(source))
+            cloneStyle[kv.Key] = kv.Value;
+
+        // Per-bridge instance tables (Phase 2 items 3/4 de-globalization) — each owns its CopyTo.
+        FormControlStateFor(source).CopyTo(FormControlStateFor(clone));
+        ScrollStateFor(source).CopyTo(ScrollStateFor(clone));
+        DialogStateFor(source).CopyTo(DialogStateFor(clone));
+        ShadowStateFor(source).CopyTo(ShadowStateFor(clone));
+        StyleSheetStateFor(source).CopyTo(StyleSheetStateFor(clone));
+        DocumentStateFor(source).CopyTo(DocumentStateFor(clone));
+        AnimationStateFor(source).CopyTo(AnimationStateFor(clone));
+
+        // Memoized position-area resolution (was ElementRuntimeState.Layout, now the bridge-level
+        // PositionAreaResolutions cache — see PositionAreaQueries.cs).
+        CopyPositionAreaResolution(source, clone);
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -295,13 +295,11 @@ public sealed partial class DomBridge
     /// set at construction/adoption (a sub-document's <c>createElement</c> node was adopted into its
     /// content document; every other node was minted from the main <c>_document</c>).
     /// </summary>
-    internal static DomDocument GetOwningDocument(DomNode node)
-    {
-        DomNode root = node;
-        while (root.ParentNode is { } parent)
-            root = parent;
-        return root as DomDocument ?? node.OwnerDocument;
-    }
+    internal static DomDocument GetOwningDocument(DomNode node) =>
+        // Phase 4 item 4/5: the absolute-root walk is canonical DomNode.GetRootNode() (the identical
+        // `while ParentNode` climb); a connected node roots to its DomDocument, a detached one falls
+        // back to the canonical owner-document set at construction/adoption.
+        node.GetRootNode() as DomDocument ?? node.OwnerDocument;
 
     /// <summary>
     /// Clones a <see cref="DomElement"/>. When <paramref name="deep"/> is true,


### PR DESCRIPTION
## Summary

Completes Phase 4 item 5 (eliminate parallel DOM state) by delegating `CloneDomElement` to canonical `DomNode.CloneNode` and consolidating the bridge's runtime-state copy into a single `CopyBridgeRuntimeStateTo` authority. Also exhausts the clean canonical neutral-algorithm reuses by delegating `CompareTreeOrder` to `DomRange.CompareBoundaryPoints` and promoting `DomNodeCollectionExtensions.IndexOfReference` to public for shared child-index scanning.

## Key Changes

- **CloneDomElement refactor (P4.20):** Reimplemented to delegate tree + attribute cloning to canonical `DomNode.CloneNode(deep)` instead of hand-rolled per-node-kind reconstruction. Introduces `CopyRuntimeStateForClonedSubtree` to walk source and clone in lockstep, applying the bridge's per-element runtime state (inline style, form control, scroll, dialog, shadow, stylesheet, document, animation, position-area) via a single `CopyBridgeRuntimeStateTo` authority. Verified byte-identical across ~14 clone suites (general, form-control-state, namespace, doctype, fragment, deep-clone, SVG attribute-case, sub-document owner-document).

- **Baked-style overlay split (P4.14-inc3):** Introduced `BakedStyleMap` and per-element `_bakedStyleOverlays` store to separate serialize-time bake writes (anchor resolver, animation snapshot, synthetic form-control styling, zoom bake) from the script-observable inline-style dict. Bakes now land in the overlay; reads merge base ∪ overlay at serialization time. `InlineStyleRuntimeState.Style` no longer carries bakes. Serialized output remains byte-identical.

- **CompareTreeOrder delegation (P4.19):** Reimplemented to delegate document-order comparison to canonical `DomRange.CompareBoundaryPoints` (the same primitive `IsPositionAfter` now uses), replacing hand-rolled ancestor-chain divergence. Reduces to `Math.Sign(CompareBoundaryPoints(firstParent, index(first), secondParent, index(second)))`.

- **IndexOfReference promotion (patches/0002):** Made `DomNodeCollectionExtensions` public so bridge consumers can reuse the canonical reference-equality child-index scan instead of re-implementing the loop.

- **Descendant-collection reuse (P4.18):** Four bridge helpers (`CollectDescendantsByTag`, `CollectStyleElements`, `CollectStyleElementsInTree`, `CollectWindowFrames`) now delegate to canonical `DomNode.Descendants().OfType<DomElement>()`, gaining document-order, level-snapshot mutation-safety.

- **Canonical neutral-algorithm reuses exhausted:** With P4.19, clean reuses are complete: `IsDescendantOf`, `IsEqualNode`, `CommonAncestorWith`, `InclusiveDescendants`, `GetRootNode`, `CompareBoundaryPoints`, and `Descendants` all delegated. Remaining P4 work (`Normalize`, `CloneDomElement` divergence handling) is genuinely blocked on architecture (MutationObserver subscription, side-effect coupling).

## Implementation Details

- Cloning does not mutate the live document, so unlike `Normalize` there is no MutationObserver/NodeIterator/live-range side-effect coupling — this half was tractable.
- Canonical `CloneNode` preserves source owner document and attribute keys verbatim (spec-correct); the old path minted from main `_document` and lowercased no-namespace names.
- Runtime-state copy is now co-located with field declarations in each `*RuntimeState` class via per-class `CopyTo(target)` methods, reducing the risk of silent omission when fields are added.
- Baked overlay uses `ConditionalWeakTable` for GC-scoped per-element storage; tombstone `null` values remove authored/prior properties from the merged view.

## Roadmap Status

Phase 4 item

https://claude.ai/code/session_01UAaA8FwNY8k5Fhx7bM4sKz