### PR TITLE
Web Animations, CSS filters, @import inlining, and adopted stylesheets

### DIFF
--- a/Broiler.Layout/Broiler.Layout/IR/DisplayList.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/DisplayList.cs
@@ -34,6 +34,8 @@ public sealed class DisplayList
 [JsonDerivedType(typeof(DrawSvgPolylineItem), "DrawSvgPolyline")]
 [JsonDerivedType(typeof(BlendModeItem), "BlendMode")]
 [JsonDerivedType(typeof(RestoreBlendModeItem), "RestoreBlendMode")]
+[JsonDerivedType(typeof(FilterItem), "Filter")]
+[JsonDerivedType(typeof(RestoreFilterItem), "RestoreFilter")]
 [JsonDerivedType(typeof(DrawTiledGradientItem), "DrawTiledGradient")]
 [JsonDerivedType(typeof(TransformItem), "Transform")]
 [JsonDerivedType(typeof(RestoreTransformItem), "RestoreTransform")]
@@ -179,6 +181,19 @@ public sealed class BlendModeItem : DisplayItem
 
 /// <summary>Restores from a blend mode layer pushed by <see cref="BlendModeItem"/>.</summary>
 public sealed class RestoreBlendModeItem : DisplayItem { }
+
+/// <summary>Begins a compositing layer whose pixels the CSS <c>filter</c> function list is
+/// applied to when the layer is restored (the colour-matrix functions: invert/grayscale/
+/// brightness/contrast/sepia/saturate/opacity/hue-rotate). Blur and drop-shadow are not
+/// modelled here.</summary>
+public sealed class FilterItem : DisplayItem
+{
+    /// <summary>CSS filter value (e.g. "invert(1) grayscale(0.5)").</summary>
+    public string Filter { get; init; } = "none";
+}
+
+/// <summary>Restores from a filter layer pushed by <see cref="FilterItem"/>.</summary>
+public sealed class RestoreFilterItem : DisplayItem { }
 
 /// <summary>
 /// Draws a tiled CSS gradient (e.g. linear-gradient) at a specified tile size.

--- a/patches/0025-html-opacity-blend-text-raster-layer.patch
+++ b/patches/0025-html-opacity-blend-text-raster-layer.patch
@@ -1,0 +1,51 @@
+From 424403a7e7a8dfe4242e2a78883aa6e7499d4b6e Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Mon, 27 Jul 2026 23:26:05 +0000
+Subject: [PATCH] paint: keep text-bearing opacity/blend layers on the raster
+ path
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+IsRasterCompatibleItem marked DrawTextItem/DrawSvgTextItem non-raster, so an
+opacity or blend layer containing text was routed to the compat backend. In the
+image renderer that backend is a stub, and once a compat layer is active
+CanUseRaster is false for every enclosed draw — so an element with 0 < opacity < 1
+and any text vanished entirely, background included (the css-view-transitions
+capture family, and any faded/semi-transparent labelled box).
+
+Text already renders on the raster canvas through the text shaper for all
+non-layer text (DrawString tries the raster path first, with a compat fallback),
+so a text-bearing layer can stay on the raster path where SaveOpacityLayer /
+SaveBlendLayer composite it correctly. Mark DrawTextItem and DrawSvgTextItem
+raster-compatible.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+---
+ .../IR/RGraphicsRasterBackend.cs                       | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs b/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs
+index 618eee5..06aa43d 100644
+--- a/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs
++++ b/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs
+@@ -161,8 +161,14 @@ internal sealed class RGraphicsRasterBackend : IRasterBackend
+         RestoreBlendModeItem => true,
+         TransformItem => false,
+         RestoreTransformItem => false,
+-        DrawTextItem => false,
+-        DrawSvgTextItem => false,
++        // Text renders on the raster canvas via the text shaper (the same path all
++        // non-layer text already uses, with a compat fallback inside DrawString), so a
++        // text-bearing opacity/blend layer can stay on the raster path. Marking it
++        // non-raster forced the whole layer onto the compat backend, which is a stub in
++        // the image renderer — so any element with `0 < opacity < 1` and text (or an SVG
++        // text) vanished entirely, background and all (css-view-transitions capture family).
++        DrawTextItem => true,
++        DrawSvgTextItem => true,
+         _ => false,
+     };
+ 
+-- 
+2.43.0
+

--- a/patches/0026-html-nonuniform-scale-raster.patch
+++ b/patches/0026-html-nonuniform-scale-raster.patch
@@ -1,0 +1,206 @@
+From fb82b75f8d4722dfb23f731dd12df64b93169320 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Mon, 27 Jul 2026 23:58:14 +0000
+Subject: [PATCH] paint: rasterise non-uniform (axis-aligned) scale transforms
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+BCanvas mapped points with a single uniform scale, so TrySaveTransform rejected
+any matrix with a != d (scaleX(), scaleY(), scale(x, y)). Rejected transforms
+route to the compat backend, which is a stub in the image renderer — so a
+non-uniformly scaled element (and its content) vanished entirely instead of
+rendering at the scaled size.
+
+Give the canvas a per-axis scale (_scaleX/_scaleY): TrySaveTransform now accepts
+axis-aligned scale (b == c == 0) including non-uniform, folding scaleX into
+_scaleX and scaleY into _scaleY. The point/rect mapping, rounded-clip corner
+radii and stroke width use the per-axis scales (stroke uses their geometric
+mean). Uniform scale sets both axes equal, so existing output is byte-identical.
+Rotation and skew (non-zero b/c) still fall back — they need a full affine
+rasteriser the raster canvas does not have.
+
+This pairs with the DOM-side transform interpolation: an animated or static
+scaleX()/scale(x, y) now both computes the right value and paints it.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+---
+ Source/Broiler.HTML.Image/BCanvas.cs | 117 +++++++++++++++------------
+ 1 file changed, 64 insertions(+), 53 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Image/BCanvas.cs b/Source/Broiler.HTML.Image/BCanvas.cs
+index 4eb0e31..bc2fe26 100644
+--- a/Source/Broiler.HTML.Image/BCanvas.cs
++++ b/Source/Broiler.HTML.Image/BCanvas.cs
+@@ -12,9 +12,10 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+     private readonly Stack<LayerState> _layerStack = new();
+     private readonly List<ClipOperation> _clipOperations = [];
+     private PointF _translation;
+-    private float _scale = 1f;
++    private float _scaleX = 1f;
++    private float _scaleY = 1f;
+ 
+-    public void Save() => _stateStack.Push(new CanvasState(_translation, _scale, _clipOperations.Count));
++    public void Save() => _stateStack.Push(new CanvasState(_translation, _scaleX, _scaleY, _clipOperations.Count));
+ 
+     public void Restore()
+     {
+@@ -23,7 +24,8 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+ 
+         var state = _stateStack.Pop();
+         _translation = state.Translation;
+-        _scale = state.Scale;
++        _scaleX = state.ScaleX;
++        _scaleY = state.ScaleY;
+ 
+         while (_clipOperations.Count > state.ClipOperationCount)
+             _clipOperations.RemoveAt(_clipOperations.Count - 1);
+@@ -34,48 +36,55 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+ 
+     /// <summary>Composes a uniform scale about the surface origin (document-root viewport zoom):
+     /// draws map point -> point*scale + translation. Uniform-only; byte-identical at scale 1.</summary>
+-    public void Scale(float scale) => _scale *= scale;
+-
+-    /// <summary>
+-    /// Applies a CSS 2D transform (matrix <c>[a,b,c,d,e,f]</c> about origin
+-    /// <paramref name="originX"/>/<paramref name="originY"/>) to the raster state, saving the prior
+-    /// state so <see cref="Restore"/> reverses it. Returns <c>false</c> — without touching state —
+-    /// when the matrix is not expressible on this canvas, which maps a point only as
+-    /// <c>p*scale + translation</c>: rotation, skew and non-uniform scale are rejected so the caller
+-    /// can route those to the fuller compat backend. Translation and uniform scale (the common
+-    /// <c>translate()</c>/<c>scale()</c> cases) are folded into <see cref="_scale"/>/<see cref="_translation"/>
+-    /// so transformed content actually rasterises instead of vanishing when the compat backend is a stub.
+-    /// </summary>
+-    public bool TrySaveTransform(float[] matrix, float originX, float originY)
+-    {
+-        if (matrix is null || matrix.Length < 6)
+-            return false;
+-
+-        float a = matrix[0], b = matrix[1], c = matrix[2], d = matrix[3], e = matrix[4], f = matrix[5];
+-
+-        // Only translation + uniform scale survive this canvas's point mapping. b/c carry
+-        // rotation/skew; a != d is a non-uniform scale.
+-        const float epsilon = 1e-4f;
+-        if (MathF.Abs(b) > epsilon || MathF.Abs(c) > epsilon || MathF.Abs(a - d) > epsilon)
+-            return false;
+-
+-        float scale = a;
+-
+-        // Transform-origin applies to the whole transform: p' = scale*(p - origin) + origin + (e,f).
+-        float localTranslateX = originX * (1f - scale) + e;
+-        float localTranslateY = originY * (1f - scale) + f;
+-
+-        // Compose ahead of the existing surface mapping (p -> p*_scale + _translation): a child point p
+-        // becomes (scale*p + localTranslate) which the surface then maps, giving
+-        // p*(scale*_scale) + (localTranslate*_scale + _translation).
+-        Save();
+-        _translation = new PointF(
+-            localTranslateX * _scale + _translation.X,
+-            localTranslateY * _scale + _translation.Y);
+-        _scale *= scale;
+-        return true;
+-    }
+-
++    public void Scale(float scale)
++    {
++        _scaleX *= scale;
++        _scaleY *= scale;
++    }
++
++    /// <summary>
++    /// Applies a CSS 2D transform (matrix <c>[a,b,c,d,e,f]</c> about origin
++    /// <paramref name="originX"/>/<paramref name="originY"/>) to the raster state, saving the prior
++    /// state so <see cref="Restore"/> reverses it. Returns <c>false</c> — without touching state —
++    /// when the matrix is not expressible on this canvas, which maps a point per axis as
++    /// <c>p*scale + translation</c>: rotation and skew (the <c>b</c>/<c>c</c> terms) are rejected so
++    /// the caller can route those to the fuller compat backend. Translation and axis-aligned scale —
++    /// including <em>non-uniform</em> scale (<c>scaleX</c>/<c>scaleY</c>/<c>scale(x, y)</c>) — are
++    /// folded into <see cref="_scaleX"/>/<see cref="_scaleY"/>/<see cref="_translation"/> so
++    /// transformed content actually rasterises instead of vanishing when the compat backend is a stub.
++    /// </summary>
++    public bool TrySaveTransform(float[] matrix, float originX, float originY)
++    {
++        if (matrix is null || matrix.Length < 6)
++            return false;
++
++        float a = matrix[0], b = matrix[1], c = matrix[2], d = matrix[3], e = matrix[4], f = matrix[5];
++
++        // Only translation + axis-aligned scale survive this canvas's per-axis point mapping. b/c
++        // carry rotation/skew, which the raster canvas cannot express; those still fall back.
++        const float epsilon = 1e-4f;
++        if (MathF.Abs(b) > epsilon || MathF.Abs(c) > epsilon)
++            return false;
++
++        float scaleX = a, scaleY = d;
++
++        // Transform-origin applies to the whole transform, per axis:
++        // p' = scale*(p - origin) + origin + (e,f).
++        float localTranslateX = originX * (1f - scaleX) + e;
++        float localTranslateY = originY * (1f - scaleY) + f;
++
++        // Compose ahead of the existing surface mapping (p -> p*_scale + _translation, per axis): a
++        // child point p becomes (scale*p + localTranslate) which the surface then maps, giving
++        // p*(scale*_scale) + (localTranslate*_scale + _translation).
++        Save();
++        _translation = new PointF(
++            localTranslateX * _scaleX + _translation.X,
++            localTranslateY * _scaleY + _translation.Y);
++        _scaleX *= scaleX;
++        _scaleY *= scaleY;
++        return true;
++    }
++
+     public void Clear(BColor color)
+     {
+         CurrentTarget.ErasePixels(color);
+@@ -97,10 +106,10 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+         double cornerSwY) =>
+         _clipOperations.Add(ClipOperation.IncludeRounded(
+             Translate(rect),
+-            (float)cornerNw * _scale, (float)cornerNwY * _scale,
+-            (float)cornerNe * _scale, (float)cornerNeY * _scale,
+-            (float)cornerSe * _scale, (float)cornerSeY * _scale,
+-            (float)cornerSw * _scale, (float)cornerSwY * _scale));
++            (float)cornerNw * _scaleX, (float)cornerNwY * _scaleY,
++            (float)cornerNe * _scaleX, (float)cornerNeY * _scaleY,
++            (float)cornerSe * _scaleX, (float)cornerSeY * _scaleY,
++            (float)cornerSw * _scaleX, (float)cornerSwY * _scaleY));
+ 
+     public void PopClip()
+     {
+@@ -132,7 +141,9 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+     {
+         var p1 = Translate(start);
+         var p2 = Translate(end);
+-        float radius = Math.Max(0.5f, strokeWidth * _scale / 2f);
++        // Stroke width has no single value under non-uniform scale; use the geometric mean of the
++        // axis scales (equal to the uniform scale when scaleX == scaleY, so byte-identical there).
++        float radius = Math.Max(0.5f, strokeWidth * MathF.Sqrt(_scaleX * _scaleY) / 2f);
+ 
+         int minX = Math.Max(0, (int)Math.Floor(Math.Min(p1.X, p2.X) - radius));
+         int minY = Math.Max(0, (int)Math.Floor(Math.Min(p1.Y, p2.Y) - radius));
+@@ -597,10 +608,10 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+     private BBitmap CurrentTarget => _layerStack.Count > 0 ? _layerStack.Peek().Bitmap : _rootBitmap;
+ 
+     private RectangleF Translate(RectangleF rect) =>
+-        new(rect.X * _scale + _translation.X, rect.Y * _scale + _translation.Y, rect.Width * _scale, rect.Height * _scale);
++        new(rect.X * _scaleX + _translation.X, rect.Y * _scaleY + _translation.Y, rect.Width * _scaleX, rect.Height * _scaleY);
+ 
+     private PointF Translate(PointF point) =>
+-        new(point.X * _scale + _translation.X, point.Y * _scale + _translation.Y);
++        new(point.X * _scaleX + _translation.X, point.Y * _scaleY + _translation.Y);
+ 
+     private bool IsVisible(int x, int y)
+     {
+@@ -890,7 +901,7 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+         return inside;
+     }
+ 
+-    private readonly record struct CanvasState(PointF Translation, float Scale, int ClipOperationCount);
++    private readonly record struct CanvasState(PointF Translation, float ScaleX, float ScaleY, int ClipOperationCount);
+ 
+     private sealed record LayerState(BBitmap Bitmap, float Opacity, string BlendMode);
+ 
+-- 
+2.43.0
+

--- a/patches/0027-graphics-filter-layer-hooks.patch
+++ b/patches/0027-graphics-filter-layer-hooks.patch
@@ -1,0 +1,41 @@
+From f0a48ee0f7bdac39a409da4c4886fd30d5f72dcb Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Tue, 28 Jul 2026 07:20:05 +0000
+Subject: [PATCH] graphics: add SaveFilterLayer/RestoreFilterLayer to the
+ RGraphics surface
+
+Introduces the compositing-layer hooks the renderer needs to apply the CSS
+colour-matrix filter functions. Both default to a no-op so platform adapters
+that do not implement pixel-level filtering keep rendering content unfiltered;
+the raster adapter overrides them to bracket a filter layer.
+---
+ Broiler.Graphics/Adapters/RGraphics.cs | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/Broiler.Graphics/Adapters/RGraphics.cs b/Broiler.Graphics/Adapters/RGraphics.cs
+index 8e043fc..139a6f4 100644
+--- a/Broiler.Graphics/Adapters/RGraphics.cs
++++ b/Broiler.Graphics/Adapters/RGraphics.cs
+@@ -88,6 +88,19 @@ public abstract class RGraphics : IDisposable
+     /// </summary>
+     public virtual void RestoreBlendLayer() { }
+ 
++    /// <summary>
++    /// Saves the canvas state and begins a new compositing layer whose pixels the CSS
++    /// <c>filter</c> function list is applied to on <see cref="RestoreFilterLayer"/> (the
++    /// colour-matrix functions). Default implementation is a no-op (content renders unfiltered).
++    /// </summary>
++    public virtual void SaveFilterLayer(string filter) { }
++
++    /// <summary>
++    /// Restores the canvas state from a previous <see cref="SaveFilterLayer"/> call, applying the
++    /// filter to the layer. Default is a no-op.
++    /// </summary>
++    public virtual void RestoreFilterLayer() { }
++
+     /// <summary>
+     /// Saves the canvas state and applies a 2D affine transform around the given origin.
+     /// The matrix elements are [a, b, c, d, e, f] matching the CSS matrix(a,b,c,d,e,f) function.
+-- 
+2.43.0
+

--- a/patches/0028-html-color-matrix-filters.patch
+++ b/patches/0028-html-color-matrix-filters.patch
@@ -1,0 +1,340 @@
+From cea2cd84798dfc76fb219173364e031db9aae17f Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Tue, 28 Jul 2026 07:19:12 +0000
+Subject: [PATCH] paint: apply CSS colour-matrix filter functions in the image
+ renderer
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+An element with a non-none `filter` establishes a stacking context but the
+image renderer ignored the property entirely, so invert()/grayscale()/sepia()/
+hue-rotate()/brightness()/contrast()/saturate()/opacity() had no visual effect
+— the element rendered exactly as if unfiltered.
+
+Emit a FilterItem/RestoreFilterItem pair around the element's compositing group
+(PaintWalker, wrapping the opacity/blend layers so the filter applies to the
+element's composited result). The raster backend brackets the group in a filter
+layer (BCanvas.SaveFilterLayer/RestoreFilterLayer); at composite time each
+non-transparent pixel is passed through ApplyColorFilter, which walks the filter
+function list left to right and applies the Filter Effects §16 colour matrices.
+Amounts accept numbers and percentages; hue-rotate accepts deg/rad/grad/turn.
+
+Only the colour-matrix subset is modelled — HasSupportedFilterFunction gates
+emission so a filter built only from blur()/drop-shadow()/url() (which need a
+convolution or SVG pass the raster canvas lacks) is left to render unfiltered
+rather than emitting an effect-free layer. When the group is not
+raster-compatible GraphicsAdapter renders the content directly (unfiltered but
+visible) instead of routing it to the stub compat backend and losing it — the
+same graceful degradation the ignored-filter path had before.
+---
+ .../Adapters/GraphicsAdapter.cs               |  20 +++
+ Source/Broiler.HTML.Image/BCanvas.cs          | 149 +++++++++++++++++-
+ .../IR/PaintWalker.Stacking.cs                |  29 ++++
+ .../IR/RGraphicsRasterBackend.cs              |  12 ++
+ 4 files changed, 209 insertions(+), 1 deletion(-)
+
+diff --git a/Source/Broiler.HTML.Image/Adapters/GraphicsAdapter.cs b/Source/Broiler.HTML.Image/Adapters/GraphicsAdapter.cs
+index 92f1c0c..318be69 100644
+--- a/Source/Broiler.HTML.Image/Adapters/GraphicsAdapter.cs
++++ b/Source/Broiler.HTML.Image/Adapters/GraphicsAdapter.cs
+@@ -299,6 +299,26 @@ internal sealed class GraphicsAdapter : RGraphics
+         _activeCompatLayerDepth = Math.Max(0, _activeCompatLayerDepth - 1);
+     }
+ 
++    public override void SaveFilterLayer(string filter)
++    {
++        // Filters need pixel readback to apply, which only the raster canvas offers. When the
++        // layer is raster-compatible, push a real filter layer there; otherwise render the content
++        // directly (unfiltered but visible) rather than route it to the stub compat backend and
++        // lose it — the same graceful degradation the ignored-filter path had before.
++        bool useRaster = _rasterCanvas is not null && _activeCompatLayerDepth == 0 && _nextLayerCanUseRaster;
++        _nextLayerCanUseRaster = false;
++        _rasterLayerStack.Push(useRaster);
++        if (useRaster)
++            _rasterCanvas!.SaveFilterLayer(filter);
++    }
++
++    public override void RestoreFilterLayer()
++    {
++        bool usedRaster = _rasterLayerStack.Count > 0 && _rasterLayerStack.Pop();
++        if (usedRaster)
++            _rasterCanvas!.RestoreFilterLayer();
++    }
++
+     public override void SaveBlendLayer(string blendMode)
+     {
+         bool useRaster = _rasterCanvas is not null
+diff --git a/Source/Broiler.HTML.Image/BCanvas.cs b/Source/Broiler.HTML.Image/BCanvas.cs
+index bc2fe26..7b25c93 100644
+--- a/Source/Broiler.HTML.Image/BCanvas.cs
++++ b/Source/Broiler.HTML.Image/BCanvas.cs
+@@ -585,6 +585,20 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+         CompositeLayer(layer);
+     }
+ 
++    public void SaveFilterLayer(string filter)
++    {
++        _layerStack.Push(new LayerState(new BBitmap(_rootBitmap.Width, _rootBitmap.Height), 1f, "normal", filter));
++    }
++
++    public void RestoreFilterLayer()
++    {
++        if (_layerStack.Count == 0)
++            return;
++
++        var layer = _layerStack.Pop();
++        CompositeLayer(layer);
++    }
++
+     public void SaveBlendLayer(string blendMode)
+     {
+         _layerStack.Push(new LayerState(new BBitmap(_rootBitmap.Width, _rootBitmap.Height), 1f, blendMode ?? "normal"));
+@@ -646,6 +660,9 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+                 if (source.A == 0)
+                     continue;
+ 
++                if (layer.Filter is { } filter)
++                    source = ApplyColorFilter(source, filter);
++
+                 if (layer.Opacity < 1f)
+                     source = ApplyOpacity(source, layer.Opacity);
+ 
+@@ -663,6 +680,136 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+         return new BColor(color.R, color.G, color.B, alpha);
+     }
+ 
++    private static readonly System.Text.RegularExpressions.Regex FilterFunctionPattern =
++        new(@"([a-zA-Z-]+)\(([^)]*)\)", System.Text.RegularExpressions.RegexOptions.Compiled);
++
++    /// <summary>
++    /// Applies the colour-matrix CSS filter functions (invert/grayscale/brightness/contrast/
++    /// sepia/saturate/opacity/hue-rotate) to a single pixel, left to right. Unsupported functions
++    /// (blur/drop-shadow/…) are skipped. Matrices follow Filter Effects §16.
++    /// </summary>
++    private static BColor ApplyColorFilter(BColor color, string filter)
++    {
++        float r = color.R, g = color.G, b = color.B, a = color.A;
++        foreach (System.Text.RegularExpressions.Match match in FilterFunctionPattern.Matches(filter))
++        {
++            var name = match.Groups[1].Value.ToLowerInvariant();
++            var arg = match.Groups[2].Value.Trim();
++            switch (name)
++            {
++                case "invert":
++                {
++                    float t = ParseFilterAmount(arg, 1f, clampToOne: true);
++                    r = Lerp(r, 255f - r, t); g = Lerp(g, 255f - g, t); b = Lerp(b, 255f - b, t);
++                    break;
++                }
++                case "grayscale":
++                {
++                    float t = ParseFilterAmount(arg, 1f, clampToOne: true);
++                    float l = 0.2126f * r + 0.7152f * g + 0.0722f * b;
++                    r = Lerp(r, l, t); g = Lerp(g, l, t); b = Lerp(b, l, t);
++                    break;
++                }
++                case "brightness":
++                {
++                    float t = ParseFilterAmount(arg, 1f, clampToOne: false);
++                    r *= t; g *= t; b *= t;
++                    break;
++                }
++                case "contrast":
++                {
++                    float t = ParseFilterAmount(arg, 1f, clampToOne: false);
++                    r = (r - 128f) * t + 128f; g = (g - 128f) * t + 128f; b = (b - 128f) * t + 128f;
++                    break;
++                }
++                case "opacity":
++                {
++                    float t = ParseFilterAmount(arg, 1f, clampToOne: true);
++                    a *= t;
++                    break;
++                }
++                case "saturate":
++                {
++                    float s = ParseFilterAmount(arg, 1f, clampToOne: false);
++                    (r, g, b) = (
++                        (0.213f + 0.787f * s) * r + (0.715f - 0.715f * s) * g + (0.072f - 0.072f * s) * b,
++                        (0.213f - 0.213f * s) * r + (0.715f + 0.285f * s) * g + (0.072f - 0.072f * s) * b,
++                        (0.213f - 0.213f * s) * r + (0.715f - 0.715f * s) * g + (0.072f + 0.928f * s) * b);
++                    break;
++                }
++                case "sepia":
++                {
++                    float s = 1f - ParseFilterAmount(arg, 1f, clampToOne: true);
++                    (r, g, b) = (
++                        (0.393f + 0.607f * s) * r + (0.769f - 0.769f * s) * g + (0.189f - 0.189f * s) * b,
++                        (0.349f - 0.349f * s) * r + (0.686f + 0.314f * s) * g + (0.168f - 0.168f * s) * b,
++                        (0.272f - 0.272f * s) * r + (0.534f - 0.534f * s) * g + (0.131f + 0.869f * s) * b);
++                    break;
++                }
++                case "hue-rotate":
++                {
++                    float rad = ParseFilterAngleRadians(arg);
++                    float cos = MathF.Cos(rad), sin = MathF.Sin(rad);
++                    (r, g, b) = (
++                        (0.213f + cos * 0.787f - sin * 0.213f) * r + (0.715f - cos * 0.715f - sin * 0.715f) * g + (0.072f - cos * 0.072f + sin * 0.928f) * b,
++                        (0.213f - cos * 0.213f + sin * 0.143f) * r + (0.715f + cos * 0.285f + sin * 0.140f) * g + (0.072f - cos * 0.072f - sin * 0.283f) * b,
++                        (0.213f - cos * 0.213f - sin * 0.787f) * r + (0.715f - cos * 0.715f + sin * 0.715f) * g + (0.072f + cos * 0.928f + sin * 0.072f) * b);
++                    break;
++                }
++            }
++        }
++
++        return new BColor(ClampByte(r), ClampByte(g), ClampByte(b), ClampByte(a));
++    }
++
++    private static float Lerp(float from, float to, float t) => from + (to - from) * t;
++
++    private static byte ClampByte(float value) => (byte)Math.Clamp((int)MathF.Round(value), 0, 255);
++
++    /// <summary>Parses a filter amount: a number, or a percentage (n%). <paramref name="clampToOne"/>
++    /// caps at 1 for the [0,1]-ranged functions (invert/grayscale/sepia/opacity).</summary>
++    private static float ParseFilterAmount(string arg, float fallback, bool clampToOne)
++    {
++        if (string.IsNullOrWhiteSpace(arg))
++            return fallback;
++
++        float value;
++        if (arg.EndsWith("%", StringComparison.Ordinal))
++        {
++            if (!float.TryParse(arg.AsSpan(0, arg.Length - 1), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var pct))
++                return fallback;
++            value = pct / 100f;
++        }
++        else if (!float.TryParse(arg, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out value))
++        {
++            return fallback;
++        }
++
++        value = Math.Max(0f, value);
++        return clampToOne ? Math.Min(1f, value) : value;
++    }
++
++    private static float ParseFilterAngleRadians(string arg)
++    {
++        arg = arg.Trim();
++        if (string.IsNullOrEmpty(arg) || arg == "0")
++            return 0f;
++
++        (string suffix, float perUnit) = arg switch
++        {
++            _ when arg.EndsWith("rad", StringComparison.OrdinalIgnoreCase) => ("rad", 1f),
++            _ when arg.EndsWith("grad", StringComparison.OrdinalIgnoreCase) => ("grad", MathF.PI / 200f),
++            _ when arg.EndsWith("turn", StringComparison.OrdinalIgnoreCase) => ("turn", MathF.PI * 2f),
++            _ when arg.EndsWith("deg", StringComparison.OrdinalIgnoreCase) => ("deg", MathF.PI / 180f),
++            _ => ("", MathF.PI / 180f),
++        };
++
++        var numberSpan = suffix.Length > 0 ? arg.AsSpan(0, arg.Length - suffix.Length) : arg.AsSpan();
++        return float.TryParse(numberSpan, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var n)
++            ? n * perUnit
++            : 0f;
++    }
++
+     private static void BlendPixel(BBitmap bitmap, int x, int y, BColor source, string blendMode)
+     {
+         if (source.A == 0)
+@@ -903,7 +1050,7 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+ 
+     private readonly record struct CanvasState(PointF Translation, float ScaleX, float ScaleY, int ClipOperationCount);
+ 
+-    private sealed record LayerState(BBitmap Bitmap, float Opacity, string BlendMode);
++    private sealed record LayerState(BBitmap Bitmap, float Opacity, string BlendMode, string? Filter = null);
+ 
+     private readonly record struct ClipOperation(
+         RectangleF Rect,
+diff --git a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Stacking.cs b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Stacking.cs
+index d09ddc2..c2544c4 100644
+--- a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Stacking.cs
++++ b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Stacking.cs
+@@ -139,6 +139,20 @@ internal static partial class PaintWalker
+             }
+         }
+ 
++        // Filter Effects §1: a non-none `filter` renders the element into a compositing group
++        // that the filter is applied to. Only the colour-matrix functions are modelled here
++        // (invert/grayscale/brightness/contrast/sepia/saturate/opacity/hue-rotate); a filter with
++        // none of those (e.g. blur only) is left to render unfiltered rather than emitting an
++        // effect-free layer. Wraps opacity/blend so it filters the element's composited result.
++        bool hasFilter = !isRoot
++            && !string.IsNullOrEmpty(style.Filter)
++            && !style.Filter.Equals("none", StringComparison.OrdinalIgnoreCase)
++            && HasSupportedFilterFunction(style.Filter);
++        if (hasFilter)
++        {
++            items.Add(new FilterItem { Bounds = bounds, Filter = style.Filter });
++        }
++
+         // CSS3: 0 < opacity < 1 creates a compositing group — all
+         // descendant content is rendered into a separate layer, then
+         // composited back at the specified opacity.
+@@ -291,11 +305,26 @@ internal static partial class PaintWalker
+         if (hasOpacity)
+             items.Add(new RestoreOpacityItem { Bounds = bounds });
+ 
++
++        // Restore filter layer (wraps opacity/blend, applied to the composited element)
++        if (hasFilter)
++            items.Add(new RestoreFilterItem { Bounds = bounds });
+         // Restore transform layer (outermost layer)
+         if (hasTransform)
+             items.Add(new RestoreTransformItem { Bounds = bounds });
+     }
+ 
++    /// <summary>Whether a CSS <c>filter</c> value contains at least one colour-matrix function
++    /// this renderer applies (invert/grayscale/brightness/contrast/sepia/saturate/opacity/
++    /// hue-rotate). Blur and drop-shadow are not modelled.</summary>
++    private static bool HasSupportedFilterFunction(string filter)
++    {
++        foreach (var name in new[] { "invert", "grayscale", "brightness", "contrast", "sepia", "saturate", "opacity", "hue-rotate" })
++            if (filter.Contains(name + "(", StringComparison.OrdinalIgnoreCase))
++                return true;
++        return false;
++    }
++
+     private static void PaintChildren(Fragment fragment, List<DisplayItem> items, Fragment? propagatedFrom = null, RectangleF viewport = default, BColor? bgClipTextColor = null, bool skipBlockBackgrounds = false)
+     {
+         if (fragment.Children.Count == 0)
+diff --git a/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs b/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs
+index 06aa43d..db0d4a0 100644
+--- a/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs
++++ b/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs
+@@ -92,6 +92,13 @@ internal sealed class RGraphicsRasterBackend : IRasterBackend
+                 case RestoreBlendModeItem:
+                     g.RestoreBlendLayer();
+                     break;
++                case FilterItem filterItem:
++                    g.HintNextLayerCanUseRaster(IsRasterCompatibleFilterLayer(list.Items, index));
++                    g.SaveFilterLayer(filterItem.Filter);
++                    break;
++                case RestoreFilterItem:
++                    g.RestoreFilterLayer();
++                    break;
+                 case TransformItem transformItem:
+                     g.SaveTransformLayer(transformItem.Matrix, transformItem.OriginX, transformItem.OriginY);
+                     break;
+@@ -109,6 +116,9 @@ internal sealed class RGraphicsRasterBackend : IRasterBackend
+         IsRasterBlendModeSupported(blendMode)
+         && IsRasterCompatibleLayer(items, startIndex, typeof(BlendModeItem), typeof(RestoreBlendModeItem));
+ 
++    private static bool IsRasterCompatibleFilterLayer(IReadOnlyList<DisplayItem> items, int startIndex) =>
++        IsRasterCompatibleLayer(items, startIndex, typeof(FilterItem), typeof(RestoreFilterItem));
++
+     private static bool IsRasterCompatibleLayer(
+         IReadOnlyList<DisplayItem> items,
+         int startIndex,
+@@ -159,6 +169,8 @@ internal sealed class RGraphicsRasterBackend : IRasterBackend
+         RestoreOpacityItem => true,
+         BlendModeItem blend => IsRasterBlendModeSupported(blend.Mode),
+         RestoreBlendModeItem => true,
++        FilterItem => true,
++        RestoreFilterItem => true,
+         TransformItem => false,
+         RestoreTransformItem => false,
+         // Text renders on the raster canvas via the text shaper (the same path all
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -659,3 +659,39 @@ and doc-file env failures as at `0010` — **zero regressions**.
 `EsModuleLinker`, so nothing in the parent repo depends on or regresses without this patch. Driving the
 now-working engine module path from the bridge (and retiring the `EsModuleLinker`) is the remaining Phase-7
 bridge task — application wiring, not a `Broiler.JS` gap.
+
+---
+
+## 0025 — `Broiler.HTML`: keep text-bearing opacity/blend layers on the raster path
+
+**Symptom.** Any element with `0 < opacity < 1` (or a non-normal `mix-blend-mode`) that
+also contained text rendered as **nothing** — background, border and text all vanished —
+in the image renderer. The `css-view-transitions` capture family
+(`old-content-captures-opacity`, `old-content-is-empty-div`, …) is the most visible
+casualty, but the bug hits any faded/semi-transparent labelled box.
+
+**Cause.** `RGraphicsRasterBackend.IsRasterCompatibleItem` marked `DrawTextItem` /
+`DrawSvgTextItem` non-raster, so `IsRasterCompatibleLayer` classified any text-bearing
+opacity/blend layer as non-raster. `GraphicsAdapter.SaveOpacityLayer` /
+`SaveBlendLayer` then routed the layer to the `_canvasCompat` backend, which is a **stub**
+in the image renderer; and once a compat layer is active `CanUseRaster` is false for every
+enclosed draw, so the layer's `FillRect` background and text alike were discarded (the same
+failure mode the `SaveTransformLayer` comment already documents for the stub compat
+backend). The raster `BCanvas` in fact renders text via the text shaper — it is the primary
+path all non-layer text already uses (`DrawString` tries raster first, with a compat
+fallback) — so a text-bearing layer can stay on the raster path where `SaveOpacityLayer` /
+`SaveBlendLayer` composite it correctly (verified: a no-text opacity box already rendered;
+only the text-bearing one vanished).
+
+**Fix.** Mark `DrawTextItem` and `DrawSvgTextItem` raster-compatible in
+`IsRasterCompatibleItem`, so a text-bearing opacity/blend layer uses the raster
+`SaveOpacityLayer` / `SaveBlendLayer` and composites correctly. Verified locally: a
+`opacity: 0.75` box with text now renders semi-transparently (background + faded text)
+instead of vanishing.
+
+**Why it's a patch.** The `Broiler.HTML` push returned **403**, so per `CLAUDE.md` it ships
+as `patches/0025-html-opacity-blend-text-raster-layer.patch` with the pointer left
+**unbumped** (pinned `d09b809`) and the submodule working tree reverted. There is **no
+main-repo fallback** — the paint/compositing pipeline lives entirely in `Broiler.HTML`, so
+the parent repo has no lever to route text-bearing opacity layers onto the raster canvas.
+The fix is renderer-visible only once the patch is applied and the pointer bumped.

--- a/patches/README.md
+++ b/patches/README.md
@@ -695,3 +695,37 @@ as `patches/0025-html-opacity-blend-text-raster-layer.patch` with the pointer le
 main-repo fallback** — the paint/compositing pipeline lives entirely in `Broiler.HTML`, so
 the parent repo has no lever to route text-bearing opacity layers onto the raster canvas.
 The fix is renderer-visible only once the patch is applied and the pointer bumped.
+
+---
+
+## 0026 — `Broiler.HTML`: rasterise non-uniform (axis-aligned) scale transforms
+
+**Symptom.** An element with a non-uniform axis-aligned scale — `scaleX()`, `scaleY()`,
+`scale(x, y)` where `x != y` — vanished entirely in the image renderer (background and
+content), the same failure mode as `0025` but for a different rejected transform.
+
+**Cause.** `BCanvas` mapped points with a single uniform `_scale`, so `TrySaveTransform`
+rejected any matrix with `a != d`. `GraphicsAdapter.SaveTransformLayer` then routed the
+transform to the `_canvasCompat` backend, which is a stub in the image renderer, and once a
+compat layer is active `CanUseRaster` is false for every enclosed draw — so the whole
+subtree was discarded.
+
+**Fix.** Give the canvas a per-axis scale (`_scaleX`/`_scaleY`). `TrySaveTransform` now
+accepts axis-aligned scale (`b == c == 0`), including non-uniform, folding `scaleX` into
+`_scaleX` and `scaleY` into `_scaleY`; the point/rect mapping, rounded-clip corner radii,
+and stroke width (geometric mean of the axis scales) use them. **Uniform scale sets both
+axes equal, so existing output is byte-identical** (verified: 205 render tests pass, the 6
+failures are all pre-existing — anchor-positioning and environmental — and fail identically
+with the patch reverted). Rotation and skew (non-zero `b`/`c`) still fall back; they need a
+full affine rasteriser the raster canvas does not have.
+
+**Pairs with the DOM side.** The parent-repo `element.animate()` + transform interpolation
+commit computes the interpolated `scale(x, y)`; this patch lets the renderer actually paint
+it, so animated and static non-uniform scales now render.
+
+**Why it's a patch.** The `Broiler.HTML` push returned **403**, so per `CLAUDE.md` it ships
+as `patches/0026-html-nonuniform-scale-raster.patch` with the pointer left **unbumped**
+(pinned `d09b809`) and the submodule working tree reverted. It is **independent of `0025`**
+(different files — `BCanvas.cs` vs `RGraphicsRasterBackend.cs`) and the two apply cleanly in
+either order. No main-repo fallback is possible — the paint pipeline lives entirely in
+`Broiler.HTML`.

--- a/patches/README.md
+++ b/patches/README.md
@@ -729,3 +729,71 @@ as `patches/0026-html-nonuniform-scale-raster.patch` with the pointer left **unb
 (different files — `BCanvas.cs` vs `RGraphicsRasterBackend.cs`) and the two apply cleanly in
 either order. No main-repo fallback is possible — the paint pipeline lives entirely in
 `Broiler.HTML`.
+
+---
+
+## 0027 — `Broiler.Graphics`: `SaveFilterLayer`/`RestoreFilterLayer` surface hooks
+
+**Symptom.** The image renderer had no way to apply the CSS `filter` property — every
+colour-matrix function (`invert()`, `grayscale()`, `brightness()`, `contrast()`, `sepia()`,
+`saturate()`, `opacity()`, `hue-rotate()`) was a visual no-op: a filtered element rendered
+exactly as if unfiltered.
+
+**Cause.** The `RGraphics` abstract surface exposed compositing-layer hooks for opacity and
+blend mode (`SaveOpacityLayer`/`SaveBlendLayer`) but none for filters, so the paint pipeline
+had no primitive to bracket a filterable compositing group with.
+
+**Fix.** Add two `virtual` methods to `RGraphics`, `SaveFilterLayer(string filter)` and
+`RestoreFilterLayer()`, both defaulting to a **no-op** — a platform adapter that does not
+implement pixel-level filtering keeps rendering content unfiltered, exactly as before. The
+raster image adapter overrides them (patch `0028`) to apply the colour matrices.
+
+**Why it's a patch.** The `Broiler.Graphics` push returned **403**, so per `CLAUDE.md` it
+ships as `patches/0027-graphics-filter-layer-hooks.patch` with the pointer left **unbumped**
+(pinned `7986c5e`) and the submodule working tree reverted. It is a pure additive change to
+the abstract surface (no behaviour change on its own) and is a **build prerequisite of
+`0028`**, which calls these methods.
+
+---
+
+## 0028 — `Broiler.HTML`: apply CSS colour-matrix filter functions
+
+**Symptom.** An element with a non-none `filter` established a stacking context but the image
+renderer ignored the property, so `invert()`/`grayscale()`/`brightness()`/`contrast()`/
+`sepia()`/`saturate()`/`opacity()`/`hue-rotate()` had no visual effect.
+
+**Cause.** `PaintWalker` emitted no display item for `filter`, and the raster canvas had no
+filter primitive — the property was dropped on the floor between layout and paint.
+
+**Fix.** `PaintWalker` emits a `FilterItem`/`RestoreFilterItem` pair around the element's
+compositing group (wrapping the opacity/blend layers, so the filter applies to the element's
+composited result). `RGraphicsRasterBackend` brackets the group in a filter layer via the
+`0027` surface hooks; `BCanvas.SaveFilterLayer`/`RestoreFilterLayer` push a layer whose pixels
+are passed through `ApplyColorFilter` at composite time — it walks the filter function list
+left to right and applies the Filter Effects §16 colour matrices (amounts accept numbers and
+percentages; `hue-rotate` accepts `deg`/`rad`/`grad`/`turn`).
+
+Only the colour-matrix subset is modelled: `HasSupportedFilterFunction` gates emission, so a
+`filter` built only from `blur()`/`drop-shadow()`/`url()` (which need a convolution or SVG
+pass the raster canvas lacks) is left to render **unfiltered** rather than emitting an
+effect-free layer. When the compositing group is not raster-compatible, `GraphicsAdapter`
+renders the content **directly (unfiltered but visible)** instead of routing it to the stub
+compat backend and losing it — the same graceful degradation the ignored-`filter` path had.
+
+**Verified** by rendering solid-colour boxes through the engine with the patch applied:
+`invert(1)` of `rgb(0,128,0)` → magenta `rgb(255,127,255)`; `grayscale(1)` → neutral gray;
+`brightness(0.5)` → half-value; `sepia(1)` → brown; `hue-rotate(120deg)` of red → green;
+`contrast(2)` → saturated; `opacity(0.5)` → 50%-blended. `filter:none` and `filter:opacity(1)`
+leave the box unchanged. Regression-checked against the `css-backgrounds/background-clip`
+subset (which uses `filter:opacity(1)` to force a stacking context): match rates are
+byte-identical with and without the change.
+
+**Why it's a patch.** The `Broiler.HTML` push returned **403**, so per `CLAUDE.md` it ships as
+`patches/0028-html-color-matrix-filters.patch` with the pointer left **unbumped** (pinned
+`d09b809`) and the submodule working tree reverted. **Ordering:** it **stacks on `0025`+`0026`**
+— all three touch `BCanvas.cs`/`RGraphicsRasterBackend.cs`, and `0028` was generated against a
+tree with `0025`+`0026` already applied, so apply them in numeric order (`0025` → `0026` →
+`0028`). It also depends on the parent-repo `Broiler.Layout` `DisplayList.cs` change (the
+`FilterItem`/`RestoreFilterItem` IR types, **pushed directly** to the parent) and on `0027`
+(`Broiler.Graphics`). No main-repo fallback is possible — the paint pipeline lives entirely in
+`Broiler.HTML`, so filters render only once the patch is applied and the pointer bumped.

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -187,6 +187,7 @@ public sealed partial class DomBridge
         RemoveRenderCommentNodes(root);
         ApplyCssomStyleSheetMutations(root);
         InlineStyleSheetImports(root);
+        ApplyBaseHrefToStyleUrls(root);
         ApplyMetaColorScheme(root);
         // Zoom baking is applied by the callers (GetRenderDocument/SerializeToHtml) before this,
         // so it can be reverted on the geometry-snapshot path; pseudo/progress below depend on

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -187,6 +187,7 @@ public sealed partial class DomBridge
         RemoveRenderCommentNodes(root);
         ApplyCssomStyleSheetMutations(root);
         InlineStyleSheetImports(root);
+        ApplyAdoptedStyleSheets(root);
         ApplyBaseHrefToStyleUrls(root);
         ApplyMetaColorScheme(root);
         // Zoom baking is applied by the callers (GetRenderDocument/SerializeToHtml) before this,

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -186,6 +186,7 @@ public sealed partial class DomBridge
         _serializationTransformsApplied = true;
         RemoveRenderCommentNodes(root);
         ApplyCssomStyleSheetMutations(root);
+        InlineStyleSheetImports(root);
         ApplyMetaColorScheme(root);
         // Zoom baking is applied by the callers (GetRenderDocument/SerializeToHtml) before this,
         // so it can be reverted on the geometry-snapshot path; pseudo/progress below depend on

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnimationResolver.cs
@@ -454,6 +454,14 @@ public sealed partial class DomBridge
             }
         }
 
+        // transform interpolates component-wise between matching function lists (the
+        // common animation case, e.g. scale/translate/rotate keyframes); `none` acts as
+        // the identity of the other side's functions. Mismatched lists (which need full
+        // matrix decomposition) fall through to discrete stepping.
+        if (string.Equals(prop, "transform", StringComparison.OrdinalIgnoreCase) &&
+            TryInterpolateTransform(fromValue, toValue, progress, out var interpolatedTransform))
+            return interpolatedTransform;
+
         if (TryInterpolateLengthValue(element, prop, fromValue, toValue, progress, out var interpolatedLength))
             return interpolatedLength;
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ConstructedStyleSheets.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ConstructedStyleSheets.cs
@@ -1,0 +1,187 @@
+using Broiler.JavaScript.BuiltIns.Null;
+using Broiler.JavaScript.BuiltIns.Boolean;
+using Broiler.JavaScript.Storage;
+using Broiler.JavaScript.BuiltIns.Array;
+using Broiler.JavaScript.Runtime;
+using Broiler.JavaScript.BuiltIns.Function;
+using Broiler.Dom;
+using Broiler.CSS;
+
+namespace Broiler.HtmlBridge;
+
+/// <summary>
+/// Constructable stylesheets (CSSOM) — <c>new CSSStyleSheet()</c>, its
+/// <c>insertRule</c>/<c>deleteRule</c>/<c>replaceSync</c>/<c>replace</c> surface, and
+/// <c>document.adoptedStyleSheets</c>. A constructed sheet is not tied to a
+/// <c>&lt;style&gt;</c>/<c>&lt;link&gt;</c> element; it carries its own rule list and applies
+/// to the document only while it is in <c>adoptedStyleSheets</c>. At serialization the adopted
+/// sheets are emitted as synthetic <c>&lt;style&gt;</c> elements appended after the document's
+/// own stylesheets, so the renderer applies them in the correct cascade order (the WPT
+/// <c>css/cssom</c> constructable family, e.g.
+/// <c>CSSStyleSheet-constructable-insertRule-base-uri</c>, which adopts a sheet whose rule sets
+/// a <c>background-image</c>).
+/// </summary>
+public sealed partial class DomBridge
+{
+    /// <summary>The live <c>document.adoptedStyleSheets</c> array (constructed sheets in
+    /// application order). Lazily created; null until first read.</summary>
+    private JSArray? _adoptedStyleSheets;
+
+    /// <summary>Rule list backing each constructed <c>CSSStyleSheet</c> object, so the
+    /// serialization pass can emit the adopted sheets' rules.</summary>
+    private readonly Dictionary<JSObject, List<CssRule>> _constructedSheetRules = [];
+
+    /// <summary><c>new CSSStyleSheet(options)</c> — an empty constructed stylesheet. Options
+    /// (media/disabled/baseURL) are accepted but not yet modelled; a constructed sheet's rules
+    /// resolve relative <c>url()</c>s against the document base at render time.</summary>
+    private JSValue CreateConstructedStyleSheet(in Arguments a)
+    {
+        var rules = new List<CssRule>();
+        return BuildConstructedStyleSheetObject(rules);
+    }
+
+    private JSObject BuildConstructedStyleSheetObject(List<CssRule> rules)
+    {
+        var sheet = new JSObject();
+        _constructedSheetRules[sheet] = rules;
+
+        List<CssRule> CurrentRules() => rules;
+        static void MarkRulesMutated() { }
+
+        // ownerNode is null for a constructed sheet; href is null (no source URL).
+        sheet.FastAddProperty((KeyString)"ownerNode", NullFunction("get ownerNode"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        sheet.FastAddProperty((KeyString)"href", NullFunction("get href"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        // disabled — a script flag on the sheet; a disabled adopted sheet does not apply.
+        var disabled = false;
+        sheet.FastAddProperty((KeyString)"disabled",
+            new JSFunction((in _) => disabled ? JSBoolean.True : JSBoolean.False, "get disabled"),
+            new JSFunction((in a) => { disabled = a.Length > 0 && a[0].BooleanValue; return JSUndefined.Value; }, "set disabled"),
+            JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        var liveCssRules = new JSObject();
+        var lastSyncedRuleCount = 0;
+        liveCssRules.FastAddProperty((KeyString)"length",
+            new JSFunction((in _) => Dom.Features.StyleSheetBinding.JsStyleSheetsGetLength002Core(CurrentRules, in _), "get length"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        liveCssRules.FastAddValue((KeyString)"item",
+            new JSFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsItem003Core(SyncLiveCssRulesIndices, liveCssRules, CurrentRules, in a), "item", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        void SyncLiveCssRulesIndices()
+        {
+            var current = CurrentRules();
+            for (var i = 0; i < current.Count; i++)
+                liveCssRules[(uint)i] = Dom.Features.StyleSheetBinding.BuildCssRuleObject(current[i], sheet);
+
+            for (var i = current.Count; i < lastSyncedRuleCount; i++)
+                liveCssRules.GetElements().RemoveAt((uint)i);
+
+            lastSyncedRuleCount = current.Count;
+        }
+
+        sheet.FastAddProperty((KeyString)"cssRules",
+            new JSFunction((in _) => Dom.Features.StyleSheetBinding.JsStyleSheetsGetCssRules004Core(SyncLiveCssRulesIndices, liveCssRules, in _), "get cssRules"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        sheet.FastAddValue((KeyString)"insertRule",
+            new JSFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsInsertRule005Core(CurrentRules, MarkRulesMutated, SyncLiveCssRulesIndices, in a), "insertRule", 2),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        sheet.FastAddValue((KeyString)"deleteRule",
+            new JSFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsDeleteRule006Core(CurrentRules, MarkRulesMutated, SyncLiveCssRulesIndices, in a), "deleteRule", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // replaceSync(text) — replace all rules from a CSS string (any @import is dropped per
+        // spec). replace(text) does the same and returns an already-resolved promise of the sheet.
+        void ReplaceFromText(string text)
+        {
+            rules.Clear();
+            foreach (var rule in new CssParser().ParseStyleSheet(text).Rules)
+            {
+                if (rule is CssAtRule at && at.Name.Equals("import", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                rules.Add(rule);
+            }
+            SyncLiveCssRulesIndices();
+        }
+
+        sheet.FastAddValue((KeyString)"replaceSync",
+            new JSFunction((in a) => { ReplaceFromText(a.Length > 0 ? a[0].ToString() : string.Empty); return JSUndefined.Value; }, "replaceSync", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        sheet.FastAddValue((KeyString)"replace",
+            new JSFunction((in a) => { ReplaceFromText(a.Length > 0 ? a[0].ToString() : string.Empty); return ResolvedThenableWith(sheet); }, "replace", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        return sheet;
+    }
+
+    /// <summary>An already-resolved thenable that yields <paramref name="value"/> — the
+    /// promise <c>CSSStyleSheet.replace()</c> returns (resolving with the sheet itself).</summary>
+    private static JSObject ResolvedThenableWith(JSValue value)
+    {
+        var thenable = new JSObject();
+        JSValue Then(in Arguments args)
+        {
+            if (args.Length > 0 && args[0] is JSFunction cb)
+            {
+                try { cb.InvokeFunction(new Arguments(cb, value)); }
+                catch { /* a replace().then callback must not abort the render */ }
+            }
+            return thenable;
+        }
+        thenable.FastAddValue((KeyString)"then", new JSFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue((KeyString)"catch", new JSFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue((KeyString)"finally",
+            new JSFunction((in a) => { if (a.Length > 0 && a[0] is JSFunction cb) { try { cb.InvokeFunction(new Arguments(cb)); } catch { } } return thenable; }, "finally", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        return thenable;
+    }
+
+    /// <summary>The live <c>document.adoptedStyleSheets</c> array, created on first access.</summary>
+    private JSArray AdoptedStyleSheetsArray() => _adoptedStyleSheets ??= new JSArray();
+
+    /// <summary>Replaces <c>document.adoptedStyleSheets</c> with the assigned array's members
+    /// (<c>document.adoptedStyleSheets = [sheet, …]</c>); <c>.push()</c> on the getter's array
+    /// is handled directly by the returned array.</summary>
+    private void SetAdoptedStyleSheets(JSValue value)
+    {
+        var replacement = new JSArray();
+        if (value is JSArray array)
+            foreach (var (_, item) in array.GetArrayElements(withHoles: false))
+                replacement.Add(item);
+
+        _adoptedStyleSheets = replacement;
+    }
+
+    /// <summary>
+    /// Emits each adopted stylesheet as a synthetic <c>&lt;style&gt;</c> appended after the
+    /// document's own stylesheets, so the renderer applies the adopted rules in cascade order.
+    /// A no-op when nothing is adopted. Runs from <see cref="ApplySerializationTransforms"/>.
+    /// </summary>
+    private void ApplyAdoptedStyleSheets(DomElement root)
+    {
+        if (_adoptedStyleSheets is null || _adoptedStyleSheets.Length == 0)
+            return;
+
+        var head = FindFirstElementByTagName(root, "head");
+        var container = head ?? root;
+
+        foreach (var (_, item) in _adoptedStyleSheets.GetArrayElements(withHoles: false))
+        {
+            if (item is not JSObject sheetObj ||
+                !_constructedSheetRules.TryGetValue(sheetObj, out var rules) ||
+                rules.Count == 0)
+                continue;
+
+            if (sheetObj[(KeyString)"disabled"] is JSValue d && d.BooleanValue)
+                continue;
+
+            var css = string.Join("\n", rules.Select(CssSerializer.Serialize));
+            var styleElement = CreateBridgeElement("style");
+            SetElementTextContent(styleElement, css);
+            SetParent(styleElement, container);
+            container.AppendChild(styleElement);
+        }
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementInterfaces.cs
@@ -125,6 +125,12 @@ public sealed partial class DomBridge
         // IElementGeometryHost contract (DomBridge.ElementGeometryHost.cs).
         Dom.Features.ElementGeometryBinding.Install(this, obj, element);
 
+        // Web Animations: element.animate(keyframes, options) bakes the animation's snapshot-time
+        // value so animation-driven property changes render (see DomBridge.WebAnimations).
+        obj.FastAddValue((KeyString)"animate",
+            new JSFunction((in a) => ElementAnimate(element, in a), "animate", 2),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
         // SVG DOM interfaces — SVGAnimatedLength/Rect stubs, SVGTextContentElement text metrics, the
         // SVGSVGElement animation timeline and the SMIL animation-element no-ops (Phase 3 P3.50:
         // extracted into the co-located SvgElementBinding feature module).

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Document.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Document.cs
@@ -116,6 +116,13 @@ public sealed partial class DomBridge
         // document.styleSheets — collection of stylesheet objects for main document
         document.FastAddProperty((KeyString)"styleSheets", new JSFunction((in a) => Dom.Features.DocumentCollectionBinding.GetStyleSheets(this, in a), "get styleSheets"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
+        // document.adoptedStyleSheets — the live array of constructed stylesheets applied to the
+        // document (CSSOM). Readable (supports .push) and assignable (= [sheet, …]).
+        document.FastAddProperty((KeyString)"adoptedStyleSheets",
+            new JSFunction((in _) => AdoptedStyleSheetsArray(), "get adoptedStyleSheets"),
+            new JSFunction((in a) => { SetAdoptedStyleSheets(a.Length > 0 ? a[0] : JSUndefined.Value); return JSUndefined.Value; }, "set adoptedStyleSheets"),
+            JSPropertyAttributes.EnumerableConfigurableProperty);
+
         // document.open() — for main document
         document.FastAddValue((KeyString)"open", new JSFunction((in _) => document, "open", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Registration.cs
@@ -54,6 +54,10 @@ public sealed partial class DomBridge
         var messageChannelCtor = new JSFunction((in _) => _messaging.CreateMessageChannel(), "MessageChannel", 0);
         window.FastAddValue((KeyString)"MessageChannel", messageChannelCtor, JSPropertyAttributes.EnumerableConfigurableValue);
         context["MessageChannel"] = messageChannelCtor;
+        // CSSStyleSheet constructor (constructable stylesheets / adoptedStyleSheets — CSSOM).
+        var cssStyleSheetCtor = new JSFunction((in a) => CreateConstructedStyleSheet(in a), "CSSStyleSheet", 0);
+        window.FastAddValue((KeyString)"CSSStyleSheet", cssStyleSheetCtor, JSPropertyAttributes.EnumerableConfigurableValue);
+        context["CSSStyleSheet"] = cssStyleSheetCtor;
         // getComputedStyle (CSSOM), co-located in the ComputedStyleBinding feature module (Phase 3).
         window.FastAddValue(
             (KeyString)"getComputedStyle",

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/StyleBaseHref.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/StyleBaseHref.cs
@@ -1,0 +1,138 @@
+using System.Linq;
+using Broiler.Dom;
+
+namespace Broiler.HtmlBridge;
+
+/// <summary>
+/// Render-time <c>&lt;base href&gt;</c> resolution for stylesheet <c>url()</c> references.
+/// The renderer resolves a relative CSS <c>url()</c> against a single document base URL and
+/// never consults the <c>&lt;base&gt;</c> element, so a page that sets
+/// <c>&lt;base href="/images/"&gt;</c> and then references <c>url(green.png)</c> resolved the
+/// image against the document's own directory instead of the base — the resource was not
+/// found and the fallback colour showed through (the WPT <c>css/…/*base-uri*</c> family, e.g.
+/// <c>css-values/inline-cache-base-uri-cssom</c>).
+/// <para>
+/// This transform rewrites relative <c>url()</c> references in every <c>&lt;style&gt;</c>
+/// against the document's first <c>&lt;base href&gt;</c> so they reach the renderer already
+/// resolved. A root-relative base (<c>/images/</c>) keeps the resolved URL root-relative, so a
+/// host-relative resource mapper (the WPT <c>wptRoot</c> handler, which serves <c>/x</c> from
+/// the test root) still recognises it; an absolute base resolves to an absolute URL.
+/// </para>
+/// <para>
+/// Runs inside <see cref="ApplySerializationTransforms"/> after
+/// <see cref="InlineStyleSheetImports"/> (so inlined <c>@import</c> content — already rebased
+/// onto the imported sheet's own URL — carries absolute <c>url()</c>s this pass leaves alone).
+/// Only the render-bound serialization is affected; the live CSSOM rule model and JS-visible
+/// serialization are untouched. Only <c>&lt;style&gt;</c> <c>url()</c>s are rewritten today;
+/// element <c>src</c>/<c>href</c> attributes still resolve without <c>&lt;base&gt;</c>.
+/// </para>
+/// </summary>
+public sealed partial class DomBridge
+{
+    /// <summary>
+    /// Rewrites relative <c>url()</c> references in every <c>&lt;style&gt;</c> in the tree
+    /// against the document's first <c>&lt;base href&gt;</c>. A no-op (byte-identical output)
+    /// when the document declares no usable <c>&lt;base href&gt;</c>.
+    /// </summary>
+    private void ApplyBaseHrefToStyleUrls(DomElement root)
+    {
+        if (!TryFindDocumentBaseHref(root, out var baseHref))
+            return;
+
+        RewriteStyleElementUrls(root, baseHref);
+    }
+
+    /// <summary>The first <c>&lt;base&gt;</c> in document order with a non-empty
+    /// <c>href</c> — the element that sets the document base URL (HTML §4.2.3).</summary>
+    private bool TryFindDocumentBaseHref(DomElement root, out string baseHref)
+    {
+        baseHref = string.Empty;
+        foreach (var element in root.Descendants().OfType<DomElement>())
+        {
+            if (element.TagName.Equals("base", StringComparison.OrdinalIgnoreCase) &&
+                TryGetAttribute(element, "href", out var href) &&
+                !string.IsNullOrWhiteSpace(href))
+            {
+                baseHref = href.Trim();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void RewriteStyleElementUrls(DomElement element, string baseHref)
+    {
+        if (!IsText(element) &&
+            element.TagName.Equals("style", StringComparison.OrdinalIgnoreCase))
+        {
+            var original = GetStyleElementCssText(element);
+            var rewritten = RewriteCssUrlsAgainstBaseHref(original, baseHref);
+            if (!string.Equals(rewritten, original, StringComparison.Ordinal))
+                SetElementTextContent(element, rewritten);
+        }
+
+        foreach (var child in ChildElements(element))
+            RewriteStyleElementUrls(child, baseHref);
+    }
+
+    /// <summary>Rewrites each relative <c>url(...)</c> in <paramref name="css"/> to its
+    /// resolution against <paramref name="baseHref"/>; absolute, <c>data:</c>, and fragment
+    /// references are left byte-identical.</summary>
+    private string RewriteCssUrlsAgainstBaseHref(string css, string baseHref)
+        => UrlFunctionPattern.Replace(css, match =>
+        {
+            var resolved = ResolveUrlAgainstBaseHref(match.Groups[2].Value, baseHref);
+            return resolved is null ? match.Value : $"url(\"{resolved}\")";
+        });
+
+    /// <summary>
+    /// Resolves a CSS <c>url()</c> value against a <c>&lt;base href&gt;</c>, or returns
+    /// <c>null</c> when it should be left untouched (empty / <c>data:</c> / fragment /
+    /// already-absolute). A root-relative base yields a root-relative result (so the
+    /// <c>wptRoot</c> host-relative mapper still resolves it); an absolute base yields an
+    /// absolute URL; a document-relative base resolves through the page URL first.
+    /// </summary>
+    private string? ResolveUrlAgainstBaseHref(string rawUrl, string baseHref)
+    {
+        var url = rawUrl.Trim();
+        if (url.Length == 0 ||
+            url.StartsWith("data:", StringComparison.OrdinalIgnoreCase) ||
+            url.StartsWith("#", StringComparison.Ordinal) ||
+            HasUrlScheme(url))
+            return null;
+
+        if (baseHref.StartsWith("/", StringComparison.Ordinal))
+        {
+            // Root-relative base: do the path math under a placeholder authority, then hand
+            // back the host-relative path so a root-relative resource mapper still matches.
+            var placeholder = new Uri("http://base.invalid", UriKind.Absolute);
+            if (Uri.TryCreate(placeholder, baseHref, out var rootBase) &&
+                Uri.TryCreate(rootBase, url, out var rootResolved))
+            {
+                var result = rootResolved.PathAndQuery + rootResolved.Fragment;
+                return string.Equals(result, url, StringComparison.Ordinal) ? null : result;
+            }
+
+            return null;
+        }
+
+        if (Uri.TryCreate(baseHref, UriKind.Absolute, out var absoluteBase) &&
+            Uri.TryCreate(absoluteBase, url, out var absoluteResolved))
+        {
+            var result = absoluteResolved.AbsoluteUri;
+            return string.Equals(result, url, StringComparison.Ordinal) ? null : result;
+        }
+
+        if (!string.IsNullOrEmpty(_pageUrl) &&
+            Uri.TryCreate(_pageUrl, UriKind.Absolute, out var pageBase) &&
+            Uri.TryCreate(pageBase, baseHref, out var docBase) &&
+            Uri.TryCreate(docBase, url, out var docResolved))
+        {
+            var result = docResolved.AbsoluteUri;
+            return string.Equals(result, url, StringComparison.Ordinal) ? null : result;
+        }
+
+        return null;
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/StyleImports.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/StyleImports.cs
@@ -1,0 +1,318 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Broiler.Dom;
+using Broiler.HtmlBridge.Internal.Scripting;
+
+namespace Broiler.HtmlBridge;
+
+/// <summary>
+/// Render-time <c>@import</c> resolution. The renderer re-parses the serialized HTML and
+/// applies each <c>&lt;style&gt;</c>/<c>&lt;link&gt;</c> sheet, but it does not fetch a
+/// sheet's <c>@import</c> rules — an <c>@import</c> statement is parsed and then ignored,
+/// so the imported rules never reach the cascade (the WPT <c>css/cssom</c> import family,
+/// e.g. <c>cssimportrule-parent</c>, rendered blank where the import set a background).
+/// This transform inlines the imported CSS text into the importing <c>&lt;style&gt;</c>
+/// during the render-bound serialization, so the renderer sees the imported rules.
+/// <para>
+/// Runs inside <see cref="ApplySerializationTransforms"/>, so it only affects the
+/// render-bound document — JS-visible <c>innerHTML</c>/<c>outerHTML</c> (which serialize
+/// without the transforms) still expose the author <c>@import</c> statement, and the
+/// live CSSOM rule model (<c>cssRules</c>) is untouched. Only <c>&lt;style&gt;</c>
+/// elements are inlined: a linked sheet's imports would need their relative <c>url()</c>s
+/// re-based onto the link (not the document), the same limitation
+/// <see cref="ApplyCssomStyleSheetMutations"/> notes for baking linked sheets.
+/// </para>
+/// </summary>
+public sealed partial class DomBridge
+{
+    /// <summary>Depth cap for nested <c>@import</c> chains — a backstop against a
+    /// pathological chain; well above any real stylesheet's nesting.</summary>
+    private const int MaxImportDepth = 32;
+
+    private static readonly System.Text.RegularExpressions.Regex UrlFunctionPattern = new(
+        @"url\(\s*(['""]?)([^'""\)]+)\1\s*\)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Inlines the leading <c>@import</c> rules of every <c>&lt;style&gt;</c> in the tree,
+    /// replacing each with the (recursively import-expanded) text of the imported sheet.
+    /// </summary>
+    private void InlineStyleSheetImports(DomElement element)
+    {
+        if (!IsText(element) &&
+            element.TagName.Equals("style", StringComparison.OrdinalIgnoreCase))
+        {
+            var original = GetStyleElementCssText(element);
+            if (HasLeadingImport(original))
+            {
+                var expanded = ExpandCssImports(
+                    original, _pageUrl, new HashSet<string>(StringComparer.OrdinalIgnoreCase), 0);
+                if (!string.Equals(expanded, original, StringComparison.Ordinal))
+                    SetElementTextContent(element, expanded);
+            }
+        }
+
+        foreach (var child in ChildElements(element))
+            InlineStyleSheetImports(child);
+    }
+
+    /// <summary>Quick, allocation-free check for a leading <c>@import</c> before the
+    /// heavier scan/fetch runs.</summary>
+    private static bool HasLeadingImport(string css)
+        => ScanLeadingImports(css).Imports.Count > 0;
+
+    /// <summary>
+    /// Replaces the leading run of <c>@import</c> statements in <paramref name="css"/> with
+    /// the fetched (and recursively expanded) text of each imported sheet, resolved against
+    /// <paramref name="baseUrl"/>. <paramref name="chain"/> tracks the current import chain
+    /// so a cycle (A→B→A) resolves to nothing instead of recursing forever; it is a
+    /// per-chain set (an already-resolved URL is removed after its subtree expands) so a
+    /// diamond import still inlines the shared sheet on each independent path.
+    /// </summary>
+    private string ExpandCssImports(string css, string baseUrl, HashSet<string> chain, int depth)
+    {
+        var (endOffset, imports) = ScanLeadingImports(css);
+        if (imports.Count == 0 || depth >= MaxImportDepth)
+            return css;
+
+        var sb = new StringBuilder();
+        foreach (var (href, media) in imports)
+        {
+            if (string.IsNullOrEmpty(href))
+                continue;
+
+            var absolute = ResolveStyleSheetUrl(href, baseUrl);
+            if (absolute is null || !chain.Add(absolute))
+                continue; // unresolvable, or already on the current chain (cycle)
+
+            try
+            {
+                var imported = FetchStyleSheetText(absolute);
+                if (!string.IsNullOrEmpty(imported))
+                {
+                    var rebased = RebaseRelativeUrls(imported, absolute);
+                    var nested = ExpandCssImports(rebased, absolute, chain, depth + 1);
+                    if (!string.IsNullOrWhiteSpace(media))
+                        sb.Append("@media ").Append(media).Append(" {\n").Append(nested).Append("\n}\n");
+                    else
+                        sb.Append(nested).Append('\n');
+                }
+            }
+            finally
+            {
+                chain.Remove(absolute);
+            }
+        }
+
+        sb.Append(css, endOffset, css.Length - endOffset);
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Scans the leading portion of a stylesheet — whitespace, comments, and any
+    /// <c>@charset</c>/<c>@import</c> statements, which per CSS syntax must precede all
+    /// style rules — collecting each <c>@import</c>'s href and media condition and the
+    /// offset at which the first non-import content begins. A stray <c>@import</c> after a
+    /// style rule is invalid and left in place (the renderer ignores it, matching browsers).
+    /// </summary>
+    private static (int EndOffset, List<(string Href, string Media)> Imports) ScanLeadingImports(string css)
+    {
+        var imports = new List<(string, string)>();
+        var i = 0;
+        var n = css.Length;
+        var consumedEnd = 0;
+
+        while (i < n)
+        {
+            // Skip whitespace.
+            while (i < n && char.IsWhiteSpace(css[i]))
+                i++;
+
+            // Skip /* comments */.
+            if (i + 1 < n && css[i] == '/' && css[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < n && !(css[i] == '*' && css[i + 1] == '/'))
+                    i++;
+                i = System.Math.Min(n, i + 2);
+                continue;
+            }
+
+            if (StartsWithAtKeyword(css, i, "@charset"))
+            {
+                i = ConsumeToSemicolon(css, i);
+                consumedEnd = i;
+                continue;
+            }
+
+            if (StartsWithAtKeyword(css, i, "@import"))
+            {
+                var stmtEnd = ConsumeToSemicolon(css, i);
+                var prelude = css[(i + "@import".Length)..stmtEnd].Trim().TrimEnd(';').Trim();
+                imports.Add(ParseImportPrelude(prelude));
+                i = stmtEnd;
+                consumedEnd = i;
+                continue;
+            }
+
+            break;
+        }
+
+        return (consumedEnd, imports);
+    }
+
+    /// <summary>Whether <paramref name="css"/> at <paramref name="pos"/> begins the at-rule
+    /// <paramref name="keyword"/> (case-insensitive) followed by a non-identifier delimiter,
+    /// so <c>@import</c> is not matched inside <c>@imports-like</c>.</summary>
+    private static bool StartsWithAtKeyword(string css, int pos, string keyword)
+    {
+        if (pos + keyword.Length > css.Length)
+            return false;
+        if (string.Compare(css, pos, keyword, 0, keyword.Length, StringComparison.OrdinalIgnoreCase) != 0)
+            return false;
+        if (pos + keyword.Length == css.Length)
+            return true;
+        var next = css[pos + keyword.Length];
+        return char.IsWhiteSpace(next) || next == '"' || next == '\'' || next == '(' || next == ';';
+    }
+
+    /// <summary>Returns the index just past the terminating <c>;</c> of a statement starting
+    /// at <paramref name="start"/>, ignoring semicolons inside strings, <c>url(...)</c>
+    /// parentheses, and comments. Falls back to end-of-input for an unterminated statement.</summary>
+    private static int ConsumeToSemicolon(string css, int start)
+    {
+        var i = start;
+        var n = css.Length;
+        while (i < n)
+        {
+            var c = css[i];
+            if (c == '"' || c == '\'')
+            {
+                var quote = c;
+                i++;
+                while (i < n && css[i] != quote)
+                {
+                    if (css[i] == '\\' && i + 1 < n)
+                        i++;
+                    i++;
+                }
+                i++;
+                continue;
+            }
+            if (c == '/' && i + 1 < n && css[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < n && !(css[i] == '*' && css[i + 1] == '/'))
+                    i++;
+                i = System.Math.Min(n, i + 2);
+                continue;
+            }
+            if (c == '(')
+            {
+                var depth = 1;
+                i++;
+                while (i < n && depth > 0)
+                {
+                    if (css[i] == '(') depth++;
+                    else if (css[i] == ')') depth--;
+                    i++;
+                }
+                continue;
+            }
+            if (c == ';')
+                return i + 1;
+            i++;
+        }
+        return n;
+    }
+
+    /// <summary>Splits an <c>@import</c> prelude (after the keyword, without the trailing
+    /// <c>;</c>) into its href and the remaining media condition.</summary>
+    private static (string Href, string Media) ParseImportPrelude(string prelude)
+    {
+        if (prelude.StartsWith("url(", StringComparison.OrdinalIgnoreCase))
+        {
+            var open = prelude.IndexOf('(');
+            var close = prelude.IndexOf(')', open + 1);
+            if (open >= 0 && close > open)
+            {
+                var href = prelude[(open + 1)..close].Trim().Trim('"', '\'');
+                return (href, prelude[(close + 1)..].Trim());
+            }
+        }
+        else if (prelude.Length > 0 && (prelude[0] == '"' || prelude[0] == '\''))
+        {
+            var quote = prelude[0];
+            var close = prelude.IndexOf(quote, 1);
+            if (close > 0)
+                return (prelude[1..close], prelude[(close + 1)..].Trim());
+        }
+
+        return (string.Empty, string.Empty);
+    }
+
+    /// <summary>Resolves a stylesheet href against a base URL. A <c>data:</c> href is its
+    /// own absolute URL; everything else goes through the shared URL resolver.</summary>
+    private string? ResolveStyleSheetUrl(string href, string baseUrl)
+    {
+        if (href.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+            return href;
+        return UrlResolver.Resolve(href, string.IsNullOrEmpty(baseUrl) ? _pageUrl : baseUrl)?.AbsoluteUri;
+    }
+
+    /// <summary>Fetches the CSS text for an already-absolute stylesheet URL — decoding a
+    /// <c>data:</c> URI in-process, or loading <c>file</c>/<c>http(s)</c> via the loader.</summary>
+    private string? FetchStyleSheetText(string absoluteUrl)
+    {
+        if (absoluteUrl.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+        {
+            var (_, body) = DecodeDataUriParts(absoluteUrl);
+            return body;
+        }
+        return FetchExternalStylesheet(absoluteUrl);
+    }
+
+    /// <summary>
+    /// Rewrites relative <c>url(...)</c> references in imported CSS to absolute URLs against
+    /// the imported sheet's own URL, so an imported sheet's relative images resolve against
+    /// the sheet rather than the importing document. Absolute, <c>data:</c>, and fragment
+    /// references are left untouched; when the base is itself a <c>data:</c> URL (no path to
+    /// resolve against) the text is returned unchanged.
+    /// </summary>
+    private static string RebaseRelativeUrls(string css, string baseUrl)
+    {
+        if (baseUrl.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+            return css;
+
+        return UrlFunctionPattern.Replace(css, match =>
+        {
+            var raw = match.Groups[2].Value.Trim();
+            if (raw.Length == 0 ||
+                raw.StartsWith("data:", StringComparison.OrdinalIgnoreCase) ||
+                raw.StartsWith("#", StringComparison.Ordinal) ||
+                HasUrlScheme(raw))
+                return match.Value;
+
+            var resolved = UrlResolver.Resolve(raw, baseUrl)?.AbsoluteUri;
+            return resolved is null ? match.Value : $"url(\"{resolved}\")";
+        });
+    }
+
+    /// <summary>Whether a URL reference already carries an explicit scheme
+    /// (<c>scheme:</c> or protocol-relative <c>//host</c>), so it should not be re-based.</summary>
+    private static bool HasUrlScheme(string url)
+    {
+        if (url.StartsWith("//", StringComparison.Ordinal))
+            return true;
+        var colon = url.IndexOf(':');
+        if (colon <= 0)
+            return false;
+        for (var i = 0; i < colon; i++)
+        {
+            var c = url[i];
+            if (!char.IsLetterOrDigit(c) && c != '+' && c != '-' && c != '.')
+                return false;
+        }
+        return true;
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/WebAnimations.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/WebAnimations.cs
@@ -1,0 +1,345 @@
+using System.Globalization;
+using System.Text;
+using Broiler.JavaScript.Storage;
+using Broiler.JavaScript.BuiltIns.Array;
+using Broiler.JavaScript.Runtime;
+using Broiler.Dom;
+
+namespace Broiler.HtmlBridge;
+
+/// <summary>
+/// Web Animations API — <c>element.animate(keyframes, options)</c>. The render is a single
+/// snapshot, so this evaluates the animation's effect at the snapshot time (the animation has
+/// just started; a negative <c>delay</c> pre-advances it — the pattern WPT interpolation tests
+/// and <c>interpolation-testcommon.js</c> use to sample a mid-point instantly) and bakes the
+/// interpolated property values into the element's render style. Previously
+/// <c>element.animate</c> was a no-op stub, so animation-driven property values never rendered
+/// (a scaled/faded/animated element drew at its base value).
+/// </summary>
+public sealed partial class DomBridge
+{
+    /// <summary>Web-Animations keyframe keys (camelCase) mapped to their CSS property names,
+    /// probed on each keyframe object (the engine's own-key enumeration is internal, and this
+    /// covers the animatable properties the interpolator supports).</summary>
+    private static readonly (string Keyframe, string Css)[] AnimatableProperties =
+    [
+        ("transform", "transform"),
+        ("opacity", "opacity"),
+        ("color", "color"),
+        ("background", "background"),
+        ("backgroundColor", "background-color"),
+        ("borderColor", "border-color"),
+        ("outlineColor", "outline-color"),
+        ("width", "width"),
+        ("height", "height"),
+        ("left", "left"),
+        ("top", "top"),
+        ("right", "right"),
+        ("bottom", "bottom"),
+        ("marginTop", "margin-top"),
+        ("marginRight", "margin-right"),
+        ("marginBottom", "margin-bottom"),
+        ("marginLeft", "margin-left"),
+        ("paddingTop", "padding-top"),
+        ("paddingRight", "padding-right"),
+        ("paddingBottom", "padding-bottom"),
+        ("paddingLeft", "padding-left"),
+        ("borderRadius", "border-radius"),
+        ("fontSize", "font-size"),
+        ("lineHeight", "line-height"),
+        ("letterSpacing", "letter-spacing"),
+        ("filter", "filter"),
+    ];
+
+    /// <summary>
+    /// <c>element.animate(keyframes, options)</c> — bakes the animation's snapshot-time value and
+    /// returns a minimal Animation object. Never throws into the caller: a malformed keyframe or
+    /// option leaves the element unbaked rather than aborting the script.
+    /// </summary>
+    private JSValue ElementAnimate(DomElement element, in Arguments a)
+    {
+        try
+        {
+            var keyframes = ParseAnimationKeyframes(a.Length > 0 ? a[0] : JSUndefined.Value);
+            var timing = ParseAnimationTiming(a.Length > 1 ? a[1] : JSUndefined.Value);
+            if (keyframes.Count >= 1 && timing.DurationMs > 0 &&
+                TryComputeSnapshotProgress(timing, out var progress))
+            {
+                var resolved = ResolveKeyframeProperties(element, keyframes, progress, timing.Easing);
+                foreach (var kv in resolved)
+                    BakedInlineStyle(element)[kv.Key] = kv.Value;
+                InvalidateStyleScope(element);
+            }
+        }
+        catch
+        {
+            // Web Animations must not break the page: a bad animate() call is inert.
+        }
+
+        return BuildAnimationObject(element);
+    }
+
+    private List<KeyframeEntry> ParseAnimationKeyframes(JSValue keyframesValue)
+    {
+        var entries = new List<KeyframeEntry>();
+        if (keyframesValue is not JSArray array)
+            return entries;
+
+        var items = array.GetArrayElements(withHoles: false).Select(t => t.value).ToList();
+        for (var i = 0; i < items.Count; i++)
+        {
+            if (items[i] is not JSObject keyframe)
+                continue;
+
+            var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (keyframeKey, cssName) in AnimatableProperties)
+            {
+                var value = keyframe[(KeyString)keyframeKey];
+                if (value is null || value.IsNullOrUndefined)
+                    continue;
+                var text = value.ToString();
+                if (!string.IsNullOrWhiteSpace(text))
+                    properties[cssName] = text;
+            }
+
+            if (properties.Count == 0)
+                continue;
+
+            // Explicit offset, else distribute evenly across the keyframe list (spec default).
+            float position;
+            var offset = keyframe[(KeyString)"offset"];
+            if (offset is not null && offset.IsNumber)
+                position = (float)offset.DoubleValue;
+            else
+                position = items.Count <= 1 ? 0f : (float)i / (items.Count - 1);
+
+            entries.Add(new KeyframeEntry(position, properties));
+        }
+
+        entries.Sort((x, y) => x.Position.CompareTo(y.Position));
+        return entries;
+    }
+
+    private readonly record struct AnimationTiming(
+        double DurationMs, double DelayMs, string Easing, string Fill,
+        double Iterations, double IterationStart);
+
+    private static AnimationTiming ParseAnimationTiming(JSValue optionsValue)
+    {
+        double duration = 0, delay = 0, iterations = 1, iterationStart = 0;
+        var easing = "linear";
+        var fill = "none";
+
+        if (optionsValue.IsNumber)
+        {
+            duration = optionsValue.DoubleValue;
+        }
+        else if (optionsValue is JSObject options)
+        {
+            if (options[(KeyString)"duration"] is { IsNumber: true } d)
+                duration = d.DoubleValue;
+            if (options[(KeyString)"delay"] is { IsNumber: true } dl)
+                delay = dl.DoubleValue;
+            if (options[(KeyString)"iterations"] is { IsNumber: true } it)
+                iterations = it.DoubleValue;
+            if (options[(KeyString)"iterationStart"] is { IsNumber: true } iterStart)
+                iterationStart = iterStart.DoubleValue;
+            if (options[(KeyString)"easing"] is { } e && !e.IsNullOrUndefined)
+                easing = e.ToString();
+            if (options[(KeyString)"fill"] is { } f && !f.IsNullOrUndefined)
+                fill = f.ToString();
+        }
+
+        return new AnimationTiming(duration, delay, easing, fill, iterations, iterationStart);
+    }
+
+    /// <summary>
+    /// Iteration progress at the snapshot. The animation has just started (current time 0), so
+    /// active time is <c>-delay</c>; a negative delay lands it mid-animation. Returns false when
+    /// the animation has no effect at the snapshot (before/after its active phase and not filled).
+    /// </summary>
+    private static bool TryComputeSnapshotProgress(AnimationTiming timing, out float progress)
+    {
+        progress = 0f;
+        var iterations = timing.Iterations <= 0 ? 1 : timing.Iterations;
+        var activeDuration = timing.DurationMs * iterations;
+        var activeTime = 0.0 - timing.DelayMs;
+
+        var fillsBackwards = timing.Fill is "backwards" or "both";
+        var fillsForwards = timing.Fill is "forwards" or "both";
+
+        if (activeTime < 0)
+        {
+            if (!fillsBackwards)
+                return false;
+            activeTime = 0;
+        }
+        else if (activeTime >= activeDuration)
+        {
+            if (!fillsForwards)
+                return false;
+            activeTime = activeDuration;
+        }
+
+        var overallProgress = (timing.DurationMs > 0 ? activeTime / timing.DurationMs : 0) + timing.IterationStart;
+        // Iteration progress in [0,1]; a whole-number boundary at the end of the active phase
+        // resolves to 1 (the animation's final value), not 0.
+        var iterationProgress = overallProgress - Math.Floor(overallProgress);
+        if (iterationProgress == 0 && overallProgress > 0)
+            iterationProgress = 1;
+
+        progress = (float)Math.Clamp(iterationProgress, 0.0, 1.0);
+        return true;
+    }
+
+    // ------------------------------------------------------------------
+    //  Transform interpolation (component-wise between matching lists)
+    // ------------------------------------------------------------------
+
+    private sealed record TransformFunction(string Name, List<string> Args);
+
+    private static bool TryInterpolateTransform(string fromValue, string toValue, float progress, out string result)
+    {
+        result = string.Empty;
+        var from = ParseTransformFunctions(fromValue);
+        var to = ParseTransformFunctions(toValue);
+        if (from is null || to is null)
+            return false;
+
+        if (from.Count == 0 && to.Count == 0)
+        {
+            result = "none";
+            return true;
+        }
+
+        // `none` interpolates as the identity of the other side's function list.
+        if (from.Count == 0)
+            from = to.Select(IdentityTransform).ToList();
+        else if (to.Count == 0)
+            to = from.Select(IdentityTransform).ToList();
+
+        if (from.Count != to.Count)
+            return false;
+
+        var builder = new StringBuilder();
+        for (var i = 0; i < from.Count; i++)
+        {
+            if (!string.Equals(from[i].Name, to[i].Name, StringComparison.OrdinalIgnoreCase) ||
+                from[i].Args.Count != to[i].Args.Count)
+                return false;
+
+            var args = new List<string>(from[i].Args.Count);
+            for (var j = 0; j < from[i].Args.Count; j++)
+            {
+                if (!TryInterpolateNumericToken(from[i].Args[j], to[i].Args[j], progress, out var arg))
+                    return false;
+                args.Add(arg);
+            }
+
+            if (builder.Length > 0)
+                builder.Append(' ');
+            builder.Append(from[i].Name).Append('(').Append(string.Join(", ", args)).Append(')');
+        }
+
+        result = builder.ToString();
+        return true;
+    }
+
+    private static List<TransformFunction>? ParseTransformFunctions(string value)
+    {
+        value = value?.Trim() ?? string.Empty;
+        var functions = new List<TransformFunction>();
+        if (value.Length == 0 || value.Equals("none", StringComparison.OrdinalIgnoreCase))
+            return functions;
+
+        var i = 0;
+        var n = value.Length;
+        while (i < n)
+        {
+            while (i < n && (char.IsWhiteSpace(value[i]) || value[i] == ','))
+                i++;
+            if (i >= n)
+                break;
+
+            var nameStart = i;
+            while (i < n && value[i] != '(')
+                i++;
+            if (i >= n)
+                return null;
+            var name = value[nameStart..i].Trim();
+            i++; // '('
+
+            var argStart = i;
+            while (i < n && value[i] != ')')
+                i++;
+            if (i >= n || name.Length == 0)
+                return null;
+            var args = value[argStart..i]
+                .Split(',')
+                .Select(s => s.Trim())
+                .Where(s => s.Length > 0)
+                .ToList();
+            i++; // ')'
+
+            functions.Add(new TransformFunction(name, args));
+        }
+
+        return functions;
+    }
+
+    private static TransformFunction IdentityTransform(TransformFunction function)
+    {
+        var lower = function.Name.ToLowerInvariant();
+        string identity =
+            lower.StartsWith("scale", StringComparison.Ordinal) ? "1"
+            : lower.StartsWith("rotate", StringComparison.Ordinal) || lower.StartsWith("skew", StringComparison.Ordinal) ? "0deg"
+            : "0";
+        return new TransformFunction(function.Name, function.Args.Select(_ => identity).ToList());
+    }
+
+    private static bool TryInterpolateNumericToken(string from, string to, float progress, out string result)
+    {
+        result = string.Empty;
+        if (!TrySplitNumberUnit(from, out var fromNumber, out var fromUnit) ||
+            !TrySplitNumberUnit(to, out var toNumber, out var toUnit))
+            return false;
+
+        string unit;
+        if (string.Equals(fromUnit, toUnit, StringComparison.OrdinalIgnoreCase))
+            unit = fromUnit;
+        else if (fromNumber == 0 && fromUnit.Length == 0)
+            unit = toUnit;
+        else if (toNumber == 0 && toUnit.Length == 0)
+            unit = fromUnit;
+        else
+            return false; // incompatible units (e.g. px vs %); no conversion here
+
+        var value = fromNumber + (toNumber - fromNumber) * progress;
+        result = value.ToString("0.#####", CultureInfo.InvariantCulture) + unit;
+        return true;
+    }
+
+    private static bool TrySplitNumberUnit(string token, out double number, out string unit)
+    {
+        number = 0;
+        unit = string.Empty;
+        token = token.Trim();
+        if (token.Length == 0)
+            return false;
+
+        var i = 0;
+        if (token[i] is '+' or '-')
+            i++;
+        var digitsStart = i;
+        while (i < token.Length && (char.IsDigit(token[i]) || token[i] == '.'))
+            i++;
+        if (i == digitsStart)
+            return false;
+
+        if (!double.TryParse(token[..i], NumberStyles.Float, CultureInfo.InvariantCulture, out number))
+            return false;
+
+        unit = token[i..].Trim();
+        return true;
+    }
+}

--- a/src/Broiler.Wpt.Tests/StyleAdoptedSheetsTests.cs
+++ b/src/Broiler.Wpt.Tests/StyleAdoptedSheetsTests.cs
@@ -1,0 +1,110 @@
+using System.IO;
+using Broiler.HTML.Image;
+using BColor = Broiler.Graphics.BColor;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression tests for constructable stylesheets and <c>document.adoptedStyleSheets</c>
+/// (<c>DomBridge.CreateConstructedStyleSheet</c> / <c>ApplyAdoptedStyleSheets</c>). A
+/// constructed <c>CSSStyleSheet</c> carries its own rule list and applies to the document only
+/// while adopted; the serialization pass emits each adopted sheet as a synthetic
+/// <c>&lt;style&gt;</c> after the document's own stylesheets so the renderer applies it in
+/// cascade order (the WPT <c>css/cssom</c> constructable family, e.g.
+/// <c>CSSStyleSheet-constructable-insertRule-base-uri</c>).
+/// </summary>
+public class StyleAdoptedSheetsTests : IDisposable
+{
+    private readonly string _root;
+
+    public StyleAdoptedSheetsTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "broiler-adopted-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        Program.ResetTestHooks();
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    private BColor RenderCenterPixel(string html)
+    {
+        var file = Path.Combine(_root, "t-" + Guid.NewGuid().ToString("N")[..6] + ".html");
+        File.WriteAllText(file, html);
+        var runner = new WptTestRunner(200, 200);
+        using var bmp = runner.RenderHtmlFileBitmapPublic(file, _root);
+        return bmp.GetPixel(100, 100);
+    }
+
+    private static bool IsRed(BColor c) => c.R > 200 && c.G < 80 && c.B < 80;
+    private static bool IsBlue(BColor c) => c.B > 200 && c.R < 80 && c.G < 80;
+    private static bool IsWhite(BColor c) => c.R > 200 && c.G > 200 && c.B > 200;
+
+    [Fact]
+    public void InsertRule_AdoptedViaPush_Applies()
+    {
+        var color = RenderCenterPixel(
+            "<!doctype html>\n<script>\n" +
+            "  const s = new CSSStyleSheet();\n" +
+            "  s.insertRule(':root { background: red }');\n" +
+            "  document.adoptedStyleSheets.push(s);\n" +
+            "</script>");
+        Assert.True(IsRed(color), $"adopted constructed sheet (insertRule + push) should apply red; got {color.R},{color.G},{color.B}.");
+    }
+
+    [Fact]
+    public void ReplaceSync_AdoptedByAssignment_Applies()
+    {
+        var color = RenderCenterPixel(
+            "<!doctype html>\n<script>\n" +
+            "  const s = new CSSStyleSheet();\n" +
+            "  s.replaceSync(':root { background: red }');\n" +
+            "  document.adoptedStyleSheets = [s];\n" +
+            "</script>");
+        Assert.True(IsRed(color), $"replaceSync + adoptedStyleSheets assignment should apply red; got {color.R},{color.G},{color.B}.");
+    }
+
+    [Fact]
+    public void AdoptedSheet_AppliesAfterAuthorStyles()
+    {
+        // Adopted sheets come after the document's own stylesheets in cascade order, so the
+        // adopted red wins over the author blue at equal specificity.
+        var color = RenderCenterPixel(
+            "<!doctype html>\n<style>:root { background: blue }</style>\n<script>\n" +
+            "  const s = new CSSStyleSheet();\n" +
+            "  s.replaceSync(':root { background: red }');\n" +
+            "  document.adoptedStyleSheets = [s];\n" +
+            "</script>");
+        Assert.True(IsRed(color), $"adopted sheet should cascade after author styles (red over blue); got {color.R},{color.G},{color.B}.");
+    }
+
+    [Fact]
+    public void DisabledAdoptedSheet_DoesNotApply()
+    {
+        // A disabled adopted sheet contributes nothing, so the author blue shows.
+        var color = RenderCenterPixel(
+            "<!doctype html>\n<style>:root { background: blue }</style>\n<script>\n" +
+            "  const s = new CSSStyleSheet();\n" +
+            "  s.replaceSync(':root { background: red }');\n" +
+            "  s.disabled = true;\n" +
+            "  document.adoptedStyleSheets = [s];\n" +
+            "</script>");
+        Assert.True(IsBlue(color), $"a disabled adopted sheet must not apply (blue author style wins); got {color.R},{color.G},{color.B}.");
+    }
+
+    [Fact]
+    public void NoAdoptedSheets_LeavesRenderingUnchanged()
+    {
+        // Never touching adoptedStyleSheets must be a no-op — the transform only runs when a
+        // sheet has been adopted.
+        var plain = RenderCenterPixel("<!doctype html>\n<style>body { margin: 0 }</style>");
+        Assert.True(IsWhite(plain), $"a page that never adopts a sheet should render white; got {plain.R},{plain.G},{plain.B}.");
+
+        var color = RenderCenterPixel(
+            "<!doctype html>\n<script>const s = new CSSStyleSheet(); s.replaceSync(':root{background:red}');</script>");
+        Assert.True(IsWhite(color), $"a constructed but unadopted sheet must not apply; got {color.R},{color.G},{color.B}.");
+    }
+}

--- a/src/Broiler.Wpt.Tests/StyleBaseHrefTests.cs
+++ b/src/Broiler.Wpt.Tests/StyleBaseHrefTests.cs
@@ -1,0 +1,100 @@
+using System.IO;
+using Broiler.HTML.Image;
+using BColor = Broiler.Graphics.BColor;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression tests for render-time <c>&lt;base href&gt;</c> resolution of stylesheet
+/// <c>url()</c> references (<c>DomBridge.ApplyBaseHrefToStyleUrls</c>, run from
+/// <c>ApplySerializationTransforms</c>). The renderer resolved a relative CSS <c>url()</c>
+/// against the document's own directory and never consulted <c>&lt;base&gt;</c>, so a page
+/// setting <c>&lt;base href="/images/"&gt;</c> and referencing <c>url(green.png)</c> failed to
+/// find the image and painted its fallback colour (the WPT <c>*base-uri*</c> family, e.g.
+/// <c>css-values/inline-cache-base-uri-cssom</c>). Rewriting the <c>url()</c> against the base
+/// during serialization — keeping a root-relative base root-relative so the <c>wptRoot</c>
+/// mapper still resolves it — closes that gap.
+/// </summary>
+public class StyleBaseHrefTests : IDisposable
+{
+    private readonly string _root;
+
+    public StyleBaseHrefTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "broiler-base-href-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_root);
+        // A solid lime image at the WPT-root-relative /images/green.png.
+        var imageDir = Path.Combine(_root, "images");
+        Directory.CreateDirectory(imageDir);
+        using var img = new BBitmap(8, 8);
+        img.Clear(new BColor(0, 255, 0, 255));
+        img.Save(Path.Combine(imageDir, "green.png"));
+    }
+
+    public void Dispose()
+    {
+        Program.ResetTestHooks();
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    private BColor RenderCenterPixel(string html)
+    {
+        var dir = Path.Combine(_root, "css", "t");
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, "t-" + Guid.NewGuid().ToString("N")[..6] + ".html");
+        File.WriteAllText(file, html);
+        var runner = new WptTestRunner(200, 200);
+        using var bmp = runner.RenderHtmlFileBitmapPublic(file, _root);
+        return bmp.GetPixel(100, 100);
+    }
+
+    private static bool IsLime(BColor c) => c.G > 200 && c.R < 80 && c.B < 80;
+    private static bool IsRed(BColor c) => c.R > 200 && c.G < 80 && c.B < 80;
+
+    [Fact]
+    public void RootRelativeBase_ResolvesRelativeCssUrl()
+    {
+        // <base href="/images/"> makes url(green.png) resolve to /images/green.png (lime),
+        // covering the red fallback. Without honouring <base> this stayed red.
+        var color = RenderCenterPixel(
+            "<!doctype html>\n<base href=\"/images/\">\n" +
+            "<style>:root { background-color: red; background-image: url(green.png); }</style>");
+        Assert.True(IsLime(color), $"root-relative <base> should resolve url(green.png) to lime; got {color.R},{color.G},{color.B}.");
+    }
+
+    [Fact]
+    public void RootRelativeBase_ResolvesUrlInScriptInsertedRule()
+    {
+        // The css-values/inline-cache-base-uri-cssom scenario: the url() arrives through
+        // CSSOM insertRule on a second stylesheet declared after <base>.
+        var color = RenderCenterPixel(
+            "<!doctype html>\n" +
+            "<style>:root { background-color: red; }</style>\n" +
+            "<base href=\"/images/\">\n" +
+            "<style>:root { background-color: red; }</style>\n" +
+            "<script>document.styleSheets[1].insertRule(`:root { background-image: url(green.png) }`);</script>");
+        Assert.True(IsLime(color), $"<base> must apply to a CSSOM-inserted url(); got {color.R},{color.G},{color.B}.");
+    }
+
+    [Fact]
+    public void AbsoluteRootRelativeUrl_WithoutBase_StillResolves()
+    {
+        // No <base>: a url(/images/green.png) is already root-relative and must still
+        // resolve — the transform is a no-op when no <base href> is present.
+        var color = RenderCenterPixel(
+            "<!doctype html>\n<style>:root { background-color: red; background-image: url(/images/green.png); }</style>");
+        Assert.True(IsLime(color), $"absolute root-relative url() should still resolve without <base>; got {color.R},{color.G},{color.B}.");
+    }
+
+    [Fact]
+    public void RelativeUrl_WithoutBase_DoesNotResolveToRoot()
+    {
+        // No <base>: a relative url(green.png) resolves against the document's own directory
+        // (css/t/), where there is no image — so the red fallback shows. This guards against
+        // the rewrite firing when there is no <base> to honour.
+        var color = RenderCenterPixel(
+            "<!doctype html>\n<style>:root { background-color: red; background-image: url(green.png); }</style>");
+        Assert.True(IsRed(color), $"without <base>, a relative url() must not resolve to the root image; got {color.R},{color.G},{color.B}.");
+    }
+}

--- a/src/Broiler.Wpt.Tests/StyleImportInliningTests.cs
+++ b/src/Broiler.Wpt.Tests/StyleImportInliningTests.cs
@@ -1,0 +1,110 @@
+using System.IO;
+using Broiler.HTML.Image;
+using BColor = Broiler.Graphics.BColor;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression tests for render-time <c>@import</c> resolution
+/// (<c>DomBridge.InlineStyleSheetImports</c>, run from
+/// <c>ApplySerializationTransforms</c>). The renderer re-parses the serialized HTML and
+/// applies each sheet, but never fetched a sheet's <c>@import</c> rules — the imported
+/// CSS never reached the cascade, so tests whose only styling came through an
+/// <c>@import</c> (the WPT <c>css/cssom</c> import family, e.g. <c>cssimportrule-parent</c>)
+/// rendered blank. Inlining the imported text into the importing <c>&lt;style&gt;</c> at
+/// serialization time closes that gap.
+/// </summary>
+public class StyleImportInliningTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public StyleImportInliningTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "broiler-style-import-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        Program.ResetTestHooks();
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private BColor RenderCenterPixel(string html)
+    {
+        var file = Path.Combine(_tempDir, "t-" + Guid.NewGuid().ToString("N")[..6] + ".html");
+        File.WriteAllText(file, html);
+        var runner = new WptTestRunner(200, 200);
+        using var bmp = runner.RenderHtmlFileBitmapPublic(file, _tempDir);
+        return bmp.GetPixel(100, 100);
+    }
+
+    private static bool IsRed(BColor c) => c.R > 200 && c.G < 80 && c.B < 80;
+    private static bool IsGreenish(BColor c) => c.G > 100 && c.R < 80 && c.B < 80;
+    private static bool IsWhite(BColor c) => c.R > 200 && c.G > 200 && c.B > 200;
+
+    [Fact]
+    public void DataUrlImport_AppliesImportedRules()
+    {
+        // @import of a data: URL must apply its rules — Chromium renders this red.
+        var color = RenderCenterPixel(
+            "<!doctype html>\n<style>@import \"data:text/css,:root{background:red}\";</style>");
+        Assert.True(IsRed(color), $"data: @import should apply a red background; got {color.R},{color.G},{color.B}.");
+    }
+
+    [Fact]
+    public void RelativeFileImport_AppliesImportedRules()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "imported.css"), ":root{background:red}");
+        var color = RenderCenterPixel(
+            "<!doctype html>\n<style>@import \"imported.css\";</style>");
+        Assert.True(IsRed(color), $"relative @import should apply a red background; got {color.R},{color.G},{color.B}.");
+    }
+
+    [Fact]
+    public void NestedImport_IsResolvedRecursively()
+    {
+        // a.css imports b.css, which sets the background — the whole chain must resolve.
+        File.WriteAllText(Path.Combine(_tempDir, "a.css"), "@import \"b.css\";");
+        File.WriteAllText(Path.Combine(_tempDir, "b.css"), ":root{background:red}");
+        var color = RenderCenterPixel(
+            "<!doctype html>\n<style>@import \"a.css\";</style>");
+        Assert.True(IsRed(color), $"nested @import chain should apply a red background; got {color.R},{color.G},{color.B}.");
+    }
+
+    [Fact]
+    public void ImportCycle_DoesNotHang_AndAppliesReachableRules()
+    {
+        // a.css imports b.css and sets red; b.css imports a.css (a cycle). Resolution
+        // must terminate — the cycle is broken — and the reachable red rule applies.
+        File.WriteAllText(Path.Combine(_tempDir, "a.css"), "@import \"b.css\";\n:root{background:red}");
+        File.WriteAllText(Path.Combine(_tempDir, "b.css"), "@import \"a.css\";");
+        var color = RenderCenterPixel(
+            "<!doctype html>\n<style>@import \"a.css\";</style>");
+        Assert.True(IsRed(color), $"cyclic @import should terminate and apply red; got {color.R},{color.G},{color.B}.");
+    }
+
+    [Fact]
+    public void ImportAfterStyleRule_IsIgnored()
+    {
+        // Per CSS syntax, an @import after a style rule is invalid and ignored. The
+        // leading rule (green) wins; the misplaced @import (red) must not apply.
+        File.WriteAllText(Path.Combine(_tempDir, "imported.css"), ":root{background:red}");
+        var color = RenderCenterPixel(
+            "<!doctype html>\n<style>:root{background:green}\n@import \"imported.css\";</style>");
+        Assert.True(IsGreenish(color),
+            $"an @import after a style rule must be ignored (background stays green); got {color.R},{color.G},{color.B}.");
+    }
+
+    [Fact]
+    public void NoImport_LeavesRenderingUnchanged()
+    {
+        // A stylesheet without @import must be untouched — no spurious rewrite.
+        var withoutImport = RenderCenterPixel("<!doctype html>\n<style>:root{background:red}</style>");
+        Assert.True(IsRed(withoutImport));
+
+        var plain = RenderCenterPixel("<!doctype html>\n<style>body{margin:0}</style>");
+        Assert.True(IsWhite(plain), $"a plain sheet should render white; got {plain.R},{plain.G},{plain.B}.");
+    }
+}

--- a/src/Broiler.Wpt.Tests/WebAnimationsTests.cs
+++ b/src/Broiler.Wpt.Tests/WebAnimationsTests.cs
@@ -1,0 +1,95 @@
+using System.IO;
+using Broiler.HTML.Image;
+using BColor = Broiler.Graphics.BColor;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression tests for <c>element.animate()</c> (Web Animations) value snapshotting and
+/// transform interpolation (<c>DomBridge.ElementAnimate</c> / <c>TryInterpolateTransform</c>).
+/// <c>element.animate</c> was previously a no-op stub, so animation-driven values never
+/// rendered; and the keyframe interpolator did not handle <c>transform</c> (it stepped
+/// discretely). These verify the snapshot value is computed and baked into the render.
+/// </summary>
+public class WebAnimationsTests : IDisposable
+{
+    private readonly string _root;
+
+    public WebAnimationsTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "broiler-web-anim-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        Program.ResetTestHooks();
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    private BBitmap Render(string html, int w = 400, int h = 200)
+    {
+        var file = Path.Combine(_root, "t-" + Guid.NewGuid().ToString("N")[..6] + ".html");
+        File.WriteAllText(file, html);
+        var runner = new WptTestRunner(w, h);
+        return runner.RenderHtmlFileBitmapPublic(file, _root);
+    }
+
+    [Fact]
+    public void Animate_BackgroundColor_BakesInterpolatedColor()
+    {
+        // black → magenta at 50% (delay -50s of a 100s animation) is rgb(~100,0,~100).
+        using var bmp = Render(
+            "<!doctype html>\n<style>.box{width:100px;height:100px;background:white}</style>\n" +
+            "<div class=box id=t></div>\n<script>\n" +
+            "  t.animate([{backgroundColor:'rgb(0,0,0)'},{backgroundColor:'rgb(200,0,200)'}], " +
+            "{duration:100000, delay:-50000, fill:'both'});\n</script>");
+        var c = bmp.GetPixel(50, 50);
+        Assert.True(c.R is > 60 and < 140 && c.G < 40 && c.B is > 60 and < 140,
+            $"backgroundColor should interpolate to mid magenta; got {c.R},{c.G},{c.B}.");
+    }
+
+    [Fact]
+    public void Animate_TransformTranslate_BakesInterpolatedOffset()
+    {
+        // translateX(0 → 400px) at 50% = 200px: the 80px green box sits around x≈200, not x≈0.
+        using var bmp = Render(
+            "<!doctype html>\n<style>.box{width:80px;height:80px;background:green}</style>\n" +
+            "<div class=box id=t></div>\n<script>\n" +
+            "  t.animate([{transform:'translateX(0px)'},{transform:'translateX(400px)'}], " +
+            "{duration:100000, delay:-50000, fill:'both'});\n</script>");
+
+        static bool IsGreen(BColor c) => c.G > 100 && c.R < 100 && c.B < 100;
+        Assert.False(IsGreen(bmp.GetPixel(10, 40)), "box must have moved away from x≈0.");
+        Assert.True(IsGreen(bmp.GetPixel(230, 40)), "box must render around the interpolated x≈200.");
+    }
+
+    [Fact]
+    public void Animate_TransformUniformScale_BakesInterpolatedScale()
+    {
+        // scale(1 → 3) at 50% = scale(2): a 40px box becomes ~80px, so a pixel at (60,60)
+        // (outside the un-scaled 40px box, inside the scaled 80px box) is green.
+        using var bmp = Render(
+            "<!doctype html>\n<style>.box{width:40px;height:40px;background:green;transform-origin:0 0}</style>\n" +
+            "<div class=box id=t></div>\n<script>\n" +
+            "  t.animate([{transform:'scale(1)'},{transform:'scale(3)'}], " +
+            "{duration:100000, delay:-50000, fill:'both'});\n</script>");
+        var c = bmp.GetPixel(60, 60);
+        Assert.True(c.G > 100 && c.R < 100 && c.B < 100,
+            $"uniform scale(2) should enlarge the box to cover (60,60); got {c.R},{c.G},{c.B}.");
+    }
+
+    [Fact]
+    public void Animate_NoOptions_IsInert_AndDoesNotThrow()
+    {
+        // A malformed/zero-duration animate() must leave the element at its base value.
+        using var bmp = Render(
+            "<!doctype html>\n<style>.box{width:100px;height:100px;background:green}</style>\n" +
+            "<div class=box id=t></div>\n<script>\n" +
+            "  t.animate([{transform:'translateX(400px)'}]);\n</script>");
+        var c = bmp.GetPixel(50, 50);
+        Assert.True(c.G > 100 && c.R < 100 && c.B < 100,
+            $"a zero-duration animate() must not move the box; got {c.R},{c.G},{c.B}.");
+    }
+}

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -3684,6 +3684,48 @@ input {
     }
 
     [Fact]
+    public void Wpt_Harness_Test_Call_Aborts_Remaining_Script_In_Defer_Mode()
+    {
+        // Regression: the reference generator has `test` undefined, so a test() call
+        // throws and aborts the rest of that <script> block before any code after it
+        // runs. The interpolation-testcommon.js `create_tests()` helper calls test()
+        // and then removes the container of test boxes; a no-op test() stub let that
+        // removal run, blanking our render against a reference that still shows the
+        // boxes (the css transform/gradient interpolation family, 0.0% MissingContent).
+        // In defer mode test() must throw so the post-call removal never runs.
+        var testHtml = @"<!DOCTYPE html>
+<style>.box { width: 120px; height: 120px; background: green; }</style>
+<script src=""/resources/testharness.js""></script>
+<div id=""c""></div>
+<script>
+  var box = document.createElement('div');
+  box.className = 'box';
+  document.getElementById('c').appendChild(box);
+  test(function() {}, 't');
+  // Reached only if test() did NOT throw — the reference (test undefined) never gets here.
+  document.getElementById('c').remove();
+</script>";
+        // The box survives because test() aborts the block before the remove().
+        var referenceHtml = @"<!DOCTYPE html>
+<style>.box { width: 120px; height: 120px; background: green; }</style>
+<div id=""c""><div class=""box""></div></div>";
+
+        var previousDefer = WptTestRunner.DeferPromiseTests;
+        WptTestRunner.DeferPromiseTests = true;
+        try
+        {
+            var result = RunTempMatchTest(testHtml, referenceHtml, "wpt-harness-test-aborts-defer");
+            Assert.True(result.Passed,
+                "In defer mode a test() call must throw and abort the rest of the block, so the " +
+                $"post-call container.remove() never runs and the box survives. Match={result.MatchPercent:F1}% Message={result.Message}");
+        }
+        finally
+        {
+            WptTestRunner.DeferPromiseTests = previousDefer;
+        }
+    }
+
+    [Fact]
     public void Wpt_Harness_CustomElements_Can_Upgrade_Parsed_ShadowTree_Nodes()
     {
         var testHtml = @"<!DOCTYPE html>

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -3644,6 +3644,46 @@ input {
     }
 
     [Fact]
+    public void Wpt_Harness_AsyncTest_Bodies_Do_Not_Run_In_Defer_Mode()
+    {
+        // Regression: the reference generator does not load testharness.js, so
+        // `async_test` is undefined there and the script aborts at its call —
+        // the body never mutates the DOM before the screenshot. The runner's
+        // stub must mirror that in reference-matching (defer) mode. Previously
+        // the async_test stub ran its body unconditionally, so an async_test
+        // that flips `<link disabled>` on (HTMLLinkElement-disabled-00{1,2,4,5})
+        // applied the green sheet — with no onload to revert it — leaving a
+        // green render against a white reference (0.0% MissingContent).
+        var testHtml = @"<!DOCTYPE html>
+<script src=""/resources/testharness.js""></script>
+<link rel=""stylesheet"" disabled href=""data:text/css,html { background: green }"">
+<script>
+  const link = document.querySelector(""link[disabled]"");
+  async_test(function(t) {
+    // Enabling the sheet here must NOT reach the render in defer mode.
+    link.disabled = false;
+  }, ""async_test body must not run in defer mode"");
+</script>";
+        // Empty document → default white background, matching the reference the
+        // Chromium generator produces (the disabled sheet never applies).
+        var referenceHtml = @"<!DOCTYPE html><html></html>";
+
+        var previousDefer = WptTestRunner.DeferPromiseTests;
+        WptTestRunner.DeferPromiseTests = true;
+        try
+        {
+            var result = RunTempMatchTest(testHtml, referenceHtml, "wpt-harness-async-test-defer");
+            Assert.True(result.Passed,
+                "In defer mode the async_test body must not run, so <link disabled> " +
+                $"stays disabled and the page stays white. Match={result.MatchPercent:F1}% Message={result.Message}");
+        }
+        finally
+        {
+            WptTestRunner.DeferPromiseTests = previousDefer;
+        }
+    }
+
+    [Fact]
     public void Wpt_Harness_CustomElements_Can_Upgrade_Parsed_ShadowTree_Nodes()
     {
         var testHtml = @"<!DOCTYPE html>

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -435,8 +435,17 @@ internal sealed partial class WptTestRunner
   }
   if (typeof async_test === 'undefined') {
     window.async_test = function(func, name) {
-      var t = { step: function(f){try{f();}catch(e){}}, done: function(){}, step_func: function(f){return f;}, step_func_done: function(f){return f;}, step_timeout: function(f,d){try{f();}catch(e){}} };
-      if (func) { try { func(t); } catch(e) {} }
+      // Reference-matching (defer) mode: the reference generator does not load
+      // testharness.js, so `async_test` is undefined there and calling it throws,
+      // aborting the rest of the script before any test body mutates the DOM.
+      // Mirror that here — return an inert handle and do NOT run the body — so
+      // DOM-mutating assertions (e.g. HTMLLinkElement-disabled toggling <link
+      // disabled> on, which never gets reverted because onload doesn't fire) do
+      // not advance the captured DOM past the reference point. Matches the `test`
+      // and `promise_test` stubs, which likewise leave bodies un-run in this mode.
+      var defer = window.__broilerDeferPromiseTests;
+      var t = { step: function(f){ if(!defer){try{f();}catch(e){}} }, done: function(){}, step_func: function(f){return f;}, step_func_done: function(f){return f;}, step_timeout: function(f,d){ if(!defer){try{f();}catch(e){}} } };
+      if (func && !defer) { try { func(t); } catch(e) {} }
       return t;
     };
   }

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -424,32 +424,29 @@ internal sealed partial class WptTestRunner
 (function() {
   var __broilerPromiseTests = [];
   var __broilerWindowLoaded = false;
-  if (typeof test === 'undefined') {
-    // Chromium-matching mode: the reference generator does not load
-    // testharness.js, so `test` is undefined there and the test body never
-    // runs before the screenshot. Some bodies mutate the DOM (e.g. toggling a
-    // class that changes color-scheme), which would advance our captured DOM
-    // past the reference point. Leave them un-run so the snapshot reflects the
-    // initial post-load state (mirrors the promise_test stub below).
+  // Reference-matching (defer) mode: the reference generator does not load
+  // testharness.js, so `test`/`async_test`/`promise_test` are undefined there and
+  // the first call to one throws — aborting the rest of that <script> block before
+  // any test body, or any post-call DOM mutation, runs. A stub that merely no-ops
+  // instead of throwing lets that later code run (e.g. interpolation-testcommon.js
+  // `create_tests()` removing its container of test boxes after calling test(), or
+  // an HTMLLinkElement-disabled async_test toggling `<link disabled>` on), advancing
+  // our captured DOM past the reference point. So in defer mode we leave these three
+  // undefined too, matching the reference generator; each <script> is eval'd in its
+  // own try/catch, so the throw aborts only that block (exactly as in a browser).
+  // Outside defer mode they are stubbed so local renders still exercise the bodies.
+  var __defer = window.__broilerDeferPromiseTests;
+  if (typeof test === 'undefined' && !__defer) {
     window.test = function(func, name) {};
   }
-  if (typeof async_test === 'undefined') {
+  if (typeof async_test === 'undefined' && !__defer) {
     window.async_test = function(func, name) {
-      // Reference-matching (defer) mode: the reference generator does not load
-      // testharness.js, so `async_test` is undefined there and calling it throws,
-      // aborting the rest of the script before any test body mutates the DOM.
-      // Mirror that here — return an inert handle and do NOT run the body — so
-      // DOM-mutating assertions (e.g. HTMLLinkElement-disabled toggling <link
-      // disabled> on, which never gets reverted because onload doesn't fire) do
-      // not advance the captured DOM past the reference point. Matches the `test`
-      // and `promise_test` stubs, which likewise leave bodies un-run in this mode.
-      var defer = window.__broilerDeferPromiseTests;
-      var t = { step: function(f){ if(!defer){try{f();}catch(e){}} }, done: function(){}, step_func: function(f){return f;}, step_func_done: function(f){return f;}, step_timeout: function(f,d){ if(!defer){try{f();}catch(e){}} } };
-      if (func && !defer) { try { func(t); } catch(e) {} }
+      var t = { step: function(f){try{f();}catch(e){}}, done: function(){}, step_func: function(f){return f;}, step_func_done: function(f){return f;}, step_timeout: function(f,d){try{f();}catch(e){}} };
+      if (func) { try { func(t); } catch(e) {} }
       return t;
     };
   }
-  if (typeof promise_test === 'undefined') {
+  if (typeof promise_test === 'undefined' && !__defer) {
     function __broilerRunPromiseTest(func) {
       // Chromium-matching mode: the reference generator screenshots at `load`,
       // before any promise_test body runs. Those bodies are assertions that


### PR DESCRIPTION
## Summary

This PR implements four major CSS/DOM features and fixes for the renderer:

1. **Web Animations API** (`element.animate()`) — snapshot-time evaluation and keyframe interpolation
2. **CSS colour-matrix filters** — invert, grayscale, brightness, contrast, sepia, saturate, opacity, hue-rotate
3. **Render-time `@import` resolution** — inline imported stylesheet text so the renderer sees imported rules
4. **Constructable stylesheets** — `new CSSStyleSheet()` and `document.adoptedStyleSheets`

Plus supporting fixes for non-uniform scale transforms, `<base href>` stylesheet URL resolution, and text-bearing opacity/blend layers.

## Key Changes

### Web Animations (`src/Broiler.HtmlBridge.Dom/DomBridge/WebAnimations.cs`)
- `ElementAnimate()` parses keyframes and timing options, computes snapshot-time progress (accounting for delay), and interpolates property values at that point
- Supports animatable properties: transform, opacity, color, background, dimensions, positioning, margins, padding, border-radius, font metrics, filter
- Transform interpolation handles `translate()`, `scale()`, `rotate()`, `skew()` with component-wise matching
- Bakes interpolated values into inline style; never throws (malformed keyframes are inert)

### CSS Colour-Matrix Filters (`patches/0028-html-color-matrix-filters.patch`)
- `ApplyColorFilter()` walks filter function list left-to-right, applying Filter Effects §16 matrices
- Supports: `invert()`, `grayscale()`, `brightness()`, `contrast()`, `sepia()`, `saturate()`, `opacity()`, `hue-rotate()`
- Amounts accept numbers and percentages; hue-rotate accepts deg/rad/grad/turn
- Emits `FilterItem`/`RestoreFilterItem` around compositing groups; raster backend applies filters at composite time
- Gracefully degrades: unsupported functions (blur, drop-shadow, url) leave content unfiltered rather than losing it

### Stylesheet `@import` Inlining (`src/Broiler.HtmlBridge.Dom/DomBridge/StyleImports.cs`)
- Scans leading `@import` statements in `<style>` elements and fetches imported sheets
- Recursively expands nested imports with cycle detection (per-chain tracking)
- Rebases relative `url()` references in imported content onto the imported sheet's URL
- Wraps media-qualified imports in `@media` blocks
- Runs at serialization time so renderer sees imported rules in cascade order

### Constructable Stylesheets (`src/Broiler.HtmlBridge.Dom/DomBridge/ConstructedStyleSheets.cs`)
- `new CSSStyleSheet()` creates an empty constructed sheet with `insertRule()`, `deleteRule()`, `replaceSync()`, `replace()` methods
- `document.adoptedStyleSheets` is a live array; adopted sheets emit as synthetic `<style>` elements after document stylesheets at serialization
- Constructed sheets carry their own rule list independent of DOM elements
- Supports cascade-correct application order (WPT `css/cssom` constructable family)

### Supporting Fixes
- **Non-uniform scale transforms** (`patches/0026-html-nonuniform-scale-raster.patch`): per-axis `_scaleX`/`_scaleY` in `BCanvas` so `scaleX()`, `scaleY()`, and `scale(x, y)` rasterize correctly
- **`<base href>` stylesheet URLs** (`src/Broiler.HtmlBridge.Dom/DomBridge/StyleBaseHref.cs`): rewrite relative `url()` in `<style>` against document's first `<base href>` during serialization
- **Text-bearing opacity/blend layers** (`patches/0025-html-opacity-blend-text-raster-layer.patch`): mark `DrawTextItem`/`DrawSvgTextItem` raster-compatible so text-bearing opacity/blend layers stay on

https://claude.ai/code/session_01KQTyn4LQB7bw1vdxMUywKb