### PR TITLE
Shadow DOM and replaced element rendering fixes

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngineTable.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngineTable.cs
@@ -189,6 +189,70 @@ internal sealed class CssLayoutEngineTable
 
         if (_footerBox != null)
             _allRows.AddRange(_footerBox.Boxes);
+
+        // CSS2.1 §17.2.1: within each row, a child that is not a table-cell (a
+        // block, inline, etc.) is wrapped — together with its consecutive
+        // non-cell siblings — in an anonymous table-cell box. GenerateAnonymousTableRows
+        // only wraps non-cell children of the *table*; a non-cell child of an
+        // explicit <div style="display:table-row"> was left uncelled and never laid
+        // out (WPT css-sizing/table-child-percentage-height-with-border-box).
+        foreach (var row in _allRows)
+            WrapRowNonCellChildrenInAnonymousCells(row, baseUrl);
+    }
+
+    /// <summary>
+    /// CSS2.1 §17.2.1: wraps each run of consecutive non-<c>table-cell</c> children of
+    /// <paramref name="row"/> in a single anonymous <c>table-cell</c> box, preserving
+    /// child order. A no-op when every child is already a table-cell.
+    /// </summary>
+    private void WrapRowNonCellChildrenInAnonymousCells(CssBox row, Uri baseUrl)
+    {
+        bool needsWrapping = false;
+        foreach (var child in row.Boxes)
+        {
+            if (child.Display != CssConstants.TableCell)
+            {
+                needsWrapping = true;
+                break;
+            }
+        }
+
+        if (!needsWrapping)
+            return;
+
+        var children = new List<CssBox>(row.Boxes);
+        row.Boxes.Clear();
+
+        List<CssBox>? pendingNonCell = null;
+
+        void FlushAnonymousCell()
+        {
+            if (pendingNonCell == null)
+                return;
+
+            // The CssBox(parent, tag) constructor appends the new cell to row.Boxes,
+            // keeping it in order after any real cells already re-added.
+            var anonCell = new CssBox(row, null, baseUrl) { Display = CssConstants.TableCell };
+            foreach (var child in pendingNonCell)
+                child.ParentBox = anonCell;
+            pendingNonCell = null;
+        }
+
+        foreach (var child in children)
+        {
+            if (child.Display == CssConstants.TableCell)
+            {
+                FlushAnonymousCell();
+                row.Boxes.Add(child);
+            }
+            else
+            {
+                pendingNonCell ??= [];
+                pendingNonCell.Add(child);
+            }
+        }
+
+        FlushAnonymousCell();
     }
 
     /// <summary>
@@ -1033,6 +1097,7 @@ internal sealed class CssLayoutEngineTable
                 cell.ActualBottom = newBottom;
                 cell.Size = new SizeF(cell.Size.Width, (float)(newBottom - cell.Location.Y));
 
+                ResolveCellPercentageHeightChildren(g, cell);
                 CssLayoutEngine.ApplyCellVerticalAlignment(g, cell);
             }
 
@@ -1040,6 +1105,61 @@ internal sealed class CssLayoutEngineTable
         }
 
         return naturalBottom + surplus;
+    }
+
+    /// <summary>
+    /// CSS2.1 §17.5.3 / §10.5: a table cell's used height is only known after the
+    /// row-height pass, so a percentage-height in-flow child laid out during the cell's
+    /// own <c>PerformLayout</c> (when the cell was still content-sized) resolved its
+    /// height against an indefinite base and fell back to its content height. Once the
+    /// cell has been stretched to its final height, make that height definite and re-run
+    /// the cell layout so such children resolve against — and fill — the cell (WPT
+    /// css-sizing/table-child-percentage-height-with-border-box). The original CSS
+    /// <c>height</c> is restored afterwards so a later full relayout pass re-derives it
+    /// naturally rather than inheriting this pass's pixel value.
+    /// </summary>
+    private void ResolveCellPercentageHeightChildren(ILayoutEnvironment g, CssBox cell)
+    {
+        if (cell is CssSpacingBox || !CellHasPercentageHeightChild(cell))
+            return;
+
+        double finalBorderBoxHeight = cell.ActualBottom - cell.Location.Y;
+        if (finalBorderBoxHeight <= 0)
+            return;
+
+        double edges = cell.ActualBorderTopWidth + cell.ActualBorderBottomWidth
+            + cell.ActualPaddingTop + cell.ActualPaddingBottom;
+        double cssHeight = string.Equals(cell.BoxSizing, "border-box", StringComparison.OrdinalIgnoreCase)
+            ? finalBorderBoxHeight
+            : Math.Max(0, finalBorderBoxHeight - edges);
+
+        string savedHeight = cell.Height;
+        var savedLocation = cell.Location;
+        cell.Height = cssHeight.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture) + "px";
+        cell.PerformLayout(g);
+        // Keep the finalized cell geometry; only the children needed re-resolution.
+        cell.Height = savedHeight;
+        cell.Location = savedLocation;
+        cell.ActualBottom = savedLocation.Y + finalBorderBoxHeight;
+        cell.Size = new SizeF(cell.Size.Width, (float)finalBorderBoxHeight);
+    }
+
+    /// <summary>Whether <paramref name="cell"/> has an in-flow child whose <c>height</c>
+    /// is a percentage — the case that needs re-resolution once the cell height is final.</summary>
+    private static bool CellHasPercentageHeightChild(CssBox cell)
+    {
+        foreach (var child in cell.Boxes)
+        {
+            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+                continue;
+            if (child.Display == CssConstants.None)
+                continue;
+            var h = child.Height;
+            if (!string.IsNullOrEmpty(h) && h.EndsWith("%", StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
     }
 
     private double GetSpannedMinWidth(CssBox row, int realcolindex, int colspan)

--- a/src/Broiler.Cli.Tests/MetaColorSchemeShadowTreeTests.cs
+++ b/src/Broiler.Cli.Tests/MetaColorSchemeShadowTreeTests.cs
@@ -1,0 +1,59 @@
+using Broiler.HtmlBridge;
+using Broiler.HTML.Image;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// A <c>&lt;meta name="color-scheme"&gt;</c> inside a shadow tree must NOT affect the document's
+/// color scheme — WPT
+/// <c>html/semantics/document-metadata/the-meta-element/color-scheme/meta-color-scheme-single-value-in-shadow-tree</c>.
+/// The meta color-scheme metadata is a document-tree concept; a meta in a shadow tree is scoped
+/// away and the root stays the light UA default.
+/// </summary>
+public class MetaColorSchemeShadowTreeTests
+{
+    private static (int R, int G, int B) RenderCanvasCenter(string script)
+    {
+        const string html = "<!DOCTYPE html><html><head></head><body></body></html>";
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///test.html");
+        context.Eval(script);
+        var serialized = bridge.SerializeToHtml();
+        using var bmp = HtmlRender.RenderToImageWithStyleSet(serialized, 100, 100);
+        var c = bmp.GetPixel(50, 50);
+        return (c.R, c.G, c.B);
+    }
+
+    [Fact]
+    public void MetaColorScheme_InShadowTree_DoesNotDarkenCanvas()
+    {
+        // Attach a shadow root and insert <meta name=color-scheme content=dark> into it. Per spec
+        // this is scoped to the shadow tree and does not set the document's color scheme, so the
+        // canvas stays the light UA default (white) rather than the dark UA canvas rgb(18,18,18).
+        var (r, g, b) = RenderCanvasCenter("""
+            var host = document.createElement('div');
+            document.body.appendChild(host);
+            var root = host.attachShadow({ mode: 'open' });
+            var meta = document.createElement('meta');
+            meta.setAttribute('name', 'color-scheme');
+            meta.setAttribute('content', 'dark');
+            root.appendChild(meta);
+        """);
+        Assert.True((r, g, b) == (255, 255, 255), $"expected light canvas, was {r},{g},{b}");
+    }
+
+    [Fact]
+    public void MetaColorScheme_InDocumentHead_DarkensCanvas()
+    {
+        // Control: the same meta in the document head DOES set a dark color scheme.
+        var (r, g, b) = RenderCanvasCenter("""
+            var meta = document.createElement('meta');
+            meta.setAttribute('name', 'color-scheme');
+            meta.setAttribute('content', 'dark');
+            document.head.appendChild(meta);
+        """);
+        Assert.True((r, g, b) == (18, 18, 18), $"expected dark canvas, was {r},{g},{b}");
+    }
+}

--- a/src/Broiler.Cli.Tests/ShadowRootInnerHtmlTests.cs
+++ b/src/Broiler.Cli.Tests/ShadowRootInnerHtmlTests.cs
@@ -1,0 +1,31 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Setting <c>innerHTML</c> on a shadow root must not inject marker nodes. The fragment parser
+/// was given the context element's tag name — <c>#shadow-root</c>, which is not an HTML element —
+/// so the round-trip came back with the unparsable open tag as a literal text node
+/// ("&lt;#shadow-root&gt;") plus a bogus comment. Both then rendered.
+/// </summary>
+public class ShadowRootInnerHtmlTests
+{
+    [Fact]
+    public void ShadowRoot_InnerHtml_ParsesWithoutMarkerNodes()
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, "<!DOCTYPE html><html><body><host-1>L</host-1></body></html>", "file:///t.html");
+
+        var result = context.Eval("""
+            var root = document.querySelector('host-1').attachShadow({ mode: 'open' });
+            root.innerHTML = '<style>x{}</style>';
+            var kinds = [];
+            for (var i = 0; i < root.childNodes.length; i++) kinds.push(root.childNodes[i].nodeName);
+            root.childNodes.length + ':' + kinds.join(',');
+        """).ToString();
+
+        Assert.Equal("1:STYLE", result);
+    }
+}

--- a/src/Broiler.Cli.Tests/StylesheetBaseHrefTests.cs
+++ b/src/Broiler.Cli.Tests/StylesheetBaseHrefTests.cs
@@ -1,0 +1,54 @@
+using Broiler.HtmlBridge;
+using Broiler.HTML.Image;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// A <c>&lt;link rel="stylesheet"&gt;</c> with a relative <c>href</c> must resolve against the
+/// document's <c>&lt;base href&gt;</c>, not the document's own directory — WPT
+/// <c>html/semantics/document-metadata/the-link-element/stylesheet-with-base</c>. The linked
+/// sheet, reachable only under the base-relative <c>resources/</c> directory, sets the page
+/// green; without base resolution the sheet 404s and the unstyled fallback shows through.
+/// </summary>
+public class StylesheetBaseHrefTests
+{
+    [Fact]
+    public void LinkedStylesheet_Href_ResolvesAgainstBaseHref()
+    {
+        var baseDir = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "broiler-basehref-" + System.Guid.NewGuid().ToString("N"));
+        var resourcesDir = System.IO.Path.Combine(baseDir, "resources");
+        System.IO.Directory.CreateDirectory(resourcesDir);
+        // The sheet exists ONLY under resources/ — reachable only if the link's relative href is
+        // resolved against <base href="resources/">, not the document's own directory.
+        System.IO.File.WriteAllText(
+            System.IO.Path.Combine(resourcesDir, "stylesheet.css"),
+            "body { background-color: green; }");
+        try
+        {
+            var pageUrl = new System.Uri(System.IO.Path.Combine(baseDir, "test.html")).AbsoluteUri;
+            const string html = """
+<!DOCTYPE html>
+<html>
+<head>
+<base href="resources/">
+<link rel="stylesheet" href="stylesheet.css">
+</head>
+<body></body>
+</html>
+""";
+            using var context = new JSContext();
+            var bridge = new DomBridge();
+            bridge.Attach(context, html, pageUrl);
+            var serialized = bridge.SerializeToHtml();
+            using var bmp = HtmlRender.RenderToImageWithStyleSet(serialized, 200, 200);
+            var c = bmp.GetPixel(100, 100);
+            Assert.True((c.R, c.G, c.B) == (0, 128, 0), $"expected green canvas, was {c.R},{c.G},{c.B}");
+        }
+        finally
+        {
+            try { System.IO.Directory.Delete(baseDir, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/src/Broiler.Cli.Tests/TablePercentHeightBorderBoxTests.cs
+++ b/src/Broiler.Cli.Tests/TablePercentHeightBorderBoxTests.cs
@@ -1,0 +1,37 @@
+using Broiler.HTML.Image;
+
+namespace Broiler.Cli.Tests;
+
+// WPT css/css-sizing/table-child-percentage-height-with-border-box: body is display:table
+// (border-box, 100%x100%), .content is a table-row (100% height, red), .wrapper is border-box
+// height:100% + padding-top:100px, green. Per the reference the green wrapper resolves to the
+// full row height and covers the red content — the viewport is entirely green.
+public class TablePercentHeightBorderBoxTests
+{
+    private const string Html = """
+<!DOCTYPE html>
+<html>
+<head><style>
+  html { height: 100%; width: 100%; }
+  body { box-sizing: border-box; display: table; margin: 0 auto; width: 100%; height: 100%; }
+  .content { box-sizing: border-box; display: table-row; width: 100%; height: 100%; background-color: red; }
+  .wrapper { box-sizing: border-box; width: 100%; height: 100%; background-color: green; padding-top: 100px; }
+</style></head>
+<body>
+  <div class="content"><div class="wrapper">wrapped content</div></div>
+</body>
+</html>
+""";
+
+    [Fact]
+    public void TableRowChild_PercentHeight_BorderBox_FillsRowGreen()
+    {
+        using var bmp = HtmlRender.RenderToImageWithStyleSet(Html, 300, 300);
+        // Below the 100px padding and near the bottom: the green wrapper must fill the whole
+        // table height, with no red (uncovered row) showing through.
+        var mid = bmp.GetPixel(150, 180);
+        var bottom = bmp.GetPixel(150, 290);
+        Assert.True((mid.R, mid.G, mid.B) == (0, 128, 0), $"mid expected green, was {mid.R},{mid.G},{mid.B}");
+        Assert.True((bottom.R, bottom.G, bottom.B) == (0, 128, 0), $"bottom expected green, was {bottom.R},{bottom.G},{bottom.B}");
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.DialogHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.DialogHost.cs
@@ -44,6 +44,8 @@ public sealed partial class DomBridge : IDialogHost
             // A fresh show clears any leftover "transitioning out" mark: if the element is now
             // transitioning `overlay` at all, it is transitioning *in*.
             DialogStateFor(element).PopoverTransitioningOut.Remove();
+            DialogStateFor(element).PopoverOverlayTransitionFinished.Remove();
+            ScheduleOverlayTransitionCompletion(element);
         }
         else
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -188,6 +188,13 @@ public sealed partial class DomBridge
         ApplyCssomStyleSheetMutations(root);
         InlineStyleSheetImports(root);
         ApplyAdoptedStyleSheets(root);
+        // A shadow root's <style> is serialized inline as a global rule, so its :host
+        // selectors must be rewritten to target that root's own host — otherwise the
+        // renderer's lenient :host matching paints every element.
+        ScopeShadowHostSelectors(root);
+        // A host's light-DOM children render only where a <slot> assigns them; with no slot in
+        // the shadow tree they generate no boxes.
+        HideUnslottedShadowHostChildren(root);
         ApplyBaseHrefToStyleUrls(root);
         ApplyMetaColorScheme(root);
         // Zoom baking is applied by the callers (GetRenderDocument/SerializeToHtml) before this,
@@ -195,6 +202,12 @@ public sealed partial class DomBridge
         // the baked sizes and must run after it.
         ApplyZoomPseudoSerializationOverrides(root);
         ApplyProgressLikeSerializationPlaceholders(root);
+        // Flatten the #shadow-root wrapper LAST: it is not an HTML element, so the renderer would
+        // paint its serialized "<#shadow-root>" open tag as literal text. It must run after every
+        // pass that reads shadow-tree ancestry — ApplyMetaColorScheme in particular skips a
+        // <meta name=color-scheme> inside a shadow tree, and unwrapping first moved that meta into
+        // the document tree and wrongly darkened the canvas.
+        UnwrapShadowRootsForRender(root);
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.cs
@@ -260,6 +260,11 @@ public sealed partial class DomBridge
             if (!TryGetAttribute(element, "name", out var name) ||
                 !name.Trim().Equals("color-scheme", StringComparison.OrdinalIgnoreCase))
                 continue;
+            // A meta in a shadow tree is not in the document tree (HTML §4.2.5.3), so it
+            // contributes no document-level color scheme (WPT
+            // meta-color-scheme-single-value-in-shadow-tree).
+            if (FindContainingShadowRoot(element) != null)
+                continue;
             if (TryGetAttribute(element, "content", out var content) &&
                 IsValidColorSchemeValue(content))
             {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -112,6 +112,12 @@ public sealed partial class DomBridge
         //      into the top layer (WPT modal-dialog-in-replaced-renderer).
         ReplaceElementsWithReplacedContent();
 
+        // -1c. An <object> with an image resource is a replaced element showing that resource;
+        //      its children are fallback and must not render. Also precedes the dialog passes so
+        //      a modal <dialog> in the fallback is never hoisted into the top layer
+        //      (WPT modal-dialog-in-object).
+        ReplaceImageObjectsWithResource();
+
         // 0. Apply UA default position:fixed to modal dialogs before anchor
         //    resolution, since browsers treat top-layer elements as fixed.
         ApplyDialogUAPositioning(DocumentElement);
@@ -351,6 +357,67 @@ public sealed partial class DomBridge
                 {
                     ["src"] = url,
                 });
+            SetParent(img, element);
+            element.AppendChild(img);
+        }
+    }
+
+    /// <summary>
+    /// HTML §4.8.4: an <c>&lt;object&gt;</c> whose resource loads is a replaced element showing that
+    /// resource; its child content is <em>fallback</em>, rendered only when the resource does not
+    /// load. Broiler renders neither half — an <c>&lt;object&gt;</c> with an image resource painted
+    /// nothing, while its fallback children (including a modal <c>&lt;dialog&gt;</c>, which was then
+    /// hoisted into the top layer) painted regardless. WPT
+    /// <c>html/semantics/interactive-elements/the-dialog-element/modal-dialog-in-object</c> needs
+    /// both: its reference is the bare <c>&lt;object&gt;</c> showing a green rectangle, with no dialog.
+    /// <para>
+    /// Reproduce the visual result the same way the sibling <c>content</c> passes do: swap the
+    /// fallback for a single <c>&lt;img&gt;</c> of the resource, carrying the object's
+    /// <c>width</c>/<c>height</c> across so the replaced box keeps its authored size.
+    /// </para>
+    /// <para>
+    /// Deliberately gated on an explicit <c>type="image/*"</c> attribute. Fallback exists precisely
+    /// so a failed resource can degrade, and Acid2 depends on that: its eyes are nested
+    /// <c>&lt;object&gt;</c>s whose outer resources must fail
+    /// (<c>data:application/x-unknown</c> with no <c>type</c>, and a 404 with
+    /// <c>type="text/html"</c>) so the inner fallback shows. None of those carries an
+    /// <c>image/*</c> type, so this pass cannot disturb them.
+    /// </para>
+    /// </summary>
+    private void ReplaceImageObjectsWithResource()
+    {
+        var root = DocumentElement;
+        if (root == null)
+            return;
+
+        var objects = root.Descendants()
+            .OfType<DomElement>()
+            .Where(e => e.TagName.Equals("object", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        foreach (var element in objects)
+        {
+            if (!TryGetAttribute(element, "type", out var type) ||
+                !type.Trim().StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (!TryGetAttribute(element, "data", out var data) || string.IsNullOrWhiteSpace(data))
+                continue;
+
+            var attributes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["src"] = data.Trim(),
+            };
+
+            // Keep the authored replaced-box size (the object's own width/height).
+            if (TryGetAttribute(element, "width", out var width) && !string.IsNullOrWhiteSpace(width))
+                attributes["width"] = width.Trim();
+            if (TryGetAttribute(element, "height", out var height) && !string.IsNullOrWhiteSpace(height))
+                attributes["height"] = height.Trim();
+
+            ClearChildren(element);
+
+            var img = CreateBridgeElement("img", attributes: attributes);
             SetParent(img, element);
             element.AppendChild(img);
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/AnchorResolver.cs
@@ -106,6 +106,12 @@ public sealed partial class DomBridge
         //     the document body with a single <img> at the origin.
         ReplaceRootWithReplacedContent();
 
+        // -1b. The same element replacement for non-root elements: the element renders the
+        //      image and its children generate no boxes. Must precede the dialog/popover
+        //      passes below so a modal <dialog> inside a replaced element is never hoisted
+        //      into the top layer (WPT modal-dialog-in-replaced-renderer).
+        ReplaceElementsWithReplacedContent();
+
         // 0. Apply UA default position:fixed to modal dialogs before anchor
         //    resolution, since browsers treat top-layer elements as fixed.
         ApplyDialogUAPositioning(DocumentElement);
@@ -289,6 +295,94 @@ public sealed partial class DomBridge
             });
         SetParent(img, body);
         body.AppendChild(img);
+    }
+
+    /// <summary>
+    /// Tags whose rendering is already replaced (or which generate no box at all), so CSS
+    /// Content 3 element replacement does not apply to them here.
+    /// </summary>
+    private static readonly HashSet<string> ContentReplacementSkipTags =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "area", "audio", "base", "br", "canvas", "col", "embed", "head", "hr", "iframe",
+            "img", "input", "link", "meta", "object", "param", "script", "select", "source",
+            "style", "textarea", "title", "track", "video",
+        };
+
+    /// <summary>
+    /// CSS Content 3 §"content" element replacement for non-root elements: an element whose
+    /// computed <c>content</c> is a replaced value (an image <c>url()</c>) is replaced by that
+    /// image, and — critically — <em>its children generate no boxes</em>.
+    /// <para>
+    /// Broiler does not model non-pseudo element replacement in layout (see
+    /// <see cref="ReplaceRootWithReplacedContent"/>, which reproduces the root case the same
+    /// way), so reproduce the visual result here: drop the element's children and give it a
+    /// single <c>&lt;img&gt;</c> of the replaced image.
+    /// </para>
+    /// <para>
+    /// Both halves matter for WPT
+    /// <c>html/semantics/interactive-elements/the-dialog-element/modal-dialog-in-replaced-renderer</c>,
+    /// whose reference is simply the replaced image with no dialog: the image half was missing
+    /// (a <c>content:url()</c> div painted nothing), and the child-suppression half is what stops
+    /// a nested modal <c>&lt;dialog&gt;</c> from being hoisted into the top layer and painted —
+    /// an element inside a replaced renderer generates no box, top layer or not. Runs before
+    /// <see cref="ApplyDialogUAPositioning"/> and backdrop synthesis, so the removed dialog is
+    /// never stamped into the top layer and no <c>::backdrop</c> is synthesized for it.
+    /// </para>
+    /// </summary>
+    private void ReplaceElementsWithReplacedContent()
+    {
+        var root = DocumentElement;
+        if (root == null)
+            return;
+
+        List<(DomElement Element, string Url)>? pending = null;
+        CollectContentReplacedElements(root, ref pending, isRoot: true);
+        if (pending == null)
+            return;
+
+        foreach (var (element, url) in pending)
+        {
+            ClearChildren(element);
+
+            var img = CreateBridgeElement(
+                "img",
+                attributes: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["src"] = url,
+                });
+            SetParent(img, element);
+            element.AppendChild(img);
+        }
+    }
+
+    /// <summary>
+    /// Collects, in document order, every element to be replaced by its <c>content</c> image.
+    /// Does not descend into a collected element (its subtree is dropped anyway) and skips the
+    /// root, which <see cref="ReplaceRootWithReplacedContent"/> owns.
+    /// </summary>
+    private void CollectContentReplacedElements(
+        DomElement element, ref List<(DomElement Element, string Url)>? acc, bool isRoot)
+    {
+        if (!isRoot &&
+            !IsText(element) &&
+            !ContentReplacementSkipTags.Contains(element.TagName) &&
+            !element.TagName.Equals("html", StringComparison.OrdinalIgnoreCase))
+        {
+            var content = GetComputedProps(element).GetValueOrDefault("content")?.Trim();
+            if (!string.IsNullOrEmpty(content))
+            {
+                var url = ExtractContentImageUrl(content);
+                if (url != null)
+                {
+                    (acc ??= []).Add((element, url));
+                    return; // Subtree generates no boxes — nothing below to collect.
+                }
+            }
+        }
+
+        foreach (var child in ChildElements(element))
+            CollectContentReplacedElements(child, ref acc, isRoot: false);
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/AnchorResolver/Dialogs.cs
@@ -1,5 +1,7 @@
 using System.Runtime.CompilerServices;
 using Broiler.HtmlBridge.Dom.Runtime;
+using Broiler.JavaScript.BuiltIns.Function;
+using Broiler.JavaScript.Runtime;
 using Broiler.Dom;
 
 namespace Broiler.HtmlBridge;
@@ -493,7 +495,91 @@ public sealed partial class DomBridge
     {
         if (DialogStateFor(element).PopoverTransitioningOut.TryGet(out var out_) && out_ is true)
             return false;
+        // The entry transition has reached its deadline on the event loop — the element is in the
+        // top layer now (CSS Position 4 §overlay: `overlay` flips to `auto` when the discrete
+        // transition finishes).
+        if (DialogStateFor(element).PopoverOverlayTransitionFinished.TryGet(out var done) && done is true)
+            return false;
         return HasDiscreteOverlayTransition(element);
+    }
+
+    /// <summary>
+    /// Schedules the end of a popover's entry <c>overlay</c> transition on the event loop, so the
+    /// element enters the top layer once the transition's duration elapses.
+    /// <para>
+    /// The completion is a real timer rather than a duration heuristic, which is what makes the two
+    /// cases fall out correctly: a page that drains its event loop (the WPT runner, and any page
+    /// that waits for <c>transitionend</c> before screenshotting) reaches the deadline and paints
+    /// the popover on top, while a render taken without draining timers still sees the transition
+    /// running and keeps the popover — and its <c>::backdrop</c> — out of the top layer.
+    /// </para>
+    /// </summary>
+    private void ScheduleOverlayTransitionCompletion(DomElement element)
+    {
+        if (!HasDiscreteOverlayTransition(element))
+            return;
+
+        var durationMs = OverlayTransitionDurationMs(element);
+        if (durationMs is null)
+            return;
+
+        _eventLoop.SetTimeout(
+            new JSFunction((in Arguments _) =>
+            {
+                DialogStateFor(element).PopoverOverlayTransitionFinished.Set(true);
+                return JSUndefined.Value;
+            }, "overlayTransitionEnd", 0),
+            durationMs.Value);
+    }
+
+    /// <summary>
+    /// The declared duration of the element's <c>overlay</c> transition in milliseconds, read from
+    /// <c>transition-duration</c> or the first time value in the <c>transition</c> shorthand.
+    /// <c>null</c> when no duration is declared (nothing to schedule).
+    /// </summary>
+    private double? OverlayTransitionDurationMs(DomElement element)
+    {
+        var props = GetComputedProps(element);
+        foreach (var source in new[]
+                 {
+                     props.GetValueOrDefault("transition-duration", string.Empty),
+                     props.GetValueOrDefault("transition", string.Empty),
+                 })
+        {
+            if (string.IsNullOrWhiteSpace(source))
+                continue;
+
+            foreach (var token in source.Split(new[] { ' ', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (TryParseTimeMs(token, out var ms))
+                    return ms;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Parses a CSS time token (<c>0.1s</c> / <c>100ms</c>) to milliseconds.</summary>
+    private static bool TryParseTimeMs(string token, out double milliseconds)
+    {
+        milliseconds = 0;
+        var culture = System.Globalization.CultureInfo.InvariantCulture;
+
+        if (token.EndsWith("ms", StringComparison.OrdinalIgnoreCase))
+        {
+            return double.TryParse(token[..^2], System.Globalization.NumberStyles.Float, culture, out milliseconds);
+        }
+
+        if (token.EndsWith("s", StringComparison.OrdinalIgnoreCase))
+        {
+            if (double.TryParse(token[..^1], System.Globalization.NumberStyles.Float, culture, out var seconds))
+            {
+                milliseconds = seconds * 1000;
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // CSS Position 4 §overlay: the computed value of the UA-controlled `overlay` property.

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/HtmlFragmentMutation.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/HtmlFragmentMutation.cs
@@ -265,6 +265,15 @@ public sealed partial class DomBridge
         if (HtmlSerializer.VoidElements.Contains(contextTag))
             return false;
 
+        // A bridge-internal container (a '#'-prefixed name such as #shadow-root) is not an HTML
+        // element, so it cannot be a fragment parsing context: the parser round-trips the context
+        // tag, and "<#shadow-root>" is unparsable — it came back as a literal text node plus a
+        // bogus comment, which then rendered as visible "<#shadow-root>" text inside every shadow
+        // host (the css/css-shadow reftest family). Parse in a neutral container context instead;
+        // a shadow root imposes no special content model of its own.
+        if (contextTag.StartsWith('#'))
+            contextTag = "div";
+
         var (fragment, _) = BuildFragmentTree(html, contextTag);
         container = fragment;
         return true;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/RuntimeStates.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/RuntimeStates.cs
@@ -121,12 +121,20 @@ internal sealed class DialogRuntimeState
     // finishes) — both have PopoverOpen set and the same transition declarations.
     public RuntimeValue<bool> PopoverTransitioningOut { get; } = new();
 
+    // CSS Position §overlay: set when the entry `overlay` transition scheduled at showPopover() has
+    // reached its deadline on the event loop, so the element is now in the top layer. Without it a
+    // discrete `overlay` transition held the popover out of the top layer forever — the transition
+    // finishing was never modelled (WPT css/css-position/overlay/overlay-transition-finished, which
+    // screenshots from its `transitionend` handler and expects the popover on top).
+    public RuntimeValue<bool> PopoverOverlayTransitionFinished { get; } = new();
+
     public void CopyTo(DialogRuntimeState target)
     {
         Modal.CopyTo(target.Modal);
         TopLayerOrder.CopyTo(target.TopLayerOrder);
         PopoverOpen.CopyTo(target.PopoverOpen);
         PopoverTransitioningOut.CopyTo(target.PopoverTransitioningOut);
+        PopoverOverlayTransitionFinished.CopyTo(target.PopoverOverlayTransitionFinished);
     }
 }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowHostSelectors.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowHostSelectors.cs
@@ -1,0 +1,336 @@
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Broiler.Dom;
+
+namespace Broiler.HtmlBridge;
+
+/// <summary>
+/// Render-time scoping of <c>:host</c> selectors (CSS Scoping 1 §3.1).
+/// <para>
+/// A shadow root's <c>&lt;style&gt;</c> is serialized inline into the render document, so the
+/// renderer sees its rules as ordinary global rules. The renderer's selector matcher lists
+/// <c>host</c>/<c>host-context</c> as recognised-but-unmodelled pseudo-classes, which are
+/// deliberately lenient and therefore match <em>every</em> element — so a single
+/// <c>:host { background: red }</c> in any shadow tree painted the whole document red (the
+/// <c>css/css-shadow</c> reftest family, e.g. <c>css-scoping-shadow-host-functional-rule</c>,
+/// whose five hosts must all end up green).
+/// </para>
+/// <para>
+/// The renderer cannot fix this by itself: it has no rule provenance, so it cannot tell which
+/// shadow tree a rule came from — and because the rules are global, one host's
+/// <c>:host(other-host)</c> rule would still match a <em>different</em> host. That knowledge
+/// exists only here, where the owning <c>#shadow-root</c> is known, so rewrite each
+/// <c>:host</c> selector to target exactly that root's host element:
+/// </para>
+/// <list type="bullet">
+///   <item><c>:host</c> → <c>[data-broiler-shadow-host="N"]</c></item>
+///   <item><c>:host(&lt;compound&gt;)</c> → <c>&lt;compound&gt;[data-broiler-shadow-host="N"]</c>,
+///         so the host must match the compound <em>and</em> be this root's host</item>
+///   <item><c>:host(&lt;complex&gt;)</c> (an argument containing a combinator, e.g.
+///         <c>:host(div host-3)</c>) is an invalid selector per the grammar
+///         (<c>&lt;compound-selector&gt;</c> only) and must match nothing</item>
+///   <item><c>:host-context(...)</c> is not modelled; it is neutralised to a never-matching
+///         selector rather than left to match everything</item>
+/// </list>
+/// <para>
+/// Matching the compound itself is delegated to the renderer, which already supports type,
+/// class, id and attribute selectors — so <c>:host(host-2.foo#bar[name=baz])</c> needs no
+/// selector engine here. Only the render-bound serialization is affected; the live CSSOM and
+/// JS-visible <c>innerHTML</c> still expose the author's <c>:host</c> text.
+/// </para>
+/// </summary>
+public sealed partial class DomBridge
+{
+    /// <summary>Marker attribute identifying a shadow host, keyed per shadow root.</summary>
+    private const string ShadowHostAttr = "data-broiler-shadow-host";
+
+    /// <summary>
+    /// A syntactically valid selector that can never match: the marker attribute is only ever
+    /// stamped with a numeric token, so this sentinel value matches no element. Used for
+    /// <c>:host</c> forms that must not match (invalid arguments, unmodelled
+    /// <c>:host-context()</c>).
+    /// </summary>
+    private const string NeverMatchesSelector = "[" + ShadowHostAttr + "=\"none\"]";
+
+    private static string HostAttrSelector(string token) =>
+        "[" + ShadowHostAttr + "=\"" + token + "\"]";
+
+    /// <summary>
+    /// Rewrites <c>:host</c> selectors in every shadow root's <c>&lt;style&gt;</c> so they
+    /// target that root's host element instead of matching every element. A no-op for a
+    /// document with no shadow roots, and for a shadow tree whose styles use no <c>:host</c>.
+    /// </summary>
+    private void ScopeShadowHostSelectors(DomElement root)
+    {
+        var index = 0;
+
+        foreach (var element in root.Descendants().OfType<DomElement>())
+        {
+            if (!string.Equals(element.TagName, "#shadow-root", StringComparison.Ordinal))
+                continue;
+
+            var host = ParentEl(element);
+            if (host == null)
+                continue;
+
+            var token = index.ToString(CultureInfo.InvariantCulture);
+            index++;
+
+            var styles = new List<DomElement>();
+            CollectStylesInShadowRoot(element, styles);
+
+            var stamped = false;
+            foreach (var style in styles)
+            {
+                var original = GetStyleElementCssText(style);
+                var rewritten = RewriteHostSelectors(original, token);
+                if (string.Equals(rewritten, original, StringComparison.Ordinal))
+                    continue;
+
+                if (!stamped)
+                {
+                    SetAttr(host, ShadowHostAttr, token);
+                    stamped = true;
+                }
+
+                SetElementTextContent(style, rewritten);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Collects the <c>&lt;style&gt;</c> elements belonging to <paramref name="shadowRoot"/>,
+    /// without descending into a nested <c>#shadow-root</c> (whose styles are scoped to their
+    /// own host by that root's own pass).
+    /// </summary>
+    private void CollectStylesInShadowRoot(DomElement shadowRoot, List<DomElement> styles)
+    {
+        foreach (var child in ChildElements(shadowRoot))
+        {
+            if (IsText(child))
+                continue;
+
+            if (string.Equals(child.TagName, "#shadow-root", StringComparison.Ordinal))
+                continue;
+
+            if (child.TagName.Equals("style", StringComparison.OrdinalIgnoreCase))
+                styles.Add(child);
+
+            CollectStylesInShadowRoot(child, styles);
+        }
+    }
+
+    /// <summary>
+    /// Rewrites every <c>:host</c> / <c>:host(...)</c> / <c>:host-context(...)</c> occurrence in
+    /// <paramref name="css"/> for the shadow host identified by <paramref name="token"/>.
+    /// Occurrences inside strings and comments are left untouched.
+    /// </summary>
+    private static string RewriteHostSelectors(string css, string token)
+    {
+        if (string.IsNullOrEmpty(css) ||
+            css.IndexOf(":host", StringComparison.OrdinalIgnoreCase) < 0)
+            return css;
+
+        var sb = new StringBuilder(css.Length + 32);
+        var i = 0;
+        var n = css.Length;
+
+        while (i < n)
+        {
+            var c = css[i];
+
+            // Preserve strings verbatim — a `content: ":host"` value is not a selector.
+            if (c == '"' || c == '\'')
+            {
+                var quote = c;
+                sb.Append(c);
+                i++;
+                while (i < n)
+                {
+                    sb.Append(css[i]);
+                    if (css[i] == '\\' && i + 1 < n)
+                    {
+                        i++;
+                        if (i < n) sb.Append(css[i]);
+                        i++;
+                        continue;
+                    }
+                    if (css[i] == quote) { i++; break; }
+                    i++;
+                }
+                continue;
+            }
+
+            // Preserve comments verbatim.
+            if (c == '/' && i + 1 < n && css[i + 1] == '*')
+            {
+                var end = css.IndexOf("*/", i + 2, StringComparison.Ordinal);
+                end = end < 0 ? n : end + 2;
+                sb.Append(css, i, end - i);
+                i = end;
+                continue;
+            }
+
+            if (c == ':' && MatchesHostKeyword(css, i, out var afterKeyword, out var isHostContext))
+            {
+                // `:host-context(...)` is not modelled — neutralise it (it must not match
+                // everything). Its argument, when present, is consumed with it.
+                if (isHostContext)
+                {
+                    if (afterKeyword < n && css[afterKeyword] == '(')
+                        afterKeyword = SkipBalancedParens(css, afterKeyword);
+                    sb.Append(NeverMatchesSelector);
+                    i = afterKeyword;
+                    continue;
+                }
+
+                if (afterKeyword < n && css[afterKeyword] == '(')
+                {
+                    var close = SkipBalancedParens(css, afterKeyword);
+                    var args = css[(afterKeyword + 1)..(close - 1)].Trim();
+
+                    // `:host()` takes a <compound-selector>; an empty argument, a selector list,
+                    // or anything containing a combinator is invalid and matches nothing.
+                    if (args.Length == 0 || HasTopLevelCombinatorOrList(args))
+                        sb.Append(NeverMatchesSelector);
+                    else
+                        sb.Append(args).Append(HostAttrSelector(token));
+
+                    i = close;
+                    continue;
+                }
+
+                sb.Append(HostAttrSelector(token));
+                i = afterKeyword;
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Whether <paramref name="css"/> at <paramref name="pos"/> (a <c>:</c>) begins the
+    /// <c>:host</c> or <c>:host-context</c> pseudo-class — and not merely an identifier that
+    /// starts with those letters (e.g. <c>:hostile</c>).
+    /// </summary>
+    private static bool MatchesHostKeyword(string css, int pos, out int afterKeyword, out bool isHostContext)
+    {
+        afterKeyword = pos;
+        isHostContext = false;
+
+        const string host = ":host";
+        const string hostContext = ":host-context";
+
+        if (string.Compare(css, pos, hostContext, 0, hostContext.Length, StringComparison.OrdinalIgnoreCase) == 0 &&
+            !IsIdentChar(CharAt(css, pos + hostContext.Length)))
+        {
+            afterKeyword = pos + hostContext.Length;
+            isHostContext = true;
+            return true;
+        }
+
+        if (string.Compare(css, pos, host, 0, host.Length, StringComparison.OrdinalIgnoreCase) == 0 &&
+            !IsIdentChar(CharAt(css, pos + host.Length)))
+        {
+            afterKeyword = pos + host.Length;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static char CharAt(string s, int i) => i < s.Length ? s[i] : '\0';
+
+    /// <summary>Whether <paramref name="c"/> can continue a CSS identifier (so <c>:host-context</c>
+    /// is not mistaken for <c>:host</c> followed by <c>-context</c>).</summary>
+    private static bool IsIdentChar(char c) =>
+        char.IsLetterOrDigit(c) || c == '-' || c == '_' || c > 0x7F;
+
+    /// <summary>Returns the index just past the <c>)</c> matching the <c>(</c> at
+    /// <paramref name="open"/>, ignoring parentheses inside strings.</summary>
+    private static int SkipBalancedParens(string css, int open)
+    {
+        var depth = 0;
+        var i = open;
+        var n = css.Length;
+
+        while (i < n)
+        {
+            var c = css[i];
+            if (c == '"' || c == '\'')
+            {
+                var quote = c;
+                i++;
+                while (i < n && css[i] != quote)
+                {
+                    if (css[i] == '\\' && i + 1 < n) i++;
+                    i++;
+                }
+                i++;
+                continue;
+            }
+
+            if (c == '(') depth++;
+            else if (c == ')')
+            {
+                depth--;
+                if (depth == 0) return i + 1;
+            }
+
+            i++;
+        }
+
+        return n;
+    }
+
+    /// <summary>
+    /// Whether a <c>:host()</c> argument is something other than a single compound selector —
+    /// i.e. it contains a descendant/child/sibling combinator or a comma — scanning only at the
+    /// top level (inside <c>[...]</c>, <c>(...)</c> and strings does not count, so
+    /// <c>host-2.foo#bar[name=baz]</c> and <c>:not(.a)</c> stay compound).
+    /// </summary>
+    private static bool HasTopLevelCombinatorOrList(string args)
+    {
+        var parenDepth = 0;
+        var bracketDepth = 0;
+        var i = 0;
+        var n = args.Length;
+
+        while (i < n)
+        {
+            var c = args[i];
+
+            if (c == '"' || c == '\'')
+            {
+                var quote = c;
+                i++;
+                while (i < n && args[i] != quote)
+                {
+                    if (args[i] == '\\' && i + 1 < n) i++;
+                    i++;
+                }
+                i++;
+                continue;
+            }
+
+            if (c == '(') parenDepth++;
+            else if (c == ')') parenDepth--;
+            else if (c == '[') bracketDepth++;
+            else if (c == ']') bracketDepth--;
+            else if (parenDepth == 0 && bracketDepth == 0 &&
+                     (char.IsWhiteSpace(c) || c == '>' || c == '+' || c == '~' || c == ','))
+            {
+                return true;
+            }
+
+            i++;
+        }
+
+        return false;
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowSlotRendering.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ShadowSlotRendering.cs
@@ -1,0 +1,142 @@
+using System.Linq;
+using Broiler.Dom;
+
+namespace Broiler.HtmlBridge;
+
+/// <summary>
+/// Render-time flattening of a shadow host's light-DOM children (DOM §4.2.2 "slottable" /
+/// CSS Scoping 1 §3.3).
+/// <para>
+/// A host's light-DOM children do not render in their own right: they render only where a
+/// <c>&lt;slot&gt;</c> in the shadow tree assigns them. The serializer emits the host's light
+/// children <em>and</em> its <c>#shadow-root</c> side by side, so a shadow tree with no
+/// <c>&lt;slot&gt;</c> at all still painted the light children — the WPT
+/// <c>css/css-shadow</c> family's standard "FAIL" text, which the references never show
+/// (<c>css-scoping-shadow-root-hides-children</c>, and the leftover text inside the green box
+/// of <c>css-scoping-shadow-host-functional-rule</c>).
+/// </para>
+/// <para>
+/// This handles the unambiguous half: when the shadow tree exposes no slot, nothing can be
+/// assigned, so the host's light children generate no boxes and are dropped from the
+/// render-bound tree. A shadow tree that <em>does</em> contain a slot is left alone — placing
+/// each child at its assigned slot is full slot flattening, which this does not attempt.
+/// Only the render-bound serialization is affected; the live DOM and JS-visible
+/// <c>innerHTML</c> still expose the light children.
+/// </para>
+/// </summary>
+public sealed partial class DomBridge
+{
+    /// <summary>
+    /// Drops the light-DOM children of every shadow host whose shadow tree contains no
+    /// <c>&lt;slot&gt;</c>. A no-op for a document with no shadow roots.
+    /// </summary>
+    private void HideUnslottedShadowHostChildren(DomElement root)
+    {
+        var shadowRoots = root.Descendants()
+            .OfType<DomElement>()
+            .Where(e => string.Equals(e.TagName, "#shadow-root", StringComparison.Ordinal))
+            .ToList();
+
+        foreach (var shadowRoot in shadowRoots)
+        {
+            var host = ParentEl(shadowRoot);
+            if (host == null)
+                continue;
+
+            // A slot somewhere in this shadow tree can assign the light children — leave them
+            // in place rather than dropping content the author expects to see.
+            if (ShadowTreeHasSlot(shadowRoot))
+                continue;
+
+            foreach (var child in host.ChildNodes.ToArray())
+            {
+                if (ReferenceEquals(child, shadowRoot))
+                    continue;
+
+                host.RemoveChild(child);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Replaces each <c>#shadow-root</c> element with its children, in place, for the
+    /// render-bound tree.
+    /// <para>
+    /// <c>#shadow-root</c> is a bridge-internal container, not an HTML element, and it is
+    /// serialized literally as <c>&lt;#shadow-root&gt;</c>. Per the HTML tokenizer a <c>&lt;</c>
+    /// followed by anything that is not an ASCII letter (or <c>!</c>, <c>/</c>, <c>?</c>) is not a
+    /// tag at all — it is emitted as character data — so the renderer painted the literal string
+    /// "&lt;#shadow-root&gt;" inside every shadow host. Flattening the wrapper away puts the
+    /// shadow content directly in the host, which is what the renderer should draw.
+    /// </para>
+    /// <para>
+    /// Deliberately limited to shadow trees with no <c>&lt;slot&gt;</c> — the same set
+    /// <see cref="HideUnslottedShadowHostChildren"/> acts on. Flattening the wrapper moves the
+    /// shadow content into the host, which changes the ancestor chain that slot assignment and
+    /// scroll-container resolution walk; restricting it to slotless trees leaves every
+    /// slot-bearing shadow tree byte-identical to its previous rendering, so this cannot disturb
+    /// slot behaviour. Slotless trees have no assignment to preserve, so the flatten is safe
+    /// there and is what the <c>css/css-shadow</c> <c>:host</c> reftests need.
+    /// </para>
+    /// <para>
+    /// Runs after the other shadow passes, which locate content by the <c>#shadow-root</c>
+    /// wrapper. Only the render-bound serialization is affected.
+    /// </para>
+    /// </summary>
+    private void UnwrapShadowRootsForRender(DomElement root)
+    {
+        var shadowRoots = root.Descendants()
+            .OfType<DomElement>()
+            .Where(e => string.Equals(e.TagName, "#shadow-root", StringComparison.Ordinal))
+            .Where(e => !ShadowTreeHasSlot(e))
+            .ToList();
+
+        // Innermost first, so unwrapping a nested root is not disturbed by its ancestor moving.
+        shadowRoots.Reverse();
+
+        foreach (var shadowRoot in shadowRoots)
+        {
+            var host = ParentEl(shadowRoot);
+            if (host == null)
+                continue;
+
+            var index = ChildIndexOf(host, shadowRoot);
+            if (index < 0)
+                continue;
+
+            RemoveNthChild(host, index);
+            SetParent(shadowRoot, null);
+
+            foreach (var child in shadowRoot.ChildNodes.ToArray())
+            {
+                InsertChildAt(host, index, child);
+                index++;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="shadowRoot"/>'s tree contains a <c>&lt;slot&gt;</c>, not
+    /// descending into a nested <c>#shadow-root</c> (whose slots assign that root's own host's
+    /// children, not this one's).
+    /// </summary>
+    private bool ShadowTreeHasSlot(DomElement shadowRoot)
+    {
+        foreach (var child in ChildElements(shadowRoot))
+        {
+            if (IsText(child))
+                continue;
+
+            if (string.Equals(child.TagName, "#shadow-root", StringComparison.Ordinal))
+                continue;
+
+            if (child.TagName.Equals("slot", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (ShadowTreeHasSlot(child))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/StyleBaseHref.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/StyleBaseHref.cs
@@ -23,16 +23,19 @@ namespace Broiler.HtmlBridge;
 /// <see cref="InlineStyleSheetImports"/> (so inlined <c>@import</c> content — already rebased
 /// onto the imported sheet's own URL — carries absolute <c>url()</c>s this pass leaves alone).
 /// Only the render-bound serialization is affected; the live CSSOM rule model and JS-visible
-/// serialization are untouched. Only <c>&lt;style&gt;</c> <c>url()</c>s are rewritten today;
-/// element <c>src</c>/<c>href</c> attributes still resolve without <c>&lt;base&gt;</c>.
+/// serialization are untouched. <c>&lt;style&gt;</c> <c>url()</c>s and
+/// <c>&lt;link rel="stylesheet"&gt;</c> <c>href</c>s are rebased against <c>&lt;base&gt;</c>;
+/// other element <c>src</c>/<c>href</c> attributes still resolve without <c>&lt;base&gt;</c>.
 /// </para>
 /// </summary>
 public sealed partial class DomBridge
 {
     /// <summary>
     /// Rewrites relative <c>url()</c> references in every <c>&lt;style&gt;</c> in the tree
-    /// against the document's first <c>&lt;base href&gt;</c>. A no-op (byte-identical output)
-    /// when the document declares no usable <c>&lt;base href&gt;</c>.
+    /// against the document's first <c>&lt;base href&gt;</c>, and likewise resolves each
+    /// <c>&lt;link rel="stylesheet"&gt;</c>'s relative <c>href</c> so the linked sheet is
+    /// fetched from the base-relative location rather than the document's own directory. A
+    /// no-op (byte-identical output) when the document declares no usable <c>&lt;base href&gt;</c>.
     /// </summary>
     private void ApplyBaseHrefToStyleUrls(DomElement root)
     {
@@ -40,6 +43,47 @@ public sealed partial class DomBridge
             return;
 
         RewriteStyleElementUrls(root, baseHref);
+        RewriteLinkStyleSheetHrefs(root, baseHref);
+    }
+
+    /// <summary>
+    /// Resolves the relative <c>href</c> of every <c>&lt;link rel="stylesheet"&gt;</c> against
+    /// the document's first <c>&lt;base href&gt;</c>. The renderer resolves a linked sheet's
+    /// <c>href</c> against the document URL and never consults <c>&lt;base&gt;</c>, so
+    /// <c>&lt;base href="resources/"&gt;</c> before <c>&lt;link href="stylesheet.css"&gt;</c>
+    /// fetched the sheet from the document's own directory instead of <c>resources/</c> — it
+    /// was not found and the unstyled fallback showed through (WPT
+    /// <c>html/semantics/document-metadata/the-link-element/stylesheet-with-base</c>). Absolute,
+    /// <c>data:</c>, root-relative, and fragment hrefs are left untouched.
+    /// </summary>
+    private void RewriteLinkStyleSheetHrefs(DomElement root, string baseHref)
+    {
+        foreach (var element in root.Descendants().OfType<DomElement>())
+        {
+            if (!element.TagName.Equals("link", StringComparison.OrdinalIgnoreCase) ||
+                !LinkRelIsStyleSheet(element) ||
+                !TryGetAttribute(element, "href", out var href) ||
+                string.IsNullOrWhiteSpace(href))
+                continue;
+
+            var resolved = ResolveUrlAgainstBaseHref(href, baseHref);
+            if (resolved is not null)
+                SetAttr(element, "href", resolved);
+        }
+    }
+
+    /// <summary>Whether a <c>&lt;link&gt;</c>'s space-separated <c>rel</c> token list includes
+    /// <c>stylesheet</c> (case-insensitive), so only sheet links have their href re-based.</summary>
+    private static bool LinkRelIsStyleSheet(DomElement element)
+    {
+        if (!TryGetAttribute(element, "rel", out var rel) || string.IsNullOrWhiteSpace(rel))
+            return false;
+
+        foreach (var token in rel.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+            if (token.Equals("stylesheet", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+        return false;
     }
 
     /// <summary>The first <c>&lt;base&gt;</c> in document order with a non-empty

--- a/src/Broiler.Wpt.Tests/ElementContentReplacementTests.cs
+++ b/src/Broiler.Wpt.Tests/ElementContentReplacementTests.cs
@@ -1,0 +1,103 @@
+using System.IO;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression guard for CSS Content 3 element replacement on a non-root element
+/// (WPT html/semantics/interactive-elements/the-dialog-element/modal-dialog-in-replaced-renderer).
+///
+/// A <c>&lt;div&gt;</c> whose computed <c>content</c> is an image <c>url()</c> is replaced by
+/// that image, and its children generate no boxes. The test nests an open modal
+/// <c>&lt;dialog&gt;</c> (green background/border) inside such a div; the reference is simply the
+/// replaced image with no dialog at all, so the dialog must not be hoisted into the top layer
+/// and painted.
+///
+/// Broiler previously did neither half: the replaced image painted nothing, and the nested modal
+/// dialog was stamped into the top layer and painted as a wide green band. Implemented in
+/// <c>DomBridge.ReplaceElementsWithReplacedContent</c> (render-prep), which runs before the
+/// dialog/popover top-layer passes.
+/// </summary>
+public class ElementContentReplacementTests : IDisposable
+{
+    public void Dispose() => Program.ResetTestHooks();
+
+    private const int W = 200;
+    private const int H = 200;
+
+    // 15x15 solid-green PNG (the image the WPT test/reference use).
+    private const string GreenPng =
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPAQMAAAABGAcJAAAAA1BMVEUAgACc" +
+        "+aWRAAAADElEQVR42mNgIAEAAAAtAAH7KhMqAAAAAElFTkSuQmCC";
+
+    private const string Preamble =
+        "<p>The test passes if you see a green square near the top of the viewport.";
+
+    private static (int Count, int MinX, int MinY, int MaxX, int MaxY) RenderGreen(string body)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-elemcontent-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string html =
+                "<!DOCTYPE html><html><head><style>" +
+                "dialog { background: green; border-color: green; }" +
+                "div { content: url(" + GreenPng + "); }" +
+                "</style></head><body>" + body + "</body></html>";
+            string file = Path.Combine(dir, "t.html");
+            File.WriteAllText(file, html);
+
+            var runner = new WptTestRunner(W, H);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+
+            int count = 0, minX = int.MaxValue, minY = int.MaxValue, maxX = -1, maxY = -1;
+            for (int y = 0; y < H; y++)
+                for (int x = 0; x < W; x++)
+                {
+                    var p = bmp.GetPixel(x, y);
+                    if (p.G > 100 && p.R < 80 && p.B < 80)
+                    {
+                        count++;
+                        if (x < minX) minX = x;
+                        if (y < minY) minY = y;
+                        if (x > maxX) maxX = x;
+                        if (y > maxY) maxY = y;
+                    }
+                }
+
+            return (count, minX, minY, maxX, maxY);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    [Fact]
+    public void ModalDialogInsideReplacedElement_GeneratesNoBox_AndImageRenders()
+    {
+        var test = RenderGreen(
+            Preamble +
+            "<div><dialog id=\"dialog\"></dialog></div>" +
+            "<script>document.getElementById('dialog').showModal();</script>");
+        var reference = RenderGreen(Preamble + "<div></div>");
+
+        // The replaced image renders at its 15x15 intrinsic size ...
+        Assert.Equal(15 * 15, reference.Count);
+        // ... and the test (open modal dialog nested in the replaced div) renders identically:
+        // the dialog contributes no box, so no extra green appears.
+        Assert.Equal(reference, test);
+    }
+
+    [Fact]
+    public void ModalDialog_OutsideReplacedElement_StillPaints()
+    {
+        // Guard the suppression above against over-reach: a modal dialog that is NOT inside a
+        // replaced element must still be hoisted into the top layer and painted.
+        var normal = RenderGreen(
+            "<dialog id=\"dialog\"></dialog>" +
+            "<script>document.getElementById('dialog').showModal();</script>");
+
+        Assert.True(normal.Count > 15 * 15,
+            $"expected a painted modal dialog larger than the 15x15 image, saw {normal.Count} green px");
+    }
+}

--- a/src/Broiler.Wpt.Tests/ObjectImageResourceTests.cs
+++ b/src/Broiler.Wpt.Tests/ObjectImageResourceTests.cs
@@ -1,0 +1,97 @@
+using System.IO;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression guard for HTML §4.8.4 <c>&lt;object&gt;</c> replacement (WPT
+/// <c>html/semantics/interactive-elements/the-dialog-element/modal-dialog-in-object</c>).
+///
+/// An <c>&lt;object&gt;</c> whose resource loads shows that resource and its children are
+/// fallback that must not render. Broiler did neither: the image resource painted nothing while
+/// the fallback painted anyway — and a modal <c>&lt;dialog&gt;</c> in the fallback was hoisted
+/// into the top layer, painting a dialog plus backdrop where the reference is a bare green
+/// rectangle. Implemented in <c>DomBridge.ReplaceImageObjectsWithResource</c> (render-prep),
+/// gated to an explicit <c>type="image/*"</c> so Acid2's deliberately-failing fallback objects
+/// (which carry no image type) are untouched.
+/// </summary>
+public class ObjectImageResourceTests : IDisposable
+{
+    public void Dispose() => Program.ResetTestHooks();
+
+    private const int W = 300;
+    private const int H = 300;
+
+    private static (int Green, int NonWhite, int MinX, int MinY, int MaxX, int MaxY) Render(string body)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-objimg-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "rect.svg"),
+                "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"100\" version=\"1.1\">" +
+                "<rect x=\"0\" y=\"0\" width=\"100\" height=\"100\" fill=\"green\"/></svg>");
+
+            string html = "<!DOCTYPE html><html><head><style>dialog{background:green;border-color:green}</style>" +
+                          "</head><body>" + body + "</body></html>";
+            string file = Path.Combine(dir, "t.html");
+            File.WriteAllText(file, html);
+
+            var runner = new WptTestRunner(W, H);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+
+            int green = 0, nonWhite = 0, minX = int.MaxValue, minY = int.MaxValue, maxX = -1, maxY = -1;
+            for (int y = 0; y < H; y++)
+                for (int x = 0; x < W; x++)
+                {
+                    var p = bmp.GetPixel(x, y);
+                    if (p.G > 100 && p.R < 100)
+                    {
+                        green++;
+                        if (x < minX) minX = x;
+                        if (y < minY) minY = y;
+                        if (x > maxX) maxX = x;
+                        if (y > maxY) maxY = y;
+                    }
+                    else if (!(p.R > 240 && p.G > 240 && p.B > 240))
+                    {
+                        nonWhite++;
+                    }
+                }
+
+            return (green, nonWhite, minX, minY, maxX, maxY);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    [Fact]
+    public void ModalDialogInObjectFallback_DoesNotRender_AndResourceDoes()
+    {
+        var test = Render(
+            "<object width=\"200\" type=\"image/svg+xml\" data=\"rect.svg\">" +
+            "<dialog id=\"dialog\"></dialog></object>" +
+            "<script>document.getElementById('dialog').showModal();</script>");
+        var reference = Render("<object width=\"200\" type=\"image/svg+xml\" data=\"rect.svg\"></object>");
+
+        // The reference is a 200x200 green square (the object's authored width, aspect preserved).
+        Assert.Equal(200 * 200, reference.Green);
+        Assert.Equal(0, reference.NonWhite);
+
+        // The test renders identically: the fallback dialog contributes neither a box nor a backdrop.
+        Assert.Equal(reference, test);
+    }
+
+    [Fact]
+    public void ObjectWithoutImageType_KeepsFallback()
+    {
+        // Guard the gate: fallback exists so a failed/non-image resource can degrade (Acid2's
+        // nested eyes). An object with no image/* type must keep rendering its fallback.
+        var fallback = Render(
+            "<object data=\"data:application/x-unknown,ERROR\">" +
+            "<div style=\"width:50px;height:50px;background:green\"></div></object>");
+
+        Assert.Equal(50 * 50, fallback.Green);
+    }
+}

--- a/src/Broiler.Wpt.Tests/OverlayTransitionFinishedTests.cs
+++ b/src/Broiler.Wpt.Tests/OverlayTransitionFinishedTests.cs
@@ -1,0 +1,83 @@
+using System.IO;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression guard for CSS Position 4 §overlay transition completion (WPT
+/// <c>css/css-position/overlay/overlay-transition-finished</c>).
+///
+/// A popover shown with a discrete <c>overlay</c> transition is held out of the top layer while the
+/// transition runs — but Broiler never modelled the transition <em>finishing</em>, so it was held
+/// out forever and rendered in normal flow beneath the page's fixed red box. The reference is a
+/// plain green viewport. <c>ScheduleOverlayTransitionCompletion</c> now schedules the transition's
+/// end on the event loop, so a page that drains it (the WPT runner, and this test) sees the popover
+/// on top; a render taken without draining timers still sees the transition running, which is what
+/// <c>OverlayTransitionRenderTests</c> pins.
+/// </summary>
+public class OverlayTransitionFinishedTests : IDisposable
+{
+    public void Dispose() => Program.ResetTestHooks();
+
+    private const int W = 200;
+    private const int H = 200;
+
+    [Fact]
+    public void OverlayTransition_Finished_PopoverPaintsOnTopOfViewport()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-overlayfin-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            const string html = """
+<!DOCTYPE html>
+<html class="reftest-wait">
+<style>
+  #transition-in, #red { display: block; border: none; width: 100vw; height: 100vh; }
+  #red { position: fixed; background-color: red; }
+  #transition-in {
+    transition: overlay 0.1s step-end;
+    transition-behavior: allow-discrete;
+    background-color: green;
+  }
+</style>
+<div id="transition-in" popover></div>
+<div id="red"></div>
+<script>
+  window.takeScreenshot = function () { document.documentElement.classList.remove('reftest-wait'); };
+  let t = document.querySelector('#transition-in');
+  t.addEventListener('transitionend', () => takeScreenshot());
+  t.offsetTop;
+  t.showPopover();
+  if (getComputedStyle(t).overlay != 'none') {
+    // Transition didn't start — the test's own fail condition (renders pink).
+    t.style.backgroundColor = 'pink';
+    takeScreenshot();
+  }
+</script>
+</html>
+""";
+            string file = Path.Combine(dir, "t.html");
+            File.WriteAllText(file, html);
+
+            var runner = new WptTestRunner(W, H);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+
+            int green = 0;
+            for (int y = 0; y < H; y++)
+                for (int x = 0; x < W; x++)
+                {
+                    var p = bmp.GetPixel(x, y);
+                    if (p.G > 100 && p.R < 100) green++;
+                }
+
+            // The reference is <body style="background-color:green"> — a plain green viewport. The
+            // popover must cover it corner to corner, over the fixed red box and with no white
+            // margin (which is what an in-flow, held-out popover left behind).
+            Assert.Equal(W * H, green);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/src/Broiler.Wpt.Tests/ShadowHostSelectorTests.cs
+++ b/src/Broiler.Wpt.Tests/ShadowHostSelectorTests.cs
@@ -1,0 +1,132 @@
+using System.IO;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Regression guard for shadow-tree rendering (the WPT <c>css/css-shadow</c> family, issue #1473).
+///
+/// A shadow root's <c>&lt;style&gt;</c> is serialized inline as a global rule, and the renderer's
+/// selector matcher treats <c>:host</c> as a recognised-but-unmodelled pseudo-class, which is
+/// lenient and matches every element — so a single <c>:host</c> rule painted the whole document.
+/// <c>DomBridge.ScopeShadowHostSelectors</c> rewrites each <c>:host</c> to target its own root's
+/// host; <c>HideUnslottedShadowHostChildren</c> drops light children a slotless shadow tree can
+/// never assign; and <c>UnwrapShadowRootsForRender</c> flattens the <c>#shadow-root</c> wrapper,
+/// whose literal <c>&lt;#shadow-root&gt;</c> serialization the renderer painted as text.
+/// </summary>
+public class ShadowHostSelectorTests : IDisposable
+{
+    public void Dispose() => Program.ResetTestHooks();
+
+    private static (int Red, int Green, int MinX, int MinY, int MaxX, int MaxY) Render(
+        string body, string script, int w = 300, int h = 300)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-shadowhost-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string html = "<!DOCTYPE html><html><head></head><body>" + body +
+                          "<script>" + script + "</script></body></html>";
+            string file = Path.Combine(dir, "t.html");
+            File.WriteAllText(file, html);
+
+            var runner = new WptTestRunner(w, h);
+            using var bmp = runner.RenderHtmlFileBitmapPublic(file, dir);
+
+            int red = 0, green = 0, minX = int.MaxValue, minY = int.MaxValue, maxX = -1, maxY = -1;
+            for (int y = 0; y < h; y++)
+                for (int x = 0; x < w; x++)
+                {
+                    var p = bmp.GetPixel(x, y);
+                    if (p.R > 150 && p.G < 100) red++;
+                    if (p.G > 100 && p.R < 100)
+                    {
+                        green++;
+                        if (x < minX) minX = x;
+                        if (y < minY) minY = y;
+                        if (x > maxX) maxX = x;
+                        if (y > maxY) maxY = y;
+                    }
+                }
+
+            return (red, green, minX, minY, maxX, maxY);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    // The WPT test css/css-shadow/css-scoping-shadow-host-functional-rule: five hosts, each with a
+    // shadow root whose style uses :host(). The reference is a single 100x100 green box, so every
+    // host must end up green and no FAIL text may show.
+    private const string FiveHostsBody = """
+<style>
+host-1, host-2, host-3, host-4, host-5 { display: block; width: 100px; height: 20px; background: red; }
+host-3, host-4, host-5 { background: green; }
+</style>
+<p>Test passes if you see a single 100px by 100px green box below.</p>
+<host-1><div>FAIL1</div></host-1>
+<host-2 id="bar" class="foo" name="baz"><div>FAIL2</div></host-2>
+<div><host-3>FAIL3</host-3></div>
+<host-4><div class="child">FAIL4</div></host-4>
+<host-5><div>FAIL5</div></host-5>
+""";
+
+    private const string FiveHostsScript = """
+var h=document.querySelector('host-1');var r=h.attachShadow({mode:'open'});
+r.innerHTML='<style> :host(host-1) { background: green !important; } </style>';
+h=document.querySelector('host-2');r=h.attachShadow({mode:'open'});
+r.innerHTML='<style> :host(host-2.foo#bar[name=baz]) { background: green !important; } </style>';
+h=document.querySelector('host-3');r=h.attachShadow({mode:'open'});
+r.innerHTML='<style> :host(div host-3) { background: red !important; } </style>';
+h=document.querySelector('host-4');r=h.attachShadow({mode:'open'});
+r.innerHTML='<style> :host(.child) { background: red !important; } </style>';
+h=document.querySelector('host-5');r=h.attachShadow({mode:'open'});
+r.innerHTML='<style> :host(host-1) { background: red !important; } </style>';
+""";
+
+    [Fact]
+    public void HostFunctionalRule_RendersSingleSolidGreenBox()
+    {
+        var (red, green, minX, minY, maxX, maxY) = Render(FiveHostsBody, FiveHostsScript);
+
+        // :host(host-1) and :host(host-2...) must match their own hosts; :host(div host-3) is an
+        // invalid complex argument, :host(.child) matches a child not the host, and host-5's
+        // :host(host-1) must not reach host-1 — so nothing is red.
+        Assert.Equal(0, red);
+
+        // A single solid 100x100 green box: no FAIL text and no "<#shadow-root>" text inside it.
+        Assert.Equal(100, maxX - minX + 1);
+        Assert.Equal(100, maxY - minY + 1);
+        Assert.Equal(100 * 100, green);
+    }
+
+    [Fact]
+    public void HostSelector_DoesNotLeakToTheWholeDocument()
+    {
+        // Guard the original failure directly: a bare :host rule in one shadow tree must style
+        // only its host, not every element on the page.
+        var (red, _, _, _, _, _) = Render(
+            "<style>host-1{display:block;width:50px;height:20px}</style><p>text</p><host-1>x</host-1>",
+            "document.querySelector('host-1').attachShadow({mode:'open'})" +
+            ".innerHTML='<style>:host{background:red}</style>';");
+
+        // Only the 50x20 host is red — not the 300x300 canvas.
+        Assert.InRange(red, 1, 50 * 20);
+    }
+
+    [Fact]
+    public void SlotlessShadowRoot_HidesHostLightChildren()
+    {
+        // With no <slot> in the shadow tree the light children can never be assigned, so they
+        // generate no boxes — the green host box must be unbroken by the light-DOM text.
+        var (_, green, minX, minY, maxX, maxY) = Render(
+            "<style>host-1{display:block;width:100px;height:40px;background:green}</style>" +
+            "<host-1><div>FAILTEXT</div></host-1>",
+            "document.querySelector('host-1').attachShadow({mode:'open'}).innerHTML='<style>x{}</style>';");
+
+        Assert.Equal(100, maxX - minX + 1);
+        Assert.Equal(40, maxY - minY + 1);
+        Assert.Equal(100 * 40, green);
+    }
+}

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -110,11 +110,15 @@ public class WptTestRunnerTests : IDisposable
         var resourcesDir = Path.Combine(testDir, "resources");
         var supportDir = Path.Combine(testDir, "support");
         var testPlanDir = Path.Combine(testDir, "test-plan");
+        var toolsDir = Path.Combine(_tempDir, "tools", "third_party", "websockets", "experiments");
+        var docsDir = Path.Combine(_tempDir, "docs", "writing-tests");
         Directory.CreateDirectory(testDir);
         Directory.CreateDirectory(refDir);
         Directory.CreateDirectory(resourcesDir);
         Directory.CreateDirectory(supportDir);
         Directory.CreateDirectory(testPlanDir);
+        Directory.CreateDirectory(toolsDir);
+        Directory.CreateDirectory(docsDir);
 
         // Actual test files (should be discovered).
         File.WriteAllText(Path.Combine(testDir, "mix-blend-mode-basic.html"), "<html></html>");
@@ -128,6 +132,9 @@ public class WptTestRunnerTests : IDisposable
         File.WriteAllText(Path.Combine(testPlanDir, "test-plan.src.html"), "<html></html>");
         File.WriteAllText(Path.Combine(testDir, "opacity-ref.html"), "<html></html>");
         File.WriteAllText(Path.Combine(testDir, "opacity-notref.html"), "<html></html>");
+        // WPT tooling / vendored third-party demos and documentation are not tests.
+        File.WriteAllText(Path.Combine(toolsDir, "first_message.html"), "<html></html>");
+        File.WriteAllText(Path.Combine(docsDir, "index.html"), "<html></html>");
 
         // Act
         var tests = WptTestRunner.DiscoverTests(_tempDir).ToList();
@@ -5239,6 +5246,38 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
         Assert.True(WptTestRunner.IsNonTestFile("/wpt/css/compositing/support/helper.html"));
         Assert.True(WptTestRunner.IsNonTestFile("C:\\wpt\\support\\utils.html"));
         Assert.True(WptTestRunner.IsNonTestFile("/wpt/css/compositing/resources/fixture.html"));
+    }
+
+    [Fact]
+    public void IsNonTestFile_Detects_Tools_Directory()
+    {
+        // WPT keeps its own runner/server infrastructure and vendored third-party
+        // libraries under tools/; none of it is a test. The websockets library's demo
+        // pages were being pixel-compared as tests and reported as 0.0%-match failures.
+        Assert.True(WptTestRunner.IsNonTestFile(
+            "/wpt/tools/third_party/websockets/experiments/authentication/first_message.html"));
+        Assert.True(WptTestRunner.IsNonTestFile(
+            "/wpt/tools/third_party/websockets/experiments/authentication/user_info.html"));
+        Assert.True(WptTestRunner.IsNonTestFile("C:\\wpt\\tools\\wptrunner\\page.html"));
+        // Also applies to a per-suite tooling directory (e.g. css/tools/).
+        Assert.True(WptTestRunner.IsNonTestFile("/wpt/css/tools/build.html"));
+    }
+
+    [Fact]
+    public void IsNonTestFile_Detects_Docs_Directory()
+    {
+        Assert.True(WptTestRunner.IsNonTestFile("/wpt/docs/writing-tests/index.html"));
+        Assert.True(WptTestRunner.IsNonTestFile("C:\\wpt\\docs\\index.html"));
+    }
+
+    [Fact]
+    public void IsNonTestFile_Allows_Real_Tests_With_Similar_Names()
+    {
+        // Guard the new segments against over-matching: a test file or directory whose
+        // name merely contains "tools"/"docs" is still a test.
+        Assert.False(WptTestRunner.IsNonTestFile("/wpt/css/css-ui/tools-in-name.html"));
+        Assert.False(WptTestRunner.IsNonTestFile("/wpt/css/css-ui/docsomething.html"));
+        Assert.False(WptTestRunner.IsNonTestFile("/wpt/html/toolsbar/basic.html"));
     }
 
     [Fact]

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -802,15 +802,29 @@ internal sealed partial class WptTestRunner
     /// Per WPT conventions, <c>reference/</c> and <c>reftest/</c> hold
     /// reference comparison files, <c>support/</c> holds shared resources,
     /// and <c>test-plan/</c> holds specification documentation.
+    /// <para>
+    /// <c>tools/</c> and <c>docs/</c> are likewise excluded: upstream WPT keeps its
+    /// own test-running infrastructure under <c>tools/</c> (wptrunner, wptserve, and
+    /// the vendored third-party libraries under <c>tools/third_party/</c>) and its
+    /// Sphinx documentation under <c>docs/</c>, and its manifest generation treats
+    /// neither as a test source. Without this, vendored demo pages were discovered and
+    /// pixel-compared as if they were tests — e.g. the <c>websockets</c> library's
+    /// <c>tools/third_party/websockets/experiments/authentication/*.html</c> demos were
+    /// reported as 0.0%-match failures in the WPT top-problems report (issue #1473),
+    /// crowding real rendering bugs out of the ranking. This is the same class of
+    /// corpus pollution the <see cref="IsManualTest"/> filter was added to fix.
+    /// </para>
     /// </summary>
     private static readonly string[] NonTestDirSegments =
     [
+        "/docs/", "\\docs\\",
         "/reference/", "\\reference\\",
         "/references/", "\\references\\",
         "/reftest/", "\\reftest\\",
         "/resources/", "\\resources\\",
         "/support/", "\\support\\",
         "/test-plan/", "\\test-plan\\",
+        "/tools/", "\\tools\\",
     ];
 
     /// <summary>
@@ -1040,6 +1054,8 @@ internal sealed partial class WptTestRunner
     /// <list type="bullet">
     ///   <item>Files in <c>reference/</c>, <c>reftest/</c>, or <c>support/</c> directories.</item>
     ///   <item>Files in <c>test-plan/</c> directories (spec documentation).</item>
+    ///   <item>Files in <c>tools/</c> (WPT's own tooling and vendored third-party code)
+    ///         or <c>docs/</c> (documentation) directories.</item>
     ///   <item>Files ending in <c>-ref.html/.htm/.xht/.xhtml</c> or <c>-notref.html/.htm/.xht/.xhtml</c>
     ///         (WPT reference/mismatch reference files).</item>
     ///   <item>Files with a <c>.src.html</c> extension (ReSpec source files).</item>


### PR DESCRIPTION
## Summary

Implements render-time scoping of shadow DOM `:host` selectors, flattening of unslotted shadow host children, and CSS Content 3 element replacement for non-root elements and `<object>` image resources. Also fixes table cell percentage-height child layout and popover overlay transition completion scheduling.

## Key Changes

### Shadow DOM Rendering
- **ShadowHostSelectors.cs** (new): Rewrites `:host` / `:host(...)` / `:host-context(...)` selectors in shadow root styles to target their specific host element via a `data-broiler-shadow-host` marker attribute. The renderer's lenient `:host` matching was painting every element; this ensures each shadow tree's rules only affect its own host.
- **ShadowSlotRendering.cs** (new): Drops light-DOM children of shadow hosts whose shadow tree contains no `<slot>` element (unslottable content). Also unwraps `#shadow-root` wrapper elements for render serialization, since the literal `<#shadow-root>` tag was rendering as text.
- **HtmlFragmentMutation.cs**: Prevents marker nodes when parsing `innerHTML` on shadow roots (context element tag `#shadow-root` is not a valid HTML element).
- **ShadowRootInnerHtmlTests.cs** (new): Regression test for shadow root innerHTML parsing.
- **MetaColorSchemeShadowTreeTests.cs** (new): Verifies `<meta name="color-scheme">` inside a shadow tree does not affect document color scheme.

### Element Replacement & Content
- **AnchorResolver.cs**: Adds `ReplaceElementsWithReplacedContent()` and `ReplaceImageObjectsWithResource()` passes before dialog/popover positioning. Elements with `content: url(image)` are replaced by that image and their children suppressed. `<object>` elements with image resources show the resource and hide fallback content.
- **ElementContentReplacementTests.cs** (new): Tests that a modal dialog nested in a `content: url()` element is not hoisted to the top layer.
- **ObjectImageResourceTests.cs** (new): Tests that a modal dialog in an `<object>` fallback is not hoisted when the object's image resource loads.

### Table Layout
- **CssLayoutEngineTable.cs**: Wraps non-`table-cell` children of table rows in anonymous table-cell boxes (CSS2.1 §17.2.1). Adds `ResolveCellPercentageHeightChildren()` to re-layout percentage-height children after the row-height pass determines the cell's final height.
- **TablePercentHeightBorderBoxTests.cs** (new): Tests percentage-height child resolution in border-box table cells.

### Popover Overlay Transitions
- **Dialogs.cs**: Schedules the completion of a popover's discrete `overlay` transition on the event loop via `ScheduleOverlayTransitionCompletion()`. The popover is held out of the top layer while the transition runs; once the duration elapses, it enters the top layer.
- **RuntimeStates.cs**: Adds `PopoverOverlayTransitionFinished` flag to track transition completion.
- **OverlayTransitionFinishedTests.cs** (new): Tests that a popover with a discrete overlay transition enters the top layer after the transition duration.

### Base Href Resolution
- **StyleBaseHref.cs**: Extends base href resolution to `<link rel="stylesheet">` `href` attributes, not just `<style>` `url()` values.
- **StylesheetBaseHrefTests.cs** (new): Tests that linked stylesheets resolve relative hrefs against `<base href>`.

### Test Infrastructure
- **WptTestRunnerTests.cs**: Excludes `tools/` and `docs/` directories from test discovery.

## Implementation Details

- Shadow host marker attributes use numeric tokens (`data-broiler-shadow-host="0"`, `"1"`, etc.) to uniquely identify each shadow root's host.
- Invalid `:host()` arguments (empty, containing combinators, or selector lists) are rewritten to a never-matching sentinel selector `[data-

https://claude.ai/code/session_01KSQCZj6N6EstR8tv2Eo29d