### PR TITLE
Add Android app bundle delivery to Broiler Preview Package

### DIFF
--- a/.github/workflows/broiler-preview-package.yml
+++ b/.github/workflows/broiler-preview-package.yml
@@ -18,6 +18,10 @@ concurrency:
 env:
   WINDOWS_CONFIGURATION: Release-Windows
   LINUX_CONFIGURATION: Release-Linux
+  # Plain Release, not a Release-Android to match the desktop pair: the Android heads switch
+  # AndroidPackageFormat to aab on '$(Configuration)' == 'Release' exactly, so any other
+  # configuration name quietly produces an APK instead.
+  ANDROID_CONFIGURATION: Release
   DOTNET_NOLOGO: 'true'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 'true'
 
@@ -527,12 +531,222 @@ jobs:
           path: ${{ runner.temp }}/release-assets/BPP-Linux-self-contained.tar.*
           if-no-files-found: error
 
+  build-android-preview-package:
+    name: Build BPP Android Package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    env:
+      BROWSER_PROJECT_PATH: src/Broiler.Browser.Android/Broiler.Browser.Android.csproj
+      WRITER_PROJECT_PATH: src/Broiler.Writer.Android/Broiler.Writer.Android.csproj
+      # The compile API and the build-tools track the android workload's Microsoft.Android.Sdk
+      # major; bump them together with scripts/install-android-sdk.sh.
+      ANDROID_API_LEVEL: '36'
+      ANDROID_BUILD_TOOLS: 36.0.0
+
+    steps:
+      - name: Checkout selected branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Setup the JDK the Android SDK tooling runs on
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Install the Android build workload
+        shell: pwsh
+        run: |
+          # net10.0-android needs the android workload: the Mono runtime packs for the device ABIs
+          # plus the MSBuild targets that turn a publish into an app bundle.
+          dotnet workload install android
+          if ($LASTEXITCODE -ne 0) {
+            throw "dotnet workload install android exited with code $LASTEXITCODE."
+          }
+
+      - name: Provision the Android SDK
+        shell: pwsh
+        run: |
+          # ubuntu-24.04 runners ship an Android SDK, but not necessarily the API level the heads
+          # compile against — install what is missing rather than a second SDK beside it.
+          $sdkRoot = $env:ANDROID_HOME
+          if ([string]::IsNullOrWhiteSpace($sdkRoot)) {
+            $sdkRoot = $env:ANDROID_SDK_ROOT
+          }
+          if ([string]::IsNullOrWhiteSpace($sdkRoot)) {
+            throw "Neither ANDROID_HOME nor ANDROID_SDK_ROOT is set; this runner has no Android SDK."
+          }
+
+          $platformJar = Join-Path $sdkRoot "platforms/android-$env:ANDROID_API_LEVEL/android.jar"
+          if (-not (Test-Path -LiteralPath $platformJar)) {
+            $sdkManager = Join-Path $sdkRoot 'cmdline-tools/latest/bin/sdkmanager'
+            if (-not (Test-Path -LiteralPath $sdkManager)) {
+              throw "The Android SDK at $sdkRoot has no API $env:ANDROID_API_LEVEL and no sdkmanager to install it with."
+            }
+
+            # The runner image pre-accepts licenses; feeding 'y' anyway keeps a package the image
+            # has not seen from blocking on a prompt.
+            ("y`n" * 50) | & $sdkManager --sdk_root="$sdkRoot" --licenses | Out-Null
+            & $sdkManager --sdk_root="$sdkRoot" `
+              "platforms;android-$env:ANDROID_API_LEVEL" `
+              "build-tools;$env:ANDROID_BUILD_TOOLS"
+          }
+
+          if (-not (Test-Path -LiteralPath $platformJar)) {
+            throw "android.jar is missing after provisioning: $platformJar"
+          }
+
+          "ANDROID_HOME=$sdkRoot" >> $env:GITHUB_ENV
+          "ANDROID_SDK_ROOT=$sdkRoot" >> $env:GITHUB_ENV
+
+      - name: Restore Android runtime graphs
+        shell: pwsh
+        run: |
+          # No --runtime: the heads declare RuntimeIdentifiers (android-arm64;android-x64) and one
+          # bundle carries both ABIs, so the restore has to cover the whole set.
+          dotnet restore $env:BROWSER_PROJECT_PATH -p:Configuration=$env:ANDROID_CONFIGURATION
+          dotnet restore $env:WRITER_PROJECT_PATH -p:Configuration=$env:ANDROID_CONFIGURATION
+
+      - name: Publish Android app bundles
+        shell: pwsh
+        run: |
+          $publishRoot = Join-Path $env:RUNNER_TEMP 'android-publish'
+
+          dotnet publish $env:BROWSER_PROJECT_PATH `
+            --configuration $env:ANDROID_CONFIGURATION `
+            --no-restore `
+            --output (Join-Path $publishRoot 'browser')
+
+          dotnet publish $env:WRITER_PROJECT_PATH `
+            --configuration $env:ANDROID_CONFIGURATION `
+            --no-restore `
+            --output (Join-Path $publishRoot 'writer')
+
+      - name: Collect and verify the Android app bundles
+        shell: pwsh
+        run: |
+          # A Release publish leaves three packages side by side: the unsigned <applicationId>.aab
+          # plus -Signed.aab and -Signed.apk, both signed with the workload's debug key. Only the
+          # unsigned bundle may ship — a debug-signed one looks release-ready and is not.
+          function Get-UnsignedBundle {
+            param(
+              [Parameter(Mandatory=$true)][string]$PublishDirectory,
+              [Parameter(Mandatory=$true)][string]$ApplicationId
+            )
+
+            $bundle = Join-Path $PublishDirectory "$ApplicationId.aab"
+            if (-not (Test-Path -LiteralPath $bundle)) {
+              $produced = @(Get-ChildItem -LiteralPath $PublishDirectory -Filter *.aab -ErrorAction SilentlyContinue |
+                ForEach-Object { $_.Name })
+              $found = if ($produced) { $produced -join ', ' } else { '(none)' }
+              throw "Expected $ApplicationId.aab in $PublishDirectory. Bundles produced: $found"
+            }
+
+            return $bundle
+          }
+
+          function Assert-AndroidAppBundle {
+            param([Parameter(Mandatory=$true)][string]$Path)
+
+            $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
+            try {
+              $entries = @($archive.Entries | ForEach-Object { $_.FullName })
+            }
+            finally {
+              $archive.Dispose()
+            }
+
+            # An .aab is a protobuf bundle, not an APK. BundleConfig.pb and the base/ split are what
+            # tell the two apart, so a wrong AndroidPackageFormat cannot ship unnoticed.
+            foreach ($required in @('BundleConfig.pb', 'base/manifest/AndroidManifest.xml')) {
+              if ($entries -notcontains $required) {
+                throw "$Path is not an Android app bundle: $required is missing."
+              }
+            }
+
+            foreach ($abi in @('arm64-v8a', 'x86_64')) {
+              if (-not ($entries | Where-Object { $_.StartsWith("base/lib/$abi/") })) {
+                throw "$Path carries no $abi native code."
+              }
+            }
+
+            # The unsigned bundle is the deliverable; a signature here means the debug-signed one
+            # was picked up by mistake.
+            $signature = @($entries | Where-Object { $_ -match '^META-INF/.+\.(RSA|DSA|EC|SF)$' })
+            if ($signature) {
+              throw "$Path is signed ($($signature -join ', ')); the preview package ships unsigned bundles."
+            }
+
+            $megabytes = [Math]::Round((Get-Item -LiteralPath $Path).Length / 1MB, 1)
+            Write-Host "==> verified $(Split-Path -Leaf $Path): app bundle, $($entries.Count) entries, $megabytes MB, unsigned"
+          }
+
+          $publishRoot = Join-Path $env:RUNNER_TEMP 'android-publish'
+          $packageRoot = Join-Path $env:RUNNER_TEMP 'packages/BPP-Android'
+          New-Item -ItemType Directory -Force -Path $packageRoot | Out-Null
+
+          $heads = @(
+            @{ Directory = 'browser'; ApplicationId = 'org.broiler.browser'; PackageName = 'Broiler.Browser.aab' }
+            @{ Directory = 'writer'; ApplicationId = 'org.broiler.writer'; PackageName = 'Broiler.Writer.aab' }
+          )
+
+          foreach ($head in $heads) {
+            $bundle = Get-UnsignedBundle `
+              -PublishDirectory (Join-Path $publishRoot $head.Directory) `
+              -ApplicationId $head.ApplicationId
+
+            Assert-AndroidAppBundle -Path $bundle
+            Copy-Item -LiteralPath $bundle -Destination (Join-Path $packageRoot $head.PackageName) -Force
+          }
+
+      - name: Package Android assets
+        shell: pwsh
+        env:
+          RELEASE_BRANCH: ${{ github.event.inputs.branch }}
+        run: |
+          $assetDir = Join-Path $env:RUNNER_TEMP 'release-assets'
+          $packageParent = Join-Path $env:RUNNER_TEMP 'packages'
+          $packageName = 'BPP-Android'
+          New-Item -ItemType Directory -Force -Path $assetDir | Out-Null
+
+          ./scripts/write-bpp-build-info.ps1 `
+            -PackageDirectory (Join-Path $packageParent $packageName) `
+            -Platform android `
+            -Variant app-bundle `
+            -Branch $env:RELEASE_BRANCH `
+            -Configuration $env:ANDROID_CONFIGURATION
+
+          # A zip rather than the Linux job's tar.xz: these bundles are fed to Android tooling from
+          # whatever desktop the developer has, and .zip opens on all three without extra tools.
+          Compress-Archive `
+            -LiteralPath (Join-Path $packageParent $packageName) `
+            -DestinationPath (Join-Path $assetDir "$packageName.zip") `
+            -Force
+
+      - name: Upload Android BPP
+        uses: actions/upload-artifact@v6
+        with:
+          name: BPP-Android
+          path: ${{ runner.temp }}/release-assets/BPP-Android.zip
+          if-no-files-found: error
+
   create-preview-package-release:
     name: Create BPP Draft Release
     runs-on: ubuntu-24.04
     needs:
       - build-windows-preview-package
       - build-linux-preview-package
+      - build-android-preview-package
     timeout-minutes: 30
 
     steps:
@@ -601,12 +815,14 @@ jobs:
           $windowsSelfContained = Resolve-Asset 'BPP-Win32-self-contained' @('.7z', '.zip')
           $linuxFrameworkDependent = Resolve-Asset 'BPP-Linux-framework-dependent' @('.tar.xz', '.tar.gz')
           $linuxSelfContained = Resolve-Asset 'BPP-Linux-self-contained' @('.tar.xz', '.tar.gz')
+          $android = Resolve-Asset 'BPP-Android' @('.zip')
 
           $packages = @(
             $windowsFrameworkDependent,
             $windowsSelfContained,
             $linuxFrameworkDependent,
-            $linuxSelfContained
+            $linuxSelfContained,
+            $android
           )
 
           foreach ($asset in $packages) {
@@ -628,7 +844,7 @@ jobs:
           # Single-quoted here-string: the notes are full of Markdown backticks, and in an
           # interpolating string PowerShell would eat them as escape characters.
           $contents = @'
-          Each package contains:
+          Each desktop package (`BPP-Win32-*`, `BPP-Linux-*`) contains:
 
           * `Broiler.Browser` — the Broiler web browser.
           * `Broiler.Writer` — the Broiler word processor (desktop).
@@ -665,6 +881,26 @@ jobs:
             ASP.NET Core 10 runtime on the target machine.
           '@
 
+          $androidNotes = @'
+          `BPP-Android.zip` carries the two Android application heads as Release app bundles:
+
+          * `Broiler.Browser.aab` — application ID `org.broiler.browser`.
+          * `Broiler.Writer.aab` — application ID `org.broiler.writer`.
+
+          Both bundles carry the `arm64-v8a` and `x86_64` ABIs, compile against API 36, and declare a
+          minimum of API 24. They are **unsigned**: release keys live outside the repository, so
+          signing and store upload belong to the delivery pipeline. An `.aab` is not installable as it
+          stands — sign it, then build and install an APK set for the device with Google `bundletool`:
+
+          ```
+          bundletool build-apks --bundle=Broiler.Browser.aab --output=Broiler.Browser.apks \
+            --ks=<keystore> --ks-key-alias=<alias>
+          bundletool install-apks --apks=Broiler.Browser.apks
+          ```
+
+          Android is an emulator-verified preview; physical-device validation is still outstanding.
+          '@
+
           $verify = @'
           Verify a download against `SHA256SUMS.txt`:
 
@@ -678,6 +914,8 @@ jobs:
             "Draft Broiler Preview Package prepared from branch $env:RELEASE_BRANCH at commit $env:SHORT_SHA.",
             '',
             $contents,
+            '',
+            $androidNotes,
             '',
             'Assets:',
             ($assetList -join "`n"),
@@ -693,6 +931,7 @@ jobs:
             $windowsSelfContained `
             $linuxFrameworkDependent `
             $linuxSelfContained `
+            $android `
             $checksumPath `
             --draft `
             --target $env:RELEASE_BRANCH `

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -496,19 +496,30 @@ failure modes worth knowing are in
 A1, A4, and A5 are no longer blocked on environment access; they are blocked only
 on being written.
 
+**Delivery update (2026-08-02):** CI now provisions Android in one place. The
+Broiler Preview Package workflow installs the `android` workload, tops the
+runner's SDK up to the compile API, publishes both heads with
+`dotnet publish -c Release`, and ships the resulting bundles as `BPP-Android.zip`
+beside the desktop packages. The bundles are the **unsigned**
+`<applicationId>.aab`; the workflow rejects the debug-key `-Signed` pair the same
+publish produces, so the artifact stays inside the A0 signing policy. That is the
+preview-delivery half of this phase. A per-change Android build, the emulator
+smoke run, and signed store-ready artifacts remain open below.
+
 **Next actions:**
 
-1. Give CI the same Android provisioning the development container now has —
-   `scripts/install-android-sdk.sh`, or the runner's own SDK image — and confirm
-   the CI egress policy allows `dl.google.com`, since the development
-   environment's allowlist does not extend to it.
+1. Extend that provisioning past the preview package —
+   `scripts/install-android-sdk.sh`, or the runner's own SDK image — to whichever
+   workflow gates changes, and confirm the CI egress policy allows
+   `dl.google.com` wherever the runner image does not already carry the SDK.
 2. Add an Android build workflow that provisions the SDK and workload and builds
    the Android solutions on every change to the shared applications, so the port
    does not silently rot.
 3. Add an instrumented smoke run — launch, render a frame, dispatch synthetic
    touch and text, rotate, background, resume — on an emulator, with the honest
    note that emulator evidence is not hardware evidence.
-4. Produce signed AAB/APK artifacts through the frozen A0 signing policy and
+4. Sign the AAB/APK artifacts through the frozen A0 signing policy — the preview
+   package already builds the Release bundles, it just cannot sign them — and
    reconcile channels, versioning, and update ownership with the existing
    release work.
 5. Record the Android support statement in [the README](../README.md) and the

--- a/docs/architecture/android.md
+++ b/docs/architecture/android.md
@@ -170,6 +170,17 @@ normal `adb install` cannot reuse stale fast-deployment assemblies. Release buil
 create AABs. Release AABs are not publishable until the external signing and
 review gates are satisfied.
 
+The [Broiler Preview Package workflow](../../.github/workflows/broiler-preview-package.yml)
+builds both heads with `dotnet publish -c Release` — the configuration name has to
+be exactly `Release`, since that is what switches `AndroidPackageFormat` to `aab` —
+and ships them as `BPP-Android.zip`. One publish leaves three packages side by
+side: the unsigned `<applicationId>.aab` plus a `-Signed.aab` and `-Signed.apk`
+carrying the workload's debug key. The workflow packages the unsigned bundle and
+fails if the file it picked turns out to be signed, so a debug-signed artifact
+cannot reach a release under the policy above. Each bundle carries `arm64-v8a` and
+`x86_64`, which is what the heads' `RuntimeIdentifiers` resolve to when the publish
+passes no `--runtime`.
+
 ## Non-goals and support boundary
 
 - No .NET MAUI, Android XML content layouts, or Android widget copy of the UI.

--- a/scripts/install-android-sdk.sh
+++ b/scripts/install-android-sdk.sh
@@ -21,7 +21,9 @@ set -uo pipefail
 SDK_DIR="${ANDROID_SDK_HOME:-/root/android-sdk}"
 
 # Versions verified together on 2026-07-30. The API level and build-tools track
-# the workload's Microsoft.Android.Sdk major (36); bump them together.
+# the workload's Microsoft.Android.Sdk major (36); bump them together. CI pins the
+# same pair in the ANDROID_API_LEVEL/ANDROID_BUILD_TOOLS env of the Android job in
+# .github/workflows/broiler-preview-package.yml — bump that with them.
 CMDLINE_TOOLS_BUILD="${ANDROID_CMDLINE_TOOLS_BUILD:-15859902}"
 ANDROID_API="${ANDROID_API_LEVEL:-36}"
 BUILD_TOOLS="${ANDROID_BUILD_TOOLS:-36.0.0}"

--- a/scripts/write-bpp-build-info.ps1
+++ b/scripts/write-bpp-build-info.ps1
@@ -14,26 +14,31 @@
     Package root to write BUILD-INFO.txt into (…/packages/BPP-Linux-self-contained).
 
 .PARAMETER Platform
-    linux or windows.
+    linux, windows, or android.
 
 .PARAMETER Variant
-    self-contained or framework-dependent.
+    self-contained or framework-dependent for the desktop packages; app-bundle for Android,
+    which has no such split — an .aab always carries its own runtime.
 
 .PARAMETER Branch
     Branch the package was built from.
 
 .PARAMETER Configuration
-    MSBuild configuration used (Release-Linux / Release-Windows).
+    MSBuild configuration used (Release-Linux / Release-Windows / Release).
 
 .EXAMPLE
     ./scripts/write-bpp-build-info.ps1 -PackageDirectory /tmp/packages/BPP-Linux-self-contained `
         -Platform linux -Variant self-contained -Branch main -Configuration Release-Linux
+
+.EXAMPLE
+    ./scripts/write-bpp-build-info.ps1 -PackageDirectory /tmp/packages/BPP-Android `
+        -Platform android -Variant app-bundle -Branch main -Configuration Release
 #>
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)][string] $PackageDirectory,
-    [Parameter(Mandatory = $true)][ValidateSet('linux', 'windows')][string] $Platform,
-    [Parameter(Mandatory = $true)][ValidateSet('self-contained', 'framework-dependent')][string] $Variant,
+    [Parameter(Mandatory = $true)][ValidateSet('linux', 'windows', 'android')][string] $Platform,
+    [Parameter(Mandatory = $true)][ValidateSet('self-contained', 'framework-dependent', 'app-bundle')][string] $Variant,
     [string] $Branch = '(unknown)',
     [string] $Configuration = '(unknown)'
 )
@@ -45,23 +50,30 @@ if (-not (Test-Path -LiteralPath $PackageDirectory)) {
     throw "Package directory not found: $PackageDirectory"
 }
 
+# app-bundle is the only Android variant and is meaningless for the desktop packages, so the
+# two sets of switches cannot be crossed.
+$isAndroid = $Platform -eq 'android'
+if ($isAndroid -ne ($Variant -eq 'app-bundle')) {
+    throw "Variant '$Variant' does not apply to platform '$Platform'."
+}
+
 $packageName = Split-Path -Leaf $PackageDirectory
 $commit = (git -C (Split-Path -Parent $PSScriptRoot) rev-parse HEAD 2>$null)
 if (-not $commit) { $commit = '(unknown)' }
 $built = [DateTime]::UtcNow.ToString('yyyy-MM-dd HH:mm:ss') + ' UTC'
 $run = if ($env:GITHUB_RUN_NUMBER) { "GitHub Actions run #$env:GITHUB_RUN_NUMBER" } else { 'local build' }
 
-$runtimeNote = if ($Variant -eq 'self-contained') {
-    'self-contained — the .NET runtime is included, nothing to install'
-}
-else {
-    'framework-dependent — requires the ASP.NET Core 10 runtime on the target machine'
+$runtimeNote = switch ($Variant) {
+    'self-contained' { 'self-contained — the .NET runtime is included, nothing to install' }
+    'framework-dependent' { 'framework-dependent — requires the ASP.NET Core 10 runtime on the target machine' }
+    'app-bundle' { 'app bundle — the .NET runtime ships inside the .aab, nothing to install' }
 }
 
-$rid = if ($Platform -eq 'windows') { 'win-x64' } else { 'linux-x64' }
-$exeSuffix = if ($Platform -eq 'windows') { '.exe' } else { '' }
-$bossLauncher = if ($Platform -eq 'windows') { 'BOSS\Start-BOSS.cmd' } else { './BOSS/run-boss.sh' }
-$bossServer = if ($Platform -eq 'windows') { 'BOSS\Broiler.Office.Server.exe' } else { './BOSS/Broiler.Office.Server' }
+$rid = switch ($Platform) {
+    'windows' { 'win-x64' }
+    'linux' { 'linux-x64' }
+    'android' { 'android-arm64, android-x64' }
+}
 
 $lines = @(
     'Broiler Preview Package'
@@ -77,36 +89,79 @@ $lines = @(
     ''
     'This is a preview build from a branch, not a supported release. Expect rough edges.'
     ''
-    'Contents'
-    '--------'
-    ''
-    ('  {0,-24}{1}' -f "Broiler.Browser$exeSuffix", 'The Broiler web browser.')
-    ('  {0,-24}{1}' -f "Broiler.Writer$exeSuffix", 'The Broiler word processor (desktop).')
-    ('  {0,-24}{1}' -f 'BOSS/', 'Broiler Office Standalone Server — serves the Broiler Writer')
-    ('  {0,-24}{1}' -f '', 'web app (WebAssembly) over HTTP from its own Kestrel host.')
-    ''
-    'Starting the Office server (BOSS)'
-    '---------------------------------'
-    ''
-    "  $bossLauncher                        listens on http://0.0.0.0:5555"
-    "  $bossServer --urls http://0.0.0.0:5555"
-    ''
-    '  Then open http://localhost:5555/ — health probe at /healthz, server details at /api/info.'
-    ''
-    '  To run it as a system service (systemd, SysV init, or a Windows service), see'
-    '  BOSS/service/. Full documentation: BOSS/README.md.'
 )
 
-if ($Variant -eq 'framework-dependent') {
+if ($isAndroid) {
     $lines += @(
+        'Contents'
+        '--------'
         ''
-        'Runtime requirement'
-        '-------------------'
+        ('  {0,-24}{1}' -f 'Broiler.Browser.aab', 'The Broiler web browser — org.broiler.browser.')
+        ('  {0,-24}{1}' -f 'Broiler.Writer.aab', 'The Broiler word processor — org.broiler.writer.')
         ''
-        '  Install the ASP.NET Core 10 runtime before running BOSS:'
-        '  https://dotnet.microsoft.com/download/dotnet/10.0  (ASP.NET Core Runtime, not just the'
-        '  .NET Runtime). The self-contained package needs no installation.'
+        '  Both bundles carry the arm64-v8a and x86_64 ABIs, compile against API 36, and declare a'
+        '  minimum of API 24.'
+        ''
+        'These bundles are UNSIGNED'
+        '--------------------------'
+        ''
+        '  Release signing keys are kept outside the repository, so a preview build cannot produce'
+        '  a store-ready artifact. Sign a bundle with your own key before installing or uploading'
+        '  it.'
+        ''
+        'Installing an .aab'
+        '------------------'
+        ''
+        '  An app bundle is not installable as it stands. Sign it, then use Google bundletool to'
+        '  build the APK set for a device and install it:'
+        ''
+        '    bundletool build-apks --bundle=Broiler.Browser.aab --output=Broiler.Browser.apks \'
+        '      --ks=<keystore> --ks-key-alias=<alias>'
+        '    bundletool install-apks --apks=Broiler.Browser.apks'
+        ''
+        '  bundletool releases: https://github.com/google/bundletool/releases'
+        ''
+        '  Android support is a preview: the applications are verified on an API 36 emulator, and'
+        '  physical-device validation is still outstanding. See docs/architecture/android.md.'
     )
+}
+else {
+    $exeSuffix = if ($Platform -eq 'windows') { '.exe' } else { '' }
+    $bossLauncher = if ($Platform -eq 'windows') { 'BOSS\Start-BOSS.cmd' } else { './BOSS/run-boss.sh' }
+    $bossServer = if ($Platform -eq 'windows') { 'BOSS\Broiler.Office.Server.exe' } else { './BOSS/Broiler.Office.Server' }
+
+    $lines += @(
+        'Contents'
+        '--------'
+        ''
+        ('  {0,-24}{1}' -f "Broiler.Browser$exeSuffix", 'The Broiler web browser.')
+        ('  {0,-24}{1}' -f "Broiler.Writer$exeSuffix", 'The Broiler word processor (desktop).')
+        ('  {0,-24}{1}' -f 'BOSS/', 'Broiler Office Standalone Server — serves the Broiler Writer')
+        ('  {0,-24}{1}' -f '', 'web app (WebAssembly) over HTTP from its own Kestrel host.')
+        ''
+        'Starting the Office server (BOSS)'
+        '---------------------------------'
+        ''
+        "  $bossLauncher                        listens on http://0.0.0.0:5555"
+        "  $bossServer --urls http://0.0.0.0:5555"
+        ''
+        '  Then open http://localhost:5555/ — health probe at /healthz, server details at /api/info.'
+        ''
+        '  To run it as a system service (systemd, SysV init, or a Windows service), see'
+        '  BOSS/service/. Full documentation: BOSS/README.md.'
+    )
+
+    if ($Variant -eq 'framework-dependent') {
+        $lines += @(
+            ''
+            'Runtime requirement'
+            '-------------------'
+            ''
+            '  Install the ASP.NET Core 10 runtime before running BOSS:'
+            '  https://dotnet.microsoft.com/download/dotnet/10.0  (ASP.NET Core Runtime, not just the'
+            '  .NET Runtime). The self-contained package needs no installation.'
+        )
+    }
 }
 
 $lines += @(


### PR DESCRIPTION
Extends the Broiler Preview Package workflow to build and ship Android application bundles alongside the existing desktop packages.

## Summary

The preview package workflow now provisions the Android SDK and .NET `android` workload, publishes both Broiler.Browser and Broiler.Writer as Release app bundles (`.aab`), and delivers them as `BPP-Android.zip`. The bundles are unsigned — release signing keys remain outside the repository per the A0 signing policy — and the workflow validates that only the unsigned bundles are packaged, rejecting any debug-signed artifacts the publish produces.

## Key changes

- **Workflow provisioning:** Added `build-android-preview-package` job that:
  - Installs the .NET `android` workload and provisions the Android SDK to API 36
  - Publishes both application heads with `dotnet publish -c Release`
  - Validates the resulting `.aab` files (verifies bundle structure, ABIs, and unsigned status)
  - Packages them into `BPP-Android.zip` with build metadata

- **Configuration:** Added `ANDROID_CONFIGURATION: Release` environment variable (plain `Release`, not `Release-Android`) because `AndroidPackageFormat` switches to `aab` only when the configuration name is exactly `Release`

- **Release notes:** Updated the draft release creation to include Android bundles and document:
  - Both bundles carry `arm64-v8a` and `x86_64` ABIs, target API 36, and declare API 24 minimum
  - Bundles are unsigned and require signing before store upload
  - Installation workflow using Google `bundletool`
  - Note that Android support is emulator-verified; physical-device validation is outstanding

- **Build info script:** Extended `write-bpp-build-info.ps1` to support Android platform and `app-bundle` variant, generating appropriate documentation for the Android packages

- **Documentation:** Updated `docs/ROADMAP.md` and `docs/architecture/android.md` to reflect that preview-delivery provisioning is now in CI, and clarified the unsigned-bundle policy and validation in the workflow

## Implementation details

- The workflow rejects any signed `.aab` or `.apk` files, ensuring only the unsigned `<applicationId>.aab` reaches the release
- Both bundles are verified to contain required protobuf structures (`BundleConfig.pb`, `AndroidManifest.xml`) and both required ABIs before packaging
- Android job depends on no other jobs and is independent of desktop builds; the release job waits for all three (Windows, Linux, Android) before creating the draft
- The `ANDROID_API_LEVEL` and `ANDROID_BUILD_TOOLS` are pinned to 36 and must be bumped together with the workload's `Microsoft.Android.Sdk` major version

https://claude.ai/code/session_01HWgoT2srdebpqbd2cJETFE