### PR TITLE
Normalize rerun manifest path to absolute before use

### DIFF
--- a/scripts/run-wpt-tests.sh
+++ b/scripts/run-wpt-tests.sh
@@ -122,6 +122,21 @@ RERUN_ARGS=()
 # cached set that may be absent, which otherwise skips every reran test).
 REF_RERUN_ARGS=()
 if [[ -n "$RERUN_JSON" ]]; then
+    # Normalize the manifest to an absolute path before it is handed to either
+    # consumer. The reference generator runs from "$REPO_ROOT/tests/wpt" (a
+    # pushd, further down) while the C# runner runs from the invocation
+    # directory, so a *relative* --rerun-json — e.g. the CI default
+    # tests/wpt-baseline/failed-tests.json — would resolve against two different
+    # working directories: the generator opens tests/wpt/tests/wpt-baseline/…
+    # and dies with ENOENT before any reference is produced. Resolving here (the
+    # invocation cwd, before any pushd) points both at the same file.
+    if [[ "$RERUN_JSON" != /* ]]; then
+        RERUN_JSON="$PWD/$RERUN_JSON"
+    fi
+    if [[ ! -f "$RERUN_JSON" ]]; then
+        echo "  ✗ Rerun manifest not found: $RERUN_JSON" >&2
+        exit 1
+    fi
     RERUN_ARGS=(--rerun-json "$RERUN_JSON")
     [[ -n "$RERUN_KIND" ]] && RERUN_ARGS+=(--rerun-kind "$RERUN_KIND")
     REF_RERUN_ARGS=(--rerun-json "$RERUN_JSON")


### PR DESCRIPTION
## Summary

Fix a path resolution bug in the WPT test runner where relative `--rerun-json` paths would resolve against different working directories depending on which consumer (reference generator vs. C# runner) was processing them, causing the reference generator to fail with ENOENT.

## Changes

- **Normalize `RERUN_JSON` to an absolute path** before passing it to either the reference generator or C# runner. The reference generator runs from `tests/wpt` (via `pushd`) while the C# runner runs from the invocation directory, so relative paths would resolve to different locations.
- **Add validation** to check that the rerun manifest file exists after normalization, with a clear error message if not found.
- **Preserve the normalized path** for both `RERUN_ARGS` and `REF_RERUN_ARGS` so both consumers reference the same file.

## Implementation Details

The fix resolves relative paths against `$PWD` (the invocation directory, before any `pushd` occurs), ensuring both the reference generator and C# runner see the same file path. This is particularly important for CI workflows that use relative paths like `tests/wpt-baseline/failed-tests.json` as the default.

https://claude.ai/code/session_019wr7s281iELpdM66ad23Vw