### PR TITLE
Add ci-commit-generated-results script for race-tolerant pushes

### DIFF
--- a/.github/workflows/octane-benchmarks.yml
+++ b/.github/workflows/octane-benchmarks.yml
@@ -139,17 +139,14 @@ jobs:
           path: tests/octane/logs/
           if-no-files-found: ignore
 
+      # A benchmarking job runs for hours, so the branch it was dispatched from
+      # has usually moved by the time it has something to commit — a plain push
+      # is rejected as non-fast-forward and the whole run's measurements are
+      # lost. The helper rebuilds the commit on the current tip and retries.
       - name: Commit results
         if: ${{ github.event.inputs.commit_results != 'false' }}
-        env:
-          BRANCH_NAME: ${{ github.ref_name }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add tests/octane/results/
-          if git diff --quiet --cached; then
-            echo "No result changes to commit."
-            exit 0
-          fi
-          git commit -m "ci: update Octane benchmark results [skip ci]"
-          git push origin "HEAD:$BRANCH_NAME"
+          bash scripts/ci-commit-generated-results.sh \
+            --branch "${{ github.ref_name }}" \
+            --message "ci: update Octane benchmark results [skip ci]" \
+            tests/octane/results/

--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -466,19 +466,12 @@ jobs:
             --merge-into "$FAILED_TESTS_FILE" \
             --merged-json "$FAILED_TESTS_FILE"
 
+      # Same race as the Octane workflow: the sharded run takes long enough that
+      # the branch has usually moved on, so the push has to be rebuilt on the
+      # current tip rather than assumed to fast-forward.
       - name: Commit manifest
-        env:
-          BRANCH_NAME: ${{ github.ref_name }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Stage first, then test the staged diff: `git diff` ignores untracked
-          # files, so checking before `git add` would never detect the manifest's
-          # first-ever creation (the file is untracked until then).
-          git add "$FAILED_TESTS_FILE"
-          if git diff --cached --quiet -- "$FAILED_TESTS_FILE"; then
-            echo "No manifest changes to commit."
-            exit 0
-          fi
-          git commit -m "ci: update WPT failed-tests manifest [skip ci]"
-          git push origin "HEAD:$BRANCH_NAME"
+          bash scripts/ci-commit-generated-results.sh \
+            --branch "${{ github.ref_name }}" \
+            --message "ci: update WPT failed-tests manifest [skip ci]" \
+            "$FAILED_TESTS_FILE"

--- a/scripts/ci-commit-generated-results.sh
+++ b/scripts/ci-commit-generated-results.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# ci-commit-generated-results.sh — commit regenerated result files back to a
+# long-running job's branch, tolerating pushes that land while the job runs.
+#
+# The Octane workflow benchmarks for up to three hours and the WPT workflow
+# shards for nearly as long; both then commit their generated results to the
+# branch they were dispatched from. A plain `git push` there is a race the job
+# usually loses on a busy day: any PR merged during the run moves the branch and
+# the push is rejected as non-fast-forward, discarding hours of measurement.
+#
+#     ! [rejected]        HEAD -> main (fetch first)
+#     error: failed to push some refs to '...'
+#
+# So instead of pushing once, this script rebuilds its commit on top of whatever
+# the branch tip has become and pushes again, up to --attempts times.
+#
+# The rebuild is a wholesale replacement of the given paths rather than a rebase:
+# these files are *generated*, always written in full by the run that produced
+# them, so a three-way merge of two runs' output has no meaning and would only
+# invent conflicts. Whoever measured last wins the result files; everything else
+# the branch gained in the meantime is preserved by construction, because the
+# fresh remote tip is the commit's new parent.
+#
+# Usage:
+#     ./scripts/ci-commit-generated-results.sh --branch <branch> \
+#         --message <commit message> <path> [<path>...]
+#
+# Options:
+#     --branch <name>    Branch to push to (required).
+#     --message <text>   Commit message (required).
+#     --attempts <n>     Push attempts before giving up (default 5).
+#     --delay <sec>      Initial backoff between attempts, doubled each
+#                        time (default 5).
+#
+# Environment:
+#     GIT_AUTHOR_IDENTITY_NAME / _EMAIL   Override the committing identity
+#                                         (default: github-actions[bot]).
+#
+# Exits 0 when the results are on the remote branch, or when there was nothing
+# to commit. Exits non-zero — loudly — when every attempt lost the race, rather
+# than leaving a green job with no results committed.
+
+set -euo pipefail
+
+BRANCH=""
+MESSAGE=""
+ATTEMPTS=5
+DELAY=5
+PATHS=()
+
+die() {
+    echo "ci-commit-generated-results: $*" >&2
+    exit 2
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --branch)   BRANCH="${2:-}"; shift 2 ;;
+        --message)  MESSAGE="${2:-}"; shift 2 ;;
+        --attempts) ATTEMPTS="${2:-}"; shift 2 ;;
+        --delay)    DELAY="${2:-}"; shift 2 ;;
+        -h|--help)  sed -n '2,45p' "$0"; exit 0 ;;
+        --)         shift; PATHS+=("$@"); break ;;
+        -*)         die "unknown option: $1" ;;
+        *)          PATHS+=("$1"); shift ;;
+    esac
+done
+
+[ -n "$BRANCH" ]  || die "--branch is required"
+[ -n "$MESSAGE" ] || die "--message is required"
+[ "${#PATHS[@]}" -gt 0 ] || die "at least one path is required"
+
+# Trailing slashes are natural to write for a results directory but break
+# `git cat-file -e <rev>:<path>` below, so normalize them away once here.
+for i in "${!PATHS[@]}"; do
+    PATHS[$i]="${PATHS[$i]%/}"
+done
+
+git config user.name  "${GIT_AUTHOR_IDENTITY_NAME:-github-actions[bot]}"
+git config user.email "${GIT_AUTHOR_IDENTITY_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
+
+# Stage first, then test the staged diff: `git diff` ignores untracked files, so
+# checking before `git add` would never detect a result file's first-ever
+# creation (it is untracked until then).
+stage() {
+    git add -A -- "${PATHS[@]}"
+}
+
+# True when the index differs from HEAD for the given paths — i.e. there is
+# something worth committing.
+staged_changes() {
+    ! git diff --cached --quiet -- "${PATHS[@]}"
+}
+
+stage
+if ! staged_changes; then
+    echo "No result changes to commit."
+    exit 0
+fi
+
+git commit -m "$MESSAGE"
+
+# The content to keep across every rebuild attempt. Kept as a commit id rather
+# than a copy on disk: it stays reachable through the reflog after the resets
+# below, so `git checkout $RESULTS -- <path>` restores exactly what was measured.
+RESULTS="$(git rev-parse HEAD)"
+
+attempt=1
+delay="$DELAY"
+while :; do
+    if git push origin "HEAD:$BRANCH"; then
+        echo "Pushed results to $BRANCH (attempt $attempt/$ATTEMPTS)."
+        exit 0
+    fi
+
+    if [ "$attempt" -ge "$ATTEMPTS" ]; then
+        die "push to $BRANCH still rejected after $ATTEMPTS attempts; results were not committed"
+    fi
+
+    echo "Push to $BRANCH was rejected — the branch moved while this job ran." >&2
+    echo "Rebuilding the results commit on the current tip (attempt $((attempt + 1))/$ATTEMPTS in ${delay}s)." >&2
+    sleep "$delay"
+    delay=$((delay * 2))
+    attempt=$((attempt + 1))
+
+    git fetch origin "$BRANCH"
+
+    # Start again from the branch tip as it is *now*. --hard also clears any
+    # working-tree dirt the benchmark left behind in tracked files, which would
+    # otherwise block the switch; the measured output is safe in $RESULTS.
+    git reset --hard FETCH_HEAD
+
+    # Replace the generated paths wholesale: drop whatever the tip carries for
+    # them, then restore this run's output. Dropping first is what makes a file
+    # this run no longer produces actually disappear.
+    for path in "${PATHS[@]}"; do
+        git rm -rq --ignore-unmatch -- "$path"
+        if git cat-file -e "$RESULTS:$path" 2>/dev/null; then
+            git checkout "$RESULTS" -- "$path"
+        fi
+    done
+
+    stage
+    if ! staged_changes; then
+        # Another run of this same job committed identical results while we were
+        # losing the race. Nothing left to say.
+        echo "Branch $BRANCH already carries these results."
+        exit 0
+    fi
+
+    git commit -m "$MESSAGE"
+    RESULTS="$(git rev-parse HEAD)"
+done

--- a/scripts/tests/test_ci_commit_generated_results.py
+++ b/scripts/tests/test_ci_commit_generated_results.py
@@ -1,0 +1,272 @@
+"""Tests for scripts/ci-commit-generated-results.sh.
+
+The script exists because of a real Octane run that benchmarked for hours and
+then threw the results away::
+
+    [main 0ab8848] ci: update Octane benchmark results [skip ci]
+     6 files changed, 1415 insertions(+), 375 deletions(-)
+     ! [rejected]        HEAD -> main (fetch first)
+    error: failed to push some refs to '.../Broiler'
+
+Something merged to main while the job ran. What these tests pin down is that
+the losing push is retried against the branch as it is *now* — and that the work
+which won the race is still there afterwards, since the whole point is to let
+people merge PRs during a benchmark rather than around it.
+
+Everything runs against real local repositories: the behaviour under test is git
+behaviour (what a non-fast-forward rejection does, what survives a rebuild),
+which cannot be checked by reading the script.
+"""
+
+from pathlib import Path
+import json
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "ci-commit-generated-results.sh"
+
+RESULTS_DIR = "tests/octane/results"
+MESSAGE = "ci: update Octane benchmark results [skip ci]"
+
+
+def git(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+class CiCommitGeneratedResultsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+        # A bare "GitHub", one clone standing in for the benchmark job, and a
+        # second clone standing in for everyone else merging while it runs.
+        self.remote = root / "remote.git"
+        subprocess.run(
+            ["git", "init", "--bare", "-b", "main", str(self.remote)],
+            check=True,
+            capture_output=True,
+        )
+
+        self.job = self._clone(root / "job")
+        self.job_results = self.job / RESULTS_DIR
+        self.job_results.mkdir(parents=True)
+        (self.job_results / "comparison.md").write_text("baseline\n")
+        (self.job / "README.md").write_text("Broiler\n")
+        git("add", "-A", cwd=self.job)
+        git("commit", "-m", "initial", cwd=self.job)
+        git("push", "-u", "origin", "main", cwd=self.job)
+
+        self.other = self._clone(root / "other")
+
+    def _clone(self, path: Path) -> Path:
+        subprocess.run(
+            ["git", "clone", str(self.remote), str(path)],
+            check=True,
+            capture_output=True,
+        )
+        git("config", "user.name", "Test", cwd=path)
+        git("config", "user.email", "test@example.com", cwd=path)
+        return path
+
+    def _run(self, *extra: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                "bash",
+                str(SCRIPT),
+                "--branch",
+                "main",
+                "--message",
+                MESSAGE,
+                "--delay",
+                "0",
+                *extra,
+                f"{RESULTS_DIR}/",
+            ],
+            cwd=cwd or self.job,
+            capture_output=True,
+            text=True,
+        )
+
+    def _land_on_main(self, path: str, contents: str, message: str) -> str:
+        """Push a competing commit from the other clone, as a merged PR would."""
+        git("pull", "--ff-only", "origin", "main", cwd=self.other)
+        target = self.other / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(contents)
+        git("add", "-A", cwd=self.other)
+        git("commit", "-m", message, cwd=self.other)
+        git("push", "origin", "main", cwd=self.other)
+        return git("rev-parse", "HEAD", cwd=self.other).strip()
+
+    def _remote_file(self, path: str) -> str:
+        return git("show", f"main:{path}", cwd=self.remote)
+
+    # --- the reported failure ------------------------------------------------
+
+    def test_results_land_even_though_the_branch_moved_during_the_run(self) -> None:
+        (self.job_results / "comparison.md").write_text("measured\n")
+        landed = self._land_on_main("src/Feature.cs", "// merged PR\n", "feat: land a PR")
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self._remote_file(f"{RESULTS_DIR}/comparison.md"), "measured\n")
+        # The PR that won the race is still on the branch, and is the parent of
+        # the results commit rather than something it replaced.
+        self.assertEqual(self._remote_file("src/Feature.cs"), "// merged PR\n")
+        self.assertEqual(
+            git("rev-parse", "main^", cwd=self.remote).strip(),
+            landed,
+        )
+        self.assertEqual(
+            git("log", "-1", "--format=%s", "main", cwd=self.remote).strip(),
+            MESSAGE,
+        )
+
+    def test_it_keeps_retrying_while_the_branch_keeps_moving(self) -> None:
+        """A busy afternoon: a PR lands just before each of the first two pushes."""
+        (self.job_results / "comparison.md").write_text("measured\n")
+
+        # A pre-push hook in the job clone lands a PR from the other clone right
+        # before each of the first two attempts leaves, so the retry is racing
+        # too rather than pushing into a branch that has settled down.
+        counter = self.job / ".git" / "push-attempts"
+        hook = self.job / ".git" / "hooks" / "pre-push"
+        hook.write_text(
+            "#!/usr/bin/env bash\n"
+            # Hooks inherit GIT_DIR/GIT_WORK_TREE, which would point every git
+            # command below back at the pushing repository.
+            "unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX\n"
+            "cat >/dev/null\n"
+            f'n=$(cat "{counter}" 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" > "{counter}"\n'
+            '[ "$n" -gt 2 ] && exit 0\n'
+            f'cd "{self.other}"\n'
+            "git pull -q --ff-only origin main\n"
+            'printf "// PR %s\\n" "$n" > "src/PR$n.cs"\n'
+            "git add -A && git commit -qm \"feat: land PR $n\" && git push -q origin main\n"
+            "exit 0\n"
+        )
+        hook.chmod(0o755)
+        (self.other / "src").mkdir(parents=True, exist_ok=True)
+
+        result = self._run("--attempts", "5")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(counter.read_text().strip(), "3")
+        self.assertEqual(self._remote_file(f"{RESULTS_DIR}/comparison.md"), "measured\n")
+        self.assertEqual(self._remote_file("src/PR1.cs"), "// PR 1\n")
+        self.assertEqual(self._remote_file("src/PR2.cs"), "// PR 2\n")
+
+    # --- what the rebuild keeps and drops ------------------------------------
+
+    def test_the_benchmarks_own_output_wins_over_a_competing_results_commit(self) -> None:
+        """Result files are generated wholesale, so the last measurement wins."""
+        (self.job_results / "comparison.md").write_text("measured by this job\n")
+        self._land_on_main(
+            f"{RESULTS_DIR}/comparison.md",
+            "measured by an older job\n",
+            "ci: update Octane benchmark results [skip ci]",
+        )
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            self._remote_file(f"{RESULTS_DIR}/comparison.md"),
+            "measured by this job\n",
+        )
+
+    def test_a_result_file_this_run_no_longer_produces_is_removed(self) -> None:
+        (self.job_results / "comparison.md").write_text("measured\n")
+        self._land_on_main(
+            f"{RESULTS_DIR}/stale-engine.json",
+            json.dumps({"engine": "gone"}),
+            "ci: update Octane benchmark results [skip ci]",
+        )
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        tracked = git("ls-tree", "-r", "--name-only", "main", cwd=self.remote).split()
+        self.assertNotIn(f"{RESULTS_DIR}/stale-engine.json", tracked)
+        self.assertIn(f"{RESULTS_DIR}/comparison.md", tracked)
+
+    def test_files_outside_the_result_paths_are_never_touched(self) -> None:
+        (self.job_results / "comparison.md").write_text("measured\n")
+        # Job-local churn in a tracked file outside the results: the rebuild
+        # resets the working tree, so this must not ride along into the commit.
+        (self.job / "README.md").write_text("scribbled on by the job\n")
+        self._land_on_main("README.md", "Broiler, edited by a PR\n", "docs: edit readme")
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self._remote_file("README.md"), "Broiler, edited by a PR\n")
+
+    # --- the quiet and the loud endings --------------------------------------
+
+    def test_nothing_measured_means_nothing_committed(self) -> None:
+        before = git("rev-parse", "main", cwd=self.remote).strip()
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("No result changes to commit.", result.stdout)
+        self.assertEqual(git("rev-parse", "main", cwd=self.remote).strip(), before)
+
+    def test_first_ever_result_file_is_committed(self) -> None:
+        """An untracked new file still counts as a change worth pushing."""
+        (self.job_results / "diagnostics.md").write_text("first run\n")
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self._remote_file(f"{RESULTS_DIR}/diagnostics.md"), "first run\n")
+
+    def test_identical_results_already_on_the_branch_end_the_retry(self) -> None:
+        (self.job_results / "comparison.md").write_text("measured\n")
+        self._land_on_main(
+            f"{RESULTS_DIR}/comparison.md",
+            "measured\n",
+            "ci: update Octane benchmark results [skip ci]",
+        )
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("already carries these results", result.stdout)
+
+    def test_a_push_that_never_succeeds_fails_the_job(self) -> None:
+        """Exhausted attempts must be loud: a green job with no results is worse."""
+        reject = self.remote / "hooks" / "pre-receive"
+        reject.write_text("#!/usr/bin/env bash\necho 'rejected by test'\nexit 1\n")
+        reject.chmod(0o755)
+        (self.job_results / "comparison.md").write_text("measured\n")
+
+        result = self._run("--attempts", "2")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("after 2 attempts", result.stderr)
+
+    def test_missing_arguments_are_rejected(self) -> None:
+        result = subprocess.run(
+            ["bash", str(SCRIPT), "--branch", "main", "--message", MESSAGE],
+            cwd=self.job,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("at least one path is required", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/octane/README.md
+++ b/tests/octane/README.md
@@ -42,6 +42,14 @@ In CI the [Octane Benchmarks workflow](../../.github/workflows/octane-benchmarks
 (`workflow_dispatch`) runs all three engines and commits the refreshed results.
 It also uploads the per-suite logs as an `octane-logs` artifact.
 
+Benchmarking takes hours, so the branch has usually moved by the time there is
+anything to commit. The commit step goes through
+[`scripts/ci-commit-generated-results.sh`](../../scripts/ci-commit-generated-results.sh),
+which rebuilds its commit on the branch tip as it is *then* and pushes again
+instead of failing on the non-fast-forward — merge PRs during a run, not around
+it. Results are generated wholesale, so if two runs touch the same file the
+later measurement wins; nothing else on the branch is disturbed.
+
 A single-engine run still refreshes the whole comparison: any per-engine result
 already in `results/` is folded back in, so `--engines jint` updates the Jint
 column against the last committed Chromium and Broiler ones. That is only honest


### PR DESCRIPTION
## Summary

Adds a new helper script `scripts/ci-commit-generated-results.sh` that safely commits and pushes generated result files from long-running CI jobs (Octane benchmarks, WPT test runs) even when the target branch moves during execution. The script rebuilds commits on the current branch tip and retries, rather than failing on non-fast-forward rejections that would discard hours of measurement work.

## Changes

- **New script: `scripts/ci-commit-generated-results.sh`**
  - Commits generated result files to a specified branch with automatic retry logic
  - Rebuilds commits on the current branch tip when pushes are rejected as non-fast-forward
  - Replaces result paths wholesale (not merge-based), so the latest measurement always wins
  - Preserves all other work that landed on the branch during the job's execution
  - Configurable retry attempts (default 5) and exponential backoff (default 5s initial delay)
  - Normalizes trailing slashes in paths and validates required arguments

- **New comprehensive test suite: `scripts/tests/test_ci_commit_generated_results.py`**
  - Tests against real local git repositories to verify actual git behavior
  - Validates the core scenario: results land despite branch movement during the run
  - Tests repeated retries when the branch keeps moving between attempts
  - Verifies rebuild semantics: latest measurement wins, stale files are removed, unrelated files untouched
  - Tests edge cases: no changes to commit, first-ever result file, identical results already on branch, exhausted retry attempts, missing arguments

- **Updated workflows to use the new script**
  - `.github/workflows/octane-benchmarks.yml`: Replaces inline push logic with script call
  - `.github/workflows/wpt-tests.yml`: Replaces inline manifest commit logic with script call
  - Both workflows now benefit from automatic retry and race-condition handling

- **Documentation updates**
  - `tests/octane/README.md`: Explains the race condition and how the script handles it

## Implementation Details

The script uses a rebuild-and-retry strategy rather than rebasing:
- Generated files are always written in full by each run, so three-way merge semantics are meaningless
- Rebuilds drop and restore result paths wholesale, ensuring stale files disappear
- The fresh remote tip becomes the commit's parent, preserving all concurrent work by construction
- Exponential backoff between retries reduces contention on busy days
- Exits cleanly (0) when results are committed or when there's nothing to commit; exits loudly (non-zero) only when all retry attempts fail, preventing silent loss of measurement data

https://claude.ai/code/session_013AHPjjT4HoamkaHfLQqdXa