### PR TITLE
Add per-test memory limit guard to WPT runner

### DIFF
--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -43,6 +43,14 @@ on:
         description: Per-test timeout in seconds.
         required: false
         default: '30'
+      memory_limit_mb:
+        description: >
+          Per-test RAM cap in MiB, measured as growth of the rendering process's
+          resident set. A test that passes it is aborted and reported as
+          MemoryLimitExceeded; a worker that reaches it is recycled between tests.
+          0 disables the cap.
+        required: false
+        default: '1024'
       most_common_problems_limit:
         description: Maximum number of common failure groups to include in the GitHub issue.
         required: false
@@ -149,6 +157,7 @@ jobs:
         include: ${{ fromJson(needs.plan.outputs.shard-matrix) }}
     env:
       BROILER_WPT_TIMEOUT_SECONDS: ${{ github.event.inputs.test_timeout_seconds || '30' }}
+      BROILER_WPT_MEMORY_LIMIT_MB: ${{ github.event.inputs.memory_limit_mb || '1024' }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,12 @@ something to attempt from inside the container.
 - WPT runner: `dotnet run --project src/Broiler.Wpt -- --wpt-dir tests/wpt
   --reference-dir tests/wpt/references [--subset <path>] [--failure-images <dir>]`.
   Pixel pass threshold is 99% match (≤1% differing pixels).
+- WPT per-test limits: 30s timeout (`--timeout`, `BROILER_WPT_TIMEOUT_SECONDS`)
+  and a 1024 MiB RAM cap (`--memory-limit-mb`, `BROILER_WPT_MEMORY_LIMIT_MB`,
+  0 disables). The cap is on the *growth* of the rendering process's resident
+  set during one test — a test that passes it is aborted and reported as
+  `MemoryLimitExceeded`, and a worker whose own resident set reaches the cap is
+  recycled between tests. See `src/Broiler.Wpt/WptMemoryGuard.cs`.
 - Current cross-component WPT work:
   `docs/ROADMAP.md#standards-and-test-infrastructure`. Generated results live
   under `tests/html/wpt-results` and `tests/css/wpt-results`.

--- a/src/Broiler.Wpt.Tests/WptMemoryGuardTests.cs
+++ b/src/Broiler.Wpt.Tests/WptMemoryGuardTests.cs
@@ -1,0 +1,255 @@
+using System.Diagnostics;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Covers the per-test RAM cap: the guard itself (with a scripted sampler, so the
+/// assertions do not depend on the real resident set), how the cap is resolved from the
+/// command line/environment, and the end-to-end abort through
+/// <see cref="Program.RunTestWithTimeout"/>.
+/// </summary>
+public sealed class WptMemoryGuardTests
+{
+    private static readonly TimeSpan FastSampling = TimeSpan.FromMilliseconds(5);
+    private const long OneMebibyte = WptMemoryGuard.BytesPerMebibyte;
+
+    /// <summary>A sampler that walks a scripted series of readings, repeating the last one.</summary>
+    private static Func<long> ScriptedSampler(params long[] samples)
+    {
+        int index = -1;
+        return () => samples[Math.Min(Interlocked.Increment(ref index), samples.Length - 1)];
+    }
+
+    /// <summary>A task that never completes, standing in for a runaway render.</summary>
+    private static Task<string> NeverCompletes() => new TaskCompletionSource<string>().Task;
+
+    [Fact]
+    public void Returns_Result_When_Test_Stays_Under_The_Limit()
+    {
+        var guard = new WptMemoryGuard(
+            limitBytes: 512 * OneMebibyte,
+            ScriptedSampler(100 * OneMebibyte, 180 * OneMebibyte),
+            sampleInterval: FastSampling);
+
+        var result = guard.Wait(Task.Delay(30).ContinueWith(_ => "rendered"), TimeSpan.FromSeconds(10));
+
+        Assert.Equal("rendered", result);
+        Assert.True(guard.IsEnabled);
+    }
+
+    [Fact]
+    public void Aborts_When_A_Test_Grows_Past_The_Limit()
+    {
+        var guard = new WptMemoryGuard(
+            limitBytes: 1024 * OneMebibyte,
+            ScriptedSampler(240 * OneMebibyte, 900 * OneMebibyte, 1500 * OneMebibyte),
+            sampleInterval: FastSampling);
+
+        var exceeded = Assert.Throws<WptMemoryLimitExceededException>(
+            () => guard.Wait(NeverCompletes(), TimeSpan.FromSeconds(10)));
+
+        Assert.Equal(1024 * OneMebibyte, exceeded.LimitBytes);
+        Assert.Equal(240 * OneMebibyte, exceeded.BaselineBytes);
+        Assert.Equal(1500 * OneMebibyte, exceeded.ObservedBytes);
+        Assert.Equal(1260 * OneMebibyte, exceeded.GrowthBytes);
+        Assert.Equal("grew from 240 MiB to 1500 MiB, +1260 MiB", exceeded.Describe());
+        Assert.Contains("grew by 1260 MiB", exceeded.Message);
+        Assert.Contains("over the 1024 MiB limit", exceeded.Message);
+        Assert.Equal(1500 * OneMebibyte, guard.PeakBytes);
+    }
+
+    [Fact]
+    public void A_Large_Baseline_Left_Behind_By_Earlier_Tests_Is_Not_Charged_To_This_One()
+    {
+        // A worker that earlier tests grew to 1.8 GiB — or a harness process that cannot
+        // hand its pages back — must not fail whichever test happens to run next. Only
+        // what this test itself adds counts against the cap.
+        var guard = new WptMemoryGuard(
+            limitBytes: 1024 * OneMebibyte,
+            ScriptedSampler(1800 * OneMebibyte, 1900 * OneMebibyte),
+            sampleInterval: FastSampling);
+
+        var result = guard.Wait(Task.Delay(30).ContinueWith(_ => "rendered"), TimeSpan.FromSeconds(10));
+
+        Assert.Equal("rendered", result);
+    }
+
+    [Fact]
+    public void Unreadable_Samples_Never_Abort_A_Test()
+    {
+        // -1 means "the resident set could not be read" (the process exited, or the
+        // platform does not report it), which must not be mistaken for a violation.
+        var guard = new WptMemoryGuard(
+            limitBytes: 1024 * OneMebibyte,
+            ScriptedSampler(-1),
+            sampleInterval: FastSampling);
+
+        var result = guard.Wait(Task.Delay(40).ContinueWith(_ => "rendered"), TimeSpan.FromSeconds(10));
+
+        Assert.Equal("rendered", result);
+        Assert.Equal(-1, guard.PeakBytes);
+    }
+
+    [Fact]
+    public void Sampler_Failures_Are_Treated_As_Unreadable()
+    {
+        var guard = new WptMemoryGuard(
+            limitBytes: 1024 * OneMebibyte,
+            () => throw new InvalidOperationException("process has exited"),
+            sampleInterval: FastSampling);
+
+        Assert.Equal("rendered", guard.Wait(Task.Delay(40).ContinueWith(_ => "rendered"), TimeSpan.FromSeconds(10)));
+    }
+
+    [Fact]
+    public void A_Disabled_Limit_Never_Samples()
+    {
+        var sampled = false;
+        var guard = new WptMemoryGuard(
+            limitBytes: 0,
+            () => { sampled = true; return 8L * 1024 * OneMebibyte; },
+            sampleInterval: FastSampling);
+
+        Assert.False(guard.IsEnabled);
+        Assert.Equal("rendered", guard.Wait(Task.Delay(30).ContinueWith(_ => "rendered"), TimeSpan.FromSeconds(10)));
+        Assert.False(sampled);
+    }
+
+    [Fact]
+    public void Timeout_Still_Wins_When_Memory_Stays_Under_The_Limit()
+    {
+        var guard = new WptMemoryGuard(
+            limitBytes: 1024 * OneMebibyte,
+            ScriptedSampler(100 * OneMebibyte),
+            sampleInterval: FastSampling);
+
+        Assert.Throws<TimeoutException>(
+            () => guard.Wait(NeverCompletes(), TimeSpan.FromMilliseconds(50)));
+    }
+
+    [Fact]
+    public void A_Faulted_Render_Surfaces_Its_Original_Exception()
+    {
+        var guard = new WptMemoryGuard(
+            limitBytes: 1024 * OneMebibyte,
+            ScriptedSampler(100 * OneMebibyte),
+            sampleInterval: FastSampling);
+        var faulting = Task.Run(new Func<string>(() =>
+        {
+            Thread.Sleep(20);
+            throw new InvalidDataException("bad reference png");
+        }));
+
+        var error = Assert.Throws<InvalidDataException>(() => guard.Wait(faulting, TimeSpan.FromSeconds(10)));
+        Assert.Equal("bad reference png", error.Message);
+    }
+
+    [Fact]
+    public void Process_Samplers_Report_A_Live_Resident_Set()
+    {
+        using var process = Process.GetCurrentProcess();
+        var sampler = WptMemoryGuard.CreateProcessSampler(process);
+
+        Assert.True(sampler() > 0);
+        Assert.True(WptMemoryGuard.CreateCurrentProcessSampler()() > 0);
+    }
+
+    [Theory]
+    [InlineData(0, "0 MiB")]
+    [InlineData(1536L * 1024, "1.5 MiB")]
+    [InlineData(1024L * 1024 * 1024, "1024 MiB")]
+    [InlineData(-1, "unknown")]
+    public void Formats_Byte_Counts_As_Mebibytes(long bytes, string expected)
+    {
+        Assert.Equal(expected, WptMemoryGuard.FormatMebibytes(bytes));
+    }
+
+    [Fact]
+    public void Memory_Limit_Defaults_To_One_Gibibyte()
+    {
+        Assert.True(Program.TryResolveRunTestMemoryLimit(null, out var limitBytes, out var error));
+        Assert.Null(error);
+        Assert.Equal(1024 * OneMebibyte, limitBytes);
+    }
+
+    [Fact]
+    public void Command_Line_Memory_Limit_Wins_And_Zero_Disables_The_Guard()
+    {
+        Assert.True(Program.TryResolveRunTestMemoryLimit(2048, out var limitBytes, out _));
+        Assert.Equal(2048 * OneMebibyte, limitBytes);
+
+        Assert.True(Program.TryResolveRunTestMemoryLimit(0, out var disabledBytes, out _));
+        Assert.Equal(0, disabledBytes);
+    }
+
+    [Fact]
+    public void Aborts_A_Test_Whose_Render_Balloons_In_Process()
+    {
+        var testPath = Path.Combine(Path.GetTempPath(), "memory-guard-abort.html");
+        Program.RunTestExecutor = static (runner, path, referenceDir, wptPath) =>
+        {
+            // Let the guard record its baseline before the render starts growing, the
+            // ordering the harness sees in a real run.
+            Thread.Sleep(100);
+
+            // Touch every page so the allocation lands in the resident set rather than
+            // staying a lazily-committed reservation.
+            var ballast = new byte[128 * OneMebibyte];
+            for (int i = 0; i < ballast.Length; i += 4096)
+                ballast[i] = 1;
+
+            Thread.Sleep(TimeSpan.FromSeconds(5));
+            GC.KeepAlive(ballast);
+            return new WptTestResult { TestPath = path, Passed = true };
+        };
+
+        try
+        {
+            var result = Program.RunTestWithTimeout(
+                new WptTestRunner(),
+                testPath,
+                Path.Combine(Path.GetTempPath(), "references"),
+                Path.GetTempPath(),
+                TimeSpan.FromSeconds(30),
+                workerThreadStarted: null,
+                memoryLimitBytes: 16 * OneMebibyte);
+
+            Assert.False(result.Passed);
+            Assert.Equal(FailureCategory.MemoryLimitExceeded, result.Category);
+            Assert.Contains("exceeding the 16 MiB per-test memory limit", result.Message);
+            Assert.NotNull(result.StackTrace);
+            Assert.Contains("=== Memory limit diagnostics ===", result.StackTrace);
+            Assert.Contains("Memory limit detection stack", result.StackTrace);
+        }
+        finally
+        {
+            Program.ResetTestHooks();
+        }
+    }
+
+    [Fact]
+    public void Leaves_A_Well_Behaved_Test_Alone()
+    {
+        Program.RunTestExecutor = static (runner, path, referenceDir, wptPath) =>
+            new WptTestResult { TestPath = path, Passed = true };
+
+        try
+        {
+            var result = Program.RunTestWithTimeout(
+                new WptTestRunner(),
+                Path.Combine(Path.GetTempPath(), "memory-guard-pass.html"),
+                Path.Combine(Path.GetTempPath(), "references"),
+                Path.GetTempPath(),
+                TimeSpan.FromSeconds(30),
+                workerThreadStarted: null,
+                memoryLimitBytes: 1024 * OneMebibyte);
+
+            Assert.True(result.Passed);
+            Assert.Equal(FailureCategory.None, result.Category);
+        }
+        finally
+        {
+            Program.ResetTestHooks();
+        }
+    }
+}

--- a/src/Broiler.Wpt/Program.cs
+++ b/src/Broiler.Wpt/Program.cs
@@ -31,6 +31,15 @@ public class Program
 
     private const double DefaultRunTestTimeoutSeconds = 30;
     private const string RunTestTimeoutEnvironmentVariable = "BROILER_WPT_TIMEOUT_SECONDS";
+
+    /// <summary>
+    /// Per-test RAM cap. A single runaway document must not be able to OOM-kill the
+    /// runner (or the CI machine) and take the whole shard's results with it, so a test
+    /// that grows the memory of the process rendering it past this cap is aborted and
+    /// reported as a failure. See <see cref="WptMemoryGuard"/> for what is measured and why.
+    /// </summary>
+    private const int DefaultRunTestMemoryLimitMegabytes = 1024;
+    private const string RunTestMemoryLimitEnvironmentVariable = "BROILER_WPT_MEMORY_LIMIT_MB";
     private const int ProgressCheckpointInterval = 25;
     private const int TopBucketLimit = 5;
     private const int MissingContentDominantBucketMinimumFailures = 5;
@@ -73,6 +82,7 @@ public class Program
         string? rerunJsonPath = null;
         RerunSelectionKind rerunSelectionKind = RerunSelectionKind.Failures;
         double? timeoutSeconds = null;
+        int? memoryLimitMegabytes = null;
         int shardCount = 1;
         int shardIndex = WptTestRunner.AllShards;
         bool nonJavaScriptOnly = false;
@@ -134,6 +144,15 @@ public class Program
 
                     timeoutSeconds = parsedTimeoutSeconds;
                     break;
+                case "--memory-limit-mb" when i + 1 < args.Length:
+                    if (!TryParseMemoryLimitMegabytes(args[++i], out var parsedMemoryLimitMegabytes))
+                    {
+                        Console.Error.WriteLine("Error: '--memory-limit-mb' must be a non-negative integer (0 disables the cap).");
+                        return 1;
+                    }
+
+                    memoryLimitMegabytes = parsedMemoryLimitMegabytes;
+                    break;
                 case "--shard-count" when i + 1 < args.Length:
                     if (!int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out shardCount) || shardCount < 1)
                     {
@@ -170,6 +189,7 @@ public class Program
                 case "--rerun-json":
                 case "--rerun-kind":
                 case "--timeout":
+                case "--memory-limit-mb":
                 case "--shard-count":
                 case "--shard-index":
                     Console.Error.WriteLine($"Error: '{args[i]}' requires a value.");
@@ -227,6 +247,12 @@ public class Program
             return 1;
         }
 
+        if (!TryResolveRunTestMemoryLimit(memoryLimitMegabytes, out var runTestMemoryLimitBytes, out var memoryLimitError))
+        {
+            Console.Error.WriteLine(memoryLimitError);
+            return 1;
+        }
+
         if (shardIndex != WptTestRunner.AllShards && shardIndex >= shardCount)
         {
             Console.Error.WriteLine($"Error: '--shard-index' ({shardIndex}) must be less than '--shard-count' ({shardCount}).");
@@ -242,6 +268,11 @@ public class Program
             useWorkerIsolation
                 ? "Isolation     : worker process (timed-out tests are killed)"
                 : "Isolation     : in-process");
+        Console.WriteLine(
+            runTestMemoryLimitBytes > 0
+                ? $"Memory limit  : {WptMemoryGuard.FormatMebibytes(runTestMemoryLimitBytes)} of growth per test" +
+                  (useWorkerIsolation ? " (worker recycled once it reaches the cap)" : "")
+                : "Memory limit  : disabled");
         if (!string.IsNullOrWhiteSpace(subset))
             Console.WriteLine($"Subset        : {subset}");
         if (shardIndex != WptTestRunner.AllShards)
@@ -321,7 +352,7 @@ public class Program
             "SIGINT",
             terminationDiagnostics.Write);
         using var workerClient = useWorkerIsolation
-            ? new WptWorkerClient(wptPath, referenceDir, failureImagesDir, verifyReference)
+            ? new WptWorkerClient(wptPath, referenceDir, failureImagesDir, verifyReference, runTestMemoryLimitBytes)
             : null;
         int completed = 0, runningPassed = 0, runningFailed = 0, runningSkipped = 0;
 
@@ -343,7 +374,8 @@ public class Program
                     referenceDir,
                     wptPath,
                     runTestTimeout,
-                    runProgress.SetWorkerThreadId);
+                    runProgress.SetWorkerThreadId,
+                    runTestMemoryLimitBytes);
             allResults.Add(result);
             completed++;
 
@@ -583,6 +615,22 @@ public class Program
         {
             return workerClient.RunTest(testPath, timeout, workerProcessStarted);
         }
+        catch (WptMemoryLimitExceededException limitExceeded)
+        {
+            // Killing the worker is what actually aborts the runaway render — the worker
+            // is mid-test and will not answer again. The next test starts a fresh one.
+            var workerProcessId = workerClient.CurrentProcessId;
+            workerClient.KillCurrentWorker();
+
+            var memoryLimitResult = CreateMemoryLimitResult(
+                testPath,
+                limitExceeded,
+                workerThreadId: -1,
+                workerProcessId);
+            Console.Error.WriteLine($"[MEMORY] {memoryLimitResult.Message}");
+            Console.Error.WriteLine(memoryLimitResult.StackTrace);
+            return memoryLimitResult;
+        }
         catch (TimeoutException)
         {
             var workerProcessId = workerClient.CurrentProcessId;
@@ -617,7 +665,8 @@ public class Program
         string referenceDir,
         string? wptPath,
         TimeSpan timeout,
-        Action<int>? workerThreadStarted = null)
+        Action<int>? workerThreadStarted = null,
+        long memoryLimitBytes = 0)
     {
         int workerThreadId = -1;
         var runTestTask = Task.Run(() =>
@@ -627,17 +676,35 @@ public class Program
             return RunTestExecutor(runner, testPath, referenceDir, wptPath);
         });
 
+        // In-process there is no worker to recycle, so an aborted test's thread keeps
+        // running and its memory stays charged to the harness. Measuring growth keeps
+        // that from being billed to every test that follows.
+        var memoryGuard = new WptMemoryGuard(
+            memoryLimitBytes,
+            WptMemoryGuard.CreateCurrentProcessSampler());
+
+        // Abandoned tasks can still fault later; observe their Exception so the process
+        // does not surface an unrelated unobserved-task crash.
+        void ObserveLaterFaults() => _ = runTestTask.ContinueWith(
+            static t => _ = t.Exception,
+            TaskContinuationOptions.OnlyOnFaulted);
+
         try
         {
-            return runTestTask.WaitAsync(timeout).GetAwaiter().GetResult();
+            return memoryGuard.Wait(runTestTask, timeout);
+        }
+        catch (WptMemoryLimitExceededException limitExceeded)
+        {
+            ObserveLaterFaults();
+
+            var memoryLimitResult = CreateMemoryLimitResult(testPath, limitExceeded, workerThreadId);
+            Console.Error.WriteLine($"[MEMORY] {memoryLimitResult.Message}");
+            Console.Error.WriteLine(memoryLimitResult.StackTrace);
+            return memoryLimitResult;
         }
         catch (TimeoutException)
         {
-            _ = runTestTask.ContinueWith(
-                // Timed-out tasks can still fault later; observe their Exception
-                // so the process does not surface an unrelated unobserved-task crash.
-                static t => _ = t.Exception,
-                TaskContinuationOptions.OnlyOnFaulted);
+            ObserveLaterFaults();
 
             var timeoutResult = CreateTimeoutResult(testPath, timeout, workerThreadId);
             Console.Error.WriteLine($"[TIMEOUT] {timeoutResult.Message}");
@@ -652,6 +719,7 @@ public class Program
         private readonly string _referenceDir;
         private readonly string? _failureImagesDir;
         private readonly bool _verifyReference;
+        private readonly long _memoryLimitBytes;
         private Process? _process;
         private Task<string?>? _pendingResponse;
 
@@ -659,12 +727,14 @@ public class Program
             string wptPath,
             string referenceDir,
             string? failureImagesDir,
-            bool verifyReference)
+            bool verifyReference,
+            long memoryLimitBytes = 0)
         {
             _wptPath = wptPath;
             _referenceDir = referenceDir;
             _failureImagesDir = failureImagesDir;
             _verifyReference = verifyReference;
+            _memoryLimitBytes = memoryLimitBytes;
         }
 
         internal int? CurrentProcessId
@@ -698,7 +768,13 @@ public class Program
             string? responseLine;
             try
             {
-                responseLine = _pendingResponse.WaitAsync(timeout).GetAwaiter().GetResult();
+                // The worker renders exactly one test at a time, so everything its resident
+                // set gains while this response is outstanding was allocated by this test.
+                var memoryGuard = new WptMemoryGuard(
+                    _memoryLimitBytes,
+                    WptMemoryGuard.CreateProcessSampler(process));
+                responseLine = memoryGuard.Wait(_pendingResponse, timeout);
+                RecycleIfOverMemoryLimit(process, testPath);
             }
             finally
             {
@@ -736,6 +812,46 @@ public class Program
                 Message = "Worker returned no test result.",
                 Category = FailureCategory.Unknown,
             };
+        }
+
+        /// <summary>
+        /// Restarts the worker between tests once its resident set has reached the cap.
+        /// The per-test guard only bounds what one test adds, so without this the worker
+        /// would drift upwards across a shard — a measured css run leaves it at ~860 MiB
+        /// after 147 tests — until the machine, not the runner, decided the matter.
+        /// Recycling here costs one worker startup and blames no test for memory that
+        /// accumulated across many.
+        /// </summary>
+        private void RecycleIfOverMemoryLimit(Process process, string testPath)
+        {
+            if (_memoryLimitBytes <= 0)
+                return;
+
+            long residentBytes;
+            try
+            {
+                if (process.HasExited)
+                    return;
+
+                process.Refresh();
+                residentBytes = process.WorkingSet64;
+            }
+            catch (Exception ex) when (
+                ex is InvalidOperationException ||
+                ex is NotSupportedException ||
+                ex is PlatformNotSupportedException ||
+                ex is System.ComponentModel.Win32Exception)
+            {
+                return;
+            }
+
+            if (residentBytes < _memoryLimitBytes)
+                return;
+
+            Console.Error.WriteLine(
+                $"[MEMORY] Recycling WPT worker: resident set {WptMemoryGuard.FormatMebibytes(residentBytes)} " +
+                $"reached the {WptMemoryGuard.FormatMebibytes(_memoryLimitBytes)} cap after {testPath}");
+            KillCurrentWorker();
         }
 
         internal void KillCurrentWorker()
@@ -948,6 +1064,48 @@ public class Program
                timeoutSeconds > 0;
     }
 
+    /// <summary>
+    /// Resolves the per-test RAM cap in bytes from (in order) the command line, the
+    /// <c>BROILER_WPT_MEMORY_LIMIT_MB</c> environment variable, and the default. A
+    /// resolved value of 0 disables the guard.
+    /// </summary>
+    internal static bool TryResolveRunTestMemoryLimit(
+        int? cliMemoryLimitMegabytes,
+        out long memoryLimitBytes,
+        out string? error)
+    {
+        memoryLimitBytes = 0;
+        error = null;
+
+        if (cliMemoryLimitMegabytes.HasValue)
+        {
+            memoryLimitBytes = cliMemoryLimitMegabytes.Value * WptMemoryGuard.BytesPerMebibyte;
+            return true;
+        }
+
+        var envMemoryLimit = Environment.GetEnvironmentVariable(RunTestMemoryLimitEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(envMemoryLimit))
+        {
+            if (!TryParseMemoryLimitMegabytes(envMemoryLimit, out var parsedEnvMemoryLimitMegabytes))
+            {
+                error = $"Error: '{RunTestMemoryLimitEnvironmentVariable}' must be a non-negative integer (0 disables the cap).";
+                return false;
+            }
+
+            memoryLimitBytes = parsedEnvMemoryLimitMegabytes * WptMemoryGuard.BytesPerMebibyte;
+            return true;
+        }
+
+        memoryLimitBytes = DefaultRunTestMemoryLimitMegabytes * WptMemoryGuard.BytesPerMebibyte;
+        return true;
+    }
+
+    private static bool TryParseMemoryLimitMegabytes(string value, out int memoryLimitMegabytes)
+    {
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out memoryLimitMegabytes) &&
+               memoryLimitMegabytes >= 0;
+    }
+
     private static bool TryParseRerunSelectionKind(string value, out RerunSelectionKind selectionKind)
     {
         selectionKind = RerunSelectionKind.Failures;
@@ -1078,6 +1236,49 @@ public class Program
             Passed = false,
             Message = message,
             Category = FailureCategory.Timeout,
+            StackTrace = stackTrace,
+        };
+    }
+
+    /// <summary>
+    /// Builds the failure result for a test aborted by <see cref="WptMemoryGuard"/>. The
+    /// message reports the footprint the test started from as well as the one it reached,
+    /// so triage can tell a test that allocated a gigabyte outright from one that did so
+    /// on top of an already-large worker.
+    /// </summary>
+    private static WptTestResult CreateMemoryLimitResult(
+        string testPath,
+        WptMemoryLimitExceededException limitExceeded,
+        int workerThreadId,
+        int? workerProcessId = null)
+    {
+        var message =
+            $"Test aborted after exceeding the {WptMemoryGuard.FormatMebibytes(limitExceeded.LimitBytes)} " +
+            $"per-test memory limit ({limitExceeded.Describe()}): {testPath}";
+        var invocationStackTrace = new StackTrace(skipFrames: 2, fNeedFileInfo: true).ToString();
+        var stackTrace = new StringBuilder()
+            .AppendLine("=== Memory limit diagnostics ===")
+            .AppendLine(message)
+            .AppendLine($"Limit: {WptMemoryGuard.FormatMebibytes(limitExceeded.LimitBytes)} of growth per test")
+            .AppendLine($"Baseline: {WptMemoryGuard.FormatMebibytes(limitExceeded.BaselineBytes)}")
+            .AppendLine($"Peak: {WptMemoryGuard.FormatMebibytes(limitExceeded.ObservedBytes)}")
+            .AppendLine($"Growth: {WptMemoryGuard.FormatMebibytes(limitExceeded.GrowthBytes)}")
+            .AppendLine($"Worker thread id: {(workerThreadId >= 0 ? workerThreadId : "unknown")}")
+            .AppendLine($"Worker process id: {(workerProcessId.HasValue ? workerProcessId.Value : "unknown")}")
+            .AppendLine()
+            .AppendLine("RunTest invocation stack:")
+            .AppendLine(invocationStackTrace)
+            .AppendLine()
+            .AppendLine("Memory limit detection stack:")
+            .AppendLine(Environment.StackTrace)
+            .ToString();
+
+        return new WptTestResult
+        {
+            TestPath = testPath,
+            Passed = false,
+            Message = message,
+            Category = FailureCategory.MemoryLimitExceeded,
             StackTrace = stackTrace,
         };
     }
@@ -2286,6 +2487,11 @@ public class Program
         Console.WriteLine("                             css-anchor-position scroll cluster. Env: BROILER_WPT_DEFER_PROMISE_TESTS=1");
         Console.WriteLine("  --timeout <SECS>           Per-test timeout in seconds (default: 30, env:");
         Console.WriteLine($"                             {RunTestTimeoutEnvironmentVariable})");
+        Console.WriteLine("  --memory-limit-mb <MB>     Per-test RAM cap in MiB, measured as growth of the rendering");
+        Console.WriteLine("                             process's resident set; a test that passes it is aborted and");
+        Console.WriteLine($"                             reported as {FailureCategory.MemoryLimitExceeded}. A worker whose own resident");
+        Console.WriteLine("                             set reaches the cap is recycled between tests. 0 disables");
+        Console.WriteLine($"                             (default: {DefaultRunTestMemoryLimitMegabytes}, env: {RunTestMemoryLimitEnvironmentVariable})");
         Console.WriteLine("  --no-worker-isolation      Run tests in-process instead of the default worker process");
         Console.WriteLine("                             isolation. Useful for debugger sessions only.");
         Console.WriteLine("  --json-output <PATH>       Write structured JSON report to the given path");

--- a/src/Broiler.Wpt/WptMemoryGuard.cs
+++ b/src/Broiler.Wpt/WptMemoryGuard.cs
@@ -1,0 +1,218 @@
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Broiler.Wpt;
+
+/// <summary>
+/// Thrown when a single WPT test grew the memory of the process rendering it past the
+/// configured cap. Carries the samples that tripped the guard so the failure result can
+/// report the footprint the test started from as well as the one it reached.
+/// </summary>
+internal sealed class WptMemoryLimitExceededException : Exception
+{
+    internal WptMemoryLimitExceededException(long limitBytes, long baselineBytes, long observedBytes)
+        : base($"Render memory grew by {WptMemoryGuard.FormatMebibytes(observedBytes - baselineBytes)} " +
+               $"during this test, over the {WptMemoryGuard.FormatMebibytes(limitBytes)} limit.")
+    {
+        LimitBytes = limitBytes;
+        BaselineBytes = baselineBytes;
+        ObservedBytes = observedBytes;
+    }
+
+    /// <summary>Configured per-test cap, in bytes.</summary>
+    internal long LimitBytes { get; }
+
+    /// <summary>Resident set of the rendering process when this test started, in bytes.</summary>
+    internal long BaselineBytes { get; }
+
+    /// <summary>Resident set of the sample that tripped the guard, in bytes.</summary>
+    internal long ObservedBytes { get; }
+
+    /// <summary>Bytes this test added on top of <see cref="BaselineBytes"/>.</summary>
+    internal long GrowthBytes => ObservedBytes - BaselineBytes;
+
+    /// <summary>Human-readable "grew from 240 MiB to 1500 MiB, +1260 MiB" summary.</summary>
+    internal string Describe() =>
+        $"grew from {WptMemoryGuard.FormatMebibytes(BaselineBytes)} to " +
+        $"{WptMemoryGuard.FormatMebibytes(ObservedBytes)}, +{WptMemoryGuard.FormatMebibytes(GrowthBytes)}";
+}
+
+/// <summary>
+/// Per-test RAM cap for the WPT runner. A single WPT document can allocate without
+/// bound — a runaway layout, an enormous decoded image — and with no cap the render
+/// process (or the CI machine) is OOM-killed, taking the whole shard's results with it.
+/// The guard polls the resident set of the process rendering the current test while the
+/// harness waits for that test's result and aborts the test once it has grown past the
+/// cap: the same "cap each test, let the suite continue" role that Broiler.JS's test262
+/// runner fills with its POSIX <c>--memory-limit-mb</c> rlimit.
+/// </summary>
+/// <remarks>
+/// The rlimit approach does not transfer directly. test262 spawns a fresh process per
+/// test, so a kernel-enforced address-space cap is exactly a per-test cap; the WPT runner
+/// reuses one worker across tests, where the same rlimit would instead cap the worker's
+/// accumulated lifetime. Hence polling, and hence <em>growth since this test started</em>
+/// rather than the absolute footprint: a measured css run leaves the worker resident at
+/// ~860 MiB after 147 well-behaved tests (mostly garbage the GC has no pressure to
+/// reclaim), so an absolute check near 1 GiB would fail whichever innocent test happened
+/// to run next. Growth charges each test only for what it itself allocated.
+/// <para>
+/// Growth alone does not bound the harness, so it is paired with worker recycling: the
+/// runner restarts a worker whose resident set has reached the cap <em>between</em> tests,
+/// where no test has to be blamed for it. See <c>Program.WptWorkerClient</c>.
+/// </para>
+/// </remarks>
+internal sealed class WptMemoryGuard
+{
+    internal const long BytesPerMebibyte = 1024 * 1024;
+
+    /// <summary>
+    /// How often the resident set is sampled while a test runs. Short enough to catch a
+    /// ballooning test well before the OS notices, cheap enough (one <c>/proc</c> read)
+    /// to run for every test in the suite.
+    /// </summary>
+    internal static readonly TimeSpan DefaultSampleInterval = TimeSpan.FromMilliseconds(100);
+
+    private readonly long _limitBytes;
+    private readonly Func<long> _sampleBytes;
+    private readonly TimeSpan _sampleInterval;
+
+    /// <param name="limitBytes">Per-test growth cap in bytes; zero or negative disables the guard.</param>
+    /// <param name="sampleBytes">
+    /// Returns the current resident set of the rendering process in bytes, or a negative
+    /// value when it cannot be read (the process exited, or the platform does not report it).
+    /// </param>
+    /// <param name="sampleInterval">Sampling interval; defaults to <see cref="DefaultSampleInterval"/>.</param>
+    internal WptMemoryGuard(long limitBytes, Func<long> sampleBytes, TimeSpan? sampleInterval = null)
+    {
+        _limitBytes = limitBytes;
+        _sampleBytes = sampleBytes;
+        _sampleInterval = sampleInterval ?? DefaultSampleInterval;
+    }
+
+    /// <summary>Resident set sampled when the wait started, in bytes (-1 when unavailable).</summary>
+    internal long BaselineBytes { get; private set; } = -1;
+
+    /// <summary>Highest resident set observed during the wait, in bytes (-1 when unavailable).</summary>
+    internal long PeakBytes { get; private set; } = -1;
+
+    /// <summary>True when the guard is armed; false when the cap is disabled.</summary>
+    internal bool IsEnabled => _limitBytes > 0;
+
+    /// <summary>
+    /// Waits for <paramref name="task"/> — the in-flight render of a single test — while
+    /// sampling memory, and returns its result.
+    /// </summary>
+    /// <exception cref="TimeoutException"><paramref name="timeout"/> elapsed first.</exception>
+    /// <exception cref="WptMemoryLimitExceededException">The cap was exceeded first.</exception>
+    internal T Wait<T>(Task<T> task, TimeSpan timeout)
+    {
+        if (!IsEnabled)
+            return task.WaitAsync(timeout).GetAwaiter().GetResult();
+
+        BaselineBytes = Sample();
+        PeakBytes = BaselineBytes;
+
+        var elapsed = Stopwatch.StartNew();
+        while (true)
+        {
+            var remaining = timeout - elapsed.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+                throw new TimeoutException("The operation has timed out.");
+
+            var slice = remaining < _sampleInterval ? remaining : _sampleInterval;
+
+            bool completed;
+            try
+            {
+                completed = task.Wait(slice);
+            }
+            catch (AggregateException)
+            {
+                // The render faulted. Fall through and rethrow the original exception
+                // (not the aggregate) through the awaiter, matching the plain
+                // WaitAsync().GetAwaiter().GetResult() path.
+                completed = true;
+            }
+
+            if (completed)
+                return task.GetAwaiter().GetResult();
+
+            ObserveMemory();
+        }
+    }
+
+    /// <summary>
+    /// Samples memory once and throws if this test has grown past the cap. Samples that
+    /// cannot be read are ignored: an unreadable resident set must not fail an otherwise
+    /// healthy test.
+    /// </summary>
+    private void ObserveMemory()
+    {
+        var sample = Sample();
+        if (sample < 0)
+            return;
+
+        // The first readable sample doubles as the baseline when the wait started before
+        // the rendering process was observable (a worker still starting up, say).
+        if (BaselineBytes < 0)
+            BaselineBytes = sample;
+        if (sample > PeakBytes)
+            PeakBytes = sample;
+
+        if (sample - BaselineBytes > _limitBytes)
+            throw new WptMemoryLimitExceededException(_limitBytes, BaselineBytes, sample);
+    }
+
+    private long Sample()
+    {
+        try
+        {
+            return _sampleBytes();
+        }
+        catch (Exception ex) when (
+            ex is InvalidOperationException ||
+            ex is NotSupportedException ||
+            ex is PlatformNotSupportedException ||
+            ex is System.ComponentModel.Win32Exception)
+        {
+            // The process exited between the liveness check and the read, or the platform
+            // does not expose the counter. Treat as "unknown" rather than as a violation.
+            return -1;
+        }
+    }
+
+    /// <summary>
+    /// Samples the resident set of <paramref name="process"/>, returning -1 once it exits.
+    /// </summary>
+    internal static Func<long> CreateProcessSampler(Process process) => () =>
+    {
+        if (process.HasExited)
+            return -1;
+
+        process.Refresh();
+        return process.WorkingSet64;
+    };
+
+    // Held for the life of the run rather than per test: Process.GetCurrentProcess()
+    // opens a handle, and a suite is thousands of tests long.
+    private static readonly Process CurrentProcess = Process.GetCurrentProcess();
+
+    /// <summary>
+    /// Samples the resident set of the harness process itself (in-process mode).
+    /// </summary>
+    internal static Func<long> CreateCurrentProcessSampler() => static () =>
+    {
+        CurrentProcess.Refresh();
+        return CurrentProcess.WorkingSet64;
+    };
+
+    /// <summary>Formats a byte count as "1024 MiB"; negative values render as "unknown".</summary>
+    internal static string FormatMebibytes(long bytes)
+    {
+        if (bytes < 0)
+            return "unknown";
+
+        var mebibytes = (double)bytes / BytesPerMebibyte;
+        return mebibytes.ToString("0.#", CultureInfo.InvariantCulture) + " MiB";
+    }
+}

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -34,6 +34,8 @@ internal enum FailureCategory
     RenderingError,
     /// <summary>The test exceeded the configured execution timeout.</summary>
     Timeout,
+    /// <summary>The test was aborted after exceeding the configured per-test RAM cap.</summary>
+    MemoryLimitExceeded,
     /// <summary>The reference image could not be decoded.</summary>
     ReferenceDecodeError,
     /// <summary>Rendered output did not match the reference image.</summary>


### PR DESCRIPTION
Implements a per-test RAM cap for the WPT runner to prevent runaway documents from OOM-killing the worker process or CI machine. A test that grows the rendering process's resident set past the configured limit is aborted and reported as a failure.

## Summary

The WPT runner now monitors memory usage during test execution and enforces a configurable per-test growth limit (default 1024 MiB). This prevents a single pathological test from consuming unbounded memory and destabilizing the entire test shard.

## Key Changes

- **`WptMemoryGuard` class**: Core guard implementation that polls the resident set of the rendering process while a test runs. Measures *growth* (not absolute footprint) since the test started, so accumulated memory from earlier tests doesn't penalize innocent tests that run later. Throws `WptMemoryLimitExceededException` when the cap is exceeded.

- **`WptMemoryLimitExceededException`**: Carries baseline, peak, and limit samples so failure diagnostics can distinguish a test that allocated a gigabyte outright from one that did so on top of an already-large worker.

- **Command-line and environment support**: 
  - New `--memory-limit-mb` flag to override the default
  - `BROILER_WPT_MEMORY_LIMIT_MB` environment variable for CI integration
  - Default 1024 MiB per test; 0 disables the guard

- **Worker recycling**: In worker-isolation mode, the runner restarts a worker between tests once its resident set reaches the cap, preventing drift across a shard without blaming any single test for accumulated memory.

- **In-process mode**: Measures growth from the harness process itself; abandoned test tasks are observed to prevent unrelated unobserved-task crashes.

- **Comprehensive test coverage**: 255-line test suite covering guard behavior, memory limit resolution, process sampling, formatting, and end-to-end abort scenarios.

- **GitHub Actions integration**: New `memory_limit_mb` workflow input parameter for per-run configuration.

## Implementation Details

- Sampling interval defaults to 100ms — frequent enough to catch ballooning tests, cheap enough (one `/proc` read) to run for every test.
- Unreadable samples (process exited, platform doesn't report resident set) are ignored rather than treated as violations.
- The guard integrates with existing timeout handling: whichever limit (time or memory) is hit first wins.
- Failure results include detailed diagnostics: baseline, peak, growth, and invocation stack traces for triage.

https://claude.ai/code/session_015sHj93iMc5XjPSENNUzLSB