### PR TITLE
ci: verify the BOSS bundle through the import map's values

### DIFF
--- a/scripts/smoke-test-boss.ps1
+++ b/scripts/smoke-test-boss.ps1
@@ -117,19 +117,37 @@ try {
         Write-Host "    /                   OK ($($index.Content.Length) bytes, import map present)"
     }
 
-    # Follow the import map to the fingerprinted runtime entry point and make sure it is really
-    # served — a wwwroot that lost _framework/ still returns a perfectly good index.html.
-    $runtimeMatch = [regex]::Match($index.Content, '_framework/dotnet\.[a-z0-9]+\.js')
-    if (-not $runtimeMatch.Success) {
-        $failures.Add('The import map references no fingerprinted _framework/dotnet.<hash>.js module.')
+    # Follow the import map and fetch every module the app boots from — a wwwroot that lost
+    # _framework/ still returns a perfectly good index.html.
+    #
+    # Walk the map's *values*, never scan the document for a module-shaped name: the keys are the
+    # unfingerprinted aliases (./_framework/dotnet.native.js, …/dotnet.runtime.js) and name no file
+    # on disk, so any pattern loose enough to match a hash can match a key instead — and the two
+    # platforms do not agree on which comes first. Only the values point at published files.
+    $importMapMatch = [regex]::Match($index.Content, '(?s)<script type="importmap">(?<json>.*?)</script>')
+    if (-not $importMapMatch.Success) {
+        $failures.Add('The import map in index.html could not be read.')
     }
     else {
-        $runtime = Invoke-BossRequest "/$($runtimeMatch.Value)"
-        if ($runtime.StatusCode -ne 200) {
-            $failures.Add("$($runtimeMatch.Value) returned HTTP $($runtime.StatusCode) — the mono-wasm runtime is not being served.")
+        $imports = $importMapMatch.Groups['json'].Value | ConvertFrom-Json
+        $modules = @()
+        if ($imports.PSObject.Properties.Name -contains 'imports') {
+            $modules = @($imports.imports.PSObject.Properties | ForEach-Object { $_.Value })
         }
-        else {
-            Write-Host "    $($runtimeMatch.Value)  OK"
+
+        if ($modules.Count -eq 0) {
+            $failures.Add('The import map lists no modules — the Writer bundle cannot boot from this shell.')
+        }
+
+        foreach ($module in $modules) {
+            $modulePath = '/' + ($module -replace '^\./', '')
+            $response = Invoke-BossRequest $modulePath
+            if ($response.StatusCode -ne 200) {
+                $failures.Add("$modulePath returned HTTP $($response.StatusCode) — a module the app boots from is not being served.")
+            }
+            else {
+                Write-Host "    $modulePath  OK"
+            }
         }
     }
 


### PR DESCRIPTION
Fixes the false failure in the BOSS smoke test that turned the Windows leg of `broiler-preview-package` red on a package that was fine.

## What went wrong

The smoke test scanned `index.html` for a module-shaped name and matched `./_framework/dotnet.native.js`. That is an import map **key** — an unfingerprinted alias that maps to the published `dotnet.native.3ypvov71w5.js` and itself names no file on disk — so the request 404d and the run failed:

```
Error: BOSS smoke test: _framework/dotnet.native.js returned HTTP 404 — the mono-wasm runtime is not being served.
```

Everything else in that job was healthy: the packaging assets were laid, the 15.1 MB Writer bundle was present, and `/healthz`, `/api/info`, the transformed shell and the SPA fallback all answered. Linux passed only because it happened to emit the fingerprinted value before the alias; the map's ordering is not a contract and the two platforms do not agree on it.

## The change

Read the map instead of pattern-matching around it: parse the importmap JSON and fetch every **value**, which is exactly the set of modules the browser boots from. That drops the ordering assumption, and it widens the check from the one runtime entry point to all four modules — so a `wwwroot` that lost any part of `_framework/` is now caught rather than only the case that happened to be sampled.

## Verification

Run against real Linux publishes, framework-dependent and self-contained:

```
    /healthz            OK
    /api/info           OK (v1.0.0.0, apps: Writer)
    /                   OK (4415 bytes, import map present)
    /_framework/dotnet.djdv2i2goj.js  OK
    /_framework/dotnet.native.3ypvov71w5.js  OK
    /_framework/dotnet.runtime.web2r9gqbh.js  OK
    /m.jjbuo6944pain.js  OK
    client-side route   OK (falls back to the app shell)
==> BOSS smoke test passed.
```

And negatively — deleting `dotnet.native.3ypvov71w5.js` from the published `wwwroot` fails the run naming the path that went missing, so the check still has teeth:

```
::error::BOSS smoke test: /_framework/dotnet.native.3ypvov71w5.js returned HTTP 404 — a module the app boots from is not being served.
```

Follow-up to #1478. The workflow only runs on manual dispatch, and the dispatch that hit this produced no draft release, so it needs re-running once this lands.