### PR TITLE
Flatten BOSS into package root; add ReadyToRun compilation

### DIFF
--- a/.github/workflows/broiler-preview-package.yml
+++ b/.github/workflows/broiler-preview-package.yml
@@ -126,13 +126,18 @@ jobs:
       - name: Restore Windows runtime graphs
         shell: pwsh
         run: |
-          dotnet restore $env:BROWSER_PROJECT_PATH --runtime win-x64 -p:Configuration=$env:WINDOWS_CONFIGURATION
-          dotnet restore $env:WRITER_PROJECT_PATH --runtime win-x64 -p:Configuration=$env:WINDOWS_CONFIGURATION
-          dotnet restore $env:BOSS_PROJECT_PATH --runtime win-x64 -p:Configuration=$env:WINDOWS_CONFIGURATION
+          # PublishReadyToRun is set here as well as on the publish: the crossgen2 compiler ships as
+          # a NuGet package (Microsoft.NETCore.App.Crossgen2.win-x64) that only enters the graph when
+          # restore already knows R2R is wanted. Publishing with --no-restore after a restore that
+          # did not would fail with NETSDK1094 ("a required package is missing").
+          dotnet restore $env:BROWSER_PROJECT_PATH --runtime win-x64 -p:Configuration=$env:WINDOWS_CONFIGURATION -p:PublishReadyToRun=true
+          dotnet restore $env:WRITER_PROJECT_PATH --runtime win-x64 -p:Configuration=$env:WINDOWS_CONFIGURATION -p:PublishReadyToRun=true
+          dotnet restore $env:BOSS_PROJECT_PATH --runtime win-x64 -p:Configuration=$env:WINDOWS_CONFIGURATION -p:PublishReadyToRun=true
 
           # The Writer WebAssembly client is not a ProjectReference of BOSS — the server publishes it
           # through an MSBuild task and vendors the result — so it needs its own restore, and one
-          # without the Windows RID: the client always targets browser-wasm.
+          # without the Windows RID: the client always targets browser-wasm. No R2R either: it is a
+          # CoreCLR ahead-of-time format, and browser-wasm runs on mono.
           dotnet restore $env:WRITER_CLIENT_PROJECT_PATH -p:Configuration=$env:WINDOWS_CONFIGURATION
 
       - name: Build Windows targets
@@ -150,6 +155,10 @@ jobs:
             --runtime win-x64 `
             --no-restore
 
+      # -p:PublishReadyToRun=true on every publish below: the assemblies are crossgen2-compiled to
+      # native code ahead of time, so the apps start without JITting their startup path. It needs a
+      # RID (--runtime win-x64, already here) and the matching restore above; it applies to the
+      # framework-dependent variant just as much as the self-contained one.
       - name: Publish Windows framework-dependent apps
         shell: pwsh
         run: |
@@ -162,7 +171,8 @@ jobs:
             --self-contained false `
             --no-restore `
             --output $output `
-            -p:UseAppHost=true
+            -p:UseAppHost=true `
+            -p:PublishReadyToRun=true
 
           dotnet publish $env:WRITER_PROJECT_PATH `
             --framework net10.0-windows `
@@ -171,17 +181,21 @@ jobs:
             --self-contained false `
             --no-restore `
             --output $output `
-            -p:UseAppHost=true
+            -p:UseAppHost=true `
+            -p:PublishReadyToRun=true
 
-          # BOSS goes into its own subfolder: it ships a vendored wwwroot, an appsettings.json and a
-          # service/ tree, none of which belong loose beside the desktop apps.
+          # BOSS publishes into the package root, not a BOSS/ subfolder: the server, its
+          # appsettings.json and its vendored wwwroot sit directly beside the desktop apps, and the
+          # packaging step lays the launcher, README and service/ tree around them there. It goes
+          # last so its vendored wwwroot is written after the desktop publishes have settled.
           dotnet publish $env:BOSS_PROJECT_PATH `
             --configuration $env:WINDOWS_CONFIGURATION `
             --runtime win-x64 `
             --self-contained false `
             --no-restore `
-            --output (Join-Path $output 'BOSS') `
-            -p:UseAppHost=true
+            --output $output `
+            -p:UseAppHost=true `
+            -p:PublishReadyToRun=true
 
       - name: Publish Windows self-contained apps
         shell: pwsh
@@ -194,7 +208,8 @@ jobs:
             --runtime win-x64 `
             --self-contained true `
             --no-restore `
-            --output $output
+            --output $output `
+            -p:PublishReadyToRun=true
 
           dotnet publish $env:WRITER_PROJECT_PATH `
             --framework net10.0-windows `
@@ -202,14 +217,16 @@ jobs:
             --runtime win-x64 `
             --self-contained true `
             --no-restore `
-            --output $output
+            --output $output `
+            -p:PublishReadyToRun=true
 
           dotnet publish $env:BOSS_PROJECT_PATH `
             --configuration $env:WINDOWS_CONFIGURATION `
             --runtime win-x64 `
             --self-contained true `
             --no-restore `
-            --output (Join-Path $output 'BOSS')
+            --output $output `
+            -p:PublishReadyToRun=true
 
       - name: Assemble and smoke-test the BOSS payloads
         shell: pwsh
@@ -217,14 +234,15 @@ jobs:
           # Lay the README, launcher and service files around each published server, then start it
           # and check it really serves the Writer — a package whose wwwroot did not survive the
           # publish still starts and answers /healthz, so only a real request catches it.
+          # The package root *is* the BOSS directory now, so both scripts take it directly.
           $packageParent = Join-Path $env:RUNNER_TEMP 'packages'
           $port = 5555
 
           foreach ($variant in @('framework-dependent', 'self-contained')) {
-            $bossDir = Join-Path $packageParent "BPP-Win32-$variant\BOSS"
+            $packageRoot = Join-Path $packageParent "BPP-Win32-$variant"
 
-            ./scripts/package-boss.ps1 -BossDirectory $bossDir -Platform windows
-            ./scripts/smoke-test-boss.ps1 -BossDirectory $bossDir -Port $port
+            ./scripts/package-boss.ps1 -PackageDirectory $packageRoot -Platform windows
+            ./scripts/smoke-test-boss.ps1 -PackageDirectory $packageRoot -Port $port
 
             # A fresh port per variant: Windows can hold a listening socket in TIME_WAIT briefly
             # after the previous server exits.
@@ -385,13 +403,18 @@ jobs:
       - name: Restore Linux runtime graphs
         shell: pwsh
         run: |
-          dotnet restore $env:BROWSER_PROJECT_PATH --runtime linux-x64 -p:Configuration=$env:LINUX_CONFIGURATION
-          dotnet restore $env:WRITER_PROJECT_PATH --runtime linux-x64 -p:Configuration=$env:LINUX_CONFIGURATION
-          dotnet restore $env:BOSS_PROJECT_PATH --runtime linux-x64 -p:Configuration=$env:LINUX_CONFIGURATION
+          # PublishReadyToRun is set here as well as on the publish: the crossgen2 compiler ships as
+          # a NuGet package (Microsoft.NETCore.App.Crossgen2.linux-x64) that only enters the graph
+          # when restore already knows R2R is wanted. Publishing with --no-restore after a restore
+          # that did not would fail with NETSDK1094 ("a required package is missing").
+          dotnet restore $env:BROWSER_PROJECT_PATH --runtime linux-x64 -p:Configuration=$env:LINUX_CONFIGURATION -p:PublishReadyToRun=true
+          dotnet restore $env:WRITER_PROJECT_PATH --runtime linux-x64 -p:Configuration=$env:LINUX_CONFIGURATION -p:PublishReadyToRun=true
+          dotnet restore $env:BOSS_PROJECT_PATH --runtime linux-x64 -p:Configuration=$env:LINUX_CONFIGURATION -p:PublishReadyToRun=true
 
           # The Writer WebAssembly client is not a ProjectReference of BOSS — the server publishes it
           # through an MSBuild task and vendors the result — so it needs its own restore, and one
-          # without the Linux RID: the client always targets browser-wasm.
+          # without the Linux RID: the client always targets browser-wasm. No R2R either: it is a
+          # CoreCLR ahead-of-time format, and browser-wasm runs on mono.
           dotnet restore $env:WRITER_CLIENT_PROJECT_PATH -p:Configuration=$env:LINUX_CONFIGURATION
 
       - name: Build Linux targets
@@ -432,6 +455,10 @@ jobs:
             --offscreen `
             --duration-ms=1
 
+      # -p:PublishReadyToRun=true on every publish below: the assemblies are crossgen2-compiled to
+      # native code ahead of time, so the apps start without JITting their startup path. It needs a
+      # RID (--runtime linux-x64, already here) and the matching restore above; it applies to the
+      # framework-dependent variant just as much as the self-contained one.
       - name: Publish Linux framework-dependent apps
         shell: pwsh
         run: |
@@ -444,7 +471,8 @@ jobs:
             --self-contained false `
             --no-restore `
             --output $output `
-            -p:UseAppHost=true
+            -p:UseAppHost=true `
+            -p:PublishReadyToRun=true
 
           dotnet publish $env:WRITER_PROJECT_PATH `
             --framework net10.0 `
@@ -453,17 +481,21 @@ jobs:
             --self-contained false `
             --no-restore `
             --output $output `
-            -p:UseAppHost=true
+            -p:UseAppHost=true `
+            -p:PublishReadyToRun=true
 
-          # BOSS goes into its own subfolder: it ships a vendored wwwroot, an appsettings.json and a
-          # service/ tree, none of which belong loose beside the desktop apps.
+          # BOSS publishes into the package root, not a BOSS/ subfolder: the server, its
+          # appsettings.json and its vendored wwwroot sit directly beside the desktop apps, and the
+          # packaging step lays the launcher, README and service/ tree around them there. It goes
+          # last so its vendored wwwroot is written after the desktop publishes have settled.
           dotnet publish $env:BOSS_PROJECT_PATH `
             --configuration $env:LINUX_CONFIGURATION `
             --runtime linux-x64 `
             --self-contained false `
             --no-restore `
-            --output (Join-Path $output 'BOSS') `
-            -p:UseAppHost=true
+            --output $output `
+            -p:UseAppHost=true `
+            -p:PublishReadyToRun=true
 
       - name: Publish Linux self-contained apps
         shell: pwsh
@@ -476,7 +508,8 @@ jobs:
             --runtime linux-x64 `
             --self-contained true `
             --no-restore `
-            --output $output
+            --output $output `
+            -p:PublishReadyToRun=true
 
           dotnet publish $env:WRITER_PROJECT_PATH `
             --framework net10.0 `
@@ -484,14 +517,16 @@ jobs:
             --runtime linux-x64 `
             --self-contained true `
             --no-restore `
-            --output $output
+            --output $output `
+            -p:PublishReadyToRun=true
 
           dotnet publish $env:BOSS_PROJECT_PATH `
             --configuration $env:LINUX_CONFIGURATION `
             --runtime linux-x64 `
             --self-contained true `
             --no-restore `
-            --output (Join-Path $output 'BOSS')
+            --output $output `
+            -p:PublishReadyToRun=true
 
       - name: Assemble and smoke-test the BOSS payloads
         shell: pwsh
@@ -499,14 +534,15 @@ jobs:
           # Lay the README, launcher and service files around each published server, then start it
           # and check it really serves the Writer — a package whose wwwroot did not survive the
           # publish still starts and answers /healthz, so only a real request catches it.
+          # The package root *is* the BOSS directory now, so both scripts take it directly.
           $packageParent = Join-Path $env:RUNNER_TEMP 'packages'
           $port = 5555
 
           foreach ($variant in @('framework-dependent', 'self-contained')) {
-            $bossDir = Join-Path $packageParent "BPP-Linux-$variant/BOSS"
+            $packageRoot = Join-Path $packageParent "BPP-Linux-$variant"
 
-            ./scripts/package-boss.ps1 -BossDirectory $bossDir -Platform linux
-            ./scripts/smoke-test-boss.ps1 -BossDirectory $bossDir -Port $port
+            ./scripts/package-boss.ps1 -PackageDirectory $packageRoot -Platform linux
+            ./scripts/smoke-test-boss.ps1 -PackageDirectory $packageRoot -Port $port
 
             $port++
           }
@@ -724,6 +760,10 @@ jobs:
           dotnet restore $env:BROWSER_PROJECT_PATH -p:Configuration=$env:ANDROID_CONFIGURATION
           dotnet restore $env:WRITER_PROJECT_PATH -p:Configuration=$env:ANDROID_CONFIGURATION
 
+      # No -p:PublishReadyToRun here or on the APK publish below, unlike the desktop jobs: R2R is a
+      # CoreCLR format produced by crossgen2, and net10.0-android runs on mono, which has no
+      # crossgen2 pack for the android-* RIDs. Mono's own ahead-of-time story is RunAOTCompilation,
+      # a different (and much slower to build) switch the heads currently pin off.
       - name: Publish Android app bundles
         shell: pwsh
         run: |
@@ -1069,35 +1109,41 @@ jobs:
           # Single-quoted here-string: the notes are full of Markdown backticks, and in an
           # interpolating string PowerShell would eat them as escape characters.
           $contents = @'
-          Each desktop package (`BPP-Win32-*`, `BPP-Linux-*`) contains:
+          Each desktop package (`BPP-Win32-*`, `BPP-Linux-*`) extracts to a single flat folder
+          holding all three applications side by side:
 
           * `Broiler.Browser` — the Broiler web browser.
           * `Broiler.Writer` — the Broiler word processor (desktop).
-          * `BOSS/` — **Broiler Office Standalone Server**: a Kestrel host that serves the Broiler
-            Writer web app (WebAssembly), so the Writer runs in a browser with no other web server
-            involved.
+          * `Broiler.Office.Server` — **BOSS**, the Broiler Office Standalone Server: a Kestrel host
+            that serves the Broiler Writer web app (WebAssembly) from the `wwwroot/` beside it, so
+            the Writer runs in a browser with no other web server involved.
 
           Starting BOSS after extracting a package:
 
           ```
-          ./BOSS/run-boss.sh --urls http://0.0.0.0:5555        # Linux
-          BOSS\Start-BOSS.cmd                                  # Windows
+          ./run-boss.sh --urls http://0.0.0.0:5555             # Linux
+          Start-BOSS.cmd                                       # Windows
           ```
 
           Then open <http://localhost:5555/>. Liveness probe at `/healthz`, server details at
           `/api/info`.
 
-          To keep it serving across reboots, `BOSS/service/` carries prepared unit files and
-          installers — a hardened systemd unit (`Type=notify`), an LSB SysV init script, a Windows
-          service installer, plus nginx and Apache reverse-proxy samples:
+          To keep it serving across reboots, `service/` carries prepared unit files and installers —
+          a hardened systemd unit (`Type=notify`), an LSB SysV init script, a Windows service
+          installer, plus nginx and Apache reverse-proxy samples:
 
           ```
-          sudo ./BOSS/service/install-service.sh --urls http://0.0.0.0:5555
-          powershell -ExecutionPolicy Bypass -File BOSS\service\Install-BossService.ps1 -OpenFirewall
+          sudo ./service/install-service.sh --urls http://0.0.0.0:5555
+          powershell -ExecutionPolicy Bypass -File service\Install-BossService.ps1 -OpenFirewall
           ```
 
-          Full documentation ships in the package: `BOSS/README.md` and `BOSS/service/README.md`.
-          Each package root also carries a `BUILD-INFO.txt` naming the branch, commit and build time.
+          Full documentation ships in the package: `README.md` and `service/README.md`. The package
+          root also carries a `BUILD-INFO.txt` naming the branch, commit and build time.
+
+          The application assemblies in a desktop package are **ReadyToRun**-compiled — precompiled
+          to native code for the target architecture, so the applications start without JITting
+          their startup path. The IL is still there, so the JIT retains its usual freedom to
+          re-optimize hot code at run time.
 
           Variants:
 

--- a/Broiler.Office.Server/README.md
+++ b/Broiler.Office.Server/README.md
@@ -95,18 +95,21 @@ Windows service.
 ## Shipping: preview packages and service files
 
 BOSS ships inside every **Broiler Preview Package** (BPP) — Linux and Windows, self-contained and
-framework-dependent — under `BOSS/`, alongside `Broiler.Browser` and `Broiler.Writer`. The
+framework-dependent — in the **package root**, alongside `Broiler.Browser` and `Broiler.Writer`,
+whose runtime files it shares. The
 [`Prepare Broiler Preview Package`](../.github/workflows/broiler-preview-package.yml) workflow
 publishes the server, lays the packaging assets around it
 ([`scripts/package-boss.ps1`](../scripts/package-boss.ps1)), and smoke-tests the result
 ([`scripts/smoke-test-boss.ps1`](../scripts/smoke-test-boss.ps1)) before anything reaches a release.
+Every desktop assembly in a BPP is published ReadyToRun, so the server starts without JITting its
+startup path.
 
 What a user gets next to the binary — end-user README, foreground launcher, and ready-to-install
 service definitions (a hardened systemd unit, an LSB SysV init script, a Windows service installer,
 nginx/Apache reverse-proxy samples) — lives in [`packaging/`](packaging/README.md).
 
 ```bash
-sudo ./BOSS/service/install-service.sh --urls http://0.0.0.0:5555     # systemd or SysV
+sudo ./service/install-service.sh --urls http://0.0.0.0:5555     # systemd or SysV
 ```
 
 ## Adding more Office apps

--- a/Broiler.Office.Server/packaging/README.md
+++ b/Broiler.Office.Server/packaging/README.md
@@ -5,15 +5,16 @@ files, install scripts, launchers and the end-user documentation.
 
 Nothing here is compiled. The `Prepare Broiler Preview Package` workflow
 ([`.github/workflows/broiler-preview-package.yml`](../../.github/workflows/broiler-preview-package.yml))
-publishes `Broiler.Office.Server` into `BOSS/` inside each package and copies this tree in around it,
-so the layout below *is* the layout a user extracts.
+publishes `Broiler.Office.Server` into the **package root** — the same flat folder as
+`Broiler.Browser` and `Broiler.Writer`, whose runtime files it shares — and copies this tree in
+around it, so the layout below *is* the layout a user extracts.
 
 ```
 packaging/
-├── common/README.md                       → BOSS/README.md            (both platforms)
+├── common/README.md                       → <package>/README.md       (both platforms)
 ├── linux/
-│   ├── run-boss.sh                        → BOSS/run-boss.sh
-│   └── service/                           → BOSS/service/
+│   ├── run-boss.sh                        → <package>/run-boss.sh
+│   └── service/                           → <package>/service/
 │       ├── README.md                        Linux service guide
 │       ├── install-service.sh               systemd or SysV, auto-detected
 │       ├── uninstall-service.sh
@@ -23,8 +24,8 @@ packaging/
 │       ├── sysv/broiler-office-server.default
 │       └── reverse-proxy/{nginx,apache}-broiler-office-server.conf
 └── windows/
-    ├── Start-BOSS.cmd                     → BOSS/Start-BOSS.cmd
-    └── service/                           → BOSS/service/
+    ├── Start-BOSS.cmd                     → <package>/Start-BOSS.cmd
+    └── service/                           → <package>/service/
         ├── README.md                        Windows service guide
         ├── Install-BossService.ps1
         └── Uninstall-BossService.ps1
@@ -50,25 +51,35 @@ only — so a user never has to work out which half of a folder applies to them.
   systemd unit can be `Type=notify` and the Windows service needs no wrapper. It also anchors the
   content root at the executable's directory, so a service manager's working directory cannot hide
   `wwwroot/`.
+* **The installers copy the package root wholesale.** Since the server's assemblies are commingled
+  with the desktop applications', there is no subset to pick out: `install-service.sh` and
+  `Install-BossService.ps1` copy the whole extracted package into the install prefix, and
+  `Broiler.Browser` / `Broiler.Writer` land there inert. That is deliberate — a selective copy would
+  have to track the server's dependency closure by hand and would break the first time it changed.
 * Shell scripts are POSIX `sh` (they run on busybox and on RHEL without bash-isms); PowerShell
   scripts stay compatible with Windows PowerShell 5.1, which is what a bare Windows Server has.
 
 ## Testing a change
 
-Publish the server and assemble a package by hand:
+Publish the server and assemble a package by hand — into a bare directory here, without the desktop
+applications the real package also carries:
 
 ```bash
 dotnet publish Broiler.Office.Server/Broiler.Office.Server.csproj -c Release-Linux \
-    -r linux-x64 --self-contained true -o /tmp/BOSS
-cp -a Broiler.Office.Server/packaging/common/README.md /tmp/BOSS/
-cp -a Broiler.Office.Server/packaging/linux/run-boss.sh /tmp/BOSS/
-cp -a Broiler.Office.Server/packaging/linux/service /tmp/BOSS/
-/tmp/BOSS/run-boss.sh --urls http://127.0.0.1:5555 &
+    -r linux-x64 --self-contained true -p:PublishReadyToRun=true -o /tmp/bpp
+./scripts/package-boss.ps1 -PackageDirectory /tmp/bpp -Platform linux
+/tmp/bpp/run-boss.sh --urls http://127.0.0.1:5555 &
 curl -fsS http://127.0.0.1:5555/healthz
 ```
 
-The workflow does exactly this and then smoke-tests `/healthz`, `/api/info` and `/` on both
-platforms, so a broken package fails the run rather than reaching a release.
+`package-boss.ps1` is the same script the workflow calls, so it copies exactly what ships and fails
+on the same missing assets. The workflow then smoke-tests `/healthz`, `/api/info` and `/` on both
+platforms ([`scripts/smoke-test-boss.ps1`](../../scripts/smoke-test-boss.ps1)), so a broken package
+fails the run rather than reaching a release.
+
+`-p:PublishReadyToRun=true` matches what the workflow publishes; drop it for a quicker local
+iteration. When it *is* set, restore has to know too (the crossgen2 compiler comes in as a NuGet
+package), which the command above handles by not passing `--no-restore`.
 
 For the server itself — the vendored-publish hosting model, endpoints, how to add another Office
 app — see [`../README.md`](../README.md).

--- a/Broiler.Office.Server/packaging/common/README.md
+++ b/Broiler.Office.Server/packaging/common/README.md
@@ -7,6 +7,10 @@ server, no Node, no Python `http.server`.
 Everything the server needs is in this directory: the executable, `appsettings.json`, and `wwwroot/`
 holding the complete Writer bundle (the mono-wasm runtime and its content-hashed assets).
 
+This is the root of a Broiler Preview Package, so `Broiler.Browser` and `Broiler.Writer` — the
+desktop applications — sit here too and share the runtime files around them. They are independent of
+the server; starting or deleting one has no effect on the others.
+
 ---
 
 ## Quick start
@@ -173,13 +177,21 @@ Turn up the detail when something is unclear:
 ## What is in this package
 
 ```
-BOSS/
-├── Broiler.Office.Server[.exe]   the server
-├── appsettings.json              configuration
-├── wwwroot/                      the Broiler Writer WebAssembly bundle
-├── README.md                     this file
+BPP-<os>-<variant>/
+├── Broiler.Office.Server[.exe]   the server (BOSS)
+├── appsettings.json              its configuration
+├── wwwroot/                      the Broiler Writer WebAssembly bundle it serves
 ├── run-boss.sh / Start-BOSS.cmd  foreground launcher
-└── service/                      unit files, install scripts, reverse-proxy samples
+├── service/                      unit files, install scripts, reverse-proxy samples
+├── README.md                     this file
+│
+├── Broiler.Browser[.exe]         the Broiler web browser (desktop)
+├── Broiler.Writer[.exe]          the Broiler word processor (desktop)
+├── BUILD-INFO.txt                which build this is: branch, commit, build time
+└── *.dll                         the runtime and libraries all three applications share
 ```
+
+The three applications live side by side in one flat folder because they share those runtime files;
+each is started directly and none of them needs the others.
 
 Source and issue tracker: <https://github.com/Broiler-Platform/Broiler>.

--- a/Broiler.Office.Server/packaging/linux/run-boss.sh
+++ b/Broiler.Office.Server/packaging/linux/run-boss.sh
@@ -20,7 +20,7 @@ BOSS_URLS=${BOSS_URLS:-http://0.0.0.0:5555}
     if [ -f "$BOSS_EXEC" ]; then
         chmod +x "$BOSS_EXEC"
     else
-        echo "run-boss.sh: $BOSS_EXEC not found — run this from the extracted BOSS directory." >&2
+        echo "run-boss.sh: $BOSS_EXEC not found — run this from the extracted package directory." >&2
         exit 1
     fi
 }

--- a/Broiler.Office.Server/packaging/linux/service/README.md
+++ b/Broiler.Office.Server/packaging/linux/service/README.md
@@ -43,6 +43,10 @@ plus its configuration file, and starts the service. **Re-running it upgrades in
 payload is refreshed (`wwwroot/` replaced wholesale) and an existing configuration file is kept, with
 the new version written beside it as `*.new`.
 
+The payload is the whole extracted package directory, because the server shares its runtime files
+with `Broiler.Browser` and `Broiler.Writer` in the same folder. Those two are copied into `--prefix`
+along with it and sit there inert — the service only ever runs `Broiler.Office.Server`.
+
 Check it:
 
 ```bash

--- a/Broiler.Office.Server/packaging/linux/service/install-service.sh
+++ b/Broiler.Office.Server/packaging/linux/service/install-service.sh
@@ -4,14 +4,19 @@
 #
 # Run it from the extracted preview package, as root:
 #
-#   sudo ./BOSS/service/install-service.sh                        # auto-detect systemd or SysV
-#   sudo ./BOSS/service/install-service.sh --urls http://0.0.0.0:5555
-#   sudo ./BOSS/service/install-service.sh --init sysv --prefix /srv/boss --user www-data
+#   sudo ./service/install-service.sh                        # auto-detect systemd or SysV
+#   sudo ./service/install-service.sh --urls http://0.0.0.0:5555
+#   sudo ./service/install-service.sh --init sysv --prefix /srv/boss --user www-data
 #
 # It copies the server next to its vendored wwwroot into --prefix, creates the service account,
 # installs the unit / init script plus its configuration file, and (unless --no-start) enables and
 # starts the service. Re-running it upgrades the payload in place; an existing configuration file is
 # never overwritten (the new one is written alongside as *.new).
+#
+# The payload is the whole extracted package directory: the server shares its runtime files with
+# Broiler.Browser and Broiler.Writer, which sit in the same folder, so those two ride along into
+# --prefix as well. They are inert there — nothing starts them, and the service only ever runs
+# Broiler.Office.Server.
 #
 # Undo with ./uninstall-service.sh.
 
@@ -25,10 +30,14 @@ INIT=auto
 START=1
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# This script lives in <package>/service/, so the parent is the package root — which is also where
+# the server, its appsettings.json and its wwwroot/ are published.
 PAYLOAD_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 
 usage() {
-    sed -n '3,20p' "$0" | sed 's/^# \{0,1\}//'
+    # The header comment above is the help text: print from line 3 up to the first line that is not
+    # a comment, so editing the header cannot leave --help printing shell code after it.
+    sed -n '3,$ { /^#/!q; s/^# \{0,1\}//p; }' "$0"
     cat <<EOF
 
 Options:

--- a/Broiler.Office.Server/packaging/windows/Start-BOSS.cmd
+++ b/Broiler.Office.Server/packaging/windows/Start-BOSS.cmd
@@ -17,7 +17,7 @@ if not defined ASPNETCORE_ENVIRONMENT set "ASPNETCORE_ENVIRONMENT=Production"
 set "DOTNET_NOLOGO=1"
 
 if not exist "%BOSS_EXEC%" (
-    echo Start-BOSS.cmd: %BOSS_EXEC% not found - run this from the extracted BOSS folder. 1>&2
+    echo Start-BOSS.cmd: %BOSS_EXEC% not found - run this from the extracted package folder. 1>&2
     exit /b 1
 )
 if not exist "%BOSS_DIR%wwwroot" (

--- a/Broiler.Office.Server/packaging/windows/service/Install-BossService.ps1
+++ b/Broiler.Office.Server/packaging/windows/service/Install-BossService.ps1
@@ -3,10 +3,15 @@
     Installs BOSS — the Broiler Office Standalone Server — as a Windows service.
 
 .DESCRIPTION
-    Copies the extracted BOSS folder to -InstallPath, registers a Windows service that starts it
+    Copies the extracted package folder to -InstallPath, registers a Windows service that starts it
     with the requested listening addresses, and starts the service. The server links
     Microsoft.Extensions.Hosting.WindowsServices, so it answers the service control protocol
     directly — no wrapper (NSSM, srvany) is needed.
+
+    The payload is the whole extracted package: the server shares its runtime files with
+    Broiler.Browser.exe and Broiler.Writer.exe, which sit in the same folder, so those two are
+    copied to -InstallPath as well. They are inert there — nothing starts them, and the service only
+    ever runs Broiler.Office.Server.exe.
 
     Re-running upgrades the payload in place: the service is stopped, the files are refreshed and
     the service is started again.
@@ -64,7 +69,7 @@ function Assert-Elevated {
 
 Assert-Elevated
 
-$payloadDir = Split-Path -Parent $PSScriptRoot          # …\BOSS  (this script lives in …\BOSS\service)
+$payloadDir = Split-Path -Parent $PSScriptRoot          # the package root (this script lives in …\service)
 $sourceExe = Join-Path $payloadDir 'Broiler.Office.Server.exe'
 
 if (-not (Test-Path -LiteralPath $sourceExe)) {

--- a/Broiler.Office.Server/packaging/windows/service/README.md
+++ b/Broiler.Office.Server/packaging/windows/service/README.md
@@ -39,6 +39,11 @@ restart-on-crash after 5 s / 10 s / 60 s), grants the service account read+execu
 tree, and starts it. **Re-running upgrades in place** — the service is stopped, `wwwroot\` is
 replaced wholesale, and the service starts again.
 
+The payload is the whole extracted package folder, because the server shares its runtime files with
+`Broiler.Browser.exe` and `Broiler.Writer.exe` in the same folder. Those two are copied to
+`-InstallPath` along with it and sit there inert — the service only ever runs
+`Broiler.Office.Server.exe`.
+
 Check it:
 
 ```powershell

--- a/scripts/package-boss.ps1
+++ b/scripts/package-boss.ps1
@@ -6,25 +6,29 @@
     `dotnet publish` produces the server, appsettings.json and the vendored Writer wwwroot. This
     script adds everything a user needs around it — the README, the foreground launcher, and the
     service unit files / install scripts for the target platform — turning the publish output into
-    the BOSS/ folder that ships inside a Broiler Preview Package (BPP).
+    a complete Broiler Preview Package (BPP).
+
+    The server publishes into the package root rather than a BOSS/ subfolder, so these assets land
+    in the same flat directory as Broiler.Browser and Broiler.Writer.
 
     Assets come from Broiler.Office.Server/packaging: common/ everywhere, then linux/ or windows/.
     Only the platform's own half is copied, so a user never has to work out which files apply.
 
     Used by .github/workflows/broiler-preview-package.yml; run it by hand to reproduce a package.
 
-.PARAMETER BossDirectory
-    The publish output directory to lay the assets into (…/BPP-<os>-<variant>/BOSS).
+.PARAMETER PackageDirectory
+    The package root to lay the assets into (…/BPP-<os>-<variant>), which is also the directory
+    `dotnet publish` wrote the server into.
 
 .PARAMETER Platform
     linux or windows — selects which half of the packaging tree ships.
 
 .EXAMPLE
-    ./scripts/package-boss.ps1 -BossDirectory /tmp/packages/BPP-Linux-self-contained/BOSS -Platform linux
+    ./scripts/package-boss.ps1 -PackageDirectory /tmp/packages/BPP-Linux-self-contained -Platform linux
 #>
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $true)][string] $BossDirectory,
+    [Parameter(Mandatory = $true)][string] $PackageDirectory,
     [Parameter(Mandatory = $true)][ValidateSet('linux', 'windows')][string] $Platform
 )
 
@@ -34,22 +38,22 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $packagingRoot = Join-Path $repoRoot 'Broiler.Office.Server/packaging'
 
-if (-not (Test-Path -LiteralPath $BossDirectory)) {
-    throw "Publish output not found: $BossDirectory"
+if (-not (Test-Path -LiteralPath $PackageDirectory)) {
+    throw "Publish output not found: $PackageDirectory"
 }
 if (-not (Test-Path -LiteralPath $packagingRoot)) {
     throw "Packaging assets not found: $packagingRoot"
 }
 
 $executableName = if ($Platform -eq 'windows') { 'Broiler.Office.Server.exe' } else { 'Broiler.Office.Server' }
-$executable = Join-Path $BossDirectory $executableName
+$executable = Join-Path $PackageDirectory $executableName
 if (-not (Test-Path -LiteralPath $executable)) {
     throw "Expected server executable was not produced: $executable"
 }
 
 # The whole point of the vendored-publish hosting model: without wwwroot the server starts, answers
 # /healthz, and 404s every page. Fail here rather than shipping that.
-$indexHtml = Join-Path $BossDirectory 'wwwroot/index.html'
+$indexHtml = Join-Path $PackageDirectory 'wwwroot/index.html'
 if (-not (Test-Path -LiteralPath $indexHtml)) {
     throw "The Writer bundle is missing from the publish output: $indexHtml"
 }
@@ -61,38 +65,38 @@ if ((Get-Content -LiteralPath $indexHtml -Raw) -notmatch '<script type="importma
     throw "The vendored index.html has no import map — the Writer bundle was not published/transformed correctly: $indexHtml"
 }
 
-Write-Host "==> laying BOSS packaging assets into $BossDirectory ($Platform)"
+Write-Host "==> laying BOSS packaging assets into $PackageDirectory ($Platform)"
 
-Copy-Item -LiteralPath (Join-Path $packagingRoot 'common/README.md') -Destination $BossDirectory -Force
+Copy-Item -LiteralPath (Join-Path $packagingRoot 'common/README.md') -Destination $PackageDirectory -Force
 
 if ($Platform -eq 'linux') {
-    Copy-Item -LiteralPath (Join-Path $packagingRoot 'linux/run-boss.sh') -Destination $BossDirectory -Force
-    Copy-Item -LiteralPath (Join-Path $packagingRoot 'linux/service') -Destination $BossDirectory -Recurse -Force
+    Copy-Item -LiteralPath (Join-Path $packagingRoot 'linux/run-boss.sh') -Destination $PackageDirectory -Force
+    Copy-Item -LiteralPath (Join-Path $packagingRoot 'linux/service') -Destination $PackageDirectory -Recurse -Force
 
     # tar preserves the mode, so set it here rather than asking users to chmod after extracting.
     if ($IsLinux -or $IsMacOS) {
-        chmod 0755 $executable (Join-Path $BossDirectory 'run-boss.sh')
-        chmod 0755 (Join-Path $BossDirectory 'service/install-service.sh') `
-                   (Join-Path $BossDirectory 'service/uninstall-service.sh') `
-                   (Join-Path $BossDirectory 'service/sysv/broiler-office-server')
+        chmod 0755 $executable (Join-Path $PackageDirectory 'run-boss.sh')
+        chmod 0755 (Join-Path $PackageDirectory 'service/install-service.sh') `
+                   (Join-Path $PackageDirectory 'service/uninstall-service.sh') `
+                   (Join-Path $PackageDirectory 'service/sysv/broiler-office-server')
     }
 }
 else {
-    Copy-Item -LiteralPath (Join-Path $packagingRoot 'windows/Start-BOSS.cmd') -Destination $BossDirectory -Force
-    Copy-Item -LiteralPath (Join-Path $packagingRoot 'windows/service') -Destination $BossDirectory -Recurse -Force
+    Copy-Item -LiteralPath (Join-Path $packagingRoot 'windows/Start-BOSS.cmd') -Destination $PackageDirectory -Force
+    Copy-Item -LiteralPath (Join-Path $packagingRoot 'windows/service') -Destination $PackageDirectory -Recurse -Force
 }
 
 $launcher = if ($Platform -eq 'windows') { 'Start-BOSS.cmd' } else { 'run-boss.sh' }
 foreach ($asset in @($executableName, 'appsettings.json', 'README.md', $launcher)) {
-    if (-not (Test-Path -LiteralPath (Join-Path $BossDirectory $asset))) {
+    if (-not (Test-Path -LiteralPath (Join-Path $PackageDirectory $asset))) {
         throw "Packaging did not produce the expected asset: $asset"
     }
     Write-Host "    $asset"
 }
 
-Get-ChildItem -LiteralPath (Join-Path $BossDirectory 'service') -Recurse -File |
-    ForEach-Object { Write-Host "    service/$([IO.Path]::GetRelativePath((Join-Path $BossDirectory 'service'), $_.FullName) -replace '\\', '/')" }
+Get-ChildItem -LiteralPath (Join-Path $PackageDirectory 'service') -Recurse -File |
+    ForEach-Object { Write-Host "    service/$([IO.Path]::GetRelativePath((Join-Path $PackageDirectory 'service'), $_.FullName) -replace '\\', '/')" }
 
-$bundleSize = (Get-ChildItem -LiteralPath (Join-Path $BossDirectory 'wwwroot') -Recurse -File |
+$bundleSize = (Get-ChildItem -LiteralPath (Join-Path $PackageDirectory 'wwwroot') -Recurse -File |
     Measure-Object -Property Length -Sum).Sum
 Write-Host ("    wwwroot/ ({0:N1} MB Writer bundle)" -f ($bundleSize / 1MB))

--- a/scripts/smoke-test-boss.ps1
+++ b/scripts/smoke-test-boss.ps1
@@ -20,8 +20,9 @@
 
     Used by .github/workflows/broiler-preview-package.yml after each publish.
 
-.PARAMETER BossDirectory
-    Directory holding the published Broiler.Office.Server and its wwwroot.
+.PARAMETER PackageDirectory
+    Directory holding the published Broiler.Office.Server and its wwwroot — the package root, since
+    the server publishes into it directly rather than into a BOSS/ subfolder.
 
 .PARAMETER Port
     Loopback port to listen on. Default 5555.
@@ -31,11 +32,11 @@
     a cold CI runner is not instant.
 
 .EXAMPLE
-    ./scripts/smoke-test-boss.ps1 -BossDirectory /tmp/packages/BPP-Linux-self-contained/BOSS
+    ./scripts/smoke-test-boss.ps1 -PackageDirectory /tmp/packages/BPP-Linux-self-contained
 #>
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $true)][string] $BossDirectory,
+    [Parameter(Mandatory = $true)][string] $PackageDirectory,
     [int] $Port = 5555,
     [int] $TimeoutSeconds = 120
 )
@@ -43,9 +44,9 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$BossDirectory = (Resolve-Path -LiteralPath $BossDirectory).Path
+$PackageDirectory = (Resolve-Path -LiteralPath $PackageDirectory).Path
 $executableName = if ($IsWindows) { 'Broiler.Office.Server.exe' } else { 'Broiler.Office.Server' }
-$executable = Join-Path $BossDirectory $executableName
+$executable = Join-Path $PackageDirectory $executableName
 if (-not (Test-Path -LiteralPath $executable)) {
     throw "Server executable not found: $executable"
 }
@@ -55,7 +56,7 @@ $logDirectory = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Pat
 $stdout = Join-Path $logDirectory "boss-smoke-$Port.out.log"
 $stderr = Join-Path $logDirectory "boss-smoke-$Port.err.log"
 
-# Not $BossDirectory: a service manager starts the server from an unrelated directory, and this is
+# Not $PackageDirectory: a service manager starts the server from an unrelated directory, and this is
 # the cheapest way to catch a content root that silently follows the caller's cwd.
 $foreignWorkingDirectory = [System.IO.Path]::GetTempPath()
 
@@ -65,7 +66,7 @@ function Invoke-BossRequest {
     Invoke-WebRequest -Uri "$baseUrl$Path" -NoProxy -TimeoutSec 30 -SkipHttpErrorCheck -UseBasicParsing
 }
 
-Write-Host "==> starting BOSS from $BossDirectory on $baseUrl"
+Write-Host "==> starting BOSS from $PackageDirectory on $baseUrl"
 $server = Start-Process -FilePath $executable `
     -ArgumentList '--urls', $baseUrl `
     -WorkingDirectory $foreignWorkingDirectory `

--- a/scripts/write-bpp-build-info.ps1
+++ b/scripts/write-bpp-build-info.ps1
@@ -167,28 +167,44 @@ if ($isAndroid) {
 }
 else {
     $exeSuffix = if ($Platform -eq 'windows') { '.exe' } else { '' }
-    $bossLauncher = if ($Platform -eq 'windows') { 'BOSS\Start-BOSS.cmd' } else { './BOSS/run-boss.sh' }
-    $bossServer = if ($Platform -eq 'windows') { 'BOSS\Broiler.Office.Server.exe' } else { './BOSS/Broiler.Office.Server' }
+    $bossLauncher = if ($Platform -eq 'windows') { 'Start-BOSS.cmd' } else { './run-boss.sh' }
+    $bossServer = if ($Platform -eq 'windows') { 'Broiler.Office.Server.exe' } else { './Broiler.Office.Server' }
 
     $lines += @(
         'Contents'
         '--------'
         ''
-        ('  {0,-24}{1}' -f "Broiler.Browser$exeSuffix", 'The Broiler web browser.')
-        ('  {0,-24}{1}' -f "Broiler.Writer$exeSuffix", 'The Broiler word processor (desktop).')
-        ('  {0,-24}{1}' -f 'BOSS/', 'Broiler Office Standalone Server — serves the Broiler Writer')
-        ('  {0,-24}{1}' -f '', 'web app (WebAssembly) over HTTP from its own Kestrel host.')
+        '  All three applications sit side by side in this folder and share the runtime files'
+        '  around them; there is nothing to install and no subfolder to descend into.'
+        ''
+        ('  {0,-30}{1}' -f "Broiler.Browser$exeSuffix", 'The Broiler web browser.')
+        ('  {0,-30}{1}' -f "Broiler.Writer$exeSuffix", 'The Broiler word processor (desktop).')
+        ('  {0,-30}{1}' -f "Broiler.Office.Server$exeSuffix", 'BOSS — the Broiler Office Standalone Server. Serves')
+        ('  {0,-30}{1}' -f '', 'the Broiler Writer web app (WebAssembly) over HTTP from')
+        ('  {0,-30}{1}' -f '', 'its own Kestrel host, out of the wwwroot/ beside it.')
+        ''
+        ('  {0,-30}{1}' -f 'wwwroot/', "The Writer's WebAssembly bundle, served by BOSS.")
+        ('  {0,-30}{1}' -f 'service/', 'Unit files and installers to run BOSS as a service.')
+        ('  {0,-30}{1}' -f 'appsettings.json', 'BOSS configuration.')
+        ('  {0,-30}{1}' -f 'README.md', 'Full BOSS documentation.')
         ''
         'Starting the Office server (BOSS)'
         '---------------------------------'
         ''
-        "  $bossLauncher                        listens on http://0.0.0.0:5555"
+        "  $bossLauncher                              listens on http://0.0.0.0:5555"
         "  $bossServer --urls http://0.0.0.0:5555"
         ''
         '  Then open http://localhost:5555/ — health probe at /healthz, server details at /api/info.'
         ''
         '  To run it as a system service (systemd, SysV init, or a Windows service), see'
-        '  BOSS/service/. Full documentation: BOSS/README.md.'
+        '  service/. Full documentation: README.md.'
+        ''
+        'Ahead-of-time compilation'
+        '-------------------------'
+        ''
+        '  The application assemblies here are ReadyToRun (R2R) — precompiled to native code for'
+        '  this architecture, so an application starts without JITting its startup path. The IL is'
+        '  still present, so the JIT can re-optimize hot code at run time as usual.'
     )
 
     if ($Variant -eq 'framework-dependent') {


### PR DESCRIPTION
## Summary

Restructure Broiler Preview Packages (BPP) to place BOSS (Broiler Office Standalone Server) in the package root alongside the desktop applications, rather than in a `BOSS/` subfolder. Additionally, enable ReadyToRun (R2R) ahead-of-time compilation for all desktop assemblies to improve startup performance.

## Key Changes

- **Package layout:** BOSS now publishes directly into the package root instead of a `BOSS/` subfolder. The server, its `appsettings.json`, `wwwroot/`, and service files sit flat alongside `Broiler.Browser` and `Broiler.Writer`, all sharing the same runtime files.

- **ReadyToRun compilation:** Added `-p:PublishReadyToRun=true` to all desktop publish steps (Windows and Linux, both framework-dependent and self-contained variants). The property is also set during restore so the crossgen2 compiler NuGet package enters the dependency graph correctly.

- **Script parameter updates:** Renamed `-BossDirectory` to `-PackageDirectory` in `package-boss.ps1` and `smoke-test-boss.ps1` to reflect that these scripts now operate on the package root rather than a BOSS-specific subdirectory.

- **Documentation updates:** Updated README files, packaging guides, and build-info output to reflect the new flat layout. Clarified that all three applications are independent and share runtime files; the service installers copy the entire package wholesale since selective copying would be fragile.

- **Launcher paths:** Updated command examples and launcher script paths throughout to remove the `BOSS/` prefix (e.g., `./run-boss.sh` instead of `./BOSS/run-boss.sh`, `Start-BOSS.cmd` instead of `BOSS\Start-BOSS.cmd`).

## Implementation Details

- ReadyToRun requires the crossgen2 compiler, which ships as a platform-specific NuGet package (`Microsoft.NETCore.App.Crossgen2.win-x64` / `.linux-x64`). This package only enters the restore graph when `PublishReadyToRun=true` is set at restore time, so the property must be passed to both `dotnet restore` and `dotnet publish` to avoid NETSDK1094 errors.

- The WebAssembly client (`Broiler.Writer.WebAssembly`) is excluded from R2R compilation because it targets `browser-wasm`, which runs on mono rather than CoreCLR and so has no crossgen2 pack. BOSS's `PublishWriterClient` target already strips `PublishReadyToRun` from the properties it hands to the client, so the global property cannot leak into that publish.

- Android packages are unaffected, for the same reason: `net10.0-android` runs on mono, which has no crossgen2 pack for the `android-*` RIDs. Mono's ahead-of-time story there is `RunAOTCompilation`, a different and much slower switch that the heads currently pin off.

- Service installers now copy the entire extracted package directory into the install prefix, since the server's assemblies are commingled with the desktop applications'. This is deliberate — a selective copy would require tracking the server's dependency closure by hand and would break on any dependency change. `Broiler.Browser` and `Broiler.Writer` land in the install prefix inert; the service only ever runs `Broiler.Office.Server`.

## Verification

Ran the Linux framework-dependent job locally, end to end:

- The three projects publish into one directory with no filename collision, and BOSS's vendored `wwwroot` survives.
- `package-boss.ps1 -PackageDirectory` assembles the package; `smoke-test-boss.ps1 -PackageDirectory` passes against the flat root (`/healthz`, `/api/info`, the transformed `index.html`, every module in the import map, SPA fallback).
- All three applications run from the flattened package.
- 65 of 66 application assemblies carry an R2R header; the exception is a type-forwarding facade with no code to compile.
- Crossgen costs roughly 10s per project and is cached between the two variants, so job runtime is essentially unchanged. Package size grows from 12 MB to 21 MB.
- The workflow YAML parses, and all 26 `pwsh` run blocks plus the modified shell scripts pass a syntax check.

Incidental fix: `install-service.sh --help` printed a fixed line range that had drifted into shell code (`set -eu`, `PREFIX=…`); it now stops at the first non-comment line.

https://claude.ai/code/session_01A9KFVK9Y2bjdjKr5TDckKc