### PR TITLE
Add BOSS (Broiler Office Standalone Server) packaging and service integration

### DIFF
--- a/.github/workflows/broiler-preview-package.yml
+++ b/.github/workflows/broiler-preview-package.yml
@@ -29,6 +29,8 @@ jobs:
     env:
       BROWSER_PROJECT_PATH: src/Broiler.Browser.Windows/Broiler.Browser.Windows.csproj
       WRITER_PROJECT_PATH: src/Broiler.Writer.Windows/Broiler.Writer.Windows.csproj
+      BOSS_PROJECT_PATH: Broiler.Office.Server/Broiler.Office.Server.csproj
+      WRITER_CLIENT_PROJECT_PATH: src/Broiler.Writer.WebAssembly/Broiler.Writer.WebAssembly.csproj
 
     steps:
       - name: Checkout selected branch
@@ -45,11 +47,27 @@ jobs:
             8.0.x
             10.0.x
 
+      - name: Install the WebAssembly build workload
+        shell: pwsh
+        run: |
+          # BOSS serves the Writer compiled to WebAssembly; publishing that client needs wasm-tools
+          # (emscripten + the browser-wasm runtime packs).
+          dotnet workload install wasm-tools
+          if ($LASTEXITCODE -ne 0) {
+            throw "dotnet workload install wasm-tools exited with code $LASTEXITCODE."
+          }
+
       - name: Restore Windows runtime graphs
         shell: pwsh
         run: |
           dotnet restore $env:BROWSER_PROJECT_PATH --runtime win-x64 -p:Configuration=$env:WINDOWS_CONFIGURATION
           dotnet restore $env:WRITER_PROJECT_PATH --runtime win-x64 -p:Configuration=$env:WINDOWS_CONFIGURATION
+          dotnet restore $env:BOSS_PROJECT_PATH --runtime win-x64 -p:Configuration=$env:WINDOWS_CONFIGURATION
+
+          # The Writer WebAssembly client is not a ProjectReference of BOSS — the server publishes it
+          # through an MSBuild task and vendors the result — so it needs its own restore, and one
+          # without the Windows RID: the client always targets browser-wasm.
+          dotnet restore $env:WRITER_CLIENT_PROJECT_PATH -p:Configuration=$env:WINDOWS_CONFIGURATION
 
       - name: Build Windows targets
         shell: pwsh
@@ -89,6 +107,16 @@ jobs:
             --output $output `
             -p:UseAppHost=true
 
+          # BOSS goes into its own subfolder: it ships a vendored wwwroot, an appsettings.json and a
+          # service/ tree, none of which belong loose beside the desktop apps.
+          dotnet publish $env:BOSS_PROJECT_PATH `
+            --configuration $env:WINDOWS_CONFIGURATION `
+            --runtime win-x64 `
+            --self-contained false `
+            --no-restore `
+            --output (Join-Path $output 'BOSS') `
+            -p:UseAppHost=true
+
       - name: Publish Windows self-contained apps
         shell: pwsh
         run: |
@@ -110,8 +138,37 @@ jobs:
             --no-restore `
             --output $output
 
+          dotnet publish $env:BOSS_PROJECT_PATH `
+            --configuration $env:WINDOWS_CONFIGURATION `
+            --runtime win-x64 `
+            --self-contained true `
+            --no-restore `
+            --output (Join-Path $output 'BOSS')
+
+      - name: Assemble and smoke-test the BOSS payloads
+        shell: pwsh
+        run: |
+          # Lay the README, launcher and service files around each published server, then start it
+          # and check it really serves the Writer — a package whose wwwroot did not survive the
+          # publish still starts and answers /healthz, so only a real request catches it.
+          $packageParent = Join-Path $env:RUNNER_TEMP 'packages'
+          $port = 5555
+
+          foreach ($variant in @('framework-dependent', 'self-contained')) {
+            $bossDir = Join-Path $packageParent "BPP-Win32-$variant\BOSS"
+
+            ./scripts/package-boss.ps1 -BossDirectory $bossDir -Platform windows
+            ./scripts/smoke-test-boss.ps1 -BossDirectory $bossDir -Port $port
+
+            # A fresh port per variant: Windows can hold a listening socket in TIME_WAIT briefly
+            # after the previous server exits.
+            $port++
+          }
+
       - name: Package Windows assets
         shell: pwsh
+        env:
+          RELEASE_BRANCH: ${{ github.event.inputs.branch }}
         run: |
           function Rename-AppPublish {
             param(
@@ -183,6 +240,13 @@ jobs:
               -PackageBaseName 'Broiler.Writer' `
               -ExecutableExtension '.exe'
 
+            ./scripts/write-bpp-build-info.ps1 `
+              -PackageDirectory $packageRoot `
+              -Platform windows `
+              -Variant $variant `
+              -Branch $env:RELEASE_BRANCH `
+              -Configuration $env:WINDOWS_CONFIGURATION
+
             New-WindowsArchive `
               -PackageParent $packageParent `
               -PackageName $packageName `
@@ -210,6 +274,8 @@ jobs:
     env:
       BROWSER_PROJECT_PATH: src/Broiler.Browser.Linux/Broiler.Browser.Linux.csproj
       WRITER_PROJECT_PATH: src/Broiler.Writer.Linux/Broiler.Writer.Linux.csproj
+      BOSS_PROJECT_PATH: Broiler.Office.Server/Broiler.Office.Server.csproj
+      WRITER_CLIENT_PROJECT_PATH: src/Broiler.Writer.WebAssembly/Broiler.Writer.WebAssembly.csproj
 
     steps:
       - name: Checkout selected branch
@@ -226,11 +292,27 @@ jobs:
             8.0.x
             10.0.x
 
+      - name: Install the WebAssembly build workload
+        shell: pwsh
+        run: |
+          # BOSS serves the Writer compiled to WebAssembly; publishing that client needs wasm-tools
+          # (emscripten + the browser-wasm runtime packs).
+          dotnet workload install wasm-tools
+          if ($LASTEXITCODE -ne 0) {
+            throw "dotnet workload install wasm-tools exited with code $LASTEXITCODE."
+          }
+
       - name: Restore Linux runtime graphs
         shell: pwsh
         run: |
           dotnet restore $env:BROWSER_PROJECT_PATH --runtime linux-x64 -p:Configuration=$env:LINUX_CONFIGURATION
           dotnet restore $env:WRITER_PROJECT_PATH --runtime linux-x64 -p:Configuration=$env:LINUX_CONFIGURATION
+          dotnet restore $env:BOSS_PROJECT_PATH --runtime linux-x64 -p:Configuration=$env:LINUX_CONFIGURATION
+
+          # The Writer WebAssembly client is not a ProjectReference of BOSS — the server publishes it
+          # through an MSBuild task and vendors the result — so it needs its own restore, and one
+          # without the Linux RID: the client always targets browser-wasm.
+          dotnet restore $env:WRITER_CLIENT_PROJECT_PATH -p:Configuration=$env:LINUX_CONFIGURATION
 
       - name: Build Linux targets
         shell: pwsh
@@ -293,6 +375,16 @@ jobs:
             --output $output `
             -p:UseAppHost=true
 
+          # BOSS goes into its own subfolder: it ships a vendored wwwroot, an appsettings.json and a
+          # service/ tree, none of which belong loose beside the desktop apps.
+          dotnet publish $env:BOSS_PROJECT_PATH `
+            --configuration $env:LINUX_CONFIGURATION `
+            --runtime linux-x64 `
+            --self-contained false `
+            --no-restore `
+            --output (Join-Path $output 'BOSS') `
+            -p:UseAppHost=true
+
       - name: Publish Linux self-contained apps
         shell: pwsh
         run: |
@@ -314,8 +406,35 @@ jobs:
             --no-restore `
             --output $output
 
+          dotnet publish $env:BOSS_PROJECT_PATH `
+            --configuration $env:LINUX_CONFIGURATION `
+            --runtime linux-x64 `
+            --self-contained true `
+            --no-restore `
+            --output (Join-Path $output 'BOSS')
+
+      - name: Assemble and smoke-test the BOSS payloads
+        shell: pwsh
+        run: |
+          # Lay the README, launcher and service files around each published server, then start it
+          # and check it really serves the Writer — a package whose wwwroot did not survive the
+          # publish still starts and answers /healthz, so only a real request catches it.
+          $packageParent = Join-Path $env:RUNNER_TEMP 'packages'
+          $port = 5555
+
+          foreach ($variant in @('framework-dependent', 'self-contained')) {
+            $bossDir = Join-Path $packageParent "BPP-Linux-$variant/BOSS"
+
+            ./scripts/package-boss.ps1 -BossDirectory $bossDir -Platform linux
+            ./scripts/smoke-test-boss.ps1 -BossDirectory $bossDir -Port $port
+
+            $port++
+          }
+
       - name: Package Linux assets
         shell: pwsh
+        env:
+          RELEASE_BRANCH: ${{ github.event.inputs.branch }}
         run: |
           function Rename-AppPublish {
             param(
@@ -380,6 +499,13 @@ jobs:
               -OriginalBaseName 'Broiler.Writer.Linux' `
               -PackageBaseName 'Broiler.Writer' `
               -ExecutableExtension ''
+
+            ./scripts/write-bpp-build-info.ps1 `
+              -PackageDirectory $packageRoot `
+              -Platform linux `
+              -Variant $variant `
+              -Branch $env:RELEASE_BRANCH `
+              -Configuration $env:LINUX_CONFIGURATION
 
             New-LinuxArchive `
               -PackageParent $packageParent `
@@ -476,27 +602,88 @@ jobs:
           $linuxFrameworkDependent = Resolve-Asset 'BPP-Linux-framework-dependent' @('.tar.xz', '.tar.gz')
           $linuxSelfContained = Resolve-Asset 'BPP-Linux-self-contained' @('.tar.xz', '.tar.gz')
 
-          foreach ($asset in @($windowsFrameworkDependent, $windowsSelfContained, $linuxFrameworkDependent, $linuxSelfContained)) {
+          $packages = @(
+            $windowsFrameworkDependent,
+            $windowsSelfContained,
+            $linuxFrameworkDependent,
+            $linuxSelfContained
+          )
+
+          foreach ($asset in $packages) {
             if (-not (Test-Path -LiteralPath $asset)) {
               throw "Missing expected BPP asset: $asset"
             }
           }
 
-          $assetList = @(
-            $windowsFrameworkDependent,
-            $windowsSelfContained,
-            $linuxFrameworkDependent,
-            $linuxSelfContained
-          ) | ForEach-Object { "- " + (Split-Path -Leaf $_) }
+          # sha256sum-compatible manifest (hash, two spaces, file name) so `sha256sum -c` works as-is
+          # after downloading the archives next to it.
+          $checksumPath = Join-Path $assetDir 'SHA256SUMS.txt'
+          $checksumLines = $packages | ForEach-Object {
+            "{0}  {1}" -f (Get-FileHash -LiteralPath $_ -Algorithm SHA256).Hash.ToLowerInvariant(), (Split-Path -Leaf $_)
+          }
+          Set-Content -LiteralPath $checksumPath -Value $checksumLines -Encoding ascii
 
-          $body = @"
-          Draft Broiler Preview Package prepared from branch $env:RELEASE_BRANCH at commit $env:SHORT_SHA.
+          $assetList = ($packages + $checksumPath) | ForEach-Object { "- " + (Split-Path -Leaf $_) }
 
-          Each package contains Broiler.Browser and Broiler.Writer.
+          # Single-quoted here-string: the notes are full of Markdown backticks, and in an
+          # interpolating string PowerShell would eat them as escape characters.
+          $contents = @'
+          Each package contains:
 
-          Assets:
-          $($assetList -join "`n")
-          "@
+          * `Broiler.Browser` — the Broiler web browser.
+          * `Broiler.Writer` — the Broiler word processor (desktop).
+          * `BOSS/` — **Broiler Office Standalone Server**: a Kestrel host that serves the Broiler
+            Writer web app (WebAssembly), so the Writer runs in a browser with no other web server
+            involved.
+
+          Starting BOSS after extracting a package:
+
+          ```
+          ./BOSS/run-boss.sh --urls http://0.0.0.0:5555        # Linux
+          BOSS\Start-BOSS.cmd                                  # Windows
+          ```
+
+          Then open <http://localhost:5555/>. Liveness probe at `/healthz`, server details at
+          `/api/info`.
+
+          To keep it serving across reboots, `BOSS/service/` carries prepared unit files and
+          installers — a hardened systemd unit (`Type=notify`), an LSB SysV init script, a Windows
+          service installer, plus nginx and Apache reverse-proxy samples:
+
+          ```
+          sudo ./BOSS/service/install-service.sh --urls http://0.0.0.0:5555
+          powershell -ExecutionPolicy Bypass -File BOSS\service\Install-BossService.ps1 -OpenFirewall
+          ```
+
+          Full documentation ships in the package: `BOSS/README.md` and `BOSS/service/README.md`.
+          Each package root also carries a `BUILD-INFO.txt` naming the branch, commit and build time.
+
+          Variants:
+
+          * **self-contained** — carries its own .NET runtime; nothing to install.
+          * **framework-dependent** — smaller, needs the .NET 10 desktop runtime and, for BOSS, the
+            ASP.NET Core 10 runtime on the target machine.
+          '@
+
+          $verify = @'
+          Verify a download against `SHA256SUMS.txt`:
+
+          ```
+          sha256sum -c SHA256SUMS.txt --ignore-missing        # Linux
+          Get-FileHash .\BPP-Win32-self-contained.7z -Algorithm SHA256   # Windows
+          ```
+          '@
+
+          $body = @(
+            "Draft Broiler Preview Package prepared from branch $env:RELEASE_BRANCH at commit $env:SHORT_SHA.",
+            '',
+            $contents,
+            '',
+            'Assets:',
+            ($assetList -join "`n"),
+            '',
+            $verify
+          ) -join "`n"
 
           $bodyPath = Join-Path $env:RUNNER_TEMP 'broiler-preview-package-notes.md'
           Set-Content -LiteralPath $bodyPath -Value $body -Encoding UTF8
@@ -506,6 +693,7 @@ jobs:
             $windowsSelfContained `
             $linuxFrameworkDependent `
             $linuxSelfContained `
+            $checksumPath `
             --draft `
             --target $env:RELEASE_BRANCH `
             --title $env:RELEASE_TITLE `

--- a/Broiler.Office.Server/Broiler.Office.Server.csproj
+++ b/Broiler.Office.Server/Broiler.Office.Server.csproj
@@ -46,6 +46,14 @@
     <WriterClientStage>$(MSBuildProjectDirectory)\$(BaseIntermediateOutputPath)writer-client\</WriterClientStage>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Service-manager integration for the prepared unit files under packaging/: systemd
+         readiness/stop notification (Type=notify) and the Windows service control protocol.
+         Both are inert when the server is started from a console. -->
+    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
+  </ItemGroup>
+
   <!-- Publish the Writer WASM client (trimmed — untrimmed crashes mono at boot) into an intermediate
        stage. Skipped once staged, so the dev inner loop stays fast; force a refresh after changing the
        Writer with -p:ForceWriterClientPublish=true (or delete obj/). -->
@@ -53,9 +61,21 @@
           Condition="!Exists('$(WriterClientStage)wwwroot\index.html') Or '$(ForceWriterClientPublish)' == 'true'">
     <Message Importance="high" Text="BOSS: publishing the Broiler Writer WASM client into $(WriterClientStage)…" />
     <RemoveDir Directories="$(WriterClientStage)" />
+    <!--
+      Strip this project's publish shape before crossing into the client. The MSBuild task hands the
+      caller's *global* properties to the child, so a self-contained / single-file / RID-specific
+      publish of THIS project would otherwise force the browser-wasm client to publish as, say,
+      linux-x64: the WebAssembly SDK then never imports its browser targets and the build dies with
+      "MSB4057: The target 'Publish' does not exist in the project" (or NETSDK1099 for a single-file
+      publish). The client always publishes for browser-wasm with its own settings — its .csproj
+      pins PublishTrimmed, and RunAOTCompilation is turned off here. Properties listed above still
+      apply: an explicit `Properties` entry outranks a global of the same name, which is what keeps
+      Configuration and the staging PublishDir flowing through.
+    -->
     <MSBuild Projects="$(WriterClientProject)"
              Targets="Publish"
-             Properties="Configuration=$(Configuration);PublishDir=$(WriterClientStage);RunAOTCompilation=false" />
+             Properties="Configuration=$(Configuration);PublishDir=$(WriterClientStage);RunAOTCompilation=false"
+             RemoveProperties="RuntimeIdentifier;RuntimeIdentifiers;SelfContained;PublishSingleFile;PublishTrimmed;PublishReadyToRun;PublishAot;UseAppHost;TargetFramework;OutputPath;OutDir;BaseOutputPath;IntermediateOutputPath;BaseIntermediateOutputPath" />
   </Target>
 
   <!-- Dev / `dotnet run`: vendor the staged bundle into this project's web root so Kestrel serves it.

--- a/Broiler.Office.Server/Program.cs
+++ b/Broiler.Office.Server/Program.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Hosting.WindowsServices;
 
 // ── BOSS: the Broiler Office Standalone Server ────────────────────────────────────────────────────
 // A Kestrel host that serves the Broiler Office web apps. Today that is the Broiler Writer word
@@ -7,10 +8,24 @@ using Microsoft.AspNetCore.StaticFiles;
 // content-hashed WebAssembly bundle (see the .csproj for how the bundle gets here). Additional Office
 // apps register the same way: vendor the client's published wwwroot and add it to the app list.
 
-var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+{
+    Args = args,
+    ContentRootPath = ResolveContentRoot(args),
+});
 
 // Kestrel is the default (and only) server here; make the intent explicit.
 builder.WebHost.UseKestrel();
+
+// Run as a managed service when launched by one — see packaging/ for the prepared unit files.
+// Both calls are no-ops for an ordinary console launch (`dotnet run`, a shell, a container), so the
+// interactive experience is unchanged. Under systemd, UseSystemd switches the host to
+// Type=notify readiness/stop signalling and journald-style log formatting; under the Windows SCM,
+// UseWindowsService answers the service control protocol, logs to the event log, and roots the
+// content root at the executable's directory (so the vendored wwwroot is found regardless of the
+// working directory the SCM hands us).
+builder.Host.UseSystemd();
+builder.Host.UseWindowsService();
 
 var app = builder.Build();
 
@@ -103,6 +118,48 @@ app.Lifetime.ApplicationStarted.Register(() =>
 });
 
 app.Run();
+
+// The content root is where the vendored Writer bundle (wwwroot/) is looked up. The host default is
+// the *working directory*, which is right for `dotnet run` (the build vendors the bundle into the
+// project directory) but wrong for a deployed server: systemd, the Windows SCM, an init script or a
+// plain `/opt/broiler/office-server/Broiler.Office.Server` invocation from elsewhere all leave the
+// working directory pointing somewhere without a wwwroot, and every page 404s while /healthz keeps
+// answering OK. Anchor it to the executable's own directory in that case.
+//
+// Returning null keeps the host default, which is what an explicit --contentRoot / ASPNETCORE_CONTENTROOT
+// needs: WebApplicationOptions.ContentRootPath is applied after the command line and would silently win.
+static string? ResolveContentRoot(string[] args)
+{
+    // Under the Windows SCM, UseWindowsService() sets the content root to the executable's directory
+    // itself — and WebApplicationBuilder rejects a *late* host-configuration change to a different
+    // value ("The content root changed from … to …"). So it has to already be that value here.
+    if (WindowsServiceHelpers.IsWindowsService())
+        return AppContext.BaseDirectory;
+
+    if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ASPNETCORE_CONTENTROOT")) ||
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_CONTENTROOT")))
+        return null;
+
+    foreach (string arg in args)
+    {
+        // Matches every spelling the command-line configuration provider accepts:
+        // --contentRoot <path>, --contentRoot=<path>, /contentRoot=<path>.
+        string token = arg.TrimStart('-', '/');
+        int separator = token.IndexOf('=');
+        if (separator >= 0)
+            token = token[..separator];
+
+        if (token.Equals("contentRoot", StringComparison.OrdinalIgnoreCase))
+            return null;
+    }
+
+    if (Directory.Exists(Path.Combine(Directory.GetCurrentDirectory(), "wwwroot")))
+        return null;
+
+    return Directory.Exists(Path.Combine(AppContext.BaseDirectory, "wwwroot"))
+        ? AppContext.BaseDirectory
+        : null;
+}
 
 /// <summary>An Office web app mounted by BOSS, as reported by <c>/api/info</c>.</summary>
 internal sealed record OfficeApp(string Name, string Description, string Path, string[] Formats);

--- a/Broiler.Office.Server/README.md
+++ b/Broiler.Office.Server/README.md
@@ -57,6 +57,11 @@ which fans the single-file / RID / self-contained flags out to the two WebAssemb
 solution (`Broiler.Writer.WebAssembly`, `Broiler.Graphics.WebAssembly`), and those cannot be
 single-file-published (`MSB4057` / `NETSDK1099`). Naming the `.csproj` avoids that.
 
+Within the project the same flags are stripped before the Writer client is published (the `MSBuild`
+task hands its caller's global properties to the child, so `-r linux-x64` would otherwise reach a
+browser-wasm project and fail the same way) — so any RID, self-contained or single-file combination
+below is safe.
+
 Framework-dependent (portable, needs the .NET runtime on the target):
 
 ```powershell
@@ -81,6 +86,28 @@ dependencies. Run it directly (on a matching linux-arm64 host):
 
 ```bash
 ./out/boss-linux-arm64/Broiler.Office.Server
+```
+
+The published server finds its `wwwroot/` next to the executable, so it can be started from any
+working directory — which is what a service manager does. `Program.cs` also calls `UseSystemd()` and
+`UseWindowsService()`, so the same binary runs unchanged as a `Type=notify` systemd unit or a
+Windows service.
+
+## Shipping: preview packages and service files
+
+BOSS ships inside every **Broiler Preview Package** (BPP) — Linux and Windows, self-contained and
+framework-dependent — under `BOSS/`, alongside `Broiler.Browser` and `Broiler.Writer`. The
+[`Prepare Broiler Preview Package`](../.github/workflows/broiler-preview-package.yml) workflow
+publishes the server, lays the packaging assets around it
+([`scripts/package-boss.ps1`](../scripts/package-boss.ps1)), and smoke-tests the result
+([`scripts/smoke-test-boss.ps1`](../scripts/smoke-test-boss.ps1)) before anything reaches a release.
+
+What a user gets next to the binary — end-user README, foreground launcher, and ready-to-install
+service definitions (a hardened systemd unit, an LSB SysV init script, a Windows service installer,
+nginx/Apache reverse-proxy samples) — lives in [`packaging/`](packaging/README.md).
+
+```bash
+sudo ./BOSS/service/install-service.sh --urls http://0.0.0.0:5555     # systemd or SysV
 ```
 
 ## Adding more Office apps

--- a/Broiler.Office.Server/packaging/README.md
+++ b/Broiler.Office.Server/packaging/README.md
@@ -1,0 +1,74 @@
+# BOSS packaging assets
+
+Everything that ships **beside** the BOSS binaries in a Broiler Preview Package (BPP): service unit
+files, install scripts, launchers and the end-user documentation.
+
+Nothing here is compiled. The `Prepare Broiler Preview Package` workflow
+([`.github/workflows/broiler-preview-package.yml`](../../.github/workflows/broiler-preview-package.yml))
+publishes `Broiler.Office.Server` into `BOSS/` inside each package and copies this tree in around it,
+so the layout below *is* the layout a user extracts.
+
+```
+packaging/
+├── common/README.md                       → BOSS/README.md            (both platforms)
+├── linux/
+│   ├── run-boss.sh                        → BOSS/run-boss.sh
+│   └── service/                           → BOSS/service/
+│       ├── README.md                        Linux service guide
+│       ├── install-service.sh               systemd or SysV, auto-detected
+│       ├── uninstall-service.sh
+│       ├── systemd/broiler-office-server.service
+│       ├── systemd/broiler-office-server.env
+│       ├── sysv/broiler-office-server
+│       ├── sysv/broiler-office-server.default
+│       └── reverse-proxy/{nginx,apache}-broiler-office-server.conf
+└── windows/
+    ├── Start-BOSS.cmd                     → BOSS/Start-BOSS.cmd
+    └── service/                           → BOSS/service/
+        ├── README.md                        Windows service guide
+        ├── Install-BossService.ps1
+        └── Uninstall-BossService.ps1
+```
+
+`common/` goes into every package; `linux/` and `windows/` go into the packages for that platform
+only — so a user never has to work out which half of a folder applies to them.
+
+## Conventions worth keeping
+
+* **Defaults are literal, not templated.** The unit file really says
+  `/opt/broiler/office-server`, `User=broiler` and `--urls http://0.0.0.0:5555`, so it can be copied
+  to `/etc/systemd/system/` by hand and work. `install-service.sh` rewrites those literals when
+  `--prefix`/`--user`/`--urls` say otherwise, which is also why they must stay spelled exactly that
+  way — the `sed` expressions in the installer match on them.
+* **Settings live outside the unit.** `/etc/broiler/office-server.env` (systemd) and
+  `/etc/default/broiler-office-server` (SysV) are never overwritten on upgrade; a new version is
+  written as `*.new` beside the existing file.
+* **`wwwroot/` is replaced wholesale, never merged.** The Writer bundle is content-hashed, and
+  mixing assets from two releases desyncs the Canvas replay stream at load
+  (`Unknown replay op …`). Every installer removes the old directory first.
+* **The service host is real.** `Program.cs` calls `UseSystemd()` and `UseWindowsService()`, so the
+  systemd unit can be `Type=notify` and the Windows service needs no wrapper. It also anchors the
+  content root at the executable's directory, so a service manager's working directory cannot hide
+  `wwwroot/`.
+* Shell scripts are POSIX `sh` (they run on busybox and on RHEL without bash-isms); PowerShell
+  scripts stay compatible with Windows PowerShell 5.1, which is what a bare Windows Server has.
+
+## Testing a change
+
+Publish the server and assemble a package by hand:
+
+```bash
+dotnet publish Broiler.Office.Server/Broiler.Office.Server.csproj -c Release-Linux \
+    -r linux-x64 --self-contained true -o /tmp/BOSS
+cp -a Broiler.Office.Server/packaging/common/README.md /tmp/BOSS/
+cp -a Broiler.Office.Server/packaging/linux/run-boss.sh /tmp/BOSS/
+cp -a Broiler.Office.Server/packaging/linux/service /tmp/BOSS/
+/tmp/BOSS/run-boss.sh --urls http://127.0.0.1:5555 &
+curl -fsS http://127.0.0.1:5555/healthz
+```
+
+The workflow does exactly this and then smoke-tests `/healthz`, `/api/info` and `/` on both
+platforms, so a broken package fails the run rather than reaching a release.
+
+For the server itself — the vendored-publish hosting model, endpoints, how to add another Office
+app — see [`../README.md`](../README.md).

--- a/Broiler.Office.Server/packaging/common/README.md
+++ b/Broiler.Office.Server/packaging/common/README.md
@@ -1,0 +1,185 @@
+# BOSS — Broiler Office Standalone Server
+
+A single Kestrel web server that hosts the **Broiler Office** web apps. Today that is **Broiler
+Writer**, the word processor, compiled to WebAssembly and served from this folder — no external web
+server, no Node, no Python `http.server`.
+
+Everything the server needs is in this directory: the executable, `appsettings.json`, and `wwwroot/`
+holding the complete Writer bundle (the mono-wasm runtime and its content-hashed assets).
+
+---
+
+## Quick start
+
+**Linux**
+
+```bash
+./run-boss.sh                                  # http://0.0.0.0:5555
+./Broiler.Office.Server --urls http://0.0.0.0:5555
+```
+
+**Windows**
+
+```bat
+Start-BOSS.cmd
+Broiler.Office.Server.exe --urls http://0.0.0.0:5555
+```
+
+Then open <http://localhost:5555/> — the Writer boots in the browser.
+
+With no arguments the server falls back to ASP.NET Core's own default, `http://localhost:5000`,
+which is reachable **from that machine only**. Pass `--urls` whenever anyone else should reach it.
+
+> **Framework-dependent packages** need the **ASP.NET Core 10 runtime** installed
+> (<https://dotnet.microsoft.com/download/dotnet/10.0> — the *ASP.NET Core Runtime*, not just the
+> .NET Runtime). **Self-contained packages** carry their own runtime and need nothing installed.
+
+---
+
+## Sample arguments
+
+| Argument | What it does |
+| --- | --- |
+| `--urls http://0.0.0.0:5555` | Listen on **every** IPv4 interface, port 5555. The usual choice for a server other machines connect to. |
+| `--urls http://127.0.0.1:5555` | Loopback only — the right setting when a reverse proxy sits in front. |
+| `--urls "http://[::]:5555"` | Every interface, IPv4 **and** IPv6. Quote it: brackets are shell metacharacters. |
+| `--urls "http://127.0.0.1:5555;http://10.0.0.4:8080"` | Several endpoints at once, semicolon-separated. |
+| `--urls http://0.0.0.0:80` | Port 80. Needs root on Linux (or `CAP_NET_BIND_SERVICE`, see `service/`) and an elevated prompt on Windows. |
+| `--environment Development` | Turns on the developer exception page and loads `appsettings.Development.json`. Do not use for a public deployment. |
+| `--contentRoot /srv/boss` | Look for `wwwroot/` (and `appsettings.json`) somewhere other than beside the executable. |
+| `--Logging:LogLevel:Default=Debug` | Raise the log level — any configuration key works as `--Section:Key=value`. |
+| `--Logging:LogLevel:Microsoft.AspNetCore=Information` | Log every request (URL, status, duration). Off by default. |
+
+Common combinations:
+
+```bash
+# Public listener, quiet logs — a plain deployment.
+./Broiler.Office.Server --urls http://0.0.0.0:5555
+
+# Behind nginx/Apache: loopback only, request logging on.
+./Broiler.Office.Server --urls http://127.0.0.1:5555 --Logging:LogLevel:Microsoft.AspNetCore=Information
+
+# Two ports, one of them HTTPS with a PFX bundle.
+./Broiler.Office.Server --urls "http://0.0.0.0:5555;https://0.0.0.0:5556" \
+    --Kestrel:Certificates:Default:Path=/etc/broiler/office-server.pfx \
+    --Kestrel:Certificates:Default:Password=secret
+```
+
+Every argument has an environment-variable twin, which is what the service unit files use:
+
+```bash
+ASPNETCORE_URLS=http://0.0.0.0:5555
+ASPNETCORE_ENVIRONMENT=Production
+Logging__LogLevel__Default=Information          # ':' becomes '__' in an environment variable
+```
+
+Precedence, lowest to highest: `appsettings.json` → `appsettings.<Environment>.json` → environment
+variables → command-line arguments. So a command-line `--urls` always wins.
+
+---
+
+## Endpoints
+
+| Route | Purpose |
+| --- | --- |
+| `/` | Broiler Writer. Any unknown path also returns the app shell, so client-side routes survive a refresh. |
+| `/healthz` | Liveness probe. Returns `200 OK` with the body `OK` — point your load balancer or monitoring here. |
+| `/api/info` | JSON: server name, version, and the list of hosted apps. |
+
+```bash
+curl -fsS http://localhost:5555/healthz && echo
+curl -fsS http://localhost:5555/api/info | jq
+```
+
+---
+
+## Running it as a service
+
+Prepared unit files, install scripts and reverse-proxy samples live in [`service/`](service/):
+
+```bash
+sudo ./service/install-service.sh --urls http://0.0.0.0:5555     # Linux: systemd or SysV, auto-detected
+```
+
+```powershell
+# Windows, from an elevated prompt
+powershell -ExecutionPolicy Bypass -File .\service\Install-BossService.ps1 -OpenFirewall
+```
+
+See [`service/README.md`](service/README.md) for the details — the systemd unit, the SysV init
+script, the Windows service, and nginx / Apache configuration.
+
+---
+
+## Configuration file
+
+`appsettings.json` sits next to the executable and is read at startup:
+
+```json
+{
+  "Logging": { "LogLevel": { "Default": "Information", "Microsoft.AspNetCore": "Warning" } },
+  "AllowedHosts": "*"
+}
+```
+
+Useful edits:
+
+* `"AllowedHosts": "office.example.com"` — reject requests carrying any other `Host` header.
+* `"Kestrel": { "Limits": { "MaxConcurrentConnections": 200 } }` — cap concurrent connections.
+* `"Kestrel": { "Certificates": { "Default": { "Path": "…pfx", "Password": "…" } } }` — HTTPS
+  without a reverse proxy.
+
+Prefer environment variables or command-line arguments for anything host-specific: they survive an
+in-place upgrade, which overwrites `appsettings.json`.
+
+---
+
+## Caching and upgrades
+
+The Writer bundle is content-hashed: every runtime asset carries its hash in the file name and is
+served `immutable`, while `index.html` and the Canvas replay module keep stable URLs and are served
+`no-cache`. That combination is what makes an upgrade safe — a browser picks up the new shell
+immediately and, through it, the new hashed assets.
+
+When you replace this folder, **replace `wwwroot/` wholesale** rather than copying files over an
+existing one. A leftover asset from an older release can be paired with the newer runtime by a
+cached shell, and the Writer then fails at load with `Unknown replay op …`. The install scripts in
+[`service/`](service/) already do this. If a browser is stuck on a stale bundle, a hard reload
+(Ctrl+Shift+R) clears it.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+| --- | --- |
+| `Failed to bind to address … address already in use` | Another process holds the port. Pick a different one with `--urls`, or find the holder: `ss -lptn 'sport = :5555'` / `netstat -ano \| findstr :5555`. |
+| Page loads but everything 404s; log says `The WebRootPath was not found` | `wwwroot/` is missing next to the executable — the package was extracted partially, or only the binary was copied. Re-extract the whole folder. |
+| `Permission denied` starting on Linux | The executable bit was lost (usually by unzipping on Windows): `chmod +x Broiler.Office.Server`. |
+| `Permission denied` binding port 80/443 on Linux | Ports below 1024 are privileged. Use 5555 behind a reverse proxy, or grant `CAP_NET_BIND_SERVICE` (see `service/README.md`). |
+| Reachable locally, not from another machine | Either the listener is loopback-only (use `--urls http://0.0.0.0:5555`) or a firewall is in the way (`ufw allow 5555/tcp`, or `-OpenFirewall` on Windows). |
+| `You must install .NET to run this application` | A framework-dependent package without the ASP.NET Core 10 runtime installed. Install it, or use the self-contained package. |
+| Writer fails at load with `Unknown replay op …` | A stale, cached bundle. Hard-reload the browser; on the server, replace `wwwroot/` wholesale rather than merging. |
+
+Turn up the detail when something is unclear:
+
+```bash
+./Broiler.Office.Server --urls http://0.0.0.0:5555 \
+    --Logging:LogLevel:Default=Debug --Logging:LogLevel:Microsoft.AspNetCore=Information
+```
+
+---
+
+## What is in this package
+
+```
+BOSS/
+├── Broiler.Office.Server[.exe]   the server
+├── appsettings.json              configuration
+├── wwwroot/                      the Broiler Writer WebAssembly bundle
+├── README.md                     this file
+├── run-boss.sh / Start-BOSS.cmd  foreground launcher
+└── service/                      unit files, install scripts, reverse-proxy samples
+```
+
+Source and issue tracker: <https://github.com/Broiler-Platform/Broiler>.

--- a/Broiler.Office.Server/packaging/linux/run-boss.sh
+++ b/Broiler.Office.Server/packaging/linux/run-boss.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# run-boss.sh — start BOSS in the foreground from the extracted package.
+#
+#   ./run-boss.sh                              # http://0.0.0.0:5555
+#   ./run-boss.sh --urls http://127.0.0.1:8080 # any argument the server accepts
+#   BOSS_URLS=http://[::]:5555 ./run-boss.sh   # or set the port via the environment
+#
+# Convenience only — for a machine that should serve the Writer across reboots, install the service:
+#   sudo ./service/install-service.sh
+
+set -eu
+
+BOSS_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BOSS_EXEC=$BOSS_DIR/Broiler.Office.Server
+BOSS_URLS=${BOSS_URLS:-http://0.0.0.0:5555}
+
+[ -x "$BOSS_EXEC" ] || {
+    # Extracting the archive on Windows and copying it over loses the executable bit.
+    if [ -f "$BOSS_EXEC" ]; then
+        chmod +x "$BOSS_EXEC"
+    else
+        echo "run-boss.sh: $BOSS_EXEC not found — run this from the extracted BOSS directory." >&2
+        exit 1
+    fi
+}
+
+[ -d "$BOSS_DIR/wwwroot" ] || {
+    echo "run-boss.sh: $BOSS_DIR/wwwroot is missing — the server has no Writer bundle to serve." >&2
+    exit 1
+}
+
+export DOTNET_NOLOGO=1
+export ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT:-Production}
+
+# Caller arguments win: they come last, and --urls is last-wins in the configuration provider.
+if [ $# -gt 0 ]; then
+    exec "$BOSS_EXEC" --urls "$BOSS_URLS" "$@"
+fi
+
+echo "BOSS — Broiler Office Standalone Server"
+echo "  Writer:  ${BOSS_URLS%%;*}/"
+echo "  Health:  ${BOSS_URLS%%;*}/healthz"
+echo "  Stop:    Ctrl+C"
+echo
+exec "$BOSS_EXEC" --urls "$BOSS_URLS"

--- a/Broiler.Office.Server/packaging/linux/service/README.md
+++ b/Broiler.Office.Server/packaging/linux/service/README.md
@@ -1,0 +1,202 @@
+# Running BOSS as a Linux service
+
+Everything here installs **BOSS — the Broiler Office Standalone Server** as a system service so the
+Broiler Writer is served across reboots.
+
+```
+service/
+├── install-service.sh      installs for systemd or SysV (auto-detected)
+├── uninstall-service.sh    undoes it
+├── systemd/
+│   ├── broiler-office-server.service    the unit
+│   └── broiler-office-server.env        settings → /etc/broiler/office-server.env
+├── sysv/
+│   ├── broiler-office-server            LSB init script
+│   └── broiler-office-server.default    settings → /etc/default (or /etc/sysconfig)
+└── reverse-proxy/
+    ├── nginx-broiler-office-server.conf
+    └── apache-broiler-office-server.conf
+```
+
+---
+
+## Install
+
+From the extracted package, as root:
+
+```bash
+sudo ./service/install-service.sh                                  # auto-detect, port 5555
+sudo ./service/install-service.sh --urls http://127.0.0.1:5555     # loopback only (reverse proxy)
+sudo ./service/install-service.sh --init sysv --prefix /srv/boss --user www-data
+```
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `--init auto\|systemd\|sysv` | `auto` | Which service manager to target. `auto` picks systemd when `/run/systemd/system` exists. |
+| `--prefix DIR` | `/opt/broiler/office-server` | Where the server and its `wwwroot/` are installed. |
+| `--user NAME` | `broiler` | Service account; created as a system user if missing. |
+| `--urls URLS` | `http://0.0.0.0:5555` | Listening addresses baked into the configuration file. |
+| `--no-start` | — | Install and enable, but leave the service stopped. |
+
+The script copies the payload into `--prefix`, creates the account, installs the unit or init script
+plus its configuration file, and starts the service. **Re-running it upgrades in place** — the
+payload is refreshed (`wwwroot/` replaced wholesale) and an existing configuration file is kept, with
+the new version written beside it as `*.new`.
+
+Check it:
+
+```bash
+curl -fsS http://localhost:5555/healthz && echo
+```
+
+---
+
+## systemd
+
+```bash
+systemctl status broiler-office-server
+systemctl restart broiler-office-server
+journalctl -u broiler-office-server -f
+sudoedit /etc/broiler/office-server.env      # listening addresses, environment, log levels
+```
+
+The unit is `Type=notify`: the server links `Microsoft.Extensions.Hosting.Systemd` and signals
+`READY=1` only once Kestrel is actually listening, so `systemctl start` returning success means the
+site is up — and another unit may order itself `After=broiler-office-server.service`.
+
+**Settings live in `/etc/broiler/office-server.env`, not in the unit.** The unit declares defaults
+with `Environment=` and then reads the env file, which is applied afterwards and therefore wins. An
+upgrade replaces the unit and leaves your env file alone.
+
+```ini
+BOSS_ARGS=--urls http://0.0.0.0:5555
+ASPNETCORE_ENVIRONMENT=Production
+```
+
+`$BOSS_ARGS` is word-split by systemd, so several arguments work:
+`BOSS_ARGS=--urls http://127.0.0.1:5555 --Logging:LogLevel:Microsoft.AspNetCore=Information`.
+
+### Sandboxing
+
+The unit is confined: `ProtectSystem=strict`, `PrivateTmp`, `NoNewPrivileges`, a restricted syscall
+filter, and no writable path other than `/var/cache/broiler-office-server`. Two consequences worth
+knowing:
+
+* `MemoryDenyWriteExecute` is deliberately **absent** — the .NET JIT needs writable-executable
+  pages, and the service will not start with it on.
+* If you point the server at a certificate or content outside the install tree, add
+  `ReadWritePaths=` / relax `ProtectHome=` accordingly with a drop-in:
+  `systemctl edit broiler-office-server`.
+
+### Privileged ports
+
+Binding 80 or 443 as a non-root user needs a capability. Uncomment in the unit (or add a drop-in):
+
+```ini
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+```
+
+Terminating TLS in a reverse proxy is usually the better answer — see `reverse-proxy/`.
+
+---
+
+## SysV init
+
+For systems without systemd (older RHEL/CentOS, Devuan, busybox images):
+
+```bash
+service broiler-office-server start|stop|restart|status
+tail -f /var/log/broiler-office-server.log
+$EDITOR /etc/default/broiler-office-server        # or /etc/sysconfig/… on RHEL
+```
+
+The init script is LSB-compliant (`status` returns 0 when running, 3 when not), uses
+`start-stop-daemon` where available and a plain `su` + PID file elsewhere, and waits up to
+`STOP_TIMEOUT` seconds for a graceful stop before `SIGKILL`. There is no journal here, so stdout and
+stderr go to `LOGFILE` — add a `logrotate` rule if the service runs long enough for that to matter:
+
+```
+/var/log/broiler-office-server.log {
+    weekly
+    rotate 8
+    compress
+    missingok
+    copytruncate
+}
+```
+
+---
+
+## Behind a reverse proxy
+
+Run BOSS on loopback and let nginx or Apache terminate TLS:
+
+```bash
+sudo ./service/install-service.sh --urls http://127.0.0.1:5555
+sudo cp service/reverse-proxy/nginx-broiler-office-server.conf /etc/nginx/sites-available/boss.conf
+sudo ln -s /etc/nginx/sites-available/boss.conf /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+Both samples pass `X-Forwarded-*` through and leave BOSS's own `Cache-Control` headers alone — the
+Writer bundle depends on them (content-hashed assets `immutable`, the shell `no-cache`). The nginx
+sample can also serve the pre-compressed `.br`/`.gz` siblings the build emits instead of
+recompressing the wasm payload per request.
+
+---
+
+## Manual install (no scripts)
+
+```bash
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin broiler
+sudo mkdir -p /opt/broiler/office-server
+sudo cp -a ./. /opt/broiler/office-server/
+sudo cp service/systemd/broiler-office-server.service /etc/systemd/system/
+sudo install -Dm640 service/systemd/broiler-office-server.env /etc/broiler/office-server.env
+sudo systemctl daemon-reload
+sudo systemctl enable --now broiler-office-server
+```
+
+Edit the unit if you install somewhere other than `/opt/broiler/office-server` or run as another
+user — the paths and `User=`/`Group=` are literal in the shipped file.
+
+---
+
+## Upgrade
+
+Extract the new package and re-run the installer; the service is restarted for you:
+
+```bash
+sudo ./service/install-service.sh --urls http://0.0.0.0:5555
+```
+
+Your `/etc/broiler/office-server.env` (or `/etc/default/broiler-office-server`) is preserved.
+
+---
+
+## Uninstall
+
+```bash
+sudo ./service/uninstall-service.sh                  # stop, disable, remove unit + files
+sudo ./service/uninstall-service.sh --keep-config    # keep the settings file
+```
+
+The service account is intentionally left behind — delete it with `userdel broiler` once you are
+sure nothing else uses it.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| `systemctl start` hangs, then times out | `Type=notify` and the process never reported ready. `journalctl -u broiler-office-server -n 50` shows why — usually a port already in use. |
+| `status=203/EXEC` | The executable bit is missing or the path in the unit is wrong: `chmod +x /opt/broiler/office-server/Broiler.Office.Server`. |
+| `status=209/STDOUT`, `226/NAMESPACE` | A sandbox directive is too strict for your kernel or filesystem. Relax it in a drop-in: `systemctl edit broiler-office-server`. |
+| Service runs, pages 404 | `wwwroot/` did not make it into the install prefix. Re-run the installer from the *complete* extracted package. |
+| `Permission denied` on port 80/443 | See **Privileged ports** above. |
+| Env file edits do nothing | `systemctl restart broiler-office-server` — the file is read at start. Check for a stray `.new` file next to it. |
+
+For anything above the service layer — arguments, endpoints, configuration precedence, caching —
+see [`../README.md`](../README.md).

--- a/Broiler.Office.Server/packaging/linux/service/install-service.sh
+++ b/Broiler.Office.Server/packaging/linux/service/install-service.sh
@@ -1,0 +1,191 @@
+#!/bin/sh
+#
+# install-service.sh — install BOSS (the Broiler Office Standalone Server) as a system service.
+#
+# Run it from the extracted preview package, as root:
+#
+#   sudo ./BOSS/service/install-service.sh                        # auto-detect systemd or SysV
+#   sudo ./BOSS/service/install-service.sh --urls http://0.0.0.0:5555
+#   sudo ./BOSS/service/install-service.sh --init sysv --prefix /srv/boss --user www-data
+#
+# It copies the server next to its vendored wwwroot into --prefix, creates the service account,
+# installs the unit / init script plus its configuration file, and (unless --no-start) enables and
+# starts the service. Re-running it upgrades the payload in place; an existing configuration file is
+# never overwritten (the new one is written alongside as *.new).
+#
+# Undo with ./uninstall-service.sh.
+
+set -eu
+
+PREFIX=/opt/broiler/office-server
+SERVICE_USER=broiler
+SERVICE_NAME=broiler-office-server
+URLS="http://0.0.0.0:5555"
+INIT=auto
+START=1
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+PAYLOAD_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+
+usage() {
+    sed -n '3,20p' "$0" | sed 's/^# \{0,1\}//'
+    cat <<EOF
+
+Options:
+  --init auto|systemd|sysv   Service manager to target (default: auto).
+  --prefix DIR               Install directory (default: $PREFIX).
+  --user NAME                Service account, created if missing (default: $SERVICE_USER).
+  --urls URLS                Listening addresses (default: $URLS).
+  --no-start                 Install and enable, but do not start the service.
+  -h, --help                 Show this help.
+EOF
+}
+
+fail() { echo "install-service.sh: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --init) INIT=${2:-}; shift 2 ;;
+        --prefix) PREFIX=${2:-}; shift 2 ;;
+        --user) SERVICE_USER=${2:-}; shift 2 ;;
+        --urls) URLS=${2:-}; shift 2 ;;
+        --no-start) START=0; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) fail "unknown option '$1' (try --help)" ;;
+    esac
+done
+
+[ "$(id -u)" = "0" ] || fail "must run as root (try: sudo $0 $*)"
+[ -f "$PAYLOAD_DIR/Broiler.Office.Server" ] || \
+    fail "Broiler.Office.Server not found in $PAYLOAD_DIR — run this script from the extracted package."
+[ -d "$PAYLOAD_DIR/wwwroot" ] || \
+    fail "$PAYLOAD_DIR/wwwroot is missing — the package is incomplete; the server has nothing to serve."
+
+case "$INIT" in
+    auto)
+        if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then
+            INIT=systemd
+        elif [ -d /etc/init.d ]; then
+            INIT=sysv
+        else
+            fail "could not detect a service manager; pass --init systemd or --init sysv"
+        fi
+        ;;
+    systemd|sysv) ;;
+    *) fail "--init must be auto, systemd or sysv" ;;
+esac
+
+echo "BOSS install"
+echo "  service manager : $INIT"
+echo "  install prefix  : $PREFIX"
+echo "  service account : $SERVICE_USER"
+echo "  listening on    : $URLS"
+echo
+
+# ── Service account ──────────────────────────────────────────────────────────────────────────────
+if id "$SERVICE_USER" >/dev/null 2>&1; then
+    echo "==> account '$SERVICE_USER' already exists"
+else
+    echo "==> creating system account '$SERVICE_USER'"
+    if command -v groupadd >/dev/null 2>&1 && command -v useradd >/dev/null 2>&1; then
+        groupadd --system "$SERVICE_USER" 2>/dev/null || true
+        useradd --system --gid "$SERVICE_USER" --home-dir "$PREFIX" \
+                --no-create-home --shell /usr/sbin/nologin "$SERVICE_USER"
+    elif command -v addgroup >/dev/null 2>&1 && command -v adduser >/dev/null 2>&1; then
+        # busybox / Alpine
+        addgroup -S "$SERVICE_USER" 2>/dev/null || true
+        adduser -S -D -H -G "$SERVICE_USER" -h "$PREFIX" -s /sbin/nologin "$SERVICE_USER"
+    else
+        fail "no useradd/adduser available — create the '$SERVICE_USER' account manually and re-run"
+    fi
+fi
+
+# ── Payload ──────────────────────────────────────────────────────────────────────────────────────
+echo "==> installing the server into $PREFIX"
+mkdir -p "$PREFIX"
+# The vendored wwwroot is content-hashed: a stale asset from a previous release can be paired with
+# a freshly-hashed runtime by a cached index.html, so replace it wholesale rather than merging.
+rm -rf "$PREFIX/wwwroot"
+# `.` copies the contents (including dotfiles) rather than nesting the directory.
+cp -a "$PAYLOAD_DIR/." "$PREFIX/"
+chown -R root:root "$PREFIX" 2>/dev/null || true
+chmod 0755 "$PREFIX/Broiler.Office.Server"
+
+# ── Service manager ──────────────────────────────────────────────────────────────────────────────
+# Replaces the packaged defaults; '|' as the sed delimiter keeps URLs and paths readable.
+rewrite() {
+    sed -e "s|/opt/broiler/office-server|$PREFIX|g" \
+        -e "s|^User=broiler$|User=$SERVICE_USER|" \
+        -e "s|^Group=broiler$|Group=$SERVICE_USER|" \
+        -e "s|^BOSS_USER=broiler$|BOSS_USER=$SERVICE_USER|" \
+        -e "s|--urls http://0.0.0.0:5555|--urls $URLS|g" \
+        "$1" > "$2"
+}
+
+# Writes to $2 unless it already exists, in which case the new content lands in $2.new so a local
+# edit survives an upgrade.
+install_config() {
+    if [ -f "$2" ]; then
+        rewrite "$1" "$2.new"
+        echo "    kept existing $2 (new version written to $2.new)"
+    else
+        rewrite "$1" "$2"
+        chmod 0640 "$2"
+        echo "    wrote $2"
+    fi
+}
+
+if [ "$INIT" = systemd ]; then
+    echo "==> installing the systemd unit"
+    rewrite "$SCRIPT_DIR/systemd/$SERVICE_NAME.service" "/etc/systemd/system/$SERVICE_NAME.service"
+    chmod 0644 "/etc/systemd/system/$SERVICE_NAME.service"
+    mkdir -p /etc/broiler
+    install_config "$SCRIPT_DIR/systemd/$SERVICE_NAME.env" /etc/broiler/office-server.env
+
+    systemctl daemon-reload
+    systemctl enable "$SERVICE_NAME" >/dev/null
+    if [ "$START" = 1 ]; then
+        systemctl restart "$SERVICE_NAME"
+        # Type=notify: systemctl returns once the server reports READY=1, so this reflects a real bind.
+        systemctl --no-pager --lines=0 status "$SERVICE_NAME" || true
+    fi
+
+    echo
+    echo "Done. Manage it with:"
+    echo "  systemctl {start|stop|restart|status} $SERVICE_NAME"
+    echo "  journalctl -u $SERVICE_NAME -f"
+    echo "  \$EDITOR /etc/broiler/office-server.env   # listening addresses and environment"
+else
+    echo "==> installing the SysV init script"
+    rewrite "$SCRIPT_DIR/sysv/$SERVICE_NAME" "/etc/init.d/$SERVICE_NAME"
+    chmod 0755 "/etc/init.d/$SERVICE_NAME"
+
+    if [ -d /etc/sysconfig ]; then
+        install_config "$SCRIPT_DIR/sysv/$SERVICE_NAME.default" "/etc/sysconfig/$SERVICE_NAME"
+    else
+        mkdir -p /etc/default
+        install_config "$SCRIPT_DIR/sysv/$SERVICE_NAME.default" "/etc/default/$SERVICE_NAME"
+    fi
+
+    if command -v update-rc.d >/dev/null 2>&1; then
+        update-rc.d "$SERVICE_NAME" defaults >/dev/null
+    elif command -v chkconfig >/dev/null 2>&1; then
+        chkconfig --add "$SERVICE_NAME"
+        chkconfig "$SERVICE_NAME" on
+    elif command -v rc-update >/dev/null 2>&1; then
+        rc-update add "$SERVICE_NAME" default >/dev/null
+    else
+        echo "    no update-rc.d/chkconfig/rc-update found — register /etc/init.d/$SERVICE_NAME manually"
+    fi
+
+    [ "$START" = 1 ] && "/etc/init.d/$SERVICE_NAME" restart
+
+    echo
+    echo "Done. Manage it with:"
+    echo "  service $SERVICE_NAME {start|stop|restart|status}"
+    echo "  tail -f /var/log/$SERVICE_NAME.log"
+fi
+
+echo
+echo "Check it is serving:"
+echo "  curl -fsS ${URLS%%;*}/healthz && echo"

--- a/Broiler.Office.Server/packaging/linux/service/reverse-proxy/apache-broiler-office-server.conf
+++ b/Broiler.Office.Server/packaging/linux/service/reverse-proxy/apache-broiler-office-server.conf
@@ -1,0 +1,43 @@
+# BOSS — Broiler Office Standalone Server behind Apache httpd.
+#
+# Needs mod_proxy, mod_proxy_http, mod_headers and mod_ssl:
+#   a2enmod proxy proxy_http headers ssl        (Debian/Ubuntu)
+#
+# Drop into /etc/apache2/sites-available/ (Debian) or /etc/httpd/conf.d/ (RHEL), adjust ServerName
+# and the certificate paths, then `apachectl configtest && systemctl reload apache2`.
+#
+# Pair it with a loopback-only listener so the server is reachable only through the proxy:
+#   BOSS_ARGS=--urls http://127.0.0.1:5555      (in /etc/broiler/office-server.env)
+
+<VirtualHost *:80>
+    ServerName office.example.com
+    Redirect permanent / https://office.example.com/
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName office.example.com
+
+    SSLEngine on
+    SSLCertificateFile    /etc/letsencrypt/live/office.example.com/fullchain.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/office.example.com/privkey.pem
+
+    ProxyPreserveHost On
+    ProxyRequests Off
+    RequestHeader set X-Forwarded-Proto "https"
+
+    # The mono-wasm runtime is a large single download; give it room.
+    ProxyTimeout 300
+
+    ProxyPass        / http://127.0.0.1:5555/ timeout=300
+    ProxyPassReverse / http://127.0.0.1:5555/
+
+    # BOSS sets Cache-Control itself (immutable for content-hashed assets, no-cache for index.html
+    # and the replay module) — do not override it here.
+
+    # Liveness endpoint, handy as a monitoring target.
+    ProxyPass        /healthz http://127.0.0.1:5555/healthz
+    ProxyPassReverse /healthz http://127.0.0.1:5555/healthz
+
+    ErrorLog  ${APACHE_LOG_DIR}/broiler-office-server-error.log
+    CustomLog ${APACHE_LOG_DIR}/broiler-office-server-access.log combined
+</VirtualHost>

--- a/Broiler.Office.Server/packaging/linux/service/reverse-proxy/nginx-broiler-office-server.conf
+++ b/Broiler.Office.Server/packaging/linux/service/reverse-proxy/nginx-broiler-office-server.conf
@@ -1,0 +1,64 @@
+# BOSS — Broiler Office Standalone Server behind nginx.
+#
+# Drop into /etc/nginx/sites-available/ (Debian) or /etc/nginx/conf.d/ (RHEL), adjust server_name and
+# the certificate paths, then `nginx -t && systemctl reload nginx`.
+#
+# Pair it with a loopback-only listener so the server is reachable only through the proxy:
+#   BOSS_ARGS=--urls http://127.0.0.1:5555        (in /etc/broiler/office-server.env)
+
+upstream broiler_office_server {
+    server 127.0.0.1:5555;
+    keepalive 16;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name office.example.com;
+
+    # Everything except the ACME challenge goes to HTTPS.
+    location /.well-known/acme-challenge/ { root /var/www/html; }
+    location / { return 301 https://$host$request_uri; }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name office.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/office.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/office.example.com/privkey.pem;
+
+    # The WebAssembly runtime is a few tens of megabytes of .wasm; the defaults are too small.
+    client_max_body_size 64m;
+    proxy_read_timeout 300s;
+
+    # BOSS already sets Cache-Control (immutable for the content-hashed runtime assets, no-cache for
+    # index.html and the replay module). Pass it through rather than overriding it here.
+    location / {
+        proxy_pass         http://broiler_office_server;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Connection        "";
+        proxy_buffering    off;
+    }
+
+    # Serve the pre-compressed .br / .gz siblings the publish step emits instead of recompressing
+    # the wasm payload on every request. `gzip_static` is built in; `brotli_static` needs
+    # ngx_brotli — drop the line if the module is not installed.
+    location /_framework/ {
+        proxy_pass http://broiler_office_server;
+        gzip_static on;
+        # brotli_static on;
+    }
+
+    # Liveness endpoint — useful as an upstream health check; keep it out of the access log.
+    location = /healthz {
+        proxy_pass http://broiler_office_server;
+        access_log off;
+    }
+}

--- a/Broiler.Office.Server/packaging/linux/service/systemd/broiler-office-server.env
+++ b/Broiler.Office.Server/packaging/linux/service/systemd/broiler-office-server.env
@@ -1,0 +1,48 @@
+# BOSS — Broiler Office Standalone Server
+# Environment file for the systemd unit. Installed to /etc/broiler/office-server.env.
+#
+# Values here override the Environment= defaults baked into the unit, so the unit file itself never
+# has to be edited (and stays replaceable on upgrade). Apply changes with:
+#
+#   sudo systemctl restart broiler-office-server
+#
+# Format is systemd's, not a shell script: KEY=value, no `export`, no command substitution. Quote a
+# value only to protect leading/trailing whitespace — quotes are stripped, they do not group words.
+
+# ── Listening addresses ──────────────────────────────────────────────────────────────────────────
+# Passed verbatim to the server; systemd word-splits this into separate arguments.
+#   http://0.0.0.0:5555        all IPv4 interfaces, port 5555
+#   http://127.0.0.1:5555      loopback only (the safe choice behind a reverse proxy)
+#   http://[::]:5555           all interfaces, IPv4 + IPv6
+# Several endpoints are separated with a semicolon:
+#   --urls "http://127.0.0.1:5555;http://10.0.0.4:5555"
+BOSS_ARGS=--urls http://0.0.0.0:5555
+
+# Equivalent to --urls; use one or the other, not both (--urls wins).
+# ASPNETCORE_URLS=http://0.0.0.0:5555
+
+# ── Environment name ─────────────────────────────────────────────────────────────────────────────
+# Selects appsettings.<name>.json and turns the developer exception page off (Production) or on.
+ASPNETCORE_ENVIRONMENT=Production
+
+# ── Logging ──────────────────────────────────────────────────────────────────────────────────────
+# Everything the server writes goes to the journal: journalctl -u broiler-office-server -f
+# Logging__LogLevel__Default=Information
+# Logging__LogLevel__Microsoft.AspNetCore=Warning
+
+# ── HTTPS (direct TLS termination, no reverse proxy) ─────────────────────────────────────────────
+# Point BOSS at a PFX bundle readable by the service user. Prefer a reverse proxy for public
+# deployments — see ../reverse-proxy/ for nginx and Apache samples.
+# BOSS_ARGS=--urls https://0.0.0.0:5556;http://127.0.0.1:5555
+# Kestrel__Certificates__Default__Path=/etc/broiler/office-server.pfx
+# Kestrel__Certificates__Default__Password=
+
+# ── Behind a reverse proxy ───────────────────────────────────────────────────────────────────────
+# Only relevant if the app is mounted somewhere other than the site root, or the proxy speaks HTTPS
+# while BOSS speaks HTTP; keep the proxy's X-Forwarded-* headers in that case.
+# ASPNETCORE_FORWARDEDHEADERS_ENABLED=true
+
+# ── Resource limits ──────────────────────────────────────────────────────────────────────────────
+# DOTNET_GCHeapHardLimit is a hex byte count: 0x10000000 = 256 MiB.
+# DOTNET_GCHeapHardLimit=0x10000000
+# DOTNET_TieredPGO=1

--- a/Broiler.Office.Server/packaging/linux/service/systemd/broiler-office-server.service
+++ b/Broiler.Office.Server/packaging/linux/service/systemd/broiler-office-server.service
@@ -1,0 +1,77 @@
+[Unit]
+Description=BOSS — Broiler Office Standalone Server
+Documentation=https://github.com/Broiler-Platform/Broiler
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# The server links Microsoft.Extensions.Hosting.Systemd, so it signals READY=1 once Kestrel is
+# listening and STOPPING=1 on shutdown. Type=notify therefore reports the unit "active" only when
+# the site is actually serving — dependent units (a reverse proxy) may order themselves After= it.
+Type=notify
+NotifyAccess=main
+
+User=broiler
+Group=broiler
+WorkingDirectory=/opt/broiler/office-server
+
+# Defaults first, environment file second: EnvironmentFile is applied after Environment=, so
+# anything set in /etc/broiler/office-server.env overrides what is declared here.
+Environment=ASPNETCORE_ENVIRONMENT=Production
+Environment=DOTNET_NOLOGO=1
+Environment=DOTNET_PRINT_TELEMETRY_MESSAGE=false
+# Extraction target for a single-file publish (ignored by a folder publish). %C is the systemd
+# cache directory declared by CacheDirectory= below.
+Environment=DOTNET_BUNDLE_EXTRACT_BASE_DIR=%C/broiler-office-server
+Environment="BOSS_ARGS=--urls http://0.0.0.0:5555"
+EnvironmentFile=-/etc/broiler/office-server.env
+
+# $BOSS_ARGS is deliberately unquoted: systemd word-splits it, so the env file can pass several
+# arguments (e.g. --urls http://0.0.0.0:5555 --environment Staging).
+ExecStart=/opt/broiler/office-server/Broiler.Office.Server $BOSS_ARGS
+
+Restart=on-failure
+RestartSec=5s
+TimeoutStopSec=30s
+KillSignal=SIGTERM
+
+# Journal identity: `journalctl -u broiler-office-server` / `-t broiler-office-server`.
+SyslogIdentifier=broiler-office-server
+
+# ── Sandboxing ───────────────────────────────────────────────────────────────────────────────────
+# Note: MemoryDenyWriteExecute is intentionally NOT set — the .NET JIT needs writable-executable
+# pages and the service will not start with it enabled.
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+RestrictNamespaces=true
+LockPersonality=true
+RemoveIPC=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+SystemCallFilter=@system-service
+SystemCallArchitectures=native
+
+# The install tree is read-only to the service (ProtectSystem=strict); these are the only writable
+# paths it gets — /var/cache/broiler-office-server and a private /tmp.
+CacheDirectory=broiler-office-server
+CacheDirectoryMode=0750
+
+LimitNOFILE=65535
+
+# Binding a privileged port (80/443) instead of 5555 needs the capability below — uncomment both
+# lines. Terminating TLS in a reverse proxy is the recommended alternative; see the samples in
+# ../reverse-proxy/.
+# AmbientCapabilities=CAP_NET_BIND_SERVICE
+# CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target

--- a/Broiler.Office.Server/packaging/linux/service/sysv/broiler-office-server
+++ b/Broiler.Office.Server/packaging/linux/service/sysv/broiler-office-server
@@ -1,0 +1,194 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          broiler-office-server
+# Required-Start:    $local_fs $remote_fs $network $syslog
+# Required-Stop:     $local_fs $remote_fs $network $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: BOSS - Broiler Office Standalone Server
+# Description:       Kestrel host serving the Broiler Office web apps (Broiler Writer).
+### END INIT INFO
+#
+# SysV init script for BOSS - the Broiler Office Standalone Server.
+#
+# Install as /etc/init.d/broiler-office-server (mode 0755), then register it:
+#   Debian/Ubuntu : update-rc.d broiler-office-server defaults
+#   RHEL/CentOS   : chkconfig --add broiler-office-server
+#   Alpine/busybox: rc-update add broiler-office-server default
+#
+# Settings live in /etc/default/broiler-office-server (Debian) or
+# /etc/sysconfig/broiler-office-server (RHEL) - see the sample beside this file. Nothing below needs
+# editing for an ordinary install.
+
+set -e
+
+NAME=broiler-office-server
+DESC="BOSS - Broiler Office Standalone Server"
+
+# ── Defaults (override in the settings file, do not edit here) ───────────────────────────────────
+BOSS_HOME=/opt/broiler/office-server
+BOSS_EXEC=
+BOSS_USER=broiler
+BOSS_ARGS="--urls http://0.0.0.0:5555"
+BOSS_ENVIRONMENT=Production
+PIDFILE=/var/run/$NAME.pid
+LOGFILE=/var/log/$NAME.log
+STOP_TIMEOUT=30
+
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+[ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+
+[ -n "$BOSS_EXEC" ] || BOSS_EXEC=$BOSS_HOME/Broiler.Office.Server
+
+export ASPNETCORE_ENVIRONMENT=$BOSS_ENVIRONMENT
+export DOTNET_NOLOGO=1
+export DOTNET_PRINT_TELEMETRY_MESSAGE=false
+# Extraction target for a single-file publish; harmless for a folder publish.
+export DOTNET_BUNDLE_EXTRACT_BASE_DIR=${DOTNET_BUNDLE_EXTRACT_BASE_DIR:-/var/cache/$NAME}
+
+# LSB exit codes: 0 = success, 1 = generic error, 3 = not running, 4 = unknown status,
+# 5 = program not installed.
+lsb_running=0
+lsb_dead=3
+
+log_action() {
+    if [ -x /lib/lsb/init-functions ] || [ -r /lib/lsb/init-functions ]; then
+        # shellcheck disable=SC1091
+        . /lib/lsb/init-functions 2>/dev/null || true
+    fi
+    echo "$*"
+}
+
+# Echoes the PID when the service is up; empty (and returns 1) when it is not.
+running_pid() {
+    [ -f "$PIDFILE" ] || return 1
+    pid=$(cat "$PIDFILE" 2>/dev/null) || return 1
+    [ -n "$pid" ] || return 1
+    kill -0 "$pid" 2>/dev/null || return 1
+    echo "$pid"
+}
+
+ensure_paths() {
+    [ -x "$BOSS_EXEC" ] || {
+        echo "$NAME: server executable not found or not executable: $BOSS_EXEC" >&2
+        exit 5
+    }
+    for dir in "$(dirname "$PIDFILE")" "$(dirname "$LOGFILE")" "$DOTNET_BUNDLE_EXTRACT_BASE_DIR"; do
+        [ -d "$dir" ] || mkdir -p "$dir"
+    done
+    : > "$LOGFILE" 2>/dev/null || true
+    if id "$BOSS_USER" >/dev/null 2>&1; then
+        chown "$BOSS_USER" "$LOGFILE" "$DOTNET_BUNDLE_EXTRACT_BASE_DIR" 2>/dev/null || true
+    fi
+}
+
+do_start() {
+    if pid=$(running_pid); then
+        log_action "$DESC is already running (pid $pid)."
+        return 0
+    fi
+
+    ensure_paths
+    log_action "Starting $DESC ..."
+
+    if command -v start-stop-daemon >/dev/null 2>&1; then
+        start-stop-daemon --start --quiet \
+            --chuid "$BOSS_USER" \
+            --chdir "$BOSS_HOME" \
+            --background \
+            --no-close \
+            --make-pidfile --pidfile "$PIDFILE" \
+            --exec "$BOSS_EXEC" -- $BOSS_ARGS >> "$LOGFILE" 2>&1
+    else
+        # No start-stop-daemon (RHEL, Alpine, minimal images): background it by hand and record the
+        # PID of the server itself - `exec` replaces the shell so $! is the server, not a wrapper.
+        su -s /bin/sh -c \
+            "cd '$BOSS_HOME' && exec '$BOSS_EXEC' $BOSS_ARGS >> '$LOGFILE' 2>&1 & echo \$! > '$PIDFILE'" \
+            "$BOSS_USER"
+    fi
+
+    # Give it a moment to fail loudly (bad port, missing wwwroot) rather than report a false start.
+    sleep 2
+    if pid=$(running_pid); then
+        log_action "$DESC started (pid $pid); logging to $LOGFILE."
+        return 0
+    fi
+
+    echo "$NAME: failed to start; see $LOGFILE" >&2
+    rm -f "$PIDFILE"
+    return 1
+}
+
+do_stop() {
+    if ! pid=$(running_pid); then
+        log_action "$DESC is not running."
+        rm -f "$PIDFILE"
+        return 0
+    fi
+
+    log_action "Stopping $DESC (pid $pid) ..."
+    kill -TERM "$pid" 2>/dev/null || true
+
+    waited=0
+    while [ "$waited" -lt "$STOP_TIMEOUT" ]; do
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    if kill -0 "$pid" 2>/dev/null; then
+        log_action "$DESC did not stop within ${STOP_TIMEOUT}s; sending SIGKILL."
+        kill -KILL "$pid" 2>/dev/null || true
+        sleep 1
+    fi
+
+    rm -f "$PIDFILE"
+    log_action "$DESC stopped."
+    return 0
+}
+
+do_status() {
+    if pid=$(running_pid); then
+        echo "$DESC is running (pid $pid)."
+        return $lsb_running
+    fi
+    if [ -f "$PIDFILE" ]; then
+        echo "$DESC is not running, but $PIDFILE exists."
+        return 1
+    fi
+    echo "$DESC is not running."
+    return $lsb_dead
+}
+
+case "$1" in
+    start)
+        do_start
+        ;;
+    stop)
+        do_stop
+        ;;
+    restart|force-reload)
+        do_stop
+        do_start
+        ;;
+    try-restart)
+        if running_pid >/dev/null; then
+            do_stop
+            do_start
+        else
+            log_action "$DESC is not running; nothing to restart."
+        fi
+        ;;
+    status)
+        # `set -e` would abort before the caller sees the LSB status code.
+        set +e
+        do_status
+        exit $?
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|try-restart|force-reload|status}" >&2
+        exit 2
+        ;;
+esac
+
+exit 0

--- a/Broiler.Office.Server/packaging/linux/service/sysv/broiler-office-server.default
+++ b/Broiler.Office.Server/packaging/linux/service/sysv/broiler-office-server.default
@@ -1,0 +1,28 @@
+# BOSS — Broiler Office Standalone Server
+# Settings for the SysV init script. Install as:
+#   Debian/Ubuntu : /etc/default/broiler-office-server
+#   RHEL/CentOS   : /etc/sysconfig/broiler-office-server
+#
+# This file is sourced by /bin/sh, so it is a shell fragment: KEY=value, quote anything containing
+# spaces. Apply changes with `service broiler-office-server restart`.
+
+# Where the package was installed and which account runs it.
+BOSS_HOME=/opt/broiler/office-server
+BOSS_USER=broiler
+
+# Arguments passed to the server. The word splitting is the shell's, so several arguments work:
+#   BOSS_ARGS="--urls http://0.0.0.0:5555 --environment Staging"
+#   BOSS_ARGS="--urls http://127.0.0.1:5555"          # loopback only, behind a reverse proxy
+#   BOSS_ARGS="--urls http://[::]:5555"               # IPv4 + IPv6
+BOSS_ARGS="--urls http://0.0.0.0:5555"
+
+# Selects appsettings.<name>.json; Production also turns off the developer exception page.
+BOSS_ENVIRONMENT=Production
+
+# stdout/stderr sink. Unlike the systemd unit there is no journal here, so the init script keeps a
+# plain log file — rotate it with logrotate if the server runs long enough to matter.
+LOGFILE=/var/log/broiler-office-server.log
+
+# PID file location and how long to wait for a graceful stop before SIGKILL.
+PIDFILE=/var/run/broiler-office-server.pid
+STOP_TIMEOUT=30

--- a/Broiler.Office.Server/packaging/linux/service/uninstall-service.sh
+++ b/Broiler.Office.Server/packaging/linux/service/uninstall-service.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+#
+# uninstall-service.sh — remove the BOSS service installed by install-service.sh.
+#
+#   sudo ./uninstall-service.sh                 # stop, disable, remove unit + install tree
+#   sudo ./uninstall-service.sh --keep-config   # leave /etc/broiler/office-server.env in place
+#   sudo ./uninstall-service.sh --keep-files    # leave /opt/broiler/office-server in place
+#
+# The service account is never deleted: it may own files outside the install tree, and removing a
+# uid that is still referenced elsewhere is the more dangerous default. Remove it by hand with
+# `userdel broiler` once you are sure.
+
+set -eu
+
+PREFIX=/opt/broiler/office-server
+SERVICE_NAME=broiler-office-server
+KEEP_CONFIG=0
+KEEP_FILES=0
+
+fail() { echo "uninstall-service.sh: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --prefix) PREFIX=${2:-}; shift 2 ;;
+        --keep-config) KEEP_CONFIG=1; shift ;;
+        --keep-files) KEEP_FILES=1; shift ;;
+        -h|--help) sed -n '3,12p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) fail "unknown option '$1' (try --help)" ;;
+    esac
+done
+
+[ "$(id -u)" = "0" ] || fail "must run as root (try: sudo $0 $*)"
+
+if [ -f "/etc/systemd/system/$SERVICE_NAME.service" ]; then
+    echo "==> removing the systemd unit"
+    systemctl stop "$SERVICE_NAME" 2>/dev/null || true
+    systemctl disable "$SERVICE_NAME" 2>/dev/null || true
+    rm -f "/etc/systemd/system/$SERVICE_NAME.service"
+    systemctl daemon-reload
+    systemctl reset-failed "$SERVICE_NAME" 2>/dev/null || true
+fi
+
+if [ -f "/etc/init.d/$SERVICE_NAME" ]; then
+    echo "==> removing the SysV init script"
+    "/etc/init.d/$SERVICE_NAME" stop 2>/dev/null || true
+    if command -v update-rc.d >/dev/null 2>&1; then
+        update-rc.d -f "$SERVICE_NAME" remove >/dev/null 2>&1 || true
+    elif command -v chkconfig >/dev/null 2>&1; then
+        chkconfig --del "$SERVICE_NAME" 2>/dev/null || true
+    elif command -v rc-update >/dev/null 2>&1; then
+        rc-update del "$SERVICE_NAME" default 2>/dev/null || true
+    fi
+    rm -f "/etc/init.d/$SERVICE_NAME"
+fi
+
+if [ "$KEEP_CONFIG" = 0 ]; then
+    echo "==> removing configuration"
+    rm -f /etc/broiler/office-server.env /etc/broiler/office-server.env.new
+    rm -f "/etc/default/$SERVICE_NAME" "/etc/default/$SERVICE_NAME.new"
+    rm -f "/etc/sysconfig/$SERVICE_NAME" "/etc/sysconfig/$SERVICE_NAME.new"
+    rmdir /etc/broiler 2>/dev/null || true
+else
+    echo "==> keeping configuration"
+fi
+
+if [ "$KEEP_FILES" = 0 ]; then
+    echo "==> removing $PREFIX"
+    rm -rf "$PREFIX"
+    rm -rf "/var/cache/$SERVICE_NAME"
+    rm -f "/var/run/$SERVICE_NAME.pid"
+    # /opt/broiler is ours only if nothing else lives there; rmdir declines otherwise.
+    rmdir "$(dirname "$PREFIX")" 2>/dev/null || true
+else
+    echo "==> keeping $PREFIX"
+fi
+
+echo
+echo "Removed. The '$SERVICE_NAME' log file (/var/log/$SERVICE_NAME.log, SysV only) and the service"
+echo "account were left untouched."

--- a/Broiler.Office.Server/packaging/windows/Start-BOSS.cmd
+++ b/Broiler.Office.Server/packaging/windows/Start-BOSS.cmd
@@ -1,0 +1,40 @@
+@echo off
+rem ---------------------------------------------------------------------------------------------
+rem  Start-BOSS.cmd - run BOSS (the Broiler Office Standalone Server) in the foreground.
+rem
+rem    Start-BOSS.cmd                                 listens on http://0.0.0.0:5555
+rem    Start-BOSS.cmd --urls http://127.0.0.1:8080    any argument the server accepts
+rem
+rem  Convenience only - to serve the Writer across reboots, install it as a Windows service:
+rem    powershell -ExecutionPolicy Bypass -File service\Install-BossService.ps1
+rem ---------------------------------------------------------------------------------------------
+setlocal
+
+set "BOSS_DIR=%~dp0"
+set "BOSS_EXEC=%BOSS_DIR%Broiler.Office.Server.exe"
+if not defined BOSS_URLS set "BOSS_URLS=http://0.0.0.0:5555"
+if not defined ASPNETCORE_ENVIRONMENT set "ASPNETCORE_ENVIRONMENT=Production"
+set "DOTNET_NOLOGO=1"
+
+if not exist "%BOSS_EXEC%" (
+    echo Start-BOSS.cmd: %BOSS_EXEC% not found - run this from the extracted BOSS folder. 1>&2
+    exit /b 1
+)
+if not exist "%BOSS_DIR%wwwroot" (
+    echo Start-BOSS.cmd: %BOSS_DIR%wwwroot is missing - the server has no Writer bundle to serve. 1>&2
+    exit /b 1
+)
+
+rem Caller arguments come last so they win (--urls is last-wins in the configuration provider).
+if not "%~1"=="" (
+    "%BOSS_EXEC%" --urls "%BOSS_URLS%" %*
+    exit /b %ERRORLEVEL%
+)
+
+echo BOSS - Broiler Office Standalone Server
+echo   Writer:  %BOSS_URLS%/
+echo   Health:  %BOSS_URLS%/healthz
+echo   Stop:    Ctrl+C
+echo.
+"%BOSS_EXEC%" --urls "%BOSS_URLS%"
+exit /b %ERRORLEVEL%

--- a/Broiler.Office.Server/packaging/windows/service/Install-BossService.ps1
+++ b/Broiler.Office.Server/packaging/windows/service/Install-BossService.ps1
@@ -1,0 +1,180 @@
+<#
+.SYNOPSIS
+    Installs BOSS — the Broiler Office Standalone Server — as a Windows service.
+
+.DESCRIPTION
+    Copies the extracted BOSS folder to -InstallPath, registers a Windows service that starts it
+    with the requested listening addresses, and starts the service. The server links
+    Microsoft.Extensions.Hosting.WindowsServices, so it answers the service control protocol
+    directly — no wrapper (NSSM, srvany) is needed.
+
+    Re-running upgrades the payload in place: the service is stopped, the files are refreshed and
+    the service is started again.
+
+.PARAMETER Urls
+    Listening addresses passed to the server. Separate several with a semicolon.
+
+.PARAMETER InstallPath
+    Where to install the server. Defaults to %ProgramFiles%\Broiler\Office Server.
+
+.PARAMETER ServiceName
+    Windows service name. Defaults to BroilerOfficeServer.
+
+.PARAMETER ServiceAccount
+    Account the service runs as. Defaults to "NT AUTHORITY\NetworkService"; pass "LocalSystem" for
+    a more privileged account, or a domain account together with -ServiceAccountPassword.
+
+.PARAMETER OpenFirewall
+    Also add an inbound Windows Firewall rule for the TCP port found in -Urls.
+
+.PARAMETER NoStart
+    Register the service but do not start it.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\Install-BossService.ps1
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\Install-BossService.ps1 -Urls http://0.0.0.0:5555 -OpenFirewall
+
+.NOTES
+    Run from an elevated PowerShell prompt. Remove with .\Uninstall-BossService.ps1.
+#>
+[CmdletBinding()]
+param(
+    [string] $Urls = 'http://0.0.0.0:5555',
+    [string] $InstallPath = (Join-Path $env:ProgramFiles 'Broiler\Office Server'),
+    [string] $ServiceName = 'BroilerOfficeServer',
+    [string] $ServiceDisplayName = 'BOSS — Broiler Office Standalone Server',
+    [string] $ServiceAccount = 'NT AUTHORITY\NetworkService',
+    [System.Security.SecureString] $ServiceAccountPassword,
+    [string] $Environment = 'Production',
+    [switch] $OpenFirewall,
+    [switch] $NoStart
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Assert-Elevated {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+    if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        throw 'Install-BossService.ps1 must run from an elevated (Administrator) PowerShell prompt.'
+    }
+}
+
+Assert-Elevated
+
+$payloadDir = Split-Path -Parent $PSScriptRoot          # …\BOSS  (this script lives in …\BOSS\service)
+$sourceExe = Join-Path $payloadDir 'Broiler.Office.Server.exe'
+
+if (-not (Test-Path -LiteralPath $sourceExe)) {
+    throw "Broiler.Office.Server.exe was not found in $payloadDir — run this script from the extracted package."
+}
+if (-not (Test-Path -LiteralPath (Join-Path $payloadDir 'wwwroot'))) {
+    throw "$payloadDir\wwwroot is missing — the package is incomplete; the server has nothing to serve."
+}
+
+Write-Host 'BOSS install'
+Write-Host "  install path    : $InstallPath"
+Write-Host "  service name    : $ServiceName"
+Write-Host "  service account : $ServiceAccount"
+Write-Host "  listening on    : $Urls"
+Write-Host ''
+
+$existing = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+if ($existing -and $existing.Status -ne 'Stopped') {
+    Write-Host '==> stopping the running service'
+    Stop-Service -Name $ServiceName -Force
+    $existing.WaitForStatus('Stopped', [TimeSpan]::FromSeconds(60))
+}
+
+Write-Host "==> copying the server to $InstallPath"
+New-Item -ItemType Directory -Force -Path $InstallPath | Out-Null
+# The vendored wwwroot is content-hashed: a stale asset from a previous release can be paired with a
+# freshly-hashed runtime by a cached index.html, so replace it wholesale rather than merging.
+$targetWwwRoot = Join-Path $InstallPath 'wwwroot'
+if (Test-Path -LiteralPath $targetWwwRoot) { Remove-Item -LiteralPath $targetWwwRoot -Recurse -Force }
+Copy-Item -Path (Join-Path $payloadDir '*') -Destination $InstallPath -Recurse -Force
+
+$targetExe = Join-Path $InstallPath 'Broiler.Office.Server.exe'
+# The service binary path is a single command line; quote the executable so a path with spaces
+# (the ProgramFiles default has one) is not split into an argument.
+$binaryPath = '"{0}" --urls "{1}"' -f $targetExe, $Urls
+
+if ($existing) {
+    Write-Host '==> updating the existing service registration'
+    # Set-Service cannot change the binary path on Windows PowerShell 5.1; sc.exe can, everywhere.
+    & sc.exe config $ServiceName binPath= $binaryPath start= delayed-auto obj= $ServiceAccount | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "sc.exe config failed with exit code $LASTEXITCODE." }
+}
+else {
+    Write-Host '==> registering the service'
+    $newServiceArgs = @{
+        Name           = $ServiceName
+        BinaryPathName = $binaryPath
+        DisplayName    = $ServiceDisplayName
+        Description    = 'Serves the Broiler Office web apps (Broiler Writer) over Kestrel.'
+        StartupType    = 'Automatic'
+    }
+    if ($ServiceAccountPassword) {
+        $newServiceArgs.Credential = [pscredential]::new($ServiceAccount, $ServiceAccountPassword)
+    }
+    New-Service @newServiceArgs | Out-Null
+
+    if (-not $ServiceAccountPassword) {
+        # Built-in accounts (NetworkService, LocalService) take no password, and New-Service has no
+        # parameter for them — set the account after creation.
+        & sc.exe config $ServiceName obj= $ServiceAccount | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "sc.exe config (account) failed with exit code $LASTEXITCODE." }
+    }
+
+    # Delayed start keeps boot responsive; the WebAssembly bundle is large but only read on demand.
+    & sc.exe config $ServiceName start= delayed-auto | Out-Null
+}
+
+# Restart on crash: after 5s, then 10s, then every 60s, with the failure count reset daily.
+& sc.exe failure $ServiceName reset= 86400 actions= restart/5000/restart/10000/restart/60000 | Out-Null
+
+Write-Host '==> setting the environment for the service'
+# ASPNETCORE_ENVIRONMENT has to reach the service process; the per-service Environment value is the
+# supported way (a machine-level variable would leak into every other process on the box).
+$serviceKey = "HKLM:\SYSTEM\CurrentControlSet\Services\$ServiceName"
+Set-ItemProperty -Path $serviceKey -Name 'Environment' -Type MultiString -Value @(
+    "ASPNETCORE_ENVIRONMENT=$Environment"
+    'DOTNET_NOLOGO=1'
+)
+
+# NetworkService/LocalService need read+execute on the install tree; ProgramFiles grants it by
+# inheritance, a custom -InstallPath may not.
+& icacls $InstallPath /grant "${ServiceAccount}:(OI)(CI)(RX)" /T /Q | Out-Null
+
+if ($OpenFirewall) {
+    $port = ([regex]::Match($Urls, ':(\d+)')).Groups[1].Value
+    if ($port) {
+        Write-Host "==> opening TCP port $port in Windows Firewall"
+        $ruleName = "$ServiceDisplayName (TCP $port)"
+        Get-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue |
+            Remove-NetFirewallRule -ErrorAction SilentlyContinue
+        New-NetFirewallRule -DisplayName $ruleName -Direction Inbound -Action Allow `
+            -Protocol TCP -LocalPort $port -Profile Any | Out-Null
+    }
+    else {
+        Write-Warning "Could not determine a TCP port from -Urls '$Urls'; no firewall rule was added."
+    }
+}
+
+if (-not $NoStart) {
+    Write-Host '==> starting the service'
+    Start-Service -Name $ServiceName
+    (Get-Service -Name $ServiceName).WaitForStatus('Running', [TimeSpan]::FromSeconds(60))
+    Get-Service -Name $ServiceName | Format-Table -AutoSize Status, Name, DisplayName
+}
+
+$probe = ($Urls -split ';')[0] -replace '0\.0\.0\.0', 'localhost' -replace '\[::\]', 'localhost'
+Write-Host ''
+Write-Host 'Done. Manage it with:'
+Write-Host "  Start-Service $ServiceName  /  Stop-Service $ServiceName  /  Get-Service $ServiceName"
+Write-Host "  Get-EventLog -LogName Application -Source $ServiceName -Newest 20"
+Write-Host ''
+Write-Host 'Check it is serving:'
+Write-Host "  Invoke-RestMethod $probe/healthz"

--- a/Broiler.Office.Server/packaging/windows/service/README.md
+++ b/Broiler.Office.Server/packaging/windows/service/README.md
@@ -1,0 +1,141 @@
+# Running BOSS as a Windows service
+
+`Install-BossService.ps1` registers **BOSS — the Broiler Office Standalone Server** with the Windows
+Service Control Manager so the Broiler Writer is served across reboots.
+
+The server links `Microsoft.Extensions.Hosting.WindowsServices`, so it speaks the service control
+protocol itself — no wrapper (NSSM, `srvany`) is involved.
+
+```
+service/
+├── Install-BossService.ps1     install / upgrade the service
+└── Uninstall-BossService.ps1   remove it
+```
+
+---
+
+## Install
+
+From an **elevated** PowerShell prompt, in the extracted package:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\service\Install-BossService.ps1
+powershell -ExecutionPolicy Bypass -File .\service\Install-BossService.ps1 -Urls http://0.0.0.0:5555 -OpenFirewall
+powershell -ExecutionPolicy Bypass -File .\service\Install-BossService.ps1 -InstallPath D:\Apps\BOSS -ServiceAccount LocalSystem
+```
+
+| Parameter | Default | Meaning |
+| --- | --- | --- |
+| `-Urls` | `http://0.0.0.0:5555` | Listening addresses; semicolon-separated for several. |
+| `-InstallPath` | `%ProgramFiles%\Broiler\Office Server` | Where the server and its `wwwroot\` are installed. |
+| `-ServiceName` | `BroilerOfficeServer` | Service name used by `Start-Service` and friends. |
+| `-ServiceAccount` | `NT AUTHORITY\NetworkService` | Account the service runs as. `LocalSystem` for more privilege, or a domain account with `-ServiceAccountPassword`. |
+| `-Environment` | `Production` | Sets `ASPNETCORE_ENVIRONMENT` for the service. |
+| `-OpenFirewall` | — | Add an inbound firewall rule for the TCP port in `-Urls`. |
+| `-NoStart` | — | Register but do not start. |
+
+The script copies the payload to `-InstallPath`, registers the service (delayed automatic start,
+restart-on-crash after 5 s / 10 s / 60 s), grants the service account read+execute on the install
+tree, and starts it. **Re-running upgrades in place** — the service is stopped, `wwwroot\` is
+replaced wholesale, and the service starts again.
+
+Check it:
+
+```powershell
+Invoke-RestMethod http://localhost:5555/healthz
+```
+
+---
+
+## Manage
+
+```powershell
+Get-Service BroilerOfficeServer
+Start-Service BroilerOfficeServer
+Stop-Service  BroilerOfficeServer
+Restart-Service BroilerOfficeServer
+
+# The service logs to the Application event log.
+Get-EventLog -LogName Application -Source BroilerOfficeServer -Newest 20
+```
+
+### Changing the listening address
+
+The addresses are part of the registered command line, so re-run the installer with the new value:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\service\Install-BossService.ps1 -Urls http://0.0.0.0:8080
+```
+
+Everything else is a per-service environment variable under
+`HKLM:\SYSTEM\CurrentControlSet\Services\BroilerOfficeServer\Environment` — the installer writes
+`ASPNETCORE_ENVIRONMENT` there, and other settings follow the same `Section__Key=value` form:
+
+```powershell
+$key = 'HKLM:\SYSTEM\CurrentControlSet\Services\BroilerOfficeServer'
+Set-ItemProperty $key -Name Environment -Type MultiString -Value @(
+    'ASPNETCORE_ENVIRONMENT=Production'
+    'Logging__LogLevel__Microsoft.AspNetCore=Information'
+)
+Restart-Service BroilerOfficeServer
+```
+
+---
+
+## Firewall
+
+`-OpenFirewall` adds the inbound rule for you. By hand:
+
+```powershell
+New-NetFirewallRule -DisplayName 'BOSS (TCP 5555)' -Direction Inbound -Action Allow `
+    -Protocol TCP -LocalPort 5555 -Profile Any
+```
+
+Without a rule the server is reachable from the machine itself only, whatever `--urls` says.
+
+---
+
+## HTTPS
+
+Either terminate TLS in front (IIS with ARR, or any reverse proxy) and let BOSS listen on
+`http://127.0.0.1:5555`, or point Kestrel at a certificate from the machine store:
+
+```powershell
+$key = 'HKLM:\SYSTEM\CurrentControlSet\Services\BroilerOfficeServer'
+Set-ItemProperty $key -Name Environment -Type MultiString -Value @(
+    'ASPNETCORE_ENVIRONMENT=Production'
+    'Kestrel__Certificates__Default__Path=C:\ProgramData\Broiler\office-server.pfx'
+    'Kestrel__Certificates__Default__Password=…'
+)
+```
+
+Then reinstall with `-Urls "http://127.0.0.1:5555;https://0.0.0.0:5556"`. The service account needs
+read access to the `.pfx`.
+
+---
+
+## Uninstall
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\service\Uninstall-BossService.ps1
+powershell -ExecutionPolicy Bypass -File .\service\Uninstall-BossService.ps1 -KeepFiles
+```
+
+Stops and deletes the service, removes the firewall rule it added, and deletes the install directory
+unless `-KeepFiles` is given.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| `…must run from an elevated (Administrator) PowerShell prompt` | Right-click PowerShell → *Run as administrator*. |
+| `…cannot be loaded because running scripts is disabled` | Invoke it as shown, with `-ExecutionPolicy Bypass -File`. |
+| Service starts, then stops immediately | Check the Application event log. Usually the port is taken (`netstat -ano \| findstr :5555`) or the account cannot read the install tree. |
+| Service runs, pages 404 | `wwwroot\` did not make it into the install path. Re-run the installer from the *complete* extracted package. |
+| Reachable locally, not from another machine | The firewall rule is missing (`-OpenFirewall`), or `-Urls` is loopback-only. |
+| `You must install .NET to run this application` | A framework-dependent package without the ASP.NET Core 10 runtime. Install it, or use the self-contained package. |
+
+For anything above the service layer — arguments, endpoints, configuration precedence, caching —
+see [`../README.md`](../README.md).

--- a/Broiler.Office.Server/packaging/windows/service/Uninstall-BossService.ps1
+++ b/Broiler.Office.Server/packaging/windows/service/Uninstall-BossService.ps1
@@ -1,0 +1,68 @@
+<#
+.SYNOPSIS
+    Removes the BOSS Windows service installed by Install-BossService.ps1.
+
+.DESCRIPTION
+    Stops and deletes the service, removes the firewall rule it added, and deletes the install
+    directory unless -KeepFiles is given.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\Uninstall-BossService.ps1
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\Uninstall-BossService.ps1 -KeepFiles
+
+.NOTES
+    Run from an elevated PowerShell prompt.
+#>
+[CmdletBinding()]
+param(
+    [string] $ServiceName = 'BroilerOfficeServer',
+    [string] $InstallPath = (Join-Path $env:ProgramFiles 'Broiler\Office Server'),
+    [switch] $KeepFiles
+)
+
+$ErrorActionPreference = 'Stop'
+
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not ([Security.Principal.WindowsPrincipal]::new($identity)).IsInRole(
+        [Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw 'Uninstall-BossService.ps1 must run from an elevated (Administrator) PowerShell prompt.'
+}
+
+$service = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+if ($service) {
+    if ($service.Status -ne 'Stopped') {
+        Write-Host '==> stopping the service'
+        Stop-Service -Name $ServiceName -Force
+        $service.WaitForStatus('Stopped', [TimeSpan]::FromSeconds(60))
+    }
+
+    Write-Host '==> deleting the service registration'
+    # Remove-Service exists only on PowerShell 6+; sc.exe works on Windows PowerShell 5.1 too.
+    if (Get-Command Remove-Service -ErrorAction SilentlyContinue) {
+        Remove-Service -Name $ServiceName
+    }
+    else {
+        & sc.exe delete $ServiceName | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "sc.exe delete failed with exit code $LASTEXITCODE." }
+    }
+}
+else {
+    Write-Host "==> service '$ServiceName' is not registered"
+}
+
+Get-NetFirewallRule -ErrorAction SilentlyContinue |
+    Where-Object DisplayName -like '*Broiler Office Standalone Server*' |
+    ForEach-Object {
+        Write-Host "==> removing firewall rule '$($_.DisplayName)'"
+        Remove-NetFirewallRule -Name $_.Name -ErrorAction SilentlyContinue
+    }
+
+if (-not $KeepFiles -and (Test-Path -LiteralPath $InstallPath)) {
+    Write-Host "==> removing $InstallPath"
+    Remove-Item -LiteralPath $InstallPath -Recurse -Force
+}
+
+Write-Host ''
+Write-Host 'Removed.'

--- a/scripts/package-boss.ps1
+++ b/scripts/package-boss.ps1
@@ -1,0 +1,98 @@
+<#
+.SYNOPSIS
+    Lays the BOSS packaging assets around a published Broiler.Office.Server.
+
+.DESCRIPTION
+    `dotnet publish` produces the server, appsettings.json and the vendored Writer wwwroot. This
+    script adds everything a user needs around it — the README, the foreground launcher, and the
+    service unit files / install scripts for the target platform — turning the publish output into
+    the BOSS/ folder that ships inside a Broiler Preview Package (BPP).
+
+    Assets come from Broiler.Office.Server/packaging: common/ everywhere, then linux/ or windows/.
+    Only the platform's own half is copied, so a user never has to work out which files apply.
+
+    Used by .github/workflows/broiler-preview-package.yml; run it by hand to reproduce a package.
+
+.PARAMETER BossDirectory
+    The publish output directory to lay the assets into (…/BPP-<os>-<variant>/BOSS).
+
+.PARAMETER Platform
+    linux or windows — selects which half of the packaging tree ships.
+
+.EXAMPLE
+    ./scripts/package-boss.ps1 -BossDirectory /tmp/packages/BPP-Linux-self-contained/BOSS -Platform linux
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string] $BossDirectory,
+    [Parameter(Mandatory = $true)][ValidateSet('linux', 'windows')][string] $Platform
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$packagingRoot = Join-Path $repoRoot 'Broiler.Office.Server/packaging'
+
+if (-not (Test-Path -LiteralPath $BossDirectory)) {
+    throw "Publish output not found: $BossDirectory"
+}
+if (-not (Test-Path -LiteralPath $packagingRoot)) {
+    throw "Packaging assets not found: $packagingRoot"
+}
+
+$executableName = if ($Platform -eq 'windows') { 'Broiler.Office.Server.exe' } else { 'Broiler.Office.Server' }
+$executable = Join-Path $BossDirectory $executableName
+if (-not (Test-Path -LiteralPath $executable)) {
+    throw "Expected server executable was not produced: $executable"
+}
+
+# The whole point of the vendored-publish hosting model: without wwwroot the server starts, answers
+# /healthz, and 404s every page. Fail here rather than shipping that.
+$indexHtml = Join-Path $BossDirectory 'wwwroot/index.html'
+if (-not (Test-Path -LiteralPath $indexHtml)) {
+    throw "The Writer bundle is missing from the publish output: $indexHtml"
+}
+
+# The WebAssembly SDK rewrites index.html with an import map pointing at the fingerprinted runtime.
+# The raw placeholder from the project's wwwroot has neither, and an app built from it cannot boot —
+# which is exactly what a hosted (non-vendored) publish would have produced.
+if ((Get-Content -LiteralPath $indexHtml -Raw) -notmatch '<script type="importmap">') {
+    throw "The vendored index.html has no import map — the Writer bundle was not published/transformed correctly: $indexHtml"
+}
+
+Write-Host "==> laying BOSS packaging assets into $BossDirectory ($Platform)"
+
+Copy-Item -LiteralPath (Join-Path $packagingRoot 'common/README.md') -Destination $BossDirectory -Force
+
+if ($Platform -eq 'linux') {
+    Copy-Item -LiteralPath (Join-Path $packagingRoot 'linux/run-boss.sh') -Destination $BossDirectory -Force
+    Copy-Item -LiteralPath (Join-Path $packagingRoot 'linux/service') -Destination $BossDirectory -Recurse -Force
+
+    # tar preserves the mode, so set it here rather than asking users to chmod after extracting.
+    if ($IsLinux -or $IsMacOS) {
+        chmod 0755 $executable (Join-Path $BossDirectory 'run-boss.sh')
+        chmod 0755 (Join-Path $BossDirectory 'service/install-service.sh') `
+                   (Join-Path $BossDirectory 'service/uninstall-service.sh') `
+                   (Join-Path $BossDirectory 'service/sysv/broiler-office-server')
+    }
+}
+else {
+    Copy-Item -LiteralPath (Join-Path $packagingRoot 'windows/Start-BOSS.cmd') -Destination $BossDirectory -Force
+    Copy-Item -LiteralPath (Join-Path $packagingRoot 'windows/service') -Destination $BossDirectory -Recurse -Force
+}
+
+$launcher = if ($Platform -eq 'windows') { 'Start-BOSS.cmd' } else { 'run-boss.sh' }
+foreach ($asset in @($executableName, 'appsettings.json', 'README.md', $launcher)) {
+    if (-not (Test-Path -LiteralPath (Join-Path $BossDirectory $asset))) {
+        throw "Packaging did not produce the expected asset: $asset"
+    }
+    Write-Host "    $asset"
+}
+
+Get-ChildItem -LiteralPath (Join-Path $BossDirectory 'service') -Recurse -File |
+    ForEach-Object { Write-Host "    service/$([IO.Path]::GetRelativePath((Join-Path $BossDirectory 'service'), $_.FullName) -replace '\\', '/')" }
+
+$bundleSize = (Get-ChildItem -LiteralPath (Join-Path $BossDirectory 'wwwroot') -Recurse -File |
+    Measure-Object -Property Length -Sum).Sum
+Write-Host ("    wwwroot/ ({0:N1} MB Writer bundle)" -f ($bundleSize / 1MB))

--- a/scripts/smoke-test-boss.ps1
+++ b/scripts/smoke-test-boss.ps1
@@ -1,0 +1,167 @@
+<#
+.SYNOPSIS
+    Starts a packaged BOSS and verifies it actually serves the Broiler Writer.
+
+.DESCRIPTION
+    Launches the published server on a loopback port and checks the things that have historically
+    broken a BOSS package:
+
+      * /healthz answers                     — the host starts at all
+      * /api/info reports server "BOSS"      — the API routes are mapped
+      * / returns the transformed index.html — the vendored Writer bundle is present and is the
+                                               WebAssembly SDK's rewritten shell, not the raw
+                                               placeholder that cannot boot
+      * the fingerprinted runtime module is served as JavaScript from _framework/
+      * an unknown path falls back to the shell — client-side routes survive a refresh
+
+    The server is deliberately started from a *different* working directory, because a service
+    manager does the same: it proves the content root resolves to the executable's own folder rather
+    than the caller's cwd (otherwise every page 404s while /healthz keeps answering OK).
+
+    Used by .github/workflows/broiler-preview-package.yml after each publish.
+
+.PARAMETER BossDirectory
+    Directory holding the published Broiler.Office.Server and its wwwroot.
+
+.PARAMETER Port
+    Loopback port to listen on. Default 5555.
+
+.PARAMETER TimeoutSeconds
+    How long to wait for the server to start serving. Default 120 — a self-contained first start on
+    a cold CI runner is not instant.
+
+.EXAMPLE
+    ./scripts/smoke-test-boss.ps1 -BossDirectory /tmp/packages/BPP-Linux-self-contained/BOSS
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string] $BossDirectory,
+    [int] $Port = 5555,
+    [int] $TimeoutSeconds = 120
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$BossDirectory = (Resolve-Path -LiteralPath $BossDirectory).Path
+$executableName = if ($IsWindows) { 'Broiler.Office.Server.exe' } else { 'Broiler.Office.Server' }
+$executable = Join-Path $BossDirectory $executableName
+if (-not (Test-Path -LiteralPath $executable)) {
+    throw "Server executable not found: $executable"
+}
+
+$baseUrl = "http://127.0.0.1:$Port"
+$logDirectory = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+$stdout = Join-Path $logDirectory "boss-smoke-$Port.out.log"
+$stderr = Join-Path $logDirectory "boss-smoke-$Port.err.log"
+
+# Not $BossDirectory: a service manager starts the server from an unrelated directory, and this is
+# the cheapest way to catch a content root that silently follows the caller's cwd.
+$foreignWorkingDirectory = [System.IO.Path]::GetTempPath()
+
+function Invoke-BossRequest {
+    param([string] $Path)
+    # -NoProxy: a proxy configured on the machine must not swallow a loopback request.
+    Invoke-WebRequest -Uri "$baseUrl$Path" -NoProxy -TimeoutSec 30 -SkipHttpErrorCheck -UseBasicParsing
+}
+
+Write-Host "==> starting BOSS from $BossDirectory on $baseUrl"
+$server = Start-Process -FilePath $executable `
+    -ArgumentList '--urls', $baseUrl `
+    -WorkingDirectory $foreignWorkingDirectory `
+    -RedirectStandardOutput $stdout `
+    -RedirectStandardError $stderr `
+    -PassThru
+
+$failures = [System.Collections.Generic.List[string]]::new()
+try {
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    $ready = $false
+    while ([DateTime]::UtcNow -lt $deadline) {
+        if ($server.HasExited) {
+            throw "The server exited with code $($server.ExitCode) before it started serving."
+        }
+
+        try {
+            $health = Invoke-BossRequest '/healthz'
+            if ($health.StatusCode -eq 200) { $ready = $true; break }
+        }
+        catch {
+            # Connection refused while Kestrel is still binding — keep waiting.
+        }
+
+        Start-Sleep -Milliseconds 500
+    }
+
+    if (-not $ready) {
+        throw "The server did not answer $baseUrl/healthz within ${TimeoutSeconds}s."
+    }
+    Write-Host '    /healthz            OK'
+
+    $info = (Invoke-BossRequest '/api/info').Content | ConvertFrom-Json
+    if ($info.server -ne 'BOSS') {
+        $failures.Add("/api/info reported server '$($info.server)', expected 'BOSS'.")
+    }
+    else {
+        Write-Host "    /api/info           OK (v$($info.version), apps: $($info.apps.name -join ', '))"
+    }
+
+    $index = Invoke-BossRequest '/'
+    if ($index.StatusCode -ne 200) {
+        $failures.Add("/ returned HTTP $($index.StatusCode) — the vendored Writer bundle is missing or unreadable.")
+    }
+    elseif ($index.Content -notmatch '<script type="importmap">') {
+        $failures.Add('/ served an index.html without an import map — the raw placeholder shell was packaged instead of the transformed one, and the Writer cannot boot.')
+    }
+    else {
+        Write-Host "    /                   OK ($($index.Content.Length) bytes, import map present)"
+    }
+
+    # Follow the import map to the fingerprinted runtime entry point and make sure it is really
+    # served — a wwwroot that lost _framework/ still returns a perfectly good index.html.
+    $runtimeMatch = [regex]::Match($index.Content, '_framework/dotnet\.[a-z0-9]+\.js')
+    if (-not $runtimeMatch.Success) {
+        $failures.Add('The import map references no fingerprinted _framework/dotnet.<hash>.js module.')
+    }
+    else {
+        $runtime = Invoke-BossRequest "/$($runtimeMatch.Value)"
+        if ($runtime.StatusCode -ne 200) {
+            $failures.Add("$($runtimeMatch.Value) returned HTTP $($runtime.StatusCode) — the mono-wasm runtime is not being served.")
+        }
+        else {
+            Write-Host "    $($runtimeMatch.Value)  OK"
+        }
+    }
+
+    # MapFallbackToFile: an in-app route must return the shell, not a 404.
+    $fallback = Invoke-BossRequest '/documents/untitled'
+    if ($fallback.StatusCode -ne 200) {
+        $failures.Add("A client-routed path returned HTTP $($fallback.StatusCode); the SPA fallback is not working.")
+    }
+    else {
+        Write-Host '    client-side route   OK (falls back to the app shell)'
+    }
+}
+finally {
+    if (-not $server.HasExited) {
+        Write-Host '==> stopping BOSS'
+        # CloseMainWindow does nothing for a console app; Kill is the portable stop, and the server
+        # holds no state that needs a graceful shutdown.
+        $server.Kill()
+        $server.WaitForExit(30000) | Out-Null
+    }
+
+    foreach ($log in @($stdout, $stderr)) {
+        if ((Test-Path -LiteralPath $log) -and (Get-Item -LiteralPath $log).Length -gt 0) {
+            Write-Host "---- $(Split-Path -Leaf $log) ----"
+            Get-Content -LiteralPath $log -Tail 40 | ForEach-Object { Write-Host "    $_" }
+        }
+    }
+}
+
+if ($failures.Count -gt 0) {
+    foreach ($failure in $failures) { Write-Host "::error::BOSS smoke test: $failure" }
+    throw "BOSS smoke test failed with $($failures.Count) problem(s)."
+}
+
+Write-Host '==> BOSS smoke test passed.'

--- a/scripts/write-bpp-build-info.ps1
+++ b/scripts/write-bpp-build-info.ps1
@@ -1,0 +1,122 @@
+<#
+.SYNOPSIS
+    Writes the BUILD-INFO.txt that ships at the root of a Broiler Preview Package.
+
+.DESCRIPTION
+    A preview package is a moving target — it is built from a branch on demand, not from a release
+    tag — so the first question anyone asks about one is "which build is this?". This drops a plain
+    text file at the package root answering that, plus what the package contains, what the target
+    machine needs, and how to start each app.
+
+    Used by .github/workflows/broiler-preview-package.yml.
+
+.PARAMETER PackageDirectory
+    Package root to write BUILD-INFO.txt into (…/packages/BPP-Linux-self-contained).
+
+.PARAMETER Platform
+    linux or windows.
+
+.PARAMETER Variant
+    self-contained or framework-dependent.
+
+.PARAMETER Branch
+    Branch the package was built from.
+
+.PARAMETER Configuration
+    MSBuild configuration used (Release-Linux / Release-Windows).
+
+.EXAMPLE
+    ./scripts/write-bpp-build-info.ps1 -PackageDirectory /tmp/packages/BPP-Linux-self-contained `
+        -Platform linux -Variant self-contained -Branch main -Configuration Release-Linux
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string] $PackageDirectory,
+    [Parameter(Mandatory = $true)][ValidateSet('linux', 'windows')][string] $Platform,
+    [Parameter(Mandatory = $true)][ValidateSet('self-contained', 'framework-dependent')][string] $Variant,
+    [string] $Branch = '(unknown)',
+    [string] $Configuration = '(unknown)'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $PackageDirectory)) {
+    throw "Package directory not found: $PackageDirectory"
+}
+
+$packageName = Split-Path -Leaf $PackageDirectory
+$commit = (git -C (Split-Path -Parent $PSScriptRoot) rev-parse HEAD 2>$null)
+if (-not $commit) { $commit = '(unknown)' }
+$built = [DateTime]::UtcNow.ToString('yyyy-MM-dd HH:mm:ss') + ' UTC'
+$run = if ($env:GITHUB_RUN_NUMBER) { "GitHub Actions run #$env:GITHUB_RUN_NUMBER" } else { 'local build' }
+
+$runtimeNote = if ($Variant -eq 'self-contained') {
+    'self-contained — the .NET runtime is included, nothing to install'
+}
+else {
+    'framework-dependent — requires the ASP.NET Core 10 runtime on the target machine'
+}
+
+$rid = if ($Platform -eq 'windows') { 'win-x64' } else { 'linux-x64' }
+$exeSuffix = if ($Platform -eq 'windows') { '.exe' } else { '' }
+$bossLauncher = if ($Platform -eq 'windows') { 'BOSS\Start-BOSS.cmd' } else { './BOSS/run-boss.sh' }
+$bossServer = if ($Platform -eq 'windows') { 'BOSS\Broiler.Office.Server.exe' } else { './BOSS/Broiler.Office.Server' }
+
+$lines = @(
+    'Broiler Preview Package'
+    '======================='
+    ''
+    "Package        : $packageName"
+    "Target         : $rid"
+    "Deployment     : $runtimeNote"
+    "Branch         : $Branch"
+    "Commit         : $commit"
+    "Configuration  : $Configuration"
+    "Built          : $built ($run)"
+    ''
+    'This is a preview build from a branch, not a supported release. Expect rough edges.'
+    ''
+    'Contents'
+    '--------'
+    ''
+    ('  {0,-24}{1}' -f "Broiler.Browser$exeSuffix", 'The Broiler web browser.')
+    ('  {0,-24}{1}' -f "Broiler.Writer$exeSuffix", 'The Broiler word processor (desktop).')
+    ('  {0,-24}{1}' -f 'BOSS/', 'Broiler Office Standalone Server — serves the Broiler Writer')
+    ('  {0,-24}{1}' -f '', 'web app (WebAssembly) over HTTP from its own Kestrel host.')
+    ''
+    'Starting the Office server (BOSS)'
+    '---------------------------------'
+    ''
+    "  $bossLauncher                        listens on http://0.0.0.0:5555"
+    "  $bossServer --urls http://0.0.0.0:5555"
+    ''
+    '  Then open http://localhost:5555/ — health probe at /healthz, server details at /api/info.'
+    ''
+    '  To run it as a system service (systemd, SysV init, or a Windows service), see'
+    '  BOSS/service/. Full documentation: BOSS/README.md.'
+)
+
+if ($Variant -eq 'framework-dependent') {
+    $lines += @(
+        ''
+        'Runtime requirement'
+        '-------------------'
+        ''
+        '  Install the ASP.NET Core 10 runtime before running BOSS:'
+        '  https://dotnet.microsoft.com/download/dotnet/10.0  (ASP.NET Core Runtime, not just the'
+        '  .NET Runtime). The self-contained package needs no installation.'
+    )
+}
+
+$lines += @(
+    ''
+    'Source, issues, documentation: https://github.com/Broiler-Platform/Broiler'
+)
+
+$destination = Join-Path $PackageDirectory 'BUILD-INFO.txt'
+# CRLF on Windows so Notepad renders it; LF elsewhere.
+$newline = if ($Platform -eq 'windows') { "`r`n" } else { "`n" }
+[System.IO.File]::WriteAllText($destination, ($lines -join $newline) + $newline)
+
+Write-Host "==> wrote $destination"


### PR DESCRIPTION
## Summary

This change introduces **BOSS** — the Broiler Office Standalone Server — as a complete, deployable package. BOSS is a Kestrel web server that hosts the Broiler Writer (compiled to WebAssembly) with no external dependencies. The change adds service integration for both Linux (systemd/SysV) and Windows, comprehensive packaging assets, smoke testing, and build-info documentation.

## Key Changes

- **Server integration**: Modified `Broiler.Office.Server/Program.cs` to support Windows service hosting and explicit content root resolution, enabling the server to run as a managed service
- **Project configuration**: Updated `Broiler.Office.Server.csproj` to include service-manager integration packages (`Microsoft.Extensions.Hosting.Systemd`, `Microsoft.Extensions.Hosting.WindowsServices`) and configure the Writer WebAssembly client as a vendored asset
- **Linux service support**: Added complete systemd and SysV init infrastructure:
  - `install-service.sh` / `uninstall-service.sh` for automated service setup
  - `broiler-office-server.service` (systemd unit with Type=notify for readiness signaling)
  - `broiler-office-server` (LSB-compliant init script)
  - Environment configuration files and reverse-proxy templates (nginx, Apache)
- **Windows service support**: Added PowerShell scripts for service installation/removal with firewall integration and delayed automatic start
- **Packaging assets**: Added user-facing documentation and launchers:
  - `README.md` (common) with quick-start, arguments, and endpoint documentation
  - `run-boss.sh` (Linux) and `Start-BOSS.cmd` (Windows) for foreground execution
  - Service-specific READMEs with configuration and troubleshooting guidance
- **Build workflow**: Updated `.github/workflows/broiler-preview-package.yml` to:
  - Install WebAssembly build workload (`wasm-tools`)
  - Restore and publish `Broiler.Office.Server` alongside existing apps
  - Restore the Writer WebAssembly client separately (no Windows RID)
  - Assemble and smoke-test BOSS payloads before packaging
- **Packaging scripts**: Added helper scripts:
  - `package-boss.ps1`: Lays service files and documentation around the published server
  - `smoke-test-boss.ps1`: Validates the server starts, serves the Writer, and handles client-side routing
  - `write-bpp-build-info.ps1`: Generates BUILD-INFO.txt with branch, commit, and usage instructions

## Notable Implementation Details

- The server resolves its content root explicitly to support service managers that start it from arbitrary working directories — a critical fix for wwwroot discovery
- Systemd unit uses `Type=notify` with readiness signaling, allowing dependent services (reverse proxies) to order themselves correctly
- Both Linux and Windows service installers support in-place upgrades: the payload is refreshed while configuration files are preserved
- Smoke tests deliberately start the server from a foreign working directory to catch content-root resolution bugs
- The Writer WebAssembly client is published separately (without Windows RID) and vendored into the server's wwwroot by an MSBuild task, not as a project reference
- Comprehensive documentation covers quick-start, configuration, reverse-proxy setup, and service management for both platforms

https://claude.ai/code/session_01CL3MW87DcJc3gLg92zGwWw