### PR TITLE
Prefix benchmark env vars to avoid MSBuild property conflicts

### DIFF
--- a/.github/workflows/octane-benchmarks.yml
+++ b/.github/workflows/octane-benchmarks.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Map the requested RIDs to runner labels
         id: select
         env:
-          PLATFORM: ${{ github.event.inputs.platform || 'linux-x64' }}
+          OCTANE_PLATFORM: ${{ github.event.inputs.platform || 'linux-x64' }}
         run: |
           set -euo pipefail
 
@@ -115,9 +115,9 @@ jobs:
             esac
           }
 
-          case "$PLATFORM" in
+          case "$OCTANE_PLATFORM" in
             all) platforms='linux-x64 win-x64 linux-arm64' ;;
-            *)   platforms="$PLATFORM" ;;
+            *)   platforms="$OCTANE_PLATFORM" ;;
           esac
 
           entries=''
@@ -183,33 +183,40 @@ jobs:
         with:
           node-version: '20'
 
+      # OCTANE_PLATFORM, not PLATFORM: this step runs `dotnet build`, and MSBuild
+      # reads every environment variable as a global property. A variable named
+      # PLATFORM therefore sets $(Platform), and any value other than AnyCPU
+      # moves the whole build to bin/<platform>/<configuration>/ — the harness
+      # then found no bin/Release and every platform's job died before it
+      # benchmarked anything. Keep benchmark-harness variables under a prefix no
+      # MSBuild property answers to.
       - name: Run Octane benchmarks
         env:
-          PLATFORM: ${{ matrix.platform }}
-          ONLY: ${{ github.event.inputs.only }}
-          VERBOSE: ${{ github.event.inputs.verbose }}
+          OCTANE_PLATFORM: ${{ matrix.platform }}
+          OCTANE_ONLY: ${{ github.event.inputs.only }}
+          OCTANE_VERBOSE: ${{ github.event.inputs.verbose }}
         run: |
           args=(
-            --platform "$PLATFORM"
+            --platform "$OCTANE_PLATFORM"
             --engines "${{ github.event.inputs.engines || 'chromium,broiler,jint' }}"
             --timeout "${{ github.event.inputs.timeout_seconds || '180' }}"
             --repetitions "${{ github.event.inputs.repetitions || '3' }}"
             --octane-ref "${{ github.event.inputs.octane_ref || 'master' }}"
           )
-          [ -n "$ONLY" ] && args+=(--only "$ONLY")
-          [ "$VERBOSE" = "true" ] && args+=(--verbose)
+          [ -n "$OCTANE_ONLY" ] && args+=(--only "$OCTANE_ONLY")
+          [ "$OCTANE_VERBOSE" = "true" ] && args+=(--verbose)
           bash scripts/run-octane-benchmarks.sh "${args[@]}"
 
       - name: Publish comparison and failure diagnostics to job summary
         if: always()
         env:
-          PLATFORM: ${{ matrix.platform }}
+          OCTANE_PLATFORM: ${{ matrix.platform }}
         run: |
           # With `all` dispatched, three jobs write into one summary; each says
           # up front which machine it is reporting on.
-          echo "## $PLATFORM" >> "$GITHUB_STEP_SUMMARY"
-          for f in "tests/octane/results/$PLATFORM/comparison.md" \
-                   "tests/octane/results/$PLATFORM/diagnostics.md"; do
+          echo "## $OCTANE_PLATFORM" >> "$GITHUB_STEP_SUMMARY"
+          for f in "tests/octane/results/$OCTANE_PLATFORM/comparison.md" \
+                   "tests/octane/results/$OCTANE_PLATFORM/diagnostics.md"; do
             [ -f "$f" ] && cat "$f" >> "$GITHUB_STEP_SUMMARY"
           done
           exit 0

--- a/scripts/run-octane-benchmarks.sh
+++ b/scripts/run-octane-benchmarks.sh
@@ -93,6 +93,18 @@ to_native() {
     fi
 }
 
+# Where MSBuild actually put a project's assembly, asked rather than assumed.
+# bin/<configuration>/ is only the default: MSBuild reads every environment
+# variable as a global property, so a caller carrying PLATFORM=linux-arm64 (or
+# any other $(Platform) that is not AnyCPU) redirects the build to
+# bin/<platform>/<configuration>/ — which is how the CI matrix's own
+# per-platform variable once made every job fail to find the shell it had just
+# built. Querying the same evaluation the build used cannot drift from it.
+target_path() {
+    dotnet msbuild "$(to_native "$1")" -nologo -p:Configuration=Release \
+        -getProperty:TargetPath 2>/dev/null | tr -d '\r' | tail -1
+}
+
 PLATFORM=""
 OCTANE_DIR=""
 OUT_DIR=""
@@ -178,10 +190,10 @@ if [[ ",$ENGINES," == *",broiler,"* ]]; then
     else
         echo "--- Step 2a: Skipping BroilerJS build (--skip-build) ---"
     fi
-    BROILER_DLL="$(find "$REPO_ROOT/Broiler.JS/Broiler.JS/Broiler.JavaScript/bin/Release" -name BroilerJS.dll | head -1)"
-    [[ -n "$BROILER_DLL" ]] || { echo "  ✗ BroilerJS.dll not found; build first." >&2; exit 1; }
+    BROILER_DLL="$(to_native "$(target_path "$BROILER_PROJ")")"
+    [[ -f "$BROILER_DLL" ]] || { echo "  ✗ BroilerJS.dll not found; build first." >&2; exit 1; }
     echo "  BroilerJS.dll: $BROILER_DLL"
-    NODE_ARGS+=(--broiler-dll "$(to_native "$BROILER_DLL")")
+    NODE_ARGS+=(--broiler-dll "$BROILER_DLL")
     echo ""
 fi
 
@@ -196,10 +208,10 @@ if [[ ",$ENGINES," == *",jint,"* ]]; then
     else
         echo "--- Step 2b: Skipping Jint shell build (--skip-build) ---"
     fi
-    JINT_DLL="$(find "$REPO_ROOT/tests/octane/jint-host/bin/Release" -name Broiler.Octane.JintHost.dll | head -1)"
-    [[ -n "$JINT_DLL" ]] || { echo "  ✗ Broiler.Octane.JintHost.dll not found; build first." >&2; exit 1; }
+    JINT_DLL="$(to_native "$(target_path "$JINT_PROJ")")"
+    [[ -f "$JINT_DLL" ]] || { echo "  ✗ Broiler.Octane.JintHost.dll not found; build first." >&2; exit 1; }
     echo "  Jint shell: $JINT_DLL"
-    NODE_ARGS+=(--jint-dll "$(to_native "$JINT_DLL")")
+    NODE_ARGS+=(--jint-dll "$JINT_DLL")
     echo ""
 fi
 

--- a/tests/octane/README.md
+++ b/tests/octane/README.md
@@ -56,6 +56,15 @@ for the full matrix, which fans out to one job per RID on its own runner
 logs are uploaded as `octane-results-<platform>` and `octane-logs-<platform>`
 artifacts, and each job commits only its own results directory.
 
+The workflow carries the RID in `OCTANE_PLATFORM`, not `PLATFORM`, and the
+prefix is load-bearing: the step also runs `dotnet build`, and MSBuild reads
+every environment variable as a global property. A variable named `PLATFORM`
+therefore sets `$(Platform)`, and any value but `AnyCPU` moves the build to
+`bin/<platform>/<configuration>/`. Name benchmark variables so no MSBuild
+property answers to them. The harness no longer assumes the default path
+either — it asks MSBuild for `TargetPath` — so a stray `Platform` in the
+environment relocates the build without losing it.
+
 Benchmarking takes hours, so the branch has usually moved by the time there is
 anything to commit. The commit step goes through
 [`scripts/ci-commit-generated-results.sh`](../../scripts/ci-commit-generated-results.sh),


### PR DESCRIPTION
## Summary

Rename environment variables used by the Octane benchmark workflow from `PLATFORM`, `ONLY`, and `VERBOSE` to `OCTANE_PLATFORM`, `OCTANE_ONLY`, and `OCTANE_VERBOSE`. This prevents MSBuild from interpreting `PLATFORM` as the `$(Platform)` global property, which was causing builds to output to `bin/<platform>/<configuration>/` instead of the expected `bin/Release/`, breaking benchmark jobs.

Additionally, update the benchmark harness to query MSBuild for the actual `TargetPath` rather than assuming the default output directory, making the build artifact discovery robust to any future environment variable conflicts.

## Key Changes

- **Workflow (`octane-benchmarks.yml`):**
  - Rename `PLATFORM` → `OCTANE_PLATFORM`, `ONLY` → `OCTANE_ONLY`, `VERBOSE` → `OCTANE_VERBOSE` in all job steps
  - Update all variable references in shell scripts and conditionals
  - Add detailed comment explaining why the prefix is necessary (MSBuild reads all env vars as global properties)

- **Benchmark harness (`run-octane-benchmarks.sh`):**
  - Add new `target_path()` function that queries MSBuild for the actual `TargetPath` property instead of assuming `bin/Release/`
  - Replace hardcoded `find` commands for `BroilerJS.dll` and `Broiler.Octane.JintHost.dll` with calls to `target_path()`
  - Remove redundant `to_native()` call on already-converted paths

- **Documentation (`tests/octane/README.md`):**
  - Document the `OCTANE_PLATFORM` prefix requirement and MSBuild property interaction
  - Explain the new `TargetPath` query approach

## Implementation Details

The root cause: MSBuild automatically treats every environment variable as a global property. When `PLATFORM=linux-arm64` was set, MSBuild's `$(Platform)` property was overridden, redirecting the build output from `bin/Release/` to `bin/linux-arm64/Release/`. The benchmark harness then failed to find the DLLs in the expected location.

By prefixing all benchmark-specific variables with `OCTANE_`, they no longer collide with any MSBuild property names. The new `target_path()` function makes the harness resilient by asking MSBuild directly where it placed the output, rather than assuming a path that could be affected by other environment variables.

https://claude.ai/code/session_01BJDjt6Axpm1YVWHgJuJoBj