### PR TITLE
Make WPT pixel pass threshold configurable

### DIFF
--- a/.github/actions/run-wpt-shard/action.yml
+++ b/.github/actions/run-wpt-shard/action.yml
@@ -6,7 +6,8 @@ description: >
   retry pass that re-runs any shard which aborted abnormally. Keeping them in
   one place is what guarantees a retried shard is measured identically to the
   attempt it replaces — a retry run with a different reference cache or a
-  different patch set would not be comparable at the 99% pixel threshold.
+  different patch set would not be comparable at the run's pixel pass threshold
+  (99% by default).
 
 inputs:
   shard-index:
@@ -56,6 +57,11 @@ inputs:
   memory-limit-mb:
     description: Per-test RAM cap in MiB (0 disables).
     required: true
+  pass-threshold:
+    description: >
+      Percentage of pixels that must match the Chromium reference for a test to
+      pass (99 = the render is at least 99% identical to the reference).
+    required: true
 
 runs:
   using: composite
@@ -93,8 +99,9 @@ runs:
     # a redirect to the one Google bucket that geo-blocked shard 0 in issue
     # #1534. Its ESRP mirror carries no x64 Linux Chromium at all. Caching is the
     # only fallback that keeps the *same* binary, and the binary has to stay the
-    # same: references are compared at a 99% pixel threshold, so regenerating a
-    # slice with a different Chrome build would read as an engine regression.
+    # same: references are compared at a pixel threshold of 99% by default, so
+    # regenerating a slice with a different Chrome build would read as an engine
+    # regression.
     #
     # Keyed on the lockfile rather than the cache epoch: bumping the epoch
     # refreshes WPT master and the reference slices, which is exactly when you
@@ -140,6 +147,11 @@ runs:
         FAILED_TESTS_FILE: ${{ inputs.failed-tests-file }}
         BROILER_WPT_TIMEOUT_SECONDS: ${{ inputs.test-timeout-seconds }}
         BROILER_WPT_MEMORY_LIMIT_MB: ${{ inputs.memory-limit-mb }}
+        # Pixel pass threshold: a test passes when its render is at least this
+        # percent identical to the Chromium reference. The runner reads the
+        # variable itself (and forwards the resolved value to its workers), so
+        # both the reference comparison and the retry pass use the same bar.
+        BROILER_WPT_PASS_THRESHOLD: ${{ inputs.pass-threshold }}
         # Match Chromium's reference generator, which screenshots at `load` before
         # any promise_test body runs: skip executing stub promise_test bodies in
         # Broiler's runner so post-load layout mutations (scrollTo, display toggling)

--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -65,6 +65,13 @@ on:
           0 disables the cap.
         required: false
         default: '1024'
+      pass_threshold:
+        description: >
+          Pixel pass threshold in percent: a test passes when Broiler's render is
+          at least this percent identical to the Chromium reference (99 = at most
+          1% of the pixels may differ).
+        required: false
+        default: '99'
       most_common_problems_limit:
         description: Maximum number of common failure groups to include in the GitHub issue.
         required: false
@@ -189,6 +196,7 @@ jobs:
           results-dir: ${{ env.RESULTS_DIR }}
           test-timeout-seconds: ${{ github.event.inputs.test_timeout_seconds || '30' }}
           memory-limit-mb: ${{ github.event.inputs.memory_limit_mb || '1024' }}
+          pass-threshold: ${{ github.event.inputs.pass_threshold || '99' }}
 
   # ── Decide which shards aborted abnormally and deserve one rerun ─────────
   #
@@ -288,6 +296,7 @@ jobs:
           results-dir: ${{ env.RESULTS_DIR }}
           test-timeout-seconds: ${{ github.event.inputs.test_timeout_seconds || '30' }}
           memory-limit-mb: ${{ github.event.inputs.memory_limit_mb || '1024' }}
+          pass-threshold: ${{ github.event.inputs.pass_threshold || '99' }}
 
   # ── Merge shard results; file an issue when there are failures ───────────
   #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,9 @@ something to attempt from inside the container.
     [Android development environment](docs/architecture/android.md#development-environment).
 - WPT runner: `dotnet run --project src/Broiler.Wpt -- --wpt-dir tests/wpt
   --reference-dir tests/wpt/references [--subset <path>] [--failure-images <dir>]`.
-  Pixel pass threshold is 99% match (≤1% differing pixels).
+  Pixel pass threshold defaults to 99% match (≤1% differing pixels) and is
+  configurable: `--pass-threshold <percent>`, `BROILER_WPT_PASS_THRESHOLD`, or the
+  `pass_threshold` input of the WPT Tests workflow.
 - WPT per-test limits: 30s timeout (`--timeout`, `BROILER_WPT_TIMEOUT_SECONDS`)
   and a 1024 MiB RAM cap (`--memory-limit-mb`, `BROILER_WPT_MEMORY_LIMIT_MB`,
   0 disables). The cap is on the *growth* of the rendering process's resident

--- a/src/Broiler.Wpt.Tests/WptPassThresholdTests.cs
+++ b/src/Broiler.Wpt.Tests/WptPassThresholdTests.cs
@@ -1,0 +1,130 @@
+using System.IO;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Covers the configurable pixel pass threshold: how the percentage is resolved from the
+/// command line/environment, how it maps onto the diff ratio <c>PixelDiffRunner</c>
+/// compares against, and that a run actually passes or fails a test by that bar.
+/// </summary>
+public sealed class WptPassThresholdTests : IDisposable
+{
+    private const string PassThresholdEnvironmentVariable = "BROILER_WPT_PASS_THRESHOLD";
+
+    private readonly string _tempDir;
+    private readonly string? _originalEnvironmentValue;
+
+    public WptPassThresholdTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "broiler-wpt-threshold-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _originalEnvironmentValue = Environment.GetEnvironmentVariable(PassThresholdEnvironmentVariable);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(PassThresholdEnvironmentVariable, _originalEnvironmentValue);
+
+        try
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, recursive: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Leaving a directory under %TEMP% behind is not a test failure.
+        }
+    }
+
+    [Fact]
+    public void Pass_Threshold_Defaults_To_99_Percent()
+    {
+        Environment.SetEnvironmentVariable(PassThresholdEnvironmentVariable, null);
+
+        Assert.True(Program.TryResolvePassThreshold(null, out var percent, out var error));
+        Assert.Null(error);
+        Assert.Equal(99, percent);
+        Assert.Equal(99, WptTestRunner.DefaultPassThresholdPercent);
+    }
+
+    [Fact]
+    public void Command_Line_Pass_Threshold_Wins_Over_The_Environment()
+    {
+        Environment.SetEnvironmentVariable(PassThresholdEnvironmentVariable, "90");
+
+        Assert.True(Program.TryResolvePassThreshold(97.5, out var percent, out _));
+        Assert.Equal(97.5, percent);
+    }
+
+    [Fact]
+    public void Environment_Pass_Threshold_Is_Used_When_No_Argument_Is_Given()
+    {
+        Environment.SetEnvironmentVariable(PassThresholdEnvironmentVariable, "95");
+
+        Assert.True(Program.TryResolvePassThreshold(null, out var percent, out _));
+        Assert.Equal(95, percent);
+    }
+
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("-1")]
+    [InlineData("101")]
+    public void Invalid_Environment_Pass_Threshold_Is_Rejected(string value)
+    {
+        Environment.SetEnvironmentVariable(PassThresholdEnvironmentVariable, value);
+
+        Assert.False(Program.TryResolvePassThreshold(null, out _, out var error));
+        Assert.Contains(PassThresholdEnvironmentVariable, error);
+    }
+
+    [Theory]
+    [InlineData(99, 0.01)]
+    [InlineData(100, 0.0)]
+    [InlineData(95, 0.05)]
+    [InlineData(0, 1.0)]
+    public void Percent_Threshold_Maps_Onto_The_Diff_Ratio(double percent, double expectedRatio)
+    {
+        var config = WptTestRunner.CreatePixelDiffConfig(percent);
+
+        Assert.Equal(expectedRatio, config.PixelDiffThreshold, precision: 10);
+    }
+
+    [Fact]
+    public void A_Two_Percent_Mismatch_Fails_At_99_But_Passes_At_97()
+    {
+        const int width = 200;
+        const int height = 100;
+        const int differingPixels = (width * height) / 50; // exactly 2% of the canvas
+
+        var testFile = Path.Combine(_tempDir, "pass-threshold.html");
+        File.WriteAllText(testFile,
+            "<!DOCTYPE html><html><body style=\"margin:0\">" +
+            "<div style=\"width:200px;height:100px;background:white\"></div></body></html>");
+
+        var referenceDir = Path.Combine(_tempDir, "references");
+        Directory.CreateDirectory(referenceDir);
+
+        // The reference is this build's own render with a known slice of its pixels
+        // repainted, so the diff ratio is exactly `differingPixels / (width * height)`
+        // and the assertions do not depend on how the page itself renders.
+        var strictRunner = new WptTestRunner(width, height, passThresholdPercent: 99);
+        using (var rendered = strictRunner.RenderHtmlFileBitmapPublic(testFile, null))
+        using (var reference = rendered.Copy())
+        {
+            for (int i = 0; i < differingPixels; i++)
+                reference.SetPixel(i % width, i / width, new Graphics.BColor(255, 0, 255, 255));
+
+            reference.Save(Path.Combine(referenceDir, "pass-threshold.png"));
+        }
+
+        var strictResult = strictRunner.RunTest(testFile, referenceDir);
+        Assert.False(strictResult.Passed);
+        Assert.Equal(FailureCategory.PixelMismatch, strictResult.Category);
+        Assert.Equal(98, strictResult.MatchPercent!.Value, precision: 3);
+
+        var lenientResult = new WptTestRunner(width, height, passThresholdPercent: 97)
+            .RunTest(testFile, referenceDir);
+        Assert.True(lenientResult.Passed, lenientResult.Message);
+        Assert.Equal(98, lenientResult.MatchPercent!.Value, precision: 3);
+    }
+}

--- a/src/Broiler.Wpt/Program.cs
+++ b/src/Broiler.Wpt/Program.cs
@@ -40,6 +40,15 @@ public class Program
     /// </summary>
     private const int DefaultRunTestMemoryLimitMegabytes = 1024;
     private const string RunTestMemoryLimitEnvironmentVariable = "BROILER_WPT_MEMORY_LIMIT_MB";
+
+    /// <summary>
+    /// Share of pixels a render must have in common with the reference for the test to
+    /// pass, in percent. The default 99 means a render passes when it is at least 99%
+    /// identical to the Chromium reference (at most 1% of the pixels differ).
+    /// </summary>
+    private const double DefaultPassThresholdPercent = WptTestRunner.DefaultPassThresholdPercent;
+    private const string PassThresholdEnvironmentVariable = "BROILER_WPT_PASS_THRESHOLD";
+
     private const int ProgressCheckpointInterval = 25;
     private const int TopBucketLimit = 5;
     private const int MissingContentDominantBucketMinimumFailures = 5;
@@ -83,6 +92,7 @@ public class Program
         RerunSelectionKind rerunSelectionKind = RerunSelectionKind.Failures;
         double? timeoutSeconds = null;
         int? memoryLimitMegabytes = null;
+        double? passThresholdPercent = null;
         int shardCount = 1;
         int shardIndex = WptTestRunner.AllShards;
         bool nonJavaScriptOnly = false;
@@ -153,6 +163,15 @@ public class Program
 
                     memoryLimitMegabytes = parsedMemoryLimitMegabytes;
                     break;
+                case "--pass-threshold" when i + 1 < args.Length:
+                    if (!TryParsePassThresholdPercent(args[++i], out var parsedPassThresholdPercent))
+                    {
+                        Console.Error.WriteLine("Error: '--pass-threshold' must be a percentage between 0 and 100.");
+                        return 1;
+                    }
+
+                    passThresholdPercent = parsedPassThresholdPercent;
+                    break;
                 case "--shard-count" when i + 1 < args.Length:
                     if (!int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out shardCount) || shardCount < 1)
                     {
@@ -190,6 +209,7 @@ public class Program
                 case "--rerun-kind":
                 case "--timeout":
                 case "--memory-limit-mb":
+                case "--pass-threshold":
                 case "--shard-count":
                 case "--shard-index":
                     Console.Error.WriteLine($"Error: '{args[i]}' requires a value.");
@@ -238,8 +258,16 @@ public class Program
         // Default reference directory to <wptPath>/references if not specified.
         referenceDir ??= Path.Combine(wptPath, "references");
 
+        // Resolved before the worker branch: a worker process does the pixel comparison
+        // itself, so it needs the same threshold the parent run was asked for.
+        if (!TryResolvePassThreshold(passThresholdPercent, out var runPassThresholdPercent, out var passThresholdError))
+        {
+            Console.Error.WriteLine(passThresholdError);
+            return 1;
+        }
+
         if (workerMode)
-            return RunWorkerMode(wptPath, referenceDir, failureImagesDir, verifyReference);
+            return RunWorkerMode(wptPath, referenceDir, failureImagesDir, verifyReference, runPassThresholdPercent);
 
         if (!TryResolveRunTestTimeout(timeoutSeconds, out var runTestTimeout, out var timeoutError))
         {
@@ -262,6 +290,8 @@ public class Program
         Console.WriteLine($"WPT directory : {Path.GetFullPath(wptPath)}");
         Console.WriteLine($"Reference dir : {Path.GetFullPath(referenceDir)}");
         Console.WriteLine($"Timeout       : {FormatSeconds(runTestTimeout)} second(s)");
+        Console.WriteLine($"Pass threshold: {FormatPassThreshold(runPassThresholdPercent)}% pixel match " +
+                          $"(at most {FormatPassThreshold(100 - runPassThresholdPercent)}% of the pixels may differ)");
         Console.WriteLine($"Mode          : {(nonJavaScriptOnly ? "non-JavaScript visual tests" : "all discovered tests")}");
         var useWorkerIsolation = !noWorkerIsolation && RunTestExecutorOverride.Value is null;
         Console.WriteLine(
@@ -284,7 +314,10 @@ public class Program
         }
         Console.WriteLine();
 
-        var runner = new WptTestRunner(failureImageDir: failureImagesDir, verifyReferenceHtml: verifyReference);
+        var runner = new WptTestRunner(
+            failureImageDir: failureImagesDir,
+            verifyReferenceHtml: verifyReference,
+            passThresholdPercent: runPassThresholdPercent);
 
         if (!string.IsNullOrWhiteSpace(failureImagesDir))
             Console.WriteLine($"Failure images: {Path.GetFullPath(failureImagesDir)}");
@@ -352,7 +385,13 @@ public class Program
             "SIGINT",
             terminationDiagnostics.Write);
         using var workerClient = useWorkerIsolation
-            ? new WptWorkerClient(wptPath, referenceDir, failureImagesDir, verifyReference, runTestMemoryLimitBytes)
+            ? new WptWorkerClient(
+                wptPath,
+                referenceDir,
+                failureImagesDir,
+                verifyReference,
+                runTestMemoryLimitBytes,
+                runPassThresholdPercent)
             : null;
         int completed = 0, runningPassed = 0, runningFailed = 0, runningSkipped = 0;
 
@@ -563,14 +602,16 @@ public class Program
         string wptPath,
         string referenceDir,
         string? failureImagesDir,
-        bool verifyReference)
+        bool verifyReference,
+        double passThresholdPercent)
     {
         var protocolOut = Console.Out;
         Console.SetOut(Console.Error);
 
         var runner = new WptTestRunner(
             failureImageDir: failureImagesDir,
-            verifyReferenceHtml: verifyReference);
+            verifyReferenceHtml: verifyReference,
+            passThresholdPercent: passThresholdPercent);
 
         protocolOut.WriteLine(JsonSerializer.Serialize(new WptWorkerResponse { Ready = true }, WorkerJsonOptions));
         protocolOut.Flush();
@@ -720,6 +761,7 @@ public class Program
         private readonly string? _failureImagesDir;
         private readonly bool _verifyReference;
         private readonly long _memoryLimitBytes;
+        private readonly double _passThresholdPercent;
         private Process? _process;
         private Task<string?>? _pendingResponse;
 
@@ -728,13 +770,15 @@ public class Program
             string referenceDir,
             string? failureImagesDir,
             bool verifyReference,
-            long memoryLimitBytes = 0)
+            long memoryLimitBytes = 0,
+            double passThresholdPercent = DefaultPassThresholdPercent)
         {
             _wptPath = wptPath;
             _referenceDir = referenceDir;
             _failureImagesDir = failureImagesDir;
             _verifyReference = verifyReference;
             _memoryLimitBytes = memoryLimitBytes;
+            _passThresholdPercent = passThresholdPercent;
         }
 
         internal int? CurrentProcessId
@@ -919,12 +963,16 @@ public class Program
 
         private Process StartWorkerProcess()
         {
+            // The worker runs the comparison, so the resolved threshold is passed
+            // explicitly rather than left to the worker's own default resolution.
             var startInfo = CreateCurrentProgramStartInfo([
                 "--wpt-worker",
                 "--wpt-dir",
                 _wptPath,
                 "--reference-dir",
                 _referenceDir,
+                "--pass-threshold",
+                _passThresholdPercent.ToString("R", CultureInfo.InvariantCulture),
             ]);
 
             if (!string.IsNullOrWhiteSpace(_failureImagesDir))
@@ -1105,6 +1153,51 @@ public class Program
         return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out memoryLimitMegabytes) &&
                memoryLimitMegabytes >= 0;
     }
+
+    /// <summary>
+    /// Resolves the pixel pass threshold, in percent, from (in order) the command line,
+    /// the <c>BROILER_WPT_PASS_THRESHOLD</c> environment variable, and the 99% default.
+    /// A test passes when its render is at least this percent identical to the reference.
+    /// </summary>
+    internal static bool TryResolvePassThreshold(
+        double? cliPassThresholdPercent,
+        out double passThresholdPercent,
+        out string? error)
+    {
+        passThresholdPercent = DefaultPassThresholdPercent;
+        error = null;
+
+        if (cliPassThresholdPercent.HasValue)
+        {
+            passThresholdPercent = cliPassThresholdPercent.Value;
+            return true;
+        }
+
+        var envPassThreshold = Environment.GetEnvironmentVariable(PassThresholdEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(envPassThreshold))
+        {
+            if (!TryParsePassThresholdPercent(envPassThreshold, out var parsedEnvPassThresholdPercent))
+            {
+                error = $"Error: '{PassThresholdEnvironmentVariable}' must be a percentage between 0 and 100.";
+                return false;
+            }
+
+            passThresholdPercent = parsedEnvPassThresholdPercent;
+        }
+
+        return true;
+    }
+
+    private static bool TryParsePassThresholdPercent(string value, out double passThresholdPercent)
+    {
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out passThresholdPercent) &&
+               passThresholdPercent >= 0 &&
+               passThresholdPercent <= 100;
+    }
+
+    /// <summary>Formats a percentage without trailing zeros (99, 99.5, 99.95).</summary>
+    internal static string FormatPassThreshold(double percent)
+        => percent.ToString("0.####", CultureInfo.InvariantCulture);
 
     private static bool TryParseRerunSelectionKind(string value, out RerunSelectionKind selectionKind)
     {
@@ -2492,6 +2585,10 @@ public class Program
         Console.WriteLine($"                             reported as {FailureCategory.MemoryLimitExceeded}. A worker whose own resident");
         Console.WriteLine("                             set reaches the cap is recycled between tests. 0 disables");
         Console.WriteLine($"                             (default: {DefaultRunTestMemoryLimitMegabytes}, env: {RunTestMemoryLimitEnvironmentVariable})");
+        Console.WriteLine("  --pass-threshold <PCT>     Percentage of pixels that must match the reference for a test");
+        Console.WriteLine("                             to pass; 99 means the render passes when it is at least 99%");
+        Console.WriteLine("                             identical to the Chromium reference");
+        Console.WriteLine($"                             (default: {FormatPassThreshold(DefaultPassThresholdPercent)}, env: {PassThresholdEnvironmentVariable})");
         Console.WriteLine("  --no-worker-isolation      Run tests in-process instead of the default worker process");
         Console.WriteLine("                             isolation. Useful for debugger sessions only.");
         Console.WriteLine("  --json-output <PATH>       Write structured JSON report to the given path");

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -789,19 +789,39 @@ internal sealed partial class WptTestRunner
 })();
 ";
 
+    /// <summary>
+    /// Percentage of pixels that must match the reference for a test to pass when no
+    /// other threshold is requested: 99% match, i.e. at most 1% of the pixels differ.
+    /// </summary>
+    public const double DefaultPassThresholdPercent = 99;
+
     private readonly int _width;
     private readonly int _height;
     private readonly string? _failureImageDir;
     private readonly bool _verifyReferenceHtml;
+    private readonly HTML.Core.IR.DeterministicRenderConfig _pixelDiffConfig;
 
     public WptTestRunner(int width = 1024, int height = 768, string? failureImageDir = null,
-        bool verifyReferenceHtml = false)
+        bool verifyReferenceHtml = false, double passThresholdPercent = DefaultPassThresholdPercent)
     {
         _width = width;
         _height = height;
         _failureImageDir = failureImageDir;
         _verifyReferenceHtml = verifyReferenceHtml;
+        _pixelDiffConfig = CreatePixelDiffConfig(passThresholdPercent);
     }
+
+    /// <summary>
+    /// Translates a pass threshold expressed as a percentage of matching pixels into the
+    /// diff-ratio form <see cref="PixelDiffRunner"/> compares against — 99% match becomes
+    /// a 0.01 maximum diff ratio. The colour tolerance stays at the deterministic-render
+    /// default; only the how-many-pixels-may-differ half is configurable.
+    /// </summary>
+    internal static HTML.Core.IR.DeterministicRenderConfig CreatePixelDiffConfig(double passThresholdPercent)
+        => new()
+        {
+            PixelDiffThreshold = Math.Clamp((100.0 - passThresholdPercent) / 100.0, 0.0, 1.0),
+        };
 
     /// <summary>
     /// Saves the rendered, reference, and diff bitmaps for a failing comparison
@@ -1398,7 +1418,7 @@ internal sealed partial class WptTestRunner
                 return null;
 
             using var refRender = RenderHtmlFileBitmap(refPath, wptRoot);
-            using var diff = PixelDiffRunner.Compare(testRender, refRender);
+            using var diff = PixelDiffRunner.Compare(testRender, refRender, _pixelDiffConfig);
             if (!diff.IsMatch)
                 return null;
 
@@ -1691,7 +1711,7 @@ internal sealed partial class WptTestRunner
 
             using (reference)
             {
-                using var diff = PixelDiffRunner.Compare(rendered, reference);
+                using var diff = PixelDiffRunner.Compare(rendered, reference, _pixelDiffConfig);
 
                 // Compute percent match for every comparison so it can be
                 // included in the logfile output and used for sorting.
@@ -1723,7 +1743,7 @@ internal sealed partial class WptTestRunner
                     try
                     {
                         using var refGolden = HTML.Image.BBitmap.Decode(refGoldenPath);
-                        using var refDiff = PixelDiffRunner.Compare(rendered, refGolden);
+                        using var refDiff = PixelDiffRunner.Compare(rendered, refGolden, _pixelDiffConfig);
                         if (refDiff.IsMatch)
                         {
                             return new WptTestResult
@@ -1820,7 +1840,7 @@ internal sealed partial class WptTestRunner
             rendered = RenderHtmlFileBitmap(testPath, wptRoot);
             reference = RenderHtmlFileBitmap(refHtmlPath, wptRoot);
 
-            using var diff = PixelDiffRunner.Compare(rendered, reference);
+            using var diff = PixelDiffRunner.Compare(rendered, reference, _pixelDiffConfig);
             double matchPct = (1.0 - diff.DiffRatio) * 100;
 
             if (diff.IsMatch)


### PR DESCRIPTION
Adds a configurable pixel pass threshold to the WPT test runner, allowing tests to pass or fail based on a customizable percentage of matching pixels rather than the hard-coded 99% default.

## Summary

The WPT runner previously required renders to be 99% identical to Chromium references to pass. This change makes that threshold configurable via:
- `--pass-threshold <percent>` command-line flag
- `BROILER_WPT_PASS_THRESHOLD` environment variable
- `pass_threshold` input in the GitHub Actions workflow

The resolved threshold is passed through to worker processes and used consistently across all pixel comparisons.

## Key Changes

- **Program.cs**: Added `--pass-threshold` CLI argument parsing and `TryResolvePassThreshold()` method to resolve the threshold from CLI, environment, or default (99%). The resolved value is passed to `WptTestRunner` and `WptWorkerClient`.
- **WptTestRunner.cs**: 
  - Added `DefaultPassThresholdPercent` constant (99)
  - Constructor now accepts `passThresholdPercent` parameter
  - Added `CreatePixelDiffConfig()` static method to convert percentage threshold to diff-ratio form for `PixelDiffRunner`
  - All `PixelDiffRunner.Compare()` calls now use the configured threshold
- **GitHub Actions**: Updated `run-wpt-shard` action and `wpt-tests` workflow to accept and pass through `pass-threshold` input
- **Tests**: Added comprehensive `WptPassThresholdTests` covering:
  - Default resolution (99%)
  - CLI override precedence
  - Environment variable usage
  - Invalid input rejection
  - Percentage-to-diff-ratio conversion
  - End-to-end pass/fail behavior with exact pixel mismatch

## Implementation Details

The threshold is converted from a percentage (e.g., 99% match) to a diff ratio (0.01 maximum difference) via `(100 - percent) / 100`, clamped to [0, 1]. This integrates with the existing `PixelDiffRunner` comparison infrastructure without changing its core logic.

Worker processes receive the resolved threshold explicitly via `--pass-threshold` to ensure consistent comparison across parent and worker runs, critical for retry passes and shard reproducibility.

https://claude.ai/code/session_01TEHMjMNHncY9npzudTSXG7