### PR TITLE
Sign Android packages with release key in preview workflow

### DIFF
--- a/.github/workflows/broiler-preview-package.yml
+++ b/.github/workflows/broiler-preview-package.yml
@@ -534,11 +534,12 @@ jobs:
   build-android-preview-package:
     name: Build BPP Android Package
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    # Four publishes rather than the two this job started with: a bundle and an arm64 APK per head.
+    timeout-minutes: 150
     outputs:
       # The signing certificate's fingerprint, for the release notes to publish. A certificate is
       # public by construction — this is what a download is checked against, not key material.
-      signing-certificate-sha256: ${{ steps.sign-android-bundles.outputs.certificate-sha256 }}
+      signing-certificate-sha256: ${{ steps.sign-android-packages.outputs.certificate-sha256 }}
     env:
       BROWSER_PROJECT_PATH: src/Broiler.Browser.Android/Broiler.Browser.Android.csproj
       WRITER_PROJECT_PATH: src/Broiler.Writer.Android/Broiler.Writer.Android.csproj
@@ -578,7 +579,7 @@ jobs:
         run: |
           # Signing is what turns the publish output into a shippable package, so the secrets it
           # needs are checked before the hour of building rather than after it.
-          ./scripts/sign-android-app-bundles.ps1 -ValidateOnly | Out-Null
+          ./scripts/sign-android-packages.ps1 -ValidateOnly | Out-Null
 
       - name: Install the Android build workload
         shell: pwsh
@@ -648,40 +649,91 @@ jobs:
             --no-restore `
             --output (Join-Path $publishRoot 'writer')
 
-      - name: Collect and verify the Android app bundles
+      - name: Publish the arm64 Release APKs
         shell: pwsh
         run: |
-          # A Release publish leaves three packages side by side: the unsigned <applicationId>.aab
-          # plus -Signed.aab and -Signed.apk, both signed with the workload's debug key. The
-          # unsigned bundle is the one to carry forward — the next step signs it with the release
-          # key, and a debug-signed bundle would arrive looking release-ready when it is not.
-          function Get-UnsignedBundle {
+          # The same Release configuration as the bundles, with two properties overridden. They go
+          # on the command line, where they become global properties and so win over the csproj:
+          #
+          #   AndroidPackageFormat  the heads switch to aab on '$(Configuration)' == 'Release', and
+          #                         this package is the directly installable counterpart.
+          #   RuntimeIdentifiers    an APK carries one ABI where a bundle carries the split set;
+          #                         arm64-v8a is the ABI real devices run.
+          #
+          # No restore of its own: android-arm64 is part of the RuntimeIdentifiers already restored
+          # above, so --no-restore is still honest. Restoring the narrower set here would rewrite
+          # project.assets.json and break the bundle publish's own --no-restore.
+          $publishRoot = Join-Path $env:RUNNER_TEMP 'android-publish'
+
+          dotnet publish $env:BROWSER_PROJECT_PATH `
+            --configuration $env:ANDROID_CONFIGURATION `
+            --no-restore `
+            -p:AndroidPackageFormat=apk `
+            -p:RuntimeIdentifiers=android-arm64 `
+            --output (Join-Path $publishRoot 'browser-arm64-apk')
+
+          dotnet publish $env:WRITER_PROJECT_PATH `
+            --configuration $env:ANDROID_CONFIGURATION `
+            --no-restore `
+            -p:AndroidPackageFormat=apk `
+            -p:RuntimeIdentifiers=android-arm64 `
+            --output (Join-Path $publishRoot 'writer-arm64-apk')
+
+      - name: Collect and verify the Android packages
+        shell: pwsh
+        run: |
+          # Either publish leaves the unsigned <applicationId> package beside a -Signed pair
+          # carrying the workload's debug key. The unsigned one is what to carry forward — the next
+          # step signs it with the release key, and a debug-signed package would arrive looking
+          # release-ready when it is not.
+          function Get-UnsignedPackage {
             param(
               [Parameter(Mandatory=$true)][string]$PublishDirectory,
-              [Parameter(Mandatory=$true)][string]$ApplicationId
+              [Parameter(Mandatory=$true)][string]$ApplicationId,
+              [Parameter(Mandatory=$true)][string]$Extension
             )
 
-            $bundle = Join-Path $PublishDirectory "$ApplicationId.aab"
-            if (-not (Test-Path -LiteralPath $bundle)) {
-              $produced = @(Get-ChildItem -LiteralPath $PublishDirectory -Filter *.aab -ErrorAction SilentlyContinue |
+            $package = Join-Path $PublishDirectory "$ApplicationId$Extension"
+            if (-not (Test-Path -LiteralPath $package)) {
+              $produced = @(Get-ChildItem -LiteralPath $PublishDirectory -Filter "*$Extension" -ErrorAction SilentlyContinue |
                 ForEach-Object { $_.Name })
               $found = if ($produced) { $produced -join ', ' } else { '(none)' }
-              throw "Expected $ApplicationId.aab in $PublishDirectory. Bundles produced: $found"
+              throw "Expected $ApplicationId$Extension in $PublishDirectory. Packages produced: $found"
             }
 
-            return $bundle
+            return $package
+          }
+
+          function Get-ArchiveEntries {
+            param([Parameter(Mandatory=$true)][string]$Path)
+
+            $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
+            try {
+              return @($archive.Entries | ForEach-Object { $_.FullName })
+            }
+            finally {
+              $archive.Dispose()
+            }
+          }
+
+          function Assert-Unsigned {
+            param(
+              [Parameter(Mandatory=$true)][string]$Path,
+              [Parameter(Mandatory=$true)][AllowEmptyCollection()][string[]]$Entries
+            )
+
+            # Signing happens in the next step, against the release key. A signature already here
+            # means the debug-signed package was picked up by mistake.
+            $signature = @($Entries | Where-Object { $_ -match '^META-INF/.+\.(RSA|DSA|EC|SF)$' })
+            if ($signature) {
+              throw "$Path is already signed ($($signature -join ', ')); the debug-signed package was picked up instead of the unsigned one."
+            }
           }
 
           function Assert-AndroidAppBundle {
             param([Parameter(Mandatory=$true)][string]$Path)
 
-            $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
-            try {
-              $entries = @($archive.Entries | ForEach-Object { $_.FullName })
-            }
-            finally {
-              $archive.Dispose()
-            }
+            $entries = @(Get-ArchiveEntries -Path $Path)
 
             # An .aab is a protobuf bundle, not an APK. BundleConfig.pb and the base/ split are what
             # tell the two apart, so a wrong AndroidPackageFormat cannot ship unnoticed.
@@ -697,15 +749,42 @@ jobs:
               }
             }
 
-            # Signing happens in the next step, against the release key. A signature already here
-            # means the debug-signed bundle was picked up by mistake.
-            $signature = @($entries | Where-Object { $_ -match '^META-INF/.+\.(RSA|DSA|EC|SF)$' })
-            if ($signature) {
-              throw "$Path is already signed ($($signature -join ', ')); the debug-signed bundle was picked up instead of the unsigned one."
-            }
+            Assert-Unsigned -Path $Path -Entries $entries
 
             $megabytes = [Math]::Round((Get-Item -LiteralPath $Path).Length / 1MB, 1)
             Write-Host "==> verified $(Split-Path -Leaf $Path): app bundle, $($entries.Count) entries, $megabytes MB, unsigned publish output"
+          }
+
+          function Assert-AndroidArm64Apk {
+            param([Parameter(Mandatory=$true)][string]$Path)
+
+            $entries = @(Get-ArchiveEntries -Path $Path)
+
+            # The mirror of the bundle's check: an APK keeps its manifest at the archive root and
+            # has no BundleConfig.pb, so neither format can ship under the other one's name.
+            if ($entries -notcontains 'AndroidManifest.xml') {
+              throw "$Path is not an APK: AndroidManifest.xml is missing from the archive root."
+            }
+
+            if ($entries -contains 'BundleConfig.pb') {
+              throw "$Path is an app bundle, not an APK; AndroidPackageFormat did not take."
+            }
+
+            # One ABI is the point of this package: an installable arm64 build. A second one means
+            # the RuntimeIdentifiers override did not take, and the download would be twice the size
+            # it needs to be.
+            $abis = @($entries |
+              ForEach-Object { if ($_ -match '^lib/([^/]+)/.') { $Matches[1] } } |
+              Sort-Object -Unique)
+            if ($abis.Count -ne 1 -or $abis[0] -ne 'arm64-v8a') {
+              $found = if ($abis.Count -gt 0) { $abis -join ', ' } else { '(none)' }
+              throw "$Path should carry arm64-v8a native code and nothing else; found: $found."
+            }
+
+            Assert-Unsigned -Path $Path -Entries $entries
+
+            $megabytes = [Math]::Round((Get-Item -LiteralPath $Path).Length / 1MB, 1)
+            Write-Host "==> verified $(Split-Path -Leaf $Path): apk, arm64-v8a, $($entries.Count) entries, $megabytes MB, unsigned publish output"
           }
 
           $publishRoot = Join-Path $env:RUNNER_TEMP 'android-publish'
@@ -713,21 +792,30 @@ jobs:
           New-Item -ItemType Directory -Force -Path $packageRoot | Out-Null
 
           $heads = @(
-            @{ Directory = 'browser'; ApplicationId = 'org.broiler.browser'; PackageName = 'Broiler.Browser.aab' }
-            @{ Directory = 'writer'; ApplicationId = 'org.broiler.writer'; PackageName = 'Broiler.Writer.aab' }
+            @{ Directory = 'browser'; ApplicationId = 'org.broiler.browser'; BundleName = 'Broiler.Browser.aab'; ApkName = 'Broiler.Browser-arm64.apk' }
+            @{ Directory = 'writer'; ApplicationId = 'org.broiler.writer'; BundleName = 'Broiler.Writer.aab'; ApkName = 'Broiler.Writer-arm64.apk' }
           )
 
           foreach ($head in $heads) {
-            $bundle = Get-UnsignedBundle `
+            $bundle = Get-UnsignedPackage `
               -PublishDirectory (Join-Path $publishRoot $head.Directory) `
-              -ApplicationId $head.ApplicationId
+              -ApplicationId $head.ApplicationId `
+              -Extension '.aab'
 
             Assert-AndroidAppBundle -Path $bundle
-            Copy-Item -LiteralPath $bundle -Destination (Join-Path $packageRoot $head.PackageName) -Force
+            Copy-Item -LiteralPath $bundle -Destination (Join-Path $packageRoot $head.BundleName) -Force
+
+            $apk = Get-UnsignedPackage `
+              -PublishDirectory (Join-Path $publishRoot "$($head.Directory)-arm64-apk") `
+              -ApplicationId $head.ApplicationId `
+              -Extension '.apk'
+
+            Assert-AndroidArm64Apk -Path $apk
+            Copy-Item -LiteralPath $apk -Destination (Join-Path $packageRoot $head.ApkName) -Force
           }
 
-      - name: Sign the Android app bundles
-        id: sign-android-bundles
+      - name: Sign the Android packages
+        id: sign-android-packages
         shell: pwsh
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
@@ -735,15 +823,20 @@ jobs:
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
-          # The copies in the package root are signed, not the publish output: the bundle that
-          # ships is the bundle that was verified. The script signs with jarsigner, checks the
-          # result verifies against the release certificate, and returns its SHA-256 fingerprint —
-          # which BUILD-INFO.txt and the release notes quote so a download can be checked.
+          # The copies in the package root are signed, not the publish output: what ships is what
+          # was verified. Bundles go through jarsigner and APKs through zipalign and apksigner —
+          # the tool each format is checked by. The script verifies every signature against the
+          # release certificate and returns its SHA-256 fingerprint, which BUILD-INFO.txt and the
+          # release notes quote so a download can be checked.
           $packageRoot = Join-Path $env:RUNNER_TEMP 'packages/BPP-Android'
 
-          $fingerprint = ./scripts/sign-android-app-bundles.ps1 -BundlePath `
-            (Join-Path $packageRoot 'Broiler.Browser.aab'), `
-            (Join-Path $packageRoot 'Broiler.Writer.aab')
+          $fingerprint = ./scripts/sign-android-packages.ps1 `
+            -BundlePath `
+              (Join-Path $packageRoot 'Broiler.Browser.aab'), `
+              (Join-Path $packageRoot 'Broiler.Writer.aab') `
+            -ApkPath `
+              (Join-Path $packageRoot 'Broiler.Browser-arm64.apk'), `
+              (Join-Path $packageRoot 'Broiler.Writer-arm64.apk')
 
           if ([string]::IsNullOrWhiteSpace($fingerprint)) {
             throw 'The signing script returned no certificate fingerprint.'
@@ -927,19 +1020,22 @@ jobs:
           '@
 
           $androidNotes = @'
-          `BPP-Android.zip` carries the two Android application heads as Release app bundles:
+          `BPP-Android.zip` carries the two Android application heads twice — as Release app bundles
+          to upload, and as arm64 Release APKs to install:
 
-          * `Broiler.Browser.aab` — application ID `org.broiler.browser`.
-          * `Broiler.Writer.aab` — application ID `org.broiler.writer`.
+          * `Broiler.Browser.aab` / `Broiler.Browser-arm64.apk` — application ID `org.broiler.browser`.
+          * `Broiler.Writer.aab` / `Broiler.Writer-arm64.apk` — application ID `org.broiler.writer`.
 
-          Both bundles carry the `arm64-v8a` and `x86_64` ABIs, compile against API 36, and declare a
-          minimum of API 24. Both are **signed with the Broiler release key** — held as repository
-          secrets, never in the repository — and the workflow verifies each signature against that
-          key before packaging. Check a download with:
+          The bundles carry the `arm64-v8a` and `x86_64` ABIs; the APKs carry `arm64-v8a` alone,
+          which is what physical devices run. All four compile against API 36 and declare a minimum
+          of API 24, and all four are **signed with the Broiler release key** — held as repository
+          secrets, never in the repository — with every signature verified against that key before
+          packaging. Each format is signed by the tool that checks it, so check a download the same
+          way:
 
           ```
           jarsigner -verify Broiler.Browser.aab
-          keytool -printcert -jarfile Broiler.Browser.aab
+          apksigner verify --print-certs -v Broiler.Browser-arm64.apk
           ```
           '@
 
@@ -958,8 +1054,15 @@ jobs:
           $androidNotes += @'
 
 
-          An `.aab` is still not installable as it stands. Build an APK set for the device with
-          Google `bundletool` and install that:
+          To put a build on an arm64 device:
+
+          ```
+          adb install -r Broiler.Browser-arm64.apk
+          ```
+
+          An `.aab` is not installable as it stands — it is the upload format. For an emulator or a
+          device on another ABI, build an APK set from the bundle with Google `bundletool` and
+          install that:
 
           ```
           bundletool build-apks --bundle=Broiler.Browser.aab --output=Broiler.Browser.apks

--- a/.github/workflows/broiler-preview-package.yml
+++ b/.github/workflows/broiler-preview-package.yml
@@ -535,6 +535,10 @@ jobs:
     name: Build BPP Android Package
     runs-on: ubuntu-24.04
     timeout-minutes: 120
+    outputs:
+      # The signing certificate's fingerprint, for the release notes to publish. A certificate is
+      # public by construction — this is what a download is checked against, not key material.
+      signing-certificate-sha256: ${{ steps.sign-android-bundles.outputs.certificate-sha256 }}
     env:
       BROWSER_PROJECT_PATH: src/Broiler.Browser.Android/Broiler.Browser.Android.csproj
       WRITER_PROJECT_PATH: src/Broiler.Writer.Android/Broiler.Writer.Android.csproj
@@ -563,6 +567,18 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+
+      - name: Check the Android signing secrets
+        shell: pwsh
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          # Signing is what turns the publish output into a shippable package, so the secrets it
+          # needs are checked before the hour of building rather than after it.
+          ./scripts/sign-android-app-bundles.ps1 -ValidateOnly | Out-Null
 
       - name: Install the Android build workload
         shell: pwsh
@@ -636,8 +652,9 @@ jobs:
         shell: pwsh
         run: |
           # A Release publish leaves three packages side by side: the unsigned <applicationId>.aab
-          # plus -Signed.aab and -Signed.apk, both signed with the workload's debug key. Only the
-          # unsigned bundle may ship — a debug-signed one looks release-ready and is not.
+          # plus -Signed.aab and -Signed.apk, both signed with the workload's debug key. The
+          # unsigned bundle is the one to carry forward — the next step signs it with the release
+          # key, and a debug-signed bundle would arrive looking release-ready when it is not.
           function Get-UnsignedBundle {
             param(
               [Parameter(Mandatory=$true)][string]$PublishDirectory,
@@ -680,15 +697,15 @@ jobs:
               }
             }
 
-            # The unsigned bundle is the deliverable; a signature here means the debug-signed one
-            # was picked up by mistake.
+            # Signing happens in the next step, against the release key. A signature already here
+            # means the debug-signed bundle was picked up by mistake.
             $signature = @($entries | Where-Object { $_ -match '^META-INF/.+\.(RSA|DSA|EC|SF)$' })
             if ($signature) {
-              throw "$Path is signed ($($signature -join ', ')); the preview package ships unsigned bundles."
+              throw "$Path is already signed ($($signature -join ', ')); the debug-signed bundle was picked up instead of the unsigned one."
             }
 
             $megabytes = [Math]::Round((Get-Item -LiteralPath $Path).Length / 1MB, 1)
-            Write-Host "==> verified $(Split-Path -Leaf $Path): app bundle, $($entries.Count) entries, $megabytes MB, unsigned"
+            Write-Host "==> verified $(Split-Path -Leaf $Path): app bundle, $($entries.Count) entries, $megabytes MB, unsigned publish output"
           }
 
           $publishRoot = Join-Path $env:RUNNER_TEMP 'android-publish'
@@ -709,6 +726,32 @@ jobs:
             Copy-Item -LiteralPath $bundle -Destination (Join-Path $packageRoot $head.PackageName) -Force
           }
 
+      - name: Sign the Android app bundles
+        id: sign-android-bundles
+        shell: pwsh
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          # The copies in the package root are signed, not the publish output: the bundle that
+          # ships is the bundle that was verified. The script signs with jarsigner, checks the
+          # result verifies against the release certificate, and returns its SHA-256 fingerprint —
+          # which BUILD-INFO.txt and the release notes quote so a download can be checked.
+          $packageRoot = Join-Path $env:RUNNER_TEMP 'packages/BPP-Android'
+
+          $fingerprint = ./scripts/sign-android-app-bundles.ps1 -BundlePath `
+            (Join-Path $packageRoot 'Broiler.Browser.aab'), `
+            (Join-Path $packageRoot 'Broiler.Writer.aab')
+
+          if ([string]::IsNullOrWhiteSpace($fingerprint)) {
+            throw 'The signing script returned no certificate fingerprint.'
+          }
+
+          "ANDROID_SIGNING_CERT_SHA256=$fingerprint" >> $env:GITHUB_ENV
+          "certificate-sha256=$fingerprint" >> $env:GITHUB_OUTPUT
+
       - name: Package Android assets
         shell: pwsh
         env:
@@ -724,7 +767,8 @@ jobs:
             -Platform android `
             -Variant app-bundle `
             -Branch $env:RELEASE_BRANCH `
-            -Configuration $env:ANDROID_CONFIGURATION
+            -Configuration $env:ANDROID_CONFIGURATION `
+            -SigningCertificateSha256 $env:ANDROID_SIGNING_CERT_SHA256
 
           # A zip rather than the Linux job's tar.xz: these bundles are fed to Android tooling from
           # whatever desktop the developer has, and .zip opens on all three without extra tools.
@@ -792,6 +836,7 @@ jobs:
           TAG_NAME: ${{ steps.metadata.outputs.tag_name }}
           RELEASE_TITLE: ${{ steps.metadata.outputs.release_title }}
           SHORT_SHA: ${{ steps.metadata.outputs.short_sha }}
+          ANDROID_SIGNING_CERT_SHA256: ${{ needs.build-android-preview-package.outputs.signing-certificate-sha256 }}
         run: |
           $assetDir = Join-Path $env:RUNNER_TEMP 'release-assets'
 
@@ -888,15 +933,41 @@ jobs:
           * `Broiler.Writer.aab` — application ID `org.broiler.writer`.
 
           Both bundles carry the `arm64-v8a` and `x86_64` ABIs, compile against API 36, and declare a
-          minimum of API 24. They are **unsigned**: release keys live outside the repository, so
-          signing and store upload belong to the delivery pipeline. An `.aab` is not installable as it
-          stands — sign it, then build and install an APK set for the device with Google `bundletool`:
+          minimum of API 24. Both are **signed with the Broiler release key** — held as repository
+          secrets, never in the repository — and the workflow verifies each signature against that
+          key before packaging. Check a download with:
 
           ```
-          bundletool build-apks --bundle=Broiler.Browser.aab --output=Broiler.Browser.apks \
-            --ks=<keystore> --ks-key-alias=<alias>
+          jarsigner -verify Broiler.Browser.aab
+          keytool -printcert -jarfile Broiler.Browser.aab
+          ```
+          '@
+
+          # A doubled backtick is one literal backtick in an expandable here-string, so the
+          # fingerprint lands in the notes as markdown inline code.
+          if (-not [string]::IsNullOrWhiteSpace($env:ANDROID_SIGNING_CERT_SHA256)) {
+            $androidNotes += @"
+
+
+          The signing certificate's SHA-256 fingerprint is:
+
+          ``$env:ANDROID_SIGNING_CERT_SHA256``
+          "@
+          }
+
+          $androidNotes += @'
+
+
+          An `.aab` is still not installable as it stands. Build an APK set for the device with
+          Google `bundletool` and install that:
+
+          ```
+          bundletool build-apks --bundle=Broiler.Browser.aab --output=Broiler.Browser.apks
           bundletool install-apks --apks=Broiler.Browser.apks
           ```
+
+          `bundletool` signs the APKs it generates with its own debug key unless `--ks` says
+          otherwise; that is a local install detail and leaves the bundle's own signature untouched.
 
           Android is an emulator-verified preview; physical-device validation is still outstanding.
           '@

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -505,18 +505,28 @@ rejects the debug-key `-Signed` pair the same publish produces, so the workload'
 debug key cannot pass itself off as a release. That is the preview-delivery half
 of this phase.
 
-**Signing update (2026-08-03):** those bundles are now signed with the release
-key. `scripts/sign-android-app-bundles.ps1` reads the key from the
+**Signing update (2026-08-03):** those packages are now signed with the release
+key. `scripts/sign-android-packages.ps1` reads the key from the
 `ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, and
-`ANDROID_KEY_PASSWORD` repository secrets, signs each bundle with `jarsigner`, and
-verifies the result against the keystore's own certificate before the package is
-built — a missing or wrong secret fails the job instead of producing an unsigned
-package. The certificate fingerprint is published in `BUILD-INFO.txt` and the
-draft release notes. This keeps the A0 policy intact: the key stays outside the
-repository, and the delivery pipeline is what signs.
+`ANDROID_KEY_PASSWORD` repository secrets, signs each one, and verifies the result
+against the keystore's own certificate before the package is built — a missing or
+wrong secret fails the job instead of producing an unsigned package. The
+certificate fingerprint is published in `BUILD-INFO.txt` and the draft release
+notes. This keeps the A0 policy intact: the key stays outside the repository, and
+the delivery pipeline is what signs.
 [Release signing](architecture/android.md#release-signing) documents the secrets
-and the verification. A per-change Android build, the emulator smoke run, and
-store delivery remain open below.
+and the verification.
+
+**Installable-artifact update (2026-08-03):** `BPP-Android.zip` now carries each
+head twice. A bundle is the upload format and cannot be installed, so beside the
+two `.aab`s the workflow publishes `Broiler.Browser-arm64.apk` and
+`Broiler.Writer-arm64.apk` — the same Release configuration with
+`AndroidPackageFormat=apk` and `RuntimeIdentifiers=android-arm64` overridden, so
+each APK carries the one ABI physical devices run. APKs are zipaligned and signed
+with `apksigner` rather than `jarsigner`: from Android 11 an APK with only a JAR
+signature is refused at install. So a preview build can now be put on a device with
+`adb install` and nothing else. A per-change Android build, the emulator smoke run,
+and store delivery remain open below.
 
 **Next actions:**
 
@@ -530,7 +540,7 @@ store delivery remain open below.
 3. Add an instrumented smoke run — launch, render a frame, dispatch synthetic
    touch and text, rotate, background, resume — on an emulator, with the honest
    note that emulator evidence is not hardware evidence.
-4. Take the signed bundles the preview package now produces the rest of the way
+4. Take the signed packages the preview package now produces the rest of the way
    to a store: decide Play App Signing versus self-managed keys and what the
    secrets' key is then upload key or app key, add key rotation and expiry
    handling, and reconcile channels, versioning, and update ownership with the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -500,11 +500,23 @@ on being written.
 Broiler Preview Package workflow installs the `android` workload, tops the
 runner's SDK up to the compile API, publishes both heads with
 `dotnet publish -c Release`, and ships the resulting bundles as `BPP-Android.zip`
-beside the desktop packages. The bundles are the **unsigned**
-`<applicationId>.aab`; the workflow rejects the debug-key `-Signed` pair the same
-publish produces, so the artifact stays inside the A0 signing policy. That is the
-preview-delivery half of this phase. A per-change Android build, the emulator
-smoke run, and signed store-ready artifacts remain open below.
+beside the desktop packages. It takes the unsigned `<applicationId>.aab` and
+rejects the debug-key `-Signed` pair the same publish produces, so the workload's
+debug key cannot pass itself off as a release. That is the preview-delivery half
+of this phase.
+
+**Signing update (2026-08-03):** those bundles are now signed with the release
+key. `scripts/sign-android-app-bundles.ps1` reads the key from the
+`ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, and
+`ANDROID_KEY_PASSWORD` repository secrets, signs each bundle with `jarsigner`, and
+verifies the result against the keystore's own certificate before the package is
+built — a missing or wrong secret fails the job instead of producing an unsigned
+package. The certificate fingerprint is published in `BUILD-INFO.txt` and the
+draft release notes. This keeps the A0 policy intact: the key stays outside the
+repository, and the delivery pipeline is what signs.
+[Release signing](architecture/android.md#release-signing) documents the secrets
+and the verification. A per-change Android build, the emulator smoke run, and
+store delivery remain open below.
 
 **Next actions:**
 
@@ -518,10 +530,11 @@ smoke run, and signed store-ready artifacts remain open below.
 3. Add an instrumented smoke run — launch, render a frame, dispatch synthetic
    touch and text, rotate, background, resume — on an emulator, with the honest
    note that emulator evidence is not hardware evidence.
-4. Sign the AAB/APK artifacts through the frozen A0 signing policy — the preview
-   package already builds the Release bundles, it just cannot sign them — and
-   reconcile channels, versioning, and update ownership with the existing
-   release work.
+4. Take the signed bundles the preview package now produces the rest of the way
+   to a store: decide Play App Signing versus self-managed keys and what the
+   secrets' key is then upload key or app key, add key rotation and expiry
+   handling, and reconcile channels, versioning, and update ownership with the
+   existing release work.
 5. Record the Android support statement in [the README](../README.md) and the
    component READMEs only after the A1–A5 gates pass, and keep it scoped to what
    was measured.

--- a/docs/architecture/android.md
+++ b/docs/architecture/android.md
@@ -27,7 +27,7 @@ layouts or Android widgets in application content.
 | AOT and trimming | Disabled. Browser uses an expression compiler based on `Reflection.Emit`, which is incompatible with full AOT. |
 | Packages | `org.broiler.writer` and `org.broiler.browser` |
 | Artifacts | Self-contained Debug APK; Release AAB |
-| Signing | Debug signing is workload-managed. Release keys stay outside the repository and signing belongs to the delivery pipeline. |
+| Signing | Debug signing is workload-managed. Release keys stay outside the repository — the delivery pipeline signs, reading the key from encrypted repository secrets. |
 | Network policy | Only Browser declares `INTERNET`; cleartext traffic is disabled for both applications. |
 
 The generated roots are `Broiler.Android.Writer.slnx`,
@@ -167,19 +167,64 @@ dotnet run --project Broiler.Graphics/Broiler.Graphics.Android.Tests
 
 Debug builds create self-contained APKs (`EmbedAssembliesIntoApk=true`) so a
 normal `adb install` cannot reuse stale fast-deployment assemblies. Release builds
-create AABs. Release AABs are not publishable until the external signing and
-review gates are satisfied.
+create AABs.
 
 The [Broiler Preview Package workflow](../../.github/workflows/broiler-preview-package.yml)
 builds both heads with `dotnet publish -c Release` — the configuration name has to
 be exactly `Release`, since that is what switches `AndroidPackageFormat` to `aab` —
 and ships them as `BPP-Android.zip`. One publish leaves three packages side by
 side: the unsigned `<applicationId>.aab` plus a `-Signed.aab` and `-Signed.apk`
-carrying the workload's debug key. The workflow packages the unsigned bundle and
-fails if the file it picked turns out to be signed, so a debug-signed artifact
-cannot reach a release under the policy above. Each bundle carries `arm64-v8a` and
+carrying the workload's debug key. The workflow takes the unsigned bundle and
+fails if the file it picked turns out to be signed already, so a debug-signed
+artifact cannot pass itself off as a release. Each bundle carries `arm64-v8a` and
 `x86_64`, which is what the heads' `RuntimeIdentifiers` resolve to when the publish
 passes no `--runtime`.
+
+### Release signing
+
+The workflow signs the bundles it packages with the release key, through
+[`scripts/sign-android-app-bundles.ps1`](../../scripts/sign-android-app-bundles.ps1).
+The key stays out of the repository, as the baseline requires: it reaches the
+runner as four repository secrets, set under *Settings > Secrets and variables >
+Actions*.
+
+| Secret | Contents |
+| --- | --- |
+| `ANDROID_KEYSTORE_BASE64` | The keystore file, base64-encoded (`base64 -w0 release.keystore`). PKCS#12 or JKS. |
+| `ANDROID_KEYSTORE_PASSWORD` | Password of that keystore. |
+| `ANDROID_KEY_ALIAS` | Alias of the signing key inside it. |
+| `ANDROID_KEY_PASSWORD` | Password of that key. For a PKCS#12 keystore this is the store password — the format keeps one password for both. |
+
+A bundle is signed with `jarsigner`, not `apksigner`: `apksigner` only speaks the
+APK signature schemes, which an `.aab` does not carry, and the JAR signature is
+what Play checks on upload. The keystore is decoded to a temporary file outside
+the workspace and deleted again when the script returns; the passwords reach
+`jarsigner` through its `-storepass:env` / `-keypass:env` forms, so they never
+appear in the process list.
+
+Signing is verified rather than assumed. Each bundle has to verify, carry a
+signature block, and — the part that catches a wrong key — present the same
+certificate the keystore holds under `ANDROID_KEY_ALIAS`. Note that
+`jarsigner -verify` exits 0 on an *unsigned* jar, reporting the verdict in its
+output only, so an exit code alone proves nothing. The certificate's SHA-256
+fingerprint is published in the package's `BUILD-INFO.txt` and in the draft
+release notes, so a download can be checked with
+`keytool -printcert -jarfile <bundle>`.
+
+A missing or wrong secret fails the job rather than falling back to an unsigned
+package, and the check runs before the build so it fails in seconds rather than
+after an hour. The same check runs locally against the four values in the
+environment, without building or signing anything:
+
+```powershell
+$env:ANDROID_KEYSTORE_BASE64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes('release.keystore'))
+$env:ANDROID_KEYSTORE_PASSWORD = '…'; $env:ANDROID_KEY_ALIAS = '…'; $env:ANDROID_KEY_PASSWORD = '…'
+./scripts/sign-android-app-bundles.ps1 -ValidateOnly
+```
+
+Play App Signing, release channels, and versioning are still open — see
+[the roadmap](../ROADMAP.md#a6--android-build-ci-and-delivery). What the pipeline
+signs with today is the key those secrets hold.
 
 ## Non-goals and support boundary
 

--- a/docs/architecture/android.md
+++ b/docs/architecture/android.md
@@ -26,7 +26,7 @@ layouts or Android widgets in application content.
 | Managed runtime | The workload's default Mono runtime with JIT |
 | AOT and trimming | Disabled. Browser uses an expression compiler based on `Reflection.Emit`, which is incompatible with full AOT. |
 | Packages | `org.broiler.writer` and `org.broiler.browser` |
-| Artifacts | Self-contained Debug APK; Release AAB |
+| Artifacts | Self-contained Debug APK; Release AAB for upload and arm64 Release APK for installation |
 | Signing | Debug signing is workload-managed. Release keys stay outside the repository — the delivery pipeline signs, reading the key from encrypted repository secrets. |
 | Network policy | Only Browser declares `INTERNET`; cleartext traffic is disabled for both applications. |
 
@@ -174,16 +174,33 @@ builds both heads with `dotnet publish -c Release` — the configuration name ha
 be exactly `Release`, since that is what switches `AndroidPackageFormat` to `aab` —
 and ships them as `BPP-Android.zip`. One publish leaves three packages side by
 side: the unsigned `<applicationId>.aab` plus a `-Signed.aab` and `-Signed.apk`
-carrying the workload's debug key. The workflow takes the unsigned bundle and
-fails if the file it picked turns out to be signed already, so a debug-signed
-artifact cannot pass itself off as a release. Each bundle carries `arm64-v8a` and
-`x86_64`, which is what the heads' `RuntimeIdentifiers` resolve to when the publish
-passes no `--runtime`.
+carrying the workload's debug key. The workflow takes the unsigned one and fails if
+the file it picked turns out to be signed already, so a debug-signed artifact
+cannot pass itself off as a release. Each bundle carries `arm64-v8a` and `x86_64`,
+which is what the heads' `RuntimeIdentifiers` resolve to when the publish passes no
+`--runtime`.
+
+A bundle is the upload format and cannot be installed, so each head is published a
+second time as a directly installable APK, with two properties overridden on the
+command line — where they are global properties and so beat the csproj:
+
+```
+dotnet publish <head> -c Release -p:AndroidPackageFormat=apk -p:RuntimeIdentifiers=android-arm64
+```
+
+`arm64-v8a` alone, because that is the ABI physical devices run and an APK carries
+one ABI where a bundle carries the split set. That publish needs no restore of its
+own: `android-arm64` is part of the `RuntimeIdentifiers` already restored, and
+restoring the narrower set would rewrite `project.assets.json` and break the bundle
+publish's `--no-restore`. The workflow checks that what it collected really is an
+APK — manifest at the archive root, no `BundleConfig.pb` — and that `lib/` holds
+`arm64-v8a` and nothing else, since a second ABI would mean the override did not
+take.
 
 ### Release signing
 
-The workflow signs the bundles it packages with the release key, through
-[`scripts/sign-android-app-bundles.ps1`](../../scripts/sign-android-app-bundles.ps1).
+The workflow signs every package it ships with the release key, through
+[`scripts/sign-android-packages.ps1`](../../scripts/sign-android-packages.ps1).
 The key stays out of the repository, as the baseline requires: it reaches the
 runner as four repository secrets, set under *Settings > Secrets and variables >
 Actions*.
@@ -195,21 +212,33 @@ Actions*.
 | `ANDROID_KEY_ALIAS` | Alias of the signing key inside it. |
 | `ANDROID_KEY_PASSWORD` | Password of that key. For a PKCS#12 keystore this is the store password — the format keeps one password for both. |
 
-A bundle is signed with `jarsigner`, not `apksigner`: `apksigner` only speaks the
-APK signature schemes, which an `.aab` does not carry, and the JAR signature is
-what Play checks on upload. The keystore is decoded to a temporary file outside
-the workspace and deleted again when the script returns; the passwords reach
-`jarsigner` through its `-storepass:env` / `-keypass:env` forms, so they never
+The two formats go through different tools, because they are checked by different
+things:
+
+* A bundle is signed with `jarsigner`. `apksigner` only speaks the APK signature
+  schemes, which an `.aab` does not carry, and the JAR signature is what Play
+  checks on upload.
+* An APK is zipaligned and signed with `apksigner`, which writes the v2/v3
+  signature blocks. An APK carrying only a JAR signature is refused at install
+  from Android 11 on, so `jarsigner` is not an option here. Alignment comes first:
+  `zipalign` moves entries within the archive, which would invalidate a signature
+  already over them. For `minSdkVersion` 24 `apksigner` signs v2+v3 and leaves v1
+  out, so `keytool -printcert -jarfile` cannot read these APKs — use
+  `apksigner verify --print-certs -v`.
+
+The keystore is decoded to a temporary file outside the workspace and deleted
+again when the script returns; the passwords reach both signers through their
+environment-variable forms (`-storepass:env`, `--ks-pass env:`), so they never
 appear in the process list.
 
-Signing is verified rather than assumed. Each bundle has to verify, carry a
-signature block, and — the part that catches a wrong key — present the same
-certificate the keystore holds under `ANDROID_KEY_ALIAS`. Note that
+Signing is verified rather than assumed. Each package has to verify and — the part
+that catches a wrong key — present the same certificate the keystore holds under
+`ANDROID_KEY_ALIAS`; verifying alone only says the package is signed by *some*
+key, which a debug key satisfies. Nor is an exit code enough on its own:
 `jarsigner -verify` exits 0 on an *unsigned* jar, reporting the verdict in its
-output only, so an exit code alone proves nothing. The certificate's SHA-256
-fingerprint is published in the package's `BUILD-INFO.txt` and in the draft
-release notes, so a download can be checked with
-`keytool -printcert -jarfile <bundle>`.
+output only. The certificate's SHA-256 fingerprint is published in the package's
+`BUILD-INFO.txt` and in the draft release notes, so a download can be checked
+against it.
 
 A missing or wrong secret fails the job rather than falling back to an unsigned
 package, and the check runs before the build so it fails in seconds rather than
@@ -219,7 +248,7 @@ environment, without building or signing anything:
 ```powershell
 $env:ANDROID_KEYSTORE_BASE64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes('release.keystore'))
 $env:ANDROID_KEYSTORE_PASSWORD = '…'; $env:ANDROID_KEY_ALIAS = '…'; $env:ANDROID_KEY_PASSWORD = '…'
-./scripts/sign-android-app-bundles.ps1 -ValidateOnly
+./scripts/sign-android-packages.ps1 -ValidateOnly
 ```
 
 Play App Signing, release channels, and versioning are still open — see

--- a/scripts/sign-android-app-bundles.ps1
+++ b/scripts/sign-android-app-bundles.ps1
@@ -1,0 +1,292 @@
+<#
+.SYNOPSIS
+    Signs Broiler's Android app bundles with the release key held in repository secrets.
+
+.DESCRIPTION
+    An .aab is signed with jarsigner, not apksigner: apksigner only speaks the APK signature
+    schemes, which a bundle does not carry, and the JAR signature produced here is what Play
+    checks on upload.
+
+    The key material never reaches a command line or the repository. The script reads four
+    environment variables, which .github/workflows/broiler-preview-package.yml maps from
+    repository secrets of the same names:
+
+        ANDROID_KEYSTORE_BASE64      the keystore file, base64-encoded (PKCS#12 or JKS)
+        ANDROID_KEYSTORE_PASSWORD    password of that keystore
+        ANDROID_KEY_ALIAS            alias of the signing key inside it
+        ANDROID_KEY_PASSWORD         password of that key
+
+    The keystore is decoded to a temporary file outside the workspace — so no packaging glob or
+    artifact upload can reach it — and deleted again before the script returns. The two passwords
+    are handed to jarsigner through its -storepass:env / -keypass:env forms, so they never appear
+    in the process list.
+
+    Signing is verified rather than assumed: jarsigner must report the bundle verified, the
+    signer certificate must be the one the keystore holds under ANDROID_KEY_ALIAS, and the bundle
+    must carry a signature block. `jarsigner -verify` exits 0 on an unsigned jar, so an exit code
+    alone proves nothing.
+
+    Returns the SHA-256 fingerprint of the signing certificate, for BUILD-INFO.txt and the release
+    notes to quote.
+
+.PARAMETER BundlePath
+    App bundles to sign in place.
+
+.PARAMETER ValidateOnly
+    Check the secrets, the toolchain, and the keystore without signing anything. The preview
+    package workflow runs this before the Android build so a missing or wrong secret fails in
+    seconds instead of after an hour of building.
+
+.EXAMPLE
+    ./scripts/sign-android-app-bundles.ps1 -ValidateOnly
+
+.EXAMPLE
+    ./scripts/sign-android-app-bundles.ps1 -BundlePath ./Broiler.Browser.aab, ./Broiler.Writer.aab
+#>
+[CmdletBinding(DefaultParameterSetName = 'Sign')]
+param(
+    [Parameter(Mandatory = $true, ParameterSetName = 'Sign', Position = 0)]
+    [ValidateNotNullOrEmpty()]
+    [string[]] $BundlePath,
+
+    [Parameter(Mandatory = $true, ParameterSetName = 'Validate')]
+    [switch] $ValidateOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+# keytool and jarsigner report through exit codes this script inspects itself; letting PowerShell
+# turn a non-zero exit into its own terminating error would replace every diagnostic below with
+# 'the command failed'.
+$PSNativeCommandUseErrorActionPreference = $false
+
+# keytool and jarsigner localize their output, and this script parses it. Pin them to English so a
+# runner's locale cannot turn 'jar verified.' into something the check does not recognize.
+$JdkLocaleArguments = @('-J-Duser.language=en', '-J-Duser.country=US')
+
+$RequiredSecrets = @(
+    'ANDROID_KEYSTORE_BASE64'
+    'ANDROID_KEYSTORE_PASSWORD'
+    'ANDROID_KEY_ALIAS'
+    'ANDROID_KEY_PASSWORD'
+)
+
+function Resolve-JdkTool {
+    param([Parameter(Mandatory = $true)][string] $Name)
+
+    # JAVA_HOME first: a CI runner carries several JDKs, and the one setup-java selected is the
+    # one whose keytool matches the jarsigner that does the signing.
+    if (-not [string]::IsNullOrWhiteSpace($env:JAVA_HOME)) {
+        foreach ($extension in @('', '.exe')) {
+            $candidate = Join-Path $env:JAVA_HOME "bin/$Name$extension"
+            if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+                return $candidate
+            }
+        }
+    }
+
+    $onPath = @(Get-Command -Name $Name -CommandType Application -ErrorAction SilentlyContinue)
+    if ($onPath.Count -gt 0) {
+        return $onPath[0].Source
+    }
+
+    throw "$Name was not found. Set JAVA_HOME to a JDK 21 installation, or put $Name on PATH."
+}
+
+function Invoke-JdkTool {
+    param(
+        [Parameter(Mandatory = $true)][string] $Executable,
+        [Parameter(Mandatory = $true)][string[]] $Arguments,
+        [string] $StandardInput
+    )
+
+    # Merged stderr arrives as error records; they are diagnostics to report, not failures in
+    # themselves, so they must not trip $ErrorActionPreference. The assignment is function-scoped.
+    $ErrorActionPreference = 'Continue'
+
+    $output = if ($PSBoundParameters.ContainsKey('StandardInput')) {
+        $StandardInput | & $Executable @Arguments 2>&1
+    }
+    else {
+        & $Executable @Arguments 2>&1
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $LASTEXITCODE
+        Output   = (@($output | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine)
+    }
+}
+
+function Get-CertificateFingerprint {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string] $ToolOutput)
+
+    # 'SHA256:' on current JDKs, 'SHA-256:' on older ones, always 32 colon-separated hex bytes.
+    $found = [regex]::Matches($ToolOutput, '(?im)^\s*SHA-?256:\s*((?:[0-9A-F]{2}:){31}[0-9A-F]{2})\s*$')
+    return @($found | ForEach-Object { $_.Groups[1].Value.ToUpperInvariant() })
+}
+
+function Assert-SignatureBlock {
+    param([Parameter(Mandatory = $true)][string] $Path)
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        $entries = @($archive.Entries | ForEach-Object { $_.FullName })
+    }
+    finally {
+        $archive.Dispose()
+    }
+
+    # A JAR signature is three entries: the manifest of digests, the .SF signature file over it,
+    # and the .RSA/.DSA/.EC block holding the signature and the signer certificate.
+    $missing = @()
+    if ($entries -notcontains 'META-INF/MANIFEST.MF') { $missing += 'META-INF/MANIFEST.MF' }
+    if (-not ($entries | Where-Object { $_ -match '^META-INF/[^/]+\.SF$' })) { $missing += 'META-INF/*.SF' }
+    if (-not ($entries | Where-Object { $_ -match '^META-INF/[^/]+\.(RSA|DSA|EC)$' })) { $missing += 'META-INF/*.RSA' }
+
+    if ($missing) {
+        throw "$Path carries no JAR signature after signing; missing $($missing -join ', ')."
+    }
+}
+
+$missingSecrets = @($RequiredSecrets | Where-Object {
+        [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_))
+    })
+if ($missingSecrets) {
+    $verb = if ($missingSecrets.Count -eq 1) { 'is' } else { 'are' }
+    throw @"
+Android release signing is not configured: $($missingSecrets -join ', ') $verb empty or unset.
+
+All four values are repository secrets, set under Settings > Secrets and variables > Actions:
+
+  ANDROID_KEYSTORE_BASE64      base64 of the release keystore ('base64 -w0 release.keystore')
+  ANDROID_KEYSTORE_PASSWORD    password of that keystore
+  ANDROID_KEY_ALIAS            alias of the signing key inside it
+  ANDROID_KEY_PASSWORD         password of that key
+
+A preview package with unsigned bundles is not a package this workflow ships, so this is a hard
+failure rather than a fallback.
+"@
+}
+
+$keytool = Resolve-JdkTool -Name 'keytool'
+$jarsigner = Resolve-JdkTool -Name 'jarsigner'
+
+$storePassword = [Environment]::GetEnvironmentVariable('ANDROID_KEYSTORE_PASSWORD')
+$keyAlias = [Environment]::GetEnvironmentVariable('ANDROID_KEY_ALIAS')
+
+# RUNNER_TEMP, never the workspace: nothing under the checkout may hold key material, where a
+# packaging glob or an artifact upload could pick it up.
+$temporaryRoot = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) { [System.IO.Path]::GetTempPath() } else { $env:RUNNER_TEMP }
+$signingDirectory = Join-Path $temporaryRoot ('broiler-android-signing-' + [Guid]::NewGuid().ToString('N'))
+$keystorePath = Join-Path $signingDirectory 'release.keystore'
+$fingerprint = $null
+
+try {
+    New-Item -ItemType Directory -Force -Path $signingDirectory | Out-Null
+
+    try {
+        # Whitespace-tolerant: a secret pasted from wrapped base64 output is still the keystore.
+        $keystoreBytes = [Convert]::FromBase64String(([Environment]::GetEnvironmentVariable('ANDROID_KEYSTORE_BASE64') -replace '\s', ''))
+    }
+    catch {
+        throw "ANDROID_KEYSTORE_BASE64 is not valid base64: $($_.Exception.Message)"
+    }
+
+    if ($keystoreBytes.Length -eq 0) {
+        throw 'ANDROID_KEYSTORE_BASE64 decodes to an empty file.'
+    }
+
+    [System.IO.File]::WriteAllBytes($keystorePath, $keystoreBytes)
+
+    # keytool has no :env password form of its own, and a password on a command line is readable
+    # by every process on the machine, so it goes in on stdin — which keytool falls back to when
+    # it is not attached to a console, as here.
+    $listing = Invoke-JdkTool -Executable $keytool -StandardInput $storePassword -Arguments (
+        $JdkLocaleArguments + @('-list', '-v', '-keystore', $keystorePath, '-alias', $keyAlias))
+    if ($listing.ExitCode -ne 0) {
+        throw @"
+keytool could not read alias '$keyAlias' from the keystore (exit code $($listing.ExitCode)).
+Check ANDROID_KEY_ALIAS against the keystore and ANDROID_KEYSTORE_PASSWORD against its password.
+
+$($listing.Output)
+"@
+    }
+
+    # @() around the call: PowerShell unrolls a single-element result on the way out of a function,
+    # and a lone string is not a collection to count or search.
+    $keystoreFingerprints = @(Get-CertificateFingerprint -ToolOutput $listing.Output)
+    if ($keystoreFingerprints.Count -eq 0) {
+        throw "keytool printed no SHA-256 certificate fingerprint for alias '$keyAlias':`n$($listing.Output)"
+    }
+
+    # The first is the leaf — the certificate that signs — with any CA certificates after it.
+    $fingerprint = $keystoreFingerprints[0]
+    Write-Host "==> signing key '$keyAlias', certificate SHA-256 $fingerprint"
+
+    if ($ValidateOnly) {
+        Write-Host '==> Android signing secrets validated; nothing signed.'
+    }
+    else {
+        foreach ($bundle in $BundlePath) {
+            if (-not (Test-Path -LiteralPath $bundle -PathType Leaf)) {
+                throw "App bundle not found: $bundle"
+            }
+
+            $resolved = (Resolve-Path -LiteralPath $bundle).ProviderPath
+
+            # jarsigner rewrites the archive in place. -sigalg is left to jarsigner so an EC key
+            # signs as readily as an RSA one; -digestalg is pinned because SHA-256 is the floor
+            # Play accepts.
+            $signing = Invoke-JdkTool -Executable $jarsigner -Arguments (
+                $JdkLocaleArguments + @(
+                    '-keystore', $keystorePath
+                    '-storepass:env', 'ANDROID_KEYSTORE_PASSWORD'
+                    '-keypass:env', 'ANDROID_KEY_PASSWORD'
+                    '-digestalg', 'SHA-256'
+                    $resolved
+                    $keyAlias
+                ))
+            if ($signing.ExitCode -ne 0) {
+                $hint = ''
+                if ($signing.Output -match 'not a private key|cannot recover key') {
+                    # PKCS#12 keeps one password for the store and its keys; keytool drops a
+                    # -keypass that differs from -storepass when it creates one, which surfaces
+                    # here as a key that cannot be unlocked.
+                    $hint = "`n`nIf the keystore is a PKCS#12 file, ANDROID_KEY_PASSWORD has to be the same value as ANDROID_KEYSTORE_PASSWORD."
+                }
+
+                throw "jarsigner failed on $resolved (exit code $($signing.ExitCode)).$hint`n`n$($signing.Output)"
+            }
+
+            # jarsigner reports an unsigned jar as 'jar is unsigned.' and still exits 0, so the
+            # verdict has to be read out of the output, not the exit code.
+            $verification = Invoke-JdkTool -Executable $jarsigner -Arguments (
+                $JdkLocaleArguments + @('-verify', '-keystore', $keystorePath, $resolved))
+            if ($verification.ExitCode -ne 0 -or $verification.Output -notmatch '(?m)^jar verified\.') {
+                throw "jarsigner did not verify $resolved after signing it (exit code $($verification.ExitCode)):`n`n$($verification.Output)"
+            }
+
+            Assert-SignatureBlock -Path $resolved
+
+            # Verified is not enough: it says the bundle is signed by *some* key. This says it is
+            # signed by ours, which is what a debug key slipping through would fail.
+            $signer = Invoke-JdkTool -Executable $keytool -Arguments (
+                $JdkLocaleArguments + @('-printcert', '-jarfile', $resolved))
+            $signerFingerprints = @(Get-CertificateFingerprint -ToolOutput $signer.Output)
+            if ($signerFingerprints -notcontains $fingerprint) {
+                $reported = if ($signerFingerprints.Count -gt 0) { $signerFingerprints -join ', ' } else { '(none)' }
+                throw "$resolved is not signed by '$keyAlias'. Expected certificate $fingerprint, found: $reported."
+            }
+
+            $megabytes = [Math]::Round((Get-Item -LiteralPath $resolved).Length / 1MB, 1)
+            Write-Host "==> signed and verified $(Split-Path -Leaf $resolved): $megabytes MB, signer $fingerprint"
+        }
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $signingDirectory) {
+        Remove-Item -LiteralPath $signingDirectory -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+return $fingerprint

--- a/scripts/sign-android-packages.ps1
+++ b/scripts/sign-android-packages.ps1
@@ -1,11 +1,15 @@
 <#
 .SYNOPSIS
-    Signs Broiler's Android app bundles with the release key held in repository secrets.
+    Signs Broiler's Android packages with the release key held in repository secrets.
 
 .DESCRIPTION
-    An .aab is signed with jarsigner, not apksigner: apksigner only speaks the APK signature
-    schemes, which a bundle does not carry, and the JAR signature produced here is what Play
-    checks on upload.
+    The two package formats are signed by different tools, because they are checked by different
+    things:
+
+    * An .aab is signed with jarsigner. apksigner only speaks the APK signature schemes, which a
+      bundle does not carry, and the JAR signature is what Play checks on upload.
+    * An .apk is zipaligned and signed with apksigner, which writes the v2/v3 signature blocks.
+      An APK carrying only a JAR signature is refused at install from Android 11 on.
 
     The key material never reaches a command line or the repository. The script reads four
     environment variables, which .github/workflows/broiler-preview-package.yml maps from
@@ -17,20 +21,25 @@
         ANDROID_KEY_PASSWORD         password of that key
 
     The keystore is decoded to a temporary file outside the workspace — so no packaging glob or
-    artifact upload can reach it — and deleted again before the script returns. The two passwords
-    are handed to jarsigner through its -storepass:env / -keypass:env forms, so they never appear
-    in the process list.
+    artifact upload can reach it — and deleted again before the script returns. The passwords are
+    handed to the signing tools through their env-variable forms (-storepass:env, --ks-pass env:),
+    so they never appear in the process list.
 
-    Signing is verified rather than assumed: jarsigner must report the bundle verified, the
-    signer certificate must be the one the keystore holds under ANDROID_KEY_ALIAS, and the bundle
-    must carry a signature block. `jarsigner -verify` exits 0 on an unsigned jar, so an exit code
-    alone proves nothing.
+    Signing is verified rather than assumed. Each package has to verify, and its signer
+    certificate has to be the one the keystore holds under ANDROID_KEY_ALIAS — verifying alone
+    only says the package is signed by *some* key, which a debug key satisfies. Neither tool's
+    exit code is sufficient on its own either: `jarsigner -verify` exits 0 on an unsigned jar and
+    reports the verdict only in its output.
 
     Returns the SHA-256 fingerprint of the signing certificate, for BUILD-INFO.txt and the release
     notes to quote.
 
 .PARAMETER BundlePath
-    App bundles to sign in place.
+    App bundles (.aab) to sign in place.
+
+.PARAMETER ApkPath
+    APKs to align and sign in place. Needs the Android SDK build-tools, located through
+    ANDROID_HOME or ANDROID_SDK_ROOT.
 
 .PARAMETER ValidateOnly
     Check the secrets, the toolchain, and the keystore without signing anything. The preview
@@ -38,16 +47,21 @@
     seconds instead of after an hour of building.
 
 .EXAMPLE
-    ./scripts/sign-android-app-bundles.ps1 -ValidateOnly
+    ./scripts/sign-android-packages.ps1 -ValidateOnly
 
 .EXAMPLE
-    ./scripts/sign-android-app-bundles.ps1 -BundlePath ./Broiler.Browser.aab, ./Broiler.Writer.aab
+    ./scripts/sign-android-packages.ps1 -BundlePath ./Broiler.Browser.aab, ./Broiler.Writer.aab
+
+.EXAMPLE
+    ./scripts/sign-android-packages.ps1 -ApkPath ./Broiler.Browser-arm64.apk
 #>
 [CmdletBinding(DefaultParameterSetName = 'Sign')]
 param(
-    [Parameter(Mandatory = $true, ParameterSetName = 'Sign', Position = 0)]
-    [ValidateNotNullOrEmpty()]
-    [string[]] $BundlePath,
+    [Parameter(ParameterSetName = 'Sign', Position = 0)]
+    [string[]] $BundlePath = @(),
+
+    [Parameter(ParameterSetName = 'Sign')]
+    [string[]] $ApkPath = @(),
 
     [Parameter(Mandatory = $true, ParameterSetName = 'Validate')]
     [switch] $ValidateOnly
@@ -93,7 +107,42 @@ function Resolve-JdkTool {
     throw "$Name was not found. Set JAVA_HOME to a JDK 21 installation, or put $Name on PATH."
 }
 
-function Invoke-JdkTool {
+function Resolve-BuildToolsTool {
+    param([Parameter(Mandatory = $true)][string] $Name)
+
+    $sdkRoot = if (-not [string]::IsNullOrWhiteSpace($env:ANDROID_HOME)) { $env:ANDROID_HOME } else { $env:ANDROID_SDK_ROOT }
+    if ([string]::IsNullOrWhiteSpace($sdkRoot)) {
+        throw "Signing an APK needs the Android SDK build-tools ($Name). Neither ANDROID_HOME nor ANDROID_SDK_ROOT is set."
+    }
+
+    $buildTools = Join-Path $sdkRoot 'build-tools'
+    if (-not (Test-Path -LiteralPath $buildTools -PathType Container)) {
+        throw "The Android SDK at $sdkRoot has no build-tools directory, so $Name is not available."
+    }
+
+    # Highest version wins, compared as versions rather than as text so 9.0.0 does not sort above
+    # 36.0.0. The workflow pins a build-tools version, but a runner image may carry others.
+    $candidates = @(Get-ChildItem -LiteralPath $buildTools -Directory -ErrorAction SilentlyContinue |
+        Sort-Object -Property @{ Expression = {
+                $parsed = [version]'0.0'
+                if ([version]::TryParse($_.Name, [ref] $parsed)) { $parsed } else { [version]'0.0' }
+            }
+        } -Descending)
+
+    foreach ($candidate in $candidates) {
+        foreach ($extension in @('', '.bat', '.exe')) {
+            $tool = Join-Path $candidate.FullName "$Name$extension"
+            if (Test-Path -LiteralPath $tool -PathType Leaf) {
+                return $tool
+            }
+        }
+    }
+
+    $versions = if ($candidates.Count -gt 0) { @($candidates | ForEach-Object { $_.Name }) -join ', ' } else { '(none)' }
+    throw "$Name was not found in any build-tools under $buildTools. Installed versions: $versions."
+}
+
+function Invoke-SigningTool {
     param(
         [Parameter(Mandatory = $true)][string] $Executable,
         [Parameter(Mandatory = $true)][string[]] $Arguments,
@@ -123,6 +172,21 @@ function Get-CertificateFingerprint {
     # 'SHA256:' on current JDKs, 'SHA-256:' on older ones, always 32 colon-separated hex bytes.
     $found = [regex]::Matches($ToolOutput, '(?im)^\s*SHA-?256:\s*((?:[0-9A-F]{2}:){31}[0-9A-F]{2})\s*$')
     return @($found | ForEach-Object { $_.Groups[1].Value.ToUpperInvariant() })
+}
+
+function Get-ApkSignerDigest {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string] $ToolOutput)
+
+    # apksigner writes the same 32 bytes keytool does, as unseparated lowercase hex:
+    # 'Signer #1 certificate SHA-256 digest: 674f25f7…'.
+    $found = [regex]::Matches($ToolOutput, '(?im)^Signer #\d+ certificate SHA-256 digest:\s*([0-9a-f]{64})\s*$')
+    return @($found | ForEach-Object { $_.Groups[1].Value.ToLowerInvariant() })
+}
+
+function ConvertTo-ComparableFingerprint {
+    param([Parameter(Mandatory = $true)][string] $Fingerprint)
+
+    return ($Fingerprint -replace '[^0-9A-Fa-f]', '').ToLowerInvariant()
 }
 
 function Assert-SignatureBlock {
@@ -163,13 +227,27 @@ All four values are repository secrets, set under Settings > Secrets and variabl
   ANDROID_KEY_ALIAS            alias of the signing key inside it
   ANDROID_KEY_PASSWORD         password of that key
 
-A preview package with unsigned bundles is not a package this workflow ships, so this is a hard
+A preview package with unsigned packages in it is not one this workflow ships, so this is a hard
 failure rather than a fallback.
 "@
 }
 
+if (-not $ValidateOnly -and $BundlePath.Count -eq 0 -and $ApkPath.Count -eq 0) {
+    throw 'Nothing to sign. Pass -BundlePath, -ApkPath, or both — or -ValidateOnly to just check the secrets.'
+}
+
 $keytool = Resolve-JdkTool -Name 'keytool'
 $jarsigner = Resolve-JdkTool -Name 'jarsigner'
+
+# Resolved only when there are APKs to sign: the build-tools are an Android SDK dependency, and a
+# bundles-only run — or the secrets check, which the workflow runs before it provisions the SDK —
+# has no business requiring one.
+$zipalign = $null
+$apksigner = $null
+if ($ApkPath.Count -gt 0) {
+    $zipalign = Resolve-BuildToolsTool -Name 'zipalign'
+    $apksigner = Resolve-BuildToolsTool -Name 'apksigner'
+}
 
 $storePassword = [Environment]::GetEnvironmentVariable('ANDROID_KEYSTORE_PASSWORD')
 $keyAlias = [Environment]::GetEnvironmentVariable('ANDROID_KEY_ALIAS')
@@ -201,7 +279,7 @@ try {
     # keytool has no :env password form of its own, and a password on a command line is readable
     # by every process on the machine, so it goes in on stdin — which keytool falls back to when
     # it is not attached to a console, as here.
-    $listing = Invoke-JdkTool -Executable $keytool -StandardInput $storePassword -Arguments (
+    $listing = Invoke-SigningTool -Executable $keytool -StandardInput $storePassword -Arguments (
         $JdkLocaleArguments + @('-list', '-v', '-keystore', $keystorePath, '-alias', $keyAlias))
     if ($listing.ExitCode -ne 0) {
         throw @"
@@ -237,7 +315,7 @@ $($listing.Output)
             # jarsigner rewrites the archive in place. -sigalg is left to jarsigner so an EC key
             # signs as readily as an RSA one; -digestalg is pinned because SHA-256 is the floor
             # Play accepts.
-            $signing = Invoke-JdkTool -Executable $jarsigner -Arguments (
+            $signing = Invoke-SigningTool -Executable $jarsigner -Arguments (
                 $JdkLocaleArguments + @(
                     '-keystore', $keystorePath
                     '-storepass:env', 'ANDROID_KEYSTORE_PASSWORD'
@@ -260,7 +338,7 @@ $($listing.Output)
 
             # jarsigner reports an unsigned jar as 'jar is unsigned.' and still exits 0, so the
             # verdict has to be read out of the output, not the exit code.
-            $verification = Invoke-JdkTool -Executable $jarsigner -Arguments (
+            $verification = Invoke-SigningTool -Executable $jarsigner -Arguments (
                 $JdkLocaleArguments + @('-verify', '-keystore', $keystorePath, $resolved))
             if ($verification.ExitCode -ne 0 -or $verification.Output -notmatch '(?m)^jar verified\.') {
                 throw "jarsigner did not verify $resolved after signing it (exit code $($verification.ExitCode)):`n`n$($verification.Output)"
@@ -270,7 +348,7 @@ $($listing.Output)
 
             # Verified is not enough: it says the bundle is signed by *some* key. This says it is
             # signed by ours, which is what a debug key slipping through would fail.
-            $signer = Invoke-JdkTool -Executable $keytool -Arguments (
+            $signer = Invoke-SigningTool -Executable $keytool -Arguments (
                 $JdkLocaleArguments + @('-printcert', '-jarfile', $resolved))
             $signerFingerprints = @(Get-CertificateFingerprint -ToolOutput $signer.Output)
             if ($signerFingerprints -notcontains $fingerprint) {
@@ -280,6 +358,74 @@ $($listing.Output)
 
             $megabytes = [Math]::Round((Get-Item -LiteralPath $resolved).Length / 1MB, 1)
             Write-Host "==> signed and verified $(Split-Path -Leaf $resolved): $megabytes MB, signer $fingerprint"
+        }
+
+        foreach ($apk in $ApkPath) {
+            if (-not (Test-Path -LiteralPath $apk -PathType Leaf)) {
+                throw "APK not found: $apk"
+            }
+
+            $resolved = (Resolve-Path -LiteralPath $apk).ProviderPath
+
+            # Align before signing, never after: zipalign moves entries within the archive, which
+            # would invalidate a signature already over them. -p page-aligns the uncompressed
+            # native libraries, which is what lets Android map them straight out of the APK.
+            $alignedPath = "$resolved.aligned"
+            $alignment = Invoke-SigningTool -Executable $zipalign -Arguments @('-p', '-f', '4', $resolved, $alignedPath)
+            if ($alignment.ExitCode -ne 0) {
+                throw "zipalign failed on $resolved (exit code $($alignment.ExitCode)):`n`n$($alignment.Output)"
+            }
+            Move-Item -LiteralPath $alignedPath -Destination $resolved -Force
+
+            # apksigner rather than jarsigner: it writes the v2/v3 signature blocks, and an APK
+            # carrying only a JAR signature is refused at install from Android 11 on. v4 is off
+            # because it writes a detached .idsig that only an incremental `adb install` reads —
+            # the package should hold packages and nothing else.
+            $signing = Invoke-SigningTool -Executable $apksigner -Arguments @(
+                'sign'
+                '--ks', $keystorePath
+                '--ks-pass', 'env:ANDROID_KEYSTORE_PASSWORD'
+                '--key-pass', 'env:ANDROID_KEY_PASSWORD'
+                '--ks-key-alias', $keyAlias
+                '--v4-signing-enabled', 'false'
+                $resolved
+            )
+            if ($signing.ExitCode -ne 0) {
+                $hint = ''
+                if ($signing.Output -match 'not a private key|cannot recover key|password was incorrect') {
+                    $hint = "`n`nIf the keystore is a PKCS#12 file, ANDROID_KEY_PASSWORD has to be the same value as ANDROID_KEYSTORE_PASSWORD."
+                }
+
+                throw "apksigner failed on $resolved (exit code $($signing.ExitCode)).$hint`n`n$($signing.Output)"
+            }
+
+            # Belt and braces: if a build-tools version ever ignores --v4-signing-enabled, the
+            # sidecar still does not reach the package.
+            Remove-Item -LiteralPath "$resolved.idsig" -Force -ErrorAction SilentlyContinue
+
+            # -v as well as --print-certs: without it apksigner prints the certificates but not the
+            # 'Verifies' verdict or the per-scheme lines, and this checks both.
+            $verification = Invoke-SigningTool -Executable $apksigner -Arguments @('verify', '--print-certs', '-v', $resolved)
+            if ($verification.ExitCode -ne 0 -or $verification.Output -notmatch '(?m)^Verifies') {
+                throw "apksigner did not verify $resolved after signing it (exit code $($verification.ExitCode)):`n`n$($verification.Output)"
+            }
+
+            # Same certificate check as the bundles, against apksigner's unseparated lowercase
+            # rendering of the same 32 bytes.
+            $signerDigests = @(Get-ApkSignerDigest -ToolOutput $verification.Output)
+            if ($signerDigests -notcontains (ConvertTo-ComparableFingerprint -Fingerprint $fingerprint)) {
+                $reported = if ($signerDigests.Count -gt 0) { $signerDigests -join ', ' } else { '(none)' }
+                throw "$resolved is not signed by '$keyAlias'. Expected certificate $fingerprint, found: $reported."
+            }
+
+            # Which schemes signed it is the point of using apksigner, so it goes in the log:
+            # v1 alone would install nowhere from Android 11 on.
+            $schemes = @(
+                [regex]::Matches($verification.Output, '(?im)^Verified using (v[0-9.]+) scheme[^:]*:\s*true\s*$') |
+                    ForEach-Object { $_.Groups[1].Value }
+            )
+            $megabytes = [Math]::Round((Get-Item -LiteralPath $resolved).Length / 1MB, 1)
+            Write-Host "==> signed and verified $(Split-Path -Leaf $resolved): $megabytes MB, $($schemes -join '+') signature, signer $fingerprint"
         }
     }
 }

--- a/scripts/write-bpp-build-info.ps1
+++ b/scripts/write-bpp-build-info.ps1
@@ -26,6 +26,11 @@
 .PARAMETER Configuration
     MSBuild configuration used (Release-Linux / Release-Windows / Release).
 
+.PARAMETER SigningCertificateSha256
+    SHA-256 fingerprint of the certificate the Android bundles are signed with, as
+    scripts/sign-android-app-bundles.ps1 reports it. Quoted in BUILD-INFO.txt so the package says
+    which key signed it. Android only.
+
 .EXAMPLE
     ./scripts/write-bpp-build-info.ps1 -PackageDirectory /tmp/packages/BPP-Linux-self-contained `
         -Platform linux -Variant self-contained -Branch main -Configuration Release-Linux
@@ -40,7 +45,8 @@ param(
     [Parameter(Mandatory = $true)][ValidateSet('linux', 'windows', 'android')][string] $Platform,
     [Parameter(Mandatory = $true)][ValidateSet('self-contained', 'framework-dependent', 'app-bundle')][string] $Variant,
     [string] $Branch = '(unknown)',
-    [string] $Configuration = '(unknown)'
+    [string] $Configuration = '(unknown)',
+    [string] $SigningCertificateSha256 = ''
 )
 
 Set-StrictMode -Version Latest
@@ -102,22 +108,41 @@ if ($isAndroid) {
         '  Both bundles carry the arm64-v8a and x86_64 ABIs, compile against API 36, and declare a'
         '  minimum of API 24.'
         ''
-        'These bundles are UNSIGNED'
-        '--------------------------'
+        'Signing'
+        '-------'
         ''
-        '  Release signing keys are kept outside the repository, so a preview build cannot produce'
-        '  a store-ready artifact. Sign a bundle with your own key before installing or uploading'
-        '  it.'
+        '  Both bundles are signed with the Broiler release key. The key itself is kept outside'
+        '  the repository — the build reads it from encrypted repository secrets — and the'
+        '  workflow verifies each signature against it before packaging.'
+        ''
+        '  Check a bundle before you install or upload it:'
+        ''
+        '    jarsigner -verify Broiler.Browser.aab'
+        '    keytool -printcert -jarfile Broiler.Browser.aab'
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($SigningCertificateSha256)) {
+        $lines += @(
+            ''
+            '  The signing certificate has this SHA-256 fingerprint:'
+            ''
+            "    $SigningCertificateSha256"
+        )
+    }
+
+    $lines += @(
         ''
         'Installing an .aab'
         '------------------'
         ''
-        '  An app bundle is not installable as it stands. Sign it, then use Google bundletool to'
-        '  build the APK set for a device and install it:'
+        '  An app bundle is not installable as it stands. Use Google bundletool to build the APK'
+        '  set for a device and install that:'
         ''
-        '    bundletool build-apks --bundle=Broiler.Browser.aab --output=Broiler.Browser.apks \'
-        '      --ks=<keystore> --ks-key-alias=<alias>'
+        '    bundletool build-apks --bundle=Broiler.Browser.aab --output=Broiler.Browser.apks'
         '    bundletool install-apks --apks=Broiler.Browser.apks'
+        ''
+        '  bundletool signs the APKs it generates with its own debug key unless --ks says'
+        '  otherwise; that is a local install detail and leaves the bundle signature untouched.'
         ''
         '  bundletool releases: https://github.com/google/bundletool/releases'
         ''

--- a/scripts/write-bpp-build-info.ps1
+++ b/scripts/write-bpp-build-info.ps1
@@ -18,7 +18,7 @@
 
 .PARAMETER Variant
     self-contained or framework-dependent for the desktop packages; app-bundle for Android,
-    which has no such split — an .aab always carries its own runtime.
+    which has no such split — an .aab and an .apk both carry their own runtime.
 
 .PARAMETER Branch
     Branch the package was built from.
@@ -27,8 +27,8 @@
     MSBuild configuration used (Release-Linux / Release-Windows / Release).
 
 .PARAMETER SigningCertificateSha256
-    SHA-256 fingerprint of the certificate the Android bundles are signed with, as
-    scripts/sign-android-app-bundles.ps1 reports it. Quoted in BUILD-INFO.txt so the package says
+    SHA-256 fingerprint of the certificate the Android packages are signed with, as
+    scripts/sign-android-packages.ps1 reports it. Quoted in BUILD-INFO.txt so the package says
     which key signed it. Android only.
 
 .EXAMPLE
@@ -72,7 +72,7 @@ $run = if ($env:GITHUB_RUN_NUMBER) { "GitHub Actions run #$env:GITHUB_RUN_NUMBER
 $runtimeNote = switch ($Variant) {
     'self-contained' { 'self-contained — the .NET runtime is included, nothing to install' }
     'framework-dependent' { 'framework-dependent — requires the ASP.NET Core 10 runtime on the target machine' }
-    'app-bundle' { 'app bundle — the .NET runtime ships inside the .aab, nothing to install' }
+    'app-bundle' { 'app bundle and APK — the .NET runtime ships inside the package, nothing to install' }
 }
 
 $rid = switch ($Platform) {
@@ -102,23 +102,31 @@ if ($isAndroid) {
         'Contents'
         '--------'
         ''
-        ('  {0,-24}{1}' -f 'Broiler.Browser.aab', 'The Broiler web browser — org.broiler.browser.')
-        ('  {0,-24}{1}' -f 'Broiler.Writer.aab', 'The Broiler word processor — org.broiler.writer.')
+        ('  {0,-30}{1}' -f 'Broiler.Browser.aab', 'The Broiler web browser — org.broiler.browser.')
+        ('  {0,-30}{1}' -f 'Broiler.Writer.aab', 'The Broiler word processor — org.broiler.writer.')
+        ('  {0,-30}{1}' -f 'Broiler.Browser-arm64.apk', 'The same browser, installable on an arm64 device.')
+        ('  {0,-30}{1}' -f 'Broiler.Writer-arm64.apk', 'The same word processor, installable on arm64.')
         ''
-        '  Both bundles carry the arm64-v8a and x86_64 ABIs, compile against API 36, and declare a'
+        '  The app bundles carry the arm64-v8a and x86_64 ABIs; the APKs carry arm64-v8a alone,'
+        '  which is what physical devices run. All four compile against API 36 and declare a'
         '  minimum of API 24.'
+        ''
+        '  Take the .apk to put a build on a device, and the .aab to upload one to Play. An app'
+        '  bundle is not installable as it stands — see below.'
         ''
         'Signing'
         '-------'
         ''
-        '  Both bundles are signed with the Broiler release key. The key itself is kept outside'
-        '  the repository — the build reads it from encrypted repository secrets — and the'
+        '  All four packages are signed with the Broiler release key. The key itself is kept'
+        '  outside the repository — the build reads it from encrypted repository secrets — and the'
         '  workflow verifies each signature against it before packaging.'
         ''
-        '  Check a bundle before you install or upload it:'
+        '  The two formats are signed by the tools that check them: the bundles carry a JAR'
+        '  signature from jarsigner, the APKs an APK Signature Scheme v2/v3 block from apksigner.'
+        '  Check a package before you install or upload it:'
         ''
         '    jarsigner -verify Broiler.Browser.aab'
-        '    keytool -printcert -jarfile Broiler.Browser.aab'
+        '    apksigner verify --print-certs -v Broiler.Browser-arm64.apk'
     )
 
     if (-not [string]::IsNullOrWhiteSpace($SigningCertificateSha256)) {
@@ -132,8 +140,15 @@ if ($isAndroid) {
 
     $lines += @(
         ''
-        'Installing an .aab'
-        '------------------'
+        'Installing'
+        '----------'
+        ''
+        '  On an arm64 device, install the APK directly:'
+        ''
+        '    adb install -r Broiler.Browser-arm64.apk'
+        ''
+        '  Sideloading from the device itself needs "install unknown apps" allowed for whichever'
+        '  app opens the file. An emulator or a device on another ABI needs the bundle instead.'
         ''
         '  An app bundle is not installable as it stands. Use Google bundletool to build the APK'
         '  set for a device and install that:'


### PR DESCRIPTION
Add release signing to the Android preview package workflow, reading the signing key from encrypted repository secrets and verifying each signature before packaging.

## Summary

The preview package workflow now signs all Android packages with the release key instead of shipping them unsigned. This keeps the A0 signing policy intact — the key stays outside the repository, encrypted in GitHub secrets — while ensuring preview builds are properly signed and verifiable.

## Key changes

- **New signing script** (`scripts/sign-android-packages.ps1`): Handles release signing for both `.aab` bundles and `.apk` files using the appropriate tools (`jarsigner` for bundles, `apksigner` for APKs). The script:
  - Reads four repository secrets: `ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`
  - Decodes the keystore to a temporary file outside the workspace (never committed or packaged)
  - Verifies each signature against the release certificate before returning the SHA-256 fingerprint
  - Supports a `-ValidateOnly` mode to check secrets and toolchain before the hour-long build

- **Installable APK artifacts**: Each head now publishes twice — the bundle for upload and an arm64-only APK for direct installation:
  - `Broiler.Browser-arm64.apk` and `Broiler.Writer-arm64.apk` alongside the `.aab` files
  - APKs carry `arm64-v8a` alone (what physical devices run) vs. bundles' `arm64-v8a` + `x86_64`
  - Zipaligned before signing to meet Android 11+ requirements

- **Workflow updates** (`broiler-preview-package.yml`):
  - Adds secrets validation step before the Android build (fails fast on missing/wrong secrets)
  - Publishes arm64 APKs with `AndroidPackageFormat=apk` and `RuntimeIdentifiers=android-arm64` overrides
  - Collects and verifies all four packages (two bundles, two APKs) before signing
  - Signs all packages and outputs the certificate fingerprint for `BUILD-INFO.txt` and release notes
  - Increased timeout from 120 to 150 minutes for the additional publishes

- **Documentation updates**:
  - `docs/architecture/android.md`: Documents the release signing process, secrets, and verification
  - `docs/ROADMAP.md`: Notes the signing and installable-artifact updates with dates
  - `scripts/write-bpp-build-info.ps1`: Updated to include APK descriptions and signing certificate info

## Implementation details

- **Two signing tools for two formats**: Bundles use `jarsigner` (what Play checks on upload); APKs use `apksigner` (required for v2/v3 signatures on Android 11+)
- **Verification is mandatory**: Each package must verify against the release certificate — a debug-signed package cannot pass itself off as a release
- **Secrets never reach the command line**: Passwords are passed through environment variables to the signing tools, keeping them off the process list
- **Temporary keystore cleanup**: The decoded keystore is deleted before the script returns, ensuring no key material reaches packaging globs or artifact uploads
- **Certificate fingerprint output**: The script returns the SHA-256 fingerprint for inclusion in release notes, allowing downloads to be verified

https://claude.ai/code/session_01JyZyCK1EwyCwiJpoP1WjTZ