### PR TITLE
Phase 5 regex optimizations: streaming global replace and single-match allocation

### DIFF
--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -73,7 +73,7 @@ the item's own section below, and nothing here is *closed* — see the acceptanc
 |---|---|
 | **0** — evidence | 0-1…0-5 ✅, 0-9…0-11 ✅. **0-6 (the CI Octane run) is still the critical path, but its headline question is answered**: run at the pinned pointer on linux-x64, Octane is **15 of 15 suites `ok` and 17 of 17 scores** — Mandreel included, which the previous local pass had failing. Geomean 217, spread **113×** against a same-machine Chromium reference. What 0-6 still owes is the *workflow* run plus 0-7's BenchmarkDotNet and 0-8's RID matrix, which a container cannot produce |
 | **1** — compile-time | 1-2's mitigation ✅ (`43bc4230`); **1-2's real fix is now on all three recursing passes** — the validator and emitter (`StackGuard` had three defects and could not fire), and now `FastParser`, whose descent aborted the process at 25 000 nesting levels **in the default configuration** and now survives 90 000 at no measurable cost. 1-1 open. 1-2's stated acceptance criterion **already passed before any work** — it measured size where the cause was nesting |
-| **2** — property access | **Every item landed or closed.** 2-0 ✅ 2-1 ✅ 2-2 ✅ 2-4 ✅ 2-7 ✅ 2-8 ✅ **2-9 ✅**; **2-3 and 2-5 closed on measurements**; 2-6 folded into 4-1. The phase's conformance gate is **satisfied**, and **its Octane exit criterion is now answered and splits: Richards is inside 200× at 183× (band 163–191) and DeltaBlue is not, at 576× (band 538–711)** — five repetitions per engine, same machine. **DeltaBlue is what phase 2 has left**, and it is the suite 2-8 was written for. Also outstanding: **2-9's ~20% compile-and-first-run cost still wants a follow-up — but not the one that was written.** Its losing-side hypothesis was measured against the control it never had (a *strict* function, which carries no Annex B deferred cells) and is **wrong**: every function materializes its trie **exactly once** whether strict or not, because the `prototype` install is withheld from shape-only storage by 2-8's DeltaBlue fix. "Stop materializing for a deferred cell" would have removed a materialization that already happened. The replacement candidate — split cache-visibility from shape-only storage — is specified and **not attempted**, since it is the code whose last regression broke DeltaBlue and it needs 0-6 |
+| **2** — property access | **Every item landed or closed.** 2-0 ✅ 2-1 ✅ 2-2 ✅ 2-4 ✅ 2-7 ✅ 2-8 ✅ **2-9 ✅**; **2-3 and 2-5 closed on measurements**; 2-6 folded into 4-1. The phase's conformance gate is **satisfied**, and **its Octane exit criterion is now answered and splits: Richards is inside 200× at 183× (band 163–191) and DeltaBlue is not, at 576× (band 538–711)** — five repetitions per engine, same machine. **DeltaBlue is what phase 2 has left** (item **2-10**), and it is the suite 2-8 was written for. Its first pass found and fixed a real defect — `push` cost every array its shape permanently, **2 503 dictionary fallbacks → 0** — but that did **not** move DeltaBlue's read hit rate, which stays at **65.96% against Richards's 86.61%** and is the live lead Also outstanding: **2-9's ~20% compile-and-first-run cost still wants a follow-up — but not the one that was written.** Its losing-side hypothesis was measured against the control it never had (a *strict* function, which carries no Annex B deferred cells) and is **wrong**: every function materializes its trie **exactly once** whether strict or not, because the `prototype` install is withheld from shape-only storage by 2-8's DeltaBlue fix. "Stop materializing for a deferred cell" would have removed a materialization that already happened. The replacement candidate — split cache-visibility from shape-only storage — is specified and **not attempted**, since it is the code whose last regression broke DeltaBlue and it needs 0-6 |
 | **3** — arithmetic | Started. **3-0 landed, both halves** — an indexed access boxed its index; a read now allocates **nothing at all** and a write loses ~32 B, on reference arrays as much as numeric ones. **3-1 measured before starting and re-specified**: it trades write allocation for read allocation 1:1, so its clean half is live memory. **3-3's parameter half landed** — and the measurement re-specified it: the gap was a per-call `JSVariable` **cell**, not a box, so a three-parameter call went **230.2 → 62.2 B**. **Probing that analysis before extending it found a wrong-answer bug shipped since P2-2** — two writes it could not see, one returning NaN and one aborting the process on valid JavaScript; fixed, at no measurable cost. Its `let`/`const` half was then **built, measured (31.98 → 0.00 B/iter) and withdrawn**: it miscompiles after any earlier compilation in the same process, including for bindings the gate never admits, so the reproduction is recorded instead of the change. 3-4 is a cost, not a task |
 | **4** — tiering | Open. **4-3's design is written** — and it re-specifies the item: this engine has no interpreter frame to reconstruct, so V8-style deopt has no counterpart here. Splits into 4-3a (state and enforce the restart contract the pilot already runs, S) and 4-3b (a generic fallback branch inside the specialized method, M–L), which gates 4-4 rather than all of phase 4. **4-1 can start now** |
 | **5** — regex | **Gate satisfied, and it overturns the phase.** `Matcher.cs` is not the default engine — `JSRegExp` routes only semantic-gap patterns to it, and Octane's corpus has no look-behind and no `u` flag, so it barely runs. The engine that does serve them is `System.Text.RegularExpressions` built **interpreted**; `RegexOptions.Compiled` is worth ~2× on six of seven real Octane patterns and a stable **4.3× against** on the seventh — a *trim* — so a use-count policy is ruled out. Largest regex cost measured was neither: `replace` with a global flag allocated **42 859 B per match**, because an Annex B legacy static copied the subject on every successful match — **fixed, 0.048x the bytes and 0.30x the time**. Decomposing what was left **per call** then found a single-match `replace` paying two full UTF-16 copies of the subject through a `StringBuilder`; concatenating three spans instead is **4.020 → 2.020 B per subject character, exactly the predicted halving**, and **the identical defect in `String.prototype.replace`'s string-`searchValue` builtin was found by reading the neighbouring code and fixed with it**. The global case's retained result list then landed too — **2 032.8 → 478.3 B per match**, dead linear on both sides, by streaming when the receiver's `exec` is the pristine intrinsic and the replacement is a `$`-free string. **Every follow-up this phase named is now closed**; what is left is item 2's `Compiled` policy, deliberately unshipped |
@@ -554,6 +554,16 @@ These were paid for once each. They apply to every phase below.
   — 4.020 B/char both — which is what established them as one defect in two places rather than
   two resembling ones. *When a profile localizes a cost to a mechanism, grep for the mechanism;
   the corpus only measures what somebody thought to add to it.*
+- **A counter that separates two workloads is a lead, not an explanation.** DeltaBlue fails
+  phase 2's gate and Richards passes it, and of every inline-cache counter the sharpest split was
+  dictionary fallbacks: **2 503 against 1**, three orders of magnitude. It traced to a real
+  defect — `push` cost every array its shape permanently — and fixing it took DeltaBlue to **0**.
+  **DeltaBlue's read hit rate then did not move by a hundredth of a percent.** The suite was
+  losing shapes it never read through, because it puts no named properties on its arrays. The fix
+  is worth keeping on its own merits and the investigation still has to start over. *Rank a
+  counter by how well it explains the metric you care about, not by how sharply it separates the
+  cases — and confirm the link by moving it, because "biggest difference" and "cause" are
+  different claims and only one of them is testable cheaply.*
 - **An exit criterion that has never been run is not a pending task, it is an unknown answer.**
   Phase 2's was *"DeltaBlue and Richards inside 200×"*, owed since the phase opened and carried
   through every item as one line of the sequencing table. Run at last, it **splits**: Richards is
@@ -2359,6 +2369,100 @@ curve whose median is ~180×, and this phase is the reason they are.
 > it worse silently.
 
 ---
+### 2-10 · DeltaBlue's dictionary fallbacks — **found, fixed, and it is not the explanation**
+
+> **Delivered as a patch, not in the pin**, for the same 403 as the rest:
+> [`patches/0062`](../patches/0062-js-array-length-keeps-shape.patch). It applies cleanly on its
+> own but **will not compile without [`patches/0061`](../patches/0061-js-measure-2-9-materialization-cause.patch)**,
+> whose counter the new emitter reads — a textual apply-check is not enough, build after applying.
+
+Phase 2's exit criterion split (Richards 183× passes, DeltaBlue 576× fails), and every phase 2
+item was sized on a probe rather than on the suite. §3.5 already records what that costs: 2-8 was
+justified by DeltaBlue's score, measured with a loop *shaped like* DeltaBlue, and broke DeltaBlue
+outright. So the first move was to run the suite itself.
+
+**`--suite-cache-metrics` (new; `SuiteCacheMetrics`) runs the real Octane suites of §0's phase 2
+cluster under the inline-cache counters.** Richards is the control — same phase, same items, and
+it *passes* — so a counter that separates the two is a lead:
+
+| | Richards (183×, passes) | **DeltaBlue (576×, fails)** | Box2D (144×) |
+|---|--:|--:|--:|
+| read cache hit rate | 86.61% | **65.96%** | 96.39% |
+| store cache hit rate | 99.74% | 80.65% | 92.57% |
+| **dictionary fallbacks** | **1** | **2 503** | 9 |
+| prototype invalidations | 37 | 2 519 | 1 944 |
+| materializations | 82 | 2 638 | 70 264 |
+
+**Three orders of magnitude on one counter.** A dictionary fallback is permanent — the object
+drops its shape and no inline cache can reach its named properties again — so 2 503 of them is
+not a tuning difference.
+
+**Traced, and the cause is `push`.** 2 507 of DeltaBlue's 2 512 array fallbacks come from
+`JSArray.SetLengthWritable`, which reaches the property store through `GetOwnProperties()`, and
+that hands out a mutable trie ref by *abandoning the shape*. Isolated one operation at a time on
+a fresh process, counting fallbacks against an empty-script baseline:
+
+| Operation | Fallbacks (before) | (after) |
+|---|--:|--:|
+| `a[i] = i`, array literal, `new Array(n)`, `a.slice()` | 0 | 0 |
+| **`a.push(i)`** | **1** | **0** |
+| **`a.pop()`** | **1** | **0** |
+| **`a.concat([3])`** | **1** | **0** |
+| `a.length = 2` | 1 | 0 |
+| `Object.defineProperty(a,'length',{writable:false})` | 1 | **1** |
+| `Object.freeze(a)` | 1 | **1** |
+
+One per array, not one per call — the first drops the shape and the rest find it already gone.
+**`push` is the most common array operation in the language**, and DeltaBlue's
+`OrderedCollection.add` is `this.elms.push(elm)`.
+
+**The fix is that a writable `length` needs no descriptor at all.** `IsLengthReadOnly` reads an
+*absent* entry as writable — the default — and the stored value is never read back, because
+`GetOwnPropertyDescriptor` builds it from `_length`. So the entry was pure write-only
+bookkeeping, and writing it cost the array its shape. `SetLengthWritable` now writes only when
+the length is non-writable or an entry already exists; the last two rows above show `freeze` and
+an explicit non-writable `length` still recording one, which is what keeps `IsLengthReadOnly`
+answerable.
+
+**It also closes a hole in this class's own stated invariant.** `JSArray.SupportsShapeTracking`
+documents that it is *"earned by not writing any named property of its own with a bare
+`ownProperties.Put`"* — and `length` was the one place that did.
+
+**What it is worth, stated honestly: the defect is real and the metric it was found by did not
+move.**
+
+- **Dictionary fallbacks: DeltaBlue 2 503 → 0**, Box2D 9 → 4, Richards 1 → 0.
+- **A named property on an array that grows now keeps hitting its cache.**
+  `GrowingAnArrayThroughABuiltInKeepsItsNamedShape` — which until now asserted the opposite, and
+  whose own comment called the fallback *"the part worth pinning, because it bounds what item 2-2
+  buys"* — now pins ≥499 hits across 500 reads after five pushes. That bound is gone.
+- **DeltaBlue's read hit rate did not change by a single hundredth: 65.96% before, 65.96%
+  after.** Nor did its prototype invalidations or materializations.
+
+- **And the score does not move either.** Re-run at five repetitions per engine, the same way the
+  gate was measured: **DeltaBlue 116 → 122 broiler-side, 576× → 581×**, against its own 16.4%
+  band — noise, in both directions. Richards is 183× → 179×. Recorded because §3.5's rule from
+  2-8 is that a change justified by a benchmark has to be *run* against that benchmark, and this
+  one was: it neither helps nor harms it.
+
+**So this is not the explanation for 576×.** DeltaBlue does not put named properties on its
+arrays, so the shapes it was losing were shapes it never read through. The counter that separated
+the two suites most sharply turned out to separate them for a reason unrelated to the gap being
+investigated — which is worth stating plainly, because the fix looked like the answer right up
+until it was measured.
+
+**Verify.** Repository suite **7 563 tests across 13 projects, 0 failures**. **test262 unchanged
+across all four pinned manifests — 8 313 executed, 8 220 passed, 84 failed, 44 skipped, 9 timed
+out, identical manifest by manifest**, `test262-arrays` among them, which is the manifest that
+covers this change most directly. Octane still runs 15 of 15 suites `ok`.
+
+**The live lead is the read hit rate itself: 65.96% against Richards's 86.61%**, one in three
+reads missing on a suite whose whole shape is polymorphic constraint objects. That is where 2-10's
+successor should start, and it should start by decomposing *which sites* miss rather than by
+assuming, which is the mistake this item just made and caught.
+
+---
+
 
 ## Phase 3 — value representation
 

--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -73,7 +73,7 @@ the item's own section below, and nothing here is *closed* — see the acceptanc
 |---|---|
 | **0** — evidence | 0-1…0-5 ✅, 0-9…0-11 ✅. **0-6 (the CI Octane run) is still the critical path, but its headline question is answered**: run at the pinned pointer on linux-x64, Octane is **15 of 15 suites `ok` and 17 of 17 scores** — Mandreel included, which the previous local pass had failing. Geomean 217, spread **113×** against a same-machine Chromium reference. What 0-6 still owes is the *workflow* run plus 0-7's BenchmarkDotNet and 0-8's RID matrix, which a container cannot produce |
 | **1** — compile-time | 1-2's mitigation ✅ (`43bc4230`); **1-2's real fix is now on all three recursing passes** — the validator and emitter (`StackGuard` had three defects and could not fire), and now `FastParser`, whose descent aborted the process at 25 000 nesting levels **in the default configuration** and now survives 90 000 at no measurable cost. 1-1 open. 1-2's stated acceptance criterion **already passed before any work** — it measured size where the cause was nesting |
-| **2** — property access | **Every item landed or closed.** 2-0 ✅ 2-1 ✅ 2-2 ✅ 2-4 ✅ 2-7 ✅ 2-8 ✅ **2-9 ✅**; **2-3 and 2-5 closed on measurements**; 2-6 folded into 4-1. The phase's conformance gate is **satisfied**, and **its Octane exit criterion is now answered and splits: Richards is inside 200× at 183× (band 163–191) and DeltaBlue is not, at 576× (band 538–711)** — five repetitions per engine, same machine. **DeltaBlue is what phase 2 has left** (item **2-10**), and it is the suite 2-8 was written for. Its first pass found and fixed a real defect — `push` cost every array its shape permanently, **2 503 dictionary fallbacks → 0** — but that did **not** move DeltaBlue's read hit rate, which stays at **65.96% against Richards's 86.61%** and is the live lead Also outstanding: **2-9's ~20% compile-and-first-run cost still wants a follow-up — but not the one that was written.** Its losing-side hypothesis was measured against the control it never had (a *strict* function, which carries no Annex B deferred cells) and is **wrong**: every function materializes its trie **exactly once** whether strict or not, because the `prototype` install is withheld from shape-only storage by 2-8's DeltaBlue fix. "Stop materializing for a deferred cell" would have removed a materialization that already happened. The replacement candidate — split cache-visibility from shape-only storage — is specified and **not attempted**, since it is the code whose last regression broke DeltaBlue and it needs 0-6 |
+| **2** — property access | **Every item landed or closed.** 2-0 ✅ 2-1 ✅ 2-2 ✅ 2-4 ✅ 2-7 ✅ 2-8 ✅ **2-9 ✅**; **2-3 and 2-5 closed on measurements**; 2-6 folded into 4-1. The phase's conformance gate is **satisfied**, and **its Octane exit criterion is now answered and splits: Richards is inside 200× at 183× (band 163–191) and DeltaBlue is not, at 576× (band 538–711)** — five repetitions per engine, same machine. **DeltaBlue is what phase 2 has left** (item **2-10**), and it is the suite 2-8 was written for. Its first pass found and fixed a real defect — `push` cost every array its shape permanently, **2 503 dictionary fallbacks → 0** — but that did **not** move DeltaBlue's read hit rate, which stays at **65.96% against Richards's 86.61%** and is the live lead. Decomposing those misses ruled out megamorphism (**0** megamorphic read sites) and, in passing, **found a live `class`-shaped instance of 2-0's defect**: `class C{}; new C()` publishes a global prototype invalidation **once per allocation** (2 002 for 2 000) where a `function` constructor publishes 1. Real, dead-linear, and **not** DeltaBlue's cause — Octane's DeltaBlue is ES5. Not fixed here Also outstanding: **2-9's ~20% compile-and-first-run cost still wants a follow-up — but not the one that was written.** Its losing-side hypothesis was measured against the control it never had (a *strict* function, which carries no Annex B deferred cells) and is **wrong**: every function materializes its trie **exactly once** whether strict or not, because the `prototype` install is withheld from shape-only storage by 2-8's DeltaBlue fix. "Stop materializing for a deferred cell" would have removed a materialization that already happened. The replacement candidate — split cache-visibility from shape-only storage — is specified and **not attempted**, since it is the code whose last regression broke DeltaBlue and it needs 0-6 |
 | **3** — arithmetic | Started. **3-0 landed, both halves** — an indexed access boxed its index; a read now allocates **nothing at all** and a write loses ~32 B, on reference arrays as much as numeric ones. **3-1 measured before starting and re-specified**: it trades write allocation for read allocation 1:1, so its clean half is live memory. **3-3's parameter half landed** — and the measurement re-specified it: the gap was a per-call `JSVariable` **cell**, not a box, so a three-parameter call went **230.2 → 62.2 B**. **Probing that analysis before extending it found a wrong-answer bug shipped since P2-2** — two writes it could not see, one returning NaN and one aborting the process on valid JavaScript; fixed, at no measurable cost. Its `let`/`const` half was then **built, measured (31.98 → 0.00 B/iter) and withdrawn**: it miscompiles after any earlier compilation in the same process, including for bindings the gate never admits, so the reproduction is recorded instead of the change. 3-4 is a cost, not a task |
 | **4** — tiering | Open. **4-3's design is written** — and it re-specifies the item: this engine has no interpreter frame to reconstruct, so V8-style deopt has no counterpart here. Splits into 4-3a (state and enforce the restart contract the pilot already runs, S) and 4-3b (a generic fallback branch inside the specialized method, M–L), which gates 4-4 rather than all of phase 4. **4-1 can start now** |
 | **5** — regex | **Gate satisfied, and it overturns the phase.** `Matcher.cs` is not the default engine — `JSRegExp` routes only semantic-gap patterns to it, and Octane's corpus has no look-behind and no `u` flag, so it barely runs. The engine that does serve them is `System.Text.RegularExpressions` built **interpreted**; `RegexOptions.Compiled` is worth ~2× on six of seven real Octane patterns and a stable **4.3× against** on the seventh — a *trim* — so a use-count policy is ruled out. Largest regex cost measured was neither: `replace` with a global flag allocated **42 859 B per match**, because an Annex B legacy static copied the subject on every successful match — **fixed, 0.048x the bytes and 0.30x the time**. Decomposing what was left **per call** then found a single-match `replace` paying two full UTF-16 copies of the subject through a `StringBuilder`; concatenating three spans instead is **4.020 → 2.020 B per subject character, exactly the predicted halving**, and **the identical defect in `String.prototype.replace`'s string-`searchValue` builtin was found by reading the neighbouring code and fixed with it**. The global case's retained result list then landed too — **2 032.8 → 478.3 B per match**, dead linear on both sides, by streaming when the receiver's `exec` is the pristine intrinsic and the replacement is a `$`-free string. **Every follow-up this phase named is now closed**; what is left is item 2's `Compiled` policy, deliberately unshipped |
@@ -554,6 +554,14 @@ These were paid for once each. They apply to every phase below.
   — 4.020 B/char both — which is what established them as one defect in two places rather than
   two resembling ones. *When a profile localizes a cost to a mechanism, grep for the mechanism;
   the corpus only measures what somebody thought to add to it.*
+- **A fix recorded as landed covers the path it was measured on, not the feature.** 2-0 removed
+  the per-allocation prototype invalidation and pinned it at "200 001 → 3" — on a `function`
+  constructor. `class C{}; new C()` still publishes one per allocation, by the same mechanism the
+  fix's own comment describes (a second write to the prototype that reads as `[[SetPrototypeOf]]`
+  on a live object). The item was not wrong and its number was not stale; its *scope* was one
+  construction path, and nothing in the record said so. *When a fix is verified through one
+  syntax, name the syntax in the claim — the next reader will otherwise take the general
+  statement, and a second path can carry the identical defect for as long as nobody spells it.*
 - **A counter that separates two workloads is a lead, not an explanation.** DeltaBlue fails
   phase 2's gate and Richards passes it, and of every inline-cache counter the sharpest split was
   dictionary fallbacks: **2 503 against 1**, three orders of magnitude. It traced to a real
@@ -2460,6 +2468,54 @@ covers this change most directly. Octane still runs 15 of 15 suites `ok`.
 reads missing on a suite whose whole shape is polymorphic constraint objects. That is where 2-10's
 successor should start, and it should start by decomposing *which sites* miss rather than by
 assuming, which is the mistake this item just made and caught.
+
+#### Decomposing the misses: not megamorphism, and a **`class`-shaped 2-0 regression found on the way**
+
+Two things are already ruled out, and one new defect fell out.
+
+**It is not megamorphism.** DeltaBlue records **0 megamorphic read sites** — every read site stays
+within the four-entry polymorphic budget. Whatever misses, misses while the site still has room.
+
+**The counter that tracks the gap is prototype invalidation: 2 519 for DeltaBlue against
+Richards's 37**, and each one retires *every* prototype-keyed entry in the process — the guard is
+deliberately coarse ("one prototype mutation anywhere"). DeltaBlue's reads are overwhelmingly
+inherited-method lookups, which are exactly the entries that retires.
+
+**Tagging the two publish sites splits them 4 543 / 115** across the cluster: almost everything
+comes from `NotifyPrototypeChainMutation` (a real `[[SetPrototypeOf]]`, or a mutation on an object
+already used as a prototype), not from `MarkUsedAsPrototype` (which is correctly guarded and fires
+once per object).
+
+**And isolating that by construct found a live defect — in `class`, not in DeltaBlue.** Counting
+invalidations against an empty-script baseline, per *n* allocations:
+
+| Construct | n = 100 | n = 500 | n = 2 000 |
+|---|--:|--:|--:|
+| `function F(){…}; new F()` | **1** | **1** | **1** |
+| **`class C{…}; new C()`** | **102** | **502** | **2 002** |
+| object literal | 0 | 0 | 0 |
+| DeltaBlue's `inheritsFrom` + `new` | 2 | 2 | — |
+
+**Dead linear at one per allocation**, and it is *precisely* item 2-0's signature — 2-0 recorded
+"200 001 invalidations per 200 000 allocations → 3". Traced, a class instantiation reaches
+`JSValue.SetPrototypeOf` → `set_BasePrototypeObject`, where `prototypeChain` is already non-null,
+so the write reads as a `[[SetPrototypeOf]]` on a live object and publishes. That is the same
+second write `JSFunction.CreateInstance` documents having removed: *"Installed by the constructor
+rather than by an initializer that overwrites what the constructor just set. … the second write
+looked like a `[[SetPrototypeOf]]` on a live object … Once per `new`."` **2-0 fixed the function
+path and the class path still does it.**
+
+**It does not explain DeltaBlue, and that is the second time in this item.** Octane's DeltaBlue is
+ES5 — its only occurrences of the word "class" are in comments — so it never constructs one. The
+defect is real, dead-linear, and reaches every `class` in modern JavaScript; it is simply not this
+suite's problem. Recorded as its own item rather than folded into 2-10, and **not fixed here**:
+the fix is the constructor-installs-the-prototype change 2-0 already made once, but this is the
+code whose last two regressions (2-0's own, and 2-8's DeltaBlue break) both came from this area,
+and it wants the Octane cluster run against it — which is now possible.
+
+**What 2-10's successor still owes** is the actual per-site attribution: *which* read sites in
+DeltaBlue miss, and why, given that they are neither megamorphic nor — now — explained by either
+of the two counters that looked most promising.
 
 ---
 

--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -21,10 +21,19 @@ so only the parent can hold the combined view.
 - **Acceptance protocol:** unchanged and unchallenged —
   [`Broiler.JS/docs/performance.md`](../Broiler.JS/docs/performance.md) governs what
   may be *claimed*. **Nothing in this document closes on the numbers it quotes.**
-- **Provenance:** the pinned submodule pointer is **`71dda1b7`**, checked 2026-08-02 against
-  the gitlink rather than against the prose. `a6f101cc` — which this section named until 3-3
+- **Provenance:** the pinned submodule pointer is **`2ebc0c3c`**, checked 2026-08-02 against
+  the gitlink rather than against the prose — **and checking it is what caught that this line
+  said `71dda1b7`**, which the pointer had moved past. `71dda1b7` is an **ancestor** of the
+  current pin, so nothing recorded against it is invalidated; the correction is to the prose,
+  not to any measurement — which is exactly the failure mode the rule two sentences down
+  already names, caught by applying it. **Phase 5's single-match `replace` change is *not* in the
+  pin**: its push to the submodule remote returned 403, so it is carried as
+  [`patches/0059`](../patches/0059-js-single-match-replace-one-allocation.patch) and the
+  pointer is deliberately unbumped — its figures below were measured on a local build of
+  `2ebc0c3c` **plus** that patch, control and change from the same tree.
+  `a6f101cc` — which this section named until 3-3
   was worked, and which every §0 and phase-2 measurement below was taken at — is an **ancestor**
-  of it, six commits back (`merge-base --is-ancestor`), so nothing recorded here is invalidated;
+  of it (`merge-base --is-ancestor`), so nothing recorded here is invalidated;
   what moved on top of it is 2-9, 3-0, 1-2's visitor stack guard and the script-host shell
   joining the solution. **A pointer written into prose goes stale silently**, which is why
   §4.1's and §3.4's figures below carry the commit they were taken at rather than "the pin".
@@ -63,7 +72,7 @@ the item's own section below, and nothing here is *closed* — see the acceptanc
 | **2** — property access | **Every item landed or closed.** 2-0 ✅ 2-1 ✅ 2-2 ✅ 2-4 ✅ 2-7 ✅ 2-8 ✅ **2-9 ✅**; **2-3 and 2-5 closed on measurements**; 2-6 folded into 4-1. The phase's conformance gate is **satisfied**; 0-6's CI Octane run is outstanding, and **2-9's ~20% compile-and-first-run cost wants a follow-up** (stop materializing for a deferred cell) |
 | **3** — arithmetic | Started. **3-0 landed, both halves** — an indexed access boxed its index; a read now allocates **nothing at all** and a write loses ~32 B, on reference arrays as much as numeric ones. **3-1 measured before starting and re-specified**: it trades write allocation for read allocation 1:1, so its clean half is live memory. **3-3's parameter half landed** — and the measurement re-specified it: the gap was a per-call `JSVariable` **cell**, not a box, so a three-parameter call went **230.2 → 62.2 B**. **Probing that analysis before extending it found a wrong-answer bug shipped since P2-2** — two writes it could not see, one returning NaN and one aborting the process on valid JavaScript; fixed, at no measurable cost. Its `let`/`const` half was then **built, measured (31.98 → 0.00 B/iter) and withdrawn**: it miscompiles after any earlier compilation in the same process, including for bindings the gate never admits, so the reproduction is recorded instead of the change. 3-4 is a cost, not a task |
 | **4** — tiering | Open. **4-3's design is written** — and it re-specifies the item: this engine has no interpreter frame to reconstruct, so V8-style deopt has no counterpart here. Splits into 4-3a (state and enforce the restart contract the pilot already runs, S) and 4-3b (a generic fallback branch inside the specialized method, M–L), which gates 4-4 rather than all of phase 4. **4-1 can start now** |
-| **5** — regex | **Gate satisfied, and it overturns the phase.** `Matcher.cs` is not the default engine — `JSRegExp` routes only semantic-gap patterns to it, and Octane's corpus has no look-behind and no `u` flag, so it barely runs. The engine that does serve them is `System.Text.RegularExpressions` built **interpreted**; `RegexOptions.Compiled` is worth ~2× on six of seven real Octane patterns and a stable **4.3× against** on the seventh — a *trim* — so a use-count policy is ruled out. Largest regex cost measured was neither: `replace` with a global flag allocated **42 859 B per match**, because an Annex B legacy static copied the subject on every successful match — **fixed, 0.048x the bytes and 0.30x the time** |
+| **5** — regex | **Gate satisfied, and it overturns the phase.** `Matcher.cs` is not the default engine — `JSRegExp` routes only semantic-gap patterns to it, and Octane's corpus has no look-behind and no `u` flag, so it barely runs. The engine that does serve them is `System.Text.RegularExpressions` built **interpreted**; `RegexOptions.Compiled` is worth ~2× on six of seven real Octane patterns and a stable **4.3× against** on the seventh — a *trim* — so a use-count policy is ruled out. Largest regex cost measured was neither: `replace` with a global flag allocated **42 859 B per match**, because an Annex B legacy static copied the subject on every successful match — **fixed, 0.048x the bytes and 0.30x the time**. Decomposing what was left **per call** then found a single-match `replace` paying two full UTF-16 copies of the subject through a `StringBuilder`; concatenating three spans instead is **4.020 → 2.020 B per subject character, exactly the predicted halving**, and **the identical defect in `String.prototype.replace`'s string-`searchValue` builtin was found by reading the neighbouring code and fixed with it**. What remains is the global case's retained result list, ~10 MB per call |
 
 **What phase 2 changed, measured.** Hit rates and byte counts are deterministic and exact; every
 wall-clock figure is a median of interleaved process-granularity pairs against a control, per §3:
@@ -520,6 +529,28 @@ These were paid for once each. They apply to every phase below.
   never reaches the component the phase is about. The engine that does serve it was one grep away
   — `new Regex(pattern, options)` with no `RegexOptions.Compiled`. *A blocker that names a file
   is making a routing claim, and routing is cheaper to check than to profile.*
+- **A `StringBuilder`'s floor is two copies, and pre-sizing removes neither.** Phase 5's
+  single-match `replace` assembled its answer through a builder: one copy into the chunk list,
+  one back out through `ToString()`. Pre-sizing it was tried first and was worth 0.2% — .NET's
+  `StringBuilder` chunks rather than doubles, so there was no reallocation waste to remove — and
+  the change that worked was to not use a builder at all, `string.Concat` over the three spans,
+  worth exactly half. The neighbouring `String.prototype.replace` had the same three appends into
+  a builder that was *already sized exactly right*, and halved by the same amount — which is the
+  cleanest statement of the point, since there was nothing left to tune. *When the final length is
+  knowable in one pass, a builder is the wrong tool rather than a mis-tuned one, and tuning it
+  optimizes the copy you should not be making.*
+- **A defect found by profiling has siblings the profile cannot see.** The single-match `replace`
+  was found in a `--regex-profile` row; the identical assembly in `String.prototype.replace`'s
+  string-`searchValue` path had **no row at all**, and was found by reading the builtin next to
+  the one being edited. Its before-slope then matched the profiled path's to three decimal places
+  — 4.020 B/char both — which is what established them as one defect in two places rather than
+  two resembling ones. *When a profile localizes a cost to a mechanism, grep for the mechanism;
+  the corpus only measures what somebody thought to add to it.*
+- **A halving that lands exactly is a check on the decomposition, not just a win.** The same item
+  predicted 4 B/char → 2 from "two full UTF-16 copies and nothing else". Measuring 4.02 → 2.02 at
+  three subject lengths is what rules out a third copy hiding in the row; a saving of *roughly*
+  half would have left the model unfalsified and untested. *Predict the number before the change,
+  then treat a miss as evidence about the model rather than noise in the measurement.*
 - **Interleave, at process granularity.** Sub-1.5% effects are only visible ABBA-
   interleaved across independent builds, ten runs each, medians compared.
 - **Hold the call site fixed when the callee is what changed.** Sizing a parameter's cost by
@@ -2906,18 +2937,21 @@ result array plus its `index` / `input` / `groups` properties. And a *single* no
 `replace` costs four bytes per subject character, which is **two full UTF-16 copies**: the
 `StringBuilder`'s chunks and then its `ToString()`.
 
-Two follow-ups, both sized by those rows and neither started:
+Two follow-ups, both sized by those rows. **The first has landed** — see below; the second has
+not started:
 
 - **The single-match replace should not use a builder at all.** `input[0..pos] + replacement +
   input[end..]` is one `string.Concat` over three spans and one allocation, halving 4 B/char
   to 2. *Pre-sizing the builder was tried first and is worth 0.2%* — .NET's `StringBuilder`
   is a chunk list, not a doubling array, so there was no reallocation waste to remove. The
   change was reverted rather than kept for a rationale that turned out to be wrong.
+  **Landed, and the halving is exact — in both builtins that had the pattern.**
 - **A global replace retains every result before it builds anything.** §22.2.6.11 collects all
   matches in step 14 and reads their properties in step 16, so 5 000 matches means 5 000 live
   result arrays — 5 000 × ~2 KB, which is exactly the ~10 MB per call still measured. Streaming
   them would change the observable order of `exec` calls against capture reads, so it is only
-  available on a fast path where nothing is patched.
+  available on a fast path where nothing is patched. **Not started, and it is now the largest
+  measured regex cost left.**
 
 **One hazard the change introduced and closed.** Deferring the slice means `Update` publishes a
 subject and two indices that must agree; three separate field writes would let a reader on
@@ -2944,6 +2978,92 @@ failure record byte-identical to the earlier runs.
 > these are single runs on a developer workstation, so what is claimed here is the allocation
 > figure, which is deterministic and exact. The scores are recorded as corroboration and as a
 > reason for 0-6 to look at them.
+
+#### The single-match follow-up landed — the halving is exact
+
+> **Delivered as a patch, not in the pin.** The push to `Broiler-Platform/Broiler.JS` returned
+> **403** — the submodule remote is outside this session's GitHub scope — so per the patch
+> workflow the pointer is **not** bumped and the change ships as
+> [`patches/0059`](../patches/0059-js-single-match-replace-one-allocation.patch) for a maintainer
+> to apply. Every figure below was measured on a local build of the pinned `2ebc0c3c` **plus**
+> that patch, with the control built from the same tree minus it. No main-repo fallback is
+> needed: this is an allocation reduction with no behaviour difference, so CI is correct without
+> it and only more allocating.
+
+`RegExp.prototype[@@replace]` accumulated into a `StringBuilder` whatever the match count. For a
+single match the answer is exactly `prefix + replacement + suffix`, so `string.Concat` over three
+spans writes it into **one** allocation of the final length, and the builder's two copies — into
+its chunk list, then back out through `ToString()` — become one.
+
+Measured with the same `--regex-profile` scaling rows, both sides built from the same tree rather
+than compared against the figures recorded above:
+
+| `replace`, one match | 5 000 | 20 000 | 80 000 | Slope |
+|---|--:|--:|--:|--:|
+| Before | 22 635 | 82 935 | 324 190 | **4.020 B/char** |
+| After | 12 483 | 42 783 | 164 030 | **2.020 B/char** |
+| | 0.55x | 0.52x | 0.51x | **exactly half** |
+
+**The predicted halving is realized to two decimal places, and that is the load-bearing part.**
+The decomposition claimed the 4 B/char was two copies of the subject *and nothing else*; removing
+one copy and getting exactly half is what confirms there was no third. The `test` and `exec` rows
+are byte-identical on both sides — 2 051 / 2 351 / 3 551 and 1 995 / 2 295 / 3 495 — so they are
+the control, and they place the saving on the replace path rather than in the profile.
+
+*(The before row's 80 000 figure is 324 190 here against the 324 135 recorded in the table above.
+Both are this build's own control, taken a pointer apart; 55 bytes on 324 KB is 0.02% and changes
+no slope. It is written as measured rather than reconciled to the earlier row.)*
+
+**The same assembly was one file over, and it is fixed too.** `String.prototype.replace` with a
+**string** `searchValue` never reaches `@@replace` — it is a separate builtin — and it replaces
+only the first occurrence, so it is single-match *by construction*. It built its answer from three
+appends into a **pre-sized** `StringBuilder`: the same two copies, and the clearest case of why
+pre-sizing does not help, since that builder was already sized exactly right. `--regex-profile`
+now carries a `replace-one-string` row beside `replace-one` so the two cannot drift apart:
+
+| `replace`, one match, **string** searchValue | 5 000 | 20 000 | 80 000 | Slope |
+|---|--:|--:|--:|--:|
+| Before | 20 406 | 80 706 | 321 965 | **4.020 B/char** |
+| After | 10 326 | 40 626 | 161 877 | **2.020 B/char** |
+| | 0.51x | 0.50x | 0.50x | **exactly half** |
+
+Its slope was already identical to the regexp path's to three decimal places before the change,
+which is what identifies the two as the same defect rather than two similar ones — and it lands
+on the same 2.020 after. **It was found by reading the neighbouring builtin, not by the profile**,
+which had no row for it; the row exists now because the fix needed one.
+
+**A global regexp that matches once takes the fast path too.** The gate is `results.Count == 1`,
+not the `g` flag: `global` decides how many results were collected, not how they are assembled,
+so `'abc'.replace(/b/g, 'X')` gets it. And step 16.p's backwards-position guard cannot apply to a
+single result — `nextSourcePosition` is still 0 and `position` is clamped to [0, lengthS], so
+`position >= 0` holds — which makes the fast path the loop's behaviour rather than an
+approximation of it.
+
+**The per-result work is shared, not duplicated.** Step 16 reads the result's properties in an
+order a Proxy can observe (`length` → `0` → `index` → captures → `groups`), and test262
+`sm/RegExp/replace-trace` pins it. Both paths call one local function rather than each carrying a
+copy, so the order cannot drift between them; it is called directly and never as a delegate, so
+the capture is a struct closure and costs no allocation.
+
+**Verify.** `SingleMatchReplaceAllocationTests` asserts the bytes and **fails on the build
+without the change** — 95 881 B/call against its 60 000 bound — while every one of its answer
+cases passes on *both* builds, which is what identifies them as regression guards rather than
+change detectors. They cover the edges the fast path now owns: a match at position 0 and at the
+end of the subject, an empty match, an empty replacement, the global-matching-once case, every
+`$` substitution form, functional replacers, surrogate pairs, an ill-behaving `exec` reporting an
+index past the subject, the Annex B statics, and the property read order — plus the same edges
+again through the string-`searchValue` builtin.
+
+**test262 is unchanged across all four pinned manifests — 8 313 executed, 8 220 passed, 84
+failed, 44 skipped, 9 timed out, identical manifest by manifest** to §3.4's recorded run, at
+suite ref `ccaac100`. And because the four pinned manifests contain no `replace` coverage at all,
+**the paths this change actually touches were run separately, control against change**:
+`RegExp/prototype/Symbol.replace`, `String/prototype/replace`, `replaceAll`, `RegExp/prototype/exec`,
+`Symbol.split`, `Symbol.match`, `annexB/built-ins/RegExp` and `staging/sm/RegExp` — **499 tests,
+484 passed, 13 failed, 2 timed out, and the failing set is the same file for file on both
+builds.** All 13 are cross-realm cases needing `$262.createRealm`, which the raw script host does
+not provide; **not one failure is in a `replace` directory.** Repository suite
+**7 604 tests across 13 projects, 0 failures** — 41 of them new here.
 
 #### Item 2 measured — and the obvious policy is the wrong one
 
@@ -2997,7 +3117,7 @@ predicate at all.
 | **2** | 2-0 ✅ → 2-1 ✅ → 2-2 ✅ → 2-4 ✅ → 2-7 ✅ → 2-8 ✅ → **2-9 ✅** (2-3's successor, L); 2-5 and **2-3 closed on measurements**, 2-6 folded into 4-1. **Every item is landed or closed** | M each, 2-9 L | The Richards/DeltaBlue/Box2D cluster | An ownership entry and owned tests **per item**; test262 properties/strict-mode **satisfied** — unchanged at `a6f101cc` plus 2-9; **DeltaBlue and Richards inside 200×** still owed from 0-6 |
 | **3** | 3-0 ✅ (both halves) → 3-3 parameters ✅ → **3-3 `let`/`const`** → 3-1 → 3-2, then *cost* 3-4 | M, then L–XL | Uniform lift across arithmetic and allocation-heavy suites | `test262-arrays`, `test262-binary-data`; allocation reported per item alongside time |
 | **4** | 4-3 design ✅ → **4-1** (unblocked) → 4-3a (S) → 4-3b (M–L) → 4-2 → 4-4 | XL | The remaining order of magnitude | Deopt correctness proven **before** any speculation ships; full test262 matrix |
-| **5** | profile ✅ → per-match subject copy on `replace`/`exec` ✅ → `Compiled` per pattern **measured, no policy shipped** → *then* consider compiling `Broiler.Regex` | L | RegExp, plus PdfJS and Typescript | Octane regex corpus profiled **before** any rewrite — **satisfied**, and it re-ordered the phase |
+| **5** | profile ✅ → per-match subject copy on `replace`/`exec` ✅ → single-match `replace` without a builder ✅ (both builtins) → **the global case's retained result list** → `Compiled` per pattern **measured, no policy shipped** → *then* consider compiling `Broiler.Regex` | L | RegExp, plus PdfJS and Typescript | Octane regex corpus profiled **before** any rewrite — **satisfied**, and it re-ordered the phase |
 
 **Dependencies.**
 

--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -71,9 +71,9 @@ the item's own section below, and nothing here is *closed* — see the acceptanc
 
 | Phase | State |
 |---|---|
-| **0** — evidence | 0-1…0-5 ✅, 0-9…0-11 ✅. **0-6 (the CI Octane run) is the critical path** — it is what phases A–F need to close on, and what phase 2's exit criterion is measured by. 0-7, 0-8 follow it |
+| **0** — evidence | 0-1…0-5 ✅, 0-9…0-11 ✅. **0-6 (the CI Octane run) is still the critical path, but its headline question is answered**: run at the pinned pointer on linux-x64, Octane is **15 of 15 suites `ok` and 17 of 17 scores** — Mandreel included, which the previous local pass had failing. Geomean 217, spread **113×** against a same-machine Chromium reference. What 0-6 still owes is the *workflow* run plus 0-7's BenchmarkDotNet and 0-8's RID matrix, which a container cannot produce |
 | **1** — compile-time | 1-2's mitigation ✅ (`43bc4230`); **1-2's real fix is now on all three recursing passes** — the validator and emitter (`StackGuard` had three defects and could not fire), and now `FastParser`, whose descent aborted the process at 25 000 nesting levels **in the default configuration** and now survives 90 000 at no measurable cost. 1-1 open. 1-2's stated acceptance criterion **already passed before any work** — it measured size where the cause was nesting |
-| **2** — property access | **Every item landed or closed.** 2-0 ✅ 2-1 ✅ 2-2 ✅ 2-4 ✅ 2-7 ✅ 2-8 ✅ **2-9 ✅**; **2-3 and 2-5 closed on measurements**; 2-6 folded into 4-1. The phase's conformance gate is **satisfied**; 0-6's CI Octane run is outstanding, and **2-9's ~20% compile-and-first-run cost still wants a follow-up — but not the one that was written.** Its losing-side hypothesis was measured against the control it never had (a *strict* function, which carries no Annex B deferred cells) and is **wrong**: every function materializes its trie **exactly once** whether strict or not, because the `prototype` install is withheld from shape-only storage by 2-8's DeltaBlue fix. "Stop materializing for a deferred cell" would have removed a materialization that already happened. The replacement candidate — split cache-visibility from shape-only storage — is specified and **not attempted**, since it is the code whose last regression broke DeltaBlue and it needs 0-6 |
+| **2** — property access | **Every item landed or closed.** 2-0 ✅ 2-1 ✅ 2-2 ✅ 2-4 ✅ 2-7 ✅ 2-8 ✅ **2-9 ✅**; **2-3 and 2-5 closed on measurements**; 2-6 folded into 4-1. The phase's conformance gate is **satisfied**, and **its Octane exit criterion is now answered and splits: Richards is inside 200× at 183× (band 163–191) and DeltaBlue is not, at 576× (band 538–711)** — five repetitions per engine, same machine. **DeltaBlue is what phase 2 has left**, and it is the suite 2-8 was written for. Also outstanding: **2-9's ~20% compile-and-first-run cost still wants a follow-up — but not the one that was written.** Its losing-side hypothesis was measured against the control it never had (a *strict* function, which carries no Annex B deferred cells) and is **wrong**: every function materializes its trie **exactly once** whether strict or not, because the `prototype` install is withheld from shape-only storage by 2-8's DeltaBlue fix. "Stop materializing for a deferred cell" would have removed a materialization that already happened. The replacement candidate — split cache-visibility from shape-only storage — is specified and **not attempted**, since it is the code whose last regression broke DeltaBlue and it needs 0-6 |
 | **3** — arithmetic | Started. **3-0 landed, both halves** — an indexed access boxed its index; a read now allocates **nothing at all** and a write loses ~32 B, on reference arrays as much as numeric ones. **3-1 measured before starting and re-specified**: it trades write allocation for read allocation 1:1, so its clean half is live memory. **3-3's parameter half landed** — and the measurement re-specified it: the gap was a per-call `JSVariable` **cell**, not a box, so a three-parameter call went **230.2 → 62.2 B**. **Probing that analysis before extending it found a wrong-answer bug shipped since P2-2** — two writes it could not see, one returning NaN and one aborting the process on valid JavaScript; fixed, at no measurable cost. Its `let`/`const` half was then **built, measured (31.98 → 0.00 B/iter) and withdrawn**: it miscompiles after any earlier compilation in the same process, including for bindings the gate never admits, so the reproduction is recorded instead of the change. 3-4 is a cost, not a task |
 | **4** — tiering | Open. **4-3's design is written** — and it re-specifies the item: this engine has no interpreter frame to reconstruct, so V8-style deopt has no counterpart here. Splits into 4-3a (state and enforce the restart contract the pilot already runs, S) and 4-3b (a generic fallback branch inside the specialized method, M–L), which gates 4-4 rather than all of phase 4. **4-1 can start now** |
 | **5** — regex | **Gate satisfied, and it overturns the phase.** `Matcher.cs` is not the default engine — `JSRegExp` routes only semantic-gap patterns to it, and Octane's corpus has no look-behind and no `u` flag, so it barely runs. The engine that does serve them is `System.Text.RegularExpressions` built **interpreted**; `RegexOptions.Compiled` is worth ~2× on six of seven real Octane patterns and a stable **4.3× against** on the seventh — a *trim* — so a use-count policy is ruled out. Largest regex cost measured was neither: `replace` with a global flag allocated **42 859 B per match**, because an Annex B legacy static copied the subject on every successful match — **fixed, 0.048x the bytes and 0.30x the time**. Decomposing what was left **per call** then found a single-match `replace` paying two full UTF-16 copies of the subject through a `StringBuilder`; concatenating three spans instead is **4.020 → 2.020 B per subject character, exactly the predicted halving**, and **the identical defect in `String.prototype.replace`'s string-`searchValue` builtin was found by reading the neighbouring code and fixed with it**. The global case's retained result list then landed too — **2 032.8 → 478.3 B per match**, dead linear on both sides, by streaming when the receiver's `exec` is the pristine intrinsic and the replacement is a `$`-free string. **Every follow-up this phase named is now closed**; what is left is item 2's `Compiled` policy, deliberately unshipped |
@@ -179,11 +179,15 @@ source documents ended up disagreeing.
 
 ### 2.1 The suite view — three numbers per Octane run
 
-| Metric | Last committed run | Target |
-|---|---|---|
-| **Scores reported** out of 17 | 12 / 17 (stale) | **17 / 17** |
-| **Geomean** over all 17 scores | 245 over the 12 that completed; ≈244 including the five *(0046)* measurements | — |
-| **Spread** = worst ÷ best, as ×-slower-than-Chromium | 4646 / 45 ≈ **103×** | **< 5×** |
+| Metric | Last committed run | **At the pin, linux-x64 (§Phase 0)** | Target |
+|---|---|---|---|
+| **Scores reported** out of 17 | 12 / 17 (stale) | **17 / 17** — 15 of 15 suites `ok` | **17 / 17** |
+| **Geomean** over all 17 scores | 245 over the 12 that completed; ≈244 including the five *(0046)* measurements | **217** over all 17 | — |
+| **Spread** = worst ÷ best, as ×-slower-than-Chromium | 4646 / 45 ≈ **103×** | 3 097 / 27 ≈ **113×** | **< 5×** |
+
+The middle column is a single repetition on a developer container with its **own** Chromium
+reference measured on the same machine, so its ratios are internally valid while its scores are
+not comparable to the left column's. It is not 0-6; see Phase 0 for what it is and is not.
 
 **Spread is the organizing metric.** Because the suite total is a geometric mean,
 flattening the curve and raising the total are the same work: moving MandreelLatency
@@ -550,6 +554,14 @@ These were paid for once each. They apply to every phase below.
   — 4.020 B/char both — which is what established them as one defect in two places rather than
   two resembling ones. *When a profile localizes a cost to a mechanism, grep for the mechanism;
   the corpus only measures what somebody thought to add to it.*
+- **An exit criterion that has never been run is not a pending task, it is an unknown answer.**
+  Phase 2's was *"DeltaBlue and Richards inside 200×"*, owed since the phase opened and carried
+  through every item as one line of the sequencing table. Run at last, it **splits**: Richards is
+  inside at 183× and DeltaBlue is outside at 576×, so the phase that was described as "every item
+  landed or closed" has in fact failed half its own gate, on the suite item 2-8 was written for.
+  Two repetitions would not have said that safely; five with a band did. *A gate carried unrun
+  reads as "nearly done" for as long as nobody runs it, and the cost of running it is almost
+  always less than the cost of the plan built on top of assuming it passes.*
 - **A hypothesis with a plausible mechanism still needs the control that would refute it.** 2-9's
   losing side was explained by the Annex B deferred cells forcing a trie rebuild — a mechanism
   read straight off the code, correct in every step, and wrong about the cause. The control that
@@ -897,6 +909,69 @@ only six frames deep, so what exhausted the budget is the engine recursing over
 0, the suite was reported rather than killed, and the other 14 were unaffected. That
 containment is 0-2 and B8 working as designed — the same overflow used to take a whole
 suite down.
+
+#### At the pinned pointer it is **17 of 17**, and phase 2's exit criterion finally has an answer
+
+Run 2026-08-03 at the pinned `2ebc0c3c` on **linux-x64**, against upstream `chromium/octane`
+`570ad1cc` (Octane v9), with the shell rebuilt by the harness rather than reused — and this
+time **both engines on the same machine**, so the ×-slower column is internally valid in a way
+no previous run's was.
+
+| | Committed run (2026-07-31, CI) | Local pass (`b3f53dcc`, win-x64) | **This run (pin, linux-x64)** |
+|---|---|---|---|
+| Suites `ok` | 10 of 15 | 14 of 15 | **15 of 15** |
+| Scores reported | 12 / 17 | 15 / 17 | **17 / 17** |
+
+**Mandreel passes now, and it is the difference between 15 and 17 scores.** The local pass
+above had it failing with 1-2's signature after 375 s of `global_init`; at the pin it completes,
+which is what **1-2's real fix landing on all three recursing passes** predicts and is the first
+run to show it. Every one of B8's five original failures stays fixed. **So 0-6's headline gate —
+17/17 with nothing timing out — is met at the pinned pointer**, which is the tree CI clones.
+
+**Read the timeout half of that gate precisely.** Nothing timed out, but two suites finish only
+because `scripts/octane-suites.json` raises their budgets above the run-wide **180 s floor**:
+**zlib at 644 s and Mandreel at 428 s**. The floor is a floor, not a bound, and it always was —
+the config file records the earlier 647 s / 313 s measurements that set those budgets. Mandreel
+is 37% slower here than the figure that budget was chosen from, which is the same
+this-machine-is-slower effect the scores show, and it leaves the budget comfortable rather than
+marginal. *"No timeout at the 180 s floor" would be the wrong sentence to carry forward: two of
+the fifteen exceed 180 s by design.*
+
+**The triad, with a same-machine Chromium reference:**
+
+| Metric | Value |
+|---|---|
+| Scores reported | **17 / 17** |
+| Broiler geomean over all 17 | **217** |
+| **Spread** = worst ÷ best, as ×-slower-than-Chromium | **113×** — MandreelLatency **3 097×** worst, SplayLatency **27×** best |
+
+MandreelLatency is still the tail by a wide margin, which is **phase 1's justification measured
+rather than quoted**: the two worst rows in the suite remain the two that measure only the front
+end. Nothing here changes that ordering.
+
+**Phase 2's exit criterion — "DeltaBlue and Richards inside 200×" — has been owed since the
+phase began. It is now answered, and it splits.** Re-run with **5 repetitions per engine**, so
+the verdict carries a band rather than a point:
+
+| Suite | Broiler median (band) | Chromium median (band) | ×-slower | Across the whole band | Gate |
+|---|--:|--:|--:|---|---|
+| **Richards** | 143 (7.0%) | 26 173 (8.6%) | **183×** | 163× – 191× | **PASS** |
+| **DeltaBlue** | 116 (16.7%) | 66 759 (10.1%) | **576×** | 538× – 711× | **FAIL** |
+
+Richards is inside 200× at *every* combination of the two bands, and DeltaBlue is outside it at
+every combination — worst-case-to-best-case it misses by between 2.7× and 3.6×. Neither verdict
+is a coin-flip against noise, which is the point of running five and reporting the band instead
+of one and reporting a number. **DeltaBlue is the item phase 2 has left**, and it is the suite
+2-8 was written for.
+
+> **What this is not.** It is not 0-6. That gate is *the workflow*, and it also carries 0-7's
+> BenchmarkDotNet comparison and 0-8's RID matrix, neither of which a container can produce —
+> §0-8 already records why a non-idle machine cannot. These results are therefore **not committed
+> to `tests/octane/results/`**, which stays CI's to write; the stale banner there still stands.
+> The full-suite numbers are **one repetition** and the harness says so in its own output. What
+> is claimed here is the pass/fail column, which is hardware-independent, and the two gate
+> ratios, which are same-machine, five-repetition and banded. The geomean and the spread are
+> recorded as this machine's, not as the campaign's.
 
 > **Superseded in part.** The same suite was re-run on **linux-x64 at `685026c0`** against
 > upstream `chromium/octane` while working 1-2, and **Mandreel completes** — `status: ok`,
@@ -3277,9 +3352,9 @@ predicate at all.
 
 | Phase | Order within it | Size | Unblocks / expected effect | Exit gate |
 |---|---|---|---|---|
-| **0** | 0-1…0-5 ✅, 0-9…0-11 ✅ → **0-6 (CI) → 0-7, 0-8** | — | Everything. 12 → **17 scores**, known noise band, and the first evidence any phase A–F can close on | 17/17, no timeout at the 180 s floor, band on record, `comparison.md` reporting the triad, **and the BenchmarkDotNet + RID-matrix rows collected** |
+| **0** | 0-1…0-5 ✅, 0-9…0-11 ✅ → **0-6 (CI — 17/17 established at the pin locally; the workflow run is still owed) → 0-7, 0-8** | — | Everything. 12 → **17 scores**, known noise band, and the first evidence any phase A–F can close on | 17/17, no timeout at the 180 s floor, band on record, `comparison.md` reporting the triad, **and the BenchmarkDotNet + RID-matrix rows collected** |
 | **1** | 1-2 mitigation ✅ → 1-2 real fix ✅ (all three passes) → **1-1** → 1-3 measure | XL | The two worst scores in the suite; page-load time generally | test262 over the four pinned manifests, no new failure **and no new timeout**; MandreelLatency and CodeLoad out of the tail |
-| **2** | 2-0 ✅ → 2-1 ✅ → 2-2 ✅ → 2-4 ✅ → 2-7 ✅ → 2-8 ✅ → **2-9 ✅** (2-3's successor, L); 2-5 and **2-3 closed on measurements**, 2-6 folded into 4-1. **Every item is landed or closed** | M each, 2-9 L | The Richards/DeltaBlue/Box2D cluster | An ownership entry and owned tests **per item**; test262 properties/strict-mode **satisfied** — unchanged at `a6f101cc` plus 2-9; **DeltaBlue and Richards inside 200×** still owed from 0-6 |
+| **2** | 2-0 ✅ → 2-1 ✅ → 2-2 ✅ → 2-4 ✅ → 2-7 ✅ → 2-8 ✅ → **2-9 ✅** (2-3's successor, L); 2-5 and **2-3 closed on measurements**, 2-6 folded into 4-1. **Every item is landed or closed** | M each, 2-9 L | The Richards/DeltaBlue/Box2D cluster | An ownership entry and owned tests **per item**; test262 properties/strict-mode **satisfied** — unchanged at `a6f101cc` plus 2-9; **DeltaBlue and Richards inside 200×** — **measured: Richards 183× PASSES, DeltaBlue 576× FAILS**, five repetitions per engine on one machine |
 | **3** | 3-0 ✅ (both halves) → 3-3 parameters ✅ → **3-3 `let`/`const`** → 3-1 → 3-2, then *cost* 3-4 | M, then L–XL | Uniform lift across arithmetic and allocation-heavy suites | `test262-arrays`, `test262-binary-data`; allocation reported per item alongside time |
 | **4** | 4-3 design ✅ → **4-1** (unblocked) → 4-3a (S) → 4-3b (M–L) → 4-2 → 4-4 | XL | The remaining order of magnitude | Deopt correctness proven **before** any speculation ships; full test262 matrix |
 | **5** | profile ✅ → per-match subject copy on `replace`/`exec` ✅ → single-match `replace` without a builder ✅ (both builtins) → the global case's retained result list ✅ → `Compiled` per pattern **measured, no policy shipped** → *then* consider compiling `Broiler.Regex` | L | RegExp, plus PdfJS and Typescript | Octane regex corpus profiled **before** any rewrite — **satisfied**, and it re-ordered the phase |

--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -26,11 +26,13 @@ so only the parent can hold the combined view.
   said `71dda1b7`**, which the pointer had moved past. `71dda1b7` is an **ancestor** of the
   current pin, so nothing recorded against it is invalidated; the correction is to the prose,
   not to any measurement — which is exactly the failure mode the rule two sentences down
-  already names, caught by applying it. **Phase 5's single-match `replace` change is *not* in the
-  pin**: its push to the submodule remote returned 403, so it is carried as
-  [`patches/0059`](../patches/0059-js-single-match-replace-one-allocation.patch) and the
-  pointer is deliberately unbumped — its figures below were measured on a local build of
-  `2ebc0c3c` **plus** that patch, control and change from the same tree.
+  already names, caught by applying it. **Phase 5's two `replace` changes are *not* in the
+  pin**: their pushes to the submodule remote returned 403, so they are carried as
+  [`patches/0059`](../patches/0059-js-single-match-replace-one-allocation.patch) and
+  [`patches/0060`](../patches/0060-js-stream-global-replace.patch) — **in that order**, since
+  `0060` builds on the function `0059` restructures — and the pointer is deliberately unbumped.
+  Their figures below were measured on a local build of `2ebc0c3c` **plus** those patches,
+  control and change from the same tree.
   `a6f101cc` — which this section named until 3-3
   was worked, and which every §0 and phase-2 measurement below was taken at — is an **ancestor**
   of it (`merge-base --is-ancestor`), so nothing recorded here is invalidated;
@@ -72,7 +74,7 @@ the item's own section below, and nothing here is *closed* — see the acceptanc
 | **2** — property access | **Every item landed or closed.** 2-0 ✅ 2-1 ✅ 2-2 ✅ 2-4 ✅ 2-7 ✅ 2-8 ✅ **2-9 ✅**; **2-3 and 2-5 closed on measurements**; 2-6 folded into 4-1. The phase's conformance gate is **satisfied**; 0-6's CI Octane run is outstanding, and **2-9's ~20% compile-and-first-run cost wants a follow-up** (stop materializing for a deferred cell) |
 | **3** — arithmetic | Started. **3-0 landed, both halves** — an indexed access boxed its index; a read now allocates **nothing at all** and a write loses ~32 B, on reference arrays as much as numeric ones. **3-1 measured before starting and re-specified**: it trades write allocation for read allocation 1:1, so its clean half is live memory. **3-3's parameter half landed** — and the measurement re-specified it: the gap was a per-call `JSVariable` **cell**, not a box, so a three-parameter call went **230.2 → 62.2 B**. **Probing that analysis before extending it found a wrong-answer bug shipped since P2-2** — two writes it could not see, one returning NaN and one aborting the process on valid JavaScript; fixed, at no measurable cost. Its `let`/`const` half was then **built, measured (31.98 → 0.00 B/iter) and withdrawn**: it miscompiles after any earlier compilation in the same process, including for bindings the gate never admits, so the reproduction is recorded instead of the change. 3-4 is a cost, not a task |
 | **4** — tiering | Open. **4-3's design is written** — and it re-specifies the item: this engine has no interpreter frame to reconstruct, so V8-style deopt has no counterpart here. Splits into 4-3a (state and enforce the restart contract the pilot already runs, S) and 4-3b (a generic fallback branch inside the specialized method, M–L), which gates 4-4 rather than all of phase 4. **4-1 can start now** |
-| **5** — regex | **Gate satisfied, and it overturns the phase.** `Matcher.cs` is not the default engine — `JSRegExp` routes only semantic-gap patterns to it, and Octane's corpus has no look-behind and no `u` flag, so it barely runs. The engine that does serve them is `System.Text.RegularExpressions` built **interpreted**; `RegexOptions.Compiled` is worth ~2× on six of seven real Octane patterns and a stable **4.3× against** on the seventh — a *trim* — so a use-count policy is ruled out. Largest regex cost measured was neither: `replace` with a global flag allocated **42 859 B per match**, because an Annex B legacy static copied the subject on every successful match — **fixed, 0.048x the bytes and 0.30x the time**. Decomposing what was left **per call** then found a single-match `replace` paying two full UTF-16 copies of the subject through a `StringBuilder`; concatenating three spans instead is **4.020 → 2.020 B per subject character, exactly the predicted halving**, and **the identical defect in `String.prototype.replace`'s string-`searchValue` builtin was found by reading the neighbouring code and fixed with it**. What remains is the global case's retained result list, ~10 MB per call |
+| **5** — regex | **Gate satisfied, and it overturns the phase.** `Matcher.cs` is not the default engine — `JSRegExp` routes only semantic-gap patterns to it, and Octane's corpus has no look-behind and no `u` flag, so it barely runs. The engine that does serve them is `System.Text.RegularExpressions` built **interpreted**; `RegexOptions.Compiled` is worth ~2× on six of seven real Octane patterns and a stable **4.3× against** on the seventh — a *trim* — so a use-count policy is ruled out. Largest regex cost measured was neither: `replace` with a global flag allocated **42 859 B per match**, because an Annex B legacy static copied the subject on every successful match — **fixed, 0.048x the bytes and 0.30x the time**. Decomposing what was left **per call** then found a single-match `replace` paying two full UTF-16 copies of the subject through a `StringBuilder`; concatenating three spans instead is **4.020 → 2.020 B per subject character, exactly the predicted halving**, and **the identical defect in `String.prototype.replace`'s string-`searchValue` builtin was found by reading the neighbouring code and fixed with it**. The global case's retained result list then landed too — **2 032.8 → 478.3 B per match**, dead linear on both sides, by streaming when the receiver's `exec` is the pristine intrinsic and the replacement is a `$`-free string. **Every follow-up this phase named is now closed**; what is left is item 2's `Compiled` policy, deliberately unshipped |
 
 **What phase 2 changed, measured.** Hit rates and byte counts are deterministic and exact; every
 wall-clock figure is a median of interleaved process-granularity pairs against a control, per §3:
@@ -546,6 +548,22 @@ These were paid for once each. They apply to every phase below.
   — 4.020 B/char both — which is what established them as one defect in two places rather than
   two resembling ones. *When a profile localizes a cost to a mechanism, grep for the mechanism;
   the corpus only measures what somebody thought to add to it.*
+- **When an optimization skips work, the design is the observers, not the work.** Phase 5's
+  streaming replace is four lines: append each replacement instead of collecting them all. Every
+  hour of it went into establishing that nobody could watch the skipped result objects — and two
+  of the three conditions that turned out to be needed are not in the item's description. The
+  sharpest is the functional replacer: because the spec collects *all* matches before calling
+  *any* replacer, the final failing `exec` has already reset `lastIndex` to 0 before user code
+  runs, so a streamed replacer would see a *different value*, not merely a different order. The
+  item said "changes the observable order"; the actual hazard was a changed value. *Enumerate who
+  could have been watching, and check what each one would see — an item that names the hazard in
+  the abstract has usually not enumerated them.*
+- **"Is this builtin unpatched" can only be asked against a pristine capture.** The `exec` guard
+  compares against `%RegExp.prototype.exec%` captured at realm init, before user code runs.
+  Reading `RegExp.prototype.exec` at call time and comparing it to itself is circular — by then
+  it may already be the patched one — and there is no property of the function object that says
+  "genuine". *Identity against something captured earlier is the test; anything cheaper is
+  answering a different question.*
 - **A halving that lands exactly is a check on the decomposition, not just a win.** The same item
   predicted 4 B/char → 2 from "two full UTF-16 copies and nothing else". Measuring 4.02 → 2.02 at
   three subject lengths is what rules out a third copy hiding in the row; a saving of *roughly*
@@ -2950,8 +2968,8 @@ not started:
   matches in step 14 and reads their properties in step 16, so 5 000 matches means 5 000 live
   result arrays — 5 000 × ~2 KB, which is exactly the ~10 MB per call still measured. Streaming
   them would change the observable order of `exec` calls against capture reads, so it is only
-  available on a fast path where nothing is patched. **Not started, and it is now the largest
-  measured regex cost left.**
+  available on a fast path where nothing is patched. **Landed — and the estimate was right to
+  three digits: 2 033 bytes per match, dead linear.**
 
 **One hazard the change introduced and closed.** Deferring the slice means `Update` publishes a
 subject and two indices that must agree; three separate field writes would let a reader on
@@ -3065,6 +3083,77 @@ builds.** All 13 are cross-realm cases needing `$262.createRealm`, which the raw
 not provide; **not one failure is in a `replace` directory.** Repository suite
 **7 604 tests across 13 projects, 0 failures** — 41 of them new here.
 
+#### The retained-result-list follow-up landed — 2 033 bytes a match, and the guard is the change
+
+> **Delivered as a patch, not in the pin**, for the same 403 as the section above, and it must be
+> applied *after* it: [`patches/0060`](../patches/0060-js-stream-global-replace.patch) builds on
+> the function [`patches/0059`](../patches/0059-js-single-match-replace-one-allocation.patch)
+> restructures. Figures below were measured on a local build of the pinned `2ebc0c3c` plus both.
+
+`RegExp.prototype[@@replace]` collects every match in step 14 and only reads their properties in
+step 16, so a global replace held one result array per match live before it assembled anything.
+**Measured with the subject held fixed and only the match count varying** — which is the
+discriminator the earlier scaling rows could not be, since they vary the subject and hold the
+match count at one:
+
+| Global replace, 40 000-char subject | 500 matches | 2 500 | 5 000 | Slope |
+|---|--:|--:|--:|--:|
+| Before | 1 181 612 | 5 247 695 | 10 329 158 | **2 032.8 B/match** |
+| After | 409 588 | 1 363 919 | 2 561 870 | **478.3 B/match** |
+| | 0.35x | 0.26x | 0.25x | **0.235x** |
+
+Dead linear on both sides — 2 033.0 and 2 032.6 across the two independent intervals before the
+change — so the retained list was the whole of it, and the previous section's "5 000 × ~2 KB ≈
+10 MB" estimate was right to three digits rather than approximately. What is left at 478 B/match
+is the match data itself: the `RegexMatchData`, its capture array and the matched string.
+
+**The optimization is four lines; the guard is the item.** Appending each replacement as it is
+produced, instead of collecting first, is trivial. Establishing that nobody can *watch* the
+results being skipped is the entire design, and it needs three conditions at once:
+
+| Condition | Why, and what breaks without it |
+|---|---|
+| The receiver's `exec` **is** the pristine `%RegExp.prototype.exec%` | Every result is then a fresh array this function is the only holder of. A patched `exec` — own property or on the prototype — must run, and its results are the user's |
+| The replacement is a **string**, not a function | A functional replacer is user code running *between* matches |
+| That string contains **no `$`** | `$&`, `` $` ``, `$'`, `$n` and `$<name>` all read back through the result object |
+
+**Two of those three are not obvious from the item's own description, and one is a real trap.**
+The item says streaming "would change the observable order of `exec` calls against capture reads",
+which is true but understates the functional-replacer case: because the spec collects *all*
+matches before calling *any* replacer, the final failing `exec` has already reset `lastIndex` to
+**0** by the time user code first runs. A streamed replacer would instead see `lastIndex` sitting
+mid-subject, at a different value for every call. That is not a reordering, it is a different
+observable value, and `AFunctionalReplacerIsNotStreamed` pins it at `0,0`.
+
+**Identity against a pristine capture is the only sound form of the `exec` test.** `%RegExp.prototype.exec%`
+is captured into `JSContext.IntrinsicRegExpExec` at realm init, before any user code can run —
+the same mechanism `IntrinsicArrayValues` and `IntrinsicPromisePrototype` already use. Reading
+`RegExp.prototype.exec` later and comparing it to itself would be circular: by then it may
+already be the patched one.
+
+**Matching still goes through one shared code path.** `Exec` is split into `ExecMatch` — the
+`lastIndex` read and write, the match, the sticky re-check and the Annex B statics — and
+`BuildExecResult`, which is the part the fast path skips. Both callers use `ExecMatch`, so
+`lastIndex` progression, engine routing and the statics cannot drift between the two paths,
+because they are the same code rather than the same intention written twice. This is the same
+device 0059 used for step 16's property read order, and for the same reason.
+
+**Verify.** `GlobalReplaceStreamingAllocationTests` asserts the bytes and **fails on the build
+without the change** — 2 610 B/match against its 1 000 bound — while all 22 guard cases pass on
+*both* builds, which is what makes them regression guards rather than change detectors. They
+cover each exclusion (patched own `exec`, patched prototype `exec`, an `exec` returning null, a
+functional replacer, and every `$` form), the empty-match advance under `/u` and without it
+(asserted as code units, because a C# literal for a lone surrogate is its own trap), sticky with
+global, `lastIndex` after the call, and the Annex B statics.
+
+Repository suite **7 627 tests across 13 projects, 0 failures**. **test262 unchanged across all
+four pinned manifests — 8 313 executed, 8 220 passed, 84 failed, 44 skipped, 9 timed out,
+identical manifest by manifest**, at suite ref `ccaac100`. The replace-path manifest was re-run
+too: **499 tests, 484 passed, 13 failed, 2 timed out, and the failing set is identical file for
+file to the *pre-0059* control** — so both of this phase's follow-ups together move no test262
+file in either direction.
+
+
 #### Item 2 measured — and the obvious policy is the wrong one
 
 The single-run table above had one pattern losing badly under `Compiled`. Repeated three times
@@ -3117,7 +3206,7 @@ predicate at all.
 | **2** | 2-0 ✅ → 2-1 ✅ → 2-2 ✅ → 2-4 ✅ → 2-7 ✅ → 2-8 ✅ → **2-9 ✅** (2-3's successor, L); 2-5 and **2-3 closed on measurements**, 2-6 folded into 4-1. **Every item is landed or closed** | M each, 2-9 L | The Richards/DeltaBlue/Box2D cluster | An ownership entry and owned tests **per item**; test262 properties/strict-mode **satisfied** — unchanged at `a6f101cc` plus 2-9; **DeltaBlue and Richards inside 200×** still owed from 0-6 |
 | **3** | 3-0 ✅ (both halves) → 3-3 parameters ✅ → **3-3 `let`/`const`** → 3-1 → 3-2, then *cost* 3-4 | M, then L–XL | Uniform lift across arithmetic and allocation-heavy suites | `test262-arrays`, `test262-binary-data`; allocation reported per item alongside time |
 | **4** | 4-3 design ✅ → **4-1** (unblocked) → 4-3a (S) → 4-3b (M–L) → 4-2 → 4-4 | XL | The remaining order of magnitude | Deopt correctness proven **before** any speculation ships; full test262 matrix |
-| **5** | profile ✅ → per-match subject copy on `replace`/`exec` ✅ → single-match `replace` without a builder ✅ (both builtins) → **the global case's retained result list** → `Compiled` per pattern **measured, no policy shipped** → *then* consider compiling `Broiler.Regex` | L | RegExp, plus PdfJS and Typescript | Octane regex corpus profiled **before** any rewrite — **satisfied**, and it re-ordered the phase |
+| **5** | profile ✅ → per-match subject copy on `replace`/`exec` ✅ → single-match `replace` without a builder ✅ (both builtins) → the global case's retained result list ✅ → `Compiled` per pattern **measured, no policy shipped** → *then* consider compiling `Broiler.Regex` | L | RegExp, plus PdfJS and Typescript | Octane regex corpus profiled **before** any rewrite — **satisfied**, and it re-ordered the phase |
 
 **Dependencies.**
 

--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -73,7 +73,7 @@ the item's own section below, and nothing here is *closed* — see the acceptanc
 |---|---|
 | **0** — evidence | 0-1…0-5 ✅, 0-9…0-11 ✅. **0-6 (the CI Octane run) is still the critical path, but its headline question is answered**: run at the pinned pointer on linux-x64, Octane is **15 of 15 suites `ok` and 17 of 17 scores** — Mandreel included, which the previous local pass had failing. Geomean 217, spread **113×** against a same-machine Chromium reference. What 0-6 still owes is the *workflow* run plus 0-7's BenchmarkDotNet and 0-8's RID matrix, which a container cannot produce |
 | **1** — compile-time | 1-2's mitigation ✅ (`43bc4230`); **1-2's real fix is now on all three recursing passes** — the validator and emitter (`StackGuard` had three defects and could not fire), and now `FastParser`, whose descent aborted the process at 25 000 nesting levels **in the default configuration** and now survives 90 000 at no measurable cost. 1-1 open. 1-2's stated acceptance criterion **already passed before any work** — it measured size where the cause was nesting |
-| **2** — property access | **Every item landed or closed.** 2-0 ✅ 2-1 ✅ 2-2 ✅ 2-4 ✅ 2-7 ✅ 2-8 ✅ **2-9 ✅**; **2-3 and 2-5 closed on measurements**; 2-6 folded into 4-1. The phase's conformance gate is **satisfied**, and **its Octane exit criterion is now answered and splits: Richards is inside 200× at 183× (band 163–191) and DeltaBlue is not, at 576× (band 538–711)** — five repetitions per engine, same machine. **DeltaBlue is what phase 2 has left** (item **2-10**), and it is the suite 2-8 was written for. Its first pass found and fixed a real defect — `push` cost every array its shape permanently, **2 503 dictionary fallbacks → 0** — but that did **not** move DeltaBlue's read hit rate, which stays at **65.96% against Richards's 86.61%** and is the live lead. Decomposing those misses ruled out megamorphism (**0** megamorphic read sites) and, in passing, **found a live `class`-shaped instance of 2-0's defect**: `class C{}; new C()` publishes a global prototype invalidation **once per allocation** (2 002 for 2 000) where a `function` constructor publishes 1. Real, dead-linear, and **not** DeltaBlue's cause — Octane's DeltaBlue is ES5. Not fixed here Also outstanding: **2-9's ~20% compile-and-first-run cost still wants a follow-up — but not the one that was written.** Its losing-side hypothesis was measured against the control it never had (a *strict* function, which carries no Annex B deferred cells) and is **wrong**: every function materializes its trie **exactly once** whether strict or not, because the `prototype` install is withheld from shape-only storage by 2-8's DeltaBlue fix. "Stop materializing for a deferred cell" would have removed a materialization that already happened. The replacement candidate — split cache-visibility from shape-only storage — is specified and **not attempted**, since it is the code whose last regression broke DeltaBlue and it needs 0-6 |
+| **2** — property access | **Every item landed or closed.** 2-0 ✅ 2-1 ✅ 2-2 ✅ 2-4 ✅ 2-7 ✅ 2-8 ✅ **2-9 ✅**; **2-3 and 2-5 closed on measurements**; 2-6 folded into 4-1. The phase's conformance gate is **satisfied**, and **its Octane exit criterion is now answered and splits: Richards is inside 200× at 183× (band 163–191) and DeltaBlue is not, at 576× (band 538–711)** — five repetitions per engine, same machine. **DeltaBlue is what phase 2 has left** (item **2-10**), and it is the suite 2-8 was written for. Its first pass found and fixed a real defect — `push` cost every array its shape permanently, **2 503 dictionary fallbacks → 0** — but that did **not** move DeltaBlue's read hit rate, which stays at **65.96% against Richards's 86.61%** and is the live lead. Decomposing those misses ruled out megamorphism (**0** megamorphic read sites) and, in passing, **found a live `class`-shaped instance of 2-0's defect**: `class C{}; new C()` published a global prototype invalidation **once per allocation** (2 002 for 2 000). **Fixed as 2-11** — the setter no longer invalidates when the chain did not actually change — and the effect on the real suites is far larger than the class case suggested, because the retirement was process-wide: **Richards's read hit rate 86.61% → 99.97%**, DeltaBlue's 65.96% → 69.45%, Box2D's 96.39% → 97.72%, with invalidations 37 → 10, 2 519 → 16 and 1 944 → 107. **DeltaBlue still fails the gate at 516×**, so the phase's open item stands Also outstanding: **2-9's ~20% compile-and-first-run cost still wants a follow-up — but not the one that was written.** Its losing-side hypothesis was measured against the control it never had (a *strict* function, which carries no Annex B deferred cells) and is **wrong**: every function materializes its trie **exactly once** whether strict or not, because the `prototype` install is withheld from shape-only storage by 2-8's DeltaBlue fix. "Stop materializing for a deferred cell" would have removed a materialization that already happened. The replacement candidate — split cache-visibility from shape-only storage — is specified and **not attempted**, since it is the code whose last regression broke DeltaBlue and it needs 0-6 |
 | **3** — arithmetic | Started. **3-0 landed, both halves** — an indexed access boxed its index; a read now allocates **nothing at all** and a write loses ~32 B, on reference arrays as much as numeric ones. **3-1 measured before starting and re-specified**: it trades write allocation for read allocation 1:1, so its clean half is live memory. **3-3's parameter half landed** — and the measurement re-specified it: the gap was a per-call `JSVariable` **cell**, not a box, so a three-parameter call went **230.2 → 62.2 B**. **Probing that analysis before extending it found a wrong-answer bug shipped since P2-2** — two writes it could not see, one returning NaN and one aborting the process on valid JavaScript; fixed, at no measurable cost. Its `let`/`const` half was then **built, measured (31.98 → 0.00 B/iter) and withdrawn**: it miscompiles after any earlier compilation in the same process, including for bindings the gate never admits, so the reproduction is recorded instead of the change. 3-4 is a cost, not a task |
 | **4** — tiering | Open. **4-3's design is written** — and it re-specifies the item: this engine has no interpreter frame to reconstruct, so V8-style deopt has no counterpart here. Splits into 4-3a (state and enforce the restart contract the pilot already runs, S) and 4-3b (a generic fallback branch inside the specialized method, M–L), which gates 4-4 rather than all of phase 4. **4-1 can start now** |
 | **5** — regex | **Gate satisfied, and it overturns the phase.** `Matcher.cs` is not the default engine — `JSRegExp` routes only semantic-gap patterns to it, and Octane's corpus has no look-behind and no `u` flag, so it barely runs. The engine that does serve them is `System.Text.RegularExpressions` built **interpreted**; `RegexOptions.Compiled` is worth ~2× on six of seven real Octane patterns and a stable **4.3× against** on the seventh — a *trim* — so a use-count policy is ruled out. Largest regex cost measured was neither: `replace` with a global flag allocated **42 859 B per match**, because an Annex B legacy static copied the subject on every successful match — **fixed, 0.048x the bytes and 0.30x the time**. Decomposing what was left **per call** then found a single-match `replace` paying two full UTF-16 copies of the subject through a `StringBuilder`; concatenating three spans instead is **4.020 → 2.020 B per subject character, exactly the predicted halving**, and **the identical defect in `String.prototype.replace`'s string-`searchValue` builtin was found by reading the neighbouring code and fixed with it**. The global case's retained result list then landed too — **2 032.8 → 478.3 B per match**, dead linear on both sides, by streaming when the receiver's `exec` is the pristine intrinsic and the replacement is a `$`-free string. **Every follow-up this phase named is now closed**; what is left is item 2's `Compiled` policy, deliberately unshipped |
@@ -562,6 +562,14 @@ These were paid for once each. They apply to every phase below.
   construction path, and nothing in the record said so. *When a fix is verified through one
   syntax, name the syntax in the claim — the next reader will otherwise take the general
   statement, and a second path can carry the identical defect for as long as nobody spells it.*
+- **A process-wide invalidation makes every workload pay for the worst one.** The prototype
+  version is deliberately coarse — one mutation anywhere retires every prototype-keyed entry
+  everywhere — so a redundant write on one construction path held *Richards's* read cache at 86%
+  when the machinery was capable of 99.97%. Richards does not construct classes; it was paying
+  for someone else's writes. Every phase 2 probe measured the machinery in isolation, where the
+  storm does not exist, and all of them reported it working. *A shared invalidation channel turns
+  a local defect into a global one and hides it from every local measurement — the only
+  instrument that sees it is a counter taken over a whole real workload.*
 - **A counter that separates two workloads is a lead, not an explanation.** DeltaBlue fails
   phase 2's gate and Richards passes it, and of every inline-cache counter the sharpest split was
   dictionary fallbacks: **2 503 against 1**, three orders of magnitude. It traced to a real
@@ -2513,9 +2521,64 @@ the fix is the constructor-installs-the-prototype change 2-0 already made once, 
 code whose last two regressions (2-0's own, and 2-8's DeltaBlue break) both came from this area,
 and it wants the Octane cluster run against it — which is now possible.
 
+#### 2-11 · The redundant prototype write — **landed, and it is the largest cache win since 2-0**
+
+> **Delivered as a patch, not in the pin**:
+> [`patches/0063`](../patches/0063-js-prototype-rewrite-no-invalidate.patch). Independent of
+> `0059`–`0062` — one file, one condition.
+
+The class path was tracked to `JSClass.CreateInstance`, and the two obvious sites were already
+correct: the instance is built with `new JSObject(instancePrototype)`, carrying 2-0's own comment.
+What publishes is the **re-apply afterwards** — `@this.BasePrototypeObject = instancePrototype`,
+writing the prototype the constructor had *already installed*. `prototypeChain` is non-null by
+then, so the setter reads it as a `[[SetPrototypeOf]]` on a live object.
+
+**The fix is to notice that the chain did not change.** Every assumption the prototype version
+guards is about *which chain this object has*; after a redundant write it has the same one, so
+nothing cached is stale. The setter now compares the resulting chain with the previous one and
+publishes only on a real change — which fixes the class path, the derived-class path and any
+other redundant assignment at once, rather than patching call sites one at a time.
+
+| Construct, per *n* allocations | Before | After |
+|---|--:|--:|
+| `class C{…}; new C()`, n = 2 000 | 2 002 | **0** |
+| `function F(){…}; new F()`, n = 2 000 | 1 | **0** |
+| `class B extends A{…}; new B()`, any n | — | **2**, flat |
+
+**On the real suites the effect is much larger than the class case suggested**, because the
+retirement was process-wide — one redundant write anywhere retired every prototype-keyed entry
+everywhere. These are exact counts, not timings:
+
+| | Prototype invalidations | Read cache hit rate | Store hit rate |
+|---|--:|--:|--:|
+| **Richards** | 37 → **10** | 86.61% → **99.97%** | 99.74% → 99.75% |
+| **DeltaBlue** | 2 519 → **16** | 65.96% → **69.45%** | 80.65% → **83.92%** |
+| **Box2D** | 1 944 → **107** | 96.39% → **97.72%** | 92.57% → 92.98% |
+
+**Richards's read cache goes from missing one read in seven to missing one in three thousand.**
+That is the phase 2 machinery finally doing on a real suite what its probes always said it did,
+and it had been masked since the phase began by an invalidation storm none of the probes
+allocated their way into.
+
+> **The scores moved the right way and are *not* claimed.** Five repetitions per engine:
+> Richards 143 → 168 (178.7× → 155.4×) and DeltaBlue 122 → 125 (581× → 516×). Richards's **+17%
+> sits inside its own 15.5% band**, so a five-run median cannot separate it from noise — §3.2.
+> What is claimed is the hit-rate and invalidation columns, which are deterministic counts.
+
+**DeltaBlue still fails phase 2's exit criterion**, at 516× against the 200× gate, and its read
+hit rate is still 69% against Richards's 99.97%. So the gap narrowed and did not close, and the
+suite remains the phase's open item.
+
+**Verify.** Repository suite **7 563 tests across 13 projects, 0 failures**. **test262 unchanged
+across all four pinned manifests — 8 313 / 8 220 / 84 / 44 / 9, identical manifest by manifest**;
+`test262-arrays` matters doubly here because the same version gates `JSArray`'s dense-element fast
+path, and `properties-proxy` and `realm-isolation` are where a wrongly-skipped invalidation would
+surface. Octane still runs 15 of 15 suites `ok`.
+
 **What 2-10's successor still owes** is the actual per-site attribution: *which* read sites in
-DeltaBlue miss, and why, given that they are neither megamorphic nor — now — explained by either
-of the two counters that looked most promising.
+DeltaBlue miss, and why. Two counters have now been ruled out and one storm removed, and the
+suite is still at 69% — so the remaining misses are not invalidation, not megamorphism and not
+dictionary mode.
 
 ---
 

--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -32,7 +32,9 @@ so only the parent can hold the combined view.
   [`patches/0060`](../patches/0060-js-stream-global-replace.patch) — **in that order**, since
   `0060` builds on the function `0059` restructures — and the pointer is deliberately unbumped.
   Their figures below were measured on a local build of `2ebc0c3c` **plus** those patches,
-  control and change from the same tree.
+  control and change from the same tree. **Item 2-9's follow-up measurement is
+  [`patches/0061`](../patches/0061-js-measure-2-9-materialization-cause.patch)**, independent of
+  those two and measured on the pin alone.
   `a6f101cc` — which this section named until 3-3
   was worked, and which every §0 and phase-2 measurement below was taken at — is an **ancestor**
   of it (`merge-base --is-ancestor`), so nothing recorded here is invalidated;
@@ -71,7 +73,7 @@ the item's own section below, and nothing here is *closed* — see the acceptanc
 |---|---|
 | **0** — evidence | 0-1…0-5 ✅, 0-9…0-11 ✅. **0-6 (the CI Octane run) is the critical path** — it is what phases A–F need to close on, and what phase 2's exit criterion is measured by. 0-7, 0-8 follow it |
 | **1** — compile-time | 1-2's mitigation ✅ (`43bc4230`); **1-2's real fix is now on all three recursing passes** — the validator and emitter (`StackGuard` had three defects and could not fire), and now `FastParser`, whose descent aborted the process at 25 000 nesting levels **in the default configuration** and now survives 90 000 at no measurable cost. 1-1 open. 1-2's stated acceptance criterion **already passed before any work** — it measured size where the cause was nesting |
-| **2** — property access | **Every item landed or closed.** 2-0 ✅ 2-1 ✅ 2-2 ✅ 2-4 ✅ 2-7 ✅ 2-8 ✅ **2-9 ✅**; **2-3 and 2-5 closed on measurements**; 2-6 folded into 4-1. The phase's conformance gate is **satisfied**; 0-6's CI Octane run is outstanding, and **2-9's ~20% compile-and-first-run cost wants a follow-up** (stop materializing for a deferred cell) |
+| **2** — property access | **Every item landed or closed.** 2-0 ✅ 2-1 ✅ 2-2 ✅ 2-4 ✅ 2-7 ✅ 2-8 ✅ **2-9 ✅**; **2-3 and 2-5 closed on measurements**; 2-6 folded into 4-1. The phase's conformance gate is **satisfied**; 0-6's CI Octane run is outstanding, and **2-9's ~20% compile-and-first-run cost still wants a follow-up — but not the one that was written.** Its losing-side hypothesis was measured against the control it never had (a *strict* function, which carries no Annex B deferred cells) and is **wrong**: every function materializes its trie **exactly once** whether strict or not, because the `prototype` install is withheld from shape-only storage by 2-8's DeltaBlue fix. "Stop materializing for a deferred cell" would have removed a materialization that already happened. The replacement candidate — split cache-visibility from shape-only storage — is specified and **not attempted**, since it is the code whose last regression broke DeltaBlue and it needs 0-6 |
 | **3** — arithmetic | Started. **3-0 landed, both halves** — an indexed access boxed its index; a read now allocates **nothing at all** and a write loses ~32 B, on reference arrays as much as numeric ones. **3-1 measured before starting and re-specified**: it trades write allocation for read allocation 1:1, so its clean half is live memory. **3-3's parameter half landed** — and the measurement re-specified it: the gap was a per-call `JSVariable` **cell**, not a box, so a three-parameter call went **230.2 → 62.2 B**. **Probing that analysis before extending it found a wrong-answer bug shipped since P2-2** — two writes it could not see, one returning NaN and one aborting the process on valid JavaScript; fixed, at no measurable cost. Its `let`/`const` half was then **built, measured (31.98 → 0.00 B/iter) and withdrawn**: it miscompiles after any earlier compilation in the same process, including for bindings the gate never admits, so the reproduction is recorded instead of the change. 3-4 is a cost, not a task |
 | **4** — tiering | Open. **4-3's design is written** — and it re-specifies the item: this engine has no interpreter frame to reconstruct, so V8-style deopt has no counterpart here. Splits into 4-3a (state and enforce the restart contract the pilot already runs, S) and 4-3b (a generic fallback branch inside the specialized method, M–L), which gates 4-4 rather than all of phase 4. **4-1 can start now** |
 | **5** — regex | **Gate satisfied, and it overturns the phase.** `Matcher.cs` is not the default engine — `JSRegExp` routes only semantic-gap patterns to it, and Octane's corpus has no look-behind and no `u` flag, so it barely runs. The engine that does serve them is `System.Text.RegularExpressions` built **interpreted**; `RegexOptions.Compiled` is worth ~2× on six of seven real Octane patterns and a stable **4.3× against** on the seventh — a *trim* — so a use-count policy is ruled out. Largest regex cost measured was neither: `replace` with a global flag allocated **42 859 B per match**, because an Annex B legacy static copied the subject on every successful match — **fixed, 0.048x the bytes and 0.30x the time**. Decomposing what was left **per call** then found a single-match `replace` paying two full UTF-16 copies of the subject through a `StringBuilder`; concatenating three spans instead is **4.020 → 2.020 B per subject character, exactly the predicted halving**, and **the identical defect in `String.prototype.replace`'s string-`searchValue` builtin was found by reading the neighbouring code and fixed with it**. The global case's retained result list then landed too — **2 032.8 → 478.3 B per match**, dead linear on both sides, by streaming when the receiver's `exec` is the pristine intrinsic and the replacement is a `$`-free string. **Every follow-up this phase named is now closed**; what is left is item 2's `Compiled` policy, deliberately unshipped |
@@ -548,6 +550,21 @@ These were paid for once each. They apply to every phase below.
   — 4.020 B/char both — which is what established them as one defect in two places rather than
   two resembling ones. *When a profile localizes a cost to a mechanism, grep for the mechanism;
   the corpus only measures what somebody thought to add to it.*
+- **A hypothesis with a plausible mechanism still needs the control that would refute it.** 2-9's
+  losing side was explained by the Annex B deferred cells forcing a trie rebuild — a mechanism
+  read straight off the code, correct in every step, and wrong about the cause. The control that
+  settles it is one line of JavaScript: a **strict** function gets no deferred cells, so if the
+  cells are the cause it must not pay. It pays exactly the same — 1.00 trie rebuilds per function
+  on both — because the `prototype` install materializes first, for an unrelated correctness
+  reason. *The question "what would I expect to see if this were false" has an answer that is
+  usually cheaper to run than the fix the hypothesis implies, and running it first is what stops
+  a fix being built for a cause that was not there.*
+- **Count the thing, do not infer it from bytes.** The same hypothesis had been probed by
+  allocation, where the deferred cells do show up — non-strict functions cost 4.8% more than
+  strict, which reads like confirmation. A counter on the rebuild itself says 1.00 on both, and
+  the 4.8% turns out to be the cells' own price and nothing to do with the trie. *An indirect
+  instrument agreeing with you is weaker evidence than a direct one, and adding the direct one
+  here was six lines.*
 - **When an optimization skips work, the design is the observers, not the work.** Phase 5's
   streaming replace is four lines: append each replacement instead of collecting them all. Every
   hour of it went into establishing that nobody could watch the skipped result objects — and two
@@ -1931,7 +1948,66 @@ movements is claimed here.** What is claimed is the allocation result, which is 
 and the compile-throughput cost, which reproduced across three separate measurement rounds.
 **The right follow-up is to stop materializing for a deferred cell** — the null-slot key it
 records needs its descriptor somewhere other than the trie — which would test the hypothesis and,
-if it holds, remove the loss.
+if it holds, remove the loss. ***It does not hold. See below: the hypothesis was measured against
+its own control and is wrong, and that follow-up would not have removed the loss.***
+
+#### The losing-side hypothesis was measured, and it is wrong — **`prototype` is what materializes**
+
+> **Delivered as a patch, not in the pin**, for the same 403 as phase 5's:
+> [`patches/0061`](../patches/0061-js-measure-2-9-materialization-cause.patch), which is
+> **measurement and instrumentation only — no behaviour change** — and is independent of
+> `0059`/`0060`, touching a disjoint set of files.
+
+The mechanism above was recorded as a hypothesis and flagged *"do not treat as settled"*. It is
+now settled, and against it. **A strict function is the control it never had**:
+`AddLegacyCallerAndArguments` runs for non-strict functions only, so if the Annex B deferred cells
+are what forces the trie, a strict function must not pay it.
+
+`--deferred-cell-cost` (new; `DeferredCellCostMetrics`) builds 4 000 functions each way, and a
+new `RecordNamedPropertiesMaterialized` counter reports trie rebuilds directly rather than
+inferring them from bytes:
+
+| Site | B/function | ns/function | **materializations/function** |
+|---|--:|--:|--:|
+| `nonstrict-create` | 356 421 | 4 667 190 | **1.00** |
+| `strict-create` | 340 161 | 4 900 524 | **1.00** |
+| `nonstrict-create-and-call` | 356 226 | 8 693 125 | **1.00** |
+| `strict-create-and-call` | 340 426 | 9 245 164 | **1.00** |
+
+**Exactly one materialization per function, on all four rows.** A strict function — which has no
+deferred cells at all — rebuilds its trie just as surely as a non-strict one, so the deferred
+cells cannot be what causes it. The wall clock says the same thing from the other side: strict is
+*marginally slower*, not faster, on both halves.
+
+**What actually materializes is the `prototype` install, and it is a correctness rule doing it.**
+Traced to `JSFunction..ctor`, whose three own-key writes are `length`, `name`, `prototype` — the
+first two stay shape-only and the third does not, because
+`JSFunction.AllowsDirectShapeWrite(uint key) => key != KeyStrings.prototype.Key` withholds that
+one key. `FastAddValue` then falls off `TryShapeOnlySetDataProperty` to `OwnProperties()`, which
+materializes. **That withhold is 2-8's DeltaBlue fix** — a cached prototype write left the second
+level of every inheritance chain unlinked — so it is load-bearing, not an oversight.
+
+**So the item is re-specified, and the planned fix is withdrawn before it was built.** Stopping
+the deferred-cell materialization would remove a materialization that has already happened: every
+function with a `prototype` has materialized before either Annex B cell is installed. The
+non-strict rows do cost **4.8% more bytes** than strict, which is the cells' real price — but it
+is a per-function 4.8%, not the compile-and-first-run loss the item is trying to explain.
+
+**The candidate that replaces it, not started and deliberately not attempted here.** The withhold
+exists so an *inline cache* cannot answer for `prototype`; shape-only *storage* is a different
+question, and `AllowsDirectShapeWrite` is currently the single answer to both — it is consulted at
+five sites, two of which are storage (`TryShapeOnlyOverwrite`, `TryShapeOnlySetDataProperty`) and
+three of which are cache paths. Splitting the two would let `prototype` live in a slot while
+staying invisible to the cache. **It is not attempted here because this is exactly the code whose
+last regression broke DeltaBlue outright**, and §3.5's own rule is that a change justified by a
+benchmark has to be run against that benchmark — which needs 0-6. The measurement is the
+deliverable; the fix is specified and left.
+
+**The first call is still unexplained, and it is not allocation.** The call roughly doubles wall
+clock (4.7 M → 8.7 M ns per function) while adding **no** managed bytes at all — the
+create-and-call rows are within 200 B of the create-only rows, on both halves. Whatever the
+first-call cost is, it allocates nothing and does not split on strictness, which rules out both
+the deferred cells and the trie. That narrows the item's open question rather than closing it.
 
 #### It holds on real programs — `--property-map-distribution`, before and after
 

--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -73,7 +73,7 @@ the item's own section below, and nothing here is *closed* — see the acceptanc
 |---|---|
 | **0** — evidence | 0-1…0-5 ✅, 0-9…0-11 ✅. **0-6 (the CI Octane run) is still the critical path, but its headline question is answered**: run at the pinned pointer on linux-x64, Octane is **15 of 15 suites `ok` and 17 of 17 scores** — Mandreel included, which the previous local pass had failing. Geomean 217, spread **113×** against a same-machine Chromium reference. What 0-6 still owes is the *workflow* run plus 0-7's BenchmarkDotNet and 0-8's RID matrix, which a container cannot produce |
 | **1** — compile-time | 1-2's mitigation ✅ (`43bc4230`); **1-2's real fix is now on all three recursing passes** — the validator and emitter (`StackGuard` had three defects and could not fire), and now `FastParser`, whose descent aborted the process at 25 000 nesting levels **in the default configuration** and now survives 90 000 at no measurable cost. 1-1 open. 1-2's stated acceptance criterion **already passed before any work** — it measured size where the cause was nesting |
-| **2** — property access | **Every item landed or closed.** 2-0 ✅ 2-1 ✅ 2-2 ✅ 2-4 ✅ 2-7 ✅ 2-8 ✅ **2-9 ✅**; **2-3 and 2-5 closed on measurements**; 2-6 folded into 4-1. The phase's conformance gate is **satisfied**, and **its Octane exit criterion is now answered and splits: Richards is inside 200× at 183× (band 163–191) and DeltaBlue is not, at 576× (band 538–711)** — five repetitions per engine, same machine. **DeltaBlue is what phase 2 has left** (item **2-10**), and it is the suite 2-8 was written for. Its first pass found and fixed a real defect — `push` cost every array its shape permanently, **2 503 dictionary fallbacks → 0** — but that did **not** move DeltaBlue's read hit rate, which stays at **65.96% against Richards's 86.61%** and is the live lead. Decomposing those misses ruled out megamorphism (**0** megamorphic read sites) and, in passing, **found a live `class`-shaped instance of 2-0's defect**: `class C{}; new C()` published a global prototype invalidation **once per allocation** (2 002 for 2 000). **Fixed as 2-11** — the setter no longer invalidates when the chain did not actually change — and the effect on the real suites is far larger than the class case suggested, because the retirement was process-wide: **Richards's read hit rate 86.61% → 99.97%**, DeltaBlue's 65.96% → 69.45%, Box2D's 96.39% → 97.72%, with invalidations 37 → 10, 2 519 → 16 and 1 944 → 107. **DeltaBlue still fails the gate at 516×**, so the phase's open item stands Also outstanding: **2-9's ~20% compile-and-first-run cost still wants a follow-up — but not the one that was written.** Its losing-side hypothesis was measured against the control it never had (a *strict* function, which carries no Annex B deferred cells) and is **wrong**: every function materializes its trie **exactly once** whether strict or not, because the `prototype` install is withheld from shape-only storage by 2-8's DeltaBlue fix. "Stop materializing for a deferred cell" would have removed a materialization that already happened. The replacement candidate — split cache-visibility from shape-only storage — is specified and **not attempted**, since it is the code whose last regression broke DeltaBlue and it needs 0-6 |
+| **2** — property access | **Every item landed or closed.** 2-0 ✅ 2-1 ✅ 2-2 ✅ 2-4 ✅ 2-7 ✅ 2-8 ✅ **2-9 ✅**; **2-3 and 2-5 closed on measurements**; 2-6 folded into 4-1. The phase's conformance gate is **satisfied**, and **its Octane exit criterion is now answered and splits: Richards is inside 200× at 183× (band 163–191) and DeltaBlue is not, at 576× (band 538–711)** — five repetitions per engine, same machine. **DeltaBlue is what phase 2 has left** (item **2-10**), and it is the suite 2-8 was written for. Its first pass found and fixed a real defect — `push` cost every array its shape permanently, **2 503 dictionary fallbacks → 0** — but that did **not** move DeltaBlue's read hit rate, which stays at **65.96% against Richards's 86.61%** and is the live lead. Decomposing those misses ruled out megamorphism (**0** megamorphic read sites) and, in passing, **found a live `class`-shaped instance of 2-0's defect**: `class C{}; new C()` published a global prototype invalidation **once per allocation** (2 002 for 2 000). **Fixed as 2-11** — the setter no longer invalidates when the chain did not actually change — and the effect on the real suites is far larger than the class case suggested, because the retirement was process-wide: **Richards's read hit rate 86.61% → 99.97%**, DeltaBlue's 65.96% → 69.45%, Box2D's 96.39% → 97.72%, with invalidations 37 → 10, 2 519 → 16 and 1 944 → 107. Then **2-12** found why the misses that remained could never heal: the cache's add path deduplicated on two keys while a hit checked six, so a stale entry was declined rather than refreshed and its site missed for the rest of the process — **77.7% of DeltaBlue's misses**. Refreshing in place takes **DeltaBlue's read hit rate to 93.16%** (65.96% before both fixes) and Box2D's to 98.83%. **DeltaBlue still fails the gate at 447×**, but the cache is no longer the reason, and what remains is not property-cache-shaped Also outstanding: **2-9's ~20% compile-and-first-run cost still wants a follow-up — but not the one that was written.** Its losing-side hypothesis was measured against the control it never had (a *strict* function, which carries no Annex B deferred cells) and is **wrong**: every function materializes its trie **exactly once** whether strict or not, because the `prototype` install is withheld from shape-only storage by 2-8's DeltaBlue fix. "Stop materializing for a deferred cell" would have removed a materialization that already happened. The replacement candidate — split cache-visibility from shape-only storage — is specified and **not attempted**, since it is the code whose last regression broke DeltaBlue and it needs 0-6 |
 | **3** — arithmetic | Started. **3-0 landed, both halves** — an indexed access boxed its index; a read now allocates **nothing at all** and a write loses ~32 B, on reference arrays as much as numeric ones. **3-1 measured before starting and re-specified**: it trades write allocation for read allocation 1:1, so its clean half is live memory. **3-3's parameter half landed** — and the measurement re-specified it: the gap was a per-call `JSVariable` **cell**, not a box, so a three-parameter call went **230.2 → 62.2 B**. **Probing that analysis before extending it found a wrong-answer bug shipped since P2-2** — two writes it could not see, one returning NaN and one aborting the process on valid JavaScript; fixed, at no measurable cost. Its `let`/`const` half was then **built, measured (31.98 → 0.00 B/iter) and withdrawn**: it miscompiles after any earlier compilation in the same process, including for bindings the gate never admits, so the reproduction is recorded instead of the change. 3-4 is a cost, not a task |
 | **4** — tiering | Open. **4-3's design is written** — and it re-specifies the item: this engine has no interpreter frame to reconstruct, so V8-style deopt has no counterpart here. Splits into 4-3a (state and enforce the restart contract the pilot already runs, S) and 4-3b (a generic fallback branch inside the specialized method, M–L), which gates 4-4 rather than all of phase 4. **4-1 can start now** |
 | **5** — regex | **Gate satisfied, and it overturns the phase.** `Matcher.cs` is not the default engine — `JSRegExp` routes only semantic-gap patterns to it, and Octane's corpus has no look-behind and no `u` flag, so it barely runs. The engine that does serve them is `System.Text.RegularExpressions` built **interpreted**; `RegexOptions.Compiled` is worth ~2× on six of seven real Octane patterns and a stable **4.3× against** on the seventh — a *trim* — so a use-count policy is ruled out. Largest regex cost measured was neither: `replace` with a global flag allocated **42 859 B per match**, because an Annex B legacy static copied the subject on every successful match — **fixed, 0.048x the bytes and 0.30x the time**. Decomposing what was left **per call** then found a single-match `replace` paying two full UTF-16 copies of the subject through a `StringBuilder`; concatenating three spans instead is **4.020 → 2.020 B per subject character, exactly the predicted halving**, and **the identical defect in `String.prototype.replace`'s string-`searchValue` builtin was found by reading the neighbouring code and fixed with it**. The global case's retained result list then landed too — **2 032.8 → 478.3 B per match**, dead linear on both sides, by streaming when the receiver's `exec` is the pristine intrinsic and the replacement is a `$`-free string. **Every follow-up this phase named is now closed**; what is left is item 2's `Compiled` policy, deliberately unshipped |
@@ -562,6 +562,14 @@ These were paid for once each. They apply to every phase below.
   construction path, and nothing in the record said so. *When a fix is verified through one
   syntax, name the syntax in the claim — the next reader will otherwise take the general
   statement, and a second path can carry the identical defect for as long as nobody spells it.*
+- **A cache entry that cannot be replaced is worse than no entry.** The inline cache's add path
+  deduplicated on `ShapeId` + `Holder`; a hit checked those plus four more guards. When one of the
+  four went stale the read missed, reached the add path, was told the entry was already present,
+  and returned — leaving the stale entry in place with no route back. That site then missed on
+  that receiver forever, and it was **77.7% of DeltaBlue's misses**. A cold site would have
+  recovered on its second read; this one could not recover at all. *Whenever a lookup and an
+  insert disagree about what identifies an entry, the insert wins and the lookup starves — check
+  that the dedup key is the whole guard, not a prefix of it.*
 - **A process-wide invalidation makes every workload pay for the worst one.** The prototype
   version is deliberately coarse — one mutation anywhere retires every prototype-keyed entry
   everywhere — so a redundant write on one construction path held *Richards's* read cache at 86%
@@ -2575,10 +2583,67 @@ across all four pinned manifests — 8 313 / 8 220 / 84 / 44 / 9, identical mani
 path, and `properties-proxy` and `realm-isolation` are where a wrongly-skipped invalidation would
 surface. Octane still runs 15 of 15 suites `ok`.
 
-**What 2-10's successor still owes** is the actual per-site attribution: *which* read sites in
-DeltaBlue miss, and why. Two counters have now been ruled out and one storm removed, and the
-suite is still at 69% — so the remaining misses are not invalidation, not megamorphism and not
-dictionary mode.
+#### 2-12 · The stale cache entry that could never be replaced — **DeltaBlue 69% → 93%**
+
+> **Delivered as a patch, not in the pin**:
+> [`patches/0064`](../patches/0064-js-refresh-stale-cache-entry.patch). Needs `0061` (the counter
+> infrastructure) and `0062` (the emitter) to compile.
+
+2-10 owed a per-site attribution, and this is it. The bare miss counter cannot say *why* a read
+missed, so the lookup's exits are now counted separately:
+
+| | Richards (99.97%) | **DeltaBlue (69.45%)** | Box2D (97.72%) |
+|---|--:|--:|--:|
+| total read misses | 208 | 306 004 | 592 263 |
+| cold — first touch of a site | 84.1% | **0.1%** | 0.9% |
+| **shape — site had room, receiver's shape not among its entries** | 15.9% | **99.9%** | 99.1% |
+| megamorphic / key mismatch / non-object | 0 | **0** | ~0 |
+
+**Effectively every DeltaBlue miss is the same exit**, and it is the one that should be
+self-correcting: a site with room that meets a new shape is supposed to *add* it and hit from
+then on. Splitting that exit further found why it does not:
+
+| | Richards | **DeltaBlue** | Box2D |
+|---|--:|--:|--:|
+| entry could not be described at all | 11 | 67 874 | 297 786 |
+| **entry ALREADY PRESENT — declined, not refreshed** | 28 | **237 738 (77.7% of all misses)** | 288 980 |
+
+**The add path deduplicates on `ShapeId` and `Holder`. A hit checks four more guards** — the
+prototype version, the receiver's prototype identity, and the holder's shape and slot. Any of
+those can go stale while the two dedup keys stay equal, and when they do the read misses, reaches
+the add path, finds an entry it considers "already present", and **returns without replacing it**.
+The entry can never be re-described, so that site misses on that receiver **for the rest of the
+process**.
+
+**The fix is one line: refresh in place instead of declining.** `entryToAdd` was just built from
+the live receiver, so it is by construction the correct replacement.
+
+| | Read hit rate | Read misses |
+|---|--:|--:|
+| **DeltaBlue** | 69.45% → **93.16%** | 306 004 → **68 534** |
+| **Box2D** | 97.72% → **98.83%** | 592 263 → **303 612** |
+| Richards | 99.97% → 99.97% | 208 → 192 |
+
+**Taken with 2-11, DeltaBlue's read cache goes 65.96% → 93.16%** and its misses fall by 78%.
+Richards was already at the ceiling and stays there, which is the control working: it had almost
+no stale entries to refresh.
+
+> **Scores moved and are still not claimed.** Five repetitions per engine: DeltaBlue **125 → 145**
+> (516× → **447×**) and Richards 168 → 170 (155× → 150×). DeltaBlue's +16% against a 13.8% band is
+> at the edge, not clear of it. Across this session the suite has gone 116 → 145 and 576× → 447×,
+> which is the direction the deterministic counters predict — but §3.2's rule stands, and what is
+> claimed here is the hit-rate column.
+
+**DeltaBlue still fails phase 2's exit criterion**, at 447× against 200×. The cache is no longer
+the reason: at 93% it is closer to Box2D (98.8%, and 144×) than to its own former self, yet its
+ratio is still three times Box2D's. **Whatever is left is not property-cache-shaped**, and that is
+a genuinely new state for this item — three explanations eliminated, two defects fixed, and the
+remaining gap now has to be looked for somewhere other than phase 2's subject.
+
+**Verify.** Repository suite **7 627 tests across 13 projects, 0 failures**. **test262 unchanged
+across all four pinned manifests — 8 313 / 8 220 / 84 / 44 / 9, identical manifest by manifest.**
+The change cannot return a wrong value: a refreshed entry is still checked by every guard on the
+next read, and the entry it replaces was one the guards had just rejected.
 
 ---
 
@@ -3577,7 +3642,7 @@ predicate at all.
 |---|---|---|---|---|
 | **0** | 0-1…0-5 ✅, 0-9…0-11 ✅ → **0-6 (CI — 17/17 established at the pin locally; the workflow run is still owed) → 0-7, 0-8** | — | Everything. 12 → **17 scores**, known noise band, and the first evidence any phase A–F can close on | 17/17, no timeout at the 180 s floor, band on record, `comparison.md` reporting the triad, **and the BenchmarkDotNet + RID-matrix rows collected** |
 | **1** | 1-2 mitigation ✅ → 1-2 real fix ✅ (all three passes) → **1-1** → 1-3 measure | XL | The two worst scores in the suite; page-load time generally | test262 over the four pinned manifests, no new failure **and no new timeout**; MandreelLatency and CodeLoad out of the tail |
-| **2** | 2-0 ✅ → 2-1 ✅ → 2-2 ✅ → 2-4 ✅ → 2-7 ✅ → 2-8 ✅ → **2-9 ✅** (2-3's successor, L); 2-5 and **2-3 closed on measurements**, 2-6 folded into 4-1. **Every item is landed or closed** | M each, 2-9 L | The Richards/DeltaBlue/Box2D cluster | An ownership entry and owned tests **per item**; test262 properties/strict-mode **satisfied** — unchanged at `a6f101cc` plus 2-9; **DeltaBlue and Richards inside 200×** — **measured: Richards 183× PASSES, DeltaBlue 576× FAILS**, five repetitions per engine on one machine |
+| **2** | 2-0 ✅ → 2-1 ✅ → 2-2 ✅ → 2-4 ✅ → 2-7 ✅ → 2-8 ✅ → **2-9 ✅** (2-3's successor, L); 2-5 and **2-3 closed on measurements**, 2-6 folded into 4-1. **Every item is landed or closed** | M each, 2-9 L | The Richards/DeltaBlue/Box2D cluster | An ownership entry and owned tests **per item**; test262 properties/strict-mode **satisfied** — unchanged at `a6f101cc` plus 2-9; **DeltaBlue and Richards inside 200×** — **measured: Richards PASSES (183× → 150× after 2-11/2-12), DeltaBlue FAILS (576× → 447×)**, five repetitions per engine on one machine |
 | **3** | 3-0 ✅ (both halves) → 3-3 parameters ✅ → **3-3 `let`/`const`** → 3-1 → 3-2, then *cost* 3-4 | M, then L–XL | Uniform lift across arithmetic and allocation-heavy suites | `test262-arrays`, `test262-binary-data`; allocation reported per item alongside time |
 | **4** | 4-3 design ✅ → **4-1** (unblocked) → 4-3a (S) → 4-3b (M–L) → 4-2 → 4-4 | XL | The remaining order of magnitude | Deopt correctness proven **before** any speculation ships; full test262 matrix |
 | **5** | profile ✅ → per-match subject copy on `replace`/`exec` ✅ → single-match `replace` without a builder ✅ (both builtins) → the global case's retained result list ✅ → `Compiled` per pattern **measured, no policy shipped** → *then* consider compiling `Broiler.Regex` | L | RegExp, plus PdfJS and Typescript | Octane regex corpus profiled **before** any rewrite — **satisfied**, and it re-ordered the phase |

--- a/patches/0059-js-single-match-replace-one-allocation.patch
+++ b/patches/0059-js-single-match-replace-one-allocation.patch
@@ -1,0 +1,339 @@
+From aca06ebe2de0212eebd237c1eb252fd1d72cffd6 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 2 Aug 2026 23:19:36 +0000
+Subject: [PATCH] Assemble a single-match replace with one allocation, not a
+ builder
+
+RegExp.prototype[@@replace] accumulated into a StringBuilder whatever the match
+count. For one match the answer is exactly prefix + replacement + suffix, so
+string.Concat over three spans writes it into ONE allocation of the final
+length, and the builder's two copies -- into its chunk list, then back out
+through ToString() -- become one.
+
+Measured per call at three subject lengths, both sides built from the same tree:
+4.020 -> 2.020 bytes per subject character, exactly the halving the previous
+decomposition predicted. Getting exactly half is the load-bearing part: it
+confirms the 4 B/char was two copies of the subject and nothing else. The test
+and exec rows are byte-identical on both sides and are the control.
+
+The same three-append assembly was one file over, in String.prototype.replace's
+string-searchValue path -- a different builtin that never reaches @@replace and
+replaces only the first occurrence, so it is single-match by construction. Its
+builder was already sized exactly right, which is the cleanest case for why
+pre-sizing does not help: it halved by the same amount, 4.020 -> 2.020. Found by
+reading the neighbouring builtin, not by the profile, which had no row for it;
+--regex-profile now carries replace-one-string beside replace-one.
+
+A global regexp that matches once takes the fast path too -- the gate is
+results.Count == 1, not the g flag -- and step 16.p's backwards-position guard
+cannot apply to a single result, so the fast path is the loop's behaviour rather
+than an approximation of it. Step 16's observable property read order is kept in
+one shared local function so it cannot drift between the two paths.
+
+SingleMatchReplaceAllocationTests asserts the bytes and fails on the build
+without the change (95 881 B/call against a 60 000 bound); its answer cases pass
+on both builds, which makes them regression guards rather than change detectors.
+Repository suite 7 604 tests across 13 projects, 0 failures. test262 unchanged
+across all four pinned manifests -- 8 313 executed, 8 220 passed, 84 failed, 44
+skipped, 9 timed out, identical manifest by manifest. The pinned manifests carry
+no replace coverage, so the touched paths were run separately control against
+change: 499 tests, 484 passed, 13 failed, 2 timed out, failing set identical
+file for file, and no failure in a replace directory.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ .../BuiltInsAssemblyInitializer.cs            |  32 ++-
+ .../String/JSStringPrototype.Pattern.cs       |  14 +-
+ .../SingleMatchReplaceAllocationTests.cs      | 189 ++++++++++++++++++
+ .../RegexProfileMetrics.cs                    |   4 +
+ 4 files changed, 230 insertions(+), 9 deletions(-)
+ create mode 100644 Broiler.JS/Broiler.JavaScript.Integration.Tests/SingleMatchReplaceAllocationTests.cs
+
+diff --git a/Broiler.JS/Broiler.JavaScript.BuiltIns/BuiltInsAssemblyInitializer.cs b/Broiler.JS/Broiler.JavaScript.BuiltIns/BuiltInsAssemblyInitializer.cs
+index 9eba4e47..b14693ea 100644
+--- a/Broiler.JS/Broiler.JavaScript.BuiltIns/BuiltInsAssemblyInitializer.cs
++++ b/Broiler.JS/Broiler.JavaScript.BuiltIns/BuiltInsAssemblyInitializer.cs
+@@ -1650,9 +1650,12 @@ internal static class BuiltInsAssemblyInitializer
+             if (results.Count == 0)
+                 return JSValue.CreateString(input);
+ 
+-            var accumulatedResult = new StringBuilder();
+-            var nextSourcePosition = 0;
+-            foreach (var result in results)
++            // §22.2.6.11 step 16 for one result. Extracted so the single-match fast path
++            // below and the accumulating loop read the result's properties in exactly the
++            // same observable order — the order test262 sm/RegExp/replace-trace pins. It is
++            // called directly and never as a delegate, so the capture is a struct closure
++            // and costs no allocation.
++            (int Position, string Matched, string Replacement) OneReplacement(JSValue result)
+             {
+                 // §22.2.6.11 step 16 evaluates the result properties in this exact order:
+                 // LengthOfArrayLike ("length") → Get "0" → Get "index" → captures loop
+@@ -1710,6 +1713,29 @@ internal static class BuiltInsAssemblyInitializer
+                     replacement = GetSubstitution(matched, input, position, captures, normalizedNamedCaptures, replacementText);
+                 }
+ 
++                return (position, matched, replacement);
++            }
++
++            // A single match needs no builder. The result is exactly prefix + replacement +
++            // suffix, and string.Concat writes those three spans into one allocation of the
++            // final length; the builder path costs two full copies of the subject — its
++            // chunks, then ToString() — which measured ~4 bytes per subject character. The
++            // step 16.p guard below cannot apply here: nextSourcePosition is still 0 on the
++            // first result and position is clamped to [0, lengthS], so position >= 0 holds.
++            if (results.Count == 1)
++            {
++                var (position, matched, replacement) = OneReplacement(results[0]);
++                var sourceTail = Math.Min(position + matched.Length, input.Length);
++                return JSValue.CreateString(string.Concat(
++                    input.AsSpan(0, position), replacement.AsSpan(), input.AsSpan(sourceTail)));
++            }
++
++            var accumulatedResult = new StringBuilder();
++            var nextSourcePosition = 0;
++            foreach (var result in results)
++            {
++                var (position, matched, replacement) = OneReplacement(result);
++
+                 // §22.2.6.11 step 16.p: only accumulate the replacement when position has
+                 // not moved backwards. An ill-behaving subclass whose exec returns a result
+                 // with index < nextSourcePosition (e.g. the test262 g-pos-decrement case)
+diff --git a/Broiler.JS/Broiler.JavaScript.BuiltIns/String/JSStringPrototype.Pattern.cs b/Broiler.JS/Broiler.JavaScript.BuiltIns/String/JSStringPrototype.Pattern.cs
+index 4576f0ce..7d434677 100644
+--- a/Broiler.JS/Broiler.JavaScript.BuiltIns/String/JSStringPrototype.Pattern.cs
++++ b/Broiler.JS/Broiler.JavaScript.BuiltIns/String/JSStringPrototype.Pattern.cs
+@@ -136,12 +136,14 @@ public partial class JSString
+                 CreateString(substr), CreateNumber(start), CreateString(@this))).StringValue
+             : GetSubstitution(substr, @this, start, replacementTemplate);
+ 
+-        // Replace only the first match.
+-        var result = new StringBuilder(@this.Length + (replaceText.Length - substr.Length));
+-        result.Append(@this, 0, start);
+-        result.Append(replaceText);
+-        result.Append(@this, end, @this.Length - end);
+-        return new JSString(result.ToString());
++        // Replace only the first match — so the answer is exactly prefix + replacement + suffix,
++        // and string.Concat writes those three spans into ONE allocation of the final length.
++        // A StringBuilder here cost two full copies of the subject (into its chunk list, then
++        // back out through ToString()) even though it was pre-sized: .NET's StringBuilder is a
++        // chunk list rather than a doubling array, so pre-sizing never removed the second copy.
++        // Same change, and same reason, as RegExp.prototype[@@replace]'s single-match path.
++        return new JSString(string.Concat(
++            @this.AsSpan(0, start), replaceText.AsSpan(), @this.AsSpan(end)));
+     }
+ 
+     [JSPrototypeMethod]
+diff --git a/Broiler.JS/Broiler.JavaScript.Integration.Tests/SingleMatchReplaceAllocationTests.cs b/Broiler.JS/Broiler.JavaScript.Integration.Tests/SingleMatchReplaceAllocationTests.cs
+new file mode 100644
+index 00000000..bd716b20
+--- /dev/null
++++ b/Broiler.JS/Broiler.JavaScript.Integration.Tests/SingleMatchReplaceAllocationTests.cs
+@@ -0,0 +1,189 @@
++using System;
++using Broiler.JavaScript.Engine;
++
++namespace Broiler.JavaScript.Integration.Tests;
++
++// RegExp.prototype[@@replace] accumulated its output into a StringBuilder even when there was
++// exactly one match. .NET's StringBuilder is a chunk list, so that costs two full UTF-16 copies
++// of the subject — the chunks, and then ToString() flattening them — which the --regex-profile
++// scaling rows measured as ~4 bytes per subject character.
++//
++// A single match needs no builder at all: the answer is exactly prefix + replacement + suffix,
++// and string.Concat writes those three spans into ONE allocation of the final length. That is
++// the 4 B/char -> 2 B/char halving these tests pin.
++//
++// The allocation is asserted in bytes rather than as a ratio because nothing about the ANSWERS
++// changes — so the second test class below pins the answers across the edges the fast path now
++// owns, and the allocation bound cannot be satisfied by returning something cheaper and wrong.
++// See docs/performance-roadmap.md phase 5.
++public class SingleMatchReplaceAllocationTests
++{
++    private const int Calls = 200;
++
++    // The needle sits in the MIDDLE, so both slices the fast path takes are non-empty and a
++    // regression that drops either one fails the answers test rather than passing quietly.
++    private static readonly string Source = $$"""
++        (function () {
++            var subject = 'a'.repeat(10000) + 'zqx' + 'a'.repeat(10000);
++            var re = /zqx/;
++            var sink = 0;
++            for (var i = 0; i < {{Calls}}; i++) { sink = subject.replace(re, 'y').length; }
++            return sink;
++        })()
++        """;
++
++    [Fact]
++    public void ASingleMatchReplaceDoesNotBuildTheSubjectTwice()
++    {
++        using var context = new JSContext();
++
++        // Warmed first: the compile, the pattern's construction and the inline-cache entries are
++        // one-time and would otherwise land in the delta.
++        Assert.Equal(20_001, (int)context.Eval(Source).DoubleValue);
++
++        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
++        GC.WaitForPendingFinalizers();
++        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
++
++        var before = GC.GetAllocatedBytesForCurrentThread();
++        Assert.Equal(20_001, (int)context.Eval(Source).DoubleValue);
++        var bytes = (GC.GetAllocatedBytesForCurrentThread() - before) / (double)Calls;
++
++        // A 20 003-character subject. Two copies measured ~82 900 B/call, one copy measures
++        // ~42 800 — the ~2 400 B of fixed per-call cost (the exec result array and its
++        // index / input / groups) is in both. The bound sits between them with roughly 40% of
++        // headroom each way, so it fails clearly before the change and is not tight after it.
++        const double Bound = 60_000;
++        Assert.True(
++            bytes < Bound,
++            $"expected under {Bound:N0} B per call for a single-match replace on a 20 003-character "
++                + $"subject, got {bytes:N0} B; building it through a StringBuilder copies the "
++                + "subject twice and costs ~82 900 B");
++    }
++}
++
++// The answers, across the edges the single-match fast path now owns. Every case here has exactly
++// one match, so every one of them takes it — including the global regexp, whose result list is
++// length 1 and which therefore no longer reaches the accumulating loop.
++public class SingleMatchReplaceAnswerTests
++{
++    [Theory]
++    // Position 0 and end-of-subject, where one of the two slices is empty.
++    [InlineData("'abc'.replace(/a/, 'X')", "Xbc")]
++    [InlineData("'abc'.replace(/c/, 'X')", "abX")]
++    [InlineData("'abc'.replace(/abc/, 'X')", "X")]
++    [InlineData("'abc'.replace(/b/, 'X')", "aXc")]
++    // An empty match consumes nothing, so the suffix must start where the prefix ended.
++    [InlineData("'abc'.replace(/(?:)/, 'X')", "Xabc")]
++    [InlineData("'abc'.replace(/(?=b)/, 'X')", "aXbc")]
++    [InlineData("''.replace(/(?:)/, 'X')", "X")]
++    // An empty replacement is a pure deletion.
++    [InlineData("'abc'.replace(/b/, '')", "ac")]
++    // A GLOBAL regexp that matches exactly once takes the fast path too.
++    [InlineData("'abc'.replace(/b/g, 'X')", "aXc")]
++    [InlineData("'abc'.replace(/z/g, 'X')", "abc")]
++    // No match at all returns the subject unchanged, before the fast path is reached.
++    [InlineData("'abc'.replace(/z/, 'X')", "abc")]
++    // The $ substitutions, which are computed before the slicing and must be unaffected by it.
++    [InlineData("'abc'.replace(/b/, '[$&]')", "a[b]c")]
++    [InlineData("'abc'.replace(/b/, '[$`]')", "a[a]c")]
++    [InlineData("'abc'.replace(/b/, \"[$']\")", "a[c]c")]
++    [InlineData("'abc'.replace(/b/, '[$$]')", "a[$]c")]
++    [InlineData("'abc'.replace(/(b)/, '[$1]')", "a[b]c")]
++    [InlineData("'abc'.replace(/(?<mid>b)/, '[$<mid>]')", "a[b]c")]
++    // A functional replacer receives match, captures, position and the whole subject.
++    [InlineData("'abc'.replace(/b/, function (m, p, s) { return m + p + s; })", "ab1abcc")]
++    [InlineData("'abc'.replace(/(b)/, function (m, c, p, s) { return c + p; })", "ab1c")]
++    // Surrogate pairs: the slices are UTF-16 index based, so a match between them must not
++    // split one. 😀 is U+1F600.
++    [InlineData("'x\\uD83D\\uDE00y'.replace(/y/, 'Z')", "x😀Z")]
++    [InlineData("'x\\uD83D\\uDE00y'.replace(/x/, 'Z')", "Z😀y")]
++    [InlineData("'\\uD83D\\uDE00'.replace(/\\uD83D\\uDE00/u, 'Z')", "Z")]
++    public void TheAnswerIsUnchanged(string source, string expected)
++    {
++        using var context = new JSContext();
++        Assert.Equal(expected, context.Eval(source).ToString());
++    }
++
++    [Theory]
++    // String.prototype.replace with a STRING searchValue is a different builtin — it never
++    // reaches @@replace — and it replaces only the first match, so it is single-match by
++    // construction. It had the same three-append assembly through a pre-sized StringBuilder.
++    [InlineData("'abc'.replace('a', 'X')", "Xbc")]
++    [InlineData("'abc'.replace('c', 'X')", "abX")]
++    [InlineData("'abc'.replace('abc', 'X')", "X")]
++    [InlineData("'abc'.replace('b', 'X')", "aXc")]
++    [InlineData("'abc'.replace('b', '')", "ac")]
++    [InlineData("'abc'.replace('', 'X')", "Xabc")]
++    [InlineData("'abc'.replace('z', 'X')", "abc")]
++    // Only the FIRST occurrence goes, which is what makes the path single-match.
++    [InlineData("'abab'.replace('a', 'X')", "Xbab")]
++    // The $ substitutions expand against the string match too.
++    [InlineData("'abc'.replace('b', '[$&]')", "a[b]c")]
++    [InlineData("'abc'.replace('b', '[$`]')", "a[a]c")]
++    [InlineData("'abc'.replace('b', \"[$']\")", "a[c]c")]
++    [InlineData("'abc'.replace('b', '[$$]')", "a[$]c")]
++    // A functional replacer receives (matched, position, subject).
++    [InlineData("'abc'.replace('b', function (m, p, s) { return m + p + s; })", "ab1abcc")]
++    // Surrogate pairs must not be split by the slices.
++    [InlineData("'x\\uD83D\\uDE00y'.replace('y', 'Z')", "x😀Z")]
++    [InlineData("'\\uD83D\\uDE00'.replace('\\uD83D\\uDE00', 'Z')", "Z")]
++    public void TheStringSearchValueAnswerIsUnchanged(string source, string expected)
++    {
++        using var context = new JSContext();
++        Assert.Equal(expected, context.Eval(source).ToString());
++    }
++
++    [Fact]
++    public void AnIllBehavingExecReportingAnIndexPastTheSubjectIsStillClamped()
++    {
++        // §22.2.6.11 step 16.f-g clamps position to [0, lengthS]. The fast path slices the
++        // subject with it, so an unclamped value would throw ArgumentOutOfRangeException out of
++        // string.Concat rather than produce the spec's answer.
++        using var context = new JSContext();
++        var answer = context.Eval("""
++            var re = /b/;
++            re.exec = function () { return { length: 1, 0: 'b', index: 9999 }; };
++            'abc'.replace(re, 'X')
++            """).ToString();
++
++        Assert.Equal("abcX", answer);
++    }
++
++    [Fact]
++    public void ASingleMatchStillRecordsTheLegacyStatics()
++    {
++        // The fast path returns before the accumulating loop, so it has to leave everything that
++        // is not the output string exactly as it was — the Annex B statics among them.
++        using var context = new JSContext();
++        var answer = context.Eval("""
++            'aXb'.replace(/X/, '-');
++            [RegExp.lastMatch, RegExp.leftContext, RegExp.rightContext, RegExp.input].join('|')
++            """).ToString();
++
++        Assert.Equal("X|a|b|aXb", answer);
++    }
++
++    [Fact]
++    public void ThePropertyReadOrderOnTheResultIsUnchanged()
++    {
++        // §22.2.6.11 step 16 reads length -> "0" -> index -> captures -> groups, and the order is
++        // observable through a Proxy result (test262 sm/RegExp/replace-trace). Extracting the
++        // per-result work into a local function so the fast path and the loop share it is what
++        // keeps this to one copy; this pins that the order survived the extraction.
++        using var context = new JSContext();
++        var answer = context.Eval("""
++            var seen = [];
++            var target = { length: 2, 0: 'b', 1: 'B', index: 1, groups: undefined };
++            var proxy = new Proxy(target, {
++                get: function (t, k) { seen.push(String(k)); return t[k]; }
++            });
++            var re = /b/;
++            re.exec = function () { return proxy; };
++            'abc'.replace(re, '[$1]');
++            seen.join(',')
++            """).ToString();
++
++        Assert.Equal("length,0,index,1,groups", answer);
++    }
++}
+diff --git a/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/RegexProfileMetrics.cs b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/RegexProfileMetrics.cs
+index f808ecec..da105b09 100644
+--- a/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/RegexProfileMetrics.cs
++++ b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/RegexProfileMetrics.cs
+@@ -183,6 +183,10 @@ internal static class RegexProfileMetrics
+                 ("test-hit", "var re = /zqx/;", "sink = re.test(subject);"),
+                 ("exec-hit", "var re = /zqx/;", "sink = re.exec(subject) !== null;"),
+                 ("replace-one", "var re = /zqx/;", "sink = subject.replace(re, 'y').length;"),
++                // The same single replacement reached through a STRING searchValue, which is a
++                // different builtin (String.prototype.replace's own path, not @@replace) that had
++                // the same two-copy assembly. Kept alongside so the two cannot drift apart.
++                ("replace-one-string", "", "sink = subject.replace('zqx', 'y').length;"),
+             })
+             {
+                 rows.Add(MeasureCalls($"{name}@{length}", length, setup, body));
+-- 
+2.43.0
+

--- a/patches/0060-js-stream-global-replace.patch
+++ b/patches/0060-js-stream-global-replace.patch
@@ -1,0 +1,546 @@
+From 0f29ccc30f06aba7631e505465b38a7b6854714c Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Mon, 3 Aug 2026 06:56:59 +0000
+Subject: [PATCH] Stream a global replace instead of retaining every match
+ result
+
+22.2.6.11 collects every match in step 14 and only reads their properties in
+step 16, so a global replace held one result array per match live before it
+assembled anything. Measured with the subject held fixed at 40 000 characters
+and only the match count varying -- the discriminator the existing scaling rows
+cannot be, since they vary the subject and hold the match count at one -- that
+is 2 032.8 bytes per match, dead linear across both intervals, 10.3 MB for a
+single 5 000-match call. Streaming takes it to 478.3 B/match, 0.235x, and what
+remains is the match data itself rather than a result object.
+
+The optimization is four lines. The guard is the item, and it needs three
+conditions at once: the receiver's exec IS the pristine %RegExp.prototype.exec%
+captured at realm init, so every result is a fresh array this function alone
+holds; the replacement is a string, so no user code runs between matches; and
+that string contains no '$', so nothing reads a capture back out of a result.
+
+Two of those three are not in the item's description, and one is a trap. Because
+the spec collects ALL matches before calling ANY replacer, the final failing
+exec has already reset lastIndex to 0 before user code first runs -- so a
+streamed functional replacer would observe a different VALUE, not merely a
+different order. The item said "changes the observable order". That understates
+it, and AFunctionalReplacerIsNotStreamed pins the real behaviour at 0,0.
+
+Identity against a capture taken at realm init is the only sound form of the
+exec test: reading RegExp.prototype.exec at call time and comparing it to itself
+is circular, since by then it may already be the patched one. This uses the same
+mechanism IntrinsicArrayValues and IntrinsicPromisePrototype already do.
+
+Exec is split into ExecMatch -- the lastIndex read and write, the match, the
+sticky re-check and the Annex B statics -- and BuildExecResult, the part the fast
+path skips. Both callers use ExecMatch, so lastIndex progression, engine routing
+and the statics cannot drift between the two paths: they are the same code, not
+the same intention written twice.
+
+GlobalReplaceStreamingAllocationTests asserts the bytes and fails on the build
+without this (2 610 B/match against a 1 000 bound); all 22 guard cases pass on
+both builds, which makes them regression guards rather than change detectors.
+They cover each exclusion, the empty-match advance under /u and without it,
+sticky with global, lastIndex after the call, and the legacy statics.
+
+Repository suite 7 627 tests across 13 projects, 0 failures. test262 unchanged
+across all four pinned manifests -- 8 313 executed, 8 220 passed, 84 failed, 44
+skipped, 9 timed out, identical manifest by manifest. The replace-path manifest
+is identical file for file to the pre-0059 control: 499 tests, 484 passed, 13
+failed, 2 timed out.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ .../BuiltInsAssemblyInitializer.cs            |  68 ++++++
+ .../RegExp/JSRegExpPrototype.cs               |  30 ++-
+ .../Broiler.JavaScript.Engine/JSContext.cs    |  17 +-
+ .../GlobalReplaceStreamingTests.cs            | 208 ++++++++++++++++++
+ .../RegexProfileMetrics.cs                    |  66 ++++++
+ 5 files changed, 386 insertions(+), 3 deletions(-)
+ create mode 100644 Broiler.JS/Broiler.JavaScript.Integration.Tests/GlobalReplaceStreamingTests.cs
+
+diff --git a/Broiler.JS/Broiler.JavaScript.BuiltIns/BuiltInsAssemblyInitializer.cs b/Broiler.JS/Broiler.JavaScript.BuiltIns/BuiltInsAssemblyInitializer.cs
+index b14693ea..f72628d9 100644
+--- a/Broiler.JS/Broiler.JavaScript.BuiltIns/BuiltInsAssemblyInitializer.cs
++++ b/Broiler.JS/Broiler.JavaScript.BuiltIns/BuiltInsAssemblyInitializer.cs
+@@ -1620,6 +1620,74 @@ internal static class BuiltInsAssemblyInitializer
+             if (global)
+                 rx[KeyStrings.lastIndex] = JSValue.NumberZero;
+ 
++            // STREAMING FAST PATH — a global replace whose per-match result objects nobody can
++            // observe. §22.2.6.11 collects every match in step 14 and only reads their properties
++            // in step 16, so 5 000 matches means 5 000 live result arrays: measured at 2 033 bytes
++            // per match, dead linear in the match count, ~10.3 MB for a single call.
++            //
++            // Nothing can reach those objects when all of the following hold, so the loop can
++            // append each replacement as it goes instead of retaining anything:
++            //   * the receiver's "exec" is the pristine %RegExp.prototype.exec% captured at realm
++            //     init, so every result is a fresh array this function is the sole holder of;
++            //   * the replacement is a string, so no user code runs between matches to observe
++            //     lastIndex or the Annex B statics part-way through the loop;
++            //   * that string contains no '$', so no capture, no named group and no $` / $' is
++            //     ever read back out of a result. This is the conservative bound: a template WITH
++            //     '$' is left on the general path rather than reconstructed here, because
++            //     GetSubstitution reads through the result object and matching that exactly is
++            //     what the general path already does.
++            // Matching still runs through ExecMatch — the same code Exec calls — so lastIndex,
++            // the sticky re-check, the engine routing and the legacy statics progress exactly as
++            // they would otherwise. The empty-match advance below is step 14.d verbatim.
++            if (global
++                && !functionalReplace
++                && replacementText.IndexOf('$') < 0
++                && rx is JSRegExp streamRegExp
++                && JSEngine.Current is JSContext streamContext
++                && streamContext.IntrinsicRegExpExec.IsFunction
++                && ReferenceEquals(rx[KeyStrings.GetOrCreate("exec")], streamContext.IntrinsicRegExpExec))
++            {
++                StringBuilder streamed = null;
++                var streamedPosition = 0;
++                while (true)
++                {
++                    var match = streamRegExp.ExecMatch(input);
++                    if (match == null)
++                        break;
++
++                    streamed ??= new StringBuilder();
++                    var position = Math.Clamp(match.Index, 0, input.Length);
++                    if (position >= streamedPosition)
++                    {
++                        if (position > streamedPosition)
++                            streamed.Append(input.AsSpan(streamedPosition, position - streamedPosition));
++
++                        streamed.Append(replacementText);
++                        streamedPosition = Math.Min(position + match.Length, input.Length);
++                    }
++
++                    if (match.Length != 0)
++                        continue;
++
++                    double streamThisIndex = ToLengthDouble(rx[KeyStrings.lastIndex]);
++                    double streamAdvanced = streamThisIndex + 1;
++                    if (fullUnicode && streamAdvanced < input.Length
++                        && char.IsHighSurrogate(input[(int)streamThisIndex])
++                        && char.IsLowSurrogate(input[(int)streamThisIndex + 1]))
++                        streamAdvanced++;
++                    rx[KeyStrings.lastIndex] = JSValue.CreateNumber(streamAdvanced);
++                }
++
++                // No match at all returns the subject itself, as step 15 does — not a copy of it.
++                if (streamed == null)
++                    return JSValue.CreateString(input);
++
++                if (streamedPosition < input.Length)
++                    streamed.Append(input.AsSpan(streamedPosition));
++
++                return JSValue.CreateString(streamed.ToString());
++            }
++
+             List<JSValue> results = [];
+             while (true)
+             {
+diff --git a/Broiler.JS/Broiler.JavaScript.BuiltIns/RegExp/JSRegExpPrototype.cs b/Broiler.JS/Broiler.JavaScript.BuiltIns/RegExp/JSRegExpPrototype.cs
+index 064c1e34..1f591ed1 100644
+--- a/Broiler.JS/Broiler.JavaScript.BuiltIns/RegExp/JSRegExpPrototype.cs
++++ b/Broiler.JS/Broiler.JavaScript.BuiltIns/RegExp/JSRegExpPrototype.cs
+@@ -133,7 +133,24 @@ public partial class JSRegExp
+     public JSValue Exec(in Arguments a)
+     {
+         var input = a.Get1().StringValue;
++        var matched = ExecMatch(input);
++        return matched == null ? NullValue : BuildExecResult(input, matched);
++    }
+ 
++    /// <summary>
++    /// Everything <see cref="Exec"/> does EXCEPT building the result object: the `lastIndex`
++    /// read and write, the match itself, the sticky re-check, and the Annex B legacy statics.
++    /// Returns null for no match.
++    /// </summary>
++    /// <remarks>
++    /// Split out so <c>RegExp.prototype[@@replace]</c>'s streaming path can drive matching
++    /// without materializing one result array per match, while remaining incapable of drifting
++    /// from <see cref="Exec"/> — both call this, so `lastIndex` progression, sticky handling,
++    /// the Broiler/.NET engine routing and the statics update are the same code, not the same
++    /// intention written twice.
++    /// </remarks>
++    internal RegexMatchData ExecMatch(string input)
++    {
+         // RegExpBuiltinExec reads `lastIndex` exactly once (via ToLength), even when
+         // the regex is neither global nor sticky; the value is only consulted in the
+         // global/sticky case (steps 8 and 12).
+@@ -148,7 +165,7 @@ public partial class JSRegExp
+         if (useLastIndex && observableLastIndex > input.Length)
+         {
+             SetObservableLastIndex(0);
+-            return NullValue;
++            return null;
+         }
+ 
+         // Perform the regular expression matching. RunMatch dispatches to the
+@@ -168,7 +185,7 @@ public partial class JSRegExp
+             if (globalSearch || sticky)
+                 SetObservableLastIndex(0);
+ 
+-            return NullValue;
++            return null;
+         }
+ 
+         if (globalSearch || sticky)
+@@ -197,6 +214,15 @@ public partial class JSRegExp
+             legacyContext.LegacyRegExp.Update(input, match.Index, match.Index + match.Length, capturedValues);
+         }
+ 
++        return match;
++    }
++
++    /// <summary>Builds the §22.2.7.2 result array for a match produced by <see cref="ExecMatch"/>.</summary>
++    private JSValue BuildExecResult(string input, RegexMatchData match)
++    {
++        var groups = match.Groups;
++        var c = captureMap != null ? captureMap.Count + 1 : groups.Length;
++
+         var result = CreateArray((uint)c);
+         var resultObject = (JSObject)result;
+ 
+diff --git a/Broiler.JS/Broiler.JavaScript.Engine/JSContext.cs b/Broiler.JS/Broiler.JavaScript.Engine/JSContext.cs
+index 709fadf7..8b853e27 100644
+--- a/Broiler.JS/Broiler.JavaScript.Engine/JSContext.cs
++++ b/Broiler.JS/Broiler.JavaScript.Engine/JSContext.cs
+@@ -97,6 +97,13 @@ public class JSContext : JSObject, IJSExecutionContext, IJSFeatureResolver, IDis
+     // functions, dynamic import, .then results, Promise.resolve/reject) must use this
+     // genuine prototype even after the global `Promise` binding is reassigned.
+     public JSObject IntrinsicPromisePrototype { get; private set; }
++    // %RegExp.prototype.exec% captured at realm init, before any user code can run.
++    // RegExp.prototype[@@replace] compares the receiver's resolved "exec" against this to
++    // decide whether a match result is observable at all: when it is the genuine builtin,
++    // nothing can see the per-match result object, so a global replace can stream instead
++    // of retaining one array per match. Identity against a pristine capture is the only
++    // sound form of that test — a value read later could already have been replaced.
++    public JSValue IntrinsicRegExpExec { get; private set; } = JSUndefined.Value;
+     public event LogEventHandler Log;
+     public event ErrorEventHandler Error;
+     public event ConsoleEvent ConsoleEvent;
+@@ -1553,7 +1560,7 @@ public class JSContext : JSObject, IJSExecutionContext, IJSFeatureResolver, IDis
+         this.synchronizationContext = synchronizationContext ?? SynchronizationContext.Current;
+         ExperimentalFeatures = experimentalFeatures;
+         Options = options ?? JSContextOptions.Default;
+-        Frames.StackUsageLimit = Options.MaxStackUsageBytes;
++        Frames.StackUsageLimit = Options.MaxStackUsageBytes;
+         FunctionTiering = new FunctionTieringController(Options.FunctionTiering);
+         if (Options.BuiltInRegistry == null && !JSEngine.HasExplicitBuiltInRegistry)
+             JSEngine.EnsureBuiltInsAssemblyLoaded();
+@@ -1616,6 +1623,14 @@ public class JSContext : JSObject, IJSExecutionContext, IJSFeatureResolver, IDis
+         {
+             IntrinsicPromisePrototype = promiseProto;
+         }
++        // Capture %RegExp.prototype.exec% for the streaming guard described on the property.
++        if (this[KeyStrings.RegExp] is IJSFunction regExpCtor
++            && regExpCtor.Prototype is JSObject regExpProto)
++        {
++            var exec = regExpProto[KeyStrings.GetOrCreate("exec")];
++            if (exec.IsFunction)
++                IntrinsicRegExpExec = exec;
++        }
+         // globalThis is { writable, enumerable: false, configurable } per spec.
+         FastAddValue(KeyStrings.globalThis, this, JSPropertyAttributes.ConfigurableValue);
+         this[KeyStrings.debug] = CreateFunction(Debug);
+diff --git a/Broiler.JS/Broiler.JavaScript.Integration.Tests/GlobalReplaceStreamingTests.cs b/Broiler.JS/Broiler.JavaScript.Integration.Tests/GlobalReplaceStreamingTests.cs
+new file mode 100644
+index 00000000..3427fb74
+--- /dev/null
++++ b/Broiler.JS/Broiler.JavaScript.Integration.Tests/GlobalReplaceStreamingTests.cs
+@@ -0,0 +1,208 @@
++using System;
++using Broiler.JavaScript.Engine;
++
++namespace Broiler.JavaScript.Integration.Tests;
++
++// §22.2.6.11 collects every match in step 14 and only reads their properties in step 16, so a
++// global replace held one result array per match live before it built anything — measured at
++// 2 033 bytes per match, dead linear in the match count, ~10.3 MB for a single 5 000-match call.
++//
++// RegExp.prototype[@@replace] now streams when nothing can observe those results: the receiver's
++// "exec" is the pristine %RegExp.prototype.exec% captured at realm init, the replacement is a
++// string, and that string contains no '$'. Under those conditions the result object is pure
++// garbage and the loop appends as it goes.
++//
++// The guard is the whole risk here, so these tests are mostly about when the fast path must NOT
++// be taken. See docs/performance-roadmap.md phase 5.
++public class GlobalReplaceStreamingAllocationTests
++{
++    private const int Calls = 20;
++    private const int Matches = 5_000;
++
++    // One 'x' every 8 characters over a 40 000-character subject.
++    private static readonly string Source = $$"""
++        (function () {
++            var subject = ('x' + 'aaaaaaa').repeat({{Matches}});
++            var re = /x/g;
++            var sink = 0;
++            for (var i = 0; i < {{Calls}}; i++) { sink = subject.replace(re, 'y').length; }
++            return sink;
++        })()
++        """;
++
++    [Fact]
++    public void AGlobalReplaceDoesNotRetainOneResultArrayPerMatch()
++    {
++        using var context = new JSContext();
++
++        // Warmed first: the compile, the pattern's construction and the inline-cache entries are
++        // one-time and would otherwise land in the delta.
++        Assert.Equal(40_000, (int)context.Eval(Source).DoubleValue);
++
++        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
++        GC.WaitForPendingFinalizers();
++        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
++
++        var before = GC.GetAllocatedBytesForCurrentThread();
++        Assert.Equal(40_000, (int)context.Eval(Source).DoubleValue);
++        var bytesPerMatch = (GC.GetAllocatedBytesForCurrentThread() - before) / (double)Calls / Matches;
++
++        // Retaining a result array per match measured 2 033 B/match; streaming measures ~478.
++        // The bound sits between them with roughly 2x of headroom each way, so it fails by a
++        // factor before the change and is not tight after it.
++        const double Bound = 1_000;
++        Assert.True(
++            bytesPerMatch < Bound,
++            $"expected under {Bound:N0} B per match for a global replace with {Matches:N0} "
++                + $"matches, got {bytesPerMatch:N0} B; retaining one result array per match "
++                + "is ~2 033 B");
++    }
++}
++
++// The guard. Every case here must produce the same answer the general path produces, and the
++// ones named "…IsNotStreamed" additionally pin that the fast path declined — they would be
++// silently wrong, not slow, if the guard let them through.
++public class GlobalReplaceStreamingGuardTests
++{
++    [Theory]
++    [InlineData("'aXbXc'.replace(/X/g, '-')", "a-b-c")]
++    [InlineData("'abc'.replace(/z/g, '-')", "abc")]
++    [InlineData("'aaa'.replace(/a/g, '')", "")]
++    [InlineData("'abc'.replace(/b/g, 'XY')", "aXYc")]
++    // Empty matches advance by one position and still emit the replacement at each.
++    [InlineData("'abc'.replace(/(?:)/g, '-')", "-a-b-c-")]
++    [InlineData("''.replace(/(?:)/g, '-')", "-")]
++    [InlineData("'abc'.replace(/x*/g, '-')", "-a-b-c-")]
++    // Sticky and global together.
++    [InlineData("'aab'.replace(/a/gy, '-')", "--b")]
++    // Non-global goes to the single-match path instead, and must be unaffected.
++    [InlineData("'aXbXc'.replace(/X/, '-')", "a-bXc")]
++    public void TheStreamedAnswerIsUnchanged(string source, string expected)
++    {
++        using var context = new JSContext();
++        Assert.Equal(expected, context.Eval(source).ToString());
++    }
++
++    [Theory]
++    // A '$' in the template reads back through the result object, so these must stay on the
++    // general path. They are the cases the guard deliberately gives up.
++    [InlineData("'aXbXc'.replace(/X/g, '[$&]')", "a[X]b[X]c")]
++    [InlineData("'a1b2'.replace(/(\\d)/g, '<$1>')", "a<1>b<2>")]
++    [InlineData("'abc'.replace(/b/g, \"[$`|$']\")", "a[a|c]c")]
++    [InlineData("'abc'.replace(/b/g, '$$')", "a$c")]
++    [InlineData("'a1'.replace(/(?<d>\\d)/g, '<$<d>>')", "a<1>")]
++    public void ATemplateWithADollarIsNotStreamed(string source, string expected)
++    {
++        using var context = new JSContext();
++        Assert.Equal(expected, context.Eval(source).ToString());
++    }
++
++    [Fact]
++    public void AFunctionalReplacerIsNotStreamed()
++    {
++        // The spec collects ALL matches before calling the replacer for any of them, so by the
++        // time user code runs the final failing exec has already reset lastIndex to 0. Streaming
++        // would let the replacer observe lastIndex mid-subject, which is why a functional
++        // replacement is excluded from the fast path — this is the test that would catch it.
++        using var context = new JSContext();
++        var answer = context.Eval("""
++            var re = /X/g, seen = [];
++            var out = 'aXbXc'.replace(re, function () { seen.push(re.lastIndex); return '-'; });
++            out + '|' + seen.join(',')
++            """).ToString();
++
++        Assert.Equal("a-b-c|0,0", answer);
++    }
++
++    [Fact]
++    public void AnOwnExecIsNotStreamed()
++    {
++        // An own "exec" is not the captured intrinsic, so the receiver's own function must run.
++        using var context = new JSContext();
++        var answer = context.Eval("""
++            var calls = 0, re = /b/g, real = RegExp.prototype.exec;
++            re.exec = function (s) { calls++; return real.call(this, s); };
++            'abcb'.replace(re, '-') + '|' + (calls > 0)
++            """).ToString();
++
++        Assert.Equal("a-c-|true", answer);
++    }
++
++    [Fact]
++    public void AnExecReturningNullIsNotStreamed()
++    {
++        using var context = new JSContext();
++        var answer = context.Eval("""
++            var re = /b/g;
++            re.exec = function () { return null; };
++            'abc'.replace(re, '-')
++            """).ToString();
++
++        Assert.Equal("abc", answer);
++    }
++
++    [Fact]
++    public void APatchedPrototypeExecIsNotStreamed()
++    {
++        // The guard compares against the intrinsic captured at realm init, so replacing
++        // RegExp.prototype.exec afterwards must take the receiver off the fast path.
++        using var context = new JSContext();
++        var answer = context.Eval("""
++            var saved = RegExp.prototype.exec, hits = 0;
++            RegExp.prototype.exec = function (s) { hits++; return saved.call(this, s); };
++            var out = 'abcb'.replace(/b/g, '-');
++            RegExp.prototype.exec = saved;
++            out + '|' + (hits > 0)
++            """).ToString();
++
++        Assert.Equal("a-c-|true", answer);
++    }
++
++    [Theory]
++    // §22.2.6.11 step 14.d advances an empty match by a code POINT under /u and by a code UNIT
++    // without it, so the same subject splits the surrogate pair one way and not the other.
++    // Asserted as code units because a C# literal for a LONE surrogate is its own trap.
++    [InlineData("(?:)/gu", "2d,d83d,de00,2d")]
++    [InlineData("(?:)/g", "2d,d83d,2d,de00,2d")]
++    public void TheEmptyMatchAdvanceRespectsTheUnicodeFlag(string pattern, string expectedUnits)
++    {
++        using var context = new JSContext();
++        var answer = context.Eval($$"""
++            (function () {
++                var r = '😀'.replace(/{{pattern}}, '-');
++                var codes = [];
++                for (var i = 0; i < r.length; i++) codes.push(r.charCodeAt(i).toString(16));
++                return codes.join(',');
++            })()
++            """).ToString();
++
++        Assert.Equal(expectedUnits, answer);
++    }
++
++    [Fact]
++    public void LastIndexIsResetAfterAStreamedReplace()
++    {
++        using var context = new JSContext();
++        var answer = context.Eval("""
++            var re = /b/g;
++            'abcb'.replace(re, '-');
++            re.lastIndex
++            """).DoubleValue;
++
++        Assert.Equal(0d, answer);
++    }
++
++    [Fact]
++    public void TheLegacyStaticsStillDescribeTheLastMatchAfterAStreamedReplace()
++    {
++        // The statics are updated per match inside ExecMatch, which the fast path still calls —
++        // this pins that streaming did not skip them, and that they describe the LAST match.
++        using var context = new JSContext();
++        var answer = context.Eval("""
++            'aXbXc'.replace(/X/g, '-');
++            [RegExp.lastMatch, RegExp.leftContext, RegExp.rightContext].join('|')
++            """).ToString();
++
++        Assert.Equal("X|aXb|c", answer);
++    }
++}
+diff --git a/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/RegexProfileMetrics.cs b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/RegexProfileMetrics.cs
+index da105b09..34750131 100644
+--- a/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/RegexProfileMetrics.cs
++++ b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/RegexProfileMetrics.cs
+@@ -196,6 +196,67 @@ internal static class RegexProfileMetrics
+         return [.. rows];
+     }
+ 
++    /// <summary>
++    /// A GLOBAL replace at a fixed subject length and a varying MATCH COUNT, per call.
++    /// </summary>
++    /// <remarks>
++    /// The scaling section above varies the subject and holds the match count at one, which is
++    /// the right discriminator for a cost that copies the subject. It is the wrong one for the
++    /// cost that is left: §22.2.6.11 collects every match in step 14 before reading any of their
++    /// properties in step 16, so what should drive the remaining bytes is the number of RESULTS
++    /// held live, not how long the subject is. Holding the subject fixed and varying only the
++    /// match count is what separates those two — a flat row would mean the retained list is not
++    /// the cost, and a linear one gives its slope in bytes per match directly.
++    /// </remarks>
++    private static Row[] MeasureMatchScaling()
++    {
++        var rows = new List<Row>();
++        foreach (var matches in new[] { 500, 2_500, 5_000 })
++        {
++            rows.Add(MeasureGlobalReplaceCalls(matches));
++        }
++
++        return [.. rows];
++    }
++
++    /// <summary>Subject length held fixed across every match count in <see cref="MeasureMatchScaling"/>.</summary>
++    private const int GlobalReplaceSubjectLength = 40_000;
++
++    private static Row MeasureGlobalReplaceCalls(int matches)
++    {
++        using var context = BenchmarkContext.Create();
++        const int Calls = 20;
++
++        // One 'x' every (40 000 / matches) characters, so the subject is the same length for
++        // every row and only the number of matches changes.
++        var stride = GlobalReplaceSubjectLength / matches;
++        var source = $$"""
++            (function (n) {
++                var subject = ('x' + 'a'.repeat({{stride - 1}})).repeat({{matches}});
++                var re = /x/g;
++                var sink = 0;
++                for (var i = 0; i < n; i++) { sink = subject.replace(re, 'y').length; }
++                return sink;
++            })
++            """;
++
++        var function = context.Eval(source, $"global-replace-{matches}.js");
++        var arguments = new Arguments(JSUndefined.Value, new JSNumber(Calls));
++        function.InvokeFunction(in arguments);
++
++        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
++        GC.WaitForPendingFinalizers();
++        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
++
++        var before = GC.GetAllocatedBytesForCurrentThread();
++        function.InvokeFunction(in arguments);
++        var bytes = GC.GetAllocatedBytesForCurrentThread() - before;
++
++        return new Row($"global-replace@{matches}-matches", "bytes per CALL, subject fixed at "
++            + GlobalReplaceSubjectLength + " chars, match count in the name",
++            0, 0, null, Math.Round((double)bytes / Calls, 1), 0, bytes);
++    }
++
+     private static Row MeasureCalls(string name, int length, string setup, string body)
+     {
+         using var context = BenchmarkContext.Create();
+@@ -253,6 +314,11 @@ internal static class RegexProfileMetrics
+                     + "its patterns once.",
+                 netEngine = netRows,
+                 scaling = MeasureScaling(),
++                matchScalingNote = "A GLOBAL replace with the SUBJECT held fixed and only the "
++                    + "match count varying, which is the discriminator the section above cannot "
++                    + "be: it says whether what is left scales with the retained result list or "
++                    + "with the subject.",
++                matchScaling = MeasureMatchScaling(),
+             },
+             new JsonSerializerOptions { WriteIndented = true }));
+     }
+-- 
+2.43.0
+

--- a/patches/0061-js-measure-2-9-materialization-cause.patch
+++ b/patches/0061-js-measure-2-9-materialization-cause.patch
@@ -1,0 +1,274 @@
+From abffbc1ed20a1941fc81e257db747662745150cc Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Mon, 3 Aug 2026 07:34:35 +0000
+Subject: [PATCH] Measure item 2-9's losing-side hypothesis against its own
+ control
+
+2-9 recorded a mechanism for its ~20% compile-and-first-run cost and was
+explicit that it was not settled: the Annex B caller/arguments deferred cells
+cannot be described from a slot, so TrackShapeKeyWithoutSlotValue materializes
+the trie and a function does the shape work as well as the trie rebuild.
+
+The control that settles it is a STRICT function. AddLegacyCallerAndArguments
+runs for non-strict functions only, so if the cells are the cause, a strict
+function must not pay. It pays exactly the same: 1.00 trie rebuilds per
+function on all four rows, strict and non-strict, called and uncalled.
+
+What materializes is the prototype install. JSFunction's three own-key writes
+are length, name, prototype; the first two stay shape-only and the third does
+not, because AllowsDirectShapeWrite withholds that one key -- which is 2-8's
+DeltaBlue fix, where a cached prototype write left the second level of every
+inheritance chain unlinked. FastAddValue then falls off
+TryShapeOnlySetDataProperty to OwnProperties(), which materializes. So the
+planned follow-up, "stop materializing for a deferred cell", would have removed
+a materialization that has already happened, and it is withdrawn before being
+built.
+
+The deferred cells do cost 4.8% more bytes than strict, which is their real
+price and is why an allocation-only probe reads like confirmation. A counter on
+the rebuild itself says 1.00 on both.
+
+Adds --deferred-cell-cost (DeferredCellCostMetrics) and a
+RecordNamedPropertiesMaterialized counter, so the rebuild is measured rather
+than inferred from bytes.
+
+Also narrows the item's remaining open question rather than closing it: the
+first call roughly doubles wall clock while adding no managed bytes at all, so
+whatever carries it allocates nothing and does not split on strictness.
+
+The replacement candidate -- split cache-visibility from shape-only storage, so
+prototype can live in a slot while staying invisible to the cache -- is
+specified and deliberately NOT attempted: it is the code whose last regression
+broke DeltaBlue outright, and a change justified by a benchmark has to be run
+against that benchmark, which needs 0-6.
+
+Repository suite 7 563 tests across 13 projects, 0 failures.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ .../JSObject.ShapeStorage.cs                  |   1 +
+ .../Broiler.JavaScript.Runtime/ObjectShape.cs |  13 +-
+ .../DeferredCellCostMetrics.cs                | 129 ++++++++++++++++++
+ .../Program.cs                                |   6 +
+ 4 files changed, 147 insertions(+), 2 deletions(-)
+ create mode 100644 Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/DeferredCellCostMetrics.cs
+
+diff --git a/Broiler.JS/Broiler.JavaScript.Runtime/JSObject.ShapeStorage.cs b/Broiler.JS/Broiler.JavaScript.Runtime/JSObject.ShapeStorage.cs
+index 66a5c2c9..c2a15c10 100644
+--- a/Broiler.JS/Broiler.JavaScript.Runtime/JSObject.ShapeStorage.cs
++++ b/Broiler.JS/Broiler.JavaScript.Runtime/JSObject.ShapeStorage.cs
+@@ -109,6 +109,7 @@ public partial class JSObject
+     private void MaterializeNamedProperties()
+     {
+         status |= ObjectStatus.NamedPropertiesMaterialized;
++        PropertyOptimizationDiagnostics.RecordNamedPropertiesMaterialized();
+ 
+         var shape = objectShape;
+         if (!SupportsShapeTracking || shape.IsDictionary)
+diff --git a/Broiler.JS/Broiler.JavaScript.Runtime/ObjectShape.cs b/Broiler.JS/Broiler.JavaScript.Runtime/ObjectShape.cs
+index 369f478e..b4b89b69 100644
+--- a/Broiler.JS/Broiler.JavaScript.Runtime/ObjectShape.cs
++++ b/Broiler.JS/Broiler.JavaScript.Runtime/ObjectShape.cs
+@@ -95,7 +95,8 @@ public readonly record struct PropertyOptimizationSnapshot(
+     long PrototypeVersion,
+     long StoreCacheHits,
+     long StoreCacheMisses,
+-    long StoreMegamorphicSites);
++    long StoreMegamorphicSites,
++    long NamedPropertiesMaterializations);
+ 
+ /// <summary>
+ /// Counters for validating shape/cache invalidation behavior.
+@@ -119,6 +120,7 @@ public static class PropertyOptimizationDiagnostics
+     private static long storeCacheHits;
+     private static long storeCacheMisses;
+     private static long storeMegamorphicSites;
++    private static long namedPropertiesMaterializations;
+ 
+     /// <summary>
+     /// Whether the counters below are recorded. Defaults to <c>false</c>; while it is
+@@ -158,6 +160,11 @@ public static class PropertyOptimizationDiagnostics
+     internal static void RecordStoreCacheHit() { if (Enabled) Interlocked.Increment(ref storeCacheHits); }
+     internal static void RecordStoreCacheMiss() { if (Enabled) Interlocked.Increment(ref storeCacheMisses); }
+     internal static void RecordStoreMegamorphic() { if (Enabled) Interlocked.Increment(ref storeMegamorphicSites); }
++    // Item 2-9's losing-side hypothesis is that a deferred cell forces the trie to be
++    // rebuilt; counting the rebuilds is what turns that from a reading of the code into a
++    // measurement, and a strict function is the control that says whether the Annex B
++    // cells are what causes them.
++    internal static void RecordNamedPropertiesMaterialized() { if (Enabled) Interlocked.Increment(ref namedPropertiesMaterializations); }
+ 
+     public static PropertyOptimizationSnapshot Snapshot() => new(
+         Interlocked.Read(ref shapeTransitions),
+@@ -170,7 +177,8 @@ public static class PropertyOptimizationDiagnostics
+         JSObject.PrototypeMutationVersion,
+         Interlocked.Read(ref storeCacheHits),
+         Interlocked.Read(ref storeCacheMisses),
+-        Interlocked.Read(ref storeMegamorphicSites));
++        Interlocked.Read(ref storeMegamorphicSites),
++        Interlocked.Read(ref namedPropertiesMaterializations));
+ 
+     public static void Reset()
+     {
+@@ -184,6 +192,7 @@ public static class PropertyOptimizationDiagnostics
+         Interlocked.Exchange(ref storeCacheHits, 0);
+         Interlocked.Exchange(ref storeCacheMisses, 0);
+         Interlocked.Exchange(ref storeMegamorphicSites, 0);
++        Interlocked.Exchange(ref namedPropertiesMaterializations, 0);
+     }
+ }
+ 
+diff --git a/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/DeferredCellCostMetrics.cs b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/DeferredCellCostMetrics.cs
+new file mode 100644
+index 00000000..86e71dd7
+--- /dev/null
++++ b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/DeferredCellCostMetrics.cs
+@@ -0,0 +1,129 @@
++using System;
++using System.Diagnostics;
++using System.Text.Json;
++using Broiler.JavaScript.BuiltIns.Number;
++using Broiler.JavaScript.Runtime;
++
++namespace Broiler.JavaScript.Engine.Benchmarks;
++
++/// <summary>
++/// Emits what an ordinary function's Annex B <c>caller</c>/<c>arguments</c> deferred cells cost
++/// it, by comparing a NON-STRICT function against a STRICT one that is identical in every other
++/// respect.
++/// </summary>
++/// <remarks>
++/// Exists to test the hypothesis roadmap item 2-9 records for its own losing side, and which it
++/// is explicit is <em>not</em> settled: "every ordinary non-strict function carries the Annex B
++/// caller/arguments as deferred cells from birth (P0-3), a deferred cell cannot be described
++/// from a slot, and <c>TrackShapeKeyWithoutSlotValue</c> therefore materializes. So a function
++/// does the shape work AND the trie rebuild where before it did the trie work alone."
++/// <para>
++/// A strict function is the control the hypothesis needs and never had.
++/// <c>AddLegacyCallerAndArguments</c> runs for non-strict functions only, so if the deferred
++/// cells are what forces materialization, a strict function must not pay it — and if strict and
++/// non-strict cost the same, the mechanism is wrong no matter how plausible it reads. That is a
++/// sharper instrument than the wall-clock ratio the item was measured with, because the byte
++/// counts are deterministic and exact while the 1.23 was a ratio between two builds.
++/// </para>
++/// <para>
++/// Both halves are reported with and without a first CALL, because the item's own decomposition
++/// is that creation alone costs 1.03 and creation-plus-one-call costs 1.23 — "something on the
++/// first-call path is carrying the rest and has not been identified". If the call's cost also
++/// splits on strictness it belongs to the same mechanism; if it does not, it is a second thing
++/// and the item needs to say so.
++/// </para>
++/// </remarks>
++internal static class DeferredCellCostMetrics
++{
++    private const int Functions = 4_000;
++
++    private sealed record Row(
++        string Site,
++        string Note,
++        double BytesPerFunction,
++        double NanosecondsPerFunction,
++        double MaterializationsPerFunction,
++        long TotalBytes,
++        double TotalMilliseconds,
++        long TotalMaterializations);
++
++    internal static void Write()
++    {
++        var rows = new[]
++        {
++            Measure("nonstrict-create", false, false,
++                "an ordinary function, created and never called — it carries the Annex B "
++                    + "caller/arguments deferred cells from birth"),
++            Measure("strict-create", true, false,
++                "the CONTROL: identical but strict, so AddLegacyCallerAndArguments never runs "
++                    + "and there are no deferred cells to describe"),
++            Measure("nonstrict-create-and-call", false, true,
++                "the shape the item measured at 1.23 — define many, call each once"),
++            Measure("strict-create-and-call", true, true,
++                "the same, strict. If the first-call cost is the deferred cells, this row does "
++                    + "not pay it; if it pays anyway, the rest of the 1.23 is something else"),
++        };
++
++        Console.WriteLine(JsonSerializer.Serialize(
++            new
++            {
++                schema = "broiler.deferred-cell-cost/1",
++                functions = Functions,
++                note = "Allocated bytes and nanoseconds per FUNCTION. Strict is the control for "
++                    + "non-strict: the only difference between the two halves is whether the "
++                    + "function gets Annex B caller/arguments as deferred cells, which is what "
++                    + "roadmap item 2-9's losing-side hypothesis turns on.",
++                rows,
++            },
++            new JsonSerializerOptions { WriteIndented = true }));
++    }
++
++    private static Row Measure(string name, bool strict, bool call, string note)
++    {
++        using var context = BenchmarkContext.Create();
++
++        // Each function is given a distinct body so nothing can be shared or cached between
++        // them, and a trivially small one so the measurement is about the function OBJECT
++        // rather than about compiling a body.
++        var prologue = strict ? "'use strict'; " : string.Empty;
++        var body = call
++            ? $"var f = new Function('a', \"{prologue}return a + \" + i + \";\"); sink += f(1);"
++            : $"var f = new Function('a', \"{prologue}return a + \" + i + \";\"); sink += f ? 1 : 0;";
++
++        var source = $$"""
++            (function (n) {
++                var sink = 0;
++                for (var i = 0; i < n; i++) { {{body}} }
++                return sink;
++            })
++            """;
++
++        var function = context.Eval(source, $"{name}.js");
++        var warm = new Arguments(JSUndefined.Value, new JSNumber(50));
++        function.InvokeFunction(in warm);
++
++        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
++        GC.WaitForPendingFinalizers();
++        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
++
++        var arguments = new Arguments(JSUndefined.Value, new JSNumber(Functions));
++        PropertyOptimizationDiagnostics.Reset();
++        using var recording = PropertyOptimizationDiagnostics.Enable();
++        var before = GC.GetAllocatedBytesForCurrentThread();
++        var stopwatch = Stopwatch.StartNew();
++        function.InvokeFunction(in arguments);
++        stopwatch.Stop();
++        var bytes = GC.GetAllocatedBytesForCurrentThread() - before;
++        var materializations = PropertyOptimizationDiagnostics.Snapshot().NamedPropertiesMaterializations;
++
++        return new Row(
++            name,
++            note,
++            Math.Round((double)bytes / Functions, 1),
++            Math.Round(stopwatch.Elapsed.TotalMilliseconds * 1_000_000 / Functions, 1),
++            Math.Round((double)materializations / Functions, 2),
++            bytes,
++            Math.Round(stopwatch.Elapsed.TotalMilliseconds, 1),
++            materializations);
++    }
++}
+diff --git a/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/Program.cs b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/Program.cs
+index 83bb7888..78db6a1d 100644
+--- a/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/Program.cs
++++ b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/Program.cs
+@@ -62,6 +62,12 @@ public static class Program
+             return;
+         }
+ 
++        if (args.Length == 1 && args[0] == "--deferred-cell-cost")
++        {
++            DeferredCellCostMetrics.Write();
++            return;
++        }
++
+         if (args.Length == 2 && args[0] == "--property-map-distribution")
+         {
+             PropertyMapDistributionMetrics.Write(args[1]);
+-- 
+2.43.0
+

--- a/patches/0062-js-array-length-keeps-shape.patch
+++ b/patches/0062-js-array-length-keeps-shape.patch
@@ -1,0 +1,375 @@
+From f360dd4eacd1e1a177b422dc9ac89cc1238c5b21 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Mon, 3 Aug 2026 09:48:39 +0000
+Subject: [PATCH] Stop a writable array length from costing the array its shape
+
+Phase 2's exit criterion split -- Richards inside 200x at 183x, DeltaBlue
+outside at 576x -- and every phase 2 item had been sized on a probe rather than
+on the suite. Running the suites under the inline-cache counters (new
+--suite-cache-metrics) put three orders of magnitude between them on one number:
+DeltaBlue took 2 503 dictionary fallbacks against Richards's 1.
+
+2 507 of DeltaBlue's 2 512 array fallbacks came from JSArray.SetLengthWritable,
+which reaches the property store through GetOwnProperties() -- a mutable trie
+ref, which abandons the object's shape permanently. That method is on the grow
+path, so push, pop and concat each cost an array its shape on first use. push is
+the most common array operation in the language, and DeltaBlue's
+OrderedCollection.add is this.elms.push(elm).
+
+A writable length needs no descriptor at all: IsLengthReadOnly reads an ABSENT
+entry as writable, the default, and the stored value is never read back because
+GetOwnPropertyDescriptor builds it from _length. So the entry was pure
+write-only bookkeeping that cost the array its shape. SetLengthWritable now
+writes only when the length is non-writable or an entry already exists --
+Object.freeze and an explicit writable:false still record one, which is what
+keeps IsLengthReadOnly answerable.
+
+This also closes a hole in the class's own stated invariant:
+JSArray.SupportsShapeTracking documents that it is earned by not writing a named
+property of its own with a bare Put, and length was the one place that did.
+
+What it is worth, stated honestly. Dictionary fallbacks: DeltaBlue 2 503 -> 0,
+Box2D 9 -> 4, Richards 1 -> 0. A named property on an array that grows now keeps
+hitting its cache -- the test that until now asserted the opposite, and whose own
+comment called the fallback "the part worth pinning, because it bounds what item
+2-2 buys", is rewritten to pin >=499 hits across 500 reads after five pushes.
+
+But DeltaBlue's read hit rate did not change by a hundredth: 65.96% before,
+65.96% after, and the score is 116 -> 122 against its own 16.4% band, 576x ->
+581x. DeltaBlue puts no named properties on its arrays, so the shapes it was
+losing were shapes it never read through. This is a real defect fixed and it is
+NOT the explanation for 576x.
+
+Repository suite 7 563 tests across 13 projects, 0 failures. test262 unchanged
+across all four pinned manifests -- 8 313 executed, 8 220 passed, 84 failed, 44
+skipped, 9 timed out, identical manifest by manifest, test262-arrays included.
+Octane still 15 of 15 suites ok.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ .../Array/JSArray.cs                          |  35 ++++
+ .../PropertyShapeCacheTests.cs                |  29 +--
+ .../Program.cs                                |   6 +
+ .../SuiteCacheMetrics.cs                      | 190 ++++++++++++++++++
+ 4 files changed, 248 insertions(+), 12 deletions(-)
+ create mode 100644 Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/SuiteCacheMetrics.cs
+
+diff --git a/Broiler.JS/Broiler.JavaScript.BuiltIns/Array/JSArray.cs b/Broiler.JS/Broiler.JavaScript.BuiltIns/Array/JSArray.cs
+index b5bc67dc..47c4088a 100644
+--- a/Broiler.JS/Broiler.JavaScript.BuiltIns/Array/JSArray.cs
++++ b/Broiler.JS/Broiler.JavaScript.BuiltIns/Array/JSArray.cs
+@@ -742,11 +742,46 @@ public partial class JSArray : JSObject
+         }
+     }
+ 
++    /// <summary>
++    /// Records the <c>length</c> descriptor, but only when it has something to say.
++    /// </summary>
++    /// <remarks>
++    /// A writable <c>length</c> needs no descriptor at all. <see cref="IsLengthReadOnly"/> reads
++    /// an <em>absent</em> entry as writable — the default — and the stored value is never read
++    /// back, because <see cref="GetOwnPropertyDescriptor"/> builds it from <c>_length</c>. So for
++    /// the overwhelmingly common case the entry was pure write-only bookkeeping.
++    /// <para>
++    /// Writing it anyway was expensive out of all proportion. <c>GetOwnProperties()</c> hands out
++    /// a mutable trie ref, which <em>abandons the object's shape</em> — permanently, into
++    /// dictionary mode — and this method is on the grow path, so <c>push</c>, <c>pop</c> and
++    /// <c>concat</c> each cost an array its shape on first use. Measured on Octane, DeltaBlue
++    /// took 2 507 dictionary fallbacks this way against Richards's 1, and its read cache hit
++    /// rate sat at 66% against Richards's 87%. It is also the exact invariant this class's
++    /// <c>SupportsShapeTracking</c> says it earns by <em>not</em> writing a named property of its
++    /// own with a bare <c>Put</c> — <c>length</c> was the one place that did.
++    /// </para>
++    /// <para>
++    /// The non-writable case still writes, and so does a re-write of an entry that already
++    /// exists, so nothing that ever recorded a descriptor stops maintaining it. See
++    /// docs/performance-roadmap.md item 2-2 and phase 2's exit criterion.
++    /// </para>
++    /// </remarks>
+     private void SetLengthWritable(bool writable)
+     {
++        if (writable && !HasStoredLengthDescriptor())
++            return;
++
+         var attributes = writable ? JSPropertyAttributes.Value : JSPropertyAttributes.ReadonlyValue;
+         GetOwnProperties().Put(KeyStrings.length.Key) = new JSProperty(KeyStrings.length, CreateNumber(_length), attributes);
+     }
++
++    /// <summary>Whether a <c>length</c> descriptor has ever been recorded in the trie.</summary>
++    /// <remarks>Read-only access (<c>create: false</c>), so asking does not abandon the shape.</remarks>
++    private bool HasStoredLengthDescriptor()
++    {
++        ref var ownProperties = ref GetOwnProperties(false);
++        return !ownProperties.IsEmpty && !ownProperties.GetValue(KeyStrings.length.Key).IsEmpty;
++    }
+ }
+ 
+ 
+diff --git a/Broiler.JS/Broiler.JavaScript.Compiler.Tests/PropertyShapeCacheTests.cs b/Broiler.JS/Broiler.JavaScript.Compiler.Tests/PropertyShapeCacheTests.cs
+index aedefda9..f327bd7b 100644
+--- a/Broiler.JS/Broiler.JavaScript.Compiler.Tests/PropertyShapeCacheTests.cs
++++ b/Broiler.JS/Broiler.JavaScript.Compiler.Tests/PropertyShapeCacheTests.cs
+@@ -460,30 +460,35 @@ public class PropertyShapeCacheTests
+     }
+ 
+     [Fact]
+-    public void GrowingAnArrayThroughABuiltInAbandonsItsNamedShape()
++    public void GrowingAnArrayThroughABuiltInKeepsItsNamedShape()
+     {
+         // `length` is computed from the element store rather than held as a data property, so
+         // it can never occupy a slot however wide eligibility gets, and it must keep tracking
+         // the elements — which it does.
+         //
+-        // The dictionary fallback is the part worth pinning, because it bounds what item 2-2
+-        // buys. `push` reaches the property store through GetOwnProperties(create: true), and
+-        // that abandons the shape by design: a mutable ref handed to another assembly could add
+-        // a named property without telling the tracker, so the fast layout is dropped rather
+-        // than trusted. Exactly one fallback for five pushes — the first drops the shape and the
+-        // rest find it already gone. Correctness is unaffected; the named-property cache is, so
+-        // an array that grows through the built-ins stops hitting. Contrast
+-        // ANamedPropertyOnAnArray_IsCached, which does not grow and keeps its shape.
++        // This used to pin the OPPOSITE, and the old comment was right that the fallback bounded
++        // what item 2-2 buys: push reached the property store through GetOwnProperties(create:
++        // true), which abandons the shape, so an array that grew through the built-ins stopped
++        // hitting the named-property cache for good. That bound is gone. SetLengthWritable no
++        // longer records a descriptor for a WRITABLE length, because an absent entry already
++        // means writable and the stored value was never read back — so push, pop and concat
++        // no longer cost an array its shape.
++        //
++        // The hit assertion is the point, not the fallback count: the fallback was only ever
++        // interesting because of what it did to the cache.
+         var (result, stats) = Measure("""
+             var a = [];
+             a.tag = 1;
+             var seen = '';
+             for (var i = 0; i < 5; i++) { a.push(i); seen += a.length; }
+-            seen;
++            var s = 0;
++            for (var i = 0; i < 500; i++) s += a.tag;
++            seen + '|' + s;
+             """);
+ 
+-        Assert.Equal("12345", result);
+-        Assert.Equal(1, stats.DictionaryFallbacks);
++        Assert.Equal("12345|500", result);
++        Assert.Equal(0, stats.DictionaryFallbacks);
++        Assert.True(stats.CacheHits >= 499, $"expected the named read to keep hitting after growth, got {stats.CacheHits}/{stats.CacheMisses}");
+     }
+ 
+     [Fact]
+diff --git a/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/Program.cs b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/Program.cs
+index 78db6a1d..e821173a 100644
+--- a/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/Program.cs
++++ b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/Program.cs
+@@ -68,6 +68,12 @@ public static class Program
+             return;
+         }
+ 
++        if (args.Length == 2 && args[0] == "--suite-cache-metrics")
++        {
++            SuiteCacheMetrics.Write(args[1]);
++            return;
++        }
++
+         if (args.Length == 2 && args[0] == "--property-map-distribution")
+         {
+             PropertyMapDistributionMetrics.Write(args[1]);
+diff --git a/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/SuiteCacheMetrics.cs b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/SuiteCacheMetrics.cs
+new file mode 100644
+index 00000000..2b25c599
+--- /dev/null
++++ b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/SuiteCacheMetrics.cs
+@@ -0,0 +1,190 @@
++using System;
++using System.Collections.Generic;
++using System.IO;
++using System.Text.Json;
++using Broiler.JavaScript.Runtime;
++
++namespace Broiler.JavaScript.Engine.Benchmarks;
++
++/// <summary>
++/// Runs real Octane suites and reports what the property inline caches actually did on them —
++/// hit rate, megamorphic sites, dictionary fallbacks, shape transitions and trie
++/// materializations — rather than what a synthetic loop shaped like them does.
++/// </summary>
++/// <remarks>
++/// Exists because phase 2's exit criterion has now been measured and it SPLIT: Richards is inside
++/// 200× at 183× and DeltaBlue is not, at 576×. Every phase 2 item was sized on a probe, and §3.5
++/// already records what that costs — 2-8 was justified by DeltaBlue's score, measured with a loop
++/// written to look like DeltaBlue's hot path, and broke DeltaBlue outright, because the loop
++/// reproduced the reads the item was about and none of the writes.
++/// <para>
++/// So the question this answers is deliberately narrow: <em>do the caches phase 2 built actually
++/// hit on the suite phase 2 is failing?</em> Richards is the control — the same cluster, the same
++/// items, and it passes — so a counter that differs sharply between the two is a lead and a
++/// counter that does not is an exoneration. Box2D is included because §0 names the same trio.
++/// </para>
++/// <para>
++/// Counters over wall clock on purpose. Hit rates and counts are deterministic and exact, and
++/// this machine has already been shown to be too noisy for a single-run score to mean anything
++/// (§Phase 0). A ratio between two suites measured in the same process is not a timing claim.
++/// </para>
++/// </remarks>
++internal static class SuiteCacheMetrics
++{
++    private sealed record Suite(string Name, string[] Files);
++
++    /// <summary>The cluster §0 names for phase 2, with Richards as the passing control.</summary>
++    private static readonly Suite[] Suites =
++    [
++        new("Richards", ["richards.js"]),
++        new("DeltaBlue", ["deltablue.js"]),
++        new("Box2D", ["box2d.js"]),
++    ];
++
++    private const int RunsPerBenchmark = 3;
++
++    private const string Driver = """
++        (function () {
++            var suites = (typeof BenchmarkSuite !== 'undefined' && BenchmarkSuite.suites) || [];
++            var ran = 0, failures = [];
++            for (var i = 0; i < suites.length; i++) {
++                var suite = suites[i];
++                for (var j = 0; j < suite.benchmarks.length; j++) {
++                    var benchmark = suite.benchmarks[j];
++                    try {
++                        benchmark.Setup();
++                        for (var k = 0; k < __runs; k++) benchmark.run();
++                        benchmark.TearDown();
++                        ran++;
++                    } catch (e) {
++                        failures.push(suite.name + '/' + benchmark.name + ': ' + e);
++                    }
++                }
++            }
++            return ran + '|' + failures.join(' ;; ');
++        })()
++        """;
++
++    internal static void Write(string octaneDirectory)
++    {
++        if (!Directory.Exists(octaneDirectory))
++        {
++            Console.Error.WriteLine($"octane directory not found: {octaneDirectory}");
++            Environment.ExitCode = 2;
++            return;
++        }
++
++        var basePath = Path.Combine(octaneDirectory, "base.js");
++        if (!File.Exists(basePath))
++        {
++            Console.Error.WriteLine($"not an Octane checkout (no base.js): {octaneDirectory}");
++            Environment.ExitCode = 2;
++            return;
++        }
++
++        var baseSource = File.ReadAllText(basePath);
++        var rows = new List<object>();
++        foreach (var suite in Suites)
++        {
++            Console.Error.WriteLine($"{suite.Name}: running ...");
++            var row = RunSuite(octaneDirectory, baseSource, suite);
++            if (row != null)
++                rows.Add(row);
++        }
++
++        Console.WriteLine(JsonSerializer.Serialize(
++            new
++            {
++                schema = "broiler.suite-cache-metrics/1",
++                runsPerBenchmark = RunsPerBenchmark,
++                note = "Property inline cache behaviour on the real Octane suites of phase 2's "
++                    + "cluster. Richards passes the phase's 200x exit criterion and DeltaBlue "
++                    + "fails it at 576x, so a counter that separates them is a lead. Counts are "
++                    + "deterministic; no wall clock is reported because this machine is too "
++                    + "noisy for a single run to mean anything.",
++                suites = rows,
++            },
++            new JsonSerializerOptions { WriteIndented = true }));
++    }
++
++    private static object RunSuite(string octaneDirectory, string baseSource, Suite suite)
++    {
++        var sources = new List<string> { baseSource };
++        foreach (var file in suite.Files)
++        {
++            var path = Path.Combine(octaneDirectory, file);
++            if (!File.Exists(path))
++            {
++                Console.Error.WriteLine($"{suite.Name}: missing {file}, skipped");
++                return null;
++            }
++
++            sources.Add(File.ReadAllText(path));
++        }
++
++        using var context = BenchmarkContext.Create();
++
++        string outcome;
++        PropertyOptimizationSnapshot snapshot;
++
++        // The window covers the LOAD as well as the run: the shapes a suite's top-level code
++        // builds are shapes the workload builds, and a cache that misses while warming is part
++        // of what the score pays for.
++        using (PropertyOptimizationDiagnostics.Enable())
++        {
++            PropertyOptimizationDiagnostics.Reset();
++            try
++            {
++                context.Eval("if (typeof print === 'undefined') { var print = function () { }; }", "shim.js");
++                for (var i = 0; i < sources.Count; i++)
++                    context.Eval(sources[i], i == 0 ? "base.js" : suite.Files[i - 1]);
++
++                context.Eval($"var __runs = {RunsPerBenchmark};", "runs.js");
++            }
++            catch (Exception e)
++            {
++                Console.Error.WriteLine($"{suite.Name}: failed to load — {e.GetType().Name}: {e.Message}");
++                return new { suite = suite.Name, loaded = false, error = $"{e.GetType().Name}: {e.Message}" };
++            }
++
++            try
++            {
++                outcome = context.Eval(Driver, "driver.js").ToString();
++            }
++            catch (Exception e)
++            {
++                outcome = $"0|driver threw {e.GetType().Name}: {e.Message}";
++            }
++
++            snapshot = PropertyOptimizationDiagnostics.Snapshot();
++        }
++
++        var split = outcome.Split('|', 2);
++        var reads = snapshot.CacheHits + snapshot.CacheMisses;
++        var writes = snapshot.StoreCacheHits + snapshot.StoreCacheMisses;
++
++        return new
++        {
++            suite = suite.Name,
++            loaded = true,
++            benchmarksRun = int.TryParse(split[0], out var ran) ? ran : 0,
++            failures = split.Length > 1 && split[1].Length > 0 ? split[1] : null,
++
++            readCacheHits = snapshot.CacheHits,
++            readCacheMisses = snapshot.CacheMisses,
++            readHitRatePercent = reads == 0 ? 0 : Math.Round(100.0 * snapshot.CacheHits / reads, 2),
++            readMegamorphicSites = snapshot.MegamorphicSites,
++
++            storeCacheHits = snapshot.StoreCacheHits,
++            storeCacheMisses = snapshot.StoreCacheMisses,
++            storeHitRatePercent = writes == 0 ? 0 : Math.Round(100.0 * snapshot.StoreCacheHits / writes, 2),
++            storeMegamorphicSites = snapshot.StoreMegamorphicSites,
++
++            polymorphicPromotions = snapshot.PolymorphicPromotions,
++            dictionaryFallbacks = snapshot.DictionaryFallbacks,
++            shapeTransitions = snapshot.ShapeTransitions,
++            prototypeInvalidations = snapshot.PrototypeInvalidations,
++            namedPropertiesMaterializations = snapshot.NamedPropertiesMaterializations,
++        };
++    }
++}
+-- 
+2.43.0
+

--- a/patches/0063-js-prototype-rewrite-no-invalidate.patch
+++ b/patches/0063-js-prototype-rewrite-no-invalidate.patch
@@ -1,0 +1,84 @@
+From 5786ea936a944f8011881f8fa1028136911fc22c Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Mon, 3 Aug 2026 11:00:27 +0000
+Subject: [PATCH] Stop a redundant prototype write from retiring every
+ prototype cache
+
+Decomposing DeltaBlue's cache misses found that a class instantiation published
+a global prototype-chain invalidation once per allocation -- 2 002 for 2 000 --
+where a function constructor published 1. That is item 2-0's defect surviving on
+a path 2-0 did not cover.
+
+The two obvious sites in JSClass.CreateInstance were already correct: the
+instance is built with new JSObject(instancePrototype), carrying 2-0's own
+comment. What publishes is the re-apply afterwards -- assigning the prototype the
+constructor had already installed. prototypeChain is non-null by then, so the
+setter reads it as a [[SetPrototypeOf]] on a live object.
+
+The fix is to notice the chain did not change. Every assumption the prototype
+version guards is about which chain an object has; after a redundant write it
+has the same one, so nothing cached is stale. The setter now compares the
+resulting chain with the previous one and publishes only on a real change --
+fixing the class path, the derived-class path and any other redundant assignment
+at once rather than patching call sites one at a time.
+
+Per n allocations: class 2 002 -> 0, function 1 -> 0, derived class 2 flat.
+
+On the real Octane suites the effect is much larger than the class case
+suggested, because the retirement was process-wide -- one redundant write
+anywhere retired every prototype-keyed entry everywhere. Exact counts:
+
+  Richards   invalidations   37 -> 10     read hit rate  86.61% -> 99.97%
+  DeltaBlue  invalidations 2519 -> 16     read hit rate  65.96% -> 69.45%
+  Box2D      invalidations 1944 -> 107    read hit rate  96.39% -> 97.72%
+
+Richards goes from missing one read in seven to one in three thousand. Every
+phase 2 probe measured the machinery in isolation, where the storm does not
+exist, and all of them reported it working.
+
+Scores moved the right way and are NOT claimed: Richards 143 -> 168 and
+DeltaBlue 122 -> 125 over five repetitions per engine, with Richards's +17%
+inside its own 15.5% band. DeltaBlue still FAILS phase 2's exit criterion at
+516x against the 200x gate.
+
+Repository suite 7 563 tests across 13 projects, 0 failures. test262 unchanged
+across all four pinned manifests -- 8 313 / 8 220 / 84 / 44 / 9, identical
+manifest by manifest. test262-arrays matters doubly because the same version
+gates JSArray's dense-element fast path; properties-proxy and realm-isolation
+are where a wrongly-skipped invalidation would surface. Octane 15 of 15 ok.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ Broiler.JS/Broiler.JavaScript.Runtime/JSObject.cs | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/Broiler.JS/Broiler.JavaScript.Runtime/JSObject.cs b/Broiler.JS/Broiler.JavaScript.Runtime/JSObject.cs
+index 32623781..bff26e7b 100644
+--- a/Broiler.JS/Broiler.JavaScript.Runtime/JSObject.cs
++++ b/Broiler.JS/Broiler.JavaScript.Runtime/JSObject.cs
+@@ -68,9 +68,20 @@ public partial class JSObject : JSValue
+             // version itself. Bumping unconditionally made the prototype version advance once
+             // per object allocation, which would leave any prototype-keyed cache permanently
+             // invalid in a loop that allocates. See docs/performance-roadmap.md P1-2.
+-            var replacingExistingPrototype = prototypeChain != null;
++            var previousChain = prototypeChain;
+             prototypeChain = prototype?.PrototypeObject;
+-            if (replacingExistingPrototype || isUsedAsPrototype)
++
++            // A write that does not CHANGE the chain invalidates nothing. Every cached
++            // assumption guarded by the prototype version is about which chain this object
++            // has, and after a redundant write it still has the same one. Without this test a
++            // re-assignment of the prototype an object already had — which class construction
++            // does once per `new`, re-applying the newTarget-derived prototype the constructor
++            // had already installed — retired every prototype-keyed inline-cache entry in the
++            // process. That is item 2-0's defect surviving on the class path: 2-0 removed the
++            // second write in JSFunction's OrdinaryCreateFromConstructor and JSClass removed
++            // its own at construction, but the later re-apply still read as a mutation.
++            var chainChanged = !ReferenceEquals(previousChain, prototypeChain);
++            if (chainChanged && (previousChain != null || isUsedAsPrototype))
+                 NotifyPrototypeChainMutation();
+ 
+             PropertyChanged?.Invoke(this, (uint.MaxValue, uint.MaxValue, null));
+-- 
+2.43.0
+

--- a/patches/0064-js-refresh-stale-cache-entry.patch
+++ b/patches/0064-js-refresh-stale-cache-entry.patch
@@ -1,0 +1,213 @@
+From 422d7fda01161cffa655325cf4b54d9d44a8fd88 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Mon, 3 Aug 2026 11:55:50 +0000
+Subject: [PATCH] Refresh a stale inline-cache entry instead of declining to
+ replace it
+
+2-10 owed a per-site attribution of DeltaBlue's misses. Counting the lookup's
+exits separately says effectively all of them (99.9%) are the same one: the site
+had room, was not megamorphic, and the receiver's shape was not among its
+entries -- the exit that is supposed to be self-correcting, because a site with
+room that meets a new shape adds it and hits from then on.
+
+Splitting that exit found why it does not correct. The add path deduplicates on
+ShapeId and Holder; a hit checks those plus the prototype version, the
+receiver's prototype identity, and the holder's shape and slot. Any of the four
+can go stale while the two dedup keys stay equal. When one does, the read
+misses, reaches the add path, is told the entry is already present, and returns
+without replacing it -- leaving the stale entry in place with no route back, so
+that site misses on that receiver for the rest of the process. 237 738 of
+DeltaBlue's 306 004 misses, 77.7%.
+
+The fix is to refresh in place. entryToAdd was just built from the live
+receiver, so it is by construction the correct replacement.
+
+  DeltaBlue  read hit rate  69.45% -> 93.16%   misses 306 004 -> 68 534
+  Box2D      read hit rate  97.72% -> 98.83%   misses 592 263 -> 303 612
+  Richards   read hit rate  99.97% -> 99.97%   misses     208 ->     192
+
+Taken with 2-11 DeltaBlue goes 65.96% -> 93.16% and its misses fall 78%.
+Richards was already at the ceiling and stays there, which is the control
+working: it had almost no stale entries to refresh.
+
+Scores moved and are still not claimed: DeltaBlue 125 -> 145 (516x -> 447x) and
+Richards 168 -> 170, five repetitions per engine, DeltaBlue's +16% against a
+13.8% band. DeltaBlue still FAILS phase 2's exit criterion at 447x -- but the
+cache is no longer the reason, and what remains is not property-cache-shaped.
+
+Also adds the miss-reason counters the attribution needed (cold, shape, key
+mismatch, megamorphic, non-object, not-describable, entry-already-present), all
+behind the existing opt-in Enabled flag.
+
+Cannot return a wrong value: a refreshed entry is still checked by every guard
+on the next read, and the entry it replaces is one the guards had just rejected.
+
+Repository suite 7 627 tests across 13 projects, 0 failures. test262 unchanged
+across all four pinned manifests -- 8 313 / 8 220 / 84 / 44 / 9, identical
+manifest by manifest.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ .../Broiler.JavaScript.Runtime/ObjectShape.cs | 76 ++++++++++++++++++-
+ .../SuiteCacheMetrics.cs                      | 11 +++
+ 2 files changed, 85 insertions(+), 2 deletions(-)
+
+diff --git a/Broiler.JS/Broiler.JavaScript.Runtime/ObjectShape.cs b/Broiler.JS/Broiler.JavaScript.Runtime/ObjectShape.cs
+index b4b89b69..34e41d73 100644
+--- a/Broiler.JS/Broiler.JavaScript.Runtime/ObjectShape.cs
++++ b/Broiler.JS/Broiler.JavaScript.Runtime/ObjectShape.cs
+@@ -96,7 +96,14 @@ public readonly record struct PropertyOptimizationSnapshot(
+     long StoreCacheHits,
+     long StoreCacheMisses,
+     long StoreMegamorphicSites,
+-    long NamedPropertiesMaterializations);
++    long NamedPropertiesMaterializations,
++    long MissMegamorphic,
++    long MissNonObject,
++    long MissCold,
++    long MissKeyMismatch,
++    long MissShape,
++    long MissNotDescribable,
++    long MissEntryAlreadyPresent);
+ 
+ /// <summary>
+ /// Counters for validating shape/cache invalidation behavior.
+@@ -121,6 +128,13 @@ public static class PropertyOptimizationDiagnostics
+     private static long storeCacheMisses;
+     private static long storeMegamorphicSites;
+     private static long namedPropertiesMaterializations;
++    private static long missMegamorphic;
++    private static long missNonObject;
++    private static long missCold;
++    private static long missKeyMismatch;
++    private static long missShape;
++    private static long missNotDescribable;
++    private static long missEntryAlreadyPresent;
+ 
+     /// <summary>
+     /// Whether the counters below are recorded. Defaults to <c>false</c>; while it is
+@@ -165,6 +179,21 @@ public static class PropertyOptimizationDiagnostics
+     // measurement, and a strict function is the control that says whether the Annex B
+     // cells are what causes them.
+     internal static void RecordNamedPropertiesMaterialized() { if (Enabled) Interlocked.Increment(ref namedPropertiesMaterializations); }
++    // Why a read MISSED, which the bare miss counter cannot say. DeltaBlue sits at a 69%
++    // read hit rate against Richards's 99.97%, with megamorphism, dictionary mode and
++    // prototype invalidation all ruled out, so the remaining question is which of the
++    // lookup's own exits it takes. Recorded only while Enabled, like every counter here.
++    internal static void RecordMissMegamorphic() { if (Enabled) Interlocked.Increment(ref missMegamorphic); }
++    internal static void RecordMissNonObject() { if (Enabled) Interlocked.Increment(ref missNonObject); }
++    internal static void RecordMissCold() { if (Enabled) Interlocked.Increment(ref missCold); }
++    internal static void RecordMissKeyMismatch() { if (Enabled) Interlocked.Increment(ref missKeyMismatch); }
++    internal static void RecordMissShape() { if (Enabled) Interlocked.Increment(ref missShape); }
++    // A miss whose entry could NOT be built: TryDescribe found the key neither in an own
++    // shape slot nor on a shape-tracked prototype, so nothing is cached and the same read
++    // misses again forever. That is the difference between a site warming up and a site that
++    // never can.
++    internal static void RecordMissNotDescribable() { if (Enabled) Interlocked.Increment(ref missNotDescribable); }
++    internal static void RecordMissEntryAlreadyPresent() { if (Enabled) Interlocked.Increment(ref missEntryAlreadyPresent); }
+ 
+     public static PropertyOptimizationSnapshot Snapshot() => new(
+         Interlocked.Read(ref shapeTransitions),
+@@ -178,7 +207,14 @@ public static class PropertyOptimizationDiagnostics
+         Interlocked.Read(ref storeCacheHits),
+         Interlocked.Read(ref storeCacheMisses),
+         Interlocked.Read(ref storeMegamorphicSites),
+-        Interlocked.Read(ref namedPropertiesMaterializations));
++        Interlocked.Read(ref namedPropertiesMaterializations),
++        Interlocked.Read(ref missMegamorphic),
++        Interlocked.Read(ref missNonObject),
++        Interlocked.Read(ref missCold),
++        Interlocked.Read(ref missKeyMismatch),
++        Interlocked.Read(ref missShape),
++        Interlocked.Read(ref missNotDescribable),
++        Interlocked.Read(ref missEntryAlreadyPresent));
+ 
+     public static void Reset()
+     {
+@@ -193,6 +229,13 @@ public static class PropertyOptimizationDiagnostics
+         Interlocked.Exchange(ref storeCacheMisses, 0);
+         Interlocked.Exchange(ref storeMegamorphicSites, 0);
+         Interlocked.Exchange(ref namedPropertiesMaterializations, 0);
++        Interlocked.Exchange(ref missMegamorphic, 0);
++        Interlocked.Exchange(ref missNonObject, 0);
++        Interlocked.Exchange(ref missCold, 0);
++        Interlocked.Exchange(ref missKeyMismatch, 0);
++        Interlocked.Exchange(ref missShape, 0);
++        Interlocked.Exchange(ref missNotDescribable, 0);
++        Interlocked.Exchange(ref missEntryAlreadyPresent, 0);
+     }
+ }
+ 
+@@ -539,6 +582,19 @@ public static class PropertyInlineCacheSite
+             }
+ 
+             PropertyOptimizationDiagnostics.RecordCacheMiss();
++            if (PropertyOptimizationDiagnostics.Enabled)
++            {
++                if (megamorphic)
++                    PropertyOptimizationDiagnostics.RecordMissMegamorphic();
++                else if (target is not JSObject)
++                    PropertyOptimizationDiagnostics.RecordMissNonObject();
++                else if (key == 0)
++                    PropertyOptimizationDiagnostics.RecordMissCold();
++                else if (key != property.Key)
++                    PropertyOptimizationDiagnostics.RecordMissKeyMismatch();
++                else
++                    PropertyOptimizationDiagnostics.RecordMissShape();
++            }
+             var result = target[property];
+ 
+             if (megamorphic || target is not JSObject ordinary || property.Metadata.IsPrivateName)
+@@ -558,11 +614,27 @@ public static class PropertyInlineCacheSite
+             }
+ 
+             if (!TryDescribe(ordinary, in property, out var entryToAdd))
++            {
++                PropertyOptimizationDiagnostics.RecordMissNotDescribable();
+                 return result;
++            }
+ 
+             for (var i = 0; i < count; i++)
+                 if (entries[i].ShapeId == entryToAdd.ShapeId && entries[i].Holder == entryToAdd.Holder)
++                {
++                    PropertyOptimizationDiagnostics.RecordMissEntryAlreadyPresent();
++
++                    // REFRESH, do not decline. ShapeId and Holder identify the entry, but
++                    // they are not what a hit checks: the prototype version, the receiver's
++                    // prototype identity, and the holder's shape and slot are all guards too,
++                    // and any of them can go stale while these two stay equal. Returning here
++                    // left the stale entry in place with no way back — the site could never
++                    // re-describe it, so it missed on this receiver for the rest of the
++                    // process. entryToAdd was just built from the live receiver, so it is by
++                    // construction the correct replacement.
++                    entries[i] = entryToAdd;
+                     return result;
++                }
+ 
+             if (count == MaxEntries)
+             {
+diff --git a/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/SuiteCacheMetrics.cs b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/SuiteCacheMetrics.cs
+index 2b25c599..ed31edc1 100644
+--- a/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/SuiteCacheMetrics.cs
++++ b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/SuiteCacheMetrics.cs
+@@ -175,6 +175,17 @@ internal static class SuiteCacheMetrics
+             readHitRatePercent = reads == 0 ? 0 : Math.Round(100.0 * snapshot.CacheHits / reads, 2),
+             readMegamorphicSites = snapshot.MegamorphicSites,
+ 
++            // Why the misses missed. Cold is one per site per key and is a floor, not a defect;
++            // shape is the interesting one — the site had room and the receiver's shape was not
++            // among the entries it held.
++            missCold = snapshot.MissCold,
++            missShape = snapshot.MissShape,
++            missNotDescribable = snapshot.MissNotDescribable,
++            missEntryAlreadyPresent = snapshot.MissEntryAlreadyPresent,
++            missKeyMismatch = snapshot.MissKeyMismatch,
++            missMegamorphic = snapshot.MissMegamorphic,
++            missNonObject = snapshot.MissNonObject,
++
+             storeCacheHits = snapshot.StoreCacheHits,
+             storeCacheMisses = snapshot.StoreCacheMisses,
+             storeHitRatePercent = writes == 0 ? 0 : Math.Round(100.0 * snapshot.StoreCacheHits / writes, 2),
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -30,11 +30,13 @@ Delete the patch file and its row below once the pointer is bumped.
 
 | `0062-js-array-length-keeps-shape` | `Broiler.JS` | Item 2-10. `JSArray.SetLengthWritable` recorded a `length` descriptor through `GetOwnProperties()`, which **abandons the object's shape permanently** — and it is on the grow path, so `push`, `pop` and `concat` each cost an array its shape on first use. A writable `length` needs no descriptor at all (`IsLengthReadOnly` reads absence as writable; the stored value is never read back). **DeltaBlue's dictionary fallbacks 2 503 → 0**, and a named property on a grown array keeps hitting its cache. Honest limit: DeltaBlue's read hit rate and score do **not** move, so this is not the explanation for its 576×. **Requires `0061` to compile.** |
 
+| `0063-js-prototype-rewrite-no-invalidate` | `Broiler.JS` | Item 2-11. A write that re-applies the prototype an object **already has** read as a `[[SetPrototypeOf]]` on a live object and retired **every** prototype-keyed inline-cache entry in the process — class construction did it once per `new` (2 002 invalidations for 2 000 allocations). The setter now publishes only when the chain actually changes. Because the retirement was process-wide the effect is far wider than the class case: **Richards's read cache hit rate 86.61% → 99.97%**, DeltaBlue 65.96% → 69.45%, Box2D 96.39% → 97.72%; invalidations 37 → 10, 2 519 → 16, 1 944 → 107. One file, one condition; independent of `0059`–`0062`. |
+
 The ten `Broiler.JS` patches this file previously carried (`0049`–`0058`) have all been
 applied and their pointer bumped; they are listed under *Recently cleared* below with the
 commit each landed as.
 
-**`0059`–`0062` are pending against the pinned pointer `2ebc0c3c`.** All four apply cleanly in
+**`0059`–`0063` are pending against the pinned pointer `2ebc0c3c`.** All five apply cleanly in
 numeric order. Two ordering constraints are real:
 
 - **`0060` after `0059`** — it touches the function `0059` restructures, so out of order they
@@ -45,11 +47,11 @@ numeric order. Two ordering constraints are real:
   build after applying.
 
 Each push to `Broiler-Platform/Broiler.JS` returned 403 from the session's git proxy, so the
-pointer is deliberately *not* bumped. None of the four needs a main-repo fallback: `0059` and
+pointer is deliberately *not* bumped. None of the five needs a main-repo fallback: `0059` and
 `0060` are allocation reductions with no behaviour difference, so CI is correct without them and
 only more allocating; `0061` adds a benchmark emitter and an opt-in counter that is off unless
-`PropertyOptimizationDiagnostics.Enabled` is set; and `0062` removes a pessimization, so without
-it CI is correct and only slower.
+`PropertyOptimizationDiagnostics.Enabled` is set; and `0062` and `0063` remove pessimizations, so
+without them CI is correct and only slower.
 
 ## Recently cleared
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -24,16 +24,18 @@ Delete the patch file and its row below once the pointer is bumped.
 | Patch | Submodule | Note |
 | --- | --- | --- |
 | `0059-js-single-match-replace-one-allocation` | `Broiler.JS` | Phase 5's first follow-up to item 1. A single-match `replace` assembled its answer through a `StringBuilder`, costing two full UTF-16 copies of the subject — into the chunk list, then back out through `ToString()`. `string.Concat` over three spans writes it in one allocation: **4.020 → 2.020 bytes per subject character**, exactly the predicted halving, in `RegExp.prototype[@@replace]` *and* in `String.prototype.replace`'s string-`searchValue` builtin, which had the same three appends into a builder that was already sized exactly right. Adds `SingleMatchReplaceAllocationTests` (41 cases) and a `replace-one-string` profile row. |
+| `0060-js-stream-global-replace` | `Broiler.JS` | Phase 5's second follow-up. §22.2.6.11 collects every match before reading any of their properties, so a global replace held one result array per match live — **2 032.8 bytes per match, dead linear**, 10.3 MB for one 5 000-match call. Streams instead when nothing can observe the results: the receiver's `exec` is the pristine `%RegExp.prototype.exec%` captured at realm init, the replacement is a string, and it contains no `$`. **478.3 B/match, 0.235x.** Splits `Exec` into `ExecMatch` + `BuildExecResult` so both paths share the `lastIndex`/sticky/statics code, and adds `JSContext.IntrinsicRegExpExec` and `GlobalReplaceStreamingTests` (23 cases). **Apply after `0059` — it builds on the same function.** |
 
 The ten `Broiler.JS` patches this file previously carried (`0049`–`0058`) have all been
 applied and their pointer bumped; they are listed under *Recently cleared* below with the
 commit each landed as.
 
-**`0059` is pending against the pinned pointer `2ebc0c3c`** — the push to
-`Broiler-Platform/Broiler.JS` returned 403 from the session's git proxy, so the pointer is
-deliberately *not* bumped. There is no main-repo fallback for it and none is needed: the
-change is an allocation reduction with no behaviour difference, so CI is correct without it,
-only more allocating.
+**`0059` and `0060` are pending against the pinned pointer `2ebc0c3c`**, in that order —
+`0060` touches the function `0059` restructures, so applying them out of order will conflict.
+The push to `Broiler-Platform/Broiler.JS` returned 403 from the session's git proxy, so the
+pointer is deliberately *not* bumped. There is no main-repo fallback for either and none is
+needed: both are allocation reductions with no behaviour difference, so CI is correct without
+them, only more allocating.
 
 ## Recently cleared
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -21,9 +21,19 @@ Delete the patch file and its row below once the pointer is bumped.
 
 ## Index
 
-**Empty — nothing is pending.** The ten `Broiler.JS` patches this file carried
-(`0049`–`0058`) have all been applied and their pointer bumped; they are listed under
-*Recently cleared* below with the commit each landed as.
+| Patch | Submodule | Note |
+| --- | --- | --- |
+| `0059-js-single-match-replace-one-allocation` | `Broiler.JS` | Phase 5's first follow-up to item 1. A single-match `replace` assembled its answer through a `StringBuilder`, costing two full UTF-16 copies of the subject — into the chunk list, then back out through `ToString()`. `string.Concat` over three spans writes it in one allocation: **4.020 → 2.020 bytes per subject character**, exactly the predicted halving, in `RegExp.prototype[@@replace]` *and* in `String.prototype.replace`'s string-`searchValue` builtin, which had the same three appends into a builder that was already sized exactly right. Adds `SingleMatchReplaceAllocationTests` (41 cases) and a `replace-one-string` profile row. |
+
+The ten `Broiler.JS` patches this file previously carried (`0049`–`0058`) have all been
+applied and their pointer bumped; they are listed under *Recently cleared* below with the
+commit each landed as.
+
+**`0059` is pending against the pinned pointer `2ebc0c3c`** — the push to
+`Broiler-Platform/Broiler.JS` returned 403 from the session's git proxy, so the pointer is
+deliberately *not* bumped. There is no main-repo fallback for it and none is needed: the
+change is an allocation reduction with no behaviour difference, so CI is correct without it,
+only more allocating.
 
 ## Recently cleared
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -32,25 +32,28 @@ Delete the patch file and its row below once the pointer is bumped.
 
 | `0063-js-prototype-rewrite-no-invalidate` | `Broiler.JS` | Item 2-11. A write that re-applies the prototype an object **already has** read as a `[[SetPrototypeOf]]` on a live object and retired **every** prototype-keyed inline-cache entry in the process — class construction did it once per `new` (2 002 invalidations for 2 000 allocations). The setter now publishes only when the chain actually changes. Because the retirement was process-wide the effect is far wider than the class case: **Richards's read cache hit rate 86.61% → 99.97%**, DeltaBlue 65.96% → 69.45%, Box2D 96.39% → 97.72%; invalidations 37 → 10, 2 519 → 16, 1 944 → 107. One file, one condition; independent of `0059`–`0062`. |
 
+| `0064-js-refresh-stale-cache-entry` | `Broiler.JS` | Item 2-12. The property inline cache's add path deduplicated on `ShapeId` + `Holder`, while a hit checked those **plus four more guards**. When one went stale the read missed, reached the add path, was told the entry was "already present", and returned without replacing it — so that site missed on that receiver **for the rest of the process**. 77.7% of DeltaBlue's misses. Refreshing in place takes **DeltaBlue's read hit rate 69.45% → 93.16%** (misses 306 004 → 68 534) and Box2D's 97.72% → 98.83%. Also adds the miss-reason counters the attribution needed. **Requires `0061` and `0062` to compile.** |
+
 The ten `Broiler.JS` patches this file previously carried (`0049`–`0058`) have all been
 applied and their pointer bumped; they are listed under *Recently cleared* below with the
 commit each landed as.
 
-**`0059`–`0063` are pending against the pinned pointer `2ebc0c3c`.** All five apply cleanly in
-numeric order. Two ordering constraints are real:
+**`0059`–`0064` are pending against the pinned pointer `2ebc0c3c`.** All six apply cleanly in
+numeric order, and the full stack builds. Two ordering constraints are real:
 
 - **`0060` after `0059`** — it touches the function `0059` restructures, so out of order they
   conflict textually.
+- **`0064` after `0061` and `0062`** — it reads `0061`'s counters and extends `0062`'s emitter.
 - **`0062` after `0061`** — `0062` applies cleanly on its own but will **not compile** without
   `0061`, because its new `--suite-cache-metrics` emitter reads the
   `NamedPropertiesMaterializations` counter `0061` adds. A textual check is not enough here;
   build after applying.
 
 Each push to `Broiler-Platform/Broiler.JS` returned 403 from the session's git proxy, so the
-pointer is deliberately *not* bumped. None of the five needs a main-repo fallback: `0059` and
+pointer is deliberately *not* bumped. None of the six needs a main-repo fallback: `0059` and
 `0060` are allocation reductions with no behaviour difference, so CI is correct without them and
 only more allocating; `0061` adds a benchmark emitter and an opt-in counter that is off unless
-`PropertyOptimizationDiagnostics.Enabled` is set; and `0062` and `0063` remove pessimizations, so
+`PropertyOptimizationDiagnostics.Enabled` is set; and `0062`, `0063` and `0064` remove pessimizations, so
 without them CI is correct and only slower.
 
 ## Recently cleared

--- a/patches/README.md
+++ b/patches/README.md
@@ -28,19 +28,28 @@ Delete the patch file and its row below once the pointer is bumped.
 
 | `0061-js-measure-2-9-materialization-cause` | `Broiler.JS` | Measurement and instrumentation only, **no behaviour change**. Item 2-9's losing-side hypothesis said the Annex B deferred cells force the trie rebuild; a *strict* function is the control it never had, and it rebuilds just as much — **1.00 per function on all four rows**. What materializes is the `prototype` install, withheld from shape-only storage by 2-8's DeltaBlue fix, so the planned "stop materializing for a deferred cell" follow-up is withdrawn before being built. Adds `--deferred-cell-cost` and a `RecordNamedPropertiesMaterialized` counter. **Independent of `0059`/`0060`** — different files, applies in any order. |
 
+| `0062-js-array-length-keeps-shape` | `Broiler.JS` | Item 2-10. `JSArray.SetLengthWritable` recorded a `length` descriptor through `GetOwnProperties()`, which **abandons the object's shape permanently** — and it is on the grow path, so `push`, `pop` and `concat` each cost an array its shape on first use. A writable `length` needs no descriptor at all (`IsLengthReadOnly` reads absence as writable; the stored value is never read back). **DeltaBlue's dictionary fallbacks 2 503 → 0**, and a named property on a grown array keeps hitting its cache. Honest limit: DeltaBlue's read hit rate and score do **not** move, so this is not the explanation for its 576×. **Requires `0061` to compile.** |
+
 The ten `Broiler.JS` patches this file previously carried (`0049`–`0058`) have all been
 applied and their pointer bumped; they are listed under *Recently cleared* below with the
 commit each landed as.
 
-**`0059`, `0060` and `0061` are pending against the pinned pointer `2ebc0c3c`.** `0059` and
-`0060` must go in that order — `0060` touches the function `0059` restructures, so applying
-them out of order will conflict. `0061` touches a disjoint set of files and applies in any
-order relative to the other two. Each push to `Broiler-Platform/Broiler.JS` returned 403 from
-the session's git proxy, so the pointer is deliberately *not* bumped. None of the three needs
-a main-repo fallback: `0059` and `0060` are allocation reductions with no behaviour
-difference, so CI is correct without them and only more allocating, and `0061` adds a
-benchmark emitter and an opt-in counter that is off unless
-`PropertyOptimizationDiagnostics.Enabled` is set.
+**`0059`–`0062` are pending against the pinned pointer `2ebc0c3c`.** All four apply cleanly in
+numeric order. Two ordering constraints are real:
+
+- **`0060` after `0059`** — it touches the function `0059` restructures, so out of order they
+  conflict textually.
+- **`0062` after `0061`** — `0062` applies cleanly on its own but will **not compile** without
+  `0061`, because its new `--suite-cache-metrics` emitter reads the
+  `NamedPropertiesMaterializations` counter `0061` adds. A textual check is not enough here;
+  build after applying.
+
+Each push to `Broiler-Platform/Broiler.JS` returned 403 from the session's git proxy, so the
+pointer is deliberately *not* bumped. None of the four needs a main-repo fallback: `0059` and
+`0060` are allocation reductions with no behaviour difference, so CI is correct without them and
+only more allocating; `0061` adds a benchmark emitter and an opt-in counter that is off unless
+`PropertyOptimizationDiagnostics.Enabled` is set; and `0062` removes a pessimization, so without
+it CI is correct and only slower.
 
 ## Recently cleared
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -26,16 +26,21 @@ Delete the patch file and its row below once the pointer is bumped.
 | `0059-js-single-match-replace-one-allocation` | `Broiler.JS` | Phase 5's first follow-up to item 1. A single-match `replace` assembled its answer through a `StringBuilder`, costing two full UTF-16 copies of the subject — into the chunk list, then back out through `ToString()`. `string.Concat` over three spans writes it in one allocation: **4.020 → 2.020 bytes per subject character**, exactly the predicted halving, in `RegExp.prototype[@@replace]` *and* in `String.prototype.replace`'s string-`searchValue` builtin, which had the same three appends into a builder that was already sized exactly right. Adds `SingleMatchReplaceAllocationTests` (41 cases) and a `replace-one-string` profile row. |
 | `0060-js-stream-global-replace` | `Broiler.JS` | Phase 5's second follow-up. §22.2.6.11 collects every match before reading any of their properties, so a global replace held one result array per match live — **2 032.8 bytes per match, dead linear**, 10.3 MB for one 5 000-match call. Streams instead when nothing can observe the results: the receiver's `exec` is the pristine `%RegExp.prototype.exec%` captured at realm init, the replacement is a string, and it contains no `$`. **478.3 B/match, 0.235x.** Splits `Exec` into `ExecMatch` + `BuildExecResult` so both paths share the `lastIndex`/sticky/statics code, and adds `JSContext.IntrinsicRegExpExec` and `GlobalReplaceStreamingTests` (23 cases). **Apply after `0059` — it builds on the same function.** |
 
+| `0061-js-measure-2-9-materialization-cause` | `Broiler.JS` | Measurement and instrumentation only, **no behaviour change**. Item 2-9's losing-side hypothesis said the Annex B deferred cells force the trie rebuild; a *strict* function is the control it never had, and it rebuilds just as much — **1.00 per function on all four rows**. What materializes is the `prototype` install, withheld from shape-only storage by 2-8's DeltaBlue fix, so the planned "stop materializing for a deferred cell" follow-up is withdrawn before being built. Adds `--deferred-cell-cost` and a `RecordNamedPropertiesMaterialized` counter. **Independent of `0059`/`0060`** — different files, applies in any order. |
+
 The ten `Broiler.JS` patches this file previously carried (`0049`–`0058`) have all been
 applied and their pointer bumped; they are listed under *Recently cleared* below with the
 commit each landed as.
 
-**`0059` and `0060` are pending against the pinned pointer `2ebc0c3c`**, in that order —
-`0060` touches the function `0059` restructures, so applying them out of order will conflict.
-The push to `Broiler-Platform/Broiler.JS` returned 403 from the session's git proxy, so the
-pointer is deliberately *not* bumped. There is no main-repo fallback for either and none is
-needed: both are allocation reductions with no behaviour difference, so CI is correct without
-them, only more allocating.
+**`0059`, `0060` and `0061` are pending against the pinned pointer `2ebc0c3c`.** `0059` and
+`0060` must go in that order — `0060` touches the function `0059` restructures, so applying
+them out of order will conflict. `0061` touches a disjoint set of files and applies in any
+order relative to the other two. Each push to `Broiler-Platform/Broiler.JS` returned 403 from
+the session's git proxy, so the pointer is deliberately *not* bumped. None of the three needs
+a main-repo fallback: `0059` and `0060` are allocation reductions with no behaviour
+difference, so CI is correct without them and only more allocating, and `0061` adds a
+benchmark emitter and an opt-in counter that is off unless
+`PropertyOptimizationDiagnostics.Enabled` is set.
 
 ## Recently cleared
 


### PR DESCRIPTION
## Summary

Completes Phase 5's regex optimization work by fixing the two largest remaining allocation costs in `RegExp.prototype[@@replace]` and `String.prototype.replace`. These changes are delivered as patches (`0059`–`0061`) since their pushes to the submodule remote returned 403; they are carried here for application by a maintainer.

Also includes Phase 2 follow-up fixes (`0062`–`0064`) that were discovered while decomposing DeltaBlue's cache behavior: array length descriptor handling, prototype invalidation on redundant writes, and stale inline-cache entry refresh.

## Key Changes

**Phase 5 regex patches (not yet in submodule):**

- **`0059-js-single-match-replace-one-allocation`**: Single-match `replace` now uses `string.Concat` over three spans instead of a `StringBuilder`, eliminating two full UTF-16 copies of the subject. Measured at exactly 4.020 → 2.020 B per subject character — the predicted halving. Applied identically to `String.prototype.replace`'s string-`searchValue` path, found by reading neighboring code.

- **`0060-js-stream-global-replace`**: Global `replace` with a string replacement and no `$` substitutions now streams results instead of retaining one array per match. Reduces allocation from 2,032.8 B/match to 478.3 B/match (0.235×). Guards on three conditions: receiver's `exec` is the pristine intrinsic, replacement is a string, and no `$` appears in it. Splits `Exec` into `ExecMatch` (lastIndex progression, engine routing, statics) and `BuildExecResult` so both paths remain identical.

- **`0061-js-measure-2-9-materialization-cause`**: Measures item 2-9's losing-side hypothesis (deferred cells force trie rebuild) against a strict-function control. Finds the hypothesis is wrong: every function materializes its trie exactly once due to prototype install, which is already withheld by 2-8's DeltaBlue fix. Adds `--deferred-cell-cost` metrics and `RecordNamedPropertiesMaterialized` counter. Withdraws the planned follow-up as it would remove a materialization that already happened.

**Phase 2 follow-up patches (discovered during decomposition):**

- **`0062-js-array-length-keeps-shape`**: `SetLengthWritable` now only writes the length descriptor when necessary (non-writable or already exists), not for the common writable case. Writable length is the default and never read back, so the entry was pure bookkeeping that abandoned the array's shape. Fixes 2,507 of DeltaBlue's 2,512 dictionary fallbacks. Does not change DeltaBlue's read hit rate (still 65.96%) because DeltaBlue puts no named properties on arrays — the shapes being lost were never read through.

- **`0063-js-prototype-rewrite-no-invalidate`**: Prototype setter now compares the resulting chain with the previous one and publishes invalidation only on real change. Fixes redundant prototype writes from publishing global invalidations: class instantiation 2,002 → 0, function constructor 1 → 0. On real Octane suites the effect is much larger because the retirement was process-wide.

- **`0064-js-refresh-stale-cache-entry`**: Inline-cache add path now refreshes stale entries in place instead of declining to replace them. The add path deduplicates on two keys while a hit checks six; when any of the four additional guards go stale, the entry is rejected and never refreshed, causing 77.7% of DeltaBlue's misses. Refreshing in place takes DeltaBlue's read hit rate from 69.45% to 93.16% (65.96% before both 2-11 and 2-12). Adds miss-reason counters (cold, shape, key mismatch, megamorphic, non-object, not-describable, entry-already-present).

## Documentation Updates

https://claude.ai/code/session_01TYebHCouHwY1XAXec1QvWQ