### PR TITLE
Implement speculative preload scan (roadmap item #17)

### DIFF
--- a/docs/architecture/multithreading.md
+++ b/docs/architecture/multithreading.md
@@ -6,15 +6,19 @@ the tooling.
 
 ## Status
 
-**Phase 2 is under way.** Six of its nine items have landed (#9, #4, #5, #6, #7,
-#10); three have not (#3, #8, #17). What building them
+**Phase 2 is under way.** Seven of its nine items have landed (#9, #4, #5, #6, #7,
+#10, #17); two have not (#3, #8). What building them
 changed is in [What building Phase 2 changed](#what-building-phase-2-changed) —
-including the three findings that matter most for what is left: **band parallelism
+including the findings that matter most for what is left: **band parallelism
 inside a primitive is the wrong unit for a page** (§4), **the largest single win
 the phase has produced was a cache, not a thread** (§5), and — from item #5 —
 **most of what looked like raster parallelism was the rasterizer drawing pixels
 nothing could see** (§8). The raster stage is no longer the largest share of a
 render on any corpus page ([§9](#9-raster-is-no-longer-the-stage-to-aim-at-and-the-published-profile-says-so)).
+Item #17 added a tenth: **the split item #2 built was never reached by the host
+that does its own script extraction**, so a whole family of round trips was still
+serial in the path this repository measures
+([§10](#10-item-17s-win-was-not-the-scan-it-was-a-host-that-never-reached-item-2s-split)).
 
 | Item | State | Evidence |
 |---|---|---|
@@ -23,9 +27,9 @@ render on any corpus page ([§9](#9-raster-is-no-longer-the-stage-to-aim-at-and-
 | #3 — band-parallel raster (`Broiler.Graphics`) | Not started | The partitioner and the exit-gate harness now exist; this is porting them to the second copy, and [§2](#2-the-rasterizer-the-profile-measures-is-item-4s-copy-not-item-3s) still says unify first. [§4](#4-band-parallelism-inside-a-primitive-is-the-wrong-unit-for-a-page) and [§8](#8-most-of-item-5-was-not-parallelism-it-was-the-rasterizer-drawing-pixels-nothing-could-see) both say the *clip narrowing* is the part worth porting first |
 | #5 — tile-parallel replay | **Done** | `TileParallelReplay`, `patches/0126-…`; `PerformPaint` at 1 → 4 tiles: `paint` **1 323.7 → 461.4 ms (2.87×)**, `rules` 3.49×, `text` 2.42×, `mixed` 2.44×, `boxes` 1.76× — faster than band parallelism on all five pages, including the three bands could not touch. Pixels identical at 1/2/4 tiles crossed with 1/4 bands on every page (`--tile-scaling`), 69 `RasterTileParallelismTests` cases, and a full WPT run at 1 and 4 tiles whose entire output diffs to **zero lines**. Most of the win was single-threaded — see [§8](#8-most-of-item-5-was-not-parallelism-it-was-the-rasterizer-drawing-pixels-nothing-could-see) |
 | #6/#7 — image decode | **Done** | `ImageDecodeParallelism`; JPEG **2.08–2.61×**, PNG **1.22–1.29×** at 4 threads, byte-identical at every setting (`--decode-scaling`, plus two cases in `Broiler.Media.Image.Managed.Tests`) |
-| #8 — concurrent decode across images | Not started | Unblocked by #9, but the headless render path loads images **synchronously and inline** (`AvoidAsyncImagesLoading`), so this needs #2's prefetch/consume split rather than a `Parallel.For` — see [§6](#6-item-8-is-a-prefetchconsume-split-not-a-parallelfor) |
+| #8 — concurrent decode across images | Not started | Unblocked by #9, but the headless render path loads images **synchronously and inline** (`AvoidAsyncImagesLoading`), so this needs #2's prefetch/consume split rather than a `Parallel.For` — see [§6](#6-item-8-is-a-prefetchconsume-split-not-a-parallelfor). Its remaining prerequisite is met: #17 supplies the image URL set (`PreloadScanResult.ResolvedUrls(PreloadKind.Image)`), so what is left is the consume split at `ImageLoadHandler` |
 | #10 — glyph outline cache | **Done** | `TrueTypeFont` caches outlines by glyph index; raster stage **1.34×** on `text`, **1.54×** on `boxes`, **1.00×** on the text-free `paint` control. The shaped-run cache the item names is *not* built — see [§5](#5-the-phases-largest-win-so-far-is-a-cache-and-not-the-one-item-10-names) |
-| #17 — preload scan | Not started | — |
+| #17 — preload scan | **Done** | `PreloadScanner` / `SpeculativePreloadScan`; a document's sub-resources are found by one tokenizer pass on a worker started before the parse. Stylesheet requests are **in flight while the document is still parsing** and external scripts in the capture host now overlap instead of going one at a time — **755.1 → 521.4 ms** (median paired ratio **0.655** over 5 interleaved pairs) on 8 scripts at 40 ms each, peak concurrency 6 against 1. Exit gate: `css/css-backgrounds` identical at `BROILER_PRELOAD_SCAN` on and off (40/16/5 both ways, every verdict and pixel-match percentage the same). 40 test cases, of which the two load-order ones are assertions on *when* a request reaches the origin rather than on a stopwatch. It also found a URL-resolution defect the CSP matcher was reading through — see [§10](#10-item-17s-win-was-not-the-scan-it-was-a-host-that-never-reached-item-2s-split) and [§11](#11-a-root-relative-url-resolved-to-the-filesystem-root-and-csp-was-matching-against-it) |
 
 **Phase 1 is complete.** All four items landed; what each one turned out to be
 worth is in [What building Phase 1 changed](#what-building-phase-1-changed).
@@ -289,6 +293,13 @@ says #17 "feeds step 1". The dependency is stronger than "compounds": for those 
 families the preload scan is not an amplifier, it is the only source of a prefetch
 trigger.
 
+**This section is right about the families and wrong about the unit.** Building #17
+showed that "wired to two of its four call-site families" is a statement about *one
+host*: `CaptureService` extracts scripts itself and so reached none of the wiring
+described here, and its script fetches were still strictly serial. A split is a
+property of a call site, not of a codebase —
+[Phase 2 §10](#10-item-17s-win-was-not-the-scan-it-was-a-host-that-never-reached-item-2s-split).
+
 ### 4. The WPT pool is bounded by memory, and the default has to know it
 
 Sized `min(cores, availableRam / 1.5 GiB)`, which on the 4-core/13 GiB container is
@@ -310,9 +321,12 @@ per-test allowance is a full GiB.
 
 ## What building Phase 2 changed
 
-Nine findings. The first three came out of item #9, the gate; the rest came out of
-the raster, text and decode work that followed it, and three of them change what
-the rest of the phase — and the phase after it — should be.
+Eleven findings. The first three came out of item #9, the gate; §4–§9 came out of
+the raster, text and decode work that followed it, and three of those change what
+the rest of the phase — and the phase after it — should be. The last two came out
+of item #17, and neither is about a thread: one is about which *host* a
+prefetch/consume split reaches, the other about a URL-resolution defect the whole
+bridge was reading through.
 
 ### 1. Item #9 was four sites, not one, and the audit's method is what hid two of them
 
@@ -536,6 +550,15 @@ This generalises past the WPT runner: **every host that runs more than one rende
 at once now owns a division it did not have to make before** — the CLI's batch
 processes are the other one in this repository.
 
+**Item #17's worker is deliberately not in that division, and the reason is the
+test for whether something belongs there.** `ApplyRenderThreadBudget` divides
+budgets that put *cores* under contention: a raster band, a tile, a decode band
+each occupy a core for the length of a render. The preload scan occupies one pool
+thread for one tokenizer pass and then blocks on I/O, so *N* workers do not produce
+*N × cores* runnable threads — they produce *N* threads that are almost always
+waiting on a socket. It has an on/off switch (`BROILER_PRELOAD_SCAN`) because the
+exit gate requires a sequential equivalent, not because a host has to size it.
+
 ### 8. Most of item #5 was not parallelism; it was the rasterizer drawing pixels nothing could see
 
 Tile-parallel replay was built as a threading item and it delivered threading
@@ -624,6 +647,101 @@ and item #12 (parallel style recalc) must not be started against a stage whose
 composition is unmeasured. That is now the largest unattributed question in the
 document, and it is larger than anything left in Phase 2.
 
+### 10. Item #17's win was not the scan; it was a host that never reached item #2's split
+
+The item is scoped as "a worker scans raw bytes for `src`/`href` while the main
+parse runs, feeding #2", and that is what was built: one `HtmlTokenizer` pass on a
+pool thread, started as the first statement of `DomBridge.ParseHtml`, whose sink
+hands the stylesheet set to the loader before the parse has produced a node. The
+part of it that produced a number was somewhere else.
+
+**The stylesheet half is worth exactly the parse, and no more.** Item #2 already
+issues a document's sheets concurrently *with each other*; all this moves is when
+they start, from after the parse to before it. The gain is therefore bounded by the
+parse time and is invisible on a small document. It is asserted rather than timed —
+an origin that holds every request open shows three sheet requests arrived while
+`Attach` was still running, and shows **zero** requests exist at the same point with
+the scan off. That is the claim; a stopwatch on it would mostly measure the host.
+
+**The script half was a serial fetch nobody had noticed, in the path this
+repository measures.** `CaptureService.ExecuteScriptsWithDom` — the capture and WPT
+entry point — walks the script tags with its own regex and called
+`FetchExternalScript` inline as it reached each one. Item #2's prefetch/consume
+split does exist for scripts, in `ScriptExtractionService.ExtractAll`, and this host
+does not call it: it extracts scripts itself. So the split was built, tested,
+measured, and **not reached by the host that renders the corpus**. Fed by the scan,
+that loop's round trips overlap:
+
+| 8 external scripts, 40 ms each | serial (scan off) | overlapped (scan on) | ratio | saved |
+|---|---:|---:|---:|---:|
+| idle machine | 755.1 ms | 521.4 ms | **0.655×** | 233.7 ms |
+| under the rest of the suite | 941.2 ms | 678.6 ms | 0.702× | 262.6 ms |
+
+Medians of five interleaved pairs each. The arithmetic predicts a saving of 240 ms
+— eight requests at six-per-host is two waves, so 320 ms of latency becomes 80 ms —
+and both runs bracket it, which is the point of quoting two: the *ratio* moves with
+what else the box is doing, the *saving* does not, because it is a count of round
+trips rather than a speed. Peak concurrency at the origin is **6** with the scan and
+exactly **1** without, which is the assertion the table rests on — `1` is the
+definition of serial, and it is checked rather than inferred.
+
+**The exit gate.** `BROILER_PRELOAD_SCAN=0` is the sequential path rather than an
+approximation of it: with no scan there is no prefetcher entry for any speculated
+URL, so every consume site takes the branch it took before the scan existed.
+`css/css-backgrounds` (61 tests) was run at both settings — **40 passed, 16 failed,
+5 skipped** each time, and diffing the full output leaves the header's
+available-memory reading and two elapsed-time lines. Every per-test verdict, every
+pixel-match percentage and every failure bucket is identical, which is what the
+change claims: it moves when a request starts and nothing else.
+
+**The generalisation is about where a split lives.** A prefetch/consume split is a
+property of a *call site*, not of a codebase: a second host that re-implements the
+extraction re-implements the serial fetch along with it, and nothing in the first
+host's tests can see that. Phase 1 §3 recorded item #2 as "wired to two of its four
+call-site families"; the truer statement is that it was wired to two families **in
+one of the hosts that has them**. Before declaring a latency item done, ask which
+entry points reach the code it was built in — and note that this is the same lesson
+as §2's, one layer up: there, the profile was measuring a different copy of the
+rasterizer than the item was aimed at.
+
+### 11. A root-relative URL resolved to the filesystem root, and CSP was matching against it
+
+`UrlResolver.Resolve` is the bridge's one URL-resolution implementation — script
+fetching, `@import`, sub-documents, `fetch()` redirects and the **CSP source
+matcher** all go through it. Its first line asked `Uri.TryCreate(url,
+UriKind.Absolute, …)` and returned the result if it succeeded.
+
+On Unix that succeeds for `/app.js`, because a leading slash is a valid absolute
+*file path* there, and yields `file:///app.js`. So every path-absolute reference in
+a document was taken off the filesystem root instead of the page's own origin:
+`<script src="/app.js">` on an `https:` page resolved to `file:///app.js`, and
+`CspSourceMatching.ResolveUri` handed that to the policy comparison — a
+`script-src 'self'` check on a URL whose origin had been replaced. Scheme-relative
+`//cdn.example/x` had the same fault for the same reason.
+
+It is one line to fix (neither form is an absolute URI under RFC 3986 — both
+require the base), and the fix is invisible on `file:` pages, which is the whole of
+the WPT corpus: resolving `/x` against `file:///a/b.html` gives `file:///x` either
+way. That is why nothing caught it.
+
+**One copy of the same mistake is left, and is deliberately left.**
+`SubDocuments.LoadSubResource` does not call the shared resolver first — it asks
+`Uri.TryCreate(resourceUrl, UriKind.Absolute, …)` itself and keeps the raw string
+when it succeeds, which is the identical fault at an identical line. Fixing it
+changes which document an `<iframe src="/x">` loads, so it belongs in a change that
+can show a WPT run either side of it, not folded into a latency item. It is
+recorded here rather than in a comment because the shared resolver being right is
+now what makes that site's inline copy visibly wrong.
+
+**What is worth carrying forward is how it surfaced.** No behaviour changed to
+expose it. It appeared because item #17's tests asserted a *resolved* URL by
+value — `https://example.test/assets/a.css` — where the existing tests on the same
+resolver asserted that fetching worked. This is the fourth time in this document
+that a stage's own instrumentation found a defect the feature was not looking for,
+and it suggests the narrower rule behind §5 and §8: **an item that asserts its
+inputs by value audits every layer it reads through**, and the layers under a
+latency item are usually older than it is.
+
 ## Master table
 
 Gain is per-stage unless stated. Effort is engineering days for one person
@@ -633,7 +751,7 @@ non-deterministic correctness defect.
 | # | Component | Site | Currently | Parallel shape | What blocks it today | Est. gain (unmeasured) | Risk | Effort | Phase |
 |---|---|---|---|---|---|---|---|---|---|
 | 1 | Tooling | [`Broiler.Wpt/Program.cs`](../../src/Broiler.Wpt/Program.cs) `RunDiscoveredTests` — **DONE** | Pool of *N* worker processes draining a shared queue (`--workers <N>\|auto`) | Work queue over *N* worker processes; results already buffered into `allResults` and sorted after the run, so order is not load-bearing | Nothing. Worker protocol is already one-command-per-line JSON over stdio | **Measured: 1.93× at 4 workers** on a 61-test subset (45.2 s → 23.4 s); identical classification at 1, 4 and auto. Bounded by RAM, not cores | Low | Done | 1 |
-| 2 | HtmlBridge | [`ScriptExtractionService.cs:303`](../../src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs), [`ResourceLoader.cs:56`](../../src/Broiler.HtmlBridge.Dom/Runtime/ResourceLoader.cs), [`SubDocuments.cs:581`](../../src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs) | Serial `GetStringAsync(..).GetAwaiter().GetResult()`, one resource at a time | Bounded-concurrency prefetch (6/host, browser convention) into a content-addressed cache; call sites then hit the cache | Call sites are synchronous and ordering-sensitive for `document.write`; needs a prefetch/consume split, not an `async` conversion | **Done for scripts and `<link>` stylesheets** (`SubResourcePrefetcher`, bounded 6/host). Iframes and `fetch()`/XHR are not wired: they have no point where the URL set is known before it is consumed, which is what item #17 supplies | Medium | Done (scripts, sheets) | 1 |
+| 2 | HtmlBridge | [`ScriptExtractionService.cs:303`](../../src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs), [`ResourceLoader.cs:56`](../../src/Broiler.HtmlBridge.Dom/Runtime/ResourceLoader.cs), [`SubDocuments.cs:581`](../../src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs) | Serial `GetStringAsync(..).GetAwaiter().GetResult()`, one resource at a time | Bounded-concurrency prefetch (6/host, browser convention) into a content-addressed cache; call sites then hit the cache | Call sites are synchronous and ordering-sensitive for `document.write`; needs a prefetch/consume split, not an `async` conversion | **Done for scripts and `<link>` stylesheets** (`SubResourcePrefetcher`, bounded 6/host), and since #17 **in the capture host too** — it extracts scripts itself and so reached none of this wiring, leaving its round trips serial ([§10](#10-item-17s-win-was-not-the-scan-it-was-a-host-that-never-reached-item-2s-split)). Iframes and `fetch()`/XHR are still not wired: #17 now supplies their URL set, but the sub-document consume site yields `(content, contentType)` through a policy chain the text prefetcher cannot serve | Medium | Done (scripts, sheets) | 1 |
 | 3 | Graphics | [`Rendering/BCanvas.cs`](../../Broiler.Graphics/Broiler.Graphics/Rendering/BCanvas.cs) `FillRect:106`, `FillGlyphContours:241`, `DrawBitmap:345`, `FillRectTiled:389`, `FillLinear/Radial/ConicGradientRect:425/468/508` | Single-threaded scanline loops | `Parallel.For` over scanline bands; per-band coverage buffer and clip stack | Per-row `coverage[]` and the `_clipOperations` list are instance state shared across rows — must become per-worker | **The 4–6× estimate belongs to item #5, not here.** Item #4 built this shape against the copy the profile measures and got 1.42× on one corpus page and nothing on three; the ceiling is set by fill size, not by cores ([§4](#4-band-parallelism-inside-a-primitive-is-the-wrong-unit-for-a-page)). `BRasterParallelism` and `RasterBandParallelismTests` are the port-ready partitioner and exit gate | Low | 2–3 d (port) | 2 |
 | 4 | HTML | [`Broiler.HTML.Image/BCanvas.cs`](../../Broiler.HTML/Source/Broiler.HTML.Image/BCanvas.cs) — **DONE** | Was the same scanline shape; now `Parallel.For` over row bands via `BRasterParallelism`, with a measured area threshold and a per-band coverage buffer in `FillGlyphContours` | Nothing | **DONE, and smaller than the estimate.** Corpus `paint` page 1 594.7 ms → 1 096.5 ms (**1.42×** end to end, 1.61× on the stage) at 4 threads; **flat on `text`, `rules` and `boxes`, which split 0 fills between them** — their raster is glyphs, and a 95-pixel fill is not splittable at any core count. Pixels identical at 1/2/4 on all five pages. See [§4](#4-band-parallelism-inside-a-primitive-is-the-wrong-unit-for-a-page) | Low | Done | 2 |
 | 5 | Graphics / Layout | [`DisplayList.cs`](../../Broiler.Layout/Broiler.Layout/IR/DisplayList.cs) replayed by [`RGraphicsRasterBackend`](../../Broiler.HTML/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs) — **DONE** | Was one pass over the whole surface; now `Parallel.For` over horizontal strips via [`TileParallelReplay`](../../Broiler.Layout/Broiler.Layout/IR/TileParallelReplay.cs), each replaying the whole list into its own strip | Nothing | **DONE, and the estimate was right about the ceiling for the wrong reason.** `PerformPaint` at 1 → 4 tiles: `paint` **1 323.7 → 461.4 ms (2.87×)**, `rules` 3.49×, `text` 2.42×, `mixed` 2.44×, `boxes` 1.76× on a 4-core box — and it beats band parallelism on all five pages. But on the pages taller than their viewport — which is most documents — a large share of it came from *not drawing invisible pixels* rather than from threads ([§8](#8-most-of-item-5-was-not-parallelism-it-was-the-rasterizer-drawing-pixels-nothing-could-see)). Pixels identical at 1/2/4 tiles × 1/4 bands; WPT output identical to the line | Low–Medium | Done | 2 |
@@ -648,7 +766,7 @@ non-deterministic correctness defect.
 | 14 | Layout | Same as #13 | No incremental invalidation | **Not multithreading.** Dirty bits + relayout roots | — | **5–50× on interactive relayout** — unmeasured, and the *first-render* layout it bounds is 0.6–6.5% of wall time; the interactive case this claims is not covered by the P0-a corpus. Also the precondition that makes #13 safe | Medium | 15–20 d | 3 |
 | 15 | JS | [`JSPromise.Post:376`](../../Broiler.JS/Broiler.JS/Broiler.JavaScript.BuiltIns/Promise/JSPromise.cs), [`JSAsyncFunction.cs:152`](../../Broiler.JS/Broiler.JS/Broiler.JavaScript.BuiltIns/Function/JSAsyncFunction.cs), [`JSGenerator.cs:435`](../../Broiler.JS/Broiler.JS/Broiler.JavaScript.BuiltIns/Generator/JSGenerator.cs) — `ThreadPool.QueueUserWorkItem` when `sc == null` | JS continuations run on pool threads, racing main-thread layout | **Remove the parallelism.** Always pump a single-threaded event loop | This is the root cause behind WPT #1445 / #1143; the CSS `_sync` lock and the concurrent bridge memo maps are mitigations for it | Negative CPU gain, **large correctness gain**; removes lock overhead on hot cascade paths | Low | 5–8 d | 0 |
 | 16 | JS | [`JSContext.cs:1562`](../../Broiler.JS/Broiler.JS/Broiler.JavaScript.Engine/JSContext.cs) `DictionaryCodeCache` (process-shared, already concurrent) | Scripts compiled on demand, serially | Background/parallel compile of independent `<script>` sources; overlap with parse and network | Cache is already concurrent; needs a compile-ahead queue fed by the preload scanner (#17) | **Removes compile from the critical path**; 1.5–3× on script-heavy first paint | Medium | 8–12 d | 3 |
-| 17 | DOM / HTML | [`HtmlTokenizer.cs`](../../Broiler.DOM/Broiler.Dom.Html/HtmlTokenizer.cs), [`DomParser.cs`](../../Broiler.HTML/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs) | Sequential (correctly — the HTML tokenizer is spec-sequential and cannot be parallelized) | **Speculative preload scan**: a worker scans raw bytes for `src`/`href` while the main parse runs, feeding #2 | Nothing; it is a read-only scan of an immutable byte buffer | Overlaps network with parse — compounds #2 rather than adding CPU | Low | 4–6 d | 2 |
+| 17 | DOM / HTML | [`PreloadScanner.cs`](../../src/Broiler.HtmlBridge.Core/Scripting/PreloadScanner.cs), [`SpeculativePreloadScan.cs`](../../src/Broiler.HtmlBridge.Core/Scripting/SpeculativePreloadScan.cs) — **DONE** | The parse stays sequential (correctly — the HTML tokenizer is spec-sequential); the sub-resource *discovery* was sequential with it | A worker tokenizes the same immutable source and hands the URL sets to the prefetcher, started as the first statement of `ParseHtml` | Nothing; it is a read-only pass over an immutable string | **DONE, and it found a second thing.** Sheet requests are in flight while the document is still parsing (asserted at the origin, not timed). The number came from the script side: the capture host does its own extraction and so never reached item #2's split — 8 scripts at 40 ms go **755.1 → 521.4 ms**, median paired ratio **0.655** over 5 pairs, peak concurrency 6 against 1. It tokenizes rather than pattern-matching bytes, and `srcset`, `<template>` and `<noscript>` are documented exclusions. See [§10](#10-item-17s-win-was-not-the-scan-it-was-a-host-that-never-reached-item-2s-split) | Low | Done | 2 |
 | 18 | JS | New: `Worker` / `MessageChannel` | Not implemented | One `JSContext` per worker thread, structured-clone message passing | Per-context state exists and `JSEngine.CurrentContext` is `AsyncLocal`, so isolation is feasible; needs the static-mutable audit from P0-c across Broiler.JS | Capability, not a speedup of existing work | High | 30–40 d | 4 |
 | 19 | Runtime | `Directory.Build.props` sets neither; `Broiler.JavaScript.Engine.Benchmarks.csproj` **does** set `ServerGarbageCollection` | Workstation GC defaults everywhere except that one benchmark project | Config knob; evaluate Server GC for headless/batch hosts | Nothing | **Measured: Server GC is 1.62× SLOWER** on a 4-core headless render (see below). Keep Workstation | Low | Done | 0 |
 | 20 | Tooling | [`Broiler.Cli`](../../src/Broiler.Cli) — capture, document convert, layout fuzz — **DONE** | Repeatable inputs + `--output-dir`, `--threads` | Threads for document convert; **child processes** for capture and fuzz | **Not "nothing":** the render path's unsynchronised caches (item #9) make two in-process renders a race, so those two go through processes | Fuzz 14.8 s → 8.9 s at 4; capture byte-identical at 1 and 4. Per-page PDF is out of scope here — the CLI shells out to the standalone Broiler.Pdf app | Low | Done | 1 |
@@ -968,14 +1086,22 @@ scripts concurrently.
    *Exit gate:* a page with *N* sub-resources issues them concurrently, and
    `document.write` ordering plus script execution order are unchanged across
    the WPT corpus.
-2. **Speculative preload scan** (item #17) on a worker over the raw byte buffer,
-   feeding step 1 and item #16. Read-only over an immutable buffer, so it is
-   safe by construction. **It now also gates step 3**, which is why it moved
-   above it.
+2. **Speculative preload scan** (item #17) — **DONE**. A worker tokenizes the raw
+   source while the main parse runs and hands the URL sets to step 1's
+   prefetcher. Read-only over an immutable string, so it is safe by construction,
+   and `BROILER_PRELOAD_SCAN=0` is the sequential path rather than an
+   approximation of it. It found that the capture host never reached step 1's
+   split at all: [§10](#10-item-17s-win-was-not-the-scan-it-was-a-host-that-never-reached-item-2s-split).
+   **It gates step 3**, which is why it moved above it, and it feeds item #16.
+   Frames are the one family it discovers but does not wire — their consume site
+   yields `(content, contentType)` through a policy chain the text prefetcher
+   cannot serve, and on the paths measured here a frame is a disk read rather
+   than a round trip.
 3. **Concurrent image decode** (item #8). The decoder statics are cleared — they
    have a re-entrancy test — and `BImageRenderer._images` is fixed, but the
    headless render path loads images synchronously and inline, so this is the
-   same prefetch/consume split as step 1 over the image URLs step 2 supplies:
+   same prefetch/consume split as step 1 over the image URLs step 2 supplies —
+   `PreloadScanResult.ResolvedUrls(PreloadKind.Image)`, which now exists:
    [§6](#6-item-8-is-a-prefetchconsume-split-not-a-parallelfor).
 
 **Not recommended:** parallel HTML tokenization. The tokenizer is a
@@ -1067,7 +1193,7 @@ Recording these so they are not revisited each time the topic comes up:
 |---|---|---|
 | **0 — Make it measurable and deterministic** | P0-a benchmarks, P0-b single-threaded event loop (#15), P0-c static-state audit, GC config evaluation (#19) | Nothing after this is trustworthy without it. #15 is a correctness fix that also removes lock overhead from the cascade. |
 | **1 — Free wins and the sequential fixes** — **DONE** | WPT worker pool (#1), CLI batch (#20), concurrent sub-resource fetch (#2), CSS rule indexing (#11) | Cheap, low-risk, and #1 shortens the feedback loop for everything else. #11 is single-threaded but must precede #12. **What it changed:** #11 met its exit gate (cascade cost is now flat in total rules) but is 2.8× on a whole render, and `parse+cascade` still dominates the rule-heavy page — so #12 needs that stage split before it is started; #20 had to use processes, which makes item #9 a gate on every render-path item, not three. |
-| **2 — Raster, decode, text** — *in progress; 6 of 9 items done* | Rasterizer unification + band/tile parallelism (#3, #4, #5), font-cache safety (#9), text caches (#10), image decode (#6, #7, #8), preload scan (#17) | Largest CPU wins, disjoint memory, verifiable by exact pixel comparison. **#9 first, and it is done** — Phase 1 §2 made it the gate on every other item here, not just on #10/#12/#13. **What it changed, in the order it matters:** band parallelism inside a primitive turned out to be the wrong unit for a page — three of five corpus pages split zero fills, because their raster is glyphs — which promotes **#5 from "supersedes #3" to the only raster parallelism the corpus can use (§4)**; the phase's largest single win was a *cache*, and not the one #10 names (§5); #8 is a prefetch/consume split needing #17 first, not a `Parallel.For` (§6); the pool and the in-process threads multiply, so the runner now divides them (§7); the item-#9 findings (§1–§3) stand. **#5 landed and about half of its win was single-threaded** — the rasterizer was walking pixels its clip could never admit (§8) — and between them #4, #10 and #5 have taken raster from the largest stage on three pages to the largest on one (§9). **What is left:** #3's port, #17 then #8 — none of them the next thing to do. The largest open question is now the parse/cascade split Phase 1 §1 named, which gates #12. See [What building Phase 2 changed](#what-building-phase-2-changed). |
+| **2 — Raster, decode, text** — *in progress; 7 of 9 items done* | Rasterizer unification + band/tile parallelism (#3, #4, #5), font-cache safety (#9), text caches (#10), image decode (#6, #7, #8), preload scan (#17) | Largest CPU wins, disjoint memory, verifiable by exact pixel comparison. **#9 first, and it is done** — Phase 1 §2 made it the gate on every other item here, not just on #10/#12/#13. **What it changed, in the order it matters:** band parallelism inside a primitive turned out to be the wrong unit for a page — three of five corpus pages split zero fills, because their raster is glyphs — which promotes **#5 from "supersedes #3" to the only raster parallelism the corpus can use (§4)**; the phase's largest single win was a *cache*, and not the one #10 names (§5); #8 is a prefetch/consume split needing #17 first, not a `Parallel.For` (§6); the pool and the in-process threads multiply, so the runner now divides them (§7); the item-#9 findings (§1–§3) stand. **#5 landed and about half of its win was single-threaded** — the rasterizer was walking pixels its clip could never admit (§8) — and between them #4, #10 and #5 have taken raster from the largest stage on three pages to the largest on one (§9). **#17 landed and its number came from somewhere the item did not name:** the capture host does its own script extraction and so never reached the split item #2 built, leaving that family serial in the path this repository measures (§10). **What is left:** #3's port, and #8 — whose last prerequisite #17 has now supplied. The largest open question is still the parse/cascade split Phase 1 §1 named, which gates #12. See [What building Phase 2 changed](#what-building-phase-2-changed). |
 | **3 — Style and incremental layout** | Cache sharding + parallel style recalc (#12), layout dirty bits (#14), parallel script compile (#16), re-enable test parallelization (#21) | Depends on Phase 1's algorithmic fixes and Phase 0's determinism. |
 | **4 — Parallel layout and workers** | Parallel intrinsic sizing and independent subtrees (#13), Web Workers (#18) | Highest cost, highest risk, lowest ceiling. Only worth starting once Phase 3's measurements say layout is still the bottleneck. |
 

--- a/src/Broiler.Cli.Tests/ApiBaselines/Broiler.HtmlBridge.Core.PublicApi.txt
+++ b/src/Broiler.Cli.Tests/ApiBaselines/Broiler.HtmlBridge.Core.PublicApi.txt
@@ -45,6 +45,31 @@ TYPE Broiler.HtmlBridge.Logging.RenderLogger
   method System.Void LogError(Broiler.HtmlBridge.Logging.LogCategory, System.String, System.String, System.Exception)
   method System.Void LogWarning(Broiler.HtmlBridge.Logging.LogCategory, System.String, System.String, System.Exception)
   property Broiler.HtmlBridge.Logging.LogLevel MinimumLevel { get; set; }
+TYPE Broiler.HtmlBridge.PreloadCandidate : System.IEquatable<Broiler.HtmlBridge.PreloadCandidate>
+  ctor (Broiler.HtmlBridge.PreloadKind, System.String, System.String, System.String)
+  method System.Boolean Equals(Broiler.HtmlBridge.PreloadCandidate)
+  method System.Boolean Equals(System.Object)
+  method System.Int32 GetHashCode()
+  method System.String ToString()
+  method System.Void Deconstruct(ref Broiler.HtmlBridge.PreloadKind, ref System.String, ref System.String, ref System.String)
+  property Broiler.HtmlBridge.PreloadKind Kind { get; set; }
+  property System.String Nonce { get; set; }
+  property System.String RawUrl { get; set; }
+  property System.String ResolvedUrl { get; set; }
+TYPE Broiler.HtmlBridge.PreloadKind : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  field System.Int32 value__
+  field const Broiler.HtmlBridge.PreloadKind Frame
+  field const Broiler.HtmlBridge.PreloadKind Image
+  field const Broiler.HtmlBridge.PreloadKind Script
+  field const Broiler.HtmlBridge.PreloadKind StyleSheet
+TYPE Broiler.HtmlBridge.PreloadScanResult
+  method System.Collections.Generic.IReadOnlyList<System.String> RawUrls(Broiler.HtmlBridge.PreloadKind)
+  method System.Collections.Generic.IReadOnlyList<System.String> ResolvedUrls(Broiler.HtmlBridge.PreloadKind)
+  property System.Collections.Generic.IReadOnlyList<Broiler.HtmlBridge.PreloadCandidate> Candidates { get; }
+  property System.String DocumentBaseUrl { get; }
+TYPE Broiler.HtmlBridge.PreloadScanner
+  method Broiler.HtmlBridge.PreloadScanResult Scan(System.String, System.String)
+  method System.Boolean MightContainCandidates(System.String)
 TYPE Broiler.HtmlBridge.ScriptExtractionService
   method Broiler.HtmlBridge.Scripting.ScriptExtractionResult ExtractAll(System.String, System.String)
   method System.Collections.Generic.IReadOnlyList<System.String> Extract(System.String)
@@ -162,3 +187,19 @@ TYPE Broiler.HtmlBridge.Scripting.ScriptTimingEntry
   property System.Boolean Succeeded { get; set; }
   property System.String Label { get; set; }
   property System.TimeSpan Elapsed { get; set; }
+TYPE Broiler.HtmlBridge.SpeculativePreloadScan
+  field const System.String EnabledEnvironmentVariable
+  method Broiler.HtmlBridge.SpeculativePreloadScan Start(System.String, System.String, Broiler.HtmlBridge.Scripting.ContentSecurityPolicy, System.Action<Broiler.HtmlBridge.PreloadScanResult>)
+  method System.Void ResetCounters()
+  property Broiler.HtmlBridge.PreloadScanResult Result { get; }
+  property System.Boolean Enabled { get; set; }
+  property System.Boolean IsCompleted { get; }
+  property System.Int64 ScansSkipped { get; }
+  property System.Int64 ScansStarted { get; }
+TYPE Broiler.HtmlBridge.SubResourcePrefetcher
+  ctor (System.Func<System.String, System.String>, System.Int32)
+  field const System.Int32 DefaultMaxConcurrentRequestsPerHost
+  method System.Boolean IsPending(System.String)
+  method System.String Consume(System.String)
+  method System.Void Prefetch(System.Collections.Generic.IEnumerable<System.String>)
+  property System.Int32 RequestedCount { get; }

--- a/src/Broiler.Cli.Tests/ApiBaselines/Broiler.HtmlBridge.Dom.PublicApi.txt
+++ b/src/Broiler.Cli.Tests/ApiBaselines/Broiler.HtmlBridge.Dom.PublicApi.txt
@@ -19,6 +19,7 @@ TYPE Broiler.HtmlBridge.DomBridge : Broiler.HtmlBridge.Dom.IDomBridgeRuntime, Sy
   method System.Void ResolveAnchorPositions(System.Int32, System.Int32)
   method System.Void ResolveAnimationSnapshots()
   method System.Void SetLocalBasePath(System.String)
+  method System.Void SyncWindowMembersOntoGlobal()
   property Broiler.Dom.DomDocument Document { get; }
   property Broiler.Dom.DomElement DocumentElement { get; }
   property Broiler.HtmlBridge.Scripting.ContentSecurityPolicy Csp { get; set; }

--- a/src/Broiler.Cli.Tests/PreloadScanOverlapTests.cs
+++ b/src/Broiler.Cli.Tests/PreloadScanOverlapTests.cs
@@ -1,0 +1,382 @@
+using System.Diagnostics;
+using System.Net;
+using System.Text;
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// The measurement behind multithreading roadmap item #17, expressed as an assertion rather than a
+/// stopwatch: <em>when</em> a document's sub-resource requests reach the origin.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A wall-clock comparison of "with the scan" against "without" is the obvious test and the wrong
+/// one — it measures the host's scheduler as much as the change, and it fails on a loaded CI box for
+/// reasons that have nothing to do with the code. What the item actually claims is structural and
+/// can be checked exactly, by an origin that <b>holds every request open until released</b>:
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <b>Overlap with the parse.</b> With the scan, the stylesheet requests have arrived at the origin
+/// while <c>Attach</c> — the parse — is still running, and <c>Attach</c> returns without waiting for
+/// them. Without it, not one request has been made by the time the parse is over.
+/// </description></item>
+/// <item><description>
+/// <b>Overlap with each other.</b> With the scan, a document's external scripts are in flight
+/// together; without it the host fetches them one at a time, so the origin never sees two at once.
+/// </description></item>
+/// </list>
+/// <para>
+/// Both are true regardless of how fast the machine is, which is what makes them assertions. The
+/// wall-clock figures that go in the roadmap come from the same shape with a fixed per-request
+/// delay, and they are the arithmetic these assertions imply.
+/// </para>
+/// </remarks>
+public sealed class PreloadScanOverlapTests : IDisposable
+{
+    private readonly LatencyOrigin _origin = new();
+
+    public void Dispose() => _origin.Dispose();
+
+    /// <summary>
+    /// The claim in the roadmap's own words — "overlaps network with parse". With the scan the
+    /// sheet requests are on the wire before the parse finishes; without it they do not exist yet.
+    /// </summary>
+    [Fact]
+    public void Stylesheet_Requests_Are_In_Flight_While_The_Document_Is_Still_Parsing()
+    {
+        var html = Document(sheets: 3, scripts: 0);
+
+        _origin.HoldRequests();
+        try
+        {
+            using var context = new JSContext();
+            var bridge = new DomBridge();
+            WithScan(true, () => bridge.Attach(context, html, _origin.PageUrl));
+
+            // Deterministic: the requests will arrive, because the worker has been handed them and
+            // nothing can withdraw them. What is being asserted is that Attach did not have to wait
+            // for them — the origin is still holding every one of them open.
+            Assert.True(_origin.WaitForRequests(3, TimeSpan.FromSeconds(10)));
+            Assert.Equal(0, _origin.CompletedCount);
+        }
+        finally
+        {
+            _origin.ReleaseRequests();
+        }
+    }
+
+    [Fact]
+    public void Without_The_Scan_No_Stylesheet_Request_Exists_When_The_Parse_Ends()
+    {
+        var html = Document(sheets: 3, scripts: 0);
+
+        _origin.HoldRequests();
+        try
+        {
+            using var context = new JSContext();
+            var bridge = new DomBridge();
+            WithScan(false, () => bridge.Attach(context, html, _origin.PageUrl));
+
+            // No wait and no window to race against: with the scan off, the only code that could
+            // have issued these requests is the post-parse sheet collection, which has not run.
+            Assert.Equal(0, _origin.ReceivedCount);
+        }
+        finally
+        {
+            _origin.ReleaseRequests();
+        }
+    }
+
+    /// <summary>
+    /// The capture host walks the script tags itself and fetched each external one inline as it
+    /// reached it, so its round trips were strictly serial — a call site item #2's split never
+    /// reached. The scan supplies the URL set early enough to fix it.
+    /// </summary>
+    [Fact]
+    public void External_Scripts_Are_Fetched_Concurrently_Rather_Than_One_At_A_Time()
+    {
+        var html = Document(sheets: 0, scripts: 4);
+
+        _origin.Reset();
+        var withScan = WithScan(true, () => CaptureService.ExecuteScriptsWithDom(html, _origin.PageUrl));
+        var concurrentPeak = _origin.PeakConcurrency;
+
+        _origin.Reset();
+        var withoutScan = WithScan(false, () => CaptureService.ExecuteScriptsWithDom(html, _origin.PageUrl));
+        var serialPeak = _origin.PeakConcurrency;
+
+        Assert.Equal(1, serialPeak);
+        Assert.True(concurrentPeak > 1, $"expected overlapping script fetches, peak was {concurrentPeak}");
+
+        // The exit gate: the scripts still run, in document order, to the same result.
+        Assert.Contains("0123", withScan);
+        Assert.Equal(withoutScan, withScan);
+    }
+
+    /// <summary>
+    /// The wall-clock figure the assertions above imply, printed rather than asserted: eight
+    /// scripts behind a fixed per-request delay cost eight delays serially and about one
+    /// concurrently.
+    /// </summary>
+    /// <remarks>
+    /// Reported as the median of interleaved pairs, because the two settings are being compared on
+    /// a shared machine: measuring all of one and then all of the other charges any drift in the
+    /// host — another test suite starting, a GC, a frequency change — entirely to whichever ran
+    /// second. A pair run back to back sees the same conditions, and the median of several pairs
+    /// discards the one that did not.
+    /// </remarks>
+    [Fact]
+    public void Serial_And_Overlapped_Wall_Clock_Are_Reported()
+    {
+        const int pairs = 5;
+        var html = Document(sheets: 0, scripts: 8);
+
+        // One untimed pass each way: the first run through this path JITs the bridge, the engine
+        // and the HTTP stack, and timing that measures the runtime warming up.
+        Run(html, scan: false);
+        Run(html, scan: true);
+
+        var ratios = new List<double>();
+        var serials = new List<double>();
+        var overlaps = new List<double>();
+        var peak = 0;
+
+        for (var i = 0; i < pairs; i++)
+        {
+            var serial = Measure(() => Run(html, scan: false));
+            var overlapped = Measure(() => Run(html, scan: true));
+            peak = Math.Max(peak, _origin.PeakConcurrency);
+
+            serials.Add(serial.TotalMilliseconds);
+            overlaps.Add(overlapped.TotalMilliseconds);
+            ratios.Add(overlapped.TotalMilliseconds / serial.TotalMilliseconds);
+        }
+
+        Console.WriteLine(
+            $"preload scan, 8 scripts at {LatencyOrigin.DelayMilliseconds} ms per request, {pairs} interleaved pairs: " +
+            $"serial median {Median(serials):F1} ms, overlapped median {Median(overlaps):F1} ms, " +
+            $"median paired ratio {Median(ratios):F3}, peak concurrency {peak}");
+
+        // Deliberately not an assertion on the ratio. The claim this file makes is the one above,
+        // about how many requests are in flight; the time that saves is arithmetic, and asserting
+        // on it would make a scheduling hiccup look like a regression.
+        Assert.NotEmpty(ratios);
+    }
+
+    private string Run(string html, bool scan)
+    {
+        _origin.Reset();
+        return WithScan(scan, () => CaptureService.ExecuteScriptsWithDom(html, _origin.PageUrl));
+    }
+
+    private static double Median(List<double> values)
+    {
+        var sorted = values.Order().ToArray();
+        return sorted.Length % 2 == 1
+            ? sorted[sorted.Length / 2]
+            : (sorted[sorted.Length / 2 - 1] + sorted[sorted.Length / 2]) / 2;
+    }
+
+    private static TimeSpan Measure(Action body)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        body();
+        return stopwatch.Elapsed;
+    }
+
+    private static T WithScan<T>(bool enabled, Func<T> body)
+    {
+        var wasEnabled = SpeculativePreloadScan.Enabled;
+        try
+        {
+            SpeculativePreloadScan.Enabled = enabled;
+            return body();
+        }
+        finally
+        {
+            SpeculativePreloadScan.Enabled = wasEnabled;
+        }
+    }
+
+    private static void WithScan(bool enabled, Action body) => WithScan(enabled, () => { body(); return 0; });
+
+    /// <summary>
+    /// A document naming <paramref name="sheets"/> stylesheets and <paramref name="scripts"/>
+    /// scripts on the local origin. Each script appends its index to <c>#result</c>, so the
+    /// serialized output pins execution order as well as content.
+    /// </summary>
+    private string Document(int sheets, int scripts)
+    {
+        var html = new StringBuilder("<!DOCTYPE html><html><head>");
+        for (var i = 0; i < sheets; i++)
+            html.Append($"""<link rel="stylesheet" href="{_origin.Url($"s{i}.css")}">""");
+        html.Append("""</head><body><div id="target">text</div><div id="result"></div>""");
+        for (var i = 0; i < scripts; i++)
+            html.Append($"""<script src="{_origin.Url($"j{i}.js")}"></script>""");
+        return html.Append("</body></html>").ToString();
+    }
+}
+
+/// <summary>
+/// A loopback origin that serves the sub-resources these tests name, after a fixed delay, and
+/// records how its requests overlapped.
+/// </summary>
+/// <remarks>
+/// The delay is what makes concurrency observable at all: without one, a fetch completes before the
+/// next begins whatever the caller intended, and a serial loop is indistinguishable from a parallel
+/// one. <see cref="HoldRequests"/> replaces the delay with a gate the test opens, which is what
+/// turns "the requests overlapped the parse" from a race into an assertion.
+/// </remarks>
+internal sealed class LatencyOrigin : IDisposable
+{
+    internal const int DelayMilliseconds = 40;
+
+    private readonly HttpListener _listener = new();
+    private readonly ManualResetEventSlim _gate = new(initialState: true);
+    private readonly Lock _sync = new();
+    private readonly string _prefix;
+    private int _inFlight;
+
+    public LatencyOrigin()
+    {
+        // Port 0 asks the OS for a free one, but HttpListener has no way to report it back, so the
+        // port is picked by binding a socket, closing it, and taking the number. The window between
+        // the two is the standard cost of this pattern and is not worth a retry loop in a test.
+        var probe = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+
+        _prefix = $"http://127.0.0.1:{port}/";
+        _listener.Prefixes.Add(_prefix);
+        _listener.Start();
+        _ = Task.Run(Serve);
+    }
+
+    /// <summary>The page URL documents under test are given, on this origin.</summary>
+    public string PageUrl => _prefix + "page.html";
+
+    /// <summary>Requests that have reached the origin.</summary>
+    public int ReceivedCount { get; private set; }
+
+    /// <summary>Requests the origin has finished answering.</summary>
+    public int CompletedCount { get; private set; }
+
+    /// <summary>The most requests that were ever open at the same time.</summary>
+    public int PeakConcurrency { get; private set; }
+
+    public string Url(string path) => _prefix + path;
+
+    public void Reset()
+    {
+        lock (_sync)
+        {
+            ReceivedCount = 0;
+            CompletedCount = 0;
+            PeakConcurrency = 0;
+        }
+    }
+
+    /// <summary>Makes every request block until <see cref="ReleaseRequests"/>.</summary>
+    public void HoldRequests()
+    {
+        Reset();
+        _gate.Reset();
+    }
+
+    public void ReleaseRequests() => _gate.Set();
+
+    /// <summary>Waits for <paramref name="count"/> requests to arrive. False on timeout.</summary>
+    public bool WaitForRequests(int count, TimeSpan timeout)
+    {
+        var deadline = Stopwatch.StartNew();
+        while (deadline.Elapsed < timeout)
+        {
+            lock (_sync)
+            {
+                if (ReceivedCount >= count)
+                    return true;
+            }
+
+            Thread.Sleep(5);
+        }
+
+        return false;
+    }
+
+    private async Task Serve()
+    {
+        while (_listener.IsListening)
+        {
+            HttpListenerContext context;
+            try
+            {
+                context = await _listener.GetContextAsync().ConfigureAwait(false);
+            }
+            catch (HttpListenerException)
+            {
+                return; // Disposed.
+            }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
+
+            _ = Task.Run(() => Answer(context));
+        }
+    }
+
+    private void Answer(HttpListenerContext context)
+    {
+        lock (_sync)
+        {
+            ReceivedCount++;
+            _inFlight++;
+            PeakConcurrency = Math.Max(PeakConcurrency, _inFlight);
+        }
+
+        // The gate is open in the timed tests (so the delay is the whole cost) and closed in the
+        // overlap ones (so nothing completes until the assertion has been made).
+        _gate.Wait();
+        Thread.Sleep(DelayMilliseconds);
+
+        var path = context.Request.Url?.AbsolutePath ?? "/";
+        var (body, contentType) = path.EndsWith(".css", StringComparison.Ordinal)
+            ? ($"#target {{ color: rgb(1, 2, 3); }}", "text/css")
+            : ($"document.getElementById('result').textContent += '{IndexIn(path)}';", "text/javascript");
+
+        var bytes = Encoding.UTF8.GetBytes(body);
+        context.Response.ContentType = contentType;
+        context.Response.ContentLength64 = bytes.Length;
+        context.Response.OutputStream.Write(bytes);
+        context.Response.Close();
+
+        lock (_sync)
+        {
+            _inFlight--;
+            CompletedCount++;
+        }
+    }
+
+    /// <summary>The digits in <c>/j2.js</c>, so a script can report which one it was.</summary>
+    private static string IndexIn(string path) => new([.. path.Where(char.IsDigit)]);
+
+    public void Dispose()
+    {
+        _gate.Set();
+        try
+        {
+            _listener.Stop();
+            _listener.Close();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Already closed.
+        }
+
+        _gate.Dispose();
+    }
+}

--- a/src/Broiler.Cli.Tests/PreloadScanTests.cs
+++ b/src/Broiler.Cli.Tests/PreloadScanTests.cs
@@ -1,0 +1,262 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Scripting;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Covers the speculative preload scan — multithreading roadmap item #17: what a document's raw
+/// source says it will fetch, discovered on a worker before the parse that would otherwise have
+/// discovered it.
+/// </summary>
+/// <remarks>
+/// Two claims are being tested and they are separable. <see cref="PreloadScanner"/> is a pure
+/// function of the source, so the bulk of this file pins down <em>what it finds and what it
+/// refuses to find</em> — the refusals matter as much, because a speculated request the document
+/// never makes is a round trip charged to an origin for nothing.
+/// <see cref="SpeculativePreloadScan"/> adds the worker, the policy filter and the sink, and the
+/// exit gate for it is that turning it off changes nothing but timing.
+/// </remarks>
+public sealed class PreloadScanTests
+{
+    private const string PageUrl = "https://example.test/dir/page.html";
+
+    private static PreloadScanResult Scan(string html) => PreloadScanner.Scan(html, PageUrl);
+
+    // ────────────── what it finds ──────────────
+
+    [Fact]
+    public void Finds_Each_Family_In_Document_Order()
+    {
+        var result = Scan("""
+            <link rel="stylesheet" href="a.css">
+            <script src="b.js"></script>
+            <img src="c.png">
+            <iframe src="d.html"></iframe>
+            """);
+
+        Assert.Equal(
+            [
+                (PreloadKind.StyleSheet, "a.css"),
+                (PreloadKind.Script, "b.js"),
+                (PreloadKind.Image, "c.png"),
+                (PreloadKind.Frame, "d.html"),
+            ],
+            result.Candidates.Select(c => (c.Kind, c.RawUrl)));
+    }
+
+    [Fact]
+    public void Resolves_Every_Candidate_Against_The_Page_Url()
+    {
+        var result = Scan("""<link rel="stylesheet" href="a.css">""");
+
+        Assert.Equal(["https://example.test/dir/a.css"], result.ResolvedUrls(PreloadKind.StyleSheet));
+        Assert.Equal(["a.css"], result.RawUrls(PreloadKind.StyleSheet));
+    }
+
+    /// <summary>
+    /// HTML §4.2.3 makes the first <c>&lt;base href&gt;</c> the base for the whole document, not
+    /// just for what follows it — which is why the scan resolves after its pass rather than during
+    /// it. A scanner that resolved as it went would get this one wrong.
+    /// </summary>
+    [Fact]
+    public void A_Base_Href_Declared_After_A_Resource_Still_Applies_To_It()
+    {
+        var result = Scan("""
+            <link rel="stylesheet" href="a.css">
+            <base href="/assets/">
+            """);
+
+        Assert.Equal("https://example.test/assets/", result.DocumentBaseUrl);
+        Assert.Equal(["https://example.test/assets/a.css"], result.ResolvedUrls(PreloadKind.StyleSheet));
+    }
+
+    [Fact]
+    public void The_First_Base_Href_Wins()
+    {
+        var result = Scan("""
+            <base href="/first/">
+            <base href="/second/">
+            <img src="a.png">
+            """);
+
+        Assert.Equal(["https://example.test/first/a.png"], result.ResolvedUrls(PreloadKind.Image));
+    }
+
+    [Fact]
+    public void The_Same_Url_Named_Twice_Is_One_Candidate()
+    {
+        var result = Scan("""
+            <script src="a.js"></script>
+            <script src="a.js"></script>
+            """);
+
+        Assert.Single(result.Candidates);
+    }
+
+    /// <summary>
+    /// Deduplication is per family: the same file linked as a stylesheet and preloaded as an image
+    /// is two different requests to two different consume sites.
+    /// </summary>
+    [Fact]
+    public void The_Same_Url_In_Two_Families_Is_Two_Candidates()
+    {
+        var result = Scan("""
+            <link rel="stylesheet" href="a.css">
+            <link rel="preload" as="image" href="a.css">
+            """);
+
+        Assert.Equal(2, result.Candidates.Count);
+    }
+
+    [Theory]
+    [InlineData("""<link rel="stylesheet" href="a.css">""", PreloadKind.StyleSheet)]
+    [InlineData("""<link rel="alternate stylesheet" href="a.css">""", PreloadKind.StyleSheet)]
+    [InlineData("""<link rel="STYLESHEET" href="a.css">""", PreloadKind.StyleSheet)]
+    [InlineData("""<link rel="modulepreload" href="a.js">""", PreloadKind.Script)]
+    [InlineData("""<link rel="preload" as="script" href="a.js">""", PreloadKind.Script)]
+    [InlineData("""<link rel="preload" as="style" href="a.css">""", PreloadKind.StyleSheet)]
+    [InlineData("""<link rel="preload" as="image" href="a.png">""", PreloadKind.Image)]
+    public void Link_Rel_Is_Read_As_A_Token_List(string html, PreloadKind expected)
+    {
+        var candidate = Assert.Single(Scan(html).Candidates);
+        Assert.Equal(expected, candidate.Kind);
+    }
+
+    [Theory]
+    [InlineData("""<link rel="icon" href="favicon.ico">""")]
+    [InlineData("""<link rel="canonical" href="/here">""")]
+    [InlineData("""<link href="a.css">""")]
+    [InlineData("""<link rel="preload" href="a.woff2">""")]
+    [InlineData("""<link rel="preload" as="font" href="a.woff2">""")]
+    public void A_Link_This_Engine_Has_No_Consume_Site_For_Is_Not_Speculated_On(string html) =>
+        Assert.Empty(Scan(html).Candidates);
+
+    [Fact]
+    public void Input_Is_An_Image_Only_When_Its_Type_Says_So()
+    {
+        Assert.Single(Scan("""<input type="image" src="submit.png">""").Candidates);
+        Assert.Empty(Scan("""<input type="text" src="submit.png">""").Candidates);
+        Assert.Empty(Scan("""<input src="submit.png">""").Candidates);
+    }
+
+    [Fact]
+    public void Object_Data_And_Embed_Src_Are_Frame_Resources()
+    {
+        Assert.Equal(PreloadKind.Frame, Assert.Single(Scan("""<object data="a.svg"></object>""").Candidates).Kind);
+        Assert.Equal(PreloadKind.Frame, Assert.Single(Scan("""<embed src="a.svg">""").Candidates).Kind);
+    }
+
+    // ────────────── what it refuses to find ──────────────
+
+    /// <summary>
+    /// The reason the scan tokenizes instead of matching a pattern over the buffer: none of these
+    /// three is a resource, and all three look exactly like one to a regex.
+    /// </summary>
+    [Theory]
+    [InlineData("""<!-- <img src="a.png"> -->""")]
+    [InlineData("""<script>var s = '<img src="a.png">';</script>""")]
+    [InlineData("""<style>/* <img src="a.png"> */</style>""")]
+    public void Text_That_Merely_Looks_Like_A_Tag_Is_Not_A_Resource(string html) =>
+        Assert.Empty(Scan(html).Candidates);
+
+    [Fact]
+    public void A_Quoted_Attribute_Containing_A_Close_Bracket_Does_Not_Truncate_The_Tag()
+    {
+        var candidate = Assert.Single(Scan("""<img alt="a > b" src="c.png">""").Candidates);
+        Assert.Equal("c.png", candidate.RawUrl);
+    }
+
+    /// <summary>
+    /// Template contents are inert until something clones them, which is a script decision this
+    /// scan cannot predict — so a template's resources are never fetched by the parse it overlaps.
+    /// </summary>
+    [Fact]
+    public void Template_Contents_Are_Inert()
+    {
+        Assert.Empty(Scan("""<template><img src="a.png"></template>""").Candidates);
+        Assert.Empty(Scan("""<template><template><img src="a.png"></template></template>""").Candidates);
+    }
+
+    [Fact]
+    public void A_Nested_Templates_End_Tag_Does_Not_Re_Open_The_Outer_One()
+    {
+        // The inner </template> closes only the inner one; `b.png` is still inert. A boolean
+        // "inside a template" flag rather than a depth counter gets exactly this case wrong.
+        Assert.Empty(Scan("""
+            <template><template><img src="a.png"></template><img src="b.png"></template>
+            """).Candidates);
+    }
+
+    [Fact]
+    public void Resources_After_A_Template_Are_Found()
+    {
+        var candidate = Assert.Single(Scan("""<template><img src="a.png"></template><img src="b.png">""").Candidates);
+        Assert.Equal("b.png", candidate.RawUrl);
+    }
+
+    [Fact]
+    public void Noscript_Contents_Are_Inert_Because_This_Engine_Runs_Scripts() =>
+        Assert.Empty(Scan("""<noscript><img src="a.png"></noscript>""").Candidates);
+
+    [Theory]
+    [InlineData("""<img src="data:image/png;base64,iVBORw0KGgo=">""")]
+    [InlineData("""<iframe src="about:blank"></iframe>""")]
+    [InlineData("""<iframe src="javascript:0"></iframe>""")]
+    [InlineData("""<img src="blob:https://example.test/abc">""")]
+    [InlineData("""<img src="#fragment">""")]
+    [InlineData("""<img src="">""")]
+    [InlineData("<img>")]
+    public void A_Url_With_No_Round_Trip_To_Save_Is_Not_A_Candidate(string html) =>
+        Assert.Empty(Scan(html).Candidates);
+
+    [Fact]
+    public void An_Iframe_With_Srcdoc_Carries_Its_Own_Content() =>
+        Assert.Empty(Scan("""<iframe srcdoc="<p>hi" src="a.html"></iframe>""").Candidates);
+
+    /// <summary>
+    /// Which <c>srcset</c> candidate a browser fetches depends on the viewport and the device pixel
+    /// ratio, and this scan runs before layout. Preloading all of them would put four requests on
+    /// the wire for one image, so the documented boundary is that <c>srcset</c> is not scanned at
+    /// all — and a bare <c>srcset</c> with no <c>src</c> therefore yields nothing.
+    /// </summary>
+    [Fact]
+    public void Srcset_Is_Not_Scanned()
+    {
+        Assert.Empty(Scan("""<img srcset="a.png 1x, b.png 2x">""").Candidates);
+
+        var candidate = Assert.Single(Scan("""<img src="a.png" srcset="b.png 2x">""").Candidates);
+        Assert.Equal("a.png", candidate.RawUrl);
+    }
+
+    [Fact]
+    public void A_Relative_Url_With_No_Base_Resolves_To_Nothing_Rather_Than_To_Itself()
+    {
+        var result = PreloadScanner.Scan("""<link rel="stylesheet" href="a.css">""", pageUrl: null);
+
+        Assert.Equal(["a.css"], result.RawUrls(PreloadKind.StyleSheet));
+        Assert.Empty(result.ResolvedUrls(PreloadKind.StyleSheet));
+    }
+
+    // ────────────── the cheap pre-check ──────────────
+
+    [Fact]
+    public void A_Document_That_Names_No_Resource_Does_Not_Get_A_Tokenizer_Pass()
+    {
+        Assert.False(PreloadScanner.MightContainCandidates("<p>hello <b>world</b></p>"));
+        Assert.False(PreloadScanner.MightContainCandidates(""));
+        Assert.False(PreloadScanner.MightContainCandidates(null));
+        Assert.True(PreloadScanner.MightContainCandidates("""<LINK REL="stylesheet" HREF="a.css">"""));
+    }
+
+    /// <summary>
+    /// The pre-check is allowed to be wrong in one direction only. Saying "might" about a document
+    /// with nothing in it costs a tokenizer pass on a pool thread; saying "no" about a document
+    /// that does name a resource would silently switch the feature off for it.
+    /// </summary>
+    [Fact]
+    public void The_Pre_Check_Is_Over_Permissive_Never_Under()
+    {
+        Assert.True(PreloadScanner.MightContainCandidates("<p>the word script appears in <scriptish>"));
+        Assert.Empty(Scan("<p>the word script appears in <scriptish>").Candidates);
+    }
+}

--- a/src/Broiler.Cli.Tests/SpeculativePreloadScanTests.cs
+++ b/src/Broiler.Cli.Tests/SpeculativePreloadScanTests.cs
@@ -1,0 +1,244 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Scripting;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Covers the worker half of multithreading roadmap item #17 — the policy filter, the sink that
+/// puts requests on the wire during the parse, and the exit gate: turning the scan off must change
+/// nothing but timing.
+/// </summary>
+public sealed class SpeculativePreloadScanTests : IDisposable
+{
+    private const string PageUrl = "https://example.test/dir/page.html";
+
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(),
+        "broiler-preload-scan-" + Guid.NewGuid().ToString("N"));
+
+    public SpeculativePreloadScanTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    // ────────────── the worker ──────────────
+
+    [Fact]
+    public void A_Started_Scan_Reports_What_It_Found()
+    {
+        var scan = SpeculativePreloadScan.Start("""<link rel="stylesheet" href="a.css">""", PageUrl);
+
+        Assert.NotNull(scan);
+        Assert.Equal(["a.css"], scan.Result.RawUrls(PreloadKind.StyleSheet));
+    }
+
+    /// <summary>
+    /// "Nothing found" and "never ran" are different claims, and only one of them costs a pool
+    /// thread — so a document that plainly names no resource returns no scan at all rather than an
+    /// empty one.
+    /// </summary>
+    [Fact]
+    public void A_Document_Naming_No_Resource_Starts_No_Worker() =>
+        Assert.Null(SpeculativePreloadScan.Start("<p>hello</p>", PageUrl));
+
+    [Fact]
+    public void The_Feature_Switch_Stops_The_Scan_Entirely()
+    {
+        var wasEnabled = SpeculativePreloadScan.Enabled;
+        try
+        {
+            SpeculativePreloadScan.Enabled = false;
+            Assert.Null(SpeculativePreloadScan.Start("""<link rel="stylesheet" href="a.css">""", PageUrl));
+        }
+        finally
+        {
+            SpeculativePreloadScan.Enabled = wasEnabled;
+        }
+    }
+
+    /// <summary>
+    /// The sink is the whole point of the worker: it is what starts the requests while the parse is
+    /// still running. It runs on the worker, before the result is published.
+    /// </summary>
+    [Fact]
+    public void The_Sink_Receives_The_Result_On_The_Worker()
+    {
+        int? sinkThread = null;
+        IReadOnlyList<string> sheets = [];
+
+        var scan = SpeculativePreloadScan.Start(
+            """<link rel="stylesheet" href="a.css"><link rel="stylesheet" href="b.css">""",
+            PageUrl,
+            csp: null,
+            result =>
+            {
+                sinkThread = Environment.CurrentManagedThreadId;
+                sheets = result.RawUrls(PreloadKind.StyleSheet);
+            });
+
+        Assert.NotNull(scan);
+        _ = scan.Result;
+
+        Assert.Equal(["a.css", "b.css"], sheets);
+        Assert.NotEqual(Environment.CurrentManagedThreadId, sinkThread);
+    }
+
+    /// <summary>
+    /// A speculation that fails must leave the document exactly as it would have been — which is a
+    /// document whose consume sites each fetch inline. A throwing sink is the one failure this can
+    /// actually be provoked into, since the scan itself is a pure function.
+    /// </summary>
+    [Fact]
+    public void A_Throwing_Sink_Does_Not_Take_The_Document_With_It()
+    {
+        var scan = SpeculativePreloadScan.Start(
+            """<link rel="stylesheet" href="a.css">""",
+            PageUrl,
+            csp: null,
+            _ => throw new InvalidOperationException("sink"));
+
+        Assert.NotNull(scan);
+        Assert.Equal(["a.css"], scan.Result.RawUrls(PreloadKind.StyleSheet));
+    }
+
+    // ────────────── the policy filter ──────────────
+
+    [Fact]
+    public void A_Script_The_Configured_Policy_Blocks_Is_Not_Requested()
+    {
+        var csp = new ContentSecurityPolicy();
+        csp.Parse("script-src 'self'");
+
+        var scan = SpeculativePreloadScan.Start(
+            """<script src="https://cdn.other.test/a.js"></script><script src="/own.js"></script>""",
+            PageUrl,
+            csp);
+
+        Assert.NotNull(scan);
+        Assert.Equal(["/own.js"], scan.Result.RawUrls(PreloadKind.Script));
+    }
+
+    /// <summary>
+    /// The meta policy is checked even when the host configured none of its own: the request itself
+    /// is what the policy stops, so "we fetched it but did not run it" is not a defensible reading.
+    /// </summary>
+    [Fact]
+    public void A_Meta_Policy_Blocks_A_Prefetch_With_No_Configured_Policy()
+    {
+        var scan = SpeculativePreloadScan.Start(
+            """
+            <meta http-equiv="Content-Security-Policy" content="style-src 'self'">
+            <link rel="stylesheet" href="https://cdn.other.test/a.css">
+            """,
+            PageUrl);
+
+        Assert.NotNull(scan);
+        Assert.Empty(scan.Result.RawUrls(PreloadKind.StyleSheet));
+    }
+
+    /// <summary>
+    /// The nonce is carried through the scan for this case. Without it a policy of the form
+    /// <c>script-src 'nonce-…'</c> would refuse every prefetch, and the scan would silently do
+    /// nothing on exactly the pages that declare one.
+    /// </summary>
+    [Fact]
+    public void A_Nonced_Script_Is_Requested_Under_A_Nonce_Policy()
+    {
+        var csp = new ContentSecurityPolicy();
+        csp.Parse("script-src 'nonce-abc123'");
+
+        var scan = SpeculativePreloadScan.Start(
+            """
+            <script src="https://cdn.other.test/a.js" nonce="abc123"></script>
+            <script src="https://cdn.other.test/b.js"></script>
+            """,
+            PageUrl,
+            csp);
+
+        Assert.NotNull(scan);
+        Assert.Equal(["https://cdn.other.test/a.js"], scan.Result.RawUrls(PreloadKind.Script));
+    }
+
+    /// <summary>
+    /// Images and frames pass through unfiltered because <see cref="ContentSecurityPolicy"/> models
+    /// neither <c>img-src</c> nor <c>frame-src</c>. That is a match for the consume sites rather
+    /// than a hole opened here — but it is the assertion that turns into a filter the day those
+    /// directives are enforced anywhere.
+    /// </summary>
+    [Fact]
+    public void Families_This_Engine_Does_Not_Police_Are_Not_Policed_Here_Either()
+    {
+        var csp = new ContentSecurityPolicy();
+        csp.Parse("default-src 'self'");
+
+        var scan = SpeculativePreloadScan.Start(
+            """<img src="https://cdn.other.test/a.png">""",
+            PageUrl,
+            csp);
+
+        Assert.NotNull(scan);
+        Assert.Equal(["https://cdn.other.test/a.png"], scan.Result.RawUrls(PreloadKind.Image));
+    }
+
+    // ────────────── the exit gate ──────────────
+
+    /// <summary>
+    /// The global exit gate for every parallel path in the roadmap: the sequential setting must
+    /// reproduce the parallel output exactly. Here that is a document whose stylesheet is fetched
+    /// through the loader — with the scan the request is in flight before the parse starts, without
+    /// it the request is made after the sheet list is collected, and the rendered result is the
+    /// same because the scan changes only when a request starts.
+    /// </summary>
+    [Fact]
+    public void A_Linked_Stylesheet_Applies_Identically_With_And_Without_The_Scan()
+    {
+        var sheet = Path.Combine(_dir, "sheet.css");
+        File.WriteAllText(sheet, "#target { color: rgb(1, 2, 3); }");
+
+        var html = $$"""
+            <!DOCTYPE html>
+            <html><head><link rel="stylesheet" href="{{new Uri(sheet).AbsoluteUri}}"></head>
+            <body>
+            <div id="target">text</div>
+            <div id="result"></div>
+            <script>
+            document.getElementById('result').textContent =
+                window.getComputedStyle(document.getElementById('target')).color;
+            </script>
+            </body></html>
+            """;
+
+        var pageUrl = new Uri(Path.Combine(_dir, "page.html")).AbsoluteUri;
+
+        var withScan = Render(html, pageUrl, scanEnabled: true);
+        var withoutScan = Render(html, pageUrl, scanEnabled: false);
+
+        // The sheet was actually reached — a test that only compared two identical failures would
+        // pass against a loader that fetched nothing at all.
+        Assert.Contains("rgb(1, 2, 3)", withScan);
+        Assert.Equal(withoutScan, withScan);
+    }
+
+    private static string Render(string html, string pageUrl, bool scanEnabled)
+    {
+        var wasEnabled = SpeculativePreloadScan.Enabled;
+        try
+        {
+            SpeculativePreloadScan.Enabled = scanEnabled;
+            return CaptureService.ExecuteScriptsWithDom(html, pageUrl);
+        }
+        finally
+        {
+            SpeculativePreloadScan.Enabled = wasEnabled;
+        }
+    }
+}

--- a/src/Broiler.Cli/CaptureService.cs
+++ b/src/Broiler.Cli/CaptureService.cs
@@ -12,6 +12,7 @@ using Broiler.CSS;
 using Broiler.HtmlBridge;
 using Broiler.HtmlBridge.Logging;
 using Broiler.HtmlBridge.Scripting;
+using Broiler.HtmlBridge.Internal.Scripting;
 using Broiler.Media.Image;
 using Broiler.HtmlBridge.Dom;
 
@@ -447,12 +448,57 @@ public class CaptureService
     /// guaranteed order. All pending timers and rAF callbacks are flushed
     /// before serialisation.
     /// </summary>
+    /// <summary>
+    /// Starts the document's speculative preload scan (multithreading roadmap item #17) and returns
+    /// the prefetcher its worker fills, or <c>null</c> when no scan ran.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This host walks the script tags itself and fetched each external one <em>inline as it
+    /// reached it</em> — the serial round trips item #2 exists to remove, in a call site item #2
+    /// never reached, because the split it built lives in <c>ScriptExtractionService.ExtractAll</c>
+    /// and capture does its own extraction. The scan is what supplies the URL set early enough to
+    /// fix that: the whole set from one pass of the source, on a worker, before the loop below has
+    /// looked at the first tag.
+    /// </para>
+    /// <para>
+    /// <b>The prefetch key is derived exactly as the consume site derives it</b> — the raw
+    /// attribute value resolved against the page URL by the same
+    /// <see cref="UrlResolver"/> call <c>FetchExternalScript</c> makes. The scan also computes a
+    /// resolution of its own, against the document's <c>&lt;base href&gt;</c>, which is the more
+    /// correct answer and the wrong one to use here: a prefetch stored under a key the consumer
+    /// never asks for is not a saved round trip, it is a second one. Whether script <c>src</c>
+    /// should honour <c>&lt;base&gt;</c> is a separate question about the consume site.
+    /// </para>
+    /// <para>
+    /// Nothing is lost if the worker is slower than this thread: <c>Consume</c> starts the fetch
+    /// itself when the scan has not reached that URL yet, and the two collapse onto one request.
+    /// </para>
+    /// </remarks>
+    private static SubResourcePrefetcher? StartScriptPrefetch(string html, string url, ContentSecurityPolicy? csp)
+    {
+        var prefetcher = new SubResourcePrefetcher(
+            resolved => ScriptExtractionService.FetchExternalScript(resolved, url));
+
+        var scan = SpeculativePreloadScan.Start(
+            html,
+            url,
+            csp,
+            result => prefetcher.Prefetch(
+                result.RawUrls(PreloadKind.Script)
+                    .Select(raw => UrlResolver.Resolve(raw, url)?.AbsoluteUri)
+                    .OfType<string>()));
+
+        return scan is null ? null : prefetcher;
+    }
+
     internal static string ExecuteScriptsWithDom(string html, string url, string? localResourceBasePath = null)
     {
         var scripts = new List<string>();
         var deferredScripts = new List<string>();
         var moduleRoots = new List<string>();
         var csp = ContentSecurityPolicy.FromHtml(html);
+        var scriptPrefetcher = StartScriptPrefetch(html, url, csp);
         foreach (Match match in AnyScriptPattern.Matches(html))
         {
             var attrs = match.Groups["attrs"].Value;
@@ -482,7 +528,10 @@ public class CaptureService
                     if (csp != null && !csp.AllowsExternalScript(srcUri, url, nonce))
                         continue;
 
-                    var fetched = FetchExternalScript(srcUri, url);
+                    // Consume side of item #2's split. Identical resolution and identical result;
+                    // the difference is that the preload scan has had this request in flight since
+                    // before the loop started, instead of it beginning here, one script at a time.
+                    var fetched = ScriptExtractionService.FetchExternalScript(srcUri, url, scriptPrefetcher);
                     if (!string.IsNullOrEmpty(fetched))
                         scriptContent = fetched;
                 }

--- a/src/Broiler.HtmlBridge.Core/Scripting/PreloadScanner.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/PreloadScanner.cs
@@ -1,0 +1,366 @@
+using Broiler.Dom.Html;
+using Broiler.HtmlBridge.Internal.Scripting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Broiler.HtmlBridge;
+
+/// <summary>The family of sub-resource a <see cref="PreloadCandidate"/> belongs to.</summary>
+/// <remarks>
+/// The families are the ones with a distinct <em>consume</em> site in the bridge, because a prefetch
+/// is only useful if the site that later blocks on the resource looks it up under the same key. They
+/// are not a taxonomy of HTML elements.
+/// </remarks>
+public enum PreloadKind
+{
+    /// <summary>An external classic or module script (<c>&lt;script src&gt;</c>, <c>&lt;link rel=modulepreload&gt;</c>).</summary>
+    Script,
+
+    /// <summary>An external stylesheet (<c>&lt;link rel=stylesheet&gt;</c>).</summary>
+    StyleSheet,
+
+    /// <summary>An image (<c>&lt;img src&gt;</c>, <c>&lt;input type=image src&gt;</c>).</summary>
+    Image,
+
+    /// <summary>A sub-document or plugin resource (<c>&lt;iframe&gt;</c>, <c>&lt;frame&gt;</c>, <c>&lt;object data&gt;</c>, <c>&lt;embed src&gt;</c>).</summary>
+    Frame,
+}
+
+/// <summary>
+/// One sub-resource the document names, in both of the forms a consume site may key it by.
+/// </summary>
+/// <param name="Kind">Which family the resource belongs to.</param>
+/// <param name="RawUrl">
+/// The attribute value exactly as written. Some consume sites key by this — the stylesheet path
+/// passes the raw <c>href</c> straight to the loader — and a prefetch stored under a differently
+/// normalized key is never consumed, so it doubles the requests instead of overlapping them.
+/// </param>
+/// <param name="ResolvedUrl">
+/// The absolute URL the raw one resolves to against the document base, or <c>null</c> when it
+/// cannot be resolved (a relative URL in a document with no base). The script path keys by this.
+/// </param>
+/// <param name="Nonce">
+/// The element's <c>nonce</c> attribute, carried so a Content Security Policy check made before the
+/// DOM exists can reach the same verdict as the one the consume site makes with the element in hand.
+/// Without it a policy of the form <c>script-src 'nonce-…'</c> would refuse every prefetch and the
+/// scan would silently do nothing on exactly the pages that declare one.
+/// </param>
+public readonly record struct PreloadCandidate(
+    PreloadKind Kind,
+    string RawUrl,
+    string? ResolvedUrl,
+    string? Nonce = null);
+
+/// <summary>
+/// What one scan of a document found: its base URL and the sub-resources it names, in document
+/// order.
+/// </summary>
+public sealed class PreloadScanResult
+{
+    internal static readonly PreloadScanResult Empty = new(null, []);
+
+    internal PreloadScanResult(string? documentBaseUrl, IReadOnlyList<PreloadCandidate> candidates)
+    {
+        DocumentBaseUrl = documentBaseUrl;
+        Candidates = candidates;
+    }
+
+    /// <summary>
+    /// The URL relative references in this document resolve against — the first
+    /// <c>&lt;base href&gt;</c> resolved against the page URL, or the page URL when there is none.
+    /// </summary>
+    public string? DocumentBaseUrl { get; }
+
+    /// <summary>Every candidate found, in document order, deduplicated by kind and raw URL.</summary>
+    public IReadOnlyList<PreloadCandidate> Candidates { get; }
+
+    /// <summary>The raw attribute values of one kind, in document order.</summary>
+    public IReadOnlyList<string> RawUrls(PreloadKind kind) =>
+        [.. Candidates.Where(c => c.Kind == kind).Select(c => c.RawUrl)];
+
+    /// <summary>
+    /// The resolved absolute URLs of one kind, in document order. A candidate that could not be
+    /// resolved is dropped rather than passed through unresolved: an unresolvable URL is one no
+    /// fetch could have been issued for either.
+    /// </summary>
+    public IReadOnlyList<string> ResolvedUrls(PreloadKind kind) =>
+        [.. Candidates.Where(c => c.Kind == kind && c.ResolvedUrl is not null).Select(c => c.ResolvedUrl!)];
+}
+
+/// <summary>
+/// Finds every sub-resource URL an HTML document names, without building a DOM. Multithreading
+/// roadmap item #17 — the speculative preload scan.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The roadmap's shape for item #17 is "a worker scans raw bytes for <c>src</c>/<c>href</c> while
+/// the main parse runs, feeding #2". This type is the scan; <see cref="SpeculativePreloadScan"/> is
+/// the worker. It exists because the two remaining sub-resource families of item #2 — sub-documents
+/// and <c>fetch()</c>/XHR — have no point at which their URL set is known before it is consumed: a
+/// frame's URL becomes known when the element is reached, which is the moment it is loaded. A
+/// speculative scan is the only thing that can produce a URL set earlier than the parse does, which
+/// is why the roadmap calls it their <em>only</em> source of a prefetch trigger rather than an
+/// amplifier.
+/// </para>
+/// <para>
+/// <b>It tokenizes rather than pattern-matching bytes.</b> The roadmap says "scans raw bytes", and a
+/// regex over the buffer is what that phrasing suggests, but <see cref="HtmlTokenizer"/> is already
+/// available, is a pure function of an immutable string, and gets the cases a pattern gets wrong:
+/// a <c>&lt;img src&gt;</c> inside a comment or inside a <c>&lt;script&gt;</c> body is not a
+/// resource, a <c>&gt;</c> inside a quoted attribute does not end a tag, and attribute names are
+/// matched from the parsed map rather than by position. Speculating a request the document never
+/// makes is not free — it is a round trip charged to the origin — so the accuracy is worth the pass.
+/// </para>
+/// <para>
+/// <b>What it deliberately does not find, and why.</b>
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <b><c>srcset</c> and <c>&lt;picture&gt;</c>.</b> Which candidate a browser fetches depends on the
+/// viewport and the device pixel ratio, neither of which a scan running before layout knows.
+/// Preloading all of them would put <em>n</em> requests on the wire for one image, which is worse
+/// than the serial fetch this is trying to remove.
+/// </description></item>
+/// <item><description>
+/// <b>Anything inside <c>&lt;template&gt;</c>.</b> Template content is inert: its resources are not
+/// fetched unless the fragment is cloned into the document, which is a script decision this scan
+/// cannot predict.
+/// </description></item>
+/// <item><description>
+/// <b>Anything inside <c>&lt;noscript&gt;</c>.</b> Broiler runs scripts, so the parser treats a
+/// <c>noscript</c> body as text and nothing in it is ever loaded.
+/// </description></item>
+/// <item><description>
+/// <b>Non-fetchable URL schemes</b> — <c>data:</c>, <c>about:</c>, <c>javascript:</c>,
+/// <c>blob:</c> — and bare fragments. There is no round trip to overlap.
+/// </description></item>
+/// <item><description>
+/// <b>CSS <c>url()</c> references.</b> They are inside a stylesheet this scan has not fetched yet;
+/// discovering them is a second scan of the sheet, which belongs with whoever consumes it.
+/// </description></item>
+/// </list>
+/// <para>
+/// <b>Base resolution happens after the pass, not during it.</b> HTML §4.2.3 makes the first
+/// <c>&lt;base href&gt;</c> in document order the base for the <em>whole</em> document, including
+/// the resources declared above it, so a scan that resolved as it went would resolve the head's
+/// resources against the wrong base whenever <c>&lt;base&gt;</c> came late. The pass collects raw
+/// values and resolves them at the end; the pass is microseconds and the requests it triggers are
+/// milliseconds, so there is nothing to gain by resolving early.
+/// </para>
+/// </remarks>
+public static class PreloadScanner
+{
+    /// <summary>
+    /// Tag-name prefixes that could introduce a candidate. Used by
+    /// <see cref="MightContainCandidates"/> to decide whether the tokenizer pass is worth starting
+    /// at all.
+    /// </summary>
+    private static readonly string[] CandidateMarkers =
+        ["<script", "<link", "<img", "<iframe", "<frame", "<object", "<embed", "<input"];
+
+    /// <summary>
+    /// A cheap, deliberately over-permissive test for whether a document can name any sub-resource.
+    /// False means the tokenizer pass would certainly find nothing, so a document with no external
+    /// resources — which most of the WPT corpus is — pays a handful of vectorized substring
+    /// searches instead of a full tokenization on a pool thread.
+    /// </summary>
+    public static bool MightContainCandidates(string? html) =>
+        !string.IsNullOrEmpty(html) &&
+        CandidateMarkers.Any(marker => html.Contains(marker, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Scans <paramref name="html"/> and returns the sub-resources it names, resolved against the
+    /// document's own <c>&lt;base href&gt;</c> where it has one and <paramref name="pageUrl"/>
+    /// otherwise.
+    /// </summary>
+    /// <param name="html">The document source. Never mutated; this is a pure function of it.</param>
+    /// <param name="pageUrl">The document's own URL, used as the base when it declares none.</param>
+    public static PreloadScanResult Scan(string? html, string? pageUrl)
+    {
+        if (string.IsNullOrEmpty(html))
+            return PreloadScanResult.Empty;
+
+        var raw = new List<PreloadCandidate>();
+        var seen = new HashSet<(PreloadKind, string)>();
+        string? baseHref = null;
+
+        // Depth counters rather than booleans: `<template><template>` is legal, and an inner
+        // element's end tag must not re-open the outer one's contents to the scan.
+        var inertDepth = 0;
+
+        foreach (var token in new HtmlTokenizer().Tokenize(html))
+        {
+            if (token.Type == TokenType.EndTag)
+            {
+                if (inertDepth > 0 && IsInertContainer(token.Name))
+                    inertDepth--;
+                continue;
+            }
+
+            if (token.Type != TokenType.StartTag || token.Name is null)
+                continue;
+
+            if (IsInertContainer(token.Name))
+            {
+                // A self-closing `<template/>` has no contents to skip. The tokenizer reports the
+                // syntax faithfully even though HTML ignores it on a non-void element, and treating
+                // it as an open container would swallow the rest of the document.
+                if (!token.SelfClosing)
+                    inertDepth++;
+                continue;
+            }
+
+            if (inertDepth > 0)
+                continue;
+
+            if (baseHref is null &&
+                string.Equals(token.Name, "base", StringComparison.OrdinalIgnoreCase) &&
+                Attribute(token, "href") is { Length: > 0 } declaredBase)
+            {
+                baseHref = declaredBase;
+                continue;
+            }
+
+            if (CandidateFor(token) is not { } candidate)
+                continue;
+
+            if (seen.Add((candidate.Kind, candidate.RawUrl)))
+                raw.Add(candidate with { Nonce = Attribute(token, "nonce") });
+        }
+
+        var documentBase = ResolveDocumentBase(baseHref, pageUrl);
+        return new PreloadScanResult(
+            documentBase,
+            [.. raw.Select(c => c with { ResolvedUrl = UrlResolver.Resolve(c.RawUrl, documentBase)?.AbsoluteUri })]);
+    }
+
+    /// <summary>
+    /// Elements whose contents are never loaded: <c>&lt;template&gt;</c> is inert until cloned, and
+    /// a <c>&lt;noscript&gt;</c> body is text in a scripting-enabled document.
+    /// </summary>
+    private static bool IsInertContainer(string? name) =>
+        string.Equals(name, "template", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(name, "noscript", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Classifies one start tag, or returns <c>null</c> when it names no fetchable sub-resource.
+    /// The <see cref="PreloadCandidate.ResolvedUrl"/> is filled in by the caller once the whole
+    /// document's base is known.
+    /// </summary>
+    private static PreloadCandidate? CandidateFor(HtmlToken tag)
+    {
+        // Switched on directly rather than lower-cased first: HtmlTokenizer lower-cases every tag
+        // name as it reads it, and a scan over a large document is one of the few places where an
+        // allocation per element would be worth noticing.
+        switch (tag.Name)
+        {
+            case "script":
+                return Candidate(PreloadKind.Script, Attribute(tag, "src"));
+
+            case "link":
+                return LinkCandidate(tag);
+
+            case "img":
+                return Candidate(PreloadKind.Image, Attribute(tag, "src"));
+
+            case "input":
+                return string.Equals(Attribute(tag, "type"), "image", StringComparison.OrdinalIgnoreCase)
+                    ? Candidate(PreloadKind.Image, Attribute(tag, "src"))
+                    : null;
+
+            case "iframe":
+                // `srcdoc` wins over `src` (HTML §4.8.5), and it is inline content with no request
+                // to overlap.
+                return Attribute(tag, "srcdoc") is not null
+                    ? null
+                    : Candidate(PreloadKind.Frame, Attribute(tag, "src"));
+
+            case "frame":
+            case "embed":
+                return Candidate(PreloadKind.Frame, Attribute(tag, "src"));
+
+            case "object":
+                return Candidate(PreloadKind.Frame, Attribute(tag, "data"));
+
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// Classifies a <c>&lt;link&gt;</c> by its <c>rel</c> keywords. <c>rel</c> is a space-separated
+    /// token list, so <c>rel="alternate stylesheet"</c> and <c>rel="preload"</c> are both matched by
+    /// token rather than by string equality.
+    /// </summary>
+    /// <remarks>
+    /// A <c>preload</c> whose <c>as</c> names a family this scanner does not model is skipped rather
+    /// than guessed at: the whole point of <c>as</c> is that the request's headers and priority
+    /// differ per destination, and a prefetch issued under the wrong one is not the request the
+    /// consume site will make.
+    /// </remarks>
+    private static PreloadCandidate? LinkCandidate(HtmlToken tag)
+    {
+        var href = Attribute(tag, "href");
+        if (href is null)
+            return null;
+
+        var rel = Attribute(tag, "rel");
+        if (rel is null)
+            return null;
+
+        var keywords = rel.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+
+        if (keywords.Contains("stylesheet", StringComparer.OrdinalIgnoreCase))
+            return Candidate(PreloadKind.StyleSheet, href);
+
+        if (keywords.Contains("modulepreload", StringComparer.OrdinalIgnoreCase))
+            return Candidate(PreloadKind.Script, href);
+
+        if (!keywords.Contains("preload", StringComparer.OrdinalIgnoreCase))
+            return null;
+
+        return Attribute(tag, "as")?.ToLowerInvariant() switch
+        {
+            "script" => Candidate(PreloadKind.Script, href),
+            "style" => Candidate(PreloadKind.StyleSheet, href),
+            "image" => Candidate(PreloadKind.Image, href),
+            _ => null,
+        };
+    }
+
+    private static PreloadCandidate? Candidate(PreloadKind kind, string? url) =>
+        IsFetchable(url) ? new PreloadCandidate(kind, url!, ResolvedUrl: null) : null;
+
+    /// <summary>
+    /// Whether a URL names something a round trip could be saved on. Inline forms carry their own
+    /// payload, <c>javascript:</c> is evaluated rather than fetched, a <c>blob:</c> is already in
+    /// memory, and a bare fragment addresses the current document.
+    /// </summary>
+    private static bool IsFetchable(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url) || url[0] == '#')
+            return false;
+
+        foreach (var scheme in (ReadOnlySpan<string>)["data:", "about:", "javascript:", "blob:"])
+        {
+            if (url.StartsWith(scheme, StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// The base every relative URL in the document resolves against. A <c>&lt;base href&gt;</c> may
+    /// itself be relative, so it is resolved against the page URL first; one that cannot be resolved
+    /// leaves the page URL in place, which is what the document would fall back to.
+    /// </summary>
+    private static string? ResolveDocumentBase(string? baseHref, string? pageUrl) =>
+        baseHref is null
+            ? pageUrl
+            : UrlResolver.Resolve(baseHref, pageUrl)?.AbsoluteUri ?? pageUrl;
+
+    private static string? Attribute(HtmlToken tag, string name) =>
+        tag.Attributes.TryGetValue(name, out var value) ? value : null;
+}

--- a/src/Broiler.HtmlBridge.Core/Scripting/SpeculativePreloadScan.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/SpeculativePreloadScan.cs
@@ -1,0 +1,214 @@
+using Broiler.HtmlBridge.Scripting;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Broiler.HtmlBridge;
+
+/// <summary>
+/// Runs a <see cref="PreloadScanner"/> pass on a worker thread while the main thread parses the same
+/// document, and hands what it finds to a sink that issues the requests. Multithreading roadmap
+/// item #17.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>What this buys, precisely.</b> Item #2 built the prefetch/consume split and wired it to the
+/// two families whose URL set is already known at a single point: external scripts (the script scan)
+/// and <c>&lt;link&gt;</c> stylesheets (the collected sheet list). Both of those points are reached
+/// <em>after</em> work that does not depend on them — the stylesheet set is collected once the whole
+/// document has been parsed and the style elements gathered, so a page's sheet requests start after
+/// the parse rather than during it. This starts them from the raw source instead, before the parse
+/// has produced a single node. The parse is CPU and the fetch is latency, so the two overlap
+/// completely; nothing here makes the parse faster, and it is not meant to.
+/// </para>
+/// <para>
+/// <b>Safe by construction, and that is the reason the roadmap rates it low risk.</b> The worker
+/// reads one immutable string and writes nothing the document owns. It builds a list of URLs and
+/// calls a sink; the sink's only job is to start requests, which the consume sites were going to
+/// start anyway, in the same order, under the same keys. No DOM node, no ambient slot and no cache
+/// of the render path is touched, so the ambient-state contract
+/// (<c>docs/architecture/multithreading-static-state.md</c>) has nothing to establish here — this
+/// worker never renders.
+/// </para>
+/// <para>
+/// <b>Nothing waits on it.</b> A caller starts a scan and carries on; the result is available to
+/// whoever wants it via <see cref="Result"/>, which blocks, but the wiring on the render path does
+/// not read it at all — the sink runs on the worker. A scan that never finishes before the document
+/// does costs one pool thread and is thrown away, and a scan that throws is swallowed: a
+/// speculation that fails must leave the document exactly as it would have been without it, which
+/// is a document whose consume sites each fetch their own resource inline.
+/// </para>
+/// <para>
+/// <b>The exit gate.</b> <c>BROILER_PRELOAD_SCAN=0</c> turns the scan off entirely, and that is the
+/// sequential path rather than an approximation of it: with no scan, no prefetcher entry exists for
+/// any speculated URL and every consume site takes the branch it took before this type existed.
+/// Output is identical because the scan changes only when a request <em>starts</em>, never which
+/// request is made or what is done with the bytes.
+/// </para>
+/// </remarks>
+public sealed class SpeculativePreloadScan
+{
+    /// <summary>
+    /// Environment variable that disables the scan. Any of <c>0</c>, <c>false</c> and <c>off</c>
+    /// (case-insensitive) turns it off; anything else, including absence, leaves it on.
+    /// </summary>
+    public const string EnabledEnvironmentVariable = "BROILER_PRELOAD_SCAN";
+
+    private static bool _enabled = ReadConfiguredEnabled();
+    private static long _scansStarted;
+    private static long _scansSkipped;
+
+    private readonly Task<PreloadScanResult> _scan;
+
+    private SpeculativePreloadScan(Task<PreloadScanResult> scan) => _scan = scan;
+
+    /// <summary>
+    /// Whether documents get a speculative scan. Settable so a determinism harness can compare the
+    /// two paths in one process; the default comes from
+    /// <see cref="EnabledEnvironmentVariable"/>.
+    /// </summary>
+    public static bool Enabled
+    {
+        get => _enabled;
+        set => _enabled = value;
+    }
+
+    /// <summary>Scans actually started. For tests and the measurement harness.</summary>
+    public static long ScansStarted => Interlocked.Read(ref _scansStarted);
+
+    /// <summary>
+    /// Scans not started because the document plainly names no sub-resource
+    /// (<see cref="PreloadScanner.MightContainCandidates"/>) or the feature is off. Counted rather
+    /// than inferred, because "the scan found nothing" and "the scan never ran" are different
+    /// claims and only one of them costs a thread.
+    /// </summary>
+    public static long ScansSkipped => Interlocked.Read(ref _scansSkipped);
+
+    /// <summary>Resets the counters. For tests, which assert on them.</summary>
+    public static void ResetCounters()
+    {
+        Interlocked.Exchange(ref _scansStarted, 0);
+        Interlocked.Exchange(ref _scansSkipped, 0);
+    }
+
+    /// <summary>
+    /// Starts a scan of <paramref name="html"/> on a worker and returns immediately. Returns
+    /// <c>null</c> when no scan was started — the feature is off, or the source names nothing
+    /// fetchable — so a caller that wants the result can tell "nothing found" from "never ran".
+    /// </summary>
+    /// <param name="html">The document source, as handed to the parser.</param>
+    /// <param name="pageUrl">The document's URL; the base for relative references and for CSP.</param>
+    /// <param name="csp">
+    /// The host's policy, if it configured one. It is checked <em>in addition to</em> any
+    /// <c>&lt;meta http-equiv&gt;</c> policy the source declares, so a resource either policy
+    /// forbids is never speculated on: putting a request on the wire is the thing the policy stops,
+    /// and "fetched but not used" is not a defensible reading of it.
+    /// </param>
+    /// <param name="onCompleted">
+    /// Runs on the worker as soon as the scan finishes, which is the whole point — it is what starts
+    /// the requests while the parse is still running. Exceptions from it are swallowed with the
+    /// rest of the scan.
+    /// </param>
+    public static SpeculativePreloadScan? Start(
+        string? html,
+        string? pageUrl,
+        ContentSecurityPolicy? csp = null,
+        Action<PreloadScanResult>? onCompleted = null)
+    {
+        if (!_enabled || !PreloadScanner.MightContainCandidates(html))
+        {
+            Interlocked.Increment(ref _scansSkipped);
+            return null;
+        }
+
+        Interlocked.Increment(ref _scansStarted);
+
+        return new SpeculativePreloadScan(Task.Run(() =>
+        {
+            PreloadScanResult result;
+            try
+            {
+                result = Authorized(PreloadScanner.Scan(html, pageUrl), html!, pageUrl, csp);
+            }
+            catch
+            {
+                // A speculation that fails leaves the document exactly as it would have been: every
+                // consume site fetches its own resource inline, as it did before this type existed.
+                return PreloadScanResult.Empty;
+            }
+
+            try
+            {
+                onCompleted?.Invoke(result);
+            }
+            catch
+            {
+                // Same contract: a sink that throws must not take the document with it. The result
+                // is still returned, so a caller reading it directly is unaffected.
+            }
+
+            return result;
+        }));
+    }
+
+    /// <summary>
+    /// The scan's findings, blocking until the worker finishes. The render path does not call this —
+    /// the sink is what does the useful work — but a consumer that wants the URL set (item #8's
+    /// image decode, item #16's compile-ahead queue) reads it here.
+    /// </summary>
+    public PreloadScanResult Result => _scan.GetAwaiter().GetResult();
+
+    /// <summary>Whether the worker has finished. Never blocks.</summary>
+    public bool IsCompleted => _scan.IsCompleted;
+
+    /// <summary>
+    /// Drops the candidates a Content Security Policy forbids, applying exactly the checks the
+    /// consume sites apply — <c>AllowsExternalScript</c> for scripts and
+    /// <c>AllowsExternalStyle</c> for stylesheets, against the raw attribute value, the page URL and
+    /// the element's own nonce.
+    /// </summary>
+    /// <remarks>
+    /// Images and sub-documents are passed through unfiltered because
+    /// <see cref="ContentSecurityPolicy"/> models neither <c>img-src</c> nor <c>frame-src</c>. That
+    /// is a match for the consume sites rather than a gap opened here: a policy this engine does not
+    /// enforce on the load is not one a prefetch can be accused of evading. It becomes a filter to
+    /// add here the day those directives are enforced anywhere.
+    /// </remarks>
+    private static PreloadScanResult Authorized(
+        PreloadScanResult scanned,
+        string html,
+        string? pageUrl,
+        ContentSecurityPolicy? configured)
+    {
+        var declared = ContentSecurityPolicy.FromHtml(html);
+        if (configured is null && declared is null)
+            return scanned;
+
+        var allowed = new List<PreloadCandidate>(scanned.Candidates.Count);
+        foreach (var candidate in scanned.Candidates)
+        {
+            if (Allows(configured, candidate, pageUrl) && Allows(declared, candidate, pageUrl))
+                allowed.Add(candidate);
+        }
+
+        return new PreloadScanResult(scanned.DocumentBaseUrl, allowed);
+    }
+
+    private static bool Allows(ContentSecurityPolicy? csp, PreloadCandidate candidate, string? pageUrl) =>
+        csp is null || candidate.Kind switch
+        {
+            PreloadKind.Script => csp.AllowsExternalScript(candidate.RawUrl, pageUrl, candidate.Nonce),
+            PreloadKind.StyleSheet => csp.AllowsExternalStyle(candidate.RawUrl, pageUrl, candidate.Nonce),
+            _ => true,
+        };
+
+    private static bool ReadConfiguredEnabled()
+    {
+        var configured = Environment.GetEnvironmentVariable(EnabledEnvironmentVariable);
+        return string.IsNullOrWhiteSpace(configured) ||
+            !(configured.Equals("0", StringComparison.Ordinal) ||
+              configured.Equals("false", StringComparison.OrdinalIgnoreCase) ||
+              configured.Equals("off", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Broiler.HtmlBridge.Core/Scripting/UrlResolver.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/UrlResolver.cs
@@ -17,7 +17,7 @@ internal static class UrlResolver
     /// </summary>
     public static Uri? Resolve(string url, string? baseUrl)
     {
-        if (Uri.TryCreate(url, UriKind.Absolute, out var absolute))
+        if (!IsPathAbsoluteReference(url) && Uri.TryCreate(url, UriKind.Absolute, out var absolute))
             return absolute;
 
         if (!string.IsNullOrWhiteSpace(baseUrl) &&
@@ -27,4 +27,22 @@ internal static class UrlResolver
 
         return null;
     }
+
+    /// <summary>
+    /// Whether <paramref name="url"/> is a path-absolute (<c>/style.css</c>) or scheme-relative
+    /// (<c>//cdn.example/style.css</c>) reference, both of which must resolve against the base
+    /// rather than stand on their own.
+    /// </summary>
+    /// <remarks>
+    /// RFC 3986 requires a scheme for an absolute URI, so neither form is one — but on Unix
+    /// <c>Uri.TryCreate("/style.css", UriKind.Absolute, …)</c> succeeds anyway and yields
+    /// <c>file:///style.css</c>, because a leading slash is a valid absolute <em>file path</em>
+    /// there. Every caller of this resolver was therefore taking a document's root-relative
+    /// references off the page's own origin and pointing them at the filesystem root: a
+    /// <c>&lt;script src="/app.js"&gt;</c> on an <c>https:</c> page resolved to
+    /// <c>file:///app.js</c>, and the CSP source matcher compared that against the policy. The
+    /// check is cheap and the two forms are the whole of what the platform gets wrong here.
+    /// </remarks>
+    private static bool IsPathAbsoluteReference(string? url) =>
+        url is { Length: > 0 } && (url[0] == '/' || url[0] == '\\');
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.HtmlParsing.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.HtmlParsing.cs
@@ -20,6 +20,13 @@ public sealed partial class DomBridge
 
     private void ParseHtml(string html)
     {
+        // Multithreading roadmap item #17. Everything from here to BuildDocumentTree is CPU the
+        // document's sub-resource fetches could have been overlapping with, and until now they did
+        // not start until the parse had finished and the sheet list had been collected. Start the
+        // speculative scan first, so its worker is issuing requests while this thread tears the old
+        // document down and builds the new one.
+        StartSpeculativePreloadScan(html);
+
         // Parse/re-parse tears down and rebuilds the live tree wholesale (ClearChildren + build);
         // these are document-construction mutations, not script mutations, so suppress observer
         // delivery for them (matching the prior explicit channel, which parse never drove).

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.PreloadScan.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.PreloadScan.cs
@@ -1,0 +1,86 @@
+namespace Broiler.HtmlBridge;
+
+/// <summary>
+/// The document's speculative preload scan — multithreading roadmap item #17. A worker reads the
+/// raw source for the sub-resources the document names and starts their requests while this thread
+/// parses the same source into a tree.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>What it changes, and what it deliberately does not.</b> Item #2 already split every
+/// sub-resource call site into prefetch and consume, so nothing here changes which request is made,
+/// which key it is stored under, or what the consuming site does with the bytes. It changes only
+/// <em>when the request starts</em>: the stylesheet set used to be handed over once the whole
+/// document had been parsed and its <c>&lt;style&gt;</c>/<c>&lt;link&gt;</c> elements collected, and
+/// is now handed over from the source text before the parse begins.
+/// </para>
+/// <para>
+/// <b>Only stylesheets are wired to a sink, and the other three families are not an oversight.</b>
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <b>Scripts</b> already have a prefetcher of their own, created by
+/// <c>ScriptExtractionService.CreateScriptPrefetcher</c> from the host's own pre-parse scan — the
+/// host needs the script list itself, so it pays for that pass whether or not this scan runs.
+/// Adding a second prefetcher keyed the same way would issue the same requests twice under two
+/// caches. The scan carries the script URLs for item #16 (compile-ahead), which is the consumer
+/// that does not exist yet.
+/// </description></item>
+/// <item><description>
+/// <b>Sub-documents</b> consume through a policy chain that yields <c>(content, contentType)</c> —
+/// local base path, WPT host mapping, <c>file://</c>, MIME sniffing — and the text prefetcher
+/// stores a <c>string</c>. Wiring them means a prefetcher over that tuple, not a call added here,
+/// and on the paths this repository measures a frame resolves to a disk read rather than a round
+/// trip, so it would be machinery bought for nothing measurable.
+/// </description></item>
+/// <item><description>
+/// <b>Images</b> are item #8, whose consume site is <c>ImageLoadHandler</c> in <c>Broiler.HTML</c>.
+/// The roadmap's §6 says #8 needs this scan to supply its URL set, and
+/// <see cref="SpeculativePreloadResult"/> is where it will read it.
+/// </description></item>
+/// </list>
+/// </remarks>
+public sealed partial class DomBridge
+{
+    private SpeculativePreloadScan? _preloadScan;
+
+    /// <summary>
+    /// The scan's findings, blocking until its worker finishes, or <c>null</c> when no scan ran —
+    /// the feature is off, or the source named nothing fetchable. Nothing on the render path reads
+    /// this: the sink does the useful work on the worker. It is the seam items #8 and #16 consume.
+    /// </summary>
+    internal PreloadScanResult? SpeculativePreloadResult => _preloadScan?.Result;
+
+    /// <summary>
+    /// Starts the scan for <paramref name="html"/> and returns at once. Called first thing in
+    /// <c>ParseHtml</c>, so the worker overlaps the whole of the teardown-and-rebuild that follows.
+    /// </summary>
+    /// <remarks>
+    /// A re-parse starts a second scan without waiting for the first. The two share one
+    /// <c>ResourceLoader</c>, so the worst case is that the outgoing document's sheets are requested
+    /// once more than they would otherwise have been; the prefetcher collapses duplicate URLs onto
+    /// one request, so in practice the second scan's sink finds the entries already there.
+    /// </remarks>
+    private void StartSpeculativePreloadScan(string html) =>
+        _preloadScan = SpeculativePreloadScan.Start(
+            html,
+            _pageUrl,
+            Csp,
+            // Runs on the worker: this is the call that puts the requests on the wire while the
+            // parse is still running, and the only reason the scan is worth doing at all.
+            //
+            // The RAW href is what is handed over, not the resolved URL, because the consuming site
+            // (`FetchExternalStylesheet`) passes the raw href to the loader — a prefetch stored
+            // under a normalized key would never be consumed and would double the requests instead
+            // of overlapping them. `minimumToOverlap: 1` because these requests overlap the parse
+            // rather than each other, so a document with one sheet still gains.
+            result =>
+            {
+                // Best-effort, and a racy read of `_disposed` is the right strength for it: losing
+                // the race issues a request whose bytes are discarded, which is what a prefetch for
+                // a resource the document never reaches already costs. A lock here would be
+                // synchronising the main thread's teardown against a speculation.
+                if (!_disposed)
+                    _resources.Prefetch(result.RawUrls(PreloadKind.StyleSheet), minimumToOverlap: 1);
+            });
+}

--- a/src/Broiler.HtmlBridge.Dom/Runtime/ResourceLoader.cs
+++ b/src/Broiler.HtmlBridge.Dom/Runtime/ResourceLoader.cs
@@ -79,24 +79,49 @@ internal sealed class ResourceLoader
     /// reached, and a URL that is consumed without having been prefetched takes the direct path.
     /// </para>
     /// <para>
-    /// A single URL is not worth prefetching — there is nothing to overlap it with — so the caller
-    /// is expected to hand over the whole set it knows about at once.
+    /// <paramref name="minimumToOverlap"/> is how many URLs make the call worth making, and the
+    /// answer depends on what the requests are being overlapped <em>with</em>. The post-parse
+    /// caller (the collected sheet list) overlaps them only with each other, so one URL buys
+    /// nothing and the default is two. The speculative preload scan (item #17) overlaps them with
+    /// the parse itself, which has not started when it calls, so there one URL is worth issuing and
+    /// it passes 1.
     /// </para>
     /// </remarks>
-    public void Prefetch(IReadOnlyCollection<string> urls)
+    public void Prefetch(IReadOnlyCollection<string> urls, int minimumToOverlap = 2)
     {
-        if (urls.Count < 2)
+        if (urls.Count < minimumToOverlap)
             return;
 
-        _prefetcher ??= new SubResourcePrefetcher(LoadTextDirect);
-        _prefetcher.Prefetch(urls.Where(url => Uri.TryCreate(url, UriKind.Absolute, out _)));
+        Prefetcher().Prefetch(urls.Where(url => Uri.TryCreate(url, UriKind.Absolute, out _)));
     }
+
+    /// <summary>
+    /// The document's prefetcher, created on first use.
+    /// </summary>
+    /// <remarks>
+    /// <b>Published atomically, because the callers are no longer all on one thread.</b> Item #17's
+    /// scan calls <see cref="Prefetch"/> from a worker while the parse it overlaps may reach the
+    /// post-parse stylesheet call on the main thread, so <c>??=</c> here would be the exact lazy-init
+    /// race the Phase 2 findings record (§1): two prefetchers built, one published, and every
+    /// request issued into the one that lost. The loser is discarded before it has issued anything —
+    /// <see cref="SubResourcePrefetcher"/> starts requests in <c>Prefetch</c>, not in its
+    /// constructor — so the cost of losing is an allocation.
+    /// </remarks>
+    private SubResourcePrefetcher Prefetcher() =>
+        _prefetcher ??
+        Interlocked.CompareExchange(ref _prefetcher, new SubResourcePrefetcher(LoadTextDirect), null) ??
+        _prefetcher;
 
     /// <summary>
     /// Requests in flight for this document, created on the first <see cref="Prefetch"/>. Null
     /// until then, so a document that never prefetches carries no extra machinery at all.
     /// </summary>
-    private SubResourcePrefetcher? _prefetcher;
+    /// <remarks>
+    /// <c>volatile</c> so the read in <see cref="LoadText"/> — a plain field read on the main
+    /// thread — cannot observe the reference before the constructor's writes that
+    /// <see cref="Prefetcher"/> published from a worker.
+    /// </remarks>
+    private volatile SubResourcePrefetcher? _prefetcher;
 
     /// <summary>
     /// Reads a local file <paramref name="path"/> as a sub-resource, applying the file read + MIME policy


### PR DESCRIPTION
Implements multithreading roadmap item #17: a speculative preload scan that discovers sub-resource URLs from raw HTML source on a worker thread while the main thread parses the document, enabling network requests to overlap with parsing rather than starting after it completes.

## Summary

This change adds a worker-based preload scanner that reads HTML source to find stylesheet, script, image, and frame URLs before the DOM is built. The scan runs concurrently with parsing, allowing requests to be issued earlier and overlapped with parse time rather than serialized after it.

## Key Changes

- **`PreloadScanner`** — Pure function that tokenizes HTML to find sub-resource URLs without building a DOM. Handles `<link>`, `<script>`, `<img>`, `<iframe>`, `<frame>`, `<object>`, `<embed>`, and `<input type=image>` elements. Deliberately excludes `srcset`/`<picture>` (viewport-dependent), template/noscript content (inert), and non-fetchable schemes. Resolves URLs against document base after scanning (not during) to handle late `<base>` declarations correctly.

- **`SpeculativePreloadScan`** — Worker wrapper that runs the scanner on a thread pool, applies Content Security Policy filtering, and invokes a sink callback on the worker to start requests before the result is published. Includes feature toggle via `BROILER_PRELOAD_SCAN` environment variable and counters for diagnostics.

- **`PreloadCandidate` / `PreloadScanResult`** — Data structures carrying discovered resources: kind (Script/StyleSheet/Image/Frame), raw URL, resolved URL, and nonce (for CSP checks).

- **`DomBridge.PreloadScan.cs`** — Wires the scan into the parse flow. Starts a scan before parsing begins and connects its stylesheet results to the prefetcher. Scripts already have their own prefetcher from host extraction; images and frames are deferred to future items (#8, #16).

- **`CaptureService`** — Updated to use the scan's script URL set, fixing the serial round-trip problem where the capture host walked script tags inline rather than using the prefetch/consume split item #2 built.

- **`ResourceLoader.Prefetch`** — Generalized to accept a `minimumToOverlap` parameter: post-parse stylesheet collection uses 2 (overlap only with each other), while the speculative scan uses 1 (overlap with parse itself).

- **`UrlResolver`** — Fixed to reject path-absolute references (`/path`) as absolute URIs (they are not), allowing them to resolve relative to base correctly.

## Testing

- **`PreloadScanTests`** — 20 cases covering what the scanner finds (all families, document order, base resolution, deduplication) and what it refuses (comments, script bodies, templates, noscript, non-fetchable schemes, srcset).

- **`SpeculativePreloadScanTests`** — 15 cases covering the worker (feature toggle, sink execution on worker thread, error isolation), CSP filtering (configured policy, meta policy, nonce handling), and the exit gate (output identical with scan off).

- **`PreloadScanOverlapTests`** — Structural assertions (not wall-clock timing) that requests arrive while parse is running and scripts fetch concurrently rather than serially, using a loopback origin that holds requests open until released. Includes a measurement harness reporting median paired ratios.

## Notable Details

- The scan is deterministic and safe by construction: it reads one immutable string, writes nothing the document owns, and the worker never renders. Failures (throwing sink) are swallowed; the document falls back to inline fetches.

- Deduplication is per-family: the same URL as both stylesheet and image preload is two requests.

- The nonce attribute is carried through the scan so CSP checks made before the DOM exists reach the same verdict as consume sites.

- Roadmap documentation updated to reflect item #17 completion and its implications for item #8 (image decode parallelism now has the URL set it needs).

https://claude.ai/code/session_013PWeRjARRDaWksYXF3dgi4