### PR TITLE
Perform WPT's `.sub` substitution, and work the run's eight 0.0% tests

### DIFF
--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -87,7 +87,7 @@ permissions:
 
 env:
   # Bump to invalidate the cached WPT checkout + references.
-  CACHE_EPOCH: '6' # reference generator honours `reftest-wait`, so a deferred-screenshot test's golden is its post-signal state
+  CACHE_EPOCH: '7' # reference generator expands `.sub` templates and serves WPT's own hosts, so every `.sub` test's golden changes
   SHARD_COUNT: '8'
   WPT_CHECKOUT_DIR: tests/wpt/checkout
   REFERENCE_DIR: tests/wpt/references

--- a/Broiler.Layout/Broiler.Layout.Tests/BorderAntialiasingTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/BorderAntialiasingTests.cs
@@ -1,0 +1,180 @@
+using System.Drawing;
+using Broiler.Layout.Engine;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// The pixel-coverage rule behind corner-miter anti-aliasing: the area of a pixel that a border
+/// side's trapezoid actually covers, which is what decides how far the two colours meeting at a
+/// miter are blended into each other.
+/// </summary>
+public class BorderAntialiasingTests
+{
+    /// <summary>A square from (0,0) to (10,10), wound clockwise on screen (y down).</summary>
+    private static PointF[] Square() =>
+    [
+        new(0, 0), new(10, 0), new(10, 10), new(0, 10),
+    ];
+
+    /// <summary>The same square wound the other way, which must not change any answer.</summary>
+    private static PointF[] SquareReversed() =>
+    [
+        new(0, 10), new(10, 10), new(10, 0), new(0, 0),
+    ];
+
+    /// <summary>
+    /// A 12px border's top side: the full width at the outer edge, mitred in by the left and right
+    /// widths at the inner edge — the shape <c>RGraphicsRasterBackend</c> builds.
+    /// </summary>
+    private static PointF[] TopTrapezoid(float width = 100, float top = 12, float left = 12, float right = 12) =>
+    [
+        new(0, 0), new(width, 0), new(width - right, top), new(left, top),
+    ];
+
+    // ── Wholly inside and wholly outside ─────────────────────────────────────
+
+    [Fact]
+    public void A_Pixel_Well_Inside_Is_Fully_Covered()
+    {
+        Assert.Equal(1f, BorderAntialiasing.Coverage(Square(), 5, 5));
+        Assert.Equal(1f, BorderAntialiasing.Coverage(SquareReversed(), 5, 5));
+    }
+
+    [Fact]
+    public void A_Pixel_Well_Outside_Is_Not_Covered()
+    {
+        Assert.Equal(0f, BorderAntialiasing.Coverage(Square(), 20, 20));
+        Assert.Equal(0f, BorderAntialiasing.Coverage(Square(), -5, 5));
+        Assert.Equal(0f, BorderAntialiasing.Coverage(SquareReversed(), 20, 20));
+    }
+
+    /// <summary>A pixel exactly on an axis-aligned boundary is in or out, never partial.</summary>
+    [Fact]
+    public void An_Axis_Aligned_Edge_Needs_No_Blending()
+    {
+        Assert.Equal(1f, BorderAntialiasing.Coverage(Square(), 0, 0));
+        Assert.Equal(1f, BorderAntialiasing.Coverage(Square(), 9, 9));
+        Assert.Equal(0f, BorderAntialiasing.Coverage(Square(), 10, 0));
+        Assert.Equal(0f, BorderAntialiasing.Coverage(Square(), 0, 10));
+    }
+
+    // ── Partial coverage ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// An axis-aligned edge is decided by the pixel centre even when it falls mid-pixel: a border's
+    /// own edges are not blended, only its mitres. Feathering them would turn a 1px border sitting
+    /// on a half-pixel into two grey rows instead of one solid one.
+    /// </summary>
+    [Fact]
+    public void A_Mid_Pixel_Axis_Aligned_Edge_Is_Not_Blended()
+    {
+        PointF[] halfSquare = [new(0, 0), new(5.8f, 0), new(5.8f, 10), new(0, 10)];
+        Assert.Equal(1f, BorderAntialiasing.Coverage(halfSquare, 5, 5));   // centre 5.5 < 5.8: in
+        Assert.Equal(0f, BorderAntialiasing.Coverage(halfSquare, 6, 5));   // centre 6.5 > 5.8: out
+    }
+
+    /// <summary>A slanted edge through the middle of a pixel covers half of it.</summary>
+    [Fact]
+    public void A_Half_Covered_Pixel_Reads_One_Half()
+    {
+        // A triangle whose hypotenuse runs corner to corner through pixel (5,5).
+        PointF[] wedge = [new(0, 0), new(11, 11), new(0, 11)];
+        Assert.Equal(0.5f, BorderAntialiasing.Coverage(wedge, 5, 5), 3);
+    }
+
+    /// <summary>
+    /// The 45° miter of an equal-width corner splits every pixel along it exactly in two, which is
+    /// why a browser paints one 50/50 pixel per row down the diagonal.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3)]
+    [InlineData(7)]
+    [InlineData(11)]
+    public void An_Equal_Width_Miter_Halves_Each_Pixel_On_It(int step)
+    {
+        var top = TopTrapezoid();
+        Assert.Equal(0.5f, BorderAntialiasing.Coverage(top, step, step), 3);
+
+        // …and the pixels either side of it are whole.
+        Assert.Equal(1f, BorderAntialiasing.Coverage(top, step + 1, step));
+        if (step > 0)
+            Assert.Equal(0f, BorderAntialiasing.Coverage(top, step - 1, step));
+    }
+
+    /// <summary>
+    /// An unequal corner is not 45°: a 12px top against a 4px left slopes one-in-three, so the
+    /// miter takes three rows to cross a pixel and the coverages step 1/6, 1/2, 5/6 — which is what
+    /// Chromium shades (measured 0.158, 0.503, 0.842 of the way between the two colours).
+    /// </summary>
+    [Fact]
+    public void An_Unequal_Miter_Steps_Three_Rows_Per_Pixel()
+    {
+        // Top 12px, left 4px: the miter runs (0,0) → (4,12).
+        var top = TopTrapezoid(width: 100, top: 12, left: 4, right: 4);
+
+        Assert.Equal(1f - 1f / 6f, BorderAntialiasing.Coverage(top, 0, 0), 2);
+        Assert.Equal(0.5f, BorderAntialiasing.Coverage(top, 0, 1), 2);
+        Assert.Equal(1f / 6f, BorderAntialiasing.Coverage(top, 0, 2), 2);
+        Assert.Equal(0f, BorderAntialiasing.Coverage(top, 0, 3));
+
+        // The next pixel column repeats the pattern one row lower.
+        Assert.Equal(1f - 1f / 6f, BorderAntialiasing.Coverage(top, 1, 3), 2);
+        Assert.Equal(0.5f, BorderAntialiasing.Coverage(top, 1, 4), 2);
+        Assert.Equal(1f / 6f, BorderAntialiasing.Coverage(top, 1, 5), 2);
+    }
+
+    /// <summary>Winding order is not part of the answer.</summary>
+    [Fact]
+    public void Coverage_Does_Not_Depend_On_Winding()
+    {
+        var top = TopTrapezoid();
+        PointF[] reversed = [top[3], top[2], top[1], top[0]];
+
+        for (int step = 0; step < 12; step++)
+        {
+            Assert.Equal(
+                BorderAntialiasing.Coverage(top, step, step),
+                BorderAntialiasing.Coverage(reversed, step, step), 4);
+        }
+    }
+
+    /// <summary>Coverage over a whole side sums to its area, so nothing is gained or lost.</summary>
+    [Fact]
+    public void Coverage_Sums_To_The_Trapezoids_Area()
+    {
+        var top = TopTrapezoid(width: 40, top: 8, left: 8, right: 8);
+        float total = 0f;
+        for (int y = -2; y < 12; y++)
+            for (int x = -2; x < 44; x++)
+                total += BorderAntialiasing.Coverage(top, x, y);
+
+        // Trapezoid area: (40 + 24) / 2 * 8 = 256.
+        Assert.Equal(256f, total, 1);
+    }
+
+    [Fact]
+    public void A_Degenerate_Polygon_Covers_Nothing()
+    {
+        Assert.Equal(0f, BorderAntialiasing.Coverage(null!, 0, 0));
+        Assert.Equal(0f, BorderAntialiasing.Coverage([new(0, 0), new(1, 1)], 0, 0));
+    }
+
+    // ── The lever ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Anti_Aliasing_Is_Off_Unless_Pinned()
+    {
+        Assert.False(BorderAntialiasing.Active);
+
+        using (BorderAntialiasing.Pin())
+        {
+            Assert.True(BorderAntialiasing.Active);
+            using (BorderAntialiasing.Pin())
+                Assert.True(BorderAntialiasing.Active);
+            Assert.True(BorderAntialiasing.Active);
+        }
+
+        Assert.False(BorderAntialiasing.Active);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout.Tests/BorderBevelTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/BorderBevelTests.cs
@@ -19,27 +19,119 @@ public class BorderBevelTests
     [Theory]
     [InlineData("inset", true)]
     [InlineData("outset", true)]
+    [InlineData("groove", true)]
+    [InlineData("ridge", true)]
     [InlineData("INSET", true)]
     [InlineData("solid", false)]
     [InlineData("dashed", false)]
     [InlineData("double", false)]
     [InlineData("none", false)]
     [InlineData(null, false)]
-    // groove and ridge bevel too, but by splitting each side lengthwise into two shades, which one
-    // colour per side cannot express — so they are deliberately left flat here.
-    [InlineData("groove", false)]
-    [InlineData("ridge", false)]
-    public void IsBevelled_Covers_Inset_And_Outset_Only(string? style, bool expected) =>
+    public void IsBevelled_Covers_The_Four_3D_Styles(string? style, bool expected) =>
         Assert.Equal(expected, BorderBevel.IsBevelled(style));
 
     [Fact]
     public void A_Style_That_Does_Not_Bevel_Passes_Its_Colour_Through()
     {
         var color = Rgb(200, 100, 50);
-        foreach (var style in new[] { "solid", "dashed", "groove", "ridge", "none", null })
+        foreach (var style in new[] { "solid", "dashed", "double", "none", null })
         {
             Assert.Equal(Tuple(color), Tuple(BorderBevel.SideColor(style, isTopOrLeft: true, color)));
             Assert.Equal(Tuple(color), Tuple(BorderBevel.SideColor(style, isTopOrLeft: false, color)));
+        }
+    }
+
+    // ── groove and ridge split each side lengthwise ──────────────────────────
+
+    /// <summary>Only groove and ridge split, and only when there is room for two halves.</summary>
+    [Theory]
+    [InlineData("groove", 8, true)]
+    [InlineData("ridge", 8, true)]
+    [InlineData("groove", 2, true)]
+    [InlineData("groove", 1, false)]     // no room — collapses to one stroke
+    [InlineData("ridge", 1, false)]
+    [InlineData("inset", 8, false)]      // bevelled, but one shade per side
+    [InlineData("outset", 8, false)]
+    [InlineData("solid", 8, false)]
+    public void SplitsIntoHalves_Needs_A_Split_Style_And_Two_Pixels(
+        string style, double width, bool expected) =>
+        Assert.Equal(expected, BorderBevel.SplitsIntoHalves(style, width));
+
+    /// <summary>
+    /// The split sits at <c>ceil(width / 2)</c> from the outer edge — measured on Chromium, which
+    /// paints a 3px groove as two dark rows then one light, and a 5px one as three then two.
+    /// </summary>
+    [Theory]
+    [InlineData(2, 1, 1)]
+    [InlineData(3, 2, 1)]
+    [InlineData(4, 2, 2)]
+    [InlineData(5, 3, 2)]
+    [InlineData(8, 4, 4)]
+    [InlineData(9, 5, 4)]
+    public void HalfWidth_Splits_At_The_Ceiling(double width, double outer, double inner)
+    {
+        Assert.Equal(outer, BorderBevel.HalfWidth("groove", width, outerHalf: true));
+        Assert.Equal(inner, BorderBevel.HalfWidth("groove", width, outerHalf: false));
+        Assert.Equal(outer, BorderBevel.HalfWidth("ridge", width, outerHalf: true));
+        Assert.Equal(inner, BorderBevel.HalfWidth("ridge", width, outerHalf: false));
+    }
+
+    /// <summary>
+    /// A style that does not split has an outer "half" that is the whole side and no inner one, so
+    /// it still emits exactly one ring.
+    /// </summary>
+    [Theory]
+    [InlineData("solid")]
+    [InlineData("inset")]
+    [InlineData("outset")]
+    [InlineData(null)]
+    public void An_Unsplit_Style_Puts_Its_Whole_Width_In_The_Outer_Half(string? style)
+    {
+        Assert.Equal(8, BorderBevel.HalfWidth(style, 8, outerHalf: true));
+        Assert.Equal(0, BorderBevel.HalfWidth(style, 8, outerHalf: false));
+    }
+
+    /// <summary>
+    /// A groove is carved into the canvas: its outer half reads as <c>inset</c> (top and left in
+    /// shadow) and its inner half as <c>outset</c>. Chromium paints an 8px grey groove's top as
+    /// four rows of <c>rgb(44,44,44)</c> then four of <c>rgb(128,128,128)</c>, and its right as the
+    /// reverse.
+    /// </summary>
+    [Fact]
+    public void Groove_Is_Inset_Outside_And_Outset_Inside()
+    {
+        var grey = Rgb(128, 128, 128);
+        Assert.Equal((44, 44, 44), Tuple(BorderBevel.HalfColor("groove", true, grey, 8, outerHalf: true)));
+        Assert.Equal((128, 128, 128), Tuple(BorderBevel.HalfColor("groove", true, grey, 8, outerHalf: false)));
+        Assert.Equal((128, 128, 128), Tuple(BorderBevel.HalfColor("groove", false, grey, 8, outerHalf: true)));
+        Assert.Equal((44, 44, 44), Tuple(BorderBevel.HalfColor("groove", false, grey, 8, outerHalf: false)));
+    }
+
+    /// <summary>A ridge stands proud of the canvas, so it is the groove the other way round.</summary>
+    [Fact]
+    public void Ridge_Is_Outset_Outside_And_Inset_Inside()
+    {
+        var grey = Rgb(128, 128, 128);
+        Assert.Equal((128, 128, 128), Tuple(BorderBevel.HalfColor("ridge", true, grey, 8, outerHalf: true)));
+        Assert.Equal((44, 44, 44), Tuple(BorderBevel.HalfColor("ridge", true, grey, 8, outerHalf: false)));
+        Assert.Equal((44, 44, 44), Tuple(BorderBevel.HalfColor("ridge", false, grey, 8, outerHalf: true)));
+        Assert.Equal((128, 128, 128), Tuple(BorderBevel.HalfColor("ridge", false, grey, 8, outerHalf: false)));
+    }
+
+    /// <summary>
+    /// At 1px there is no room for two halves, and Chromium paints the lit shade on <em>all four</em>
+    /// sides — not the outer half's shade, which would differ per side.
+    /// </summary>
+    [Theory]
+    [InlineData("groove")]
+    [InlineData("ridge")]
+    public void A_One_Pixel_Groove_Or_Ridge_Is_A_Single_Lit_Stroke(string style)
+    {
+        var grey = Rgb(128, 128, 128);
+        foreach (var isTopOrLeft in new[] { true, false })
+        {
+            Assert.Equal((128, 128, 128),
+                Tuple(BorderBevel.HalfColor(style, isTopOrLeft, grey, 1, outerHalf: true)));
         }
     }
 

--- a/Broiler.Layout/Broiler.Layout.Tests/BorderBevelTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/BorderBevelTests.cs
@@ -1,0 +1,138 @@
+using Broiler.Graphics;
+using Broiler.Layout.Engine;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// CSS 2.1 §8.5.3: <c>inset</c> and <c>outset</c> paint a bevel rather than four flat sides. The
+/// spec leaves the shades to the UA, so every expectation here is a number measured off Chromium
+/// directly — <c>&lt;div style="border:8px inset …"&gt;</c> screenshotted and sampled per side.
+/// </summary>
+public class BorderBevelTests
+{
+    private static BColor Rgb(int r, int g, int b) => BColor.FromArgb(255, (byte)r, (byte)g, (byte)b);
+
+    private static (int R, int G, int B) Tuple(BColor c) => (c.R, c.G, c.B);
+
+    // ── Which styles bevel ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("inset", true)]
+    [InlineData("outset", true)]
+    [InlineData("INSET", true)]
+    [InlineData("solid", false)]
+    [InlineData("dashed", false)]
+    [InlineData("double", false)]
+    [InlineData("none", false)]
+    [InlineData(null, false)]
+    // groove and ridge bevel too, but by splitting each side lengthwise into two shades, which one
+    // colour per side cannot express — so they are deliberately left flat here.
+    [InlineData("groove", false)]
+    [InlineData("ridge", false)]
+    public void IsBevelled_Covers_Inset_And_Outset_Only(string? style, bool expected) =>
+        Assert.Equal(expected, BorderBevel.IsBevelled(style));
+
+    [Fact]
+    public void A_Style_That_Does_Not_Bevel_Passes_Its_Colour_Through()
+    {
+        var color = Rgb(200, 100, 50);
+        foreach (var style in new[] { "solid", "dashed", "groove", "ridge", "none", null })
+        {
+            Assert.Equal(Tuple(color), Tuple(BorderBevel.SideColor(style, isTopOrLeft: true, color)));
+            Assert.Equal(Tuple(color), Tuple(BorderBevel.SideColor(style, isTopOrLeft: false, color)));
+        }
+    }
+
+    // ── The shades themselves ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Every one of these is a Chromium measurement. The darkened side scales all three channels by
+    /// the factor that takes the <em>largest</em> one down by 0.33 of full intensity, which is what
+    /// keeps the hue: <c>rgb(200,100,50)</c> goes to <c>rgb(116,58,29)</c> — all ×0.58 — where a
+    /// per-channel subtraction would have given <c>rgb(116,16,0)</c>.
+    /// </summary>
+    [Theory]
+    [InlineData(255, 255, 255, 171, 171, 171)]
+    [InlineData(200, 200, 200, 116, 116, 116)]
+    [InlineData(128, 128, 128, 44, 44, 44)]
+    [InlineData(255, 0, 0, 171, 0, 0)]
+    [InlineData(0, 128, 0, 0, 44, 0)]
+    [InlineData(200, 100, 50, 116, 58, 29)]
+    [InlineData(238, 238, 238, 154, 154, 154)]   // the UA bevel base — an <hr>/<iframe> border
+    [InlineData(64, 64, 64, 0, 0, 0)]            // already darker than the step: clamps to black
+    [InlineData(0, 0, 0, 0, 0, 0)]               // black has nothing left to darken
+    public void Darken_Matches_Chromium(int r, int g, int b, int dr, int dg, int db) =>
+        Assert.Equal((dr, dg, db), Tuple(BorderBevel.Darken(Rgb(r, g, b))));
+
+    /// <summary>
+    /// The lit side is the colour itself — except black, which would otherwise be indistinguishable
+    /// from its own darkened side and leave no bevel at all.
+    /// </summary>
+    [Theory]
+    [InlineData(255, 255, 255, 255, 255, 255)]
+    [InlineData(128, 128, 128, 128, 128, 128)]
+    [InlineData(200, 100, 50, 200, 100, 50)]
+    [InlineData(238, 238, 238, 238, 238, 238)]
+    [InlineData(0, 0, 0, 0x54, 0x54, 0x54)]
+    public void Lighten_Is_The_Colour_Itself_Except_Black(int r, int g, int b, int lr, int lg, int lb) =>
+        Assert.Equal((lr, lg, lb), Tuple(BorderBevel.Lighten(Rgb(r, g, b))));
+
+    // ── Which side gets which shade ──────────────────────────────────────────
+
+    /// <summary>
+    /// <c>inset</c> sinks the box: the top and left are in shadow, the bottom and right catch the
+    /// light. Measured on Chromium as <c>rgb(44,44,44)</c> / <c>rgb(128,128,128)</c> for a grey.
+    /// </summary>
+    [Fact]
+    public void Inset_Darkens_The_Top_And_Left()
+    {
+        var grey = Rgb(128, 128, 128);
+        Assert.Equal((44, 44, 44), Tuple(BorderBevel.SideColor("inset", isTopOrLeft: true, grey)));
+        Assert.Equal((128, 128, 128), Tuple(BorderBevel.SideColor("inset", isTopOrLeft: false, grey)));
+    }
+
+    /// <summary><c>outset</c> raises it, so the shading is the other way round.</summary>
+    [Fact]
+    public void Outset_Darkens_The_Bottom_And_Right()
+    {
+        var grey = Rgb(128, 128, 128);
+        Assert.Equal((128, 128, 128), Tuple(BorderBevel.SideColor("outset", isTopOrLeft: true, grey)));
+        Assert.Equal((44, 44, 44), Tuple(BorderBevel.SideColor("outset", isTopOrLeft: false, grey)));
+    }
+
+    /// <summary>
+    /// The default <c>&lt;iframe&gt;</c> and <c>&lt;hr&gt;</c> border, end to end: the UA stylesheet
+    /// states <c>#EEEEEE</c> as the bevel base and the shading turns it into the <c>#9A9A9A</c> /
+    /// <c>#EEEEEE</c> pair every browser paints. This pair is what
+    /// <c>css/css-color-adjust/…/color-scheme-iframe-background</c> is scored against.
+    /// </summary>
+    [Fact]
+    public void The_Ua_Bevel_Base_Produces_The_Default_Frame_Border()
+    {
+        var basis = Rgb(0xEE, 0xEE, 0xEE);
+        Assert.Equal((0x9A, 0x9A, 0x9A), Tuple(BorderBevel.SideColor("inset", isTopOrLeft: true, basis)));
+        Assert.Equal((0xEE, 0xEE, 0xEE), Tuple(BorderBevel.SideColor("inset", isTopOrLeft: false, basis)));
+    }
+
+    /// <summary>An explicitly black bevel keeps Chromium's black / <c>#545454</c> pair.</summary>
+    [Fact]
+    public void An_Explicitly_Black_Bevel_Lightens_Rather_Than_Darkens()
+    {
+        var black = Rgb(0, 0, 0);
+        Assert.Equal((0, 0, 0), Tuple(BorderBevel.SideColor("inset", isTopOrLeft: true, black)));
+        Assert.Equal((0x54, 0x54, 0x54), Tuple(BorderBevel.SideColor("inset", isTopOrLeft: false, black)));
+    }
+
+    /// <summary>Alpha rides through both shades, so a translucent bevel stays translucent.</summary>
+    [Fact]
+    public void Alpha_Is_Preserved()
+    {
+        var translucent = BColor.FromArgb(128, 200, 100, 50);
+        Assert.Equal(128, BorderBevel.SideColor("inset", isTopOrLeft: true, translucent).A);
+        Assert.Equal(128, BorderBevel.SideColor("inset", isTopOrLeft: false, translucent).A);
+
+        var translucentBlack = BColor.FromArgb(64, 0, 0, 0);
+        Assert.Equal(64, BorderBevel.Lighten(translucentBlack).A);
+        Assert.Equal(64, BorderBevel.Darken(translucentBlack).A);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout.Tests/LayoutArchitectureTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/LayoutArchitectureTests.cs
@@ -55,6 +55,9 @@ public sealed class LayoutArchitectureTests
                 // Headless live-geometry snapshot (Phase 5 engine-native live geometry) reads the
                 // internal box tree via HeadlessLayoutView.
                 "Broiler.HTML.Headless",
+                // Rasterises a nested browsing context, so it reads EmbeddedCanvas to decide
+                // whether that frame's canvas is opaque or transparent (CSS Color Adjust §2.4).
+                "Broiler.HTML.Image",
                 "Broiler.HTML.Orchestration",
                 // The bridge writes the Phase 5 visual-viewport channel
                 // (NativeAnchorPlacement.VisualViewportScale) around the shared geometry snapshot.

--- a/Broiler.Layout/Broiler.Layout/Broiler.Layout.csproj
+++ b/Broiler.Layout/Broiler.Layout/Broiler.Layout.csproj
@@ -21,6 +21,9 @@
     <InternalsVisibleTo Include="Broiler.HTML.Dom" />
     <InternalsVisibleTo Include="Broiler.HTML" />
     <InternalsVisibleTo Include="Broiler.HTML.Orchestration" />
+    <!-- Rasterises a nested browsing context, so it reads EmbeddedCanvas to decide whether that
+         frame's canvas is opaque or transparent (CSS Color Adjust §2.4). -->
+    <InternalsVisibleTo Include="Broiler.HTML.Image" />
     <InternalsVisibleTo Include="Broiler.Cli.Tests" />
     <InternalsVisibleTo Include="Broiler.DevConsole" />
     <InternalsVisibleTo Include="Broiler.DevConsole.Tests" />

--- a/Broiler.Layout/Broiler.Layout/Engine/BorderAntialiasing.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/BorderAntialiasing.cs
@@ -1,0 +1,222 @@
+using System.Drawing;
+
+namespace Broiler.Layout.Engine;
+
+/// <summary>
+/// Anti-aliasing for the diagonal a border's corner miter cuts across, and the pixel-coverage rule
+/// behind it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A border side is painted as a trapezoid whose slanted ends are the miters it shares with its
+/// neighbours (CSS 2.1 §8.5.4 — "the border is divided at the corners by a straight line"). Filled
+/// by testing each pixel's centre, that diagonal comes out as a staircase: a 12px border with a red
+/// top and an orange left steps orange one pixel further into red on each row, where a browser lays
+/// one blended pixel per row along it. The staircase is the whole of the difference — the sides
+/// themselves are axis-aligned and land on pixel boundaries either way.
+/// </para>
+/// <para>
+/// <b>Coverage, not a special case for 45°.</b> The miter is only diagonal when the two sides are
+/// the same width; a 12px top against a 4px left slopes one-in-three, and Chromium shades three
+/// pixels per step accordingly. So the rule is the area of the pixel the trapezoid actually covers,
+/// which reproduces both.
+/// </para>
+/// <para>
+/// <b>Opt-in, because anti-aliasing shared edges conflates.</b> Two trapezoids meeting along a
+/// miter each cover about half of the pixels on it; blended independently onto the page they leave
+/// the background showing through the seam. The border painter avoids that by filling the corner
+/// square with the first side's colour before either is drawn, so the second blends over an already
+/// opaque corner — but nothing else that fills a polygon does, which is why this is a lever the
+/// border path pins rather than something the rasteriser does for every shape.
+/// </para>
+/// <para>
+/// Thread-static and scope-restoring, like the engine's other render levers
+/// (<see cref="CanvasBackdrop.Current"/>, <see cref="EmbeddedCanvas.EmbedderColorScheme"/>): a
+/// display list is replayed synchronously on the thread that owns the surface, and a tiled replay
+/// gives each tile its own thread and its own scope.
+/// </para>
+/// </remarks>
+internal static class BorderAntialiasing
+{
+    /// <summary>
+    /// Whether the polygon being filled on this thread is a border side whose slanted ends should
+    /// be anti-aliased. <see langword="false"/> by default, so every other fill is unchanged.
+    /// </summary>
+    [System.ThreadStatic]
+    public static bool Active;
+
+    /// <summary>
+    /// Turns anti-aliasing on for the lifetime of the returned scope and restores the previous
+    /// value when it is disposed.
+    /// </summary>
+    public static System.IDisposable Pin()
+    {
+        var scope = new Scope(Active);
+        Active = true;
+        return scope;
+    }
+
+    /// <summary>
+    /// Half a pixel's diagonal. A pixel centre further inside every edge than this cannot be
+    /// clipped by any of them, and one further outside any single edge cannot be touched at all —
+    /// so the exact area is only computed for the handful of pixels a miter actually crosses.
+    /// </summary>
+    private const float HalfDiagonal = 0.7072f;
+
+    /// <summary>
+    /// The fraction of the pixel at (<paramref name="pixelX"/>, <paramref name="pixelY"/>) covered
+    /// by <paramref name="polygon"/>, which must be convex — every border side is a trapezoid.
+    /// Returns 0 or 1 for the pixels that are wholly out or wholly in.
+    /// </summary>
+    public static float Coverage(PointF[] polygon, int pixelX, int pixelY)
+    {
+        if (polygon is null || polygon.Length < 3)
+            return 0f;
+
+        // Orient the polygon so "inside" is consistently the positive side of every edge. The
+        // shoelace sign says which way it winds; screen space has y down, so the test is written
+        // against the sign rather than against a name that would mean the opposite on paper.
+        bool invert = SignedArea(polygon) > 0;
+
+        float centreX = pixelX + 0.5f, centreY = pixelY + 0.5f;
+        var centre = new PointF(centreX, centreY);
+        float nearest = float.PositiveInfinity;
+        bool anySlanted = false;
+
+        for (int i = 0; i < polygon.Length; i++)
+        {
+            var a = polygon[i];
+            var b = polygon[(i + 1) % polygon.Length];
+            float dx = b.X - a.X, dy = b.Y - a.Y;
+            float length = (float)System.Math.Sqrt(dx * dx + dy * dy);
+            if (length <= 0f)
+                continue;
+
+            // An axis-aligned edge is decided by the pixel centre, exactly as it always was. Only
+            // the mitres are blended: a border's own edges are straight lines the layout puts where
+            // it puts them, and feathering those turns a hairline sitting on a half-pixel into two
+            // grey rows instead of one solid one — which is not what a browser draws, and is what a
+            // page full of 1px form-control borders would look like.
+            if (dx == 0f || dy == 0f)
+            {
+                if (Side(a, b, centre, invert) < 0f)
+                    return 0f;
+                continue;
+            }
+
+            anySlanted = true;
+
+            // Signed distance from the centre to this edge, positive inside.
+            float side = ((centreX - a.X) * dy - (centreY - a.Y) * dx) / length;
+            if (invert)
+                side = -side;
+
+            if (side < -HalfDiagonal)
+                return 0f;              // wholly outside this edge, so outside the polygon
+
+            nearest = System.Math.Min(nearest, side);
+        }
+
+        if (!anySlanted || nearest > HalfDiagonal)
+            return 1f;                  // clear of every mitre, so wholly inside
+
+        return ClippedArea(polygon, invert, pixelX, pixelY);
+    }
+
+    /// <summary>
+    /// The area of the unit pixel square left after clipping it against every edge of the polygon
+    /// (Sutherland–Hodgman), which for a convex polygon is exactly the covered area.
+    /// </summary>
+    private static float ClippedArea(PointF[] polygon, bool invert, int pixelX, int pixelY)
+    {
+        // The pixel square, which the clip whittles down edge by edge.
+        var subject = new PointF[16];
+        int count = 4;
+        subject[0] = new PointF(pixelX, pixelY);
+        subject[1] = new PointF(pixelX + 1, pixelY);
+        subject[2] = new PointF(pixelX + 1, pixelY + 1);
+        subject[3] = new PointF(pixelX, pixelY + 1);
+
+        var clipped = new PointF[16];
+
+        for (int i = 0; i < polygon.Length && count > 0; i++)
+        {
+            var a = polygon[i];
+            var b = polygon[(i + 1) % polygon.Length];
+            // Only the mitres clip: the axis-aligned edges were already decided by the centre.
+            if ((a.X == b.X && a.Y == b.Y) || a.X == b.X || a.Y == b.Y)
+                continue;
+
+            int written = 0;
+            for (int j = 0; j < count; j++)
+            {
+                var current = subject[j];
+                var previous = subject[(j + count - 1) % count];
+                float currentSide = Side(a, b, current, invert);
+                float previousSide = Side(a, b, previous, invert);
+
+                if (currentSide >= 0f)
+                {
+                    if (previousSide < 0f && written < clipped.Length)
+                        clipped[written++] = Intersect(previous, current, previousSide, currentSide);
+                    if (written < clipped.Length)
+                        clipped[written++] = current;
+                }
+                else if (previousSide >= 0f && written < clipped.Length)
+                {
+                    clipped[written++] = Intersect(previous, current, previousSide, currentSide);
+                }
+            }
+
+            count = written;
+            System.Array.Copy(clipped, subject, count);
+        }
+
+        if (count < 3)
+            return 0f;
+
+        return System.Math.Clamp(System.Math.Abs(SignedArea(subject, count)), 0f, 1f);
+    }
+
+    private static float Side(PointF a, PointF b, PointF p, bool invert)
+    {
+        float cross = (p.X - a.X) * (b.Y - a.Y) - (p.Y - a.Y) * (b.X - a.X);
+        return invert ? -cross : cross;
+    }
+
+    private static PointF Intersect(PointF from, PointF to, float fromSide, float toSide)
+    {
+        float span = fromSide - toSide;
+        float t = span == 0f ? 0f : fromSide / span;
+        return new PointF(from.X + (to.X - from.X) * t, from.Y + (to.Y - from.Y) * t);
+    }
+
+    private static float SignedArea(PointF[] points) => SignedArea(points, points.Length);
+
+    private static float SignedArea(PointF[] points, int count)
+    {
+        float sum = 0f;
+        for (int i = 0; i < count; i++)
+        {
+            var a = points[i];
+            var b = points[(i + 1) % count];
+            sum += a.X * b.Y - b.X * a.Y;
+        }
+
+        return sum / 2f;
+    }
+
+    private sealed class Scope(bool previous) : System.IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            Active = previous;
+        }
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/BorderBevel.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/BorderBevel.cs
@@ -24,11 +24,13 @@ namespace Broiler.Layout.Engine;
 /// <c>border: 2px inset black</c>.
 /// </para>
 /// <para>
-/// <c>groove</c> and <c>ridge</c> are <em>not</em> handled here. They split each side lengthwise
-/// into two halves carrying the two shades — measurably so: a 16px grey <c>groove</c> paints its
-/// outer half <c>#2C2C2C</c> and its inner half <c>#808080</c>, where <c>inset</c> paints the whole
-/// width <c>#2C2C2C</c>. That needs two rectangles per side rather than one colour per side, so
-/// they keep painting flat until the paint path can express it.
+/// <c>groove</c> and <c>ridge</c> carry the same two shades but split each side lengthwise between
+/// them: a groove is an <c>inset</c> bevel on its outer half and an <c>outset</c> one on its inner
+/// half — carved into the canvas — and a ridge is the mirror. The split sits at
+/// <c>ceil(width / 2)</c> from the outer edge, again measured rather than assumed (a 3px groove
+/// paints two dark rows then one light, a 5px one three then two). Below 2px there is no room for
+/// two halves and both styles collapse to a single stroke of the <em>lit</em> shade on all four
+/// sides, which is what Chromium paints for <c>border: 1px groove</c>.
 /// </para>
 /// <para>
 /// <b>An unspecified border colour is the UA stylesheet's business, not this type's.</b> CSS makes
@@ -57,25 +59,68 @@ internal static class BorderBevel
 
     /// <summary>Whether <paramref name="borderStyle"/> paints a bevel this type models.</summary>
     public static bool IsBevelled(string? borderStyle) =>
-        IsStyle(borderStyle, "inset") || IsStyle(borderStyle, "outset");
+        IsStyle(borderStyle, "inset") || IsStyle(borderStyle, "outset")
+        || IsStyle(borderStyle, "groove") || IsStyle(borderStyle, "ridge");
 
     /// <summary>
-    /// The colour one side of a bevelled border is painted, or <paramref name="color"/> unchanged
-    /// when <paramref name="borderStyle"/> is not one this type bevels.
+    /// Whether a side of this style and <paramref name="width"/> is painted as two nested rings
+    /// rather than one — <c>groove</c> and <c>ridge</c>, wide enough to show both halves.
+    /// </summary>
+    public static bool SplitsIntoHalves(string? borderStyle, double width) =>
+        width >= 2 && (IsStyle(borderStyle, "groove") || IsStyle(borderStyle, "ridge"));
+
+    /// <summary>
+    /// The thickness of one half of a side: for a split style the outer half is
+    /// <c>ceil(width / 2)</c> and the inner half is the remainder; for every other style the outer
+    /// "half" is the whole side and the inner one is nothing.
+    /// </summary>
+    public static double HalfWidth(string? borderStyle, double width, bool outerHalf)
+    {
+        if (!SplitsIntoHalves(borderStyle, width))
+            return outerHalf ? width : 0;
+
+        double outer = System.Math.Ceiling(width / 2);
+        return outerHalf ? outer : width - outer;
+    }
+
+    /// <summary>
+    /// The colour one half of a side is painted. For a style that is not split the outer half is
+    /// the whole side, and this is the flat shade it takes.
     /// </summary>
     /// <param name="borderStyle">The side's used <c>border-style</c>.</param>
     /// <param name="isTopOrLeft">Whether this is the top or left side.</param>
     /// <param name="color">The side's used <c>border-color</c>.</param>
-    public static BColor SideColor(string? borderStyle, bool isTopOrLeft, BColor color)
+    /// <param name="width">The side's used width, which decides whether it splits.</param>
+    /// <param name="outerHalf">Which half is being painted.</param>
+    public static BColor HalfColor(
+        string? borderStyle, bool isTopOrLeft, BColor color, double width, bool outerHalf)
     {
         if (!IsBevelled(borderStyle))
             return color;
 
-        // `inset` sinks the box, so the light falls on its bottom and right; `outset` raises it and
-        // lights the top and left instead.
-        bool darkened = isTopOrLeft == IsStyle(borderStyle, "inset");
-        return darkened ? Darken(color) : Lighten(color);
+        if (!SplitsIntoHalves(borderStyle, width))
+        {
+            // A groove or ridge too thin to split is a single stroke of the lit shade.
+            if (!IsStyle(borderStyle, "inset") && !IsStyle(borderStyle, "outset"))
+                return Lighten(color);
+
+            // `inset` sinks the box, so the light falls on its bottom and right; `outset` raises it
+            // and lights the top and left instead.
+            return isTopOrLeft == IsStyle(borderStyle, "inset") ? Darken(color) : Lighten(color);
+        }
+
+        // A groove is carved in: its outer half reads as `inset` and its inner half as `outset`.
+        // A ridge stands proud, so the two are swapped.
+        bool halfReadsAsInset = outerHalf == IsStyle(borderStyle, "groove");
+        return halfReadsAsInset == isTopOrLeft ? Darken(color) : Lighten(color);
     }
+
+    /// <summary>
+    /// The colour of a side that is painted as one ring. Equivalent to
+    /// <see cref="HalfColor"/> for the outer half of an unsplit side.
+    /// </summary>
+    public static BColor SideColor(string? borderStyle, bool isTopOrLeft, BColor color) =>
+        HalfColor(borderStyle, isTopOrLeft, color, width: 1, outerHalf: true);
 
     /// <summary>
     /// Chromium's <c>Color::Dark()</c>: scales every channel by <c>(v - 0.33) / v</c>, where

--- a/Broiler.Layout/Broiler.Layout/Engine/BorderBevel.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/BorderBevel.cs
@@ -1,0 +1,110 @@
+using Broiler.Graphics;
+
+namespace Broiler.Layout.Engine;
+
+/// <summary>
+/// CSS 2.1 §8.5.3: <c>inset</c> and <c>outset</c> paint a 3D bevel — two sides in a darkened shade
+/// of the border colour and two in the colour itself — rather than four flat sides.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The spec leaves the shades to the UA ("the colors are based on the <c>border-color</c> property,
+/// but UAs may choose their own algorithm"), so a reference implementation's numbers are the only
+/// thing an engine can be measured against. These are Chromium's, read off it directly rather than
+/// inferred from its source: the darkened side scales every channel so that the <em>largest</em>
+/// one loses 0.33 of full intensity, and the lit side is the colour unchanged. Scaling by the
+/// largest channel rather than subtracting per channel is what keeps the hue —
+/// <c>rgb(200,100,50)</c> darkens to <c>rgb(116,58,29)</c>, all three at ×0.58, where a flat
+/// subtraction would give <c>rgb(116,16,0)</c> and turn brown into red.
+/// </para>
+/// <para>
+/// Black is the one colour with a special case on each side, and it needs one: it cannot be
+/// darkened, so a black bevel would be four identical black sides. The dark side stays black and
+/// the lit side becomes <c>#545454</c>, which is what Chromium paints for
+/// <c>border: 2px inset black</c>.
+/// </para>
+/// <para>
+/// <c>groove</c> and <c>ridge</c> are <em>not</em> handled here. They split each side lengthwise
+/// into two halves carrying the two shades — measurably so: a 16px grey <c>groove</c> paints its
+/// outer half <c>#2C2C2C</c> and its inner half <c>#808080</c>, where <c>inset</c> paints the whole
+/// width <c>#2C2C2C</c>. That needs two rectangles per side rather than one colour per side, so
+/// they keep painting flat until the paint path can express it.
+/// </para>
+/// <para>
+/// <b>An unspecified border colour is the UA stylesheet's business, not this type's.</b> CSS makes
+/// the initial <c>border-color</c> <c>currentColor</c>, which on black text bevels into two blacks;
+/// browsers substitute a light grey so the bevel is visible. Broiler states that grey directly in
+/// the UA stylesheet — <c>hr</c> and <c>iframe</c>, the two elements the HTML Standard renders with
+/// a bevelled border, carry <c>border-color: #EEEEEE</c> — and this type shades it from there. The
+/// rendering matches; the computed <c>border-color</c> differs from Chromium's, which keeps
+/// <c>currentColor</c> and substitutes at paint time. An author element with a bevelled border and
+/// no colour of its own therefore still bevels from black rather than from the grey.
+/// </para>
+/// </remarks>
+internal static class BorderBevel
+{
+    /// <summary>
+    /// How much of full intensity the darkened side loses, as a fraction — Chromium's
+    /// <c>Color::Dark()</c> constant (0.33 ≈ 84/255).
+    /// </summary>
+    private const float DarkenAmount = 0.33f;
+
+    /// <summary>
+    /// What the lit side of a black bevel is painted, since black cannot be darkened away from
+    /// itself. Chromium's <c>kLightenedBlack</c>.
+    /// </summary>
+    private static readonly BColor LightenedBlack = BColor.FromArgb(255, 0x54, 0x54, 0x54);
+
+    /// <summary>Whether <paramref name="borderStyle"/> paints a bevel this type models.</summary>
+    public static bool IsBevelled(string? borderStyle) =>
+        IsStyle(borderStyle, "inset") || IsStyle(borderStyle, "outset");
+
+    /// <summary>
+    /// The colour one side of a bevelled border is painted, or <paramref name="color"/> unchanged
+    /// when <paramref name="borderStyle"/> is not one this type bevels.
+    /// </summary>
+    /// <param name="borderStyle">The side's used <c>border-style</c>.</param>
+    /// <param name="isTopOrLeft">Whether this is the top or left side.</param>
+    /// <param name="color">The side's used <c>border-color</c>.</param>
+    public static BColor SideColor(string? borderStyle, bool isTopOrLeft, BColor color)
+    {
+        if (!IsBevelled(borderStyle))
+            return color;
+
+        // `inset` sinks the box, so the light falls on its bottom and right; `outset` raises it and
+        // lights the top and left instead.
+        bool darkened = isTopOrLeft == IsStyle(borderStyle, "inset");
+        return darkened ? Darken(color) : Lighten(color);
+    }
+
+    /// <summary>
+    /// Chromium's <c>Color::Dark()</c>: scales every channel by <c>(v - 0.33) / v</c>, where
+    /// <c>v</c> is the largest channel, so the hue is kept and a colour already darker than the
+    /// step lands on black. Alpha is untouched.
+    /// </summary>
+    public static BColor Darken(BColor color)
+    {
+        float r = color.R / 255f, g = color.G / 255f, b = color.B / 255f;
+        float v = System.Math.Max(r, System.Math.Max(g, b));
+        if (v <= 0f)
+            return color;   // black has nothing left to darken
+
+        float multiplier = System.Math.Max(0f, (v - DarkenAmount) / v);
+        return BColor.FromArgb(color.A, Channel(r, multiplier), Channel(g, multiplier), Channel(b, multiplier));
+    }
+
+    /// <summary>
+    /// The lit side: the colour itself, except black, which would otherwise make the bevel
+    /// invisible against its own darkened side.
+    /// </summary>
+    public static BColor Lighten(BColor color) =>
+        color.R == 0 && color.G == 0 && color.B == 0
+            ? BColor.FromArgb(color.A, LightenedBlack.R, LightenedBlack.G, LightenedBlack.B)
+            : color;
+
+    private static bool IsStyle(string? borderStyle, string name) =>
+        borderStyle is not null && borderStyle.Equals(name, System.StringComparison.OrdinalIgnoreCase);
+
+    private static byte Channel(float value, float multiplier) =>
+        (byte)System.Math.Clamp((int)System.Math.Round(value * multiplier * 255f), 0, 255);
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -2633,6 +2633,14 @@ internal abstract partial class CssBoxProperties
         TextTransform = p.TextTransform;
         Visibility = p.Visibility;
         ImageAnimation = p.ImageAnimation;
+        // CSS Color Adjust §2.1: `color-scheme` is an inherited property. It was read only off the
+        // root element (for the canvas backdrop), which never inherits anything, so its absence
+        // here went unnoticed — until an <iframe> had to be asked for its *own* used scheme to
+        // decide whether the frame's canvas is opaque (§2.4, Engine.EmbeddedCanvas). Without this
+        // an iframe under `html { color-scheme: dark }` reported `normal`, and WPT
+        // color-scheme-iframe-background-mismatch-opaque-cross-origin-002 painted the frame
+        // transparent when the schemes genuinely did differ.
+        ColorScheme = p.ColorScheme;
         _textIndent = p._textIndent;
         TextAlign = p.TextAlign;
         TextAlignLast = p.TextAlignLast;

--- a/Broiler.Layout/Broiler.Layout/Engine/DocumentRoot.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/DocumentRoot.cs
@@ -2,7 +2,8 @@ namespace Broiler.Layout.Engine;
 
 /// <summary>
 /// The directory a <em>root-relative</em> sub-document URL — <c>&lt;frame src="/a/b.html"&gt;</c> —
-/// resolves against, when the host knows what the document root of a local render is.
+/// resolves against, when the host knows what the document root of a local render is, together
+/// with the hosts (if any) that root is the content of — see <see cref="LocalOriginHosts"/>.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -39,17 +40,83 @@ internal static class DocumentRoot
     public static string? Current;
 
     /// <summary>
-    /// Sets <see cref="Current"/> for the lifetime of the returned scope and restores the previous
-    /// value when it is disposed, so nesting is safe.
+    /// Hosts whose content <see cref="Current"/> holds — an absolute URL naming one of them is the
+    /// same file as the root-relative URL with its origin removed. Null or empty (the default)
+    /// leaves every absolute URL unresolved, which is what a renderer with no network does.
     /// </summary>
-    public static System.IDisposable Pin(string? root)
+    /// <remarks>
+    /// Hosts are matched <em>exactly</em>, never by suffix: a caller that also serves subdomains
+    /// lists them. The WPT runner is the caller this exists for — WPT serves every one of its
+    /// hosts from one checkout, so <c>http://not-web-platform.test:8000/css/x.html</c> and
+    /// <c>/css/x.html</c> name one file, which is how a test's cross-origin frame is reachable
+    /// offline. Exactness is what keeps that honest: WPT also mints deliberately
+    /// <em>unresolvable</em> hosts under the same parent domain (<c>nonexistent.web-platform.test</c>,
+    /// for tests about load failure), and a suffix rule would serve those content. The list comes
+    /// from the host, so the engine holds no knowledge of WPT either way.
+    /// </remarks>
+    [System.ThreadStatic]
+    public static string[]? LocalOriginHosts;
+
+    /// <summary>
+    /// Sets <see cref="Current"/> and <see cref="LocalOriginHosts"/> for the lifetime of the
+    /// returned scope and restores the previous values when it is disposed, so nesting is safe.
+    /// </summary>
+    public static System.IDisposable Pin(string? root, string[]? localOriginHosts = null)
     {
-        var scope = new Scope(Current);
+        var scope = new Scope(Current, LocalOriginHosts);
         Current = root;
+        LocalOriginHosts = localOriginHosts;
         return scope;
     }
 
-    private sealed class Scope(string? previous) : System.IDisposable
+    /// <summary>
+    /// The root-relative form of <paramref name="url"/> when it is an absolute http(s) URL on one
+    /// of this thread's <see cref="LocalOriginHosts"/>, else <see langword="null"/>.
+    /// </summary>
+    public static string? TryStripLocalOrigin(string? url) => TryStripLocalOrigin(url, LocalOriginHosts);
+
+    /// <summary>
+    /// The root-relative form of <paramref name="url"/> — path, query and fragment — when it is an
+    /// absolute <c>http</c>/<c>https</c> URL whose host is exactly one of <paramref name="hosts"/>,
+    /// else <see langword="null"/>. Pure, so a caller with its own host list (the WPT runner's
+    /// resource loaders) shares this one implementation of the rule.
+    /// </summary>
+    public static string? TryStripLocalOrigin(string? url, System.Collections.Generic.IReadOnlyList<string>? hosts)
+    {
+        if (string.IsNullOrEmpty(url) || hosts is not { Count: > 0 })
+            return null;
+
+        if (!System.Uri.TryCreate(url, System.UriKind.Absolute, out var uri))
+            return null;
+
+        if (!uri.Scheme.Equals("http", System.StringComparison.OrdinalIgnoreCase)
+            && !uri.Scheme.Equals("https", System.StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        // Uri lower-cases and IDNA-encodes the host, so the comparison is against the same form the
+        // host list is written in (`xn--lve-6lad.web-platform.test`, never `élève.…`).
+        string host = uri.Host;
+        bool served = false;
+        foreach (var candidate in hosts)
+        {
+            if (!string.IsNullOrEmpty(candidate)
+                && host.Equals(candidate, System.StringComparison.OrdinalIgnoreCase))
+            {
+                served = true;
+                break;
+            }
+        }
+
+        if (!served)
+            return null;
+
+        // PathAndQuery keeps the query a WPT URL routinely carries (`?pipe=`, cache-busters); the
+        // loaders downstream strip it before touching the disk, exactly as they do for a URL that
+        // arrived root-relative in the first place.
+        return uri.PathAndQuery + uri.Fragment;
+    }
+
+    private sealed class Scope(string? previous, string[]? previousHosts) : System.IDisposable
     {
         private bool _disposed;
 
@@ -60,6 +127,7 @@ internal static class DocumentRoot
 
             _disposed = true;
             Current = previous;
+            LocalOriginHosts = previousHosts;
         }
     }
 }

--- a/Broiler.Layout/Broiler.Layout/Engine/EmbeddedCanvas.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/EmbeddedCanvas.cs
@@ -1,0 +1,114 @@
+namespace Broiler.Layout.Engine;
+
+/// <summary>
+/// CSS Color Adjust 1 §2.4: whether the canvas of a <em>nested browsing context</em> — the document
+/// inside an <c>&lt;iframe&gt;</c>, <c>&lt;frame&gt;</c> or <c>&lt;object type="text/html"&gt;</c> —
+/// is painted opaquely, or left transparent so the embedding page shows through it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A nested browsing context's canvas is <b>transparent by default</b>: a frame whose document
+/// propagates no background lets the embedder's pixels through, which is why
+/// <c>&lt;iframe src="dark-frame-ref.html"&gt;</c> over a white page is white. The one exception is
+/// the colour-scheme mismatch: <em>"if the used color scheme of the element and the used color
+/// scheme of the embedded document's root element differ, the canvas is painted with the embedded
+/// root's default background"</em>. Without it a dark-scheme document embedded in a light page
+/// would show light through its own dark text.
+/// </para>
+/// <para>
+/// The comparison is between the <b>embedding element</b> and the <b>embedded root</b> — not
+/// between the two documents. That distinction is the whole content of WPT
+/// <c>css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background</c> (a dark
+/// frame in a dark-scheme <c>&lt;iframe&gt;</c> on a light page stays transparent) and of
+/// <c>…-mismatch-opaque-cross-origin-003.sub</c> (a light frame in a light-scheme
+/// <c>&lt;iframe&gt;</c> on a dark page stays transparent). Both rendered an opaque box before this
+/// existed, because the embedding element's <c>color-scheme</c> was never consulted.
+/// </para>
+/// <para>
+/// Thread-static and scope-restoring, like the engine's other render levers
+/// (<see cref="CanvasBackdrop.Current"/>, <see cref="DocumentRoot.Current"/>): a frame is
+/// rasterised synchronously on the thread compositing it, and the value has to be the one belonging
+/// to <em>this</em> frame while its own canvas is painted. Nothing pinned means "not embedded", so
+/// a top-level document is unaffected — <see cref="PaintsOpaqueBackdrop"/> answers
+/// <see langword="true"/> and every render that sets nothing is byte-identical to before.
+/// </para>
+/// </remarks>
+internal static class EmbeddedCanvas
+{
+    /// <summary>
+    /// The computed <c>color-scheme</c> of the element embedding the document being rendered on
+    /// this thread, or <see langword="null"/> when the document is not embedded at all.
+    /// </summary>
+    [System.ThreadStatic]
+    public static string? EmbedderColorScheme;
+
+    /// <summary>
+    /// Whether the document being rendered on this thread is inside a nested browsing context.
+    /// Distinct from <see cref="EmbedderColorScheme"/> being null, because an embedding element
+    /// with no <c>color-scheme</c> at all is still an embedding element.
+    /// </summary>
+    [System.ThreadStatic]
+    public static bool IsEmbedded;
+
+    /// <summary>
+    /// Marks the render inside the returned scope as embedded in an element whose computed
+    /// <c>color-scheme</c> is <paramref name="embedderColorScheme"/>, restoring the previous values
+    /// when it is disposed — so sibling frames and nested frames each see their own embedder.
+    /// </summary>
+    public static System.IDisposable Pin(string? embedderColorScheme)
+    {
+        var scope = new Scope(EmbedderColorScheme, IsEmbedded);
+        EmbedderColorScheme = embedderColorScheme;
+        IsEmbedded = true;
+        return scope;
+    }
+
+    /// <summary>
+    /// CSS Color Adjust §2.2–2.3: whether a <c>color-scheme</c> value resolves to a dark used
+    /// scheme against the reference environment's light preference — the list offers <c>dark</c>
+    /// but not <c>light</c>. The <c>only</c> keyword does not change this (it forbids a UA override
+    /// that is not performed here).
+    /// </summary>
+    public static bool UsesDarkColorScheme(string? colorScheme)
+    {
+        if (string.IsNullOrWhiteSpace(colorScheme))
+            return false;
+
+        bool hasDark = false, hasLight = false;
+        foreach (var token in colorScheme.Split((char[]?)null, System.StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (token.Equals("dark", System.StringComparison.OrdinalIgnoreCase))
+                hasDark = true;
+            else if (token.Equals("light", System.StringComparison.OrdinalIgnoreCase))
+                hasLight = true;
+        }
+
+        return hasDark && !hasLight;
+    }
+
+    /// <summary>
+    /// Whether the UA paints an opaque backdrop under a document whose root element's computed
+    /// <c>color-scheme</c> is <paramref name="embeddedRootColorScheme"/>: always for a document
+    /// that is not embedded, and for an embedded one only when its used scheme differs from its
+    /// embedding element's. <see langword="false"/> means the canvas is transparent and the
+    /// embedder shows through.
+    /// </summary>
+    public static bool PaintsOpaqueBackdrop(string? embeddedRootColorScheme) =>
+        !IsEmbedded
+        || UsesDarkColorScheme(EmbedderColorScheme) != UsesDarkColorScheme(embeddedRootColorScheme);
+
+    private sealed class Scope(string? previousScheme, bool previousIsEmbedded) : System.IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            EmbedderColorScheme = previousScheme;
+            IsEmbedded = previousIsEmbedded;
+        }
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/IR/FragmentTreeBuilder.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/FragmentTreeBuilder.cs
@@ -579,6 +579,15 @@ internal static class FragmentTreeBuilder
             return (null, null);
         }
 
+        // An absolute URL naming a host the caller serves from the document root is that root's
+        // file under a different name: dropping the origin leaves the root-relative URL for the
+        // same resource. Without this a frame pointed at such a host is a network fetch a local
+        // render cannot make, so it paints empty — which is what WPT's cross-origin reftests
+        // (`http://not-web-platform.test:8000/…`, every host of theirs served from one checkout)
+        // showed. No list set, no absolute URL resolves, and nothing changes.
+        if (Engine.DocumentRoot.TryStripLocalOrigin(url) is { Length: > 0 } servedLocally)
+            url = servedLocally;
+
         // HTML §"resolve a URL": a leading `/` is resolved against the document's origin, not
         // against the directory the containing page sits in. A file:// render has no origin to
         // ask, so the root comes from the host (DocumentRoot) — and joining such a URL onto the

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -9,12 +9,14 @@
   new list is the same tests under new numbers:
   [#1497 (2026-07-30)](#the-next-run-issue-1497-2026-07-30),
   [#1538 (2026-08-05)](#the-next-run-issue-1538-2026-08-05),
-  [#1562 (2026-08-07)](#the-next-run-issue-1562-2026-08-07) and
-  [#1612 (2026-08-12)](#the-next-run-issue-1612-2026-08-12). Where a re-run
+  [#1562 (2026-08-07)](#the-next-run-issue-1562-2026-08-07),
+  [#1612 (2026-08-12)](#the-next-run-issue-1612-2026-08-12) and
+  [#1615 (2026-08-12)](#the-next-run-issue-1615-2026-08-12). Where a re-run
   contradicts something below, the section says so and the row here is struck
   through — read the newest section first. #1612 contradicts two of them: the
   frameset test was not a frameset bug, and `image-animation: paused` is no
-  longer unimplemented.
+  longer unimplemented. #1615 contradicts a third: `.sub` tests are no longer
+  unjudgeable offline, because the runner now performs the substitution itself.
 - **Not in scope:** problem 1 (the `DomDocument.CreateElement` crash) is fixed —
   frames no longer parse a non-HTML resource as markup, and `patches/0035-…`
   carried the DOM-layer fix (since applied). Problems 2 and 3 are both per-test
@@ -711,31 +713,39 @@ Four caveats, all learned the hard way:
 
 ## Items that need the WPT server before they can be judged
 
-- **Tests:** problem 5
-  (`css/css-color-adjust/…/color-scheme-iframe-background-mismatch-opaque-cross-origin-002.sub.html`),
+> **Partly resolved.** The `.sub` half of this needed no server at all — see
+> [#1615](#the-runner-never-performed-wpts-sub-substitution--problem-1-fixed).
+> The runner now expands `.sub` templates itself and serves WPT's own hosts from
+> the checkout, so problem 5 is reproducible, **fixed and passing**, and so is
+> every other `.sub` test's cross-origin frame. What remains below is the `?pipe=`
+> half and the script-built-DOM case.
+
+- **Tests:** ~~problem 5
+  (`css/css-color-adjust/…/color-scheme-iframe-background-mismatch-opaque-cross-origin-002.sub.html`)~~ **fixed**,
   problem 4 (`css/css-backgrounds/background-image-shared-stylesheet.html`),
   problem 13 (`css/css-transforms/animation/transform-interpolation-002.html`).
 - **Owner:** the WPT runner, then the component the confirmed failure names.
-- **Current evidence:** all three are reported at 0.0% by CI but are not
-  reproducible offline, and their local scores are misleading:
-  - problem 5 needs `.sub` substitution and a cross-origin host. Offline Broiler
-    paints the `#121212` dark canvas backdrop and Chromium paints white, which
-    hints at a `color-scheme` propagation difference but proves nothing without
-    the real cross-origin frame.
+- **Current evidence:** both remaining tests are reported at 0.0% by CI but are
+  not reproducible offline, and their local scores are misleading:
   - problem 4 needs `?pipe=trickle(d2)` for its image and a script-injected
     `data:text/css` stylesheet; offline neither engine loads the image, so the
     pair matched at 99.8% locally while CI reports 0.0%.
   - problem 13 builds its whole DOM from `interpolation-testcommon.js`; offline
     both renders are empty (100% local match, 0.0% on CI), so the CI artifact's
     `rendered.png` is the only evidence that says what Broiler actually drew.
+  - ~~problem 5 needs `.sub` substitution and a cross-origin host.~~ It needed
+    substitution, which is now done on both sides of the comparison; the
+    "cross-origin host" was a red herring, because WPT serves all of its hosts
+    from one checkout.
 - **Next actions:**
-  1. Pull the `wpt-merged` artifact's failure images for these three before
+  1. Pull the `wpt-merged` artifact's failure images for these two before
      opening any component work — the local pipeline cannot see their real
      failure.
-  2. Decide whether the runner should serve tests over a local HTTP origin with
-     substitution and pipe support, which is what would make this whole class
-     reproducible.
-- **Exit gate:** each of the three is either reproducible locally or reassigned to
+  2. `?pipe=` is the remaining server behaviour worth emulating; the `sub` pipe is
+     done, and the handlers are per-pipe and independent
+     (`tools/wptserve/wptserve/pipes.py`), so `trickle`, `status` and `header` can
+     follow the same shape — a runner-side transform, not a server.
+- **Exit gate:** each of the two is either reproducible locally or reassigned to
   an owning component with a CI-artifact failure image as its evidence.
 
 ## Runner: a `manual/` test was being scored — **fixed**
@@ -1823,6 +1833,149 @@ Local numbers are this container's, against Chromium references generated here.
 | 7 | `fullscreen/rendering/backdrop-inherit` | 0.0% | 0.0% | **won't fix** — same, and ours inherits `--bg` from the fullscreen element as the test asserts |
 | 8 | `resource-timing/initiator-type/frameset` | 0.0% | **0.0% → 99.7%** | **fixed** — a root-relative `<frame src>` resolved against the page's directory; main repo, on CI immediately |
 | 9 | `css-color-adjust/…/mismatch-dynamic` | 0.0% | 0.0% | **won't fix** — Chromium fails this reftest against its own reference |
+
+## The next run (issue #1615, 2026-08-12)
+
+7 593 failures, no incomplete shards. **This run's 0.0% list is the previous
+run's, minus the one that was fixed** — the eight tests reported here are #1612's
+problems 1–7 and 9, and `resource-timing/initiator-type/frameset` has dropped off
+because it now passes. So the six *won't fix* verdicts and the one
+screenshot-artifact verdict all stood; every one was re-rendered here and
+reproduced its documented colours to the tenth of a percent (100 % `#00FF00` for
+both `image-animation` tests, 100 % `#008000` for `at-custom-media-basic` and
+`backdrop-inherit`, 99.1 % for `backdrop-iframe`, 99.8 % white for
+`mismatch-dynamic`, 99.95 % yellow for `page-margin-002-print`).
+
+That left exactly one test with any headroom: **problem 1, the one that could not
+be judged offline at all.** It can now, and it passes.
+
+### The runner never performed WPT's `.sub` substitution — problem 1, **fixed**
+
+- **Test:** problem 1,
+  `css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-opaque-cross-origin-002.sub.html`.
+  CI 0.0%, local **0.0% → passing**, and 100.00 % pixel-identical to the test's
+  own `rel=match` reference.
+- **Owner:** the WPT runner (`src/Broiler.Wpt`) and its reference generator, with
+  a two-line hook in `Broiler.Layout`.
+- **The diagnosis this replaces.** [Items that need the WPT
+  server](#items-that-need-the-wpt-server-before-they-can-be-judged) had this
+  test as unreproducible without a real server and a second host, and the next
+  action was to decide whether to serve the suite over a local HTTP origin. No
+  server is needed. A `.sub` file is a **template**: WPT's server expands
+  `{{host}}`, `{{ports[http][0]}}` and friends before sending it
+  (`tools/wptserve/wptserve/handlers.py` — the rule is a literal `".sub." in
+  path`). Read straight off disk the placeholders survive into the markup, so
+  this test's frame pointed at the uninterpretable URL
+  `http://{{hosts[alt][]}}:{{ports[http][0]}}/css/…/support/light-frame.html`,
+  loaded nothing, and the page rendered 100 % `#121212` — the parent's dark
+  canvas showing through an empty frame. **Neither side of the comparison
+  substituted**, so Chromium's golden was blank for the same reason and the score
+  was meaningless in both directions. There are **1 419 `.sub.html` files** in
+  the tree; 51 of them are reftests.
+- **The second half: WPT's hosts are all one checkout.** Substituting alone only
+  moves the problem — the URL becomes `http://not-web-platform.test:8000/css/…`,
+  which a local render still cannot fetch. But WPT serves *every* one of its
+  hosts from the same document root, so that URL and `/css/…` name one file.
+  Recognising that is what makes a cross-origin frame reachable offline.
+- **What landed, all main repo — on CI immediately, no patch.**
+  `WptSubstitution` performs the substitution with WPT's own defaults
+  (`tools/serve/serve.py`): primary host `web-platform.test`, alternate
+  `not-web-platform.test`, the subdomain set closed under the two-deep products
+  `_make_subdomains_product` builds, IDNA-encoded, and ports pinned to the
+  documented numbers so a render is reproducible. `Broiler.Layout.Engine.DocumentRoot`
+  — the lever [#1612 problem 8](#a-root-relative-frame-src-resolved-against-the-wrong-directory--problem-8-fixed)
+  added — gains a list of hosts served from that root, and `FragmentTreeBuilder`
+  strips such an origin before its existing root-relative branch. The runner's
+  stylesheet and image loaders take the same view through
+  `TryResolveWptRootRelativePath`. `scripts/generate-wpt-references.js` mirrors
+  both halves, because the two sides must render the same bytes.
+- **Only what a file on disk can answer is substituted.** `{{uuid()}}`,
+  `{{headers[…]}}`, `{{GET[…]}}`, `{{file_hash(…)}}` and `{{$var}}` describe a
+  live request and are left **verbatim**, so a test using them renders exactly as
+  it did before. `{{not_domains[nonexistent]}}` is left alone for a stronger
+  reason — it names a host that is *meant* not to resolve — and the served-host
+  match is exact rather than by suffix for the same reason, so
+  `nonexistent.web-platform.test` is never served content.
+- **Empty by default.** A host that declares no served hosts renders byte-for-byte
+  as before: an absolute URL stays the unfetchable empty box it has always been.
+- **CACHE_EPOCH is bumped to 7.** Every `.sub` test's golden changes, so the
+  cached reference slice must be regenerated or the two sides disagree by
+  construction.
+- **Verified:** 0.0% → passing, and the render is the *right* pixels —
+  **100.00 % identical** to `support/light-frame.html`, the reference the test
+  itself declares. 47 focused substitution cases and 16 frame-loading cases pin
+  it, including the negative halves: an unknown or request-scoped placeholder
+  left verbatim, `not_domains` left verbatim, an unlisted host and a subdomain of
+  a listed one both refused, a non-http scheme left alone, `..` unable to escape
+  the root, and a served URL naming nothing still painting empty. The reference
+  generator's own 28 node tests assert the JS mirror agrees case for case.
+
+### What else moved, and the one it exposed
+
+Measured before/after across three directories, each with locally generated
+Chromium references on **both** sides so the comparison is like for like:
+
+| Subset | Tests | Before | After |
+| --- | --- | --- | --- |
+| `css/css-color-adjust/rendering/dark-color-scheme` | 29 | 22 passing | 22 passing |
+| `css/css-values/urls` + `html/syntax/speculative-parsing/…/document-write` | 121 | 121 passing | 121 passing |
+
+Outside the cross-origin-iframe family the change is inert — 121 tests,
+identical both ways. Inside it, four tests moved, and the net is zero because two
+of them were **passing for the wrong reason**:
+
+- **Gained (2).** `…-opaque-cross-origin-002.sub` (the problem above) and
+  `color-scheme-iframe-preferred-page-dark-cross-origin.sub` both load their
+  frame now and match.
+- **Lost, and correctly (1).** `…-mismatch-dynamic-cross-origin.sub` is the
+  cross-origin twin of problem 9, and it fails for exactly the same reason its
+  same-origin twin does: Broiler renders **100.00 % identical to the test's own
+  `rel=match`** (`support/light-frame-scrolling.html`, white), while Chromium's
+  reference is 99.8 % `#121212`. It used to pass only because *both* engines
+  rendered an empty frame. Same **won't fix** class as problem 9.
+- **Lost, and it is a real bug (1).** `…-opaque-cross-origin-003.sub` now paints a
+  200×200 white box that should not be there. The test sets `color-scheme: dark`
+  on `html` but `color-scheme: light` on the `iframe` **element**, and the frame's
+  own root is light — so the embedding element and the embedded root *agree*, no
+  opaque backdrop is called for (CSS Color Adjust §2.3), and the frame should stay
+  transparent with the dark page showing through. Its own reference is 99.84 %
+  `#121212` and Chromium's is 99.80 % `#121212`; ours is 94.76 % `#121212` plus
+  exactly 40 000 white pixels. **Broiler always paints an embedded document's
+  canvas opaque** — `HtmlRender.CompositeEmbeddedDocuments` renders the frame with
+  its own canvas resolved and `BlitOnto` copies the result pixel-for-pixel, with
+  no alpha — so it never consults the embedding element's used `color-scheme` and
+  cannot leave a frame transparent at all. This was invisible while the frame
+  never loaded.
+  - **Owner:** `Broiler.HTML` (`HtmlRender.CompositeEmbeddedDocuments` /
+    `BlitOnto`), so a submodule patch, plus the used-`color-scheme` comparison the
+    decision needs.
+  - **Next action:** give the embedded render a transparent canvas when the
+    embedding element's used colour scheme matches the embedded root's, and
+    alpha-composite the blit instead of copying. Both halves are needed: a
+    transparent canvas that is copied would *erase* the parent instead of showing
+    through it.
+  - **Exit gate:** `…-opaque-cross-origin-003.sub` reaches its reference's
+    99.8 % `#121212` with `…-002.sub`, `…-001.sub`, `-mismatch-alpha` and
+    `-mismatch-opaque` unchanged.
+  - **Not a regression to hide.** The test's former pass is exactly the shape this
+    document already calls **untrustworthy** — passing by rendering nothing. A
+    truthful failure that names a real gap is worth more than a green tick that
+    depended on a frame never loading.
+
+### #1615 problems, at a glance
+
+Local numbers are this container's, against Chromium references generated here.
+
+| # | Test | CI | Local | Status |
+| --- | --- | --- | --- | --- |
+| 1 | `css-color-adjust/…/opaque-cross-origin-002.sub` | 0.0% | **0.0% → passing** | **fixed** — the runner performs WPT's `.sub` substitution and serves WPT's hosts from the checkout; main repo, on CI immediately |
+| 2 | `css-image-animation/image-animation-body-background-root-propagation-paused` | 0.0% | 100% `#00FF00` | **won't fix** — re-verified; ours matches the test's `rel=match`, Chromium has no `image-animation` |
+| 3 | `css-image-animation/image-animation-root-background-paused` | 0.0% | 100% `#00FF00` | **won't fix** — same |
+| 4 | `css-page/page-margin-002-print` | 0.0% | 99.95% `#FFFF00` | **won't fix** — re-verified; the reference is a `vertical-rl` viewport-screenshot artifact |
+| 5 | `mediaqueries/at-custom-media-basic` | 0.0% | 100% `#008000` | **won't fix** — re-verified; ours matches `/css/reference/green.html`, Chromium has no `@custom-media` |
+| 6 | `fullscreen/rendering/backdrop-iframe` | 0.0% | 99.1% `#008000` | **won't fix** — re-verified; the reference never entered fullscreen (no WebDriver) |
+| 7 | `fullscreen/rendering/backdrop-inherit` | 0.0% | 100% `#008000` | **won't fix** — same |
+| 8 | `css-color-adjust/…/mismatch-dynamic` | 0.0% | 99.8% white | **won't fix** — re-verified; ours matches the test's `rel=match`, Chromium fails it |
 
 ## Reported problems, at a glance
 

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -1990,9 +1990,9 @@ bug.)
 - **A separate gap the fix uncovered — since fixed.** `color-scheme-iframe-background`
   stopped at 98.9 % rather than passing, on a residual that was not colour-scheme
   related at all: the default `<iframe>` border. See
-  [the bevel section below](#an-insetoutset-border-was-painted-flat--fixed-pending-patch).
+  [the bevel section below](#a-3d-border-was-painted-flat--fixed-pending-patch).
 
-### An `inset`/`outset` border was painted flat — **fixed, pending patch**
+### A 3D border was painted flat — **fixed, pending patch**
 
 - **Tests:** `css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background`
   (98.9 % → **99.4 %, passing**, on top of the frame-canvas fix), and 89 tests
@@ -2000,13 +2000,14 @@ bug.)
   that carry an `<iframe>` or an `<hr>`.
 - **Owner:** `Broiler.HTML` (`PaintWalker.Decorations`, `CssDefaults`) for the call
   and the UA base; `Broiler.Layout` for the rule.
-- **The gap.** CSS 2.1 §8.5.3 paints `inset` and `outset` as a bevel — two sides
-  in a darkened shade of the border colour, two in the colour itself. The IR paint
-  path used the colour flat on all four sides, so the border the HTML Standard
-  puts on every `<iframe>` and `<hr>` (`border: 2px inset`) came out **solid
-  black** where every browser paints `#9A9A9A` over `#EEEEEE`. On a 600×400 frame
-  that ring is 4 012 px — half of the test's residual, and exactly the half that
-  kept it under the threshold.
+- **The gap.** CSS 2.1 §8.5.3 paints `inset`, `outset`, `groove` and `ridge` as a
+  bevel — two sides in a darkened shade of the border colour, two in the colour
+  itself. The IR paint path used the colour flat on all four sides, so the border
+  the HTML Standard puts on every `<iframe>` and `<hr>` (`border: 2px inset`) came
+  out **solid black** where every browser paints `#9A9A9A` over `#EEEEEE`, and the
+  `border: 2px groove` it puts on every `<fieldset>` came out flat too. On a
+  600×400 frame that ring is 4 012 px — half of the test's residual, and exactly
+  the half that kept it under the threshold.
 - **Measured, not guessed.** The spec leaves the shades to the UA, so the rule
   came from screenshotting Chromium and sampling each side. The darkened side
   scales all three channels by the factor that takes the *largest* one down by
@@ -2028,11 +2029,23 @@ bug.)
   **89 changed and every one of them improved** — none worse — with one more
   passing; many went 99.7–99.8 % to 100.0 %. `hr` renders identically to before.
   30 focused cases pin the shading numbers against the Chromium measurements.
-- **Remaining, and deliberately:** `groove` and `ridge` still paint flat. They
-  split each side lengthwise into two shades — a 16px grey `groove` paints its
-  outer half `#2C2C2C` and its inner half `#808080`, where `inset` paints the
-  whole width `#2C2C2C` — which needs two rectangles per side rather than one
-  colour per side. Exit gate: a grey `groove` shows both halves.
+- **`groove` and `ridge` split each side lengthwise**, and are emitted as two
+  nested rings rather than one. A groove reads as `inset` on its outer half and
+  `outset` on its inner half; a ridge is the mirror. The split sits at
+  `ceil(width / 2)` from the outer edge — a 3px groove is two dark rows then one
+  light, a 5px one three then two — and below 2px there is no room for two halves,
+  where Chromium paints a single stroke of the *lit* shade on all four sides. That
+  1px case is the one place the two styles agree and the only one that is not a
+  split; it was found by measuring all four sides rather than just the top, which
+  is where a per-side rule would have looked right and been wrong.
+  - **Verified:** five more tests moved, all improvements, the largest
+    `fieldset-vertical` at +0.67 points — `<fieldset>` is rendered
+    `border: 2px groove`, so it is the element this reaches most. Against Chromium
+    directly, a page of groove and ridge boxes matches to **99.95 %**.
+- **Remaining:** the corner miters. The 0.05 % residual above is antialiasing on
+  the 45° diagonal between two differently-coloured sides — Broiler steps it,
+  Chromium feathers it — and a plain four-colour `solid` border shows the same
+  thing, so it is not a bevel gap. Owner: the raster backend's border geometry.
 - **Also remaining:** the other half of `color-scheme-iframe-background`'s original
   residual (≈ 4 356 px) is text antialiasing inside the frame, unrelated to
   borders and below the threshold now that the bevel is right.

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -2042,13 +2042,54 @@ bug.)
     `fieldset-vertical` at +0.67 points — `<fieldset>` is rendered
     `border: 2px groove`, so it is the element this reaches most. Against Chromium
     directly, a page of groove and ridge boxes matches to **99.95 %**.
-- **Remaining:** the corner miters. The 0.05 % residual above is antialiasing on
-  the 45° diagonal between two differently-coloured sides — Broiler steps it,
-  Chromium feathers it — and a plain four-colour `solid` border shows the same
-  thing, so it is not a bevel gap. Owner: the raster backend's border geometry.
+- **The corner miters — since fixed.** The 0.05 % residual above was the 45°
+  diagonal between two differently-coloured sides: Broiler stepped it, Chromium
+  feathers it. See [the miter section below](#a-border-corner-had-no-mitre-and-no-anti-aliasing--fixed-pending-patch).
 - **Also remaining:** the other half of `color-scheme-iframe-background`'s original
   residual (≈ 4 356 px) is text antialiasing inside the frame, unrelated to
   borders and below the threshold now that the bevel is right.
+
+### A border corner had no mitre, and no anti-aliasing — **fixed, pending patch**
+
+- **Owner:** `Broiler.HTML` (`RGraphicsRasterBackend`, `BCanvas`) for the paint;
+  `Broiler.Layout` for the coverage rule.
+- **Two gaps, found one behind the other.** CSS 2.1 §8.5.4 divides a border at its
+  corners by a straight line.
+  1. **A stroke has no mitre.** Only `solid` was painted as a trapezoid; `inset`,
+     `outset`, `groove` and `ridge` were stroked along their centre lines, and a
+     stroke butts square into its neighbour — so whichever side was drawn last
+     owned the whole corner. Invisible while two sides share a colour, glaring
+     when they do not, which is exactly what a `groove` does.
+  2. **The mitre was a staircase.** Filled by testing each pixel's centre, the
+     diagonal steps one pixel per row where a browser lays one blended pixel
+     along it.
+- **Coverage, not a 45° special case.** The miter is only diagonal when the two
+  sides are equally wide. A 12px top against a 4px left slopes one-in-three, and
+  the pixel coverages come out 1/6, 1/2, 5/6 — against Chromium's measured 0.158,
+  0.503, 0.842. The rule is the area of the pixel the trapezoid covers, and it
+  reproduces both.
+- **Only the mitres blend.** The first attempt anti-aliased *every* edge of the
+  trapezoid and regressed 210 tests, five of them out of passing. A border's own
+  edges are straight lines the layout puts where it puts them, and feathering them
+  turns a 1px form-control border sitting on a half-pixel into two grey rows
+  instead of one solid one. Axis-aligned edges keep the pixel-centre test; only
+  the diagonals carry coverage. **That failure is the useful part of this entry** —
+  the obvious version of the fix is the wrong one, and only a broad measurement
+  said so.
+- **Why it is opt-in.** Two trapezoids meeting along a mitre each cover about half
+  of the pixels on it, so blended independently onto the page they leave the
+  background showing through the seam. The corner rectangle already filled for
+  same-coloured sides is now filled for every corner, with the colour of whichever
+  side is drawn first, so the second blends over an opaque corner. A translucent
+  side disables the whole thing, since that fill would composite its alpha twice.
+- **Verified:** against Chromium directly, a 12px four-colour border's corners go
+  from **48 differing pixels to 12** (the rest off by 1/255) with the corner pixel
+  now exact, and a page of groove and ridge boxes from **425 to 21**. Across
+  1 949 tests of `css/css-backgrounds`, `html/rendering`, `css/css-gaps` and this
+  directory, **no test changes state in either direction** and the net is
+  **+1.578 points** (+1.707 across 55 tests against −0.129 across 103, one of
+  which loses more than a hundredth of a point). Ships as
+  [`patches/0006`](../patches/README.md).
 
 ### #1615 problems, at a glance
 

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -1922,7 +1922,10 @@ Chromium references on **both** sides so the comparison is like for like:
 
 Outside the cross-origin-iframe family the change is inert — 121 tests,
 identical both ways. Inside it, four tests moved, and the net is zero because two
-of them were **passing for the wrong reason**:
+of them were **passing for the wrong reason**. (The frame-canvas fix below then
+took that directory to **24 passing**; the four moves are recorded as the
+substitution change left them, because the second of them is what pointed at the
+bug.)
 
 - **Gained (2).** `…-opaque-cross-origin-002.sub` (the problem above) and
   `color-scheme-iframe-preferred-page-dark-cross-origin.sub` both load their
@@ -1933,34 +1936,65 @@ of them were **passing for the wrong reason**:
   `rel=match`** (`support/light-frame-scrolling.html`, white), while Chromium's
   reference is 99.8 % `#121212`. It used to pass only because *both* engines
   rendered an empty frame. Same **won't fix** class as problem 9.
-- **Lost, and it is a real bug (1).** `…-opaque-cross-origin-003.sub` now paints a
-  200×200 white box that should not be there. The test sets `color-scheme: dark`
-  on `html` but `color-scheme: light` on the `iframe` **element**, and the frame's
-  own root is light — so the embedding element and the embedded root *agree*, no
-  opaque backdrop is called for (CSS Color Adjust §2.3), and the frame should stay
-  transparent with the dark page showing through. Its own reference is 99.84 %
-  `#121212` and Chromium's is 99.80 % `#121212`; ours is 94.76 % `#121212` plus
-  exactly 40 000 white pixels. **Broiler always paints an embedded document's
-  canvas opaque** — `HtmlRender.CompositeEmbeddedDocuments` renders the frame with
-  its own canvas resolved and `BlitOnto` copies the result pixel-for-pixel, with
-  no alpha — so it never consults the embedding element's used `color-scheme` and
-  cannot leave a frame transparent at all. This was invisible while the frame
-  never loaded.
-  - **Owner:** `Broiler.HTML` (`HtmlRender.CompositeEmbeddedDocuments` /
-    `BlitOnto`), so a submodule patch, plus the used-`color-scheme` comparison the
-    decision needs.
-  - **Next action:** give the embedded render a transparent canvas when the
-    embedding element's used colour scheme matches the embedded root's, and
-    alpha-composite the blit instead of copying. Both halves are needed: a
-    transparent canvas that is copied would *erase* the parent instead of showing
-    through it.
-  - **Exit gate:** `…-opaque-cross-origin-003.sub` reaches its reference's
-    99.8 % `#121212` with `…-002.sub`, `…-001.sub`, `-mismatch-alpha` and
-    `-mismatch-opaque` unchanged.
-  - **Not a regression to hide.** The test's former pass is exactly the shape this
-    document already calls **untrustworthy** — passing by rendering nothing. A
-    truthful failure that names a real gap is worth more than a green tick that
-    depended on a frame never loading.
+- **Lost, and it is a real bug (1).** `…-opaque-cross-origin-003.sub` painted a
+  200×200 white box that should not be there. **Since fixed** — see
+  [the frame-canvas section below](#a-frames-canvas-was-never-transparent--003sub-and-iframe-background-fixed-pending-patch).
+  Worth keeping the shape of it on record: the test's former pass is exactly what
+  this document calls **untrustworthy** — passing by rendering nothing — and a
+  truthful failure that named a real gap was worth more than a green tick that
+  depended on a frame never loading.
+
+### A frame's canvas was never transparent — 003.sub and `iframe-background`, **fixed, pending patch**
+
+- **Tests:** `css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-opaque-cross-origin-003.sub`
+  (94.7 % → **99.8 %, passing**) and `…/color-scheme-iframe-background`
+  (69.0 % → **98.9 %**), plus `…/color-scheme-iframe-background-mismatch-used-preferred`
+  (94.6 % → **99.5 %, passing**) which fell out with them.
+- **Owner:** `Broiler.HTML` (`HtmlRender`, `PaintWalker.CanvasBackground`) for the
+  renderer half; `Broiler.Layout` for the rule and the cascade fix.
+- **The rule.** CSS Color Adjust 1 §2.4: a nested browsing context's canvas is
+  **transparent** — the embedder shows through it — *unless* the used colour
+  scheme of the **embedding element** differs from the embedded root's, in which
+  case the UA paints an opaque backdrop of the embedded root's scheme. The
+  comparison is element-to-root, not document-to-document, and these two tests are
+  built on precisely that: one puts a dark frame in a dark-scheme `<iframe>` on a
+  light page, the other a light frame in a light-scheme `<iframe>` on a dark page,
+  and both ask for the page to show through.
+- **Two bugs, not one.**
+  1. **The canvas was always opaque.** `RenderToImageCore` erased every embedded
+     document to its resolved canvas colour, `PaintWalker.EmitCanvasBackground`
+     painted the UA dark fill unconditionally, and `BlitOnto` copied the result
+     pixel-for-pixel with no alpha. A frame could not be transparent at all, so
+     the embedding element's `color-scheme` was never consulted.
+  2. **`color-scheme` did not inherit.** §2.1 makes it an inherited property, but
+     it was missing from `CssBoxProperties.InheritStyle` — unnoticed because it was
+     only ever read off the root element, which inherits nothing. An `<iframe>`
+     under `html { color-scheme: dark }` therefore reported `normal`. Fixing only
+     the first bug regressed `…-002.sub` (the frame went transparent when the
+     schemes genuinely *did* differ); the two have to land together.
+- **What landed where.** `Broiler.Layout.Engine.EmbeddedCanvas` is the rule — a
+  thread-static, scope-restoring lever like `CanvasBackdrop` and `DocumentRoot`,
+  carrying the embedding element's computed `color-scheme` and answering
+  `PaintsOpaqueBackdrop`. Unpinned means "not embedded", so it answers `true` and
+  a top-level render is byte-identical. That, the inheritance fix, and the WPT
+  runner's own frame compositor (`WptDocumentRenderer`, which pins the lever and
+  composites source-over) are **main repo**. The renderer's side is
+  [`patches/0004`](../patches/README.md) — the `Broiler.HTML` remote 403s from
+  here — and until it is applied the two tests keep their current scores.
+- **Verified:** the dark-color-scheme directory goes **22 → 24 of 29** with
+  nothing lost, and `html/semantics/embedded-content/the-iframe-element` is
+  **unchanged across all 161 tests** — the change is inert for a frame that fills
+  its own canvas, which is nearly all of them. 22 focused cases cover the rule,
+  the cascade and the render, four of them probing for the patch so they become
+  real guards when the pointer is bumped.
+- **A separate gap the fix uncovered.** `color-scheme-iframe-background` stops at
+  98.9 % rather than passing, and the residual 1.1 % is not colour-scheme related:
+  Broiler paints a **black** default `<iframe>` border where Chromium paints a
+  **grey inset** one, one pixel further in. It is 100.00 % identical to its own
+  `rel=match` reference either way — both Broiler renders carry the same border,
+  so it cancels in the reftest suite and only shows against Chromium's golden.
+  Owner: the UA stylesheet's `iframe` border. Exit gate: the test reaches ≥ 99 %
+  against the Chromium reference with its interior unchanged.
 
 ### #1615 problems, at a glance
 

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -1987,14 +1987,55 @@ bug.)
   its own canvas, which is nearly all of them. 22 focused cases cover the rule,
   the cascade and the render, four of them probing for the patch so they become
   real guards when the pointer is bumped.
-- **A separate gap the fix uncovered.** `color-scheme-iframe-background` stops at
-  98.9 % rather than passing, and the residual 1.1 % is not colour-scheme related:
-  Broiler paints a **black** default `<iframe>` border where Chromium paints a
-  **grey inset** one, one pixel further in. It is 100.00 % identical to its own
-  `rel=match` reference either way — both Broiler renders carry the same border,
-  so it cancels in the reftest suite and only shows against Chromium's golden.
-  Owner: the UA stylesheet's `iframe` border. Exit gate: the test reaches ≥ 99 %
-  against the Chromium reference with its interior unchanged.
+- **A separate gap the fix uncovered — since fixed.** `color-scheme-iframe-background`
+  stopped at 98.9 % rather than passing, on a residual that was not colour-scheme
+  related at all: the default `<iframe>` border. See
+  [the bevel section below](#an-insetoutset-border-was-painted-flat--fixed-pending-patch).
+
+### An `inset`/`outset` border was painted flat — **fixed, pending patch**
+
+- **Tests:** `css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background`
+  (98.9 % → **99.4 %, passing**, on top of the frame-canvas fix), and 89 tests
+  across `html/rendering` and `html/semantics/embedded-content/the-iframe-element`
+  that carry an `<iframe>` or an `<hr>`.
+- **Owner:** `Broiler.HTML` (`PaintWalker.Decorations`, `CssDefaults`) for the call
+  and the UA base; `Broiler.Layout` for the rule.
+- **The gap.** CSS 2.1 §8.5.3 paints `inset` and `outset` as a bevel — two sides
+  in a darkened shade of the border colour, two in the colour itself. The IR paint
+  path used the colour flat on all four sides, so the border the HTML Standard
+  puts on every `<iframe>` and `<hr>` (`border: 2px inset`) came out **solid
+  black** where every browser paints `#9A9A9A` over `#EEEEEE`. On a 600×400 frame
+  that ring is 4 012 px — half of the test's residual, and exactly the half that
+  kept it under the threshold.
+- **Measured, not guessed.** The spec leaves the shades to the UA, so the rule
+  came from screenshotting Chromium and sampling each side. The darkened side
+  scales all three channels by the factor that takes the *largest* one down by
+  0.33 of full intensity — which is what keeps the hue: `rgb(200,100,50)` darkens
+  to `rgb(116,58,29)`, all ×0.58, where the per-channel subtraction the greys
+  alone suggested would have given `rgb(116,16,0)` and turned brown into red. The
+  lit side is the colour itself, except black, whose lit side is `#545454`.
+- **The second half is the UA stylesheet.** CSS makes the initial `border-color`
+  `currentColor`, which bevels black-on-black; browsers substitute a light grey at
+  paint time. Broiler states that grey in the UA stylesheet instead — which is
+  what `hr` already did, with the *result* of the bevel hard-coded per side
+  (`#9A9A9A`/`#EEEEEE`). Those four declarations collapse to one
+  `border-color: #EEEEEE` now the engine derives the pair, and `iframe` gets the
+  same base. **The two halves must land together:** shading while `hr` still
+  carried the pre-bevelled colours would darken `#9A9A9A` a second time and
+  regress every `<hr>`, which is why the call sits in
+  [`patches/0005`](../patches/README.md) rather than in `ComputedStyleBuilder`.
+- **Verified:** across 665 tests of `html/rendering` and the iframe element,
+  **89 changed and every one of them improved** — none worse — with one more
+  passing; many went 99.7–99.8 % to 100.0 %. `hr` renders identically to before.
+  30 focused cases pin the shading numbers against the Chromium measurements.
+- **Remaining, and deliberately:** `groove` and `ridge` still paint flat. They
+  split each side lengthwise into two shades — a 16px grey `groove` paints its
+  outer half `#2C2C2C` and its inner half `#808080`, where `inset` paints the
+  whole width `#2C2C2C` — which needs two rectangles per side rather than one
+  colour per side. Exit gate: a grey `groove` shows both halves.
+- **Also remaining:** the other half of `color-scheme-iframe-background`'s original
+  residual (≈ 4 356 px) is text antialiasing inside the frame, unrelated to
+  borders and below the threshold now that the bevel is right.
 
 ### #1615 problems, at a glance
 

--- a/patches/0004-html-embedded-canvas-color-scheme.patch
+++ b/patches/0004-html-embedded-canvas-color-scheme.patch
@@ -1,0 +1,237 @@
+From 81346b36dac416aec5e9ac46fe8701ae19db907c Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Wed, 12 Aug 2026 10:05:18 +0000
+Subject: [PATCH] Paint a frame's canvas opaque only when its colour scheme
+ differs from its embedder's
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CSS Color Adjust 1 §2.4: a nested browsing context's canvas is transparent — the
+embedder shows through it — unless the used colour scheme of the *embedding
+element* differs from the embedded root's, in which case the UA paints an opaque
+backdrop of the embedded root's scheme.
+
+Only the second half was modelled. An embedded document's canvas was always
+resolved opaque (ResolveCanvasBackground, plus PaintWalker's own UA dark fill),
+and BlitOnto copied the result pixel-for-pixel, so a frame could never be
+transparent and the embedding element's color-scheme was never consulted at all.
+Two WPT tests turn on exactly that: color-scheme-iframe-background puts a dark
+frame in a dark-scheme <iframe> on a light page and asks for the light page to
+show through (69.0% before), and
+color-scheme-iframe-background-mismatch-opaque-cross-origin-003.sub puts a light
+frame in a light-scheme <iframe> on a dark page and asks the same (94.7% before,
+a 200x200 white box that should not have existed).
+
+The decision itself is Broiler.Layout.Engine.EmbeddedCanvas in the main
+repository — a thread-static, scope-restoring render lever like CanvasBackdrop
+and DocumentRoot, carrying the embedding element's computed color-scheme and
+answering PaintsOpaqueBackdrop. Nothing pinned means "not embedded", so it
+answers true and a top-level document renders byte-identically to before. This
+patch is the three call sites: the frame compositor pins the lever around each
+frame's render, RenderToImageCore erases to transparent instead of the resolved
+canvas colour when the lever says the canvas is transparent, and PaintWalker
+skips its UA dark fill in the same case. GetRootColorScheme exposes the embedded
+root's value, which the rasterising caller has no other way to reach.
+
+BlitOnto becomes source-over rather than a copy, since a transparent canvas has
+to composite over the page instead of punching it out. An opaque source still
+takes the copy path, so a frame that fills its own canvas — every frame, before
+this — is unchanged.
+
+Verified against WPT: color-scheme-iframe-background 69.0% -> 98.9% (100.00%
+against its own rel=match reference; the residual is a pre-existing default
+iframe border difference, Broiler black against Chromium's grey inset),
+...-003.sub 94.7% -> 99.8% passing, ...-mismatch-used-preferred 94.6% -> 99.5%
+passing, and the dark-color-scheme directory 22 -> 24 of 29 with nothing lost.
+html/semantics/embedded-content/the-iframe-element is unchanged across all 161
+tests.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ Source/Broiler.HTML.Image/HtmlContainer.cs    |  6 ++
+ Source/Broiler.HTML.Image/HtmlRender.cs       | 59 +++++++++++++++++--
+ .../HtmlContainerInt.cs                       | 20 +++++++
+ .../IR/PaintWalker.CanvasBackground.cs        | 16 ++++-
+ 4 files changed, 96 insertions(+), 5 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Image/HtmlContainer.cs b/Source/Broiler.HTML.Image/HtmlContainer.cs
+index a373de8..0ba2d55 100644
+--- a/Source/Broiler.HTML.Image/HtmlContainer.cs
++++ b/Source/Broiler.HTML.Image/HtmlContainer.cs
+@@ -287,6 +287,12 @@ public sealed class HtmlContainer : IDisposable
+     /// </summary>
+     public BColor GetRootBackgroundColor() => HtmlContainerInt.GetRootBackgroundColor();
+ 
++    /// <summary>
++    /// The computed <c>color-scheme</c> of the document's root element. A frame's canvas is
++    /// transparent unless this differs from the embedding element's (CSS Color Adjust §2.4).
++    /// </summary>
++    public string? GetRootColorScheme() => HtmlContainerInt.GetRootColorScheme();
++
+     public void Dispose() => HtmlContainerInt.Dispose();
+ 
+     private static ControlAdapter CreateControl(PointF mouseLocation, bool leftButton, bool rightButton) =>
+diff --git a/Source/Broiler.HTML.Image/HtmlRender.cs b/Source/Broiler.HTML.Image/HtmlRender.cs
+index 98fddd5..ef83673 100644
+--- a/Source/Broiler.HTML.Image/HtmlRender.cs
++++ b/Source/Broiler.HTML.Image/HtmlRender.cs
+@@ -283,7 +283,18 @@ public static class HtmlRender
+             if (backgroundColor is null)
+                 bgColor = ResolveCanvasBackground(container, bgColor);
+ 
+-            bitmap.Erase(bgColor);
++            // CSS Color Adjust §2.4: a nested browsing context whose used colour scheme matches its
++            // embedding element's has a *transparent* canvas — no UA backdrop — so the embedder
++            // shows through wherever the document propagates no background of its own. Erasing to
++            // transparent is what leaves it showing: the frame composites over the page rather than
++            // replacing it (see BlitOnto). A background the document really does propagate is
++            // painted by PaintWalker.EmitCanvasBackground either way, so only the UA's own backdrop
++            // is dropped here. Nothing pinned means "not embedded", so a top-level document erases
++            // to its resolved canvas colour exactly as before.
++            bitmap.Erase(
++                Broiler.Layout.Engine.EmbeddedCanvas.PaintsOpaqueBackdrop(container.GetRootColorScheme())
++                    ? bgColor
++                    : BColor.Transparent);
+ 
+             var clip = new RectangleF(0, 0, width, height);
+             container.PerformLayout(bitmap, clip);
+@@ -340,6 +351,13 @@ public static class HtmlRender
+ 
+             if (dw > 0 && dh > 0 && fitsAllocation)
+             {
++                // CSS Color Adjust §2.4: whether this frame's canvas is opaque is decided against
++                // *this element's* used colour scheme, not the containing document's — an <iframe>
++                // may carry its own `color-scheme`, and WPT
++                // color-scheme-iframe-background(-mismatch-opaque-cross-origin-003) turn on exactly
++                // that distinction. Scoped to this frame's render, so sibling and nested frames
++                // each compare against their own embedding element.
++                using var embedded = Broiler.Layout.Engine.EmbeddedCanvas.Pin(fragment.Style.ColorScheme);
+                 using var sub = RenderToImageCore(
+                     fragment.EmbeddedDocumentHtml, dw, dh,
+                     backgroundColor: null,          // resolve the embedded document's own canvas background
+@@ -355,8 +373,14 @@ public static class HtmlRender
+             CompositeEmbeddedDocuments(child, target, stylesheetLoad, imageLoad, embedDepth);
+     }
+ 
+-    /// <summary>Copies <paramref name="source"/> onto <paramref name="target"/> at
+-    /// (<paramref name="destX"/>, <paramref name="destY"/>), clipped to the target.</summary>
++    /// <summary>Composites <paramref name="source"/> onto <paramref name="target"/> at
++    /// (<paramref name="destX"/>, <paramref name="destY"/>), clipped to the target.
++    /// <para>
++    /// Source-over rather than a copy, because a frame's canvas may legitimately be transparent
++    /// (CSS Color Adjust §2.4): copying would punch the embedder out instead of letting it show
++    /// through. A fully opaque frame — every frame, before that rule was modelled — still takes the
++    /// copy path, so this is byte-identical for one.
++    /// </para></summary>
+     private static void BlitOnto(BBitmap target, BBitmap source, int destX, int destY)
+     {
+         for (int y = 0; y < source.Height; y++)
+@@ -369,11 +393,38 @@ public static class HtmlRender
+                 int tx = destX + x;
+                 if ((uint)tx >= (uint)target.Width)
+                     continue;
+-                target.SetPixel(tx, ty, source.GetPixel(x, y));
++                target.SetPixel(tx, ty, BlendOver(source.GetPixel(x, y), target.GetPixel(tx, ty)));
+             }
+         }
+     }
+ 
++    /// <summary>
++    /// Porter-Duff source-over of <paramref name="source"/> onto <paramref name="destination"/>,
++    /// on straight (non-premultiplied) alpha.
++    /// </summary>
++    private static BColor BlendOver(BColor source, BColor destination)
++    {
++        if (source.A == 255 || destination.A == 0)
++            return source;
++        if (source.A == 0)
++            return destination;
++
++        float sa = source.A / 255f;
++        float da = destination.A / 255f;
++        float outA = sa + da * (1f - sa);
++        if (outA <= 0f)
++            return BColor.Transparent;
++
++        byte Channel(byte s, byte d) =>
++            (byte)Math.Clamp((int)Math.Round((s * sa + d * da * (1f - sa)) / outA), 0, 255);
++
++        return BColor.FromArgb(
++            (byte)Math.Clamp((int)Math.Round(outA * 255f), 0, 255),
++            Channel(source.R, destination.R),
++            Channel(source.G, destination.G),
++            Channel(source.B, destination.B));
++    }
++
+     private static BBitmap RenderToImageAutoSizedCore(string html, int maxWidth, int maxHeight,
+         BColor? backgroundColor,
+         HtmlStyleSet styleSet,
+diff --git a/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs b/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
+index 5c592ef..cc65aba 100644
+--- a/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
++++ b/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
+@@ -237,6 +237,26 @@ public sealed class HtmlContainerInt : IHtmlContainerInt, IDisposable
+         return BColor.Empty;
+     }
+ 
++    /// <summary>
++    /// The computed <c>color-scheme</c> of the document's root element, or <c>null</c> when there
++    /// is no root box. A frame's canvas opacity is decided by comparing this with the embedding
++    /// element's (CSS Color Adjust §2.4, Broiler.Layout.Engine.EmbeddedCanvas), and the caller
++    /// rasterising the frame has no other way to reach it.
++    /// </summary>
++    public string? GetRootColorScheme()
++    {
++        if (Root == null)
++            return null;
++
++        foreach (var child in Root.Boxes)
++        {
++            if (string.Equals(child.HtmlTag?.Name, "html", StringComparison.OrdinalIgnoreCase))
++                return child.ColorScheme;
++        }
++
++        return null;
++    }
++
+     // CSS Color Adjust §2.3: the UA dark canvas backdrop colour Chromium paints
+     // for a dark used color scheme.
+     private static readonly BColor CanvasDarkBackdrop = BColor.FromArgb(255, 18, 18, 18);
+diff --git a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs
+index 4bae763..bdeb5e9 100644
+--- a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs
++++ b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs
+@@ -57,7 +57,12 @@ internal static partial class PaintWalker
+         // *translucent* propagated background composites against, so carry it
+         // down to EmitCanvasBackgroundLayers rather than assuming white there.
+         BColor canvasBackdrop = Broiler.Layout.Engine.CanvasBackdrop.Current ?? BColor.White;
+-        if (RootUsesDarkColorScheme(root))
++        // §2.4: a nested browsing context's canvas is transparent unless its used colour
++        // scheme differs from its embedding element's, so a dark frame inside a dark-scheme
++        // <iframe> paints no backdrop at all and the embedder shows through it. Nothing pinned
++        // means "not embedded", so a top-level document keeps painting its backdrop as before.
++        if (RootUsesDarkColorScheme(root)
++            && Broiler.Layout.Engine.EmbeddedCanvas.PaintsOpaqueBackdrop(RootColorScheme(root)))
+         {
+             canvasBackdrop = DarkCanvasColor;
+             items.Add(new FillRectItem { Bounds = viewport, Color = DarkCanvasColor });
+@@ -325,6 +330,15 @@ internal static partial class PaintWalker
+     // Chromium paints for a dark used color scheme (rgb(18, 18, 18)).
+     private static readonly BColor DarkCanvasColor = BColor.FromArgb(255, 18, 18, 18);
+ 
++    /// <summary>
++    /// The document root element's computed <c>color-scheme</c> — the value the canvas is
++    /// governed by. <c>root</c> may be the <c>html</c> fragment itself or a synthetic parent,
++    /// so the lookup is the one <see cref="RootUsesDarkColorScheme"/> performs, named once so
++    /// that the darkness test and the opacity decision cannot read different elements.
++    /// </summary>
++    private static string? RootColorScheme(Fragment root) =>
++        (FindFragmentByTag(root, "html") ?? FindFirstBlockChild(root) ?? root).Style.ColorScheme;
++
+     /// <summary>
+     /// CSS Color Adjust §2.2–2.3: whether the document root element's used
+     /// color scheme is <c>dark</c>, which makes the canvas backdrop dark.
+-- 
+2.43.0
+

--- a/patches/0005-html-border-bevel.patch
+++ b/patches/0005-html-border-bevel.patch
@@ -1,0 +1,116 @@
+From 32bf19f400b3ddbb56ebe33ce4740409e619fdd2 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Wed, 12 Aug 2026 12:56:22 +0000
+Subject: [PATCH] Shade an inset/outset border into a bevel instead of four
+ flat sides
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CSS 2.1 §8.5.3: `inset` and `outset` paint two sides in a darkened shade of the
+border colour and two in the colour itself. The IR paint path used the border
+colour flat on all four sides, so every bevelled border rendered as a plain box —
+including the one the HTML Standard puts on every `<iframe>` and `<hr>`,
+`border: 2px inset`, which browsers paint #9A9A9A over #EEEEEE and Broiler
+painted solid black.
+
+The shading itself is Broiler.Layout.Engine.BorderBevel in the main repository,
+where its numbers are covered by tests; this patch is the call and the UA
+stylesheet's base colour.
+
+The spec leaves the shades to the UA, so the rule was measured off Chromium
+rather than guessed: the darkened side scales all three channels by the factor
+that takes the largest one down by 0.33 of full intensity — keeping the hue, so
+rgb(200,100,50) darkens to rgb(116,58,29) rather than the rgb(116,16,0) a
+per-channel subtraction would give — and the lit side is the colour itself,
+except black, whose lit side is #545454 so that a black bevel is still a bevel.
+
+CssDefaults carries the other half. CSS makes the initial border-color
+`currentColor`, which bevels black-on-black, and browsers substitute a light grey
+so the bevel is visible; Broiler states that grey in the UA stylesheet instead.
+`hr` already did exactly this, with the *result* of the bevel hard-coded per side
+(#9A9A9A top/left, #EEEEEE bottom/right) — that becomes a single
+`border-color: #EEEEEE` now the engine derives the pair, and `iframe` gets the
+same base. Rendering is unchanged for `hr` and matches Chromium exactly for
+`iframe`.
+
+groove and ridge are untouched. They split each side lengthwise into two shades —
+a 16px grey groove paints its outer half #2C2C2C and its inner half #808080,
+where inset paints the whole width #2C2C2C — which needs two rectangles per side
+rather than one colour per side.
+
+Verified across 665 tests of html/rendering and
+html/semantics/embedded-content/the-iframe-element: 89 changed, every one of them
+an improvement, none worse, and one more passing. With the frame-canvas patch
+alongside it, css/css-color-adjust/rendering/dark-color-scheme goes to 25 of 29
+and color-scheme-iframe-background reaches 99.4% from 69.0%.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ Source/Broiler.HTML.Core/CssDefaults.cs       |  8 +++++--
+ .../IR/PaintWalker.Decorations.cs             | 23 +++++++++++++++----
+ 2 files changed, 25 insertions(+), 6 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Core/CssDefaults.cs b/Source/Broiler.HTML.Core/CssDefaults.cs
+index f2ac049..5c782e1 100644
+--- a/Source/Broiler.HTML.Core/CssDefaults.cs
++++ b/Source/Broiler.HTML.Core/CssDefaults.cs
+@@ -117,7 +117,7 @@ internal static class CssDefaults
+            directly in DomParser (TranslateAttributes / ApplyTableBorder), not
+            here, and author CSS is left to win normally. */
+         /* Replaced inline elements — WHATWG default rendering */
+-        iframe          { border: 2px inset; display: inline-block }
++        iframe          { border: 2px inset #EEEEEE; display: inline-block }
+         object          { display: inline-block }
+ 
+         /* HTML5 semantic/sectioning elements – display:block per WHATWG */
+@@ -148,7 +148,11 @@ internal static class CssDefaults
+         script, link,
+         meta, area,
+         base, param     { display:none }
+-        hr              { border-top-color: #9A9A9A; border-left-color: #9A9A9A; border-bottom-color: #EEEEEE; border-right-color: #EEEEEE; }
++        /* The bevel base, not the bevel: Engine.BorderBevel darkens the top and left of an
++           `inset` border, turning this into the #9A9A9A/#EEEEEE pair browsers paint. CSS makes
++           the initial border-color `currentColor`, which bevels black-on-black; every engine
++           substitutes a light grey, and stating it here is how Broiler does that. */
++        hr              { border-color: #EEEEEE; }
+         pre             { font-size: 10pt; margin-top: 15px; }
+         
+         /*This is the background of the HtmlToolTip*/
+diff --git a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Decorations.cs b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Decorations.cs
+index 71b0e17..90bd0e6 100644
+--- a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Decorations.cs
++++ b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Decorations.cs
+@@ -534,10 +534,25 @@ internal static partial class PaintWalker
+             {
+                 Bounds = rect,
+                 Widths = border,
+-                TopColor = hasTop ? style.ActualBorderTopColor : BColor.Empty,
+-                RightColor = (hasRight && isLast) ? style.ActualBorderRightColor : BColor.Empty,
+-                BottomColor = hasBottom ? style.ActualBorderBottomColor : BColor.Empty,
+-                LeftColor = (hasLeft && isFirst) ? style.ActualBorderLeftColor : BColor.Empty,
++                // CSS 2.1 §8.5.3: `inset`/`outset` paint a bevel — two sides darkened, two lit —
++                // rather than four flat sides. Any other style passes the colour through
++                // untouched (Broiler.Layout.Engine.BorderBevel).
++                TopColor = hasTop
++                    ? Broiler.Layout.Engine.BorderBevel.SideColor(
++                        style.BorderTopStyle, isTopOrLeft: true, style.ActualBorderTopColor)
++                    : BColor.Empty,
++                RightColor = (hasRight && isLast)
++                    ? Broiler.Layout.Engine.BorderBevel.SideColor(
++                        style.BorderRightStyle, isTopOrLeft: false, style.ActualBorderRightColor)
++                    : BColor.Empty,
++                BottomColor = hasBottom
++                    ? Broiler.Layout.Engine.BorderBevel.SideColor(
++                        style.BorderBottomStyle, isTopOrLeft: false, style.ActualBorderBottomColor)
++                    : BColor.Empty,
++                LeftColor = (hasLeft && isFirst)
++                    ? Broiler.Layout.Engine.BorderBevel.SideColor(
++                        style.BorderLeftStyle, isTopOrLeft: true, style.ActualBorderLeftColor)
++                    : BColor.Empty,
+                 // Style kept for Phase 1 backward compat; per-side styles are authoritative
+                 Style = style.BorderTopStyle ?? "solid",
+                 TopStyle = style.BorderTopStyle ?? "none",
+-- 
+2.43.0
+

--- a/patches/0005-html-border-bevel.patch
+++ b/patches/0005-html-border-bevel.patch
@@ -1,55 +1,62 @@
-From 32bf19f400b3ddbb56ebe33ce4740409e619fdd2 Mon Sep 17 00:00:00 2001
+From abf82af2445973298a415e69207fac8cebf3e67d Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
-Date: Wed, 12 Aug 2026 12:56:22 +0000
-Subject: [PATCH] Shade an inset/outset border into a bevel instead of four
- flat sides
+Date: Wed, 12 Aug 2026 13:38:46 +0000
+Subject: [PATCH] Paint the four 3D border styles as bevels instead of flat
+ sides
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
-CSS 2.1 §8.5.3: `inset` and `outset` paint two sides in a darkened shade of the
-border colour and two in the colour itself. The IR paint path used the border
-colour flat on all four sides, so every bevelled border rendered as a plain box —
-including the one the HTML Standard puts on every `<iframe>` and `<hr>`,
-`border: 2px inset`, which browsers paint #9A9A9A over #EEEEEE and Broiler
-painted solid black.
+CSS 2.1 §8.5.3: `inset`, `outset`, `groove` and `ridge` shade a border into a
+bevel — two sides darkened and two lit — rather than painting the border colour
+flat on all four. The IR paint path did the latter, so every bevelled border
+rendered as a plain box, including the one the HTML Standard puts on every
+`<iframe>` and `<hr>` (`border: 2px inset`, which browsers paint #9A9A9A over
+#EEEEEE and Broiler painted solid black) and the `border: 2px groove` it puts on
+every `<fieldset>`.
 
-The shading itself is Broiler.Layout.Engine.BorderBevel in the main repository,
+The shading rule is Broiler.Layout.Engine.BorderBevel in the main repository,
 where its numbers are covered by tests; this patch is the call and the UA
 stylesheet's base colour.
 
-The spec leaves the shades to the UA, so the rule was measured off Chromium
-rather than guessed: the darkened side scales all three channels by the factor
-that takes the largest one down by 0.33 of full intensity — keeping the hue, so
-rgb(200,100,50) darkens to rgb(116,58,29) rather than the rgb(116,16,0) a
+The spec leaves the shades to the UA, so everything here was measured off
+Chromium rather than guessed. The darkened side scales all three channels by the
+factor that takes the largest one down by 0.33 of full intensity — keeping the
+hue, so rgb(200,100,50) darkens to rgb(116,58,29) rather than the rgb(116,16,0) a
 per-channel subtraction would give — and the lit side is the colour itself,
-except black, whose lit side is #545454 so that a black bevel is still a bevel.
+except black, whose lit side is #545454 so a black bevel is still a bevel.
 
-CssDefaults carries the other half. CSS makes the initial border-color
-`currentColor`, which bevels black-on-black, and browsers substitute a light grey
-so the bevel is visible; Broiler states that grey in the UA stylesheet instead.
-`hr` already did exactly this, with the *result* of the bevel hard-coded per side
-(#9A9A9A top/left, #EEEEEE bottom/right) — that becomes a single
-`border-color: #EEEEEE` now the engine derives the pair, and `iframe` gets the
-same base. Rendering is unchanged for `hr` and matches Chromium exactly for
+`groove` and `ridge` carry those same two shades but split each side lengthwise,
+so a side is emitted as two nested rings: a groove reads as `inset` on its outer
+half and `outset` on its inner half, and a ridge is the mirror. The split sits at
+ceil(width / 2) from the outer edge — a 3px groove is two dark rows then one
+light, a 5px one is three then two — and below 2px there is no room for two
+halves, where Chromium paints a single stroke of the lit shade on all four sides.
+Every other style has an outer "half" that is the whole side and an empty inner
+one, so it still emits exactly the one item it always did.
+
+CssDefaults carries the other half of the `inset` case. CSS makes the initial
+border-color `currentColor`, which bevels black-on-black, and browsers substitute
+a light grey so the bevel is visible; Broiler states that grey in the UA
+stylesheet instead. `hr` already did exactly this, with the *result* of the bevel
+hard-coded per side (#9A9A9A top/left, #EEEEEE bottom/right) — that becomes a
+single `border-color: #EEEEEE` now the engine derives the pair, and `iframe` gets
+the same base. Rendering is unchanged for `hr` and matches Chromium exactly for
 `iframe`.
 
-groove and ridge are untouched. They split each side lengthwise into two shades —
-a 16px grey groove paints its outer half #2C2C2C and its inner half #808080,
-where inset paints the whole width #2C2C2C — which needs two rectangles per side
-rather than one colour per side.
-
-Verified across 665 tests of html/rendering and
-html/semantics/embedded-content/the-iframe-element: 89 changed, every one of them
-an improvement, none worse, and one more passing. With the frame-canvas patch
-alongside it, css/css-color-adjust/rendering/dark-color-scheme goes to 25 of 29
-and color-scheme-iframe-background reaches 99.4% from 69.0%.
+Verified across 1 127 tests of html/rendering, css/css-gaps and
+html/semantics/embedded-content/the-iframe-element. The inset/outset half changed
+89 of them, every one an improvement and one more passing; the groove/ridge half
+changed five more, again all improvements, the largest being fieldset-vertical at
++0.67 points. Nothing regressed in either. Directly against Chromium, a page of
+groove and ridge boxes matches to 99.95%, the residual being corner-miter
+antialiasing that a plain four-colour solid border shows too.
 
 Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
 ---
- Source/Broiler.HTML.Core/CssDefaults.cs       |  8 +++++--
- .../IR/PaintWalker.Decorations.cs             | 23 +++++++++++++++----
- 2 files changed, 25 insertions(+), 6 deletions(-)
+ Source/Broiler.HTML.Core/CssDefaults.cs       |  8 +-
+ .../IR/PaintWalker.Decorations.cs             | 92 +++++++++++++++----
+ 2 files changed, 80 insertions(+), 20 deletions(-)
 
 diff --git a/Source/Broiler.HTML.Core/CssDefaults.cs b/Source/Broiler.HTML.Core/CssDefaults.cs
 index f2ac049..5c782e1 100644
@@ -78,39 +85,116 @@ index f2ac049..5c782e1 100644
          
          /*This is the background of the HtmlToolTip*/
 diff --git a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Decorations.cs b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Decorations.cs
-index 71b0e17..90bd0e6 100644
+index 71b0e17..047b854 100644
 --- a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Decorations.cs
 +++ b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Decorations.cs
-@@ -534,10 +534,25 @@ internal static partial class PaintWalker
+@@ -3,6 +3,7 @@ using System.Collections.Generic;
+ using System.Drawing;
+ using Broiler.Graphics;
+ using Broiler.Layout.IR;
++using Bevel = Broiler.Layout.Engine.BorderBevel;
+ 
+ 
+ namespace Broiler.HTML.Orchestration.IR;
+@@ -530,25 +531,80 @@ internal static partial class PaintWalker
+             bool isFirst = i == 0;
+             bool isLast = i == rects.Count - 1;
+ 
+-            items.Add(new DrawBorderItem
++            // CSS 2.1 §8.5.3: a bevelled border is not four flat sides.  `inset`/`outset` shade
++            // two sides down and light the other two; `groove`/`ridge` carry the same two shades
++            // but split each side lengthwise, so they paint as two nested rings.  Every other
++            // style has an outer "half" that is the whole side and an empty inner one, which
++            // leaves it emitting exactly the one item it always did.  The rule, and which half
++            // gets which shade, is Broiler.Layout.Engine.BorderBevel.
++            var outerWidths = new BoxEdges(
++                Bevel.HalfWidth(style.BorderTopStyle, border.Top, outerHalf: true),
++                Bevel.HalfWidth(style.BorderRightStyle, border.Right, outerHalf: true),
++                Bevel.HalfWidth(style.BorderBottomStyle, border.Bottom, outerHalf: true),
++                Bevel.HalfWidth(style.BorderLeftStyle, border.Left, outerHalf: true));
++
++            for (int half = 0; half < 2; half++)
              {
-                 Bounds = rect,
-                 Widths = border,
+-                Bounds = rect,
+-                Widths = border,
 -                TopColor = hasTop ? style.ActualBorderTopColor : BColor.Empty,
 -                RightColor = (hasRight && isLast) ? style.ActualBorderRightColor : BColor.Empty,
 -                BottomColor = hasBottom ? style.ActualBorderBottomColor : BColor.Empty,
 -                LeftColor = (hasLeft && isFirst) ? style.ActualBorderLeftColor : BColor.Empty,
-+                // CSS 2.1 §8.5.3: `inset`/`outset` paint a bevel — two sides darkened, two lit —
-+                // rather than four flat sides. Any other style passes the colour through
-+                // untouched (Broiler.Layout.Engine.BorderBevel).
-+                TopColor = hasTop
-+                    ? Broiler.Layout.Engine.BorderBevel.SideColor(
-+                        style.BorderTopStyle, isTopOrLeft: true, style.ActualBorderTopColor)
-+                    : BColor.Empty,
-+                RightColor = (hasRight && isLast)
-+                    ? Broiler.Layout.Engine.BorderBevel.SideColor(
-+                        style.BorderRightStyle, isTopOrLeft: false, style.ActualBorderRightColor)
-+                    : BColor.Empty,
-+                BottomColor = hasBottom
-+                    ? Broiler.Layout.Engine.BorderBevel.SideColor(
-+                        style.BorderBottomStyle, isTopOrLeft: false, style.ActualBorderBottomColor)
-+                    : BColor.Empty,
-+                LeftColor = (hasLeft && isFirst)
-+                    ? Broiler.Layout.Engine.BorderBevel.SideColor(
-+                        style.BorderLeftStyle, isTopOrLeft: true, style.ActualBorderLeftColor)
-+                    : BColor.Empty,
-                 // Style kept for Phase 1 backward compat; per-side styles are authoritative
-                 Style = style.BorderTopStyle ?? "solid",
-                 TopStyle = style.BorderTopStyle ?? "none",
+-                // Style kept for Phase 1 backward compat; per-side styles are authoritative
+-                Style = style.BorderTopStyle ?? "solid",
+-                TopStyle = style.BorderTopStyle ?? "none",
+-                RightStyle = (isLast) ? (style.BorderRightStyle ?? "none") : "none",
+-                BottomStyle = style.BorderBottomStyle ?? "none",
+-                LeftStyle = (isFirst) ? (style.BorderLeftStyle ?? "none") : "none",
+-                CornerNw = style.ActualCornerNw,
+-                CornerNe = style.ActualCornerNe,
+-                CornerSe = style.ActualCornerSe,
+-                CornerSw = style.ActualCornerSw,
+-            });
++                bool outerHalf = half == 0;
++                var widths = outerHalf
++                    ? outerWidths
++                    : new BoxEdges(
++                        Bevel.HalfWidth(style.BorderTopStyle, border.Top, outerHalf: false),
++                        Bevel.HalfWidth(style.BorderRightStyle, border.Right, outerHalf: false),
++                        Bevel.HalfWidth(style.BorderBottomStyle, border.Bottom, outerHalf: false),
++                        Bevel.HalfWidth(style.BorderLeftStyle, border.Left, outerHalf: false));
++
++                if (widths.Top <= 0 && widths.Right <= 0 && widths.Bottom <= 0 && widths.Left <= 0)
++                    continue;
++
++                // The inner ring sits inside the outer one, so its box is the border box pulled in
++                // by the outer half and its corner radii shrink by the same amount.
++                var bounds = outerHalf
++                    ? rect
++                    : new RectangleF(
++                        rect.X + (float)outerWidths.Left,
++                        rect.Y + (float)outerWidths.Top,
++                        rect.Width - (float)(outerWidths.Left + outerWidths.Right),
++                        rect.Height - (float)(outerWidths.Top + outerWidths.Bottom));
++
++                if (bounds.Width <= 0 || bounds.Height <= 0)
++                    continue;
++
++                double InnerRadius(double radius, double inset) =>
++                    outerHalf ? radius : Math.Max(0, radius - inset);
++
++                items.Add(new DrawBorderItem
++                {
++                    Bounds = bounds,
++                    Widths = widths,
++                    TopColor = hasTop
++                        ? Bevel.HalfColor(style.BorderTopStyle, isTopOrLeft: true,
++                            style.ActualBorderTopColor, border.Top, outerHalf)
++                        : BColor.Empty,
++                    RightColor = (hasRight && isLast)
++                        ? Bevel.HalfColor(style.BorderRightStyle, isTopOrLeft: false,
++                            style.ActualBorderRightColor, border.Right, outerHalf)
++                        : BColor.Empty,
++                    BottomColor = hasBottom
++                        ? Bevel.HalfColor(style.BorderBottomStyle, isTopOrLeft: false,
++                            style.ActualBorderBottomColor, border.Bottom, outerHalf)
++                        : BColor.Empty,
++                    LeftColor = (hasLeft && isFirst)
++                        ? Bevel.HalfColor(style.BorderLeftStyle, isTopOrLeft: true,
++                            style.ActualBorderLeftColor, border.Left, outerHalf)
++                        : BColor.Empty,
++                    // Style kept for Phase 1 backward compat; per-side styles are authoritative
++                    Style = style.BorderTopStyle ?? "solid",
++                    TopStyle = style.BorderTopStyle ?? "none",
++                    RightStyle = (isLast) ? (style.BorderRightStyle ?? "none") : "none",
++                    BottomStyle = style.BorderBottomStyle ?? "none",
++                    LeftStyle = (isFirst) ? (style.BorderLeftStyle ?? "none") : "none",
++                    CornerNw = InnerRadius(style.ActualCornerNw, outerWidths.Left),
++                    CornerNe = InnerRadius(style.ActualCornerNe, outerWidths.Right),
++                    CornerSe = InnerRadius(style.ActualCornerSe, outerWidths.Right),
++                    CornerSw = InnerRadius(style.ActualCornerSw, outerWidths.Left),
++                });
++            }
+         }
+     }
+ 
 -- 
 2.43.0
 

--- a/patches/0006-html-border-miter.patch
+++ b/patches/0006-html-border-miter.patch
@@ -1,0 +1,241 @@
+From a736053403cafe8d460667698f2533a53d363d14 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Wed, 12 Aug 2026 14:25:59 +0000
+Subject: [PATCH] Mitre a border's corners and anti-alias the diagonal
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CSS 2.1 §8.5.4 divides a border at its corners by a straight line. Two things
+here did not.
+
+A stroke has no mitre. Only `solid` was painted as a trapezoid; `inset`,
+`outset`, `groove` and `ridge` were stroked along their centre lines with a plain
+solid pen, which butts square into the neighbouring side, so whichever side was
+drawn last owned the whole corner. That is invisible while the two sides share a
+colour and glaring when they do not — which is exactly what the 3D styles do,
+since a groove puts a darkened top against a lit right. They now take the same
+trapezoid path, which draws the same band and mitres it properly.
+
+The mitre itself was a staircase. Filled by testing each pixel's centre, the
+diagonal steps one pixel per row where a browser lays one blended pixel along it.
+Broiler.Layout.Engine.BorderAntialiasing is the coverage rule — the area of the
+pixel the trapezoid actually covers — and the border path pins it around the four
+sides. It is opt-in for a reason: two trapezoids meeting along a mitre each cover
+about half of the pixels on it, so blended independently onto the page they leave
+the background showing through the seam. The corner fill that already existed for
+same-coloured sides now runs for every corner, filling it with the colour of
+whichever side is drawn first, so the second blends over an opaque corner instead.
+
+Only the mitres are blended. The first attempt anti-aliased every edge of the
+trapezoid and regressed 210 tests, five of them from passing — a border's own
+edges are straight lines the layout puts where it puts them, and feathering those
+turns a 1px form-control border sitting on a half-pixel into two grey rows
+instead of one solid one. Axis-aligned edges keep the pixel-centre test they
+always had; only the diagonals carry coverage.
+
+Measured against Chromium directly: a 12px four-colour border's corners go from
+48 differing pixels to 12 (the rest differing by 1/255), and the corner pixel now
+matches exactly — rgb(255,83,0) where red meets orange. A page of groove and
+ridge boxes goes from 425 differing pixels to 21. An unequal corner is handled by
+the same rule rather than a special case for 45°: a 12px top against a 4px left
+slopes one-in-three, and the coverages come out 1/6, 1/2, 5/6 against Chromium's
+measured 0.158, 0.503, 0.842.
+
+Across 1949 tests of css/css-backgrounds, html/rendering, css/css-gaps and the
+dark-color-scheme directory: no test changes state in either direction, and the
+net is +1.578 points — +1.707 across 55 tests against -0.129 across 103, where
+only one test loses more than a hundredth of a point and none loses more than a
+tenth. Those small losses are mitre pixels rounding the other way from Chromium's.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ Source/Broiler.HTML.Image/BCanvas.cs          | 26 ++++++-
+ .../IR/RGraphicsRasterBackend.cs              | 78 +++++++++++++++----
+ 2 files changed, 85 insertions(+), 19 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Image/BCanvas.cs b/Source/Broiler.HTML.Image/BCanvas.cs
+index f95d901..9aef6a8 100644
+--- a/Source/Broiler.HTML.Image/BCanvas.cs
++++ b/Source/Broiler.HTML.Image/BCanvas.cs
+@@ -362,6 +362,13 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+         if (!NarrowToClip(ref startX, ref startY, ref endX, ref endY))
+             return;
+ 
++        // A border side's mitres are anti-aliased; its own axis-aligned edges, and every other
++        // polygon, are filled by testing the pixel centre as they always have been. See
++        // Broiler.Layout.Engine.BorderAntialiasing for why this is a lever the border path pins
++        // rather than the rasteriser's default: two shapes sharing an edge, each blended
++        // independently, leave the background showing through the seam.
++        bool antialias = Broiler.Layout.Engine.BorderAntialiasing.Active;
++
+         ForEachBand(startY, endY, startX, endX, (fromY, toY) =>
+         {
+             for (int y = fromY; y <= toY; y++)
+@@ -371,8 +378,23 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+                     if (!IsVisible(x, y))
+                         continue;
+ 
+-                    if (ContainsPolygonPoint(translated, x + 0.5f, y + 0.5f))
+-                        BlendPixel(CurrentTarget, x, y, color, blendMode: "normal");
++                    if (!antialias)
++                    {
++                        if (ContainsPolygonPoint(translated, x + 0.5f, y + 0.5f))
++                            BlendPixel(CurrentTarget, x, y, color, blendMode: "normal");
++                        continue;
++                    }
++
++                    float coverage = Broiler.Layout.Engine.BorderAntialiasing.Coverage(translated, x, y);
++                    if (coverage <= 0f)
++                        continue;
++
++                    var covered = coverage >= 1f
++                        ? color
++                        : BColor.FromArgb((byte)Math.Clamp((int)Math.Round(color.A * coverage), 0, 255),
++                            color.R, color.G, color.B);
++                    if (covered.A > 0)
++                        BlendPixel(CurrentTarget, x, y, covered, blendMode: "normal");
+                 }
+             }
+         });
+diff --git a/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs b/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs
+index 28f38e0..255103b 100644
+--- a/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs
++++ b/Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs
+@@ -353,10 +353,19 @@ internal sealed class RGraphicsRasterBackend : IRasterBackend
+         // rendering with anti-aliasing enabled produces the
+         // correct CSS 2.1 Appendix E paint order.
+ 
+-        // Fill corner rectangles to prevent anti-aliased seams along
+-        // the diagonal edges where two same-color border trapezoids meet.
++        // Fill corner rectangles to prevent anti-aliased seams along the diagonal edges where two
++        // border trapezoids meet: the second one drawn blends its mitre over an already opaque
++        // corner instead of over the page, which is what keeps the background out of the seam.
+         FillBorderCorners(g, item);
+ 
++        // The mitres are the only part of a border that is not axis-aligned, and filling them by
++        // pixel centre steps them into a staircase. Anti-alias them — but only when every side that
++        // is drawn is opaque, since the corner fill above is what makes blending safe and it cannot
++        // run for a translucent side without compositing it twice.
++        using var antialias = AllDrawnSidesAreOpaque(item)
++            ? Broiler.Layout.Engine.BorderAntialiasing.Pin()
++            : null;
++
+         // Top border
+         if (widths.Top > 0 && item.TopColor.A > 0 && IsBorderStyleVisible(item.TopStyle))
+         {
+@@ -364,7 +373,7 @@ internal sealed class RGraphicsRasterBackend : IRasterBackend
+             {
+                 DrawDoubleBorderSide(g, item, Border.Top);
+             }
+-            else if (item.TopStyle == "solid")
++            else if (UsesMitredTrapezoid(item.TopStyle))
+             {
+                 // Trapezoid rendering for correct corner joins with asymmetric widths
+                 var pts = new PointF[4];
+@@ -388,7 +397,7 @@ internal sealed class RGraphicsRasterBackend : IRasterBackend
+             {
+                 DrawDoubleBorderSide(g, item, Border.Left);
+             }
+-            else if (item.LeftStyle == "solid")
++            else if (UsesMitredTrapezoid(item.LeftStyle))
+             {
+                 var pts = new PointF[4];
+                 pts[0] = new PointF(bounds.Left, bounds.Top);
+@@ -411,7 +420,7 @@ internal sealed class RGraphicsRasterBackend : IRasterBackend
+             {
+                 DrawDoubleBorderSide(g, item, Border.Bottom);
+             }
+-            else if (item.BottomStyle == "solid")
++            else if (UsesMitredTrapezoid(item.BottomStyle))
+             {
+                 var pts = new PointF[4];
+                 pts[0] = new PointF((float)(bounds.Left + widths.Left), (float)(bounds.Bottom - widths.Bottom));
+@@ -435,7 +444,7 @@ internal sealed class RGraphicsRasterBackend : IRasterBackend
+             {
+                 DrawDoubleBorderSide(g, item, Border.Right);
+             }
+-            else if (item.RightStyle == "solid")
++            else if (UsesMitredTrapezoid(item.RightStyle))
+             {
+                 var pts = new PointF[4];
+                 pts[0] = new PointF((float)(bounds.Right - widths.Right), (float)(bounds.Top + widths.Top));
+@@ -472,29 +481,64 @@ internal sealed class RGraphicsRasterBackend : IRasterBackend
+         bool hasBottom = widths.Bottom > 0 && item.BottomColor.A == 255 && IsCornerFillBorderStyle(item.BottomStyle);
+         bool hasLeft = widths.Left > 0 && item.LeftColor.A == 255 && IsCornerFillBorderStyle(item.LeftStyle);
+ 
+-        // Top-left corner
+-        if (hasTop && hasLeft && item.TopColor == item.LeftColor)
++        // The fill is the colour of whichever of the two sides is drawn *first* — the sides go top,
++        // left, bottom, right — so the second one's mitre blends over it and the corner ends up the
++        // two colours mixed by coverage rather than either of them over the page. Where the two
++        // agree this is the same rectangle it always was.
++
++        // Top-left corner: top is drawn before left.
++        if (hasTop && hasLeft)
+             g.DrawRectangle(g.GetSolidBrush(item.TopColor),
+                 bounds.Left, bounds.Top, widths.Left, widths.Top);
+ 
+-        // Top-right corner
+-        if (hasTop && hasRight && item.TopColor == item.RightColor)
++        // Top-right corner: top is drawn before right.
++        if (hasTop && hasRight)
+             g.DrawRectangle(g.GetSolidBrush(item.TopColor),
+                 bounds.Right - widths.Right, bounds.Top, widths.Right, widths.Top);
+ 
+-        // Bottom-left corner
+-        if (hasBottom && hasLeft && item.BottomColor == item.LeftColor)
+-            g.DrawRectangle(g.GetSolidBrush(item.BottomColor),
++        // Bottom-left corner: left is drawn before bottom.
++        if (hasBottom && hasLeft)
++            g.DrawRectangle(g.GetSolidBrush(item.LeftColor),
+                 bounds.Left, bounds.Bottom - widths.Bottom, widths.Left, widths.Bottom);
+ 
+-        // Bottom-right corner
+-        if (hasBottom && hasRight && item.BottomColor == item.RightColor)
++        // Bottom-right corner: bottom is drawn before right.
++        if (hasBottom && hasRight)
+             g.DrawRectangle(g.GetSolidBrush(item.BottomColor),
+                 bounds.Right - widths.Right, bounds.Bottom - widths.Bottom, widths.Right, widths.Bottom);
+     }
+ 
+-    private static bool IsCornerFillBorderStyle(string? style) =>
+-        string.Equals(style, "solid", StringComparison.OrdinalIgnoreCase);
++    /// <summary>
++    /// Whether every side this item actually draws is fully opaque. Anti-aliasing a mitre relies on
++    /// the corner fill underneath it, which a translucent side cannot have — it would composite the
++    /// same alpha twice — so such a border keeps the pixel-centre fill it has always had.
++    /// </summary>
++    private static bool AllDrawnSidesAreOpaque(DrawBorderItem item)
++    {
++        var widths = item.Widths;
++        return (widths.Top <= 0 || !IsBorderStyleVisible(item.TopStyle) || item.TopColor.A == 255)
++            && (widths.Right <= 0 || !IsBorderStyleVisible(item.RightStyle) || item.RightColor.A == 255)
++            && (widths.Bottom <= 0 || !IsBorderStyleVisible(item.BottomStyle) || item.BottomColor.A == 255)
++            && (widths.Left <= 0 || !IsBorderStyleVisible(item.LeftStyle) || item.LeftColor.A == 255);
++    }
++
++    private static bool IsCornerFillBorderStyle(string? style) => UsesMitredTrapezoid(style);
++
++    /// <summary>
++    /// Whether a side of this style is painted as a mitred trapezoid rather than stroked along its
++    /// centre line. CSS 2.1 §8.5.4 divides every border at its corners by a straight line, but a
++    /// stroke has no mitre — it butts square into its neighbour, so whichever side is drawn last
++    /// owns the whole corner. That is only invisible while the two sides share a colour, which is
++    /// exactly what the 3D styles do not do: a `groove` puts a darkened top against a lit right.
++    /// They stroke solid (<see cref="CreateBorderPen"/> gives them <c>DashStyle.Solid</c>), so the
++    /// trapezoid draws the same band and mitres it properly. `dashed`, `dotted` and `double` keep
++    /// their own paths, which are about the pattern along the side rather than its ends.
++    /// </summary>
++    private static bool UsesMitredTrapezoid(string? style) =>
++        string.Equals(style, "solid", StringComparison.OrdinalIgnoreCase)
++        || string.Equals(style, "inset", StringComparison.OrdinalIgnoreCase)
++        || string.Equals(style, "outset", StringComparison.OrdinalIgnoreCase)
++        || string.Equals(style, "groove", StringComparison.OrdinalIgnoreCase)
++        || string.Equals(style, "ridge", StringComparison.OrdinalIgnoreCase);
+ 
+     private static void DrawDoubleBorderSide(RGraphics g, DrawBorderItem item, Border side)
+     {
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -91,3 +91,66 @@ on CI today (99.7 %) from the main-repo half of that work —
 `FragmentTreeBuilder.TryLoadEmbeddedDocument`. This patch is the multi-frame
 case, which no test in the current subset covers; nothing regresses while it
 waits.
+
+### `0004-html-embedded-canvas-color-scheme.patch` — `Broiler.HTML`
+
+Three call sites plus one accessor, in
+`Source/Broiler.HTML.Image/HtmlRender.cs`,
+`Source/Broiler.HTML.Orchestration/IR/PaintWalker.CanvasBackground.cs`,
+`Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs` and
+`Source/Broiler.HTML.Image/HtmlContainer.cs`:
+
+- `CompositeEmbeddedDocuments` pins `Broiler.Layout.Engine.EmbeddedCanvas` to the
+  embedding element's computed `color-scheme` around each frame's render;
+- `RenderToImageCore` erases to transparent instead of the resolved canvas colour
+  when the lever says that frame's canvas is transparent;
+- `EmitCanvasBackground` skips its UA dark fill in the same case;
+- `BlitOnto` becomes source-over rather than a copy, since a transparent canvas
+  has to composite over the page instead of punching it out — an opaque source
+  still takes the copy path, so an opaque frame is byte-identical;
+- `GetRootColorScheme` exposes the embedded root's computed value, which the
+  rasterising caller has no other way to reach.
+
+`EmbeddedCanvas` itself is **already in this repository**
+(`Broiler.Layout/Broiler.Layout/Engine/EmbeddedCanvas.cs`), thread-static and
+unpinned by default, so the main repo builds and every render that pins nothing
+is byte-identical to today. So is the `color-scheme` inheritance half
+(`CssBoxProperties.InheritStyle`) and the runner's own frame compositor
+(`WptDocumentRenderer`), which already pins the lever and composites source-over.
+The patch is the renderer's side of the same rule.
+
+CSS Color Adjust 1 §2.4: a nested browsing context's canvas is **transparent** —
+the embedder shows through it — unless the used colour scheme of the *embedding
+element* differs from the embedded root's, in which case the UA paints an opaque
+backdrop of the embedded root's scheme. Only the second half was modelled: an
+embedded document's canvas was always resolved opaque and the blit copied it
+pixel-for-pixel, so a frame could never be transparent and the embedding
+element's `color-scheme` was never consulted at all.
+
+Wanted by two WPT tests that turn on exactly that distinction, both in
+`css/css-color-adjust/rendering/dark-color-scheme`:
+`color-scheme-iframe-background` puts a dark frame in a dark-scheme `<iframe>` on
+a light page and asks for the light page to show through (69.0 % without this),
+and `color-scheme-iframe-background-mismatch-opaque-cross-origin-003.sub` puts a
+light frame in a light-scheme `<iframe>` on a dark page and asks the same
+(94.7 % without this — a 200×200 white box that should not exist). With the patch
+applied they measure 98.9 % and 99.8 %, the directory goes 22 → 24 of 29 with
+nothing lost, and `html/semantics/embedded-content/the-iframe-element` is
+unchanged across all 161 tests. `color-scheme-iframe-background`'s residual 1.1 %
+is a *separate*, pre-existing gap — Broiler paints a black default `<iframe>`
+border where Chromium paints a grey inset one — and it is 100.00 % identical to
+its own `rel=match` reference either way.
+
+**No main-repo fallback, deliberately.** The decision has to be made while the
+frame's own canvas is erased and while its paint walker runs, both inside the
+renderer; the only main-repo lever that reaches that point is
+`RenderToImageWithStyleSet`'s `backgroundColor`, which cannot express
+"transparent" (`BColor.Transparent` and `default(BColor)` are the same value, and
+the renderer reads `default` as "resolve it yourself"). Re-routing the runner's
+frame rendering around `HtmlRender` to work about it would duplicate canvas
+resolution in the runner and still leave the UA dark fill unfixable, which is the
+kind of contortion the repository rule warns against. Until this is applied the
+two tests keep their current scores, and
+`src/Broiler.Cli.Tests/EmbeddedCanvasColorSchemeTests.cs` probes for the fix and
+disarms its four render assertions — they become real guards the moment the
+pointer is bumped.

--- a/patches/README.md
+++ b/patches/README.md
@@ -154,3 +154,60 @@ two tests keep their current scores, and
 `src/Broiler.Cli.Tests/EmbeddedCanvasColorSchemeTests.cs` probes for the fix and
 disarms its four render assertions — they become real guards the moment the
 pointer is bumped.
+
+### `0005-html-border-bevel.patch` — `Broiler.HTML`
+
+Two call-shaped changes, in
+`Source/Broiler.HTML.Orchestration/IR/PaintWalker.Decorations.cs` and
+`Source/Broiler.HTML.Core/CssDefaults.cs`:
+
+- the border display item takes each side's colour from
+  `Broiler.Layout.Engine.BorderBevel.SideColor` instead of using the border
+  colour flat on all four sides;
+- the UA stylesheet states the *base* of the bevel rather than its result —
+  `iframe { border: 2px inset #EEEEEE }`, and `hr`'s four hard-coded per-side
+  colours collapse to one `border-color: #EEEEEE`.
+
+`BorderBevel` itself is **already in this repository**
+(`Broiler.Layout/Broiler.Layout/Engine/BorderBevel.cs`), a pure function with 30
+tests pinning its numbers, so the main repo builds and — because nothing calls it
+until this patch lands — renders byte-identically to today.
+
+CSS 2.1 §8.5.3 paints `inset` and `outset` as a bevel: two sides in a darkened
+shade of the border colour, two in the colour itself. The IR paint path used the
+colour flat on every side, so the border the HTML Standard puts on every
+`<iframe>` and `<hr>` — `border: 2px inset`, which browsers paint `#9A9A9A` over
+`#EEEEEE` — came out solid black.
+
+The spec leaves the shades to the UA, so the rule was **measured off Chromium**
+rather than guessed. The darkened side scales all three channels by the factor
+that takes the largest one down by 0.33 of full intensity, which is what keeps
+the hue: `rgb(200,100,50)` → `rgb(116,58,29)`, all ×0.58, where a per-channel
+subtraction would give `rgb(116,16,0)` and turn brown into red. The lit side is
+the colour itself, except black, whose lit side is `#545454` so a black bevel is
+still a bevel.
+
+**Why the UA stylesheet carries the colour.** CSS makes the initial
+`border-color` `currentColor`, which bevels black-on-black; browsers substitute a
+light grey at paint time so the bevel is visible. Broiler states that grey in the
+UA stylesheet instead — which is what `hr` already did, with the *result* of the
+bevel hard-coded per side. The rendering matches Chromium; the computed
+`border-color` differs from it (`#EEEEEE` rather than `currentColor`), and an
+author element with a bevelled border and no colour of its own still bevels from
+black rather than from the grey. Both are noted in `BorderBevel`'s remarks.
+
+**Why the call is here and not in `ComputedStyleBuilder`.** Putting it in the main
+repo would have shaded borders while the pinned `CssDefaults` still hard-coded
+`hr`'s bevel per side — darkening `#9A9A9A` a second time and regressing every
+`<hr>` on CI. The two halves have to arrive together, so both are in this patch.
+
+`groove` and `ridge` are untouched: they split each side lengthwise into two
+shades (a 16px grey `groove` paints its outer half `#2C2C2C` and its inner half
+`#808080`, where `inset` paints the whole width `#2C2C2C`), which needs two
+rectangles per side rather than one colour per side.
+
+Verified across 665 tests of `html/rendering` and
+`html/semantics/embedded-content/the-iframe-element`: **89 changed, every one an
+improvement, none worse**, and one more passing. Applied together with
+`0004`, `css/css-color-adjust/rendering/dark-color-scheme` reaches 25 of 29 and
+`color-scheme-iframe-background` reaches 99.4 % from 69.0 %.

--- a/patches/README.md
+++ b/patches/README.md
@@ -223,3 +223,56 @@ the residual being corner-miter antialiasing that a plain four-colour `solid`
 border shows too. Applied together with `0004`,
 `css/css-color-adjust/rendering/dark-color-scheme` reaches 25 of 29 and
 `color-scheme-iframe-background` reaches 99.4 % from 69.0 %.
+
+### `0006-html-border-miter.patch` — `Broiler.HTML`
+
+Two changes, in `Source/Broiler.HTML.Orchestration/IR/RGraphicsRasterBackend.cs`
+and `Source/Broiler.HTML.Image/BCanvas.cs`:
+
+- `inset`, `outset`, `groove` and `ridge` take the **mitred trapezoid** path that
+  only `solid` took, instead of being stroked along their centre lines;
+- the border path pins `Broiler.Layout.Engine.BorderAntialiasing` around its four
+  sides, and `BCanvas.FillPolygon` blends by coverage while it is pinned.
+
+`BorderAntialiasing` — the lever and the coverage rule — is **already in this
+repository** (`Broiler.Layout/Broiler.Layout/Engine/BorderAntialiasing.cs`),
+thread-static and unpinned by default, with 14 tests. Nothing calls it until this
+patch lands, so the main repo renders byte-identically to today.
+
+CSS 2.1 §8.5.4 divides a border at its corners by a straight line. **A stroke has
+no mitre**: it butts square into the neighbouring side, so whichever side is drawn
+last owns the whole corner. That is invisible while two sides share a colour and
+glaring when they do not — which is exactly what the 3D styles do, a `groove`
+putting a darkened top against a lit right. They stroke *solid*
+(`CreateBorderPen` gives them `DashStyle.Solid`), so the trapezoid draws the same
+band and simply mitres it. `dashed`, `dotted` and `double` keep their own paths,
+which are about the pattern along a side rather than its ends.
+
+**The mitre is blended; the border's own edges are not.** Filling by pixel centre
+steps the diagonal into a staircase where a browser lays one blended pixel along
+it. The first attempt anti-aliased every edge of the trapezoid and regressed 210
+tests, five of them out of passing: a border's own edges are straight lines the
+layout puts where it puts them, and feathering those turns a 1px form-control
+border sitting on a half-pixel into two grey rows instead of one solid one. Only
+the diagonals carry coverage now.
+
+**Why the corner fill runs for every corner.** Two trapezoids meeting along a
+mitre each cover about half of the pixels on it, so blended independently onto the
+page they leave the background showing through the seam. The corner rectangle that
+was already filled for same-coloured sides is now filled for every corner, with
+the colour of whichever side is drawn **first** (the order is top, left, bottom,
+right), so the second blends over an opaque corner. Where the two colours agree it
+is the same rectangle it always was, and a translucent side disables the whole
+thing — the fill cannot run for one without compositing its alpha twice.
+
+Verified against Chromium directly: a 12px four-colour border's corners go from
+**48 differing pixels to 12** (the rest differing by 1/255), with the corner pixel
+now exact — `rgb(255,83,0)` where red meets orange. A page of groove and ridge
+boxes goes from **425 differing pixels to 21**. Unequal corners fall out of the
+same rule rather than a special case for 45°: a 12px top against a 4px left slopes
+one-in-three and the coverages come out 1/6, 1/2, 5/6 against Chromium's measured
+0.158, 0.503, 0.842. Across 1 949 tests of `css/css-backgrounds`,
+`html/rendering`, `css/css-gaps` and the dark-color-scheme directory **no test
+changes state in either direction**, and the net is **+1.578 points** — +1.707
+across 55 tests against −0.129 across 103, only one of which loses more than a
+hundredth of a point.

--- a/patches/README.md
+++ b/patches/README.md
@@ -161,9 +161,10 @@ Two call-shaped changes, in
 `Source/Broiler.HTML.Orchestration/IR/PaintWalker.Decorations.cs` and
 `Source/Broiler.HTML.Core/CssDefaults.cs`:
 
-- the border display item takes each side's colour from
-  `Broiler.Layout.Engine.BorderBevel.SideColor` instead of using the border
-  colour flat on all four sides;
+- the border display item takes each side's colour and thickness from
+  `Broiler.Layout.Engine.BorderBevel` instead of using the border colour flat on
+  all four sides, and a side that splits lengthwise (`groove`/`ridge`) is emitted
+  as two nested rings rather than one;
 - the UA stylesheet states the *base* of the bevel rather than its result —
   `iframe { border: 2px inset #EEEEEE }`, and `hr`'s four hard-coded per-side
   colours collapse to one `border-color: #EEEEEE`.
@@ -201,13 +202,24 @@ repo would have shaded borders while the pinned `CssDefaults` still hard-coded
 `hr`'s bevel per side — darkening `#9A9A9A` a second time and regressing every
 `<hr>` on CI. The two halves have to arrive together, so both are in this patch.
 
-`groove` and `ridge` are untouched: they split each side lengthwise into two
-shades (a 16px grey `groove` paints its outer half `#2C2C2C` and its inner half
-`#808080`, where `inset` paints the whole width `#2C2C2C`), which needs two
-rectangles per side rather than one colour per side.
+`groove` and `ridge` carry the same two shades but split each side lengthwise, so
+those sides are emitted as **two nested rings**: a groove reads as `inset` on its
+outer half and `outset` on its inner half, and a ridge is the mirror. The split
+sits at `ceil(width / 2)` from the outer edge — a 3px groove is two dark rows then
+one light, a 5px one three then two — and below 2px there is no room for two
+halves, where Chromium paints a single stroke of the lit shade on all four sides.
+Every other style has an outer "half" that is the whole side and an empty inner
+one, so it still emits exactly the one display item it always did. This is what
+puts the bevel on every `<fieldset>`, which the HTML Standard renders with
+`border: 2px groove`.
 
-Verified across 665 tests of `html/rendering` and
-`html/semantics/embedded-content/the-iframe-element`: **89 changed, every one an
-improvement, none worse**, and one more passing. Applied together with
-`0004`, `css/css-color-adjust/rendering/dark-color-scheme` reaches 25 of 29 and
+Verified across 1 127 tests of `html/rendering`, `css/css-gaps` and
+`html/semantics/embedded-content/the-iframe-element`. The `inset`/`outset` half
+changed **89, every one an improvement**, with one more passing; the
+`groove`/`ridge` half changed **five more, again all improvements**, the largest
+being `fieldset-vertical` at +0.67 points. **Nothing regressed in either.**
+Directly against Chromium, a page of groove and ridge boxes matches to 99.95 %,
+the residual being corner-miter antialiasing that a plain four-colour `solid`
+border shows too. Applied together with `0004`,
+`css/css-color-adjust/rendering/dark-color-scheme` reaches 25 of 29 and
 `color-scheme-iframe-background` reaches 99.4 % from 69.0 %.

--- a/scripts/generate-wpt-references.js
+++ b/scripts/generate-wpt-references.js
@@ -20,7 +20,8 @@
 
 const path = require('path');
 const fs = require('fs');
-const { pathToFileURL } = require('url');
+const url = require('url');
+const { pathToFileURL } = url;
 
 // ---------------------------------------------------------------------------
 // Config
@@ -304,6 +305,178 @@ function decodeFileUrlPath(requestUrl) {
     const encodedPath = requestUrl.replace(/^file:\/\//i, '').split(/[?#]/)[0];
     try {
         return decodeURIComponent(encodedPath);
+    } catch {
+        return null;
+    }
+}
+
+// ── WPT `.sub` template substitution ─────────────────────────────────────────
+// The mirror of src/Broiler.Wpt/WptSubstitution.cs, and it has to stay one: the
+// two sides render the same bytes or every `.sub` test fails on a spurious
+// mismatch. Values are WPT's own defaults (tools/serve/serve.py
+// ConfigBuilder._default, tools/wptserve/wptserve/config.py _get_domains).
+const WPT_PRIMARY_HOST = 'web-platform.test';
+const WPT_ALTERNATE_HOST = 'not-web-platform.test';
+const WPT_PORTS = {
+    http: [8000, 8001],
+    https: [8443, 8444],
+    ws: [8888],
+    wss: [8889],
+    h2: [9000],
+};
+const WPT_BASE_SUBDOMAINS = ['www', 'www1', 'www2', '天気の良い日', 'élève'];
+
+/** WPT's _make_subdomains_product: every dot-joined tuple of the labels, up to `depth` long. */
+function makeSubdomainProduct(labels, depth) {
+    const result = [];
+    let level = labels;
+    for (let i = 1; i <= depth; i++) {
+        result.push(...level);
+        level = level.flatMap((prefix) => labels.map((label) => `${prefix}.${label}`));
+    }
+    return result;
+}
+
+/** all_domains: {alias: {subdomain: host}}, with non-ASCII labels IDNA-encoded. */
+const WPT_ALL_DOMAINS = (() => {
+    const subdomains = makeSubdomainProduct(WPT_BASE_SUBDOMAINS, 2);
+    const all = {};
+    for (const [alias, host] of [['', WPT_PRIMARY_HOST], ['alt', WPT_ALTERNATE_HOST]]) {
+        const domains = { '': host };
+        for (const subdomain of subdomains) {
+            domains[subdomain] = `${url.domainToASCII(subdomain)}.${host}`;
+        }
+        all[alias] = domains;
+    }
+    return all;
+})();
+
+/**
+ * Every host WPT serves from the checkout, exactly (never by suffix — WPT also
+ * mints deliberately unresolvable names such as nonexistent.web-platform.test,
+ * and serving those content would turn a load-failure test into a passing one).
+ */
+const WPT_SERVED_HOSTS = new Set(
+    Object.values(WPT_ALL_DOMAINS).flatMap((domains) => Object.values(domains)));
+
+/**
+ * Whether `p` names a template WPT serves through the `sub` pipe. WPT's rule is
+ * a literal `".sub." in path` (tools/wptserve/wptserve/handlers.py) — a
+ * case-sensitive substring test, so x.sub.html and x.tentative.sub.html both
+ * qualify. Only the basename is examined, so a checkout directory carrying
+ * `.sub.` in its own name does not make every file beneath it a template.
+ */
+function isSubstitutionFile(p) {
+    return typeof p === 'string' && path.basename(p).includes('.sub.');
+}
+
+function resolveWptTemplateField(expression, rootRelativePath) {
+    // `{{$id:uuid()}}` needs a live request; leave it, as the C# side does.
+    if (expression.startsWith('$')) {
+        return null;
+    }
+    const field = /^([A-Za-z_][A-Za-z0-9_-]*)((?:\[[^\]]*\])*)$/.exec(expression);
+    if (field === null) {
+        return null;   // a function call, or something this parser does not model
+    }
+    const name = field[1];
+    const indexes = [...field[2].matchAll(/\[([^\]]*)\]/g)].map((m) => m[1]);
+    const domain = (alias, subdomain) => {
+        const domains = WPT_ALL_DOMAINS[alias];
+        return domains !== undefined && Object.hasOwn(domains, subdomain) ? domains[subdomain] : null;
+    };
+
+    if (name === 'host' && indexes.length === 0) {
+        return WPT_PRIMARY_HOST;
+    }
+    if (name === 'hosts' && indexes.length === 2) {
+        return domain(indexes[0], indexes[1]);
+    }
+    if (name === 'domains' && indexes.length === 1) {
+        return domain('', indexes[0]);
+    }
+    if (name === 'ports' && indexes.length === 2) {
+        const ports = WPT_PORTS[indexes[0]];
+        const i = /^[0-9]+$/.test(indexes[1]) ? Number(indexes[1]) : -1;
+        return ports !== undefined && i >= 0 && i < ports.length ? String(ports[i]) : null;
+    }
+    if (name === 'location' && indexes.length === 1 && rootRelativePath !== null) {
+        const port = String(WPT_PORTS.http[0]);
+        const pathOnly = rootRelativePath.split(/[?#]/)[0];
+        const query = rootRelativePath.includes('?')
+            ? `?${rootRelativePath.split('?')[1].split('#')[0]}`
+            : '?';
+        switch (indexes[0]) {
+            case 'server': return `http://${WPT_PRIMARY_HOST}:${port}`;
+            case 'scheme': return 'http';
+            case 'host': return `${WPT_PRIMARY_HOST}:${port}`;
+            case 'hostname': return WPT_PRIMARY_HOST;
+            case 'port': return port;
+            case 'path':
+            case 'pathname': return pathOnly;
+            case 'query': return query;
+            default: return null;
+        }
+    }
+    return null;
+}
+
+/** Expand the placeholders a file on disk can answer; leave the rest verbatim. */
+function applyWptSubstitution(content, rootRelativePath = null) {
+    if (!content.includes('{{')) {
+        return content;
+    }
+    return content.replace(/\{\{([^}]*)\}\}/g, (whole, expression) => {
+        const resolved = resolveWptTemplateField(expression, rootRelativePath);
+        return resolved === null ? whole : resolved;
+    });
+}
+
+/** The root-relative URL path of `filePath` under `baseDir`, or null when outside it. */
+function rootRelativePathUnder(baseDir, filePath) {
+    const resolvedBase = path.resolve(baseDir);
+    const resolved = path.resolve(filePath);
+    if (resolved !== resolvedBase && !resolved.startsWith(resolvedBase + path.sep)) {
+        return null;
+    }
+    return '/' + path.relative(resolvedBase, resolved).split(path.sep).join('/');
+}
+
+/**
+ * The root-relative form of an absolute http(s) URL on a host WPT serves from
+ * the checkout, or `null` for any other URL. A substituted `.sub` test points
+ * its cross-origin frame at such a URL; offline there is no server to answer
+ * it, but the file it names is right here.
+ */
+function stripWptServedOrigin(requestUrl) {
+    let parsed;
+    try {
+        parsed = new URL(requestUrl);
+    } catch {
+        return null;
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return null;
+    }
+    return WPT_SERVED_HOSTS.has(parsed.hostname) ? parsed.pathname + parsed.search : null;
+}
+
+/** Resolve a root-relative WPT path to a file under `baseDir`, or null. */
+function resolveUnderBaseDir(baseDir, rootRelative) {
+    const resolvedBase = path.resolve(baseDir);
+    const withoutQuery = rootRelative.split(/[?#]/)[0];
+    let decoded;
+    try {
+        decoded = decodeURIComponent(withoutQuery);
+    } catch {
+        decoded = withoutQuery;
+    }
+    const candidate = path.resolve(resolvedBase, '.' + decoded);
+    if (candidate !== resolvedBase && !candidate.startsWith(resolvedBase + path.sep)) {
+        return null;
+    }
+    try {
+        return fs.existsSync(candidate) && fs.statSync(candidate).isFile() ? candidate : null;
     } catch {
         return null;
     }
@@ -627,18 +800,56 @@ async function main(args = process.argv.slice(2)) {
     let errors = 0;
     const total = testFiles.length;
 
-    async function fileRouteHandler(route) {
-        const served = resolveRootRelativeResource(resolvedBaseDir, route.request().url());
-        if (served === null) {
-            // The test document, a resolvable relative sub-resource, or an
-            // unmappable path — let Chromium load (or 404) it directly.
-            return route.continue();
+    // Serve one on-disk file, expanding it first when it is a `.sub` template —
+    // WPT's server pipes every such file through `sub` before sending it, so a
+    // reference generated from the raw bytes renders placeholder text and URLs
+    // that address nothing.
+    async function fulfillFromDisk(route, file) {
+        let body = fs.readFileSync(file);
+        if (isSubstitutionFile(file)) {
+            body = applyWptSubstitution(
+                body.toString('utf8'), rootRelativePathUnder(resolvedBaseDir, file));
         }
         await route.fulfill({
             status: 200,
-            contentType: contentTypeForExtension(path.extname(served)),
-            body: fs.readFileSync(served),
+            contentType: contentTypeForExtension(path.extname(file)),
+            body,
         });
+    }
+
+    async function fileRouteHandler(route) {
+        const requestUrl = route.request().url();
+        const served = resolveRootRelativeResource(resolvedBaseDir, requestUrl);
+        if (served !== null) {
+            return fulfillFromDisk(route, served);
+        }
+        // The test document or a resolvable relative sub-resource: Chromium can
+        // load it itself unless it is a template, which has to be expanded here.
+        const rawPath = decodeFileUrlPath(requestUrl);
+        if (rawPath !== null && isSubstitutionFile(rawPath)) {
+            try {
+                if (fs.existsSync(rawPath) && fs.statSync(rawPath).isFile()) {
+                    return fulfillFromDisk(route, rawPath);
+                }
+            } catch { /* fall through — let Chromium 404 it */ }
+        }
+        // An unmappable path — let Chromium load (or 404) it directly.
+        return route.continue();
+    }
+
+    // A substituted test addresses WPT's own hosts (http://not-web-platform.test:8000/…).
+    // They are all served from this one checkout, so answer them from it; anything
+    // else on the network is left exactly as it was.
+    async function servedOriginRouteHandler(route) {
+        const rootRelative = stripWptServedOrigin(route.request().url());
+        if (rootRelative === null) {
+            return route.continue();
+        }
+        const file = resolveUnderBaseDir(resolvedBaseDir, rootRelative);
+        if (file === null) {
+            return route.fulfill({ status: 404, contentType: 'text/plain', body: '' });
+        }
+        return fulfillFromDisk(route, file);
     }
 
     // Create a fresh context + page, registering the resource route.  Used both
@@ -661,6 +872,7 @@ async function main(args = process.argv.slice(2)) {
         try {
             const context = await browser.newContext(createBrowserContextOptions(nonJsOnly));
             await context.route(/^file:\/\//i, fileRouteHandler);
+            await context.route(/^https?:\/\//i, servedOriginRouteHandler);
             const page = await context.newPage();
             return { context, page };
         } catch (err) {
@@ -671,6 +883,7 @@ async function main(args = process.argv.slice(2)) {
             await restartBrowser(err.message || err);
             const context = await browser.newContext(createBrowserContextOptions(nonJsOnly));
             await context.route(/^file:\/\//i, fileRouteHandler);
+            await context.route(/^https?:\/\//i, servedOriginRouteHandler);
             const page = await context.newPage();
             return { context, page };
         }
@@ -764,8 +977,13 @@ module.exports = {
     renderTestWithWatchdog,
     requiresJavaScript,
     resolveRenderTimeoutMs,
+    applyWptSubstitution,
+    isSubstitutionFile,
     resolveRootRelativeResource,
+    resolveUnderBaseDir,
+    rootRelativePathUnder,
     shardIndexForPath,
+    stripWptServedOrigin,
     waitForReftestReady,
     withTimeout,
 };

--- a/scripts/tests/generate-wpt-references.test.js
+++ b/scripts/tests/generate-wpt-references.test.js
@@ -21,8 +21,13 @@ const {
     renderTestWithWatchdog,
     requiresJavaScript,
     resolveRenderTimeoutMs,
+    applyWptSubstitution,
+    isSubstitutionFile,
     resolveRootRelativeResource,
+    resolveUnderBaseDir,
+    rootRelativePathUnder,
     shardIndexForPath,
+    stripWptServedOrigin,
     waitForReftestReady,
     withTimeout,
 } = require('../generate-wpt-references.js');
@@ -365,4 +370,95 @@ test('closeQuietly survives a teardown that fails or wedges', async () => {
     const started = Date.now();
     await closeQuietly({ close: never }, 'wedged close', 20);
     assert.ok(Date.now() - started < 5_000, 'a wedged close must be bounded');
+});
+
+// ── WPT `.sub` template substitution ─────────────────────────────────────────
+// These must agree with src/Broiler.Wpt/WptSubstitution.cs case for case: the
+// runner and the reference generator render the same bytes or every `.sub` test
+// fails on a spurious pixel mismatch.
+
+test('a .sub file is recognised the way WPT recognises one', () => {
+    // WPT's rule is a literal `".sub." in path`, so it is a substring test and
+    // case-sensitive (tools/wptserve/wptserve/handlers.py).
+    for (const name of ['a.sub.html', 'a.sub.css', 'dir/a.tentative.sub.html', 'a.sub.tentative.html']) {
+        assert.equal(isSubstitutionFile(name), true, name);
+    }
+    for (const name of ['a.html', 'a.subtle.html', 'sub.html', 'a.sub', 'a.SUB.html', '', null]) {
+        assert.equal(isSubstitutionFile(name), false, String(name));
+    }
+});
+
+test('substitution expands the fields a file on disk can answer', () => {
+    assert.equal(applyWptSubstitution('{{host}}'), 'web-platform.test');
+    assert.equal(applyWptSubstitution('{{hosts[alt][]}}'), 'not-web-platform.test');
+    assert.equal(applyWptSubstitution('{{hosts[][]}}'), 'web-platform.test');
+    assert.equal(applyWptSubstitution('{{domains[www]}}'), 'www.web-platform.test');
+    assert.equal(applyWptSubstitution('{{domains[www.www1]}}'), 'www.www1.web-platform.test');
+    assert.equal(applyWptSubstitution('{{domains[élève]}}'), 'xn--lve-6lad.web-platform.test');
+    assert.equal(applyWptSubstitution('{{ports[http][0]}}'), '8000');
+    assert.equal(applyWptSubstitution('{{ports[https][0]}}'), '8443');
+    assert.equal(
+        applyWptSubstitution('<iframe src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/a.html">'),
+        '<iframe src="http://not-web-platform.test:8000/css/a.html">');
+});
+
+test('a placeholder only a live request could answer is left verbatim', () => {
+    // Rendering a fabricated value would be a worse lie than rendering the
+    // template text — and {{not_domains[…]}} names a host meant NOT to resolve.
+    for (const placeholder of [
+        '{{uuid()}}', '{{$id:uuid()}}', '{{$id}}', '{{headers[Host]}}', '{{GET[name]}}',
+        '{{file_hash(md5, dom/interfaces.html)}}', '{{not_domains[nonexistent]}}',
+        '{{ports[http][9]}}', '{{nonsense[1]}}', '{{location[host]}}',
+    ]) {
+        assert.equal(applyWptSubstitution(placeholder), placeholder);
+    }
+});
+
+test('{{location[…]}} answers once the document path is known', () => {
+    const p = '/css/x/y.sub.html';
+    assert.equal(applyWptSubstitution('{{location[server]}}', p), 'http://web-platform.test:8000');
+    assert.equal(applyWptSubstitution('{{location[host]}}', p), 'web-platform.test:8000');
+    assert.equal(applyWptSubstitution('{{location[path]}}', p), p);
+});
+
+test('a served WPT origin is stripped to its path, and nothing else is', () => {
+    assert.equal(
+        stripWptServedOrigin('http://web-platform.test:8000/css/a.html'), '/css/a.html');
+    assert.equal(
+        stripWptServedOrigin('http://not-web-platform.test:8000/css/a.html'), '/css/a.html');
+    assert.equal(
+        stripWptServedOrigin('https://www.web-platform.test:8443/css/a.html?x=1'), '/css/a.html?x=1');
+    // WPT mints nonexistent.* hosts to be unreachable; serving them would turn a
+    // load-failure test into a passing one.
+    for (const url of [
+        'http://nonexistent.web-platform.test:8000/css/a.html',
+        'http://example.com/css/a.html',
+        'http://web-platform.test.evil.example/css/a.html',
+        'ftp://web-platform.test:8000/css/a.html',
+        '/css/a.html',
+        'not a url',
+    ]) {
+        assert.equal(stripWptServedOrigin(url), null, url);
+    }
+});
+
+test('a served path resolves under the base dir and cannot escape it', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wpt-served-'));
+    try {
+        fs.mkdirSync(path.join(dir, 'css'), { recursive: true });
+        const file = path.join(dir, 'css', 'a.html');
+        fs.writeFileSync(file, '<p>a</p>');
+
+        assert.equal(resolveUnderBaseDir(dir, '/css/a.html'), file);
+        assert.equal(resolveUnderBaseDir(dir, '/css/a.html?pipe=trickle(d1)'), file);
+        assert.equal(resolveUnderBaseDir(dir, '/css/missing.html'), null);
+        assert.equal(resolveUnderBaseDir(dir, '/../outside.html'), null);
+        // A directory is not a document.
+        assert.equal(resolveUnderBaseDir(dir, '/css'), null);
+
+        assert.equal(rootRelativePathUnder(dir, file), '/css/a.html');
+        assert.equal(rootRelativePathUnder(dir, path.join(dir + '-sibling', 'a.html')), null);
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
 });

--- a/src/Broiler.Cli.Tests/EmbeddedCanvasColorSchemeTests.cs
+++ b/src/Broiler.Cli.Tests/EmbeddedCanvasColorSchemeTests.cs
@@ -1,0 +1,343 @@
+using Broiler.HTML.Image;
+using Broiler.Layout.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// CSS Color Adjust 1 §2.4: a nested browsing context's canvas is transparent — the embedder shows
+/// through it — unless the <em>embedding element's</em> used colour scheme differs from the embedded
+/// root's, in which case the UA paints an opaque backdrop of the embedded root's scheme.
+/// <para>
+/// Both halves were missing. The frame's canvas was always resolved opaque, so a matching pair
+/// painted a box that should not have been there (WPT
+/// <c>color-scheme-iframe-background</c>, <c>…-mismatch-opaque-cross-origin-003.sub</c>); and
+/// <c>color-scheme</c> did not inherit, so an <c>&lt;iframe&gt;</c> under
+/// <c>html { color-scheme: dark }</c> reported <c>normal</c> and the comparison was made against the
+/// wrong value.
+/// </para>
+/// </summary>
+public class EmbeddedCanvasColorSchemeTests : IDisposable
+{
+    private const int FrameWidth = 200;
+    private const int FrameHeight = 150;
+    private const int PageWidth = 400;
+    private const int PageHeight = 300;
+
+    /// <summary>The UA dark canvas backdrop (CSS Color Adjust §2.3).</summary>
+    private static readonly (int R, int G, int B) UaDark = (18, 18, 18);
+    private static readonly (int R, int G, int B) White = (255, 255, 255);
+    private static readonly (int R, int G, int B) Red = (255, 0, 0);
+    private static readonly (int R, int G, int B) Blue = (0, 0, 255);
+
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("broiler-embedded-canvas").FullName;
+
+    public void Dispose() => Directory.Delete(_root, recursive: true);
+
+    private void WriteFrame(string name, string content) =>
+        File.WriteAllText(Path.Combine(_root, name), content);
+
+    /// <summary>A frame document that propagates no background of its own.</summary>
+    private static string FrameDocument(string? colorScheme) =>
+        colorScheme is null
+            ? "<!DOCTYPE html><p>frame</p>"
+            : $"<!DOCTYPE html><style>:root{{color-scheme:{colorScheme}}}</style><p>frame</p>";
+
+    /// <summary>
+    /// Renders a page whose body has <paramref name="pageBackground"/> and holds one frame, and
+    /// returns the pixel at the centre of the frame's content box.
+    /// </summary>
+    private (int R, int G, int B) RenderFrameCentre(
+        string pageBackground, string? rootColorScheme, string? iframeColorScheme, string frameSrc)
+    {
+        var rootStyle = rootColorScheme is null ? "" : $"html{{color-scheme:{rootColorScheme}}}";
+        var frameStyle = iframeColorScheme is null ? "" : $"color-scheme:{iframeColorScheme};";
+        var page = $$"""
+<!DOCTYPE html>
+<style>
+  {{rootStyle}}
+  body { margin: 0; background: {{pageBackground}} }
+  iframe { width: {{FrameWidth}}px; height: {{FrameHeight}}px; border: 0; {{frameStyle}} }
+</style>
+<iframe src="{{frameSrc}}"></iframe>
+""";
+        var pagePath = Path.Combine(_root, "page.html");
+        File.WriteAllText(pagePath, page);
+
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(
+            page, PageWidth, PageHeight, baseUrl: new Uri(pagePath).AbsoluteUri);
+
+        var pixel = bitmap.GetPixel(FrameWidth / 2, FrameHeight / 2);
+        return (pixel.R, pixel.G, pixel.B);
+    }
+
+    /// <summary>
+    /// Whether the pinned <c>Broiler.HTML</c> can leave a frame's canvas transparent. The renderer
+    /// half of this ships as <c>patches/0004-html-embedded-canvas-color-scheme.patch</c> and the
+    /// submodule remote is outside this session's GitHub scope, so until a maintainer applies it
+    /// and bumps the pointer every frame is still composited opaque and the render assertions
+    /// cannot hold. Probed rather than assumed, so they become real guards the moment the patch
+    /// lands — the same shape as <c>TemplateContentInertnessTests</c>.
+    /// </summary>
+    private bool FrameCanvasCanBeTransparent()
+    {
+        WriteFrame("probe-frame.html", FrameDocument("light"));
+        return RenderFrameCentre("red", rootColorScheme: null,
+            iframeColorScheme: "light", "probe-frame.html") == Red;
+    }
+
+    // ── The canvas is transparent when the schemes agree ─────────────────────
+
+    /// <summary>
+    /// The bug this fixes, in its simplest form: a light frame in a light-scheme
+    /// <c>&lt;iframe&gt;</c> on a red page shows the red page, not a white box.
+    /// </summary>
+    [Fact]
+    public void A_Matching_Light_Frame_Is_Transparent()
+    {
+        if (!FrameCanvasCanBeTransparent())
+            return; // patch 0004 not applied; see FrameCanvasCanBeTransparent.
+
+        WriteFrame("frame.html", FrameDocument("light"));
+
+        Assert.Equal(Red, RenderFrameCentre("red", rootColorScheme: null,
+            iframeColorScheme: "light", "frame.html"));
+    }
+
+    /// <summary>
+    /// WPT <c>color-scheme-iframe-background</c>: a dark frame in a dark-scheme
+    /// <c>&lt;iframe&gt;</c> on a light page stays transparent, so the light page shows through
+    /// rather than the UA dark backdrop.
+    /// </summary>
+    [Fact]
+    public void A_Matching_Dark_Frame_Is_Transparent()
+    {
+        if (!FrameCanvasCanBeTransparent())
+            return; // patch 0004 not applied; see FrameCanvasCanBeTransparent.
+
+        WriteFrame("frame.html", FrameDocument("dark"));
+
+        Assert.Equal(White, RenderFrameCentre("white", rootColorScheme: null,
+            iframeColorScheme: "dark", "frame.html"));
+    }
+
+    /// <summary>
+    /// WPT <c>…-mismatch-opaque-cross-origin-003.sub</c>: the embedding element's own
+    /// <c>color-scheme</c> is what counts, not the document's. A light <c>&lt;iframe&gt;</c> under a
+    /// dark root, holding a light frame, agrees with its frame — so the dark page shows through.
+    /// </summary>
+    [Fact]
+    public void The_Comparison_Is_Against_The_Embedding_Element_Not_The_Document()
+    {
+        if (!FrameCanvasCanBeTransparent())
+            return; // patch 0004 not applied; see FrameCanvasCanBeTransparent.
+
+        WriteFrame("frame.html", FrameDocument("light"));
+
+        Assert.Equal(UaDark, RenderFrameCentre("transparent", rootColorScheme: "dark",
+            iframeColorScheme: "light", "frame.html"));
+    }
+
+    // ── …and opaque when they differ ─────────────────────────────────────────
+
+    /// <summary>
+    /// WPT <c>…-mismatch-opaque</c>: a dark frame in a light <c>&lt;iframe&gt;</c> gets the UA dark
+    /// backdrop, so the red page does *not* show through.
+    /// </summary>
+    [Fact]
+    public void A_Dark_Frame_In_A_Light_Element_Gets_The_Dark_Backdrop()
+    {
+        WriteFrame("frame.html", FrameDocument("dark"));
+
+        Assert.Equal(UaDark, RenderFrameCentre("red", rootColorScheme: null,
+            iframeColorScheme: null, "frame.html"));
+    }
+
+    /// <summary>
+    /// WPT <c>…-mismatch-opaque-cross-origin-002.sub</c>: a light frame in a dark <c>&lt;iframe&gt;</c>
+    /// gets an opaque white canvas, hiding the dark page behind it. This is the case that
+    /// <c>color-scheme</c> inheritance decides — the iframe declares nothing and takes <c>dark</c>
+    /// from the root.
+    /// </summary>
+    [Fact]
+    public void A_Light_Frame_Under_An_Inherited_Dark_Scheme_Gets_An_Opaque_White_Canvas()
+    {
+        WriteFrame("frame.html", FrameDocument("light"));
+
+        Assert.Equal(White, RenderFrameCentre("transparent", rootColorScheme: "dark",
+            iframeColorScheme: null, "frame.html"));
+    }
+
+    /// <summary>
+    /// A frame that propagates a background of its own paints it whether the canvas is transparent
+    /// or not — only the UA's backdrop is dropped, never the document's own painting.
+    /// </summary>
+    [Fact]
+    public void A_Frames_Own_Background_Still_Paints_When_The_Canvas_Is_Transparent()
+    {
+        if (!FrameCanvasCanBeTransparent())
+            return; // patch 0004 not applied; see FrameCanvasCanBeTransparent.
+
+        WriteFrame("frame.html",
+            "<!DOCTYPE html><style>:root{color-scheme:light;background:blue}</style><p>frame</p>");
+
+        Assert.Equal(Blue, RenderFrameCentre("red", rootColorScheme: null,
+            iframeColorScheme: "light", "frame.html"));
+    }
+
+    /// <summary>
+    /// A frame that never loaded has no canvas at all, so the embedder shows through — the empty
+    /// box behaviour an unresolvable <c>src</c> has always had.
+    /// </summary>
+    [Fact]
+    public void An_Unloadable_Frame_Leaves_The_Page_Showing()
+    {
+        Assert.Equal(Red, RenderFrameCentre("red", rootColorScheme: null,
+            iframeColorScheme: null, "missing.html"));
+    }
+
+    // ── color-scheme inherits (CSS Color Adjust §2.1) ────────────────────────
+
+    /// <summary>
+    /// Walks the laid-out fragment tree for the first fragment of <paramref name="tagName"/> and
+    /// returns its computed <c>color-scheme</c>.
+    /// </summary>
+    private static string? ComputedColorScheme(string html, string tagName)
+    {
+        using var container = new HtmlContainer
+        {
+            Location = new System.Drawing.PointF(0, 0),
+            MaxSize = new System.Drawing.SizeF(PageWidth, PageHeight),
+            AvoidAsyncImagesLoading = true,
+            AvoidImagesLateLoading = true,
+        };
+        container.SetHtmlWithStyleSet(html);
+        container.PerformLayout(new System.Drawing.RectangleF(0, 0, PageWidth, PageHeight));
+
+        static Broiler.Layout.IR.Fragment? Find(Broiler.Layout.IR.Fragment? fragment, string tag)
+        {
+            if (fragment is null)
+                return null;
+            if (string.Equals(fragment.Style.TagName, tag, StringComparison.OrdinalIgnoreCase))
+                return fragment;
+
+            foreach (var child in fragment.Children)
+                if (Find(child, tag) is { } found)
+                    return found;
+
+            return null;
+        }
+
+        return Find(container.LatestFragmentTree, tagName)?.Style.ColorScheme;
+    }
+
+    /// <summary>
+    /// §2.1 makes <c>color-scheme</c> an inherited property. It was read only off the root element,
+    /// which inherits nothing, so its absence from the inherited set went unnoticed until an
+    /// <c>&lt;iframe&gt;</c> had to be asked for its own used scheme.
+    /// </summary>
+    [Fact]
+    public void ColorScheme_Inherits_To_Descendants()
+    {
+        const string html = """
+<!DOCTYPE html>
+<style>html { color-scheme: dark }</style>
+<div><span id="deep">x</span></div>
+""";
+        Assert.Equal("dark", ComputedColorScheme(html, "div"));
+        Assert.Equal("dark", ComputedColorScheme(html, "span"));
+    }
+
+    /// <summary>A descendant's own declaration still wins over the inherited value.</summary>
+    [Fact]
+    public void A_Descendants_Own_ColorScheme_Overrides_The_Inherited_One()
+    {
+        const string html = """
+<!DOCTYPE html>
+<style>html { color-scheme: dark } div { color-scheme: light }</style>
+<div>x</div>
+""";
+        Assert.Equal("light", ComputedColorScheme(html, "div"));
+    }
+
+    /// <summary>With nothing declared anywhere the computed value stays the initial one.</summary>
+    [Fact]
+    public void ColorScheme_Defaults_To_Normal()
+    {
+        Assert.Equal("normal", ComputedColorScheme("<!DOCTYPE html><div>x</div>", "div"));
+    }
+
+    // ── The rule itself ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A document that is not embedded always paints its backdrop, so nothing about a top-level
+    /// render changes: this is what keeps the lever inert everywhere it is not pinned.
+    /// </summary>
+    [Fact]
+    public void A_Document_That_Is_Not_Embedded_Always_Paints_Its_Backdrop()
+    {
+        Assert.True(EmbeddedCanvas.PaintsOpaqueBackdrop("dark"));
+        Assert.True(EmbeddedCanvas.PaintsOpaqueBackdrop("light"));
+        Assert.True(EmbeddedCanvas.PaintsOpaqueBackdrop(null));
+    }
+
+    [Fact]
+    public void The_Backdrop_Is_Painted_Exactly_When_The_Used_Schemes_Differ()
+    {
+        using (EmbeddedCanvas.Pin("dark"))
+        {
+            Assert.False(EmbeddedCanvas.PaintsOpaqueBackdrop("dark"));
+            Assert.True(EmbeddedCanvas.PaintsOpaqueBackdrop("light"));
+            Assert.True(EmbeddedCanvas.PaintsOpaqueBackdrop("normal"));
+            Assert.True(EmbeddedCanvas.PaintsOpaqueBackdrop(null));
+        }
+
+        using (EmbeddedCanvas.Pin("light"))
+        {
+            Assert.True(EmbeddedCanvas.PaintsOpaqueBackdrop("dark"));
+            Assert.False(EmbeddedCanvas.PaintsOpaqueBackdrop("light"));
+            // `normal` and an absent value are both "not dark", so they agree with `light`.
+            Assert.False(EmbeddedCanvas.PaintsOpaqueBackdrop("normal"));
+            Assert.False(EmbeddedCanvas.PaintsOpaqueBackdrop(null));
+        }
+    }
+
+    /// <summary>
+    /// §2.2–2.3: a used scheme is dark when the list offers <c>dark</c> and not <c>light</c>; a
+    /// <c>light dark</c> pair resolves to the environment's light preference, and <c>only</c> does
+    /// not change the outcome.
+    /// </summary>
+    [Theory]
+    [InlineData("dark", true)]
+    [InlineData("only dark", true)]
+    [InlineData("dark normal", true)]
+    [InlineData("light dark", false)]
+    [InlineData("dark light", false)]
+    [InlineData("light", false)]
+    [InlineData("normal", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void UsesDarkColorScheme_Resolves_Against_A_Light_Preference(string? value, bool expected) =>
+        Assert.Equal(expected, EmbeddedCanvas.UsesDarkColorScheme(value));
+
+    /// <summary>Nesting restores, so sibling frames do not inherit one another's embedder.</summary>
+    [Fact]
+    public void Pinning_Nests_And_Restores()
+    {
+        Assert.False(EmbeddedCanvas.IsEmbedded);
+
+        using (EmbeddedCanvas.Pin("dark"))
+        {
+            Assert.True(EmbeddedCanvas.IsEmbedded);
+            Assert.Equal("dark", EmbeddedCanvas.EmbedderColorScheme);
+
+            using (EmbeddedCanvas.Pin("light"))
+                Assert.Equal("light", EmbeddedCanvas.EmbedderColorScheme);
+
+            Assert.Equal("dark", EmbeddedCanvas.EmbedderColorScheme);
+        }
+
+        Assert.False(EmbeddedCanvas.IsEmbedded);
+        Assert.Null(EmbeddedCanvas.EmbedderColorScheme);
+    }
+}

--- a/src/Broiler.Cli.Tests/ServedOriginFrameSrcTests.cs
+++ b/src/Broiler.Cli.Tests/ServedOriginFrameSrcTests.cs
@@ -1,0 +1,226 @@
+using Broiler.HTML.Image;
+using Broiler.Layout.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// A nested browsing context whose <c>src</c> is an <em>absolute</em> URL on a host the render is
+/// told is served from its document root loads that file, instead of painting the empty box a
+/// local render has no way to fetch.
+/// <para>
+/// WPT is the case this exists for. Its cross-origin reftests point a frame at a second host —
+/// <c>http://not-web-platform.test:8000/css/…</c> — and WPT serves every one of its hosts from the
+/// same checkout, so the URL names a file that is already on disk. Without this the frame painted
+/// nothing and the test scored 0.0% against a reference whose frame was empty for the same reason
+/// (<c>css/css-color-adjust/…/color-scheme-iframe-background-mismatch-opaque-cross-origin-002.sub</c>).
+/// </para>
+/// </summary>
+public class ServedOriginFrameSrcTests : IDisposable
+{
+    private const int FrameWidth = 200;
+    private const int FrameHeight = 150;
+
+    private static readonly (int R, int G, int B) White = (255, 255, 255);
+    private static readonly (int R, int G, int B) Red = (255, 0, 0);
+    private static readonly (int R, int G, int B) Blue = (0, 0, 255);
+
+    private const string ServedHost = "web-platform.test";
+    private const string AlternateHost = "not-web-platform.test";
+    private static readonly string[] ServedHosts = [ServedHost, AlternateHost];
+
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("broiler-served-origin").FullName;
+
+    public void Dispose() => Directory.Delete(_root, recursive: true);
+
+    private const string RedDocument = "<!DOCTYPE html><body style='margin:0;background:red'></body>";
+    private const string BlueDocument = "<!DOCTYPE html><body style='margin:0;background:blue'></body>";
+
+    private void WriteResource(string relativePath, string content)
+    {
+        var path = Path.Combine(_root, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+    }
+
+    private static string Page(string frameSrc) => $$"""
+<!DOCTYPE html>
+<body style="margin:0;background:white">
+<style>iframe{width:{{FrameWidth}}px;height:{{FrameHeight}}px;border:0}</style>
+<iframe src="{{frameSrc}}"></iframe>
+</body>
+""";
+
+    /// <summary>
+    /// Renders a page holding one frame from a sub-directory of the root, so a URL resolved against
+    /// the root and one resolved against the page's own directory cannot accidentally agree.
+    /// Returns the pixel at the centre of the frame; white means the frame painted nothing.
+    /// </summary>
+    private (int R, int G, int B) RenderFrameCentre(string frameSrc, string? documentRoot, string[]? servedHosts)
+    {
+        var pagePath = Path.Combine(_root, "pages", "page.html");
+        Directory.CreateDirectory(Path.GetDirectoryName(pagePath)!);
+        File.WriteAllText(pagePath, Page(frameSrc));
+
+        using var pinned = DocumentRoot.Pin(documentRoot, servedHosts);
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(
+            Page(frameSrc), 400, 300, baseUrl: new Uri(pagePath).AbsoluteUri);
+
+        var pixel = bitmap.GetPixel(FrameWidth / 2, FrameHeight / 2);
+        return (pixel.R, pixel.G, pixel.B);
+    }
+
+    /// <summary>The fix: an absolute URL on a served host loads the file under the root.</summary>
+    [Fact]
+    public void Frame_On_A_Served_Host_Loads_From_The_Document_Root()
+    {
+        WriteResource(Path.Combine("css", "frame.html"), RedDocument);
+
+        Assert.Equal(Red, RenderFrameCentre(
+            $"http://{ServedHost}:8000/css/frame.html", _root, ServedHosts));
+    }
+
+    /// <summary>
+    /// The whole point of the WPT case: the <em>second</em> origin is served from the same root, so
+    /// a cross-origin frame renders the document that host would have returned.
+    /// </summary>
+    [Fact]
+    public void Frame_On_The_Alternate_Host_Loads_From_The_Same_Root()
+    {
+        WriteResource(Path.Combine("css", "frame.html"), RedDocument);
+
+        Assert.Equal(Red, RenderFrameCentre(
+            $"http://{AlternateHost}:8000/css/frame.html", _root, ServedHosts));
+    }
+
+    /// <summary>Any port on a served host is that host: WPT allocates several, and https too.</summary>
+    [Theory]
+    [InlineData("http", 8000)]
+    [InlineData("http", 8001)]
+    [InlineData("https", 8443)]
+    public void Any_Port_And_Either_Scheme_On_A_Served_Host_Resolves(string scheme, int port)
+    {
+        WriteResource(Path.Combine("css", "frame.html"), RedDocument);
+
+        Assert.Equal(Red, RenderFrameCentre(
+            $"{scheme}://{ServedHost}:{port}/css/frame.html", _root, ServedHosts));
+    }
+
+    /// <summary>
+    /// Null by default: a host that declares no served origins renders exactly as before, so an
+    /// absolute URL stays the unfetchable, empty box it has always been.
+    /// </summary>
+    [Fact]
+    public void No_Served_Hosts_Leaves_An_Absolute_Url_Unresolved()
+    {
+        WriteResource(Path.Combine("css", "frame.html"), RedDocument);
+
+        Assert.Equal(White, RenderFrameCentre(
+            $"http://{ServedHost}:8000/css/frame.html", _root, servedHosts: null));
+    }
+
+    /// <summary>A served host without a root has nothing to resolve against.</summary>
+    [Fact]
+    public void No_Document_Root_Leaves_An_Absolute_Url_Unresolved()
+    {
+        WriteResource(Path.Combine("css", "frame.html"), RedDocument);
+
+        Assert.Equal(White, RenderFrameCentre(
+            $"http://{ServedHost}:8000/css/frame.html", documentRoot: null, ServedHosts));
+    }
+
+    /// <summary>
+    /// A host that is not on the list is not ours to read off the local disk — including a
+    /// subdomain of one that is. WPT mints <c>nonexistent.web-platform.test</c> precisely so that
+    /// it fails to resolve; serving it content would turn a load-failure test into a passing one.
+    /// </summary>
+    [Theory]
+    [InlineData("example.com")]
+    [InlineData("nonexistent.web-platform.test")]
+    [InlineData("web-platform.test.evil.example")]
+    public void An_Unlisted_Host_Is_Not_Served(string host)
+    {
+        WriteResource(Path.Combine("css", "frame.html"), RedDocument);
+
+        Assert.Equal(White, RenderFrameCentre(
+            $"http://{host}:8000/css/frame.html", _root, ServedHosts));
+    }
+
+    /// <summary>A subdomain resolves only when the caller lists it, which is how WPT declares its own.</summary>
+    [Fact]
+    public void A_Listed_Subdomain_Is_Served()
+    {
+        WriteResource(Path.Combine("css", "frame.html"), RedDocument);
+
+        Assert.Equal(Red, RenderFrameCentre(
+            $"http://www.{ServedHost}:8000/css/frame.html", _root,
+            [ServedHost, $"www.{ServedHost}"]));
+    }
+
+    /// <summary>
+    /// Only http(s) is served: a <c>file:</c> or <c>data:</c> URL keeps whatever meaning it already
+    /// had rather than being re-pointed at the root.
+    /// </summary>
+    [Fact]
+    public void A_Non_Http_Scheme_Is_Left_Alone()
+    {
+        WriteResource(Path.Combine("css", "frame.html"), RedDocument);
+
+        Assert.Equal(White, RenderFrameCentre(
+            $"ftp://{ServedHost}:8000/css/frame.html", _root, ServedHosts));
+    }
+
+    /// <summary>
+    /// The origin is dropped, not the path's meaning: the URL still names its own file, not one
+    /// beside the page. The page lives in <c>pages/</c> and holds a red frame document of its own,
+    /// so resolving against the page's directory would paint red instead of blue.
+    /// </summary>
+    [Fact]
+    public void The_Path_Is_Root_Relative_Not_Page_Relative()
+    {
+        WriteResource(Path.Combine("pages", "frame.html"), RedDocument);
+        WriteResource("frame.html", BlueDocument);
+
+        Assert.Equal(Blue, RenderFrameCentre(
+            $"http://{ServedHost}:8000/frame.html", _root, ServedHosts));
+    }
+
+    /// <summary>
+    /// A query addresses a server that is not there; the path alone names the file. WPT decorates
+    /// resource URLs with <c>?pipe=</c> and cache-busters routinely.
+    /// </summary>
+    [Fact]
+    public void A_Query_Or_Fragment_Does_Not_Stop_The_Resolve()
+    {
+        WriteResource(Path.Combine("css", "frame.html"), RedDocument);
+
+        Assert.Equal(Red, RenderFrameCentre(
+            $"http://{ServedHost}:8000/css/frame.html?pipe=trickle(d1)#top", _root, ServedHosts));
+    }
+
+    /// <summary>A served URL that names nothing on disk stays the empty box, rather than throwing.</summary>
+    [Fact]
+    public void A_Served_Url_That_Names_Nothing_Paints_Empty()
+    {
+        Assert.Equal(White, RenderFrameCentre(
+            $"http://{ServedHost}:8000/css/missing.html", _root, ServedHosts));
+    }
+
+    /// <summary>`..` in a served URL cannot walk out of the document root.</summary>
+    [Fact]
+    public void A_Served_Url_Cannot_Escape_The_Root()
+    {
+        var outside = Path.Combine(Path.GetDirectoryName(_root)!,
+            "broiler-served-origin-outside-" + Guid.NewGuid().ToString("N")[..8] + ".html");
+        File.WriteAllText(outside, RedDocument);
+        try
+        {
+            Assert.Equal(White, RenderFrameCentre(
+                $"http://{ServedHost}:8000/../{Path.GetFileName(outside)}", _root, ServedHosts));
+        }
+        finally
+        {
+            File.Delete(outside);
+        }
+    }
+}

--- a/src/Broiler.Wpt.Tests/WptSubstitutionTests.cs
+++ b/src/Broiler.Wpt.Tests/WptSubstitutionTests.cs
@@ -1,0 +1,269 @@
+using System.IO;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// WPT's <c>sub</c> pipe, as the runner performs it: a <c>*.sub.*</c> file is a template the
+/// server expands before serving, so reading one straight off disk renders placeholder text and
+/// URLs that address nothing.
+/// </summary>
+public class WptSubstitutionTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("broiler-wpt-substitution").FullName;
+
+    public void Dispose() => Directory.Delete(_root, recursive: true);
+
+    // ── Which files are templates ────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("a.sub.html", true)]
+    [InlineData("a.sub.css", true)]
+    [InlineData("a.sub.js", true)]
+    [InlineData("deep/dir/a.sub.xhtml", true)]
+    [InlineData("a.tentative.sub.html", true)]
+    [InlineData("a.sub.tentative.html", true)]
+    [InlineData("a.html", false)]
+    [InlineData("a.subtle.html", false)]
+    [InlineData("sub.html", false)]
+    [InlineData("a.sub", false)]
+    [InlineData("a.SUB.html", false)]
+    public void IsSubstitutionFile_Follows_The_Naming_Rule(string path, bool expected) =>
+        Assert.Equal(expected, WptSubstitution.IsSubstitutionFile(path));
+
+    [Fact]
+    public void IsSubstitutionFile_Tolerates_Empty_Input()
+    {
+        Assert.False(WptSubstitution.IsSubstitutionFile(null));
+        Assert.False(WptSubstitution.IsSubstitutionFile(""));
+    }
+
+    // ── The fields a file on disk can answer ─────────────────────────────────
+
+    [Fact]
+    public void Host_And_Alternate_Host_Are_WPTs_Defaults()
+    {
+        Assert.Equal("web-platform.test", WptSubstitution.Apply("{{host}}"));
+        Assert.Equal("not-web-platform.test", WptSubstitution.Apply("{{hosts[alt][]}}"));
+        Assert.Equal("web-platform.test", WptSubstitution.Apply("{{hosts[][]}}"));
+    }
+
+    [Fact]
+    public void Domains_Index_The_Primary_Hosts_Subdomains()
+    {
+        Assert.Equal("www.web-platform.test", WptSubstitution.Apply("{{domains[www]}}"));
+        Assert.Equal("www2.web-platform.test", WptSubstitution.Apply("{{domains[www2]}}"));
+        Assert.Equal("web-platform.test", WptSubstitution.Apply("{{domains[]}}"));
+        Assert.Equal("www1.not-web-platform.test", WptSubstitution.Apply("{{hosts[alt][www1]}}"));
+    }
+
+    /// <summary>WPT closes its subdomain set under two-deep products (`_make_subdomains_product`).</summary>
+    [Fact]
+    public void A_Two_Deep_Subdomain_Product_Resolves()
+    {
+        Assert.Equal("www.www1.web-platform.test", WptSubstitution.Apply("{{domains[www.www1]}}"));
+    }
+
+    /// <summary>Non-ASCII labels are IDNA-encoded, exactly as <c>_get_domains</c> encodes them.</summary>
+    [Fact]
+    public void A_Non_Ascii_Subdomain_Is_Idna_Encoded()
+    {
+        Assert.Equal("xn--lve-6lad.web-platform.test", WptSubstitution.Apply("{{domains[élève]}}"));
+    }
+
+    [Fact]
+    public void Ports_Are_Indexed_Per_Protocol()
+    {
+        Assert.Equal("8000", WptSubstitution.Apply("{{ports[http][0]}}"));
+        Assert.Equal("8001", WptSubstitution.Apply("{{ports[http][1]}}"));
+        Assert.Equal("8443", WptSubstitution.Apply("{{ports[https][0]}}"));
+    }
+
+    [Fact]
+    public void An_Out_Of_Range_Port_Index_Is_Left_Alone() =>
+        Assert.Equal("{{ports[http][9]}}", WptSubstitution.Apply("{{ports[http][9]}}"));
+
+    [Fact]
+    public void Location_Reports_The_Documents_Own_Url()
+    {
+        const string path = "/css/x/y.sub.html";
+        Assert.Equal("http://web-platform.test:8000", WptSubstitution.Apply("{{location[server]}}", path));
+        Assert.Equal("web-platform.test:8000", WptSubstitution.Apply("{{location[host]}}", path));
+        Assert.Equal("web-platform.test", WptSubstitution.Apply("{{location[hostname]}}", path));
+        Assert.Equal("http", WptSubstitution.Apply("{{location[scheme]}}", path));
+        Assert.Equal("8000", WptSubstitution.Apply("{{location[port]}}", path));
+        Assert.Equal(path, WptSubstitution.Apply("{{location[path]}}", path));
+    }
+
+    /// <summary>Without a known path the document has no URL to report, so the field is left alone.</summary>
+    [Fact]
+    public void Location_Without_A_Path_Is_Left_Alone() =>
+        Assert.Equal("{{location[host]}}", WptSubstitution.Apply("{{location[host]}}"));
+
+    // ── What is deliberately *not* substituted ───────────────────────────────
+
+    /// <summary>
+    /// A placeholder that describes a live request has no answer here. Leaving it verbatim renders
+    /// the test exactly as it did before this existed; inventing a value would be a worse lie.
+    /// </summary>
+    [Theory]
+    [InlineData("{{uuid()}}")]
+    [InlineData("{{$id:uuid()}}")]
+    [InlineData("{{$id}}")]
+    [InlineData("{{headers[Host]}}")]
+    [InlineData("{{GET[name]}}")]
+    [InlineData("{{file_hash(md5, dom/interfaces.html)}}")]
+    [InlineData("{{fs_path(css/x.html)}}")]
+    [InlineData("{{header_or_default(X-Test, absent)}}")]
+    public void A_Request_Scoped_Placeholder_Is_Left_Verbatim(string placeholder) =>
+        Assert.Equal(placeholder, WptSubstitution.Apply(placeholder));
+
+    /// <summary>
+    /// <c>not_domains</c> names a host that is *meant* not to resolve. Substituting it would hand a
+    /// load-failure test a working URL and turn it into a test of something else.
+    /// </summary>
+    [Fact]
+    public void Not_Domains_Is_Left_Verbatim() =>
+        Assert.Equal("{{not_domains[nonexistent]}}", WptSubstitution.Apply("{{not_domains[nonexistent]}}"));
+
+    [Fact]
+    public void An_Unknown_Field_Is_Left_Verbatim() =>
+        Assert.Equal("{{nonsense[1]}}", WptSubstitution.Apply("{{nonsense[1]}}"));
+
+    // ── Whole-document behaviour ─────────────────────────────────────────────
+
+    [Fact]
+    public void A_Frame_Url_Is_Expanded_In_Place()
+    {
+        const string markup =
+            "<iframe src=\"http://{{hosts[alt][]}}:{{ports[http][0]}}/css/a/support/light-frame.html\"></iframe>";
+
+        Assert.Equal(
+            "<iframe src=\"http://not-web-platform.test:8000/css/a/support/light-frame.html\"></iframe>",
+            WptSubstitution.Apply(markup));
+    }
+
+    [Fact]
+    public void Content_Without_Placeholders_Is_Returned_Unchanged()
+    {
+        const string markup = "<!doctype html><p>nothing to expand</p>";
+        Assert.Same(markup, WptSubstitution.Apply(markup));
+    }
+
+    /// <summary>Only a template is expanded; an ordinary document keeps any braces it contains.</summary>
+    [Fact]
+    public void ReadDocument_Expands_Only_A_Substitution_File()
+    {
+        var template = Path.Combine(_root, "a.sub.html");
+        var plain = Path.Combine(_root, "a.html");
+        File.WriteAllText(template, "<p>{{host}}</p>");
+        File.WriteAllText(plain, "<p>{{host}}</p>");
+
+        Assert.Equal("<p>web-platform.test</p>", WptSubstitution.ReadDocument(template, _root));
+        Assert.Equal("<p>{{host}}</p>", WptSubstitution.ReadDocument(plain, _root));
+    }
+
+    [Fact]
+    public void ReadDocument_Anchors_Location_At_The_Checkout()
+    {
+        var nested = Path.Combine(_root, "css", "x");
+        Directory.CreateDirectory(nested);
+        var template = Path.Combine(nested, "y.sub.html");
+        File.WriteAllText(template, "<p>{{location[path]}}</p>");
+
+        Assert.Equal("<p>/css/x/y.sub.html</p>", WptSubstitution.ReadDocument(template, _root));
+    }
+
+    // ── The document root a path is reported against ─────────────────────────
+
+    [Fact]
+    public void TryRootRelativePath_Is_Relative_To_The_Checkout()
+    {
+        var path = Path.Combine(_root, "css", "x.sub.html");
+        Assert.Equal("/css/x.sub.html", WptSubstitution.TryRootRelativePath(path, _root));
+    }
+
+    /// <summary>
+    /// The separator matters: a sibling directory whose name merely starts with the root's is
+    /// outside it.
+    /// </summary>
+    [Fact]
+    public void TryRootRelativePath_Rejects_A_Path_Outside_The_Checkout()
+    {
+        Assert.Null(WptSubstitution.TryRootRelativePath(_root + "-sibling/x.sub.html", _root));
+        Assert.Null(WptSubstitution.TryRootRelativePath(Path.Combine(_root, "x.sub.html"), null));
+    }
+
+    // ── The hosts served from the checkout ───────────────────────────────────
+
+    [Fact]
+    public void A_Served_Origin_Is_Stripped_To_Its_Path()
+    {
+        Assert.Equal("/css/a.html",
+            WptSubstitution.TryStripServedOrigin("http://web-platform.test:8000/css/a.html"));
+        Assert.Equal("/css/a.html",
+            WptSubstitution.TryStripServedOrigin("http://not-web-platform.test:8000/css/a.html"));
+        Assert.Equal("/css/a.html",
+            WptSubstitution.TryStripServedOrigin("https://www.web-platform.test:8443/css/a.html"));
+    }
+
+    [Fact]
+    public void A_Served_Origin_Keeps_Its_Query()
+    {
+        Assert.Equal("/css/a.html?pipe=trickle(d1)",
+            WptSubstitution.TryStripServedOrigin("http://web-platform.test:8000/css/a.html?pipe=trickle(d1)"));
+    }
+
+    /// <summary>
+    /// WPT mints <c>nonexistent.*</c> hosts to be unreachable. Serving them from the checkout would
+    /// make a load-failure test pass by loading something.
+    /// </summary>
+    [Theory]
+    [InlineData("http://nonexistent.web-platform.test:8000/css/a.html")]
+    [InlineData("http://example.com/css/a.html")]
+    [InlineData("http://web-platform.test.evil.example/css/a.html")]
+    [InlineData("ftp://web-platform.test:8000/css/a.html")]
+    [InlineData("/css/a.html")]
+    [InlineData("css/a.html")]
+    [InlineData(null)]
+    public void An_Unserved_Url_Is_Not_Stripped(string? url) =>
+        Assert.Null(WptSubstitution.TryStripServedOrigin(url));
+
+    /// <summary>
+    /// Every host the substitution can produce is a host the runner serves — otherwise a URL it
+    /// wrote itself would be one it then refuses to resolve.
+    /// </summary>
+    [Fact]
+    public void Every_Substitutable_Host_Is_Served()
+    {
+        foreach (var placeholder in new[]
+                 {
+                     "{{host}}", "{{hosts[][]}}", "{{hosts[alt][]}}", "{{domains[www]}}",
+                     "{{domains[www.www1]}}", "{{domains[élève]}}", "{{hosts[alt][www2]}}",
+                 })
+        {
+            var host = WptSubstitution.Apply(placeholder);
+            Assert.Equal("/x.html", WptSubstitution.TryStripServedOrigin($"http://{host}:8000/x.html"));
+        }
+    }
+
+    /// <summary>
+    /// The runner's own resource loaders take the same view: a substituted absolute URL names the
+    /// same file as the root-relative one it was built from.
+    /// </summary>
+    [Fact]
+    public void The_Resource_Resolver_Accepts_A_Served_Origin()
+    {
+        var dir = Path.Combine(_root, "images");
+        Directory.CreateDirectory(dir);
+        var onDisk = Path.Combine(dir, "blue.png");
+        File.WriteAllBytes(onDisk, [0]);
+
+        Assert.Equal(onDisk,
+            WptTestRunner.TryResolveWptRootRelativePath("http://web-platform.test:8000/images/blue.png", _root));
+        Assert.Equal(onDisk,
+            WptTestRunner.TryResolveWptRootRelativePath("/images/blue.png", _root));
+        Assert.Null(
+            WptTestRunner.TryResolveWptRootRelativePath("http://example.com/images/blue.png", _root));
+    }
+}

--- a/src/Broiler.Wpt/WptDocumentRenderer.cs
+++ b/src/Broiler.Wpt/WptDocumentRenderer.cs
@@ -651,6 +651,12 @@ internal static class WptDocumentRenderer
 
             if (dw > 0 && dh > 0 && fitsAllocation)
             {
+                // CSS Color Adjust §2.4: this frame's canvas is transparent unless its used colour
+                // scheme differs from *this element's* — the embedding element's, which may carry
+                // its own `color-scheme` independent of the containing document's. Pinned around
+                // the render so the frame's own canvas paint sees its embedder, exactly as
+                // HtmlRender.CompositeEmbeddedDocuments does it on the string-render path.
+                using var embedded = Broiler.Layout.Engine.EmbeddedCanvas.Pin(fragment.Style.ColorScheme);
                 using var sub = HtmlRender.RenderToImageWithStyleSet(
                     fragment.EmbeddedDocumentHtml!,
                     dw,
@@ -659,7 +665,7 @@ internal static class WptDocumentRenderer
                     stylesheetLoad: stylesheetLoad,
                     imageLoad: imageLoad,
                     baseUrl: fragment.EmbeddedDocumentBaseUrl);
-                BlitOnto(target, sub, dx, dy);
+                BlitFrameOnto(target, sub, dx, dy);
             }
         }
 
@@ -684,5 +690,62 @@ internal static class WptDocumentRenderer
                 target.SetPixel(tx, ty, source.GetPixel(x, y));
             }
         }
+    }
+
+    /// <summary>
+    /// Composites a rendered frame over <paramref name="target"/>, source-over rather than a copy:
+    /// a frame whose canvas is transparent (CSS Color Adjust §2.4) has to let the embedder show
+    /// through instead of punching it out. An opaque source takes the copy path, so a frame that
+    /// fills its own canvas — every frame, before that rule was modelled — is unchanged.
+    /// <para>
+    /// Separate from <see cref="BlitOnto"/> deliberately: that one also stacks the <c>@page</c>
+    /// backdrop, flow and margin-box layers of a print render, which are composed by replacement
+    /// and are no part of this rule.
+    /// </para>
+    /// </summary>
+    private static void BlitFrameOnto(BBitmap target, BBitmap source, int destX, int destY)
+    {
+        for (int y = 0; y < source.Height; y++)
+        {
+            int ty = destY + y;
+            if (ty < 0 || ty >= target.Height)
+                continue;
+
+            for (int x = 0; x < source.Width; x++)
+            {
+                int tx = destX + x;
+                if (tx < 0 || tx >= target.Width)
+                    continue;
+
+                target.SetPixel(tx, ty, BlendOver(source.GetPixel(x, y), target.GetPixel(tx, ty)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Porter-Duff source-over on straight (non-premultiplied) alpha. Mirrors
+    /// <c>HtmlRender.BlendOver</c>, which the string-render path composites frames with.
+    /// </summary>
+    private static BColor BlendOver(BColor source, BColor destination)
+    {
+        if (source.A == 255 || destination.A == 0)
+            return source;
+        if (source.A == 0)
+            return destination;
+
+        float sa = source.A / 255f;
+        float da = destination.A / 255f;
+        float outA = sa + da * (1f - sa);
+        if (outA <= 0f)
+            return BColor.Transparent;
+
+        byte Channel(byte s, byte d) =>
+            (byte)Math.Clamp((int)Math.Round((s * sa + d * da * (1f - sa)) / outA), 0, 255);
+
+        return BColor.FromArgb(
+            (byte)Math.Clamp((int)Math.Round(outA * 255f), 0, 255),
+            Channel(source.R, destination.R),
+            Channel(source.G, destination.G),
+            Channel(source.B, destination.B));
     }
 }

--- a/src/Broiler.Wpt/WptSubstitution.cs
+++ b/src/Broiler.Wpt/WptSubstitution.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Broiler.Wpt;
+
+/// <summary>
+/// WPT's server-side template substitution — the <c>sub</c> pipe every <c>*.sub.*</c> file is
+/// served through — and the set of hosts the runner therefore serves from the checkout.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A file whose name carries a <c>.sub</c> component is a <em>template</em>, not a document: the
+/// WPT server expands <c>{{host}}</c>, <c>{{ports[http][0]}}</c> and friends before sending it
+/// (<c>tools/wptserve/wptserve/pipes.py</c>). Read straight off disk the placeholders survive into
+/// the markup, so a URL built from them addresses nothing — which is why WPT's cross-origin
+/// reftests rendered an empty frame here and scored 0.0% against a reference whose frame was
+/// empty for the same reason. There are ~1 400 <c>.sub.html</c> files in the tree.
+/// </para>
+/// <para>
+/// The values are WPT's own defaults (<c>tools/serve/serve.py</c> <c>ConfigBuilder._default</c>,
+/// <c>tools/wptserve/wptserve/config.py</c> <c>_get_domains</c>): primary host
+/// <c>web-platform.test</c>, alternate host <c>not-web-platform.test</c>, and a subdomain set whose
+/// two-deep products (<c>www.www1</c>, …) are generated the way <c>_make_subdomains_product</c>
+/// generates them. Ports WPT allocates dynamically are pinned to the numbers its documentation
+/// uses, because a render has to be reproducible.
+/// </para>
+/// <para>
+/// <b>Only what a file on disk can answer is substituted.</b> <c>{{uuid()}}</c>,
+/// <c>{{headers[…]}}</c>, <c>{{GET[…]}}</c>, <c>{{file_hash(…)}}</c> and <c>{{$var:…}}</c> describe
+/// a live request; those placeholders are left exactly as they were read, so such a test renders
+/// as it does today rather than with a fabricated value. <c>{{not_domains[…]}}</c> is left alone
+/// for a stronger reason: it names a host that is *meant* not to resolve.
+/// </para>
+/// </remarks>
+internal static class WptSubstitution
+{
+    /// <summary>The primary host tests are served from (<c>browser_host</c>).</summary>
+    public const string PrimaryHost = "web-platform.test";
+
+    /// <summary>The second origin, for cross-origin tests (<c>alternate_hosts["alt"]</c>).</summary>
+    public const string AlternateHost = "not-web-platform.test";
+
+    /// <summary>
+    /// The port a substituted URL is given for each protocol. WPT fixes the first http and https
+    /// ports and allocates the rest at start-up; a runner has no server to ask, and the number only
+    /// has to round-trip through <see cref="ServedHosts"/>, so the documented ones are used.
+    /// </summary>
+    private static readonly Dictionary<string, int[]> Ports = new(StringComparer.Ordinal)
+    {
+        ["http"] = [8000, 8001],
+        ["https"] = [8443, 8444],
+        ["ws"] = [8888],
+        ["wss"] = [8889],
+        ["h2"] = [9000],
+    };
+
+    /// <summary>
+    /// WPT's subdomain set, closed under the two-deep products <c>_make_subdomains_product</c>
+    /// builds (<c>www</c>, <c>www.www1</c>, …), plus <c>""</c> for the bare host. Non-ASCII labels
+    /// are IDNA-encoded here exactly as <c>_get_domains</c> encodes them.
+    /// </summary>
+    private static readonly string[] BaseSubdomains = ["www", "www1", "www2", "天気の良い日", "élève"];
+
+    private static readonly Dictionary<string, Dictionary<string, string>> AllDomains = BuildAllDomains();
+
+    /// <summary>
+    /// Every host name <see cref="AllDomains"/> can produce, in the IDNA form a URL carries. These
+    /// are the hosts the runner serves from the checkout: WPT gives them all the same document
+    /// root, so an absolute URL on one of them names a file under the checkout.
+    /// </summary>
+    public static readonly string[] ServedHosts = AllDomains
+        .SelectMany(alias => alias.Value.Values)
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .OrderBy(host => host, StringComparer.Ordinal)
+        .ToArray();
+
+    /// <summary>Matches WPT's own template regex: <c>{{</c>, anything but <c>}</c>, <c>}}</c>.</summary>
+    private static readonly System.Text.RegularExpressions.Regex TemplateRegex = new(@"\{\{([^}]*)\}\}", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    /// <summary>An identifier followed by zero or more <c>[…]</c> indexes, and nothing else.</summary>
+    private static readonly System.Text.RegularExpressions.Regex FieldRegex = new(@"^([A-Za-z_][A-Za-z0-9_-]*)((?:\[[^\]]*\])*)$", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    private static readonly System.Text.RegularExpressions.Regex IndexRegex = new(@"\[([^\]]*)\]", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    /// <summary>
+    /// Whether <paramref name="path"/> names a template WPT would serve through the <c>sub</c>
+    /// pipe. WPT's rule is a literal <c>".sub." in path</c>
+    /// (<c>tools/wptserve/wptserve/handlers.py</c>), so it is a substring test and not an extension
+    /// one: <c>x.sub.html</c> and <c>x.tentative.sub.html</c> are both templates, and the match is
+    /// case-sensitive because Python's <c>in</c> is. Only the file name is examined — WPT tests the
+    /// request path, and the difference is a checkout directory with <c>.sub.</c> in its own name,
+    /// which would otherwise make every file beneath it a template.
+    /// </summary>
+    public static bool IsSubstitutionFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        var name = System.IO.Path.GetFileName(path);
+        return !string.IsNullOrEmpty(name) && name.Contains(".sub.", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Expands the placeholders in <paramref name="content"/> that a file on disk can answer,
+    /// leaving every other placeholder untouched. <paramref name="rootRelativePath"/> is the
+    /// document's own path under the checkout (<c>/css/…/x.sub.html</c>), which is what
+    /// <c>{{location[…]}}</c> reports; pass <see langword="null"/> to leave those alone too.
+    /// </summary>
+    public static string Apply(string content, string? rootRelativePath = null)
+    {
+        if (string.IsNullOrEmpty(content) || !content.Contains("{{", StringComparison.Ordinal))
+            return content;
+
+        return TemplateRegex.Replace(content, match =>
+        {
+            var resolved = TryResolveField(match.Groups[1].Value, rootRelativePath);
+            // An unsupported field keeps the placeholder verbatim: rendering a made-up value would
+            // be a worse lie than rendering the template text the reference also shows.
+            return resolved ?? match.Value;
+        });
+    }
+
+    /// <summary>
+    /// Reads <paramref name="path"/> and applies <see cref="Apply"/> when it is a template.
+    /// <paramref name="wptRoot"/> anchors <c>{{location[…]}}</c>; without it the document's own URL
+    /// is unknown and those placeholders are left alone.
+    /// </summary>
+    public static string ReadDocument(string path, string? wptRoot)
+    {
+        var content = System.IO.File.ReadAllText(path);
+        return IsSubstitutionFile(path) ? Apply(content, TryRootRelativePath(path, wptRoot)) : content;
+    }
+
+    /// <summary>
+    /// The root-relative URL path of <paramref name="path"/> under <paramref name="wptRoot"/>, or
+    /// <see langword="null"/> when it lies outside the checkout.
+    /// </summary>
+    internal static string? TryRootRelativePath(string path, string? wptRoot)
+    {
+        if (string.IsNullOrEmpty(wptRoot))
+            return null;
+
+        try
+        {
+            var full = System.IO.Path.GetFullPath(path);
+            // The separator matters: without it `/wpt` would claim `/wpt-scratch/x.sub.html`.
+            var root = System.IO.Path.GetFullPath(wptRoot).TrimEnd(System.IO.Path.DirectorySeparatorChar)
+                       + System.IO.Path.DirectorySeparatorChar;
+            if (!full.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            var relative = full[root.Length..].Replace(System.IO.Path.DirectorySeparatorChar, '/');
+            return "/" + relative.TrimStart('/');
+        }
+        catch (Exception ex) when (ex is ArgumentException or System.IO.PathTooLongException or NotSupportedException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// The root-relative form of an absolute URL on one of <see cref="ServedHosts"/>, or
+    /// <see langword="null"/>. Shares the engine's implementation so the runner's resource loaders
+    /// and its frame loading agree on what "served from the checkout" means.
+    /// </summary>
+    public static string? TryStripServedOrigin(string? url) =>
+        Broiler.Layout.Engine.DocumentRoot.TryStripLocalOrigin(url, ServedHosts);
+
+    private static string? TryResolveField(string expression, string? rootRelativePath)
+    {
+        // `{{$id:uuid()}}` / `{{$id}}` — a stash variable, which needs a request to have a value.
+        if (expression.StartsWith("$", StringComparison.Ordinal))
+            return null;
+
+        var field = FieldRegex.Match(expression);
+        if (!field.Success)
+            return null;   // a function call, or something this parser does not model
+
+        var name = field.Groups[1].Value;
+        var indexes = IndexRegex.Matches(field.Groups[2].Value).Select(m => m.Groups[1].Value).ToArray();
+
+        return name switch
+        {
+            "host" when indexes.Length == 0 => PrimaryHost,
+            "hosts" when indexes.Length == 2 => TryDomain(indexes[0], indexes[1]),
+            "domains" when indexes.Length == 1 => TryDomain("", indexes[0]),
+            "ports" when indexes.Length == 2 => TryPort(indexes[0], indexes[1]),
+            "location" when indexes.Length == 1 => TryLocation(indexes[0], rootRelativePath),
+            _ => null,
+        };
+    }
+
+    private static string? TryDomain(string alias, string subdomain) =>
+        AllDomains.TryGetValue(alias, out var domains) && domains.TryGetValue(subdomain, out var host)
+            ? host
+            : null;
+
+    private static string? TryPort(string protocol, string index) =>
+        Ports.TryGetValue(protocol, out var ports)
+        && int.TryParse(index, NumberStyles.None, CultureInfo.InvariantCulture, out var i)
+        && i >= 0 && i < ports.Length
+            ? ports[i].ToString(CultureInfo.InvariantCulture)
+            : null;
+
+    private static string? TryLocation(string key, string? rootRelativePath)
+    {
+        if (rootRelativePath is null)
+            return null;
+
+        var port = Ports["http"][0].ToString(CultureInfo.InvariantCulture);
+        var pathOnly = rootRelativePath.Split('?', '#')[0];
+        var query = rootRelativePath.Contains('?', StringComparison.Ordinal)
+            ? "?" + rootRelativePath.Split('?')[1].Split('#')[0]
+            : "?";
+
+        return key switch
+        {
+            "server" => $"http://{PrimaryHost}:{port}",
+            "scheme" => "http",
+            "host" => $"{PrimaryHost}:{port}",
+            "hostname" => PrimaryHost,
+            "port" => port,
+            "path" or "pathname" => pathOnly,
+            "query" => query,
+            _ => null,
+        };
+    }
+
+    private static Dictionary<string, Dictionary<string, string>> BuildAllDomains()
+    {
+        var subdomains = MakeSubdomainProduct(BaseSubdomains, depth: 2);
+        var hosts = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [""] = PrimaryHost,
+            ["alt"] = AlternateHost,
+        };
+
+        var idn = new IdnMapping();
+        var all = new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal);
+        foreach (var (alias, host) in hosts)
+        {
+            var domains = new Dictionary<string, string>(StringComparer.Ordinal) { [""] = host };
+            foreach (var subdomain in subdomains)
+                domains[subdomain] = idn.GetAscii(subdomain) + "." + host;
+
+            all[alias] = domains;
+        }
+
+        return all;
+    }
+
+    /// <summary>
+    /// WPT's <c>_make_subdomains_product</c>: every dot-joined tuple of the base labels up to
+    /// <paramref name="depth"/> long, so <c>www</c> and <c>www.www1</c> are both valid subdomains.
+    /// </summary>
+    private static List<string> MakeSubdomainProduct(IReadOnlyList<string> labels, int depth)
+    {
+        var result = new List<string>();
+        IEnumerable<string> level = labels;
+        for (var i = 1; i <= depth; i++)
+        {
+            result.AddRange(level);
+            level = level.SelectMany(prefix => labels.Select(label => prefix + "." + label)).ToList();
+        }
+
+        return result;
+    }
+}

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -1689,7 +1689,7 @@ internal sealed partial class WptTestRunner
         string html;
         try
         {
-            html = File.ReadAllText(testPath);
+            html = WptSubstitution.ReadDocument(testPath, wptRoot);
         }
         catch (Exception ex)
         {
@@ -1818,8 +1818,10 @@ internal sealed partial class WptTestRunner
         {
             using var presentation = ImageAnimationClock.Pin(presentationTime);
             // The checkout is the document root a `/`-rooted <frame>/<iframe> src resolves against,
-            // matching what the stylesheet/image handlers above already do for their own URLs.
-            using var documentRoot = Broiler.Layout.Engine.DocumentRoot.Pin(wptRoot);
+            // matching what the stylesheet/image handlers above already do for their own URLs — and
+            // it is what WPT's own hosts serve, so a substituted `.sub` template's cross-origin
+            // frame resolves to the same checkout instead of to a network fetch that cannot happen.
+            using var documentRoot = Broiler.Layout.Engine.DocumentRoot.Pin(wptRoot, WptSubstitution.ServedHosts);
             rendered = RenderWithNativeAnchor(html, () => renderDocument is not null
                 ? WptDocumentRenderer.RenderToImage(renderDocument, _width, _height,
                     backgroundColor: BColor.White,
@@ -2046,7 +2048,7 @@ internal sealed partial class WptTestRunner
         string html;
         try
         {
-            html = File.ReadAllText(testPath);
+            html = WptSubstitution.ReadDocument(testPath, wptRoot);
         }
         catch (Exception ex)
         {
@@ -2406,9 +2408,12 @@ internal sealed partial class WptTestRunner
     }
 
     /// <summary>
-    /// Maps a root-relative WPT URL (<c>/images/blue.png</c>, <c>/fonts/Ahem.ttf</c>) onto the file
-    /// it names under <paramref name="wptRoot"/>, mirroring what a real WPT server resolves. Returns
-    /// <c>null</c> when the URL is not root-relative or names nothing on disk.
+    /// Maps a root-relative WPT URL (<c>/images/blue.png</c>, <c>/fonts/Ahem.ttf</c>) — or an
+    /// absolute one on a host WPT serves from the same checkout
+    /// (<c>http://www.web-platform.test:8000/images/blue.png</c>, which is what a substituted
+    /// <c>.sub</c> template carries) — onto the file it names under <paramref name="wptRoot"/>,
+    /// mirroring what a real WPT server resolves. Returns <c>null</c> when the URL is neither of
+    /// those or names nothing on disk.
     /// <para>
     /// The query and fragment are stripped, and percent-escapes decoded, before touching the disk —
     /// exactly what the reference generator's <c>decodeFileUrlPath</c> does on its side. WPT routinely
@@ -2421,6 +2426,11 @@ internal sealed partial class WptTestRunner
     /// </summary>
     internal static string? TryResolveWptRootRelativePath(string? src, string wptRoot)
     {
+        // A `.sub` template's URLs are absolute and on a WPT host (`http://www.web-platform.test:8000/…`)
+        // once substituted. WPT serves every one of those hosts from this same checkout, so such a
+        // URL is the root-relative one with an origin in front of it.
+        src = WptSubstitution.TryStripServedOrigin(src) ?? src;
+
         if (src == null || !src.StartsWith("/", StringComparison.Ordinal))
             return null;
 
@@ -2469,7 +2479,7 @@ internal sealed partial class WptTestRunner
     {
         string html;
         using (WptPhaseTrace.Measure(WptPhaseTrace.Phases.FileRead))
-            html = File.ReadAllText(htmlPath);
+            html = WptSubstitution.ReadDocument(htmlPath, wptRoot);
 
         if (IsMediaPlaybackTest(html))
             throw new InvalidOperationException("Test requires media playback.");
@@ -2517,8 +2527,10 @@ internal sealed partial class WptTestRunner
 
         using var presentation = ImageAnimationClock.Pin(presentationTime);
         // The checkout is the document root a `/`-rooted <frame>/<iframe> src resolves against,
-        // matching what the stylesheet/image handlers above already do for their own URLs.
-        using var documentRoot = Broiler.Layout.Engine.DocumentRoot.Pin(wptRoot);
+        // matching what the stylesheet/image handlers above already do for their own URLs — and
+        // it is what WPT's own hosts serve, so a substituted `.sub` template's cross-origin frame
+        // resolves to the same checkout instead of to a network fetch that cannot happen.
+        using var documentRoot = Broiler.Layout.Engine.DocumentRoot.Pin(wptRoot, WptSubstitution.ServedHosts);
         using (WptPhaseTrace.Measure(WptPhaseTrace.Phases.Render))
         {
             // `@page` paint applies to paged media only, so it is read for a print test and for


### PR DESCRIPTION
https://claude.ai/code/session_01UEupk7UdYdQNAXpQ3ex1m7