### PR TITLE
Add end-of-workflow retry pass for abnormally-aborted WPT shards

### DIFF
--- a/.github/actions/run-wpt-shard/action.yml
+++ b/.github/actions/run-wpt-shard/action.yml
@@ -1,0 +1,240 @@
+name: Run WPT shard
+description: >
+  Provision a runner, run one shard of the WPT suite, and upload its results as
+  an artifact. Factored out of .github/workflows/wpt-tests.yml because two jobs
+  need exactly these steps: the initial sharded pass and the end-of-workflow
+  retry pass that re-runs any shard which aborted abnormally. Keeping them in
+  one place is what guarantees a retried shard is measured identically to the
+  attempt it replaces — a retry run with a different reference cache or a
+  different patch set would not be comparable at the 99% pixel threshold.
+
+inputs:
+  shard-index:
+    description: Zero-based index of the shard to run.
+    required: true
+  shard-count:
+    description: Total number of shards the suite is split into.
+    required: true
+  attempt-suffix:
+    description: >
+      Suffix appended to this attempt's artifact and result-file names — empty
+      for the first attempt, "-retry" for the end-of-workflow rerun. The names
+      have to differ because every shard artifact is downloaded into one merged
+      directory; scripts/merge-wpt-shards.py reads the suffix back off the file
+      name so a retry supersedes the attempt it replaces instead of being summed
+      alongside it.
+    required: false
+    default: ''
+  subset:
+    description: Semicolon-separated WPT subset patterns, or empty for the full suite.
+    required: false
+    default: ''
+  rerun-failed:
+    description: >
+      "true" to rerun only the previously-failed tests listed in
+      failed-tests-file, reusing cached references.
+    required: false
+    default: 'false'
+  failed-tests-file:
+    description: Path to the committed failing-test manifest used by rerun-failed.
+    required: true
+  cache-epoch:
+    description: Cache epoch; bumping it refreshes the WPT checkout and references.
+    required: true
+  wpt-checkout-dir:
+    description: Directory holding the (cached) WPT checkout.
+    required: true
+  reference-dir:
+    description: Directory holding this shard's (cached) Chromium reference slice.
+    required: true
+  results-dir:
+    description: Directory the runner writes its results into.
+    required: true
+  test-timeout-seconds:
+    description: Per-test timeout in seconds.
+    required: true
+  memory-limit-mb:
+    description: Per-test RAM cap in MiB (0 disables).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: |
+          8.0.x
+          10.0.x
+
+    - uses: actions/setup-node@v5
+      with:
+        node-version: '20'
+
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Restore WPT checkout
+      uses: actions/cache@v5
+      with:
+        path: ${{ inputs.wpt-checkout-dir }}
+        key: wpt-checkout-${{ inputs.cache-epoch }}
+
+    - name: Cache shard references
+      uses: actions/cache@v5
+      with:
+        path: ${{ inputs.reference-dir }}
+        key: wpt-refs-${{ inputs.cache-epoch }}-shard-${{ inputs.shard-index }}
+
+    # Keep the Chromium build itself between runs, so a run only depends on the
+    # download being reachable when Playwright is actually bumped. There is no
+    # mirror to fall back to: for linux64 Playwright serves Chromium as a Chrome
+    # for Testing build, and every URL for it — cdn.playwright.dev included — is
+    # a redirect to the one Google bucket that geo-blocked shard 0 in issue
+    # #1534. Its ESRP mirror carries no x64 Linux Chromium at all. Caching is the
+    # only fallback that keeps the *same* binary, and the binary has to stay the
+    # same: references are compared at a 99% pixel threshold, so regenerating a
+    # slice with a different Chrome build would read as an engine regression.
+    #
+    # Keyed on the lockfile rather than the cache epoch: bumping the epoch
+    # refreshes WPT master and the reference slices, which is exactly when you
+    # still want the browser. The restore-key prefix means an unrelated lockfile
+    # edit reuses the existing browser instead of re-downloading it, while a
+    # genuine Playwright bump misses and fetches the new revision.
+    - name: Cache Playwright browsers
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: wpt-playwright-${{ runner.os }}-${{ hashFiles('tests/wpt/package-lock.json') }}
+        restore-keys: wpt-playwright-${{ runner.os }}-
+
+    # Apply any submodule fix that could not be pushed to its remote (push 403
+    # → captured under patches/) and is NOT yet in the pinned pointer, so the
+    # runner exercises it. Live again as of issue #1497: PENDING_PATCHES carries
+    # 0043 (Broiler.CSS — the @container recursion that crashed the worker and
+    # gated 68 tests), 0044 and 0045 (Broiler.HTML — percentage scale factors,
+    # and a table painting its own background). Without this step those three
+    # fixes are absent from the run no matter how many times the suite is
+    # re-run, because their remotes are outside the session's GitHub scope.
+    # Entries are added only after checking they do not reverse-apply to the
+    # pinned pointer and do apply cleanly; the mechanism is idempotent, so an
+    # entry stops applying by itself once a maintainer lands the fix upstream
+    # and bumps the pointer. A patch that has gone stale against a drifted
+    # pointer fails this step loudly rather than being skipped — that is
+    # deliberate, since silently dropping a fix is what the step exists to
+    # prevent. The build compiles submodule source in place, so patching the
+    # checked-out working tree is sufficient — no pointer bump. Only Broiler's
+    # render is affected; Chromium reference generation is untouched.
+    - name: Apply pending submodule patches
+      shell: bash
+      run: bash scripts/apply-pending-wpt-patches.sh
+
+    - name: Run WPT shard ${{ inputs.shard-index }}${{ inputs.attempt-suffix }}
+      id: wpt
+      shell: bash
+      env:
+        SHARD_INDEX: ${{ inputs.shard-index }}
+        SHARD_COUNT: ${{ inputs.shard-count }}
+        SUBSET: ${{ inputs.subset }}
+        RERUN_FAILED: ${{ inputs.rerun-failed }}
+        FAILED_TESTS_FILE: ${{ inputs.failed-tests-file }}
+        BROILER_WPT_TIMEOUT_SECONDS: ${{ inputs.test-timeout-seconds }}
+        BROILER_WPT_MEMORY_LIMIT_MB: ${{ inputs.memory-limit-mb }}
+        # Match Chromium's reference generator, which screenshots at `load` before
+        # any promise_test body runs: skip executing stub promise_test bodies in
+        # Broiler's runner so post-load layout mutations (scrollTo, display toggling)
+        # in the css-anchor-position scroll cluster do not advance the captured DOM
+        # past the reference point. Affects only the C# runner, not the (Chromium)
+        # reference generation. Revert by removing this line if it regresses tests.
+        BROILER_WPT_DEFER_PROMISE_TESTS: '1'
+      run: |
+        # The regular WPT suite executes JavaScript in both Chromium and
+        # Broiler. --non-js remains available only for explicit local runs.
+        ARGS=(--shard-index "$SHARD_INDEX" --shard-count "$SHARD_COUNT")
+        if [ -n "$SUBSET" ]; then
+          ARGS+=(--subset "$SUBSET")
+        fi
+        if [ "$RERUN_FAILED" = "true" ]; then
+          # Incremental: rerun only the previously-failed tests. Reference
+          # generation is NOT skipped — run-wpt-tests.sh restricts it to just the
+          # rerun set (fast, and it guarantees those tests have references).
+          # Skipping generation here relied on a cached reference set that is not
+          # reliably present, which skipped every reran test as "missing
+          # reference image" and made the run meaningless.
+          ARGS+=(--rerun-json "$FAILED_TESTS_FILE")
+        fi
+        EXIT=0
+        bash scripts/run-wpt-tests.sh "${ARGS[@]}" || EXIT=$?
+        echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
+        echo "Shard $SHARD_INDEX finished (exit $EXIT)."
+        exit "$EXIT"
+
+    - name: Collect shard result
+      if: always()
+      shell: bash
+      env:
+        RESULTS_DIR: ${{ inputs.results-dir }}
+        SHARD_INDEX: ${{ inputs.shard-index }}
+        ATTEMPT_SUFFIX: ${{ inputs.attempt-suffix }}
+        WPT_EXIT_CODE: ${{ steps.wpt.outputs.exit_code }}
+      run: |
+        mkdir -p shard-out
+        STEM="wpt-shard-${SHARD_INDEX}${ATTEMPT_SUFFIX}"
+        cp "$RESULTS_DIR/wpt-results.json" "shard-out/${STEM}.json" 2>/dev/null || true
+        cp "$RESULTS_DIR/wpt-results.log"  "shard-out/${STEM}.log"  2>/dev/null || true
+        EXIT="$WPT_EXIT_CODE"
+        if ! [[ "$EXIT" =~ ^[0-9]+$ ]]; then
+          EXIT=1
+        fi
+        # run-wpt-tests.sh leaves a marker when the shard could not run a single
+        # test — e.g. the Playwright CDN refused its Chromium download. Folding
+        # that into the status file is what lets the merge step name the real
+        # cause instead of guessing at one (issue #1534).
+        python3 - "$SHARD_INDEX" "$EXIT" \
+          "$RESULTS_DIR/wpt-shard-failure.json" \
+          "shard-out/${STEM}-status.json" <<'PY'
+        import json, sys
+
+        shard_index, exit_code, marker_path, out_path = sys.argv[1:5]
+        status = {"shardIndex": int(shard_index), "exitCode": int(exit_code)}
+        try:
+            with open(marker_path, encoding="utf-8") as handle:
+                marker = json.load(handle)
+        except (OSError, ValueError):
+            marker = None
+        if isinstance(marker, dict):
+            if marker.get("reason"):
+                status["failureReason"] = str(marker["reason"])
+            if marker.get("detail"):
+                status["failureDetail"] = str(marker["detail"])
+        with open(out_path, "w", encoding="utf-8") as handle:
+            json.dump(status, handle)
+            handle.write("\n")
+        PY
+
+    - name: Shard step summary
+      if: always()
+      shell: bash
+      env:
+        RESULTS_DIR: ${{ inputs.results-dir }}
+        SHARD_INDEX: ${{ inputs.shard-index }}
+        SHARD_COUNT: ${{ inputs.shard-count }}
+        ATTEMPT_SUFFIX: ${{ inputs.attempt-suffix }}
+      run: |
+        SUMMARY="$RESULTS_DIR/wpt-summary.txt"
+        if [ -f "$SUMMARY" ]; then
+          LABEL="WPT shard ${SHARD_INDEX}/${SHARD_COUNT}"
+          if [ -n "$ATTEMPT_SUFFIX" ]; then
+            LABEL="$LABEL (retry)"
+          fi
+          echo "### $LABEL" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+    - uses: actions/upload-artifact@v6
+      if: always()
+      with:
+        name: wpt-shard-${{ inputs.shard-index }}${{ inputs.attempt-suffix }}
+        path: shard-out

--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -24,6 +24,14 @@ name: WPT Tests
 # browserless slice that would report every test as a missing reference, and
 # records why it stopped so the merged report names that cause rather than
 # guessing at a runner eviction. See scripts/lib/wpt-browser-install.sh.
+#
+# Any shard that aborts abnormally — evicted runner, unobtainable browser, hard
+# crash, i.e. no conclusive report — is rerun once at the end of the workflow by
+# the `retry` job, before the results are merged. A rerun shard's artifacts carry
+# a `-retry` suffix, and merge-wpt-shards.py keeps only the latest attempt per
+# shard, so the rerun's results are merged with the other shards' in place of the
+# aborted attempt rather than added on top of it. Shards that merely *fail* tests
+# are not rerun — they already measured their slice.
 
 on:
   workflow_dispatch:
@@ -161,174 +169,133 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.plan.outputs.shard-matrix) }}
-    env:
-      BROILER_WPT_TIMEOUT_SECONDS: ${{ github.event.inputs.test_timeout_seconds || '30' }}
-      BROILER_WPT_MEMORY_LIMIT_MB: ${{ github.event.inputs.memory_limit_mb || '1024' }}
     steps:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - uses: actions/setup-dotnet@v5
+      # Every provisioning/run/collect/upload step lives in the composite action,
+      # so the retry pass below runs a shard exactly the way this pass did.
+      - uses: ./.github/actions/run-wpt-shard
         with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
+          shard-index: ${{ matrix.shard-index }}
+          shard-count: ${{ env.SHARD_COUNT }}
+          subset: ${{ github.event.inputs.subset || '' }}
+          rerun-failed: ${{ needs.plan.outputs.rerun-failed }}
+          failed-tests-file: ${{ env.FAILED_TESTS_FILE }}
+          cache-epoch: ${{ env.CACHE_EPOCH }}
+          wpt-checkout-dir: ${{ env.WPT_CHECKOUT_DIR }}
+          reference-dir: ${{ env.REFERENCE_DIR }}
+          results-dir: ${{ env.RESULTS_DIR }}
+          test-timeout-seconds: ${{ github.event.inputs.test_timeout_seconds || '30' }}
+          memory-limit-mb: ${{ github.event.inputs.memory_limit_mb || '1024' }}
 
-      - uses: actions/setup-node@v5
-        with:
-          node-version: '20'
+  # ── Decide which shards aborted abnormally and deserve one rerun ─────────
+  #
+  # "Abnormally" is not "some tests failed": a shard that finishes and reports
+  # failures exits 1 with a full report, and rerunning it would only burn an hour
+  # to produce the same answer. What is retried is a shard that produced *no
+  # conclusive report* — its runner was evicted mid-run (the "shutdown signal"
+  # case, where the always() upload never happened), it died before running a
+  # test (e.g. the Playwright CDN geo-blocked its Chromium download, issue
+  # #1534), or it crashed hard enough to lose its report. Those are the runs
+  # whose whole slice went unmeasured, and they are exactly the shards
+  # merge-wpt-shards.py already flags as incomplete — so the same code decides
+  # here rather than a second, drifting definition of "incomplete".
+  retry-plan:
+    needs: [plan, run]
+    # !cancelled() rather than always(): if a human cancels the workflow, every
+    # shard looks incomplete and retrying them all is the opposite of what was
+    # asked. A single evicted shard does not cancel the run, so it still retries.
+    if: ${{ !cancelled() && needs.run.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    outputs:
+      retry-matrix: ${{ steps.detect.outputs.incomplete_shard_matrix }}
+      retry-shards: ${{ steps.detect.outputs.incomplete_shard_indexes }}
+      has-retries: ${{ steps.detect.outputs.has_incomplete_shards }}
+    steps:
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
-      - name: Restore WPT checkout
-        uses: actions/cache@v5
+      # Tolerated failure: when *every* shard died before its upload step there
+      # is no artifact to match, and download-artifact treats that as an error.
+      # That case is precisely the one worth retrying, so it must not stop the
+      # job — the detect step below then sees an empty directory and flags every
+      # dispatched shard.
+      - name: Download shard results
+        continue-on-error: true
+        uses: actions/download-artifact@v7
         with:
-          path: ${{ env.WPT_CHECKOUT_DIR }}
-          key: wpt-checkout-${{ env.CACHE_EPOCH }}
+          pattern: wpt-shard-*
+          path: shard-results
+          merge-multiple: true
 
-      - name: Cache shard references
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.REFERENCE_DIR }}
-          key: wpt-refs-${{ env.CACHE_EPOCH }}-shard-${{ matrix.shard-index }}
-
-      # Keep the Chromium build itself between runs, so a run only depends on the
-      # download being reachable when Playwright is actually bumped. There is no
-      # mirror to fall back to: for linux64 Playwright serves Chromium as a Chrome
-      # for Testing build, and every URL for it — cdn.playwright.dev included — is
-      # a redirect to the one Google bucket that geo-blocked shard 0 in issue
-      # #1534. Its ESRP mirror carries no x64 Linux Chromium at all. Caching is the
-      # only fallback that keeps the *same* binary, and the binary has to stay the
-      # same: references are compared at a 99% pixel threshold, so regenerating a
-      # slice with a different Chrome build would read as an engine regression.
-      #
-      # Keyed on the lockfile rather than CACHE_EPOCH: bumping the epoch refreshes
-      # WPT master and the reference slices, which is exactly when you still want
-      # the browser. The restore-key prefix means an unrelated lockfile edit reuses
-      # the existing browser instead of re-downloading it, while a genuine
-      # Playwright bump misses and fetches the new revision.
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: wpt-playwright-${{ runner.os }}-${{ hashFiles('tests/wpt/package-lock.json') }}
-          restore-keys: wpt-playwright-${{ runner.os }}-
-
-      # Apply any submodule fix that could not be pushed to its remote (push 403
-      # → captured under patches/) and is NOT yet in the pinned pointer, so the
-      # runner exercises it. Live again as of issue #1497: PENDING_PATCHES carries
-      # 0043 (Broiler.CSS — the @container recursion that crashed the worker and
-      # gated 68 tests), 0044 and 0045 (Broiler.HTML — percentage scale factors,
-      # and a table painting its own background). Without this step those three
-      # fixes are absent from the run no matter how many times the suite is
-      # re-run, because their remotes are outside the session's GitHub scope.
-      # Entries are added only after checking they do not reverse-apply to the
-      # pinned pointer and do apply cleanly; the mechanism is idempotent, so an
-      # entry stops applying by itself once a maintainer lands the fix upstream
-      # and bumps the pointer. A patch that has gone stale against a drifted
-      # pointer fails this step loudly rather than being skipped — that is
-      # deliberate, since silently dropping a fix is what the step exists to
-      # prevent. The build compiles submodule source in place, so patching the
-      # checked-out working tree is sufficient — no pointer bump. Only Broiler's
-      # render is affected; Chromium reference generation is untouched.
-      - name: Apply pending submodule patches
+      - name: Detect shards that aborted abnormally
+        id: detect
         shell: bash
-        run: bash scripts/apply-pending-wpt-patches.sh
+        run: |
+          mkdir -p shard-results
+          python scripts/merge-wpt-shards.py \
+            --shard-dir shard-results \
+            --expected-shards "${{ needs.plan.outputs.expected-shards }}" \
+            --github-output "$GITHUB_OUTPUT"
 
-      - name: Run WPT shard ${{ matrix.shard-index }}
-        id: wpt
+      - name: Report the retry plan
         shell: bash
         env:
-          SUBSET: ${{ github.event.inputs.subset || '' }}
-          RERUN_FAILED: ${{ needs.plan.outputs.rerun-failed }}
-          # Match Chromium's reference generator, which screenshots at `load` before
-          # any promise_test body runs: skip executing stub promise_test bodies in
-          # Broiler's runner so post-load layout mutations (scrollTo, display toggling)
-          # in the css-anchor-position scroll cluster do not advance the captured DOM
-          # past the reference point. Affects only the C# runner, not the (Chromium)
-          # reference generation. Revert by removing this line if it regresses tests.
-          BROILER_WPT_DEFER_PROMISE_TESTS: '1'
+          RETRY_SHARDS: ${{ steps.detect.outputs.incomplete_shard_indexes }}
         run: |
-          # The regular WPT suite executes JavaScript in both Chromium and
-          # Broiler. --non-js remains available only for explicit local runs.
-          ARGS=(--shard-index "${{ matrix.shard-index }}" --shard-count "$SHARD_COUNT")
-          if [ -n "$SUBSET" ]; then
-            ARGS+=(--subset "$SUBSET")
-          fi
-          if [ "$RERUN_FAILED" = "true" ]; then
-            # Incremental: rerun only the previously-failed tests. Reference
-            # generation is NOT skipped — run-wpt-tests.sh restricts it to just the
-            # rerun set (fast, and it guarantees those tests have references).
-            # Skipping generation here relied on a cached reference set that is not
-            # reliably present, which skipped every reran test as "missing
-            # reference image" and made the run meaningless.
-            ARGS+=(--rerun-json "$FAILED_TESTS_FILE")
-          fi
-          EXIT=0
-          bash scripts/run-wpt-tests.sh "${ARGS[@]}" || EXIT=$?
-          echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
-          echo "Shard ${{ matrix.shard-index }} finished (exit $EXIT)."
-          exit "$EXIT"
-
-      - name: Collect shard result
-        if: always()
-        run: |
-          mkdir -p shard-out
-          cp "$RESULTS_DIR/wpt-results.json" "shard-out/wpt-shard-${{ matrix.shard-index }}.json" 2>/dev/null || true
-          cp "$RESULTS_DIR/wpt-results.log"  "shard-out/wpt-shard-${{ matrix.shard-index }}.log"  2>/dev/null || true
-          EXIT="${{ steps.wpt.outputs.exit_code }}"
-          if ! [[ "$EXIT" =~ ^[0-9]+$ ]]; then
-            EXIT=1
-          fi
-          # run-wpt-tests.sh leaves a marker when the shard could not run a single
-          # test — e.g. the Playwright CDN refused its Chromium download. Folding
-          # that into the status file is what lets the merge step name the real
-          # cause instead of guessing at one (issue #1534).
-          python3 - "${{ matrix.shard-index }}" "$EXIT" \
-            "$RESULTS_DIR/wpt-shard-failure.json" \
-            "shard-out/wpt-shard-${{ matrix.shard-index }}-status.json" <<'PY'
-          import json, sys
-
-          shard_index, exit_code, marker_path, out_path = sys.argv[1:5]
-          status = {"shardIndex": int(shard_index), "exitCode": int(exit_code)}
-          try:
-              with open(marker_path, encoding="utf-8") as handle:
-                  marker = json.load(handle)
-          except (OSError, ValueError):
-              marker = None
-          if isinstance(marker, dict):
-              if marker.get("reason"):
-                  status["failureReason"] = str(marker["reason"])
-              if marker.get("detail"):
-                  status["failureDetail"] = str(marker["detail"])
-          with open(out_path, "w", encoding="utf-8") as handle:
-              json.dump(status, handle)
-              handle.write("\n")
-          PY
-
-      - name: Shard step summary
-        if: always()
-        run: |
-          SUMMARY="$RESULTS_DIR/wpt-summary.txt"
-          if [ -f "$SUMMARY" ]; then
-            echo "### WPT shard ${{ matrix.shard-index }}/${SHARD_COUNT}" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "$RETRY_SHARDS" ]; then
+            echo "### WPT retry pass" >> "$GITHUB_STEP_SUMMARY"
+            echo "Rerunning shard(s) that aborted abnormally: \`$RETRY_SHARDS\`." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - uses: actions/upload-artifact@v6
-        if: always()
+  # ── Rerun the aborted shards, once, at the end of the workflow ───────────
+  #
+  # One retry pass only: a shard that aborts twice is reported as incomplete just
+  # as before, rather than looping the workflow for hours. Each retry uploads to
+  # `wpt-shard-<i>-retry`, whose files carry the same `-retry` suffix, so the
+  # merge step can tell the two attempts apart in the flattened download
+  # directory and let the retry supersede — not add to — the attempt it replaces.
+  retry:
+    needs: [plan, prepare, retry-plan]
+    if: ${{ !cancelled() && needs.retry-plan.outputs.has-retries == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.retry-plan.outputs.retry-matrix) }}
+    steps:
+      - uses: actions/checkout@v5
         with:
-          name: wpt-shard-${{ matrix.shard-index }}
-          path: shard-out
+          submodules: recursive
+
+      - uses: ./.github/actions/run-wpt-shard
+        with:
+          shard-index: ${{ matrix.shard-index }}
+          shard-count: ${{ env.SHARD_COUNT }}
+          attempt-suffix: '-retry'
+          subset: ${{ github.event.inputs.subset || '' }}
+          rerun-failed: ${{ needs.plan.outputs.rerun-failed }}
+          failed-tests-file: ${{ env.FAILED_TESTS_FILE }}
+          cache-epoch: ${{ env.CACHE_EPOCH }}
+          wpt-checkout-dir: ${{ env.WPT_CHECKOUT_DIR }}
+          reference-dir: ${{ env.REFERENCE_DIR }}
+          results-dir: ${{ env.RESULTS_DIR }}
+          test-timeout-seconds: ${{ github.event.inputs.test_timeout_seconds || '30' }}
+          memory-limit-mb: ${{ github.event.inputs.memory_limit_mb || '1024' }}
 
   # ── Merge shard results; file an issue when there are failures ───────────
+  #
+  # Depends on `retry` as well as `run` so the merge sees the reruns' artifacts;
+  # `always()` keeps it running when the retry job was skipped (nothing aborted)
+  # or itself failed.
   report:
-    needs: [plan, run]
+    needs: [plan, run, retry]
     if: always() && needs.run.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
@@ -424,7 +391,7 @@ jobs:
 
   # ── Persist the failing-test manifest for incremental reruns ─────────────
   persist-failed:
-    needs: run
+    needs: [run, retry]
     # Refresh the failed-tests manifest (tests/wpt-baseline/failed-tests.json),
     # which drives incremental --rerun-failed-only runs, after any run that
     # actually executed shards — success OR failure. The run job reports
@@ -439,6 +406,10 @@ jobs:
     # subset/single-shard/rerun run updates just its own slice without shrinking
     # the manifest — no full-suite gate needed, and a crashed shard simply leaves
     # its tests' existing entries untouched rather than dropping them.
+    #
+    # `retry` is in `needs` only so the reruns' artifacts are on hand before the
+    # merge; it is not part of the gate, since it is skipped on the normal path
+    # where nothing aborted.
     if: >-
       always()
       && (needs.run.result == 'success' || needs.run.result == 'failure')

--- a/scripts/merge-wpt-shards.py
+++ b/scripts/merge-wpt-shards.py
@@ -31,10 +31,22 @@ lets a partial subset/shard/rerun run update its own slice of the manifest
 without shrinking it, so persistence is safe on every run, not just a full-suite
 one.
 
+A shard that aborts abnormally (runner eviction, a browser it could not
+download, a hard crash) is rerun once at the end of the workflow, and uploads
+its results with a ``-retry`` suffix alongside the aborted attempt's. Both land
+in the same directory, so the two are reconciled here: for each shard only the
+latest attempt is merged, meaning a retry *replaces* the attempt it repeats
+rather than being summed with it. ``retriedShards`` records which shards that
+happened to.
+
 When ``--github-output`` is given (the ``$GITHUB_OUTPUT`` file), the script also
 writes ``failed_count``, ``total_count``, ``incomplete_shard_count``,
-``create_issue``, ``biggest_problem_count`` and ``create_biggest_issue`` step
-outputs. The last two drive the second (biggest-problems) issue.
+``create_issue``, ``biggest_problem_count``, ``create_biggest_issue``,
+``incomplete_shard_indexes``, ``incomplete_shard_matrix``,
+``has_incomplete_shards`` and ``retried_shard_count`` step outputs.
+``create_(biggest_)issue`` drive the two issues; the ``incomplete_shard_*``
+trio drives the retry pass, which re-dispatches exactly the shards flagged
+incomplete.
 """
 
 from __future__ import annotations
@@ -94,6 +106,74 @@ def _family_key(relative_path: str) -> str:
     return f"{directory}/{collapsed}" if directory else collapsed
 
 
+# The WPT workflow's retry pass re-runs, at the end of the run, any shard that
+# aborted abnormally, and uploads that attempt's files with this suffix
+# (``wpt-shard-3-retry.json`` beside the original ``wpt-shard-3.json``). Both
+# attempts therefore land in the same flattened download directory, and the
+# suffix is the only thing distinguishing them — the runner's own report has no
+# notion of attempts. Reading it back here is what lets a retry *supersede* the
+# attempt it replaces instead of being summed alongside it, which would
+# double-count a shard that uploaded a partial report before dying.
+RETRY_SUFFIX = "-retry"
+STATUS_SUFFIX = "-status"
+
+
+def _attempt_number(path: Path) -> int:
+    """Which pass a shard artifact came from: 1 for the end-of-workflow retry, 0
+    for the original attempt."""
+    stem = path.stem
+    if stem.endswith(STATUS_SUFFIX):
+        stem = stem[: -len(STATUS_SUFFIX)]
+    return 1 if stem.endswith(RETRY_SUFFIX) else 0
+
+
+def _report_shard_index(report: dict) -> int | None:
+    shard = report.get("shard")
+    if not isinstance(shard, dict):
+        return None
+    try:
+        return int(shard.get("index"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _status_shard_index(status: dict) -> int | None:
+    try:
+        return int(status["shardIndex"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _select_latest_attempts(entries, index_of):
+    """Collapse per-shard artifacts down to the latest attempt of each shard.
+
+    ``entries`` is an iterable of ``(path, payload)``. When the retry pass reran
+    a shard, both attempts are present; only the retry describes what that slice
+    actually did, so the earlier attempt is dropped rather than merged next to
+    it. Payloads whose shard index cannot be read are all kept — there is nothing
+    to supersede them with, and dropping them would lose results.
+
+    Returns ``(entries, retried_shard_indexes)``, the second being the shards a
+    retry attempt actually superseded.
+    """
+    latest: dict[int, tuple[int, Path, dict]] = {}
+    kept: list[tuple[Path, dict]] = []
+    retried: set[int] = set()
+    for path, payload in entries:
+        shard_index = index_of(payload)
+        if shard_index is None:
+            kept.append((path, payload))
+            continue
+        attempt = _attempt_number(path)
+        if attempt > 0:
+            retried.add(shard_index)
+        current = latest.get(shard_index)
+        if current is None or attempt >= current[0]:
+            latest[shard_index] = (attempt, path, payload)
+    kept.extend((path, payload) for _attempt, path, payload in latest.values())
+    return kept, retried
+
+
 def _iter_shard_reports(shard_dir: Path):
     # Recurse so it does not matter whether artifacts were downloaded flat or
     # into per-shard subdirectories.
@@ -105,6 +185,12 @@ def _iter_shard_reports(shard_dir: Path):
         # Only consider documents that look like a Broiler.Wpt report.
         if isinstance(data, dict) and "summary" in data and "results" in data:
             yield path, data
+
+
+def _shard_reports(shard_dir: Path):
+    """Shard reports with each retried shard represented by its retry only."""
+    entries, _retried = _select_latest_attempts(_iter_shard_reports(shard_dir), _report_shard_index)
+    return entries
 
 
 def _iter_shard_statuses(shard_dir: Path):
@@ -138,14 +224,19 @@ def _format_incomplete_shard(status: dict) -> str:
     has received a shutdown signal"), so the whole slice went unmeasured rather
     than crashing on a specific test."""
     reason = status.get("failureReason")
+    # A shard the workflow's retry pass already reran is labelled as such: it is
+    # the *rerun* that came back inconclusive, so "re-run the workflow" is no
+    # longer the obvious next step.
+    retried = " after rerun" if status.get("retried") else ""
     if reason:
         # An unrecognised reason is still more informative than the exit code, so
         # it is shown as-is rather than dropped.
-        return f"shard {status['shardIndex']} ({FAILURE_REASON_LABELS.get(reason, reason)})"
+        label = FAILURE_REASON_LABELS.get(reason, reason)
+        return f"shard {status['shardIndex']} ({label}{retried})"
     exit_code = status["exitCode"]
     if exit_code == "missing":
-        return f"shard {status['shardIndex']} (no report uploaded)"
-    return f"shard {status['shardIndex']} (exit {exit_code})"
+        return f"shard {status['shardIndex']} (no report uploaded{retried})"
+    return f"shard {status['shardIndex']} (exit {exit_code}{retried})"
 
 
 def _incomplete_shard_cause_sentences(shards: list[dict]) -> list[str]:
@@ -173,6 +264,17 @@ def _incomplete_shard_cause_sentences(shards: list[dict]) -> list[str]:
             "A shard that recorded no reason is usually a transient CI-runner "
             "eviction (the runner received a shutdown signal before its upload step "
             "ran), which is likewise not a test regression."
+        )
+
+    retried = [str(status["shardIndex"]) for status in shards if status.get("retried")]
+    if retried:
+        # Worth saying plainly: the workflow's own retry pass already spent a
+        # second full run on these and they still came back inconclusive, so this
+        # is not the usual one-off eviction that clears by itself.
+        subject = f"Shard {retried[0]} was" if len(retried) == 1 else f"Shards {', '.join(retried)} were"
+        sentences.append(
+            f"{subject} already rerun automatically at the end of this run and still "
+            "did not complete, so this is unlikely to be a one-off runner eviction."
         )
 
     return sentences
@@ -402,15 +504,18 @@ def merge(
     family_groups: dict[str, dict] = {}
     reported_shard_indexes: set[int] = set()
 
-    for _path, report in _iter_shard_reports(shard_dir):
+    # Reports first: a shard the retry pass reran contributes its retry only, so
+    # the totals below count each shard's slice exactly once.
+    report_entries, retried_by_report = _select_latest_attempts(
+        _iter_shard_reports(shard_dir), _report_shard_index
+    )
+
+    for _path, report in report_entries:
         shard_count += 1
         summary = report.get("summary", {})
-        shard = report.get("shard")
-        if isinstance(shard, dict):
-            try:
-                reported_shard_indexes.add(int(shard.get("index")))
-            except (TypeError, ValueError):
-                pass
+        shard_index = _report_shard_index(report)
+        if shard_index is not None:
+            reported_shard_indexes.add(shard_index)
         passed += int(summary.get("passed", 0) or 0)
         failed += int(summary.get("failed", 0) or 0)
         skipped += int(summary.get("skipped", 0) or 0)
@@ -537,7 +642,14 @@ def merge(
     # download, say — so the report can name the cause instead of inferring one
     # from a bare non-zero exit.
     shard_failure_reasons: dict[int, dict[str, str]] = {}
-    for _path, status in _iter_shard_statuses(shard_dir):
+    status_entries, retried_by_status = _select_latest_attempts(
+        _iter_shard_statuses(shard_dir), _status_shard_index
+    )
+    # Shards the end-of-workflow retry pass reran. A shard is "retried" if either
+    # kind of artifact carries the retry suffix: a rerun that died before writing
+    # a report still leaves a status file, and a rerun that succeeded leaves both.
+    retried_shard_indexes = sorted(retried_by_report | retried_by_status)
+    for _path, status in status_entries:
         try:
             shard_index = int(status["shardIndex"])
             exit_code = int(status["exitCode"])
@@ -586,6 +698,10 @@ def merge(
             {
                 "shardIndex": shard_index,
                 "exitCode": exit_code if exit_code is not None else "missing",
+                # Still unmeasured *after* the workflow already reran it, which
+                # rules out a one-off runner eviction and is worth saying out
+                # loud — the report otherwise reads as if a rerun might fix it.
+                **({"retried": True} if shard_index in retried_by_report | retried_by_status else {}),
                 **shard_failure_reasons.get(shard_index, {}),
             }
         )
@@ -646,6 +762,7 @@ def merge(
         "shardCount": shard_count,
         "problemLimit": problem_limit,
         "incompleteShards": incomplete_shards,
+        "retriedShards": retried_shard_indexes,
         "topProblems": top_problems,
         "topFailingDirectories": directory_counter.most_common(problem_limit),
         "failuresByCategory": category_counter.most_common(),
@@ -665,7 +782,7 @@ def _collect_executed_paths(shard_dir: Path) -> set[str]:
     deliberately excluded, so a test that merely skipped this run does not evict
     its existing manifest entry. Used to scope ``merge_into_manifest``."""
     executed: set[str] = set()
-    for _path, report in _iter_shard_reports(shard_dir):
+    for _path, report in _shard_reports(shard_dir):
         for result in report.get("results", []):
             if not isinstance(result, dict) or result.get("skipped"):
                 continue
@@ -729,6 +846,17 @@ def render_issue_markdown(merged: dict, run_url: str | None) -> str:
         f"- Failed: {summary['failed']}",
         f"- Skipped: {summary['skipped']}",
         f"- Incomplete shards: {len(merged['incompleteShards'])}",
+    ]
+    # Shards the workflow reran at the end because their first attempt aborted
+    # abnormally. Their retry's results are what the totals above count — the
+    # aborted attempt is superseded, not added to it.
+    retried = merged.get("retriedShards") or []
+    if retried:
+        lines.append(
+            "- Shards rerun after an abnormal abort: "
+            + ", ".join(str(index) for index in retried)
+        )
+    lines += [
         "",
         f"### Top {merged['problemLimit']} problems",
         "",
@@ -976,6 +1104,14 @@ def main() -> int:
           f"{failed} failed, {merged['summary']['skipped']} skipped, {total} total.")
 
     if args.github_output:
+        # The indexes of the shards that went unmeasured, in the two shapes the
+        # workflow's retry pass needs: a comma-separated list for the log/summary
+        # and a ready-to-use `strategy.matrix.include` array. `retry` only
+        # re-dispatches shards that produced no conclusive report — a shard that
+        # ran to completion and merely reported failing tests is not incomplete
+        # and is never rerun.
+        incomplete_indexes = [status["shardIndex"] for status in merged["incompleteShards"]]
+        matrix = json.dumps([{"shard-index": index} for index in incomplete_indexes])
         with args.github_output.open("a", encoding="utf-8") as handle:
             handle.write(f"failed_count={failed}\n")
             handle.write(f"total_count={total}\n")
@@ -983,6 +1119,14 @@ def main() -> int:
             handle.write(f"create_issue={'true' if failed > 0 or incomplete_shard_count > 0 else 'false'}\n")
             handle.write(f"biggest_problem_count={biggest_problem_count}\n")
             handle.write(f"create_biggest_issue={'true' if biggest_problem_count > 0 else 'false'}\n")
+            handle.write(
+                "incomplete_shard_indexes="
+                + ",".join(str(index) for index in incomplete_indexes)
+                + "\n"
+            )
+            handle.write(f"incomplete_shard_matrix={matrix}\n")
+            handle.write(f"has_incomplete_shards={'true' if incomplete_indexes else 'false'}\n")
+            handle.write(f"retried_shard_count={len(merged['retriedShards'])}\n")
 
     return 0
 

--- a/scripts/tests/test_merge_wpt_shards.py
+++ b/scripts/tests/test_merge_wpt_shards.py
@@ -46,6 +46,7 @@ class MergeWptShardsTests(unittest.TestCase):
         exit_code: int,
         failure_reason: str | None = None,
         failure_detail: str | None = None,
+        attempt_suffix: str = "",
     ) -> None:
         status = {"shardIndex": shard_index, "exitCode": exit_code}
         # The workflow's "Collect shard result" step folds these in from the marker
@@ -54,7 +55,7 @@ class MergeWptShardsTests(unittest.TestCase):
             status["failureReason"] = failure_reason
         if failure_detail is not None:
             status["failureDetail"] = failure_detail
-        (root / f"wpt-shard-{shard_index}-status.json").write_text(
+        (root / f"wpt-shard-{shard_index}{attempt_suffix}-status.json").write_text(
             json.dumps(status),
             encoding="utf-8",
         )
@@ -961,6 +962,262 @@ class MergeWptShardsTests(unittest.TestCase):
 
         self.assertNotEqual(0, result.returncode)
         self.assertIn("--problem-limit must be a positive integer", result.stderr)
+
+    # ── The end-of-workflow retry pass ───────────────────────────────────────
+    #
+    # A shard that aborts abnormally is rerun once at the end of the workflow and
+    # uploads its files with a `-retry` suffix, next to whatever the aborted
+    # attempt managed to leave behind. These cover the reconciliation: the retry
+    # replaces the attempt it repeats, and never adds to it.
+
+    def test_retry_report_supersedes_the_aborted_attempt(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            # Shard 0 died partway through: one failure recorded, then the crash.
+            self._write_report(
+                shard_dir,
+                "wpt-shard-0.json",
+                0,
+                [self._failure("css/a/one.html", "RenderingError")],
+            )
+            self._write_status(shard_dir, shard_index=0, exit_code=134)
+            # The rerun measured the whole slice.
+            self._write_report(
+                shard_dir,
+                "wpt-shard-0-retry.json",
+                0,
+                [
+                    self._failure("css/a/one.html", "RenderingError"),
+                    self._failure("css/a/two.html", "Timeout"),
+                ],
+            )
+            self._write_status(shard_dir, shard_index=0, exit_code=1, attempt_suffix="-retry")
+            self._write_report(
+                shard_dir,
+                "wpt-shard-1.json",
+                1,
+                [self._failure("html/a/three.html", "Timeout")],
+            )
+            self._write_status(shard_dir, shard_index=1, exit_code=1)
+
+            merged = MODULE.merge(shard_dir, expected_shard_indexes={0, 1})
+
+            # Two shards' worth of totals, not three: the aborted attempt's
+            # summary is dropped, not summed with its rerun's.
+            self.assertEqual(2, merged["shardCount"])
+            self.assertEqual(3, merged["summary"]["failed"])
+            self.assertEqual(2, merged["summary"]["passed"])
+            self.assertEqual(5, merged["summary"]["total"])
+            # The rerun produced a report, so the slice is measured after all.
+            self.assertEqual([], merged["incompleteShards"])
+            self.assertEqual([0], merged["retriedShards"])
+
+            markdown = MODULE.render_issue_markdown(merged, "https://example.test/run/1")
+            self.assertIn("Shards rerun after an abnormal abort: 0", markdown)
+            self.assertIn("Incomplete shards: 0", markdown)
+
+    def test_shard_that_aborts_again_is_reported_as_retried(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._write_report(
+                shard_dir,
+                "wpt-shard-1.json",
+                1,
+                [self._failure("html/a/three.html", "Timeout")],
+            )
+            self._write_status(shard_dir, shard_index=1, exit_code=1)
+            # Shard 0 aborted, was rerun, and aborted again — no report either time.
+            self._write_status(
+                shard_dir,
+                shard_index=0,
+                exit_code=1,
+                failure_reason="BrowserDownloadBlocked",
+                failure_detail="Chromium download returned HTTP 403.",
+            )
+            self._write_status(
+                shard_dir,
+                shard_index=0,
+                exit_code=1,
+                failure_reason="BrowserDownloadBlocked",
+                failure_detail="Chromium download returned HTTP 403.",
+                attempt_suffix="-retry",
+            )
+
+            merged = MODULE.merge(shard_dir, expected_shard_indexes={0, 1})
+
+            self.assertEqual(
+                [
+                    {
+                        "shardIndex": 0,
+                        "exitCode": 1,
+                        "retried": True,
+                        "failureReason": "BrowserDownloadBlocked",
+                        "failureDetail": "Chromium download returned HTTP 403.",
+                    }
+                ],
+                merged["incompleteShards"],
+            )
+            self.assertEqual([0], merged["retriedShards"])
+
+            biggest = MODULE.render_biggest_problems_markdown(merged, None)
+            self.assertIn("shard 0 (Chromium download refused after rerun)", biggest)
+            self.assertIn("already rerun automatically at the end of this run", biggest)
+
+    def test_incomplete_shards_drive_the_retry_matrix(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            github_output = shard_dir / "github-output.txt"
+            # Shard 0 reported; shard 2 crashed after running; shard 1 uploaded
+            # nothing at all (its runner was lost mid-run).
+            self._write_report(
+                shard_dir,
+                "wpt-shard-0.json",
+                0,
+                [self._failure("css/a/one.html", "Timeout")],
+            )
+            self._write_status(shard_dir, shard_index=0, exit_code=1)
+            self._write_status(shard_dir, shard_index=2, exit_code=134)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--shard-dir",
+                    temp,
+                    "--expected-shards",
+                    "0,1,2",
+                    "--github-output",
+                    str(github_output),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            outputs = github_output.read_text(encoding="utf-8")
+            self.assertIn("has_incomplete_shards=true\n", outputs)
+            self.assertIn("incomplete_shard_indexes=1,2\n", outputs)
+            self.assertIn(
+                'incomplete_shard_matrix=[{"shard-index": 1}, {"shard-index": 2}]\n',
+                outputs,
+            )
+            self.assertIn("retried_shard_count=0\n", outputs)
+
+    def test_failing_but_complete_shard_is_not_retried(self) -> None:
+        # The retry pass exists for shards that went unmeasured, not for shards
+        # that measured their slice and found failures — rerunning those would
+        # burn a full run to produce the same answer.
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            github_output = shard_dir / "github-output.txt"
+            self._write_report(
+                shard_dir,
+                "wpt-shard-0.json",
+                0,
+                [self._failure("css/a/one.html", "PixelMismatch", "LayoutShift")],
+            )
+            self._write_status(shard_dir, shard_index=0, exit_code=1)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--shard-dir",
+                    temp,
+                    "--expected-shards",
+                    "0",
+                    "--github-output",
+                    str(github_output),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            outputs = github_output.read_text(encoding="utf-8")
+            self.assertIn("has_incomplete_shards=false\n", outputs)
+            self.assertIn("incomplete_shard_indexes=\n", outputs)
+            self.assertIn("incomplete_shard_matrix=[]\n", outputs)
+            # The failure itself is still reported, just not rerun.
+            self.assertIn("failed_count=1\n", outputs)
+
+    def test_retry_supersedes_the_aborted_attempt_in_the_manifest(self) -> None:
+        # --merge-into scopes persistence to the tests a run exercised. A rerun
+        # shard's *rerun* results are that scope; the aborted attempt's partial
+        # verdicts must not resurrect entries the rerun has since passed.
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp) / "shards"
+            shard_dir.mkdir()
+            manifest = Path(temp) / "failed-tests.json"
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "summary": {"passed": 0, "failed": 1, "skipped": 0, "total": 1},
+                        "results": [
+                            {
+                                "relativeTestPath": "css/a/one.html",
+                                "passed": False,
+                                "skipped": False,
+                                "category": "RenderingError",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            # The aborted attempt saw css/a/one.html fail; the rerun saw it pass
+            # (it is absent from the rerun's failures) and css/a/two.html fail.
+            self._write_report(
+                shard_dir,
+                "wpt-shard-0.json",
+                0,
+                [self._failure("css/a/one.html", "RenderingError")],
+            )
+            self._write_status(shard_dir, shard_index=0, exit_code=134)
+            (shard_dir / "wpt-shard-0-retry.json").write_text(
+                json.dumps(
+                    {
+                        "summary": {"passed": 1, "failed": 1, "skipped": 0, "total": 2},
+                        "shard": {"index": 0, "count": 8},
+                        "results": [
+                            {
+                                "relativeTestPath": "css/a/one.html",
+                                "passed": True,
+                                "skipped": False,
+                                "category": "Pass",
+                            },
+                            self._failure("css/a/two.html", "Timeout"),
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self._write_status(shard_dir, shard_index=0, exit_code=1, attempt_suffix="-retry")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--shard-dir",
+                    str(shard_dir),
+                    "--merge-into",
+                    str(manifest),
+                    "--merged-json",
+                    str(manifest),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            written = json.loads(manifest.read_text(encoding="utf-8"))
+            self.assertEqual(
+                ["css/a/two.html"],
+                [entry["relativeTestPath"] for entry in written["results"]],
+            )
 
     @staticmethod
     def _failure(path: str, category: str, sub_category: str | None = None) -> dict:


### PR DESCRIPTION
## Summary

Implements an end-of-workflow retry mechanism for WPT test shards that abort abnormally (runner eviction, browser download failure, hard crash) without producing a conclusive test report. Shards that merely fail tests are not rerun — only those that went unmeasured are retried once, with results merged to replace the aborted attempt rather than being summed alongside it.

## Key Changes

- **Composite action for shard execution** (`.github/actions/run-wpt-shard/action.yml`): Factors out all provisioning, execution, and result-collection steps into a reusable composite action so the retry pass runs shards identically to the initial pass. Accepts an `attempt-suffix` parameter to distinguish retry artifacts (`-retry`) from initial attempts.

- **Retry detection and planning** (`retry-plan` job): New job that downloads initial shard results, runs `merge-wpt-shards.py` to detect incomplete shards (those with no conclusive report), and outputs a retry matrix for shards that need rerunning.

- **Retry execution** (`retry` job): Conditionally runs only when incomplete shards are detected, re-executes those shards with `-retry` suffix on artifacts and status files.

- **Artifact reconciliation in merge script** (`scripts/merge-wpt-shards.py`):
  - Adds `_select_latest_attempts()` to collapse per-shard artifacts when both initial and retry attempts exist, keeping only the latest attempt per shard
  - Tracks `retried_shard_indexes` to record which shards were rerun
  - Marks incomplete shards with a `retried` flag when they aborted even after the retry pass
  - Updates markdown rendering to note when a shard was "already rerun automatically"
  - Outputs `incomplete_shard_indexes`, `incomplete_shard_matrix`, `has_incomplete_shards`, and `retried_shard_count` for workflow orchestration

- **Test coverage** (`scripts/tests/test_merge_wpt_shards.py`): Comprehensive tests for retry reconciliation, including:
  - Retry report superseding aborted attempt
  - Shards that abort again after retry
  - Retry matrix generation from incomplete shards
  - Distinction between failing-but-complete shards (not retried) and incomplete ones
  - Manifest persistence with retry supersession

- **Workflow documentation**: Extended comments in `wpt-tests.yml` explaining the retry mechanism and its relationship to incomplete shard detection.

## Implementation Details

- Retry artifacts use a `-retry` suffix on both JSON reports and status files, allowing the merge script to distinguish attempts by filename alone (no metadata in the report itself).
- Only shards flagged as incomplete by `merge-wpt-shards.py` are retried — the same logic that detects incomplete shards drives the retry decision, ensuring consistency.
- A shard that aborts twice is reported as incomplete with `retried: true`, making it clear the workflow already spent a second full run on it.
- The retry pass runs after all initial shards complete, so a single evicted shard does not block the workflow — it retries at the end.
- Retry results are merged in place of the aborted attempt's partial results, not added on top, preventing double-counting of test outcomes.

https://claude.ai/code/session_014escZNqcGYiDSwQvs9agub