### PR TITLE
Add WPT reftest mode: render both test and reference with Broiler

### DIFF
--- a/.github/actions/run-wpt-reftest-shard/action.yml
+++ b/.github/actions/run-wpt-reftest-shard/action.yml
@@ -1,0 +1,211 @@
+name: Run WPT reftest shard
+description: >
+  Provision a runner, run one shard of the WPT *reftest* suite, and upload its
+  results as an artifact. The reftest counterpart of ./.github/actions/run-wpt-shard,
+  and deliberately the same shape so the initial pass and the end-of-workflow retry
+  pass share one definition of how a shard is measured.
+
+  What it does NOT do is the point: no Playwright, no Chromium, no reference-image
+  cache. A reftest declares its own reference inside the WPT checkout, and both the
+  test and that reference are rendered by Broiler, so a shard needs nothing but the
+  checkout and the .NET SDK. That also removes the browser-provisioning outage this
+  suite's sibling has to defend against (issue #1534) — there is no browser to fail
+  to download.
+
+inputs:
+  shard-index:
+    description: Zero-based index of the shard to run.
+    required: true
+  shard-count:
+    description: Total number of shards the reftest suite is split into.
+    required: true
+  attempt-suffix:
+    description: >
+      Suffix appended to this attempt's artifact and result-file names — empty for
+      the first attempt, "-retry" for the end-of-workflow rerun. The names have to
+      differ because every shard artifact is downloaded into one merged directory;
+      scripts/merge-wpt-shards.py reads the suffix back off the file name so a retry
+      supersedes the attempt it replaces instead of being summed alongside it.
+    required: false
+    default: ''
+  subset:
+    description: Semicolon-separated WPT subset patterns, or empty for every reftest.
+    required: false
+    default: ''
+  rerun-failed:
+    description: >
+      "true" to rerun only the previously-failed reftests listed in failed-tests-file.
+    required: false
+    default: 'false'
+  failed-tests-file:
+    description: Path to the committed failing-reftest manifest used by rerun-failed.
+    required: true
+  cache-epoch:
+    description: Cache epoch; bumping it refreshes the WPT checkout.
+    required: true
+  wpt-checkout-dir:
+    description: Directory holding the (cached) WPT checkout.
+    required: true
+  results-dir:
+    description: Directory the runner writes its results into.
+    required: true
+  test-timeout-seconds:
+    description: Per-test timeout in seconds.
+    required: true
+  memory-limit-mb:
+    description: Per-test RAM cap in MiB (0 disables).
+    required: true
+  pass-threshold:
+    description: >
+      Percentage of pixels that must match for a reftest to pass — here, between
+      Broiler's render of the test and Broiler's render of the test's own reference
+      (99 = the two are at least 99% identical).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: |
+          8.0.x
+          10.0.x
+
+    # Node is deliberately absent — it is the golden-image shard's Playwright
+    # dependency and nothing here needs it. Python stays: the collect step below
+    # folds the runner's failure marker into the shard status file with it.
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Restore WPT checkout
+      uses: actions/cache@v5
+      with:
+        path: ${{ inputs.wpt-checkout-dir }}
+        key: wpt-checkout-${{ inputs.cache-epoch }}
+
+    # Apply any submodule fix that could not be pushed to its remote (push 403 →
+    # captured under patches/) and is not yet in the pinned pointer, so the runner
+    # exercises it. Same mechanism, same patch set, and for the same reason as the
+    # golden-image suite: without this step those fixes are absent from the run no
+    # matter how many times it is re-run, because their remotes are outside the
+    # session's GitHub scope. The build compiles submodule source in place, so
+    # patching the checked-out working tree is enough — no pointer bump. A patch
+    # gone stale against a drifted pointer fails this step loudly rather than being
+    # skipped, which is the whole point of having the step.
+    - name: Apply pending submodule patches
+      shell: bash
+      run: bash scripts/apply-pending-wpt-patches.sh
+
+    - name: Run WPT reftest shard ${{ inputs.shard-index }}${{ inputs.attempt-suffix }}
+      id: wpt
+      shell: bash
+      env:
+        SHARD_INDEX: ${{ inputs.shard-index }}
+        SHARD_COUNT: ${{ inputs.shard-count }}
+        SUBSET: ${{ inputs.subset }}
+        RERUN_FAILED: ${{ inputs.rerun-failed }}
+        FAILED_TESTS_FILE: ${{ inputs.failed-tests-file }}
+        RESULTS_DIR: ${{ inputs.results-dir }}
+        BROILER_WPT_TIMEOUT_SECONDS: ${{ inputs.test-timeout-seconds }}
+        BROILER_WPT_MEMORY_LIMIT_MB: ${{ inputs.memory-limit-mb }}
+        # Pixel pass threshold for the test-vs-reference comparison. The runner
+        # reads the variable itself and forwards the resolved value to its workers,
+        # so the first pass and the retry pass use the same bar.
+        BROILER_WPT_PASS_THRESHOLD: ${{ inputs.pass-threshold }}
+        # Deliberately NOT set here, unlike the golden-image suite: deferring
+        # promise_test bodies exists to freeze the DOM at the moment Chromium's
+        # reference generator screenshots (`load`). A reftest has no Chromium
+        # capture to line up with — the test and its reference are both taken at
+        # Broiler's own capture point — so the override would only make this run
+        # measure something other than what the page does.
+      run: |
+        # --wpt-dir is deliberately not passed: left to its default the script
+        # clones the checkout itself, so a cache miss costs a clone instead of
+        # failing the shard. The cached path and that default are the same
+        # directory (tests/wpt/checkout).
+        ARGS=(--shard-index "$SHARD_INDEX" --shard-count "$SHARD_COUNT")
+        ARGS+=(--output-dir "$RESULTS_DIR")
+        if [ -n "$SUBSET" ]; then
+          ARGS+=(--subset "$SUBSET")
+        fi
+        if [ "$RERUN_FAILED" = "true" ]; then
+          # Incremental: rerun only the previously-failed reftests. Nothing has to
+          # be regenerated first — a reftest's baseline is the checkout — so this
+          # is simply a narrower test list.
+          ARGS+=(--rerun-json "$FAILED_TESTS_FILE")
+        fi
+        EXIT=0
+        bash scripts/run-wpt-reftests.sh "${ARGS[@]}" || EXIT=$?
+        echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
+        echo "Reftest shard $SHARD_INDEX finished (exit $EXIT)."
+        exit "$EXIT"
+
+    - name: Collect shard result
+      if: always()
+      shell: bash
+      env:
+        RESULTS_DIR: ${{ inputs.results-dir }}
+        SHARD_INDEX: ${{ inputs.shard-index }}
+        ATTEMPT_SUFFIX: ${{ inputs.attempt-suffix }}
+        WPT_EXIT_CODE: ${{ steps.wpt.outputs.exit_code }}
+      run: |
+        mkdir -p shard-out
+        STEM="wpt-shard-${SHARD_INDEX}${ATTEMPT_SUFFIX}"
+        cp "$RESULTS_DIR/wpt-results.json" "shard-out/${STEM}.json" 2>/dev/null || true
+        cp "$RESULTS_DIR/wpt-results.log"  "shard-out/${STEM}.log"  2>/dev/null || true
+        EXIT="$WPT_EXIT_CODE"
+        if ! [[ "$EXIT" =~ ^[0-9]+$ ]]; then
+          EXIT=1
+        fi
+        # The runner leaves a marker when the shard could not run a single test.
+        # Folding it into the status file lets the merge step name the real cause
+        # instead of guessing at one.
+        python3 - "$SHARD_INDEX" "$EXIT" \
+          "$RESULTS_DIR/wpt-shard-failure.json" \
+          "shard-out/${STEM}-status.json" <<'PY'
+        import json, sys
+
+        shard_index, exit_code, marker_path, out_path = sys.argv[1:5]
+        status = {"shardIndex": int(shard_index), "exitCode": int(exit_code)}
+        try:
+            with open(marker_path, encoding="utf-8") as handle:
+                marker = json.load(handle)
+        except (OSError, ValueError):
+            marker = None
+        if isinstance(marker, dict):
+            if marker.get("reason"):
+                status["failureReason"] = str(marker["reason"])
+            if marker.get("detail"):
+                status["failureDetail"] = str(marker["detail"])
+        with open(out_path, "w", encoding="utf-8") as handle:
+            json.dump(status, handle)
+            handle.write("\n")
+        PY
+
+    - name: Shard step summary
+      if: always()
+      shell: bash
+      env:
+        RESULTS_DIR: ${{ inputs.results-dir }}
+        SHARD_INDEX: ${{ inputs.shard-index }}
+        SHARD_COUNT: ${{ inputs.shard-count }}
+        ATTEMPT_SUFFIX: ${{ inputs.attempt-suffix }}
+      run: |
+        SUMMARY="$RESULTS_DIR/wpt-summary.txt"
+        if [ -f "$SUMMARY" ]; then
+          LABEL="WPT reftest shard ${SHARD_INDEX}/${SHARD_COUNT}"
+          if [ -n "$ATTEMPT_SUFFIX" ]; then
+            LABEL="$LABEL (retry)"
+          fi
+          echo "### $LABEL" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+    - uses: actions/upload-artifact@v6
+      if: always()
+      with:
+        name: wpt-shard-${{ inputs.shard-index }}${{ inputs.attempt-suffix }}
+        path: shard-out

--- a/.github/workflows/wpt-reftests.yml
+++ b/.github/workflows/wpt-reftests.yml
@@ -1,0 +1,467 @@
+name: WPT Reftests
+
+# Web Platform Tests **reftest** runner — Broiler on both sides, no other engine.
+#
+# This is the sibling of wpt-tests.yml and is modelled directly on it: same plan →
+# prepare → run → retry → report → persist-failed shape, same sharding, same merge
+# and issue-filing tooling. One thing differs, and it is the reason the workflow
+# exists.
+#
+# wpt-tests.yml measures Broiler against a Chromium screenshot: every shard
+# downloads Chromium through Playwright, screenshots each test, and compares
+# Broiler's render to that PNG. A reftest needs none of that. A WPT reftest states
+# its own correct rendering inside the checkout —
+#
+#     <link rel="match"    href="foo-ref.html">   the render must equal this
+#     <link rel="mismatch" href="bar-ref.html">   the render must differ from this
+#
+# — so this workflow runs *only* the tests carrying such a declaration (or a
+# reference image), renders BOTH the test and its reference with Broiler, and
+# compares the two. Tests with no reference are not run at all, and no reference
+# images are generated, cached, or read.
+#
+# What that buys and what it costs, stated plainly:
+#   + No browser download, so no Chromium provisioning outage (issue #1534) and a
+#     far cheaper run — no Playwright cache, no reference cache, no epoch to bump
+#     for references.
+#   + A failure is never a Chromium-vs-Broiler font, scrollbar, or anti-aliasing
+#     difference. Test and reference go through the same renderer, so a mismatch is
+#     a genuine disagreement with what WPT says the test should look like.
+#   − A bug that hits the test and its reference identically still passes here. This
+#     suite proves self-consistency against WPT's own reference, not correctness
+#     against a shipping browser. It complements wpt-tests.yml; it does not replace
+#     it, and its pass rate is not comparable to that suite's.
+#
+# The manually dispatched workflow can target every reftest, a subset, a single
+# shard, or only the previously-failed reftests. Every run merges the shard results
+# and, when failures exist, files the same two GitHub issues the golden-image suite
+# does (most common failure groups, and the run's biggest problems), titled so the
+# two suites' issues are never confused.
+#
+# Any shard that aborts abnormally — evicted runner, hard crash, i.e. no conclusive
+# report — is rerun once at the end of the workflow by the `retry` job, before the
+# results are merged. A rerun shard's artifacts carry a `-retry` suffix, and
+# merge-wpt-shards.py keeps only the latest attempt per shard. Shards that merely
+# *fail* tests are not rerun — they already measured their slice.
+
+on:
+  workflow_dispatch:
+    inputs:
+      subset:
+        description: >
+          Semicolon-separated WPT subset patterns with optional wildcards, applied
+          before the reftest filter. Examples: "css/css-flexbox", "css/CSS2;css/css-*".
+          Empty = every reftest in the checkout.
+        required: false
+        default: ''
+      shard_index:
+        description: Zero-based shard index to run, or -1 for all shards.
+        required: false
+        default: '-1'
+      rerun_failed_only:
+        description: >
+          Rerun only the previously-failed reftests from the committed manifest
+          (tests/wpt-baseline/failed-reftests.json).
+        type: boolean
+        required: false
+        default: false
+      test_timeout_seconds:
+        description: Per-test timeout in seconds.
+        required: false
+        default: '30'
+      memory_limit_mb:
+        description: >
+          Per-test RAM cap in MiB, measured as growth of the rendering process's
+          resident set. A test that passes it is aborted and reported as
+          MemoryLimitExceeded; a worker that reaches it is recycled between tests.
+          0 disables the cap.
+        required: false
+        default: '1024'
+      pass_threshold:
+        description: >
+          Pixel pass threshold in percent: a reftest passes when Broiler's render of
+          the test is at least this percent identical to Broiler's render of the
+          test's own reference (99 = at most 1% of the pixels may differ).
+        required: false
+        default: '99'
+      most_common_problems_limit:
+        description: Maximum number of common failure groups to include in the GitHub issue.
+        required: false
+        default: '10'
+      biggest_problems_limit:
+        description: Maximum number of biggest problems to include in the second (severity-focused) GitHub issue.
+        required: false
+        default: '3'
+
+permissions:
+  contents: write   # persist-failed commits the failing-reftest manifest
+  issues: write
+
+env:
+  # Bump to invalidate the cached WPT checkout. Unlike the golden-image suite there
+  # are no cached reference images behind this, so bumping it costs one clone.
+  CACHE_EPOCH: '1'
+  SHARD_COUNT: '8'
+  WPT_CHECKOUT_DIR: tests/wpt/checkout
+  RESULTS_DIR: tests/wpt-reftest-results
+  # Its own manifest: a reftest failure and a golden-image failure are different
+  # measurements of the same test, and folding them into one file would let either
+  # suite's rerun set be silently rewritten by the other's.
+  FAILED_TESTS_FILE: tests/wpt-baseline/failed-reftests.json
+  MOST_COMMON_PROBLEMS_LIMIT: ${{ github.event.inputs.most_common_problems_limit || '10' }}
+  BIGGEST_PROBLEMS_LIMIT: ${{ github.event.inputs.biggest_problems_limit || '3' }}
+
+jobs:
+  # ── Resolve the shard matrix and whether to run incrementally ────────────
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      shard-matrix: ${{ steps.resolve.outputs.shard-matrix }}
+      rerun-failed: ${{ steps.resolve.outputs.rerun-failed }}
+      expected-shards: ${{ steps.resolve.outputs.expected-shards }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Resolve plan
+        id: resolve
+        shell: bash
+        env:
+          SELECTED_SHARD_INDEX: ${{ github.event.inputs.shard_index || '-1' }}
+          RERUN_FAILED_ONLY: ${{ github.event.inputs.rerun_failed_only || 'false' }}
+        run: |
+          python <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          shard_count = int(os.environ["SHARD_COUNT"])
+          try:
+              selected = int(os.environ["SELECTED_SHARD_INDEX"])
+          except ValueError:
+              sys.exit(f"shard_index must be an integer, got {os.environ['SELECTED_SHARD_INDEX']!r}")
+
+          if selected == -1:
+              matrix = [{"shard-index": i} for i in range(shard_count)]
+          elif 0 <= selected < shard_count:
+              matrix = [{"shard-index": selected}]
+          else:
+              sys.exit(f"shard_index must be -1 or between 0 and {shard_count - 1}, got {selected}")
+
+          rerun_requested = os.environ["RERUN_FAILED_ONLY"].strip().lower() == "true"
+          rerun_failed = rerun_requested and Path(os.environ["FAILED_TESTS_FILE"]).exists()
+
+          # The exact set of shard indexes this run dispatches. The merge step uses
+          # it to spot a dispatched shard that uploaded nothing (its job cancelled
+          # mid-run), which would otherwise be silently dropped from the merged
+          # totals rather than flagged as an incomplete shard.
+          expected_shards = ",".join(str(entry["shard-index"]) for entry in matrix)
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"shard-matrix={json.dumps(matrix)}\n")
+              fh.write(f"rerun-failed={'true' if rerun_failed else 'false'}\n")
+              fh.write(f"expected-shards={expected_shards}\n")
+          PY
+
+  # ── Clone + cache the WPT checkout once (shared by all shards) ────────────
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Cache WPT checkout
+        id: cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.WPT_CHECKOUT_DIR }}
+          key: wpt-checkout-${{ env.CACHE_EPOCH }}
+
+      - name: Clone WPT (shallow) on cache miss
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          git clone --single-branch --branch master --depth 1 \
+            https://github.com/web-platform-tests/wpt.git "$WPT_CHECKOUT_DIR"
+
+  # ── Run one shard of the reftest suite ──────────────────────────────────
+  run:
+    needs: [plan, prepare]
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.plan.outputs.shard-matrix) }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      # Every provisioning/run/collect/upload step lives in the composite action,
+      # so the retry pass below runs a shard exactly the way this pass did.
+      - uses: ./.github/actions/run-wpt-reftest-shard
+        with:
+          shard-index: ${{ matrix.shard-index }}
+          shard-count: ${{ env.SHARD_COUNT }}
+          subset: ${{ github.event.inputs.subset || '' }}
+          rerun-failed: ${{ needs.plan.outputs.rerun-failed }}
+          failed-tests-file: ${{ env.FAILED_TESTS_FILE }}
+          cache-epoch: ${{ env.CACHE_EPOCH }}
+          wpt-checkout-dir: ${{ env.WPT_CHECKOUT_DIR }}
+          results-dir: ${{ env.RESULTS_DIR }}
+          test-timeout-seconds: ${{ github.event.inputs.test_timeout_seconds || '30' }}
+          memory-limit-mb: ${{ github.event.inputs.memory_limit_mb || '1024' }}
+          pass-threshold: ${{ github.event.inputs.pass_threshold || '99' }}
+
+  # ── Decide which shards aborted abnormally and deserve one rerun ─────────
+  #
+  # "Abnormally" is not "some tests failed": a shard that finishes and reports
+  # failures exits 1 with a full report, and rerunning it would only burn time to
+  # produce the same answer. What is retried is a shard that produced *no
+  # conclusive report* — its runner was evicted mid-run, or it crashed hard enough
+  # to lose its report. Those are exactly the shards merge-wpt-shards.py already
+  # flags as incomplete, so the same code decides here rather than a second,
+  # drifting definition of "incomplete".
+  retry-plan:
+    needs: [plan, run]
+    # !cancelled() rather than always(): if a human cancels the workflow, every
+    # shard looks incomplete and retrying them all is the opposite of what was
+    # asked. A single evicted shard does not cancel the run, so it still retries.
+    if: ${{ !cancelled() && needs.run.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    outputs:
+      retry-matrix: ${{ steps.detect.outputs.incomplete_shard_matrix }}
+      retry-shards: ${{ steps.detect.outputs.incomplete_shard_indexes }}
+      has-retries: ${{ steps.detect.outputs.has_incomplete_shards }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      # Tolerated failure: when *every* shard died before its upload step there is
+      # no artifact to match, and download-artifact treats that as an error. That
+      # case is precisely the one worth retrying, so it must not stop the job — the
+      # detect step below then sees an empty directory and flags every dispatched
+      # shard.
+      - name: Download shard results
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          pattern: wpt-shard-*
+          path: shard-results
+          merge-multiple: true
+
+      - name: Detect shards that aborted abnormally
+        id: detect
+        shell: bash
+        run: |
+          mkdir -p shard-results
+          python scripts/merge-wpt-shards.py \
+            --shard-dir shard-results \
+            --expected-shards "${{ needs.plan.outputs.expected-shards }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Report the retry plan
+        shell: bash
+        env:
+          RETRY_SHARDS: ${{ steps.detect.outputs.incomplete_shard_indexes }}
+        run: |
+          if [ -n "$RETRY_SHARDS" ]; then
+            echo "### WPT reftest retry pass" >> "$GITHUB_STEP_SUMMARY"
+            echo "Rerunning shard(s) that aborted abnormally: \`$RETRY_SHARDS\`." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  # ── Rerun the aborted shards, once, at the end of the workflow ───────────
+  #
+  # One retry pass only: a shard that aborts twice is reported as incomplete just
+  # as before, rather than looping the workflow for hours. Each retry uploads to
+  # `wpt-shard-<i>-retry`, whose files carry the same `-retry` suffix, so the merge
+  # step can tell the two attempts apart in the flattened download directory and
+  # let the retry supersede — not add to — the attempt it replaces.
+  retry:
+    needs: [plan, prepare, retry-plan]
+    if: ${{ !cancelled() && needs.retry-plan.outputs.has-retries == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.retry-plan.outputs.retry-matrix) }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/run-wpt-reftest-shard
+        with:
+          shard-index: ${{ matrix.shard-index }}
+          shard-count: ${{ env.SHARD_COUNT }}
+          attempt-suffix: '-retry'
+          subset: ${{ github.event.inputs.subset || '' }}
+          rerun-failed: ${{ needs.plan.outputs.rerun-failed }}
+          failed-tests-file: ${{ env.FAILED_TESTS_FILE }}
+          cache-epoch: ${{ env.CACHE_EPOCH }}
+          wpt-checkout-dir: ${{ env.WPT_CHECKOUT_DIR }}
+          results-dir: ${{ env.RESULTS_DIR }}
+          test-timeout-seconds: ${{ github.event.inputs.test_timeout_seconds || '30' }}
+          memory-limit-mb: ${{ github.event.inputs.memory_limit_mb || '1024' }}
+          pass-threshold: ${{ github.event.inputs.pass_threshold || '99' }}
+
+  # ── Merge shard results; file an issue when there are failures ───────────
+  #
+  # Depends on `retry` as well as `run` so the merge sees the reruns' artifacts;
+  # `always()` keeps it running when the retry job was skipped (nothing aborted)
+  # or itself failed.
+  report:
+    needs: [plan, run, retry]
+    if: always() && needs.run.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Download shard results
+        uses: actions/download-artifact@v7
+        with:
+          pattern: wpt-shard-*
+          path: shard-results
+          merge-multiple: true
+
+      - name: Merge shard results
+        id: merge
+        shell: bash
+        env:
+          WPT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python scripts/merge-wpt-shards.py \
+            --shard-dir shard-results \
+            --merged-json wpt-merged/wpt-results.json \
+            --issue-md wpt-merged/issue.md \
+            --biggest-issue-md wpt-merged/biggest-issue.md \
+            --problem-limit "$MOST_COMMON_PROBLEMS_LIMIT" \
+            --biggest-problem-limit "$BIGGEST_PROBLEMS_LIMIT" \
+            --expected-shards "${{ needs.plan.outputs.expected-shards }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Publish merged summary
+        if: always()
+        run: |
+          if [ -f wpt-merged/issue.md ]; then
+            cat wpt-merged/issue.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: wpt-reftests-merged
+          path: wpt-merged
+
+      - name: Create GitHub issue for the most common failures
+        if: steps.merge.outputs.create_issue == 'true'
+        uses: actions/github-script@v8
+        env:
+          FAILED_COUNT: ${{ steps.merge.outputs.failed_count }}
+          INCOMPLETE_SHARD_COUNT: ${{ steps.merge.outputs.incomplete_shard_count }}
+        with:
+          # Prefer the configured PAT/App token, then use this workflow's token.
+          github-token: ${{ secrets.ISSUE_TOKEN || github.token }}
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('wpt-merged/issue.md', 'utf8').trim();
+            const today = new Date().toISOString().slice(0, 10);
+            const incomplete = Number(process.env.INCOMPLETE_SHARD_COUNT || 0);
+            const failureSummary = incomplete > 0
+              ? `${process.env.FAILED_COUNT} failing reftest(s), ${incomplete} incomplete shard(s)`
+              : `${process.env.FAILED_COUNT} failing reftest(s)`;
+            // "reftest run" in the title, so these never read as the golden-image
+            // suite's issues: the two measure the same tests against different
+            // baselines and their counts are not comparable.
+            const title = `WPT reftest run: ${failureSummary} (${today})`;
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+            });
+            core.info(`Created issue #${issue.data.number}: ${issue.data.html_url}`);
+
+      - name: Create GitHub issue for the biggest problems
+        if: steps.merge.outputs.create_biggest_issue == 'true'
+        uses: actions/github-script@v8
+        env:
+          BIGGEST_PROBLEM_COUNT: ${{ steps.merge.outputs.biggest_problem_count }}
+        with:
+          # Prefer the configured PAT/App token, then use this workflow's token.
+          github-token: ${{ secrets.ISSUE_TOKEN || github.token }}
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('wpt-merged/biggest-issue.md', 'utf8').trim();
+            const today = new Date().toISOString().slice(0, 10);
+            const count = Number(process.env.BIGGEST_PROBLEM_COUNT || 0);
+            const title = `WPT reftest run: top ${count} biggest problem(s) (${today})`;
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+            });
+            core.info(`Created biggest-problems issue #${issue.data.number}: ${issue.data.html_url}`);
+
+  # ── Persist the failing-reftest manifest for incremental reruns ──────────
+  persist-failed:
+    needs: [run, retry]
+    # Refresh the manifest after any run that actually executed shards — success OR
+    # failure. The run job reports `failure` precisely when some tests failed (the
+    # runner exits 1 on any failure), which is exactly when there are failures worth
+    # recording; gating on `success` alone would skip persistence in that case and
+    # never record them. `skipped`/`cancelled` are excluded (the shards never ran).
+    #
+    # Persistence is scope-aware (merge-wpt-shards.py --merge-into): only tests this
+    # run actually exercised are refreshed, while entries for tests outside the
+    # run's subset/shards are preserved. So a partial subset/single-shard/rerun run
+    # updates just its own slice without shrinking the manifest — and a crashed
+    # shard leaves its tests' existing entries untouched rather than dropping them.
+    #
+    # `retry` is in `needs` only so the reruns' artifacts are on hand before the
+    # merge; it is not part of the gate, since it is skipped on the normal path
+    # where nothing aborted.
+    if: >-
+      always()
+      && (needs.run.result == 'success' || needs.run.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref_name }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Download shard results
+        uses: actions/download-artifact@v7
+        with:
+          pattern: wpt-shard-*
+          path: shard-results
+          merge-multiple: true
+
+      - name: Merge failures into the manifest
+        run: |
+          python scripts/merge-wpt-shards.py \
+            --shard-dir shard-results \
+            --merge-into "$FAILED_TESTS_FILE" \
+            --merged-json "$FAILED_TESTS_FILE"
+
+      # Same race as the golden-image suite: the sharded run takes long enough that
+      # the branch has usually moved on, so the push has to be rebuilt on the
+      # current tip rather than assumed to fast-forward.
+      - name: Commit manifest
+        run: |
+          bash scripts/ci-commit-generated-results.sh \
+            --branch "${{ github.ref_name }}" \
+            --message "ci: update WPT failed-reftests manifest [skip ci]" \
+            "$FAILED_TESTS_FILE"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,14 @@ something to attempt from inside the container.
   Pixel pass threshold defaults to 99% match (≤1% differing pixels) and is
   configurable: `--pass-threshold <percent>`, `BROILER_WPT_PASS_THRESHOLD`, or the
   `pass_threshold` input of the WPT Tests workflow.
+- WPT **reftest** runner — a second, independent suite that uses no other engine:
+  `./scripts/run-wpt-reftests.sh --wpt-dir tests/wpt/checkout [--subset <path>]`,
+  or `dotnet run --project src/Broiler.Wpt -- --wpt-dir <dir> --reftests-only`.
+  It runs only the tests declaring `<link rel="match">` / `<link rel="mismatch">`
+  (or a reference image) and renders **both** the test and its reference with
+  Broiler — no Chromium, no reference-image directory. CI: the `WPT Reftests`
+  workflow. Its pass rate is not comparable to the golden-image suite's; see
+  `docs/wpt-reftests.md`.
 - WPT per-test limits: 30s timeout (`--timeout`, `BROILER_WPT_TIMEOUT_SECONDS`)
   and a 1024 MiB RAM cap (`--memory-limit-mb`, `BROILER_WPT_MEMORY_LIMIT_MB`,
   0 disables). The cap is on the *growth* of the rendering process's resident

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -95,6 +95,15 @@ The current WPT artifacts remain the evidence source:
 - Re-run the Google comparison against a recorded input and Chromium revision;
   record actual milestone measurements rather than inferring compliance from API
   presence.
+- Cross-check the golden-image suite against the engine-independent one. The
+  [WPT Reftests](../.github/workflows/wpt-reftests.yml) workflow decides the
+  reftest half of the corpus with no second engine — Broiler renders both the
+  test and the `rel=match`/`rel=mismatch` reference it declares — so a test
+  failing there is disagreeing with WPT's own statement of the result rather
+  than with a Chromium screenshot. A test that fails the golden-image suite but
+  passes here is evidence the golden, not the engine, is the outlier; the
+  converse is a real defect the Chromium comparison happened to mask. See
+  [WPT reftests](wpt-reftests.md).
 - Keep prioritized WPT failures in generated reports and component roadmaps.
   Root tracking should cover only cross-component runner, timeout, reference, and
   ownership problems. The worst-scoring pixel mismatches of the current run, with

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -1,0 +1,118 @@
+# WPT reftests — Broiler against WPT's own references
+
+The [WPT Reftests](../.github/workflows/wpt-reftests.yml) workflow runs the half
+of the Web Platform Tests corpus that carries its own answer, and decides each
+test **without any other rendering engine**.
+
+## What a reftest is, and why it needs no reference image
+
+A WPT reftest states its correct rendering inside the checkout, as a link in the
+test document:
+
+```html
+<link rel="match"    href="foo-ref.html">   <!-- must render identically to this -->
+<link rel="mismatch" href="bar-notref.html"><!-- must NOT render identically to this -->
+```
+
+The reference is deliberately written to be simple — it produces the same picture
+using only features the test does not exercise. So the pair can be checked by one
+engine on its own: render the test, render the reference, compare the two
+bitmaps. That is what this suite does, with Broiler on both sides.
+
+The main suite ([WPT Tests](../.github/workflows/wpt-tests.yml)) works the other
+way: every shard downloads Chromium through Playwright, screenshots each test,
+and compares Broiler's render against that PNG. The two suites answer different
+questions and their pass rates are **not comparable**.
+
+|                         | `wpt-tests.yml` (golden images)             | `wpt-reftests.yml` (this suite)                    |
+| ----------------------- | ------------------------------------------- | -------------------------------------------------- |
+| Baseline                | Chromium screenshot of the test             | Broiler's render of the test's declared reference   |
+| Tests run               | every discovered document                   | only those declaring a reference                    |
+| Needs a browser         | yes (Playwright Chromium, cached)           | no                                                  |
+| A failure can be        | a real bug, **or** a font/scrollbar/AA difference between engines, **or** a stale golden | a real disagreement with what WPT says the test should look like |
+| Blind spot              | Chromium missing the feature under test     | a bug that hits the test and its reference alike    |
+
+The trade is worth stating plainly: this suite cannot catch a defect that damages
+the test and its reference identically, because both go through the same
+renderer. In exchange nothing is ever attributed to Broiler that is really a
+cross-engine rendering difference, and a run needs no browser download — which
+also removes the browser-provisioning outage the golden-image suite has to defend
+against ([issue #1534](https://github.com/Broiler-Platform/Broiler/issues/1534)).
+
+## Running it
+
+CI: **Actions → WPT Reftests → Run workflow.** Inputs mirror the golden-image
+suite — `subset`, `shard_index`, `rerun_failed_only`, `test_timeout_seconds`,
+`memory_limit_mb`, `pass_threshold`, and the two issue-size limits.
+
+Locally:
+
+```sh
+# Every reftest in a checkout
+./scripts/run-wpt-reftests.sh --wpt-dir tests/wpt/checkout
+
+# One directory, with the failing renders saved for triage
+./scripts/run-wpt-reftests.sh --wpt-dir tests/wpt/checkout \
+    --subset "css/css-flexbox" --failure-images /tmp/reftest-failures
+```
+
+Or the runner directly:
+
+```sh
+dotnet run --project src/Broiler.Wpt -- \
+    --wpt-dir tests/wpt/checkout --reftests-only [--subset <path>]
+```
+
+`--reftests-only` is the whole switch: it narrows discovery to tests with a
+resolvable reference and decides each one by rendering both sides.
+`--reference-dir` is ignored in this mode and nothing reads or writes the
+reference-image tree.
+
+## How a test is decided
+
+Implemented in
+[`WptTestRunner.RunReferenceTest`](../src/Broiler.Wpt/WptTestRunner.cs).
+
+1. **Membership.** A test is in the suite when it declares at least one
+   `rel="match"` / `rel="mismatch"` href that resolves to a file present on disk
+   (root-relative hrefs map under the WPT root; query and fragment are stripped).
+   Everything else — including a test whose href dangles — is dropped before the
+   run rather than reported as skipped, so the totals describe only tests the
+   suite could actually decide.
+2. **Render.** The test is rendered by Broiler. A reference href naming a bitmap
+   (`.png`, `.jpg`, …) is decoded as-is; any other reference is rendered by
+   Broiler too.
+3. **Compare** at the run's pixel pass threshold (99% by default, i.e. at most 1%
+   of pixels may differ) — the same threshold and comparer the golden-image suite
+   uses.
+4. **Verdict.** A `rel="match"` reference must be reproduced; with several of
+   them the test passes on the first one it reproduces (WPT's own rule) and the
+   closest candidate is what a failure reports. A test whose references are all
+   `rel="mismatch"` passes only when it differs from every one of them.
+
+Manual tests, variant tests, and media-playback tests are skipped exactly as in
+the golden-image path. Reference *chains* — a reference that itself declares a
+reference — are not followed; the declared reference is rendered as written,
+which is what the chain asserts it looks like anyway.
+
+## CI shape
+
+The workflow is a copy of `wpt-tests.yml` with the Chromium stage removed, so
+everything downstream is shared rather than reimplemented:
+
+- 8 deterministic shards, the same FNV-1a(relative-path) assignment.
+- One composite action, [`run-wpt-reftest-shard`](../.github/actions/run-wpt-reftest-shard/action.yml),
+  used by both the initial pass and the end-of-workflow retry pass, so a retried
+  shard is measured exactly like the attempt it replaces.
+- `scripts/merge-wpt-shards.py` merges the shards, detects shards that aborted
+  abnormally, files the two failure issues, and folds failures into the manifest.
+- Its own rerun manifest, `tests/wpt-baseline/failed-reftests.json` — a reftest
+  failure and a golden-image failure are different measurements of the same test,
+  so they must not overwrite each other.
+- Issues from this suite are titled `WPT reftest run: …` so they are never
+  confused with the golden-image suite's.
+
+Two things the reftest shard deliberately does *not* inherit: the Playwright and
+reference caches (there is nothing to cache), and `BROILER_WPT_DEFER_PROMISE_TESTS`
+— that override exists to freeze the DOM at the point Chromium's reference
+generator screenshots, and a reftest has no Chromium capture to line up with.

--- a/scripts/run-wpt-reftests.sh
+++ b/scripts/run-wpt-reftests.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# run-wpt-reftests.sh — Run the WPT *reftests* against Broiler, and only those.
+#
+# A WPT reftest carries its own answer: the test document declares
+# `<link rel="match" href="…">` (its render must be identical to that reference)
+# or `<link rel="mismatch" href="…">` (it must differ from it). Both sides are
+# rendered by Broiler and compared to each other, so this run needs no Chromium,
+# no Playwright, and no generated reference images — nothing outside the WPT
+# checkout is consulted. Tests that declare no reference are not run at all.
+#
+# That is the whole difference from scripts/run-wpt-tests.sh, which this script
+# is otherwise a copy of: its Step 2 (generate Chromium reference PNGs via
+# Playwright) is gone, and the runner is invoked with --reftests-only instead of
+# --reference-dir. Everything else — the checkout, sharding, the rerun manifest,
+# the summary/analysis files, the exit code — behaves identically, so the two
+# runs are comparable and the same merge tooling reads both.
+#
+# What a result means here is narrower than in the golden-image suite, and worth
+# stating: a pass says Broiler renders the test the same way it renders WPT's own
+# statement of the correct result. A shared bug that hits test and reference
+# alike still passes. In exchange, nothing is attributed to Broiler that is
+# really a Chromium-vs-Broiler font/scrollbar/AA difference, and a run costs no
+# browser download.
+#
+# Usage:
+#     ./scripts/run-wpt-reftests.sh [OPTIONS]
+#
+# Options:
+#     --output-dir <dir>   Directory for results (default: tests/wpt-reftest-results)
+#     --wpt-dir <dir>      Use an existing WPT checkout instead of cloning
+#     --shallow            Shallow-clone only (depth 1, much faster; default)
+#     --subset <patterns>  Semicolon-separated sub-path patterns with optional
+#                          wildcards (e.g. "css/CSS2;css/css-*")
+#     --shard-count <N>    Split the reftests into N deterministic shards
+#     --shard-index <I>    Run only shard I (0-based), or -1 for all
+#     --rerun-json <path>  Rerun only tests from a prior JSON report
+#     --rerun-kind <kind>  Which prior results to rerun (failures|timeouts)
+#     --non-js             Run only documents that do not depend on JavaScript
+#     --failure-images <dir>  Save rendered/reference/diff PNGs for each failure
+#     -h, --help           Show this help message
+#
+# Prerequisites:
+#     - .NET 10 SDK
+#     - git (for cloning WPT)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+OUTPUT_DIR="$REPO_ROOT/tests/wpt-reftest-results"
+WPT_DIR=""
+SHALLOW=true
+SUBSET=""
+SHARD_INDEX=-1
+SHARD_COUNT=1
+RERUN_JSON=""
+RERUN_KIND=""
+NON_JS=false
+FAILURE_IMAGES_DIR=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --wpt-dir)
+            WPT_DIR="$2"
+            shift 2
+            ;;
+        --shallow)
+            SHALLOW=true
+            shift
+            ;;
+        --subset)
+            SUBSET="$2"
+            shift 2
+            ;;
+        --shard-index)
+            SHARD_INDEX="$2"
+            shift 2
+            ;;
+        --shard-count)
+            SHARD_COUNT="$2"
+            shift 2
+            ;;
+        --rerun-json)
+            RERUN_JSON="$2"
+            shift 2
+            ;;
+        --rerun-kind)
+            RERUN_KIND="$2"
+            shift 2
+            ;;
+        --non-js)
+            NON_JS=true
+            shift
+            ;;
+        --failure-images)
+            FAILURE_IMAGES_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Runs only the WPT reftests (rel=match / rel=mismatch), rendering both"
+            echo "the test and its reference with Broiler. No Chromium, no reference images."
+            echo ""
+            echo "Options:"
+            echo "  --output-dir <dir>            Directory for results (default: tests/wpt-reftest-results)"
+            echo "  --wpt-dir <dir>               Use an existing WPT checkout instead of cloning"
+            echo "  --shallow                     Shallow-clone only (depth 1, faster; default)"
+            echo "  --subset <patterns>           Semicolon-separated sub-path patterns with wildcards"
+            echo "                                (e.g. \"css/CSS2;css/css-*\" or \"css/css-flexbox\")"
+            echo "  --shard-count <N>             Split the reftests into N deterministic shards (default: 1)"
+            echo "  --shard-index <I>             Run only shard I (0-based), or -1 for all (default: -1)"
+            echo "  --rerun-json <path>           Rerun only tests from a prior JSON report (incremental)"
+            echo "  --rerun-kind <failures|timeouts>  Which prior results to rerun (default: failures)"
+            echo "  --non-js                      Run only non-JavaScript WPT documents"
+            echo "  --failure-images <dir>        Save rendered/reference/diff PNGs for each failure"
+            echo "  -h, --help                    Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Shard arguments. The reftest run has only one consumer of them — the C# runner
+# — because there is no reference generator to keep in step, but the assignment
+# function is the same FNV-1a(relative-path) % shard-count, so a shard index
+# means the same slice of a given test set in both suites.
+SHARD_ARGS=()
+if [[ "$SHARD_INDEX" != "-1" || "$SHARD_COUNT" != "1" ]]; then
+    SHARD_ARGS=(--shard-count "$SHARD_COUNT" --shard-index "$SHARD_INDEX")
+fi
+
+RERUN_ARGS=()
+if [[ -n "$RERUN_JSON" ]]; then
+    # Normalized to an absolute path before it is handed on, so it resolves
+    # against the invocation directory rather than wherever the runner runs from.
+    if [[ "$RERUN_JSON" != /* ]]; then
+        RERUN_JSON="$PWD/$RERUN_JSON"
+    fi
+    if [[ ! -f "$RERUN_JSON" ]]; then
+        echo "  ✗ Rerun manifest not found: $RERUN_JSON" >&2
+        exit 1
+    fi
+    RERUN_ARGS=(--rerun-json "$RERUN_JSON")
+    [[ -n "$RERUN_KIND" ]] && RERUN_ARGS+=(--rerun-kind "$RERUN_KIND")
+fi
+
+NON_JS_ARGS=()
+if [[ "$NON_JS" == "true" ]]; then
+    NON_JS_ARGS=(--non-js)
+fi
+
+FAILURE_IMAGE_ARGS=()
+if [[ -n "$FAILURE_IMAGES_DIR" ]]; then
+    FAILURE_IMAGE_ARGS=(--failure-images "$FAILURE_IMAGES_DIR")
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+# Marker describing why this shard could not run at all, read by the workflow's
+# "Collect shard result" step. Cleared up front so a stale marker from an earlier
+# run in the same workspace cannot be attributed to this one. The reftest suite
+# has no browser to fail to provision — the one thing that writes this marker in
+# the golden-image suite — but the file is still cleared and still honoured, so
+# the two suites' collect steps stay identical.
+FAILURE_MARKER="$OUTPUT_DIR/wpt-shard-failure.json"
+rm -f "$FAILURE_MARKER"
+
+LOGFILE="$OUTPUT_DIR/wpt-results.log"
+
+echo "=== Broiler WPT Reftest Runner (Broiler-only, no reference images) ==="
+echo "Repository root : $REPO_ROOT"
+echo "Output directory: $OUTPUT_DIR"
+echo "Log file        : $LOGFILE"
+echo ""
+
+# --- Step 1: Obtain a WPT checkout ------------------------------------------
+
+if [[ -z "$WPT_DIR" ]]; then
+    WPT_DIR="$REPO_ROOT/tests/wpt/checkout"
+    if [[ -d "$WPT_DIR/.git" ]]; then
+        echo "--- Step 1: Using existing WPT checkout at $WPT_DIR ---"
+    else
+        echo "--- Step 1: Cloning web-platform-tests ---"
+        CLONE_ARGS=(clone --single-branch --branch master)
+        if [[ "$SHALLOW" == "true" ]]; then
+            CLONE_ARGS+=(--depth 1)
+            echo "  (shallow clone, depth=1)"
+        fi
+        git "${CLONE_ARGS[@]}" \
+            https://github.com/web-platform-tests/wpt.git \
+            "$WPT_DIR" 2>&1 | tail -5
+        echo "  ✓ WPT cloned to: $WPT_DIR"
+    fi
+else
+    echo "--- Step 1: Using provided WPT directory: $WPT_DIR ---"
+    if [[ ! -d "$WPT_DIR" ]]; then
+        echo "  ✗ WPT directory not found: $WPT_DIR" >&2
+        exit 1
+    fi
+fi
+
+TEST_DIR="$WPT_DIR"
+SUBSET_ARGS=()
+if [[ -n "$SUBSET" ]]; then
+    SUBSET_ARGS+=(--subset "$SUBSET")
+    echo "  Subset patterns: $SUBSET"
+fi
+echo ""
+
+# --- Step 2: Build Broiler.Wpt ----------------------------------------------
+#
+# There is deliberately no reference-generation step here. The golden-image
+# suite's Step 2 downloads Chromium and screenshots every test; a reftest run
+# gets its baseline from the checkout itself.
+
+echo "--- Step 2: Building Broiler.Wpt ---"
+dotnet build "$REPO_ROOT/src/Broiler.Wpt/Broiler.Wpt.csproj" \
+    --configuration Release --nologo --verbosity quiet 2>&1
+echo "  ✓ Build succeeded"
+echo ""
+
+# --- Step 3: Run the reftests -----------------------------------------------
+
+echo "--- Step 3: Running WPT reftests ---"
+echo "  Test directory: $TEST_DIR"
+echo "  Writing results to: $LOGFILE"
+echo ""
+
+JSON_REPORT="$OUTPUT_DIR/wpt-results.json"
+MARKDOWN_REPORT="$OUTPUT_DIR/wpt-triage-summary.md"
+
+set +e
+dotnet run --project "$REPO_ROOT/src/Broiler.Wpt" \
+    --configuration Release --no-build -- \
+    --wpt-dir "$TEST_DIR" --reftests-only \
+    --json-output "$JSON_REPORT" --markdown-output "$MARKDOWN_REPORT" \
+    "${FAILURE_IMAGE_ARGS[@]}" "${SUBSET_ARGS[@]}" \
+    "${SHARD_ARGS[@]}" "${RERUN_ARGS[@]}" "${NON_JS_ARGS[@]}" 2>&1 | tee "$LOGFILE"
+WPT_EXIT=$?
+set -e
+
+echo ""
+echo "=== WPT Reftest Run Complete ==="
+echo "Exit code : $WPT_EXIT"
+echo "Log file  : $LOGFILE"
+echo "JSON file : $JSON_REPORT"
+echo "Markdown  : $MARKDOWN_REPORT"
+
+# --- Step 4: Generate summary -----------------------------------------------
+
+echo ""
+echo "--- Summary ---"
+if [[ -f "$LOGFILE" ]]; then
+    PASSED="$(grep -c '^\[PASS\]' "$LOGFILE" || true)"
+    FAILED="$(grep -c '^\[FAIL\]' "$LOGFILE" || true)"
+    SKIPPED="$(grep -oP '(?<=, )\d+(?= skipped)' "$LOGFILE" || true)"
+    PASSED="${PASSED:-0}"
+    FAILED="${FAILED:-0}"
+    SKIPPED="${SKIPPED:-0}"
+    echo "  Passed : $PASSED"
+    echo "  Failed : $FAILED"
+    echo "  Skipped: $SKIPPED"
+
+    SUMMARY="$OUTPUT_DIR/wpt-summary.txt"
+    {
+        echo "WPT Reftest Results Summary"
+        echo "==========================="
+        echo "Date     : $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+        echo "Mode     : reftests only (rel=match/rel=mismatch), both sides rendered by Broiler"
+        echo "Subset   : ${SUBSET:-"(all)"}"
+        echo "Passed   : $PASSED"
+        echo "Failed   : $FAILED"
+        echo "Skipped  : $SKIPPED"
+        echo ""
+        if [[ "$FAILED" -gt 0 ]]; then
+            echo "Failed tests:"
+            grep '^\[FAIL\]' "$LOGFILE" | sed 's/^\[FAIL\] /  /' || true
+        fi
+    } > "$SUMMARY"
+    echo "  Summary: $SUMMARY"
+    if [[ -f "$MARKDOWN_REPORT" ]]; then
+        echo "  Triage : $MARKDOWN_REPORT"
+    fi
+
+    if [[ "$FAILED" -gt 0 ]]; then
+        ANALYSIS="$OUTPUT_DIR/wpt-root-cause-analysis.txt"
+        {
+            echo "WPT Reftest Root Cause Analysis"
+            echo "==============================="
+            echo "Date     : $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+            echo "Subset   : ${SUBSET:-"(all)"}"
+            echo ""
+            # NOTE: This list must stay in sync with the FailureCategory
+            # enum in src/Broiler.Wpt/WptTestRunner.cs.
+            for CAT in PixelMismatch ScriptError RenderingError FileIO ReferenceDecodeError Unknown; do
+                COUNT="$(grep -c "^\[FAIL\] \[$CAT\]" "$LOGFILE" 2>/dev/null || true)"
+                COUNT="${COUNT:-0}"
+                if [[ "$COUNT" -gt 0 ]]; then
+                    echo "$CAT: $COUNT failure(s)"
+                    grep "^\[FAIL\] \[$CAT\]" "$LOGFILE" | sed "s/^\[FAIL\] \[$CAT\] /  /" || true
+                    echo ""
+                fi
+            done
+
+            # NOTE: This list must stay in sync with the MismatchCategory
+            # enum in Broiler.HTML/Source/Broiler.HTML.Image/MismatchClassifier.cs.
+            echo "PixelMismatch Sub-Categories:"
+            for SUBCAT in SizeMismatch SubpixelAntiAliasing ColorShift LayoutShift MissingContent MinorDiff; do
+                SCOUNT="$(grep -c "^\[FAIL\] \[PixelMismatch\] \[$SUBCAT\]" "$LOGFILE" 2>/dev/null || true)"
+                SCOUNT="${SCOUNT:-0}"
+                if [[ "$SCOUNT" -gt 0 ]]; then
+                    echo "  $SUBCAT: $SCOUNT failure(s)"
+                fi
+            done
+            echo ""
+
+            if grep -q "^=== Root Cause Analysis ===$" "$LOGFILE"; then
+                echo "--- Detailed Root Cause Breakdown ---"
+                sed -n '/^=== Root Cause Analysis ===/,$ p' "$LOGFILE"
+            fi
+        } > "$ANALYSIS"
+        echo "  Analysis: $ANALYSIS"
+    fi
+fi
+
+echo ""
+echo "=== Done ==="
+exit $WPT_EXIT

--- a/src/Broiler.Wpt.Tests/ReferenceTestModeTests.cs
+++ b/src/Broiler.Wpt.Tests/ReferenceTestModeTests.cs
@@ -1,0 +1,331 @@
+using System.IO;
+using Broiler.HTML.Image;
+using BColor = Broiler.Graphics.BColor;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Unit tests for reftest mode — the <c>--reftests-only</c> run in which a test is
+/// decided against the reference it declares for itself
+/// (<c>&lt;link rel="match"&gt;</c> / <c>&lt;link rel="mismatch"&gt;</c>), with both
+/// sides rendered by Broiler and no reference image or second engine involved.
+/// </summary>
+public class ReferenceTestModeTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ReferenceTestModeTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "broiler-wpt-reftest-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (!Directory.Exists(_tempDir))
+            return;
+
+        try
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Leaving a directory under %TEMP% behind is not a test failure.
+        }
+    }
+
+    private string WriteFile(string relativePath, string content)
+    {
+        var fullPath = Path.Combine(_tempDir, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, content);
+        return fullPath;
+    }
+
+    private static string Page(string body) =>
+        $"<!DOCTYPE html><html><head><style>body {{ margin: 0; }}</style></head><body>{body}</body></html>";
+
+    private static string PageWithLink(string rel, string href, string body) =>
+        "<!DOCTYPE html><html><head>" +
+        $"<link rel=\"{rel}\" href=\"{href}\">" +
+        "<style>body { margin: 0; }</style></head>" +
+        $"<body>{body}</body></html>";
+
+    private static WptTestRunner CreateRunner() =>
+        new(320, 240, referenceTestsOnly: true);
+
+    // ── Reference-link extraction ───────────────────────────────────────────
+
+    [Fact]
+    public void ExtractReferenceLinks_Reads_Match_And_Mismatch_In_Document_Order()
+    {
+        var links = WptTestRunner.ExtractReferenceLinks(
+            "<link rel=\"help\" href=\"https://example.test/spec\">" +
+            "<link rel=\"match\" href=\"a-ref.html\">" +
+            "<link rel='mismatch' href='b-notref.html'>");
+
+        Assert.Collection(
+            links,
+            first =>
+            {
+                Assert.Equal("a-ref.html", first.Href);
+                Assert.True(first.IsMatch);
+            },
+            second =>
+            {
+                Assert.Equal("b-notref.html", second.Href);
+                Assert.False(second.IsMatch);
+            });
+    }
+
+    [Fact]
+    public void ExtractReferenceLinks_Does_Not_Read_Mismatch_As_Match()
+    {
+        // "mismatch" contains "match": a naive substring test would classify this
+        // reference as one the render must reproduce — the exact inversion of what
+        // the test asks for, turning every mismatch reftest's verdict upside down.
+        var links = WptTestRunner.ExtractReferenceLinks("<link rel=\"mismatch\" href=\"notref.html\">");
+
+        var link = Assert.Single(links);
+        Assert.False(link.IsMatch);
+    }
+
+    [Fact]
+    public void ExtractReferenceLinks_Is_Empty_For_A_Test_That_Declares_No_Reference()
+    {
+        Assert.Empty(WptTestRunner.ExtractReferenceLinks(Page("<p>no reference here</p>")));
+    }
+
+    [Theory]
+    [InlineData("foo-ref.html", "foo-ref.html")]
+    [InlineData("foo-ref.html?query", "foo-ref.html")]
+    [InlineData("foo-ref.html#fragment", "foo-ref.html")]
+    public void TryResolveReferenceHref_Resolves_Relative_To_The_Test_And_Strips_Query_And_Fragment(
+        string href, string expectedFileName)
+    {
+        var testPath = Path.Combine(_tempDir, "css", "suite", "foo.html");
+
+        Assert.True(WptTestRunner.TryResolveReferenceHref(href, testPath, _tempDir, out var resolved));
+        Assert.Equal(
+            Path.Combine(_tempDir, "css", "suite", expectedFileName),
+            resolved);
+    }
+
+    [Fact]
+    public void TryResolveReferenceHref_Maps_A_Root_Relative_Href_Under_The_Wpt_Root()
+    {
+        var testPath = Path.Combine(_tempDir, "css", "suite", "foo.html");
+
+        Assert.True(WptTestRunner.TryResolveReferenceHref("/common/blank.html", testPath, _tempDir, out var resolved));
+        Assert.Equal(Path.Combine(_tempDir, "common", "blank.html"), resolved);
+    }
+
+    [Fact]
+    public void TryResolveReferenceHref_Rejects_An_Empty_Href()
+    {
+        var testPath = Path.Combine(_tempDir, "foo.html");
+
+        Assert.False(WptTestRunner.TryResolveReferenceHref("   ", testPath, _tempDir, out _));
+        Assert.False(WptTestRunner.TryResolveReferenceHref(null, testPath, _tempDir, out _));
+    }
+
+    // ── Suite membership ────────────────────────────────────────────────────
+
+    [Fact]
+    public void FilterToReferenceTests_Keeps_Only_Tests_Whose_Reference_Exists()
+    {
+        var withReference = WriteFile("with-reference.html", PageWithLink("match", "with-reference-ref.html", ""));
+        WriteFile("with-reference-ref.html", Page(""));
+        var danglingReference = WriteFile("dangling.html", PageWithLink("match", "absent-ref.html", ""));
+        var noReference = WriteFile("plain.html", Page("<p>x</p>"));
+
+        var kept = WptTestRunner
+            .FilterToReferenceTests([withReference, danglingReference, noReference], _tempDir)
+            .ToList();
+
+        // A dangling href is dropped as firmly as no href at all: reftest mode can
+        // only decide a test whose reference is actually on disk, and reporting the
+        // other two would pad the totals with cases it never measured.
+        Assert.Equal([withReference], kept);
+    }
+
+    [Fact]
+    public void FilterToReferenceTests_Keeps_A_Test_Whose_Reference_Is_An_Image()
+    {
+        var test = WriteFile("image-ref-test.html", PageWithLink("match", "expected.png", ""));
+        CreateSolidPng(Path.Combine(_tempDir, "expected.png"), BColor.White);
+
+        Assert.Equal(
+            [test],
+            WptTestRunner.FilterToReferenceTests([test], _tempDir).ToList());
+    }
+
+    [Theory]
+    [InlineData("ref.html", false)]
+    [InlineData("ref.png", true)]
+    [InlineData("ref.PNG", true)]
+    [InlineData("ref.jpg", true)]
+    [InlineData("ref.webp", true)]
+    public void IsReferenceImagePath_Distinguishes_Bitmaps_From_Documents(string fileName, bool expected)
+    {
+        Assert.Equal(expected, WptTestRunner.IsReferenceImagePath(fileName));
+    }
+
+    // ── Deciding a reftest ──────────────────────────────────────────────────
+
+    [Fact]
+    public void RunReferenceTest_Passes_When_The_Render_Reproduces_Its_Match_Reference()
+    {
+        var test = WriteFile(
+            "green.html",
+            PageWithLink("match", "green-ref.html", "<div style=\"width:100px;height:100px;background:green\"></div>"));
+        WriteFile("green-ref.html", Page("<div style=\"width:100px;height:100px;background:#008000\"></div>"));
+
+        var result = CreateRunner().RunReferenceTest(test, _tempDir);
+
+        Assert.True(result.Passed, result.Message);
+        Assert.False(result.Skipped);
+        Assert.Equal(100, result.MatchPercent!.Value, 3);
+    }
+
+    [Fact]
+    public void RunReferenceTest_Fails_When_The_Render_Differs_From_Its_Match_Reference()
+    {
+        var test = WriteFile(
+            "differs.html",
+            PageWithLink("match", "differs-ref.html", "<div style=\"width:200px;height:200px;background:red\"></div>"));
+        WriteFile("differs-ref.html", Page("<div style=\"width:200px;height:200px;background:blue\"></div>"));
+
+        var result = CreateRunner().RunReferenceTest(test, _tempDir);
+
+        Assert.False(result.Passed);
+        Assert.False(result.Skipped);
+        Assert.Equal(FailureCategory.PixelMismatch, result.Category);
+        // The reference is named in the message, relative to the WPT root: with
+        // several candidates the report is otherwise silent about which one the
+        // percentage belongs to.
+        Assert.Contains("differs-ref.html", result.Message);
+    }
+
+    [Fact]
+    public void RunReferenceTest_Passes_When_A_Mismatch_Reference_Renders_Differently()
+    {
+        var test = WriteFile(
+            "not-blue.html",
+            PageWithLink("mismatch", "not-blue-notref.html", "<div style=\"width:200px;height:200px;background:red\"></div>"));
+        WriteFile("not-blue-notref.html", Page("<div style=\"width:200px;height:200px;background:blue\"></div>"));
+
+        var result = CreateRunner().RunReferenceTest(test, _tempDir);
+
+        Assert.True(result.Passed, result.Message);
+    }
+
+    [Fact]
+    public void RunReferenceTest_Fails_When_A_Mismatch_Reference_Renders_Identically()
+    {
+        var body = "<div style=\"width:200px;height:200px;background:red\"></div>";
+        var test = WriteFile("same.html", PageWithLink("mismatch", "same-notref.html", body));
+        WriteFile("same-notref.html", Page(body));
+
+        var result = CreateRunner().RunReferenceTest(test, _tempDir);
+
+        Assert.False(result.Passed);
+        Assert.Equal(FailureCategory.PixelMismatch, result.Category);
+        Assert.Contains("rel=mismatch", result.Message);
+    }
+
+    [Fact]
+    public void RunReferenceTest_Passes_On_The_Second_Match_Reference_When_The_First_Differs()
+    {
+        // WPT's own rule for several rel=match links: the test passes if it
+        // reproduces any one of them.
+        var test = WriteFile(
+            "two-refs.html",
+            "<!DOCTYPE html><html><head>" +
+            "<link rel=\"match\" href=\"wrong-ref.html\">" +
+            "<link rel=\"match\" href=\"right-ref.html\">" +
+            "<style>body { margin: 0; }</style></head>" +
+            "<body><div style=\"width:120px;height:120px;background:green\"></div></body></html>");
+        WriteFile("wrong-ref.html", Page("<div style=\"width:120px;height:120px;background:red\"></div>"));
+        WriteFile("right-ref.html", Page("<div style=\"width:120px;height:120px;background:green\"></div>"));
+
+        var result = CreateRunner().RunReferenceTest(test, _tempDir);
+
+        Assert.True(result.Passed, result.Message);
+    }
+
+    [Fact]
+    public void RunReferenceTest_Compares_Against_A_Reference_Image_Without_Rendering_It()
+    {
+        var test = WriteFile(
+            "against-png.html",
+            PageWithLink("match", "against-png-ref.png", "<div style=\"width:320px;height:240px;background:white\"></div>"));
+        CreateSolidPng(Path.Combine(_tempDir, "against-png-ref.png"), BColor.White);
+
+        var result = CreateRunner().RunReferenceTest(test, _tempDir);
+
+        Assert.True(result.Passed, result.Message);
+    }
+
+    [Fact]
+    public void RunReferenceTest_Skips_A_Test_That_Declares_No_Reference()
+    {
+        var test = WriteFile("plain.html", Page("<p>nothing declared</p>"));
+
+        var result = CreateRunner().RunReferenceTest(test, _tempDir);
+
+        Assert.True(result.Skipped);
+        Assert.False(result.Passed);
+        Assert.Equal(SkipReason.NoReferenceDeclared, result.SkipReason);
+    }
+
+    [Fact]
+    public void RunReferenceTest_Reports_A_Missing_Test_File_As_FileIO()
+    {
+        var result = CreateRunner().RunReferenceTest(Path.Combine(_tempDir, "absent.html"), _tempDir);
+
+        Assert.False(result.Passed);
+        Assert.Equal(FailureCategory.FileIO, result.Category);
+    }
+
+    [Fact]
+    public void RunTest_Routes_To_Reference_Mode_And_Never_Reads_The_Reference_Directory()
+    {
+        var test = WriteFile(
+            "routed.html",
+            PageWithLink("match", "routed-ref.html", "<div style=\"width:80px;height:80px;background:green\"></div>"));
+        WriteFile("routed-ref.html", Page("<div style=\"width:80px;height:80px;background:green\"></div>"));
+
+        // The reference directory does not exist. In the golden-image path that is a
+        // MissingReferenceImage skip; in reftest mode it must not be consulted at all,
+        // which is what lets the CI job run with no reference generation step.
+        var result = CreateRunner().RunTest(test, Path.Combine(_tempDir, "no-such-reference-dir"), _tempDir);
+
+        Assert.True(result.Passed, result.Message);
+        Assert.NotEqual(SkipReason.MissingReferenceImage, result.SkipReason);
+    }
+
+    [Fact]
+    public void RunTest_Without_Reference_Mode_Still_Skips_On_A_Missing_Reference_Image()
+    {
+        var test = WriteFile(
+            "golden.html",
+            PageWithLink("match", "golden-ref.html", "<div style=\"width:80px;height:80px;background:green\"></div>"));
+        WriteFile("golden-ref.html", Page("<div style=\"width:80px;height:80px;background:green\"></div>"));
+
+        var result = new WptTestRunner(320, 240)
+            .RunTest(test, Path.Combine(_tempDir, "no-such-reference-dir"), _tempDir);
+
+        Assert.True(result.Skipped);
+        Assert.Equal(SkipReason.MissingReferenceImage, result.SkipReason);
+    }
+
+    private static void CreateSolidPng(string path, BColor color)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using var bitmap = new BBitmap(320, 240);
+        bitmap.Clear(color);
+        bitmap.Save(path);
+    }
+}

--- a/src/Broiler.Wpt/Program.cs
+++ b/src/Broiler.Wpt/Program.cs
@@ -96,6 +96,7 @@ public class Program
         int shardCount = 1;
         int shardIndex = WptTestRunner.AllShards;
         bool nonJavaScriptOnly = false;
+        bool referenceTestsOnly = false;
         bool verifyReference = false;
         bool workerMode = false;
         bool noWorkerIsolation = false;
@@ -194,6 +195,9 @@ public class Program
                 case "--non-js":
                     nonJavaScriptOnly = true;
                     break;
+                case "--reftests-only":
+                    referenceTestsOnly = true;
+                    break;
                 case "--verify-reference":
                     verifyReference = true;
                     break;
@@ -267,7 +271,7 @@ public class Program
         }
 
         if (workerMode)
-            return RunWorkerMode(wptPath, referenceDir, failureImagesDir, verifyReference, runPassThresholdPercent);
+            return RunWorkerMode(wptPath, referenceDir, failureImagesDir, verifyReference, runPassThresholdPercent, referenceTestsOnly);
 
         if (!TryResolveRunTestTimeout(timeoutSeconds, out var runTestTimeout, out var timeoutError))
         {
@@ -288,11 +292,14 @@ public class Program
         }
 
         Console.WriteLine($"WPT directory : {Path.GetFullPath(wptPath)}");
-        Console.WriteLine($"Reference dir : {Path.GetFullPath(referenceDir)}");
+        if (referenceTestsOnly)
+            Console.WriteLine("Reference dir : (unused — reftest mode renders both sides with Broiler)");
+        else
+            Console.WriteLine($"Reference dir : {Path.GetFullPath(referenceDir)}");
         Console.WriteLine($"Timeout       : {FormatSeconds(runTestTimeout)} second(s)");
         Console.WriteLine($"Pass threshold: {FormatPassThreshold(runPassThresholdPercent)}% pixel match " +
                           $"(at most {FormatPassThreshold(100 - runPassThresholdPercent)}% of the pixels may differ)");
-        Console.WriteLine($"Mode          : {(nonJavaScriptOnly ? "non-JavaScript visual tests" : "all discovered tests")}");
+        Console.WriteLine($"Mode          : {DescribeRunMode(referenceTestsOnly, nonJavaScriptOnly)}");
         var useWorkerIsolation = !noWorkerIsolation && RunTestExecutorOverride.Value is null;
         Console.WriteLine(
             useWorkerIsolation
@@ -317,7 +324,8 @@ public class Program
         var runner = new WptTestRunner(
             failureImageDir: failureImagesDir,
             verifyReferenceHtml: verifyReference,
-            passThresholdPercent: runPassThresholdPercent);
+            passThresholdPercent: runPassThresholdPercent,
+            referenceTestsOnly: referenceTestsOnly);
 
         if (!string.IsNullOrWhiteSpace(failureImagesDir))
             Console.WriteLine($"Failure images: {Path.GetFullPath(failureImagesDir)}");
@@ -339,6 +347,22 @@ public class Program
         var discoveredTests = WptTestRunner
             .DiscoverTests(wptPath, subsetPatterns, nonJavaScriptOnly)
             .ToList();
+
+        // Reftest mode runs exactly the cases that carry their own answer: a
+        // rel=match / rel=mismatch reference present in the checkout. Everything else
+        // is dropped before the run rather than reported as skipped, so the totals
+        // describe only tests this mode could actually decide. Applied before the
+        // rerun and shard filters so a shard's slice is a slice of the reftests.
+        if (referenceTestsOnly)
+        {
+            int beforeFilter = discoveredTests.Count;
+            discoveredTests = WptTestRunner
+                .FilterToReferenceTests(discoveredTests, wptPath)
+                .ToList();
+            Console.WriteLine(
+                $"Reftests      : {discoveredTests.Count} of {beforeFilter} discovered document(s) declare a reference");
+        }
+
         if (!string.IsNullOrWhiteSpace(rerunJsonPath))
         {
             if (!TryLoadRerunSelection(rerunJsonPath, wptPath, rerunSelectionKind, out var rerunTests, out var rerunError))
@@ -391,7 +415,8 @@ public class Program
                 failureImagesDir,
                 verifyReference,
                 runTestMemoryLimitBytes,
-                runPassThresholdPercent)
+                runPassThresholdPercent,
+                referenceTestsOnly)
             : null;
         int completed = 0, runningPassed = 0, runningFailed = 0, runningSkipped = 0;
 
@@ -603,7 +628,8 @@ public class Program
         string referenceDir,
         string? failureImagesDir,
         bool verifyReference,
-        double passThresholdPercent)
+        double passThresholdPercent,
+        bool referenceTestsOnly)
     {
         var protocolOut = Console.Out;
         Console.SetOut(Console.Error);
@@ -611,7 +637,8 @@ public class Program
         var runner = new WptTestRunner(
             failureImageDir: failureImagesDir,
             verifyReferenceHtml: verifyReference,
-            passThresholdPercent: passThresholdPercent);
+            passThresholdPercent: passThresholdPercent,
+            referenceTestsOnly: referenceTestsOnly);
 
         protocolOut.WriteLine(JsonSerializer.Serialize(new WptWorkerResponse { Ready = true }, WorkerJsonOptions));
         protocolOut.Flush();
@@ -762,6 +789,7 @@ public class Program
         private readonly bool _verifyReference;
         private readonly long _memoryLimitBytes;
         private readonly double _passThresholdPercent;
+        private readonly bool _referenceTestsOnly;
         private Process? _process;
         private Task<string?>? _pendingResponse;
 
@@ -771,7 +799,8 @@ public class Program
             string? failureImagesDir,
             bool verifyReference,
             long memoryLimitBytes = 0,
-            double passThresholdPercent = DefaultPassThresholdPercent)
+            double passThresholdPercent = DefaultPassThresholdPercent,
+            bool referenceTestsOnly = false)
         {
             _wptPath = wptPath;
             _referenceDir = referenceDir;
@@ -779,6 +808,7 @@ public class Program
             _verifyReference = verifyReference;
             _memoryLimitBytes = memoryLimitBytes;
             _passThresholdPercent = passThresholdPercent;
+            _referenceTestsOnly = referenceTestsOnly;
         }
 
         internal int? CurrentProcessId
@@ -983,6 +1013,12 @@ public class Program
 
             if (_verifyReference)
                 startInfo.ArgumentList.Add("--verify-reference");
+
+            // The worker decides the case, so it has to know it is deciding a reftest —
+            // otherwise it would compare against a reference PNG the reftest run never
+            // generates and report every test as a missing reference.
+            if (_referenceTestsOnly)
+                startInfo.ArgumentList.Add("--reftests-only");
 
             startInfo.RedirectStandardInput = true;
             startInfo.RedirectStandardOutput = true;
@@ -2555,6 +2591,23 @@ public class Program
             writer.WriteLine($"- `{FormatSubsetCommand(bucket.Key)}` ({bucket.Value} timeout(s))");
     }
 
+    /// <summary>
+    /// One line describing what this run measures, for the header block. Reftest mode
+    /// is named first because it changes what a result <em>means</em>: no reference
+    /// image is involved and no second engine is consulted.
+    /// </summary>
+    private static string DescribeRunMode(bool referenceTestsOnly, bool nonJavaScriptOnly)
+    {
+        if (referenceTestsOnly)
+        {
+            return nonJavaScriptOnly
+                ? "reftests only (non-JavaScript), both sides rendered by Broiler"
+                : "reftests only (rel=match/rel=mismatch), both sides rendered by Broiler";
+        }
+
+        return nonJavaScriptOnly ? "non-JavaScript visual tests" : "all discovered tests";
+    }
+
     private static void PrintUsage()
     {
         Console.WriteLine("Usage: Broiler.Wpt <wpt-directory> [OPTIONS]");
@@ -2575,6 +2628,11 @@ public class Program
         Console.WriteLine("  --shard-count <N>          Split discovered tests into N deterministic shards (default: 1)");
         Console.WriteLine("  --shard-index <I>          Run only shard I (0-based), or -1 for all shards (default: -1)");
         Console.WriteLine("  --non-js                   Exclude JavaScript-dependent documents (Broiler.HTML WPT policy)");
+        Console.WriteLine("  --reftests-only            Run only WPT reftests — the tests that declare their own");
+        Console.WriteLine("                             reference via <link rel=\"match\"> / <link rel=\"mismatch\">, or");
+        Console.WriteLine("                             a reference image — and decide each by rendering BOTH the test");
+        Console.WriteLine("                             and its reference with Broiler. No reference directory is read");
+        Console.WriteLine("                             and no other engine is involved; --reference-dir is ignored.");
         Console.WriteLine("  --defer-promise-tests      Do not run stub promise_test bodies before the snapshot, matching");
         Console.WriteLine("                             Chromium's reference generator (captures at load). Fixes the");
         Console.WriteLine("                             css-anchor-position scroll cluster. Env: BROILER_WPT_DEFER_PROMISE_TESTS=1");

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -56,6 +56,15 @@ internal enum SkipReason
     UnsupportedWptVariant,
 
     /// <summary>
+    /// Reftest mode only: the test declares no usable <c>&lt;link rel="match"&gt;</c> /
+    /// <c>&lt;link rel="mismatch"&gt;</c> reference, or every href it declares names a
+    /// file that is not on disk. Reftest mode has nothing to compare against, so the
+    /// case is reported as skipped rather than failed. See
+    /// <see cref="WptTestRunner.RunReferenceTest"/>.
+    /// </summary>
+    NoReferenceDeclared,
+
+    /// <summary>
     /// A WPT <em>manual</em> test (filename ends in <c>-manual</c>). These
     /// require human interaction and cannot be validated by an automated pixel
     /// harness, so — like the upstream wptrunner, which excludes them unless
@@ -799,15 +808,18 @@ internal sealed partial class WptTestRunner
     private readonly int _height;
     private readonly string? _failureImageDir;
     private readonly bool _verifyReferenceHtml;
+    private readonly bool _referenceTestsOnly;
     private readonly HTML.Core.IR.DeterministicRenderConfig _pixelDiffConfig;
 
     public WptTestRunner(int width = 1024, int height = 768, string? failureImageDir = null,
-        bool verifyReferenceHtml = false, double passThresholdPercent = DefaultPassThresholdPercent)
+        bool verifyReferenceHtml = false, double passThresholdPercent = DefaultPassThresholdPercent,
+        bool referenceTestsOnly = false)
     {
         _width = width;
         _height = height;
         _failureImageDir = failureImageDir;
         _verifyReferenceHtml = verifyReferenceHtml;
+        _referenceTestsOnly = referenceTestsOnly;
         _pixelDiffConfig = CreatePixelDiffConfig(passThresholdPercent);
     }
 
@@ -1257,6 +1269,7 @@ internal sealed partial class WptTestRunner
     private static readonly Regex MetaTagPattern = new(@"<meta\b[^>]*>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
     private static readonly Regex RelHelpPattern = new(@"\brel\s*=\s*[""']?\s*help\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
     private static readonly Regex RelMatchPattern = new(@"\brel\s*=\s*[""']?\s*match\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex RelMismatchPattern = new(@"\brel\s*=\s*[""']?\s*mismatch\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
     private static readonly Regex NameAssertPattern = new(@"\bname\s*=\s*[""']?\s*assert\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
     private static readonly Regex NameVariantPattern = new(@"\bname\s*=\s*[""']?\s*variant\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
     private static readonly Regex HrefValuePattern = new(@"\bhref\s*=\s*(?:""([^""]*)""|'([^']*)'|([^\s>]+))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -1334,6 +1347,120 @@ internal sealed partial class WptTestRunner
     }
 
     /// <summary>
+    /// One reference a test declares about itself: the href of a
+    /// <c>&lt;link rel="match"&gt;</c> (the render must be identical to it) or of a
+    /// <c>&lt;link rel="mismatch"&gt;</c> (the render must <em>differ</em> from it).
+    /// </summary>
+    internal readonly record struct WptReferenceLink(string Href, bool IsMatch);
+
+    /// <summary>
+    /// Extracts every reference a test declares — both <c>rel="match"</c> and
+    /// <c>rel="mismatch"</c> links, in document order. This is the reftest half of
+    /// WPT: a test carrying one of these links says what its own correct rendering
+    /// looks like, so it can be checked without a second engine's screenshot.
+    /// Returns an empty list for a test that declares nothing.
+    /// </summary>
+    internal static IReadOnlyList<WptReferenceLink> ExtractReferenceLinks(string html)
+    {
+        var links = new List<WptReferenceLink>();
+        foreach (Match link in LinkTagPattern.Matches(html))
+        {
+            bool isMatch = RelMatchPattern.IsMatch(link.Value);
+            if (!isMatch && !RelMismatchPattern.IsMatch(link.Value))
+                continue;
+            if (TryExtractAttributeValue(HrefValuePattern, link.Value, out var href))
+                links.Add(new WptReferenceLink(href, isMatch));
+        }
+
+        return links;
+    }
+
+    /// <summary>
+    /// Resolves a reference href onto the file it names: a root-relative
+    /// <c>/css/foo-ref.html</c> maps under <paramref name="wptRoot"/>, anything else
+    /// resolves against the test's own directory, and any query/fragment is stripped
+    /// first. Purely syntactic — the caller decides whether the file has to exist.
+    /// Returns false for an empty or unusable href.
+    /// </summary>
+    internal static bool TryResolveReferenceHref(
+        string? href, string testPath, string? wptRoot, out string referencePath)
+    {
+        referencePath = string.Empty;
+        if (string.IsNullOrWhiteSpace(href))
+            return false;
+
+        try
+        {
+            var trimmed = href.Split('#', '?')[0].Trim();
+            if (trimmed.Length == 0)
+                return false;
+
+            referencePath = trimmed.StartsWith("/", StringComparison.Ordinal) && wptRoot != null
+                ? Path.GetFullPath(Path.Combine(wptRoot, trimmed.TrimStart('/')))
+                : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Path.GetFullPath(testPath))!, trimmed));
+            return true;
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            referencePath = string.Empty;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Image extensions a reference href may name directly. WPT reftests normally
+    /// point at a reference <em>document</em>, but a reference that is already a
+    /// bitmap needs no rendering at all — it is decoded and compared as-is.
+    /// </summary>
+    private static readonly HashSet<string> ReferenceImageExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp",
+    };
+
+    /// <summary>
+    /// True when a reference href names a bitmap rather than a document to render.
+    /// </summary>
+    internal static bool IsReferenceImagePath(string referencePath)
+        => ReferenceImageExtensions.Contains(Path.GetExtension(referencePath));
+
+    /// <summary>
+    /// True when <paramref name="testPath"/> declares at least one reference —
+    /// image or HTML — that is actually present on disk. This is the membership
+    /// test for the reftest suite: a case that answers false has nothing to be
+    /// compared against without a second engine, so reftest mode never runs it.
+    /// Never throws; an unreadable file simply answers false.
+    /// </summary>
+    internal static bool HasResolvableReference(string testPath, string? wptRoot)
+    {
+        try
+        {
+            foreach (var link in ExtractReferenceLinks(File.ReadAllText(testPath)))
+            {
+                if (TryResolveReferenceHref(link.Href, testPath, wptRoot, out var referencePath)
+                    && File.Exists(referencePath))
+                {
+                    return true;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Narrows a discovered test set to the cases reftest mode can actually run:
+    /// those declaring a <c>rel="match"</c> / <c>rel="mismatch"</c> reference that
+    /// exists on disk. Every other case is dropped here rather than reported as
+    /// skipped, so a reftest run's totals describe only tests it could decide.
+    /// </summary>
+    internal static IEnumerable<string> FilterToReferenceTests(IEnumerable<string> tests, string? wptRoot)
+        => tests.Where(testPath => HasResolvableReference(testPath, wptRoot));
+
+    /// <summary>
     /// Resolves the committed golden PNG for a reftest's <c>rel="match"</c>
     /// reference file, mirroring how <see cref="RunTest"/> derives the test's
     /// own golden path (relative to <paramref name="wptRoot"/> with a
@@ -1357,17 +1484,8 @@ internal sealed partial class WptTestRunner
         referenceGoldenPath = string.Empty;
         try
         {
-            var href = ExtractMatchHref(html);
-            if (string.IsNullOrWhiteSpace(href))
+            if (!TryResolveReferenceHref(ExtractMatchHref(html), testPath, wptRoot, out var refPath))
                 return false;
-
-            href = href.Split('#', '?')[0].Trim();
-            if (href.Length == 0)
-                return false;
-
-            string refPath = href.StartsWith("/", StringComparison.Ordinal) && wptRoot != null
-                ? Path.GetFullPath(Path.Combine(wptRoot, href.TrimStart('/')))
-                : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(testPath)!, href));
 
             string refRelative = wptRoot is not null
                 ? Path.GetRelativePath(wptRoot, refPath)
@@ -1401,21 +1519,13 @@ internal sealed partial class WptTestRunner
     {
         try
         {
-            var href = ExtractMatchHref(html);
-            if (string.IsNullOrWhiteSpace(href))
-                return null;
-
             // Strip any fragment/query and resolve relative to the test file
             // (a root-relative "/foo" maps under the WPT root).
-            href = href.Split('#', '?')[0].Trim();
-            if (href.Length == 0)
+            if (!TryResolveReferenceHref(ExtractMatchHref(html), testPath, wptRoot, out var refPath)
+                || !File.Exists(refPath))
+            {
                 return null;
-
-            string refPath = href.StartsWith("/", StringComparison.Ordinal) && wptRoot != null
-                ? Path.GetFullPath(Path.Combine(wptRoot, href.TrimStart('/')))
-                : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(testPath)!, href));
-            if (!File.Exists(refPath))
-                return null;
+            }
 
             using var refRender = RenderHtmlFileBitmap(refPath, wptRoot);
             using var diff = PixelDiffRunner.Compare(testRender, refRender, _pixelDiffConfig);
@@ -1473,9 +1583,17 @@ internal sealed partial class WptTestRunner
     /// <summary>
     /// Runs a single test: renders the HTML with the Broiler stack and
     /// compares the result against a Chromium/Playwright reference image.
+    /// <para>
+    /// When the runner was constructed with <c>referenceTestsOnly</c>, the case is
+    /// instead decided as a WPT reftest — both sides rendered by Broiler, no
+    /// reference directory consulted. See <see cref="RunReferenceTest"/>.
+    /// </para>
     /// </summary>
     internal WptTestResult RunTest(string testPath, string referenceDir, string? wptRoot = null)
     {
+        if (_referenceTestsOnly)
+            return RunReferenceTest(testPath, wptRoot);
+
         if (!File.Exists(testPath))
         {
             return new WptTestResult
@@ -1811,6 +1929,326 @@ internal sealed partial class WptTestRunner
             }
         }
     }
+
+    /// <summary>
+    /// Decides one WPT reftest entirely inside Broiler: the test document and the
+    /// reference it declares are both rendered by this engine and compared against
+    /// each other at the runner's pass threshold. Nothing outside the WPT checkout is
+    /// consulted — no Chromium screenshot, no committed golden — so the only thing a
+    /// result can say is whether Broiler agrees with WPT's own statement of what the
+    /// test should look like.
+    /// <para>
+    /// A <c>rel="match"</c> reference must be reproduced pixel-for-pixel (within the
+    /// threshold); a <c>rel="mismatch"</c> reference must <em>not</em> be. When a test
+    /// declares several <c>rel="match"</c> references it passes on the first one it
+    /// reproduces, which is WPT's own rule; the closest of the failing candidates is
+    /// the one reported. A test whose references are all <c>rel="mismatch"</c> passes
+    /// only when it differs from every one of them.
+    /// </para>
+    /// <para>
+    /// A reference href that already names a bitmap is decoded rather than rendered.
+    /// Reference chains (a reference that itself declares a reference) are not
+    /// followed: the declared reference is rendered as written, which is what the
+    /// chain asserts it looks like anyway.
+    /// </para>
+    /// </summary>
+    /// <param name="testPath">Path to the test HTML file.</param>
+    /// <param name="wptRoot">WPT checkout root, for fonts and root-relative resources.</param>
+    internal WptTestResult RunReferenceTest(string testPath, string? wptRoot = null)
+    {
+        if (!File.Exists(testPath))
+        {
+            return new WptTestResult
+            {
+                TestPath = testPath,
+                Passed = false,
+                Message = "Test file not found.",
+                Category = FailureCategory.FileIO,
+            };
+        }
+
+        // Manual tests need a human, exactly as in the golden-image path.
+        if (IsManualTest(testPath))
+        {
+            return new WptTestResult
+            {
+                TestPath = testPath,
+                Skipped = true,
+                SkipReason = SkipReason.ManualTest,
+                Message = "WPT manual test (filename ends in -manual, or a manual/ path segment); requires human interaction.",
+            };
+        }
+
+        string html;
+        try
+        {
+            html = File.ReadAllText(testPath);
+        }
+        catch (Exception ex)
+        {
+            return new WptTestResult
+            {
+                TestPath = testPath,
+                Passed = false,
+                Message = $"Failed to read test file: {ex.Message}",
+                Category = FailureCategory.FileIO,
+                StackTrace = ex.StackTrace,
+            };
+        }
+
+        var metadata = ExtractTestMetadata(html);
+
+        if (IsWptVariantTest(html))
+        {
+            return new WptTestResult
+            {
+                TestPath = testPath,
+                Skipped = true,
+                SkipReason = SkipReason.UnsupportedWptVariant,
+                Message = "WPT variant test; Broiler's pixel runner does not expand query-specific variants yet.",
+                HelpLinks = metadata.HelpLinks,
+                Assertion = metadata.Assertion,
+            };
+        }
+
+        if (IsMediaPlaybackTest(html))
+        {
+            return new WptTestResult
+            {
+                TestPath = testPath,
+                Skipped = true,
+                SkipReason = SkipReason.UnsupportedMediaPlayback,
+                Message = "Test requires media playback (video/audio) which is not supported.",
+            };
+        }
+
+        var references = new List<(string Path, bool IsMatch)>();
+        foreach (var link in ExtractReferenceLinks(html))
+        {
+            if (TryResolveReferenceHref(link.Href, testPath, wptRoot, out var referencePath)
+                && File.Exists(referencePath))
+            {
+                references.Add((referencePath, link.IsMatch));
+            }
+        }
+
+        if (references.Count == 0)
+        {
+            return new WptTestResult
+            {
+                TestPath = testPath,
+                Skipped = true,
+                SkipReason = SkipReason.NoReferenceDeclared,
+                Message = "No rel=match/rel=mismatch reference on disk; nothing to compare against in reftest mode.",
+                HelpLinks = metadata.HelpLinks,
+                Assertion = metadata.Assertion,
+            };
+        }
+
+        // Fonts before the first render, for the same reason the golden path loads them
+        // there: the first text measurement caches the typeface it resolves per family.
+        if (wptRoot != null)
+            EnsureWptFontsLoaded(wptRoot);
+
+        HTML.Image.BBitmap rendered;
+        try
+        {
+            rendered = RenderHtmlFileBitmap(testPath, wptRoot);
+        }
+        catch (Exception ex)
+        {
+            return new WptTestResult
+            {
+                TestPath = testPath,
+                Passed = false,
+                Message = $"Rendering failed: {ex.Message}",
+                Category = FailureCategory.RenderingError,
+                StackTrace = ex.StackTrace,
+                HelpLinks = metadata.HelpLinks,
+                Assertion = metadata.Assertion,
+            };
+        }
+
+        using (rendered)
+        {
+            var matches = references.Where(r => r.IsMatch).ToList();
+            return matches.Count > 0
+                ? CompareAgainstMatchReferences(testPath, wptRoot, rendered, matches, metadata)
+                : CompareAgainstMismatchReferences(testPath, wptRoot, rendered, references, metadata);
+        }
+    }
+
+    /// <summary>
+    /// The <c>rel="match"</c> half of <see cref="RunReferenceTest"/>: pass on the first
+    /// reference the render reproduces, otherwise report the closest candidate.
+    /// </summary>
+    private WptTestResult CompareAgainstMatchReferences(
+        string testPath,
+        string? wptRoot,
+        HTML.Image.BBitmap rendered,
+        IReadOnlyList<(string Path, bool IsMatch)> references,
+        TestMetadata metadata)
+    {
+        WptTestResult? closestFailure = null;
+        foreach (var (referencePath, _) in references)
+        {
+            if (!TryLoadReferenceBitmap(testPath, referencePath, wptRoot, metadata, out var reference, out var loadFailure))
+            {
+                // A reference that cannot be produced is itself the finding; keep it only
+                // if no comparison ever happens, so a later reference can still pass.
+                closestFailure ??= loadFailure;
+                continue;
+            }
+
+            using (reference)
+            {
+                using var diff = PixelDiffRunner.Compare(rendered, reference, _pixelDiffConfig);
+                double matchPct = (1.0 - diff.DiffRatio) * 100;
+
+                if (diff.IsMatch)
+                {
+                    return new WptTestResult
+                    {
+                        TestPath = testPath,
+                        Passed = true,
+                        MatchPercent = matchPct,
+                        Message = $"Matches {DescribeReference(referencePath, wptRoot)} at {matchPct:F1}%.",
+                    };
+                }
+
+                if (closestFailure is null || matchPct > (closestFailure.MatchPercent ?? -1))
+                {
+                    var diagnostics = MismatchClassifier.Classify(
+                        diff, rendered.Width, rendered.Height, reference.Width, reference.Height);
+                    var bands = DisplacementBandAnalyzer.Analyze(diff.Mismatches);
+                    var displacementProfile = DisplacementBandAnalyzer.DescribeNonUniform(bands);
+                    var message =
+                        $"Pixel mismatch against {DescribeReference(referencePath, wptRoot)}: " +
+                        $"{matchPct:F1}% match ({diff.DiffPixelCount}/{diff.TotalPixelCount} pixels differ) — {diagnostics.Summary}";
+                    if (displacementProfile != null)
+                        message = $"{message} [{displacementProfile}]";
+
+                    var images = SaveFailureImages(testPath, wptRoot, rendered, reference, diff.DiffBitmap);
+
+                    closestFailure = new WptTestResult
+                    {
+                        TestPath = testPath,
+                        Passed = false,
+                        MatchPercent = matchPct,
+                        Message = message,
+                        Category = FailureCategory.PixelMismatch,
+                        MismatchDiagnostics = diagnostics,
+                        DisplacementProfile = displacementProfile,
+                        RenderedImagePath = images.Rendered,
+                        ReferenceImagePath = images.Reference,
+                        DiffImagePath = images.Diff,
+                        HelpLinks = metadata.HelpLinks,
+                        Assertion = metadata.Assertion,
+                    };
+                }
+            }
+        }
+
+        return closestFailure!;
+    }
+
+    /// <summary>
+    /// The <c>rel="mismatch"</c> half of <see cref="RunReferenceTest"/>: the render has
+    /// to differ from every declared reference, so any one it reproduces is a failure.
+    /// </summary>
+    private WptTestResult CompareAgainstMismatchReferences(
+        string testPath,
+        string? wptRoot,
+        HTML.Image.BBitmap rendered,
+        IReadOnlyList<(string Path, bool IsMatch)> references,
+        TestMetadata metadata)
+    {
+        foreach (var (referencePath, _) in references)
+        {
+            if (!TryLoadReferenceBitmap(testPath, referencePath, wptRoot, metadata, out var reference, out var loadFailure))
+                return loadFailure!;
+
+            using (reference)
+            {
+                using var diff = PixelDiffRunner.Compare(rendered, reference, _pixelDiffConfig);
+                if (!diff.IsMatch)
+                    continue;
+
+                double matchPct = (1.0 - diff.DiffRatio) * 100;
+                var images = SaveFailureImages(testPath, wptRoot, rendered, reference, diff.DiffBitmap);
+                return new WptTestResult
+                {
+                    TestPath = testPath,
+                    Passed = false,
+                    MatchPercent = matchPct,
+                    Message =
+                        $"Render is identical ({matchPct:F1}%) to {DescribeReference(referencePath, wptRoot)}, " +
+                        "which the test declares it must differ from (rel=mismatch).",
+                    Category = FailureCategory.PixelMismatch,
+                    RenderedImagePath = images.Rendered,
+                    ReferenceImagePath = images.Reference,
+                    DiffImagePath = images.Diff,
+                    HelpLinks = metadata.HelpLinks,
+                    Assertion = metadata.Assertion,
+                };
+            }
+        }
+
+        return new WptTestResult
+        {
+            TestPath = testPath,
+            Passed = true,
+            Message = $"Differs from all {references.Count} rel=mismatch reference(s), as required.",
+        };
+    }
+
+    /// <summary>
+    /// Produces the bitmap a reference stands for: decoded when the href names an
+    /// image, rendered by Broiler when it names a document. On failure returns the
+    /// result the test should carry (a decode error and a render error are distinct
+    /// categories, and neither is the test's own fault).
+    /// </summary>
+    private bool TryLoadReferenceBitmap(
+        string testPath,
+        string referencePath,
+        string? wptRoot,
+        TestMetadata metadata,
+        out HTML.Image.BBitmap bitmap,
+        out WptTestResult? failure)
+    {
+        bool isImage = IsReferenceImagePath(referencePath);
+        try
+        {
+            bitmap = isImage
+                ? HTML.Image.BBitmap.Decode(referencePath)
+                : RenderHtmlFileBitmap(referencePath, wptRoot);
+            failure = null;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            bitmap = null!;
+            failure = new WptTestResult
+            {
+                TestPath = testPath,
+                Passed = false,
+                Message = isImage
+                    ? $"Failed to decode reference image {DescribeReference(referencePath, wptRoot)}: {ex.Message}"
+                    : $"Failed to render reference document {DescribeReference(referencePath, wptRoot)}: {ex.Message}",
+                Category = isImage ? FailureCategory.ReferenceDecodeError : FailureCategory.RenderingError,
+                StackTrace = ex.StackTrace,
+                HelpLinks = metadata.HelpLinks,
+                Assertion = metadata.Assertion,
+            };
+            return false;
+        }
+    }
+
+    /// <summary>Names a reference the way a report should show it: relative to the WPT root.</summary>
+    private static string DescribeReference(string referencePath, string? wptRoot)
+        => (wptRoot is not null
+            ? Path.GetRelativePath(wptRoot, referencePath)
+            : Path.GetFileName(referencePath)).Replace('\\', '/');
 
     /// <summary>
     /// Runs a WPT <c>rel="match"</c> test by rendering both the test HTML and


### PR DESCRIPTION
## Summary

Adds a new reftest-only mode to the WPT runner that decides tests entirely within Broiler by rendering both the test document and its declared reference (`<link rel="match">` / `<link rel="mismatch">`) and comparing them at a configurable pixel threshold. This eliminates the need for Chromium screenshots, reference image caches, or any external rendering engine.

## Key Changes

- **New `SkipReason.NoReferenceDeclared`**: Enum value for tests that declare no usable reference link or whose reference files don't exist on disk.

- **Reference link extraction and resolution**:
  - `ExtractReferenceLinks()`: Parses HTML to extract all `rel="match"` and `rel="mismatch"` links in document order, returning `WptReferenceLink` records.
  - `TryResolveReferenceHref()`: Resolves reference hrefs (root-relative or relative-to-test) and strips query/fragment, handling both HTML documents and bitmap images.
  - `IsReferenceImagePath()`: Detects when a reference is a bitmap (`.png`, `.jpg`, `.webp`, etc.) rather than an HTML document.

- **Suite membership filtering**:
  - `HasResolvableReference()`: Checks if a test declares at least one reference that exists on disk.
  - `FilterToReferenceTests()`: Narrows a test set to only those with resolvable references, so reftest runs report only tests they can actually decide.

- **Reftest decision logic**:
  - `RunReferenceTest()`: New method that renders both test and reference with Broiler, compares them at the pass threshold, and returns a result. Handles both HTML references (rendered) and image references (decoded and compared directly).
  - `--reftests-only` flag and `referenceTestsOnly` constructor parameter to enable the mode.

- **Workflow and scripting**:
  - New `.github/workflows/wpt-reftests.yml`: CI workflow that runs reftest shards with no Chromium provisioning, caching, or reference-image generation. Includes plan → prepare → run → retry → report → persist-failed shape matching the golden-image suite.
  - New `.github/actions/run-wpt-reftest-shard/action.yml`: Composite action for provisioning and running a single reftest shard.
  - New `scripts/run-wpt-reftests.sh`: Local script to run reftests with the same options as the golden-image suite (subset, sharding, rerun manifest, failure images).

- **Testing**:
  - New `ReferenceTestModeTests` unit test class covering reference-link extraction, href resolution, suite membership filtering, and reftest decision logic.

- **Documentation**:
  - New `docs/wpt-reftests.md`: Explains what reftests are, why they need no reference images, how they differ from the golden-image suite, and how to run them locally or in CI.

## Notable Implementation Details

- Both test and reference go through the same renderer, so a shared bug that hits both identically still passes. This is a trade-off: the suite cannot catch such defects, but it also never attributes cross-engine rendering differences (fonts, scrollbars, anti-aliasing) to Broiler.

- Reference hrefs can be root-relative (`/common/blank.html`, resolved under the WPT root) or relative to the test's directory. Query strings and fragments are stripped before resolution.

- The reftest suite has its own failure manifest (`tests/wpt-baseline/failed-reftests.json`) separate from the golden-image suite's, so rerun sets from either suite don't interfere with the other.

- Reftest mode is opt-in via `--reftests-only` flag; the default behavior (golden-image comparison) is unchanged.

https://claude.ai/code/session_01UHD2iZZfxRRRASTjEskUsh