### PR TITLE
Fix NETSDK1047 in the arm64 APK publish: override the ABI through the heads

### DIFF
--- a/.github/workflows/broiler-preview-package.yml
+++ b/.github/workflows/broiler-preview-package.yml
@@ -652,31 +652,33 @@ jobs:
       - name: Publish the arm64 Release APKs
         shell: pwsh
         run: |
-          # The same Release configuration as the bundles, with two properties overridden. They go
-          # on the command line, where they become global properties and so win over the csproj:
+          # The same Release configuration as the bundles, with two properties overridden:
           #
           #   AndroidPackageFormat  the heads switch to aab on '$(Configuration)' == 'Release', and
           #                         this package is the directly installable counterpart.
-          #   RuntimeIdentifiers    an APK carries one ABI where a bundle carries the split set;
+          #   BroilerAndroidAbis    an APK carries one ABI where a bundle carries the split set;
           #                         arm64-v8a is the ABI real devices run.
           #
-          # No restore of its own: android-arm64 is part of the RuntimeIdentifiers already restored
-          # above, so --no-restore is still honest. Restoring the narrower set here would rewrite
-          # project.assets.json and break the bundle publish's own --no-restore.
+          # The ABI override is BroilerAndroidAbis and not RuntimeIdentifiers itself, because a
+          # property on the command line is an MSBuild *global* property: it reaches every project
+          # in the graph, so RuntimeIdentifiers=android-arm64 also lands on the referenced net10.0
+          # libraries, which were restored without it and fail NETSDK1047 asking for a
+          # 'net10.0/android-arm64' target they have no reason to have. Only the two heads read
+          # BroilerAndroidAbis, so nothing below them changes and --no-restore stays honest.
           $publishRoot = Join-Path $env:RUNNER_TEMP 'android-publish'
 
           dotnet publish $env:BROWSER_PROJECT_PATH `
             --configuration $env:ANDROID_CONFIGURATION `
             --no-restore `
             -p:AndroidPackageFormat=apk `
-            -p:RuntimeIdentifiers=android-arm64 `
+            -p:BroilerAndroidAbis=android-arm64 `
             --output (Join-Path $publishRoot 'browser-arm64-apk')
 
           dotnet publish $env:WRITER_PROJECT_PATH `
             --configuration $env:ANDROID_CONFIGURATION `
             --no-restore `
             -p:AndroidPackageFormat=apk `
-            -p:RuntimeIdentifiers=android-arm64 `
+            -p:BroilerAndroidAbis=android-arm64 `
             --output (Join-Path $publishRoot 'writer-arm64-apk')
 
       - name: Collect and verify the Android packages

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -521,8 +521,8 @@ and the verification.
 head twice. A bundle is the upload format and cannot be installed, so beside the
 two `.aab`s the workflow publishes `Broiler.Browser-arm64.apk` and
 `Broiler.Writer-arm64.apk` — the same Release configuration with
-`AndroidPackageFormat=apk` and `RuntimeIdentifiers=android-arm64` overridden, so
-each APK carries the one ABI physical devices run. APKs are zipaligned and signed
+`AndroidPackageFormat=apk` and the heads' own `BroilerAndroidAbis=android-arm64`
+overridden, so each APK carries the one ABI physical devices run. APKs are zipaligned and signed
 with `apksigner` rather than `jarsigner`: from Android 11 an APK with only a JAR
 signature is refused at install. So a preview build can now be put on a device with
 `adb install` and nothing else. A per-change Android build, the emulator smoke run,

--- a/docs/architecture/android.md
+++ b/docs/architecture/android.md
@@ -22,7 +22,7 @@ layouts or Android widgets in application content.
 | --- | --- |
 | Target framework / compile API | `net10.0-android36.0` / API 36 |
 | Minimum API | API 24 (`SupportedOSPlatformVersion=24`) |
-| Shipped ABIs | `android-arm64`; `android-x64` is retained for emulator CI |
+| Shipped ABIs | `android-arm64`; `android-x64` is retained for emulator CI. `BroilerAndroidAbis` overrides the pair per publish — the preview package's APK uses it to build `arm64-v8a` alone. |
 | Managed runtime | The workload's default Mono runtime with JIT |
 | AOT and trimming | Disabled. Browser uses an expression compiler based on `Reflection.Emit`, which is incompatible with full AOT. |
 | Packages | `org.broiler.writer` and `org.broiler.browser` |
@@ -181,21 +181,28 @@ which is what the heads' `RuntimeIdentifiers` resolve to when the publish passes
 `--runtime`.
 
 A bundle is the upload format and cannot be installed, so each head is published a
-second time as a directly installable APK, with two properties overridden on the
-command line — where they are global properties and so beat the csproj:
+second time as a directly installable APK:
 
 ```
-dotnet publish <head> -c Release -p:AndroidPackageFormat=apk -p:RuntimeIdentifiers=android-arm64
+dotnet publish <head> -c Release -p:AndroidPackageFormat=apk -p:BroilerAndroidAbis=android-arm64
 ```
 
 `arm64-v8a` alone, because that is the ABI physical devices run and an APK carries
-one ABI where a bundle carries the split set. That publish needs no restore of its
-own: `android-arm64` is part of the `RuntimeIdentifiers` already restored, and
-restoring the narrower set would rewrite `project.assets.json` and break the bundle
-publish's `--no-restore`. The workflow checks that what it collected really is an
-APK — manifest at the archive root, no `BundleConfig.pb` — and that `lib/` holds
-`arm64-v8a` and nothing else, since a second ABI would mean the override did not
-take.
+one ABI where a bundle carries the split set.
+
+The ABI override goes through `BroilerAndroidAbis`, which each head expands into
+its own `RuntimeIdentifiers`, rather than passing `RuntimeIdentifiers` on the
+command line directly. **A property on the command line is an MSBuild global
+property: it reaches every project in the graph.** `RuntimeIdentifiers=android-arm64`
+therefore also lands on the referenced `net10.0` libraries — `Broiler.Browser.Core`,
+`Broiler.CSS`, `Broiler.Dom` and the rest — which were restored without it and fail
+with `NETSDK1047`, asking for a `net10.0/android-arm64` target they have no reason
+to have. Only the two heads read `BroilerAndroidAbis`, so nothing below them
+changes and both publishes keep `--no-restore`.
+
+The workflow checks that what it collected really is an APK — manifest at the
+archive root, no `BundleConfig.pb` — and that `lib/` holds `arm64-v8a` and nothing
+else, since a second ABI would mean the override did not take.
 
 ### Release signing
 

--- a/src/Broiler.Browser.Android/Broiler.Browser.Android.csproj
+++ b/src/Broiler.Browser.Android/Broiler.Browser.Android.csproj
@@ -13,7 +13,14 @@
     <ApplicationTitle>Broiler Browser</ApplicationTitle>
     <ApplicationVersion>1</ApplicationVersion>
     <ApplicationDisplayVersion>0.1.0</ApplicationDisplayVersion>
-    <RuntimeIdentifiers>android-arm64;android-x64</RuntimeIdentifiers>
+    <!-- The ABI set, overridable for a single-ABI package (the preview package's arm64 APK).
+         It goes through a Broiler-owned property rather than passing RuntimeIdentifiers itself on
+         the command line: that would be an MSBuild global property, so it would reach every
+         referenced net10.0 library too, and a library restored without it fails NETSDK1047 asking
+         for a 'net10.0/android-arm64' target it has no reason to have. Only this head reads
+         BroilerAndroidAbis, so the override lands where it means something. -->
+    <BroilerAndroidAbis Condition="'$(BroilerAndroidAbis)' == ''">android-arm64;android-x64</BroilerAndroidAbis>
+    <RuntimeIdentifiers>$(BroilerAndroidAbis)</RuntimeIdentifiers>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
     <RunAOTCompilation>false</RunAOTCompilation>
     <PublishTrimmed>false</PublishTrimmed>

--- a/src/Broiler.Writer.Android/Broiler.Writer.Android.csproj
+++ b/src/Broiler.Writer.Android/Broiler.Writer.Android.csproj
@@ -13,7 +13,14 @@
     <ApplicationTitle>Broiler Writer</ApplicationTitle>
     <ApplicationVersion>1</ApplicationVersion>
     <ApplicationDisplayVersion>0.1.0</ApplicationDisplayVersion>
-    <RuntimeIdentifiers>android-arm64;android-x64</RuntimeIdentifiers>
+    <!-- The ABI set, overridable for a single-ABI package (the preview package's arm64 APK).
+         It goes through a Broiler-owned property rather than passing RuntimeIdentifiers itself on
+         the command line: that would be an MSBuild global property, so it would reach every
+         referenced net10.0 library too, and a library restored without it fails NETSDK1047 asking
+         for a 'net10.0/android-arm64' target it has no reason to have. Only this head reads
+         BroilerAndroidAbis, so the override lands where it means something. -->
+    <BroilerAndroidAbis Condition="'$(BroilerAndroidAbis)' == ''">android-arm64;android-x64</BroilerAndroidAbis>
+    <RuntimeIdentifiers>$(BroilerAndroidAbis)</RuntimeIdentifiers>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
     <RunAOTCompilation>false</RunAOTCompilation>
     <PublishTrimmed>false</PublishTrimmed>


### PR DESCRIPTION
Fixes the Android preview-package job, which failed on every Broiler component after #1518:

```
error NETSDK1047: Assets file '.../src/Broiler.Browser.Core/obj/project.assets.json'
doesn't have a target for 'net10.0/android-arm64'.
```

## Cause

A property on the `dotnet publish` command line is an MSBuild **global** property, so it reaches every project in the graph — not just the head being published. The arm64 APK publish passed `-p:RuntimeIdentifiers=android-arm64`, which therefore also landed on the referenced `net10.0` libraries (`Broiler.Browser.Core`, `Broiler.CSS`, `Broiler.Dom`, and the rest). Those were restored without it, and a library with a single-RID `RuntimeIdentifiers` resolves a RID-specific assets target it has no reason to have.

The commit that added the APK publish asserted the opposite in a comment — that `android-arm64` was already covered by the restore, so `--no-restore` held. That is true for the head; the libraries never had RID-specific targets at all. After the workflow's restore, `Broiler.Browser.Core`'s assets file carries exactly one target, `net10.0`.

## Fix

Each Android head expands its own `BroilerAndroidAbis` into `RuntimeIdentifiers`, defaulting to the existing `android-arm64;android-x64`, and the APK publish overrides that instead:

```
dotnet publish <head> -c Release -p:AndroidPackageFormat=apk -p:BroilerAndroidAbis=android-arm64
```

Only the two heads read `BroilerAndroidAbis`, so nothing below them changes, `--no-restore` stays valid for all four publishes, and no assets file is rewritten mid-job.

Restoring for the narrower set instead would also have worked, but it would restore plain `net10.0` libraries "for android-arm64" — meaningless for them — and would leave the bundle publish silently depending on running first.

## Verification

Run against the real toolchain (android workload 36.1.69, SDK 36, build-tools 36.0.0) rather than reasoned about:

- The failure reproduces on the merged workflow and disappears with this change.
- Both heads publish. Bundles still carry `arm64-v8a` and `x86_64`; APKs carry `arm64-v8a` alone (`aapt2 dump badging` reports `native-code: 'arm64-v8a'`) and are half the size of the bundles (21 MB vs 41 MB).
- The publish output really is named `<applicationId>.apk` beside a debug-signed `-Signed.apk`, which is what the collect step assumes — the other assumption in #1518 that had never actually been run.
- The workflow's collect, sign and package steps, extracted from the YAML and run over those real artifacts, produce a `BPP-Android.zip` whose APKs verify v2+v3 under the release key and are 16 KB-page aligned, and whose bundles verify under `jarsigner`.

## Files

- `src/Broiler.Browser.Android/*.csproj`, `src/Broiler.Writer.Android/*.csproj` — the `BroilerAndroidAbis` indirection, with a comment on why the override cannot be `RuntimeIdentifiers` itself.
- `.github/workflows/broiler-preview-package.yml` — the APK publish uses the new property; the comment now states the actual mechanism.
- `docs/architecture/android.md`, `docs/ROADMAP.md` — corrected; both carried the wrong `--no-restore` reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyZyCK1EwyCwiJpoP1WjTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyZyCK1EwyCwiJpoP1WjTZ)_