### PR TITLE
Surface cancelled shards and restrict rerun reference generation

### DIFF
--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -74,6 +74,7 @@ jobs:
     outputs:
       shard-matrix: ${{ steps.resolve.outputs.shard-matrix }}
       rerun-failed: ${{ steps.resolve.outputs.rerun-failed }}
+      expected-shards: ${{ steps.resolve.outputs.expected-shards }}
     steps:
       - uses: actions/checkout@v5
 
@@ -106,9 +107,16 @@ jobs:
           rerun_requested = os.environ["RERUN_FAILED_ONLY"].strip().lower() == "true"
           rerun_failed = rerun_requested and Path(os.environ["FAILED_TESTS_FILE"]).exists()
 
+          # The exact set of shard indexes this run dispatches. The merge step uses
+          # it to spot a dispatched shard that uploaded nothing (its job cancelled
+          # mid-run), which would otherwise be silently dropped from the merged
+          # totals rather than flagged as an incomplete shard.
+          expected_shards = ",".join(str(entry["shard-index"]) for entry in matrix)
+
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
               fh.write(f"shard-matrix={json.dumps(matrix)}\n")
               fh.write(f"rerun-failed={'true' if rerun_failed else 'false'}\n")
+              fh.write(f"expected-shards={expected_shards}\n")
           PY
 
   # ── Clone + cache the WPT checkout once (shared by all shards) ────────────
@@ -251,7 +259,7 @@ jobs:
 
   # ── Merge shard results; file an issue when there are failures ───────────
   report:
-    needs: run
+    needs: [plan, run]
     if: always() && needs.run.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
@@ -281,6 +289,7 @@ jobs:
             --biggest-issue-md wpt-merged/biggest-issue.md \
             --problem-limit "$MOST_COMMON_PROBLEMS_LIMIT" \
             --biggest-problem-limit "$BIGGEST_PROBLEMS_LIMIT" \
+            --expected-shards "${{ needs.plan.outputs.expected-shards }}" \
             --github-output "$GITHUB_OUTPUT"
 
       - name: Publish merged summary

--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -217,8 +217,13 @@ jobs:
             ARGS+=(--subset "$SUBSET")
           fi
           if [ "$RERUN_FAILED" = "true" ]; then
-            # Incremental: rerun only previously-failed tests, reusing cached refs.
-            ARGS+=(--rerun-json "$FAILED_TESTS_FILE" --skip-reference-generation)
+            # Incremental: rerun only the previously-failed tests. Reference
+            # generation is NOT skipped — run-wpt-tests.sh restricts it to just the
+            # rerun set (fast, and it guarantees those tests have references).
+            # Skipping generation here relied on a cached reference set that is not
+            # reliably present, which skipped every reran test as "missing
+            # reference image" and made the run meaningless.
+            ARGS+=(--rerun-json "$FAILED_TESTS_FILE")
           fi
           EXIT=0
           bash scripts/run-wpt-tests.sh "${ARGS[@]}" || EXIT=$?

--- a/scripts/generate-wpt-references.js
+++ b/scripts/generate-wpt-references.js
@@ -250,6 +250,36 @@ function isBrowserClosedError(error) {
     return /browser (?:has been )?closed|target page, context or browser has been closed|browser disconnected/i.test(message);
 }
 
+/**
+ * Load the set of forward-slash relative test paths named in a prior JSON report
+ * (the incremental-rerun manifest). Used to restrict reference generation to the
+ * tests an incremental run will actually re-execute, so references exist for
+ * exactly that set — the C# runner's `--rerun-json` filters the same manifest, so
+ * the two stay in lock-step.
+ *
+ * Every entry in the failed-tests manifest is a rerun candidate, so all paths are
+ * taken. `relativeTestPath` (already forward-slash, relative to the WPT root) is
+ * preferred; `testPath` is a fallback. Returns a Set of normalised relative paths.
+ */
+function loadRerunTestPaths(rerunJson) {
+    const data = JSON.parse(fs.readFileSync(rerunJson, 'utf8'));
+    const results = data && Array.isArray(data.results) ? data.results : null;
+    if (!results) {
+        throw new Error(`rerun report ${rerunJson} has no top-level 'results' array`);
+    }
+    const paths = new Set();
+    for (const result of results) {
+        if (!result || typeof result !== 'object') {
+            continue;
+        }
+        const raw = result.relativeTestPath || result.testPath;
+        if (typeof raw === 'string' && raw.trim() !== '') {
+            paths.add(raw.split(path.sep).join('/').replace(/\\/g, '/'));
+        }
+    }
+    return paths;
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -261,6 +291,7 @@ async function main(args = process.argv.slice(2)) {
     let shardCount = 1;
     let shardIndex = ALL_SHARDS;
     let nonJsOnly = false;
+    let rerunJson = null;
 
     for (let i = 0; i < args.length; i++) {
         if (args[i] === '--concurrency' && i + 1 < args.length) {
@@ -271,6 +302,8 @@ async function main(args = process.argv.slice(2)) {
             shardCount = parseInt(args[++i], 10);
         } else if (args[i] === '--shard-index' && i + 1 < args.length) {
             shardIndex = parseInt(args[++i], 10);
+        } else if (args[i] === '--rerun-json' && i + 1 < args.length) {
+            rerunJson = args[++i];
         } else if (args[i] === '--non-js') {
             nonJsOnly = true;
         } else if (!testDir) {
@@ -316,6 +349,28 @@ async function main(args = process.argv.slice(2)) {
         testFiles = testFiles.filter((testFile) =>
             !requiresJavaScript(fs.readFileSync(testFile, 'utf8')));
         console.log(`Non-JS mode: selected ${testFiles.length} files; skipped ${beforeFilter - testFiles.length} JavaScript-dependent files`);
+    }
+
+    // Incremental rerun: restrict generation to the tests named in the prior
+    // manifest, matching the C# runner's own `--rerun-json` filter. Applied before
+    // sharding (like the runner) so shard N still generates exactly the rerun tests
+    // it will execute. This is what makes an incremental run correct: without it
+    // the run reused a cached reference set that may be absent, so every reran test
+    // was skipped as "missing reference image".
+    if (rerunJson) {
+        let rerunPaths;
+        try {
+            rerunPaths = loadRerunTestPaths(rerunJson);
+        } catch (error) {
+            console.error(`Error: ${error.message}`);
+            process.exit(1);
+        }
+        const beforeRerun = testFiles.length;
+        testFiles = testFiles.filter((testFile) => {
+            const relative = path.relative(baseDir, testFile).split(path.sep).join('/');
+            return rerunPaths.has(relative);
+        });
+        console.log(`Rerun mode: selected ${testFiles.length} of ${beforeRerun} files present in ${rerunJson}`);
     }
 
     // When sharding, keep only the files assigned to this shard by the same
@@ -524,6 +579,7 @@ module.exports = {
     isWptHarnessScript,
     main,
     isBrowserClosedError,
+    loadRerunTestPaths,
     parsePositiveIntegerEnv,
     requiresJavaScript,
     resolveRootRelativeResource,

--- a/scripts/merge-wpt-shards.py
+++ b/scripts/merge-wpt-shards.py
@@ -117,6 +117,16 @@ def _iter_shard_statuses(shard_dir: Path):
             yield path, data
 
 
+def _format_incomplete_shard(status: dict) -> str:
+    """Human-readable label for an incomplete shard. A numeric exit code means the
+    shard crashed after running; the ``"missing"`` sentinel means it uploaded
+    nothing at all (its job was cancelled before the collect/upload steps)."""
+    exit_code = status["exitCode"]
+    if exit_code == "missing":
+        return f"shard {status['shardIndex']} (no report uploaded)"
+    return f"shard {status['shardIndex']} (exit {exit_code})"
+
+
 def _problem_identity(result: dict) -> tuple[str, str, str | None]:
     """Return a stable key and label for a failure root-cause group."""
     category = str(result.get("category") or "Unknown")
@@ -169,9 +179,7 @@ def _rank_biggest_problems(
 
     if incomplete_shards:
         shards = sorted(incomplete_shards, key=lambda status: status["shardIndex"])
-        listing = ", ".join(
-            f"shard {status['shardIndex']} (exit {status['exitCode']})" for status in shards
-        )
+        listing = ", ".join(_format_incomplete_shard(status) for status in shards)
         problems.append(
             {
                 "kind": "IncompleteShards",
@@ -311,6 +319,7 @@ def merge(
     problem_limit: int = DEFAULT_PROBLEM_LIMIT,
     biggest_problem_limit: int = DEFAULT_BIGGEST_PROBLEM_LIMIT,
     low_match_threshold: float = DEFAULT_LOW_MATCH_THRESHOLD,
+    expected_shard_indexes: set[int] | None = None,
 ) -> dict:
     passed = failed = skipped = total = 0
     shard_count = 0
@@ -452,16 +461,50 @@ def merge(
             if len(family_group["examples"]) < PROBLEM_EXAMPLE_LIMIT:
                 family_group["examples"].append(relative_path)
 
-    incomplete_shards = []
+    # Exit code left behind by each shard that got far enough to run the
+    # "Collect shard result" step (index -> exit code).
+    shard_exit_codes: dict[int, int] = {}
     for _path, status in _iter_shard_statuses(shard_dir):
         try:
             shard_index = int(status["shardIndex"])
             exit_code = int(status["exitCode"])
         except (TypeError, ValueError):
             continue
-        if exit_code == 0 or shard_index in reported_shard_indexes:
+        shard_exit_codes[shard_index] = exit_code
+
+    # A shard is incomplete when it produced no conclusive report. There are two
+    # ways that happens, and the second one used to be invisible:
+    #   1. it left a status file with a non-zero exit — it crashed after the run
+    #      step but the runner still ran the always() collect step; or
+    #   2. it was dispatched (its index is in expected_shard_indexes) but produced
+    #      neither a report nor a status file. Its job was cancelled mid-run — e.g.
+    #      it hit the job timeout-minutes — so the always() collect/upload steps
+    #      never ran and its whole slice silently vanished from the artifacts.
+    #
+    # Case 2 is the important one: the merged pass/fail/skip/total counts are a raw
+    # SUM over the shards that uploaded, so a vanished shard drops ~1/N of every
+    # count with no indication. That is why the "skipped" total is not comparable
+    # between runs — a run that merges 6 of 8 shards reports ~6/8 of the skips a
+    # full 8-shard merge would. Flagging the missing shard makes the shortfall
+    # visible (incomplete_shard_count > 0 → the issue and summary say so) instead
+    # of silently under-counting.
+    candidate_indexes = set(shard_exit_codes)
+    if expected_shard_indexes is not None:
+        candidate_indexes |= set(expected_shard_indexes)
+
+    incomplete_shards = []
+    for shard_index in sorted(candidate_indexes):
+        if shard_index in reported_shard_indexes:
             continue
-        incomplete_shards.append({"shardIndex": shard_index, "exitCode": exit_code})
+        exit_code = shard_exit_codes.get(shard_index)
+        # A clean exit with no report is odd but not an incomplete run; leave it.
+        if exit_code == 0:
+            continue
+        incomplete_shards.append(
+            # A dispatched shard that left no status file at all never uploaded
+            # anything — record it as "missing" rather than a numeric exit code.
+            {"shardIndex": shard_index, "exitCode": exit_code if exit_code is not None else "missing"}
+        )
 
     if incomplete_shards:
         incomplete_shards.sort(key=lambda status: status["shardIndex"])
@@ -472,7 +515,7 @@ def merge(
             "subCategory": None,
             "count": len(incomplete_shards),
             "examples": [
-                f"shard {status['shardIndex']} (exit {status['exitCode']})"
+                _format_incomplete_shard(status)
                 for status in incomplete_shards[:PROBLEM_EXAMPLE_LIMIT]
             ],
         }
@@ -787,6 +830,13 @@ def main() -> int:
         help="A pixel match below this percent counts as a 'low percent match' big "
         f"problem (default: {DEFAULT_LOW_MATCH_THRESHOLD:g})",
     )
+    parser.add_argument(
+        "--expected-shards",
+        help="Comma-separated shard indexes this run dispatched (e.g. '0,1,2,3,4,5,6,7'). "
+        "Any expected shard that uploaded neither a report nor a status file is "
+        "flagged incomplete, so a shard whose job was cancelled mid-run (its slice "
+        "silently missing from the merged totals) is surfaced instead of dropped.",
+    )
     parser.add_argument("--run-url", default=os.environ.get("WPT_RUN_URL"), help="Workflow run URL for the issue footer")
     parser.add_argument("--github-output", type=Path, help="Path to $GITHUB_OUTPUT for step outputs")
     args = parser.parse_args()
@@ -798,11 +848,21 @@ def main() -> int:
     if not 0 <= args.low_match_threshold <= 100:
         parser.error("--low-match-threshold must be between 0 and 100")
 
+    expected_shard_indexes: set[int] | None = None
+    if args.expected_shards is not None:
+        try:
+            expected_shard_indexes = {
+                int(token) for token in args.expected_shards.split(",") if token.strip() != ""
+            }
+        except ValueError:
+            parser.error("--expected-shards must be a comma-separated list of integers")
+
     merged = merge(
         args.shard_dir,
         args.problem_limit,
         args.biggest_problem_limit,
         args.low_match_threshold,
+        expected_shard_indexes=expected_shard_indexes,
     )
 
     if args.merge_into:

--- a/scripts/run-wpt-tests.sh
+++ b/scripts/run-wpt-tests.sh
@@ -116,9 +116,15 @@ fi
 
 # Incremental rerun arguments for the C# runner.
 RERUN_ARGS=()
+# Incremental rerun arguments for the reference generator. When a rerun manifest
+# is given, generation is restricted to exactly the tests being re-run (fast, and
+# — crucially — it guarantees those tests have references rather than relying on a
+# cached set that may be absent, which otherwise skips every reran test).
+REF_RERUN_ARGS=()
 if [[ -n "$RERUN_JSON" ]]; then
     RERUN_ARGS=(--rerun-json "$RERUN_JSON")
     [[ -n "$RERUN_KIND" ]] && RERUN_ARGS+=(--rerun-kind "$RERUN_KIND")
+    REF_RERUN_ARGS=(--rerun-json "$RERUN_JSON")
 fi
 
 NON_JS_ARGS=()
@@ -269,7 +275,7 @@ elif command -v npx &>/dev/null; then
                     if ! NODE_PATH="$REPO_ROOT/tests/wpt/node_modules" \
                         node "$SCRIPT_DIR/generate-wpt-references.js" \
                         "$MATCH_DIR" "$REFERENCE_DIR" --concurrency 8 --base-dir "$WPT_DIR" \
-                        "${SHARD_ARGS[@]}" "${NON_JS_ARGS[@]}" 2>&1; then
+                        "${SHARD_ARGS[@]}" "${REF_RERUN_ARGS[@]}" "${NON_JS_ARGS[@]}" 2>&1; then
                         echo "  ✗ Reference generation failed for $MATCH_DIR" >&2
                         REF_GEN_OK=false
                     fi
@@ -284,7 +290,7 @@ elif command -v npx &>/dev/null; then
         if ! NODE_PATH="$REPO_ROOT/tests/wpt/node_modules" \
             node "$SCRIPT_DIR/generate-wpt-references.js" \
             "$TEST_DIR" "$REFERENCE_DIR" --concurrency 8 \
-            "${SHARD_ARGS[@]}" "${NON_JS_ARGS[@]}" 2>&1; then
+            "${SHARD_ARGS[@]}" "${REF_RERUN_ARGS[@]}" "${NON_JS_ARGS[@]}" 2>&1; then
             REF_GEN_OK=false
         fi
     fi

--- a/scripts/tests/generate-wpt-references.test.js
+++ b/scripts/tests/generate-wpt-references.test.js
@@ -13,6 +13,7 @@ const {
     isBrowserClosedError,
     isNonTestFile,
     isWptHarnessScript,
+    loadRerunTestPaths,
     parsePositiveIntegerEnv,
     requiresJavaScript,
     resolveRootRelativeResource,
@@ -182,5 +183,40 @@ test('positive integer env parsing falls back for invalid values', () => {
         } else {
             process.env[name] = original;
         }
+    }
+});
+
+test('loadRerunTestPaths collects manifest relative paths, testPath fallback', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'broiler-wpt-rerun-'));
+    try {
+        const manifest = path.join(dir, 'failed-tests.json');
+        fs.writeFileSync(manifest, JSON.stringify({
+            results: [
+                { relativeTestPath: 'css/a/one.html', passed: false, skipped: false },
+                { relativeTestPath: 'html/b/two.xht', passed: false, skipped: false },
+                { testPath: 'css/c/three.html' },        // fallback when no relativeTestPath
+                { relativeTestPath: '', passed: false },  // ignored: empty
+                'not-an-object',                          // ignored: not a dict
+            ],
+        }));
+
+        const paths = loadRerunTestPaths(manifest);
+        assert.deepEqual(
+            [...paths].sort(),
+            ['css/a/one.html', 'css/c/three.html', 'html/b/two.xht'],
+        );
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test('loadRerunTestPaths rejects a manifest without a results array', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'broiler-wpt-rerun-bad-'));
+    try {
+        const manifest = path.join(dir, 'bad.json');
+        fs.writeFileSync(manifest, JSON.stringify({ summary: {} }));
+        assert.throws(() => loadRerunTestPaths(manifest), /no top-level 'results' array/);
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
     }
 });

--- a/scripts/tests/test_merge_wpt_shards.py
+++ b/scripts/tests/test_merge_wpt_shards.py
@@ -270,6 +270,59 @@ class MergeWptShardsTests(unittest.TestCase):
             self.assertIn("incomplete_shard_count=1", outputs)
             self.assertIn("create_issue=true", outputs)
 
+    def test_expected_shard_that_uploaded_nothing_is_flagged_incomplete(self) -> None:
+        # Two of the four dispatched shards reported; the other two uploaded
+        # neither a report nor a status file (their jobs were cancelled mid-run).
+        # Without --expected-shards those two vanish silently, dropping ~half of
+        # every merged count; with it they are surfaced as incomplete shards.
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._write_report(
+                shard_dir,
+                "shard-0.json",
+                0,
+                [self._failure("css/a/one.html", "PixelMismatch", "MissingContent")],
+            )
+            self._write_report(
+                shard_dir,
+                "shard-1.json",
+                1,
+                [self._failure("html/a/two.html", "PixelMismatch", "MissingContent")],
+            )
+
+            # Baseline: no expected set → the missing shards stay invisible.
+            blind = MODULE.merge(shard_dir)
+            self.assertEqual([], blind["incompleteShards"])
+
+            merged = MODULE.merge(shard_dir, expected_shard_indexes={0, 1, 2, 3})
+            self.assertEqual(
+                [
+                    {"shardIndex": 2, "exitCode": "missing"},
+                    {"shardIndex": 3, "exitCode": "missing"},
+                ],
+                merged["incompleteShards"],
+            )
+
+            markdown = MODULE.render_issue_markdown(merged, "https://example.test/run/1")
+            self.assertIn("Incomplete shards: 2", markdown)
+            self.assertIn("shard 2 (no report uploaded)", markdown)
+
+    def test_reported_expected_shard_is_not_flagged(self) -> None:
+        # A shard that both reported and left a status file is complete, and an
+        # expected set that matches the reports produces no incomplete shards.
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._write_report(
+                shard_dir,
+                "shard-0.json",
+                0,
+                [self._failure("css/a/one.html", "PixelMismatch", "MissingContent")],
+            )
+            self._write_status(shard_dir, shard_index=0, exit_code=1)
+
+            merged = MODULE.merge(shard_dir, expected_shard_indexes={0})
+            self.assertEqual([], merged["incompleteShards"])
+
     def test_merge_into_preserves_out_of_scope_entries(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             # Manifest lives outside the scanned shard dir, as in production


### PR DESCRIPTION
## Summary

This change improves visibility of incomplete WPT test runs by detecting shards that were dispatched but produced no output (job cancelled mid-run), and fixes incremental rerun reference generation to only generate references for tests that will actually be re-executed.

## Key Changes

- **Detect missing shards in merge step**: Added `--expected-shards` argument to `merge-wpt-shards.py` to track which shard indexes were dispatched. Shards that were expected but uploaded neither a report nor a status file are now flagged as incomplete with exit code `"missing"`, making silent data loss visible in merged totals.

- **Format incomplete shard labels**: Extracted `_format_incomplete_shard()` helper to consistently display both crash exits (numeric code) and cancelled jobs (`"missing"` sentinel) in human-readable form.

- **Restrict rerun reference generation**: Modified `generate-wpt-references.js` to accept `--rerun-json` argument and filter test files to only those in the rerun manifest. This ensures incremental runs generate references for exactly the tests being re-executed, avoiding the previous issue where cached references were unavailable and every reran test was skipped as "missing reference image."

- **Update workflow and test runner**: 
  - GitHub Actions workflow now outputs `expected-shards` from the plan step and passes it to the merge step
  - `run-wpt-tests.sh` now passes `--rerun-json` to reference generation (previously it was skipped entirely during reruns)
  - Added comprehensive tests for missing shard detection and rerun path filtering

## Implementation Details

The key insight is that a dispatched shard can disappear in two ways:
1. It crashed after running (leaves a status file with non-zero exit code)
2. Its job was cancelled mid-run (leaves nothing at all — no report, no status file)

Case 2 was previously invisible, causing merged pass/fail/skip counts to silently under-report by ~1/N of the total. By tracking expected shard indexes and comparing against what actually reported, we can surface these missing shards as incomplete.

For incremental reruns, the reference generator now loads the rerun manifest and filters to only those test paths before sharding, matching the C# runner's own filtering. This guarantees references exist for the exact set of tests being re-executed.

https://claude.ai/code/session_01XbvEJo2dMtariSDyJWgEFW