### PR TITLE
Read DOCX block-level content recursively; flatten tables

### DIFF
--- a/Broiler.Documents/Broiler.Documents.Docx.Tests/DocxCapitalizationTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx.Tests/DocxCapitalizationTests.cs
@@ -1,0 +1,134 @@
+namespace Broiler.Documents.Docx.Tests;
+
+/// <summary>
+/// <c>w:caps</c> and <c>w:smallCaps</c>. Word stores the author's casing and
+/// draws capitals, so these must survive as an attribute rather than being baked
+/// into the text — otherwise an open-and-save rewrites what the author typed.
+/// </summary>
+public sealed class DocxCapitalizationTests
+{
+    [Fact]
+    public void Reads_Caps_As_An_Attribute_Not_As_Uppercased_Text()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadBody(
+            "<w:p><w:r><w:rPr><w:caps/></w:rPr><w:t>Elene Bartky</w:t></w:r></w:p>");
+
+        RichTextParagraph paragraph = Assert.Single(result.Document.Paragraphs);
+        Assert.Equal("Elene Bartky", paragraph.Text);
+        Assert.Equal(TextCapitalization.AllCaps, paragraph.StyleAt(0).Capitalization);
+    }
+
+    [Fact]
+    public void Reads_SmallCaps()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadBody(
+            "<w:p><w:r><w:rPr><w:smallCaps/></w:rPr><w:t>Kontakt</w:t></w:r></w:p>");
+
+        Assert.Equal(
+            TextCapitalization.SmallCaps,
+            Assert.Single(result.Document.Paragraphs).StyleAt(0).Capitalization);
+    }
+
+    [Fact]
+    public void Reads_Caps_Declared_By_A_Paragraph_Style()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.StyledParagraph("Title", "Elene Bartky"),
+            DocxTestPackage.Style("Title", "<w:rPr><w:caps/><w:sz w:val=\"96\"/></w:rPr>"));
+
+        RichTextParagraph paragraph = Assert.Single(result.Document.Paragraphs);
+        Assert.Equal("Elene Bartky", paragraph.Text);
+        Assert.Equal(TextCapitalization.AllCaps, paragraph.StyleAt(0).Capitalization);
+        Assert.Equal(48f, paragraph.StyleAt(0).FontSize);
+    }
+
+    [Fact]
+    public void A_Run_Can_Turn_Off_The_Caps_Its_Style_Applied()
+    {
+        string paragraph =
+            "<w:p><w:pPr><w:pStyle w:val=\"Title\"/></w:pPr>" +
+            "<w:r><w:rPr><w:caps w:val=\"0\"/></w:rPr><w:t>quiet</w:t></w:r></w:p>";
+
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            paragraph,
+            DocxTestPackage.Style("Title", "<w:rPr><w:caps/></w:rPr>"));
+
+        Assert.Equal(
+            TextCapitalization.None,
+            Assert.Single(result.Document.Paragraphs).StyleAt(0).Capitalization);
+    }
+
+    /// <summary>Turning one kind off must not disturb the other.</summary>
+    [Fact]
+    public void Turning_SmallCaps_Off_Leaves_Inherited_AllCaps_Alone()
+    {
+        string paragraph =
+            "<w:p><w:pPr><w:pStyle w:val=\"Title\"/></w:pPr>" +
+            "<w:r><w:rPr><w:smallCaps w:val=\"0\"/></w:rPr><w:t>loud</w:t></w:r></w:p>";
+
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            paragraph,
+            DocxTestPackage.Style("Title", "<w:rPr><w:caps/></w:rPr>"));
+
+        Assert.Equal(
+            TextCapitalization.AllCaps,
+            Assert.Single(result.Document.Paragraphs).StyleAt(0).Capitalization);
+    }
+
+    /// <summary>Word draws all caps when a run asks for both.</summary>
+    [Fact]
+    public void All_Caps_Wins_When_A_Run_Declares_Both()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadBody(
+            "<w:p><w:r><w:rPr><w:smallCaps/><w:caps/></w:rPr><w:t>text</w:t></w:r></w:p>");
+
+        Assert.Equal(
+            TextCapitalization.AllCaps,
+            Assert.Single(result.Document.Paragraphs).StyleAt(0).Capitalization);
+    }
+
+    [Theory]
+    [InlineData(TextCapitalization.AllCaps, "caps")]
+    [InlineData(TextCapitalization.SmallCaps, "smallCaps")]
+    public void Writes_Capitalization_As_A_Run_Property(TextCapitalization capitalization, string expectedElement)
+    {
+        RichTextDocument document = RichTextDocument.FromParagraphs(
+        [
+            RichTextParagraph.Create("Elene Bartky", InlineStyle.Default with { Capitalization = capitalization }),
+        ]);
+
+        byte[] bytes = DocxDocumentCodec.WriteToArray(document);
+        string documentXml = ReadDocumentPart(bytes);
+
+        Assert.Contains("<w:" + expectedElement, documentXml, StringComparison.Ordinal);
+        Assert.Contains("Elene Bartky", documentXml, StringComparison.Ordinal);
+        Assert.DoesNotContain("ELENE BARTKY", documentXml, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(TextCapitalization.None)]
+    [InlineData(TextCapitalization.AllCaps)]
+    [InlineData(TextCapitalization.SmallCaps)]
+    public void Round_Trips_Capitalization_Without_Rewriting_The_Text(TextCapitalization capitalization)
+    {
+        RichTextDocument original = RichTextDocument.FromParagraphs(
+        [
+            RichTextParagraph.Create("Elene Bartky", InlineStyle.Default with { Capitalization = capitalization }),
+        ]);
+
+        byte[] bytes = DocxDocumentCodec.WriteToArray(original);
+        using var stream = new MemoryStream(bytes, writable: false);
+        DocumentReadResult result = new DocxDocumentCodec().Read(stream);
+
+        RichTextParagraph paragraph = Assert.Single(result.Document.Paragraphs);
+        Assert.Equal("Elene Bartky", paragraph.Text);
+        Assert.Equal(capitalization, paragraph.StyleAt(0).Capitalization);
+    }
+
+    private static string ReadDocumentPart(byte[] bytes)
+    {
+        using var archive = new System.IO.Compression.ZipArchive(new MemoryStream(bytes), System.IO.Compression.ZipArchiveMode.Read);
+        using var reader = new StreamReader(archive.GetEntry("word/document.xml")!.Open());
+        return reader.ReadToEnd();
+    }
+}

--- a/Broiler.Documents/Broiler.Documents.Docx.Tests/DocxReaderBlockContentTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx.Tests/DocxReaderBlockContentTests.cs
@@ -1,0 +1,324 @@
+using System.Text;
+
+namespace Broiler.Documents.Docx.Tests;
+
+/// <summary>
+/// Covers block-level DOCX content: everything a <c>w:body</c> may hold besides
+/// a bare <c>w:p</c>. The reader used to walk only the direct <c>w:p</c>
+/// children of the body, so a document whose content lived inside a layout table
+/// — the shape every CV and letterhead template uses — opened completely empty.
+/// </summary>
+public sealed class DocxReaderBlockContentTests
+{
+    [Fact]
+    public void Reads_Paragraphs_Held_By_A_Table()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadBody(
+            DocxTestPackage.Table(
+                [DocxTestPackage.Paragraph("left"), DocxTestPackage.Paragraph("right")]));
+
+        Assert.False(result.HasErrors);
+        Assert.Equal(2, result.Document.ParagraphCount);
+        Assert.Equal("left", result.Document.Paragraphs[0].Text);
+        Assert.Equal("right", result.Document.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void Reads_Table_Cells_In_Row_Major_Order()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadBody(
+            DocxTestPackage.Table(
+                [DocxTestPackage.Paragraph("r1c1"), DocxTestPackage.Paragraph("r1c2")],
+                [DocxTestPackage.Paragraph("r2c1"), DocxTestPackage.Paragraph("r2c2")]));
+
+        Assert.Equal(
+            new[] { "r1c1", "r1c2", "r2c1", "r2c2" },
+            result.Document.Paragraphs.Select(paragraph => paragraph.Text).ToArray());
+    }
+
+    /// <summary>
+    /// The reported document: one layout table holding the whole CV, followed by
+    /// the single empty paragraph Word requires before <c>w:sectPr</c>. Before the
+    /// fix this read as one empty paragraph and no text at all.
+    /// </summary>
+    [Fact]
+    public void Reads_A_Cv_Shaped_Document_Whose_Body_Is_One_Layout_Table()
+    {
+        string body =
+            DocxTestPackage.Table(
+                [
+                    DocxTestPackage.Paragraph("Elene Bartky") + DocxTestPackage.Paragraph("Hebamme"),
+                    string.Empty,
+                    DocxTestPackage.Paragraph("Berufserfahrung") + DocxTestPackage.Paragraph("Seit 11/2020"),
+                ]) +
+            "<w:p/>" +
+            "<w:sectPr><w:pgSz w:w=\"11906\" w:h=\"16838\"/></w:sectPr>";
+
+        DocumentReadResult result = DocxTestPackage.ReadBody(body);
+
+        Assert.Contains("Elene Bartky", result.Document.PlainText, StringComparison.Ordinal);
+        Assert.Contains("Berufserfahrung", result.Document.PlainText, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Code == "docx.document.empty");
+    }
+
+    [Fact]
+    public void Reads_Tables_Nested_Inside_A_Cell()
+    {
+        string inner = DocxTestPackage.Table([[DocxTestPackage.Paragraph("inner")]]);
+        DocumentReadResult result = DocxTestPackage.ReadBody(
+            DocxTestPackage.Table([[DocxTestPackage.Paragraph("outer") + inner]]));
+
+        Assert.Equal(
+            new[] { "outer", "inner" },
+            result.Document.Paragraphs.Select(paragraph => paragraph.Text).ToArray());
+    }
+
+    [Fact]
+    public void Reads_Paragraph_Styles_Inside_Table_Cells()
+    {
+        string cell =
+            "<w:p><w:pPr><w:jc w:val=\"center\"/><w:numPr>" +
+            "<w:ilvl w:val=\"0\"/><w:numId w:val=\"1\"/>" +
+            "</w:numPr></w:pPr><w:r><w:t>bullet</w:t></w:r></w:p>";
+
+        DocumentReadResult result = DocxTestPackage.ReadBody(DocxTestPackage.Table([[cell]]));
+
+        RichTextParagraph paragraph = Assert.Single(result.Document.Paragraphs);
+        Assert.Equal("bullet", paragraph.Text);
+        Assert.Equal(TextAlignment.Center, paragraph.Style.Alignment);
+        Assert.Equal(ListKind.Bullet, paragraph.Style.ListKind);
+    }
+
+    [Fact]
+    public void Reads_Run_Styles_Inside_Table_Cells()
+    {
+        string cell =
+            "<w:p><w:r><w:rPr><w:b/><w:sz w:val=\"36\"/></w:rPr><w:t>Name</w:t></w:r></w:p>";
+
+        DocumentReadResult result = DocxTestPackage.ReadBody(DocxTestPackage.Table([[cell]]));
+
+        RichTextParagraph paragraph = Assert.Single(result.Document.Paragraphs);
+        InlineStyle style = paragraph.StyleAt(0);
+        Assert.True(style.Bold);
+        Assert.Equal(18f, style.FontSize);
+    }
+
+    [Fact]
+    public void Reads_Block_Level_Structured_Document_Tags()
+    {
+        string body =
+            "<w:sdt><w:sdtPr><w:id w:val=\"1\"/></w:sdtPr><w:sdtContent>" +
+            DocxTestPackage.Paragraph("placeholder") +
+            "</w:sdtContent></w:sdt>";
+
+        DocumentReadResult result = DocxTestPackage.ReadBody(body);
+
+        Assert.Equal("placeholder", Assert.Single(result.Document.Paragraphs).Text);
+    }
+
+    [Fact]
+    public void Reads_Table_Rows_Wrapped_In_A_Structured_Document_Tag()
+    {
+        string row =
+            "<w:sdt><w:sdtPr/><w:sdtContent><w:tr><w:tc>" +
+            DocxTestPackage.Paragraph("row in a content control") +
+            "</w:tc></w:tr></w:sdtContent></w:sdt>";
+
+        DocumentReadResult result = DocxTestPackage.ReadBody("<w:tbl><w:tblPr/>" + row + "</w:tbl>");
+
+        Assert.Equal("row in a content control", Assert.Single(result.Document.Paragraphs).Text);
+    }
+
+    [Fact]
+    public void Reads_Inserted_Revisions_And_Skips_Deleted_Ones()
+    {
+        string body =
+            "<w:ins w:id=\"1\" w:author=\"a\">" + DocxTestPackage.Paragraph("kept") + "</w:ins>" +
+            "<w:del w:id=\"2\" w:author=\"a\">" + DocxTestPackage.Paragraph("gone") + "</w:del>";
+
+        DocumentReadResult result = DocxTestPackage.ReadBody(body);
+
+        Assert.Equal("kept", Assert.Single(result.Document.Paragraphs).Text);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "docx.revision.delete");
+    }
+
+    [Fact]
+    public void Reads_Only_One_Branch_Of_Alternate_Content()
+    {
+        string body =
+            "<mc:AlternateContent>" +
+            "<mc:Choice Requires=\"wps\">" + DocxTestPackage.Paragraph("choice") + "</mc:Choice>" +
+            "<mc:Fallback>" + DocxTestPackage.Paragraph("fallback") + "</mc:Fallback>" +
+            "</mc:AlternateContent>";
+
+        DocumentReadResult result = DocxTestPackage.ReadBody(body);
+
+        Assert.Equal("choice", Assert.Single(result.Document.Paragraphs).Text);
+    }
+
+    [Fact]
+    public void Falls_Back_When_Alternate_Content_Has_No_Choice()
+    {
+        string body =
+            "<mc:AlternateContent><mc:Fallback>" +
+            DocxTestPackage.Paragraph("fallback") +
+            "</mc:Fallback></mc:AlternateContent>";
+
+        DocumentReadResult result = DocxTestPackage.ReadBody(body);
+
+        Assert.Equal("fallback", Assert.Single(result.Document.Paragraphs).Text);
+    }
+
+    [Fact]
+    public void Skips_Structural_Blocks_Without_A_Diagnostic()
+    {
+        string body =
+            "<w:bookmarkStart w:id=\"0\" w:name=\"_top\"/>" +
+            DocxTestPackage.Paragraph("text") +
+            "<w:bookmarkEnd w:id=\"0\"/>" +
+            "<w:sectPr/>";
+
+        DocumentReadResult result = DocxTestPackage.ReadBody(body);
+
+        Assert.Equal("text", Assert.Single(result.Document.Paragraphs).Text);
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Code == "docx.block.unsupported");
+    }
+
+    [Fact]
+    public void Reports_An_Unsupported_Block_Once_Per_Element_Name()
+    {
+        string body =
+            "<w:someFutureBlock/><w:someFutureBlock/><w:anotherFutureBlock/>" +
+            DocxTestPackage.Paragraph("text");
+
+        DocumentReadResult result = DocxTestPackage.ReadBody(body);
+
+        DocumentDiagnostic[] unsupported = result.Diagnostics
+            .Where(diagnostic => diagnostic.Code == "docx.block.unsupported")
+            .ToArray();
+
+        Assert.Equal(2, unsupported.Length);
+        Assert.Contains(unsupported, diagnostic => diagnostic.Message.Contains("someFutureBlock", StringComparison.Ordinal));
+        Assert.Contains(unsupported, diagnostic => diagnostic.Message.Contains("anotherFutureBlock", StringComparison.Ordinal));
+        Assert.Equal("text", Assert.Single(result.Document.Paragraphs).Text);
+    }
+
+    [Fact]
+    public void Warns_When_Block_Content_Produces_No_Paragraphs()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadBody("<w:tbl><w:tblPr/><w:tblGrid/></w:tbl>");
+
+        Assert.Equal(string.Empty, result.Document.PlainText);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "docx.document.empty");
+    }
+
+    [Fact]
+    public void Does_Not_Warn_When_The_Body_Is_Genuinely_Empty()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadBody("<w:sectPr/>");
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Code == "docx.document.empty");
+    }
+
+    [Fact]
+    public void Reports_A_Read_Summary_With_Paragraph_And_Table_Counts()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadBody(
+            DocxTestPackage.Table([[DocxTestPackage.Paragraph("a"), DocxTestPackage.Paragraph("b")]]));
+
+        DocumentDiagnostic summary = Assert.Single(
+            result.Diagnostics,
+            diagnostic => diagnostic.Code == "docx.read.summary");
+
+        Assert.Equal(DocumentDiagnosticSeverity.Info, summary.Severity);
+        Assert.Contains("2 paragraph(s)", summary.Message, StringComparison.Ordinal);
+        Assert.Contains("1 table(s)", summary.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Reports_Flattened_Tables_Once()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadBody(
+            DocxTestPackage.Table([[DocxTestPackage.Paragraph("a")]]) +
+            DocxTestPackage.Table([[DocxTestPackage.Paragraph("b")]]));
+
+        Assert.Single(result.Diagnostics, diagnostic => diagnostic.Code == "docx.table.flattened");
+    }
+
+    [Fact]
+    public void Stops_At_MaxGroupDepth_Instead_Of_Recursing_Without_Bound()
+    {
+        var body = new StringBuilder(DocxTestPackage.Paragraph("deepest"));
+        for (int i = 0; i < 32; i++)
+            body = new StringBuilder(DocxTestPackage.Table([[body.ToString()]]));
+
+        DocumentReadResult result = DocxTestPackage.ReadBody(
+            body.ToString(),
+            new DocumentReadOptions(new DocumentLimits(maxGroupDepth: 4)));
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "docx.limit.depth");
+        Assert.Equal(string.Empty, result.Document.PlainText);
+    }
+
+    [Fact]
+    public void Reads_Deeply_Nested_Tables_Within_MaxGroupDepth()
+    {
+        var body = new StringBuilder(DocxTestPackage.Paragraph("deepest"));
+        for (int i = 0; i < 8; i++)
+            body = new StringBuilder(DocxTestPackage.Table([[body.ToString()]]));
+
+        DocumentReadResult result = DocxTestPackage.ReadBody(body.ToString());
+
+        Assert.Equal("deepest", Assert.Single(result.Document.Paragraphs).Text);
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Code == "docx.limit.depth");
+    }
+
+    [Fact]
+    public void Notes_Headers_And_Footers_That_Were_Not_Imported()
+    {
+        var extraParts = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["word/_rels/document.xml.rels"] =
+                "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
+                "<Relationship Id=\"rId2\" " +
+                "Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/header\" " +
+                "Target=\"header1.xml\"/>" +
+                "</Relationships>",
+            ["word/header1.xml"] =
+                "<w:hdr " + DocxTestPackage.BodyNamespaceDeclarations + ">" +
+                DocxTestPackage.Paragraph("page header") +
+                "</w:hdr>",
+        };
+
+        byte[] bytes = DocxTestPackage.FromBody(DocxTestPackage.Paragraph("body"), extraParts);
+        using var stream = new MemoryStream(bytes, writable: false);
+        DocumentReadResult result = new DocxDocumentCodec().Read(stream);
+
+        Assert.Equal("body", Assert.Single(result.Document.Paragraphs).Text);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "docx.part.headerfooter");
+    }
+
+    /// <summary>A DOCX Broiler wrote must still round-trip through the block walker.</summary>
+    [Fact]
+    public void Round_Trips_A_Document_Written_By_The_Docx_Writer()
+    {
+        RichTextDocument original = RichTextDocument.FromParagraphs(
+        [
+            RichTextParagraph.Plain("first"),
+            RichTextParagraph.Plain("second"),
+        ]);
+
+        byte[] bytes = DocxDocumentCodec.WriteToArray(original);
+        using var stream = new MemoryStream(bytes, writable: false);
+        DocumentReadResult result = new DocxDocumentCodec().Read(stream);
+
+        Assert.Equal(
+            new[] { "first", "second" },
+            result.Document.Paragraphs.Select(paragraph => paragraph.Text).ToArray());
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Code == "docx.block.unsupported");
+    }
+}

--- a/Broiler.Documents/Broiler.Documents.Docx.Tests/DocxReaderStyleTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx.Tests/DocxReaderStyleTests.cs
@@ -1,0 +1,306 @@
+namespace Broiler.Documents.Docx.Tests;
+
+/// <summary>
+/// Covers <c>word/styles.xml</c> resolution — document defaults, the
+/// <c>w:basedOn</c> chain, <c>w:pStyle</c>, <c>w:rStyle</c>, and theme fonts.
+/// Template documents carry almost no direct formatting, so a paragraph's
+/// appearance lives entirely in the style it names.
+/// </summary>
+public sealed class DocxReaderStyleTests
+{
+    [Fact]
+    public void Applies_Run_Properties_From_A_Named_Paragraph_Style()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.StyledParagraph("Title", "Elene Bartky"),
+            DocxTestPackage.Style("Title", "<w:rPr><w:b/><w:sz w:val=\"96\"/></w:rPr>"));
+
+        InlineStyle style = Assert.Single(result.Document.Paragraphs).StyleAt(0);
+        Assert.True(style.Bold);
+        Assert.Equal(48f, style.FontSize);
+    }
+
+    [Fact]
+    public void Applies_Paragraph_Properties_From_A_Named_Paragraph_Style()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.StyledParagraph("Centered", "text"),
+            DocxTestPackage.Style(
+                "Centered",
+                "<w:pPr><w:jc w:val=\"center\"/><w:spacing w:after=\"240\"/></w:pPr>"));
+
+        ParagraphStyle style = Assert.Single(result.Document.Paragraphs).Style;
+        Assert.Equal(TextAlignment.Center, style.Alignment);
+        Assert.Equal(12f, style.SpacingAfter);
+    }
+
+    [Fact]
+    public void Walks_The_BasedOn_Chain_Root_First()
+    {
+        string styles =
+            DocxTestPackage.Style("Base", "<w:rPr><w:sz w:val=\"20\"/><w:i/></w:rPr>") +
+            DocxTestPackage.Style("Derived", "<w:rPr><w:sz w:val=\"48\"/></w:rPr>", basedOn: "Base");
+
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.StyledParagraph("Derived", "text"),
+            styles);
+
+        InlineStyle style = Assert.Single(result.Document.Paragraphs).StyleAt(0);
+        Assert.Equal(24f, style.FontSize);  // the derived style wins
+        Assert.True(style.Italic);          // and inherits what it does not set
+    }
+
+    [Fact]
+    public void Applies_Document_Defaults_To_Unstyled_Paragraphs()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.Paragraph("text"),
+            DocxTestPackage.DocumentDefaults("<w:rPr><w:sz w:val=\"24\"/></w:rPr>"));
+
+        Assert.Equal(12f, Assert.Single(result.Document.Paragraphs).StyleAt(0).FontSize);
+    }
+
+    [Fact]
+    public void Applies_The_Default_Paragraph_Style_When_No_Style_Is_Named()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.Paragraph("text"),
+            DocxTestPackage.Style("Normal", "<w:rPr><w:sz w:val=\"20\"/></w:rPr>", isDefault: true));
+
+        Assert.Equal(10f, Assert.Single(result.Document.Paragraphs).StyleAt(0).FontSize);
+    }
+
+    /// <summary>
+    /// ECMA-376 §17.7.2: the default style applies to content that names no
+    /// style. A paragraph naming its own style picks up the default only when
+    /// its <c>w:basedOn</c> chain leads there.
+    /// </summary>
+    [Fact]
+    public void Does_Not_Apply_The_Default_Paragraph_Style_To_A_Paragraph_That_Names_One()
+    {
+        string styles =
+            DocxTestPackage.Style("Normal", "<w:rPr><w:sz w:val=\"20\"/></w:rPr>", isDefault: true) +
+            DocxTestPackage.Style("Loud", "<w:rPr><w:b/></w:rPr>");
+
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.StyledParagraph("Loud", "text"),
+            styles);
+
+        InlineStyle style = Assert.Single(result.Document.Paragraphs).StyleAt(0);
+        Assert.True(style.Bold);
+        Assert.Null(style.FontSize);
+    }
+
+    [Fact]
+    public void Direct_Run_Properties_Override_The_Paragraph_Style()
+    {
+        string paragraph =
+            "<w:p><w:pPr><w:pStyle w:val=\"Title\"/></w:pPr>" +
+            "<w:r><w:rPr><w:sz w:val=\"20\"/></w:rPr><w:t>text</w:t></w:r></w:p>";
+
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            paragraph,
+            DocxTestPackage.Style("Title", "<w:rPr><w:b/><w:sz w:val=\"96\"/></w:rPr>"));
+
+        InlineStyle style = Assert.Single(result.Document.Paragraphs).StyleAt(0);
+        Assert.Equal(10f, style.FontSize);
+        Assert.True(style.Bold);
+    }
+
+    [Fact]
+    public void Direct_Paragraph_Properties_Override_The_Paragraph_Style()
+    {
+        string paragraph =
+            "<w:p><w:pPr><w:pStyle w:val=\"Centered\"/><w:jc w:val=\"right\"/></w:pPr>" +
+            "<w:r><w:t>text</w:t></w:r></w:p>";
+
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            paragraph,
+            DocxTestPackage.Style("Centered", "<w:pPr><w:jc w:val=\"center\"/></w:pPr>"));
+
+        Assert.Equal(TextAlignment.Right, Assert.Single(result.Document.Paragraphs).Style.Alignment);
+    }
+
+    [Fact]
+    public void Applies_A_Character_Style_Named_By_RStyle()
+    {
+        string paragraph =
+            "<w:p><w:r><w:rPr><w:rStyle w:val=\"Emphasis\"/></w:rPr><w:t>text</w:t></w:r></w:p>";
+
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            paragraph,
+            DocxTestPackage.Style("Emphasis", "<w:rPr><w:i/></w:rPr>", type: "character"));
+
+        Assert.True(Assert.Single(result.Document.Paragraphs).StyleAt(0).Italic);
+    }
+
+    [Fact]
+    public void A_Character_Style_Overrides_The_Paragraph_Style_And_Yields_To_Direct_Formatting()
+    {
+        string styles =
+            DocxTestPackage.Style("Body", "<w:rPr><w:sz w:val=\"20\"/><w:b/></w:rPr>") +
+            DocxTestPackage.Style("Big", "<w:rPr><w:sz w:val=\"48\"/></w:rPr>", type: "character");
+
+        string paragraph =
+            "<w:p><w:pPr><w:pStyle w:val=\"Body\"/></w:pPr>" +
+            "<w:r><w:rPr><w:rStyle w:val=\"Big\"/></w:rPr><w:t>styled</w:t></w:r>" +
+            "<w:r><w:rPr><w:rStyle w:val=\"Big\"/><w:sz w:val=\"28\"/></w:rPr><w:t>direct</w:t></w:r></w:p>";
+
+        DocumentReadResult result = DocxTestPackage.ReadStyled(paragraph, styles);
+
+        RichTextParagraph read = Assert.Single(result.Document.Paragraphs);
+        Assert.Equal("styleddirect", read.Text);
+        Assert.Equal(24f, read.StyleAt(0).FontSize);
+        Assert.True(read.StyleAt(0).Bold);           // still inherited from the paragraph style
+        Assert.Equal(14f, read.StyleAt(read.Text.IndexOf("direct", StringComparison.Ordinal)).FontSize);
+    }
+
+    [Fact]
+    public void Resolves_Theme_Fonts_Referenced_By_A_Style()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.StyledParagraph("Heading", "heading"),
+            DocxTestPackage.Style("Heading", "<w:rPr><w:rFonts w:asciiTheme=\"majorHAnsi\"/></w:rPr>"),
+            DocxTestPackage.ThemeXml("Century Gothic", "Calibri"));
+
+        Assert.Equal("Century Gothic", Assert.Single(result.Document.Paragraphs).StyleAt(0).FontFamily);
+    }
+
+    [Fact]
+    public void Resolves_The_Minor_Theme_Font_For_Body_Text()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.Paragraph("body"),
+            DocxTestPackage.DocumentDefaults("<w:rPr><w:rFonts w:asciiTheme=\"minorHAnsi\"/></w:rPr>"),
+            DocxTestPackage.ThemeXml("Century Gothic", "Calibri"));
+
+        Assert.Equal("Calibri", Assert.Single(result.Document.Paragraphs).StyleAt(0).FontFamily);
+    }
+
+    [Fact]
+    public void An_Explicit_Font_Name_Wins_Over_A_Theme_Reference()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.StyledParagraph("Heading", "heading"),
+            DocxTestPackage.Style(
+                "Heading",
+                "<w:rPr><w:rFonts w:ascii=\"Georgia\" w:asciiTheme=\"majorHAnsi\"/></w:rPr>"),
+            DocxTestPackage.ThemeXml("Century Gothic", "Calibri"));
+
+        Assert.Equal("Georgia", Assert.Single(result.Document.Paragraphs).StyleAt(0).FontFamily);
+    }
+
+    [Fact]
+    public void Applies_List_Numbering_Declared_By_A_Paragraph_Style()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.StyledParagraph("ListBullet", "item"),
+            DocxTestPackage.Style(
+                "ListBullet",
+                "<w:pPr><w:numPr><w:numId w:val=\"1\"/></w:numPr><w:ind w:left=\"720\"/></w:pPr>"));
+
+        ParagraphStyle style = Assert.Single(result.Document.Paragraphs).Style;
+        Assert.Equal(ListKind.Bullet, style.ListKind);
+        Assert.Equal(2, style.IndentLevel);
+    }
+
+    [Fact]
+    public void A_Zero_NumId_Opts_A_Paragraph_Out_Of_Its_Styles_List()
+    {
+        string paragraph =
+            "<w:p><w:pPr><w:pStyle w:val=\"ListBullet\"/>" +
+            "<w:numPr><w:numId w:val=\"0\"/></w:numPr></w:pPr>" +
+            "<w:r><w:t>not a bullet</w:t></w:r></w:p>";
+
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            paragraph,
+            DocxTestPackage.Style("ListBullet", "<w:pPr><w:numPr><w:numId w:val=\"1\"/></w:numPr></w:pPr>"));
+
+        Assert.Equal(ListKind.None, Assert.Single(result.Document.Paragraphs).Style.ListKind);
+    }
+
+    [Fact]
+    public void Resolves_Styles_For_Paragraphs_Inside_Table_Cells()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.Table([[DocxTestPackage.StyledParagraph("Title", "Elene Bartky")]]),
+            DocxTestPackage.Style("Title", "<w:rPr><w:sz w:val=\"96\"/></w:rPr>"));
+
+        RichTextParagraph paragraph = Assert.Single(result.Document.Paragraphs);
+        Assert.Equal("Elene Bartky", paragraph.Text);
+        Assert.Equal(48f, paragraph.StyleAt(0).FontSize);
+    }
+
+    [Fact]
+    public void Reports_A_Style_Reference_That_Names_An_Undefined_Style()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.StyledParagraph("Missing", "text") +
+            DocxTestPackage.StyledParagraph("Missing", "more"),
+            DocxTestPackage.Style("Present", "<w:rPr><w:b/></w:rPr>"));
+
+        DocumentDiagnostic diagnostic = Assert.Single(
+            result.Diagnostics,
+            candidate => candidate.Code == "docx.styles.unknown");
+
+        Assert.Contains("Missing", diagnostic.Message, StringComparison.Ordinal);
+        Assert.Equal("text", result.Document.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void Cuts_A_Cyclic_BasedOn_Chain_Short()
+    {
+        string styles =
+            DocxTestPackage.Style("A", "<w:rPr><w:b/></w:rPr>", basedOn: "B") +
+            DocxTestPackage.Style("B", "<w:rPr><w:i/></w:rPr>", basedOn: "A");
+
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.StyledParagraph("A", "text"),
+            styles);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "docx.styles.cycle");
+
+        InlineStyle style = Assert.Single(result.Document.Paragraphs).StyleAt(0);
+        Assert.True(style.Bold);
+        Assert.True(style.Italic);
+    }
+
+    /// <summary>A missing style table is one fact about the package, not one note per style reference.</summary>
+    [Fact]
+    public void Reports_A_Missing_Styles_Part_Once()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadBody(
+            DocxTestPackage.StyledParagraph("Title", "text") +
+            DocxTestPackage.StyledParagraph("Subtitle", "more"));
+
+        Assert.Equal("text", result.Document.Paragraphs[0].Text);
+        Assert.Single(result.Diagnostics, diagnostic => diagnostic.Code == "docx.styles.missing");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Code == "docx.styles.unknown");
+    }
+
+    [Fact]
+    public void Reads_An_Unstyled_Document_With_No_Styles_Part_Without_Notes()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadBody(DocxTestPackage.Paragraph("text"));
+
+        Assert.Equal("text", Assert.Single(result.Document.Paragraphs).Text);
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Code.StartsWith("docx.styles", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Reports_The_Resolved_Style_Count_In_The_Read_Summary()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadStyled(
+            DocxTestPackage.Paragraph("text"),
+            DocxTestPackage.Style("A", "<w:rPr><w:b/></w:rPr>") +
+            DocxTestPackage.Style("B", "<w:rPr><w:i/></w:rPr>"));
+
+        DocumentDiagnostic summary = Assert.Single(
+            result.Diagnostics,
+            diagnostic => diagnostic.Code == "docx.read.summary");
+
+        Assert.Contains("2 style(s)", summary.Message, StringComparison.Ordinal);
+    }
+}

--- a/Broiler.Documents/Broiler.Documents.Docx.Tests/DocxTestPackage.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx.Tests/DocxTestPackage.cs
@@ -58,6 +58,59 @@ internal static class DocxTestPackage
         return new DocxDocumentCodec().Read(stream, options);
     }
 
+    /// <summary>
+    /// Reads a package carrying a <c>word/styles.xml</c> — and optionally a
+    /// theme — alongside the body. Both are found by convention; the test
+    /// packages declare no document-level relationships.
+    /// </summary>
+    public static DocumentReadResult ReadStyled(string bodyXml, string stylesInnerXml, string? themeXml = null)
+    {
+        var parts = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["word/styles.xml"] = "<w:styles " + BodyNamespaceDeclarations + ">" + stylesInnerXml + "</w:styles>",
+        };
+
+        if (themeXml is not null)
+            parts["word/theme/theme1.xml"] = themeXml;
+
+        using var stream = new MemoryStream(FromBody(bodyXml, parts), writable: false);
+        return new DocxDocumentCodec().Read(stream);
+    }
+
+    /// <summary>A <c>w:style</c> definition; pass the inner <c>w:pPr</c>/<c>w:rPr</c> as <paramref name="propertiesXml"/>.</summary>
+    public static string Style(
+        string styleId,
+        string propertiesXml,
+        string type = "paragraph",
+        string? basedOn = null,
+        bool isDefault = false) =>
+        "<w:style w:type=\"" + type + "\" w:styleId=\"" + styleId + "\"" +
+        (isDefault ? " w:default=\"1\"" : string.Empty) + ">" +
+        "<w:name w:val=\"" + styleId + "\"/>" +
+        (basedOn is null ? string.Empty : "<w:basedOn w:val=\"" + basedOn + "\"/>") +
+        propertiesXml +
+        "</w:style>";
+
+    /// <summary>A <c>w:docDefaults</c> block wrapping the given run properties.</summary>
+    public static string DocumentDefaults(string runPropertiesXml, string paragraphPropertiesXml = "") =>
+        "<w:docDefaults>" +
+        "<w:rPrDefault>" + runPropertiesXml + "</w:rPrDefault>" +
+        "<w:pPrDefault>" + paragraphPropertiesXml + "</w:pPrDefault>" +
+        "</w:docDefaults>";
+
+    /// <summary>A theme part declaring only the major/minor latin typefaces.</summary>
+    public static string ThemeXml(string majorLatin, string minorLatin) =>
+        "<a:theme xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\" name=\"test\">" +
+        "<a:themeElements><a:fontScheme name=\"test\">" +
+        "<a:majorFont><a:latin typeface=\"" + majorLatin + "\"/></a:majorFont>" +
+        "<a:minorFont><a:latin typeface=\"" + minorLatin + "\"/></a:minorFont>" +
+        "</a:fontScheme></a:themeElements></a:theme>";
+
+    /// <summary>A <c>w:p</c> that names a paragraph style and holds one unformatted run.</summary>
+    public static string StyledParagraph(string styleId, string text) =>
+        "<w:p><w:pPr><w:pStyle w:val=\"" + styleId + "\"/></w:pPr>" +
+        "<w:r><w:t xml:space=\"preserve\">" + Escape(text) + "</w:t></w:r></w:p>";
+
     /// <summary>A <c>w:p</c> holding a single run of <paramref name="text"/>.</summary>
     public static string Paragraph(string text) =>
         "<w:p><w:r><w:t xml:space=\"preserve\">" + Escape(text) + "</w:t></w:r></w:p>";

--- a/Broiler.Documents/Broiler.Documents.Docx.Tests/DocxTestPackage.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx.Tests/DocxTestPackage.cs
@@ -1,0 +1,101 @@
+using System.IO.Compression;
+using System.Text;
+
+namespace Broiler.Documents.Docx.Tests;
+
+/// <summary>
+/// Builds minimal DOCX packages around a hand-written <c>w:body</c> so reader
+/// tests can state the exact WordprocessingML they exercise. Only the parts the
+/// reader needs are written: the content types, the package relationship that
+/// points at the main document, and the parts a test asks for.
+/// </summary>
+internal static class DocxTestPackage
+{
+    public const string BodyNamespaceDeclarations =
+        "xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\" " +
+        "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" " +
+        "xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"";
+
+    /// <summary>Wraps <paramref name="bodyXml"/> in a document part and zips a package around it.</summary>
+    public static byte[] FromBody(string bodyXml, IReadOnlyDictionary<string, string>? extraParts = null)
+    {
+        string documentXml =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+            "<w:document " + BodyNamespaceDeclarations + ">" +
+            "<w:body>" + bodyXml + "</w:body>" +
+            "</w:document>";
+
+        var parts = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["[Content_Types].xml"] =
+                "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">" +
+                "<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>" +
+                "<Override PartName=\"/word/document.xml\" ContentType=\"" +
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml\"/>" +
+                "</Types>",
+            ["_rels/.rels"] =
+                "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
+                "<Relationship Id=\"rId1\" " +
+                "Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" " +
+                "Target=\"word/document.xml\"/>" +
+                "</Relationships>",
+            ["word/document.xml"] = documentXml,
+        };
+
+        if (extraParts is not null)
+        {
+            foreach (KeyValuePair<string, string> part in extraParts)
+                parts[part.Key] = part.Value;
+        }
+
+        return Zip(parts);
+    }
+
+    /// <summary>Reads a package built by <see cref="FromBody"/> through the public codec.</summary>
+    public static DocumentReadResult ReadBody(string bodyXml, DocumentReadOptions? options = null)
+    {
+        using var stream = new MemoryStream(FromBody(bodyXml), writable: false);
+        return new DocxDocumentCodec().Read(stream, options);
+    }
+
+    /// <summary>A <c>w:p</c> holding a single run of <paramref name="text"/>.</summary>
+    public static string Paragraph(string text) =>
+        "<w:p><w:r><w:t xml:space=\"preserve\">" + Escape(text) + "</w:t></w:r></w:p>";
+
+    /// <summary>A table whose rows are given as arrays of cell contents.</summary>
+    public static string Table(params string[][] rows)
+    {
+        var builder = new StringBuilder("<w:tbl><w:tblPr><w:tblW w:w=\"9000\" w:type=\"dxa\"/></w:tblPr><w:tblGrid/>");
+        foreach (string[] row in rows)
+        {
+            builder.Append("<w:tr><w:trPr/>");
+            foreach (string cell in row)
+                builder.Append("<w:tc><w:tcPr/>").Append(cell).Append("</w:tc>");
+            builder.Append("</w:tr>");
+        }
+
+        return builder.Append("</w:tbl>").ToString();
+    }
+
+    private static string Escape(string text) =>
+        text.Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal);
+
+    private static byte[] Zip(IReadOnlyDictionary<string, string> parts)
+    {
+        using var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (KeyValuePair<string, string> part in parts)
+            {
+                ZipArchiveEntry entry = archive.CreateEntry(part.Key, CompressionLevel.NoCompression);
+                using Stream stream = entry.Open();
+                byte[] bytes = Encoding.UTF8.GetBytes(part.Value);
+                stream.Write(bytes, 0, bytes.Length);
+            }
+        }
+
+        return buffer.ToArray();
+    }
+}

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxNamespaces.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxNamespaces.cs
@@ -13,6 +13,9 @@ internal static class DocxNamespaces
     /// <summary>Markup compatibility, used by <c>mc:AlternateContent</c> blocks.</summary>
     public static readonly XNamespace MarkupCompatibility = "http://schemas.openxmlformats.org/markup-compatibility/2006";
 
+    /// <summary>DrawingML, used by the theme part's font scheme.</summary>
+    public static readonly XNamespace Drawing = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
     public const string OfficeDocumentRelationship =
         "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument";
 
@@ -21,6 +24,12 @@ internal static class DocxNamespaces
 
     public const string NumberingRelationship =
         "http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering";
+
+    public const string StylesRelationship =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles";
+
+    public const string ThemeRelationship =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme";
 
     public const string HeaderRelationship =
         "http://schemas.openxmlformats.org/officeDocument/2006/relationships/header";

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxNamespaces.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxNamespaces.cs
@@ -10,6 +10,9 @@ internal static class DocxNamespaces
     public static readonly XNamespace Wordprocessing = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
     public static readonly XNamespace Xml = "http://www.w3.org/XML/1998/namespace";
 
+    /// <summary>Markup compatibility, used by <c>mc:AlternateContent</c> blocks.</summary>
+    public static readonly XNamespace MarkupCompatibility = "http://schemas.openxmlformats.org/markup-compatibility/2006";
+
     public const string OfficeDocumentRelationship =
         "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument";
 
@@ -18,6 +21,12 @@ internal static class DocxNamespaces
 
     public const string NumberingRelationship =
         "http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering";
+
+    public const string HeaderRelationship =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/header";
+
+    public const string FooterRelationship =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer";
 
     public const string DocumentContentType =
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml";

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxPackage.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxPackage.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Broiler.Documents.Docx;
+
+/// <summary>
+/// Open Packaging Conventions plumbing shared by the DOCX parts: locating an
+/// entry, loading it as XML within the read limits, resolving relationship
+/// targets, and normalizing package paths.
+/// </summary>
+internal static class DocxPackage
+{
+    public static ZipArchiveEntry? FindEntry(ZipArchive archive, string path)
+    {
+        string normalized = path.TrimStart('/').Replace('\\', '/');
+        return archive.Entries.FirstOrDefault(entry =>
+            entry.FullName.Replace('\\', '/').Equals(normalized, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public static XDocument? LoadEntryXml(
+        ZipArchiveEntry entry,
+        DocumentLimits limits,
+        List<DocumentDiagnostic> diagnostics,
+        string diagnosticCode)
+    {
+        if (entry.Length > limits.MaxBinBytes)
+        {
+            diagnostics.Add(DocumentDiagnostic.Error(
+                diagnosticCode + ".limit",
+                "A DOCX XML part exceeded MaxBinBytes and was skipped."));
+            return null;
+        }
+
+        try
+        {
+            using Stream stream = entry.Open();
+            return XDocument.Load(stream, LoadOptions.None);
+        }
+        catch (Exception ex) when (ex is XmlException or InvalidDataException)
+        {
+            diagnostics.Add(DocumentDiagnostic.Error(
+                diagnosticCode,
+                "A DOCX XML part could not be parsed: " + ex.GetType().Name + "."));
+            return null;
+        }
+    }
+
+    public static DocxRelationships ReadRelationships(
+        ZipArchive archive,
+        string path,
+        string baseDirectory,
+        DocumentLimits limits,
+        List<DocumentDiagnostic> diagnostics)
+    {
+        ZipArchiveEntry? entry = FindEntry(archive, path);
+        if (entry is null)
+            return DocxRelationships.Empty;
+
+        XDocument? rels = LoadEntryXml(entry, limits, diagnostics, "docx.relationships");
+        if (rels?.Root is null)
+            return DocxRelationships.Empty;
+
+        var relationships = new List<DocxRelationship>();
+        foreach (XElement element in rels.Root.Elements(DocxNamespaces.PackageRelationships + "Relationship"))
+        {
+            string? id = (string?)element.Attribute("Id");
+            string? type = (string?)element.Attribute("Type");
+            string? target = (string?)element.Attribute("Target");
+            if (string.IsNullOrWhiteSpace(id) ||
+                string.IsNullOrWhiteSpace(type) ||
+                string.IsNullOrWhiteSpace(target))
+            {
+                continue;
+            }
+
+            bool external = string.Equals((string?)element.Attribute("TargetMode"), "External", StringComparison.OrdinalIgnoreCase);
+            string resolved = external ? target : NormalizePackagePath(baseDirectory, target);
+            relationships.Add(new DocxRelationship(id, type, resolved, external));
+        }
+
+        return new DocxRelationships(relationships);
+    }
+
+    /// <summary>The path of the relationships part that belongs to <paramref name="partPath"/>.</summary>
+    public static string RelationshipsPartPath(string partPath)
+    {
+        string normalized = partPath.TrimStart('/').Replace('\\', '/');
+        int slash = normalized.LastIndexOf('/');
+        if (slash < 0)
+            return "_rels/" + normalized + ".rels";
+
+        return normalized[..slash] + "/_rels/" + normalized[(slash + 1)..] + ".rels";
+    }
+
+    public static string BasePartDirectory(string partPath)
+    {
+        string normalized = partPath.TrimStart('/').Replace('\\', '/');
+        int slash = normalized.LastIndexOf('/');
+        return slash < 0 ? string.Empty : normalized[..slash];
+    }
+
+    public static string NormalizePackagePath(string baseDirectory, string target)
+    {
+        target = target.Replace('\\', '/');
+        if (target.StartsWith("/", StringComparison.Ordinal))
+            return target.TrimStart('/');
+
+        var parts = new List<string>();
+        if (!string.IsNullOrEmpty(baseDirectory))
+            parts.AddRange(baseDirectory.Split('/', StringSplitOptions.RemoveEmptyEntries));
+
+        foreach (string part in target.Split('/', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (part == ".")
+                continue;
+            if (part == "..")
+            {
+                if (parts.Count > 0)
+                    parts.RemoveAt(parts.Count - 1);
+                continue;
+            }
+
+            parts.Add(part);
+        }
+
+        return string.Join("/", parts);
+    }
+
+    /// <summary>
+    /// Resolves the path of a part referenced by relationship type, falling back
+    /// to the conventional file name beside the main document when the
+    /// relationship is absent.
+    /// </summary>
+    public static string ResolvePartPath(
+        DocxRelationships relationships,
+        string relationshipType,
+        string baseDirectory,
+        string conventionalName)
+    {
+        foreach (DocxRelationship relationship in relationships.All)
+        {
+            if (relationship.Type.Equals(relationshipType, StringComparison.Ordinal) && !relationship.TargetModeExternal)
+                return relationship.Target;
+        }
+
+        return NormalizePackagePath(baseDirectory, conventionalName);
+    }
+}
+
+internal sealed class DocxRelationships
+{
+    private readonly Dictionary<string, DocxRelationship> _byId;
+
+    public DocxRelationships(IEnumerable<DocxRelationship> relationships)
+    {
+        All = relationships.ToArray();
+        _byId = new Dictionary<string, DocxRelationship>(StringComparer.Ordinal);
+        foreach (DocxRelationship relationship in All)
+            _byId[relationship.Id] = relationship;
+    }
+
+    public static DocxRelationships Empty { get; } = new(Array.Empty<DocxRelationship>());
+
+    public IReadOnlyList<DocxRelationship> All { get; }
+
+    public bool TryGet(string id, out DocxRelationship? relationship) =>
+        _byId.TryGetValue(id, out relationship);
+}
+
+internal sealed record DocxRelationship(
+    string Id,
+    string Type,
+    string Target,
+    bool TargetModeExternal);

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxReader.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxReader.cs
@@ -522,6 +522,12 @@ internal static class DocxReader
         style = ApplyOnOff(rPr, "strike", style, static (s, v) => s with { Strikethrough = v });
         style = ApplyOnOff(rPr, "dstrike", style, static (s, v) => s with { Strikethrough = v });
 
+        // w:smallCaps first: when a run turns both on, Word draws all caps. An
+        // explicit "off" clears only the kind it names, so a run can drop the
+        // small caps its style applied without disturbing anything else.
+        style = ApplyCapitalization(rPr, "smallCaps", TextCapitalization.SmallCaps, style);
+        style = ApplyCapitalization(rPr, "caps", TextCapitalization.AllCaps, style);
+
         XElement? underline = rPr.Element(DocxNamespaces.Wordprocessing + "u");
         if (underline is not null)
         {
@@ -605,6 +611,25 @@ internal static class DocxReader
         return uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
             uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) ||
             uri.Scheme.Equals(Uri.UriSchemeMailto, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static InlineStyle ApplyCapitalization(
+        XElement rPr,
+        string localName,
+        TextCapitalization kind,
+        InlineStyle style)
+    {
+        XElement? element = rPr.Element(DocxNamespaces.Wordprocessing + localName);
+        if (element is null)
+            return style;
+
+        if (ReadOnOff(element))
+            return style with { Capitalization = kind };
+
+        // Turning one kind off leaves the other alone.
+        return style.Capitalization == kind
+            ? style with { Capitalization = TextCapitalization.None }
+            : style;
     }
 
     private static InlineStyle ApplyOnOff(

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxReader.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxReader.cs
@@ -24,7 +24,7 @@ internal static class DocxReader
             using var stream = new MemoryStream(bytes, writable: false);
             using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
             string documentPart = FindMainDocumentPart(archive, options.Limits, diagnostics) ?? "word/document.xml";
-            ZipArchiveEntry? documentEntry = FindEntry(archive, documentPart);
+            ZipArchiveEntry? documentEntry = DocxPackage.FindEntry(archive, documentPart);
             if (documentEntry is null)
             {
                 diagnostics.Add(DocumentDiagnostic.Error(
@@ -33,20 +33,27 @@ internal static class DocxReader
                 return new DocumentReadResult(RichTextDocument.Empty, diagnostics);
             }
 
-            XDocument? documentXml = LoadEntryXml(documentEntry, options.Limits, diagnostics, "docx.document.xml");
+            XDocument? documentXml = DocxPackage.LoadEntryXml(documentEntry, options.Limits, diagnostics, "docx.document.xml");
             if (documentXml is null)
                 return new DocumentReadResult(RichTextDocument.Empty, diagnostics);
 
-            DocxRelationships documentRelationships = ReadRelationships(
+            string baseDirectory = DocxPackage.BasePartDirectory(documentPart);
+            DocxRelationships documentRelationships = DocxPackage.ReadRelationships(
                 archive,
-                RelationshipsPartPath(documentPart),
-                BasePartDirectory(documentPart),
+                DocxPackage.RelationshipsPartPath(documentPart),
+                baseDirectory,
                 options.Limits,
                 diagnostics);
             DocxNumbering numbering = DocxNumbering.Load(
                 archive,
                 documentRelationships,
-                BasePartDirectory(documentPart),
+                baseDirectory,
+                options.Limits,
+                diagnostics);
+            DocxStyles styles = DocxStyles.Load(
+                archive,
+                documentRelationships,
+                baseDirectory,
                 options.Limits,
                 diagnostics);
 
@@ -54,6 +61,7 @@ internal static class DocxReader
                 documentXml,
                 documentRelationships,
                 numbering,
+                styles,
                 options.Limits,
                 diagnostics);
             ReportUnreadParts(documentRelationships, diagnostics);
@@ -79,6 +87,7 @@ internal static class DocxReader
         XDocument documentXml,
         DocxRelationships relationships,
         DocxNumbering numbering,
+        DocxStyles styles,
         DocumentLimits limits,
         List<DocumentDiagnostic> diagnostics)
     {
@@ -92,10 +101,18 @@ internal static class DocxReader
         }
 
         var builder = new DocxDocumentBuilder(limits, diagnostics);
-        ReadBlockContent(body.Elements(), relationships, numbering, builder, depth: 0);
-        builder.ReportReadSummary(body.Elements().Any(IsContentBlock));
+        var context = new DocxReadContext(relationships, numbering, styles, builder);
+        ReadBlockContent(body.Elements(), context, depth: 0);
+        builder.ReportReadSummary(body.Elements().Any(IsContentBlock), styles.Count);
         return builder.Build();
     }
+
+    /// <summary>Everything a read needs to turn one element into document content.</summary>
+    private sealed record DocxReadContext(
+        DocxRelationships Relationships,
+        DocxNumbering Numbering,
+        DocxStyles Styles,
+        DocxDocumentBuilder Builder);
 
     /// <summary>
     /// Walks WordprocessingML block-level content — the <c>EG_BlockLevelElts</c>
@@ -106,11 +123,10 @@ internal static class DocxReader
     /// </summary>
     private static void ReadBlockContent(
         IEnumerable<XElement> elements,
-        DocxRelationships relationships,
-        DocxNumbering numbering,
-        DocxDocumentBuilder builder,
+        DocxReadContext context,
         int depth)
     {
+        DocxDocumentBuilder builder = context.Builder;
         if (depth > builder.Limits.MaxGroupDepth)
         {
             builder.AddDiagnosticOnce(
@@ -125,13 +141,13 @@ internal static class DocxReader
 
             if (name == DocxNamespaces.Wordprocessing + "p")
             {
-                ReadParagraph(element, relationships, numbering, builder);
+                ReadParagraph(element, context);
                 continue;
             }
 
             if (name == DocxNamespaces.Wordprocessing + "tbl")
             {
-                ReadTable(element, relationships, numbering, builder, depth + 1);
+                ReadTable(element, context, depth + 1);
                 continue;
             }
 
@@ -141,7 +157,7 @@ internal static class DocxReader
             {
                 XElement? content = element.Element(DocxNamespaces.Wordprocessing + "sdtContent");
                 if (content is not null)
-                    ReadBlockContent(content.Elements(), relationships, numbering, builder, depth + 1);
+                    ReadBlockContent(content.Elements(), context, depth + 1);
                 continue;
             }
 
@@ -152,7 +168,7 @@ internal static class DocxReader
                 name == DocxNamespaces.Wordprocessing + "customXml" ||
                 name == DocxNamespaces.Wordprocessing + "smartTag")
             {
-                ReadBlockContent(element.Elements(), relationships, numbering, builder, depth + 1);
+                ReadBlockContent(element.Elements(), context, depth + 1);
                 continue;
             }
 
@@ -165,7 +181,7 @@ internal static class DocxReader
 
             if (name == DocxNamespaces.MarkupCompatibility + "AlternateContent")
             {
-                ReadAlternateContent(element, relationships, numbering, builder, depth + 1);
+                ReadAlternateContent(element, context, depth + 1);
                 continue;
             }
 
@@ -182,18 +198,13 @@ internal static class DocxReader
     /// alternative would be losing every word the table holds — which is exactly
     /// what a CV or letterhead template puts there.
     /// </summary>
-    private static void ReadTable(
-        XElement table,
-        DocxRelationships relationships,
-        DocxNumbering numbering,
-        DocxDocumentBuilder builder,
-        int depth)
+    private static void ReadTable(XElement table, DocxReadContext context, int depth)
     {
-        builder.NoteTable();
+        context.Builder.NoteTable();
         foreach (XElement row in EnumerateTableChildren(table, "tr"))
         {
             foreach (XElement cell in EnumerateTableChildren(row, "tc"))
-                ReadBlockContent(cell.Elements(), relationships, numbering, builder, depth + 1);
+                ReadBlockContent(cell.Elements(), context, depth + 1);
         }
     }
 
@@ -237,18 +248,13 @@ internal static class DocxReader
     /// falling back to <c>mc:Fallback</c>. Only one branch may contribute, or the
     /// same content would be read twice.
     /// </summary>
-    private static void ReadAlternateContent(
-        XElement alternate,
-        DocxRelationships relationships,
-        DocxNumbering numbering,
-        DocxDocumentBuilder builder,
-        int depth)
+    private static void ReadAlternateContent(XElement alternate, DocxReadContext context, int depth)
     {
         XElement? branch =
             alternate.Element(DocxNamespaces.MarkupCompatibility + "Choice") ??
             alternate.Element(DocxNamespaces.MarkupCompatibility + "Fallback");
         if (branch is not null)
-            ReadBlockContent(branch.Elements(), relationships, numbering, builder, depth + 1);
+            ReadBlockContent(branch.Elements(), context, depth + 1);
     }
 
     /// <summary>Block-level elements that carry no text and are skipped silently.</summary>
@@ -289,22 +295,33 @@ internal static class DocxReader
         }
     }
 
-    private static void ReadParagraph(
-        XElement paragraph,
-        DocxRelationships relationships,
-        DocxNumbering numbering,
-        DocxDocumentBuilder builder)
+    private static void ReadParagraph(XElement paragraph, DocxReadContext context)
     {
-        ParagraphStyle paragraphStyle = ReadParagraphStyle(paragraph.Element(DocxNamespaces.Wordprocessing + "pPr"), numbering);
-        builder.StartParagraph(paragraphStyle);
-        ReadParagraphChildren(paragraph.Elements(), relationships, builder, InlineStyle.Default);
-        builder.FinishParagraph();
+        XElement? pPr = paragraph.Element(DocxNamespaces.Wordprocessing + "pPr");
+        string? paragraphStyleId = WordValue(pPr?.Element(DocxNamespaces.Wordprocessing + "pStyle"));
+
+        ParagraphStyle paragraphStyle = ReadParagraphStyle(pPr, paragraphStyleId, context);
+        context.Builder.StartParagraph(paragraphStyle);
+        ReadParagraphChildren(paragraph.Elements(), context, ReadInheritedRunStyle(paragraphStyleId, context));
+        context.Builder.FinishParagraph();
+    }
+
+    /// <summary>
+    /// The character formatting a run inherits before its own <c>w:rPr</c>:
+    /// document defaults followed by the paragraph style chain's run properties.
+    /// </summary>
+    private static InlineStyle ReadInheritedRunStyle(string? paragraphStyleId, DocxReadContext context)
+    {
+        InlineStyle style = InlineStyle.Default;
+        foreach (XElement rPr in context.Styles.RunPropertiesForParagraph(paragraphStyleId))
+            style = ApplyRunProperties(rPr, style, context.Styles.Theme);
+
+        return style;
     }
 
     private static void ReadParagraphChildren(
         IEnumerable<XElement> elements,
-        DocxRelationships relationships,
-        DocxDocumentBuilder builder,
+        DocxReadContext context,
         InlineStyle style)
     {
         foreach (XElement element in elements)
@@ -314,20 +331,20 @@ internal static class DocxReader
 
             if (element.Name == DocxNamespaces.Wordprocessing + "r")
             {
-                ReadRun(element, relationships, builder, style);
+                ReadRun(element, context, style);
                 continue;
             }
 
             if (element.Name == DocxNamespaces.Wordprocessing + "hyperlink")
             {
-                InlineStyle hyperlinkStyle = ApplyHyperlinkStyle(element, relationships, style, builder);
-                ReadParagraphChildren(element.Elements(), relationships, builder, hyperlinkStyle);
+                InlineStyle hyperlinkStyle = ApplyHyperlinkStyle(element, context.Relationships, style, context.Builder);
+                ReadParagraphChildren(element.Elements(), context, hyperlinkStyle);
                 continue;
             }
 
             if (element.Name == DocxNamespaces.Wordprocessing + "del")
             {
-                builder.AddDiagnosticOnce("docx.revision.delete", "Deleted revision content was skipped.");
+                context.Builder.AddDiagnosticOnce("docx.revision.delete", "Deleted revision content was skipped.");
                 continue;
             }
 
@@ -335,22 +352,28 @@ internal static class DocxReader
             {
                 XElement? content = element.Element(DocxNamespaces.Wordprocessing + "sdtContent");
                 if (content is not null)
-                    ReadParagraphChildren(content.Elements(), relationships, builder, style);
+                    ReadParagraphChildren(content.Elements(), context, style);
                 continue;
             }
 
             if (element.HasElements)
-                ReadParagraphChildren(element.Elements(), relationships, builder, style);
+                ReadParagraphChildren(element.Elements(), context, style);
         }
     }
 
-    private static void ReadRun(
-        XElement run,
-        DocxRelationships relationships,
-        DocxDocumentBuilder builder,
-        InlineStyle inherited)
+    private static void ReadRun(XElement run, DocxReadContext context, InlineStyle inherited)
     {
-        InlineStyle style = ReadRunStyle(run.Element(DocxNamespaces.Wordprocessing + "rPr"), inherited);
+        DocxDocumentBuilder builder = context.Builder;
+        XElement? rPr = run.Element(DocxNamespaces.Wordprocessing + "rPr");
+
+        // ECMA-376 §17.7.2: the character style named by w:rStyle applies over
+        // the paragraph's inherited formatting, and the run's own w:rPr over that.
+        InlineStyle style = inherited;
+        string? characterStyleId = WordValue(rPr?.Element(DocxNamespaces.Wordprocessing + "rStyle"));
+        foreach (XElement styleRunProperties in context.Styles.RunPropertiesForCharacterStyle(characterStyleId))
+            style = ApplyRunProperties(styleRunProperties, style, context.Styles.Theme);
+
+        style = ApplyRunProperties(rPr, style, context.Styles.Theme);
         foreach (XElement child in run.Elements())
         {
             if (child.Name == DocxNamespaces.Wordprocessing + "rPr")
@@ -402,9 +425,29 @@ internal static class DocxReader
         }
     }
 
-    private static ParagraphStyle ReadParagraphStyle(XElement? pPr, DocxNumbering numbering)
+    /// <summary>
+    /// Resolves a paragraph's style: document defaults, then the
+    /// <c>w:pStyle</c> chain from its root down, then the paragraph's own
+    /// <c>w:pPr</c>. A template paragraph often carries no direct formatting at
+    /// all, so skipping the chain leaves every heading looking like body text.
+    /// </summary>
+    private static ParagraphStyle ReadParagraphStyle(
+        XElement? pPr,
+        string? paragraphStyleId,
+        DocxReadContext context)
     {
         ParagraphStyle style = ParagraphStyle.Default;
+        foreach (XElement styleParagraphProperties in context.Styles.ParagraphProperties(paragraphStyleId))
+            style = ApplyParagraphProperties(styleParagraphProperties, context.Numbering, style);
+
+        return ApplyParagraphProperties(pPr, context.Numbering, style);
+    }
+
+    private static ParagraphStyle ApplyParagraphProperties(
+        XElement? pPr,
+        DocxNumbering numbering,
+        ParagraphStyle style)
+    {
         if (pPr is null)
             return style;
 
@@ -441,21 +484,35 @@ internal static class DocxReader
         XElement? numPr = pPr.Element(DocxNamespaces.Wordprocessing + "numPr");
         if (numPr is not null)
         {
-            int indent = style.IndentLevel;
-            if (TryReadInt(numPr.Element(DocxNamespaces.Wordprocessing + "ilvl")?.Attribute(DocxNamespaces.Wordprocessing + "val"), out int ilvl))
-                indent = Math.Max(indent, ilvl + 1);
+            bool hasNumId = TryReadInt(
+                numPr.Element(DocxNamespaces.Wordprocessing + "numId")?.Attribute(DocxNamespaces.Wordprocessing + "val"),
+                out int numId);
 
-            ListKind kind = ListKind.Bullet;
-            if (TryReadInt(numPr.Element(DocxNamespaces.Wordprocessing + "numId")?.Attribute(DocxNamespaces.Wordprocessing + "val"), out int numId))
-                kind = numbering.KindFor(numId);
+            // numId 0 is how a paragraph opts out of a list its style applied.
+            if (hasNumId && numId == 0)
+            {
+                style = style with { ListKind = ListKind.None };
+            }
+            else
+            {
+                int indent = style.IndentLevel;
+                if (TryReadInt(numPr.Element(DocxNamespaces.Wordprocessing + "ilvl")?.Attribute(DocxNamespaces.Wordprocessing + "val"), out int ilvl))
+                    indent = Math.Max(indent, ilvl + 1);
 
-            style = style with { ListKind = kind, IndentLevel = Math.Max(1, indent) };
+                ListKind kind = hasNumId ? numbering.KindFor(numId) : ListKind.Bullet;
+                style = style with { ListKind = kind, IndentLevel = Math.Max(1, indent) };
+            }
         }
 
         return style;
     }
 
-    private static InlineStyle ReadRunStyle(XElement? rPr, InlineStyle style)
+    /// <summary>
+    /// Applies one <c>w:rPr</c> over an inherited style. Called once per link in
+    /// the style chain and finally for the run's own properties, so only the
+    /// elements actually present override what came before.
+    /// </summary>
+    private static InlineStyle ApplyRunProperties(XElement? rPr, InlineStyle style, DocxTheme theme)
     {
         if (rPr is null)
             return style;
@@ -477,7 +534,11 @@ internal static class DocxReader
             (string?)fonts?.Attribute(DocxNamespaces.Wordprocessing + "ascii") ??
             (string?)fonts?.Attribute(DocxNamespaces.Wordprocessing + "hAnsi") ??
             (string?)fonts?.Attribute(DocxNamespaces.Wordprocessing + "cs") ??
-            (string?)fonts?.Attribute(DocxNamespaces.Wordprocessing + "eastAsia");
+            (string?)fonts?.Attribute(DocxNamespaces.Wordprocessing + "eastAsia") ??
+            // Styles usually name fonts through the theme rather than directly.
+            theme.Resolve((string?)fonts?.Attribute(DocxNamespaces.Wordprocessing + "asciiTheme")) ??
+            theme.Resolve((string?)fonts?.Attribute(DocxNamespaces.Wordprocessing + "hAnsiTheme")) ??
+            theme.Resolve((string?)fonts?.Attribute(DocxNamespaces.Wordprocessing + "cstheme"));
         if (!string.IsNullOrWhiteSpace(fontFamily))
             style = style with { FontFamily = fontFamily };
 
@@ -570,7 +631,7 @@ internal static class DocxReader
         DocumentLimits limits,
         List<DocumentDiagnostic> diagnostics)
     {
-        DocxRelationships packageRelationships = ReadRelationships(
+        DocxRelationships packageRelationships = DocxPackage.ReadRelationships(
             archive,
             "_rels/.rels",
             string.Empty,
@@ -583,121 +644,6 @@ internal static class DocxReader
         }
 
         return null;
-    }
-
-    private static DocxRelationships ReadRelationships(
-        ZipArchive archive,
-        string path,
-        string baseDirectory,
-        DocumentLimits limits,
-        List<DocumentDiagnostic> diagnostics)
-    {
-        ZipArchiveEntry? entry = FindEntry(archive, path);
-        if (entry is null)
-            return DocxRelationships.Empty;
-
-        XDocument? rels = LoadEntryXml(entry, limits, diagnostics, "docx.relationships");
-        if (rels?.Root is null)
-            return DocxRelationships.Empty;
-
-        var relationships = new List<DocxRelationship>();
-        foreach (XElement element in rels.Root.Elements(DocxNamespaces.PackageRelationships + "Relationship"))
-        {
-            string? id = (string?)element.Attribute("Id");
-            string? type = (string?)element.Attribute("Type");
-            string? target = (string?)element.Attribute("Target");
-            if (string.IsNullOrWhiteSpace(id) ||
-                string.IsNullOrWhiteSpace(type) ||
-                string.IsNullOrWhiteSpace(target))
-            {
-                continue;
-            }
-
-            bool external = string.Equals((string?)element.Attribute("TargetMode"), "External", StringComparison.OrdinalIgnoreCase);
-            string resolved = external ? target : NormalizePackagePath(baseDirectory, target);
-            relationships.Add(new DocxRelationship(id, type, resolved, external));
-        }
-
-        return new DocxRelationships(relationships);
-    }
-
-    private static XDocument? LoadEntryXml(
-        ZipArchiveEntry entry,
-        DocumentLimits limits,
-        List<DocumentDiagnostic> diagnostics,
-        string diagnosticCode)
-    {
-        if (entry.Length > limits.MaxBinBytes)
-        {
-            diagnostics.Add(DocumentDiagnostic.Error(
-                diagnosticCode + ".limit",
-                "A DOCX XML part exceeded MaxBinBytes and was skipped."));
-            return null;
-        }
-
-        try
-        {
-            using Stream stream = entry.Open();
-            return XDocument.Load(stream, LoadOptions.None);
-        }
-        catch (Exception ex) when (ex is XmlException or InvalidDataException)
-        {
-            diagnostics.Add(DocumentDiagnostic.Error(
-                diagnosticCode,
-                "A DOCX XML part could not be parsed: " + ex.GetType().Name + "."));
-            return null;
-        }
-    }
-
-    private static ZipArchiveEntry? FindEntry(ZipArchive archive, string path)
-    {
-        string normalized = path.TrimStart('/').Replace('\\', '/');
-        return archive.Entries.FirstOrDefault(entry =>
-            entry.FullName.Replace('\\', '/').Equals(normalized, StringComparison.OrdinalIgnoreCase));
-    }
-
-    private static string RelationshipsPartPath(string partPath)
-    {
-        string normalized = partPath.TrimStart('/').Replace('\\', '/');
-        int slash = normalized.LastIndexOf('/');
-        if (slash < 0)
-            return "_rels/" + normalized + ".rels";
-
-        return normalized[..slash] + "/_rels/" + normalized[(slash + 1)..] + ".rels";
-    }
-
-    private static string BasePartDirectory(string partPath)
-    {
-        string normalized = partPath.TrimStart('/').Replace('\\', '/');
-        int slash = normalized.LastIndexOf('/');
-        return slash < 0 ? string.Empty : normalized[..slash];
-    }
-
-    private static string NormalizePackagePath(string baseDirectory, string target)
-    {
-        target = target.Replace('\\', '/');
-        if (target.StartsWith("/", StringComparison.Ordinal))
-            return target.TrimStart('/');
-
-        var parts = new List<string>();
-        if (!string.IsNullOrEmpty(baseDirectory))
-            parts.AddRange(baseDirectory.Split('/', StringSplitOptions.RemoveEmptyEntries));
-
-        foreach (string part in target.Split('/', StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (part == ".")
-                continue;
-            if (part == "..")
-            {
-                if (parts.Count > 0)
-                    parts.RemoveAt(parts.Count - 1);
-                continue;
-            }
-
-            parts.Add(part);
-        }
-
-        return string.Join("/", parts);
     }
 
     private static string? WordValue(XElement? element) =>
@@ -805,7 +751,7 @@ internal static class DocxReader
         /// a body with block content that yields no paragraphs is a reader bug,
         /// not an empty file, and it should say so rather than open blank.
         /// </summary>
-        public void ReportReadSummary(bool bodyHadContentBlocks)
+        public void ReportReadSummary(bool bodyHadContentBlocks, int styleCount)
         {
             if (_paragraphs.Count == 0 && bodyHadContentBlocks)
             {
@@ -818,7 +764,8 @@ internal static class DocxReader
                 "docx.read.summary",
                 "DOCX read produced " + _paragraphs.Count.ToString(CultureInfo.InvariantCulture) +
                 " paragraph(s), flattened " + _tableCount.ToString(CultureInfo.InvariantCulture) +
-                " table(s), and skipped " + _unsupportedBlockCount.ToString(CultureInfo.InvariantCulture) +
+                " table(s), loaded " + styleCount.ToString(CultureInfo.InvariantCulture) +
+                " style(s), and skipped " + _unsupportedBlockCount.ToString(CultureInfo.InvariantCulture) +
                 " unsupported block(s)."));
         }
 
@@ -888,30 +835,6 @@ internal static class DocxReader
         private readonly record struct Segment(string Text, InlineStyle Style);
     }
 
-    private sealed class DocxRelationships
-    {
-        private readonly Dictionary<string, DocxRelationship> _byId;
-
-        public DocxRelationships(IEnumerable<DocxRelationship> relationships)
-        {
-            All = relationships.ToArray();
-            _byId = All.ToDictionary(relationship => relationship.Id, StringComparer.Ordinal);
-        }
-
-        public static DocxRelationships Empty { get; } = new(Array.Empty<DocxRelationship>());
-
-        public IReadOnlyList<DocxRelationship> All { get; }
-
-        public bool TryGet(string id, out DocxRelationship? relationship) =>
-            _byId.TryGetValue(id, out relationship);
-    }
-
-    private sealed record DocxRelationship(
-        string Id,
-        string Type,
-        string Target,
-        bool TargetModeExternal);
-
     private sealed class DocxNumbering
     {
         private readonly Dictionary<int, ListKind> _numKinds;
@@ -927,16 +850,17 @@ internal static class DocxReader
             DocumentLimits limits,
             List<DocumentDiagnostic> diagnostics)
         {
-            string? numberingPath = documentRelationships.All
-                .FirstOrDefault(relationship => relationship.Type.Equals(DocxNamespaces.NumberingRelationship, StringComparison.Ordinal))
-                ?.Target;
-            numberingPath ??= NormalizePackagePath(documentBaseDirectory, "numbering.xml");
+            string numberingPath = DocxPackage.ResolvePartPath(
+                documentRelationships,
+                DocxNamespaces.NumberingRelationship,
+                documentBaseDirectory,
+                "numbering.xml");
 
-            ZipArchiveEntry? entry = FindEntry(archive, numberingPath);
+            ZipArchiveEntry? entry = DocxPackage.FindEntry(archive, numberingPath);
             if (entry is null)
                 return Empty;
 
-            XDocument? xml = LoadEntryXml(entry, limits, diagnostics, "docx.numbering");
+            XDocument? xml = DocxPackage.LoadEntryXml(entry, limits, diagnostics, "docx.numbering");
             if (xml?.Root is null)
                 return Empty;
 

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxReader.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxReader.cs
@@ -56,6 +56,7 @@ internal static class DocxReader
                 numbering,
                 options.Limits,
                 diagnostics);
+            ReportUnreadParts(documentRelationships, diagnostics);
             return new DocumentReadResult(document, diagnostics);
         }
         catch (InvalidDataException ex)
@@ -91,10 +92,201 @@ internal static class DocxReader
         }
 
         var builder = new DocxDocumentBuilder(limits, diagnostics);
-        foreach (XElement paragraph in body.Elements(DocxNamespaces.Wordprocessing + "p"))
-            ReadParagraph(paragraph, relationships, numbering, builder);
-
+        ReadBlockContent(body.Elements(), relationships, numbering, builder, depth: 0);
+        builder.ReportReadSummary(body.Elements().Any(IsContentBlock));
         return builder.Build();
+    }
+
+    /// <summary>
+    /// Walks WordprocessingML block-level content — the <c>EG_BlockLevelElts</c>
+    /// group. Paragraphs are the only shape <see cref="RichTextDocument"/> can
+    /// represent, so tables and other block containers are flattened into their
+    /// paragraphs in document order rather than dropped. Anything genuinely not
+    /// understood raises a diagnostic instead of vanishing.
+    /// </summary>
+    private static void ReadBlockContent(
+        IEnumerable<XElement> elements,
+        DocxRelationships relationships,
+        DocxNumbering numbering,
+        DocxDocumentBuilder builder,
+        int depth)
+    {
+        if (depth > builder.Limits.MaxGroupDepth)
+        {
+            builder.AddDiagnosticOnce(
+                "docx.limit.depth",
+                "DOCX block nesting exceeded MaxGroupDepth; the deepest content was skipped.");
+            return;
+        }
+
+        foreach (XElement element in elements)
+        {
+            XName name = element.Name;
+
+            if (name == DocxNamespaces.Wordprocessing + "p")
+            {
+                ReadParagraph(element, relationships, numbering, builder);
+                continue;
+            }
+
+            if (name == DocxNamespaces.Wordprocessing + "tbl")
+            {
+                ReadTable(element, relationships, numbering, builder, depth + 1);
+                continue;
+            }
+
+            // A block-level structured document tag (content control) wraps real
+            // block content in w:sdtContent; the surrounding w:sdtPr is metadata.
+            if (name == DocxNamespaces.Wordprocessing + "sdt")
+            {
+                XElement? content = element.Element(DocxNamespaces.Wordprocessing + "sdtContent");
+                if (content is not null)
+                    ReadBlockContent(content.Elements(), relationships, numbering, builder, depth + 1);
+                continue;
+            }
+
+            // Accepted revisions and move destinations are live content; the
+            // deleted/moved-from side is not.
+            if (name == DocxNamespaces.Wordprocessing + "ins" ||
+                name == DocxNamespaces.Wordprocessing + "moveTo" ||
+                name == DocxNamespaces.Wordprocessing + "customXml" ||
+                name == DocxNamespaces.Wordprocessing + "smartTag")
+            {
+                ReadBlockContent(element.Elements(), relationships, numbering, builder, depth + 1);
+                continue;
+            }
+
+            if (name == DocxNamespaces.Wordprocessing + "del" ||
+                name == DocxNamespaces.Wordprocessing + "moveFrom")
+            {
+                builder.AddDiagnosticOnce("docx.revision.delete", "Deleted revision content was skipped.");
+                continue;
+            }
+
+            if (name == DocxNamespaces.MarkupCompatibility + "AlternateContent")
+            {
+                ReadAlternateContent(element, relationships, numbering, builder, depth + 1);
+                continue;
+            }
+
+            if (IsIgnorableBlock(name))
+                continue;
+
+            builder.AddUnsupportedBlock(name);
+        }
+    }
+
+    /// <summary>
+    /// Flattens a table into the paragraphs of its cells, read left-to-right and
+    /// top-to-bottom. <see cref="RichTextDocument"/> has no table shape, so the
+    /// alternative would be losing every word the table holds — which is exactly
+    /// what a CV or letterhead template puts there.
+    /// </summary>
+    private static void ReadTable(
+        XElement table,
+        DocxRelationships relationships,
+        DocxNumbering numbering,
+        DocxDocumentBuilder builder,
+        int depth)
+    {
+        builder.NoteTable();
+        foreach (XElement row in EnumerateTableChildren(table, "tr"))
+        {
+            foreach (XElement cell in EnumerateTableChildren(row, "tc"))
+                ReadBlockContent(cell.Elements(), relationships, numbering, builder, depth + 1);
+        }
+    }
+
+    /// <summary>
+    /// Yields the <paramref name="localName"/> children of a table or row,
+    /// looking through the content controls and revision markers Word may wrap
+    /// rows and cells in.
+    /// </summary>
+    private static IEnumerable<XElement> EnumerateTableChildren(XElement parent, string localName)
+    {
+        foreach (XElement child in parent.Elements())
+        {
+            if (child.Name == DocxNamespaces.Wordprocessing + localName)
+            {
+                yield return child;
+                continue;
+            }
+
+            if (child.Name == DocxNamespaces.Wordprocessing + "sdt")
+            {
+                XElement? content = child.Element(DocxNamespaces.Wordprocessing + "sdtContent");
+                if (content is null)
+                    continue;
+
+                foreach (XElement nested in EnumerateTableChildren(content, localName))
+                    yield return nested;
+                continue;
+            }
+
+            if (child.Name == DocxNamespaces.Wordprocessing + "ins" ||
+                child.Name == DocxNamespaces.Wordprocessing + "customXml")
+            {
+                foreach (XElement nested in EnumerateTableChildren(child, localName))
+                    yield return nested;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads an <c>mc:AlternateContent</c> block: the first <c>mc:Choice</c>,
+    /// falling back to <c>mc:Fallback</c>. Only one branch may contribute, or the
+    /// same content would be read twice.
+    /// </summary>
+    private static void ReadAlternateContent(
+        XElement alternate,
+        DocxRelationships relationships,
+        DocxNumbering numbering,
+        DocxDocumentBuilder builder,
+        int depth)
+    {
+        XElement? branch =
+            alternate.Element(DocxNamespaces.MarkupCompatibility + "Choice") ??
+            alternate.Element(DocxNamespaces.MarkupCompatibility + "Fallback");
+        if (branch is not null)
+            ReadBlockContent(branch.Elements(), relationships, numbering, builder, depth + 1);
+    }
+
+    /// <summary>Block-level elements that carry no text and are skipped silently.</summary>
+    private static bool IsIgnorableBlock(XName name)
+    {
+        if (name.Namespace != DocxNamespaces.Wordprocessing)
+            return false;
+
+        return name.LocalName is
+            "sectPr" or
+            "tblPr" or "tblGrid" or "trPr" or "tcPr" or "sdtPr" or "sdtEndPr" or
+            "bookmarkStart" or "bookmarkEnd" or
+            "commentRangeStart" or "commentRangeEnd" or
+            "proofErr" or "permStart" or "permEnd";
+    }
+
+    /// <summary>True when a body child could contribute text, used to tell an empty document from a dropped one.</summary>
+    private static bool IsContentBlock(XElement element) =>
+        element.Name != DocxNamespaces.Wordprocessing + "sectPr";
+
+    private static void ReportUnreadParts(
+        DocxRelationships relationships,
+        List<DocumentDiagnostic> diagnostics)
+    {
+        bool hasHeader = false;
+        bool hasFooter = false;
+        foreach (DocxRelationship relationship in relationships.All)
+        {
+            hasHeader |= relationship.Type.Equals(DocxNamespaces.HeaderRelationship, StringComparison.Ordinal);
+            hasFooter |= relationship.Type.Equals(DocxNamespaces.FooterRelationship, StringComparison.Ordinal);
+        }
+
+        if (hasHeader || hasFooter)
+        {
+            diagnostics.Add(DocumentDiagnostic.Info(
+                "docx.part.headerfooter",
+                "DOCX headers and footers are not part of the document body and were not imported."));
+        }
     }
 
     private static void ReadParagraph(
@@ -575,11 +767,59 @@ internal static class DocxReader
         private readonly List<Segment> _segments = [];
         private readonly HashSet<string> _diagnosticOnce = new(StringComparer.Ordinal);
         private ParagraphStyle _paragraphStyle = ParagraphStyle.Default;
+        private int _tableCount;
+        private int _unsupportedBlockCount;
 
         public DocxDocumentBuilder(DocumentLimits limits, List<DocumentDiagnostic> diagnostics)
         {
             _limits = limits;
             _diagnostics = diagnostics;
+        }
+
+        public DocumentLimits Limits => _limits;
+
+        public void NoteTable()
+        {
+            _tableCount++;
+            AddDiagnosticOnce(
+                "docx.table.flattened",
+                "DOCX tables were flattened into their cell paragraphs, in row order.");
+        }
+
+        /// <summary>
+        /// Records a block-level element the reader does not understand. Keyed by
+        /// element name so each distinct construct is reported once — the name is
+        /// markup structure, never document text (ADR 0004 privacy rule).
+        /// </summary>
+        public void AddUnsupportedBlock(XName name)
+        {
+            _unsupportedBlockCount++;
+            AddDiagnosticOnce(
+                "docx.block.unsupported:" + name.LocalName,
+                "docx.block.unsupported",
+                "An unsupported DOCX block-level element was skipped: " + name.LocalName + ".");
+        }
+
+        /// <summary>
+        /// Emits the read summary. The counts make a silent content loss visible:
+        /// a body with block content that yields no paragraphs is a reader bug,
+        /// not an empty file, and it should say so rather than open blank.
+        /// </summary>
+        public void ReportReadSummary(bool bodyHadContentBlocks)
+        {
+            if (_paragraphs.Count == 0 && bodyHadContentBlocks)
+            {
+                _diagnostics.Add(DocumentDiagnostic.Warning(
+                    "docx.document.empty",
+                    "DOCX body contained block-level content but produced no paragraphs."));
+            }
+
+            _diagnostics.Add(DocumentDiagnostic.Info(
+                "docx.read.summary",
+                "DOCX read produced " + _paragraphs.Count.ToString(CultureInfo.InvariantCulture) +
+                " paragraph(s), flattened " + _tableCount.ToString(CultureInfo.InvariantCulture) +
+                " table(s), and skipped " + _unsupportedBlockCount.ToString(CultureInfo.InvariantCulture) +
+                " unsupported block(s)."));
         }
 
         public void StartParagraph(ParagraphStyle style)
@@ -636,9 +876,12 @@ internal static class DocxReader
                 ? RichTextDocument.Empty
                 : RichTextDocument.FromParagraphs(_paragraphs);
 
-        public void AddDiagnosticOnce(string code, string message)
+        public void AddDiagnosticOnce(string code, string message) =>
+            AddDiagnosticOnce(code, code, message);
+
+        public void AddDiagnosticOnce(string key, string code, string message)
         {
-            if (_diagnosticOnce.Add(code))
+            if (_diagnosticOnce.Add(key))
                 _diagnostics.Add(DocumentDiagnostic.Warning(code, message));
         }
 

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxStyles.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxStyles.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Broiler.Documents.Docx;
+
+/// <summary>
+/// The style table from <c>word/styles.xml</c>: document defaults plus the named
+/// paragraph and character styles a document refers to through <c>w:pStyle</c>
+/// and <c>w:rStyle</c>.
+/// </summary>
+/// <remarks>
+/// Templates put nearly all of their formatting here — a CV's name is a 48pt
+/// <c>Title</c> paragraph carrying no direct formatting at all — so a reader that
+/// only honors direct <c>w:pPr</c>/<c>w:rPr</c> renders such a document as
+/// undifferentiated body text. Resolution follows ECMA-376 §17.7.2: document
+/// defaults first, then the <c>w:basedOn</c> chain from its root down to the
+/// referenced style, then direct formatting (applied by the caller). The default
+/// style applies only to content that names no style of its own.
+/// </remarks>
+internal sealed class DocxStyles
+{
+    private readonly Dictionary<string, StyleDefinition> _styles;
+    private readonly XElement? _defaultParagraphProperties;
+    private readonly XElement? _defaultRunProperties;
+    private readonly string? _defaultParagraphStyleId;
+    private readonly int _maxChainDepth;
+    private readonly List<DocumentDiagnostic> _diagnostics;
+    private readonly HashSet<string> _reported = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, XElement[]> _chainCache = new(StringComparer.Ordinal);
+
+    private DocxStyles(
+        Dictionary<string, StyleDefinition> styles,
+        XElement? defaultParagraphProperties,
+        XElement? defaultRunProperties,
+        string? defaultParagraphStyleId,
+        DocxTheme theme,
+        int maxChainDepth,
+        List<DocumentDiagnostic> diagnostics)
+    {
+        _styles = styles;
+        _defaultParagraphProperties = defaultParagraphProperties;
+        _defaultRunProperties = defaultRunProperties;
+        _defaultParagraphStyleId = defaultParagraphStyleId;
+        _maxChainDepth = maxChainDepth;
+        _diagnostics = diagnostics;
+        Theme = theme;
+    }
+
+    /// <summary>Theme fonts, needed to resolve <c>w:rFonts</c> theme references.</summary>
+    public DocxTheme Theme { get; }
+
+    /// <summary>The number of named styles that were loaded.</summary>
+    public int Count => _styles.Count;
+
+    public static DocxStyles Load(
+        ZipArchive archive,
+        DocxRelationships documentRelationships,
+        string documentBaseDirectory,
+        DocumentLimits limits,
+        List<DocumentDiagnostic> diagnostics)
+    {
+        DocxTheme theme = DocxTheme.Load(
+            archive,
+            documentRelationships,
+            documentBaseDirectory,
+            limits,
+            diagnostics);
+
+        string stylesPath = DocxPackage.ResolvePartPath(
+            documentRelationships,
+            DocxNamespaces.StylesRelationship,
+            documentBaseDirectory,
+            "styles.xml");
+
+        ZipArchiveEntry? entry = DocxPackage.FindEntry(archive, stylesPath);
+        if (entry is null)
+            return WithoutStyles(theme, limits, diagnostics);
+
+        XDocument? xml = DocxPackage.LoadEntryXml(entry, limits, diagnostics, "docx.styles");
+        if (xml?.Root is null)
+            return WithoutStyles(theme, limits, diagnostics);
+
+        XElement? docDefaults = xml.Root.Element(DocxNamespaces.Wordprocessing + "docDefaults");
+        XElement? defaultParagraphProperties = docDefaults
+            ?.Element(DocxNamespaces.Wordprocessing + "pPrDefault")
+            ?.Element(DocxNamespaces.Wordprocessing + "pPr");
+        XElement? defaultRunProperties = docDefaults
+            ?.Element(DocxNamespaces.Wordprocessing + "rPrDefault")
+            ?.Element(DocxNamespaces.Wordprocessing + "rPr");
+
+        var styles = new Dictionary<string, StyleDefinition>(StringComparer.Ordinal);
+        string? defaultParagraphStyleId = null;
+        foreach (XElement style in xml.Root.Elements(DocxNamespaces.Wordprocessing + "style"))
+        {
+            string? id = (string?)style.Attribute(DocxNamespaces.Wordprocessing + "styleId");
+            if (string.IsNullOrEmpty(id))
+                continue;
+
+            string type = (string?)style.Attribute(DocxNamespaces.Wordprocessing + "type") ?? "paragraph";
+            var definition = new StyleDefinition(
+                id,
+                type,
+                (string?)style.Element(DocxNamespaces.Wordprocessing + "basedOn")?.Attribute(DocxNamespaces.Wordprocessing + "val"),
+                style.Element(DocxNamespaces.Wordprocessing + "pPr"),
+                style.Element(DocxNamespaces.Wordprocessing + "rPr"));
+            styles[id] = definition;
+
+            bool isDefault = IsOn((string?)style.Attribute(DocxNamespaces.Wordprocessing + "default"));
+            if (isDefault && type.Equals("paragraph", StringComparison.Ordinal))
+                defaultParagraphStyleId ??= id;
+        }
+
+        return new DocxStyles(
+            styles,
+            defaultParagraphProperties,
+            defaultRunProperties,
+            defaultParagraphStyleId,
+            theme,
+            limits.MaxGroupDepth,
+            diagnostics);
+    }
+
+    private static DocxStyles WithoutStyles(
+        DocxTheme theme,
+        DocumentLimits limits,
+        List<DocumentDiagnostic> diagnostics) =>
+        new(new Dictionary<string, StyleDefinition>(StringComparer.Ordinal),
+            defaultParagraphProperties: null,
+            defaultRunProperties: null,
+            defaultParagraphStyleId: null,
+            theme,
+            limits.MaxGroupDepth,
+            diagnostics);
+
+    /// <summary>
+    /// The <c>w:pPr</c> elements that apply to a paragraph naming
+    /// <paramref name="paragraphStyleId"/>, least specific first. The caller
+    /// applies the paragraph's own <c>w:pPr</c> after these.
+    /// </summary>
+    public IReadOnlyList<XElement> ParagraphProperties(string? paragraphStyleId) =>
+        Resolve("p:" + (paragraphStyleId ?? string.Empty), () =>
+        {
+            var properties = new List<XElement>();
+            if (_defaultParagraphProperties is not null)
+                properties.Add(_defaultParagraphProperties);
+
+            foreach (StyleDefinition style in ParagraphChain(paragraphStyleId))
+            {
+                if (style.ParagraphProperties is not null)
+                    properties.Add(style.ParagraphProperties);
+            }
+
+            return properties;
+        });
+
+    /// <summary>
+    /// The <c>w:rPr</c> elements that form a run's inherited character formatting
+    /// inside a paragraph naming <paramref name="paragraphStyleId"/>: document
+    /// defaults, then the paragraph style chain's run properties.
+    /// </summary>
+    public IReadOnlyList<XElement> RunPropertiesForParagraph(string? paragraphStyleId) =>
+        Resolve("pr:" + (paragraphStyleId ?? string.Empty), () =>
+        {
+            var properties = new List<XElement>();
+            if (_defaultRunProperties is not null)
+                properties.Add(_defaultRunProperties);
+
+            foreach (StyleDefinition style in ParagraphChain(paragraphStyleId))
+            {
+                if (style.RunProperties is not null)
+                    properties.Add(style.RunProperties);
+            }
+
+            return properties;
+        });
+
+    /// <summary>
+    /// The <c>w:rPr</c> elements of a character style named by <c>w:rStyle</c>,
+    /// least specific first. Applied over the paragraph's inherited formatting
+    /// and before the run's own <c>w:rPr</c>.
+    /// </summary>
+    public IReadOnlyList<XElement> RunPropertiesForCharacterStyle(string? characterStyleId)
+    {
+        if (string.IsNullOrEmpty(characterStyleId))
+            return Array.Empty<XElement>();
+
+        return Resolve("cr:" + characterStyleId, () =>
+        {
+            var properties = new List<XElement>();
+            foreach (StyleDefinition style in Chain(characterStyleId))
+            {
+                if (style.RunProperties is not null)
+                    properties.Add(style.RunProperties);
+            }
+
+            return properties;
+        });
+    }
+
+    private IReadOnlyList<XElement> Resolve(string key, Func<List<XElement>> build)
+    {
+        if (_chainCache.TryGetValue(key, out XElement[]? cached))
+            return cached;
+
+        XElement[] resolved = build().ToArray();
+        _chainCache[key] = resolved;
+        return resolved;
+    }
+
+    /// <summary>
+    /// The style chain for a paragraph. A paragraph that names no style inherits
+    /// the document's default paragraph style; one that names a style does not,
+    /// except through its own <c>w:basedOn</c> ancestry.
+    /// </summary>
+    private List<StyleDefinition> ParagraphChain(string? paragraphStyleId) =>
+        Chain(string.IsNullOrEmpty(paragraphStyleId) ? _defaultParagraphStyleId : paragraphStyleId);
+
+    /// <summary>Walks <c>w:basedOn</c> to the root and returns the chain root-first.</summary>
+    private List<StyleDefinition> Chain(string? styleId)
+    {
+        var chain = new List<StyleDefinition>();
+        if (string.IsNullOrEmpty(styleId))
+            return chain;
+
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        string? current = styleId;
+        while (!string.IsNullOrEmpty(current))
+        {
+            if (!_styles.TryGetValue(current, out StyleDefinition? style))
+            {
+                // A package with no style table at all is one fact, not one per
+                // referenced id. Otherwise only the id the document actually
+                // referenced is worth reporting — a dangling w:basedOn inside the
+                // table is the same defect seen one link further along.
+                if (_styles.Count == 0)
+                {
+                    Report(
+                        "docx.styles.missing",
+                        "docx.styles.missing",
+                        "DOCX content referenced named styles, but the package had no styles part.");
+                }
+                else if (string.Equals(current, styleId, StringComparison.Ordinal))
+                {
+                    Report(
+                        "docx.styles.unknown:" + current,
+                        "docx.styles.unknown",
+                        "A DOCX style reference named an undefined style: " + current + ".");
+                }
+
+                break;
+            }
+
+            if (!visited.Add(current))
+            {
+                Report("docx.styles.cycle", "docx.styles.cycle", "A DOCX style inheritance chain was cyclic and was cut short.");
+                break;
+            }
+
+            if (chain.Count >= _maxChainDepth)
+            {
+                Report("docx.styles.depth", "docx.styles.depth", "A DOCX style inheritance chain exceeded MaxGroupDepth and was cut short.");
+                break;
+            }
+
+            chain.Add(style);
+            current = style.BasedOn;
+        }
+
+        chain.Reverse();
+        return chain;
+    }
+
+    private void Report(string key, string code, string message)
+    {
+        if (_reported.Add(key))
+            _diagnostics.Add(DocumentDiagnostic.Warning(code, message));
+    }
+
+    private static bool IsOn(string? value) =>
+        value is not null &&
+        !(value.Equals("false", StringComparison.OrdinalIgnoreCase) ||
+          value.Equals("0", StringComparison.Ordinal) ||
+          value.Equals("off", StringComparison.OrdinalIgnoreCase));
+
+    private sealed record StyleDefinition(
+        string Id,
+        string Type,
+        string? BasedOn,
+        XElement? ParagraphProperties,
+        XElement? RunProperties);
+}
+
+/// <summary>
+/// The major/minor latin typefaces from <c>word/theme/theme1.xml</c>. Styles
+/// reference fonts through <c>w:rFonts w:asciiTheme="majorHAnsi"</c> rather than
+/// by name, so without the theme every themed run loses its family.
+/// </summary>
+internal sealed class DocxTheme
+{
+    private DocxTheme(string? majorLatin, string? minorLatin)
+    {
+        MajorLatin = majorLatin;
+        MinorLatin = minorLatin;
+    }
+
+    public static DocxTheme Empty { get; } = new(null, null);
+
+    public string? MajorLatin { get; }
+
+    public string? MinorLatin { get; }
+
+    public static DocxTheme Load(
+        ZipArchive archive,
+        DocxRelationships documentRelationships,
+        string documentBaseDirectory,
+        DocumentLimits limits,
+        List<DocumentDiagnostic> diagnostics)
+    {
+        string themePath = DocxPackage.ResolvePartPath(
+            documentRelationships,
+            DocxNamespaces.ThemeRelationship,
+            documentBaseDirectory,
+            "theme/theme1.xml");
+
+        ZipArchiveEntry? entry = DocxPackage.FindEntry(archive, themePath);
+        if (entry is null)
+            return Empty;
+
+        XDocument? xml = DocxPackage.LoadEntryXml(entry, limits, diagnostics, "docx.theme");
+        XElement? fontScheme = xml?.Root
+            ?.Element(DocxNamespaces.Drawing + "themeElements")
+            ?.Element(DocxNamespaces.Drawing + "fontScheme");
+        if (fontScheme is null)
+            return Empty;
+
+        return new DocxTheme(
+            LatinTypeface(fontScheme.Element(DocxNamespaces.Drawing + "majorFont")),
+            LatinTypeface(fontScheme.Element(DocxNamespaces.Drawing + "minorFont")));
+    }
+
+    /// <summary>Maps a <c>w:rFonts</c> theme reference such as <c>majorHAnsi</c> to a family name.</summary>
+    public string? Resolve(string? themeReference)
+    {
+        if (string.IsNullOrEmpty(themeReference))
+            return null;
+        if (themeReference.StartsWith("major", StringComparison.OrdinalIgnoreCase))
+            return MajorLatin;
+        if (themeReference.StartsWith("minor", StringComparison.OrdinalIgnoreCase))
+            return MinorLatin;
+
+        return null;
+    }
+
+    private static string? LatinTypeface(XElement? font)
+    {
+        string? typeface = (string?)font?.Element(DocxNamespaces.Drawing + "latin")?.Attribute("typeface");
+        return string.IsNullOrWhiteSpace(typeface) ? null : typeface;
+    }
+}

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxWriter.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxWriter.cs
@@ -197,6 +197,10 @@ public static class DocxWriter
             properties.Add(new XElement(DocxNamespaces.Wordprocessing + "u", WordAttribute("val", "single")));
         if (style.Strikethrough)
             properties.Add(new XElement(DocxNamespaces.Wordprocessing + "strike"));
+        if (style.Capitalization == TextCapitalization.AllCaps)
+            properties.Add(new XElement(DocxNamespaces.Wordprocessing + "caps"));
+        else if (style.Capitalization == TextCapitalization.SmallCaps)
+            properties.Add(new XElement(DocxNamespaces.Wordprocessing + "smallCaps"));
 
         if (!string.IsNullOrWhiteSpace(style.FontFamily))
         {

--- a/Broiler.Documents/Broiler.Documents.FormatCodes.Tests/FormatCodeProjectorGoldenTests.cs
+++ b/Broiler.Documents/Broiler.Documents.FormatCodes.Tests/FormatCodeProjectorGoldenTests.cs
@@ -49,6 +49,7 @@ public sealed class FormatCodeProjectorGoldenTests
             Foreground = new BColor(0x11, 0x22, 0x33, 0x44),
             Background = new BColor(0xFF, 0xF2, 0xA8, 0xFF),
             LinkHref = "https://example.test/[x]",
+            Capitalization = TextCapitalization.SmallCaps,
         };
 
         FormatCodeProjection projection = _projector.Project(
@@ -58,9 +59,24 @@ public sealed class FormatCodeProjectorGoldenTests
             "[Bold ON][Italic ON][Underline ON][Strike ON]" +
             "[Font \"A\\\"\\[B\\]\\\\C\"][Size 17]" +
             "[Text Color #11223344][Highlight #FFF2A8FF]" +
-            "[Link \"https://example.test/\\[x\\]\"]x" +
-            "[Link OFF][Highlight NONE][Text Color DEFAULT][Size DEFAULT]" +
+            "[Link \"https://example.test/\\[x\\]\"][Small Caps ON]x" +
+            "[Caps OFF][Link OFF][Highlight NONE][Text Color DEFAULT][Size DEFAULT]" +
             "[Font DEFAULT][Strike OFF][Underline OFF][Italic OFF][Bold OFF]",
+            projection.Text);
+    }
+
+    [Fact]
+    public void Capitalization_Projects_Its_Kind_And_Closes_As_One_Property()
+    {
+        RichTextParagraph paragraph = RichTextParagraph
+            .Create("a", new InlineStyle { Capitalization = TextCapitalization.AllCaps })
+            .Append(RichTextParagraph.Create("b", new InlineStyle { Capitalization = TextCapitalization.SmallCaps }));
+
+        FormatCodeProjection projection = _projector.Project(
+            RichTextDocument.FromParagraphs([paragraph]));
+
+        Assert.Equal(
+            "[All Caps ON]a[Caps OFF][Small Caps ON]b[Caps OFF]",
             projection.Text);
     }
 

--- a/Broiler.Documents/Broiler.Documents.FormatCodes/FormatCodeEditIntent.cs
+++ b/Broiler.Documents/Broiler.Documents.FormatCodes/FormatCodeEditIntent.cs
@@ -38,6 +38,11 @@ public enum FormatCodeProperty
     Foreground,
     Background,
     Link,
+
+    // Inline properties are projected by their offset from Bold, so a new one
+    // belongs at the end of that contiguous run — before the paragraph
+    // properties, which start at Alignment.
+    Capitalization,
     Alignment,
     ListKind,
     IndentLevel,
@@ -70,6 +75,8 @@ public enum FormatCodePaletteEntry
     Foreground,
     Background,
     Link,
+    AllCaps,
+    SmallCaps,
     AlignLeft,
     AlignCenter,
     AlignRight,
@@ -307,6 +314,10 @@ public static class FormatCodeInsertPalette
             new ApplyFormatCodeInlineIntent(range, InlineStyleDelta.WithBackground(background)),
         FormatCodePaletteEntry.Link when value is string href =>
             new ApplyFormatCodeInlineIntent(range, InlineStyleDelta.WithLink(href.Trim())),
+        FormatCodePaletteEntry.AllCaps =>
+            new ApplyFormatCodeInlineIntent(range, InlineStyleDelta.WithCapitalization(TextCapitalization.AllCaps)),
+        FormatCodePaletteEntry.SmallCaps =>
+            new ApplyFormatCodeInlineIntent(range, InlineStyleDelta.WithCapitalization(TextCapitalization.SmallCaps)),
         FormatCodePaletteEntry.AlignLeft =>
             new ApplyFormatCodeParagraphIntent(range, ParagraphStyleDelta.WithAlignment(TextAlignment.Left)),
         FormatCodePaletteEntry.AlignCenter =>

--- a/Broiler.Documents/Broiler.Documents.FormatCodes/FormatCodeProjector.cs
+++ b/Broiler.Documents/Broiler.Documents.FormatCodes/FormatCodeProjector.cs
@@ -11,7 +11,7 @@ namespace Broiler.Documents.FormatCodes;
 /// <summary>Projects normalized Broiler rich-text state into grammar-version 1 tokens.</summary>
 public sealed class FormatCodeProjector
 {
-    private const int InlinePropertyCount = 9;
+    private const int InlinePropertyCount = 10;
 
     public FormatCodeProjection Project(
         RichTextDocument document,
@@ -408,6 +408,7 @@ public sealed class FormatCodeProjector
         6 => left.Foreground != right.Foreground,
         7 => left.Background != right.Background,
         8 => !string.Equals(NormalizeLink(left.LinkHref), NormalizeLink(right.LinkHref), StringComparison.Ordinal),
+        9 => left.Capitalization != right.Capitalization,
         _ => throw new ArgumentOutOfRangeException(nameof(property)),
     };
 
@@ -424,6 +425,7 @@ public sealed class FormatCodeProjector
             6 => InlineStyleDelta.WithForeground(BColor.Empty),
             7 => InlineStyleDelta.WithBackground(BColor.Empty),
             8 => InlineStyleDelta.WithLink(null),
+            9 => InlineStyleDelta.WithCapitalization(TextCapitalization.None),
             _ => throw new ArgumentOutOfRangeException(nameof(property)),
         };
         return new FormatCodeTokenEditDescriptor(
@@ -453,6 +455,7 @@ public sealed class FormatCodeProjector
         6 => !style.Foreground.IsEmpty,
         7 => !style.Background.IsEmpty,
         8 => NormalizeLink(style.LinkHref) is not null,
+        9 => style.Capitalization != TextCapitalization.None,
         _ => throw new ArgumentOutOfRangeException(nameof(property)),
     };
 
@@ -467,6 +470,7 @@ public sealed class FormatCodeProjector
         6 => "[Text Color DEFAULT]",
         7 => "[Highlight NONE]",
         8 => "[Link OFF]",
+        9 => "[Caps OFF]",
         _ => throw new ArgumentOutOfRangeException(nameof(property)),
     };
 
@@ -484,6 +488,7 @@ public sealed class FormatCodeProjector
         6 => $"[Text Color {FormatColor(style.Foreground)}]",
         7 => $"[Highlight {FormatColor(style.Background)}]",
         8 => $"[Link \"{EscapeQuoted(NormalizeLink(style.LinkHref)!, options)}\"]",
+        9 => style.Capitalization == TextCapitalization.SmallCaps ? "[Small Caps ON]" : "[All Caps ON]",
         _ => throw new ArgumentOutOfRangeException(nameof(property)),
     };
 

--- a/Broiler.Documents/Broiler.Documents.Html.Tests/HtmlCapitalizationTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Html.Tests/HtmlCapitalizationTests.cs
@@ -1,0 +1,78 @@
+namespace Broiler.Documents.Html.Tests;
+
+/// <summary>
+/// <c>text-transform: uppercase</c> and <c>font-variant: small-caps</c> — the CSS
+/// spellings of the same display property, and the reason HTML export of a
+/// capitalized run keeps the author's casing in the markup.
+/// </summary>
+public sealed class HtmlCapitalizationTests
+{
+    private static RichTextDocument Read(string html)
+    {
+        var codec = new HtmlDocumentCodec();
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(html));
+        return codec.Read(stream).Document;
+    }
+
+    private static string Write(RichTextDocument document) =>
+        System.Text.Encoding.UTF8.GetString(HtmlWriter.WriteToArray(document));
+
+    [Fact]
+    public void Reads_Text_Transform_Uppercase()
+    {
+        RichTextDocument document = Read(
+            "<p><span style=\"text-transform: uppercase\">Elene Bartky</span></p>");
+
+        RichTextParagraph paragraph = Assert.Single(document.Paragraphs);
+        Assert.Equal("Elene Bartky", paragraph.Text);
+        Assert.Equal(TextCapitalization.AllCaps, paragraph.StyleAt(0).Capitalization);
+    }
+
+    [Fact]
+    public void Reads_Font_Variant_Small_Caps()
+    {
+        RichTextDocument document = Read(
+            "<p><span style=\"font-variant: small-caps\">Kontakt</span></p>");
+
+        Assert.Equal(
+            TextCapitalization.SmallCaps,
+            Assert.Single(document.Paragraphs).StyleAt(0).Capitalization);
+    }
+
+    [Fact]
+    public void Writes_Text_Transform_For_All_Caps_And_Leaves_The_Text_Alone()
+    {
+        RichTextDocument document = RichTextDocument.FromParagraphs(
+        [
+            RichTextParagraph.Create(
+                "Elene Bartky",
+                InlineStyle.Default with { Capitalization = TextCapitalization.AllCaps }),
+        ]);
+
+        string html = Write(document);
+
+        Assert.Contains("text-transform: uppercase", html, StringComparison.Ordinal);
+        Assert.Contains("Elene Bartky", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("ELENE BARTKY", html, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(TextCapitalization.None)]
+    [InlineData(TextCapitalization.AllCaps)]
+    [InlineData(TextCapitalization.SmallCaps)]
+    public void Round_Trips_Capitalization(TextCapitalization capitalization)
+    {
+        RichTextDocument original = RichTextDocument.FromParagraphs(
+        [
+            RichTextParagraph.Create(
+                "Elene Bartky",
+                InlineStyle.Default with { Capitalization = capitalization }),
+        ]);
+
+        RichTextDocument round = Read(Write(original));
+
+        RichTextParagraph paragraph = Assert.Single(round.Paragraphs);
+        Assert.Equal("Elene Bartky", paragraph.Text);
+        Assert.Equal(capitalization, paragraph.StyleAt(0).Capitalization);
+    }
+}

--- a/Broiler.Documents/Broiler.Documents.Html/HtmlReader.cs
+++ b/Broiler.Documents/Broiler.Documents.Html/HtmlReader.cs
@@ -285,6 +285,25 @@ internal static class HtmlReader
                 if (HtmlCss.TryParseColor(value.Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(), out BColor background))
                     return style with { Background = background };
                 break;
+            case "text-transform":
+                if (value.Equals("uppercase", StringComparison.OrdinalIgnoreCase))
+                    return style with { Capitalization = TextCapitalization.AllCaps };
+                if (value.Equals("none", StringComparison.OrdinalIgnoreCase) &&
+                    style.Capitalization == TextCapitalization.AllCaps)
+                {
+                    return style with { Capitalization = TextCapitalization.None };
+                }
+                break;
+            case "font-variant":
+            case "font-variant-caps":
+                if (value.Equals("small-caps", StringComparison.OrdinalIgnoreCase))
+                    return style with { Capitalization = TextCapitalization.SmallCaps };
+                if (value.Equals("normal", StringComparison.OrdinalIgnoreCase) &&
+                    style.Capitalization == TextCapitalization.SmallCaps)
+                {
+                    return style with { Capitalization = TextCapitalization.None };
+                }
+                break;
             case "font-family":
                 return style with { FontFamily = HtmlCss.ParseFontFamily(value) };
             case "font-size":

--- a/Broiler.Documents/Broiler.Documents.Html/HtmlWriter.cs
+++ b/Broiler.Documents/Broiler.Documents.Html/HtmlWriter.cs
@@ -138,6 +138,11 @@ public static class HtmlWriter
         if (decoration.Length > 0)
             declarations.Add("text-decoration: " + decoration);
 
+        if (style.Capitalization == TextCapitalization.AllCaps)
+            declarations.Add("text-transform: uppercase");
+        else if (style.Capitalization == TextCapitalization.SmallCaps)
+            declarations.Add("font-variant: small-caps");
+
         if (style.FontFamily is not null)
             declarations.Add("font-family: " + QuoteCssString(style.FontFamily));
         if (style.FontSize.HasValue)

--- a/Broiler.Documents/Broiler.Documents.Model/InlineStyle.cs
+++ b/Broiler.Documents/Broiler.Documents.Model/InlineStyle.cs
@@ -23,6 +23,12 @@ public readonly record struct InlineStyle
 
     public bool Strikethrough { get; init; }
 
+    /// <summary>
+    /// How the run's letters are cased when drawn. Presentation only — the text
+    /// itself is stored as the author typed it.
+    /// </summary>
+    public TextCapitalization Capitalization { get; init; }
+
     /// <summary>Foreground color, or <see cref="BColor.Empty"/> for the default color.</summary>
     public BColor Foreground { get; init; }
 

--- a/Broiler.Documents/Broiler.Documents.Model/InlineStyleDelta.cs
+++ b/Broiler.Documents/Broiler.Documents.Model/InlineStyleDelta.cs
@@ -18,6 +18,8 @@ public readonly record struct InlineStyleDelta
 
     public bool? Strikethrough { get; init; }
 
+    public TextCapitalization? Capitalization { get; init; }
+
     public BColor? Foreground { get; init; }
 
     public BColor? Background { get; init; }
@@ -41,6 +43,7 @@ public readonly record struct InlineStyleDelta
         Italic = Italic ?? style.Italic,
         Underline = Underline ?? style.Underline,
         Strikethrough = Strikethrough ?? style.Strikethrough,
+        Capitalization = Capitalization ?? style.Capitalization,
         Foreground = Foreground ?? style.Foreground,
         Background = Background ?? style.Background,
         FontFamily = SetFontFamily ? FontFamily : style.FontFamily,
@@ -55,6 +58,9 @@ public readonly record struct InlineStyleDelta
     public static InlineStyleDelta ToggleUnderline(bool on) => new() { Underline = on };
 
     public static InlineStyleDelta ToggleStrikethrough(bool on) => new() { Strikethrough = on };
+
+    public static InlineStyleDelta WithCapitalization(TextCapitalization capitalization) =>
+        new() { Capitalization = capitalization };
 
     public static InlineStyleDelta WithForeground(BColor color) => new() { Foreground = color };
 
@@ -73,6 +79,7 @@ public readonly record struct InlineStyleDelta
         Italic = false,
         Underline = false,
         Strikethrough = false,
+        Capitalization = TextCapitalization.None,
         Foreground = BColor.Empty,
         Background = BColor.Empty,
         SetFontFamily = true,

--- a/Broiler.Documents/Broiler.Documents.Model/TextCapitalization.cs
+++ b/Broiler.Documents/Broiler.Documents.Model/TextCapitalization.cs
@@ -1,0 +1,21 @@
+namespace Broiler.Documents.Model;
+
+/// <summary>
+/// How a run's letters are cased when drawn. This is presentation only — the
+/// stored text keeps the author's casing, so turning capitalization off restores
+/// exactly what was typed.
+/// </summary>
+public enum TextCapitalization
+{
+    /// <summary>Draw the text as stored.</summary>
+    None = 0,
+
+    /// <summary>Draw every letter as a capital.</summary>
+    AllCaps,
+
+    /// <summary>
+    /// Draw every letter as a capital, with letters that were typed in lower
+    /// case drawn smaller than those that were typed as capitals.
+    /// </summary>
+    SmallCaps,
+}

--- a/Broiler.Documents/Broiler.Documents.Rtf.Tests/RtfCapitalizationTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Rtf.Tests/RtfCapitalizationTests.cs
@@ -1,0 +1,87 @@
+namespace Broiler.Documents.Rtf.Tests;
+
+/// <summary>
+/// <c>\caps</c> and <c>\scaps</c>. Like their DOCX counterparts these are display
+/// properties over text stored in the author's own casing.
+/// </summary>
+public sealed class RtfCapitalizationTests
+{
+    private static RichTextDocument Read(string rtf)
+    {
+        var codec = new RtfDocumentCodec();
+        using var stream = new MemoryStream(System.Text.Encoding.ASCII.GetBytes(rtf));
+        return codec.Read(stream).Document;
+    }
+
+    [Fact]
+    public void Reads_Caps_As_An_Attribute_Not_As_Uppercased_Text()
+    {
+        RichTextDocument document = Read(@"{\rtf1\ansi{\caps Elene Bartky}}");
+
+        RichTextParagraph paragraph = Assert.Single(document.Paragraphs);
+        Assert.Equal("Elene Bartky", paragraph.Text);
+        Assert.Equal(TextCapitalization.AllCaps, paragraph.StyleAt(0).Capitalization);
+    }
+
+    [Fact]
+    public void Reads_Small_Caps()
+    {
+        RichTextDocument document = Read(@"{\rtf1\ansi{\scaps Kontakt}}");
+
+        Assert.Equal(
+            TextCapitalization.SmallCaps,
+            Assert.Single(document.Paragraphs).StyleAt(0).Capitalization);
+    }
+
+    [Fact]
+    public void Caps0_Turns_Capitalization_Off()
+    {
+        RichTextDocument document = Read(@"{\rtf1\ansi{\caps\caps0 plain}}");
+
+        Assert.Equal(
+            TextCapitalization.None,
+            Assert.Single(document.Paragraphs).StyleAt(0).Capitalization);
+    }
+
+    /// <summary>Each control word clears only the kind it names.</summary>
+    [Fact]
+    public void Scaps0_Leaves_An_Active_Caps_State_Alone()
+    {
+        RichTextDocument document = Read(@"{\rtf1\ansi{\caps\scaps0 loud}}");
+
+        Assert.Equal(
+            TextCapitalization.AllCaps,
+            Assert.Single(document.Paragraphs).StyleAt(0).Capitalization);
+    }
+
+    [Fact]
+    public void Plain_Resets_Capitalization()
+    {
+        RichTextDocument document = Read(@"{\rtf1\ansi{\caps\plain quiet}}");
+
+        Assert.Equal(
+            TextCapitalization.None,
+            Assert.Single(document.Paragraphs).StyleAt(0).Capitalization);
+    }
+
+    [Theory]
+    [InlineData(TextCapitalization.None)]
+    [InlineData(TextCapitalization.AllCaps)]
+    [InlineData(TextCapitalization.SmallCaps)]
+    public void Round_Trips_Capitalization_Without_Rewriting_The_Text(TextCapitalization capitalization)
+    {
+        RichTextDocument original = RichTextDocument.FromParagraphs(
+        [
+            RichTextParagraph.Create("Elene Bartky", InlineStyle.Default with { Capitalization = capitalization }),
+        ]);
+
+        byte[] bytes = RtfWriter.WriteToArray(original);
+        var codec = new RtfDocumentCodec();
+        using var stream = new MemoryStream(bytes);
+        RichTextDocument round = codec.Read(stream).Document;
+
+        RichTextParagraph paragraph = Assert.Single(round.Paragraphs);
+        Assert.Equal("Elene Bartky", paragraph.Text);
+        Assert.Equal(capitalization, paragraph.StyleAt(0).Capitalization);
+    }
+}

--- a/Broiler.Documents/Broiler.Documents.Rtf/RtfReader.cs
+++ b/Broiler.Documents/Broiler.Documents.Rtf/RtfReader.cs
@@ -220,6 +220,8 @@ public static class RtfReader
                 case "strike": _state.Char = _state.Char with { Strikethrough = !(has && p == 0) }; break;
                 case "ul": _state.Char = _state.Char with { Underline = !(has && p == 0) }; break;
                 case "ulnone": _state.Char = _state.Char with { Underline = false }; break;
+                case "caps": _state.Char = ApplyCapitalization(_state.Char, TextCapitalization.AllCaps, !(has && p == 0)); break;
+                case "scaps": _state.Char = ApplyCapitalization(_state.Char, TextCapitalization.SmallCaps, !(has && p == 0)); break;
                 case "plain": _state.Char = InlineStyle.Default; break;
                 case "fs": _state.Char = _state.Char with { FontSize = has ? p / 2f : null }; break;
                 case "f":
@@ -262,6 +264,21 @@ public static class RtfReader
                 case "emspace": AppendChar(0x2003); break;
                 default: break; // Unknown formatting control word: ignore (predictable degradation).
             }
+        }
+
+        /// <summary>
+        /// Turns one capitalization kind on or off. <c>\caps0</c> and
+        /// <c>\scaps0</c> each clear only the kind they name, so a run can drop
+        /// small caps without disturbing an all-caps state and vice versa.
+        /// </summary>
+        private static InlineStyle ApplyCapitalization(InlineStyle style, TextCapitalization kind, bool on)
+        {
+            if (on)
+                return style with { Capitalization = kind };
+
+            return style.Capitalization == kind
+                ? style with { Capitalization = TextCapitalization.None }
+                : style;
         }
 
         private void HandleControlSymbol(char symbol)

--- a/Broiler.Documents/Broiler.Documents.Rtf/RtfWriter.cs
+++ b/Broiler.Documents/Broiler.Documents.Rtf/RtfWriter.cs
@@ -189,6 +189,8 @@ public static class RtfWriter
         if (style.Italic) b.Append("\\i");
         if (style.Underline) b.Append("\\ul");
         if (style.Strikethrough) b.Append("\\strike");
+        if (style.Capitalization == TextCapitalization.AllCaps) b.Append("\\caps");
+        else if (style.Capitalization == TextCapitalization.SmallCaps) b.Append("\\scaps");
         if (style.FontFamily is not null)
             b.Append("\\f").Append(fonts.IndexOf(style.FontFamily));
         if (style.FontSize.HasValue)

--- a/Broiler.Documents/docs/docx-conformance.md
+++ b/Broiler.Documents/docs/docx-conformance.md
@@ -18,6 +18,15 @@ Open XML WordprocessingML package parts.
   letterhead templates hold their entire text.
 - Direct inline formatting: bold, italic, underline, strikethrough, font
   family, font size, foreground color, and background shading.
+- Named styles from `word/styles.xml`, resolved per ECMA-376 §17.7.2: document
+  defaults (`w:docDefaults`), then the `w:basedOn` chain from its root down to
+  the style named by `w:pStyle` (paragraphs) or `w:rStyle` (runs), then direct
+  formatting. The default style (`w:default="1"`) applies only to content that
+  names no style of its own. Template documents carry nearly all of their
+  formatting here rather than inline.
+- Theme fonts from `word/theme/theme1.xml`: `w:rFonts` theme references such as
+  `w:asciiTheme="majorHAnsi"` resolve to the theme's major/minor latin typeface.
+  An explicit font name on the same element wins.
 - Paragraph formatting: left/center/right alignment, line spacing, spacing
   before/after, indentation, bullet lists, and numbered lists.
 - External hyperlinks for `http`, `https`, and `mailto`, plus internal anchor
@@ -25,9 +34,14 @@ Open XML WordprocessingML package parts.
 
 ## Intentional Limits
 
-- Styles, themes, tracked deletions, embedded objects, images, fields, comments,
-  headers, footers, footnotes, table geometry, and section layout are skipped or
+- Tracked deletions, embedded objects, images, fields, comments, headers,
+  footers, footnotes, table geometry, and section layout are skipped or
   approximated with diagnostics where applicable.
+- Style resolution covers the attributes `RichTextDocument` models. Style
+  features outside it — `w:caps`, character spacing/scaling, table styles,
+  numbering-level overrides, conditional table formatting — are ignored, as are
+  theme colors (`w:themeColor`); Word writes the computed RGB into `w:val`
+  alongside them, which is what the reader uses.
 - Table structure (grid, spans, borders, cell shading) is not represented; only
   the cell text survives flattening.
 - Block nesting deeper than `DocumentLimits.MaxGroupDepth` is abandoned with a
@@ -45,11 +59,15 @@ that opens blank can be told apart from a document that *is* blank:
 
 | Code | Severity | Meaning |
 | --- | --- | --- |
-| `docx.read.summary` | Info | Paragraph, table, and skipped-block counts for the read. |
+| `docx.read.summary` | Info | Paragraph, table, style, and skipped-block counts for the read. |
 | `docx.document.empty` | Warning | The body held block-level content but produced no paragraphs — a reader gap, not an empty file. |
 | `docx.table.flattened` | Warning | At least one table was flattened into its cell paragraphs. |
 | `docx.block.unsupported` | Warning | A block-level element was not understood; the message names the element. Reported once per distinct name. |
 | `docx.limit.depth` | Warning | Block nesting hit `MaxGroupDepth`; the deepest content was skipped. |
+| `docx.styles.missing` | Warning | Content named styles but the package has no styles part. Reported once. |
+| `docx.styles.unknown` | Warning | A `w:pStyle`/`w:rStyle` named a style the table does not define. Once per id. |
+| `docx.styles.cycle` | Warning | A `w:basedOn` chain was cyclic and was cut short. |
+| `docx.styles.depth` | Warning | A `w:basedOn` chain exceeded `MaxGroupDepth` and was cut short. |
 | `docx.part.headerfooter` | Info | The package has headers or footers, which are not part of the body. |
 
 `Broiler.Cli --convert-doc <in> --output <out>` prints all of them, which is the

--- a/Broiler.Documents/docs/docx-conformance.md
+++ b/Broiler.Documents/docs/docx-conformance.md
@@ -18,6 +18,11 @@ Open XML WordprocessingML package parts.
   letterhead templates hold their entire text.
 - Direct inline formatting: bold, italic, underline, strikethrough, font
   family, font size, foreground color, and background shading.
+- Capitalization: `w:caps` and `w:smallCaps`, read and written as a style
+  attribute. The text keeps the casing the author typed and the capitals are
+  applied when drawing, so an open-and-save does not rewrite it. An explicit
+  `w:val="0"` clears only the kind it names; a run declaring both draws all caps,
+  as Word does.
 - Named styles from `word/styles.xml`, resolved per ECMA-376 §17.7.2: document
   defaults (`w:docDefaults`), then the `w:basedOn` chain from its root down to
   the style named by `w:pStyle` (paragraphs) or `w:rStyle` (runs), then direct
@@ -38,10 +43,10 @@ Open XML WordprocessingML package parts.
   footers, footnotes, table geometry, and section layout are skipped or
   approximated with diagnostics where applicable.
 - Style resolution covers the attributes `RichTextDocument` models. Style
-  features outside it — `w:caps`, character spacing/scaling, table styles,
-  numbering-level overrides, conditional table formatting — are ignored, as are
-  theme colors (`w:themeColor`); Word writes the computed RGB into `w:val`
-  alongside them, which is what the reader uses.
+  features outside it — character spacing/scaling, table styles, numbering-level
+  overrides, conditional table formatting — are ignored, as are theme colors
+  (`w:themeColor`); Word writes the computed RGB into `w:val` alongside them,
+  which is what the reader uses.
 - Table structure (grid, spans, borders, cell shading) is not represented; only
   the cell text survives flattening.
 - Block nesting deeper than `DocumentLimits.MaxGroupDepth` is abandoned with a

--- a/Broiler.Documents/docs/docx-conformance.md
+++ b/Broiler.Documents/docs/docx-conformance.md
@@ -8,6 +8,14 @@ Open XML WordprocessingML package parts.
 - Main document package discovery through `_rels/.rels` with fallback to
   `word/document.xml`.
 - Paragraphs, empty paragraphs, tabs, and soft line breaks.
+- Block-level containers, walked recursively so their paragraphs are read rather
+  than dropped: tables (`w:tbl`/`w:tr`/`w:tc`, including nested tables),
+  structured document tags (`w:sdt`), accepted revisions (`w:ins`, `w:moveTo`),
+  `w:customXml`/`w:smartTag` wrappers, and `mc:AlternateContent` (first
+  `mc:Choice`, else `mc:Fallback`). Tables are flattened into their cell
+  paragraphs in row-major order, with a `docx.table.flattened` diagnostic —
+  `RichTextDocument` has no table shape, and layout tables are how CV and
+  letterhead templates hold their entire text.
 - Direct inline formatting: bold, italic, underline, strikethrough, font
   family, font size, foreground color, and background shading.
 - Paragraph formatting: left/center/right alignment, line spacing, spacing
@@ -18,12 +26,36 @@ Open XML WordprocessingML package parts.
 ## Intentional Limits
 
 - Styles, themes, tracked deletions, embedded objects, images, fields, comments,
-  headers, footers, footnotes, tables, and section layout are skipped or
+  headers, footers, footnotes, table geometry, and section layout are skipped or
   approximated with diagnostics where applicable.
+- Table structure (grid, spans, borders, cell shading) is not represented; only
+  the cell text survives flattening.
+- Block nesting deeper than `DocumentLimits.MaxGroupDepth` is abandoned with a
+  `docx.limit.depth` diagnostic.
 - DOCX packages above `DocumentLimits.MaxDocumentBytes` are not parsed.
 - XML parts above `DocumentLimits.MaxBinBytes` are skipped.
 - Color alpha is not represented by DOCX; RGB channels are written with a
   diagnostic.
+
+## Read Diagnostics
+
+Every read ends with a `docx.read.summary` info diagnostic carrying the
+paragraph, flattened-table, and skipped-block counts. It exists so a document
+that opens blank can be told apart from a document that *is* blank:
+
+| Code | Severity | Meaning |
+| --- | --- | --- |
+| `docx.read.summary` | Info | Paragraph, table, and skipped-block counts for the read. |
+| `docx.document.empty` | Warning | The body held block-level content but produced no paragraphs — a reader gap, not an empty file. |
+| `docx.table.flattened` | Warning | At least one table was flattened into its cell paragraphs. |
+| `docx.block.unsupported` | Warning | A block-level element was not understood; the message names the element. Reported once per distinct name. |
+| `docx.limit.depth` | Warning | Block nesting hit `MaxGroupDepth`; the deepest content was skipped. |
+| `docx.part.headerfooter` | Info | The package has headers or footers, which are not part of the body. |
+
+`Broiler.Cli --convert-doc <in> --output <out>` prints all of them, which is the
+quickest way to see what a problem document lost. In the Writer, set
+`BROILER_WRITER_DOCUMENT_LOG=1` to have the same list written to stderr on every
+open; the status bar always reports a read that produced no text.
 
 ## Probe Policy
 

--- a/Broiler.Documents/docs/html-conformance.md
+++ b/Broiler.Documents/docs/html-conformance.md
@@ -25,6 +25,7 @@ for parsing and writes deterministic UTF-8 HTML with `HtmlSerializer`.
 | `<i>`, `<em>` | `InlineStyle.Italic` | CSS `font-style:italic/oblique` also maps. |
 | `<u>` | `InlineStyle.Underline` | CSS `text-decoration: underline` also maps. |
 | `<s>`, `<strike>`, `<del>` | `InlineStyle.Strikethrough` | CSS `line-through` also maps. |
+| CSS `text-transform: uppercase`, `font-variant: small-caps` | `InlineStyle.Capitalization` | Display only; the markup keeps the author's casing. |
 | `<a href>` | `InlineStyle.LinkHref` | `http`, `https`, and `mailto` only; other schemes are dropped with `html.link`. |
 | `<font face color>` | `FontFamily`, `Foreground` | Legacy compatibility only. |
 | CSS `color`, `background-color` | `Foreground`, `Background` | Named colors, `#rgb`, `#rrggbb`, and `rgb(...)`. |

--- a/Broiler.Documents/docs/rtf-conformance.md
+++ b/Broiler.Documents/docs/rtf-conformance.md
@@ -11,7 +11,7 @@ below are exercised by `RtfConformanceTests`, `RtfLimitTests`, and
 
 | Group | Control words |
 |---|---|
-| Inline character | `\b` `\b0` `\i` `\i0` `\ul` `\ul0` `\ulnone` `\strike` `\strike0` `\plain` `\fsN` `\fN` `\cfN` `\cbN` `\highlightN` |
+| Inline character | `\b` `\b0` `\i` `\i0` `\ul` `\ul0` `\ulnone` `\strike` `\strike0` `\caps` `\caps0` `\scaps` `\scaps0` `\plain` `\fsN` `\fN` `\cfN` `\cbN` `\highlightN` |
 | Paragraph | `\pard` `\ql` `\qc` `\qr` `\liN` `\sbN` `\saN` |
 | Breaks & entities | `\par` `\line` `\tab` `\cell` (→ tab) `\row` (→ paragraph) `\lquote` `\rquote` `\ldblquote` `\rdblquote` `\bullet` `\endash` `\emdash` `\enspace` `\emspace` |
 | Control symbols | `\\` `\{` `\}` `\~` (nbsp) `\_` (nb-hyphen) `\-` (optional hyphen, dropped) `\`+CR/LF (→ paragraph) `\*` (destination marker) |

--- a/Broiler.UI/docs/adr/0014-rich-text-document-model.md
+++ b/Broiler.UI/docs/adr/0014-rich-text-document-model.md
@@ -10,6 +10,15 @@
 > assembly (depends only on `Broiler.Graphics`). Opaque positions, copy-on-write
 > snapshots, transaction undo, and the style subset are all preserved.
 
+> **Update (2026-08-06).** The inline style table below gains one attribute:
+> **capitalization** (none / all caps / small caps). It is added because every
+> word-processing format the DOCX/RTF/HTML codecs read carries it as a *display*
+> property — `w:caps`, `\caps`, `text-transform` — over text stored in the
+> author's own casing. Without a model attribute the only way to honor it is to
+> rewrite the text at read time, which loses the author's casing on the next
+> save. The attribute is presentation-only and changes no other guarantee: it
+> does not affect positions, text indexing, or run normalization.
+
 ## Context
 
 RichEdit needs an editor state model independent of rendering (roadmap Phase 1)
@@ -51,6 +60,7 @@ explicit.
   | Italic | yes |
   | Underline | yes |
   | Strikethrough | yes |
+  | Capitalization (none/all caps/small caps) | yes (added 2026-08-06) |
   | Foreground color | yes |
   | Background color | yes |
   | Link metadata (href + display text) | yes |

--- a/Broiler.UI/src/Abstractions/Text/Broiler.UI.RichEdit/RichEditCommand.cs
+++ b/Broiler.UI/src/Abstractions/Text/Broiler.UI.RichEdit/RichEditCommand.cs
@@ -28,6 +28,8 @@ public enum RichEditCommand
     Italic,
     Underline,
     Strikethrough,
+    AllCaps,
+    SmallCaps,
     SetForeground,
     SetBackground,
     SetFontFamily,

--- a/Broiler.UI/src/Abstractions/Text/Broiler.UI.RichEdit/UiRichEdit.cs
+++ b/Broiler.UI/src/Abstractions/Text/Broiler.UI.RichEdit/UiRichEdit.cs
@@ -205,6 +205,8 @@ public abstract class UiRichEdit : UiElement
             RichEditCommand.Italic => RichEditCommandState.For(editable, inline.Italic),
             RichEditCommand.Underline => RichEditCommandState.For(editable, inline.Underline),
             RichEditCommand.Strikethrough => RichEditCommandState.For(editable, inline.Strikethrough),
+            RichEditCommand.AllCaps => RichEditCommandState.For(editable, inline.Capitalization == TextCapitalization.AllCaps),
+            RichEditCommand.SmallCaps => RichEditCommandState.For(editable, inline.Capitalization == TextCapitalization.SmallCaps),
             RichEditCommand.SetForeground or RichEditCommand.SetBackground or
             RichEditCommand.SetFontFamily or RichEditCommand.SetFontSize or RichEditCommand.SetFont or
             RichEditCommand.ClearFormatting =>
@@ -348,6 +350,8 @@ public abstract class UiRichEdit : UiElement
         RichEditCommand.Italic => _editor.ApplyInlineStyle(InlineStyleDelta.ToggleItalic(!CurrentInlineStyle.Italic)),
         RichEditCommand.Underline => _editor.ApplyInlineStyle(InlineStyleDelta.ToggleUnderline(!CurrentInlineStyle.Underline)),
         RichEditCommand.Strikethrough => _editor.ApplyInlineStyle(InlineStyleDelta.ToggleStrikethrough(!CurrentInlineStyle.Strikethrough)),
+        RichEditCommand.AllCaps => _editor.ApplyInlineStyle(ToggleCapitalization(TextCapitalization.AllCaps)),
+        RichEditCommand.SmallCaps => _editor.ApplyInlineStyle(ToggleCapitalization(TextCapitalization.SmallCaps)),
         RichEditCommand.SetForeground => parameter is BColor foreground && _editor.ApplyInlineStyle(InlineStyleDelta.WithForeground(foreground)),
         RichEditCommand.SetBackground => parameter is BColor background && _editor.ApplyInlineStyle(InlineStyleDelta.WithBackground(background)),
         RichEditCommand.SetFontFamily => _editor.ApplyInlineStyle(InlineStyleDelta.WithFontFamily(NormalizeFontFamily(parameter as string))),
@@ -382,6 +386,15 @@ public abstract class UiRichEdit : UiElement
         ListKind target = CurrentParagraphStyle.ListKind == kind ? ListKind.None : kind;
         return _editor.SetListKind(target);
     }
+
+    /// <summary>
+    /// Turns <paramref name="kind"/> on, or back off when it is already the
+    /// current capitalization. The two kinds are exclusive, so switching between
+    /// them replaces rather than combines.
+    /// </summary>
+    private InlineStyleDelta ToggleCapitalization(TextCapitalization kind) =>
+        InlineStyleDelta.WithCapitalization(
+            CurrentInlineStyle.Capitalization == kind ? TextCapitalization.None : kind);
 
     private static InlineStyleDelta FontStyleDelta(BFontStyle font) => new()
     {

--- a/Broiler.UI/src/Implementations/Standard/Text/Broiler.UI.RichEdit.Standard/StandardRichEdit.cs
+++ b/Broiler.UI/src/Implementations/Standard/Text/Broiler.UI.RichEdit.Standard/StandardRichEdit.cs
@@ -341,10 +341,20 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
             return;
 
         double x = CaretX(Selection.Focus);
-        BFontStyle font = RunFont(CaretInlineStyle);
-        double advance = BTextMeasurer.MeasureAdvance(_compositionText, font);
+        InlineStyle style = CaretInlineStyle;
+        BFontStyle font = RunFont(style);
+        double advance = MeasurePieces(_compositionText, style, font);
         BColor color = IsEnabled ? Foreground : PlaceholderForeground;
-        renderList.DrawText(new BTextRun(_compositionText, font, color), new BPoint(x, y));
+
+        // Preedit text is drawn with the capitalization it will take once
+        // committed, so the text does not jump when the IME finishes.
+        double pieceX = x;
+        foreach (ShapedPiece piece in ShapePieces(_compositionText, style, font))
+        {
+            renderList.DrawText(new BTextRun(piece.Text, piece.Font, color), new BPoint(pieceX, y));
+            pieceX += BTextMeasurer.MeasureAdvance(piece.Text, piece.Font);
+        }
+
         renderList.FillRect(new BRect(x, y + line.Height - 2, advance, 1), color); // composition underline
     }
 
@@ -369,11 +379,82 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
                 continue;
 
             string text = paragraph.Text.Substring(segStart, segEnd - segStart);
-            BFontStyle font = RunFont(run.Style);
-            double advance = BTextMeasurer.MeasureAdvance(text, font);
-            yield return new LineSegment(text, run.Style, font, x, advance);
-            x += advance;
+            foreach (ShapedPiece piece in ShapePieces(text, run.Style, RunFont(run.Style)))
+            {
+                double advance = BTextMeasurer.MeasureAdvance(piece.Text, piece.Font);
+                yield return new LineSegment(piece.Text, run.Style, piece.Font, x, advance);
+                x += advance;
+            }
         }
+    }
+
+    /// <summary>How much smaller a small-caps letter is drawn than a full capital.</summary>
+    private const double SmallCapsScale = 0.8;
+
+    /// <summary>A stretch of a run as it is drawn: the glyphs, and the font to draw them with.</summary>
+    private readonly record struct ShapedPiece(string Text, BFontStyle Font);
+
+    /// <summary>
+    /// The pieces a stored substring is drawn as. Capitalization is a display
+    /// property — the document keeps the casing the author typed, and this is the
+    /// only place it becomes capitals, so turning it off restores the original
+    /// text exactly. Small caps additionally splits the substring wherever the
+    /// stored case changes, so letters typed in lower case can be drawn smaller
+    /// than the ones typed as capitals.
+    /// </summary>
+    private static IEnumerable<ShapedPiece> ShapePieces(string text, InlineStyle style, BFontStyle font)
+    {
+        if (text.Length == 0)
+            yield break;
+
+        if (style.Capitalization == TextCapitalization.AllCaps)
+        {
+            yield return new ShapedPiece(text.ToUpperInvariant(), font);
+            yield break;
+        }
+
+        if (style.Capitalization != TextCapitalization.SmallCaps)
+        {
+            yield return new ShapedPiece(text, font);
+            yield break;
+        }
+
+        BFontStyle reduced = font with { SizeInPixels = Math.Max(1, font.SizeInPixels * SmallCapsScale) };
+        int start = 0;
+        bool small = char.IsLower(text[0]);
+        for (int i = 1; i <= text.Length; i++)
+        {
+            if (i < text.Length && char.IsLower(text[i]) == small)
+                continue;
+
+            string piece = text[start..i];
+            yield return small
+                ? new ShapedPiece(piece.ToUpperInvariant(), reduced)
+                : new ShapedPiece(piece, font);
+
+            if (i < text.Length)
+            {
+                start = i;
+                small = char.IsLower(text[i]);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The advance of a stored substring as drawn. Every measurement goes through
+    /// here so caret placement, selection rectangles, and wrapping agree with what
+    /// <see cref="DrawText"/> puts on screen.
+    /// </summary>
+    private static double MeasurePieces(string text, InlineStyle style, BFontStyle font)
+    {
+        if (style.Capitalization == TextCapitalization.None)
+            return BTextMeasurer.MeasureAdvance(text, font);
+
+        double advance = 0;
+        foreach (ShapedPiece piece in ShapePieces(text, style, font))
+            advance += BTextMeasurer.MeasureAdvance(piece.Text, piece.Font);
+
+        return advance;
     }
 
     private BFontStyle RunFont(InlineStyle style)
@@ -1065,7 +1146,7 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
                 continue;
 
             string text = paragraph.Text.Substring(segmentStart, segmentEnd - segmentStart);
-            advance += BTextMeasurer.MeasureAdvance(text, RunFont(run.Style));
+            advance += MeasurePieces(text, run.Style, RunFont(run.Style));
         }
 
         return advance;
@@ -1205,11 +1286,11 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
         if (index + 1 < text.Length && char.IsHighSurrogate(text[index]) && char.IsLowSurrogate(text[index + 1]))
         {
             step = 2;
-            return BTextMeasurer.MeasureAdvance(text.Substring(index, 2), font);
+            return MeasurePieces(text.Substring(index, 2), style, font);
         }
 
         step = 1;
-        return BTextMeasurer.MeasureAdvance(text[index].ToString(), font);
+        return MeasurePieces(text[index].ToString(), style, font);
     }
 
     private bool IsDoubleClick(BPoint point)

--- a/Broiler.UI/tests/Text/Broiler.UI.RichEdit.Standard.Tests/StandardRichEditCapitalizationTests.cs
+++ b/Broiler.UI/tests/Text/Broiler.UI.RichEdit.Standard.Tests/StandardRichEditCapitalizationTests.cs
@@ -1,0 +1,189 @@
+using Broiler.Graphics;
+using static Broiler.UI.RichEdit.Standard.Tests.RichEditStandardHarness;
+
+namespace Broiler.UI.RichEdit.Standard.Tests;
+
+/// <summary>
+/// Capitalization is a display property: the control draws capitals while the
+/// document keeps the casing the author typed. These tests pin both halves of
+/// that — what reaches the render list, and what the model still holds.
+/// </summary>
+public sealed class StandardRichEditCapitalizationTests
+{
+    private static RichEditScene WithSelectionAll(string text)
+    {
+        RichEditScene scene = Create(new BSize(640, 200), text);
+        scene.Session.SetFocus(scene.Edit);
+        scene.Edit.Selection = new RichTextRange(scene.Edit.Document.Start, scene.Edit.Document.End);
+        return scene;
+    }
+
+    private static IEnumerable<BTextRun> DrawnRuns(BRenderList list) =>
+        list.Commands.OfType<BRenderCommand.DrawText>().Select(c => c.Text);
+
+    [Fact]
+    public void All_Caps_Draws_Capitals()
+    {
+        RichEditScene scene = WithSelectionAll("Elene Bartky");
+        scene.Edit.ExecuteCommand(RichEditCommand.AllCaps);
+
+        BRenderList list = scene.Session.RenderFrame();
+
+        Assert.Contains(DrawnRuns(list), run => run.Text == "ELENE BARTKY");
+        scene.Session.Dispose();
+    }
+
+    [Fact]
+    public void All_Caps_Leaves_The_Stored_Text_Untouched()
+    {
+        RichEditScene scene = WithSelectionAll("Elene Bartky");
+        scene.Edit.ExecuteCommand(RichEditCommand.AllCaps);
+        scene.Session.RenderFrame();
+
+        Assert.Equal("Elene Bartky", scene.Edit.Document.PlainText);
+        scene.Session.Dispose();
+    }
+
+    [Fact]
+    public void Turning_All_Caps_Off_Restores_The_Original_Casing_On_Screen()
+    {
+        RichEditScene scene = WithSelectionAll("Elene Bartky");
+        scene.Edit.ExecuteCommand(RichEditCommand.AllCaps);
+        scene.Session.RenderFrame();
+        scene.Edit.ExecuteCommand(RichEditCommand.AllCaps);
+
+        BRenderList list = scene.Session.RenderFrame();
+
+        Assert.Contains(DrawnRuns(list), run => run.Text == "Elene Bartky");
+        scene.Session.Dispose();
+    }
+
+    /// <summary>
+    /// Small caps splits the run where the stored case changes: capitals keep the
+    /// run's size, letters typed in lower case are drawn as capitals at a reduced
+    /// size.
+    /// </summary>
+    [Fact]
+    public void Small_Caps_Draws_Lowercase_Letters_As_Smaller_Capitals()
+    {
+        RichEditScene scene = WithSelectionAll("Ab");
+        scene.Edit.ExecuteCommand(RichEditCommand.SmallCaps);
+
+        BRenderList list = scene.Session.RenderFrame();
+        BTextRun[] runs = DrawnRuns(list).Where(run => run.Text is "A" or "B").ToArray();
+
+        BTextRun full = Assert.Single(runs, run => run.Text == "A");
+        BTextRun reduced = Assert.Single(runs, run => run.Text == "B");
+        Assert.True(
+            reduced.Font.SizeInPixels < full.Font.SizeInPixels,
+            "the letter typed in lower case should be drawn smaller");
+        scene.Session.Dispose();
+    }
+
+    [Fact]
+    public void Small_Caps_Leaves_The_Stored_Text_Untouched()
+    {
+        RichEditScene scene = WithSelectionAll("Ab");
+        scene.Edit.ExecuteCommand(RichEditCommand.SmallCaps);
+        scene.Session.RenderFrame();
+
+        Assert.Equal("Ab", scene.Edit.Document.PlainText);
+        scene.Session.Dispose();
+    }
+
+    [Fact]
+    public void The_Two_Capitalization_Kinds_Replace_Each_Other()
+    {
+        RichEditScene scene = WithSelectionAll("Ab");
+        scene.Edit.ExecuteCommand(RichEditCommand.AllCaps);
+        scene.Edit.ExecuteCommand(RichEditCommand.SmallCaps);
+
+        Assert.False(scene.Edit.GetCommandState(RichEditCommand.AllCaps).IsToggled);
+        Assert.True(scene.Edit.GetCommandState(RichEditCommand.SmallCaps).IsToggled);
+        scene.Session.Dispose();
+    }
+
+    [Fact]
+    public void Command_State_Reports_The_Active_Capitalization()
+    {
+        RichEditScene scene = WithSelectionAll("hello");
+
+        Assert.False(scene.Edit.GetCommandState(RichEditCommand.AllCaps).IsToggled);
+        scene.Edit.ExecuteCommand(RichEditCommand.AllCaps);
+        Assert.True(scene.Edit.GetCommandState(RichEditCommand.AllCaps).IsToggled);
+        scene.Edit.ExecuteCommand(RichEditCommand.AllCaps);
+        Assert.False(scene.Edit.GetCommandState(RichEditCommand.AllCaps).IsToggled);
+        scene.Session.Dispose();
+    }
+
+    [Fact]
+    public void Clearing_Formatting_Removes_Capitalization()
+    {
+        RichEditScene scene = WithSelectionAll("Elene Bartky");
+        scene.Edit.ExecuteCommand(RichEditCommand.AllCaps);
+        scene.Edit.ExecuteCommand(RichEditCommand.ClearFormatting);
+
+        BRenderList list = scene.Session.RenderFrame();
+
+        Assert.Contains(DrawnRuns(list), run => run.Text == "Elene Bartky");
+        scene.Session.Dispose();
+    }
+
+    /// <summary>
+    /// Caret placement and drawing must go through the same measurement, or the
+    /// caret drifts away from the glyphs. Capitals are not reliably wider than
+    /// their lowercase forms, so the assertion is agreement, not direction: the
+    /// caret at the end of the text lands exactly where the drawn glyphs end.
+    /// </summary>
+    [Theory]
+    [InlineData(RichEditCommand.AllCaps, "Elene Bartky")]
+    [InlineData(RichEditCommand.SmallCaps, "Elene Bartky")]
+    public void Caret_Lands_Where_The_Drawn_Glyphs_End(RichEditCommand command, string text)
+    {
+        RichEditScene scene = WithSelectionAll(text);
+        scene.Edit.ExecuteCommand(command);
+        scene.Edit.Selection = RichTextRange.Caret(scene.Edit.Document.End);
+        scene.Session.RenderFrame();
+
+        BRenderList list = scene.Session.RenderFrame();
+        BRenderCommand.DrawText last = list.Commands.OfType<BRenderCommand.DrawText>().Last();
+        double drawnEnd = last.Origin.X + BTextMeasurer.MeasureAdvance(last.Text.Text, last.Text.Font);
+
+        Assert.Equal(drawnEnd, CaretLeft(list), precision: 3);
+        scene.Session.Dispose();
+    }
+
+    /// <summary>Small caps must not change how much room the text takes when nothing is capitalized.</summary>
+    [Fact]
+    public void Small_Caps_Of_An_All_Lowercase_Run_Is_Narrower_Than_All_Caps()
+    {
+        double small = TextWidth("hello", RichEditCommand.SmallCaps);
+        double full = TextWidth("hello", RichEditCommand.AllCaps);
+
+        Assert.True(small < full, $"small caps ({small}) should be narrower than all caps ({full})");
+    }
+
+    private static double TextWidth(string text, RichEditCommand command)
+    {
+        RichEditScene scene = WithSelectionAll(text);
+        scene.Edit.ExecuteCommand(command);
+        scene.Edit.Selection = RichTextRange.Caret(scene.Edit.Document.End);
+        scene.Session.RenderFrame();
+
+        BRenderList list = scene.Session.RenderFrame();
+        double width = list.Commands
+            .OfType<BRenderCommand.DrawText>()
+            .Sum(drawn => BTextMeasurer.MeasureAdvance(drawn.Text.Text, drawn.Text.Font));
+
+        scene.Session.Dispose();
+        return width;
+    }
+
+    /// <summary>The caret is the thin filled rectangle furthest along the line.</summary>
+    private static double CaretLeft(BRenderList list) =>
+        list.Commands
+            .OfType<BRenderCommand.FillRect>()
+            .Where(fill => fill.Rect.Width <= 2)
+            .Select(fill => fill.Rect.Left)
+            .Max();
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ are versioned in lockstep during the preview.
 
 ## [Unreleased]
 
+### Fixed
+
+- `Broiler.Documents` — the DOCX reader walked only the direct `w:p` children of
+  `w:body`, so a document whose content lived inside a layout table (the shape CV
+  and letterhead templates use) opened completely empty in Broiler.Writer. Block
+  content is now walked recursively: tables, structured document tags, accepted
+  revisions, and `mc:AlternateContent`.
+
+### Added
+
+- `Broiler.Documents` — DOCX read diagnostics: `docx.read.summary`,
+  `docx.document.empty`, `docx.table.flattened`, `docx.block.unsupported`,
+  `docx.limit.depth`, and `docx.part.headerfooter`.
+- `Broiler.Cli` — `--convert-doc` prints every read diagnostic and the character
+  count, not just a diagnostic count.
+- `Broiler.Writer` — the status bar calls out a document that read as no content,
+  and `BROILER_WRITER_DOCUMENT_LOG=1` writes the read diagnostics to stderr.
+
 ## [0.1.0-preview.1] — first preview
 
 First packaged preview of the Broiler component libraries. **APIs are unstable**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,18 @@ are versioned in lockstep during the preview.
   and letterhead templates use) opened completely empty in Broiler.Writer. Block
   content is now walked recursively: tables, structured document tags, accepted
   revisions, and `mc:AlternateContent`.
+- `Broiler.Documents` — the DOCX reader ignored `word/styles.xml`, so template
+  documents (whose paragraphs carry no direct formatting at all) read as
+  undifferentiated body text. Named paragraph and character styles now resolve
+  through `w:docDefaults` and the `w:basedOn` chain, and `w:rFonts` theme
+  references resolve against `word/theme/theme1.xml`.
 
 ### Added
 
 - `Broiler.Documents` — DOCX read diagnostics: `docx.read.summary`,
   `docx.document.empty`, `docx.table.flattened`, `docx.block.unsupported`,
-  `docx.limit.depth`, and `docx.part.headerfooter`.
+  `docx.limit.depth`, `docx.part.headerfooter`, `docx.styles.missing`,
+  `docx.styles.unknown`, `docx.styles.cycle`, and `docx.styles.depth`.
 - `Broiler.Cli` — `--convert-doc` prints every read diagnostic and the character
   count, not just a diagnostic count.
 - `Broiler.Writer` — the status bar calls out a document that read as no content,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ are versioned in lockstep during the preview.
 
 ### Added
 
+- `Broiler.Documents.Model` — `InlineStyle.Capitalization` (`none`/`all caps`/
+  `small caps`), extending the ADR 0014 inline style set. Capitalization is a
+  display property: the text keeps the casing the author typed, so an
+  open-and-save no longer rewrites it. Round-trips as DOCX `w:caps`/
+  `w:smallCaps`, RTF `\caps`/`\scaps`, and CSS `text-transform`/`font-variant`.
+- `Broiler.UI.RichEdit` — draws capitalization, synthesizing small caps by
+  drawing letters typed in lower case as capitals at a reduced size, plus
+  `RichEditCommand.AllCaps`/`SmallCaps` and formatting-code tokens
+  `[All Caps ON]`, `[Small Caps ON]`, and `[Caps OFF]`.
 - `Broiler.Documents` — DOCX read diagnostics: `docx.read.summary`,
   `docx.document.empty`, `docx.table.flattened`, `docx.block.unsupported`,
   `docx.limit.depth`, `docx.part.headerfooter`, `docx.styles.missing`,

--- a/src/Broiler.Cli/DocumentConvertService.cs
+++ b/src/Broiler.Cli/DocumentConvertService.cs
@@ -77,7 +77,25 @@ public static class DocumentConvertService
         File.WriteAllBytes(outputPath, output);
         Console.WriteLine(
             $"Converted {inputPath} -> {outputPath} " +
-            $"({match.Codec.Name}, {read.Document.ParagraphCount} paragraph(s), {read.Diagnostics.Count} diagnostic(s)).");
+            $"({match.Codec.Name}, {read.Document.ParagraphCount} paragraph(s), " +
+            $"{read.Document.PlainText.Length} character(s), {read.Diagnostics.Count} diagnostic(s)).");
+        WriteDiagnostics(read.Diagnostics);
         return 0;
+    }
+
+    /// <summary>
+    /// Prints every read diagnostic. A conversion that silently drops content is
+    /// the hardest kind to debug, so the codes go to the console rather than
+    /// being summarized away as a count.
+    /// </summary>
+    private static void WriteDiagnostics(IReadOnlyList<DocumentDiagnostic> diagnostics)
+    {
+        foreach (DocumentDiagnostic diagnostic in diagnostics)
+        {
+            TextWriter writer = diagnostic.Severity == DocumentDiagnosticSeverity.Error
+                ? Console.Error
+                : Console.Out;
+            writer.WriteLine($"  {diagnostic.Severity}: {diagnostic.Code}: {diagnostic.Message}");
+        }
     }
 }

--- a/src/Broiler.Writer.FormatCodes.Tests/WriterDocumentLoadTests.cs
+++ b/src/Broiler.Writer.FormatCodes.Tests/WriterDocumentLoadTests.cs
@@ -1,0 +1,132 @@
+using System.IO.Compression;
+using System.Text;
+using Broiler.Documents;
+using Broiler.Documents.Model;
+using Broiler.Graphics;
+
+namespace Broiler.Writer.FormatCodes.Tests;
+
+/// <summary>
+/// End-to-end cover for opening a document in the Writer. The regression this
+/// guards is a DOCX whose whole body is one layout table — the shape CV and
+/// letterhead templates use — which opened as a blank page with no explanation.
+/// </summary>
+public sealed class WriterDocumentLoadTests
+{
+    [Fact]
+    public void Opens_A_Docx_Whose_Body_Is_A_Layout_Table()
+    {
+        using WriterApp app = CreateApp();
+        byte[] bytes = TableDocx("Elene Bartky", "Berufserfahrung");
+
+        using var stream = new MemoryStream(bytes, writable: false);
+        Assert.True(app.LoadDocument(stream, "Lebenslauf.docx"));
+
+        string text = app.Document.PlainText;
+        Assert.Contains("Elene Bartky", text, StringComparison.Ordinal);
+        Assert.Contains("Berufserfahrung", text, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            app.LastReadDiagnostics,
+            diagnostic => diagnostic.Code == "docx.document.empty");
+    }
+
+    [Fact]
+    public void Keeps_The_Read_Diagnostics_Of_The_Last_Open()
+    {
+        using WriterApp app = CreateApp();
+        using var stream = new MemoryStream(TableDocx("cell"), writable: false);
+        app.LoadDocument(stream, "table.docx");
+
+        Assert.Contains(app.LastReadDiagnostics, diagnostic => diagnostic.Code == "docx.read.summary");
+        Assert.Contains(app.LastReadDiagnostics, diagnostic => diagnostic.Code == "docx.table.flattened");
+    }
+
+    [Fact]
+    public void Open_Status_Ignores_Info_Notes()
+    {
+        var result = new DocumentReadResult(
+            RichTextDocument.FromPlainText("text"),
+            [DocumentDiagnostic.Info("docx.read.summary", "summary")]);
+
+        Assert.Equal("Opened file.docx", WriterApp.DescribeOpen("file.docx", result));
+    }
+
+    [Fact]
+    public void Open_Status_Counts_Warnings_And_Errors()
+    {
+        var result = new DocumentReadResult(
+            RichTextDocument.FromPlainText("text"),
+            [
+                DocumentDiagnostic.Info("docx.read.summary", "summary"),
+                DocumentDiagnostic.Warning("docx.table.flattened", "flattened"),
+                DocumentDiagnostic.Warning("docx.skip.embedded", "skipped"),
+            ]);
+
+        Assert.Equal("Opened file.docx with 2 note(s)", WriterApp.DescribeOpen("file.docx", result));
+    }
+
+    [Fact]
+    public void Open_Status_Calls_Out_A_Document_With_No_Readable_Content()
+    {
+        var result = new DocumentReadResult(
+            RichTextDocument.Empty,
+            [DocumentDiagnostic.Warning("docx.document.empty", "empty")]);
+
+        Assert.Equal(
+            "Opened file.docx (no readable content) with 1 note(s)",
+            WriterApp.DescribeOpen("file.docx", result));
+    }
+
+    private static WriterApp CreateApp()
+    {
+        var host = new WriterUiHost(
+            () => new BSize(1200, 800),
+            () => 1,
+            () => { },
+            _ => { });
+        return new WriterApp(host, () => { });
+    }
+
+    /// <summary>A DOCX package whose body holds nothing but a one-row table.</summary>
+    private static byte[] TableDocx(params string[] cells)
+    {
+        var body = new StringBuilder("<w:tbl><w:tblPr/><w:tblGrid/><w:tr>");
+        foreach (string cell in cells)
+            body.Append("<w:tc><w:tcPr/><w:p><w:r><w:t>").Append(cell).Append("</w:t></w:r></w:p></w:tc>");
+        body.Append("</w:tr></w:tbl><w:p/>");
+
+        var parts = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["[Content_Types].xml"] =
+                "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">" +
+                "<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>" +
+                "<Override PartName=\"/word/document.xml\" ContentType=\"" +
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml\"/>" +
+                "</Types>",
+            ["_rels/.rels"] =
+                "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
+                "<Relationship Id=\"rId1\" " +
+                "Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" " +
+                "Target=\"word/document.xml\"/>" +
+                "</Relationships>",
+            ["word/document.xml"] =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+                "<w:document xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\">" +
+                "<w:body>" + body + "</w:body></w:document>",
+        };
+
+        using var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (KeyValuePair<string, string> part in parts)
+            {
+                ZipArchiveEntry entry = archive.CreateEntry(part.Key, CompressionLevel.NoCompression);
+                using Stream stream = entry.Open();
+                byte[] encoded = Encoding.UTF8.GetBytes(part.Value);
+                stream.Write(encoded, 0, encoded.Length);
+            }
+        }
+
+        return buffer.ToArray();
+    }
+}

--- a/src/Broiler.Writer/WriterApp.cs
+++ b/src/Broiler.Writer/WriterApp.cs
@@ -69,6 +69,7 @@ internal sealed class WriterApp : IDisposable
     private string? _currentDocumentPath;
     private string _lastDirectory = Environment.CurrentDirectory;
     private string _lastAction = "Ready";
+    private IReadOnlyList<DocumentDiagnostic> _lastReadDiagnostics = Array.Empty<DocumentDiagnostic>();
 
     private const string DefaultDocumentExtension = ".rtf";
     private static readonly BSize FileDialogPreferredSize = new(740, 430);
@@ -210,6 +211,15 @@ internal sealed class WriterApp : IDisposable
 
     public UiSession Session => _session;
 
+    /// <summary>The document currently in the editor.</summary>
+    internal RichTextDocument Document => _editor.Document;
+
+    /// <summary>
+    /// The diagnostics of the most recent read, kept so a document that opens
+    /// unexpectedly blank can be explained rather than guessed at.
+    /// </summary>
+    internal IReadOnlyList<DocumentDiagnostic> LastReadDiagnostics => _lastReadDiagnostics;
+
     public BRenderList RenderFrame() => _session.RenderFrame();
 
     public void Dispatch(UiInputEvent input)
@@ -238,9 +248,7 @@ internal sealed class WriterApp : IDisposable
             DocumentReadResult result = ReadDocument(displayName, copy.ToArray());
             _currentDocumentPath = displayName;
             _title.Text = Path.GetFileName(displayName);
-            _lastAction = result.Diagnostics.Count == 0
-                ? "Opened " + Path.GetFileName(displayName)
-                : "Opened " + Path.GetFileName(displayName) + " with " + result.Diagnostics.Count.ToString(CultureInfo.InvariantCulture) + " note(s)";
+            _lastAction = DescribeOpen(Path.GetFileName(displayName), result);
             _editor.Document = result.Document;
             _editor.Selection = RichTextRange.Caret(_editor.Document.Start);
             _session.SetFocus(_editor);
@@ -695,9 +703,7 @@ internal sealed class WriterApp : IDisposable
             _currentDocumentPath = fullPath;
             _lastDirectory = Path.GetDirectoryName(fullPath) ?? _lastDirectory;
             _title.Text = Path.GetFileName(fullPath);
-            _lastAction = result.Diagnostics.Count == 0
-                ? "Opened " + Path.GetFileName(fullPath)
-                : "Opened " + Path.GetFileName(fullPath) + " with " + result.Diagnostics.Count.ToString(CultureInfo.InvariantCulture) + " note(s)";
+            _lastAction = DescribeOpen(Path.GetFileName(fullPath), result);
             _editor.Document = result.Document;
             _editor.Selection = RichTextRange.Caret(_editor.Document.Start);
             _session.SetFocus(_editor);
@@ -894,7 +900,56 @@ internal sealed class WriterApp : IDisposable
             throw new NotSupportedException("No readable document codec recognized '" + Path.GetExtension(fullPath) + "'.");
 
         using var readStream = new MemoryStream(bytes, writable: false);
-        return match.Codec.Read(readStream);
+        DocumentReadResult result = match.Codec.Read(readStream);
+        _lastReadDiagnostics = result.Diagnostics;
+        LogReadDiagnostics(match.Codec.Name, fullPath, result);
+        return result;
+    }
+
+    /// <summary>
+    /// Writes the read diagnostics to stderr when
+    /// <c>BROILER_WRITER_DOCUMENT_LOG</c> is set. Off by default: the status bar
+    /// carries the summary, and this is the switch for chasing one bad file.
+    /// </summary>
+    private static void LogReadDiagnostics(string codecName, string fullPath, DocumentReadResult result)
+    {
+        if (!IsDocumentLoggingEnabled)
+            return;
+
+        Console.Error.WriteLine(
+            "[writer] read " + Path.GetFileName(fullPath) + " via " + codecName + ": " +
+            result.Document.ParagraphCount.ToString(CultureInfo.InvariantCulture) + " paragraph(s), " +
+            result.Document.PlainText.Length.ToString(CultureInfo.InvariantCulture) + " character(s), " +
+            result.Diagnostics.Count.ToString(CultureInfo.InvariantCulture) + " diagnostic(s)");
+        foreach (DocumentDiagnostic diagnostic in result.Diagnostics)
+            Console.Error.WriteLine("[writer]   " + diagnostic);
+    }
+
+    private static bool IsDocumentLoggingEnabled =>
+        Environment.GetEnvironmentVariable("BROILER_WRITER_DOCUMENT_LOG") is "1" or "true" or "TRUE" or "on";
+
+    /// <summary>
+    /// Builds the status-bar text for a completed open. Info-level notes are
+    /// routine and stay out of the count; a read that produced no text at all is
+    /// called out, because "nothing happened" is the one outcome the user cannot
+    /// otherwise tell apart from an empty file.
+    /// </summary>
+    internal static string DescribeOpen(string fileName, DocumentReadResult result)
+    {
+        string text = "Opened " + fileName;
+        if (result.Document.PlainText.Length == 0)
+            text += " (no readable content)";
+
+        int notes = 0;
+        foreach (DocumentDiagnostic diagnostic in result.Diagnostics)
+        {
+            if (diagnostic.Severity != DocumentDiagnosticSeverity.Info)
+                notes++;
+        }
+
+        return notes == 0
+            ? text
+            : text + " with " + notes.ToString(CultureInfo.InvariantCulture) + " note(s)";
     }
 
     private static DocumentWriteResult WriteDocument(


### PR DESCRIPTION
## Summary

The DOCX reader previously walked only direct `w:p` children of `w:body`, causing documents whose content lived inside layout tables (the standard shape for CVs and letterhead templates) to open completely empty. This change walks block-level content recursively, extracting paragraphs from tables, structured document tags, accepted revisions, and alternate content blocks.

## Key Changes

- **Block content walker** (`ReadBlockContent`): Recursively processes all `EG_BlockLevelElts` — paragraphs, tables, structured document tags (`w:sdt`), accepted revisions (`w:ins`, `w:moveTo`), custom XML wrappers, and `mc:AlternateContent` blocks. Deleted revisions and moved-from content are skipped with diagnostics.

- **Table flattening** (`ReadTable`): Tables are flattened into their cell paragraphs in row-major order, with a `docx.table.flattened` diagnostic. This preserves all text since `RichTextDocument` has no table shape.

- **Nested table and content control support** (`EnumerateTableChildren`): Rows and cells wrapped in structured document tags or revision markers are unwrapped and processed correctly.

- **Alternate content handling** (`ReadAlternateContent`): Reads the first `mc:Choice` or falls back to `mc:Fallback`, ensuring content is not duplicated.

- **Depth limiting**: Block nesting deeper than `DocumentLimits.MaxGroupDepth` (default 256) is abandoned with a `docx.limit.depth` diagnostic to prevent unbounded recursion.

- **Diagnostics**: New codes track the read operation:
  - `docx.read.summary`: Paragraph, table, and unsupported block counts
  - `docx.document.empty`: Warning when block content yields no paragraphs
  - `docx.table.flattened`: Tables were flattened
  - `docx.block.unsupported`: Unknown block-level elements (keyed by name, reported once per distinct element)
  - `docx.limit.depth`: Nesting limit exceeded
  - `docx.revision.delete`: Deleted revision content skipped
  - `docx.part.headerfooter`: Headers/footers not imported

- **Writer integration**: `WriterApp` now stores and logs read diagnostics; the status bar calls out documents that read as empty, and `BROILER_WRITER_DOCUMENT_LOG` enables diagnostic logging to stderr.

- **CLI enhancement**: `--convert-doc` now prints every diagnostic and character count, not just a count.

## Implementation Details

- Ignorable structural blocks (`w:sectPr`, `w:tblPr`, `w:bookmarkStart`, etc.) are skipped silently without diagnostics.
- Unsupported blocks are reported once per element name (the name is markup structure, never document text, per ADR 0004 privacy rule).
- The read summary is always emitted as an info diagnostic, making silent content loss visible.
- Test coverage includes CV-shaped documents, nested tables, content controls wrapping table rows, revision markers, and alternate content branches.

## Verification

Local runs on the reporting document (one layout table holding the whole CV): before, `1 paragraph(s), 0 diagnostic(s)` and no text at all; after, 81 paragraphs / 1504 characters, verified end to end through `WriterApp.LoadDocument`. Full `Broiler.Documents` suite (284 tests) and `Broiler.Writer.FormatCodes.Tests` (26) pass.

## Known Gaps (diagnosed, not hidden)

- Images are dropped (`docx.skip.embedded`) — `RichTextDocument` has no image shape.
- Flattening is row-major, so a two-column layout table reads its sidebar after the main column.
- `w:pStyle` is still not resolved against `styles.xml`, so text arrives with direct formatting only. Separate fidelity gap, deliberately out of scope here.

https://claude.ai/code/session_019NKBW8FvxCzP3ZevVL6aHn