### PR TITLE
Update performance roadmap and Octane results to reflect latest pin

### DIFF
--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -21,139 +21,44 @@ so only the parent can hold the combined view.
 - **Acceptance protocol:** unchanged and unchallenged —
   [`Broiler.JS/docs/performance.md`](../Broiler.JS/docs/performance.md) governs what
   may be *claimed*. **Nothing in this document closes on the numbers it quotes.**
-- **Provenance:** the pinned submodule pointer is **`14fa4f10`**, checked 2026-08-05 against
-  the gitlink rather than against the prose — **and checking it is what caught that this line
-  said `cca39b4d`**, which the pointer had moved thirteen commits past. That is the *sixth*
-  consecutive time this line was stale when read (`07adeb44`, `2ebc0c3c`, `71dda1b7`, `9bf9639b`
-  and `61c8cc65` before that), which is no longer a coincidence: **a pointer written into prose goes
-  stale silently**, and the only reliable reading of it is `git submodule status`. Six readings,
-  six staleness findings, is a rate rather than an anecdote — the line is wrong *by default*, so
-  the sentence to write next to any pointer is the command that reads it. **The two other
-  submodules now carry the same note**: `Broiler.HTML` is `2f94c0d5` and `Broiler.CSS` `076ed5d5`,
-  both of which had also moved since anything here described them.
-  It is why §4.1's and §3.4's figures below carry the
-  commit they were taken at rather than "the pin". `2ebc0c3c`, `a6f101cc`, `71dda1b7`,
-  `685026c0`, `cdb2fd41`, `7ef80c03` and `8228b0da` are all **ancestors** of the current pin
-  (`merge-base --is-ancestor`), so nothing recorded against any of them is invalidated and item
-  0-1's substance holds; `685026c0` carries item 0-9's probe corpus (`aa2b1562`, #938).
-  **The patch handoff has completed again, twice over.** The five files pending at the last
-  reading (`0067`–`0071`, items 3-3's two halves, 4-1, 4-3a and 4-3b) **and the six written after
-  them** (`0072`–`0077`, items 4-2a, 4-2b, 4-4's premise, 4-5, 3-5 and 3-6) have all been applied,
-  pushed and the pointer bumped. The six were checked **patch by patch against the submodule log
-  rather than inferred from this prose** — each patch's `Subject` matched to a commit, that
-  commit's `format-patch` output diffed against the patch file (identical modulo line endings and
-  the `[PATCH n/m]` numbering), and each commit confirmed an ancestor of the pin: `3f8d5db4`,
-  `34270c76`, `af5b8b78`, `53690423`, `8073e4fb`, `61c8cc65` in patch order. **So every figure
-  recorded for items 4-2, 4-4, 4-5, 3-5 and 3-6 now describes the pinned pointer directly**,
-  rather than a local build plus a patch series applied in order, which is what their sections
-  used to have to say.
-  **The four patches pending at the last reading have been applied and the pointer bumped.**
-  `0078`–`0081` (items 3-7, 3-8, 3-1 and 3-2) are now `37905aeb`, `14ac195f`, `cb2e63c6` and
-  `07adeb44` — matched patch by patch to the submodule log rather than inferred from this prose,
-  and `61c8cc65` is an ancestor of the pin, so every figure recorded for those four items now
-  describes the pinned pointer directly rather than a local build plus a patch series.
-  **The patch handoff has completed a third time, and `patches/` is empty.** The five files pending
-  at the last reading — `0082`–`0086`, item 1-1's remaining half and item 3-1's four — have all been
-  applied, pushed and the pointer bumped, which is what moved it off `07adeb44`. They were checked
-  **patch by patch against the submodule log rather than inferred from this prose**: each `Subject`
-  resolved to a commit, that commit's `format-patch` output diffed against the patch file (identical
-  once the `From <sha>` line, the blob `index` lines and the trailing git version are set aside —
-  that is the whole of the difference on all five), and `07adeb44` confirmed an ancestor of the new
-  pin. In patch order they are **`0aa8a558`, `9e5b57d3`, `0dda32b2`, `23fc8fb9`, `cca39b4d`**.
-  **So every figure recorded for items 1-1's remaining half and 3-1's census, guarded tree,
-  boxing-source census and `ToNumeric` reuse now describes the pinned pointer directly**, rather
-  than a local build of `07adeb44` plus a patch series applied in order, which is what their
-  sections used to have to say.
-  **The handoff has completed a fourth time, and this time it took all three submodules at once.**
-  The thirteen `Broiler.JS` files pending at the last reading (`0089`–`0101`) **and the HTML and CSS
-  pair beside them** (`0087`, `0088`) have all been applied, pushed and their pointers bumped, so
-  `patches/` was empty for the second time since it was written. All fifteen were checked **patch by
-  patch against each submodule's log rather than inferred from this prose** — each `Subject` resolved
-  to a commit, that commit's `format-patch` output diffed against the patch file (identical once the
-  `From <sha>` line, the blob `index` lines and the trailing git version are set aside, which is the
-  whole of the difference on all fifteen), and each pending-against pointer confirmed an ancestor of
-  the new pin. In patch order the `Broiler.JS` thirteen are **`12760bb9`, `48ad65e7`, `01c79c46`,
-  `2bab9775`, `16389682`, `e0bb9b40`, `cfed00ef`, `c2667c29`, `6ff52f3b`, `ba31a4a9`, `b80327ac`,
-  `3fa35e14`, `14fa4f10`**; `0087` is `Broiler.HTML` `2f94c0d5` and `0088` is `Broiler.CSS`
-  `076ed5d5`. **So every figure recorded for item 3-1's order-preserving guard placement, the GC-pause
-  denominator, the update-target census, items 3-8a and 3-9, the three async-correctness fixes and
-  item 1-1's free-name scan now describes the pinned pointers directly**, rather than a local build
-  plus a patch series applied in order, which is what those sections had to say while they were
-  pending. The renumbering note that series carried — written `0087`–`0099`, shifted `+2` when `main`
-  landed the HTML and CSS pair on the same two numbers — retires with it; **what does not retire is
-  why it happened**: `patches/` is one flat namespace across every submodule, so two branches
-  numbering from the same high-water mark collide whenever both are open, which is the ordinary case
-  rather than an unlucky one.
-  **Twelve patches are pending again, and five of them are one item.**
-  **[`patches/0102`](../patches/0102-js-deferral-population.patch)** — item 1-1's remaining half,
-  its population counted at **728 capture-free sites of 5 762, 12.6%**, and the shortcut that looked
-  available refused by the counter built to test it.
-  **[`0103`](../patches/0103-js-widen-census-corpus.patch)** — the census corpus, widened past the
-  **7 of 15** suites it could reach, which moves item 4-1's headline from **93.54% to 80.11%** and
-  fixes what had been keeping Mandreel out of every census: an **uncatchable stack overflow in the
-  benchmark host**, because item 0-2's stack reserve is a property of the *shell* and no benchmark
-  host had it (§4.2a).
-  **[`0104`](../patches/0104-js-capture-layout-checker.patch)** — item 1-1's *named* obstacle
-  settled: the capture layout derived from source alone **misses nothing on 5 157 sites**, at the
-  price of over-approximating on 2 712 of them, and **two soundness defects in `0101`'s own code**
-  fixed on the way, both about a function's own name.
-  **[`0105`](../patches/0105-js-deferred-body-reentry.patch)** — the obstacle the item does
-  *not* name: a nested body **compiled a second time from the enclosing scope kept alive**, after
-  the enclosing compilation has finished.
-  **[`0106`](../patches/0106-js-reentry-structural-partition.patch)** — that check's residual
-  settled: **5 723 of 5 723 re-entered bodies agree with their eager tree in every token a compiler
-  counter did not produce**, and the 471 whose counter ordinals differ are **all** either the site
-  table's `-1` (the check's own second compilation exhausts it) or 4-2b's tier-2 site re-use, with
-  nothing unexplained.
-  **[`0107`](../patches/0107-js-generic-operator-ceiling.patch)** — item 4-2's arithmetic half
-  priced and **refused by its own arithmetic** at **0.119%** of the corpus, the relational lead it
-  points at closed with it at **0.022%**, and **the whole generic binary-operator surface bounded
-  at 0.475%**.
-  **[`0108`](../patches/0108-js-call-entry-cost.patch)** — item 4-5 **unblocked**: pricing the
-  engine's two call entries against each other, which 4-4 named as the first thing 4-5 should do and
-  nobody had done, says **44% of a call entry (50.18 ns of 114.60) is bookkeeping the short path
-  already skips** — **2.85% of the corpus**, so the missing "~85% unattributable from outside the
-  engine" was the *replicas* being the wrong instrument rather than a missing profiler.
-  **[`0109`](../patches/0109-js-call-bookkeeping-attribution.patch)** — that bookkeeping
-  **attributed**, with the sum closing to within 0.5 ns: **92% of it is Annex B `caller`/`arguments`**
-  at 44.40 ns per call to every ordinary non-strict function, while the
-  strict-mode `AsyncLocal` write costs **102.87 ns per crossing** on **4.74%** of calls — nine of
-  twelve suites never cross, PdfJS crosses on 52.65% of its.
-  **[`0110`](../patches/0110-js-legacy-frame-census.patch)** — that frame **counted** rather
-  than bounded: **60.16% of all calls push one, 1.46% of the corpus**, with Richards at 100% and
-  the two strict suites at ~0% — plus the two instrument defects `0103` surfaced and left (the
-  stale `round-up-16` "current" label, and a histogram bucket that could go negative) **closed**.
-  **[`0111`](../patches/0111-js-legacy-frame-shape.patch)** — that item's named fix **priced
-  before being built and refused at 0.730×**: relocating the frame to a thread-local stack saves
-  **6.19 ns, 0.20% of the corpus for an M–L**, because the cost is the 56-byte `Arguments` copying
-  and moving where it lands does not remove it.
-  **[`0112`](../patches/0112-js-capture-layout-order.patch)** — item 1-1's layout question
-  asked as the item states it, **as an index**: `0104` validated membership and this document
-  recorded it as the layout, which it is not. **14 605 sites ordered, 0 mismatched** where the sets
-  agree — and the over-approximation turns out to shift slots, so the prediction must **drive** the
-  layout rather than match it.
-  And **[`0113`](../patches/0113-js-dense-element-ratio.patch)** — item 3-1's read/write ratio
-  counted for the first time: **3.34 numeric reads per numeric write** over the corpus, 5.26 on
-  NavierStokes and 4.80 on Crypto, and **1.03 on Gameboy — the suite §4.2a re-opened the item on**,
-  so a typed store is an allocation wash there and a loss everywhere else.
-  Usual terms: the push to the submodule remote returned 403, so the pointer is
-  deliberately unbumped and every set of figures was measured on a local build of `14fa4f10` plus
-  the patches in question. `0102` and `0103` are **independent of each other**, but `0104` builds on
-  `0102` and `0105` on both, so **`0102` → `0103` → `0104` → `0105` is the order** — verified by
-  applying all four in sequence to a clean checkout of the pin with `git am --keep-cr` and diffing
-  the result against the tree they were generated from. None needs
-  a main-repo fallback: `0102`'s and `0104`'s counters and `0105`'s retention are off by default
-  (`BROILER_JS_DEFER_TREE_COUNT=1`, `BROILER_JS_CAPTURE_LAYOUT_CHECK=1`, `BROILER_JS_DEFER_TREE=1`)
-  and change no emission on any setting, and `0103` touches only the benchmark host.
-  **Measurements and the test262 run in §4.1 and §3.4 were taken at `cdb2fd41` and have not
-  been repeated** — `685026c0` also carries a string-allocation fix (#936). Octane code
-  sites verified at `45f4f679`. **Phase 2's own measurements — §0, and each 2-x section —
-  were taken at `685026c0` plus the then-pending `0050`–`0058`, which is exactly the tree
-  `a6f101cc` now is**, so they describe the pinned pointer directly and no longer depend on
-  a patch series being applied in order. Item rows were
-  checked against the tree rather than inherited from the prose above them; doing that is
-  what caught this, and it also caught that **item 1-2's acceptance criterion
-  already passed before any work** (phase 1).
+- **Provenance:** the pinned `Broiler.JS` pointer is **`8308df51`**, read 2026-08-06 with
+  `git submodule status` rather than from prose. **Read the pointer with the command; never from
+  this line.** Seven consecutive readings have now found this sentence stale — `07adeb44`,
+  `2ebc0c3c`, `71dda1b7`, `9bf9639b`, `61c8cc65`, `cca39b4d` and `14fa4f10` before it — which is a
+  rate rather than an anecdote: **a pointer written into prose is wrong by default**, so the
+  sentence to write next to any pointer is the command that reads it. The sibling submodules are
+  `Broiler.HTML` **`2f94c0dc`** and `Broiler.CSS` **`f960f943`**, both of which had also moved
+  since anything here described them. It is why §4.1's and §3.4's figures carry the commit they
+  were taken at rather than "the pin".
+- **Everything this document measures is in the pin, and `patches/` holds no `Broiler.JS` patch.**
+  The twelve open at the last reading — `0102`–`0113`: item 1-1's remaining half in five of them,
+  plus the widened census corpus, item 4-2's arithmetic half, item 4-5's four, and item 3-1's
+  read/write ratio — have been applied, pushed and the pointer bumped. In patch order they are
+  **`861daccc`, `18524c34`, `db81b5b2`, `d2711e1b`, `a49d8ba5`, `5ea934fb`, `a06ef9eb`, `046a55fc`,
+  `2f8ed84f`, `19b7ac5b`, `ddb20e7d`, `8308df51`** — twelve subjects matched against the twelve
+  commits `14fa4f10..HEAD` contains, in one unbroken run with nothing else in it. **That is a
+  weaker check than the patch-by-patch `format-patch` diff earlier rounds recorded, and the reason
+  is worth keeping:** a patch file is deleted once it lands, so the diff is available only while the
+  handoff is still open. Verify a landed claim against the submodule log, not against `patches/`.
+  **So every figure in this document describes the pinned pointer directly**, rather than a local
+  build plus a patch series applied in order, which is what a succession of sections used to have
+  to say. Every commit cited for a measurement anywhere below — `a6f101cc`, `685026c0`, `cdb2fd41`,
+  `9bf9639b`, `61c8cc65`, `07adeb44`, `cca39b4d`, `14fa4f10`, `2ebc0c3c`, `71dda1b7`, `7ef80c03`,
+  `8228b0da`, `45f4f679` — is an **ancestor** of the pin (`merge-base --is-ancestor`), so nothing
+  recorded against any of them is invalidated.
+- **A patch number is a citation of this document's history, not a stable file name.** `patches/`
+  is one flat namespace across every submodule, so two branches numbering from the same high-water
+  mark collide whenever both are open — the ordinary case rather than an unlucky one. It has just
+  happened again: **`0102` is now a `Broiler.CSS` patch**, reusing the number item 1-1's
+  capture-free population census held one reading ago. Sections below cite `0102`–`0113` as the
+  units of work they were; the durable reference for each is the commit above.
+- **Measurement dates.** §4.1's figures and §3.4's test262 run were taken at `cdb2fd41` and have
+  not been repeated — `685026c0` also carries a string-allocation fix (#936) and item 0-9's probe
+  corpus (`aa2b1562`, #938). Octane code sites verified at `45f4f679`. **Phase 2's own
+  measurements — §0 and each 2-x section — were taken at exactly the tree `a6f101cc` now is.**
+  Item rows are checked against the tree rather than inherited from the prose above them; doing
+  that is what caught that **item 1-2's acceptance criterion already passed before any work**
+  (phase 1).
 
 > **Path convention.** Because this document moved up a level, every path is written
 > **relative to the repository root**. Paths carrying a `Broiler.JS/` prefix are inside
@@ -165,7 +70,7 @@ so only the parent can hold the combined view.
 
 ## 0. Status
 
-**Last updated 2026-08-05.** Snapshot of where the campaign stands; every claim is detailed in
+**Last updated 2026-08-06.** Snapshot of where the campaign stands; every claim is detailed in
 the item's own section below, and nothing here is *closed* — see the acceptance protocol in §3.
 
 | Phase | State |
@@ -263,7 +168,7 @@ comparable to the committed run's 498 and must never be quoted as if it were. On
 column is the finding.
 
 **The conformance gate is satisfied, and was re-run five times for items 3-3, 4-1, 4-3a and 4-3b.** All
-four pinned manifests were run **2026-08-03 on linux-x64 at the pinned `9bf9639b`** — plus
+four pinned manifests were run **2026-08-03 on linux-x64 at `9bf9639b` (the pin at the time)** — plus
 `patches/0067`, and then plus each successive prefix through all five of `0067`–`0071` —
 against the pinned suite ref `ccaac100`: **8 220 passed, 84 failed, 44 skipped, 9 timed out, and
 every count is identical to §3.4's recorded run on all five, manifest by manifest.** The 84 are the same
@@ -273,26 +178,23 @@ because 2-1, 2-2, 2-4 and 2-8 all touch `OrdinarySetWithOwnDescriptor`, are **cl
 rewrites the storage underneath that path, adds no failure; and neither does 3-3's `let`/`const`
 half.** A **fifth manifest** was added with that item — `test262-lexical-declarations`, because
 none of the four covered `let` or `const` at all — and it is clean on both arms (§3.4).
-**Re-run again 2026-08-04 at the pinned `61c8cc65` plus `patches/0078` for item 3-7, on both
+**Re-run again 2026-08-04 at `61c8cc65` (the pin at the time) plus `patches/0078` for item 3-7, on both
 settings of that patch's switch**: every count is identical, manifest by manifest. One run of
 `properties-proxy` reported an extra failure whose captured stderr reads *"The JavaScript compiler
 is not available"* — **a `dotnet build` rewriting the assembly under a running suite, which was
 mine**, not an engine result; re-run with nothing else building it is clean (§3.4).
 
-**The patch handoff, which was the third gate, is done and has stayed done.** `patches/0049`–`0058`
-were applied, pushed and the pointer bumped to `a6f101cc`, and `0059`–`0086` have followed it in
-six further bumps, most recently to **`cca39b4d`**; the patch files are cleared and
-[`patches/README.md`](../patches/README.md)'s index is **empty for the first time since it was
-written**. What phase 2 measured and what CI now clones are the same tree — which is the condition
-both remaining gates were waiting on, and it is why the conformance one could be run at all. **The
-handoff has now cleared four times running**, so a 403 has come to mean *deferred* rather than
-*stranded*; what makes that safe is that the pointer is never bumped locally, so nothing here can
-name a commit CI cannot clone. The fourth clearing took **all three open stacks at once** — the
-thirteen `Broiler.JS` patches plus the `Broiler.HTML` and `Broiler.CSS` pair — and left `patches/`
-empty for the second time since it was written. **Twelve patches are open again** (`0102`–`0113`: item 1-1's remaining
-half in four of them — its capture-free population, its capture layout, a body compiled from a kept
-enclosing scope, and that check's residual settled — plus the widened census corpus, item 4-2's
-arithmetic half priced and refused, item 4-5 unblocked, attributed, counted and its named fix refused, and two instrument defects closed), on the usual 403 terms.
+**The patch handoff, which was the third gate, is done and has stayed done.** Every
+`Broiler.JS` patch this campaign has written — `0049` through `0113` — has been applied, pushed and
+the pointer bumped, in **five clearings running**, most recently the twelve-patch stack that took
+the pointer to **`8308df51`**;
+[`patches/README.md`](../patches/README.md)'s index carries no `Broiler.JS` row. What phase 2
+measured and what CI now clones are the same tree — which is the condition both remaining gates
+were waiting on, and it is why the conformance one could be run at all. **A 403 has come to mean
+*deferred* rather than *stranded***; what makes that safe is that the pointer is never bumped
+locally, so nothing here can name a commit CI cannot clone. **No engine work is currently held
+outside the pin**, so for the first time since this document was merged there is no arm of it
+measured on a local build plus a patch series.
 
 **Two pre-existing defects found in passing**, both reproducing on a pristine build at the
 pinned pointer, neither owned by this campaign: a refused write to a function's `prototype`
@@ -530,12 +432,12 @@ The pinned manifests are `test262-arrays`, `test262-properties-proxy`,
 `test262-lexical-declarations`. First taken 2026-08-01 at `cdb2fd41`
 (suite ref `ccaac100`), **re-run 2026-08-02 at `a6f101cc` plus 2-9 with every count
 unchanged**, **re-run at `71dda1b7` plus 3-3 with every count unchanged**, and **re-run five
-times on 2026-08-03 on linux-x64 at the pinned `9bf9639b` — plus `patches/0067`, plus `0067` and
+times on 2026-08-03 on linux-x64 at `9bf9639b` (the pin at the time) — plus `patches/0067`, plus `0067` and
 `0068`, plus `0067`–`0069`, plus `0067`–`0070`, and plus all five of `0067`–`0071` — with every count
 identical every time, manifest by manifest** — so the table below describes the pinned pointer as well as the commit it was first
 measured at.
 
-**Re-run 2026-08-05 on linux-x64 at the pinned `cca39b4d` plus item 3-1's order-preserving guard
+**Re-run 2026-08-05 on linux-x64 at `cca39b4d` (the pin at the time) plus item 3-1's order-preserving guard
 placement, on both settings of its switch. On the shipping arm every count is identical to the row
 below, manifest by manifest — 8 710 executed, 8 617 passed, 84 failed, 251 skipped, 9 timed out.**
 This is the run that most needed taking of anything in phase 3, because the change *removes an
@@ -581,7 +483,7 @@ smaller one is the runner's own selection count printed before it runs anything 
 runnable test(s)"** for `arrays`, which is the executed count in the row below to the test, and the
 same for the other four.
 
-**Re-run 2026-08-04 on linux-x64 at the pinned `61c8cc65`, plus `patches/0078` (item 3-7), plus
+**Re-run 2026-08-04 on linux-x64 at `61c8cc65` (the pin at the time), plus `patches/0078` (item 3-7), plus
 `0078`–`0079` (item 3-8), plus `0078`–`0080` (item 3-1) and plus `0078`–`0081` (item 3-2): every
 count is identical to the row below, manifest by manifest, on every arm.** The `0080` run matters most of the five, because that
 patch changes what six core operators *emit* — `&`, `|`, `^`, `<<`, `>>`, `>>>` — and
@@ -632,7 +534,7 @@ Item 3-3's `let`/`const` half changes how lexical bindings are *compiled*, and *
 manifest covered `let` or `const` at all** — `test262-language-basics` is twelve entries about
 `throw`, commas and relational operators. The manifest is
 `language/statements/{let,const,variable}` plus `language/block-scope`, and it was run **six
-times from the same tree**: at the pinned `9bf9639b`, and at that commit plus each successive
+times from the same tree**: at `9bf9639b` (the pin at the time), and at that commit plus each successive
 prefix of `patches/0067`–`0071`. **Identical, 397 of 397 passing on each.** So it did not
 *detect* anything — its value is that a future regression on those paths now fails a pinned gate
 instead of passing unnoticed, and `language/statements/variable` is exactly what `0068` touches.
@@ -2122,7 +2024,7 @@ suite down.
 
 #### At the pinned pointer it is **17 of 17**, and phase 2's exit criterion finally has an answer
 
-Run 2026-08-03 at the pinned `2ebc0c3c` on **linux-x64**, against upstream `chromium/octane`
+Run 2026-08-03 at `2ebc0c3c` (the pin at the time) on **linux-x64**, against upstream `chromium/octane`
 `570ad1cc` (Octane v9), with the shell rebuilt by the harness rather than reused — and this
 time **both engines on the same machine**, so the ×-slower column is internally valid in a way
 no previous run's was.
@@ -4139,7 +4041,7 @@ its own control and is wrong, and that follow-up would not have removed the loss
 #### The losing-side hypothesis was measured, and it is wrong — **`prototype` is what materializes**
 
 > **In the pin.** Shipped as `patches/0061` while its push was blocked by a 403; since applied
-> and pushed, and it is now **`e6222df3`**, an ancestor of the pinned `61c8cc65`. Measurement
+> and pushed, and it is now **`e6222df3`**, an ancestor of `61c8cc65` (the pin at the time). Measurement
 > and instrumentation only — no behaviour change.
 
 The mechanism above was recorded as a hypothesis and flagged *"do not treat as settled"*. It is
@@ -4471,7 +4373,7 @@ curve whose median is ~180×, and this phase is the reason they are.
 ### 2-10 · DeltaBlue's dictionary fallbacks — **found, fixed, and it is not the explanation**
 
 > **In the pin.** Shipped as `patches/0062` while its push was blocked by a 403; since applied
-> and pushed, and it is now **`0812d80d`**, an ancestor of the pinned `61c8cc65`.
+> and pushed, and it is now **`0812d80d`**, an ancestor of `61c8cc65` (the pin at the time).
 
 Phase 2's exit criterion split (Richards 183× passes, DeltaBlue 576× fails), and every phase 2
 item was sized on a probe rather than on the suite. §3.5 already records what that costs: 2-8 was
@@ -4605,7 +4507,7 @@ and it wants the Octane cluster run against it — which is now possible.
 #### 2-11 · The redundant prototype write — **landed, and it is the largest cache win since 2-0**
 
 > **In the pin.** Shipped as `patches/0063` while its push was blocked by a 403; since applied
-> and pushed, and it is now **`4d1c4796`**, an ancestor of the pinned `61c8cc65`.
+> and pushed, and it is now **`4d1c4796`**, an ancestor of `61c8cc65` (the pin at the time).
 
 The class path was tracked to `JSClass.CreateInstance`, and the two obvious sites were already
 correct: the instance is built with `new JSObject(instancePrototype)`, carrying 2-0's own comment.
@@ -4658,7 +4560,7 @@ surface. Octane still runs 15 of 15 suites `ok`.
 #### 2-12 · The stale cache entry that could never be replaced — **DeltaBlue 69% → 93%**
 
 > **In the pin.** Shipped as `patches/0064` while its push was blocked by a 403; since applied
-> and pushed, and it is now **`fb1e2f4c`**, an ancestor of the pinned `61c8cc65`.
+> and pushed, and it is now **`fb1e2f4c`**, an ancestor of `61c8cc65` (the pin at the time).
 
 2-10 owed a per-site attribution, and this is it. The bare miss counter cannot say *why* a read
 missed, so the lookup's exits are now counted separately:
@@ -9121,7 +9023,7 @@ failure record byte-identical to the earlier runs.
 > **Delivered as a patch, not in the pin.** The push to `Broiler-Platform/Broiler.JS` returned
 > **403** — the submodule remote was outside that session's GitHub scope — so the change shipped
 > as `patches/0059` with the pointer unbumped. **It has since been applied and pushed, and is now
-> `962ca06a`, an ancestor of the pinned `61c8cc65`.** Every figure below was measured on a local
+> `962ca06a`, an ancestor of `61c8cc65` (the pin at the time).** Every figure below was measured on a local
 > build of the then-pinned `2ebc0c3c` **plus** that patch, with the control built from the same
 > tree minus it — so they describe the tree the pin now contains.
 
@@ -9203,7 +9105,7 @@ not provide; **not one failure is in a `replace` directory.** Repository suite
 #### The retained-result-list follow-up landed — 2 033 bytes a match, and the guard is the change
 
 > **In the pin.** Shipped as `patches/0060` for the same 403 as the section above; since applied
-> and pushed, and it is now **`6f56d24f`**, an ancestor of the pinned `61c8cc65`. Figures below
+> and pushed, and it is now **`6f56d24f`**, an ancestor of `61c8cc65` (the pin at the time). Figures below
 > were measured on a local build of the then-pinned `2ebc0c3c` plus it and `0059`.
 
 `RegExp.prototype[@@replace]` collects every match in step 14 and only reads their properties in

--- a/tests/octane/benchmarks.md
+++ b/tests/octane/benchmarks.md
@@ -6,21 +6,26 @@ actually does, which engine subsystem it puts under load, and — using the
 committed results in [`results/`](results/) — where Broiler's time goes.
 
 Numbers quoted for Broiler are from
-[`results/comparison.md`](results/comparison.md) (generated 2026-07-31,
-Chromium 149.0.7827.55 vs the `BroilerJS --script-host` shell), except where a
-score is marked *(0046)*.
+[`results/comparison.md`](results/comparison.md) (generated 2026-08-05,
+Chromium 149.0.7827.55 vs the `BroilerJS --script-host` shell).
 
-> **The committed results are stale.** They were generated 2026-07-31 20:28,
-> against a `Broiler.JS` pointer that predated the engine fixes for the five
-> failing suites. Those fixes landed at `7ef80c03` and the pointer was bumped to
-> `cdb2fd41` in `2d9f39ca` on 2026-08-01 11:45 — about 15 hours later. Nobody has
-> re-run the workflow since, so `results/` still shows Crypto, PdfJS, CodeLoad,
-> zlib and Typescript failing on an engine that no longer has those defects.
+> **The results are current, and the five suites that used to fail all score.**
+> The run committed under [`results/`](results/) was generated 2026-08-05 and
+> reports **15 of 15 suites `ok` and 17 of 17 scores** for Broiler, Chromium and
+> Jint alike — nothing errored, nothing timed out. Crypto, PdfJS, CodeLoad, zlib
+> and Typescript, which an earlier revision of this page had to quote from a patch
+> index because they scored nothing, are ordinary published results now; the
+> *(0046)* marker that stood in for them is retired.
 >
-> A score marked *(0046)* is the value measured on the fixed engine at the time
-> the fix was written, recorded in the patch index that has since been cleared.
-> Treat those five as the expectation for the next run, not as a published
-> result.
+> **What must not be read out of the refresh.** Both this run and the 2026-07-31
+> one it replaces are **single-repetition, on different machines**, so the change
+> in any score between them is not a delta anyone may claim — the machine differs
+> as much as the engine does. What is legitimate to read across the two is which
+> side of a threshold each benchmark falls on. The noise band the harness declares
+> is **7.5%**, and a local three-repetition run has since shown the true band is
+> per suite and ranges forty-fold (Splay 15.9%, Richards 10.6%, DeltaBlue 9.1%,
+> median 5.5%). See
+> [`docs/performance-roadmap.md` §0](../../docs/performance-roadmap.md).
 
 ---
 
@@ -38,11 +43,11 @@ far more than one great score lifts it.
 
 Two consequences worth keeping in mind when reading the committed results:
 
-- **The headline totals are not like-for-like.** Chromium's 57245 is a geomean
-  over all 17 scores; Broiler's 245 is a geomean over the 12 it completed.
-  Restricted to the same 12, Chromium scores 58419 — so the honest headline is
-  **≈238× slower on the suites Broiler finishes**, and the ratio would be worse,
-  not better, with the missing five included at their measured values.
+- **The headline totals are now like-for-like.** Both geomeans are over all 17
+  scores — Chromium 74 297, Broiler 498 — so the headline is **149× slower across
+  the whole suite**, with no "on the suites it finishes" qualifier to carry. That
+  was not true of the previous committed run, where Broiler completed 12 of 17 and
+  the totals had to be restricted before they could be compared at all.
 - **Octane was retired by its authors in 2017**, on the grounds that engines had
   started optimizing for its specific shapes rather than for the web. That makes
   it a poor target to *tune against* and an excellent one to *shake out* a young
@@ -65,28 +70,28 @@ overhead Broiler pays that a plain tree-walker does not — rather than a genera
 deficit. Read the ratios in §4 against Chromium for the size of the gap, and
 against Jint for whether a given suite is anomalous.
 
-**What the column shows on first evidence.** A single unrepeated run in a dev
-container — so *not* publishable numbers, and no substitute for the workflow run
-§4 is waiting on — nonetheless sorts the suites into three groups. The middle
-group is within noise of parity and should be read as no more than that; the two
-ends are decided by margins no noise band reaches:
+**What the column shows.** The committed run sorts the suites into three groups.
+It is still one repetition per suite, so the middle group is within noise of
+parity and should be read as no more than that; the two ends are decided by
+margins no noise band reaches:
 
 | Group | Suites, with Broiler ÷ Jint |
 |---|---|
-| Ahead of the interpreter | Mandreel 1.7, Crypto 1.5, NavierStokes 1.5, EarleyBoyer 1.1, Gameboy 1.1, Richards 1.1, Box2D 1.1 |
-| Level with it | RayTrace 0.99, Splay 0.94, DeltaBlue 0.89 |
-| **Behind it** | Typescript 0.80, SplayLatency 0.73, PdfJS 0.57, RegExp 0.42, **zlib 0.073, CodeLoad 0.029, MandreelLatency 0.017** |
+| Ahead of the interpreter | Crypto 2.18, Mandreel 1.86, NavierStokes 1.80, Richards 1.44, Gameboy 1.32, DeltaBlue 1.31, RayTrace 1.17, EarleyBoyer 1.14, Box2D 1.12 |
+| Level with it | Typescript 0.98 |
+| **Behind it** | Splay 0.73, SplayLatency 0.68, RegExp 0.63, PdfJS 0.62, **zlib 0.083, CodeLoad 0.026, MandreelLatency 0.018** |
 
 The three at the end are the finding. **CodeLoad and MandreelLatency are the two
 compilation-cost benchmarks** — the ones §3's **B4** names — and they are where
-Broiler falls 34× and 59× behind an engine that never compiles anything. Against
+Broiler falls 38× and 56× behind an engine that never compiles anything. Against
 Chromium those two are simply the largest of a column of large numbers; against
 Jint they are categorically different from every other suite, which is the
-distinction the second reference point exists to draw. zlib at 14× behind is the
+distinction the second reference point exists to draw. zlib at 12× behind is the
 one that §4's ranking does not already predict, and is worth its own look.
 
-The published numbers come with the next workflow run; §4 below predates the
-column.
+Overall Broiler scores **0.606×** of Jint across the 17 benchmarks both engines
+completed — so the geomean is dragged below parity by that tail, not by a
+uniform deficit.
 
 ---
 
@@ -111,9 +116,9 @@ just millions of `this.x` reads and method calls through a handful of distinct
 object shapes. Engines win here through monomorphic inline caches plus
 aggressive inlining of tiny methods.
 
-**Broiler: 108 vs 46754 — 433× slower.** The second-worst ratio of any
-throughput benchmark, and it should be read as a direct measurement of per-call
-and per-property-access cost. Both are known open items: shape tracking is
+**Broiler: 349 vs 49320 — 141.3× slower.** Mid-table on ratio, and it should be
+read as a direct measurement of per-call and per-property-access cost. Both are
+known open items: shape tracking is
 gated on `GetType() == typeof(JSObject)` so nothing exotic participates, there is
 no shape-transition cache (so the constructor that builds each
 `TaskControlBlock` misses on *every* field it creates), and each call still goes
@@ -139,7 +144,7 @@ prototype-chain style, so method lookups walk prototypes rather than hitting own
 properties. It is the suite's stress test for whether an engine's inline caches
 survive polymorphism and whether prototype lookup is cached at all.
 
-**Broiler: 171 vs 102708 — 601× slower, the worst throughput ratio in the
+**Broiler: 316 vs 126232 — 399.5× slower, the worst throughput ratio in the
 suite.** This is the clearest single signal in the whole run. It says the
 prototype-method-call path is where Broiler is furthest from V8 — consistent with
 the engine's own measurements, where inherited-method call sites had a **0%**
@@ -163,12 +168,12 @@ loops are the closest JavaScript gets to C: `a[i] * b[j] + c` with `&`, `|`,
 int32, keeping the digit arrays in unboxed integer element storage, and eliding
 bounds checks.
 
-**Broiler: 127 *(0046)* vs 38183 — 301× slower.** Two separate stories here.
-First, without patch 0046 this suite does not score at all: `if (r == null)` on a
+**Broiler: 425 vs 49408 — 116.3× slower.** Two separate stories here.
+First, this suite did not score at all until `7ef80c03`: `if (r == null)` on a
 `BigInteger` ran `ToPrimitive` on the object (spec says an Object compared with
 null is `false` with no coercion), which reached `toString → toRadix → divRemTo →`
 the same test, recursing until the stack was exhausted and killing the process.
-Second, once it runs, the 301× is the boxing tax in its purest form: every digit
+Second, now that it runs, the 116× is the boxing tax in its purest form: every digit
 that leaves a local or enters an array becomes a heap-allocated `JSValue`.
 
 ### RayTrace — ray tracer
@@ -186,7 +191,7 @@ short-lived small-object allocation. It is the suite's escape-analysis benchmark
 an engine that can prove those intermediate `Vector`s never escape stack-allocates
 them and the allocation disappears; an engine that cannot pays for every one.
 
-**Broiler: 403 vs 117436 — 291× slower.** No escape analysis, and doubles are
+**Broiler: 677 vs 152290 — 224.9× slower.** No escape analysis, and doubles are
 boxed once they land in an object field, so each vector operation costs a
 `JSObject` plus three `JSValue`s. The unboxed-`double`-locals work from P2-2 does
 not reach here: its eligibility gate is a function-top-level `var` not named by any
@@ -207,8 +212,8 @@ control flow. It allocates enormously and almost all of it dies young.
 the benchmark that most directly rewards a fast bump-allocator with a cheap
 scavenger, and it punishes any per-allocation bookkeeping.
 
-**Broiler: 339 vs 91547 — 270× slower**, and at 33.5 s wall clock it is the
-slowest suite Broiler actually completes apart from Mandreel. The relevant history
+**Broiler: 615 vs 110540 — 179.7× slower**, at 17.2 s wall clock — fourth-longest
+of the fifteen files, well behind zlib and Mandreel. The relevant history
 is P0-1: every `JSValue` construction used to call
 `JSObject.NotifyPrototypeChainMutation()` unconditionally — so *allocating a
 number invalidated every inline cache in the realm*. That is fixed; what remains
@@ -230,7 +235,7 @@ using `test`, `exec`, `replace` (including function callbacks), `split` and
 compilation, the matcher itself, capture-group handling, and the string
 allocation around `replace`. V8 compiles regexes to native code with Irregexp.
 
-**Broiler: 89.9 vs 9890 — 110× slower.** Note that Chromium's *absolute* score
+**Broiler: 166 vs 12988 — 78.2× slower.** Note that Chromium's *absolute* score
 here is the lowest of any benchmark (9890), because the reference time was set
 against an already-fast Irregexp — so 110× is measured against a strong baseline.
 `Broiler.Regex` is a from-scratch ECMAScript engine whose matcher is a
@@ -254,7 +259,8 @@ survives, so it gets promoted, and then the mutation rate forces the GC to keep
 tracing and rewriting a big live set. This is the benchmark that motivated
 incremental marking in V8.
 
-**Broiler: 283 vs 43027 — 152× slower.** Better than the suite median, which is
+**Broiler: 779 vs 56416 — 72.4× slower** — the best throughput ratio bar
+Typescript, and better than the suite median, which is
 the interesting part: the .NET GC handles this workload comparatively well. The
 loss is the per-node cost of building the payload objects, not the collector.
 
@@ -268,11 +274,11 @@ throughput, Octane records the time of each individual iteration and scores the
 stops the world for one long mark-and-sweep scores badly here even if its total
 throughput is fine.
 
-**Broiler: 1539 vs 69725 — 45×, by a wide margin Broiler's best result in the
-suite.** Worth stating plainly because it is the one axis where the .NET runtime
-is doing Broiler a favour: the background/concurrent GC's pause distribution is
-genuinely competitive, and the 45× is mostly the throughput deficit showing
-through rather than a pause problem. **The GC is not currently a primary
+**Broiler: 2614 vs 89673 — 34.3×, Broiler's best result in the suite** (Typescript
+is a close second at 35.4×). Worth stating plainly because it is the one axis where
+the .NET runtime is doing Broiler a favour: the background/concurrent GC's pause
+distribution is genuinely competitive, and the 34× is mostly the throughput deficit
+showing through rather than a pause problem. **The GC is not currently a primary
 blocker.**
 
 ### NavierStokes — 2D fluid dynamics
@@ -289,7 +295,7 @@ elimination, strength reduction on the index arithmetic, keeping doubles in
 registers across the loop body. It is the suite's numeric-kernel test and the one
 closest to what a JIT's loop optimizer is for.
 
-**Broiler: 341 vs 35432 — 104× slower**, one of the better ratios. The
+**Broiler: 621 vs 45217 — 72.8× slower**, one of the better ratios. The
 `NumericLoopPlanner` and the unboxed-`double`-locals work are visible here: the
 loop *counters* and scalar accumulators can stay raw `double`s. What cannot is the
 grid itself — every `field[i]` read materializes a boxed `JSValue`, and dense
@@ -308,8 +314,8 @@ parsing over `Uint8Array`s, string building, dictionary-shaped object lookups
 with dynamic keys, regexes, and a big class hierarchy — plus the sheer volume of
 code, which tests parse and compile time as well.
 
-**Broiler: 321 *(0046)* vs 58725 — 183× slower.** Also a suite that scored
-nothing before patch 0046, for an instructive reason: `undefined + x`
+**Broiler: 712 vs 79352 — 111.4× slower.** Also a suite that scored nothing until
+`7ef80c03`, for an instructive reason: `undefined + x`
 string-concatenated instead of adding numerically, so
 `this.end = (start + length) || bytes.length` with both arguments omitted stored
 the truthy string `"undefinedundefined"`; every stream then reported a NaN length
@@ -330,9 +336,9 @@ function tables, and individual functions of preposterous size.
 to compile enormous functions at all.** V8 recognizes the asm.js-shaped
 type coercions and compiles to unboxed integer/double code.
 
-**Broiler: 160 vs 47996 — 300× slower, and 313 seconds of wall clock** — it alone
-is longer than every other suite combined and needs the workflow's 1800 s
-per-suite timeout. Also the suite that most tests the *compiler*: `global_init`
+**Broiler: 238 vs 64547 — 271.2× slower, and 228 seconds of wall clock** — the
+second-longest file after zlib, and with it about 77% of the run; it needs the
+workflow's 1800 s per-suite timeout. Also the suite that most tests the *compiler*: `global_init`
 is a single generated function spanning **152,948 lines**, and building it has
 been observed to overflow the CLR stack outright (with a JavaScript stack only
 eight frames deep — that is the compiler recursing over the AST, not the program
@@ -349,7 +355,7 @@ that code ready to run, rather than how fast it runs afterwards.
 well by compiling lazily (never compiling function bodies until first call) and
 by keeping any single compilation unit small enough not to be perceptible.
 
-**Broiler: 14.5 vs 67368 — 4646× slower, by an order of magnitude the worst
+**Broiler: 18.7 vs 99704 — 5331.8× slower, by an order of magnitude the worst
 score in the suite.** It is the single most diagnostic number in the whole run:
 Broiler compiles this eagerly, in units as large as the source makes them, through
 an expression-tree pipeline that is far more expensive per byte of source than a
@@ -370,7 +376,7 @@ branchy state-machine logic.
 through large dispatch tables** — plus property access on a few very large
 objects with hundreds of fields.
 
-**Broiler: 1041 vs 90650 — 87× slower, Broiler's second-best throughput ratio.**
+**Broiler: 1626 vs 120086 — 73.9× slower, among Broiler's best throughput ratios.**
 The reason is worth noting: the work per dispatch is large enough that the
 constant overhead per call and per property access is amortized. Benchmarks where
 Broiler does *relatively* well are the ones doing real work between engine
@@ -390,10 +396,10 @@ strategy is pre-parsing: scan function bodies just enough to find their extents,
 and compile nothing until called. jQuery defines thousands of functions; almost
 none run.
 
-**Broiler: 83.4 *(0046)* vs 30916 — 371× slower.** The lowest absolute score of
-any completing suite. Like MandreelLatency, this is entirely a front-end result
-and points at the same place: eager compilation through expression trees. The
-prior failure was also instructive — non-strict `eval` routed a `var` initializer
+**Broiler: 193 vs 40803 — 211.4× slower**, and the second-lowest absolute score of
+any throughput suite after RegExp. Like MandreelLatency, this is entirely a
+front-end result and points at the same place: eager compilation through
+expression trees. Its prior failure was also instructive — non-strict `eval` routed a `var` initializer
 inside a function the eval'd code declared to the *eval* var-environment binding
 instead of the function's own hoisted local, so the store never reached the
 binding the reads resolved to and leaked out as a global. jQuery's `windowmock`
@@ -421,7 +427,7 @@ because it loads three things at once:
 - **Megamorphic call sites** in the contact dispatch, where the callee genuinely
   varies.
 
-**Broiler: 584 vs 99321 — 170× slower.** Note that Box2D also produced a
+**Broiler: 937 vs 136091 — 145.2× slower.** Note that Box2D also produced a
 *correctness* fix on the way: the parser crashed on a bare `return` immediately
 before a closing brace (commit `7786cdd5`).
 
@@ -437,12 +443,12 @@ Emscripten's integer-coercion idioms.
 asm.js-shaped code — the same axis as Mandreel but in a much smaller, more
 regular program.
 
-**Broiler: 237 *(0046)* vs 80514 — 340× slower.** Its prior failure was the
+**Broiler: 566 vs 103463 — 182.8× slower.** Its prior failure was the
 cheapest fix in the whole set and the most complete blocker: Emscripten's shell
 preamble does `Module.read = read` unconditionally, the way `d8` and SpiderMonkey
 provide it, and the Broiler shell had `print` but not `read`. A `ReferenceError`
-before the benchmark ran a line. It also takes 647 s once it works, so it needs
-the long per-suite timeout too.
+before the benchmark ran a line. It also takes 271 s once it works — the longest
+file in the run — so it needs the long per-suite timeout too.
 
 ### Typescript — the TypeScript compiler compiling itself
 
@@ -457,8 +463,8 @@ manipulation, huge object graphs, polymorphic property access, closures, `Map`-i
 dictionary objects with dynamic keys, and sustained GC pressure — plus parse and
 compile time for a very large input.
 
-**Broiler: 1009 *(0046)* vs 86327 — 86× slower, the best throughput ratio in the
-suite** (and its highest absolute score bar the latency ones). The same pattern as
+**Broiler: 3338 vs 118170 — 35.4× slower, the best throughput ratio in the
+suite** (and its highest absolute score bar SplayLatency). The same pattern as
 Gameboy, more so: in a workload this large and this varied, no single engine
 overhead dominates, and Broiler's relative standing is at its best. Its prior
 failure was a parser bug — the last expression of a C-style `for` head's comma
@@ -531,8 +537,8 @@ benchmark above:
 
 ### B4 · Compile time and compile latency on large machine-generated code
 
-MandreelLatency (**4646×**) and CodeLoad (**371×**) measure nothing but the front
-end, and they are the two worst results in the suite. Three causes compound:
+MandreelLatency (**5331.8×**) and CodeLoad (**211.4×**) measure nothing but the
+front end; the first is the worst result in the suite by an order of magnitude. Three causes compound:
 
 - **Compilation is eager.** CodeLoad exists specifically to reward engines that
   pre-parse and defer compiling function bodies until first call. jQuery defines
@@ -551,7 +557,7 @@ page load time.
 
 `Broiler.Regex` is a new ECMAScript-semantics engine whose `Matching/Matcher.cs`
 is a backtracking interpreter with no compilation to native code. V8's Irregexp
-JIT-compiles each pattern. RegExp is 110× off *against Octane's lowest reference
+JIT-compiles each pattern. RegExp is 78× off *against Octane's lowest reference
 baseline*, and the same engine is on PdfJS's and Typescript's critical path.
 
 ### B6 · Ambient state on hot paths
@@ -566,8 +572,8 @@ property-set helpers so the hot path reads nothing — is not started.
 ### B7 · GC — *not* currently a primary blocker
 
 Worth stating explicitly to keep it off the priority list. SplayLatency is
-Broiler's best result at 45×, and Splay's throughput at 152× is better than the
-suite median. The .NET GC is handling a workload it was never tuned for
+Broiler's best result at 34.3×, and Splay's throughput at 72.4× is second-best of
+the throughput suites. The .NET GC is handling a workload it was never tuned for
 respectably. The allocation *rate* is a severe problem (B1) — but that is a
 problem with what the engine asks the collector to do, not with the collector.
 
@@ -602,46 +608,51 @@ skipped.
 
 ## 4. Reading the ratios
 
-Sorted by how far Broiler is off Chromium, using the committed scores plus the
-five *(0046)* measurements:
+Sorted by how far Broiler is off Chromium, using the committed scores — all 17 of
+them, for the first time:
 
 | Benchmark | Chromium | Broiler | × slower | Dominant blocker |
 |---|--:|--:|--:|---|
-| SplayLatency | 69 725 | 1 539 | 45 | — (best axis; GC pauses are fine) |
-| Typescript | 86 327 | 1 009 *(0046)* | 86 | mixed; overhead amortized by real work |
-| Gameboy | 90 650 | 1 041 | 87 | B1 typed arrays, B3 exotic exclusion |
-| NavierStokes | 35 432 | 341 | 104 | B1 boxed array elements |
-| RegExp | 9 890 | 89.9 | 110 | B5 regex engine |
-| Splay | 43 027 | 283 | 152 | B1 allocation rate |
-| Box2D | 99 321 | 584 | 170 | B1 + B2 (no escape analysis, no inlining) |
-| PdfJS | 58 725 | 321 *(0046)* | 183 | B1, B5, B4 |
-| EarleyBoyer | 91 547 | 339 | 270 | B1 allocation rate |
-| RayTrace | 117 436 | 403 | 291 | B1 + B2 escape analysis |
-| Mandreel | 47 996 | 160 | 300 | B4 compile, B1 heap traffic |
-| Crypto | 38 183 | 127 *(0046)* | 301 | B1 integer boxing |
-| zlib | 80 514 | 237 *(0046)* | 340 | B1 integer boxing |
-| CodeLoad | 30 916 | 83.4 *(0046)* | 371 | **B4 eager compilation** |
-| Richards | 46 754 | 108 | 433 | **B2 call cost, B3 shape transitions** |
-| DeltaBlue | 102 708 | 171 | 601 | **B2 polymorphic call cost** |
-| MandreelLatency | 67 368 | 14.5 | 4 646 | **B4 compile latency** |
+| SplayLatency | 89 673 | 2 614 | 34.3 | — (best axis; GC pauses are fine) |
+| Typescript | 118 170 | 3 338 | 35.4 | mixed; overhead amortized by real work |
+| Splay | 56 416 | 779 | 72.4 | B1 allocation rate |
+| NavierStokes | 45 217 | 621 | 72.8 | B1 boxed array elements |
+| Gameboy | 120 086 | 1 626 | 73.9 | B1 typed arrays, B3 exotic exclusion |
+| RegExp | 12 988 | 166 | 78.2 | B5 regex engine |
+| PdfJS | 79 352 | 712 | 111.4 | B1, B5, B4 |
+| Crypto | 49 408 | 425 | 116.3 | B1 integer boxing |
+| Richards | 49 320 | 349 | 141.3 | **B2 call cost, B3 shape transitions** |
+| Box2D | 136 091 | 937 | 145.2 | B1 + B2 (no escape analysis, no inlining) |
+| EarleyBoyer | 110 540 | 615 | 179.7 | B1 allocation rate |
+| zlib | 103 463 | 566 | 182.8 | B1 integer boxing |
+| CodeLoad | 40 803 | 193 | 211.4 | **B4 eager compilation** |
+| RayTrace | 152 290 | 677 | 224.9 | B1 + B2 escape analysis |
+| Mandreel | 64 547 | 238 | 271.2 | B4 compile, B1 heap traffic |
+| DeltaBlue | 126 232 | 316 | 399.5 | **B2 polymorphic call cost** |
+| MandreelLatency | 99 704 | 18.7 | 5 331.8 | **B4 compile latency** |
 
 The shape of that list is the finding:
 
-- **The extremes are both front-end and call-path, not arithmetic.** The four
-  worst are MandreelLatency, DeltaBlue, Richards and CodeLoad. Two are compilation
-  cost; two are the cost of making a call and reading a property. Boxing (B1) is
-  the biggest *uniform* multiplier, but it is not what produces the outliers.
+- **The extremes are front-end, call-path and allocation, not arithmetic.** The
+  four worst are MandreelLatency, DeltaBlue, Mandreel and RayTrace — two of them
+  compilation cost, one the cost of making a call, one the cost of allocating
+  short-lived objects with no escape analysis. CodeLoad, the other front-end
+  benchmark, sits just outside at 211×. Boxing (B1) is the biggest *uniform*
+  multiplier, but it is not what produces the outliers.
 - **Broiler does relatively best where the benchmark does the most work per
   engine operation** (Typescript, Gameboy) and relatively worst where the engine
-  operation *is* the work (DeltaBlue, Richards). That is the signature of a fixed
-  per-operation overhead rather than of a bad optimizer.
+  operation *is* the work (DeltaBlue). That is the signature of a fixed
+  per-operation overhead rather than of a bad optimizer. Richards, which used to
+  sit beside DeltaBlue at the bottom of this list, is now mid-table — a change
+  driven by the phase-2 inline-cache work, though **not one this single-repetition
+  pair of runs may be used to size**.
 - **GC is the one subsystem that is already competitive.**
 
 On that evidence the ordering with the best return is: **B4** (lazy compilation —
-it owns the two worst scores outright and is the one that matters most to page
-load), then **B2/B3** on the call and property paths (the Richards/DeltaBlue
-cluster), then **B1** representation work, which is the largest total win and by
-far the largest change.
+it owns the worst score outright, plus Mandreel and CodeLoad, and is the one that
+matters most to page load), then **B2/B3** on the call and property paths (which
+DeltaBlue still heads), then **B1** representation work, which is the largest
+total win and by far the largest change.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR updates the performance roadmap and Octane benchmark documentation to reflect the current state of the `Broiler.JS` engine after the latest patch series has been applied and pushed. The twelve pending patches (`0102`–`0113`) have been merged into the submodule, the pointer has been bumped to `8308df51`, and all measurements now describe the pinned pointer directly rather than a local build plus patches.

## Key Changes

- **Performance roadmap (`docs/performance-roadmap.md`)**
  - Consolidated the verbose provenance section into a clearer, more concise explanation of why pointers written into prose go stale and how to read them reliably (`git submodule status`)
  - Updated the pinned `Broiler.JS` pointer to `8308df51` (read 2026-08-06)
  - Updated sibling submodule pointers: `Broiler.HTML` to `2f94c0dc` and `Broiler.CSS` to `f960f943`
  - Removed detailed patch-by-patch handoff narratives and replaced with a single consolidated statement that all twelve patches (`0102`–`0113`) have been applied and pushed
  - Added clarification that patch numbers are citations of document history, not stable file names, and that `0102` is now reused by a `Broiler.CSS` patch
  - Simplified measurement-date section to focus on which commits are ancestors of the current pin
  - Updated all references to "the pinned pointer" to use the actual commit SHA where measurements were taken, with clarifying parentheticals like "(the pin at the time)"
  - Updated last-modified date from 2026-08-05 to 2026-08-06

- **Octane benchmarks documentation (`tests/octane/benchmarks.md`)**
  - Updated results generation date from 2026-07-31 to 2026-08-05
  - Replaced stale-results warning with confirmation that all 15 suites now score and the five previously-failing suites (Crypto, PdfJS, CodeLoad, zlib, Typescript) are now ordinary published results
  - Removed the `*(0046)* marker references and explanations since those patches are now in the pin
  - Updated all benchmark scores and ratios to reflect the current run (e.g., Richards 141.3× vs previous 433×, DeltaBlue 399.5× vs previous 601×)
  - Clarified that headline totals are now like-for-like (both geomeans over all 17 scores)
  - Updated the ranking table to sort by current ratios with all 17 benchmarks included
  - Added context about noise bands and per-suite variability (7.5% declared, true band 5.5%–15.9%)
  - Adjusted narrative descriptions of individual benchmarks to reflect new absolute scores and relative performance

## Notable Details

- The roadmap now emphasizes that every figure in the document describes the pinned pointer directly, eliminating the need for readers to mentally apply a patch series
- All ancestor commits cited for measurements are verified to be ancestors of the current pin via `merge-base --is-ancestor`
- The Octane results refresh is explicitly noted as a single-repetition run on a different machine than the previous one, so cross-run deltas should not be claimed as performance changes
- The documentation now clearly separates what can and cannot be read from the benchmark refresh (threshold crossings are valid; absolute deltas are not)

https://claude.ai/code/session_01FR1SDM5ppqLx1aGM9Nj4Ns