### PR TITLE
Fix browser install retry logic and add failure classification

### DIFF
--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -18,6 +18,12 @@ name: WPT Tests
 #
 # Reference generation (Chromium via Playwright) is expensive, so each shard
 # caches its reference slice. Bump CACHE_EPOCH to refresh WPT master + refs.
+#
+# A shard that cannot obtain Chromium at all — the CDN answers some runners with
+# a 403 "not available in your location" — stops immediately instead of running a
+# browserless slice that would report every test as a missing reference, and
+# records why it stopped so the merged report names that cause rather than
+# guessing at a runner eviction. See scripts/lib/wpt-browser-install.sh.
 
 on:
   workflow_dispatch:
@@ -255,9 +261,31 @@ jobs:
           if ! [[ "$EXIT" =~ ^[0-9]+$ ]]; then
             EXIT=1
           fi
-          printf '{"shardIndex":%s,"exitCode":%s}\n' \
-            "${{ matrix.shard-index }}" "$EXIT" \
-            > "shard-out/wpt-shard-${{ matrix.shard-index }}-status.json"
+          # run-wpt-tests.sh leaves a marker when the shard could not run a single
+          # test — e.g. the Playwright CDN refused its Chromium download. Folding
+          # that into the status file is what lets the merge step name the real
+          # cause instead of guessing at one (issue #1534).
+          python3 - "${{ matrix.shard-index }}" "$EXIT" \
+            "$RESULTS_DIR/wpt-shard-failure.json" \
+            "shard-out/wpt-shard-${{ matrix.shard-index }}-status.json" <<'PY'
+          import json, sys
+
+          shard_index, exit_code, marker_path, out_path = sys.argv[1:5]
+          status = {"shardIndex": int(shard_index), "exitCode": int(exit_code)}
+          try:
+              with open(marker_path, encoding="utf-8") as handle:
+                  marker = json.load(handle)
+          except (OSError, ValueError):
+              marker = None
+          if isinstance(marker, dict):
+              if marker.get("reason"):
+                  status["failureReason"] = str(marker["reason"])
+              if marker.get("detail"):
+                  status["failureDetail"] = str(marker["detail"])
+          with open(out_path, "w", encoding="utf-8") as handle:
+              json.dump(status, handle)
+              handle.write("\n")
+          PY
 
       - name: Shard step summary
         if: always()

--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -195,6 +195,28 @@ jobs:
           path: ${{ env.REFERENCE_DIR }}
           key: wpt-refs-${{ env.CACHE_EPOCH }}-shard-${{ matrix.shard-index }}
 
+      # Keep the Chromium build itself between runs, so a run only depends on the
+      # download being reachable when Playwright is actually bumped. There is no
+      # mirror to fall back to: for linux64 Playwright serves Chromium as a Chrome
+      # for Testing build, and every URL for it — cdn.playwright.dev included — is
+      # a redirect to the one Google bucket that geo-blocked shard 0 in issue
+      # #1534. Its ESRP mirror carries no x64 Linux Chromium at all. Caching is the
+      # only fallback that keeps the *same* binary, and the binary has to stay the
+      # same: references are compared at a 99% pixel threshold, so regenerating a
+      # slice with a different Chrome build would read as an engine regression.
+      #
+      # Keyed on the lockfile rather than CACHE_EPOCH: bumping the epoch refreshes
+      # WPT master and the reference slices, which is exactly when you still want
+      # the browser. The restore-key prefix means an unrelated lockfile edit reuses
+      # the existing browser instead of re-downloading it, while a genuine
+      # Playwright bump misses and fetches the new revision.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: wpt-playwright-${{ runner.os }}-${{ hashFiles('tests/wpt/package-lock.json') }}
+          restore-keys: wpt-playwright-${{ runner.os }}-
+
       # Apply any submodule fix that could not be pushed to its remote (push 403
       # → captured under patches/) and is NOT yet in the pinned pointer, so the
       # runner exercises it. Live again as of issue #1497: PENDING_PATCHES carries

--- a/scripts/lib/wpt-browser-install.sh
+++ b/scripts/lib/wpt-browser-install.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# wpt-browser-install.sh — provisioning Chromium for WPT reference generation.
+#
+# Sourced by run-wpt-tests.sh. It lives in its own file so the retry and
+# failure-classification logic can be exercised directly by
+# scripts/tests/test_wpt_browser_install.py instead of only via a full WPT run —
+# the bug this file was extracted to fix (a retry helper that reported success
+# after every attempt failed) is exactly the kind a unit test catches.
+
+# sysexits.h EX_UNAVAILABLE. Distinct from the runner's own exit 1 ("some tests
+# failed") so a shard that never got to run a single test is not mistaken for a
+# shard that ran and found failures.
+WPT_EXIT_BROWSER_UNAVAILABLE=69
+
+# Reasons recorded in the failure marker. They travel through the shard status
+# JSON into merge-wpt-shards.py, which renders them in the generated issue.
+WPT_REASON_BROWSER_BLOCKED="BrowserDownloadBlocked"
+WPT_REASON_BROWSER_INSTALL_FAILED="BrowserInstallFailed"
+
+# Set by wpt_run_with_retries_tail: "true" when the abort classifier judged the
+# failure deterministic and the remaining attempts were skipped.
+WPT_RETRY_NON_RETRYABLE=false
+
+# True when a Playwright browser download failed for a reason that will repeat on
+# every attempt from this runner: the CDN refused the request outright with HTTP
+# 403 / AccessDenied, which is how its geo-restriction ("We're sorry, but this
+# service is not available in your location") surfaces. A retry keeps the same
+# runner IP, so the answer cannot change within a job — issue #1534 burned ~4.5
+# minutes on five identical 403s before giving up.
+wpt_is_browser_download_blocked() {
+    local log_file="$1"
+    [[ -f "$log_file" ]] || return 1
+    grep -qiE \
+        'server returned code 403|<Code>AccessDenied</Code>|not available in your location' \
+        "$log_file"
+}
+
+# Run "$@" with retries, echoing a tail of its captured output.
+#
+# Args: <description> <max_attempts> <delay_seconds> <success_tail_lines>
+#       <failure_tail_lines> <command...>
+#
+# The delay doubles after each failed attempt. When WPT_RETRY_ABORT_CLASSIFIER
+# names a shell function, it is called with the captured log after a failed
+# attempt; a zero return means retrying cannot help and the remaining attempts
+# are skipped. Returns the failing command's own exit status.
+wpt_run_with_retries_tail() {
+    local description="$1"
+    local max_attempts="$2"
+    local delay_seconds="$3"
+    local success_tail_lines="$4"
+    local failure_tail_lines="$5"
+    shift 5
+
+    local attempt=1
+    local status=0
+    local log_file
+    log_file="$(mktemp)"
+
+    WPT_RETRY_NON_RETRYABLE=false
+
+    while (( attempt <= max_attempts )); do
+        # Capture the command's own status. Reading $? after an `if cmd; then
+        # ... fi` instead yields the *if compound's* status, which is 0 when the
+        # condition failed and there is no else branch — that read the failure as
+        # a success and let the caller march on (issue #1534).
+        status=0
+        "$@" >"$log_file" 2>&1 || status=$?
+
+        if (( status == 0 )); then
+            tail -n "$success_tail_lines" "$log_file" || true
+            rm -f "$log_file"
+            return 0
+        fi
+
+        echo "  $description failed on attempt $attempt/$max_attempts (exit $status)." >&2
+        tail -n "$failure_tail_lines" "$log_file" >&2 || true
+
+        if [[ -n "${WPT_RETRY_ABORT_CLASSIFIER:-}" ]] \
+            && "$WPT_RETRY_ABORT_CLASSIFIER" "$log_file"; then
+            WPT_RETRY_NON_RETRYABLE=true
+            echo "  $description failed for a reason that will not change on a retry;" \
+                 "skipping the remaining attempt(s)." >&2
+            rm -f "$log_file"
+            return "$status"
+        fi
+
+        if (( attempt == max_attempts )); then
+            echo "  $description failed after $max_attempts attempt(s)." >&2
+            rm -f "$log_file"
+            return "$status"
+        fi
+
+        echo "  Retrying $description in ${delay_seconds}s..." >&2
+        sleep "$delay_seconds"
+        attempt=$((attempt + 1))
+        delay_seconds=$((delay_seconds * 2))
+    done
+}
+
+# Record why a shard could not run, for the workflow's "Collect shard result"
+# step to fold into the shard status JSON. Without it the merge step sees only a
+# bare non-zero exit and has to guess at the cause — in issue #1534 it reported a
+# geo-blocked Chromium download as a probable CI-runner eviction.
+#
+# Args: <marker_path> <reason> <detail>
+wpt_write_failure_marker() {
+    local marker_path="$1"
+    local reason="$2"
+    local detail="$3"
+
+    local marker_dir
+    marker_dir="$(dirname "$marker_path")"
+    mkdir -p "$marker_dir"
+
+    # Escape the two characters that can appear in a one-line JSON string value.
+    local escaped_detail
+    escaped_detail="$(printf '%s' "$detail" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+
+    printf '{"reason":"%s","detail":"%s"}\n' "$reason" "$escaped_detail" > "$marker_path"
+}

--- a/scripts/merge-wpt-shards.py
+++ b/scripts/merge-wpt-shards.py
@@ -117,17 +117,65 @@ def _iter_shard_statuses(shard_dir: Path):
             yield path, data
 
 
+# Human-readable labels for the failure reasons a shard can record before it runs
+# a single test (written by scripts/lib/wpt-browser-install.sh). A shard reporting
+# one of these went unmeasured for an infrastructure reason, not an engine one.
+FAILURE_REASON_LABELS = {
+    "BrowserDownloadBlocked": "Chromium download refused",
+    "BrowserInstallFailed": "Chromium install failed",
+}
+
+
 def _format_incomplete_shard(status: dict) -> str:
-    """Human-readable label for an incomplete shard. A numeric exit code means the
-    shard crashed after running; the ``"missing"`` sentinel means it uploaded
-    nothing at all — its runner was lost before the ``if: always()`` collect/upload
-    steps could run (typically a spot-runner shutdown signal, i.e. the WPT step ends
-    with ``exit code 143`` / "The runner has received a shutdown signal"), so the
-    whole slice went unmeasured rather than crashing on a specific test."""
+    """Human-readable label for an incomplete shard.
+
+    A recorded ``failureReason`` is the most specific thing available — the shard
+    said why it could not run — so it wins over the bare exit code. Failing that,
+    a numeric exit code means the shard crashed after running; the ``"missing"``
+    sentinel means it uploaded nothing at all — its runner was lost before the
+    ``if: always()`` collect/upload steps could run (typically a spot-runner
+    shutdown signal, i.e. the WPT step ends with ``exit code 143`` / "The runner
+    has received a shutdown signal"), so the whole slice went unmeasured rather
+    than crashing on a specific test."""
+    reason = status.get("failureReason")
+    if reason:
+        # An unrecognised reason is still more informative than the exit code, so
+        # it is shown as-is rather than dropped.
+        return f"shard {status['shardIndex']} ({FAILURE_REASON_LABELS.get(reason, reason)})"
     exit_code = status["exitCode"]
     if exit_code == "missing":
         return f"shard {status['shardIndex']} (no report uploaded)"
     return f"shard {status['shardIndex']} (exit {exit_code})"
+
+
+def _incomplete_shard_cause_sentences(shards: list[dict]) -> list[str]:
+    """Explain *why* the incomplete shards are incomplete.
+
+    A shard that recorded a ``failureDetail`` said exactly why it never ran a
+    test, so that explanation is quoted rather than guessed at. Only shards with
+    nothing recorded fall back to the eviction guess — the common cause of a
+    silent "no report uploaded", but flatly wrong for issue #1534, where shard 0
+    exited 1 because the Playwright CDN geo-blocked its Chromium download."""
+    sentences: list[str] = []
+
+    explained = [status for status in shards if status.get("failureDetail")]
+    for status in explained:
+        sentences.append(f"Shard {status['shardIndex']}: {status['failureDetail']}")
+    if explained:
+        sentences.append(
+            "A shard that could not provision its browser is a CI infrastructure "
+            "outage rather than a test regression — no code change fixes it, and it "
+            "clears on its own."
+        )
+
+    if any(not status.get("failureDetail") for status in shards):
+        sentences.append(
+            "A shard that recorded no reason is usually a transient CI-runner "
+            "eviction (the runner received a shutdown signal before its upload step "
+            "ran), which is likewise not a test regression."
+        )
+
+    return sentences
 
 
 def _incomplete_shard_recovery_hint(shards: list[dict]) -> str:
@@ -200,14 +248,15 @@ def _rank_biggest_problems(
                 "severity": len(shards),
                 "impact": len(shards),
                 "title": f"{len(shards)} shard(s) did not complete",
-                "detail": (
-                    "A whole shard's tests are unaccounted for — the pass/fail of that "
-                    f"slice is unknown. {listing}. A shard reported as \"no report "
-                    "uploaded\" is usually a transient CI-runner eviction (the runner "
-                    "received a shutdown signal before its upload step ran), not a test "
-                    "regression, so its slice can be remeasured without a code change: "
-                    f"re-run the WPT Tests workflow and {_incomplete_shard_recovery_hint(shards)} "
-                    "(cached references make the rerun fast)."
+                "detail": " ".join(
+                    [
+                        "A whole shard's tests are unaccounted for — the pass/fail of "
+                        f"that slice is unknown. {listing}.",
+                        *_incomplete_shard_cause_sentences(shards),
+                        "The slice can be remeasured without a code change: re-run the "
+                        f"WPT Tests workflow and {_incomplete_shard_recovery_hint(shards)} "
+                        "(cached references make the rerun fast).",
+                    ]
                 ),
             }
         )
@@ -482,6 +531,12 @@ def merge(
     # Exit code left behind by each shard that got far enough to run the
     # "Collect shard result" step (index -> exit code).
     shard_exit_codes: dict[int, int] = {}
+    # Why a shard could not run, for the shards that managed to say so
+    # (index -> the marker fields). run-wpt-tests.sh records this for failures
+    # that stop a shard before any test executes — a browser it could not
+    # download, say — so the report can name the cause instead of inferring one
+    # from a bare non-zero exit.
+    shard_failure_reasons: dict[int, dict[str, str]] = {}
     for _path, status in _iter_shard_statuses(shard_dir):
         try:
             shard_index = int(status["shardIndex"])
@@ -489,6 +544,13 @@ def merge(
         except (TypeError, ValueError):
             continue
         shard_exit_codes[shard_index] = exit_code
+        marker = {
+            field: status[field].strip()
+            for field in ("failureReason", "failureDetail")
+            if isinstance(status.get(field), str) and status[field].strip()
+        }
+        if marker:
+            shard_failure_reasons[shard_index] = marker
 
     # A shard is incomplete when it produced no conclusive report. There are two
     # ways that happens, and the second one used to be invisible:
@@ -521,7 +583,11 @@ def merge(
         incomplete_shards.append(
             # A dispatched shard that left no status file at all never uploaded
             # anything — record it as "missing" rather than a numeric exit code.
-            {"shardIndex": shard_index, "exitCode": exit_code if exit_code is not None else "missing"}
+            {
+                "shardIndex": shard_index,
+                "exitCode": exit_code if exit_code is not None else "missing",
+                **shard_failure_reasons.get(shard_index, {}),
+            }
         )
 
     if incomplete_shards:

--- a/scripts/run-wpt-tests.sh
+++ b/scripts/run-wpt-tests.sh
@@ -157,44 +157,16 @@ if ! [[ "$PLAYWRIGHT_INSTALL_RETRY_DELAY_SECONDS" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
-run_with_retries_tail() {
-    local description="$1"
-    local max_attempts="$2"
-    local delay_seconds="$3"
-    local success_tail_lines="$4"
-    local failure_tail_lines="$5"
-    shift 5
-
-    local attempt=1
-    local status=0
-    local log_file
-    log_file="$(mktemp)"
-
-    while (( attempt <= max_attempts )); do
-        if "$@" >"$log_file" 2>&1; then
-            tail -n "$success_tail_lines" "$log_file" || true
-            rm -f "$log_file"
-            return 0
-        fi
-
-        status=$?
-        echo "  $description failed on attempt $attempt/$max_attempts (exit $status)." >&2
-        tail -n "$failure_tail_lines" "$log_file" >&2 || true
-
-        if (( attempt == max_attempts )); then
-            echo "  $description failed after $max_attempts attempt(s)." >&2
-            rm -f "$log_file"
-            return "$status"
-        fi
-
-        echo "  Retrying $description in ${delay_seconds}s..." >&2
-        sleep "$delay_seconds"
-        attempt=$((attempt + 1))
-        delay_seconds=$((delay_seconds * 2))
-    done
-}
+# shellcheck source=lib/wpt-browser-install.sh
+source "$SCRIPT_DIR/lib/wpt-browser-install.sh"
 
 mkdir -p "$OUTPUT_DIR"
+
+# Marker describing why this shard could not run at all, read by the workflow's
+# "Collect shard result" step. Cleared up front so a stale marker from an earlier
+# run in the same workspace cannot be attributed to this one.
+FAILURE_MARKER="$OUTPUT_DIR/wpt-shard-failure.json"
+rm -f "$FAILURE_MARKER"
 
 LOGFILE="$OUTPUT_DIR/wpt-results.log"
 
@@ -258,13 +230,35 @@ elif command -v npx &>/dev/null; then
         npm install 2>&1 | tail -10
     fi
     echo "  Installing Playwright Chromium (up to $PLAYWRIGHT_INSTALL_RETRIES attempt(s))"
-    run_with_retries_tail \
+    INSTALL_STATUS=0
+    WPT_RETRY_ABORT_CLASSIFIER=wpt_is_browser_download_blocked
+    wpt_run_with_retries_tail \
         "Playwright Chromium install" \
         "$PLAYWRIGHT_INSTALL_RETRIES" \
         "$PLAYWRIGHT_INSTALL_RETRY_DELAY_SECONDS" \
         10 \
         40 \
-        npx playwright install --with-deps chromium
+        npx playwright install --with-deps chromium || INSTALL_STATUS=$?
+    unset WPT_RETRY_ABORT_CLASSIFIER
+
+    # Without Chromium there is nothing to generate references *from*, so every
+    # test in this slice would be reported as "missing reference image" — a whole
+    # shard of noise that looks like an engine regression. Stop here instead, and
+    # leave behind why, so the merged report can say so (issue #1534).
+    if (( INSTALL_STATUS != 0 )); then
+        if [[ "$WPT_RETRY_NON_RETRYABLE" == "true" ]]; then
+            REASON="$WPT_REASON_BROWSER_BLOCKED"
+            DETAIL="The Playwright CDN refused this runner's Chromium download (HTTP 403 / AccessDenied — the build is not served to every location). No test ran."
+        else
+            REASON="$WPT_REASON_BROWSER_INSTALL_FAILED"
+            DETAIL="Installing Playwright Chromium failed after $PLAYWRIGHT_INSTALL_RETRIES attempt(s). No test ran."
+        fi
+        echo "  ✗ $DETAIL" >&2
+        echo "    This is a browser-provisioning outage, not a test regression:" >&2
+        echo "    re-run the shard once the download succeeds again." >&2
+        wpt_write_failure_marker "$FAILURE_MARKER" "$REASON" "$DETAIL"
+        exit "$WPT_EXIT_BROWSER_UNAVAILABLE"
+    fi
 
     # Set NODE_PATH so require('playwright') resolves from the local
     # node_modules installed above (Node.js resolves modules relative to

--- a/scripts/tests/test_merge_wpt_shards.py
+++ b/scripts/tests/test_merge_wpt_shards.py
@@ -39,9 +39,23 @@ class MergeWptShardsTests(unittest.TestCase):
             encoding="utf-8",
         )
 
-    def _write_status(self, root: Path, shard_index: int, exit_code: int) -> None:
+    def _write_status(
+        self,
+        root: Path,
+        shard_index: int,
+        exit_code: int,
+        failure_reason: str | None = None,
+        failure_detail: str | None = None,
+    ) -> None:
+        status = {"shardIndex": shard_index, "exitCode": exit_code}
+        # The workflow's "Collect shard result" step folds these in from the marker
+        # run-wpt-tests.sh leaves when a shard dies before running a single test.
+        if failure_reason is not None:
+            status["failureReason"] = failure_reason
+        if failure_detail is not None:
+            status["failureDetail"] = failure_detail
         (root / f"wpt-shard-{shard_index}-status.json").write_text(
-            json.dumps({"shardIndex": shard_index, "exitCode": exit_code}),
+            json.dumps(status),
             encoding="utf-8",
         )
 
@@ -322,6 +336,92 @@ class MergeWptShardsTests(unittest.TestCase):
 
             merged = MODULE.merge(shard_dir, expected_shard_indexes={0})
             self.assertEqual([], merged["incompleteShards"])
+
+    def test_recorded_failure_reason_replaces_the_eviction_guess(self) -> None:
+        # Issue #1534: shard 0 exited 1 because the Playwright CDN refused its
+        # Chromium download, so no test ran. The report used to attribute every
+        # incomplete shard to a runner eviction, which sent triage looking for a
+        # cancelled job that never existed.
+        detail = (
+            "The Playwright CDN refused this runner's Chromium download "
+            "(HTTP 403 / AccessDenied). No test ran."
+        )
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._write_status(
+                shard_dir,
+                shard_index=0,
+                exit_code=69,
+                failure_reason="BrowserDownloadBlocked",
+                failure_detail=detail,
+            )
+
+            merged = MODULE.merge(shard_dir, expected_shard_indexes={0})
+            self.assertEqual(
+                [
+                    {
+                        "shardIndex": 0,
+                        "exitCode": 69,
+                        "failureReason": "BrowserDownloadBlocked",
+                        "failureDetail": detail,
+                    }
+                ],
+                merged["incompleteShards"],
+            )
+
+            problem = merged["biggestProblems"][0]
+            self.assertEqual("IncompleteShards", problem["kind"])
+            self.assertIn("shard 0 (Chromium download refused)", problem["detail"])
+            self.assertIn(f"Shard 0: {detail}", problem["detail"])
+            self.assertIn("CI infrastructure outage", problem["detail"])
+            self.assertNotIn("eviction", problem["detail"])
+            # The recovery action is unchanged — the block clears on its own.
+            self.assertIn("set shard_index=0", problem["detail"])
+
+    def test_unexplained_shard_keeps_the_eviction_guess(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._write_status(shard_dir, shard_index=2, exit_code=134)
+
+            problem = MODULE.merge(shard_dir)["biggestProblems"][0]
+            self.assertIn("shard 2 (exit 134)", problem["detail"])
+            self.assertIn("eviction", problem["detail"])
+            self.assertNotIn("CI infrastructure outage", problem["detail"])
+
+    def test_mixed_shards_explain_each_cause_separately(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._write_status(
+                shard_dir,
+                shard_index=0,
+                exit_code=69,
+                failure_reason="BrowserInstallFailed",
+                failure_detail="Installing Playwright Chromium failed. No test ran.",
+            )
+            self._write_status(shard_dir, shard_index=5, exit_code=1)
+
+            merged = MODULE.merge(shard_dir)
+            problem = merged["biggestProblems"][0]
+            self.assertIn("shard 0 (Chromium install failed)", problem["detail"])
+            self.assertIn("shard 5 (exit 1)", problem["detail"])
+            self.assertIn("Shard 0: Installing Playwright Chromium failed.", problem["detail"])
+            self.assertIn("eviction", problem["detail"])
+            self.assertIn(
+                "re-dispatch once per shard, setting shard_index to 0, 5", problem["detail"]
+            )
+
+    def test_unknown_failure_reason_is_surfaced_verbatim(self) -> None:
+        # A reason added to the runner but not yet to the label table must not be
+        # silently swallowed back into a bare exit code.
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._write_status(
+                shard_dir, shard_index=1, exit_code=70, failure_reason="DiskFull"
+            )
+
+            merged = MODULE.merge(shard_dir)
+            markdown = MODULE.render_issue_markdown(merged, "https://example.test/run/1")
+            self.assertIn("shard 1 (DiskFull)", markdown)
 
     def test_merge_into_preserves_out_of_scope_entries(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/scripts/tests/test_wpt_browser_install.py
+++ b/scripts/tests/test_wpt_browser_install.py
@@ -1,0 +1,162 @@
+"""Tests for scripts/lib/wpt-browser-install.sh.
+
+The library is sourced into a real bash subprocess and driven from there. That is
+deliberate: what these tests pin down is shell semantics — above all that a failed
+command's exit status reaches the caller — and those cannot be checked by reading
+the script. The original helper captured ``$?`` after an ``if cmd; then ... fi``,
+which yields the *if compound's* status (0 when the condition failed and there is
+no else branch), so it reported "(exit 0)" and returned success after every
+attempt had failed. run-wpt-tests.sh then walked on into a reference-generation
+pass with no browser (issue #1534).
+"""
+
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+LIB_PATH = Path(__file__).resolve().parents[1] / "lib" / "wpt-browser-install.sh"
+
+# Trimmed from the real shard-0 output of workflow run 31008929475.
+GEO_BLOCK_OUTPUT = (
+    "Downloading Chrome for Testing 147.0.7727.15 (playwright chromium v1217) from "
+    "https://cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-linux64.zip\n"
+    "Error: Download failed: server returned code 403 body "
+    "'<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?><Error><Code>AccessDenied</Code>"
+    "<Message>Access denied.</Message><Details>We are sorry, but this service is not "
+    "available in your location</Details></Error>'.\n"
+    "Failed to install browsers\n"
+)
+
+
+class WptBrowserInstallTests(unittest.TestCase):
+    def _run(self, script: str, cwd: str | None = None) -> subprocess.CompletedProcess:
+        """Run *script* with the library sourced, under run-wpt-tests.sh's shell flags."""
+        return subprocess.run(
+            ["bash", "-euo", "pipefail", "-c", f'source "{LIB_PATH}"\n{script}'],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+        )
+
+    # --- exit-status propagation (the issue #1534 regression) ----------------
+
+    def test_retry_helper_returns_the_failing_commands_exit_status(self) -> None:
+        result = self._run(
+            'STATUS=0\n'
+            'wpt_run_with_retries_tail "install" 1 0 5 5 bash -c "exit 42" || STATUS=$?\n'
+            'echo "status=$STATUS"'
+        )
+        self.assertIn("status=42", result.stdout)
+        self.assertIn("(exit 42)", result.stderr)
+        self.assertNotIn("(exit 0)", result.stderr)
+
+    def test_exhausted_retries_abort_a_set_e_caller(self) -> None:
+        """The failure must stop the script, not be swallowed into a success."""
+        result = self._run(
+            'wpt_run_with_retries_tail "install" 2 0 5 5 bash -c "exit 7"\n'
+            'echo "REACHED-AFTER-FAILURE"'
+        )
+        self.assertEqual(result.returncode, 7)
+        self.assertNotIn("REACHED-AFTER-FAILURE", result.stdout)
+        self.assertIn("failed after 2 attempt(s)", result.stderr)
+
+    def test_retry_helper_succeeds_after_a_transient_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            counter = Path(tmp) / "attempts"
+            counter.write_text("", encoding="utf-8")
+            result = self._run(
+                f'attempt() {{ echo x >> "{counter}"; '
+                f'  [ "$(wc -l < "{counter}")" -ge 3 ] && {{ echo "install ok"; return 0; }}; '
+                "  return 1; }\n"
+                'wpt_run_with_retries_tail "install" 5 0 5 5 attempt\n'
+                'echo "REACHED-AFTER-SUCCESS"'
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("install ok", result.stdout)
+            self.assertIn("REACHED-AFTER-SUCCESS", result.stdout)
+            self.assertEqual(len(counter.read_text(encoding="utf-8").split()), 3)
+
+    # --- non-retryable classification ---------------------------------------
+
+    def test_geo_blocked_download_is_not_retried(self) -> None:
+        """A 403 is deterministic for this runner's IP; five identical waits are waste."""
+        with tempfile.TemporaryDirectory() as tmp:
+            counter = Path(tmp) / "attempts"
+            counter.write_text("", encoding="utf-8")
+            result = self._run(
+                f'attempt() {{ echo x >> "{counter}"; printf "%s" "{GEO_BLOCK_OUTPUT}"; return 1; }}\n'
+                "STATUS=0\n"
+                "WPT_RETRY_ABORT_CLASSIFIER=wpt_is_browser_download_blocked\n"
+                'wpt_run_with_retries_tail "install" 5 30 5 40 attempt || STATUS=$?\n'
+                'echo "status=$STATUS non_retryable=$WPT_RETRY_NON_RETRYABLE"'
+            )
+            self.assertIn("status=1", result.stdout)
+            self.assertIn("non_retryable=true", result.stdout)
+            self.assertEqual(len(counter.read_text(encoding="utf-8").split()), 1)
+            self.assertIn("will not change on a retry", result.stderr)
+            self.assertNotIn("Retrying", result.stderr)
+
+    def test_unrelated_failure_still_uses_every_attempt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            counter = Path(tmp) / "attempts"
+            counter.write_text("", encoding="utf-8")
+            result = self._run(
+                f'attempt() {{ echo x >> "{counter}"; echo "ETIMEDOUT: connection reset"; return 1; }}\n'
+                "STATUS=0\n"
+                "WPT_RETRY_ABORT_CLASSIFIER=wpt_is_browser_download_blocked\n"
+                'wpt_run_with_retries_tail "install" 3 0 5 5 attempt || STATUS=$?\n'
+                'echo "status=$STATUS non_retryable=$WPT_RETRY_NON_RETRYABLE"'
+            )
+            self.assertIn("status=1", result.stdout)
+            self.assertIn("non_retryable=false", result.stdout)
+            self.assertEqual(len(counter.read_text(encoding="utf-8").split()), 3)
+
+    def test_classifier_recognises_the_403_signatures(self) -> None:
+        for label, line in (
+            ("http status", "Error: Download failed: server returned code 403 body"),
+            ("s3 error code", "<Error><Code>AccessDenied</Code></Error>"),
+            ("geo message", "We're sorry, but this service is not available in your location"),
+        ):
+            with self.subTest(label), tempfile.TemporaryDirectory() as tmp:
+                log = Path(tmp) / "install.log"
+                log.write_text(line + "\n", encoding="utf-8")
+                result = self._run(
+                    f'if wpt_is_browser_download_blocked "{log}"; then echo BLOCKED; else echo OPEN; fi'
+                )
+                self.assertIn("BLOCKED", result.stdout)
+
+    def test_classifier_ignores_unrelated_and_missing_logs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "install.log"
+            log.write_text("npm ERR! network socket hang up\n", encoding="utf-8")
+            result = self._run(
+                f'if wpt_is_browser_download_blocked "{log}"; then echo BLOCKED; else echo OPEN; fi\n'
+                f'if wpt_is_browser_download_blocked "{tmp}/absent.log"; then echo BLOCKED; else echo OPEN; fi'
+            )
+            self.assertEqual(result.stdout.split(), ["OPEN", "OPEN"])
+
+    # --- failure marker ------------------------------------------------------
+
+    def test_failure_marker_is_valid_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            marker = Path(tmp) / "nested" / "wpt-shard-failure.json"
+            detail = 'Refused: "403" \\ AccessDenied.'
+            result = self._run(
+                f'wpt_write_failure_marker "{marker}" "$WPT_REASON_BROWSER_BLOCKED" {json.dumps(detail)}'
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(marker.read_text(encoding="utf-8"))
+            self.assertEqual(payload["reason"], "BrowserDownloadBlocked")
+            self.assertEqual(payload["detail"], detail)
+
+    def test_browser_unavailable_exit_code_is_distinct_from_test_failure(self) -> None:
+        """Exit 1 means "tests failed"; a shard that never ran a test must not use it."""
+        result = self._run('echo "$WPT_EXIT_BROWSER_UNAVAILABLE"')
+        self.assertEqual(result.stdout.strip(), "69")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes issue #1534 where a Playwright Chromium download blocked by geo-restriction (HTTP 403) was retried five times identically, wasting ~4.5 minutes. The root cause was a shell script bug where `$?` was read after an `if` compound statement, capturing the compound's status (0 on failed condition with no else) rather than the command's actual exit status.

This change extracts retry and failure-classification logic into a dedicated library (`scripts/lib/wpt-browser-install.sh`), adds comprehensive unit tests, and integrates failure markers into the WPT workflow so incomplete shards can report their actual cause instead of being misattributed to runner evictions.

## Key Changes

- **New library: `scripts/lib/wpt-browser-install.sh`**
  - `wpt_run_with_retries_tail()`: Retry helper that correctly captures command exit status (fixes the `$?` bug)
  - `wpt_is_browser_download_blocked()`: Classifier that detects geo-blocked CDN downloads (403 / AccessDenied / location-unavailable signatures)
  - `wpt_write_failure_marker()`: Records why a shard failed before running any tests
  - Exit code `WPT_EXIT_BROWSER_UNAVAILABLE=69` to distinguish browser provisioning failures from test failures

- **New test suite: `scripts/tests/test_wpt_browser_install.py`**
  - 162 lines of unit tests exercising shell semantics directly in bash subprocesses
  - Tests exit-status propagation, retry exhaustion, transient-failure recovery
  - Tests non-retryable classification (geo-blocked downloads skip remaining attempts)
  - Tests failure marker JSON generation

- **Updated `scripts/run-wpt-tests.sh`**
  - Sources the new library and uses `wpt_run_with_retries_tail()` for Chromium install
  - Detects geo-blocked downloads via `WPT_RETRY_ABORT_CLASSIFIER` and stops immediately
  - Writes failure marker with reason ("BrowserDownloadBlocked" or "BrowserInstallFailed") and detail
  - Exits with code 69 when browser provisioning fails, preventing noise from browserless test runs

- **Updated `scripts/merge-wpt-shards.py`**
  - Reads `failureReason` and `failureDetail` from shard status JSON
  - `FAILURE_REASON_LABELS` maps reasons to human-readable descriptions
  - `_incomplete_shard_cause_sentences()` generates context-aware explanations:
    - Shards with recorded details quote them verbatim
    - Shards with no explanation fall back to the eviction guess
    - Distinguishes infrastructure outages (browser provisioning) from test regressions
  - Incomplete shard report now names the actual cause instead of guessing

- **Updated `.github/workflows/wpt-tests.yml`**
  - "Collect shard result" step now folds failure marker into status JSON
  - Added Playwright browser cache (keyed on `package-lock.json`) to avoid re-downloading on unrelated changes
  - Cache preserves the exact binary across runs so reference pixel comparisons remain valid

## Implementation Details

- The retry helper uses `status=0; "$@" >"$log_file" 2>&1 || status=$?` to capture the command's true exit status, avoiding the `if` compound bug
- Geo-block detection uses grep patterns for three signatures: HTTP 403 status, S3 AccessDenied error code, and location-unavailable message
- Failure markers are JSON files written to `$OUTPUT_DIR/wpt-shard-failure.json` before exit, read by the workflow's collect step
- Exit code 69 (`EX_UNAVAILABLE` from sysexits.h) is distinct from the runner's own exit 1 ("tests failed"), preventing misclassification
- The browser cache uses a restore-key prefix so unrelated lockfile edits reuse the existing browser, while genuine Playwright bumps fetch the new revision

https://claude.ai/code/session_01Q7ZzV2a1MUaC2go7GyMs3F