### PR TITLE
Multithreading Phase 1: rule indexing, worker pools, and batch parallelism

### DIFF
--- a/docs/architecture/multithreading.md
+++ b/docs/architecture/multithreading.md
@@ -6,6 +6,16 @@ the tooling.
 
 ## Status
 
+**Phase 1 is complete.** All four items landed; what each one turned out to be
+worth is in [What building Phase 1 changed](#what-building-phase-1-changed).
+
+| Item | State | Evidence |
+|---|---|---|
+| #1 — WPT worker pool | **Done** | `--workers <N>\|auto` in `src/Broiler.Wpt/Program.cs`; 45.2 s → 23.4 s on a 61-test subset at 4 cores, identical classification at 1, 4 and auto |
+| #20 — CLI batch parallelism | **Done** | `src/Broiler.Cli/BatchRunner.cs`; batch capture byte-identical at 1 and 4 threads, fuzz 14.8 s → 8.9 s with the same 224 failure files |
+| #2 — concurrent sub-resource fetch | **Done, partly** | `SubResourcePrefetcher`; wired to external scripts and `<link>` stylesheets. Iframes/`fetch()`/XHR are **not** wired — see the item below |
+| #11 — CSS rule indexing | **Done** | `patches/0123-css-cascade-rule-index.patch`; exit gate met — cascade cost is flat in total rules (32× rules: 30.8× → **1.64×** time, 32.0× → **1.13×** bytes); corpus `rules` page 5 219 ms → 1 842 ms; WPT unchanged |
+
 **Phase 0 is complete.** The estimates below are no longer the only evidence:
 there is a stage profile, a cascade benchmark, and a GC measurement, and three of
 the four Phase 0 items closed against their exit gates. What the numbers changed
@@ -155,6 +165,93 @@ not worth parallelizing; only its replay is.
 
 See item #19 below.
 
+## What building Phase 1 changed
+
+Four items, and the two things worth carrying forward are a shortfall and a
+constraint neither of which the plan anticipated.
+
+### 1. Rule indexing met its exit gate; the render it sits in did not move 10–100×
+
+Both statements are measurements of the same change and neither is the headline
+alone.
+
+**The exit gate — "cost scales with matched rules, not total rules" — is met.**
+`RuleScalingBenchmarks` holds the element set and the matched-rule count fixed at
+four and grows only the rules that cannot match:
+
+| Rules in sheet | Cold cascade, before | after | | Allocated, before | after |
+|---:|---:|---:|---:|---:|---:|
+| 100 | 114.9 ms | **15.74 ms** | 7.3× | 181.7 MB | **8.57 MB** |
+| 400 | 466.5 ms | **15.65 ms** | 29.8× | 722.0 MB | **8.70 MB** |
+| 1 600 | 2 532.2 ms | **18.80 ms** | 134.7× | 2 897.5 MB | **9.10 MB** |
+| 3 200 | 3 543.6 ms | **25.89 ms** | 136.9× | 5 817.9 MB | **9.69 MB** |
+
+32× the rules used to cost 30.8× the time and 32.0× the bytes; it now costs
+**1.64× the time and 1.13× the bytes**. That is the linear-in-total-rules defect
+gone, on both axes — and the allocation collapse (600× at the top of the range) is
+the second defect Phase 0 named, which no GC setting could have fixed. The
+projected 10–100× is real on this axis and exceeded at the top of it.
+
+*(Run with BenchmarkDotNet's short job, so the confidence intervals are wide — but
+the claim being made is flat-versus-linear across two orders of magnitude, which no
+plausible interval touches.)*
+
+**On a whole render it is 2.8×.** The corpus's `rules` page goes **5 218.96 ms →
+1 841.71 ms** end to end, its `parse+cascade` stage **5 035.35 ms → 1 698.11 ms**.
+That is not a contradiction: the benchmark isolates exactly the cost the index
+removes, while the stage also parses 110 296 characters of source and 900 rules and
+then cascades against the rules that *do* match. Amdahl, not a shortfall.
+
+**Consequence:** `parse+cascade` is still 92.2% of that page, and it is now unknown
+which half. The next cascade item is splitting that stage — item #12 (parallel style
+recalc) must not be started against a stage whose composition is unmeasured, and it
+would be aimed at the cascade half of a row that may now be mostly parse.
+
+### 2. The render path cannot be parallelized in-process yet, and that decides item #20's shape
+
+Item #20 reads "per-file / per-page parallelism", blocked by "Nothing". That is
+true of document conversion — `Broiler.Documents` has no assignable statics at all,
+only lookup tables — and false of everything that renders. The P0-c audit's two
+genuine unsynchronised caches (`FontsHandler`'s four dictionaries and
+`BImageRenderer._images`) sit on process-wide singletons on the render path, so two
+captures, or two layout-fuzz cases, in one process is a data race today.
+
+So the CLI parallelizes document conversion on threads and capture and layout fuzz
+across **child processes** — the same answer the WPT runner's worker pool already
+rested on, for the same reason. It is not a workaround: process isolation is what
+makes "identical output at any worker count" checkable by comparing bytes, which is
+what the global exit gate asks for.
+
+**Consequence:** item #9 (font-cache thread safety, Phase 2) gates more than the
+three items it is credited with. Until it lands, *every* CPU-parallel item on the
+render path is a process-parallel item.
+
+### 3. Item #2 is wired to two of its four call-site families, and the other two need item #17
+
+The prefetch/consume split is built and is live for external scripts and `<link>`
+stylesheets — the two places where the whole set of URLs is already known at a
+single point (the script scan; the collected sheet list). Iframes/sub-documents
+(`SubDocuments.cs`) and `fetch()`/XHR have no such point: a sub-document URL becomes
+known when the element is reached, which is the moment it is consumed, so there is
+nothing to overlap it with.
+
+That is what item #17, the speculative preload scan, is for, and the roadmap already
+says #17 "feeds step 1". The dependency is stronger than "compounds": for those two
+families the preload scan is not an amplifier, it is the only source of a prefetch
+trigger.
+
+### 4. The WPT pool is bounded by memory, and the default has to know it
+
+Sized `min(cores, availableRam / 1.5 GiB)`, which on the 4-core/13 GiB container is
+4 workers and on a 16-core box with 4 GiB free is 2. Measured on
+`css/css-backgrounds` (61 tests): 45.2 s at one worker, 23.4 s at four — 1.93×, not
+4×, because worker startup and the runner's own serial reporting are a fixed share
+of a 61-test run. On a full shard the constant amortizes.
+
+Where the memory figure cannot be read at all, the pool stays at **one** worker.
+Guessing high on an unreadable budget is how a runner OOM-kills a CI box, and the
+per-test allowance is a full GiB.
+
 ## Master table
 
 Gain is per-stage unless stated. Effort is engineering days for one person
@@ -163,8 +260,8 @@ non-deterministic correctness defect.
 
 | # | Component | Site | Currently | Parallel shape | What blocks it today | Est. gain (unmeasured) | Risk | Effort | Phase |
 |---|---|---|---|---|---|---|---|---|---|
-| 1 | Tooling | [`Broiler.Wpt/Program.cs:359`](../../src/Broiler.Wpt/Program.cs) — `foreach (var testPath in discoveredTests)` with one `WptWorkerClient` | Sequential, 1 worker process, ≤30 s/test | Work queue over *N* worker processes; results already buffered into `allResults` and sorted after the run, so order is not load-bearing | Nothing. Worker protocol is already one-command-per-line JSON over stdio | **Near-linear in worker count**; bounded by RAM, not cores (§Phase 1) | Low | 2–3 d | 1 |
-| 2 | HtmlBridge | [`ScriptExtractionService.cs:303`](../../src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs), [`ResourceLoader.cs:56`](../../src/Broiler.HtmlBridge.Dom/Runtime/ResourceLoader.cs), [`SubDocuments.cs:581`](../../src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs) | Serial `GetStringAsync(..).GetAwaiter().GetResult()`, one resource at a time | Bounded-concurrency prefetch (6/host, browser convention) into a content-addressed cache; call sites then hit the cache | Call sites are synchronous and ordering-sensitive for `document.write`; needs a prefetch/consume split, not an `async` conversion | **Page-load latency 3–6×** on multi-resource pages (latency, not CPU) | Medium | 5–8 d | 1 |
+| 1 | Tooling | [`Broiler.Wpt/Program.cs`](../../src/Broiler.Wpt/Program.cs) `RunDiscoveredTests` — **DONE** | Pool of *N* worker processes draining a shared queue (`--workers <N>\|auto`) | Work queue over *N* worker processes; results already buffered into `allResults` and sorted after the run, so order is not load-bearing | Nothing. Worker protocol is already one-command-per-line JSON over stdio | **Measured: 1.93× at 4 workers** on a 61-test subset (45.2 s → 23.4 s); identical classification at 1, 4 and auto. Bounded by RAM, not cores | Low | Done | 1 |
+| 2 | HtmlBridge | [`ScriptExtractionService.cs:303`](../../src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs), [`ResourceLoader.cs:56`](../../src/Broiler.HtmlBridge.Dom/Runtime/ResourceLoader.cs), [`SubDocuments.cs:581`](../../src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs) | Serial `GetStringAsync(..).GetAwaiter().GetResult()`, one resource at a time | Bounded-concurrency prefetch (6/host, browser convention) into a content-addressed cache; call sites then hit the cache | Call sites are synchronous and ordering-sensitive for `document.write`; needs a prefetch/consume split, not an `async` conversion | **Done for scripts and `<link>` stylesheets** (`SubResourcePrefetcher`, bounded 6/host). Iframes and `fetch()`/XHR are not wired: they have no point where the URL set is known before it is consumed, which is what item #17 supplies | Medium | Done (scripts, sheets) | 1 |
 | 3 | Graphics | [`Rendering/BCanvas.cs`](../../Broiler.Graphics/Broiler.Graphics/Rendering/BCanvas.cs) `FillRect:106`, `FillGlyphContours:241`, `DrawBitmap:345`, `FillRectTiled:389`, `FillLinear/Radial/ConicGradientRect:425/468/508` | Single-threaded scanline loops | `Parallel.For` over scanline bands; per-band coverage buffer and clip stack | Per-row `coverage[]` and the `_clipOperations` list are instance state shared across rows — must become per-worker | **4–6× on 8 cores** (estimate) of a stage **measured at 46.9–80.8% of a render** — the largest measured share in the document | Low | 4–6 d | 2 |
 | 4 | HTML | [`Broiler.HTML.Image/BCanvas.cs`](../../Broiler.HTML/Source/Broiler.HTML.Image/BCanvas.cs) `:128/262/364/406/456/508/554/655` | Same scanline shape, second copy of the rasterizer | Same as #3 | Same as #3, plus the duplication itself | Same as #3 | Low | 3–4 d (or 0, if unified with #3 first) | 2 |
 | 5 | Graphics / Layout | [`DisplayList.cs`](../../Broiler.Layout/Broiler.Layout/IR/DisplayList.cs) + [`BRenderList.cs`](../../Broiler.Graphics/Broiler.Graphics/RenderList/BRenderList.cs) replayed by [`RGraphicsRasterBackend`](../../Broiler.HTML/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs) | One pass, whole surface | **Tile-parallel replay**: partition the target into tiles, each worker replays the whole immutable list clipped to its tile | Already immutable and flat with explicit `ClipItem`/`RestoreItem`/`OpacityItem` stack items — this is the right structure. Needs per-tile state and layer (`OpacityItem`) handling | **5–7× on 8 cores** (estimate) for full-page renders; better locality than #3. **Measured:** the replay is 46.9–80.8% of a render while the display-list *build* is 0.3–0.7%, so only the replay is worth parallelizing | Low–Medium | 6–10 d | 2 |
@@ -173,7 +270,7 @@ non-deterministic correctness defect.
 | 8 | Media / HTML | Per-image decode, driven from [`ImageLoadHandler.cs:177`](../../Broiler.HTML/Source/Broiler.HTML.Core/Handlers/ImageLoadHandler.cs) | Already `ThreadPool.QueueUserWorkItem` for file reads; decode is on the completion path | Decode *N* page images concurrently — coarser and better than #6/#7 | Decoder statics must be verified re-entrant; `BImageRenderer._images` is a plain `Dictionary` | **Near-linear in image count** up to core count | Low | 2–3 d | 2 |
 | 9 | Graphics | [`FontsHandler.cs:13`](../../Broiler.Graphics/Broiler.Graphics/Text/FontsHandler.cs) `_fontsCache`, `_featuredFontsCache`; [`TrueTypeFont.cs`](../../Broiler.Graphics/Broiler.Graphics/Text/TrueTypeFont.cs) | Plain `Dictionary`, no synchronization | Not a speedup itself — a **hard prerequisite** for #10, #12, #13 | Nested `Dictionary<string, Dictionary<double, Dictionary<FontStyle, RFont>>>` corrupts under concurrent read/write | Enables ~3 items | Low | 2 d | 2 |
 | 10 | Graphics | [`ComplexTextShaper.Shape:72`](../../Broiler.Graphics/Broiler.Graphics/Text/ComplexTextShaper.cs) | Called per run during layout | Already a static pure function → parallel-safe. Add a shaped-run cache keyed by (font, text, features) | Needs #9 | **Cache alone is the bigger win**; parallel shaping 3–5× on the shaping stage | Low | 3–4 d | 2 |
-| 11 | CSS | [`CssStyleEngine.CollectFromRules:623`](../../Broiler.CSS/Broiler.CSS.Dom/CssStyleEngine.cs) — linear scan of every rule of every sheet, per element | O(elements × rules) | **Not multithreading.** Rule index (bucket by id/class/tag) + ancestor bloom filter | Nothing — this is the standard engine design and it is simply absent | **Measured:** the cascade is 96.3% of a 900-rule / 700-element render (3.68 s), and cost + allocation are both linear in *total* rules with matches held fixed (32× rules -> 30.8× time, 32.0× bytes). The document's 10–100× is a floor | Low | 8–12 d | 1 |
+| 11 | CSS | [`CssStyleEngine.CollectFromRules:623`](../../Broiler.CSS/Broiler.CSS.Dom/CssStyleEngine.cs) — linear scan of every rule of every sheet, per element | O(elements × rules) | **Not multithreading.** Rule index (bucket by id/class/tag) + ancestor bloom filter | Nothing — this is the standard engine design and it is simply absent | **DONE.** Exit gate met: with matches fixed at four, 32× the rules now costs 1.64× the time and 1.13× the bytes (was 30.8× / 32.0×) — up to **136.9× faster** and **600× less garbage** at 3 200 rules. On a whole render the corpus `rules` page is 5 218.96 ms → 1 841.71 ms (2.8×); see [What building Phase 1 changed](#what-building-phase-1-changed) §1. `patches/0123-css-cascade-rule-index.patch` | Low | Done | 1 |
 | 12 | CSS | `GetComputedStyle:151` / `GetCascadedDeclarationMap:555` over the element set | Sequential per element; caches under one global `_sync` lock | Parallel style recalc over DOM subtrees, Stylo-style | Global lock over `_cache`/`_sparseCache`/`_declaredCascadeCache` becomes the bottleneck; needs sharding + per-thread L1. Do #11 first or you parallelize the wrong thing | **2–4× on styling** after #11 | Medium | 10–15 d | 3 |
 | 13 | Layout | [`CssBox.PerformLayout:347`](../../Broiler.Layout/Broiler.Layout/Engine/CssBox.cs), [`PerformLayoutImp:37`](../../Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs) | Full-tree, in-place mutation, from the root every pass — **twice** when width is unrestricted ([`HtmlContainerInt.cs:929,936`](../../Broiler.HTML/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs)) | Parallel intrinsic sizing; parallel independent subtrees (abspos/fixed, flex+grid items, table cells, multicol, subdocuments) | Mutable shared tree; ambient thread-static state (`CssLengthParser` viewport, [`DocumentModeContext.cs:22`](../../Broiler.Layout/Broiler.Layout/DocumentModeContext.cs)); no dirty-bit invalidation to bound the work | **1.5–2.5×** of a stage **measured at 0.6–6.5% of a render** on every corpus page, including one built to load layout — so a few percent overall at best | **High** | 20–30 d | 4 |
 | 14 | Layout | Same as #13 | No incremental invalidation | **Not multithreading.** Dirty bits + relayout roots | — | **5–50× on interactive relayout** — unmeasured, and the *first-render* layout it bounds is 0.6–6.5% of wall time; the interactive case this claims is not covered by the P0-a corpus. Also the precondition that makes #13 safe | Medium | 15–20 d | 3 |
@@ -182,7 +279,7 @@ non-deterministic correctness defect.
 | 17 | DOM / HTML | [`HtmlTokenizer.cs`](../../Broiler.DOM/Broiler.Dom.Html/HtmlTokenizer.cs), [`DomParser.cs`](../../Broiler.HTML/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs) | Sequential (correctly — the HTML tokenizer is spec-sequential and cannot be parallelized) | **Speculative preload scan**: a worker scans raw bytes for `src`/`href` while the main parse runs, feeding #2 | Nothing; it is a read-only scan of an immutable byte buffer | Overlaps network with parse — compounds #2 rather than adding CPU | Low | 4–6 d | 2 |
 | 18 | JS | New: `Worker` / `MessageChannel` | Not implemented | One `JSContext` per worker thread, structured-clone message passing | Per-context state exists and `JSEngine.CurrentContext` is `AsyncLocal`, so isolation is feasible; needs the static-mutable audit from P0-c across Broiler.JS | Capability, not a speedup of existing work | High | 30–40 d | 4 |
 | 19 | Runtime | `Directory.Build.props` sets neither; `Broiler.JavaScript.Engine.Benchmarks.csproj` **does** set `ServerGarbageCollection` | Workstation GC defaults everywhere except that one benchmark project | Config knob; evaluate Server GC for headless/batch hosts | Nothing | **Measured: Server GC is 1.62× SLOWER** on a 4-core headless render (see below). Keep Workstation | Low | Done | 0 |
-| 20 | Tooling | [`Broiler.Cli`](../../src/Broiler.Cli) — capture, document convert, layout fuzz | Sequential per input | Per-file / per-page parallelism | Nothing | Near-linear in file count | Low | 2–3 d | 1 |
+| 20 | Tooling | [`Broiler.Cli`](../../src/Broiler.Cli) — capture, document convert, layout fuzz — **DONE** | Repeatable inputs + `--output-dir`, `--threads` | Threads for document convert; **child processes** for capture and fuzz | **Not "nothing":** the render path's unsynchronised caches (item #9) make two in-process renders a race, so those two go through processes | Fuzz 14.8 s → 8.9 s at 4; capture byte-identical at 1 and 4. Per-page PDF is out of scope here — the CLI shells out to the standalone Broiler.Pdf app | Low | Done | 1 |
 | 21 | Tests | [`Broiler.JavaScript.BuiltIns.Tests/AssemblyInfo.cs:3`](../../Broiler.JS/Broiler.JS/Broiler.JavaScript.BuiltIns.Tests/AssemblyInfo.cs) — `DisableTestParallelization = true` | Whole assembly serialized | Re-enable once #15 lands and per-test context isolation is confirmed | Almost certainly disabled *because* of #15 | Test-suite wall time | Low | 1–2 d | 3 |
 | 22 | Input | [`Broiler.Input.*`](../../Broiler.Input) — Linux keyboard `Task.Run`, Windows camera `new Thread`, `lock (_gate)` throughout | **Already correctly threaded** | — | — | None available | — | — | — |
 | 23 | UI | [`Broiler.UI`](../../Broiler.UI/src) measure/arrange over the widget tree | Sequential | Parallel measure is possible but widget trees are small (~hundreds of nodes) | — | Negligible; the real win is keeping layout/paint off the input thread (responsiveness, not throughput) | — | — | Not recommended |
@@ -371,13 +468,28 @@ no gain.
 
 ### Broiler.CSS
 
-1. **Rule indexing first** (item #11) — bucket rules by rightmost simple
-   selector (id / class / tag / universal) and add an ancestor bloom filter, so
-   an element tests a handful of candidate rules instead of all of them. This is
-   single-threaded and is expected to dominate every parallel option.
-   *Exit gate:* cascade benchmark from P0-a shows the per-element rule tests
-   scaling with matched rules, not total rules; computed-style output unchanged
-   across the CSS + WPT suites.
+1. **Rule indexing first** (item #11) — **DONE**, as
+   `patches/0123-css-cascade-rule-index.patch`. Rules are bucketed by their
+   rightmost simple selector (id / class / type / universal) in
+   `CssCascadeRuleIndex`; an element merges the buckets its own keys reach and
+   tests those.
+   *Exit gate — met.* `RuleScalingBenchmarks` with matches held at four: 32× the
+   rules costs 1.64× the time and 1.13× the allocation, against 30.8× and 32.0×
+   before — the per-element cost now tracks matched rules, not total rules.
+   Computed-style output unchanged: `Broiler.CSS.Tests` 341/341,
+   `Broiler.CSS.Dom.Tests` 383 passed (the 2 failures are pre-existing
+   architecture tests, verified on a clean tree), and WPT
+   `css/css-backgrounds` + `css/CSS2/linebox` is identical over 62 tests —
+   same pass/fail/skip and the same average pixel match to fourteen digits.
+   *Not built:* the ancestor bloom filter. The key buckets alone flattened the
+   scaling curve, so the filter has nothing left to remove on this benchmark;
+   it belongs with a measurement that shows descendant-combinator rejection
+   costing something.
+   Note for step 2 and item #12: the cascade now also carries a *third*
+   generation counter. The rule index is memoized against sheet/environment
+   changes only, deliberately not against the DOM-mutation invalidation that
+   clears the caches below — a sharding design must not collapse the two.
+
 2. **Shard the caches.** `_cache`, `_sparseCache`, and `_declaredCascadeCache`
    sit behind one `_sync`. Move to per-shard locks or `ConcurrentDictionary`
    with a per-thread first-level cache, keeping the existing generation-guard
@@ -525,7 +637,7 @@ Recording these so they are not revisited each time the topic comes up:
 | Phase | Contents | Rationale |
 |---|---|---|
 | **0 — Make it measurable and deterministic** | P0-a benchmarks, P0-b single-threaded event loop (#15), P0-c static-state audit, GC config evaluation (#19) | Nothing after this is trustworthy without it. #15 is a correctness fix that also removes lock overhead from the cascade. |
-| **1 — Free wins and the sequential fixes** | WPT worker pool (#1), CLI batch (#20), concurrent sub-resource fetch (#2), CSS rule indexing (#11) | Cheap, low-risk, and #1 shortens the feedback loop for everything else. #11 is single-threaded but must precede #12. |
+| **1 — Free wins and the sequential fixes** — **DONE** | WPT worker pool (#1), CLI batch (#20), concurrent sub-resource fetch (#2), CSS rule indexing (#11) | Cheap, low-risk, and #1 shortens the feedback loop for everything else. #11 is single-threaded but must precede #12. **What it changed:** #11 met its exit gate (cascade cost is now flat in total rules) but is 2.8× on a whole render, and `parse+cascade` still dominates the rule-heavy page — so #12 needs that stage split before it is started; #20 had to use processes, which makes item #9 a gate on every render-path item, not three. |
 | **2 — Raster, decode, text** | Rasterizer unification + band/tile parallelism (#3, #4, #5), font-cache safety (#9), shaped-run cache (#10), image decode (#6, #7, #8), preload scan (#17) | Largest CPU wins, disjoint memory, verifiable by exact pixel comparison. |
 | **3 — Style and incremental layout** | Cache sharding + parallel style recalc (#12), layout dirty bits (#14), parallel script compile (#16), re-enable test parallelization (#21) | Depends on Phase 1's algorithmic fixes and Phase 0's determinism. |
 | **4 — Parallel layout and workers** | Parallel intrinsic sizing and independent subtrees (#13), Web Workers (#18) | Highest cost, highest risk, lowest ceiling. Only worth starting once Phase 3's measurements say layout is still the bottleneck. |

--- a/patches/0123-css-cascade-rule-index.patch
+++ b/patches/0123-css-cascade-rule-index.patch
@@ -1,0 +1,1331 @@
+From fc7006f015384ca33d25c1d1b5cf87f10388e377 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sat, 8 Aug 2026 09:21:17 +0000
+Subject: [PATCH] Cascade: index rules by their key instead of scanning every
+ rule per element
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Multithreading roadmap item #11 — measured as the highest-value item in
+that document, ahead of every parallel item including the rasterizer, and
+single-threaded work.
+
+The cascade did a linear scan: for every element, every rule of every
+sheet, selector-matched. On the roadmap corpus's rule-heavy page that is
+96.5% of a 5.2 s render, and RuleScalingBenchmarks showed cost and
+allocation both linear in TOTAL rules with the matched set held fixed at
+four (32x the rules -> 30.8x the time, 32.0x the bytes).
+
+CssCascadeRuleIndex flattens the sheet set into document order once and
+files each rule under the simple selector its subject must carry — id,
+class, or type — with everything else in a universal bucket. An element
+then merges the buckets its own id/classes/tag reach and tests only those.
+
+Two properties carry the correctness argument, and both are deliberate:
+
+  - A key is a NECESSARY condition for a match, never a sufficient one.
+    Candidates still go through the unchanged selector matcher, so the
+    index can only be wrong by omitting a rule — and every case that is
+    not certainly narrower (a bare :is()/:not(), an attribute-only
+    compound, a namespaced type, an escaped identifier, anything the
+    scanner does not model) resolves to universal. Losing selectivity
+    costs time; losing a rule loses the page.
+  - Candidates come back in document order via a k-way merge of the
+    buckets, so the cascade's source-order tie-break is unchanged. A rule
+    that never matched never advanced the tie-break counter, so visiting
+    only candidates yields the same winners.
+
+@media and @supports are resolved once at build time — they depend on the
+environment and the feature oracle, both fixed for an index's lifetime —
+so non-applying groups cost nothing per element. @container depends on the
+element, so those conditions travel with the entry and are evaluated per
+candidate. The index is memoized against a sheet generation bumped only by
+sheet and environment changes, never by DOM mutation, which bumps the
+computed-style caches constantly.
+
+The linear scan is kept and kept reachable behind CssStyleEngine's
+UseRuleIndex, as the index's oracle: CssCascadeRuleIndexTests asserts the
+two cascades agree property by property, over hand-written selector shapes
+and over a generated 1200-rule sheet against a 120-element document.
+
+Measured on the roadmap corpus: the rules page goes from 5218.96 ms to
+1841.71 ms end to end, its parse+cascade stage from 5035.35 ms to
+1698.11 ms. WPT css/css-backgrounds + css/CSS2/linebox is unchanged —
+same pass/fail/skip on all 62 tests and the same 98.62% average pixel
+match.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_019qdy431jVeVWp5as6fYXNQ
+---
+ .../CssCascadeRuleIndexTests.cs               | 344 ++++++++++++++++++
+ Broiler.CSS.Dom/Broiler.CSS.Dom.csproj        |   4 +
+ Broiler.CSS.Dom/CssCascadeRuleIndex.cs        | 281 ++++++++++++++
+ Broiler.CSS.Dom/CssStyleEngine.cs             | 271 +++++++++-----
+ Broiler.CSS/CssSelectorKey.cs                 |  42 +++
+ Broiler.CSS/CssSelectorParser.cs              | 181 +++++++++
+ 6 files changed, 1035 insertions(+), 88 deletions(-)
+ create mode 100644 Broiler.CSS.Dom.Tests/CssCascadeRuleIndexTests.cs
+ create mode 100644 Broiler.CSS.Dom/CssCascadeRuleIndex.cs
+ create mode 100644 Broiler.CSS/CssSelectorKey.cs
+
+diff --git a/Broiler.CSS.Dom.Tests/CssCascadeRuleIndexTests.cs b/Broiler.CSS.Dom.Tests/CssCascadeRuleIndexTests.cs
+new file mode 100644
+index 0000000..daa93eb
+--- /dev/null
++++ b/Broiler.CSS.Dom.Tests/CssCascadeRuleIndexTests.cs
+@@ -0,0 +1,344 @@
++using Broiler.Dom;
++
++namespace Broiler.CSS.Dom.Tests;
++
++/// <summary>
++/// Covers the cascade rule index (multithreading roadmap item #11), mostly by differential
++/// testing: the linear scan the index replaced is still reachable behind
++/// <c>CssStyleEngine.UseRuleIndex</c>, so every case here asserts that the indexed cascade and
++/// the exhaustive one agree. An optimisation whose claim is "same answers, less work" is worth
++/// exactly as much as the evidence for the first half.
++/// </summary>
++public sealed class CssCascadeRuleIndexTests
++{
++    private static (DomDocument Document, DomElement Html, DomElement Body) NewDocument()
++    {
++        var document = new DomDocument();
++        var html = document.CreateElement("html");
++        var body = document.CreateElement("body");
++        document.AppendChild(html);
++        html.AppendChild(body);
++        return (document, html, body);
++    }
++
++    private static CssStyleEngine EngineWith(string css, bool useRuleIndex, CssEnvironment? environment = null)
++    {
++        var engine = new CssStyleEngine { UseRuleIndex = useRuleIndex };
++        if (environment is { } env)
++            engine.UpdateEnvironment(env);
++        engine.AddStyleSheet(new CssParser().ParseStyleSheet(css));
++        return engine;
++    }
++
++    /// <summary>
++    /// Asserts the indexed and exhaustive cascades agree for every element in the document that
++    /// <paramref name="build"/> populates.
++    /// </summary>
++    private static void AssertCascadesAgree(string css, Action<DomElement> build, CssEnvironment? environment = null)
++    {
++        var (_, _, indexedBody) = NewDocument();
++        build(indexedBody);
++        var indexed = EngineWith(css, useRuleIndex: true, environment);
++
++        var (_, _, scannedBody) = NewDocument();
++        build(scannedBody);
++        var scanned = EngineWith(css, useRuleIndex: false, environment);
++
++        var indexedElements = indexedBody.Descendants().OfType<DomElement>().ToList();
++        var scannedElements = scannedBody.Descendants().OfType<DomElement>().ToList();
++        Assert.Equal(scannedElements.Count, indexedElements.Count);
++        Assert.NotEmpty(indexedElements);
++
++        for (var i = 0; i < indexedElements.Count; i++)
++        {
++            var expected = scanned.GetCascadedStyle(scannedElements[i]);
++            var actual = indexed.GetCascadedStyle(indexedElements[i]);
++
++            Assert.Equal(
++                expected.OrderBy(kv => kv.Key, StringComparer.Ordinal).ToList(),
++                actual.OrderBy(kv => kv.Key, StringComparer.Ordinal).ToList());
++        }
++    }
++
++    private static DomElement Add(DomElement parent, string tag, string? id = null, string? className = null)
++    {
++        var element = parent.OwnerDocument!.CreateElement(tag);
++        if (id is not null)
++            element.Id = id;
++        if (className is not null)
++            element.ClassName = className;
++        parent.AppendChild(element);
++        return element;
++    }
++
++    [Fact]
++    public void Id_Class_And_Type_Keyed_Rules_Cascade_As_They_Did()
++    {
++        AssertCascadesAgree(
++            """
++            div { color: red; margin: 1px; }
++            .c { color: green; }
++            #x { color: blue; }
++            span { color: purple; }
++            .other { color: pink; }
++            #absent { color: black; }
++            """,
++            body =>
++            {
++                Add(body, "div", id: "x", className: "c");
++                Add(body, "div", className: "c");
++                Add(body, "span");
++                Add(body, "p");
++            });
++    }
++
++    [Fact]
++    public void Source_Order_Still_Breaks_A_Specificity_Tie()
++    {
++        // The index visits only candidates, so if it visited them in bucket order rather than
++        // document order the loser of a tie would win. This is the case that catches that.
++        AssertCascadesAgree(
++            ".c { color: red; } div { color: black; } .c { color: green; }",
++            body => Add(body, "div", className: "c"));
++    }
++
++    [Fact]
++    public void A_Rule_Reachable_Through_Two_Keys_Is_Applied_Once()
++    {
++        AssertCascadesAgree(
++            ".a, .b { color: red; } .a.b { color: green; }",
++            body => Add(body, "div", className: "a b"));
++    }
++
++    [Fact]
++    public void Descendant_And_Child_Combinators_Key_On_The_Subject()
++    {
++        AssertCascadesAgree(
++            """
++            #main .row > td.cell { color: green; }
++            .row td { color: red; }
++            body div span { color: blue; }
++            """,
++            body =>
++            {
++                var main = Add(body, "div", id: "main");
++                var row = Add(main, "div", className: "row");
++                Add(row, "td", className: "cell");
++                Add(row, "td");
++                Add(Add(body, "div"), "span");
++            });
++    }
++
++    [Theory]
++    [InlineData("[data-x] { color: green; }")]
++    [InlineData("*[hidden] { color: green; }")]
++    [InlineData(":not(.c) { color: green; }")]
++    [InlineData(":is(.c, .d) { color: green; }")]
++    [InlineData("* { color: green; }")]
++    [InlineData(":root { color: green; }")]
++    public void Selectors_With_No_Narrowing_Key_Still_Reach_Every_Element(string css)
++    {
++        // These are the ones a too-clever key extractor loses: each can match an element that
++        // carries no id, class or tag the index could have filed it under.
++        AssertCascadesAgree(
++            css + " div { margin: 1px; }",
++            body =>
++            {
++                var div = Add(body, "div");
++                div.SetAttribute("data-x", "1");
++                div.SetAttribute("hidden", "");
++                Add(body, "span", className: "c");
++            });
++    }
++
++    [Fact]
++    public void A_Pseudo_Element_Rule_Keys_On_The_Element_It_Is_Attached_To()
++    {
++        AssertCascadesAgree(
++            "div::before { color: green; } .c::after { color: red; }",
++            body => Add(body, "div", className: "c"));
++    }
++
++    [Fact]
++    public void Rules_Inside_A_Matching_Media_Query_Are_Indexed()
++    {
++        AssertCascadesAgree(
++            "@media (min-width: 100px) { div { color: green; } } div { margin: 1px; }",
++            body => Add(body, "div"),
++            new CssEnvironment(800, 600));
++    }
++
++    [Fact]
++    public void Rules_Inside_A_Non_Matching_Media_Query_Are_Dropped()
++    {
++        AssertCascadesAgree(
++            "@media (min-width: 2000px) { div { color: green; } } div { color: red; }",
++            body => Add(body, "div"),
++            new CssEnvironment(800, 600));
++    }
++
++    [Fact]
++    public void Rules_Inside_A_Supports_Condition_Follow_The_Condition()
++    {
++        AssertCascadesAgree(
++            """
++            @supports (color: green) { div { color: green; } }
++            @supports (unknown-property: 1) { div { color: red; } }
++            """,
++            body => Add(body, "div"));
++    }
++
++    [Fact]
++    public void Nested_Conditional_Groups_Follow_Every_Enclosing_Condition()
++    {
++        AssertCascadesAgree(
++            "@media (min-width: 100px) { @supports (color: green) { .c { color: green; } } }",
++            body => Add(body, "div", className: "c"),
++            new CssEnvironment(800, 600));
++    }
++
++    [Fact]
++    public void A_Sheet_Added_After_The_First_Cascade_Rebuilds_The_Index()
++    {
++        // The index is memoized against the sheet set; a stale one would silently ignore a sheet
++        // added after the first query, which is exactly what a document that loads CSS late does.
++        var (_, _, body) = NewDocument();
++        var div = Add(body, "div", className: "c");
++
++        var engine = new CssStyleEngine();
++        engine.AddStyleSheet(new CssParser().ParseStyleSheet("div { color: red; }"));
++        Assert.Equal("red", engine.GetCascadedStyle(div)["color"]);
++
++        engine.AddStyleSheet(new CssParser().ParseStyleSheet(".c { color: green; }"));
++        Assert.Equal("green", engine.GetCascadedStyle(div)["color"]);
++    }
++
++    [Fact]
++    public void Clearing_The_Sheets_Empties_The_Index()
++    {
++        var (_, _, body) = NewDocument();
++        var div = Add(body, "div");
++
++        var engine = new CssStyleEngine();
++        engine.AddStyleSheet(new CssParser().ParseStyleSheet("div { color: red; }"));
++        Assert.Equal("red", engine.GetCascadedStyle(div)["color"]);
++
++        engine.ClearStyleSheets();
++        Assert.False(engine.GetCascadedStyle(div).ContainsKey("color"));
++    }
++
++    [Fact]
++    public void Changing_The_Viewport_Re_Resolves_Media_Queries()
++    {
++        var (_, _, body) = NewDocument();
++        var div = Add(body, "div");
++
++        var engine = new CssStyleEngine();
++        engine.UpdateEnvironment(new CssEnvironment(800, 600));
++        engine.AddStyleSheet(new CssParser().ParseStyleSheet("@media (min-width: 1000px) { div { color: green; } }"));
++        Assert.False(engine.GetCascadedStyle(div).ContainsKey("color"));
++
++        engine.UpdateEnvironment(new CssEnvironment(1200, 600));
++        Assert.Equal("green", engine.GetCascadedStyle(div)["color"]);
++    }
++
++    [Fact]
++    public void The_Index_Agrees_With_The_Scan_Across_A_Generated_Sheet_And_Document()
++    {
++        // The shape the measurement used: many rules, few matches. Generated rather than
++        // hand-written so the agreement is asserted over hundreds of selector/element pairs
++        // instead of the handful anyone would think to write down.
++        var css = new System.Text.StringBuilder();
++        for (var i = 0; i < 300; i++)
++        {
++            css.Append(CultureInvariant($".gen-{i} {{ padding: {i}px; }}"));
++            css.Append(CultureInvariant($"#id-{i} {{ margin: {i}px; }}"));
++            css.Append(CultureInvariant($"div.gen-{i} span {{ color: rgb({i % 256}, 0, 0); }}"));
++            css.Append(CultureInvariant($"[data-gen=\"{i}\"] {{ border-width: {i}px; }}"));
++        }
++
++        AssertCascadesAgree(css.ToString(), body =>
++        {
++            for (var i = 0; i < 60; i++)
++            {
++                var div = Add(body, "div", id: $"id-{i * 5}", className: $"gen-{i * 3} shared");
++                div.SetAttribute("data-gen", (i * 7).ToString(System.Globalization.CultureInfo.InvariantCulture));
++                Add(div, "span", className: $"gen-{i}");
++            }
++        });
++    }
++
++    private static string CultureInvariant(FormattableString text) =>
++        FormattableString.Invariant(text);
++
++    [Fact]
++    public void The_Index_Files_Keyed_Rules_Away_From_The_Universal_Bucket()
++    {
++        // The performance claim, stated as a property rather than a timing: of these six rules
++        // only the two that could match anything are left for every element to test.
++        var index = CssCascadeRuleIndex.Build(
++            [(new CssParser().ParseStyleSheet(
++                """
++                div { color: red; }
++                .c { color: green; }
++                #x { color: blue; }
++                #main .row > td.cell { color: black; }
++                [data-x] { color: pink; }
++                :is(.a, .b) { color: grey; }
++                """), CssOrigin.Author)],
++            _ => true,
++            _ => true);
++
++        Assert.Equal(6, index.RuleCount);
++        Assert.Equal(2, index.UniversalRuleCount);
++    }
++
++    [Fact]
++    public void An_Element_Only_Sees_Rules_Its_Own_Keys_Reach()
++    {
++        var index = CssCascadeRuleIndex.Build(
++            [(new CssParser().ParseStyleSheet(
++                """
++                div { color: red; }
++                .c { color: green; }
++                #x { color: blue; }
++                span { color: purple; }
++                #other { color: black; }
++                .absent { color: pink; }
++                """), CssOrigin.Author)],
++            _ => true,
++            _ => true);
++
++        var (_, _, body) = NewDocument();
++        var div = Add(body, "div", id: "x", className: "c");
++
++        var candidates = new List<int>();
++        index.CollectCandidates(div, candidates);
++
++        // div, .c and #x — not span, #other or .absent.
++        Assert.Equal([0, 1, 2], candidates);
++    }
++
++    [Fact]
++    public void Candidates_Come_Back_In_Document_Order()
++    {
++        var index = CssCascadeRuleIndex.Build(
++            [(new CssParser().ParseStyleSheet(
++                """
++                #x { color: blue; }
++                * { color: grey; }
++                .c { color: green; }
++                div { color: red; }
++                """), CssOrigin.Author)],
++            _ => true,
++            _ => true);
++
++        var (_, _, body) = NewDocument();
++        var div = Add(body, "div", id: "x", className: "c");
++
++        var candidates = new List<int>();
++        index.CollectCandidates(div, candidates);
++
++        Assert.Equal([0, 1, 2, 3], candidates);
++    }
++}
+diff --git a/Broiler.CSS.Dom/Broiler.CSS.Dom.csproj b/Broiler.CSS.Dom/Broiler.CSS.Dom.csproj
+index cd2541b..534fe72 100644
+--- a/Broiler.CSS.Dom/Broiler.CSS.Dom.csproj
++++ b/Broiler.CSS.Dom/Broiler.CSS.Dom.csproj
+@@ -16,4 +16,8 @@
+     <ProjectReference Include="$(BroilerDomPath)" />
+   </ItemGroup>
+ 
++  <ItemGroup>
++    <InternalsVisibleTo Include="Broiler.CSS.Dom.Tests" />
++  </ItemGroup>
++
+ </Project>
+diff --git a/Broiler.CSS.Dom/CssCascadeRuleIndex.cs b/Broiler.CSS.Dom/CssCascadeRuleIndex.cs
+new file mode 100644
+index 0000000..c55be92
+--- /dev/null
++++ b/Broiler.CSS.Dom/CssCascadeRuleIndex.cs
+@@ -0,0 +1,281 @@
++using System;
++using System.Collections.Generic;
++using Broiler.Dom;
++
++namespace Broiler.CSS.Dom;
++
++/// <summary>
++/// A cascade-ready view of a stylesheet set: every style rule flattened into document order and
++/// filed under the simple selector its subject must carry, so an element tests a handful of
++/// candidate rules instead of all of them. Multithreading roadmap item #11.
++/// </summary>
++/// <remarks>
++/// <para>
++/// The cascade was a linear scan: for every element, every rule of every sheet, selector-matched.
++/// The measured shape of that is in <c>docs/architecture/multithreading.md</c> — on a 900-rule,
++/// 700-element page the cascade is 96.3% of a 5.0 s render, and holding the <em>matched</em> rule
++/// count fixed at four while growing the sheet from 100 to 3 200 rules took the cold cascade from
++/// 114.9 ms to 3 543.6 ms and the allocation from 181.7 MB to 5 817.9 MB. Cost was linear in
++/// total rules; it should be linear in matched ones.
++/// </para>
++/// <para>
++/// <b>Correctness rests on two properties, both deliberate.</b>
++/// </para>
++/// <list type="number">
++/// <item><description>
++/// A key is a <em>necessary</em> condition for a match, never a sufficient one — see
++/// <see cref="CssSelectorParser.GetKey"/>. Candidates still go through the full selector matcher
++/// unchanged, so the index can only ever be wrong by <em>omitting</em> a rule, and every
++/// uncertain case is filed under the universal bucket instead.
++/// </description></item>
++/// <item><description>
++/// Candidates are returned in document order, the order the linear scan visited them in. The
++/// cascade's tie-break counter is relative, and a rule that never matched never advanced it, so
++/// visiting only the candidates produces the same winners the full scan did.
++/// </description></item>
++/// </list>
++/// <para>
++/// <b>Conditional groups are resolved as far as they can be, once.</b> <c>@media</c> and
++/// <c>@supports</c> depend on the environment and the feature oracle, both fixed for an index's
++/// lifetime, so a group that does not apply is dropped at build time and costs nothing per
++/// element. <c>@container</c> depends on the element being styled, so those conditions travel with
++/// the entry and are evaluated per candidate — but only for candidates, which is already far fewer
++/// evaluations than the scan performed.
++/// </para>
++/// <para>
++/// An index is immutable once built. The engine rebuilds it when the sheet set or environment
++/// changes, and — importantly — <em>not</em> when the DOM mutates: the index is a function of the
++/// stylesheets alone, so DOM churn, which invalidates the computed-style caches constantly, must
++/// not throw it away.
++/// </para>
++/// </remarks>
++internal sealed class CssCascadeRuleIndex
++{
++    /// <summary>
++    /// One style rule as the cascade will visit it: its origin, its position in document order,
++    /// and any element-dependent conditional groups enclosing it.
++    /// </summary>
++    internal readonly record struct Entry(
++        CssStyleRule Rule,
++        CssOrigin Origin,
++        CssAtRule[]? ContainerConditions);
++
++    private readonly Entry[] _entries;
++    private readonly Dictionary<string, List<int>> _byId;
++    private readonly Dictionary<string, List<int>> _byClass;
++    private readonly Dictionary<string, List<int>> _byType;
++    private readonly List<int> _universal;
++
++    private CssCascadeRuleIndex(
++        Entry[] entries,
++        Dictionary<string, List<int>> byId,
++        Dictionary<string, List<int>> byClass,
++        Dictionary<string, List<int>> byType,
++        List<int> universal)
++    {
++        _entries = entries;
++        _byId = byId;
++        _byClass = byClass;
++        _byType = byType;
++        _universal = universal;
++    }
++
++    /// <summary>Total style rules in the index, after conditional-group filtering.</summary>
++    internal int RuleCount => _entries.Length;
++
++    /// <summary>Rules no key could narrow, which every element has to test.</summary>
++    internal int UniversalRuleCount => _universal.Count;
++
++    /// <summary>
++    /// Builds an index over the sheets in cascade order. <paramref name="mediaApplies"/> and
++    /// <paramref name="supportsApplies"/> decide the environment-fixed conditional groups now;
++    /// <c>@container</c> groups are kept for per-element evaluation.
++    /// </summary>
++    internal static CssCascadeRuleIndex Build(
++        IReadOnlyList<(CssStyleSheet Sheet, CssOrigin Origin)> sheets,
++        Func<string, bool> mediaApplies,
++        Func<string, bool> supportsApplies)
++    {
++        var entries = new List<Entry>();
++        var byId = new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase);
++        var byClass = new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase);
++        var byType = new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase);
++        var universal = new List<int>();
++
++        void File(int entryIndex, CssStyleRule rule)
++        {
++            var filed = false;
++
++            foreach (var selector in rule.Selectors.Selectors)
++            {
++                var key = CssSelectorParser.GetKey(selector.Text);
++                var bucket = key.Kind switch
++                {
++                    CssSelectorKeyKind.Id => byId,
++                    CssSelectorKeyKind.Class => byClass,
++                    CssSelectorKeyKind.Type => byType,
++                    _ => null,
++                };
++
++                if (bucket is null)
++                {
++                    // One unkeyable selector in the list makes the whole rule universal: the rule
++                    // is visited as a unit, and dropping it from the universal bucket because a
++                    // *different* selector in the same list was keyable would lose the match.
++                    universal.Add(entryIndex);
++                    return;
++                }
++
++                var list = bucket.TryGetValue(key.Name, out var existing)
++                    ? existing
++                    : bucket[key.Name] = [];
++
++                // A selector list may name the same key twice (`.a p, .b p`); one entry per bucket
++                // is enough, and duplicates would make the candidate merge do needless work.
++                if (list.Count == 0 || list[^1] != entryIndex)
++                    list.Add(entryIndex);
++
++                filed = true;
++            }
++
++            // A rule with no selectors at all can never match; filing it universally would only
++            // make every element pay for it.
++            if (!filed)
++                return;
++        }
++
++        void Walk(IReadOnlyList<CssRule> rules, CssOrigin origin, List<CssAtRule>? containerConditions)
++        {
++            foreach (var rule in rules)
++            {
++                switch (rule)
++                {
++                    case CssStyleRule styleRule:
++                        entries.Add(new Entry(
++                            styleRule,
++                            origin,
++                            containerConditions is { Count: > 0 } ? containerConditions.ToArray() : null));
++                        File(entries.Count - 1, styleRule);
++                        break;
++
++                    case CssAtRule atRule when atRule.Name.Equals("media", StringComparison.OrdinalIgnoreCase):
++                        if (mediaApplies(atRule.Prelude))
++                            Walk(atRule.Rules, origin, containerConditions);
++                        break;
++
++                    case CssAtRule atRule when atRule.Name.Equals("supports", StringComparison.OrdinalIgnoreCase):
++                        if (supportsApplies(atRule.Prelude))
++                            Walk(atRule.Rules, origin, containerConditions);
++                        break;
++
++                    case CssAtRule atRule when atRule.Name.Equals("container", StringComparison.OrdinalIgnoreCase):
++                    {
++                        // Element-dependent: kept, not decided.
++                        var nested = containerConditions is null
++                            ? [atRule]
++                            : new List<CssAtRule>(containerConditions) { atRule };
++                        Walk(atRule.Rules, origin, nested);
++                        break;
++                    }
++                }
++            }
++        }
++
++        foreach (var (sheet, origin) in sheets)
++            Walk(sheet.Rules, origin, containerConditions: null);
++
++        return new CssCascadeRuleIndex([.. entries], byId, byClass, byType, universal);
++    }
++
++    /// <summary>
++    /// Appends the entry indices <paramref name="element"/> could match, in document order, to
++    /// <paramref name="candidates"/> (which is cleared first).
++    /// </summary>
++    /// <remarks>
++    /// The buckets are each already in ascending document order, so this is a k-way merge rather
++    /// than a sort — and the merge is what restores the visiting order the linear scan had, which
++    /// is what keeps the cascade's tie-breaking identical.
++    /// </remarks>
++    internal void CollectCandidates(DomElement element, List<int> candidates)
++    {
++        candidates.Clear();
++
++        // At most: universal + type + id + one per class.
++        var lists = new List<List<int>>(4);
++
++        if (_universal.Count > 0)
++            lists.Add(_universal);
++
++        if (_byType.Count > 0 && _byType.TryGetValue(element.LocalName, out var typeBucket))
++            lists.Add(typeBucket);
++
++        if (_byId.Count > 0 &&
++            element.GetAttribute("id") is { Length: > 0 } id &&
++            _byId.TryGetValue(id, out var idBucket))
++        {
++            lists.Add(idBucket);
++        }
++
++        if (_byClass.Count > 0 && element.GetAttribute("class") is { Length: > 0 } classAttribute)
++        {
++            foreach (var className in classAttribute.Split(
++                         (char[]?)null,
++                         StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
++            {
++                if (_byClass.TryGetValue(className, out var classBucket))
++                    lists.Add(classBucket);
++            }
++        }
++
++        switch (lists.Count)
++        {
++            case 0:
++                return;
++
++            case 1:
++                candidates.AddRange(lists[0]);
++                return;
++        }
++
++        Merge(lists, candidates);
++    }
++
++    /// <summary>Merges ascending index lists into one ascending list, dropping duplicates.</summary>
++    private static void Merge(List<List<int>> lists, List<int> candidates)
++    {
++        var cursors = new int[lists.Count];
++        var previous = -1;
++
++        while (true)
++        {
++            var smallest = int.MaxValue;
++            var from = -1;
++
++            for (var i = 0; i < lists.Count; i++)
++            {
++                var cursor = cursors[i];
++                if (cursor < lists[i].Count && lists[i][cursor] < smallest)
++                {
++                    smallest = lists[i][cursor];
++                    from = i;
++                }
++            }
++
++            if (from < 0)
++                return;
++
++            cursors[from]++;
++
++            // A rule reachable through two keys (`.a.b` on an element with both) must be visited
++            // once, exactly as the linear scan visited it once.
++            if (smallest != previous)
++            {
++                candidates.Add(smallest);
++                previous = smallest;
++            }
++        }
++    }
++
++    /// <summary>The entry at <paramref name="index"/>, as returned by <see cref="CollectCandidates"/>.</summary>
++    internal Entry this[int index] => _entries[index];
++}
+diff --git a/Broiler.CSS.Dom/CssStyleEngine.cs b/Broiler.CSS.Dom/CssStyleEngine.cs
+index ff4616a..9cb885d 100644
+--- a/Broiler.CSS.Dom/CssStyleEngine.cs
++++ b/Broiler.CSS.Dom/CssStyleEngine.cs
+@@ -23,19 +23,19 @@ namespace Broiler.CSS.Dom;
+ public sealed partial class CssStyleEngine
+ {
+     private readonly CssSelectorMatcher _matcher;
+-    // Guards every mutable field below (_sheets, the three memo caches, _observedDocuments,
+-    // _registrations, _cacheGeneration). The engine is re-entered concurrently: the HtmlBridge's
+-    // GetComputedProps routes through this engine's sparse projection, and JS continuations
+-    // dispatched on ThreadPool threads run that computed-style/geometry work concurrently with the
+-    // main-thread layout pass — a plain Dictionary/List corrupts under that race and aborts the
+-    // process ("non-concurrent collections must have exclusive access", WPT #1445; the sibling
+-    // bridge memo maps were made concurrent for the same reason in #1143). Critical sections are
+-    // kept tight and NEVER span the cascade computation, which calls back into the host (selector
+-    // matching → DOM bridge → re-sync of this engine's stylesheets); holding the lock across that
+-    // re-entrant callback is unnecessary (Monitor is reentrant per-thread) and would widen the
+-    // critical section for no benefit. Stylesheet snapshots + the cache-store generation guard make
+-    // the lock-free compute window self-consistent.
+-    private readonly object _sync = new();
++    // Guards every mutable field below (_sheets, the three memo caches, _observedDocuments,
++    // _registrations, _cacheGeneration). The engine is re-entered concurrently: the HtmlBridge's
++    // GetComputedProps routes through this engine's sparse projection, and JS continuations
++    // dispatched on ThreadPool threads run that computed-style/geometry work concurrently with the
++    // main-thread layout pass — a plain Dictionary/List corrupts under that race and aborts the
++    // process ("non-concurrent collections must have exclusive access", WPT #1445; the sibling
++    // bridge memo maps were made concurrent for the same reason in #1143). Critical sections are
++    // kept tight and NEVER span the cascade computation, which calls back into the host (selector
++    // matching → DOM bridge → re-sync of this engine's stylesheets); holding the lock across that
++    // re-entrant callback is unnecessary (Monitor is reentrant per-thread) and would widen the
++    // critical section for no benefit. Stylesheet snapshots + the cache-store generation guard make
++    // the lock-free compute window self-consistent.
++    private readonly object _sync = new();
+     private readonly List<StyleSheetEntry> _sheets = [];
+     private readonly Dictionary<(DomElement Element, string? Pseudo), CssComputedStyle> _cache = [];
+     // Sparse computed-style memo: the specified + sparse-inheritance projection (no
+@@ -56,6 +56,14 @@ public sealed partial class CssStyleEngine
+     // stylesheet re-sync (host callback during selector matching, see the _sheets
+     // snapshot note in GetCascadedDeclarationMap) can never store a stale entry.
+     private int _cacheGeneration;
++    // Bumped only when the *stylesheets* or the environment change — never by a DOM mutation.
++    // The rule index is a function of the sheets alone, and _cacheGeneration is bumped on every
++    // mutation, so keying the index on that would rebuild it constantly for no reason.
++    private int _sheetGeneration;
++    // The cascade rule index for _sheetGeneration, built on first use (multithreading roadmap
++    // item #11). Immutable once built, so a cascade can hold it while the engine re-syncs.
++    private CssCascadeRuleIndex? _ruleIndex;
++    private int _ruleIndexGeneration = -1;
+     private readonly HashSet<DomDocument> _observedDocuments = [];
+     private CssEnvironment _environment = CssEnvironment.Headless;
+     // Host-supplied override for an element's inline declaration block. The HtmlBridge
+@@ -93,23 +101,25 @@ public sealed partial class CssStyleEngine
+     public void AddStyleSheet(CssStyleSheet sheet, CssOrigin origin = CssOrigin.Author)
+     {
+         ArgumentNullException.ThrowIfNull(sheet);
+-        lock (_sync)
+-        {
+-            _sheets.Add(new StyleSheetEntry(sheet, origin));
+-            InvalidateAll();
+-        }
++        lock (_sync)
++        {
++            _sheets.Add(new StyleSheetEntry(sheet, origin));
++            _sheetGeneration++;
++            InvalidateAll();
++        }
+     }
+ 
+     /// <summary>Removes all registered stylesheets.</summary>
+     public void ClearStyleSheets()
+     {
+-        lock (_sync)
+-        {
+-            if (_sheets.Count == 0)
+-                return;
+-            _sheets.Clear();
+-            InvalidateAll();
+-        }
++        lock (_sync)
++        {
++            if (_sheets.Count == 0)
++                return;
++            _sheets.Clear();
++            _sheetGeneration++;
++            InvalidateAll();
++        }
+     }
+ 
+     /// <summary>
+@@ -121,6 +131,8 @@ public sealed partial class CssStyleEngine
+         if (_environment.Equals(environment))
+             return;
+         _environment = environment;
++        lock (_sync)
++            _sheetGeneration++;
+         InvalidateAll();
+     }
+ 
+@@ -163,20 +175,20 @@ public sealed partial class CssStyleEngine
+ 
+         var normalizedPseudo = NormalizePseudoElement(pseudoElement);
+         var key = (element, normalizedPseudo);
+-        lock (_sync)
+-        {
+-            if (_cache.TryGetValue(key, out var cached))
+-                return cached;
+-        }
+-
+-        // Computed outside the lock: ComputeStyle re-enters the host (selector matching → DOM
+-        // bridge) which may mutate this engine's stylesheets, and it recurses into the ancestor
+-        // chain. A benign race where two threads compute the same key both store a valid snapshot
+-        // (last writer wins); it never corrupts the cache.
++        lock (_sync)
++        {
++            if (_cache.TryGetValue(key, out var cached))
++                return cached;
++        }
++
++        // Computed outside the lock: ComputeStyle re-enters the host (selector matching → DOM
++        // bridge) which may mutate this engine's stylesheets, and it recurses into the ancestor
++        // chain. A benign race where two threads compute the same key both store a valid snapshot
++        // (last writer wins); it never corrupts the cache.
+         var computed = ComputeStyle(element, normalizedPseudo, []);
+         var snapshot = new CssComputedStyle(computed);
+-        lock (_sync)
+-            _cache[key] = snapshot;
++        lock (_sync)
++            _cache[key] = snapshot;
+         return snapshot;
+     }
+ 
+@@ -415,16 +427,16 @@ public sealed partial class CssStyleEngine
+     private CssComputedStyle GetComputedStyleInternal(DomElement element, HashSet<DomElement> ancestorsInProgress)
+     {
+         var key = ((DomElement, string?))(element, null);
+-        lock (_sync)
+-        {
+-            if (_cache.TryGetValue(key, out var cached))
+-                return cached;
+-        }
++        lock (_sync)
++        {
++            if (_cache.TryGetValue(key, out var cached))
++                return cached;
++        }
+ 
+         var computed = ComputeStyle(element, pseudoElement: null, ancestorsInProgress);
+         var snapshot = new CssComputedStyle(computed);
+-        lock (_sync)
+-            _cache[key] = snapshot;
++        lock (_sync)
++            _cache[key] = snapshot;
+         return snapshot;
+     }
+ 
+@@ -435,17 +447,17 @@ public sealed partial class CssStyleEngine
+         DomElement element, HashSet<DomElement> ancestorsInProgress)
+     {
+         var key = ((DomElement, string?))(element, null);
+-        lock (_sync)
+-        {
+-            if (_sparseCache.TryGetValue(key, out var cached))
+-                return cached;
+-        }
++        lock (_sync)
++        {
++            if (_sparseCache.TryGetValue(key, out var cached))
++                return cached;
++        }
+ 
+         IReadOnlyDictionary<string, string> computed = ComputeStyle(
+             element, pseudoElement: null, ancestorsInProgress,
+             backfillInitials: false, sparseInheritance: true);
+-        lock (_sync)
+-            _sparseCache[key] = computed;
++        lock (_sync)
++            _sparseCache[key] = computed;
+         return computed;
+     }
+ 
+@@ -558,34 +570,56 @@ public sealed partial class CssStyleEngine
+         bool includeInlineStyle)
+     {
+         var key = (element, pseudoElement, includeInlineStyle);
+-        lock (_sync)
+-        {
+-            if (_declaredCascadeCache.TryGetValue(key, out var cached))
+-                return cached;
+-        }
+-
+-        // Snapshot the sheet list and cache generation together under the lock before iterating:
+-        // selector matching (below) can call back into the host (e.g. the DOM bridge) which may
+-        // re-sync this engine's stylesheets mid-cascade (ClearStyleSheets + AddStyleSheet) when the
+-        // document mutated — e.g. while anchor positioning rewrites styles — and another thread may
+-        // mutate _sheets concurrently. Iterating the live list under either would throw ("Collection
+-        // was modified", WPT content-visibility-anchor-positioning; or the concurrent-collection
+-        // corruption abort, WPT #1445). The snapshot keeps the in-progress cascade self-consistent
+-        // and crash-free, and the generation captured alongside it lets the store below reject a
+-        // result that raced an invalidation.
+-        int generation;
+-        StyleSheetEntry[] sheetsSnapshot;
+-        lock (_sync)
+-        {
+-            generation = _cacheGeneration;
+-            sheetsSnapshot = _sheets.ToArray();
+-        }
++        lock (_sync)
++        {
++            if (_declaredCascadeCache.TryGetValue(key, out var cached))
++                return cached;
++        }
++
++        // Snapshot the sheet list and cache generation together under the lock before iterating:
++        // selector matching (below) can call back into the host (e.g. the DOM bridge) which may
++        // re-sync this engine's stylesheets mid-cascade (ClearStyleSheets + AddStyleSheet) when the
++        // document mutated — e.g. while anchor positioning rewrites styles — and another thread may
++        // mutate _sheets concurrently. Iterating the live list under either would throw ("Collection
++        // was modified", WPT content-visibility-anchor-positioning; or the concurrent-collection
++        // corruption abort, WPT #1445). The snapshot keeps the in-progress cascade self-consistent
++        // and crash-free, and the generation captured alongside it lets the store below reject a
++        // result that raced an invalidation.
++        int generation;
++        CssCascadeRuleIndex? ruleIndex;
++        StyleSheetEntry[] sheetsSnapshot;
++        lock (_sync)
++        {
++            generation = _cacheGeneration;
++            ruleIndex = UseRuleIndex ? GetOrBuildRuleIndex() : null;
++            sheetsSnapshot = ruleIndex is null ? _sheets.ToArray() : [];
++        }
+ 
+         var winners = new Dictionary<string, CascadeSlot>(StringComparer.OrdinalIgnoreCase);
+         var order = 0;
+ 
+-        foreach (var entry in sheetsSnapshot)
+-            CollectFromRules(entry.Sheet.Rules, entry.Origin, element, pseudoElement, winners, ref order);
++        if (ruleIndex is not null)
++        {
++            // Only the rules whose key this element carries, in document order (roadmap item #11).
++            var candidates = new List<int>();
++            ruleIndex.CollectCandidates(element, candidates);
++            foreach (var candidate in candidates)
++            {
++                var entry = ruleIndex[candidate];
++                if (entry.ContainerConditions is { } conditions &&
++                    !ContainerConditionsHold(conditions, element, pseudoElement))
++                {
++                    continue;
++                }
++
++                ApplyStyleRule(entry.Rule, entry.Origin, element, pseudoElement, winners, ref order);
++            }
++        }
++        else
++        {
++            foreach (var entry in sheetsSnapshot)
++                CollectFromRules(entry.Sheet.Rules, entry.Origin, element, pseudoElement, winners, ref order);
++        }
+ 
+         if (includeInlineStyle && pseudoElement is null)
+         {
+@@ -611,15 +645,76 @@ public sealed partial class CssStyleEngine
+         // Only memoize when no invalidation occurred while this cascade was computed:
+         // a host re-sync (see the snapshot note above) bumps the generation and clears
+         // the cache, so a result derived from the pre-re-sync sheet snapshot is stale.
+-        lock (_sync)
+-        {
+-            if (generation == _cacheGeneration)
+-                _declaredCascadeCache[key] = map;
+-        }
++        lock (_sync)
++        {
++            if (generation == _cacheGeneration)
++                _declaredCascadeCache[key] = map;
++        }
+ 
+         return map;
+     }
+ 
++    /// <summary>
++    /// Selects the cascade's rule-selection strategy. True — the default, and the only value
++    /// production uses — buckets rules by their key and tests the candidates
++    /// (<see cref="CssCascadeRuleIndex"/>); false restores the linear scan of every rule of every
++    /// sheet the index replaced.
++    /// </summary>
++    /// <remarks>
++    /// The linear scan is kept, and kept reachable, as the index's oracle: an optimisation whose
++    /// claim is "same answers, less work" is only worth trusting if the old answers can still be
++    /// produced and compared against. <c>CssCascadeRuleIndexTests</c> does exactly that over
++    /// generated documents and sheets.
++    /// </remarks>
++    internal bool UseRuleIndex { get; set; } = true;
++
++    /// <summary>
++    /// The rule index for the current sheet set, built on first use after a sheet/environment
++    /// change. Multithreading roadmap item #11.
++    /// </summary>
++    /// <remarks>
++    /// Called with <see cref="_sync"/> held, and returns an immutable index the caller keeps using
++    /// outside the lock — the same discipline the sheet snapshot it replaced had, and for the same
++    /// reason: selector matching can call back into the host, which may re-sync this engine's
++    /// stylesheets mid-cascade. A cascade that started against one index finishes against it, and
++    /// the generation guard at the end refuses to memoize a result that raced the change.
++    /// </remarks>
++    private CssCascadeRuleIndex GetOrBuildRuleIndex()
++    {
++        if (_ruleIndex is { } current && _ruleIndexGeneration == _sheetGeneration)
++            return current;
++
++        var sheets = new List<(CssStyleSheet Sheet, CssOrigin Origin)>(_sheets.Count);
++        foreach (var entry in _sheets)
++            sheets.Add((entry.Sheet, entry.Origin));
++
++        var viewportWidth = _environment.ViewportWidth;
++        var viewportHeight = _environment.ViewportHeight;
++
++        _ruleIndex = CssCascadeRuleIndex.Build(
++            sheets,
++            prelude => EvaluateMediaQuery(prelude, viewportWidth, viewportHeight),
++            prelude => SupportsConditionSyntax.EvaluatesTrue(prelude, IsFeatureQuerySupported));
++        _ruleIndexGeneration = _sheetGeneration;
++        return _ruleIndex;
++    }
++
++    /// <summary>
++    /// True when every <c>@container</c> group enclosing a candidate rule holds for this element.
++    /// These are the conditions the index could not decide at build time, because they depend on
++    /// the element's query container rather than on the environment.
++    /// </summary>
++    private bool ContainerConditionsHold(CssAtRule[] conditions, DomElement element, string? pseudoElement)
++    {
++        foreach (var condition in conditions)
++        {
++            if (!EvaluateContainerQuery(condition.Prelude, element, pseudoElement))
++                return false;
++        }
++
++        return true;
++    }
++
+     private void CollectFromRules(
+         IReadOnlyList<CssRule> rules,
+         CssOrigin origin,
+@@ -652,14 +747,14 @@ public sealed partial class CssStyleEngine
+                     if (SupportsConditionSyntax.EvaluatesTrue(atRule.Prelude, IsFeatureQuerySupported))
+                         CollectFromRules(atRule.Rules, origin, element, pseudoElement, winners, ref order);
+                     break;
+-
+-                case CssAtRule atRule when atRule.Name.Equals("container", StringComparison.OrdinalIgnoreCase):
+-                    // An @container rule applies its contents only when the element's query container
+-                    // satisfies the size condition. An unresolved container/size evaluates to false,
+-                    // matching the prior behaviour of ignoring the rule (see CssStyleEngine.ContainerQueries).
+-                    if (EvaluateContainerQuery(atRule.Prelude, element, pseudoElement))
+-                        CollectFromRules(atRule.Rules, origin, element, pseudoElement, winners, ref order);
+-                    break;
++
++                case CssAtRule atRule when atRule.Name.Equals("container", StringComparison.OrdinalIgnoreCase):
++                    // An @container rule applies its contents only when the element's query container
++                    // satisfies the size condition. An unresolved container/size evaluates to false,
++                    // matching the prior behaviour of ignoring the rule (see CssStyleEngine.ContainerQueries).
++                    if (EvaluateContainerQuery(atRule.Prelude, element, pseudoElement))
++                        CollectFromRules(atRule.Rules, origin, element, pseudoElement, winners, ref order);
++                    break;
+             }
+         }
+     }
+diff --git a/Broiler.CSS/CssSelectorKey.cs b/Broiler.CSS/CssSelectorKey.cs
+new file mode 100644
+index 0000000..5970a9b
+--- /dev/null
++++ b/Broiler.CSS/CssSelectorKey.cs
+@@ -0,0 +1,42 @@
++using System;
++
++namespace Broiler.CSS;
++
++/// <summary>What kind of simple selector a rule is keyed on. See <see cref="CssSelectorKey"/>.</summary>
++public enum CssSelectorKeyKind
++{
++    /// <summary>No narrowing key — the selector must be tested against every element.</summary>
++    Universal,
++
++    /// <summary>The subject element's tag name.</summary>
++    Type,
++
++    /// <summary>One class the subject element must carry.</summary>
++    Class,
++
++    /// <summary>The subject element's id.</summary>
++    Id,
++}
++
++/// <summary>
++/// A simple selector the subject of a complex selector must satisfy — the bucket a rule is filed
++/// under in a cascade rule index. Produced by <see cref="CssSelectorParser.GetKey"/>, whose
++/// remarks carry the one-sided contract this rests on.
++/// </summary>
++/// <param name="Kind">Which kind of key, or <see cref="CssSelectorKeyKind.Universal"/> for none.</param>
++/// <param name="Name">
++/// The id, class or tag name; empty for <see cref="CssSelectorKeyKind.Universal"/>.
++/// </param>
++public readonly record struct CssSelectorKey(CssSelectorKeyKind Kind, string Name)
++{
++    /// <summary>The key of a selector that could match anything.</summary>
++    public static CssSelectorKey Universal { get; } = new(CssSelectorKeyKind.Universal, string.Empty);
++
++    public override string ToString() => Kind switch
++    {
++        CssSelectorKeyKind.Id => "#" + Name,
++        CssSelectorKeyKind.Class => "." + Name,
++        CssSelectorKeyKind.Type => Name,
++        _ => "*",
++    };
++}
+diff --git a/Broiler.CSS/CssSelectorParser.cs b/Broiler.CSS/CssSelectorParser.cs
+index 22e33d8..3154185 100644
+--- a/Broiler.CSS/CssSelectorParser.cs
++++ b/Broiler.CSS/CssSelectorParser.cs
+@@ -227,6 +227,187 @@ public static class CssSelectorParser
+         return index;
+     }
+ 
++    /// <summary>
++    /// The <em>key</em> of a complex selector: a simple selector its subject element must carry
++    /// for the selector to have any chance of matching. This is what lets a cascade bucket rules
++    /// by their rightmost simple selector and test only the handful an element could match,
++    /// instead of every rule of every sheet (multithreading roadmap item #11).
++    /// </summary>
++    /// <remarks>
++    /// <para>
++    /// The key comes from the <em>rightmost</em> compound, because that is the compound the
++    /// subject element itself has to satisfy — everything to its left constrains ancestors and
++    /// siblings. <c>#main .row > td.cell:hover</c> keys on class <c>cell</c>: an element without
++    /// that class cannot match, whatever its ancestry.
++    /// </para>
++    /// <para>
++    /// <b>The contract is one-sided and that is the whole safety argument.</b> A key is a
++    /// <em>necessary</em> condition, never a sufficient one — a keyed rule is a candidate that
++    /// still goes through the full matcher. So the only way this can be wrong is by returning a
++    /// key an element lacks for a selector that would have matched it, and every case that is not
++    /// certainly narrower resolves to <see cref="CssSelectorKeyKind.Universal"/>: a bare
++    /// <c>:is(…)</c>/<c>:not(…)</c>, an attribute-only compound, a namespaced type, an escaped
++    /// identifier, or anything this scanner does not recognise. Losing selectivity costs time;
++    /// losing a rule loses the page.
++    /// </para>
++    /// <para>
++    /// Within one compound an id beats a class beats a type, which is simply the order of how
++    /// much each one narrows the candidate set.
++    /// </para>
++    /// </remarks>
++    public static CssSelectorKey GetKey(string? selector)
++    {
++        if (string.IsNullOrWhiteSpace(selector))
++            return CssSelectorKey.Universal;
++
++        string? rightmost = null;
++        foreach (var compound in SplitCompounds(selector))
++            rightmost = compound;
++
++        return rightmost is null ? CssSelectorKey.Universal : KeyOfCompound(rightmost);
++    }
++
++    private static CssSelectorKey KeyOfCompound(string compound)
++    {
++        // An escaped identifier would have to be unescaped to compare against a DOM value, and a
++        // namespaced type (`svg|rect`) is not the plain tag name a bucket is keyed on. Both are
++        // rare; neither is worth a subtle bug.
++        if (compound.IndexOf('\\') >= 0 || compound.IndexOf('|') >= 0)
++            return CssSelectorKey.Universal;
++
++        string? id = null;
++        string? className = null;
++        string? tag = null;
++        var index = 0;
++
++        if (index < compound.Length && IsNameStart(compound[index]))
++        {
++            var end = ConsumeName(compound, index);
++            tag = compound[index..end];
++            index = end;
++        }
++        else if (index < compound.Length && compound[index] == '*')
++        {
++            index++;
++        }
++
++        while (index < compound.Length)
++        {
++            switch (compound[index])
++            {
++                case '#':
++                {
++                    var end = ConsumeName(compound, index + 1);
++                    if (end == index + 1)
++                        return CssSelectorKey.Universal;
++                    id ??= compound[(index + 1)..end];
++                    index = end;
++                    break;
++                }
++
++                case '.':
++                {
++                    var end = ConsumeName(compound, index + 1);
++                    if (end == index + 1)
++                        return CssSelectorKey.Universal;
++                    className ??= compound[(index + 1)..end];
++                    index = end;
++                    break;
++                }
++
++                case '[':
++                {
++                    // An attribute filter narrows nothing this index can key on, but it also does
++                    // not widen the compound — skip it and keep whatever id/class/type it sits on.
++                    var end = SkipBalanced(compound, index, '[', ']');
++                    if (end <= index)
++                        return CssSelectorKey.Universal;
++                    index = end;
++                    break;
++                }
++
++                case ':':
++                {
++                    // Same for a pseudo-class or pseudo-element: `td.cell:hover` and
++                    // `div::before` still require the td/div they are attached to. A functional
++                    // pseudo's argument is skipped wholesale — a key from inside `:not(...)` would
++                    // be exactly backwards, and one from inside `:is(...)` holds only if every
++                    // branch agrees, which is not worth deciding here.
++                    index++;
++                    if (index < compound.Length && compound[index] == ':')
++                        index++;
++
++                    var end = ConsumeName(compound, index);
++                    if (end == index)
++                        return CssSelectorKey.Universal;
++                    index = end;
++
++                    if (index < compound.Length && compound[index] == '(')
++                    {
++                        var close = SkipBalanced(compound, index, '(', ')');
++                        if (close <= index)
++                            return CssSelectorKey.Universal;
++                        index = close;
++                    }
++
++                    break;
++                }
++
++                default:
++                    // Something this scanner does not model; assume it could match anything.
++                    return CssSelectorKey.Universal;
++            }
++        }
++
++        if (id is not null)
++            return new CssSelectorKey(CssSelectorKeyKind.Id, id);
++        if (className is not null)
++            return new CssSelectorKey(CssSelectorKeyKind.Class, className);
++        if (tag is not null)
++            return new CssSelectorKey(CssSelectorKeyKind.Type, tag);
++
++        return CssSelectorKey.Universal;
++    }
++
++    /// <summary>Index just past the <paramref name="close"/> matching the <paramref name="open"/>
++    /// at <paramref name="index"/>, or <paramref name="index"/> when it is unbalanced.</summary>
++    private static int SkipBalanced(string text, int index, char open, char close)
++    {
++        var depth = 0;
++        char quote = '\0';
++        for (var i = index; i < text.Length; i++)
++        {
++            var character = text[i];
++            if (quote != '\0')
++            {
++                if (character == '\\')
++                    i++;
++                else if (character == quote)
++                    quote = '\0';
++                continue;
++            }
++
++            if (character is '"' or '\'')
++            {
++                quote = character;
++                continue;
++            }
++
++            if (character == open)
++            {
++                depth++;
++            }
++            else if (character == close)
++            {
++                depth--;
++                if (depth == 0)
++                    return i + 1;
++            }
++        }
++
++        return index;
++    }
++
+     private static bool IsNameStart(char character) =>
+         char.IsLetter(character) || character is '_' or '-' || character >= 0x80;
+ 
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,45 @@
+# Pending submodule patches
+
+Fixes that belong in a submodule (`Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`,
+`Broiler.JS`, `Broiler.Graphics`) but could not be pushed to their remote from
+the session that wrote them: the git proxy only authorises repos in the session's
+GitHub scope, so a push to a submodule remote outside it returns **403**. Rather
+than bump a submodule pointer at a commit CI cannot clone, the change is captured
+here as a `git format-patch` file for a maintainer to apply.
+
+The directory is a backlog, not an archive: it holds only what is *currently*
+pending. A patch is deleted from here, along with its row below, once its fix is
+upstream and the submodule pointer is bumped.
+
+## Applying
+
+```sh
+cd <Submodule>
+git am --keep-cr ../patches/NNNN-<slug>.patch
+git push origin HEAD
+cd ..
+git add <Submodule>        # bump the pointer only after the push succeeds
+```
+
+**`--keep-cr` is not optional for a patch that touches a file with CRLF line endings**, which
+several `Broiler.JS` sources are (mixed CRLF and LF, within one file). `git am` runs the patch
+through `mailinfo`, which normalizes the line endings of the diff body unless told not to — so the
+context lines stop matching the file and the apply fails with *"patch does not apply"* on a patch
+that is perfectly good. `git apply` does not have the problem, which is exactly why it is not the
+check: these instructions use `am`, so `am` is what a patch has to survive. Verified per patch by
+applying it to a clean checkout of the pinned pointer and diffing the result against the branch it
+was generated from.
+
+## Exercised on CI before they land
+
+`scripts/apply-pending-wpt-patches.sh` applies the patches listed in its
+`PENDING_PATCHES` array to the checked-out submodule trees before the WPT run, so
+a pending fix is reflected in CI's numbers rather than waiting on the pointer. It
+is idempotent — a patch already contained in the pinned pointer reverse-applies
+and is skipped — so an entry stops applying by itself once a maintainer lands it.
+
+## Index
+
+| Patch | Submodule | Note |
+| --- | --- | --- |
+| `0123-css-cascade-rule-index` | `Broiler.CSS` | **The cascade tested every rule of every sheet against every element; it now tests only the rules an element's own id, classes and tag can reach.** Multithreading roadmap item #11 — the item that document's Phase 0 measurements identify as its highest-value one, ahead of every parallel item including the rasterizer, and single-threaded work. The evidence it was written against: on the roadmap corpus's rule-heavy page (700 `<div>`s, two classes each, against a 900-rule sheet) `parse+cascade` was **96.5% of a 5.2 s render**, and `RuleScalingBenchmarks` — which holds the *matched* rule count fixed at four while growing the sheet — measured cost and allocation both linear in **total** rules: 32× the rules gave 30.8× the time and 32.0× the bytes. `CssCascadeRuleIndex` flattens the sheet set into document order once and files each rule under the simple selector its subject must carry (id / class / type), with everything else in a universal bucket; an element merges the buckets its own keys reach and tests those. **The correctness argument is one-sided by construction and that is the whole point**: a key is a *necessary* condition for a match, never a sufficient one, candidates still go through the unchanged selector matcher, so the index can only be wrong by *omitting* a rule — and every case that is not certainly narrower resolves to the universal bucket (a bare `:is()`/`:not()`, an attribute-only compound, a namespaced type, an escaped identifier, anything the key scanner does not model). Candidates come back in **document order**, via a k-way merge of the buckets rather than a sort, so the cascade's source-order tie-break is untouched — a rule that never matched never advanced the tie-break counter, so visiting only candidates yields the same winners. `@media`/`@supports` are resolved once at index-build time (they depend on the environment and the feature oracle, both fixed for an index's lifetime) so a non-applying group costs nothing per element; `@container` depends on the element, so those conditions travel with the entry and are evaluated per candidate. The index is memoized against a **sheet** generation bumped only by sheet/environment changes — deliberately not by DOM mutation, which bumps the computed-style caches constantly and would otherwise rebuild the index on every tree edit. **The linear scan is kept and kept reachable** behind `CssStyleEngine.UseRuleIndex`, as the index's oracle: `CssCascadeRuleIndexTests` (22 cases) asserts the two cascades agree property by property — id/class/type keying, source-order tie-breaks, a rule reachable through two keys, combinators, pseudo-elements, the six unkeyable selector shapes, matching and non-matching `@media`, `@supports`, nested groups, late-added sheets, `ClearStyleSheets`, a viewport change — and over a generated 1200-rule sheet against a 120-element document. **Measured, and the exit gate is the scaling shape rather than a single number**: with `RuleScalingBenchmarks` holding the matched set at four and growing only the rules that cannot match, 32× the rules used to cost 30.8× the time and 32.0× the bytes and now costs **1.64× the time and 1.13× the bytes** — 114.9 ms → 15.74 ms at 100 rules, 3 543.6 ms → **25.89 ms** at 3 200 (136.9×), with allocation 5 817.9 MB → **9.69 MB** (600×). On a whole render the corpus `rules` page goes **5 218.96 ms → 1 841.71 ms** end to end and its `parse+cascade` stage **5 035.35 ms → 1 698.11 ms** (2.8× and 3.0×) — the smaller figure is Amdahl, since that stage also parses 110 296 characters and then cascades the rules that do match. **No rendering change**: `css/css-backgrounds` + `css/CSS2/linebox` (62 tests) is identical before and after — same pass/fail/skip on every test and the same 98.62245927777205% average pixel match to fourteen digits. Component suites: `Broiler.CSS.Tests` 341/341, `Broiler.CSS.Dom.Tests` 383 passed with the two `CssDomArchitectureTests` failures that are **pre-existing** (verified on a clean tree: 361 passed, the same 2 failed). Applies cleanly to the pinned `Broiler.CSS` pointer (`edc9fa9`) and survives `git am --keep-cr` — verified by applying it to a fresh clone of the pin and diffing the result against the branch it was generated from (identical tree). **Listed in `scripts/apply-pending-wpt-patches.sh`**: unlike a thread-safety or scheduling patch, this one *could* move rendering if the key extraction were ever wrong, so having the WPT run exercise it against the pinned pointer is the check worth having — and its claim is precisely that the numbers do not move. |

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -47,6 +47,11 @@ set -euo pipefail
 #     Listing it would fail this script and take the whole run down, so it needs
 #     regenerating against the current pointer before it can go back in.
 PENDING_PATCHES=(
+  # Multithreading roadmap item #11: the cascade tests only the rules an element's
+  # own keys reach instead of every rule of every sheet. Listed — unlike a thread-
+  # safety patch — because it *could* move rendering if the key extraction were
+  # wrong, and its whole claim is that it does not; the WPT run is that check.
+  "Broiler.CSS|patches/0123-css-cascade-rule-index.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/Broiler.Cli.Tests/BatchRunnerTests.cs
+++ b/src/Broiler.Cli.Tests/BatchRunnerTests.cs
@@ -1,0 +1,162 @@
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Covers the CLI's batch machinery (multithreading roadmap item #20): how a batch is sized,
+/// how output paths are derived, and the property the exit gate rests on — that a batch's
+/// transcript and results do not depend on how many threads ran it.
+/// </summary>
+public sealed class BatchRunnerTests
+{
+    private static IReadOnlyList<BatchItem> Items(int count) =>
+        Enumerable.Range(0, count)
+            .Select(i => new BatchItem($"input-{i:D2}", $"/out/input-{i:D2}.md"))
+            .ToList();
+
+    [Fact]
+    public void Every_Item_Runs_Exactly_Once_Across_The_Batch()
+    {
+        var items = Items(40);
+        var seen = new System.Collections.Concurrent.ConcurrentBag<string>();
+
+        var result = BatchRunner.RunInProcess(items, degreeOfParallelism: 8, (item, _, _) =>
+        {
+            seen.Add(item.Input);
+            return 0;
+        });
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(
+            items.Select(i => i.Input).OrderBy(s => s, StringComparer.Ordinal),
+            seen.OrderBy(s => s, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Outcomes_Are_In_Input_Order_Even_When_Items_Finish_Out_Of_Order()
+    {
+        // The reason a batch can be parallel at all: the transcript is replayed from an
+        // index-keyed array, so a slow first item does not reorder the report.
+        var items = Items(16);
+
+        var result = BatchRunner.RunInProcess(items, degreeOfParallelism: 8, (item, standardOutput, _) =>
+        {
+            int ordinal = int.Parse(item.Input["input-".Length..]);
+            Thread.Sleep((16 - ordinal) * 2);
+            standardOutput.Write(item.Input);
+            return 0;
+        });
+
+        Assert.Equal(
+            items.Select(i => i.Input).ToList(),
+            result.Outcomes.Select(o => o.StandardOutput).ToList());
+    }
+
+    [Fact]
+    public void A_Failed_Item_Fails_The_Batch_But_Does_Not_Stop_It()
+    {
+        var items = Items(6);
+
+        var result = BatchRunner.RunInProcess(items, degreeOfParallelism: 4, (item, _, standardError) =>
+        {
+            if (item.Input.EndsWith("03", StringComparison.Ordinal))
+            {
+                standardError.Write("boom");
+                return 1;
+            }
+
+            return 0;
+        });
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Equal(6, result.Outcomes.Count);
+        Assert.Equal(1, result.Outcomes.Count(o => o.ExitCode != 0));
+    }
+
+    [Fact]
+    public void A_Throwing_Item_Is_Reported_Rather_Than_Taking_The_Batch_Down()
+    {
+        var items = Items(4);
+
+        var result = BatchRunner.RunInProcess(items, degreeOfParallelism: 4, (item, _, _) =>
+            item.Input.EndsWith("02", StringComparison.Ordinal)
+                ? throw new InvalidOperationException("codec exploded")
+                : 0);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("codec exploded", result.Outcomes[2].StandardError);
+        Assert.All(new[] { 0, 1, 3 }, i => Assert.Equal(0, result.Outcomes[i].ExitCode));
+    }
+
+    [Fact]
+    public void An_Empty_Batch_Succeeds_Without_Running_Anything()
+    {
+        var result = BatchRunner.RunInProcess([], degreeOfParallelism: 8, (_, _, _) =>
+            throw new InvalidOperationException("should not run"));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Outcomes);
+    }
+
+    [Fact]
+    public void Degree_Never_Exceeds_The_Number_Of_Items()
+    {
+        Assert.Equal(3, BatchRunner.ResolveDegreeOfParallelism(requested: 16, itemCount: 3, processorCount: 8));
+    }
+
+    [Fact]
+    public void Degree_Defaults_To_One_Per_Core()
+    {
+        Assert.Equal(8, BatchRunner.ResolveDegreeOfParallelism(requested: null, itemCount: 40, processorCount: 8));
+    }
+
+    [Fact]
+    public void Degree_Is_At_Least_One()
+    {
+        Assert.Equal(1, BatchRunner.ResolveDegreeOfParallelism(requested: 0, itemCount: 40, processorCount: 0));
+    }
+
+    [Fact]
+    public void Output_Paths_Are_Derived_From_The_Input_Name()
+    {
+        var items = BatchRunner.DeriveOutputPaths(
+            ["/docs/report.rtf", "/docs/notes.docx"],
+            outputDir: "/out",
+            extension: "md");
+
+        Assert.Equal(Path.Combine("/out", "report.md"), items[0].OutputPath);
+        Assert.Equal(Path.Combine("/out", "notes.md"), items[1].OutputPath);
+    }
+
+    [Fact]
+    public void Colliding_Names_Are_Disambiguated_In_Input_Order()
+    {
+        // Same file name from two directories must not have one result overwrite the other.
+        var items = BatchRunner.DeriveOutputPaths(
+            ["/a/report.rtf", "/b/report.docx", "/c/report.html"],
+            outputDir: "/out",
+            extension: "md");
+
+        Assert.Equal(Path.Combine("/out", "report.md"), items[0].OutputPath);
+        Assert.Equal(Path.Combine("/out", "report-2.md"), items[1].OutputPath);
+        Assert.Equal(Path.Combine("/out", "report-3.md"), items[2].OutputPath);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/a/page.html", "page.png")]
+    [InlineData("https://example.com/", "example.com.png")]
+    [InlineData("https://example.com", "example.com.png")]
+    public void Url_Inputs_Derive_A_Name_From_The_Last_Path_Segment(string url, string expected)
+    {
+        var items = BatchRunner.DeriveOutputPaths([url], outputDir: "/out", extension: "png");
+
+        Assert.Equal(Path.Combine("/out", expected), items[0].OutputPath);
+    }
+
+    [Fact]
+    public void A_Leading_Dot_On_The_Extension_Is_Accepted()
+    {
+        var items = BatchRunner.DeriveOutputPaths(["/docs/report.rtf"], outputDir: "/out", extension: ".md");
+
+        Assert.Equal(Path.Combine("/out", "report.md"), items[0].OutputPath);
+    }
+}

--- a/src/Broiler.Cli.Tests/LayoutFuzzShardsTests.cs
+++ b/src/Broiler.Cli.Tests/LayoutFuzzShardsTests.cs
@@ -1,0 +1,131 @@
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Covers the fuzz seed partition and the shard totals protocol. The partition carries the
+/// whole correctness argument for a sharded fuzz run: a case depends only on its seed, so a
+/// partition that covers the sequential seed set exactly, once each, examines the same
+/// documents and produces the same failures.
+/// </summary>
+public sealed class LayoutFuzzShardsTests
+{
+    [Theory]
+    [InlineData(200, 4)]
+    [InlineData(1000, 7)]
+    [InlineData(101, 10)]
+    [InlineData(5, 5)]
+    [InlineData(1, 4)]
+    public void The_Shards_Cover_The_Sequential_Seed_Set_Exactly_Once(int count, int shardCount)
+    {
+        const int baseSeed = 4242;
+        var shards = LayoutFuzzShards.Partition(count, baseSeed, shardCount);
+
+        var shardSeeds = shards
+            .SelectMany(shard => Enumerable.Range(shard.BaseSeed, shard.Count))
+            .ToList();
+
+        Assert.Equal(Enumerable.Range(baseSeed, count), shardSeeds);
+    }
+
+    [Fact]
+    public void Shards_Are_Contiguous_And_Balanced_To_Within_One_Case()
+    {
+        var shards = LayoutFuzzShards.Partition(count: 101, baseSeed: 0, shardCount: 4);
+
+        Assert.Equal(4, shards.Count);
+        Assert.Equal(1, shards.Max(s => s.Count) - shards.Min(s => s.Count));
+        for (int i = 1; i < shards.Count; i++)
+            Assert.Equal(shards[i - 1].BaseSeed + shards[i - 1].Count, shards[i].BaseSeed);
+    }
+
+    [Fact]
+    public void A_Zero_Case_Run_Has_No_Shards()
+    {
+        Assert.Empty(LayoutFuzzShards.Partition(count: 0, baseSeed: 1, shardCount: 4));
+    }
+
+    [Fact]
+    public void A_Small_Run_Is_Not_Split_Across_Processes()
+    {
+        // Below the per-shard minimum the process startup costs more than the cases do.
+        Assert.Equal(1, LayoutFuzzShards.ResolveShardCount(requested: 8, caseCount: 20, processorCount: 8));
+    }
+
+    [Fact]
+    public void A_Large_Run_Uses_The_Requested_Shard_Count()
+    {
+        Assert.Equal(8, LayoutFuzzShards.ResolveShardCount(requested: 8, caseCount: 1000, processorCount: 4));
+    }
+
+    [Fact]
+    public void Shard_Count_Defaults_To_One_Per_Core()
+    {
+        Assert.Equal(4, LayoutFuzzShards.ResolveShardCount(requested: null, caseCount: 1000, processorCount: 4));
+    }
+
+    [Fact]
+    public void Shard_Count_Is_Capped_So_No_Shard_Is_Trivially_Small()
+    {
+        // 60 cases over 16 cores would be 3 cases per process; the cap keeps it at 2 shards.
+        Assert.Equal(2, LayoutFuzzShards.ResolveShardCount(requested: 16, caseCount: 60, processorCount: 16));
+    }
+
+    [Fact]
+    public void Totals_Round_Trip_Through_The_Marker_Line()
+    {
+        var totals = new LayoutFuzzTotals(Cases: 250, Failures: 7, Crashes: 2);
+
+        Assert.True(LayoutFuzzShards.TryParseTotals(LayoutFuzzShards.FormatTotals(totals), out var parsed));
+        Assert.Equal(totals, parsed);
+    }
+
+    [Fact]
+    public void Ordinary_Transcript_Lines_Are_Not_Mistaken_For_Totals()
+    {
+        Assert.False(LayoutFuzzShards.TryParseTotals("Fuzz complete: 200 cases, 56 failure(s).", out _));
+        Assert.False(LayoutFuzzShards.TryParseTotals("  [FAIL] seed 4242: 3 violation(s)", out _));
+    }
+
+    [Fact]
+    public void Shard_Totals_Sum_To_The_Whole_Run()
+    {
+        var transcripts = new[]
+        {
+            $"  [FAIL] seed 1: 2 violation(s)\n{LayoutFuzzShards.FormatTotals(new LayoutFuzzTotals(50, 18, 0))}\n",
+            LayoutFuzzShards.FormatTotals(new LayoutFuzzTotals(50, 12, 1)) + "\n",
+            LayoutFuzzShards.FormatTotals(new LayoutFuzzTotals(50, 14, 0)) + "\n",
+            LayoutFuzzShards.FormatTotals(new LayoutFuzzTotals(50, 12, 3)) + "\n",
+        };
+
+        Assert.Equal(new LayoutFuzzTotals(200, 56, 4), LayoutFuzzShards.Aggregate(transcripts));
+    }
+
+    [Fact]
+    public void A_Shard_That_Died_Before_Reporting_Shows_Up_As_A_Case_Shortfall()
+    {
+        // Silence must not read as "nothing went wrong": the missing cases are what tells the
+        // parent a worker exited early, and what makes it warn rather than report a short run.
+        var transcripts = new[]
+        {
+            LayoutFuzzShards.FormatTotals(new LayoutFuzzTotals(50, 1, 0)) + "\n",
+            "Unhandled exception. System.OutOfMemoryException\n",
+        };
+
+        Assert.Equal(new LayoutFuzzTotals(50, 1, 0), LayoutFuzzShards.Aggregate(transcripts));
+    }
+
+    [Fact]
+    public void Stripping_Totals_Leaves_The_Human_Transcript_Intact()
+    {
+        var transcript =
+            "Layout fuzz: running 50 cases…\n" +
+            "  [FAIL] seed 4242: 3 violation(s)\n" +
+            LayoutFuzzShards.FormatTotals(new LayoutFuzzTotals(50, 1, 0)) + "\n";
+
+        var stripped = LayoutFuzzShards.StripTotals(transcript);
+
+        Assert.Contains("Layout fuzz: running 50 cases…", stripped);
+        Assert.Contains("[FAIL] seed 4242", stripped);
+        Assert.DoesNotContain("##fuzz-totals", stripped);
+    }
+}

--- a/src/Broiler.Cli.Tests/ScriptPrefetchTests.cs
+++ b/src/Broiler.Cli.Tests/ScriptPrefetchTests.cs
@@ -1,0 +1,152 @@
+using Broiler.HtmlBridge.Scripting;
+using Broiler.HtmlBridge;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Covers the script side of concurrent sub-resource fetching (multithreading roadmap item #2):
+/// which scripts a document prefetches, and — the exit gate — that prefetching changes nothing
+/// about what the extractor returns or the order it returns it in.
+/// </summary>
+public sealed class ScriptPrefetchTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(),
+        "broiler-script-prefetch-" + Guid.NewGuid().ToString("N"));
+
+    public ScriptPrefetchTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private string WriteScript(string name, string body)
+    {
+        var path = Path.Combine(_dir, name);
+        File.WriteAllText(path, body);
+        return path;
+    }
+
+    private static string PageUrl(string dir) => new Uri(Path.Combine(dir, "page.html")).AbsoluteUri;
+
+    [Fact]
+    public void Every_External_Script_Is_Prefetched()
+    {
+        const string html = """
+            <script src="a.js"></script>
+            <script src="b.js"></script>
+            <script src="c.js"></script>
+            """;
+
+        var prefetcher = ScriptExtractionService.CreateScriptPrefetcher(html, PageUrl(_dir), csp: null);
+
+        Assert.NotNull(prefetcher);
+        Assert.Equal(3, prefetcher.RequestedCount);
+    }
+
+    [Fact]
+    public void The_Same_Script_Included_Twice_Is_Requested_Once()
+    {
+        const string html = """
+            <script src="a.js"></script>
+            <script src="a.js"></script>
+            <script src="b.js"></script>
+            """;
+
+        var prefetcher = ScriptExtractionService.CreateScriptPrefetcher(html, PageUrl(_dir), csp: null);
+
+        Assert.Equal(2, prefetcher!.RequestedCount);
+    }
+
+    [Fact]
+    public void Inline_And_Data_Uri_Scripts_Are_Not_Requested()
+    {
+        const string html = """
+            <script>var inline = 1;</script>
+            <script src="data:text/javascript,var d = 2;"></script>
+            <script src="a.js"></script>
+            <script src="b.js"></script>
+            """;
+
+        var prefetcher = ScriptExtractionService.CreateScriptPrefetcher(html, PageUrl(_dir), csp: null);
+
+        Assert.Equal(2, prefetcher!.RequestedCount);
+    }
+
+    [Fact]
+    public void A_Document_With_One_External_Script_Gets_No_Prefetcher()
+    {
+        // Nothing to overlap a single round trip with, so the sequential path is left exactly as
+        // it was rather than paying for machinery that cannot help.
+        const string html = """<script src="only.js"></script>""";
+
+        Assert.Null(ScriptExtractionService.CreateScriptPrefetcher(html, PageUrl(_dir), csp: null));
+    }
+
+    [Fact]
+    public void A_Csp_Blocked_Script_Is_Not_Requested()
+    {
+        // Prefetching a blocked script would put the very request CSP forbids on the wire —
+        // "fetched but not executed" is not what the policy says.
+        const string html = """
+            <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
+            <script src="https://evil.example/x.js"></script>
+            <script src="a.js"></script>
+            <script src="b.js"></script>
+            """;
+
+        var csp = ContentSecurityPolicy.FromHtml(html);
+        Assert.NotNull(csp);
+
+        var prefetcher = ScriptExtractionService.CreateScriptPrefetcher(html, PageUrl(_dir), csp);
+
+        Assert.Equal(2, prefetcher!.RequestedCount);
+        Assert.False(prefetcher.IsPending("https://evil.example/x.js"));
+    }
+
+    [Fact]
+    public void Extraction_Returns_The_Same_Scripts_In_The_Same_Order_As_Before_Prefetching()
+    {
+        // The exit gate: prefetching may only change when a request starts, never what the
+        // document ends up executing or in what order.
+        WriteScript("a.js", "var a = 1;");
+        WriteScript("b.js", "var b = 2;");
+        WriteScript("c.js", "var c = 3;");
+
+        var html = """
+            <script src="a.js"></script>
+            <script>var inline = 0;</script>
+            <script src="b.js"></script>
+            <script src="c.js" defer></script>
+            """;
+
+        var result = ScriptExtractionService.ExtractAll(html, PageUrl(_dir));
+
+        Assert.Equal(["var a = 1;", "var inline = 0;", "var b = 2;"], result.Scripts);
+        Assert.Equal(["var c = 3;"], result.DeferredScripts);
+    }
+
+    [Fact]
+    public void A_Script_That_Cannot_Be_Fetched_Is_Skipped_Exactly_As_Before()
+    {
+        WriteScript("a.js", "var a = 1;");
+
+        var html = """
+            <script src="a.js"></script>
+            <script src="missing.js"></script>
+            <script src="also-missing.js"></script>
+            """;
+
+        var result = ScriptExtractionService.ExtractAll(html, PageUrl(_dir));
+
+        Assert.Equal(["var a = 1;"], result.Scripts);
+    }
+}

--- a/src/Broiler.Cli.Tests/SubResourcePrefetcherTests.cs
+++ b/src/Broiler.Cli.Tests/SubResourcePrefetcherTests.cs
@@ -1,0 +1,204 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Broiler.HtmlBridge;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Covers the prefetch/consume split behind concurrent sub-resource fetching (multithreading
+/// roadmap item #2): that requests overlap, that a resource is still requested exactly once,
+/// that per-host concurrency is bounded, and that a consumer sees the same value it would have
+/// seen fetching inline.
+/// </summary>
+public sealed class SubResourcePrefetcherTests
+{
+    /// <summary>
+    /// Runs a batch of prefetches whose fetches all block until released, and reports the highest
+    /// number that were in flight at once.
+    /// </summary>
+    /// <remarks>
+    /// Overlap is asserted by observing concurrency, not by timing the batch: a wall-clock bound
+    /// would be measuring this machine's thread-pool injection rate as much as the prefetcher, and
+    /// would go flaky the moment the test host schedules another class alongside this one.
+    /// </remarks>
+    private static int MeasurePeakConcurrency(
+        IReadOnlyList<string> urls,
+        int maxConcurrentRequestsPerHost,
+        int expectedConcurrency)
+    {
+        int inFlight = 0, peak = 0;
+        var gate = new object();
+        using var release = new ManualResetEventSlim(false);
+
+        var prefetcher = new SubResourcePrefetcher(
+            _ =>
+            {
+                lock (gate)
+                {
+                    inFlight++;
+                    peak = Math.Max(peak, inFlight);
+                }
+
+                release.Wait(TimeSpan.FromSeconds(10));
+
+                lock (gate)
+                    inFlight--;
+
+                return "content";
+            },
+            maxConcurrentRequestsPerHost);
+
+        prefetcher.Prefetch(urls);
+
+        // Wait for the expected overlap rather than for a fixed duration: the thread pool injects
+        // threads over time, so a fixed sleep is a race against an unrelated schedule.
+        var deadline = Stopwatch.StartNew();
+        while (deadline.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            lock (gate)
+            {
+                if (peak >= expectedConcurrency)
+                    break;
+            }
+
+            Thread.Sleep(10);
+        }
+
+        // Let a cap violation show itself: the batch has reached the concurrency it was expected to,
+        // so anything above it would appear in this window rather than after the release.
+        Thread.Sleep(250);
+
+        release.Set();
+        foreach (var url in urls)
+            prefetcher.Consume(url);
+
+        lock (gate)
+            return peak;
+    }
+
+    [Fact]
+    public void Prefetched_Requests_Overlap_Instead_Of_Running_One_At_A_Time()
+    {
+        // The whole point of the item: a page's sub-resources are on the wire together, so their
+        // round trips overlap instead of being paid one after another.
+        var urls = Enumerable.Range(0, 4).Select(i => $"https://example.com/{i}.js").ToList();
+
+        var peak = MeasurePeakConcurrency(urls, maxConcurrentRequestsPerHost: 4, expectedConcurrency: 2);
+
+        Assert.True(peak >= 2, $"peak concurrency was {peak} — the prefetches are still serial");
+    }
+
+    [Fact]
+    public void Prefetched_Content_Reaches_The_Consumer_Unchanged()
+    {
+        var urls = Enumerable.Range(0, 6).Select(i => $"https://example.com/{i}.js").ToList();
+        var prefetcher = new SubResourcePrefetcher(url => $"body of {url}");
+
+        prefetcher.Prefetch(urls);
+
+        Assert.Equal(urls.Select(url => $"body of {url}").ToList(), urls.Select(prefetcher.Consume).ToList());
+    }
+
+    [Fact]
+    public void A_Resource_Is_Fetched_Once_However_Often_It_Is_Named()
+    {
+        var fetches = new ConcurrentBag<string>();
+        var prefetcher = new SubResourcePrefetcher(url =>
+        {
+            fetches.Add(url);
+            return "content";
+        });
+
+        prefetcher.Prefetch(["https://example.com/a.js", "https://example.com/a.js"]);
+        prefetcher.Prefetch(["https://example.com/a.js"]);
+        Assert.Equal("content", prefetcher.Consume("https://example.com/a.js"));
+        Assert.Equal("content", prefetcher.Consume("https://example.com/a.js"));
+
+        Assert.Single(fetches);
+        Assert.Equal(1, prefetcher.RequestedCount);
+    }
+
+    [Fact]
+    public void A_Url_That_Was_Never_Prefetched_Is_Still_Fetched_On_Consume()
+    {
+        // What makes this safe to adopt one call site at a time: consuming works with or without
+        // a prior prefetch, so a missed prefetch is a lost speedup and never a lost resource.
+        var prefetcher = new SubResourcePrefetcher(url => $"body of {url}");
+
+        Assert.Equal("body of https://example.com/late.js", prefetcher.Consume("https://example.com/late.js"));
+    }
+
+    [Fact]
+    public void Concurrency_Is_Bounded_Per_Host()
+    {
+        // Twelve resources from one origin, allowance of three: an origin must never see more than
+        // its share, however many the document names.
+        var urls = Enumerable.Range(0, 12).Select(i => $"https://example.com/{i}.css").ToList();
+
+        var peak = MeasurePeakConcurrency(urls, maxConcurrentRequestsPerHost: 3, expectedConcurrency: 3);
+
+        Assert.True(peak <= 3, $"peak in-flight per host was {peak}, above the cap of 3");
+    }
+
+    [Fact]
+    public void Different_Hosts_Do_Not_Share_One_Hosts_Allowance()
+    {
+        // The cap is per host, so a page pulling from four origins is not serialized behind one.
+        var urls = Enumerable.Range(0, 4).Select(i => $"https://host{i}.example/a.css").ToList();
+
+        var peak = MeasurePeakConcurrency(urls, maxConcurrentRequestsPerHost: 1, expectedConcurrency: 2);
+
+        Assert.True(peak > 1, "four distinct hosts were serialized against each other");
+    }
+
+    [Fact]
+    public void A_Failed_Fetch_Is_Reported_As_No_Content_Rather_Than_Thrown()
+    {
+        // A dead sub-resource is not a dead page; the consumer applies whatever it already did
+        // for a fetch that came back empty.
+        var prefetcher = new SubResourcePrefetcher(_ => throw new HttpRequestException("connection refused"));
+
+        prefetcher.Prefetch(["https://example.com/gone.js"]);
+
+        Assert.Null(prefetcher.Consume("https://example.com/gone.js"));
+    }
+
+    [Fact]
+    public void A_Failure_Is_Not_Retried_On_Every_Consume()
+    {
+        int attempts = 0;
+        var prefetcher = new SubResourcePrefetcher(_ =>
+        {
+            Interlocked.Increment(ref attempts);
+            throw new HttpRequestException("connection refused");
+        });
+
+        prefetcher.Prefetch(["https://example.com/gone.js"]);
+        prefetcher.Consume("https://example.com/gone.js");
+        prefetcher.Consume("https://example.com/gone.js");
+
+        Assert.Equal(1, attempts);
+    }
+
+    [Fact]
+    public void Pending_Reports_Whether_A_Request_Was_Issued()
+    {
+        var prefetcher = new SubResourcePrefetcher(url => url);
+
+        prefetcher.Prefetch(["https://example.com/a.js"]);
+
+        Assert.True(prefetcher.IsPending("https://example.com/a.js"));
+        Assert.False(prefetcher.IsPending("https://example.com/b.js"));
+    }
+
+    [Fact]
+    public void Blank_Urls_Are_Not_Requested()
+    {
+        var prefetcher = new SubResourcePrefetcher(_ => throw new InvalidOperationException("should not fetch"));
+
+        prefetcher.Prefetch(["", "   "]);
+
+        Assert.Equal(0, prefetcher.RequestedCount);
+        Assert.Null(prefetcher.Consume(""));
+    }
+}

--- a/src/Broiler.Cli/BatchRunner.cs
+++ b/src/Broiler.Cli/BatchRunner.cs
@@ -1,0 +1,344 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace Broiler.Cli;
+
+/// <summary>One input of a batch and the file its result is written to.</summary>
+internal sealed record BatchItem(string Input, string OutputPath);
+
+/// <summary>
+/// What one batch item produced: its exit code and everything it wrote, held rather than
+/// printed so the console transcript can be replayed in input order (see
+/// <see cref="BatchRunner"/>).
+/// </summary>
+internal sealed record BatchItemOutcome(int ExitCode, string StandardOutput, string StandardError);
+
+/// <summary>
+/// A whole batch: the process exit code it implies, and each item's outcome in input order so a
+/// caller that knows more than "non-zero means failed" — the fuzz sharder, whose shards exit 1
+/// to report violations found — can summarize it itself.
+/// </summary>
+internal sealed record BatchRunResult(int ExitCode, IReadOnlyList<BatchItemOutcome> Outcomes);
+
+/// <summary>
+/// Runs a batch of CLI inputs concurrently. Multithreading roadmap item #20.
+/// </summary>
+/// <remarks>
+/// <para>
+/// There are two execution modes, and which one an operation may use is decided by whether
+/// it touches the render path, not by convenience:
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <see cref="RunInProcess"/> — threads in this process. Correct only for work that reaches
+/// no shared mutable engine state. Document conversion qualifies: the static-state audit
+/// (<c>docs/architecture/multithreading-static-state.md</c>) finds Broiler.Documents has no
+/// assignable statics at all, only lookup tables filled by their initialisers.
+/// </description></item>
+/// <item><description>
+/// <see cref="RunInChildProcesses"/> — one child <c>Broiler.Cli</c> per item, bounded. This is
+/// what rendering work has to use today: the render path still holds unsynchronised caches on
+/// process-wide singletons (<c>FontsHandler</c>'s four dictionaries, <c>BImageRenderer._images</c>),
+/// which roadmap items #9 and #8 exist to fix. Until they land, two renders in one process is a
+/// data race, and a second process is the cheap correct answer — the same reasoning the WPT
+/// runner's worker pool rests on.
+/// </description></item>
+/// </list>
+/// <para>
+/// Both modes buffer each item's output and replay the whole transcript in input order once the
+/// batch finishes, so a batch produces the same bytes on stdout at any thread count. Progress is
+/// reported as items complete, which is the one thing that legitimately varies.
+/// </para>
+/// </remarks>
+internal static class BatchRunner
+{
+    /// <summary>
+    /// Resolves the thread/process count for a batch: an explicit <c>--threads</c> wins,
+    /// otherwise one per core, and never more than there are items to do.
+    /// </summary>
+    internal static int ResolveDegreeOfParallelism(int? requested, int itemCount, int processorCount)
+    {
+        if (itemCount <= 0)
+            return 1;
+
+        int degree = requested is { } explicitDegree
+            ? Math.Max(1, explicitDegree)
+            : Math.Max(1, processorCount);
+
+        return Math.Min(degree, itemCount);
+    }
+
+    /// <summary>
+    /// Derives <c>&lt;outputDir&gt;/&lt;input name&gt;.&lt;extension&gt;</c> for each input.
+    /// Two inputs from different directories can share a file name, so a collision appends
+    /// <c>-2</c>, <c>-3</c>, … in input order — deterministic, and never silently overwriting
+    /// one item's result with another's.
+    /// </summary>
+    internal static IReadOnlyList<BatchItem> DeriveOutputPaths(
+        IReadOnlyList<string> inputs,
+        string outputDir,
+        string extension)
+    {
+        var normalizedExtension = extension.StartsWith('.') ? extension : "." + extension;
+        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var items = new List<BatchItem>(inputs.Count);
+
+        foreach (var input in inputs)
+        {
+            var stem = DeriveStem(input);
+            var candidate = stem + normalizedExtension;
+            for (int suffix = 2; !used.Add(candidate); suffix++)
+                candidate = $"{stem}-{suffix}{normalizedExtension}";
+
+            items.Add(new BatchItem(input, Path.Combine(outputDir, candidate)));
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// The output file's base name for an input. A file path contributes its own name; a URL
+    /// contributes its last non-empty path segment, falling back to the host, so
+    /// <c>https://example.com/a/b.html</c> becomes <c>b</c> and <c>https://example.com/</c>
+    /// becomes <c>example.com</c>.
+    /// </summary>
+    private static string DeriveStem(string input)
+    {
+        string candidate = input;
+
+        if (Uri.TryCreate(input, UriKind.Absolute, out var uri) && !uri.IsFile)
+        {
+            var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length == 0)
+            {
+                // A host is not a file name: "example.com" would lose its ".com" to
+                // GetFileNameWithoutExtension and collide with every other example.* host.
+                return SanitizeFileName(uri.Host);
+            }
+
+            candidate = segments[^1];
+        }
+        else if (uri is { IsFile: true })
+        {
+            candidate = uri.LocalPath;
+        }
+
+        var stem = Path.GetFileNameWithoutExtension(candidate);
+        if (string.IsNullOrWhiteSpace(stem))
+            stem = Path.GetFileName(candidate);
+        if (string.IsNullOrWhiteSpace(stem))
+            stem = "output";
+
+        return SanitizeFileName(stem);
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(name.Length);
+        foreach (var c in name)
+            builder.Append(Array.IndexOf(invalid, c) >= 0 ? '_' : c);
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Runs <paramref name="convert"/> over the batch on <paramref name="degreeOfParallelism"/>
+    /// threads of this process. See the type remarks for when this is admissible.
+    /// </summary>
+    internal static BatchRunResult RunInProcess(
+        IReadOnlyList<BatchItem> items,
+        int degreeOfParallelism,
+        Func<BatchItem, TextWriter, TextWriter, int> convert)
+    {
+        return Run(items, degreeOfParallelism, summarize: true, (item, _) =>
+        {
+            var standardOutput = new StringWriter();
+            var standardError = new StringWriter();
+            int exitCode;
+            try
+            {
+                exitCode = convert(item, standardOutput, standardError);
+            }
+            catch (Exception ex)
+            {
+                standardError.WriteLine($"Unexpected error converting {item.Input}: {ex.Message}");
+                exitCode = 1;
+            }
+
+            return new BatchItemOutcome(exitCode, standardOutput.ToString(), standardError.ToString());
+        });
+    }
+
+    /// <summary>
+    /// Runs each item as its own <c>Broiler.Cli</c> process, at most
+    /// <paramref name="degreeOfParallelism"/> at a time. <paramref name="argumentsFor"/> builds
+    /// the child's argument list, which is an ordinary single-input invocation — the child needs
+    /// to know nothing about batching, so a batch item behaves exactly as it would alone.
+    /// </summary>
+    internal static BatchRunResult RunInChildProcesses(
+        IReadOnlyList<BatchItem> items,
+        int degreeOfParallelism,
+        Func<BatchItem, int, IReadOnlyList<string>> argumentsFor,
+        bool summarize = true,
+        Func<string, string>? filterTranscript = null)
+    {
+        return Run(
+            items,
+            degreeOfParallelism,
+            summarize,
+            (item, index) => RunChild(argumentsFor(item, index)),
+            filterTranscript);
+    }
+
+    private static BatchItemOutcome RunChild(IReadOnlyList<string> arguments)
+    {
+        var startInfo = CreateCurrentProgramStartInfo(arguments);
+        try
+        {
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start a Broiler.Cli worker process.");
+
+            // Read both pipes before waiting: a child that fills one of them while the parent
+            // waits on exit deadlocks, and a full-page capture writes enough to do it.
+            var standardOutput = process.StandardOutput.ReadToEndAsync();
+            var standardError = process.StandardError.ReadToEndAsync();
+            process.WaitForExit();
+
+            return new BatchItemOutcome(
+                process.ExitCode,
+                standardOutput.GetAwaiter().GetResult(),
+                standardError.GetAwaiter().GetResult());
+        }
+        catch (Exception ex)
+        {
+            return new BatchItemOutcome(1, string.Empty, $"Worker process failed: {ex.Message}{Environment.NewLine}");
+        }
+    }
+
+    private static BatchRunResult Run(
+        IReadOnlyList<BatchItem> items,
+        int degreeOfParallelism,
+        bool summarize,
+        Func<BatchItem, int, BatchItemOutcome> execute,
+        Func<string, string>? filterTranscript = null)
+    {
+        if (items.Count == 0)
+            return new BatchRunResult(0, []);
+
+        var outcomes = new BatchItemOutcome[items.Count];
+        int nextIndex = -1;
+        int completed = 0;
+
+        void RunSlot()
+        {
+            while (true)
+            {
+                int index = Interlocked.Increment(ref nextIndex);
+                if (index >= items.Count)
+                    return;
+
+                outcomes[index] = execute(items[index], index);
+                int done = Interlocked.Increment(ref completed);
+                Console.WriteLine($"[{done}/{items.Count}] {items[index].Input} -> {items[index].OutputPath}");
+            }
+        }
+
+        int slots = Math.Clamp(degreeOfParallelism, 1, items.Count);
+        if (slots == 1)
+        {
+            RunSlot();
+        }
+        else
+        {
+            var tasks = new Task[slots];
+            for (int slot = 0; slot < slots; slot++)
+                tasks[slot] = Task.Run(RunSlot);
+            Task.WaitAll(tasks);
+        }
+
+        return new BatchRunResult(Report(items, outcomes, summarize, filterTranscript), outcomes);
+    }
+
+    /// <summary>
+    /// Replays every item's output in input order and returns 0 only if every item succeeded.
+    /// With <paramref name="summarize"/> false the transcript is still replayed but the
+    /// pass/fail tally is left to the caller, because a non-zero exit does not always mean the
+    /// item failed.
+    /// </summary>
+    private static int Report(
+        IReadOnlyList<BatchItem> items,
+        IReadOnlyList<BatchItemOutcome> outcomes,
+        bool summarize,
+        Func<string, string>? filterTranscript)
+    {
+        int failed = 0;
+
+        Console.WriteLine();
+        for (int i = 0; i < items.Count; i++)
+        {
+            var outcome = outcomes[i];
+            // The caller still sees the unfiltered text in the returned outcomes; the filter only
+            // keeps machine-readable lines a child emits for its parent out of the transcript.
+            var standardOutput = filterTranscript is null
+                ? outcome.StandardOutput
+                : filterTranscript(outcome.StandardOutput);
+            if (!string.IsNullOrEmpty(standardOutput))
+                Console.Out.Write(standardOutput);
+            if (!string.IsNullOrEmpty(outcome.StandardError))
+                Console.Error.Write(outcome.StandardError);
+            if (outcome.ExitCode == 0)
+                continue;
+
+            failed++;
+            if (summarize)
+                Console.Error.WriteLine($"Failed ({outcome.ExitCode}): {items[i].Input}");
+        }
+
+        if (summarize)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"Batch complete: {items.Count} item(s), {items.Count - failed} succeeded, {failed} failed.");
+        }
+
+        return failed > 0 ? 1 : 0;
+    }
+
+    /// <summary>
+    /// A start info that re-invokes this same program — the framework-dependent case runs
+    /// through <c>dotnet &lt;assembly&gt;</c>, since <c>Environment.ProcessPath</c> is then the
+    /// shared host rather than the app.
+    /// </summary>
+    internal static ProcessStartInfo CreateCurrentProgramStartInfo(IEnumerable<string> arguments)
+    {
+        var processPath = Environment.ProcessPath;
+        var assemblyPath = typeof(BatchRunner).Assembly.Location;
+        var startInfo = new ProcessStartInfo
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        if (!string.IsNullOrWhiteSpace(processPath) && !IsDotNetHost(processPath))
+        {
+            startInfo.FileName = processPath;
+        }
+        else
+        {
+            startInfo.FileName = string.IsNullOrWhiteSpace(processPath) ? "dotnet" : processPath;
+            startInfo.ArgumentList.Add(assemblyPath);
+        }
+
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+
+        return startInfo;
+    }
+
+    private static bool IsDotNetHost(string processPath)
+    {
+        var fileName = Path.GetFileNameWithoutExtension(processPath);
+        return string.Equals(fileName, "dotnet", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Broiler.Cli/DocumentConvertService.cs
+++ b/src/Broiler.Cli/DocumentConvertService.cs
@@ -16,11 +16,19 @@ namespace Broiler.Cli;
 /// </summary>
 public static class DocumentConvertService
 {
-    public static int Convert(string inputPath, string outputPath)
+    public static int Convert(string inputPath, string outputPath) =>
+        Convert(inputPath, outputPath, Console.Out, Console.Error);
+
+    /// <summary>
+    /// Converts one document, writing its transcript to the given writers rather than straight
+    /// to the console. A batch conversion runs several of these concurrently and replays each
+    /// item's output in input order, which it can only do if the output is capturable.
+    /// </summary>
+    public static int Convert(string inputPath, string outputPath, TextWriter standardOutput, TextWriter standardError)
     {
         if (!File.Exists(inputPath))
         {
-            Console.Error.WriteLine($"Error: input file not found: {inputPath}");
+            standardError.WriteLine($"Error: input file not found: {inputPath}");
             return 1;
         }
 
@@ -40,7 +48,7 @@ public static class DocumentConvertService
 
         if (match is null)
         {
-            Console.Error.WriteLine($"Error: no document codec recognized '{inputPath}'.");
+            standardError.WriteLine($"Error: no document codec recognized '{inputPath}'.");
             return 1;
         }
 
@@ -70,16 +78,20 @@ public static class DocumentConvertService
                 output = MarkdownWriter.WriteToArray(read.Document);
                 break;
             default:
-                Console.Error.WriteLine($"Error: unsupported output format '{extension}'. Use .txt, .rtf, .docx, .html, or .md.");
+                standardError.WriteLine($"Error: unsupported output format '{extension}'. Use .txt, .rtf, .docx, .html, or .md.");
                 return 1;
         }
 
+        var outputDirectory = Path.GetDirectoryName(Path.GetFullPath(outputPath));
+        if (!string.IsNullOrEmpty(outputDirectory))
+            Directory.CreateDirectory(outputDirectory);
+
         File.WriteAllBytes(outputPath, output);
-        Console.WriteLine(
+        standardOutput.WriteLine(
             $"Converted {inputPath} -> {outputPath} " +
             $"({match.Codec.Name}, {read.Document.ParagraphCount} paragraph(s), " +
             $"{read.Document.PlainText.Length} character(s), {read.Diagnostics.Count} diagnostic(s)).");
-        WriteDiagnostics(read.Diagnostics);
+        WriteDiagnostics(read.Diagnostics, standardOutput, standardError);
         return 0;
     }
 
@@ -88,13 +100,16 @@ public static class DocumentConvertService
     /// the hardest kind to debug, so the codes go to the console rather than
     /// being summarized away as a count.
     /// </summary>
-    private static void WriteDiagnostics(IReadOnlyList<DocumentDiagnostic> diagnostics)
+    private static void WriteDiagnostics(
+        IReadOnlyList<DocumentDiagnostic> diagnostics,
+        TextWriter standardOutput,
+        TextWriter standardError)
     {
         foreach (DocumentDiagnostic diagnostic in diagnostics)
         {
             TextWriter writer = diagnostic.Severity == DocumentDiagnosticSeverity.Error
-                ? Console.Error
-                : Console.Out;
+                ? standardError
+                : standardOutput;
             writer.WriteLine($"  {diagnostic.Severity}: {diagnostic.Code}: {diagnostic.Message}");
         }
     }

--- a/src/Broiler.Cli/LayoutFuzzService.cs
+++ b/src/Broiler.Cli/LayoutFuzzService.cs
@@ -1,4 +1,5 @@
 using System.Drawing;
+using System.Globalization;
 using Broiler.Layout.IR;
 using Broiler.HTML.Core.IR;
 using Broiler.HTML.Image;
@@ -16,12 +17,28 @@ internal sealed class LayoutFuzzService
     /// Runs the layout fuzz and prints results to the console.
     /// Returns 0 if no violations were found, 1 if any violations occurred.
     /// </summary>
-    public int Run(int count, int? seed = null, string? outputDir = null)
+    /// <remarks>
+    /// With <paramref name="threads"/> above 1 the seed range is split into contiguous shards
+    /// run by child processes, not threads. Each case lays out a document, and layout reaches
+    /// the unsynchronised font caches the static-state audit names, so two cases in one process
+    /// would race; a shard per process costs one startup and is exactly as deterministic,
+    /// because a case's behaviour depends only on its seed.
+    /// </remarks>
+    public int Run(
+        int count,
+        int? seed = null,
+        string? outputDir = null,
+        int? threads = null,
+        bool emitTotals = false)
     {
         int baseSeed = seed ?? Environment.TickCount;
         string failDir = outputDir ?? Path.Combine(Directory.GetCurrentDirectory(), "fuzz-failures");
         int failureCount = 0;
         int crashCount = 0;
+
+        int shardCount = LayoutFuzzShards.ResolveShardCount(threads, count, Environment.ProcessorCount);
+        if (shardCount > 1)
+            return RunSharded(count, baseSeed, failDir, shardCount);
 
         Console.WriteLine($"Layout fuzz: running {count} cases (base seed {baseSeed})…");
 
@@ -77,7 +94,74 @@ internal sealed class LayoutFuzzService
             Console.WriteLine($"Failure details saved to: {failDir}");
         }
 
+        // A shard's totals have to reach the parent that spawned it, and parsing English prose
+        // out of a transcript is how that breaks the first time the prose is reworded. Only a
+        // shard emits this; a run somebody typed themselves has no parent to report to.
+        if (emitTotals)
+            Console.WriteLine(LayoutFuzzShards.FormatTotals(new LayoutFuzzTotals(count, failureCount, crashCount)));
+
         return failureCount > 0 ? 1 : 0;
+    }
+
+    /// <summary>
+    /// Runs the same seed range as the sequential path, split across child processes. The union
+    /// of the shards is the identical seed set — <see cref="LayoutFuzzShards.Partition"/> is
+    /// what guarantees that, and is unit-tested for it — so a sharded run finds the same
+    /// failures and writes the same per-seed files.
+    /// </summary>
+    private static int RunSharded(int count, int baseSeed, string failDir, int shardCount)
+    {
+        var shards = LayoutFuzzShards.Partition(count, baseSeed, shardCount);
+        Console.WriteLine(
+            $"Layout fuzz: running {count} cases (base seed {baseSeed}) across {shards.Count} worker process(es)…");
+
+        var items = shards
+            .Select(shard => new BatchItem($"seeds {shard.BaseSeed}..{shard.BaseSeed + shard.Count - 1}", failDir))
+            .ToList();
+
+        var batch = BatchRunner.RunInChildProcesses(
+            items,
+            shards.Count,
+            (_, index) =>
+            {
+                var shard = shards[index];
+                return
+                [
+                    "--fuzz-layout",
+                    "--count",
+                    shard.Count.ToString(CultureInfo.InvariantCulture),
+                    "--seed",
+                    shard.BaseSeed.ToString(CultureInfo.InvariantCulture),
+                    "--threads",
+                    "1",
+                    "--output",
+                    failDir,
+                    "--emit-totals",
+                ];
+            },
+            // A shard exits 1 when it finds violations, which is the fuzz doing its job — the
+            // generic "N failed" tally would read that as N broken workers.
+            summarize: false,
+            filterTranscript: LayoutFuzzShards.StripTotals);
+
+        var totals = LayoutFuzzShards.Aggregate(batch.Outcomes.Select(outcome => outcome.StandardOutput));
+
+        Console.WriteLine();
+        if (totals.Cases != count)
+        {
+            // A shard that died before printing its totals would otherwise be invisible: the
+            // run would report fewer cases than it was asked for and still look complete.
+            Console.Error.WriteLine(
+                $"Warning: only {totals.Cases} of {count} case(s) reported totals — a worker process " +
+                "exited without finishing. Re-run with --threads 1 to reproduce.");
+        }
+
+        Console.WriteLine(
+            $"Fuzz complete: {totals.Cases} cases, {totals.Failures} failure(s), {totals.Crashes} crash(es).");
+        if (totals.Failures > 0)
+            Console.WriteLine($"Failure details saved to: {failDir}");
+
+        return totals.Failures > 0 || totals.Cases != count ? 1 : 0;
     }
 
     private static Fragment? BuildFragmentTree(string html)

--- a/src/Broiler.Cli/LayoutFuzzShards.cs
+++ b/src/Broiler.Cli/LayoutFuzzShards.cs
@@ -1,0 +1,145 @@
+using System.Globalization;
+
+namespace Broiler.Cli;
+
+/// <summary>A contiguous slice of the fuzz seed range, run by one worker process.</summary>
+internal readonly record struct LayoutFuzzShard(int BaseSeed, int Count);
+
+/// <summary>What a fuzz run (or one shard of one) examined and found.</summary>
+internal readonly record struct LayoutFuzzTotals(int Cases, int Failures, int Crashes)
+{
+    internal LayoutFuzzTotals Add(LayoutFuzzTotals other) =>
+        new(Cases + other.Cases, Failures + other.Failures, Crashes + other.Crashes);
+}
+
+/// <summary>
+/// Splits a fuzz run's seed range across worker processes. Multithreading roadmap item #20.
+/// </summary>
+/// <remarks>
+/// The partition is the whole correctness argument for a parallel fuzz run: a case's behaviour
+/// depends only on its seed, so as long as the shards' seeds are exactly the sequential run's
+/// seeds — each once — the sharded run examines the same documents and writes the same
+/// per-seed failure files. That property is what <c>Partition</c> guarantees and what its tests
+/// assert; nothing else about a fuzz run has to be synchronized.
+/// </remarks>
+internal static class LayoutFuzzShards
+{
+    /// <summary>
+    /// Fewest cases worth handing to a separate process. Below this the process startup costs
+    /// more than the cases do, so a small run stays in-process no matter what was asked for.
+    /// </summary>
+    internal const int MinimumCasesPerShard = 25;
+
+    internal static int ResolveShardCount(int? requested, int caseCount, int processorCount)
+    {
+        if (caseCount <= 0)
+            return 1;
+
+        int shardCount = requested is { } explicitShards
+            ? Math.Max(1, explicitShards)
+            : Math.Max(1, processorCount);
+
+        return Math.Clamp(shardCount, 1, Math.Max(1, caseCount / MinimumCasesPerShard));
+    }
+
+    /// <summary>
+    /// Splits <paramref name="count"/> cases starting at <paramref name="baseSeed"/> into
+    /// <paramref name="shardCount"/> contiguous shards. The remainder is spread over the first
+    /// shards rather than dumped on the last one, so the slowest shard is never a whole extra
+    /// chunk behind the others.
+    /// </summary>
+    internal static IReadOnlyList<LayoutFuzzShard> Partition(int count, int baseSeed, int shardCount)
+    {
+        if (count <= 0)
+            return [];
+
+        int shards = Math.Clamp(shardCount, 1, count);
+        int chunk = count / shards;
+        int remainder = count % shards;
+
+        var partition = new List<LayoutFuzzShard>(shards);
+        int seed = baseSeed;
+        for (int i = 0; i < shards; i++)
+        {
+            int shardSize = chunk + (i < remainder ? 1 : 0);
+            partition.Add(new LayoutFuzzShard(seed, shardSize));
+            seed += shardSize;
+        }
+
+        return partition;
+    }
+
+    /// <summary>
+    /// Prefix of the machine-readable totals line a fuzz run prints last. The parent sums these
+    /// rather than reading the human summary, so rewording the transcript cannot silently break
+    /// a sharded run's arithmetic.
+    /// </summary>
+    private const string TotalsMarker = "##fuzz-totals";
+
+    /// <summary>
+    /// Drops the machine-readable totals lines from a shard's transcript. The parent parses them
+    /// from the raw text; a reader of the console should not have to see them.
+    /// </summary>
+    internal static string StripTotals(string transcript) =>
+        string.Join(
+            '\n',
+            transcript
+                .Split('\n')
+                .Where(line => !line.TrimStart().StartsWith(TotalsMarker, StringComparison.Ordinal)));
+
+    internal static string FormatTotals(LayoutFuzzTotals totals) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"{TotalsMarker} cases={totals.Cases} failures={totals.Failures} crashes={totals.Crashes}");
+
+    internal static bool TryParseTotals(string line, out LayoutFuzzTotals totals)
+    {
+        totals = default;
+        var trimmed = line.Trim();
+        if (!trimmed.StartsWith(TotalsMarker, StringComparison.Ordinal))
+            return false;
+
+        int cases = 0, failures = 0, crashes = 0;
+        foreach (var field in trimmed[TotalsMarker.Length..].Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var separator = field.IndexOf('=');
+            if (separator < 0)
+                return false;
+
+            if (!int.TryParse(field[(separator + 1)..], NumberStyles.Integer, CultureInfo.InvariantCulture, out int value))
+                return false;
+
+            switch (field[..separator])
+            {
+                case "cases": cases = value; break;
+                case "failures": failures = value; break;
+                case "crashes": crashes = value; break;
+                default: return false;
+            }
+        }
+
+        totals = new LayoutFuzzTotals(cases, failures, crashes);
+        return true;
+    }
+
+    /// <summary>
+    /// Sums the totals reported by each shard's transcript. A shard that printed no totals
+    /// contributes nothing, which is what makes a died-early shard visible as a case shortfall
+    /// rather than as a silently smaller run.
+    /// </summary>
+    internal static LayoutFuzzTotals Aggregate(IEnumerable<string> transcripts)
+    {
+        var total = new LayoutFuzzTotals(0, 0, 0);
+
+        foreach (var transcript in transcripts)
+        {
+            foreach (var line in transcript.Split('\n'))
+            {
+                if (TryParseTotals(line, out var shardTotals))
+                    total = total.Add(shardTotals);
+            }
+        }
+
+        return total;
+    }
+}

--- a/src/Broiler.Cli/Program.cs
+++ b/src/Broiler.Cli/Program.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text.Json;
 using Broiler.HTML.Image;
 using Broiler.HtmlBridge.Logging;
@@ -24,10 +25,20 @@ public class Program
             new Broiler.Media.MediaCodecCatalog(Broiler.Media.Image.Managed.ManagedImageCodecs.CreateCodecs()));
 
         string? pdfInputPath = null;
-        string? convertDocInput = null;
-        string? url = null;
-        string? captureImageUrl = null;
+        // Repeatable inputs: one is the single-input path this CLI has always had, more than
+        // one is a batch. Accumulating rather than overwriting is what makes `--convert-doc a
+        // --convert-doc b` mean both instead of only the last.
+        var convertDocInputs = new List<string>();
+        var urls = new List<string>();
+        var captureImageUrls = new List<string>();
         string? output = null;
+        string? outputDir = null;
+        string? outputFormat = null;
+        int? threads = null;
+        int? fuzzSeed = null;
+        // Set by the parent on a fuzz shard so the child appends a machine-readable totals line
+        // for it to sum. Not part of the documented surface — it only means anything to a parent.
+        bool emitFuzzTotals = false;
         bool preservePdfLayout = false;
         bool fullPage = false;
         bool testEngines = false;
@@ -47,16 +58,40 @@ public class Program
                     pdfInputPath = args[++i];
                     break;
                 case "--convert-doc" when i + 1 < args.Length:
-                    convertDocInput = args[++i];
+                    convertDocInputs.Add(args[++i]);
                     break;
                 case "--url" when i + 1 < args.Length:
-                    url = args[++i];
+                    urls.Add(args[++i]);
                     break;
                 case "--capture-image" when i + 1 < args.Length:
-                    captureImageUrl = args[++i];
+                    captureImageUrls.Add(args[++i]);
                     break;
                 case "--output" when i + 1 < args.Length:
                     output = args[++i];
+                    break;
+                case "--output-dir" when i + 1 < args.Length:
+                    outputDir = args[++i];
+                    break;
+                case "--output-format" when i + 1 < args.Length:
+                    outputFormat = args[++i];
+                    break;
+                case "--threads" when i + 1 < args.Length:
+                    if (!int.TryParse(args[++i], out int parsedThreads) || parsedThreads <= 0)
+                    {
+                        Console.Error.WriteLine("Error: '--threads' must be a positive integer.");
+                        return 1;
+                    }
+
+                    threads = parsedThreads;
+                    break;
+                case "--seed" when i + 1 < args.Length:
+                    if (!int.TryParse(args[++i], out int parsedSeed))
+                    {
+                        Console.Error.WriteLine("Error: '--seed' must be an integer.");
+                        return 1;
+                    }
+
+                    fuzzSeed = parsedSeed;
                     break;
                 case "--preserve-layout":
                     preservePdfLayout = true;
@@ -94,6 +129,9 @@ public class Program
                 case "--fuzz-layout":
                     fuzzLayout = true;
                     break;
+                case "--emit-totals":
+                    emitFuzzTotals = true;
+                    break;
                 case "--diagnostics":
                     diagnostics = true;
                     break;
@@ -109,6 +147,10 @@ public class Program
                 case "--url":
                 case "--capture-image":
                 case "--output":
+                case "--output-dir":
+                case "--output-format":
+                case "--threads":
+                case "--seed":
                 case "--timeout":
                 case "--width":
                 case "--height":
@@ -126,16 +168,8 @@ public class Program
             }
         }
 
-        if (convertDocInput is not null)
-        {
-            if (output is null)
-            {
-                Console.Error.WriteLine("Error: '--convert-doc' requires '--output <file.txt|file.rtf|file.docx|file.html|file.md>'.");
-                return 1;
-            }
-
-            return DocumentConvertService.Convert(convertDocInput, output);
-        }
+        if (convertDocInputs.Count > 0)
+            return RunDocumentConversion(convertDocInputs, output, outputDir, outputFormat, threads);
 
         if (testEngines)
         {
@@ -145,7 +179,12 @@ public class Program
         if (fuzzLayout)
         {
             var fuzzService = new LayoutFuzzService();
-            return fuzzService.Run(fuzzCount, outputDir: output);
+            return fuzzService.Run(
+                fuzzCount,
+                seed: fuzzSeed,
+                outputDir: output,
+                threads: threads,
+                emitTotals: emitFuzzTotals);
         }
 
         // When --diagnostics is active, subscribe to the render logger and
@@ -161,6 +200,29 @@ public class Program
         }
 
         int exitCode;
+
+        // Batch capture runs each input as its own child process rather than on a thread: the
+        // render path still has unsynchronised caches on process-wide singletons (roadmap items
+        // #9/#8), so a second render in this process would be a data race. See BatchRunner.
+        if (captureImageUrls.Count > 1 || urls.Count > 1)
+        {
+            exitCode = RunBatchCapture(
+                captureImageUrls,
+                urls,
+                outputDir,
+                outputFormat,
+                threads,
+                width,
+                height,
+                fullPage,
+                followFirstLink,
+                timeoutSeconds);
+            EmitDiagnostics(diagHandler, diagnosticEntries);
+            return exitCode;
+        }
+
+        string? url = urls.Count > 0 ? urls[0] : null;
+        string? captureImageUrl = captureImageUrls.Count > 0 ? captureImageUrls[0] : null;
 
         if (pdfInputPath is not null)
         {
@@ -321,6 +383,120 @@ public class Program
         return exitCode;
     }
 
+    /// <summary>
+    /// Converts one document, or a batch of them across threads. Conversion touches no engine
+    /// state — Broiler.Documents has no assignable statics, only lookup tables — so a batch runs
+    /// in this process rather than paying for one child per file.
+    /// </summary>
+    private static int RunDocumentConversion(
+        IReadOnlyList<string> inputs,
+        string? output,
+        string? outputDir,
+        string? outputFormat,
+        int? threads)
+    {
+        if (inputs.Count == 1 && outputDir is null)
+        {
+            if (output is null)
+            {
+                Console.Error.WriteLine("Error: '--convert-doc' requires '--output <file.txt|file.rtf|file.docx|file.html|file.md>' (or '--output-dir <DIR> --output-format <EXT>').");
+                return 1;
+            }
+
+            return DocumentConvertService.Convert(inputs[0], output);
+        }
+
+        if (outputDir is null)
+        {
+            Console.Error.WriteLine("Error: converting several documents requires '--output-dir <DIR>'.");
+            return 1;
+        }
+
+        if (outputFormat is null)
+        {
+            Console.Error.WriteLine("Error: '--output-dir' requires '--output-format <txt|rtf|docx|html|md>' — the output format comes from the file extension, which a derived name has to be told.");
+            return 1;
+        }
+
+        var items = BatchRunner.DeriveOutputPaths(inputs, outputDir, outputFormat);
+        int degree = BatchRunner.ResolveDegreeOfParallelism(threads, items.Count, Environment.ProcessorCount);
+        Console.WriteLine($"Converting {items.Count} document(s) on {degree} thread(s)…");
+
+        return BatchRunner.RunInProcess(
+            items,
+            degree,
+            (item, standardOutput, standardError) =>
+                DocumentConvertService.Convert(item.Input, item.OutputPath, standardOutput, standardError))
+            .ExitCode;
+    }
+
+    /// <summary>
+    /// Captures several URLs concurrently, each in its own child <c>Broiler.Cli</c> process.
+    /// The child invocation is an ordinary single-URL capture, so a batched capture and a
+    /// hand-run one produce the same file by the same code path.
+    /// </summary>
+    private static int RunBatchCapture(
+        IReadOnlyList<string> captureImageUrls,
+        IReadOnlyList<string> urls,
+        string? outputDir,
+        string? outputFormat,
+        int? threads,
+        int width,
+        int height,
+        bool fullPage,
+        bool followFirstLink,
+        int timeoutSeconds)
+    {
+        if (captureImageUrls.Count > 0 && urls.Count > 0)
+        {
+            Console.Error.WriteLine("Error: '--capture-image' and '--url' cannot be batched together in one run.");
+            return 1;
+        }
+
+        if (outputDir is null)
+        {
+            Console.Error.WriteLine("Error: capturing several URLs requires '--output-dir <DIR>'.");
+            return 1;
+        }
+
+        bool imageMode = captureImageUrls.Count > 0;
+        var inputs = imageMode ? captureImageUrls : urls;
+        var extension = outputFormat ?? (imageMode ? "png" : "html");
+        var items = BatchRunner.DeriveOutputPaths(inputs, outputDir, extension);
+        int degree = BatchRunner.ResolveDegreeOfParallelism(threads, items.Count, Environment.ProcessorCount);
+
+        Directory.CreateDirectory(outputDir);
+        Console.WriteLine($"Capturing {items.Count} URL(s) across {degree} worker process(es)…");
+
+        return BatchRunner.RunInChildProcesses(items, degree, (item, _) =>
+        {
+            var arguments = new List<string>
+            {
+                imageMode ? "--capture-image" : "--url",
+                item.Input,
+                "--output",
+                item.OutputPath,
+                "--timeout",
+                timeoutSeconds.ToString(CultureInfo.InvariantCulture),
+            };
+
+            if (imageMode)
+            {
+                arguments.Add("--width");
+                arguments.Add(width.ToString(CultureInfo.InvariantCulture));
+                arguments.Add("--height");
+                arguments.Add(height.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (fullPage)
+                arguments.Add("--full-page");
+            if (followFirstLink)
+                arguments.Add("--follow-first-link");
+
+            return arguments;
+        }).ExitCode;
+    }
+
     private static void PrintUsage()
     {
         Console.WriteLine("Usage: Broiler.Cli --convert-pdf <PDF> [--output <FILE|DIR>] [--preserve-layout]");
@@ -336,6 +512,15 @@ public class Program
         Console.WriteLine("  --url <URL>            The URL of the website to capture");
         Console.WriteLine("  --capture-image <URL>  Capture the website as an image (PNG or JPEG)");
         Console.WriteLine("  --output <FILE|DIR>    Output file path, or output directory for PDF conversion");
+        Console.WriteLine("  --output-dir <DIR>     Output directory for a batch. --convert-doc, --url and");
+        Console.WriteLine("                         --capture-image may each be repeated; with more than one input");
+        Console.WriteLine("                         the items run concurrently and each result is written to");
+        Console.WriteLine("                         <DIR>/<input name>.<format>");
+        Console.WriteLine("  --output-format <EXT>  Output extension for a batch (default: png for --capture-image,");
+        Console.WriteLine("                         html for --url; required for --convert-doc batches)");
+        Console.WriteLine("  --threads <N>          Concurrency for a batch or for --fuzz-layout (default: one per");
+        Console.WriteLine("                         core). --threads 1 reproduces the sequential run exactly.");
+        Console.WriteLine("  --seed <N>             Base seed for --fuzz-layout (default: a clock reading)");
         Console.WriteLine("  --preserve-layout      Preserve PDF page layout and styling during PDF conversion");
         Console.WriteLine("  --width <PIXELS>       Image width in pixels (default: 1024, used with --capture-image)");
         Console.WriteLine("  --height <PIXELS>      Image height in pixels (default: 768, used with --capture-image)");

--- a/src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs
@@ -52,7 +52,8 @@ public static partial class ScriptExtractionService
     /// external check, then is decoded / fetched. Returns <c>null</c> when blocked, empty, or unresolvable.
     /// </summary>
     private static string? ResolveModuleSource(
-        ScriptSourceKind kind, string? url, string rawContent, string? nonce, ContentSecurityPolicy? csp, string? pageUrl)
+        ScriptSourceKind kind, string? url, string rawContent, string? nonce, ContentSecurityPolicy? csp, string? pageUrl,
+        SubResourcePrefetcher? prefetcher = null)
     {
         switch (kind)
         {
@@ -69,7 +70,7 @@ public static partial class ScriptExtractionService
             case ScriptSourceKind.External:
                 if (csp != null && !csp.AllowsExternalScript(url!, pageUrl, nonce))
                     return null;
-                var fetched = FetchExternalScript(url!, pageUrl);
+                var fetched = FetchExternalScript(url!, pageUrl, prefetcher);
                 return string.IsNullOrEmpty(fetched) ? null : fetched;
 
             default:
@@ -132,6 +133,11 @@ public static partial class ScriptExtractionService
         var moduleEntryKeys = new HashSet<string>(StringComparer.Ordinal);
         var csp = ContentSecurityPolicy.FromHtml(html);
 
+        // Prefetch pass (roadmap item #2): every external script this document will fetch is
+        // requested now, concurrently and bounded per host. The walk below is untouched — it still
+        // resolves each script in document order, it just no longer starts each round trip itself.
+        var prefetcher = CreateScriptPrefetcher(html, pageUrl, csp);
+
         var documentOrder = 0;
         foreach (var tag in HtmlScriptScanner.EnumerateScripts(html))
         {
@@ -160,7 +166,7 @@ public static partial class ScriptExtractionService
                 // per-occurrence key, so they never dedup; a repeated src module is recorded once.
                 if (kind == ScriptSourceKind.Inline || !moduleMap.TryGet(moduleKey, out _))
                 {
-                    var moduleSource = ResolveModuleSource(kind, url, tag.RawContent, nonce, csp, pageUrl);
+                    var moduleSource = ResolveModuleSource(kind, url, tag.RawContent, nonce, csp, pageUrl, prefetcher);
                     moduleMap.Add(new ModuleMapEntry(documentOrder, kind, moduleKey, url, moduleSource, IsExecutable: moduleSource != null));
 
                     if (moduleSource != null)
@@ -198,7 +204,7 @@ public static partial class ScriptExtractionService
                 {
                     if (csp == null || csp.AllowsExternalScript(url!, pageUrl, nonce))
                     {
-                        var fetched = FetchExternalScript(url!, pageUrl);
+                        var fetched = FetchExternalScript(url!, pageUrl, prefetcher);
                         if (!string.IsNullOrEmpty(fetched))
                             scriptContent = fetched;
                     }
@@ -282,29 +288,27 @@ public static partial class ScriptExtractionService
     /// Relative URLs are resolved against the page <paramref name="pageUrl"/>.
     /// Returns the script text content, or <c>null</c> on failure.
     /// </summary>
-    public static string? FetchExternalScript(string scriptUrl, string? pageUrl)
+    public static string? FetchExternalScript(string scriptUrl, string? pageUrl) =>
+        FetchExternalScript(scriptUrl, pageUrl, prefetcher: null);
+
+    /// <summary>
+    /// The same fetch, but consuming <paramref name="prefetcher"/> when one is supplied. The URL
+    /// resolution, the ordering, and the value the caller gets back are unchanged — the only
+    /// difference is that the request may already have been in flight since the document was
+    /// scanned. Multithreading roadmap item #2.
+    /// </summary>
+    internal static string? FetchExternalScript(string scriptUrl, string? pageUrl, SubResourcePrefetcher? prefetcher)
     {
         try
         {
             // Resolve relative URLs against the page URL via the shared resolver.
             if (UrlResolver.Resolve(scriptUrl, pageUrl) is not { } resolvedUri)
                 return null;
+
             var resolvedUrl = resolvedUri.AbsoluteUri;
-
-            // Handle file:// URLs — read from local filesystem
-            if (resolvedUri.Scheme.Equals("file", StringComparison.OrdinalIgnoreCase))
-            {
-                var path = resolvedUri.LocalPath;
-                return File.Exists(path) ? File.ReadAllText(path) : null;
-            }
-
-            // Synchronous HTTP fetch.  ConfigureAwait(false) prevents
-            // deadlocks when the caller is on a UI dispatcher.
-            var content = SharedHttpClient.GetStringAsync(resolvedUrl)
-                .ConfigureAwait(false)
-                .GetAwaiter()
-                .GetResult();
-            return content;
+            return prefetcher is not null
+                ? prefetcher.Consume(resolvedUrl)
+                : FetchResolvedScript(resolvedUrl);
         }
         catch (Exception ex)
         {
@@ -312,6 +316,75 @@ public static partial class ScriptExtractionService
                 $"Failed to fetch external script '{scriptUrl}': {ex.Message}", ex);
             return null;
         }
+    }
+
+    /// <summary>
+    /// Fetches an already-resolved absolute script URL. This is the blocking primitive: it runs
+    /// inline at the call site when there is no prefetcher, and on a prefetch worker when there is.
+    /// </summary>
+    private static string? FetchResolvedScript(string resolvedUrl)
+    {
+        if (!Uri.TryCreate(resolvedUrl, UriKind.Absolute, out var uri))
+            return null;
+
+        // Handle file:// URLs — read from local filesystem
+        if (uri.Scheme.Equals("file", StringComparison.OrdinalIgnoreCase))
+        {
+            var path = uri.LocalPath;
+            return File.Exists(path) ? File.ReadAllText(path) : null;
+        }
+
+        // Synchronous HTTP fetch.  ConfigureAwait(false) prevents
+        // deadlocks when the caller is on a UI dispatcher.
+        return SharedHttpClient.GetStringAsync(resolvedUrl)
+            .ConfigureAwait(false)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    /// <summary>
+    /// Issues concurrent requests for every external script the document will fetch, before the
+    /// document-order walk that consumes them one at a time. Multithreading roadmap item #2.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The scan applies the <em>same</em> CSP check the consuming walk applies. Prefetching a
+    /// blocked script would put a request on the wire that the policy forbids — the request itself
+    /// is the thing CSP is stopping, so "we fetched it but did not run it" is not a defensible
+    /// reading of the policy.
+    /// </para>
+    /// <para>
+    /// A document with fewer than two external scripts gets no prefetcher: there is no round trip
+    /// to overlap, and the sequential path is then bit-for-bit the code that ran before.
+    /// </para>
+    /// </remarks>
+    internal static SubResourcePrefetcher? CreateScriptPrefetcher(
+        string html,
+        string? pageUrl,
+        ContentSecurityPolicy? csp)
+    {
+        var urls = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var tag in HtmlScriptScanner.EnumerateScripts(html))
+        {
+            var src = GetSrc(tag.Attributes);
+            if (src is null || src.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (csp != null && !csp.AllowsExternalScript(src, pageUrl, GetNonce(tag.Attributes)))
+                continue;
+
+            if (UrlResolver.Resolve(src, pageUrl) is { } resolved && seen.Add(resolved.AbsoluteUri))
+                urls.Add(resolved.AbsoluteUri);
+        }
+
+        if (urls.Count < 2)
+            return null;
+
+        var prefetcher = new SubResourcePrefetcher(FetchResolvedScript);
+        prefetcher.Prefetch(urls);
+        return prefetcher;
     }
 
     [GeneratedRegex(@"\s+", RegexOptions.Compiled)]

--- a/src/Broiler.HtmlBridge.Core/Scripting/SubResourcePrefetcher.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/SubResourcePrefetcher.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Broiler.HtmlBridge;
+
+/// <summary>
+/// Issues sub-resource fetches concurrently ahead of the synchronous call sites that consume
+/// them. Multithreading roadmap item #2.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every sub-resource call site in the bridge — external scripts, stylesheets, iframes,
+/// <c>fetch()</c> — blocks on <c>GetAwaiter().GetResult()</c>, one resource at a time, so a page
+/// with twenty sub-resources pays twenty serial round trips. The roadmap's answer is not to make
+/// those call sites <c>async</c> (they are ordering-sensitive: <c>document.write</c> and script
+/// execution order both depend on running in document order), but to split them in two:
+/// </para>
+/// <list type="number">
+/// <item><description>
+/// <b>Prefetch.</b> When a set of URLs becomes known — the moment a document's scripts have been
+/// scanned, say — issue them all at once, bounded per host.
+/// </description></item>
+/// <item><description>
+/// <b>Consume.</b> The call site stays exactly where it was, synchronous and in document order,
+/// but now blocks on a request that has been in flight since the scan instead of starting one.
+/// </description></item>
+/// </list>
+/// <para>
+/// The win is latency, not CPU: the round trips overlap. Ordering is untouched, because the
+/// consume step still happens at the original call site in the original order — the cache only
+/// changes when a request <em>starts</em>, never when its result is used.
+/// </para>
+/// <para>
+/// <b>Lifetime is per document, deliberately.</b> A process-wide cache would serve one document's
+/// bytes to the next and would be exactly the kind of unsynchronised shared cache the static-state
+/// audit (<c>docs/architecture/multithreading-static-state.md</c>) exists to keep out of the
+/// render path. An instance is created by whoever owns the document and dies with it.
+/// </para>
+/// <para>
+/// <b>Fetch failures are cached as failures.</b> A prefetch that throws yields <c>null</c>, and
+/// the consumer treats that exactly as its own failed fetch would have — a resource is attempted
+/// once per document, as it was before.
+/// </para>
+/// </remarks>
+public sealed class SubResourcePrefetcher
+{
+    /// <summary>
+    /// Concurrent requests allowed per host. Six is the browser convention for HTTP/1.1 and the
+    /// figure the roadmap names; more than this is rude to the origin and, past the connection
+    /// limit, buys nothing.
+    /// </summary>
+    public const int DefaultMaxConcurrentRequestsPerHost = 6;
+
+    private readonly ConcurrentDictionary<string, Lazy<Task<string?>>> _entries = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _hostGates = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Func<string, string?> _fetch;
+    private readonly int _maxConcurrentRequestsPerHost;
+
+    /// <param name="fetch">
+    /// The blocking fetch this prefetcher parallelizes — the very function the consuming call site
+    /// would otherwise have run inline. Taking it as a parameter is what lets scripts, stylesheets
+    /// and sub-documents share one prefetcher without this type knowing any of their policy
+    /// (CSP checks, WPT host mapping, file:// handling) — that all stays in the caller.
+    /// </param>
+    /// <param name="maxConcurrentRequestsPerHost">Per-host concurrency cap.</param>
+    public SubResourcePrefetcher(
+        Func<string, string?> fetch,
+        int maxConcurrentRequestsPerHost = DefaultMaxConcurrentRequestsPerHost)
+    {
+        _fetch = fetch ?? throw new ArgumentNullException(nameof(fetch));
+        _maxConcurrentRequestsPerHost = Math.Max(1, maxConcurrentRequestsPerHost);
+    }
+
+    /// <summary>Number of URLs this prefetcher has issued a request for. For tests and diagnostics.</summary>
+    public int RequestedCount => _entries.Count;
+
+    /// <summary>
+    /// Starts a fetch for each URL that does not already have one. Returns immediately; nothing
+    /// here waits. Duplicate URLs — the same script included twice, a stylesheet linked from two
+    /// places — collapse onto one request, which is what makes prefetching safe to call
+    /// generously.
+    /// </summary>
+    public void Prefetch(IEnumerable<string> urls)
+    {
+        ArgumentNullException.ThrowIfNull(urls);
+
+        foreach (var url in urls)
+        {
+            // Reading .Value is what starts the request. Creating the entry alone would leave every
+            // fetch to be forced by its own Consume — i.e. exactly the serial behaviour this
+            // replaces, with extra machinery.
+            if (!string.IsNullOrWhiteSpace(url))
+                _ = EntryFor(url).Value;
+        }
+    }
+
+    /// <summary>
+    /// Returns the content for <paramref name="url"/>, blocking until it arrives. A prefetched URL
+    /// has been in flight since <see cref="Prefetch"/>; one that was never prefetched is fetched
+    /// now, so a call site behaves identically whether or not a prefetch ran — which is what keeps
+    /// this safe to adopt one call site at a time.
+    /// </summary>
+    public string? Consume(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return null;
+
+        // Not ConfigureAwait-able through a Lazy; GetAwaiter().GetResult() on a task that was
+        // started with Task.Run never has a captured context to deadlock against.
+        return EntryFor(url).Value.GetAwaiter().GetResult();
+    }
+
+    /// <summary>True when a request for <paramref name="url"/> has already been issued.</summary>
+    public bool IsPending(string url) => _entries.ContainsKey(url);
+
+    private Lazy<Task<string?>> EntryFor(string url) =>
+        // LazyThreadSafetyMode.ExecutionAndPublication: GetOrAdd may run the factory more than
+        // once under contention, and each extra run would be an extra HTTP request. The Lazy makes
+        // the losing factory's value cheap to discard — only the published one ever starts a task.
+        _entries.GetOrAdd(
+            url,
+            static (key, state) => new Lazy<Task<string?>>(
+                () => state.StartFetch(key),
+                LazyThreadSafetyMode.ExecutionAndPublication),
+            this);
+
+    private Task<string?> StartFetch(string url)
+    {
+        var gate = _hostGates.GetOrAdd(
+            HostOf(url),
+            static (_, maxPerHost) => new SemaphoreSlim(maxPerHost, maxPerHost),
+            _maxConcurrentRequestsPerHost);
+
+        return Task.Run(() =>
+        {
+            gate.Wait();
+            try
+            {
+                return _fetch(url);
+            }
+            catch
+            {
+                // A failed sub-resource is not a failed page: the consumer sees null and applies
+                // whatever it already did for a fetch that came back empty.
+                return (string?)null;
+            }
+            finally
+            {
+                gate.Release();
+            }
+        });
+    }
+
+    /// <summary>
+    /// The host a URL's concurrency is charged to. Anything unparseable — and every
+    /// <c>file://</c> URL, which has no meaningful host — shares one bucket; local reads are not
+    /// what the per-host cap is protecting.
+    /// </summary>
+    private static string HostOf(string url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var uri) && !string.IsNullOrEmpty(uri.Host)
+            ? uri.Host
+            : string.Empty;
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ComputedStyleEngine.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ComputedStyleEngine.cs
@@ -77,6 +77,12 @@ public sealed partial class DomBridge
         // gates each on the element's `media` attribute against the viewport and re-syncs the
         // engine only when the effective set changes. Text extraction (canonical DomText children /
         // CSSOM rule text / external-sheet runtime state) stays here because it needs the DOM and loading.
+        // Prefetch pass (multithreading roadmap item #2): the whole sheet set is known here, and the
+        // loop below fetches each external one at the moment it reaches it — serially. Issuing them
+        // all now lets the round trips overlap; the loop still consumes them in document order, so
+        // the cascade sees the same sheets in the same order.
+        PrefetchExternalStylesheets(styleElements);
+
         var sources = new List<CssStyleScopeBuilder.StyleSource>(styleElements.Count);
         foreach (var styleEl in styleElements)
             sources.Add(new CssStyleScopeBuilder.StyleSource(

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Css.cs
@@ -733,6 +733,49 @@ public sealed partial class DomBridge
     }
 
     /// <summary>
+    /// Asks the loader to start fetching every external stylesheet in <paramref name="styleElements"/>
+    /// that this document has not already fetched. Multithreading roadmap item #2.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The URL handed over is the same string <see cref="GetStyleElementSourceText"/> will pass to
+    /// <see cref="FetchExternalStylesheet"/> — the raw <c>href</c> — because a prefetch keyed on a
+    /// differently-normalized URL would simply never be consumed, silently doubling the requests
+    /// instead of overlapping them.
+    /// </para>
+    /// <para>
+    /// The CSP check is applied here too: a sheet the policy blocks must not have a request put on
+    /// the wire on its behalf, and the consuming path already refuses it.
+    /// </para>
+    /// </remarks>
+    private void PrefetchExternalStylesheets(List<DomElement> styleElements)
+    {
+        List<string>? urls = null;
+
+        foreach (var styleEl in styleElements)
+        {
+            if (!string.Equals(styleEl.TagName, "link", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (!TryGetAttribute(styleEl, "href", out var href) || string.IsNullOrEmpty(href))
+                continue;
+
+            // Already fetched for this document — the consuming path reads the cached text and
+            // never calls the loader, so a request here would be pure waste.
+            if (StyleSheetStateFor(styleEl).FetchedCss.TryGet(out _))
+                continue;
+
+            if (!IsExternalStyleAllowedByCsp(styleEl, href))
+                continue;
+
+            (urls ??= []).Add(href);
+        }
+
+        if (urls is not null)
+            _resources.Prefetch(urls);
+    }
+
+    /// <summary>
     /// Fetches an external CSS stylesheet from an HTTP/HTTPS URL.
     /// Returns the CSS text content, or <c>null</c> on failure.
     /// </summary>

--- a/src/Broiler.HtmlBridge.Dom/Runtime/ResourceLoader.cs
+++ b/src/Broiler.HtmlBridge.Dom/Runtime/ResourceLoader.cs
@@ -40,7 +40,15 @@ internal sealed class ResourceLoader
     /// file. I/O exceptions propagate so the caller can log with its own context. This replaces the
     /// file/http switch that stylesheet/sub-resource feature callbacks used to inline.
     /// </summary>
-    public string? LoadText(string url)
+    public string? LoadText(string url) =>
+        // Consume side of the prefetch/consume split (multithreading roadmap item #2): identical
+        // policy and identical result, but a URL that was prefetched has been in flight since the
+        // document named it rather than starting its round trip here.
+        _prefetcher is { } prefetcher && prefetcher.IsPending(url)
+            ? prefetcher.Consume(url)
+            : LoadTextDirect(url);
+
+    private string? LoadTextDirect(string url)
     {
         if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
             return null;
@@ -57,6 +65,38 @@ internal sealed class ResourceLoader
 
         return null;
     }
+
+    /// <summary>
+    /// Issues concurrent requests for text sub-resources this document is going to load — external
+    /// stylesheets, above all — so <see cref="LoadText"/> blocks on a request already in flight.
+    /// Multithreading roadmap item #2.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The prefetcher lives on the loader, and the loader is per document, so a document's fetched
+    /// bytes cannot be served to the next one. Prefetching is idempotent and additive: a URL that
+    /// is never consumed costs one request that would have been made had the resource been
+    /// reached, and a URL that is consumed without having been prefetched takes the direct path.
+    /// </para>
+    /// <para>
+    /// A single URL is not worth prefetching — there is nothing to overlap it with — so the caller
+    /// is expected to hand over the whole set it knows about at once.
+    /// </para>
+    /// </remarks>
+    public void Prefetch(IReadOnlyCollection<string> urls)
+    {
+        if (urls.Count < 2)
+            return;
+
+        _prefetcher ??= new SubResourcePrefetcher(LoadTextDirect);
+        _prefetcher.Prefetch(urls.Where(url => Uri.TryCreate(url, UriKind.Absolute, out _)));
+    }
+
+    /// <summary>
+    /// Requests in flight for this document, created on the first <see cref="Prefetch"/>. Null
+    /// until then, so a document that never prefetches carries no extra machinery at all.
+    /// </summary>
+    private SubResourcePrefetcher? _prefetcher;
 
     /// <summary>
     /// Reads a local file <paramref name="path"/> as a sub-resource, applying the file read + MIME policy

--- a/src/Broiler.Wpt.Tests/WptWorkerPoolTests.cs
+++ b/src/Broiler.Wpt.Tests/WptWorkerPoolTests.cs
@@ -1,0 +1,261 @@
+using System.Diagnostics;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Covers the parallel WPT worker pool: how the pool is sized, and the property the
+/// exit gate rests on — that a run's results, and therefore its pass/fail/skip
+/// classification, are identical at 1 and <em>N</em> workers.
+/// </summary>
+public sealed class WptWorkerPoolTests
+{
+    private const long OneGibibyte = 1024L * 1024 * 1024;
+
+    private static Program.TestQueueOptions QueueOptions(string wptPath, int workerCount) => new(
+        WptPath: wptPath,
+        ReferenceDir: Path.Combine(wptPath, "references"),
+        FailureImagesDir: null,
+        VerifyReference: false,
+        MemoryLimitBytes: 0,
+        PassThresholdPercent: 99,
+        ReferenceTestsOnly: false,
+        Timeout: TimeSpan.FromSeconds(30),
+        WorkerCount: workerCount,
+        // In-process: the queue is exercised through the RunTestExecutor override rather
+        // than by starting real worker processes, which keeps these tests to milliseconds.
+        UseWorkerIsolation: false);
+
+    private static IReadOnlyList<WptTestResult> RunQueue(
+        IReadOnlyList<string> tests,
+        int workerCount,
+        Func<string, WptTestResult> executor)
+    {
+        Program.RunTestExecutor = (_, testPath, _, _) => executor(testPath);
+        try
+        {
+            return Program.RunDiscoveredTests(
+                tests,
+                QueueOptions(Path.GetTempPath(), workerCount),
+                new WptTestRunner(),
+                new Program.WptRunProgress(tests.Count),
+                Stopwatch.StartNew());
+        }
+        finally
+        {
+            Program.RunTestExecutor = null!;
+        }
+    }
+
+    private static List<string> TestPaths(int count) =>
+        Enumerable.Range(0, count).Select(i => Path.Combine(Path.GetTempPath(), $"test-{i:D3}.html")).ToList();
+
+    [Fact]
+    public void Results_Are_In_Discovery_Order_Even_When_Tests_Finish_Out_Of_Order()
+    {
+        // The pool's whole safety argument: a slot writes its result into the index it
+        // claimed, so completion order — which is what parallelism actually changes —
+        // never reaches the reporting code.
+        var tests = TestPaths(24);
+        var results = RunQueue(tests, workerCount: 6, testPath =>
+        {
+            // Earlier tests take longest, so completion order is close to reversed.
+            int ordinal = int.Parse(Path.GetFileNameWithoutExtension(testPath)["test-".Length..]);
+            Thread.Sleep((24 - ordinal) * 2);
+            return new WptTestResult { TestPath = testPath, Passed = true };
+        });
+
+        Assert.Equal(tests, results.Select(r => r.TestPath).ToList());
+    }
+
+    [Fact]
+    public void Classification_Is_Identical_At_One_And_Many_Workers()
+    {
+        var tests = TestPaths(30);
+
+        WptTestResult Decide(string testPath)
+        {
+            int ordinal = int.Parse(Path.GetFileNameWithoutExtension(testPath)["test-".Length..]);
+            return (ordinal % 3) switch
+            {
+                0 => new WptTestResult { TestPath = testPath, Passed = true, MatchPercent = 100 },
+                1 => new WptTestResult { TestPath = testPath, Passed = false, MatchPercent = 42 },
+                _ => new WptTestResult { TestPath = testPath, Skipped = true, SkipReason = SkipReason.MissingReferenceImage },
+            };
+        }
+
+        var sequential = RunQueue(tests, workerCount: 1, Decide);
+        var parallel = RunQueue(tests, workerCount: 8, Decide);
+
+        Assert.Equal(
+            sequential.Select(r => (r.TestPath, r.Passed, r.Skipped, r.MatchPercent)).ToList(),
+            parallel.Select(r => (r.TestPath, r.Passed, r.Skipped, r.MatchPercent)).ToList());
+    }
+
+    [Fact]
+    public void Every_Test_Runs_Exactly_Once_Across_The_Pool()
+    {
+        var tests = TestPaths(50);
+        var seen = new System.Collections.Concurrent.ConcurrentBag<string>();
+
+        var results = RunQueue(tests, workerCount: 8, testPath =>
+        {
+            seen.Add(testPath);
+            return new WptTestResult { TestPath = testPath, Passed = true };
+        });
+
+        Assert.Equal(tests.Count, results.Count);
+        Assert.Equal(tests.OrderBy(p => p, StringComparer.Ordinal), seen.OrderBy(p => p, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void An_Empty_Test_Set_Runs_No_Slots()
+    {
+        var results = RunQueue([], workerCount: 8, _ => throw new InvalidOperationException("should not run"));
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Pool_Is_Sized_By_Memory_When_Memory_Is_Scarcer_Than_Cores()
+    {
+        // 16 cores but 4 GiB free: 1.5 GiB per worker allows 2, and RAM is the binding
+        // constraint because each worker may hold a full 1 GiB per-test allowance.
+        Assert.Equal(
+            2,
+            Program.ResolveWorkerCount(
+                requested: null,
+                useWorkerIsolation: true,
+                processorCount: 16,
+                availableMemoryBytes: 4 * OneGibibyte));
+    }
+
+    [Fact]
+    public void Pool_Is_Sized_By_Cores_When_Memory_Is_Plentiful()
+    {
+        Assert.Equal(
+            4,
+            Program.ResolveWorkerCount(
+                requested: null,
+                useWorkerIsolation: true,
+                processorCount: 4,
+                availableMemoryBytes: 64 * OneGibibyte));
+    }
+
+    [Fact]
+    public void Pool_Never_Drops_Below_One_Worker()
+    {
+        Assert.Equal(
+            1,
+            Program.ResolveWorkerCount(
+                requested: null,
+                useWorkerIsolation: true,
+                processorCount: 8,
+                availableMemoryBytes: 256L * 1024 * 1024));
+    }
+
+    [Fact]
+    public void Unknown_Available_Memory_Does_Not_Parallelize()
+    {
+        // Guessing high on an unreadable memory figure is how a runner OOM-kills a CI box,
+        // so an unknown budget means one worker, exactly as before this option existed.
+        Assert.Equal(
+            1,
+            Program.ResolveWorkerCount(
+                requested: null,
+                useWorkerIsolation: true,
+                processorCount: 32,
+                availableMemoryBytes: 0));
+    }
+
+    [Fact]
+    public void An_Explicit_Worker_Count_Overrides_The_Automatic_Sizing()
+    {
+        Assert.Equal(
+            12,
+            Program.ResolveWorkerCount(
+                requested: 12,
+                useWorkerIsolation: true,
+                processorCount: 4,
+                availableMemoryBytes: 2 * OneGibibyte));
+    }
+
+    [Fact]
+    public void In_Process_Mode_Is_Always_One_Worker()
+    {
+        // The engine is single-threaded by design; two documents in one process would race
+        // the shared render state the static-state audit enumerates.
+        Assert.Equal(
+            1,
+            Program.ResolveWorkerCount(
+                requested: 8,
+                useWorkerIsolation: false,
+                processorCount: 16,
+                availableMemoryBytes: 64 * OneGibibyte));
+    }
+
+    [Theory]
+    [InlineData("1", 1)]
+    [InlineData("16", 16)]
+    public void Worker_Count_Parses_Positive_Integers(string value, int expected)
+    {
+        Assert.True(Program.TryParseWorkerCount(value, out var parsed));
+        Assert.Equal(expected, parsed);
+    }
+
+    [Fact]
+    public void Worker_Count_Accepts_Auto_As_No_Explicit_Request()
+    {
+        Assert.True(Program.TryParseWorkerCount("auto", out var parsed));
+        Assert.Null(parsed);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-2")]
+    [InlineData("many")]
+    [InlineData("")]
+    public void Worker_Count_Rejects_Values_That_Cannot_Size_A_Pool(string value)
+    {
+        Assert.False(Program.TryParseWorkerCount(value, out _));
+    }
+
+    [Fact]
+    public void Available_Memory_Is_Reported_As_A_Usable_Figure()
+    {
+        // Either source may be missing on a given platform, but both returning nothing
+        // would silently pin every run to one worker — so assert the runner can read one.
+        Assert.True(Program.GetAvailableMemoryBytes() > 0);
+    }
+
+    [Fact]
+    public void Termination_Diagnostics_Name_Every_In_Flight_Test()
+    {
+        var progress = new Program.WptRunProgress(totalTests: 100);
+        progress.StartTest(slot: 0, testPath: "/wpt/css/a.html", displayPath: "css/a.html", ordinal: 41);
+        progress.StartTest(slot: 2, testPath: "/wpt/css/c.html", displayPath: "css/c.html", ordinal: 43);
+        progress.SetWorkerProcessId(slot: 0, workerProcessId: 111);
+        progress.SetWorkerProcessId(slot: 2, workerProcessId: 333);
+
+        var diagnostics = Program.CreateTerminationDiagnostics("SIGTERM", progress.Snapshot());
+
+        Assert.Contains("Current test: (41/100) css/a.html", diagnostics);
+        Assert.Contains("In-flight tests: 2", diagnostics);
+        Assert.Contains("(41/100) css/a.html [pid 111", diagnostics);
+        Assert.Contains("(43/100) css/c.html [pid 333", diagnostics);
+    }
+
+    [Fact]
+    public void A_Completed_Slot_Leaves_The_In_Flight_List()
+    {
+        var progress = new Program.WptRunProgress(totalTests: 10);
+        progress.StartTest(slot: 0, testPath: "/wpt/css/a.html", displayPath: "css/a.html", ordinal: 1);
+        progress.StartTest(slot: 1, testPath: "/wpt/css/b.html", displayPath: "css/b.html", ordinal: 2);
+        progress.CompleteTest(slot: 0, completed: 1, passed: 1, failed: 0, skipped: 0);
+
+        var snapshot = progress.Snapshot();
+
+        Assert.Equal(1, snapshot.Completed);
+        Assert.Equal("css/b.html", snapshot.CurrentDisplayPath);
+        Assert.Single(snapshot.InFlight!);
+    }
+}

--- a/src/Broiler.Wpt/Program.cs
+++ b/src/Broiler.Wpt/Program.cs
@@ -49,6 +49,17 @@ public class Program
     private const double DefaultPassThresholdPercent = WptTestRunner.DefaultPassThresholdPercent;
     private const string PassThresholdEnvironmentVariable = "BROILER_WPT_PASS_THRESHOLD";
 
+    /// <summary>
+    /// Memory budgeted per parallel worker process when the pool size is chosen
+    /// automatically. A worker is allowed <see cref="DefaultRunTestMemoryLimitMegabytes"/>
+    /// of resident-set growth per test and is recycled once it reaches that cap, so
+    /// <em>N</em> workers can legitimately need <em>N</em> GiB plus baseline. The extra
+    /// half-gigabyte per worker is that baseline (runtime, fonts, the WPT manifest).
+    /// The pool is therefore sized by memory as well as by cores — a 16-core machine
+    /// with 4 GiB free runs 2 workers, not 16.
+    /// </summary>
+    internal const long WorkerMemoryBudgetBytes = 1536L * 1024 * 1024;
+
     private const int ProgressCheckpointInterval = 25;
     private const int TopBucketLimit = 5;
     private const int MissingContentDominantBucketMinimumFailures = 5;
@@ -100,6 +111,7 @@ public class Program
         bool verifyReference = false;
         bool workerMode = false;
         bool noWorkerIsolation = false;
+        int? requestedWorkerCount = null;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -110,6 +122,14 @@ public class Program
                     break;
                 case "--no-worker-isolation":
                     noWorkerIsolation = true;
+                    break;
+                case "--workers" when i + 1 < args.Length:
+                    if (!TryParseWorkerCount(args[++i], out requestedWorkerCount))
+                    {
+                        Console.Error.WriteLine("Error: '--workers' must be a positive integer or 'auto'.");
+                        return 1;
+                    }
+
                     break;
                 case "--wpt-dir" when i + 1 < args.Length:
                     wptPath = args[++i];
@@ -216,6 +236,7 @@ public class Program
                 case "--pass-threshold":
                 case "--shard-count":
                 case "--shard-index":
+                case "--workers":
                     Console.Error.WriteLine($"Error: '{args[i]}' requires a value.");
                     PrintUsage();
                     return 1;
@@ -305,6 +326,13 @@ public class Program
             useWorkerIsolation
                 ? "Isolation     : worker process (timed-out tests are killed)"
                 : "Isolation     : in-process");
+
+        var workerPoolSize = ResolveWorkerCount(
+            requestedWorkerCount,
+            useWorkerIsolation,
+            Environment.ProcessorCount,
+            GetAvailableMemoryBytes());
+        Console.WriteLine($"Workers       : {DescribeWorkerPool(workerPoolSize, requestedWorkerCount, useWorkerIsolation)}");
         Console.WriteLine(
             runTestMemoryLimitBytes > 0
                 ? $"Memory limit  : {WptMemoryGuard.FormatMebibytes(runTestMemoryLimitBytes)} of growth per test" +
@@ -394,9 +422,6 @@ public class Program
         if (totalTests > 0)
             Console.WriteLine("--- Progress ---");
 
-        // Collect all results first so they can still be sorted by percent
-        // match before writing the final summary/log output.
-        var allResults = new List<WptTestResult>(totalTests);
         var progressStopwatch = Stopwatch.StartNew();
         var runProgress = new WptRunProgress(totalTests);
         var terminationDiagnostics = new TerminationDiagnosticWriter(runProgress);
@@ -408,58 +433,28 @@ public class Program
             PosixSignal.SIGINT,
             "SIGINT",
             terminationDiagnostics.Write);
-        using var workerClient = useWorkerIsolation
-            ? new WptWorkerClient(
-                wptPath,
-                referenceDir,
-                failureImagesDir,
-                verifyReference,
-                runTestMemoryLimitBytes,
-                runPassThresholdPercent,
-                referenceTestsOnly)
-            : null;
-        int completed = 0, runningPassed = 0, runningFailed = 0, runningSkipped = 0;
 
-        foreach (var testPath in discoveredTests)
-        {
-            var displayPath = Path.GetRelativePath(wptPath, testPath).Replace('\\', '/');
-            runProgress.StartTest(testPath, displayPath, completed + 1);
-            Console.WriteLine($"[RUN ] ({completed + 1}/{totalTests}) {displayPath}");
-
-            var result = workerClient is not null
-                ? RunTestWithWorkerTimeout(
-                    workerClient,
-                    testPath,
-                    runTestTimeout,
-                    runProgress.SetWorkerProcessId)
-                : RunTestWithTimeout(
-                    runner,
-                    testPath,
-                    referenceDir,
-                    wptPath,
-                    runTestTimeout,
-                    runProgress.SetWorkerThreadId,
-                    runTestMemoryLimitBytes);
-            allResults.Add(result);
-            completed++;
-
-            if (result.Passed)
-                runningPassed++;
-            else if (result.Skipped)
-                runningSkipped++;
-            else
-                runningFailed++;
-
-            runProgress.CompleteTest(completed, runningPassed, runningFailed, runningSkipped);
-
-            if (completed == totalTests || completed % ProgressCheckpointInterval == 0)
-            {
-                Console.WriteLine(
-                    $"[INFO] Completed {completed}/{totalTests} tests " +
-                    $"({runningPassed} passed, {runningFailed} failed, {runningSkipped} skipped) " +
-                    $"after {progressStopwatch.Elapsed:hh\\:mm\\:ss}");
-            }
-        }
+        // Collect all results first so they can still be sorted by percent
+        // match before writing the final summary/log output. Results are stored
+        // by discovery index rather than by completion order, so the list a
+        // parallel run hands to the reporting below is the same list — in the
+        // same order — a sequential run would have produced.
+        var allResults = RunDiscoveredTests(
+            discoveredTests,
+            new TestQueueOptions(
+                WptPath: wptPath,
+                ReferenceDir: referenceDir,
+                FailureImagesDir: failureImagesDir,
+                VerifyReference: verifyReference,
+                MemoryLimitBytes: runTestMemoryLimitBytes,
+                PassThresholdPercent: runPassThresholdPercent,
+                ReferenceTestsOnly: referenceTestsOnly,
+                Timeout: runTestTimeout,
+                WorkerCount: workerPoolSize,
+                UseWorkerIsolation: useWorkerIsolation),
+            runner,
+            runProgress,
+            progressStopwatch);
 
         var skippedResults = allResults.Where(r => r.Skipped).ToList();
 
@@ -671,6 +666,263 @@ public class Program
         }
 
         return 0;
+    }
+
+    /// <summary>
+    /// Everything a queue slot needs to decide a test, gathered so the pool below can be
+    /// read without threading a dozen parameters through it.
+    /// </summary>
+    internal sealed record TestQueueOptions(
+        string WptPath,
+        string ReferenceDir,
+        string? FailureImagesDir,
+        bool VerifyReference,
+        long MemoryLimitBytes,
+        double PassThresholdPercent,
+        bool ReferenceTestsOnly,
+        TimeSpan Timeout,
+        int WorkerCount,
+        bool UseWorkerIsolation);
+
+    /// <summary>
+    /// Drains <paramref name="discoveredTests"/> through a pool of
+    /// <see cref="TestQueueOptions.WorkerCount"/> worker processes, each slot claiming the
+    /// next unstarted index and owning its own <see cref="WptWorkerClient"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two properties make this safe to parallelize at all, and both are properties of the
+    /// existing design rather than anything added here: a worker process is a whole second
+    /// copy of the engine, so no engine state is shared between slots; and results were
+    /// already buffered and re-sorted before reporting, so completion order was never
+    /// load-bearing.
+    /// </para>
+    /// <para>
+    /// Results are written into a slot of the returned list keyed by discovery index, so the
+    /// order the reporting code sees is discovery order at any pool size — a one-worker run
+    /// is byte-identical to the sequential runner this replaced, and an <em>N</em>-worker run
+    /// produces the same pass/fail/skip classification in the same sequence.
+    /// </para>
+    /// <para>
+    /// The <c>[RUN ]</c> ordinal is the test's discovery index, not a completion counter:
+    /// with several tests in flight a counter would name a different test in each line's
+    /// numbering. The <c>[INFO]</c> checkpoint still counts completions.
+    /// </para>
+    /// </remarks>
+    internal static IReadOnlyList<WptTestResult> RunDiscoveredTests(
+        IReadOnlyList<string> discoveredTests,
+        TestQueueOptions options,
+        WptTestRunner runner,
+        WptRunProgress runProgress,
+        Stopwatch progressStopwatch)
+    {
+        int totalTests = discoveredTests.Count;
+        var results = new WptTestResult[totalTests];
+        if (totalTests == 0)
+            return results;
+
+        int nextIndex = -1;
+        int completed = 0, runningPassed = 0, runningFailed = 0, runningSkipped = 0;
+        var counterSync = new object();
+
+        void RunSlot(int slot)
+        {
+            // Each slot owns its worker process for the whole run: it is recycled on
+            // timeout/memory-limit exactly as before, but never shared, so one slot killing
+            // its worker cannot abort a test another slot is midway through.
+            using var workerClient = options.UseWorkerIsolation
+                ? new WptWorkerClient(
+                    options.WptPath,
+                    options.ReferenceDir,
+                    options.FailureImagesDir,
+                    options.VerifyReference,
+                    options.MemoryLimitBytes,
+                    options.PassThresholdPercent,
+                    options.ReferenceTestsOnly)
+                : null;
+
+            while (true)
+            {
+                int index = Interlocked.Increment(ref nextIndex);
+                if (index >= totalTests)
+                    return;
+
+                var testPath = discoveredTests[index];
+                var displayPath = Path.GetRelativePath(options.WptPath, testPath).Replace('\\', '/');
+                runProgress.StartTest(slot, testPath, displayPath, index + 1);
+                Console.WriteLine($"[RUN ] ({index + 1}/{totalTests}) {displayPath}");
+
+                var result = workerClient is not null
+                    ? RunTestWithWorkerTimeout(
+                        workerClient,
+                        testPath,
+                        options.Timeout,
+                        processId => runProgress.SetWorkerProcessId(slot, processId))
+                    : RunTestWithTimeout(
+                        runner,
+                        testPath,
+                        options.ReferenceDir,
+                        options.WptPath,
+                        options.Timeout,
+                        threadId => runProgress.SetWorkerThreadId(slot, threadId),
+                        options.MemoryLimitBytes);
+                results[index] = result;
+
+                lock (counterSync)
+                {
+                    completed++;
+                    if (result.Passed)
+                        runningPassed++;
+                    else if (result.Skipped)
+                        runningSkipped++;
+                    else
+                        runningFailed++;
+
+                    runProgress.CompleteTest(slot, completed, runningPassed, runningFailed, runningSkipped);
+
+                    if (completed == totalTests || completed % ProgressCheckpointInterval == 0)
+                    {
+                        Console.WriteLine(
+                            $"[INFO] Completed {completed}/{totalTests} tests " +
+                            $"({runningPassed} passed, {runningFailed} failed, {runningSkipped} skipped) " +
+                            $"after {progressStopwatch.Elapsed:hh\\:mm\\:ss}");
+                    }
+                }
+            }
+        }
+
+        int slotCount = Math.Clamp(options.WorkerCount, 1, totalTests);
+        if (slotCount == 1)
+        {
+            // Run on the calling thread when there is one slot: the sequential path stays
+            // exactly as reproducible as it was, with no task scheduling in between.
+            RunSlot(0);
+            return results;
+        }
+
+        var slots = new Task[slotCount];
+        for (int slot = 0; slot < slotCount; slot++)
+        {
+            int capturedSlot = slot;
+            slots[slot] = Task.Run(() => RunSlot(capturedSlot));
+        }
+
+        Task.WaitAll(slots);
+        return results;
+    }
+
+    /// <summary>
+    /// Resolves the worker-pool size. An explicit <c>--workers N</c> wins; otherwise the pool
+    /// is <c>min(cores, availableMemory / 1.5 GiB)</c>, because a worker's ceiling is RAM, not
+    /// CPU (see <see cref="WorkerMemoryBudgetBytes"/>). In-process mode is always one slot: the
+    /// engine is single-threaded by design (multithreading roadmap item #15) and running two
+    /// documents in one process would race the shared render state the P0-c audit enumerates.
+    /// </summary>
+    internal static int ResolveWorkerCount(
+        int? requested,
+        bool useWorkerIsolation,
+        int processorCount,
+        long availableMemoryBytes)
+    {
+        if (!useWorkerIsolation)
+            return 1;
+
+        if (requested is { } explicitCount)
+            return Math.Max(1, explicitCount);
+
+        int byCores = Math.Max(1, processorCount);
+        if (availableMemoryBytes <= 0)
+            return 1;
+
+        long byMemory = availableMemoryBytes / WorkerMemoryBudgetBytes;
+        return (int)Math.Clamp(byMemory, 1, byCores);
+    }
+
+    private static string DescribeWorkerPool(int workerCount, int? requested, bool useWorkerIsolation)
+    {
+        if (!useWorkerIsolation)
+            return "1 (in-process mode renders one document at a time)";
+
+        var sizing = requested.HasValue
+            ? "explicit (--workers)"
+            : $"auto: min({Environment.ProcessorCount} core(s), " +
+              $"{WptMemoryGuard.FormatMebibytes(GetAvailableMemoryBytes())} available / " +
+              $"{WptMemoryGuard.FormatMebibytes(WorkerMemoryBudgetBytes)} per worker)";
+
+        return $"{workerCount} worker process(es) — {sizing}";
+    }
+
+    /// <summary>
+    /// Memory the pool may plan around. Both sources are consulted and the smaller wins:
+    /// <c>/proc/meminfo</c>'s <c>MemAvailable</c> knows what other processes on the machine are
+    /// already using but reports the host's memory inside a container, while the GC's figure
+    /// honours the cgroup limit but not the machine's current load. Returns 0 when neither is
+    /// readable, which <see cref="ResolveWorkerCount"/> treats as "do not parallelize".
+    /// </summary>
+    internal static long GetAvailableMemoryBytes()
+    {
+        long available = 0;
+
+        try
+        {
+            long totalAvailable = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+            if (totalAvailable > 0)
+                available = totalAvailable;
+        }
+        catch (PlatformNotSupportedException)
+        {
+            // Fall through to the /proc reading below.
+        }
+
+        if (TryReadLinuxMemAvailableBytes(out long memAvailable))
+            available = available > 0 ? Math.Min(available, memAvailable) : memAvailable;
+
+        return available;
+    }
+
+    private static bool TryReadLinuxMemAvailableBytes(out long bytes)
+    {
+        bytes = 0;
+        if (!OperatingSystem.IsLinux())
+            return false;
+
+        try
+        {
+            foreach (var line in File.ReadLines("/proc/meminfo"))
+            {
+                if (!line.StartsWith("MemAvailable:", StringComparison.Ordinal))
+                    continue;
+
+                var fields = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                if (fields.Length >= 2 &&
+                    long.TryParse(fields[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out long kibibytes))
+                {
+                    bytes = kibibytes * 1024;
+                    return bytes > 0;
+                }
+
+                return false;
+            }
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    internal static bool TryParseWorkerCount(string value, out int? workerCount)
+    {
+        workerCount = null;
+        if (string.Equals(value, "auto", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed) || parsed < 1)
+            return false;
+
+        workerCount = parsed;
+        return true;
     }
 
     private static WptTestResult RunTestWithWorkerTimeout(
@@ -1412,57 +1664,55 @@ public class Program
         };
     }
 
-    private sealed class WptRunProgress
+    /// <summary>
+    /// Run-wide progress, tracking one in-flight test per pool slot. A SIGTERM during a
+    /// parallel run has to name <em>every</em> test that was running, not just one — with N
+    /// workers the test that hung is as likely to be in another slot as in the one the
+    /// snapshot happens to report first.
+    /// </summary>
+    internal sealed class WptRunProgress
     {
         private readonly object _sync = new();
         private readonly Stopwatch _runStopwatch = Stopwatch.StartNew();
         private readonly int _totalTests;
-        private Stopwatch? _currentTestStopwatch;
+        private readonly Dictionary<int, SlotState> _inFlight = [];
         private int _completed;
         private int _passed;
         private int _failed;
         private int _skipped;
-        private int? _currentOrdinal;
-        private int _workerThreadId = -1;
-        private int? _workerProcessId;
-        private string? _currentDisplayPath;
-        private string? _currentTestPath;
 
         internal WptRunProgress(int totalTests)
         {
             _totalTests = totalTests;
         }
 
-        internal void StartTest(string testPath, string displayPath, int ordinal)
+        internal void StartTest(int slot, string testPath, string displayPath, int ordinal)
         {
             lock (_sync)
             {
-                _currentTestPath = testPath;
-                _currentDisplayPath = displayPath;
-                _currentOrdinal = ordinal;
-                _workerThreadId = -1;
-                _workerProcessId = null;
-                _currentTestStopwatch = Stopwatch.StartNew();
+                _inFlight[slot] = new SlotState(testPath, displayPath, ordinal);
             }
         }
 
-        internal void SetWorkerThreadId(int workerThreadId)
+        internal void SetWorkerThreadId(int slot, int workerThreadId)
         {
             lock (_sync)
             {
-                _workerThreadId = workerThreadId;
+                if (_inFlight.TryGetValue(slot, out var state))
+                    state.WorkerThreadId = workerThreadId;
             }
         }
 
-        internal void SetWorkerProcessId(int workerProcessId)
+        internal void SetWorkerProcessId(int slot, int workerProcessId)
         {
             lock (_sync)
             {
-                _workerProcessId = workerProcessId;
+                if (_inFlight.TryGetValue(slot, out var state))
+                    state.WorkerProcessId = workerProcessId;
             }
         }
 
-        internal void CompleteTest(int completed, int passed, int failed, int skipped)
+        internal void CompleteTest(int slot, int completed, int passed, int failed, int skipped)
         {
             lock (_sync)
             {
@@ -1470,12 +1720,7 @@ public class Program
                 _passed = passed;
                 _failed = failed;
                 _skipped = skipped;
-                _currentTestPath = null;
-                _currentDisplayPath = null;
-                _currentOrdinal = null;
-                _workerThreadId = -1;
-                _workerProcessId = null;
-                _currentTestStopwatch = null;
+                _inFlight.Remove(slot);
             }
         }
 
@@ -1483,20 +1728,46 @@ public class Program
         {
             lock (_sync)
             {
+                // Ordered by slot so a snapshot of the same set of in-flight tests always
+                // reads the same way; the first is reported as "current" so the
+                // single-worker diagnostic is unchanged.
+                var inFlight = _inFlight
+                    .OrderBy(entry => entry.Key)
+                    .Select(entry => entry.Value.ToRecord())
+                    .ToList();
+                var current = inFlight.Count > 0 ? inFlight[0] : (WptInFlightTest?)null;
+
                 return new WptRunProgressSnapshot(
                     _completed,
                     _totalTests,
                     _passed,
                     _failed,
                     _skipped,
-                    _currentOrdinal,
-                    _currentDisplayPath,
-                    _currentTestPath,
+                    current?.Ordinal,
+                    current?.DisplayPath,
+                    current?.TestPath,
                     _runStopwatch.Elapsed,
-                    _currentTestStopwatch?.Elapsed,
-                    _workerThreadId,
-                    _workerProcessId);
+                    current?.Elapsed,
+                    current?.WorkerThreadId ?? -1,
+                    current?.WorkerProcessId,
+                    inFlight);
             }
+        }
+
+        private sealed class SlotState(string testPath, string displayPath, int ordinal)
+        {
+            private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+
+            internal int WorkerThreadId { get; set; } = -1;
+            internal int? WorkerProcessId { get; set; }
+
+            internal WptInFlightTest ToRecord() => new(
+                ordinal,
+                displayPath,
+                testPath,
+                _stopwatch.Elapsed,
+                WorkerThreadId,
+                WorkerProcessId);
         }
     }
 
@@ -1520,6 +1791,21 @@ public class Program
         }
     }
 
+    /// <summary>One test a pool slot had in flight when the snapshot was taken.</summary>
+    internal readonly record struct WptInFlightTest(
+        int Ordinal,
+        string DisplayPath,
+        string TestPath,
+        TimeSpan Elapsed,
+        int WorkerThreadId,
+        int? WorkerProcessId);
+
+    /// <summary>
+    /// The <c>Current*</c> members describe the first in-flight test — the whole story for a
+    /// one-worker run. <see cref="InFlight"/> carries all of them, which is what a parallel run
+    /// needs; it defaults to null so a snapshot can still be constructed from the
+    /// single-test fields alone.
+    /// </summary>
     internal readonly record struct WptRunProgressSnapshot(
         int Completed,
         int TotalTests,
@@ -1532,7 +1818,8 @@ public class Program
         TimeSpan RunElapsed,
         TimeSpan? CurrentTestElapsed,
         int WorkerThreadId,
-        int? WorkerProcessId);
+        int? WorkerProcessId,
+        IReadOnlyList<WptInFlightTest>? InFlight = null);
 
     internal static string CreateTerminationDiagnostics(
         string reason,
@@ -1570,6 +1857,23 @@ public class Program
         else
         {
             diagnostics.AppendLine("Current test: none");
+        }
+
+        // With a worker pool the "current" test above is one of several, and the one that
+        // hung is as likely to be any of the others — so list every slot that was busy.
+        if (snapshot.InFlight is { Count: > 1 } inFlight)
+        {
+            diagnostics.AppendLine();
+            diagnostics.AppendLine($"In-flight tests: {inFlight.Count}");
+            foreach (var test in inFlight)
+            {
+                var processTag = test.WorkerProcessId.HasValue
+                    ? $"pid {test.WorkerProcessId.Value}"
+                    : "pid unknown";
+                diagnostics.AppendLine(
+                    $"  ({test.Ordinal}/{snapshot.TotalTests}) {test.DisplayPath} " +
+                    $"[{processTag}, elapsed {FormatDuration(test.Elapsed)}]");
+            }
         }
 
         return diagnostics
@@ -1636,7 +1940,7 @@ public class Program
     /// analytics and automated triage.
     /// </summary>
     private static void WriteJsonReport(
-        List<WptTestResult> allResults,
+        IReadOnlyList<WptTestResult> allResults,
         string path,
         int passed,
         int failed,
@@ -1797,7 +2101,7 @@ public class Program
     }
 
     private static void WriteMarkdownSummary(
-        List<WptTestResult> allResults,
+        IReadOnlyList<WptTestResult> allResults,
         string path,
         int passed,
         int failed,
@@ -2648,7 +2952,12 @@ public class Program
         Console.WriteLine("                             identical to the Chromium reference");
         Console.WriteLine($"                             (default: {FormatPassThreshold(DefaultPassThresholdPercent)}, env: {PassThresholdEnvironmentVariable})");
         Console.WriteLine("  --no-worker-isolation      Run tests in-process instead of the default worker process");
-        Console.WriteLine("                             isolation. Useful for debugger sessions only.");
+        Console.WriteLine("                             isolation. Useful for debugger sessions only. Implies");
+        Console.WriteLine("                             --workers 1.");
+        Console.WriteLine("  --workers <N>|auto         Number of worker processes draining the test queue");
+        Console.WriteLine("                             (default: auto = min(cores, available RAM / 1.5 GiB), since a");
+        Console.WriteLine("                             worker's ceiling is memory rather than CPU). --workers 1");
+        Console.WriteLine("                             reproduces the sequential run exactly.");
         Console.WriteLine("  --json-output <PATH>       Write structured JSON report to the given path");
         Console.WriteLine("  --markdown-output <PATH>   Write triage-focused Markdown summary to the given path");
         Console.WriteLine("  --failure-images <DIR>     Save rendered/reference/diff PNGs for each failure under DIR");


### PR DESCRIPTION
Implements four items from the multithreading roadmap, completing Phase 1:

## Summary

This PR lands the first phase of multithreading work: CSS rule indexing (item #11), WPT worker pool parallelism (item #1), CLI batch processing (item #20), and concurrent sub-resource prefetching (item #2). The changes maintain correctness through differential testing and deterministic partitioning while delivering significant performance gains.

## Key Changes

**CSS Rule Indexing (item #11)** — `patches/0123-css-cascade-rule-index.patch`
- Replaces linear cascade scan with indexed lookup by selector key (id, class, type, or universal bucket)
- Rules are indexed once per sheet generation and memoized; @media/@supports resolved at build time, @container evaluated per-candidate
- Exit gate met: cascade cost is now flat in total rules (32× rules: 30.8× → **1.64×** time, 32.0× → **1.13×** bytes)
- Corpus `rules` page: 5,219 ms → 1,842 ms end-to-end; parse+cascade: 5,035 ms → 1,698 ms
- WPT css/css-backgrounds + css/CSS2/linebox: unchanged (62 tests, 98.62% average pixel match)
- Correctness verified by `CssCascadeRuleIndexTests`: indexed and exhaustive cascades agree property-by-property over hand-written selectors and 1200-rule generated sheets

**WPT Worker Pool (item #1)** — `src/Broiler.Wpt/Program.cs`
- Adds `--workers <N>|auto` flag to parallelize test execution across worker processes
- Pool size resolved by available memory and core count; each worker budgeted 1.5 GiB
- Results collected in discovery order despite out-of-order completion via index-keyed array
- Exit gate met: identical classification at 1, 4, and auto workers; 45.2 s → 23.4 s on 61-test subset at 4 cores

**CLI Batch Parallelism (item #20)** — `src/Broiler.Cli/BatchRunner.cs`
- Splits batch inputs across threads (in-process for document conversion) or child processes (for rendering)
- Output paths derived deterministically; collisions resolved by appending `-2`, `-3`, etc. in input order
- Transcript replayed in input order from index-keyed array, so batch output is byte-identical at any thread count
- Exit gate met: fuzz 14.8 s → 8.9 s with identical 224 failure files

**Concurrent Sub-Resource Prefetch (item #2)** — `src/Broiler.HtmlBridge.Core/Scripting/SubResourcePrefetcher.cs`
- Splits fetch into prefetch (issue all URLs at once, bounded per-host) and consume (block at original call site)
- Wired to external scripts and `<link>` stylesheets; iframes/fetch/XHR not yet wired
- Per-document lifetime prevents cross-document cache pollution
- Exit gate met: prefetching changes nothing about extraction results or order

**Layout Fuzz Sharding** — `src/Broiler.Cli/LayoutFuzzService.cs`, `src/Broiler.Cli/LayoutFuzzShards.cs`
- Partitions seed range into contiguous shards run by child processes (not threads, due to unsynchronised font caches)
- Partition covers sequential seed set exactly once, so sharded run examines same documents and produces same failures
- Shard totals protocol allows parent to sum results

## Implementation Details

- **Correctness through differential testing:** CSS cascade index is verified against the linear scan it replaces via `CssCascadeRuleIndexTests`, which asserts agreement over hundreds of selector/element pairs
- **Deterministic parallelism:** Worker pools, batch runners, and fuzz shards all use index-keyed result arrays to ensure output is independent of completion order
- **Memory-aware pool sizing:** WPT

https://claude.ai/code/session_019qdy431jVeVWp5as6fYXNQ