### PR TITLE
Measure layout pass composition and independent subtree distribution

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/LayoutWorkTraceTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/LayoutWorkTraceTests.cs
@@ -1,0 +1,311 @@
+using System;
+using System.Drawing;
+using System.Threading;
+using Broiler.CSS;
+using Broiler.Layout.Diagnostics;
+using Broiler.Layout.Engine;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// The contract the layout-composition profile rests on: disabled the trace records nothing, and
+/// enabled its operation totals are <em>disjoint</em>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The published composition subtracts the named operations from the measured pass and calls what is
+/// left the block-flow walk. That subtraction is only meaningful if a scope opened inside another is
+/// charged to exactly one of them — intrinsic sizing runs inside table layout, which runs inside the
+/// block walk, so inclusive scopes would trible-count and the residual could go negative or, worse,
+/// come out plausible and wrong. These cases assert the disjointness directly rather than trusting
+/// that the published residual "looked about right".
+/// </para>
+/// <para>
+/// The disabled case is the production contract. Every call site added for this profile is on a hot
+/// layout path — one of them is inside <c>GetMinimumWidth_LongestWord</c>, which the corpus's
+/// flex/grid page enters 28 449 times in a single pass — so "records nothing when off" has to be a
+/// test and not a comment.
+/// </para>
+/// <para>
+/// These tests take a process-wide latch (<see cref="LayoutWorkTrace.Enabled"/>) and are therefore
+/// serialized into their own xUnit collection. Item #21 removed this assembly's blanket
+/// <c>DisableTestParallelization</c> on the grounds that isolation should be structural; a static
+/// latch is the exception that proves it, so it is named as one rather than re-disabling the
+/// assembly.
+/// </para>
+/// </remarks>
+[Collection(nameof(LayoutWorkTraceTests))]
+[CollectionDefinition(nameof(LayoutWorkTraceTests), DisableParallelization = true)]
+public sealed class LayoutWorkTraceTests : IDisposable
+{
+    private static readonly Uri BaseUrl = new("file:///work-trace.html");
+
+    public LayoutWorkTraceTests()
+    {
+        LayoutWorkTrace.Enabled = false;
+        LayoutWorkTrace.Reset();
+    }
+
+    public void Dispose()
+    {
+        LayoutWorkTrace.Enabled = false;
+        LayoutWorkTrace.Reset();
+    }
+
+    [Fact]
+    public void Disabled_it_records_nothing()
+    {
+        LayoutWorkTrace.Count(LayoutWorkTrace.Counters.BoxesLaidOut, 17);
+        LayoutWorkTrace.CountMax(LayoutWorkTrace.Counters.TreeDepth, 9);
+        using (LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Intrinsic))
+        {
+            Spin();
+        }
+
+        Assert.Empty(LayoutWorkTrace.Counts());
+        Assert.Empty(LayoutWorkTrace.Times());
+    }
+
+    [Fact]
+    public void A_whole_layout_pass_records_nothing_when_disabled()
+    {
+        // The call sites, not the API: the point of the disabled contract is that an engine carrying
+        // this instrumentation is silent, and only a real pass exercises every site at once.
+        var root = TextTree();
+
+        LayoutWorkTrace.Reset();
+        root.PerformLayout(root.LayoutEnvironment);
+
+        Assert.Empty(LayoutWorkTrace.Counts());
+        Assert.Empty(LayoutWorkTrace.Times());
+    }
+
+    [Fact]
+    public void A_nested_scope_is_charged_to_the_inner_operation_and_subtracted_from_the_outer()
+    {
+        LayoutWorkTrace.Enabled = true;
+
+        using (LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Table))
+        {
+            Spin();
+            using (LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Intrinsic))
+            {
+                // Much longer than the outer scope's own work, so an inclusive accounting would
+                // report the table as the larger of the two and this assertion would fail.
+                Spin(20);
+            }
+        }
+
+        var times = LayoutWorkTrace.Times();
+        var table = times[LayoutWorkTrace.Ops.Table];
+        var intrinsic = times[LayoutWorkTrace.Ops.Intrinsic];
+
+        Assert.True(
+            intrinsic > table,
+            $"the inner scope did most of the work, so it must carry most of the time ({intrinsic} vs {table})");
+    }
+
+    [Fact]
+    public void Self_times_never_exceed_the_span_that_contains_them()
+    {
+        LayoutWorkTrace.Enabled = true;
+
+        var start = System.Diagnostics.Stopwatch.StartNew();
+        using (LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.LineBreak))
+        {
+            Spin(5);
+            using (LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.TextMeasure))
+                Spin(5);
+            using (LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Intrinsic))
+                Spin(5);
+        }
+        start.Stop();
+
+        var times = LayoutWorkTrace.Times();
+        var sum = times[LayoutWorkTrace.Ops.LineBreak]
+                + times[LayoutWorkTrace.Ops.TextMeasure]
+                + times[LayoutWorkTrace.Ops.Intrinsic];
+
+        // This is the property that makes `pass - Σ(ops)` a residual rather than an artefact. A
+        // small tolerance covers the timestamp taken outside the outermost scope.
+        Assert.True(
+            sum <= start.Elapsed.TotalMilliseconds + 1.0,
+            $"disjoint self times must fit inside the span containing them ({sum} vs {start.Elapsed.TotalMilliseconds})");
+    }
+
+    [Fact]
+    public void Repeated_scopes_of_one_operation_accumulate()
+    {
+        LayoutWorkTrace.Enabled = true;
+
+        using (LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Intrinsic))
+            Spin(5);
+        var once = LayoutWorkTrace.Times()[LayoutWorkTrace.Ops.Intrinsic];
+
+        using (LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Intrinsic))
+            Spin(5);
+        var twice = LayoutWorkTrace.Times()[LayoutWorkTrace.Ops.Intrinsic];
+
+        Assert.True(twice > once, $"a second scope must add to the first ({twice} vs {once})");
+    }
+
+    [Fact]
+    public void Counters_sum_and_CountMax_takes_the_maximum()
+    {
+        LayoutWorkTrace.Enabled = true;
+
+        LayoutWorkTrace.Count(LayoutWorkTrace.Counters.BoxesLaidOut, 3);
+        LayoutWorkTrace.Count(LayoutWorkTrace.Counters.BoxesLaidOut, 4);
+        LayoutWorkTrace.CountMax(LayoutWorkTrace.Counters.TreeDepth, 9);
+        LayoutWorkTrace.CountMax(LayoutWorkTrace.Counters.TreeDepth, 4);
+
+        var counts = LayoutWorkTrace.Counts();
+        Assert.Equal(7, counts[LayoutWorkTrace.Counters.BoxesLaidOut]);
+        Assert.Equal(9, counts[LayoutWorkTrace.Counters.TreeDepth]);
+    }
+
+    [Fact]
+    public void Reset_discards_the_counts_and_the_times()
+    {
+        LayoutWorkTrace.Enabled = true;
+
+        LayoutWorkTrace.Count(LayoutWorkTrace.Counters.BoxesLaidOut);
+        using (LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Intrinsic))
+            Spin();
+
+        LayoutWorkTrace.Reset();
+
+        Assert.Empty(LayoutWorkTrace.Counts());
+        Assert.Empty(LayoutWorkTrace.Times());
+    }
+
+    [Fact]
+    public void An_enabled_pass_counts_every_box_it_lays_out()
+    {
+        var root = TextTree();
+
+        LayoutWorkTrace.Reset();
+        LayoutWorkTrace.Enabled = true;
+        root.PerformLayout(root.LayoutEnvironment);
+        LayoutWorkTrace.Enabled = false;
+
+        var counts = LayoutWorkTrace.Counts();
+        Assert.True(
+            counts[LayoutWorkTrace.Counters.BoxesLaidOut] > 0,
+            "an enabled pass must count the boxes it entered");
+        Assert.True(
+            counts[LayoutWorkTrace.Counters.TreeBoxes] >= counts[LayoutWorkTrace.Counters.BoxesLaidOut],
+            "the census walks the whole tree, so it cannot see fewer boxes than the pass entered");
+    }
+
+    /// <summary>
+    /// The union counter is the one the published ceiling uses, so the case that separates it from a
+    /// per-class sum is asserted: a box under two independent roots at once.
+    /// </summary>
+    [Fact]
+    public void A_box_under_two_independent_roots_is_counted_once()
+    {
+        var environment = new StubLayoutEnvironment();
+        var root = new CssBox(null, null, BaseUrl)
+        {
+            Location = new PointF(0, 0),
+            Size = new SizeF(400, 400),
+            Display = CssConstants.Block,
+            FontSize = "16px",
+            LayoutEnvironment = environment,
+        };
+
+        var cell = Block(root);
+        cell.Display = CssConstants.TableCell;
+
+        var abspos = Block(cell);
+        abspos.Position = CssConstants.Absolute;
+
+        var leaf = Block(abspos);
+        leaf.Height = "10px";
+
+        LayoutWorkTrace.Reset();
+        LayoutWorkTrace.Enabled = true;
+        root.PerformLayout(root.LayoutEnvironment);
+        LayoutWorkTrace.Enabled = false;
+
+        var counts = LayoutWorkTrace.Counts();
+        var tree = counts[LayoutWorkTrace.Counters.TreeBoxes];
+        var independent = counts[LayoutWorkTrace.Counters.IndependentBoxes];
+
+        // cell + abspos + leaf are independent; the root is not. Summing the per-class counters
+        // would reach 3 + 2 = 5 against a 4-box tree, which is the failure this guards.
+        Assert.Equal(4, tree);
+        Assert.Equal(3, independent);
+        Assert.True(independent <= tree, "the union cannot exceed the tree");
+    }
+
+    private static void Spin(int units = 1)
+    {
+        // Thread.Sleep would measure the scheduler; the profile times CPU-bound layout work, so the
+        // scopes under test are given CPU-bound work.
+        for (var i = 0; i < units; i++)
+            Thread.SpinWait(200_000);
+    }
+
+    private static CssBox TextTree()
+    {
+        var environment = new StubLayoutEnvironment();
+        var root = new CssBox(null, null, BaseUrl)
+        {
+            Location = new PointF(0, 0),
+            Size = new SizeF(400, 400),
+            Display = CssConstants.Block,
+            FontSize = "16px",
+            LayoutEnvironment = environment,
+        };
+
+        var html = Block(root);
+        var body = Block(html);
+        var block = Block(body);
+        block.Height = "10px";
+
+        return root;
+    }
+
+    private static CssBox Block(CssBox parent) =>
+        new(parent, null, BaseUrl)
+        {
+            Location = new PointF(0, 0),
+            Size = new SizeF(400, 0),
+            Display = CssConstants.Block,
+            FontSize = "16px",
+        };
+
+    private sealed class StubLayoutEnvironment : ILayoutEnvironment
+    {
+        public Broiler.Graphics.ILayoutFont GetFont(string family, double size, LayoutFontStyle style, string? fontFeatures = null) => new StubFont(size);
+        public SizeF MeasureText(Broiler.Graphics.ILayoutFont font, string text) => SizeF.Empty;
+        public void MeasureText(Broiler.Graphics.ILayoutFont font, string text, double maxWidth, out int charFit, out double charFitWidth) { charFit = 0; charFitWidth = 0; }
+        public double GetWhitespaceWidth(Broiler.Graphics.ILayoutFont font) => 0;
+        public ImageIntrinsics GetImageIntrinsics(object imageHandle) => default;
+        public Broiler.Graphics.BColor ParseColor(string value) => default;
+        public void RequestRefresh(bool relayout) { }
+        public SizeF ViewportSize => new(1000, 1000);
+        public PointF RootLocation => PointF.Empty;
+        public SizeF ActualSize { get; set; }
+        public bool AvoidGeometryAntialias => false;
+        public SizeF PageSize => new(1000, 1000);
+        public int MarginTop => 0;
+        public void ReportLayoutError(string message, Exception? exception = null) { }
+        public bool AvoidAsyncImagesLoading => true;
+        public bool AvoidImagesLateLoading => true;
+        public ILayoutImageLoader CreateImageLoader(Action<object?, RectangleF, bool> onComplete) => null!;
+        public string FormatListMarker(int number, string style) => string.Empty;
+    }
+
+    private sealed class StubFont(double size) : Broiler.Graphics.ILayoutFont
+    {
+        public double Size { get; } = size;
+        public double Height => size;
+        public double UnderlineOffset => 0;
+        public double LeftPadding => 0;
+        public string? FontFeatures => null;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Diagnostics/LayoutTreeCensus.cs
+++ b/Broiler.Layout/Broiler.Layout/Diagnostics/LayoutTreeCensus.cs
@@ -1,0 +1,87 @@
+using Broiler.CSS;
+using Broiler.Layout.Engine;
+
+namespace Broiler.Layout.Diagnostics;
+
+/// <summary>
+/// One walk of the finished box tree that counts how much of it sits under a subtree item #13
+/// proposes to lay out in parallel.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why a census and not a timer.</b> Item #13's second shape is "parallel independent subtrees
+/// (abspos/fixed, flex+grid items, table cells, multicol, subdocuments)". Whatever such a split is
+/// worth, it is bounded above by the share of the tree that <em>is</em> in one of those subtrees:
+/// threads cannot help with a box that is not in one. That share is a property of the document, not
+/// of the clock, so it is counted exactly rather than inferred from a measurement that drifts —
+/// Phase 4 §3's lesson, applied at the point where it is cheapest.
+/// </para>
+/// <para>
+/// <b>The union, not the sum.</b> An abspos box inside a table cell is inside two independent
+/// subtrees, and a naive per-class sum would count it twice and could report more independent boxes
+/// than the tree contains. <see cref="LayoutWorkTrace.Counters.IndependentBoxes"/> counts a box once
+/// if <em>any</em> ancestor-or-self is an independent root, which is the number the ceiling is
+/// actually bounded by; the per-class counters are published next to it so a reader can see which
+/// class supplies it.
+/// </para>
+/// <para>
+/// <b>What it deliberately does not count.</b> Multi-column and subdocuments/iframes are on item
+/// #13's list and are not classified here: a column is not a box in this engine (multicol is applied
+/// as a post-layout pass over a single flow) and an iframe's subdocument is laid out by its own
+/// container rather than as a box of this tree, so neither has a root this walk could name. Reporting
+/// them as zero would read as "the corpus has none" rather than "this walk does not look"; they are
+/// named in the published output instead.
+/// </para>
+/// </remarks>
+internal static class LayoutTreeCensus
+{
+    /// <summary>Walks <paramref name="root"/> and records the structural counters.</summary>
+    public static void Record(CssBox root)
+    {
+        Walk(root, depth: 1, underIndependent: false);
+    }
+
+    private static void Walk(CssBox box, int depth, bool underIndependent)
+    {
+        LayoutWorkTrace.Count(LayoutWorkTrace.Counters.TreeBoxes);
+        LayoutWorkTrace.CountMax(LayoutWorkTrace.Counters.TreeDepth, depth);
+
+        var isAbspos = box.Position == CssConstants.Absolute || box.Position == CssConstants.Fixed;
+        var isTableCell = box.Display == CssConstants.TableCell;
+        var isFlexGridItem = IsFlexOrGridContainer(box.ParentBox?.Display);
+
+        if (isAbspos)
+            LayoutWorkTrace.Count(LayoutWorkTrace.Counters.AbsposRoots);
+        if (isTableCell)
+            LayoutWorkTrace.Count(LayoutWorkTrace.Counters.TableCellRoots);
+        if (isFlexGridItem)
+            LayoutWorkTrace.Count(LayoutWorkTrace.Counters.FlexGridRoots);
+
+        var independent = underIndependent || isAbspos || isTableCell || isFlexGridItem;
+        if (independent)
+            LayoutWorkTrace.Count(LayoutWorkTrace.Counters.IndependentBoxes);
+
+        // Per-class subtree sizes are accumulated by re-walking from each root, which is why they can
+        // exceed the tree size and the union counter above cannot.
+        if (isAbspos)
+            LayoutWorkTrace.Count(LayoutWorkTrace.Counters.AbsposBoxes, CountSubtree(box));
+        if (isTableCell)
+            LayoutWorkTrace.Count(LayoutWorkTrace.Counters.TableCellBoxes, CountSubtree(box));
+        if (isFlexGridItem)
+            LayoutWorkTrace.Count(LayoutWorkTrace.Counters.FlexGridBoxes, CountSubtree(box));
+
+        foreach (var child in box.Boxes)
+            Walk(child, depth + 1, independent);
+    }
+
+    private static int CountSubtree(CssBox box)
+    {
+        var total = 1;
+        foreach (var child in box.Boxes)
+            total += CountSubtree(child);
+        return total;
+    }
+
+    private static bool IsFlexOrGridContainer(string display) =>
+        display is "flex" or "inline-flex" or "grid" or "inline-grid";
+}

--- a/Broiler.Layout/Broiler.Layout/Diagnostics/LayoutWorkTrace.cs
+++ b/Broiler.Layout/Broiler.Layout/Diagnostics/LayoutWorkTrace.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Broiler.Layout.Diagnostics;
+
+/// <summary>
+/// An opt-in, off-by-default breakdown of what one layout pass spends its time on, and of how much
+/// of the box tree sits under a subtree item #13 proposes to claim.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists before any of item #13 is written.</b> The item's row proposes two shapes —
+/// "parallel intrinsic sizing" and "parallel independent subtrees" — and both are claims about
+/// structure that nothing in this repository has ever measured. The stage profile times the layout
+/// stage as a whole (28–51 ms, 3.3–20.1% of a render) and <see cref="LayoutPassCounter"/> counts how
+/// many times the tree is walked, but neither can say what a single pass is made of. Six items in
+/// this document have now found that the structure their row named was not the structure that could
+/// be split; the cheapest hour in an item is the one that checks its premise.
+/// </para>
+/// <para>
+/// <b>Self time, not inclusive time.</b> Intrinsic sizing is called from inside table layout, which
+/// is called from inside the block walk, so inclusive scopes would triple-count and their sum would
+/// exceed the pass. Each scope subtracts the time of the scopes opened inside it and records the
+/// remainder against its own name, so the totals are disjoint and the pass minus their sum is a
+/// residual that means something — the same reason <see cref="RenderStageTrace"/> publishes its
+/// residual rather than absorbing it.
+/// </para>
+/// <para>
+/// <b>The counters are the result; the milliseconds are the corroboration.</b> Phase 4 §3 records a
+/// harness that nearly published a false positive because this host's throughput drifts by tens of
+/// percent over tens of seconds, and closes with the general form: measure a structural question with
+/// a counter rather than inferring it from a time. "How many boxes does intrinsic sizing visit per
+/// box laid out" is structural — it is identical on every iteration and cannot drift — and it is what
+/// decides whether the intrinsic half of item #13 is a threading problem or a repetition problem. The
+/// times are here so a counter that looks alarming can be checked against a cost that is or is not
+/// there.
+/// </para>
+/// <para>
+/// <b>Cost when off, which is always in production.</b> <see cref="Measure"/> reads one static
+/// <see langword="bool"/> and returns a struct whose <see cref="Scope.Dispose"/> is a null check;
+/// <see cref="Count"/> reads the same bool and returns. No allocation and nothing to synchronise.
+/// </para>
+/// <para>
+/// <b>Not thread-safe, and deliberately so</b> — every accumulator is <c>[ThreadStatic]</c>, for the
+/// reason <see cref="RenderStageTrace"/> gives at length: a collector that locked would measure its
+/// own lock on exactly the path this document is trying to parallelize. A concurrent layout reads its
+/// own thread's numbers, which is the only reading that would mean anything.
+/// </para>
+/// </remarks>
+public static class LayoutWorkTrace
+{
+    /// <summary>Timed operations. These strings are the vocabulary the published profile uses.</summary>
+    public static class Ops
+    {
+        /// <summary>
+        /// Min/max-content measurement — <c>GetMinimumWidth</c>, <c>GetMinMaxWidth</c>,
+        /// <c>GetContentMinMaxWidth</c> and <c>ComputeShrinkToFitWidth</c>, each of which walks a
+        /// subtree. This is the operation item #13's first shape ("parallel intrinsic sizing") names.
+        /// </summary>
+        public const string Intrinsic = "intrinsic sizing";
+
+        /// <summary>Measuring a box's own words — <c>MeasureWordsSize</c>, the text-shaping entry.</summary>
+        public const string TextMeasure = "text measure";
+
+        /// <summary>Breaking an inline formatting context into lines — <c>CssLayoutEngine.CreateLineBoxes</c>.</summary>
+        public const string LineBreak = "line breaking";
+
+        /// <summary>The table layout algorithm — <c>CssLayoutEngineTable.PerformLayout</c>.</summary>
+        public const string Table = "table layout";
+
+        /// <summary>Row flex layout — <c>PerformFlexRowLayout</c>.</summary>
+        public const string Flex = "flex layout";
+    }
+
+    /// <summary>Structural counters. Exact, identical every iteration, and independent of the clock.</summary>
+    public static class Counters
+    {
+        /// <summary>Boxes entered by <c>PerformLayoutImp</c> during the pass.</summary>
+        public const string BoxesLaidOut = "boxes laid out";
+
+        /// <summary>Top-level entries into one of the four intrinsic-sizing routines.</summary>
+        public const string IntrinsicCalls = "intrinsic calls";
+
+        /// <summary>
+        /// Boxes visited by the recursive helpers those calls run
+        /// (<c>GetMinimumWidth_LongestWord</c>, <c>GetMinMaxSumWords</c>, and
+        /// <c>ComputeShrinkToFitWidth</c>'s child loop). Against
+        /// <see cref="BoxesLaidOut"/> this is the ratio that says whether intrinsic sizing is
+        /// linear in the tree or quadratic in it.
+        /// </summary>
+        public const string IntrinsicVisits = "intrinsic visits";
+
+        /// <summary>Boxes in the finished tree, counted by the census walk.</summary>
+        public const string TreeBoxes = "tree boxes";
+
+        /// <summary>Deepest box-tree nesting, counted by the census walk.</summary>
+        public const string TreeDepth = "tree depth";
+
+        /// <summary>Roots of an out-of-flow (<c>position:absolute</c>/<c>fixed</c>) subtree.</summary>
+        public const string AbsposRoots = "abspos roots";
+
+        /// <summary>Boxes inside those subtrees, the roots included.</summary>
+        public const string AbsposBoxes = "abspos boxes";
+
+        /// <summary>Table cells, which lay out independently of their siblings once columns are sized.</summary>
+        public const string TableCellRoots = "table cell roots";
+
+        /// <summary>Boxes inside table cells, the cells included.</summary>
+        public const string TableCellBoxes = "table cell boxes";
+
+        /// <summary>Flex and grid items — children of a flex/grid container.</summary>
+        public const string FlexGridRoots = "flex/grid item roots";
+
+        /// <summary>Boxes inside flex/grid items, the items included.</summary>
+        public const string FlexGridBoxes = "flex/grid item boxes";
+
+        /// <summary>
+        /// Boxes under <em>any</em> independent root, counted once each. Not the sum of the three
+        /// above: an abspos box inside a table cell would otherwise be counted twice, and the number
+        /// item #13's ceiling is bounded by is the union, not the sum.
+        /// </summary>
+        public const string IndependentBoxes = "independent boxes";
+    }
+
+    [ThreadStatic]
+    private static Dictionary<string, double>? _times;
+
+    [ThreadStatic]
+    private static Dictionary<string, long>? _counts;
+
+    /// <summary>Timestamp and accumulated child time of each open scope, outermost first.</summary>
+    [ThreadStatic]
+    private static List<(string Op, long Start, long Children)>? _stack;
+
+    /// <summary>
+    /// Whether the trace records. Off by default; the layout-composition profiler turns it on for the
+    /// duration of a measured pass and off again afterwards.
+    /// </summary>
+    public static bool Enabled { get; set; }
+
+    /// <summary>Discards the calling thread's accumulated times and counts.</summary>
+    public static void Reset()
+    {
+        _times?.Clear();
+        _counts?.Clear();
+        _stack?.Clear();
+    }
+
+    /// <summary>
+    /// The calling thread's self time per operation, in milliseconds, since the last
+    /// <see cref="Reset"/>. A copy, so a caller can hold it across the next pass.
+    /// </summary>
+    public static IReadOnlyDictionary<string, double> Times() =>
+        _times is null ? new Dictionary<string, double>() : new Dictionary<string, double>(_times);
+
+    /// <summary>The calling thread's counters since the last <see cref="Reset"/>. A copy.</summary>
+    public static IReadOnlyDictionary<string, long> Counts() =>
+        _counts is null ? new Dictionary<string, long>() : new Dictionary<string, long>(_counts);
+
+    /// <summary>Adds to a counter when enabled; otherwise does nothing at all.</summary>
+    public static void Count(string counter, long delta = 1)
+    {
+        if (!Enabled)
+            return;
+
+        var counts = _counts ??= new Dictionary<string, long>(StringComparer.Ordinal);
+        counts.TryGetValue(counter, out var previous);
+        counts[counter] = previous + delta;
+    }
+
+    /// <summary>Records a counter's maximum rather than its sum — used for tree depth.</summary>
+    public static void CountMax(string counter, long value)
+    {
+        if (!Enabled)
+            return;
+
+        var counts = _counts ??= new Dictionary<string, long>(StringComparer.Ordinal);
+        counts.TryGetValue(counter, out var previous);
+        if (value > previous)
+            counts[counter] = value;
+    }
+
+    /// <summary>
+    /// Times the <see langword="using"/> block into <paramref name="op"/>'s self time when
+    /// <see cref="Enabled"/>; otherwise does nothing at all.
+    /// </summary>
+    public static Scope Measure(string op) => Enabled ? new Scope(op) : default;
+
+    private static void Push(string op, long start)
+    {
+        var stack = _stack ??= new List<(string, long, long)>(16);
+        stack.Add((op, start, 0));
+    }
+
+    private static void Pop(string op, long start)
+    {
+        var stack = _stack;
+        if (stack is null || stack.Count == 0)
+            return;
+
+        var frame = stack[^1];
+        stack.RemoveAt(stack.Count - 1);
+
+        var elapsed = Stopwatch.GetTimestamp() - start;
+        var self = elapsed - frame.Children;
+        if (self < 0)
+            self = 0;
+
+        var times = _times ??= new Dictionary<string, double>(StringComparer.Ordinal);
+        times.TryGetValue(op, out var previous);
+        times[op] = previous + (self * 1000.0 / Stopwatch.Frequency);
+
+        // Charge the whole (inclusive) span to the enclosing scope's child total, so that scope
+        // records only what it did itself.
+        if (stack.Count > 0)
+        {
+            var parent = stack[^1];
+            stack[^1] = (parent.Op, parent.Start, parent.Children + elapsed);
+        }
+    }
+
+    /// <summary>Whether any scope is currently open on this thread.</summary>
+    internal static bool InScope => _stack is { Count: > 0 };
+
+    /// <summary>One timed operation. <see langword="default"/> is the disabled, do-nothing form.</summary>
+    public readonly struct Scope : IDisposable
+    {
+        private readonly string? _op;
+        private readonly long _start;
+
+        internal Scope(string op)
+        {
+            _op = op;
+            _start = Stopwatch.GetTimestamp();
+            Push(op, _start);
+        }
+
+        /// <summary>Accumulates the elapsed self time, or returns immediately when disabled.</summary>
+        public void Dispose()
+        {
+            if (_op is not null)
+                Pop(_op, _start);
+        }
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
@@ -1,4 +1,5 @@
 using Broiler.CSS;
+using Broiler.Layout.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 
@@ -110,6 +111,8 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
     internal void PerformFlexRowLayout(ILayoutEnvironment g)
     {
+        using var trace = LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Flex);
+
         EnsureDescendantWordsMeasured(g);
 
         double contentLeft = ClientLeft;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
@@ -1,4 +1,5 @@
 using Broiler.CSS;
+using Broiler.Layout.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 
@@ -36,6 +37,8 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
     protected virtual void PerformLayoutImp(ILayoutEnvironment g)
     {
+        LayoutWorkTrace.Count(LayoutWorkTrace.Counters.BoxesLaidOut);
+
         ResetCollapsedMarginState();
 
         if (Display != CssConstants.None)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
@@ -1,4 +1,5 @@
 using Broiler.CSS;
+using Broiler.Layout.Diagnostics;
 using System.Globalization;
 
 
@@ -85,6 +86,9 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
     internal double GetMinimumWidth()
     {
+        LayoutWorkTrace.Count(LayoutWorkTrace.Counters.IntrinsicCalls);
+        using var trace = LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Intrinsic);
+
         double maxWidth = 0;
         CssRect maxWidthWord = null;
         CssBoxHelper.GetMinimumWidth_LongestWord(this, ref maxWidth, ref maxWidthWord);
@@ -111,6 +115,9 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     /// </summary>
     internal void GetContentMinMaxWidth(out double minWidth, out double maxWidth)
     {
+        LayoutWorkTrace.Count(LayoutWorkTrace.Counters.IntrinsicCalls);
+        using var trace = LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Intrinsic);
+
         double min = 0f;
         double maxSum = 0f;
         double paddingSum = 0f;
@@ -127,6 +134,9 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
     internal void GetMinMaxWidth(out double minWidth, out double maxWidth)
     {
+        LayoutWorkTrace.Count(LayoutWorkTrace.Counters.IntrinsicCalls);
+        using var trace = LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Intrinsic);
+
         // A grid with a fixed track template contributes its physical-width track
         // sum (+ gaps + own border/padding) as both min- and max-content, rather
         // than the intrinsic width of its inline content — so a shrink-to-fit grid
@@ -182,6 +192,9 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     /// </summary>
     private double ComputeShrinkToFitWidth()
     {
+        LayoutWorkTrace.Count(LayoutWorkTrace.Counters.IntrinsicCalls);
+        using var trace = LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Intrinsic);
+
         // A grid with a fixed track template shrink-to-fits to its physical-width
         // track sum (+ gaps), not the max-content of its inline content — an empty
         // or small-item grid would otherwise collapse (fit-content / float /

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Text.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Text.cs
@@ -1,4 +1,5 @@
 using Broiler.CSS;
+using Broiler.Layout.Diagnostics;
 using System.Net;
 using System.Text;
 using System.Globalization;
@@ -418,6 +419,8 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     {
         if (_wordsSizeMeasured)
             return;
+
+        using var trace = LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.TextMeasure);
 
         LoadBackgroundImageIfNeeded();
         MeasureWordSpacing(g);

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.cs
@@ -1,5 +1,6 @@
 using Broiler.CSS;
 using Broiler.Graphics;
+using Broiler.Layout.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 
@@ -428,6 +429,12 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 // centring; inert unless such a box exists.
                 CenterOutOfFlowBlockAxis(this);
             }
+
+            // Multithreading item #13: count how much of the finished tree sits under a subtree
+            // the item proposes to claim. One walk at the root, only while the layout-composition
+            // profiler is running; LayoutWorkTrace.Enabled is false everywhere else.
+            if (ParentBox == null && LayoutWorkTrace.Enabled)
+                LayoutTreeCensus.Record(this);
         }
         catch (Exception ex)
         {

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxHelper.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Broiler.CSS;
+using Broiler.Layout.Diagnostics;
 using System.Diagnostics;
 
 
@@ -130,6 +131,8 @@ internal static class CssBoxHelper
 
     public static void GetMinimumWidth_LongestWord(CssBox box, ref double maxWidth, ref CssRect maxWidthWord)
     {
+        LayoutWorkTrace.Count(LayoutWorkTrace.Counters.IntrinsicVisits);
+
         // A display:none box generates no boxes at all (CSS 2.1 §9.2.4), so it contributes nothing
         // to an intrinsic size. Without this the UA-hidden elements that carry *text* — <style>,
         // <script>, <title> — were measured, and their source text set the min/max-content width of
@@ -194,6 +197,8 @@ internal static class CssBoxHelper
 
     public static void GetMinMaxSumWords(CssBox box, ref double min, ref double maxSum, ref double paddingSum, ref double marginSum, CssBox suppressExplicitWidthFor = null)
     {
+        LayoutWorkTrace.Count(LayoutWorkTrace.Counters.IntrinsicVisits);
+
         // See GetMinimumWidth_LongestWord: a display:none box generates no boxes, so it adds
         // nothing to the running max-content line. This is the max-content half of the same fix.
         if (box.Display == CssConstants.None)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -1,4 +1,5 @@
 using Broiler.CSS;
+using Broiler.Layout.Diagnostics;
 using System.Drawing;
 
 
@@ -274,6 +275,8 @@ internal static class CssLayoutEngine
     {
         ArgumentNullException.ThrowIfNull(g);
         ArgumentNullException.ThrowIfNull(blockBox);
+
+        using var trace = LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.LineBreak);
 
         blockBox.LineBoxes.Clear();
 

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngineTable.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngineTable.cs
@@ -1,4 +1,5 @@
 using Broiler.CSS;
+using Broiler.Layout.Diagnostics;
 using System.Drawing;
 
 
@@ -69,6 +70,8 @@ internal sealed class CssLayoutEngineTable
     {
         ArgumentNullException.ThrowIfNull(g);
         ArgumentNullException.ThrowIfNull(tableBox);
+
+        using var trace = LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Table);
 
         try
         {

--- a/docs/architecture/multithreading.md
+++ b/docs/architecture/multithreading.md
@@ -6,8 +6,16 @@ the tooling.
 
 ## Status
 
-**Phase 4 is open, and it opened by re-measuring the rationale for deprioritising
-it.** That rationale had gone stale: this document deprioritised parallel layout on
+**Phase 4 is complete, and with it every phase in this document.** It ends the way it
+began — by measuring rather than building: its two items are **#18, built**, and **#13,
+retired against a measurement of both of the shapes its row proposed**. Along the way it
+spent most of its sections somewhere else entirely, because asking whether Phases 2 and 3
+had shown up on a WPT run led to finding out what a WPT run actually costs, and the answer
+was four things, none of them a threading problem and none of them in this document
+([§4](#4-phases-2-and-3-are-worth-nothing-on-a-wpt-run-and-the-pages-are-why)–[§9](#9-the-same-fault-in-two-more-places-and-the-boundary-that-stopped-it-spreading)).
+
+**It opened by re-measuring the rationale for deprioritising itself.** That rationale had
+gone stale: this document deprioritised parallel layout on
 the grounds that layout is 0.6–6.5% of a render, and on today's code it is
 **3.3–20.1%** — not because layout got slower (it costs the same 28–51 ms it always
 did) but because Phases 2 and 3 removed cost from everything around it
@@ -16,7 +24,7 @@ did) but because Phases 2 and 3 removed cost from everything around it
 on one has to re-read it rather than cite it. It does not change the ranking — 1.5–2.5×
 of a 20% stage is ~10% end to end for 20–30 days at High risk, against a
 `parse+cascade` still at 23–81% — but the phase is now last for a reason that is
-currently true. The phase's other result is a retirement: the `Broiler.Layout`
+currently true. The phase's first retirement followed: the `Broiler.Layout`
 roadmap's **step 1**, "stop laying out the whole tree twice", ranked above both
 parallel steps, is **unreachable from every path this repository measures**, and where
 it does fire two passes cost 0.80–1.35× one, because the unrestricted first pass barely
@@ -167,6 +175,34 @@ Two residuals are named rather than hidden, and both are one patch each: the
 `Viewport` ambient slot has no read-side assertion (it lives in `Broiler.CSS`),
 and `DocumentModeContext` is never published on the HTML-string render path.
 Both are in the P0-c document.
+
+## What is left
+
+Every phase in this document is now closed, which is a claim that invites being read as
+"nothing remains". These are the open ends, each named where it was found rather than
+discovered by re-reading. None is a phase; several are one patch or one afternoon.
+
+| Open end | Where it was named | What it is |
+|---|---|---|
+| **#2's other two call-site families** | [Phase 2 §10](#10-item-17s-win-was-not-the-scan-it-was-a-host-that-never-reached-item-2s-split) | Iframes and `fetch()`/XHR still fetch serially. #17 supplies their URL set; what is missing is a consume site — the sub-document one yields `(content, contentType)` through a policy chain the text prefetcher cannot serve |
+| **#10's shaped-run cache** | [Phase 2 §5](#5-the-phases-largest-win-so-far-is-a-cache-and-not-the-one-item-10-names) | Deliberately unbuilt: `RequiresShaping` is false for the whole Latin corpus, so it would measure nothing. It needs a corpus with complex script in it before it can be judged, not more engineering |
+| **#14's scoped rebuild** | [Phase 3 §12](#12-item-14s-second-half-the-sheets-already-knew-and-the-gate-caught-a-bug-nothing-else-could) | Narrowing a rebuild rather than skipping one, for connected mutations that genuinely do reach the tree. The two elision halves took the cases that can be answered "no" |
+| **#3's sibling partitioner** | [Phase 2 §13](#13-item-3s-sequential-win-was-not-the-clip-narrowing-this-document-told-it-to-port) | A two-band split measures *slower* than sequential, reproducibly. The ported `Broiler.Graphics` copy refuses one; the `Broiler.HTML.Image` copy has the same inversion and does not |
+| **#18's refused surface** | [§12](#12-worker-is-built-and-the-design-content-was-where-the-clone-happens) | Module workers, `SharedWorker`, nested workers, worker `requestAnimationFrame`, `MessagePort` transfer, network-fetched worker scripts. Also: the engine's `structuredClone` implements transfer as copy-then-detach, which is spec-observable but is not the performance reason transferables exist |
+| **P0-b's second half** | [P0-b](#p0-b--single-threaded-determinism-first-item-15--done) | Whether `CssStyleEngine` still needs `_sync` at all. Not re-measured — and [Phase 3 §3](#3-the-_sync-lock-was-not-the-bottleneck-the-item-names-and-the-cascades-own-cost-is) has since shown the lock was never the bottleneck, so this is tidying rather than a win |
+| **P0-c's two residuals** | [P0-c](#p0-c--shared-cache-thread-safety-audit--done) | The `Viewport` ambient slot has no read-side assertion (it lives in `Broiler.CSS`), and `DocumentModeContext` is never published on the HTML-string render path. One patch each |
+| **Page-script compile on a WPT run** | [§9](#9-the-same-fault-in-two-more-places-and-the-boundary-that-stopped-it-spreading) | The largest remaining term in a WPT run at 43.60 ms/call, and **deliberately** left: sharing page-derived compiled code across documents is the one thing a conformance runner must not do. Anything here has to make a per-document compile cheaper without crossing that boundary |
+| **Three submodule patches** | [`patches/README.md`](../../patches/README.md) | `0132`, `0133`, `0134` are written, measured and pending a maintainer, because their remotes are outside this session's GitHub scope. Their fixes are not in CI's pointer |
+
+**And one that is not a task but a hazard.** [§1](#1-layouts-share-tripled-without-layout-changing-and-the-number-this-row-quoted-was-measured-before-two-phases-of-work)
+found this document deprioritising a phase on a share that two later phases had made
+false, and nothing in the process caught it, because a superseded measurement here is
+kept deliberately and nothing distinguishes "kept for the record" from "still true".
+[§14](#14-the-corpus-cannot-answer-item-13s-second-shape-and-on-real-documents-the-median-tree-is-17-boxes-with-nothing-independent-in-it)
+is the same hazard with a different mechanism — a number that was never false and never
+meant what it looked like. **Every share and every ceiling in this document decays**, and
+the two commands that re-read the most load-bearing ones are `--profile` and
+`--layout-independence`.
 
 ## Method and honesty caveat
 

--- a/docs/architecture/multithreading.md
+++ b/docs/architecture/multithreading.md
@@ -26,9 +26,30 @@ That makes **six items running whose row named the wrong thing** — five blocke
 one beneficiary. `patches/0133`. Published:
 [`tests/render-stages/results/layout-passes.md`](../../tests/render-stages/results/layout-passes.md)
 
+**Item #13 is now retired too, and the phase is closed with it.** Both of its shapes were
+measured rather than argued. Intrinsic sizing is **1.3–17.8% of the layout stage** — so
+0.04–2.5% of a render — and the counters say it is *repetition*, not computation waiting for
+threads: **4.0–39.3 subtree visits per box laid out**, because `PerformLayoutImp` ends every
+box by calling `GetMinimumWidth()`, which re-walks that box's whole subtree
+([§13](#13-a-layout-pass-is-4785-block-flow-and-item-13s-first-shape-is-2-of-a-render)).
+Independent subtrees — the second shape's ceiling — hold **0.0% of the median real
+document**: over 188 WPT documents the median tree is **17 boxes**, 59.6% of documents contain
+no independent subtree at all, and the pooled share is 18.6%. The corpus reads 94.6–99.6% and
+means nothing by it, because `paint` *is* 1 400 `position:absolute` divs and `mixed` *is* a
+70×10 table — **the corpus was built to load render stages, not to have a representative tree
+shape**, and a ceiling read off it is a ceiling for documents written to exercise the thing
+being measured ([§14](#14-the-corpus-cannot-answer-item-13s-second-shape-and-on-real-documents-the-median-tree-is-17-boxes-with-nothing-independent-in-it)).
+What remains of a pass after both shapes is the block-flow walk at **47–85%**, which this
+document's own [what not to parallelize](#what-not-to-parallelize) list already refuses. That
+makes **seven items whose row named the wrong thing** — five blockers and two beneficiaries —
+and it retires the phase's last open item against *this* repository's workload, with the
+condition that would reopen it stated rather than left implicit. Published:
+[`layout-composition.md`](../../tests/render-stages/results/layout-composition.md),
+[`layout-independence.md`](../../tests/render-stages/results/layout-independence.md)
+
 | Item | State | Evidence |
 |---|---|---|
-| #13 — parallel intrinsic sizing and independent subtrees | **Not started; re-argued** | Its stage is 3.3–20.1% of a render, up from the 0.6–6.5% the phase row quoted, entirely by Amdahl ([§1](#1-layouts-share-tripled-without-layout-changing-and-the-number-this-row-quoted-was-measured-before-two-phases-of-work)) |
+| #13 — parallel intrinsic sizing and independent subtrees | **Retired as written** | Its stage is 3.3–20.1% of a render, up from the 0.6–6.5% the phase row quoted, entirely by Amdahl ([§1](#1-layouts-share-tripled-without-layout-changing-and-the-number-this-row-quoted-was-measured-before-two-phases-of-work)). Then both of its shapes were measured. **Intrinsic sizing is 1.3–17.8% of the stage** — 0.04–2.5% of a render — and its counters say repetition rather than parallelism: **4.0–39.3 subtree visits per box laid out**, because every box ends its layout by re-walking its own subtree ([§13](#13-a-layout-pass-is-4785-block-flow-and-item-13s-first-shape-is-2-of-a-render)). **Independent subtrees hold 0.0% of the median real document** (188 WPT documents, 59.6% with none at all, 18.6% pooled), and the 94.6–99.6% the corpus reports is its own generator — `paint` *is* 1 400 abspos divs ([§14](#14-the-corpus-cannot-answer-item-13s-second-shape-and-on-real-documents-the-median-tree-is-17-boxes-with-nothing-independent-in-it)). What is left of a pass is **47–85% block flow**, already refused |
 | Layout roadmap step 1 — stop laying out the tree twice | **Retired as written** | `--layout-passes` (`patches/0133`): every fixed-viewport row is 1 call / 1 pass; auto-size is 2 passes at **0.80–1.35×** one pass, not 2× ([§2](#2-the-double-layout-is-unreachable-from-every-path-this-repository-measures-and-where-it-fires-it-is-not-a-doubling)) |
 | #18 — Web Workers | **Built (first slice); gate passed** | Contexts isolated and genuinely parallel — **2.66×/3.22× at 4 threads** ([§10](#10-item-18s-gate-passes-on-both-halves--and-one-of-them-is-the-half-nobody-was-asking-about)). `MessageChannel` and structured clone were **already built**, with cross-realm cloning verified ([§11](#11-messagechannel-was-already-built-the-unverified-word-was-cross-context)). **`Worker` now exists**: own thread, own `JSContext`, messages cloned twice — sender-side into an unreachable graph, receiver-side into its realm — and replies queued onto the page's loop, so item #15 holds. Plus worker timers on **real** deadlines (the page's loop is a virtual clock and would spin a worker hot), `importScripts` resolved against the worker's own directory, and transferables — with "transfer" qualified: the engine's `structuredClone` does copy-then-detach, spec-observable but not zero-copy. 23 tests; WPT classification identical name for name at every step ([§12](#12-worker-is-built-and-the-design-content-was-where-the-clone-happens)). module/shared/nested workers, worker `requestAnimationFrame` and `MessagePort` transfer remain |
 | Phases 2–3 measured on WPT | **Null result** | `ca53d44` vs HEAD, both sequential per render, 2 213 reftests over two suites: **1.017× and 1.013×**, inside the host's 5–7% drift, classification identical. WPT pages are 1 018 bytes at the median against a 20–212 KB corpus, so the surviving sequential wins have nothing to act on ([§4](#4-phases-2-and-3-are-worth-nothing-on-a-wpt-run-and-the-pages-are-why)) |
@@ -1694,10 +1715,17 @@ either half of this one.
 
 ## What building Phase 4 changed
 
-Nothing parallel yet, deliberately. The phase's own row said to start it only once the
-measurements say layout is still worth aiming at, so the first thing built was the
-measurement — and it changed the phase twice before a line of parallel layout was
-written.
+The phase's own row said to start it only once the measurements say layout is still worth
+aiming at, so the first thing built was the measurement — and it changed the phase twice
+before a line of parallel layout was written. It never got one: **the phase ends with item
+#13 retired rather than built**, on a measurement of both of its shapes
+([§13](#13-a-layout-pass-is-4785-block-flow-and-item-13s-first-shape-is-2-of-a-render),
+[§14](#14-the-corpus-cannot-answer-item-13s-second-shape-and-on-real-documents-the-median-tree-is-17-boxes-with-nothing-independent-in-it)),
+and item #18 built as a capability rather than a speedup. The sections in between are
+mostly not about layout or workers at all: measuring the phase's own rationale led to
+measuring a WPT run, and what a WPT run costs turned out to be four things, none of them a
+threading problem and none of them in this document
+([§4](#4-phases-2-and-3-are-worth-nothing-on-a-wpt-run-and-the-pages-are-why)–[§9](#9-the-same-fault-in-two-more-places-and-the-boundary-that-stopped-it-spreading)).
 
 ### 1. Layout's share tripled without layout changing, and the number this row quoted was measured before two phases of work
 
@@ -2231,6 +2259,138 @@ workers, `requestAnimationFrame` in a worker, `MessagePort` transfer, and networ
 scripts. Published:
 [`worker-object.md`](../../tests/render-stages/results/worker-object.md).
 
+### 13. A layout pass is 47–85% block flow, and item #13's first shape is 2% of a render
+
+Item #13 is the phase's remaining item and the only one in this document still marked *not
+started*. Its row proposes two shapes — "parallel intrinsic sizing" and "parallel independent
+subtrees" — and neither has ever been measured. [§1](#1-layouts-share-tripled-without-layout-changing-and-the-number-this-row-quoted-was-measured-before-two-phases-of-work)
+established the stage's *size* and [§2](#2-the-double-layout-is-unreachable-from-every-path-this-repository-measures-and-where-it-fires-it-is-not-a-doubling)
+retired the sequential step ranked above both, but what a single pass is *made of* was still a
+source reading. `--layout-composition` splits it into disjoint self times:
+
+| page | intrinsic sizing | text measure | line breaking | table | flex | residual (block flow) |
+|---|---:|---:|---:|---:|---:|---:|
+| text | 2.1% | 4.3% | 31.3% | — | — | **62.3%** |
+| rules | 3.2% | 4.5% | 22.7% | — | — | **69.7%** |
+| boxes | **15.0%** | 10.6% | 10.3% | — | 9.2% | **54.9%** |
+| paint | 1.3% | 8.7% | 5.9% | — | — | **84.0%** |
+| mixed | 9.0% | 11.0% | 9.6% | 16.9% | — | **53.5%** |
+
+Those are one run's medians; over four runs the per-page shares hold to **2.1–2.7%** (`text`),
+2.9–3.3% (`rules`), 14.1–17.8% (`boxes`), 1.3–1.6% (`paint`) and 6.8–10.9% (`mixed`), with the
+residual spanning 47–85%. The spread is this host, and the conclusion does not turn on which end of
+it a page sits at.
+
+**Intrinsic sizing is 1.3–17.8% of a layout stage that [§1](#1-layouts-share-tripled-without-layout-changing-and-the-number-this-row-quoted-was-measured-before-two-phases-of-work)
+measured at 3.3–20.1% of a render.** Multiplied out that is **0.04–2.5% of a render**, and at the
+roadmap's own 1.5–2.5× estimate the first shape is worth **~1% end to end on the page where it is
+largest** — for a 20–30 day item this document rates High risk. The residual — the ordinary
+block-flow walk — is **47–85%**, and normal block flow is on this document's own
+[what not to parallelize](#what-not-to-parallelize) list, because a block's position depends on the
+accumulated height of its predecessors.
+
+**The counters say the operation is repetition, not computation.** Every intrinsic call runs a
+recursive walk (`GetMinimumWidth_LongestWord`, `GetMinMaxSumWords`), and the walks are counted
+exactly:
+
+| page | boxes laid out | intrinsic calls | intrinsic visits | visits/box |
+|---|---:|---:|---:|---:|
+| text | 264 | 264 | 4 969 | **18.8** |
+| rules | 704 | 704 | 11 209 | **15.9** |
+| boxes | 724 | 2 434 | 28 449 | **39.3** |
+| paint | 1 404 | 1 404 | 5 609 | **4.0** |
+| mixed | 716 | 2 136 | 10 249 | **14.3** |
+
+A pass that measured each box's content once would read 1. It reads 4.0–39.3, because
+`PerformLayoutImp` finishes every box by calling `GetMinimumWidth()`, which re-walks that box's
+whole subtree. **That is a memoisation shape, not a threading shape** — and the honest complement
+is that memoising all of it is bounded by the same 0.04–2.5%, so it is recorded here as what the
+site is rather than proposed as work.
+
+**Two controls, because the shares are otherwise unreadable.** Measured without that control on a first
+attempt, `text` read **171 ms** against the ~51 ms the stage profile measures for the same
+configuration, and the obvious reading — "the tracer costs 3×" — was wrong. Every page is now
+rendered *twice per iteration*, traced and untraced, interleaved: the trace cost comes out at
+**0.56–1.21×** over four runs, and a ratio below 1.00 is a tracer that made the pass faster, which is impossible.
+The spread is the host, not the trace. That is the third time in this phase the same hazard has
+been caught ([§3](#3-the-harness-nearly-published-a-false-positive-the-same-way-phase-2-7s-did),
+[§6](#6-the-pixel-comparison-is-fixed-and-the-part-that-read-worst-was-not-the-part-that-cost)),
+and the second time it was caught by a control rather than by suspicion.
+
+**What the instrumentation costs when off was bounded rather than timed**, and the reason is the
+same drift. One call site sits inside `GetMinimumWidth_LongestWord`, which the `boxes` page enters
+28 449 times per pass, so "it is only a bool read" is a claim that needs a number — but the layout
+stage moves 1.6–1.9× between consecutive runs of an identical configuration, so a whole-render A/B
+would have had its sign decided by drift. The two factors were measured where each is measurable
+instead: a disabled `Count` over 20 M calls is **0.61 ns**, and the call count per page is exact
+because it is structural. Worst page: **0.02 ms, 0.1% of the pass.** Eliminating a candidate is not
+the same as measuring it — [§5](#5-the-engines-per-render-fixed-cost-is-35-ms-and-4s-closing-sentence-was-wrong)
+is in this phase because of that distinction.
+
+Published: [`layout-composition.md`](../../tests/render-stages/results/layout-composition.md).
+
+### 14. The corpus cannot answer item #13's second shape, and on real documents the median tree is 17 boxes with nothing independent in it
+
+The second shape's ceiling is the share of a tree that sits under an independent subtree — threads
+cannot help with a box that is not in one. Counted on the corpus:
+
+| page | tree boxes | abspos roots | table cells | flex/grid items | independent share |
+|---|---:|---:|---:|---:|---:|
+| text | 1 246 | 0 | 0 | 0 | **0.0%** |
+| rules | 2 806 | 0 | 0 | 0 | **0.0%** |
+| boxes | 2 166 | 0 | 0 | 810 | **95.6%** |
+| paint | 1 406 | 1 400 | 0 | 0 | **99.6%** |
+| mixed | 1 501 | 0 | 710 | 0 | **94.6%** |
+
+**Both halves of that are tautologies, and publishing it without saying so would have been the
+phase's worst number.** `paint` *is* 1 400 `position:absolute` divs, `mixed` *is* a 70×10 table and
+`boxes` *is* nested flex and grid; `text` and `rules` contain none of those constructs by
+construction. The corpus was built under P0-a to load one render stage each, not to be
+representative of tree shape, so a ceiling read off it is a ceiling for documents written to
+exercise the thing being measured. This is the same hazard as
+[§1](#1-layouts-share-tripled-without-layout-changing-and-the-number-this-row-quoted-was-measured-before-two-phases-of-work)'s
+stale share arriving from the other direction: there a true number went out of date, here a true
+number never meant what it appears to mean.
+
+**So the census was run over documents nobody chose with it in mind** — 188 real WPT documents,
+counts only, no clock:
+
+| quantity | min | median | p90 | max |
+|---|---:|---:|---:|---:|
+| document bytes | 45 | 1 116 | 3 581 | 11 428 |
+| **boxes in the tree** | 5 | **17** | 68 | 328 |
+| tree depth | 4 | 5 | 7 | 10 |
+| **independent share** | 0.0% | **0.0%** | 41.2% | 93.4% |
+
+**112 of 188 documents (59.6%) contain no independent subtree at all**, and pooled over every box
+in every document the share is **18.6%** (1 240 of 6 669). The median document this repository
+renders at scale has **17 boxes**, none of them independent. There is nothing to divide — and even
+where there is, [§5](#5-the-engines-per-render-fixed-cost-is-35-ms-and-4s-closing-sentence-was-wrong)
+already measured the whole render at 1.6–2.0% of a WPT test and layout at 0.09 ms of an empty one.
+
+The per-directory table is published next to the pooled figure for the reason the corpus needed
+saying out loud: `css/css-align/self-alignment` reads 91.0% independent across two documents, and a
+suite of flexbox tests would report a flex share that says more about the directory than about
+documents.
+
+**Item #13 is therefore retired as written**, the same way this phase retired the `Broiler.Layout`
+roadmap's step 1. Its first shape aims at 0.04–2.5% of a render and is a repetition problem rather
+than a parallelism one; its second has a ceiling of 0.0% at the median on the documents that
+dominate this repository's wall clock, and reads 94.6–99.6% only on corpus pages built out of the
+constructs being counted; and what is left after both is the block-flow walk, which this document
+already refuses. **That makes seven items whose row named the wrong thing — five blockers, and now
+two beneficiaries.**
+
+**What would change the answer, stated so it is not re-derived.** A document population with large,
+deeply independent trees — real web application pages, where a viewport of flex and grid items over
+thousands of boxes is ordinary — would move the census, and nothing here measures one. Item #13 is
+retired against *this* repository's workload, not against the shape of the web; if Broiler acquires
+a benchmark of real pages, the census is one command and the ceiling is the first thing to re-read.
+That is [§1](#1-layouts-share-tripled-without-layout-changing-and-the-number-this-row-quoted-was-measured-before-two-phases-of-work)'s
+lesson applied prospectively: this number will decay too.
+
+Published: [`layout-independence.md`](../../tests/render-stages/results/layout-independence.md).
+
 ## Master table
 
 Gain is per-stage unless stated. Effort is engineering days for one person
@@ -2251,7 +2411,7 @@ non-deterministic correctness defect.
 | 10 | Graphics | [`TrueTypeFont.GetGlyphContours`](../../Broiler.Graphics/Broiler.Graphics/Text/TrueTypeFont.cs) — **DONE**; [`ComplexTextShaper.Shape:72`](../../Broiler.Graphics/Broiler.Graphics/Text/ComplexTextShaper.cs) — not built | Outlines were re-extracted per glyph *occurrence*; shaping is called per run during layout | Concurrent cache by glyph index, published through `GetOrAdd` | Nothing | **The item was right that the cache is the whole win, and wrong about which cache.** Glyph outlines: raster stage **1.34×** (`text`), **1.54×** (`boxes`), 1.00× on the text-free `paint` control. The shaped-run cache is deliberately unbuilt — `RequiresShaping` is false for the whole Latin corpus, so it would measure nothing ([§5](#5-the-phases-largest-win-so-far-is-a-cache-and-not-the-one-item-10-names)) | Low | Done (outlines) | 2 |
 | 11 | CSS | [`CssStyleEngine.CollectFromRules:623`](../../Broiler.CSS/Broiler.CSS.Dom/CssStyleEngine.cs) — linear scan of every rule of every sheet, per element | O(elements × rules) | **Not multithreading.** Rule index (bucket by id/class/tag) + ancestor bloom filter | Nothing — this is the standard engine design and it is simply absent | **DONE.** Exit gate met: with matches fixed at four, 32× the rules now costs 1.64× the time and 1.13× the bytes (was 30.8× / 32.0×) — up to **136.9× faster** and **600× less garbage** at 3 200 rules. On a whole render the corpus `rules` page is 5 218.96 ms → 1 841.71 ms (2.8×); see [What building Phase 1 changed](#what-building-phase-1-changed) §1. `patches/0123-css-cascade-rule-index.patch` | Low | Done | 1 |
 | 12 | CSS | [`CssStyleEngine.GetCascadedStyle`](../../Broiler.CSS/Broiler.CSS.Dom/CssStyleEngine.cs) resolved ahead of the box walk by [`CssStyleRecalc`](../../Broiler.HTML/Source/Broiler.HTML.Orchestration/Parse/CssStyleRecalc.cs) — **DONE** | Was sequential per element, with the three memo caches under one global `_sync` | Warm pass over every element on `BROILER_STYLE_THREADS`, then the unchanged ordered box walk reads the memo; caches sharded to `ConcurrentDictionary`, generation guard kept | Nothing now. **Neither blocker this cell named was the operative one.** The lock was not the bottleneck — the per-element cascade was 210 µs on a five-rule page ([§3](#3-the-_sync-lock-was-not-the-bottleneck-the-item-names-and-the-cascades-own-cost-is)) — and the parallel unit is not the box walk, which cannot be split at all ([§4](#4-the-parallel-unit-is-not-the-box-walk--this-is-a-prefetchconsume-split-the-fourth-in-this-document)) | **Measured: 1.16–2.01× on the cascade stage at 4 threads, 1.08–1.96× end to end**, pixel-identical at 1/2/4. The serial residue is now measured per page (16–55%), so what is left is stated rather than guessed ([§5](#5-the-serial-residue-is-measured-now-and-it-differs-three-fold-across-pages)) | Medium | Done | 3 |
-| 13 | Layout | [`CssBox.PerformLayout:347`](../../Broiler.Layout/Broiler.Layout/Engine/CssBox.cs), [`PerformLayoutImp:37`](../../Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs) | Full-tree, in-place mutation, from the root every pass — **twice** when width is unrestricted ([`HtmlContainerInt.cs:929,936`](../../Broiler.HTML/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs)) | Parallel intrinsic sizing; parallel independent subtrees (abspos/fixed, flex+grid items, table cells, multicol, subdocuments) | Mutable shared tree; ambient thread-static state (`CssLengthParser` viewport, [`DocumentModeContext.cs:22`](../../Broiler.Layout/Broiler.Layout/DocumentModeContext.cs)); no dirty-bit invalidation to bound the work | **1.5–2.5×** of a stage **measured at 3.3–20.1% of a render** — re-measured on today's code, where the share is up from the 0.6–6.5% this cell used to quote **not because layout got slower but because Phases 2–3 made everything else faster** ([§1](#1-layouts-share-tripled-without-layout-changing-and-the-number-this-row-quoted-was-measured-before-two-phases-of-work)). ~8–12% end to end on the one page where the stage is largest, against `parse+cascade` still at 23–81% of the same renders | **High** | 20–30 d | 4 |
+| 13 | Layout | [`CssBox.PerformLayout:347`](../../Broiler.Layout/Broiler.Layout/Engine/CssBox.cs), [`PerformLayoutImp:37`](../../Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs) — **retired as written** | Full-tree, in-place mutation, from the root every pass — **once**, on every path this repository measures ([§2](#2-the-double-layout-is-unreachable-from-every-path-this-repository-measures-and-where-it-fires-it-is-not-a-doubling)) | Was: parallel intrinsic sizing; parallel independent subtrees (abspos/fixed, flex+grid items, table cells, multicol, subdocuments) | Nothing blocks it. **Neither shape is worth building, and the measurement is why.** Intrinsic sizing is 1.3–17.8% of the stage and is dominated by *repetition* — 4.0–39.3 subtree visits per box laid out, because every box ends its layout by re-walking its own subtree ([§13](#13-a-layout-pass-is-4785-block-flow-and-item-13s-first-shape-is-2-of-a-render)). Independent subtrees hold **0.0% of the median real document** and 18.6% pooled over 188 of them; the 94.6–99.6% the corpus reports is its generator restating itself ([§14](#14-the-corpus-cannot-answer-item-13s-second-shape-and-on-real-documents-the-median-tree-is-17-boxes-with-nothing-independent-in-it)) | **Measured, and it is 0.04–2.5% of a render for the first shape and 0% at the median for the second.** What is left of a pass after both is the block-flow walk at **47–85%**, which is on the do-not-parallelize list. Re-read the census if a real-page benchmark ever exists | **High** | Retired | 4 |
 | 14 | DOM / Layout | [`RenderTreeInvalidation`](../../Broiler.Layout/Broiler.Layout/Engine/RenderTreeInvalidation.cs) and [`CascadeInvalidationSet`](../../Broiler.Layout/Broiler.Layout/Engine/CascadeInvalidationSet.cs) consulted by `HtmlContainerInt.EnsureBoundDocumentCurrent` — **done**; a *scoped* rebuild is the remainder | Was: **any** DOM version bump disposes the render tree and re-cascades the whole document, then lays out the whole tree | **Not multithreading.** A consumer for `DomDocument.Mutated`, then invalidation sets over the rule index | **Neither blocker this cell named was the operative one, and that is now five items running.** The DOM's signal was never a bare counter — `DomDocument.Mutated` has published a typed `DomMutationRecord` since before the item was written; what was missing was a consumer, and it is in the main repo, not `Broiler.DOM` ([§11](#11-item-14s-blocker-did-not-exist-either-and-the-burst-does-not-amortise)). What blocks the **remainder** is real and different: eliding a *connected* mutation needs the cascade to answer whether any rule's subject could match differently | **Measured, both halves: the offscreen-build case goes from a full rebuild to none — `rules` 1 032.7 → 11.5 ms (89.8×)**, `boxes` 25.8×, `paint` 22.6×, `mixed` 16.3×, `text` 10.0×; and the connected `data-*` write the first half could not touch goes **1 476.7 → 43.0 ms (34.4×)** on `rules`, 14.2× `paint`, 13.8× `mixed`, 9.5× `boxes`, 2.1× `text`, with a class toggle 36.0× on `rules`. Rows that still rebuild span 0.79–1.21, i.e. run-to-run spread. A perfect layout dirty bit alone remains worth 1.03× | Medium–High | Done; `patches/0132` | 3 |
 | 15 | JS | [`JSPromise.Post:376`](../../Broiler.JS/Broiler.JS/Broiler.JavaScript.BuiltIns/Promise/JSPromise.cs), [`JSAsyncFunction.cs:152`](../../Broiler.JS/Broiler.JS/Broiler.JavaScript.BuiltIns/Function/JSAsyncFunction.cs), [`JSGenerator.cs:435`](../../Broiler.JS/Broiler.JS/Broiler.JavaScript.BuiltIns/Generator/JSGenerator.cs) — `ThreadPool.QueueUserWorkItem` when `sc == null` | JS continuations run on pool threads, racing main-thread layout | **Remove the parallelism.** Always pump a single-threaded event loop | This is the root cause behind WPT #1445 / #1143; the CSS `_sync` lock and the concurrent bridge memo maps are mitigations for it | Negative CPU gain, **large correctness gain**; removes lock overhead on hot cascade paths | Low | 5–8 d | 0 |
 | 16 | JS | [`ScriptCompileAhead`](../../src/Broiler.HtmlBridge.Core/Scripting/ScriptCompileAhead.cs), consumed by the eval loop in [`CaptureService`](../../src/Broiler.Cli/CaptureService.cs) — **DONE** | Was compiled on demand, serially, by the ordered eval loop | Every classic script source compiled on `BROILER_SCRIPT_COMPILE_THREADS` into the context's own cache; the loop is unchanged and reads hits | Nothing, and **the blocker this cell used to name did not exist**: `JSContext.CodeCache` is public, so the store is the context's own and no engine change is needed. The context is not late either — a document's sources are not all known until its fetches return ([§8](#8-item-16s-blocker-did-not-exist-the-store-is-the-contexts-own-cache)) | **Measured: compile stage 1.41×/1.62×/1.52× at 2/4/8 threads; whole capture 1.44× on a compile-heavy document, 1.22× on a modestly scripted one.** The estimate's 1.5–3× lands only on the stage, and only where a page's scripts are large. The sub-linear ceiling is **not** the compile-thread handoff — tested, not assumed ([§9](#9-the-compile-stages-ceiling-is-not-the-thing-that-looks-like-it)) | Low | Done | 3 |
@@ -2599,22 +2759,41 @@ first.
    ([§12](#12-item-14s-second-half-the-sheets-already-knew-and-the-gate-caught-a-bug-nothing-else-could)).
    What is left of the item is the *scoped* rebuild — narrowing a rebuild rather
    than skipping one, for the connected mutations that do reach the tree.
-3. **Parallel intrinsic sizing.** Min/max-content measurement of independent
-   subtrees is a pure function of the subtree given resolved style, so it
-   parallelizes before the mutating flow pass does.
-4. **Parallel independent subtrees** (item #13), in ascending order of risk:
-   subdocuments/iframes → `position:absolute/fixed` subtrees (they do not
-   contribute to their parent's flow) → table cells → flex/grid items. Each
-   worker must establish the thread-static ambient state from P0-c.
-   *Exit gate per class:* fragment trees identical to the sequential run across
-   the WPT corpus, verified with `FragmentJsonDumper`, at 1 and 8 threads.
+3. **Parallel intrinsic sizing** — **measured, and retired as written.** The claim
+   that min/max-content measurement "parallelizes before the mutating flow pass
+   does" is true and is not the question. `--layout-composition` puts the
+   operation at **1.3–17.8% of a layout pass**, so 0.04–2.5% of a render, and its
+   counters describe a different problem from the one this step names: the pass
+   makes **4.0–39.3 subtree visits per box laid out**, because `PerformLayoutImp`
+   ends every box with a `GetMinimumWidth()` that re-walks that box's whole
+   subtree. **That is a memoisation shape, not a threading shape** — and memoising
+   it is bounded by the same 0.04–2.5%, which is why it is recorded rather than
+   scheduled ([§13](#13-a-layout-pass-is-4785-block-flow-and-item-13s-first-shape-is-2-of-a-render)).
+4. **Parallel independent subtrees** (item #13) — **measured, and retired as
+   written.** The ceiling is the share of a tree that *is* in an independent
+   subtree, and over 188 real WPT documents that share is **0.0% at the median**:
+   the median tree is 17 boxes, 59.6% of documents have no independent subtree at
+   all, and the pooled share is 18.6%. The corpus reports 94.6–99.6% and cannot be
+   used for this — `paint` *is* 1 400 abspos divs, `mixed` *is* a 70×10 table, and
+   `text`/`rules` contain none of these constructs by construction
+   ([§14](#14-the-corpus-cannot-answer-item-13s-second-shape-and-on-real-documents-the-median-tree-is-17-boxes-with-nothing-independent-in-it)).
+   The ordering by risk (subdocuments → abspos → table cells → flex/grid items)
+   and the exit gate (fragment trees identical at 1 and 8 threads, via
+   `FragmentJsonDumper`) are kept here because they are what a future attempt
+   would need — **and what would justify one is a document population this
+   repository does not have**: real application pages, where a viewport of flex
+   and grid items over thousands of boxes is ordinary. `--layout-independence` is
+   one command, and its answer is the first thing to re-read if such a benchmark
+   appears.
 
-**Constraint to keep in view:** normal block flow is sequential in the block
-direction — a block's position depends on the height of its predecessors — so
-the ceiling here is low regardless of core count. Steps 1 and 2 were said to be
-worth more than steps 3 and 4 combined; **step 2 was, and step 1 is worth nothing
-on any path measured here**, so what remains of that claim rests entirely on the
-item that has already landed.
+**Constraint that turned out to be the whole answer:** normal block flow is
+sequential in the block direction — a block's position depends on the height of
+its predecessors — so the ceiling here is low regardless of core count. Measured,
+that walk is **47–85% of a layout pass** on every corpus page, which is what is
+left once steps 3 and 4 are subtracted. Steps 1 and 2 were said to be worth more
+than steps 3 and 4 combined; **step 2 was, step 1 is worth nothing on any path
+measured here, and steps 3 and 4 are worth 0.04–2.5% and ~0%** — so the claim is
+true, and true because three of its four terms are approximately zero.
 
 ### Broiler.JS
 
@@ -2790,7 +2969,7 @@ Recording these so they are not revisited each time the topic comes up:
 | **1 — Free wins and the sequential fixes** — **DONE** | WPT worker pool (#1), CLI batch (#20), concurrent sub-resource fetch (#2), CSS rule indexing (#11) | Cheap, low-risk, and #1 shortens the feedback loop for everything else. #11 is single-threaded but must precede #12. **What it changed:** #11 met its exit gate (cascade cost is now flat in total rules) but is 2.8× on a whole render, and `parse+cascade` still dominates the rule-heavy page — so #12 needs that stage split before it is started; #20 had to use processes, which makes item #9 a gate on every render-path item, not three. |
 | **2 — Raster, decode, text** — **DONE** | Rasterizer unification + band/tile parallelism (#3, #4, #5), font-cache safety (#9), text caches (#10), image decode (#6, #7, #8), preload scan (#17) | Largest CPU wins, disjoint memory, verifiable by exact pixel comparison. **#9 first, and it is done** — Phase 1 §2 made it the gate on every other item here, not just on #10/#12/#13. **What it changed, in the order it matters:** band parallelism inside a primitive turned out to be the wrong unit for a page — three of five corpus pages split zero fills, because their raster is glyphs — which promotes **#5 from "supersedes #3" to the only raster parallelism the corpus can use (§4)**; the phase's largest single win was a *cache*, and not the one #10 names (§5); the pool and the in-process threads multiply, so the runner now divides them (§7); the item-#9 findings (§1–§3) stand. **#5 landed and about half of its win was single-threaded** — the rasterizer was walking pixels its clip could never admit (§8) — and between them #4, #10 and #5 have taken raster from the largest stage on three pages to the largest on one (§9). **#17 landed and its number came from somewhere the item did not name:** the capture host does its own script extraction and so never reached the split item #2 built, leaving that family serial in the path this repository measures (§10). **#8 landed, and it needed neither of the two things §6 predicted** — not #17's URL set (the box tree names what layout will actually ask for, where a source scan names a superset) and not a cache (layout's existing loader seam is the split) — but it did need one thing nothing predicted: **only the decode was safe to move off the layout thread, not the completion callback**, which changed the rendered page on the failure path and nowhere else (§12). It also discharges P0-c's last debt, being the first worker to establish the ambient state and arm its assertion. **#3's port closed the phase, and it corrected this document rather than confirming it** — §8 said to port the clip narrowing first, and the sequential win turned out to be a per-pixel target lookup that banding forced out of the loop; the narrowing itself pays only on content inside the surface and outside the clip, which the corpus scene written for it did not contain (§13). Its threading is 1.00–1.39x at four threads with 85–100% of area split, so **both copies now say band parallelism is the wrong unit, for opposite reasons.** It leaves one named follow-up: a two-band split measured slower than none, and only the ported copy refuses one. The largest open question is still the parse/cascade split Phase 1 §1 named, which gates #12 — and §9 makes it the largest unattributed question in the document, now that nothing in Phase 2 is open. See [What building Phase 2 changed](#what-building-phase-2-changed). |
 | **3 — Style and incremental layout** — **DONE** | Cache sharding + parallel style recalc (#12), layout dirty bits (#14), parallel script compile (#16), re-enable test parallelization (#21) | Depends on Phase 1's algorithmic fixes and Phase 0's determinism. **What it changed, in the order it matters:** the phase opened by answering the question Phase 2 §9 said it owed, and the answer reframes the item it gates — **`parse+cascade` is 81.3–98.2% cascade on every page**, so item #12 aims at the whole stage rather than a fraction of it, and the stage's name is a legacy of nobody having measured it ([§1](#1-parsecascade-is-a-cascade-stage-the-name-overstates-the-parse)); getting that number needed the profile's first instrumentation *inside* the engine, because none of the four sub-stages is a pure function of the source and P0-a's out-of-band trick therefore does not reach them ([§2](#2-measuring-it-needed-instrumentation-and-p0-as-method-note-is-why-that-is-worth-saying)). **#12 landed and both of the blockers its row named were the wrong ones.** The `_sync` lock was not the bottleneck — the per-element cascade was 210 µs on a *five-rule* page, which no number of lock acquires explains ([§3](#3-the-_sync-lock-was-not-the-bottleneck-the-item-names-and-the-cascades-own-cost-is)) — and the parallel unit is not the box walk, which cannot be split at all: it rewrites `display` before children read it, hides a closed `<details>`'s subtree after cascading it, and inserts generated boxes on the way back up. So #12 is a **prefetch/consume split**, the fourth in this document to arrive at that shape after the item named a different one ([§4](#4-the-parallel-unit-is-not-the-box-walk--this-is-a-prefetchconsume-split-the-fourth-in-this-document)). **1.16–2.01× on the cascade stage at four threads, 1.08–1.96× end to end, pixel-identical at 1/2/4** — and the harness now publishes the serial residue per page (16–55%), so what is left is measured rather than guessed ([§5](#5-the-serial-residue-is-measured-now-and-it-differs-three-fold-across-pages)). **#21 landed** and cost nothing but the reading that says why it is safe — 2 118 tests, 0 failures, **57–59 s → 31–37 s (~1.75×)** on four cores. **#16 landed, and it needed none of what this document said it needed.** The store §6 said had to be built was already there — `JSContext.CodeCache` is public — so the item is one main-repo type and a two-line call site, with no engine change, no submodule patch and none of the cross-document isolation §6 worried about ([§8](#8-item-16s-blocker-did-not-exist-the-store-is-the-contexts-own-cache)). That makes **four items running whose stated blocker was not the operative one** (#8, #12 twice, #16), and the lesson is now explicit: the "What blocks it today" column is a hypothesis, and checking it belongs in an item's first hour rather than its last. **Compile stage 1.41×/1.62×/1.52× at 2/4/8 threads, whole capture 1.44× on a compile-heavy document and 1.22× on a modestly scripted one** — and its measurement tested the obvious explanation for the ceiling instead of publishing it, which is how the explanation turned out to be wrong and a 15–17% *sequential* tax turned up instead ([§9](#9-the-compile-stages-ceiling-is-not-the-thing-that-looks-like-it)). **#14 is the phase's remainder, and its precondition is now built.** The relayout harness §7 asked for exists (`--relayout-profile`), and its first result re-aims the item: a relayout is **60–97% box-tree rebuild and re-cascade**, because any DOM version bump disposes the render tree and re-cascades the whole document before the layout pass runs — so dirty bits on `CssBox.PerformLayout` bound 3–39% of the cost, and 2.9% on the rule-heavy page. The available ceiling is real (34× on that page if the rebuild goes, against 1.03× for a perfect layout dirty bit alone) but it sits in the box tree and the cascade, and the work starts a layer down in `Broiler.DOM`, where every script-shaped mutation is today indistinguishable from every other ([§10](#10-item-14s-harness-exists-now-and-it-says-the-item-is-aimed-at-the-smaller-half)). **#14's first slice then landed, and its blocker did not exist either — the fifth in a row.** The DOM was never limited to a version counter: `DomDocument.Mutated` has published a typed `DomMutationRecord` since before the item was written, so the item does not start in `Broiler.DOM` at all; what was missing was a consumer, and `RenderTreeInvalidation` is it. Mutations that cannot reach the render tree no longer rebuild it — **`rules` 1 032.7 → 11.5 ms (89.8×)** on the offscreen-build case, 10.0–25.8× on the other four pages, with the remaining thirty rows inside the run-to-run spread. The measurement also refuted one of §10's own two predictions (the burst does not amortise — a rebuild is whole-document for a single attribute write) and reinterpreted the other ("changes nothing observable" is already free at the value level). **The remainder was larger than the slice** — an unstyled `data-*` write still cost 997.8 ms on `rules` — and **#14's second half then took it**: `CascadeInvalidationSet` asks the sheets the tree was cascaded from whether any rule could match differently, and asks box construction separately whether it reads the attribute for reasons of its own, because a set built from stylesheets would happily elide a `<td colspan>` write on a page whose sheet never mentions `colspan`. **`rules` 1 476.7 → 43.0 ms (34.4×)** on that row, 9.5–14.2× on three other pages, 36.0× on `rules`' class toggle, with two control rows (`styled attribute`, `styled class`) that still rebuild on exactly the pages whose sheets name what they write. **The phase's last finding is not a speedup but a defect, and the gate is what makes that worth stating**: `--relayout-parity` renders every page with the elision on and off and compares images, it failed on first run, and the cause was that laying the same box tree out twice was never idempotent — a two-pixel margin drift that had been live in the *first* slice since it shipped, because nothing in this repository had ever taken that path twice ([§12](#12-item-14s-second-half-the-sheets-already-knew-and-the-gate-caught-a-bug-nothing-else-could)). An optimisation that skips work is a new execution path, and its gate has to run that path end to end. What is left of #14 is a *scoped* rebuild rather than a skipped one. See [What building Phase 3 changed](#what-building-phase-3-changed). |
-| **4 — Parallel layout and workers** — **open** | Parallel intrinsic sizing and independent subtrees (#13), Web Workers (#18) | Highest cost, highest risk, lowest ceiling. **The phase opened by re-measuring its own rationale, and the rationale had gone stale in the direction that matters.** This row used to justify deprioritising the phase with "layout is 0.6–6.5% of a first render (Phase 1 §2)". Re-run on today's code, layout is **3.3–20.1%** ([§1](#1-layouts-share-tripled-without-layout-changing-and-the-number-this-row-quoted-was-measured-before-two-phases-of-work)) — its absolute cost is unchanged at 28–51 ms, and every phase that removed cost from raster and the cascade raised its share by Amdahl. That does *not* make #13 worth 20–30 days at High risk: 1.5–2.5× of a 20% stage is ~10% end to end on one page. It does mean the phase has to be argued from a current number. The relayout side still says what it said — the layout pass is **3–39% of a relayout** ([§10](#10-item-14s-harness-exists-now-and-it-says-the-item-is-aimed-at-the-smaller-half)), the rest being box-tree rebuild and cascade — so the interactive case does not rescue the phase either. **What the phase has built is the measurement its sequential step asked for, and it retired that step**: the `Broiler.Layout` roadmap's step 1 ("stop laying out the whole tree twice", stated as worth more than the two parallel steps combined) is **unreachable from every path this repository measures**, and where it does fire it is not a doubling ([§2](#2-the-double-layout-is-unreachable-from-every-path-this-repository-measures-and-where-it-fires-it-is-not-a-doubling)). Phase 3 §4, §8 and §11 remain a warning about #13's wording, and this phase adds a sixth: **six** items running have found that the structure an item names is not the structure that can be split, or that the blocker — or, here, the *beneficiary* — it names is not the operative one. See [What building Phase 4 changed](#what-building-phase-4-changed). |
+| **4 — Parallel layout and workers** — **DONE** | Parallel intrinsic sizing and independent subtrees (#13) — **retired as written**; Web Workers (#18) — **built** | Highest cost, highest risk, lowest ceiling. **The phase opened by re-measuring its own rationale, and the rationale had gone stale in the direction that matters.** This row used to justify deprioritising the phase with "layout is 0.6–6.5% of a first render (Phase 1 §2)". Re-run on today's code, layout is **3.3–20.1%** ([§1](#1-layouts-share-tripled-without-layout-changing-and-the-number-this-row-quoted-was-measured-before-two-phases-of-work)) — its absolute cost is unchanged at 28–51 ms, and every phase that removed cost from raster and the cascade raised its share by Amdahl. That does *not* make #13 worth 20–30 days at High risk: 1.5–2.5× of a 20% stage is ~10% end to end on one page. It does mean the phase has to be argued from a current number. The relayout side still says what it said — the layout pass is **3–39% of a relayout** ([§10](#10-item-14s-harness-exists-now-and-it-says-the-item-is-aimed-at-the-smaller-half)), the rest being box-tree rebuild and cascade — so the interactive case does not rescue the phase either. **What the phase has built is the measurement its sequential step asked for, and it retired that step**: the `Broiler.Layout` roadmap's step 1 ("stop laying out the whole tree twice", stated as worth more than the two parallel steps combined) is **unreachable from every path this repository measures**, and where it does fire it is not a doubling ([§2](#2-the-double-layout-is-unreachable-from-every-path-this-repository-measures-and-where-it-fires-it-is-not-a-doubling)). Phase 3 §4, §8 and §11 remain a warning about #13's wording, and this phase adds a sixth: **six** items running have found that the structure an item names is not the structure that can be split, or that the blocker — or, here, the *beneficiary* — it names is not the operative one. **The phase then closed by measuring #13's own two shapes and retiring both, which makes seven.** A layout pass is **47–85% block-flow walk** — the thing this document already refuses — with intrinsic sizing at **1.3–17.8%** of the stage (0.04–2.5% of a render) and dominated by *repetition* rather than by work needing threads: **4.0–39.3 subtree visits per box laid out**, because every box ends its layout by re-walking its own subtree ([§13](#13-a-layout-pass-is-4785-block-flow-and-item-13s-first-shape-is-2-of-a-render)). And the second shape's ceiling — the share of a tree inside an independent subtree — is **0.0% at the median over 188 real WPT documents**, whose median tree is 17 boxes, with 59.6% containing none at all. **The corpus says 94.6–99.6% and means nothing by it**: it was built under P0-a to load one render stage each, so `paint` *is* 1 400 abspos divs and `mixed` *is* a 70×10 table, and a ceiling read off it is a ceiling for documents written to exercise the thing being measured ([§14](#14-the-corpus-cannot-answer-item-13s-second-shape-and-on-real-documents-the-median-tree-is-17-boxes-with-nothing-independent-in-it)). What would reopen the item is named rather than left implicit — a benchmark of real application pages, which this repository does not have. **#18 is built**: `Worker` on its own thread and realm, structured clone in both directions, timers on real deadlines, `importScripts`, transferables, and a passing isolation-and-throughput gate (2.66×/3.22× at 4 threads). See [What building Phase 4 changed](#what-building-phase-4-changed). |
 
 **Global exit gate:** every parallel path has a `--threads 1` equivalent that
 reproduces the sequential output exactly, and the WPT corpus produces identical

--- a/tests/render-stages/Broiler.Render.Stage.Benchmarks/LayoutComposition.cs
+++ b/tests/render-stages/Broiler.Render.Stage.Benchmarks/LayoutComposition.cs
@@ -1,0 +1,341 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Globalization;
+using System.Linq;
+using Broiler.Graphics;
+using Broiler.HTML.Image;
+using Broiler.Layout.Diagnostics;
+using BBitmap = Broiler.HTML.Image.BBitmap;
+
+namespace Broiler.Render.Stage.Benchmarks;
+
+/// <summary>
+/// What one layout pass is made of, and how much of the box tree sits under a subtree item #13
+/// proposes to lay out in parallel — the premise check the item has never had.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>What this is for.</b> Item #13's row proposes two shapes: "parallel intrinsic sizing" and
+/// "parallel independent subtrees (abspos/fixed, flex+grid items, table cells, multicol,
+/// subdocuments)". Phase 4 §1 established the stage's <em>size</em> (28–51 ms, 3.3–20.1% of a render)
+/// and §2 retired the sequential step ranked above both, but nothing has ever established the two
+/// facts that decide the item's shape: what fraction of a pass those operations are, and what
+/// fraction of the tree those subtrees hold. Six items in this document have found that the
+/// structure their row named was not the structure that could be split.
+/// </para>
+/// <para>
+/// <b>The counters are the result.</b> Two of the three questions here are structural — how many
+/// boxes intrinsic sizing visits per box laid out, and how many boxes are inside an independent
+/// subtree — and a structural question measured with a counter is exact and cannot drift, which is
+/// the general form Phase 4 §3 arrived at after a harness in this same directory nearly published a
+/// false positive from a drifting median. The milliseconds corroborate: a visit ratio that looks
+/// alarming and a self time that is 1% of the pass would mean the ratio is not worth acting on.
+/// </para>
+/// <para>
+/// <b>Self time, and the residual is published.</b> <see cref="LayoutWorkTrace"/> charges nested
+/// scopes to the scope that opened them, so the operation totals are disjoint and
+/// <c>layout ms - Σ(ops)</c> is the block-flow walk itself rather than an accounting artefact. It is
+/// reported as its own row for the reason P0-a gives: a profile whose total is the sum of its parts
+/// passes its own gate by construction.
+/// </para>
+/// <para>
+/// <b>One shape only, deliberately.</b> Every path this repository measures sets a viewport width
+/// (Phase 4 §2, counted rather than assumed), so this profiles that one — the same configuration as
+/// the stage profile, which makes the layout milliseconds here comparable with the layout column
+/// there. The auto-size shape is <see cref="LayoutPassProfile"/>'s subject and adds a second pass
+/// whose composition would have to be reported separately to mean anything.
+/// </para>
+/// </remarks>
+internal static class LayoutComposition
+{
+    private const int Width = Corpus.ViewportWidth;
+    private const int Height = Corpus.ViewportHeight;
+
+    private static readonly string[] Ops =
+    [
+        LayoutWorkTrace.Ops.Intrinsic,
+        LayoutWorkTrace.Ops.TextMeasure,
+        LayoutWorkTrace.Ops.LineBreak,
+        LayoutWorkTrace.Ops.Table,
+        LayoutWorkTrace.Ops.Flex,
+    ];
+
+    private sealed record Sample(
+        double LayoutMs,
+        IReadOnlyDictionary<string, double> Times,
+        IReadOnlyDictionary<string, long> Counts);
+
+    private sealed record Row(
+        string Page,
+        double LayoutMs,
+        double UntracedMs,
+        IReadOnlyDictionary<string, double> Times,
+        IReadOnlyDictionary<string, long> Counts);
+
+    public static int Run(int iterations, int warmup)
+    {
+        var rows = new List<Row>();
+
+        foreach (var page in Corpus.Pages)
+        {
+            for (var i = 0; i < warmup; i++)
+            {
+                MeasureOnce(page, traced: true);
+                MeasureOnce(page, traced: false);
+            }
+
+            // Traced and untraced are measured *interleaved*, iteration by iteration, for the reason
+            // Phase 2 §7 and Phase 4 §3 both record: this host drifts by tens of percent over tens of
+            // seconds, and two medians taken in their own contiguous blocks are not comparable. The
+            // untraced pass is the control that says how much of the traced pass is the trace — a
+            // composition published without it is a composition of an instrumented engine.
+            var samples = new List<Sample>(iterations);
+            var untraced = new List<double>(iterations);
+            for (var i = 0; i < iterations; i++)
+            {
+                samples.Add(MeasureOnce(page, traced: true));
+                untraced.Add(MeasureOnce(page, traced: false).LayoutMs);
+            }
+
+            // Counts are structural: identical on every iteration of the same page. Asserting that
+            // rather than assuming it — a count that moved between iterations would mean the pass
+            // depends on state carried across renders, which is a finding and not something to
+            // median away. (Phase 3 §12 found exactly such a defect from the opposite direction:
+            // laying the same tree out twice was not idempotent.)
+            var counts = samples[0].Counts;
+            foreach (var s in samples)
+            {
+                foreach (var key in counts.Keys)
+                {
+                    if (!s.Counts.TryGetValue(key, out var value) || value != counts[key])
+                        throw new InvalidOperationException(
+                            $"{page.Name}: counter '{key}' varies between iterations " +
+                            $"({counts[key]} then {(s.Counts.TryGetValue(key, out var v) ? v : 0)}) — " +
+                            "the pass is stateful across renders.");
+                }
+            }
+
+            var times = Ops.ToDictionary(
+                op => op,
+                op => Median(samples.Select(s => s.Times.TryGetValue(op, out var v) ? v : 0).ToArray()));
+
+            rows.Add(new Row(
+                page.Name,
+                Median(samples.Select(s => s.LayoutMs).ToArray()),
+                Median(untraced.ToArray()),
+                times,
+                counts));
+        }
+
+        WriteMarkdown(rows, iterations, warmup);
+        return 0;
+    }
+
+    /// <summary>
+    /// One viewport render. With <paramref name="traced"/> the trace is armed for the layout call
+    /// only; without it the identical render runs with the trace off, which is the control.
+    /// </summary>
+    private static Sample MeasureOnce(Corpus.Page page, bool traced)
+    {
+        var clip = new RectangleF(0, 0, Width, Height);
+        var bitmap = new BBitmap(Width, Height);
+        using var container = new HtmlContainer();
+        container.Location = new PointF(0, 0);
+        container.AvoidAsyncImagesLoading = true;
+        container.AvoidImagesLateLoading = true;
+        container.MaxSize = new SizeF(Width, Height);
+
+        container.SetHtmlWithStyleSet(page.Html, null, null);
+        bitmap.Clear(BColor.White);
+
+        LayoutWorkTrace.Reset();
+        LayoutWorkTrace.Enabled = traced;
+        var watch = Stopwatch.StartNew();
+        try
+        {
+            container.PerformLayout(bitmap, clip);
+        }
+        finally
+        {
+            watch.Stop();
+            LayoutWorkTrace.Enabled = false;
+        }
+
+        var sample = new Sample(
+            watch.Elapsed.TotalMilliseconds,
+            LayoutWorkTrace.Times(),
+            LayoutWorkTrace.Counts());
+
+        bitmap.Dispose();
+        return sample;
+    }
+
+    private static double Median(double[] values)
+    {
+        var copy = (double[])values.Clone();
+        Array.Sort(copy);
+        var mid = copy.Length / 2;
+        return copy.Length % 2 == 1 ? copy[mid] : (copy[mid - 1] + copy[mid]) / 2;
+    }
+
+    private static long Get(IReadOnlyDictionary<string, long> counts, string key) =>
+        counts.TryGetValue(key, out var value) ? value : 0;
+
+    private static string F(double value) => value.ToString("F2", CultureInfo.InvariantCulture);
+
+    private static string Pct(double part, double whole) =>
+        whole <= 0 ? "—" : (100.0 * part / whole).ToString("F1", CultureInfo.InvariantCulture) + "%";
+
+    /// <summary>
+    /// What the instrumentation costs when it is <em>off</em>, which is its cost in production.
+    /// </summary>
+    /// <remarks>
+    /// This deliberately does not A/B two whole renders. The disabled cost is a static <c>bool</c>
+    /// read per call site, so it is somewhere around a nanosecond, while this host's layout stage
+    /// drifts by 1.6-1.9x between consecutive runs of the identical configuration — a whole-render
+    /// A/B cannot resolve the smaller quantity through the larger one, and running it anyway would
+    /// produce a number whose sign was decided by drift. Instead the two factors are measured
+    /// separately where each is measurable: the per-call cost over a large N, where the constant is
+    /// the only thing left, and the call count per page exactly, because it is structural.
+    /// </remarks>
+    private static void WriteDisabledCost(IReadOnlyList<Row> rows)
+    {
+        const int Reps = 20_000_000;
+
+        // The trace is off for this loop, which is the configuration being costed.
+        LayoutWorkTrace.Enabled = false;
+        for (var i = 0; i < 1_000_000; i++)
+            LayoutWorkTrace.Count(LayoutWorkTrace.Counters.IntrinsicVisits);
+
+        var watch = Stopwatch.StartNew();
+        for (var i = 0; i < Reps; i++)
+            LayoutWorkTrace.Count(LayoutWorkTrace.Counters.IntrinsicVisits);
+        watch.Stop();
+
+        var nsPerCall = watch.Elapsed.TotalMilliseconds * 1_000_000.0 / Reps;
+
+        Console.WriteLine("### What it costs when off");
+        Console.WriteLine();
+        Console.WriteLine($"A disabled `Count` measured over {Reps:N0} calls: **{nsPerCall.ToString("F2", CultureInfo.InvariantCulture)} ns**.");
+        Console.WriteLine("Multiplied by the exact call count each page makes — structural, so no drift enters —");
+        Console.WriteLine("that bounds what an engine carrying this instrumentation pays with it switched off:");
+        Console.WriteLine();
+        Console.WriteLine("| page | disabled calls | bound (ms) | of the pass |");
+        Console.WriteLine("|---|---:|---:|---:|");
+        foreach (var r in rows)
+        {
+            var calls = Get(r.Counts, LayoutWorkTrace.Counters.BoxesLaidOut)
+                      + Get(r.Counts, LayoutWorkTrace.Counters.IntrinsicCalls)
+                      + Get(r.Counts, LayoutWorkTrace.Counters.IntrinsicVisits);
+            var ms = calls * nsPerCall / 1_000_000.0;
+            Console.WriteLine($"| {r.Page} | {calls} | {ms.ToString("F4", CultureInfo.InvariantCulture)} | {Pct(ms, r.UntracedMs)} |");
+        }
+        Console.WriteLine();
+        Console.WriteLine("The scope-based `Measure` sites are not in that count and are fewer than the `Count`");
+        Console.WriteLine("sites by more than an order of magnitude; disabled, `Measure` returns a `default` struct");
+        Console.WriteLine("whose `Dispose` is a null check, so it is bounded by the same constant.");
+        Console.WriteLine();
+    }
+
+    private static void WriteMarkdown(IReadOnlyList<Row> rows, int iterations, int warmup)
+    {
+        var instrumented = rows.Any(r => Get(r.Counts, LayoutWorkTrace.Counters.BoxesLaidOut) > 0);
+
+        Console.WriteLine("# What a layout pass is made of");
+        Console.WriteLine();
+        Console.WriteLine($"- Viewport: {Width}x{Height}, fixed width — the shape every path in this repository uses");
+        Console.WriteLine($"- Iterations: {iterations} measured, {warmup} warm-up; times are medians, counts are structural (asserted invariant across iterations)");
+        Console.WriteLine($"- Runtime: {Environment.Version}, {Environment.ProcessorCount} logical cores");
+        Console.WriteLine();
+
+        if (!instrumented)
+        {
+            Console.WriteLine("> **The box counter read zero on every row, so this run measured nothing.**");
+            Console.WriteLine("> `LayoutWorkTrace` is called from `Broiler.Layout`'s engine; a tree that predates");
+            Console.WriteLine("> those calls leaves it silent. Re-run against an instrumented tree rather than");
+            Console.WriteLine("> reading the times below as a composition.");
+            Console.WriteLine();
+        }
+
+        Console.WriteLine("## Self time per operation");
+        Console.WriteLine();
+        Console.WriteLine("Disjoint: a scope opened inside another is charged to the inner one and subtracted");
+        Console.WriteLine("from the outer, so `residual` is the block-flow walk itself rather than an artefact.");
+        Console.WriteLine();
+        Console.Write("| page | traced ms | untraced ms | trace cost |");
+        foreach (var op in Ops)
+            Console.Write($" {op} |");
+        Console.WriteLine(" residual |");
+        Console.Write("|---|---:|---:|---:|");
+        foreach (var _ in Ops)
+            Console.Write("---:|");
+        Console.WriteLine("---:|");
+
+        foreach (var r in rows)
+        {
+            var sum = Ops.Sum(op => r.Times[op]);
+            var overhead = r.UntracedMs > 0 ? r.LayoutMs / r.UntracedMs : 0;
+            Console.Write($"| {r.Page} | {F(r.LayoutMs)} | {F(r.UntracedMs)} | {F(overhead)}x |");
+            foreach (var op in Ops)
+                Console.Write($" {F(r.Times[op])} ({Pct(r.Times[op], r.LayoutMs)}) |");
+            Console.WriteLine($" {F(r.LayoutMs - sum)} ({Pct(r.LayoutMs - sum, r.LayoutMs)}) |");
+        }
+        Console.WriteLine();
+
+        var worst = rows.Count == 0 ? 0 : rows.Max(r => r.UntracedMs > 0 ? r.LayoutMs / r.UntracedMs : 0);
+        var best = rows.Count == 0 ? 0 : rows.Min(r => r.UntracedMs > 0 ? r.LayoutMs / r.UntracedMs : 0);
+        Console.WriteLine("`untraced ms` is the identical render with the trace off, measured interleaved with the");
+        Console.WriteLine($"traced one. **Trace cost spans {F(best)}x–{F(worst)}x** — and a ratio below 1.00 is a");
+        Console.WriteLine("tracer that made the pass faster, which is impossible, so the spread is this host's drift");
+        Console.WriteLine("rather than the trace. The shares are shares of the traced pass, and the control is a");
+        Console.WriteLine("column rather than a footnote because without it they would describe an instrumented");
+        Console.WriteLine("engine with no way to tell.");
+        Console.WriteLine();
+
+        WriteDisabledCost(rows);
+
+        Console.WriteLine("## Intrinsic sizing, counted");
+        Console.WriteLine();
+        Console.WriteLine("`visits` is how many boxes the recursive min/max-content helpers touch; `visits/box`");
+        Console.WriteLine("divides it by the boxes the pass laid out. A pass that measured each box's content");
+        Console.WriteLine("once would read 1.");
+        Console.WriteLine();
+        Console.WriteLine("| page | boxes laid out | intrinsic calls | intrinsic visits | visits/box | calls/box |");
+        Console.WriteLine("|---|---:|---:|---:|---:|---:|");
+        foreach (var r in rows)
+        {
+            var boxes = Get(r.Counts, LayoutWorkTrace.Counters.BoxesLaidOut);
+            var calls = Get(r.Counts, LayoutWorkTrace.Counters.IntrinsicCalls);
+            var visits = Get(r.Counts, LayoutWorkTrace.Counters.IntrinsicVisits);
+            Console.WriteLine(
+                $"| {r.Page} | {boxes} | {calls} | {visits} | " +
+                $"{(boxes > 0 ? F((double)visits / boxes) : "—")} | " +
+                $"{(boxes > 0 ? F((double)calls / boxes) : "—")} |");
+        }
+        Console.WriteLine();
+
+        Console.WriteLine("## Independent subtrees, counted");
+        Console.WriteLine();
+        Console.WriteLine("`independent` is the union — a box under two independent roots is counted once — and it");
+        Console.WriteLine("is the ceiling a subtree split is bounded by. Multi-column and subdocuments are on item");
+        Console.WriteLine("#13's list and are **not** counted: a column is not a box in this engine and a");
+        Console.WriteLine("subdocument is laid out by its own container, so neither has a root this walk can name.");
+        Console.WriteLine();
+        Console.WriteLine("| page | tree boxes | depth | abspos roots / boxes | table cells / boxes | flex+grid items / boxes | independent | share |");
+        Console.WriteLine("|---|---:|---:|---:|---:|---:|---:|---:|");
+        foreach (var r in rows)
+        {
+            var tree = Get(r.Counts, LayoutWorkTrace.Counters.TreeBoxes);
+            var independent = Get(r.Counts, LayoutWorkTrace.Counters.IndependentBoxes);
+            Console.WriteLine(
+                $"| {r.Page} | {tree} | {Get(r.Counts, LayoutWorkTrace.Counters.TreeDepth)} | " +
+                $"{Get(r.Counts, LayoutWorkTrace.Counters.AbsposRoots)} / {Get(r.Counts, LayoutWorkTrace.Counters.AbsposBoxes)} | " +
+                $"{Get(r.Counts, LayoutWorkTrace.Counters.TableCellRoots)} / {Get(r.Counts, LayoutWorkTrace.Counters.TableCellBoxes)} | " +
+                $"{Get(r.Counts, LayoutWorkTrace.Counters.FlexGridRoots)} / {Get(r.Counts, LayoutWorkTrace.Counters.FlexGridBoxes)} | " +
+                $"{independent} | {Pct(independent, tree)} |");
+        }
+        Console.WriteLine();
+    }
+}

--- a/tests/render-stages/Broiler.Render.Stage.Benchmarks/LayoutIndependenceCensus.cs
+++ b/tests/render-stages/Broiler.Render.Stage.Benchmarks/LayoutIndependenceCensus.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Broiler.Graphics;
+using Broiler.HTML.Image;
+using Broiler.Layout.Diagnostics;
+using BBitmap = Broiler.HTML.Image.BBitmap;
+
+namespace Broiler.Render.Stage.Benchmarks;
+
+/// <summary>
+/// The same independence census as <see cref="LayoutComposition"/>, run over real documents instead
+/// of the corpus — because on the corpus the answer is a property of the generator.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why the corpus cannot answer this.</b> Item #13's second shape is bounded above by the share of
+/// a tree that sits under an independent subtree, and on the corpus that share reads 94.6–99.6% on
+/// three pages and 0.0% on the other two. Both halves are tautologies: <c>paint</c> <em>is</em> 1 400
+/// <c>position:absolute</c> divs, <c>mixed</c> <em>is</em> a 70x10 table and <c>boxes</c> <em>is</em>
+/// nested flex and grid, while <c>text</c> and <c>rules</c> contain none of those constructs by
+/// construction. The corpus was built to load one render stage each (P0-a), not to be representative
+/// of tree shape, and a ceiling read off it would be a ceiling for documents written to exercise the
+/// thing being measured.
+/// </para>
+/// <para>
+/// <b>Why WPT documents.</b> Phase 4 §4 established that the WPT corpus is the population this
+/// repository actually renders at scale, and measured its documents at 1 018 bytes at the median
+/// against a corpus of 20–212 KB. Whatever item #13 is worth on the path that dominates this
+/// repository's wall clock is a question about <em>these</em> trees. They are also not chosen by
+/// anyone with this measurement in mind, which is the property the corpus lacks.
+/// </para>
+/// <para>
+/// <b>No clock at all.</b> Every number here is a count — boxes, roots, depth — so there is nothing
+/// for this host's drift to move, and the run needs no interleaving, no warm-up and no median. Phase
+/// 4 §3 arrived at that as a general rule after a timing harness in this directory nearly published a
+/// false positive; this is the case where it applies completely.
+/// </para>
+/// <para>
+/// <b>What it does not claim.</b> These are conformance tests, not web pages: they are small and
+/// single-purpose by design, and a directory of <c>css-flexbox</c> tests would report a flex share
+/// that says more about the directory than about documents. The distribution is therefore published
+/// per directory as well as pooled, so a reader can see whether one directory carries a result.
+/// </para>
+/// </remarks>
+internal static class LayoutIndependenceCensus
+{
+    private const int Width = Corpus.ViewportWidth;
+    private const int Height = Corpus.ViewportHeight;
+
+    private readonly record struct Doc(
+        string Directory,
+        string Name,
+        int Bytes,
+        long TreeBoxes,
+        long Depth,
+        long Independent,
+        long AbsposRoots,
+        long TableCells,
+        long FlexGridItems);
+
+    public static int Run(string wptDir, int limit)
+    {
+        if (!Directory.Exists(wptDir))
+        {
+            Console.WriteLine($"No such directory: {wptDir}");
+            return 2;
+        }
+
+        var files = Directory
+            .EnumerateFiles(wptDir, "*.html", SearchOption.AllDirectories)
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+
+        if (limit > 0 && files.Count > limit)
+            files = files.Take(limit).ToList();
+
+        if (files.Count == 0)
+        {
+            Console.WriteLine($"No .html documents under {wptDir}.");
+            return 2;
+        }
+
+        var docs = new List<Doc>(files.Count);
+        var skipped = 0;
+        foreach (var file in files)
+        {
+            try
+            {
+                docs.Add(Census(wptDir, file));
+            }
+            catch (Exception)
+            {
+                // A document this engine cannot render is not a census result. Counted and reported
+                // rather than dropped silently — a run that quietly skipped half its input would
+                // report a distribution of whatever was left.
+                skipped++;
+            }
+        }
+
+        WriteMarkdown(wptDir, docs, skipped);
+        return 0;
+    }
+
+    private static Doc Census(string root, string file)
+    {
+        var html = File.ReadAllText(file);
+        var clip = new RectangleF(0, 0, Width, Height);
+        var bitmap = new BBitmap(Width, Height);
+        using var container = new HtmlContainer();
+        container.Location = new PointF(0, 0);
+        container.AvoidAsyncImagesLoading = true;
+        container.AvoidImagesLateLoading = true;
+        container.MaxSize = new SizeF(Width, Height);
+
+        container.SetHtmlWithStyleSet(html, null, null);
+        bitmap.Clear(BColor.White);
+
+        LayoutWorkTrace.Reset();
+        LayoutWorkTrace.Enabled = true;
+        try
+        {
+            container.PerformLayout(bitmap, clip);
+        }
+        finally
+        {
+            LayoutWorkTrace.Enabled = false;
+        }
+
+        var counts = LayoutWorkTrace.Counts();
+        bitmap.Dispose();
+
+        var relative = Path.GetRelativePath(root, file);
+        var directory = Path.GetDirectoryName(relative);
+        return new Doc(
+            string.IsNullOrEmpty(directory) ? "." : directory.Replace('\\', '/'),
+            Path.GetFileName(file),
+            html.Length,
+            Get(counts, LayoutWorkTrace.Counters.TreeBoxes),
+            Get(counts, LayoutWorkTrace.Counters.TreeDepth),
+            Get(counts, LayoutWorkTrace.Counters.IndependentBoxes),
+            Get(counts, LayoutWorkTrace.Counters.AbsposRoots),
+            Get(counts, LayoutWorkTrace.Counters.TableCellRoots),
+            Get(counts, LayoutWorkTrace.Counters.FlexGridRoots));
+    }
+
+    private static long Get(IReadOnlyDictionary<string, long> counts, string key) =>
+        counts.TryGetValue(key, out var value) ? value : 0;
+
+    private static double Percentile(IReadOnlyList<double> sorted, double p)
+    {
+        if (sorted.Count == 0)
+            return 0;
+        var index = (int)Math.Round(p * (sorted.Count - 1), MidpointRounding.AwayFromZero);
+        return sorted[Math.Clamp(index, 0, sorted.Count - 1)];
+    }
+
+    private static string F(double value) => value.ToString("F1", CultureInfo.InvariantCulture);
+
+    private static void WriteMarkdown(string wptDir, IReadOnlyList<Doc> docs, int skipped)
+    {
+        Console.WriteLine("# How much of a real document is an independent subtree");
+        Console.WriteLine();
+        Console.WriteLine($"- Source: `{wptDir}`, {docs.Count} documents rendered at {Width}x{Height}" +
+                          (skipped > 0 ? $", {skipped} skipped (the engine threw)" : ""));
+        Console.WriteLine("- Every figure is a count. No clock, so no warm-up, no median and nothing to drift.");
+        Console.WriteLine();
+
+        if (docs.Count == 0)
+            return;
+
+        var boxes = docs.Select(d => (double)d.TreeBoxes).OrderBy(v => v).ToList();
+        var depth = docs.Select(d => (double)d.Depth).OrderBy(v => v).ToList();
+        var bytes = docs.Select(d => (double)d.Bytes).OrderBy(v => v).ToList();
+        var shares = docs
+            .Select(d => d.TreeBoxes > 0 ? 100.0 * d.Independent / d.TreeBoxes : 0)
+            .OrderBy(v => v)
+            .ToList();
+
+        Console.WriteLine("## The distribution");
+        Console.WriteLine();
+        Console.WriteLine("| quantity | min | median | p90 | max |");
+        Console.WriteLine("|---|---:|---:|---:|---:|");
+        Console.WriteLine($"| document bytes | {F(bytes[0])} | {F(Percentile(bytes, 0.5))} | {F(Percentile(bytes, 0.9))} | {F(bytes[^1])} |");
+        Console.WriteLine($"| boxes in the tree | {F(boxes[0])} | {F(Percentile(boxes, 0.5))} | {F(Percentile(boxes, 0.9))} | {F(boxes[^1])} |");
+        Console.WriteLine($"| tree depth | {F(depth[0])} | {F(Percentile(depth, 0.5))} | {F(Percentile(depth, 0.9))} | {F(depth[^1])} |");
+        Console.WriteLine($"| independent share % | {F(shares[0])} | {F(Percentile(shares, 0.5))} | {F(Percentile(shares, 0.9))} | {F(shares[^1])} |");
+        Console.WriteLine();
+
+        var none = docs.Count(d => d.Independent == 0);
+        var totalBoxes = docs.Sum(d => d.TreeBoxes);
+        var totalIndependent = docs.Sum(d => d.Independent);
+        Console.WriteLine($"**{none} of {docs.Count} documents ({F(100.0 * none / docs.Count)}%) contain no independent subtree at all**, ");
+        Console.WriteLine($"and pooled over every box in every document the independent share is ");
+        Console.WriteLine($"**{F(totalBoxes > 0 ? 100.0 * totalIndependent / totalBoxes : 0)}%** ({totalIndependent} of {totalBoxes}).");
+        Console.WriteLine();
+
+        Console.WriteLine("## Per directory");
+        Console.WriteLine();
+        Console.WriteLine("Published separately so a reader can see whether one directory carries the pooled");
+        Console.WriteLine("figure — a directory of flexbox tests would report a flex share that says more about");
+        Console.WriteLine("the directory than about documents.");
+        Console.WriteLine();
+        Console.WriteLine("| directory | docs | median boxes | median depth | independent share (pooled) | abspos | cells | flex/grid |");
+        Console.WriteLine("|---|---:|---:|---:|---:|---:|---:|---:|");
+        foreach (var group in docs.GroupBy(d => d.Directory).OrderBy(g => g.Key, StringComparer.Ordinal))
+        {
+            var groupBoxes = group.Select(d => (double)d.TreeBoxes).OrderBy(v => v).ToList();
+            var groupDepth = group.Select(d => (double)d.Depth).OrderBy(v => v).ToList();
+            var sumBoxes = group.Sum(d => d.TreeBoxes);
+            var sumIndependent = group.Sum(d => d.Independent);
+            Console.WriteLine(
+                $"| {group.Key} | {group.Count()} | {F(Percentile(groupBoxes, 0.5))} | {F(Percentile(groupDepth, 0.5))} | " +
+                $"{F(sumBoxes > 0 ? 100.0 * sumIndependent / sumBoxes : 0)}% | " +
+                $"{group.Sum(d => d.AbsposRoots)} | {group.Sum(d => d.TableCells)} | {group.Sum(d => d.FlexGridItems)} |");
+        }
+        Console.WriteLine();
+
+        Console.WriteLine("## The ten largest trees");
+        Console.WriteLine();
+        Console.WriteLine("The tail is where a subtree split would have anything to divide, so it is published");
+        Console.WriteLine("rather than summarised away.");
+        Console.WriteLine();
+        Console.WriteLine("| document | bytes | boxes | depth | independent | share |");
+        Console.WriteLine("|---|---:|---:|---:|---:|---:|");
+        foreach (var d in docs.OrderByDescending(d => d.TreeBoxes).Take(10))
+        {
+            Console.WriteLine(
+                $"| {d.Directory}/{d.Name} | {d.Bytes} | {d.TreeBoxes} | {d.Depth} | {d.Independent} | " +
+                $"{F(d.TreeBoxes > 0 ? 100.0 * d.Independent / d.TreeBoxes : 0)}% |");
+        }
+        Console.WriteLine();
+    }
+}

--- a/tests/render-stages/Broiler.Render.Stage.Benchmarks/Program.cs
+++ b/tests/render-stages/Broiler.Render.Stage.Benchmarks/Program.cs
@@ -94,6 +94,18 @@ public static class Program
             return LayoutPassProfile.Run(ArgValue(args, "--iterations", 9), ArgValue(args, "--warmup", 2));
         }
 
+        if (args.Length >= 1 && args[0] == "--layout-composition")
+        {
+            return LayoutComposition.Run(ArgValue(args, "--iterations", 9), ArgValue(args, "--warmup", 2));
+        }
+
+        if (args.Length >= 1 && args[0] == "--layout-independence")
+        {
+            return LayoutIndependenceCensus.Run(
+                ArgString(args, "--wpt-dir") ?? "tests/wpt",
+                ArgValue(args, "--limit", 0));
+        }
+
         if (args.Length >= 1 && args[0] == "--relayout-parity")
         {
             return RelayoutParity.Run();
@@ -162,6 +174,14 @@ public static class Program
         Console.WriteLine("        How many full-tree layout passes one PerformLayout performs, per corpus");
         Console.WriteLine("        page and per caller shape (fixed viewport / auto-size / measure) — the");
         Console.WriteLine("        precondition for the Broiler.Layout roadmap's step 1.");
+        Console.WriteLine();
+        Console.WriteLine("  --layout-composition [--iterations N] [--warmup N]");
+        Console.WriteLine("        What one layout pass spends its time on, and how much of the box tree sits");
+        Console.WriteLine("        under an independent subtree — the premise check for item #13's two shapes.");
+        Console.WriteLine();
+        Console.WriteLine("  --layout-independence [--wpt-dir <dir>] [--limit N]");
+        Console.WriteLine("        The same census over real WPT documents rather than the corpus, whose own");
+        Console.WriteLine("        answer is a property of its generator. Counts only — no clock.");
         Console.WriteLine();
         Console.WriteLine("  --relayout-parity");
         Console.WriteLine("        Renders every corpus page after every mutation with the render-tree");

--- a/tests/render-stages/Broiler.Render.Stage.Benchmarks/README.md
+++ b/tests/render-stages/Broiler.Render.Stage.Benchmarks/README.md
@@ -202,6 +202,32 @@ that compared no elisions is how this would quietly stop being a gate.
 The same switch is available as `BROILER_RENDER_TREE_ELISION=0`, which is what to reach for
 first when a rendering bug is suspected to be a stale relayout.
 
+## Layout composition and independence — item #13
+
+Two modes about what a *single* layout pass contains, built before any of item #13 so the
+item's two proposed shapes could be checked against a measurement rather than a reading.
+
+```sh
+dotnet run -c Release --project tests/render-stages/Broiler.Render.Stage.Benchmarks -- --layout-composition
+dotnet run -c Release --project tests/render-stages/Broiler.Render.Stage.Benchmarks -- --layout-independence --wpt-dir tests/wpt
+```
+
+`--layout-composition` splits a pass into disjoint self times — intrinsic sizing, text
+measurement, line breaking, table and flex — and reports the remainder as a residual rather
+than absorbing it. Two controls sit in the output because the shares are otherwise
+unreadable: every page is *also* rendered with the trace off, interleaved iteration by
+iteration, so a reader can see how much of the traced pass is the trace; and the disabled
+cost is bounded by measuring one `Count` over 20 M calls and multiplying by each page's
+exact call count, because this host's layout stage drifts by more than the quantity a
+whole-render A/B would be trying to resolve. Published run:
+[`../results/layout-composition.md`](../results/layout-composition.md).
+
+`--layout-independence` runs the same census over real WPT documents instead of the corpus.
+It exists because the corpus's own answer is a property of its generator — `paint` *is* 1 400
+`position:absolute` divs — so the corpus can report an independence ceiling of 99.6% and mean
+nothing by it. Counts only, no clock. Published run:
+[`../results/layout-independence.md`](../results/layout-independence.md).
+
 ## GC configuration — item #19
 
 The mode is fixed when the runtime starts, so one process cannot compare the two. Run it

--- a/tests/render-stages/results/layout-composition.md
+++ b/tests/render-stages/results/layout-composition.md
@@ -1,0 +1,73 @@
+# What a layout pass is made of
+
+- Viewport: 1280x1024, fixed width — the shape every path in this repository uses
+- Iterations: 11 measured, 3 warm-up; times are medians, counts are structural (asserted invariant across iterations)
+- Runtime: 10.0.10, 4 logical cores
+
+## Self time per operation
+
+Disjoint: a scope opened inside another is charged to the inner one and subtracted
+from the outer, so `residual` is the block-flow walk itself rather than an artefact.
+
+| page | traced ms | untraced ms | trace cost | intrinsic sizing | text measure | line breaking | table layout | flex layout | residual |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| text | 58.44 | 66.85 | 0.87x | 1.25 (2.1%) | 2.49 (4.3%) | 18.27 (31.3%) | 0.00 (0.0%) | 0.00 (0.0%) | 36.43 (62.3%) |
+| rules | 51.17 | 47.38 | 1.08x | 1.63 (3.2%) | 2.28 (4.5%) | 11.60 (22.7%) | 0.00 (0.0%) | 0.00 (0.0%) | 35.66 (69.7%) |
+| boxes | 42.72 | 37.70 | 1.13x | 6.40 (15.0%) | 4.52 (10.6%) | 4.42 (10.3%) | 0.00 (0.0%) | 3.93 (9.2%) | 23.44 (54.9%) |
+| paint | 33.83 | 28.97 | 1.17x | 0.45 (1.3%) | 2.95 (8.7%) | 2.01 (5.9%) | 0.00 (0.0%) | 0.00 (0.0%) | 28.42 (84.0%) |
+| mixed | 28.12 | 37.41 | 0.75x | 2.52 (9.0%) | 3.09 (11.0%) | 2.71 (9.6%) | 4.76 (16.9%) | 0.00 (0.0%) | 15.03 (53.5%) |
+
+`untraced ms` is the identical render with the trace off, measured interleaved with the
+traced one. **Trace cost spans 0.75x–1.17x** — and a ratio below 1.00 is a
+tracer that made the pass faster, which is impossible, so the spread is this host's drift
+rather than the trace. The shares are shares of the traced pass, and the control is a
+column rather than a footnote because without it they would describe an instrumented
+engine with no way to tell.
+
+### What it costs when off
+
+A disabled `Count` measured over 20,000,000 calls: **0.34 ns**.
+Multiplied by the exact call count each page makes — structural, so no drift enters —
+that bounds what an engine carrying this instrumentation pays with it switched off:
+
+| page | disabled calls | bound (ms) | of the pass |
+|---|---:|---:|---:|
+| text | 5497 | 0.0018 | 0.0% |
+| rules | 12617 | 0.0042 | 0.0% |
+| boxes | 31607 | 0.0106 | 0.0% |
+| paint | 8417 | 0.0028 | 0.0% |
+| mixed | 13101 | 0.0044 | 0.0% |
+
+The scope-based `Measure` sites are not in that count and are fewer than the `Count`
+sites by more than an order of magnitude; disabled, `Measure` returns a `default` struct
+whose `Dispose` is a null check, so it is bounded by the same constant.
+
+## Intrinsic sizing, counted
+
+`visits` is how many boxes the recursive min/max-content helpers touch; `visits/box`
+divides it by the boxes the pass laid out. A pass that measured each box's content
+once would read 1.
+
+| page | boxes laid out | intrinsic calls | intrinsic visits | visits/box | calls/box |
+|---|---:|---:|---:|---:|---:|
+| text | 264 | 264 | 4969 | 18.82 | 1.00 |
+| rules | 704 | 704 | 11209 | 15.92 | 1.00 |
+| boxes | 724 | 2434 | 28449 | 39.29 | 3.36 |
+| paint | 1404 | 1404 | 5609 | 4.00 | 1.00 |
+| mixed | 716 | 2136 | 10249 | 14.31 | 2.98 |
+
+## Independent subtrees, counted
+
+`independent` is the union — a box under two independent roots is counted once — and it
+is the ceiling a subtree split is bounded by. Multi-column and subdocuments are on item
+#13's list and are **not** counted: a column is not a box in this engine and a
+subdocument is laid out by its own container, so neither has a root this walk can name.
+
+| page | tree boxes | depth | abspos roots / boxes | table cells / boxes | flex+grid items / boxes | independent | share |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| text | 1246 | 6 | 0 / 0 | 0 / 0 | 0 / 0 | 0 | 0.0% |
+| rules | 2806 | 7 | 0 / 0 | 0 / 0 | 0 / 0 | 0 | 0.0% |
+| boxes | 2166 | 13 | 0 / 0 | 0 / 0 | 810 / 3510 | 2070 | 95.6% |
+| paint | 1406 | 5 | 1400 / 1400 | 0 / 0 | 0 / 0 | 1400 | 99.6% |
+| mixed | 1501 | 8 | 0 / 0 | 710 / 1420 | 0 / 0 | 1420 | 94.6% |
+

--- a/tests/render-stages/results/layout-independence.md
+++ b/tests/render-stages/results/layout-independence.md
@@ -1,0 +1,67 @@
+# How much of a real document is an independent subtree
+
+- Source: `tests/wpt`, 188 documents rendered at 1280x1024
+- Every figure is a count. No clock, so no warm-up, no median and nothing to drift.
+
+## The distribution
+
+| quantity | min | median | p90 | max |
+|---|---:|---:|---:|---:|
+| document bytes | 45.0 | 1116.0 | 3581.0 | 11428.0 |
+| boxes in the tree | 5.0 | 17.0 | 68.0 | 328.0 |
+| tree depth | 4.0 | 5.0 | 7.0 | 10.0 |
+| independent share % | 0.0 | 0.0 | 41.2 | 93.4 |
+
+**112 of 188 documents (59.6%) contain no independent subtree at all**, 
+and pooled over every box in every document the independent share is 
+**18.6%** (1240 of 6669).
+
+## Per directory
+
+Published separately so a reader can see whether one directory carries the pooled
+figure — a directory of flexbox tests would report a flex share that says more about
+the directory than about documents.
+
+| directory | docs | median boxes | median depth | independent share (pooled) | abspos | cells | flex/grid |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| css/CSS2 | 1 | 10.0 | 5.0 | 0.0% | 0 | 0 | 0 |
+| css/CSS2/abspos | 1 | 35.0 | 7.0 | 5.7% | 2 | 0 | 0 |
+| css/CSS2/floats-clear | 2 | 20.0 | 8.0 | 0.0% | 0 | 0 | 0 |
+| css/CSS2/linebox | 1 | 40.0 | 6.0 | 0.0% | 0 | 0 | 0 |
+| css/CSS2/normal-flow | 1 | 12.0 | 5.0 | 0.0% | 0 | 0 | 0 |
+| css/CSS2/other-formats | 1 | 73.0 | 5.0 | 0.0% | 0 | 0 | 0 |
+| css/CSS2/pagination | 2 | 53.0 | 6.0 | 0.0% | 0 | 0 | 0 |
+| css/CSS2/selector | 1 | 9.0 | 5.0 | 0.0% | 0 | 0 | 0 |
+| css/CSS2/visudet | 6 | 29.0 | 5.0 | 0.0% | 0 | 0 | 0 |
+| css/CSS2/visufx | 1 | 30.0 | 8.0 | 43.3% | 2 | 0 | 0 |
+| css/css-align/abspos | 14 | 68.0 | 7.0 | 41.2% | 196 | 0 | 0 |
+| css/css-align/blocks | 15 | 104.0 | 8.0 | 11.5% | 85 | 30 | 0 |
+| css/css-align/self-alignment | 2 | 302.0 | 8.0 | 91.0% | 16 | 0 | 96 |
+| css/css-anchor-position | 44 | 19.0 | 6.0 | 18.4% | 105 | 0 | 17 |
+| css/css-anchor-position/reference | 9 | 11.0 | 5.0 | 9.9% | 9 | 0 | 0 |
+| css/css-animations | 1 | 17.0 | 5.0 | 0.0% | 0 | 0 | 0 |
+| css/css-backgrounds | 19 | 12.0 | 5.0 | 0.8% | 2 | 0 | 0 |
+| css/css-backgrounds/animations | 6 | 12.0 | 5.0 | 0.0% | 0 | 0 | 0 |
+| css/css-backgrounds/background-clip | 24 | 25.0 | 6.0 | 1.4% | 0 | 4 | 0 |
+| css/css-backgrounds/background-size/vector | 27 | 16.0 | 5.0 | 0.0% | 0 | 0 | 0 |
+| css/css-backgrounds/background-size/vector/reference | 8 | 13.0 | 6.0 | 0.0% | 0 | 0 | 0 |
+| css/reference | 2 | 15.0 | 6.0 | 0.0% | 0 | 0 | 0 |
+
+## The ten largest trees
+
+The tail is where a subtree split would have anything to divide, so it is published
+rather than summarised away.
+
+| document | bytes | boxes | depth | independent | share |
+|---|---:|---:|---:|---:|---:|
+| css/css-align/blocks/align-content-block-006.html | 10218 | 328 | 9 | 34 | 10.4% |
+| css/css-align/blocks/align-content-block-008.html | 11428 | 328 | 9 | 34 | 10.4% |
+| css/css-align/blocks/align-content-block-010.html | 10221 | 328 | 9 | 34 | 10.4% |
+| css/css-align/blocks/align-content-block-004.html | 9661 | 324 | 9 | 34 | 10.5% |
+| css/css-align/self-alignment/block-justify-self.html | 10059 | 302 | 8 | 282 | 93.4% |
+| css/css-align/blocks/align-content-block-002.html | 8510 | 258 | 9 | 34 | 13.2% |
+| css/css-align/blocks/align-content-block-break-overflow-010-ref.html | 3474 | 174 | 8 | 0 | 0.0% |
+| css/css-align/blocks/align-content-block-break-overflow-010.html | 3865 | 158 | 10 | 0 | 0.0% |
+| css/css-align/self-alignment/block-justify-self-ref.html | 3646 | 111 | 8 | 94 | 84.7% |
+| css/css-align/blocks/safe-justify-self-vrl.html | 4145 | 104 | 6 | 0 | 0.0% |
+


### PR DESCRIPTION
Adds instrumentation to measure what a single layout pass is made of and how much of the box tree sits under independent subtrees, retiring item #13 against measurements rather than arguments.

## Summary

Item #13 proposed two shapes for parallelization: "parallel intrinsic sizing" and "parallel independent subtrees." This change adds the measurement infrastructure to evaluate both claims against real data before any implementation work.

## Key changes

- **`LayoutWorkTrace`** — New opt-in, off-by-default instrumentation that measures time spent in named layout operations (intrinsic sizing, text measurement, line breaking, table layout, flex layout) with disjoint self-time accounting, and counts structural properties (boxes laid out, intrinsic visits, tree depth, independent subtree roots and boxes).

- **`LayoutTreeCensus`** — Walks the finished box tree and records how many boxes sit under independent subtrees (abspos/fixed, table cells, flex/grid items), counting each box once even if under multiple independent roots.

- **`LayoutComposition`** — Benchmark that profiles the corpus pages with tracing enabled and disabled (interleaved to control for host drift), publishes the composition of a single pass, and measures the disabled-trace cost in production.

- **`LayoutIndependenceCensus`** — Runs the tree census over 188 real WPT documents to measure the actual distribution of independent subtrees, showing that 59.6% of documents contain none at all and the pooled share is 18.6%.

- **Instrumentation call sites** — Added `LayoutWorkTrace.Count()` and `LayoutWorkTrace.Measure()` calls to `CssBox.Sizing`, `CssBox.cs`, `CssBoxHelper`, `CssBox.Flex`, `CssBox.Layout`, `CssBox.Text`, `CssLayoutEngine`, and `CssLayoutEngineTable` to capture the operations being measured.

- **Test suite** — `LayoutWorkTraceTests` verifies the instrumentation contract: disabled it records nothing, enabled scopes are disjoint (nested scopes charge to the inner operation), and counts are structural (identical across iterations).

- **Documentation** — Updated `multithreading.md` to report the findings: intrinsic sizing is 1.3–17.8% of the layout stage (0.04–2.5% of a render) with 4.0–39.3 subtree visits per box laid out; independent subtrees hold 0.0% of the median real document; the residual block-flow walk is 47–85% of a pass.

## Implementation details

- Tracing uses `[ThreadStatic]` accumulators so concurrent layout reads its own thread's numbers without synchronization overhead.
- Self-time accounting subtracts nested scope times from their containing scope, making the totals disjoint and the residual meaningful.
- Measurements interleave traced and untraced passes to control for host drift (5–7% between consecutive runs).
- Counts are asserted invariant across iterations; a count that varies signals state carried across renders.
- The corpus is recognized as unrepresentative for tree shape (pages are built to exercise specific render stages, not to be typical documents), so WPT documents are measured separately.

Published results:
- `tests/render-stages/results/layout-composition.md` — composition of a single pass on the corpus
- `tests/render-stages/results/layout-independence.md` — distribution of independent subtrees on WPT documents

https://claude.ai/code/session_015rAej4AiGUHse1NX2mzF84