### PR TITLE
Add embedded image support to document model and codecs

### DIFF
--- a/Broiler.Documents/Broiler.Documents.Docx.Tests/DocxImageTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx.Tests/DocxImageTests.cs
@@ -1,0 +1,300 @@
+using System.IO.Compression;
+
+namespace Broiler.Documents.Docx.Tests;
+
+/// <summary>
+/// Reading and writing embedded pictures: the DrawingML and VML shapes a run can
+/// hold, the media parts they reference, and the package a write produces.
+/// </summary>
+public sealed class DocxImageTests
+{
+    /// <summary>914400 EMUs per inch; one inch square is the size these tests use.</summary>
+    private const long OneInchEmus = 914400;
+
+    private static Dictionary<string, byte[]> Media(string path, byte[]? bytes = null) =>
+        new(StringComparer.Ordinal) { [path] = bytes ?? DocxTestPackage.OnePixelPng };
+
+    [Fact]
+    public void Reads_An_Inline_Drawing_As_One_Image_Character()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadWithMedia(
+            "<w:p>" + DocxTestPackage.DrawingRun("rId7", OneInchEmus, OneInchEmus / 2) + "</w:p>",
+            DocxTestPackage.ImageRelationship("rId7", "media/image1.png"),
+            Media("word/media/image1.png"));
+
+        RichTextParagraph paragraph = Assert.Single(result.Document.Paragraphs);
+        Assert.Equal(InlineImage.PlaceholderText, paragraph.Text);
+
+        StyleRun run = Assert.Single(paragraph.Runs);
+        InlineImage image = Assert.IsType<InlineImage>(run.Style.Image);
+        Assert.Equal(1, run.Length);
+        Assert.Equal("image/png", image.ContentType);
+        Assert.Equal(DocxTestPackage.OnePixelPng, image.Data.ToArray());
+
+        // 914400 EMUs is one inch, which is 72 points.
+        Assert.Equal(72, image.Width, 3);
+        Assert.Equal(36, image.Height, 3);
+    }
+
+    [Fact]
+    public void Reads_Alternative_Text_And_Keeps_Surrounding_Text_In_Order()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadWithMedia(
+            "<w:p><w:r><w:t>before </w:t></w:r>" +
+            DocxTestPackage.DrawingRun("rId7", OneInchEmus, OneInchEmus, altText: "a logo") +
+            "<w:r><w:t> after</w:t></w:r></w:p>",
+            DocxTestPackage.ImageRelationship("rId7", "media/image1.png"),
+            Media("word/media/image1.png"));
+
+        RichTextParagraph paragraph = Assert.Single(result.Document.Paragraphs);
+        Assert.Equal("before " + InlineImage.PlaceholderText + " after", paragraph.Text);
+        Assert.Equal(3, paragraph.Runs.Count);
+        Assert.Equal("a logo", paragraph.Runs[1].Style.Image?.AltText);
+        Assert.Null(paragraph.Runs[0].Style.Image);
+        Assert.Null(paragraph.Runs[2].Style.Image);
+    }
+
+    [Fact]
+    public void Keeps_The_Runs_Own_Formatting_On_An_Image()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadWithMedia(
+            "<w:p><w:hyperlink r:id=\"rId8\">" +
+            DocxTestPackage.DrawingRun("rId7", OneInchEmus, OneInchEmus) +
+            "</w:hyperlink></w:p>",
+            DocxTestPackage.ImageRelationship("rId7", "media/image1.png") +
+            "<Relationship Id=\"rId8\" " +
+            "Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink\" " +
+            "Target=\"https://example.test/\" TargetMode=\"External\"/>",
+            Media("word/media/image1.png"));
+
+        StyleRun run = Assert.Single(Assert.Single(result.Document.Paragraphs).Runs);
+        Assert.NotNull(run.Style.Image);
+        Assert.Equal("https://example.test/", run.Style.LinkHref);
+    }
+
+    [Fact]
+    public void Reads_A_Legacy_Vml_Picture_And_Its_Css_Size()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadWithMedia(
+            "<w:p>" + DocxTestPackage.VmlPictureRun("rId7", "width:90pt;height:45pt") + "</w:p>",
+            DocxTestPackage.ImageRelationship("rId7", "media/image1.png"),
+            Media("word/media/image1.png"));
+
+        StyleRun run = Assert.Single(Assert.Single(result.Document.Paragraphs).Runs);
+        InlineImage image = Assert.IsType<InlineImage>(run.Style.Image);
+        Assert.Equal(90, image.Width, 3);
+        Assert.Equal(45, image.Height, 3);
+    }
+
+    [Fact]
+    public void Reads_One_Media_Part_Once_When_Several_Runs_Share_It()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadWithMedia(
+            "<w:p>" +
+            DocxTestPackage.DrawingRun("rId7", OneInchEmus, OneInchEmus) +
+            DocxTestPackage.DrawingRun("rId7", OneInchEmus, OneInchEmus) +
+            "</w:p>",
+            DocxTestPackage.ImageRelationship("rId7", "media/image1.png"),
+            Media("word/media/image1.png"));
+
+        RichTextParagraph paragraph = Assert.Single(result.Document.Paragraphs);
+
+        // Two pictures are two characters and two runs: each carries its own
+        // image object, so neither collapses into the other.
+        Assert.Equal(2, paragraph.Text.Length);
+        Assert.Equal(2, paragraph.Runs.Count);
+        Assert.NotSame(paragraph.Runs[0].Style.Image, paragraph.Runs[1].Style.Image);
+        Assert.Equal(
+            paragraph.Runs[0].Style.Image!.Data.ToArray(),
+            paragraph.Runs[1].Style.Image!.Data.ToArray());
+    }
+
+    [Fact]
+    public void Counts_Images_In_The_Read_Summary()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadWithMedia(
+            "<w:p>" + DocxTestPackage.DrawingRun("rId7", OneInchEmus, OneInchEmus) + "</w:p>",
+            DocxTestPackage.ImageRelationship("rId7", "media/image1.png"),
+            Media("word/media/image1.png"));
+
+        DocumentDiagnostic summary = Assert.Single(
+            result.Diagnostics.Where(d => d.Code == "docx.read.summary"));
+        Assert.Contains("embedded 1 image(s)", summary.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Reports_A_Picture_Whose_Media_Part_Is_Missing()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadWithMedia(
+            "<w:p>" + DocxTestPackage.DrawingRun("rId7", OneInchEmus, OneInchEmus) + "</w:p>",
+            DocxTestPackage.ImageRelationship("rId7", "media/image1.png"),
+            new Dictionary<string, byte[]>(StringComparer.Ordinal));
+
+        Assert.Empty(Assert.Single(result.Document.Paragraphs).Text);
+        Assert.Contains(result.Diagnostics, d => d.Code == "docx.image.missing");
+    }
+
+    [Fact]
+    public void Reports_A_Picture_Whose_Relationship_Is_Undefined()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadWithMedia(
+            "<w:p>" + DocxTestPackage.DrawingRun("rId99", OneInchEmus, OneInchEmus) + "</w:p>",
+            DocxTestPackage.ImageRelationship("rId7", "media/image1.png"),
+            Media("word/media/image1.png"));
+
+        Assert.Empty(Assert.Single(result.Document.Paragraphs).Text);
+        Assert.Contains(result.Diagnostics, d => d.Code == "docx.image.relationship");
+    }
+
+    [Fact]
+    public void Reports_An_Image_Format_It_Does_Not_Carry()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadWithMedia(
+            "<w:p>" + DocxTestPackage.DrawingRun("rId7", OneInchEmus, OneInchEmus) + "</w:p>",
+            DocxTestPackage.ImageRelationship("rId7", "media/image1.emf"),
+            Media("word/media/image1.emf", [0x01, 0x00, 0x00, 0x00, 0x6C]));
+
+        Assert.Empty(Assert.Single(result.Document.Paragraphs).Text);
+        Assert.Contains(result.Diagnostics, d => d.Code == "docx.image.format");
+    }
+
+    [Fact]
+    public void Skips_An_Image_Part_Over_The_Binary_Limit()
+    {
+        // The limit has to clear the package's XML parts, which it also governs,
+        // so the picture rather than the document is what exceeds it.
+        byte[] oversized = new byte[8192];
+        DocxTestPackage.OnePixelPng.CopyTo(oversized, 0);
+
+        var options = new DocumentReadOptions(new DocumentLimits(maxBinBytes: 4096));
+        DocumentReadResult result = DocxTestPackage.ReadWithMedia(
+            "<w:p>" + DocxTestPackage.DrawingRun("rId7", OneInchEmus, OneInchEmus) + "</w:p>",
+            DocxTestPackage.ImageRelationship("rId7", "media/image1.png"),
+            Media("word/media/image1.png", oversized),
+            options);
+
+        Assert.Empty(Assert.Single(result.Document.Paragraphs).Text);
+        Assert.Contains(result.Diagnostics, d => d.Code == "docx.image.limit");
+    }
+
+    [Fact]
+    public void Does_Not_Fetch_An_Externally_Linked_Picture()
+    {
+        DocumentReadResult result = DocxTestPackage.ReadWithMedia(
+            "<w:p>" + DocxTestPackage.DrawingRun("rId7", OneInchEmus, OneInchEmus) + "</w:p>",
+            "<Relationship Id=\"rId7\" " +
+            "Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\" " +
+            "Target=\"https://example.test/logo.png\" TargetMode=\"External\"/>",
+            new Dictionary<string, byte[]>(StringComparer.Ordinal));
+
+        Assert.Empty(Assert.Single(result.Document.Paragraphs).Text);
+        Assert.Contains(result.Diagnostics, d => d.Code == "docx.image.external");
+    }
+
+    [Fact]
+    public void Writes_An_Image_As_A_Media_Part_With_Its_Relationship_And_Content_Type()
+    {
+        var image = new InlineImage(DocxTestPackage.OnePixelPng, "image/png", 72, 36, "a logo");
+        RichTextDocument document = RichTextDocument.FromParagraphs(
+        [
+            RichTextParagraph.Create(InlineImage.PlaceholderText, InlineStyle.Default with { Image = image }),
+        ]);
+
+        byte[] bytes = DocxDocumentCodec.WriteToArray(document);
+        using var archive = new ZipArchive(new MemoryStream(bytes), ZipArchiveMode.Read);
+
+        ZipArchiveEntry media = Assert.IsType<ZipArchiveEntry>(archive.GetEntry("word/media/image1.png"));
+        using (Stream stream = media.Open())
+        using (var buffer = new MemoryStream())
+        {
+            stream.CopyTo(buffer);
+            Assert.Equal(DocxTestPackage.OnePixelPng, buffer.ToArray());
+        }
+
+        string relationships = ReadEntry(archive, "word/_rels/document.xml.rels");
+        Assert.Contains("relationships/image", relationships, StringComparison.Ordinal);
+        Assert.Contains("media/image1.png", relationships, StringComparison.Ordinal);
+
+        string contentTypes = ReadEntry(archive, "[Content_Types].xml");
+        Assert.Contains("Extension=\"png\"", contentTypes, StringComparison.Ordinal);
+
+        string documentXml = ReadEntry(archive, "word/document.xml");
+        Assert.Contains("<w:drawing>", documentXml, StringComparison.Ordinal);
+        Assert.Contains("descr=\"a logo\"", documentXml, StringComparison.Ordinal);
+
+        // 72 points and 36 points, in EMUs.
+        Assert.Contains("cx=\"914400\"", documentXml, StringComparison.Ordinal);
+        Assert.Contains("cy=\"457200\"", documentXml, StringComparison.Ordinal);
+        Assert.DoesNotContain("￼", documentXml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Writes_One_Media_Part_For_An_Image_Used_Twice()
+    {
+        var image = new InlineImage(DocxTestPackage.OnePixelPng, "image/png", 72, 72);
+        var style = InlineStyle.Default with { Image = image };
+        RichTextDocument document = RichTextDocument.FromParagraphs(
+        [
+            RichTextParagraph.Create(InlineImage.PlaceholderText, style),
+            RichTextParagraph.Create(InlineImage.PlaceholderText, style),
+        ]);
+
+        byte[] bytes = DocxDocumentCodec.WriteToArray(document);
+        using var archive = new ZipArchive(new MemoryStream(bytes), ZipArchiveMode.Read);
+
+        Assert.NotNull(archive.GetEntry("word/media/image1.png"));
+        Assert.Null(archive.GetEntry("word/media/image2.png"));
+    }
+
+    [Fact]
+    public void Round_Trips_An_Image_Through_Write_And_Read()
+    {
+        var image = new InlineImage(DocxTestPackage.OnePixelPng, "image/png", 120, 60, "a logo");
+        RichTextDocument document = RichTextDocument.FromParagraphs(
+        [
+            RichTextParagraph.Create("before", InlineStyle.Default)
+                .InsertText(6, InlineImage.PlaceholderText, InlineStyle.Default with { Image = image })
+                .InsertText(7, "after", InlineStyle.Default),
+        ]);
+
+        byte[] bytes = DocxDocumentCodec.WriteToArray(document);
+        using var stream = new MemoryStream(bytes, writable: false);
+        DocumentReadResult result = new DocxDocumentCodec().Read(stream);
+
+        RichTextParagraph paragraph = Assert.Single(result.Document.Paragraphs);
+        Assert.Equal("before" + InlineImage.PlaceholderText + "after", paragraph.Text);
+
+        InlineImage restored = Assert.IsType<InlineImage>(paragraph.Runs[1].Style.Image);
+        Assert.Equal(DocxTestPackage.OnePixelPng, restored.Data.ToArray());
+        Assert.Equal("image/png", restored.ContentType);
+        Assert.Equal(120, restored.Width, 3);
+        Assert.Equal(60, restored.Height, 3);
+        Assert.Equal("a logo", restored.AltText);
+    }
+
+    [Fact]
+    public void Drops_A_Placeholder_Character_That_Carries_No_Image()
+    {
+        RichTextDocument document = RichTextDocument.FromParagraphs(
+        [
+            RichTextParagraph.Create("a" + InlineImage.PlaceholderText + "b", InlineStyle.Default),
+        ]);
+
+        using var buffer = new MemoryStream();
+        DocumentWriteResult write = new DocxDocumentCodec().Write(document, buffer);
+
+        using var archive = new ZipArchive(new MemoryStream(buffer.ToArray()), ZipArchiveMode.Read);
+        string documentXml = ReadEntry(archive, "word/document.xml");
+
+        Assert.DoesNotContain("￼", documentXml, StringComparison.Ordinal);
+        Assert.Contains(write.Diagnostics, d => d.Code == "docx.image.placeholder");
+    }
+
+    private static string ReadEntry(ZipArchive archive, string path)
+    {
+        ZipArchiveEntry entry = Assert.IsType<ZipArchiveEntry>(archive.GetEntry(path));
+        using Stream stream = entry.Open();
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/Broiler.Documents/Broiler.Documents.Docx.Tests/DocxTestPackage.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx.Tests/DocxTestPackage.cs
@@ -17,7 +17,10 @@ internal static class DocxTestPackage
         "xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"";
 
     /// <summary>Wraps <paramref name="bodyXml"/> in a document part and zips a package around it.</summary>
-    public static byte[] FromBody(string bodyXml, IReadOnlyDictionary<string, string>? extraParts = null)
+    public static byte[] FromBody(
+        string bodyXml,
+        IReadOnlyDictionary<string, string>? extraParts = null,
+        IReadOnlyDictionary<string, byte[]>? binaryParts = null)
     {
         string documentXml =
             "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
@@ -48,8 +51,94 @@ internal static class DocxTestPackage
                 parts[part.Key] = part.Value;
         }
 
-        return Zip(parts);
+        var binary = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        foreach (KeyValuePair<string, string> part in parts)
+            binary[part.Key] = Encoding.UTF8.GetBytes(part.Value);
+
+        if (binaryParts is not null)
+        {
+            foreach (KeyValuePair<string, byte[]> part in binaryParts)
+                binary[part.Key] = part.Value;
+        }
+
+        return Zip(binary);
     }
+
+    /// <summary>
+    /// Reads a package whose document part declares relationships and carries
+    /// media parts — the shape a package with pictures has.
+    /// </summary>
+    public static DocumentReadResult ReadWithMedia(
+        string bodyXml,
+        string relationshipsInnerXml,
+        IReadOnlyDictionary<string, byte[]> mediaParts,
+        DocumentReadOptions? options = null)
+    {
+        var parts = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["word/_rels/document.xml.rels"] =
+                "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
+                relationshipsInnerXml +
+                "</Relationships>",
+        };
+
+        using var stream = new MemoryStream(FromBody(bodyXml, parts, mediaParts), writable: false);
+        return new DocxDocumentCodec().Read(stream, options);
+    }
+
+    /// <summary>An image relationship pointing at a part under <c>word/media</c>.</summary>
+    public static string ImageRelationship(string id, string target) =>
+        "<Relationship Id=\"" + id + "\" " +
+        "Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\" " +
+        "Target=\"" + target + "\"/>";
+
+    /// <summary>
+    /// A run holding one DrawingML picture sized in EMUs, as Word writes it.
+    /// </summary>
+    public static string DrawingRun(
+        string relationshipId,
+        long widthEmus,
+        long heightEmus,
+        string? altText = null) =>
+        "<w:r><w:drawing>" +
+        "<wp:inline xmlns:wp=\"http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing\" " +
+        "distT=\"0\" distB=\"0\" distL=\"0\" distR=\"0\">" +
+        "<wp:extent cx=\"" + widthEmus + "\" cy=\"" + heightEmus + "\"/>" +
+        "<wp:docPr id=\"1\" name=\"Picture 1\"" +
+        (altText is null ? string.Empty : " descr=\"" + Escape(altText) + "\"") + "/>" +
+        "<a:graphic xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\">" +
+        "<a:graphicData uri=\"http://schemas.openxmlformats.org/drawingml/2006/picture\">" +
+        "<pic:pic xmlns:pic=\"http://schemas.openxmlformats.org/drawingml/2006/picture\">" +
+        "<pic:nvPicPr><pic:cNvPr id=\"1\" name=\"Picture 1\"/><pic:cNvPicPr/></pic:nvPicPr>" +
+        "<pic:blipFill><a:blip r:embed=\"" + relationshipId + "\"/>" +
+        "<a:stretch><a:fillRect/></a:stretch></pic:blipFill>" +
+        "<pic:spPr><a:prstGeom prst=\"rect\"><a:avLst/></a:prstGeom></pic:spPr>" +
+        "</pic:pic></a:graphicData></a:graphic>" +
+        "</wp:inline></w:drawing></w:r>";
+
+    /// <summary>A run holding the legacy VML picture shape, sized by CSS.</summary>
+    public static string VmlPictureRun(string relationshipId, string style) =>
+        "<w:r><w:pict>" +
+        "<v:shape xmlns:v=\"urn:schemas-microsoft-com:vml\" id=\"logo\" style=\"" + style + "\">" +
+        "<v:imagedata r:id=\"" + relationshipId + "\"/>" +
+        "</v:shape></w:pict></w:r>";
+
+    /// <summary>
+    /// The smallest valid PNG this codec will accept: a one-pixel image, used
+    /// wherever a test needs real image bytes rather than their content.
+    /// </summary>
+    public static byte[] OnePixelPng { get; } =
+    [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+        0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+        0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+        0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+        0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+        0x42, 0x60, 0x82,
+    ];
 
     /// <summary>Reads a package built by <see cref="FromBody"/> through the public codec.</summary>
     public static DocumentReadResult ReadBody(string bodyXml, DocumentReadOptions? options = null)
@@ -135,17 +224,16 @@ internal static class DocxTestPackage
             .Replace("<", "&lt;", StringComparison.Ordinal)
             .Replace(">", "&gt;", StringComparison.Ordinal);
 
-    private static byte[] Zip(IReadOnlyDictionary<string, string> parts)
+    private static byte[] Zip(IReadOnlyDictionary<string, byte[]> parts)
     {
         using var buffer = new MemoryStream();
         using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
         {
-            foreach (KeyValuePair<string, string> part in parts)
+            foreach (KeyValuePair<string, byte[]> part in parts)
             {
                 ZipArchiveEntry entry = archive.CreateEntry(part.Key, CompressionLevel.NoCompression);
                 using Stream stream = entry.Open();
-                byte[] bytes = Encoding.UTF8.GetBytes(part.Value);
-                stream.Write(bytes, 0, bytes.Length);
+                stream.Write(part.Value, 0, part.Value.Length);
             }
         }
 

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxImageFormats.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxImageFormats.cs
@@ -1,0 +1,75 @@
+using System;
+
+namespace Broiler.Documents.Docx;
+
+/// <summary>
+/// The raster image formats the DOCX codec carries between a package's
+/// <c>word/media</c> parts and <see cref="Model.InlineImage"/>.
+/// </summary>
+/// <remarks>
+/// The list is deliberately raster-only. Word also embeds EMF/WMF metafiles —
+/// usually as the fallback branch beside a chart or a shape — and those cannot
+/// be decoded into pixels here, so they are reported rather than carried as an
+/// image that would draw as nothing.
+/// </remarks>
+internal static class DocxImageFormats
+{
+    /// <summary>The media type for a media part's extension, or null when it is not a raster image.</summary>
+    public static string? ContentTypeForExtension(string? extension)
+    {
+        if (string.IsNullOrEmpty(extension))
+            return null;
+
+        return extension.TrimStart('.').ToLowerInvariant() switch
+        {
+            "png" => "image/png",
+            "jpg" or "jpeg" or "jpe" => "image/jpeg",
+            "gif" => "image/gif",
+            "bmp" or "dib" => "image/bmp",
+            "tif" or "tiff" => "image/tiff",
+            "webp" => "image/webp",
+            "ico" => "image/x-icon",
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// The media type implied by the leading bytes, used when the media part's
+    /// extension is missing or unknown. Sniffing only confirms formats already on
+    /// the supported list; it never widens it.
+    /// </summary>
+    public static string? ContentTypeForSignature(ReadOnlySpan<byte> data)
+    {
+        if (StartsWith(data, [0x89, (byte)'P', (byte)'N', (byte)'G', 0x0D, 0x0A, 0x1A, 0x0A]))
+            return "image/png";
+        if (StartsWith(data, [0xFF, 0xD8, 0xFF]))
+            return "image/jpeg";
+        if (StartsWith(data, "GIF87a"u8) || StartsWith(data, "GIF89a"u8))
+            return "image/gif";
+        if (StartsWith(data, "BM"u8))
+            return "image/bmp";
+        if (StartsWith(data, [0x49, 0x49, 0x2A, 0x00]) || StartsWith(data, [0x4D, 0x4D, 0x00, 0x2A]))
+            return "image/tiff";
+        if (data.Length >= 12 && StartsWith(data, "RIFF"u8) && data[8..12].SequenceEqual("WEBP"u8))
+            return "image/webp";
+
+        return null;
+    }
+
+    /// <summary>The file extension a writer should give a part of <paramref name="contentType"/>.</summary>
+    public static string ExtensionForContentType(string? contentType) =>
+        contentType?.ToLowerInvariant() switch
+        {
+            "image/png" => "png",
+            "image/jpeg" or "image/jpg" => "jpeg",
+            "image/gif" => "gif",
+            "image/bmp" or "image/x-ms-bmp" => "bmp",
+            "image/tiff" => "tiff",
+            "image/webp" => "webp",
+            "image/x-icon" or "image/vnd.microsoft.icon" => "ico",
+            _ => "png",
+        };
+
+    private static bool StartsWith(ReadOnlySpan<byte> data, ReadOnlySpan<byte> prefix) =>
+        data.Length >= prefix.Length && data[..prefix.Length].SequenceEqual(prefix);
+}

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxImages.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxImages.cs
@@ -1,0 +1,392 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Xml.Linq;
+using Broiler.Documents.Model;
+
+namespace Broiler.Documents.Docx;
+
+/// <summary>
+/// Reads the picture markup a run can hold — DrawingML (<c>w:drawing</c>) and
+/// the legacy VML shape (<c>w:pict</c>) — into <see cref="InlineImage"/> values,
+/// loading each referenced <c>word/media</c> part at most once.
+/// </summary>
+internal sealed class DocxImageLoader
+{
+    /// <summary>English Metric Units per point: 914400 per inch over 72 points per inch.</summary>
+    private const double EmusPerPoint = 12700.0;
+
+    /// <summary>
+    /// A ceiling on what one picture may draw as. Word stores the display size,
+    /// and a corrupt or hostile extent would otherwise ask the layout for a line
+    /// millions of units tall.
+    /// </summary>
+    private const double MaxDisplayExtent = 20000.0;
+
+    private readonly ZipArchive _archive;
+    private readonly DocumentLimits _limits;
+    private readonly Dictionary<string, MediaPart?> _parts = new(StringComparer.OrdinalIgnoreCase);
+
+    public DocxImageLoader(ZipArchive archive, DocumentLimits limits)
+    {
+        _archive = archive;
+        _limits = limits;
+    }
+
+    /// <summary>How many pictures this read turned into inline images.</summary>
+    public int ImageCount { get; private set; }
+
+    /// <summary>
+    /// Reads a <c>w:drawing</c> or <c>w:pict</c> element. Returns null — after
+    /// recording why — when the element holds no picture this codec can carry.
+    /// </summary>
+    public InlineImage? Read(
+        XElement element,
+        DocxRelationships relationships,
+        IDocxImageDiagnostics diagnostics)
+    {
+        InlineImage? image = element.Name == DocxNamespaces.Wordprocessing + "drawing"
+            ? ReadDrawing(element, relationships, diagnostics)
+            : ReadVmlPicture(element, relationships, diagnostics);
+
+        if (image is not null)
+            ImageCount++;
+
+        return image;
+    }
+
+    /// <summary>
+    /// Reads the DrawingML shape: <c>wp:inline</c> or <c>wp:anchor</c>, then the
+    /// <c>pic:pic</c> under its graphic data. Anchored (floating) pictures are
+    /// read as inline ones — the model has no float, and dropping them would lose
+    /// the logo at the top of most letterhead templates.
+    /// </summary>
+    private InlineImage? ReadDrawing(
+        XElement drawing,
+        DocxRelationships relationships,
+        IDocxImageDiagnostics diagnostics)
+    {
+        foreach (XElement wrapper in drawing.Elements())
+        {
+            bool isInline = wrapper.Name == DocxNamespaces.WordDrawing + "inline";
+            bool isAnchor = wrapper.Name == DocxNamespaces.WordDrawing + "anchor";
+            if (!isInline && !isAnchor)
+                continue;
+
+            if (isAnchor)
+            {
+                diagnostics.AddDiagnosticOnce(
+                    "docx.image.anchored",
+                    "A floating DOCX picture was placed inline; text wrapping is not represented.");
+            }
+
+            XElement? blip = FindDescendant(wrapper, DocxNamespaces.Drawing + "blip");
+            if (blip is null)
+            {
+                diagnostics.AddDiagnosticOnce(
+                    "docx.image.shape",
+                    "A DOCX drawing held no embedded picture and was skipped.");
+                return null;
+            }
+
+            string? relationshipId = (string?)blip.Attribute(DocxNamespaces.Relationships + "embed");
+            if (string.IsNullOrWhiteSpace(relationshipId))
+            {
+                // r:link points at an image outside the package. Reading it would
+                // be a network or file fetch from document content (ADR 0004).
+                diagnostics.AddDiagnosticOnce(
+                    "docx.image.external",
+                    "A DOCX picture linked to an external image, which is not fetched.");
+                return null;
+            }
+
+            (double width, double height) = ReadExtent(wrapper);
+            (string? altText, string? name) = ReadDescription(wrapper);
+            return Load(relationshipId, relationships, width, height, altText, name, diagnostics);
+        }
+
+        diagnostics.AddDiagnosticOnce(
+            "docx.image.shape",
+            "A DOCX drawing held no embedded picture and was skipped.");
+        return null;
+    }
+
+    /// <summary>
+    /// Reads the legacy VML picture: <c>w:pict/v:shape/v:imagedata</c>, sized by
+    /// the shape's CSS <c>style</c>. Word wrote this shape for images before
+    /// DrawingML and still writes it inside fields and some headers.
+    /// </summary>
+    private InlineImage? ReadVmlPicture(
+        XElement pict,
+        DocxRelationships relationships,
+        IDocxImageDiagnostics diagnostics)
+    {
+        XElement? imageData = FindDescendant(pict, DocxNamespaces.Vml + "imagedata");
+        if (imageData is null)
+        {
+            diagnostics.AddDiagnosticOnce(
+                "docx.image.shape",
+                "A DOCX drawing held no embedded picture and was skipped.");
+            return null;
+        }
+
+        string? relationshipId = (string?)imageData.Attribute(DocxNamespaces.Relationships + "id");
+        if (string.IsNullOrWhiteSpace(relationshipId))
+        {
+            diagnostics.AddDiagnosticOnce(
+                "docx.image.external",
+                "A DOCX picture linked to an external image, which is not fetched.");
+            return null;
+        }
+
+        XElement? shape = imageData.Parent;
+        (double width, double height) = ReadVmlStyleExtent((string?)shape?.Attribute("style"));
+        string? altText = (string?)shape?.Attribute("alt") ?? (string?)imageData.Attribute("title");
+        string? name = (string?)shape?.Attribute("id");
+        return Load(relationshipId, relationships, width, height, altText, name, diagnostics);
+    }
+
+    private InlineImage? Load(
+        string relationshipId,
+        DocxRelationships relationships,
+        double width,
+        double height,
+        string? altText,
+        string? name,
+        IDocxImageDiagnostics diagnostics)
+    {
+        if (!relationships.TryGet(relationshipId, out DocxRelationship? relationship) || relationship is null)
+        {
+            diagnostics.AddDiagnosticOnce(
+                "docx.image.relationship",
+                "A DOCX picture named a relationship the package does not define.");
+            return null;
+        }
+
+        if (relationship.TargetModeExternal)
+        {
+            diagnostics.AddDiagnosticOnce(
+                "docx.image.external",
+                "A DOCX picture linked to an external image, which is not fetched.");
+            return null;
+        }
+
+        MediaPart? part = LoadPart(relationship.Target, diagnostics);
+        if (part is null)
+            return null;
+
+        return new InlineImage(
+            part.Data,
+            part.ContentType,
+            width,
+            height,
+            altText,
+            string.IsNullOrWhiteSpace(name) ? Path.GetFileNameWithoutExtension(relationship.Target) : name);
+    }
+
+    /// <summary>
+    /// Loads a media part's bytes, once per part path. A part that fails — too
+    /// large, missing, or not a raster format — is cached as a failure so a
+    /// document that references it a hundred times reports once and does not
+    /// re-read the entry a hundred times.
+    /// </summary>
+    private MediaPart? LoadPart(string partPath, IDocxImageDiagnostics diagnostics)
+    {
+        if (_parts.TryGetValue(partPath, out MediaPart? cached))
+            return cached;
+
+        MediaPart? part = ReadPart(partPath, diagnostics);
+        _parts[partPath] = part;
+        return part;
+    }
+
+    private MediaPart? ReadPart(string partPath, IDocxImageDiagnostics diagnostics)
+    {
+        ZipArchiveEntry? entry = DocxPackage.FindEntry(_archive, partPath);
+        if (entry is null)
+        {
+            diagnostics.AddDiagnosticOnce(
+                "docx.image.missing",
+                "A DOCX picture referenced a media part the package does not contain.");
+            return null;
+        }
+
+        if (entry.Length > _limits.MaxBinBytes)
+        {
+            diagnostics.AddDiagnosticOnce(
+                "docx.image.limit",
+                "A DOCX image part exceeded MaxBinBytes and was skipped.");
+            return null;
+        }
+
+        byte[]? data = ReadEntryBytes(entry, _limits.MaxBinBytes);
+        if (data is null)
+        {
+            diagnostics.AddDiagnosticOnce(
+                "docx.image.limit",
+                "A DOCX image part exceeded MaxBinBytes and was skipped.");
+            return null;
+        }
+
+        string? contentType =
+            DocxImageFormats.ContentTypeForExtension(Path.GetExtension(partPath)) ??
+            DocxImageFormats.ContentTypeForSignature(data);
+        if (contentType is null)
+        {
+            // EMF/WMF metafiles land here, as does anything Word stored under an
+            // extension this codec does not decode.
+            diagnostics.AddDiagnosticOnce(
+                "docx.image.format",
+                "A DOCX picture used an image format this codec does not carry and was skipped.");
+            return null;
+        }
+
+        return new MediaPart(data, contentType);
+    }
+
+    /// <summary>
+    /// Reads an entry with the limit applied to what actually decompresses, not
+    /// to the size its ZIP header claims — a compressed part can lie about its
+    /// length (ADR 0004).
+    /// </summary>
+    private static byte[]? ReadEntryBytes(ZipArchiveEntry entry, long maxBytes)
+    {
+        using Stream stream = entry.Open();
+        using var buffer = new MemoryStream();
+        byte[] chunk = new byte[8192];
+        long total = 0;
+
+        while (true)
+        {
+            int read = stream.Read(chunk, 0, chunk.Length);
+            if (read == 0)
+                return buffer.ToArray();
+
+            total += read;
+            if (total > maxBytes)
+                return null;
+
+            buffer.Write(chunk, 0, read);
+        }
+    }
+
+    /// <summary>
+    /// The display size of a drawing, from <c>wp:extent</c> (EMUs). A missing or
+    /// unusable extent yields zero, which means "draw at the image's own size".
+    /// </summary>
+    private static (double Width, double Height) ReadExtent(XElement wrapper)
+    {
+        XElement? extent = wrapper.Element(DocxNamespaces.WordDrawing + "extent") ??
+            FindDescendant(wrapper, DocxNamespaces.Drawing + "ext");
+        if (extent is null)
+            return (0, 0);
+
+        double width = EmuToPoints((string?)extent.Attribute("cx"));
+        double height = EmuToPoints((string?)extent.Attribute("cy"));
+        return (width, height);
+    }
+
+    private static double EmuToPoints(string? value)
+    {
+        if (!long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out long emus) || emus <= 0)
+            return 0;
+
+        return Math.Min(emus / EmusPerPoint, MaxDisplayExtent);
+    }
+
+    /// <summary>
+    /// The alternative text and name of a drawing, from <c>wp:docPr</c> — the
+    /// same pair Word's "Edit Alt Text" writes.
+    /// </summary>
+    private static (string? AltText, string? Name) ReadDescription(XElement wrapper)
+    {
+        XElement? docPr = wrapper.Element(DocxNamespaces.WordDrawing + "docPr") ??
+            FindDescendant(wrapper, DocxNamespaces.Picture + "cNvPr");
+        if (docPr is null)
+            return (null, null);
+
+        return ((string?)docPr.Attribute("descr"), (string?)docPr.Attribute("name"));
+    }
+
+    /// <summary>
+    /// The display size of a VML shape, from the CSS lengths in its
+    /// <c>style</c> attribute.
+    /// </summary>
+    private static (double Width, double Height) ReadVmlStyleExtent(string? style)
+    {
+        if (string.IsNullOrWhiteSpace(style))
+            return (0, 0);
+
+        double width = 0;
+        double height = 0;
+        foreach (string declaration in style.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            int colon = declaration.IndexOf(':');
+            if (colon <= 0)
+                continue;
+
+            string property = declaration[..colon].Trim();
+            string value = declaration[(colon + 1)..].Trim();
+            if (property.Equals("width", StringComparison.OrdinalIgnoreCase))
+                width = CssLengthToPoints(value);
+            else if (property.Equals("height", StringComparison.OrdinalIgnoreCase))
+                height = CssLengthToPoints(value);
+        }
+
+        return (width, height);
+    }
+
+    /// <summary>
+    /// Converts a VML CSS length to points. VML's own default unit is the point,
+    /// which is what a bare number means here.
+    /// </summary>
+    private static double CssLengthToPoints(string value)
+    {
+        int end = 0;
+        while (end < value.Length && (char.IsAsciiDigit(value[end]) || value[end] is '.' or '-' or '+'))
+            end++;
+
+        if (end == 0 ||
+            !double.TryParse(value[..end], NumberStyles.Float, CultureInfo.InvariantCulture, out double number) ||
+            number <= 0)
+        {
+            return 0;
+        }
+
+        double points = value[end..].Trim().ToLowerInvariant() switch
+        {
+            "pt" or "" => number,
+            "in" => number * 72,
+            "cm" => number * 72 / 2.54,
+            "mm" => number * 72 / 25.4,
+            "pc" => number * 12,
+            "px" => number * 72 / 96,
+            _ => 0,
+        };
+
+        return Math.Min(points, MaxDisplayExtent);
+    }
+
+    /// <summary>
+    /// The first descendant with <paramref name="name"/>. Picture markup nests
+    /// several levels deep through namespaces the reader does not otherwise
+    /// model, and matching the leaf is more robust than walking every wrapper.
+    /// </summary>
+    private static XElement? FindDescendant(XElement root, XName name)
+    {
+        foreach (XElement descendant in root.Descendants(name))
+            return descendant;
+
+        return null;
+    }
+
+    private sealed record MediaPart(byte[] Data, string ContentType);
+}
+
+/// <summary>The once-per-code diagnostic sink the image loader reports through.</summary>
+internal interface IDocxImageDiagnostics
+{
+    void AddDiagnosticOnce(string code, string message);
+}

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxNamespaces.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxNamespaces.cs
@@ -13,8 +13,18 @@ internal static class DocxNamespaces
     /// <summary>Markup compatibility, used by <c>mc:AlternateContent</c> blocks.</summary>
     public static readonly XNamespace MarkupCompatibility = "http://schemas.openxmlformats.org/markup-compatibility/2006";
 
-    /// <summary>DrawingML, used by the theme part's font scheme.</summary>
+    /// <summary>DrawingML, used by the theme part's font scheme and by picture fills.</summary>
     public static readonly XNamespace Drawing = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
+    /// <summary>WordprocessingML drawing, the <c>wp:inline</c>/<c>wp:anchor</c> wrapper around a picture.</summary>
+    public static readonly XNamespace WordDrawing =
+        "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing";
+
+    /// <summary>DrawingML picture, the <c>pic:pic</c> shape a drawing embeds.</summary>
+    public static readonly XNamespace Picture = "http://schemas.openxmlformats.org/drawingml/2006/picture";
+
+    /// <summary>VML, used by the legacy <c>w:pict</c> image shape.</summary>
+    public static readonly XNamespace Vml = "urn:schemas-microsoft-com:vml";
 
     public const string OfficeDocumentRelationship =
         "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument";
@@ -36,6 +46,9 @@ internal static class DocxNamespaces
 
     public const string FooterRelationship =
         "http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer";
+
+    public const string ImageRelationship =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
 
     public const string DocumentContentType =
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml";

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxReader.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxReader.cs
@@ -57,11 +57,13 @@ internal static class DocxReader
                 options.Limits,
                 diagnostics);
 
+            var images = new DocxImageLoader(archive, options.Limits);
             RichTextDocument document = ReadDocumentXml(
                 documentXml,
                 documentRelationships,
                 numbering,
                 styles,
+                images,
                 options.Limits,
                 diagnostics);
             ReportUnreadParts(documentRelationships, diagnostics);
@@ -88,6 +90,7 @@ internal static class DocxReader
         DocxRelationships relationships,
         DocxNumbering numbering,
         DocxStyles styles,
+        DocxImageLoader images,
         DocumentLimits limits,
         List<DocumentDiagnostic> diagnostics)
     {
@@ -101,9 +104,9 @@ internal static class DocxReader
         }
 
         var builder = new DocxDocumentBuilder(limits, diagnostics);
-        var context = new DocxReadContext(relationships, numbering, styles, builder);
+        var context = new DocxReadContext(relationships, numbering, styles, images, builder);
         ReadBlockContent(body.Elements(), context, depth: 0);
-        builder.ReportReadSummary(body.Elements().Any(IsContentBlock), styles.Count);
+        builder.ReportReadSummary(body.Elements().Any(IsContentBlock), styles.Count, images.ImageCount);
         return builder.Build();
     }
 
@@ -112,6 +115,7 @@ internal static class DocxReader
         DocxRelationships Relationships,
         DocxNumbering Numbering,
         DocxStyles Styles,
+        DocxImageLoader Images,
         DocxDocumentBuilder Builder);
 
     /// <summary>
@@ -374,7 +378,20 @@ internal static class DocxReader
             style = ApplyRunProperties(styleRunProperties, style, context.Styles.Theme);
 
         style = ApplyRunProperties(rPr, style, context.Styles.Theme);
-        foreach (XElement child in run.Elements())
+        ReadRunContent(run.Elements(), context, style);
+    }
+
+    /// <summary>
+    /// Reads the content children of a run, with the run's resolved character
+    /// style already in hand.
+    /// </summary>
+    private static void ReadRunContent(
+        IEnumerable<XElement> elements,
+        DocxReadContext context,
+        InlineStyle style)
+    {
+        DocxDocumentBuilder builder = context.Builder;
+        foreach (XElement child in elements)
         {
             if (child.Name == DocxNamespaces.Wordprocessing + "rPr")
                 continue;
@@ -417,12 +434,42 @@ internal static class DocxReader
             }
 
             if (child.Name == DocxNamespaces.Wordprocessing + "drawing" ||
-                child.Name == DocxNamespaces.Wordprocessing + "object" ||
                 child.Name == DocxNamespaces.Wordprocessing + "pict")
             {
-                builder.AddDiagnosticOnce("docx.skip.embedded", "Embedded DOCX drawing or object content was skipped.");
+                ReadPicture(child, context, style);
+                continue;
             }
+
+            // Word wraps a picture that needs a legacy fallback in
+            // mc:AlternateContent. Exactly one branch may contribute, or the same
+            // picture is read twice.
+            if (child.Name == DocxNamespaces.MarkupCompatibility + "AlternateContent")
+            {
+                XElement? branch =
+                    child.Element(DocxNamespaces.MarkupCompatibility + "Choice") ??
+                    child.Element(DocxNamespaces.MarkupCompatibility + "Fallback");
+                if (branch is not null)
+                    ReadRunContent(branch.Elements(), context, style);
+                continue;
+            }
+
+            if (child.Name == DocxNamespaces.Wordprocessing + "object")
+                builder.AddDiagnosticOnce("docx.skip.embedded", "Embedded DOCX object content was skipped.");
         }
+    }
+
+    /// <summary>
+    /// Appends a picture as one <see cref="InlineImage.Placeholder"/> character
+    /// carrying the image on its style. The run's own character formatting is
+    /// kept on it, so a picture inside a hyperlink stays inside that link.
+    /// </summary>
+    private static void ReadPicture(XElement picture, DocxReadContext context, InlineStyle style)
+    {
+        InlineImage? image = context.Images.Read(picture, context.Relationships, context.Builder);
+        if (image is null)
+            return;
+
+        context.Builder.AppendText(InlineImage.PlaceholderText, style with { Image = image });
     }
 
     /// <summary>
@@ -730,7 +777,7 @@ internal static class DocxReader
         return !color.IsEmpty;
     }
 
-    private sealed class DocxDocumentBuilder
+    private sealed class DocxDocumentBuilder : IDocxImageDiagnostics
     {
         private readonly DocumentLimits _limits;
         private readonly List<DocumentDiagnostic> _diagnostics;
@@ -776,7 +823,7 @@ internal static class DocxReader
         /// a body with block content that yields no paragraphs is a reader bug,
         /// not an empty file, and it should say so rather than open blank.
         /// </summary>
-        public void ReportReadSummary(bool bodyHadContentBlocks, int styleCount)
+        public void ReportReadSummary(bool bodyHadContentBlocks, int styleCount, int imageCount)
         {
             if (_paragraphs.Count == 0 && bodyHadContentBlocks)
             {
@@ -790,7 +837,8 @@ internal static class DocxReader
                 "DOCX read produced " + _paragraphs.Count.ToString(CultureInfo.InvariantCulture) +
                 " paragraph(s), flattened " + _tableCount.ToString(CultureInfo.InvariantCulture) +
                 " table(s), loaded " + styleCount.ToString(CultureInfo.InvariantCulture) +
-                " style(s), and skipped " + _unsupportedBlockCount.ToString(CultureInfo.InvariantCulture) +
+                " style(s), embedded " + imageCount.ToString(CultureInfo.InvariantCulture) +
+                " image(s), and skipped " + _unsupportedBlockCount.ToString(CultureInfo.InvariantCulture) +
                 " unsupported block(s)."));
         }
 

--- a/Broiler.Documents/Broiler.Documents.Docx/DocxWriter.cs
+++ b/Broiler.Documents/Broiler.Documents.Docx/DocxWriter.cs
@@ -18,6 +18,9 @@ public static class DocxWriter
     private static readonly DateTimeOffset ZipTimestamp =
         new(new DateTime(1980, 1, 1, 0, 0, 0, DateTimeKind.Utc));
 
+    /// <summary>The size an image with no stated display size is written at: one inch square.</summary>
+    private const double DefaultImagePoints = 72.0;
+
     public static DocumentWriteResult Write(
         RichTextDocument document,
         Stream destination,
@@ -33,13 +36,15 @@ public static class DocxWriter
         using var package = new MemoryStream();
         using (var archive = new ZipArchive(package, ZipArchiveMode.Create, leaveOpen: true))
         {
-            AddXmlEntry(archive, "[Content_Types].xml", BuildContentTypes(context.HasNumbering));
+            AddXmlEntry(archive, "[Content_Types].xml", BuildContentTypes(context));
             AddXmlEntry(archive, "_rels/.rels", BuildPackageRelationships());
             AddXmlEntry(archive, "word/document.xml", documentXml);
             if (context.HasDocumentRelationships)
                 AddXmlEntry(archive, "word/_rels/document.xml.rels", BuildDocumentRelationships(context));
             if (context.HasNumbering)
                 AddXmlEntry(archive, "word/numbering.xml", BuildNumbering());
+            foreach (DocxImagePart image in context.Images)
+                AddBinaryEntry(archive, image.PartPath, image.Data.Span);
         }
 
         byte[] bytes = package.ToArray();
@@ -62,13 +67,23 @@ public static class DocxWriter
 
         body.Add(new XElement(DocxNamespaces.Wordprocessing + "sectPr"));
 
-        return new XDocument(
-            new XDeclaration("1.0", "utf-8", "yes"),
-            new XElement(
-                DocxNamespaces.Wordprocessing + "document",
-                new XAttribute(XNamespace.Xmlns + "w", DocxNamespaces.Wordprocessing.NamespaceName),
-                new XAttribute(XNamespace.Xmlns + "r", DocxNamespaces.Relationships.NamespaceName),
-                body));
+        var root = new XElement(
+            DocxNamespaces.Wordprocessing + "document",
+            new XAttribute(XNamespace.Xmlns + "w", DocxNamespaces.Wordprocessing.NamespaceName),
+            new XAttribute(XNamespace.Xmlns + "r", DocxNamespaces.Relationships.NamespaceName));
+
+        // Declared at the root only when used, so a text-only document keeps the
+        // same minimal document.xml it has always produced.
+        if (context.Images.Count > 0)
+        {
+            root.Add(
+                new XAttribute(XNamespace.Xmlns + "wp", DocxNamespaces.WordDrawing.NamespaceName),
+                new XAttribute(XNamespace.Xmlns + "a", DocxNamespaces.Drawing.NamespaceName),
+                new XAttribute(XNamespace.Xmlns + "pic", DocxNamespaces.Picture.NamespaceName));
+        }
+
+        root.Add(body);
+        return new XDocument(new XDeclaration("1.0", "utf-8", "yes"), root);
     }
 
     private static XElement BuildParagraph(RichTextParagraph paragraph, DocxWriteContext context)
@@ -182,7 +197,7 @@ public static class DocxWriter
         XElement? properties = BuildRunProperties(style, context);
         if (properties is not null)
             run.Add(properties);
-        AddTextContent(run, text);
+        AddRunContent(run, text, style, context);
         return run;
     }
 
@@ -239,25 +254,138 @@ public static class DocxWriter
         return properties.HasElements ? properties : null;
     }
 
-    private static void AddTextContent(XElement run, string text)
+    /// <summary>
+    /// Writes a run's characters, turning the ones the model stores as single
+    /// code points back into their WordprocessingML elements: tab, soft line
+    /// break, and the object replacement character that carries a picture.
+    /// </summary>
+    private static void AddRunContent(XElement run, string text, InlineStyle style, DocxWriteContext context)
     {
         int start = 0;
         for (int i = 0; i < text.Length; i++)
         {
-            if (text[i] != '\t' && text[i] != (char)0x2028)
+            char character = text[i];
+            if (character != '\t' && character != (char)0x2028 && character != InlineImage.Placeholder)
                 continue;
 
             if (i > start)
                 run.Add(TextElement(text[start..i]));
 
-            run.Add(text[i] == '\t'
-                ? new XElement(DocxNamespaces.Wordprocessing + "tab")
-                : new XElement(DocxNamespaces.Wordprocessing + "br"));
+            switch (character)
+            {
+                case '\t':
+                    run.Add(new XElement(DocxNamespaces.Wordprocessing + "tab"));
+                    break;
+                case (char)0x2028:
+                    run.Add(new XElement(DocxNamespaces.Wordprocessing + "br"));
+                    break;
+                default:
+                    AddPicture(run, style.Image, context);
+                    break;
+            }
+
             start = i + 1;
         }
 
         if (start < text.Length)
             run.Add(TextElement(text[start..]));
+    }
+
+    /// <summary>
+    /// Writes one picture as an inline DrawingML frame and registers its media
+    /// part. A placeholder character whose run carries no image is dropped rather
+    /// than written through — Word would draw it as a missing-glyph box.
+    /// </summary>
+    private static void AddPicture(XElement run, InlineImage? image, DocxWriteContext context)
+    {
+        if (image is null)
+        {
+            context.AddDiagnosticOnce(
+                "docx.image.placeholder",
+                "An object replacement character with no image attached was dropped.");
+            return;
+        }
+
+        DocxImagePart part = context.GetImagePart(image);
+        long widthEmus = Emus(image.Width > 0 ? image.Width : DefaultImagePoints);
+        long heightEmus = Emus(image.Height > 0 ? image.Height : DefaultImagePoints);
+        if (!image.HasExplicitSize)
+        {
+            context.AddDiagnosticOnce(
+                "docx.image.size",
+                "An image carried no display size and was written one inch square.");
+        }
+
+        string name = "Picture " + part.Index.ToString(CultureInfo.InvariantCulture);
+        var pictureProperties = new XElement(
+            DocxNamespaces.Picture + "cNvPr",
+            new XAttribute("id", part.Index.ToString(CultureInfo.InvariantCulture)),
+            new XAttribute("name", name));
+        var frameProperties = new XElement(
+            DocxNamespaces.WordDrawing + "docPr",
+            new XAttribute("id", part.Index.ToString(CultureInfo.InvariantCulture)),
+            new XAttribute("name", name));
+        if (image.AltText.Length > 0)
+        {
+            pictureProperties.Add(new XAttribute("descr", image.AltText));
+            frameProperties.Add(new XAttribute("descr", image.AltText));
+        }
+
+        var extent = new XElement(
+            DocxNamespaces.Drawing + "ext",
+            new XAttribute("cx", widthEmus.ToString(CultureInfo.InvariantCulture)),
+            new XAttribute("cy", heightEmus.ToString(CultureInfo.InvariantCulture)));
+
+        run.Add(new XElement(
+            DocxNamespaces.Wordprocessing + "drawing",
+            new XElement(
+                DocxNamespaces.WordDrawing + "inline",
+                new XAttribute("distT", "0"),
+                new XAttribute("distB", "0"),
+                new XAttribute("distL", "0"),
+                new XAttribute("distR", "0"),
+                new XElement(
+                    DocxNamespaces.WordDrawing + "extent",
+                    new XAttribute("cx", widthEmus.ToString(CultureInfo.InvariantCulture)),
+                    new XAttribute("cy", heightEmus.ToString(CultureInfo.InvariantCulture))),
+                frameProperties,
+                new XElement(
+                    DocxNamespaces.WordDrawing + "cNvGraphicFramePr",
+                    new XElement(
+                        DocxNamespaces.Drawing + "graphicFrameLocks",
+                        new XAttribute("noChangeAspect", "1"))),
+                new XElement(
+                    DocxNamespaces.Drawing + "graphic",
+                    new XElement(
+                        DocxNamespaces.Drawing + "graphicData",
+                        new XAttribute("uri", DocxNamespaces.Picture.NamespaceName),
+                        new XElement(
+                            DocxNamespaces.Picture + "pic",
+                            new XElement(
+                                DocxNamespaces.Picture + "nvPicPr",
+                                pictureProperties,
+                                new XElement(DocxNamespaces.Picture + "cNvPicPr")),
+                            new XElement(
+                                DocxNamespaces.Picture + "blipFill",
+                                new XElement(
+                                    DocxNamespaces.Drawing + "blip",
+                                    new XAttribute(DocxNamespaces.Relationships + "embed", part.RelationshipId)),
+                                new XElement(
+                                    DocxNamespaces.Drawing + "stretch",
+                                    new XElement(DocxNamespaces.Drawing + "fillRect"))),
+                            new XElement(
+                                DocxNamespaces.Picture + "spPr",
+                                new XElement(
+                                    DocxNamespaces.Drawing + "xfrm",
+                                    new XElement(
+                                        DocxNamespaces.Drawing + "off",
+                                        new XAttribute("x", "0"),
+                                        new XAttribute("y", "0")),
+                                    extent),
+                                new XElement(
+                                    DocxNamespaces.Drawing + "prstGeom",
+                                    new XAttribute("prst", "rect"),
+                                    new XElement(DocxNamespaces.Drawing + "avLst")))))))));
     }
 
     private static XElement TextElement(string value) =>
@@ -266,7 +394,7 @@ public static class DocxWriter
             new XAttribute(DocxNamespaces.Xml + "space", "preserve"),
             value);
 
-    private static XDocument BuildContentTypes(bool includeNumbering)
+    private static XDocument BuildContentTypes(DocxWriteContext context)
     {
         var types = new XElement(
             DocxNamespaces.ContentTypes + "Types",
@@ -284,12 +412,22 @@ public static class DocxWriter
                 new XAttribute("PartName", "/word/document.xml"),
                 new XAttribute("ContentType", DocxNamespaces.DocumentContentType)));
 
-        if (includeNumbering)
+        if (context.HasNumbering)
         {
             types.Add(new XElement(
                 DocxNamespaces.ContentTypes + "Override",
                 new XAttribute("PartName", "/word/numbering.xml"),
                 new XAttribute("ContentType", DocxNamespaces.NumberingContentType)));
+        }
+
+        // One Default per distinct media extension, which is how OPC types the
+        // binary parts under word/media.
+        foreach (KeyValuePair<string, string> media in context.MediaContentTypes)
+        {
+            types.Add(new XElement(
+                DocxNamespaces.ContentTypes + "Default",
+                new XAttribute("Extension", media.Key),
+                new XAttribute("ContentType", media.Value)));
         }
 
         return new XDocument(new XDeclaration("1.0", "utf-8", "yes"), types);
@@ -330,6 +468,15 @@ public static class DocxWriter
                 new XAttribute("Type", DocxNamespaces.HyperlinkRelationship),
                 new XAttribute("Target", relationship.Key),
                 new XAttribute("TargetMode", "External")));
+        }
+
+        foreach (DocxImagePart image in context.Images)
+        {
+            root.Add(new XElement(
+                DocxNamespaces.PackageRelationships + "Relationship",
+                new XAttribute("Id", image.RelationshipId),
+                new XAttribute("Type", DocxNamespaces.ImageRelationship),
+                new XAttribute("Target", image.RelativeTarget)));
         }
 
         return new XDocument(new XDeclaration("1.0", "utf-8", "yes"), root);
@@ -394,6 +541,14 @@ public static class DocxWriter
         document.Save(writer);
     }
 
+    private static void AddBinaryEntry(ZipArchive archive, string path, ReadOnlySpan<byte> data)
+    {
+        ZipArchiveEntry entry = archive.CreateEntry(path, CompressionLevel.Fastest);
+        entry.LastWriteTime = ZipTimestamp;
+        using Stream stream = entry.Open();
+        stream.Write(data);
+    }
+
     private static bool IsExternalLink(string href)
     {
         if (!Uri.TryCreate(href, UriKind.Absolute, out Uri? uri))
@@ -409,6 +564,9 @@ public static class DocxWriter
 
     private static int Twips(float points) => (int)Math.Round(points * 20f);
 
+    /// <summary>English Metric Units for a length in points: 914400 per inch over 72 points.</summary>
+    private static long Emus(double points) => (long)Math.Round(points * 12700.0);
+
     private static string FormatColor(BColor color, DocxWriteContext context)
     {
         if (color.A != 255)
@@ -420,6 +578,9 @@ public static class DocxWriter
     private sealed class DocxWriteContext
     {
         private readonly Dictionary<string, string> _hyperlinks = new(StringComparer.Ordinal);
+        private readonly Dictionary<InlineImage, DocxImagePart> _images = new(ReferenceEqualityComparer.Instance);
+        private readonly List<DocxImagePart> _imageOrder = [];
+        private readonly Dictionary<string, string> _mediaContentTypes = new(StringComparer.Ordinal);
         private readonly List<DocumentDiagnostic> _diagnostics = [];
         private readonly HashSet<string> _diagnosticOnce = new(StringComparer.Ordinal);
         private int _nextRelationshipId;
@@ -432,11 +593,17 @@ public static class DocxWriter
 
         public bool HasNumbering { get; }
 
-        public bool HasDocumentRelationships => HasNumbering || _hyperlinks.Count > 0;
+        public bool HasDocumentRelationships => HasNumbering || _hyperlinks.Count > 0 || _imageOrder.Count > 0;
 
         public string NumberingRelationshipId => "rId1";
 
         public IReadOnlyDictionary<string, string> HyperlinkRelationships => _hyperlinks;
+
+        /// <summary>The media parts to write, in the order they were first used.</summary>
+        public IReadOnlyList<DocxImagePart> Images => _imageOrder;
+
+        /// <summary>Media extension to content type, for the package's content-type defaults.</summary>
+        public IReadOnlyDictionary<string, string> MediaContentTypes => _mediaContentTypes;
 
         public IReadOnlyList<DocumentDiagnostic> Diagnostics => _diagnostics;
 
@@ -451,10 +618,44 @@ public static class DocxWriter
             return id;
         }
 
+        /// <summary>
+        /// The media part for <paramref name="image"/>, created on first use.
+        /// Keyed by identity, so a document that shows the same image object in
+        /// several places stores its bytes once.
+        /// </summary>
+        public DocxImagePart GetImagePart(InlineImage image)
+        {
+            if (_images.TryGetValue(image, out DocxImagePart? existing))
+                return existing;
+
+            int index = _imageOrder.Count + 1;
+            string extension = DocxImageFormats.ExtensionForContentType(image.ContentType);
+            string fileName = "image" + index.ToString(CultureInfo.InvariantCulture) + "." + extension;
+            var part = new DocxImagePart(
+                index,
+                "rId" + _nextRelationshipId.ToString(CultureInfo.InvariantCulture),
+                "word/media/" + fileName,
+                "media/" + fileName,
+                image.Data);
+            _nextRelationshipId++;
+            _images[image] = part;
+            _imageOrder.Add(part);
+            _mediaContentTypes[extension] = image.ContentType;
+            return part;
+        }
+
         public void AddDiagnosticOnce(string code, string message)
         {
             if (_diagnosticOnce.Add(code))
                 _diagnostics.Add(DocumentDiagnostic.Warning(code, message));
         }
     }
+
+    /// <summary>One <c>word/media</c> part: where it lives and how the document refers to it.</summary>
+    private sealed record DocxImagePart(
+        int Index,
+        string RelationshipId,
+        string PartPath,
+        string RelativeTarget,
+        ReadOnlyMemory<byte> Data);
 }

--- a/Broiler.Documents/Broiler.Documents.FormatCodes.Tests/FormatCodeProjectorGoldenTests.cs
+++ b/Broiler.Documents/Broiler.Documents.FormatCodes.Tests/FormatCodeProjectorGoldenTests.cs
@@ -124,6 +124,26 @@ public sealed class FormatCodeProjectorGoldenTests
     }
 
     [Fact]
+    public void An_Embedded_Image_Projects_As_An_Image_Structure_Code()
+    {
+        var image = new InlineImage(new byte[] { 1, 2, 3 }, "image/png", 40, 20, "a logo");
+        RichTextDocument document = RichTextDocument.FromParagraphs(
+        [
+            RichTextParagraph.Create("a", InlineStyle.Default)
+                .InsertText(1, InlineImage.PlaceholderText, InlineStyle.Default with { Image = image })
+                .InsertText(2, "b", InlineStyle.Default),
+        ]);
+
+        FormatCodeProjection projection = _projector.Project(document);
+
+        Assert.Equal("a[Image]b", projection.Text);
+        FormatCodeToken token = Assert.Single(
+            projection.Tokens.Where(t => t.DisplayText == "[Image]"));
+        Assert.Equal(FormatCodeTokenKind.StructureCode, token.Kind);
+        Assert.Equal(FormatCodeProperty.Image, token.EditDescriptor?.Property);
+    }
+
+    [Fact]
     public void Paragraphs_Reset_Inline_State_And_Use_One_Canonical_Boundary()
     {
         InlineStyle bold = new() { Bold = true };

--- a/Broiler.Documents/Broiler.Documents.FormatCodes/FormatCodeEditIntent.cs
+++ b/Broiler.Documents/Broiler.Documents.FormatCodes/FormatCodeEditIntent.cs
@@ -52,6 +52,10 @@ public enum FormatCodeProperty
     Tab,
     LineBreak,
     ParagraphBreak,
+
+    // The single character an embedded image occupies. Like the other structure
+    // properties it is removed by deleting that character.
+    Image,
 }
 
 /// <summary>

--- a/Broiler.Documents/Broiler.Documents.FormatCodes/FormatCodeProjector.cs
+++ b/Broiler.Documents/Broiler.Documents.FormatCodes/FormatCodeProjector.cs
@@ -317,6 +317,13 @@ public sealed class FormatCodeProjector
                         affected, FormatCodeMappingMode.Expanded,
                         StructureDescriptor(FormatCodeProperty.LineBreak, affected));
                     break;
+                case InlineImage.Placeholder:
+                    // The character an image occupies. Removing the token
+                    // removes that character, which is what deletes the picture.
+                    builder.AddToken(FormatCodeTokenKind.StructureCode, "[Image]", sourceBefore, sourceAfter,
+                        affected, FormatCodeMappingMode.Expanded,
+                        StructureDescriptor(FormatCodeProperty.Image, affected));
+                    break;
                 case '\\':
                     builder.AddToken(FormatCodeTokenKind.Escape, "\\\\", sourceBefore, sourceAfter, affected, FormatCodeMappingMode.Expanded);
                     break;
@@ -346,7 +353,7 @@ public sealed class FormatCodeProjector
     private static bool RequiresSpecialToken(string text, int index)
     {
         char character = text[index];
-        if (character is '\t' or '\u2028' or '\\' or '[' or ']')
+        if (character is '\t' or '\u2028' or InlineImage.Placeholder or '\\' or '[' or ']')
             return true;
         if (char.IsHighSurrogate(character))
             return index + 1 >= text.Length || !char.IsLowSurrogate(text[index + 1]);

--- a/Broiler.Documents/Broiler.Documents.FormatCodes/GRAMMAR.md
+++ b/Broiler.Documents/Broiler.Documents.FormatCodes/GRAMMAR.md
@@ -73,6 +73,7 @@ Out-of-domain metrics are preserved rather than silently corrected.
 |---|---|
 | Tab (`U+0009`) | `[Tab]` |
 | Soft line break (`U+2028`) | `[Line Break]` |
+| Embedded image (`U+FFFC`) | `[Image]` |
 | Boundary between paragraphs | `[Paragraph Break]` followed by LF |
 | Paragraph with no characters | `[Empty Paragraph]` |
 | Literal backslash | `\\` |

--- a/Broiler.Documents/Broiler.Documents.Html.Tests/HtmlWriterTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Html.Tests/HtmlWriterTests.cs
@@ -95,6 +95,23 @@ public sealed class HtmlWriterTests
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "html.list");
     }
 
+    [Fact]
+    public void Writes_An_Embedded_Image_As_A_Data_Uri()
+    {
+        var image = new InlineImage(new byte[] { 1, 2, 3 }, "image/png", 40, 20, "a logo");
+        RichTextDocument document = SingleParagraph(
+            ("before", InlineStyle.Default),
+            (InlineImage.PlaceholderText, InlineStyle.Default with { Image = image }));
+
+        string html = Write(document);
+
+        Assert.Contains("<img src=\"data:image/png;base64,AQID\"", html, StringComparison.Ordinal);
+        Assert.Contains("alt=\"a logo\"", html, StringComparison.Ordinal);
+        Assert.Contains("width: 40pt", html, StringComparison.Ordinal);
+        Assert.Contains("before", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("\uFFFC", html, StringComparison.Ordinal);
+    }
+
     private static string Write(RichTextDocument document) =>
         Encoding.UTF8.GetString(HtmlDocumentCodec.WriteToArray(document));
 

--- a/Broiler.Documents/Broiler.Documents.Html/HtmlWriter.cs
+++ b/Broiler.Documents/Broiler.Documents.Html/HtmlWriter.cs
@@ -61,13 +61,17 @@ public static class HtmlWriter
                 p.SetAttribute("style", paragraphStyle);
 
             body.AppendChild(p);
-            AppendRuns(document, p, paragraph);
+            AppendRuns(document, p, paragraph, diagnostics);
         }
 
         return document;
     }
 
-    private static void AppendRuns(DomDocument document, DomNode parent, RichTextParagraph paragraph)
+    private static void AppendRuns(
+        DomDocument document,
+        DomNode parent,
+        RichTextParagraph paragraph,
+        List<DocumentDiagnostic> diagnostics)
     {
         int offset = 0;
         foreach (StyleRun run in paragraph.Runs)
@@ -78,15 +82,75 @@ public static class HtmlWriter
             DomNode target = CreateRunContainer(document, run.Style);
             if (target is DomElement element)
             {
-                AppendTextWithBreaks(document, element, text);
+                AppendRunContent(document, element, text, run.Style, diagnostics);
                 parent.AppendChild(element);
             }
             else
             {
-                AppendTextWithBreaks(document, parent, text);
+                AppendRunContent(document, parent, text, run.Style, diagnostics);
             }
         }
     }
+
+    /// <summary>
+    /// Appends a run's characters, turning each image placeholder into an
+    /// <c>img</c> whose source is a data URI. HTML has nowhere else to keep the
+    /// bytes, and an external file beside the document would make a single-file
+    /// export no longer single-file.
+    /// </summary>
+    private static void AppendRunContent(
+        DomDocument document,
+        DomNode parent,
+        string text,
+        InlineStyle style,
+        List<DocumentDiagnostic> diagnostics)
+    {
+        if (style.Image is not InlineImage image)
+        {
+            AppendTextWithBreaks(document, parent, text);
+            return;
+        }
+
+        int start = 0;
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (text[i] != InlineImage.Placeholder)
+                continue;
+
+            if (i > start)
+                AppendTextWithBreaks(document, parent, text[start..i]);
+
+            parent.AppendChild(CreateImageElement(document, image, diagnostics));
+            start = i + 1;
+        }
+
+        if (start < text.Length)
+            AppendTextWithBreaks(document, parent, text[start..]);
+    }
+
+    private static DomElement CreateImageElement(
+        DomDocument document,
+        InlineImage image,
+        List<DocumentDiagnostic> diagnostics)
+    {
+        DomElement img = document.CreateElement("img");
+        img.SetAttribute("src", "data:" + image.ContentType + ";base64," + Convert.ToBase64String(image.Data.Span));
+        img.SetAttribute("alt", image.AltText);
+        if (image.HasExplicitSize)
+        {
+            img.SetAttribute(
+                "style",
+                "width: " + FormatLength(image.Width) + "; height: " + FormatLength(image.Height));
+        }
+
+        diagnostics.Add(DocumentDiagnostic.Info(
+            "html.image.datauri",
+            "An embedded image was written as a base64 data URI."));
+        return img;
+    }
+
+    private static string FormatLength(double value) =>
+        value.ToString("0.###", CultureInfo.InvariantCulture) + "pt";
 
     private static DomNode CreateRunContainer(DomDocument document, InlineStyle style)
     {

--- a/Broiler.Documents/Broiler.Documents.Markdown.Tests/MarkdownWriterTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Markdown.Tests/MarkdownWriterTests.cs
@@ -71,6 +71,24 @@ public sealed class MarkdownWriterTests
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "markdown.inline-style");
     }
 
+    [Fact]
+    public void Writes_An_Embedded_Image_As_A_Data_Uri()
+    {
+        var image = new InlineImage(new byte[] { 1, 2, 3 }, "image/png", 40, 20, "a logo");
+        RichTextDocument document = RichTextDocument.FromParagraphs(new[]
+        {
+            MakeParagraph(
+                ParagraphStyle.Default,
+                ("before ", InlineStyle.Default),
+                (InlineImage.PlaceholderText, InlineStyle.Default with { Image = image })),
+        });
+
+        string markdown = Write(document);
+
+        Assert.Contains("![a logo](data:image/png;base64,AQID)", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("\uFFFC", markdown, StringComparison.Ordinal);
+    }
+
     private static string Write(RichTextDocument document) =>
         System.Text.Encoding.UTF8.GetString(MarkdownDocumentCodec.WriteToArray(document));
 

--- a/Broiler.Documents/Broiler.Documents.Markdown/MarkdownWriter.cs
+++ b/Broiler.Documents/Broiler.Documents.Markdown/MarkdownWriter.cs
@@ -79,6 +79,9 @@ public static class MarkdownWriter
         InlineStyle style,
         List<DocumentDiagnostic> diagnostics)
     {
+        if (style.Image is InlineImage image)
+            return FormatImageRun(text, image, style, diagnostics);
+
         string formatted = EscapeText(text);
 
         if (style.FontFamily is not null && style.FontFamily.Equals("monospace", StringComparison.OrdinalIgnoreCase))
@@ -106,6 +109,41 @@ public static class MarkdownWriter
         }
 
         return formatted;
+    }
+
+    /// <summary>
+    /// Writes an image run as CommonMark image syntax with a data URI. Markdown
+    /// has no container of its own, so the bytes travel in the link destination
+    /// or they do not travel at all.
+    /// </summary>
+    private static string FormatImageRun(
+        string text,
+        InlineImage image,
+        InlineStyle style,
+        List<DocumentDiagnostic> diagnostics)
+    {
+        string destination = "data:" + image.ContentType + ";base64," + Convert.ToBase64String(image.Data.Span);
+        string alt = image.AltText.Replace("]", "\\]", StringComparison.Ordinal);
+        var builder = new StringBuilder();
+        foreach (char character in text)
+        {
+            if (character == InlineImage.Placeholder)
+                builder.Append("![").Append(alt).Append("](").Append(destination).Append(')');
+            else
+                builder.Append(EscapeText(character.ToString()));
+        }
+
+        diagnostics.Add(DocumentDiagnostic.Info(
+            "markdown.image.datauri",
+            "An embedded image was written as a base64 data URI."));
+        if (style.Bold || style.Italic || style.Strikethrough || style.Underline)
+        {
+            diagnostics.Add(DocumentDiagnostic.Warning(
+                "markdown.inline-style",
+                "Markdown writer dropped character formatting carried by an image run."));
+        }
+
+        return builder.ToString();
     }
 
     private static string EscapeText(string text)

--- a/Broiler.Documents/Broiler.Documents.Model.Tests/InlineImageTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Model.Tests/InlineImageTests.cs
@@ -1,0 +1,107 @@
+namespace Broiler.Documents.Model.Tests;
+
+/// <summary>
+/// How an image behaves as a document character: it occupies one position, edits
+/// like any other character, and never merges with a different picture.
+/// </summary>
+public sealed class InlineImageTests
+{
+    private static readonly byte[] Bytes = [1, 2, 3, 4];
+
+    private static InlineImage Image(string? altText = null) =>
+        new(Bytes, "image/png", 40, 20, altText);
+
+    [Fact]
+    public void An_Image_Run_Occupies_Exactly_One_Character()
+    {
+        InlineImage image = Image();
+        RichTextParagraph paragraph = RichTextParagraph.Create("ab", InlineStyle.Default)
+            .InsertText(1, InlineImage.PlaceholderText, InlineStyle.Default with { Image = image });
+
+        Assert.Equal("a" + InlineImage.PlaceholderText + "b", paragraph.Text);
+        Assert.Equal(3, paragraph.Length);
+        Assert.Equal(3, paragraph.Runs.Count);
+        Assert.Same(image, paragraph.Runs[1].Style.Image);
+        Assert.Equal(1, paragraph.Runs[1].Length);
+    }
+
+    [Fact]
+    public void Two_Different_Images_Stay_In_Separate_Runs()
+    {
+        RichTextParagraph paragraph = RichTextParagraph.Empty
+            .InsertText(0, InlineImage.PlaceholderText, InlineStyle.Default with { Image = Image() })
+            .InsertText(1, InlineImage.PlaceholderText, InlineStyle.Default with { Image = Image() });
+
+        // The two images hold identical bytes; identity is what keeps them apart,
+        // so run normalization does not silently fuse two pictures into one run.
+        Assert.Equal(2, paragraph.Runs.Count);
+    }
+
+    [Fact]
+    public void Deleting_The_Image_Character_Removes_The_Image()
+    {
+        RichTextParagraph paragraph = RichTextParagraph.Create("ab", InlineStyle.Default)
+            .InsertText(1, InlineImage.PlaceholderText, InlineStyle.Default with { Image = Image() })
+            .RemoveRange(1, 1);
+
+        Assert.Equal("ab", paragraph.Text);
+        Assert.DoesNotContain(paragraph.Runs, run => run.Style.IsImage);
+    }
+
+    [Fact]
+    public void Clearing_Formatting_Over_An_Image_Keeps_The_Image()
+    {
+        InlineImage image = Image();
+        RichTextParagraph paragraph = RichTextParagraph.Create(
+                InlineImage.PlaceholderText,
+                InlineStyle.Default with { Image = image, Bold = true })
+            .ApplyInlineStyle(0, 1, InlineStyleDelta.Clear);
+
+        StyleRun run = Assert.Single(paragraph.Runs);
+        Assert.Same(image, run.Style.Image);
+        Assert.False(run.Style.Bold);
+    }
+
+    [Fact]
+    public void Slicing_A_Range_Carries_The_Image_With_It()
+    {
+        InlineImage image = Image();
+        RichTextDocument document = RichTextDocument.FromParagraphs(
+        [
+            RichTextParagraph.Create("ab", InlineStyle.Default)
+                .InsertText(1, InlineImage.PlaceholderText, InlineStyle.Default with { Image = image }),
+        ]);
+
+        RichTextDocument slice = document.Slice(
+            new RichTextRange(new RichTextPosition(0, 1), new RichTextPosition(0, 2)));
+
+        StyleRun run = Assert.Single(Assert.Single(slice.Paragraphs).Runs);
+        Assert.Same(image, run.Style.Image);
+    }
+
+    [Fact]
+    public void An_Image_Reports_Whether_Its_Size_Was_Stated()
+    {
+        Assert.True(Image().HasExplicitSize);
+        Assert.False(new InlineImage(Bytes, "image/png", 0, 0).HasExplicitSize);
+    }
+
+    [Fact]
+    public void Resizing_Keeps_The_Bytes_And_The_Description()
+    {
+        InlineImage resized = Image("a logo").WithSize(80, 40);
+
+        Assert.Equal(80, resized.Width);
+        Assert.Equal(40, resized.Height);
+        Assert.Equal("a logo", resized.AltText);
+        Assert.Equal(Bytes, resized.Data.ToArray());
+    }
+
+    [Fact]
+    public void An_Image_Needs_A_Content_Type_And_A_Non_Negative_Size()
+    {
+        Assert.Throws<ArgumentException>(() => new InlineImage(Bytes, " ", 1, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new InlineImage(Bytes, "image/png", -1, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new InlineImage(Bytes, "image/png", 1, -1));
+    }
+}

--- a/Broiler.Documents/Broiler.Documents.Model/InlineImage.cs
+++ b/Broiler.Documents/Broiler.Documents.Model/InlineImage.cs
@@ -1,0 +1,85 @@
+using System;
+
+namespace Broiler.Documents.Model;
+
+/// <summary>
+/// An image embedded in a document. The model has no separate inline-object
+/// shape, so an image lives on the <see cref="InlineStyle"/> of a run whose text
+/// is the single object replacement character <see cref="Placeholder"/>: the
+/// image occupies exactly one character position, which is what makes carets,
+/// selections, deletion, and paragraph splitting work on it without a second set
+/// of rules.
+/// </summary>
+/// <remarks>
+/// Instances are compared by reference, so two runs carrying the same image
+/// object merge and two runs carrying equal bytes do not. That keeps a document
+/// that repeats one picture cheap without forcing a byte comparison into every
+/// run-normalization pass.
+/// </remarks>
+public sealed class InlineImage
+{
+    /// <summary>
+    /// U+FFFC OBJECT REPLACEMENT CHARACTER — the one character an image run
+    /// holds. Text is never stored for an image; alternative text lives in
+    /// <see cref="AltText"/>.
+    /// </summary>
+    public const char Placeholder = '\uFFFC';
+
+    /// <summary><see cref="Placeholder"/> as a string, for insertion calls.</summary>
+    public const string PlaceholderText = "\uFFFC";
+
+    public InlineImage(
+        ReadOnlyMemory<byte> data,
+        string contentType,
+        double width,
+        double height,
+        string? altText = null,
+        string? name = null)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+            throw new ArgumentException("An inline image needs a content type.", nameof(contentType));
+        if (width < 0 || double.IsNaN(width))
+            throw new ArgumentOutOfRangeException(nameof(width));
+        if (height < 0 || double.IsNaN(height))
+            throw new ArgumentOutOfRangeException(nameof(height));
+
+        Data = data;
+        ContentType = contentType;
+        Width = width;
+        Height = height;
+        AltText = altText ?? string.Empty;
+        Name = string.IsNullOrWhiteSpace(name) ? "image" : name;
+    }
+
+    /// <summary>The encoded image bytes, in the encoding named by <see cref="ContentType"/>.</summary>
+    public ReadOnlyMemory<byte> Data { get; }
+
+    /// <summary>The IANA media type of <see cref="Data"/>, for example <c>image/png</c>.</summary>
+    public string ContentType { get; }
+
+    /// <summary>
+    /// Display width in the same logical units as <see cref="InlineStyle.FontSize"/>
+    /// (points at 1:1 scale). Zero means "use the encoded pixel size".
+    /// </summary>
+    public double Width { get; }
+
+    /// <summary>Display height, in the units described by <see cref="Width"/>.</summary>
+    public double Height { get; }
+
+    /// <summary>Alternative text, or the empty string when the source gave none.</summary>
+    public string AltText { get; }
+
+    /// <summary>A short name for the image, used to name the part a writer emits.</summary>
+    public string Name { get; }
+
+    /// <summary>True when the source stated a display size rather than leaving it implied.</summary>
+    public bool HasExplicitSize => Width > 0 && Height > 0;
+
+    /// <summary>Returns the same image drawn at a different size.</summary>
+    public InlineImage WithSize(double width, double height) =>
+        new(Data, ContentType, width, height, AltText, Name);
+
+    /// <summary>Returns the same image with different alternative text.</summary>
+    public InlineImage WithAltText(string? altText) =>
+        new(Data, ContentType, Width, Height, altText, Name);
+}

--- a/Broiler.Documents/Broiler.Documents.Model/InlineStyle.cs
+++ b/Broiler.Documents/Broiler.Documents.Model/InlineStyle.cs
@@ -38,9 +38,20 @@ public readonly record struct InlineStyle
     /// <summary>Link target, or <see langword="null"/> when the run is not a link.</summary>
     public string? LinkHref { get; init; }
 
+    /// <summary>
+    /// The image drawn in place of the run's text, or <see langword="null"/> for
+    /// an ordinary text run. An image run holds exactly one
+    /// <see cref="InlineImage.Placeholder"/> character per image, so the image
+    /// takes one character position in the document.
+    /// </summary>
+    public InlineImage? Image { get; init; }
+
     /// <summary>The unformatted default style (<c>default(InlineStyle)</c>).</summary>
     public static InlineStyle Default => default;
 
     /// <summary>True when the run carries link metadata.</summary>
     public bool IsLink => !string.IsNullOrEmpty(LinkHref);
+
+    /// <summary>True when the run draws an image rather than text.</summary>
+    public bool IsImage => Image is not null;
 }

--- a/Broiler.Documents/Broiler.Documents.Model/InlineStyleDelta.cs
+++ b/Broiler.Documents/Broiler.Documents.Model/InlineStyleDelta.cs
@@ -36,7 +36,12 @@ public readonly record struct InlineStyleDelta
 
     public string? LinkHref { get; init; }
 
-    /// <summary>Applies this delta over <paramref name="style"/>.</summary>
+    /// <summary>
+    /// Applies this delta over <paramref name="style"/>. An
+    /// <see cref="InlineStyle.Image"/> is content rather than formatting and is
+    /// never touched here — clearing formatting over a picture must not delete
+    /// the picture.
+    /// </summary>
     public InlineStyle Apply(InlineStyle style) => style with
     {
         Bold = Bold ?? style.Bold,

--- a/Broiler.Documents/Broiler.Documents.Rtf.Tests/RtfWriterTests.cs
+++ b/Broiler.Documents/Broiler.Documents.Rtf.Tests/RtfWriterTests.cs
@@ -5,6 +5,39 @@ namespace Broiler.Documents.Rtf.Tests;
 
 public sealed class RtfWriterTests
 {
+    [Fact]
+    public void Writes_An_Embedded_Png_As_A_Pict_Destination()
+    {
+        var image = new InlineImage(new byte[] { 0xDE, 0xAD }, "image/png", 40, 20);
+        RichTextDocument document = RichTextDocument.FromParagraphs(new[]
+        {
+            RichTextParagraph.Create(InlineImage.PlaceholderText, InlineStyle.Default with { Image = image }),
+        });
+
+        string rtf = Write(document);
+
+        Assert.Contains("{\\pict\\pngblip", rtf, StringComparison.Ordinal);
+        Assert.Contains("\\picwgoal800", rtf, StringComparison.Ordinal);
+        Assert.Contains("\\pichgoal400", rtf, StringComparison.Ordinal);
+        Assert.Contains("dead}", rtf, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Drops_An_Image_Format_Rtf_Cannot_Name()
+    {
+        var image = new InlineImage(new byte[] { 1, 2 }, "image/webp", 40, 20);
+        RichTextDocument document = RichTextDocument.FromParagraphs(new[]
+        {
+            RichTextParagraph.Create(InlineImage.PlaceholderText, InlineStyle.Default with { Image = image }),
+        });
+
+        using var stream = new MemoryStream();
+        DocumentWriteResult result = RtfWriter.Write(document, stream);
+
+        Assert.DoesNotContain("\\pict", Encoding.ASCII.GetString(stream.ToArray()), StringComparison.Ordinal);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "rtf.image.format");
+    }
+
     private static string Write(RichTextDocument document) =>
         Encoding.ASCII.GetString(RtfWriter.WriteToArray(document));
 

--- a/Broiler.Documents/Broiler.Documents.Rtf/RtfWriter.cs
+++ b/Broiler.Documents/Broiler.Documents.Rtf/RtfWriter.cs
@@ -29,6 +29,8 @@ public static class RtfWriter
 
         var fonts = new ResourceTable<string>(StringComparer.Ordinal);
         var colors = new ResourceTable<BColor>(EqualityComparer<BColor>.Default);
+        var diagnostics = new List<DocumentDiagnostic>();
+        var reported = new HashSet<string>(StringComparer.Ordinal);
         CollectResources(document, fonts, colors);
 
         var sb = new StringBuilder();
@@ -41,7 +43,7 @@ public static class RtfWriter
             sb.Append("\\pard\\plain");
             WriteParagraphProperties(sb, paragraph.Style);
             sb.Append(' ');
-            WriteRuns(sb, paragraph, fonts, colors);
+            WriteRuns(sb, paragraph, fonts, colors, diagnostics, reported);
             sb.Append("\\par\n");
         }
 
@@ -49,7 +51,7 @@ public static class RtfWriter
 
         byte[] bytes = Encoding.ASCII.GetBytes(sb.ToString());
         destination.Write(bytes, 0, bytes.Length);
-        return new DocumentWriteResult(bytes.Length);
+        return new DocumentWriteResult(bytes.Length, diagnostics);
     }
 
     /// <summary>Serialize to a byte array (convenience over the stream overload).</summary>
@@ -129,14 +131,16 @@ public static class RtfWriter
         StringBuilder sb,
         RichTextParagraph paragraph,
         ResourceTable<string> fonts,
-        ResourceTable<BColor> colors)
+        ResourceTable<BColor> colors,
+        List<DocumentDiagnostic> diagnostics,
+        HashSet<string> reported)
     {
         int offset = 0;
         foreach (StyleRun run in paragraph.Runs)
         {
             string text = paragraph.Text.Substring(offset, run.Length);
             offset += run.Length;
-            WriteRun(sb, text, run.Style, fonts, colors);
+            WriteRun(sb, text, run.Style, fonts, colors, diagnostics, reported);
         }
     }
 
@@ -145,8 +149,16 @@ public static class RtfWriter
         string text,
         InlineStyle style,
         ResourceTable<string> fonts,
-        ResourceTable<BColor> colors)
+        ResourceTable<BColor> colors,
+        List<DocumentDiagnostic> diagnostics,
+        HashSet<string> reported)
     {
+        if (style.Image is InlineImage image)
+        {
+            WriteImageRun(sb, text, image, style, fonts, colors, diagnostics, reported);
+            return;
+        }
+
         if (!string.IsNullOrEmpty(style.LinkHref))
         {
             sb.Append("{\\field{\\*\\fldinst{HYPERLINK \"");
@@ -159,6 +171,88 @@ public static class RtfWriter
 
         WriteStyledText(sb, text, style, fonts, colors);
     }
+
+    /// <summary>
+    /// Writes an image run as an RTF <c>\pict</c> destination. RTF names only a
+    /// few picture encodings; bytes in any other format are dropped with a
+    /// diagnostic rather than written under a label that would misdescribe them.
+    /// </summary>
+    private static void WriteImageRun(
+        StringBuilder sb,
+        string text,
+        InlineImage image,
+        InlineStyle style,
+        ResourceTable<string> fonts,
+        ResourceTable<BColor> colors,
+        List<DocumentDiagnostic> diagnostics,
+        HashSet<string> reported)
+    {
+        string? blip = PictureControlWord(image.ContentType);
+        int start = 0;
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (text[i] != InlineImage.Placeholder)
+                continue;
+
+            if (i > start)
+                WriteStyledText(sb, text[start..i], style, fonts, colors);
+
+            if (blip is null)
+            {
+                AddOnce(
+                    diagnostics,
+                    reported,
+                    "rtf.image.format",
+                    "RTF carries only PNG and JPEG pictures; an image in another format was dropped.");
+            }
+            else
+            {
+                WritePicture(sb, image, blip);
+            }
+
+            start = i + 1;
+        }
+
+        if (start < text.Length)
+            WriteStyledText(sb, text[start..], style, fonts, colors);
+    }
+
+    private static void WritePicture(StringBuilder sb, InlineImage image, string blip)
+    {
+        sb.Append("{\\pict").Append(blip);
+        if (image.HasExplicitSize)
+        {
+            sb.Append("\\picwgoal").Append(Twips((float)image.Width));
+            sb.Append("\\pichgoal").Append(Twips((float)image.Height));
+        }
+
+        sb.Append(' ');
+        ReadOnlySpan<byte> data = image.Data.Span;
+        foreach (byte value in data)
+            sb.Append(HexDigits[value >> 4]).Append(HexDigits[value & 0x0F]);
+
+        sb.Append('}');
+    }
+
+    private static string? PictureControlWord(string contentType) =>
+        contentType.ToLowerInvariant() switch
+        {
+            "image/png" => "\\pngblip",
+            "image/jpeg" or "image/jpg" => "\\jpegblip",
+            _ => null,
+        };
+
+    private static void AddOnce(
+        List<DocumentDiagnostic> diagnostics,
+        HashSet<string> reported,
+        string code,
+        string message)
+    {
+        if (reported.Add(code))
+            diagnostics.Add(DocumentDiagnostic.Warning(code, message));
+    }
+
+    private const string HexDigits = "0123456789abcdef";
 
     private static void WriteStyledText(
         StringBuilder sb,

--- a/Broiler.Documents/docs/docx-conformance.md
+++ b/Broiler.Documents/docs/docx-conformance.md
@@ -36,12 +36,31 @@ Open XML WordprocessingML package parts.
   before/after, indentation, bullet lists, and numbered lists.
 - External hyperlinks for `http`, `https`, and `mailto`, plus internal anchor
   links.
+- Embedded pictures, read and written as a single object replacement character
+  (`U+FFFC`) whose run carries the image. Both shapes Word writes are read:
+  DrawingML (`w:drawing`, inline and anchored, including a picture inside
+  `mc:AlternateContent`) and the legacy VML shape (`w:pict`/`v:imagedata`). The
+  display size comes from `wp:extent` in EMUs, or from the VML shape's CSS
+  `width`/`height`; alternative text comes from `wp:docPr@descr`. A write stores
+  each distinct image once under `word/media`, with its relationship and a
+  content-type default for its extension. Raster formats only: PNG, JPEG, GIF,
+  BMP, TIFF, WebP, and ICO.
 
 ## Intentional Limits
 
-- Tracked deletions, embedded objects, images, fields, comments, headers,
-  footers, footnotes, table geometry, and section layout are skipped or
-  approximated with diagnostics where applicable.
+- Tracked deletions, embedded objects, fields, comments, headers, footers,
+  footnotes, table geometry, and section layout are skipped or approximated with
+  diagnostics where applicable.
+- A picture is content, not layout: an anchored (floating) picture is read as an
+  inline one and its text wrapping, position, and z-order are not represented.
+  Crops, rotation, borders, and picture effects are dropped; the image is written
+  back as a plain inline frame at its display size.
+- EMF/WMF metafiles — what Word embeds for charts, SmartArt, and shape fallbacks
+  — are not carried, because they cannot be decoded to pixels here. They are
+  reported as `docx.image.format` rather than kept as a picture that would draw
+  as nothing.
+- An image linked with `r:link` rather than embedded is not fetched; reading it
+  would mean a network or file request driven by document content (ADR 0004).
 - Style resolution covers the attributes `RichTextDocument` models. Style
   features outside it — character spacing/scaling, table styles, numbering-level
   overrides, conditional table formatting — are ignored, as are theme colors
@@ -59,12 +78,12 @@ Open XML WordprocessingML package parts.
 ## Read Diagnostics
 
 Every read ends with a `docx.read.summary` info diagnostic carrying the
-paragraph, flattened-table, and skipped-block counts. It exists so a document
-that opens blank can be told apart from a document that *is* blank:
+paragraph, flattened-table, style, image, and skipped-block counts. It exists so
+a document that opens blank can be told apart from a document that *is* blank:
 
 | Code | Severity | Meaning |
 | --- | --- | --- |
-| `docx.read.summary` | Info | Paragraph, table, style, and skipped-block counts for the read. |
+| `docx.read.summary` | Info | Paragraph, table, style, image, and skipped-block counts for the read. |
 | `docx.document.empty` | Warning | The body held block-level content but produced no paragraphs — a reader gap, not an empty file. |
 | `docx.table.flattened` | Warning | At least one table was flattened into its cell paragraphs. |
 | `docx.block.unsupported` | Warning | A block-level element was not understood; the message names the element. Reported once per distinct name. |
@@ -74,6 +93,13 @@ that opens blank can be told apart from a document that *is* blank:
 | `docx.styles.cycle` | Warning | A `w:basedOn` chain was cyclic and was cut short. |
 | `docx.styles.depth` | Warning | A `w:basedOn` chain exceeded `MaxGroupDepth` and was cut short. |
 | `docx.part.headerfooter` | Info | The package has headers or footers, which are not part of the body. |
+| `docx.image.missing` | Warning | A picture referenced a media part the package does not contain. |
+| `docx.image.relationship` | Warning | A picture named a relationship the package does not define. |
+| `docx.image.external` | Warning | A picture linked to an image outside the package, which is not fetched. |
+| `docx.image.format` | Warning | A picture used an image format this codec does not carry (EMF/WMF and the like). |
+| `docx.image.limit` | Warning | An image part exceeded `MaxBinBytes` and was skipped. |
+| `docx.image.shape` | Warning | A drawing held no embedded picture. |
+| `docx.image.anchored` | Warning | A floating picture was placed inline; wrapping is not represented. |
 
 `Broiler.Cli --convert-doc <in> --output <out>` prints all of them, which is the
 quickest way to see what a problem document lost. In the Writer, set

--- a/Broiler.Documents/docs/html-conformance.md
+++ b/Broiler.Documents/docs/html-conformance.md
@@ -47,12 +47,16 @@ spaces; `<pre>` preserves whitespace.
 | Soft breaks | `<br>` |
 | Inline style fields | CSS on `<span>` or `<a>` |
 | `LinkHref` | `<a href="...">` |
+| `InlineStyle.Image` | `<img src="data:...;base64,...">` with `alt` and a CSS size |
 | Paragraph alignment, line spacing, indent, spacing | CSS on `<p>` |
 
 `ListKind` is not written in the first subset; the writer preserves indentation
-and emits an `html.list` diagnostic. Non-model constructs such as tables,
-images, embedded objects, scripts, stylesheets, forms, and metadata are not
-serialized from the model.
+and emits an `html.list` diagnostic. An embedded image is written inline as a
+base64 data URI (`html.image.datauri`), which keeps an exported page a single
+file; the reader does not turn `<img>` back into a model image, so an image does
+not survive an HTML round-trip. Non-model constructs such as tables, embedded
+objects, scripts, stylesheets, forms, and metadata are not serialized from the
+model.
 
 ## Security And Limits
 

--- a/Broiler.Documents/docs/markdown-conformance.md
+++ b/Broiler.Documents/docs/markdown-conformance.md
@@ -49,7 +49,10 @@ is intentionally conservative.
 
 The writer emits UTF-8 Markdown with a trailing newline. Unsupported paragraph
 style fields (alignment, line spacing, spacing before/after) produce
-`markdown.paragraph-style`. Unsupported inline style fields (underline, size,
+`markdown.paragraph-style`. An embedded image is written as CommonMark image
+syntax with a base64 data URI (`markdown.image.datauri`); the reader does not
+turn it back into a model image, so an image does not survive a Markdown
+round-trip. Unsupported inline style fields (underline, size,
 foreground/background color, and non-monospace font family) produce
 `markdown.inline-style`.
 

--- a/Broiler.Documents/docs/rtf-conformance.md
+++ b/Broiler.Documents/docs/rtf-conformance.md
@@ -76,8 +76,13 @@ Group nesting is iterative (no recursion), so depth cannot overflow the stack.
 The writer emits the honoured subset above as pure ASCII: a `{\rtf1\ansi\ansicpg1252\deff0\uc1`
 header, `\fonttbl`/`\colortbl` built from the styles used, one group-wrapped run
 per style, and a `\par` after every paragraph. Non-ASCII characters are escaped
-as `\uN?`. Round-trip (model → RTF → model) is lossless for any document the
-reader can produce, with two documented exceptions: line spacing and list kind
+as `\uN?`. An embedded image is written as a `\pict` destination — `\pngblip`
+or `\jpegblip`, sized with `\picwgoal`/`\pichgoal` — so a picture survives into
+Word and WordPad; any other image format is dropped with `rtf.image.format`.
+Because `\pict` is a skipped destination on the read side, an image does **not**
+survive a model → RTF → model round-trip; DOCX is the format that round-trips
+pictures. Round-trip is otherwise lossless for any document the reader can
+produce, with two further documented exceptions: line spacing and list kind
 are not written (they are not read either, so they stay at their defaults); and a
 **non-ASCII font-family name** is escaped as `\uN` on write, which the font-table
 reader does not decode (font names are read as their literal bytes) — so such a

--- a/Broiler.Linux.Writer.slnx
+++ b/Broiler.Linux.Writer.slnx
@@ -38,6 +38,7 @@
   </Folder>
   <Folder Name="/Dependencies/Broiler.Media/">
     <Project Path="Broiler.Media/Broiler.Media.Image/Broiler.Media.Image.csproj" />
+    <Project Path="Broiler.Media/Broiler.Media.Image.Managed/Broiler.Media.Image.Managed.csproj" />
     <Project Path="Broiler.Media/Broiler.Media/Broiler.Media.csproj" />
   </Folder>
   <Folder Name="/Dependencies/Broiler.UI/">

--- a/Broiler.UI/src/Foundation/Broiler.UI/Host/IUiImageHost.cs
+++ b/Broiler.UI/src/Foundation/Broiler.UI/Host/IUiImageHost.cs
@@ -1,0 +1,25 @@
+using System;
+using Broiler.Graphics;
+
+namespace Broiler.UI;
+
+/// <summary>
+/// An optional host capability: turning encoded image bytes into a
+/// <see cref="BImageHandle"/> the render list can draw. Only a host that owns a
+/// renderer can do this, so controls that draw document images look for this
+/// interface on <see cref="IUiHost"/> and fall back to a placeholder box when it
+/// is absent.
+/// </summary>
+public interface IUiImageHost
+{
+    /// <summary>
+    /// Creates a drawable image from encoded bytes (PNG, JPEG, and whatever else
+    /// the backend decodes). Returns <see cref="BImageHandle.Invalid"/> when the
+    /// bytes cannot be decoded — a malformed image in a document must not throw
+    /// out of a render pass.
+    /// </summary>
+    BImageHandle CreateImage(ReadOnlySpan<byte> encodedImage);
+
+    /// <summary>Releases a handle returned by <see cref="CreateImage"/>.</summary>
+    void ReleaseImage(BImageHandle image);
+}

--- a/Broiler.UI/src/Implementations/Standard/Text/Broiler.UI.RichEdit.Standard/StandardRichEdit.cs
+++ b/Broiler.UI/src/Implementations/Standard/Text/Broiler.UI.RichEdit.Standard/StandardRichEdit.cs
@@ -35,6 +35,7 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
     }
 
     private readonly List<VisualLine> _lines = [];
+    private readonly Dictionary<InlineImage, BImageHandle> _imageHandles = new(ReferenceEqualityComparer.Instance);
     private RichTextDocument? _layoutDocument;
     private BFontStyle? _layoutFont;
     private double _layoutWidth = double.NaN;
@@ -53,6 +54,12 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
     private bool _isTouchScrolling;
 
     private const double TouchScrollThreshold = 6;
+
+    /// <summary>The box an image with no known size is drawn in, and the minimum for any image.</summary>
+    private const double FallbackImageExtent = 72;
+
+    /// <summary>Space left around an inline image so it does not touch the text above and below it.</summary>
+    private const double ImageMargin = 2;
 
     public BColor Background { get; set; } = StandardControlPaint.Surface;
 
@@ -213,11 +220,24 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
         };
     }
 
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+
+        // A layout built before the session existed sized its images from the
+        // fallback box, because no host was there to decode them. Rebuild it now
+        // that one is, or those sizes would stick until the document changes.
+        _layoutValid = false;
+    }
+
     protected override void OnDetached()
     {
         if (Session?.Host is IUiTextInputHost textInput)
             textInput.ClearCaret(this);
 
+        // The handles belong to the detaching session's renderer, so they are
+        // released here rather than kept for a session that cannot draw them.
+        ReleaseImages();
         base.OnDetached();
     }
 
@@ -312,10 +332,45 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
             foreach (LineSegment segment in LineSegments(line))
             {
                 BColor color = IsEnabled && !segment.Style.Foreground.IsEmpty ? segment.Style.Foreground : fallback;
+                if (segment.Image is InlineImage image)
+                {
+                    DrawInlineImage(renderList, image, segment, y, line.Height, color);
+                    continue;
+                }
+
                 renderList.DrawText(new BTextRun(segment.Text, segment.Font, color), new BPoint(segment.X, y));
                 DrawDecorations(renderList, segment, y, line.Height, color);
             }
         }
+    }
+
+    /// <summary>
+    /// Draws one inline picture, bottom-aligned in its line the way Word sits an
+    /// inline image on the text baseline. An image the backend could not decode
+    /// is drawn as an outlined box, so the document still shows where it is.
+    /// </summary>
+    private void DrawInlineImage(
+        BRenderList renderList,
+        InlineImage image,
+        LineSegment segment,
+        double lineTop,
+        double lineHeight,
+        BColor color)
+    {
+        BSize size = ImageDisplaySize(image);
+        double height = Math.Min(size.Height, Math.Max(0, lineHeight - (ImageMargin * 2)));
+        double top = lineTop + Math.Max(ImageMargin, lineHeight - height - ImageMargin);
+        var destination = new BRect(segment.X, top, segment.Advance, height);
+
+        BImageHandle handle = ResolveImage(image);
+        if (handle.IsValid)
+        {
+            var source = new BRect(0, 0, handle.PixelSize.Width, handle.PixelSize.Height);
+            renderList.DrawImage(handle, source, destination, IsEnabled ? 1.0 : 0.5);
+            return;
+        }
+
+        StandardControlPaint.StrokeRounded(renderList, destination, color, StandardControlPaint.ControlRadius, 1);
     }
 
     private void DrawDecorations(BRenderList renderList, LineSegment segment, double y, double lineHeight, BColor color)
@@ -379,6 +434,30 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
                 continue;
 
             string text = paragraph.Text.Substring(segStart, segEnd - segStart);
+            if (run.Style.Image is InlineImage image)
+            {
+                // Every placeholder character in an image run draws the image, so
+                // a run that happens to hold two of them draws two pictures
+                // rather than one stretched across both character positions.
+                foreach (char character in text)
+                {
+                    if (character == InlineImage.Placeholder)
+                    {
+                        double width = ImageDisplaySize(image).Width;
+                        yield return LineSegment.ForImage(image, run.Style, x, width);
+                        x += width;
+                        continue;
+                    }
+
+                    string single = character.ToString();
+                    double advance = MeasurePieces(single, run.Style, RunFont(run.Style));
+                    yield return new LineSegment(single, run.Style, RunFont(run.Style), x, advance);
+                    x += advance;
+                }
+
+                continue;
+            }
+
             foreach (ShapedPiece piece in ShapePieces(text, run.Style, RunFont(run.Style)))
             {
                 double advance = BTextMeasurer.MeasureAdvance(piece.Text, piece.Font);
@@ -386,6 +465,57 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
                 x += advance;
             }
         }
+    }
+
+    /// <summary>
+    /// The size an inline image is drawn at: the display size the document
+    /// states, else the decoded pixel size, else a fixed box. The box keeps a
+    /// picture the backend could not decode visible and selectable instead of
+    /// collapsing it to nothing.
+    /// </summary>
+    private BSize ImageDisplaySize(InlineImage image)
+    {
+        if (image.HasExplicitSize)
+            return new BSize(image.Width, image.Height);
+
+        BImageHandle handle = ResolveImage(image);
+        if (handle.IsValid && handle.PixelSize.Width > 0 && handle.PixelSize.Height > 0)
+            return handle.PixelSize;
+
+        return new BSize(FallbackImageExtent, FallbackImageExtent);
+    }
+
+    /// <summary>
+    /// The backend handle for an image, created once per image object and kept
+    /// until the control is detached. A host with no image capability, or bytes
+    /// the backend cannot decode, cache as invalid so the failure is not retried
+    /// on every frame.
+    /// </summary>
+    private BImageHandle ResolveImage(InlineImage image)
+    {
+        if (_imageHandles.TryGetValue(image, out BImageHandle cached))
+            return cached;
+
+        BImageHandle handle = BImageHandle.Invalid;
+        if (Session?.Host is IUiImageHost imageHost && !image.Data.IsEmpty)
+            handle = imageHost.CreateImage(image.Data.Span);
+
+        _imageHandles[image] = handle;
+        return handle;
+    }
+
+    private void ReleaseImages()
+    {
+        if (Session?.Host is IUiImageHost imageHost)
+        {
+            foreach (BImageHandle handle in _imageHandles.Values)
+            {
+                if (handle.IsValid)
+                    imageHost.ReleaseImage(handle);
+            }
+        }
+
+        _imageHandles.Clear();
     }
 
     /// <summary>How much smaller a small-caps letter is drawn than a full capital.</summary>
@@ -453,6 +583,27 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
         double advance = 0;
         foreach (ShapedPiece piece in ShapePieces(text, style, font))
             advance += BTextMeasurer.MeasureAdvance(piece.Text, piece.Font);
+
+        return advance;
+    }
+
+    /// <summary>
+    /// The advance of a substring of one run, counting a picture as the width it
+    /// is drawn at. Caret placement, selection rectangles, and wrapping all come
+    /// through here, so an image occupies the same horizontal space in each.
+    /// </summary>
+    private double MeasureRunText(string text, InlineStyle style)
+    {
+        if (style.Image is not InlineImage image)
+            return MeasurePieces(text, style, RunFont(style));
+
+        double advance = 0;
+        foreach (char character in text)
+        {
+            advance += character == InlineImage.Placeholder
+                ? ImageDisplaySize(image).Width
+                : MeasurePieces(character.ToString(), style, RunFont(style));
+        }
 
         return advance;
     }
@@ -1146,7 +1297,7 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
                 continue;
 
             string text = paragraph.Text.Substring(segmentStart, segmentEnd - segmentStart);
-            advance += MeasurePieces(text, run.Style, RunFont(run.Style));
+            advance += MeasureRunText(text, run.Style);
         }
 
         return advance;
@@ -1210,6 +1361,46 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
         }
 
         _contentHeight = y;
+        ReleaseImagesNotIn(document);
+    }
+
+    /// <summary>
+    /// Releases the handles of images the document no longer contains. Layout is
+    /// the right moment: it runs when the document actually changed, not once per
+    /// frame, and opening a second document would otherwise leave the first
+    /// document's pictures uploaded for the life of the control.
+    /// </summary>
+    private void ReleaseImagesNotIn(RichTextDocument document)
+    {
+        if (_imageHandles.Count == 0)
+            return;
+
+        var live = new HashSet<InlineImage>(ReferenceEqualityComparer.Instance);
+        foreach (RichTextParagraph paragraph in document.Paragraphs)
+        {
+            foreach (StyleRun run in paragraph.Runs)
+            {
+                if (run.Style.Image is InlineImage image)
+                    live.Add(image);
+            }
+        }
+
+        List<InlineImage>? stale = null;
+        foreach (KeyValuePair<InlineImage, BImageHandle> entry in _imageHandles)
+        {
+            if (!live.Contains(entry.Key))
+                (stale ??= []).Add(entry.Key);
+        }
+
+        if (stale is null)
+            return;
+
+        var imageHost = Session?.Host as IUiImageHost;
+        foreach (InlineImage image in stale)
+        {
+            if (_imageHandles.Remove(image, out BImageHandle handle) && handle.IsValid)
+                imageHost?.ReleaseImage(handle);
+        }
     }
 
     private static IEnumerable<(int Start, int End)> HardSegments(string text)
@@ -1272,7 +1463,11 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
             if (Math.Max(start, runStart) >= Math.Min(end, runEnd))
                 continue;
 
-            height = Math.Max(height, BTextMeasurer.GetLineHeight(RunFont(run.Style)));
+            // A picture makes its line as tall as it needs to be, or the image
+            // would be clipped by the surrounding text's line height.
+            height = run.Style.Image is InlineImage image
+                ? Math.Max(height, ImageDisplaySize(image).Height + (ImageMargin * 2))
+                : Math.Max(height, BTextMeasurer.GetLineHeight(RunFont(run.Style)));
         }
 
         return height;
@@ -1283,6 +1478,12 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
         string text = paragraph.Text;
         InlineStyle style = paragraph.StyleAt(index);
         BFontStyle font = RunFont(style);
+        if (text[index] == InlineImage.Placeholder && style.Image is InlineImage image)
+        {
+            step = 1;
+            return ImageDisplaySize(image).Width;
+        }
+
         if (index + 1 < text.Length && char.IsHighSurrogate(text[index]) && char.IsLowSurrogate(text[index + 1]))
         {
             step = 2;
@@ -1323,5 +1524,20 @@ public sealed class StandardRichEdit : UiRichEdit, IStandardThemedControl, IUiTe
 
     private readonly record struct VisualLine(int ParagraphIndex, int Start, int End, double Top, double Height);
 
-    private readonly record struct LineSegment(string Text, InlineStyle Style, BFontStyle Font, double X, double Advance);
+    /// <summary>
+    /// A stretch of a visual line as it is drawn. <see cref="Image"/> is set only
+    /// for a picture, and then <see cref="Text"/> is the placeholder character it
+    /// occupies rather than anything to draw as glyphs.
+    /// </summary>
+    private readonly record struct LineSegment(
+        string Text,
+        InlineStyle Style,
+        BFontStyle Font,
+        double X,
+        double Advance,
+        InlineImage? Image = null)
+    {
+        public static LineSegment ForImage(InlineImage image, InlineStyle style, double x, double width) =>
+            new(InlineImage.PlaceholderText, style, BFontStyle.Default, x, width, image);
+    }
 }

--- a/Broiler.UI/tests/Text/Broiler.UI.RichEdit.Standard.Tests/RichEditStandardHarness.cs
+++ b/Broiler.UI/tests/Text/Broiler.UI.RichEdit.Standard.Tests/RichEditStandardHarness.cs
@@ -7,9 +7,18 @@ using Broiler.UI.Standard;
 
 namespace Broiler.UI.RichEdit.Standard.Tests;
 
-internal sealed class TestHost : IUiHost, IUiClipboardHost, IUiTextInputHost
+internal sealed class TestHost : IUiHost, IUiClipboardHost, IUiTextInputHost, IUiImageHost
 {
+    private ulong _nextImageId;
+
     public TestHost(BSize viewportSize) => ViewportSize = viewportSize;
+
+    /// <summary>The pixel size handed back for a created image, or null to fail every decode.</summary>
+    public BSize? ImagePixelSize { get; set; } = new BSize(20, 10);
+
+    public int CreatedImages { get; private set; }
+
+    public int ReleasedImages { get; private set; }
 
     public BSize ViewportSize { get; }
 
@@ -46,6 +55,17 @@ internal sealed class TestHost : IUiHost, IUiClipboardHost, IUiTextInputHost
         LastCaret = null;
         ClearCaretCount++;
     }
+
+    public BImageHandle CreateImage(ReadOnlySpan<byte> encodedImage)
+    {
+        CreatedImages++;
+        if (ImagePixelSize is not BSize size)
+            return BImageHandle.Invalid;
+
+        return BImageHandle.FromId(++_nextImageId, size);
+    }
+
+    public void ReleaseImage(BImageHandle image) => ReleasedImages++;
 }
 
 internal sealed class ManualClock : IUiClock

--- a/Broiler.UI/tests/Text/Broiler.UI.RichEdit.Standard.Tests/StandardRichEditImageRenderTests.cs
+++ b/Broiler.UI/tests/Text/Broiler.UI.RichEdit.Standard.Tests/StandardRichEditImageRenderTests.cs
@@ -1,0 +1,188 @@
+using Broiler.Graphics;
+using static Broiler.UI.RichEdit.Standard.Tests.RichEditStandardHarness;
+
+namespace Broiler.UI.RichEdit.Standard.Tests;
+
+/// <summary>
+/// Drawing an inline image: the picture reaches the render list, takes its
+/// display width in the line, makes the line tall enough for it, and degrades to
+/// an outline when nothing can decode it.
+/// </summary>
+public sealed class StandardRichEditImageRenderTests
+{
+    private static readonly byte[] Bytes = [1, 2, 3, 4];
+
+    private static InlineImage Image(double width = 60, double height = 40) =>
+        new(Bytes, "image/png", width, height, "a logo");
+
+    private static RichEditScene WithImage(InlineImage image, string before = "", string after = "")
+    {
+        RichEditScene scene = Create(new BSize(400, 200));
+        RichTextParagraph paragraph = RichTextParagraph.Create(before, InlineStyle.Default)
+            .InsertText(before.Length, InlineImage.PlaceholderText, InlineStyle.Default with { Image = image })
+            .InsertText(before.Length + 1, after, InlineStyle.Default);
+        scene.Edit.Document = RichTextDocument.FromParagraphs([paragraph]);
+        return scene;
+    }
+
+    private static IEnumerable<BRenderCommand.DrawImage> DrawnImages(BRenderList list) =>
+        list.Commands.OfType<BRenderCommand.DrawImage>();
+
+    [Fact]
+    public void Draws_An_Inline_Image_At_Its_Display_Size()
+    {
+        RichEditScene scene = WithImage(Image(60, 40));
+
+        BRenderList list = scene.Session.RenderFrame();
+
+        BRenderCommand.DrawImage drawn = Assert.Single(DrawnImages(list));
+        Assert.Equal(60, drawn.Destination.Width, 3);
+        Assert.Equal(40, drawn.Destination.Height, 3);
+        Assert.Equal(1, scene.Host.CreatedImages);
+        scene.Session.Dispose();
+    }
+
+    [Fact]
+    public void Uploads_An_Image_Once_However_Many_Frames_Are_Drawn()
+    {
+        RichEditScene scene = WithImage(Image());
+
+        scene.Session.RenderFrame();
+        scene.Session.RenderFrame();
+        scene.Session.RenderFrame();
+
+        Assert.Equal(1, scene.Host.CreatedImages);
+        scene.Session.Dispose();
+    }
+
+    [Fact]
+    public void An_Image_Takes_Its_Width_In_The_Line()
+    {
+        RichEditScene scene = WithImage(Image(60, 40), before: "ab", after: "cd");
+
+        BRenderList list = scene.Session.RenderFrame();
+        BRenderCommand.DrawImage drawn = Assert.Single(DrawnImages(list));
+
+        // The text after the picture starts where the picture ends, so the caret
+        // and selection metrics agree with what is on screen.
+        BRenderCommand.DrawText after = Assert.Single(
+            list.Commands.OfType<BRenderCommand.DrawText>().Where(c => c.Text.Text == "cd"));
+        Assert.Equal(drawn.Destination.Right, after.Origin.X, 3);
+        scene.Session.Dispose();
+    }
+
+    [Fact]
+    public void An_Image_Makes_Its_Line_Tall_Enough_To_Show_It()
+    {
+        RichEditScene tall = WithImage(Image(60, 120), before: "ab");
+        RichEditScene plain = WithImage(Image(60, 10), before: "ab");
+
+        BRenderCommand.DrawImage tallImage = Assert.Single(DrawnImages(tall.Session.RenderFrame()));
+        BRenderCommand.DrawImage shortImage = Assert.Single(DrawnImages(plain.Session.RenderFrame()));
+
+        // A picture taller than the text is drawn at full height rather than
+        // clipped to the line height the text alone would give.
+        Assert.Equal(120, tallImage.Destination.Height, 3);
+        Assert.Equal(10, shortImage.Destination.Height, 3);
+
+        // The text beside it moves down with the taller line.
+        double tallTextY = TextOrigin(tall, "ab").Y;
+        double shortTextY = TextOrigin(plain, "ab").Y;
+        Assert.Equal(tallTextY, shortTextY, 3);
+        Assert.True(tallImage.Destination.Bottom > shortImage.Destination.Bottom);
+        tall.Session.Dispose();
+        plain.Session.Dispose();
+    }
+
+    private static BPoint TextOrigin(RichEditScene scene, string text) =>
+        scene.Session.RenderFrame().Commands
+            .OfType<BRenderCommand.DrawText>()
+            .First(c => c.Text.Text == text)
+            .Origin;
+
+    [Fact]
+    public void Falls_Back_To_An_Outline_When_The_Image_Cannot_Be_Decoded()
+    {
+        RichEditScene scene = WithImage(Image());
+        scene.Host.ImagePixelSize = null;
+
+        BRenderList list = scene.Session.RenderFrame();
+
+        Assert.Empty(DrawnImages(list));
+        Assert.Equal(1, scene.Host.CreatedImages);
+        scene.Session.Dispose();
+    }
+
+    [Fact]
+    public void An_Image_With_No_Stated_Size_Uses_Its_Decoded_Pixel_Size()
+    {
+        RichEditScene scene = WithImage(new InlineImage(Bytes, "image/png", 0, 0));
+
+        // The harness host reports every image as 20x10 pixels.
+        BRenderCommand.DrawImage drawn = Assert.Single(DrawnImages(scene.Session.RenderFrame()));
+
+        Assert.Equal(20, drawn.Destination.Width, 3);
+        Assert.Equal(10, drawn.Destination.Height, 3);
+        scene.Session.Dispose();
+    }
+
+    [Fact]
+    public void Two_Images_On_One_Line_Are_Both_Drawn()
+    {
+        RichEditScene scene = Create(new BSize(400, 200));
+        RichTextParagraph paragraph = RichTextParagraph.Empty
+            .InsertText(0, InlineImage.PlaceholderText, InlineStyle.Default with { Image = Image(30, 20) })
+            .InsertText(1, InlineImage.PlaceholderText, InlineStyle.Default with { Image = Image(30, 20) });
+        scene.Edit.Document = RichTextDocument.FromParagraphs([paragraph]);
+
+        BRenderList list = scene.Session.RenderFrame();
+
+        Assert.Equal(2, DrawnImages(list).Count());
+        scene.Session.Dispose();
+    }
+
+    [Fact]
+    public void Releases_The_Handles_Of_A_Document_That_Was_Replaced()
+    {
+        RichEditScene scene = WithImage(Image());
+        scene.Session.RenderFrame();
+        Assert.Equal(1, scene.Host.CreatedImages);
+
+        // Opening a second document must not leave the first one's pictures
+        // uploaded for the life of the control.
+        scene.Edit.Document = RichTextDocument.FromPlainText("plain");
+        scene.Session.RenderFrame();
+
+        Assert.Equal(1, scene.Host.ReleasedImages);
+        scene.Session.Dispose();
+    }
+
+    [Fact]
+    public void Keeps_An_Image_Uploaded_While_The_Document_Is_Edited_Around_It()
+    {
+        RichEditScene scene = WithImage(Image(), before: "ab");
+        scene.Session.RenderFrame();
+
+        scene.Edit.Selection = RichTextRange.Caret(scene.Edit.Document.Start);
+        scene.Edit.ExecuteCommand(RichEditCommand.InsertText, "xy");
+        scene.Session.RenderFrame();
+
+        // Every edit produces a new document snapshot; the picture in it is the
+        // same object, so it is neither released nor uploaded a second time.
+        Assert.Equal(1, scene.Host.CreatedImages);
+        Assert.Equal(0, scene.Host.ReleasedImages);
+        scene.Session.Dispose();
+    }
+
+    [Fact]
+    public void Releases_Its_Image_Handles_When_Detached()
+    {
+        RichEditScene scene = WithImage(Image());
+        scene.Session.RenderFrame();
+        Assert.Equal(1, scene.Host.CreatedImages);
+
+        scene.Session.Dispose();
+
+        Assert.Equal(1, scene.Host.ReleasedImages);
+    }
+}

--- a/Broiler.Windows.Writer.slnx
+++ b/Broiler.Windows.Writer.slnx
@@ -34,6 +34,7 @@
   </Folder>
   <Folder Name="/Dependencies/Broiler.Media/">
     <Project Path="Broiler.Media/Broiler.Media.Image/Broiler.Media.Image.csproj" />
+    <Project Path="Broiler.Media/Broiler.Media.Image.Managed/Broiler.Media.Image.Managed.csproj" />
     <Project Path="Broiler.Media/Broiler.Media.Video/Broiler.Media.Video.csproj" />
     <Project Path="Broiler.Media/Broiler.Media/Broiler.Media.csproj" />
   </Folder>

--- a/src/Broiler.Writer.FormatCodes.Tests/Broiler.Writer.FormatCodes.Tests.csproj
+++ b/src/Broiler.Writer.FormatCodes.Tests/Broiler.Writer.FormatCodes.Tests.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\Broiler.Writer.FormatCodes\Broiler.Writer.FormatCodes.csproj" />
     <ProjectReference Include="..\Broiler.Writer\Broiler.Writer.Core.csproj" />
     <ProjectReference Include="..\..\Broiler.UI\src\Implementations\Standard\Text\Broiler.UI.RichEdit.Standard\Broiler.UI.RichEdit.Standard.csproj" />
+    <ProjectReference Include="..\..\Broiler.Media\Broiler.Media.Image.Managed\Broiler.Media.Image.Managed.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Broiler.Writer.FormatCodes.Tests/WriterImageRenderTests.cs
+++ b/src/Broiler.Writer.FormatCodes.Tests/WriterImageRenderTests.cs
@@ -1,0 +1,135 @@
+using System.Runtime.CompilerServices;
+using Broiler.Documents.Model;
+using Broiler.Graphics;
+using Broiler.Media;
+using Broiler.Media.Image.Managed;
+
+namespace Broiler.Writer.FormatCodes.Tests;
+
+/// <summary>
+/// Test-host composition root, matching what the Writer entry points do: without
+/// a registered catalog the renderer cannot decode a document's images.
+/// </summary>
+internal static class WriterImageCodecBootstrap
+{
+    [ModuleInitializer]
+    internal static void Register() =>
+        BImageCodecs.Use(new MediaCodecCatalog(ManagedImageCodecs.CreateCodecs()));
+}
+
+/// <summary>
+/// The whole chain in one place: a DOCX with a picture is opened in the Writer,
+/// and the frame it renders actually contains that picture. This is what breaks
+/// if any single link — codec, model, editor layout, or host image upload — is
+/// wired up wrong.
+/// </summary>
+public sealed class WriterImageRenderTests
+{
+    [Fact]
+    public void A_Picture_In_An_Opened_Docx_Reaches_The_Render_List()
+    {
+        using var renderer = new BImageRenderer();
+        var host = new WriterUiHost(
+            () => new BSize(1200, 800),
+            () => 1,
+            () => { },
+            _ => { },
+            getRenderer: () => renderer);
+        using var app = new WriterApp(host, () => { });
+
+        var image = new InlineImage(RedDotPng, "image/png", 48, 24, "a red dot");
+        byte[] docx = Broiler.Documents.Docx.DocxDocumentCodec.WriteToArray(
+            RichTextDocument.FromParagraphs(
+            [
+                RichTextParagraph.Create(InlineImage.PlaceholderText, InlineStyle.Default with { Image = image }),
+            ]));
+
+        using var stream = new MemoryStream(docx, writable: false);
+        Assert.True(app.LoadDocument(stream, "picture.docx"));
+
+        BRenderList frame = app.RenderFrame();
+        BRenderCommand.DrawImage drawn = Assert.Single(
+            frame.Commands.OfType<BRenderCommand.DrawImage>());
+
+        Assert.Equal(48, drawn.Destination.Width, 3);
+        Assert.Equal(24, drawn.Destination.Height, 3);
+        Assert.True(drawn.Image.IsValid);
+    }
+
+    [Fact]
+    public void The_Rendered_Frame_Actually_Contains_The_Pictures_Pixels()
+    {
+        using var renderer = new BImageRenderer();
+        var host = new WriterUiHost(
+            () => new BSize(900, 600),
+            () => 1,
+            () => { },
+            _ => { },
+            getRenderer: () => renderer);
+        using var app = new WriterApp(host, () => { });
+
+        var image = new InlineImage(RedDotPng, "image/png", 64, 64, "a red square");
+        byte[] docx = Broiler.Documents.Docx.DocxDocumentCodec.WriteToArray(
+            RichTextDocument.FromParagraphs(
+            [
+                RichTextParagraph.Create(InlineImage.PlaceholderText, InlineStyle.Default with { Image = image }),
+            ]));
+
+        using var stream = new MemoryStream(docx, writable: false);
+        Assert.True(app.LoadDocument(stream, "picture.docx"));
+
+        BRenderList frame = app.RenderFrame();
+        var descriptor = BSurfaceDescriptor.Default(new BSize(900, 600));
+        using BBitmap bitmap = renderer.RenderToImage(frame, descriptor, BFrameContext.Default);
+
+        BRenderCommand.DrawImage drawn = Assert.Single(frame.Commands.OfType<BRenderCommand.DrawImage>());
+        BColor sample = bitmap.GetPixel(
+            (int)Math.Round(drawn.Destination.Left + (drawn.Destination.Width / 2)),
+            (int)Math.Round(drawn.Destination.Top + (drawn.Destination.Height / 2)));
+
+        // The source PNG is solid red; the middle of the destination rectangle is
+        // where it lands on the page.
+        Assert.True(sample.R > 200, "expected red at the picture's centre, got " + sample);
+        Assert.True(sample.G < 60, "expected red at the picture's centre, got " + sample);
+        Assert.True(sample.B < 60, "expected red at the picture's centre, got " + sample);
+    }
+
+    [Fact]
+    public void A_Picture_The_Renderer_Cannot_Decode_Does_Not_Break_The_Frame()
+    {
+        using var renderer = new BImageRenderer();
+        var host = new WriterUiHost(
+            () => new BSize(1200, 800),
+            () => 1,
+            () => { },
+            _ => { },
+            getRenderer: () => renderer);
+        using var app = new WriterApp(host, () => { });
+
+        // A PNG signature over bytes that decode to nothing: the document is
+        // still readable, and the editor must render rather than throw.
+        byte[] brokenBytes = [.. RedDotPng[..8], 0, 0, 0, 0];
+        var broken = new InlineImage(brokenBytes, "image/png", 40, 20);
+        byte[] docx = Broiler.Documents.Docx.DocxDocumentCodec.WriteToArray(
+            RichTextDocument.FromParagraphs(
+            [
+                RichTextParagraph.Create("text ", InlineStyle.Default)
+                    .InsertText(5, InlineImage.PlaceholderText, InlineStyle.Default with { Image = broken }),
+            ]));
+
+        using var stream = new MemoryStream(docx, writable: false);
+        Assert.True(app.LoadDocument(stream, "broken.docx"));
+
+        BRenderList frame = app.RenderFrame();
+
+        Assert.Empty(frame.Commands.OfType<BRenderCommand.DrawImage>());
+        Assert.Contains(
+            frame.Commands.OfType<BRenderCommand.DrawText>(),
+            command => command.Text.Text.Contains("text", StringComparison.Ordinal));
+    }
+
+    /// <summary>An 8x8 red PNG — real bytes, so the managed decoder produces pixels.</summary>
+    private static readonly byte[] RedDotPng = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAEUlEQVR4" +
+        "2mP4z8CAFTEMLQkAKP8/wc53yE8AAAAASUVORK5CYII=");
+}

--- a/src/Broiler.Writer.FormatCodes.Tests/WriterImageTests.cs
+++ b/src/Broiler.Writer.FormatCodes.Tests/WriterImageTests.cs
@@ -1,0 +1,163 @@
+using Broiler.Documents.Model;
+using Broiler.Graphics;
+
+namespace Broiler.Writer.FormatCodes.Tests;
+
+/// <summary>
+/// Inserting a picture in the Writer and saving it back out: the image reaches
+/// the document as one character sized from the file's own pixels, and a
+/// save-and-reopen through DOCX brings it back.
+/// </summary>
+public sealed class WriterImageTests
+{
+    /// <summary>A 4x2 PNG: only the IHDR is read, so the pixel data can be a stub.</summary>
+    private static readonly byte[] FourByTwoPng =
+    [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x02,
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00,
+    ];
+
+    [Fact]
+    public void Inserts_A_Picture_As_One_Character_At_Its_Pixel_Size()
+    {
+        using WriterApp app = CreateApp();
+        string path = WriteTempImage("insert.png", FourByTwoPng);
+
+        try
+        {
+            Assert.True(app.InsertPicture(path));
+
+            // The picture takes exactly one character position in the document.
+            Assert.Equal(1, app.Document.PlainText.Count(c => c == InlineImage.Placeholder));
+
+            InlineImage image = Assert.IsType<InlineImage>(SingleImage(app.Document));
+            Assert.Equal("image/png", image.ContentType);
+            Assert.Equal(4, image.Width);
+            Assert.Equal(2, image.Height);
+
+            // The file name becomes the alternative text; the temp prefix is
+            // part of the name this test wrote.
+            Assert.EndsWith("insert", image.AltText, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Refuses_A_File_That_Is_Not_An_Image()
+    {
+        using WriterApp app = CreateApp();
+        string path = WriteTempImage("notes.txt", "just text"u8.ToArray());
+
+        try
+        {
+            Assert.False(app.InsertPicture(path));
+            Assert.DoesNotContain(InlineImage.Placeholder, app.Document.PlainText);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Round_Trips_An_Inserted_Picture_Through_Docx()
+    {
+        using WriterApp app = CreateApp();
+        string path = WriteTempImage("logo.png", FourByTwoPng);
+
+        try
+        {
+            Assert.True(app.InsertPicture(path));
+
+            using var saved = new MemoryStream();
+            Assert.True(app.WriteDocument(saved, "doc.docx", updateIdentity: false));
+
+            using WriterApp reopened = CreateApp();
+            using var source = new MemoryStream(saved.ToArray(), writable: false);
+            Assert.True(reopened.LoadDocument(source, "doc.docx"));
+
+            InlineImage image = Assert.IsType<InlineImage>(SingleImage(reopened.Document));
+            Assert.Equal(FourByTwoPng, image.Data.ToArray());
+            Assert.Equal("image/png", image.ContentType);
+            Assert.Equal(4, image.Width, 3);
+            Assert.Equal(2, image.Height, 3);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Scales_A_Wide_Picture_Down_And_Keeps_Its_Aspect_Ratio()
+    {
+        // 2000x1000 in the IHDR; the Writer caps an inserted picture's width.
+        byte[] wide = (byte[])FourByTwoPng.Clone();
+        WriteBigEndian(wide, 16, 2000);
+        WriteBigEndian(wide, 20, 1000);
+
+        BSize size = WriterImageFormats.MeasureDisplaySize(wide, maxWidth: 420);
+
+        Assert.Equal(420, size.Width);
+        Assert.Equal(210, size.Height);
+    }
+
+    [Fact]
+    public void Reads_The_Pixel_Size_Of_A_Gif_And_A_Bmp()
+    {
+        byte[] gif = [.."GIF89a"u8, 0x0A, 0x00, 0x05, 0x00];
+        Assert.True(WriterImageFormats.TryReadPixelSize(gif, out int gifWidth, out int gifHeight));
+        Assert.Equal(10, gifWidth);
+        Assert.Equal(5, gifHeight);
+
+        byte[] bmp = new byte[26];
+        bmp[0] = (byte)'B';
+        bmp[1] = (byte)'M';
+        bmp[18] = 8;
+        bmp[22] = 0xFC; // -4 little-endian: a top-down bitmap, whose height is still four rows.
+        bmp[23] = 0xFF;
+        bmp[24] = 0xFF;
+        bmp[25] = 0xFF;
+        Assert.True(WriterImageFormats.TryReadPixelSize(bmp, out int bmpWidth, out int bmpHeight));
+        Assert.Equal(8, bmpWidth);
+        Assert.Equal(4, bmpHeight);
+    }
+
+    /// <summary>The one image in a document, so a test need not know which run holds it.</summary>
+    private static InlineImage? SingleImage(RichTextDocument document) =>
+        Assert.Single(document.Paragraphs
+            .SelectMany(paragraph => paragraph.Runs)
+            .Select(run => run.Style.Image)
+            .Where(image => image is not null));
+
+    private static void WriteBigEndian(byte[] buffer, int offset, int value)
+    {
+        buffer[offset] = (byte)(value >> 24);
+        buffer[offset + 1] = (byte)(value >> 16);
+        buffer[offset + 2] = (byte)(value >> 8);
+        buffer[offset + 3] = (byte)value;
+    }
+
+    private static string WriteTempImage(string fileName, byte[] bytes)
+    {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + "-" + fileName);
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    private static WriterApp CreateApp()
+    {
+        var host = new WriterUiHost(
+            () => new BSize(1200, 800),
+            () => 1,
+            () => { },
+            _ => { });
+        return new WriterApp(host, () => { });
+    }
+}

--- a/src/Broiler.Writer.Linux/Broiler.Writer.Linux.csproj
+++ b/src/Broiler.Writer.Linux/Broiler.Writer.Linux.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Broiler.Writer\Broiler.Writer.Core.csproj" />
+    <ProjectReference Include="..\..\Broiler.Media\Broiler.Media.Image.Managed\Broiler.Media.Image.Managed.csproj" />
     <ProjectReference Include="..\..\Broiler.Graphics\Broiler.Graphics.Linux\Broiler.Graphics.Linux.csproj" />
     <ProjectReference Include="..\..\Broiler.Graphics\Broiler.Graphics.Linux.OpenGL\Broiler.Graphics.Linux.OpenGL.csproj" />
     <ProjectReference Include="..\..\Broiler.Input\Broiler.Input.Keyboard.Linux\Broiler.Input.Keyboard.Linux.csproj" />

--- a/src/Broiler.Writer.Linux/LinuxWriterRunner.cs
+++ b/src/Broiler.Writer.Linux/LinuxWriterRunner.cs
@@ -52,7 +52,8 @@ internal static class LinuxWriterRunner
             {
                 lastFrameContext = new BFrameContext(WriterPalette.Canvas, frameIndex++, RenderOptions);
                 renderer.Render(surface, renderList, lastFrameContext);
-            });
+            },
+            getRenderer: () => renderer);
         using WriterApp app = new(host, () => closeRequested = true);
 
         await using LinuxInputCoordinator input = new(canUseEvdev, Console.WriteLine, externalPointer: x11Window is not null);

--- a/src/Broiler.Writer.Linux/Program.cs
+++ b/src/Broiler.Writer.Linux/Program.cs
@@ -9,6 +9,12 @@ internal static class Program
 {
     private static async Task<int> Main(string[] args)
     {
+        // Composition root: without a codec catalog the renderer cannot decode
+        // the images a document embeds, and the editor would draw every picture
+        // as an empty outline.
+        Broiler.Graphics.BImageCodecs.Use(
+            new Broiler.Media.MediaCodecCatalog(Broiler.Media.Image.Managed.ManagedImageCodecs.CreateCodecs()));
+
         LinuxWriterOptions options = LinuxWriterOptions.Parse(args);
         if (options.ShowHelp)
         {

--- a/src/Broiler.Writer.WebAssembly/README.md
+++ b/src/Broiler.Writer.WebAssembly/README.md
@@ -21,6 +21,13 @@ sandbox has no ambient file system, so:
   `Broiler.Documents` writer and **download** the result. Save As prompts for a file name whose
   extension selects the format.
 
+- **Embedded images** in an opened document are read and written back by the codecs exactly as on
+  the desktop, but they are **not drawn**: this host does not implement `IUiImageHost`, so the
+  editor draws each picture as an outlined box of the right size. Nothing is lost — a document
+  opened and saved here keeps its pictures — they are simply not rendered. Implementing it means
+  registering an image codec catalog (`BImageCodecs.Use`) and bridging
+  `BrowserCanvasRenderer.CreateImage`, which adds the managed decoders to the download payload.
+
 Everything else — the window, menu, toolbar, RichEdit editing and formatting, the font dialog, the
 status bar, and scrolling — is the same code as the desktop Writer.
 

--- a/src/Broiler.Writer.Windows/Broiler.Writer.Windows.csproj
+++ b/src/Broiler.Writer.Windows/Broiler.Writer.Windows.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Broiler.Writer\Broiler.Writer.Core.csproj" />
+    <ProjectReference Include="..\..\Broiler.Media\Broiler.Media.Image.Managed\Broiler.Media.Image.Managed.csproj" />
     <ProjectReference Include="..\..\Broiler.Graphics\Broiler.Graphics.Windows\Broiler.Graphics.Direct2D.csproj" />
   </ItemGroup>
 

--- a/src/Broiler.Writer.Windows/Program.cs
+++ b/src/Broiler.Writer.Windows/Program.cs
@@ -13,6 +13,12 @@ internal static class Program
     {
         _ = SetProcessDpiAwarenessContext(new IntPtr(-4)); // PER_MONITOR_AWARE_V2, best effort.
 
+        // Composition root: without a codec catalog the renderer cannot decode
+        // the images a document embeds, and the editor would draw every picture
+        // as an empty outline.
+        Broiler.Graphics.BImageCodecs.Use(
+            new Broiler.Media.MediaCodecCatalog(Broiler.Media.Image.Managed.ManagedImageCodecs.CreateCodecs()));
+
         try
         {
             using var window = new WriterWindow();

--- a/src/Broiler.Writer.Windows/WriterWindow.cs
+++ b/src/Broiler.Writer.Windows/WriterWindow.cs
@@ -34,7 +34,8 @@ internal sealed class WriterWindow : Direct2DWindow
             () => ClientSize,
             () => DpiScale,
             Invalidate,
-            static _ => { });
+            static _ => { },
+            getRenderer: () => Renderer);
         _app = new WriterApp(_host, CloseNativeWindow);
     }
 

--- a/src/Broiler.Writer/WriterApp.cs
+++ b/src/Broiler.Writer/WriterApp.cs
@@ -89,6 +89,17 @@ internal sealed class WriterApp : IDisposable
         new("HTML (*.html)", "*.html;*.htm", ".html"),
         new("Markdown (*.md)", "*.md;*.markdown", ".md"),
     ];
+    private static readonly UiFileDialogFilter[] OpenPictureFileFilters =
+    [
+        new("Images", "*.png;*.jpg;*.jpeg;*.gif;*.bmp;*.webp", ".png"),
+        new("PNG (*.png)", "*.png", ".png"),
+        new("JPEG (*.jpg, *.jpeg)", "*.jpg;*.jpeg", ".jpg"),
+        new("GIF (*.gif)", "*.gif", ".gif"),
+        new("Bitmap (*.bmp)", "*.bmp", ".bmp"),
+    ];
+
+    /// <summary>The widest a freshly inserted picture is placed at, in editor units.</summary>
+    private const double MaxInsertedPictureWidth = 420;
 
     public WriterApp(
         WriterUiHost host,
@@ -307,6 +318,7 @@ internal sealed class WriterApp : IDisposable
         dispatcher.Add(new StandardCommand("file.save", SaveDocument));
         dispatcher.Add(new StandardCommand("file.save-as", ShowSaveDialog));
         dispatcher.Add(new StandardCommand("file.exit", _requestClose));
+        dispatcher.Add(new StandardCommand("insert.picture", ShowInsertPictureDialog));
         dispatcher.Add(new StandardCommand("view.formatting-codes", ToggleFormattingCodes));
         AddFormatCodeCommands(dispatcher);
         dispatcher.Add(new StandardCommand("format.font", ShowFontDialog, () => _editor.GetCommandState(RichEditCommand.SetFont).IsEnabled));
@@ -352,6 +364,12 @@ internal sealed class WriterApp : IDisposable
         format.Children.Add(RichEditItem("underline", "Underline", "format.underline", RichEditCommand.Underline, 'U', checkable: true));
         format.Children.Add(RichEditItem("strike", "Strikethrough", "format.strike", RichEditCommand.Strikethrough, 'S', checkable: true));
         format.Children.Add(RichEditItem("clear", "Clear formatting", "format.clear", RichEditCommand.ClearFormatting, 'C'));
+
+        format.Children.Add(new UiMenuItem("picture", "Insert picture...")
+        {
+            CommandName = "insert.picture",
+            AccessKey = 'R',
+        });
 
         var insertCode = new UiMenuItem("insert-code", "Insert Code") { AccessKey = 'D' };
         insertCode.Children.Add(new UiMenuItem("code-bold", "Bold") { CommandName = "formatcodes.insert.bold" });
@@ -741,6 +759,79 @@ internal sealed class WriterApp : IDisposable
 
         _session.SetFocus(_editor);
         RefreshUi();
+    }
+
+    private void ShowInsertPictureDialog()
+    {
+        var dialog = new StandardFileDialog
+        {
+            Mode = UiFileDialogMode.Open,
+            CurrentDirectory = GetDialogDirectory(),
+            PreferredSize = FileDialogPreferredSize,
+        };
+        dialog.SetFileTypeFilters(OpenPictureFileFilters);
+        dialog.ResultCompleted += (_, e) =>
+        {
+            if (e.Result.Kind == UiDialogResultKind.Accepted && !string.IsNullOrWhiteSpace(e.Result.Value))
+                InsertPicture(e.Result.Value);
+        };
+
+        dialog.ShowOpenModal(_rootWindow, GetDialogPlacement());
+        _lastAction = "Insert picture";
+        RefreshUi();
+    }
+
+    /// <summary>
+    /// Reads an image file and inserts it at the caret as a single inline image
+    /// character. The size comes from the decoded pixels, scaled down so a photo
+    /// straight from a camera does not arrive several thousand units wide.
+    /// </summary>
+    internal bool InsertPicture(string path)
+    {
+        try
+        {
+            string fullPath = Path.GetFullPath(path);
+            byte[] bytes = File.ReadAllBytes(fullPath);
+            string? contentType = WriterImageFormats.ContentTypeFor(fullPath, bytes);
+            if (contentType is null)
+            {
+                _lastAction = "Insert picture failed: unsupported image format";
+                RefreshUi();
+                return false;
+            }
+
+            _lastDirectory = Path.GetDirectoryName(fullPath) ?? _lastDirectory;
+            BSize size = WriterImageFormats.MeasureDisplaySize(bytes, MaxInsertedPictureWidth);
+            var image = new InlineImage(
+                bytes,
+                contentType,
+                size.Width,
+                size.Height,
+                altText: Path.GetFileNameWithoutExtension(fullPath),
+                name: Path.GetFileNameWithoutExtension(fullPath));
+
+            // The rich-paste primitive is the only insertion path that carries a
+            // style of its own; InsertText takes the caret's style, which has no
+            // image on it.
+            bool inserted = _editor.InsertDocument(RichTextDocument.FromParagraphs(
+            [
+                RichTextParagraph.Create(
+                    InlineImage.PlaceholderText,
+                    _editor.CaretInlineStyle with { Image = image }),
+            ]));
+            _lastAction = inserted
+                ? "Inserted picture " + Path.GetFileName(fullPath)
+                : "Insert picture unavailable";
+            _session.SetFocus(_editor);
+            RefreshUi();
+            return inserted;
+        }
+        catch (Exception ex) when (IsFileOperationException(ex))
+        {
+            _lastAction = "Insert picture failed: " + ex.Message;
+            RefreshUi();
+            return false;
+        }
     }
 
     private void ShowFontDialog()

--- a/src/Broiler.Writer/WriterImageFormats.cs
+++ b/src/Broiler.Writer/WriterImageFormats.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using Broiler.Graphics;
+
+namespace Broiler.Writer;
+
+/// <summary>
+/// Recognizes the image files the Writer will insert and reads their pixel size
+/// straight out of the encoded header.
+/// </summary>
+/// <remarks>
+/// The size is read here rather than by decoding, so choosing an insertion size
+/// costs no pixel buffer and works before — or without — a renderer that can
+/// upload the image. A format whose header is not understood still inserts; it
+/// simply arrives at the default size.
+/// </remarks>
+internal static class WriterImageFormats
+{
+    /// <summary>The size an image of unknown dimensions is inserted at.</summary>
+    private const double DefaultExtent = 200;
+
+    /// <summary>
+    /// The media type for an image file, from its extension and confirmed
+    /// against the bytes. Returns null when this is not an image format the
+    /// document codecs carry.
+    /// </summary>
+    public static string? ContentTypeFor(string path, ReadOnlySpan<byte> data)
+    {
+        string? signature = ContentTypeForSignature(data);
+        if (signature is not null)
+            return signature;
+
+        // A file whose bytes are unrecognized but whose extension is a known
+        // image type is still worth carrying: the renderer, not this table,
+        // decides what decodes.
+        return Path.GetExtension(path).TrimStart('.').ToLowerInvariant() switch
+        {
+            "png" => "image/png",
+            "jpg" or "jpeg" or "jpe" => "image/jpeg",
+            "gif" => "image/gif",
+            "bmp" or "dib" => "image/bmp",
+            "tif" or "tiff" => "image/tiff",
+            "webp" => "image/webp",
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// The size to insert an image at: its own pixel size, scaled down to
+    /// <paramref name="maxWidth"/> so a photo straight from a camera does not
+    /// arrive several thousand units wide.
+    /// </summary>
+    public static BSize MeasureDisplaySize(ReadOnlySpan<byte> data, double maxWidth)
+    {
+        if (!TryReadPixelSize(data, out int width, out int height) || width <= 0 || height <= 0)
+            return new BSize(DefaultExtent, DefaultExtent);
+
+        if (maxWidth <= 0 || width <= maxWidth)
+            return new BSize(width, height);
+
+        double scale = maxWidth / width;
+        return new BSize(maxWidth, Math.Max(1, Math.Round(height * scale)));
+    }
+
+    /// <summary>Reads the pixel dimensions from an encoded image header.</summary>
+    public static bool TryReadPixelSize(ReadOnlySpan<byte> data, out int width, out int height)
+    {
+        width = 0;
+        height = 0;
+        if (StartsWith(data, [0x89, (byte)'P', (byte)'N', (byte)'G']))
+            return TryReadPngSize(data, out width, out height);
+        if (StartsWith(data, [0xFF, 0xD8]))
+            return TryReadJpegSize(data, out width, out height);
+        if (StartsWith(data, "GIF8"u8))
+            return TryReadGifSize(data, out width, out height);
+        if (StartsWith(data, "BM"u8))
+            return TryReadBmpSize(data, out width, out height);
+
+        return false;
+    }
+
+    private static string? ContentTypeForSignature(ReadOnlySpan<byte> data)
+    {
+        if (StartsWith(data, [0x89, (byte)'P', (byte)'N', (byte)'G', 0x0D, 0x0A, 0x1A, 0x0A]))
+            return "image/png";
+        if (StartsWith(data, [0xFF, 0xD8, 0xFF]))
+            return "image/jpeg";
+        if (StartsWith(data, "GIF87a"u8) || StartsWith(data, "GIF89a"u8))
+            return "image/gif";
+        if (StartsWith(data, "BM"u8))
+            return "image/bmp";
+        if (StartsWith(data, [0x49, 0x49, 0x2A, 0x00]) || StartsWith(data, [0x4D, 0x4D, 0x00, 0x2A]))
+            return "image/tiff";
+        if (data.Length >= 12 && StartsWith(data, "RIFF"u8) && data[8..12].SequenceEqual("WEBP"u8))
+            return "image/webp";
+
+        return null;
+    }
+
+    /// <summary>PNG: the IHDR chunk is first and holds width then height, big-endian.</summary>
+    private static bool TryReadPngSize(ReadOnlySpan<byte> data, out int width, out int height)
+    {
+        width = 0;
+        height = 0;
+        if (data.Length < 24 || !data[12..16].SequenceEqual("IHDR"u8))
+            return false;
+
+        width = BinaryPrimitives.ReadInt32BigEndian(data[16..20]);
+        height = BinaryPrimitives.ReadInt32BigEndian(data[20..24]);
+        return true;
+    }
+
+    /// <summary>JPEG: walk the marker segments to the start-of-frame that states the size.</summary>
+    private static bool TryReadJpegSize(ReadOnlySpan<byte> data, out int width, out int height)
+    {
+        width = 0;
+        height = 0;
+        int offset = 2;
+        while (offset + 4 <= data.Length)
+        {
+            if (data[offset] != 0xFF)
+            {
+                offset++;
+                continue;
+            }
+
+            byte marker = data[offset + 1];
+            offset += 2;
+            if (marker is 0xD8 or 0x01 || (marker >= 0xD0 && marker <= 0xD7))
+                continue;
+            if (offset + 2 > data.Length)
+                return false;
+
+            int length = BinaryPrimitives.ReadUInt16BigEndian(data[offset..(offset + 2)]);
+            if (length < 2)
+                return false;
+
+            // SOF0..SOF15, excluding the DHT/JPG/DAC markers interleaved in that range.
+            bool isStartOfFrame = marker >= 0xC0 && marker <= 0xCF && marker is not (0xC4 or 0xC8 or 0xCC);
+            if (isStartOfFrame)
+            {
+                if (offset + 7 > data.Length)
+                    return false;
+
+                height = BinaryPrimitives.ReadUInt16BigEndian(data[(offset + 3)..(offset + 5)]);
+                width = BinaryPrimitives.ReadUInt16BigEndian(data[(offset + 5)..(offset + 7)]);
+                return width > 0 && height > 0;
+            }
+
+            offset += length;
+        }
+
+        return false;
+    }
+
+    /// <summary>GIF: the logical screen descriptor follows the six-byte signature, little-endian.</summary>
+    private static bool TryReadGifSize(ReadOnlySpan<byte> data, out int width, out int height)
+    {
+        width = 0;
+        height = 0;
+        if (data.Length < 10)
+            return false;
+
+        width = BinaryPrimitives.ReadUInt16LittleEndian(data[6..8]);
+        height = BinaryPrimitives.ReadUInt16LittleEndian(data[8..10]);
+        return true;
+    }
+
+    /// <summary>BMP: the DIB header states the size; a negative height means top-down rows.</summary>
+    private static bool TryReadBmpSize(ReadOnlySpan<byte> data, out int width, out int height)
+    {
+        width = 0;
+        height = 0;
+        if (data.Length < 26)
+            return false;
+
+        width = BinaryPrimitives.ReadInt32LittleEndian(data[18..22]);
+        height = Math.Abs(BinaryPrimitives.ReadInt32LittleEndian(data[22..26]));
+        return true;
+    }
+
+    private static bool StartsWith(ReadOnlySpan<byte> data, ReadOnlySpan<byte> prefix) =>
+        data.Length >= prefix.Length && data[..prefix.Length].SequenceEqual(prefix);
+}

--- a/src/Broiler.Writer/WriterUiHost.cs
+++ b/src/Broiler.Writer/WriterUiHost.cs
@@ -4,7 +4,7 @@ using Broiler.UI;
 
 namespace Broiler.Writer;
 
-internal sealed class WriterUiHost : IUiHost, IUiClipboardHost, IUiTextInputHost, IDisposable
+internal sealed class WriterUiHost : IUiHost, IUiClipboardHost, IUiTextInputHost, IUiImageHost, IDisposable
 {
     private readonly Func<BSize> _getViewportSize;
     private readonly Func<double> _getScale;
@@ -13,6 +13,7 @@ internal sealed class WriterUiHost : IUiHost, IUiClipboardHost, IUiTextInputHost
     private readonly Func<string?>? _getClipboardText;
     private readonly Action<string>? _setClipboardText;
     private readonly Action<UiTextCaretInfo?>? _caretChanged;
+    private readonly Func<IBroilerRenderer?>? _getRenderer;
     private string _clipboardText = string.Empty;
 
     public WriterUiHost(
@@ -22,7 +23,8 @@ internal sealed class WriterUiHost : IUiHost, IUiClipboardHost, IUiTextInputHost
         Action<BRenderList> present,
         Func<string?>? getClipboardText = null,
         Action<string>? setClipboardText = null,
-        Action<UiTextCaretInfo?>? caretChanged = null)
+        Action<UiTextCaretInfo?>? caretChanged = null,
+        Func<IBroilerRenderer?>? getRenderer = null)
     {
         _getViewportSize = getViewportSize ?? throw new ArgumentNullException(nameof(getViewportSize));
         _getScale = getScale ?? throw new ArgumentNullException(nameof(getScale));
@@ -31,6 +33,7 @@ internal sealed class WriterUiHost : IUiHost, IUiClipboardHost, IUiTextInputHost
         _getClipboardText = getClipboardText;
         _setClipboardText = setClipboardText;
         _caretChanged = caretChanged;
+        _getRenderer = getRenderer;
     }
 
     public BSize ViewportSize => _getViewportSize();
@@ -83,6 +86,38 @@ internal sealed class WriterUiHost : IUiHost, IUiClipboardHost, IUiTextInputHost
     {
         LastCaret = caret;
         _caretChanged?.Invoke(caret);
+    }
+
+    /// <summary>
+    /// Uploads a document image to the renderer backing this host. A host built
+    /// without a renderer — the headless test host, and any surface that only
+    /// captures render lists — reports failure, and the editor then draws the
+    /// picture's outline instead.
+    /// </summary>
+    public BImageHandle CreateImage(ReadOnlySpan<byte> encodedImage)
+    {
+        IBroilerRenderer? renderer = _getRenderer?.Invoke();
+        if (renderer is null || encodedImage.IsEmpty)
+            return BImageHandle.Invalid;
+
+        try
+        {
+            return renderer.CreateImage(encodedImage);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            // A document can carry any bytes at all; a decoder that rejects them
+            // must not take down the frame.
+            return BImageHandle.Invalid;
+        }
+    }
+
+    public void ReleaseImage(BImageHandle image)
+    {
+        if (!image.IsValid)
+            return;
+
+        _getRenderer?.Invoke()?.ReleaseImage(image);
     }
 
     public void ClearCaret(UiElement owner)


### PR DESCRIPTION
## Summary

This change adds embedded image support across the document model and the codecs (DOCX, HTML, RTF, Markdown), plus rendering in the Writer. Images are represented as a single object replacement character (`U+FFFC`) in the document text, so they integrate with existing text editing, selection, and layout logic without special-case handling.

## Key Changes

**Document Model**
- Added `InlineImage` class to represent embedded pictures with encoded bytes, content type, display dimensions, and alternative text
- Extended `InlineStyle` to carry an optional `InlineImage` reference
- Images occupy exactly one character position in a paragraph, so caret movement, selection, deletion, paragraph splitting, slicing, and undo work on them unmodified
- `InlineStyleDelta.Apply` deliberately never touches `Image` — clearing formatting over a picture must not delete the picture

**DOCX Codec**
- Added `DocxImageLoader` to read both DrawingML (`w:drawing`, inline and anchored, including inside `mc:AlternateContent`) and legacy VML (`w:pict`/`v:imagedata`) picture shapes
- Reads display sizes from DrawingML `wp:extent` (EMUs) and VML CSS `width`/`height`; alternative text from `wp:docPr@descr`
- Caches media parts by part path so a document referencing one image many times reads it once
- Added `DocxImageFormats` to map media-part extensions to IANA media types for raster formats (PNG, JPEG, GIF, BMP, TIFF, WebP, ICO), with signature sniffing as a fallback
- Extended `DocxWriter` to emit images as DrawingML inline shapes, writing each distinct image once to `word/media/` with its relationship and a content-type default

**Other Codecs**

None of these silently drop a picture on save, though only DOCX round-trips one:
- **HTML writer**: `<img>` with a base64 data URI, `alt`, and a CSS size — keeps an exported page a single file
- **Markdown writer**: CommonMark `[alt](data:...)` image syntax with a base64 data URI
- **RTF writer**: a `\pict` destination (`\pngblip`/`\jpegblip`, sized with `\picwgoal`/`\pichgoal`) carrying the hex-encoded image bytes; any other format is dropped with `rtf.image.format`
- The HTML, Markdown, and RTF *readers* do not turn these back into model images, so a round-trip through those formats loses pictures. DOCX is the format that round-trips.

**Formatting Codes**
- The image character projects as a `[Image]` structure code rather than a stray glyph, with `FormatCodeProperty.Image` for its removal intent

**UI Rendering**
- Added the optional `IUiImageHost` host capability for turning encoded bytes into a drawable handle
- Extended `StandardRichEdit` to draw inline images bottom-aligned in their line, with an outlined-box fallback when nothing can decode the bytes
- Lines grow to fit a picture taller than their text, so an image is not clipped
- Handles are uploaded once per image object and released when the document is replaced or the control detaches

**Writer Application**
- Added Format → "Insert picture..." with a file dialog for the common image formats
- Images are inserted at their own pixel size, capped at 420 units wide; dimensions are read straight from the file header (`WriterImageFormats`) with no decode
- The host is wired to the platform renderer on Linux and Windows, and both entry points now register the managed image codecs — without a catalog the renderer cannot decode anything and every picture would draw as an empty outline

**Testing**
- DOCX image reading: DrawingML, VML, alt text, formatting carried on an image run, shared media parts, and the failure paths (missing part, undefined relationship, unsupported format, over-limit part, external link)
- DOCX writing: media part, relationship, content-type default, single part for a reused image, and a placeholder with no image attached
- Model: one character per image, run separation, deletion, clear-formatting, slicing
- Rendering: display size, upload-once, line advance, line height, decode failure, cache release on document change and detach
- End-to-end: a DOCX with a picture opened in the Writer renders a valid `DrawImage`, and a pixel sample at the picture's centre confirms it is actually painted

## Security And Limits

- Media parts are bounded by `MaxBinBytes` against what actually decompresses, not the size the ZIP header claims
- Externally linked images (`r:link`) are never fetched — that would be a network or file request driven by document content (ADR 0004)
- EMF/WMF metafiles cannot be decoded to pixels here, so they are reported as `docx.image.format` rather than carried as a picture that would draw as nothing
- Display extents are capped so a corrupt or hostile value cannot ask layout for a line millions of units tall

## Known Limitations

- **WebAssembly and Android show placeholders, not pictures.** Their hosts do not implement `IUiImageHost`, so the editor draws each picture as an outlined box. Documents open and save with images intact; they are simply not drawn. For WebAssembly this is a payload trade-off (it means shipping the managed decoders), documented in that head's README rather than decided here.
- Anchored (floating) DOCX pictures are read as inline ones — the model has no float — and text wrapping, position, z-order, crops, rotation, and picture effects are not represented.

https://claude.ai/code/session_012yF5bLpwCMy2UF29fLv62e