### PR TITLE
Implement concurrent image prefetch (multithreading item #8)

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/ImagePrefetchWorkerContractTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/ImagePrefetchWorkerContractTests.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using Broiler.CSS;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// Multithreading item #8's half of the P0-c contract: the image-prefetch worker is the first thread
+/// in the repository that runs render-path work off the layout thread, so it is the first that has to
+/// establish the ambient state and arm the assertion that says it did.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this is a test rather than a comment.</b> <c>multithreading.md</c> §3 records the debt in
+/// exactly these terms — <i>the first item that creates a worker has to arm
+/// <see cref="AmbientRenderState.EnforceOnThisThread"/> in the same place it calls
+/// <see cref="AmbientRenderState.Establish"/>, or the instrumentation bought by P0-c goes unused</i>.
+/// Every ambient slot is <c>[ThreadStatic]</c>, so a worker that skips the contract does not fail: it
+/// reads a default and produces a plausible-looking wrong render. Nothing about that is visible in a
+/// pixel comparison of documents whose images happen not to read a slot, which is every document in
+/// the corpus. So the contract is asserted directly, on the real worker.
+/// </para>
+/// <para>
+/// <b>And why the assertion has to be disarmed again.</b> These workers are pool threads. One that
+/// went back to the pool still armed would make an ordinary unestablished read on some later,
+/// unrelated piece of work throw — including in another test running concurrently in this same
+/// assembly. That is the flaky-assertion-about-thread-safety failure the enforcement switch's own
+/// remarks warn about, so leaving the switch as it was found is part of the contract and is checked
+/// here.
+/// </para>
+/// </remarks>
+public sealed class ImagePrefetchWorkerContractTests
+{
+    private const float ViewportWidth = 1024;
+    private const float ViewportHeight = 768;
+
+    /// <summary>
+    /// Every load runs on a thread that has established all three slots, and none of them runs on a
+    /// thread that has only inherited the caller's.
+    /// </summary>
+    [Fact]
+    public void EveryPrefetchWorkerEstablishesTheAmbientState()
+    {
+        var established = new ConcurrentBag<AmbientRenderState.Slots>();
+        RunAll(8, () => established.Add(AmbientRenderState.EstablishedOnThisThread));
+
+        Assert.Equal(8, established.Count);
+        Assert.All(established, slots => Assert.Equal(AmbientRenderState.Slots.All, slots));
+    }
+
+    /// <summary>
+    /// The viewport and quirks flag a worker sees are the document's, not whatever the pooled thread
+    /// last rendered. This is the failure the assertion exists to catch, so it is worth checking that
+    /// the values are right and not merely that a record was written.
+    /// </summary>
+    [Fact]
+    public void APrefetchWorkerSeesThisDocumentsViewportAndDocumentMode()
+    {
+        var quirks = DocumentModeContext.CurrentQuirksMode;
+        try
+        {
+            DocumentModeContext.CurrentQuirksMode = true;
+
+            // The viewport is read through a length rather than through a record, because a viewport
+            // that was recorded but not applied is exactly the failure this slot has: every
+            // vw/vh silently resolves to zero and the render looks like a layout bug.
+            var seen = new ConcurrentBag<(double Vw, double Vh, bool Quirks)>();
+            RunAll(4, () => seen.Add((
+                CssLengthParser.ParseLength("50vw", 0, 16),
+                CssLengthParser.ParseLength("25vh", 0, 16),
+                DocumentModeContext.CurrentQuirksMode)));
+
+            Assert.Equal(4, seen.Count);
+            Assert.All(seen, s =>
+            {
+                Assert.Equal(ViewportWidth / 2, s.Vw, precision: 3);
+                Assert.Equal(ViewportHeight / 4, s.Vh, precision: 3);
+                Assert.True(s.Quirks);
+            });
+        }
+        finally
+        {
+            DocumentModeContext.CurrentQuirksMode = quirks;
+        }
+    }
+
+    /// <summary>
+    /// A worker leaves the enforcement switch as it found it, so a pooled thread returning to the
+    /// pool does not arm an assertion for whatever runs on it next.
+    /// </summary>
+    [Fact]
+    public void APrefetchWorkerLeavesTheEnforcementSwitchAsItFoundIt()
+    {
+        var threads = new ConcurrentDictionary<int, byte>();
+        var armedInside = new ConcurrentBag<bool>();
+
+        // Two rounds over the same pool: the second round is what can observe the first round's
+        // threads, which is the only way a leaked switch shows up at all.
+        for (var round = 0; round < 2; round++)
+        {
+            RunAll(4, () =>
+            {
+                threads.TryAdd(Environment.CurrentManagedThreadId, 0);
+                armedInside.Add(AmbientRenderState.EnforceOnThisThread);
+            });
+        }
+
+        // Armed inside every load — that is the contract's active half.
+        Assert.All(armedInside, armed => Assert.True(armed));
+
+        // And disarmed again by the time the load returns. Observed from plain pool workers, which
+        // is how a leaked switch would reach unrelated work in the first place.
+        var leaked = new ConcurrentBag<string>();
+        RunAllWithoutContract(threads.Count, () =>
+        {
+            if (AmbientRenderState.EnforceOnThisThread)
+                leaked.Add($"thread {Environment.CurrentManagedThreadId} came back armed");
+        });
+
+        Assert.Empty(leaked);
+    }
+
+    /// <summary>
+    /// A worker clears its record, so the next document's loads cannot be satisfied by state this
+    /// document established.
+    /// </summary>
+    [Fact]
+    public void APrefetchWorkerClearsItsRecordOnTheWayOut()
+    {
+        RunAll(4, () => { });
+
+        var afterwards = new ConcurrentBag<AmbientRenderState.Slots>();
+        RunAllWithoutContract(4, () => afterwards.Add(AmbientRenderState.EstablishedOnThisThread));
+
+        Assert.All(afterwards, slots =>
+            Assert.NotEqual(AmbientRenderState.Slots.All, slots));
+    }
+
+    /// <summary>
+    /// A budget of one runs the loads inline on the calling thread — the pre-change path — so it
+    /// neither establishes nor arms anything.
+    /// </summary>
+    [Fact]
+    public void ABudgetOfOneRunsInlineAndTouchesNoAmbientState()
+    {
+        var previous = ImagePrefetch.MaxDegreeOfParallelism;
+        try
+        {
+            ImagePrefetch.MaxDegreeOfParallelism = 1;
+
+            var callerThread = Environment.CurrentManagedThreadId;
+            var threads = new List<int>();
+            var armed = new List<bool>();
+            var loads = new Action[4];
+            for (var i = 0; i < loads.Length; i++)
+            {
+                loads[i] = () =>
+                {
+                    threads.Add(Environment.CurrentManagedThreadId);
+                    armed.Add(AmbientRenderState.EnforceOnThisThread);
+                };
+            }
+
+            ImagePrefetch.RunAll(loads, ViewportWidth, ViewportHeight, rootWritingMode: null);
+
+            Assert.All(threads, id => Assert.Equal(callerThread, id));
+            Assert.All(armed, a => Assert.False(a));
+        }
+        finally
+        {
+            ImagePrefetch.MaxDegreeOfParallelism = previous;
+        }
+    }
+
+    /// <summary>
+    /// Every load runs exactly once, and the call does not return until all of them have. The join is
+    /// what makes a replaced box's intrinsic size independent of scheduling.
+    /// </summary>
+    [Fact]
+    public void RunAllRunsEveryLoadExactlyOnceAndJoins()
+    {
+        var counts = new int[16];
+        var loads = new Action[counts.Length];
+        for (var i = 0; i < loads.Length; i++)
+        {
+            var index = i;
+            loads[i] = () =>
+            {
+                Thread.Sleep(1);
+                Interlocked.Increment(ref counts[index]);
+            };
+        }
+
+        var previous = ImagePrefetch.MaxDegreeOfParallelism;
+        try
+        {
+            ImagePrefetch.MaxDegreeOfParallelism = 4;
+            ImagePrefetch.RunAll(loads, ViewportWidth, ViewportHeight, rootWritingMode: null);
+        }
+        finally
+        {
+            ImagePrefetch.MaxDegreeOfParallelism = previous;
+        }
+
+        Assert.All(counts, count => Assert.Equal(1, count));
+    }
+
+    private static void RunAll(int loadCount, Action body)
+    {
+        var previous = ImagePrefetch.MaxDegreeOfParallelism;
+        try
+        {
+            ImagePrefetch.MaxDegreeOfParallelism = 4;
+
+            var loads = new Action[loadCount];
+            for (var i = 0; i < loadCount; i++)
+                loads[i] = body;
+
+            ImagePrefetch.RunAll(loads, ViewportWidth, ViewportHeight, rootWritingMode: null);
+        }
+        finally
+        {
+            ImagePrefetch.MaxDegreeOfParallelism = previous;
+        }
+    }
+
+    /// <summary>
+    /// Runs <paramref name="body"/> on pool threads without establishing anything — the observer for
+    /// "what did the prefetch leave behind on a thread it borrowed".
+    /// </summary>
+    private static void RunAllWithoutContract(int count, Action body)
+    {
+        var tasks = new System.Threading.Tasks.Task[Math.Max(1, count)];
+        using var barrier = new Barrier(tasks.Length);
+        for (var i = 0; i < tasks.Length; i++)
+        {
+            tasks[i] = System.Threading.Tasks.Task.Run(() =>
+            {
+                // A barrier rather than a plain fan-out: without it the pool can satisfy every task
+                // with one thread, and the observation would cover one of the threads the prefetch
+                // borrowed rather than all of them.
+                barrier.SignalAndWait(TimeSpan.FromSeconds(30));
+                body();
+            });
+        }
+
+        System.Threading.Tasks.Task.WaitAll(tasks);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/DeferredImageLoad.cs
+++ b/Broiler.Layout/Broiler.Layout/DeferredImageLoad.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Drawing;
+
+namespace Broiler.Layout;
+
+/// <summary>
+/// Holds an image load's completion until the layout thread reaches the point that would have run it,
+/// then runs it there. Multithreading roadmap item #8.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>This is what makes the prefetch's output identical rather than merely equivalent.</b> A load has
+/// two halves: the expensive one (resolve the source, read the bytes, decode them) and the one that
+/// touches the box (store the image, store its rectangle, set the error border on failure, and ask the
+/// host to refresh). Only the first is safe to move: the second is where the serial path's <em>timing</em>
+/// is observable, because a box that acquires a 2px error border before its width is resolved lays out
+/// differently from one that acquires it after.
+/// </para>
+/// <para>
+/// <b>That is not a hypothesis; it is what the exit gate caught.</b> With the completion applied on the
+/// worker, a document of three broken <c>&lt;img&gt;</c>s rendered 6–10 pixels wider than the serial
+/// render — the error borders landed early enough to widen boxes the serial path had already measured.
+/// Every document with working images was byte-identical, which is exactly how this class of defect
+/// survives a test suite: the failure path is the one whose callback does something.
+/// </para>
+/// <para>
+/// <b>Why capture-and-replay rather than a two-phase loader.</b> The host's loader takes its completion
+/// callback at construction and invokes it inside <c>LoadImage</c>; asking it to separate decoding from
+/// notifying would change <c>ILayoutImageLoader</c> and every implementation of it. Wrapping the callback
+/// needs neither, and it makes the identity argument structural: the real callback runs on the layout
+/// thread, at the same call site, in the same order, with the arguments the loader produced. There is no
+/// document for which that can differ, so nothing rests on which documents were tried.
+/// </para>
+/// <para>
+/// <b>After <see cref="Release"/> it is a pass-through.</b> A host may complete a load more than once —
+/// a late load replacing a placeholder — and those completions belong to whoever asked for them, not to
+/// the prefetch. So the wrapper forwards anything that arrives after the deferred completion has been
+/// applied, which also means a load that never completed during the prefetch is simply a load that
+/// completes normally later.
+/// </para>
+/// </remarks>
+internal sealed class DeferredImageLoad(Action<object?, RectangleF, bool> target)
+{
+    private readonly Action<object?, RectangleF, bool> _target =
+        target ?? throw new ArgumentNullException(nameof(target));
+
+    private readonly object _gate = new();
+    private object? _image;
+    private RectangleF _rectangle;
+    private bool _async;
+    private bool _captured;
+    private bool _released;
+
+    /// <summary>
+    /// The callback the loader is given. Captures the completion while the load is a speculation and
+    /// forwards it once it is not.
+    /// </summary>
+    /// <remarks>
+    /// Locked rather than volatile, because it publishes three values that have to be seen together:
+    /// a torn read here would apply one load's image with another's rectangle. The lock is taken once
+    /// per image, which is not a rate worth optimising.
+    /// </remarks>
+    public void OnCompleted(object? image, RectangleF rectangle, bool async)
+    {
+        lock (_gate)
+        {
+            if (!_released)
+            {
+                _image = image;
+                _rectangle = rectangle;
+                _async = async;
+                _captured = true;
+                return;
+            }
+        }
+
+        _target(image, rectangle, async);
+    }
+
+    /// <summary>
+    /// Applies the captured completion, if the load produced one, and stops deferring. Called on the
+    /// layout thread from the site the serial path would have completed at.
+    /// </summary>
+    public void Release()
+    {
+        object? image;
+        RectangleF rectangle;
+        bool async;
+
+        lock (_gate)
+        {
+            if (_released)
+                return;
+
+            _released = true;
+            if (!_captured)
+                return;
+
+            image = _image;
+            rectangle = _rectangle;
+            async = _async;
+        }
+
+        // Outside the lock: the callback runs arbitrary layout code (it sets an error border, and it
+        // may ask the host to refresh), and none of that should run holding this object's gate.
+        _target(image, rectangle, async);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Background.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Background.cs
@@ -12,34 +12,73 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     /// subclasses (e.g. <see cref="CssBoxImage"/>) that replace the base
     /// measurement logic.
     /// </summary>
-    protected void LoadBackgroundImageIfNeeded()
+    protected void LoadBackgroundImageIfNeeded() => LoadBackgroundImages(deferCompletions: false);
+
+    /// <summary>
+    /// Loads the background image layers, once.
+    /// </summary>
+    /// <param name="deferCompletions">
+    /// <c>true</c> when called from the image prefetch (multithreading item #8), which runs on a worker
+    /// before the layout pass: each layer's completion is then captured rather than applied, and the
+    /// inline call below applies it from the site that would have produced it. See
+    /// <see cref="DeferredImageLoad"/> for why only the decode is safe to move.
+    /// </param>
+    private void LoadBackgroundImages(bool deferCompletions)
     {
+        // A prefetched layer's completion is applied here — the point the serial path completed at —
+        // rather than on the worker that decoded it. This runs before the initialized check because
+        // the prefetch has already set that flag.
+        if (ReleaseDeferredBackgroundLoads())
+            return;
+
         if (BackgroundImage == CssConstants.None || _backgroundImagesInitialized)
             return;
 
         _backgroundImagesInitialized = true;
         var layers = SplitBackgroundImageLayers(BackgroundImage);
-        
+
         if (layers.Count == 0)
             return;
 
         _backgroundImageLoadHandlers = new List<ILayoutImageLoader?>(layers.Count);
-        
+
         foreach (var layer in layers)
         {
             var src = TryExtractBackgroundImageUrl(layer);
-            
+
             if (string.IsNullOrEmpty(src))
             {
                 _backgroundImageLoadHandlers.Add(null);
                 continue;
             }
 
-            var imageLoadHandler = LayoutEnvironment.CreateImageLoader(OnImageLoadComplete);
-            
+            var deferred = deferCompletions ? new DeferredImageLoad(OnImageLoadComplete) : null;
+            if (deferred != null)
+                (_deferredBackgroundLoads ??= []).Add(deferred);
+
+            var imageLoadHandler = LayoutEnvironment.CreateImageLoader(
+                deferred is null ? OnImageLoadComplete : deferred.OnCompleted);
+
             _backgroundImageLoadHandlers.Add(imageLoadHandler);
             imageLoadHandler.LoadImage(src, HtmlTag?.Attributes, BaseUrl);
         }
+    }
+
+    /// <summary>
+    /// Applies the completions the prefetch captured for this box's background layers, in the order it
+    /// created them, and returns whether there were any.
+    /// </summary>
+    private bool ReleaseDeferredBackgroundLoads()
+    {
+        var deferred = _deferredBackgroundLoads;
+        if (deferred is null)
+            return false;
+
+        _deferredBackgroundLoads = null;
+        foreach (var load in deferred)
+            load.Release();
+
+        return true;
     }
 
     private static List<string> SplitBackgroundImageLayers(string backgroundImage)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.ImagePrefetch.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.ImagePrefetch.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using Broiler.CSS;
+
+namespace Broiler.Layout.Engine;
+
+/// <summary>
+/// The document-wide image walk that turns a serial run of inline decodes into one concurrent batch.
+/// Multithreading roadmap item #8; the budget, the diagnostics and the reasoning are on
+/// <see cref="ImagePrefetch"/>.
+/// </summary>
+internal partial class CssBox
+{
+    /// <summary>
+    /// Issues every image load this document is certain to need, concurrently, before the layout
+    /// pass reaches any of them. Called at the document root.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>"Certain to need" is the whole of the correctness argument, and it is deliberately
+    /// one-sided.</b> A box the walk skips loads its image exactly where it did before — inline, in
+    /// <c>MeasureWordsSize</c> — so under-collecting costs speed and nothing else. Over-collecting
+    /// costs correctness: an image loaded for a box layout never measures is a request on the wire
+    /// the document did not make, and, for a broken source, an error reported that the host would
+    /// never have seen. So the walk claims a box only when it can see that layout will reach it, and
+    /// resolves everything else to "leave it alone".
+    /// </para>
+    /// <para>
+    /// <b>What that rules out, concretely.</b> <c>PerformLayoutImp</c> measures words only when
+    /// <c>Display != none</c>, so a <c>display:none</c> subtree is not entered. That is not the same
+    /// as saying such a box never loads — <c>EnsureDescendantWordsMeasured</c>, the shrink-to-fit
+    /// pre-pass, walks descendants without consulting <c>Display</c>, so an image inside a hidden
+    /// subtree of an auto-width box does still load. Prefetching it would be correct on that page and
+    /// wrong on the next one, and the walk cannot tell them apart without running layout, so it
+    /// declines the whole class and those images load inline as they always did.
+    /// </para>
+    /// </remarks>
+    internal static void PrefetchDocumentImages(CssBox root, ILayoutEnvironment g)
+    {
+        if (ImagePrefetch.MaxDegreeOfParallelism <= 1)
+            return;
+
+        if (!ImagePrefetch.AppliesTo(g))
+        {
+            ImagePrefetch.NoteSkippedNotSynchronous();
+            return;
+        }
+
+        var pending = new List<CssBox>();
+        CollectPendingImageBoxes(root, pending);
+
+        if (pending.Count < ImagePrefetch.MinimumImagesToOverlap)
+        {
+            if (pending.Count > 0)
+                ImagePrefetch.NoteSkippedBelowMinimum();
+            return;
+        }
+
+        var loads = new Action[pending.Count];
+        for (var i = 0; i < pending.Count; i++)
+        {
+            var box = pending[i];
+            loads[i] = () => box.LoadImagesForPrefetch(g);
+        }
+
+        var viewport = g.ViewportSize;
+        ImagePrefetch.RunAll(loads, viewport.Width, viewport.Height, root.WritingMode);
+    }
+
+    /// <summary>
+    /// Collects the boxes with an unstarted image load, skipping <c>display:none</c> subtrees.
+    /// Iterative rather than recursive: a deep document is a deep box tree, and the walk runs at the
+    /// root of every render.
+    /// </summary>
+    private static void CollectPendingImageBoxes(CssBox root, List<CssBox> pending)
+    {
+        var stack = new Stack<CssBox>();
+        stack.Push(root);
+
+        while (stack.Count > 0)
+        {
+            var box = stack.Pop();
+            if (box.Display == CssConstants.None)
+                continue;
+
+            if (box.HasPendingImageLoad)
+                pending.Add(box);
+
+            foreach (var child in box.Boxes)
+                stack.Push(child);
+        }
+    }
+
+    /// <summary>
+    /// Whether this box has an image load that has not been started yet. The background-image test is
+    /// the same pair of conditions <see cref="LoadBackgroundImageIfNeeded"/> opens with, so a box that
+    /// would do nothing is never claimed; <see cref="CssBoxImage"/> adds its replaced-content image.
+    /// </summary>
+    internal virtual bool HasPendingImageLoad =>
+        BackgroundImage != CssConstants.None && !_backgroundImagesInitialized;
+
+    /// <summary>
+    /// Runs this box's pending image loads on a prefetch worker. Overridden by
+    /// <see cref="CssBoxImage"/>, whose replaced content is a second load.
+    /// </summary>
+    /// <remarks>
+    /// <b>It calls the same methods layout would.</b> Not a copy of them: the flags they set
+    /// (<c>_backgroundImagesInitialized</c>, <c>_imageLoadHandler</c>) are what makes the later
+    /// <c>MeasureWordsSize</c> skip the load for this box, so the prefetch and the consume site cannot
+    /// drift apart into two ways of loading an image. What the consume site still does is apply the
+    /// completion this worker captured — the decode moves, the callback does not
+    /// (<see cref="DeferredImageLoad"/>).
+    /// </remarks>
+    internal virtual void LoadImagesForPrefetch(ILayoutEnvironment g) =>
+        LoadBackgroundImages(deferCompletions: true);
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -108,6 +108,13 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     private List<ILayoutImageLoader?>? _backgroundImageLoadHandlers;
     private bool _backgroundImagesInitialized;
 
+    /// <summary>
+    /// Background-layer completions the image prefetch (multithreading item #8) captured on a worker,
+    /// waiting to be applied on the layout thread. Null on every box the prefetch did not claim, which
+    /// is every box when the prefetch is off.
+    /// </summary>
+    private List<DeferredImageLoad>? _deferredBackgroundLoads;
+
     internal Dictionary<string, string> CustomProperties { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     internal void SetCustomProperty(string propertyName, string value)
@@ -348,6 +355,15 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     {
         try
         {
+            // Multithreading item #8: a document's images are loaded and decoded one at a time,
+            // inline, at whichever MeasureWordsSize first reaches each of them. Issue them all here
+            // instead, concurrently, and join before any measurement happens — so the pass below
+            // finds every image already loaded and does exactly what it did before. At the root
+            // only: a nested layout (a table cell re-measuring, a subdocument) shares this
+            // document's boxes, and re-walking them would find nothing pending but pay for the walk.
+            if (ParentBox == null)
+                PrefetchDocumentImages(this, g);
+
             // PROTOTYPE (BROILER_VERTICAL_FLOW): a vertical-writing-mode rotation
             // root lays its whole subtree out in a logical (horizontal) frame.
             // While that frame layout runs, a transposed box's physical

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxImage.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxImage.cs
@@ -10,6 +10,13 @@ internal sealed class CssBoxImage : CssBox
     private ILayoutImageLoader _imageLoadHandler;
     private bool _imageLoadingComplete;
 
+    /// <summary>
+    /// This box's replaced-content completion, captured by the image prefetch (multithreading item #8)
+    /// on the worker that decoded it and waiting for the layout thread to reach the point that would
+    /// have run it. Null whenever the prefetch did not claim this box, which is always when it is off.
+    /// </summary>
+    private DeferredImageLoad? _deferredContentLoad;
+
     public CssBoxImage(CssBox parent, HtmlTag tag, Uri baseUrl) : base(parent, tag, baseUrl)
     {
         _imageWord = new CssRectImage(this);
@@ -27,28 +34,74 @@ internal sealed class CssBoxImage : CssBox
             // CssBoxImage overrides MeasureWordsSize entirely, so the base
             // class's background-image loading code would otherwise be skipped.
             LoadBackgroundImageIfNeeded();
-
-            if (_imageLoadHandler == null && (LayoutEnvironment.AvoidAsyncImagesLoading || LayoutEnvironment.AvoidImagesLateLoading))
-            {
-                _imageLoadHandler = LayoutEnvironment.CreateImageLoader(OnLoadImageComplete);
-
-                if (Content != null && Content != CssConstants.Normal)
-                    _imageLoadHandler.LoadImage(Content, HtmlTag?.Attributes, BaseUrl);
-                else
-                {
-                    var src = GetAttribute("src");
-                    // <object data="..."> fallback: use 'data' attribute when 'src' is absent
-                    if (string.IsNullOrEmpty(src))
-                        src = GetAttribute("data");
-                    _imageLoadHandler.LoadImage(src, HtmlTag?.Attributes, BaseUrl);
-                }
-            }
+            LoadContentImageIfNeeded();
 
             MeasureWordSpacing(g);
             _wordsSizeMeasured = true;
         }
 
         CssLayoutEngine.MeasureImageSize(g, _imageWord);
+    }
+
+    /// <summary>
+    /// Creates this box's image loader and starts the load, once. Extracted from
+    /// <see cref="MeasureWordsSize"/> so the image prefetch (multithreading item #8) starts the load
+    /// by calling the same code rather than a copy of it — the <c>_imageLoadHandler != null</c> guard
+    /// is then what makes the later inline call a no-op, and the two cannot drift apart.
+    /// </summary>
+    /// <param name="deferCompletion">
+    /// <c>true</c> when called from the prefetch worker: the completion is captured rather than applied,
+    /// and the inline call applies it. It is the completion, not the decode, that a box's layout can
+    /// observe the timing of — see <see cref="DeferredImageLoad"/>.
+    /// </param>
+    private void LoadContentImageIfNeeded(bool deferCompletion = false)
+    {
+        // A prefetched load's completion is applied here, which is where the serial path applied it.
+        if (_deferredContentLoad is { } deferredLoad)
+        {
+            _deferredContentLoad = null;
+            deferredLoad.Release();
+            return;
+        }
+
+        if (_imageLoadHandler != null
+            || !(LayoutEnvironment.AvoidAsyncImagesLoading || LayoutEnvironment.AvoidImagesLateLoading))
+        {
+            return;
+        }
+
+        var deferred = deferCompletion ? new DeferredImageLoad(OnLoadImageComplete) : null;
+        _deferredContentLoad = deferred;
+        _imageLoadHandler = LayoutEnvironment.CreateImageLoader(
+            deferred is null ? OnLoadImageComplete : deferred.OnCompleted);
+
+        if (Content != null && Content != CssConstants.Normal)
+        {
+            _imageLoadHandler.LoadImage(Content, HtmlTag?.Attributes, BaseUrl);
+            return;
+        }
+
+        var src = GetAttribute("src");
+        // <object data="..."> fallback: use 'data' attribute when 'src' is absent
+        if (string.IsNullOrEmpty(src))
+            src = GetAttribute("data");
+        _imageLoadHandler.LoadImage(src, HtmlTag?.Attributes, BaseUrl);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// The replaced content is a load of its own, in addition to any background image, and it is the
+    /// one that decides a replaced box's intrinsic size — so an <c>&lt;img&gt;</c> with no background
+    /// is still worth claiming.
+    /// </remarks>
+    internal override bool HasPendingImageLoad =>
+        base.HasPendingImageLoad || _imageLoadHandler == null;
+
+    /// <inheritdoc/>
+    internal override void LoadImagesForPrefetch(ILayoutEnvironment g)
+    {
+        base.LoadImagesForPrefetch(g);
+        LoadContentImageIfNeeded(deferCompletion: true);
     }
 
     public override void Dispose()

--- a/Broiler.Layout/Broiler.Layout/ImagePrefetch.cs
+++ b/Broiler.Layout/Broiler.Layout/ImagePrefetch.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Broiler.CSS;
+
+namespace Broiler.Layout;
+
+/// <summary>
+/// The thread budget a document's image loads are issued on, and the diagnostics that say what the
+/// walk decided. Multithreading roadmap item #8.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The item is a prefetch/consume split, not a <c>Parallel.For</c> over decoders.</b> Items #6
+/// and #7 parallelize the inside of one decode; this parallelizes across the images a document has.
+/// The blocker the master table named — <c>BImageRenderer._images</c> — was cleared by item #9, and
+/// the one it did not name is what decides the shape: <c>ImageLoadHandler.SetImageFromFile</c>
+/// already queues its decode to the thread pool <em>unless</em> <c>AvoidAsyncImagesLoading</c> is
+/// set, and every headless entry point sets it, because the render is synchronous and must have
+/// every image before layout measures a replaced box. So on exactly the paths this repository
+/// measures, a document's images are read and decoded <b>one at a time, inline</b>, in the order
+/// layout happens to reach them.
+/// </para>
+/// <para>
+/// <b>Where the split lives, and why it needs no new seam.</b> Layout already asks the host for a
+/// loader per image (<see cref="ILayoutEnvironment.CreateImageLoader"/>) and calls
+/// <see cref="ILayoutImageLoader.LoadImage"/> on it — from inside <c>MeasureWordsSize</c>, which is
+/// the inline serial point. The prefetch is that same pair of calls, for every image the document
+/// names, issued from a worker before the layout pass starts; the consume site is
+/// <c>MeasureWordsSize</c> itself, which finds the box's loader already populated and does nothing.
+/// Nothing about which request is made, under which key, or what is done with the bytes changes —
+/// only <em>when</em> each load starts and <em>on which thread</em> it runs. That is the same
+/// property item #2's prefetcher has, and it is what makes the sequential path exactly reproducible
+/// rather than approximately so.
+/// </para>
+/// <para>
+/// <b>Two levels of decode parallelism compound here, unlike bands and tiles — and dividing them was
+/// measured and does nothing.</b> A tile view runs its scanline bands inline, so a render spends one
+/// or the other (<c>docs/architecture/multithreading.md</c> §7). Across-image and within-image decode
+/// are not like that: <em>N</em> concurrent loads each splitting their own decode into items #6/#7's
+/// <em>N</em> bands is <em>N²</em> runnable threads on <em>N</em> cores, so narrowing the inner budget
+/// to <c>cores / loads</c> looks like the correction oversubscription obviously calls for. Over four
+/// interleaved runs of the item's fixture it does not consistently do anything: layout undivided
+/// 94.7 / 91.3 / 101.8 / 85.6 ms against divided 92.1 / 90.6 / 94.0 / 93.6, which is three runs
+/// favouring the division by 1–8% and a fourth penalising it by 9%. The .NET pool already serialises
+/// the excess, and the wave that runs with fewer than <em>N</em> loads left wants every core it can
+/// get. So no division ships, the seam that would have exposed the decoder's budget to layout was
+/// removed again, and <c>--image-prefetch-scaling</c> keeps the divided configuration as a column so
+/// the null result stays re-runnable rather than remembered.
+/// </para>
+/// <para>
+/// <b>A budget of 1 is the pre-change path, not an approximation of it.</b> At 1 the walk does not
+/// run at all, so every box reaches <c>MeasureWordsSize</c> with no loader and creates one exactly
+/// where it used to, in layout order, on the layout thread. That is what the exit gate compares
+/// against.
+/// </para>
+/// </remarks>
+public static class ImagePrefetch
+{
+    /// <summary>Environment variable that overrides the default thread budget.</summary>
+    public const string ThreadsEnvironmentVariable = "BROILER_IMAGE_PREFETCH_THREADS";
+
+    /// <summary>
+    /// Images a document must name before the walk is worth running. Two, because one image
+    /// concurrently is one image serially plus a task — there is nothing to overlap it with, since
+    /// the layout pass that would have loaded it has not started.
+    /// </summary>
+    public const int MinimumImagesToOverlap = 2;
+
+    private static int _maxDegreeOfParallelism = ReadConfiguredDegree();
+
+    private static long _documentsWalked;
+    private static long _loadsIssued;
+    private static long _documentsBelowMinimum;
+    private static long _documentsNotSynchronous;
+
+    /// <summary>
+    /// Maximum image loads in flight at once. <c>1</c> disables the walk entirely — see the class
+    /// remarks; it is the pre-change path rather than a one-wide version of the new one.
+    /// </summary>
+    public static int MaxDegreeOfParallelism
+    {
+        get => _maxDegreeOfParallelism;
+        set => _maxDegreeOfParallelism = Math.Max(1, value);
+    }
+
+    /// <summary>
+    /// Whether to count what the walk decided. Off by default; read once per document, so the cost
+    /// is a branch per render rather than per image.
+    /// </summary>
+    /// <remarks>
+    /// The interesting question about this item is not how fast four concurrent decodes are — that
+    /// is arithmetic — but <em>how many images a page gives the walk to overlap</em>, and how often
+    /// a document is skipped for one of the two reasons it can be. A flat scaling row means
+    /// something different in each case: "the loads did not overlap" and "there were no loads to
+    /// overlap" call for opposite next steps.
+    /// </remarks>
+    public static bool CollectDiagnostics { get; set; }
+
+    /// <summary>
+    /// Documents whose images were issued by the walk, loads issued, documents skipped for naming
+    /// fewer than <see cref="MinimumImagesToOverlap"/> images, and documents skipped because the
+    /// host does not load images synchronously.
+    /// </summary>
+    /// <remarks>
+    /// Process-wide and interlocked, unlike <c>BRasterParallelism</c>'s per-thread counters: this
+    /// counts documents rather than fills, so there are a handful of writes per render rather than
+    /// thousands, and a caller wants the total across the workers the walk itself created.
+    /// </remarks>
+    public static (long DocumentsWalked, long LoadsIssued, long DocumentsBelowMinimum, long DocumentsNotSynchronous)
+        Diagnostics => (
+            Interlocked.Read(ref _documentsWalked),
+            Interlocked.Read(ref _loadsIssued),
+            Interlocked.Read(ref _documentsBelowMinimum),
+            Interlocked.Read(ref _documentsNotSynchronous));
+
+    /// <summary>Zeroes the counters.</summary>
+    public static void ResetDiagnostics()
+    {
+        Interlocked.Exchange(ref _documentsWalked, 0);
+        Interlocked.Exchange(ref _loadsIssued, 0);
+        Interlocked.Exchange(ref _documentsBelowMinimum, 0);
+        Interlocked.Exchange(ref _documentsNotSynchronous, 0);
+    }
+
+    internal static void NoteSkippedBelowMinimum()
+    {
+        if (CollectDiagnostics)
+            Interlocked.Increment(ref _documentsBelowMinimum);
+    }
+
+    internal static void NoteSkippedNotSynchronous()
+    {
+        if (CollectDiagnostics)
+            Interlocked.Increment(ref _documentsNotSynchronous);
+    }
+
+    /// <summary>
+    /// Whether a host's image-loading configuration is the one this item applies to: synchronous,
+    /// with no late loading.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>AvoidAsyncImagesLoading</c> is what makes the decode inline and serial, so it is what makes
+    /// the item worth doing at all: with it clear, the host's loader already queues to the thread pool
+    /// and there is nothing here to win.
+    /// </para>
+    /// <para>
+    /// <b><c>AvoidImagesLateLoading</c> is in the test to bound the change, not because the change is
+    /// unsafe without it.</b> A load that completes while late loading is permitted asks the host to
+    /// refresh, and an earlier version of this item — which applied completions on the worker — would
+    /// have made that call from a thread the host never agreed to be called back on.
+    /// <see cref="DeferredImageLoad"/> removed that hazard by construction: every completion now runs
+    /// on the layout thread at its original call site, refresh request included. The flag stays in the
+    /// test because every headless entry point sets both, so requiring both keeps the item confined to
+    /// the configuration it was measured in — and a host that permits late loading has an image
+    /// lifecycle this item was not measured against.
+    /// </para>
+    /// </remarks>
+    internal static bool AppliesTo(ILayoutEnvironment environment) =>
+        environment.AvoidAsyncImagesLoading && environment.AvoidImagesLateLoading;
+
+    /// <summary>
+    /// Runs <paramref name="loads"/> concurrently, up to the budget, and returns once every one of
+    /// them has finished. Each worker establishes the ambient render state before it runs a load and
+    /// clears its record afterwards.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>It joins, and the join is the correctness argument.</b> Every load has completed before
+    /// this returns, so the layout pass that follows sees exactly the state it would have seen had
+    /// each load run inline at the box that needed it: the same images, the same failures, the same
+    /// error borders. What changes is that the loads happened at once and earlier. Returning before
+    /// they finished would make a replaced box's intrinsic size depend on scheduling, which is the
+    /// one thing a render must never do.
+    /// </para>
+    /// <para>
+    /// <b>This is the first worker thread in the repository that runs render-path work, so it is the
+    /// first that owes the ambient-state contract</b> (P0-c; <c>multithreading.md</c> §3 records the
+    /// debt and says the item that creates a worker has to arm the enforcement in the same place it
+    /// establishes). A load can reach SVG rasterization, which draws — so the thread is treated as a
+    /// render thread whether or not today's decoders happen to read a thread-affine slot. Arming
+    /// <see cref="AmbientRenderState.EnforceOnThisThread"/> is what turns "they happen not to" from
+    /// an assumption into a checked claim, and it costs a debug-only branch.
+    /// </para>
+    /// </remarks>
+    /// <param name="loads">One action per image load, each touching only its own box.</param>
+    /// <param name="viewportWidth">Initial containing block width, for the workers' ambient state.</param>
+    /// <param name="viewportHeight">Initial containing block height, for the workers' ambient state.</param>
+    /// <param name="rootWritingMode">The root element's writing mode, which names the logical axes.</param>
+    internal static void RunAll(
+        IReadOnlyList<Action> loads,
+        float viewportWidth,
+        float viewportHeight,
+        string? rootWritingMode)
+    {
+        ArgumentNullException.ThrowIfNull(loads);
+
+        var threads = Math.Min(_maxDegreeOfParallelism, loads.Count);
+        if (threads <= 1)
+        {
+            foreach (var load in loads)
+                load();
+            return;
+        }
+
+        // Read on the calling thread, which is the one that parsed the document; a worker that read
+        // it would read whatever the last document on that pooled thread left behind.
+        var quirksMode = DocumentModeContext.CurrentQuirksMode;
+
+        if (CollectDiagnostics)
+        {
+            Interlocked.Increment(ref _documentsWalked);
+            Interlocked.Add(ref _loadsIssued, loads.Count);
+        }
+
+        Parallel.For(
+            0,
+            loads.Count,
+            new ParallelOptions { MaxDegreeOfParallelism = threads },
+            i =>
+            {
+                var enforcing = AmbientRenderState.EnforceOnThisThread;
+                AmbientRenderState.Establish(viewportWidth, viewportHeight, rootWritingMode, quirksMode);
+                AmbientRenderState.EnforceOnThisThread = true;
+                try
+                {
+                    loads[i]();
+                }
+                finally
+                {
+                    // A pooled thread must not vouch for state the next document has not set, and
+                    // must not leave the assertion armed for whatever runs on it next — this method
+                    // is the only place in the process that arms it, so it is the only place that
+                    // can be sure of turning it off.
+                    AmbientRenderState.ClearThreadRecord();
+                    AmbientRenderState.EnforceOnThisThread = enforcing;
+                }
+            });
+    }
+
+    private static int ReadConfiguredDegree()
+    {
+        var configured = Environment.GetEnvironmentVariable(ThreadsEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(configured) &&
+            int.TryParse(configured, out var threads) &&
+            threads > 0)
+        {
+            return threads;
+        }
+
+        return Environment.ProcessorCount;
+    }
+}

--- a/Broiler.Media/Broiler.Media.Image.Managed/ImageDecodeParallelism.cs
+++ b/Broiler.Media/Broiler.Media.Image.Managed/ImageDecodeParallelism.cs
@@ -39,6 +39,14 @@ namespace Broiler.Media.Image.Managed;
 /// Setting it to <c>1</c> is the sequential path — not an approximation of it, the same code with
 /// one band.
 /// </para>
+/// <para>
+/// <b>It stays internal, and item #8 is the reason that is worth saying.</b> Layout now issues a
+/// document's image loads concurrently, so <em>N</em> loads each splitting their own decode into
+/// <em>N</em> bands is <em>N²</em> runnable threads on <em>N</em> cores — an obvious candidate for a
+/// host-side division of this budget. It was built and measured, and dividing was worth nothing
+/// either way (see <c>ImagePrefetch</c>) — so the seam that would have exposed this type to the hosts
+/// was removed again and the environment variable is still the only way a host configures it.
+/// </para>
 /// </remarks>
 internal static class ImageDecodeParallelism
 {

--- a/docs/architecture/multithreading-static-state.md
+++ b/docs/architecture/multithreading-static-state.md
@@ -99,6 +99,20 @@ the code that introduces worker threads, which is also the code that calls
 `Establish`; arming it process-wide would make every existing single-threaded render
 pay for a hazard it does not have.
 
+*It now has one caller, which is what this instrumentation was waiting for.*
+Multithreading item #8's image prefetch (`Broiler.Layout/ImagePrefetch.cs`) runs a
+document's image loads on pool threads before the layout pass, and
+`ImagePrefetch.RunAll` calls `Establish` and arms the switch per load, then calls
+`ClearThreadRecord` and restores the switch on the way out — so a pooled thread
+neither vouches for the next document's state nor leaves the assertion armed for
+unrelated work that lands on it next. `ImagePrefetchWorkerContractTests` asserts both
+halves on the real worker, and 3 of its 6 cases fail against the code before that item.
+**What arming it found was nothing, and that is the useful part**: an image load can
+reach SVG rasterization, which opens a canvas and draws text, but `BSvgRasterizer`
+reads none of these slots — it parses its own attributes and builds its own coordinate
+context, and the font caches under it were made thread-safe by item #9. That was an
+assumption before and is a checked claim now.
+
 *Until Phase 2 there was a second, stronger reason, and it was a finding rather than
 a preference:* turning it on failed every render in the repository, because
 `DocumentModeContext.CurrentQuirksMode` was **never written on the HTML-string render

--- a/docs/architecture/multithreading.md
+++ b/docs/architecture/multithreading.md
@@ -6,8 +6,8 @@ the tooling.
 
 ## Status
 
-**Phase 2 is under way.** Seven of its nine items have landed (#9, #4, #5, #6, #7,
-#10, #17); two have not (#3, #8). What building them
+**Phase 2 is under way.** Eight of its nine items have landed (#9, #4, #5, #6, #7,
+#8, #10, #17); one has not (#3). What building them
 changed is in [What building Phase 2 changed](#what-building-phase-2-changed) —
 including the findings that matter most for what is left: **band parallelism
 inside a primitive is the wrong unit for a page** (§4), **the largest single win
@@ -19,6 +19,11 @@ Item #17 added a tenth: **the split item #2 built was never reached by the host
 that does its own script extraction**, so a whole family of round trips was still
 serial in the path this repository measures
 ([§10](#10-item-17s-win-was-not-the-scan-it-was-a-host-that-never-reached-item-2s-split)).
+Item #8 added an eleventh, and it is the sharpest one in the phase: **only half of
+a load was safe to move earlier.** Moving a load's *completion* off the layout
+thread as well as its decode changed the rendered page — on the failure path only,
+which is the path whose callback does something
+([§12](#12-only-half-of-an-image-load-was-safe-to-move-and-the-other-half-changed-the-page)).
 
 | Item | State | Evidence |
 |---|---|---|
@@ -27,7 +32,7 @@ serial in the path this repository measures
 | #3 — band-parallel raster (`Broiler.Graphics`) | Not started | The partitioner and the exit-gate harness now exist; this is porting them to the second copy, and [§2](#2-the-rasterizer-the-profile-measures-is-item-4s-copy-not-item-3s) still says unify first. [§4](#4-band-parallelism-inside-a-primitive-is-the-wrong-unit-for-a-page) and [§8](#8-most-of-item-5-was-not-parallelism-it-was-the-rasterizer-drawing-pixels-nothing-could-see) both say the *clip narrowing* is the part worth porting first |
 | #5 — tile-parallel replay | **Done** | `TileParallelReplay`, `patches/0126-…`; `PerformPaint` at 1 → 4 tiles: `paint` **1 323.7 → 461.4 ms (2.87×)**, `rules` 3.49×, `text` 2.42×, `mixed` 2.44×, `boxes` 1.76× — faster than band parallelism on all five pages, including the three bands could not touch. Pixels identical at 1/2/4 tiles crossed with 1/4 bands on every page (`--tile-scaling`), 69 `RasterTileParallelismTests` cases, and a full WPT run at 1 and 4 tiles whose entire output diffs to **zero lines**. Most of the win was single-threaded — see [§8](#8-most-of-item-5-was-not-parallelism-it-was-the-rasterizer-drawing-pixels-nothing-could-see) |
 | #6/#7 — image decode | **Done** | `ImageDecodeParallelism`; JPEG **2.08–2.61×**, PNG **1.22–1.29×** at 4 threads, byte-identical at every setting (`--decode-scaling`, plus two cases in `Broiler.Media.Image.Managed.Tests`) |
-| #8 — concurrent decode across images | Not started | Unblocked by #9, but the headless render path loads images **synchronously and inline** (`AvoidAsyncImagesLoading`), so this needs #2's prefetch/consume split rather than a `Parallel.For` — see [§6](#6-item-8-is-a-prefetchconsume-split-not-a-parallelfor). Its remaining prerequisite is met: #17 supplies the image URL set (`PreloadScanResult.ResolvedUrls(PreloadKind.Image)`), so what is left is the consume split at `ImageLoadHandler` |
+| #8 — concurrent decode across images | **Done** | `ImagePrefetch` / `CssBox.PrefetchDocumentImages` / `DeferredImageLoad`; a document's image loads are issued from a worker pool before the layout pass and joined before it starts, so the pass finds every image already loaded. On a 12-image fixture at 4 concurrent loads: `PerformLayout` **183.7 → 97.1 ms (1.89×)**, whole render 204.3 → 118.4 (1.73×), over four runs 1.80–1.96× and 1.70–1.81× (`--image-prefetch-scaling`). Pixels identical at 1/2/3/4/8 loads over eleven documents (51 `ImagePrefetchTests` cases) and `css/css-backgrounds` identical at the budget on and off (40/16/5 both ways). **Only the decode moved; the completion callback did not** — moving it changed the page, see [§12](#12-only-half-of-an-image-load-was-safe-to-move-and-the-other-half-changed-the-page). It also discharges P0-c's outstanding debt: this is the first worker in the repository to establish the ambient render state and arm its assertion (6 `ImagePrefetchWorkerContractTests` cases, 3 of which fail against the code before the change) |
 | #10 — glyph outline cache | **Done** | `TrueTypeFont` caches outlines by glyph index; raster stage **1.34×** on `text`, **1.54×** on `boxes`, **1.00×** on the text-free `paint` control. The shaped-run cache the item names is *not* built — see [§5](#5-the-phases-largest-win-so-far-is-a-cache-and-not-the-one-item-10-names) |
 | #17 — preload scan | **Done** | `PreloadScanner` / `SpeculativePreloadScan`; a document's sub-resources are found by one tokenizer pass on a worker started before the parse. Stylesheet requests are **in flight while the document is still parsing** and external scripts in the capture host now overlap instead of going one at a time — **755.1 → 521.4 ms** (median paired ratio **0.655** over 5 interleaved pairs) on 8 scripts at 40 ms each, peak concurrency 6 against 1. Exit gate: `css/css-backgrounds` identical at `BROILER_PRELOAD_SCAN` on and off (40/16/5 both ways, every verdict and pixel-match percentage the same). 40 test cases, of which the two load-order ones are assertions on *when* a request reaches the origin rather than on a stopwatch. It also found a URL-resolution defect the CSP matcher was reading through — see [§10](#10-item-17s-win-was-not-the-scan-it-was-a-host-that-never-reached-item-2s-split) and [§11](#11-a-root-relative-url-resolved-to-the-filesystem-root-and-csp-was-matching-against-it) |
 
@@ -399,18 +404,32 @@ bytes. It does mean items #8, #10, #12 and #13 no longer have to route around
 this, and that a future in-process worker pool is now a design choice rather than
 a blocked one.
 
-**What is still owed before that pool exists:** the ambient-state contract is
-instrumented on all three slots but still off by default, and nothing yet calls
-`AmbientRenderState.Establish` on a worker thread because there are no worker
-threads. The first item that creates one has to arm `EnforceOnThisThread` in the
-same place it calls `Establish`, or the instrumentation bought here goes unused.
+**What was still owed before that pool exists — and item #8 has now paid it.** The
+ambient-state contract was instrumented on all three slots but off by default,
+because nothing called `AmbientRenderState.Establish` on a worker thread: there
+were no worker threads. The debt was recorded here as *the first item that creates
+one has to arm `EnforceOnThisThread` in the same place it calls `Establish`, or the
+instrumentation bought here goes unused.* Item #8's image-prefetch worker is that
+thread, and it does both — `ImagePrefetch.RunAll` establishes every slot per load
+and arms the assertion for the duration, then clears the record and restores the
+switch so a pooled thread does not vouch for the next document's state or leave a
+trap for whatever runs on it next. `ImagePrefetchWorkerContractTests` asserts all
+of that on the real worker, and 3 of its 6 cases fail against the code before it.
+
+**What arming it bought, given that nothing failed:** an audit rather than a fix.
+An image load can reach SVG rasterization, which opens a canvas and draws — text
+included — so a prefetch worker is a render thread by any reasonable definition.
+Following the enforcement through said `BSvgRasterizer` reads none of the three
+slots: it parses its own attributes and builds its own coordinate context, and the
+font cache underneath it was made thread-safe by item #9. That is now a checked
+claim instead of an assumption, and the check is what will fire the day an image
+decode grows a dependency on the viewport.
 
 Band-parallel raster (item #4) does **not** discharge that debt, and it is worth
-saying why it does not need to: a band never leaves the primitive it was created
+saying why it did not need to: a band never leaves the primitive it was created
 in, so it inherits nothing and establishes nothing. The ambient slots are read
 during *layout* and during display-list *construction*, both of which have
-finished before a fill starts. The first item that has to arm the enforcement is
-still the first one that renders a whole document off the calling thread.
+finished before a fill starts.
 
 ### 4. Band parallelism inside a primitive is the wrong unit for a page
 
@@ -516,6 +535,31 @@ cache. The `SubResourcePrefetcher` written for #2 is the precedent, and item #17
 (the preload scan) is what supplies the URL set — so **#17 should come before
 #8**, which is the reverse of the order the component roadmap lists them in.
 
+**Half of that prediction was right, and the half that was wrong saved the work.**
+The shape is a prefetch/consume split, as this section says. But the URL set turned
+out not to need item #17 at all: the box tree already holds it, and it holds it
+better. A preload scan finds what a document's *source* names, which is a
+superset — an `<img>` inside a `display:none` subtree, or one a script removed
+before layout, is a URL in the source and not a load the document makes. The box
+tree, walked at the document root after construction and before the layout pass,
+names what layout is about to ask for; and because a box the walk skips simply
+loads inline as it always did, an incomplete answer costs speed rather than
+correctness. So `PreloadScanResult.ResolvedUrls(PreloadKind.Image)` is still
+unconsumed, and item #16 remains its only prospective customer. The general point
+is worth keeping: **discovering a resource set from the structure the consumer will
+actually walk beats discovering it from the source, whenever that structure exists
+in time.** For images it does; for stylesheets, which item #17 does feed, it does
+not — those are wanted before there is a tree at all.
+
+**And the "consuming from a cache" half was unnecessary too.** Layout already asks
+the host for a loader per image and calls `LoadImage` on it; the prefetch is those
+same two calls, moved. No cache keyed by URL, no ownership transfer, no second way
+to load an image — and no submodule change, because the whole of it sits in
+`Broiler.Layout`. A cache would additionally have had to decide what to do about a
+document referencing one file twice, which today is two loaders and two decodes;
+collapsing them would have changed how many times the file is read, which is not a
+change a latency item gets to make on the way past.
+
 **What the exit gate actually ran on.** The corpus scaling harness compares pixels
 per page, which is five documents. The gate the roadmap sets is the WPT corpus, and
 it was run twice at four workers — once with the raster and decode budgets forced
@@ -558,6 +602,40 @@ thread for one tokenizer pass and then blocks on I/O, so *N* workers do not prod
 *N × cores* runnable threads — they produce *N* threads that are almost always
 waiting on a socket. It has an on/off switch (`BROILER_PRELOAD_SCAN`) because the
 exit gate requires a sequential equivalent, not because a host has to size it.
+
+**Item #8's budget passes that test and is in the division**
+(`BROILER_IMAGE_PREFETCH_THREADS`): a concurrent image load holds a core for the
+length of a decode, which is exactly the shape the division is for. One consequence
+is worth stating rather than discovering: at the pool's default of one worker per
+core the per-worker figure is 1, and 1 turns the walk off. That is the right answer
+— *N* workers each rendering a document already saturate the cores, and there is
+nothing left for a second axis to win — but it does mean **a default WPT run does
+not exercise item #8**, which is why its gate is run at `--workers 1`.
+
+**Its two budgets are the first pair in this document that genuinely compound, and
+dividing them is still wrong.** A concurrent image load decodes through items
+#6/#7's band partitioner, so *N* loads at *N* bands is *N²* runnable threads on
+*N* cores — unlike bands and tiles, which a tile view keeps from ever running at
+once. The correction was built and measured at nothing: over four interleaved runs
+the layout stage reads 94.7 / 91.3 / 101.8 / 85.6 ms undivided against
+92.1 / 90.6 / 94.0 / 93.6 divided — three runs favour the division by 1–8% and the
+fourth penalises it by 9%, so the effect does not have a sign, let alone a size.
+The .NET pool already serialises the excess, and a document's images do not divide
+evenly into waves — the last wave runs with fewer loads than the budget and wants
+every core it can get. So the
+prefetch budget gets the same figure as the decode budget, for a different reason
+than the tile budget does, and `--image-prefetch-scaling` keeps the divided
+configuration as a column so the null result stays re-runnable.
+
+**How that null result was nearly a false positive is the more useful half.**
+Measured in its own block rather than inside the interleave, dividing read **1.10×
+faster** on the first run and **1.17× slower** on the second — the sign of the
+effect changed between two runs of the same code. `DecodeScaling` already documents
+why for this host (throughput drifts by tens of percent over tens of seconds) and
+its own settings are interleaved for that reason; the mistake was assuming a
+configuration measured *outside* the interleave could be compared with the ones
+inside it, however carefully its own medians were taken. **A median is only
+comparable with another median taken under the same drift.**
 
 ### 8. Most of item #5 was not parallelism; it was the rasterizer drawing pixels nothing could see
 
@@ -742,6 +820,66 @@ and it suggests the narrower rule behind §5 and §8: **an item that asserts its
 inputs by value audits every layer it reads through**, and the layers under a
 latency item are usually older than it is.
 
+### 12. Only half of an image load was safe to move, and the other half changed the page
+
+Item #8 is a latency-and-CPU item with an easy-looking shape: a document's images
+are read and decoded one at a time, inline, so issue them all at once from a pool
+before the layout pass and join before it starts. That is what shipped, and it is
+worth **1.73–1.89×** on a 12-image document. The first version of it rendered a
+different page, and what it got wrong is the part worth recording.
+
+**A load has two halves and only one of them is arithmetic.** The expensive half
+resolves the source, reads the bytes and decodes them. The other half is the
+completion callback: it stores the image and its rectangle on the box, sets a 2px
+error border when the image is null, and may ask the host to refresh. Moving the
+whole load to a worker moves both — and the second half is *observable*, because a
+box that acquires an error border before its width is resolved lays out differently
+from one that acquires it after. Three broken `<img>` elements rendered **6–10
+pixels wider** with the loads on workers than with them inline.
+
+**Every document with working images was byte-identical, which is how this class of
+defect survives a test suite.** The divergence lived entirely on the failure path,
+because that is the path whose callback *does* something: on success the callback
+stores two values the layout pass was going to read anyway, and the order it stores
+them in relative to the pass is invisible. Ten of the eleven documents in the item's
+test suite passed against the broken version. So the fix is not "handle failures
+too" — it is to stop relying on which documents were tried:
+`DeferredImageLoad` wraps the callback the host's loader is given, captures the
+completion on the worker, and applies it from the inline call site the serial path
+would have completed at. The real callback then runs on the layout thread, at the
+same call site, in the same order, with the arguments the loader produced. There is
+no document for which that can differ.
+
+**The generalisation.** Item #5's lesson was *check what a stage is recomputing, and
+what it is computing that nobody will see*. This one is the other half of moving
+work earlier: **ask what the work notifies, not only what it computes.** A pure
+function can be hoisted; a function that writes to the object its caller is about to
+measure cannot, and the difference is invisible on every input whose write happens
+to be idempotent with respect to the measurement.
+
+**A second thing this item did not need, and the reason is reusable.** §6 predicted
+#8 would consume item #17's image URL set. It does not, and should not: a preload
+scan finds what a document's *source* names, which is a superset of what layout will
+ask for — an `<img>` in a `display:none` subtree is in the source and is not a load
+the document makes. The box tree, walked at the root after construction, names what
+the consumer is about to walk. **Discover a resource set from the structure the
+consumer will actually walk, whenever that structure exists in time.** For images it
+does. For stylesheets, which #17 does feed, it does not: those are wanted before
+there is a tree at all. That is the whole of the difference between the two items,
+and it is why one scan does not serve both.
+
+**Recorded in passing, and deliberately not fixed here:** a missing image file
+completes with a null image and reports **nothing** to the host —
+`ImageLoadHandler.SetImageFromFile` calls `ImageLoadComplete()` on the
+`!source.Exists` branch without a `ReportError`, where every other failure path
+reports. It also passes `async: true` there on a host that has asked for
+synchronous loading, which is what makes a broken image request a refresh it should
+not. Both are pre-existing, both live in `Broiler.HTML`, and neither is something a
+concurrency item gets to change on the way past — a load that starts reporting
+would change what a host is told about pages that render identically today. They
+surfaced because this item's tests counted error reports, which is §11's lesson
+again: an item that asserts a value audits the layer under it.
+
 ## Master table
 
 Gain is per-stage unless stated. Effort is engineering days for one person
@@ -757,7 +895,7 @@ non-deterministic correctness defect.
 | 5 | Graphics / Layout | [`DisplayList.cs`](../../Broiler.Layout/Broiler.Layout/IR/DisplayList.cs) replayed by [`RGraphicsRasterBackend`](../../Broiler.HTML/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs) — **DONE** | Was one pass over the whole surface; now `Parallel.For` over horizontal strips via [`TileParallelReplay`](../../Broiler.Layout/Broiler.Layout/IR/TileParallelReplay.cs), each replaying the whole list into its own strip | Nothing | **DONE, and the estimate was right about the ceiling for the wrong reason.** `PerformPaint` at 1 → 4 tiles: `paint` **1 323.7 → 461.4 ms (2.87×)**, `rules` 3.49×, `text` 2.42×, `mixed` 2.44×, `boxes` 1.76× on a 4-core box — and it beats band parallelism on all five pages. But on the pages taller than their viewport — which is most documents — a large share of it came from *not drawing invisible pixels* rather than from threads ([§8](#8-most-of-item-5-was-not-parallelism-it-was-the-rasterizer-drawing-pixels-nothing-could-see)). Pixels identical at 1/2/4 tiles × 1/4 bands; WPT output identical to the line | Low–Medium | Done | 2 |
 | 6 | Media | [`JpegDecoder.cs:385`](../../Broiler.Media/Broiler.Media.Image.Managed/Jpeg/JpegDecoder.cs) dequantize+IDCT per block, `:424` upsample + YCbCr→RGB per row | Sequential | `Parallel.For` over blocks / rows. Entropy decode stays sequential (optionally per-RST-interval) | Nothing structural; blocks and output rows are disjoint | **DONE. Measured 2.08–2.61× at 4 threads** (gradient / flat-block fixtures, 1 024²), which lands inside the estimate. Byte-identical at 1, 2 and 4 threads. `JpegDct.Inverse` also took a caller-owned scratch buffer, removing a 512-byte allocation per block | Low | Done | 2 |
 | 7 | Media | [`PngDecoder.cs:293`](../../Broiler.Media/Broiler.Media.Image.Managed/Png/PngDecoder.cs) expand-to-RGBA | Sequential | `Parallel.For` over rows | Inflate (`:62`) and unfilter (`:63`) are genuinely sequential — Up/Paeth read the previous row | **DONE. Measured 1.22–1.29× at 4 threads**, just under the estimate: inflate and unfilter are a larger share of a PNG decode than the estimate assumed, and both are on the do-not-parallelize list | Low | Done | 2 |
-| 8 | Media / HTML | Per-image decode, driven from [`ImageLoadHandler.cs:177`](../../Broiler.HTML/Source/Broiler.HTML.Core/Handlers/ImageLoadHandler.cs) | Already `ThreadPool.QueueUserWorkItem` for file reads; decode is on the completion path | Decode *N* page images concurrently — coarser and better than #6/#7 | **Not what this cell said.** `BImageRenderer._images` is fixed and the decoders are covered by a re-entrancy test, but every headless entry point sets `AvoidAsyncImagesLoading`, so decode is synchronous and inline. Needs #2's prefetch/consume split fed by #17 ([§6](#6-item-8-is-a-prefetchconsume-split-not-a-parallelfor)) | **Near-linear in image count** up to core count | Low | 3–4 d, after #17 | 2 |
+| 8 | Media / HTML — **DONE** | The document-wide walk in [`CssBox.ImagePrefetch.cs`](../../Broiler.Layout/Broiler.Layout/Engine/CssBox.ImagePrefetch.cs), consumed at `MeasureWordsSize`; loads still run through [`ImageLoadHandler`](../../Broiler.HTML/Source/Broiler.HTML.Core/Handlers/ImageLoadHandler.cs) | One worker per image, up to `BROILER_IMAGE_PREFETCH_THREADS`, joined before the layout pass | Nothing. **Neither blocker this cell named was the one that mattered.** `BImageRenderer._images` was cleared by #9; the shape was decided by every headless entry point setting `AvoidAsyncImagesLoading`, which makes decode synchronous and inline ([§6](#6-item-8-is-a-prefetchconsume-split-not-a-parallelfor)). It needed neither #17's URL set nor a cache, and it needed one thing the row could not have predicted: the completion callback has to stay on the layout thread ([§12](#12-only-half-of-an-image-load-was-safe-to-move-and-the-other-half-changed-the-page)) | **Measured: 1.89× of `PerformLayout`, 1.73× end to end** at 4 concurrent loads on a 12-image fixture (1.80–1.96× / 1.70–1.81× over four runs). Sub-linear in image count, not near-linear: the decodes already split into bands, so the cores were not idle | Low | Done | 2 |
 | 9 | Graphics | [`FontsHandler.cs`](../../Broiler.Graphics/Broiler.Graphics/Text/FontsHandler.cs), [`TrueTypeFont.cs`](../../Broiler.Graphics/Broiler.Graphics/Text/TrueTypeFont.cs), [`FallbackSystemFont.cs`](../../Broiler.Graphics/Broiler.Graphics/Rendering/FallbackSystemFont.cs), [`BImageRenderer.cs`](../../Broiler.Graphics/Broiler.Graphics/Rendering/BImageRenderer.cs) — **DONE** | Plain `Dictionary`, no synchronization; and two lazy-init latches published before their values | Not a speedup itself — a **hard prerequisite** for #10, #12, #13, and per Phase 1 §2 for *every* CPU-parallel render-path item | Nothing now | **DONE.** Nested map flattened to one concurrent dictionary; image table concurrent and handle allocation interlocked; replay transform state moved per-call; `TrueTypeFont`'s five lazy tables re-published through `Lazy` in `ExecutionAndPublication`. Both P0-c residuals closed with it. Enables ~4 items | Low | Done | 2 |
 | 10 | Graphics | [`TrueTypeFont.GetGlyphContours`](../../Broiler.Graphics/Broiler.Graphics/Text/TrueTypeFont.cs) — **DONE**; [`ComplexTextShaper.Shape:72`](../../Broiler.Graphics/Broiler.Graphics/Text/ComplexTextShaper.cs) — not built | Outlines were re-extracted per glyph *occurrence*; shaping is called per run during layout | Concurrent cache by glyph index, published through `GetOrAdd` | Nothing | **The item was right that the cache is the whole win, and wrong about which cache.** Glyph outlines: raster stage **1.34×** (`text`), **1.54×** (`boxes`), 1.00× on the text-free `paint` control. The shaped-run cache is deliberately unbuilt — `RequiresShaping` is false for the whole Latin corpus, so it would measure nothing ([§5](#5-the-phases-largest-win-so-far-is-a-cache-and-not-the-one-item-10-names)) | Low | Done (outlines) | 2 |
 | 11 | CSS | [`CssStyleEngine.CollectFromRules:623`](../../Broiler.CSS/Broiler.CSS.Dom/CssStyleEngine.cs) — linear scan of every rule of every sheet, per element | O(elements × rules) | **Not multithreading.** Rule index (bucket by id/class/tag) + ancestor bloom filter | Nothing — this is the standard engine design and it is simply absent | **DONE.** Exit gate met: with matches fixed at four, 32× the rules now costs 1.64× the time and 1.13× the bytes (was 30.8× / 32.0×) — up to **136.9× faster** and **600× less garbage** at 3 200 rules. On a whole render the corpus `rules` page is 5 218.96 ms → 1 841.71 ms (2.8×); see [What building Phase 1 changed](#what-building-phase-1-changed) §1. `patches/0123-css-cascade-rule-index.patch` | Low | Done | 1 |
@@ -1111,10 +1249,29 @@ here, and step 2 is that.
 
 ### Broiler.Media
 
-1. **Concurrent decode across images** (item #8) — still the better win when a
-   page has several images, but it is a prefetch/consume split rather than the
-   coarse `Parallel.For` this step used to describe, and it wants item #17 first:
-   [§6](#6-item-8-is-a-prefetchconsume-split-not-a-parallelfor).
+1. **Concurrent decode across images** (item #8) — **DONE**, and it is the better
+   win when a page has several images. A prefetch/consume split rather than the
+   coarse `Parallel.For` this step used to describe
+   ([§6](#6-item-8-is-a-prefetchconsume-split-not-a-parallelfor)), but **not** fed by
+   item #17 as that section predicted: the box tree names what layout will actually
+   ask for, where a source scan names a superset
+   ([§12](#12-only-half-of-an-image-load-was-safe-to-move-and-the-other-half-changed-the-page)).
+   The walk lives in `Broiler.Layout` — `ImagePrefetch` holds the budget
+   (`BROILER_IMAGE_PREFETCH_THREADS`, where 1 is the pre-change path) and
+   `DeferredImageLoad` is what keeps each completion on the layout thread.
+   *Exit gate — met.* Pixels identical at 1, 2, 3, 4 and 8 concurrent loads over
+   eleven documents chosen for what decides something about the walk (background
+   layers, a box that is both, duplicate sources, both kinds of failure, SVG, inline
+   data, hidden subtrees, table cells) — 51 `ImagePrefetchTests` cases; the walk's
+   claim count asserted directly where pixels cannot see it, which is what pins the
+   `display:none` exclusion; and WPT `css/CSS2` — whose `visudet` replaced-element
+   tests carry seven images each, the shape a late decode would corrupt — identical
+   at the budget on and off (13 passed, 4 failed, 0 skipped both ways, 97.16%
+   average match, whole output differing by one elapsed-time line).
+   `css/css-backgrounds` was run the same way and is also identical (40/16/5), but
+   **that run is a no-regression check rather than a gate**: no file in that subset
+   references two images, so the walk never ran in it. Worth saying, because a
+   subset that cannot reach the code under test proves nothing about it.
 2. **JPEG intra-image** (item #6) — **DONE**. Bands of block rows for
    dequantize + IDCT, bands of output rows for upsample + YCbCr→RGB; the
    dequantized block and the IDCT intermediate moved inside the band, which is
@@ -1134,7 +1291,11 @@ here, and step 2 is that.
 Both go through `ImageDecodeParallelism`, whose budget is
 `BROILER_IMAGE_DECODE_THREADS` and whose default any host running several renders
 at once must divide — see
-[§7](#7-two-kinds-of-parallelism-now-multiply-and-the-runner-has-to-divide).
+[§7](#7-two-kinds-of-parallelism-now-multiply-and-the-runner-has-to-divide). Item
+#8's budget is in the same division, and the two of them are the first pair in this
+document that genuinely compound: a concurrent load decodes through the band
+partitioner, so *N* loads at *N* bands is *N²* threads. Dividing the inner one
+anyway measured as nothing, and §7 has the figures.
 
 ### Tooling — Broiler.Wpt and Broiler.Cli
 
@@ -1193,7 +1354,7 @@ Recording these so they are not revisited each time the topic comes up:
 |---|---|---|
 | **0 — Make it measurable and deterministic** | P0-a benchmarks, P0-b single-threaded event loop (#15), P0-c static-state audit, GC config evaluation (#19) | Nothing after this is trustworthy without it. #15 is a correctness fix that also removes lock overhead from the cascade. |
 | **1 — Free wins and the sequential fixes** — **DONE** | WPT worker pool (#1), CLI batch (#20), concurrent sub-resource fetch (#2), CSS rule indexing (#11) | Cheap, low-risk, and #1 shortens the feedback loop for everything else. #11 is single-threaded but must precede #12. **What it changed:** #11 met its exit gate (cascade cost is now flat in total rules) but is 2.8× on a whole render, and `parse+cascade` still dominates the rule-heavy page — so #12 needs that stage split before it is started; #20 had to use processes, which makes item #9 a gate on every render-path item, not three. |
-| **2 — Raster, decode, text** — *in progress; 7 of 9 items done* | Rasterizer unification + band/tile parallelism (#3, #4, #5), font-cache safety (#9), text caches (#10), image decode (#6, #7, #8), preload scan (#17) | Largest CPU wins, disjoint memory, verifiable by exact pixel comparison. **#9 first, and it is done** — Phase 1 §2 made it the gate on every other item here, not just on #10/#12/#13. **What it changed, in the order it matters:** band parallelism inside a primitive turned out to be the wrong unit for a page — three of five corpus pages split zero fills, because their raster is glyphs — which promotes **#5 from "supersedes #3" to the only raster parallelism the corpus can use (§4)**; the phase's largest single win was a *cache*, and not the one #10 names (§5); #8 is a prefetch/consume split needing #17 first, not a `Parallel.For` (§6); the pool and the in-process threads multiply, so the runner now divides them (§7); the item-#9 findings (§1–§3) stand. **#5 landed and about half of its win was single-threaded** — the rasterizer was walking pixels its clip could never admit (§8) — and between them #4, #10 and #5 have taken raster from the largest stage on three pages to the largest on one (§9). **#17 landed and its number came from somewhere the item did not name:** the capture host does its own script extraction and so never reached the split item #2 built, leaving that family serial in the path this repository measures (§10). **What is left:** #3's port, and #8 — whose last prerequisite #17 has now supplied. The largest open question is still the parse/cascade split Phase 1 §1 named, which gates #12. See [What building Phase 2 changed](#what-building-phase-2-changed). |
+| **2 — Raster, decode, text** — *in progress; 8 of 9 items done* | Rasterizer unification + band/tile parallelism (#3, #4, #5), font-cache safety (#9), text caches (#10), image decode (#6, #7, #8), preload scan (#17) | Largest CPU wins, disjoint memory, verifiable by exact pixel comparison. **#9 first, and it is done** — Phase 1 §2 made it the gate on every other item here, not just on #10/#12/#13. **What it changed, in the order it matters:** band parallelism inside a primitive turned out to be the wrong unit for a page — three of five corpus pages split zero fills, because their raster is glyphs — which promotes **#5 from "supersedes #3" to the only raster parallelism the corpus can use (§4)**; the phase's largest single win was a *cache*, and not the one #10 names (§5); the pool and the in-process threads multiply, so the runner now divides them (§7); the item-#9 findings (§1–§3) stand. **#5 landed and about half of its win was single-threaded** — the rasterizer was walking pixels its clip could never admit (§8) — and between them #4, #10 and #5 have taken raster from the largest stage on three pages to the largest on one (§9). **#17 landed and its number came from somewhere the item did not name:** the capture host does its own script extraction and so never reached the split item #2 built, leaving that family serial in the path this repository measures (§10). **#8 landed, and it needed neither of the two things §6 predicted** — not #17's URL set (the box tree names what layout will actually ask for, where a source scan names a superset) and not a cache (layout's existing loader seam is the split) — but it did need one thing nothing predicted: **only the decode was safe to move off the layout thread, not the completion callback**, which changed the rendered page on the failure path and nowhere else (§12). It also discharges P0-c's last debt, being the first worker to establish the ambient state and arm its assertion. **What is left: #3's port**, which §4 and §8 both say should be the clip narrowing first and should be scheduled for the Writer and Broiler.UI paths rather than for a repeat of the 4–6x estimate. The largest open question is still the parse/cascade split Phase 1 §1 named, which gates #12 — and §9 makes it the largest unattributed question in the document. See [What building Phase 2 changed](#what-building-phase-2-changed). |
 | **3 — Style and incremental layout** | Cache sharding + parallel style recalc (#12), layout dirty bits (#14), parallel script compile (#16), re-enable test parallelization (#21) | Depends on Phase 1's algorithmic fixes and Phase 0's determinism. |
 | **4 — Parallel layout and workers** | Parallel intrinsic sizing and independent subtrees (#13), Web Workers (#18) | Highest cost, highest risk, lowest ceiling. Only worth starting once Phase 3's measurements say layout is still the bottleneck. |
 

--- a/src/Broiler.Cli.Tests/ImagePrefetchTests.cs
+++ b/src/Broiler.Cli.Tests/ImagePrefetchTests.cs
@@ -1,0 +1,506 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Broiler.Graphics;
+using Broiler.HTML.Core.Entities;
+using Broiler.HTML.Image;
+using Broiler.Layout;
+using Xunit;
+using BBitmap = Broiler.HTML.Image.BBitmap;
+using BColor = Broiler.Graphics.BColor;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// The exit gate for multithreading item #8: issuing a document's image loads concurrently produces
+/// the same render the serial inline loads did, at every budget — and claims no image the serial path
+/// would not have loaded.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Whole documents, and the files they reference.</b> The unit of this item is a document: what it
+/// changes is when a page's image loads start relative to the layout pass, so a test that drove a
+/// loader directly would exercise the part that did not change. The fixture writes real PNG, JPEG and
+/// SVG files to a temporary directory because <c>SetImageFromFile</c> is the path the roadmap's §6
+/// identifies as inline and serial; a <c>data:</c> URI decodes through <c>SetFromInlineData</c>
+/// instead, so it is present as one document rather than as all of them.
+/// </para>
+/// <para>
+/// <b>Byte comparison, not tolerance.</b> The roadmap's global exit gate is that a parallel path has a
+/// single-threaded equivalent reproducing its output <em>exactly</em>. For this item a tolerance would
+/// forgive the failure that matters most: an image whose decode landed after the box that needed it
+/// was measured, which is a replaced box at the wrong intrinsic size and a page that reflows around
+/// it.
+/// </para>
+/// <para>
+/// <b>Half of these cases are about what the walk refuses to claim, and that is deliberate.</b> The
+/// walk is one-sided by construction — a box it skips loads its image exactly where it did before, so
+/// under-claiming costs speed and over-claiming costs correctness. An image loaded for a box layout
+/// never measures is a request the document did not make and, for a broken source, an error the host
+/// would never have seen; neither is visible in a pixel comparison. So the counters are asserted
+/// directly.
+/// </para>
+/// </remarks>
+public sealed class ImagePrefetchTests : IClassFixture<ImagePrefetchTests.ImageFiles>
+{
+    private const int Width = 400;
+    private const int Height = 500;
+
+    private readonly ImageFiles _files;
+
+    public ImagePrefetchTests(ImageFiles files) => _files = files;
+
+    /// <summary>
+    /// Documents under test, one per shape that decides something about the walk. Named so a failure
+    /// says which shape diverged.
+    /// </summary>
+    private IReadOnlyDictionary<string, string> Documents => new Dictionary<string, string>
+    {
+        // The ordinary case: several replaced images, all of them measured.
+        ["several images"] = Document(Images(6)),
+
+        // Background layers reach the walk through CssBox rather than CssBoxImage, so they are a
+        // second claim site and not a variant of the first.
+        ["background layers"] = Document(Backgrounds(6)),
+
+        // A box that is both: a replaced image with a background of its own is two loads on one box,
+        // and CssBoxImage.LoadImagesForPrefetch has to do both.
+        ["image with its own background"] = Document(
+            $"<img src=\"{Name(0)}\" style=\"width:120px;height:90px;background-image:url({Name(1)})\">"
+            + $"<img src=\"{Name(2)}\" style=\"width:120px;height:90px;background-image:url({Name(3)})\">"),
+
+        // Mixed, which is what a real page looks like.
+        ["mixed"] = Document(Images(4) + Backgrounds(4)),
+
+        // The same file referenced twice: two boxes, two loaders, two loads — as before. A cache that
+        // collapsed them would change how many times the file is read.
+        ["duplicate sources"] = Document(
+            $"<img src=\"{Name(0)}\" style=\"width:120px;height:90px\">"
+            + $"<img src=\"{Name(0)}\" style=\"width:120px;height:90px\">"
+            + $"<div style=\"width:120px;height:90px;background-image:url({Name(0)})\"></div>"),
+
+        // Sources that fail, in the two ways a load can: a file that is not there, and inline data
+        // that will not decode. Both fail on a worker now, so both have to produce the box's error
+        // border and the host's error report exactly as they did when they failed during layout.
+        // Only the second reports: a missing file completes with a null image and no report at all,
+        // which is pre-existing behaviour in the load handler and is why the malformed data URI is
+        // here rather than three missing files.
+        ["broken sources"] = Document(
+            "<img src=\"does-not-exist-1.png\" style=\"width:120px;height:90px\">"
+            + $"<img src=\"{Name(0)}\" style=\"width:120px;height:90px\">"
+            + "<img src=\"does-not-exist-2.jpg\" style=\"width:120px;height:90px\">"
+            + "<img src=\"data:image/png;base64,not-base64-at-all\" style=\"width:120px;height:90px\">"
+            + "<img src=\"data:image/png;base64,\" style=\"width:120px;height:90px\">"),
+
+        // SVG, because it is the one image kind whose "decode" rasterizes — it opens a canvas and
+        // draws, including text. That is the case that makes a prefetch worker a render thread.
+        ["svg images"] = Document(
+            $"<img src=\"{SvgName(0)}\" style=\"width:150px;height:100px\">"
+            + $"<img src=\"{SvgName(1)}\" style=\"width:150px;height:100px\">"
+            + $"<img src=\"{Name(0)}\" style=\"width:120px;height:90px\">"),
+
+        // A data: URI alongside files: it takes SetFromInlineData rather than SetImageFromFile, so a
+        // walk that mishandled it would show up here and nowhere else.
+        ["inline data alongside files"] = Document(
+            "<img src=\"data:image/svg+xml;utf8,"
+            + "<svg xmlns='http://www.w3.org/2000/svg' width='40' height='30'><rect width='40' height='30' fill='%23c00'/></svg>"
+            + "\" style=\"width:80px;height:60px\">"
+            + Images(4)),
+
+        // display:none subtrees, which the walk must not claim: layout does not measure them, so an
+        // image inside one is not loaded — and a prefetch would load it.
+        ["hidden images"] = Document(
+            Images(3)
+            + $"<div style=\"display:none\"><img src=\"{Name(4)}\"><img src=\"{Name(5)}\"></div>"),
+
+        // An auto-width box, where the shrink-to-fit pre-pass measures descendants without consulting
+        // Display. Nothing here asserts a count; it is present because it is the case the walk's
+        // remarks say it declines, and the render still has to come out right.
+        ["shrink to fit around a hidden image"] = Document(
+            "<div style=\"float:left\">" + Images(2)
+            + $"<span style=\"display:none\"><img src=\"{Name(3)}\"></span></div>"),
+
+        // Images inside a table, whose cells are measured through a different path
+        // (CssLayoutEngineTable calls MeasureWordsSize itself).
+        ["images in a table"] = Document(
+            "<table><tr>"
+            + $"<td><img src=\"{Name(0)}\" style=\"width:90px;height:70px\"></td>"
+            + $"<td><img src=\"{Name(1)}\" style=\"width:90px;height:70px\"></td>"
+            + $"<td style=\"background-image:url({Name(2)})\">cell</td>"
+            + "</tr></table>"),
+    };
+
+    public static TheoryData<string, int> Cases
+    {
+        get
+        {
+            var data = new TheoryData<string, int>();
+            foreach (var name in new ImagePrefetchTests(ImageFiles.Shared).Documents.Keys)
+            {
+                foreach (var loads in new[] { 2, 3, 4, 8 })
+                    data.Add(name, loads);
+            }
+
+            return data;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void Concurrent_Image_Loads_Render_The_Same_Pixels_As_Serial_Ones(string document, int loads)
+    {
+        var serial = Render(Documents[document], concurrentLoads: 1);
+        var concurrent = Render(Documents[document], concurrentLoads: loads);
+
+        Assert.Equal(serial, concurrent);
+    }
+
+    /// <summary>
+    /// Guards the guard: every document above must actually reach the walk, or the equality
+    /// assertions are comparing the serial path with itself.
+    /// </summary>
+    [Fact]
+    public void These_Documents_Actually_Reach_The_Walk()
+    {
+        foreach ((string name, string html) in Documents)
+        {
+            var counts = RenderCounting(html, concurrentLoads: 4);
+
+            Assert.True(
+                counts.DocumentsWalked > 0,
+                $"'{name}' was never walked ({counts.DocumentsBelowMinimum} below-minimum, "
+                + $"{counts.DocumentsNotSynchronous} async-host skip(s)), so its equality test proves nothing.");
+            Assert.True(
+                counts.LoadsIssued >= ImagePrefetch.MinimumImagesToOverlap,
+                $"'{name}' issued only {counts.LoadsIssued} load(s).");
+        }
+    }
+
+    /// <summary>
+    /// A budget of one is the pre-change path, not a one-wide version of the new one: the walk does
+    /// not run, so every box creates its loader in <c>MeasureWordsSize</c> exactly where it used to.
+    /// </summary>
+    [Fact]
+    public void A_Budget_Of_One_Does_Not_Walk_At_All()
+    {
+        var counts = RenderCounting(Documents["several images"], concurrentLoads: 1);
+
+        Assert.Equal(0, counts.DocumentsWalked);
+        Assert.Equal(0, counts.LoadsIssued);
+
+        // Not even counted as a skip: at a budget of one the walk returns before it can have an
+        // opinion about the document, which is what makes this setting the untouched path.
+        Assert.Equal(0, counts.DocumentsBelowMinimum);
+        Assert.Equal(0, counts.DocumentsNotSynchronous);
+    }
+
+    /// <summary>
+    /// One image is not worth a worker: there is nothing to overlap it with, because the layout pass
+    /// that would otherwise have loaded it has not started.
+    /// </summary>
+    [Fact]
+    public void A_Document_Naming_One_Image_Is_Left_Alone()
+    {
+        var counts = RenderCounting(
+            Document($"<img src=\"{Name(0)}\" style=\"width:120px;height:90px\">"),
+            concurrentLoads: 4);
+
+        Assert.Equal(0, counts.DocumentsWalked);
+        Assert.Equal(1, counts.DocumentsBelowMinimum);
+    }
+
+    /// <summary>
+    /// A document with no images at all is neither walked nor counted as a skip — "nothing to do" is
+    /// not one of the two reasons a page can be declined for.
+    /// </summary>
+    [Fact]
+    public void A_Document_With_No_Images_Is_Not_Counted_At_All()
+    {
+        var counts = RenderCounting(Document("<p>no images here</p>"), concurrentLoads: 4);
+
+        Assert.Equal(0, counts.DocumentsWalked);
+        Assert.Equal(0, counts.DocumentsBelowMinimum);
+        Assert.Equal(0, counts.DocumentsNotSynchronous);
+    }
+
+    /// <summary>
+    /// A host that permits late image loading is skipped, and the reason is recorded separately from
+    /// "too few images".
+    /// </summary>
+    /// <remarks>
+    /// <b>This is a safety property, not a policy one.</b> A load that completes while late loading is
+    /// permitted calls <c>RequestRefresh</c> from whichever thread it completed on, and handing a host
+    /// a relayout request on a worker it never agreed to be called back on is exactly what a
+    /// speculation must not do. So the configuration is declined rather than accommodated.
+    /// </remarks>
+    [Fact]
+    public void A_Host_That_Permits_Late_Image_Loading_Is_Skipped()
+    {
+        var counts = RenderCounting(
+            Documents["several images"],
+            concurrentLoads: 4,
+            avoidImagesLateLoading: false);
+
+        Assert.Equal(0, counts.DocumentsWalked);
+        Assert.Equal(1, counts.DocumentsNotSynchronous);
+        Assert.Equal(0, counts.DocumentsBelowMinimum);
+    }
+
+    /// <summary>
+    /// An image inside a <c>display:none</c> subtree is not claimed. Layout does not measure that
+    /// subtree, so loading its image would put a request on the wire the document did not make.
+    /// </summary>
+    /// <remarks>
+    /// The count is the assertion because the pixels cannot be: a hidden image draws nothing either
+    /// way, so a walk that loaded it would render identically and differ only in what it fetched and
+    /// what it reported. Two of the five images in this document are hidden.
+    /// </remarks>
+    [Fact]
+    public void An_Image_In_A_Hidden_Subtree_Is_Not_Claimed()
+    {
+        var counts = RenderCounting(Documents["hidden images"], concurrentLoads: 4);
+
+        Assert.Equal(3, counts.LoadsIssued);
+    }
+
+    /// <summary>
+    /// A broken source is reported to the host exactly as often as the serial path reported it: once
+    /// per reference, from whichever thread ran the load.
+    /// </summary>
+    /// <remarks>
+    /// <b>A count, because a count is what the event carries</b> —
+    /// <c>HtmlRenderErrorEventArgs</c> exposes only the error's <c>Type</c>. The number is still the
+    /// property worth pinning: a walk that claimed a box layout would not have measured would report
+    /// more, and one that loaded an image twice would too. Order is deliberately not asserted, since
+    /// the loads no longer complete in document order and nothing about an image failure's meaning
+    /// depends on which of two the host hears about first.
+    /// </remarks>
+    [Fact]
+    public void A_Broken_Source_Is_Reported_The_Same_Number_Of_Times()
+    {
+        var serial = CountImageErrors(Documents["broken sources"], concurrentLoads: 1);
+        var concurrent = CountImageErrors(Documents["broken sources"], concurrentLoads: 4);
+
+        Assert.True(serial > 0, "the serial render reported no image error, so this proves nothing");
+        Assert.Equal(serial, concurrent);
+    }
+
+    private byte[] Render(string html, int concurrentLoads)
+    {
+        var previous = ImagePrefetch.MaxDegreeOfParallelism;
+        ImagePrefetch.MaxDegreeOfParallelism = concurrentLoads;
+        try
+        {
+            using var bitmap = HtmlRender.RenderToImageWithStyleSet(
+                html, Width, Height,
+                backgroundColor: new BColor(255, 255, 255, 255),
+                baseUrl: _files.BaseUrl);
+            return bitmap.Encode();
+        }
+        finally
+        {
+            ImagePrefetch.MaxDegreeOfParallelism = previous;
+        }
+    }
+
+    private (long DocumentsWalked, long LoadsIssued, long DocumentsBelowMinimum, long DocumentsNotSynchronous)
+        RenderCounting(string html, int concurrentLoads, bool avoidImagesLateLoading = true)
+    {
+        var previous = ImagePrefetch.MaxDegreeOfParallelism;
+        ImagePrefetch.MaxDegreeOfParallelism = concurrentLoads;
+        ImagePrefetch.ResetDiagnostics();
+        ImagePrefetch.CollectDiagnostics = true;
+        try
+        {
+            RenderThroughContainer(html, avoidImagesLateLoading);
+            return ImagePrefetch.Diagnostics;
+        }
+        finally
+        {
+            ImagePrefetch.CollectDiagnostics = false;
+            ImagePrefetch.MaxDegreeOfParallelism = previous;
+        }
+    }
+
+    /// <summary>
+    /// Renders through a container rather than <c>HtmlRender</c>, because the image-loading flags are
+    /// what some of these cases vary and <c>HtmlRender</c> sets both of them itself.
+    /// </summary>
+    private void RenderThroughContainer(string html, bool avoidImagesLateLoading)
+    {
+        var clip = new RectangleF(0, 0, Width, Height);
+        using var bitmap = new BBitmap(Width, Height);
+        using var container = new HtmlContainer();
+        container.Location = new PointF(0, 0);
+        container.MaxSize = new SizeF(Width, Height);
+        container.AvoidAsyncImagesLoading = true;
+        container.AvoidImagesLateLoading = avoidImagesLateLoading;
+        container.SetHtmlWithStyleSet(html, null, _files.BaseUrl);
+        bitmap.Clear(BColor.White);
+        container.PerformLayout(bitmap, clip);
+        container.PerformPaint(bitmap, clip);
+    }
+
+    private int CountImageErrors(string html, int concurrentLoads)
+    {
+        var errors = 0;
+        var previous = ImagePrefetch.MaxDegreeOfParallelism;
+        ImagePrefetch.MaxDegreeOfParallelism = concurrentLoads;
+        try
+        {
+            var clip = new RectangleF(0, 0, Width, Height);
+            using var bitmap = new BBitmap(Width, Height);
+            using var container = new HtmlContainer();
+            container.Location = new PointF(0, 0);
+            container.MaxSize = new SizeF(Width, Height);
+            container.AvoidAsyncImagesLoading = true;
+            container.AvoidImagesLateLoading = true;
+            // Counted with an interlocked increment because the loads that report these now run
+            // concurrently, which is the change. A host that keeps a list here needs the same care,
+            // and this counter needing it is the test noticing that on the host's behalf.
+            container.RenderError += (_, args) =>
+            {
+                if (args.Type == HtmlRenderErrorType.Image)
+                    Interlocked.Increment(ref errors);
+            };
+            container.SetHtmlWithStyleSet(html, null, _files.BaseUrl);
+            bitmap.Clear(BColor.White);
+            container.PerformLayout(bitmap, clip);
+            container.PerformPaint(bitmap, clip);
+        }
+        finally
+        {
+            ImagePrefetch.MaxDegreeOfParallelism = previous;
+        }
+
+        return errors;
+    }
+
+    private static string Document(string body) =>
+        "<!DOCTYPE html><html><head><style>"
+        + "body{margin:0;font:13px/1.4 sans-serif}"
+        + "img{display:inline-block;margin:2px}"
+        + ".bg{width:110px;height:80px;display:inline-block;margin:2px;"
+        + "background-repeat:no-repeat;background-size:cover}"
+        + "</style></head><body>" + body + "</body></html>";
+
+    private static string Images(int count)
+    {
+        var sb = new StringBuilder();
+        for (var i = 0; i < count; i++)
+            sb.Append("<img src=\"").Append(Name(i)).Append("\" style=\"width:110px;height:80px\">");
+        return sb.ToString();
+    }
+
+    private static string Backgrounds(int count)
+    {
+        var sb = new StringBuilder();
+        for (var i = 0; i < count; i++)
+            sb.Append("<div class=\"bg\" style=\"background-image:url(").Append(Name(i)).Append(")\"></div>");
+        return sb.ToString();
+    }
+
+    private static string Name(int i) => ImageFiles.NameOf(i);
+
+    private static string SvgName(int i) => ImageFiles.SvgNameOf(i);
+
+    /// <summary>
+    /// A directory of encoded images shared by every case in this class, written once and deleted
+    /// when the class finishes.
+    /// </summary>
+    /// <remarks>
+    /// <b>Shared rather than per-case, and it has to be.</b> These files are inputs, not state: no
+    /// case writes to them, and encoding eight bitmaps per theory case would dominate the run. The
+    /// static <see cref="Shared"/> exists only for <see cref="Cases"/>, which xunit evaluates before
+    /// any fixture is constructed and which needs the file names to build the documents.
+    /// </remarks>
+    public sealed class ImageFiles : IDisposable
+    {
+        private const int FileCount = 8;
+        private const int Size = 64;
+
+        private static readonly Lazy<ImageFiles> Lazy = new(() => new ImageFiles());
+
+        private readonly string _directory;
+
+        public ImageFiles()
+        {
+            _directory = Path.Combine(
+                Path.GetTempPath(),
+                "broiler-image-prefetch-tests-"
+                    + Environment.ProcessId.ToString(CultureInfo.InvariantCulture)
+                    + "-" + Guid.NewGuid().ToString("N")[..8]);
+            Directory.CreateDirectory(_directory);
+
+            for (var i = 0; i < FileCount; i++)
+            {
+                using var source = BuildImage(i);
+                File.WriteAllBytes(
+                    Path.Combine(_directory, NameOf(i)),
+                    i % 2 == 0
+                        ? source.Encode(Media.Image.ImageEncodeFormat.Png, 100)
+                        : source.Encode(Media.Image.ImageEncodeFormat.Jpeg, 90));
+            }
+
+            for (var i = 0; i < 2; i++)
+            {
+                File.WriteAllText(Path.Combine(_directory, SvgNameOf(i)),
+                    "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"120\" height=\"80\">"
+                    + $"<rect x=\"4\" y=\"4\" width=\"112\" height=\"72\" fill=\"#{i}9{i}\" stroke=\"#333\"/>"
+                    + $"<circle cx=\"{30 + i * 20}\" cy=\"40\" r=\"18\" fill=\"#fc0\"/>"
+                    + $"<text x=\"10\" y=\"70\" font-size=\"12\">svg {i}</text></svg>");
+            }
+
+            BaseUrl = new Uri(Path.Combine(_directory, "page.html")).AbsoluteUri;
+        }
+
+        internal static ImageFiles Shared => Lazy.Value;
+
+        /// <summary>Base for the documents' relative <c>src</c>s — this directory.</summary>
+        public string BaseUrl { get; }
+
+        internal static string NameOf(int i) =>
+            i % 2 == 0
+                ? "f" + (i % FileCount).ToString(CultureInfo.InvariantCulture) + ".png"
+                : "f" + (i % FileCount).ToString(CultureInfo.InvariantCulture) + ".jpg";
+
+        internal static string SvgNameOf(int i) =>
+            "s" + i.ToString(CultureInfo.InvariantCulture) + ".svg";
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_directory, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A leftover temp directory is not a failed test.
+            }
+        }
+
+        /// <summary>Deterministic and distinct per index, so no two files decode to the same pixels.</summary>
+        private static BBitmap BuildImage(int seed)
+        {
+            var bitmap = new BBitmap(Size, Size);
+            var offset = seed * 29;
+            for (var y = 0; y < Size; y++)
+            {
+                for (var x = 0; x < Size; x++)
+                {
+                    bitmap.SetPixel(x, y, new BColor(
+                        (byte)((x * 4 + offset) & 0xFF),
+                        (byte)((y * 4 + offset) & 0xFF),
+                        (byte)(((x + y) * 2 + offset) & 0xFF),
+                        255));
+                }
+            }
+
+            return bitmap;
+        }
+    }
+}

--- a/src/Broiler.Wpt/Program.cs
+++ b/src/Broiler.Wpt/Program.cs
@@ -896,6 +896,7 @@ public class Program
         "BROILER_RASTER_THREADS",
         "BROILER_RASTER_TILES",
         "BROILER_IMAGE_DECODE_THREADS",
+        "BROILER_IMAGE_PREFETCH_THREADS",
     ];
 
     private static string DescribeWorkerPool(int workerCount, int? requested, bool useWorkerIsolation)

--- a/tests/render-stages/Broiler.Render.Stage.Benchmarks/ImagePrefetchScaling.cs
+++ b/tests/render-stages/Broiler.Render.Stage.Benchmarks/ImagePrefetchScaling.cs
@@ -1,0 +1,457 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using Broiler.Graphics;
+using Broiler.HTML.Image;
+using Broiler.Layout;
+using Broiler.Media.Image;
+using Broiler.Media.Image.Managed;
+using BBitmap = Broiler.HTML.Image.BBitmap;
+
+namespace Broiler.Render.Stage.Benchmarks;
+
+/// <summary>
+/// Multithreading item #8: what issuing a document's image loads concurrently is worth, whether any
+/// setting changes a pixel, and — when a page does not move — which of the reasons the walk declined
+/// it for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this harness needs a page of its own.</b> The five <see cref="Corpus"/> pages contain no
+/// images at all, by construction: each is built to load one stage, and an <c>&lt;img&gt;</c> on the
+/// text page would have folded decode into the text row. So there is nothing in the corpus this item
+/// can be measured on, and adding an image to a corpus page would change every number the published
+/// stage profile quotes. <see cref="DecodeScaling"/> set the precedent — items #6 and #7 are measured
+/// on fixtures that harness builds — and this follows it, one level up: the fixture here is a
+/// document plus the files it references, because the thing being measured is what a *document's*
+/// worth of images costs.
+/// </para>
+/// <para>
+/// <b>The files are real files on disk, and that is the point.</b> A <c>data:</c> URI would decode
+/// through <c>SetFromInlineData</c>, which is a different call path from
+/// <c>SetImageFromFile</c>/<c>LoadImageFromFile</c> — and the second is the one the roadmap's §6 says
+/// is inline and serial on every headless entry point. Measuring the first would measure a path no
+/// page with real images takes.
+/// </para>
+/// <para>
+/// <b>The layout stage is timed, not just the render.</b> Image loads run from
+/// <c>MeasureWordsSize</c>, which is inside <c>PerformLayout</c> — so that is the stage the item
+/// moves, and it is reported next to the whole render. An end-to-end table alone would divide the
+/// effect by however much of the render is raster before reporting it.
+/// </para>
+/// <para>
+/// <b>Both budgets are swept, because unlike bands and tiles these two compound.</b> A tile view runs
+/// its bands inline, so a render spends one or the other; a concurrent image load decodes with items
+/// #6/#7's band parallelism inside it, so <em>N</em> loads at <em>N</em> bands is <em>N²</em>
+/// runnable threads on <em>N</em> cores. The last column is the full prefetch budget with the
+/// within-image budget divided by the loads in flight — the correction that oversubscription obviously
+/// calls for, and which this harness measured at nothing. It is kept as a column rather than deleted
+/// along with the seam it was meant to justify, because a null result is only worth anything while it
+/// can be re-run; the speedup column deliberately excludes it, since it is a variant of the full
+/// budget rather than more of it.
+/// </para>
+/// </remarks>
+internal static class ImagePrefetchScaling
+{
+    /// <summary>Images the fixture document references. Enough to fill the budget several times over.</summary>
+    private const int ImageCount = 12;
+
+    /// <summary>
+    /// Pixels per side of each fixture image. Large enough that one decode is tens of milliseconds —
+    /// a page of thumbnails would measure the scheduler rather than the decoder.
+    /// </summary>
+    private const int ImageSize = 768;
+
+    /// <summary>
+    /// Builds the fixture, renders it at every prefetch setting, and reports medians, speedups, what
+    /// the walk decided, and whether the image matched the sequential render. Non-zero exit code if
+    /// any setting drew different pixels.
+    /// </summary>
+    public static int Run(int iterations, int warmup)
+    {
+        if (iterations < 1)
+            throw new ArgumentOutOfRangeException(nameof(iterations), iterations, "Need at least one iteration.");
+
+        var fixture = Fixture.Create();
+        try
+        {
+            return Run(fixture, iterations, warmup);
+        }
+        finally
+        {
+            fixture.Dispose();
+        }
+    }
+
+    private static int Run(Fixture fixture, int iterations, int warmup)
+    {
+        var settings = Settings();
+        var configuredPrefetch = ImagePrefetch.MaxDegreeOfParallelism;
+        var configuredDecode = ImageDecodeParallelism.MaxDegreeOfParallelism;
+        var mismatches = new List<string>();
+
+        Console.WriteLine("# Image prefetch scaling (multithreading item #8)");
+        Console.WriteLine();
+        Console.WriteLine($"- Runtime: {Environment.Version}, {Environment.ProcessorCount} logical cores");
+        Console.WriteLine($"- Viewport: {Corpus.ViewportWidth}x{Corpus.ViewportHeight}");
+        Console.WriteLine($"- Fixture: {ImageCount} images at {ImageSize}x{ImageSize}, "
+            + $"{fixture.EncodedBytes:N0} encoded bytes on disk, half PNG and half JPEG");
+        Console.WriteLine($"- {iterations} measured iterations, {warmup} warm-up; figures are medians");
+        Console.WriteLine($"- Columns: {string.Join(", ", Array.ConvertAll(settings, s => s.Label))}");
+        Console.WriteLine($"- Within-image decode budget (items #6/#7): {Environment.ProcessorCount}, "
+            + "except the divided column");
+        Console.WriteLine($"- Minimum images to overlap: {ImagePrefetch.MinimumImagesToOverlap}");
+        Console.WriteLine();
+
+        try
+        {
+            var reference = RenderPixels(fixture, settings[0]);
+            foreach (var setting in settings)
+            {
+                if (setting == settings[0])
+                    continue;
+                if (!SameBytes(reference, RenderPixels(fixture, setting)))
+                    mismatches.Add(setting.Label);
+            }
+
+            var (layout, total) = Measure(fixture, settings, iterations, warmup);
+
+            Report("Layout stage (`PerformLayout`, which is where an image load runs)", settings, layout);
+            Report("End to end, the same renders", settings, total);
+
+            Console.WriteLine("What the walk decided, at the full prefetch budget:");
+            Console.WriteLine();
+            var decisions = CountDecisions(fixture);
+            Console.WriteLine("| documents walked | loads issued | skipped: below minimum | skipped: host loads async |");
+            Console.WriteLine("|---:|---:|---:|---:|");
+            Console.WriteLine(string.Create(
+                CultureInfo.InvariantCulture,
+                $"| {decisions.DocumentsWalked:N0} | {decisions.LoadsIssued:N0} | "
+                + $"{decisions.DocumentsBelowMinimum:N0} | {decisions.DocumentsNotSynchronous:N0} |"));
+            Console.WriteLine();
+        }
+        finally
+        {
+            ImagePrefetch.MaxDegreeOfParallelism = configuredPrefetch;
+            ImageDecodeParallelism.MaxDegreeOfParallelism = configuredDecode;
+        }
+
+        if (mismatches.Count == 0)
+        {
+            Console.WriteLine("Every setting rendered pixel-identically to the sequential render.");
+            return 0;
+        }
+
+        Console.WriteLine($"**{mismatches.Count} setting(s) rendered different pixels: {string.Join(", ", mismatches)}**");
+        return 1;
+    }
+
+    private static void Report(string title, Setting[] settings, double[] medians)
+    {
+        Console.WriteLine($"{title}:");
+        Console.WriteLine();
+        Console.WriteLine("| " + string.Join(" | ", Array.ConvertAll(settings, s => s.Label + " ms")) + " | speedup |");
+        Console.WriteLine("|" + string.Concat(Array.ConvertAll(settings, _ => "---:|")) + "---:|");
+
+        var cells = new string[settings.Length];
+        for (var i = 0; i < settings.Length; i++)
+            cells[i] = medians[i].ToString("F1", CultureInfo.InvariantCulture);
+
+        // Against the widest undivided column, not the last one: the divided column is a different
+        // configuration of the same budget, so quoting it as the speedup would report the
+        // pessimization as this item's result.
+        var widest = Array.FindLastIndex(settings, s => !s.DivideDecodeBudget);
+        Console.WriteLine(string.Create(
+            CultureInfo.InvariantCulture,
+            $"| {string.Join(" | ", cells)} | {medians[0] / medians[widest]:F2}x |"));
+        Console.WriteLine();
+    }
+
+    /// <summary>
+    /// One column of the tables: how many loads run at once, and whether the within-image decode
+    /// budget is divided across them.
+    /// </summary>
+    private sealed record Setting(string Label, int ConcurrentLoads, bool DivideDecodeBudget);
+
+    /// <summary>
+    /// 1, 2, 4 and the core count with the decode budget left alone, then the core count again with
+    /// it divided.
+    /// </summary>
+    /// <remarks>
+    /// <b>The divided configuration is a column, not a separate measurement, and that correction is
+    /// the reason it is spelled this way.</b> Measured in its own block it came out 1.10x faster than
+    /// the undivided one on the first run of this harness and 1.17x <em>slower</em> on the second —
+    /// the sign of the effect changed, because a block of nine renders sits under a different stretch
+    /// of this host's throughput drift than the interleaved sweep it was being compared against. The
+    /// remedy is the one <see cref="DecodeScaling"/> already documents for the same host: put every
+    /// configuration in one round-robin so they all sit under the same drift. A configuration
+    /// measured outside the interleave is not comparable with the ones inside it, however carefully
+    /// its own medians are taken.
+    /// </remarks>
+    private static Setting[] Settings()
+    {
+        var loads = new SortedSet<int> { 1, 2, 4, Environment.ProcessorCount };
+        var settings = new List<Setting>();
+        foreach (var count in loads)
+            settings.Add(new Setting($"{count} load", count, DivideDecodeBudget: false));
+
+        settings.Add(new Setting($"{Environment.ProcessorCount} load, decode divided",
+            Environment.ProcessorCount, DivideDecodeBudget: true));
+        return [.. settings];
+    }
+
+    /// <summary>
+    /// Applies one column's two budgets.
+    /// </summary>
+    /// <remarks>
+    /// <b>The within-image budget is set for the whole render rather than scoped to the prefetch, and
+    /// on this fixture those are the same thing.</b> Every image the document names is claimed by the
+    /// walk and joined before layout measures anything, and nothing else in a render decodes — so the
+    /// only decodes that happen are the prefetch's, and a render-wide setting reaches exactly them.
+    /// Scoping it properly would need a seam in <c>ImagePrefetch</c> for layout to narrow a budget it
+    /// does not reference, which is machinery this column exists to say is not worth having.
+    /// </remarks>
+    private static void ApplySetting(Setting setting)
+    {
+        ImagePrefetch.MaxDegreeOfParallelism = setting.ConcurrentLoads;
+        ImageDecodeParallelism.MaxDegreeOfParallelism = setting.DivideDecodeBudget
+            ? Math.Max(1, Environment.ProcessorCount / Math.Max(1, setting.ConcurrentLoads))
+            : Environment.ProcessorCount;
+    }
+
+    private static (double[] Layout, double[] Total) Measure(
+        Fixture fixture, Setting[] settings, int iterations, int warmup)
+    {
+        foreach (var setting in settings)
+        {
+            for (var i = 0; i < warmup; i++)
+                RenderOnce(fixture, setting);
+        }
+
+        var layout = new double[settings.Length][];
+        var total = new double[settings.Length][];
+        for (var i = 0; i < settings.Length; i++)
+        {
+            layout[i] = new double[iterations];
+            total[i] = new double[iterations];
+        }
+
+        // Interleaved within each iteration, for the reason DecodeScaling gives: this host's
+        // throughput drifts enough over a run to swamp the effect if a setting is measured in a block.
+        for (var iteration = 0; iteration < iterations; iteration++)
+        {
+            for (var i = 0; i < settings.Length; i++)
+            {
+                var sample = RenderOnce(fixture, settings[i]);
+                layout[i][iteration] = sample.Layout;
+                total[i][iteration] = sample.Total;
+            }
+        }
+
+        var layoutMedians = new double[settings.Length];
+        var totalMedians = new double[settings.Length];
+        for (var i = 0; i < settings.Length; i++)
+        {
+            layoutMedians[i] = Median(layout[i]);
+            totalMedians[i] = Median(total[i]);
+        }
+
+        return (layoutMedians, totalMedians);
+    }
+
+    private static double Median(double[] values)
+    {
+        Array.Sort(values);
+        return values[values.Length / 2];
+    }
+
+    private static (long DocumentsWalked, long LoadsIssued, long DocumentsBelowMinimum, long DocumentsNotSynchronous)
+        CountDecisions(Fixture fixture)
+    {
+        ImagePrefetch.ResetDiagnostics();
+        ImagePrefetch.CollectDiagnostics = true;
+        try
+        {
+            RenderOnce(fixture, new Setting("diagnostics", Environment.ProcessorCount, DivideDecodeBudget: false));
+            return ImagePrefetch.Diagnostics;
+        }
+        finally
+        {
+            ImagePrefetch.CollectDiagnostics = false;
+        }
+    }
+
+    /// <summary>
+    /// One render, with the layout stage timed inside it. Mirrors <c>HtmlRender.RenderToImageCore</c>
+    /// the way <see cref="TileScaling"/> does, so the stage boundary is the same public call the
+    /// profile attributes rather than an instrumented copy.
+    /// </summary>
+    private static (double Total, double Layout) RenderOnce(Fixture fixture, Setting setting)
+    {
+        ApplySetting(setting);
+
+        const int width = Corpus.ViewportWidth;
+        const int height = Corpus.ViewportHeight;
+        var clip = new RectangleF(0, 0, width, height);
+
+        var outer = Stopwatch.StartNew();
+        var bitmap = new BBitmap(width, height);
+        using var container = new HtmlContainer();
+        container.Location = new PointF(0, 0);
+        container.MaxSize = new SizeF(width, height);
+        container.AvoidAsyncImagesLoading = true;
+        container.AvoidImagesLateLoading = true;
+        container.SetHtmlWithStyleSet(fixture.Html, null, fixture.BaseUrl);
+        bitmap.Clear(BColor.White);
+
+        var layout = Stopwatch.StartNew();
+        container.PerformLayout(bitmap, clip);
+        layout.Stop();
+
+        container.PerformPaint(bitmap, clip);
+        bitmap.Dispose();
+        outer.Stop();
+
+        return (outer.Elapsed.TotalMilliseconds, layout.Elapsed.TotalMilliseconds);
+    }
+
+    private static byte[] RenderPixels(Fixture fixture, Setting setting)
+    {
+        ApplySetting(setting);
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(
+            fixture.Html,
+            Corpus.ViewportWidth,
+            Corpus.ViewportHeight,
+            backgroundColor: BColor.White,
+            baseUrl: fixture.BaseUrl);
+        return bitmap.Encode();
+    }
+
+    private static bool SameBytes(byte[] expected, byte[] actual)
+    {
+        if (expected.Length != actual.Length)
+            return false;
+        for (var i = 0; i < expected.Length; i++)
+        {
+            if (expected[i] != actual[i])
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// A directory of encoded images and the document that references them. Deleted on dispose; the
+    /// files are what make the render take the <c>LoadImageFromFile</c> path this item is about.
+    /// </summary>
+    private sealed class Fixture : IDisposable
+    {
+        private readonly string _directory;
+
+        private Fixture(string directory, string html, string baseUrl, long encodedBytes)
+        {
+            _directory = directory;
+            Html = html;
+            BaseUrl = baseUrl;
+            EncodedBytes = encodedBytes;
+        }
+
+        public string Html { get; }
+
+        /// <summary>Base for the document's relative <c>src</c>s — the fixture's own directory.</summary>
+        public string BaseUrl { get; }
+
+        public long EncodedBytes { get; }
+
+        public static Fixture Create()
+        {
+            var directory = Path.Combine(
+                Path.GetTempPath(),
+                "broiler-image-prefetch-" + Environment.ProcessId.ToString(CultureInfo.InvariantCulture));
+            Directory.CreateDirectory(directory);
+
+            long encoded = 0;
+            var names = new string[ImageCount];
+            for (var i = 0; i < ImageCount; i++)
+            {
+                // Half PNG, half JPEG: their decoders have different serial shares (item #6 measured
+                // 2.08–2.61x on JPEG against 1.22–1.29x on PNG), so a fixture of one of them would
+                // report a speedup that belongs to that format rather than to a page.
+                var png = i % 2 == 0;
+                names[i] = png ? $"i{i}.png" : $"i{i}.jpg";
+
+                // Distinct content per image, so nothing upstream can collapse two loads into one
+                // and report a speedup that is really a cache hit.
+                using var source = BuildImage(ImageSize, i);
+                var bytes = png
+                    ? source.Encode(ImageEncodeFormat.Png, 100)
+                    : source.Encode(ImageEncodeFormat.Jpeg, 85);
+                File.WriteAllBytes(Path.Combine(directory, names[i]), bytes);
+                encoded += bytes.Length;
+            }
+
+            var css = new StringBuilder()
+                .Append("body{margin:0;font:13px/1.4 sans-serif}")
+                .Append(".t{width:150px;height:120px;display:inline-block;margin:2px}")
+                .Append(".bg{width:180px;height:100px;display:inline-block;margin:2px;")
+                .Append("background-repeat:no-repeat;background-size:cover}")
+                .ToString();
+
+            var body = new StringBuilder();
+            for (var i = 0; i < ImageCount; i++)
+            {
+                // Two thirds as replaced content and one third as a background layer, so both of the
+                // walk's claim sites are exercised by the page it is measured on.
+                if (i % 3 == 2)
+                    body.Append("<div class=\"bg\" style=\"background-image:url(").Append(names[i]).Append(")\"></div>");
+                else
+                    body.Append("<img class=\"t\" src=\"").Append(names[i]).Append("\" alt=\"\">");
+            }
+
+            var html = "<!DOCTYPE html><html><head><style>" + css + "</style></head><body>"
+                + body + "</body></html>";
+
+            var baseUrl = new Uri(Path.Combine(directory, "page.html")).AbsoluteUri;
+            return new Fixture(directory, html, baseUrl, encoded);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_directory, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A leftover temp directory is not a failed measurement.
+            }
+        }
+
+        /// <summary>
+        /// A deterministic image whose content depends on <paramref name="seed"/>. Same shape as
+        /// <see cref="DecodeScaling"/>'s gradient, offset per image so no two files are identical.
+        /// </summary>
+        private static BBitmap BuildImage(int size, int seed)
+        {
+            var bitmap = new BBitmap(size, size);
+            var offset = seed * 37;
+            for (var y = 0; y < size; y++)
+            {
+                for (var x = 0; x < size; x++)
+                {
+                    bitmap.SetPixel(x, y, new BColor(
+                        (byte)((x + offset) * 255 / size),
+                        (byte)((y + offset) * 255 / size),
+                        (byte)((x + y + offset) * 255 / (2 * size)),
+                        255));
+                }
+            }
+
+            return bitmap;
+        }
+    }
+}

--- a/tests/render-stages/Broiler.Render.Stage.Benchmarks/Program.cs
+++ b/tests/render-stages/Broiler.Render.Stage.Benchmarks/Program.cs
@@ -41,6 +41,11 @@ public static class Program
             return TileScaling.Run(ArgValue(args, "--iterations", 9), ArgValue(args, "--warmup", 2));
         }
 
+        if (args.Length >= 1 && args[0] == "--image-prefetch-scaling")
+        {
+            return ImagePrefetchScaling.Run(ArgValue(args, "--iterations", 9), ArgValue(args, "--warmup", 2));
+        }
+
         if (args.Length >= 1 && args[0] == "--gc-config")
         {
             GcConfigurationMetrics.Run(ArgValue(args, "--rounds", 20));
@@ -76,6 +81,10 @@ public static class Program
         Console.WriteLine("  --tile-scaling [--iterations N] [--warmup N]");
         Console.WriteLine("        Corpus render time against the raster tile budget (item #5).");
         Console.WriteLine("        Exits 1 if any tile setting renders different pixels.");
+        Console.WriteLine();
+        Console.WriteLine("  --image-prefetch-scaling [--iterations N] [--warmup N]");
+        Console.WriteLine("        Render time of an image-heavy page against the concurrent-load budget (item #8).");
+        Console.WriteLine("        Exits 1 if any setting renders different pixels.");
         Console.WriteLine();
         Console.WriteLine("  --gc-config [--rounds N]");
         Console.WriteLine("        Throughput and GC counters for the process's GC mode (item #19).");

--- a/tests/render-stages/Broiler.Render.Stage.Benchmarks/README.md
+++ b/tests/render-stages/Broiler.Render.Stage.Benchmarks/README.md
@@ -56,9 +56,9 @@ dotnet run -c Release --project tests/render-stages/Broiler.Render.Stage.Benchma
 `--job short` is enough to separate anything that differs by more than a few percent and
 finishes in minutes; drop it for publication numbers.
 
-## Thread scaling — items #4, #6, #7
+## Thread scaling — items #4, #5, #6, #7, #8
 
-Three modes that answer "how does this stage scale with threads, and does it change a
+Four modes that answer "how does this stage scale with threads, and does it change a
 pixel". All report the second question as part of the first and **exit non-zero if any
 setting produced different bytes**, because a speedup measured without that check is not
 evidence of anything.
@@ -67,6 +67,7 @@ evidence of anything.
 dotnet run -c Release --project tests/render-stages/Broiler.Render.Stage.Benchmarks -- --raster-scaling
 dotnet run -c Release --project tests/render-stages/Broiler.Render.Stage.Benchmarks -- --tile-scaling
 dotnet run -c Release --project tests/render-stages/Broiler.Render.Stage.Benchmarks -- --decode-scaling
+dotnet run -c Release --project tests/render-stages/Broiler.Render.Stage.Benchmarks -- --image-prefetch-scaling
 ```
 
 `--raster-scaling` renders the whole corpus at 1, 2, 4 and *cores* raster threads, and
@@ -89,10 +90,30 @@ expected to be zero.
 photographic ramp and flat tiles, which load the entropy stages very differently) at the same
 settings.
 
-**Both interleave their settings within each iteration rather than measuring one setting at a
-time.** This container's throughput drifts by tens of percent over tens of seconds — enough
+`--image-prefetch-scaling` renders an image-heavy document at 1, 2, 4 and *cores* concurrent
+image loads (item #8) and reports the `PerformLayout` stage — where an image load runs — beside
+the whole render. **It owns its fixture rather than using the corpus, and that is not a
+shortcut:** the five corpus pages contain no images by construction, since each is built to
+load one stage, so adding one would both fold decode into another page's row and invalidate
+every number the published profile quotes. The fixture is a directory of real PNG, JPEG files
+plus the document that references them, because `SetImageFromFile` is the path that is inline
+and serial; a `data:` URI takes a different one. It follows the timings with the walk's own
+count of how many loads it issued and, when it declined a document, whether that was for naming
+too few images or for a host that loads them asynchronously — as with the tile driver's two
+refusal counts, those call for opposite next steps.
+
+Its last column is the full concurrent-load budget with the *within*-image decode budget divided
+across the loads in flight — the correction that `N` loads × `N` bands on `N` cores obviously
+calls for. Over four runs it has no consistent sign (three favour it by 1–8%, one penalises it by
+9%), and it is kept as a column so that null result stays re-runnable rather than remembered.
+
+**All of them interleave their settings within each iteration rather than measuring one setting
+at a time.** This container's throughput drifts by tens of percent over tens of seconds — enough
 that the same untouched decode measured in two consecutive processes differs by more than the
 effect being measured. Blocked measurement cannot tell a speedup from the box getting faster.
+The divided column above is the cautionary example: measured in its own block it read 1.10×
+faster than the undivided one on one run and 1.17× *slower* on the next, and only interleaving
+it showed that the true answer is neither.
 
 The budgets are also settable directly, which is what a caller running several renders at once
 should do (see the multithreading roadmap, "two kinds of parallelism now multiply"):
@@ -104,11 +125,17 @@ should do (see the multithreading roadmap, "two kinds of parallelism now multipl
 | `BROILER_RASTER_MIN_BAND` | Pixels one band must be worth |
 | `BROILER_RASTER_TILES` | Tiles one display-list replay may be split into (item #5) |
 | `BROILER_RASTER_MIN_TILE_ROWS` | Rows a tile must be worth before the surface is split further |
-| `BROILER_IMAGE_DECODE_THREADS` | Threads one decode pass may use |
+| `BROILER_IMAGE_DECODE_THREADS` | Threads one decode pass may use (items #6, #7) |
+| `BROILER_IMAGE_PREFETCH_THREADS` | Image loads a document may have in flight at once (item #8) |
 
 The two raster budgets do not compound: a tile view runs its scanline bands inline, so a render
 spends whichever of the two it is using and never both. A host dividing cores between processes
 should give each the same figure rather than a share of it.
+
+The two *decode* budgets do compound — a concurrent image load decodes through the band
+partitioner — but dividing them measured as nothing (see above), so they are also given the same
+figure. `BROILER_IMAGE_PREFETCH_THREADS=1` turns the walk off entirely rather than running it one
+wide, which is what makes it the sequential path the exit gate compares against.
 
 ## GC configuration — item #19
 


### PR DESCRIPTION
## Summary

Implements multithreading roadmap item #8: concurrent image prefetching. A document's image loads are now issued from a worker pool before the layout pass begins, allowing decode operations to overlap with layout work. This achieves ~1.9× speedup on layout and ~1.7× on the full render for image-heavy documents, with pixel-identical output to the serial path.

## Key Changes

- **`ImagePrefetch` class** (`Broiler.Layout`): Manages the thread budget for concurrent image loads, diagnostics collection, and the prefetch/consume split. A budget of 1 disables the feature entirely (pre-change path). Minimum 2 images required to justify worker overhead.

- **`DeferredImageLoad` class** (`Broiler.Layout`): Captures image load completions on the worker thread and replays them on the layout thread at the point they would have originally run. This is critical for correctness: only the decode is safe to move off the layout thread; the completion callback (which sets error borders and requests refresh) must run synchronously where layout expects it, or replaced boxes measure at wrong intrinsic sizes.

- **`CssBox.ImagePrefetch.cs`** (`Broiler.Layout.Engine`): Document-wide image walk that collects all images the layout pass will certainly measure, then issues their loads concurrently. Deliberately conservative: skips `display:none` subtrees (which layout doesn't measure) and documents with async-capable hosts (to avoid calling `RequestRefresh` from an unexpected thread).

- **`CssBoxImage` and `CssBox.Background` modifications**: Integrated deferred completion handling. Background images and replaced-content images both participate in the prefetch, with completions deferred until the layout thread reaches the measurement point.

- **Test suites**:
  - `ImagePrefetchTests` (51 cases): Verifies pixel-identical rendering across 1/2/3/4/8 concurrent loads on 11 document shapes (several images, backgrounds, mixed, broken sources, SVG, hidden subtrees, tables, etc.). Guards that documents actually reach the walk and that a budget of 1 disables it entirely.
  - `ImagePrefetchWorkerContractTests` (6 cases): Validates that prefetch workers establish ambient render state (`AmbientRenderState.Establish`) and arm the enforcement assertion (`EnforceOnThisThread`), then disarm it before returning to the pool—the first worker in the repository to discharge this P0-c debt.

- **Benchmark harness** (`ImagePrefetchScaling`): Measures layout and end-to-end render time across 1/2/4/N concurrent loads on a 12-image fixture, reports medians and speedups, and verifies pixel identity. Includes a divided-decode-budget variant (measured but found to have no consistent effect).

- **Documentation**: Updated `multithreading.md` with item #8's completion, including the critical finding that only the decode half of an image load is safe to move—moving the completion callback changed rendered pages on the failure path (error borders landing early enough to widen boxes).

## Notable Implementation Details

- **Correctness by construction**: The prefetch issues the same `CreateImageLoader` / `LoadImage` calls the serial path would, in the same order, with the same arguments. The only difference is *when* and *on which thread*. Deferred completions ensure the callback runs at the original call site on the layout thread.

- **Conservative walk**: Declines documents with fewer than 2 images (nothing to overlap), async-capable hosts (would call `RequestRefresh` from a worker), or shrink-to-fit pre-passes (cannot distinguish measured from unmeasured descendants without running layout). These documents load images inline exactly as before.

- **Ambient state contract**: First worker in the repository to call `AmbientRenderState.Establish` and arm `EnforceOnThisThread`. Disarms before returning to the pool to prevent leaking the enforcement switch to unrelated work.

- **No decode-budget division**: Measured dividing the within-image decode budget (`ImageDecodeParallelism`) by the number of concurrent loads, but found no consistent benefit. The .NET thread pool already serializes excess work, and waves with fewer

https://claude.ai/code/session_01WXRW8YatMEpAq8K5DTowmD