### PR TITLE
Release image sub-resource file handles, and dispose the DomBridge sessions that held them

### DIFF
--- a/src/Broiler.Cli/CaptureService.cs
+++ b/src/Broiler.Cli/CaptureService.cs
@@ -525,7 +525,12 @@ public class CaptureService
         using var microTaskContext = MicroTaskSynchronizationContext.Install(microTasks);
         using JSContext context = useEngineModules ? new BridgeModuleContext(csp, url) : new JSContext();
         RegisterRuntimeExtensions(context, microTasks, csp);
-        var bridge = new DomBridge();
+        // Disposed with this call, and declared after the context so it is torn down first: the
+        // bridge owns a per-document session — the headless layout view and its HtmlContainer
+        // (hence the whole box tree and every sub-resource its image load handlers hold), timer
+        // and animation queues, listener stores, observers and message ports. Only the serialized
+        // HTML string outlives this scope, so there is nothing to keep the session alive for.
+        using var bridge = new DomBridge();
         bridge.Csp = csp;
         bridge.TaskCheckpointCallback = () => microTasks.Drain();
         // Attach enforces the CSP style-src family on the parsed DOM itself (it runs

--- a/src/Broiler.Engines.Baseline/Program.cs
+++ b/src/Broiler.Engines.Baseline/Program.cs
@@ -299,21 +299,21 @@ internal static partial class Program
             MeasureNanosecondsPerOperation("css.selector-match", "Run repeated Selectors Level 4 matches through querySelectorAll", 12, 1000, () =>
             {
                 using var context = new JSContext();
-                var bridge = new DomBridge();
+                using var bridge = new DomBridge();
                 bridge.Attach(context, BenchmarkSamples.CssBridgeDocument, "https://example.test/");
                 context.Eval("for (var i = 0; i < 1000; i++) document.querySelectorAll('#host > .card[data-state=\"active\"]:nth-child(2)');");
             }),
             MeasureNanosecondsPerOperation("css.computed-style", "Resolve and read a cached computed style through the bridge", 12, 1000, () =>
             {
                 using var context = new JSContext();
-                var bridge = new DomBridge();
+                using var bridge = new DomBridge();
                 bridge.Attach(context, BenchmarkSamples.CssBridgeDocument, "https://example.test/");
                 context.Eval("var target = document.getElementById('target'); for (var i = 0; i < 1000; i++) window.getComputedStyle(target).getPropertyValue('margin-left');");
             }),
             MeasureNanosecondsPerOperation("css.invalidation", "Invalidate class-dependent style and recompute it through the bridge", 12, 250, () =>
             {
                 using var context = new JSContext();
-                var bridge = new DomBridge();
+                using var bridge = new DomBridge();
                 bridge.Attach(context, BenchmarkSamples.CssBridgeDocument, "https://example.test/");
                 context.Eval("var target = document.getElementById('target'); for (var i = 0; i < 250; i++) { target.className = i % 2 ? 'card active' : 'card'; window.getComputedStyle(target).getPropertyValue('color'); }");
             }),
@@ -325,28 +325,28 @@ internal static partial class Program
             MeasureNanosecondsPerOperation("bridge.dom-call", "Repeated document.getElementById().getAttribute() calls", 12, 2000, () =>
             {
                 using var context = new JSContext();
-                var bridge = new DomBridge();
+                using var bridge = new DomBridge();
                 bridge.Attach(context, BenchmarkSamples.BridgeDocument, "https://example.test/");
                 context.Eval("for (var i = 0; i < 2000; i++) { document.getElementById('target').getAttribute('data-value'); }");
             }),
             MeasureNanosecondsPerOperation("bridge.mutation", "Repeated textContent mutations through the DOM bridge", 12, 500, () =>
             {
                 using var context = new JSContext();
-                var bridge = new DomBridge();
+                using var bridge = new DomBridge();
                 bridge.Attach(context, BenchmarkSamples.BridgeDocument, "https://example.test/");
                 context.Eval(@"var host = document.getElementById('host'); for (var i = 0; i < 500; i++) { var item = document.createElement('span'); item.textContent = 'node-' + i; host.appendChild(item); }");
             }),
             MeasureMilliseconds("bridge.serialize", "Attach and serialize the bridge-owned DOM", 15, () =>
             {
                 using var context = new JSContext();
-                var bridge = new DomBridge();
+                using var bridge = new DomBridge();
                 bridge.Attach(context, BenchmarkSamples.HtmlDocument, "https://example.test/");
                 _ = bridge.SerializeToHtml();
             }),
             MeasureMilliseconds("bridge.render-handoff", "Serialize the bridge-owned DOM and reparse it for raster rendering", 10, () =>
             {
                 using var context = new JSContext();
-                var bridge = new DomBridge();
+                using var bridge = new DomBridge();
                 bridge.Attach(context, BenchmarkSamples.HtmlDocument, "https://example.test/");
                 var serialized = bridge.SerializeToHtml();
                 using var bitmap = HtmlRender.RenderToImageWithStyleSet(
@@ -355,7 +355,7 @@ internal static partial class Program
             MeasureMilliseconds("bridge.typed-render-handoff", "Hand the canonical DOM directly to layout without serialization or reparsing", 10, () =>
             {
                 using var context = new JSContext();
-                var bridge = new DomBridge();
+                using var bridge = new DomBridge();
                 bridge.Attach(context, BenchmarkSamples.HtmlDocument, "https://example.test/");
                 using var container = CreateHtmlContainer();
                 container.MaxSize = new SizeF(1024, 768);

--- a/src/Broiler.HtmlBridge.Scripting/ScriptEngine.cs
+++ b/src/Broiler.HtmlBridge.Scripting/ScriptEngine.cs
@@ -157,21 +157,35 @@ public sealed partial class ScriptEngine : ITypedScriptEngine
             using JSContext context = moduleContext ?? new JSContext();
             RegisterRuntimeExtensions(context);
             var bridge = _domBridgeFactory.Create();
-            bridge.Csp = Csp;
-            bridge.TaskCheckpointCallback = () => MicroTasks.Drain();
+            try
+            {
+                bridge.Csp = Csp;
+                bridge.TaskCheckpointCallback = () => MicroTasks.Drain();
 
-            if (!string.IsNullOrEmpty(url))
-                bridge.Attach(context, html, url);
-            else
-                bridge.Attach(context, html);
+                if (!string.IsNullOrEmpty(url))
+                    bridge.Attach(context, html, url);
+                else
+                    bridge.Attach(context, html);
 
-            // Event-loop ordering (EL-3): run the synchronous script phases (regular → deferred → modules)
-            // with only microtask checkpoints between them, then — after the window load event — drain the
-            // timer queue to completion. So a timer scheduled by an early script fires after all script
-            // execution (in deadline order), not eagerly between scripts, matching the HTML task model.
-            RunPageScripts(context, bridge, moduleContext, scripts, deferredScripts, url, roots,
-                _ => MicroTasks.Drain(), DrainAsyncWork, "ScriptEngine.Execute");
-            return createResult(bridge);
+                // Event-loop ordering (EL-3): run the synchronous script phases (regular → deferred → modules)
+                // with only microtask checkpoints between them, then — after the window load event — drain the
+                // timer queue to completion. So a timer scheduled by an early script fires after all script
+                // execution (in deadline order), not eagerly between scripts, matching the HTML task model.
+                RunPageScripts(context, bridge, moduleContext, scripts, deferredScripts, url, roots,
+                    _ => MicroTasks.Drain(), DrainAsyncWork, "ScriptEngine.Execute");
+                return createResult(bridge);
+            }
+            finally
+            {
+                // This path owns the bridge — unlike ExecuteInteractive, which hands it to the
+                // returned InteractiveSession — so the per-document session (layout view and its
+                // container, timers, listeners, observers) is released here instead of leaking one
+                // per executed page. `createResult` has already run, and it yields either
+                // serialized HTML or an isolated render projection; neither reads bridge state
+                // afterwards. Runs before the enclosing `using` releases the borrowed JSContext.
+                // The cast is because IDomBridgeRuntime is not IDisposable (see DomBridge.Lifetime).
+                (bridge as IDisposable)?.Dispose();
+            }
         }
         finally
         {

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -25,13 +25,15 @@ public class WptTestRunnerTests : IDisposable
         if (!Directory.Exists(_tempDir))
             return;
 
-        // Best-effort cleanup. A test that has just rendered a document can still hold an
-        // open handle to a sub-resource it loaded (a background-image SVG, say) when the
-        // recursive delete reaches it, and on Windows that fails the *test* with an
-        // IOException from RemoveDirectoryRecursive rather than reporting anything about
-        // what the test actually asserted. Leaving a directory under %TEMP% behind is not a
-        // test failure; losing the assertion result to a teardown race is. Retry briefly to
-        // let the handle drop, then give up quietly.
+        // Best-effort cleanup. This used to fail for a reason of our own making: the renderer
+        // held an open handle to every image sub-resource it had loaded (a background-image
+        // SVG, say) for as long as the box tree lived, so the recursive delete hit a file the
+        // engine still had open. That is fixed at the source — ImageLoadHandler now closes the
+        // file as soon as the image is decoded, and the WPT runner disposes the DomBridge whose
+        // layout view owned the box tree — so nothing here should be locked any more.
+        // The retry stays only for locks outside our control (a virus scanner or the search
+        // indexer transiently opening a file we just wrote). Leaving a directory under %TEMP%
+        // behind is not a test failure; losing the assertion result to a teardown race is.
         for (var attempt = 0; ; attempt++)
         {
             try

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -2322,7 +2322,7 @@ internal sealed partial class WptTestRunner
             // positioning, animation snapshots, etc. via the DomBridge.
             using var microTaskContext2 = MicroTaskSynchronizationContext.Install(microTasks);
             using var context2 = new JSContext();
-            var bridge2 = new DomBridge { NativeAnchorPlacement = NativeAnchorPlacement, NativeTopLayer = NativeAnchorPlacement, NativeBackdrop = NativeBackdrop };
+            using var bridge2 = new DomBridge { NativeAnchorPlacement = NativeAnchorPlacement, NativeTopLayer = NativeAnchorPlacement, NativeBackdrop = NativeBackdrop };
             bridge2.Attach(context2, html, url);
             // Inject browser API stubs so onload handlers etc. can reference them.
             try { context2.Eval(BrowserApiStubs); } catch { /* best-effort */ }
@@ -2339,7 +2339,11 @@ internal sealed partial class WptTestRunner
         // continuations on the thread pool, racing this thread's serialize/render.
         using var microTaskContext = MicroTaskSynchronizationContext.Install(microTasks);
         using var context = new JSContext();
-        var bridge = new DomBridge { NativeAnchorPlacement = NativeAnchorPlacement, NativeTopLayer = NativeAnchorPlacement, NativeBackdrop = NativeBackdrop };
+        // Disposed with this call: the bridge owns a per-document session — the headless layout
+        // view and its HtmlContainer (hence the whole box tree and every sub-resource its image
+        // load handlers hold), timer/animation queues, listener stores and observers. Leaving it
+        // to the GC kept one of those sessions alive per rendered document.
+        using var bridge = new DomBridge { NativeAnchorPlacement = NativeAnchorPlacement, NativeTopLayer = NativeAnchorPlacement, NativeBackdrop = NativeBackdrop };
         bridge.TaskCheckpointCallback = () => microTasks.Drain();
         context["queueMicrotask"] = new JSFunction((in Arguments a) =>
         {


### PR DESCRIPTION
## What this fixes

`Broiler.Wpt.Tests.WptTestRunnerTests` renders into a per-test temp directory and
deletes it recursively in `Dispose()`. On Windows that intermittently threw:

```
System.IO.IOException : The process cannot access the file
'nonpercent-width-nonpercent-height-viewbox.svg' because it is being used by another process.
   at System.IO.FileSystem.RemoveDirectoryRecursive(...)
```

The file is a background-image SVG loaded by the just-completed render. Teardown had
been made best-effort so a cleanup race no longer failed the assertion, but that only
hid the symptom.

**The engine really did retain the handle.** A probe that renders the case and then
tries to delete the SVG failed immediately *and* kept failing after a forced
`GC.Collect()` + `WaitForPendingFinalizers()` — so the handle was strongly reachable,
not merely awaiting finalization. This was not a delete-after-close timing artifact.

Bisecting the layers separated the causes cleanly:

| Path | Delete after render |
| --- | --- |
| `HtmlRender.RenderToImageWithStyleSet` (core render) | OK |
| `WptTestRunner.RunMatchTest` | `IOException` |

The core render was already correct — its `HtmlContainer` is `using`-scoped and
disposal chains down through `CssBox.Dispose()` to the background-image loaders. Two
defects combined on the runner path.

### 1. The handler held the stream for its whole lifetime

`ImageLoadHandler` kept the `FileStream` in a field and disposed it only when the
handler was disposed. That is inherited from the upstream renderer, where GDI+
requires the stream to outlive the decoded image — but it does not apply here: the
only `ImageFromStreamInt` implementation copies the encoded bytes into a `byte[]`
before decoding, and nothing read the field afterwards. It existed solely to be
disposed. The stream is now scoped to the decode.

### 2. The runner leaked whole document sessions

`ExecuteScriptsWithDom` built two `DomBridge` instances and disposed neither.
`DomBridge` owns a per-document session — the headless layout view and its
`HtmlContainer`, hence the entire box tree and every sub-resource its image load
handlers hold, plus timer/animation queues, listener stores, observers and message
ports. That is why the handle outlived the render here but not on the direct path.

Fix 1 alone releases the handle; fix 2 is the leak that exposed it, and it matters on
its own for a branch about render memory.

### Same leak elsewhere

`CaptureService` (×1) and the engine baseline benchmarks (×8) had the identical bug;
the benchmark lambdas run 10–15 iterations each, so they leaked a session per
iteration into the numbers the harness reports. `ScriptEngine.ExecuteCore` needed a
`try`/`finally` and a cast rather than `using`, because `IDomBridgeRuntime` is
deliberately not `IDisposable` yet — promoting it is deferred Phase 2 work, so this
matches the idiom already used in `ExecuteInteractive`'s failure path.

`ScriptEngine.ExecuteInteractive` is **not** a leak and is left alone: it transfers
ownership to the returned `InteractiveSession`.

## Reviewer notes

**The `Broiler.HTML` pointer is bumped to a commit on an unmerged branch.**
`abc8c71` sits on `fix/image-load-handler-file-handle`, pushed to
`Broiler-Platform/Broiler.HTML`. CI clones by SHA so it resolves, but that branch
needs its own PR and merge before this lands on `main`, or `main` will point at a
non-`main` submodule commit.

Disposing in `ExecuteCore` is safe for both result shapes: `Execute` returns
serialized HTML, and `ExecuteToDocument` returns `GetRenderDocument()`'s *isolated
projection*, which has bridge-owned style and form-control state reflected into it
eagerly and which `Dispose` explicitly does not touch.

## Testing

Both suites were baselined by stashing every change (parent repo **and** submodule)
and re-running, then compared as failing-test-name sets rather than counts.

- **`Broiler.Wpt.Tests`** — 70 failures / 705 before, 70 after, **byte-identical
  name sets**: zero new, zero fixed. The 106 `BackgroundSizeVector` tests pass, which
  confirms the SVG still decodes rather than the file merely being closed early.
- **`Broiler.Cli.Tests`** (Release) — 80–81 failures / 2467, and the count is not
  stable on a pristine tree. The one test that differed,
  `GoogleSearchPolyfillTests.AutoSized_ScrollMetrics_Ignore_MarginOnly_NonOverflow_Cases`,
  is order-dependent: it fails 3/3 **in isolation both with and without these
  changes**, and a repeat baseline run reproduced the failure with everything
  stashed. Reverting the `CaptureService` and `ScriptEngine` changes individually did
  not restore the pass either.

Unrelated pre-existing instability seen while baselining: the Cli suite sometimes
hangs after `Acid3Phase5Tests.PhaseE_Acid3_Score_At_Least_100` on a pristine tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
