### PR TITLE
DOM wrapper functions: disable prototype creation, add declarative shadow DOM

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
@@ -39,6 +39,66 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
     private bool IsFlexContainer() => Display is "flex" or "inline-flex";
 
+    /// <summary>
+    /// CSS Flexbox §5.4 / CSS Display §3: reorders this container's children into <em>order-modified
+    /// document order</em> — ascending <c>order</c>, document order preserved within an ordinal group.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Done by sorting <see cref="CssBoxProperties.Boxes"/> in place rather than inside one layout
+    /// algorithm, because the children reach the page by several routes: a row flex container walks
+    /// this list itself, a column one falls through to ordinary block/inline flow over the same list
+    /// (the line-break-per-item path in <c>CssLayoutEngine</c>), and painting walks it too. `order`
+    /// is defined to affect layout *and* paint order, so moving the boxes once serves all three.
+    /// </para>
+    /// <para>
+    /// The sort is stable, so equal <c>order</c> keeps document order, and it is idempotent: a list
+    /// already in order-modified order re-sorts to itself, which matters because layout runs more
+    /// than once per render. Boxes whose <c>order</c> is absent or not an integer count as 0, the
+    /// initial value.
+    /// </para>
+    /// </remarks>
+    private void ApplyOrderModifiedDocumentOrder()
+    {
+        if (Boxes.Count < 2)
+            return;
+
+        var orders = new int[Boxes.Count];
+        var reordered = false;
+        for (var index = 0; index < Boxes.Count; index++)
+        {
+            orders[index] = ParseOrder(Boxes[index].Order);
+            if (index > 0 && orders[index] < orders[index - 1])
+                reordered = true;
+        }
+
+        if (!reordered)
+            return;
+
+        // List<T>.Sort is unstable, so pair each box with its document index and break ties on it.
+        var sorted = new List<CssBox>(Boxes.Count);
+        var indices = new List<int>(Boxes.Count);
+        for (var index = 0; index < Boxes.Count; index++)
+            indices.Add(index);
+
+        indices.Sort((left, right) =>
+        {
+            var byOrder = orders[left].CompareTo(orders[right]);
+            return byOrder != 0 ? byOrder : left.CompareTo(right);
+        });
+
+        foreach (var index in indices)
+            sorted.Add(Boxes[index]);
+
+        Boxes.Clear();
+        Boxes.AddRange(sorted);
+    }
+
+    private static int ParseOrder(string? value) =>
+        int.TryParse((value ?? string.Empty).Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var order)
+            ? order
+            : 0;
+
     internal bool IsRowFlexContainer()
     {
         if (!IsFlexContainer())

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
@@ -1097,6 +1097,8 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 {
                     TextAlign = CssConstants.Right;
                 }
+
+                ApplyOrderModifiedDocumentOrder();
             }
 
             if (IsRowFlexContainer())

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -999,6 +999,14 @@ internal abstract partial class CssBoxProperties
     public string FlexBasis { get; set; } = "auto";
     public string FlexWrap { get; set; } = "nowrap";
 
+    /// <summary>
+    /// CSS Display §3 / Flexbox §5.4 <c>order</c>: an integer (initial <c>0</c>) that places a flex
+    /// or grid item into an ordinal group. Items are laid out and painted in <em>order-modified
+    /// document order</em> — ascending <c>order</c>, document order within a group — rather than
+    /// plain document order.
+    /// </summary>
+    public string Order { get; set; } = "0";
+
     // CSS Box Alignment §8: the initial value of justify-content is 'normal',
     // not 'flex-start'. In a flex container 'normal' behaves as 'flex-start'
     // (packed at the main-start edge), so flex layout is unchanged; in a grid
@@ -2536,6 +2544,7 @@ internal abstract partial class CssBoxProperties
         FlexShrink = p.FlexShrink;
         FlexBasis = p.FlexBasis;
         FlexWrap = p.FlexWrap;
+        Order = p.Order;
         JustifyContent = p.JustifyContent;
         JustifyItems = p.JustifyItems;
         AlignItems = p.AlignItems;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -47,6 +47,7 @@ internal static partial class CssUtils
             "flex-shrink" => cssBox.FlexShrink,
             "flex-basis" => cssBox.FlexBasis,
             "flex-wrap" => cssBox.FlexWrap,
+            "order" => cssBox.Order,
             "justify-content" => cssBox.JustifyContent,
             "justify-items" => cssBox.JustifyItems,
             "align-items" => cssBox.AlignItems,
@@ -284,6 +285,9 @@ internal static partial class CssUtils
                 break;
             case "flex-wrap":
                 cssBox.FlexWrap = value;
+                break;
+            case "order":
+                cssBox.Order = value;
                 break;
             case "justify-content":
                 cssBox.JustifyContent = value;

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -184,23 +184,45 @@ Four caveats, all learned the hard way:
      computed style, so it re-asserted `visibility: visible` (the initial value
      nearly everything has) *over* the pair's inherited `hidden`. Only a
      non-initial `visibility` is carried now.
-- **What did *not* work, and why it is worth knowing.** The remaining gap is that
-  the root capture carries only a background colour, no content, so
-  `::view-transition-old(root)` is transparent and the author backdrop shows
-  through the page. Reproducing the page by **cloning the DOM** into the snapshot
-  box was implemented, measured, and reverted. It did fix problems 19, 21 and 23
-  outright (0.0% → 100%), but across the 458 local `css-view-transitions` tests it
-  was **+8 passing / −7 passing** — and it cost 79 pixel points on
-  `root-to-shared-animation-end` (82.7% → 3.1%) and ~4 on
-  `content-with-transform-old-/new-image`. Restricting the clone to the *old*
-  snapshot did not rescue those. The reason is structural, not a missing detail: a
-  DOM clone re-lays-out and is only *close*, while the transparent box let the
-  **live page** show through — and the live page is pixel-exact. Anywhere the old
-  root snapshot is genuinely visible, exact beats close. **A root capture needs a
-  rasterised snapshot from the renderer, which is a `Broiler.HTML` capability, not
-  something the bridge can synthesise from the DOM.** That is what the original
-  "capture the old and new snapshots as images" next action asked for, and it
-  still stands.
+- **What did *not* work, and why it is worth knowing.** The root capture used to
+  carry only a background colour, no content, so `::view-transition-old(root)` was
+  transparent and the author backdrop showed through the page. Reproducing the
+  page by **cloning the DOM** into the snapshot box was implemented, measured, and
+  reverted. It did fix problems 19, 21 and 23 outright (0.0% → 100%), but across
+  the 458 local `css-view-transitions` tests it was **+8 passing / −7 passing** —
+  and it cost 79 pixel points on `root-to-shared-animation-end` (82.7% → 3.1%) and
+  ~4 on `content-with-transform-old-/new-image`. Restricting the clone to the
+  *old* snapshot did not rescue those. The reason is structural, not a missing
+  detail: a DOM clone re-lays-out and is only *close*, while the transparent box
+  let the **live page** show through — and the live page is pixel-exact. Anywhere
+  the old root snapshot is genuinely visible, exact beats close.
+- **What did work: gate the clone on whether the page can show through at all.**
+  The two cases are distinguishable without a rasteriser. The live page can only
+  stand in for the snapshot while nothing paints between them; once the author
+  gives the bare `::view-transition` a background, that backdrop hides the page
+  and a content-less snapshot has nothing left to fall back on — which is exactly
+  when the viewport comes out a flat wash of the backdrop colour. So the root
+  snapshot now clones **only when `::view-transition` paints a background**
+  (`RootOverlayOccludesPage`), and every test that leaves the overlay transparent
+  keeps the untouched, pixel-exact live-page path. That is why this does not
+  reintroduce the −7: `root-to-shared-animation-end` and
+  `content-with-transform-old-/new-image` set no `::view-transition` background,
+  so the gate is false for them. It closes issue #1500 problems 13, 15 and 17
+  (`new-content-captures-root`, `old-content-captures-root`,
+  `root-captured-as-different-tag`), all three of which had rendered as a flat
+  pink page. Two details the clone needs to be worth anything: it must skip
+  `<head>`/`<style>`/`<script>`/`<link>` (re-inserting them duplicates author
+  rules into the document and re-fetches resources) and it must **keep `id`
+  attributes**, which the per-element snapshot path strips — a whole page of
+  id-styled content otherwise reproduces as unstyled boxes. Keeping them is safe
+  because the pseudo tree is materialised on a fresh render projection, so the
+  duplicate ids never reach the tree page script observes.
+- **Still open where the overlay is transparent.** The gated clone says nothing
+  about the cases the live page already covers, and it is still a clone: **a root
+  capture that is exact in both cases needs a rasterised snapshot from the
+  renderer, which is a `Broiler.HTML` capability, not something the bridge can
+  synthesise from the DOM.** That is what the original "capture the old and new
+  snapshots as images" next action asked for, and it still stands.
 - **A trap the attempt uncovered, worth keeping for whoever does the raster
   version.** The overlay serializes after `</body>` and the HTML parser
   foster-parents it back *inside* `<body>`, so a rule anchored on an ancestor

--- a/src/Broiler.Cli.Tests/ApiBaselines/Broiler.HtmlBridge.Core.PublicApi.txt
+++ b/src/Broiler.Cli.Tests/ApiBaselines/Broiler.HtmlBridge.Core.PublicApi.txt
@@ -69,6 +69,14 @@ TYPE Broiler.HtmlBridge.Scripting.MicroTaskQueue
   method System.Collections.Generic.IReadOnlyList<System.Exception> Drain()
   method System.Void Enqueue(System.Action)
   property System.Int32 Count { get; }
+TYPE Broiler.HtmlBridge.Scripting.MicroTaskSynchronizationContext : System.Threading.SynchronizationContext
+  ctor (Broiler.HtmlBridge.Scripting.MicroTaskQueue)
+  method Broiler.HtmlBridge.Scripting.MicroTaskSynchronizationContext+Scope Install(Broiler.HtmlBridge.Scripting.MicroTaskQueue)
+  method System.Threading.SynchronizationContext CreateCopy()
+  method System.Void Post(System.Threading.SendOrPostCallback, System.Object)
+  method System.Void Send(System.Threading.SendOrPostCallback, System.Object)
+TYPE Broiler.HtmlBridge.Scripting.MicroTaskSynchronizationContext+Scope : System.IDisposable
+  method System.Void Dispose()
 TYPE Broiler.HtmlBridge.Scripting.ModuleMap
   ctor ()
   method System.Boolean TryGet(System.String, ref Broiler.HtmlBridge.Scripting.ModuleMapEntry)

--- a/src/Broiler.Cli.Tests/AsyncContinuationThreadingTests.cs
+++ b/src/Broiler.Cli.Tests/AsyncContinuationThreadingTests.cs
@@ -1,0 +1,117 @@
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// JavaScript is single-threaded, so a promise reaction must run on the thread driving the page, at
+/// a microtask checkpoint — not on the thread pool, concurrently with it.
+/// <para>
+/// The engine picks a reaction's target with
+/// <c>SynchronizationContext.Current ?? context.synchronizationContext</c> and falls back to
+/// <c>ThreadPool.QueueUserWorkItem</c>. Nothing installed a queueing context, so <c>await</c>
+/// continuations resumed on pool threads and raced the host's serialize/render. Cheap continuations
+/// usually won the race and looked fine; an expensive one lost it. A geometry query — a full layout —
+/// lost reliably, so <c>await something; el.getBoundingClientRect()</c> appeared to truncate the rest
+/// of the function silently: no exception, no rejection, not even a <c>finally</c>, because the
+/// continuation was still running elsewhere when the page was read.
+/// </para>
+/// </summary>
+public class AsyncContinuationThreadingTests
+{
+    private static string Exec(string script)
+    {
+        var html = $@"<!doctype html>
+<html><head><title>Test</title></head>
+<body>
+<div id=""tall"" style=""width:10px;height:2000px""></div>
+<div id=""result""></div>
+<script>
+{script}
+</script>
+</body>
+</html>";
+        return CaptureService.ExecuteScriptsWithDom(html, "https://example.com");
+    }
+
+    [Fact]
+    public void A_Geometry_Query_After_Await_Completes_Before_The_Page_Is_Read()
+    {
+        var result = Exec("""
+            var log = [];
+            async function run() {
+              log.push('before');
+              await Promise.resolve();
+              log.push('after');
+              log.push('h=' + document.documentElement.scrollHeight);
+              log.push('end');
+            }
+            run().then(function(){ log.push('resolved'); document.getElementById('result').textContent = log.join('|'); });
+        """);
+
+        Assert.Contains("before|after|", result);
+        Assert.Contains("|end|resolved", result);
+        Assert.DoesNotContain("h=0|", result);
+    }
+
+    [Fact]
+    public void The_Rest_Of_An_Async_Function_Runs_After_A_Geometry_Query()
+    {
+        // The specific shape that broke: the statements after the measurement, and the try/finally
+        // around it, must all run.
+        var result = Exec("""
+            var log = [];
+            async function run() {
+              await Promise.resolve();
+              try { document.getElementById('tall').getBoundingClientRect(); log.push('measured'); }
+              finally { log.push('finally'); }
+              log.push('tail');
+              document.getElementById('result').textContent = log.join('|');
+            }
+            run();
+        """);
+
+        Assert.Contains("measured|finally|tail", result);
+    }
+
+    [Fact]
+    public void Await_Continuations_Keep_Microtask_Ordering()
+    {
+        // Running reactions as microtasks on the driving thread — rather than whenever a pool thread
+        // happens to get to them — also makes their ordering deterministic.
+        var result = Exec("""
+            var log = [];
+            (async function(){ log.push('a1'); await Promise.resolve(); log.push('a2'); })();
+            Promise.resolve().then(function(){ log.push('p1'); });
+            log.push('sync');
+            setTimeout(function(){
+              log.push('timeout');
+              document.getElementById('result').textContent = log.join('|');
+            }, 0);
+        """);
+
+        // The synchronous body runs to completion first, then both microtasks, then the timer task.
+        // The relative order of the two microtasks is an engine tick detail and deliberately not
+        // pinned; that they both land in the microtask phase — rather than whenever a pool thread
+        // reaches them — is the point.
+        Assert.Matches(@"a1\|sync\|(a2\|p1|p1\|a2)\|timeout", result);
+    }
+
+    [Fact]
+    public void A_Scroll_Awaited_Through_Its_Event_Is_Observed()
+    {
+        // The pattern the WPT scroll tests use: set a scroll offset, await the resulting event, then
+        // measure. Every step has to land before the page is read.
+        var result = Exec("""
+            var log = [];
+            async function run() {
+              await new Promise(function(resolve){
+                addEventListener('scroll', function(){ log.push('scrolled'); resolve(); }, { once: true });
+                document.documentElement.scrollTop = 400;
+              });
+              log.push('top=' + document.documentElement.scrollTop);
+              document.getElementById('result').textContent = log.join('|');
+            }
+            run();
+        """);
+
+        Assert.Contains("scrolled|top=400", result);
+    }
+}

--- a/src/Broiler.Cli.Tests/DeclarativeShadowDomTests.cs
+++ b/src/Broiler.Cli.Tests/DeclarativeShadowDomTests.cs
@@ -1,0 +1,156 @@
+using Broiler.HtmlBridge;
+using Broiler.HTML.Image;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Declarative shadow DOM (HTML §4.12.3) and the one selector allowed to style into it.
+/// <para>
+/// <c>attachShadow()</c> content already rendered; <c>&lt;template shadowrootmode&gt;</c> did not,
+/// because the template was never turned into a shadow root — everything downstream of that (styling
+/// the tree, flattening it for the renderer, capturing it in a view transition) was already in
+/// place. And a document-level <c>::part()</c> rule painted correctly yet was invisible to computed
+/// style, because a shadow tree's style scope holds only its own sheets. Both cost WPT
+/// <c>css/css-view-transitions/auto-name-from-id-shadow</c> (issue #1500 problem 9) its second item.
+/// </para>
+/// </summary>
+public class DeclarativeShadowDomTests
+{
+    // Through the bridge, which is where a declarative shadow root is materialised, then rendered
+    // from the serialized (shadow-flattened) document the renderer actually consumes.
+    private static BBitmap Render(string html)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///test.html");
+        return HtmlRender.RenderToImageWithStyleSet(bridge.SerializeToHtml(), 300, 300);
+    }
+
+    private static string Eval(string html, string script)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///test.html");
+        context.Eval(script);
+        return bridge.SerializeToHtml();
+    }
+
+    private static void AssertPixel(BBitmap bitmap, int x, int y, byte r, byte g, byte b, string what)
+    {
+        var actual = bitmap.GetPixel(x, y);
+        Assert.True(
+            actual.R == r && actual.G == g && actual.B == b,
+            $"{what} at ({x},{y}) was {actual.R},{actual.G},{actual.B}, expected {r},{g},{b}");
+    }
+
+    [Fact]
+    public void Declarative_Shadow_Root_Content_Renders()
+    {
+        const string html = """
+<!DOCTYPE html>
+<html>
+<style> body { margin: 0; } .box { width: 100px; height: 50px; background: red; } </style>
+<div id="host"><template shadowrootmode="open"><div class="box"></div></template></div>
+</html>
+""";
+        using var bitmap = Render(html);
+        AssertPixel(bitmap, 50, 25, 255, 0, 0, "the declarative shadow tree's content");
+    }
+
+    [Fact]
+    public void Declarative_Shadow_Root_Is_A_Real_Shadow_Root()
+    {
+        // The template becomes a shadow root on its parent and is itself gone from the tree —
+        // observable through the same `shadowRoot` property attachShadow() populates.
+        var html = Eval("""
+<!DOCTYPE html>
+<html><div id="host"><template shadowrootmode="open"><span id="inner">hi</span></template></div>
+<div id="out"></div></html>
+""", """
+var host = document.getElementById('host');
+var root = host.shadowRoot;
+document.getElementById('out').textContent =
+  'root=' + (root ? 'yes' : 'no') +
+  ' inner=' + (root && root.querySelector('#inner') ? 'yes' : 'no') +
+  ' templates=' + document.getElementsByTagName('template').length;
+""");
+
+        Assert.Contains("root=yes", html);
+        Assert.Contains("inner=yes", html);
+        Assert.Contains("templates=0", html);
+    }
+
+    [Fact]
+    public void A_Closed_Declarative_Root_Still_Renders_But_Is_Not_Exposed()
+    {
+        var html = Eval("""
+<!DOCTYPE html>
+<html><div id="host"><template shadowrootmode="closed"><span>hi</span></template></div>
+<div id="out"></div></html>
+""", "document.getElementById('out').textContent = 'root=' + (document.getElementById('host').shadowRoot ? 'yes' : 'no');");
+
+        Assert.Contains("root=no", html);
+    }
+
+    [Fact]
+    public void A_Template_Without_Shadowrootmode_Stays_An_Inert_Template()
+    {
+        // Ordinary <template> content must keep generating no boxes.
+        const string html = """
+<!DOCTYPE html>
+<html>
+<style> body { margin: 0; } .box { width: 100px; height: 50px; background: red; } </style>
+<div id="host"><template><div class="box"></div></template></div>
+</html>
+""";
+        using var bitmap = Render(html);
+        AssertPixel(bitmap, 50, 25, 255, 255, 255, "nothing — a plain template does not render");
+    }
+
+    [Fact]
+    public void Outer_Part_Rules_Reach_Into_The_Shadow_Tree()
+    {
+        // ::part() is the sanctioned way for the outer tree to style a shadow tree's exposed
+        // elements. It has to reach both the renderer (pixels) and computed style — the latter is
+        // what a view transition reads to find `view-transition-name`.
+        const string html = """
+<!DOCTYPE html>
+<html>
+<style>
+  body { margin: 0; }
+  ::part(swatch) { width: 100px; height: 50px; background: lime; }
+</style>
+<div id="host"><template shadowrootmode="open"><div part="swatch"></div></template></div>
+</html>
+""";
+        using var bitmap = Render(html);
+        AssertPixel(bitmap, 50, 25, 0, 255, 0, "the part styled from the outer document");
+
+        var serialized = Eval(html + "<div id=\"out\"></div>", """
+var part = document.getElementById('host').shadowRoot.querySelector('[part]');
+document.getElementById('out').textContent = 'w=' + getComputedStyle(part).getPropertyValue('width');
+""");
+        Assert.Contains("w=100px", serialized);
+    }
+
+    [Fact]
+    public void An_Unexposed_Shadow_Element_Is_Not_Reachable_By_Part()
+    {
+        // Encapsulation still holds for everything the shadow tree does not expose: an outer rule
+        // must not style a shadow element that carries no matching part.
+        const string html = """
+<!DOCTYPE html>
+<html>
+<style>
+  body { margin: 0; }
+  ::part(swatch) { width: 100px; height: 50px; background: lime; }
+  div { width: 100px; height: 50px; }
+</style>
+<div id="host"><template shadowrootmode="open"><div part="other"></div></template></div>
+</html>
+""";
+        using var bitmap = Render(html);
+        AssertPixel(bitmap, 50, 25, 255, 255, 255, "nothing — the part name does not match");
+    }
+}

--- a/src/Broiler.Cli.Tests/DomWrapperFunctionTests.cs
+++ b/src/Broiler.Cli.Tests/DomWrapperFunctionTests.cs
@@ -1,0 +1,150 @@
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// A node's JS wrapper is built eagerly and per node — an element gets ~149 own members, each a
+/// native callable. Those callables are WebIDL operations and attribute accessors, so per
+/// <see href="https://webidl.spec.whatwg.org/#es-operations">WebIDL</see> they are ordinary
+/// functions: not constructors, and carrying no <c>prototype</c> property. The bridge used to mint
+/// them with <c>JSFunction</c>'s default <c>createPrototype: true</c>, which both diverged from the
+/// spec and allocated a second throwaway <see cref="Broiler.JavaScript.Runtime.JSObject"/> (plus its
+/// <c>constructor</c> back-reference) for every member of every node.
+///
+/// That was the top-ranked problem of the 2026-07-31 WPT run: <c>css/css-variables/url-syntax-crash.html</c>
+/// appends 10,000 spans and was aborted for exceeding the 4096 MiB per-test memory limit. The cost
+/// was never about <c>var()</c> or <c>@property</c> — 2,000 spans parsed from static markup are
+/// free, while 2,000 bare <c>document.createElement("span")</c> calls (never inserted) cost ~0.5 MiB
+/// each.
+/// </summary>
+public class DomWrapperFunctionTests
+{
+    private static string ExecJs(string jsCode)
+    {
+        var html = $@"<!doctype html>
+<html><head><title>Test</title></head>
+<body>
+<div id=""result""></div>
+<script>
+{jsCode}
+</script>
+</body>
+</html>";
+        return CaptureService.ExecuteScriptsWithDom(html, "https://example.com");
+    }
+
+    [Fact]
+    public void Dom_Operations_Are_Not_Constructors_And_Have_No_Prototype()
+    {
+        var result = ExecJs(@"
+            var el = document.createElement('span');
+            var out = [];
+            out.push('proto:' + typeof el.setAttribute.prototype);
+            out.push('appendProto:' + typeof el.appendChild.prototype);
+            var threw = false;
+            try { new el.setAttribute(); } catch (e) { threw = true; }
+            out.push('newThrows:' + threw);
+            document.getElementById('result').textContent = out.join(',');
+        ");
+
+        Assert.Contains("proto:undefined", result);
+        Assert.Contains("appendProto:undefined", result);
+        Assert.Contains("newThrows:true", result);
+    }
+
+    [Fact]
+    public void Dom_Operations_And_Accessors_Still_Work()
+    {
+        // The prototype is the only thing that goes away — calling and property access are unchanged.
+        var result = ExecJs(@"
+            var el = document.createElement('span');
+            el.setAttribute('data-x', '1');
+            el.id = 'abc';
+            el.className = 'c1';
+            el.classList.add('c2');
+            el.style.color = 'red';
+            el.appendChild(document.createTextNode('hi'));
+            document.getElementById('result').textContent = [
+                el.getAttribute('data-x'), el.id, el.className,
+                el.style.color, el.textContent, el.childNodes.length
+            ].join('|');
+        ");
+
+        Assert.Contains("1|abc|c1 c2|red|hi|1", result);
+    }
+
+    [Fact]
+    public void Interface_Objects_Remain_Constructable()
+    {
+        // `createPrototype: false` also makes a function non-constructable
+        // (JSConstructorOperations.IsConstructor tests `prototype != null || IsConstructable`), so
+        // the interface objects JS may legitimately `new` must keep the default JSFunction.
+        var result = ExecJs(@"
+            var out = [];
+            out.push('url:' + new URL('https://a.example/b').pathname);
+            out.push('urlProto:' + typeof URL.prototype);
+            out.push('headers:' + (new Headers() instanceof Headers));
+            out.push('formData:' + typeof new FormData());
+            document.getElementById('result').textContent = out.join(',');
+        ");
+
+        Assert.Contains("url:/b", result);
+        Assert.Contains("urlProto:object", result);
+        Assert.Contains("headers:true", result);
+        Assert.Contains("formData:object", result);
+    }
+
+    /// <summary>
+    /// Source guard: wrapper members must be minted through <c>DomFunction</c>. Only the files that
+    /// register interface objects (which JS constructs with <c>new</c>) may use <c>JSFunction</c>
+    /// directly. Without this, a new binding added the obvious way silently reintroduces a
+    /// per-member prototype allocation on every node.
+    /// </summary>
+    [Fact]
+    public void Bridge_Mints_Wrapper_Members_Through_DomFunction()
+    {
+        // These register interface objects — URL, Response, Request, Headers, FormData,
+        // MessageChannel, CSSStyleSheet — which must stay constructable.
+        var interfaceObjectFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Document.cs",
+            "Registration.cs",
+            "FetchBinding.cs",
+        };
+
+        var bridgeRoot = Path.Combine(FindRepositoryRoot(), "src", "Broiler.HtmlBridge.Dom");
+        Assert.True(Directory.Exists(bridgeRoot), $"Bridge source not found at {bridgeRoot}");
+
+        var offenders = Directory
+            .EnumerateFiles(bridgeRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => !interfaceObjectFiles.Contains(Path.GetFileName(path)))
+            .Where(path => File.ReadAllText(path).Contains("new JSFunction(", StringComparison.Ordinal))
+            .Select(path => Path.GetRelativePath(bridgeRoot, path))
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            offenders.Length == 0,
+            "These bridge files mint wrapper members with `new JSFunction(`, which allocates a " +
+            "throwaway prototype object per member per node. Use `new DomFunction(` instead — or, " +
+            "if the file genuinely registers a constructable interface object, add it to " +
+            $"interfaceObjectFiles above:{Environment.NewLine}  " +
+            string.Join($"{Environment.NewLine}  ", offenders));
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, ".gitmodules")) &&
+                File.Exists(Path.Combine(directory.FullName, "Directory.Build.props")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate repository root containing .gitmodules and Directory.Build.props.");
+    }
+}

--- a/src/Broiler.Cli.Tests/FlexOrderTests.cs
+++ b/src/Broiler.Cli.Tests/FlexOrderTests.cs
@@ -1,0 +1,116 @@
+using Broiler.HTML.Image;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// CSS Flexbox §5.4 / CSS Display §3 <c>order</c>: flex items are laid out and painted in
+/// order-modified document order — ascending <c>order</c>, document order within an ordinal group.
+/// The property was previously unknown to the engine entirely, so `order` was inert and items always
+/// stayed in document order.
+/// </summary>
+public class FlexOrderTests
+{
+    private static BBitmap Render(string html) =>
+        HtmlRender.RenderToImageWithStyleSet(html, 300, 300);
+
+    private static void AssertPixel(BBitmap bitmap, int x, int y, byte r, byte g, byte b, string what)
+    {
+        var actual = bitmap.GetPixel(x, y);
+        Assert.True(
+            actual.R == r && actual.G == g && actual.B == b,
+            $"{what} at ({x},{y}) was {actual.R},{actual.G},{actual.B}, expected {r},{g},{b}");
+    }
+
+    private const string ColumnHtml = """
+<!DOCTYPE html>
+<html>
+<style>
+  body { margin: 0; }
+  main { display: flex; flex-direction: column; }
+  div { width: 100px; height: 50px; }
+  #first { background: red; order: 2; }
+  #second { background: blue; }
+</style>
+<main><div id="first"></div><div id="second"></div></main>
+</html>
+""";
+
+    private const string RowHtml = """
+<!DOCTYPE html>
+<html>
+<style>
+  body { margin: 0; }
+  main { display: flex; flex-direction: row; }
+  div { width: 100px; height: 50px; }
+  #first { background: red; order: 2; }
+  #second { background: blue; }
+</style>
+<main><div id="first"></div><div id="second"></div></main>
+</html>
+""";
+
+    [Fact]
+    public void Order_Reorders_Column_Flex_Items()
+    {
+        using var bitmap = Render(ColumnHtml);
+
+        // `first` comes first in the document but carries order:2, so it lays out below `second`.
+        AssertPixel(bitmap, 50, 25, 0, 0, 255, "the order:0 item on the first row");
+        AssertPixel(bitmap, 50, 75, 255, 0, 0, "the order:2 item on the second row");
+    }
+
+    [Fact]
+    public void Order_Reorders_Row_Flex_Items()
+    {
+        using var bitmap = Render(RowHtml);
+
+        AssertPixel(bitmap, 50, 25, 0, 0, 255, "the order:0 item in the first column");
+        AssertPixel(bitmap, 150, 25, 255, 0, 0, "the order:2 item in the second column");
+    }
+
+    [Fact]
+    public void Equal_Order_Keeps_Document_Order()
+    {
+        // The reorder must be stable: an ordinal group holds its document order, and a container
+        // where every item shares the initial `order` is untouched.
+        const string html = """
+<!DOCTYPE html>
+<html>
+<style>
+  body { margin: 0; }
+  main { display: flex; flex-direction: column; }
+  div { width: 100px; height: 50px; }
+  #first { background: red; }
+  #second { background: blue; }
+</style>
+<main><div id="first"></div><div id="second"></div></main>
+</html>
+""";
+        using var bitmap = Render(html);
+
+        AssertPixel(bitmap, 50, 25, 255, 0, 0, "the first item in document order");
+        AssertPixel(bitmap, 50, 75, 0, 0, 255, "the second item in document order");
+    }
+
+    [Fact]
+    public void Order_Is_Ignored_Outside_A_Flex_Or_Grid_Container()
+    {
+        // `order` only applies to flex/grid items. In ordinary block flow it must do nothing.
+        const string html = """
+<!DOCTYPE html>
+<html>
+<style>
+  body { margin: 0; }
+  div { width: 100px; height: 50px; }
+  #first { background: red; order: 2; }
+  #second { background: blue; }
+</style>
+<main><div id="first"></div><div id="second"></div></main>
+</html>
+""";
+        using var bitmap = Render(html);
+
+        AssertPixel(bitmap, 50, 25, 255, 0, 0, "the block-flow first child, unmoved");
+        AssertPixel(bitmap, 50, 75, 0, 0, 255, "the block-flow second child, unmoved");
+    }
+}

--- a/src/Broiler.Cli.Tests/Transform3dFlatteningTests.cs
+++ b/src/Broiler.Cli.Tests/Transform3dFlatteningTests.cs
@@ -1,0 +1,96 @@
+using Broiler.HTML.Image;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// The 3D spellings of transforms that are really 2D — <c>translate3d</c>, <c>scale3d</c>,
+/// <c>rotate3d</c> about Z, a 2D <c>matrix3d</c> — were skipped as unknown functions, so an element
+/// using any of them rendered untransformed. Authors write them constantly (<c>translate3d</c> to
+/// force GPU promotion), and a WPT reference may spell in 3D exactly what its test spells in 2D:
+/// <c>css-view-transitions/content-with-transform-ref</c> uses <c>scale3d(2,3,1)</c> where the test
+/// uses <c>scale(2,3)</c>, so the reference rendered at the wrong size.
+/// <para>
+/// Genuine 3D stays unsupported on purpose — see
+/// <see cref="A_Rotation_Needing_Depth_Is_Still_Skipped"/>.
+/// </para>
+/// </summary>
+public class Transform3dFlatteningTests
+{
+    // 60x30 box at (100, 40); each case is compared against the 2D spelling it is equivalent to.
+    private static string Page(string transform) => $$"""
+<!DOCTYPE html>
+<html>
+<style>
+  body { margin: 0; }
+  #box { position: absolute; left: 100px; top: 40px; width: 60px; height: 30px;
+         background: red; transform: {{transform}}; transform-origin: 0 0; }
+</style>
+<div id="box"></div>
+</html>
+""";
+
+    private static BBitmap Render(string transform) =>
+        HtmlRender.RenderToImageWithStyleSet(Page(transform), 400, 200);
+
+    private static void AssertSameAs(string threeD, string twoD)
+    {
+        using var actual = Render(threeD);
+        using var expected = Render(twoD);
+
+        for (var y = 0; y < 200; y += 2)
+        {
+            for (var x = 0; x < 400; x += 2)
+            {
+                var a = actual.GetPixel(x, y);
+                var e = expected.GetPixel(x, y);
+                Assert.True(a.R == e.R && a.G == e.G && a.B == e.B,
+                    $"`{threeD}` differs from `{twoD}` at ({x},{y}): " +
+                    $"{a.R},{a.G},{a.B} vs {e.R},{e.G},{e.B}");
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("translate3d(50px, 20px, 0)", "translate(50px, 20px)")]
+    [InlineData("translate3d(50px, 20px, 90px)", "translate(50px, 20px)")]   // Z is inert without perspective
+    [InlineData("translateZ(90px)", "none")]
+    [InlineData("scale3d(2, 3, 1)", "scale(2, 3)")]
+    [InlineData("scale3d(2, 3, 7)", "scale(2, 3)")]
+    [InlineData("scaleZ(7)", "none")]
+    [InlineData("matrix3d(2,0,0,0, 0,3,0,0, 0,0,1,0, 40,10,0,1)", "matrix(2,0,0,3,40,10)")]
+    public void A_3D_Spelling_Renders_As_Its_2D_Equivalent(string threeD, string twoD)
+        => AssertSameAs(threeD, twoD);
+
+    [Fact]
+    public void A_Rotation_About_Z_Is_An_In_Plane_Rotation()
+    {
+        // rotate3d's axis decides: only Z rotates within the page. A negative Z reverses it, which
+        // is why the sign is taken from the axis rather than the angle alone.
+        AssertSameAs("rotate3d(0, 0, 1, 30deg)", "rotate(30deg)");
+        AssertSameAs("rotate3d(0, 0, 2, 30deg)", "rotate(30deg)");
+        AssertSameAs("rotate3d(0, 0, -1, 30deg)", "rotate(-30deg)");
+        AssertSameAs("rotateZ(30deg)", "rotate(30deg)");
+    }
+
+    [Fact]
+    public void A_Rotation_Needing_Depth_Is_Still_Skipped()
+    {
+        // Projecting each 3D function to the page plane on its own is not the same as composing in
+        // 3D and projecting once, so a `preserve-3d` chain that cancels in space would stop
+        // cancelling — WPT css-anchor-position/transform-005 rotates about an axis and then by its
+        // inverse and expects a plain square. Leaving these unsupported (as before) is the honest
+        // answer; approximating them is worse than not doing them.
+        AssertSameAs("rotate3d(1, 1, 1, 90deg)", "none");
+        AssertSameAs("rotateX(60deg)", "none");
+        AssertSameAs("rotateY(60deg)", "none");
+        AssertSameAs("rotate3d(0, 0, 0, 90deg)", "none");   // degenerate axis is a no-op per spec
+    }
+
+    [Fact]
+    public void A_Genuinely_3D_Matrix_Is_Still_Skipped()
+    {
+        // Only a matrix3d whose Z row and column are the identity is a 2D matrix.
+        AssertSameAs("matrix3d(1,0,0,0, 0,1,0,0, 0,0,1,0.002, 0,0,0,1)", "none");
+        AssertSameAs("matrix3d(1,0,0,0, 0,0,1,0, 0,1,0,0, 0,0,0,1)", "none");
+    }
+}

--- a/src/Broiler.Cli.Tests/ViewTransitionGroupAnimationTests.cs
+++ b/src/Broiler.Cli.Tests/ViewTransitionGroupAnimationTests.cs
@@ -1,0 +1,112 @@
+using Broiler.HtmlBridge;
+using Broiler.HTML.Image;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Where a <c>::view-transition-group</c> sits when the reftests freeze it, and which author rules
+/// reach it.
+/// <para>
+/// A group animates old→new geometry and the reftests screenshot it frozen at time 0. "Frozen at
+/// time 0" is not the same as "at the old geometry": the group's <c>animation-timing-function</c> is
+/// evaluated at input 0, and the <c>steps(…, jump-start)</c> family jumps before it advances, so it
+/// is already part-way to the new geometry there. WPT <c>auto-name</c> and <c>auto-name-from-id</c>
+/// (issue #1500 problems 7 and 8) pin exactly that with <c>steps(2, start)</c> — output 1/2 — and
+/// address the rule by <c>view-transition-class</c> rather than by name.
+/// </para>
+/// </summary>
+public class ViewTransitionGroupAnimationTests
+{
+    private static BBitmap Render(string html, string script)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///test.html");
+        context.Eval(script);
+        return HtmlRender.RenderToImageWithStyleSet(bridge.SerializeToHtml(), 300, 300);
+    }
+
+    private static void AssertPixel(BBitmap bitmap, int x, int y, byte r, byte g, byte b, string what)
+    {
+        var actual = bitmap.GetPixel(x, y);
+        Assert.True(
+            actual.R == r && actual.G == g && actual.B == b,
+            $"{what} at ({x},{y}) was {actual.R},{actual.G},{actual.B}, expected {r},{g},{b}");
+    }
+
+    // Mirrors WPT auto-name: two column-flex items swap via `order`, so item1 travels (0,0)→(0,100)
+    // and item2 travels (100,100)→(100,0). `groupRule` selects how the group is addressed and timed.
+    private static string Page(string groupRule) => $$"""
+<!DOCTYPE html>
+<html>
+<style>
+  body { margin: 0; }
+  div { width: 100px; height: 100px; }
+  main { display: flex; flex-direction: column; }
+  .item { view-transition-name: auto; view-transition-class: item; }
+  main.switch #item1 { order: 2; }
+  #item1 { background: green; }
+  #item2 { background: yellow; position: relative; left: 100px; }
+  :root { view-transition-name: none; }
+  html::view-transition { background: rebeccapurple; }
+  {{groupRule}}
+  html::view-transition-old(*) { animation: unset; opacity: 0 }
+  html::view-transition-new(*) { animation: unset; opacity: 1 }
+</style>
+<main id="main"><div class="item" id="item1"></div><div class="item" id="item2"></div></main>
+</html>
+""";
+
+    private const string Switch =
+        "document.startViewTransition(() => { document.querySelector('main').classList.add('switch'); });";
+
+    [Theory]
+    // The name-less `.item` shorthand, and the explicit `*.item` form: both select every group whose
+    // captured element carries `view-transition-class: item`.
+    [InlineData(".item")]
+    [InlineData("*.item")]
+    public void Steps_Jump_Start_Freezes_The_Group_Midway(string argument)
+    {
+        var html = Page(
+            $"html::view-transition-group({argument}) {{ animation-timing-function: steps(2, start); }}");
+
+        using var bitmap = Render(html, Switch);
+
+        // steps(2, start) is 1/2 at input 0, so each group sits at the midpoint of its travel:
+        // item1 at y 50..150, item2 at y 50..150 one column over.
+        AssertPixel(bitmap, 50, 100, 0, 128, 0, "the green item at its midpoint");
+        AssertPixel(bitmap, 150, 100, 255, 255, 0, "the yellow item at its midpoint");
+
+        // Nothing is left at either endpoint.
+        AssertPixel(bitmap, 50, 25, 102, 51, 153, "the backdrop above the green item");
+        AssertPixel(bitmap, 150, 25, 102, 51, 153, "the backdrop above the yellow item");
+    }
+
+    [Fact]
+    public void Default_Timing_Leaves_The_Group_At_The_Old_Geometry()
+    {
+        // linear (and every ease / cubic-bezier / jump-end steps) is 0 at input 0, so the group stays
+        // where it has always been placed. This is the path almost every other test takes.
+        var html = Page("html::view-transition-group(*) { animation-timing-function: linear; }");
+
+        using var bitmap = Render(html, Switch);
+
+        AssertPixel(bitmap, 50, 50, 0, 128, 0, "the green item at its old geometry");
+        AssertPixel(bitmap, 150, 150, 255, 255, 0, "the yellow item at its old geometry");
+    }
+
+    [Fact]
+    public void A_Class_Rule_Does_Not_Reach_A_Group_Without_That_Class()
+    {
+        // `view-transition-class` gates the match: a rule for `.other` must not time these groups,
+        // leaving them at the old geometry.
+        var html = Page(
+            "html::view-transition-group(*.other) { animation-timing-function: steps(2, start); }");
+
+        using var bitmap = Render(html, Switch);
+
+        AssertPixel(bitmap, 50, 50, 0, 128, 0, "the green item, untimed, at its old geometry");
+        AssertPixel(bitmap, 150, 150, 255, 255, 0, "the yellow item, untimed, at its old geometry");
+    }
+}

--- a/src/Broiler.Cli.Tests/ViewTransitionRootCaptureTests.cs
+++ b/src/Broiler.Cli.Tests/ViewTransitionRootCaptureTests.cs
@@ -8,13 +8,18 @@ namespace Broiler.Cli.Tests;
 /// The name the <em>document</em> is captured under, and the box the spec puts between a group and
 /// its two snapshots.
 /// <para>
-/// Neither closes WPT issue #1491 problems 19, 21 or 23 on its own. Those need the root snapshot to
-/// reproduce the page, and reproducing it by cloning the DOM was tried and reverted: it is close but
-/// not exact, and where the old root snapshot is genuinely visible "close" scores worse than the
+/// A root snapshot reproduces the page by cloning the DOM only when the author paints
+/// <c>::view-transition</c>. Cloning it unconditionally was tried and reverted: the clone is close
+/// but not exact, and wherever the page shows through the overlay "close" scores worse than the
 /// transparent box it replaced, because the live page underneath is pixel-exact. Measured over the
-/// 458 local <c>css-view-transitions</c> tests it was +8 passing / −7 passing, and it cost 79 pixel
-/// points on <c>root-to-shared-animation-end</c>. A real capture wants a rasterised snapshot from
-/// the renderer, not a DOM clone — see <c>docs/wpt-rendering-gaps.md</c>.
+/// 458 local <c>css-view-transitions</c> tests that was +8 passing / −7 passing, and it cost 79
+/// pixel points on <c>root-to-shared-animation-end</c>. The gate keeps that exact path for every
+/// test that leaves the overlay transparent, and only clones where the page cannot show through at
+/// all — there a content-less snapshot leaves the backdrop colour flooding the viewport, which is
+/// how WPT <c>old-content-captures-root</c>, <c>new-content-captures-root</c> and
+/// <c>root-captured-as-different-tag</c> (issue #1500 problems 13, 15 and 17) rendered as a flat
+/// pink page. A capture that is exact in both cases wants a rasterised snapshot from the renderer,
+/// not a DOM clone — see <c>docs/wpt-rendering-gaps.md</c>.
 /// </para>
 /// </summary>
 public class ViewTransitionRootCaptureTests
@@ -61,9 +66,68 @@ public class ViewTransitionRootCaptureTests
         using var bitmap = Render(html, "document.startViewTransition(() => { document.body.style.background = 'red'; });");
 
         // The `(root)` rule must not have matched: its `background: red` would fill the group over
-        // the whole viewport. What shows instead is the ::view-transition backdrop, because the root
-        // snapshot itself is not reproduced (see the class remarks).
-        AssertPixel(bitmap, 150, 150, 255, 192, 203, "the backdrop, not the (root) rule's red");
+        // the whole viewport. What shows instead is the captured page — this test paints
+        // `::view-transition`, so the root snapshot reproduces the page rather than letting it show
+        // through (see the class remarks).
+        AssertPixel(bitmap, 150, 150, 255, 255, 255, "the captured canvas, not the (root) rule's red");
+        AssertPixel(bitmap, 50, 50, 0, 0, 255, "the captured pre-callback box");
+    }
+
+    // With the overlay painted, the page cannot show through, so the old root snapshot has to
+    // reproduce it — including content the callback has since changed (WPT old-content-captures-root).
+    [Fact]
+    public void Painted_Overlay_Makes_The_Old_Root_Snapshot_Reproduce_The_Page()
+    {
+        const string html = """
+<!DOCTYPE html>
+<html class="reftest-wait">
+<style>
+  body { background: white; margin: 0; }
+  #box { position: absolute; top: 20px; left: 20px; width: 60px; height: 60px; background: blue; }
+  html::view-transition { background: pink; }
+  html::view-transition-old(root) { animation: unset; opacity: 1; }
+  html::view-transition-new(root) { animation: unset; opacity: 0; }
+</style>
+<div id="box"></div>
+</html>
+""";
+        using var bitmap = Render(html,
+            "document.startViewTransition(() => {" +
+            "  document.getElementById('box').style.background = 'red';" +
+            "  document.body.style.background = 'lime'; });");
+
+        // Pre-callback state, not the live page and not the backdrop: the box is still blue, the
+        // canvas still white. Without a content box the whole viewport came out pink.
+        AssertPixel(bitmap, 50, 50, 0, 0, 255, "the captured pre-callback box");
+        AssertPixel(bitmap, 150, 150, 255, 255, 255, "the captured canvas");
+    }
+
+    // The gate matters as much as the capture: cloning the root unconditionally was measured at
+    // +8/-7 passing and reverted (see the class remarks), because a transparent snapshot over the
+    // live page is pixel-exact where a clone is only close. With no author background on
+    // ::view-transition the snapshot must stay content-less and let the page through.
+    [Fact]
+    public void Transparent_Overlay_Leaves_The_Root_Snapshot_Content_Less()
+    {
+        const string html = """
+<!DOCTYPE html>
+<html class="reftest-wait">
+<style>
+  body { background: white; margin: 0; }
+  #box { position: absolute; top: 20px; left: 20px; width: 60px; height: 60px; background: blue; }
+  html::view-transition-old(root) { animation: unset; opacity: 1; }
+  html::view-transition-new(root) { animation: unset; opacity: 0; }
+</style>
+<div id="box"></div>
+</html>
+""";
+        using var bitmap = Render(html,
+            "document.startViewTransition(() => {" +
+            "  document.getElementById('box').style.background = 'red'; });");
+
+        // What shows is the live page — the box the callback turned red — through a snapshot that
+        // reproduced nothing. A clone here would have shown the stale blue.
+        AssertPixel(bitmap, 50, 50, 255, 0, 0, "the live page through the empty snapshot");
     }
 
     // ::view-transition-image-pair is the box the spec puts between a group and its old/new pair, so

--- a/src/Broiler.Cli.Tests/ViewTransitionRootCaptureTests.cs
+++ b/src/Broiler.Cli.Tests/ViewTransitionRootCaptureTests.cs
@@ -130,6 +130,59 @@ public class ViewTransitionRootCaptureTests
         AssertPixel(bitmap, 50, 50, 255, 0, 0, "the live page through the empty snapshot");
     }
 
+    // The overlay backdrop is not the only way the live page stops being able to stand in for the
+    // snapshot. An effect on the snapshot re-renders its pixels, and the page beneath is not
+    // affected by it — so a transparent snapshot over a perfectly visible page shows the wrong
+    // thing. WPT {old,new}-content-root-scrollbar-with-fixed-background invert the captured page.
+    [Fact]
+    public void A_Filter_On_The_Old_Snapshot_Makes_It_Reproduce_The_Page()
+    {
+        const string html = """
+<!DOCTYPE html>
+<html class="reftest-wait">
+<style>
+  body { background: white; margin: 0; }
+  #box { position: absolute; top: 20px; left: 20px; width: 60px; height: 60px; background: blue; }
+  html::view-transition-old(root) { animation: unset; filter: invert(1); }
+  html::view-transition-new(root) { animation: unset; opacity: 0; }
+</style>
+<div id="box"></div>
+</html>
+""";
+        using var bitmap = Render(html, "document.startViewTransition(() => { document.body.style.background = 'lime'; });");
+
+        // Blue inverted is yellow, and the white canvas inverts to black. Without content the
+        // snapshot had nothing to invert and the un-inverted live page showed through instead.
+        AssertPixel(bitmap, 50, 50, 255, 255, 0, "the captured box, inverted");
+        AssertPixel(bitmap, 150, 150, 0, 0, 0, "the captured canvas, inverted");
+    }
+
+    // The counterpart, and the reason the effect list is not simply "any author declaration":
+    // opacity only composites the snapshot against what is behind it, which is exactly what the live
+    // page already does. root-to-shared-animation-end pins `::view-transition-old(*) { opacity: 1 }`
+    // and cost 79 pixel points the one time this was treated as needing content.
+    [Fact]
+    public void Opacity_Alone_Leaves_The_Snapshot_Content_Less()
+    {
+        const string html = """
+<!DOCTYPE html>
+<html class="reftest-wait">
+<style>
+  body { background: white; margin: 0; }
+  #box { position: absolute; top: 20px; left: 20px; width: 60px; height: 60px; background: blue; }
+  html::view-transition-old(root) { animation: unset; opacity: 1; }
+  html::view-transition-new(root) { animation: unset; opacity: 0; }
+</style>
+<div id="box"></div>
+</html>
+""";
+        using var bitmap = Render(html,
+            "document.startViewTransition(() => { document.getElementById('box').style.background = 'red'; });");
+
+        // The live page — the box the callback turned red — shows through, as before.
+        AssertPixel(bitmap, 50, 50, 255, 0, 0, "the live page through the empty snapshot");
+    }
+
     // ::view-transition-image-pair is the box the spec puts between a group and its old/new pair, so
     // a rule can address both at once. old-content-captures-root hides an entire group with it.
     [Fact]

--- a/src/Broiler.Cli.Tests/ViewportScrollEventTests.cs
+++ b/src/Broiler.Cli.Tests/ViewportScrollEventTests.cs
@@ -1,0 +1,113 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// CSSOM View fires a scrolling event at the <em>Document</em> when the scrolling box is the
+/// viewport, so it reaches <c>window</c> through the propagation path — which is why
+/// <c>addEventListener("scroll", …)</c> at global scope, the idiomatic spelling, is how a page
+/// observes its own scrolling.
+/// <para>
+/// The bridge dispatched the event on the document element and marked it non-bubbling, so a window
+/// listener never saw it: <c>document.documentElement.scrollTop = N</c> scrolled silently — the
+/// offset changed and the render moved, but nothing was notified.
+/// </para>
+/// </summary>
+public class ViewportScrollEventTests
+{
+    private const string Page = """
+<!DOCTYPE html>
+<html>
+<style> body { margin: 0; } #tall { width: 100px; height: 4000px; } </style>
+<div id="tall"></div>
+<div id="out"></div>
+</html>
+""";
+
+    private static string Run(string script)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, Page, "file:///test.html");
+        context.Eval(script);
+        return bridge.SerializeToHtml();
+    }
+
+    [Fact]
+    public void Setting_ScrollTop_Notifies_A_Window_Scroll_Listener()
+    {
+        var html = Run("""
+            var fired = 0;
+            addEventListener('scroll', function(){ fired++; }, { once: true, capture: true });
+            document.documentElement.scrollTop = 500;
+            document.getElementById('out').textContent =
+              'fired=' + fired + ' top=' + document.documentElement.scrollTop;
+        """);
+
+        Assert.Contains("fired=1", html);
+        Assert.Contains("top=500", html);
+    }
+
+    [Fact]
+    public void ScrollTo_And_ScrollBy_Notify_Too()
+    {
+        var html = Run("""
+            var fired = 0;
+            addEventListener('scroll', function(){ fired++; });
+            window.scrollTo(0, 200);
+            window.scrollBy(0, 100);
+            document.getElementById('out').textContent =
+              'fired=' + fired + ' top=' + document.documentElement.scrollTop;
+        """);
+
+        Assert.Contains("fired=2", html);
+        Assert.Contains("top=300", html);
+    }
+
+    [Fact]
+    public void A_Scroll_That_Does_Not_Move_Notifies_Nothing()
+    {
+        // The dispatch is gated on the offset actually changing, and must stay that way — a
+        // no-op assignment is not a scroll.
+        var html = Run("""
+            document.documentElement.scrollTop = 0;
+            var fired = 0;
+            addEventListener('scroll', function(){ fired++; });
+            document.documentElement.scrollTop = 0;
+            document.getElementById('out').textContent = 'fired=' + fired;
+        """);
+
+        Assert.Contains("fired=0", html);
+    }
+
+    [Fact]
+    public void An_Element_Scroll_Still_Reaches_Its_Own_Listener_Only()
+    {
+        // Only the viewport propagates to the window; a scroller's own event stays on the element,
+        // which is what it did before and what CSSOM View asks for.
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, """
+<!DOCTYPE html>
+<html>
+<style> #box { width: 100px; height: 100px; overflow: scroll; } #inner { height: 900px; } </style>
+<div id="box"><div id="inner"></div></div>
+<div id="out"></div>
+</html>
+""", "file:///test.html");
+        context.Eval("""
+            var onWindow = 0, onElement = 0;
+            addEventListener('scroll', function(){ onWindow++; });
+            var box = document.getElementById('box');
+            box.addEventListener('scroll', function(){ onElement++; });
+            box.scrollTop = 50;
+            document.getElementById('out').textContent =
+              'window=' + onWindow + ' element=' + onElement;
+        """);
+
+        var html = bridge.SerializeToHtml();
+        Assert.Contains("window=0", html);
+        Assert.Contains("element=1", html);
+    }
+}

--- a/src/Broiler.Cli/CaptureService.cs
+++ b/src/Broiler.Cli/CaptureService.cs
@@ -520,6 +520,9 @@ public class CaptureService
         // plain JSContext and the modules are skipped (unchanged net effect: they did not execute).
         var useEngineModules = moduleRoots.Count > 0 && EngineModuleSupport.Available;
         var microTasks = new MicroTaskQueue();
+        // See MicroTaskSynchronizationContext: without this the engine resumes await continuations
+        // on the thread pool, concurrently with this thread's serialize/render.
+        using var microTaskContext = MicroTaskSynchronizationContext.Install(microTasks);
         using JSContext context = useEngineModules ? new BridgeModuleContext(csp, url) : new JSContext();
         RegisterRuntimeExtensions(context, microTasks, csp);
         var bridge = new DomBridge();

--- a/src/Broiler.HtmlBridge.Core/Scripting/MicroTaskSynchronizationContext.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/MicroTaskSynchronizationContext.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Threading;
+
+namespace Broiler.HtmlBridge.Scripting;
+
+/// <summary>
+/// A <see cref="SynchronizationContext"/> that routes posted callbacks into a
+/// <see cref="MicroTaskQueue"/> instead of the thread pool, so JavaScript stays single-threaded.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The engine resolves a promise reaction's target with
+/// <c>SynchronizationContext.Current ?? context.synchronizationContext</c> and falls back to
+/// <c>ThreadPool.QueueUserWorkItem</c> when neither is set. Both fallbacks run the reaction
+/// <em>concurrently with the thread that is driving the page</em>: an <c>await</c> continuation
+/// resumed on a pool thread races the host, which then serializes, renders, or reads results before
+/// the continuation has finished. Anything cheap appeared to work — the race was usually won — while
+/// a continuation whose next step was expensive lost it. A geometry query (a full layout) reliably
+/// lost, so <c>await something; el.getBoundingClientRect()</c> looked like it silently truncated the
+/// rest of the function: no exception, no rejection, not even a <c>finally</c>, because the
+/// continuation was still running on another thread when the page was captured.
+/// </para>
+/// <para>
+/// Posting into the microtask queue instead makes a reaction a microtask, which is what the HTML
+/// spec calls it, and it then runs on the driving thread at the checkpoints the host already has
+/// (<c>TaskCheckpointCallback</c>, and the drain that follows each script phase). <see cref="Send"/>
+/// stays synchronous — a caller asking to run inline is entitled to that, and the queue is not
+/// reentrancy-safe for it.
+/// </para>
+/// <para>
+/// Install it around script execution with <see cref="Install"/>, whose returned scope restores the
+/// thread's previous context. It must be current on the thread while script runs, because a promise
+/// captures its context when it is created, not when it settles.
+/// </para>
+/// </remarks>
+public sealed class MicroTaskSynchronizationContext : SynchronizationContext
+{
+    private readonly MicroTaskQueue _queue;
+
+    public MicroTaskSynchronizationContext(MicroTaskQueue queue)
+    {
+        ArgumentNullException.ThrowIfNull(queue);
+        _queue = queue;
+    }
+
+    public override void Post(SendOrPostCallback d, object? state)
+    {
+        ArgumentNullException.ThrowIfNull(d);
+        _queue.Enqueue(() => d(state));
+    }
+
+    public override void Send(SendOrPostCallback d, object? state)
+    {
+        ArgumentNullException.ThrowIfNull(d);
+        d(state);
+    }
+
+    // The engine may copy the context onto a captured execution context; the queue is shared, so the
+    // copy must post to the same one rather than to a fresh queue nothing drains.
+    public override SynchronizationContext CreateCopy() => this;
+
+    /// <summary>
+    /// Makes a context backed by <paramref name="queue"/> current on the calling thread until the
+    /// returned scope is disposed.
+    /// </summary>
+    public static Scope Install(MicroTaskQueue queue) => new(queue);
+
+    public readonly struct Scope : IDisposable
+    {
+        private readonly SynchronizationContext? _previous;
+
+        internal Scope(MicroTaskQueue queue)
+        {
+            _previous = Current;
+            SetSynchronizationContext(new MicroTaskSynchronizationContext(queue));
+        }
+
+        public void Dispose() => SetSynchronizationContext(_previous);
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ComputedStyleEngine.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ComputedStyleEngine.cs
@@ -84,8 +84,92 @@ public sealed partial class DomBridge
                 CSS.Dom.CssOrigin.Author,
                 GetAttr(styleEl, "media")));
 
+        AppendOuterPartRules(docRoot, sources);
+
         var (vpWidth, vpHeight) = GetViewportForDocRoot(docRoot);
         return scope.ScopeBuilder.Sync(sources, new CssEnvironment(vpWidth, vpHeight));
+    }
+
+    /// <summary>
+    /// Adds the enclosing tree's <c>::part()</c> rules to a shadow tree's style scope.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A shadow tree gets its own scope holding only the sheets inside it, which is exactly the
+    /// encapsulation the spec asks for — with one sanctioned exception. <c>::part()</c> (CSS Shadow
+    /// Parts) is how the outer tree styles elements the shadow tree deliberately exposes, so those
+    /// rules, and only those, have to cross the boundary. Without this a document-level
+    /// <c>::part(name)</c> rule painted correctly (the renderer sees the tree already flattened) yet
+    /// was invisible to <c>getComputedStyle</c> and to everything reading computed values — which is
+    /// how WPT auto-name-from-id-shadow lost the <c>view-transition-name</c> its part rule sets, and
+    /// with it the element's whole view-transition capture.
+    /// </para>
+    /// <para>
+    /// Appended after the shadow tree's own sheets: per CSS Scoping, declarations from the outer
+    /// tree win over the inner tree's at equal specificity.
+    /// </para>
+    /// </remarks>
+    private void AppendOuterPartRules(DomElement docRoot, List<CssStyleScopeBuilder.StyleSource> sources)
+    {
+        if (!docRoot.TagName.StartsWith('#') || ParentEl(docRoot) is not { } shadowHost)
+            return;
+
+        var outerStyles = new List<DomElement>();
+        CollectStyleElementsInTree(GetDocumentRootFor(shadowHost), outerStyles);
+
+        foreach (var styleEl in outerStyles)
+        {
+            var partRules = ExtractPartRules(GetStyleElementCssText(styleEl));
+            if (partRules.Length > 0)
+                sources.Add(new CssStyleScopeBuilder.StyleSource(
+                    partRules, CSS.Dom.CssOrigin.Author, GetAttr(styleEl, "media")));
+        }
+    }
+
+    /// <summary>
+    /// The <c>::part()</c> rules of a stylesheet, returned as CSS text. A brace-depth scan rather
+    /// than a parse: it keeps each qualifying rule's own text verbatim, so the cascade sees exactly
+    /// what the author wrote. Rules nested in an at-rule (<c>@media</c> …) are not lifted out — a
+    /// <c>::part()</c> inside one still will not cross into a shadow tree.
+    /// </summary>
+    private static string ExtractPartRules(string css)
+    {
+        if (string.IsNullOrEmpty(css) || css.IndexOf("::part(", StringComparison.OrdinalIgnoreCase) < 0)
+            return string.Empty;
+
+        var kept = new System.Text.StringBuilder();
+        var depth = 0;
+        var ruleStart = 0;
+        var preludeEnd = -1;
+
+        for (var index = 0; index < css.Length; index++)
+        {
+            var character = css[index];
+            if (character == '{')
+            {
+                if (depth == 0)
+                    preludeEnd = index;
+                depth++;
+            }
+            else if (character == '}')
+            {
+                depth--;
+                if (depth != 0)
+                    continue;
+
+                if (preludeEnd > ruleStart &&
+                    css.AsSpan(ruleStart, preludeEnd - ruleStart)
+                        .IndexOf("::part(", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    kept.Append(css, ruleStart, index - ruleStart + 1).Append('\n');
+                }
+
+                ruleStart = index + 1;
+                preludeEnd = -1;
+            }
+        }
+
+        return kept.ToString();
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.HtmlParsing.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.HtmlParsing.cs
@@ -85,10 +85,93 @@ public sealed partial class DomBridge
         if (!_document.ChildNodes.Contains(DocumentElement))
             _document.AppendChild(DocumentElement);
 
+        AttachDeclarativeShadowRoots(DocumentElement);
+
 
         // Stylesheet discovery is document-scoped and lazy through the shared
         // CssStyleEngine. A rebuilt document must not retain the prior engines.
         ResetComputedStyleEngines();
+    }
+
+    /// <summary>
+    /// HTML §4.12.3: turns every <c>&lt;template shadowrootmode="open|closed"&gt;</c> into a real
+    /// shadow root on its parent — the declarative counterpart of <c>attachShadow()</c>. The template
+    /// contributes its children to the new root and is then dropped from the tree.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The spec does this inside the tree builder, as the template's end tag is seen. Doing it as a
+    /// pass over the finished tree is equivalent for a parsed document — nothing observes the
+    /// intermediate state, because script has not run yet — and keeps the shared
+    /// <c>HtmlDocumentParser</c> free of a bridge-only concept.
+    /// </para>
+    /// <para>
+    /// Only the shadow root is new here: everything downstream of it (styling the shadow tree,
+    /// flattening the <c>#shadow-root</c> wrapper for the renderer, capturing it in a view
+    /// transition) is the same machinery <c>attachShadow()</c> already drove, which is why
+    /// imperative shadow content rendered while declarative content did not.
+    /// </para>
+    /// </remarks>
+    private void AttachDeclarativeShadowRoots(DomElement root)
+    {
+        // Depth-first with an explicit stack: a shadow tree may itself contain declarative shadow
+        // roots, and those templates only become reachable once their content has been moved.
+        var pending = new Stack<DomElement>();
+        pending.Push(root);
+
+        while (pending.Count > 0)
+        {
+            var element = pending.Pop();
+
+            for (var index = element.ChildNodes.Count - 1; index >= 0; index--)
+            {
+                if (element.ChildNodes[index] is not DomElement child)
+                    continue;
+
+                if (!TryTakeDeclarativeShadowRoot(element, child, index, out var shadowRoot))
+                {
+                    pending.Push(child);
+                    continue;
+                }
+
+                pending.Push(shadowRoot);
+            }
+        }
+    }
+
+    /// <summary>
+    /// When <paramref name="child"/> is a declarative shadow-root template of <paramref name="host"/>,
+    /// moves its children into a freshly attached shadow root, removes the template, and returns the
+    /// root. Returns <see langword="false"/> for anything else, leaving the tree untouched.
+    /// </summary>
+    private bool TryTakeDeclarativeShadowRoot(
+        DomElement host, DomElement child, int childIndex, out DomElement shadowRoot)
+    {
+        shadowRoot = null!;
+
+        if (!string.Equals(child.TagName, "template", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var mode = child.GetAttribute("shadowrootmode")?.Trim();
+        if (!string.Equals(mode, "open", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(mode, "closed", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        // "Only the first declarative shadow root wins": a second template on the same host is an
+        // ordinary inert <template>, per the spec's already-has-a-shadow-root check.
+        if (GetShadowRoot(host) is not null)
+            return false;
+
+        shadowRoot = ((Dom.Features.IShadowDomHost)this).AttachShadowRoot(host, mode!.ToLowerInvariant());
+
+        foreach (var content in child.ChildNodes.ToArray())
+        {
+            SetParent(content, shadowRoot);
+            shadowRoot.AppendChild(content);
+        }
+
+        RemoveNthChild(host, childIndex);
+        return true;
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ViewTransition.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ViewTransition.cs
@@ -294,23 +294,13 @@ public sealed partial class DomBridge
         if (rootName is not null)
         {
             var (l, t, w, h) = GetBoundingClientRectForDomElement(DocumentElement, isRoot: true);
-            // A root snapshot is normally left content-less and the live page under the overlay
-            // stands in for it — pixel-exact where a DOM clone is only close. Reproducing it by
-            // cloning unconditionally was tried and reverted (+8/-7 passing over the 458 local
-            // css-view-transitions tests, -79 pixel points on root-to-shared-animation-end), and
-            // for good reason: wherever the page shows through, "close" scores worse than exact.
-            //
-            // But the page can only stand in while it is actually visible. Once the author gives
-            // `::view-transition` a background, that overlay paints between the page and the
-            // snapshot, and a content-less snapshot leaves the backdrop colour flooding the
-            // viewport — WPT old-content-captures-root, new-content-captures-root and
-            // root-captured-as-different-tag all render as a flat pink page. Clone only in that
-            // case, so every test that does not paint the overlay keeps the exact live-page path.
-            // The fallback fill stays exactly what it was: AttachSnapshotPaint only uses it when
-            // there is no content box, i.e. on the ungated path, which must keep behaving as before.
+            // Content-less unless the live page provably cannot stand in for this snapshot — see
+            // RootSnapshotNeedsContent. The fallback fill stays exactly what it was:
+            // AttachSnapshotPaint only uses it when there is no content box, i.e. on the ungated
+            // path, which must keep behaving as before.
             state.OldCaptures[rootName] = new NamedSnapshot(l, t, w, h,
                 rootStyle.GetValueOrDefault("background-color") ?? "transparent",
-                RootOverlayOccludesPage(DocumentElement)
+                RootSnapshotNeedsContent(DocumentElement, "old")
                     ? BuildRootViewTransitionSnapshotContent(rootStyle)
                     : null);
         }
@@ -496,8 +486,7 @@ public sealed partial class DomBridge
     private void ApplyViewTransitionPseudoTree(DomElement root)
     {
         var pseudoRules = CollectViewTransitionPseudoDeclarations(root);
-        var captures = CollectViewTransitionCaptures(
-            root, AuthorPaintsBackground(LookupPseudo(pseudoRules, "", null)));
+        var captures = CollectViewTransitionCaptures(root, RootSnapshotNeedsContent(root, "new"));
 
         // A view transition that captured nothing (no element carries a used
         // view-transition-name — e.g. `:root { view-transition-name: none }` with no other
@@ -908,13 +897,91 @@ public sealed partial class DomBridge
     }
 
     /// <summary>
-    /// Whether the author's bare <c>::view-transition</c> declarations paint a backdrop between the
-    /// live page and the snapshots above it. While they do not, a root snapshot can stay
-    /// content-less and let the page show through — the exact rendering. Once they do, the page is
-    /// hidden and the snapshot has to reproduce it (see the callers).
+    /// Whether the root's <paramref name="side"/> (<c>old</c> / <c>new</c>) snapshot has to reproduce
+    /// the page rather than let the live page show through it.
     /// </summary>
-    private bool RootOverlayOccludesPage(DomElement root) =>
-        AuthorPaintsBackground(LookupPseudo(CollectViewTransitionPseudoDeclarations(root), "", null));
+    /// <remarks>
+    /// <para>
+    /// A root snapshot is normally left content-less: it sits over the live page, which renders the
+    /// same thing pixel-exactly, where a DOM clone is only close. Cloning unconditionally was tried
+    /// and reverted (+8/-7 passing across the 458 local css-view-transitions tests, -79 pixel points
+    /// on <c>root-to-shared-animation-end</c>). So the clone is gated on the page provably not being
+    /// able to stand in, which happens two ways:
+    /// </para>
+    /// <para>
+    /// The author paints the bare <c>::view-transition</c>. That backdrop sits between the page and
+    /// the snapshot, so the page is not visible through it at all and a content-less snapshot leaves
+    /// the backdrop colour flooding the viewport.
+    /// </para>
+    /// <para>
+    /// Or the author gives this side's pseudo an effect that re-renders the snapshot's own pixels —
+    /// <c>filter</c> and friends. The page beneath is not filtered, so even a fully transparent
+    /// snapshot over a perfectly visible page shows the wrong thing: WPT
+    /// <c>{old,new}-content-root-scrollbar-with-fixed-background</c> invert the captured page with
+    /// <c>filter: invert(1)</c> and expect an inverted viewport.
+    /// </para>
+    /// <para>
+    /// <c>opacity</c> is deliberately not in that set, and the distinction is what keeps the old
+    /// regression away: it only composites the snapshot against what is behind it, which is exactly
+    /// what the live page already does. <c>root-to-shared-animation-end</c> pins
+    /// <c>::view-transition-old(*) { opacity: 1 }</c>, and treating that as needing content is
+    /// precisely the -79 case. <c>transform</c> is likewise excluded — the group already carries the
+    /// captured placement — pending a measurement that shows a test needs it.
+    /// </para>
+    /// </remarks>
+    private bool RootSnapshotNeedsContent(DomElement root, string side)
+    {
+        var pseudoRules = CollectViewTransitionPseudoDeclarations(root);
+        if (AuthorPaintsBackground(LookupPseudo(pseudoRules, string.Empty, null)))
+            return true;
+
+        var rootName = ResolveRootViewTransitionName(UsedStyleForCapture(root));
+        return HasSnapshotAlteringEffect(LookupRootPseudo(pseudoRules, side, rootName));
+    }
+
+    /// <summary>The declarations an author aimed at the root's <paramref name="kind"/> pseudo, taking
+    /// both the <c>*</c> and the by-name forms (the root has no <c>view-transition-class</c> path of
+    /// its own to consider).</summary>
+    private static Dictionary<string, string> LookupRootPseudo(
+        Dictionary<string, Dictionary<string, string>> pseudoRules, string kind, string? rootName)
+    {
+        var merged = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
+
+        void Merge(string argument)
+        {
+            if (pseudoRules.TryGetValue($"{kind}|{argument}", out var bucket))
+                foreach (var (key, value) in bucket)
+                    merged[key] = value;
+        }
+
+        Merge("*");
+        if (!string.IsNullOrEmpty(rootName))
+            Merge(rootName!);
+
+        return merged;
+    }
+
+    /// <summary>Properties that re-render a snapshot's own pixels, so the live page underneath cannot
+    /// stand in for it however visible that page is. Compositing-only knobs (<c>opacity</c>) and
+    /// placement (<c>transform</c>) are not here — see <see cref="RootSnapshotNeedsContent"/>.</summary>
+    private static readonly string[] SnapshotAlteringProperties =
+    {
+        "filter", "backdrop-filter", "mix-blend-mode", "mask", "mask-image", "clip-path",
+    };
+
+    private static bool HasSnapshotAlteringEffect(Dictionary<string, string> declarations)
+    {
+        foreach (var property in SnapshotAlteringProperties)
+        {
+            if (declarations.TryGetValue(property, out var value) &&
+                !string.IsNullOrWhiteSpace(value) &&
+                !value.Trim().Equals("none", System.StringComparison.OrdinalIgnoreCase) &&
+                !value.Trim().Equals("normal", System.StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
 
     /// <summary>Metadata and script children that never paint, so a root snapshot must not clone them:
     /// re-inserting <c>&lt;style&gt;</c>/<c>&lt;link&gt;</c> would duplicate author rules into the live
@@ -1050,7 +1117,7 @@ public sealed partial class DomBridge
     /// "new" one (the element as it stands now), in old-then-new document order. Names appearing only
     /// on one side keep just that snapshot; the group is placed at the old geometry when present.
     /// </summary>
-    private List<ViewTransitionCapture> CollectViewTransitionCaptures(DomElement root, bool rootOverlayOccludesPage = false)
+    private List<ViewTransitionCapture> CollectViewTransitionCaptures(DomElement root, bool newRootNeedsContent = false)
     {
         var newCaptures = new Dictionary<string, NamedSnapshot>(System.StringComparer.Ordinal);
         var order = new List<string>();
@@ -1069,17 +1136,12 @@ public sealed partial class DomBridge
         if (rootName is not null)
         {
             var (l, t, w, h) = GetBoundingClientRectForDomElement(root, isRoot: true);
-            // The new root snapshot is normally left content-less on purpose: it sits over the live
-            // page, which is the same content it would be reproducing — and the real rendering is
-            // exact where a DOM clone is only close. Cloning it unconditionally cost 7 tests between
-            // 0.8 and 4 pixel-points, and 79 on root-to-shared-animation-end, for no test it alone
-            // fixed. But the live page can only stand in for it while nothing paints in between:
-            // once the author gives `::view-transition` a background, that overlay hides the page
-            // and a content-less snapshot leaves the backdrop colour flooding the viewport (WPT
-            // new-content-captures-root rendered as flat pink). Clone it only in that case.
+            // Content-less unless the live page provably cannot stand in for this snapshot — see
+            // RootSnapshotNeedsContent for the two ways that happens and why cloning it
+            // unconditionally was reverted.
             AddNew(rootName, new NamedSnapshot(l, t, w, h,
                 rootStyle.GetValueOrDefault("background-color") ?? "transparent",
-                rootOverlayOccludesPage ? BuildRootViewTransitionSnapshotContent(rootStyle) : null));
+                newRootNeedsContent ? BuildRootViewTransitionSnapshotContent(rootStyle) : null));
             classesByName[rootName] = rootStyle.GetValueOrDefault("view-transition-class") ?? string.Empty;
         }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ViewTransition.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ViewTransition.cs
@@ -294,8 +294,25 @@ public sealed partial class DomBridge
         if (rootName is not null)
         {
             var (l, t, w, h) = GetBoundingClientRectForDomElement(DocumentElement, isRoot: true);
+            // A root snapshot is normally left content-less and the live page under the overlay
+            // stands in for it — pixel-exact where a DOM clone is only close. Reproducing it by
+            // cloning unconditionally was tried and reverted (+8/-7 passing over the 458 local
+            // css-view-transitions tests, -79 pixel points on root-to-shared-animation-end), and
+            // for good reason: wherever the page shows through, "close" scores worse than exact.
+            //
+            // But the page can only stand in while it is actually visible. Once the author gives
+            // `::view-transition` a background, that overlay paints between the page and the
+            // snapshot, and a content-less snapshot leaves the backdrop colour flooding the
+            // viewport — WPT old-content-captures-root, new-content-captures-root and
+            // root-captured-as-different-tag all render as a flat pink page. Clone only in that
+            // case, so every test that does not paint the overlay keeps the exact live-page path.
+            // The fallback fill stays exactly what it was: AttachSnapshotPaint only uses it when
+            // there is no content box, i.e. on the ungated path, which must keep behaving as before.
             state.OldCaptures[rootName] = new NamedSnapshot(l, t, w, h,
-                rootStyle.GetValueOrDefault("background-color") ?? "transparent");
+                rootStyle.GetValueOrDefault("background-color") ?? "transparent",
+                RootOverlayOccludesPage(DocumentElement)
+                    ? BuildRootViewTransitionSnapshotContent(rootStyle)
+                    : null);
         }
 
         foreach (var element in DocumentElement.Descendants().OfType<DomElement>())
@@ -479,7 +496,8 @@ public sealed partial class DomBridge
     private void ApplyViewTransitionPseudoTree(DomElement root)
     {
         var pseudoRules = CollectViewTransitionPseudoDeclarations(root);
-        var captures = CollectViewTransitionCaptures(root);
+        var captures = CollectViewTransitionCaptures(
+            root, AuthorPaintsBackground(LookupPseudo(pseudoRules, "", null)));
 
         // A view transition that captured nothing (no element carries a used
         // view-transition-name — e.g. `:root { view-transition-name: none }` with no other
@@ -747,7 +765,16 @@ public sealed partial class DomBridge
     /// snapshot box (100%); positioning, insets, margins, and the outer width/height come from the
     /// captured geometry on that box, not from the element's own computed values.
     /// </summary>
-    private DomElement BuildViewTransitionSnapshotContent(DomElement element)
+    /// <param name="asRootSnapshot">
+    /// This is the whole-page root snapshot rather than one element's. Two things follow: children
+    /// that never paint are not cloned (cloning <c>&lt;head&gt;</c> would re-insert its
+    /// <c>&lt;style&gt;</c>/<c>&lt;script&gt;</c>, duplicating author rules and re-fetching external
+    /// resources), and <c>id</c> attributes are kept so page-level <c>#id</c> rules still match the
+    /// clone — without them a whole page of id-styled content reproduces as blank boxes. Keeping
+    /// them is safe here because the pseudo tree is materialised on a fresh render projection, so
+    /// the duplicate ids never reach the live tree page script can observe.
+    /// </param>
+    private DomElement BuildViewTransitionSnapshotContent(DomElement element, bool asRootSnapshot = false)
     {
         var used = UsedStyleForCapture(element);
 
@@ -782,8 +809,11 @@ public sealed partial class DomBridge
         // Clone the element's content verbatim (text and any descendants) so the snapshot paints it.
         foreach (var child in element.ChildNodes.ToArray())
         {
+            if (asRootSnapshot && IsNonRenderedSnapshotChild(child))
+                continue;
+
             var clone = child.CloneNode(deep: true);
-            StripCapturedIdentifiers(clone);
+            StripCapturedIdentifiers(clone, preserveIds: asRootSnapshot);
             content.AppendChild(clone);
         }
 
@@ -791,20 +821,106 @@ public sealed partial class DomBridge
     }
 
 
+    /// <summary>
+    /// Whether the author's bare <c>::view-transition</c> declarations paint a backdrop between the
+    /// live page and the snapshots above it. While they do not, a root snapshot can stay
+    /// content-less and let the page show through — the exact rendering. Once they do, the page is
+    /// hidden and the snapshot has to reproduce it (see the callers).
+    /// </summary>
+    private bool RootOverlayOccludesPage(DomElement root) =>
+        AuthorPaintsBackground(LookupPseudo(CollectViewTransitionPseudoDeclarations(root), "", null));
+
+    /// <summary>Metadata and script children that never paint, so a root snapshot must not clone them:
+    /// re-inserting <c>&lt;style&gt;</c>/<c>&lt;link&gt;</c> would duplicate author rules into the live
+    /// document and <c>&lt;script&gt;</c>/<c>&lt;link&gt;</c> could re-fetch external resources.</summary>
+    private static bool IsNonRenderedSnapshotChild(DomNode node) =>
+        node is DomElement element &&
+        element.TagName is { } tag &&
+        (tag.Equals("head", System.StringComparison.OrdinalIgnoreCase) ||
+         tag.Equals("style", System.StringComparison.OrdinalIgnoreCase) ||
+         tag.Equals("script", System.StringComparison.OrdinalIgnoreCase) ||
+         tag.Equals("link", System.StringComparison.OrdinalIgnoreCase) ||
+         tag.Equals("meta", System.StringComparison.OrdinalIgnoreCase) ||
+         tag.Equals("title", System.StringComparison.OrdinalIgnoreCase) ||
+         tag.Equals("base", System.StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// The old root snapshot's content: the page as it stands before the update callback. Built like
+    /// any other captured element's content box, minus the parts of <c>&lt;html&gt;</c> that never
+    /// paint — cloning <c>&lt;head&gt;</c> would re-insert its <c>&lt;style&gt;</c>/<c>&lt;script&gt;</c>
+    /// into the live document, duplicating author rules (including the <c>::view-transition</c> rules
+    /// driving the transition) and re-fetching external resources.
+    /// </summary>
+    private DomElement BuildRootViewTransitionSnapshotContent(Dictionary<string, string> rootStyle)
+    {
+        var content = BuildViewTransitionSnapshotContent(DocumentElement, asRootSnapshot: true);
+        // The root snapshot captures the viewport, so it paints the canvas background rather than
+        // the root box's own — which is usually `transparent`, and would let the ::view-transition
+        // background behind the snapshot show through the captured page.
+        InlineStyle(content)["background-color"] = ResolveCapturedCanvasBackground(rootStyle);
+        return content;
+    }
+
+    /// <summary>
+    /// The canvas background at capture time, per the CSS 2.1 §14.2 propagation model: the root's own
+    /// background when it paints one, else the body's (which propagates to the canvas), else the
+    /// UA default. A root snapshot must be opaque — it stands in for the whole viewport.
+    /// </summary>
+    private string ResolveCapturedCanvasBackground(Dictionary<string, string> rootStyle)
+    {
+        if (PaintsBackground(rootStyle.GetValueOrDefault("background-color")) is { } rootBackground)
+            return rootBackground;
+
+        foreach (var element in DocumentElement.Descendants().OfType<DomElement>())
+        {
+            if (!string.Equals(element.TagName, "body", System.StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (PaintsBackground(UsedStyleForCapture(element).GetValueOrDefault("background-color")) is { } body)
+                return body;
+            break;
+        }
+
+        return "white";
+    }
+
+    /// <summary>The colour when it actually paints, or null when it is absent or fully transparent
+    /// (<c>transparent</c> and the <c>rgba(…, 0)</c> the computed-style engine serializes it as).</summary>
+    private static string? PaintsBackground(string? value)
+    {
+        var trimmed = value?.Trim();
+        if (string.IsNullOrEmpty(trimmed) ||
+            trimmed.Equals("transparent", System.StringComparison.OrdinalIgnoreCase) ||
+            trimmed.Equals("none", System.StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        // rgba(…, 0) / rgb(… / 0) — a fully transparent computed colour paints nothing.
+        var lastComma = trimmed.LastIndexOf(',');
+        if (trimmed.EndsWith(")", System.StringComparison.Ordinal) && lastComma >= 0)
+        {
+            var alpha = trimmed[(lastComma + 1)..].TrimEnd(')').Trim();
+            if (double.TryParse(alpha, System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out var parsed) && parsed == 0)
+                return null;
+        }
+
+        return trimmed;
+    }
+
     /// <summary>Strips identity/capture markers from a cloned snapshot subtree: <c>id</c> (so the
     /// clone does not duplicate a live element's id) and any inline <c>view-transition-name</c> (so a
     /// re-serialize cannot capture the clone as a named element).</summary>
-    private void StripCapturedIdentifiers(DomNode node)
+    private void StripCapturedIdentifiers(DomNode node, bool preserveIds = false)
     {
         if (node is DomElement element)
         {
-            if (element.HasAttribute("id"))
+            if (!preserveIds && element.HasAttribute("id"))
                 element.RemoveAttribute("id");
             InlineStyle(element).Remove("view-transition-name");
         }
 
         foreach (var child in node.ChildNodes.ToArray())
-            StripCapturedIdentifiers(child);
+            StripCapturedIdentifiers(child, preserveIds);
     }
 
     /// <summary>
@@ -845,7 +961,7 @@ public sealed partial class DomBridge
     /// "new" one (the element as it stands now), in old-then-new document order. Names appearing only
     /// on one side keep just that snapshot; the group is placed at the old geometry when present.
     /// </summary>
-    private List<ViewTransitionCapture> CollectViewTransitionCaptures(DomElement root)
+    private List<ViewTransitionCapture> CollectViewTransitionCaptures(DomElement root, bool rootOverlayOccludesPage = false)
     {
         var newCaptures = new Dictionary<string, NamedSnapshot>(System.StringComparer.Ordinal);
         var order = new List<string>();
@@ -861,13 +977,17 @@ public sealed partial class DomBridge
         if (rootName is not null)
         {
             var (l, t, w, h) = GetBoundingClientRectForDomElement(root, isRoot: true);
-            // Only the *old* root snapshot is reproduced by cloning. The new one is left
-            // content-less on purpose: it sits over the live page, which is the same content it
-            // would be reproducing — and the real rendering is exact where a DOM clone is only
-            // close. Cloning it too cost 7 tests between 0.8 and 4 pixel-points, and 79 on
-            // root-to-shared-animation-end, for no test it alone fixed.
+            // The new root snapshot is normally left content-less on purpose: it sits over the live
+            // page, which is the same content it would be reproducing — and the real rendering is
+            // exact where a DOM clone is only close. Cloning it unconditionally cost 7 tests between
+            // 0.8 and 4 pixel-points, and 79 on root-to-shared-animation-end, for no test it alone
+            // fixed. But the live page can only stand in for it while nothing paints in between:
+            // once the author gives `::view-transition` a background, that overlay hides the page
+            // and a content-less snapshot leaves the backdrop colour flooding the viewport (WPT
+            // new-content-captures-root rendered as flat pink). Clone it only in that case.
             AddNew(rootName, new NamedSnapshot(l, t, w, h,
-                rootStyle.GetValueOrDefault("background-color") ?? "transparent"));
+                rootStyle.GetValueOrDefault("background-color") ?? "transparent",
+                rootOverlayOccludesPage ? BuildRootViewTransitionSnapshotContent(rootStyle) : null));
         }
 
         foreach (var element in root.Descendants().OfType<DomElement>())

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ViewTransition.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ViewTransition.cs
@@ -537,8 +537,27 @@ public sealed partial class DomBridge
         {
             // The group animates old→new geometry; the reftests freeze it at the start, so it sits at
             // the old geometry when the element existed before the transition, else the new.
+            var groupDeclarations = LookupPseudo(pseudoRules, "group", capture);
+            var groupLeft = capture.GroupLeft;
+            var groupTop = capture.GroupTop;
             var groupW = capture.HasOld ? capture.OldWidth : capture.NewWidth;
             var groupH = capture.HasOld ? capture.OldHeight : capture.NewHeight;
+
+            // "Frozen at the start" is the animation's output at time 0, which is not always the old
+            // geometry: an author timing function of the `steps(…, jump-start)` family jumps before it
+            // advances, so at t=0 the group is already part-way to the new geometry. WPT auto-name
+            // pins exactly that with `steps(2, start)` — output 1/2 at t=0 — and its reference is the
+            // two items at the midpoint between their old and new positions. Every other timing
+            // function (linear, the eases, cubic-bezier, the jump-end family) is 0 at t=0 and leaves
+            // the group on the old geometry, which is what it has always done.
+            var progress = FrozenGroupProgress(groupDeclarations);
+            if (progress > 0 && capture.HasOld && capture.HasNew)
+            {
+                groupLeft = Interpolate(capture.OldLeft, capture.NewLeft, progress);
+                groupTop = Interpolate(capture.OldTop, capture.NewTop, progress);
+                groupW = Interpolate(capture.OldWidth, capture.NewWidth, progress);
+                groupH = Interpolate(capture.OldHeight, capture.NewHeight, progress);
+            }
             // The captured position is carried by the group's transform — its UA style, per spec, is
             // `position: absolute; inset: 0` with a transform translating to the snapshot's location.
             // Keeping left/top at 0 lets an author `::view-transition-group(name)` rule that sets
@@ -558,10 +577,10 @@ public sealed partial class DomBridge
 
             var group = CreateStyledBox(BaseStyle(
                 ("position", "absolute"), ("left", "0"), ("top", "0"),
-                ("transform", $"translate({Px(capture.GroupLeft)}, {Px(capture.GroupTop)})"),
+                ("transform", $"translate({Px(groupLeft)}, {Px(groupTop)})"),
                 ("width", Px(groupW)), ("height", Px(groupH)),
                 ("overflow", clipsContent ? "hidden" : "visible")),
-                LookupPseudo(pseudoRules, "group", capture));
+                groupDeclarations);
 
             // Between the group and its two snapshots sits ::view-transition-image-pair, the box the
             // spec gives the old/new pair so a rule can address both at once — WPT
@@ -821,6 +840,73 @@ public sealed partial class DomBridge
     }
 
 
+    private static double Interpolate(double from, double to, double progress) =>
+        from + ((to - from) * progress);
+
+    /// <summary>
+    /// The group animation's output at time 0 — the moment the reftests freeze it at. Read from the
+    /// group's <c>animation-timing-function</c>, because an easing function need not be 0 at input 0.
+    /// <para>
+    /// Only the <c>steps()</c> family can be non-zero there. <c>steps(n, jump-start)</c> (and its
+    /// <c>start</c> alias) takes its first jump immediately, so it outputs <c>1/n</c> at input 0;
+    /// <c>jump-both</c> has one extra jump and outputs <c>1/(n+1)</c>; the <c>step-start</c> keyword is
+    /// <c>steps(1, jump-start)</c>, so it is already fully at the new geometry. Everything else — the
+    /// <c>jump-end</c>/<c>end</c>/<c>jump-none</c> steps, <c>linear</c>, the eases,
+    /// <c>cubic-bezier()</c>, and an absent or unparseable value — is 0 at input 0 and leaves the
+    /// group exactly where it has always been placed.
+    /// </para>
+    /// This is a static read of a frozen animation, not a timeline: nothing here advances with time.
+    /// </summary>
+    private static double FrozenGroupProgress(Dictionary<string, string> groupDeclarations)
+    {
+        if (!groupDeclarations.TryGetValue("animation-timing-function", out var raw) ||
+            string.IsNullOrWhiteSpace(raw))
+            return 0;
+
+        // A comma-separated list pairs with animation-name; the group has one animation, so the
+        // first entry governs. Splitting on the top-level comma keeps `steps(2, start)` intact.
+        var value = FirstTopLevelValue(raw).Trim();
+
+        if (value.Equals("step-start", System.StringComparison.OrdinalIgnoreCase))
+            return 1;
+
+        if (!value.StartsWith("steps(", System.StringComparison.OrdinalIgnoreCase) ||
+            !value.EndsWith(")", System.StringComparison.Ordinal))
+            return 0;
+
+        var arguments = value[6..^1].Split(',');
+        if (arguments.Length == 0 ||
+            !int.TryParse(arguments[0].Trim(), System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out var steps) ||
+            steps < 1)
+            return 0;
+
+        var position = arguments.Length > 1 ? arguments[1].Trim() : "end";
+        if (position.Equals("start", System.StringComparison.OrdinalIgnoreCase) ||
+            position.Equals("jump-start", System.StringComparison.OrdinalIgnoreCase))
+            return 1d / steps;
+        if (position.Equals("jump-both", System.StringComparison.OrdinalIgnoreCase))
+            return 1d / (steps + 1);
+
+        return 0;
+    }
+
+    /// <summary>The first entry of a comma-separated CSS value list, ignoring commas nested inside
+    /// functional notation (so <c>steps(2, start)</c> survives as one entry).</summary>
+    private static string FirstTopLevelValue(string value)
+    {
+        var depth = 0;
+        for (var index = 0; index < value.Length; index++)
+        {
+            var character = value[index];
+            if (character == '(') depth++;
+            else if (character == ')') depth--;
+            else if (character == ',' && depth == 0) return value[..index];
+        }
+
+        return value;
+    }
+
     /// <summary>
     /// Whether the author's bare <c>::view-transition</c> declarations paint a backdrop between the
     /// live page and the snapshots above it. While they do not, a root snapshot can stay
@@ -952,9 +1038,12 @@ public sealed partial class DomBridge
 
     private readonly record struct ViewTransitionCapture(
         string Name,
+        // The captured element's `view-transition-class` list, matched by a pseudo argument's
+        // `.class` part (css-view-transitions-2 <pt-class-selector>). Empty when it has none.
+        string Classes,
         double GroupLeft, double GroupTop,
-        bool HasOld, double OldWidth, double OldHeight, string OldBackground, DomElement? OldContent,
-        bool HasNew, double NewWidth, double NewHeight, string NewBackground, DomElement? NewContent);
+        bool HasOld, double OldLeft, double OldTop, double OldWidth, double OldHeight, string OldBackground, DomElement? OldContent,
+        bool HasNew, double NewLeft, double NewTop, double NewWidth, double NewHeight, string NewBackground, DomElement? NewContent);
 
     /// <summary>
     /// The captured names, each pairing the "old" snapshot (from before the update callback) with the
@@ -965,6 +1054,9 @@ public sealed partial class DomBridge
     {
         var newCaptures = new Dictionary<string, NamedSnapshot>(System.StringComparer.Ordinal);
         var order = new List<string>();
+        // `view-transition-class` per captured name, so ::view-transition-group(*.item) can address a
+        // group by class rather than by name (css-view-transitions-2).
+        var classesByName = new Dictionary<string, string>(System.StringComparer.Ordinal);
 
         void AddNew(string name, NamedSnapshot snapshot)
         {
@@ -988,6 +1080,7 @@ public sealed partial class DomBridge
             AddNew(rootName, new NamedSnapshot(l, t, w, h,
                 rootStyle.GetValueOrDefault("background-color") ?? "transparent",
                 rootOverlayOccludesPage ? BuildRootViewTransitionSnapshotContent(rootStyle) : null));
+            classesByName[rootName] = rootStyle.GetValueOrDefault("view-transition-class") ?? string.Empty;
         }
 
         foreach (var element in root.Descendants().OfType<DomElement>())
@@ -1001,6 +1094,7 @@ public sealed partial class DomBridge
             AddNew(name, new NamedSnapshot(l, t, w, h,
                 style.GetValueOrDefault("background-color") ?? "transparent",
                 BuildViewTransitionSnapshotContent(element)));
+            classesByName.TryAdd(name, style.GetValueOrDefault("view-transition-class") ?? string.Empty);
         }
 
         var oldCaptures = _activeViewTransition!.OldCaptures;
@@ -1016,9 +1110,9 @@ public sealed partial class DomBridge
             var hasNew = newCaptures.TryGetValue(name, out var @new);
             var anchor = hasOld ? old : @new; // group start geometry
             captures.Add(new ViewTransitionCapture(
-                name, anchor.Left, anchor.Top,
-                hasOld, old.Width, old.Height, old.BackgroundColor, old.Content,
-                hasNew, @new.Width, @new.Height, @new.BackgroundColor, @new.Content));
+                name, classesByName.GetValueOrDefault(name) ?? string.Empty, anchor.Left, anchor.Top,
+                hasOld, old.Left, old.Top, old.Width, old.Height, old.BackgroundColor, old.Content,
+                hasNew, @new.Left, @new.Top, @new.Width, @new.Height, @new.BackgroundColor, @new.Content));
         }
 
         return captures;
@@ -1166,9 +1260,74 @@ public sealed partial class DomBridge
             return merged;
         }
 
+        // css-view-transitions-2 lets a pseudo argument select by class as well as by name —
+        // `::view-transition-group(*.item)`, and the name-less `.item` shorthand — where the classes
+        // come from the captured element's `view-transition-class`. Merge least-specific first so a
+        // more specific rule wins: `*`, then class-only rules, then the exact name (with or without
+        // classes of its own). WPT auto-name drives its whole transition off `(.item)`.
         Merge("*");
+
+        var classes = SplitViewTransitionClasses(capture.Value.Classes);
+        var prefix = $"{kind}|";
+        foreach (var key in pseudoRules.Keys)
+        {
+            if (!key.StartsWith(prefix, System.StringComparison.Ordinal))
+                continue;
+
+            var argument = key[prefix.Length..];
+            if (argument.Length == 0 || argument == "*" || argument == capture.Value.Name)
+                continue; // handled by the explicit merges around this loop
+
+            var (nameSelector, requiredClasses) = ParsePseudoArgument(argument);
+            if (requiredClasses.Count == 0)
+                continue; // a plain name that is not this capture's
+
+            if (nameSelector is not "*" && !string.Equals(nameSelector, capture.Value.Name, System.StringComparison.Ordinal))
+                continue;
+
+            if (requiredClasses.All(required => classes.Contains(required)))
+                Merge(argument);
+        }
+
         Merge(capture.Value.Name);
         return merged;
+    }
+
+    /// <summary>Splits a <c>view-transition-class</c> value into its idents. <c>none</c> (the initial
+    /// value) contributes nothing.</summary>
+    private static HashSet<string> SplitViewTransitionClasses(string? value)
+    {
+        var classes = new HashSet<string>(System.StringComparer.Ordinal);
+        if (string.IsNullOrWhiteSpace(value))
+            return classes;
+
+        foreach (var token in value.Split((char[]?)null, System.StringSplitOptions.RemoveEmptyEntries))
+            if (!token.Equals("none", System.StringComparison.OrdinalIgnoreCase))
+                classes.Add(token);
+
+        return classes;
+    }
+
+    /// <summary>
+    /// Splits a <c>::view-transition-*()</c> argument into its name selector and class selectors —
+    /// <c>&lt;pt-name-selector&gt;&lt;pt-class-selector&gt;?</c>. A leading <c>.</c> means the name
+    /// selector was omitted, which is the same as <c>*</c>.
+    /// </summary>
+    private static (string Name, List<string> Classes) ParsePseudoArgument(string argument)
+    {
+        var trimmed = argument.Trim();
+        var dot = trimmed.IndexOf('.');
+        if (dot < 0)
+            return (trimmed, []);
+
+        var name = dot == 0 ? "*" : trimmed[..dot];
+        var classes = trimmed[(dot + 1)..]
+            .Split('.', System.StringSplitOptions.RemoveEmptyEntries)
+            .Select(static part => part.Trim())
+            .Where(static part => part.Length > 0)
+            .ToList();
+
+        return (name, classes);
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ViewTransition.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ViewTransition.cs
@@ -184,7 +184,7 @@ public sealed partial class DomBridge
         // skipTransition() ends the transition without animating; the still is already the final
         // state here, so it is a no-op beyond clearing the active state.
         transition.FastAddValue((KeyString)"skipTransition",
-            new JSFunction((in _) => { _activeViewTransition = null; return JSUndefined.Value; }, "skipTransition", 0),
+            new DomFunction((in _) => { _activeViewTransition = null; return JSUndefined.Value; }, "skipTransition", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         return transition;
@@ -210,10 +210,10 @@ public sealed partial class DomBridge
             }
             return thenable;
         }
-        thenable.FastAddValue((KeyString)"then", new JSFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        thenable.FastAddValue((KeyString)"catch", new JSFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue((KeyString)"then", new DomFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue((KeyString)"catch", new DomFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         thenable.FastAddValue((KeyString)"finally",
-            new JSFunction((in a) => { if (a.Length > 0 && a[0] is JSFunction cb) { try { cb.InvokeFunction(new Arguments(cb)); } catch { } } return thenable; }, "finally", 1),
+            new DomFunction((in a) => { if (a.Length > 0 && a[0] is JSFunction cb) { try { cb.InvokeFunction(new Arguments(cb)); } catch { } } return thenable; }, "finally", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         return thenable;
     }
@@ -257,10 +257,10 @@ public sealed partial class DomBridge
             RunAndMaybeFinish(args.Length > 0 ? args[0] as JSFunction : null);
             return thenable;
         }
-        thenable.FastAddValue((KeyString)"then", new JSFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        thenable.FastAddValue((KeyString)"catch", new JSFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue((KeyString)"then", new DomFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue((KeyString)"catch", new DomFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         thenable.FastAddValue((KeyString)"finally",
-            new JSFunction((in a) => { RunAndMaybeFinish(a.Length > 0 ? a[0] as JSFunction : null); return thenable; }, "finally", 1),
+            new DomFunction((in a) => { RunAndMaybeFinish(a.Length > 0 ? a[0] as JSFunction : null); return thenable; }, "finally", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         return thenable;
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.WindowLoad.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.WindowLoad.cs
@@ -185,26 +185,26 @@ public sealed partial class DomBridge
         var legacyCancelBubble = false;
         evt[(KeyString)"defaultPrevented"] = prevented ? JSBoolean.True : JSBoolean.False;
         evt.FastAddValue((KeyString)"stopPropagation",
-            new JSFunction((in _) => JsCallbackStopPropagation001Core(ref legacyCancelBubble, in _), "stopPropagation", 0),
+            new DomFunction((in _) => JsCallbackStopPropagation001Core(ref legacyCancelBubble, in _), "stopPropagation", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         evt.FastAddValue((KeyString)"stopImmediatePropagation",
-            new JSFunction((in _) => JsCallbackStopImmediatePropagation002Core(ref immediateStopped, ref legacyCancelBubble, in _), "stopImmediatePropagation", 0),
+            new DomFunction((in _) => JsCallbackStopImmediatePropagation002Core(ref immediateStopped, ref legacyCancelBubble, in _), "stopImmediatePropagation", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         evt.FastAddValue((KeyString)"preventDefault",
-            new JSFunction((in _) => JsCallbackPreventDefault003Core(currentListenerPassive, evt, ref prevented, in _), "preventDefault", 0),
+            new DomFunction((in _) => JsCallbackPreventDefault003Core(currentListenerPassive, evt, ref prevented, in _), "preventDefault", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         evt.FastAddProperty(
             (KeyString)"cancelBubble",
-            new JSFunction((in _) => legacyCancelBubble ? JSBoolean.True : JSBoolean.False, "get cancelBubble"),
-            new JSFunction((in setArgs) => JsCallbackSetCancelBubble005Core(ref legacyCancelBubble, in setArgs), "set cancelBubble"),
+            new DomFunction((in _) => legacyCancelBubble ? JSBoolean.True : JSBoolean.False, "get cancelBubble"),
+            new DomFunction((in setArgs) => JsCallbackSetCancelBubble005Core(ref legacyCancelBubble, in setArgs), "set cancelBubble"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
         evt.FastAddProperty(
             (KeyString)"returnValue",
-            new JSFunction((in _) => prevented ? JSBoolean.False : JSBoolean.True, "get returnValue"),
-            new JSFunction((in setArgs) => JsCallbackSetReturnValue007Core(currentListenerPassive, evt, ref prevented, in setArgs), "set returnValue"),
+            new DomFunction((in _) => prevented ? JSBoolean.False : JSBoolean.True, "get returnValue"),
+            new DomFunction((in setArgs) => JsCallbackSetReturnValue007Core(currentListenerPassive, evt, ref prevented, in setArgs), "set returnValue"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
         evt.FastAddValue((KeyString)"composedPath",
-            new JSFunction((in _) => new JSArray(_windowJSObject), "composedPath", 0),
+            new DomFunction((in _) => new JSArray(_windowJSObject), "composedPath", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         if (_eventTargets.TryGetWindowListeners(eventType, out var listeners))

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ConstructedStyleSheets.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ConstructedStyleSheets.cs
@@ -57,17 +57,17 @@ public sealed partial class DomBridge
         // disabled — a script flag on the sheet; a disabled adopted sheet does not apply.
         var disabled = false;
         sheet.FastAddProperty((KeyString)"disabled",
-            new JSFunction((in _) => disabled ? JSBoolean.True : JSBoolean.False, "get disabled"),
-            new JSFunction((in a) => { disabled = a.Length > 0 && a[0].BooleanValue; return JSUndefined.Value; }, "set disabled"),
+            new DomFunction((in _) => disabled ? JSBoolean.True : JSBoolean.False, "get disabled"),
+            new DomFunction((in a) => { disabled = a.Length > 0 && a[0].BooleanValue; return JSUndefined.Value; }, "set disabled"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         var liveCssRules = new JSObject();
         var lastSyncedRuleCount = 0;
         liveCssRules.FastAddProperty((KeyString)"length",
-            new JSFunction((in _) => Dom.Features.StyleSheetBinding.JsStyleSheetsGetLength002Core(CurrentRules, in _), "get length"),
+            new DomFunction((in _) => Dom.Features.StyleSheetBinding.JsStyleSheetsGetLength002Core(CurrentRules, in _), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         liveCssRules.FastAddValue((KeyString)"item",
-            new JSFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsItem003Core(SyncLiveCssRulesIndices, liveCssRules, CurrentRules, in a), "item", 1),
+            new DomFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsItem003Core(SyncLiveCssRulesIndices, liveCssRules, CurrentRules, in a), "item", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         void SyncLiveCssRulesIndices()
@@ -83,13 +83,13 @@ public sealed partial class DomBridge
         }
 
         sheet.FastAddProperty((KeyString)"cssRules",
-            new JSFunction((in _) => Dom.Features.StyleSheetBinding.JsStyleSheetsGetCssRules004Core(SyncLiveCssRulesIndices, liveCssRules, in _), "get cssRules"),
+            new DomFunction((in _) => Dom.Features.StyleSheetBinding.JsStyleSheetsGetCssRules004Core(SyncLiveCssRulesIndices, liveCssRules, in _), "get cssRules"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         sheet.FastAddValue((KeyString)"insertRule",
-            new JSFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsInsertRule005Core(CurrentRules, MarkRulesMutated, SyncLiveCssRulesIndices, in a), "insertRule", 2),
+            new DomFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsInsertRule005Core(CurrentRules, MarkRulesMutated, SyncLiveCssRulesIndices, in a), "insertRule", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
         sheet.FastAddValue((KeyString)"deleteRule",
-            new JSFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsDeleteRule006Core(CurrentRules, MarkRulesMutated, SyncLiveCssRulesIndices, in a), "deleteRule", 1),
+            new DomFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsDeleteRule006Core(CurrentRules, MarkRulesMutated, SyncLiveCssRulesIndices, in a), "deleteRule", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // replaceSync(text) — replace all rules from a CSS string (any @import is dropped per
@@ -107,10 +107,10 @@ public sealed partial class DomBridge
         }
 
         sheet.FastAddValue((KeyString)"replaceSync",
-            new JSFunction((in a) => { ReplaceFromText(a.Length > 0 ? a[0].ToString() : string.Empty); return JSUndefined.Value; }, "replaceSync", 1),
+            new DomFunction((in a) => { ReplaceFromText(a.Length > 0 ? a[0].ToString() : string.Empty); return JSUndefined.Value; }, "replaceSync", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         sheet.FastAddValue((KeyString)"replace",
-            new JSFunction((in a) => { ReplaceFromText(a.Length > 0 ? a[0].ToString() : string.Empty); return ResolvedThenableWith(sheet); }, "replace", 1),
+            new DomFunction((in a) => { ReplaceFromText(a.Length > 0 ? a[0].ToString() : string.Empty); return ResolvedThenableWith(sheet); }, "replace", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         return sheet;
@@ -130,10 +130,10 @@ public sealed partial class DomBridge
             }
             return thenable;
         }
-        thenable.FastAddValue((KeyString)"then", new JSFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        thenable.FastAddValue((KeyString)"catch", new JSFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue((KeyString)"then", new DomFunction(Then, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        thenable.FastAddValue((KeyString)"catch", new DomFunction((in _) => thenable, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         thenable.FastAddValue((KeyString)"finally",
-            new JSFunction((in a) => { if (a.Length > 0 && a[0] is JSFunction cb) { try { cb.InvokeFunction(new Arguments(cb)); } catch { } } return thenable; }, "finally", 1),
+            new DomFunction((in a) => { if (a.Length > 0 && a[0] is JSFunction cb) { try { cb.InvokeFunction(new Arguments(cb)); } catch { } } return thenable; }, "finally", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         return thenable;
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/DomFunction.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/DomFunction.cs
@@ -1,0 +1,44 @@
+using Broiler.JavaScript.Ast.Misc;
+using Broiler.JavaScript.BuiltIns.Function;
+using Broiler.JavaScript.Runtime;
+
+namespace Broiler.HtmlBridge;
+
+/// <summary>
+/// A native DOM callable — a WebIDL operation (<c>appendChild</c>, <c>setAttribute</c>, …) or an
+/// attribute accessor (<c>get id</c>, <c>set textContent</c>, …) — installed on a node's JS wrapper.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Identical to <see cref="JSFunction"/> except that it is built with <c>createPrototype: false</c>,
+/// so it carries no <c>prototype</c> object. That is what WebIDL requires: only interface objects
+/// are constructors, while operations and attribute accessors are ordinary non-constructor
+/// functions — <c>el.setAttribute.prototype</c> is <c>undefined</c> and <c>new el.setAttribute()</c>
+/// throws a TypeError. The engine's own builtins already register their members this way
+/// (<c>BuiltInsAssemblyInitializer</c> passes <c>createPrototype: false</c> throughout); the DOM
+/// bridge did not, so every wrapper member also minted a throwaway prototype object.
+/// </para>
+/// <para>
+/// That mattered because a node's wrapper is built eagerly and per node: an element gets ~149 own
+/// members, each of which allocated a <see cref="JSFunction"/> <em>plus</em> a second
+/// <see cref="JSObject"/> for its unreachable <c>prototype</c> plus that object's
+/// <c>constructor</c> back-reference. Dropping the prototype roughly halves the retained cost of a
+/// wrapper — the difference between a document of 10k script-created elements fitting in the WPT
+/// per-test memory budget and being aborted (<c>css/css-variables/url-syntax-crash.html</c>).
+/// </para>
+/// <para>
+/// Use this for anything installed on a node, declaration, or collection wrapper. Interface objects
+/// that JS may legitimately <c>new</c> (<c>URL</c>, <c>Response</c>, <c>Headers</c>, … — registered
+/// in <c>DomBridge/Registration/</c> and <c>Features/FetchBinding.cs</c>) must keep using
+/// <see cref="JSFunction"/>, because <c>createPrototype: false</c> also makes a function
+/// non-constructable (<c>JSConstructorOperations.IsConstructor</c> tests
+/// <c>prototype != null || IsConstructable</c>).
+/// </para>
+/// </remarks>
+internal sealed class DomFunction : JSFunction
+{
+    internal DomFunction(JSFunctionDelegate f, in StringSpan name, int length = 0)
+        : base(f, in name, StringSpan.Empty, length, createPrototype: false)
+    {
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementInterfaces.cs
@@ -51,15 +51,15 @@ public sealed partial class DomBridge
         // HTMLLabelElement — htmlFor property (maps to 'for' content attribute)
         if (tag == "label")
         {
-            obj.FastAddProperty((KeyString)"htmlFor", new JSFunction((in _) => TryGetAttribute(element, "for", out var f) ? new JSString(f) : new JSString(string.Empty), "get htmlFor"),
-                new JSFunction((in a) => Dom.Features.ElementReflectionBinding.SetHtmlFor(element, in a), "set htmlFor"), JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddProperty((KeyString)"htmlFor", new DomFunction((in _) => TryGetAttribute(element, "for", out var f) ? new JSString(f) : new JSString(string.Empty), "get htmlFor"),
+                new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetHtmlFor(element, in a), "set htmlFor"), JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
         // HTMLMetaElement — httpEquiv property (maps to 'http-equiv' content attribute)
         if (tag == "meta")
         {
-            obj.FastAddProperty((KeyString)"httpEquiv", new JSFunction((in _) => TryGetAttribute(element, "http-equiv", out var he) ? new JSString(he) : new JSString(string.Empty), "get httpEquiv"),
-                new JSFunction((in a) => Dom.Features.ElementReflectionBinding.SetHttpEquiv(element, in a), "set httpEquiv"), JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddProperty((KeyString)"httpEquiv", new DomFunction((in _) => TryGetAttribute(element, "http-equiv", out var he) ? new JSString(he) : new JSString(string.Empty), "get httpEquiv"),
+                new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetHttpEquiv(element, in a), "set httpEquiv"), JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
         // HTMLObjectElement — data property with URI resolution + contentDocument + getSVGDocument + type
@@ -69,26 +69,26 @@ public sealed partial class DomBridge
             // setter, contentDocument getter and getSVGDocument() are sub-document-coupled and live in the
             // ObjectElementBinding feature module (Phase 3 P3.52).
             obj.FastAddProperty((KeyString)"data",
-                new JSFunction((in _) => Dom.Features.ElementReflectionBinding.GetData(this, element, in _), "get data"),
-                new JSFunction((in a) => Dom.Features.ObjectElementBinding.SetData(this, element, in a), "set data"),
+                new DomFunction((in _) => Dom.Features.ElementReflectionBinding.GetData(this, element, in _), "get data"),
+                new DomFunction((in a) => Dom.Features.ObjectElementBinding.SetData(this, element, in a), "set data"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
 
             // type property (MIME type of the resource)
             obj.FastAddProperty((KeyString)"type",
-                new JSFunction((in _) => TryGetAttribute(element, "type", out var t) ? new JSString(t) : new JSString(string.Empty), "get type"),
-                new JSFunction((in a) => Dom.Features.ElementReflectionBinding.SetType(element, in a), "set type"),
+                new DomFunction((in _) => TryGetAttribute(element, "type", out var t) ? new JSString(t) : new JSString(string.Empty), "get type"),
+                new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetType(element, in a), "set type"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
 
             // contentDocument for <object> element (with same-origin check)
             // Returns null when the resource fails to load (HTTP 404, file not found, etc.)
             // which signals that the fallback content (child nodes) should be visible.
             obj.FastAddProperty((KeyString)"contentDocument",
-                new JSFunction((in _) => Dom.Features.ObjectElementBinding.GetContentDocument(this, element, in _), "get contentDocument"),
+                new DomFunction((in _) => Dom.Features.ObjectElementBinding.GetContentDocument(this, element, in _), "get contentDocument"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
             // getSVGDocument() for <object> element
             obj.FastAddValue((KeyString)"getSVGDocument",
-                new JSFunction((in _) => Dom.Features.ObjectElementBinding.GetSvgDocument(this, element, in _), "getSVGDocument", 0),
+                new DomFunction((in _) => Dom.Features.ObjectElementBinding.GetSvgDocument(this, element, in _), "getSVGDocument", 0),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
@@ -96,8 +96,8 @@ public sealed partial class DomBridge
         if (tag == "a")
         {
             obj.FastAddProperty((KeyString)"href",
-                new JSFunction((in _) => Dom.Features.ElementReflectionBinding.GetHref(this, element, in _), "get href"),
-                new JSFunction((in a) => Dom.Features.ElementReflectionBinding.SetHref(element, in a), "set href"),
+                new DomFunction((in _) => Dom.Features.ElementReflectionBinding.GetHref(this, element, in _), "get href"),
+                new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetHref(element, in a), "set href"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
@@ -109,15 +109,15 @@ public sealed partial class DomBridge
             {
                 var captured = attrName; // capture for closure
                 obj.FastAddProperty((KeyString)captured,
-                    new JSFunction((in _) => TryGetAttribute(element, captured, out var v) ? new JSString(v) : new JSString(string.Empty), "get " + captured),
-                    new JSFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedAttribute(captured, element, in a), "set " + captured),
+                    new DomFunction((in _) => TryGetAttribute(element, captured, out var v) ? new JSString(v) : new JSString(string.Empty), "get " + captured),
+                    new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedAttribute(captured, element, in a), "set " + captured),
                     JSPropertyAttributes.EnumerableConfigurableProperty);
             }
 
             // href — with URI resolution like <a>
             obj.FastAddProperty((KeyString)"href",
-                new JSFunction((in _) => Dom.Features.ElementReflectionBinding.GetHref(this, element, in _), "get href"),
-                new JSFunction((in a) => Dom.Features.ElementReflectionBinding.SetHref(element, in a), "set href"),
+                new DomFunction((in _) => Dom.Features.ElementReflectionBinding.GetHref(this, element, in _), "get href"),
+                new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetHref(element, in a), "set href"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
@@ -132,8 +132,8 @@ public sealed partial class DomBridge
             // fresh load event (HTML §4.2.4) — the shape UIEvent.load.stylesheet waits on.
             var isLink = tag == "link";
             obj.FastAddProperty((KeyString)"href",
-                new JSFunction((in _) => Dom.Features.ElementReflectionBinding.GetHref(this, element, in _), "get href"),
-                new JSFunction((in a) =>
+                new DomFunction((in _) => Dom.Features.ElementReflectionBinding.GetHref(this, element, in _), "get href"),
+                new DomFunction((in a) =>
                 {
                     var result = Dom.Features.ElementReflectionBinding.SetHref(element, in a);
                     if (isLink)
@@ -153,8 +153,8 @@ public sealed partial class DomBridge
                 var captured = attrName; // capture for closure
                 var firesLoad = captured == "rel";
                 obj.FastAddProperty((KeyString)idlName,
-                    new JSFunction((in _) => TryGetAttribute(element, captured, out var v) ? new JSString(v) : new JSString(string.Empty), "get " + idlName),
-                    new JSFunction((in a) =>
+                    new DomFunction((in _) => TryGetAttribute(element, captured, out var v) ? new JSString(v) : new JSString(string.Empty), "get " + idlName),
+                    new DomFunction((in a) =>
                     {
                         var result = Dom.Features.ElementReflectionBinding.SetReflectedAttribute(captured, element, in a);
                         if (firesLoad)
@@ -174,8 +174,8 @@ public sealed partial class DomBridge
             {
                 var dimName = dim;
                 obj.FastAddProperty((KeyString)dimName,
-                    new JSFunction((in _) => Dom.Features.ComputedStyleBinding.GetUsedDimension(this, dimName, element, in _), "get " + dimName),
-                    new JSFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedDimension(dimName, element, in a), "set " + dimName),
+                    new DomFunction((in _) => Dom.Features.ComputedStyleBinding.GetUsedDimension(this, dimName, element, in _), "get " + dimName),
+                    new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedDimension(dimName, element, in a), "set " + dimName),
                     JSPropertyAttributes.EnumerableConfigurableProperty);
             }
         }
@@ -191,9 +191,9 @@ public sealed partial class DomBridge
             {
                 var dimName = dim;
                 obj.FastAddProperty((KeyString)dimName,
-                    new JSFunction((in _) => new JSString(
+                    new DomFunction((in _) => new JSString(
                         TryGetAttribute(element, dimName, out var v) ? v : string.Empty), "get " + dimName),
-                    new JSFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedDimension(dimName, element, in a), "set " + dimName),
+                    new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedDimension(dimName, element, in a), "set " + dimName),
                     JSPropertyAttributes.EnumerableConfigurableProperty);
             }
         }
@@ -208,7 +208,7 @@ public sealed partial class DomBridge
         // Web Animations: element.animate(keyframes, options) bakes the animation's snapshot-time
         // value so animation-driven property changes render (see DomBridge.WebAnimations).
         obj.FastAddValue((KeyString)"animate",
-            new JSFunction((in a) => ElementAnimate(element, in a), "animate", 2),
+            new DomFunction((in a) => ElementAnimate(element, in a), "animate", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // SVG DOM interfaces — SVGAnimatedLength/Rect stubs, SVGTextContentElement text metrics, the

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.NonElementNodes.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.NonElementNodes.cs
@@ -38,171 +38,171 @@ public sealed partial class DomBridge
 
         // -- Node identity --
         obj.FastAddProperty((KeyString)"nodeType",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeType(node, in a), "get nodeType"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeType(node, in a), "get nodeType"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"nodeName",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeName(node, in a), "get nodeName"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeName(node, in a), "get nodeName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"localName",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLocalName(node, in a), "get localName"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLocalName(node, in a), "get localName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"prefix",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPrefix(node, in a), "get prefix"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPrefix(node, in a), "get prefix"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"namespaceURI",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNamespaceURI(node, in a), "get namespaceURI"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNamespaceURI(node, in a), "get namespaceURI"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // -- Character data --
         obj.FastAddProperty((KeyString)"nodeValue",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeValue(node, in a), "get nodeValue"),
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.SetNodeValue(this, node, in a), "set nodeValue"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeValue(node, in a), "get nodeValue"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.SetNodeValue(this, node, in a), "set nodeValue"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"textContent",
-            new JSFunction((in _) => GetNodeTextValue(node), "get textContent"),
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.SetNodeValue(this, node, in a), "set textContent"),
+            new DomFunction((in _) => GetNodeTextValue(node), "get textContent"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.SetNodeValue(this, node, in a), "set textContent"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"data",
-            new JSFunction((in a) => Dom.Features.CharacterDataBinding.GetData(node, in a), "get data"),
-            new JSFunction((in a) => Dom.Features.CharacterDataBinding.SetData(this, node, in a), "set data"),
+            new DomFunction((in a) => Dom.Features.CharacterDataBinding.GetData(node, in a), "get data"),
+            new DomFunction((in a) => Dom.Features.CharacterDataBinding.SetData(this, node, in a), "set data"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"length",
-            new JSFunction((in a) => Dom.Features.CharacterDataBinding.GetLength(node, in a), "get length"),
+            new DomFunction((in a) => Dom.Features.CharacterDataBinding.GetLength(node, in a), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // splitText is Text-only (not on Comment).
         if (IsText(node))
         {
             obj.FastAddValue((KeyString)"splitText",
-                new JSFunction((in a) => Dom.Features.CharacterDataBinding.SplitText(this, node, in a), "splitText", 1),
+                new DomFunction((in a) => Dom.Features.CharacterDataBinding.SplitText(this, node, in a), "splitText", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
         obj.FastAddValue((KeyString)"substringData",
-            new JSFunction((in a) => Dom.Features.CharacterDataBinding.SubstringData(node, in a), "substringData", 2),
+            new DomFunction((in a) => Dom.Features.CharacterDataBinding.SubstringData(node, in a), "substringData", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"appendData",
-            new JSFunction((in a) => Dom.Features.CharacterDataBinding.AppendData(this, node, in a), "appendData", 1),
+            new DomFunction((in a) => Dom.Features.CharacterDataBinding.AppendData(this, node, in a), "appendData", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"deleteData",
-            new JSFunction((in a) => Dom.Features.CharacterDataBinding.DeleteData(this, node, in a), "deleteData", 2),
+            new DomFunction((in a) => Dom.Features.CharacterDataBinding.DeleteData(this, node, in a), "deleteData", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"insertData",
-            new JSFunction((in a) => Dom.Features.CharacterDataBinding.InsertData(this, node, in a), "insertData", 2),
+            new DomFunction((in a) => Dom.Features.CharacterDataBinding.InsertData(this, node, in a), "insertData", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"replaceData",
-            new JSFunction((in a) => Dom.Features.CharacterDataBinding.ReplaceData(this, node, in a), "replaceData", 3),
+            new DomFunction((in a) => Dom.Features.CharacterDataBinding.ReplaceData(this, node, in a), "replaceData", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- Tree navigation --
         obj.FastAddProperty((KeyString)"parentNode",
-            new JSFunction((in a) => node.ParentNode != null ? ToJSObject(node.ParentNode) : JSNull.Value, "get parentNode"),
+            new DomFunction((in a) => node.ParentNode != null ? ToJSObject(node.ParentNode) : JSNull.Value, "get parentNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"parentElement",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetParentElement(this, node, in a), "get parentElement"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetParentElement(this, node, in a), "get parentElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"isConnected",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetIsConnected(this, node, in a), "get isConnected"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetIsConnected(this, node, in a), "get isConnected"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"childNodes",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetChildNodes(this, node, in a), "get childNodes"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetChildNodes(this, node, in a), "get childNodes"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"firstChild",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetFirstChild(this, node, in a), "get firstChild"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetFirstChild(this, node, in a), "get firstChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"lastChild",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLastChild(this, node, in a), "get lastChild"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLastChild(this, node, in a), "get lastChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"nextSibling",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNextSibling(this, node, in a), "get nextSibling"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNextSibling(this, node, in a), "get nextSibling"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"previousSibling",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPreviousSibling(this, node, in a), "get previousSibling"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPreviousSibling(this, node, in a), "get previousSibling"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"ownerDocument",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetOwnerDocument(this, node, in a), "get ownerDocument"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetOwnerDocument(this, node, in a), "get ownerDocument"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddValue((KeyString)"hasChildNodes",
-            new JSFunction((in a) => node.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasChildNodes", 0),
+            new DomFunction((in a) => node.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasChildNodes", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- Node methods --
         obj.FastAddValue((KeyString)"cloneNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.CloneNode(this, node, in a), "cloneNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CloneNode(this, node, in a), "cloneNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"contains",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.Contains(this, node, in a), "contains", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.Contains(this, node, in a), "contains", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"compareDocumentPosition",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.CompareDocumentPosition(this, node, in a), "compareDocumentPosition", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CompareDocumentPosition(this, node, in a), "compareDocumentPosition", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"isSameNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsSameNode(this, node, in a), "isSameNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsSameNode(this, node, in a), "isSameNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"isEqualNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsEqualNode(this, node, in a), "isEqualNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsEqualNode(this, node, in a), "isEqualNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"getRootNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.GetRootNode(this, node, in a), "getRootNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.GetRootNode(this, node, in a), "getRootNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"normalize",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.Normalize(this, node, in a), "normalize", 0),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.Normalize(this, node, in a), "normalize", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- ChildNode mixin --
         obj.FastAddValue((KeyString)"remove",
-            new JSFunction((in a) => Dom.Features.ChildNodeBinding.Remove(this, node, in a), "remove", 0),
+            new DomFunction((in a) => Dom.Features.ChildNodeBinding.Remove(this, node, in a), "remove", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"before",
-            new JSFunction((in a) => Dom.Features.ChildNodeBinding.Before(this, node, in a), "before", 0),
+            new DomFunction((in a) => Dom.Features.ChildNodeBinding.Before(this, node, in a), "before", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"after",
-            new JSFunction((in a) => Dom.Features.ChildNodeBinding.After(this, node, in a), "after", 0),
+            new DomFunction((in a) => Dom.Features.ChildNodeBinding.After(this, node, in a), "after", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"replaceWith",
-            new JSFunction((in a) => Dom.Features.ChildNodeBinding.ReplaceWith(this, node, in a), "replaceWith", 0),
+            new DomFunction((in a) => Dom.Features.ChildNodeBinding.ReplaceWith(this, node, in a), "replaceWith", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- EventTarget --
         obj.FastAddValue((KeyString)"addEventListener",
-            new JSFunction((in a) => Dom.Features.EventTargetBinding.AddEventListener(this, node, in a), "addEventListener", 3),
+            new DomFunction((in a) => Dom.Features.EventTargetBinding.AddEventListener(this, node, in a), "addEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"removeEventListener",
-            new JSFunction((in a) => Dom.Features.EventTargetBinding.RemoveEventListener(this, node, in a), "removeEventListener", 3),
+            new DomFunction((in a) => Dom.Features.EventTargetBinding.RemoveEventListener(this, node, in a), "removeEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"dispatchEvent",
-            new JSFunction((in a) => Dom.Features.EventTargetBinding.DispatchEvent(this, node, in a), "dispatchEvent", 1),
+            new DomFunction((in a) => Dom.Features.EventTargetBinding.DispatchEvent(this, node, in a), "dispatchEvent", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Node type constants (exist on all Node objects).
@@ -231,32 +231,32 @@ public sealed partial class DomBridge
 
         // -- Node identity --
         obj.FastAddProperty((KeyString)"nodeType",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeType(node, in a), "get nodeType"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeType(node, in a), "get nodeType"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"nodeName",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeName(node, in a), "get nodeName"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeName(node, in a), "get nodeName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"nodeValue",
-            new JSFunction((in _) => JSNull.Value, "get nodeValue"),
+            new DomFunction((in _) => JSNull.Value, "get nodeValue"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"textContent",
-            new JSFunction((in _) => JSNull.Value, "get textContent"),
+            new DomFunction((in _) => JSNull.Value, "get textContent"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // -- DocumentType interface --
         obj.FastAddProperty((KeyString)"name",
-            new JSFunction((in _) => new JSString(doctype.Name), "get name"),
+            new DomFunction((in _) => new JSString(doctype.Name), "get name"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"publicId",
-            new JSFunction((in _) => Dom.Features.NodeAccessorsBinding.GetPublicId(node, in _), "get publicId"),
+            new DomFunction((in _) => Dom.Features.NodeAccessorsBinding.GetPublicId(node, in _), "get publicId"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"systemId",
-            new JSFunction((in _) => Dom.Features.NodeAccessorsBinding.GetSystemId(node, in _), "get systemId"),
+            new DomFunction((in _) => Dom.Features.NodeAccessorsBinding.GetSystemId(node, in _), "get systemId"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"internalSubset",
@@ -265,86 +265,86 @@ public sealed partial class DomBridge
 
         // -- Tree navigation --
         obj.FastAddProperty((KeyString)"parentNode",
-            new JSFunction((in a) => node.ParentNode != null ? ToJSObject(node.ParentNode) : JSNull.Value, "get parentNode"),
+            new DomFunction((in a) => node.ParentNode != null ? ToJSObject(node.ParentNode) : JSNull.Value, "get parentNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"parentElement",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetParentElement(this, node, in a), "get parentElement"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetParentElement(this, node, in a), "get parentElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"previousSibling",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPreviousSibling(this, node, in a), "get previousSibling"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPreviousSibling(this, node, in a), "get previousSibling"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"nextSibling",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNextSibling(this, node, in a), "get nextSibling"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNextSibling(this, node, in a), "get nextSibling"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"ownerDocument",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetOwnerDocument(this, node, in a), "get ownerDocument"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetOwnerDocument(this, node, in a), "get ownerDocument"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"isConnected",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetIsConnected(this, node, in a), "get isConnected"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetIsConnected(this, node, in a), "get isConnected"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddValue((KeyString)"hasChildNodes",
-            new JSFunction((in a) => JSBoolean.False, "hasChildNodes", 0),
+            new DomFunction((in a) => JSBoolean.False, "hasChildNodes", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- Node methods --
         obj.FastAddValue((KeyString)"cloneNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.CloneNode(this, node, in a), "cloneNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CloneNode(this, node, in a), "cloneNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"isEqualNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsEqualNode(this, node, in a), "isEqualNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsEqualNode(this, node, in a), "isEqualNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"isSameNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsSameNode(this, node, in a), "isSameNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsSameNode(this, node, in a), "isSameNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"contains",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.Contains(this, node, in a), "contains", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.Contains(this, node, in a), "contains", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"compareDocumentPosition",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.CompareDocumentPosition(this, node, in a), "compareDocumentPosition", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CompareDocumentPosition(this, node, in a), "compareDocumentPosition", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"getRootNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.GetRootNode(this, node, in a), "getRootNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.GetRootNode(this, node, in a), "getRootNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- ChildNode mixin --
         obj.FastAddValue((KeyString)"remove",
-            new JSFunction((in a) => Dom.Features.ChildNodeBinding.Remove(this, node, in a), "remove", 0),
+            new DomFunction((in a) => Dom.Features.ChildNodeBinding.Remove(this, node, in a), "remove", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"before",
-            new JSFunction((in a) => Dom.Features.ChildNodeBinding.Before(this, node, in a), "before", 0),
+            new DomFunction((in a) => Dom.Features.ChildNodeBinding.Before(this, node, in a), "before", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"after",
-            new JSFunction((in a) => Dom.Features.ChildNodeBinding.After(this, node, in a), "after", 0),
+            new DomFunction((in a) => Dom.Features.ChildNodeBinding.After(this, node, in a), "after", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"replaceWith",
-            new JSFunction((in a) => Dom.Features.ChildNodeBinding.ReplaceWith(this, node, in a), "replaceWith", 0),
+            new DomFunction((in a) => Dom.Features.ChildNodeBinding.ReplaceWith(this, node, in a), "replaceWith", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- EventTarget --
         obj.FastAddValue((KeyString)"addEventListener",
-            new JSFunction((in a) => Dom.Features.EventTargetBinding.AddEventListener(this, node, in a), "addEventListener", 3),
+            new DomFunction((in a) => Dom.Features.EventTargetBinding.AddEventListener(this, node, in a), "addEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"removeEventListener",
-            new JSFunction((in a) => Dom.Features.EventTargetBinding.RemoveEventListener(this, node, in a), "removeEventListener", 3),
+            new DomFunction((in a) => Dom.Features.EventTargetBinding.RemoveEventListener(this, node, in a), "removeEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"dispatchEvent",
-            new JSFunction((in a) => Dom.Features.EventTargetBinding.DispatchEvent(this, node, in a), "dispatchEvent", 1),
+            new DomFunction((in a) => Dom.Features.EventTargetBinding.DispatchEvent(this, node, in a), "dispatchEvent", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Node type constants (exist on all Node objects).
@@ -374,57 +374,57 @@ public sealed partial class DomBridge
 
         // -- Node identity --
         obj.FastAddProperty((KeyString)"nodeType",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeType(node, in a), "get nodeType"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeType(node, in a), "get nodeType"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddProperty((KeyString)"nodeName",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeName(node, in a), "get nodeName"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeName(node, in a), "get nodeName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddProperty((KeyString)"nodeValue",
-            new JSFunction((in _) => JSNull.Value, "get nodeValue"),
+            new DomFunction((in _) => JSNull.Value, "get nodeValue"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddProperty((KeyString)"ownerDocument",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetOwnerDocument(this, node, in a), "get ownerDocument"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetOwnerDocument(this, node, in a), "get ownerDocument"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // -- Tree navigation --
         obj.FastAddProperty((KeyString)"parentNode",
-            new JSFunction((in _) => node.ParentNode != null ? ToJSObject(node.ParentNode) : JSNull.Value, "get parentNode"),
+            new DomFunction((in _) => node.ParentNode != null ? ToJSObject(node.ParentNode) : JSNull.Value, "get parentNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddProperty((KeyString)"parentElement",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetParentElement(this, node, in a), "get parentElement"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetParentElement(this, node, in a), "get parentElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddProperty((KeyString)"childNodes",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetChildNodes(this, node, in a), "get childNodes"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetChildNodes(this, node, in a), "get childNodes"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddProperty((KeyString)"firstChild",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetFirstChild(this, node, in a), "get firstChild"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetFirstChild(this, node, in a), "get firstChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddProperty((KeyString)"lastChild",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLastChild(this, node, in a), "get lastChild"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLastChild(this, node, in a), "get lastChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddProperty((KeyString)"isConnected",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetIsConnected(this, node, in a), "get isConnected"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetIsConnected(this, node, in a), "get isConnected"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddValue((KeyString)"hasChildNodes",
-            new JSFunction((in a) => fragment.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasChildNodes", 0),
+            new DomFunction((in a) => fragment.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasChildNodes", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- ParentNode mixin (element views) --
         obj.FastAddProperty((KeyString)"children",
-            new JSFunction((in _) => new JSArray([.. ChildElements(fragment).Where(c => !IsText(c)).Select(c => (JSValue)ToJSObject(c))]), "get children"),
+            new DomFunction((in _) => new JSArray([.. ChildElements(fragment).Where(c => !IsText(c)).Select(c => (JSValue)ToJSObject(c))]), "get children"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddProperty((KeyString)"childElementCount",
-            new JSFunction((in _) => new JSNumber(ChildElements(fragment).Count(c => !IsText(c))), "get childElementCount"),
+            new DomFunction((in _) => new JSNumber(ChildElements(fragment).Count(c => !IsText(c))), "get childElementCount"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddProperty((KeyString)"firstElementChild",
-            new JSFunction((in _) =>
+            new DomFunction((in _) =>
             {
                 var first = ChildElements(fragment).FirstOrDefault(c => !IsText(c));
                 return first != null ? ToJSObject(first) : JSNull.Value;
             }, "get firstElementChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         obj.FastAddProperty((KeyString)"lastElementChild",
-            new JSFunction((in _) =>
+            new DomFunction((in _) =>
             {
                 var last = ChildElements(fragment).LastOrDefault(c => !IsText(c));
                 return last != null ? ToJSObject(last) : JSNull.Value;
@@ -433,8 +433,8 @@ public sealed partial class DomBridge
 
         // -- textContent (get/set) --
         obj.FastAddProperty((KeyString)"textContent",
-            new JSFunction((in _) => GetNodeTextValue(node), "get textContent"),
-            new JSFunction((in a) =>
+            new DomFunction((in _) => GetNodeTextValue(node), "get textContent"),
+            new DomFunction((in a) =>
             {
                 ClearChildren(fragment);
                 var value = a.Length > 0 ? a[0].ToString() : string.Empty;
@@ -446,7 +446,7 @@ public sealed partial class DomBridge
 
         // -- Child manipulation --
         obj.FastAddValue((KeyString)"appendChild",
-            new JSFunction((in a) =>
+            new DomFunction((in a) =>
             {
                 if (a.Length == 0 || a[0] is not JSObject childObj)
                     return JSUndefined.Value;
@@ -460,7 +460,7 @@ public sealed partial class DomBridge
             }, "appendChild", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"insertBefore",
-            new JSFunction((in a) =>
+            new DomFunction((in a) =>
             {
                 if (a.Length == 0 || a[0] is not JSObject newChildObj)
                     return JSUndefined.Value;
@@ -487,7 +487,7 @@ public sealed partial class DomBridge
             }, "insertBefore", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"removeChild",
-            new JSFunction((in a) =>
+            new DomFunction((in a) =>
             {
                 if (a.Length == 0 || a[0] is not JSObject childObj)
                     return JSUndefined.Value;
@@ -504,7 +504,7 @@ public sealed partial class DomBridge
             }, "removeChild", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"replaceChild",
-            new JSFunction((in a) =>
+            new DomFunction((in a) =>
             {
                 if (a.Length < 2 || a[0] is not JSObject newObj || a[1] is not JSObject oldObj)
                     return JSUndefined.Value;
@@ -521,7 +521,7 @@ public sealed partial class DomBridge
             }, "replaceChild", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"append",
-            new JSFunction((in a) =>
+            new DomFunction((in a) =>
             {
                 if (a.Length == 0)
                     return JSUndefined.Value;
@@ -533,7 +533,7 @@ public sealed partial class DomBridge
             }, "append", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"prepend",
-            new JSFunction((in a) =>
+            new DomFunction((in a) =>
             {
                 if (a.Length == 0)
                     return JSUndefined.Value;
@@ -547,44 +547,44 @@ public sealed partial class DomBridge
 
         // -- Query --
         obj.FastAddValue((KeyString)"querySelector",
-            new JSFunction((in a) => FindInDescendants(fragment, a.Length > 0 ? a[0].ToString() : string.Empty, false, bridge), "querySelector", 1),
+            new DomFunction((in a) => FindInDescendants(fragment, a.Length > 0 ? a[0].ToString() : string.Empty, false, bridge), "querySelector", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"querySelectorAll",
-            new JSFunction((in a) => FindInDescendants(fragment, a.Length > 0 ? a[0].ToString() : string.Empty, true, bridge), "querySelectorAll", 1),
+            new DomFunction((in a) => FindInDescendants(fragment, a.Length > 0 ? a[0].ToString() : string.Empty, true, bridge), "querySelectorAll", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- Node methods --
         obj.FastAddValue((KeyString)"cloneNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.CloneNode(this, node, in a), "cloneNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CloneNode(this, node, in a), "cloneNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"isEqualNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsEqualNode(this, node, in a), "isEqualNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsEqualNode(this, node, in a), "isEqualNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"isSameNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsSameNode(this, node, in a), "isSameNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsSameNode(this, node, in a), "isSameNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"contains",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.Contains(this, node, in a), "contains", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.Contains(this, node, in a), "contains", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"compareDocumentPosition",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.CompareDocumentPosition(this, node, in a), "compareDocumentPosition", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CompareDocumentPosition(this, node, in a), "compareDocumentPosition", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"getRootNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.GetRootNode(this, node, in a), "getRootNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.GetRootNode(this, node, in a), "getRootNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"normalize",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.Normalize(this, node, in a), "normalize", 0),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.Normalize(this, node, in a), "normalize", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- EventTarget --
         obj.FastAddValue((KeyString)"addEventListener",
-            new JSFunction((in a) => Dom.Features.EventTargetBinding.AddEventListener(this, node, in a), "addEventListener", 3),
+            new DomFunction((in a) => Dom.Features.EventTargetBinding.AddEventListener(this, node, in a), "addEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"removeEventListener",
-            new JSFunction((in a) => Dom.Features.EventTargetBinding.RemoveEventListener(this, node, in a), "removeEventListener", 3),
+            new DomFunction((in a) => Dom.Features.EventTargetBinding.RemoveEventListener(this, node, in a), "removeEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
         obj.FastAddValue((KeyString)"dispatchEvent",
-            new JSFunction((in a) => Dom.Features.EventTargetBinding.DispatchEvent(this, node, in a), "dispatchEvent", 1),
+            new DomFunction((in a) => Dom.Features.EventTargetBinding.DispatchEvent(this, node, in a), "dispatchEvent", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Node type constants (exist on all Node objects).

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -96,7 +96,7 @@ public sealed partial class DomBridge
         // shadowRoot (read-only) — Phase 3 P3.62: co-located ShadowDomBinding feature module, reached
         // through IShadowDomHost (DomBridge.ShadowDomHost.cs).
         obj.FastAddProperty((KeyString)"shadowRoot",
-            new JSFunction((in _) => Dom.Features.ShadowDomBinding.GetShadowRoot(this, element, in _), "get shadowRoot"),
+            new DomFunction((in _) => Dom.Features.ShadowDomBinding.GetShadowRoot(this, element, in _), "get shadowRoot"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // textContent (read/write) + innerText / outerText (read) — Phase 3 P3.57: ElementContentBinding.
@@ -123,8 +123,8 @@ public sealed partial class DomBridge
         var styleObj = Dom.Features.StyleDeclarationBinding.BuildInlineDeclaration(bridge, element, OnStyleMutation,
             onPositionAreaInvalidate: bridge.ClearPositionAreaResolution);
         obj.FastAddProperty((KeyString)"style",
-            new JSFunction((in a) => styleObj, "get style"),
-            new JSFunction((in a) => Dom.Features.StyleDeclarationBinding.SetInlineStyleCssText(bridge, element, OnStyleMutation, in a), "set style"),
+            new DomFunction((in a) => styleObj, "get style"),
+            new DomFunction((in a) => Dom.Features.StyleDeclarationBinding.SetInlineStyleCssText(bridge, element, OnStyleMutation, in a), "set style"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // classList — class list manipulation (Phase 3 P3.6: co-located ClassListBinding module)
@@ -134,111 +134,111 @@ public sealed partial class DomBridge
 
         // attributes — NamedNodeMap interface
         obj.FastAddProperty((KeyString)"attributes",
-            new JSFunction((in _) => _attributes.BuildNamedNodeMap(element, obj), "get attributes"),
+            new DomFunction((in _) => _attributes.BuildNamedNodeMap(element, obj), "get attributes"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // setAttribute(name, value)
         var bridgeForSet = this;
         obj.FastAddValue((KeyString)"setAttribute",
-            new JSFunction((in a) => _attributes.SetAttribute(element, in a), "setAttribute", 2),
+            new DomFunction((in a) => _attributes.SetAttribute(element, in a), "setAttribute", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // getAttribute(name)
         obj.FastAddValue((KeyString)"getAttribute",
-            new JSFunction((in a) => _attributes.GetAttribute(element, in a), "getAttribute", 1),
+            new DomFunction((in a) => _attributes.GetAttribute(element, in a), "getAttribute", 1),
              JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"getAttributeNode",
-            new JSFunction((in a) => _attributes.GetAttributeNode(element, obj, in a), "getAttributeNode", 1),
+            new DomFunction((in a) => _attributes.GetAttributeNode(element, obj, in a), "getAttributeNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"getAttributeNodeNS",
-            new JSFunction((in a) => _attributes.GetAttributeNodeNS(element, obj, in a), "getAttributeNodeNS", 2),
+            new DomFunction((in a) => _attributes.GetAttributeNodeNS(element, obj, in a), "getAttributeNodeNS", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- DOM tree navigation --
 
         // parentNode (read-only, dynamic)
         obj.FastAddProperty((KeyString)"parentNode",
-            new JSFunction((in a) => element.ParentNode != null ? ToJSObject(element.ParentNode) : JSNull.Value, "get parentNode"),
+            new DomFunction((in a) => element.ParentNode != null ? ToJSObject(element.ParentNode) : JSNull.Value, "get parentNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"isConnected",
-            new JSFunction((in _) => Dom.Features.NodeAccessorsBinding.GetIsConnected(this, element, in _), "get isConnected"),
+            new DomFunction((in _) => Dom.Features.NodeAccessorsBinding.GetIsConnected(this, element, in _), "get isConnected"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // childNodes (read-only, dynamic)
         obj.FastAddProperty((KeyString)"childNodes",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetChildNodes(this, element, in a), "get childNodes"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetChildNodes(this, element, in a), "get childNodes"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // firstChild (read-only, dynamic)
         obj.FastAddProperty((KeyString)"firstChild",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetFirstChild(this, element, in a), "get firstChild"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetFirstChild(this, element, in a), "get firstChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // lastChild (read-only, dynamic)
         obj.FastAddProperty((KeyString)"lastChild",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLastChild(this, element, in a), "get lastChild"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLastChild(this, element, in a), "get lastChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // nextSibling (read-only, dynamic)
         obj.FastAddProperty((KeyString)"nextSibling",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNextSibling(this, element, in a), "get nextSibling"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNextSibling(this, element, in a), "get nextSibling"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // previousSibling (read-only, dynamic)
         obj.FastAddProperty((KeyString)"previousSibling",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPreviousSibling(this, element, in a), "get previousSibling"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPreviousSibling(this, element, in a), "get previousSibling"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // nodeType (read-only)
         obj.FastAddProperty((KeyString)"nodeType",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeType(element, in a), "get nodeType"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeType(element, in a), "get nodeType"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // nodeName (read-only)
         obj.FastAddProperty((KeyString)"nodeName",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeName(element, in a), "get nodeName"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeName(element, in a), "get nodeName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // localName (read-only) — null for non-element nodes; local part of tag name for elements
         obj.FastAddProperty((KeyString)"localName",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLocalName(element, in a), "get localName"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetLocalName(element, in a), "get localName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // prefix (read-only) — namespace prefix or null
         obj.FastAddProperty((KeyString)"prefix",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPrefix(element, in a), "get prefix"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetPrefix(element, in a), "get prefix"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // namespaceURI (read-only) — returns namespace URI for elements created via createElementNS
         obj.FastAddProperty((KeyString)"namespaceURI",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNamespaceURI(element, in a), "get namespaceURI"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNamespaceURI(element, in a), "get namespaceURI"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // nodeValue (read/write) — null for elements, text content for text/comment nodes
         obj.FastAddProperty((KeyString)"nodeValue",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeValue(element, in a), "get nodeValue"),
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.SetNodeValue(this, element, in a), "set nodeValue"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetNodeValue(element, in a), "get nodeValue"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.SetNodeValue(this, element, in a), "set nodeValue"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // data (read/write) — for text nodes and comment nodes (alias for nodeValue/textContent)
         obj.FastAddProperty((KeyString)"data",
-            new JSFunction((in a) => Dom.Features.CharacterDataBinding.GetData(element, in a), "get data"),
-            new JSFunction((in a) => Dom.Features.CharacterDataBinding.SetData(this, element, in a), "set data"),
+            new DomFunction((in a) => Dom.Features.CharacterDataBinding.GetData(element, in a), "get data"),
+            new DomFunction((in a) => Dom.Features.CharacterDataBinding.SetData(this, element, in a), "set data"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // length (read-only) — character count for text/comment nodes, child count for elements
         obj.FastAddProperty((KeyString)"length",
-            new JSFunction((in a) => Dom.Features.CharacterDataBinding.GetLength(element, in a), "get length"),
+            new DomFunction((in a) => Dom.Features.CharacterDataBinding.GetLength(element, in a), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // splitText(offset) — splits a text node at the given character offset
         if (IsText(element))
         {
             obj.FastAddValue((KeyString)"splitText",
-                new JSFunction((in a) => Dom.Features.CharacterDataBinding.SplitText(this, element, in a), "splitText", 1),
+                new DomFunction((in a) => Dom.Features.CharacterDataBinding.SplitText(this, element, in a), "splitText", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
@@ -246,174 +246,174 @@ public sealed partial class DomBridge
         if (IsText(element) || IsComment(element))
         {
             obj.FastAddValue((KeyString)"substringData",
-                new JSFunction((in a) => Dom.Features.CharacterDataBinding.SubstringData(element, in a), "substringData", 2),
+                new DomFunction((in a) => Dom.Features.CharacterDataBinding.SubstringData(element, in a), "substringData", 2),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             obj.FastAddValue((KeyString)"appendData",
-                new JSFunction((in a) => Dom.Features.CharacterDataBinding.AppendData(this, element, in a), "appendData", 1),
+                new DomFunction((in a) => Dom.Features.CharacterDataBinding.AppendData(this, element, in a), "appendData", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             obj.FastAddValue((KeyString)"deleteData",
-                new JSFunction((in a) => Dom.Features.CharacterDataBinding.DeleteData(this, element, in a), "deleteData", 2),
+                new DomFunction((in a) => Dom.Features.CharacterDataBinding.DeleteData(this, element, in a), "deleteData", 2),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             obj.FastAddValue((KeyString)"insertData",
-                new JSFunction((in a) => Dom.Features.CharacterDataBinding.InsertData(this, element, in a), "insertData", 2),
+                new DomFunction((in a) => Dom.Features.CharacterDataBinding.InsertData(this, element, in a), "insertData", 2),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             obj.FastAddValue((KeyString)"replaceData",
-                new JSFunction((in a) => Dom.Features.CharacterDataBinding.ReplaceData(this, element, in a), "replaceData", 3),
+                new DomFunction((in a) => Dom.Features.CharacterDataBinding.ReplaceData(this, element, in a), "replaceData", 3),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
         // ownerDocument (read-only) — returns the Document node (nodeType=9)
         obj.FastAddProperty((KeyString)"ownerDocument",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetOwnerDocument(this, element, in a), "get ownerDocument"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetOwnerDocument(this, element, in a), "get ownerDocument"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // parentElement (read-only, dynamic) — like parentNode but returns null for non-element parents
         obj.FastAddProperty((KeyString)"parentElement",
-            new JSFunction((in a) => Dom.Features.NodeAccessorsBinding.GetParentElement(this, element, in a), "get parentElement"),
+            new DomFunction((in a) => Dom.Features.NodeAccessorsBinding.GetParentElement(this, element, in a), "get parentElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // hasChildNodes()
         obj.FastAddValue((KeyString)"hasChildNodes",
-            new JSFunction((in a) => element.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasChildNodes", 0),
+            new DomFunction((in a) => element.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasChildNodes", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // hasAttribute(name)
         obj.FastAddValue((KeyString)"hasAttribute",
-            new JSFunction((in a) => _attributes.HasAttribute(element, in a), "hasAttribute", 1),
+            new DomFunction((in a) => _attributes.HasAttribute(element, in a), "hasAttribute", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // hasAttributes()
         obj.FastAddValue((KeyString)"hasAttributes",
-            new JSFunction((in _) => element.Attributes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasAttributes", 0),
+            new DomFunction((in _) => element.Attributes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasAttributes", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // getAttributeNames()
         obj.FastAddValue((KeyString)"getAttributeNames",
-            new JSFunction((in _) => new JSArray([.. AttributeNames(element).Select(static name => (JSValue)new JSString(name))]), "getAttributeNames", 0),
+            new DomFunction((in _) => new JSArray([.. AttributeNames(element).Select(static name => (JSValue)new JSString(name))]), "getAttributeNames", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // removeAttribute(name)
         obj.FastAddValue((KeyString)"removeAttribute",
-            new JSFunction((in a) => _attributes.RemoveAttribute(element, in a), "removeAttribute", 1),
+            new DomFunction((in a) => _attributes.RemoveAttribute(element, in a), "removeAttribute", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // toggleAttribute(name, force)
         obj.FastAddValue((KeyString)"toggleAttribute",
-            new JSFunction((in a) => _attributes.ToggleAttribute(element, in a), "toggleAttribute", 2),
+            new DomFunction((in a) => _attributes.ToggleAttribute(element, in a), "toggleAttribute", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"setAttributeNode",
-            new JSFunction((in a) => _attributes.SetAttributeNode(element, obj, in a), "setAttributeNode", 1),
+            new DomFunction((in a) => _attributes.SetAttributeNode(element, obj, in a), "setAttributeNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"setAttributeNodeNS",
-            new JSFunction((in a) => _attributes.SetAttributeNodeNS(element, obj, in a), "setAttributeNodeNS", 1),
+            new DomFunction((in a) => _attributes.SetAttributeNodeNS(element, obj, in a), "setAttributeNodeNS", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"removeAttributeNode",
-            new JSFunction((in a) => _attributes.RemoveAttributeNode(element, obj, in a), "removeAttributeNode", 1),
+            new DomFunction((in a) => _attributes.RemoveAttributeNode(element, obj, in a), "removeAttributeNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"removeAttributeNodeNS",
-            new JSFunction((in a) => _attributes.RemoveAttributeNodeNS(element, obj, in a), "removeAttributeNodeNS", 1),
+            new DomFunction((in a) => _attributes.RemoveAttributeNodeNS(element, obj, in a), "removeAttributeNodeNS", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // setAttributeNS(namespace, qualifiedName, value)
         obj.FastAddValue((KeyString)"setAttributeNS",
-            new JSFunction((in a) => _attributes.SetAttributeNS(element, in a), "setAttributeNS", 3),
+            new DomFunction((in a) => _attributes.SetAttributeNS(element, in a), "setAttributeNS", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // getAttributeNS(namespace, localName)
         obj.FastAddValue((KeyString)"getAttributeNS",
-            new JSFunction((in a) => _attributes.GetAttributeNS(element, in a), "getAttributeNS", 2),
+            new DomFunction((in a) => _attributes.GetAttributeNS(element, in a), "getAttributeNS", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // removeAttributeNS(namespace, localName)
         obj.FastAddValue((KeyString)"removeAttributeNS",
-            new JSFunction((in a) => _attributes.RemoveAttributeNS(element, in a), "removeAttributeNS", 2),
+            new DomFunction((in a) => _attributes.RemoveAttributeNS(element, in a), "removeAttributeNS", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // hasAttributeNS(namespace, localName)
         obj.FastAddValue((KeyString)"hasAttributeNS",
-            new JSFunction((in a) => _attributes.HasAttributeNS(element, in a), "hasAttributeNS", 2),
+            new DomFunction((in a) => _attributes.HasAttributeNS(element, in a), "hasAttributeNS", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // contains(otherNode) — returns true if otherNode is a descendant
         obj.FastAddValue((KeyString)"contains",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.Contains(this, element, in a), "contains", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.Contains(this, element, in a), "contains", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // compareDocumentPosition(otherNode)
         obj.FastAddValue((KeyString)"compareDocumentPosition",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.CompareDocumentPosition(this, element, in a), "compareDocumentPosition", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CompareDocumentPosition(this, element, in a), "compareDocumentPosition", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // isSameNode(otherNode)
         obj.FastAddValue((KeyString)"isSameNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsSameNode(this, element, in a), "isSameNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsSameNode(this, element, in a), "isSameNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // normalize()
         obj.FastAddValue((KeyString)"normalize",
-            new JSFunction((in _) => Dom.Features.NodeRelationshipsBinding.Normalize(this, element, in _), "normalize", 0),
+            new DomFunction((in _) => Dom.Features.NodeRelationshipsBinding.Normalize(this, element, in _), "normalize", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // isEqualNode(otherNode)
         obj.FastAddValue((KeyString)"isEqualNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsEqualNode(this, element, in a), "isEqualNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.IsEqualNode(this, element, in a), "isEqualNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"getRootNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.GetRootNode(this, element, in a), "getRootNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.GetRootNode(this, element, in a), "getRootNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // cloneNode(deep)
         obj.FastAddValue((KeyString)"cloneNode",
-            new JSFunction((in a) => Dom.Features.NodeRelationshipsBinding.CloneNode(this, element, in a), "cloneNode", 1),
+            new DomFunction((in a) => Dom.Features.NodeRelationshipsBinding.CloneNode(this, element, in a), "cloneNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // insertBefore(newChild, refChild)
         obj.FastAddValue((KeyString)"insertBefore",
-            new JSFunction((in a) => Dom.Features.TreeMutationBinding.InsertBefore(this, element, in a), "insertBefore", 2),
+            new DomFunction((in a) => Dom.Features.TreeMutationBinding.InsertBefore(this, element, in a), "insertBefore", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // moveBefore(node, refChild) — the atomic, state-preserving sibling of insertBefore.
         obj.FastAddValue((KeyString)"moveBefore",
-            new JSFunction((in a) => Dom.Features.TreeMutationBinding.MoveBefore(this, element, in a), "moveBefore", 2),
+            new DomFunction((in a) => Dom.Features.TreeMutationBinding.MoveBefore(this, element, in a), "moveBefore", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // children (read-only) — element children only (no text nodes)
         obj.FastAddProperty((KeyString)"children",
-            new JSFunction((in a) => Dom.Features.ElementTraversalBinding.GetChildren(this, element, in a), "get children"),
+            new DomFunction((in a) => Dom.Features.ElementTraversalBinding.GetChildren(this, element, in a), "get children"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // childElementCount (read-only)
         obj.FastAddProperty((KeyString)"childElementCount",
-            new JSFunction((in a) => new JSNumber(ChildElements(element).Count(c => !IsText(c))), "get childElementCount"),
+            new DomFunction((in a) => new JSNumber(ChildElements(element).Count(c => !IsText(c))), "get childElementCount"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // firstElementChild (read-only)
         obj.FastAddProperty((KeyString)"firstElementChild",
-            new JSFunction((in a) => Dom.Features.ElementTraversalBinding.GetFirstElementChild(this, element, in a), "get firstElementChild"),
+            new DomFunction((in a) => Dom.Features.ElementTraversalBinding.GetFirstElementChild(this, element, in a), "get firstElementChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // lastElementChild (read-only)
         obj.FastAddProperty((KeyString)"lastElementChild",
-            new JSFunction((in a) => Dom.Features.ElementTraversalBinding.GetLastElementChild(this, element, in a), "get lastElementChild"),
+            new DomFunction((in a) => Dom.Features.ElementTraversalBinding.GetLastElementChild(this, element, in a), "get lastElementChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // nextElementSibling (read-only)
         obj.FastAddProperty((KeyString)"nextElementSibling",
-            new JSFunction((in a) => Dom.Features.ElementTraversalBinding.GetNextElementSibling(this, element, in a), "get nextElementSibling"),
+            new DomFunction((in a) => Dom.Features.ElementTraversalBinding.GetNextElementSibling(this, element, in a), "get nextElementSibling"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // previousElementSibling (read-only)
         obj.FastAddProperty((KeyString)"previousElementSibling",
-            new JSFunction((in a) => Dom.Features.ElementTraversalBinding.GetPreviousElementSibling(this, element, in a), "get previousElementSibling"),
+            new DomFunction((in a) => Dom.Features.ElementTraversalBinding.GetPreviousElementSibling(this, element, in a), "get previousElementSibling"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // -- DOM manipulation methods --
@@ -425,94 +425,94 @@ public sealed partial class DomBridge
         if (string.Equals(element.TagName, "template", StringComparison.OrdinalIgnoreCase))
         {
             obj.FastAddProperty((KeyString)"content",
-                new JSFunction((in a) => bridge.ToJSObject(bridge.GetTemplateContent(element)), "get content"),
+                new DomFunction((in a) => bridge.ToJSObject(bridge.GetTemplateContent(element)), "get content"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
         // attachShadow(init) — Phase 3 P3.62: co-located ShadowDomBinding feature module.
         obj.FastAddValue((KeyString)"attachShadow",
-            new JSFunction((in a) => Dom.Features.ShadowDomBinding.AttachShadow(this, element, in a), "attachShadow", 1),
+            new DomFunction((in a) => Dom.Features.ShadowDomBinding.AttachShadow(this, element, in a), "attachShadow", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // appendChild(child)
         obj.FastAddValue((KeyString)"appendChild",
-            new JSFunction((in a) => Dom.Features.TreeMutationBinding.AppendChild(this, element, in a), "appendChild", 1),
+            new DomFunction((in a) => Dom.Features.TreeMutationBinding.AppendChild(this, element, in a), "appendChild", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"append",
-            new JSFunction((in a) => Dom.Features.TreeMutationBinding.Append(this, element, in a), "append", 0),
+            new DomFunction((in a) => Dom.Features.TreeMutationBinding.Append(this, element, in a), "append", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"prepend",
-            new JSFunction((in a) => Dom.Features.TreeMutationBinding.Prepend(this, element, in a), "prepend", 0),
+            new DomFunction((in a) => Dom.Features.TreeMutationBinding.Prepend(this, element, in a), "prepend", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // removeChild(child)
         obj.FastAddValue((KeyString)"removeChild",
-            new JSFunction((in a) => Dom.Features.TreeMutationBinding.RemoveChild(this, element, in a), "removeChild", 1),
+            new DomFunction((in a) => Dom.Features.TreeMutationBinding.RemoveChild(this, element, in a), "removeChild", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // replaceChild(newChild, oldChild)
         obj.FastAddValue((KeyString)"replaceChild",
-            new JSFunction((in a) => Dom.Features.TreeMutationBinding.ReplaceChild(this, element, in a), "replaceChild", 2),
+            new DomFunction((in a) => Dom.Features.TreeMutationBinding.ReplaceChild(this, element, in a), "replaceChild", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // remove() — ChildNode.remove() per DOM Living Standard
         obj.FastAddValue((KeyString)"remove",
-            new JSFunction((in a) => Dom.Features.ChildNodeBinding.Remove(this, element, in a), "remove", 0),
+            new DomFunction((in a) => Dom.Features.ChildNodeBinding.Remove(this, element, in a), "remove", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"before",
-            new JSFunction((in a) => Dom.Features.ChildNodeBinding.Before(this, element, in a), "before", 0),
+            new DomFunction((in a) => Dom.Features.ChildNodeBinding.Before(this, element, in a), "before", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"after",
-            new JSFunction((in a) => Dom.Features.ChildNodeBinding.After(this, element, in a), "after", 0),
+            new DomFunction((in a) => Dom.Features.ChildNodeBinding.After(this, element, in a), "after", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"replaceWith",
-            new JSFunction((in a) => Dom.Features.ChildNodeBinding.ReplaceWith(this, element, in a), "replaceWith", 0),
+            new DomFunction((in a) => Dom.Features.ChildNodeBinding.ReplaceWith(this, element, in a), "replaceWith", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // -- DOM events --
 
         // addEventListener(type, listener, useCapture)
         obj.FastAddValue((KeyString)"addEventListener",
-            new JSFunction((in a) => Dom.Features.EventTargetBinding.AddEventListener(this, element, in a), "addEventListener", 3),
+            new DomFunction((in a) => Dom.Features.EventTargetBinding.AddEventListener(this, element, in a), "addEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // removeEventListener(type, listener, useCapture)
         obj.FastAddValue((KeyString)"removeEventListener",
-            new JSFunction((in a) => Dom.Features.EventTargetBinding.RemoveEventListener(this, element, in a), "removeEventListener", 3),
+            new DomFunction((in a) => Dom.Features.EventTargetBinding.RemoveEventListener(this, element, in a), "removeEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // dispatchEvent(event) — DOM Events Level 3 with capture/target/bubble phases
         obj.FastAddValue((KeyString)"dispatchEvent",
-            new JSFunction((in a) => Dom.Features.EventTargetBinding.DispatchEvent(this, element, in a), "dispatchEvent", 1),
+            new DomFunction((in a) => Dom.Features.EventTargetBinding.DispatchEvent(this, element, in a), "dispatchEvent", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // element.click() — creates and dispatches a MouseEvent
         // For checkboxes and radio buttons, toggles checked state.
         obj.FastAddValue((KeyString)"click",
-            new JSFunction((in _) => Dom.Features.EventTargetBinding.Click(this, element, in _), "click", 0),
+            new DomFunction((in _) => Dom.Features.EventTargetBinding.Click(this, element, in _), "click", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // element.focus() — creates and dispatches a FocusEvent-like object
         obj.FastAddValue((KeyString)"focus",
-            new JSFunction((in _) => Dom.Features.EventTargetBinding.Focus(this, element, in _), "focus", 0),
+            new DomFunction((in _) => Dom.Features.EventTargetBinding.Focus(this, element, in _), "focus", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // element.blur() — creates and dispatches a FocusEvent-like object
         obj.FastAddValue((KeyString)"blur",
-            new JSFunction((in _) => Dom.Features.EventTargetBinding.Blur(this, element, in _), "blur", 0),
+            new DomFunction((in _) => Dom.Features.EventTargetBinding.Blur(this, element, in _), "blur", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // on* inline event handler properties (onclick, onload, etc.)
         foreach (var eventName in InlineEventNames)
         {
             obj.FastAddProperty((KeyString)$"on{eventName}",
-                new JSFunction((in _) => Dom.Features.EventHandlerReflectorBinding.GetOn(this, element, eventName, in _), $"get on{eventName}"),
-                new JSFunction((in a) => Dom.Features.EventHandlerReflectorBinding.SetOn(this, element, eventName, in a), $"set on{eventName}"),
+                new DomFunction((in _) => Dom.Features.EventHandlerReflectorBinding.GetOn(this, element, eventName, in _), $"get on{eventName}"),
+                new DomFunction((in a) => Dom.Features.EventHandlerReflectorBinding.SetOn(this, element, eventName, in a), $"set on{eventName}"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
@@ -528,36 +528,36 @@ public sealed partial class DomBridge
 
         // checkValidity() — form validation (Phase 3 P3.9: FormBinding owns the validity check)
         obj.FastAddValue((KeyString)"checkValidity",
-            new JSFunction((in a) => _forms.IsElementValid(element) ? JSBoolean.True : JSBoolean.False, "checkValidity", 0),
+            new DomFunction((in a) => _forms.IsElementValid(element) ? JSBoolean.True : JSBoolean.False, "checkValidity", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // reportValidity() — form validation
         obj.FastAddValue((KeyString)"reportValidity",
-            new JSFunction((in a) => _forms.IsElementValid(element) ? JSBoolean.True : JSBoolean.False, "reportValidity", 0),
+            new DomFunction((in a) => _forms.IsElementValid(element) ? JSBoolean.True : JSBoolean.False, "reportValidity", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // submit() — for form elements (Phase 3 P3.61: co-located FormSubmitBinding feature module,
         // reached through IFormSubmitHost; DomBridge.FormSubmitHost.cs).
         obj.FastAddValue((KeyString)"submit",
-            new JSFunction((in a) => Dom.Features.FormSubmitBinding.Submit(this, element, obj, in a), "submit", 0),
+            new DomFunction((in a) => Dom.Features.FormSubmitBinding.Submit(this, element, obj, in a), "submit", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // querySelector on elements
         obj.FastAddValue((KeyString)"querySelector",
-            new JSFunction((in a) => Dom.Features.SelectorsBinding.QuerySelector(this, element, in a), "querySelector", 1),
+            new DomFunction((in a) => Dom.Features.SelectorsBinding.QuerySelector(this, element, in a), "querySelector", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // querySelectorAll on elements
         obj.FastAddValue((KeyString)"querySelectorAll",
-            new JSFunction((in a) => Dom.Features.SelectorsBinding.QuerySelectorAll(this, element, in a), "querySelectorAll", 1),
+            new DomFunction((in a) => Dom.Features.SelectorsBinding.QuerySelectorAll(this, element, in a), "querySelectorAll", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"matches",
-            new JSFunction((in a) => Dom.Features.SelectorsBinding.Matches(this, element, in a), "matches", 1),
+            new DomFunction((in a) => Dom.Features.SelectorsBinding.Matches(this, element, in a), "matches", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"closest",
-            new JSFunction((in a) => Dom.Features.SelectorsBinding.Closest(this, element, in a), "closest", 1),
+            new DomFunction((in a) => Dom.Features.SelectorsBinding.Closest(this, element, in a), "closest", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // insertAdjacentElement / insertAdjacentText / insertAdjacentHTML — Phase 3 P3.56: extracted into
@@ -567,7 +567,7 @@ public sealed partial class DomBridge
 
         // getElementsByTagName on elements — searches descendants in tree order
         obj.FastAddValue((KeyString)"getElementsByTagName",
-            new JSFunction((in a) => Dom.Features.SelectorsBinding.GetElementsByTagName(this, element, in a), "getElementsByTagName", 1),
+            new DomFunction((in a) => Dom.Features.SelectorsBinding.GetElementsByTagName(this, element, in a), "getElementsByTagName", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // getContext(contextType) — for <canvas> elements. Phase 3 P3.64: extracted into the co-located

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.Scrolling.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/LayoutMetrics.Scrolling.cs
@@ -300,6 +300,7 @@ public sealed partial class DomBridge
             return;
 
         DispatchElementEvent(element, "scroll");
+        DispatchViewportScrollEventToWindow(element, "scroll");
     }
 
     private void DispatchScrollEndEventIfNeeded(DomElement element, double previousLeft, double previousTop)
@@ -309,6 +310,31 @@ public sealed partial class DomBridge
             return;
 
         DispatchElementEvent(element, "scrollend");
+        DispatchViewportScrollEventToWindow(element, "scrollend");
+    }
+
+    /// <summary>
+    /// Also delivers a viewport scroll to <c>window</c>'s listeners.
+    /// </summary>
+    /// <remarks>
+    /// CSSOM View fires a scrolling event at the <em>Document</em> when the scrolling box is the
+    /// viewport, so it reaches the window through the propagation path — which is why
+    /// <c>addEventListener("scroll", …)</c> at global scope (a window listener, the idiomatic
+    /// spelling) is how pages observe page scrolling. This bridge dispatches the event on the
+    /// document element and marks it non-bubbling, so a window listener never saw it and
+    /// <c>document.documentElement.scrollTop = N</c> looked like it scrolled silently: the offset
+    /// changed and the render moved, but nothing was notified. WPT
+    /// <c>css-view-transitions/*-root-scrollbar-with-fixed-background</c> awaits exactly such a
+    /// listener before it starts its transition, so the test simply stopped there.
+    /// <para>
+    /// Delivered in addition to the element dispatch rather than instead of it, so element-level
+    /// and <c>onscroll</c> listeners keep seeing what they saw before.
+    /// </para>
+    /// </remarks>
+    private void DispatchViewportScrollEventToWindow(DomElement element, string eventType)
+    {
+        if (ReferenceEquals(element, DocumentElement))
+            DispatchWindowEvent(eventType);
     }
 
     private void DispatchElementEvent(DomElement element, string eventType)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Animations.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Animations.cs
@@ -105,18 +105,18 @@ public sealed partial class DomBridge
         var animationState = AnimationStateFor(element);
         animation.FastAddProperty(
             (KeyString)"currentTime",
-            new JSFunction((in _) => Dom.Features.AnimationObjectBinding.GetCurrentTime(animationState, in _), "get currentTime"),
-            new JSFunction((in a) => Dom.Features.AnimationObjectBinding.SetCurrentTime(animationState, in a), "set currentTime"),
+            new DomFunction((in _) => Dom.Features.AnimationObjectBinding.GetCurrentTime(animationState, in _), "get currentTime"),
+            new DomFunction((in a) => Dom.Features.AnimationObjectBinding.SetCurrentTime(animationState, in a), "set currentTime"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         var ready = new JSObject();
         ready.FastAddValue(
             (KeyString)"then",
-            new JSFunction((in a) => Dom.Features.AnimationObjectBinding.Then(ready, in a), "then", 1),
+            new DomFunction((in a) => Dom.Features.AnimationObjectBinding.Then(ready, in a), "then", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         ready.FastAddValue(
             (KeyString)"catch",
-            new JSFunction((in _) => ready, "catch", 1),
+            new DomFunction((in _) => ready, "catch", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         animation.FastAddValue((KeyString)"ready", ready, JSPropertyAttributes.EnumerableConfigurableValue);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Polyfills.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Polyfills.cs
@@ -21,8 +21,8 @@ public sealed partial class DomBridge
         var cookieStore = "";
         document.FastAddProperty(
             (KeyString)"cookie",
-            new JSFunction((in _) => new JSString(cookieStore), "get cookie"),
-            new JSFunction((in a) => Dom.Features.WindowDocumentMiscBinding.SetCookie(ref cookieStore, in a), "set cookie"),
+            new DomFunction((in _) => new JSString(cookieStore), "get cookie"),
+            new DomFunction((in a) => Dom.Features.WindowDocumentMiscBinding.SetCookie(ref cookieStore, in a), "set cookie"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
@@ -19,7 +19,7 @@ public sealed partial class DomBridge
         window.FastAddValue((KeyString)"localStorage", Dom.Features.WebStorageBinding.BuildLocalStorage(), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // window.matchMedia(query) — evaluates basic media queries
-        window.FastAddValue((KeyString)"matchMedia", new JSFunction((in a) => Dom.Features.MatchMediaBinding.MatchMedia(this, in a), "matchMedia", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"matchMedia", new DomFunction((in a) => Dom.Features.MatchMediaBinding.MatchMedia(this, in a), "matchMedia", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // window.location (read-only)
         var location = new JSObject();
@@ -36,15 +36,15 @@ public sealed partial class DomBridge
 
         // window timers / animation frames — thin adapters over the P2.4 BrowserEventLoop, co-located
         // in the TimerBinding feature module (Phase 3).
-        window.FastAddValue((KeyString)"setTimeout", new JSFunction((in a) => Dom.Features.TimerBinding.SetTimeout(_eventLoop, in a), "setTimeout", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"clearTimeout", new JSFunction((in a) => Dom.Features.TimerBinding.ClearTimeout(_eventLoop, in a), "clearTimeout", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"setInterval", new JSFunction((in a) => Dom.Features.TimerBinding.SetInterval(_eventLoop, in a), "setInterval", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"clearInterval", new JSFunction((in a) => Dom.Features.TimerBinding.ClearInterval(_eventLoop, in a), "clearInterval", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"requestAnimationFrame", new JSFunction((in a) => Dom.Features.TimerBinding.RequestAnimationFrame(_eventLoop, in a), "requestAnimationFrame", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"cancelAnimationFrame", new JSFunction((in a) => Dom.Features.TimerBinding.CancelAnimationFrame(_eventLoop, in a), "cancelAnimationFrame", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"setTimeout", new DomFunction((in a) => Dom.Features.TimerBinding.SetTimeout(_eventLoop, in a), "setTimeout", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"clearTimeout", new DomFunction((in a) => Dom.Features.TimerBinding.ClearTimeout(_eventLoop, in a), "clearTimeout", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"setInterval", new DomFunction((in a) => Dom.Features.TimerBinding.SetInterval(_eventLoop, in a), "setInterval", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"clearInterval", new DomFunction((in a) => Dom.Features.TimerBinding.ClearInterval(_eventLoop, in a), "clearInterval", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"requestAnimationFrame", new DomFunction((in a) => Dom.Features.TimerBinding.RequestAnimationFrame(_eventLoop, in a), "requestAnimationFrame", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"cancelAnimationFrame", new DomFunction((in a) => Dom.Features.TimerBinding.CancelAnimationFrame(_eventLoop, in a), "cancelAnimationFrame", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // window.alert(msg) — logs to debug output
-        window.FastAddValue((KeyString)"alert", new JSFunction(Dom.Features.WindowDocumentMiscBinding.Alert, "alert", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"alert", new DomFunction(Dom.Features.WindowDocumentMiscBinding.Alert, "alert", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // console object (shared between window.console and global console)
         var console = Dom.Features.ConsoleBinding.Build();
@@ -98,10 +98,10 @@ public sealed partial class DomBridge
         var performanceTimeOrigin = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         var performanceObj = new JSObject();
         performanceObj.FastAddValue((KeyString)"timeOrigin", new JSNumber(performanceTimeOrigin), JSPropertyAttributes.EnumerableConfigurableValue);
-        performanceObj.FastAddValue((KeyString)"now", new JSFunction((in _) => Dom.Features.WindowDocumentMiscBinding.PerformanceNow(performanceTimeOrigin, in _), "now", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObj.FastAddValue((KeyString)"now", new DomFunction((in _) => Dom.Features.WindowDocumentMiscBinding.PerformanceNow(performanceTimeOrigin, in _), "now", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // performance.getEntriesByType() — stub returning empty array
-        performanceObj.FastAddValue((KeyString)"getEntriesByType", new JSFunction((in _) => new JSArray(), "getEntriesByType", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObj.FastAddValue((KeyString)"getEntriesByType", new DomFunction((in _) => new JSArray(), "getEntriesByType", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // performance.mark() / performance.measure() — no-op stubs
         performanceObj.FastAddValue((KeyString)"mark", UndefinedFunction("mark", 1), JSPropertyAttributes.EnumerableConfigurableValue);
@@ -124,7 +124,7 @@ public sealed partial class DomBridge
         navigatorObj.FastAddValue((KeyString)"vendor", new JSString(""), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // sendBeacon(url, data) — queues a fire-and-forget POST via fetch semantics
-        navigatorObj.FastAddValue((KeyString)"sendBeacon", new JSFunction((in a) => Dom.Features.BeaconBinding.Send(window, in a), "sendBeacon", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        navigatorObj.FastAddValue((KeyString)"sendBeacon", new DomFunction((in a) => Dom.Features.BeaconBinding.Send(window, in a), "sendBeacon", 2), JSPropertyAttributes.EnumerableConfigurableValue);
         window.FastAddValue((KeyString)"navigator", navigatorObj, JSPropertyAttributes.EnumerableConfigurableValue);
 
         context["navigator"] = navigatorObj;
@@ -137,31 +137,31 @@ public sealed partial class DomBridge
         var vpWidth = _viewportWidth;
         var vpHeight = _viewportHeight;
 
-        window.FastAddProperty((KeyString)"innerWidth", new JSFunction((in _) => new JSNumber(vpWidth), "get innerWidth"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"innerHeight", new JSFunction((in _) => new JSNumber(vpHeight), "get innerHeight"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"outerWidth", new JSFunction((in _) => new JSNumber(vpWidth), "get outerWidth"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"outerHeight", new JSFunction((in _) => new JSNumber(vpHeight), "get outerHeight"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"scrollX", new JSFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: false)), "get scrollX"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"scrollY", new JSFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: true)), "get scrollY"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"pageXOffset", new JSFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: false)), "get pageXOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        window.FastAddProperty((KeyString)"pageYOffset", new JSFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: true)), "get pageYOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty((KeyString)"innerWidth", new DomFunction((in _) => new JSNumber(vpWidth), "get innerWidth"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty((KeyString)"innerHeight", new DomFunction((in _) => new JSNumber(vpHeight), "get innerHeight"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty((KeyString)"outerWidth", new DomFunction((in _) => new JSNumber(vpWidth), "get outerWidth"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty((KeyString)"outerHeight", new DomFunction((in _) => new JSNumber(vpHeight), "get outerHeight"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty((KeyString)"scrollX", new DomFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: false)), "get scrollX"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty((KeyString)"scrollY", new DomFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: true)), "get scrollY"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty((KeyString)"pageXOffset", new DomFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: false)), "get pageXOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty((KeyString)"pageYOffset", new DomFunction((in _) => new JSNumber(GetElementScrollOffset(DocumentElement, vertical: true)), "get pageYOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // window scroll / scrollTo / scrollBy, co-located in the WindowScrollBinding feature module (Phase 3).
-        window.FastAddValue((KeyString)"scroll", new JSFunction((in a) => Dom.Features.WindowScrollBinding.Scroll(this, in a), "scroll", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"scrollTo", new JSFunction((in a) => Dom.Features.WindowScrollBinding.ScrollTo(this, in a), "scrollTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"scrollBy", new JSFunction((in a) => Dom.Features.WindowScrollBinding.ScrollBy(this, in a), "scrollBy", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"scroll", new DomFunction((in a) => Dom.Features.WindowScrollBinding.Scroll(this, in a), "scroll", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"scrollTo", new DomFunction((in a) => Dom.Features.WindowScrollBinding.ScrollTo(this, in a), "scrollTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"scrollBy", new DomFunction((in a) => Dom.Features.WindowScrollBinding.ScrollBy(this, in a), "scrollBy", 2), JSPropertyAttributes.EnumerableConfigurableValue);
         // window addEventListener / removeEventListener / dispatchEvent, co-located in the
         // WindowEventTargetBinding feature module (Phase 3). These reach the global object — so
         // the idiomatic unqualified `addEventListener("load", …)` registers a window listener,
         // as it does in a browser — through MirrorWindowMembersOntoGlobal, which shares the
         // identical function objects so the two spellings address one listener store.
-        window.FastAddValue((KeyString)"addEventListener", new JSFunction((in a) => Dom.Features.WindowEventTargetBinding.AddEventListener(this, in a), "addEventListener", 3), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"removeEventListener", new JSFunction((in a) => Dom.Features.WindowEventTargetBinding.RemoveEventListener(this, in a), "removeEventListener", 3), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"dispatchEvent", new JSFunction((in a) => Dom.Features.WindowEventTargetBinding.DispatchEvent(this, in a), "dispatchEvent", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"addEventListener", new DomFunction((in a) => Dom.Features.WindowEventTargetBinding.AddEventListener(this, in a), "addEventListener", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"removeEventListener", new DomFunction((in a) => Dom.Features.WindowEventTargetBinding.RemoveEventListener(this, in a), "removeEventListener", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"dispatchEvent", new DomFunction((in a) => Dom.Features.WindowEventTargetBinding.DispatchEvent(this, in a), "dispatchEvent", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         _messaging.RegisterWindowMessaging(window);
 
-        window.FastAddProperty((KeyString)"frames", new JSFunction((in _) => BuildWindowFramesArray(), "get frames"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        window.FastAddProperty((KeyString)"frames", new DomFunction((in _) => BuildWindowFramesArray(), "get frames"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
         context["frames"] = BuildWindowFramesArray();
 
         // window.screen — basic stub for screen dimensions
@@ -178,16 +178,16 @@ public sealed partial class DomBridge
 
         var visualViewport = new JSObject();
         _visualViewportJSObject = visualViewport;
-        visualViewport.FastAddProperty((KeyString)"width", new JSFunction((in _) => new JSNumber(GetVisualViewportWidth()), "get width"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        visualViewport.FastAddProperty((KeyString)"height", new JSFunction((in _) => new JSNumber(GetVisualViewportHeight()), "get height"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        visualViewport.FastAddProperty((KeyString)"scale", new JSFunction((in _) => new JSNumber(GetVisualViewportScale()), "get scale"), new JSFunction((in a) => Dom.Features.WindowDocumentMiscBinding.SetVisualViewportScale(this, in a), "set scale"), JSPropertyAttributes.EnumerableConfigurableProperty);
-        visualViewport.FastAddProperty((KeyString)"pageLeft", new JSFunction((in _) => new JSNumber(GetVisualViewportPageOffset(vertical: false)), "get pageLeft"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        visualViewport.FastAddProperty((KeyString)"pageTop", new JSFunction((in _) => new JSNumber(GetVisualViewportPageOffset(vertical: true)), "get pageTop"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        visualViewport.FastAddProperty((KeyString)"width", new DomFunction((in _) => new JSNumber(GetVisualViewportWidth()), "get width"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        visualViewport.FastAddProperty((KeyString)"height", new DomFunction((in _) => new JSNumber(GetVisualViewportHeight()), "get height"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        visualViewport.FastAddProperty((KeyString)"scale", new DomFunction((in _) => new JSNumber(GetVisualViewportScale()), "get scale"), new DomFunction((in a) => Dom.Features.WindowDocumentMiscBinding.SetVisualViewportScale(this, in a), "set scale"), JSPropertyAttributes.EnumerableConfigurableProperty);
+        visualViewport.FastAddProperty((KeyString)"pageLeft", new DomFunction((in _) => new JSNumber(GetVisualViewportPageOffset(vertical: false)), "get pageLeft"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        visualViewport.FastAddProperty((KeyString)"pageTop", new DomFunction((in _) => new JSNumber(GetVisualViewportPageOffset(vertical: true)), "get pageTop"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // visualViewport addEventListener / removeEventListener (scroll), co-located in the
         // VisualViewportEventTargetBinding feature module (Phase 3).
-        visualViewport.FastAddValue((KeyString)"addEventListener", new JSFunction((in a) => Dom.Features.VisualViewportEventTargetBinding.AddEventListener(this, in a), "addEventListener", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        visualViewport.FastAddValue((KeyString)"removeEventListener", new JSFunction((in a) => Dom.Features.VisualViewportEventTargetBinding.RemoveEventListener(this, in a), "removeEventListener", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        visualViewport.FastAddValue((KeyString)"addEventListener", new DomFunction((in a) => Dom.Features.VisualViewportEventTargetBinding.AddEventListener(this, in a), "addEventListener", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        visualViewport.FastAddValue((KeyString)"removeEventListener", new DomFunction((in a) => Dom.Features.VisualViewportEventTargetBinding.RemoveEventListener(this, in a), "removeEventListener", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
         window.FastAddValue((KeyString)"visualViewport", visualViewport, JSPropertyAttributes.EnumerableConfigurableValue);
         context["visualViewport"] = visualViewport;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SharedLayoutGeometry.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SharedLayoutGeometry.cs
@@ -65,7 +65,34 @@ public sealed partial class DomBridge
     /// </summary>
     private bool TryGetSharedLayoutGeometry(DomElement element, out BoxGeometry geometry)
     {
-        var snapshot = _sharedGeometrySnapshot ??= BuildSharedGeometrySnapshot();
+        // The lazy build must run marked as a geometry pass, exactly as WithLayoutGeometryCache
+        // marks its own. Building the snapshot creates a render projection, and that projection
+        // materialises a running view transition's pseudo tree — which measures the captured
+        // elements, i.e. asks for geometry again. ApplyViewTransitionRendering skips itself while a
+        // pass is active, so the flag is what terminates the cycle; without it this path recursed
+        // BuildSharedGeometrySnapshot → view-transition pseudo tree → getBoundingClientRect →
+        // BuildSharedGeometrySnapshot until the stack overflowed.
+        //
+        // Latent until an await continuation could reach a geometry query mid-transition (the
+        // reactions used to race away on the thread pool), and reachable from any non-pass shared
+        // query, so it is guarded here rather than at the caller.
+        var snapshot = _sharedGeometrySnapshot;
+        if (snapshot is null)
+        {
+            var owner = !_layoutGeometryPassActive;
+            if (owner)
+                _layoutGeometryPassActive = true;
+            try
+            {
+                snapshot = _sharedGeometrySnapshot ??= BuildSharedGeometrySnapshot();
+            }
+            finally
+            {
+                if (owner)
+                    _layoutGeometryPassActive = false;
+            }
+        }
+
         return snapshot.TryGetValue(ResolveRenderSource(element), out geometry);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/StyleSheets.cs
@@ -114,7 +114,7 @@ public sealed partial class DomBridge
         var sheet = new JSObject();
 
         // ownerNode
-        sheet.FastAddProperty((KeyString)"ownerNode", new JSFunction((in _) => ToJSObject(styleElement), "get ownerNode"),
+        sheet.FastAddProperty((KeyString)"ownerNode", new DomFunction((in _) => ToJSObject(styleElement), "get ownerNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // href — null for inline stylesheets
@@ -125,8 +125,8 @@ public sealed partial class DomBridge
         // applying (CSSOM §2.3). Getting reads the effective state (script flag, else the
         // <link disabled> content attribute); setting stores the script flag and re-cascades.
         sheet.FastAddProperty((KeyString)"disabled",
-            new JSFunction((in _) => IsStyleSheetDisabled(styleElement) ? JSBoolean.True : JSBoolean.False, "get disabled"),
-            new JSFunction((in a) => { SetStyleSheetDisabledFlag(styleElement, a.Length > 0 && a[0].BooleanValue); return JSUndefined.Value; }, "set disabled"),
+            new DomFunction((in _) => IsStyleSheetDisabled(styleElement) ? JSBoolean.True : JSBoolean.False, "get disabled"),
+            new DomFunction((in a) => { SetStyleSheetDisabledFlag(styleElement, a.Length > 0 && a[0].BooleanValue); return JSUndefined.Value; }, "set disabled"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // Internal rules storage for this stylesheet — the single shared, mutable
@@ -142,11 +142,11 @@ public sealed partial class DomBridge
         var lastSyncedRuleCount = 0;
         // length is a live getter that always reflects the current rule count
         liveCssRules.FastAddProperty((KeyString)"length",
-            new JSFunction((in _) => Dom.Features.StyleSheetBinding.JsStyleSheetsGetLength002Core(CurrentRules, in _), "get length"),
+            new DomFunction((in _) => Dom.Features.StyleSheetBinding.JsStyleSheetsGetLength002Core(CurrentRules, in _), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         liveCssRules.FastAddValue((KeyString)"item",
-            new JSFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsItem003Core(SyncLiveCssRulesIndices, liveCssRules, CurrentRules, in a), "item", 1),
+            new DomFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsItem003Core(SyncLiveCssRulesIndices, liveCssRules, CurrentRules, in a), "item", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Syncs indexed properties on the live cssRules object with the shared model
@@ -167,18 +167,18 @@ public sealed partial class DomBridge
 
         // cssRules — returns the live collection, syncing indices on access
         sheet.FastAddProperty((KeyString)"cssRules",
-            new JSFunction((in _) => Dom.Features.StyleSheetBinding.JsStyleSheetsGetCssRules004Core(SyncLiveCssRulesIndices, liveCssRules, in _), "get cssRules"),
+            new DomFunction((in _) => Dom.Features.StyleSheetBinding.JsStyleSheetsGetCssRules004Core(SyncLiveCssRulesIndices, liveCssRules, in _), "get cssRules"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // insertRule(rule, index) — mutates the shared model (marking it mutated so
         // the renderer/engine serialize from it) and resyncs the live collection
         sheet.FastAddValue((KeyString)"insertRule",
-            new JSFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsInsertRule005Core(CurrentRules, MarkRulesMutated, SyncLiveCssRulesIndices, in a), "insertRule", 2),
+            new DomFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsInsertRule005Core(CurrentRules, MarkRulesMutated, SyncLiveCssRulesIndices, in a), "insertRule", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // deleteRule(index) — removes a rule from the shared model
         sheet.FastAddValue((KeyString)"deleteRule",
-            new JSFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsDeleteRule006Core(CurrentRules, MarkRulesMutated, SyncLiveCssRulesIndices, in a), "deleteRule", 1),
+            new DomFunction((in a) => Dom.Features.StyleSheetBinding.JsStyleSheetsDeleteRule006Core(CurrentRules, MarkRulesMutated, SyncLiveCssRulesIndices, in a), "deleteRule", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         _styleSheetCache[styleElement] = sheet;

--- a/src/Broiler.HtmlBridge.Dom/Features/AttributesBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/AttributesBinding.cs
@@ -35,29 +35,29 @@ internal sealed class AttributesBinding(IAttributesHost host)
         var map = new JSObject();
 
         // length — number of attributes
-        map.FastAddProperty((KeyString)"length", new JSFunction((in _) => new JSNumber(element.Attributes.Count), "get length"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        map.FastAddProperty((KeyString)"length", new DomFunction((in _) => new JSNumber(element.Attributes.Count), "get length"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // getNamedItem(name) — returns Attr node or null
-        map.FastAddValue((KeyString)"getNamedItem", new JSFunction((in a) => GetNamedItem(element, ownerObj, in a), "getNamedItem", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        map.FastAddValue((KeyString)"getNamedItemNS", new JSFunction((in a) => GetNamedItemNS(element, ownerObj, in a), "getNamedItemNS", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        map.FastAddValue((KeyString)"getNamedItem", new DomFunction((in a) => GetNamedItem(element, ownerObj, in a), "getNamedItem", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        map.FastAddValue((KeyString)"getNamedItemNS", new DomFunction((in a) => GetNamedItemNS(element, ownerObj, in a), "getNamedItemNS", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // setNamedItem(attr) — adds/replaces attribute from Attr node, returns old Attr or null
-        map.FastAddValue((KeyString)"setNamedItem", new JSFunction((in a) => SetNamedItem(element, ownerObj, in a), "setNamedItem", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        map.FastAddValue((KeyString)"setNamedItemNS", new JSFunction((in a) => SetNamedItemNS(element, ownerObj, in a), "setNamedItemNS", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        map.FastAddValue((KeyString)"setNamedItem", new DomFunction((in a) => SetNamedItem(element, ownerObj, in a), "setNamedItem", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        map.FastAddValue((KeyString)"setNamedItemNS", new DomFunction((in a) => SetNamedItemNS(element, ownerObj, in a), "setNamedItemNS", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // removeNamedItem(name) — removes and returns the Attr node
-        map.FastAddValue((KeyString)"removeNamedItem", new JSFunction((in a) => RemoveNamedItem(element, ownerObj, in a), "removeNamedItem", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        map.FastAddValue((KeyString)"removeNamedItemNS", new JSFunction((in a) => RemoveNamedItemNS(element, ownerObj, in a), "removeNamedItemNS", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        map.FastAddValue((KeyString)"removeNamedItem", new DomFunction((in a) => RemoveNamedItem(element, ownerObj, in a), "removeNamedItem", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        map.FastAddValue((KeyString)"removeNamedItemNS", new DomFunction((in a) => RemoveNamedItemNS(element, ownerObj, in a), "removeNamedItemNS", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // item(index) — returns Attr node at position
-        map.FastAddValue((KeyString)"item", new JSFunction((in a) => Item(element, ownerObj, in a), "item", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        map.FastAddValue((KeyString)"item", new DomFunction((in a) => Item(element, ownerObj, in a), "item", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Numeric index access — expose each attribute by index
         var attrKeys = DomBridge.AttributeNames(element).ToList();
         for (var i = 0; i < attrKeys.Count; i++)
         {
             var idx = i;
-            map.FastAddProperty((KeyString)idx.ToString(), new JSFunction((in _) => IndexedItem(element, idx, ownerObj, in _), "get " + idx), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+            map.FastAddProperty((KeyString)idx.ToString(), new DomFunction((in _) => IndexedItem(element, idx, ownerObj, in _), "get " + idx), null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
         return map;

--- a/src/Broiler.HtmlBridge.Dom/Features/CanvasBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/CanvasBinding.cs
@@ -32,7 +32,7 @@ internal static class CanvasBinding
     public static void Install(JSObject obj, DomElement element)
     {
         obj.FastAddValue((KeyString)"getContext",
-            new JSFunction((in a) => GetContext(element, in a), "getContext", 1),
+            new DomFunction((in a) => GetContext(element, in a), "getContext", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
 
@@ -70,70 +70,70 @@ internal static class CanvasBinding
 
         // fillStyle (get/set)
         ctx.FastAddProperty((KeyString)"fillStyle",
-            new JSFunction((in _) => new JSString(context2d.FillStyle), "get fillStyle"),
-            new JSFunction((in a) => SetFillStyle(context2d, in a), "set fillStyle"),
+            new DomFunction((in _) => new JSString(context2d.FillStyle), "get fillStyle"),
+            new DomFunction((in a) => SetFillStyle(context2d, in a), "set fillStyle"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // strokeStyle (get/set)
         ctx.FastAddProperty((KeyString)"strokeStyle",
-            new JSFunction((in _) => new JSString(context2d.StrokeStyle), "get strokeStyle"),
-            new JSFunction((in a) => SetStrokeStyle(context2d, in a), "set strokeStyle"),
+            new DomFunction((in _) => new JSString(context2d.StrokeStyle), "get strokeStyle"),
+            new DomFunction((in a) => SetStrokeStyle(context2d, in a), "set strokeStyle"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // lineWidth (get/set)
         ctx.FastAddProperty((KeyString)"lineWidth",
-            new JSFunction((in _) => new JSNumber(context2d.LineWidth), "get lineWidth"),
-            new JSFunction((in a) => SetLineWidth(context2d, in a), "set lineWidth"),
+            new DomFunction((in _) => new JSNumber(context2d.LineWidth), "get lineWidth"),
+            new DomFunction((in a) => SetLineWidth(context2d, in a), "set lineWidth"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // font (get/set)
         ctx.FastAddProperty((KeyString)"font",
-            new JSFunction((in _) => new JSString(context2d.Font), "get font"),
-            new JSFunction((in a) => SetFont(context2d, in a), "set font"),
+            new DomFunction((in _) => new JSString(context2d.Font), "get font"),
+            new DomFunction((in a) => SetFont(context2d, in a), "set font"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // globalAlpha (get/set)
         ctx.FastAddProperty((KeyString)"globalAlpha",
-            new JSFunction((in _) => new JSNumber(context2d.GlobalAlpha), "get globalAlpha"),
-            new JSFunction((in a) => SetGlobalAlpha(context2d, in a), "set globalAlpha"),
+            new DomFunction((in _) => new JSNumber(context2d.GlobalAlpha), "get globalAlpha"),
+            new DomFunction((in a) => SetGlobalAlpha(context2d, in a), "set globalAlpha"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // canvas property
         ctx.FastAddProperty((KeyString)"canvas",
-            new JSFunction((in _) => new JSObject(), "get canvas"),
+            new DomFunction((in _) => new JSObject(), "get canvas"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // Drawing methods
-        ctx.FastAddValue((KeyString)"fillRect", new JSFunction((in a) => FillRect(context2d, in a), "fillRect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"fillRect", new DomFunction((in a) => FillRect(context2d, in a), "fillRect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"strokeRect", new JSFunction((in a) => StrokeRect(context2d, in a), "strokeRect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"strokeRect", new DomFunction((in a) => StrokeRect(context2d, in a), "strokeRect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"clearRect", new JSFunction((in a) => ClearRect(context2d, in a), "clearRect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"clearRect", new DomFunction((in a) => ClearRect(context2d, in a), "clearRect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"beginPath", new JSFunction((in _) => BeginPath(context2d, in _), "beginPath", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"beginPath", new DomFunction((in _) => BeginPath(context2d, in _), "beginPath", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"moveTo", new JSFunction((in a) => MoveTo(context2d, in a), "moveTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"moveTo", new DomFunction((in a) => MoveTo(context2d, in a), "moveTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"lineTo", new JSFunction((in a) => LineTo(context2d, in a), "lineTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"lineTo", new DomFunction((in a) => LineTo(context2d, in a), "lineTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"arc", new JSFunction((in a) => Arc(context2d, in a), "arc", 5), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"arc", new DomFunction((in a) => Arc(context2d, in a), "arc", 5), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"closePath", new JSFunction((in _) => ClosePath(context2d, in _), "closePath", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"closePath", new DomFunction((in _) => ClosePath(context2d, in _), "closePath", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"fill", new JSFunction((in _) => Fill(context2d, in _), "fill", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"fill", new DomFunction((in _) => Fill(context2d, in _), "fill", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"stroke", new JSFunction((in _) => Stroke(context2d, in _), "stroke", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"stroke", new DomFunction((in _) => Stroke(context2d, in _), "stroke", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"fillText", new JSFunction((in a) => FillText(context2d, in a), "fillText", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"fillText", new DomFunction((in a) => FillText(context2d, in a), "fillText", 3), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"strokeText", new JSFunction((in a) => StrokeText(context2d, in a), "strokeText", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"strokeText", new DomFunction((in a) => StrokeText(context2d, in a), "strokeText", 3), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"save", new JSFunction((in _) => Save(context2d, in _), "save", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"save", new DomFunction((in _) => Save(context2d, in _), "save", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        ctx.FastAddValue((KeyString)"restore", new JSFunction((in _) => Restore(context2d, in _), "restore", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"restore", new DomFunction((in _) => Restore(context2d, in _), "restore", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // measureText(text) — returns { width: ... }
-        ctx.FastAddValue((KeyString)"measureText", new JSFunction((in a) => MeasureText(in a), "measureText", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"measureText", new DomFunction((in a) => MeasureText(in a), "measureText", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         return ctx;
     }

--- a/src/Broiler.HtmlBridge.Dom/Features/ClassListBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ClassListBinding.cs
@@ -26,23 +26,23 @@ internal static class ClassListBinding
         var classList = new JSObject();
 
         classList.FastAddValue((KeyString)"contains",
-            new JSFunction((in a) => Contains(element, in a), "contains", 1),
+            new DomFunction((in a) => Contains(element, in a), "contains", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         classList.FastAddValue((KeyString)"add",
-            new JSFunction((in a) => Add(element, onClassChanged, in a), "add"),
+            new DomFunction((in a) => Add(element, onClassChanged, in a), "add"),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         classList.FastAddValue((KeyString)"remove",
-            new JSFunction((in a) => Remove(element, onClassChanged, in a), "remove"),
+            new DomFunction((in a) => Remove(element, onClassChanged, in a), "remove"),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         classList.FastAddValue((KeyString)"toggle",
-            new JSFunction((in a) => Toggle(element, onClassChanged, in a), "toggle", 1),
+            new DomFunction((in a) => Toggle(element, onClassChanged, in a), "toggle", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         classList.FastAddValue((KeyString)"replace",
-            new JSFunction((in a) => Replace(element, onClassChanged, in a), "replace", 2),
+            new DomFunction((in a) => Replace(element, onClassChanged, in a), "replace", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         return classList;

--- a/src/Broiler.HtmlBridge.Dom/Features/ConsoleBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ConsoleBinding.cs
@@ -26,22 +26,22 @@ internal static class ConsoleBinding
 
         console.FastAddValue(
             (KeyString)"log",
-            new JSFunction(Log, "log"),
+            new DomFunction(Log, "log"),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         console.FastAddValue(
             (KeyString)"warn",
-            new JSFunction(Warn, "warn"),
+            new DomFunction(Warn, "warn"),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         console.FastAddValue(
             (KeyString)"error",
-            new JSFunction(Error, "error"),
+            new DomFunction(Error, "error"),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         console.FastAddValue(
             (KeyString)"info",
-            new JSFunction(Info, "info"),
+            new DomFunction(Info, "info"),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         return console;

--- a/src/Broiler.HtmlBridge.Dom/Features/CryptoBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/CryptoBinding.cs
@@ -27,12 +27,12 @@ internal static class CryptoBinding
 
         crypto.FastAddValue(
             (KeyString)"getRandomValues",
-            new JSFunction(GetRandomValues, "getRandomValues", 1),
+            new DomFunction(GetRandomValues, "getRandomValues", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         crypto.FastAddValue(
             (KeyString)"randomUUID",
-            new JSFunction(RandomUuid, "randomUUID", 0),
+            new DomFunction(RandomUuid, "randomUUID", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         return crypto;

--- a/src/Broiler.HtmlBridge.Dom/Features/DialogBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/DialogBinding.cs
@@ -30,23 +30,23 @@ internal sealed class DialogBinding(IDialogHost host)
         if (tag == "details")
         {
             obj.FastAddProperty((KeyString)"open",
-                new JSFunction((in _) => _host.HasOpenAttribute(element) ? JSBoolean.True : JSBoolean.False, "get open"),
-                new JSFunction((in a) => SetOpenState(element, in a), "set open"),
+                new DomFunction((in _) => _host.HasOpenAttribute(element) ? JSBoolean.True : JSBoolean.False, "get open"),
+                new DomFunction((in a) => SetOpenState(element, in a), "set open"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
         if (tag == "dialog")
         {
-            obj.FastAddValue((KeyString)"showModal", new JSFunction((in _) => ShowModal(element), "showModal", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"show", new JSFunction((in _) => Show(element), "show", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"close", new JSFunction((in a) => Close(element, in a), "close", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue((KeyString)"showModal", new DomFunction((in _) => ShowModal(element), "showModal", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue((KeyString)"show", new DomFunction((in _) => Show(element), "show", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue((KeyString)"close", new DomFunction((in a) => Close(element, in a), "close", 1), JSPropertyAttributes.EnumerableConfigurableValue);
             obj.FastAddProperty((KeyString)"open",
-                new JSFunction((in _) => _host.HasOpenAttribute(element) ? JSBoolean.True : JSBoolean.False, "get open"),
-                new JSFunction((in a) => SetOpenState(element, in a), "set open"),
+                new DomFunction((in _) => _host.HasOpenAttribute(element) ? JSBoolean.True : JSBoolean.False, "get open"),
+                new DomFunction((in a) => SetOpenState(element, in a), "set open"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
             obj.FastAddProperty((KeyString)"returnValue",
-                new JSFunction((in _) => new JSString(_host.GetReturnValue(element)), "get returnValue"),
-                new JSFunction((in a) => SetReturnValue(element, in a), "set returnValue"),
+                new DomFunction((in _) => new JSString(_host.GetReturnValue(element)), "get returnValue"),
+                new DomFunction((in a) => SetReturnValue(element, in a), "set returnValue"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
@@ -54,8 +54,8 @@ internal sealed class DialogBinding(IDialogHost host)
         // carrying the global `popover` attribute, not tied to a tag.
         if (hasPopover)
         {
-            obj.FastAddValue((KeyString)"showPopover", new JSFunction((in _) => ShowPopover(element), "showPopover", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"hidePopover", new JSFunction((in _) => HidePopover(element), "hidePopover", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue((KeyString)"showPopover", new DomFunction((in _) => ShowPopover(element), "showPopover", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue((KeyString)"hidePopover", new DomFunction((in _) => HidePopover(element), "hidePopover", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         }
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/ElementContentBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ElementContentBinding.cs
@@ -25,14 +25,14 @@ internal static class ElementContentBinding
     {
         // innerHTML (read/write)
         obj.FastAddProperty((KeyString)"innerHTML",
-            new JSFunction((in _) => new JSString(host.SerializeChildrenToHtml(element)), "get innerHTML"),
-            new JSFunction((in a) => SetInnerHtml(host, element, in a), "set innerHTML"),
+            new DomFunction((in _) => new JSString(host.SerializeChildrenToHtml(element)), "get innerHTML"),
+            new DomFunction((in a) => SetInnerHtml(host, element, in a), "set innerHTML"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // outerHTML (read/write)
         obj.FastAddProperty((KeyString)"outerHTML",
-            new JSFunction((in _) => new JSString(host.SerializeElementToHtml(element)), "get outerHTML"),
-            new JSFunction((in a) => SetOuterHtml(host, element, in a), "set outerHTML"),
+            new DomFunction((in _) => new JSString(host.SerializeElementToHtml(element)), "get outerHTML"),
+            new DomFunction((in a) => SetOuterHtml(host, element, in a), "set outerHTML"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
     }
 
@@ -41,16 +41,16 @@ internal static class ElementContentBinding
     {
         // textContent (read/write)
         obj.FastAddProperty((KeyString)"textContent",
-            new JSFunction((in _) => host.GetNodeTextValue(element), "get textContent"),
-            new JSFunction((in a) => SetTextContent(host, element, in a), "set textContent"),
+            new DomFunction((in _) => host.GetNodeTextValue(element), "get textContent"),
+            new DomFunction((in a) => SetTextContent(host, element, in a), "set textContent"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"innerText",
-            new JSFunction((in _) => host.GetNodeTextValue(element), "get innerText"),
+            new DomFunction((in _) => host.GetNodeTextValue(element), "get innerText"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"outerText",
-            new JSFunction((in _) => host.GetNodeTextValue(element), "get outerText"),
+            new DomFunction((in _) => host.GetNodeTextValue(element), "get outerText"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/ElementGeometryBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ElementGeometryBinding.cs
@@ -35,87 +35,87 @@ internal static class ElementGeometryBinding
         var isViewportElement = host.IsViewportElementForMetrics(element);
 
         obj.FastAddProperty((KeyString)"clientTop",
-            new JSFunction((in _) => new JSNumber(host.GetClientTopForDomElement(element)), "get clientTop"),
+            new DomFunction((in _) => new JSNumber(host.GetClientTopForDomElement(element)), "get clientTop"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"clientLeft",
-            new JSFunction((in _) => new JSNumber(host.GetClientLeftForDomElement(element)), "get clientLeft"),
+            new DomFunction((in _) => new JSNumber(host.GetClientLeftForDomElement(element)), "get clientLeft"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"clientWidth",
-            new JSFunction((in _) => new JSNumber(host.GetClientWidthForDomElement(element, isViewportElement)), "get clientWidth"),
+            new DomFunction((in _) => new JSNumber(host.GetClientWidthForDomElement(element, isViewportElement)), "get clientWidth"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"clientHeight",
-            new JSFunction((in _) => new JSNumber(host.GetClientHeightForDomElement(element, isViewportElement)), "get clientHeight"),
+            new DomFunction((in _) => new JSNumber(host.GetClientHeightForDomElement(element, isViewportElement)), "get clientHeight"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"offsetWidth",
-            new JSFunction((in _) => new JSNumber(host.GetOffsetWidthForDomElement(element, isViewportElement)), "get offsetWidth"),
+            new DomFunction((in _) => new JSNumber(host.GetOffsetWidthForDomElement(element, isViewportElement)), "get offsetWidth"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"offsetHeight",
-            new JSFunction((in _) => new JSNumber(host.GetOffsetHeightForDomElement(element, isViewportElement)), "get offsetHeight"),
+            new DomFunction((in _) => new JSNumber(host.GetOffsetHeightForDomElement(element, isViewportElement)), "get offsetHeight"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"scrollWidth",
-            new JSFunction((in _) => new JSNumber(host.GetScrollWidthForDomElement(element, isViewportElement)), "get scrollWidth"),
+            new DomFunction((in _) => new JSNumber(host.GetScrollWidthForDomElement(element, isViewportElement)), "get scrollWidth"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"scrollHeight",
-            new JSFunction((in _) => new JSNumber(host.GetScrollHeightForDomElement(element, isViewportElement)), "get scrollHeight"),
+            new DomFunction((in _) => new JSNumber(host.GetScrollHeightForDomElement(element, isViewportElement)), "get scrollHeight"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"scrollTop",
-            new JSFunction((in _) => GetScrollTop(host, element), "get scrollTop"),
-            new JSFunction((in a) => SetScrollTop(host, element, in a), "set scrollTop"),
+            new DomFunction((in _) => GetScrollTop(host, element), "get scrollTop"),
+            new DomFunction((in a) => SetScrollTop(host, element, in a), "set scrollTop"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"scrollLeft",
-            new JSFunction((in _) => GetScrollLeft(host, element), "get scrollLeft"),
-            new JSFunction((in a) => SetScrollLeft(host, element, in a), "set scrollLeft"),
+            new DomFunction((in _) => GetScrollLeft(host, element), "get scrollLeft"),
+            new DomFunction((in a) => SetScrollLeft(host, element, in a), "set scrollLeft"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"offsetTop",
-            new JSFunction((in _) => new JSNumber(host.GetOffsetTopForDomElement(element)), "get offsetTop"),
+            new DomFunction((in _) => new JSNumber(host.GetOffsetTopForDomElement(element)), "get offsetTop"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"offsetLeft",
-            new JSFunction((in _) => new JSNumber(host.GetOffsetLeftForDomElement(element)), "get offsetLeft"),
+            new DomFunction((in _) => new JSNumber(host.GetOffsetLeftForDomElement(element)), "get offsetLeft"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"offsetParent",
-            new JSFunction((in _) => GetOffsetParent(host, element), "get offsetParent"),
+            new DomFunction((in _) => GetOffsetParent(host, element), "get offsetParent"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // getBoundingClientRect() — returns DOMRect-like object
         obj.FastAddValue((KeyString)"getBoundingClientRect",
-            new JSFunction((in _) => GetBoundingClientRect(host, element, isViewportElement), "getBoundingClientRect", 0),
+            new DomFunction((in _) => GetBoundingClientRect(host, element, isViewportElement), "getBoundingClientRect", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // getClientRects() — returns array with one DOMRect for root elements
         obj.FastAddValue((KeyString)"getClientRects",
-            new JSFunction((in a2) => GetClientRects(host, element, isViewportElement), "getClientRects", 0),
+            new DomFunction((in a2) => GetClientRects(host, element, isViewportElement), "getClientRects", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"scrollIntoView",
-            new JSFunction((in a) => ScrollIntoView(host, element, in a), "scrollIntoView", 1),
+            new DomFunction((in a) => ScrollIntoView(host, element, in a), "scrollIntoView", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"scroll",
-            new JSFunction((in a) => Scroll(host, element, in a), "scroll", 2),
+            new DomFunction((in a) => Scroll(host, element, in a), "scroll", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"scrollTo",
-            new JSFunction((in a) => Scroll(host, element, in a), "scrollTo", 2),
+            new DomFunction((in a) => Scroll(host, element, in a), "scrollTo", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"scrollBy",
-            new JSFunction((in a) => ScrollBy(host, element, in a), "scrollBy", 2),
+            new DomFunction((in a) => ScrollBy(host, element, in a), "scrollBy", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"scrollParent",
-            new JSFunction((in _) => GetScrollParent(host, element), "scrollParent", 0),
+            new DomFunction((in _) => GetScrollParent(host, element), "scrollParent", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/EventDispatchBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/EventDispatchBinding.cs
@@ -64,30 +64,30 @@ internal sealed class EventDispatchBinding(IEventDispatchHost host)
         evt[(KeyString)"eventPhase"] = new JSNumber(0);
 
         evt.FastAddValue((KeyString)"stopPropagation",
-            new JSFunction((in _) => EventStopPropagation(ref legacyCancelBubble, ref stopped, in _), "stopPropagation", 0),
+            new DomFunction((in _) => EventStopPropagation(ref legacyCancelBubble, ref stopped, in _), "stopPropagation", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         evt.FastAddValue((KeyString)"stopImmediatePropagation",
-            new JSFunction((in _) => EventStopImmediatePropagation(ref immediateStopped, ref legacyCancelBubble, ref stopped, in _), "stopImmediatePropagation", 0),
+            new DomFunction((in _) => EventStopImmediatePropagation(ref immediateStopped, ref legacyCancelBubble, ref stopped, in _), "stopImmediatePropagation", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         evt.FastAddValue((KeyString)"preventDefault",
-            new JSFunction((in _) => EventPreventDefault(currentListenerPassive, evt, ref prevented, in _), "preventDefault", 0),
+            new DomFunction((in _) => EventPreventDefault(currentListenerPassive, evt, ref prevented, in _), "preventDefault", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         evt.FastAddProperty(
             (KeyString)"cancelBubble",
-            new JSFunction((in _) => legacyCancelBubble ? JSBoolean.True : JSBoolean.False, "get cancelBubble"),
-            new JSFunction((in setArgs) => EventSetCancelBubble(ref legacyCancelBubble, ref stopped, in setArgs), "set cancelBubble"),
+            new DomFunction((in _) => legacyCancelBubble ? JSBoolean.True : JSBoolean.False, "get cancelBubble"),
+            new DomFunction((in setArgs) => EventSetCancelBubble(ref legacyCancelBubble, ref stopped, in setArgs), "set cancelBubble"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         evt.FastAddProperty((KeyString)"returnValue",
-            new JSFunction((in _) => prevented ? JSBoolean.False : JSBoolean.True, "get returnValue"),
-            new JSFunction((in setArgs) => EventSetReturnValue(currentListenerPassive, evt, ref prevented, in setArgs), "set returnValue"),
+            new DomFunction((in _) => prevented ? JSBoolean.False : JSBoolean.True, "get returnValue"),
+            new DomFunction((in setArgs) => EventSetReturnValue(currentListenerPassive, evt, ref prevented, in setArgs), "set returnValue"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         evt.FastAddValue((KeyString)"composedPath",
-            new JSFunction((in _) => BuildComposedPathValue(target, path), "composedPath", 0),
+            new DomFunction((in _) => BuildComposedPathValue(target, path), "composedPath", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Phase 1: Capture (root → parent of target)

--- a/src/Broiler.HtmlBridge.Dom/Features/EventTargetBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/EventTargetBinding.cs
@@ -129,7 +129,7 @@ internal static class EventTargetBinding
                         return JSUndefined.Value;
                     }
 
-                    submitEvt.FastAddValue((KeyString)"preventDefault", new JSFunction(JsJsObjectsPreventDefault100, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+                    submitEvt.FastAddValue((KeyString)"preventDefault", new DomFunction(JsJsObjectsPreventDefault100, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
                     submitEvt.FastAddValue((KeyString)"stopPropagation", DomBridge.UndefinedFunction("stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
                     submitEvt.FastAddValue((KeyString)"stopImmediatePropagation", DomBridge.UndefinedFunction("stopImmediatePropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
                     host.DispatchEventOnElement(form, submitEvt);

--- a/src/Broiler.HtmlBridge.Dom/Features/FetchBinding.Callbacks.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/FetchBinding.Callbacks.cs
@@ -158,7 +158,7 @@ internal sealed partial class FetchBinding
             return promise;
         }
 
-        promise.FastAddValue((KeyString)"then", new JSFunction(JsRegistrationThen118, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        promise.FastAddValue((KeyString)"then", new DomFunction(JsRegistrationThen118, "then", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationCatch119(in Arguments catchArgs)
         {
             if (rejected && catchArgs.Length > 0 && catchArgs[0] is JSFunction cb)
@@ -176,7 +176,7 @@ internal sealed partial class FetchBinding
             return promise;
         }
 
-        promise.FastAddValue((KeyString)"catch", new JSFunction(JsRegistrationCatch119, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        promise.FastAddValue((KeyString)"catch", new DomFunction(JsRegistrationCatch119, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         return promise;
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/FormBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/FormBinding.cs
@@ -32,16 +32,16 @@ internal sealed class FormBinding(IFormHost host)
 
         // elements — the form controls collection (numeric + named access)
         obj.FastAddProperty((KeyString)"elements",
-            new JSFunction((in _) => BuildElementsCollection(element), "get elements"),
+            new DomFunction((in _) => BuildElementsCollection(element), "get elements"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         // length — alias for elements.length
         obj.FastAddProperty((KeyString)"length",
-            new JSFunction((in _) => new JSNumber(HtmlElementQueries.CollectFormControls(element).Count), "get length"),
+            new DomFunction((in _) => new JSNumber(HtmlElementQueries.CollectFormControls(element).Count), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         // action (read/write)
         obj.FastAddProperty((KeyString)"action",
-            new JSFunction((in _) => DomBridge.TryGetAttribute(element, "action", out var act) ? new JSString(act) : new JSString(string.Empty), "get action"),
-            new JSFunction((in a) => SetAction(element, in a), "set action"),
+            new DomFunction((in _) => DomBridge.TryGetAttribute(element, "action", out var act) ? new JSString(act) : new JSString(string.Empty), "get action"),
+            new DomFunction((in a) => SetAction(element, in a), "set action"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
     }
 
@@ -57,7 +57,7 @@ internal sealed class FormBinding(IFormHost host)
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
         collection.FastAddProperty((KeyString)"length",
-            new JSFunction((in _) => new JSNumber(HtmlElementQueries.CollectFormControls(form).Count), "get length"),
+            new DomFunction((in _) => new JSNumber(HtmlElementQueries.CollectFormControls(form).Count), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         return collection;

--- a/src/Broiler.HtmlBridge.Dom/Features/FormControlBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/FormControlBinding.cs
@@ -29,52 +29,52 @@ internal sealed class FormControlBinding(IFormControlHost host)
         // value (read/write) — for input, textarea, select elements.
         // The IDL 'value' property is NOT reflected as a content attribute for inputs.
         obj.FastAddProperty((KeyString)"value",
-            new JSFunction((in _) => GetValue(element), "get value"),
-            new JSFunction((in a) => SetValue(element, in a), "set value"),
+            new DomFunction((in _) => GetValue(element), "get value"),
+            new DomFunction((in a) => SetValue(element, in a), "set value"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // checked (read/write) — for checkbox and radio inputs. Uses the typed checked-state slot as the
         // "dirty" IDL state that tracks programmatic changes; setAttribute("checked") only sets the
         // content attribute and does NOT affect this IDL state.
         obj.FastAddProperty((KeyString)"checked",
-            new JSFunction((in _) => GetChecked(element), "get checked"),
-            new JSFunction((in a) => SetChecked(element, in a), "set checked"),
+            new DomFunction((in _) => GetChecked(element), "get checked"),
+            new DomFunction((in a) => SetChecked(element, in a), "set checked"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // type (read/write) — for input/button elements; getter returns lowercase.
         obj.FastAddProperty((KeyString)"type",
-            new JSFunction((in _) => GetType(element), "get type"),
-            new JSFunction((in a) => SetType(element, in a), "set type"),
+            new DomFunction((in _) => GetType(element), "get type"),
+            new DomFunction((in a) => SetType(element, in a), "set type"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // name (read/write) — for form elements; syncs with content attribute.
         obj.FastAddProperty((KeyString)"name",
-            new JSFunction((in _) => GetName(element), "get name"),
-            new JSFunction((in a) => SetName(element, in a), "set name"),
+            new DomFunction((in _) => GetName(element), "get name"),
+            new DomFunction((in a) => SetName(element, in a), "set name"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // disabled (read/write) — for form controls.
         obj.FastAddProperty((KeyString)"disabled",
-            new JSFunction((in _) => DomBridge.HasAttr(element, "disabled") ? JSBoolean.True : JSBoolean.False, "get disabled"),
-            new JSFunction((in a) => SetDisabled(element, in a), "set disabled"),
+            new DomFunction((in _) => DomBridge.HasAttr(element, "disabled") ? JSBoolean.True : JSBoolean.False, "get disabled"),
+            new DomFunction((in a) => SetDisabled(element, in a), "set disabled"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // hidden (read/write) — global reflected boolean attribute.
         obj.FastAddProperty((KeyString)"hidden",
-            new JSFunction((in _) => DomBridge.HasAttr(element, "hidden") ? JSBoolean.True : JSBoolean.False, "get hidden"),
-            new JSFunction((in a) => SetHidden(element, in a), "set hidden"),
+            new DomFunction((in _) => DomBridge.HasAttr(element, "hidden") ? JSBoolean.True : JSBoolean.False, "get hidden"),
+            new DomFunction((in a) => SetHidden(element, in a), "set hidden"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // tabIndex (read/write) — global reflected numeric attribute.
         obj.FastAddProperty((KeyString)"tabIndex",
-            new JSFunction((in _) => GetTabIndex(element), "get tabIndex"),
-            new JSFunction((in a) => SetTabIndex(element, in a), "set tabIndex"),
+            new DomFunction((in _) => GetTabIndex(element), "get tabIndex"),
+            new DomFunction((in a) => SetTabIndex(element, in a), "set tabIndex"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // required (read/write) — form validation.
         obj.FastAddProperty((KeyString)"required",
-            new JSFunction((in _) => DomBridge.HasAttr(element, "required") ? JSBoolean.True : JSBoolean.False, "get required"),
-            new JSFunction((in a) => SetRequired(element, in a), "set required"),
+            new DomFunction((in _) => DomBridge.HasAttr(element, "required") ? JSBoolean.True : JSBoolean.False, "get required"),
+            new DomFunction((in a) => SetRequired(element, in a), "set required"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/FormSubmitBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/FormSubmitBinding.cs
@@ -40,7 +40,7 @@ internal static class FormSubmitBinding
                 return JSUndefined.Value;
             }
 
-            submitEvt.FastAddValue((KeyString)"preventDefault", new JSFunction(PreventDefault, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            submitEvt.FastAddValue((KeyString)"preventDefault", new DomFunction(PreventDefault, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
             submitEvt.FastAddValue((KeyString)"stopPropagation", DomBridge.UndefinedFunction("stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
             if (host.GetEventListeners(element).TryGetValue("submit", out var submitListeners))
             {

--- a/src/Broiler.HtmlBridge.Dom/Features/GlobalAttributeBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/GlobalAttributeBinding.cs
@@ -26,44 +26,44 @@ internal static class GlobalAttributeBinding
     public static void Install(IGlobalAttributeHost host, JSObject obj, DomElement element)
     {
         obj.FastAddProperty((KeyString)"id",
-            new JSFunction((in _) => element.Id != null ? new JSString(element.Id) : JSNull.Value, "get id"),
-            new JSFunction((in a) => SetId(host, element, in a), "set id"),
+            new DomFunction((in _) => element.Id != null ? new JSString(element.Id) : JSNull.Value, "get id"),
+            new DomFunction((in a) => SetId(host, element, in a), "set id"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // className (read/write) — reflects the 'class' content attribute
         obj.FastAddProperty((KeyString)"className",
-            new JSFunction((in _) => GetClassName(element), "get className"),
-            new JSFunction((in a) => SetClassName(host, element, in a), "set className"),
+            new DomFunction((in _) => GetClassName(element), "get className"),
+            new DomFunction((in a) => SetClassName(host, element, in a), "set className"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // title (read/write) — synced with attributes["title"]
         obj.FastAddProperty((KeyString)"title",
-            new JSFunction((in _) => ReflectedGet(element, "title"), "get title"),
-            new JSFunction((in a) => ReflectedSet(element, "title", in a), "set title"),
+            new DomFunction((in _) => ReflectedGet(element, "title"), "get title"),
+            new DomFunction((in a) => ReflectedSet(element, "title", in a), "set title"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // lang (read/write) — synced with attributes["lang"]
         obj.FastAddProperty((KeyString)"lang",
-            new JSFunction((in _) => ReflectedGet(element, "lang"), "get lang"),
-            new JSFunction((in a) => ReflectedSet(element, "lang", in a), "set lang"),
+            new DomFunction((in _) => ReflectedGet(element, "lang"), "get lang"),
+            new DomFunction((in a) => ReflectedSet(element, "lang", in a), "set lang"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // accessKey (read/write) — synced with attributes["accesskey"]
         obj.FastAddProperty((KeyString)"accessKey",
-            new JSFunction((in _) => ReflectedGet(element, "accesskey"), "get accessKey"),
-            new JSFunction((in a) => ReflectedSet(element, "accesskey", in a), "set accessKey"),
+            new DomFunction((in _) => ReflectedGet(element, "accesskey"), "get accessKey"),
+            new DomFunction((in a) => ReflectedSet(element, "accesskey", in a), "set accessKey"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // dir (read/write) — synced with attributes["dir"]
         obj.FastAddProperty((KeyString)"dir",
-            new JSFunction((in _) => ReflectedGet(element, "dir"), "get dir"),
-            new JSFunction((in a) => SetDir(host, element, in a), "set dir"),
+            new DomFunction((in _) => ReflectedGet(element, "dir"), "get dir"),
+            new DomFunction((in a) => SetDir(host, element, in a), "set dir"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // draggable (read/write) — reflected enumerated attribute
         obj.FastAddProperty((KeyString)"draggable",
-            new JSFunction((in _) => GetDraggable(element), "get draggable"),
-            new JSFunction((in a) => SetDraggable(element, in a), "set draggable"),
+            new DomFunction((in _) => GetDraggable(element), "get draggable"),
+            new DomFunction((in a) => SetDraggable(element, in a), "set draggable"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/IframeElementBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/IframeElementBinding.cs
@@ -31,32 +31,32 @@ internal static class IframeElementBinding
             return;
 
         obj.FastAddProperty((KeyString)"contentDocument",
-            new JSFunction((in _) => GetContentDocument(host, element), "get contentDocument"),
+            new DomFunction((in _) => GetContentDocument(host, element), "get contentDocument"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"contentWindow",
-            new JSFunction((in _) => GetContentWindow(host, element), "get contentWindow"),
+            new DomFunction((in _) => GetContentWindow(host, element), "get contentWindow"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // getSVGDocument() — returns contentDocument (same as contentDocument for same-origin)
         obj.FastAddValue((KeyString)"getSVGDocument",
-            new JSFunction((in _) => GetContentDocument(host, element), "getSVGDocument", 0),
+            new DomFunction((in _) => GetContentDocument(host, element), "getSVGDocument", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // src property (read/write) — for iframe elements
         obj.FastAddProperty((KeyString)"src",
-            new JSFunction((in _) => DomBridge.TryGetAttribute(element, "src", out var s) ? new JSString(s) : new JSString(string.Empty), "get src"),
-            new JSFunction((in a) => SetFrameAttribute(host, element, "src", in a), "set src"),
+            new DomFunction((in _) => DomBridge.TryGetAttribute(element, "src", out var s) ? new JSString(s) : new JSString(string.Empty), "get src"),
+            new DomFunction((in a) => SetFrameAttribute(host, element, "src", in a), "set src"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         obj.FastAddProperty((KeyString)"srcdoc",
-            new JSFunction((in _) => DomBridge.TryGetAttribute(element, "srcdoc", out var s) ? new JSString(s) : new JSString(string.Empty), "get srcdoc"),
-            new JSFunction((in a) => SetFrameAttribute(host, element, "srcdoc", in a), "set srcdoc"),
+            new DomFunction((in _) => DomBridge.TryGetAttribute(element, "srcdoc", out var s) ? new JSString(s) : new JSString(string.Empty), "get srcdoc"),
+            new DomFunction((in a) => SetFrameAttribute(host, element, "srcdoc", in a), "set srcdoc"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // sandbox attribute access
         obj.FastAddProperty((KeyString)"sandbox",
-            new JSFunction((in _) => DomBridge.TryGetAttribute(element, "sandbox", out var sandbox) ? new JSString(sandbox) : new JSString(string.Empty), "get sandbox"),
+            new DomFunction((in _) => DomBridge.TryGetAttribute(element, "sandbox", out var sandbox) ? new JSString(sandbox) : new JSString(string.Empty), "get sandbox"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/InsertAdjacentBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/InsertAdjacentBinding.cs
@@ -24,15 +24,15 @@ internal static class InsertAdjacentBinding
     public static void Install(IInsertAdjacentHost host, JSObject obj, DomElement element)
     {
         obj.FastAddValue((KeyString)"insertAdjacentElement",
-            new JSFunction((in a) => InsertAdjacentElement(host, element, in a), "insertAdjacentElement", 2),
+            new DomFunction((in a) => InsertAdjacentElement(host, element, in a), "insertAdjacentElement", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"insertAdjacentText",
-            new JSFunction((in a) => InsertAdjacentText(host, element, in a), "insertAdjacentText", 2),
+            new DomFunction((in a) => InsertAdjacentText(host, element, in a), "insertAdjacentText", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddValue((KeyString)"insertAdjacentHTML",
-            new JSFunction((in a) => InsertAdjacentHtml(host, element, in a), "insertAdjacentHTML", 2),
+            new DomFunction((in a) => InsertAdjacentHtml(host, element, in a), "insertAdjacentHTML", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/LegacyEventBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/LegacyEventBinding.cs
@@ -66,14 +66,14 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"stopPropagation", new JSFunction(JsRegistrationStopPropagation018, "stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"stopPropagation", new DomFunction(JsRegistrationStopPropagation018, "stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationStopImmediatePropagation019(in Arguments _)
         {
             legacyCancelBubble = true;
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"stopImmediatePropagation", new JSFunction(JsRegistrationStopImmediatePropagation019, "stopImmediatePropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"stopImmediatePropagation", new DomFunction(JsRegistrationStopImmediatePropagation019, "stopImmediatePropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationPreventDefault020(in Arguments _)
         {
             var cancelable = evt[(KeyString)"cancelable"];
@@ -82,7 +82,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"preventDefault", new JSFunction(JsRegistrationPreventDefault020, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"preventDefault", new DomFunction(JsRegistrationPreventDefault020, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationGetCancelBubble021(in Arguments _)
         {
             return legacyCancelBubble ? JSBoolean.True : JSBoolean.False;
@@ -95,7 +95,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddProperty((KeyString)"cancelBubble", new JSFunction(JsRegistrationGetCancelBubble021, "get cancelBubble"), new JSFunction(JsRegistrationSetCancelBubble022, "set cancelBubble"), JSPropertyAttributes.EnumerableConfigurableProperty);
+        evt.FastAddProperty((KeyString)"cancelBubble", new DomFunction(JsRegistrationGetCancelBubble021, "get cancelBubble"), new DomFunction(JsRegistrationSetCancelBubble022, "set cancelBubble"), JSPropertyAttributes.EnumerableConfigurableProperty);
         JSValue JsRegistrationGetReturnValue023(in Arguments _)
         {
             return evt[(KeyString)"defaultPrevented"].BooleanValue ? JSBoolean.False : JSBoolean.True;
@@ -109,7 +109,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddProperty((KeyString)"returnValue", new JSFunction(JsRegistrationGetReturnValue023, "get returnValue"), new JSFunction(JsRegistrationSetReturnValue024, "set returnValue"), JSPropertyAttributes.EnumerableConfigurableProperty);
+        evt.FastAddProperty((KeyString)"returnValue", new DomFunction(JsRegistrationGetReturnValue023, "get returnValue"), new DomFunction(JsRegistrationSetReturnValue024, "set returnValue"), JSPropertyAttributes.EnumerableConfigurableProperty);
         JSValue JsRegistrationInitEvent025(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -121,7 +121,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initEvent", new JSFunction(JsRegistrationInitEvent025, "initEvent", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initEvent", new DomFunction(JsRegistrationInitEvent025, "initEvent", 3), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationInitUIEvent026(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -137,7 +137,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initUIEvent", new JSFunction(JsRegistrationInitUIEvent026, "initUIEvent", 5), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initUIEvent", new DomFunction(JsRegistrationInitUIEvent026, "initUIEvent", 5), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationInitInputEvent027(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -157,7 +157,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initInputEvent", new JSFunction(JsRegistrationInitInputEvent027, "initInputEvent", 7), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initInputEvent", new DomFunction(JsRegistrationInitInputEvent027, "initInputEvent", 7), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationInitCustomEvent028(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -170,7 +170,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initCustomEvent", new JSFunction(JsRegistrationInitCustomEvent028, "initCustomEvent", 4), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initCustomEvent", new DomFunction(JsRegistrationInitCustomEvent028, "initCustomEvent", 4), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationInitFocusEvent029(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -188,7 +188,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initFocusEvent", new JSFunction(JsRegistrationInitFocusEvent029, "initFocusEvent", 6), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initFocusEvent", new DomFunction(JsRegistrationInitFocusEvent029, "initFocusEvent", 6), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationInitKeyboardEvent030(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -231,7 +231,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initKeyboardEvent", new JSFunction(JsRegistrationInitKeyboardEvent030, "initKeyboardEvent", 13), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initKeyboardEvent", new DomFunction(JsRegistrationInitKeyboardEvent030, "initKeyboardEvent", 13), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationInitMouseEvent031(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -286,7 +286,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initMouseEvent", new JSFunction(JsRegistrationInitMouseEvent031, "initMouseEvent", 15), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initMouseEvent", new DomFunction(JsRegistrationInitMouseEvent031, "initMouseEvent", 15), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue JsRegistrationInitWheelEvent032(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -339,7 +339,7 @@ internal static class LegacyEventBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initWheelEvent", new JSFunction(JsRegistrationInitWheelEvent032, "initWheelEvent", 16), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initWheelEvent", new DomFunction(JsRegistrationInitWheelEvent032, "initWheelEvent", 16), JSPropertyAttributes.EnumerableConfigurableValue);
         return evt;
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/MessagingBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/MessagingBinding.cs
@@ -53,15 +53,15 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
     internal void InstallEventTargetApi(JSObject target, string logContext)
     {
         target.FastAddValue((KeyString)"addEventListener",
-            new JSFunction((in a) => AddEventListener(target, in a), "addEventListener", 3),
+            new DomFunction((in a) => AddEventListener(target, in a), "addEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         target.FastAddValue((KeyString)"removeEventListener",
-            new JSFunction((in a) => RemoveEventListener(target, in a), "removeEventListener", 3),
+            new DomFunction((in a) => RemoveEventListener(target, in a), "removeEventListener", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         target.FastAddValue((KeyString)"dispatchEvent",
-            new JSFunction((in a) => DispatchEvent(logContext, target, in a), "dispatchEvent", 1),
+            new DomFunction((in a) => DispatchEvent(logContext, target, in a), "dispatchEvent", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
 
@@ -124,29 +124,29 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
         evt[(KeyString)"defaultPrevented"] = prevented ? JSBoolean.True : JSBoolean.False;
 
         evt.FastAddValue((KeyString)"stopPropagation",
-            new JSFunction((in _) => StopPropagation(ref legacyCancelBubble, in _), "stopPropagation", 0),
+            new DomFunction((in _) => StopPropagation(ref legacyCancelBubble, in _), "stopPropagation", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         evt.FastAddValue((KeyString)"stopImmediatePropagation",
-            new JSFunction((in _) => StopImmediatePropagation(ref immediateStopped, ref legacyCancelBubble, in _), "stopImmediatePropagation", 0),
+            new DomFunction((in _) => StopImmediatePropagation(ref immediateStopped, ref legacyCancelBubble, in _), "stopImmediatePropagation", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         evt.FastAddValue((KeyString)"preventDefault",
-            new JSFunction((in _) => PreventDefault(currentListenerPassive, evt, ref prevented, in _), "preventDefault", 0),
+            new DomFunction((in _) => PreventDefault(currentListenerPassive, evt, ref prevented, in _), "preventDefault", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         evt.FastAddProperty((KeyString)"cancelBubble",
-            new JSFunction((in _) => legacyCancelBubble ? JSBoolean.True : JSBoolean.False, "get cancelBubble"),
-            new JSFunction((in setArgs) => SetCancelBubble(ref legacyCancelBubble, in setArgs), "set cancelBubble"),
+            new DomFunction((in _) => legacyCancelBubble ? JSBoolean.True : JSBoolean.False, "get cancelBubble"),
+            new DomFunction((in setArgs) => SetCancelBubble(ref legacyCancelBubble, in setArgs), "set cancelBubble"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         evt.FastAddProperty((KeyString)"returnValue",
-            new JSFunction((in _) => prevented ? JSBoolean.False : JSBoolean.True, "get returnValue"),
-            new JSFunction((in setArgs) => SetReturnValue(currentListenerPassive, evt, ref prevented, in setArgs), "set returnValue"),
+            new DomFunction((in _) => prevented ? JSBoolean.False : JSBoolean.True, "get returnValue"),
+            new DomFunction((in setArgs) => SetReturnValue(currentListenerPassive, evt, ref prevented, in setArgs), "set returnValue"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         evt.FastAddValue((KeyString)"composedPath",
-            new JSFunction((in _) => new JSArray(target), "composedPath", 0),
+            new DomFunction((in _) => new JSArray(target), "composedPath", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         InvokeEventTargetHandler(target, eventType, evt, logContext);
@@ -248,7 +248,7 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
     {
         window.FastAddValue(
             (KeyString)"postMessage",
-            new JSFunction((in a) => WindowPostMessage(window, in a), "postMessage", 2),
+            new DomFunction((in a) => WindowPostMessage(window, in a), "postMessage", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
 
@@ -462,20 +462,20 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
         JSValue onMessageHandler = JSNull.Value;
 
         port.FastAddValue((KeyString)"postMessage",
-            new JSFunction((in a) => PortPostMessage(port, in a), "postMessage", 1),
+            new DomFunction((in a) => PortPostMessage(port, in a), "postMessage", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         port.FastAddProperty((KeyString)"onmessage",
-            new JSFunction((in _) => onMessageHandler, "get onmessage"),
-            new JSFunction((in a) => SetOnMessage(ref onMessageHandler, port, in a), "set onmessage"),
+            new DomFunction((in _) => onMessageHandler, "get onmessage"),
+            new DomFunction((in a) => SetOnMessage(ref onMessageHandler, port, in a), "set onmessage"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         port.FastAddValue((KeyString)"start",
-            new JSFunction((in a) => StartPort(port, in a), "start", 0),
+            new DomFunction((in a) => StartPort(port, in a), "start", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         port.FastAddValue((KeyString)"close",
-            new JSFunction((in a) => ClosePort(port, in a), "close", 0),
+            new DomFunction((in a) => ClosePort(port, in a), "close", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         return port;

--- a/src/Broiler.HtmlBridge.Dom/Features/MutationObserverBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/MutationObserverBinding.cs
@@ -44,8 +44,8 @@ internal sealed class MutationObserverBinding(IMutationObserverHost host)
     /// </summary>
     internal void RegisterDocumentApis(JSContext context)
     {
-        var registerMutationObserverFn = new JSFunction((in a) => RegisterObserver(in a), "__broilerRegisterMutationObserver", 3);
-        var unregisterMutationObserverFn = new JSFunction((in a) => UnregisterObserver(in a), "__broilerUnregisterMutationObserver", 1);
+        var registerMutationObserverFn = new DomFunction((in a) => RegisterObserver(in a), "__broilerRegisterMutationObserver", 3);
+        var unregisterMutationObserverFn = new DomFunction((in a) => UnregisterObserver(in a), "__broilerUnregisterMutationObserver", 1);
         context["__broilerRegisterMutationObserver"] = registerMutationObserverFn;
         context["__broilerUnregisterMutationObserver"] = unregisterMutationObserverFn;
         // MutationObserver — DOM Level 4

--- a/src/Broiler.HtmlBridge.Dom/Features/SelectBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SelectBinding.cs
@@ -30,26 +30,26 @@ internal sealed class SelectBinding(ISelectHost host)
         if (tag == "select")
         {
             obj.FastAddValue((KeyString)"add",
-                new JSFunction((in a) => Add(element, in a), "add", 2),
+                new DomFunction((in a) => Add(element, in a), "add", 2),
                 JSPropertyAttributes.EnumerableConfigurableValue);
             obj.FastAddProperty((KeyString)"options",
-                new JSFunction((in _) => GetOptions(element), "get options"),
+                new DomFunction((in _) => GetOptions(element), "get options"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
             obj.FastAddProperty((KeyString)"selectedIndex",
-                new JSFunction((in _) => new JSNumber(GetSelectedIndex(element)), "get selectedIndex"),
-                new JSFunction((in a) => SetSelectedIndexCallback(element, in a), "set selectedIndex"),
+                new DomFunction((in _) => new JSNumber(GetSelectedIndex(element)), "get selectedIndex"),
+                new DomFunction((in a) => SetSelectedIndexCallback(element, in a), "set selectedIndex"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
             obj.FastAddProperty((KeyString)"size",
-                new JSFunction((in _) => GetSize(element), "get size"),
-                new JSFunction((in a) => SetSize(element, in a), "set size"),
+                new DomFunction((in _) => GetSize(element), "get size"),
+                new DomFunction((in a) => SetSize(element, in a), "set size"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
         if (tag == "option")
         {
             obj.FastAddProperty((KeyString)"defaultSelected",
-                new JSFunction((in _) => _host.GetOptionDefaultSelected(element) ? JSBoolean.True : JSBoolean.False, "get defaultSelected"),
-                new JSFunction((in a) => SetDefaultSelected(element, in a), "set defaultSelected"),
+                new DomFunction((in _) => _host.GetOptionDefaultSelected(element) ? JSBoolean.True : JSBoolean.False, "get defaultSelected"),
+                new DomFunction((in a) => SetDefaultSelected(element, in a), "set defaultSelected"),
                 JSPropertyAttributes.EnumerableConfigurableProperty);
         }
     }
@@ -92,7 +92,7 @@ internal sealed class SelectBinding(ISelectHost host)
                 opts.Add(_host.ToJSObject(c));
         var arr = new JSArray(opts);
         arr.FastAddProperty((KeyString)"length",
-            new JSFunction((in _) => new JSNumber(opts.Count), "get length"),
+            new DomFunction((in _) => new JSNumber(opts.Count), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         return arr;
     }

--- a/src/Broiler.HtmlBridge.Dom/Features/StyleDeclarationBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/StyleDeclarationBinding.cs
@@ -47,41 +47,41 @@ internal static partial class StyleDeclarationBinding
         var style = new CssStyleDeclaration(host, element, onMutation, onPositionAreaInvalidate);
 
         style.FastAddProperty((KeyString)"cssText",
-            new JSFunction((in a) => InlineGetCssText(host, element, in a), "get cssText"),
-            new JSFunction((in a) => InlineSetCssText(host, element, onMutation, in a), "set cssText"),
+            new DomFunction((in a) => InlineGetCssText(host, element, in a), "get cssText"),
+            new DomFunction((in a) => InlineSetCssText(host, element, onMutation, in a), "set cssText"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         style.FastAddValue((KeyString)"setProperty",
-            new JSFunction((in a) => InlineSetProperty(host, element, onMutation, in a), "setProperty", 2),
+            new DomFunction((in a) => InlineSetProperty(host, element, onMutation, in a), "setProperty", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         style.FastAddValue((KeyString)"getPropertyValue",
-            new JSFunction((in a) => InlineGetPropertyValue(host, element, in a), "getPropertyValue", 1),
+            new DomFunction((in a) => InlineGetPropertyValue(host, element, in a), "getPropertyValue", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         style.FastAddValue((KeyString)"removeProperty",
-            new JSFunction((in a) => InlineRemoveProperty(host, element, onMutation, in a), "removeProperty", 1),
+            new DomFunction((in a) => InlineRemoveProperty(host, element, onMutation, in a), "removeProperty", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         style.FastAddProperty((KeyString)"cssFloat",
-            new JSFunction((in a) => InlineGetCssFloat(host, element, in a), "get cssFloat"),
-            new JSFunction((in a) => InlineSetCssFloat(host, element, onMutation, in a), "set cssFloat"),
+            new DomFunction((in a) => InlineGetCssFloat(host, element, in a), "get cssFloat"),
+            new DomFunction((in a) => InlineSetCssFloat(host, element, onMutation, in a), "set cssFloat"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         style.FastAddProperty((KeyString)"length",
-            new JSFunction((in _) => new JSNumber(GetStylePropertyNames(host, element).Count), "get length"),
+            new DomFunction((in _) => new JSNumber(GetStylePropertyNames(host, element).Count), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         style.FastAddValue((KeyString)"item",
-            new JSFunction((in a) => InlineItem(host, element, in a), "item", 1),
+            new DomFunction((in a) => InlineItem(host, element, in a), "item", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         style.FastAddValue((KeyString)"getPropertyPriority",
-            new JSFunction((in a) => InlineGetPropertyPriority(host, element, in a), "getPropertyPriority", 1),
+            new DomFunction((in a) => InlineGetPropertyPriority(host, element, in a), "getPropertyPriority", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         style.FastAddProperty((KeyString)"parentRule",
-            new JSFunction((in _) => parentRule ?? JSNull.Value, "get parentRule"),
+            new DomFunction((in _) => parentRule ?? JSNull.Value, "get parentRule"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         return style;
@@ -94,41 +94,41 @@ internal static partial class StyleDeclarationBinding
         var style = new CssRuleStyleDeclaration(styleMap);
 
         style.FastAddProperty((KeyString)"cssText",
-            new JSFunction((in _) => RuleGetCssText(styleMap, in _), "get cssText"),
-            new JSFunction((in a) => RuleSetCssText(styleMap, in a), "set cssText"),
+            new DomFunction((in _) => RuleGetCssText(styleMap, in _), "get cssText"),
+            new DomFunction((in a) => RuleSetCssText(styleMap, in a), "set cssText"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         style.FastAddValue((KeyString)"setProperty",
-            new JSFunction((in a) => RuleSetProperty(styleMap, in a), "setProperty", 2),
+            new DomFunction((in a) => RuleSetProperty(styleMap, in a), "setProperty", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         style.FastAddValue((KeyString)"getPropertyValue",
-            new JSFunction((in a) => RuleGetPropertyValue(styleMap, in a), "getPropertyValue", 1),
+            new DomFunction((in a) => RuleGetPropertyValue(styleMap, in a), "getPropertyValue", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         style.FastAddValue((KeyString)"removeProperty",
-            new JSFunction((in a) => RuleRemoveProperty(styleMap, in a), "removeProperty", 1),
+            new DomFunction((in a) => RuleRemoveProperty(styleMap, in a), "removeProperty", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         style.FastAddProperty((KeyString)"cssFloat",
-            new JSFunction((in _) => RuleGetCssFloat(styleMap, in _), "get cssFloat"),
-            new JSFunction((in a) => RuleSetCssFloat(styleMap, in a), "set cssFloat"),
+            new DomFunction((in _) => RuleGetCssFloat(styleMap, in _), "get cssFloat"),
+            new DomFunction((in a) => RuleSetCssFloat(styleMap, in a), "set cssFloat"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         style.FastAddProperty((KeyString)"length",
-            new JSFunction((in _) => new JSNumber(GetStylePropertyNames(styleMap).Count), "get length"),
+            new DomFunction((in _) => new JSNumber(GetStylePropertyNames(styleMap).Count), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         style.FastAddValue((KeyString)"item",
-            new JSFunction((in a) => RuleItem(styleMap, in a), "item", 1),
+            new DomFunction((in a) => RuleItem(styleMap, in a), "item", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         style.FastAddValue((KeyString)"getPropertyPriority",
-            new JSFunction((in a) => RuleGetPropertyPriority(styleMap, in a), "getPropertyPriority", 1),
+            new DomFunction((in a) => RuleGetPropertyPriority(styleMap, in a), "getPropertyPriority", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         style.FastAddProperty((KeyString)"parentRule",
-            new JSFunction((in _) => parentRule ?? JSNull.Value, "get parentRule"),
+            new DomFunction((in _) => parentRule ?? JSNull.Value, "get parentRule"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         return style;
@@ -153,11 +153,11 @@ internal static partial class StyleDeclarationBinding
         }
 
         // getPropertyValue method (supports both kebab-case and camelCase lookups)
-        obj.FastAddValue((KeyString)"getPropertyValue", new JSFunction((in a) => ComputedGetPropertyValue(computed, in a), "getPropertyValue", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddProperty((KeyString)"length", new JSFunction((in _) => new JSNumber(propertyNames.Count), "get length"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        obj.FastAddValue((KeyString)"getPropertyValue", new DomFunction((in a) => ComputedGetPropertyValue(computed, in a), "getPropertyValue", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddProperty((KeyString)"length", new DomFunction((in _) => new JSNumber(propertyNames.Count), "get length"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        obj.FastAddValue((KeyString)"item", new JSFunction((in a) => ComputedItem(propertyNames, in a), "item", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        obj.FastAddValue((KeyString)"getPropertyPriority", new JSFunction((in _) => new JSString(string.Empty), "getPropertyPriority", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"item", new DomFunction((in a) => ComputedItem(propertyNames, in a), "item", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        obj.FastAddValue((KeyString)"getPropertyPriority", new DomFunction((in _) => new JSString(string.Empty), "getPropertyPriority", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         obj.FastAddProperty((KeyString)"parentRule", DomBridge.NullFunction("get parentRule"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/StyleSheetBinding.Rules.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/StyleSheetBinding.Rules.cs
@@ -56,10 +56,10 @@ internal static partial class StyleSheetBinding
 
         var ruleObj = new JSObject();
         ruleObj.FastAddProperty((KeyString)"parentStyleSheet",
-            new JSFunction((in _) => parentStyleSheet, "get parentStyleSheet"),
+            new DomFunction((in _) => parentStyleSheet, "get parentStyleSheet"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         ruleObj.FastAddProperty((KeyString)"parentRule",
-            new JSFunction((in _) => parentRule ?? JSNull.Value, "get parentRule"),
+            new DomFunction((in _) => parentRule ?? JSNull.Value, "get parentRule"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         ruleObj.FastAddValue((KeyString)"type", new JSNumber((int)kind), JSPropertyAttributes.EnumerableConfigurableValue);
@@ -82,7 +82,7 @@ internal static partial class StyleSheetBinding
                     var encoding = CssomRuleMetadata.GetCharsetEncoding((CssAtRule)rule);
                     ruleObj.FastAddValue((KeyString)"encoding", new JSString(encoding), JSPropertyAttributes.EnumerableConfigurableValue);
                     ruleObj.FastAddProperty((KeyString)"cssText",
-                        new JSFunction((in _) => new JSString($"@charset \"{encoding}\";"), "get cssText"),
+                        new DomFunction((in _) => new JSString($"@charset \"{encoding}\";"), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
                 }
@@ -93,7 +93,7 @@ internal static partial class StyleSheetBinding
                     ruleObj.FastAddValue((KeyString)"href", new JSString(import.Href), JSPropertyAttributes.EnumerableConfigurableValue);
                     ruleObj.FastAddValue((KeyString)"media", new JSString(import.Media), JSPropertyAttributes.EnumerableConfigurableValue);
                     ruleObj.FastAddProperty((KeyString)"cssText",
-                        new JSFunction((in _) => JsStyleSheetsGetCssText017Core(import.Href, import.Media, in _), "get cssText"),
+                        new DomFunction((in _) => JsStyleSheetsGetCssText017Core(import.Href, import.Media, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
                 }
@@ -110,7 +110,7 @@ internal static partial class StyleSheetBinding
                     ruleObj.FastAddValue((KeyString)"media", new JSString(mediaText), JSPropertyAttributes.EnumerableConfigurableValue);
                     ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
                     ruleObj.FastAddProperty((KeyString)"cssText",
-                        new JSFunction((in _) => JsStyleSheetsGetCssText018Core(mediaText, nestedRuleObjects, in _), "get cssText"),
+                        new DomFunction((in _) => JsStyleSheetsGetCssText018Core(mediaText, nestedRuleObjects, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
                 }
@@ -119,7 +119,7 @@ internal static partial class StyleSheetBinding
                 {
                     var styleObj = StyleFromBlock(((CssAtRule)rule).Declarations);
                     ruleObj.FastAddProperty((KeyString)"cssText",
-                        new JSFunction((in _) => JsStyleSheetsGetCssText019Core(styleObj, in _), "get cssText"),
+                        new DomFunction((in _) => JsStyleSheetsGetCssText019Core(styleObj, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
                     break;
@@ -136,7 +136,7 @@ internal static partial class StyleSheetBinding
                     ruleObj.FastAddValue((KeyString)"name", new JSString(name), JSPropertyAttributes.EnumerableConfigurableValue);
                     ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
                     ruleObj.FastAddProperty((KeyString)"cssText",
-                        new JSFunction((in _) => JsStyleSheetsGetCssText020Core(name, nestedRuleObjects, in _), "get cssText"),
+                        new DomFunction((in _) => JsStyleSheetsGetCssText020Core(name, nestedRuleObjects, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
                 }
@@ -159,7 +159,7 @@ internal static partial class StyleSheetBinding
                         string.IsNullOrEmpty(initialValue) ? JSNull.Value : new JSString(initialValue),
                         JSPropertyAttributes.EnumerableConfigurableValue);
                     ruleObj.FastAddProperty((KeyString)"cssText",
-                        new JSFunction((in _) => JsStyleSheetsGetCssText021Core(inherits, initialValue, propertyName, syntax, in _), "get cssText"),
+                        new DomFunction((in _) => JsStyleSheetsGetCssText021Core(inherits, initialValue, propertyName, syntax, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
                 }
@@ -194,7 +194,7 @@ internal static partial class StyleSheetBinding
                     }
 
                     ruleObj.FastAddProperty((KeyString)"cssText",
-                        new JSFunction((in _) => JsStyleSheetsGetCssText022Core(descriptorMap, ruleName, ruleObj, in _), "get cssText"),
+                        new DomFunction((in _) => JsStyleSheetsGetCssText022Core(descriptorMap, ruleName, ruleObj, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
                 }
@@ -211,7 +211,7 @@ internal static partial class StyleSheetBinding
                     ruleObj.FastAddValue((KeyString)"conditionText", new JSString(conditionText), JSPropertyAttributes.EnumerableConfigurableValue);
                     ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
                     ruleObj.FastAddProperty((KeyString)"cssText",
-                        new JSFunction((in _) => JsStyleSheetsGetCssText023Core(conditionText, nestedRuleObjects, in _), "get cssText"),
+                        new DomFunction((in _) => JsStyleSheetsGetCssText023Core(conditionText, nestedRuleObjects, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
                 }
@@ -231,7 +231,7 @@ internal static partial class StyleSheetBinding
                             JSPropertyAttributes.EnumerableConfigurableValue);
                         ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
                         ruleObj.FastAddProperty((KeyString)"cssText",
-                            new JSFunction((in _) => JsStyleSheetsGetCssText024Core(nameText, nestedRuleObjects, in _), "get cssText"),
+                            new DomFunction((in _) => JsStyleSheetsGetCssText024Core(nameText, nestedRuleObjects, in _), "get cssText"),
                             null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     }
                     else
@@ -242,7 +242,7 @@ internal static partial class StyleSheetBinding
                             JSPropertyAttributes.EnumerableConfigurableValue);
                         ruleObj.FastAddValue((KeyString)"cssRules", BuildCssRuleListObject([]), JSPropertyAttributes.EnumerableConfigurableValue);
                         ruleObj.FastAddProperty((KeyString)"cssText",
-                            new JSFunction((in _) => JsStyleSheetsGetCssText025Core(nameText, in _), "get cssText"),
+                            new DomFunction((in _) => JsStyleSheetsGetCssText025Core(nameText, in _), "get cssText"),
                             null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     }
                     break;
@@ -256,7 +256,7 @@ internal static partial class StyleSheetBinding
                         string.IsNullOrEmpty(ns.Prefix) ? JSUndefined.Value : new JSString(ns.Prefix),
                         JSPropertyAttributes.EnumerableConfigurableValue);
                     ruleObj.FastAddProperty((KeyString)"cssText",
-                        new JSFunction((in _) => JsStyleSheetsGetCssText026Core(ns.Uri, ns.Prefix, in _), "get cssText"),
+                        new DomFunction((in _) => JsStyleSheetsGetCssText026Core(ns.Uri, ns.Prefix, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
                 }
@@ -269,7 +269,7 @@ internal static partial class StyleSheetBinding
                     ruleObj.FastAddValue((KeyString)"selectorText", new JSString(selectorText), JSPropertyAttributes.EnumerableConfigurableValue);
                     ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
                     ruleObj.FastAddProperty((KeyString)"cssText",
-                        new JSFunction((in _) => JsStyleSheetsGetCssText027Core(selectorText, styleObj, in _), "get cssText"),
+                        new DomFunction((in _) => JsStyleSheetsGetCssText027Core(selectorText, styleObj, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     break;
                 }
@@ -281,7 +281,7 @@ internal static partial class StyleSheetBinding
                     var selectorText = CssomRuleMetadata.GetSelectorText(styleRule);
                     ruleObj.FastAddValue((KeyString)"selectorText", new JSString(selectorText), JSPropertyAttributes.EnumerableConfigurableValue);
                     ruleObj.FastAddProperty((KeyString)"cssText",
-                        new JSFunction((in _) => JsStyleSheetsGetCssText028Core(ruleObj, selectorText, in _), "get cssText"),
+                        new DomFunction((in _) => JsStyleSheetsGetCssText028Core(ruleObj, selectorText, in _), "get cssText"),
                         null, JSPropertyAttributes.EnumerableConfigurableProperty);
                     var styleObj = StyleFromBlock(styleRule.Declarations);
                     ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
@@ -297,10 +297,10 @@ internal static partial class StyleSheetBinding
         var ruleObj = new JSObject();
         ruleObj.FastAddProperty(
             (KeyString)"parentStyleSheet",
-            new JSFunction((in _) => parentStyleSheet, "get parentStyleSheet"),
+            new DomFunction((in _) => parentStyleSheet, "get parentStyleSheet"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         ruleObj.FastAddProperty((KeyString)"parentRule",
-            new JSFunction((in _) => parentRule ?? JSNull.Value, "get parentRule"),
+            new DomFunction((in _) => parentRule ?? JSNull.Value, "get parentRule"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         var trimmedRuleText = ruleText.Trim();
@@ -315,7 +315,7 @@ internal static partial class StyleSheetBinding
 
             ruleObj.FastAddValue((KeyString)"encoding", new JSString(encoding), JSPropertyAttributes.EnumerableConfigurableValue);
             ruleObj.FastAddProperty((KeyString)"cssText",
-                new JSFunction((in _) => new JSString($"@charset \"{encoding}\";"), "get cssText"),
+                new DomFunction((in _) => new JSString($"@charset \"{encoding}\";"), "get cssText"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
         else if (trimmedRuleText.StartsWith("@import", StringComparison.OrdinalIgnoreCase))
@@ -350,7 +350,7 @@ internal static partial class StyleSheetBinding
             ruleObj.FastAddValue((KeyString)"href", new JSString(href), JSPropertyAttributes.EnumerableConfigurableValue);
             ruleObj.FastAddValue((KeyString)"media", new JSString(mediaText), JSPropertyAttributes.EnumerableConfigurableValue);
             ruleObj.FastAddProperty((KeyString)"cssText",
-                new JSFunction((in _) => JsStyleSheetsGetCssText017Core(href, mediaText, in _), "get cssText"),
+                new DomFunction((in _) => JsStyleSheetsGetCssText017Core(href, mediaText, in _), "get cssText"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
         else if (trimmedRuleText.StartsWith("@media", StringComparison.OrdinalIgnoreCase))
@@ -371,7 +371,7 @@ internal static partial class StyleSheetBinding
                 ruleObj.FastAddValue((KeyString)"media", new JSString(mediaText), JSPropertyAttributes.EnumerableConfigurableValue);
                 ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
                 ruleObj.FastAddProperty((KeyString)"cssText",
-                    new JSFunction((in _) => JsStyleSheetsGetCssText018Core(mediaText, nestedRuleObjects, in _), "get cssText"),
+                    new DomFunction((in _) => JsStyleSheetsGetCssText018Core(mediaText, nestedRuleObjects, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
         }
@@ -389,7 +389,7 @@ internal static partial class StyleSheetBinding
                 var styleMap = DomBridge.ParseStyle(declarations);
                 var styleObj = StyleDeclarationBinding.BuildRuleDeclaration(styleMap, ruleObj);
                 ruleObj.FastAddProperty((KeyString)"cssText",
-                    new JSFunction((in _) => JsStyleSheetsGetCssText019Core(styleObj, in _), "get cssText"),
+                    new DomFunction((in _) => JsStyleSheetsGetCssText019Core(styleObj, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
                 ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
             }
@@ -413,7 +413,7 @@ internal static partial class StyleSheetBinding
                 ruleObj.FastAddValue((KeyString)"name", new JSString(name), JSPropertyAttributes.EnumerableConfigurableValue);
                 ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
                 ruleObj.FastAddProperty((KeyString)"cssText",
-                    new JSFunction((in _) => JsStyleSheetsGetCssText020Core(name, nestedRuleObjects, in _), "get cssText"),
+                    new DomFunction((in _) => JsStyleSheetsGetCssText020Core(name, nestedRuleObjects, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
         }
@@ -443,7 +443,7 @@ internal static partial class StyleSheetBinding
                     string.IsNullOrEmpty(initialValue) ? JSNull.Value : new JSString(initialValue),
                     JSPropertyAttributes.EnumerableConfigurableValue);
                 ruleObj.FastAddProperty((KeyString)"cssText",
-                    new JSFunction((in _) => JsStyleSheetsGetCssText021Core(inherits, initialValue, propertyName, syntax, in _), "get cssText"),
+                    new DomFunction((in _) => JsStyleSheetsGetCssText021Core(inherits, initialValue, propertyName, syntax, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
         }
@@ -484,7 +484,7 @@ internal static partial class StyleSheetBinding
                 }
 
                 ruleObj.FastAddProperty((KeyString)"cssText",
-                    new JSFunction((in _) => JsStyleSheetsGetCssText022Core(descriptorMap, ruleName, ruleObj, in _), "get cssText"),
+                    new DomFunction((in _) => JsStyleSheetsGetCssText022Core(descriptorMap, ruleName, ruleObj, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
         }
@@ -506,7 +506,7 @@ internal static partial class StyleSheetBinding
                 ruleObj.FastAddValue((KeyString)"conditionText", new JSString(conditionText), JSPropertyAttributes.EnumerableConfigurableValue);
                 ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
                 ruleObj.FastAddProperty((KeyString)"cssText",
-                    new JSFunction((in _) => JsStyleSheetsGetCssText023Core(conditionText, nestedRuleObjects, in _), "get cssText"),
+                    new DomFunction((in _) => JsStyleSheetsGetCssText023Core(conditionText, nestedRuleObjects, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
         }
@@ -531,7 +531,7 @@ internal static partial class StyleSheetBinding
                     JSPropertyAttributes.EnumerableConfigurableValue);
                 ruleObj.FastAddValue((KeyString)"cssRules", nestedCssRules, JSPropertyAttributes.EnumerableConfigurableValue);
                 ruleObj.FastAddProperty((KeyString)"cssText",
-                    new JSFunction((in _) => JsStyleSheetsGetCssText024Core(nameText, nestedRuleObjects, in _), "get cssText"),
+                    new DomFunction((in _) => JsStyleSheetsGetCssText024Core(nameText, nestedRuleObjects, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
             else
@@ -542,7 +542,7 @@ internal static partial class StyleSheetBinding
                     JSPropertyAttributes.EnumerableConfigurableValue);
                 ruleObj.FastAddValue((KeyString)"cssRules", BuildCssRuleListObject([]), JSPropertyAttributes.EnumerableConfigurableValue);
                 ruleObj.FastAddProperty((KeyString)"cssText",
-                    new JSFunction((in _) => JsStyleSheetsGetCssText025Core(nameText, in _), "get cssText"),
+                    new DomFunction((in _) => JsStyleSheetsGetCssText025Core(nameText, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
         }
@@ -571,7 +571,7 @@ internal static partial class StyleSheetBinding
                 string.IsNullOrEmpty(prefix) ? JSUndefined.Value : new JSString(prefix),
                 JSPropertyAttributes.EnumerableConfigurableValue);
             ruleObj.FastAddProperty((KeyString)"cssText",
-                new JSFunction((in _) => JsStyleSheetsGetCssText026Core(namespaceUri, prefix, in _), "get cssText"),
+                new DomFunction((in _) => JsStyleSheetsGetCssText026Core(namespaceUri, prefix, in _), "get cssText"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
         else if (trimmedRuleText.StartsWith("@page", StringComparison.OrdinalIgnoreCase))
@@ -591,7 +591,7 @@ internal static partial class StyleSheetBinding
                 ruleObj.FastAddValue((KeyString)"selectorText", new JSString(selectorText), JSPropertyAttributes.EnumerableConfigurableValue);
                 ruleObj.FastAddValue((KeyString)"style", styleObj, JSPropertyAttributes.EnumerableConfigurableValue);
                 ruleObj.FastAddProperty((KeyString)"cssText",
-                    new JSFunction((in _) => JsStyleSheetsGetCssText027Core(selectorText, styleObj, in _), "get cssText"),
+                    new DomFunction((in _) => JsStyleSheetsGetCssText027Core(selectorText, styleObj, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
             }
         }
@@ -607,7 +607,7 @@ internal static partial class StyleSheetBinding
                 var selectorText = ruleText[..braceOpen].Trim();
                 ruleObj.FastAddValue((KeyString)"selectorText", new JSString(selectorText), JSPropertyAttributes.EnumerableConfigurableValue);
                 ruleObj.FastAddProperty((KeyString)"cssText",
-                    new JSFunction((in _) => JsStyleSheetsGetCssText028Core(ruleObj, selectorText, in _), "get cssText"),
+                    new DomFunction((in _) => JsStyleSheetsGetCssText028Core(ruleObj, selectorText, in _), "get cssText"),
                     null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
                 int braceClose = ruleText.LastIndexOf('}');

--- a/src/Broiler.HtmlBridge.Dom/Features/StyleSheetBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/StyleSheetBinding.cs
@@ -61,19 +61,19 @@ internal static partial class StyleSheetBinding
         SyncIndices();
 
         cssRuleList.FastAddProperty((KeyString)"length",
-            new JSFunction((in _) => new JSNumber(rules.Count), "get length"),
+            new DomFunction((in _) => new JSNumber(rules.Count), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         cssRuleList.FastAddValue((KeyString)"item",
-            new JSFunction((in a) => JsStyleSheetsItem008Core(rules, in a), "item", 1),
+            new DomFunction((in a) => JsStyleSheetsItem008Core(rules, in a), "item", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         cssRuleList.FastAddValue((KeyString)"insertRule",
-            new JSFunction((in a) => JsStyleSheetsInsertRule009Core(SyncIndices, ruleFactory, rules, in a), "insertRule", 2),
+            new DomFunction((in a) => JsStyleSheetsInsertRule009Core(SyncIndices, ruleFactory, rules, in a), "insertRule", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         cssRuleList.FastAddValue((KeyString)"deleteRule",
-            new JSFunction((in a) => JsStyleSheetsDeleteRule010Core(SyncIndices, rules, in a), "deleteRule", 1),
+            new DomFunction((in a) => JsStyleSheetsDeleteRule010Core(SyncIndices, rules, in a), "deleteRule", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         return cssRuleList;
@@ -114,11 +114,11 @@ internal static partial class StyleSheetBinding
 
         var ruleObj = new JSObject();
         ruleObj.FastAddProperty((KeyString)"parentStyleSheet",
-            new JSFunction((in _) => parentStyleSheet, "get parentStyleSheet"),
+            new DomFunction((in _) => parentStyleSheet, "get parentStyleSheet"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         ruleObj.FastAddProperty((KeyString)"parentRule",
-            new JSFunction((in _) => parentRule, "get parentRule"),
+            new DomFunction((in _) => parentRule, "get parentRule"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         ruleObj.FastAddValue((KeyString)"type", new JSNumber(8), JSPropertyAttributes.EnumerableConfigurableValue);
@@ -126,7 +126,7 @@ internal static partial class StyleSheetBinding
         var keyText = CssomRuleMetadata.GetSelectorText(styleRule);
         ruleObj.FastAddValue((KeyString)"keyText", new JSString(keyText), JSPropertyAttributes.EnumerableConfigurableValue);
         ruleObj.FastAddProperty((KeyString)"cssText",
-            new JSFunction((in _) => JsStyleSheetsGetCssText013Core(keyText, ruleObj, in _), "get cssText"),
+            new DomFunction((in _) => JsStyleSheetsGetCssText013Core(keyText, ruleObj, in _), "get cssText"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         var styleObj = StyleDeclarationBinding.BuildRuleDeclaration(DomBridge.ParseStyle(CssSerializer.Serialize(styleRule.Declarations)), ruleObj);
@@ -139,11 +139,11 @@ internal static partial class StyleSheetBinding
     {
         var ruleObj = new JSObject();
         ruleObj.FastAddProperty((KeyString)"parentStyleSheet",
-            new JSFunction((in _) => parentStyleSheet, "get parentStyleSheet"),
+            new DomFunction((in _) => parentStyleSheet, "get parentStyleSheet"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         ruleObj.FastAddProperty((KeyString)"parentRule",
-            new JSFunction((in _) => parentRule, "get parentRule"),
+            new DomFunction((in _) => parentRule, "get parentRule"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         ruleObj.FastAddValue((KeyString)"type", new JSNumber(8), JSPropertyAttributes.EnumerableConfigurableValue);
@@ -154,7 +154,7 @@ internal static partial class StyleSheetBinding
             var keyText = ruleText[..braceOpen].Trim();
             ruleObj.FastAddValue((KeyString)"keyText", new JSString(keyText), JSPropertyAttributes.EnumerableConfigurableValue);
             ruleObj.FastAddProperty((KeyString)"cssText",
-                new JSFunction((in _) => JsStyleSheetsGetCssText013Core(keyText, ruleObj, in _), "get cssText"),
+                new DomFunction((in _) => JsStyleSheetsGetCssText013Core(keyText, ruleObj, in _), "get cssText"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
             int braceClose = ruleText.LastIndexOf('}');

--- a/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.Events.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.Events.cs
@@ -60,21 +60,21 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"stopPropagation", new JSFunction(StopPropagation, "stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"stopPropagation", new DomFunction(StopPropagation, "stopPropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue StopImmediatePropagation(in Arguments __)
         {
             legacyCancelBubble = true;
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"stopImmediatePropagation", new JSFunction(StopImmediatePropagation, "stopImmediatePropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"stopImmediatePropagation", new DomFunction(StopImmediatePropagation, "stopImmediatePropagation", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue PreventDefault(in Arguments __)
         {
             evt[(KeyString)"defaultPrevented"] = JSBoolean.True;
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"preventDefault", new JSFunction(PreventDefault, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"preventDefault", new DomFunction(PreventDefault, "preventDefault", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue GetCancelBubble(in Arguments __)
         {
             return legacyCancelBubble ? JSBoolean.True : JSBoolean.False;
@@ -87,7 +87,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddProperty((KeyString)"cancelBubble", new JSFunction(GetCancelBubble, "get cancelBubble"), new JSFunction(SetCancelBubble, "set cancelBubble"), JSPropertyAttributes.EnumerableConfigurableProperty);
+        evt.FastAddProperty((KeyString)"cancelBubble", new DomFunction(GetCancelBubble, "get cancelBubble"), new DomFunction(SetCancelBubble, "set cancelBubble"), JSPropertyAttributes.EnumerableConfigurableProperty);
         JSValue GetReturnValue(in Arguments __)
         {
             return evt[(KeyString)"defaultPrevented"].BooleanValue ? JSBoolean.False : JSBoolean.True;
@@ -100,7 +100,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddProperty((KeyString)"returnValue", new JSFunction(GetReturnValue, "get returnValue"), new JSFunction(SetReturnValue, "set returnValue"), JSPropertyAttributes.EnumerableConfigurableProperty);
+        evt.FastAddProperty((KeyString)"returnValue", new DomFunction(GetReturnValue, "get returnValue"), new DomFunction(SetReturnValue, "set returnValue"), JSPropertyAttributes.EnumerableConfigurableProperty);
         JSValue InitEvent(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -112,7 +112,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initEvent", new JSFunction(InitEvent, "initEvent", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initEvent", new DomFunction(InitEvent, "initEvent", 3), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue InitUIEvent(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -128,7 +128,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initUIEvent", new JSFunction(InitUIEvent, "initUIEvent", 5), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initUIEvent", new DomFunction(InitUIEvent, "initUIEvent", 5), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue InitCustomEvent(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -141,7 +141,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initCustomEvent", new JSFunction(InitCustomEvent, "initCustomEvent", 4), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initCustomEvent", new DomFunction(InitCustomEvent, "initCustomEvent", 4), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue InitFocusEvent(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -159,7 +159,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initFocusEvent", new JSFunction(InitFocusEvent, "initFocusEvent", 6), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initFocusEvent", new DomFunction(InitFocusEvent, "initFocusEvent", 6), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue InitKeyboardEvent(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -202,7 +202,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initKeyboardEvent", new JSFunction(InitKeyboardEvent, "initKeyboardEvent", 13), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initKeyboardEvent", new DomFunction(InitKeyboardEvent, "initKeyboardEvent", 13), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue InitMouseEvent(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -257,7 +257,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initMouseEvent", new JSFunction(InitMouseEvent, "initMouseEvent", 15), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initMouseEvent", new DomFunction(InitMouseEvent, "initMouseEvent", 15), JSPropertyAttributes.EnumerableConfigurableValue);
         JSValue InitWheelEvent(in Arguments initArgs)
         {
             if (initArgs.Length > 0)
@@ -310,7 +310,7 @@ internal sealed partial class SubDocumentBinding
             return JSUndefined.Value;
         }
 
-        evt.FastAddValue((KeyString)"initWheelEvent", new JSFunction(InitWheelEvent, "initWheelEvent", 16), JSPropertyAttributes.EnumerableConfigurableValue);
+        evt.FastAddValue((KeyString)"initWheelEvent", new DomFunction(InitWheelEvent, "initWheelEvent", 16), JSPropertyAttributes.EnumerableConfigurableValue);
         return evt;
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.cs
@@ -44,62 +44,62 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
         _host.RegisterDocumentWrapper(docRoot, doc);
 
         doc.FastAddProperty((KeyString)"documentElement",
-            new JSFunction((in _) => DomBridge.GetDocumentElement(docRoot) is { } de ? _host.ToJSObject(de) : JSNull.Value, "get documentElement"),
+            new DomFunction((in _) => DomBridge.GetDocumentElement(docRoot) is { } de ? _host.ToJSObject(de) : JSNull.Value, "get documentElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         doc.FastAddProperty((KeyString)"scrollingElement",
-            new JSFunction((in _) => DomBridge.GetDocumentElement(docRoot) is { } se ? _host.ToJSObject(se) : JSNull.Value, "get scrollingElement"),
+            new DomFunction((in _) => DomBridge.GetDocumentElement(docRoot) is { } se ? _host.ToJSObject(se) : JSNull.Value, "get scrollingElement"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // body
         doc.FastAddProperty((KeyString)"body",
-            new JSFunction((in _) => GetBody(docRoot), "get body"),
+            new DomFunction((in _) => GetBody(docRoot), "get body"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // head
         doc.FastAddProperty((KeyString)"head",
-            new JSFunction((in _) => GetHead(docRoot), "get head"),
+            new DomFunction((in _) => GetHead(docRoot), "get head"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // title (dynamic getter from <title> element in <head>)
         doc.FastAddProperty((KeyString)"title",
-            new JSFunction((in _) => GetTitle(docRoot), "get title"),
-            new JSFunction((in a) => SetTitle(docRoot, in a), "set title"),
+            new DomFunction((in _) => GetTitle(docRoot), "get title"),
+            new DomFunction((in a) => SetTitle(docRoot, in a), "set title"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // forms (dynamic collection of <form> elements)
         doc.FastAddProperty((KeyString)"forms",
-            new JSFunction((in _) => GetForms(docRoot), "get forms"),
+            new DomFunction((in _) => GetForms(docRoot), "get forms"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // childNodes
         doc.FastAddProperty((KeyString)"childNodes",
-            new JSFunction((in _) => GetChildNodes(docRoot), "get childNodes"),
+            new DomFunction((in _) => GetChildNodes(docRoot), "get childNodes"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // firstChild
         doc.FastAddProperty((KeyString)"firstChild",
-            new JSFunction((in _) => docRoot.ChildNodes.Count > 0 ? _host.ToJSObject(DomBridge.ChildAt(docRoot, 0)) : JSNull.Value, "get firstChild"),
+            new DomFunction((in _) => docRoot.ChildNodes.Count > 0 ? _host.ToJSObject(DomBridge.ChildAt(docRoot, 0)) : JSNull.Value, "get firstChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // lastChild
         doc.FastAddProperty((KeyString)"lastChild",
-            new JSFunction((in _) => docRoot.ChildNodes.Count > 0 ? _host.ToJSObject(DomBridge.ChildAt(docRoot, ^1)) : JSNull.Value, "get lastChild"),
+            new DomFunction((in _) => docRoot.ChildNodes.Count > 0 ? _host.ToJSObject(DomBridge.ChildAt(docRoot, ^1)) : JSNull.Value, "get lastChild"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // hasChildNodes()
         doc.FastAddValue((KeyString)"hasChildNodes",
-            new JSFunction((in _) => docRoot.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasChildNodes", 0),
+            new DomFunction((in _) => docRoot.ChildNodes.Count > 0 ? JSBoolean.True : JSBoolean.False, "hasChildNodes", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // nodeType = DOCUMENT_NODE (9)
         doc.FastAddProperty((KeyString)"nodeType",
-            new JSFunction((in _) => new JSNumber(9), "get nodeType"),
+            new DomFunction((in _) => new JSNumber(9), "get nodeType"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // nodeName = "#document"
         doc.FastAddProperty((KeyString)"nodeName",
-            new JSFunction((in _) => new JSString("#document"), "get nodeName"),
+            new DomFunction((in _) => new JSString("#document"), "get nodeName"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // localName = null for document
@@ -109,59 +109,59 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
 
         // getElementById(id)
         doc.FastAddValue((KeyString)"getElementById",
-            new JSFunction((in a) => GetElementById(docRoot, in a), "getElementById", 1),
+            new DomFunction((in a) => GetElementById(docRoot, in a), "getElementById", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // getElementsByTagName(tag)
         doc.FastAddValue((KeyString)"getElementsByTagName",
-            new JSFunction((in a) => GetElementsByTagName(docRoot, in a), "getElementsByTagName", 1),
+            new DomFunction((in a) => GetElementsByTagName(docRoot, in a), "getElementsByTagName", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // createElement(tag)
         doc.FastAddValue((KeyString)"createElement",
-            new JSFunction((in a) => CreateElement(docRoot, in a), "createElement", 1),
+            new DomFunction((in a) => CreateElement(docRoot, in a), "createElement", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // createTextNode(text)
         doc.FastAddValue((KeyString)"createTextNode",
-            new JSFunction((in a) => CreateTextNode(docRoot, in a), "createTextNode", 1),
+            new DomFunction((in a) => CreateTextNode(docRoot, in a), "createTextNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // createComment(data)
         doc.FastAddValue((KeyString)"createComment",
-            new JSFunction((in a) => CreateComment(docRoot, in a), "createComment", 1),
+            new DomFunction((in a) => CreateComment(docRoot, in a), "createComment", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // createElementNS(ns, localName)
         doc.FastAddValue((KeyString)"createElementNS",
-            new JSFunction((in a) => CreateElementNS(docRoot, in a), "createElementNS", 2),
+            new DomFunction((in a) => CreateElementNS(docRoot, in a), "createElementNS", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // createEvent(type)
         doc.FastAddValue((KeyString)"createEvent",
-            new JSFunction((in a) => CreateEvent(in a), "createEvent", 1),
+            new DomFunction((in a) => CreateEvent(in a), "createEvent", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // querySelector / querySelectorAll
         doc.FastAddValue((KeyString)"querySelector",
-            new JSFunction((in a) => QuerySelector(docRoot, in a), "querySelector", 1),
+            new DomFunction((in a) => QuerySelector(docRoot, in a), "querySelector", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         doc.FastAddValue((KeyString)"querySelectorAll",
-            new JSFunction((in a) => QuerySelectorAll(docRoot, in a), "querySelectorAll", 1),
+            new DomFunction((in a) => QuerySelectorAll(docRoot, in a), "querySelectorAll", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         doc.FastAddValue((KeyString)"elementFromPoint",
-            new JSFunction((in a) => ElementFromPoint(docRoot, in a), "elementFromPoint", 2),
+            new DomFunction((in a) => ElementFromPoint(docRoot, in a), "elementFromPoint", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         doc.FastAddValue((KeyString)"elementsFromPoint",
-            new JSFunction((in a) => ElementsFromPoint(docRoot, in a), "elementsFromPoint", 2),
+            new DomFunction((in a) => ElementsFromPoint(docRoot, in a), "elementsFromPoint", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.open()
         doc.FastAddValue((KeyString)"open",
-            new JSFunction((in _) => Open(doc, docRoot), "open", 0),
+            new DomFunction((in _) => Open(doc, docRoot), "open", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.close()
@@ -171,40 +171,40 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
 
         // document.write(html)
         doc.FastAddValue((KeyString)"write",
-            new JSFunction((in a) => Write(docRoot, in a), "write", 1),
+            new DomFunction((in a) => Write(docRoot, in a), "write", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // document.images
         doc.FastAddProperty((KeyString)"images",
-            new JSFunction((in _) => GetImages(docRoot), "get images"),
+            new DomFunction((in _) => GetImages(docRoot), "get images"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.links
         doc.FastAddProperty((KeyString)"links",
-            new JSFunction((in _) => GetLinks(docRoot), "get links"),
+            new DomFunction((in _) => GetLinks(docRoot), "get links"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document.styleSheets
         doc.FastAddProperty((KeyString)"styleSheets",
-            new JSFunction((in _) => _host.BuildStyleSheetsCollection(docRoot), "get styleSheets"),
+            new DomFunction((in _) => _host.BuildStyleSheetsCollection(docRoot), "get styleSheets"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // removeChild on document
         doc.FastAddValue((KeyString)"removeChild",
-            new JSFunction((in a) => RemoveChild(docRoot, in a), "removeChild", 1),
+            new DomFunction((in a) => RemoveChild(docRoot, in a), "removeChild", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // appendChild on document
         doc.FastAddValue((KeyString)"appendChild",
-            new JSFunction((in a) => AppendChild(docRoot, in a), "appendChild", 1),
+            new DomFunction((in a) => AppendChild(docRoot, in a), "appendChild", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         doc.FastAddValue((KeyString)"append",
-            new JSFunction((in a) => Append(docRoot, in a), "append", 0),
+            new DomFunction((in a) => Append(docRoot, in a), "append", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         doc.FastAddValue((KeyString)"prepend",
-            new JSFunction((in a) => Prepend(docRoot, in a), "prepend", 0),
+            new DomFunction((in a) => Prepend(docRoot, in a), "prepend", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Node type constants
@@ -221,13 +221,13 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
             DomBridge.TrueFunction("hasFeature", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
         subImpl.FastAddValue((KeyString)"createDocumentType",
-            new JSFunction((in a) => CreateDocumentType(in a), "createDocumentType", 3),
+            new DomFunction((in a) => CreateDocumentType(in a), "createDocumentType", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
         subImpl.FastAddValue((KeyString)"createDocument",
-            new JSFunction((in a) => CreateDocument(in a), "createDocument", 3),
+            new DomFunction((in a) => CreateDocument(in a), "createDocument", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
         subImpl.FastAddValue((KeyString)"createHTMLDocument",
-            new JSFunction((in a) => CreateHTMLDocument(in a), "createHTMLDocument", 1),
+            new DomFunction((in a) => CreateHTMLDocument(in a), "createHTMLDocument", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         doc.FastAddValue((KeyString)"implementation",
             subImpl, JSPropertyAttributes.EnumerableConfigurableValue);
@@ -241,17 +241,17 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
 
         // createTreeWalker(root, whatToShow, filter)
         doc.FastAddValue((KeyString)"createTreeWalker",
-            new JSFunction((in a) => CreateTreeWalker(in a), "createTreeWalker", 3),
+            new DomFunction((in a) => CreateTreeWalker(in a), "createTreeWalker", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // createNodeIterator(root, whatToShow, filter)
         doc.FastAddValue((KeyString)"createNodeIterator",
-            new JSFunction((in a) => CreateNodeIterator(in a), "createNodeIterator", 3),
+            new DomFunction((in a) => CreateNodeIterator(in a), "createNodeIterator", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // createRange()
         doc.FastAddValue((KeyString)"createRange",
-            new JSFunction((in _) => _host.BuildRange(docRoot), "createRange", 0),
+            new DomFunction((in _) => _host.BuildRange(docRoot), "createRange", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         return doc;

--- a/src/Broiler.HtmlBridge.Dom/Features/SubWindowBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubWindowBinding.cs
@@ -53,7 +53,7 @@ internal sealed class SubWindowBinding(
         _messaging.RegisterWindowMessaging(subWindow);
 
         subWindow.FastAddProperty((KeyString)"document",
-            new JSFunction((in _) => _host.GetOrCreateSubDocument(containerElement), "get document"),
+            new DomFunction((in _) => _host.GetOrCreateSubDocument(containerElement), "get document"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         var locationHref = GetSubWindowLocationHref(containerElement);
@@ -77,14 +77,14 @@ internal sealed class SubWindowBinding(
         }
         subWindow.FastAddValue((KeyString)"location", iframeLocation, JSPropertyAttributes.EnumerableConfigurableValue);
 
-        subWindow.FastAddProperty((KeyString)"scrollX", new JSFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: false)), "get scrollX"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        subWindow.FastAddProperty((KeyString)"scrollY", new JSFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: true)), "get scrollY"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        subWindow.FastAddProperty((KeyString)"pageXOffset", new JSFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: false)), "get pageXOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        subWindow.FastAddProperty((KeyString)"pageYOffset", new JSFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: true)), "get pageYOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        subWindow.FastAddProperty((KeyString)"scrollX", new DomFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: false)), "get scrollX"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        subWindow.FastAddProperty((KeyString)"scrollY", new DomFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: true)), "get scrollY"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        subWindow.FastAddProperty((KeyString)"pageXOffset", new DomFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: false)), "get pageXOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        subWindow.FastAddProperty((KeyString)"pageYOffset", new DomFunction((in _) => new JSNumber(GetSubWindowScrollOffset(containerElement, vertical: true)), "get pageYOffset"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        subWindow.FastAddValue((KeyString)"scroll", new JSFunction((in a) => Scroll(containerElement, in a), "scroll", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        subWindow.FastAddValue((KeyString)"scrollTo", new JSFunction((in a) => ScrollTo(containerElement, in a), "scrollTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
-        subWindow.FastAddValue((KeyString)"scrollBy", new JSFunction((in a) => ScrollBy(containerElement, in a), "scrollBy", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        subWindow.FastAddValue((KeyString)"scroll", new DomFunction((in a) => Scroll(containerElement, in a), "scroll", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        subWindow.FastAddValue((KeyString)"scrollTo", new DomFunction((in a) => ScrollTo(containerElement, in a), "scrollTo", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        subWindow.FastAddValue((KeyString)"scrollBy", new DomFunction((in a) => ScrollBy(containerElement, in a), "scrollBy", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
         subWindow.FastAddValue((KeyString)"self", subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
         subWindow.FastAddValue((KeyString)"window", subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
@@ -112,7 +112,7 @@ internal sealed class SubWindowBinding(
         // window.getComputedStyle — sub-window needs its own copy so that
         // doc.defaultView.getComputedStyle(node, "") resolves CSS rules from
         // the sub-document's <style> elements rather than the main document.
-        subWindow.FastAddValue((KeyString)"getComputedStyle", new JSFunction((in a) => GetComputedStyle(in a), "getComputedStyle", 2),
+        subWindow.FastAddValue((KeyString)"getComputedStyle", new DomFunction((in a) => GetComputedStyle(in a), "getComputedStyle", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         return subWindow;

--- a/src/Broiler.HtmlBridge.Dom/Features/SvgElementBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SvgElementBinding.cs
@@ -52,7 +52,7 @@ internal static class SvgElementBinding
         {
             var attrName = dimAttr; // capture for closure
             obj.FastAddProperty((KeyString)attrName,
-                new JSFunction((in _) => BuildAnimatedLength(attrName, element), $"get {attrName}"),
+                new DomFunction((in _) => BuildAnimatedLength(attrName, element), $"get {attrName}"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
@@ -60,7 +60,7 @@ internal static class SvgElementBinding
         if (tag == "svg" || tag == "svg:svg")
         {
             obj.FastAddProperty((KeyString)"viewBox",
-                new JSFunction((in _) => GetViewBox(element), "get viewBox"),
+                new DomFunction((in _) => GetViewBox(element), "get viewBox"),
                 null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
@@ -69,32 +69,32 @@ internal static class SvgElementBinding
             tag == "textpath" || tag == "svg:textpath")
         {
             obj.FastAddValue((KeyString)"getNumberOfChars",
-                new JSFunction((in _) => GetNumberOfChars(element), "getNumberOfChars", 0),
+                new DomFunction((in _) => GetNumberOfChars(element), "getNumberOfChars", 0),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             // getComputedTextLength() — returns estimated total advance width
             obj.FastAddValue((KeyString)"getComputedTextLength",
-                new JSFunction((in _) => GetComputedTextLength(element), "getComputedTextLength", 0),
+                new DomFunction((in _) => GetComputedTextLength(element), "getComputedTextLength", 0),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             // getSubStringLength(charnum, nchars) — returns advance width of substring
             obj.FastAddValue((KeyString)"getSubStringLength",
-                new JSFunction((in a) => GetSubStringLength(element, in a), "getSubStringLength", 2),
+                new DomFunction((in a) => GetSubStringLength(element, in a), "getSubStringLength", 2),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             // getStartPositionOfChar(charnum) — returns SVGPoint {x, y}
             obj.FastAddValue((KeyString)"getStartPositionOfChar",
-                new JSFunction((in a) => GetStartPositionOfChar(element, in a), "getStartPositionOfChar", 1),
+                new DomFunction((in a) => GetStartPositionOfChar(element, in a), "getStartPositionOfChar", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             // getEndPositionOfChar(charnum) — returns SVGPoint {x, y}
             obj.FastAddValue((KeyString)"getEndPositionOfChar",
-                new JSFunction((in a) => GetEndPositionOfChar(element, in a), "getEndPositionOfChar", 1),
+                new DomFunction((in a) => GetEndPositionOfChar(element, in a), "getEndPositionOfChar", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             // getRotationOfChar(charnum) — returns rotation angle in degrees
             obj.FastAddValue((KeyString)"getRotationOfChar",
-                new JSFunction((in a) => GetRotationOfChar(element, in a), "getRotationOfChar", 1),
+                new DomFunction((in a) => GetRotationOfChar(element, in a), "getRotationOfChar", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
@@ -104,11 +104,11 @@ internal static class SvgElementBinding
             double currentTime = 0;
 
             obj.FastAddValue((KeyString)"getCurrentTime",
-                new JSFunction((in _) => new JSNumber(currentTime), "getCurrentTime", 0),
+                new DomFunction((in _) => new JSNumber(currentTime), "getCurrentTime", 0),
                 JSPropertyAttributes.EnumerableConfigurableValue);
 
             obj.FastAddValue((KeyString)"setCurrentTime",
-                new JSFunction((in a) => SetCurrentTime(ref currentTime, in a), "setCurrentTime", 1),
+                new DomFunction((in a) => SetCurrentTime(ref currentTime, in a), "setCurrentTime", 1),
                 JSPropertyAttributes.EnumerableConfigurableValue);
         }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/TableBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TableBinding.cs
@@ -31,37 +31,37 @@ internal sealed class TableBinding(ITableHost host)
         // HTMLTableElement interface
         if (tag == "table")
         {
-            obj.FastAddProperty((KeyString)"caption", new JSFunction((in _) => GetCaption(element), "get caption"), DomBridge.UndefinedFunction("set caption"), JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddProperty((KeyString)"tHead", new JSFunction((in _) => GetTHead(element), "get tHead"), DomBridge.UndefinedFunction("set tHead"), JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddProperty((KeyString)"tFoot", new JSFunction((in _) => GetTFoot(element), "get tFoot"), DomBridge.UndefinedFunction("set tFoot"), JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddProperty((KeyString)"tBodies", new JSFunction((in _) => GetTBodies(element), "get tBodies"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddProperty((KeyString)"caption", new DomFunction((in _) => GetCaption(element), "get caption"), DomBridge.UndefinedFunction("set caption"), JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddProperty((KeyString)"tHead", new DomFunction((in _) => GetTHead(element), "get tHead"), DomBridge.UndefinedFunction("set tHead"), JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddProperty((KeyString)"tFoot", new DomFunction((in _) => GetTFoot(element), "get tFoot"), DomBridge.UndefinedFunction("set tFoot"), JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddProperty((KeyString)"tBodies", new DomFunction((in _) => GetTBodies(element), "get tBodies"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
             // rows (read-only) — all <tr> in spec order: thead rows, then tbody/direct-tr rows, then tfoot rows
-            obj.FastAddProperty((KeyString)"rows", new JSFunction((in _) => BuildTableRows(element), "get rows"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddValue((KeyString)"createCaption", new JSFunction((in _) => CreateCaption(element), "createCaption", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"createTHead", new JSFunction((in _) => CreateTHead(element), "createTHead", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"createTFoot", new JSFunction((in _) => CreateTFoot(element), "createTFoot", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"deleteCaption", new JSFunction((in _) => DeleteCaption(element), "deleteCaption", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"deleteTHead", new JSFunction((in _) => DeleteTHead(element), "deleteTHead", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"deleteTFoot", new JSFunction((in _) => DeleteTFoot(element), "deleteTFoot", 0), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"insertRow", new JSFunction((in a) => TableInsertRow(element, in a), "insertRow", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"deleteRow", new JSFunction((in a) => TableDeleteRow(element, in a), "deleteRow", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddProperty((KeyString)"rows", new DomFunction((in _) => BuildTableRows(element), "get rows"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddValue((KeyString)"createCaption", new DomFunction((in _) => CreateCaption(element), "createCaption", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue((KeyString)"createTHead", new DomFunction((in _) => CreateTHead(element), "createTHead", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue((KeyString)"createTFoot", new DomFunction((in _) => CreateTFoot(element), "createTFoot", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue((KeyString)"deleteCaption", new DomFunction((in _) => DeleteCaption(element), "deleteCaption", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue((KeyString)"deleteTHead", new DomFunction((in _) => DeleteTHead(element), "deleteTHead", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue((KeyString)"deleteTFoot", new DomFunction((in _) => DeleteTFoot(element), "deleteTFoot", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue((KeyString)"insertRow", new DomFunction((in a) => TableInsertRow(element, in a), "insertRow", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue((KeyString)"deleteRow", new DomFunction((in a) => TableDeleteRow(element, in a), "deleteRow", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
         // HTMLTableSectionElement (thead, tbody, tfoot) — rows and insertRow
         if (tag == "thead" || tag == "tbody" || tag == "tfoot")
         {
-            obj.FastAddProperty((KeyString)"rows", new JSFunction((in _) => SectionGetRows(element), "get rows"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddValue((KeyString)"insertRow", new JSFunction((in a) => SectionInsertRow(element, in a), "insertRow", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddProperty((KeyString)"rows", new DomFunction((in _) => SectionGetRows(element), "get rows"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddValue((KeyString)"insertRow", new DomFunction((in a) => SectionInsertRow(element, in a), "insertRow", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         }
 
         // HTMLTableRowElement (tr) — rowIndex, sectionRowIndex, cells, insertCell, deleteCell
         if (tag == "tr")
         {
-            obj.FastAddProperty((KeyString)"rowIndex", new JSFunction((in _) => RowGetRowIndex(element), "get rowIndex"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddProperty((KeyString)"sectionRowIndex", new JSFunction((in _) => RowGetSectionRowIndex(element), "get sectionRowIndex"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddProperty((KeyString)"cells", new JSFunction((in _) => RowGetCells(element), "get cells"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-            obj.FastAddValue((KeyString)"insertCell", new JSFunction((in a) => RowInsertCell(element, in a), "insertCell", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-            obj.FastAddValue((KeyString)"deleteCell", new JSFunction((in a) => RowDeleteCell(element, in a), "deleteCell", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddProperty((KeyString)"rowIndex", new DomFunction((in _) => RowGetRowIndex(element), "get rowIndex"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddProperty((KeyString)"sectionRowIndex", new DomFunction((in _) => RowGetSectionRowIndex(element), "get sectionRowIndex"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddProperty((KeyString)"cells", new DomFunction((in _) => RowGetCells(element), "get cells"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+            obj.FastAddValue((KeyString)"insertCell", new DomFunction((in a) => RowInsertCell(element, in a), "insertCell", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+            obj.FastAddValue((KeyString)"deleteCell", new DomFunction((in a) => RowDeleteCell(element, in a), "deleteCell", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         }
     }
 
@@ -278,7 +278,7 @@ internal sealed class TableBinding(ITableHost host)
     private static JSObject WithLength(JSArray array, int length)
     {
         array.FastAddProperty((KeyString)"length",
-            new JSFunction((in _) => new JSNumber(length), "get length"),
+            new DomFunction((in _) => new JSNumber(length), "get length"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         return array;
     }

--- a/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TraversalBinding.cs
@@ -59,22 +59,22 @@ internal sealed partial class TraversalBinding(ITraversalHost host)
         // document.createTreeWalker(root, whatToShow, filter)
         document.FastAddValue(
             (KeyString)"createTreeWalker",
-            new JSFunction((in a) => CreateTreeWalker(in a), "createTreeWalker", 3),
+            new DomFunction((in a) => CreateTreeWalker(in a), "createTreeWalker", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
         // document.createNodeIterator(root, whatToShow, filter)
         document.FastAddValue(
             (KeyString)"createNodeIterator",
-            new JSFunction((in a) => CreateNodeIterator(in a), "createNodeIterator", 3),
+            new DomFunction((in a) => CreateNodeIterator(in a), "createNodeIterator", 3),
             JSPropertyAttributes.EnumerableConfigurableValue);
         // document.createRange()
         document.FastAddValue(
             (KeyString)"createRange",
-            new JSFunction((in _) => BuildRange(), "createRange", 0),
+            new DomFunction((in _) => BuildRange(), "createRange", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         // document.createComment(data)
         document.FastAddValue(
             (KeyString)"createComment",
-            new JSFunction((in a) => CreateComment(in a), "createComment", 1),
+            new DomFunction((in a) => CreateComment(in a), "createComment", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
     }
 
@@ -159,8 +159,8 @@ internal sealed partial class TraversalBinding(ITraversalHost host)
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         tw.FastAddProperty((KeyString)"currentNode",
-            new JSFunction((in a) => _host.ToJSObject(walker.CurrentNode), "get currentNode"),
-            new JSFunction((in a) =>
+            new DomFunction((in a) => _host.ToJSObject(walker.CurrentNode), "get currentNode"),
+            new DomFunction((in a) =>
             {
                 if (a.Length > 0 && a[0] is JSObject nodeObject &&
                     _host.FindDomNodeByJSObject(nodeObject) is { } node)
@@ -176,27 +176,27 @@ internal sealed partial class TraversalBinding(ITraversalHost host)
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         tw.FastAddValue((KeyString)"parentNode",
-            new JSFunction((in a) => ToTraversalJsValue(walker.ParentNode()), "parentNode", 0),
+            new DomFunction((in a) => ToTraversalJsValue(walker.ParentNode()), "parentNode", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         tw.FastAddValue((KeyString)"firstChild",
-            new JSFunction((in a) => ToTraversalJsValue(walker.FirstChild()), "firstChild", 0),
+            new DomFunction((in a) => ToTraversalJsValue(walker.FirstChild()), "firstChild", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         tw.FastAddValue((KeyString)"lastChild",
-            new JSFunction((in a) => ToTraversalJsValue(walker.LastChild()), "lastChild", 0),
+            new DomFunction((in a) => ToTraversalJsValue(walker.LastChild()), "lastChild", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         tw.FastAddValue((KeyString)"nextSibling",
-            new JSFunction((in a) => ToTraversalJsValue(walker.NextSibling()), "nextSibling", 0),
+            new DomFunction((in a) => ToTraversalJsValue(walker.NextSibling()), "nextSibling", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         tw.FastAddValue((KeyString)"previousSibling",
-            new JSFunction((in a) => ToTraversalJsValue(walker.PreviousSibling()), "previousSibling", 0),
+            new DomFunction((in a) => ToTraversalJsValue(walker.PreviousSibling()), "previousSibling", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         // nextNode() — depth-first pre-order traversal forward
         tw.FastAddValue((KeyString)"nextNode",
-            new JSFunction((in a) => ToTraversalJsValue(walker.NextNode()), "nextNode", 0),
+            new DomFunction((in a) => ToTraversalJsValue(walker.NextNode()), "nextNode", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         // previousNode() — depth-first pre-order traversal backward
         tw.FastAddValue((KeyString)"previousNode",
-            new JSFunction((in a) => ToTraversalJsValue(walker.PreviousNode()), "previousNode", 0),
+            new DomFunction((in a) => ToTraversalJsValue(walker.PreviousNode()), "previousNode", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         return tw;
@@ -226,21 +226,21 @@ internal sealed partial class TraversalBinding(ITraversalHost host)
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         iter.FastAddProperty((KeyString)"referenceNode",
-            new JSFunction((in a) => ToTraversalJsValue(iterator.ReferenceNode), "get referenceNode"),
+            new DomFunction((in a) => ToTraversalJsValue(iterator.ReferenceNode), "get referenceNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         iter.FastAddProperty((KeyString)"pointerBeforeReferenceNode",
-            new JSFunction((in a) => iterator.PointerBeforeReferenceNode ? JSBoolean.True : JSBoolean.False, "get pointerBeforeReferenceNode"),
+            new DomFunction((in a) => iterator.PointerBeforeReferenceNode ? JSBoolean.True : JSBoolean.False, "get pointerBeforeReferenceNode"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         iter.FastAddValue((KeyString)"nextNode",
-            new JSFunction((in a) => ToTraversalJsValue(iterator.NextNode()), "nextNode", 0),
+            new DomFunction((in a) => ToTraversalJsValue(iterator.NextNode()), "nextNode", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         iter.FastAddValue((KeyString)"previousNode",
-            new JSFunction((in a) => ToTraversalJsValue(iterator.PreviousNode()), "previousNode", 0),
+            new DomFunction((in a) => ToTraversalJsValue(iterator.PreviousNode()), "previousNode", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         iter.FastAddValue((KeyString)"detach",
-            new JSFunction((in a) =>
+            new DomFunction((in a) =>
             {
                 iterator.Dispose();
                 return JSUndefined.Value;
@@ -263,80 +263,80 @@ internal sealed partial class TraversalBinding(ITraversalHost host)
         var state = new BridgeDomRange(_host, docRoot);
 
         range.FastAddProperty((KeyString)"startContainer",
-            new JSFunction((in a) => _host.ToJSObject(state.StartContainer), "get startContainer"),
+            new DomFunction((in a) => _host.ToJSObject(state.StartContainer), "get startContainer"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         range.FastAddProperty((KeyString)"startOffset",
-            new JSFunction((in a) => new JSNumber(state.StartOffset), "get startOffset"),
+            new DomFunction((in a) => new JSNumber(state.StartOffset), "get startOffset"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         range.FastAddProperty((KeyString)"endContainer",
-            new JSFunction((in a) => _host.ToJSObject(state.EndContainer), "get endContainer"),
+            new DomFunction((in a) => _host.ToJSObject(state.EndContainer), "get endContainer"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         range.FastAddProperty((KeyString)"endOffset",
-            new JSFunction((in a) => new JSNumber(state.EndOffset), "get endOffset"),
+            new DomFunction((in a) => new JSNumber(state.EndOffset), "get endOffset"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         range.FastAddProperty((KeyString)"collapsed",
-            new JSFunction((in a) => state.Collapsed ? JSBoolean.True : JSBoolean.False, "get collapsed"),
+            new DomFunction((in a) => state.Collapsed ? JSBoolean.True : JSBoolean.False, "get collapsed"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
         range.FastAddProperty((KeyString)"commonAncestorContainer",
-            new JSFunction((in a) => RangeGetCommonAncestorContainer(state, in a), "get commonAncestorContainer"),
+            new DomFunction((in a) => RangeGetCommonAncestorContainer(state, in a), "get commonAncestorContainer"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         range.FastAddValue((KeyString)"getBoundingClientRect",
-            new JSFunction((in _) => RangeGetBoundingClientRect(state, in _), "getBoundingClientRect", 0),
+            new DomFunction((in _) => RangeGetBoundingClientRect(state, in _), "getBoundingClientRect", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"getClientRects",
-            new JSFunction((in _) => RangeGetClientRects(state, in _), "getClientRects", 0),
+            new DomFunction((in _) => RangeGetClientRects(state, in _), "getClientRects", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"setStart",
-            new JSFunction((in a) => RangeSetStart(state, in a), "setStart", 2),
+            new DomFunction((in a) => RangeSetStart(state, in a), "setStart", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"setEnd",
-            new JSFunction((in a) => RangeSetEnd(state, in a), "setEnd", 2),
+            new DomFunction((in a) => RangeSetEnd(state, in a), "setEnd", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"setStartBefore",
-            new JSFunction((in a) => RangeSetStartBefore(state, in a), "setStartBefore", 1),
+            new DomFunction((in a) => RangeSetStartBefore(state, in a), "setStartBefore", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"setStartAfter",
-            new JSFunction((in a) => RangeSetStartAfter(state, in a), "setStartAfter", 1),
+            new DomFunction((in a) => RangeSetStartAfter(state, in a), "setStartAfter", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"setEndBefore",
-            new JSFunction((in a) => RangeSetEndBefore(state, in a), "setEndBefore", 1),
+            new DomFunction((in a) => RangeSetEndBefore(state, in a), "setEndBefore", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"setEndAfter",
-            new JSFunction((in a) => RangeSetEndAfter(state, in a), "setEndAfter", 1),
+            new DomFunction((in a) => RangeSetEndAfter(state, in a), "setEndAfter", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"collapse",
-            new JSFunction((in a) => RangeCollapse(state, in a), "collapse", 1),
+            new DomFunction((in a) => RangeCollapse(state, in a), "collapse", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"selectNode",
-            new JSFunction((in a) => RangeSelectNode(state, in a), "selectNode", 1),
+            new DomFunction((in a) => RangeSelectNode(state, in a), "selectNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"selectNodeContents",
-            new JSFunction((in a) => RangeSelectNodeContents(state, in a), "selectNodeContents", 1),
+            new DomFunction((in a) => RangeSelectNodeContents(state, in a), "selectNodeContents", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"cloneContents",
-            new JSFunction((in a) => RangeCloneContents(state, in a), "cloneContents", 0),
+            new DomFunction((in a) => RangeCloneContents(state, in a), "cloneContents", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"extractContents",
-            new JSFunction((in a) => RangeExtractContents(state, in a), "extractContents", 0),
+            new DomFunction((in a) => RangeExtractContents(state, in a), "extractContents", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"deleteContents",
-            new JSFunction((in a) => RangeDeleteContents(state, in a), "deleteContents", 0),
+            new DomFunction((in a) => RangeDeleteContents(state, in a), "deleteContents", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"insertNode",
-            new JSFunction((in a) => RangeInsertNode(state, in a), "insertNode", 1),
+            new DomFunction((in a) => RangeInsertNode(state, in a), "insertNode", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"surroundContents",
-            new JSFunction((in a) => RangeSurroundContents(state, in a), "surroundContents", 1),
+            new DomFunction((in a) => RangeSurroundContents(state, in a), "surroundContents", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"cloneRange",
-            new JSFunction((in a) => RangeCloneRange(state, in a), "cloneRange", 0),
+            new DomFunction((in a) => RangeCloneRange(state, in a), "cloneRange", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"compareBoundaryPoints",
-            new JSFunction((in a) => RangeCompareBoundaryPoints(state, in a), "compareBoundaryPoints", 2),
+            new DomFunction((in a) => RangeCompareBoundaryPoints(state, in a), "compareBoundaryPoints", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
         range.FastAddValue((KeyString)"toString",
-            new JSFunction((in a) => RangeToString(state, in a), "toString", 0),
+            new DomFunction((in a) => RangeToString(state, in a), "toString", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         // Range comparison constants

--- a/src/Broiler.HtmlBridge.Dom/Features/WebStorageBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/WebStorageBinding.cs
@@ -24,19 +24,19 @@ internal static class WebStorageBinding
         var store = new Dictionary<string, string>();
 
         storage.FastAddValue((KeyString)"getItem",
-            new JSFunction((in a) => GetItem(store, in a), "getItem", 1),
+            new DomFunction((in a) => GetItem(store, in a), "getItem", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         storage.FastAddValue((KeyString)"setItem",
-            new JSFunction((in a) => SetItem(storage, store, in a), "setItem", 2),
+            new DomFunction((in a) => SetItem(storage, store, in a), "setItem", 2),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         storage.FastAddValue((KeyString)"removeItem",
-            new JSFunction((in a) => RemoveItem(storage, store, in a), "removeItem", 1),
+            new DomFunction((in a) => RemoveItem(storage, store, in a), "removeItem", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         storage.FastAddValue((KeyString)"clear",
-            new JSFunction((in a) => Clear(storage, store, in a), "clear", 0),
+            new DomFunction((in a) => Clear(storage, store, in a), "clear", 0),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
         return storage;

--- a/src/Broiler.HtmlBridge.Scripting/ScriptEngine.cs
+++ b/src/Broiler.HtmlBridge.Scripting/ScriptEngine.cs
@@ -150,6 +150,10 @@ public sealed partial class ScriptEngine : ITypedScriptEngine
 
         try
         {
+            // Current on this thread for the whole of script execution, because a promise captures
+            // its synchronization context when it is created, not when it settles. Without it the
+            // engine resumes continuations on the thread pool, concurrently with this thread.
+            using var microTaskContext = MicroTaskSynchronizationContext.Install(MicroTasks);
             using JSContext context = moduleContext ?? new JSContext();
             RegisterRuntimeExtensions(context);
             var bridge = _domBridgeFactory.Create();
@@ -313,6 +317,11 @@ public sealed partial class ScriptEngine : ITypedScriptEngine
         // disposes both. If setup throws before the session is built, the catch disposes them so a
         // failed ExecuteInteractive never leaks a JS context or an event loop (Phase 8 item 2). The
         // CSP is restored in the finally on every path.
+        // Scoped to setup: the promises created while the page's scripts run capture it here. A
+        // later session Step() runs on the caller's thread, which installs nothing — the interactive
+        // path drains explicitly between steps, so a reaction that lands on the pool there is the
+        // caller's own pacing rather than a race against a render.
+        using var microTaskContext = MicroTaskSynchronizationContext.Install(MicroTasks);
         JSContext context = moduleContext ?? new JSContext();
         IDomBridgeRuntime? bridge = null;
         try

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -2320,6 +2320,7 @@ internal sealed partial class WptTestRunner
         {
             // Even with no inline scripts, we still need to process anchor
             // positioning, animation snapshots, etc. via the DomBridge.
+            using var microTaskContext2 = MicroTaskSynchronizationContext.Install(microTasks);
             using var context2 = new JSContext();
             var bridge2 = new DomBridge { NativeAnchorPlacement = NativeAnchorPlacement, NativeTopLayer = NativeAnchorPlacement, NativeBackdrop = NativeBackdrop };
             bridge2.Attach(context2, html, url);
@@ -2333,6 +2334,10 @@ internal sealed partial class WptTestRunner
             return (bridge2.SerializeToHtml(), assertions2);
         }
 
+        // Current on this thread for the whole of script execution: a promise captures its
+        // synchronization context when it is created, so without this the engine resumes await
+        // continuations on the thread pool, racing this thread's serialize/render.
+        using var microTaskContext = MicroTaskSynchronizationContext.Install(microTasks);
         using var context = new JSContext();
         var bridge = new DomBridge { NativeAnchorPlacement = NativeAnchorPlacement, NativeTopLayer = NativeAnchorPlacement, NativeBackdrop = NativeBackdrop };
         bridge.TaskCheckpointCallback = () => microTasks.Drain();


### PR DESCRIPTION
## Summary

This change addresses two separate issues: (1) excessive memory allocation in DOM node wrappers by disabling prototype creation on native callables, and (2) missing support for declarative shadow DOM and related rendering gaps in view transitions.

## Key Changes

### DOM Wrapper Function Optimization
- Introduced `DomFunction` class that wraps `JSFunction` with `createPrototype: false`, matching WebIDL spec requirements that DOM operations and attribute accessors are ordinary functions without `prototype` properties
- Replaced ~500+ `JSFunction` instantiations across all DOM binding files with `DomFunction`
- This eliminates throwaway `JSObject` allocations (prototype + constructor back-reference) for every member of every node, addressing the top-ranked WPT memory issue (`css/css-variables/url-syntax-crash.html` was aborting at 4096 MiB limit)

### Declarative Shadow DOM Support
- Implemented `AttachDeclarativeShadowRoots()` to convert `<template shadowrootmode="open|closed">` elements into real shadow roots per HTML §4.12.3
- Templates contribute their children to the new root and are removed from the tree
- Runs as a post-parse pass (equivalent to tree-builder timing for parsed documents)

### View Transition Root Capture Improvements
- Added conditional content cloning for root snapshots: only clone the DOM when the author paints `::view-transition` (detected via `RootSnapshotNeedsContent()`)
- Keeps the transparent backdrop path for tests that don't paint the overlay, avoiding the pixel-accuracy regression from unconditional cloning
- Fixes WPT issues #1500 problems 13, 15, 17 (`old-content-captures-root`, `new-content-captures-root`, `root-captured-as-different-tag`)

### Shadow Tree Styling
- Added `AppendOuterPartRules()` to inject document-level `::part()` rules into shadow tree scopes, enabling outer-tree styling of exposed shadow DOM elements
- Fixes computed style visibility for `::part()` selectors

### View Transition Group Animation Timing
- Corrected group animation freezing point: "frozen at time 0" evaluates the timing function at input 0, which for `steps(…, jump-start)` is already part-way to new geometry
- Captures and applies author `animation-timing-function` rules to groups via `view-transition-class`
- Fixes WPT issues #1500 problems 7, 8 (`auto-name`, `auto-name-from-id`)

### Flexbox `order` Property
- Implemented CSS Flexbox §5.4 / CSS Display §3 `order` property support
- Reorders flex container children into order-modified document order (ascending `order`, document order within ordinal group)
- Applied during layout via `ApplyOrderModification()`

### Promise Microtask Threading
- Introduced `MicroTaskSynchronizationContext` to route promise reactions into the microtask queue instead of the thread pool
- Ensures JavaScript stays single-threaded; fixes race conditions where `await` continuations resumed on pool threads and lost races with serialization/rendering
- Particularly fixes geometry queries after `await` appearing to truncate silently

### Viewport Scroll Events
- Fixed scroll event dispatch: now fires on `Document` (reaching `window` through propagation) instead of just `documentElement`
- Enables idiomatic `addEventListener("scroll", …)` at global scope to observe viewport scrolling

### 3D Transform Flattening
- Added support for 2D-equivalent 3D transform functions: `translate3d`, `scale3d`, `rotate3d` (about Z), 2D `matrix3d`
- Fixes WPT reference rendering where references use 3D spellings of 2D transforms

### Test Coverage
- Added `DeclarativeShadowDomTests` for shadow root materialization and rendering
- Added `DomWrapperFunctionTests` verifying DOM operations are not constructors and carry no prototype
- Added `AsyncContinuationThreadingTests` for promise microtask threading
- Added `FlexOrderTests` for flexbox order property
- Added

https://claude.ai/code/session_01GnUsuaAcR4hSvYpmCqDU9A