### PR TITLE
Add Jint as a third reference engine to Octane benchmarks

### DIFF
--- a/.github/workflows/octane-benchmarks.yml
+++ b/.github/workflows/octane-benchmarks.yml
@@ -1,24 +1,27 @@
 name: Octane Benchmarks
 
 # Runs Google's Octane 2.0 JavaScript benchmark suite (https://github.com/chromium/octane)
-# under two engines and commits the comparison back to the repository:
+# under three engines and commits the comparison back to the repository:
 #
 #   * Chromium  — real V8 in a headless browser, driven by Playwright.
 #   * Broiler   — the BroilerJS `--script-host` shell (the Broiler.JS engine).
+#   * Jint      — https://github.com/sebastienros/jint, a managed ECMAScript
+#                 interpreter, run through tests/octane/jint-host. The managed
+#                 reference point: same runtime, same script, same process shape.
 #
-# Each Octane suite runs in isolation (a fresh Chromium page / a fresh Broiler
+# Each Octane suite runs in isolation (a fresh Chromium page / a fresh shell
 # process) so a crash, hang, or error in one suite never discards the others —
-# Broiler is experimental and some suites do not yet complete. Results and a
-# Chromium-vs-Broiler comparison are written to tests/octane/results and, on the
-# default branch, committed.
+# Broiler is experimental and some suites do not yet complete. Results and the
+# comparison are written to tests/octane/results and, on the default branch,
+# committed.
 
 on:
   workflow_dispatch:
     inputs:
       engines:
-        description: Comma-separated engines to run (chromium,broiler).
+        description: Comma-separated engines to run (chromium,broiler,jint).
         required: false
-        default: 'chromium,broiler'
+        default: 'chromium,broiler,jint'
       timeout_seconds:
         description: >-
           Per-suite timeout floor in seconds. A slow suite (Mandreel, zlib) raises
@@ -63,9 +66,11 @@ concurrency:
 
 jobs:
   benchmark:
-    name: Octane (Chromium vs Broiler)
+    name: Octane (Chromium vs Broiler vs Jint)
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # Jint adds about ten minutes to the previous 90: it completes every suite,
+    # and its slowest (Mandreel) measured 104s against Broiler's 313s.
+    timeout-minutes: 105
     steps:
       - uses: actions/checkout@v5
         with:
@@ -90,7 +95,7 @@ jobs:
           VERBOSE: ${{ github.event.inputs.verbose }}
         run: |
           args=(
-            --engines "${{ github.event.inputs.engines || 'chromium,broiler' }}"
+            --engines "${{ github.event.inputs.engines || 'chromium,broiler,jint' }}"
             --timeout "${{ github.event.inputs.timeout_seconds || '180' }}"
             --repetitions "${{ github.event.inputs.repetitions || '1' }}"
             --octane-ref "${{ github.event.inputs.octane_ref || 'master' }}"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -31,3 +31,13 @@ endorsed Broiler.
 Broiler.Unicode contains generated tables based on Unicode and CLDR data. Those data
 files remain subject to the [Unicode Terms of Use](https://www.unicode.org/terms_of_use.html),
 as identified in that component's documentation and notices.
+
+## Jint
+
+The Octane benchmark harness runs one of its reference engines on
+[Jint](https://github.com/sebastienros/jint), an independent managed ECMAScript
+interpreter by Sébastien Ros and contributors, licensed under the BSD 2-Clause License.
+It is consumed as an unmodified NuGet package by
+[`tests/octane/jint-host`](tests/octane/jint-host), a benchmark tool that is not part of
+any shipped Broiler component and carries no Jint code. Jint is used here only as a
+measurement reference; its authors have not reviewed or endorsed Broiler.

--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -845,10 +845,19 @@ For 0-6:
 
 ```text
 Actions → Octane Benchmarks → Run workflow
-  engines:         chromium,broiler
+  engines:         chromium,broiler,jint
   timeout_seconds: 180          # Mandreel and zlib raise their own
   repetitions:     3            # the first run that can distinguish signal
 ```
+
+`jint` is the third engine the harness gained after this section was written:
+[Jint](https://github.com/sebastienros/jint) run through `tests/octane/jint-host`,
+with the same shell surface and stack budget as `BroilerJS --script-host`. It
+costs about ten minutes of the run and adds the managed-versus-managed ratio —
+another AST-walking managed engine on the same runtime, so unlike the Chromium
+column it lands near 1 and moves with a Broiler change rather than dwarfing it.
+It is a reference, not a target: Jint has no compilation tier, so a suite where
+Broiler loses to it names a specific defect rather than a general deficit.
 
 **Exit gate for phase 0:**
 

--- a/scripts/octane-suites.json
+++ b/scripts/octane-suites.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Octane 2.0 benchmark suites in run.js load order. Each suite is run as an isolated process/page so a crash or hang in one engine does not lose the others. `files` are concatenated after base.js (and the shared runner) for a self-contained single-suite run.",
-  "_timeoutComment": "`timeoutSec` raises one suite's budget above the run-wide --timeout (which stays a floor for every suite, so a debugging run can still widen everything at once). Set only where a measured duration needs it: under Broiler, Mandreel ran 313 s and zlib 647 s, both far past the 180 s default, so a --only run of either reported a spurious timeout. The values below are roughly 3x the measured duration. Chromium finishes every suite in about 2 s and is unaffected.",
+  "_timeoutComment": "`timeoutSec` raises one suite's budget above the run-wide --timeout (which stays a floor for every suite, so a debugging run can still widen everything at once). Set only where a measured duration needs it: under Broiler, Mandreel ran 313 s and zlib 647 s, both far past the 180 s default, so a --only run of either reported a spurious timeout. The values below are roughly 3x the measured duration. Chromium finishes every suite in about 2 s and is unaffected; so is Jint, whose slowest suite (Mandreel) measured 104 s, inside the default floor.",
   "suites": [
     { "name": "Richards",     "files": ["richards.js"] },
     { "name": "DeltaBlue",    "files": ["deltablue.js"] },

--- a/scripts/run-octane-benchmarks.sh
+++ b/scripts/run-octane-benchmarks.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # run-octane-benchmarks.sh — run Google's Octane 2.0 JavaScript benchmark suite
-# under Chromium (V8 via Playwright) and Broiler (the BroilerJS shell), then
-# write per-engine result files and a Chromium-vs-Broiler comparison report.
+# under Chromium (V8 via Playwright), Broiler (the BroilerJS shell) and Jint (a
+# managed ECMAScript interpreter), then write per-engine result files and a
+# comparison report.
+#
+# Chromium says how far Broiler is from V8; Jint says how it compares to another
+# managed engine on the same runtime, which is the closer reference point.
 #
 # Source suite: https://github.com/chromium/octane
 #
@@ -12,7 +16,8 @@
 #     --octane-dir <dir>   Existing Octane checkout (default: clone into tests/octane/checkout)
 #     --out-dir <dir>      Results directory (default: tests/octane/results)
 #     --log-dir <dir>      Per-suite diagnostic logs (default: tests/octane/logs)
-#     --engines <list>     Comma-separated engines to run (default: chromium,broiler)
+#     --engines <list>     Comma-separated engines to run: chromium, broiler, jint
+#                          (default: chromium,broiler,jint)
 #     --timeout <sec>      Per-suite timeout floor in seconds (default: 180). A
 #                          slow suite may raise its own budget in
 #                          scripts/octane-suites.json.
@@ -22,7 +27,7 @@
 #     --noise-band <pct>   Spread above which a benchmark is flagged as noisy
 #                          (default: 7.5)
 #     --octane-ref <ref>   Git ref of chromium/octane to check out (default: master)
-#     --skip-build         Do not rebuild BroilerJS (reuse an existing Release build)
+#     --skip-build         Do not rebuild the engine shells (reuse existing Release builds)
 #     --only <list>        Comma-separated suites to run, e.g. --only Crypto,zlib.
 #                          Writes to <log-dir>/partial/ so a debugging run never
 #                          overwrites the committed full-run results.
@@ -40,7 +45,7 @@
 # repro command) and a diagnostics.md summarizing where it failed.
 #
 # Prerequisites:
-#     - .NET 10 SDK (BroilerJS shell)
+#     - .NET 10 SDK (the BroilerJS and Jint shells)
 #     - Node.js + npm (Playwright Chromium driver)
 #     - git (to clone the Octane suite)
 
@@ -52,7 +57,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 OCTANE_DIR=""
 OUT_DIR="$REPO_ROOT/tests/octane/results"
 LOG_DIR="$REPO_ROOT/tests/octane/logs"
-ENGINES="chromium,broiler"
+ENGINES="chromium,broiler,jint"
 TIMEOUT=180
 OCTANE_REF="master"
 SKIP_BUILD=false
@@ -76,7 +81,7 @@ while [[ $# -gt 0 ]]; do
         --no-trace) EXTRA_ARGS+=(--no-trace); shift ;;
         --broiler-env) EXTRA_ARGS+=(--broiler-env "$2"); shift 2 ;;
         -h|--help)
-            sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,43p' "$0" | sed 's/^# \{0,1\}//'
             exit 0 ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
@@ -113,21 +118,39 @@ echo ""
 NODE_ARGS=(--octane-dir "$OCTANE_DIR" --out-dir "$OUT_DIR" --log-dir "$LOG_DIR" \
            --engines "$ENGINES" --timeout "$TIMEOUT" "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}")
 
-# --- Step 2: Build the BroilerJS shell (if running the broiler engine) --------
+# --- Step 2: Build the shell hosts for whichever engines are running ----------
 
 if [[ ",$ENGINES," == *",broiler,"* ]]; then
     BROILER_PROJ="$REPO_ROOT/Broiler.JS/Broiler.JS/Broiler.JavaScript/Broiler.JavaScript.csproj"
     if [[ "$SKIP_BUILD" != "true" ]]; then
-        echo "--- Step 2: Building BroilerJS shell (Release) ---"
+        echo "--- Step 2a: Building BroilerJS shell (Release) ---"
         dotnet build "$BROILER_PROJ" --configuration Release --nologo --verbosity quiet 2>&1 | tail -3
         echo "  ✓ Build succeeded"
     else
-        echo "--- Step 2: Skipping BroilerJS build (--skip-build) ---"
+        echo "--- Step 2a: Skipping BroilerJS build (--skip-build) ---"
     fi
     BROILER_DLL="$(find "$REPO_ROOT/Broiler.JS/Broiler.JS/Broiler.JavaScript/bin/Release" -name BroilerJS.dll | head -1)"
     [[ -n "$BROILER_DLL" ]] || { echo "  ✗ BroilerJS.dll not found; build first." >&2; exit 1; }
     echo "  BroilerJS.dll: $BROILER_DLL"
     NODE_ARGS+=(--broiler-dll "$BROILER_DLL")
+    echo ""
+fi
+
+# The Jint shell is a small console app over the Jint NuGet package; building it
+# needs a package restore, which is the one part of this step that needs network.
+if [[ ",$ENGINES," == *",jint,"* ]]; then
+    JINT_PROJ="$REPO_ROOT/tests/octane/jint-host/Broiler.Octane.JintHost.csproj"
+    if [[ "$SKIP_BUILD" != "true" ]]; then
+        echo "--- Step 2b: Building the Jint shell (Release) ---"
+        dotnet build "$JINT_PROJ" --configuration Release --nologo --verbosity quiet 2>&1 | tail -3
+        echo "  ✓ Build succeeded"
+    else
+        echo "--- Step 2b: Skipping Jint shell build (--skip-build) ---"
+    fi
+    JINT_DLL="$(find "$REPO_ROOT/tests/octane/jint-host/bin/Release" -name Broiler.Octane.JintHost.dll | head -1)"
+    [[ -n "$JINT_DLL" ]] || { echo "  ✗ Broiler.Octane.JintHost.dll not found; build first." >&2; exit 1; }
+    echo "  Jint shell: $JINT_DLL"
+    NODE_ARGS+=(--jint-dll "$JINT_DLL")
     echo ""
 fi
 

--- a/scripts/run-octane.mjs
+++ b/scripts/run-octane.mjs
@@ -1,9 +1,16 @@
 // run-octane.mjs — run the Octane 2.0 benchmark suite under Chromium (V8 via
-// Playwright) and/or Broiler (the BroilerJS --script-host shell), then emit a
-// per-engine result file, a comparison report, and a failure diagnostics report.
+// Playwright), Broiler (the BroilerJS --script-host shell) and/or Jint (a
+// managed ECMAScript interpreter), then emit a per-engine result file, a
+// comparison report, and a failure diagnostics report.
+//
+// Chromium answers "how far is Broiler from V8" — a number about a JIT-compiling
+// C++ engine. Jint answers the question a Broiler change is steered by: how
+// Broiler compares to another managed engine on the same CLR, running the same
+// script in the same process shape. Both are reference points, neither replaces
+// the other.
 //
 // Each Octane suite is executed in isolation — a fresh Chromium page or a fresh
-// Broiler process — so a crash, hang, or error in one suite never discards the
+// shell process — so a crash, hang, or error in one suite never discards the
 // others. This matters because Broiler is an experimental engine: some suites
 // score, some throw a catchable error, and some abort the whole process.
 //
@@ -16,7 +23,10 @@
 //     command. Broiler prints a JS stack trace on an unhandled throw, and
 //     surfaces a CLR fault as a catchable JS error whose *message* carries the
 //     .NET exception type and its whole managed stack — both are kept verbatim.
-//   * Stack traces are mapped back to Octane sources. Broiler runs one
+//     Jint reports an escaping JavaScript error as an unhandled .NET exception
+//     whose inner exception is the JavaScript stack, so the same capture reads
+//     both engines.
+//   * Stack traces are mapped back to Octane sources. A shell engine runs one
 //     concatenated script per suite, so its traces cite lines in a temporary
 //     file; every such line is rewritten to the file and line it came from
 //     (base.js:371, crypto.js:104, …) using the offsets recorded when the
@@ -32,9 +42,12 @@
 //
 // Options:
 //   --octane-dir <dir>     Octane checkout (contains base.js, richards.js, …). Required.
-//   --engines <list>       Comma-separated: chromium,broiler (default: chromium,broiler)
+//   --engines <list>       Comma-separated: chromium,broiler,jint
+//                          (default: chromium,broiler,jint)
 //   --broiler-dll <path>   BroilerJS.dll to run with `dotnet ... --script-host`.
 //                          Required when broiler is in --engines.
+//   --jint-dll <path>      Broiler.Octane.JintHost.dll — the Jint shell.
+//                          Required when jint is in --engines.
 //   --out-dir <dir>        Where result JSON/MD are written (default: tests/octane/results)
 //   --log-dir <dir>        Where per-suite logs are written (default: tests/octane/logs)
 //   --suites <path>        Suite manifest (default: scripts/octane-suites.json)
@@ -78,8 +91,9 @@ const REPORT_CLR_FRAMES = 30;
 function parseArgs(argv) {
   const opts = {
     octaneDir: null,
-    engines: 'chromium,broiler',
+    engines: 'chromium,broiler,jint',
     broilerDll: null,
+    jintDll: null,
     outDir: join(REPO_ROOT, 'tests', 'octane', 'results'),
     logDir: join(REPO_ROOT, 'tests', 'octane', 'logs'),
     suites: join(__dirname, 'octane-suites.json'),
@@ -100,6 +114,7 @@ function parseArgs(argv) {
       case '--octane-dir': opts.octaneDir = next(); break;
       case '--engines': opts.engines = next(); break;
       case '--broiler-dll': opts.broilerDll = next(); break;
+      case '--jint-dll': opts.jintDll = next(); break;
       case '--out-dir': opts.outDir = next(); break;
       case '--log-dir': opts.logDir = next(); break;
       case '--suites': opts.suites = next(); break;
@@ -301,10 +316,14 @@ function tryJson(s) {
 // Read back the diagnostic lines octane-runner.js streamed. Works on partial
 // output, which is the point: a killed process still tells us how far it got.
 export function parseDiagnostics(stdout) {
-  const out = { start: null, traces: [], errors: [], fatal: null, loaded: [], notes: [], result: null };
+  const out = { start: null, traces: [], errors: [], fatal: null, loaded: [], notes: [], result: null, engine: null };
   if (!stdout) return out;
   for (const line of String(stdout).replace(/\r/g, '').split('\n')) {
-    if (line.startsWith('OCTANE_TRACE ')) {
+    if (line.startsWith('OCTANE_ENGINE ')) {
+      // A shell naming itself and its version, ahead of the script. Optional:
+      // the BroilerJS shell does not print one and keeps its static label.
+      out.engine = tryJson(line.slice('OCTANE_ENGINE '.length)) ?? out.engine;
+    } else if (line.startsWith('OCTANE_TRACE ')) {
       const v = tryJson(line.slice('OCTANE_TRACE '.length));
       if (v) out.traces.push(v);
     } else if (line.startsWith('OCTANE_ERROR ')) {
@@ -359,6 +378,18 @@ export function parseClrException(text) {
   return { ...outer, inner, frames };
 }
 
+// Jint spells a JS frame the way V8 does, with the location parenthesized and
+// the function name omitted at top level:
+//
+//   at <fn> (<file>:<line>:<col>)
+//   at <file>:<line>:<col>               top-level code, no enclosing function
+//
+// Tried before the Broiler spellings below because the two overlap: without the
+// parentheses the generic pattern reads `at f (crypto.js:405:12)` as a function
+// named `f (crypto.js` — a frame that localizes nothing.
+const V8_FRAME = /^\s*at\s+(?:(.+?)\s+)?\((.+):(\d+):(\d+)\)\s*$/;
+const V8_TOP_LEVEL_FRAME = /^\s*at\s+(\S.*):(\d+):(\d+)\s*$/;
+
 // Broiler spells a JS frame three ways, and each one localizes a different
 // class of failure — so all three are recognized:
 //
@@ -378,6 +409,16 @@ export function parseJsStack(text) {
   if (!text) return [];
   const frames = [];
   for (const line of String(text).replace(/\r/g, '').split('\n')) {
+    const named = V8_FRAME.exec(line);
+    if (named) {
+      frames.push({ fn: named[1]?.trim() || '<anonymous>', file: named[2].trim(), line: Number(named[3]) });
+      continue;
+    }
+    const topLevel = V8_TOP_LEVEL_FRAME.exec(line);
+    if (topLevel) {
+      frames.push({ fn: '<top level>', file: topLevel[1].trim(), line: Number(topLevel[2]) });
+      continue;
+    }
     const m = /^\s*at\s+(.+?)(?:\s+in\s+|[:-])(\S.*?)(?::line[ \t]+(\d+)|:(\d+))(?:,(\d+))?(?:\([^)]*\))?\s*$/.exec(line);
     if (m) {
       if (MANAGED_FRAME.test(line.trim().replace(/^at\s+/, ''))) continue;
@@ -585,10 +626,36 @@ function writeSuiteLog(path, sections) {
   writeFileSync(path, `${lines.join('\n')}\n`);
 }
 
-// ── Broiler: one isolated `dotnet … --script-host <combined>` process per suite
-async function runBroiler(opts, suites, baseJs, runnerJs, dirs) {
-  if (!opts.broilerDll) throw new Error('--broiler-dll is required for the broiler engine');
-  const logDir = join(dirs.logDir, 'broiler');
+// ── Shell engines: one isolated `dotnet <shell> <combined>` process per suite ──
+// Broiler and Jint differ only in which assembly is launched and what it wants
+// on its command line; everything downstream — the combined script, the
+// breadcrumbs, the line mapping, the failure classification — is identical,
+// because both are JavaScript shells reading the same script and printing the
+// same diagnostic protocol.
+export const SHELL_ENGINES = {
+  broiler: {
+    label: 'Broiler.JS (BroilerJS --script-host)',
+    dllOption: '--broiler-dll',
+    dll: (opts) => opts.broilerDll,
+    args: (dll, combined) => [dll, '--script-host', combined],
+    env: (opts) => ({ ...process.env, ...opts.broilerEnv }),
+  },
+  jint: {
+    // Replaced by whatever the shell reports in its OCTANE_ENGINE line, which
+    // names the Jint version that actually ran.
+    label: 'Jint (interpreter)',
+    dllOption: '--jint-dll',
+    dll: (opts) => opts.jintDll,
+    args: (dll, combined) => [dll, combined],
+    env: () => ({ ...process.env }),
+  },
+};
+
+async function runShellEngine(engine, opts, suites, baseJs, runnerJs, dirs) {
+  const spec = SHELL_ENGINES[engine];
+  const dll = spec.dll(opts);
+  if (!dll) throw new Error(`${spec.dllOption} is required for the ${engine} engine`);
+  const logDir = join(dirs.logDir, engine);
   const scriptDir = join(logDir, 'scripts');
   mkdirSync(scriptDir, { recursive: true });
 
@@ -596,6 +663,7 @@ async function runBroiler(opts, suites, baseJs, runnerJs, dirs) {
   const stability = {};
   const suiteStatus = {};
   let octaneVersion = null;
+  let engineLabel = spec.label;
 
   for (const suite of suites) {
     const parts = [{ file: 'base.js', text: baseJs }];
@@ -606,8 +674,8 @@ async function runBroiler(opts, suites, baseJs, runnerJs, dirs) {
     const combined = join(scriptDir, `${suite.name}.js`);
     writeFileSync(combined, text);
 
-    const args = [opts.broilerDll, '--script-host', combined];
-    const repro = `dotnet ${opts.broilerDll} --script-host ${combined}`;
+    const args = spec.args(dll, combined);
+    const repro = `dotnet ${args.join(' ')}`;
 
     // Map every citation of the combined script back to the Octane source, and
     // trim the repo root off engine frames, before anything is read or shown.
@@ -624,22 +692,25 @@ async function runBroiler(opts, suites, baseJs, runnerJs, dirs) {
       const logName = opts.repetitions === 1 ? `${suite.name}.log` : `${suite.name}.rep${rep}.log`;
       const label = opts.repetitions === 1 ? suite.name : `${suite.name} (${rep}/${opts.repetitions})`;
 
-      process.stderr.write(`[broiler] ${label} … `);
+      process.stderr.write(`[${engine}] ${label} … `);
       if (opts.verbose) process.stderr.write('\n');
 
       const res = await runProcess('dotnet', args, {
         timeoutMs: timeoutSec * 1000,
-        env: { ...process.env, ...opts.broilerEnv },
-        onStdout: opts.verbose ? createLineStreamer(`[broiler:${suite.name}] `, clean) : null,
-        onStderr: opts.verbose ? createLineStreamer(`[broiler:${suite.name}!] `, clean) : null,
+        env: spec.env(opts),
+        onStdout: opts.verbose ? createLineStreamer(`[${engine}:${suite.name}] `, clean) : null,
+        onStderr: opts.verbose ? createLineStreamer(`[${engine}:${suite.name}!] `, clean) : null,
       });
 
       const stdout = clean(res.stdout);
       const stderr = clean(res.stderr);
       const mapped = { ...res, stdout, stderr };
       const diag = parseDiagnostics(stdout);
+      // A shell that names itself (and its version) is labelled with what ran
+      // rather than with what the harness assumed was installed.
+      if (diag.engine?.label) engineLabel = diag.engine.label;
 
-      const status = classifyBroilerSuite(mapped, diag, {
+      const status = classifyShellSuite(mapped, diag, {
         combined,
         repro,
         log: relative(REPO_ROOT, join(logDir, logName)),
@@ -672,7 +743,7 @@ async function runBroiler(opts, suites, baseJs, runnerJs, dirs) {
       ]);
 
       if (!opts.verbose) process.stderr.write(`${status.status}\n`);
-      else process.stderr.write(`[broiler] ${label} … ${status.status}\n`);
+      else process.stderr.write(`[${engine}] ${label} … ${status.status}\n`);
       if (status.status !== 'ok') {
         const where = describeWhere(status.failedAt);
         const detail = clamp(status.error ?? '', 160);
@@ -704,8 +775,8 @@ async function runBroiler(opts, suites, baseJs, runnerJs, dirs) {
   }
 
   return {
-    engine: 'broiler',
-    engineLabel: 'Broiler.JS (BroilerJS --script-host)',
+    engine,
+    engineLabel,
     octaneVersion,
     perSuiteTimeoutSec: opts.timeout,
     repetitions: opts.repetitions,
@@ -720,7 +791,7 @@ async function runBroiler(opts, suites, baseJs, runnerJs, dirs) {
 // Turn a finished child process into a suite verdict plus everything needed to
 // act on it. The status vocabulary (ok/error/timeout/crash) is unchanged; the
 // surrounding detail is what is new.
-function classifyBroilerSuite(res, diag, paths) {
+function classifyShellSuite(res, diag, paths) {
   const base = {
     exitCode: res.code ?? null,
     signal: res.signal ?? null,
@@ -943,12 +1014,18 @@ async function runChromium(opts, suites, baseJs, runnerJs, dirs) {
 }
 
 // ── Comparison report ───────────────────────────────────────────────────────
+// Engines in report order. Broiler is the subject; Chromium and Jint are the two
+// reference points it is read against.
+export const ENGINE_IDS = ['chromium', 'broiler', 'jint'];
+
 export function buildComparison(results, generatedAt) {
   const chromium = results.chromium;
   const broiler = results.broiler;
+  const jint = results.jint;
+  const present = ENGINE_IDS.filter((id) => results[id]);
   const names = new Set();
-  for (const r of [chromium, broiler]) {
-    if (!r) continue;
+  for (const id of present) {
+    const r = results[id];
     for (const k of Object.keys(r.benchmarks)) names.add(k);
     for (const k of Object.keys(r.suiteStatus)) names.add(k);
   }
@@ -962,49 +1039,59 @@ export function buildComparison(results, generatedAt) {
     return { score: null, status: st ? st.status : 'n/a', error: st?.error, errorType: st?.errorType };
   }
 
+  // Higher is better in Octane, so a ratio above 1 means the first engine won.
+  const ratio = (a, b, digits) => (a.score && b.score ? Number((a.score / b.score).toFixed(digits)) : null);
+
   const comparison = {
     generatedAt,
-    octaneVersion: (chromium?.octaneVersion ?? broiler?.octaneVersion) ?? null,
-    engines: {
-      chromium: chromium ? { label: chromium.engineLabel, geomean: chromium.geomean } : null,
-      broiler: broiler ? { label: broiler.engineLabel, geomean: broiler.geomean } : null,
-    },
+    octaneVersion: present.map((id) => results[id].octaneVersion).find(Boolean) ?? null,
+    engines: Object.fromEntries(ENGINE_IDS.map((id) => [
+      id,
+      results[id] ? { label: results[id].engineLabel, geomean: results[id].geomean } : null,
+    ])),
     benchmarks: rows.map((name) => {
       const c = cell(chromium, name);
       const b = cell(broiler, name);
-      const ratio = c.score && b.score ? Number((b.score / c.score).toFixed(3)) : null;
-      const slower = c.score && b.score ? Number((c.score / b.score).toFixed(1)) : null;
+      const j = cell(jint, name);
       return {
         name,
         chromium: c,
         broiler: b,
-        broilerVsChromium: ratio,
-        broilerTimesSlower: slower,
-        stability: {
-          chromium: chromium?.stability?.[name] ?? null,
-          broiler: broiler?.stability?.[name] ?? null,
-        },
+        jint: j,
+        broilerVsChromium: ratio(b, c, 3),
+        broilerTimesSlower: ratio(c, b, 1),
+        jintVsChromium: ratio(j, c, 3),
+        // The managed-versus-managed number: above 1, Broiler beat Jint on this
+        // suite. Unlike the Chromium ratio it is expected to be near 1, so it is
+        // the one a Broiler change is actually read against.
+        broilerVsJint: ratio(b, j, 3),
+        stability: Object.fromEntries(ENGINE_IDS.map((id) => [id, results[id]?.stability?.[name] ?? null])),
       };
     }),
   };
-  comparison.summary = summarize(comparison, { chromium, broiler });
+  comparison.summary = summarize(comparison, results);
   return comparison;
 }
 
-// The three numbers this comparison is read for. Coverage and spread are here
-// because the geomean alone hides both: a run that drops five suites still
-// reports a geomean, and a profile with one catastrophic score reports much the
-// same total as an evenly-bad one while being a completely different problem.
-function summarize(cmp, { chromium, broiler }) {
+// The numbers this comparison is read for. Coverage and spread are here because
+// the geomean alone hides both: a run that drops five suites still reports a
+// geomean, and a profile with one catastrophic score reports much the same total
+// as an evenly-bad one while being a completely different problem.
+function summarize(cmp, results) {
+  const { chromium, broiler, jint } = results;
   const scored = cmp.benchmarks.filter((r) => r.broilerTimesSlower != null);
   const factors = scored.map((r) => r.broilerTimesSlower);
   const best = scored.find((r) => r.broilerTimesSlower === Math.min(...factors)) ?? null;
   const worst = scored.find((r) => r.broilerTimesSlower === Math.max(...factors)) ?? null;
   const count = (r) => (r ? Object.keys(r.benchmarks).length : 0);
   const expected = new Set(cmp.benchmarks.map((r) => r.name)).size;
+  // Only the engines this run has results for, so a two-engine run reports the
+  // same shape it always did rather than a column of zeroes for one that never ran.
+  const present = ENGINE_IDS.filter((id) => results[id]);
+  const perEngine = (fn) => Object.fromEntries(present.map((id) => [id, fn(results[id])]));
   return {
-    scoresReported: { chromium: count(chromium), broiler: count(broiler), expected },
-    geomean: { chromium: chromium?.geomean ?? null, broiler: broiler?.geomean ?? null },
+    scoresReported: { ...perEngine(count), expected },
+    geomean: perEngine((r) => r.geomean ?? null),
     // "Smoothness": how far apart the best and worst suites are. A uniformly
     // slow engine is a healthier engine than a mostly-fine one with an outlier,
     // because the outlier is a single subsystem failing rather than a broad
@@ -1014,36 +1101,58 @@ function summarize(cmp, { chromium, broiler }) {
       best: best && { name: best.name, timesSlower: best.broilerTimesSlower },
       worst: worst && { name: worst.name, timesSlower: worst.broilerTimesSlower },
     },
-    repetitions: broiler?.repetitions ?? chromium?.repetitions ?? 1,
-    noiseBandPercent: broiler?.noiseBandPercent ?? chromium?.noiseBandPercent ?? null,
+    // Broiler against the other managed engine, over the suites both scored —
+    // the geomeans above cannot be divided for this, since each is taken over
+    // whatever suites that engine happened to complete.
+    broilerVsJint: geomeanRatio(cmp.benchmarks.map((r) => r.broilerVsJint)),
+    repetitions: broiler?.repetitions ?? chromium?.repetitions ?? jint?.repetitions ?? 1,
+    noiseBandPercent: broiler?.noiseBandPercent ?? chromium?.noiseBandPercent ?? jint?.noiseBandPercent ?? null,
   };
 }
 
-export function renderMarkdown(cmp, broiler) {
+// Geometric mean of the per-benchmark ratios, ignoring the suites where one of
+// the two engines has no score.
+function geomeanRatio(ratios) {
+  const xs = ratios.filter((v) => Number.isFinite(v) && v > 0);
+  if (xs.length === 0) return null;
+  return { ratio: Number(Math.exp(xs.reduce((a, v) => a + Math.log(v), 0) / xs.length).toFixed(3)), benchmarks: xs.length };
+}
+
+const ENGINE_TITLES = { chromium: 'Chromium', broiler: 'Broiler', jint: 'Jint' };
+
+// The Jint columns appear only when a Jint result is in the run: a
+// Chromium-vs-Broiler run renders exactly the table it always did rather than
+// carrying two columns of dashes for an engine nobody asked for.
+export function renderMarkdown(cmp, results) {
+  const byEngine = results ?? {};
   const c = cmp.engines.chromium;
   const b = cmp.engines.broiler;
+  const j = cmp.engines.jint;
   const fmt = (cell) => {
     if (cell.score != null) return String(cell.score);
     if (cell.status === 'n/a') return '—';
     return `_${cell.status}_`;
   };
+  const present = ENGINE_IDS.filter((id) => cmp.engines[id]);
   const lines = [];
-  lines.push(`# Octane 2.0 benchmark — Chromium vs Broiler`);
+  lines.push(`# Octane 2.0 benchmark — ${present.map((id) => ENGINE_TITLES[id]).join(' vs ') || 'no engines'}`);
   lines.push('');
   lines.push(`- Generated: \`${cmp.generatedAt}\``);
   lines.push(`- Octane version: \`${cmp.octaneVersion ?? 'unknown'}\``);
-  if (c) lines.push(`- Chromium: \`${c.label}\` — **overall score ${c.geomean ?? 'n/a'}**`);
-  if (b) lines.push(`- Broiler: \`${b.label}\` — **overall score ${b.geomean ?? 'n/a'}**`);
+  for (const id of present) {
+    lines.push(`- ${ENGINE_TITLES[id]}: \`${cmp.engines[id].label}\` — **overall score ${cmp.engines[id].geomean ?? 'n/a'}**`);
+  }
   const s = cmp.summary;
   if (s) {
     lines.push(`- Repetitions per suite: ${s.repetitions}${s.repetitions === 1 ? ' — **a single run; deltas against it cannot be distinguished from noise**' : ` (median reported; noise band ${s.noiseBandPercent}%)`}`);
     lines.push('');
-    lines.push('| | Chromium | Broiler |');
-    lines.push('|---|--:|--:|');
-    lines.push(`| Scores reported (of ${s.scoresReported.expected}) | ${s.scoresReported.chromium} | ${s.scoresReported.broiler} |`);
-    lines.push(`| Overall (geomean) | ${s.geomean.chromium ?? '—'} | ${s.geomean.broiler ?? '—'} |`);
+    const cells = (values) => `| ${values.join(' | ')} |`;
+    lines.push(cells(['', ...present.map((id) => ENGINE_TITLES[id])]));
+    lines.push(`|---|${present.map(() => '--:|').join('')}`);
+    lines.push(cells([`Scores reported (of ${s.scoresReported.expected})`, ...present.map((id) => s.scoresReported[id] ?? '—')]));
+    lines.push(cells(['Overall (geomean)', ...present.map((id) => s.geomean[id] ?? '—')]));
     if (s.spread) {
-      lines.push(`| Spread (worst ÷ best suite) | — | ${s.spread.factor}× |`);
+      lines.push(cells(['Spread (worst ÷ best suite)', ...present.map((id) => (id === 'broiler' ? `${s.spread.factor}×` : '—'))]));
     }
     lines.push('');
     if (s.spread) {
@@ -1053,40 +1162,59 @@ export function renderMarkdown(cmp, broiler) {
         'engine being uniformly behind. See [`../roadmap.md`](../roadmap.md).');
       lines.push('');
     }
+    if (s.broilerVsJint) {
+      lines.push(`Against Jint — a managed interpreter on the same runtime, and so the closer reference point — ` +
+        `Broiler scores **${s.broilerVsJint.ratio}×** across the ${s.broilerVsJint.benchmarks} benchmark` +
+        `${s.broilerVsJint.benchmarks === 1 ? '' : 's'} both engines completed (geometric mean of the per-benchmark ratios).`);
+      lines.push('');
+    }
   }
   lines.push('Higher is better. "Broiler / Chromium" is the ratio of scores on suites both engines completed.');
+  if (j) lines.push('"Broiler / Jint" is the same ratio against the other managed engine: above 1, Broiler is ahead.');
   lines.push('');
   const noisy = (st) => (st && st.bandPercent != null && cmp.summary && st.bandPercent > cmp.summary.noiseBandPercent ? ' ⚠' : '');
   const showBand = cmp.summary && cmp.summary.repetitions > 1;
-  lines.push(`| Benchmark | Chromium | Broiler |${showBand ? ' Broiler spread |' : ''} Broiler / Chromium | × slower |`);
-  lines.push(`|---|--:|--:|${showBand ? '--:|' : ''}--:|--:|`);
+  lines.push(`| Benchmark | Chromium | Broiler |${j ? ' Jint |' : ''}${showBand ? ' Broiler spread |' : ''} Broiler / Chromium | × slower |${j ? ' Broiler / Jint |' : ''}`);
+  lines.push(`|---|--:|--:|${j ? '--:|' : ''}${showBand ? '--:|' : ''}--:|--:|${j ? '--:|' : ''}`);
   for (const row of cmp.benchmarks) {
     const ratio = row.broilerVsChromium != null ? row.broilerVsChromium.toFixed(3) : '—';
     const slower = row.broilerTimesSlower != null ? `${row.broilerTimesSlower}×` : '—';
     const st = row.stability?.broiler;
     const band = showBand ? ` ${st?.bandPercent != null ? `${st.bandPercent}%${noisy(st)}` : '—'} |` : '';
-    lines.push(`| ${row.name} | ${fmt(row.chromium)} | ${fmt(row.broiler)} |${band} ${ratio} | ${slower} |`);
+    const jintScore = j ? ` ${fmt(row.jint)} |` : '';
+    const jintRatio = j ? ` ${row.broilerVsJint != null ? row.broilerVsJint.toFixed(3) : '—'} |` : '';
+    lines.push(`| ${row.name} | ${fmt(row.chromium)} | ${fmt(row.broiler)} |${jintScore}${band} ${ratio} | ${slower} |${jintRatio}`);
   }
-  lines.push(`| **Overall (geomean)** | **${c?.geomean ?? '—'}** | **${b?.geomean ?? '—'}** |${showBand ? ' |' : ''} ${c?.geomean && b?.geomean ? (b.geomean / c.geomean).toFixed(3) : '—'} | ${c?.geomean && b?.geomean ? `${(c.geomean / b.geomean).toFixed(0)}×` : '—'} |`);
+  const overallJint = j ? ` **${j.geomean ?? '—'}** |` : '';
+  const overallVsJint = j ? ` ${s?.broilerVsJint ? s.broilerVsJint.ratio.toFixed(3) : '—'} |` : '';
+  lines.push(`| **Overall (geomean)** | **${c?.geomean ?? '—'}** | **${b?.geomean ?? '—'}** |${overallJint}${showBand ? ' |' : ''} ${c?.geomean && b?.geomean ? (b.geomean / c.geomean).toFixed(3) : '—'} | ${c?.geomean && b?.geomean ? `${(c.geomean / b.geomean).toFixed(0)}×` : '—'} |${overallVsJint}`);
   lines.push('');
   if (showBand) {
     lines.push(`⚠ marks a benchmark whose spread across ${cmp.summary.repetitions} repetitions exceeded the ${cmp.summary.noiseBandPercent}% band.`);
     lines.push('');
   }
 
-  const failures = Object.entries(broiler?.suiteStatus ?? {}).filter(([, s]) => s.status !== 'ok');
-  if (failures.length) {
-    lines.push('## Broiler failures');
+  // Failures per shell engine. Jint's are worth reporting for the same reason
+  // its scores are: a suite that fails under both managed engines is usually
+  // saying something about the benchmark's host expectations, not about Broiler.
+  let anyFailures = false;
+  for (const id of Object.keys(SHELL_ENGINES)) {
+    const failures = Object.entries(byEngine[id]?.suiteStatus ?? {}).filter(([, st]) => st.status !== 'ok');
+    if (!failures.length) continue;
+    anyFailures = true;
+    lines.push(`## ${ENGINE_TITLES[id]} failures`);
     lines.push('');
     lines.push('| Suite | Status | Failing type | Where | Detail |');
     lines.push('|---|---|---|---|---|');
-    for (const [name, s] of failures) {
-      const where = describeWhere(s.failedAt)?.replace(/\|/g, '\\|') ?? '—';
-      const type = s.errorType ? `\`${s.errorType}\`` : '—';
-      const detail = clamp(s.error ?? '', 140).replace(/\|/g, '\\|');
-      lines.push(`| ${name} | ${s.status} | ${type} | ${where} | ${detail} |`);
+    for (const [name, st] of failures) {
+      const where = describeWhere(st.failedAt)?.replace(/\|/g, '\\|') ?? '—';
+      const type = st.errorType ? `\`${st.errorType}\`` : '—';
+      const detail = clamp(st.error ?? '', 140).replace(/\|/g, '\\|');
+      lines.push(`| ${name} | ${st.status} | ${type} | ${where} | ${detail} |`);
     }
     lines.push('');
+  }
+  if (anyFailures) {
     lines.push('Stack traces, the phase each failure reached, and a repro command are in');
     lines.push('[`diagnostics.md`](diagnostics.md); full per-suite output is under `tests/octane/logs/`.');
     lines.push('');
@@ -1100,40 +1228,61 @@ export function renderMarkdown(cmp, broiler) {
 // ── Diagnostics report ──────────────────────────────────────────────────────
 // The artifact a person actually reads to fix a failing suite: what broke,
 // where it broke, the stack on both sides of the JS/CLR boundary, and how to
-// re-run just that suite.
-function renderDiagnostics(broiler, generatedAt) {
+// re-run just that suite. One section per shell engine — a Jint failure is not
+// a Broiler bug, but "both managed engines fail this suite the same way" is the
+// fastest way to tell a Broiler defect from a benchmark that expects a host
+// facility neither shell provides.
+export function renderDiagnostics(results, generatedAt) {
+  const engines = Object.keys(SHELL_ENGINES).filter((id) => results[id]);
   const lines = [];
-  lines.push('# Broiler Octane failure diagnostics');
+  lines.push('# Octane failure diagnostics');
   lines.push('');
   lines.push(`- Generated: \`${generatedAt}\``);
-  lines.push(`- Engine: \`${broiler.engineLabel}\``);
-  lines.push(`- Per-suite timeout: ${broiler.perSuiteTimeoutSec}s (floor; a suite may raise its own — the budget each ran under is in its section below)`);
-  if ((broiler.repetitions ?? 1) > 1) lines.push(`- Repetitions per suite: ${broiler.repetitions}`);
-  lines.push('');
-
-  const entries = Object.entries(broiler.suiteStatus);
-  const failures = entries.filter(([, s]) => s.status !== 'ok');
-  if (!failures.length) {
-    lines.push('All suites completed. Nothing to diagnose.');
-    lines.push('');
-    return lines.join('\n');
+  for (const id of engines) {
+    const r = results[id];
+    lines.push(`- ${ENGINE_TITLES[id]}: \`${r.engineLabel}\` — per-suite timeout ${r.perSuiteTimeoutSec}s ` +
+      `(floor; a suite may raise its own — the budget each ran under is in its section below)` +
+      `${(r.repetitions ?? 1) > 1 ? `, ${r.repetitions} repetitions` : ''}`);
   }
-
-  lines.push(`${failures.length} of ${entries.length} suites did not complete.`);
   lines.push('');
   lines.push('Statuses: **error** — Octane caught the throw and scored the rest;');
   lines.push('**crash** — the process died and took the suite with it;');
   lines.push('**timeout** — no result within the per-suite timeout.');
   lines.push('');
+
+  for (const id of engines) lines.push(...engineDiagnostics(id, results[id]));
+
+  lines.push('---');
+  lines.push('_Generated by `scripts/run-octane.mjs`. Re-runs of a single suite write to `tests/octane/logs/partial/`._');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function engineDiagnostics(engine, result) {
+  const title = ENGINE_TITLES[engine];
+  const lines = [];
+  lines.push(`## ${title}`);
+  lines.push('');
+
+  const entries = Object.entries(result.suiteStatus);
+  const failures = entries.filter(([, s]) => s.status !== 'ok');
+  if (!failures.length) {
+    lines.push(`All ${entries.length} suites completed. Nothing to diagnose.`);
+    lines.push('');
+    return lines;
+  }
+
+  lines.push(`${failures.length} of ${entries.length} suites did not complete.`);
+  lines.push('');
   lines.push('| Suite | Status | Failing type | Where |');
   lines.push('|---|---|---|---|');
   for (const [name, s] of failures) {
-    lines.push(`| [${name}](#${name.toLowerCase()}) | ${s.status} | ${s.errorType ? `\`${s.errorType}\`` : '—'} | ${describeWhere(s.failedAt)?.replace(/\|/g, '\\|') ?? '—'} |`);
+    lines.push(`| [${name}](#${anchor(engine, name)}) | ${s.status} | ${s.errorType ? `\`${s.errorType}\`` : '—'} | ${describeWhere(s.failedAt)?.replace(/\|/g, '\\|') ?? '—'} |`);
   }
   lines.push('');
 
   for (const [name, s] of failures) {
-    lines.push(`## ${name}`);
+    lines.push(`### ${title}: ${name}`);
     lines.push('');
     lines.push(`- **Status**: ${s.status}${s.exitCode != null ? ` (exit code ${describeExitCode(s.exitCode)}${s.signal ? `, signal ${s.signal}` : ''})` : ''}`);
     if (s.errorType) lines.push(`- **Failing type**: \`${s.errorType}\`${s.errorKind === 'clr' ? ' (.NET exception surfaced through the engine)' : ''}`);
@@ -1156,7 +1305,7 @@ function renderDiagnostics(broiler, generatedAt) {
     }
 
     if (s.clrStack?.length) {
-      lines.push('**Engine (.NET) stack** — where inside Broiler the fault happened:');
+      lines.push(`**Engine (.NET) stack** — where inside ${title} the fault happened:`);
       lines.push('');
       lines.push('```text');
       lines.push(...formatFrames(s.clrStack, REPORT_CLR_FRAMES));
@@ -1179,15 +1328,19 @@ function renderDiagnostics(broiler, generatedAt) {
     lines.push('Re-run just this suite:');
     lines.push('');
     lines.push('```bash');
-    lines.push(`./scripts/run-octane-benchmarks.sh --engines broiler --skip-build --only ${name} --verbose`);
+    lines.push(`./scripts/run-octane-benchmarks.sh --engines ${engine} --skip-build --only ${name} --verbose`);
     lines.push('```');
     lines.push('');
   }
 
-  lines.push('---');
-  lines.push('_Generated by `scripts/run-octane.mjs`. Re-runs of a single suite write to `tests/octane/logs/partial/`._');
-  lines.push('');
-  return lines.join('\n');
+  return lines;
+}
+
+// GitHub's heading slug for `### <Title>: <Suite>`. Qualified by the engine
+// because two engines can fail the same suite, and an unqualified `#crypto`
+// would then link to whichever section came first.
+function anchor(engine, suite) {
+  return `${ENGINE_TITLES[engine]}-${suite}`.toLowerCase();
 }
 
 async function main() {
@@ -1211,12 +1364,16 @@ async function main() {
     process.stderr.write(`[octane] --only ${opts.only.join(',')}: writing to ${outDir} (committed results left alone)\n`);
   }
 
+  const unknown = engines.filter((e) => e !== 'chromium' && !(e in SHELL_ENGINES));
+  if (unknown.length) {
+    throw new Error(`Unknown engine: ${unknown.join(', ')}. Known engines: chromium, ${Object.keys(SHELL_ENGINES).join(', ')}`);
+  }
+
   const results = {};
   for (const engine of engines) {
-    let r;
-    if (engine === 'broiler') r = await runBroiler(opts, suites, baseJs, runnerJs, dirs);
-    else if (engine === 'chromium') r = await runChromium(opts, suites, baseJs, runnerJs, dirs);
-    else throw new Error(`Unknown engine: ${engine}`);
+    const r = engine === 'chromium'
+      ? await runChromium(opts, suites, baseJs, runnerJs, dirs)
+      : await runShellEngine(engine, opts, suites, baseJs, runnerJs, dirs);
     r.generatedAt = generatedAt;
     results[engine] = r;
     const out = join(outDir, `${engine}-results.json`);
@@ -1224,11 +1381,14 @@ async function main() {
     process.stderr.write(`[${engine}] wrote ${out} (overall score: ${r.geomean ?? 'n/a'})\n`);
   }
 
-  if (results.broiler) {
+  const diagnosed = Object.keys(SHELL_ENGINES).filter((id) => results[id]);
+  if (diagnosed.length) {
     const diagnostics = join(outDir, 'diagnostics.md');
-    writeFileSync(diagnostics, renderDiagnostics(results.broiler, generatedAt));
-    const failed = Object.values(results.broiler.suiteStatus).filter((s) => s.status !== 'ok').length;
-    process.stderr.write(`[broiler] wrote ${diagnostics} (${failed} failing suite${failed === 1 ? '' : 's'})\n`);
+    writeFileSync(diagnostics, renderDiagnostics(results, generatedAt));
+    const failed = diagnosed
+      .map((id) => `${id}: ${Object.values(results[id].suiteStatus).filter((s) => s.status !== 'ok').length}`)
+      .join(', ');
+    process.stderr.write(`[octane] wrote ${diagnostics} (failing suites — ${failed})\n`);
   }
 
   // A partial run compares nothing: its suite set is a subset, so folding it
@@ -1239,8 +1399,8 @@ async function main() {
   }
 
   // Fold in any per-engine result already on disk so a single-engine run still
-  // refreshes the comparison against the other engine's last result.
-  for (const engine of ['chromium', 'broiler']) {
+  // refreshes the comparison against the other engines' last results.
+  for (const engine of ENGINE_IDS) {
     if (results[engine]) continue;
     const p = join(outDir, `${engine}-results.json`);
     if (existsSync(p)) results[engine] = JSON.parse(readFileSync(p, 'utf8'));
@@ -1248,7 +1408,7 @@ async function main() {
 
   const cmp = buildComparison(results, generatedAt);
   writeFileSync(join(outDir, 'comparison.json'), `${JSON.stringify(cmp, null, 2)}\n`);
-  writeFileSync(join(outDir, 'comparison.md'), renderMarkdown(cmp, results.broiler));
+  writeFileSync(join(outDir, 'comparison.md'), renderMarkdown(cmp, results));
   process.stderr.write('[compare] wrote comparison.json + comparison.md\n');
 }
 

--- a/tests/octane/README.md
+++ b/tests/octane/README.md
@@ -1,12 +1,24 @@
 # Octane benchmark harness
 
 Runs Google's [Octane 2.0](https://github.com/chromium/octane) JavaScript
-benchmark suite under two engines and produces a side-by-side comparison:
+benchmark suite under three engines and produces a side-by-side comparison:
 
 | Engine | How it runs |
 |---|---|
 | **Chromium** | Real V8 in a headless browser, driven by Playwright. |
 | **Broiler** | The `BroilerJS --script-host` shell (the Broiler.JS engine). |
+| **Jint** | [Jint](https://github.com/sebastienros/jint), a managed ECMAScript interpreter, through the [`jint-host`](jint-host) shell. |
+
+Broiler is the subject; the other two are reference points, and they answer
+different questions. Chromium says how far Broiler is from V8 — a JIT-compiling
+C++ engine, so the answer is a large number that moves slowly. **Jint says how
+Broiler compares to another managed engine on the same runtime**, running the
+same script in the same process shape, and that ratio sits near 1 — which makes
+it the number a Broiler change can actually be judged by.
+
+Jint is a reference, not a target: it is an AST interpreter with no compilation
+tier at all, so beating it is a floor rather than a goal, and a suite where
+Broiler *loses* to an interpreter is pointing at a specific defect.
 
 This file covers *how* the harness runs. For what each benchmark actually does,
 which engine subsystem it loads, and where Broiler's time goes on it, see
@@ -16,16 +28,25 @@ which engine subsystem it loads, and where Broiler's time goes on it, see
 ## Running
 
 ```bash
-# Full run (clones chromium/octane, builds BroilerJS, installs Chromium):
+# Full run (clones chromium/octane, builds the two shells, installs Chromium):
 ./scripts/run-octane-benchmarks.sh
 
 # Faster local iteration against an existing checkout / build:
 ./scripts/run-octane-benchmarks.sh --octane-dir /path/to/octane --skip-build --engines broiler
+
+# The two managed engines, no browser needed:
+./scripts/run-octane-benchmarks.sh --octane-dir /path/to/octane --engines broiler,jint
 ```
 
 In CI the [Octane Benchmarks workflow](../../.github/workflows/octane-benchmarks.yml)
-(`workflow_dispatch`) runs both engines and commits the refreshed results. It
-also uploads the per-suite logs as an `octane-logs` artifact.
+(`workflow_dispatch`) runs all three engines and commits the refreshed results.
+It also uploads the per-suite logs as an `octane-logs` artifact.
+
+A single-engine run still refreshes the whole comparison: any per-engine result
+already in `results/` is folded back in, so `--engines jint` updates the Jint
+column against the last committed Chromium and Broiler ones. That is only honest
+when the runs come from the same machine — which is why the published numbers
+come from the workflow rather than from a workstation.
 
 ### Measuring, rather than just running
 
@@ -47,7 +68,11 @@ others is reported as **flaky** rather than averaged into a pass.
 The comparison also leads with the three numbers the run is read for: how many
 of the expected scores were reported, the geomean, and the **spread between the
 best and worst suite** — the last being the one [`roadmap.md`](roadmap.md) is
-organized around.
+organized around. Below them sits **Broiler ÷ Jint**, the geometric mean of the
+per-benchmark ratios over the suites both managed engines completed. It is a
+geomean of ratios rather than a ratio of geomeans because each engine's geomean
+is taken over whatever suites *it* finished, and dividing those compares two
+different suite sets.
 
 ### Per-suite time budgets
 
@@ -58,6 +83,10 @@ Mandreel (1200 s) and zlib (1800 s), which measured 313 s and 647 s under
 Broiler. Raising `--timeout` still widens every suite at once for a debugging
 run. The budget a suite ran under is recorded in its log and its status entry.
 
+Those budgets are set by Broiler, which is the slow one: Jint's longest suite
+(Mandreel) measured 104 s, inside the 180 s floor, so no suite needs a raised
+budget on its account.
+
 ## How it works
 
 Octane registers one `BenchmarkSuite` per benchmark file. The shared runner
@@ -66,13 +95,22 @@ suites and reports each score. In a JS shell (no `window`) Octane runs
 synchronously and the runner prints `OCTANE_RESULT_JSON {…}`; in a browser page
 it yields via `setTimeout`, so the Playwright driver awaits a Promise instead.
 
-Each suite is executed **in isolation** — a fresh Chromium page or a fresh
-Broiler process per suite — driven by the manifest
+Each suite is executed **in isolation** — a fresh Chromium page or a fresh shell
+process per suite — driven by the manifest
 [`scripts/octane-suites.json`](../../scripts/octane-suites.json). This is
 deliberate: Broiler is experimental, so a suite may score, throw a catchable
 error, hang, or abort the whole process. Isolation means one bad suite never
 discards the others. Each suite is classified `ok` / `error` / `timeout` /
 `crash`. The orchestration lives in [`scripts/run-octane.mjs`](../../scripts/run-octane.mjs).
+
+Broiler and Jint go through the same path — one `dotnet <shell> <combined script>`
+process per suite — differing only in which assembly is launched. The two shells
+also expose the *same* host surface: `print`, `read`, and no `window`. That is
+deliberate. A benchmark that fails for want of a host function then fails the
+same way under both, and the comparison stays a statement about the engine
+rather than about which shell was more generous. The Jint side of it is
+[`jint-host/Program.cs`](jint-host/Program.cs), which mirrors the BroilerJS
+shell down to the 16 MiB stack JavaScript runs on.
 
 The overall score is the geometric mean of the per-benchmark scores an engine
 completed, matching Octane's own methodology.
@@ -85,19 +123,26 @@ keeps the evidence rather than a one-line summary of it.
 **Start with [`results/diagnostics.md`](results/diagnostics.md).** For every
 suite that did not complete it gives the failing exception type, the benchmark /
 phase / iteration it died in, the engine (.NET) stack, the JavaScript stack, and
-a command to re-run that one suite.
+a command to re-run that one suite. It carries a section per shell engine:
+a Jint failure is not a Broiler bug, but *both* managed engines failing a suite
+the same way is the fastest way to tell a Broiler defect from a benchmark
+expecting a host facility neither shell provides.
 
 Three things make that report possible:
 
-- **Broiler's own error detail is kept in full.** When a .NET fault surfaces as
-  a catchable JS error, the exception type and its entire managed stack live in
-  the error's *message* — that is the diagnostic, and the runner captures it
+- **The engine's own error detail is kept in full.** When a .NET fault surfaces
+  as a catchable JS error, the exception type and its entire managed stack live
+  in the error's *message* — that is the diagnostic, and the runner captures it
   instead of truncating to the first line. An unhandled throw is recovered from
-  the process's stderr instead.
-- **Stack traces are mapped back to Octane sources.** Broiler runs one
+  the process's stderr instead: Broiler prints its own dump there, and Jint's
+  escapes as an unhandled .NET exception whose inner exception is the JavaScript
+  stack.
+- **Stack traces are mapped back to Octane sources.** Each shell runs one
   concatenated script per suite, so its traces cite lines in a temporary file.
   `run-octane.mjs` records where each part landed and rewrites every citation to
-  the file it came from, so a frame reads `base.js:371`, not `<temp>:2109`.
+  the file it came from, so a frame reads `base.js:371`, not `<temp>:2109`. Both
+  frame spellings are understood — Broiler's `at <fn>:<file>:<line>,<col>` and
+  Jint's V8-style `at <fn> (<file>:<line>:<col>)`.
 - **The runner leaves breadcrumbs.** [`scripts/octane-runner.js`](../../scripts/octane-runner.js)
   prints a line on entering each `Setup` / `run` / `tearDown` phase (and on
   iterations 1, 2, 4, 8, … of the measured loop). A suite that aborts the
@@ -125,7 +170,7 @@ to pass an engine diagnostic switch through, e.g.
 
 The parsing this depends on is covered by
 [`harness-selftest.mjs`](harness-selftest.mjs), which runs against recorded
-BroilerJS output and needs no engine, checkout, or network:
+BroilerJS and Jint output and needs no engine, checkout, or network:
 
 ```bash
 node tests/octane/harness-selftest.mjs
@@ -138,18 +183,26 @@ tests/octane/
 ├── package.json            # Playwright dependency (committed)
 ├── package-lock.json       # committed
 ├── harness-selftest.mjs    # committed; checks the diagnostic parsing
+├── jint-host/              # committed; the Jint shell — Program.cs and a csproj
+│                           #   whose only dependency is the Jint package
 ├── checkout/               # chromium/octane clone (gitignored, runtime)
 ├── node_modules/           # gitignored, runtime
 ├── logs/                   # gitignored, runtime
 │   ├── broiler/
 │   │   ├── <suite>.log     # full stdout/stderr, exit code, repro command
 │   │   └── scripts/        # combined script, kept for failing suites
+│   ├── jint/               # same shape as broiler/
 │   ├── chromium/<suite>.log
 │   └── partial/            # output of a --only run
 └── results/                # committed
     ├── chromium-results.json
     ├── broiler-results.json
+    ├── jint-results.json
     ├── comparison.json
     ├── comparison.md       # human-readable table
-    └── diagnostics.md      # why each failing suite failed
+    └── diagnostics.md      # why each failing suite failed, per engine
 ```
+
+The Jint shell is built by `run-octane-benchmarks.sh` alongside the BroilerJS
+one and belongs to no solution: it is a harness tool, not a Broiler component,
+and it references no repository project.

--- a/tests/octane/benchmarks.md
+++ b/tests/octane/benchmarks.md
@@ -65,6 +65,26 @@ overhead Broiler pays that a plain tree-walker does not — rather than a genera
 deficit. Read the ratios in §4 against Chromium for the size of the gap, and
 against Jint for whether a given suite is anomalous.
 
+**What the column shows on first evidence.** A single unrepeated run in a dev
+container — so *not* publishable numbers, and no substitute for the workflow run
+§4 is waiting on — nonetheless sorts the suites into three groups. The middle
+group is within noise of parity and should be read as no more than that; the two
+ends are decided by margins no noise band reaches:
+
+| Group | Suites, with Broiler ÷ Jint |
+|---|---|
+| Ahead of the interpreter | Mandreel 1.7, Crypto 1.5, NavierStokes 1.5, EarleyBoyer 1.1, Gameboy 1.1, Richards 1.1, Box2D 1.1 |
+| Level with it | RayTrace 0.99, Splay 0.94, DeltaBlue 0.89 |
+| **Behind it** | Typescript 0.80, SplayLatency 0.73, PdfJS 0.57, RegExp 0.42, **zlib 0.073, CodeLoad 0.029, MandreelLatency 0.017** |
+
+The three at the end are the finding. **CodeLoad and MandreelLatency are the two
+compilation-cost benchmarks** — the ones §3's **B4** names — and they are where
+Broiler falls 34× and 59× behind an engine that never compiles anything. Against
+Chromium those two are simply the largest of a column of large numbers; against
+Jint they are categorically different from every other suite, which is the
+distinction the second reference point exists to draw. zlib at 14× behind is the
+one that §4's ranking does not already predict, and is worth its own look.
+
 The published numbers come with the next workflow run; §4 below predates the
 column.
 

--- a/tests/octane/benchmarks.md
+++ b/tests/octane/benchmarks.md
@@ -49,6 +49,25 @@ Two consequences worth keeping in mind when reading the committed results:
   engine with: it is 15 large, real, self-contained programs that exercise almost
   every path an engine has, and it either runs them or it does not.
 
+### A third column: Jint
+
+The harness now also runs [Jint](https://github.com/sebastienros/jint), a
+managed ECMAScript interpreter, in a shell with the same host surface and stack
+budget as `BroilerJS --script-host` (see [`README.md`](README.md)). Its column
+answers a different question from Chromium's. V8 is a JIT-compiling C++ engine,
+so its ratio is a four-figure number that no single change moves; Jint is an AST
+interpreter on the same runtime, so **Broiler ÷ Jint lands near 1 and moves with
+the work**.
+
+That makes it a floor rather than a target. Jint has no compilation tier at all,
+so a benchmark where Broiler is *behind* it is naming a specific defect — an
+overhead Broiler pays that a plain tree-walker does not — rather than a general
+deficit. Read the ratios in §4 against Chromium for the size of the gap, and
+against Jint for whether a given suite is anomalous.
+
+The published numbers come with the next workflow run; §4 below predates the
+column.
+
 ---
 
 ## 2. The benchmarks

--- a/tests/octane/harness-selftest.mjs
+++ b/tests/octane/harness-selftest.mjs
@@ -1,14 +1,14 @@
 // harness-selftest.mjs — checks the diagnostic parsing in scripts/run-octane.mjs
-// against real Broiler output.
+// against real Broiler and Jint output.
 //
 //     node tests/octane/harness-selftest.mjs
 //
 // These are the parts of the Octane harness that can silently degrade: if the
 // combined-script line mapping or the stack-trace parsing stops working, the
 // benchmark still runs and still reports "crash" — it just stops saying where.
-// The fixtures below are verbatim excerpts of what BroilerJS actually printed,
-// so a change in either the harness or the engine's output format shows up as
-// a failure here rather than as a quietly emptier report.
+// The fixtures below are verbatim excerpts of what the two shells actually
+// printed, so a change in either the harness or an engine's output format shows
+// up as a failure here rather than as a quietly emptier report.
 //
 // No engine, no Octane checkout, and no network are needed.
 
@@ -24,6 +24,7 @@ import {
   parseClrException,
   parseDiagnostics,
   parseJsStack,
+  renderDiagnostics,
   renderMarkdown,
   shortenEnginePaths,
   suiteTimeoutSec,
@@ -193,6 +194,59 @@ checkTrue('unhandled block starts at the engine banner',
   extractUnhandledBlock(`noise\n${CRYPTO_STDERR}`).startsWith('Unhandled exception.'));
 check('unhandled block absent', extractUnhandledBlock('clean exit'), null);
 
+// ── Jint stack parsing ──────────────────────────────────────────────────────
+// Jint spells frames the way V8 does, so the same text has to be read a second
+// way. Recorded from a tests/octane/jint-host run — a throw that escaped every
+// handler arrives as an unhandled .NET exception whose *inner* exception is the
+// JavaScript stack, with the managed frames below it — with the script path and
+// line numbers retargeted at the fixture segments above.
+
+const JINT_CRASH = `Unhandled exception. Jint.Runtime.JavaScriptException: missingGlobal is not defined
+ ---> Error: missingGlobal is not defined
+    at setupFixture (${COMBINED}:405:27)
+    at ${COMBINED}:402:1
+   --- End of inner exception stack trace ---
+   at Jint.Engine.ScriptEvaluation(ScriptRecord scriptRecord, ParserOptions parserOptions)
+   at Jint.Engine.Execute(String code, String source)
+   at Broiler.Octane.JintHost.Program.Run(FileInfo script, Int32 maxFrames) in tests/octane/jint-host/Program.cs:line 174`;
+
+const jintClr = parseClrException(JINT_CRASH);
+check('jint: the escaping exception is the engine one', jintClr.type, 'Jint.Runtime.JavaScriptException');
+check('jint: its message is the JavaScript error', jintClr.message, 'missingGlobal is not defined');
+checkTrue('jint: the bare `Error:` inner line is not read as a managed exception', jintClr.inner.length === 0, JSON.stringify(jintClr.inner));
+checkTrue('jint: JavaScript frames stay out of the engine stack',
+  !jintClr.frames.some((f) => f.includes('setupFixture')),
+  jintClr.frames.join('\n'));
+
+// Both JS frames must survive, including the top-level one that has no function
+// name — for a load-time failure that frame is the whole localization.
+check('jint: `at <fn> (<file>:<line>:<col>)` frames',
+  parseJsStack(annotateCombinedPaths(JINT_CRASH, COMBINED, segments)),
+  [
+    { fn: 'setupFixture', file: 'crypto.js', line: 5 },
+    { fn: '<top level>', file: 'crypto.js', line: 2 },
+  ]);
+
+check('jint: an anonymous parenthesized frame',
+  parseJsStack('    at (crypto.js:12:3)'),
+  [{ fn: '<anonymous>', file: 'crypto.js', line: 12 }]);
+
+// A file name may contain both a dash and a directory separator; the split has
+// to land on the last two numbers, not the first colon.
+check('jint: a path with its own colons and dashes',
+  parseJsStack('    at run (/tmp/o/zlib-data.js:65:12)'),
+  [{ fn: 'run', file: '/tmp/o/zlib-data.js', line: 65 }]);
+
+// The Broiler spellings must keep winning on Broiler output: its column is
+// comma-separated, which is what keeps the two apart.
+check('jint: the V8 pattern does not swallow a Broiler frame',
+  parseJsStack('    at inline:earley-boyer.js:203,4'),
+  [{ fn: 'inline', file: 'earley-boyer.js', line: 203 }]);
+
+check('annotate: a V8-spelled citation keeps its column',
+  annotateCombinedPaths(`    at Encrypt (${COMBINED}:405:12)`, COMBINED, segments),
+  '    at Encrypt (crypto.js:5:12)');
+
 // ── Runner diagnostics ──────────────────────────────────────────────────────
 // The breadcrumbs must survive truncation: a killed process leaves a stdout
 // that ends mid-line, and that partial tail is exactly when they matter.
@@ -282,6 +336,75 @@ const single = buildComparison({
 }, '2026-01-01T00:00:00.000Z');
 checkTrue('render: one repetition says so plainly', renderMarkdown(single, null).includes('cannot be distinguished from noise'));
 checkTrue('render: one repetition has no spread column', !renderMarkdown(single, null).includes('Broiler spread'));
+
+// A two-engine run must keep reporting exactly what it did before Jint existed:
+// no empty columns, no zeroed coverage entry for an engine that never ran.
+checkTrue('render: no Jint column when Jint did not run', !md.includes('Jint'), md.slice(0, 600));
+checkTrue('compare: coverage names only the engines that ran', !('jint' in cmp.summary.scoresReported));
+check('compare: no managed-versus-managed number without Jint', cmp.summary.broilerVsJint, null);
+
+// ── Three engines ───────────────────────────────────────────────────────────
+// Jint is the managed reference point, so the number it adds is Broiler ÷ Jint —
+// which, unlike the Chromium ratio, is expected to land near 1.
+
+const three = buildComparison({
+  chromium: {
+    engineLabel: 'Chromium test', geomean: 50000, repetitions: 1,
+    benchmarks: { Richards: 40000, Splay: 40000, zlib: 80000 },
+    suiteStatus: { Richards: { status: 'ok' }, Splay: { status: 'ok' }, zlib: { status: 'ok' } },
+  },
+  broiler: {
+    engineLabel: 'Broiler test', geomean: 200, repetitions: 1,
+    benchmarks: { Richards: 100, Splay: 400 },
+    suiteStatus: { Richards: { status: 'ok' }, Splay: { status: 'ok' }, zlib: { status: 'error' } },
+  },
+  jint: {
+    engineLabel: 'Jint 4.15.3 (interpreter)', geomean: 300, repetitions: 1,
+    benchmarks: { Richards: 200, Splay: 200, zlib: 500 },
+    suiteStatus: { Richards: { status: 'ok' }, Splay: { status: 'ok' }, zlib: { status: 'ok' } },
+  },
+}, '2026-01-01T00:00:00.000Z');
+
+check('three: coverage counts all three engines', three.summary.scoresReported, { chromium: 3, broiler: 2, jint: 3, expected: 3 });
+check('three: Broiler behind Jint on a suite', three.benchmarks.find((r) => r.name === 'Richards').broilerVsJint, 0.5);
+check('three: Broiler ahead of Jint on a suite', three.benchmarks.find((r) => r.name === 'Splay').broilerVsJint, 2);
+check('three: no ratio where Broiler has no score', three.benchmarks.find((r) => r.name === 'zlib').broilerVsJint, null);
+check('three: Jint keeps its own ratio against Chromium', three.benchmarks.find((r) => r.name === 'zlib').jintVsChromium, 0.006);
+// Geometric mean of 0.5 and 2 is 1 — and it is taken over the ratios, not over
+// the geomeans, which are each computed on a different set of suites.
+check('three: the summary ratio is the geomean of the per-benchmark ones', three.summary.broilerVsJint, { ratio: 1, benchmarks: 2 });
+
+const md3 = renderMarkdown(three, {});
+checkTrue('three: the title names every engine', md3.startsWith('# Octane 2.0 benchmark — Chromium vs Broiler vs Jint'), md3.slice(0, 120));
+checkTrue('three: coverage row carries the Jint column', md3.includes('| Scores reported (of 3) | 3 | 2 | 3 |'), md3.slice(0, 900));
+checkTrue('three: the table grows a Broiler / Jint column', md3.includes('Broiler / Jint |'), md3.slice(0, 1800));
+checkTrue('three: the Jint score is in the row', /\| Splay \| 40000 \| 400 \| 200 \|/.test(md3), md3);
+
+// ── Diagnostics across engines ──────────────────────────────────────────────
+// Two shells can fail the same suite, so each failure needs an anchor and a
+// re-run command of its own — an unqualified `#crypto` would send both links to
+// whichever section happened to be written first.
+
+const diagnostics = renderDiagnostics({
+  broiler: {
+    engineLabel: 'Broiler test', perSuiteTimeoutSec: 180, repetitions: 1,
+    suiteStatus: {
+      Crypto: { status: 'crash', errorType: 'Broiler.JavaScript.Runtime.JSException', error: 'Maximum call stack size exceeded', failedAt: { benchmark: 'Encrypt', phase: 'run', iteration: 1 } },
+      Splay: { status: 'ok' },
+    },
+  },
+  jint: {
+    engineLabel: 'Jint 4.15.3 (interpreter)', perSuiteTimeoutSec: 180, repetitions: 1,
+    suiteStatus: { Crypto: { status: 'ok' }, Splay: { status: 'ok' } },
+  },
+}, '2026-01-01T00:00:00.000Z');
+
+checkTrue('diagnostics: one section per shell engine', diagnostics.includes('## Broiler') && diagnostics.includes('## Jint'), diagnostics);
+checkTrue('diagnostics: the failing suite is qualified by its engine', diagnostics.includes('### Broiler: Crypto'), diagnostics);
+checkTrue('diagnostics: its index links to that qualified anchor', diagnostics.includes('[Crypto](#broiler-crypto)'), diagnostics);
+checkTrue('diagnostics: an engine that completed everything says so', diagnostics.includes('All 2 suites completed. Nothing to diagnose.'), diagnostics);
+checkTrue('diagnostics: the re-run command names the engine that failed',
+  diagnostics.includes('--engines broiler --skip-build --only Crypto'), diagnostics);
 
 // ── Report ──────────────────────────────────────────────────────────────────
 

--- a/tests/octane/jint-host/Broiler.Octane.JintHost.csproj
+++ b/tests/octane/jint-host/Broiler.Octane.JintHost.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <RootNamespace>Broiler.Octane.JintHost</RootNamespace>
+    <AssemblyName>Broiler.Octane.JintHost</AssemblyName>
+    <!--
+      Not part of any solution: this is a benchmark-harness tool, built directly
+      by scripts/run-octane-benchmarks.sh the same way the BroilerJS shell is,
+      and it references no repository project — only the Jint package.
+    -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- https://github.com/sebastienros/jint — BSD-2-Clause managed ECMAScript interpreter. -->
+    <PackageReference Include="Jint" Version="4.15.3" />
+  </ItemGroup>
+
+</Project>

--- a/tests/octane/jint-host/Program.cs
+++ b/tests/octane/jint-host/Program.cs
@@ -1,0 +1,246 @@
+// Broiler.Octane.JintHost — the JavaScript shell the Octane harness runs its
+// `jint` engine in, backed by Jint (https://github.com/sebastienros/jint), a
+// managed ECMAScript interpreter.
+//
+//     dotnet Broiler.Octane.JintHost.dll <script.js> [--stack-mb N] [--max-frames N]
+//
+// scripts/run-octane.mjs builds one combined script per Octane suite (base.js +
+// the benchmark files + scripts/octane-runner.js) and runs it in a fresh process
+// of this shell, exactly as it does for `BroilerJS --script-host`.
+//
+// Why Jint is here: Chromium answers "how far is Broiler from V8", which is a
+// number about a JIT-compiling C++ engine. Jint answers the question a Broiler
+// change is actually steered by — how Broiler compares to another managed engine
+// on the same CLR, running the same script in the same process shape.
+//
+// The shell surface is deliberately the one BroilerJS's --script-host mode
+// defines and nothing more: `print`, `read`, and no `window`. A suite that fails
+// for want of a host function then fails the same way under both engines, and
+// the comparison stays a statement about the engine rather than about which
+// shell was more generous.
+
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Text.Json.Nodes;
+using Jint;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+
+namespace Broiler.Octane.JintHost;
+
+internal static class Program
+{
+    // Same budget the BroilerJS shell gives JavaScript (Broiler.JavaScript/Program.cs,
+    // ScriptHostStackBytes), rather than whatever the runtime handed Main — 1 MiB
+    // on Windows, 8 MiB on a typical Linux. Two managed engines measured against
+    // each other should get the same stack.
+    private const int DefaultStackBytes = 16 * 1024 * 1024;
+
+    // Arms Jint's call-depth guard (Options.Constraints.MaxExecutionStackCount).
+    // What that buys is the failure *mode*. Disarmed — the Jint default, a
+    // negative count — a runaway recursion exhausts the CLR stack, and a stack
+    // overflow is not catchable: the process aborts and the suite reports no
+    // result at all. Armed, the same recursion raises `RangeError: Maximum call
+    // stack size exceeded`, which the benchmark can catch and Octane can report,
+    // exactly as it would in a browser. That mirrors the BroilerJS shell, which
+    // reaches the same outcome through its 4 MiB stack reserve.
+    //
+    // The depth actually reached comes from the stack budget above rather than
+    // from this number: measured on .NET 10/linux-x64, a 16 MiB stack trips the
+    // guard between 9,000 and 10,000 frames of plain recursion, and a 64 MiB one
+    // between 30,000 and 60,000. So this is an upper bound that the stack reaches
+    // first — set to the frame count 16 MiB affords, which is the same order as
+    // V8's own limit (~13,955) and as the ~10,000 frames the BroilerJS shell
+    // budgets for.
+    private const int DefaultMaxFrames = 10_000;
+
+    private static int Main(string[] args)
+    {
+        string? scriptPath = null;
+        var stackBytes = DefaultStackBytes;
+        var maxFrames = DefaultMaxFrames;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--stack-mb":
+                    if (!TryTakeInt(args, ref i, out var mb) || mb <= 0) return Usage("--stack-mb expects a positive integer");
+                    stackBytes = mb * 1024 * 1024;
+                    break;
+                case "--max-frames":
+                    if (!TryTakeInt(args, ref i, out maxFrames)) return Usage("--max-frames expects an integer (negative disarms the guard)");
+                    break;
+                case "-h":
+                case "--help":
+                    return Usage(null);
+                default:
+                    if (args[i].StartsWith('-')) return Usage($"Unknown option: {args[i]}");
+                    if (scriptPath != null) return Usage("Only one script may be given");
+                    scriptPath = args[i];
+                    break;
+            }
+        }
+
+        if (scriptPath == null) return Usage("A script path is required");
+        var script = new FileInfo(scriptPath);
+        if (!script.Exists) return Usage($"Script not found: {script.FullName}");
+
+        // Read back by scripts/run-octane.mjs, which labels the engine in the
+        // comparison with what it says. The version that ran is a property of the
+        // run, not something the harness should be hard-coding on its side.
+        var version = JintVersion();
+        Console.WriteLine("OCTANE_ENGINE " + new JsonObject
+        {
+            ["engine"] = "jint",
+            ["label"] = $"Jint {version} (interpreter)",
+            ["version"] = version,
+            ["maxFrames"] = maxFrames,
+            ["stackBytes"] = stackBytes,
+        }.ToJsonString());
+
+        return RunOnOwnThread(script, stackBytes, maxFrames);
+    }
+
+    private static bool TryTakeInt(string[] args, ref int i, out int value)
+    {
+        value = 0;
+        return i + 1 < args.Length && int.TryParse(args[++i], out value);
+    }
+
+    private static int Usage(string? error)
+    {
+        var to = error == null ? Console.Out : Console.Error;
+        if (error != null) to.WriteLine($"error: {error}");
+        to.WriteLine("""
+            usage: Broiler.Octane.JintHost <script.js> [--stack-mb N] [--max-frames N]
+
+              --stack-mb N     Stack for the thread JavaScript runs on (default: 16). This
+                               is what decides how deep recursion can go — roughly 9,000
+                               frames at the default.
+              --max-frames N   Arm Jint's call-depth guard at N frames, so exhausting the
+                               stack raises `RangeError: Maximum call stack size exceeded`
+                               instead of aborting the process (default: 10000). A negative
+                               count disarms it, which is Jint's own default.
+            """);
+        return error == null ? 0 : 2;
+    }
+
+    // JavaScript runs on a thread this shell sizes itself; an escaping exception is
+    // rethrown on the main thread so an uncaught JavaScript error still reaches the
+    // runtime's unhandled-exception path with its original stack — which is what
+    // prints the `Unhandled exception.` block (engine frames, and the JavaScript
+    // frames Jint attaches as an inner exception) that the harness reads back when
+    // a suite dies without reporting a result.
+    private static int RunOnOwnThread(FileInfo script, int stackBytes, int maxFrames)
+    {
+        ExceptionDispatchInfo? failure = null;
+        var thread = new Thread(
+            () =>
+            {
+                try
+                {
+                    Run(script, maxFrames);
+                }
+                catch (Exception ex)
+                {
+                    failure = ExceptionDispatchInfo.Capture(ex);
+                }
+            },
+            stackBytes);
+
+        thread.Start();
+        thread.Join();
+        failure?.Throw();
+        return 0;
+    }
+
+    private static void Run(FileInfo script, int maxFrames)
+    {
+        var engine = new Engine(options =>
+        {
+            // Everything else stays at Jint's defaults — no statement budget, no
+            // execution timeout, no memory cap. The harness enforces its own
+            // per-suite timeout by killing this process, and a constraint that
+            // fired mid-benchmark would be measuring the constraint.
+            options.Constraints.MaxExecutionStackCount = maxFrames;
+        });
+
+        DefineShellGlobals(engine);
+
+        // The path is what Jint cites in stack traces. Passing the combined
+        // script's real path is what lets the harness rewrite those citations back
+        // to the Octane file each line came from (base.js:371, crypto.js:104, …).
+        engine.Execute(File.ReadAllText(script.FullName), script.FullName);
+    }
+
+    // Host functions provided by JavaScript shells (V8's d8, SpiderMonkey's js)
+    // that are not part of ECMAScript. Kept in step with the BroilerJS shell's
+    // DefineScriptHostGlobals, down to the argument handling.
+    private static void DefineShellGlobals(Engine engine)
+    {
+        // `print(...values)` writes the space-joined string form of its arguments,
+        // followed by a newline, to standard output and returns undefined. The
+        // Octane runner reports every result and diagnostic through it.
+        engine.SetValue("print", new ClrFunction(
+            engine,
+            "print",
+            (_, args) =>
+            {
+                var parts = new string[args.Length];
+                for (var i = 0; i < args.Length; i++)
+                    parts[i] = TypeConverter.ToString(args[i]);
+
+                Console.WriteLine(string.Join(" ", parts));
+                return JsValue.Undefined;
+            },
+            length: 1));
+
+        // `read(path)` returns the file's contents as a string; `read(path, "binary")`
+        // returns them as a Uint8Array. Emscripten's shell preamble references it
+        // unconditionally — `Module.read = read` — which is how Octane's zlib
+        // benchmark loads outside a browser: without the binding that bare
+        // reference is a ReferenceError before the benchmark runs a line, even
+        // though it never reads a file (its corpus is embedded in zlib-data.js).
+        engine.SetValue("read", new ClrFunction(
+            engine,
+            "read",
+            (_, args) =>
+            {
+                if (args.Length == 0 || args[0].IsUndefined())
+                    throw new JavaScriptException(engine.Intrinsics.TypeError, "read requires a file path");
+
+                var path = TypeConverter.ToString(args[0]);
+                var binary = args.Length > 1
+                    && !args[1].IsUndefined()
+                    && string.Equals(TypeConverter.ToString(args[1]), "binary", StringComparison.Ordinal);
+
+                try
+                {
+                    return binary
+                        ? engine.Intrinsics.Uint8Array.Construct(File.ReadAllBytes(path))
+                        : new JsString(File.ReadAllText(path));
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    throw new JavaScriptException(engine.Intrinsics.Error, $"Cannot read file {path}: {ex.Message}");
+                }
+            },
+            length: 1));
+    }
+
+    // "4.15.3", not the "4.15.3+<commit>" the informational version carries: the
+    // engine label is read by people comparing runs, and the commit hash is noise
+    // in a table cell.
+    private static string JintVersion()
+    {
+        var assembly = typeof(Engine).Assembly;
+        var informational = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (string.IsNullOrEmpty(informational))
+            return assembly.GetName().Version?.ToString() ?? "unknown";
+
+        var plus = informational.IndexOf('+');
+        return plus < 0 ? informational : informational[..plus];
+    }
+}


### PR DESCRIPTION
Extends the Octane benchmark harness to run [Jint](https://github.com/sebastienros/jint), a managed ECMAScript interpreter, alongside Chromium and Broiler. This adds a second reference point that answers a different question: how Broiler compares to another managed engine on the same CLR, running the same script in the same process shape.

## Key changes

- **New `jint-host` shell** (`tests/octane/jint-host/`): A .NET executable that runs JavaScript via Jint with the same host surface (`print`, `read`) and stack budget as the BroilerJS shell. Captures escaping JavaScript errors as unhandled .NET exceptions with the JS stack as an inner exception, matching the diagnostic protocol the harness already parses.

- **Unified shell engine abstraction** (`scripts/run-octane.mjs`): Refactored Broiler-specific code into a generic `runShellEngine()` function and `SHELL_ENGINES` configuration object. Both Broiler and Jint now share the same combined-script generation, line mapping, stack-trace parsing, and failure classification logic.

- **V8-style stack frame parsing**: Added regex patterns to recognize Jint's V8-compatible stack traces (`at <fn> (<file>:<line>:<col>)` and top-level frames), tried before the existing Broiler patterns to avoid ambiguity.

- **Engine self-reporting**: Shells can now print an `OCTANE_ENGINE` diagnostic line naming themselves and their version, which the harness uses to label results rather than hard-coding assumptions about what was installed.

- **Three-engine comparison**: Updated `buildComparison()` to handle all three engines, adding `broilerVsJint` ratio (geometric mean of per-benchmark ratios) as the managed-versus-managed reference point. Comparison reports now include Jint columns only when Jint results are present, preserving the shape of two-engine runs.

- **Documentation and CI**: Updated README, benchmarks guide, workflow, and shell script to explain the three-engine setup and the different questions each reference point answers.

## Implementation notes

- Jint runs on a thread sized by `--stack-mb` (default 16 MiB, matching BroilerJS) with a configurable call-depth guard (`--max-frames`, default 10,000) to raise `RangeError` on stack exhaustion instead of aborting the process.

- The `SHELL_ENGINES` map defines per-engine differences (DLL path, command-line args, environment) while keeping all downstream logic (script combination, diagnostics parsing, failure classification) engine-agnostic.

- Stack traces are mapped back to Octane sources using the same line-offset mechanism for both shells, since both run one concatenated script per suite.

- Comparison ratios use a helper `geomeanRatio()` function to compute geometric means of per-benchmark ratios, which is necessary because each engine's geomean is taken over whatever suites it completed.

https://claude.ai/code/session_01MKpZSYBiyD3mUtZCx4Rpyu