### PR TITLE
Phase 7 item 6: ES module graph linking and execution

### DIFF
--- a/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
@@ -5,8 +5,10 @@ patches `0004`–`0007` applied upstream and the `Broiler.HTML` pointer bumped t
 `HtmlPostProcessor` video/progress/meter/select fallbacks are dropped) — only the terminal
 `Broiler.HtmlBridge.Rendering` project deletion remains, gated on relocating the test-harness shims
 behind the WPT pixel reftest gate. **Phase 7 items 1–5 complete** (CSP split, script descriptors,
-loader/`UrlResolver`/`Origin` consolidation, external-stylesheet CSP, and host-layer CSP enforcement);
-the remainder is item 6's module import/export graph + event-loop integration. **Phase 8 proposed.**
+loader/`UrlResolver`/`Origin` consolidation, external-stylesheet CSP, and host-layer CSP enforcement) **and
+item 6's static import/export module graph linked and executing** (P7.17); the remaining item-6 tail is the
+engine-coupled part — live cyclic bindings, `import.meta`, top-level-await-as-async, dynamic `import()`, and
+event-loop ordering. **Phase 8 proposed.**
 
 This document tracks the **not-yet-fully-delivered** phases of the HtmlBridge
 complexity-reduction program: removing `Broiler.HtmlBridge.Rendering` (Phase 6),
@@ -519,18 +521,47 @@ Exit criteria:
   CSP / origin / resolver / snapshot suites green. With this, **item 5 is done** (the WPT runner sharing the
   same `bridge.Csp`-driven path remains a harness follow-up, not a DOM/CSS-visibility gap).
 
-- **Remaining for Phase 7 — item 6 module graph/linker only.** Items 1 (CSP split — P7.1/P7.5/P7.10/P7.11),
-  3 (script descriptors — P7.2), 4 (loader/`UrlResolver`/`Origin` consolidation — P7.3–P7.9, P7.15) and
-  5 (host-layer CSP incl. external stylesheets — P7.14, P7.16) are **done**: no feature callback constructs
-  an `HttpClient` or inlines a `file`/`data`-URI/`File.*` switch; one `UrlResolver` and one `Origin` primitive
-  are shared across all five named consumers (script, CSS, fetch, XHR, frames); and DOM/CSS never see CSP.
-  **Still open — item 6 (rest):** the deepest part of module loading beyond P7.12/P7.13 — the
-  **import/export module graph** (specifier resolution, linking, dedup of *dependencies* via the module map,
-  cyclic handling), `import.meta`/top-level-`await`, and moving module ordering into the real browser **event
-  loop** (rather than the current deferred-bucket approximation). Fetching + inline/data/file execution +
-  URL dedup are done (P7.12–P7.13); the graph/linker and event-loop integration are the substantial
-  remainder — a genuine module-system feature that reaches into the `Broiler.JS` engine (submodule,
-  push-authorization-gated) and is best delivered as its own multi-slice track, not folded into this pass.
+- **P7.17 (2026-07-20) — item 6 (major slice): the ES module import/export graph + linker.** Extended module
+  handling from "run an isolated inline module body" (P7.12/P7.13) to a real **linked import graph**.
+  Engine-capability audit first: `Broiler.JS` *parses* `import`/`export` but has **no drivable module records**
+  — the compiler desugars static import/export into CommonJS-style ops keyed on magic scope vars that exist
+  only when a body is compiled with the module arg list (via `JSModuleContext`, which needs the **`internal`**
+  `CoreScript.AllowTopLevelAwaitScope`). Driving the engine's lowering therefore needs a `Broiler.JS` change
+  (submodule, push-gated) and cannot ship on CI now. So the graph is linked at the **bridge layer** (main-repo,
+  CI-landable) by a source-to-source transform the existing `JSContext.Eval` path runs:
+  - `EsModuleScanner` — a string/template/comment/regex-aware scanner that finds a module's **top-level**
+    static `import`/`export` statements only (never one inside a string, comment, `obj.export`, `exports.x`,
+    or a nested scope; `import(...)`/`import.meta` are left as expressions). Any unrecognised/malformed form
+    marks the module unsupported so the linker leaves it as-is — the feature is strictly **additive**.
+  - `EsModuleLinker` — rewrites each module into a strict IIFE wired to an idempotent runtime registry: it
+    registers its exports object under its key *before* running (so a cycle sees the in-progress object), reads
+    imports from the registry, and publishes exports. Supported forms: default/named(+`as`)/namespace/side-effect
+    imports; `export` declarations, export lists, `export default`, and re-exports (`export {…} from`,
+    `export *`, `export * as`). Bindings are snapshots (namespace imports are live references) — the one
+    spec-fidelity caveat, matching the engine's own non-live desugaring.
+  - `ModuleGraphLoader` — from the document's module roots, resolves each specifier (shared `UrlResolver`,
+    relative to the importing module), fetches (CSP-gated, same authorised path as classic scripts), dedups by
+    resolved URL, orders the graph **dependency-first** (cycle-safe post-order), and renders the ordered linked
+    programs. `ScriptExtractionService.ExtractAll` now feeds its authorised module roots to the loader and
+    returns the linked graph in `ModuleScripts`; the existing deferred-bucket consumers
+    (`RenderingPipeline`, `DomBridge.ExecuteSubDocumentScripts`) run them in list order unchanged.
+    New `EsModuleGraphTests` (16) drive real graphs through a live `JSContext` — named/default/namespace/aliased
+    imports, `export`/re-export/`export *`, diamond dedup (shared module evaluated once), cycles, side-effect
+    imports, scope isolation, scanner robustness (strings/comments/dynamic-import not mis-transformed),
+    unsupported-form fallback, and a 3-module disk-backed graph through `ExtractAll` — all green. New syntax
+    types are `internal` → **no public-API change**; the existing `ModuleScriptSliceTests` (10) stay green.
+
+- **Remaining for Phase 7 — item 6 tail (engine-coupled).** With P7.17 the static import/export graph is
+  linked and executed. What remains is the engine-coupled tail, deliberately deferred because it needs
+  `Broiler.JS` (submodule, push-authorization-gated) or is architecturally larger: **live bindings across
+  cycles** (the bridge linker uses snapshot semantics — matching the engine's own desugaring — so a value
+  read across a cycle before its exporter finishes is stale), **`import.meta`** beyond leaving it inert,
+  **top-level `await`** as genuinely async (the transform is synchronous; a TLA module falls back), **dynamic
+  `import()`** wired to the graph via the engine's `HostImportModule` hook, and moving module ordering into the
+  real browser **event loop** rather than the deferred-bucket approximation. The cleanest long-term path for
+  these is to drive the engine's own module lowering (expose a public module-compile entry / make
+  `CoreScript.AllowTopLevelAwaitScope` public) via a `Broiler.JS` patch, then have the bridge supply the
+  URL-based loader — captured here as the follow-up seam.
 
 ### Phase 8 - simplify Core and Scripting, then reconsider assemblies
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-remaining.md
@@ -1,8 +1,14 @@
 # HtmlBridge complexity-reduction — remaining phases
 
-Status: Phase 6 in progress (concerns 1 & 3 delivered); Phases 7–8 proposed
+Status: **Phase 6 native-rendering migration complete** (all three concerns delivered; submodule
+patches `0004`–`0007` applied upstream and the `Broiler.HTML` pointer bumped to `5c16c12`; the
+`HtmlPostProcessor` video/progress/meter/select fallbacks are dropped) — only the terminal
+`Broiler.HtmlBridge.Rendering` project deletion remains, gated on relocating the test-harness shims
+behind the WPT pixel reftest gate. **Phase 7 items 1–5 complete** (CSP split, script descriptors,
+loader/`UrlResolver`/`Origin` consolidation, external-stylesheet CSP, and host-layer CSP enforcement);
+the remainder is item 6's module import/export graph + event-loop integration. **Phase 8 proposed.**
 
-This document tracks the **not-yet-delivered** phases of the HtmlBridge
+This document tracks the **not-yet-fully-delivered** phases of the HtmlBridge
 complexity-reduction program: removing `Broiler.HtmlBridge.Rendering` (Phase 6),
 isolating loading / security / browsing-context policy (Phase 7), and
 simplifying Core and Scripting before reconsidering assemblies (Phase 8).
@@ -143,7 +149,10 @@ Exit criteria:
   `Acid3RegressionTests` + guards/profile/native suites green (no public-API change: all internal).
 
 - **P6.6 (2026-07-20) — Concern 2, native-behaviour migration: `<video>` replaced-element handling
-  (submodule patch `0005`, pending).** Native replacement for `HtmlPostProcessor.ReplaceVideoWithPlaceholder`
+  (submodule patch `0005`, applied upstream).** **Update:** patch `0005` was pushed to `Broiler.HTML`
+  (`5561eb0`, contained in the pinned `5c16c12`) and the pointer bumped, so
+  `HtmlPostProcessor.ReplaceVideoWithPlaceholder` has been **dropped** — the renderer boxes `<video>`
+  natively. Original authoring note follows. Native replacement for `HtmlPostProcessor.ReplaceVideoWithPlaceholder`
   (which string-rewrites `<video>…</video>` into a black `<div>` at its width/height or 300×150). Added a
   post-cascade `CorrectVideoBoxes` pass in `Broiler.HTML` (`DomParser`) — mirroring `CorrectIframeBoxes` — that
   makes a `<video>` box `inline-block`, sizes it (author CSS size wins; else the `width`/`height` presentation
@@ -160,7 +169,11 @@ Exit criteria:
   removal is unblocked; `patches/README.md` corrected accordingly.
 
 - **P6.7 (2026-07-20) — Concern 2, native-behaviour migration: `<progress>`/`<meter>` replaced-element
-  handling (submodule patch `0006`, pending).** Native replacement for
+  handling (submodule patch `0006`, applied upstream).** **Update:** patch `0006` was pushed to
+  `Broiler.HTML` (`444cace`, contained in the pinned `5c16c12`) and the pointer bumped, so
+  `HtmlPostProcessor.ReplaceProgressLikeWithPlaceholder` has been **dropped** (native coverage:
+  `FormControlRenderTests.Meter_NativeRender_Follows_WritingMode_And_Direction`). Original authoring note
+  follows. Native replacement for
   `HtmlPostProcessor.ReplaceProgressLikeWithPlaceholder` (which string-rewrites the elements into a styled
   `<div>` track + fill). Added a post-cascade `CorrectProgressBoxes` pass in `Broiler.HTML` (`DomParser`) that
   renders each as a bordered `inline-block` track (1px `#767676`, bg `#f0f0f0`/`#e6e6e6`, `120×16` or `16×120`
@@ -173,7 +186,11 @@ Exit criteria:
   is the one remaining replaced-element fallback.
 
 - **P6.8 (2026-07-20) — Concern 2, native-behaviour migration: `<select multiple>` replaced-element handling
-  (submodule patch `0007`, pending, stacks on `0006`).** Native replacement (native-appearance case) for
+  (submodule patch `0007`, applied upstream, stacks on `0006`).** **Update:** patch `0007` was pushed to
+  `Broiler.HTML` (`5c16c12`, the pinned pointer) and the pointer bumped, so
+  `HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder` has been **dropped** (both appearance modes render
+  natively; the string-rewrite unit test was retired in favour of the WPT/Acid reftest gate). Original
+  authoring note follows. Native replacement (native-appearance case) for
   `HtmlPostProcessor.ReplaceSelectMultipleWithPlaceholder`. Added a post-cascade `CorrectSelectMultipleBoxes`
   pass in `Broiler.HTML` (`DomParser`) rendering the control as an `inline-block` list box: one 16px row track
   per visible option (`size` clamped 2..8, default 4), first row `#3875d7` selection highlight, alternating
@@ -197,16 +214,20 @@ Exit criteria:
   (528 px) and grey field; `appearance:none` drops the chrome entirely (0 px) and uses white. Patch `0007`
   regenerated to include this; `<select multiple>` native rendering now covers both appearance modes.
 
-- **Remaining for Phase 6 — Concern 2 native migration + project deletion.** With native rendering written for
-  every replaced element **and both `<select>` appearance modes**, the residue is: (a) **pointer bumps** for
-  `patches/0005`–`0007` (submodule-push authorization — out of session scope) so
-  `ReplaceVideo`/`ReplaceProgressLike`/`ReplaceSelectMultiple` (and the now-redundant `StripIframeContent`,
-  `0004` already applied) can drop from `HtmlPostProcessor`; (b) the protective `StripScriptTags` and the
-  test-harness-only shims (`StripHiddenTestArtifacts`, `StripObjectContent`, `RewriteRootSelector`) relocated
-  to test support once the reftest gate can validate; then the emptied `Broiler.HtmlBridge.Rendering` project
-  is deleted. Per the disposition, `HtmlPostProcessor` must **not** be moved wholesale to rename it; the
-  migration is behavioural. **All native-rendering authoring is done**; the remaining steps are
-  push-authorization and test-harness relocation, not new rendering code.
+- **Remaining for Phase 6 — Concern 2 project deletion only.** The native migration is **done and shipped**:
+  patches `0004`–`0007` are applied upstream, the `Broiler.HTML` pointer is bumped to `5c16c12`, and the
+  `ReplaceVideo`/`ReplaceProgressLike`/`ReplaceSelectMultiple` fallbacks (and their exclusive
+  helpers/patterns) have been **dropped** from `HtmlPostProcessor` — the renderer now boxes every replaced
+  element natively (both `<select>` appearance modes). The residue is: (a) `StripIframeContent` is now a
+  redundant belt-and-suspenders strip (`0004`'s native `CorrectIframeBoxes` is pinned) whose removal is
+  **unblocked** but deliberately deferred to keep changes focused and because it touches the WPT render
+  harness path (pixel-reftest-gated, not validatable in a bare container); (b) the protective `StripScriptTags`
+  and the test-harness-only shims (`StripHiddenTestArtifacts`, `StripObjectContent`, `RewriteRootSelector`)
+  relocated to test support once the reftest gate can validate; then the emptied `Broiler.HtmlBridge.Rendering`
+  project (still consumed by `Broiler.Browser.Core`/`Broiler.Cli`/`Broiler.Wpt`) is deleted. Per the
+  disposition, `HtmlPostProcessor` must **not** be moved wholesale to rename it; the migration is behavioural.
+  **All native-rendering authoring is done and merged**; the terminal step is test-harness relocation +
+  project deletion, both gated on the WPT pixel reftest gate — not new rendering code.
 
 ### Phase 7 - isolate loading, security and browsing-context policy
 
@@ -461,18 +482,55 @@ Exit criteria:
   CSP and giving the WPT runner the same `bridge.Csp`-driven path are follow-ups, but DOM/CSS never seeing CSP
   and every execution path delivering authorised inline-style content is done.
 
-- **Remaining for Phase 7.** Still open: item 6 (rest) — the deepest part of module loading beyond P7.12/P7.13: the
+- **P7.15 (2026-07-20) — item 4 complete: unify the origin helpers behind one `Origin` primitive.** The
+  `scheme://host[:port]` origin serialization was copy-pasted in **five** places and the scheme+host+port
+  comparison in **two**: `MessagingBinding.GetWindowOrigin` (`postMessage` target-origin delivery),
+  `DomBridge.Attach` (`_pageOrigin`/`_pageHost`), `SubWindowBinding` (the iframe `Location`
+  `origin`/`host` projections), `Utilities.IsCrossOrigin` (cross-origin check), and
+  `CspSourceMatching.IsSameOrigin` (CSP `'self'` match). Added an internal `Origin`
+  (`Broiler.HtmlBridge.Core/Scripting/Origin.cs`, alongside `UrlResolver`) with three primitives —
+  `Of(Uri)` (origin serialization, default port omitted), `HostOf(Uri)` (the `Location.host` form), and
+  `SchemeHostPortEquals(Uri, Uri)` (the origin-equality primitive) — and routed all five/two sites through
+  it. **Behaviour-preserving:** the serialization is byte-identical across all sites and the compare
+  primitive is identical in `IsCrossOrigin`/`IsSameOrigin`, so each caller keeps its own surrounding policy
+  (which of `about:blank`/`data:`/`file:` inherit the embedding origin, and the null-page handling) — only
+  the shared primitive is consolidated. `Origin` is `internal` in Core, visible to Dom via
+  `InternalsVisibleTo`, so **no public-API change**. New `OriginTests` (4) pin the serialization / host form
+  / scheme+host+port equality / case-insensitivity; the CSP / messaging / sub-window / sub-resource suites
+  stay green (the same 3 `HttpSubResource` relative-iframe/WPT-root failures are pre-existing network-env
+  failures, identical on the `2b33fe6` baseline). This closes the "one URL resolution/**origin**
+  implementation shared by script, CSS, fetch, XHR and frames" exit criterion's origin half, so **item 4 is
+  now fully done**.
+
+- **P7.16 (2026-07-20) — item 5 complete: external-stylesheet (`<link rel=stylesheet>`) CSP gating.** P7.14
+  centralised *inline* style CSP into the bridge, but the **external**-stylesheet load path
+  (`DomBridge.FetchExternalStylesheet`, reached from computed-style building) consulted **no** CSP at all —
+  a `style-src`-blocked `<link>` href was still fetched and applied. Added
+  `ContentSecurityPolicy.AllowsExternalStyle(styleUrl, pageUrl, nonce)` — the style analogue of
+  `AllowsExternalScript`, applying the same source-token matching (`*`, `'self'` via the shared
+  `CspSourceMatching`/`Origin`, scheme source, absolute host source) plus a `<link>` nonce over the
+  `style-src-elem` → `style-src` → `default-src` fallback, but **not** `'unsafe-inline'` (irrelevant to a
+  fetched URL) nor `'strict-dynamic'` (script-only). Gated the fetch at its call site
+  (`GetStyleElementSourceText`) via a new `IsExternalStyleAllowedByCsp` helper, so DOM/CSS never fetch or
+  apply a blocked external stylesheet — the item-5 rule ("CSP stays in the host layer; DOM and CSS receive
+  already-authorised content") now holds for external styles too. New `ContentSecurityPolicyTests` (4) pin
+  `'none'`/`'self'`/host/scheme/nonce matching and the `style-src-elem`/`default-src` fallback. `AllowsExternalStyle`
+  is public on `ContentSecurityPolicy` → **Core public-API baseline regenerated** (adds the one method);
+  CSP / origin / resolver / snapshot suites green. With this, **item 5 is done** (the WPT runner sharing the
+  same `bridge.Csp`-driven path remains a harness follow-up, not a DOM/CSS-visibility gap).
+
+- **Remaining for Phase 7 — item 6 module graph/linker only.** Items 1 (CSP split — P7.1/P7.5/P7.10/P7.11),
+  3 (script descriptors — P7.2), 4 (loader/`UrlResolver`/`Origin` consolidation — P7.3–P7.9, P7.15) and
+  5 (host-layer CSP incl. external stylesheets — P7.14, P7.16) are **done**: no feature callback constructs
+  an `HttpClient` or inlines a `file`/`data`-URI/`File.*` switch; one `UrlResolver` and one `Origin` primitive
+  are shared across all five named consumers (script, CSS, fetch, XHR, frames); and DOM/CSS never see CSP.
+  **Still open — item 6 (rest):** the deepest part of module loading beyond P7.12/P7.13 — the
   **import/export module graph** (specifier resolution, linking, dedup of *dependencies* via the module map,
   cyclic handling), `import.meta`/top-level-`await`, and moving module ordering into the real browser **event
   loop** (rather than the current deferred-bucket approximation). Fetching + inline/data/file execution +
   URL dedup are done (P7.12–P7.13); the graph/linker and event-loop integration are the substantial
-  remainder. These and item 5 are larger or WPT-reftest-sensitive.
-  Item 1 (CSP split), item 3 (script descriptors) and item 4 (loader/resolver consolidation) are **done**:
-  the file/http text dispatch (P7.3–P7.4), one shared URL resolver across all five named consumers —
-  script/CSP (P7.6), frames (P7.7) and fetch/XHR (P7.9) — and the sub-resource file/local reads (P7.8) all now
-  live behind the loader/`UrlResolver`, so no feature callback constructs an `HttpClient` or inlines a
-  `file`/`data`-URI/`File.*` switch for the text-load paths. The one remaining item-4-adjacent cleanup is
-  unifying the *origin* helpers (same-origin/origin-extraction), tracked as a separate scoped step.
+  remainder — a genuine module-system feature that reaches into the `Broiler.JS` engine (submodule,
+  push-authorization-gated) and is best delivered as its own multi-slice track, not folded into this pass.
 
 ### Phase 8 - simplify Core and Scripting, then reconsider assemblies
 

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -4,7 +4,9 @@ Status: **in delivery** — Phases 0–5 delivered to their in-scope terminal st
 [implemented delivery log](htmlbridge-complexity-reduction-implemented.md)); Phase 6's native-rendering
 migration is complete and merged (submodule patches `0004`–`0007` applied upstream), with only the terminal
 `Broiler.HtmlBridge.Rendering` project deletion outstanding (WPT-reftest-gated); Phase 7 items 1–5 are
-done, leaving item 6's module import/export graph + event-loop integration; Phase 8 remains proposed. Per-phase
+done and item 6's static import/export module graph is linked and executing (P7.17), leaving item 6's
+engine-coupled tail (live cyclic bindings, `import.meta`, top-level-await-as-async, dynamic `import()`,
+event-loop ordering); Phase 8 remains proposed. Per-phase
 detail: [remaining phases](htmlbridge-complexity-reduction-remaining.md).
 
 Baseline date: 2026-07-13

--- a/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
+++ b/docs/roadmap/htmlbridge-complexity-reduction-roadmap.md
@@ -1,6 +1,11 @@
 # HtmlBridge complexity-reduction roadmap
 
-Status: proposed
+Status: **in delivery** — Phases 0–5 delivered to their in-scope terminal state (see the
+[implemented delivery log](htmlbridge-complexity-reduction-implemented.md)); Phase 6's native-rendering
+migration is complete and merged (submodule patches `0004`–`0007` applied upstream), with only the terminal
+`Broiler.HtmlBridge.Rendering` project deletion outstanding (WPT-reftest-gated); Phase 7 items 1–5 are
+done, leaving item 6's module import/export graph + event-loop integration; Phase 8 remains proposed. Per-phase
+detail: [remaining phases](htmlbridge-complexity-reduction-remaining.md).
 
 Baseline date: 2026-07-13
 

--- a/src/Broiler.App/Rendering/RenderingPipeline.cs
+++ b/src/Broiler.App/Rendering/RenderingPipeline.cs
@@ -32,8 +32,9 @@ public sealed class RenderingPipeline(
             ? result.Scripts
             : result.Scripts.Concat(result.AsyncScripts).ToArray();
 
-        // Module scripts are deferred (Phase 7 item 6, first slice): run authorised inline modules after
-        // the classic deferred scripts. They are already wrapped for module semantics by ExtractAll.
+        // Module scripts are deferred (Phase 7 item 6): run the linked module graph after the classic
+        // deferred scripts. ExtractAll returns the programs in dependency-first order, so running them in
+        // list order (appended after the classic deferred scripts) satisfies the graph's evaluation order.
         var deferred = result.ModuleScripts.Count == 0
             ? result.DeferredScripts
             : result.DeferredScripts.Concat(result.ModuleScripts).ToArray();

--- a/src/Broiler.Cli.Tests/ApiBaselines/Broiler.HtmlBridge.Core.PublicApi.txt
+++ b/src/Broiler.Cli.Tests/ApiBaselines/Broiler.HtmlBridge.Core.PublicApi.txt
@@ -55,6 +55,7 @@ TYPE Broiler.HtmlBridge.Scripting.ContentSecurityPolicy
   method Broiler.HtmlBridge.Scripting.ContentSecurityPolicy FromHtml(System.String)
   method System.Boolean AffectsStyles()
   method System.Boolean AllowsExternalScript(System.String, System.String, System.String)
+  method System.Boolean AllowsExternalStyle(System.String, System.String, System.String)
   method System.Boolean AllowsInlineEventHandler(System.String)
   method System.Boolean AllowsInlineScript(System.String, System.String)
   method System.Boolean AllowsInlineStyleAttribute()

--- a/src/Broiler.Cli.Tests/ContentSecurityPolicyTests.cs
+++ b/src/Broiler.Cli.Tests/ContentSecurityPolicyTests.cs
@@ -477,4 +477,67 @@ public class ContentSecurityPolicyTests
         Assert.Contains("background: green", result);
         Assert.Contains("<style", result);
     }
+
+    // Phase 7 item 5: external-stylesheet (<link rel=stylesheet>) CSP gating. The style analogue of
+    // AllowsExternalScript, applied at the FetchExternalStylesheet call site so DOM/CSS never fetch or
+    // apply a style-src-blocked external stylesheet.
+
+    [Fact]
+    public void AllowsExternalStyle_None_Blocks_Every_External_Stylesheet()
+    {
+        var csp = new ContentSecurityPolicy();
+        csp.Parse("style-src 'none'");
+
+        Assert.False(csp.AllowsExternalStyle("https://cdn.test/a.css", "https://a.test/page.html"));
+        Assert.False(csp.AllowsExternalStyle("a.css", "https://a.test/page.html"));
+    }
+
+    [Fact]
+    public void AllowsExternalStyle_Self_Allows_SameOrigin_And_Blocks_CrossOrigin()
+    {
+        var csp = new ContentSecurityPolicy();
+        csp.Parse("style-src 'self'");
+
+        Assert.True(csp.AllowsExternalStyle("https://a.test/theme.css", "https://a.test/page.html"));
+        Assert.False(csp.AllowsExternalStyle("https://cdn.test/theme.css", "https://a.test/page.html"));
+    }
+
+    [Fact]
+    public void AllowsExternalStyle_Honours_Host_Scheme_And_Nonce_Sources()
+    {
+        var host = new ContentSecurityPolicy();
+        host.Parse("style-src https://cdn.test");
+        Assert.True(host.AllowsExternalStyle("https://cdn.test/lib/a.css", "https://a.test/page.html"));
+        Assert.False(host.AllowsExternalStyle("https://evil.test/a.css", "https://a.test/page.html"));
+
+        var scheme = new ContentSecurityPolicy();
+        scheme.Parse("style-src https:");
+        Assert.True(scheme.AllowsExternalStyle("https://anywhere.test/a.css", "https://a.test/page.html"));
+        Assert.False(scheme.AllowsExternalStyle("http://anywhere.test/a.css", "https://a.test/page.html"));
+
+        var nonce = new ContentSecurityPolicy();
+        nonce.Parse("style-src 'nonce-abc123'");
+        Assert.True(nonce.AllowsExternalStyle("https://cdn.test/a.css", "https://a.test/page.html", "abc123"));
+        Assert.False(nonce.AllowsExternalStyle("https://cdn.test/a.css", "https://a.test/page.html", "wrong"));
+    }
+
+    [Fact]
+    public void AllowsExternalStyle_StyleSrcElem_Takes_Precedence_And_Falls_Back_To_DefaultSrc()
+    {
+        // style-src-elem wins over style-src for a <link>.
+        var elem = new ContentSecurityPolicy();
+        elem.Parse("style-src 'none'; style-src-elem 'self'");
+        Assert.True(elem.AllowsExternalStyle("https://a.test/a.css", "https://a.test/page.html"));
+
+        // With neither style directive, default-src applies.
+        var fallback = new ContentSecurityPolicy();
+        fallback.Parse("default-src 'self'");
+        Assert.True(fallback.AllowsExternalStyle("https://a.test/a.css", "https://a.test/page.html"));
+        Assert.False(fallback.AllowsExternalStyle("https://cdn.test/a.css", "https://a.test/page.html"));
+
+        // No relevant directive at all → allowed (empty effective source set).
+        var empty = new ContentSecurityPolicy();
+        empty.Parse("img-src 'self'");
+        Assert.True(empty.AllowsExternalStyle("https://cdn.test/a.css", "https://a.test/page.html"));
+    }
 }

--- a/src/Broiler.Cli.Tests/EsModuleGraphTests.cs
+++ b/src/Broiler.Cli.Tests/EsModuleGraphTests.cs
@@ -1,0 +1,299 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Scripting;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Phase 7 item 6: end-to-end tests for the ES module graph — <see cref="EsModuleScanner"/> +
+/// <see cref="EsModuleLinker"/> + <see cref="ModuleGraphLoader"/> — driven through a real
+/// <see cref="JSContext"/>. Each test builds a small module graph from in-memory sources, links it, evals
+/// the resulting programs in dependency order, and asserts on the observable <c>globalThis</c> state, so
+/// the actual import/export wiring (not just the string transform) is verified.
+/// </summary>
+public sealed class EsModuleGraphTests
+{
+    /// <summary>Links the graph rooted at <paramref name="entries"/> over the in-memory <paramref name="files"/>
+    /// and evaluates every program in order in a fresh context; returns the context for assertions.</summary>
+    private static JSContext RunGraph(
+        List<ModuleGraphLoader.GraphModule> entries,
+        Dictionary<string, string> files)
+    {
+        ModuleGraphLoader.ResolveAndFetch fetch = (specifier, baseUrl) =>
+        {
+            var resolved = UrlResolver.Resolve(specifier, baseUrl);
+            if (resolved == null) return null;
+            var key = resolved.AbsoluteUri;
+            return files.TryGetValue(key, out var src) ? (key, src) : null;
+        };
+
+        var result = ModuleGraphLoader.Load(entries, fetch);
+        var ctx = new JSContext();
+        foreach (var program in result.Programs)
+            ctx.Eval(program);
+        return ctx;
+    }
+
+    private static string Eval(JSContext ctx, string expr) => ctx.Eval(expr).ToString();
+
+    [Fact]
+    public void Named_Import_Export_Across_Two_Modules()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["file:///app/util.mjs"] = "export const answer = 42; export function twice(x){ return x*2; }",
+        };
+        var entries = new List<ModuleGraphLoader.GraphModule>
+        {
+            new("file:///app/main.mjs",
+                "import { answer, twice } from './util.mjs'; globalThis.out = answer + twice(4);",
+                "file:///app/main.mjs"),
+        };
+
+        using var ctx = RunGraph(entries, files);
+        Assert.Equal("50", Eval(ctx, "globalThis.out")); // 42 + 8
+    }
+
+    [Fact]
+    public void Default_Import_And_Export()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["file:///app/greet.mjs"] = "export default function(name){ return 'hi ' + name; }",
+        };
+        var entries = new List<ModuleGraphLoader.GraphModule>
+        {
+            new("file:///app/main.mjs",
+                "import greet from './greet.mjs'; globalThis.msg = greet('bo');",
+                "file:///app/main.mjs"),
+        };
+
+        using var ctx = RunGraph(entries, files);
+        Assert.Equal("hi bo", Eval(ctx, "globalThis.msg"));
+    }
+
+    [Fact]
+    public void Namespace_Import_Binds_Live_Exports_Object()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["file:///app/lib.mjs"] = "export const a = 1; export const b = 2;",
+        };
+        var entries = new List<ModuleGraphLoader.GraphModule>
+        {
+            new("file:///app/main.mjs",
+                "import * as lib from './lib.mjs'; globalThis.sum = lib.a + lib.b;",
+                "file:///app/main.mjs"),
+        };
+
+        using var ctx = RunGraph(entries, files);
+        Assert.Equal("3", Eval(ctx, "globalThis.sum"));
+    }
+
+    [Fact]
+    public void Aliased_Named_Import_And_Export()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["file:///app/m.mjs"] = "const internal = 7; export { internal as value };",
+        };
+        var entries = new List<ModuleGraphLoader.GraphModule>
+        {
+            new("file:///app/main.mjs",
+                "import { value as v } from './m.mjs'; globalThis.v = v;",
+                "file:///app/main.mjs"),
+        };
+
+        using var ctx = RunGraph(entries, files);
+        Assert.Equal("7", Eval(ctx, "globalThis.v"));
+    }
+
+    [Fact]
+    public void ReExport_Named_And_Star()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["file:///app/a.mjs"] = "export const x = 10; export const y = 20;",
+            ["file:///app/b.mjs"] = "export { x } from './a.mjs'; export * from './a.mjs';",
+        };
+        var entries = new List<ModuleGraphLoader.GraphModule>
+        {
+            new("file:///app/main.mjs",
+                "import { x, y } from './b.mjs'; globalThis.xy = x + '/' + y;",
+                "file:///app/main.mjs"),
+        };
+
+        using var ctx = RunGraph(entries, files);
+        Assert.Equal("10/20", Eval(ctx, "globalThis.xy"));
+    }
+
+    [Fact]
+    public void Diamond_Dependency_Evaluates_Shared_Module_Once()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["file:///app/base.mjs"] = "globalThis.baseEvals = (globalThis.baseEvals||0)+1; export const v = 5;",
+            ["file:///app/left.mjs"] = "import { v } from './base.mjs'; export const l = v + 1;",
+            ["file:///app/right.mjs"] = "import { v } from './base.mjs'; export const r = v + 2;",
+        };
+        var entries = new List<ModuleGraphLoader.GraphModule>
+        {
+            new("file:///app/main.mjs",
+                "import { l } from './left.mjs'; import { r } from './right.mjs'; globalThis.lr = l + r;",
+                "file:///app/main.mjs"),
+        };
+
+        using var ctx = RunGraph(entries, files);
+        Assert.Equal("13", Eval(ctx, "globalThis.lr")); // (5+1)+(5+2)
+        Assert.Equal("1", Eval(ctx, "globalThis.baseEvals")); // base evaluated exactly once
+    }
+
+    [Fact]
+    public void Circular_Import_Does_Not_Crash()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["file:///app/a.mjs"] = "import { fromB } from './b.mjs'; export const fromA = 'A'; globalThis.aSawB = typeof fromB;",
+            ["file:///app/b.mjs"] = "import { fromA } from './a.mjs'; export const fromB = 'B'; globalThis.bSawA = typeof fromA;",
+        };
+        var entries = new List<ModuleGraphLoader.GraphModule>
+        {
+            new("file:///app/a.mjs", files["file:///app/a.mjs"], "file:///app/a.mjs"),
+        };
+
+        using var ctx = RunGraph(entries, files);
+        // One side of the cycle sees the other's export populated; the back-edge side sees undefined
+        // (snapshot semantics). Either way, no crash and both modules ran.
+        Assert.Contains(Eval(ctx, "globalThis.aSawB"), new[] { "string", "undefined" });
+        Assert.Contains(Eval(ctx, "globalThis.bSawA"), new[] { "string", "undefined" });
+    }
+
+    [Fact]
+    public void SideEffect_Import_Runs_Dependency()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["file:///app/fx.mjs"] = "globalThis.sideEffect = 'done';",
+        };
+        var entries = new List<ModuleGraphLoader.GraphModule>
+        {
+            new("file:///app/main.mjs", "import './fx.mjs'; globalThis.after = globalThis.sideEffect;",
+                "file:///app/main.mjs"),
+        };
+
+        using var ctx = RunGraph(entries, files);
+        Assert.Equal("done", Eval(ctx, "globalThis.after"));
+    }
+
+    [Fact]
+    public void Module_Top_Level_Declarations_Do_Not_Leak_To_Global()
+    {
+        var entries = new List<ModuleGraphLoader.GraphModule>
+        {
+            new("file:///app/main.mjs", "const secret = 99; export const shown = 1; globalThis.check = typeof secret;",
+                "file:///app/main.mjs"),
+        };
+
+        using var ctx = RunGraph(entries, new Dictionary<string, string>());
+        Assert.Equal("number", Eval(ctx, "globalThis.check")); // visible inside the module
+        Assert.Equal("undefined", Eval(ctx, "typeof secret"));  // not leaked to global
+    }
+
+    // ── scanner robustness ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Import_Export_Keywords_Inside_Strings_And_Comments_Are_Not_Module_Syntax()
+    {
+        var syntax = EsModuleScanner.Scan(
+            "const s = 'import x from \\'y\\''; // export const z = 1\n" +
+            "/* import a from 'b' */ const exports_like = importScripts;");
+        Assert.True(syntax.Supported);
+        Assert.False(syntax.HasModuleSyntax); // nothing real to transform
+    }
+
+    [Fact]
+    public void Dynamic_Import_And_Import_Meta_Are_Left_As_Expressions()
+    {
+        var syntax = EsModuleScanner.Scan(
+            "const p = import('./x.mjs'); const u = import.meta.url; export const ok = 1;");
+        Assert.True(syntax.Supported);
+        Assert.Empty(syntax.Imports);          // import(...) / import.meta are not import statements
+        Assert.Single(syntax.Exports);         // only the real export was recorded
+    }
+
+    [Fact]
+    public void Destructuring_Export_Is_Unsupported_And_Falls_Back()
+    {
+        var syntax = EsModuleScanner.Scan("export const { a, b } = obj;");
+        Assert.False(syntax.Supported);
+    }
+
+    [Fact]
+    public void Real_Import_Adjacent_To_A_String_Mentioning_Import_Is_Transformed()
+    {
+        var files = new Dictionary<string, string> { ["file:///app/d.mjs"] = "export const val = 3;" };
+        var entries = new List<ModuleGraphLoader.GraphModule>
+        {
+            new("file:///app/main.mjs",
+                "import { val } from './d.mjs'; globalThis.note = 'use import wisely'; globalThis.val = val;",
+                "file:///app/main.mjs"),
+        };
+        using var ctx = RunGraph(entries, files);
+        Assert.Equal("3", Eval(ctx, "globalThis.val"));
+        Assert.Equal("use import wisely", Eval(ctx, "globalThis.note"));
+    }
+
+    // ── full ExtractAll integration ─────────────────────────────────────────
+
+    [Fact]
+    public void ExtractAll_Links_An_Inline_Module_Import_Graph_From_Disk()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "brmod_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "util.mjs"),
+                "import { base } from './base.mjs'; export const answer = base + 2;");
+            File.WriteAllText(Path.Combine(dir, "base.mjs"), "export const base = 40;");
+            var pageUrl = new Uri(Path.Combine(dir, "index.html")).AbsoluteUri;
+
+            const string html =
+                "<script type=\"module\">import { answer } from './util.mjs'; globalThis.result = answer;</script>";
+
+            var result = ScriptExtractionService.ExtractAll(html, pageUrl);
+
+            // Three modules in the graph (base ← util ← inline), ordered dependency-first.
+            Assert.Equal(3, result.ModuleScripts.Count);
+
+            using var ctx = new JSContext();
+            foreach (var program in result.ModuleScripts)
+                ctx.Eval(program);
+            Assert.Equal("42", ctx.Eval("globalThis.result").ToString());
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Unresolvable_Dependency_Renders_Runtime_Throw_Not_Silent_Undefined()
+    {
+        var entries = new List<ModuleGraphLoader.GraphModule>
+        {
+            new("file:///app/main.mjs", "import { x } from './missing.mjs'; globalThis.x = x;",
+                "file:///app/main.mjs"),
+        };
+
+        // The missing module can't be fetched; the linked program throws at runtime (caught by Eval here).
+        var result = ModuleGraphLoader.Load(entries, (_, _) => null);
+        using var ctx = new JSContext();
+        var threw = false;
+        try { foreach (var p in result.Programs) ctx.Eval(p); }
+        catch { threw = true; }
+        Assert.True(threw);
+    }
+}

--- a/src/Broiler.Cli.Tests/OriginTests.cs
+++ b/src/Broiler.Cli.Tests/OriginTests.cs
@@ -1,0 +1,44 @@
+using System;
+using Broiler.HtmlBridge.Scripting;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Phase 7 (item 4): tests for the shared <see cref="Origin"/> primitive that replaced the five
+/// copy-pasted <c>scheme://host[:port]</c> constructions and two scheme/host/port comparisons across the
+/// CSP matcher, cross-origin check, <c>postMessage</c> delivery, and the <c>Location</c> projections.
+/// </summary>
+public sealed class OriginTests
+{
+    [Fact]
+    public void Of_Serializes_Scheme_Host_And_Omits_Default_Port()
+    {
+        Assert.Equal("https://a.test", Origin.Of(new Uri("https://a.test/page.html")));
+        Assert.Equal("http://a.test", Origin.Of(new Uri("http://a.test:80/x")));      // default port omitted
+        Assert.Equal("https://a.test:8443", Origin.Of(new Uri("https://a.test:8443/x"))); // non-default kept
+    }
+
+    [Fact]
+    public void HostOf_Returns_Host_With_Optional_Port()
+    {
+        Assert.Equal("a.test", Origin.HostOf(new Uri("https://a.test/x")));
+        Assert.Equal("a.test:8443", Origin.HostOf(new Uri("https://a.test:8443/x")));
+    }
+
+    [Fact]
+    public void SchemeHostPortEquals_Compares_All_Three_Components()
+    {
+        var a = new Uri("https://a.test:443/x");
+        Assert.True(Origin.SchemeHostPortEquals(a, new Uri("https://a.test/y")));    // default 443 == 443
+        Assert.False(Origin.SchemeHostPortEquals(a, new Uri("http://a.test/y")));    // scheme
+        Assert.False(Origin.SchemeHostPortEquals(a, new Uri("https://b.test/y")));   // host
+        Assert.False(Origin.SchemeHostPortEquals(a, new Uri("https://a.test:8443/y"))); // port
+    }
+
+    [Fact]
+    public void SchemeHostPortEquals_Is_Case_Insensitive_On_Scheme_And_Host()
+    {
+        Assert.True(Origin.SchemeHostPortEquals(
+            new Uri("HTTPS://A.TEST/x"), new Uri("https://a.test/y")));
+    }
+}

--- a/src/Broiler.HtmlBridge.Core/Scripting/ContentSecurityPolicy.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/ContentSecurityPolicy.cs
@@ -256,6 +256,50 @@ public sealed class ContentSecurityPolicy
     }
 
     /// <summary>
+    /// Returns whether an external stylesheet URL (a <c>&lt;link rel="stylesheet"&gt;</c> href) is allowed
+    /// under the effective <c>style-src-elem</c> → <c>style-src</c> → <c>default-src</c> directive. This is
+    /// the style analogue of <see cref="AllowsExternalScript"/>: it applies the same source-token matching
+    /// (<c>*</c>, <c>'self'</c>, scheme source, absolute host source) plus a <c>&lt;link&gt;</c> nonce, but
+    /// not <c>'unsafe-inline'</c> (which does not apply to a fetched URL) nor <c>'strict-dynamic'</c> (a
+    /// script-only keyword).
+    /// </summary>
+    public bool AllowsExternalStyle(string styleUrl, string? pageUrl, string? nonce = null)
+    {
+        var sources = GetEffectiveStyleElementSources();
+        if (sources.Count == 0)
+            return true;
+
+        if (IsNoneOnly(sources))
+            return false;
+
+        if (!string.IsNullOrEmpty(nonce) && MatchesNonce(sources, nonce))
+            return true;
+
+        var resolved = CspSourceMatching.ResolveUri(styleUrl, pageUrl);
+        if (resolved == null)
+            return false;
+
+        foreach (var source in sources)
+        {
+            if (string.Equals(source, "*", StringComparison.Ordinal))
+                return true;
+
+            if (string.Equals(source, "'self'", StringComparison.OrdinalIgnoreCase) &&
+                CspSourceMatching.IsSameOrigin(resolved, pageUrl))
+                return true;
+
+            if (CspSourceMatching.IsSchemeSource(source) &&
+                string.Equals(resolved.Scheme, source[..^1], StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (CspSourceMatching.MatchesAbsoluteSource(source, resolved))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Extract the first CSP policy declared through a
     /// <c>&lt;meta http-equiv=\"Content-Security-Policy\"&gt;</c> tag.
     /// Returns <c>null</c> when no supported policy is present.

--- a/src/Broiler.HtmlBridge.Core/Scripting/CspSourceMatching.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/CspSourceMatching.cs
@@ -29,9 +29,7 @@ internal static class CspSourceMatching
             string.Equals(pageUri.Scheme, "file", StringComparison.OrdinalIgnoreCase))
             return true;
 
-        return string.Equals(candidate.Scheme, pageUri.Scheme, StringComparison.OrdinalIgnoreCase) &&
-               string.Equals(candidate.Host, pageUri.Host, StringComparison.OrdinalIgnoreCase) &&
-               candidate.Port == pageUri.Port;
+        return Origin.SchemeHostPortEquals(candidate, pageUri);
     }
 
     /// <summary>Whether a CSP source token is a bare scheme source such as <c>https:</c>

--- a/src/Broiler.HtmlBridge.Core/Scripting/EsModuleLinker.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/EsModuleLinker.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Broiler.HtmlBridge.Scripting;
+
+/// <summary>
+/// Rewrites one module's source (Phase 7 item 6) into a plain-JavaScript program that a non-module
+/// evaluator (<c>JSContext.Eval</c>) can run, wiring its <c>import</c>/<c>export</c> statements to a
+/// runtime module registry shared across the document's module graph. Each module becomes a strict IIFE
+/// that (1) registers its exports object under its key before running (so a circular import sees the
+/// in-progress object), (2) reads its imports from the registry, and (3) publishes its exports.
+/// </summary>
+/// <remarks>
+/// <para>Bindings are <b>snapshots</b> taken at the end of the exporting module's evaluation, not live
+/// bindings. Because the graph is evaluated dependency-first, an acyclic import always reads a fully
+/// populated exports object; the snapshot only differs from spec behaviour for a value reassigned after
+/// evaluation or read across a cycle. A namespace import (<c>import * as ns</c>) binds the exports object
+/// itself, so it does reflect later writes.</para>
+/// <para>The bootstrap program (<see cref="Bootstrap"/>) must run once before any module program.</para>
+/// </remarks>
+internal static class EsModuleLinker
+{
+    /// <summary>The registry helpers, evaluated once before the module programs.</summary>
+    public const string Bootstrap =
+        "globalThis.__brmods=globalThis.__brmods||{};" +
+        "globalThis.__brreg=function(k){var m=globalThis.__brmods[k];if(!m){m={};globalThis.__brmods[k]=m;}return m;};" +
+        "globalThis.__brqr=function(k){var m=globalThis.__brmods[k];if(!m){m={};globalThis.__brmods[k]=m;}return m;};";
+
+    private readonly record struct Edit(int Start, int Length, string Text);
+
+    /// <summary>
+    /// Renders <paramref name="source"/> (whose parsed <paramref name="syntax"/> is
+    /// <see cref="EsModuleSyntax.Supported"/>) into its linked program. <paramref name="keyOf"/> maps an
+    /// import specifier to its resolved registry key (the resolved module URL); it must return non-null for
+    /// every dependency (the graph loader guarantees this before rendering).
+    /// </summary>
+    public static string Render(string source, EsModuleSyntax syntax, string moduleKey, Func<string, string?> keyOf)
+    {
+        var edits = new List<Edit>();
+        var endAssigns = new StringBuilder();
+
+        foreach (var imp in syntax.Imports)
+        {
+            var key = keyOf(imp.Specifier);
+            var sb = new StringBuilder();
+            if (key == null)
+            {
+                // Unresolved dependency — fail loudly at runtime rather than silently binding undefined.
+                sb.Append("throw new Error(\"Module not found: ").Append(JsEscapeRaw(imp.Specifier)).Append("\");");
+            }
+            else
+            {
+                var req = $"globalThis.__brqr({JsString(key)})";
+                if (imp.NamespaceName != null)
+                    sb.Append("var ").Append(imp.NamespaceName).Append('=').Append(req).Append(';');
+                if (imp.DefaultName != null)
+                    sb.Append("var ").Append(imp.DefaultName).Append('=').Append(req).Append("[\"default\"];");
+                foreach (var (imported, local) in imp.Named)
+                    sb.Append("var ").Append(local).Append('=').Append(req).Append('[').Append(JsString(imported)).Append("];");
+                if (imp.NamespaceName == null && imp.DefaultName == null && imp.Named.Count == 0)
+                    sb.Append(req).Append(';'); // side-effect import
+            }
+            edits.Add(new Edit(imp.Start, imp.Length, sb.ToString()));
+        }
+
+        foreach (var exp in syntax.Exports)
+        {
+            switch (exp.Kind)
+            {
+                case ModuleExportKind.Declaration:
+                    // Strip `export `; publish the declared names at module end (after the declaration runs).
+                    edits.Add(new Edit(exp.Start, exp.Length, string.Empty));
+                    foreach (var name in exp.Names!)
+                        endAssigns.Append("__E[").Append(JsString(name)).Append("]=").Append(name).Append(';');
+                    break;
+
+                case ModuleExportKind.NamedList:
+                    // Remove the statement; publish local→exported at module end (locals may be hoisted).
+                    edits.Add(new Edit(exp.Start, exp.Length, string.Empty));
+                    foreach (var (local, exported) in exp.Bindings!)
+                        endAssigns.Append("__E[").Append(JsString(exported)).Append("]=").Append(local).Append(';');
+                    break;
+
+                case ModuleExportKind.ReExportNamed:
+                {
+                    var key = keyOf(exp.Specifier!);
+                    var sb = new StringBuilder();
+                    if (key == null)
+                        sb.Append("throw new Error(\"Module not found: ").Append(JsEscapeRaw(exp.Specifier!)).Append("\");");
+                    else
+                    {
+                        var req = $"globalThis.__brqr({JsString(key)})";
+                        foreach (var (imported, exported) in exp.Bindings!)
+                            sb.Append("__E[").Append(JsString(exported)).Append("]=").Append(req).Append('[').Append(JsString(imported)).Append("];");
+                    }
+                    edits.Add(new Edit(exp.Start, exp.Length, sb.ToString()));
+                    break;
+                }
+
+                case ModuleExportKind.ReExportStar:
+                {
+                    var key = keyOf(exp.Specifier!);
+                    string text = key == null
+                        ? $"throw new Error(\"Module not found: {JsEscapeRaw(exp.Specifier!)}\");"
+                        : $"(function(_s){{for(var _k in _s){{if(_k!==\"default\")__E[_k]=_s[_k];}}}})(globalThis.__brqr({JsString(key)}));";
+                    edits.Add(new Edit(exp.Start, exp.Length, text));
+                    break;
+                }
+
+                case ModuleExportKind.ReExportStarAs:
+                {
+                    var key = keyOf(exp.Specifier!);
+                    string text = key == null
+                        ? $"throw new Error(\"Module not found: {JsEscapeRaw(exp.Specifier!)}\");"
+                        : $"__E[{JsString(exp.NamespaceName!)}]=globalThis.__brqr({JsString(key)});";
+                    edits.Add(new Edit(exp.Start, exp.Length, text));
+                    break;
+                }
+
+                case ModuleExportKind.Default:
+                    // Replace `export ... default` with an assignment; the expression/decl that follows stays.
+                    edits.Add(new Edit(exp.Start, exp.Length, "__E[\"default\"]="));
+                    break;
+            }
+        }
+
+        edits.Sort((a, b) => a.Start.CompareTo(b.Start));
+
+        var body = new StringBuilder(source.Length + 64);
+        int pos = 0;
+        foreach (var e in edits)
+        {
+            if (e.Start > pos)
+                body.Append(source, pos, e.Start - pos);
+            body.Append(e.Text);
+            pos = e.Start + e.Length;
+        }
+        if (pos < source.Length)
+            body.Append(source, pos, source.Length - pos);
+
+        var program = new StringBuilder();
+        // Self-bootstrap: the registry helpers are idempotent, so every module program can define them and
+        // the programs can run in any dependency-first order without a separate bootstrap step.
+        program.Append(Bootstrap).Append('\n');
+        program.Append("(function(){\"use strict\";\n");
+        program.Append("var __E=globalThis.__brreg(").Append(JsString(moduleKey)).Append(");\n");
+        program.Append(body);
+        program.Append('\n');
+        program.Append(endAssigns);
+        program.Append("\n})();");
+        return program.ToString();
+    }
+
+    /// <summary>Produces a JS double-quoted string literal for <paramref name="s"/>.</summary>
+    private static string JsString(string s) => "\"" + JsEscapeRaw(s) + "\"";
+
+    private static string JsEscapeRaw(string s)
+    {
+        var sb = new StringBuilder(s.Length + 8);
+        foreach (var c in s)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case '\u2028': sb.Append("\\u2028"); break;
+                case '\u2029': sb.Append("\\u2029"); break;
+                default: sb.Append(c); break;
+            }
+        }
+        return sb.ToString();
+    }
+}

--- a/src/Broiler.HtmlBridge.Core/Scripting/EsModuleScanner.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/EsModuleScanner.cs
@@ -1,0 +1,572 @@
+using System;
+using System.Collections.Generic;
+
+namespace Broiler.HtmlBridge.Scripting;
+
+/// <summary>
+/// A focused scanner (Phase 7 item 6) that finds a module's <b>top-level</b> static <c>import</c>/
+/// <c>export</c> statements so the <see cref="EsModuleLinker"/> can rewrite them into a runtime registry.
+/// It is deliberately not a full JS parser: it tracks string / template / comment / regex literals and
+/// bracket nesting so it never mistakes an <c>import</c>/<c>export</c> inside a string, a comment, a
+/// property name (<c>obj.export</c>), <c>exports.x</c> (CommonJS), or a nested scope for a module
+/// statement, and it recognises only the import/export forms it can transform correctly. Any unrecognised
+/// or malformed top-level form sets <see cref="EsModuleSyntax.Supported"/> to <c>false</c>, and the linker
+/// then leaves that module untransformed rather than emitting wrong code — so the feature is additive.
+/// </summary>
+/// <remarks>
+/// Deliberately out of scope (each marks the module unsupported, or is left as-is): destructuring exports
+/// (<c>export const { a } = o</c>), <c>import.meta</c> and dynamic <c>import(...)</c> at statement start
+/// (left untouched — they are expressions, not module statements), and top-level <c>await</c>.
+/// </remarks>
+internal static class EsModuleScanner
+{
+    public static EsModuleSyntax Scan(string source)
+    {
+        var syntax = new EsModuleSyntax();
+        int n = source.Length;
+        int i = 0;
+        int depth = 0;              // () [] {} nesting
+        char prevSignificant = '\0'; // last non-ws/comment char (for regex detection + property guard)
+
+        while (i < n)
+        {
+            char c = source[i];
+
+            // Whitespace.
+            if (c is ' ' or '\t' or '\r' or '\n' or '\f' or '\v')
+            {
+                i++;
+                continue;
+            }
+
+            // Comments.
+            if (c == '/' && i + 1 < n && source[i + 1] == '/')
+            {
+                i += 2;
+                while (i < n && source[i] != '\n') i++;
+                continue;
+            }
+            if (c == '/' && i + 1 < n && source[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < n && !(source[i] == '*' && source[i + 1] == '/')) i++;
+                i = Math.Min(n, i + 2);
+                continue;
+            }
+
+            // String literals.
+            if (c is '"' or '\'')
+            {
+                i = SkipString(source, i, c);
+                prevSignificant = c;
+                continue;
+            }
+
+            // Template literals (with ${ } interpolation; nesting-aware).
+            if (c == '`')
+            {
+                i = SkipTemplate(source, i);
+                prevSignificant = '`';
+                continue;
+            }
+
+            // Regex literal vs division: only when a regex is grammatically allowed here.
+            if (c == '/' && RegexAllowed(prevSignificant))
+            {
+                i = SkipRegex(source, i);
+                prevSignificant = '/';
+                continue;
+            }
+
+            // Bracket nesting.
+            if (c is '(' or '[' or '{') { depth++; prevSignificant = c; i++; continue; }
+            if (c is ')' or ']' or '}') { if (depth > 0) depth--; prevSignificant = c; i++; continue; }
+
+            // Only top-level import/export statements are module syntax.
+            if (depth == 0 && (c == 'i' || c == 'e') && prevSignificant != '.' &&
+                IsWordAt(source, i, out int wordEnd) is { } word &&
+                (word == "import" || word == "export") &&
+                (i == 0 || !IsIdentPart(source[i - 1])))
+            {
+                if (word == "import")
+                {
+                    // Distinguish `import(...)` / `import.meta` (expressions) from an import statement.
+                    int p = SkipTrivia(source, wordEnd);
+                    if (p < n && (source[p] == '(' || source[p] == '.'))
+                    {
+                        // Dynamic import / import.meta — leave untouched, advance past the keyword.
+                        prevSignificant = 't';
+                        i = wordEnd;
+                        continue;
+                    }
+                    if (!ParseImport(source, i, wordEnd, syntax, out i))
+                    {
+                        syntax.Supported = false;
+                        return syntax;
+                    }
+                    prevSignificant = ';';
+                    continue;
+                }
+                else // export
+                {
+                    if (!ParseExport(source, i, wordEnd, syntax, out i))
+                    {
+                        syntax.Supported = false;
+                        return syntax;
+                    }
+                    prevSignificant = ';';
+                    continue;
+                }
+            }
+
+            prevSignificant = c;
+            i++;
+        }
+
+        return syntax;
+    }
+
+    // ── import ──────────────────────────────────────────────────────────────
+
+    private static bool ParseImport(string src, int stmtStart, int afterKw, EsModuleSyntax syntax, out int next)
+    {
+        next = afterKw;
+        int i = SkipTrivia(src, afterKw);
+        int n = src.Length;
+        if (i >= n) return false;
+
+        // Side-effect import: import "spec";
+        if (src[i] is '"' or '\'')
+        {
+            if (!ReadStringLiteral(src, i, out var spec, out int afterSpec)) return false;
+            int end = ConsumeToStatementEnd(src, afterSpec);
+            syntax.Imports.Add(new ModuleImport(spec, null, null, [], stmtStart, end - stmtStart));
+            next = end;
+            return true;
+        }
+
+        string? defaultName = null;
+        string? namespaceName = null;
+        var named = new List<(string, string)>();
+
+        // default binding
+        if (IsIdentStart(src[i]))
+        {
+            defaultName = ReadIdent(src, ref i);
+            i = SkipTrivia(src, i);
+            if (i < n && src[i] == ',') { i = SkipTrivia(src, i + 1); }
+            else
+            {
+                // must be `from`
+                if (!ExpectWord(src, ref i, "from")) return false;
+                return FinishImport(src, i, stmtStart, defaultName, null, named, syntax, out next);
+            }
+        }
+
+        if (i < n && src[i] == '*')
+        {
+            i = SkipTrivia(src, i + 1);
+            if (!ExpectWord(src, ref i, "as")) return false;
+            i = SkipTrivia(src, i);
+            if (i >= n || !IsIdentStart(src[i])) return false;
+            namespaceName = ReadIdent(src, ref i);
+            i = SkipTrivia(src, i);
+        }
+        else if (i < n && src[i] == '{')
+        {
+            if (!ReadNamedList(src, ref i, named)) return false;
+            i = SkipTrivia(src, i);
+        }
+        else
+        {
+            return false;
+        }
+
+        if (!ExpectWord(src, ref i, "from")) return false;
+        return FinishImport(src, i, stmtStart, defaultName, namespaceName, named, syntax, out next);
+    }
+
+    private static bool FinishImport(
+        string src, int i, int stmtStart, string? defaultName, string? namespaceName,
+        List<(string, string)> named, EsModuleSyntax syntax, out int next)
+    {
+        next = i;
+        i = SkipTrivia(src, i);
+        if (i >= src.Length || src[i] is not ('"' or '\'')) return false;
+        if (!ReadStringLiteral(src, i, out var spec, out int afterSpec)) return false;
+        int end = ConsumeToStatementEnd(src, afterSpec);
+        syntax.Imports.Add(new ModuleImport(spec, defaultName, namespaceName, named, stmtStart, end - stmtStart));
+        next = end;
+        return true;
+    }
+
+    // ── export ──────────────────────────────────────────────────────────────
+
+    private static bool ParseExport(string src, int stmtStart, int afterKw, EsModuleSyntax syntax, out int next)
+    {
+        next = afterKw;
+        int n = src.Length;
+        int i = SkipTrivia(src, afterKw);
+        if (i >= n) return false;
+
+        // export * [as ns] from "spec"
+        if (src[i] == '*')
+        {
+            i = SkipTrivia(src, i + 1);
+            string? nsName = null;
+            if (StartsWord(src, i, "as"))
+            {
+                i = SkipTrivia(src, i + 2);
+                if (i >= n || !IsIdentStart(src[i])) return false;
+                nsName = ReadIdent(src, ref i);
+                i = SkipTrivia(src, i);
+            }
+            if (!ExpectWord(src, ref i, "from")) return false;
+            i = SkipTrivia(src, i);
+            if (!ReadStringLiteral(src, i, out var spec, out int afterSpec)) return false;
+            int end = ConsumeToStatementEnd(src, afterSpec);
+            syntax.Exports.Add(nsName == null
+                ? new ModuleExport(ModuleExportKind.ReExportStar, stmtStart, end - stmtStart, Specifier: spec)
+                : new ModuleExport(ModuleExportKind.ReExportStarAs, stmtStart, end - stmtStart, Specifier: spec, NamespaceName: nsName));
+            next = end;
+            return true;
+        }
+
+        // export { ... } [from "spec"]
+        if (src[i] == '{')
+        {
+            var pairs = new List<(string, string)>();
+            if (!ReadNamedList(src, ref i, pairs)) return false;
+            i = SkipTrivia(src, i);
+            if (StartsWord(src, i, "from"))
+            {
+                i = SkipTrivia(src, i + 4);
+                if (!ReadStringLiteral(src, i, out var spec, out int afterSpec)) return false;
+                int end = ConsumeToStatementEnd(src, afterSpec);
+                // For re-export, the pair is (imported, exported).
+                syntax.Exports.Add(new ModuleExport(ModuleExportKind.ReExportNamed, stmtStart, end - stmtStart,
+                    Specifier: spec, Bindings: pairs));
+                next = end;
+                return true;
+            }
+            else
+            {
+                int end = ConsumeToStatementEnd(src, i);
+                // For a local list, the pair is (local, exported).
+                syntax.Exports.Add(new ModuleExport(ModuleExportKind.NamedList, stmtStart, end - stmtStart,
+                    Bindings: pairs));
+                next = end;
+                return true;
+            }
+        }
+
+        // export default ...
+        if (StartsWord(src, i, "default"))
+        {
+            int afterDefault = i + 7; // "default"
+            // The rewrite span covers only `export ... default`; the expression/decl stays in place.
+            syntax.Exports.Add(new ModuleExport(ModuleExportKind.Default, stmtStart, afterDefault - stmtStart));
+            next = afterDefault;
+            return true;
+        }
+
+        // export const/let/var/function/class/async function NAME ...
+        var names = new List<string>();
+        int declKwStart = i;
+        string? kw = IsWordAt(src, i, out int kwEnd) ;
+        if (kw is "function" or "class")
+        {
+            i = SkipTrivia(src, kwEnd);
+            if (kw == "function" && i < n && src[i] == '*') i = SkipTrivia(src, i + 1); // generator
+            if (i >= n || !IsIdentStart(src[i])) return false;
+            names.Add(ReadIdent(src, ref i));
+        }
+        else if (kw == "async")
+        {
+            i = SkipTrivia(src, kwEnd);
+            if (!StartsWord(src, i, "function")) return false;
+            i = SkipTrivia(src, i + 8);
+            if (i < n && src[i] == '*') i = SkipTrivia(src, i + 1);
+            if (i >= n || !IsIdentStart(src[i])) return false;
+            names.Add(ReadIdent(src, ref i));
+        }
+        else if (kw is "const" or "let" or "var")
+        {
+            if (!CollectDeclaredNames(src, kwEnd, names)) return false;
+        }
+        else
+        {
+            return false; // unsupported export form
+        }
+
+        // Strip only `export ` (keyword + following trivia up to the declaration keyword); the declaration
+        // stays and its exported names are assigned at module end by the linker.
+        syntax.Exports.Add(new ModuleExport(ModuleExportKind.Declaration, stmtStart, declKwStart - stmtStart,
+            Names: names));
+        next = declKwStart;
+        return true;
+    }
+
+    /// <summary>
+    /// Collects the simple binding identifiers of a <c>const/let/var</c> declaration (the name after the
+    /// keyword and after each top-level comma), scanning nesting-aware to the declaration's terminating
+    /// <c>;</c> or EOF. Returns <c>false</c> for a destructuring pattern (an unsupported form).
+    /// </summary>
+    private static bool CollectDeclaredNames(string src, int afterKw, List<string> names)
+    {
+        int n = src.Length;
+        int i = SkipTrivia(src, afterKw);
+        bool expectName = true;
+        int depth = 0;
+        while (i < n)
+        {
+            char c = src[i];
+            if (expectName && depth == 0)
+            {
+                if (c is '{' or '[') return false; // destructuring — unsupported
+                if (!IsIdentStart(c)) return false;
+                names.Add(ReadIdent(src, ref i));
+                expectName = false;
+                continue;
+            }
+
+            // Skip strings/templates/comments/regex inside initializers so commas/semicolons there don't count.
+            if (c is '"' or '\'') { i = SkipString(src, i, c); continue; }
+            if (c == '`') { i = SkipTemplate(src, i); continue; }
+            if (c == '/' && i + 1 < n && src[i + 1] == '/') { while (i < n && src[i] != '\n') i++; continue; }
+            if (c == '/' && i + 1 < n && src[i + 1] == '*') { i += 2; while (i + 1 < n && !(src[i] == '*' && src[i + 1] == '/')) i++; i = Math.Min(n, i + 2); continue; }
+
+            if (c is '(' or '[' or '{') { depth++; i++; continue; }
+            if (c is ')' or ']' or '}') { if (depth > 0) depth--; i++; continue; }
+
+            if (depth == 0)
+            {
+                if (c == ';') return true;
+                if (c == ',') { expectName = true; i++; i = SkipTrivia(src, i); continue; }
+            }
+            i++;
+        }
+        return true; // EOF terminates the declaration (ASI)
+    }
+
+    // ── shared readers ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Reads a <c>{ a, b as c }</c> list into (name, alias) pairs (alias == name when no <c>as</c>). A
+    /// member name may be an identifier or a string literal (<c>{ "a-b" as c }</c>). A trailing comma is
+    /// allowed. On entry <paramref name="i"/> is at the <c>{</c>; on success it is left at the <c>}</c>.
+    /// </summary>
+    private static bool ReadNamedList(string src, ref int i, List<(string, string)> pairs)
+    {
+        int n = src.Length;
+        if (i >= n || src[i] != '{') return false;
+        i = SkipTrivia(src, i + 1);
+        while (i < n && src[i] != '}')
+        {
+            string name;
+            if (src[i] is '"' or '\'')
+            {
+                if (!ReadStringLiteral(src, i, out name, out int afterStr)) return false;
+                i = SkipTrivia(src, afterStr);
+            }
+            else if (IsIdentStart(src[i]))
+            {
+                name = ReadIdent(src, ref i);
+                i = SkipTrivia(src, i);
+            }
+            else
+            {
+                return false;
+            }
+
+            string alias = name;
+            if (StartsWord(src, i, "as"))
+            {
+                i = SkipTrivia(src, i + 2);
+                if (i < n && (src[i] is '"' or '\''))
+                {
+                    if (!ReadStringLiteral(src, i, out alias, out int afterAlias)) return false;
+                    i = SkipTrivia(src, afterAlias);
+                }
+                else if (i < n && IsIdentStart(src[i]))
+                {
+                    alias = ReadIdent(src, ref i);
+                    i = SkipTrivia(src, i);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            pairs.Add((name, alias));
+            if (i < n && src[i] == ',') { i = SkipTrivia(src, i + 1); }
+            else break;
+        }
+        if (i >= n || src[i] != '}') return false;
+        i++; // consume the closing '}'
+        return true;
+    }
+
+    // ── low-level lexing helpers ──────────────────────────────────────────────
+
+    private static int SkipTrivia(string src, int i)
+    {
+        int n = src.Length;
+        while (i < n)
+        {
+            char c = src[i];
+            if (c is ' ' or '\t' or '\r' or '\n' or '\f' or '\v') { i++; continue; }
+            if (c == '/' && i + 1 < n && src[i + 1] == '/') { i += 2; while (i < n && src[i] != '\n') i++; continue; }
+            if (c == '/' && i + 1 < n && src[i + 1] == '*') { i += 2; while (i + 1 < n && !(src[i] == '*' && src[i + 1] == '/')) i++; i = Math.Min(n, i + 2); continue; }
+            break;
+        }
+        return i;
+    }
+
+    private static int SkipString(string src, int i, char quote)
+    {
+        int n = src.Length;
+        i++;
+        while (i < n)
+        {
+            char c = src[i];
+            if (c == '\\') { i += 2; continue; }
+            if (c == quote) return i + 1;
+            i++;
+        }
+        return n;
+    }
+
+    private static int SkipTemplate(string src, int i)
+    {
+        int n = src.Length;
+        i++; // past opening `
+        while (i < n)
+        {
+            char c = src[i];
+            if (c == '\\') { i += 2; continue; }
+            if (c == '`') return i + 1;
+            if (c == '$' && i + 1 < n && src[i + 1] == '{')
+            {
+                i += 2;
+                int braces = 1;
+                while (i < n && braces > 0)
+                {
+                    char d = src[i];
+                    if (d == '\\') { i += 2; continue; }
+                    if (d is '"' or '\'') { i = SkipString(src, i, d); continue; }
+                    if (d == '`') { i = SkipTemplate(src, i); continue; }
+                    if (d == '{') braces++;
+                    else if (d == '}') braces--;
+                    i++;
+                }
+                continue;
+            }
+            i++;
+        }
+        return n;
+    }
+
+    private static int SkipRegex(string src, int i)
+    {
+        int n = src.Length;
+        i++; // past opening /
+        bool inClass = false;
+        while (i < n)
+        {
+            char c = src[i];
+            if (c == '\\') { i += 2; continue; }
+            if (c == '\n') return i; // unterminated — bail
+            if (c == '[') inClass = true;
+            else if (c == ']') inClass = false;
+            else if (c == '/' && !inClass) { i++; break; }
+            i++;
+        }
+        // flags
+        while (i < n && IsIdentPart(src[i])) i++;
+        return i;
+    }
+
+    private static bool RegexAllowed(char prev)
+    {
+        // A regex may follow nothing, an operator, or an opener — but not an identifier/number/closer/string.
+        if (prev == '\0') return true;
+        if (IsIdentPart(prev)) return false;
+        if (prev is ')' or ']' or '}') return false;
+        if (prev is '"' or '\'' or '`') return false;
+        return true;
+    }
+
+    private static bool ReadStringLiteral(string src, int i, out string value, out int after)
+    {
+        value = "";
+        after = i;
+        int n = src.Length;
+        if (i >= n || src[i] is not ('"' or '\'')) return false;
+        char q = src[i];
+        int start = i + 1;
+        int j = start;
+        var sb = new System.Text.StringBuilder();
+        while (j < n)
+        {
+            char c = src[j];
+            if (c == '\\')
+            {
+                if (j + 1 < n) { sb.Append(src[j + 1]); j += 2; continue; }
+                return false;
+            }
+            if (c == q) { value = sb.ToString(); after = j + 1; return true; }
+            sb.Append(c);
+            j++;
+        }
+        return false;
+    }
+
+    private static bool ExpectWord(string src, ref int i, string word)
+    {
+        i = SkipTrivia(src, i);
+        if (!StartsWord(src, i, word)) return false;
+        i = SkipTrivia(src, i + word.Length);
+        return true;
+    }
+
+    private static bool StartsWord(string src, int i, string word)
+    {
+        if (i + word.Length > src.Length) return false;
+        for (int k = 0; k < word.Length; k++)
+            if (src[i + k] != word[k]) return false;
+        int end = i + word.Length;
+        if (end < src.Length && IsIdentPart(src[end])) return false;
+        if (i > 0 && IsIdentPart(src[i - 1])) return false;
+        return true;
+    }
+
+    private static string? IsWordAt(string src, int i, out int end)
+    {
+        end = i;
+        if (i >= src.Length || !IsIdentStart(src[i])) return null;
+        int j = i;
+        while (j < src.Length && IsIdentPart(src[j])) j++;
+        end = j;
+        return src[i..j];
+    }
+
+    private static string ReadIdent(string src, ref int i)
+    {
+        int start = i;
+        while (i < src.Length && IsIdentPart(src[i])) i++;
+        return src[start..i];
+    }
+
+    /// <summary>Consumes an optional trailing <c>;</c> after a statement, returning the position after it.</summary>
+    private static int ConsumeToStatementEnd(string src, int i)
+    {
+        i = SkipTrivia(src, i);
+        if (i < src.Length && src[i] == ';') return i + 1;
+        return i;
+    }
+
+    private static bool IsIdentStart(char c) => char.IsLetter(c) || c == '_' || c == '$';
+    private static bool IsIdentPart(char c) => char.IsLetterOrDigit(c) || c == '_' || c == '$';
+}

--- a/src/Broiler.HtmlBridge.Core/Scripting/EsModuleSyntax.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/EsModuleSyntax.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Broiler.HtmlBridge.Scripting;
+
+/// <summary>
+/// A single top-level <c>import</c> statement parsed from a module (Phase 7 item 6). Models the union of
+/// the import forms: a default binding, a namespace (<c>* as ns</c>) binding, and/or a named list, plus a
+/// side-effect-only import (all binding fields empty). <see cref="Start"/>/<see cref="Length"/> mark the
+/// statement's span in the module source so the linker can replace it in place.
+/// </summary>
+internal sealed record ModuleImport(
+    string Specifier,
+    string? DefaultName,
+    string? NamespaceName,
+    IReadOnlyList<(string Imported, string Local)> Named,
+    int Start,
+    int Length);
+
+/// <summary>The kind of a parsed top-level <c>export</c> statement (Phase 7 item 6).</summary>
+internal enum ModuleExportKind
+{
+    /// <summary><c>export const/let/var/function/class NAME …</c> — the declaration stays; NAME is exported.</summary>
+    Declaration,
+
+    /// <summary><c>export { a, b as c }</c> — local bindings exported (optionally renamed).</summary>
+    NamedList,
+
+    /// <summary><c>export { a, b as c } from "spec"</c> — re-export named bindings from another module.</summary>
+    ReExportNamed,
+
+    /// <summary><c>export * from "spec"</c> — re-export all (except <c>default</c>).</summary>
+    ReExportStar,
+
+    /// <summary><c>export * as ns from "spec"</c> — re-export the namespace under a name.</summary>
+    ReExportStarAs,
+
+    /// <summary><c>export default EXPR</c> / <c>export default function/class …</c>.</summary>
+    Default,
+}
+
+/// <summary>
+/// A single top-level <c>export</c> statement parsed from a module (Phase 7 item 6). The fields used
+/// depend on <see cref="Kind"/>; <see cref="Start"/>/<see cref="Length"/> mark the span the linker rewrites.
+/// </summary>
+internal sealed record ModuleExport(
+    ModuleExportKind Kind,
+    int Start,
+    int Length,
+    string? Specifier = null,
+    IReadOnlyList<(string Local, string Exported)>? Bindings = null,
+    IReadOnlyList<string>? Names = null,
+    string? NamespaceName = null,
+    string? DefaultBoundName = null);
+
+/// <summary>
+/// The parsed module-syntax view of one module source (Phase 7 item 6): its top-level static
+/// <c>import</c>/<c>export</c> statements. <see cref="Supported"/> is <c>false</c> when the scanner meets a
+/// form it does not confidently handle (destructuring exports, an unterminated statement, etc.) — the
+/// linker then falls back to running the module as-is rather than emitting a wrong transform, so the
+/// feature is strictly additive.
+/// </summary>
+internal sealed class EsModuleSyntax
+{
+    /// <summary>Top-level <c>import</c> statements in source order.</summary>
+    public List<ModuleImport> Imports { get; } = [];
+
+    /// <summary>Top-level <c>export</c> statements in source order.</summary>
+    public List<ModuleExport> Exports { get; } = [];
+
+    /// <summary>Whether every top-level import/export was recognised (so the transform is safe to apply).</summary>
+    public bool Supported { get; internal set; } = true;
+
+    /// <summary>Whether the module has any static import/export at all (else it needs no linking).</summary>
+    public bool HasModuleSyntax => Imports.Count > 0 || Exports.Count > 0;
+
+    /// <summary>The distinct import specifiers this module depends on, in first-seen order (imports then re-exports).</summary>
+    public IReadOnlyList<string> Dependencies()
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var deps = new List<string>();
+        void Add(string? s)
+        {
+            if (!string.IsNullOrEmpty(s) && seen.Add(s)) deps.Add(s);
+        }
+        foreach (var imp in Imports) Add(imp.Specifier);
+        foreach (var exp in Exports) Add(exp.Specifier);
+        return deps;
+    }
+}

--- a/src/Broiler.HtmlBridge.Core/Scripting/IScriptExtractor.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/IScriptExtractor.cs
@@ -34,10 +34,12 @@ public sealed record ScriptDescriptor(
 
 /// <summary>
 /// One entry in a document's <see cref="ModuleMap"/> (Phase 7 item 6): a recognised
-/// <c>&lt;script type="module"&gt;</c> keyed for the browser module system. Inline modules are keyed by a
-/// synthetic <c>inline:{order}</c> id and carry their authorised body in <see cref="Source"/>; module
-/// scripts with a <c>src</c> are recorded with their URL but not yet fetched (a later slice loads them),
-/// so their <see cref="Source"/> is <c>null</c> and <see cref="IsExecutable"/> is <c>false</c>.
+/// <c>&lt;script type="module"&gt;</c> root keyed for the browser module system. Inline modules are keyed by
+/// a synthetic <c>inline:{order}</c> id; module scripts with a <c>src</c> are keyed by URL. An authorised
+/// module carries its resolved body in <see cref="Source"/> with <see cref="IsExecutable"/> <c>true</c>; a
+/// module blocked by CSP or unresolvable has a <c>null</c> <see cref="Source"/> and is not executable. The
+/// map records the document's top-level module roots; the linked graph (roots + transitive dependencies)
+/// is in <see cref="ScriptExtractionResult.ModuleScripts"/>.
 /// </summary>
 public sealed record ModuleMapEntry(
     int DocumentOrder,
@@ -48,11 +50,11 @@ public sealed record ModuleMapEntry(
     bool IsExecutable);
 
 /// <summary>
-/// The document's module map (Phase 7 item 6, first slice): the registry of recognised
-/// <c>&lt;script type="module"&gt;</c> elements in document order, so a module is no longer silently
-/// dropped. Inline modules are executable now; external/data-URI module loading (fetch + import graph) is
-/// a later slice. Keyed by <see cref="ModuleMapEntry.Key"/> (an inline module's synthetic id or an
-/// external module's URL).
+/// The document's module map (Phase 7 item 6): the registry of recognised
+/// <c>&lt;script type="module"&gt;</c> roots in document order, so a module is never silently dropped.
+/// Inline, <c>data:</c> and external module roots are all resolved and, when authorised, linked into the
+/// executable graph. Keyed by <see cref="ModuleMapEntry.Key"/> (an inline module's synthetic id or a module
+/// URL).
 /// </summary>
 public sealed class ModuleMap
 {
@@ -106,11 +108,12 @@ public sealed class ScriptExtractionResult(
     public IReadOnlyList<ScriptDescriptor> Descriptors { get; } = descriptors ?? [];
 
     /// <summary>
-    /// Executable inline module bodies (Phase 7 item 6, first slice), in document order, each already
-    /// wrapped for module top-level semantics (strict mode, own scope) by
-    /// <see cref="ModuleScriptWrapper.WrapInlineModule"/>. Module scripts are deferred, so a consumer runs
-    /// these after the classic <see cref="DeferredScripts"/>. External/data-URI module loading is a later
-    /// slice, so those modules appear only in <see cref="ModuleMap"/>, not here.
+    /// The document's linked module graph (Phase 7 item 6) as executable programs in <b>dependency-first</b>
+    /// order — every module (each <c>&lt;script type="module"&gt;</c> root plus its transitively imported
+    /// dependencies) rewritten so its <c>import</c>/<c>export</c> statements read/write a shared runtime
+    /// registry, each in its own strict module scope. Module scripts are deferred, so a consumer runs these
+    /// after the classic <see cref="DeferredScripts"/>; running them in list order satisfies the graph's
+    /// evaluation order. A module whose syntax cannot be transformed runs as-is (fallback).
     /// </summary>
     public IReadOnlyList<string> ModuleScripts { get; } = moduleScripts ?? [];
 

--- a/src/Broiler.HtmlBridge.Core/Scripting/ModuleGraphLoader.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/ModuleGraphLoader.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+
+namespace Broiler.HtmlBridge.Scripting;
+
+/// <summary>
+/// Builds and links a document's ES module graph (Phase 7 item 6). Starting from the document's
+/// <c>&lt;script type="module"&gt;</c> entries, it resolves each static import specifier to a URL, fetches
+/// the dependency, recurses, dedups repeated modules, orders the graph dependency-first (cycle-safe), and
+/// renders each module to a linked plain-JS program (via <see cref="EsModuleLinker"/>) that the existing
+/// non-module evaluator runs in order. A module whose syntax the scanner cannot confidently transform
+/// falls back to running as-is (today's behaviour), so the feature is strictly additive.
+/// </summary>
+internal static class ModuleGraphLoader
+{
+    /// <summary>A discovered/entry module: its registry key (resolved URL or synthetic inline id), its
+    /// source text, and the base URL its relative imports resolve against.</summary>
+    public readonly record struct GraphModule(string Key, string Source, string? BaseUrl);
+
+    /// <summary>Resolves an import specifier (relative to <paramref name="baseUrl"/>) to its absolute key
+    /// and fetches its source; returns <c>null</c> when it cannot be resolved/fetched/authorised.</summary>
+    public delegate (string Key, string Source)? ResolveAndFetch(string specifier, string? baseUrl);
+
+    /// <summary>The linked, dependency-ordered module programs to evaluate in sequence.</summary>
+    public sealed record Result(IReadOnlyList<string> Programs, IReadOnlyList<string> OrderedKeys);
+
+    private sealed class Node
+    {
+        public required string Key;
+        public required string Source;
+        public required string? BaseUrl;
+        public required EsModuleSyntax Syntax;
+        public readonly Dictionary<string, string?> DepKeys = new(StringComparer.Ordinal); // specifier -> resolved key
+    }
+
+    /// <summary>
+    /// Loads and links the graph rooted at <paramref name="entries"/> (in document order). Entry modules
+    /// are already resolved+fetched (inline modules carry a synthetic key); <paramref name="resolveAndFetch"/>
+    /// loads their transitive dependencies.
+    /// </summary>
+    public static Result Load(IReadOnlyList<GraphModule> entries, ResolveAndFetch resolveAndFetch)
+    {
+        var nodes = new Dictionary<string, Node>(StringComparer.Ordinal);
+
+        Node Intern(GraphModule m)
+        {
+            if (nodes.TryGetValue(m.Key, out var existing))
+                return existing;
+            var node = new Node
+            {
+                Key = m.Key,
+                Source = m.Source,
+                BaseUrl = m.BaseUrl,
+                Syntax = EsModuleScanner.Scan(m.Source),
+            };
+            nodes[m.Key] = node;
+            return node;
+        }
+
+        var order = new List<string>();
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var visiting = new HashSet<string>(StringComparer.Ordinal);
+
+        void Visit(Node node)
+        {
+            if (!visited.Add(node.Key)) return;   // already fully processed
+            visiting.Add(node.Key);
+
+            if (node.Syntax.Supported)
+            {
+                foreach (var specifier in node.Syntax.Dependencies())
+                {
+                    var loaded = resolveAndFetch(specifier, node.BaseUrl);
+                    if (loaded is not { } dep)
+                    {
+                        node.DepKeys[specifier] = null; // unresolved — renders a runtime throw
+                        continue;
+                    }
+
+                    node.DepKeys[specifier] = dep.Key;
+                    var depNode = Intern(new GraphModule(dep.Key, dep.Source, dep.Key));
+                    if (!visiting.Contains(depNode.Key))   // skip the back-edge of a cycle
+                        Visit(depNode);
+                }
+            }
+
+            visiting.Remove(node.Key);
+            order.Add(node.Key);                  // post-order: dependencies precede this module
+        }
+
+        foreach (var entry in entries)
+            Visit(Intern(entry));
+
+        var programs = new List<string>(order.Count);
+        foreach (var key in order)
+        {
+            var node = nodes[key];
+            programs.Add(node.Syntax.Supported
+                ? EsModuleLinker.Render(node.Source, node.Syntax, node.Key,
+                    spec => node.DepKeys.TryGetValue(spec, out var k) ? k : null)
+                : ModuleScriptWrapper.WrapInlineModule(node.Source)); // fallback: today's behaviour
+        }
+
+        return new Result(programs, order);
+    }
+}

--- a/src/Broiler.HtmlBridge.Core/Scripting/ModuleScriptWrapper.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/ModuleScriptWrapper.cs
@@ -9,10 +9,11 @@ namespace Broiler.HtmlBridge.Scripting;
 /// <c>this</c> is <c>undefined</c> (a strict function invoked without a receiver) as in a module.
 /// </summary>
 /// <remarks>
-/// This is deliberately a first slice: it does not provide <c>import</c>/<c>export</c>, <c>import.meta</c>
-/// or top-level <c>await</c>. A wrapped module that uses those raises a syntax/runtime error at execution
-/// (surfaced to the caller's logger) rather than being silently skipped — full module-graph loading is a
-/// later slice.
+/// This wrapper handles a module with no <c>import</c>/<c>export</c>. Modules that use them are linked by
+/// the <see cref="ModuleGraphLoader"/> (resolve + fetch + dedup + dependency-first order + import/export
+/// rewrite); this wrapper is the loader's <b>fallback</b> for a module whose syntax the scanner cannot
+/// confidently transform (destructuring exports, top-level <c>await</c>) — the module then runs as-is and
+/// any unsupported construct surfaces its error at execution rather than being silently skipped.
 /// </remarks>
 public static class ModuleScriptWrapper
 {

--- a/src/Broiler.HtmlBridge.Core/Scripting/Origin.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/Origin.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace Broiler.HtmlBridge.Scripting;
+
+/// <summary>
+/// The one origin serialization/comparison implementation shared by CSP source matching, cross-origin
+/// checks, <c>postMessage</c> target-origin delivery, and the <c>Location</c> <c>origin</c>/<c>host</c>
+/// projections (Phase 7 item 4 — the "one URL resolution/origin implementation shared by script, CSS,
+/// fetch, XHR and frames" exit criterion, origin half). Before this, the
+/// <c>scheme://host[:port]</c> construction was copy-pasted in five places and the scheme+host+port
+/// comparison in two; this collapses both to a single primitive.
+/// </summary>
+/// <remarks>
+/// This helper is the origin <em>primitive</em> only. Each caller keeps its own surrounding policy —
+/// which schemes/values inherit the embedding origin (<c>about:blank</c>, <c>data:</c>, <c>file:</c>),
+/// how a null page URL is treated — because those nuances differ per site (a cross-origin check and a
+/// CSP <c>'self'</c> match do not agree on <c>file:</c>). Only the shared serialization and the
+/// scheme/host/port equality live here.
+/// </remarks>
+internal static class Origin
+{
+    /// <summary>
+    /// The origin serialization <c>scheme://host[:port]</c> (the default port is omitted). This matches
+    /// the URL Standard's ASCII origin serialization for the schemes Broiler models.
+    /// </summary>
+    public static string Of(Uri uri) =>
+        $"{uri.Scheme}://{HostOf(uri)}";
+
+    /// <summary>
+    /// The <c>host[:port]</c> form used by <c>Location.host</c> (the default port is omitted).
+    /// </summary>
+    public static string HostOf(Uri uri) =>
+        uri.IsDefaultPort ? uri.Host : $"{uri.Host}:{uri.Port}";
+
+    /// <summary>
+    /// Whether two URIs share scheme, host and port — the origin-equality primitive underlying both the
+    /// cross-origin check and the CSP <c>'self'</c> match. Scheme/host compare case-insensitively.
+    /// </summary>
+    public static bool SchemeHostPortEquals(Uri a, Uri b) =>
+        string.Equals(a.Scheme, b.Scheme, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(a.Host, b.Host, StringComparison.OrdinalIgnoreCase) &&
+        a.Port == b.Port;
+}

--- a/src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs
@@ -170,6 +170,8 @@ public static partial class ScriptExtractionService
         var descriptors = new List<ScriptDescriptor>();
         var moduleScripts = new List<string>();
         var moduleMap = new ModuleMap();
+        var moduleEntries = new List<ModuleGraphLoader.GraphModule>();
+        var moduleEntryKeys = new HashSet<string>(StringComparer.Ordinal);
         var csp = ContentSecurityPolicy.FromHtml(html);
 
         var documentOrder = 0;
@@ -187,10 +189,11 @@ public static partial class ScriptExtractionService
             var url = kind == ScriptSourceKind.Inline ? null : src;
 
             // Phase 7 item 6: record every recognised module in the module map so it is not silently
-            // dropped, and make an authorised module executable with module semantics. Inline bodies
-            // (slice 1) plus data:/external sources (slice 2) are resolved through the same authorised
-            // decode/fetch path as classic scripts. The classic buckets/descriptors below are unchanged
-            // (modules stay out of them).
+            // dropped, and collect the authorised top-level modules as roots of the import graph. Inline
+            // bodies plus data:/external sources are resolved through the same authorised decode/fetch path
+            // as classic scripts; the graph loader (below) then resolves+fetches their transitive imports,
+            // dedups, orders dependency-first, and links import/export. The classic buckets/descriptors
+            // below are unchanged (modules stay out of them).
             if (isModule)
             {
                 var moduleKey = kind == ScriptSourceKind.Inline ? $"inline:{documentOrder}" : url ?? $"module:{documentOrder}";
@@ -200,9 +203,22 @@ public static partial class ScriptExtractionService
                 if (kind == ScriptSourceKind.Inline || !moduleMap.TryGet(moduleKey, out _))
                 {
                     var moduleSource = ResolveModuleSource(kind, url, tag.RawContent, nonce, csp, pageUrl);
-                    if (moduleSource != null)
-                        moduleScripts.Add(ModuleScriptWrapper.WrapInlineModule(moduleSource));
                     moduleMap.Add(new ModuleMapEntry(documentOrder, kind, moduleKey, url, moduleSource, IsExecutable: moduleSource != null));
+
+                    if (moduleSource != null)
+                    {
+                        // The graph key must be the resolved absolute URL so a module's relative imports
+                        // resolve against it and repeated modules dedup; inline/data keep a synthetic/data key.
+                        var graphKey = kind switch
+                        {
+                            ScriptSourceKind.Inline => $"inline:{documentOrder}",
+                            ScriptSourceKind.DataUri => url!,
+                            _ => UrlResolver.Resolve(url!, pageUrl)?.AbsoluteUri ?? url!,
+                        };
+                        var baseUrl = kind == ScriptSourceKind.Inline ? pageUrl : graphKey;
+                        if (moduleEntryKeys.Add(graphKey))
+                            moduleEntries.Add(new ModuleGraphLoader.GraphModule(graphKey, moduleSource, baseUrl));
+                    }
                 }
             }
 
@@ -257,7 +273,47 @@ public static partial class ScriptExtractionService
                 scripts.Add(scriptContent);
         }
 
+        // Phase 7 item 6: build and link the module graph from the authorised top-level module roots.
+        // The loader resolves+fetches each transitive dependency (CSP-gated), dedups, orders the graph
+        // dependency-first, and renders each module to a linked plain-JS program the existing evaluator
+        // runs in order. A module whose syntax the scanner cannot transform falls back to running as-is.
+        if (moduleEntries.Count > 0)
+        {
+            var graph = ModuleGraphLoader.Load(moduleEntries,
+                (specifier, baseUrl) => ResolveDependencyModule(specifier, baseUrl, csp, pageUrl));
+            moduleScripts.AddRange(graph.Programs);
+        }
+
         return new ScriptExtractionResult(scripts, deferredScripts, asyncScripts, descriptors, moduleScripts, moduleMap);
+    }
+
+    /// <summary>
+    /// Resolves and fetches one module-graph dependency (Phase 7 item 6): a <c>data:</c> specifier is
+    /// decoded; anything else is resolved against the importing module's base URL and fetched via the same
+    /// authorised path as a classic external script. Every fetch is CSP-gated (<c>script-src</c>). Returns
+    /// the resolved absolute key + source, or <c>null</c> when unresolvable, empty, or blocked.
+    /// </summary>
+    private static (string Key, string Source)? ResolveDependencyModule(
+        string specifier, string? baseUrl, ContentSecurityPolicy? csp, string? pageUrl)
+    {
+        if (specifier.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+        {
+            if (csp != null && !csp.AllowsExternalScript(specifier, pageUrl, null))
+                return null;
+            var decoded = DecodeDataUri(specifier);
+            return string.IsNullOrEmpty(decoded) ? null : (specifier, decoded);
+        }
+
+        var resolved = UrlResolver.Resolve(specifier, baseUrl);
+        if (resolved == null)
+            return null;
+
+        var key = resolved.AbsoluteUri;
+        if (csp != null && !csp.AllowsExternalScript(key, pageUrl, null))
+            return null;
+
+        var source = FetchExternalScript(key, baseUrl);
+        return string.IsNullOrEmpty(source) ? null : (key, source);
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -569,12 +569,12 @@ public sealed partial class DomBridge : IDomBridgeRuntime
         {
             _pageUrl = uri.ToString();
             _pageProtocol = uri.Scheme + ":";
-            _pageHost = uri.IsDefaultPort ? uri.Host : $"{uri.Host}:{uri.Port}";
+            _pageHost = Origin.HostOf(uri);
             _pageHostName = uri.Host;
             _pagePathName = uri.AbsolutePath;
             _pageSearch = uri.Query;
             _pageHash = uri.Fragment;
-            _pageOrigin = $"{uri.Scheme}://{(uri.IsDefaultPort ? uri.Host : $"{uri.Host}:{uri.Port}")}";
+            _pageOrigin = Origin.Of(uri);
         }
         else
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -330,7 +330,8 @@ public sealed partial class DomBridge
         if (string.Equals(styleEl.TagName, "link", StringComparison.OrdinalIgnoreCase) &&
             cssText.Length == 0 &&
             TryGetAttribute(styleEl, "href", out var href) &&
-            !string.IsNullOrEmpty(href))
+            !string.IsNullOrEmpty(href) &&
+            IsExternalStyleAllowedByCsp(styleEl, href))
         {
             if (StyleSheetStateFor(styleEl).FetchedCss.TryGet(out var cachedCss) && cachedCss is string cachedStr)
             {
@@ -704,6 +705,22 @@ public sealed partial class DomBridge
 
         var px = ParseCssLengthToPixels(value.Trim());
         return !double.IsNaN(px) && px > 0 ? (int)px : 0;
+    }
+
+    /// <summary>
+    /// Whether the document's Content Security Policy permits fetching and applying an external stylesheet
+    /// from <paramref name="href"/> (a <c>&lt;link rel="stylesheet"&gt;</c>). When no policy is configured
+    /// every stylesheet is allowed. Mirrors the script-side <see cref="ContentSecurityPolicy.AllowsExternalScript"/>
+    /// gate so DOM/CSS never fetch or apply a <c>style-src</c>-blocked external stylesheet (Phase 7 item 5:
+    /// CSP stays in the host layer; DOM and CSS receive already-authorised content).
+    /// </summary>
+    private bool IsExternalStyleAllowedByCsp(DomElement linkEl, string href)
+    {
+        if (Csp == null)
+            return true;
+
+        var nonce = TryGetAttribute(linkEl, "nonce", out var nonceValue) ? nonceValue : null;
+        return Csp.AllowsExternalStyle(href, _pageUrl, nonce);
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -380,9 +380,9 @@ public sealed partial class DomBridge
                 }
             }
 
-            // Phase 7 item 6 (first slice): authorised inline module scripts, deferred, run last. Already
-            // wrapped for module semantics by ExtractAll; an unsupported (import/export) module surfaces its
-            // error here instead of being silently skipped.
+            // Phase 7 item 6: the linked module graph, deferred, runs last in dependency-first order.
+            // ExtractAll resolves+links import/export; an unsupported module falls back to running as-is and
+            // surfaces its error here instead of being silently skipped.
             foreach (var script in extraction.ModuleScripts)
             {
                 try

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -201,10 +201,8 @@ public sealed partial class DomBridge
         if (string.Equals(targetUri.Scheme, "file", StringComparison.OrdinalIgnoreCase)) return false;
         if (string.IsNullOrWhiteSpace(pageUrl)) return false;
         if (!Uri.TryCreate(pageUrl, UriKind.Absolute, out var pageUri)) return false;
-        // Same-origin: same scheme + host + port
-        return !string.Equals(targetUri.Scheme, pageUri.Scheme, StringComparison.OrdinalIgnoreCase) ||
-               !string.Equals(targetUri.Host, pageUri.Host, StringComparison.OrdinalIgnoreCase) ||
-               targetUri.Port != pageUri.Port;
+        // Same-origin: same scheme + host + port (shared origin primitive)
+        return !Scripting.Origin.SchemeHostPortEquals(targetUri, pageUri);
     }
 
     private static string NormalizeWptPlaceholderUrl(string url)

--- a/src/Broiler.HtmlBridge.Dom/Features/MessagingBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/MessagingBinding.cs
@@ -400,7 +400,7 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
                 return origin;
 
             if (Uri.TryCreate(href, UriKind.Absolute, out var hrefUri))
-                return $"{hrefUri.Scheme}://{(hrefUri.IsDefaultPort ? hrefUri.Host : $"{hrefUri.Host}:{hrefUri.Port}")}";
+                return Scripting.Origin.Of(hrefUri);
         }
 
         return string.Empty;

--- a/src/Broiler.HtmlBridge.Dom/Features/SubWindowBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubWindowBinding.cs
@@ -63,12 +63,12 @@ internal sealed class SubWindowBinding(
         if (Uri.TryCreate(locationHref, UriKind.Absolute, out var locationUri))
         {
             iframeLocation.FastAddValue((KeyString)"protocol", new JSString(locationUri.Scheme + ":"), JSPropertyAttributes.EnumerableConfigurableValue);
-            iframeLocation.FastAddValue((KeyString)"host", new JSString(locationUri.IsDefaultPort ? locationUri.Host : $"{locationUri.Host}:{locationUri.Port}"), JSPropertyAttributes.EnumerableConfigurableValue);
+            iframeLocation.FastAddValue((KeyString)"host", new JSString(Scripting.Origin.HostOf(locationUri)), JSPropertyAttributes.EnumerableConfigurableValue);
             iframeLocation.FastAddValue((KeyString)"hostname", new JSString(locationUri.Host), JSPropertyAttributes.EnumerableConfigurableValue);
             iframeLocation.FastAddValue((KeyString)"pathname", new JSString(locationUri.AbsolutePath), JSPropertyAttributes.EnumerableConfigurableValue);
             iframeLocation.FastAddValue((KeyString)"search", new JSString(locationUri.Query), JSPropertyAttributes.EnumerableConfigurableValue);
             iframeLocation.FastAddValue((KeyString)"hash", new JSString(locationUri.Fragment), JSPropertyAttributes.EnumerableConfigurableValue);
-            iframeLocation.FastAddValue((KeyString)"origin", new JSString($"{locationUri.Scheme}://{(locationUri.IsDefaultPort ? locationUri.Host : $"{locationUri.Host}:{locationUri.Port}")}"), JSPropertyAttributes.EnumerableConfigurableValue);
+            iframeLocation.FastAddValue((KeyString)"origin", new JSString(Scripting.Origin.Of(locationUri)), JSPropertyAttributes.EnumerableConfigurableValue);
         }
         else
         {


### PR DESCRIPTION
Implements static ES module import/export parsing, graph resolution, and linked execution for `<script type="module">` (Phase 7 item 6, first slice — P7.17). Modules are now discovered, their dependencies resolved and deduplicated, ordered dependency-first, and rewritten into plain-JS programs that wire imports/exports through a runtime registry, allowing the existing non-module evaluator to execute them with module semantics.

## Key changes

- **`EsModuleScanner`** — A focused (non-full-parser) scanner that finds top-level static `import`/`export` statements while tracking string/template/comment/regex literals and bracket nesting to avoid false positives. Unrecognised or malformed forms mark the module unsupported, leaving it untransformed (additive feature).

- **`EsModuleSyntax`, `ModuleImport`, `ModuleExport`** — Data structures capturing parsed import/export statements with their source spans for in-place rewriting.

- **`EsModuleLinker`** — Rewrites a module's source into a strict IIFE that registers its exports object in a runtime registry before evaluation, reads imports from the registry, and publishes exports at the end. Bindings are snapshots (not live), and namespace imports bind the exports object itself.

- **`ModuleGraphLoader`** — Builds and links the module graph: starting from document `<script type="module">` entries, resolves each static import specifier to a URL, fetches dependencies, recurses, deduplicates, orders dependency-first (cycle-safe), and renders each module to a linked program via `EsModuleLinker`.

- **`Origin`** — New shared primitive for origin serialization/comparison (Phase 7 item 4), replacing five copy-pasted `scheme://host[:port]` constructions and two comparisons across CSP, cross-origin checks, `postMessage`, and `Location` projections.

- **`ContentSecurityPolicy.AllowsExternalStyle`** — New method (Phase 7 item 5) that gates external stylesheets (`<link rel="stylesheet">`) by `style-src-elem` → `style-src` → `default-src` CSP directives, applied at the `FetchExternalStylesheet` call site so DOM/CSS never fetch or apply a style-src-blocked stylesheet.

- **`ScriptExtractionService`** — Updated to collect top-level module entries and invoke `ModuleGraphLoader` to build and link the graph before returning programs for execution.

- **`Css.cs`** — Added CSP check (`IsExternalStyleAllowedByCsp`) before fetching external stylesheets.

- **Test coverage** — `EsModuleGraphTests` (end-to-end module graph tests via real `JSContext`) and `OriginTests` verify the implementation; `ContentSecurityPolicyTests` extended with external-stylesheet CSP tests.

- **Documentation** — Roadmap updated to reflect Phase 6 completion (native video/progress/meter/select fallbacks dropped) and Phase 7 items 1–6 status.

## Notable implementation details

- The scanner deliberately avoids full JS parsing: it tracks nesting and literal boundaries only to distinguish top-level module statements from expressions, property names, CommonJS, and nested scopes. Any unrecognised form sets `Supported = false`, and the linker leaves that module untransformed rather than emitting wrong code.

- Modules are rendered as strict IIFEs that register their exports object in `globalThis.__brmods` before evaluation (so circular imports see the in-progress object), read imports from the registry via `globalThis.__brqr`, and publish exports at the end. A bootstrap program (`EsModuleLinker.Bootstrap`) initializes the registry once before any module program.

- The graph loader deduplicates modules by resolved URL and orders them dependency-first (cycle-safe), so each module's dependencies are evaluated before it, and a shared dependency (diamond pattern) is evaluated exactly once.

- Circular imports are handled: one side of the cycle sees the other's exports populated; the back-edge side sees undefined (snapshot semantics). No crash; both modules run.

- Unresolved dependencies fail loudly at runtime with a clear

https://claude.ai/code/session_01N5QksUGz81L8zaZDexgj8d