### PR TITLE
Fix scroll snap and scrollIntoView on root with overflow:hidden

### DIFF
--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.ScrollGeometry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.ScrollGeometry.cs
@@ -273,18 +273,21 @@ public sealed partial class DomBridge
     {
         var normalizedAlignment = NormalizeScrollIntoViewAlignment(alignment, "start");
         var offset = offsetOverride ?? OffsetWithinAncestorPreferShared(element, scrollContainer, vertical);
-        var targetSize = vertical ? GetBorderBoxHeight(GetComputedProps(element), element) : GetBorderBoxWidth(GetComputedProps(element), element);
+        var targetSize = GetScrollIntoViewTargetSize(element, vertical);
+        var viewportSize = viewportSizeOverride ?? (vertical
+            ? GetClientHeightForDomElement(scrollContainer, IsDocumentElement(scrollContainer))
+            : GetClientWidthForDomElement(scrollContainer, IsDocumentElement(scrollContainer)));
+        // scroll-margin is <length> only (no percentages); scroll-padding is
+        // <length-percentage> resolved against the scrollport size on the same axis
+        // (CSS Scroll Snap 1 §5.1/§5.2).
         var (marginStart, marginStartOwner) = ResolveScrollIntoViewInset(element, vertical ? "scroll-margin-top" : "scroll-margin-left");
         var (marginEnd, marginEndOwner) = ResolveScrollIntoViewInset(element, vertical ? "scroll-margin-bottom" : "scroll-margin-right");
-        var (paddingStart, paddingStartOwner) = ResolveScrollIntoViewInset(scrollContainer, vertical ? "scroll-padding-top" : "scroll-padding-left");
-        var (paddingEnd, paddingEndOwner) = ResolveScrollIntoViewInset(scrollContainer, vertical ? "scroll-padding-bottom" : "scroll-padding-right");
+        var (paddingStart, paddingStartOwner) = ResolveScrollIntoViewInset(scrollContainer, vertical ? "scroll-padding-top" : "scroll-padding-left", viewportSize);
+        var (paddingEnd, paddingEndOwner) = ResolveScrollIntoViewInset(scrollContainer, vertical ? "scroll-padding-bottom" : "scroll-padding-right", viewportSize);
         marginStart = ConvertInsetToScrollContainerCoordinates(marginStart, marginStartOwner, scrollContainer);
         marginEnd = ConvertInsetToScrollContainerCoordinates(marginEnd, marginEndOwner, scrollContainer);
         paddingStart = ConvertInsetToScrollContainerCoordinates(paddingStart, paddingStartOwner, scrollContainer);
         paddingEnd = ConvertInsetToScrollContainerCoordinates(paddingEnd, paddingEndOwner, scrollContainer);
-        var viewportSize = viewportSizeOverride ?? (vertical
-            ? GetClientHeightForDomElement(scrollContainer, IsDocumentElement(scrollContainer))
-            : GetClientWidthForDomElement(scrollContainer, IsDocumentElement(scrollContainer)));
         var currentScroll = currentScrollOverride ?? GetElementScrollOffset(scrollContainer, vertical);
         var physicalCurrentScroll = coordinateSpaceIsPhysical
             ? currentScroll
@@ -337,6 +340,32 @@ public sealed partial class DomBridge
         return currentScroll;
     }
 
+    /// <summary>
+    /// The border-box extent of a <c>scrollIntoView</c> / scroll-snap target along the axis,
+    /// preferring the real laid-out box from the shared geometry snapshot and falling back to
+    /// the computed-style reconstruction only when the element has no box.
+    ///
+    /// <para>The style reconstruction sums <c>height</c> + padding + border-width as declared,
+    /// so it silently drops anything it cannot parse as a length — notably the
+    /// <c>thin</c>/<c>medium</c>/<c>thick</c> border-width keywords. That under-measured the
+    /// target by exactly the border width and shifted every end/center alignment by the same
+    /// amount (issue #1439: css-scroll-snap/scroll-snap-root-002's
+    /// <c>border-bottom: solid orange thick</c> pushed its 5px stripe off the bottom edge).
+    /// The snapshot already carries the used border box, which needs no reconstruction.</para>
+    ///
+    /// <para>Both paths report the element's own unzoomed CSS pixels, so this preserves the
+    /// existing zoom convention at the call site (the size is used unconverted, unlike the
+    /// insets, which pass through <see cref="ConvertInsetToScrollContainerCoordinates"/>).</para>
+    /// </summary>
+    private double GetScrollIntoViewTargetSize(DomElement element, bool vertical)
+    {
+        if (TrySharedBorderBoxExtent(element, vertical, out var sharedExtent) && double.IsFinite(sharedExtent))
+            return sharedExtent;
+
+        var props = GetComputedProps(element);
+        return vertical ? GetBorderBoxHeight(props, element) : GetBorderBoxWidth(props, element);
+    }
+
     private double ConvertPhysicalScrollPosition(DomElement scrollContainer,
         bool vertical, double physicalPosition, bool coordinateSpaceIsPhysical)
         => coordinateSpaceIsPhysical
@@ -373,14 +402,64 @@ public sealed partial class DomBridge
             : (minLeft < 0 ? maxLeft - minLeft : maxLeft);
     }
 
-    private (double Value, DomElement Owner) ResolveScrollIntoViewInset(DomElement element, string propertyName)
+    /// <summary>
+    /// Resolves one <c>scroll-margin-*</c> / <c>scroll-padding-*</c> longhand on
+    /// <paramref name="element"/> to pixels, falling back to the corresponding 1-to-4-value
+    /// box shorthand (<c>scroll-margin</c> / <c>scroll-padding</c>) when the longhand is
+    /// absent.
+    ///
+    /// <para>The shorthand fallback is what makes <c>scroll-padding: 25%</c> and
+    /// <c>scroll-margin: 25vh</c> take effect: the style engine keeps these shorthands as
+    /// declared rather than expanding them into longhands, so reading only the longhand
+    /// yielded 0 and <c>scrollIntoView</c> ignored both insets entirely (issue #1439).</para>
+    ///
+    /// <para><paramref name="percentageBasis"/> is the scrollport size along the axis, used
+    /// for <c>scroll-padding</c>'s percentages (CSS Scroll Snap 1 §5.2). It is left null for
+    /// <c>scroll-margin</c>, which takes <c>&lt;length&gt;</c> only.</para>
+    /// </summary>
+    private (double Value, DomElement Owner) ResolveScrollIntoViewInset(
+        DomElement element, string propertyName, double? percentageBasis = null)
     {
         var props = GetComputedProps(element);
         var value = props.GetValueOrDefault(propertyName);
         if (string.Equals(value, "inherit", StringComparison.OrdinalIgnoreCase) && ParentEl(element) != null)
-            return ResolveScrollIntoViewInset(ParentEl(element), propertyName);
+            return ResolveScrollIntoViewInset(ParentEl(element), propertyName, percentageBasis);
 
-        return (ParseCssLengthToPixelsWithViewport(value, element), element);
+        if (string.IsNullOrWhiteSpace(value))
+            value = ResolveScrollInsetFromShorthand(props, propertyName);
+
+        return (ParseCssLengthToPixelsWithViewport(value, element, percentageBasis: percentageBasis), element);
+    }
+
+    /// <summary>
+    /// Picks the side named by <paramref name="longhandName"/> out of the matching
+    /// <c>scroll-margin</c>/<c>scroll-padding</c> box shorthand in <paramref name="props"/>,
+    /// or null when the shorthand is absent. Logical (<c>-block</c>/<c>-inline</c>) shorthands
+    /// are not consulted — only the physical four-side form.
+    /// </summary>
+    private static string? ResolveScrollInsetFromShorthand(
+        Dictionary<string, string> props, string longhandName)
+    {
+        var lastDash = longhandName.LastIndexOf('-');
+        if (lastDash <= 0)
+            return null;
+
+        var shorthandName = longhandName[..lastDash];
+        var side = longhandName[(lastDash + 1)..];
+        var shorthand = props.GetValueOrDefault(shorthandName);
+        if (string.IsNullOrWhiteSpace(shorthand))
+            return null;
+
+        var parts = shorthand.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        var (top, right, bottom, left) = CssBoxShorthand.SelectTrbl(parts);
+        return side switch
+        {
+            "top" => top,
+            "right" => right,
+            "bottom" => bottom,
+            "left" => left,
+            _ => null,
+        };
     }
 
     private double ConvertInsetToScrollContainerCoordinates(double inset, DomElement insetOwner, DomElement scrollContainer)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.ScrollSnap.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.ScrollSnap.cs
@@ -1,0 +1,152 @@
+using Broiler.Dom;
+using Broiler.CSS;
+
+namespace Broiler.HtmlBridge;
+
+/// <summary>
+/// CSS Scroll Snap (Level 1) snap-position resolution for programmatic scrolls.
+///
+/// <para>A scroll container whose <c>scroll-snap-type</c> names an axis with the
+/// <c>mandatory</c> strictness must come to rest on a snap position on that axis after
+/// <em>any</em> scroll — including <c>scrollIntoView</c>, <c>scrollTo</c>/<c>scroll</c>,
+/// <c>scrollBy</c>, and a plain <c>scrollTop</c>/<c>scrollLeft</c> assignment (CSS Scroll
+/// Snap 1 §2, §6.1). Snapping is therefore applied at the single choke point where a
+/// requested offset becomes the stored one (<c>ResolveElementScrollOffsets</c>), rather than
+/// in any individual scrolling entry point.</para>
+///
+/// <para>Only <c>mandatory</c> snapping is implemented. <c>proximity</c> leaves the choice of
+/// whether a candidate is "close enough" up to the UA, so declining to snap is a conforming
+/// outcome and matches what the engine did before.</para>
+///
+/// <para>Root propagation falls out of the existing container model: for the viewport the
+/// scroll container element is <c>&lt;html&gt;</c>, so <c>scroll-snap-type</c> and
+/// <c>scroll-padding</c> are read from the root element and <c>&lt;body&gt;</c> is never
+/// consulted — which is exactly the distinction css-scroll-snap/scroll-snap-root-002 asserts
+/// (issue #1439).</para>
+/// </summary>
+public sealed partial class DomBridge
+{
+    /// <summary>
+    /// Returns the snap position closest to <paramref name="proposedOffset"/> on
+    /// <paramref name="vertical"/>'s axis, or <paramref name="proposedOffset"/> unchanged when
+    /// <paramref name="scrollContainer"/> is not a mandatory snap container on that axis or
+    /// has no snap areas.
+    /// </summary>
+    /// <param name="proposedOffset">The already-clamped offset the scroll would land on.</param>
+    private double ResolveScrollSnapPosition(DomElement scrollContainer, bool vertical, double proposedOffset)
+    {
+        if (!double.IsFinite(proposedOffset) || !HasMandatoryScrollSnapOnAxis(scrollContainer, vertical))
+            return proposedOffset;
+
+        var (minLeft, maxLeft, minTop, maxTop) = GetScrollBounds(scrollContainer);
+        var min = vertical ? minTop : minLeft;
+        var max = vertical ? maxTop : maxLeft;
+
+        var best = proposedOffset;
+        var bestDistance = double.PositiveInfinity;
+
+        foreach (var descendant in EnumerateRenderedDescendants(scrollContainer))
+        {
+            var alignment = GetScrollSnapAlignmentForAxis(descendant, scrollContainer, vertical);
+            if (alignment == null)
+                continue;
+
+            // A box only snaps in its own nearest scroll container, so a snap area inside a
+            // nested scroller must not pull this container's offset around.
+            if (!ReferenceEquals(FindScrollContainer(descendant), scrollContainer))
+                continue;
+
+            var candidate = ResolveScrollIntoViewOffset(descendant, scrollContainer, vertical, alignment);
+            if (!double.IsFinite(candidate))
+                continue;
+
+            candidate = Math.Clamp(candidate, min, max);
+
+            var distance = Math.Abs(candidate - proposedOffset);
+            if (distance < bestDistance)
+            {
+                bestDistance = distance;
+                best = candidate;
+            }
+        }
+
+        return best;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="scrollContainer"/> declares <c>scroll-snap-type</c> with
+    /// <c>mandatory</c> strictness covering <paramref name="vertical"/>'s axis. The axis
+    /// keyword may be physical (<c>x</c>/<c>y</c>), logical (<c>block</c>/<c>inline</c>, which
+    /// resolve through the container's <c>writing-mode</c>), or <c>both</c>.
+    /// </summary>
+    private bool HasMandatoryScrollSnapOnAxis(DomElement scrollContainer, bool vertical)
+    {
+        var props = GetComputedProps(scrollContainer);
+        var declared = props.GetValueOrDefault("scroll-snap-type");
+        if (string.IsNullOrWhiteSpace(declared))
+            return false;
+
+        var tokens = declared.Trim().ToLowerInvariant()
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length == 0 || tokens[0] == "none")
+            return false;
+
+        // Strictness is optional and defaults to `proximity`, which this implementation
+        // deliberately leaves un-snapped (see the type remarks).
+        if (!tokens.Contains("mandatory"))
+            return false;
+
+        var blockAxisIsVertical = !CssWritingMode.IsVertical(props.GetValueOrDefault("writing-mode"));
+        return tokens[0] switch
+        {
+            "both" => true,
+            "x" => !vertical,
+            "y" => vertical,
+            "block" => vertical == blockAxisIsVertical,
+            "inline" => vertical != blockAxisIsVertical,
+            _ => false,
+        };
+    }
+
+    /// <summary>
+    /// The physical <c>start</c>/<c>end</c>/<c>center</c> alignment <paramref name="element"/>
+    /// requests on <paramref name="vertical"/>'s axis, or null when it declares no
+    /// <c>scroll-snap-align</c> or opts that axis out with <c>none</c>.
+    ///
+    /// <para><c>scroll-snap-align</c> takes one or two logical keywords in block-then-inline
+    /// order, so they are mapped to physical axes through the same writing-mode/direction
+    /// resolution <c>scrollIntoView</c>'s <c>block</c>/<c>inline</c> options use.</para>
+    /// </summary>
+    private string? GetScrollSnapAlignmentForAxis(DomElement element, DomElement scrollContainer, bool vertical)
+    {
+        var declared = GetComputedProps(element).GetValueOrDefault("scroll-snap-align");
+        if (string.IsNullOrWhiteSpace(declared))
+            return null;
+
+        var tokens = declared.Trim().ToLowerInvariant()
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length == 0)
+            return null;
+
+        var block = tokens[0];
+        var inline = tokens.Length > 1 ? tokens[1] : tokens[0];
+        if (!IsScrollSnapAlignmentKeyword(block) || !IsScrollSnapAlignmentKeyword(inline))
+            return null;
+
+        // Map through the container's writing mode by asking for the physical alignments of
+        // this logical pair, then keep only the axis being snapped. "none" is checked on the
+        // logical value first, because the physical resolution normalises it away.
+        var blockAxisIsVertical = !CssWritingMode.IsVertical(
+            GetComputedProps(scrollContainer).GetValueOrDefault("writing-mode"));
+        var logicalForAxis = vertical == blockAxisIsVertical ? block : inline;
+        if (logicalForAxis == "none")
+            return null;
+
+        var (horizontal, verticalAlignment) =
+            ResolvePhysicalScrollIntoViewAlignments(scrollContainer, block, inline);
+        return vertical ? verticalAlignment : horizontal;
+    }
+
+    private static bool IsScrollSnapAlignmentKeyword(string token) =>
+        token is "none" or "start" or "end" or "center";
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.Scrolling.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.Scrolling.cs
@@ -220,6 +220,18 @@ public sealed partial class DomBridge
             nextTop = Math.Clamp(nextTop, minTop, maxTop);
         }
 
+        // A mandatory snap container must come to rest on a snap position after any scroll,
+        // so this is applied to the result of every scrolling entry point rather than to any
+        // one of them (CSS Scroll Snap 1 §2). A non-snapping container is unchanged.
+        //
+        // This runs even under `clamp: false` (window.scrollTo/scrollBy and the element
+        // scroll/scrollTo/scrollBy bindings), which is deliberate: snapping is a property of
+        // the container, not of the API used to reach it, and a snap position is by definition
+        // inside the scrollable range. Callers that opt out of clamping still get no clamping
+        // on an ordinary scroll container — only on one that asked to snap.
+        nextLeft = ResolveScrollSnapPosition(element, vertical: false, nextLeft);
+        nextTop = ResolveScrollSnapPosition(element, vertical: true, nextTop);
+
         return (nextLeft, nextTop);
     }
 
@@ -498,13 +510,25 @@ public sealed partial class DomBridge
         return axisValue;
     }
 
+    /// <summary>
+    /// Whether a root-propagated <c>overflow</c> value makes the viewport non-scrollable.
+    /// Only <c>clip</c> does: it suppresses the scroll container entirely (CSS Overflow 3
+    /// §3.3), so the scrollport has no scroll offset to set.
+    /// <para><c>overflow: hidden</c> does <em>not</em> belong here. It still establishes a
+    /// scroll container — it only removes the <em>user-interaction</em> affordance, while
+    /// programmatic scrolling (<c>scrollTop</c>/<c>scrollLeft</c>, <c>scrollTo</c>,
+    /// <c>scrollIntoView</c>) keeps working. Treating it as non-scrollable pinned every such
+    /// document at offset 0, which silently broke the very common WPT reftest idiom
+    /// <c>:root { overflow: hidden; /* hide scrollbars for reftest analysis */ }</c> on any
+    /// test that also scrolls (issue #1439: css-scroll-snap/scroll-snap-root-001 and -002
+    /// both rendered their unscrolled red FAIL block).</para>
+    /// </summary>
     private static bool DisablesRootScrolling(string? overflowValue)
     {
         if (string.IsNullOrWhiteSpace(overflowValue))
             return false;
 
-        var normalized = overflowValue.Trim().ToLowerInvariant();
-        return normalized.Contains("hidden") || normalized.Contains("clip");
+        return overflowValue.Trim().ToLowerInvariant().Contains("clip");
     }
 
     private static bool EnablesScrollingBox(string? overflowValue)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.cs
@@ -379,11 +379,19 @@ public sealed partial class DomBridge
             ? Math.Max(0, paddingBox.Bottom - contentBox.Bottom)
             : Math.Max(0, paddingBox.Right - contentBox.Right);
 
+        // Trailing margins only extend the *viewport's* scrolling area (see
+        // GetScrollableOverflowEndMargin). Percentage margins resolve against the containing
+        // block's inline size, for which the scroll container's content width is the basis.
+        var includeEndMargins = IsViewportElementForMetrics(element);
+        var marginPercentageBasis = (double)contentBox.Width;
+
         foreach (var descendant in EnumerateRenderedDescendants(element))
         {
             if (!TryGetSharedLayoutGeometry(descendant, out var childBox))
                 continue;
-            var childEnd = vertical ? childBox.BorderBox.Bottom : childBox.BorderBox.Right;
+            double childEnd = vertical ? childBox.BorderBox.Bottom : childBox.BorderBox.Right;
+            if (includeEndMargins)
+                childEnd += GetScrollableOverflowEndMargin(descendant, vertical, marginPercentageBasis);
             max = Math.Max(max, (childEnd - origin) + endPadding);
         }
 
@@ -392,6 +400,48 @@ public sealed partial class DomBridge
         // zoomed descendant's larger baked extent still counts as overflow.
         extent = UnzoomSharedExtent(max, element);
         return true;
+    }
+
+    /// <summary>
+    /// The end-edge (bottom / right) margin of <paramref name="descendant"/> that extends the
+    /// <em>viewport's</em> scrolling area past the descendant's border box.
+    ///
+    /// <para>The document's scrolling area is its total layout height, which runs to the end of
+    /// the last block's margin box — a trailing <c>margin-bottom</c> below the last block is
+    /// scrollable. Unioning border boxes alone truncated the document by exactly that margin
+    /// and clamped every programmatic scroll to a max that was too small (issue #1439:
+    /// css-scroll-snap/scroll-snap-root-001 must scroll to 998.4px, but the missing
+    /// <c>#target { margin-bottom: 120vh }</c> capped the document at 636.4px).</para>
+    ///
+    /// <para><b>This is deliberately restricted to the viewport.</b> For an ordinary element
+    /// scroll container, a child's margin does not by itself create scrollable overflow — an
+    /// auto-sized box grows to fit its children's margins, and a margin that collapses out of
+    /// it is not content the box can scroll to. <c>Wpt_CssomView_AutoSized_ScrollMetrics_Do_Not
+    /// _Report_MarginOnly_Overflow</c> pins that: margins alone must leave
+    /// <c>scrollHeight == clientHeight</c>. Applying this to every scroll container broke it.</para>
+    ///
+    /// <para>Only positive margins extend the area: a negative margin pulls content back toward
+    /// the origin and never adds scrollable space. The caller takes a <c>max</c> over all
+    /// descendants, so a margin that collapses up through several ancestors is counted once at
+    /// whichever box carries it rather than accumulating.</para>
+    /// </summary>
+    private double GetScrollableOverflowEndMargin(DomElement descendant, bool vertical, double percentageBasis)
+    {
+        var props = GetComputedProps(descendant);
+
+        // position: fixed boxes are anchored to the viewport, not to the scroll container's
+        // content, so they contribute no scrollable overflow at all (and neither do their
+        // margins). The border-box union above predates this helper and still includes them;
+        // this only avoids *growing* that pre-existing behaviour.
+        if (string.Equals(props.GetValueOrDefault("position"), "fixed", StringComparison.OrdinalIgnoreCase))
+            return 0;
+
+        var margin = ParseCssLengthToPixelsWithViewport(
+            props.GetValueOrDefault(vertical ? "margin-bottom" : "margin-right"),
+            descendant,
+            percentageBasis: percentageBasis);
+
+        return double.IsFinite(margin) ? Math.Max(0, margin) : 0;
     }
 
     /// <summary>

--- a/src/Broiler.Wpt.Tests/ScrollSnapRootPropagationTests.cs
+++ b/src/Broiler.Wpt.Tests/ScrollSnapRootPropagationTests.cs
@@ -1,0 +1,310 @@
+using System.IO;
+using Broiler.HTML.Image;
+using BColor = Broiler.Graphics.BColor;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression guard for the root-scroller programmatic-scroll cluster of issue #1439
+/// (<c>css/css-scroll-snap/scroll-snap-root-001</c> and <c>-002</c>, both reported at 0.0%
+/// pixel match). Four independent defects stacked up to pin those documents at scroll offset
+/// 0 — or, once they scrolled, at the wrong offset:
+///
+/// <list type="number">
+/// <item><description><b>Root <c>overflow: hidden</c> refused every programmatic scroll.</b>
+/// <c>DisablesRootScrolling</c> treated <c>hidden</c> like <c>clip</c>, but <c>hidden</c> still
+/// establishes a scroll container — it only drops the user-interaction affordance, while
+/// <c>scrollTop</c>/<c>scrollIntoView</c> keep working (CSS Overflow 3 §3.3). Both WPT tests use
+/// the very common reftest idiom <c>:root { overflow: hidden; /* hide scrollbars */ }</c>.</description></item>
+/// <item><description><b><c>scrollHeight</c> dropped trailing margins.</b> The scrollable overflow
+/// region is built from descendants' <em>margin</em> boxes (CSS Overflow 3 §3.1); unioning border
+/// boxes alone truncated the document by the last child's <c>margin-bottom</c> and clamped scrolls
+/// to a max that was too small.</description></item>
+/// <item><description><b><c>scroll-padding</c>/<c>scroll-margin</c> shorthands resolved to 0.</b>
+/// The style engine keeps them as declared instead of expanding to longhands, and
+/// <c>scroll-padding</c>'s percentages had no scrollport basis, so <c>scrollIntoView</c> ignored
+/// both insets.</description></item>
+/// <item><description><b>No scroll snapping.</b> A <c>mandatory</c> snap container must come to
+/// rest on a snap position after any scroll (CSS Scroll Snap 1 §2), which is what makes an
+/// <c>end</c>-aligned target land at the scrollport's end edge rather than its start.</description></item>
+/// </list>
+///
+/// <para>A fifth defect surfaced once the offsets were right: the <c>scrollIntoView</c> target
+/// size was reconstructed from computed-style strings, which silently dropped the
+/// <c>thin</c>/<c>medium</c>/<c>thick</c> border-width keywords and shifted every end/center
+/// alignment by the border width.</para>
+///
+/// <para>The two WPT-mirroring fixtures below assert exact geometry, because the whole point of
+/// those tests is that a specific edge lands on a specific pixel row.</para>
+/// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
+public class ScrollSnapRootPropagationTests : IDisposable
+{
+    public void Dispose() => Program.ResetTestHooks();
+
+    // The WPT reference PNGs for this cluster are rendered at 1024x768, and both fixtures are
+    // written in vh units, so the viewport size is load-bearing for the expected pixel rows.
+    private const int W = 1024;
+    private const int H = 768;
+
+    private static BBitmap Render(string html)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-snap-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        string file = Path.Combine(dir, "t.html");
+        File.WriteAllText(file, html);
+        try
+        {
+            var runner = new WptTestRunner(W, H);
+            return runner.RenderHtmlFileBitmapPublic(file, dir);
+        }
+        finally { try { Directory.Delete(dir, true); } catch { } }
+    }
+
+    private static bool IsRed(BColor p) => p.R > 200 && p.G < 80 && p.B < 80;
+    // CSS `green` is #008000, so the green channel sits at 128 — not the 255 a `#0f0` fixture
+    // would give. The threshold has to stay below that or every green assertion goes vacuous.
+    private static bool IsGreen(BColor p) => p.G > 100 && p.R < 80 && p.B < 80;
+    private static bool IsBlue(BColor p) => p.B > 150 && p.R < 80 && p.G < 80;
+    private static bool IsOrange(BColor p) => p.R > 200 && p.G is > 120 and < 210 && p.B < 100;
+
+    private static int Count(BBitmap bmp, Func<BColor, bool> match)
+    {
+        int n = 0;
+        for (int y = 0; y < H; y++)
+            for (int x = 0; x < W; x++)
+                if (match(bmp.GetPixel(x, y)))
+                    n++;
+        return n;
+    }
+
+    /// <summary>First and last row containing a pixel matching <paramref name="match"/>, or (-1, -1).</summary>
+    private static (int First, int Last) RowSpan(BBitmap bmp, Func<BColor, bool> match)
+    {
+        int first = -1, last = -1;
+        for (int y = 0; y < H; y++)
+        {
+            for (int x = 0; x < W; x++)
+            {
+                if (!match(bmp.GetPixel(x, y)))
+                    continue;
+                if (first < 0)
+                    first = y;
+                last = y;
+                break;
+            }
+        }
+        return (first, last);
+    }
+
+    // ---------------------------------------------------------------------
+    // 1. Root overflow: hidden is still programmatically scrollable
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void RootOverflowHidden_StillAcceptsProgrammaticScroll()
+    {
+        const string html =
+            "<!DOCTYPE html><html><head><style>" +
+            "html{overflow:hidden} body{margin:0}" +
+            ".red{height:100vh;background:red} .green{height:100vh;background:green}" +
+            "</style></head><body>" +
+            "<div class=\"red\"></div><div class=\"green\"></div>" +
+            "<script>document.documentElement.scrollTop = 768;</script>" +
+            "</body></html>";
+
+        using var bmp = Render(html);
+        Assert.True(Count(bmp, IsGreen) > W * H * 0.95,
+            "overflow:hidden root did not scroll; hidden must still allow programmatic scrolling.");
+        Assert.True(Count(bmp, IsRed) < W * H * 0.02, "red block still visible after scrolling past it.");
+    }
+
+    /// <summary><c>overflow: clip</c> genuinely suppresses the scroll container, so it must stay pinned.</summary>
+    [Fact]
+    public void RootOverflowClip_RemainsUnscrollable()
+    {
+        const string html =
+            "<!DOCTYPE html><html><head><style>" +
+            "html{overflow:clip} body{margin:0}" +
+            ".red{height:100vh;background:red} .green{height:100vh;background:green}" +
+            "</style></head><body>" +
+            "<div class=\"red\"></div><div class=\"green\"></div>" +
+            "<script>document.documentElement.scrollTop = 768;</script>" +
+            "</body></html>";
+
+        using var bmp = Render(html);
+        Assert.True(Count(bmp, IsRed) > W * H * 0.95,
+            "overflow:clip root scrolled; clip suppresses the scroll container entirely.");
+    }
+
+    // ---------------------------------------------------------------------
+    // 2. Trailing bottom margin is scrollable overflow
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// The last in-flow child's <c>margin-bottom</c> adds 100vh of scrollable area, so scrolling
+    /// to the maximum offset moves the green block fully off-screen. Before the fix the document
+    /// ended at the green block's border box, capping the scroll one viewport earlier and leaving
+    /// green filling the screen.
+    /// </summary>
+    [Fact]
+    public void ScrollableOverflow_IncludesTrailingBottomMargin()
+    {
+        const string html =
+            "<!DOCTYPE html><html><head><style>" +
+            "body{margin:0} .red{height:100vh;background:red}" +
+            ".green{height:100vh;background:green;margin-bottom:100vh}" +
+            "</style></head><body>" +
+            "<div class=\"red\"></div><div class=\"green\"></div>" +
+            "<script>document.documentElement.scrollTop = 99999;</script>" +
+            "</body></html>";
+
+        using var bmp = Render(html);
+        Assert.True(Count(bmp, IsGreen) < W * H * 0.02,
+            "green still visible at max scroll; the trailing margin was not scrollable overflow.");
+        Assert.True(Count(bmp, IsRed) < W * H * 0.02, "red still visible at max scroll.");
+    }
+
+    // ---------------------------------------------------------------------
+    // 3. scroll-padding / scroll-margin shorthands (WPT scroll-snap-root-001)
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// Mirrors <c>css/css-scroll-snap/scroll-snap-root-001</c>. <c>#target</c>'s border box starts
+    /// at y=1382.4; <c>scroll-margin: 25vh</c> (192) pulls the snap area start to 1190.4 and the
+    /// root's <c>scroll-padding: 25%</c> (192 of the 768px scrollport) pushes the snapport start to
+    /// 192, so the scroll lands at 998.4 and the blue border-top paints at 1382.4 - 998.4 = 384 —
+    /// the vertical centre the test's own message describes.
+    /// </summary>
+    [Fact]
+    public void ScrollIntoView_HonoursScrollPaddingAndScrollMarginShorthands()
+    {
+        const string html =
+            "<!DOCTYPE html><html><head><style>" +
+            "html,body{margin:0;padding:0}" +
+            ":root{scroll-snap-type:block mandatory;scroll-padding:25%;overflow:hidden}" +
+            "#fail{font:bold 2em;background:red;height:120vh;margin-bottom:60vh}" +
+            "#target{margin-bottom:120vh;scroll-margin:25vh;scroll-snap-align:start;border-top:solid blue}" +
+            "</style></head><body>" +
+            "<div id=\"fail\">FAIL</div>" +
+            "<div id=\"target\"><div>Test passes if the blue line above is centered in the viewport.</div></div>" +
+            "<script>document.getElementById('target').scrollIntoView();</script>" +
+            "</body></html>";
+
+        using var bmp = Render(html);
+        Assert.Equal(0, Count(bmp, IsRed));
+
+        var (firstBlue, _) = RowSpan(bmp, IsBlue);
+        Assert.InRange(firstBlue, 383, 385);
+    }
+
+    // ---------------------------------------------------------------------
+    // 4. Mandatory snapping + body scroll-padding must not propagate (WPT -002)
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// Mirrors <c>css/css-scroll-snap/scroll-snap-root-002</c>. <c>#target</c>'s border box is
+    /// 1843.2..1868.2 (20px content + a 5px <c>thick</c> bottom border). <c>scroll-snap-align: end</c>
+    /// under a <c>mandatory</c> root snap container aligns that end edge with the scrollport's end,
+    /// giving 1868.2 - 768 = 1100.2 and painting the orange stripe on the last rows.
+    ///
+    /// <para>The <c>scroll-padding: 25%</c> on <c>&lt;body&gt;</c> is the trap the WPT test is named
+    /// for: only the root element propagates to the viewport. Honouring body's would shorten the
+    /// snapport to 576 and push the stripe off-screen.</para>
+    /// </summary>
+    [Fact]
+    public void MandatorySnap_EndAlignment_LandsTargetAtScrollportEnd()
+    {
+        const string html =
+            "<!DOCTYPE html><html><head><style>" +
+            "html,body{margin:0;padding:0}" +
+            ":root{scroll-snap-type:block mandatory;overflow:hidden}" +
+            "body{scroll-padding:25%}" +
+            "#fail{height:120vh;font:bold 2em;background:red}" +
+            "#target{margin:120vh 0;scroll-snap-align:end;border-bottom:solid orange thick;height:20px}" +
+            "</style></head><body>" +
+            "<div id=\"fail\">FAIL</div>" +
+            "<div id=\"target\"><div>Test passes if the orange stripe below is exactly at the bottom of the viewport.</div></div>" +
+            "<script>document.getElementById('target').scrollIntoView();</script>" +
+            "</body></html>";
+
+        using var bmp = Render(html);
+        Assert.Equal(0, Count(bmp, IsRed));
+
+        var (firstOrange, lastOrange) = RowSpan(bmp, IsOrange);
+        Assert.InRange(firstOrange, 762, 764);
+        Assert.Equal(H - 1, lastOrange);
+    }
+
+    /// <summary>
+    /// The same document without <c>scroll-snap-type</c> must NOT snap: a plain
+    /// <c>scrollIntoView()</c> start-aligns, putting the target's top at the scrollport top and
+    /// leaving the orange stripe 25px down rather than at the bottom edge. Guards the snap hook
+    /// against firing on ordinary scroll containers.
+    /// </summary>
+    [Fact]
+    public void WithoutScrollSnapType_ScrollIntoViewStartAligns()
+    {
+        const string html =
+            "<!DOCTYPE html><html><head><style>" +
+            "html,body{margin:0;padding:0}" +
+            ":root{overflow:hidden}" +
+            "#target{margin:120vh 0;scroll-snap-align:end;border-bottom:solid orange thick;height:20px}" +
+            "</style></head><body>" +
+            "<div id=\"fail\" style=\"height:120vh;background:red\">FAIL</div>" +
+            "<div id=\"target\"></div>" +
+            "<script>document.getElementById('target').scrollIntoView();</script>" +
+            "</body></html>";
+
+        using var bmp = Render(html);
+        var (firstOrange, _) = RowSpan(bmp, IsOrange);
+        Assert.InRange(firstOrange, 19, 21);
+    }
+
+    /// <summary><c>proximity</c> leaves the snap decision to the UA, so it must not move the scroll.</summary>
+    [Fact]
+    public void ProximityScrollSnapType_DoesNotSnap()
+    {
+        const string html =
+            "<!DOCTYPE html><html><head><style>" +
+            "html,body{margin:0;padding:0}" +
+            ":root{scroll-snap-type:block proximity;overflow:hidden}" +
+            "#target{margin:120vh 0;scroll-snap-align:end;border-bottom:solid orange thick;height:20px}" +
+            "</style></head><body>" +
+            "<div id=\"fail\" style=\"height:120vh;background:red\">FAIL</div>" +
+            "<div id=\"target\"></div>" +
+            "<script>document.getElementById('target').scrollIntoView();</script>" +
+            "</body></html>";
+
+        using var bmp = Render(html);
+        var (firstOrange, _) = RowSpan(bmp, IsOrange);
+        Assert.InRange(firstOrange, 19, 21);
+    }
+
+    // ---------------------------------------------------------------------
+    // 5. Keyword border widths count toward the scrollIntoView target size
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// <c>scrollIntoView({block:'end'})</c> aligns the target's border-box end with the scrollport
+    /// end, so a <c>thick</c> (5px) bottom border must be part of the measured size. Reconstructing
+    /// the size from computed-style strings dropped the keyword and left the border off-screen.
+    /// </summary>
+    [Fact]
+    public void ScrollIntoViewEnd_CountsKeywordBorderWidthInTargetSize()
+    {
+        const string html =
+            "<!DOCTYPE html><html><head><style>" +
+            "html,body{margin:0;padding:0} :root{overflow:hidden}" +
+            "#target{margin:120vh 0;border-bottom:solid orange thick;height:20px}" +
+            "</style></head><body>" +
+            "<div style=\"height:120vh\"></div>" +
+            "<div id=\"target\"></div>" +
+            "<script>document.getElementById('target').scrollIntoView({block:'end'});</script>" +
+            "</body></html>";
+
+        using var bmp = Render(html);
+        var (_, lastOrange) = RowSpan(bmp, IsOrange);
+        Assert.Equal(H - 1, lastOrange);
+    }
+}

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -2371,6 +2371,14 @@ input {
     for (const match of document.querySelectorAll('.target')) {
       match.scrollIntoView({ block: 'start', inline: 'start' });
     }
+    // This fixture measures the zoom x scroll-inset math *inside* the nested
+    // scrollers. Its content also overflows the 320x240 viewport, so
+    // scrollIntoView legitimately continues outward and scrolls the document as
+    // well: the root is a scroll container even under overflow: hidden, which
+    // only removes the user-interaction affordance (CSS Overflow 3 SS3.3). That
+    // viewport scroll is incidental to what is being compared and the reference
+    // does not model it, so it is reset to keep the comparison on the containers.
+    document.documentElement.scrollTo(0, 0);
   </script>
 </body>
 </html>";
@@ -2458,6 +2466,14 @@ input {
     for (const match of document.querySelectorAll('.target')) {
       match.scrollIntoView({ block: 'start', inline: 'start' });
     }
+    // This fixture measures the zoom x scroll-inset math *inside* the nested
+    // scrollers. Its content also overflows the 320x240 viewport, so
+    // scrollIntoView legitimately continues outward and scrolls the document as
+    // well: the root is a scroll container even under overflow: hidden, which
+    // only removes the user-interaction affordance (CSS Overflow 3 SS3.3). That
+    // viewport scroll is incidental to what is being compared and the reference
+    // does not model it, so it is reset to keep the comparison on the containers.
+    document.documentElement.scrollTo(0, 0);
   </script>
 </body>
 </html>";
@@ -2975,6 +2991,14 @@ input {
     for (const match of document.querySelectorAll('.target')) {
       match.scrollIntoView();
     }
+    // This fixture measures the zoom x scroll-inset math *inside* the nested
+    // scrollers. Its content also overflows the 320x240 viewport, so
+    // scrollIntoView legitimately continues outward and scrolls the document as
+    // well: the root is a scroll container even under overflow: hidden, which
+    // only removes the user-interaction affordance (CSS Overflow 3 SS3.3). That
+    // viewport scroll is incidental to what is being compared and the reference
+    // does not model it, so it is reset to keep the comparison on the containers.
+    document.documentElement.scrollTo(0, 0);
   </script>
 </body>
 </html>";
@@ -3075,6 +3099,14 @@ input {
     for (const match of document.querySelectorAll('.target')) {
       match.scrollIntoView();
     }
+    // This fixture measures the zoom x scroll-inset math *inside* the nested
+    // scrollers. Its content also overflows the 320x240 viewport, so
+    // scrollIntoView legitimately continues outward and scrolls the document as
+    // well: the root is a scroll container even under overflow: hidden, which
+    // only removes the user-interaction affordance (CSS Overflow 3 SS3.3). That
+    // viewport scroll is incidental to what is being compared and the reference
+    // does not model it, so it is reset to keep the comparison on the containers.
+    document.documentElement.scrollTo(0, 0);
   </script>
 </body>
 </html>";


### PR DESCRIPTION
## Summary

Fixes five stacked defects that pinned WPT tests `css/css-scroll-snap/scroll-snap-root-001` and `-002` at 0% pixel match. Root elements with `overflow: hidden` now accept programmatic scrolls, trailing margins extend scrollable overflow, scroll-padding/scroll-margin shorthands resolve correctly, mandatory snap positioning works, and keyword border widths are counted in scrollIntoView target sizing.

## Key Changes

- **Root overflow:hidden now scrollable**: `DisablesRootScrolling` incorrectly treated `hidden` like `clip`. Per CSS Overflow 3 §3.3, `hidden` still establishes a scroll container — it only removes the user-interaction affordance. Programmatic scrolling (`scrollTop`, `scrollIntoView`, etc.) must work.

- **Trailing margins in scrollable overflow**: The scrollable overflow region is built from descendants' margin boxes (CSS Overflow 3 §3.1), not border boxes. Added `GetScrollableOverflowEndMargin` to include positive end margins of in-flow descendants in the viewport's scrollable area. Restricted to viewport only — ordinary scroll containers' margins don't extend scrollable overflow.

- **scroll-padding/scroll-margin shorthand resolution**: The style engine keeps shorthands as declared rather than expanding to longhands. Added `ResolveScrollInsetFromShorthand` to extract individual sides from the box shorthand when longhands are absent. Percentages in `scroll-padding` now resolve against the scrollport size on the same axis (CSS Scroll Snap 1 §5.2).

- **Mandatory scroll snap positioning**: Implemented `ResolveScrollSnapPosition` and `HasMandatoryScrollSnapOnAxis` to snap to positions after any programmatic scroll. Only `mandatory` strictness snaps (per spec); `proximity` is left un-snapped as a conforming UA choice. Snap resolution runs at the single choke point where requested offsets become stored ones, applying to all scrolling entry points uniformly.

- **Keyword border widths in scrollIntoView**: Added `GetScrollIntoViewTargetSize` to prefer the real laid-out border box from the shared geometry snapshot over computed-style reconstruction. The reconstruction silently dropped `thin`/`medium`/`thick` keywords, under-measuring targets and shifting end/center alignments by the border width.

- **Root propagation for snap properties**: Root-scroller snap properties (`scroll-snap-type`, `scroll-padding`) are read from `<html>` only; `<body>` is never consulted. This matches the existing container model and the distinction WPT test `scroll-snap-root-002` asserts (issue #1439).

## Test Coverage

Added `ScrollSnapRootPropagationTests` with seven fixtures covering all five defects:
- `RootOverflowHidden_StillAcceptsProgrammaticScroll` / `RootOverflowClip_RemainsUnscrollable`
- `ScrollableOverflow_IncludesTrailingBottomMargin`
- `ScrollIntoView_HonoursScrollPaddingAndScrollMarginShorthands`
- `MandatorySnap_EndAlignment_LandsTargetAtScrollportEnd` / `WithoutScrollSnapType_ScrollIntoViewStartAligns` / `ProximityScrollSnapType_DoesNotSnap`
- `ScrollIntoViewEnd_CountsKeywordBorderWidthInTargetSize`

Updated existing WPT fixtures to reset root scroll after nested-container tests, since `overflow: hidden` now allows programmatic scrolling and `scrollIntoView` legitimately scrolls the document as well as nested scrollers.

https://claude.ai/code/session_0119SxxLRK3xaFpRPFAuoPrY