### PR TITLE
Widen low-match threshold to surface near-miss pixel mismatches

### DIFF
--- a/docs/roadmap/wpt-triage-and-diagnostics.md
+++ b/docs/roadmap/wpt-triage-and-diagnostics.md
@@ -1877,8 +1877,17 @@ files a **second, severity-focused issue** listing the run's few biggest problem
   - **tier 1 — crashes**, one entry per `triage.exceptionSignatures` signature,
     ordered by the number of tests it gated (one throw → many failures → one fix).
   - **tier 2 — low percent matches**, one entry per `triage.lowestMatchTests` case
-    below `--low-match-threshold` (default 50%): the render is substantially wrong,
-    not a near-miss. The 99% pass threshold means anything this low is a gross error.
+    below the low-match threshold (starting at `--low-match-threshold`, default 50%):
+    the render is substantially wrong, not a near-miss. The 99% pass threshold means
+    anything this low is a gross error.
+- **The low-match threshold widens to fill the issue** (`_rank_biggest_problems_escalating`):
+  the 50% start is only the *first* cut-off. When the sub-threshold mismatches — plus the
+  incomplete-shard and crash entries — don't reach `--biggest-problem-limit` problems, the
+  threshold is raised by 10 points and the ranking retried, repeating until the issue fills,
+  the threshold hits 100%, or a wider band would admit no further mismatch (every candidate
+  is already below the cut-off). So a run whose only failures are near-miss mismatches now
+  surfaces its worst renders instead of an empty severity issue, and the issue text reports
+  the widened cut-off actually used (`merged["lowMatchThreshold"]`).
 - **Selection is diversity-first**: the worst entry of each distinct kind is taken
   before a second slot is spent on a kind already shown, then leftover slots fill by
   next-worst overall. So the top-3 spans *incomplete shard + crash + low match* when
@@ -1887,13 +1896,18 @@ files a **second, severity-focused issue** listing the run's few biggest problem
 - **Output**: merged `biggestProblems` (`{kind, tier, severity, impact, title, detail}`)
   + `--biggest-issue-md` renders the second issue body; the CLI emits
   `create_biggest_issue` / `biggest_problem_count` step outputs. `wpt-tests.yml`'s
-  report job creates the issue only when there is at least one big problem (a run whose
-  only failures are near-miss mismatches files the primary issue but not this one). The
-  count is bounded by `--biggest-problem-limit` (workflow input `biggest_problems_limit`,
-  default 3).
+  report job creates the issue only when there is at least one big problem (a run with no
+  crash, no incomplete shard, and no pixel mismatch at all files the primary issue but not
+  this one). The count is bounded by `--biggest-problem-limit` (workflow input
+  `biggest_problems_limit`, default 3).
 - **Tests** (`test_merge_wpt_shards.py`): `test_ranks_biggest_problems_by_blast_radius`,
   `test_biggest_problems_are_diversity_first`, `test_biggest_problem_limit_bounds_the_list`,
-  `test_cli_emits_biggest_issue_outputs`, `test_no_biggest_issue_when_only_near_miss_mismatches`,
+  `test_cli_emits_biggest_issue_outputs`, `test_biggest_issue_widens_threshold_to_surface_near_miss`,
+  `test_no_biggest_issue_when_no_severity_signals`,
+  `test_low_match_threshold_widens_in_steps_until_issue_is_full`,
+  `test_low_match_threshold_not_widened_when_start_already_fills_issue`,
+  `test_low_match_threshold_stops_widening_when_nothing_left_to_find`,
+  `test_low_match_threshold_widens_to_ceiling_for_near_miss`,
   `test_cli_rejects_out_of_range_low_match_threshold`.
 
 ---

--- a/scripts/merge-wpt-shards.py
+++ b/scripts/merge-wpt-shards.py
@@ -14,10 +14,14 @@ own ``wpt-results.json``. This script combines those shard reports to produce:
 * ``--biggest-issue-md`` — a Markdown body for a *second*, severity-focused
   issue that lists only the run's few biggest problems, ranked by blast radius:
   incomplete shards first (a whole slice went unmeasured), then crashes (one bug
-  gating many tests), then the worst pixel mismatches. Each crash names an example
-  gated test and the issue spells out the ``--render`` command to reproduce a
-  listed test, so every entry points at its cause. This is the "what hurt most
-  this run" companion to the frequency-ranked ``--issue-md`` view.
+  gating many tests), then the worst pixel mismatches. A pixel mismatch counts as
+  a "low percent match" problem only when it renders below the low-match
+  threshold (50% by default); when too few mismatches clear that bar to fill the
+  issue, the threshold is widened in 10-point steps until it does (or nothing
+  more can be found). Each crash names an example gated test and the issue spells
+  out the ``--render`` command to reproduce a listed test, so every entry points
+  at its cause. This is the "what hurt most this run" companion to the
+  frequency-ranked ``--issue-md`` view.
 
 When ``--merge-into`` names an existing manifest, the run's failures are folded
 into it *by scope* instead of replacing it: entries for tests this run actually
@@ -57,8 +61,16 @@ DEFAULT_BIGGEST_PROBLEM_LIMIT = 3
 # A pixel mismatch counts as a "low percent match" big problem only when the
 # rendered output matches the reference by less than this percentage — i.e. the
 # render is substantially wrong, not merely off by a hair (the pass threshold is
-# 99%). Runs where every mismatch is a near-miss surface no low-match problem.
+# 99%). This is only the *starting* cut-off: when too few mismatches fall below
+# it to fill the issue, it is widened (see below).
 DEFAULT_LOW_MATCH_THRESHOLD = 50.0
+# When the sub-threshold mismatches — together with the incomplete-shard and
+# crash entries — don't fill the biggest-problems issue to its limit, the
+# low-match threshold is widened by this many percentage points and the ranking
+# retried, repeating up to the ceiling. So a run whose only mismatches are near
+# misses still surfaces its worst renders instead of an empty severity issue.
+LOW_MATCH_THRESHOLD_STEP = 10.0
+LOW_MATCH_THRESHOLD_CEILING = 100.0
 
 
 def _bucket_directory(relative_path: str) -> str:
@@ -244,6 +256,54 @@ def _rank_biggest_problems(
             selected_indices.append(index)
 
     return [ordered[index] for index in sorted(selected_indices)]
+
+
+def _rank_biggest_problems_escalating(
+    incomplete_shards: list[dict],
+    exception_signatures: Counter[str],
+    exception_examples: dict[str, list[str]],
+    low_match_tests: list[dict],
+    limit: int,
+    low_match_threshold: float,
+) -> tuple[list[dict], float]:
+    """Rank the biggest problems, widening the low-match threshold until the
+    issue is full.
+
+    ``_rank_biggest_problems`` only counts a pixel mismatch as a "low percent
+    match" problem when its render matched the reference by *less than* the
+    threshold. When those sub-threshold mismatches — together with the
+    incomplete-shard and crash entries — don't reach ``limit`` biggest problems,
+    the threshold is raised by ``LOW_MATCH_THRESHOLD_STEP`` points and the ranking
+    retried, repeating until the list reaches ``limit``, the threshold hits
+    ``LOW_MATCH_THRESHOLD_CEILING``, or widening it further would admit no
+    additional mismatch (every candidate is already below the cut-off).
+
+    Returns the ranked problems and the threshold actually used, so the issue
+    text can report the real cut-off rather than the (possibly stricter) start.
+    """
+    threshold = float(low_match_threshold)
+    # The closest-matching candidate mismatch. Once the threshold clears it, a
+    # wider band would capture nothing new, so escalating past it is pointless.
+    highest_match = max(
+        (test["matchPercent"] for test in low_match_tests), default=None
+    )
+    while True:
+        problems = _rank_biggest_problems(
+            incomplete_shards,
+            exception_signatures,
+            exception_examples,
+            low_match_tests,
+            limit,
+            threshold,
+        )
+        if (
+            len(problems) >= limit
+            or threshold >= LOW_MATCH_THRESHOLD_CEILING
+            or highest_match is None
+            or threshold > highest_match
+        ):
+            return problems, threshold
+        threshold = min(threshold + LOW_MATCH_THRESHOLD_STEP, LOW_MATCH_THRESHOLD_CEILING)
 
 
 def merge(
@@ -440,7 +500,7 @@ def merge(
         key=lambda group: (-group["count"], group["family"]),
     )[:problem_limit]
 
-    biggest_problems = _rank_biggest_problems(
+    biggest_problems, effective_low_match_threshold = _rank_biggest_problems_escalating(
         incomplete_shards,
         exception_signature_counter,
         exception_examples,
@@ -466,7 +526,7 @@ def merge(
         "exceptionSignatures": exception_signature_counter.most_common(problem_limit),
         "failureFamilies": top_families,
         "biggestProblemLimit": biggest_problem_limit,
-        "lowMatchThreshold": low_match_threshold,
+        "lowMatchThreshold": effective_low_match_threshold,
         "biggestProblems": biggest_problems,
         "results": failures,
     }

--- a/scripts/tests/test_merge_wpt_shards.py
+++ b/scripts/tests/test_merge_wpt_shards.py
@@ -544,6 +544,88 @@ class MergeWptShardsTests(unittest.TestCase):
             self.assertEqual(2, len(merged["biggestProblems"]))
             self.assertEqual([9, 4], [p["impact"] for p in merged["biggestProblems"]])
 
+    def _low_match_report(self, root: Path, name: str, shard_index: int, matches: list[float]) -> None:
+        (root / name).write_text(
+            json.dumps(
+                {
+                    "summary": {"passed": 0, "failed": len(matches), "skipped": 0, "total": len(matches)},
+                    "shard": {"index": shard_index, "count": 8},
+                    "triage": {
+                        "lowestMatchTests": [
+                            {
+                                "testPath": f"css/a/m{i}.html",
+                                "matchPercent": match,
+                                "category": "PixelMismatch",
+                                "subCategory": "MissingContent",
+                            }
+                            for i, match in enumerate(matches)
+                        ]
+                    },
+                    "results": [self._failure(f"css/a/m{i}.html", "PixelMismatch", "MissingContent") for i in range(len(matches))],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_low_match_threshold_widens_in_steps_until_issue_is_full(self) -> None:
+        # Mismatches at 45/55/65%, no crashes or incomplete shards, limit 2. At the
+        # 50% start only 45% qualifies (1 < 2), so the threshold steps to 60% where
+        # 45% and 55% both qualify and the issue fills. It stops there — it does not
+        # keep climbing to grab 65%.
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._low_match_report(shard_dir, "shard-0.json", 0, [45.0, 55.0, 65.0])
+
+            merged = MODULE.merge(shard_dir, biggest_problem_limit=2, low_match_threshold=50.0)
+
+            self.assertEqual(60.0, merged["lowMatchThreshold"])
+            biggest = merged["biggestProblems"]
+            self.assertEqual(2, len(biggest))
+            self.assertEqual(["LowMatch", "LowMatch"], [p["kind"] for p in biggest])
+            self.assertEqual([45.0, 55.0], sorted(p["matchPercent"] for p in biggest))
+
+            markdown = MODULE.render_biggest_problems_markdown(merged, None)
+            self.assertIn("< 60% match", markdown)
+
+    def test_low_match_threshold_not_widened_when_start_already_fills_issue(self) -> None:
+        # Two sub-50% mismatches with limit 2: the issue is already full at the
+        # start, so the threshold is left at 50% (a 70% mismatch stays hidden).
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._low_match_report(shard_dir, "shard-0.json", 0, [20.0, 30.0, 70.0])
+
+            merged = MODULE.merge(shard_dir, biggest_problem_limit=2, low_match_threshold=50.0)
+
+            self.assertEqual(50.0, merged["lowMatchThreshold"])
+            self.assertEqual(2, len(merged["biggestProblems"]))
+            self.assertEqual([20.0, 30.0], sorted(p["matchPercent"] for p in merged["biggestProblems"]))
+
+    def test_low_match_threshold_stops_widening_when_nothing_left_to_find(self) -> None:
+        # A single 30% mismatch with limit 3: the issue can never fill, but every
+        # candidate is already below the 50% start, so widening would add nothing
+        # and the threshold is left at 50% rather than climbing to the ceiling.
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._low_match_report(shard_dir, "shard-0.json", 0, [30.0])
+
+            merged = MODULE.merge(shard_dir, biggest_problem_limit=3, low_match_threshold=50.0)
+
+            self.assertEqual(50.0, merged["lowMatchThreshold"])
+            self.assertEqual(1, len(merged["biggestProblems"]))
+
+    def test_low_match_threshold_widens_to_ceiling_for_near_miss(self) -> None:
+        # Only a 96% near-miss with limit 3: the threshold climbs 50→60→…→100,
+        # capping at the ceiling, and surfaces the mismatch there.
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._low_match_report(shard_dir, "shard-0.json", 0, [96.0])
+
+            merged = MODULE.merge(shard_dir, biggest_problem_limit=3, low_match_threshold=50.0)
+
+            self.assertEqual(100.0, merged["lowMatchThreshold"])
+            self.assertEqual(1, len(merged["biggestProblems"]))
+            self.assertEqual("LowMatch", merged["biggestProblems"][0]["kind"])
+
     def test_cli_emits_biggest_issue_outputs(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             shard_dir = Path(temp)
@@ -585,10 +667,15 @@ class MergeWptShardsTests(unittest.TestCase):
             self.assertIn("biggest_problem_count=1", outputs)
             self.assertIn("Crash gating 7 test(s)", biggest_md.read_text(encoding="utf-8"))
 
-    def test_no_biggest_issue_when_only_near_miss_mismatches(self) -> None:
+    def test_biggest_issue_widens_threshold_to_surface_near_miss(self) -> None:
+        # Only a single near-miss mismatch (97.5%), no crash, no incomplete shard.
+        # At the 50% start it clears no bar, but the threshold is widened in
+        # 10-point steps until the mismatch surfaces, so the second issue is still
+        # filed instead of silently swallowing the run's only severe signal.
         with tempfile.TemporaryDirectory() as temp:
             shard_dir = Path(temp)
             github_output = shard_dir / "github-output.txt"
+            biggest_md = shard_dir / "biggest.md"
             (shard_dir / "shard-0.json").write_text(
                 json.dumps(
                     {
@@ -617,6 +704,8 @@ class MergeWptShardsTests(unittest.TestCase):
                     str(SCRIPT_PATH),
                     "--shard-dir",
                     temp,
+                    "--biggest-issue-md",
+                    str(biggest_md),
                     "--github-output",
                     str(github_output),
                 ],
@@ -627,7 +716,51 @@ class MergeWptShardsTests(unittest.TestCase):
 
             self.assertEqual(0, result.returncode, result.stderr)
             outputs = github_output.read_text(encoding="utf-8")
-            # No crash, no incomplete shard, only a near-miss match → no second issue.
+            # The widened threshold captures the near-miss → second issue is filed.
+            self.assertIn("create_biggest_issue=true", outputs)
+            self.assertIn("biggest_problem_count=1", outputs)
+            self.assertIn("create_issue=true", outputs)
+            # The issue text reports the widened cut-off (100%), not the 50% start.
+            markdown = biggest_md.read_text(encoding="utf-8")
+            self.assertIn("< 100% match", markdown)
+            self.assertIn("97.5% match — css/a/x.html", markdown)
+
+    def test_no_biggest_issue_when_no_severity_signals(self) -> None:
+        # A plain failure with no crash, no incomplete shard, and no pixel
+        # mismatch at all: widening the threshold has nothing to find, so no
+        # second issue is filed.
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            github_output = shard_dir / "github-output.txt"
+            (shard_dir / "shard-0.json").write_text(
+                json.dumps(
+                    {
+                        "summary": {"passed": 1, "failed": 1, "skipped": 0, "total": 2},
+                        "shard": {"index": 0, "count": 8},
+                        "results": [self._failure("css/a/x.html", "RenderingError")],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self._write_status(shard_dir, shard_index=0, exit_code=1)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--shard-dir",
+                    temp,
+                    "--github-output",
+                    str(github_output),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            outputs = github_output.read_text(encoding="utf-8")
+            # Nothing to widen into → no second issue.
             self.assertIn("create_biggest_issue=false", outputs)
             self.assertIn("biggest_problem_count=0", outputs)
             # The run still failed, so the primary (most-common) issue is still filed.


### PR DESCRIPTION
## Summary

When ranking the biggest problems for the severity-focused issue, the low-match threshold (default 50%) is now widened in 10-point steps if too few pixel mismatches fall below it to fill the issue. This ensures that runs with only near-miss mismatches surface their worst renders instead of filing an empty severity issue.

## Key Changes

- **New `_rank_biggest_problems_escalating()` function**: Wraps the existing `_rank_biggest_problems()` ranking logic with threshold escalation. When the initial ranking doesn't reach the `biggest_problem_limit`, the threshold is raised by `LOW_MATCH_THRESHOLD_STEP` (10 points) and ranking is retried, repeating until:
  - The issue fills to the limit, OR
  - The threshold reaches `LOW_MATCH_THRESHOLD_CEILING` (100%), OR
  - Widening further would admit no additional mismatches (every candidate is already below the cut-off)

- **Updated `merge()` function**: Now calls `_rank_biggest_problems_escalating()` instead of `_rank_biggest_problems()` directly, capturing both the ranked problems and the effective threshold used. The merged output's `lowMatchThreshold` field now reflects the actual cut-off applied, not the starting value.

- **New constants**: `LOW_MATCH_THRESHOLD_STEP` (10.0) and `LOW_MATCH_THRESHOLD_CEILING` (100.0) control the escalation behavior.

- **Comprehensive test coverage**: Four new unit tests validate the escalation logic:
  - `test_low_match_threshold_widens_in_steps_until_issue_is_full`: Threshold steps from 50% → 60% to capture two mismatches at 45%/55%, stopping before 65%
  - `test_low_match_threshold_not_widened_when_start_already_fills_issue`: No widening when the initial threshold already fills the issue
  - `test_low_match_threshold_stops_widening_when_nothing_left_to_find`: Threshold stays at 50% when all candidates are already below it
  - `test_low_match_threshold_widens_to_ceiling_for_near_miss`: Threshold climbs to 100% to surface a 96% near-miss

- **Updated CLI test**: Renamed `test_no_biggest_issue_when_only_near_miss_mismatches` to `test_biggest_issue_widens_threshold_to_surface_near_miss` and updated it to verify that a 97.5% near-miss is now surfaced with the widened threshold (100%) reported in the markdown. Added a new `test_no_biggest_issue_when_no_severity_signals` test to verify that runs with no crashes, incomplete shards, or pixel mismatches still don't file a second issue.

- **Documentation updates**: Updated module docstring and roadmap to explain the threshold widening behavior and its rationale.

## Implementation Details

The escalation logic is conservative: it only widens the threshold when necessary to fill the issue, and it stops as soon as the issue reaches capacity or further widening would be pointless. The effective threshold is always reported in the output so issue text can accurately describe the cut-off applied.

https://claude.ai/code/session_01SA1aaNE86KXcjphnMZGcMa