### PR TITLE
Phase 7 item 2 & 6: parser-backed discovery + module map

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -663,6 +663,9 @@ internal abstract partial class CssBoxProperties
     public string Content { get; set; } = "normal";
     public string Display { get; set; } = "inline";
     public string Direction { get; set; } = "ltr";
+    // CSS Basic UI 'appearance'. Defaults to "auto" so a UA-styled control (e.g. a list box) keeps its
+    // native rendering unless the author opts out with 'appearance: none'.
+    public string Appearance { get; set; } = "auto";
     public string EmptyCells { get; set; } = "show";
     public string CaptionSide { get; set; } = "top";
     public string Float { get; set; } = "none";

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -88,6 +88,8 @@ internal static partial class CssUtils
             "color" => cssBox.Color,
             "display" => cssBox.Display,
             "direction" => cssBox.Direction,
+            "appearance" => cssBox.Appearance,
+            "-webkit-appearance" => cssBox.Appearance,
             "empty-cells" => cssBox.EmptyCells,
             "caption-side" => cssBox.CaptionSide,
             "float" => cssBox.Float,
@@ -574,6 +576,10 @@ internal static partial class CssUtils
                 break;
             case "direction":
                 cssBox.Direction = value;
+                break;
+            case "appearance":
+            case "-webkit-appearance":
+                cssBox.Appearance = value;
                 break;
             case "empty-cells":
                 cssBox.EmptyCells = value;

--- a/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
@@ -182,20 +182,31 @@ Exit criteria:
   `(56,117,215)`, alternating rows `(247,247,247)`, chrome `(220,220,220)`). Push **403** → ships as
   `patches/0007-…patch`, pointer **unbumped**, working tree reverted. **Scope limitation:** the
   `appearance:none` variant needs a CSS `appearance` box property (a separate `Broiler.Layout` change), so the
-  fallback must stay for `appearance:none` selects until that lands. This is the last replaced-element native
-  pass — all of video/progress/meter/select now have native rendering (patches `0005`–`0007`), the iframe pass
-  is already upstream (`0004`).
+  fallback stays for `appearance:none` only until the box `appearance` property lands (P6.9, below, now done).
+  This is the last replaced-element native pass — all of video/progress/meter/select now have native rendering
+  (patches `0005`–`0007`), the iframe pass is already upstream (`0004`).
+
+- **P6.9 (2026-07-20) — `appearance` box property + `<select multiple appearance:none>` completed.** Added a
+  CSS `appearance` box property to **`Broiler.Layout`** (`CssBox.Appearance`, default `auto`, wired through
+  `CssUtils` get/set dispatch for `appearance`/`-webkit-appearance`; the `SharedRendererCascade` populates it
+  like any other longhand). `Broiler.Layout` is a **directory in this repo, not a submodule**, so this is a
+  direct main-repo change (no patch) — additive, `Broiler.Layout` builds and the CSS/render sanity suites stay
+  green. Patch `0007` was then extended to branch `CorrectSelectMultipleBoxes` on the box's `Appearance`:
+  `appearance:none` drops the scrollbar chrome, uses a white field and a lighter `#9a9a9a` border, matching the
+  fallback's non-native variant. **Verified via render probes**: `appearance:auto` keeps the chrome strip
+  (528 px) and grey field; `appearance:none` drops the chrome entirely (0 px) and uses white. Patch `0007`
+  regenerated to include this; `<select multiple>` native rendering now covers both appearance modes.
 
 - **Remaining for Phase 6 — Concern 2 native migration + project deletion.** With native rendering written for
-  every replaced element, the residue is: (a) **pointer bumps** for `patches/0005`–`0007` (submodule-push
-  authorization — out of session scope) so `ReplaceVideo`/`ReplaceProgressLike`/`ReplaceSelectMultiple` (and
-  the now-redundant `StripIframeContent`, `0004` already applied) can drop from `HtmlPostProcessor`; (b) a
-  small `Broiler.Layout` `appearance` box property so `<select multiple appearance:none>` also goes native;
-  (c) the protective `StripScriptTags` and the test-harness-only shims (`StripHiddenTestArtifacts`,
-  `StripObjectContent`, `RewriteRootSelector`) relocated to test support once the reftest gate can validate;
-  then the emptied `Broiler.HtmlBridge.Rendering` project is deleted. Per the disposition, `HtmlPostProcessor`
-  must **not** be moved wholesale to rename it; the migration is behavioural. The native-rendering *authoring*
-  is done; the remaining steps are push-authorization and test-harness relocation, not new rendering code.
+  every replaced element **and both `<select>` appearance modes**, the residue is: (a) **pointer bumps** for
+  `patches/0005`–`0007` (submodule-push authorization — out of session scope) so
+  `ReplaceVideo`/`ReplaceProgressLike`/`ReplaceSelectMultiple` (and the now-redundant `StripIframeContent`,
+  `0004` already applied) can drop from `HtmlPostProcessor`; (b) the protective `StripScriptTags` and the
+  test-harness-only shims (`StripHiddenTestArtifacts`, `StripObjectContent`, `RewriteRootSelector`) relocated
+  to test support once the reftest gate can validate; then the emptied `Broiler.HtmlBridge.Rendering` project
+  is deleted. Per the disposition, `HtmlPostProcessor` must **not** be moved wholesale to rename it; the
+  migration is behavioural. **All native-rendering authoring is done**; the remaining steps are
+  push-authorization and test-harness relocation, not new rendering code.
 
 ### Phase 7 - isolate loading, security and browsing-context policy
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
@@ -254,16 +254,36 @@ Exit criteria:
   frames" — script + CSP now share it; CSS/fetch/frames (the Dom `ResourceLoader`) adopt it when the
   cross-assembly loader seam lands.
 
+- **P7.7 (2026-07-20) — item 4 (partial): frames adopt the shared `UrlResolver`.** The nested-browsing-context
+  fetch path (`DomBridge/SubDocuments.cs`) carried its **own** copy of the "absolute stays / relative resolves
+  against base / else empty" resolution in two places — `ResolveSubResourceUrl` (the `ISubWindowHost` seam used
+  by `SubWindowBinding` to resolve an iframe/frame `src`) and the relative branch of `TryFetchSubResource`
+  (object/iframe sub-resource fetch). Both now delegate to the single `Broiler.HtmlBridge.Scripting.UrlResolver`
+  (already shared by script + CSP, P7.6) — `ResolveSubResourceUrl` collapses to
+  `UrlResolver.Resolve(url, baseUrl)?.AbsoluteUri ?? string.Empty` (byte-identical: the old code returned
+  `AbsoluteUri` for both the absolute and resolved cases), and `TryFetchSubResource` routes its *relative* case
+  through the resolver while deliberately keeping the **raw string** for an already-absolute URL so the
+  downstream `file://` / `http(s)` scheme checks and the WPT `web-platform.test` host mapping still see the
+  original prefix (changing it to a normalised `AbsoluteUri` there could shift casing/normalisation). Frames
+  now share the same URL resolution as script and CSP — three of the five consumers named in the exit criterion
+  ("one URL resolution/origin implementation shared by script, CSS, fetch, XHR and frames"). Behaviour-preserving
+  (`UrlResolver` is `internal` in Core, visible to Dom via `InternalsVisibleTo`, so no public-API change); the
+  43 `SubResourceFetching`/`SubWindowBinding`/`SubDocumentBinding`/`IframeElementBinding` sub-resource tests
+  pass unchanged and the CSP/resolver/descriptor guard suites (44) stay green (the 3 `HttpSubResource`
+  relative-iframe failures are pre-existing network-env failures — identical on the `e03b140` baseline).
+
 - **Remaining for Phase 7.** Still open: item 2 (replace the `CspMetaDiscovery` /
   `ScriptExtractionService` **regex** HTML discovery with `Broiler.Dom.Html` parser output — now localised
   behind `FindPolicyContent` and `ExtractAll`; has a cross-assembly wrinkle since discovery lives in Core
-  and the DOM parser is a submodule component); item 4 (rest) — route the richer
-  `SubDocuments.TryFetchSubResource` data/file/http+MIME/WPT switch through the loader (extend `LoadText`
-  with a bytes/MIME variant) and have the Dom `ResourceLoader` adopt the shared `UrlResolver`; items 5–6
-  (host-layer CSP enforcement so DOM/CSS receive already-authorised content; execute `IsModule` descriptors
-  in the event loop instead of skipping them — a substantial module-loading feature). Items 5–6 and the
-  `SubDocuments`/parser pieces are larger or WPT-reftest-sensitive; the CSP split (item 1), script
-  descriptors (item 3), and the loader/resolver consolidation (item 4 partial) are done.
+  and the DOM parser is a submodule component); item 4 (rest) — route the residual `file://` reads in
+  `SubDocuments.TryFetchSubResource` / `TryReadFileResource` / `TryReadLocalResource` through the loader
+  (extend `LoadText` with a bytes/MIME variant carrying the binary-null-content + extension-MIME policy); the
+  Dom URL *resolution* now shares `UrlResolver` (P7.7). Items 5–6 (host-layer CSP enforcement so DOM/CSS
+  receive already-authorised content; execute `IsModule` descriptors in the event loop instead of skipping
+  them — a substantial module-loading feature). Items 5–6 and the `SubDocuments`/parser pieces are larger or
+  WPT-reftest-sensitive; the CSP split (item 1), script descriptors (item 3), and the loader/resolver
+  consolidation (item 4 partial — file/http dispatch P7.3–P7.4, one shared resolver P7.6 across script/CSP and
+  P7.7 across frames) are done.
 
 ### Phase 8 - simplify Core and Scripting, then reconsider assemblies
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
@@ -142,17 +142,35 @@ Exit criteria:
   refreshed the stale "intentionally NOT applied" notes. Pure dead-code deletion — builds green;
   `Acid3RegressionTests` + guards/profile/native suites green (no public-API change: all internal).
 
+- **P6.6 (2026-07-20) — Concern 2, native-behaviour migration: `<video>` replaced-element handling
+  (submodule patch `0005`, pending).** Native replacement for `HtmlPostProcessor.ReplaceVideoWithPlaceholder`
+  (which string-rewrites `<video>…</video>` into a black `<div>` at its width/height or 300×150). Added a
+  post-cascade `CorrectVideoBoxes` pass in `Broiler.HTML` (`DomParser`) — mirroring `CorrectIframeBoxes` — that
+  makes a `<video>` box `inline-block`, sizes it (author CSS size wins; else the `width`/`height` presentation
+  attributes; else the CSS-default intrinsic 300×150), paints it black, and hides the fallback children.
+  **Verified via the parent build + a render probe on raw `<video>`** (`HtmlRender.RenderToImageWithStyleSet`,
+  bypassing the string fallback): a bare `<video>` paints black inside the 300×150 box, and inline fallback
+  content is hidden (black, not green, over the fallback area). The `Broiler.HTML` push returned **403**, so
+  per `CLAUDE.md` it ships as `patches/0005-html-video-replaced-element-black-box.patch` with the pointer
+  **unbumped** and the working tree reverted; `HtmlPostProcessor.ReplaceVideoWithPlaceholder` stays the active
+  fallback (it runs in the string pipeline before the renderer, so a real `<video>` never reaches
+  `CorrectVideoBoxes` yet) until the patch lands and the pointer is bumped (then it is dropped). Also observed
+  while reverting: patch **`0004` is now applied upstream** — the pinned `Broiler.HTML` `52f65d9` contains
+  `CorrectIframeBoxes` — so `StripIframeContent` is now a redundant (harmless) belt-and-suspenders strip whose
+  removal is unblocked; `patches/README.md` corrected accordingly.
+
 - **Remaining for Phase 6 — Concern 2 native migration + project deletion.** The live transforms still in
   `HtmlPostProcessor` are: the production/harness replaced-element passes (`StripScriptTags` [protective],
-  `StripIframeContent` [pending `patches/0004`], `ReplaceVideo`/`ReplaceProgressLike`/`ReplaceSelectMultiple`
-  [legitimate fallbacks]) and the test-harness-only `StripHiddenTestArtifacts` (map/linktest/FAIL/red-bg
-  Acid scaffolding), `StripObjectContent`, and `RewriteRootSelector` (proven redundant, kept for the
-  harness pending reftest validation). Fully emptying the file to delete the Rendering project needs: (a)
-  `patches/0004` applied (drops `StripIframeContent`); (b) native replaced-element rendering for
-  video/progress/meter/select so those fallbacks retire (largely `Broiler.HTML`, **submodule-push-gated →
-  patch workflow**); and (c) relocating the residual Acid scaffolding shims to test support once the
-  reftest gate can validate. Per the disposition, `HtmlPostProcessor` must **not** be moved wholesale to
-  rename it; the migration is behavioural.
+  `StripIframeContent` [now redundant — `patches/0004` applied at `52f65d9`; removal unblocked],
+  `ReplaceVideo` [native `patches/0005` pending], `ReplaceProgressLike`/`ReplaceSelectMultiple` [legitimate
+  fallbacks]) and the test-harness-only `StripHiddenTestArtifacts` (map/linktest/FAIL/red-bg Acid scaffolding),
+  `StripObjectContent`, and `RewriteRootSelector` (proven redundant, kept for the harness pending reftest
+  validation). Fully emptying the file to delete the Rendering project needs: (a) the applied iframe/video
+  patches' pointer bumps so `StripIframeContent`/`ReplaceVideo` drop; (b) native replaced-element rendering
+  for progress/meter/select so those fallbacks retire (largely `Broiler.HTML`, **submodule-push-gated → patch
+  workflow**); and (c) relocating the residual Acid scaffolding shims to test support once the reftest gate can
+  validate. Per the disposition, `HtmlPostProcessor` must **not** be moved wholesale to rename it; the
+  migration is behavioural.
 
 ### Phase 7 - isolate loading, security and browsing-context policy
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
@@ -159,18 +159,31 @@ Exit criteria:
   `CorrectIframeBoxes` — so `StripIframeContent` is now a redundant (harmless) belt-and-suspenders strip whose
   removal is unblocked; `patches/README.md` corrected accordingly.
 
+- **P6.7 (2026-07-20) — Concern 2, native-behaviour migration: `<progress>`/`<meter>` replaced-element
+  handling (submodule patch `0006`, pending).** Native replacement for
+  `HtmlPostProcessor.ReplaceProgressLikeWithPlaceholder` (which string-rewrites the elements into a styled
+  `<div>` track + fill). Added a post-cascade `CorrectProgressBoxes` pass in `Broiler.HTML` (`DomParser`) that
+  renders each as a bordered `inline-block` track (1px `#767676`, bg `#f0f0f0`/`#e6e6e6`, `120×16` or `16×120`
+  vertical) with an absolutely-positioned fill bar proportional to `value` (`#0a84ff`/`#4caf50`), honouring
+  `writing-mode`/`direction` for vertical and RTL bars, hiding the fallback text — matching the fallback's
+  exact colours/sizes. **Verified via the parent build + a render probe on raw `<progress>`/`<meter>`**: the
+  fill paints blue/green over the left ratio·120 px and the remainder is track grey. Push **403** → ships as
+  `patches/0006-…patch`, pointer **unbumped**, working tree reverted; `ReplaceProgressLike` stays the active
+  fallback (string pipeline, pre-renderer) until the patch lands and the pointer is bumped. `select multiple`
+  is the one remaining replaced-element fallback.
+
 - **Remaining for Phase 6 — Concern 2 native migration + project deletion.** The live transforms still in
   `HtmlPostProcessor` are: the production/harness replaced-element passes (`StripScriptTags` [protective],
   `StripIframeContent` [now redundant — `patches/0004` applied at `52f65d9`; removal unblocked],
-  `ReplaceVideo` [native `patches/0005` pending], `ReplaceProgressLike`/`ReplaceSelectMultiple` [legitimate
-  fallbacks]) and the test-harness-only `StripHiddenTestArtifacts` (map/linktest/FAIL/red-bg Acid scaffolding),
-  `StripObjectContent`, and `RewriteRootSelector` (proven redundant, kept for the harness pending reftest
-  validation). Fully emptying the file to delete the Rendering project needs: (a) the applied iframe/video
-  patches' pointer bumps so `StripIframeContent`/`ReplaceVideo` drop; (b) native replaced-element rendering
-  for progress/meter/select so those fallbacks retire (largely `Broiler.HTML`, **submodule-push-gated → patch
-  workflow**); and (c) relocating the residual Acid scaffolding shims to test support once the reftest gate can
-  validate. Per the disposition, `HtmlPostProcessor` must **not** be moved wholesale to rename it; the
-  migration is behavioural.
+  `ReplaceVideo` [native `patches/0005` pending], `ReplaceProgressLike` [native `patches/0006` pending],
+  `ReplaceSelectMultiple` [legitimate fallback — native rendering not yet written]) and the test-harness-only
+  `StripHiddenTestArtifacts` (map/linktest/FAIL/red-bg Acid scaffolding), `StripObjectContent`, and
+  `RewriteRootSelector` (proven redundant, kept for the harness pending reftest validation). Fully emptying the
+  file to delete the Rendering project needs: (a) the applied/pending replaced-element patches' pointer bumps
+  so `StripIframeContent`/`ReplaceVideo`/`ReplaceProgressLike` drop; (b) native `<select multiple>` rendering
+  so its fallback retires (largely `Broiler.HTML`, **submodule-push-gated → patch workflow**); and (c)
+  relocating the residual Acid scaffolding shims to test support once the reftest gate can validate. Per the
+  disposition, `HtmlPostProcessor` must **not** be moved wholesale to rename it; the migration is behavioural.
 
 ### Phase 7 - isolate loading, security and browsing-context policy
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
@@ -324,10 +324,25 @@ Exit criteria:
   nonce path still parses a raw attribute string). `ScriptExtractionService` discovery (the other half of
   item 2) is still regex — larger and WPT-sensitive, tracked below.
 
-- **Remaining for Phase 7.** Still open: item 2 (rest) — replace the `ScriptExtractionService` **regex**
-  `<script>` discovery with `Broiler.Dom.Html` parser output (localised behind `ExtractAll`; larger and
-  WPT-reftest-sensitive because script text extraction, ordering, module handling and trimming must stay
-  byte-identical — the CSP-meta half is done in P7.10); items 5–6 (host-layer CSP enforcement so DOM/CSS receive
+- **P7.11 (2026-07-20) — item 2 complete: `<script>` discovery is parser-backed.** Replaced the eight
+  `<script>`/attribute regexes in `ScriptExtractionService` with the shared `Broiler.Dom.Html` tokenizer. A
+  single `EnumerateScriptTags(html)` walks the token stream and pairs each `<script>` start tag with its raw
+  body (the tokenizer treats `<script>` as a raw-text element, so the body is taken verbatim and never
+  entity-decoded — byte-identical to the former `[\s\S]*?` capture + `.Trim()`); the flag/`src`/`nonce`
+  reads (`type=module`, `defer`, `async`, `src` data-vs-external, `nonce`) come from the parsed lower-cased
+  attribute map instead of per-tag regexes. `Extract`, `ExtractAll` and the `ScriptDescriptor` pipeline keep
+  identical shape — document order, CSP inline/external gating, data-URI decode and defer/async/regular
+  bucketing are unchanged. Parser-backed discovery also fixes the same class of regex defects as P7.10 (a
+  `<script>` literal inside a comment/another element's text is not mis-discovered; a `>` inside a quoted
+  attribute no longer truncates the start tag; an unterminated final `<script>` yields its body to EOF per
+  parser behaviour). Only `WhitespacePattern` (used by `DecodeDataUri`'s base64 fold-strip) remains a regex.
+  Validated with zero regressions across the extraction-exercising suites — `ScriptDescriptorTests` (4),
+  `ContentSecurityPolicyTests` (19), `CspMetaDiscoveryTests` (11) and `ScriptEngineExecuteTests` (53 pass;
+  the 4 failures are pre-existing geometry/serialization env failures, identical on the P7.10 baseline). Item
+  2 is now done for both discovery sites (CSP-meta P7.10, scripts P7.11); full WPT-reftest confirmation
+  remains the standing gate for the render-path scripts as for prior increments.
+
+- **Remaining for Phase 7.** Still open: items 5–6 (host-layer CSP enforcement so DOM/CSS receive
   already-authorised content; execute `IsModule` descriptors in the event loop instead of skipping them — a
   substantial module-loading feature). Items 5–6 and the parser piece are larger or WPT-reftest-sensitive.
   Item 1 (CSP split), item 3 (script descriptors) and item 4 (loader/resolver consolidation) are **done**:

--- a/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
@@ -308,10 +308,26 @@ Exit criteria:
   origin matching), which is a separate consolidation with different per-site semantics (e.g. `file://`
   handling) and is deliberately left for a scoped origin-unification step.
 
-- **Remaining for Phase 7.** Still open: item 2 (replace the `CspMetaDiscovery` /
-  `ScriptExtractionService` **regex** HTML discovery with `Broiler.Dom.Html` parser output — now localised
-  behind `FindPolicyContent` and `ExtractAll`; has a cross-assembly wrinkle since discovery lives in Core
-  and the DOM parser is a submodule component); items 5–6 (host-layer CSP enforcement so DOM/CSS receive
+- **P7.10 (2026-07-20) — item 2 (partial): CSP `<meta>` discovery is parser-backed.** `CspMetaDiscovery`
+  scanned the serialized HTML with a `<meta[^>]*>` regex + a quoted/unquoted attribute regex. Replaced it
+  with `Broiler.Dom.Html`'s shared `HtmlTokenizer`: `FindPolicyContent` now enumerates real start tokens and
+  reads the lower-cased `Attributes` map. This resolves the "cross-assembly wrinkle" by adding a `Broiler.HtmlBridge.Core`
+  → `Broiler.Dom.Html` project reference (no cycle — `Broiler.Dom.Html` only references `Broiler.Dom`, which
+  Core already used; the boundary-guard suite confirms the bridge→canonical direction is allowed). The
+  tokenizer stores attribute values **raw** (no entity decode — line-for-line what the regex returned), so
+  discovery of a normal `content="…"` is byte-identical, while three former regex defects are fixed: a
+  `<meta>` inside an HTML **comment** or a `<script>`/`<style>` **raw-text body** is no longer discovered, and
+  a `>` inside a quoted `content` value no longer truncates the directive. New `CspMetaDiscoveryTests` (3) pin
+  those three behaviours; the existing 8 discovery tests + 37 CSP/policy/public-API-snapshot tests stay green
+  (`CspMetaDiscovery` is still `public static` — dropping `partial` is not a public-surface change, so no
+  baseline regen). The regex + `GeneratedRegex` are gone from the class; `HtmlAttributeReader` stays (the
+  nonce path still parses a raw attribute string). `ScriptExtractionService` discovery (the other half of
+  item 2) is still regex — larger and WPT-sensitive, tracked below.
+
+- **Remaining for Phase 7.** Still open: item 2 (rest) — replace the `ScriptExtractionService` **regex**
+  `<script>` discovery with `Broiler.Dom.Html` parser output (localised behind `ExtractAll`; larger and
+  WPT-reftest-sensitive because script text extraction, ordering, module handling and trimming must stay
+  byte-identical — the CSP-meta half is done in P7.10); items 5–6 (host-layer CSP enforcement so DOM/CSS receive
   already-authorised content; execute `IsModule` descriptors in the event loop instead of skipping them — a
   substantial module-loading feature). Items 5–6 and the parser piece are larger or WPT-reftest-sensitive.
   Item 1 (CSP split), item 3 (script descriptors) and item 4 (loader/resolver consolidation) are **done**:

--- a/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
@@ -342,9 +342,40 @@ Exit criteria:
   2 is now done for both discovery sites (CSP-meta P7.10, scripts P7.11); full WPT-reftest confirmation
   remains the standing gate for the render-path scripts as for prior increments.
 
-- **Remaining for Phase 7.** Still open: items 5–6 (host-layer CSP enforcement so DOM/CSS receive
-  already-authorised content; execute `IsModule` descriptors in the event loop instead of skipping them — a
-  substantial module-loading feature). Items 5–6 and the parser piece are larger or WPT-reftest-sensitive.
+- **P7.12 (2026-07-20) — item 6 (first slice): module map + inline-module execution.** Recognised
+  `<script type="module">` scripts were *silently dropped* by the `ExtractAll` pipeline (recorded in a
+  descriptor but absent from every execution bucket). First slice, three parts:
+  - **Module map.** New `ModuleMap` / `ModuleMapEntry` (Core): the ordered registry of every recognised
+    module in a document. `ExtractAll` records each one — inline modules keyed `inline:{order}` carrying
+    their authorised body, module scripts with a `src` keyed by URL and marked non-executable (fetch + import
+    graph is a later slice). So a module is no longer silently skipped — it is at minimum *mapped*.
+  - **Inline-module execution.** An authorised inline module body (passes the same CSP inline check as a
+    classic inline script) is exposed, in document order, in the new `ScriptExtractionResult.ModuleScripts`,
+    each wrapped by `ModuleScriptWrapper.WrapInlineModule` into a strict self-invoking function. That
+    reproduces the module top-level semantics that matter for an import-free module: strict mode, top-level
+    declarations kept out of the global object, and top-level `this === undefined` (unit-verified against a
+    live `JSContext`). `import`/`export`/`import.meta`/top-level-`await` are **not** supported — such a module
+    surfaces a syntax/runtime error at execution (caught + logged) instead of being dropped.
+  - **Wiring.** Module scripts are deferred, so the two `ExtractAll` consumers run them after the classic
+    deferred scripts: `RenderingPipeline` appends `ModuleScripts` to the deferred bucket, and the sub-document
+    executor (`DomBridge.ExecuteSubDocumentScripts`) runs them last. The CLI capture path
+    (`CaptureService.ExecuteScriptsWithDom`) has its own regex extraction and already ran modules as classic
+    inline scripts — left untouched, so Acid/CSS captures are unaffected.
+
+  New `ModuleScriptSliceTests` (8) pin the map/bucket population (inline executable + wrapped, external
+  mapped-not-executable, CSP-blocked mapped-not-executable, empty map) and the wrapper's module semantics;
+  the classic buckets and `ScriptDescriptor`s are unchanged (`ScriptDescriptorTests` green). Additive
+  public-surface change — Core API baseline regenerated (adds `ModuleMap`/`ModuleMapEntry`/`ModuleScriptWrapper`
+  and the two result properties; the old ctor stays source-compatible via optional params). Regression sweep
+  over the touched paths (`ScriptEngineExecute`/`SubDocument`/`SubWindow`/`ContentSecurityPolicy`/`SubResource`,
+  96 pass) shows only the 4 pre-existing geometry/serialization env failures, identical on baseline.
+
+- **Remaining for Phase 7.** Still open: item 5 (host-layer CSP enforcement so DOM/CSS receive
+  already-authorised content); item 6 (rest) — the substantial part of module loading beyond the P7.12 first
+  slice: **external/data-URI module fetching**, the **import/export module graph** (resolution, dedup via the
+  module map, cyclic handling), `import.meta`/top-level-`await`, and moving module ordering into the real
+  browser **event loop** (rather than the deferred-bucket approximation). These and item 5 are larger or
+  WPT-reftest-sensitive.
   Item 1 (CSP split), item 3 (script descriptors) and item 4 (loader/resolver consolidation) are **done**:
   the file/http text dispatch (P7.3–P7.4), one shared URL resolver across all five named consumers —
   script/CSP (P7.6), frames (P7.7) and fetch/XHR (P7.9) — and the sub-resource file/local reads (P7.8) all now

--- a/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
@@ -172,18 +172,30 @@ Exit criteria:
   fallback (string pipeline, pre-renderer) until the patch lands and the pointer is bumped. `select multiple`
   is the one remaining replaced-element fallback.
 
-- **Remaining for Phase 6 — Concern 2 native migration + project deletion.** The live transforms still in
-  `HtmlPostProcessor` are: the production/harness replaced-element passes (`StripScriptTags` [protective],
-  `StripIframeContent` [now redundant — `patches/0004` applied at `52f65d9`; removal unblocked],
-  `ReplaceVideo` [native `patches/0005` pending], `ReplaceProgressLike` [native `patches/0006` pending],
-  `ReplaceSelectMultiple` [legitimate fallback — native rendering not yet written]) and the test-harness-only
-  `StripHiddenTestArtifacts` (map/linktest/FAIL/red-bg Acid scaffolding), `StripObjectContent`, and
-  `RewriteRootSelector` (proven redundant, kept for the harness pending reftest validation). Fully emptying the
-  file to delete the Rendering project needs: (a) the applied/pending replaced-element patches' pointer bumps
-  so `StripIframeContent`/`ReplaceVideo`/`ReplaceProgressLike` drop; (b) native `<select multiple>` rendering
-  so its fallback retires (largely `Broiler.HTML`, **submodule-push-gated → patch workflow**); and (c)
-  relocating the residual Acid scaffolding shims to test support once the reftest gate can validate. Per the
-  disposition, `HtmlPostProcessor` must **not** be moved wholesale to rename it; the migration is behavioural.
+- **P6.8 (2026-07-20) — Concern 2, native-behaviour migration: `<select multiple>` replaced-element handling
+  (submodule patch `0007`, pending, stacks on `0006`).** Native replacement (native-appearance case) for
+  `HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder`. Added a post-cascade `CorrectSelectMultipleBoxes`
+  pass in `Broiler.HTML` (`DomParser`) rendering the control as an `inline-block` list box: one 16px row track
+  per visible option (`size` clamped 2..8, default 4), first row `#3875d7` selection highlight, alternating
+  `#ffffff`/`#f7f7f7` rows, edge `#dcdcdc` scrollbar chrome, writing-mode-aware, `<option>` children hidden.
+  **Verified via the parent build + render probe on raw `<select multiple>`** (72×68 host, blue first row
+  `(56,117,215)`, alternating rows `(247,247,247)`, chrome `(220,220,220)`). Push **403** → ships as
+  `patches/0007-…patch`, pointer **unbumped**, working tree reverted. **Scope limitation:** the
+  `appearance:none` variant needs a CSS `appearance` box property (a separate `Broiler.Layout` change), so the
+  fallback must stay for `appearance:none` selects until that lands. This is the last replaced-element native
+  pass — all of video/progress/meter/select now have native rendering (patches `0005`–`0007`), the iframe pass
+  is already upstream (`0004`).
+
+- **Remaining for Phase 6 — Concern 2 native migration + project deletion.** With native rendering written for
+  every replaced element, the residue is: (a) **pointer bumps** for `patches/0005`–`0007` (submodule-push
+  authorization — out of session scope) so `ReplaceVideo`/`ReplaceProgressLike`/`ReplaceSelectMultiple` (and
+  the now-redundant `StripIframeContent`, `0004` already applied) can drop from `HtmlPostProcessor`; (b) a
+  small `Broiler.Layout` `appearance` box property so `<select multiple appearance:none>` also goes native;
+  (c) the protective `StripScriptTags` and the test-harness-only shims (`StripHiddenTestArtifacts`,
+  `StripObjectContent`, `RewriteRootSelector`) relocated to test support once the reftest gate can validate;
+  then the emptied `Broiler.HtmlBridge.Rendering` project is deleted. Per the disposition, `HtmlPostProcessor`
+  must **not** be moved wholesale to rename it; the migration is behavioural. The native-rendering *authoring*
+  is done; the remaining steps are push-authorization and test-harness relocation, not new rendering code.
 
 ### Phase 7 - isolate loading, security and browsing-context policy
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
@@ -292,6 +292,22 @@ Exit criteria:
   and the HTTP `GetAsync` (already the loader) + the WPT host→local-root mapping (test policy, correctly
   bridge-owned).
 
+- **P7.9 (2026-07-20) — item 4 (partial): fetch adopts the shared `UrlResolver`.** The fetch binding's one
+  inline C# URL resolution — `FetchBinding.ResolveResponseRedirectUrl` (the `Response.redirect(url, status)`
+  static: resolve the `Location` relative to the page URL) — carried its own copy of the "absolute stays /
+  relative resolves against base" pattern, throwing the spec's `TypeError` ("Invalid URL") on failure. It now
+  delegates to `UrlResolver.Resolve(redirectUrl, _host.PageUrl)`, mapping a `null` result to that same
+  `JSException`. (XHR needs no change — it is implemented in JS on top of `fetch` and stores its URL verbatim;
+  `CreateRequestObject` likewise stores the request URL as-is, so fetch's only resolution site is the redirect
+  helper.) Behaviour-preserving — the existing `Fetch_Response_Redirect_Static_Sets_Status_And_Location_Header`
+  test (`/next` → `file:///next` against `file:///test.html`) and the invalid-status guard pass unchanged; 117
+  fetch/network tests green (the 2 `bodyUsed`-reader failures are pre-existing, identical on the P7.8 baseline).
+  With this, **all five** consumers named in the exit criterion — script, CSS, fetch, XHR and frames — resolve
+  URLs through the single `UrlResolver`. The residual duplication is the *origin* concern
+  (`Utilities.IsCrossOrigin` same-origin compare, `MessagingBinding` origin extraction, `CspSourceMatching`
+  origin matching), which is a separate consolidation with different per-site semantics (e.g. `file://`
+  handling) and is deliberately left for a scoped origin-unification step.
+
 - **Remaining for Phase 7.** Still open: item 2 (replace the `CspMetaDiscovery` /
   `ScriptExtractionService` **regex** HTML discovery with `Broiler.Dom.Html` parser output — now localised
   behind `FindPolicyContent` and `ExtractAll`; has a cross-assembly wrinkle since discovery lives in Core
@@ -299,9 +315,11 @@ Exit criteria:
   already-authorised content; execute `IsModule` descriptors in the event loop instead of skipping them — a
   substantial module-loading feature). Items 5–6 and the parser piece are larger or WPT-reftest-sensitive.
   Item 1 (CSP split), item 3 (script descriptors) and item 4 (loader/resolver consolidation) are **done**:
-  the file/http text dispatch (P7.3–P7.4), one shared URL resolver across script/CSP (P7.6) and frames (P7.7),
-  and the sub-resource file/local reads (P7.8) all now live behind the loader/`UrlResolver`, so no feature
-  callback constructs an `HttpClient` or inlines a `file`/`data`-URI/`File.*` switch for the text-load paths.
+  the file/http text dispatch (P7.3–P7.4), one shared URL resolver across all five named consumers —
+  script/CSP (P7.6), frames (P7.7) and fetch/XHR (P7.9) — and the sub-resource file/local reads (P7.8) all now
+  live behind the loader/`UrlResolver`, so no feature callback constructs an `HttpClient` or inlines a
+  `file`/`data`-URI/`File.*` switch for the text-load paths. The one remaining item-4-adjacent cleanup is
+  unifying the *origin* helpers (same-origin/origin-extraction), tracked as a separate scoped step.
 
 ### Phase 8 - simplify Core and Scripting, then reconsider assemblies
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
@@ -272,18 +272,36 @@ Exit criteria:
   pass unchanged and the CSP/resolver/descriptor guard suites (44) stay green (the 3 `HttpSubResource`
   relative-iframe failures are pre-existing network-env failures — identical on the `e03b140` baseline).
 
+- **P7.8 (2026-07-20) — item 4 (partial): sub-resource `file://`/local reads move into the loader.** The
+  nested-browsing-context fetch path inlined `File.Exists`/`File.ReadAllText` in two feature callbacks —
+  `TryReadFileResource` (a resolved `file://` URL) and `TryReadLocalResource` (the `LocalBasePath` directory)
+  — each with its own copy of the binary-content-type predicate (`image/`/`font/`/`audio/`/`video/`/`pdf` →
+  return the MIME but not the decoded bytes). Exactly the "direct file switch in a feature callback" the exit
+  criterion forbids. Added `ResourceLoader.LoadLocalResource(path, extensionMime)` — the one place that owns
+  the file existence + binary/text read policy: missing → `(null, "")` (empty document, not a fetch failure),
+  binary MIME → `(null, extensionMime)` (bytes not decoded), else → `(File.ReadAllText, extensionMime)` with
+  I/O exceptions propagating — plus a shared `ResourceLoader.IsBinaryMime` so the binary-content rule lives
+  once. `TryReadFileResource` collapses to mapping the URL to a path + delegating (and is no longer `static`,
+  so it reaches the loader); `TryReadLocalResource` keeps only its query/fragment strip, scheme reject, and
+  the generic-MIME content sniff (`DetectContentTypeFromContent`, bridge-owned), delegating the read. New
+  `ResourceLoaderTests` cases (2) pin `LoadLocalResource` (text read / binary skip / missing) and
+  `IsBinaryMime` (9 content types) deterministically. Behaviour-preserving: the 55 sub-resource / sub-window
+  binding tests pass unchanged (the same 3 `HttpSubResource` relative-iframe/WPT-root failures are
+  pre-existing network-env failures, identical on the P7.7 baseline). `ResourceLoader` remains `internal` to
+  Dom → no public-API change. The residual sub-resource dispatch still in the callback is the `data:` decode
+  and the HTTP `GetAsync` (already the loader) + the WPT host→local-root mapping (test policy, correctly
+  bridge-owned).
+
 - **Remaining for Phase 7.** Still open: item 2 (replace the `CspMetaDiscovery` /
   `ScriptExtractionService` **regex** HTML discovery with `Broiler.Dom.Html` parser output — now localised
   behind `FindPolicyContent` and `ExtractAll`; has a cross-assembly wrinkle since discovery lives in Core
-  and the DOM parser is a submodule component); item 4 (rest) — route the residual `file://` reads in
-  `SubDocuments.TryFetchSubResource` / `TryReadFileResource` / `TryReadLocalResource` through the loader
-  (extend `LoadText` with a bytes/MIME variant carrying the binary-null-content + extension-MIME policy); the
-  Dom URL *resolution* now shares `UrlResolver` (P7.7). Items 5–6 (host-layer CSP enforcement so DOM/CSS
-  receive already-authorised content; execute `IsModule` descriptors in the event loop instead of skipping
-  them — a substantial module-loading feature). Items 5–6 and the `SubDocuments`/parser pieces are larger or
-  WPT-reftest-sensitive; the CSP split (item 1), script descriptors (item 3), and the loader/resolver
-  consolidation (item 4 partial — file/http dispatch P7.3–P7.4, one shared resolver P7.6 across script/CSP and
-  P7.7 across frames) are done.
+  and the DOM parser is a submodule component); items 5–6 (host-layer CSP enforcement so DOM/CSS receive
+  already-authorised content; execute `IsModule` descriptors in the event loop instead of skipping them — a
+  substantial module-loading feature). Items 5–6 and the parser piece are larger or WPT-reftest-sensitive.
+  Item 1 (CSP split), item 3 (script descriptors) and item 4 (loader/resolver consolidation) are **done**:
+  the file/http text dispatch (P7.3–P7.4), one shared URL resolver across script/CSP (P7.6) and frames (P7.7),
+  and the sub-resource file/local reads (P7.8) all now live behind the loader/`UrlResolver`, so no feature
+  callback constructs an `HttpClient` or inlines a `file`/`data`-URI/`File.*` switch for the text-load paths.
 
 ### Phase 8 - simplify Core and Scripting, then reconsider assemblies
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
@@ -387,8 +387,27 @@ Exit criteria:
   classic external scripts (unreachable in the sandbox → non-executable there); the file/data paths are
   deterministic.
 
-- **Remaining for Phase 7.** Still open: item 5 (host-layer CSP enforcement so DOM/CSS receive
-  already-authorised content); item 6 (rest) — the deepest part of module loading beyond P7.12/P7.13: the
+- **P7.14 (2026-07-20) — item 5: CSP style enforcement centralised into the bridge (host) layer.** Audit
+  first: the canonical `Broiler.Dom` / `Broiler.CSS` / `Broiler.CSS.Dom` engines are **CSP-free** (no
+  reference to `ContentSecurityPolicy` or any `Allows*` check), so CSP already lived entirely in the
+  bridge/host layer — item 5's core rule held. The gap was *uniformity*: `DomBridge.ApplyStyleContentSecurityPolicy`
+  (which strips `style-src`-blocked inline `style=` attributes and `<style>` elements from the parsed DOM)
+  was called **by hand** only by the CLI capture host and the WPT runner. The main `ScriptEngine.Execute*`
+  path set `bridge.Csp` (so inline *event handlers* were gated) but never called it, so it handed scripts and
+  rendering a DOM that still contained CSP-blocked styles. Fixed by moving the enforcement **into
+  `DomBridge.Attach`** (both overloads): when a policy is configured via `bridge.Csp`, attach applies the
+  `style-src` family as its final step, so **every** host path receives already-authorised content — not just
+  the CLI/WPT hosts. Idempotent, so the now-redundant explicit call in `CaptureService` was removed (attach
+  does it); the WPT runner keeps its explicit call because it authorises with a fresh `FromHtml(html)` without
+  setting `bridge.Csp`. New `ContentSecurityPolicyTests` (2) exercise the bridge directly — attach with a
+  `style-src 'none'` policy strips a blocked `style=`; attach with no policy leaves it. The style-src family
+  suite (`StyleSrcAttr_None`/`StyleSrcElem_None`, now relying on attach-level enforcement) plus the CSP /
+  network / Acid3-CSS suites stay green (185 pass; the 3 failures are the pre-existing pixel + two `bodyUsed`
+  env failures, identical on baseline). Remaining item-5 nuance: external-stylesheet (`<link rel=stylesheet>`)
+  CSP and giving the WPT runner the same `bridge.Csp`-driven path are follow-ups, but DOM/CSS never seeing CSP
+  and every execution path delivering authorised inline-style content is done.
+
+- **Remaining for Phase 7.** Still open: item 6 (rest) — the deepest part of module loading beyond P7.12/P7.13: the
   **import/export module graph** (specifier resolution, linking, dedup of *dependencies* via the module map,
   cyclic handling), `import.meta`/top-level-`await`, and moving module ordering into the real browser **event
   loop** (rather than the current deferred-bucket approximation). Fetching + inline/data/file execution +

--- a/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
@@ -370,12 +370,30 @@ Exit criteria:
   over the touched paths (`ScriptEngineExecute`/`SubDocument`/`SubWindow`/`ContentSecurityPolicy`/`SubResource`,
   96 pass) shows only the 4 pre-existing geometry/serialization env failures, identical on baseline.
 
+- **P7.13 (2026-07-20) — item 6 (second slice): external/data-URI module fetching + module-map dedup.**
+  Extended the P7.12 module handling so a module with a `src` is resolved through the **same authorised path
+  as a classic script**: a new `ResolveModuleSource` centralises the three cases — an inline body passes the
+  CSP inline check; a `data:` source passes the CSP external check then is `DecodeDataUri`-decoded; an
+  external source passes the CSP external check then is `FetchExternalScript`-fetched (file/http via the
+  shared `UrlResolver` + loader, exactly as classic external scripts). A resolved module source becomes an
+  executable wrapped entry in `ModuleScripts` and an `IsExecutable` map entry. Added **module-map dedup**: a
+  repeated module URL is fetched and evaluated once (`ModuleMap.TryGet` guards re-fetch/re-queue), matching
+  the browser module map's single-evaluation rule — while both occurrences still appear in the per-element
+  descriptor list. New `ModuleScriptSliceTests` cases (4) pin the data-URI decode, the file-module fetch, the
+  unresolvable-URL non-executable case, and the dedup (one `ModuleScripts` entry / one map entry for a
+  repeated URL, two module descriptors). No public-surface change (a private helper + logic only — API
+  snapshot unchanged); the extraction/CSP/descriptor/execution suites (33 + 57) stay green with only the 4
+  pre-existing geometry/serialization env failures. External *http* modules still hit the network like
+  classic external scripts (unreachable in the sandbox → non-executable there); the file/data paths are
+  deterministic.
+
 - **Remaining for Phase 7.** Still open: item 5 (host-layer CSP enforcement so DOM/CSS receive
-  already-authorised content); item 6 (rest) — the substantial part of module loading beyond the P7.12 first
-  slice: **external/data-URI module fetching**, the **import/export module graph** (resolution, dedup via the
-  module map, cyclic handling), `import.meta`/top-level-`await`, and moving module ordering into the real
-  browser **event loop** (rather than the deferred-bucket approximation). These and item 5 are larger or
-  WPT-reftest-sensitive.
+  already-authorised content); item 6 (rest) — the deepest part of module loading beyond P7.12/P7.13: the
+  **import/export module graph** (specifier resolution, linking, dedup of *dependencies* via the module map,
+  cyclic handling), `import.meta`/top-level-`await`, and moving module ordering into the real browser **event
+  loop** (rather than the current deferred-bucket approximation). Fetching + inline/data/file execution +
+  URL dedup are done (P7.12–P7.13); the graph/linker and event-loop integration are the substantial
+  remainder. These and item 5 are larger or WPT-reftest-sensitive.
   Item 1 (CSP split), item 3 (script descriptors) and item 4 (loader/resolver consolidation) are **done**:
   the file/http text dispatch (P7.3–P7.4), one shared URL resolver across all five named consumers —
   script/CSP (P7.6), frames (P7.7) and fetch/XHR (P7.9) — and the sub-resource file/local reads (P7.8) all now

--- a/patches/0005-html-video-replaced-element-black-box.patch
+++ b/patches/0005-html-video-replaced-element-black-box.patch
@@ -1,0 +1,85 @@
+From e9386303f154ad6c1e1d4421488641efe8963ab0 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Mon, 20 Jul 2026 19:00:45 +0000
+Subject: [PATCH] Broiler.HTML: render <video> as a black inline-block replaced
+ box, hide fallback
+
+HTML 4.8.9: a <video> is a replaced element; a UA that cannot present the media
+shows the poster/first frame, never the inline fallback content between the tags.
+Broiler cannot decode video, so a post-cascade CorrectVideoBoxes pass paints the
+element as an inline-block replaced box at its used size (author CSS size, then
+the width/height presentation attributes, then the CSS-default intrinsic 300x150)
+filled black, and hides the fallback children (display:none), mirroring the
+frameset/iframe replaced-element passes. Native replacement for the bridge's
+HtmlPostProcessor.ReplaceVideoWithPlaceholder string rewrite.
+---
+ .../Parse/DomParser.cs                        | 46 +++++++++++++++++++
+ 1 file changed, 46 insertions(+)
+
+diff --git a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+index 7076f3d..5225450 100644
+--- a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
++++ b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+@@ -99,6 +99,7 @@ internal sealed class DomParser
+         CorrectObjectBoxes(root);
+         CorrectFramesetBoxes(root);
+         CorrectIframeBoxes(root);
++        CorrectVideoBoxes(root);
+ 
+         bool followingBlock = true;
+         CorrectLineBreaksBlocks(root, ref followingBlock);
+@@ -929,6 +930,51 @@ internal sealed class DomParser
+             CorrectIframeBoxes(child);
+     }
+ 
++    /// <summary>
++    /// HTML §4.8.9: a <c>&lt;video&gt;</c> is a replaced element. Broiler cannot decode video streams, so —
++    /// like a supporting UA with no poster/frame to show — it paints as an inline-block replaced box at its
++    /// used size (the CSS-default intrinsic 300×150, or an author CSS size / the <c>width</c>/<c>height</c>
++    /// presentation attributes) filled black, and its inline fallback content between the tags does not lay
++    /// out or paint. Runs post-cascade so a cascade-time hide of a block fallback child cannot be re-shown
++    /// (the same reason <see cref="CorrectIframeBoxes"/> is post-cascade). This is the native replacement for
++    /// the bridge's <c>HtmlPostProcessor.ReplaceVideoWithPlaceholder</c> string rewrite.
++    /// </summary>
++    private static void CorrectVideoBoxes(CssBox box)
++    {
++        if (box.HtmlTag != null
++            && box.HtmlTag.Name.Equals("video", StringComparison.OrdinalIgnoreCase))
++        {
++            box.Display = CssConstants.InlineBlock;
++            // Author CSS sizing wins; otherwise the width/height presentation attributes, then the CSS
++            // replaced-element intrinsic default 300×150.
++            if (box.Width == CssConstants.Auto)
++                box.Width = PresentationLengthPx(box, "width", "300px");
++            if (box.Height == CssConstants.Auto)
++                box.Height = PresentationLengthPx(box, "height", "150px");
++            box.BackgroundColor = "black";
++            foreach (var child in box.Boxes)
++                child.Display = CssConstants.None;
++            return;
++        }
++
++        foreach (var child in box.Boxes)
++            CorrectVideoBoxes(child);
++    }
++
++    /// <summary>
++    /// Reads a numeric <c>width</c>/<c>height</c> presentation attribute as a pixel length, falling back to
++    /// <paramref name="fallback"/> when the attribute is absent or non-numeric (percentages and other units
++    /// are left to CSS).
++    /// </summary>
++    private static string PresentationLengthPx(CssBox box, string attribute, string fallback)
++    {
++        var raw = box.HtmlTag?.TryGetAttribute(attribute);
++        return !string.IsNullOrWhiteSpace(raw)
++               && double.TryParse(raw, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out _)
++            ? raw + "px"
++            : fallback;
++    }
++
+     private static void CorrectFramesetBoxes(CssBox box)
+     {
+         bool isFrameset = box.HtmlTag != null
+-- 
+2.43.0
+

--- a/patches/0006-html-progress-meter-native-track-fill.patch
+++ b/patches/0006-html-progress-meter-native-track-fill.patch
@@ -1,0 +1,138 @@
+From 1ede017bd922ce1e605817374317d0f1882971fb Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Mon, 20 Jul 2026 19:10:50 +0000
+Subject: [PATCH] Broiler.HTML: render <progress>/<meter> as a native track
+ with proportional fill
+
+HTML 4.10.13/4.10.14: <progress>/<meter> are replaced form controls. Broiler has
+no native control chrome, so a post-cascade CorrectProgressBoxes pass renders each
+as a bordered inline-block track (1px #767676, bg #f0f0f0 progress / #e6e6e6 meter,
+120x16 or 16x120 vertical) with an absolutely-positioned fill bar proportional to
+value (#0a84ff progress / #4caf50 meter), honouring writing-mode/direction for
+vertical and reversed bars, and hides the element's fallback text. Native
+replacement for HtmlPostProcessor.ReplaceProgressLikeWithPlaceholder; matches its
+exact colours/sizes.
+---
+ .../Parse/DomParser.cs                        | 99 +++++++++++++++++++
+ 1 file changed, 99 insertions(+)
+
+diff --git a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+index 7076f3d..df935f2 100644
+--- a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
++++ b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+@@ -99,6 +99,7 @@ internal sealed class DomParser
+         CorrectObjectBoxes(root);
+         CorrectFramesetBoxes(root);
+         CorrectIframeBoxes(root);
++        CorrectProgressBoxes(root, baseUrl);
+ 
+         bool followingBlock = true;
+         CorrectLineBreaksBlocks(root, ref followingBlock);
+@@ -929,6 +930,104 @@ internal sealed class DomParser
+             CorrectIframeBoxes(child);
+     }
+ 
++    private const double DefaultProgressTrackLengthPx = 120;
++
++    /// <summary>
++    /// HTML §4.10.13/4.10.14: <c>&lt;progress&gt;</c> / <c>&lt;meter&gt;</c> are replaced form controls.
++    /// Broiler has no native control chrome, so — matching the bridge's
++    /// <c>HtmlPostProcessor.ReplaceProgressLikeWithPlaceholder</c> fallback — a post-cascade pass renders each
++    /// as a bordered <c>inline-block</c> track with an absolutely-positioned fill bar proportional to
++    /// <c>value</c> (honouring writing-mode / direction for vertical and reversed bars) and hides the
++    /// element's fallback text. Runs post-cascade so the injected fill box and forced track geometry are not
++    /// re-cascaded. Native replacement for the string rewrite; matches its exact colours/sizes so retiring the
++    /// fallback (once the pointer is bumped) does not change rendering.
++    /// </summary>
++    private static void CorrectProgressBoxes(CssBox box, Uri baseUrl)
++    {
++        if (box.HtmlTag != null
++            && (box.HtmlTag.Name.Equals("progress", StringComparison.OrdinalIgnoreCase)
++                || box.HtmlTag.Name.Equals("meter", StringComparison.OrdinalIgnoreCase)))
++        {
++            bool isMeter = box.HtmlTag.Name.Equals("meter", StringComparison.OrdinalIgnoreCase);
++            bool vertical = box.WritingMode != null
++                && (box.WritingMode.StartsWith("vertical", StringComparison.OrdinalIgnoreCase)
++                    || box.WritingMode.StartsWith("sideways", StringComparison.OrdinalIgnoreCase));
++            bool reverseInline = string.Equals(box.Direction, "rtl", StringComparison.OrdinalIgnoreCase);
++            double ratio = ResolveProgressValueRatio(box, isMeter);
++
++            // Track (host) box — forced geometry/appearance, matching the string fallback.
++            box.Display = CssConstants.InlineBlock;
++            box.BoxSizing = "border-box";
++            box.Position = CssConstants.Relative;
++            box.Overflow = CssConstants.Hidden;
++            box.PaddingLeft = box.PaddingRight = box.PaddingTop = box.PaddingBottom = "0";
++            SetUniformBorder(box, "1px", "solid", "#767676");
++            box.BackgroundColor = isMeter ? "#e6e6e6" : "#f0f0f0";
++            box.VerticalAlign = "middle";
++            box.Width = vertical ? "16px" : "120px";
++            box.Height = vertical ? "120px" : "16px";
++
++            // The element's fallback text/content does not paint; the fill bar replaces it.
++            foreach (var child in box.Boxes)
++                child.Display = CssConstants.None;
++
++            // Fill bar — absolutely positioned within the relative track, sized to the value ratio.
++            var fillExtent = (DefaultProgressTrackLengthPx * ratio)
++                .ToString("0.###", System.Globalization.CultureInfo.InvariantCulture) + "px";
++            var fill = CssBoxHelper.CreateBlock(box, baseUrl);
++            fill.Position = CssConstants.Absolute;
++            fill.BackgroundColor = isMeter ? "#4caf50" : "#0a84ff";
++            if (vertical)
++            {
++                fill.Left = "0";
++                fill.Right = "0";
++                if (reverseInline) fill.Bottom = "0"; else fill.Top = "0";
++                fill.Height = fillExtent;
++            }
++            else
++            {
++                fill.Top = "0";
++                fill.Bottom = "0";
++                if (reverseInline) fill.Right = "0"; else fill.Left = "0";
++                fill.Width = fillExtent;
++            }
++            return;
++        }
++
++        foreach (var child in box.Boxes)
++            CorrectProgressBoxes(child, baseUrl);
++    }
++
++    private static void SetUniformBorder(CssBox box, string width, string style, string color)
++    {
++        box.BorderLeftWidth = box.BorderRightWidth = box.BorderTopWidth = box.BorderBottomWidth = width;
++        box.BorderLeftStyle = box.BorderRightStyle = box.BorderTopStyle = box.BorderBottomStyle = style;
++        box.BorderLeftColor = box.BorderRightColor = box.BorderTopColor = box.BorderBottomColor = color;
++    }
++
++    /// <summary>
++    /// Resolves a <c>&lt;progress&gt;</c>/<c>&lt;meter&gt;</c> fill ratio in [0,1] from its numeric
++    /// <c>value</c>/<c>max</c> (and, for <c>&lt;meter&gt;</c>, <c>min</c>) attributes, mirroring the fallback.
++    /// </summary>
++    private static double ResolveProgressValueRatio(CssBox box, bool isMeter)
++    {
++        double min = isMeter ? ReadNumericAttribute(box, "min", 0) : 0;
++        double max = ReadNumericAttribute(box, "max", 1);
++        if (max <= min)
++            max = min + 1;
++        double value = ReadNumericAttribute(box, "value", min);
++        return Math.Clamp((value - min) / (max - min), 0, 1);
++    }
++
++    private static double ReadNumericAttribute(CssBox box, string name, double fallback)
++    {
++        var raw = box.HtmlTag?.TryGetAttribute(name);
++        return !string.IsNullOrWhiteSpace(raw)
++               && double.TryParse(raw, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var v)
++            ? v
++            : fallback;
++    }
++
+     private static void CorrectFramesetBoxes(CssBox box)
+     {
+         bool isFrameset = box.HtmlTag != null
+-- 
+2.43.0
+

--- a/patches/0007-html-select-multiple-native-listbox.patch
+++ b/patches/0007-html-select-multiple-native-listbox.patch
@@ -1,26 +1,14 @@
-From 3fe21a63e39abc860ca02f3b4ad46395076c841e Mon Sep 17 00:00:00 2001
+From 4c2a868e1eb40134e09ac8672859020041510f1c Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
-Date: Mon, 20 Jul 2026 19:17:02 +0000
-Subject: [PATCH] Broiler.HTML: render <select multiple> as a native list box
- (appearance:auto)
+Date: Mon, 20 Jul 2026 19:34:36 +0000
+Subject: [PATCH] 0007 select + appearance
 
-HTML 4.10.7: <select multiple> is a replaced list-box control. Broiler has no
-native control chrome, so a post-cascade CorrectSelectMultipleBoxes pass renders
-it as an inline-block list box: one 16px row track per visible option (size,
-clamped 2..8, default 4) with the first row as the selection highlight (#3875d7)
-and the rest alternating (#ffffff / #f7f7f7), an edge scrollbar-chrome strip
-(#dcdcdc), honouring writing-mode for vertical/reversed boxes, hiding the real
-<option> children. Matches the native-appearance case of
-HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder. The appearance:none
-variant needs a CSS appearance box property (separate Broiler.Layout change), so
-the fallback stays for it. Depends on patch 0006 (shares SetUniformBorder /
-ReadNumericAttribute).
 ---
- .../Parse/DomParser.cs                        | 120 ++++++++++++++++++
- 1 file changed, 120 insertions(+)
+ .../Parse/DomParser.cs                        | 127 ++++++++++++++++++
+ 1 file changed, 127 insertions(+)
 
 diff --git a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
-index df935f2..0284876 100644
+index df935f2..0496311 100644
 --- a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
 +++ b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
 @@ -100,6 +100,7 @@ internal sealed class DomParser
@@ -31,7 +19,7 @@ index df935f2..0284876 100644
  
          bool followingBlock = true;
          CorrectLineBreaksBlocks(root, ref followingBlock);
-@@ -1028,6 +1029,125 @@ internal sealed class DomParser
+@@ -1028,6 +1029,132 @@ internal sealed class DomParser
              : fallback;
      }
  
@@ -50,10 +38,9 @@ index df935f2..0284876 100644
 +    /// are laid out because the engine discovers absolutes by walking the tree at layout time).
 +    /// </summary>
 +    /// <remarks>
-+    /// Scope: this renders the <c>appearance:auto</c> (native) list box. The fallback also has an
-+    /// <c>appearance:none</c> variant (no chrome, white background); distinguishing it natively needs a CSS
-+    /// <c>appearance</c> property on the box model (a separate <c>Broiler.Layout</c> change), so until that
-+    /// lands the fallback must stay for <c>appearance:none</c> selects.
++    /// Both appearance modes are covered: <c>appearance:auto</c> (native — chrome strip, grey field) and
++    /// <c>appearance:none</c> (no chrome, white field, lighter border), branched on the box's cascaded
++    /// <c>Appearance</c> value.
 +    /// </remarks>
 +    private static void CorrectSelectMultipleBoxes(CssBox box, Uri baseUrl)
 +    {
@@ -67,17 +54,22 @@ index df935f2..0284876 100644
 +            bool reverseBlock = box.WritingMode != null
 +                && box.WritingMode.EndsWith("-rl", StringComparison.OrdinalIgnoreCase);
 +
++            // 'appearance:none' opts out of the native list-box chrome (no scrollbar strip, white field,
++            // lighter border) — CSS Basic UI; the box's Appearance is populated by the cascade.
++            bool nativeAppearance = !string.Equals(box.Appearance, "none", StringComparison.OrdinalIgnoreCase);
++
 +            int visibleTracks = (int)Math.Clamp(
 +                ReadNumericAttribute(box, "size", SelectMultipleDefaultVisibleTracks), 2, 8);
 +
++            int chromeInset = nativeAppearance ? SelectMultipleChromeThicknessPx : 2;
 +            int blockExtent = (visibleTracks * SelectMultipleTrackThicknessPx) + 4;
 +            int hostWidth = vertical ? blockExtent : SelectMultipleInlineExtentPx;
 +            int hostHeight = vertical ? SelectMultipleInlineExtentPx : blockExtent;
 +            int contentWidth = vertical
 +                ? visibleTracks * SelectMultipleTrackThicknessPx
-+                : SelectMultipleInlineExtentPx - SelectMultipleChromeThicknessPx;
++                : SelectMultipleInlineExtentPx - chromeInset;
 +            int contentHeight = vertical
-+                ? SelectMultipleInlineExtentPx - SelectMultipleChromeThicknessPx
++                ? SelectMultipleInlineExtentPx - chromeInset
 +                : visibleTracks * SelectMultipleTrackThicknessPx;
 +
 +            // Host (list box) — forced geometry/appearance, matching the string fallback.
@@ -90,8 +82,8 @@ index df935f2..0284876 100644
 +            box.FontFamily = "sans-serif";
 +            box.Width = hostWidth + "px";
 +            box.Height = hostHeight + "px";
-+            SetUniformBorder(box, "1px", "solid", "#767676");
-+            box.BackgroundColor = "#f0f0f0";
++            SetUniformBorder(box, "1px", "solid", nativeAppearance ? "#767676" : "#9a9a9a");
++            box.BackgroundColor = nativeAppearance ? "#f0f0f0" : "#ffffff";
 +
 +            // The real <option> children do not paint; the row tracks replace them.
 +            foreach (var child in box.Boxes)
@@ -123,29 +115,32 @@ index df935f2..0284876 100644
 +                }
 +            }
 +
-+            // Scrollbar-chrome strip along the block-end edge.
-+            var chrome = CssBoxHelper.CreateBlock(box, baseUrl);
-+            chrome.Position = CssConstants.Absolute;
-+            chrome.BackgroundColor = "#dcdcdc";
-+            if (vertical)
++            // Scrollbar-chrome strip along the block-end edge — native appearance only.
++            if (nativeAppearance)
 +            {
-+                chrome.Left = "1px";
-+                if (reverseBlock) chrome.Top = "1px"; else chrome.Bottom = "1px";
-+                chrome.Width = (hostWidth - 2) + "px";
-+                chrome.Height = (SelectMultipleChromeThicknessPx - 2) + "px";
-+                chrome.BorderTopWidth = "1px";
-+                chrome.BorderTopStyle = "solid";
-+                chrome.BorderTopColor = "#b8b8b8";
-+            }
-+            else
-+            {
-+                chrome.Top = "1px";
-+                chrome.Right = "1px";
-+                chrome.Width = (SelectMultipleChromeThicknessPx - 2) + "px";
-+                chrome.Height = (hostHeight - 2) + "px";
-+                chrome.BorderLeftWidth = "1px";
-+                chrome.BorderLeftStyle = "solid";
-+                chrome.BorderLeftColor = "#b8b8b8";
++                var chrome = CssBoxHelper.CreateBlock(box, baseUrl);
++                chrome.Position = CssConstants.Absolute;
++                chrome.BackgroundColor = "#dcdcdc";
++                if (vertical)
++                {
++                    chrome.Left = "1px";
++                    if (reverseBlock) chrome.Top = "1px"; else chrome.Bottom = "1px";
++                    chrome.Width = (hostWidth - 2) + "px";
++                    chrome.Height = (SelectMultipleChromeThicknessPx - 2) + "px";
++                    chrome.BorderTopWidth = "1px";
++                    chrome.BorderTopStyle = "solid";
++                    chrome.BorderTopColor = "#b8b8b8";
++                }
++                else
++                {
++                    chrome.Top = "1px";
++                    chrome.Right = "1px";
++                    chrome.Width = (SelectMultipleChromeThicknessPx - 2) + "px";
++                    chrome.Height = (hostHeight - 2) + "px";
++                    chrome.BorderLeftWidth = "1px";
++                    chrome.BorderLeftStyle = "solid";
++                    chrome.BorderLeftColor = "#b8b8b8";
++                }
 +            }
 +            return;
 +        }

--- a/patches/0007-html-select-multiple-native-listbox.patch
+++ b/patches/0007-html-select-multiple-native-listbox.patch
@@ -1,0 +1,162 @@
+From 3fe21a63e39abc860ca02f3b4ad46395076c841e Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Mon, 20 Jul 2026 19:17:02 +0000
+Subject: [PATCH] Broiler.HTML: render <select multiple> as a native list box
+ (appearance:auto)
+
+HTML 4.10.7: <select multiple> is a replaced list-box control. Broiler has no
+native control chrome, so a post-cascade CorrectSelectMultipleBoxes pass renders
+it as an inline-block list box: one 16px row track per visible option (size,
+clamped 2..8, default 4) with the first row as the selection highlight (#3875d7)
+and the rest alternating (#ffffff / #f7f7f7), an edge scrollbar-chrome strip
+(#dcdcdc), honouring writing-mode for vertical/reversed boxes, hiding the real
+<option> children. Matches the native-appearance case of
+HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder. The appearance:none
+variant needs a CSS appearance box property (separate Broiler.Layout change), so
+the fallback stays for it. Depends on patch 0006 (shares SetUniformBorder /
+ReadNumericAttribute).
+---
+ .../Parse/DomParser.cs                        | 120 ++++++++++++++++++
+ 1 file changed, 120 insertions(+)
+
+diff --git a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+index df935f2..0284876 100644
+--- a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
++++ b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+@@ -100,6 +100,7 @@ internal sealed class DomParser
+         CorrectFramesetBoxes(root);
+         CorrectIframeBoxes(root);
+         CorrectProgressBoxes(root, baseUrl);
++        CorrectSelectMultipleBoxes(root, baseUrl);
+ 
+         bool followingBlock = true;
+         CorrectLineBreaksBlocks(root, ref followingBlock);
+@@ -1028,6 +1029,125 @@ internal sealed class DomParser
+             : fallback;
+     }
+ 
++    private const int SelectMultipleDefaultVisibleTracks = 4;
++    private const int SelectMultipleTrackThicknessPx = 16;
++    private const int SelectMultipleInlineExtentPx = 72;
++    private const int SelectMultipleChromeThicknessPx = 10;
++
++    /// <summary>
++    /// HTML §4.10.7: a <c>&lt;select multiple&gt;</c> is a replaced list-box control. Broiler has no native
++    /// control chrome, so — matching the bridge's <c>HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder</c>
++    /// fallback (native-appearance case) — a post-cascade pass renders it as an <c>inline-block</c> list box
++    /// with one row track per visible option (the first row painted as the selection highlight, the rest
++    /// alternating), an edge scrollbar-chrome strip, honouring <c>writing-mode</c> for vertical/reversed
++    /// boxes, and hides the real <c>&lt;option&gt;</c> children. Runs post-cascade (absolute row/chrome boxes
++    /// are laid out because the engine discovers absolutes by walking the tree at layout time).
++    /// </summary>
++    /// <remarks>
++    /// Scope: this renders the <c>appearance:auto</c> (native) list box. The fallback also has an
++    /// <c>appearance:none</c> variant (no chrome, white background); distinguishing it natively needs a CSS
++    /// <c>appearance</c> property on the box model (a separate <c>Broiler.Layout</c> change), so until that
++    /// lands the fallback must stay for <c>appearance:none</c> selects.
++    /// </remarks>
++    private static void CorrectSelectMultipleBoxes(CssBox box, Uri baseUrl)
++    {
++        if (box.HtmlTag != null
++            && box.HtmlTag.Name.Equals("select", StringComparison.OrdinalIgnoreCase)
++            && box.HtmlTag.HasAttribute("multiple"))
++        {
++            bool vertical = box.WritingMode != null
++                && (box.WritingMode.StartsWith("vertical", StringComparison.OrdinalIgnoreCase)
++                    || box.WritingMode.StartsWith("sideways", StringComparison.OrdinalIgnoreCase));
++            bool reverseBlock = box.WritingMode != null
++                && box.WritingMode.EndsWith("-rl", StringComparison.OrdinalIgnoreCase);
++
++            int visibleTracks = (int)Math.Clamp(
++                ReadNumericAttribute(box, "size", SelectMultipleDefaultVisibleTracks), 2, 8);
++
++            int blockExtent = (visibleTracks * SelectMultipleTrackThicknessPx) + 4;
++            int hostWidth = vertical ? blockExtent : SelectMultipleInlineExtentPx;
++            int hostHeight = vertical ? SelectMultipleInlineExtentPx : blockExtent;
++            int contentWidth = vertical
++                ? visibleTracks * SelectMultipleTrackThicknessPx
++                : SelectMultipleInlineExtentPx - SelectMultipleChromeThicknessPx;
++            int contentHeight = vertical
++                ? SelectMultipleInlineExtentPx - SelectMultipleChromeThicknessPx
++                : visibleTracks * SelectMultipleTrackThicknessPx;
++
++            // Host (list box) — forced geometry/appearance, matching the string fallback.
++            box.Display = CssConstants.InlineBlock;
++            box.Position = CssConstants.Relative;
++            box.BoxSizing = "border-box";
++            box.Overflow = CssConstants.Hidden;
++            box.VerticalAlign = "middle";
++            box.FontSize = "13px";
++            box.FontFamily = "sans-serif";
++            box.Width = hostWidth + "px";
++            box.Height = hostHeight + "px";
++            SetUniformBorder(box, "1px", "solid", "#767676");
++            box.BackgroundColor = "#f0f0f0";
++
++            // The real <option> children do not paint; the row tracks replace them.
++            foreach (var child in box.Boxes)
++                child.Display = CssConstants.None;
++
++            for (int i = 0; i < visibleTracks; i++)
++            {
++                var background = i == 0 ? "#3875d7" : (i % 2 == 0 ? "#ffffff" : "#f7f7f7");
++                int offset = 1 + (i * SelectMultipleTrackThicknessPx);
++                var track = CssBoxHelper.CreateBlock(box, baseUrl);
++                track.Position = CssConstants.Absolute;
++                track.BackgroundColor = background;
++                if (vertical)
++                {
++                    track.Top = "1px";
++                    if (reverseBlock) track.Right = offset + "px"; else track.Left = offset + "px";
++                    track.Width = SelectMultipleTrackThicknessPx + "px";
++                    track.Height = Math.Max(contentHeight, 8) + "px";
++                }
++                else
++                {
++                    track.Left = "1px";
++                    track.Top = offset + "px";
++                    track.Width = Math.Max(contentWidth, 8) + "px";
++                    track.Height = SelectMultipleTrackThicknessPx + "px";
++                    track.BorderBottomWidth = "1px";
++                    track.BorderBottomStyle = "solid";
++                    track.BorderBottomColor = "#d0d0d0";
++                }
++            }
++
++            // Scrollbar-chrome strip along the block-end edge.
++            var chrome = CssBoxHelper.CreateBlock(box, baseUrl);
++            chrome.Position = CssConstants.Absolute;
++            chrome.BackgroundColor = "#dcdcdc";
++            if (vertical)
++            {
++                chrome.Left = "1px";
++                if (reverseBlock) chrome.Top = "1px"; else chrome.Bottom = "1px";
++                chrome.Width = (hostWidth - 2) + "px";
++                chrome.Height = (SelectMultipleChromeThicknessPx - 2) + "px";
++                chrome.BorderTopWidth = "1px";
++                chrome.BorderTopStyle = "solid";
++                chrome.BorderTopColor = "#b8b8b8";
++            }
++            else
++            {
++                chrome.Top = "1px";
++                chrome.Right = "1px";
++                chrome.Width = (SelectMultipleChromeThicknessPx - 2) + "px";
++                chrome.Height = (hostHeight - 2) + "px";
++                chrome.BorderLeftWidth = "1px";
++                chrome.BorderLeftStyle = "solid";
++                chrome.BorderLeftColor = "#b8b8b8";
++            }
++            return;
++        }
++
++        foreach (var child in box.Boxes)
++            CorrectSelectMultipleBoxes(child, baseUrl);
++    }
++
+     private static void CorrectFramesetBoxes(CssBox box)
+     {
+         bool isFrameset = box.HtmlTag != null
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -12,7 +12,9 @@ pointers pin the commits that contain them** (retained only for provenance). Pat
 treat `<iframe>` as a replaced element; hide inline fallback content"* contains its
 `CorrectIframeBoxes` pass (verified 2026-07-20). Patch **0005 is PENDING** — its
 Broiler.HTML working-tree change was reverted after a 403, so the pinned SHA does **not**
-contain it and the main-repo fallback stays active.
+contain it and the main-repo fallback stays active. Patch **0006 is PENDING** on the
+same basis (reverted after a 403; the main-repo `ReplaceProgressLike` fallback stays
+active).
 
 | Patch | Target submodule | Pinned commit / status | Main-repo follow-up |
 |---|---|---|---|
@@ -21,6 +23,7 @@ contain it and the main-repo fallback stays active.
 | 0003 — `Normalize()` fires one `characterData` record per text run | `Broiler.DOM` | applied — `8e8325f` *DomNode.Normalize(): one characterData record per contiguous text run* (the pinned pointer) | **Done / works either way** — `DomBridge.NormalizeNode` already delegates to `node.Normalize()`; canonical now matches the bridge's former one-record-per-run behaviour exactly. |
 | 0004 — treat `<iframe>` as a replaced element (hide inline fallback) | `Broiler.HTML` | **applied** — pinned `52f65d9` *DomParser: treat `<iframe>` as a replaced element; hide inline fallback content* contains `CorrectIframeBoxes` | **Unblocked, not yet wired** — the pinned renderer now hides iframe fallback natively, so `HtmlPostProcessor.StripIframeContent` can be dropped (it is now a redundant belt-and-suspenders strip). Not done here to keep this change focused. |
 | 0005 — render `<video>` as a black inline-block replaced box (hide fallback) | `Broiler.HTML` | **PENDING** — reverted from the working tree after a 403; pinned SHA `52f65d9` does **not** contain it | **Not yet wired** — once applied + pointer bumped, drop `HtmlPostProcessor.ReplaceVideoWithPlaceholder` (Phase 6 concern 2). Until then that regex rewrite is the active fallback. |
+| 0006 — render `<progress>`/`<meter>` as a native track with proportional fill | `Broiler.HTML` | **PENDING** — reverted from the working tree after a 403; pinned SHA `52f65d9` does **not** contain it | **Not yet wired** — once applied + pointer bumped, drop `HtmlPostProcessor.ReplaceProgressLikeWithPlaceholder`. Until then that regex rewrite is the active fallback. Adds `CorrectProgressBoxes` after `CorrectIframeBoxes` — same call-site line as `0005`, so applying both together needs a trivial adjacency resolution. |
 
 To apply a *future* patch (kept for reference):
 
@@ -35,6 +38,41 @@ git add <Submodule>                         # bump the pointer
 Then do the "Follow-up (main-repo)" wiring named for that patch — it is deferred until
 the pointer is bumped because it references the patched API, which does not exist at the
 previously-pinned submodule SHA (so it would not compile against the pinned clone on CI).
+
+---
+
+## 0006 — `Broiler.HTML`: render `<progress>`/`<meter>` as a native track with proportional fill
+
+**Target:** `Broiler.HTML` (`Source/Broiler.HTML.Orchestration/Parse/DomParser.cs`).
+**Status: PENDING** (reverted after a 403; pinned SHA `52f65d9` does not contain it).
+**Depends on:** nothing (adds a call adjacent to `0005`'s — see the table note).
+
+**What it does.** HTML §4.10.13/4.10.14: `<progress>`/`<meter>` are replaced form controls. Broiler has no
+native control chrome, so a post-cascade `CorrectProgressBoxes` pass renders each as a bordered
+`inline-block` track (1px `#767676`, background `#f0f0f0` progress / `#e6e6e6` meter, `120×16` — `16×120`
+vertical) with an **absolutely-positioned fill bar** proportional to `value` (`#0a84ff` progress / `#4caf50`
+meter), honouring `writing-mode`/`direction` for vertical and RTL-reversed bars, and hides the element's
+fallback text. The value ratio mirrors the fallback (`meter` reads `min`/`max`/`value`; `progress` reads
+`value`/`max`). Runs post-cascade so the injected fill box and forced track geometry are not re-cascaded (the
+absolute fill is still laid out — the engine discovers absolutely-positioned boxes by walking the box tree at
+layout time).
+
+**Verified locally** (patch applied in the submodule working tree, parent build compiling it in place) via a
+render-probe using `HtmlRender.RenderToImageWithStyleSet` on **raw** `<progress value="0.5">` / `<meter
+value="0.5">` (bypassing the string fallback): the track paints border `#767676` + track grey, the left ~60px
+(ratio 0.5 × 120) paints the fill colour — `(10,132,255)` blue for progress, `(76,175,80)` green for meter —
+and the region past the fill is track grey `(240,240,240)`. Full pixel validation needs the Acid/WPT reftest
+gate.
+
+**Why it's a patch.** The `Broiler.HTML` push returned **403** (submodule remote outside the session's GitHub
+scope), so per `CLAUDE.md` it ships as `patches/0006-html-progress-meter-native-track-fill.patch` with the
+pointer left **unbumped** and the working tree reverted.
+
+**Main-repo follow-up (once applied + pointer bumped).** Drop
+`HtmlPostProcessor.ReplaceProgressLikeWithPlaceholder` (the regex that rewrites `<progress>`/`<meter>` into a
+styled `<div>` track) — the renderer then boxes them natively. **Current fallback (unchanged until applied):**
+that rewrite runs in the string pipeline before the renderer, so a real `<progress>`/`<meter>` never reaches
+`CorrectProgressBoxes` yet and nothing on CI depends on this patch.
 
 ---
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -12,9 +12,10 @@ pointers pin the commits that contain them** (retained only for provenance). Pat
 treat `<iframe>` as a replaced element; hide inline fallback content"* contains its
 `CorrectIframeBoxes` pass (verified 2026-07-20). Patch **0005 is PENDING** — its
 Broiler.HTML working-tree change was reverted after a 403, so the pinned SHA does **not**
-contain it and the main-repo fallback stays active. Patch **0006 is PENDING** on the
-same basis (reverted after a 403; the main-repo `ReplaceProgressLike` fallback stays
-active).
+contain it and the main-repo fallback stays active. Patches **0006 and 0007 are
+PENDING** on the same basis (reverted after a 403; the main-repo `ReplaceProgressLike`
+/ `ReplaceSelectMultiple` fallbacks stay active). **0007 stacks on 0006** (they share
+`SetUniformBorder`/`ReadNumericAttribute`) — apply 0006 first.
 
 | Patch | Target submodule | Pinned commit / status | Main-repo follow-up |
 |---|---|---|---|
@@ -24,6 +25,7 @@ active).
 | 0004 — treat `<iframe>` as a replaced element (hide inline fallback) | `Broiler.HTML` | **applied** — pinned `52f65d9` *DomParser: treat `<iframe>` as a replaced element; hide inline fallback content* contains `CorrectIframeBoxes` | **Unblocked, not yet wired** — the pinned renderer now hides iframe fallback natively, so `HtmlPostProcessor.StripIframeContent` can be dropped (it is now a redundant belt-and-suspenders strip). Not done here to keep this change focused. |
 | 0005 — render `<video>` as a black inline-block replaced box (hide fallback) | `Broiler.HTML` | **PENDING** — reverted from the working tree after a 403; pinned SHA `52f65d9` does **not** contain it | **Not yet wired** — once applied + pointer bumped, drop `HtmlPostProcessor.ReplaceVideoWithPlaceholder` (Phase 6 concern 2). Until then that regex rewrite is the active fallback. |
 | 0006 — render `<progress>`/`<meter>` as a native track with proportional fill | `Broiler.HTML` | **PENDING** — reverted from the working tree after a 403; pinned SHA `52f65d9` does **not** contain it | **Not yet wired** — once applied + pointer bumped, drop `HtmlPostProcessor.ReplaceProgressLikeWithPlaceholder`. Until then that regex rewrite is the active fallback. Adds `CorrectProgressBoxes` after `CorrectIframeBoxes` — same call-site line as `0005`, so applying both together needs a trivial adjacency resolution. |
+| 0007 — render `<select multiple>` as a native list box (appearance:auto) | `Broiler.HTML` | **PENDING** — reverted from the working tree after a 403; **stacks on 0006** (apply 0006 first) | **Not yet wired** — once applied + pointer bumped, drop `HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder` for the `appearance:auto` case. The `appearance:none` variant needs a CSS `appearance` box property (a separate `Broiler.Layout` change), so the fallback must stay until that lands. |
 
 To apply a *future* patch (kept for reference):
 
@@ -38,6 +40,43 @@ git add <Submodule>                         # bump the pointer
 Then do the "Follow-up (main-repo)" wiring named for that patch — it is deferred until
 the pointer is bumped because it references the patched API, which does not exist at the
 previously-pinned submodule SHA (so it would not compile against the pinned clone on CI).
+
+---
+
+## 0007 — `Broiler.HTML`: render `<select multiple>` as a native list box (appearance:auto)
+
+**Target:** `Broiler.HTML` (`Source/Broiler.HTML.Orchestration/Parse/DomParser.cs`).
+**Status: PENDING** (reverted after a 403; pinned SHA `52f65d9` does not contain it).
+**Depends on:** **0006** (shares the `SetUniformBorder`/`ReadNumericAttribute` helpers — apply 0006 first).
+
+**What it does.** HTML §4.10.7: `<select multiple>` is a replaced list-box control. Broiler has no native
+control chrome, so a post-cascade `CorrectSelectMultipleBoxes` pass renders it as an `inline-block` list box:
+one 16px row track per visible option (`size`, clamped 2..8, default 4), the first row painted as the
+selection highlight `#3875d7` and the rest alternating `#ffffff`/`#f7f7f7`, an edge scrollbar-chrome strip
+`#dcdcdc` with a `#b8b8b8` border, honouring `writing-mode` for vertical/`-rl`-reversed boxes, and hides the
+real `<option>` children. Track/chrome boxes are absolutely positioned within the relative host (laid out
+because the engine discovers absolutes by walking the tree at layout time). Matches the **native-appearance**
+case of `HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder`.
+
+**Scope / limitation.** Renders the `appearance:auto` list box only. The fallback also renders an
+`appearance:none` variant (no chrome, white background); distinguishing it natively needs a CSS `appearance`
+property on the box model — a separate `Broiler.Layout` change — so the fallback must stay for
+`appearance:none` selects until that lands.
+
+**Verified locally** (patch applied on top of 0006 in the submodule working tree, parent build compiling it in
+place) via a render-probe on raw `<select multiple>…</select>`: a 72×68 host paints border `#767676`, the
+first row `(56,117,215)` selection highlight, alternating rows `(247,247,247)`, the chrome strip `(220,220,220)`
+with a `(184,184,184)` border, and row borders `(208,208,208)` — all the fallback's colours. Full pixel
+validation needs the Acid/WPT reftest gate.
+
+**Why it's a patch.** The `Broiler.HTML` push returned **403**, so per `CLAUDE.md` it ships as
+`patches/0007-html-select-multiple-native-listbox.patch` with the pointer left **unbumped** and the working
+tree reverted.
+
+**Main-repo follow-up (once applied + pointer bumped, and the `appearance` property exists).** Drop
+`HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder`. **Current fallback (unchanged until then):** the
+string rewrite runs before the renderer, so a real `<select multiple>` never reaches `CorrectSelectMultipleBoxes`
+yet and nothing on CI depends on this patch.
 
 ---
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -6,18 +6,21 @@ scope, so `git push` returns **403**). Each is captured here as a `git format-pa
 file for a maintainer to apply to the target submodule, push, and bump the submodule
 pointer in the parent repo.
 
-**Status.** Patches **0001–0003 have been applied upstream and the parent submodule
-pointers pin the commits that contain them** (retained only for provenance; they no
-longer apply — verified 2026-07-20 by reverse-apply against the pinned trees).
-Patch **0004 is PENDING** — its Broiler.HTML working-tree change was reverted after a
-403, so the pinned SHA does **not** contain it and the main-repo fallback stays active.
+**Status.** Patches **0001–0004 have been applied upstream and the parent submodule
+pointers pin the commits that contain them** (retained only for provenance). Patch
+**0004** in particular is now applied — the pinned `Broiler.HTML` `52f65d9` *"DomParser:
+treat `<iframe>` as a replaced element; hide inline fallback content"* contains its
+`CorrectIframeBoxes` pass (verified 2026-07-20). Patch **0005 is PENDING** — its
+Broiler.HTML working-tree change was reverted after a 403, so the pinned SHA does **not**
+contain it and the main-repo fallback stays active.
 
 | Patch | Target submodule | Pinned commit / status | Main-repo follow-up |
 |---|---|---|---|
 | 0001 — plumb `viewportZoom` through the static render entry | `Broiler.HTML` | applied — `9977672` *HtmlRender: plumb viewportZoom through the static render entry* | **Unblocked, not yet wired** — the visual-viewport render cutover (see below). The serialization bake remains the active fallback until it lands. |
 | 0002 — make `DomNodeCollectionExtensions` public | `Broiler.DOM` | applied — `5c71ac9` *Make DomNodeCollectionExtensions public for host reuse* (ancestor of the pinned `8e8325f`) | **Done** — `DomBridge.ChildIndexOf` delegates to `element.ChildNodes.IndexOfReference(child)`. |
 | 0003 — `Normalize()` fires one `characterData` record per text run | `Broiler.DOM` | applied — `8e8325f` *DomNode.Normalize(): one characterData record per contiguous text run* (the pinned pointer) | **Done / works either way** — `DomBridge.NormalizeNode` already delegates to `node.Normalize()`; canonical now matches the bridge's former one-record-per-run behaviour exactly. |
-| 0004 — treat `<iframe>` as a replaced element (hide inline fallback) | `Broiler.HTML` | **PENDING** — reverted from the working tree after a 403; pinned SHA `9977672` does **not** contain it | **Not yet wired** — once applied + pointer bumped, drop `HtmlPostProcessor.StripIframeContent` (Phase 6 concern 2). Until then that regex strip is the active fallback. |
+| 0004 — treat `<iframe>` as a replaced element (hide inline fallback) | `Broiler.HTML` | **applied** — pinned `52f65d9` *DomParser: treat `<iframe>` as a replaced element; hide inline fallback content* contains `CorrectIframeBoxes` | **Unblocked, not yet wired** — the pinned renderer now hides iframe fallback natively, so `HtmlPostProcessor.StripIframeContent` can be dropped (it is now a redundant belt-and-suspenders strip). Not done here to keep this change focused. |
+| 0005 — render `<video>` as a black inline-block replaced box (hide fallback) | `Broiler.HTML` | **PENDING** — reverted from the working tree after a 403; pinned SHA `52f65d9` does **not** contain it | **Not yet wired** — once applied + pointer bumped, drop `HtmlPostProcessor.ReplaceVideoWithPlaceholder` (Phase 6 concern 2). Until then that regex rewrite is the active fallback. |
 
 To apply a *future* patch (kept for reference):
 
@@ -32,6 +35,38 @@ git add <Submodule>                         # bump the pointer
 Then do the "Follow-up (main-repo)" wiring named for that patch — it is deferred until
 the pointer is bumped because it references the patched API, which does not exist at the
 previously-pinned submodule SHA (so it would not compile against the pinned clone on CI).
+
+---
+
+## 0005 — `Broiler.HTML`: render `<video>` as a black inline-block replaced box (hide fallback)
+
+**Target:** `Broiler.HTML` (`Source/Broiler.HTML.Orchestration/Parse/DomParser.cs`).
+**Status: PENDING** (reverted after a 403; pinned SHA `52f65d9` does not contain it).
+**Depends on:** nothing.
+
+**What it does.** HTML §4.8.9: a `<video>` is a replaced element; a UA that cannot present the media shows
+the poster/first frame and never renders the inline fallback content between the tags. Broiler cannot decode
+video, so a post-cascade `CorrectVideoBoxes` pass (mirroring `CorrectIframeBoxes`/`CorrectFramesetBoxes`)
+sets the box to `inline-block`, sizes it (author CSS size wins; else the `width`/`height` presentation
+attributes; else the CSS-default intrinsic **300×150**), paints it **black**, and hides the fallback children
+(`display:none`). Runs post-cascade so a cascade-time hide of a block fallback child cannot be re-shown.
+
+**Verified locally** (patch applied in the submodule working tree, parent build compiling it in place) via a
+render-probe using `HtmlRender.RenderToImageWithStyleSet` on **raw** `<video>` (bypassing the string
+fallback): a bare `<video></video>` paints black at a pixel well inside the 300×150 box (0,0,0), and a
+`<video><div style="background-color:green;width:120px;height:120px"></div></video>` paints **black** — not
+green — over the fallback area (the inline fallback is hidden). Full pixel validation needs the Acid/WPT
+reftest gate.
+
+**Why it's a patch.** The `Broiler.HTML` push returned **403** (submodule remote outside the session's GitHub
+scope), so per `CLAUDE.md` it ships as `patches/0005-html-video-replaced-element-black-box.patch` with the
+pointer left **unbumped** and the working tree reverted.
+
+**Main-repo follow-up (once applied + pointer bumped).** Drop `HtmlPostProcessor.ReplaceVideoWithPlaceholder`
+(the regex that rewrites `<video>…</video>` into a black `<div>`) from `Process`/`ProcessForBrowsing` — the
+renderer then boxes `<video>` natively. **Current fallback (unchanged until applied):** that rewrite runs in
+the string pipeline *before* the renderer, so a real `<video>` never reaches `CorrectVideoBoxes` yet and
+nothing on CI depends on this patch.
 
 ---
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -25,7 +25,7 @@ PENDING** on the same basis (reverted after a 403; the main-repo `ReplaceProgres
 | 0004 — treat `<iframe>` as a replaced element (hide inline fallback) | `Broiler.HTML` | **applied** — pinned `52f65d9` *DomParser: treat `<iframe>` as a replaced element; hide inline fallback content* contains `CorrectIframeBoxes` | **Unblocked, not yet wired** — the pinned renderer now hides iframe fallback natively, so `HtmlPostProcessor.StripIframeContent` can be dropped (it is now a redundant belt-and-suspenders strip). Not done here to keep this change focused. |
 | 0005 — render `<video>` as a black inline-block replaced box (hide fallback) | `Broiler.HTML` | **PENDING** — reverted from the working tree after a 403; pinned SHA `52f65d9` does **not** contain it | **Not yet wired** — once applied + pointer bumped, drop `HtmlPostProcessor.ReplaceVideoWithPlaceholder` (Phase 6 concern 2). Until then that regex rewrite is the active fallback. |
 | 0006 — render `<progress>`/`<meter>` as a native track with proportional fill | `Broiler.HTML` | **PENDING** — reverted from the working tree after a 403; pinned SHA `52f65d9` does **not** contain it | **Not yet wired** — once applied + pointer bumped, drop `HtmlPostProcessor.ReplaceProgressLikeWithPlaceholder`. Until then that regex rewrite is the active fallback. Adds `CorrectProgressBoxes` after `CorrectIframeBoxes` — same call-site line as `0005`, so applying both together needs a trivial adjacency resolution. |
-| 0007 — render `<select multiple>` as a native list box (appearance:auto) | `Broiler.HTML` | **PENDING** — reverted from the working tree after a 403; **stacks on 0006** (apply 0006 first) | **Not yet wired** — once applied + pointer bumped, drop `HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder` for the `appearance:auto` case. The `appearance:none` variant needs a CSS `appearance` box property (a separate `Broiler.Layout` change), so the fallback must stay until that lands. |
+| 0007 — render `<select multiple>` as a native list box (both appearance modes) | `Broiler.HTML` | **PENDING** — reverted from the working tree after a 403; **stacks on 0006** (apply 0006 first) | **Not yet wired** — once applied + pointer bumped, drop `HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder`. Reads the box's `Appearance` (the `appearance` box property landed in the main repo's `Broiler.Layout`, so it is present when this submodule is built in the parent), covering both `appearance:auto` and `appearance:none`. |
 
 To apply a *future* patch (kept for reference):
 
@@ -47,36 +47,39 @@ previously-pinned submodule SHA (so it would not compile against the pinned clon
 
 **Target:** `Broiler.HTML` (`Source/Broiler.HTML.Orchestration/Parse/DomParser.cs`).
 **Status: PENDING** (reverted after a 403; pinned SHA `52f65d9` does not contain it).
-**Depends on:** **0006** (shares the `SetUniformBorder`/`ReadNumericAttribute` helpers — apply 0006 first).
+**Depends on:** **0006** (shares the `SetUniformBorder`/`ReadNumericAttribute` helpers — apply 0006 first)
+and the main-repo `Broiler.Layout` `appearance` box property (already landed in the parent — see below).
 
 **What it does.** HTML §4.10.7: `<select multiple>` is a replaced list-box control. Broiler has no native
 control chrome, so a post-cascade `CorrectSelectMultipleBoxes` pass renders it as an `inline-block` list box:
 one 16px row track per visible option (`size`, clamped 2..8, default 4), the first row painted as the
-selection highlight `#3875d7` and the rest alternating `#ffffff`/`#f7f7f7`, an edge scrollbar-chrome strip
-`#dcdcdc` with a `#b8b8b8` border, honouring `writing-mode` for vertical/`-rl`-reversed boxes, and hides the
-real `<option>` children. Track/chrome boxes are absolutely positioned within the relative host (laid out
-because the engine discovers absolutes by walking the tree at layout time). Matches the **native-appearance**
-case of `HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder`.
+selection highlight `#3875d7` and the rest alternating `#ffffff`/`#f7f7f7`, honouring `writing-mode` for
+vertical/`-rl`-reversed boxes, and hides the real `<option>` children. Track/chrome boxes are absolutely
+positioned within the relative host (laid out because the engine discovers absolutes by walking the tree at
+layout time). Both appearance modes are covered, branched on the box's cascaded `Appearance`:
+`appearance:auto` (grey `#f0f0f0` field, `#767676` border, an edge `#dcdcdc` scrollbar-chrome strip) and
+`appearance:none` (white field, lighter `#9a9a9a` border, no chrome). Matches
+`HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder`.
 
-**Scope / limitation.** Renders the `appearance:auto` list box only. The fallback also renders an
-`appearance:none` variant (no chrome, white background); distinguishing it natively needs a CSS `appearance`
-property on the box model — a separate `Broiler.Layout` change — so the fallback must stay for
-`appearance:none` selects until that lands.
+**The `appearance` box property is main-repo, not a patch.** `Broiler.Layout` is a directory in this repo
+(not a submodule), so `CssBox.Appearance` + its `CssUtils` get/set dispatch landed directly on the parent
+branch. This patch reads `box.Appearance`; because the `Broiler.HTML` submodule is built in the parent
+checkout, that property is present at build time.
 
 **Verified locally** (patch applied on top of 0006 in the submodule working tree, parent build compiling it in
-place) via a render-probe on raw `<select multiple>…</select>`: a 72×68 host paints border `#767676`, the
-first row `(56,117,215)` selection highlight, alternating rows `(247,247,247)`, the chrome strip `(220,220,220)`
-with a `(184,184,184)` border, and row borders `(208,208,208)` — all the fallback's colours. Full pixel
-validation needs the Acid/WPT reftest gate.
+place) via render-probes on raw `<select multiple>`: the `appearance:auto` box paints border `#767676`, first
+row `(56,117,215)`, alternating rows `(247,247,247)`, chrome `(220,220,220)`+`(184,184,184)` border, row
+borders `(208,208,208)`; the `appearance:none` box drops the chrome entirely (0 chrome pixels) and uses a
+white field. Full pixel validation needs the Acid/WPT reftest gate.
 
 **Why it's a patch.** The `Broiler.HTML` push returned **403**, so per `CLAUDE.md` it ships as
 `patches/0007-html-select-multiple-native-listbox.patch` with the pointer left **unbumped** and the working
 tree reverted.
 
-**Main-repo follow-up (once applied + pointer bumped, and the `appearance` property exists).** Drop
-`HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder`. **Current fallback (unchanged until then):** the
-string rewrite runs before the renderer, so a real `<select multiple>` never reaches `CorrectSelectMultipleBoxes`
-yet and nothing on CI depends on this patch.
+**Main-repo follow-up (once applied + pointer bumped).** Drop
+`HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder` (the `appearance` property it depends on is already
+in the parent). **Current fallback (unchanged until then):** the string rewrite runs before the renderer, so a
+real `<select multiple>` never reaches `CorrectSelectMultipleBoxes` yet and nothing on CI depends on this patch.
 
 ---
 

--- a/src/Broiler.App/Rendering/RenderingPipeline.cs
+++ b/src/Broiler.App/Rendering/RenderingPipeline.cs
@@ -31,7 +31,13 @@ public sealed class RenderingPipeline(
         var executableScripts = result.AsyncScripts.Count == 0
             ? result.Scripts
             : result.Scripts.Concat(result.AsyncScripts).ToArray();
-        return (normalisedUrl, new PageContent(html, executableScripts, normalisedUrl, result.DeferredScripts));
+
+        // Module scripts are deferred (Phase 7 item 6, first slice): run authorised inline modules after
+        // the classic deferred scripts. They are already wrapped for module semantics by ExtractAll.
+        var deferred = result.ModuleScripts.Count == 0
+            ? result.DeferredScripts
+            : result.DeferredScripts.Concat(result.ModuleScripts).ToArray();
+        return (normalisedUrl, new PageContent(html, executableScripts, normalisedUrl, deferred));
     }
 
     /// <summary>

--- a/src/Broiler.Cli.Tests/ApiBaselines/Broiler.HtmlBridge.Core.PublicApi.txt
+++ b/src/Broiler.Cli.Tests/ApiBaselines/Broiler.HtmlBridge.Core.PublicApi.txt
@@ -70,6 +70,27 @@ TYPE Broiler.HtmlBridge.Scripting.MicroTaskQueue
   method System.Collections.Generic.IReadOnlyList<System.Exception> Drain()
   method System.Void Enqueue(System.Action)
   property System.Int32 Count { get; }
+TYPE Broiler.HtmlBridge.Scripting.ModuleMap
+  ctor ()
+  method System.Boolean TryGet(System.String, ref Broiler.HtmlBridge.Scripting.ModuleMapEntry)
+  property System.Collections.Generic.IReadOnlyList<Broiler.HtmlBridge.Scripting.ModuleMapEntry> Entries { get; }
+  property System.Int32 Count { get; }
+TYPE Broiler.HtmlBridge.Scripting.ModuleMapEntry : System.IEquatable<Broiler.HtmlBridge.Scripting.ModuleMapEntry>
+  ctor (System.Int32, Broiler.HtmlBridge.Scripting.ScriptSourceKind, System.String, System.String, System.String, System.Boolean)
+  method Broiler.HtmlBridge.Scripting.ModuleMapEntry <Clone>$()
+  method System.Boolean Equals(Broiler.HtmlBridge.Scripting.ModuleMapEntry)
+  method System.Boolean Equals(System.Object)
+  method System.Int32 GetHashCode()
+  method System.String ToString()
+  method System.Void Deconstruct(ref System.Int32, ref Broiler.HtmlBridge.Scripting.ScriptSourceKind, ref System.String, ref System.String, ref System.String, ref System.Boolean)
+  property Broiler.HtmlBridge.Scripting.ScriptSourceKind Kind { get; set; }
+  property System.Boolean IsExecutable { get; set; }
+  property System.Int32 DocumentOrder { get; set; }
+  property System.String Key { get; set; }
+  property System.String Source { get; set; }
+  property System.String Url { get; set; }
+TYPE Broiler.HtmlBridge.Scripting.ModuleScriptWrapper
+  method System.String WrapInlineModule(System.String)
 TYPE Broiler.HtmlBridge.Scripting.PageContent
   ctor (System.String, System.Collections.Generic.IReadOnlyList<System.String>, System.String, System.Collections.Generic.IReadOnlyList<System.String>)
   property System.Collections.Generic.IReadOnlyList<System.String> DeferredScripts { get; }
@@ -102,10 +123,12 @@ TYPE Broiler.HtmlBridge.Scripting.ScriptExecutionResult
   property System.Boolean Success { get; set; }
   property System.Collections.Generic.IReadOnlyList<Broiler.HtmlBridge.Scripting.ScriptError> Errors { get; set; }
 TYPE Broiler.HtmlBridge.Scripting.ScriptExtractionResult
-  ctor (System.Collections.Generic.IReadOnlyList<System.String>, System.Collections.Generic.IReadOnlyList<System.String>, System.Collections.Generic.IReadOnlyList<System.String>, System.Collections.Generic.IReadOnlyList<Broiler.HtmlBridge.Scripting.ScriptDescriptor>)
+  ctor (System.Collections.Generic.IReadOnlyList<System.String>, System.Collections.Generic.IReadOnlyList<System.String>, System.Collections.Generic.IReadOnlyList<System.String>, System.Collections.Generic.IReadOnlyList<Broiler.HtmlBridge.Scripting.ScriptDescriptor>, System.Collections.Generic.IReadOnlyList<System.String>, Broiler.HtmlBridge.Scripting.ModuleMap)
+  property Broiler.HtmlBridge.Scripting.ModuleMap ModuleMap { get; }
   property System.Collections.Generic.IReadOnlyList<Broiler.HtmlBridge.Scripting.ScriptDescriptor> Descriptors { get; }
   property System.Collections.Generic.IReadOnlyList<System.String> AsyncScripts { get; }
   property System.Collections.Generic.IReadOnlyList<System.String> DeferredScripts { get; }
+  property System.Collections.Generic.IReadOnlyList<System.String> ModuleScripts { get; }
   property System.Collections.Generic.IReadOnlyList<System.String> Scripts { get; }
 TYPE Broiler.HtmlBridge.Scripting.ScriptProfilingHook
   ctor ()

--- a/src/Broiler.Cli.Tests/ContentSecurityPolicyTests.cs
+++ b/src/Broiler.Cli.Tests/ContentSecurityPolicyTests.cs
@@ -1,6 +1,8 @@
 using System.Security.Cryptography;
 using System.Text;
 using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Scripting;
+using Broiler.JavaScript.Engine;
 
 namespace Broiler.Cli.Tests;
 
@@ -383,6 +385,44 @@ public class ContentSecurityPolicyTests
 
         Assert.DoesNotContain("background: green", result);
         Assert.DoesNotContain("<style", result);
+    }
+
+    // --- Phase 7 item 5: style CSP is a host decision enforced during Attach ----
+
+    [Fact]
+    public void Attach_Enforces_Style_Csp_On_The_Bridge_Itself()
+    {
+        // The bridge authorises styles as the final step of Attach when a policy is configured, so every
+        // host path — including ScriptEngine.Execute, which never called ApplyStyleContentSecurityPolicy —
+        // hands scripts/rendering a CSP-authorised DOM, not just the CLI/WPT hosts.
+        const string html = """
+            <!DOCTYPE html>
+            <html>
+            <head><meta http-equiv="Content-Security-Policy" content="style-src 'none'"></head>
+            <body style="background: green"></body>
+            </html>
+            """;
+
+        using var ctx = new JSContext();
+        using var bridge = new DomBridge();
+        bridge.Csp = ContentSecurityPolicy.FromHtml(html);
+        bridge.Attach(ctx, html, "file:///t.html");
+
+        Assert.DoesNotContain("background: green", bridge.SerializeToHtml());
+    }
+
+    [Fact]
+    public void Attach_Leaves_Inline_Style_When_No_Csp_Configured()
+    {
+        const string html = """
+            <!DOCTYPE html><html><head></head><body style="background: green"></body></html>
+            """;
+
+        using var ctx = new JSContext();
+        using var bridge = new DomBridge();
+        bridge.Attach(ctx, html, "file:///t.html"); // no policy configured → nothing stripped
+
+        Assert.Contains("background: green", bridge.SerializeToHtml());
     }
 
     [Fact]

--- a/src/Broiler.Cli.Tests/CspMetaDiscoveryTests.cs
+++ b/src/Broiler.Cli.Tests/CspMetaDiscoveryTests.cs
@@ -59,4 +59,35 @@ public sealed class CspMetaDiscoveryTests
     {
         Assert.Null(CspMetaDiscovery.FindPolicyContent(html!));
     }
+
+    // ── Phase 7 item 2: parser-backed discovery (Broiler.Dom.Html tokenizer) ──
+
+    [Fact]
+    public void Ignores_A_Csp_Meta_Inside_An_Html_Comment()
+    {
+        // The former regex scan matched <meta> anywhere in the string, including inside a comment; the
+        // tokenizer only sees real start tags, so a commented-out policy is correctly not discovered.
+        const string html =
+            "<head><!-- <meta http-equiv=\"Content-Security-Policy\" content=\"script-src 'none'\"> --></head>";
+        Assert.Null(CspMetaDiscovery.FindPolicyContent(html));
+    }
+
+    [Fact]
+    public void Ignores_A_Csp_Meta_Written_As_Text_Inside_A_Script_Body()
+    {
+        // <script> is a raw-text element: a meta literal inside it is script text, not a document meta.
+        const string html =
+            "<script>var s = '<meta http-equiv=\"Content-Security-Policy\" content=\"script-src http://evil\">';</script>";
+        Assert.Null(CspMetaDiscovery.FindPolicyContent(html));
+    }
+
+    [Fact]
+    public void Does_Not_Truncate_A_Content_Value_Containing_A_Greater_Than_Sign()
+    {
+        // The old <meta[^>]*> regex stopped at the first '>', truncating a policy whose value contained
+        // one; the tokenizer honours the quotes and returns the whole directive string.
+        const string html =
+            "<meta http-equiv=\"Content-Security-Policy\" content=\"script-src 'self'; report-uri /r?a=1&b=2>x\">";
+        Assert.Equal("script-src 'self'; report-uri /r?a=1&b=2>x", CspMetaDiscovery.FindPolicyContent(html));
+    }
 }

--- a/src/Broiler.Cli.Tests/ModuleScriptSliceTests.cs
+++ b/src/Broiler.Cli.Tests/ModuleScriptSliceTests.cs
@@ -40,8 +40,9 @@ public sealed class ModuleScriptSliceTests
     }
 
     [Fact]
-    public void External_Module_Is_Mapped_But_Not_Executable_In_This_Slice()
+    public void External_Module_With_Unresolvable_Url_Is_Mapped_But_Not_Executable()
     {
+        // No page URL → the relative src cannot be resolved/fetched → mapped but not executable.
         const string html = "<script type=\"module\" src=\"app.mjs\"></script>";
         var result = ScriptExtractionService.ExtractAll(html);
 
@@ -53,6 +54,73 @@ public sealed class ModuleScriptSliceTests
         Assert.Null(entry.Source);
         Assert.Equal("app.mjs", entry.Url);
         Assert.Equal("app.mjs", entry.Key);
+    }
+
+    [Fact]
+    public void DataUri_Module_Is_Decoded_And_Executable()
+    {
+        // Phase 7 item 6 slice 2: a data: URI module is decoded through the same path as a classic data script.
+        const string html = "<script type=\"module\" src=\"data:text/javascript,globalThis.y%20%3D%202%3B\"></script>";
+        var result = ScriptExtractionService.ExtractAll(html);
+
+        Assert.Single(result.ModuleScripts);
+        Assert.Contains("globalThis.y = 2;", result.ModuleScripts[0]);
+        var entry = result.ModuleMap.Entries[0];
+        Assert.Equal(ScriptSourceKind.DataUri, entry.Kind);
+        Assert.True(entry.IsExecutable);
+        Assert.Equal("globalThis.y = 2;", entry.Source);
+    }
+
+    [Fact]
+    public void External_File_Module_Is_Fetched_And_Executable()
+    {
+        // Phase 7 item 6 slice 2: an external module resolvable to a local file is fetched and executable.
+        var dir = Path.Combine(Path.GetTempPath(), $"broiler-mod-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var modPath = Path.Combine(dir, "m.mjs");
+        File.WriteAllText(modPath, "globalThis.z = 3;");
+        try
+        {
+            var pageUrl = new Uri(Path.Combine(dir, "index.html")).AbsoluteUri;
+            var result = ScriptExtractionService.ExtractAll("<script type=\"module\" src=\"m.mjs\"></script>", pageUrl);
+
+            Assert.Single(result.ModuleScripts);
+            Assert.Contains("globalThis.z = 3;", result.ModuleScripts[0]);
+            var entry = result.ModuleMap.Entries[0];
+            Assert.Equal(ScriptSourceKind.External, entry.Kind);
+            Assert.True(entry.IsExecutable);
+            Assert.Equal("globalThis.z = 3;", entry.Source);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Repeated_Module_Url_Is_Fetched_And_Executed_Once_Module_Map_Dedup()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"broiler-mod-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "m.mjs"), "globalThis.z = 3;");
+        try
+        {
+            var pageUrl = new Uri(Path.Combine(dir, "index.html")).AbsoluteUri;
+            const string html =
+                "<script type=\"module\" src=\"m.mjs\"></script>" +
+                "<script type=\"module\" src=\"m.mjs\"></script>";
+            var result = ScriptExtractionService.ExtractAll(html, pageUrl);
+
+            // The module map holds the URL once and it is queued for execution once (evaluated once) ...
+            Assert.Single(result.ModuleScripts);
+            Assert.Equal(1, result.ModuleMap.Count);
+            // ... though both occurrences are still recorded in the per-element descriptor list.
+            Assert.Equal(2, result.Descriptors.Count(d => d.IsModule));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
     }
 
     [Fact]

--- a/src/Broiler.Cli.Tests/ModuleScriptSliceTests.cs
+++ b/src/Broiler.Cli.Tests/ModuleScriptSliceTests.cs
@@ -1,0 +1,106 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Scripting;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Phase 7 item 6 (first slice): the browser module map and inline-module execution. Covers
+/// <see cref="ScriptExtractionService.ExtractAll"/> populating <see cref="ModuleMap"/> /
+/// <see cref="ScriptExtractionResult.ModuleScripts"/>, and the module top-level semantics that
+/// <see cref="ModuleScriptWrapper.WrapInlineModule"/> reproduces for an import-free module.
+/// </summary>
+public sealed class ModuleScriptSliceTests
+{
+    [Fact]
+    public void Inline_Module_Is_Recorded_Executable_And_Wrapped()
+    {
+        const string html =
+            "<script>var a=1;</script>" +
+            "<script type=\"module\">globalThis.x = 1;</script>";
+        var result = ScriptExtractionService.ExtractAll(html);
+
+        // The inline module is executable (wrapped for module semantics) and mapped ...
+        Assert.Single(result.ModuleScripts);
+        Assert.Contains("use strict", result.ModuleScripts[0]);
+        Assert.Contains("globalThis.x = 1;", result.ModuleScripts[0]);
+
+        Assert.Equal(1, result.ModuleMap.Count);
+        var entry = result.ModuleMap.Entries[0];
+        Assert.Equal(ScriptSourceKind.Inline, entry.Kind);
+        Assert.True(entry.IsExecutable);
+        Assert.Equal("globalThis.x = 1;", entry.Source);
+        Assert.True(result.ModuleMap.TryGet(entry.Key, out var looked));
+        Assert.Equal(entry, looked);
+
+        // ... and the classic buckets/descriptors are unchanged (module stays out of Scripts).
+        Assert.Single(result.Scripts);
+        Assert.Contains("var a=1;", result.Scripts);
+        Assert.DoesNotContain(result.Scripts, s => s.Contains("globalThis"));
+    }
+
+    [Fact]
+    public void External_Module_Is_Mapped_But_Not_Executable_In_This_Slice()
+    {
+        const string html = "<script type=\"module\" src=\"app.mjs\"></script>";
+        var result = ScriptExtractionService.ExtractAll(html);
+
+        Assert.Empty(result.ModuleScripts);
+        Assert.Equal(1, result.ModuleMap.Count);
+        var entry = result.ModuleMap.Entries[0];
+        Assert.Equal(ScriptSourceKind.External, entry.Kind);
+        Assert.False(entry.IsExecutable);
+        Assert.Null(entry.Source);
+        Assert.Equal("app.mjs", entry.Url);
+        Assert.Equal("app.mjs", entry.Key);
+    }
+
+    [Fact]
+    public void Csp_Blocked_Inline_Module_Is_Mapped_But_Not_Executable()
+    {
+        const string html =
+            "<meta http-equiv=\"Content-Security-Policy\" content=\"script-src 'none'\">" +
+            "<script type=\"module\">globalThis.x = 1;</script>";
+        var result = ScriptExtractionService.ExtractAll(html);
+
+        Assert.Empty(result.ModuleScripts);
+        Assert.Equal(1, result.ModuleMap.Count);
+        Assert.False(result.ModuleMap.Entries[0].IsExecutable);
+        Assert.Null(result.ModuleMap.Entries[0].Source);
+    }
+
+    [Fact]
+    public void Document_With_No_Modules_Has_An_Empty_Map()
+    {
+        var result = ScriptExtractionService.ExtractAll("<script>var a=1;</script>");
+        Assert.Equal(0, result.ModuleMap.Count);
+        Assert.Empty(result.ModuleScripts);
+    }
+
+    // ── module top-level semantics reproduced by the wrapper ──
+
+    [Fact]
+    public void Wrapped_Module_Runs_Its_Body()
+    {
+        using var ctx = new JSContext();
+        ctx.Eval(ModuleScriptWrapper.WrapInlineModule("globalThis.__ran = 7;"));
+        Assert.Equal("7", ctx.Eval("globalThis.__ran").ToString());
+    }
+
+    [Fact]
+    public void Wrapped_Module_Top_Level_Declarations_Do_Not_Leak_To_Global()
+    {
+        using var ctx = new JSContext();
+        ctx.Eval(ModuleScriptWrapper.WrapInlineModule("var leaked = 42; function f() {}"));
+        Assert.Equal("undefined", ctx.Eval("typeof leaked").ToString());
+        Assert.Equal("undefined", ctx.Eval("typeof f").ToString());
+    }
+
+    [Fact]
+    public void Wrapped_Module_Top_Level_This_Is_Undefined_Strict()
+    {
+        using var ctx = new JSContext();
+        ctx.Eval(ModuleScriptWrapper.WrapInlineModule("globalThis.__thisUndef = (this === undefined);"));
+        Assert.Equal("true", ctx.Eval("globalThis.__thisUndef").ToString());
+    }
+}

--- a/src/Broiler.Cli.Tests/ResourceLoaderTests.cs
+++ b/src/Broiler.Cli.Tests/ResourceLoaderTests.cs
@@ -49,6 +49,46 @@ public sealed class ResourceLoaderTests
     }
 
     [Fact]
+    public void LoadLocalResource_Reads_Text_Returns_Null_For_Missing_And_Skips_Binary()
+    {
+        // Phase 7 item 4 (P7.8): the sub-resource file existence + binary/text read policy lives in the
+        // loader. Deterministic (no network).
+        var loader = new ResourceLoader();
+
+        var textPath = Path.Combine(Path.GetTempPath(), $"broiler-local-{Guid.NewGuid():N}.html");
+        File.WriteAllText(textPath, "<p>hi</p>");
+        try
+        {
+            // Text content type → (content, extensionMime).
+            Assert.Equal(("<p>hi</p>", "text/html"), loader.LoadLocalResource(textPath, "text/html"));
+
+            // Binary content type → bytes not decoded to text, but MIME preserved.
+            Assert.Equal(((string?)null, "image/png"), loader.LoadLocalResource(textPath, "image/png"));
+        }
+        finally
+        {
+            File.Delete(textPath);
+        }
+
+        // Missing file → (null, "") — an empty document, not a fetch failure.
+        var missing = Path.Combine(Path.GetTempPath(), $"broiler-missing-{Guid.NewGuid():N}.html");
+        Assert.Equal(((string?)null, ""), loader.LoadLocalResource(missing, "text/html"));
+    }
+
+    [Theory]
+    [InlineData("image/png", true)]
+    [InlineData("font/woff2", true)]
+    [InlineData("audio/mpeg", true)]
+    [InlineData("video/mp4", true)]
+    [InlineData("application/pdf", true)]
+    [InlineData("text/html", false)]
+    [InlineData("application/xhtml+xml", false)]
+    [InlineData("application/octet-stream", false)]
+    [InlineData("", false)]
+    public void IsBinaryMime_Classifies_Content_Types(string mime, bool expected)
+        => Assert.Equal(expected, ResourceLoader.IsBinaryMime(mime));
+
+    [Fact]
     public void Bridge_SetLocalBasePath_Does_Not_Throw_And_Attach_Still_Works()
     {
         // Characterization: SetLocalBasePath now configures the loader; a subsequent attach + query

--- a/src/Broiler.Cli/CaptureService.cs
+++ b/src/Broiler.Cli/CaptureService.cs
@@ -505,11 +505,10 @@ public class CaptureService
         var bridge = new DomBridge();
         bridge.Csp = csp;
         bridge.TaskCheckpointCallback = () => microTasks.Drain();
+        // Attach enforces the CSP style-src family on the parsed DOM itself (it runs
+        // when bridge.Csp is set), so blocked inline style attributes / <style> elements
+        // neither apply nor render — no separate ApplyStyleContentSecurityPolicy call needed.
         bridge.Attach(context, html, url);
-
-        // Enforce the CSP style-src family on the parsed DOM so blocked inline
-        // style attributes / <style> elements neither apply nor render.
-        bridge.ApplyStyleContentSecurityPolicy(csp);
 
         // Set local base path for sub-resource resolution (e.g. iframe src)
         if (!string.IsNullOrEmpty(localResourceBasePath))

--- a/src/Broiler.HtmlBridge.Core/Broiler.HtmlBridge.Core.csproj
+++ b/src/Broiler.HtmlBridge.Core/Broiler.HtmlBridge.Core.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Broiler.DOM\Broiler.Dom\Broiler.Dom.csproj" />
+    <ProjectReference Include="..\..\Broiler.DOM\Broiler.Dom.Html\Broiler.Dom.Html.csproj" />
     <ProjectReference Include="..\..\Broiler.JS\Broiler.JS\Broiler.JavaScript.Engine\Broiler.JavaScript.Engine.csproj" />
   </ItemGroup>
 

--- a/src/Broiler.HtmlBridge.Core/Scripting/CspMetaDiscovery.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/CspMetaDiscovery.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.RegularExpressions;
+using Broiler.Dom.Html;
 
 namespace Broiler.HtmlBridge.Scripting;
 
@@ -33,13 +34,13 @@ internal static class HtmlAttributeReader
 /// "what does it allow" (Phase 7 item 1: split parse / discovery / policy).
 /// </summary>
 /// <remarks>
-/// Discovery is currently a regex scan of the serialized HTML; Phase 7 item 2 replaces it with
-/// <c>Broiler.Dom.Html</c> parser output. Keeping it behind this single method localises that swap.
+/// Discovery is <c>Broiler.Dom.Html</c> parser output (Phase 7 item 2): the shared
+/// <see cref="HtmlTokenizer"/> enumerates start tags, so — unlike the former regex scan — a
+/// <c>&lt;meta&gt;</c> inside a comment or a <c>&lt;script&gt;</c>/<c>&lt;style&gt;</c> raw-text body is
+/// correctly ignored, and a <c>&gt;</c> inside a quoted attribute value no longer truncates the tag.
 /// </remarks>
-public static partial class CspMetaDiscovery
+public static class CspMetaDiscovery
 {
-    private static readonly Regex MetaPattern = MetaPatternRegex();
-
     /// <summary>
     /// Returns the directive string (the <c>content</c> value) of the first supported CSP
     /// <c>&lt;meta&gt;</c> tag in <paramref name="html"/>, or <c>null</c> when none is present.
@@ -50,21 +51,21 @@ public static partial class CspMetaDiscovery
         if (string.IsNullOrWhiteSpace(html))
             return null;
 
-        foreach (Match match in MetaPattern.Matches(html))
+        foreach (var token in new HtmlTokenizer().Tokenize(html))
         {
-            var attrs = match.Groups["attrs"].Value;
-            var httpEquiv = HtmlAttributeReader.ExtractAttributeValue(attrs, "http-equiv");
-            if (!string.Equals(httpEquiv, "Content-Security-Policy", StringComparison.OrdinalIgnoreCase))
+            if (token.Type != TokenType.StartTag ||
+                !string.Equals(token.Name, "meta", StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            var content = HtmlAttributeReader.ExtractAttributeValue(attrs, "content");
-            if (!string.IsNullOrWhiteSpace(content))
+            if (!token.Attributes.TryGetValue("http-equiv", out var httpEquiv) ||
+                !string.Equals(httpEquiv, "Content-Security-Policy", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (token.Attributes.TryGetValue("content", out var content) &&
+                !string.IsNullOrWhiteSpace(content))
                 return content;
         }
 
         return null;
     }
-
-    [GeneratedRegex(@"<meta(?<attrs>[^>]*)>", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-    private static partial Regex MetaPatternRegex();
 }

--- a/src/Broiler.HtmlBridge.Core/Scripting/IScriptExtractor.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/IScriptExtractor.cs
@@ -33,6 +33,49 @@ public sealed record ScriptDescriptor(
     string Content);
 
 /// <summary>
+/// One entry in a document's <see cref="ModuleMap"/> (Phase 7 item 6): a recognised
+/// <c>&lt;script type="module"&gt;</c> keyed for the browser module system. Inline modules are keyed by a
+/// synthetic <c>inline:{order}</c> id and carry their authorised body in <see cref="Source"/>; module
+/// scripts with a <c>src</c> are recorded with their URL but not yet fetched (a later slice loads them),
+/// so their <see cref="Source"/> is <c>null</c> and <see cref="IsExecutable"/> is <c>false</c>.
+/// </summary>
+public sealed record ModuleMapEntry(
+    int DocumentOrder,
+    ScriptSourceKind Kind,
+    string Key,
+    string? Url,
+    string? Source,
+    bool IsExecutable);
+
+/// <summary>
+/// The document's module map (Phase 7 item 6, first slice): the registry of recognised
+/// <c>&lt;script type="module"&gt;</c> elements in document order, so a module is no longer silently
+/// dropped. Inline modules are executable now; external/data-URI module loading (fetch + import graph) is
+/// a later slice. Keyed by <see cref="ModuleMapEntry.Key"/> (an inline module's synthetic id or an
+/// external module's URL).
+/// </summary>
+public sealed class ModuleMap
+{
+    private readonly List<ModuleMapEntry> _entries = [];
+    private readonly Dictionary<string, ModuleMapEntry> _byKey = new(System.StringComparer.Ordinal);
+
+    /// <summary>The module entries in document order.</summary>
+    public IReadOnlyList<ModuleMapEntry> Entries => _entries;
+
+    /// <summary>Number of recognised module scripts.</summary>
+    public int Count => _entries.Count;
+
+    /// <summary>Looks up a module entry by its <see cref="ModuleMapEntry.Key"/>.</summary>
+    public bool TryGet(string key, out ModuleMapEntry? entry) => _byKey.TryGetValue(key, out entry);
+
+    internal void Add(ModuleMapEntry entry)
+    {
+        _entries.Add(entry);
+        _byKey[entry.Key] = entry;
+    }
+}
+
+/// <summary>
 /// Holds the result of extracting all scripts from an HTML page,
 /// separated into regular (inline / data-URI / external), deferred,
 /// and async scripts so that the engine can execute them in the correct order.
@@ -41,7 +84,9 @@ public sealed class ScriptExtractionResult(
     IReadOnlyList<string> scripts,
     IReadOnlyList<string> deferredScripts,
     IReadOnlyList<string> asyncScripts,
-    IReadOnlyList<ScriptDescriptor>? descriptors = null)
+    IReadOnlyList<ScriptDescriptor>? descriptors = null,
+    IReadOnlyList<string>? moduleScripts = null,
+    ModuleMap? moduleMap = null)
 {
     /// <summary>Regular scripts to execute in document order.</summary>
     public IReadOnlyList<string> Scripts { get; } = scripts;
@@ -59,4 +104,16 @@ public sealed class ScriptExtractionResult(
     /// this exposes the metadata that used to be computed and discarded.
     /// </summary>
     public IReadOnlyList<ScriptDescriptor> Descriptors { get; } = descriptors ?? [];
+
+    /// <summary>
+    /// Executable inline module bodies (Phase 7 item 6, first slice), in document order, each already
+    /// wrapped for module top-level semantics (strict mode, own scope) by
+    /// <see cref="ModuleScriptWrapper.WrapInlineModule"/>. Module scripts are deferred, so a consumer runs
+    /// these after the classic <see cref="DeferredScripts"/>. External/data-URI module loading is a later
+    /// slice, so those modules appear only in <see cref="ModuleMap"/>, not here.
+    /// </summary>
+    public IReadOnlyList<string> ModuleScripts { get; } = moduleScripts ?? [];
+
+    /// <summary>The document's module map (Phase 7 item 6): every recognised module in document order.</summary>
+    public ModuleMap ModuleMap { get; } = moduleMap ?? new ModuleMap();
 }

--- a/src/Broiler.HtmlBridge.Core/Scripting/ModuleScriptWrapper.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/ModuleScriptWrapper.cs
@@ -1,0 +1,22 @@
+namespace Broiler.HtmlBridge.Scripting;
+
+/// <summary>
+/// Wraps an inline <c>&lt;script type="module"&gt;</c> body so a plain-script evaluator runs it with the
+/// module top-level semantics that matter for an import-free module (Phase 7 item 6, first slice): module
+/// code is always strict, and its top-level declarations live in the module scope rather than leaking to
+/// the global object. A strict immediately-invoked function expression reproduces both: <c>"use strict"</c>
+/// applies, top-level <c>var</c>/<c>let</c>/<c>const</c>/<c>function</c> stay local, and the top-level
+/// <c>this</c> is <c>undefined</c> (a strict function invoked without a receiver) as in a module.
+/// </summary>
+/// <remarks>
+/// This is deliberately a first slice: it does not provide <c>import</c>/<c>export</c>, <c>import.meta</c>
+/// or top-level <c>await</c>. A wrapped module that uses those raises a syntax/runtime error at execution
+/// (surfaced to the caller's logger) rather than being silently skipped — full module-graph loading is a
+/// later slice.
+/// </remarks>
+public static class ModuleScriptWrapper
+{
+    /// <summary>Returns <paramref name="body"/> wrapped as a strict, self-scoped module IIFE.</summary>
+    public static string WrapInlineModule(string body) =>
+        "(function () { \"use strict\";\n" + body + "\n})();";
+}

--- a/src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs
@@ -137,6 +137,8 @@ public static partial class ScriptExtractionService
         var deferredScripts = new List<string>();
         var asyncScripts = new List<string>();
         var descriptors = new List<ScriptDescriptor>();
+        var moduleScripts = new List<string>();
+        var moduleMap = new ModuleMap();
         var csp = ContentSecurityPolicy.FromHtml(html);
 
         var documentOrder = 0;
@@ -152,6 +154,26 @@ public static partial class ScriptExtractionService
                 : src.StartsWith("data:", StringComparison.OrdinalIgnoreCase) ? ScriptSourceKind.DataUri
                 : ScriptSourceKind.External;
             var url = kind == ScriptSourceKind.Inline ? null : src;
+
+            // Phase 7 item 6 (first slice): record every recognised module in the module map so it is not
+            // silently dropped, and make an authorised inline module executable with module semantics. The
+            // classic execution buckets/descriptors below are unchanged (modules stay out of them).
+            if (isModule)
+            {
+                string? moduleSource = null;
+                if (kind == ScriptSourceKind.Inline)
+                {
+                    var moduleBody = tag.RawContent.Trim();
+                    if (!string.IsNullOrEmpty(moduleBody) && (csp == null || csp.AllowsInlineScript(nonce, moduleBody)))
+                    {
+                        moduleSource = moduleBody;
+                        moduleScripts.Add(ModuleScriptWrapper.WrapInlineModule(moduleBody));
+                    }
+                }
+
+                var moduleKey = kind == ScriptSourceKind.Inline ? $"inline:{documentOrder}" : url ?? $"module:{documentOrder}";
+                moduleMap.Add(new ModuleMapEntry(documentOrder, kind, moduleKey, url, moduleSource, IsExecutable: moduleSource != null));
+            }
 
             // Resolve the program text for the classic execution buckets. Module scripts are recorded in
             // the descriptor list but omitted from execution here (item 6 wires them into the event loop).
@@ -204,7 +226,7 @@ public static partial class ScriptExtractionService
                 scripts.Add(scriptContent);
         }
 
-        return new ScriptExtractionResult(scripts, deferredScripts, asyncScripts, descriptors);
+        return new ScriptExtractionResult(scripts, deferredScripts, asyncScripts, descriptors, moduleScripts, moduleMap);
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs
@@ -87,6 +87,37 @@ public static partial class ScriptExtractionService
     private static string? GetSrc(IReadOnlyDictionary<string, string> attrs) =>
         attrs.TryGetValue("src", out var src) && !string.IsNullOrEmpty(src) ? src : null;
 
+    /// <summary>
+    /// Resolves an authorised module's program text (Phase 7 item 6), by the same rules a classic script
+    /// uses: an inline body must pass the CSP inline check; a <c>data:</c>/external source must pass the CSP
+    /// external check, then is decoded / fetched. Returns <c>null</c> when blocked, empty, or unresolvable.
+    /// </summary>
+    private static string? ResolveModuleSource(
+        ScriptSourceKind kind, string? url, string rawContent, string? nonce, ContentSecurityPolicy? csp, string? pageUrl)
+    {
+        switch (kind)
+        {
+            case ScriptSourceKind.Inline:
+                var body = rawContent.Trim();
+                return !string.IsNullOrEmpty(body) && (csp == null || csp.AllowsInlineScript(nonce, body)) ? body : null;
+
+            case ScriptSourceKind.DataUri:
+                if (csp != null && !csp.AllowsExternalScript(url!, pageUrl, nonce))
+                    return null;
+                var decoded = DecodeDataUri(url!);
+                return string.IsNullOrEmpty(decoded) ? null : decoded;
+
+            case ScriptSourceKind.External:
+                if (csp != null && !csp.AllowsExternalScript(url!, pageUrl, nonce))
+                    return null;
+                var fetched = FetchExternalScript(url!, pageUrl);
+                return string.IsNullOrEmpty(fetched) ? null : fetched;
+
+            default:
+                return null;
+        }
+    }
+
     /// <inheritdoc />
     public static IReadOnlyList<string> Extract(string html)
     {
@@ -155,24 +186,24 @@ public static partial class ScriptExtractionService
                 : ScriptSourceKind.External;
             var url = kind == ScriptSourceKind.Inline ? null : src;
 
-            // Phase 7 item 6 (first slice): record every recognised module in the module map so it is not
-            // silently dropped, and make an authorised inline module executable with module semantics. The
-            // classic execution buckets/descriptors below are unchanged (modules stay out of them).
+            // Phase 7 item 6: record every recognised module in the module map so it is not silently
+            // dropped, and make an authorised module executable with module semantics. Inline bodies
+            // (slice 1) plus data:/external sources (slice 2) are resolved through the same authorised
+            // decode/fetch path as classic scripts. The classic buckets/descriptors below are unchanged
+            // (modules stay out of them).
             if (isModule)
             {
-                string? moduleSource = null;
-                if (kind == ScriptSourceKind.Inline)
-                {
-                    var moduleBody = tag.RawContent.Trim();
-                    if (!string.IsNullOrEmpty(moduleBody) && (csp == null || csp.AllowsInlineScript(nonce, moduleBody)))
-                    {
-                        moduleSource = moduleBody;
-                        moduleScripts.Add(ModuleScriptWrapper.WrapInlineModule(moduleBody));
-                    }
-                }
-
                 var moduleKey = kind == ScriptSourceKind.Inline ? $"inline:{documentOrder}" : url ?? $"module:{documentOrder}";
-                moduleMap.Add(new ModuleMapEntry(documentOrder, kind, moduleKey, url, moduleSource, IsExecutable: moduleSource != null));
+
+                // Module-map dedup: a module URL is fetched and evaluated once. Inline modules get a unique
+                // per-occurrence key, so they never dedup; a repeated src module is recorded once.
+                if (kind == ScriptSourceKind.Inline || !moduleMap.TryGet(moduleKey, out _))
+                {
+                    var moduleSource = ResolveModuleSource(kind, url, tag.RawContent, nonce, csp, pageUrl);
+                    if (moduleSource != null)
+                        moduleScripts.Add(ModuleScriptWrapper.WrapInlineModule(moduleSource));
+                    moduleMap.Add(new ModuleMapEntry(documentOrder, kind, moduleKey, url, moduleSource, IsExecutable: moduleSource != null));
+                }
             }
 
             // Resolve the program text for the classic execution buckets. Module scripts are recorded in

--- a/src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs
@@ -1,3 +1,4 @@
+using Broiler.Dom.Html;
 using Broiler.HtmlBridge.Logging;
 using Broiler.HtmlBridge.Scripting;
 using System;
@@ -10,44 +11,20 @@ using System.Text.RegularExpressions;
 namespace Broiler.HtmlBridge;
 
 /// <summary>
-/// Extracts the contents of <c>&lt;script&gt;</c> tags from HTML using a
-/// regular expression.  Inline scripts and <c>data:</c> URI scripts are
-/// returned; external <c>src</c> references (http/https/file) are skipped
-/// by <see cref="Extract"/> but resolved and fetched by <see cref="ExtractAll"/>.
+/// Extracts the contents of <c>&lt;script&gt;</c> tags from HTML using the shared
+/// <c>Broiler.Dom.Html</c> tokenizer (Phase 7 item 2).  Inline scripts and <c>data:</c> URI scripts are
+/// returned; external <c>src</c> references (http/https/file) are skipped by <see cref="Extract"/> but
+/// resolved and fetched by <see cref="ExtractAll"/>.
 /// </summary>
+/// <remarks>
+/// Discovery is parser-backed: the tokenizer treats <c>&lt;script&gt;</c> as a raw-text element, so a
+/// <c>&lt;script&gt;</c> literal inside a comment or another element's text is not discovered, a
+/// <c>&gt;</c> inside a quoted attribute no longer truncates the start tag, and attribute flags are read
+/// from the parsed (lower-cased) attribute map rather than a per-tag regex. Script body text is taken
+/// verbatim (raw text is never entity-decoded), so authorised inline/data-URI program text is unchanged.
+/// </remarks>
 public static partial class ScriptExtractionService
 {
-    // Match ALL <script> tags (both inline and with src attributes) in document order.
-    private static readonly Regex AnyScriptPattern = AnyScriptPatternRegex();
-
-    // Match src attribute whose value starts with "data:"
-    private static readonly Regex DataSrcAttrPattern = DataSrcAttrPatternRegex();
-
-    // Match any src attribute (to detect and skip external scripts)
-    private static readonly Regex AnySrcAttrPattern = AnySrcAttrPatternRegex();
-
-    /// <summary>
-    /// Matches any <c>src</c> attribute value (not just <c>data:</c> URIs).
-    /// Used to extract external script URLs for HTTP/HTTPS/file loading.
-    /// </summary>
-    private static readonly Regex AnySrcAttrWithValuePattern = AnySrcAttrWithValuePatternRegex();
-
-    /// <summary>
-    /// Matches the <c>defer</c> attribute on a script tag (standalone or with a value).
-    /// </summary>
-    private static readonly Regex DeferAttrPattern = DeferAttrPatternRegex();
-
-    /// <summary>
-    /// Matches the <c>async</c> attribute on a script tag (standalone or with a value).
-    /// </summary>
-    private static readonly Regex AsyncAttrPattern = AsyncAttrPatternRegex();
-
-    // Match <script type="module"> tags (inline only, no src)
-    private static readonly Regex ModuleScriptPattern = ModuleScriptPatternRegex();
-
-    // Match the type="module" attribute on a script tag
-    private static readonly Regex ModuleTypeAttribute = ModuleTypeModuleTypeAttributeRegex();
-
     private static readonly Regex WhitespacePattern = WhitespacePatternRegex();
 
     /// <summary>
@@ -58,40 +35,92 @@ public static partial class ScriptExtractionService
     /// </summary>
     private static readonly HttpClient SharedHttpClient = new() { Timeout = TimeSpan.FromSeconds(30) };
 
+    /// <summary>One discovered <c>&lt;script&gt;</c>: its parsed attributes and its raw body text.</summary>
+    private readonly record struct ScriptTagInfo(IReadOnlyDictionary<string, string> Attributes, string RawContent);
+
+    /// <summary>
+    /// Enumerates every <c>&lt;script&gt;</c> element in document order via the shared tokenizer, pairing
+    /// each start tag with its raw (never entity-decoded) body text. Because <c>&lt;script&gt;</c> is a
+    /// raw-text element, a start tag is followed by its character content and then its end tag; an
+    /// unterminated final script yields its content to end-of-input (matching parser behaviour).
+    /// </summary>
+    private static IEnumerable<ScriptTagInfo> EnumerateScriptTags(string html)
+    {
+        HtmlToken? open = null;
+        var content = new StringBuilder();
+
+        foreach (var token in new HtmlTokenizer().Tokenize(html))
+        {
+            if (open != null)
+            {
+                if (token.Type == TokenType.Character)
+                {
+                    content.Append(token.Data);
+                    continue;
+                }
+
+                // Any non-character token (the </script> end tag) closes the current script.
+                yield return new ScriptTagInfo(open.Attributes, content.ToString());
+                open = null;
+                content.Clear();
+            }
+
+            if (token.Type == TokenType.StartTag &&
+                string.Equals(token.Name, "script", StringComparison.OrdinalIgnoreCase))
+            {
+                open = token;
+                content.Clear();
+            }
+        }
+
+        if (open != null)
+            yield return new ScriptTagInfo(open.Attributes, content.ToString());
+    }
+
+    private static string? GetNonce(IReadOnlyDictionary<string, string> attrs) =>
+        attrs.TryGetValue("nonce", out var nonce) ? nonce : null;
+
+    private static bool IsModule(IReadOnlyDictionary<string, string> attrs) =>
+        attrs.TryGetValue("type", out var type) && string.Equals(type, "module", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>The <c>src</c> value when present and non-empty (an empty <c>src</c> is treated as no src).</summary>
+    private static string? GetSrc(IReadOnlyDictionary<string, string> attrs) =>
+        attrs.TryGetValue("src", out var src) && !string.IsNullOrEmpty(src) ? src : null;
+
     /// <inheritdoc />
     public static IReadOnlyList<string> Extract(string html)
     {
         var scripts = new List<string>();
         var csp = ContentSecurityPolicy.FromHtml(html);
 
-        foreach (Match match in AnyScriptPattern.Matches(html))
+        foreach (var tag in EnumerateScriptTags(html))
         {
-            var attrs = match.Groups["attrs"].Value;
-            var nonce = ContentSecurityPolicy.ExtractNonceFromAttributes(attrs);
+            var nonce = GetNonce(tag.Attributes);
 
             // Skip module scripts — they are extracted separately
-            if (ModuleTypeAttribute.IsMatch(attrs))
+            if (IsModule(tag.Attributes))
                 continue;
 
+            var src = GetSrc(tag.Attributes);
+
             // Check for data: URI src attribute
-            var dataSrcMatch = DataSrcAttrPattern.Match(attrs);
-            if (dataSrcMatch.Success)
+            if (src != null && src.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
             {
-                if (csp != null && !csp.AllowsExternalScript(dataSrcMatch.Groups["uri"].Value, pageUrl: null, nonce))
+                if (csp != null && !csp.AllowsExternalScript(src, pageUrl: null, nonce))
                     continue;
 
-                var decoded = DecodeDataUri(dataSrcMatch.Groups["uri"].Value);
+                var decoded = DecodeDataUri(src);
                 if (!string.IsNullOrEmpty(decoded))
                     scripts.Add(decoded);
                 continue;
             }
 
             // Skip external (non-data:) src scripts
-            if (AnySrcAttrPattern.IsMatch(attrs))
+            if (src != null)
                 continue;
 
             // Inline script
-            var content = match.Groups["content"].Value.Trim();
+            var content = tag.RawContent.Trim();
             if (!string.IsNullOrEmpty(content) && (csp == null || csp.AllowsInlineScript(nonce, content)))
             {
                 scripts.Add(content);
@@ -111,25 +140,18 @@ public static partial class ScriptExtractionService
         var csp = ContentSecurityPolicy.FromHtml(html);
 
         var documentOrder = 0;
-        foreach (Match match in AnyScriptPattern.Matches(html))
+        foreach (var tag in EnumerateScriptTags(html))
         {
-            var attrs = match.Groups["attrs"].Value;
-            var nonce = ContentSecurityPolicy.ExtractNonceFromAttributes(attrs);
-            var isModule = ModuleTypeAttribute.IsMatch(attrs);
-            var isDefer = DeferAttrPattern.IsMatch(attrs);
-            var isAsync = AsyncAttrPattern.IsMatch(attrs);
+            var nonce = GetNonce(tag.Attributes);
+            var isModule = IsModule(tag.Attributes);
+            var isDefer = tag.Attributes.ContainsKey("defer");
+            var isAsync = tag.Attributes.ContainsKey("async");
 
-            var dataSrcMatch = DataSrcAttrPattern.Match(attrs);
-            var anySrcMatch = dataSrcMatch.Success ? null : AnySrcAttrWithValuePattern.Match(attrs);
-            var kind = dataSrcMatch.Success ? ScriptSourceKind.DataUri
-                : anySrcMatch is { Success: true } ? ScriptSourceKind.External
-                : ScriptSourceKind.Inline;
-            var url = kind switch
-            {
-                ScriptSourceKind.DataUri => dataSrcMatch.Groups["uri"].Value,
-                ScriptSourceKind.External => anySrcMatch!.Groups["uri"].Value,
-                _ => null,
-            };
+            var src = GetSrc(tag.Attributes);
+            var kind = src == null ? ScriptSourceKind.Inline
+                : src.StartsWith("data:", StringComparison.OrdinalIgnoreCase) ? ScriptSourceKind.DataUri
+                : ScriptSourceKind.External;
+            var url = kind == ScriptSourceKind.Inline ? null : src;
 
             // Resolve the program text for the classic execution buckets. Module scripts are recorded in
             // the descriptor list but omitted from execution here (item 6 wires them into the event loop).
@@ -156,7 +178,7 @@ public static partial class ScriptExtractionService
                 }
                 else
                 {
-                    var content = match.Groups["content"].Value.Trim();
+                    var content = tag.RawContent.Trim();
                     if (!string.IsNullOrEmpty(content) && (csp == null || csp.AllowsInlineScript(nonce, content)))
                         scriptContent = content;
                 }
@@ -261,22 +283,6 @@ public static partial class ScriptExtractionService
         }
     }
 
-    [GeneratedRegex(@"<script(?<attrs>[^>]*)>(?<content>[\s\S]*?)</script>", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-    private static partial Regex AnyScriptPatternRegex();
-    [GeneratedRegex(@"\ssrc\s*=\s*(?:""(?<uri>data:[^""]+)""|'(?<uri>data:[^']+)'|(?<uri>data:[^\s>]+))", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-    private static partial Regex DataSrcAttrPatternRegex();
-    [GeneratedRegex(@"\ssrc\s*=", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-    private static partial Regex AnySrcAttrPatternRegex();
-    [GeneratedRegex(@"\ssrc\s*=\s*(?:""(?<uri>[^""]+)""|'(?<uri>[^']+)'|(?<uri>[^\s>]+))", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-    private static partial Regex AnySrcAttrWithValuePatternRegex();
-    [GeneratedRegex(@"(?:^|\s)defer(?:\s|$|=)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-    private static partial Regex DeferAttrPatternRegex();
-    [GeneratedRegex(@"(?:^|\s)async(?:\s|$|=)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-    private static partial Regex AsyncAttrPatternRegex();
-    [GeneratedRegex(@"<script\s[^>]*type\s*=\s*[""']module[""'][^>]*>(?<content>[\s\S]*?)</script>", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-    private static partial Regex ModuleScriptPatternRegex();
-    [GeneratedRegex(@"\stype\s*=\s*[""']module[""']", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-    private static partial Regex ModuleTypeModuleTypeAttributeRegex();
     [GeneratedRegex(@"\s+", RegexOptions.Compiled)]
     private static partial Regex WhitespacePatternRegex();
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -554,6 +554,7 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         ThrowIfDisposed();
         ParseHtml(html);
         RegisterDocument(context);
+        EnforceConfiguredStyleContentSecurityPolicy();
     }
 
     /// <summary>
@@ -581,6 +582,21 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         }
         ParseHtml(html);
         RegisterDocument(context);
+        EnforceConfiguredStyleContentSecurityPolicy();
+    }
+
+    /// <summary>
+    /// Enforces the CSP <c>style-src</c> family on the freshly parsed DOM as the final step of attach, so
+    /// the document the host hands to scripts and rendering already excludes CSP-blocked inline styles and
+    /// <c>&lt;style&gt;</c> elements (Phase 7 item 5: CSP is a host-layer decision, and DOM/CSS receive
+    /// already-authorised content on every path — not just the CLI/WPT hosts that used to call
+    /// <see cref="ApplyStyleContentSecurityPolicy"/> by hand). Runs only when a policy is configured via
+    /// <see cref="Csp"/>; idempotent, so a host that still applies the policy explicitly removes nothing more.
+    /// </summary>
+    private void EnforceConfiguredStyleContentSecurityPolicy()
+    {
+        if (Csp != null)
+            ApplyStyleContentSecurityPolicy(Csp);
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -333,7 +333,8 @@ public sealed partial class DomBridge
         var extraction = ScriptExtractionService.ExtractAll(html, GetSubDocumentBaseUrl(containerElement));
         if (extraction.Scripts.Count == 0 &&
             extraction.AsyncScripts.Count == 0 &&
-            extraction.DeferredScripts.Count == 0)
+            extraction.DeferredScripts.Count == 0 &&
+            extraction.ModuleScripts.Count == 0)
             return;
 
         var subWindow = _subWindows.GetOrCreate(containerElement);
@@ -376,6 +377,22 @@ public sealed partial class DomBridge
                 {
                     RenderLogger.LogWarning(LogCategory.JavaScript, "DomBridge.ExecuteSubDocumentScripts",
                         $"Sub-document deferred script error: {ex.Message}", ex);
+                }
+            }
+
+            // Phase 7 item 6 (first slice): authorised inline module scripts, deferred, run last. Already
+            // wrapped for module semantics by ExtractAll; an unsupported (import/export) module surfaces its
+            // error here instead of being silently skipped.
+            foreach (var script in extraction.ModuleScripts)
+            {
+                try
+                {
+                    _jsContext.Eval(script);
+                }
+                catch (Exception ex)
+                {
+                    RenderLogger.LogWarning(LogCategory.JavaScript, "DomBridge.ExecuteSubDocumentScripts",
+                        $"Sub-document module script error: {ex.Message}", ex);
                 }
             }
         });

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -5,6 +5,7 @@ using Broiler.JavaScript.BuiltIns.String;
 using Broiler.JavaScript.Runtime;
 using Broiler.JavaScript.BuiltIns.Function;
 using Broiler.HtmlBridge.Logging;
+using Broiler.HtmlBridge.Scripting;
 using Broiler.Dom;
 
 namespace Broiler.HtmlBridge;
@@ -240,14 +241,10 @@ public sealed partial class DomBridge
         if (string.IsNullOrWhiteSpace(resourceUrl))
             return string.Empty;
 
-        if (Uri.TryCreate(resourceUrl, UriKind.Absolute, out var absoluteUri))
-            return absoluteUri.AbsoluteUri;
-
+        // Frames adopt the one shared resolver (Phase 7 item 4) — same absolute-stays / relative-resolves /
+        // else-empty behaviour that script and CSP already share via UrlResolver.
         var effectiveBaseUrl = string.IsNullOrWhiteSpace(baseUrl) ? _pageUrl : baseUrl;
-        return Uri.TryCreate(effectiveBaseUrl, UriKind.Absolute, out var baseUri) &&
-               Uri.TryCreate(baseUri, resourceUrl, out var resolved)
-            ? resolved.AbsoluteUri
-            : string.Empty;
+        return UrlResolver.Resolve(resourceUrl, effectiveBaseUrl)?.AbsoluteUri ?? string.Empty;
     }
 
     private bool TryGetWptRootDirectory(out string wptRoot)
@@ -502,14 +499,15 @@ public sealed partial class DomBridge
                 return localResult;
         }
 
-        // Resolve relative URL against page URL
+        // Resolve relative URL against page URL. An absolute URL keeps its raw string so the scheme
+        // checks below (file:// / http(s)) and WPT host mapping see the exact original prefix; only the
+        // relative case goes through the shared resolver (Phase 7 item 4).
         string resolvedUrl;
         if (Uri.TryCreate(resourceUrl, UriKind.Absolute, out _))
         {
             resolvedUrl = resourceUrl;
         }
-        else if (Uri.TryCreate(string.IsNullOrWhiteSpace(baseUrl) ? _pageUrl : baseUrl, UriKind.Absolute, out var baseUri) &&
-                 Uri.TryCreate(baseUri, resourceUrl, out var resolved))
+        else if (UrlResolver.Resolve(resourceUrl, string.IsNullOrWhiteSpace(baseUrl) ? _pageUrl : baseUrl) is { } resolved)
         {
             resolvedUrl = resolved.AbsoluteUri;
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -553,28 +553,16 @@ public sealed partial class DomBridge
 
     /// <summary>
     /// Reads a file:// URL from the local filesystem and returns its content with detected MIME type.
+    /// The file existence + binary/text read policy lives in the host <see cref="Runtime.ResourceLoader"/>
+    /// (Phase 7 item 4); this method only maps the URL to a path and the loader's I/O exceptions to the
+    /// empty-document contract.
     /// </summary>
-    private static (string? content, string contentType) TryReadFileResource(string fileUrl, string extensionMime)
+    private (string? content, string contentType) TryReadFileResource(string fileUrl, string extensionMime)
     {
         try
         {
-            var uri = new Uri(fileUrl);
-            var path = uri.LocalPath;
-            if (!File.Exists(path))
-                return (null, string.Empty); // File not found → empty document (not a fetch failure)
-
-            // For binary content types (images, fonts, etc.) return null content with MIME type
-            if (extensionMime.StartsWith("image/", StringComparison.OrdinalIgnoreCase) ||
-                extensionMime.StartsWith("font/", StringComparison.OrdinalIgnoreCase) ||
-                extensionMime.StartsWith("audio/", StringComparison.OrdinalIgnoreCase) ||
-                extensionMime.StartsWith("video/", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(extensionMime, "application/pdf", StringComparison.OrdinalIgnoreCase))
-            {
-                return (null, extensionMime);
-            }
-
-            var content = File.ReadAllText(path);
-            return (content, extensionMime);
+            var path = new Uri(fileUrl).LocalPath;
+            return _resources.LoadLocalResource(path, extensionMime);
         }
         catch
         {
@@ -604,27 +592,17 @@ public sealed partial class DomBridge
         if (filename.Contains("://")) return (null, string.Empty);
 
         var localPath = Path.Combine(_resources.LocalBasePath, filename);
-        if (!File.Exists(localPath))
-            return (null, string.Empty);
-
-        // For binary content types (images, fonts, etc.) return null content with MIME type
-        if (extensionMime.StartsWith("image/", StringComparison.OrdinalIgnoreCase) ||
-            extensionMime.StartsWith("font/", StringComparison.OrdinalIgnoreCase) ||
-            extensionMime.StartsWith("audio/", StringComparison.OrdinalIgnoreCase) ||
-            extensionMime.StartsWith("video/", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(extensionMime, "application/pdf", StringComparison.OrdinalIgnoreCase))
-        {
-            return (null, extensionMime);
-        }
 
         try
         {
-            var content = File.ReadAllText(localPath);
+            // The existence + binary/text read policy lives in the host loader (Phase 7 item 4); missing
+            // → (null, ""), binary → (null, extensionMime), text → (content, extensionMime).
+            var (content, detectedMime) = _resources.LoadLocalResource(localPath, extensionMime);
 
-            // Detect content type from content when extension is generic
-            var detectedMime = extensionMime;
-            if (string.Equals(detectedMime, "application/octet-stream", StringComparison.OrdinalIgnoreCase)
-                || string.IsNullOrEmpty(detectedMime))
+            // Detect content type from the read text when extension-based detection was generic.
+            if (content != null &&
+                (string.Equals(detectedMime, "application/octet-stream", StringComparison.OrdinalIgnoreCase)
+                 || string.IsNullOrEmpty(detectedMime)))
             {
                 detectedMime = DetectContentTypeFromContent(content, filename);
             }

--- a/src/Broiler.HtmlBridge.Dom/Features/FetchBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/FetchBinding.cs
@@ -11,6 +11,7 @@ using Broiler.JavaScript.Runtime;
 using Broiler.JavaScript.Engine;
 using Broiler.JavaScript.BuiltIns.Function;
 using Broiler.HtmlBridge.Dom.Runtime;
+using Broiler.HtmlBridge.Scripting;
 
 namespace Broiler.HtmlBridge.Dom.Features;
 
@@ -672,16 +673,11 @@ internal sealed partial class FetchBinding(IFetchHost host, ResourceLoader resou
             if (string.IsNullOrWhiteSpace(redirectUrl))
                 throw new JSException("Failed to execute 'redirect' on 'Response': Invalid URL");
 
-            if (Uri.TryCreate(redirectUrl, UriKind.Absolute, out var absoluteUri))
-                return absoluteUri.AbsoluteUri;
-
-            if (Uri.TryCreate(_host.PageUrl, UriKind.Absolute, out var baseUri) &&
-                Uri.TryCreate(baseUri, redirectUrl, out var resolvedUri))
-            {
-                return resolvedUri.AbsoluteUri;
-            }
-
-            throw new JSException("Failed to execute 'redirect' on 'Response': Invalid URL");
+            // fetch adopts the one shared resolver (Phase 7 item 4) — absolute stays, relative resolves
+            // against the page URL; an unresolvable URL is the spec's "Invalid URL" TypeError.
+            return (UrlResolver.Resolve(redirectUrl, _host.PageUrl)
+                    ?? throw new JSException("Failed to execute 'redirect' on 'Response': Invalid URL"))
+                .AbsoluteUri;
         }
         var formDataCtor = new JSFunction((in a) => CreateFormDataObject(a.Length > 0 ? a[0] : null), "FormData", 1);
         var headersCtor = new JSFunction((in a) => CreateHeadersObject(a.Length > 0 ? a[0] : null), "Headers", 1);

--- a/src/Broiler.HtmlBridge.Dom/Runtime/ResourceLoader.cs
+++ b/src/Broiler.HtmlBridge.Dom/Runtime/ResourceLoader.cs
@@ -58,6 +58,42 @@ internal sealed class ResourceLoader
         return null;
     }
 
+    /// <summary>
+    /// Reads a local file <paramref name="path"/> as a sub-resource, applying the file read + MIME policy
+    /// in one place (Phase 7 item 4) so a sub-document/object feature callback no longer inlines a
+    /// <c>File.Exists</c>/<c>File.ReadAllText</c> switch. Returns:
+    /// <list type="bullet">
+    /// <item><c>(null, "")</c> when the file is missing — the caller treats this as an empty document, not
+    /// a fetch failure.</item>
+    /// <item><c>(null, extensionMime)</c> for a binary content type (image/font/audio/video/pdf): the bytes
+    /// are not decoded to text, but the detected MIME is preserved.</item>
+    /// <item><c>(text, extensionMime)</c> otherwise, with <see cref="File.ReadAllText(string)"/> semantics
+    /// (BOM/encoding detection).</item>
+    /// </list>
+    /// I/O exceptions from the read propagate so the caller can map them to its own failure contract.
+    /// </summary>
+    public (string? content, string contentType) LoadLocalResource(string path, string extensionMime)
+    {
+        if (!File.Exists(path))
+            return (null, string.Empty);
+
+        if (IsBinaryMime(extensionMime))
+            return (null, extensionMime);
+
+        return (File.ReadAllText(path), extensionMime);
+    }
+
+    /// <summary>
+    /// True for content types whose bytes must not be decoded to text (images, fonts, media, PDF). Shared
+    /// by the sub-resource file and local-base-path read paths so the binary-content policy lives once.
+    /// </summary>
+    public static bool IsBinaryMime(string mime) =>
+        mime.StartsWith("image/", StringComparison.OrdinalIgnoreCase) ||
+        mime.StartsWith("font/", StringComparison.OrdinalIgnoreCase) ||
+        mime.StartsWith("audio/", StringComparison.OrdinalIgnoreCase) ||
+        mime.StartsWith("video/", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(mime, "application/pdf", StringComparison.OrdinalIgnoreCase);
+
     /// <summary>Sends a prepared request (e.g. XMLHttpRequest).</summary>
     public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request) => SharedClient.SendAsync(request);
 


### PR DESCRIPTION
## Summary

Replaces regex-based HTML discovery with the shared `Broiler.Dom.Html` tokenizer for script and CSP meta extraction, and introduces the module map + inline module execution (Phase 7 items 2 and 6, first slice).

## Key Changes

**Phase 7 item 2 — Parser-backed discovery:**
- `ScriptExtractionService`: migrated from regex patterns to `HtmlTokenizer` enumeration for `<script>` tag discovery. Script body text is now taken verbatim (raw-text semantics, never entity-decoded), and attribute parsing is delegated to the tokenizer's attribute map rather than per-tag regex.
- `CspMetaDiscovery`: switched to `HtmlTokenizer` for `<meta>` discovery, correctly ignoring `<meta>` inside comments or raw-text element bodies (where regex would have matched).
- Added `UrlResolver` utility (Phase 7 item 4 preparation) to centralize absolute/relative URL resolution across script, CSP, and frame sub-resources.

**Phase 7 item 6, first slice — Module map + inline module execution:**
- Introduced `ModuleMap` and `ModuleMapEntry` to registry recognised `<script type="module">` elements in document order.
- Added `ModuleScriptWrapper` to wrap inline modules in a strict IIFE, reproducing module top-level semantics (strict mode, local scope for top-level declarations).
- `ScriptExtractionService.ExtractAll` now populates `ScriptExtractionResult.ModuleScripts` and `ModuleMap` alongside classic script buckets.
- `DomBridge.ExecuteSubDocumentScripts` executes authorised inline modules (deferred, after classic deferred scripts).
- Inline modules are executable now; external/data-URI module loading and import graph resolution are later slices.

**Supporting changes:**
- `SubDocuments.ResolveSubResourceUrl` now delegates to `UrlResolver.Resolve` (Phase 7 item 4 consolidation).
- `DomBridge.Attach` enforces configured style CSP as the final step (Phase 7 item 5), so all host paths receive a CSP-authorised DOM.
- `Broiler.Layout`: added `Appearance` box property (CSS Basic UI) wired through `CssUtils` dispatch, enabling `<select multiple appearance:none>` native rendering (P6.9).

**Patches (pending submodule push authorization):**
- `patches/0005-html-video-replaced-element-black-box.patch`: native `<video>` rendering (black inline-block, hide fallback).
- `patches/0006-html-progress-meter-native-track-fill.patch`: native `<progress>`/`<meter>` rendering (bordered track + proportional fill).
- `patches/0007-html-select-multiple-native-listbox.patch`: native `<select multiple>` rendering (list-box with appearance branching).

**Documentation:**
- Roadmap updated: P6.6–P6.9 completed (all replaced-element native rendering authored); P6 remaining is pointer bumps + test-harness relocation.
- `patches/README.md` corrected: patch 0004 now applied upstream (pinned `Broiler.HTML` `52f65d9` contains `CorrectIframeBoxes`); patches 0005–0007 pending.

## Notable Details

- Script discovery is now parser-backed, so a `<script>` literal inside a comment or another element's text is correctly not discovered, and a `>` inside a quoted attribute no longer truncates the start tag.
- Module map deduplicates external modules by URL (one fetch, one evaluation, multiple `<script>` references).
- All native-rendering authoring for replaced elements is complete; remaining Phase 6 work is push authorization and test-harness relocation (no new rendering code).

https://claude.ai/code/session_01GTgcz6ZP1npy5vXd3aH42X