### PR TITLE
WPT reftests: five root-cause fixes (~212 tests), and two Broiler.HTML patches

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/ClipRectProjectionTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/ClipRectProjectionTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Drawing;
+using Broiler.Layout.Engine;
+using Broiler.Layout.IR;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// CSS 2.1 §11.1.2 <c>clip</c>, and the <c>clip-path: inset()</c> it is resolved into.
+/// </summary>
+/// <remarks>
+/// The property is stated from two edges — <c>top</c>/<c>bottom</c> measured down from the border
+/// box's top, <c>right</c>/<c>left</c> measured right from its left — so the numbers that look like
+/// a full box are usually an empty clip. That is the shape most of <c>css/CSS2/visufx/clip-*</c>
+/// state, each under a different unit, and each meaning "nothing should be visible".
+/// </remarks>
+public sealed class ClipRectProjectionTests
+{
+    private static readonly Uri BaseUrl = new("file:///clip.html");
+
+    /// <summary>An absolutely positioned box of <paramref name="size"/> px, square by default.</summary>
+    private static CssBox NewBox(string clip, float size = 96, string position = "absolute")
+    {
+        var box = Bare(position, size);
+        CssUtils.SetPropertyValue(box, "clip", clip);
+        return box;
+    }
+
+    private static CssBox Bare(string position = "absolute", float size = 96) =>
+        new(null, null, BaseUrl)
+        {
+            Position = position,
+            Size = new SizeF(size, size),
+            Location = new PointF(0, 0),
+            LayoutEnvironment = new FakeLayoutEnvironment(),
+        };
+
+    [Fact]
+    public void Clip_RoundTrips_Through_The_Cascade_Mapping()
+    {
+        var box = NewBox("rect(0px, 1px, 1px, 0px)");
+        Assert.Equal("rect(0px, 1px, 1px, 0px)", CssUtils.GetPropertyValue(box, "clip"));
+    }
+
+    [Fact]
+    public void The_Initial_Value_Is_Auto_And_Projects_Nothing()
+    {
+        var box = Bare();
+        Assert.Equal("auto", box.Clip);
+        Assert.False(ClipRect.TryProjectAsInset(box, out _));
+    }
+
+    // rect(top, right, bottom, left) → inset(top, width - right, height - bottom, left).
+    [Fact]
+    public void A_Rect_Becomes_The_Inset_Of_The_Same_Rectangle()
+    {
+        Assert.True(ClipRect.TryProjectAsInset(NewBox("rect(10px, 25px, 50px, 10px)", size: 100), out var inset));
+        Assert.Equal("inset(10px 75px 50px 10px)", inset);
+    }
+
+    // Four equal offsets on a box of the same size is an empty clip: the rectangle runs from the
+    // 96px mark to the 96px mark on both axes. Every unit spelling of it means the same thing.
+    [Theory]
+    [InlineData("rect(96px, 96px, 96px, 96px)")]
+    [InlineData("rect(1in, 1in, 1in, 1in)")]
+    [InlineData("rect(72pt, 72pt, 72pt, 72pt)")]
+    [InlineData("rect(6pc, 6pc, 6pc, 6pc)")]
+    [InlineData("rect(2.54cm, 2.54cm, 2.54cm, 2.54cm)")]
+    [InlineData("rect(25.4mm, 25.4mm, 25.4mm, 25.4mm)")]
+    public void Four_Equal_Offsets_On_A_Square_Box_Are_An_Empty_Clip(string clip)
+    {
+        Assert.True(ClipRect.TryProjectAsInset(NewBox(clip), out var inset));
+        Assert.Equal("inset(96px 0px 0px 96px)", inset);
+    }
+
+    // Zero on every side is the same empty clip at the box's origin — as is negative zero, which
+    // clip-004…-015 spell out one unit at a time.
+    [Theory]
+    [InlineData("rect(0, 0, 0, 0)")]
+    [InlineData("rect(0px, 0px, 0px, 0px)")]
+    [InlineData("rect(-0px, -0px, -0px, -0px)")]
+    [InlineData("rect(+0px, +0px, +0px, +0px)")]
+    public void Zero_On_Every_Side_Is_An_Empty_Clip_At_The_Origin(string clip)
+    {
+        Assert.True(ClipRect.TryProjectAsInset(NewBox(clip), out var inset));
+        Assert.Equal("inset(0px 96px 96px 0px)", inset);
+    }
+
+    // `auto` is the border edge on that side: no inset from top or left, and the full extent to
+    // right and bottom.
+    [Fact]
+    public void Auto_Sides_Are_The_Border_Edges()
+    {
+        Assert.True(ClipRect.TryProjectAsInset(NewBox("rect(auto, auto, auto, auto)"), out var inset));
+        Assert.Equal("inset(0px 0px 0px 0px)", inset);
+    }
+
+    [Fact]
+    public void A_Clip_Larger_Than_The_Box_Insets_Negatively()
+    {
+        Assert.True(ClipRect.TryProjectAsInset(NewBox("rect(-50px, auto, auto, -50px)"), out var inset));
+        Assert.Equal("inset(-50px 0px 0px -50px)", inset);
+    }
+
+    // CSS 2.1's grammar says commas; every engine has always taken spaces too, and clip-016…-021
+    // exist to say so, one per mixture.
+    [Theory]
+    [InlineData("rect(0 0 0 0)")]
+    [InlineData("rect(0,0,0 0)")]
+    [InlineData("rect(0,0 0,0)")]
+    [InlineData("rect(0 0,0 0)")]
+    [InlineData("rect( 0 0 0 0 )")]
+    public void Commas_And_Spaces_Separate_The_Sides_Alike(string clip) =>
+        Assert.True(ClipRect.TryProjectAsInset(NewBox(clip), out _));
+
+    // "Applies to: absolutely positioned elements."
+    [Theory]
+    [InlineData("static")]
+    [InlineData("relative")]
+    [InlineData("sticky")]
+    public void Clip_Does_Not_Apply_To_A_Box_That_Is_Not_Absolutely_Positioned(string position) =>
+        Assert.False(ClipRect.TryProjectAsInset(NewBox("rect(0, 0, 0, 0)", position: position), out _));
+
+    [Fact]
+    public void Clip_Applies_To_A_Fixed_Box_Too() =>
+        Assert.True(ClipRect.TryProjectAsInset(NewBox("rect(0, 0, 0, 0)", position: "fixed"), out _));
+
+    // An invalid value is dropped, leaving the element unclipped — the grammar takes lengths and
+    // `auto`, so a percentage, a shape function, or the wrong number of sides is not a clip.
+    [Theory]
+    [InlineData("auto")]
+    [InlineData("circle(10px, 25px)")]
+    [InlineData("rect(0, 0, 0)")]
+    [InlineData("rect(0, 0, 0, 0, 0)")]
+    [InlineData("rect(0%, 0%, 0%, 0%)")]
+    [InlineData("rect(0, 0, 0, red)")]
+    public void An_Invalid_Value_Projects_Nothing(string clip) =>
+        Assert.False(ClipRect.TryProjectAsInset(NewBox(clip), out _));
+
+    // CSS Masking 1 §7: a real clip-path supersedes clip, so the box paints with its own.
+    [Fact]
+    public void A_Clip_Path_Wins_Over_Clip()
+    {
+        var box = NewBox("rect(0, 0, 0, 0)");
+        box.ClipPath = "circle(50%)";
+        Assert.Equal("circle(50%)", ClipRect.EffectiveClipPath(box));
+    }
+
+    [Fact]
+    public void Clip_Is_Projected_When_Clip_Path_Says_None()
+    {
+        var box = NewBox("rect(0, 0, 0, 0)");
+        Assert.Equal("inset(0px 96px 96px 0px)", ClipRect.EffectiveClipPath(box));
+    }
+
+    [Fact]
+    public void A_Box_With_Neither_Keeps_Its_Own_Clip_Path()
+    {
+        var box = Bare();
+        Assert.Equal("none", ClipRect.EffectiveClipPath(box));
+    }
+
+    // Minimal ILayoutEnvironment: supplies a fixed 16px font so a rect() side stated in `em` or
+    // `ex` resolves. These boxes carry no text or replaced content, so nothing else is exercised.
+    private sealed class FakeLayoutEnvironment : Broiler.Layout.ILayoutEnvironment
+    {
+        private static readonly Broiler.Graphics.ILayoutFont TheFont = new FakeFont();
+        public Broiler.Graphics.ILayoutFont GetFont(string family, double size, LayoutFontStyle style, string? fontFeatures = null) => TheFont;
+        public SizeF MeasureText(Broiler.Graphics.ILayoutFont font, string text) => SizeF.Empty;
+        public void MeasureText(Broiler.Graphics.ILayoutFont font, string text, double maxWidth, out int charFit, out double charFitWidth) { charFit = 0; charFitWidth = 0; }
+        public double GetWhitespaceWidth(Broiler.Graphics.ILayoutFont font) => 0;
+        public Broiler.Layout.ImageIntrinsics GetImageIntrinsics(object imageHandle) => default;
+        public Broiler.Graphics.BColor ParseColor(string value) => default;
+        public void RequestRefresh(bool relayout) { }
+        public SizeF ViewportSize => new(1000, 1000);
+        public PointF RootLocation => PointF.Empty;
+        public SizeF ActualSize { get; set; }
+        public bool AvoidGeometryAntialias => false;
+        public SizeF PageSize => new(1000, 1000);
+        public int MarginTop => 0;
+        public void ReportLayoutError(string message, Exception? exception = null) { }
+        public bool AvoidAsyncImagesLoading => true;
+        public bool AvoidImagesLateLoading => true;
+        public Broiler.Layout.ILayoutImageLoader CreateImageLoader(Action<object?, RectangleF, bool> onComplete) => null!;
+        public string FormatListMarker(int number, string style) => string.Empty;
+    }
+
+    private sealed class FakeFont : Broiler.Graphics.ILayoutFont
+    {
+        public double Size => 16;
+        public double Height => 16;
+        public double UnderlineOffset => 0;
+        public double LeftPadding => 0;
+        public string? FontFeatures => null;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout.Tests/InlineRelativePositionTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/InlineRelativePositionTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Drawing;
+using System.Linq;
+using Broiler.Layout.Engine;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// CSS 2.1 §9.4.3: <c>position: relative</c> on an <em>inline-level</em> box.
+/// </summary>
+/// <remarks>
+/// The offset is visual — the box keeps its place in the flow and its content is drawn somewhere
+/// else — so it has to reach the words, which is what <c>OffsetLeft</c>/<c>OffsetTop</c> do.
+/// <c>PerformLayout</c> applies it for every box it lays out, but an inline-level box is laid out by
+/// <c>CreateLineBoxes</c> and never goes through <c>PerformLayout</c>, so nothing applied it at all:
+/// an inline <c>&lt;span&gt;</c> or <c>&lt;img&gt;</c> asking to be moved rendered at its static
+/// position. It is the shape CSS2's own reference documents use to place a swatch, so the cost
+/// landed on the reference side — 68 of <c>css/css-writing-modes</c>' reftests, whose references are
+/// ordinary horizontal documents.
+/// </remarks>
+public sealed class InlineRelativePositionTests
+{
+    private static readonly Uri BaseUrl = new("file:///relative.html");
+
+    private static CssBox Container(string writingMode = "horizontal-tb")
+    {
+        var root = new CssBox(null, new HtmlTag("div", false, null), BaseUrl)
+        {
+            Display = "block",
+            Location = new PointF(0, 0),
+            Size = new SizeF(400, 200),
+            WritingMode = writingMode,
+            LayoutEnvironment = new FakeLayoutEnvironment(),
+        };
+        return root;
+    }
+
+    private static CssBox Inline(CssBox parent, string? left = null, string? top = null,
+        string? right = null, string? bottom = null, string position = "relative")
+    {
+        var box = new CssBox(parent, new HtmlTag("span", false, null), BaseUrl) { Display = "inline" };
+        box.Position = position;
+        if (left != null) box.Left = left;
+        if (top != null) box.Top = top;
+        if (right != null) box.Right = right;
+        if (bottom != null) box.Bottom = bottom;
+        box.Words.Add(new CssRectWord(box, "X", false, false));
+        return box;
+    }
+
+    private static (double Left, double Top) WordOf(CssBox box) =>
+        (box.Words.Single().Left, box.Words.Single().Top);
+
+    /// <summary>
+    /// Where the word lands, less where the same word lands with no offset at all. Line layout
+    /// assigns word positions from scratch on every pass — which is also why a re-layout cannot
+    /// compound these offsets — so the shift is only readable against a static control.
+    /// </summary>
+    private static (double X, double Y) Shift(
+        string writingMode = "horizontal-tb",
+        string? left = null, string? top = null, string? right = null, string? bottom = null)
+    {
+        var moved = Container(writingMode);
+        var movedSpan = Inline(moved, left, top, right, bottom);
+        moved.PerformLayout(moved.LayoutEnvironment);
+
+        var still = Container(writingMode);
+        var stillSpan = Inline(still, position: "static");
+        still.PerformLayout(still.LayoutEnvironment);
+
+        var (mx, my) = WordOf(movedSpan);
+        var (sx, sy) = WordOf(stillSpan);
+        return (mx - sx, my - sy);
+    }
+
+    [Fact]
+    public void An_Inline_Box_Offsets_Its_Words() =>
+        Assert.Equal((60, 30), Shift(left: "60px", top: "30px"));
+
+    // CSS2.1 §9.4.3: with `left` auto and `right` set, the box moves the other way.
+    [Fact]
+    public void Right_And_Bottom_Offset_The_Other_Way() =>
+        Assert.Equal((-15, -5), Shift(right: "15px", bottom: "5px"));
+
+    [Fact]
+    public void A_Static_Inline_Box_Is_Left_Where_It_Was() =>
+        Assert.Equal((0, 0), Shift());
+
+    // Offsets compound: a relative box inside a relative box moves by both.
+    [Fact]
+    public void Nested_Relative_Inline_Boxes_Compound()
+    {
+        var moved = Container();
+        var outer = Inline(moved, left: "60px", top: "30px");
+        var inner = Inline(outer, left: "5px", top: "7px");
+        moved.PerformLayout(moved.LayoutEnvironment);
+
+        var still = Container();
+        var stillOuter = Inline(still, position: "static");
+        var stillInner = Inline(stillOuter, position: "static");
+        still.PerformLayout(still.LayoutEnvironment);
+
+        var (ix, iy) = WordOf(inner);
+        var (sx, sy) = WordOf(stillInner);
+        Assert.Equal((65, 37), (ix - sx, iy - sy));
+    }
+
+    // An inline-block is inline-*level* but is laid out as a block, so its own PerformLayout
+    // applies its offset — the walk must leave it alone, or it moves by double.
+    // CSS2/margin-padding-clear/margin-collapse-001's reference stacks two of them and is the pair
+    // that caught it; this pins the half the walk is responsible for, since the harness below does
+    // not run an inline-block's own layout. A shift of zero here is the walk declining to touch it.
+    [Theory]
+    [InlineData("inline-block")]
+    [InlineData("inline-flex")]
+    [InlineData("inline-grid")]
+    public void The_Walk_Leaves_A_Box_That_Lays_Itself_Out_Alone(string display)
+    {
+        var moved = Container();
+        var box = Inline(moved, left: "60px", top: "30px");
+        box.Display = display;
+        moved.PerformLayout(moved.LayoutEnvironment);
+
+        var still = Container();
+        var stillBox = Inline(still, position: "static");
+        stillBox.Display = display;
+        still.PerformLayout(still.LayoutEnvironment);
+
+        var (mx, my) = WordOf(box);
+        var (sx, sy) = WordOf(stillBox);
+        Assert.Equal((0, 0), (mx - sx, my - sy));
+    }
+
+    // `left`/`top` are physical, but a vertical container's words sit in the engine's rotated
+    // space, so the offset would arrive turned a quarter turn. Until that mapping exists, a
+    // vertical container is left alone rather than moved wrongly — which is what
+    // css-writing-modes/vrl-inline-paint-invalidation asks for.
+    [Theory]
+    [InlineData("vertical-rl")]
+    [InlineData("vertical-lr")]
+    [InlineData("sideways-rl")]
+    [InlineData("sideways-lr")]
+    public void A_Vertical_Container_Leaves_Its_Inline_Boxes_Alone(string writingMode) =>
+        Assert.Equal((0, 0), Shift(writingMode, left: "60px", top: "30px"));
+
+    // Minimal ILayoutEnvironment: a fixed font, and nothing else these boxes reach.
+    private sealed class FakeLayoutEnvironment : Broiler.Layout.ILayoutEnvironment
+    {
+        private static readonly Broiler.Graphics.ILayoutFont TheFont = new FakeFont();
+        public Broiler.Graphics.ILayoutFont GetFont(string family, double size, LayoutFontStyle style, string? fontFeatures = null) => TheFont;
+        public SizeF MeasureText(Broiler.Graphics.ILayoutFont font, string text) => new(8, 16);
+        public void MeasureText(Broiler.Graphics.ILayoutFont font, string text, double maxWidth, out int charFit, out double charFitWidth) { charFit = text.Length; charFitWidth = 8; }
+        public double GetWhitespaceWidth(Broiler.Graphics.ILayoutFont font) => 4;
+        public Broiler.Layout.ImageIntrinsics GetImageIntrinsics(object imageHandle) => default;
+        public Broiler.Graphics.BColor ParseColor(string value) => default;
+        public void RequestRefresh(bool relayout) { }
+        public SizeF ViewportSize => new(1000, 1000);
+        public PointF RootLocation => PointF.Empty;
+        public SizeF ActualSize { get; set; }
+        public bool AvoidGeometryAntialias => false;
+        public SizeF PageSize => new(1000, 1000);
+        public int MarginTop => 0;
+        public void ReportLayoutError(string message, Exception? exception = null) { }
+        public bool AvoidAsyncImagesLoading => true;
+        public bool AvoidImagesLateLoading => true;
+        public Broiler.Layout.ILayoutImageLoader CreateImageLoader(Action<object?, RectangleF, bool> onComplete) => null!;
+        public string FormatListMarker(int number, string style) => string.Empty;
+    }
+
+    private sealed class FakeFont : Broiler.Graphics.ILayoutFont
+    {
+        public double Size => 16;
+        public double Height => 16;
+        public double UnderlineOffset => 0;
+        public double LeftPadding => 0;
+        public string? FontFeatures => null;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout.Tests/ReplacedImageSizingTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/ReplacedImageSizingTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Drawing;
+using Broiler.Layout.Engine;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// CSS 2.1 §10.4: how a replaced element's used width and height come out of what the author stated
+/// and what the image itself is.
+/// </summary>
+/// <remarks>
+/// The intrinsic ratio fills in a dimension left <c>auto</c>; it never overrules one the author
+/// stated. A percentage width is a stated width like any other — it is only resolved later, against
+/// the containing block — and treating it as if it were <c>auto</c> made
+/// <c>&lt;img width="100%" height="50"&gt;</c> come out as tall as it was wide. That is the shape
+/// CSS2's own reference documents use to draw a coloured band, so the cost landed on the
+/// <em>reference</em> side of 85 reftests in <c>css/CSS2/backgrounds</c> alone, where the test was
+/// right all along.
+/// </remarks>
+public sealed class ReplacedImageSizingTests
+{
+    private static readonly Uri BaseUrl = new("file:///image.html");
+
+    /// <summary>A 10×10 image (ratio 1) in a 400px-wide containing block.</summary>
+    private static CssRectImage Measure(string width, string height, double imageWidth = 10, double imageHeight = 10)
+    {
+        var environment = new FakeLayoutEnvironment(new ImageIntrinsics(imageWidth, imageHeight, true));
+
+        var containingBlock = new CssBox(null, null, BaseUrl)
+        {
+            Display = "block",
+            Size = new SizeF(400, 400),
+            LayoutEnvironment = environment,
+        };
+
+        var box = new CssBox(containingBlock, null, BaseUrl) { Display = "inline", Width = width, Height = height };
+        var word = new CssRectImage(box) { Image = new object() };
+
+        CssLayoutEngine.MeasureImageSize(environment, word);
+        return word;
+    }
+
+    [Fact]
+    public void A_Percentage_Width_And_A_Stated_Height_Are_Both_Used()
+    {
+        var word = Measure("100%", "50px");
+
+        Assert.Equal(400, word.Width, 3);
+        Assert.Equal(50, word.Height, 3);
+    }
+
+    [Fact]
+    public void A_Length_Width_And_A_Stated_Height_Are_Both_Used()
+    {
+        var word = Measure("200px", "20px");
+
+        Assert.Equal(200, word.Width, 3);
+        Assert.Equal(20, word.Height, 3);
+    }
+
+    // With the height left to the image, the ratio fills it in — from a percentage width as much as
+    // from a length one.
+    [Theory]
+    [InlineData("100%", 400, 200)]
+    [InlineData("50%", 200, 100)]
+    [InlineData("120px", 120, 60)]
+    public void An_Auto_Height_Comes_From_The_Ratio(string width, double expectedWidth, double expectedHeight)
+    {
+        var word = Measure(width, "auto", imageWidth: 20, imageHeight: 10);
+
+        Assert.Equal(expectedWidth, word.Width, 3);
+        Assert.Equal(expectedHeight, word.Height, 3);
+    }
+
+    [Fact]
+    public void An_Auto_Width_Comes_From_The_Ratio()
+    {
+        var word = Measure("auto", "30px", imageWidth: 20, imageHeight: 10);
+
+        Assert.Equal(60, word.Width, 3);
+        Assert.Equal(30, word.Height, 3);
+    }
+
+    [Fact]
+    public void Neither_Stated_Is_The_Intrinsic_Size()
+    {
+        var word = Measure("auto", "auto", imageWidth: 33, imageHeight: 17);
+
+        Assert.Equal(33, word.Width, 3);
+        Assert.Equal(17, word.Height, 3);
+    }
+
+    // Minimal ILayoutEnvironment: a fixed font, and the one image's intrinsics.
+    private sealed class FakeLayoutEnvironment(ImageIntrinsics intrinsics) : Broiler.Layout.ILayoutEnvironment
+    {
+        private static readonly Broiler.Graphics.ILayoutFont TheFont = new FakeFont();
+        public Broiler.Graphics.ILayoutFont GetFont(string family, double size, LayoutFontStyle style, string? fontFeatures = null) => TheFont;
+        public SizeF MeasureText(Broiler.Graphics.ILayoutFont font, string text) => SizeF.Empty;
+        public void MeasureText(Broiler.Graphics.ILayoutFont font, string text, double maxWidth, out int charFit, out double charFitWidth) { charFit = 0; charFitWidth = 0; }
+        public double GetWhitespaceWidth(Broiler.Graphics.ILayoutFont font) => 0;
+        public Broiler.Layout.ImageIntrinsics GetImageIntrinsics(object imageHandle) => intrinsics;
+        public Broiler.Graphics.BColor ParseColor(string value) => default;
+        public void RequestRefresh(bool relayout) { }
+        public SizeF ViewportSize => new(1000, 1000);
+        public PointF RootLocation => PointF.Empty;
+        public SizeF ActualSize { get; set; }
+        public bool AvoidGeometryAntialias => false;
+        public SizeF PageSize => new(1000, 1000);
+        public int MarginTop => 0;
+        public void ReportLayoutError(string message, Exception? exception = null) { }
+        public bool AvoidAsyncImagesLoading => true;
+        public bool AvoidImagesLateLoading => true;
+        public Broiler.Layout.ILayoutImageLoader CreateImageLoader(Action<object?, RectangleF, bool> onComplete) => null!;
+        public string FormatListMarker(int number, string style) => string.Empty;
+    }
+
+    private sealed class FakeFont : Broiler.Graphics.ILayoutFont
+    {
+        public double Size => 16;
+        public double Height => 16;
+        public double UnderlineOffset => 0;
+        public double LeftPadding => 0;
+        public string? FontFeatures => null;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CanvasBackdrop.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CanvasBackdrop.cs
@@ -1,0 +1,33 @@
+using Broiler.Graphics;
+
+namespace Broiler.Layout.Engine;
+
+/// <summary>
+/// The colour the canvas composites a translucent propagated background against — the paint that is
+/// already on the surface underneath it, when the caller knows it is not the white the paint walker
+/// otherwise assumes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CSS 2.1 §14.2 propagates the root element's (or <c>&lt;body&gt;</c>'s) background to the canvas,
+/// and the paint walker emits it as one opaque fill: a half-transparent background is flattened
+/// against the canvas backdrop first, which is white unless the document's used colour scheme is
+/// dark. That is right for a render onto a blank surface and wrong for one onto a surface that
+/// already carries paint — CSS Paged Media 3 §7.2's page background is exactly that case, and
+/// <c>page-box-002-print</c> is the reftest that states it: <c>body { background: #f008 }</c> over
+/// <c>@page { background: #00f }</c> must come out violet, not pink.
+/// </para>
+/// <para>
+/// Thread-static and null by default, like the engine's other render levers
+/// (<see cref="NativeZoom.Enabled"/>, <see cref="NativeAnchorPlacement.Enabled"/>): a caller sets it
+/// around one render on one thread, and every render that does not is byte-identical to before. It
+/// carries a single colour rather than the surface because the flatten produces a single colour —
+/// so the WPT runner sets it only when the page background under the whole page area is one flat
+/// colour, and leaves the white assumption standing when it is an image or a gradient.
+/// </para>
+/// </remarks>
+internal static class CanvasBackdrop
+{
+    [System.ThreadStatic]
+    public static BColor? Current;
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
@@ -1132,6 +1132,15 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                     }
                 }
 
+                // CSS2.1 §9.4.3: a relatively positioned inline-level box is offset
+                // visually once its line boxes exist. PerformLayout does that for every box
+                // it lays out, but an inline-level box is laid out by CreateLineBoxes and
+                // never goes through PerformLayout — so nothing moved an inline <span> or
+                // <img> that asked to be moved, and `position: relative; left: 160px` on one
+                // rendered at its static position.
+                if (!CssWritingMode.IsVertical(WritingMode))
+                    OffsetRelativeInlineDescendants();
+
                 // CSS2.1 §10.6.7: Elements that establish a new block
                 // formatting context (BFC) must include descendant floats
                 // in their auto-height calculation.  The inline path above
@@ -2353,6 +2362,54 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     /// CSS2.1 §9.4.3: apply the visual position:relative offset after layout
     /// (doesnot affect flow).
     /// </summary>
+    /// <summary>
+    /// Applies <c>position: relative</c> offsets to the inline-level boxes inside this container's
+    /// line boxes — the ones <see cref="PerformLayout"/> never sees.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="OffsetLeft"/> carries a shift into the box's own words, its line-box rectangles
+    /// and its descendants, so a relative box nested inside another moves by both — which is what
+    /// compounding offsets means, and it comes out the same whichever end of the chain is offset
+    /// first, translations being additive. Each box's own offset is applied exactly once, because
+    /// only the box that declares one is ever offset.
+    /// </para>
+    /// <para>
+    /// Only <c>display: inline</c>, and the walk stops at everything else. A block-level box, a
+    /// float, and an <c>inline-block</c> (or <c>inline-flex</c>/<c>inline-grid</c>) all get their
+    /// own <see cref="PerformLayout"/> and apply their own offset there — an inline-block is
+    /// inline-<em>level</em> but is laid out as a block, so including it applied the offset twice
+    /// and moved it by double: <c>CSS2/margin-padding-clear/margin-collapse-001</c>'s reference
+    /// stacks two <c>position: relative</c> inline-blocks and is what caught it. Such a box still
+    /// moves with a relative <em>ancestor</em>, because <see cref="OffsetLeft"/> carries the
+    /// ancestor's shift into every descendant regardless of display.
+    /// </para>
+    /// <para>
+    /// <b>Horizontal containers only.</b> <c>left</c> and <c>top</c> are physical, but a vertical
+    /// container's words are positioned in the engine's rotated space, so the offset would arrive
+    /// turned a quarter turn: measured on <c>vertical-rl</c>, a <c>left: 60px; top: 30px</c> came
+    /// out as a visual <c>(-30, +60)</c>, and on <c>vertical-lr</c> as <c>(+30, +60)</c>. Applying
+    /// it there needs that mapping per writing mode — including the two <c>sideways-*</c> modes,
+    /// which this has not measured — so a vertical container is left alone rather than moved
+    /// wrongly. It is what happened before this existed, and
+    /// <c>css-writing-modes/vrl-inline-paint-invalidation</c> is the pair that says so.
+    /// </para>
+    /// </remarks>
+    private void OffsetRelativeInlineDescendants()
+    {
+        foreach (CssBox child in Boxes)
+        {
+            if (child.Display != CssConstants.Inline || child.Float != CssConstants.None
+                || child.Position is CssConstants.Absolute or CssConstants.Fixed)
+            {
+                continue;
+            }
+
+            child.OffsetRelativeInlineDescendants();
+            child.ApplyRelativePositionOffset();
+        }
+    }
+
     private void ApplyRelativePositionOffset()
     {
         // Apply position:relative offset after layout (visual only, does not affect flow)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -48,6 +48,7 @@ internal abstract partial class CssBoxProperties
     private string _backgroundImage = "none";
     private string _backgroundClip = "border-box";
     private string _clipPath = "none";
+    private string _clip = "auto";
     private string _textIndent = "0";
     private string _textDecorationColor = "currentcolor";
     private string _top = "auto";
@@ -1101,6 +1102,18 @@ internal abstract partial class CssBoxProperties
     {
         get => _clipPath;
         set => _clipPath = value ?? "none";
+    }
+
+    /// <summary>
+    /// CSS 2.1 §11.1.2 <c>clip</c>, as written: <c>auto</c>, or
+    /// <c>rect(&lt;top&gt;, &lt;right&gt;, &lt;bottom&gt;, &lt;left&gt;)</c> — the legacy spelling
+    /// of a rectangular clip on an absolutely positioned element's border box.
+    /// <see cref="Broiler.Layout.IR.ClipRect"/> resolves it against that box.
+    /// </summary>
+    public string Clip
+    {
+        get => _clip;
+        set => _clip = value ?? "auto";
     }
 
     /// <summary>
@@ -2720,6 +2733,7 @@ internal abstract partial class CssBoxProperties
         BoxSizing = p.BoxSizing;
         BackgroundClip = p.BackgroundClip;
         ClipPath = p.ClipPath;
+        Clip = p.Clip;
         FlexDirection = p.FlexDirection;
         FlexGrow = p.FlexGrow;
         FlexShrink = p.FlexShrink;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -101,6 +101,12 @@ internal static class CssLayoutEngine
         bool hasImageTagHeight = TryResolveDefiniteImageLength(imageWord.OwnerBox.Height, em, out double tagHeightPx);
         bool scaleImageHeight = false;
 
+        // A percentage width is a stated width too — resolved against the containing block rather
+        // than read off the declaration, which is the only reason it is not a "tag" width here.
+        // The aspect-ratio pass below must not treat it as `auto` and derive it back from the
+        // height, or `<img width="100%" height="50">` comes out 50px wide.
+        bool hasStatedWidth = hasImageTagWidth;
+
         if (hasImageTagWidth)
         {
             imageWord.Width = tagWidthPx;
@@ -115,7 +121,16 @@ internal static class CssLayoutEngine
             if (width.Number > 0 && width.IsPercentage)
             {
                 imageWord.Width = width.Number * imageWord.OwnerBox.ContainingBlock.Size.Width;
-                scaleImageHeight = true;
+
+                // Only when the height is left to the image. CSS 2.1 §10.4 uses the intrinsic
+                // ratio to fill in a dimension that is `auto`, not to overrule one the author
+                // stated — and a percentage width is no different from a length one in that. The
+                // max-width clamp below already says `!hasImageTagHeight`; this said `true`, so
+                // `<img width="100%" height="50">` came out as tall as it was wide. That is the
+                // shape CSS2's own reference files use, so the cost landed on the reference side
+                // of 85 reftests in css/CSS2/backgrounds alone.
+                scaleImageHeight = !hasImageTagHeight;
+                hasStatedWidth = true;
             }
             else if (image != null)
             {
@@ -177,16 +192,16 @@ internal static class CssLayoutEngine
 
         if (hasCssAspectRatio)
         {
-            bool widthDriven = (hasImageTagWidth && !hasImageTagHeight) || scaleImageHeight;
+            bool widthDriven = (hasStatedWidth && !hasImageTagHeight) || scaleImageHeight;
 
             if (widthDriven)
                 imageWord.Height = imageWord.Width / cssAspectRatio;
-            else if (hasImageTagHeight && !hasImageTagWidth)
+            else if (hasImageTagHeight && !hasStatedWidth)
                 imageWord.Width = imageWord.Height * cssAspectRatio;
         }
         else if (image != null && image.Value.HasIntrinsicRatio)
         {
-            bool widthDriven = (hasImageTagWidth && !hasImageTagHeight) || scaleImageHeight;
+            bool widthDriven = (hasStatedWidth && !hasImageTagHeight) || scaleImageHeight;
             // If only the width was set in the html tag, ratio the height.
             if (widthDriven)
             {
@@ -195,7 +210,7 @@ internal static class CssLayoutEngine
                 imageWord.Height = image.Value.Height * ratio;
             }
             // If only the height was set in the html tag, ratio the width.
-            else if (hasImageTagHeight && !hasImageTagWidth)
+            else if (hasImageTagHeight && !hasStatedWidth)
             {
                 // Divide the given tag height with the actual image height, to get the ratio.
                 double ratio = imageWord.Height / image.Value.Height;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -143,6 +143,7 @@ internal static partial class CssUtils
             "overflow" => cssBox.Overflow,
             "box-sizing" => cssBox.BoxSizing,
             "clip-path" => cssBox.ClipPath,
+            "clip" => cssBox.Clip,
             "transform" => cssBox.Transform,
             "will-change" => cssBox.WillChange,
             "align-content" => cssBox.AlignContent,
@@ -332,6 +333,9 @@ internal static partial class CssUtils
                 break;
             case "clip-path":
                 cssBox.ClipPath = value;
+                break;
+            case "clip":
+                cssBox.Clip = value;
                 break;
             case "transform":
                 cssBox.Transform = value;

--- a/Broiler.Layout/Broiler.Layout/IR/ClipRect.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/ClipRect.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Globalization;
+using Broiler.CSS;
+using Broiler.Layout.Engine;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// CSS 2.1 §11.1.2 <c>clip</c>: the legacy rectangular clip on an absolutely positioned element.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>clip</c> and <c>clip-path: inset()</c> name the same operation — a rectangle the element and
+/// everything inside it is clipped to, measured on the border box — so this resolves the one into
+/// the other rather than adding a second clip to the paint. The projection happens once, in
+/// <see cref="ComputedStyleBuilder"/>, where the element's used border box is already known; every
+/// consumer downstream sees an ordinary <c>clip-path</c> and needs to know nothing about the legacy
+/// spelling. CSS Masking 1 §7 makes that ordering right as well as convenient: a real
+/// <c>clip-path</c> supersedes <c>clip</c>, so it is only consulted when <c>clip-path</c> is
+/// <c>none</c>.
+/// </para>
+/// <para>
+/// The geometry is stated from two edges, not four: <c>top</c> and <c>bottom</c> are offsets down
+/// from the border box's top edge, <c>right</c> and <c>left</c> offsets right from its left edge —
+/// so <c>rect(96px, 96px, 96px, 96px)</c> on a 96×96 box is an <em>empty</em> clip, not a full one,
+/// and the twenty-odd <c>css/CSS2/visufx/clip-*</c> tests that state one under a different unit all
+/// mean "nothing should be visible".
+/// </para>
+/// </remarks>
+internal static class ClipRect
+{
+    /// <summary>
+    /// The <c>clip-path</c> a box paints with: its own when it states one, otherwise the projection
+    /// of its <c>clip</c>, otherwise its own unchanged.
+    /// </summary>
+    internal static string EffectiveClipPath(CssBoxProperties box)
+    {
+        var clipPath = box.ClipPath;
+        if (!string.IsNullOrWhiteSpace(clipPath)
+            && !clipPath.Trim().Equals("none", StringComparison.OrdinalIgnoreCase))
+        {
+            return clipPath;
+        }
+
+        return TryProjectAsInset(box, out var projected) ? projected : clipPath;
+    }
+
+    /// <summary>
+    /// Projects <paramref name="box"/>'s <c>clip</c> onto the equivalent
+    /// <c>clip-path: inset(…)</c>, or returns <c>false</c> when it declares none, is not on a box
+    /// <c>clip</c> applies to, or is not a valid <c>rect()</c>.
+    /// </summary>
+    internal static bool TryProjectAsInset(CssBoxProperties box, out string inset)
+    {
+        inset = string.Empty;
+
+        // "Applies to: absolutely positioned elements" — `clip` on anything else is dropped, not
+        // silently honoured, or a `clip` inherited into a static descendant would clip it too.
+        var position = box.Position;
+        if (!position.Equals("absolute", StringComparison.OrdinalIgnoreCase)
+            && !position.Equals("fixed", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // The em height comes from the box's resolved font, so it is asked for only once a side
+        // that needs it is in hand: this runs for every box the style phase builds, and all but a
+        // handful say `auto`.
+        if (!TryParseRect(box.Clip, box.GetEmHeight, out var top, out var right, out var bottom, out var left))
+            return false;
+
+        var (width, height) = BorderBoxSize(box);
+
+        // `+ 0` collapses the negative zero `rect(-0px, …)` parses to, which would otherwise be
+        // written out as `-0px`: the same geometry, spelled in a way no other length here is.
+        double insetTop = (top ?? 0) + 0;
+        double insetLeft = (left ?? 0) + 0;
+        double insetRight = (right is { } r ? width - r : 0) + 0;
+        double insetBottom = (bottom is { } b ? height - b : 0) + 0;
+
+        inset = string.Create(
+            CultureInfo.InvariantCulture,
+            $"inset({insetTop:0.###}px {insetRight:0.###}px {insetBottom:0.###}px {insetLeft:0.###}px)");
+        return true;
+    }
+
+    /// <summary>
+    /// Parses <c>rect(&lt;top&gt;, &lt;right&gt;, &lt;bottom&gt;, &lt;left&gt;)</c>, each side a
+    /// length or <c>auto</c> (returned as <c>null</c>). Commas are optional and may be mixed with
+    /// spaces — CSS 2.1's grammar says commas, every engine has always taken either, and
+    /// <c>clip-016</c>…<c>-021</c> exist to say so, one per mixture.
+    /// </summary>
+    private static bool TryParseRect(
+        string? clip, Func<double> emHeight,
+        out double? top, out double? right, out double? bottom, out double? left)
+    {
+        top = right = bottom = left = null;
+
+        if (string.IsNullOrWhiteSpace(clip))
+            return false;
+
+        var value = clip.Trim();
+        if (!value.StartsWith("rect(", StringComparison.OrdinalIgnoreCase)
+            || !value.EndsWith(")", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var sides = value[5..^1].Split([',', ' ', '\t', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries);
+        if (sides.Length != 4)
+            return false;
+
+        var resolved = new double?[4];
+        for (int i = 0; i < 4; i++)
+        {
+            if (!TryParseSide(sides[i], emHeight, out resolved[i]))
+                return false;
+        }
+
+        (top, right, bottom, left) = (resolved[0], resolved[1], resolved[2], resolved[3]);
+        return true;
+    }
+
+    /// <summary>One side of a <c>rect()</c>: a length, or <c>auto</c> — which is <c>null</c> here.</summary>
+    /// <remarks>
+    /// Percentages are not lengths in this grammar, and a declaration carrying one is invalid rather
+    /// than resolved against something — so it is rejected here and the element is left unclipped,
+    /// which is what dropping the declaration means.
+    /// </remarks>
+    private static bool TryParseSide(string side, Func<double> emHeight, out double? length)
+    {
+        length = null;
+
+        if (side.Equals("auto", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // A `<length>` starts with its number. The length parser is forgiving — it falls back to
+        // zero for a token it cannot read — so the grammar is checked here instead, or
+        // `rect(0, 0, 0, red)` would be a valid clip of zero.
+        if (side.Length == 0 || (!char.IsAsciiDigit(side[0]) && side[0] is not ('+' or '-' or '.')))
+            return false;
+
+        if (side.Contains('%', StringComparison.Ordinal))
+            return false;
+
+        double parsed = CssLengthParser.ParseLength(side, 0, emHeight());
+        if (double.IsNaN(parsed) || double.IsInfinity(parsed))
+            return false;
+
+        length = parsed;
+        return true;
+    }
+
+    /// <summary>
+    /// The box's used border-box size, by the same reading <c>FragmentTreeBuilder</c> takes: a
+    /// block-level box never has its <c>Height</c> set during layout and an auto-width absolutely
+    /// positioned one can still carry a NaN width, so both fall back to the laid-out edges.
+    /// </summary>
+    private static (double Width, double Height) BorderBoxSize(CssBoxProperties box)
+    {
+        double width = box.Size.Width;
+        if (double.IsNaN(width) || width <= 0)
+            width = box.ActualRight - box.Location.X;
+
+        double height = box.Size.Height;
+        double laidOut = box.ActualBottom - box.Location.Y;
+        if (double.IsNaN(height) || laidOut > height)
+            height = laidOut;
+
+        return (Math.Max(0, width), Math.Max(0, height));
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/IR/ComputedStyleBuilder.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/ComputedStyleBuilder.cs
@@ -160,7 +160,9 @@ internal static class ComputedStyleBuilder
             Filter = box.Filter,
             Isolation = box.Isolation,
             BackgroundClip = box.BackgroundClip,
-            ClipPath = box.ClipPath,
+            // CSS 2.1 §11.1.2's `clip` is the same rectangular clip `clip-path: inset()` names, so
+            // it is resolved into one here rather than applied a second time in paint.
+            ClipPath = ClipRect.EffectiveClipPath(box),
             Contain = box.Contain,
             OverflowClipMargin = box.ActualOverflowClipMargin,
             ContentVisibility = box.ContentVisibility,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,16 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `Broiler.Layout` — `position: relative` now offsets an inline-level box. CSS 2.1
+  §9.4.3's offset is visual, so it has to reach the box's words; `PerformLayout`
+  applied it for every box it lays out, but an inline-level box is laid out by
+  `CreateLineBoxes` and never goes through `PerformLayout` — so neither an inline
+  `<span>` nor an inline `<img>` moved at all. `css/css-writing-modes` goes
+  419 → 487 of 1139 reftests, nothing lost: the family that gains is
+  `abs-pos-non-replaced-v{lr,rl}-*`, whose *references* place their swatch with
+  `position: relative`. Vertical containers are excluded — their words sit in the
+  engine's rotated space, so a physical `left`/`top` arrives turned a quarter turn
+  and needs a per-writing-mode mapping first.
 - `Broiler.Layout` — a replaced element whose width is a percentage no longer
   ignores its stated height. CSS 2.1 §10.4 uses the intrinsic ratio to fill in a
   dimension left `auto`, not to overrule one the author stated, but the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,10 @@ are versioned in lockstep during the preview.
   §9.4.3's offset is visual, so it has to reach the box's words; `PerformLayout`
   applied it for every box it lays out, but an inline-level box is laid out by
   `CreateLineBoxes` and never goes through `PerformLayout` — so neither an inline
-  `<span>` nor an inline `<img>` moved at all. `css/css-writing-modes` goes
-  419 → 487 of 1139 reftests, nothing lost: the family that gains is
+  `<span>` nor an inline `<img>` moved at all. **+73 reftests, none lost**, over a
+  16 059-test sweep: `css/css-writing-modes` +68 (419 → 487 of 1139),
+  `CSS2/box-display` +3, `CSS2/positioning` +1, `CSS2/visuren` +1. The family that
+  gains is
   `abs-pos-non-replaced-v{lr,rl}-*`, whose *references* place their swatch with
   `position: relative`. Vertical containers are excluded — their words sit in the
   engine's rotated space, so a physical `left`/`top` arrives turned a quarter turn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ are versioned in lockstep during the preview.
 
 ## [Unreleased]
 
+### Added
+
+- `Broiler.Wpt` — a WPT `-print` reftest now renders the paint its own `@page`
+  rule puts on the sheet (CSS Paged Media 3 §7): the page background over the
+  whole page box, margins included, and the page's border and padding on the box
+  the margins leave, with the flow inset by them. Independent of the
+  `BROILER_WPT_PAGED_PRINT` lever, because a page paints whether or not the flow
+  is paginated — `css-page/page-background-image-print` states outright that its
+  background should print and not show on screen. A page whose root element
+  generates no box paints nothing at all, and `visibility` applies in the page
+  context. `css/css-page` goes 133 → 136 of 224 reftests (137 once
+  `patches/0001-html-canvas-backdrop-lever.patch` is applied); documents that
+  declare no page paint render byte-identically to before.
+- `Broiler.Layout` — `Engine.CanvasBackdrop`, the colour a translucent canvas
+  background (CSS 2.1 §14.2) is composited against when the surface underneath it
+  already carries paint. Thread-static and null by default, so a render that does
+  not set it is unchanged. Read by a one-line `Broiler.HTML` change carried as
+  `patches/0001-html-canvas-backdrop-lever.patch`.
+
 ### Changed
 
 - `Broiler.Layout` / `Broiler.HTML.Image` — a page's display list is now replayed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,14 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `Broiler.Layout` — a replaced element whose width is a percentage no longer
+  ignores its stated height. CSS 2.1 §10.4 uses the intrinsic ratio to fill in a
+  dimension left `auto`, not to overrule one the author stated, but the
+  percentage-width branch of `MeasureImageSize` set the derive-the-height flag
+  unconditionally — so `<img width="100%" height="50">` came out as tall as it was
+  wide. `css/CSS2/backgrounds` goes 204 → 247 of 339 reftests: the tests were
+  right all along, and the bug was in the reference documents they are compared
+  against, which draw their coloured band exactly that way.
 - `Broiler.Documents` — the DOCX reader walked only the direct `w:p` children of
   `w:body`, so a document whose content lived inside a layout table (the shape CV
   and letterhead templates use) opened completely empty in Broiler.Writer. Block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,22 @@ are versioned in lockstep during the preview.
   is paginated — `css-page/page-background-image-print` states outright that its
   background should print and not show on screen. A page whose root element
   generates no box paints nothing at all, and `visibility` applies in the page
-  context. `css/css-page` goes 133 → 136 of 224 reftests (137 once
-  `patches/0001-html-canvas-backdrop-lever.patch` is applied); documents that
-  declare no page paint render byte-identically to before.
+  context. `css/css-page` goes 133 → 137 of 224 reftests (138 once
+  `patches/0001-html-canvas-backdrop-lever.patch` is applied), nothing lost;
+  documents that declare no page paint render byte-identically to before.
+- `Broiler.Layout` — CSS 2.1 §11.1.2 `clip`, the legacy rectangular clip on an
+  absolutely positioned element. Resolved into the `clip-path: inset()` that names
+  the same operation (`IR.ClipRect`, in `ComputedStyleBuilder`, where the used
+  border box is known), so nothing downstream needs a second clip; a real
+  `clip-path` supersedes it, per CSS Masking 1 §7. With
+  `patches/0002-html-empty-inset-clip.patch`, which stops an empty `inset()` being
+  dropped as if it were no clip, `css/CSS2/visufx` goes 6 → 50 of 51 reftests and
+  `css-masking/clip` gains two, none lost.
+- `Broiler.Wpt` — inline scripts in an XHTML test are unwrapped from their XML
+  CDATA section before execution. `<![CDATA[` is a syntax error, so every script
+  in such a document was lost — including the functions an `onload` attribute goes
+  on to call, which left the test rendering its pre-script state.
+  `css/CSS2` goes 4863 → 4908 of 6216 reftests, nothing lost.
 - `Broiler.Layout` — `Engine.CanvasBackdrop`, the colour a translucent canvas
   background (CSS 2.1 §14.2) is composited against when the surface underneath it
   already carries paint. Thread-static and null by default, so a render that does

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,11 @@ are versioned in lockstep during the preview.
   dimension left `auto`, not to overrule one the author stated, but the
   percentage-width branch of `MeasureImageSize` set the derive-the-height flag
   unconditionally — so `<img width="100%" height="50">` came out as tall as it was
-  wide. `css/CSS2/backgrounds` goes 204 → 247 of 339 reftests: the tests were
-  right all along, and the bug was in the reference documents they are compared
-  against, which draw their coloured band exactly that way.
+  wide. **+89 reftests, none lost**, over a 16 059-test sweep of every directory
+  that sizes a replaced element: `css/CSS2/backgrounds` +43 (204 → 247 of 339),
+  `normal-flow` +22, `borders` +13, `positioning` +10. The tests were right all
+  along — the bug was in the reference documents they are compared against, which
+  draw their coloured band exactly that way.
 - `Broiler.Documents` — the DOCX reader walked only the direct `w:p` children of
   `w:body`, so a document whose content lived inside a layout table (the shape CV
   and letterhead templates use) opened completely empty in Broiler.Writer. Block

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -512,6 +512,41 @@ scale.** The diff was in the part of the picture the tests were not about — 43
 to do with replaced-element sizing, all failing because the document they were
 being compared against was drawn with an `<img>`.
 
+## Next lead: an out-of-flow replaced element with an auto size renders nothing
+
+Diagnosed, not fixed. `css/CSS2/positioning/absolute-replaced-width-*` is 40
+failures at 96.5–98.8 % match, and what the diff is missing is the whole image:
+
+```html
+<div style="position:relative; width:200px; height:60px">
+  <img src="blue15x15.png" style="position:absolute">      <!-- nothing paints -->
+  <img src="blue15x15.png" style="float:left">             <!-- nothing paints -->
+  <img src="blue15x15.png" style="position:absolute; width:40px; height:40px">
+</div>                                                      <!-- this one paints -->
+```
+
+An `<img>` paints in flow, and paints out of flow **only when both dimensions are
+stated**. Dumping the fragment tree separates three distinct defects, and each
+wants its own before/after sweep:
+
+1. **Absolutely positioned, auto size.** The box is laid out (it has a line box)
+   but its fragment comes out `0×0`, so nothing of it is painted — not the image,
+   not even a background set on it.
+2. **Floated.** `CreateLineBoxes` skips floats as out-of-flow and the loop that
+   lays them out afterwards iterates the container's own `Boxes` — so a float
+   inside an *anonymous* block (which is where an `<img>` between text nodes ends
+   up) is never reached at all. Its anonymous parent is left `lines=1`, height 0.
+3. **`display: block` and absolutely positioned.** No fragment is produced for the
+   image at all.
+
+The engine is right at the point where the fix belongs: `CssBox.PerformLayout`
+routes `IsBlock || isOutOfFlow` down the block path, and `isOutOfFlow` covers
+`absolute`/`fixed` but not `float`; neither path sizes a *replaced* box from its
+image the way the inline path does. Keep any fix narrow to boxes that carry an
+image word — those render nothing today, so the blast radius of getting them
+wrong is small, while the same change on non-replaced boxes would touch every
+float in the corpus.
+
 ## Flex items are stretched now, and what that says about the scoreboard
 
 `align-items: stretch` is the initial value, so it is what happens to most flex

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -500,8 +500,11 @@ The same flag also stood in for "the width is stated" in the aspect-ratio pass,
 where a percentage width had to stop counting as `auto` — otherwise fixing the
 height merely moved the bug to the width, deriving 50px back out of it.
 
-**`css/CSS2/backgrounds` goes 204 → 247 of 339.** The tests were rendering
-correctly the whole time.
+**`css/CSS2/backgrounds` goes 204 → 247 of 339**, and the fix reaches further than
+the directory that surfaced it: over a 16 059-test sweep of every directory that
+sizes a replaced element, **+89 reftests and none lost** — `backgrounds` +43,
+`CSS2/normal-flow` +22, `CSS2/borders` +13, `CSS2/positioning` +10. The tests were
+rendering correctly the whole time.
 
 **This is the reference-side failure mode the section above warns about, at
 scale.** The diff was in the part of the picture the tests were not about — 43

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -512,6 +512,51 @@ scale.** The diff was in the part of the picture the tests were not about — 43
 to do with replaced-element sizing, all failing because the document they were
 being compared against was drawn with an `<img>`.
 
+## `position: relative` did nothing to an inline box, and it cost 68 writing-mode reftests
+
+`css/css-writing-modes` is the corpus's largest winnable group, and its largest
+family — `abs-pos-non-replaced-v{lr,rl}-*`, 224 tests at a median 97.4 % — turned
+out not to be about vertical layout at all. Their **references** are ordinary
+horizontal documents that place a swatch like this:
+
+```html
+<style>img#green-square { position: relative; left: 160px; top: 80px; }</style>
+<div><img id="green-square" src="swatch-green.png" width="80" height="80"></div>
+```
+
+The swatch rendered at its static position, so the reference showed the green
+square in the wrong place while the *test* had it right.
+
+CSS 2.1 §9.4.3's offset is visual — the box keeps its place in the flow and its
+content is painted somewhere else — so it has to reach the words, which is what
+`OffsetLeft`/`OffsetTop` already do. `PerformLayout` applies it for every box it
+lays out; an **inline-level** box is laid out by `CreateLineBoxes` and never goes
+through `PerformLayout`, so nothing applied it at all. Neither an inline `<img>`
+nor an inline `<span>` moved. The fix walks the inline descendants once the line
+boxes exist (`CssBox.OffsetRelativeInlineDescendants`).
+
+**The walk is `display: inline` only, and that distinction is the whole of it.**
+An `inline-block` is inline-*level* but is laid out as a block and already applies
+its own offset in `PerformLayout`, so including it moved such a box by double —
+`CSS2/margin-padding-clear/margin-collapse-001`'s reference stacks two relatively
+positioned inline-blocks and was the pair that caught it. Such a box still moves
+with a relative *ancestor*, because `OffsetLeft` carries the ancestor's shift into
+every descendant whatever its display.
+
+**`css/css-writing-modes` goes 419 → 487 of 1139, nothing lost.**
+
+**Vertical containers are deliberately left out.** `left`/`top` are physical, but
+a vertical container's words sit in the engine's rotated space, so the offset
+arrives turned a quarter turn: measured on `vertical-rl`, `left: 60px; top: 30px`
+came out as a visual `(-30, +60)`, and on `vertical-lr` as `(+30, +60)`. Applying
+it there needs a per-writing-mode mapping — the two `sideways-*` modes included,
+which has not been measured — and doing it wrongly is worse than not doing it:
+`vrl-inline-paint-invalidation` was the single regression when the offset went in
+unmapped, and it is the pair to fix against when someone works out the mapping.
+
+That is also the reason the family only moved 60 of its 224 tests: the rest fail
+on their *test* side, which is what these were written to exercise.
+
 ## Next lead: an out-of-flow replaced element with an auto size renders nothing
 
 Diagnosed, not fixed. `css/CSS2/positioning/absolute-replaced-width-*` is 40

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -543,7 +543,10 @@ positioned inline-blocks and was the pair that caught it. Such a box still moves
 with a relative *ancestor*, because `OffsetLeft` carries the ancestor's shift into
 every descendant whatever its display.
 
-**`css/css-writing-modes` goes 419 → 487 of 1139, nothing lost.**
+**`css/css-writing-modes` goes 419 → 487 of 1139**, and over a 16 059-test sweep
+the change is **+73 with none lost** — `CSS2/box-display` +3, `CSS2/positioning`
++1 and `CSS2/visuren` +1 besides, all of them references that place something with
+`position: relative` on an inline box.
 
 **Vertical containers are deliberately left out.** `left`/`top` are physical, but
 a vertical container's words sit in the engine's rotated space, so the offset

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -358,9 +358,16 @@ and its reference states the same colour on `html`, so the two agree only when
 the page paints. Before this, `page-box-001-print`, `-002`, `-003` and `-011` each
 matched their reference by **0.0 %**: the reference paints the colour through a
 `body` background and the test through its `@page`, and only one of the two was
-drawn. `css/css-page` goes **133 → 136** (`page-box-000`, `-001`, `-003` and
-`-011` gained, one lost — see named pages below), and **137** once the
+drawn. `css/css-page` goes **133 → 137** — `page-background-image-print`,
+`page-box-000`, `-001`, `-003` and `-011`, nothing lost — and **138** once the
 `Broiler.HTML` patch below is applied.
+
+> Measure with an **absolute** `--wpt-dir`, the way `scripts/run-wpt-reftests.sh`
+> and CI do (`WPT_DIR="$REPO_ROOT/tests/wpt/checkout"`). A relative one does not
+> resolve a test's root-relative resources — `url(/images/green.png)` and
+> `<img src="/images/…">` silently render nothing — so a run started by hand with
+> `--wpt-dir tests/wpt/checkout` reports failures CI does not have, and a
+> before/after comparison across the two spellings is not a comparison at all.
 
 Three details are the whole of it, and each is a WPT pair stating it:
 
@@ -398,14 +405,75 @@ when it is an image or a gradient. The one-line call site is
 `patches/0001-html-canvas-backdrop-lever.patch`; until it is applied
 `page-box-002-print` stays at 0.0 % and everything else here works without it.
 
-**What is still missing is named pages, and it costs one test.**
-`WptPageDecoration` reads the unconditional `@page` only, as `WptPageBox` does —
-so `page-name-table-001-print`, whose content selects a `@page square` that
-overrides the unconditional rule's red with `#eee`, now paints red where it used
-to paint nothing. It was passing because *neither* side drew a page background;
-that was a false pass, and it is an honest failure now. Fixing it properly needs
-the `page` property in the fragment tree's computed style, which is also what the
-paged run needs for per-name page sizes.
+**What is still missing is named pages.** `WptPageDecoration` reads the
+unconditional `@page` only, as `WptPageBox` does, so a page a name selects paints
+the wrong rule's background — `page-name-table-001-print` puts its table on a
+`@page square` whose `#eee` overrides the unconditional red, and fails either way.
+Fixing it needs the `page` property in the fragment tree's computed style, which
+is what the paged run needs for per-name page sizes too.
+
+## Scripts in an XHTML test never ran, and it cost 45 reftests
+
+Half of `css/CSS2` is `.xht`, and an XHTML test writes its inline scripts inside
+an XML CDATA section:
+
+```xml
+<script type="text/javascript"><![CDATA[
+  function startTest() { … }
+]]></script>
+```
+
+An XML parser consumes the wrapper and hands the engine what is between the
+markers. This runner does not parse the document to find its scripts — it scans
+the source — so it handed the engine the markers too, `<![CDATA[` is a syntax
+error, and **the whole script was lost with it**. Not just the statements: the
+functions an `onload` attribute goes on to call went with them, so a test whose
+result depends on `body onload="startTest()"` rendered its unscripted state and
+was compared as if that were the answer.
+
+Stripping the wrapper (`WptTestRunner.StripCdataSection`, with the commented
+`//<![CDATA[` and `<!-- … -->` spellings) took **`css/CSS2` from 4863 to 4908 of
+6216**, nothing lost. The gains are where scripted CSS2 tests live:
+`box-display` +30 (its `insert-block-in-*` / `delete-inline-in-*` DOM-mutation
+family), `tables` +14, `positioning` +1. 395 documents in the checkout carry a
+CDATA-wrapped script, so the reach is wider than the tests it happens to move
+today.
+
+**The tell for this class of bug is a test that renders its "before" state.**
+Nothing errors, nothing is skipped, and the rendered image is a plausible render
+— of the document as it stood before a script it never ran.
+
+## `clip` is implemented, and most of what it clips is nothing
+
+CSS 2.1 §11.1.2's `clip` had no implementation at all: `ComputedStyle` had no such
+property and the paint walker never looked for one, so `css/CSS2/visufx/clip-*`
+rendered 44 unclipped elements over references that show none of them.
+
+It is implemented as a projection rather than a second clip.
+`clip: rect(<top>, <right>, <bottom>, <left>)` and `clip-path: inset()` name the
+same operation — a rectangle the element and everything inside it is clipped to,
+measured on the border box — so `Broiler.Layout/…/IR/ClipRect.cs` resolves the one
+into the other in `ComputedStyleBuilder`, where the used border box is already
+known. Everything downstream sees an ordinary `clip-path`. CSS Masking 1 §7 makes
+that ordering right as well as convenient: a real `clip-path` supersedes `clip`,
+so `clip` is only consulted when `clip-path` is `none`.
+
+**The geometry is stated from two edges, not four**, and that is the whole reason
+this family looked unwinnable. `top` and `bottom` are offsets down from the border
+box's top edge, `right` and `left` offsets right from its left edge — so
+`rect(96px, 96px, 96px, 96px)` on a 96×96 box is an *empty* clip, and about forty
+of the tests state exactly that, one per unit spelling (`1in`, `72pt`, `6pc`,
+`2.54cm`, `-0px`, `+0px`, …). Each means "nothing should be visible".
+
+The paint walker dropped an empty `inset()` as if it were no clip, which painted
+the element in full — `patches/0002-html-empty-inset-clip.patch` is the four lines
+that emit it instead. With both halves: **`css/CSS2/visufx` 6 → 50 of 51**, plus
+two in `css-masking/clip` that were the same bug reached through `clip-path`
+directly, and nothing lost. Without the patch the main-repo half still lands the
+non-empty cases; it is the empty ones that wait on it.
+
+Every `clip-*` test in the directory passes then; the one failure left in it is
+`visibility-005`, which is about `visibility` and not about clipping at all.
 
 ## Flex items are stretched now, and what that says about the scoreboard
 

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -341,6 +341,72 @@ with paged media:
   on the test side: doing so alone would separate the eight margin-box tests that
   use one from references that still render the literal text.
 
+### `@page` paint is not behind the lever, because it is not about pagination
+
+CSS Paged Media 3 §7 lets the sheet itself carry paint — a background, a border
+and a padding on the `@page` rule — and that is a different question from whether
+the flow is cut into pages. So it is **not** behind `BROILER_WPT_PAGED_PRINT`: a
+`-print` reftest gets its page's paint whether or not it is paginated, decided by
+the same `-print` stem and carried into the reference render the same way (see
+`WptTestRunner.PrintMedia`, which the paged lever now sits on top of rather than
+beside).
+
+It has to be on for the unpaginated run, because the pairs that state it are
+written to be read on screen. `css-page/page-background-image-print` says so
+outright — *"Should print on a green background but not display it on screen"* —
+and its reference states the same colour on `html`, so the two agree only when
+the page paints. Before this, `page-box-001-print`, `-002`, `-003` and `-011` each
+matched their reference by **0.0 %**: the reference paints the colour through a
+`body` background and the test through its `@page`, and only one of the two was
+drawn. `css/css-page` goes **133 → 136** (`page-box-000`, `-001`, `-003` and
+`-011` gained, one lost — see named pages below), and **137** once the
+`Broiler.HTML` patch below is applied.
+
+Three details are the whole of it, and each is a WPT pair stating it:
+
+- **The background covers the whole page box, margins included; the border and
+  padding sit on the box the margins leave.** `page-background-004-print` states
+  a 500×300 page with a 50px margin and matches a reference that is solid yellow
+  corner to corner, while `page-box-008-print` paints its margin ring in the page
+  background and its padding ring in the propagated `body` one. So the backdrop
+  is two boxes — a full-sheet one carrying the background declarations, an inset
+  one carrying the border and padding — and both are ordinary divs handed to the
+  same renderer that will draw the page, which is what makes a page background
+  that is a gradient or an image work without the runner knowing they exist. The
+  distance from that box to the page area is measured off a render of it for the
+  same reason (`WptPageDecoration.MeasureInsets`), rather than by parsing
+  `border-width` shorthands, logical spellings and percentages a second time.
+- **A page that generates no content paints nothing at all.**
+  `root-element-display-none-print` states a hotpink page with a red border and
+  matches an *empty document*: a root element with no box generates no page, so
+  the sheet's own paint goes with it.
+- **`visibility` applies in the page context** (§5.1) and to the background and
+  the border alike, keeping the space they take.
+  `page-visibility-hidden-001-print` hides a red page border and matches a
+  reference whose border is `solid transparent`.
+
+**One pair needs a `Broiler.HTML` change and carries a patch**:
+`page-box-002-print` puts a half-transparent `body` background over a blue page
+and must come out violet. CSS 2.1 §14.2 propagates the `body` background to the
+canvas, and the paint walker flattens a translucent one into a single opaque fill
+against a backdrop it assumes is white — right for a render onto a blank surface,
+wrong for one onto a page background. The colour to composite against now comes
+from `Broiler.Layout.Engine.CanvasBackdrop` (main repo, thread-static, null by
+default so every other render is byte-identical), which the runner sets when the
+page background under the whole page area is one flat colour and leaves alone
+when it is an image or a gradient. The one-line call site is
+`patches/0001-html-canvas-backdrop-lever.patch`; until it is applied
+`page-box-002-print` stays at 0.0 % and everything else here works without it.
+
+**What is still missing is named pages, and it costs one test.**
+`WptPageDecoration` reads the unconditional `@page` only, as `WptPageBox` does —
+so `page-name-table-001-print`, whose content selects a `@page square` that
+overrides the unconditional rule's red with `#eee`, now paints red where it used
+to paint nothing. It was passing because *neither* side drew a page background;
+that was a false pass, and it is an honest failure now. Fixing it properly needs
+the `page` property in the fragment tree's computed style, which is also what the
+paged run needs for per-name page sizes.
+
 ## Flex items are stretched now, and what that says about the scoreboard
 
 `align-items: stretch` is the initial value, so it is what happens to most flex

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -475,6 +475,40 @@ non-empty cases; it is the empty ones that wait on it.
 Every `clip-*` test in the directory passes then; the one failure left in it is
 `visibility-005`, which is about `visibility` and not about clipping at all.
 
+## A percentage width made a replaced element ignore its height
+
+`css/CSS2/backgrounds` had 135 failures at a median 97.7 % match — the signature
+of something small and systematic rather than a missing feature. It was in the
+**references**, and in one line of the layout engine.
+
+CSS2's background references draw their coloured band the same way:
+
+```html
+<div><img src="support/1x1-green.png" width="100%" height="50" alt="…" /></div>
+```
+
+CSS 2.1 §10.4 uses a replaced element's intrinsic ratio to fill in a dimension
+left `auto`; it never overrules one the author stated. `MeasureImageSize` agreed
+for a length width — `width="200" height="20"` came out 200×20 — but its
+percentage-width branch set the "now derive the height from the ratio" flag
+unconditionally. So a 1×1 green pixel at `width="100%" height="50"` came out as
+tall as it was wide: a full-page green block where the reference wanted a 50px
+band. The max-width clamp a few lines below had it right (`!hasImageTagHeight`);
+this one said `true`.
+
+The same flag also stood in for "the width is stated" in the aspect-ratio pass,
+where a percentage width had to stop counting as `auto` — otherwise fixing the
+height merely moved the bug to the width, deriving 50px back out of it.
+
+**`css/CSS2/backgrounds` goes 204 → 247 of 339.** The tests were rendering
+correctly the whole time.
+
+**This is the reference-side failure mode the section above warns about, at
+scale.** The diff was in the part of the picture the tests were not about — 43
+`background-N` and 42 `background-position-N` tests, none of which have anything
+to do with replaced-element sizing, all failing because the document they were
+being compared against was drawn with an `<img>`.
+
 ## Flex items are stretched now, and what that says about the scoreboard
 
 `align-items: stretch` is the initial value, so it is what happens to most flex

--- a/patches/0001-html-canvas-backdrop-lever.patch
+++ b/patches/0001-html-canvas-backdrop-lever.patch
@@ -1,0 +1,40 @@
+From e9ef268ab2c551c3e4fa78e930b2550d77e4de88 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Tue, 11 Aug 2026 19:29:16 +0000
+Subject: [PATCH] Let a caller say what the canvas composites its background
+ against
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CSS 2.1 §14.2 propagates the root element's background to the canvas, and
+EmitCanvasBackground flattens a translucent one against an assumed white
+backdrop before emitting it as a single opaque fill. That is right for a
+render onto a blank surface and wrong for one onto a surface that already
+carries paint — CSS Paged Media 3 §7.2's page background is that case, and
+the css-page/page-box-002-print reftest states it: a #f008 body over a #00f
+@page must come out violet, not pink.
+
+Read the backdrop from Broiler.Layout.Engine.CanvasBackdrop, falling back
+to white when nothing set it, so every render that does not set it is
+byte-identical to before.
+---
+ .../IR/PaintWalker.CanvasBackground.cs                          | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs
+index bae2bd1..4bae763 100644
+--- a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs
++++ b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs
+@@ -56,7 +56,7 @@ internal static partial class PaintWalker
+         // body leave the dark backdrop showing. It is also the backdrop a
+         // *translucent* propagated background composites against, so carry it
+         // down to EmitCanvasBackgroundLayers rather than assuming white there.
+-        BColor canvasBackdrop = BColor.White;
++        BColor canvasBackdrop = Broiler.Layout.Engine.CanvasBackdrop.Current ?? BColor.White;
+         if (RootUsesDarkColorScheme(root))
+         {
+             canvasBackdrop = DarkCanvasColor;
+-- 
+2.43.0
+

--- a/patches/0002-html-empty-inset-clip.patch
+++ b/patches/0002-html-empty-inset-clip.patch
@@ -1,0 +1,42 @@
+From 805773748b4373f3db41691a4894e0ea5858e5ef Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Tue, 11 Aug 2026 20:38:26 +0000
+Subject: [PATCH] Treat an empty inset clip as a clip, not as no clip
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+TryCreateClipPathItem dropped a clip-path: inset() whose rectangle came
+out empty, leaving the element painted in full. An empty rectangle is a
+clip that admits nothing — inset(100% 0 0 0) says the element is not to
+be seen — and the raster backend already clips to it correctly once it is
+emitted.
+
+This is what CSS 2.1 §11.1.2's clip projects onto: rect(96px, 96px, 96px,
+96px) on a 96x96 box is an empty clip, and it is the shape most of
+css/CSS2/visufx/clip-* state. With the projection in Broiler.Layout, that
+directory goes 6 -> 50 of 51, and css-masking/clip gains two of its own.
+---
+ .../Broiler.HTML.Orchestration/IR/PaintWalker.Geometry.cs   | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Geometry.cs b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Geometry.cs
+index 4f230c5..0f0f5a4 100644
+--- a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Geometry.cs
++++ b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Geometry.cs
+@@ -240,8 +240,10 @@ internal static partial class PaintWalker
+             bounds.Y + top,
+             Math.Max(0, bounds.Width - left - right),
+             Math.Max(0, bounds.Height - top - bottom));
+-        if (clipRect.Width <= 0 || clipRect.Height <= 0)
+-            return false;
++        // An empty rectangle is a clip that admits nothing, not the absence of one:
++        // `inset(100% 0 0 0)`, and the `clip: rect(96px, 96px, 96px, 96px)` that projects onto
++        // it, both say the element is not to be seen. Emitting it lets the backend clip to it;
++        // dropping it painted the element in full.
+ 
+         clipItem = new ClipItem { Bounds = bounds, ClipRect = clipRect };
+         return true;
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -46,3 +46,23 @@ list is built, so the composited-away colour is not recoverable from the rendere
 pixels afterwards; a runner-side workaround would have to re-implement canvas
 background propagation to guess what was flattened. One reftest is not worth
 that, and the patch is one line.
+
+### `0002-html-empty-inset-clip.patch` — `Broiler.HTML`
+
+Four lines in `Source/Broiler.HTML.Orchestration/IR/PaintWalker.Geometry.cs`: a
+`clip-path: inset()` whose rectangle comes out empty is emitted as a clip instead
+of being dropped. An empty rectangle is a clip that admits nothing —
+`inset(100% 0 0 0)` says the element is not to be seen — and the raster backend
+clips to it correctly once it arrives; dropping it painted the element in full.
+
+Wanted by CSS 2.1 §11.1.2 `clip`, which is implemented **in this repository**
+(`Broiler.Layout/Broiler.Layout/IR/ClipRect.cs`, projecting onto the `clip-path`
+the paint walker already applies — see
+[docs/wpt-reftests.md](../docs/wpt-reftests.md)). Most of what `clip` states *is*
+an empty rectangle: `rect(96px, 96px, 96px, 96px)` on a 96×96 box runs from the
+96px mark to the 96px mark on both axes. So the main-repo half lands the
+non-empty cases and this unlocks the rest — measured together, **+46 reftests,
+none lost**: `css/CSS2/visufx` 6 → 50 of 51, and two in `css-masking/clip` that
+were the same bug reached through `clip-path` directly.
+
+Applying it does not need `0001`; the two touch different files.

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,48 @@
+# Submodule patches waiting to be applied
+
+`Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
+are git submodules with their own remotes. A session whose GitHub scope is this
+repository alone cannot push to them — the git proxy answers **403** — so a fix
+that belongs in a submodule is committed there, exported with
+`git format-patch`, and left here for a maintainer to apply. The submodule
+working tree is then reverted to its pinned commit and **the gitlink is not
+bumped**: CI clones a submodule by pointer, and a pointer to a commit that was
+never pushed would break the build.
+
+Applying one:
+
+```sh
+cd <Submodule>
+git checkout -b <branch> && git am ../patches/NNNN-<slug>.patch
+git push origin HEAD
+cd .. && git add <Submodule>      # bump the pointer only once the push succeeds
+```
+
+## Index
+
+### `0001-html-canvas-backdrop-lever.patch` — `Broiler.HTML`
+
+One line in `Source/Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs`:
+the colour a translucent propagated canvas background (CSS 2.1 §14.2) is
+flattened against becomes `Broiler.Layout.Engine.CanvasBackdrop.Current ??
+BColor.White` instead of `BColor.White`.
+
+`CanvasBackdrop` itself is **already in this repository**
+(`Broiler.Layout/Broiler.Layout/Engine/CanvasBackdrop.cs`), thread-static and
+null by default, so the main repo builds and every render that does not set it is
+byte-identical to today. The patch is only the call.
+
+Wanted by the WPT reftest runner's `@page` paint (CSS Paged Media 3 §7 — see
+[docs/wpt-reftests.md](../docs/wpt-reftests.md#page-paint-is-not-behind-the-lever-because-it-is-not-about-pagination)):
+a page background is painted under the flow, and a `body` background propagated
+over it has to composite with it rather than against an assumed white.
+`css/css-page/page-box-002-print` is the pair that states it — `body {
+background: #f008 }` over `@page { background: #00f }` must come out violet, not
+pink — and it stays at 0.0 % until this is applied. Nothing else in the `@page`
+paint work depends on it.
+
+**No main-repo fallback, deliberately.** The flatten happens while the display
+list is built, so the composited-away colour is not recoverable from the rendered
+pixels afterwards; a runner-side workaround would have to re-implement canvas
+background propagation to guess what was flattened. One reftest is not worth
+that, and the patch is one line.

--- a/src/Broiler.Wpt.Tests/PagePaintRenderTests.cs
+++ b/src/Broiler.Wpt.Tests/PagePaintRenderTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.IO;
+using Broiler.HTML.Image;
+using Xunit;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// The paint an <c>@page</c> rule puts on the sheet — CSS Paged Media 3 §7's page background, and
+/// the border and padding between the page's margin and its page area.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unpaginated, which is how a <c>-print</c> reftest renders by default
+/// (<see cref="WptTestRunner.PagedPrint"/> is off): the surface stays the runner's viewport and
+/// stands in for one sheet. The page's own paint goes underneath it either way, and that is what
+/// these cover — <c>css-page/page-box-001-print</c> and its neighbours state a page background and
+/// match a reference that states the same colour on <c>body</c>, so a page that paints nothing
+/// matches them by 0.0 %.
+/// </para>
+/// <para>
+/// The pairing with <see cref="PagedPrintRenderTests"/> is deliberate: that file covers cutting the
+/// flow into pages, this one covers what is painted under it, and the two are independent — the
+/// page paints whether or not the flow is paginated.
+/// </para>
+/// </remarks>
+public sealed class PagePaintRenderTests : IDisposable
+{
+    public void Dispose() => Program.ResetTestHooks();
+
+    private const string Text = "text";
+
+    [Fact]
+    public void A_Page_Background_Paints_The_Whole_Sheet()
+    {
+        using var rendered = RenderPrint(
+            "<!DOCTYPE html><style>@page { margin: 0; background: yellow; }</style>" + Text);
+
+        AssertColor(rendered, 200, 150, 255, 255, 0);
+        AssertColor(rendered, 399, 299, 255, 255, 0);
+    }
+
+    // The control: the same document without the page background renders on white, as every
+    // undecorated render does. Nothing about the decorated path may leak into it.
+    [Fact]
+    public void A_Page_With_No_Paint_Leaves_The_Sheet_White()
+    {
+        using var rendered = RenderPrint("<!DOCTYPE html><style>@page { margin: 0; }</style>" + Text);
+
+        AssertColor(rendered, 200, 150, 255, 255, 255);
+    }
+
+    // `@page` applies to paged media and to nothing else, so a test that is not a print test never
+    // paints one. `page-background-image-print` says as much in its own words: its background
+    // should print and not show on screen.
+    [Fact]
+    public void A_Page_Background_Does_Not_Paint_On_Screen()
+    {
+        using var rendered = Render(
+            "screen-test.html",
+            "<!DOCTYPE html><style>@page { margin: 0; background: yellow; }</style>" + Text);
+
+        AssertColor(rendered, 200, 150, 255, 255, 255);
+    }
+
+    // CSS Paged Media 3 §7.2 paints the page background over the whole page box, margin area
+    // included — `page-background-004-print` states a page with a 50px margin and matches a
+    // reference that is solid yellow corner to corner.
+    [Fact]
+    public void A_Page_Background_Covers_The_Margin_Area()
+    {
+        using var rendered = RenderPrint(
+            "<!DOCTYPE html><style>@page { margin: 50px; background: yellow; }</style>" + Text);
+
+        AssertColor(rendered, 5, 5, 255, 255, 0);
+    }
+
+    // The border, unlike the background, sits on the box the margins leave.
+    [Fact]
+    public void A_Page_Border_Is_Drawn_Inside_The_Page_Margin()
+    {
+        using var rendered = RenderPrint(
+            "<!DOCTYPE html><style>@page { margin: 20px; border: 10px solid black; }</style>" + Text);
+
+        AssertColor(rendered, 200, 25, 0, 0, 0);
+        AssertColor(rendered, 200, 5, 255, 255, 255);
+    }
+
+    // A page that states a border and padding moves its page area in by them, which is how
+    // `page-box-011-print` lines up with a reference that insets its content with a `body` border
+    // and padding of its own.
+    [Fact]
+    public void A_Page_Border_And_Padding_Inset_The_Flow()
+    {
+        using var withInsets = RenderPrint(
+            "<!DOCTYPE html><style>@page { margin: 0; border: 10px solid black; padding: 10px; }"
+            + "html,body { margin: 0; } div { height: 10px; background: #00f; }</style><div></div>");
+
+        Assert.Equal(255, withInsets.GetPixel(200, 25).B);
+        Assert.Equal(255, withInsets.GetPixel(200, 15).R);
+    }
+
+    // css-page-3 §5.1: `visibility` applies in the page context. `page-visibility-hidden-001-print`
+    // hides a red page border and matches a reference whose border is `solid transparent` — so the
+    // border keeps its space and paints nothing.
+    [Fact]
+    public void A_Hidden_Page_Paints_Neither_Its_Background_Nor_Its_Border()
+    {
+        using var rendered = RenderPrint(
+            "<!DOCTYPE html><style>@page { visibility: hidden; margin: 0;"
+            + " border: 10px solid black; background: yellow; }</style>" + Text);
+
+        AssertColor(rendered, 200, 5, 255, 255, 255);
+        AssertColor(rendered, 200, 150, 255, 255, 255);
+    }
+
+    // A root element that generates no box generates no page, so nothing of the sheet is painted.
+    // `root-element-display-none-print` states a hotpink page with a red border and matches an
+    // empty document.
+    [Fact]
+    public void A_Display_None_Root_Leaves_The_Sheet_Blank()
+    {
+        using var rendered = RenderPrint(
+            "<!DOCTYPE html><style>@page { margin: 0; border: 10px solid red; background: hotpink; }"
+            + "html { display: none; }</style>FAIL");
+
+        AssertColor(rendered, 200, 150, 255, 255, 255);
+        AssertColor(rendered, 200, 5, 255, 255, 255);
+    }
+
+    // ---- what the rule contributes ----
+
+    [Theory]
+    [InlineData("@page { size: 200px; margin: 10px; }", false)]
+    [InlineData("@page { visibility: hidden; }", false)]
+    [InlineData("@page { background: yellow; }", true)]
+    [InlineData("@page { background-image: url(x.png); }", true)]
+    [InlineData("@page { border: 1px solid; }", true)]
+    [InlineData("@page { padding: 1px; }", true)]
+    [InlineData("@page :first { background: yellow; }", false)]
+    public void A_Page_Is_Decorated_Only_When_It_Paints(string css, bool decorated) =>
+        Assert.Equal(decorated, WptPageDecoration.Resolve("<style>" + css + "</style>") is not null);
+
+    [Fact]
+    public void Later_Declarations_Win_And_Land_On_The_Box_They_Belong_To()
+    {
+        var decoration = WptPageDecoration.Resolve(
+            "<style>@page { background: red; border: 1px solid; }</style>"
+            + "<style>@page { background: green; }</style>");
+
+        Assert.NotNull(decoration);
+        Assert.Equal("background:green;", decoration!.BackgroundCss);
+        Assert.Equal("border:1px solid;", decoration.BoxCss);
+        Assert.True(decoration.HasInsets);
+    }
+
+    // `border-radius` changes the shape the border draws, not the space it takes, so it comes along
+    // with the border without making the page area worth measuring.
+    [Fact]
+    public void A_Border_Radius_Alone_Insets_Nothing()
+    {
+        var decoration = WptPageDecoration.Resolve("<style>@page { border-radius: 4px; }</style>");
+
+        Assert.NotNull(decoration);
+        Assert.False(decoration!.HasInsets);
+    }
+
+    private static void AssertColor(BBitmap bitmap, int x, int y, int r, int g, int b)
+    {
+        var pixel = bitmap.GetPixel(x, y);
+        Assert.Equal((r, g, b), (pixel.R, pixel.G, pixel.B));
+    }
+
+    /// <summary>Renders <paramref name="html"/> as a file whose name marks it a print test.</summary>
+    private static BBitmap RenderPrint(string html) => Render("page-paint-print.html", html);
+
+    private static BBitmap Render(string name, string html)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-page-paint-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, name);
+            File.WriteAllText(file, html);
+            return new WptTestRunner(400, 300).RenderHtmlFileBitmapPublic(file, dir);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch (IOException) { }
+        }
+    }
+}

--- a/src/Broiler.Wpt.Tests/XhtmlScriptCdataTests.cs
+++ b/src/Broiler.Wpt.Tests/XhtmlScriptCdataTests.cs
@@ -1,0 +1,43 @@
+using Xunit;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Inline scripts in an XHTML test, which the corpus writes inside an XML CDATA section.
+/// </summary>
+/// <remarks>
+/// The runner finds a document's scripts by scanning its source, so it sees the CDATA markers an
+/// XML parser would have consumed. <c>&lt;![CDATA[</c> is a syntax error, and the throw took the
+/// whole script with it — including any function an <c>onload</c> attribute went on to call, which
+/// is how <c>css/CSS2</c>'s scripted tests are written. Stripping the wrapper is what lets them run
+/// at all; it took <c>css/CSS2</c> from 4863 to 4908 of 6216 reftests, the gains concentrated in
+/// <c>box-display</c>'s insert/delete-block DOM tests and <c>tables</c>.
+/// </remarks>
+public sealed class XhtmlScriptCdataTests
+{
+    [Fact]
+    public void A_Cdata_Section_Leaves_Only_The_Script()
+    {
+        Assert.Equal(
+            "var a = 1;",
+            WptTestRunner.StripCdataSection("\n  <![CDATA[\n  var a = 1;\n  ]]>\n").Trim());
+    }
+
+    // The spellings that survive an HTML parser as well as an XML one: the markers commented out,
+    // and the whole block wrapped in an HTML comment. Both are noise to the engine either way.
+    [Theory]
+    [InlineData("//<![CDATA[\nvar a = 1;\n//]]>")]
+    [InlineData("// <![CDATA[\nvar a = 1;\n// ]]>")]
+    [InlineData("<!-- <![CDATA[\nvar a = 1;\n]]> -->")]
+    public void The_Commented_Spellings_Are_Stripped_Too(string content) =>
+        Assert.Equal("var a = 1;", WptTestRunner.StripCdataSection(content).Trim());
+
+    // A script that carries no wrapper is handed over untouched — including one that merely
+    // mentions the markers inside a string, since only a wrapper at the very edges is removed.
+    [Theory]
+    [InlineData("var a = 1;")]
+    [InlineData("var a = \"<![CDATA[\";")]
+    [InlineData("")]
+    public void A_Script_Without_A_Wrapper_Is_Unchanged(string content) =>
+        Assert.Equal(content.Trim(), WptTestRunner.StripCdataSection(content).Trim());
+}

--- a/src/Broiler.Wpt/WptDocumentRenderer.cs
+++ b/src/Broiler.Wpt/WptDocumentRenderer.cs
@@ -43,7 +43,47 @@ internal static class WptDocumentRenderer
         BColor backgroundColor,
         EventHandler<HtmlStylesheetLoadEventArgs>? stylesheetLoad,
         EventHandler<HtmlImageLoadEventArgs>? imageLoad,
-        string? baseUrl)
+        string? baseUrl,
+        BBitmap? baseLayer = null) =>
+        RenderToImage(document, html: null, width, height, backgroundColor,
+            stylesheetLoad, imageLoad, baseUrl, baseLayer);
+
+    /// <summary>
+    /// Renders <paramref name="document"/> — or <paramref name="html"/>, when no document was
+    /// projected — onto a surface that starts as <paramref name="baseLayer"/>.
+    /// </summary>
+    /// <remarks>
+    /// The base layer is what the render composites onto, exactly as the flat
+    /// <paramref name="backgroundColor"/> is when there is none: the engine paints over whatever the
+    /// surface already holds, so a canvas background the root propagates blends with the page
+    /// background beneath it rather than replacing it. That is the whole of
+    /// <c>page-box-002-print</c>, whose half-transparent red body over a blue <c>@page</c> has to
+    /// come out violet.
+    /// </remarks>
+    internal static BBitmap RenderToImage(
+        DomDocument? document,
+        string? html,
+        int width,
+        int height,
+        BColor backgroundColor,
+        EventHandler<HtmlStylesheetLoadEventArgs>? stylesheetLoad,
+        EventHandler<HtmlImageLoadEventArgs>? imageLoad,
+        string? baseUrl,
+        BBitmap? baseLayer = null) =>
+        RenderToImage(document, html, width, height, backgroundColor,
+            stylesheetLoad, imageLoad, baseUrl, baseLayer, out _);
+
+    private static BBitmap RenderToImage(
+        DomDocument? document,
+        string? html,
+        int width,
+        int height,
+        BColor backgroundColor,
+        EventHandler<HtmlStylesheetLoadEventArgs>? stylesheetLoad,
+        EventHandler<HtmlImageLoadEventArgs>? imageLoad,
+        string? baseUrl,
+        BBitmap? baseLayer,
+        out Fragment? tree)
     {
         var bitmap = new BBitmap(width, height);
 
@@ -60,25 +100,207 @@ internal static class WptDocumentRenderer
         if (imageLoad != null)
             container.ImageLoad += imageLoad;
 
-        // The string path publishes this from the markup it is handed
-        // (HtmlContainerInt.SetHtmlWithStyleSet); binding a document does not, so the document's
-        // own doctype has to say it here. Without this the render inherits whatever this thread
-        // last rendered — which happens to be right, since the bridge parsed this very test, but
-        // only by accident and only for as long as one thread renders one document.
-        Broiler.Layout.DocumentModeContext.CurrentQuirksMode = SelectsQuirksMode(document);
-
-        container.SetDocumentWithStyleSet(document, baseStyleSet: null, baseUrl: baseUrl);
+        if (document is not null)
+        {
+            // The string path publishes this from the markup it is handed
+            // (HtmlContainerInt.SetHtmlWithStyleSet); binding a document does not, so the document's
+            // own doctype has to say it here. Without this the render inherits whatever this thread
+            // last rendered — which happens to be right, since the bridge parsed this very test, but
+            // only by accident and only for as long as one thread renders one document.
+            Broiler.Layout.DocumentModeContext.CurrentQuirksMode = SelectsQuirksMode(document);
+            container.SetDocumentWithStyleSet(document, baseStyleSet: null, baseUrl: baseUrl);
+        }
+        else
+        {
+            container.SetHtmlWithStyleSet(html ?? string.Empty, baseStyleSet: null, baseUrl: baseUrl);
+        }
 
         bitmap.Clear(backgroundColor);
+        if (baseLayer is not null)
+            BlitOnto(bitmap, baseLayer, 0, 0);
 
         var clip = new RectangleF(0, 0, width, height);
         container.PerformLayout(bitmap, clip);
         container.PerformPaint(bitmap, clip);
 
-        if (container.LatestFragmentTree is { } tree)
+        tree = container.LatestFragmentTree;
+        if (tree is not null)
             CompositeEmbeddedDocuments(tree, bitmap, stylesheetLoad, imageLoad);
 
         return bitmap;
+    }
+
+    /// <summary>
+    /// Renders a document over the paint its own <c>@page</c> puts on the sheet: the page
+    /// background, and the border and padding between the page's margin and its page area.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// One page, not a paginated flow — this is the unpaginated render every <c>-print</c> reftest
+    /// gets by default (<see cref="WptTestRunner.PagedPrint"/>), with the sheet's own paint put back
+    /// under it. Without this a page background is simply not drawn, and a test whose reference
+    /// states the same colour as a <c>body</c> background matches it by 0.0 %:
+    /// <c>page-box-001-print</c>, <c>-002</c>, <c>-003</c> and <c>page-background-image-print</c> are
+    /// each that failure.
+    /// </para>
+    /// <para>
+    /// The flow is rendered into the page area — the border box less the page's border and padding —
+    /// so a page that states them moves the content in by them, the way
+    /// <c>page-box-011-print</c>'s reference moves it in with a <c>body</c> border and padding of
+    /// its own.
+    /// </para>
+    /// </remarks>
+    internal static BBitmap RenderDecorated(
+        DomDocument? document,
+        string html,
+        WptPageBox page,
+        WptPageDecoration decoration,
+        BColor backgroundColor,
+        EventHandler<HtmlStylesheetLoadEventArgs>? stylesheetLoad,
+        EventHandler<HtmlImageLoadEventArgs>? imageLoad,
+        string? baseUrl)
+    {
+        int sheetWidth = Math.Max(1, (int)Math.Round(page.BoxSize.Width));
+        int sheetHeight = Math.Max(1, (int)Math.Round(page.BoxSize.Height));
+
+        using var backdrop = decoration.Render(page, stylesheetLoad, imageLoad, baseUrl);
+        var insets = decoration.MeasureInsets(page, stylesheetLoad, imageLoad, baseUrl);
+        var borderBox = WptPageDecoration.BorderBox(page);
+
+        int areaX = (int)Math.Round(borderBox.X + insets.Left);
+        int areaY = (int)Math.Round(borderBox.Y + insets.Top);
+        int areaWidth = Math.Max(1, (int)Math.Round(borderBox.Width - insets.Left - insets.Right));
+        int areaHeight = Math.Max(1, (int)Math.Round(borderBox.Height - insets.Top - insets.Bottom));
+
+        using var underneath = Crop(backdrop, areaX, areaY, areaWidth, areaHeight, backgroundColor);
+
+        BBitmap flow;
+        Fragment? tree;
+        var previousBackdrop = Broiler.Layout.Engine.CanvasBackdrop.Current;
+        Broiler.Layout.Engine.CanvasBackdrop.Current = UniformColor(underneath);
+        try
+        {
+            flow = RenderToImage(
+                document, html, areaWidth, areaHeight, backgroundColor,
+                stylesheetLoad, imageLoad, baseUrl, baseLayer: underneath, tree: out tree);
+        }
+        finally
+        {
+            Broiler.Layout.Engine.CanvasBackdrop.Current = previousBackdrop;
+        }
+
+        using var _ = flow;
+
+        var output = new BBitmap(sheetWidth, sheetHeight);
+        output.Clear(backgroundColor);
+
+        // A root element that generates no box generates no page either, so nothing of the sheet is
+        // painted — not the flow, and not the `@page`'s own background and border.
+        // `root-element-display-none-print` states exactly that, and its reference is an empty
+        // document.
+        if (!GeneratesPageContent(tree))
+            return output;
+
+        BlitOnto(output, backdrop, 0, 0);
+        BlitOnto(output, flow, areaX, areaY);
+
+        return output;
+    }
+
+    /// <summary>
+    /// Whether a laid-out document puts anything on a page: some box below the fragment tree's root
+    /// that is neither <c>display: none</c> nor collapsed to nothing.
+    /// </summary>
+    /// <remarks>
+    /// The tree's root is the canvas rather than the root element, so a document whose root element
+    /// is <c>display: none</c> still produces one — with every fragment under it <c>none</c> and
+    /// zero-sized, which is what this looks for. An empty <c>&lt;body&gt;</c> is not that case: its
+    /// box is the width of the page even when it is no lines tall, so a page whose only content is
+    /// its own background still counts as generated.
+    /// </remarks>
+    private static bool GeneratesPageContent(Fragment? tree)
+    {
+        if (tree is null)
+            return false;
+
+        foreach (var child in tree.Children)
+        {
+            if (GeneratesBox(child))
+                return true;
+        }
+
+        return false;
+
+        static bool GeneratesBox(Fragment fragment)
+        {
+            if (!string.Equals(fragment.Style.Display, "none", StringComparison.OrdinalIgnoreCase)
+                && (fragment.Size.Width > 0 || fragment.Size.Height > 0))
+            {
+                return true;
+            }
+
+            foreach (var child in fragment.Children)
+            {
+                if (GeneratesBox(child))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The single colour <paramref name="bitmap"/> is painted in, or <c>null</c> when it is not all
+    /// one colour.
+    /// </summary>
+    /// <remarks>
+    /// What the canvas can be told it is compositing against
+    /// (<c>Broiler.Layout.Engine.CanvasBackdrop</c>): the paint walker flattens a translucent
+    /// propagated background into one opaque colour, so a backdrop it can use has to <em>be</em> one
+    /// colour. A page whose background is an image or a gradient answers null and keeps the white
+    /// assumption, which is what every render did before this existed.
+    /// </remarks>
+    private static BColor? UniformColor(BBitmap bitmap)
+    {
+        if (bitmap.Width == 0 || bitmap.Height == 0)
+            return null;
+
+        var first = bitmap.GetPixel(0, 0);
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                if (bitmap.GetPixel(x, y) != first)
+                    return null;
+            }
+        }
+
+        return first;
+    }
+
+    /// <summary>A rectangle of <paramref name="source"/>, padded with <paramref name="fill"/>.</summary>
+    private static BBitmap Crop(BBitmap source, int x, int y, int width, int height, BColor fill)
+    {
+        var crop = new BBitmap(width, height);
+        crop.Clear(fill);
+
+        for (int row = 0; row < height; row++)
+        {
+            int sy = y + row;
+            if (sy < 0 || sy >= source.Height)
+                continue;
+
+            for (int column = 0; column < width; column++)
+            {
+                int sx = x + column;
+                if (sx < 0 || sx >= source.Width)
+                    continue;
+
+                crop.SetPixel(column, row, source.GetPixel(sx, sy));
+            }
+        }
+
+        return crop;
     }
 
     /// <summary>The most pages a paged render lays out and composes.</summary>
@@ -115,11 +337,19 @@ internal static class WptDocumentRenderer
         BColor backgroundColor,
         EventHandler<HtmlStylesheetLoadEventArgs>? stylesheetLoad,
         EventHandler<HtmlImageLoadEventArgs>? imageLoad,
-        string? baseUrl)
+        string? baseUrl,
+        WptPageDecoration? decoration = null)
     {
+        // The page's own paint, and the border and padding it insets the page area by. Every page
+        // of the flow gets the same sheet, so this is resolved once and stamped per page below.
+        using var backdrop = decoration?.Render(page, stylesheetLoad, imageLoad, baseUrl);
+        var insets = decoration?.MeasureInsets(page, stylesheetLoad, imageLoad, baseUrl) ?? (0, 0, 0, 0);
+
         var area = page.AreaSize;
-        int areaWidth = Math.Max(1, (int)Math.Round(area.Width));
-        int areaHeight = Math.Max(1, (int)Math.Round(area.Height));
+        int areaWidth = Math.Max(1, (int)Math.Round(area.Width - insets.Item1 - insets.Item3));
+        int areaHeight = Math.Max(1, (int)Math.Round(area.Height - insets.Item2 - insets.Item4));
+        int areaX = (int)Math.Round(page.MarginLeft + insets.Item1);
+        int areaY = (int)Math.Round(page.MarginTop + insets.Item2);
 
         using var surface = new BBitmap(areaWidth, areaHeight * MaxRenderedPages);
 
@@ -148,6 +378,15 @@ internal static class WptDocumentRenderer
 
         surface.Clear(backgroundColor);
 
+        // Every page band starts as the sheet's page area, so a canvas background the root
+        // propagates composites onto the page background instead of hiding it.
+        if (backdrop is not null)
+        {
+            using var underneath = Crop(backdrop, areaX, areaY, areaWidth, areaHeight, backgroundColor);
+            for (int p = 0; p < MaxRenderedPages; p++)
+                BlitOnto(surface, underneath, 0, p * areaHeight);
+        }
+
         var clip = new RectangleF(0, 0, surface.Width, surface.Height);
 
         SetPageSize(container, new SizeF(areaWidth, areaHeight));
@@ -164,20 +403,24 @@ internal static class WptDocumentRenderer
 
         int boxWidth = Math.Max(1, (int)Math.Round(page.BoxSize.Width));
         int boxHeight = Math.Max(1, (int)Math.Round(page.BoxSize.Height));
-        int marginLeft = (int)Math.Round(page.MarginLeft);
-        int marginTop = (int)Math.Round(page.MarginTop);
 
         var output = new BBitmap(boxWidth, boxHeight * pages);
         output.Clear(backgroundColor);
 
-        // The margin ring first, then the flow's band over the page area it leaves blank. The two
-        // never overlap — a margin box lives in the margin by construction — so the order only
-        // decides which one pays for the rounding at the page area's edge, and the flow is the one
-        // whose position the rest of the render is measured against.
+        // The sheet's own paint under everything, then the margin ring, then the flow's band over
+        // the page area both leave blank. The last two never overlap — a margin box lives in the
+        // margin by construction — so their order only decides which one pays for the rounding at
+        // the page area's edge, and the flow is the one the rest of the render is measured against.
+        if (backdrop is not null)
+        {
+            for (int p = 0; p < pages; p++)
+                BlitOnto(output, backdrop, 0, p * boxHeight);
+        }
+
         PaintMarginBoxes(output, html, page, pages, boxWidth, boxHeight, stylesheetLoad, imageLoad, baseUrl);
 
         for (int p = 0; p < pages; p++)
-            BlitBand(output, surface, p * areaHeight, marginLeft, p * boxHeight + marginTop, areaWidth, areaHeight);
+            BlitBand(output, surface, p * areaHeight, areaX, p * boxHeight + areaY, areaWidth, areaHeight);
 
         return output;
     }

--- a/src/Broiler.Wpt/WptPageDecoration.cs
+++ b/src/Broiler.Wpt/WptPageDecoration.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Broiler.CSS;
+using Broiler.Graphics;
+using Broiler.HTML.Core.Entities;
+using Broiler.HTML.Image;
+
+// Both Broiler.Graphics and Broiler.HTML.Image define a BBitmap; the renderer's is the one the
+// container paints into and the one the comparer reads.
+using BBitmap = Broiler.HTML.Image.BBitmap;
+
+namespace Broiler.Wpt;
+
+/// <summary>
+/// The paint an <c>@page</c> rule puts on the sheet itself — CSS Paged Media 3 §7's page
+/// background, and the border and padding that sit between the page's margin and its page area.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="WptPageBox"/> already reads the <c>@page</c> for the geometry a paged render lays out
+/// against; this reads it for the pixels underneath that. They are different questions and stay in
+/// different files: a page box exists for every document, while a page decoration exists only for
+/// the handful that ask for one, and everything else must render byte-identically to before.
+/// </para>
+/// <para>
+/// Two boxes, because the page paints in two places. §7.2 puts the page background over the
+/// <em>whole</em> page box, margin area included — <c>page-background-004-print</c> states a 500×300
+/// page with a 50px margin and its reference is 500×300 of solid yellow — while the border and
+/// padding belong to the box the margin leaves, which is where <c>page-box-008-print</c> paints its
+/// margin ring blue and its padding ring hotpink. So the backdrop is a full-sheet box carrying the
+/// background declarations and an inset box carrying the border and padding ones.
+/// </para>
+/// <para>
+/// Nothing here re-implements CSS. The declarations are copied onto two ordinary divs and handed to
+/// the same renderer that will draw the page, which is what makes a page background that is an
+/// image, a gradient, or a <c>border-image</c> work without this file knowing they exist. The same
+/// reason drives <see cref="MeasureInsets"/>: the distance from the border box to the page area is
+/// read off a render of the box rather than by parsing <c>border-width</c> here.
+/// </para>
+/// </remarks>
+/// <param name="BackgroundCss">Declarations painting the whole sheet.</param>
+/// <param name="BoxCss">Declarations bordering and padding the box the page's margins leave.</param>
+/// <param name="HasInsets">
+/// Whether <paramref name="BoxCss"/> carries a border or padding — the only two things that move
+/// the page area in from that box, and so the only reason to measure it.
+/// </param>
+internal sealed record WptPageDecoration(string BackgroundCss, string BoxCss, bool HasInsets)
+{
+    /// <summary>
+    /// The decoration <paramref name="html"/>'s unconditional <c>@page</c> rules declare, or
+    /// <c>null</c> when they declare none — which is every document that does not style the sheet,
+    /// and the reason this costs nothing for the rest of the suite.
+    /// </summary>
+    internal static WptPageDecoration? Resolve(string html)
+    {
+        // Later declarations win, and a shorthand must not be reordered behind the longhand that
+        // follows it, so the cascade is kept as a name-keyed list in source order.
+        var background = new List<CssDeclaration>();
+        var box = new List<CssDeclaration>();
+        bool paints = false, insets = false;
+
+        foreach (var (declarations, _) in WptPageBox.EnumerateUnconditionalPageBlocks(html))
+        {
+            foreach (var declaration in declarations.Declarations)
+            {
+                var name = declaration.Name.Trim().ToLowerInvariant();
+
+                // `visibility` applies to the page context and to nothing else in the document
+                // (css-page-3 §5.1), so it goes on both boxes: a hidden page keeps the space its
+                // border and padding take and paints neither them nor its background.
+                // `page-visibility-hidden-001-print` is the pair that states it, matching a
+                // reference whose page border is `solid transparent`.
+                if (name == "visibility")
+                {
+                    Replace(background, name, declaration);
+                    Replace(box, name, declaration);
+                }
+                else if (IsBackgroundProperty(name))
+                {
+                    Replace(background, name, declaration);
+                    paints = true;
+                }
+                else if (IsBoxProperty(name))
+                {
+                    Replace(box, name, declaration);
+                    paints = true;
+                    insets |= !name.StartsWith("border-radius", StringComparison.Ordinal)
+                        && !name.StartsWith("border-image", StringComparison.Ordinal);
+                }
+            }
+        }
+
+        // A page that says only `visibility` paints nothing and moves nothing; it renders exactly as
+        // an undecorated one, so it is not worth a decorated render.
+        if (!paints)
+            return null;
+
+        return new WptPageDecoration(Serialize(background), Serialize(box), insets);
+
+        static void Replace(List<CssDeclaration> into, string name, CssDeclaration declaration)
+        {
+            into.RemoveAll(existing => existing.Name.Trim().Equals(name, StringComparison.OrdinalIgnoreCase));
+            into.Add(declaration);
+        }
+    }
+
+    /// <summary>
+    /// Renders the sheet's backdrop: the page background over the whole page box, and the page's
+    /// border and padding on the box its margins leave.
+    /// </summary>
+    internal BBitmap Render(
+        WptPageBox page,
+        EventHandler<HtmlStylesheetLoadEventArgs>? stylesheetLoad,
+        EventHandler<HtmlImageLoadEventArgs>? imageLoad,
+        string? baseUrl)
+    {
+        int sheetWidth = Math.Max(1, (int)Math.Round(page.BoxSize.Width));
+        int sheetHeight = Math.Max(1, (int)Math.Round(page.BoxSize.Height));
+        var borderBox = BorderBox(page);
+
+        var markup = new StringBuilder()
+            .Append("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><style>")
+            .Append("html,body{margin:0;padding:0;border:0;}")
+            .Append("#s{position:absolute;left:0;top:0;")
+            .Append("width:").Append(Px(sheetWidth)).Append(";height:").Append(Px(sheetHeight)).Append(';')
+            .Append(BackgroundCss).Append('}')
+            .Append("#b{position:absolute;box-sizing:border-box;")
+            .Append("left:").Append(Px(borderBox.X)).Append(";top:").Append(Px(borderBox.Y)).Append(';')
+            .Append("width:").Append(Px(borderBox.Width)).Append(";height:").Append(Px(borderBox.Height)).Append(';')
+            .Append(BoxCss).Append('}')
+            .Append("</style></head><body><div id=\"s\"></div><div id=\"b\"></div></body></html>")
+            .ToString();
+
+        return HtmlRender.RenderToImageWithStyleSet(
+            markup, sheetWidth, sheetHeight,
+            styleSet: null,
+            backgroundColor: Broiler.Graphics.BColor.White,
+            stylesheetLoad: stylesheetLoad,
+            imageLoad: imageLoad,
+            baseUrl: baseUrl);
+    }
+
+    /// <summary>
+    /// How far the page area sits inside the page's border box — the border and padding the
+    /// <c>@page</c> declares, in used pixels.
+    /// </summary>
+    /// <remarks>
+    /// Measured off a render rather than parsed: <c>border-width</c> reaches its used value through
+    /// the shorthand, the style keyword (a <c>border-style</c> of <c>none</c> zeroes a stated width),
+    /// the physical/logical mapping that <c>page-box-008-print</c>'s <c>padding-block-start</c> goes
+    /// through, and percentages that resolve against the box. The renderer resolves all of that
+    /// already, so the probe states the box, fills its content area with a colour nothing else uses,
+    /// and reads the extent back — the same trick
+    /// <c>WptDocumentRenderer.MeasureMarginBoxes</c> uses on the margin ring.
+    /// </remarks>
+    internal (float Left, float Top, float Right, float Bottom) MeasureInsets(
+        WptPageBox page,
+        EventHandler<HtmlStylesheetLoadEventArgs>? stylesheetLoad,
+        EventHandler<HtmlImageLoadEventArgs>? imageLoad,
+        string? baseUrl)
+    {
+        if (!HasInsets)
+            return (0, 0, 0, 0);
+
+        var borderBox = BorderBox(page);
+        int width = Math.Max(1, (int)Math.Round(borderBox.Width));
+        int height = Math.Max(1, (int)Math.Round(borderBox.Height));
+
+        var markup = new StringBuilder()
+            .Append("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><style>")
+            .Append("html,body{margin:0;padding:0;border:0;}")
+            .Append("#b{position:absolute;left:0;top:0;box-sizing:border-box;")
+            .Append("width:").Append(Px(width)).Append(";height:").Append(Px(height)).Append(';')
+            .Append(BoxCss).Append("background:none;}")
+            .Append("#c{width:100%;height:100%;background:rgb(0,255,0);}")
+            .Append("</style></head><body><div id=\"b\"><div id=\"c\"></div></div></body></html>")
+            .ToString();
+
+        using var probe = HtmlRender.RenderToImageWithStyleSet(
+            markup, width, height,
+            styleSet: null,
+            backgroundColor: Broiler.Graphics.BColor.White,
+            stylesheetLoad: stylesheetLoad,
+            imageLoad: imageLoad,
+            baseUrl: baseUrl);
+
+        int minX = int.MaxValue, minY = int.MaxValue, maxX = int.MinValue, maxY = int.MinValue;
+        for (int y = 0; y < probe.Height; y++)
+        {
+            for (int x = 0; x < probe.Width; x++)
+            {
+                var pixel = probe.GetPixel(x, y);
+                if (pixel.R != 0 || pixel.G != 255 || pixel.B != 0)
+                    continue;
+
+                minX = Math.Min(minX, x);
+                minY = Math.Min(minY, y);
+                maxX = Math.Max(maxX, x);
+                maxY = Math.Max(maxY, y);
+            }
+        }
+
+        // A box whose content area came out empty — a border thicker than the page — insets nothing
+        // rather than a negative page area.
+        if (maxX < minX)
+            return (0, 0, 0, 0);
+
+        return (minX, minY, Math.Max(0, width - 1 - maxX), Math.Max(0, height - 1 - maxY));
+    }
+
+    /// <summary>The page box less its margins: the box the page's border and padding live on.</summary>
+    internal static RectangleF BorderBox(WptPageBox page) => new(
+        page.MarginLeft,
+        page.MarginTop,
+        Math.Max(1, page.BoxSize.Width - page.MarginLeft - page.MarginRight),
+        Math.Max(1, page.BoxSize.Height - page.MarginTop - page.MarginBottom));
+
+    private static bool IsBackgroundProperty(string name) =>
+        name == "background" || name.StartsWith("background-", StringComparison.Ordinal);
+
+    /// <remarks>
+    /// <c>border-radius</c> and <c>border-image</c> come along with the border because they change
+    /// the shape it draws, not the space it takes.
+    /// </remarks>
+    private static bool IsBoxProperty(string name) =>
+        name == "border" || name.StartsWith("border-", StringComparison.Ordinal)
+        || name == "padding" || name.StartsWith("padding-", StringComparison.Ordinal);
+
+    private static string Serialize(IEnumerable<CssDeclaration> declarations)
+    {
+        var css = new StringBuilder();
+        foreach (var declaration in declarations)
+        {
+            css.Append(declaration.Name.Trim()).Append(':').Append(declaration.Value.Text.Trim());
+            if (declaration.Important)
+                css.Append(" !important");
+            css.Append(';');
+        }
+
+        return css.ToString();
+    }
+
+    private static string Px(double value) =>
+        value.ToString("0.###", CultureInfo.InvariantCulture) + "px";
+}

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -2885,6 +2885,44 @@ internal sealed partial class WptTestRunner
         Broiler.Dom.DomDocument? Document,
         IReadOnlyList<DomBridge.CheckLayoutAssertion> LayoutAssertions);
 
+    /// <summary>
+    /// The script inside an XML CDATA section, or <paramref name="content"/> unchanged when it is
+    /// not wrapped in one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// An XHTML test writes its inline scripts as <c>&lt;![CDATA[ … ]]&gt;</c> — an XML parser
+    /// consumes the wrapper and hands the engine what is between the markers, but this scan reads
+    /// the file as text and would hand the engine the markers too. <c>&lt;![CDATA[</c> is a syntax
+    /// error, so the whole script threw and every one of the document's scripts was lost with it:
+    /// not just the statements, but the functions an <c>onload</c> attribute goes on to call. That
+    /// is why <c>css/CSS2/visufx/clip-001.xht</c> never ran the <c>clip = "auto"</c> its result
+    /// depends on, and it is the same for every scripted test in the <c>.xht</c> half of the corpus.
+    /// </para>
+    /// <para>
+    /// The commented spellings (<c>//&lt;![CDATA[</c>, <c>&lt;!-- … --&gt;</c>) are handled too:
+    /// they are the same wrapper written to survive an HTML parser, and both halves are only ever
+    /// noise to the engine.
+    /// </para>
+    /// </remarks>
+    internal static string StripCdataSection(string content)
+    {
+        var trimmed = content.Trim();
+
+        // `//<![CDATA[` and `// ]]>` — the JS-comment spelling, which the engine would tolerate but
+        // which the plain form below is the general case of.
+        trimmed = CdataOpenPattern().Replace(trimmed, string.Empty, 1);
+        trimmed = CdataClosePattern().Replace(trimmed, string.Empty, 1);
+
+        return trimmed;
+    }
+
+    [GeneratedRegex(@"\A\s*(?://\s*|<!--\s*)?<!\[CDATA\[")]
+    private static partial Regex CdataOpenPattern();
+
+    [GeneratedRegex(@"(?://\s*)?\]\]>(?:\s*-->)?\s*\z")]
+    private static partial Regex CdataClosePattern();
+
     private static ExecutedDocument ExecuteScriptsWithDom(
         string html,
         string url,
@@ -2962,7 +3000,7 @@ internal sealed partial class WptTestRunner
             }
 
             // Inline script
-            var content = match.Groups["content"].Value.Trim();
+            var content = StripCdataSection(match.Groups["content"].Value).Trim();
             if (string.IsNullOrEmpty(content)) continue;
 
             if (isDefer)

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -2515,11 +2515,31 @@ internal sealed partial class WptTestRunner
         using var presentation = ImageAnimationClock.Pin(presentationTime);
         using (WptPhaseTrace.Measure(WptPhaseTrace.Phases.Render))
         {
+            // `@page` paint applies to paged media only, so it is read for a print test and for
+            // nothing else — and for both sides of one, since PrintMedia is set from the test path
+            // for the whole reftest. A document with no page background, border or padding resolves
+            // to null here and renders exactly as it always has.
+            var decoration = PrintMedia ? WptPageDecoration.Resolve(html) : null;
+
             if (PagedRender)
             {
                 var page = WptPageBox.Resolve(html, new System.Drawing.SizeF(_width, _height));
                 return RenderWithNativeAnchor(html, () => WptDocumentRenderer.RenderPaged(
                     renderDocument, html, page,
+                    backgroundColor: BColor.White,
+                    stylesheetLoad: stylesheetHandler, imageLoad: imageHandler, baseUrl: testBaseUrl,
+                    decoration: decoration));
+            }
+
+            if (decoration is not null)
+            {
+                // Unpaginated, so the surface stays the runner's viewport and only the `@page`'s
+                // margins are taken from the rule: taking its `size` too would resize one side of a
+                // comparison whose reference states no size of its own.
+                var sheet = WptPageBox.Resolve(html, new System.Drawing.SizeF(_width, _height))
+                    with { BoxSize = new System.Drawing.SizeF(_width, _height) };
+                return RenderWithNativeAnchor(html, () => WptDocumentRenderer.RenderDecorated(
+                    renderDocument, html, sheet, decoration,
                     backgroundColor: BColor.White,
                     stylesheetLoad: stylesheetHandler, imageLoad: imageHandler, baseUrl: testBaseUrl));
             }
@@ -2574,22 +2594,43 @@ internal sealed partial class WptTestRunner
     private static bool PagedRender;
 
     /// <summary>
-    /// Runs <paramref name="body"/> with paged rendering on iff the lever is on and
-    /// <paramref name="testPath"/> names a WPT print test — the <c>-print</c> suffix on the file's
-    /// stem, which is the convention the suite uses to mark one and the trigger every other runner
-    /// reads.
+    /// Whether the render in progress stands in for a printed page — set for the whole of one
+    /// <c>-print</c> reftest, its references included, by the same rule and for the same reason as
+    /// <see cref="PagedRender"/>.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="PagedRender"/> because it answers a different question: that one
+    /// asks whether to cut the flow into pages, which is still behind the
+    /// <see cref="PagedPrint"/> lever, while this asks whether the document is being rendered for
+    /// paged media at all — which decides whether its <c>@page</c> paints, and is true whether or
+    /// not the flow is paginated. <c>page-background-image-print</c> is the pair that needs the
+    /// distinction: it says outright that its background should print and not show on screen, and
+    /// its reference states the same colour on <c>html</c>, so the two agree only when the page
+    /// paints.
+    /// </remarks>
+    [ThreadStatic]
+    private static bool PrintMedia;
+
+    /// <summary>
+    /// Runs <paramref name="body"/> in print media iff <paramref name="testPath"/> names a WPT
+    /// print test — the <c>-print</c> suffix on the file's stem, which is the convention the suite
+    /// uses to mark one and the trigger every other runner reads — and with paged rendering on iff
+    /// the lever is on besides.
     /// </summary>
     private static T InPageModeFor<T>(string testPath, Func<T> body)
     {
-        bool previous = PagedRender;
-        PagedRender = PagedPrint && IsPrintTestPath(testPath);
+        bool previousPaged = PagedRender;
+        bool previousPrint = PrintMedia;
+        PrintMedia = IsPrintTestPath(testPath);
+        PagedRender = PagedPrint && PrintMedia;
         try
         {
             return body();
         }
         finally
         {
-            PagedRender = previous;
+            PagedRender = previousPaged;
+            PrintMedia = previousPrint;
         }
     }
 


### PR DESCRIPTION
Triage of [issue #1607](https://github.com/Broiler-Platform/Broiler/issues/1607) (top-30 reftest problems). Five root causes, each measured with a before/after sweep. **~212 reftests fixed, none lost in any sweep.**

Four of the five turned out to be defects in the *reference* documents rather than the tests — the failure mode `docs/wpt-reftests.md` already warns about, at scale.

## Results

| Fix | Reftests | Measured over |
| --- | --- | --- |
| `@page` paint (CSS Paged Media 3 §7) | **+5** (+1 with patch 0001) | `css/css-page` 133 → 137 of 224 |
| XHTML CDATA scripts | **+45** | `css/CSS2` 4863 → 4908 of 6216 |
| `clip` (CSS 2.1 §11.1.2) | **+46**, all with patch 0002 | `css/CSS2/visufx` 6 → 50 of 51, `css-masking/clip` +2 |
| Replaced-element percentage width | **+89** | 16 059-test sweep, 0 lost |
| Inline `position: relative` | **+73** | 16 059-test sweep, 0 lost |

## The five causes

- **`@page` paint** — the page background covers the whole page box (margins included), the border and padding sit on the box the margins leave. Not behind `BROILER_WPT_PAGED_PRINT`: a page paints whether or not the flow is paginated, and `page-background-image-print` says outright that its background should print and not show on screen. A root that generates no box paints nothing; `visibility` applies in the page context.
- **XHTML scripts never ran.** Half of `css/CSS2` is `.xht`, and an XHTML test wraps inline scripts in `<[CDATA[ … ]]>`. The runner scans source rather than parsing it, so the engine got the markers too — a syntax error that took the whole script with it, including functions an `onload` attribute goes on to call. Such tests rendered their pre-script state. 395 documents in the checkout carry one.
- **`clip` had no implementation at all.** Implemented as a projection onto the `clip-path: inset()` that names the same operation, resolved where the used border box is known. The catch is that `clip` is stated from two edges, not four — `rect(96px, 96px, 96px, 96px)` on a 96×96 box is an *empty* clip, which is what ~40 of the tests state, one per unit spelling.
- **Percentage width made a replaced element ignore its height.** `<img width="100%" height="50">` came out as tall as it was wide. CSS2's reference documents draw their coloured band exactly that way, so it cost the reference side of 89 comparisons across four CSS2 directories.
- **`position: relative` did nothing to an inline box.** The offset is visual, so it must reach the words; `PerformLayout` applies it for every box it lays out, but an inline-level box is laid out by `CreateLineBoxes` and never goes through it. Neither an inline `<span>` nor an inline `<img>` moved.

## Two `Broiler.HTML` patches need applying — `patches/`

`Broiler.HTML` is outside this session's push scope (the git proxy returns 403), so two submodule changes ship as patch files with an index in `patches/README.md`. **Submodule pointers are deliberately unchanged** — CI clones by pointer, and a pointer to an unpushed commit would break the build. The main repo builds and all tests pass without them.

- `0001-html-canvas-backdrop-lever.patch` — one line, so a translucent propagated canvas background composites against the page background instead of an assumed white. Unlocks `page-box-002-print`. The type it reads (`Broiler.Layout.Engine.CanvasBackdrop`) is already in this PR.
- `0002-html-empty-inset-clip.patch` — four lines, so an empty `clip-path: inset()` is emitted as a clip rather than dropped as no clip. **Unlocks all 46 of the `clip` gains**; the main-repo half alone lands only the non-empty cases.

## Deliberate limits, stated rather than hidden

- **Inline relative offsets skip vertical writing modes.** `left`/`top` are physical, but a vertical container's words sit in the engine's rotated space, so the offset arrives turned a quarter turn (measured: `vertical-rl` → visual `(-30, +60)`; `vertical-lr` → `(+30, +60)`). Applying it unmapped regressed `vrl-inline-paint-invalidation`, so vertical containers are left alone — as they were before — with the measurements recorded for whoever does the mapping.
- **The inline walk is `display: inline` only.** An `inline-block` is inline-*level* but laid out as a block and already applies its own offset; including it moved such boxes by double.
- **Named `@page` rules are still unread**, as in `WptPageBox` — so a page a name selects paints the unconditional rule's background.
- Nothing was done to `grid-lanes` (637 failures) or `jpegxl`: fixing those trades reftests against the golden-image suite, which is a deliberate existing decision.

## Notes for reviewers

- `docs/wpt-reftests.md` carries the reasoning for each fix and two written-up open leads — out-of-flow replaced elements (three distinct defects, `absolute-replaced-width-*`, 40 tests) and the vertical-mode mapping above.
- It also now warns that measurements must use an **absolute** `--wpt-dir`, as `scripts/run-wpt-reftests.sh` and CI do: a relative one silently fails to resolve a test's root-relative resources, which invalidates any before/after comparison across the two spellings.
- Test suites: `Broiler.Layout.Tests` 572/572, `Broiler.Wpt.Tests` 878 passing with the same 55 pre-existing environmental failures as on `main`.