### PR TITLE
Synthesize documents for embedded media, images, and text resources

### DIFF
--- a/Broiler.Layout/Broiler.Layout/IR/FragmentTreeBuilder.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/FragmentTreeBuilder.cs
@@ -542,12 +542,163 @@ internal static class FragmentTreeBuilder
             if (!File.Exists(docPath))
                 return (null, null);
 
-            return (File.ReadAllText(docPath), new Uri(docPath).AbsoluteUri);
+            string docUrl = new Uri(docPath).AbsoluteUri;
+            string markup = BuildEmbeddedDocumentMarkup(docPath, docUrl);
+            return markup == null ? (null, null) : (markup, docUrl);
         }
         catch
         {
             return (null, null);
         }
+    }
+
+    /// <summary>
+    /// The markup a nested browsing context renders for the resource at
+    /// <paramref name="path"/>, or <c>null</c> when the resource has no document
+    /// representation (the frame then paints empty).
+    /// </summary>
+    /// <remarks>
+    /// Only an HTML resource is its own document. Navigating a frame to an image,
+    /// to media, or to plain text does not parse the resource as markup: the UA
+    /// synthesises a document that presents it (HTML §"read-image" /
+    /// §"read-media" / §"read-text"). Feeding such a resource to the HTML parser
+    /// instead is not merely wrong output — the tokeniser mints tag names out of
+    /// binary noise, and a name like <c>n&#x5;4&#x353;:</c> (real bytes from a
+    /// WebM file) reaches <c>DomDocument.CreateElement</c> and throws, taking down
+    /// the whole page render (WPT
+    /// <c>navigation-timing/dom-interactive-media-document.html</c>).
+    /// </remarks>
+    private static string BuildEmbeddedDocumentMarkup(string path, string docUrl)
+    {
+        switch (ClassifyEmbeddedResource(path))
+        {
+            case EmbeddedResourceKind.Html:
+                return File.ReadAllText(path);
+
+            case EmbeddedResourceKind.Image:
+                // Image document: the image alone on the canvas, at its natural size.
+                return "<!DOCTYPE html><html><head><style>html,body{margin:0}</style></head>"
+                     + $"<body><img src=\"{AttributeEscaped(docUrl)}\"></body></html>";
+
+            case EmbeddedResourceKind.Media:
+                // Media document: one media element alone on a black canvas, as a
+                // top-level media document paints it — a <video> for audio too,
+                // which is the element a UA media document builds either way.
+                return "<!DOCTYPE html><html><head><style>html,body{margin:0;background:#000}</style></head>"
+                     + $"<body><video controls src=\"{AttributeEscaped(docUrl)}\"></video></body></html>";
+
+            case EmbeddedResourceKind.PlainText:
+                return BuildPlainTextDocument(File.ReadAllText(path));
+
+            case EmbeddedResourceKind.Unknown:
+                // No extension to classify by (common for generated WPT resources):
+                // sniff the bytes rather than guess. Text is treated as markup — an
+                // extensionless HTML resource is the usual case — and binary is not.
+                return LooksBinary(path) ? null : File.ReadAllText(path);
+
+            default:
+                // A resource we can classify but cannot present (PDF, a font, an
+                // archive): no document, so no markup.
+                return null;
+        }
+    }
+
+    /// <summary>A plain-text document: the text preserved in a <c>&lt;pre&gt;</c>, as a
+    /// text document's UA stylesheet presents it.</summary>
+    private static string BuildPlainTextDocument(string text)
+    {
+        var sb = new StringBuilder(
+            "<!DOCTYPE html><html><head><style>html,body{margin:0}"
+            + "pre{margin:0;white-space:pre-wrap;word-wrap:break-word}</style></head><body><pre>");
+        AppendXmlEscaped(sb, text);
+        sb.Append("</pre></body></html>");
+        return sb.ToString();
+    }
+
+    private enum EmbeddedResourceKind
+    {
+        /// <summary>Markup — parse it as the frame's document.</summary>
+        Html,
+        Image,
+        /// <summary>Audio or video.</summary>
+        Media,
+        PlainText,
+        /// <summary>Classified, but with no document representation (PDF, font, …).</summary>
+        Opaque,
+        /// <summary>Not classifiable from the file name.</summary>
+        Unknown,
+    }
+
+    /// <summary>Classifies an embedded resource by file extension, the only signal a
+    /// file:// load carries (there is no Content-Type header).</summary>
+    private static EmbeddedResourceKind ClassifyEmbeddedResource(string path) =>
+        Path.GetExtension(path).ToLowerInvariant() switch
+        {
+            "" => EmbeddedResourceKind.Unknown,
+            ".html" or ".htm" or ".xhtml" or ".xht" or ".shtml" or ".svg" => EmbeddedResourceKind.Html,
+            ".txt" or ".text" or ".csv" or ".md" or ".js" or ".mjs" or ".css" or ".json"
+                => EmbeddedResourceKind.PlainText,
+            ".png" or ".jpg" or ".jpeg" or ".gif" or ".webp" or ".bmp" or ".ico" or ".avif"
+                => EmbeddedResourceKind.Image,
+            ".webm" or ".mp4" or ".m4v" or ".ogv" or ".mov" or ".mkv"
+                or ".mp3" or ".m4a" or ".wav" or ".ogg" or ".oga" or ".flac" or ".opus"
+                => EmbeddedResourceKind.Media,
+            ".pdf" or ".woff" or ".woff2" or ".ttf" or ".otf" or ".eot"
+                or ".zip" or ".gz" or ".wasm" => EmbeddedResourceKind.Opaque,
+            // .py/.asis/.sub and friends: WPT server-generated resources whose
+            // payload is usually markup, and anything else unrecognised.
+            _ => EmbeddedResourceKind.Unknown,
+        };
+
+    /// <summary>
+    /// True when the head of <paramref name="path"/> does not decode as text — a NUL
+    /// byte or an invalid UTF-8 sequence. Both are impossible in a text resource and
+    /// characteristic of a binary one, so this is the last guard that keeps binary
+    /// bytes out of the HTML parser when the file name says nothing.
+    /// </summary>
+    private static bool LooksBinary(string path)
+    {
+        const int SniffLength = 1024;
+        byte[] head;
+        try
+        {
+            using var stream = File.OpenRead(path);
+            head = new byte[(int)Math.Min(SniffLength, Math.Max(stream.Length, 0))];
+            int read = stream.Read(head, 0, head.Length);
+            if (read < head.Length)
+                Array.Resize(ref head, read);
+        }
+        catch
+        {
+            return true;
+        }
+
+        if (Array.IndexOf(head, (byte)0) >= 0)
+            return true;
+
+        try
+        {
+            // Decode all but a possibly truncated trailing sequence: a multi-byte
+            // character straddling the sniff boundary is not evidence of binary.
+            int end = head.Length;
+            for (int i = 0; i < 4 && end > 0 && (head[end - 1] & 0x80) != 0; i++)
+                end--;
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true)
+                .GetString(head, 0, end);
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return true;
+        }
+    }
+
+    /// <summary>Escapes <paramref name="value"/> for a double-quoted attribute.</summary>
+    private static string AttributeEscaped(string value)
+    {
+        var sb = new StringBuilder(value.Length);
+        AppendXmlEscaped(sb, value);
+        return sb.ToString();
     }
 
     private static bool HasHtmlExtension(string url)

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ conformance, and implementation work belongs with that component.
 | Document | Purpose |
 | --- | --- |
 | [Root roadmap](ROADMAP.md) | The unfinished cross-repository work and its exit gates |
+| [WPT rendering gaps](wpt-rendering-gaps.md) | The worst-scoring WPT pixel mismatches, the capability each one is missing, and its owning component |
 | [HtmlBridge architecture](architecture/htmlbridge.md) | Current bridge assemblies, ownership boundaries, and public seams |
 | [Browser WebAssembly architecture](architecture/browser-webassembly.md) | Current browser-host, rendering, input, and support decisions |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -97,7 +97,9 @@ The current WPT artifacts remain the evidence source:
   presence.
 - Keep prioritized WPT failures in generated reports and component roadmaps.
   Root tracking should cover only cross-component runner, timeout, reference, and
-  ownership problems.
+  ownership problems. The worst-scoring pixel mismatches of the current run, with
+  the capability each is missing and the component that owns it, are in
+  [WPT rendering gaps](wpt-rendering-gaps.md).
 - Prototype per-component stress attribution with a small Broiler.JS slice before
   investing in full coverage-guided selection.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -153,11 +153,34 @@ The current assembly and ownership boundaries are in
   evidence before retiring their compatibility levers.
 - Remove vestigial cutover flags only after their rollback and differential tests
   have been replaced by permanent invariant tests.
+- Give the element JS wrapper a shared prototype instead of a per-instance
+  surface. `DomBridge.ToJSObject` installs the whole element API — every
+  reflector, method, `style`, `classList`, `dataset` — onto each wrapper object,
+  so one script-created element costs **~550 KiB** of retained memory. Measured
+  on this container (peak RSS of `Broiler.Wpt --render`, 107 MiB baseline):
+
+  | Page | Peak RSS |
+  | --- | --- |
+  | 10 000 `<span>`s in the markup (no wrapper) | 223 MiB |
+  | 4 000 `document.createElement("span")`, never inserted | 2 290 MiB |
+  | 4 000 created and appended | 2 294 MiB |
+
+  The cost is linear per created element and attaches to `createElement` itself,
+  not to insertion, layout, or style: creating the wrapper is what allocates.
+  This is what the WPT runner's per-test memory guard reports as
+  `Program.Main — Test aborted after exceeding the … per-test memory limit`
+  (issue #1491 problems 2 and 3: `css/css-variables/url-syntax-crash.html` and
+  `editing/crashtests/insertparagraph-in-listitem-in-svg-followed-by-collapsible-spaces.html`,
+  both of which create ~10 000 elements from script — the custom property in the
+  first is incidental, a bare 10 000-span loop blows the same limit). It crosses
+  the bridge and the JS engine's object model, so it cannot be fixed inside
+  either alone.
 
 **Exit gate:** all execution surfaces use the same ordered scheduling model,
 session dependencies are instance-scoped, native zoom/top-layer behavior is
-enabled for every supported consumer, and focused plus broad regression gates
-remain green.
+enabled for every supported consumer, a script-created element's wrapper costs a
+constant handful of bytes over its canonical node, and focused plus broad
+regression gates remain green.
 
 ## Linux application preview
 

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -1,0 +1,308 @@
+# WPT rendering gaps — the worst pixel mismatches
+
+- **Scope:** the `< 50% match` tail of the WPT run reported in
+  [issue #1491](https://github.com/Broiler-Platform/Broiler/issues/1491),
+  problems 4–30. Each of those 27 tests renders at **0.0–2.5%** of its Chromium
+  reference, so each is a whole-canvas difference rather than a tolerance
+  problem.
+- **Not in scope:** problem 1 (the `DomDocument.CreateElement` crash) is fixed —
+  frames no longer parse a non-HTML resource as markup, and
+  `patches/0035-…` carries the DOM-layer fix. Problems 2 and 3 (per-test memory
+  aborts) are the per-element JS wrapper cost, tracked in
+  [the root roadmap](ROADMAP.md#htmlbridge-runtime).
+- **Companion documents:** [root roadmap](ROADMAP.md) for cross-component work;
+  the component roadmaps own the implementation once an item below names them.
+
+Every item names an owner, the evidence behind it, its next action, and an
+objective exit gate. Where the evidence is a local measurement rather than the CI
+artifact, it says so — several of these tests cannot be reproduced faithfully
+without the WPT server, and a local number that looks better than CI's usually
+means *both* engines rendered nothing.
+
+## Reproducing one of these locally
+
+The runner compares Broiler's render against a Chromium screenshot of the same
+test, so a local investigation needs both halves:
+
+```sh
+# 1. Broiler's render
+dotnet run --project src/Broiler.Wpt -- --wpt-dir <checkout> --render <checkout>/<test>
+
+# 2. Chromium's reference (Playwright is pinned in tests/wpt/package.json;
+#    this container already has a browser at $PLAYWRIGHT_BROWSERS_PATH)
+node scripts/generate-wpt-references.js <checkout>/<dir> <refs>/<dir> --base-dir <checkout>
+
+# 3. The comparison, its category, and side-by-side images
+dotnet run --project src/Broiler.Wpt -- --wpt-dir <checkout> --reference-dir <refs> \
+  --subset <dir> --failure-images <out>
+```
+
+Two caveats, both learned the hard way while writing this document:
+
+- **A test that needs the WPT server cannot be reproduced from a bare checkout.**
+  `.sub.html` files need substitution, `?pipe=trickle(…)` needs the server's pipe
+  handlers, and cross-origin tests need a second host. Offline, both engines fail
+  the same way and the match score is meaningless — a *higher* local score than
+  CI is the signature of this.
+- **Reference generation must honour `reftest-wait`.** A flat screenshot delay
+  reads a view-transition or `takeScreenshotDelayed` test at the wrong moment, so
+  the local reference disagrees with CI's.
+
+## Animated images always paint their first frame
+
+- **Tests:** problems 7–10, all four
+  `css/css-image-animation/image-animation-*-paused.html`.
+- **Owner:** Broiler.Media (frame selection) with Broiler.HTML (a paint-time
+  clock).
+- **Current evidence:** measured locally, and unambiguous — for all four tests
+  Broiler's canvas is 100% `rgb(0,255,0)` and Chromium's is 100% `rgb(255,0,0)`.
+  The tests set an animated GIF (`images/anim-gr.gif`, two frames, green then
+  red) as the root or body background and ask for `image-animation: paused`.
+  Chromium does not implement `image-animation`, so its reference is simply the
+  frame its own timeline had reached at screenshot time (300 ms, via
+  `takeScreenshotDelayed`); Broiler paints frame 0 because nothing in the static
+  render path carries elapsed time into image decoding. The propagation
+  variations (root vs body, propagating or not) are incidental — the background
+  is painted in every case, only its frame is wrong.
+- **Next actions:**
+  1. Give the render pass a pinned presentation time and select an animated
+     image's frame from its own frame delays against that time, instead of
+     always decoding frame 0.
+  2. Thread the runner's reftest-wait delay into that presentation time so a
+     `takeScreenshotDelayed(N)` test is rendered as of N.
+  3. Only then implement `image-animation: paused` itself; while Chromium's
+     reference is the unpaused render, honouring the property makes these four
+     tests *diverge* rather than converge.
+- **Exit gate:** an animated image paints the frame its timeline selects at the
+  pass's presentation time, the four tests match their references, and a focused
+  test pins frame selection at two different presentation times.
+
+## View transitions composite no captured content
+
+- **Tests:** problems 14–23, ten `css/css-view-transitions/*` tests.
+- **Owner:** HtmlBridge (`DomBridge.ViewTransition.cs`) with Broiler.HTML for the
+  snapshot compositing.
+- **Current evidence:** the pseudo tree is materialised, but nothing captured
+  goes into it. In `auto-name.html` Broiler's canvas is 97%
+  `rebeccapurple` — exactly the `html::view-transition { background:
+  rebeccapurple }` root the test sets — while Chromium's is 97% white with the 1%
+  green and 1% yellow squares that are the captured old/new items. So the
+  `::view-transition` root paints as an opaque box over the viewport and the
+  `::view-transition-old()` / `::view-transition-new()` images are absent.
+  `root-captured-as-different-tag` (ours 100% red vs 98% white) and
+  `old-/new-content-captures-root` (ours 99% pink) fail the same way. The two
+  `iframe-and-main-frame-transition-*` tests render blank against a reference
+  that is 75% green + 25% blue, so there the transition never starts at all.
+- **Next actions:**
+  1. Capture the old and new snapshots as images and paint them in the
+     `::view-transition-old()` / `::view-transition-new()` boxes, rather than
+     materialising the pseudo tree as empty positioned boxes.
+  2. Keep the `::view-transition` root behind the captured groups in paint order.
+  3. Make `document.startViewTransition`'s callback and its `ready` promise run
+     the DOM update before the screenshot, which the blank-rendering iframe pair
+     suggests is not happening for a nested browsing context.
+- **Exit gate:** a paused view transition composites both captured snapshots at
+  their group geometry, the ten tests report a non-trivial match, and a focused
+  test asserts old/new snapshot paint order against the pseudo root.
+
+## System colour keywords resolve to a dark palette
+
+- **Test:** problem 28, `forced-colors-mode/forced-colors-mode-20.html`.
+- **Owner:** Broiler.CSS.
+- **Current evidence:** the test paints `body { background-color: Canvas }`.
+  Broiler's canvas is 98% black; Chromium's is 98% white. Forced colors are not
+  active in either engine (the reference is an ordinary Chromium render), so
+  `Canvas` must resolve to the light palette's white. Broiler resolving it to
+  black turns every system-colour test into a whole-canvas mismatch, and this one
+  is only the worst-scoring member of that family.
+- **Next actions:**
+  1. Resolve the CSS system colours (`Canvas`, `CanvasText`, `LinkText`, `Field`,
+     `ButtonFace`, …) from the light palette by default.
+  2. Switch palettes only where a used `color-scheme` or an emulated forced-colors
+     mode asks for it, and keep `forced-colors` computing to `none` while nothing
+     emulates it.
+- **Exit gate:** `getComputedStyle` reports the light-palette value for every
+  system colour in a default document, the test matches, and a focused test
+  covers the `color-scheme: dark` switch.
+
+## `contrast-color()` and style container queries
+
+- **Test:** problem 6, `css/css-color/contrast-color-style-query.html`.
+- **Owner:** Broiler.CSS.
+- **Current evidence:** Broiler renders 100% white where Chromium renders 100%
+  green. The test needs three features to compose: an `@property`-registered
+  `<color>` custom property, `contrast-color(#000)` resolving to an absolute
+  colour, and `@container style(--contrast-color: white)` matching on it. Any one
+  missing leaves the `background: green` rule unapplied, which is what the blank
+  render shows.
+- **Next action:** implement `contrast-color()` as an absolute-colour resolution
+  at computed-value time, then confirm whether the style container query
+  evaluates registered custom properties; the test distinguishes the two once
+  either lands.
+- **Exit gate:** `contrast-color()` computes to an absolute colour, a style
+  container query matches on a registered custom property, and the test matches.
+
+## `<base href>` is ignored for `<link rel=stylesheet>` in the render path
+
+- **Test:** problem 25,
+  `html/semantics/document-metadata/the-link-element/stylesheet-with-base.html`.
+- **Owner:** main repo (the renderer's stylesheet resolution).
+- **Current evidence:** the test sets `<base href="resources/">` and links
+  `stylesheet.css`, so only `resources/stylesheet.css` (green) may load — the
+  sibling `stylesheet.css` next to the test sets red as the trap. Broiler renders
+  100% red. It resolved the href against the document URL and loaded the trap
+  file, which is exactly what the `<base>` is there to prevent.
+- **Next actions:**
+  1. Resolve a `<link rel=stylesheet>` href against the document's base URL in
+     the render path. `e4cc5e9` fixed one such site; this render path is a second
+     one, so find the shared seam rather than patching a third.
+  2. Cover `@import` and `url()` inside a `<base>`-scoped document at the same
+     time.
+- **Exit gate:** every stylesheet URL in the render path resolves against
+  `<base href>`, the test matches, and a focused test asserts the trap file is
+  never loaded.
+
+## Screen-layout gaps behind the three `*-print.html` tests
+
+- **Tests:** problems 11, 12 and 30 — `css/css-page/monolithic-overflow-011-print.html`,
+  `page-margin-002-print.html`, `page-box-008-print.html`.
+- **Owner:** Broiler.Layout.
+- **Current evidence:** these are `@page` tests, but the runner and its reference
+  generator both screenshot them **on screen**, where Chromium largely ignores
+  `@page`. So none of the three is blocked on paged media — each is an ordinary
+  screen-layout gap:
+  - `page-box-008`: Broiler is 99% hotpink (the body background) where Chromium
+    is 99% yellow (a `block-size: 100vb` box). The logical viewport unit `vb`
+    does not resolve, so the box has no size.
+  - `monolithic-overflow-011`: Broiler renders 99% white against 95% yellow + 5%
+    hotpink — the `display: table` subtree with a `contain: size; height: 350vh`
+    row-group paints nothing.
+  - `page-margin-002`: Broiler is 100% yellow, Chromium 100% white, with
+    `writing-mode: vertical-rl` on the root and three `100vw × 100vh` blocks.
+    The two engines disagree about where a vertical-rl root's initial scroll
+    position is. **Unconfirmed** — verify the scroll origin before treating this
+    as a paint bug.
+- **Next actions:**
+  1. Resolve the logical viewport units (`vb`, `vi`, and their `sv`/`lv`/`dv`
+     variants) against the writing mode.
+  2. Lay out and paint a `contain: size` box inside table internals.
+  3. Establish what a vertical-rl root's initial scroll position is and align the
+     canvas extent with it.
+- **Exit gate:** all three tests match on screen, with focused tests for logical
+  viewport units and for `contain: size` in table internals — and no paged-media
+  work is required to get there.
+
+## Frameset frames render nothing
+
+- **Test:** problem 26, `resource-timing/initiator-type/frameset.html`.
+- **Owner:** HtmlBridge (nested browsing contexts) with Broiler.HTML.
+- **Current evidence:** Broiler's canvas is 100% white; Chromium's is 100%
+  `#dddddd` with frame borders. `0b3c596` and `a06b53c` moved `<frame>`
+  sub-documents and the iframe default object size forward, so this is the
+  remaining `<frameset>` case: the frameset grid paints neither its own canvas
+  nor its frames' documents.
+- **Next action:** render a `<frameset>`'s frames as nested browsing contexts
+  positioned on the frameset grid, and paint the frameset's own canvas behind
+  them.
+- **Exit gate:** the test matches, and a focused test asserts a two-frame
+  frameset paints both documents at their grid rects.
+
+## `Node.moveBefore` is missing
+
+- **Test:** problem 27, `dom/nodes/moveBefore/preserve-render-blocking-style.html`.
+- **Owner:** Broiler.DOM with HtmlBridge for the binding.
+- **Current evidence:** Broiler renders white where Chromium renders 100% green.
+  The test moves a render-blocking `<style>` with `moveBefore()` and asserts the
+  styles survive the move; without the method the script throws and the document
+  is never styled.
+- **Next actions:**
+  1. Implement `moveBefore()` as a state-preserving move (no removal/insertion
+     pair), and expose it on the bridge's node surface.
+  2. Keep a moved render-blocking element's blocking state intact.
+- **Exit gate:** the test matches, and focused tests cover a move within and
+  across parents plus the render-blocking case.
+
+## Shadow-DOM focus delegation paints the wrong surface
+
+- **Test:** problem 29, `shadow-dom/focus-navigation/delegatesFocus-highlight-sibling.html`.
+- **Owner:** HtmlBridge (shadow tree + focus) with Broiler.HTML for control
+  chrome.
+- **Current evidence:** Broiler's canvas is 99% `#cccccc` — one flat grey area —
+  where Chromium's is 98% white with form-control chrome and a focus highlight.
+  The rendered surface, not just the highlight, is wrong, so this is more than a
+  missing focus ring.
+- **Next action:** establish what Broiler is painting grey (a slotted host box, or
+  a UA widget fallback) before touching focus delegation itself; the highlight is
+  the test's subject but not its current failure.
+- **Exit gate:** the test matches, with a focused test for `delegatesFocus`
+  moving focus to the first focusable shadow descendant.
+
+## Items that need the WPT server before they can be judged
+
+- **Tests:** problem 5
+  (`css/css-color-adjust/…/color-scheme-iframe-background-mismatch-opaque-cross-origin-002.sub.html`),
+  problem 4 (`css/css-backgrounds/background-image-shared-stylesheet.html`),
+  problem 13 (`css/css-transforms/animation/transform-interpolation-002.html`).
+- **Owner:** the WPT runner, then the component the confirmed failure names.
+- **Current evidence:** all three are reported at 0.0% by CI but are not
+  reproducible offline, and their local scores are misleading:
+  - problem 5 needs `.sub` substitution and a cross-origin host. Offline Broiler
+    paints the `#121212` dark canvas backdrop and Chromium paints white, which
+    hints at a `color-scheme` propagation difference but proves nothing without
+    the real cross-origin frame.
+  - problem 4 needs `?pipe=trickle(d2)` for its image and a script-injected
+    `data:text/css` stylesheet; offline neither engine loads the image, so the
+    pair matched at 99.8% locally while CI reports 0.0%.
+  - problem 13 builds its whole DOM from `interpolation-testcommon.js`; offline
+    both renders are empty (100% local match, 0.0% on CI), so the CI artifact's
+    `rendered.png` is the only evidence that says what Broiler actually drew.
+- **Next actions:**
+  1. Pull the `wpt-merged` artifact's failure images for these three before
+     opening any component work — the local pipeline cannot see their real
+     failure.
+  2. Decide whether the runner should serve tests over a local HTTP origin with
+     substitution and pipe support, which is what would make this whole class
+     reproducible.
+- **Exit gate:** each of the three is either reproducible locally or reassigned to
+  an owning component with a CI-artifact failure image as its evidence.
+
+## Runner: a `manual/` test is being scored
+
+- **Test:** problem 24,
+  `html/canvas/element/manual/draw-element-image/dialog-paints-in-top-layer.tentative.html`.
+- **Owner:** the WPT runner (`src/Broiler.Wpt`).
+- **Current evidence:** the test sits under a `manual/` path segment and is
+  `.tentative`, but it is discovered and scored as a Regular test. Its reference
+  is a 100% white Chromium canvas, because Chromium does not implement the
+  proposed `draw-element-image` API either — so the only way to "pass" is to
+  render nothing. Broiler paints a dialog (98% `#e5e5e5` + 2% green), which is
+  arguably the more useful behaviour.
+- **Next action:** treat a `manual/` path segment as a manual test in discovery,
+  the way a `-manual.html` suffix already is, and report the count change so the
+  drop is not read as a regression.
+- **Exit gate:** `manual/` tests land in the Manual bucket, the run's Regular
+  count changes by exactly the number reclassified, and problem 24 leaves the
+  scored set.
+
+## Reported problems, at a glance
+
+Local numbers come from this container against locally generated Chromium
+references; CI's are authoritative where they disagree.
+
+| # | Test | CI | Local observation |
+| --- | --- | --- | --- |
+| 4 | `css-backgrounds/background-image-shared-stylesheet` | 0.0% | 99.8% — needs the server's `trickle` pipe |
+| 5 | `css-color-adjust/…/cross-origin-002.sub` | 0.0% | ours `#121212`, Chromium white — needs `.sub` |
+| 6 | `css-color/contrast-color-style-query` | 0.0% | ours white, Chromium green |
+| 7–10 | `css-image-animation/*-paused` (4) | 0.0% | ours green frame 0, Chromium red |
+| 11 | `css-page/monolithic-overflow-011-print` | 0.0% | ours blank, Chromium yellow + hotpink |
+| 12 | `css-page/page-margin-002-print` | 0.0% | ours yellow, Chromium white |
+| 13 | `css-transforms/animation/transform-interpolation-002` | 0.0% | 100% — both empty offline |
+| 14–23 | `css-view-transitions/*` (10) | 0.0–1.3% | pseudo root paints, captures absent |
+| 24 | `canvas/…/manual/dialog-paints-in-top-layer.tentative` | 0.0% | ours dialog, Chromium blank (unsupported) |
+| 25 | `the-link-element/stylesheet-with-base` | 0.0% | ours red (trap file), Chromium white |
+| 26 | `resource-timing/initiator-type/frameset` | 0.0% | ours white, Chromium `#dddddd` |
+| 27 | `dom/nodes/moveBefore/preserve-render-blocking-style` | 0.0% | ours white, Chromium green |
+| 28 | `forced-colors-mode/forced-colors-mode-20` | 0.0% | ours black, Chromium white |
+| 29 | `shadow-dom/focus-navigation/delegatesFocus-highlight-sibling` | 0.0% | ours flat `#cccccc`, Chromium white + chrome |
+| 30 | `css-page/page-box-008-print` | 0.0% | ours hotpink, Chromium yellow |

--- a/patches/0035-dom-create-element-local-name-colon.patch
+++ b/patches/0035-dom-create-element-local-name-colon.patch
@@ -1,0 +1,146 @@
+From 08071a72d20d260aa00de256a71cab0e80f16584 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Thu, 30 Jul 2026 10:03:13 +0000
+Subject: [PATCH] dom: keep a colon in a createElement local name instead of
+ throwing
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+document.createElement() takes a local name, so per DOM it performs no
+prefix splitting and no qualified-name validation. Routing it through the
+namespace-aware DomName constructor rejected any name whose colons did not
+form a valid prefix — and that constructor is what the HTML parser reaches
+through DomDocument.CreateElement for every start tag.
+
+The tokeniser accepts any character but whitespace, '/' and '>' in a tag
+name, so markup as unremarkable as <x::y> threw "is not a valid qualified
+name" and took down the whole page render. WPT
+navigation-timing/dom-interactive-media-document.html hit it with a tag
+name minted from WebM bytes ('n\x054\u0353:').
+
+createElementNS keeps the namespace-aware constructor, prefix splitting and
+validation included.
+---
+ Broiler.Dom.Tests/DomKernelTests.cs | 28 ++++++++++++++++++++++++++++
+ Broiler.Dom/DomDocument.cs          | 13 ++++++++++++-
+ Broiler.Dom/DomName.cs              | 25 ++++++++++++++++++++-----
+ 3 files changed, 60 insertions(+), 6 deletions(-)
+
+diff --git a/Broiler.Dom.Tests/DomKernelTests.cs b/Broiler.Dom.Tests/DomKernelTests.cs
+index 4bb5ea8..766afb3 100644
+--- a/Broiler.Dom.Tests/DomKernelTests.cs
++++ b/Broiler.Dom.Tests/DomKernelTests.cs
+@@ -172,6 +172,34 @@ public sealed class DomKernelTests
+         Assert.Null(element.GetAttributeNS("http://www.w3.org/1999/xlink", "href"));
+     }
+ 
++    [Fact]
++    public void CreateElement_Keeps_A_Colon_In_The_Local_Name_Without_Throwing()
++    {
++        // Per DOM, createElement() takes a LOCAL name, so it performs no prefix
++        // splitting and no qualified-name validation — the same element-creation
++        // shape the HTML parser needs. Regression (WPT issue #1491
++        // navigation-timing/dom-interactive-media-document.html): a tag name the
++        // tokeniser legitimately produced ('n\x054͓:', from binary bytes fed
++        // to the parser as markup) threw "is not a valid qualified name" here and
++        // took down the whole page render.
++        var document = new DomDocument();
++
++        var element = document.CreateElement("x::y");
++
++        Assert.Equal("x::y", element.LocalName);
++        Assert.Equal("x::y", element.TagName);
++        Assert.Null(element.Prefix);
++        Assert.Equal(DomNamespaces.Html, element.NamespaceUri);
++
++        // Trailing and leading colons are names too, not errors.
++        Assert.Equal("n4͓:", document.CreateElement("n4͓:").LocalName);
++        Assert.Equal(":y", document.CreateElement(":y").LocalName);
++
++        // A prefixed name still splits — and still validates — via createElementNS.
++        Assert.Equal("svg", document.CreateElementNS(DomNamespaces.Svg, "svg:use").Prefix);
++        Assert.Throws<DomException>(() => document.CreateElementNS(DomNamespaces.Svg, "svg:use:"));
++    }
++
+     [Fact]
+     public void Id_Index_Tracks_Connection_Mutation_And_Tree_Order()
+     {
+diff --git a/Broiler.Dom/DomDocument.cs b/Broiler.Dom/DomDocument.cs
+index bcfe5a2..0538a3b 100644
+--- a/Broiler.Dom/DomDocument.cs
++++ b/Broiler.Dom/DomDocument.cs
+@@ -71,7 +71,18 @@ public sealed class DomDocument : DomNode
+         return clone;
+     }
+ 
+-    public DomElement CreateElement(string localName) => new(this, new DomName(DomNamespaces.Html, localName.ToLowerInvariant()));
++    /// <summary>
++    /// Creates an HTML-namespace element whose local name is <paramref name="localName"/>
++    /// lowercased. Per DOM, <c>createElement</c> takes a local name, so the whole name is
++    /// kept verbatim — a ':' in it is an ordinary character, not a prefix separator, and
++    /// never an error. That is also what the HTML parser needs: its tokeniser accepts any
++    /// character but whitespace, '/' and '&gt;' in a tag name, so markup as unremarkable as
++    /// <c>&lt;x::y&gt;</c> — or a resource mistakenly fed to the parser as markup — would
++    /// otherwise throw here and take down the whole page. Prefix splitting and
++    /// namespace validation belong to <see cref="CreateElementNS"/>.
++    /// </summary>
++    public DomElement CreateElement(string localName) =>
++        new(this, DomName.CreateLocal(DomNamespaces.Html, localName.ToLowerInvariant()));
+ 
+     public DomElement CreateElementNS(string? namespaceUri, string qualifiedName) =>
+         new(this, new DomName(namespaceUri, qualifiedName));
+diff --git a/Broiler.Dom/DomName.cs b/Broiler.Dom/DomName.cs
+index b180b3a..2ebe8e8 100644
+--- a/Broiler.Dom/DomName.cs
++++ b/Broiler.Dom/DomName.cs
+@@ -40,14 +40,18 @@ public readonly record struct DomName
+         QualifiedName = qualifiedName;
+     }
+ 
++    // Distinguishes the non-splitting constructor below from the namespace-aware
++    // one, which has the same parameter types.
++    private enum Unsplit { Name }
++
+     // Non-splitting constructor: the whole name is the local name, with no
+-    // prefix or namespace processing (used by CreateLocal).
+-    private DomName(string localName)
++    // prefix processing; the namespace is taken as given (used by CreateLocal).
++    private DomName(string? namespaceUri, string localName, Unsplit _)
+     {
+         LocalName = localName;
+         QualifiedName = localName;
+         Prefix = null;
+-        NamespaceUri = null;
++        NamespaceUri = string.IsNullOrEmpty(namespaceUri) ? null : namespaceUri;
+     }
+ 
+     /// <summary>
+@@ -59,11 +63,22 @@ public readonly record struct DomName
+     /// literally "xlink:href" (no namespace) rather than throwing. The
+     /// namespace-aware constructor is for <c>setAttributeNS</c>.
+     /// </summary>
+-    public static DomName CreateLocal(string localName)
++    public static DomName CreateLocal(string localName) => CreateLocal(null, localName);
++
++    /// <summary>
++    /// Creates a name in <paramref name="namespaceUri"/> with NO prefix processing:
++    /// the entire <paramref name="localName"/> becomes the local (and qualified) name
++    /// even if it contains a ':'. This is the shape of the DOM "create an element"
++    /// internal algorithm, which takes a local name — not a qualified one — so neither
++    /// the HTML parser nor <c>document.createElement()</c> splits off a prefix or
++    /// rejects a colon; only <c>createElementNS</c> does namespace-aware validation
++    /// (the constructor above).
++    /// </summary>
++    public static DomName CreateLocal(string? namespaceUri, string localName)
+     {
+         if (string.IsNullOrWhiteSpace(localName))
+             throw new ArgumentException("A local name is required.", nameof(localName));
+-        return new DomName(localName);
++        return new DomName(namespaceUri, localName, Unsplit.Name);
+     }
+ 
+     public string? NamespaceUri { get; }
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,33 @@
+# Pending submodule patches
+
+Fixes that belong in a submodule (`Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`,
+`Broiler.JS`, `Broiler.Graphics`) but could not be pushed to their remote from
+the session that wrote them: the git proxy only authorises repos in the session's
+GitHub scope, so a push to a submodule remote outside it returns **403**. Rather
+than bump a submodule pointer at a commit CI cannot clone, the change is captured
+here as a `git format-patch` file for a maintainer to apply.
+
+## Applying
+
+```sh
+cd <Submodule>
+git am ../patches/NNNN-<slug>.patch
+git push origin HEAD
+cd ..
+git add <Submodule>        # bump the pointer only after the push succeeds
+```
+
+Delete the patch file and its row below once the pointer is bumped.
+
+## Index
+
+| Patch | Submodule | Summary |
+| --- | --- | --- |
+| `0035-dom-create-element-local-name-colon.patch` | `Broiler.DOM` | Stop `DomDocument.CreateElement` routing through the namespace-aware `DomName` constructor. Per DOM, `createElement` takes a *local* name: it does no prefix splitting and no qualified-name validation. Because that is also the HTML parser's element-creation path, a tag name the tokeniser legitimately produced — anything with a leading, trailing or doubled colon, e.g. `<x::y>` — threw `'…' is not a valid qualified name` and took down the whole page render (WPT issue #1491 problem 1, `navigation-timing/dom-interactive-media-document.html`, whose name came from WebM bytes). |
+
+A main-repo fallback ships for 0035, so the WPT test that reported the crash is
+green on CI without it: `FragmentTreeBuilder.BuildEmbeddedDocumentMarkup` no
+longer feeds a frame's non-HTML resource to the HTML parser, which is what minted
+that tag name. The patch is the fix at its own layer — it covers every other way
+such a tag name reaches the parser, ordinary markup included — so it is still
+worth applying.

--- a/src/Broiler.Cli.Tests/EmbeddedMediaDocumentTests.cs
+++ b/src/Broiler.Cli.Tests/EmbeddedMediaDocumentTests.cs
@@ -1,0 +1,122 @@
+using Broiler.HTML.Image;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// WPT issue #1491, problem 1: navigation-timing/dom-interactive-media-document.html
+/// (<c>&lt;iframe src="../media/A4.webm"&gt;</c>) crashed the whole page render with
+/// <c>DomDocument.CreateElement — 'n&#x5;4&#x353;:' is not a valid qualified name</c>.
+///
+/// The frame's resource was read with <c>File.ReadAllText</c> and handed to the HTML
+/// parser whatever it was, so the tokeniser minted that tag name out of WebM bytes.
+/// Navigating a frame to media, to an image, or to plain text does not parse the
+/// resource as markup: the UA synthesises a document that presents it (HTML
+/// §"read-media" / §"read-image" / §"read-text").
+/// </summary>
+public class EmbeddedMediaDocumentTests : IDisposable
+{
+    private readonly string _dir = Directory.CreateTempSubdirectory("broiler-embedded-doc").FullName;
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private string WriteFile(string name, byte[] bytes)
+    {
+        var path = Path.Combine(_dir, name);
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    private string PageWithFrame(string resourceName) => $@"<!DOCTYPE html>
+<body style=""margin:0"">
+  <iframe src=""{resourceName}"" style=""width:200px;height:200px;border:0"" frameborder=""0""></iframe>
+</body>";
+
+    private BBitmap RenderPageWithFrame(string resourceName) =>
+        HtmlRender.RenderToImageWithStyleSet(
+            PageWithFrame(resourceName), 200, 200,
+            baseUrl: new Uri(Path.Combine(_dir, "page.html")).AbsoluteUri);
+
+    /// <summary>
+    /// The bytes that produced the crash: the 4118-byte offset of WPT's
+    /// <c>media/A4.webm</c>, where <c>&lt;N&#x5;4</c> starts a tag name the HTML
+    /// tokeniser accepts and that ends in a colon.
+    /// </summary>
+    private static byte[] MediaBytesThatTokeniseAsATag() =>
+        [0x1A, 0x45, 0xDF, 0xA3, .. "<N4"u8, 0xEB, 0xCD, 0x93, (byte)':', 0x2F, 0xF8, 0x41, 0x98];
+
+    [Fact]
+    public void Frame_To_A_Media_Resource_Does_Not_Parse_Its_Bytes_As_Markup()
+    {
+        WriteFile("A4.webm", MediaBytesThatTokeniseAsATag());
+
+        // The crash was a throw out of the render, so completing at all is the assertion.
+        using var bitmap = RenderPageWithFrame("A4.webm");
+
+        // A media document paints its own black canvas rather than the host page's white.
+        var pixel = bitmap.GetPixel(100, 100);
+        Assert.True(pixel.R <= 40 && pixel.G <= 40 && pixel.B <= 40,
+            $"Expected the media document's black canvas but got ({pixel.R},{pixel.G},{pixel.B}).");
+    }
+
+    [Fact]
+    public void Frame_To_An_Opaque_Resource_Paints_Nothing()
+    {
+        // A PDF has no synthesised document here: the frame stays empty rather
+        // than showing the file's bytes as text.
+        WriteFile("doc.pdf", [.. "%PDF-1.7\n<pdf::obj junk"u8, 0x00, 0x01, 0x02]);
+
+        using var bitmap = RenderPageWithFrame("doc.pdf");
+
+        var pixel = bitmap.GetPixel(100, 100);
+        Assert.True(pixel.R >= 245 && pixel.G >= 245 && pixel.B >= 245,
+            $"Expected an empty frame but got ({pixel.R},{pixel.G},{pixel.B}).");
+    }
+
+    [Fact]
+    public void Frame_To_An_Extensionless_Binary_Resource_Does_Not_Parse_Its_Bytes_As_Markup()
+    {
+        // Nothing in the name says binary, so the bytes decide: a NUL byte and an
+        // invalid UTF-8 sequence both keep the resource out of the HTML parser.
+        WriteFile("resource", [.. "<x::y"u8, 0x00, 0xEB, 0xCD, 0x93]);
+
+        using var bitmap = RenderPageWithFrame("resource");
+
+        var pixel = bitmap.GetPixel(100, 100);
+        Assert.True(pixel.R >= 245 && pixel.G >= 245 && pixel.B >= 245,
+            $"Expected an empty frame but got ({pixel.R},{pixel.G},{pixel.B}).");
+    }
+
+    [Fact]
+    public void Frame_To_An_Extensionless_Text_Resource_Is_Still_Parsed_As_Markup()
+    {
+        // The common case the sniff must not break: an extensionless HTML resource
+        // (WPT serves plenty) is still the frame's document.
+        WriteFile("resource", "<body style='margin:0;background:red'>"u8.ToArray());
+
+        using var bitmap = RenderPageWithFrame("resource");
+
+        var pixel = bitmap.GetPixel(100, 100);
+        Assert.True(pixel.R >= 200 && pixel.G <= 40 && pixel.B <= 40,
+            $"Expected the frame's red document to paint but got ({pixel.R},{pixel.G},{pixel.B}).");
+    }
+
+    [Fact]
+    public void Frame_To_A_Plain_Text_Resource_Presents_The_Text()
+    {
+        WriteFile("notes.txt", "hello <not-a-tag>"u8.ToArray());
+
+        using var bitmap = RenderPageWithFrame("notes.txt");
+
+        // The text document paints glyphs on the default white canvas: some pixel
+        // in the first text line must be dark.
+        bool painted = false;
+        for (int y = 0; y < 40 && !painted; y++)
+            for (int x = 0; x < 200 && !painted; x++)
+            {
+                var p = bitmap.GetPixel(x, y);
+                painted = p.R < 128 && p.G < 128 && p.B < 128;
+            }
+
+        Assert.True(painted, "Expected the plain-text document's text to paint in the frame.");
+    }
+}


### PR DESCRIPTION
## Summary

Frames navigating to non-HTML resources (media files, images, plain text) no longer parse those bytes as markup. Instead, the renderer synthesizes appropriate HTML documents that present the resource, matching the UA behavior specified in HTML §"read-media", §"read-image", and §"read-text".

This fixes WPT issue #1491 problem 1 (`navigation-timing/dom-interactive-media-document.html`), where a WebM file's bytes were fed to the HTML parser, producing tag names like `<n\x054͓:>` that crashed `DomDocument.CreateElement` with "is not a valid qualified name". The crash is now prevented at two layers:

1. **Main repo (FragmentTreeBuilder):** Classify embedded resources by file extension and sniff binary content. Only HTML resources and extensionless text files are parsed as markup; media, images, and opaque resources (PDF, fonts, archives) get synthesized documents or remain empty.

2. **Submodule patch (Broiler.DOM):** `DomDocument.CreateElement` now routes through a non-splitting `DomName.CreateLocal` constructor that accepts colons as ordinary characters, matching the DOM spec. The namespace-aware constructor (with prefix splitting and validation) is reserved for `createElementNS`.

## Key Changes

- **`FragmentTreeBuilder.BuildEmbeddedDocumentMarkup`** (new): Classifies resources and synthesizes documents:
  - HTML: parsed as-is
  - Images: wrapped in `<img src="…">` on a transparent canvas
  - Media (audio/video): wrapped in `<video controls src="…">` on a black canvas
  - Plain text (.txt, .csv, .md, .js, .json, etc.): wrapped in `<pre>` with XML escaping
  - Opaque (PDF, fonts, archives): no document (frame stays empty)
  - Extensionless: sniffed for NUL bytes and invalid UTF-8 to distinguish text from binary

- **`EmbeddedResourceKind` enum** (new): Classifies resources by extension with fallback binary sniffing

- **`LooksBinary` method** (new): Checks the first 1 KiB for NUL bytes or invalid UTF-8 sequences to keep binary out of the HTML parser when the filename provides no signal

- **`AttributeEscaped` and `BuildPlainTextDocument` helpers** (new): Escape synthesized document content safely

- **Submodule patch `0035-dom-create-element-local-name-colon.patch`**: Adds `DomName.CreateLocal(namespaceUri, localName)` that keeps the entire name verbatim (no prefix splitting), and routes `DomDocument.CreateElement` through it. `createElementNS` retains the namespace-aware constructor with validation.

- **`patches/README.md`** (new): Documents the pending submodule patch and its application workflow

- **`EmbeddedMediaDocumentTests`** (new): Regression tests covering media, opaque, binary, and text resources in frames

- **`docs/wpt-rendering-gaps.md`** (new): Comprehensive analysis of the 27 worst-scoring WPT pixel mismatches (0.0–2.5% match), with owner, evidence, next actions, and exit gates for each. Includes reproduction instructions and a summary table.

- **`docs/ROADMAP.md`** (updated): References the rendering gaps document and adds memory-cost analysis of the JS wrapper per-element allocation (~550 KiB per created element)

- **`docs/README.md`** (updated): Links to the new rendering gaps document

## Implementation Details

- Resource classification is extension-based (case-insensitive) with a fallback to binary sniffing for extensionless files. The sniff reads up to 1 KiB and checks for NUL bytes (impossible in text) and invalid UTF-8 sequences (characteristic of binary).

- Synthesized documents use minimal inline styles to avoid stylesheet dependencies and preserve the resource's natural presentation (transparent canvas for images, black for media, white for text).

- The patch to `Broiler.DOM` is captured in

https://claude.ai/code/session_01ABJRUGNKrmKXuYRAdugmfU