### PR TITLE
Clear pending WPT submodule patches; retain infrastructure

### DIFF
--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -174,12 +174,16 @@ jobs:
 
       # Apply any submodule fix that could not be pushed to its remote (push 403
       # → captured under patches/) and is NOT yet in the pinned pointer, so the
-      # runner exercises it. Idempotent and scoped to the pending patch(es) only
-      # (currently just 0012); patches already contained in the pinned pointer
-      # (0013-0016) are detected as present and skipped, never re-applied. The
-      # build compiles submodule source in place, so patching the checked-out
-      # working tree before the build is sufficient — no pointer bump. Only
-      # Broiler's render is affected; Chromium reference generation is untouched.
+      # runner exercises it. Currently a no-op: the script's PENDING_PATCHES list
+      # is empty, so CI runs strictly against the pinned submodule pointers and
+      # applies no patches. The step (and script) are retained as intact
+      # infrastructure — a future pending patch is re-enabled by adding its entry
+      # to scripts/apply-pending-wpt-patches.sh, no workflow change required. When
+      # patches are configured the mechanism is idempotent (fixes already in the
+      # pinned pointer are detected and skipped) and the build compiles submodule
+      # source in place, so patching the checked-out working tree is sufficient —
+      # no pointer bump. Only Broiler's render is affected; Chromium reference
+      # generation is untouched.
       - name: Apply pending submodule patches
         shell: bash
         run: bash scripts/apply-pending-wpt-patches.sh

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -20,24 +20,32 @@
 # pointer bump.
 #
 # Each entry is "<submodule-dir>|<patch-file-relative-to-repo-root>".
+#
+# NOTE: PENDING_PATCHES is intentionally EMPTY — CI no longer applies any
+# submodule patches on top of the pinned pointers. The mechanism below is kept
+# intact so a future pending patch (one that cannot be pushed to its submodule
+# remote) can be re-enabled simply by adding its "<submodule-dir>|<patch>" entry
+# to the array; no other change is needed.
 
 set -euo pipefail
 
 # Patches whose fix is not in the pinned submodule pointer and could not be
 # pushed to the submodule remote (push 403 → captured under patches/).
-PENDING_PATCHES=(
-  "Broiler.HTML|patches/0012-html-bg-clip-text-tables.patch"
-  "Broiler.JS|patches/0013-js-ilcodegen-declare-temp-fallback.patch"
-  "Broiler.JS|patches/0014-js-ilcodegen-assignparameter-temp-fallback.patch"
-  "Broiler.JS|patches/0015-js-stable-temp-locals-and-late-snapshot.patch"
-  "Broiler.JS|patches/0016-js-stringmap-threadlocal-sentinel.patch"
-)
+# Empty by default — add entries here to have CI apply them again.
+PENDING_PATCHES=()
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 applied=0
 skipped=0
+
+# No pending patches configured: nothing to apply. (Guard the expansion below,
+# which would trip `set -u` on an empty array in older bash.)
+if [ "${#PENDING_PATCHES[@]}" -eq 0 ]; then
+  echo "Pending WPT patches: none configured — nothing to apply."
+  exit 0
+fi
 
 for entry in "${PENDING_PATCHES[@]}"; do
   submodule="${entry%%|*}"


### PR DESCRIPTION
## Summary

Clears the `PENDING_PATCHES` array in the WPT patch application script and updates documentation to reflect that CI now runs strictly against pinned submodule pointers without applying any patches. The patch mechanism and workflow remain intact for future use.

## Changes

- **scripts/apply-pending-wpt-patches.sh**
  - Emptied `PENDING_PATCHES` array (removed 5 patch entries for Broiler.HTML and Broiler.JS)
  - Added early-exit guard to skip processing when no patches are configured
  - Expanded comments explaining the intentional empty state and how to re-enable patches in the future

- **.github/workflows/wpt-tests.yml**
  - Updated step documentation to clarify that patch application is currently a no-op
  - Noted that the step and script are retained as infrastructure for future pending patches
  - Explained that re-enabling patches requires only adding entries to the script, not workflow changes

## Implementation Details

The changes maintain the existing patch infrastructure without modification — the script's loop and patch-application logic remain unchanged. A new guard clause (`if [ "${#PENDING_PATCHES[@]}" -eq 0 ]`) prevents the script from attempting to iterate an empty array in older bash versions (which would fail under `set -u`). The documentation clarifies that this is a deliberate, reversible state: future patches can be re-enabled by simply adding their entries back to the `PENDING_PATCHES` array.

https://claude.ai/code/session_01MoQMmc6jwfEvTyCAE5HYjz