### PR TITLE
Fix replaced element sizing and viewport overflow propagation

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/ReplacedBoxSizingTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/ReplacedBoxSizingTests.cs
@@ -1,0 +1,147 @@
+using Broiler.Layout.Engine;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// CSS2.1 §10.4/§10.7: the min/max constraint pass over a tentative replaced-element size.
+/// </summary>
+/// <remarks>
+/// The interesting half is that the two axes are <em>coupled</em> for a box with an intrinsic ratio.
+/// Clamping them independently is what made WPT
+/// <c>css-sizing/replaced-max-size-saturation</c> — an 8000×8000 <c>&lt;canvas&gt;</c> under
+/// <c>max-width: 120px; max-height: 100px</c> — come out 120×100 (a rectangle) where every browser
+/// renders the 100×100 square the test's reference draws.
+/// </remarks>
+public sealed class ReplacedBoxSizingTests
+{
+    private static (double Width, double Height) Constrain(
+        double width, double height, double ratio,
+        double minWidth = 0, double maxWidth = double.PositiveInfinity,
+        double minHeight = 0, double maxHeight = double.PositiveInfinity,
+        bool widthIsAuto = true, bool heightIsAuto = true)
+    {
+        ReplacedBoxSizing.ApplyMinMax(
+            ref width, ref height, widthIsAuto, heightIsAuto, ratio,
+            new ReplacedBoxSizing.Bounds(minWidth, maxWidth),
+            new ReplacedBoxSizing.Bounds(minHeight, maxHeight));
+
+        return (width, height);
+    }
+
+    [Fact]
+    public void An_Unconstrained_Size_Is_Left_Alone()
+    {
+        Assert.Equal((400d, 200d), Constrain(400, 200, ratio: 2));
+    }
+
+    // The saturation test itself: both upper bounds are violated, and max-height bites harder
+    // (100/8000 < 120/8000), so the height wins and the width follows the 1:1 ratio.
+    [Fact]
+    public void Both_Maximums_Violated_Keeps_The_Ratio_Of_Whichever_Bites_Harder()
+    {
+        Assert.Equal((100d, 100d), Constrain(8000, 8000, ratio: 1, maxWidth: 120, maxHeight: 100));
+    }
+
+    [Fact]
+    public void Both_Maximums_Violated_The_Other_Way_Round_Lets_The_Width_Win()
+    {
+        // 200×800 (ratio 1/4) under 100×700: max-width/w = 0.5 ≤ max-height/h = 0.875, so the width
+        // is the binding constraint and the height follows it down through the ratio.
+        Assert.Equal((100d, 400d), Constrain(200, 800, ratio: 0.25, maxWidth: 100, maxHeight: 700));
+    }
+
+    [Fact]
+    public void An_Over_Wide_Box_Pulls_Its_Auto_Height_Down_Through_The_Ratio()
+    {
+        Assert.Equal((100d, 50d), Constrain(400, 200, ratio: 2, maxWidth: 100));
+    }
+
+    [Fact]
+    public void An_Over_Tall_Box_Pulls_Its_Auto_Width_Down_Through_The_Ratio()
+    {
+        Assert.Equal((100d, 50d), Constrain(400, 200, ratio: 2, maxHeight: 50));
+    }
+
+    [Fact]
+    public void An_Under_Wide_Box_Grows_Both_Axes()
+    {
+        Assert.Equal((400d, 200d), Constrain(40, 20, ratio: 2, minWidth: 400));
+    }
+
+    [Fact]
+    public void An_Under_Tall_Box_Grows_Both_Axes()
+    {
+        Assert.Equal((400d, 200d), Constrain(40, 20, ratio: 2, minHeight: 200));
+    }
+
+    // The ratio-preserving growth is still bounded by the other axis's maximum.
+    [Fact]
+    public void Growing_To_Min_Width_Stops_At_Max_Height()
+    {
+        Assert.Equal((400d, 100d), Constrain(40, 20, ratio: 2, minWidth: 400, maxHeight: 100));
+    }
+
+    [Fact]
+    public void Both_Minimums_Violated_Keeps_The_Ratio_Of_Whichever_Bites_Harder()
+    {
+        // min-width/w = 10 > min-height/h = 5, so the width is the binding constraint.
+        Assert.Equal((400d, 200d), Constrain(40, 20, ratio: 2, minWidth: 400, minHeight: 100));
+    }
+
+    [Fact]
+    public void Both_Minimums_Violated_The_Other_Way_Round_Lets_The_Height_Win()
+    {
+        // min-height/h = 10 ≥ min-width/w = 5, so the height is the binding constraint.
+        Assert.Equal((400d, 200d), Constrain(40, 20, ratio: 2, minWidth: 200, minHeight: 200));
+    }
+
+    [Fact]
+    public void Opposing_Violations_Take_Both_Bounds_And_Drop_The_Ratio()
+    {
+        Assert.Equal((200d, 50d), Constrain(40, 200, ratio: 0.2, minWidth: 200, maxHeight: 50));
+        Assert.Equal((100d, 80d), Constrain(400, 20, ratio: 20, maxWidth: 100, minHeight: 80));
+    }
+
+    // With no intrinsic ratio the axes are independent — which is also the whole of the correct
+    // behaviour for a non-replaced inline-block.
+    [Fact]
+    public void Without_A_Ratio_Each_Axis_Is_Clamped_On_Its_Own()
+    {
+        Assert.Equal((120d, 100d), Constrain(8000, 8000, ratio: 0, maxWidth: 120, maxHeight: 100));
+    }
+
+    [Fact]
+    public void A_Minimum_Beats_A_Smaller_Maximum()
+    {
+        Assert.Equal((80d, 40d), Constrain(10, 5, ratio: 0, minWidth: 80, maxWidth: 20, minHeight: 40, maxHeight: 10));
+    }
+
+    // A stated axis is the author's; clamping it moves the auto one through the ratio, never the
+    // other way round. Chromium renders `height: 1000px; max-width: 100px` on a 1:1 image as
+    // 100×1000 — the max-width shortens the width only.
+    [Fact]
+    public void A_Stated_Height_Is_Not_Shortened_By_Max_Width()
+    {
+        Assert.Equal((100d, 1000d), Constrain(1000, 1000, ratio: 1, maxWidth: 100, heightIsAuto: false));
+    }
+
+    [Fact]
+    public void Clamping_A_Stated_Height_Re_Derives_The_Auto_Width()
+    {
+        Assert.Equal((100d, 100d), Constrain(1000, 1000, ratio: 1, maxHeight: 100, heightIsAuto: false));
+    }
+
+    [Fact]
+    public void Clamping_A_Stated_Width_Re_Derives_The_Auto_Height()
+    {
+        Assert.Equal((100d, 50d), Constrain(1000, 500, ratio: 2, maxWidth: 100, widthIsAuto: false));
+    }
+
+    [Fact]
+    public void With_Both_Axes_Stated_Neither_Follows_The_Other()
+    {
+        Assert.Equal((120d, 100d), Constrain(8000, 8000, ratio: 1, maxWidth: 120, maxHeight: 100,
+            widthIsAuto: false, heightIsAuto: false));
+    }
+}

--- a/Broiler.Layout/Broiler.Layout.Tests/ReplacedImageSizingTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/ReplacedImageSizingTests.cs
@@ -231,6 +231,49 @@ public sealed class ReplacedImageSizingTests
         Assert.Equal(0, word.Height, 3);
     }
 
+    // CSS2.1 §10.3.8/§10.6.5: an absolutely positioned replaced element is sized by the *replaced*
+    // rules — the insets decide where it goes, never how big it is, and `right`/`bottom` are what
+    // give way when they over-constrain. Broiler used to solve the §10.3.7 inset equation for it
+    // (stretching an `<img left:4em; right:0; top:4em; bottom:0>` across the whole inset box) or, if
+    // `right` was absent, shrink-to-fit it against its non-existent children and get zero — which
+    // is why an `<img position:absolute; left:4em; top:4em>` painted nothing at all.
+    // WPT CSS2/positioning/abspos-025 and the 22 `absolute-replaced-*` tests pin the rendering; this
+    // pins the sizing rule the call sites now share.
+    [Theory]
+    [InlineData("auto", "auto", 15d, 15d)]
+    [InlineData("40px", "auto", 40d, 40d)]
+    [InlineData("auto", "40px", 40d, 40d)]
+    public void An_Abspos_Replaced_Box_Is_Sized_By_Its_Natural_Size_Not_By_Its_Insets(
+        string width, string height, double expectedWidth, double expectedHeight)
+    {
+        var environment = new FakeLayoutEnvironment(new ImageIntrinsics(15, 15, true));
+        var root = new CssBox(null, null, BaseUrl)
+        {
+            Display = "block",
+            Size = new SizeF(400, 400),
+            LayoutEnvironment = environment,
+        };
+        var box = new CssBox(root, new HtmlTag("canvas", false, null), BaseUrl)
+        {
+            Display = "block",
+            Position = "absolute",
+            Left = "64px",
+            Right = "0",
+            Top = "64px",
+            Bottom = "0",
+            Width = width,
+            Height = height,
+            IntrinsicReplacedSize = new SizeF(15, 15),
+            LayoutEnvironment = environment,
+        };
+
+        box.ResolveReplacedContentSize(box.IntrinsicReplacedSize.Value, 400,
+            out double contentWidth, out double contentHeight);
+
+        Assert.Equal(expectedWidth, contentWidth, 3);
+        Assert.Equal(expectedHeight, contentHeight, 3);
+    }
+
     // Minimal ILayoutEnvironment: a fixed font, and the one image's intrinsics.
     private sealed class FakeLayoutEnvironment(ImageIntrinsics intrinsics) : Broiler.Layout.ILayoutEnvironment
     {

--- a/Broiler.Layout/Broiler.Layout.Tests/ReplacedImageSizingTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/ReplacedImageSizingTests.cs
@@ -91,6 +91,135 @@ public sealed class ReplacedImageSizingTests
         Assert.Equal(17, word.Height, 3);
     }
 
+    // ─────────── CSS2.1 §10.4/§10.7: min-/max-* on an inline replaced element ───────────
+    //
+    // These are WPT css-sizing/block-image-percentage-max-height-inside-inline and
+    // css-sizing/image-percentage-max-height-in-anonymous-block, which both put a 1×1 image with
+    // `height: 1000px; max-width: 100px; max-height: 100%` inside a 100px-tall <div> and expect a
+    // 100px green square. Every expectation below was taken from Chromium rather than read off the
+    // spec — which is how the third case got written down correctly.
+
+    /// <summary>The image sits in <c>div{height:100px}</c> → (optionally an anonymous block) → img,
+    /// which is the shape both WPT tests build.</summary>
+    private static CssRectImage MeasureInDefiniteBlock(
+        string width, string height, string maxWidth, string maxHeight,
+        bool throughAnonymousBlock, double imageWidth = 1, double imageHeight = 1)
+    {
+        var environment = new FakeLayoutEnvironment(new ImageIntrinsics(imageWidth, imageHeight, true));
+
+        var root = new CssBox(null, null, BaseUrl)
+        {
+            Display = "block",
+            Size = new SizeF(400, 400),
+            LayoutEnvironment = environment,
+        };
+        var definite = new CssBox(root, new HtmlTag("div", false, null), BaseUrl)
+        {
+            Display = "block",
+            Width = "100px",
+            Height = "100px",
+            Size = new SizeF(100, 0),
+            LayoutEnvironment = environment,
+        };
+        // An anonymous block has no HtmlTag and never an author height, so it must not be the
+        // percentage basis — the walk has to climb past it to the <div>.
+        var parent = throughAnonymousBlock
+            ? new CssBox(definite, null, BaseUrl) { Display = "block", LayoutEnvironment = environment }
+            : definite;
+
+        var box = new CssBox(parent, new HtmlTag("img", true, null), BaseUrl)
+        {
+            Display = "inline",
+            Width = width,
+            Height = height,
+            MaxWidth = maxWidth,
+            MaxHeight = maxHeight,
+            LayoutEnvironment = environment,
+        };
+        var word = new CssRectImage(box) { Image = new object() };
+
+        CssLayoutEngine.MeasureImageSize(environment, word);
+        return word;
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void A_Percentage_Max_Height_Resolves_Against_The_Nearest_Definite_Element(bool throughAnonymousBlock)
+    {
+        var word = MeasureInDefiniteBlock("auto", "1000px", "100px", "100%", throughAnonymousBlock);
+
+        Assert.Equal(100, word.Width, 3);
+        Assert.Equal(100, word.Height, 3);
+    }
+
+    // A stated height is the author's: max-width shortens the ratio-derived width and leaves it be.
+    [Fact]
+    public void Max_Width_Shortens_The_Derived_Width_Only()
+    {
+        var word = MeasureInDefiniteBlock("auto", "1000px", "100px", "none", throughAnonymousBlock: false);
+
+        Assert.Equal(100, word.Width, 3);
+        Assert.Equal(1000, word.Height, 3);
+    }
+
+    // Both axes auto and both maximums violated: §10.4's table, which keeps the ratio rather than
+    // taking one bound per axis (that would be 120×100 here).
+    [Fact]
+    public void Both_Maximums_Violated_Keeps_The_Intrinsic_Ratio()
+    {
+        var word = MeasureInDefiniteBlock("auto", "auto", "120px", "100px", throughAnonymousBlock: false,
+            imageWidth: 8000, imageHeight: 8000);
+
+        Assert.Equal(100, word.Width, 3);
+        Assert.Equal(100, word.Height, 3);
+    }
+
+    // CSS2.1 §10.7: with nothing definite above it, a percentage max-height is `none`.
+    [Fact]
+    public void A_Percentage_Max_Height_Against_An_Indefinite_Ancestor_Does_Not_Clamp()
+    {
+        var environment = new FakeLayoutEnvironment(new ImageIntrinsics(1, 1, true));
+        var root = new CssBox(null, null, BaseUrl)
+        {
+            Display = "block",
+            Size = new SizeF(400, 400),
+            LayoutEnvironment = environment,
+        };
+        var autoHeight = new CssBox(root, new HtmlTag("div", false, null), BaseUrl)
+        {
+            Display = "block",
+            LayoutEnvironment = environment,
+        };
+        var box = new CssBox(autoHeight, new HtmlTag("img", true, null), BaseUrl)
+        {
+            Display = "inline",
+            Height = "1000px",
+            MaxHeight = "10%",
+            LayoutEnvironment = environment,
+        };
+        var word = new CssRectImage(box) { Image = new object() };
+
+        CssLayoutEngine.MeasureImageSize(environment, word);
+
+        Assert.Equal(1000, word.Height, 3);
+    }
+
+    // ParseLength resolves an unrecognised unit to 0px, so a keyword max-* must be rejected before
+    // it reaches the parser rather than clamping the image out of existence.
+    [Theory]
+    [InlineData("fit-content")]
+    [InlineData("max-content")]
+    [InlineData("stretch")]
+    public void A_Keyword_Max_Width_Leaves_The_Image_Alone(string keyword)
+    {
+        var word = MeasureInDefiniteBlock("auto", "auto", keyword, "none", throughAnonymousBlock: false,
+            imageWidth: 40, imageHeight: 20);
+
+        Assert.Equal(40, word.Width, 3);
+        Assert.Equal(20, word.Height, 3);
+    }
+
     // Minimal ILayoutEnvironment: a fixed font, and the one image's intrinsics.
     private sealed class FakeLayoutEnvironment(ImageIntrinsics intrinsics) : Broiler.Layout.ILayoutEnvironment
     {

--- a/Broiler.Layout/Broiler.Layout.Tests/ReplacedImageSizingTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/ReplacedImageSizingTests.cs
@@ -220,6 +220,17 @@ public sealed class ReplacedImageSizingTests
         Assert.Equal(20, word.Height, 3);
     }
 
+    // The other half of that guard: zero is min-*'s initial value but a real clamp for max-*, so it
+    // must not be filtered out with the keywords (WPT CSS2/normal-flow/max-height-101).
+    [Fact]
+    public void A_Zero_Max_Height_Clamps_To_Nothing()
+    {
+        var word = MeasureInDefiniteBlock("auto", "auto", "none", "0", throughAnonymousBlock: false,
+            imageWidth: 40, imageHeight: 20);
+
+        Assert.Equal(0, word.Height, 3);
+    }
+
     // Minimal ILayoutEnvironment: a fixed font, and the one image's intrinsics.
     private sealed class FakeLayoutEnvironment(ImageIntrinsics intrinsics) : Broiler.Layout.ILayoutEnvironment
     {

--- a/Broiler.Layout/Broiler.Layout.Tests/ViewportOverflowPropagationTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/ViewportOverflowPropagationTests.cs
@@ -1,0 +1,105 @@
+using System;
+using Broiler.Layout.Engine;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// CSS Overflow 3 §3.3: a non-<c>visible</c> <c>overflow</c> on the <c>&lt;body&gt;</c> is applied
+/// to the <b>viewport</b>, not to the body's own box, whenever the root element leaves its own
+/// <c>overflow</c> at <c>visible</c>.
+/// </summary>
+/// <remarks>
+/// Broiler had no propagation at all, so <c>body { overflow: hidden }</c> clipped the body's own
+/// box — WPT <c>css-overflow/overflow-body-propagation-009</c> renders 0.3 % of the canvas where the
+/// reference renders 82 %. The rule that needs pinning is not the common case but the
+/// disqualifications: only the <em>first</em> <c>&lt;body&gt;</c> propagates, only if it generates a
+/// box, and never over a root element that set its own value
+/// (<c>overflow-body-propagation-016</c> is a document with two of them).
+/// </remarks>
+public sealed class ViewportOverflowPropagationTests
+{
+    private static readonly Uri BaseUrl = new("file:///page.html");
+
+    /// <summary>Builds <c>html &gt; body…</c> and runs the propagation on the body at
+    /// <paramref name="bodyIndex"/>, returning that body's used overflow.</summary>
+    private static (string Body, string Root) Propagate(
+        string rootOverflow, string[] bodyOverflows, string[] bodyDisplays, int bodyIndex)
+    {
+        var root = new CssBox(null, new HtmlTag("html", false, null), BaseUrl)
+        {
+            Display = "block",
+            Overflow = rootOverflow,
+        };
+
+        var bodies = new CssBox[bodyOverflows.Length];
+        for (int i = 0; i < bodyOverflows.Length; i++)
+        {
+            bodies[i] = new CssBox(root, new HtmlTag("body", false, null), BaseUrl)
+            {
+                Display = bodyDisplays[i],
+                Overflow = bodyOverflows[i],
+            };
+        }
+
+        bodies[bodyIndex].ApplyViewportOverflowPropagation();
+        return (bodies[bodyIndex].Overflow, root.Overflow);
+    }
+
+    [Theory]
+    [InlineData("hidden")]
+    [InlineData("clip")]
+    [InlineData("scroll")]
+    [InlineData("auto")]
+    public void The_Bodys_Overflow_Goes_To_The_Viewport(string overflow)
+    {
+        var (body, root) = Propagate("visible", [overflow], ["block"], 0);
+
+        Assert.Equal("visible", body);
+        // The value lands on the viewport, which Broiler clips at the canvas edge — not on the root
+        // element's box, whose border box is a different rectangle once the body has margins.
+        Assert.Equal("visible", root);
+    }
+
+    [Fact]
+    public void A_Root_That_Set_Its_Own_Overflow_Keeps_It_And_The_Body_Keeps_Its_Own()
+    {
+        var (body, root) = Propagate("scroll", ["hidden"], ["block"], 0);
+
+        Assert.Equal("hidden", body);
+        Assert.Equal("scroll", root);
+    }
+
+    [Fact]
+    public void A_Visible_Body_Has_Nothing_To_Propagate()
+    {
+        Assert.Equal("visible", Propagate("visible", ["visible"], ["block"], 0).Body);
+    }
+
+    // Two <body> elements: only the first propagates, so the second keeps its own clip.
+    [Fact]
+    public void A_Second_Body_Does_Not_Propagate()
+    {
+        var (body, _) = Propagate("visible", ["scroll", "hidden"], ["block", "block"], 1);
+
+        Assert.Equal("hidden", body);
+    }
+
+    // …and when the first generates no box, nothing propagates at all — the turn does not pass to
+    // the second (overflow-body-propagation-016).
+    [Fact]
+    public void A_Display_None_First_Body_Does_Not_Hand_The_Turn_To_The_Second()
+    {
+        var (body, _) = Propagate("visible", ["scroll", "hidden"], ["none", "block"], 1);
+
+        Assert.Equal("hidden", body);
+    }
+
+    [Fact]
+    public void A_Display_None_First_Body_Propagates_Nothing_Itself()
+    {
+        var (body, _) = Propagate("visible", ["scroll", "hidden"], ["none", "block"], 0);
+
+        Assert.Equal("scroll", body);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
@@ -569,4 +569,89 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         return flowCb?.Size.Height ?? 0;
     }
 
+    /// <summary>
+    /// CSS2.1 §10.7: the block size a percentage <c>min-height</c>/<c>max-height</c> on this box
+    /// resolves against, or <see langword="false"/> when the containing block's block size is
+    /// indefinite — the percentage then takes its initial value (<c>0</c> for <c>min-height</c>,
+    /// <c>none</c> for <c>max-height</c>).
+    /// </summary>
+    /// <remarks>
+    /// <para>Unlike <see cref="PercentageHeightContainingBlockHeight"/> this walks <b>past anonymous
+    /// boxes</b>. An anonymous block is not an element: it has no author height, so its block size
+    /// is always content-derived, and stopping at one would make every percentage inside it resolve
+    /// to the initial value. Browsers skip them and resolve against the nearest real element, which
+    /// is exactly what WPT <c>css-sizing/image-percentage-max-height-in-anonymous-block</c> and
+    /// <c>css-sizing/block-image-percentage-max-height-inside-inline</c> are built to check: in both
+    /// the <c>&lt;img&gt;</c> lands in an anonymous block, and its <c>max-height: 100%</c> must still
+    /// see the <c>height: 100px</c> <c>&lt;div&gt;</c> two boxes up.</para>
+    /// <para>Read at measurement time, before block heights are resolved bottom-up, so a definite
+    /// basis is derived from the <em>specified</em> height rather than from
+    /// <see cref="CssBoxProperties.Size"/> — which is still 0 for an ancestor that has not been laid
+    /// out yet.</para>
+    /// </remarks>
+    internal bool TryGetPercentageBlockSizeBasis(out double basis)
+    {
+        basis = 0;
+
+        // An out-of-flow box's containing block is a padding box with a definite height (the
+        // viewport for the initial containing block), so a percentage never resolves to the
+        // initial value there.
+        if (Position is CssConstants.Absolute or CssConstants.Fixed)
+        {
+            basis = PercentageHeightContainingBlockHeight();
+            return basis > 0;
+        }
+
+        for (var cb = ContainingBlock; cb != null; cb = cb.ContainingBlock)
+        {
+            // The initial containing block is the viewport, which is always definite (§10.5).
+            if (cb.ParentBox == null)
+            {
+                if (LayoutEnvironment == null)
+                    return false;
+
+                basis = LayoutEnvironment.ViewportSize.Height;
+                return basis > 0;
+            }
+
+            bool heightIsAuto = cb.Height == CssConstants.Auto || string.IsNullOrEmpty(cb.Height);
+
+            if (!heightIsAuto && !cb.Height.Contains('%'))
+            {
+                double cssHeight = CssLengthParser.ParseLength(cb.Height, 0, cb.GetEmHeight());
+                if (cssHeight > 0)
+                {
+                    basis = cb.ResolveSpecifiedHeightToContentBox(cssHeight);
+                    return true;
+                }
+
+                return false;
+            }
+
+            // CSS Sizing 4 §4: an auto block axis that the box's aspect ratio makes definite is a
+            // definite basis, the same exception HeightPercentageResolvesToAuto makes.
+            if (heightIsAuto && cb.HasDefiniteAspectRatioBlockHeight())
+            {
+                cb.TryGetAspectRatioBlockHeight(out basis);
+                return basis > 0;
+            }
+
+            // A real element with an auto (or already-resolved percentage) height: its used block
+            // size, when layout has settled it, and otherwise indefinite. Size.Height is a border
+            // box, so the padding and border come off it to leave the content height percentages
+            // resolve against.
+            if (cb.HtmlTag != null)
+            {
+                basis = Math.Max(0, cb.Size.Height
+                    - cb.ActualPaddingTop - cb.ActualPaddingBottom
+                    - cb.ActualBorderTopWidth - cb.ActualBorderBottomWidth);
+                return basis > 0 && !heightIsAuto;
+            }
+
+            // Anonymous: keep climbing.
+        }
+
+        return false;
+    }
+
 }

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
@@ -640,7 +640,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             // size, when layout has settled it, and otherwise indefinite. Size.Height is a border
             // box, so the padding and border come off it to leave the content height percentages
             // resolve against.
-            if (cb.HtmlTag != null)
+            if (cb.HtmlTag != null && !cb.IsBlockifiedInlineSplit)
             {
                 basis = Math.Max(0, cb.Size.Height
                     - cb.ActualPaddingTop - cb.ActualPaddingBottom
@@ -648,7 +648,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 return basis > 0 && !heightIsAuto;
             }
 
-            // Anonymous: keep climbing.
+            // Anonymous, or an inline blockified by a block-inside-inline split: keep climbing.
         }
 
         return false;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
@@ -160,7 +160,16 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                     - ContainingBlock.ActualBorderLeftWidth - ContainingBlock.ActualBorderRightWidth;
         }
 
-        if (IsIntrinsicWidthKeyword(Width) && Float == CssConstants.None)
+        // CSS2.1 §10.3.4: a block-level *replaced* element resolves its width with the inline rules
+        // (§10.3.2) — an auto width is its natural width, not the containing block's. Only a box
+        // carrying a natural size reaches this (a `display: block` <canvas>); the min/max pass
+        // inside settles both axes together, and ResolveUsedBlockHeight reads the block one back.
+        if (IntrinsicReplacedSize is { Width: > 0, Height: > 0 } naturalSize)
+        {
+            ResolveReplacedContentSize(naturalSize, width, out double replacedWidth, out _);
+            width = ResolveSpecifiedWidthToBorderBox(replacedWidth);
+        }
+        else if (IsIntrinsicWidthKeyword(Width) && Float == CssConstants.None)
         {
             // CSS Sizing 3 §5: width resolves to an intrinsic size
             // (min-content / max-content / fit-content). This also applies to an
@@ -234,9 +243,11 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
         // CSS2.1 §10.4: Apply max-width constraint even when
         // Width is auto — the tentative used width must not exceed
-        // max-width.
+        // max-width. A replaced box has already had both bounds applied to both axes together
+        // above, and re-clamping here would use a different percentage basis.
+        bool replacedSizeSettled = IntrinsicReplacedSize is { Width: > 0, Height: > 0 };
 
-        if (MaxWidth != "none" && !string.IsNullOrEmpty(MaxWidth))
+        if (!replacedSizeSettled && MaxWidth != "none" && !string.IsNullOrEmpty(MaxWidth))
         {
             double maxW = ResolveMaxWidthLength(width);
             maxW = ResolveSpecifiedWidthToBorderBox(maxW);
@@ -245,7 +256,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
         // CSS2.1 §10.4: Apply min-width constraint (min wins over
         // max per §10.4) — also when Width is auto.
-        if (MinWidth != "0" && !string.IsNullOrEmpty(MinWidth))
+        if (!replacedSizeSettled && MinWidth != "0" && !string.IsNullOrEmpty(MinWidth))
         {
             double minW = ResolveMinWidthLength(width);
 
@@ -1372,6 +1383,20 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             ActualBottom = Location.Y + borderBoxH;
         }
 
+        // CSS2.1 §10.6.2: a block-level replaced box's block size comes from its natural size and
+        // ratio, not from its (hidden) content — the same pass that settled its width in
+        // ResolveBlockUsedWidth, re-run now that Size.Width is final. Without it a
+        // `display: block` <canvas> measured its content height as zero and vanished.
+        if (IntrinsicReplacedSize is { Width: > 0, Height: > 0 } naturalSize)
+        {
+            double availableInlineSize = ContainingBlock.Size.Width
+                - ContainingBlock.ActualPaddingLeft - ContainingBlock.ActualPaddingRight
+                - ContainingBlock.ActualBorderLeftWidth - ContainingBlock.ActualBorderRightWidth;
+
+            ResolveReplacedContentSize(naturalSize, availableInlineSize, out _, out double replacedHeight);
+            ActualBottom = Location.Y + ResolveSpecifiedHeightToBorderBox(replacedHeight);
+        }
+
         // CSS Sizing 4 §4: a box with a preferred aspect-ratio and an auto block
         // (height) axis derives its used height from its used inline (width) size.
         // Runs after the explicit-height paths above (so an author height still
@@ -1431,68 +1456,24 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     {
         // CSS2.1 §10.7: Apply min-height / max-height constraints.
         // When min-height > max-height, min-height wins.
-        {
-            double contentHeight = ActualBottom - Location.Y - ActualPaddingTop - ActualPaddingBottom - ActualBorderTopWidth - ActualBorderBottomWidth;
-            bool constrained = false;
+        //
+        // ResolveBlockSizeBounds carries the §10.7 rules, including the one that turns a percentage
+        // into the property's initial value when the containing block's block size is indefinite —
+        // and it looks that basis up through TryGetPercentageBlockSizeBasis, which climbs past
+        // *anonymous* boxes. Reading ContainingBlock.Height directly, as this used to, stopped at
+        // the anonymous block a block-inside-inline split leaves around a `display: block` <img>
+        // and so treated its `max-height: 100%` as `none` (WPT
+        // css-sizing/block-image-percentage-max-height-inside-inline).
+        var bounds = ResolveBlockSizeBounds();
+        if (bounds.IsUnconstrained)
+            return;
 
-            // CSS2.1 §9.6.1: For fixed-position elements, percentage
-            // heights resolve against the viewport, not the parent.
-            double cbHeight = (Position == CssConstants.Fixed && LayoutEnvironment != null)
-                ? FixedPositioningViewport().Height
-                : ContainingBlock.Size.Height;
+        double contentHeight = ActualBottom - Location.Y
+            - ActualPaddingTop - ActualPaddingBottom - ActualBorderTopWidth - ActualBorderBottomWidth;
+        double clamped = bounds.Clamp(contentHeight);
 
-            if (MaxHeight != "none" && !string.IsNullOrEmpty(MaxHeight))
-            {
-                // CSS2.1 §10.7: If the containing block's height is not
-                // specified explicitly and this element is not absolutely
-                // positioned, a percentage max-height is treated as 'none'.
-                // Exception: the initial containing block always has a
-                // definite height (the viewport), per §10.5.
-                bool maxIsPercentageAuto = MaxHeight.Contains('%')
-                    && Position != CssConstants.Absolute && Position != CssConstants.Fixed
-                    && ContainingBlock?.ParentBox != null
-                    && (ContainingBlock.Height == CssConstants.Auto || string.IsNullOrEmpty(ContainingBlock.Height));
-
-                if (!maxIsPercentageAuto)
-                {
-                    double maxH = ParseUsedLength(MaxHeight, cbHeight);
-
-                    if (contentHeight > maxH)
-                    {
-                        contentHeight = maxH;
-                        constrained = true;
-                    }
-                }
-            }
-
-            if (MinHeight != "0" && !string.IsNullOrEmpty(MinHeight))
-            {
-                // CSS2.1 §10.7: If the containing block's height is not
-                // specified explicitly and this element is not absolutely
-                // positioned, a percentage min-height is treated as '0'.
-                // Exception: the initial containing block always has a
-                // definite height (the viewport), per §10.5.
-                bool minIsPercentageAuto = MinHeight.Contains('%')
-                    && Position != CssConstants.Absolute && Position != CssConstants.Fixed
-                    && ContainingBlock?.ParentBox != null
-                    && (ContainingBlock.Height == CssConstants.Auto || string.IsNullOrEmpty(ContainingBlock.Height));
-
-                if (!minIsPercentageAuto)
-                {
-                    double minH = ParseUsedLength(MinHeight, cbHeight);
-                    if (contentHeight < minH)
-                    {
-                        contentHeight = minH;
-                        constrained = true;
-                    }
-                }
-            }
-
-            if (constrained)
-            {
-                ActualBottom = Location.Y + ResolveSpecifiedHeightToBorderBox(contentHeight);
-            }
-        }
+        if (clamped != contentHeight)
+            ActualBottom = Location.Y + ResolveSpecifiedHeightToBorderBox(clamped);
     }
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
@@ -160,14 +160,14 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                     - ContainingBlock.ActualBorderLeftWidth - ContainingBlock.ActualBorderRightWidth;
         }
 
-        // CSS2.1 §10.3.4: a block-level *replaced* element resolves its width with the inline rules
-        // (§10.3.2) — an auto width is its natural width, not the containing block's. Only a box
-        // carrying a natural size reaches this (a `display: block` <canvas>); the min/max pass
-        // inside settles both axes together, and ResolveUsedBlockHeight reads the block one back.
-        if (IntrinsicReplacedSize is { Width: > 0, Height: > 0 } naturalSize)
+        // CSS2.1 §10.3.4/§10.3.8: a block-level or out-of-flow *replaced* element resolves its width
+        // with the inline rules (§10.3.2) — an auto width is its natural width, not the containing
+        // block's, and for an absolutely positioned one it is not the inset constraint equation
+        // either (`right` is what gives way). The min/max pass inside settles both axes together,
+        // and ResolveUsedBlockHeight reads the block one back.
+        if (TryResolveReplacedBorderBoxSize(width, out double replacedWidth, out _))
         {
-            ResolveReplacedContentSize(naturalSize, width, out double replacedWidth, out _);
-            width = ResolveSpecifiedWidthToBorderBox(replacedWidth);
+            width = replacedWidth;
         }
         else if (IsIntrinsicWidthKeyword(Width) && Float == CssConstants.None)
         {
@@ -245,7 +245,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         // Width is auto — the tentative used width must not exceed
         // max-width. A replaced box has already had both bounds applied to both axes together
         // above, and re-clamping here would use a different percentage basis.
-        bool replacedSizeSettled = IntrinsicReplacedSize is { Width: > 0, Height: > 0 };
+        bool replacedSizeSettled = TryGetNaturalReplacedSize(out _);
 
         if (!replacedSizeSettled && MaxWidth != "none" && !string.IsNullOrEmpty(MaxWidth))
         {
@@ -342,7 +342,14 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         // with auto width use shrink-to-fit when at least one of
         // left/right is auto.  Shrink-to-fit =
         //   min(max(preferred_minimum, available), preferred)
-        if ((Width == CssConstants.Auto || string.IsNullOrEmpty(Width))
+        //
+        // Non-replaced is the operative word, and it was not being honoured: a replaced box's auto
+        // width is its natural width (§10.3.8), and shrink-to-fit measures *children*, of which an
+        // <img> or <canvas> has none — so an `<img position:absolute; left:4em; top:4em>` came out
+        // zero pixels wide and painted nothing at all. With `right` also set the branch was skipped
+        // and the same image stretched across the inset box instead; both are now the natural size.
+        if (!replacedSizeSettled
+            && (Width == CssConstants.Auto || string.IsNullOrEmpty(Width))
             && (Position == CssConstants.Absolute || Position == CssConstants.Fixed)
             && (Left == null || Left == CssConstants.Auto
              || Right == null || Right == CssConstants.Auto))
@@ -1383,18 +1390,19 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             ActualBottom = Location.Y + borderBoxH;
         }
 
-        // CSS2.1 §10.6.2: a block-level replaced box's block size comes from its natural size and
-        // ratio, not from its (hidden) content — the same pass that settled its width in
-        // ResolveBlockUsedWidth, re-run now that Size.Width is final. Without it a
-        // `display: block` <canvas> measured its content height as zero and vanished.
-        if (IntrinsicReplacedSize is { Width: > 0, Height: > 0 } naturalSize)
+        // CSS2.1 §10.6.2/§10.6.5: a block-level or out-of-flow replaced box's block size comes from
+        // its natural size and ratio, not from its (hidden) content and not from a top/bottom inset
+        // pair — the same pass that settled its width in ResolveBlockUsedWidth, re-run now that
+        // Size.Width is final. Without it a `display: block` <canvas> measured its content height as
+        // zero and vanished, and an absolutely positioned <img> with four insets stretched to fill
+        // them.
         {
             double availableInlineSize = ContainingBlock.Size.Width
                 - ContainingBlock.ActualPaddingLeft - ContainingBlock.ActualPaddingRight
                 - ContainingBlock.ActualBorderLeftWidth - ContainingBlock.ActualBorderRightWidth;
 
-            ResolveReplacedContentSize(naturalSize, availableInlineSize, out _, out double replacedHeight);
-            ActualBottom = Location.Y + ResolveSpecifiedHeightToBorderBox(replacedHeight);
+            if (TryResolveReplacedBorderBoxSize(availableInlineSize, out _, out double replacedHeight))
+                ActualBottom = Location.Y + replacedHeight;
         }
 
         // CSS Sizing 4 §4: a box with a preferred aspect-ratio and an auto block

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
@@ -35,11 +35,67 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             or "start" or "flex-start" or "self-start" or "left";
     }
 
+    /// <summary>
+    /// CSS Overflow 3 §3.3 (overflow viewport propagation): when the root element's <c>overflow</c>
+    /// is <c>visible</c>, the <c>&lt;body&gt;</c>'s is applied to the <b>viewport</b> instead, and
+    /// the body's own used value becomes <c>visible</c>. The root element's own non-<c>visible</c>
+    /// value is propagated the same way and the body's is then left alone.
+    /// </summary>
+    /// <remarks>
+    /// Broiler had no propagation at all, so <c>body { overflow: hidden }</c> — one of the most
+    /// common declarations there is — clipped the body's own box instead of the viewport. WPT
+    /// <c>css-overflow/overflow-body-propagation-009</c> is the sharp version: a 30×30 body clipped
+    /// a 10 000px child down to 0.3 % of the canvas where the reference fills 82 %. Idempotent, so
+    /// running it on every layout pass is safe: once the body reads <c>visible</c> there is nothing
+    /// left to move.
+    /// </remarks>
+    internal void ApplyViewportOverflowPropagation()
+    {
+        if (HtmlTag == null || !HtmlTag.Name.Equals("body", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        if (ParentBox is not { HtmlTag: not null } root
+            || !root.HtmlTag.Name.Equals("html", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        if (string.IsNullOrEmpty(Overflow) || Overflow == CssConstants.Visible)
+            return;
+
+        // The root's own value wins and is what the viewport already uses; the body's is then not
+        // propagated, and (per §3.3) it keeps it.
+        if (!string.IsNullOrEmpty(root.Overflow) && root.Overflow != CssConstants.Visible)
+            return;
+
+        // Only the *first* <body> propagates, and only if it generates a box. A document with two
+        // of them (WPT css-overflow/overflow-body-propagation-016) must leave the second one's
+        // `overflow: hidden` clipping its own contents — and if the first generates no box, nothing
+        // propagates at all rather than the turn passing to the second.
+        foreach (var child in root.Boxes)
+        {
+            if (child.HtmlTag == null
+                || !child.HtmlTag.Name.Equals("body", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (child != this || child.Display == CssConstants.None)
+                return;
+
+            break;
+        }
+
+        // The value goes to the *viewport*, not to the root element's box: Broiler's canvas already
+        // clips there, so the propagation is exactly the removal of the body's own clip. Putting it
+        // on the root box instead would clip at the root's border box, which is not the same
+        // rectangle once the body has margins.
+        Overflow = CssConstants.Visible;
+    }
+
     protected virtual void PerformLayoutImp(ILayoutEnvironment g)
     {
         LayoutWorkTrace.Count(LayoutWorkTrace.Counters.BoxesLaidOut);
 
         ResetCollapsedMarginState();
+
+        ApplyViewportOverflowPropagation();
 
         if (Display != CssConstants.None)
         {

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
@@ -52,6 +52,18 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         return Math.Max(0, cssHeight);
     }
 
+    /// <summary>The inverse of <see cref="ResolveSpecifiedHeightToBorderBox"/>: the content-box
+    /// height a specified <c>height</c> names. A percentage child resolves against this, not against
+    /// the border box (CSS2.1 §10.5 — percentages are relative to the containing block's
+    /// <em>content</em> height).</summary>
+    private double ResolveSpecifiedHeightToContentBox(double cssHeight)
+    {
+        if (UsesBorderBoxSizing)
+            cssHeight -= ActualPaddingTop + ActualPaddingBottom + ActualBorderTopWidth + ActualBorderBottomWidth;
+
+        return Math.Max(0, cssHeight);
+    }
+
     /// <summary>
     /// CSS2.1 §10.7: clamp a specified (author-declared) height to
     /// <c>min-height</c>/<c>max-height</c> in the same box-sizing frame (both share
@@ -82,6 +94,119 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             if (specifiedHeight < minH) specifiedHeight = minH;
         }
         return specifiedHeight;
+    }
+
+    /// <summary>
+    /// CSS2.1 §10.4: this box's <c>min-width</c>/<c>max-width</c> as used lengths, in the frame
+    /// <c>box-sizing</c> names (the caller converts). A percentage resolves against the containing
+    /// block's inline size, which is always definite; <c>max-width: none</c> is
+    /// <see cref="double.PositiveInfinity"/>.
+    /// </summary>
+    internal ReplacedBoxSizing.Bounds ResolveInlineSizeBounds()
+    {
+        double cbWidth = ContainingBlock?.Size.Width ?? 0;
+        double em = GetEmHeight();
+
+        double min = 0;
+        if (IsSizeConstraintLength(MinWidth))
+        {
+            double v = CssLengthParser.ParseLength(MinWidth, cbWidth, em);
+            if (v > 0 && !double.IsNaN(v))
+                min = v;
+        }
+
+        double max = double.PositiveInfinity;
+        if (IsSizeConstraintLength(MaxWidth))
+        {
+            double v = CssLengthParser.ParseLength(MaxWidth, cbWidth, em);
+            if (v >= 0 && !double.IsNaN(v))
+                max = v;
+        }
+
+        return new ReplacedBoxSizing.Bounds(min, max);
+    }
+
+    /// <summary>
+    /// Whether a <c>min-*</c>/<c>max-*</c> value is a length, percentage or math function this can
+    /// resolve — as opposed to a keyword (<c>none</c>, <c>auto</c>, <c>fit-content</c>,
+    /// <c>min-content</c>, <c>stretch</c>, <c>inherit</c>, …), which is left unconstrained.
+    /// </summary>
+    /// <remarks>
+    /// The guard is load-bearing, not defensive: <see cref="CssLengthParser.ParseLength"/> resolves
+    /// an unrecognised unit to <c>0px</c>, so handing it <c>max-width: fit-content</c> would clamp
+    /// the box to nothing rather than leave it alone.
+    /// </remarks>
+    private static bool IsSizeConstraintLength(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        string t = value.Trim();
+
+        if (t == "0" || t.Equals("none", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        char c0 = t[0];
+        if (char.IsAsciiDigit(c0) || c0 == '.')
+            return true;
+
+        if ((c0 == '+' || c0 == '-') && t.Length > 1 && (char.IsAsciiDigit(t[1]) || t[1] == '.'))
+            return true;
+
+        return t.StartsWith("calc(", StringComparison.OrdinalIgnoreCase)
+            || t.StartsWith("min(", StringComparison.OrdinalIgnoreCase)
+            || t.StartsWith("max(", StringComparison.OrdinalIgnoreCase)
+            || t.StartsWith("clamp(", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// CSS2.1 §10.7: this box's <c>min-height</c>/<c>max-height</c> as used lengths, in the frame
+    /// <c>box-sizing</c> names (the caller converts). A percentage against an <em>indefinite</em>
+    /// containing block takes the property's initial value — <c>0</c> for <c>min-height</c>,
+    /// <c>none</c> for <c>max-height</c> — so an unresolvable percentage never clamps anything.
+    /// </summary>
+    internal ReplacedBoxSizing.Bounds ResolveBlockSizeBounds()
+    {
+        double em = GetEmHeight();
+        double? percentBasis = null;
+
+        double min = 0;
+        if (IsSizeConstraintLength(MinHeight)
+            && TryResolveBlockSizeLength(MinHeight, em, ref percentBasis, out double minLength)
+            && minLength > 0)
+        {
+            min = minLength;
+        }
+
+        double max = double.PositiveInfinity;
+        if (IsSizeConstraintLength(MaxHeight)
+            && TryResolveBlockSizeLength(MaxHeight, em, ref percentBasis, out double maxLength)
+            && maxLength >= 0)
+        {
+            max = maxLength;
+        }
+
+        return new ReplacedBoxSizing.Bounds(min, max);
+    }
+
+    /// <summary>Resolves one block-axis length, looking the percentage basis up at most once (it
+    /// walks the ancestor chain) and reporting <see langword="false"/> when a percentage has no
+    /// definite basis to resolve against.</summary>
+    private bool TryResolveBlockSizeLength(string value, double em, ref double? percentBasis, out double length)
+    {
+        length = 0;
+
+        if (value.Contains('%'))
+        {
+            if (percentBasis is null)
+                percentBasis = TryGetPercentageBlockSizeBasis(out double basis) ? basis : double.NaN;
+
+            if (double.IsNaN(percentBasis.Value))
+                return false;
+        }
+
+        length = CssLengthParser.ParseLength(value, percentBasis ?? 0, em);
+        return !double.IsNaN(length) && !double.IsInfinity(length);
     }
 
     internal double GetMinimumWidth()

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
@@ -1,5 +1,6 @@
 using Broiler.CSS;
 using Broiler.Layout.Diagnostics;
+using System.Drawing;
 using System.Globalization;
 
 
@@ -72,29 +73,8 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     /// min-/max-height against an indefinite (auto-height) flow containing block is
     /// treated as its initial value (<c>0</c>/<c>none</c>), per §10.7.
     /// </summary>
-    private double ClampSpecifiedHeightToMinMax(double specifiedHeight)
-    {
-        double cbHeight = (Position == CssConstants.Fixed && LayoutEnvironment != null)
-            ? LayoutEnvironment.ViewportSize.Height
-            : ContainingBlock?.Size.Height ?? 0;
-        bool cbIndefinite = Position is not (CssConstants.Absolute or CssConstants.Fixed)
-            && ContainingBlock?.ParentBox != null
-            && (ContainingBlock.Height == CssConstants.Auto || string.IsNullOrEmpty(ContainingBlock.Height));
-
-        if (MaxHeight != "none" && !string.IsNullOrEmpty(MaxHeight)
-            && !(MaxHeight.Contains('%') && cbIndefinite))
-        {
-            double maxH = CssLengthParser.ParseLength(MaxHeight, cbHeight, GetEmHeight());
-            if (specifiedHeight > maxH) specifiedHeight = maxH;
-        }
-        if (MinHeight != "0" && !string.IsNullOrEmpty(MinHeight)
-            && !(MinHeight.Contains('%') && cbIndefinite))
-        {
-            double minH = CssLengthParser.ParseLength(MinHeight, cbHeight, GetEmHeight());
-            if (specifiedHeight < minH) specifiedHeight = minH;
-        }
-        return specifiedHeight;
-    }
+    private double ClampSpecifiedHeightToMinMax(double specifiedHeight) =>
+        ResolveBlockSizeBounds().Clamp(specifiedHeight);
 
     /// <summary>
     /// CSS2.1 §10.4: this box's <c>min-width</c>/<c>max-width</c> as used lengths, in the frame
@@ -143,7 +123,9 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
         string t = value.Trim();
 
-        if (t == "0" || t.Equals("none", StringComparison.OrdinalIgnoreCase))
+        // `none` is max-*'s initial value. Zero is *not* excluded: it is min-*'s initial value and
+        // a no-op there, but `max-height: 0` is a real clamp (WPT CSS2/normal-flow/max-height-101).
+        if (t.Equals("none", StringComparison.OrdinalIgnoreCase))
             return false;
 
         char c0 = t[0];
@@ -207,6 +189,113 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
         length = CssLengthParser.ParseLength(value, percentBasis ?? 0, em);
         return !double.IsNaN(length) && !double.IsInfinity(length);
+    }
+
+    /// <summary>Moves a min/max bound out of the frame <c>box-sizing</c> names and into the content
+    /// box, so it can clamp a content-box size. A no-op under the default <c>content-box</c>.</summary>
+    private ReplacedBoxSizing.Bounds ToContentBoxBounds(ReplacedBoxSizing.Bounds bounds, double borderAndPadding)
+    {
+        if (borderAndPadding <= 0 || !UsesBorderBoxSizing)
+            return bounds;
+
+        return new ReplacedBoxSizing.Bounds(
+            Math.Max(0, bounds.Min - borderAndPadding),
+            double.IsPositiveInfinity(bounds.Max) ? bounds.Max : Math.Max(0, bounds.Max - borderAndPadding));
+    }
+
+    /// <summary>
+    /// The used content width this box's specified <c>width</c> names, or <see langword="false"/>
+    /// when there is none to use — <c>auto</c>, empty, or an intrinsic-sizing keyword. A replaced
+    /// box then takes its inline axis from its natural size, or from the block axis through its
+    /// ratio.
+    /// </summary>
+    private bool TryResolveSpecifiedReplacedContentWidth(double availableInlineSize, out double contentWidth)
+    {
+        contentWidth = 0;
+
+        if (Width == CssConstants.Auto || string.IsNullOrEmpty(Width) || IsIntrinsicSizingWidthKeyword(Width))
+            return false;
+
+        double specified = CssLengthParser.ParseLength(Width, availableInlineSize, GetEmHeight());
+        if (double.IsNaN(specified) || double.IsInfinity(specified) || specified < 0)
+            return false;
+
+        contentWidth = UsesBorderBoxSizing
+            ? Math.Max(0, specified - ActualBorderLeftWidth - ActualBorderRightWidth
+                          - ActualPaddingLeft - ActualPaddingRight)
+            : specified;
+        return true;
+    }
+
+    /// <summary>
+    /// The used content height this box's specified <c>height</c> names, or <see langword="false"/>
+    /// when there is none to use — <c>auto</c>, an intrinsic-sizing keyword, or (CSS2.1 §10.5) a
+    /// percentage with no definite basis to resolve against, which computes to <c>auto</c>. A
+    /// replaced box then takes its block axis from its natural size, or from the inline axis
+    /// through its ratio.
+    /// </summary>
+    private bool TryResolveSpecifiedReplacedContentHeight(out double contentHeight)
+    {
+        contentHeight = 0;
+
+        if (Height == CssConstants.Auto || string.IsNullOrEmpty(Height) || IsIntrinsicSizingHeightKeyword(Height))
+            return false;
+
+        double basis = 0;
+        if (Height.Contains('%') && !TryGetPercentageBlockSizeBasis(out basis))
+            return false;
+
+        double specified = CssLengthParser.ParseLength(Height, basis, GetEmHeight());
+        if (double.IsNaN(specified) || double.IsInfinity(specified) || specified < 0)
+            return false;
+
+        contentHeight = ResolveSpecifiedHeightToContentBox(specified);
+        return true;
+    }
+
+    /// <summary>
+    /// CSS2.1 §10.3.2/§10.6.2 then §10.4: the used <em>content</em> size of a replaced box that
+    /// carries a natural size (<see cref="CssBoxProperties.IntrinsicReplacedSize"/> — a
+    /// <c>&lt;canvas&gt;</c>). An axis the author left <c>auto</c> comes from the natural size, or
+    /// from the other axis through the ratio when that one is stated; then the min/max constraints
+    /// are applied to both together.
+    /// </summary>
+    /// <remarks>
+    /// Shared by the atomic inline-level path (<see cref="CssLayoutEngine"/>'s inline flow) and the
+    /// block-level one (<see cref="ResolveBlockUsedWidth"/> / <see cref="ResolveUsedBlockHeight"/>),
+    /// so a <c>display: block</c> canvas is sized by the same rules as an inline one.
+    /// </remarks>
+    internal void ResolveReplacedContentSize(
+        SizeF natural, double availableInlineSize, out double contentWidth, out double contentHeight)
+    {
+        bool widthIsAuto = !TryResolveSpecifiedReplacedContentWidth(availableInlineSize, out contentWidth);
+        bool heightIsAuto = !TryResolveSpecifiedReplacedContentHeight(out contentHeight);
+
+        if (widthIsAuto)
+            contentWidth = natural.Width;
+        if (heightIsAuto)
+            contentHeight = natural.Height;
+
+        // CSS Sizing 4 §4: an author `aspect-ratio` is a *preferred* ratio that replaces the
+        // natural one for filling in whichever axis is auto.
+        double ratio = natural.Height > 0 ? natural.Width / natural.Height : 0;
+        if (TryParseAspectRatio(AspectRatio, out double preferred) && preferred > 0)
+            ratio = preferred;
+
+        if (ratio > 0)
+        {
+            if (widthIsAuto && !heightIsAuto)
+                contentWidth = contentHeight * ratio;
+            else if (heightIsAuto && !widthIsAuto)
+                contentHeight = contentWidth / ratio;
+        }
+
+        ReplacedBoxSizing.ApplyMinMax(
+            ref contentWidth, ref contentHeight, widthIsAuto, heightIsAuto, ratio,
+            ToContentBoxBounds(ResolveInlineSizeBounds(),
+                ActualBorderLeftWidth + ActualBorderRightWidth + ActualPaddingLeft + ActualPaddingRight),
+            ToContentBoxBounds(ResolveBlockSizeBounds(),
+                ActualBorderTopWidth + ActualBorderBottomWidth + ActualPaddingTop + ActualPaddingBottom));
     }
 
     internal double GetMinimumWidth()

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
@@ -298,6 +298,56 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 ActualBorderTopWidth + ActualBorderBottomWidth + ActualPaddingTop + ActualPaddingBottom));
     }
 
+    /// <summary>
+    /// The natural (intrinsic) size of a replaced box, from whichever source it has one: the
+    /// <c>width</c>/<c>height</c> content attributes a <c>&lt;canvas&gt;</c> records in
+    /// <see cref="CssBoxProperties.IntrinsicReplacedSize"/>, or the decoded bitmap behind an
+    /// <c>&lt;img&gt;</c>'s word. <see langword="false"/> for every non-replaced box, and for a
+    /// replaced one whose content has not loaded (which has no natural size to offer).
+    /// </summary>
+    private bool TryGetNaturalReplacedSize(out SizeF natural)
+    {
+        if (IntrinsicReplacedSize is { Width: > 0, Height: > 0 } declared)
+        {
+            natural = declared;
+            return true;
+        }
+
+        if (LayoutEnvironment != null
+            && Words.Count == 1 && Words[0] is CssRectImage { Image: not null } imageWord
+            && LayoutEnvironment.GetImageIntrinsics(imageWord.Image) is { Width: > 0, Height: > 0 } bitmap)
+        {
+            natural = new SizeF((float)bitmap.Width, (float)bitmap.Height);
+            return true;
+        }
+
+        natural = default;
+        return false;
+    }
+
+    /// <summary>
+    /// CSS2.1 §10.3.4/§10.6.5: the used border-box size of a <em>block-level or out-of-flow</em>
+    /// replaced box. Both axes come from the replaced rules (§10.3.2/§10.6.2), never from the
+    /// containing block's width or from an inset constraint equation — an
+    /// <c>&lt;img position:absolute; left:4em; right:0; top:4em; bottom:0&gt;</c> keeps its natural
+    /// size and lets <c>right</c>/<c>bottom</c> give way, rather than stretching across the inset
+    /// box (WPT CSS2/positioning/abspos-025).
+    /// </summary>
+    internal bool TryResolveReplacedBorderBoxSize(double availableInlineSize, out double width, out double height)
+    {
+        width = 0;
+        height = 0;
+
+        if (!TryGetNaturalReplacedSize(out SizeF natural))
+            return false;
+
+        ResolveReplacedContentSize(natural, availableInlineSize, out double contentWidth, out double contentHeight);
+
+        width = ResolveSpecifiedWidthToBorderBox(contentWidth);
+        height = ResolveSpecifiedHeightToBorderBox(contentHeight);
+        return true;
+    }
+
     internal double GetMinimumWidth()
     {
         LayoutWorkTrace.Count(LayoutWorkTrace.Counters.IntrinsicCalls);

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -762,8 +762,18 @@ internal partial class CssBox
         bool widthIsPercent = !string.IsNullOrEmpty(item.Width) && item.Width.EndsWith('%');
         bool heightIsPercent = !string.IsNullOrEmpty(item.Height) && item.Height.EndsWith('%');
 
-        bool widthFills = FillsArea(item.Width) && (widthIsPercent || SelfAlignmentStretches(item.JustifySelf, JustifyItems));
-        bool heightFills = FillsArea(item.Height) && (heightIsPercent || SelfAlignmentStretches(item.AlignSelf, AlignItems));
+        // CSS Box Alignment §6.1: `normal` — the default — behaves as `start`, not `stretch`, for a
+        // *replaced* box with a natural size, so a <canvas> grid item keeps its own size instead of
+        // being pulled out to the track. Only the default is overridden; an explicit
+        // `justify-self: stretch` still stretches.
+        bool replacedKeepsSize = item.IntrinsicReplacedSize is { Width: > 0, Height: > 0 };
+
+        bool widthFills = FillsArea(item.Width)
+            && (widthIsPercent || (SelfAlignmentStretches(item.JustifySelf, JustifyItems)
+                                   && !(replacedKeepsSize && IsNormalAlignment(item.JustifySelf, JustifyItems))));
+        bool heightFills = FillsArea(item.Height)
+            && (heightIsPercent || (SelfAlignmentStretches(item.AlignSelf, AlignItems)
+                                    && !(replacedKeepsSize && IsNormalAlignment(item.AlignSelf, AlignItems))));
 
         double targetLeft = areaLeft + marginL;
         double targetTop = areaTop + marginT;
@@ -1583,6 +1593,23 @@ internal partial class CssBox
         else if (v.StartsWith("unsafe ")) v = v[7..].Trim();
 
         return string.IsNullOrEmpty(v) || v == "normal" || v == "stretch";
+    }
+
+    /// <summary>
+    /// True when a grid item's used self-alignment on an axis is the initial <c>normal</c> — the
+    /// case CSS Box Alignment §6.1 resolves differently for a replaced box (as <c>start</c>) than
+    /// for everything else (as <c>stretch</c>). An explicit <c>stretch</c> is not <c>normal</c> and
+    /// stretches whatever the box is.
+    /// </summary>
+    private static bool IsNormalAlignment(string self, string items)
+    {
+        string v = self;
+        if (string.IsNullOrEmpty(v) || v == "auto" || v == "normal")
+            v = items;
+
+        v = (v ?? "").Trim().ToLowerInvariant();
+
+        return string.IsNullOrEmpty(v) || v == "auto" || v == "normal";
     }
 
     private static double GridAxisAlignmentOffset(string self, string items, double free, bool rtl)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -689,6 +689,22 @@ internal abstract partial class CssBoxProperties
     /// </remarks>
     public SizeF? IntrinsicReplacedSize { get; set; }
 
+    /// <summary>
+    /// CSS2.1 §9.2.1.1: set on an <b>inline</b> element's box that the block-inside-inline
+    /// correction has blockified in order to break it around a block-level child. The element is
+    /// still inline as far as CSS is concerned — the block-level <c>display</c> is an artefact of
+    /// how the split is modelled — so it is not a containing block a percentage resolves against,
+    /// any more than the anonymous blocks the same split creates are.
+    /// </summary>
+    /// <remarks>
+    /// WPT <c>css-sizing/block-image-percentage-max-height-inside-inline</c> is exactly this shape:
+    /// a <c>display: block</c> <c>&lt;img&gt;</c> inside a <c>&lt;span&gt;</c> inside a
+    /// <c>height: 100px</c> <c>&lt;div&gt;</c>. Stopping at the blockified span made the image's
+    /// <c>max-height: 100%</c> resolve against an indefinite block size, so §10.7 turned it into
+    /// <c>none</c> and the image kept its 1000px height.
+    /// </remarks>
+    public bool IsBlockifiedInlineSplit { get; set; }
+
     public string InlineSize
     {
         get => _inlineSize;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -672,6 +672,23 @@ internal abstract partial class CssBoxProperties
     /// (<see cref="CssBox.TryResolveAspectRatioBlockHeight"/>).</summary>
     public string AspectRatio { get; set; } = "auto";
 
+    /// <summary>
+    /// CSS Images 3 §4: the <b>natural (intrinsic) size</b> of an atomic inline-level box that is a
+    /// replaced element sized from something other than a decoded image — currently a
+    /// <c>&lt;canvas&gt;</c>, whose bitmap is its <c>width</c>/<c>height</c> content attributes
+    /// (HTML §4.12.5, defaulting to 300×150). <see langword="null"/> for every other box, which is
+    /// what keeps the replaced sizing path off for the overwhelming majority.
+    /// </summary>
+    /// <remarks>
+    /// This is what separates a replaced box from an ordinary <c>inline-block</c> that merely has a
+    /// <c>width</c> and a <c>height</c>: an axis the author left <c>auto</c> takes the natural size
+    /// rather than shrink-to-fit, and the two axes stay tied by the natural ratio when
+    /// <c>min-*</c>/<c>max-*</c> clamp one of them (CSS2.1 §10.4 — see
+    /// <see cref="ReplacedBoxSizing"/>). The renderer sets it during style resolution; layout never
+    /// derives it.
+    /// </remarks>
+    public SizeF? IntrinsicReplacedSize { get; set; }
+
     public string InlineSize
     {
         get => _inlineSize;
@@ -2731,6 +2748,7 @@ internal abstract partial class CssBoxProperties
         IsMinWidthSpecified = p.IsMinWidthSpecified;
         MinHeight = p.MinHeight;
         MaxHeight = p.MaxHeight;
+        IntrinsicReplacedSize = p.IntrinsicReplacedSize;
         _wordSpacing = p._wordSpacing;
         Opacity = p.Opacity;
         BoxShadow = p.BoxShadow;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -99,7 +99,6 @@ internal static class CssLayoutEngine
         // its intrinsic size. (WPT css-grid/nested-grid-item-block-size-001.)
         bool hasImageTagWidth = TryResolveDefiniteImageLength(imageWord.OwnerBox.Width, em, out double tagWidthPx);
         bool hasImageTagHeight = TryResolveDefiniteImageLength(imageWord.OwnerBox.Height, em, out double tagHeightPx);
-        bool scaleImageHeight = false;
 
         // A percentage width is a stated width too — resolved against the containing block rather
         // than read off the declaration, which is the only reason it is not a "tag" width here.
@@ -122,14 +121,12 @@ internal static class CssLayoutEngine
             {
                 imageWord.Width = width.Number * imageWord.OwnerBox.ContainingBlock.Size.Width;
 
-                // Only when the height is left to the image. CSS 2.1 §10.4 uses the intrinsic
-                // ratio to fill in a dimension that is `auto`, not to overrule one the author
-                // stated — and a percentage width is no different from a length one in that. The
-                // max-width clamp below already says `!hasImageTagHeight`; this said `true`, so
-                // `<img width="100%" height="50">` came out as tall as it was wide. That is the
-                // shape CSS2's own reference files use, so the cost landed on the reference side
-                // of 85 reftests in css/CSS2/backgrounds alone.
-                scaleImageHeight = !hasImageTagHeight;
+                // CSS 2.1 §10.4 uses the intrinsic ratio to fill in a dimension that is `auto`, not
+                // to overrule one the author stated — and a percentage width is no different from a
+                // length one in that. Treating it as auto made `<img width="100%" height="50">`
+                // come out as tall as it was wide. That is the shape CSS2's own reference files use,
+                // so the cost landed on the reference side of 85 reftests in css/CSS2/backgrounds
+                // alone.
                 hasStatedWidth = true;
             }
             else if (image != null)
@@ -144,26 +141,6 @@ internal static class CssLayoutEngine
             else
             {
                 imageWord.Width = hasImageTagHeight ? tagHeightPx / 1.14f : 20;
-            }
-        }
-
-        var maxWidth = new CssLength(imageWord.OwnerBox.MaxWidth);
-        if (maxWidth.Number > 0)
-        {
-            double maxWidthVal = -1;
-            if (maxWidth.Unit == CssUnit.Px)
-            {
-                maxWidthVal = maxWidth.Number;
-            }
-            else if (maxWidth.IsPercentage)
-            {
-                maxWidthVal = maxWidth.Number * imageWord.OwnerBox.ContainingBlock.Size.Width;
-            }
-
-            if (maxWidthVal > -1 && imageWord.Width > maxWidthVal)
-            {
-                imageWord.Width = maxWidthVal;
-                scaleImageHeight = !hasImageTagHeight;
             }
         }
 
@@ -190,98 +167,37 @@ internal static class CssLayoutEngine
             CssBox.TryParseAspectRatio(imageWord.OwnerBox.AspectRatio, out double cssAspectRatio)
             && cssAspectRatio > 0;
 
-        if (hasCssAspectRatio)
-        {
-            bool widthDriven = (hasStatedWidth && !hasImageTagHeight) || scaleImageHeight;
+        // The ratio the box is sized by: the author's preferred one when declared, otherwise the
+        // image's natural one. Zero when the box has neither, which leaves the two axes independent.
+        double usedRatio = hasCssAspectRatio
+            ? cssAspectRatio
+            : image is { HasIntrinsicRatio: true, Height: > 0 } natural ? natural.Width / natural.Height : 0;
 
+        bool widthDriven = hasStatedWidth && !hasImageTagHeight;
+
+        if (usedRatio > 0)
+        {
+            // If only the width was stated, the ratio fills in the height, and vice versa.
             if (widthDriven)
-                imageWord.Height = imageWord.Width / cssAspectRatio;
+                imageWord.Height = imageWord.Width / usedRatio;
             else if (hasImageTagHeight && !hasStatedWidth)
-                imageWord.Width = imageWord.Height * cssAspectRatio;
-        }
-        else if (image != null && image.Value.HasIntrinsicRatio)
-        {
-            bool widthDriven = (hasStatedWidth && !hasImageTagHeight) || scaleImageHeight;
-            // If only the width was set in the html tag, ratio the height.
-            if (widthDriven)
-            {
-                // Divide the given tag width with the actual image width, to get the ratio.
-                double ratio = imageWord.Width / image.Value.Width;
-                imageWord.Height = image.Value.Height * ratio;
-            }
-            // If only the height was set in the html tag, ratio the width.
-            else if (hasImageTagHeight && !hasStatedWidth)
-            {
-                // Divide the given tag height with the actual image height, to get the ratio.
-                double ratio = imageWord.Height / image.Value.Height;
-                imageWord.Width = image.Value.Width * ratio;
-            }
+                imageWord.Width = imageWord.Height * usedRatio;
         }
 
-        // CSS2.1 §10.4/§10.7: Apply min/max width/height constraints
-        // for replaced elements (images).  These are applied after intrinsic
-        // sizing and aspect-ratio adjustments.
-        var minWidth = new CssLength(imageWord.OwnerBox.MinWidth);
-        if (minWidth.Number > 0)
-        {
-            double minWidthVal = minWidth.Unit == CssUnit.Px
-                ? minWidth.Number
-                : minWidth.IsPercentage
-                    ? minWidth.Number * imageWord.OwnerBox.ContainingBlock.Size.Width
-                    : -1;
+        // CSS2.1 §10.4/§10.7: apply the min/max constraints to the tentative size settled above.
+        // The two axes are coupled through the ratio, so this cannot be four independent clamps —
+        // see ReplacedBoxSizing for the table §10.4 resolves a double violation with.
+        double usedWidth = imageWord.Width;
+        double usedHeight = imageWord.Height;
 
-            if (minWidthVal > 0 && imageWord.Width < minWidthVal)
-            {
-                if (image != null && !hasImageTagHeight && image.Value.HasIntrinsicRatio)
-                {
-                    double ratio = minWidthVal / imageWord.Width;
-                    imageWord.Height *= ratio;
-                }
+        ReplacedBoxSizing.ApplyMinMax(
+            ref usedWidth, ref usedHeight,
+            widthIsAuto: !hasStatedWidth, heightIsAuto: !hasImageTagHeight, usedRatio,
+            imageWord.OwnerBox.ResolveInlineSizeBounds(),
+            imageWord.OwnerBox.ResolveBlockSizeBounds());
 
-                imageWord.Width = minWidthVal;
-            }
-        }
-
-        var maxHeight = new CssLength(imageWord.OwnerBox.MaxHeight);
-        if (maxHeight.Number > 0)
-        {
-            double maxHeightVal = maxHeight.Unit == CssUnit.Px
-                ? maxHeight.Number
-                : maxHeight.IsPercentage
-                    ? maxHeight.Number * imageWord.OwnerBox.ContainingBlock.Size.Height
-                    : -1;
-
-            if (maxHeightVal > 0 && imageWord.Height > maxHeightVal)
-            {
-                if (image != null && !hasImageTagWidth && image.Value.HasIntrinsicRatio)
-                {
-                    double ratio = maxHeightVal / imageWord.Height;
-                    imageWord.Width *= ratio;
-                }
-                imageWord.Height = maxHeightVal;
-            }
-        }
-
-        var minHeight = new CssLength(imageWord.OwnerBox.MinHeight);
-        if (minHeight.Number > 0)
-        {
-            double minHeightVal = minHeight.Unit == CssUnit.Px
-                ? minHeight.Number
-                : minHeight.IsPercentage
-                    ? minHeight.Number * imageWord.OwnerBox.ContainingBlock.Size.Height
-                    : -1;
-
-            if (minHeightVal > 0 && imageWord.Height < minHeightVal)
-            {
-                if (image != null && !hasImageTagWidth && image.Value.HasIntrinsicRatio)
-                {
-                    double ratio = minHeightVal / imageWord.Height;
-                    imageWord.Width *= ratio;
-                }
-
-                imageWord.Height = minHeightVal;
-            }
-        }
+        imageWord.Width = usedWidth;
+        imageWord.Height = usedHeight;
 
         imageWord.Height += imageWord.OwnerBox.ActualBorderBottomWidth + imageWord.OwnerBox.ActualBorderTopWidth + imageWord.OwnerBox.ActualPaddingTop + imageWord.OwnerBox.ActualPaddingBottom;
     }
@@ -1172,6 +1088,21 @@ internal static class CssLayoutEngine
     /// its children while participating in the parent's inline
     /// formatting context as a single opaque box.
     /// </summary>
+    /// <summary>
+    /// Moves a min/max bound from the frame <c>box-sizing</c> names into the content box, so it can
+    /// clamp a content-box size. A no-op under the default <c>content-box</c>.
+    /// </summary>
+    private static ReplacedBoxSizing.Bounds ToContentBox(
+        ReplacedBoxSizing.Bounds bounds, CssBox b, double borderAndPadding)
+    {
+        if (borderAndPadding <= 0 || !b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase))
+            return bounds;
+
+        return new ReplacedBoxSizing.Bounds(
+            Math.Max(0, bounds.Min - borderAndPadding),
+            double.IsPositiveInfinity(bounds.Max) ? bounds.Max : Math.Max(0, bounds.Max - borderAndPadding));
+    }
+
     private static void FlowInlineBlock(ILayoutEnvironment g, CssBox blockbox, CssBox b,
         double limitRight, double linespacing, double startx,
         double leftspacing, double rightspacing,
@@ -1184,9 +1115,23 @@ internal static class CssLayoutEngine
             - blockbox.ActualPaddingLeft - blockbox.ActualPaddingRight
             - blockbox.ActualBorderLeftWidth - blockbox.ActualBorderRightWidth;
 
+        // CSS Images 3 §4 / CSS2.1 §10.4: a replaced atomic inline — a <canvas>, whose natural size
+        // is its width/height content attributes — takes an auto axis from its natural size rather
+        // than shrinking to fit its (absent) content, and keeps the two axes tied by the natural
+        // ratio while min-*/max-* clamp them. Sized in one step below; the per-axis clamps that
+        // follow are skipped for it.
+        var intrinsic = b.IntrinsicReplacedSize;
+        bool isReplaced = intrinsic is { Width: > 0, Height: > 0 };
+        bool replacedWidthIsAuto = b.Width == CssConstants.Auto || string.IsNullOrEmpty(b.Width);
+        bool replacedHeightIsAuto = b.Height == CssConstants.Auto || string.IsNullOrEmpty(b.Height);
+
         // --- Compute inline-block content width ---
         double ibContentWidth;
-        if (b.Width != CssConstants.Auto && !string.IsNullOrEmpty(b.Width))
+        if (isReplaced && replacedWidthIsAuto)
+        {
+            ibContentWidth = intrinsic.Value.Width;
+        }
+        else if (b.Width != CssConstants.Auto && !string.IsNullOrEmpty(b.Width))
         {
             ibContentWidth = CssLengthParser.ParseLength(b.Width, containerWidth, b.GetEmHeight());
             if (b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase))
@@ -1219,10 +1164,44 @@ internal static class CssLayoutEngine
             ibContentWidth = Math.Min(Math.Max(prefMin, available), prefMax);
         }
 
+        // The replaced box's own natural block size, settled together with its width below.
+        double replacedContentHeight = isReplaced ? intrinsic.Value.Height : 0;
+
+        if (isReplaced)
+        {
+            if (!replacedHeightIsAuto)
+            {
+                replacedContentHeight = CssLengthParser.ParseLength(b.Height, containerWidth, b.GetEmHeight());
+                if (b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase))
+                {
+                    replacedContentHeight -= b.ActualBorderTopWidth + b.ActualBorderBottomWidth
+                        + b.ActualPaddingTop + b.ActualPaddingBottom;
+                }
+                if (replacedContentHeight < 0)
+                    replacedContentHeight = 0;
+            }
+
+            double naturalRatio = intrinsic.Value.Width / intrinsic.Value.Height;
+
+            // The ratio fills in whichever axis the author left auto, before the constraints run.
+            if (replacedWidthIsAuto && !replacedHeightIsAuto)
+                ibContentWidth = replacedContentHeight * naturalRatio;
+            else if (replacedHeightIsAuto && !replacedWidthIsAuto)
+                replacedContentHeight = ibContentWidth / naturalRatio;
+
+            ReplacedBoxSizing.ApplyMinMax(
+                ref ibContentWidth, ref replacedContentHeight,
+                replacedWidthIsAuto, replacedHeightIsAuto, naturalRatio,
+                ToContentBox(b.ResolveInlineSizeBounds(), b,
+                    b.ActualBorderLeftWidth + b.ActualBorderRightWidth + b.ActualPaddingLeft + b.ActualPaddingRight),
+                ToContentBox(b.ResolveBlockSizeBounds(), b,
+                    b.ActualBorderTopWidth + b.ActualBorderBottomWidth + b.ActualPaddingTop + b.ActualPaddingBottom));
+        }
+
         // CSS 2.1 §10.4: Apply min-width constraint.
         // min-width takes priority over computed width (including
         // shrink-to-fit for auto-width inline-blocks).
-        if (b.MinWidth != "0" && !string.IsNullOrEmpty(b.MinWidth))
+        if (!isReplaced && b.MinWidth != "0" && !string.IsNullOrEmpty(b.MinWidth))
         {
             double minW = CssLengthParser.ParseLength(b.MinWidth, containerWidth, b.GetEmHeight());
             double minContentW = b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase)
@@ -1238,7 +1217,7 @@ internal static class CssLayoutEngine
         // max-width limits the computed width from above.  When both
         // min-width and max-width are specified, min-width wins if it
         // exceeds max-width (CSS2.1 §10.4).
-        if (b.MaxWidth != "none" && !string.IsNullOrEmpty(b.MaxWidth))
+        if (!isReplaced && b.MaxWidth != "none" && !string.IsNullOrEmpty(b.MaxWidth))
         {
             double maxW = CssLengthParser.ParseLength(b.MaxWidth, containerWidth, b.GetEmHeight());
             double maxContentW = b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase)
@@ -1383,7 +1362,14 @@ internal static class CssLayoutEngine
             && b.ParentBox != null
             && b.ParentBox.Display is "grid" or "inline-grid";
 
-        if (heightIsPercent && isInFlowGridItem)
+        if (isReplaced)
+        {
+            // Already settled with the width, constraints and all.
+            ibHeight = replacedContentHeight
+                + b.ActualBorderTopWidth + b.ActualBorderBottomWidth
+                + b.ActualPaddingTop + b.ActualPaddingBottom;
+        }
+        else if (heightIsPercent && isInFlowGridItem)
         {
             ibHeight = Math.Max(0, b.ActualBottom - b.Location.Y);
         }
@@ -1414,17 +1400,24 @@ internal static class CssLayoutEngine
 
         }
 
-        // CSS 2.1 §10.7: Apply min-height constraint for inline-blocks.
-        if (b.MinHeight != "0" && !string.IsNullOrEmpty(b.MinHeight))
+        // CSS 2.1 §10.7: clamp the block axis to min-height / max-height. ibHeight is a border-box
+        // height, so a content-box bound has the box's own border and padding added to it.
+        // max-height had no arm here at all until now, which is why a `display: inline-block` box
+        // with `height: 1000px; max-height: 60px` stayed 1000px tall while the same declarations on
+        // a `display: block` box clamped correctly (WPT issue #1562 problem 30 recorded it as the
+        // second of the three gaps behind css-sizing/replaced-max-size-saturation).
+        var blockBounds = isReplaced ? ReplacedBoxSizing.Bounds.Unconstrained : b.ResolveBlockSizeBounds();
+        if (!blockBounds.IsUnconstrained)
         {
-            double minH = CssLengthParser.ParseLength(b.MinHeight, containerWidth, b.GetEmHeight());
-            double minBoxH = b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase)
-                ? minH
-                : minH
-                    + b.ActualBorderTopWidth + b.ActualBorderBottomWidth
-                    + b.ActualPaddingTop + b.ActualPaddingBottom;
-            if (minBoxH > ibHeight)
-                ibHeight = minBoxH;
+            double borderAndPadding = b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase)
+                ? 0
+                : b.ActualBorderTopWidth + b.ActualBorderBottomWidth
+                  + b.ActualPaddingTop + b.ActualPaddingBottom;
+
+            ibHeight = new ReplacedBoxSizing.Bounds(
+                    blockBounds.Min > 0 ? blockBounds.Min + borderAndPadding : 0,
+                    double.IsPositiveInfinity(blockBounds.Max) ? blockBounds.Max : blockBounds.Max + borderAndPadding)
+                .Clamp(ibHeight);
         }
 
         b.ActualBottom = b.Location.Y + ibHeight;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -1088,21 +1088,6 @@ internal static class CssLayoutEngine
     /// its children while participating in the parent's inline
     /// formatting context as a single opaque box.
     /// </summary>
-    /// <summary>
-    /// Moves a min/max bound from the frame <c>box-sizing</c> names into the content box, so it can
-    /// clamp a content-box size. A no-op under the default <c>content-box</c>.
-    /// </summary>
-    private static ReplacedBoxSizing.Bounds ToContentBox(
-        ReplacedBoxSizing.Bounds bounds, CssBox b, double borderAndPadding)
-    {
-        if (borderAndPadding <= 0 || !b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase))
-            return bounds;
-
-        return new ReplacedBoxSizing.Bounds(
-            Math.Max(0, bounds.Min - borderAndPadding),
-            double.IsPositiveInfinity(bounds.Max) ? bounds.Max : Math.Max(0, bounds.Max - borderAndPadding));
-    }
-
     private static void FlowInlineBlock(ILayoutEnvironment g, CssBox blockbox, CssBox b,
         double limitRight, double linespacing, double startx,
         double leftspacing, double rightspacing,
@@ -1122,14 +1107,15 @@ internal static class CssLayoutEngine
         // follow are skipped for it.
         var intrinsic = b.IntrinsicReplacedSize;
         bool isReplaced = intrinsic is { Width: > 0, Height: > 0 };
-        bool replacedWidthIsAuto = b.Width == CssConstants.Auto || string.IsNullOrEmpty(b.Width);
-        bool replacedHeightIsAuto = b.Height == CssConstants.Auto || string.IsNullOrEmpty(b.Height);
 
         // --- Compute inline-block content width ---
+        // A replaced box settles both axes at once, constraints and all, so the per-axis clamps
+        // below are skipped for it and the height branch reads the result back.
+        double replacedContentHeight = 0;
         double ibContentWidth;
-        if (isReplaced && replacedWidthIsAuto)
+        if (isReplaced)
         {
-            ibContentWidth = intrinsic.Value.Width;
+            b.ResolveReplacedContentSize(intrinsic.Value, containerWidth, out ibContentWidth, out replacedContentHeight);
         }
         else if (b.Width != CssConstants.Auto && !string.IsNullOrEmpty(b.Width))
         {
@@ -1162,40 +1148,6 @@ internal static class CssLayoutEngine
                 - b.ActualBorderLeftWidth - b.ActualBorderRightWidth
                 - b.ActualPaddingLeft - b.ActualPaddingRight);
             ibContentWidth = Math.Min(Math.Max(prefMin, available), prefMax);
-        }
-
-        // The replaced box's own natural block size, settled together with its width below.
-        double replacedContentHeight = isReplaced ? intrinsic.Value.Height : 0;
-
-        if (isReplaced)
-        {
-            if (!replacedHeightIsAuto)
-            {
-                replacedContentHeight = CssLengthParser.ParseLength(b.Height, containerWidth, b.GetEmHeight());
-                if (b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase))
-                {
-                    replacedContentHeight -= b.ActualBorderTopWidth + b.ActualBorderBottomWidth
-                        + b.ActualPaddingTop + b.ActualPaddingBottom;
-                }
-                if (replacedContentHeight < 0)
-                    replacedContentHeight = 0;
-            }
-
-            double naturalRatio = intrinsic.Value.Width / intrinsic.Value.Height;
-
-            // The ratio fills in whichever axis the author left auto, before the constraints run.
-            if (replacedWidthIsAuto && !replacedHeightIsAuto)
-                ibContentWidth = replacedContentHeight * naturalRatio;
-            else if (replacedHeightIsAuto && !replacedWidthIsAuto)
-                replacedContentHeight = ibContentWidth / naturalRatio;
-
-            ReplacedBoxSizing.ApplyMinMax(
-                ref ibContentWidth, ref replacedContentHeight,
-                replacedWidthIsAuto, replacedHeightIsAuto, naturalRatio,
-                ToContentBox(b.ResolveInlineSizeBounds(), b,
-                    b.ActualBorderLeftWidth + b.ActualBorderRightWidth + b.ActualPaddingLeft + b.ActualPaddingRight),
-                ToContentBox(b.ResolveBlockSizeBounds(), b,
-                    b.ActualBorderTopWidth + b.ActualBorderBottomWidth + b.ActualPaddingTop + b.ActualPaddingBottom));
         }
 
         // CSS 2.1 §10.4: Apply min-width constraint.

--- a/Broiler.Layout/Broiler.Layout/Engine/ReplacedBoxSizing.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/ReplacedBoxSizing.cs
@@ -1,0 +1,189 @@
+namespace Broiler.Layout.Engine;
+
+/// <summary>
+/// CSS2.1 §10.4/§10.7: the used width and height of a box once
+/// <c>min-width</c>/<c>max-width</c>/<c>min-height</c>/<c>max-height</c> are applied to a
+/// tentative size.
+/// <para>For an ordinary box the two axes are independent — each is clamped on its own, with
+/// <c>min-*</c> winning over <c>max-*</c>. For a <b>replaced</b> box with an intrinsic ratio the
+/// axes are coupled: an axis the author left <c>auto</c> was derived from the other one through the
+/// ratio, so clamping the stated axis has to re-derive it. When <em>both</em> axes are auto and both
+/// constraints are violated, neither clamp can simply win — §10.4 settles it with a table that
+/// compares how hard each constraint bites (<c>max-width/w</c> against <c>max-height/h</c>) and
+/// keeps the shape square. That table is what
+/// WPT <c>css-sizing/replaced-max-size-saturation</c> asserts: an 8000×8000 canvas under
+/// <c>max-width: 120px; max-height: 100px</c> is <b>100×100</b>, not 120×100.</para>
+/// </summary>
+/// <remarks>
+/// Shared by the two paths that size a replaced box, so they cannot drift: the inline replaced word
+/// (<see cref="CssLayoutEngine.MeasureImageSize"/>, an <c>&lt;img&gt;</c>) and the atomic
+/// inline-level box (<see cref="CssLayoutEngine"/>'s inline flow, which is where a
+/// <c>&lt;canvas&gt;</c> and every other <c>inline-block</c> is sized). Ratio-less boxes get the
+/// per-axis clamp, which is also the whole of the correct behaviour for a non-replaced
+/// <c>inline-block</c>.
+/// </remarks>
+internal static class ReplacedBoxSizing
+{
+    /// <summary>The min/max bounds of one axis, in the same box-sizing frame as the size clamped.</summary>
+    /// <param name="Min">Lower bound; <c>0</c> when <c>min-*</c> is at its initial value.</param>
+    /// <param name="Max">Upper bound; <see cref="double.PositiveInfinity"/> for <c>max-*: none</c>
+    /// (and for a percentage <c>max-*</c> that §10.7 turns into <c>none</c> against an indefinite
+    /// containing block).</param>
+    internal readonly record struct Bounds(double Min, double Max)
+    {
+        /// <summary>No constraint on this axis.</summary>
+        public static Bounds Unconstrained => new(0, double.PositiveInfinity);
+
+        /// <summary>Whether either bound would actually move a size.</summary>
+        public bool IsUnconstrained => Min <= 0 && double.IsPositiveInfinity(Max);
+
+        /// <summary>CSS2.1 §10.4: clamp to <c>[Min, Max]</c>, with <c>min-*</c> winning when it
+        /// exceeds <c>max-*</c>.</summary>
+        public double Clamp(double value)
+        {
+            if (value > Max) value = Max;
+            if (value < Min) value = Min;
+            return value;
+        }
+    }
+
+    /// <summary>
+    /// Applies the min/max constraints to a tentative <paramref name="width"/>/<paramref name="height"/>.
+    /// </summary>
+    /// <param name="widthIsAuto">Whether the tentative width was <em>derived</em> (from the intrinsic
+    /// size or through the ratio) rather than stated by the author. A stated axis is never re-derived.</param>
+    /// <param name="heightIsAuto">The same for the block axis.</param>
+    /// <param name="ratio">The used width ÷ height ratio, or <c>0</c> when the box has none — in
+    /// which case the axes are clamped independently.</param>
+    internal static void ApplyMinMax(
+        ref double width, ref double height,
+        bool widthIsAuto, bool heightIsAuto, double ratio,
+        Bounds widthBounds, Bounds heightBounds)
+    {
+        if (widthBounds.IsUnconstrained && heightBounds.IsUnconstrained)
+            return;
+
+        bool hasRatio = ratio > 0 && !double.IsInfinity(ratio) && width > 0 && height > 0;
+
+        if (!hasRatio)
+        {
+            width = widthBounds.Clamp(width);
+            height = heightBounds.Clamp(height);
+            return;
+        }
+
+        // CSS2.1 §10.4, "for replaced elements with an intrinsic ratio and both 'width' and
+        // 'height' specified as 'auto'": the constraint-violation table. Only this case needs it —
+        // with one axis stated, that axis is clamped on its own terms and the auto one simply
+        // follows it through the ratio (below), which is what Chromium does for
+        // `height: 1000px; max-width: 100px` (100×1000: the height is stated, so max-width does
+        // not shorten it).
+        if (widthIsAuto && heightIsAuto)
+        {
+            ApplyConstraintTable(ref width, ref height, ratio, widthBounds, heightBounds);
+            return;
+        }
+
+        // One axis is stated: clamp it, re-derive the auto one from the clamped value through the
+        // ratio, then clamp that one too (it cannot push back on the stated axis).
+        if (!widthIsAuto)
+        {
+            width = widthBounds.Clamp(width);
+            if (heightIsAuto)
+                height = width / ratio;
+        }
+
+        if (!heightIsAuto)
+        {
+            height = heightBounds.Clamp(height);
+            if (widthIsAuto)
+                width = height * ratio;
+        }
+
+        if (widthIsAuto)
+            width = widthBounds.Clamp(width);
+        if (heightIsAuto)
+            height = heightBounds.Clamp(height);
+    }
+
+    /// <summary>
+    /// CSS2.1 §10.4's constraint-violation table, verbatim: pick the resolved pair for whichever
+    /// combination of the four constraints the tentative size violates.
+    /// </summary>
+    private static void ApplyConstraintTable(
+        ref double width, ref double height, double ratio,
+        Bounds widthBounds, Bounds heightBounds)
+    {
+        double w = width, h = height;
+        double minW = widthBounds.Min, maxW = widthBounds.Max;
+        double minH = heightBounds.Min, maxH = heightBounds.Max;
+
+        bool overW = w > maxW, underW = w < minW;
+        bool overH = h > maxH, underH = h < minH;
+
+        // h/w and w/h are the intrinsic ratio the tentative size already carries; using it rather
+        // than the measured quotient keeps a degenerate tentative size (a zero axis is filtered out
+        // by the caller's `hasRatio`) from steering the result.
+        double hOverW = 1 / ratio;
+        double wOverH = ratio;
+
+        if (overW && overH)
+        {
+            // Both upper bounds violated: the one that has to shrink the box *more* wins, and the
+            // other axis follows through the ratio (floored by its own min).
+            if (maxW / w <= maxH / h)
+            {
+                width = maxW;
+                height = Math.Max(minH, maxW * hOverW);
+            }
+            else
+            {
+                width = Math.Max(minW, maxH * wOverH);
+                height = maxH;
+            }
+        }
+        else if (underW && underH)
+        {
+            if (minW / w <= minH / h)
+            {
+                width = Math.Min(maxW, minH * wOverH);
+                height = minH;
+            }
+            else
+            {
+                width = minW;
+                height = Math.Min(maxH, minW * hOverW);
+            }
+        }
+        else if (underW && overH)
+        {
+            width = minW;
+            height = maxH;
+        }
+        else if (overW && underH)
+        {
+            width = maxW;
+            height = minH;
+        }
+        else if (overW)
+        {
+            width = maxW;
+            height = Math.Max(maxW * hOverW, minH);
+        }
+        else if (underW)
+        {
+            width = minW;
+            height = Math.Min(minW * hOverW, maxH);
+        }
+        else if (overH)
+        {
+            width = Math.Max(maxH * wOverH, minW);
+            height = maxH;
+        }
+        else if (underH)
+        {
+            width = Math.Min(minH * wOverH, maxW);
+            height = minH;
+        }
+    }
+}

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -2469,11 +2469,12 @@ previous runs' lists were almost entirely tests that had already been triaged an
 judged correct, which is the thing that work was for. It shows in what this run
 was able to be about: an engine defect rather than the reporting of one.
 
-Three of the 30 turned out to be the same element, and a fourth joined them.
+Three of the 30 turned out to be the same element, and two more joined them.
 
-Four of the 30 are fixed here: problems 12, 14 and 15 are one replaced element
-between them, and problem 24 turned out to be the same subject seen from the
-out-of-flow side.
+Five of the 30 are fixed here: problems 12, 14 and 15 are one replaced element
+between them, problem 24 turned out to be the same subject seen from the
+out-of-flow side, and problem 29 is unrelated — a whole CSS feature that was
+simply absent.
 
 ### Three tests, three defects, one replaced element — problems 12, 14 and 15, **fixed**
 
@@ -2650,9 +2651,9 @@ as reported. Measured after this run's fix.
 | 24 | `CSS2/positioning/abspos-025` | 13.6% | **passes (99.6%)** | **fixed** — this run; see below |
 | 25, 26 | `conformance-checkers/html/elements/{track,video}/src-isvalid` (2) | 14.4% | — | open — no `rel=match` |
 | 27 | `css-flexbox/percentage-heights-003` | 15.4% | — | open — no `rel=match`; a `check-layout-th.js` test |
-| 29 | `css-overflow/overflow-body-propagation-009` | 18.1% | 18.1% | open — reproduces; `overflow: clip` propagation from `<body>` |
+| 29 | `css-overflow/overflow-body-propagation-009` | 18.1% | **passes (100%)** | **fixed** — this run; see below |
 
-**Four fixed, fifteen of the nineteen reproduce against their own reference.**
+**Five fixed, fourteen of the nineteen reproduce against their own reference.**
 That last number is the reference-disagreement split doing its job: before #1618
 this list would have been padded with tests Broiler renders correctly, and now it
 is almost entirely tests it does not.
@@ -2699,6 +2700,40 @@ is almost entirely tests it does not.
   the ratio from the cross axis. Broiler does not implement that transfer, and the
   item was only landing on the reference by having no natural size to transfer
   from. Left open — it is a flexbox rule, not a replaced-sizing one.
+
+### `overflow` on `<body>` was never propagated to the viewport — problem 29, **fixed**
+
+- **Test:** `css-overflow/overflow-body-propagation-009`, 18.1 % on CI and 18.1 %
+  against its own reference. `body { overflow: clip }` on a 30×30 body holding a
+  10 000 px child: CSS Overflow 3 §3.3 applies that `overflow` to the **viewport**
+  and leaves the body's own used value `visible`, so the child fills the canvas.
+  Broiler clipped it to the body — 0.3 % of the canvas blue against a reference
+  that is 82 %.
+- **Nothing was propagated, for any value.** Three probes (`hidden`, `clip`,
+  `auto`) all clipped the body's own box, so this is not a missing keyword in a
+  list — the rule was absent.
+- **The fix is a used-value adjustment, and the interesting half is the
+  disqualifications.** The value goes to the viewport, which Broiler already clips
+  at the canvas edge, so propagating means *removing* the body's own clip rather
+  than moving it onto the root element's box — those are different rectangles once
+  the body has margins, and putting it on the root scored 25 % where dropping it
+  scores 100 %. It must also apply to the **first** `<body>` only, and only if that
+  one generates a box: `overflow-body-propagation-016` is a document with two of
+  them where the first is `display: none`, and there the second has to keep its own
+  `overflow: hidden`. A first pass without that guard fixed 009 and broke 016.
+- **Sweep: 11 749 → 11 750 passing, +4 and −3.** The gains are 009 and two more of
+  its own family (`-014`, `-015`) plus `css-sizing/fit-content-block-size-abspos`.
+  The three losses are pre-existing gaps the propagation exposes rather than
+  causes: `css-flexbox/flexbox-definite-sizes-003` and `-004` (92.2 %) both set
+  `body { overflow: hidden }` and then resolve a descendant's `max-height: 100%`,
+  which is CSS Flexbox's definite-size rule and not this one, and
+  `css-images/image-orientation/image-orientation-img-object-fit` is at 98.7 %
+  against a 99 % threshold. Net +1 on the sweep, +1 on the reported list, and a
+  feature that was not there before.
+- **What this is not.** The viewport is still not a real clip container in Broiler
+  — it is the canvas edge. That is indistinguishable for a top-level document, and
+  it is why this fix is small; a nested browsing context with its own propagated
+  overflow would need the real thing.
 
 ### The split has a threshold, and two entries fall through it
 

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -40,8 +40,9 @@
   [#1538 (2026-08-05)](#the-next-run-issue-1538-2026-08-05),
   [#1562 (2026-08-07)](#the-next-run-issue-1562-2026-08-07),
   [#1612 (2026-08-12)](#the-next-run-issue-1612-2026-08-12),
-  [#1615 (2026-08-12)](#the-next-run-issue-1615-2026-08-12) and
-  [#1618 (2026-08-12)](#the-next-run-issue-1618-2026-08-12). Where a re-run
+  [#1615 (2026-08-12)](#the-next-run-issue-1615-2026-08-12),
+  [#1618 (2026-08-12)](#the-next-run-issue-1618-2026-08-12) and
+  [#1624 (2026-08-12)](#the-next-run-issue-1624-2026-08-12). Where a re-run
   contradicts something below, the section says so and the row here is struck
   through — read the newest section first. #1612 contradicts two of them: the
   frameset test was not a frameset bug, and `image-animation: paused` is no
@@ -49,7 +50,8 @@
   unjudgeable offline, because the runner now performs the substitution itself.
   #1618 stops the pattern repeating: the run reports these verdicts itself now,
   so a test that is right by its own reference is no longer ranked as the run's
-  worst render.
+  worst render — and #1624 is the first list that split produced, three of whose
+  entries turned out to be one replaced element.
 - **Not in scope:** problem 1 (the `DomDocument.CreateElement` crash) is fixed —
   frames no longer parse a non-HTML resource as markup, and `patches/0035-…`
   carried the DOM-layer fix (since applied). Problems 2 and 3 are both per-test
@@ -2456,6 +2458,218 @@ a wrong impression of the engine:
 - **The paged-reftest figure was one release out of date** — 212, not 213
   (`docs/wpt-reftests.md` was updated and the citation here, plus the runner's
   `--help`, were not).
+
+## The next run (issue #1624, 2026-08-12)
+
+7 651 failures, no incomplete shards. This is the **first severity list the
+reference-disagreement split produced** ([#1618](#the-next-run-issue-1618-2026-08-12)):
+40 mismatches are reported under their own *Not ranked* heading, and the 30
+*Biggest problems* above them are tests that really do render wrong. The three
+previous runs' lists were almost entirely tests that had already been triaged and
+judged correct, which is the thing that work was for. It shows in what this run
+was able to be about: an engine defect rather than the reporting of one.
+
+Three of the 30 turned out to be the same element.
+
+### Three tests, three defects, one replaced element — problems 12, 14 and 15, **fixed**
+
+- **Tests.** `css-sizing/replaced-max-size-saturation` (8.3 % on CI),
+  `css-sizing/block-image-percentage-max-height-inside-inline` (9.7 %) and
+  `css-sizing/image-percentage-max-height-in-anonymous-block` (9.7 %). Each asks
+  for a 100 px green square; Broiler drew a 1000×1000 or 8000×8000 block, clipped
+  by the viewport into a full-page slab.
+- **None is a reference disagreement.** All three reproduce offline against the
+  `rel=match` reference the test itself declares — **8.6 %, 10.1 % and 10.1 %**,
+  within rounding of CI's numbers. The engine is wrong, not the golden.
+- **The three defects were already named.** The
+  [#1562 problem 30 section](#canvas-is-not-a-replaced-element--problem-30-diagnosed-not-fixed)
+  diagnosed `replaced-max-size-saturation` down to three separate gaps and closed
+  with "left for a session that can do all three". This is that session, and the
+  diagnosis held on all three counts. A fourth turned up on the way.
+
+**1. The min/max pass clamped four properties one at a time.** A replaced box's
+two axes are coupled by its ratio: an axis left `auto` was *derived* from the
+other one, so clamping the stated axis has to re-derive it — and when both axes
+are auto and both maximums are violated, neither clamp can simply win. CSS2.1
+§10.4 settles that with a constraint-violation table that compares how hard each
+bound bites (`max-width/w` against `max-height/h`) and keeps the shape. Broiler
+had no `max-width` arm for a replaced element at all, and applied the other three
+independently. The table now lives in `Broiler.Layout.Engine.ReplacedBoxSizing`,
+shared by the two paths that size a replaced box so they cannot drift.
+
+**2. `max-height` was never applied to an `inline-block`.** `FlowInlineBlock` had
+a `min-height` arm and nothing beside it, so `height: 1000px; max-height: 60px`
+stayed 1000 px tall on an `inline-block` while the same declarations on a
+`display: block` box clamped correctly. That is gap (2) of the three, and it was
+never about replaced elements — every atomic inline-level box had it.
+
+**3. `<canvas>` was not a replaced element.** HTML §4.12.5 makes its
+`width`/`height` content attributes the dimensions of its *bitmap* — its natural
+size — and the Rendering section maps no presentation `width`/`height` for it,
+unlike `<img>` or `<table>`. `DomParser.TranslateAttributes` projected them onto
+CSS `width`/`height` regardless, which made both axes independently *stated*, so
+even a correct §10.4 pass would clamp each on its own and give 120×100 where the
+test wants 100×100. Left alone entirely, a `<canvas>` laid out as a non-replaced
+inline — the one box type `max-width`/`max-height` do not apply to.
+`CorrectCanvasBoxes` now records the attributes as the box's natural size and
+makes it an atomic inline-level box. Only the UA default `display` is replaced; an
+author `display` is theirs to keep.
+
+**4. A percentage `min-`/`max-height` resolved against an anonymous block** — and
+an anonymous block is not an element, has no author height, and so is *always*
+indefinite, which turned the percentage into its initial value (`0` / `none`) and
+made it clamp nothing. Browsers climb to the nearest real element. This is not a
+detail: both percentage-max-height tests are built around an image that lands in
+an anonymous block — one after a sibling `<div>`, one through a `<span>` that a
+block-inside-inline split has to break up — and that is the whole point of having
+two of them. This one is not in the #1562 diagnosis; it only became visible once
+defect 1 stopped masking it.
+
+#### Every expectation here is Chromium's, measured rather than read off the spec
+
+Chromium is installed in this container for the golden-image suite, so each case
+was put to it directly through `getBoundingClientRect` rather than argued from
+§10.4. That was worth doing: it overturned one reading of the spec that looked
+obvious and is wrong (row 2).
+
+| Probe | Chromium | Broiler before | Broiler after |
+| --- | --- | --- | --- |
+| 1×1 img, `max-width:100px; height:1000px; max-height:100%` in a 100 px block | 100×100 | 1000×1000 | **100×100** |
+| 1×1 img, `max-width:100px; height:1000px` (no max-height) | 100×**1000** | 1000×1000 | **100×1000** |
+| `<canvas width=8000 height=8000>`, `max-width:120px; max-height:100px` | 100×100 | 8000×8000 | **100×100** |
+| `<canvas width=400 height=200>`, `max-width:100px` | 100×50 | 400×200 | **100×50** |
+| `<canvas width=400 height=200>`, no CSS | 400×200 | 0-sized inline | **400×200** |
+| `inline-block`, `width:200px; height:1000px; max-height:60px` | 200×60 | 200×1000 | **200×60** |
+| `inline-block`, `height:1000px; max-height:100%` in a 100 px block | 50×100 | 50×1000 | **50×100** |
+| block img in a `<span>`, `max-height:100%` in a 100 px block | 100×100 | 1000×1000 | **100×100** |
+| img, `width:1000px; max-width:100px`, auto height | 100×100 | 1000×1000 | **100×100** |
+
+Row 2 is the one to keep. `height: 1000px; max-width: 100px` on a 1:1 image is
+**100×1000**, not the 100×100 the §10.4 table would give — because the table is
+written for "both `width` and `height` specified as `auto`", and a *stated* axis
+is never re-derived from a clamp on the other one. Applying the table
+unconditionally would have "fixed" three tests and quietly broken every image
+with a stated height and a `max-width`, which is a common shape. The gate on
+`widthIsAuto && heightIsAuto` is the whole difference and it is pinned by a test.
+
+#### Where it landed, and what is on CI now
+
+- **Main repo, live on CI:** `ReplacedBoxSizing` (the table), the `max-height` arm
+  in `FlowInlineBlock`, `CssBox.ResolveInlineSizeBounds`/`ResolveBlockSizeBounds`
+  (which also stop a keyword `max-width: fit-content` from being parsed as `0px`
+  and collapsing the box — `CssLengthParser` resolves an unrecognised unit to
+  zero), `CssBox.TryGetPercentageBlockSizeBasis` (the anonymous-block walk), and
+  `CssBoxProperties.IntrinsicReplacedSize`.
+- **`Broiler.HTML`, as a patch:** the 61-line `DomParser` change. Its push to
+  `Broiler-Platform/Broiler.HTML` is denied (403 — the submodule remote is outside
+  this session's GitHub scope), so it ships as a patch with the gitlink left
+  unbumped, and it is registered in `scripts/apply-pending-wpt-patches.sh` so the
+  WPT run exercises it rather than the un-fixed pointer. Identify it by its commit
+  subject, *"parse: size a `<canvas>` as a replaced element, not from presentation
+  width/height"* — not by its number, which is recycled.
+- **The type is in the main repo and the call is in the submodule**, deliberately:
+  `IntrinsicReplacedSize` is a main-repo box property, so the submodule patch is
+  the parse-time code that fills it in and nothing else.
+
+#### Verified
+
+- **The three tests pass**, and `css/css-sizing` as a whole goes from **253 to 260
+  of 562** reftests.
+- **`Broiler.Layout.Tests`: 663 passing, 0 failing**, including 25 new cases. The
+  §10.4 table gets one per row of the table plus both orders of each two-bound
+  case; the layout-level ones pin the anonymous-block walk (both with and without
+  the anonymous box, so the walk is doing something), the indefinite-basis case
+  where a percentage must clamp nothing, and the keyword-`max-width` guard.
+- **A 17 077-test reftest sweep across 18 directories** (`css/CSS2`, `css/css-sizing`,
+  `css/css-flexbox`, `css/css-grid`, `css/css-images`, `css/css-backgrounds`,
+  `css/css-display`, `css/css-tables`, `css/css-position`, `css/css-overflow`,
+  `css/css-inline`, `css/css-text`, `css/css-align`, `css/css-ui`, `css/css-box`,
+  `css/css-writing-modes`, `html`, `canvas`), run before and after: **11 674 →
+  11 705 passing**, with **34 newly passing and 3 newly failing**. The 34 are not
+  only the three: unifying the §10.7 clamp picks up ten `CSS2/normal-flow/max-height-*`
+  tests, the percentage-basis walk picks up
+  `css-sizing/intrinsic-height-{abspos,fixedpos}-percentage-child` and two
+  `css-tables/percent-height-replaced-in-percent-cell-*`, and modelling `<canvas>`
+  picks up `css-flexbox/canvas-contain-size`,
+  `css-grid/grid-items/percentage-size-indefinite-replaced` and four
+  `css-sizing/intrinsic-percent-replaced-*`.
+- **The three that regressed are all `<canvas>`, and two of them were passing by
+  rendering nothing** — the trap this document warns about, now sprung in the
+  other direction:
+  - `css-images/object-view-box-writing-mode-canvas` (94.3 %). The test's canvas
+    carries `background-color: black` and the reference's does not; Broiler cannot
+    paint a canvas bitmap, so with the canvas sized at zero *both* sides were blank
+    white and agreed. Giving it its real size paints the black box the test asks
+    for against a reference whose canvas shows a painted bitmap Broiler has no 2D
+    context to produce. Nothing here is a sizing bug.
+  - `css-grid/alignment/grid-align-baseline-005` (92.3 %) is the same in a grid,
+    plus a placement gap it uncovers: the two items land in separate rows where the
+    template asks for one.
+  - `css-sizing/intrinsic-percent-replaced-012` (98.7 %, against a 99 % threshold)
+    is a genuine near-miss on a `display: block` canvas under `height: 100%`.
+- **One rule was tried and removed on the evidence.** Declining the ratio transfer
+  into a percentage block size with no definite basis looked right and improved
+  `grid-align-baseline-005` from 92.3 % to 96.8 % — and cost three other tests
+  (`css-sizing/intrinsic-percent-replaced-008`, `-dynamic-008` and
+  `css-grid/grid-items/percentage-size-indefinite-replaced`, all of which assert
+  that behaviour and all of which want the transfer). It is not in the change. The
+  sweep is what settled it; the reasoning on its own pointed the wrong way twice.
+
+### #1624 problems, at a glance
+
+`rel=match` is this container's reftest-suite result — Broiler against the
+reference the test itself declares, no other engine involved. 19 of the 30 carry
+one; the other 11 can only be judged against a Chromium golden, and are recorded
+as reported. Measured after this run's fix.
+
+| # | Test | CI | `rel=match` | Status |
+| --- | --- | --- | --- | --- |
+| 1 | `css-page/page-margin-002-print` | 0.0% | 89.2% | **won't fix** — a `-print` test scored on screen; unchanged from [#1618](#page-margin-002-print-is-not-the-exception-it-looks-like) |
+| 2 | `css-grid/…/column-subgrid-auto-fill-003` | 0.8% | **94.0%** | open — see the note below; `grid-lanes` is an unshipped draft feature |
+| 3 | `css-grid/…/column-subgrid-orthogonal-writing-mode-004` | 0.9% | **94.8%** | open — same |
+| 4 | `css-view-transitions/view-transition-waituntil-animation-manipulation` | 1.3% | 1.3% | open — view transitions do not capture the document |
+| 5 | `css-view-transitions/root-to-shared-animation-start` | 1.5% | 1.5% | open — same |
+| 6–9 | `css-view-transitions/massive-element-*-of-viewport-partially-onscreen-{new,old}` (4) | 2.0–2.6% | 2.0–2.7% | open — same |
+| 10 | `css-backgrounds/background-image-shared-stylesheet` | 5.7% | 5.7% | open — a script-injected `data:text/css` stylesheet never applies ([re-diagnosed in the audit](#one-test-reclassified-css-backgroundsbackground-image-shared-stylesheet)) |
+| 11 | `filter-effects/svg-filter-filter-units-user-space` | 8.0% | **95.3%** | open — see the note below |
+| 12 | `css-sizing/replaced-max-size-saturation` | 8.3% | **passes (100%)** | **fixed** — this run |
+| 13 | `css-grid/abspos/grid-sizing-positioned-items-001` | 9.1% | — | open — no `rel=match`; judged from CI |
+| 14 | `css-sizing/block-image-percentage-max-height-inside-inline` | 9.7% | **passes (100%)** | **fixed** — this run |
+| 15 | `css-sizing/image-percentage-max-height-in-anonymous-block` | 9.7% | **passes (100%)** | **fixed** — this run |
+| 16 | `cssom-view/scrollIntoView-fixed` | 10.9% | — | open — no `rel=match`; needs scripted scrolling |
+| 17, 20, 23, 28, 30 | `conformance-checkers/html-svg/*-isvalid` (5) | 11.1–19.3% | — | open — no `rel=match`; large inline-SVG documents, not triaged this run |
+| 18, 19 | `css-view-transitions/{new,old}-content-has-scrollbars` (2) | 11.1% | 11.1% | open — view transitions |
+| 21 | `scroll-animations/css/scroll-timeline-nearest-with-absolute-positioned-element` | 11.3% | — | open — no `rel=match` |
+| 22 | `css-grid/…/column-subgrid-auto-fill-008` | 11.5% | 10.4% | open — reproduces; `grid-lanes` track sizing |
+| 24 | `CSS2/positioning/abspos-025` | 13.6% | 13.7% | open — reproduces; an abspos replaced element with four offsets |
+| 25, 26 | `conformance-checkers/html/elements/{track,video}/src-isvalid` (2) | 14.4% | — | open — no `rel=match` |
+| 27 | `css-flexbox/percentage-heights-003` | 15.4% | — | open — no `rel=match`; a `check-layout-th.js` test |
+| 29 | `css-overflow/overflow-body-propagation-009` | 18.1% | 18.1% | open — reproduces; `overflow: clip` propagation from `<body>` |
+
+**Three fixed, sixteen of the nineteen reproduce against their own reference.**
+That last number is the reference-disagreement split doing its job: before #1618
+this list would have been padded with tests Broiler renders correctly, and now it
+is almost entirely tests it does not.
+
+### The split has a threshold, and two entries fall through it
+
+Problems 2, 3 and 11 are the exception, and they are worth a note because they
+point at the next improvement to the report rather than to the renderer. Each
+scores **94–95 % against the reference the test itself declares** while CI reports
+**0.8–8.0 %** against Chromium's golden. A gap that large in that direction is the
+signature of a reference disagreement — but `--verify-reference` only sets
+`suspectReference` when Broiler *reproduces* the declared reference, and
+"reproduces" means clearing the same 99 % pass threshold. At 94 % they do not
+clear it, so they are ranked as though nothing were known about them.
+
+Problems 2 and 3 are `css-grid/grid-lanes`, which
+[#1538 problems 12 and 13](#problems-12-and-13-are-an-unshipped-draft-feature-not-a-layout-bug)
+already established is an unshipped draft feature Chromium drops to `display:
+block` — exactly the shape that produces a permanent 0.x % against a golden.
+Recording the reference score alongside the golden one, rather than only using it
+as a pass/fail gate, would separate "wrong everywhere" from "wrong only against
+Chromium" without needing a second threshold to be tuned. Left for a run that owns
+the report.
 
 ## Reported problems, at a glance
 

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -2469,7 +2469,11 @@ previous runs' lists were almost entirely tests that had already been triaged an
 judged correct, which is the thing that work was for. It shows in what this run
 was able to be about: an engine defect rather than the reporting of one.
 
-Three of the 30 turned out to be the same element.
+Three of the 30 turned out to be the same element, and a fourth joined them.
+
+Four of the 30 are fixed here: problems 12, 14 and 15 are one replaced element
+between them, and problem 24 turned out to be the same subject seen from the
+out-of-flow side.
 
 ### Three tests, three defects, one replaced element — problems 12, 14 and 15, **fixed**
 
@@ -2554,7 +2558,9 @@ with a stated height and a `max-width`, which is a common shape. The gate on
 
 #### Where it landed, and what is on CI now
 
-- **Main repo, live on CI:** `ReplacedBoxSizing` (the table), the `max-height` arm
+- **Main repo, live on CI:** `ReplacedBoxSizing` (the table), the replaced
+  block-level/out-of-flow sizing path (`CssBox.ResolveReplacedContentSize`,
+  `TryGetNaturalReplacedSize`, `TryResolveReplacedBorderBoxSize`), the `max-height` arm
   in `FlowInlineBlock`, `CssBox.ResolveInlineSizeBounds`/`ResolveBlockSizeBounds`
   (which also stop a keyword `max-width: fit-content` from being parsed as `0px`
   and collapsing the box — `CssLengthParser` resolves an unrecognised unit to
@@ -2641,15 +2647,58 @@ as reported. Measured after this run's fix.
 | 18, 19 | `css-view-transitions/{new,old}-content-has-scrollbars` (2) | 11.1% | 11.1% | open — view transitions |
 | 21 | `scroll-animations/css/scroll-timeline-nearest-with-absolute-positioned-element` | 11.3% | — | open — no `rel=match` |
 | 22 | `css-grid/…/column-subgrid-auto-fill-008` | 11.5% | 10.4% | open — reproduces; `grid-lanes` track sizing |
-| 24 | `CSS2/positioning/abspos-025` | 13.6% | 13.7% | open — reproduces; an abspos replaced element with four offsets |
+| 24 | `CSS2/positioning/abspos-025` | 13.6% | **passes (99.6%)** | **fixed** — this run; see below |
 | 25, 26 | `conformance-checkers/html/elements/{track,video}/src-isvalid` (2) | 14.4% | — | open — no `rel=match` |
 | 27 | `css-flexbox/percentage-heights-003` | 15.4% | — | open — no `rel=match`; a `check-layout-th.js` test |
 | 29 | `css-overflow/overflow-body-propagation-009` | 18.1% | 18.1% | open — reproduces; `overflow: clip` propagation from `<body>` |
 
-**Three fixed, sixteen of the nineteen reproduce against their own reference.**
+**Four fixed, fifteen of the nineteen reproduce against their own reference.**
 That last number is the reference-disagreement split doing its job: before #1618
 this list would have been padded with tests Broiler renders correctly, and now it
 is almost entirely tests it does not.
+
+### An absolutely positioned `<img>` rendered nothing at all — problem 24, **fixed**
+
+- **Test:** `CSS2/positioning/abspos-025`, 13.6 % on CI and 13.7 % against its own
+  reference. An `<img>` with `position: absolute; left: 4em; right: 0; top: 4em;
+  bottom: 0` must keep its natural 15×15 size and let `right`/`bottom` give way
+  (CSS2.1 §10.3.8/§10.6.5); Broiler stretched it across the whole inset box.
+- **Probing it turned up something worse than the test.** The stretch only happens
+  when `right` is set. With `left`/`top` alone — the ordinary way anyone positions
+  an image — an absolutely positioned `<img>` **rendered nothing at all**, and the
+  same was true of a `<canvas>`. That is not in the reported list because no test
+  in the top 30 exercises it; it came out of nine constructed probes measured
+  against Chromium.
+- **Both are the same missing clause, in two places that each say the right thing
+  in a comment and then do not do it.** `ResolveBlockUsedWidth` solves the §10.3.7
+  inset equation "for absolutely positioned, **non-replaced** elements", and falls
+  back to shrink-to-fit "for absolutely positioned **non-replaced** elements with
+  auto width" — but neither branch excluded replaced boxes. With `right` set the
+  first branch stretched the image to the insets; without it the second measured
+  the box's *children*, of which an `<img>` has none, and produced zero. A
+  zero-width box paints no image, which is why nothing appeared.
+- **The fix** routes a block-level or out-of-flow replaced box through the same
+  `CssBox.ResolveReplacedContentSize` the inline path already used, and skips both
+  non-replaced branches for it. `TryGetNaturalReplacedSize` is what makes that
+  possible for an `<img>` as well as a `<canvas>`: the natural size comes from
+  `IntrinsicReplacedSize` when the element declares one and from the decoded
+  bitmap's intrinsics otherwise.
+- **Verified against Chromium on seven inset combinations** — all four insets, each
+  pair, none at all, and `width: 40px` with four insets (40×40: the height follows
+  the width through the ratio). Broiler now matches on every one.
+- **The sweep is what shows the size of it.** Re-running the same 17 077 reftests:
+  **11 705 → 11 749 passing**, and the 45 newly-passing tests are almost entirely
+  the family this rule governs — 22 `CSS2/positioning/absolute-replaced-{width,height}-*`,
+  `abspos-025` and `abspos-026`, six `css-flexbox/flex-aspect-ratio-img-row-*`,
+  four `css-flexbox/flex-minimum-width-flex-items-*`, and
+  `css-position/position-absolute-replaced-no-intrinsic-size.tentative`. Against
+  the run's own baseline that is **+79 newly passing and 4 newly failing**.
+- **The one new failure** is `css-flexbox/flexbox-min-width-auto-002b` at 98.5 %
+  against a 99 % threshold: it measures `min-width: auto` on a flex item that has
+  an intrinsic ratio and a `min-height`, which CSS Flexbox §4.5 resolves through
+  the ratio from the cross axis. Broiler does not implement that transfer, and the
+  item was only landing on the reference by having no natural size to transfer
+  from. Left open — it is a flexbox rule, not a replaced-sizing one.
 
 ### The split has a threshold, and two entries fall through it
 

--- a/patches/0004-html-canvas-replaced-element.patch
+++ b/patches/0004-html-canvas-replaced-element.patch
@@ -1,11 +1,13 @@
-From 561dc4532504b31b2d13af380fccb7243275dd3c Mon Sep 17 00:00:00 2001
+From ffa04e728d4899d5689b3c3b71b7e2d2d80ea49d Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
 Date: Wed, 12 Aug 2026 21:27:33 +0000
-Subject: [PATCH] parse: size a <canvas> as a replaced element, not from
- presentation width/height
+Subject: [PATCH] parse: size a <canvas> as a replaced element, and mark a
+ blockified inline split
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
+
+Two parse-time facts the layout engine needs, both feeding main-repo types.
 
 HTML §4.12.5 gives <canvas> its bitmap dimensions from the width/height content
 attributes (300x150 by default). They are the element's *natural* size, and the
@@ -16,22 +18,30 @@ its own instead of keeping the natural ratio: an 8000x8000 canvas under
 `max-width: 120px; max-height: 100px` came out 120x100 where every browser draws
 the 100x100 square WPT css-sizing/replaced-max-size-saturation asks for. Left
 alone entirely, a <canvas> laid out as a non-replaced inline — the one box type
-max-width and max-height do not apply to at all.
+max-width and max-height do not apply to. CorrectCanvasBoxes now records the
+attributes as CssBox.IntrinsicReplacedSize and makes the box atomic inline-level,
+so the layout engine sizes it through CSS2.1 §10.4. Only the UA default display
+is replaced; an author `display` is theirs to keep. Fallback content between the
+tags is hidden, as in any UA that supports canvas.
 
-CorrectCanvasBoxes now records the attributes as CssBox.IntrinsicReplacedSize and
-makes the box an atomic inline-level one, so the layout engine sizes it through
-the CSS2.1 §10.4 replaced-element rules. Only the UA default display is replaced;
-an author `display` is theirs to keep. Fallback content between the tags is
-hidden, as in any UA that supports canvas.
+CSS2.1 §9.2.1.1: breaking an inline around a block-level child sets the inline's
+own display to block, in both arms of CorrectBlockInsideInlineImp. The element is
+still inline as far as CSS is concerned, so that box must not act as a containing
+block a percentage resolves against — any more than the anonymous blocks the same
+split creates do. CssBox.IsBlockifiedInlineSplit records it. Without it a
+`display: block` <img> inside a <span> inside a `height: 100px` <div> resolved
+its `max-height: 100%` against an indefinite block size, so §10.7 turned it into
+`none` and the image kept its 1000px height (WPT
+css-sizing/block-image-percentage-max-height-inside-inline).
 
 Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
 Claude-Session: https://claude.ai/code/session_01JHgRgAUtWB14ZWuPrN4f4E
 ---
- .../Parse/DomParser.cs                        | 61 +++++++++++++++++++
- 1 file changed, 61 insertions(+)
+ .../Parse/DomParser.cs                        | 68 +++++++++++++++++++
+ 1 file changed, 68 insertions(+)
 
 diff --git a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
-index 7735727..22a7b50 100644
+index 7735727..dd827a0 100644
 --- a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
 +++ b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
 @@ -121,6 +121,7 @@ internal sealed class DomParser
@@ -120,6 +130,28 @@ index 7735727..22a7b50 100644
      /// <summary>
      /// Reads a numeric <c>width</c>/<c>height</c> presentation attribute as a pixel length, falling back to
      /// <paramref name="fallback"/> when the attribute is absent or non-numeric (percentages and other units
+@@ -1611,7 +1672,13 @@ internal sealed class DomParser
+         // Also inherit any split-positioned-ancestor from a higher level.
+         CssBox splitAncestor = wasPositioned ? box : box.SplitPositionedAncestor;
+         if (box.Display == CssConstants.Inline)
++        {
+             box.Display = CssConstants.Block;
++            // The element is still inline as far as CSS is concerned; the block-level display is
++            // an artefact of how this split is modelled. Layout needs to know, because a box like
++            // this is not a containing block a percentage resolves against.
++            box.IsBlockifiedInlineSplit = true;
++        }
+ 
+         if (box.Boxes.Count > 1 || box.Boxes[0].Boxes.Count > 1)
+         {
+@@ -1685,6 +1752,7 @@ internal sealed class DomParser
+         else if (box.Boxes[0].Display == CssConstants.Inline)
+         {
+             box.Boxes[0].Display = CssConstants.Block;
++            box.Boxes[0].IsBlockifiedInlineSplit = true;
+         }
+ 
+         return null;
 -- 
 2.43.0
 

--- a/patches/0004-html-canvas-replaced-element.patch
+++ b/patches/0004-html-canvas-replaced-element.patch
@@ -1,0 +1,125 @@
+From 561dc4532504b31b2d13af380fccb7243275dd3c Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Wed, 12 Aug 2026 21:27:33 +0000
+Subject: [PATCH] parse: size a <canvas> as a replaced element, not from
+ presentation width/height
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+HTML §4.12.5 gives <canvas> its bitmap dimensions from the width/height content
+attributes (300x150 by default). They are the element's *natural* size, and the
+Rendering section maps no presentation width/height for it — unlike <img> or
+<table>. TranslateAttributes projected them onto CSS width/height anyway, which
+made both axes independently stated, so max-width and max-height clamped each on
+its own instead of keeping the natural ratio: an 8000x8000 canvas under
+`max-width: 120px; max-height: 100px` came out 120x100 where every browser draws
+the 100x100 square WPT css-sizing/replaced-max-size-saturation asks for. Left
+alone entirely, a <canvas> laid out as a non-replaced inline — the one box type
+max-width and max-height do not apply to at all.
+
+CorrectCanvasBoxes now records the attributes as CssBox.IntrinsicReplacedSize and
+makes the box an atomic inline-level one, so the layout engine sizes it through
+the CSS2.1 §10.4 replaced-element rules. Only the UA default display is replaced;
+an author `display` is theirs to keep. Fallback content between the tags is
+hidden, as in any UA that supports canvas.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01JHgRgAUtWB14ZWuPrN4f4E
+---
+ .../Parse/DomParser.cs                        | 61 +++++++++++++++++++
+ 1 file changed, 61 insertions(+)
+
+diff --git a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+index 7735727..22a7b50 100644
+--- a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
++++ b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+@@ -121,6 +121,7 @@ internal sealed class DomParser
+             CorrectFramesetBoxes(root);
+             CorrectIframeBoxes(root);
+             CorrectVideoBoxes(root);
++            CorrectCanvasBoxes(root);
+             CorrectProgressBoxes(root, baseUrl);
+             CorrectSelectMultipleBoxes(root, baseUrl);
+ 
+@@ -674,10 +675,20 @@ internal sealed class DomParser
+         if (!tag.HasAttributes())
+             return;
+ 
++        // HTML §4.12.5: a <canvas>'s width/height content attributes are the dimensions of its
++        // *bitmap*, and the Rendering section maps no presentation width/height for it — unlike
++        // <img>, <table> and the rest below. Projecting them onto CSS width/height made the two axes
++        // independently stated, so `max-width`/`max-height` clamped each on its own instead of
++        // keeping the natural ratio; CorrectCanvasBoxes records them as the natural size instead.
++        bool isCanvas = tag.Name.Equals("canvas", StringComparison.OrdinalIgnoreCase);
++
+         foreach (string att in tag.Attributes.Keys)
+         {
+             string value = tag.Attributes[att];
+ 
++            if (isCanvas && (att == HtmlConstants.Width || att == HtmlConstants.Height))
++                continue;
++
+             switch (att)
+             {
+                 case HtmlConstants.Align:
+@@ -1015,6 +1026,56 @@ internal sealed class DomParser
+             CorrectVideoBoxes(child);
+     }
+ 
++    /// <summary>
++    /// HTML §4.12.5: a <c>&lt;canvas&gt;</c> is a replaced element whose <b>natural</b> size is its
++    /// <c>width</c>/<c>height</c> content attributes, defaulting to the 300×150 bitmap. Natural, not
++    /// a CSS width and height: the distinction only shows once <c>max-width</c>/<c>max-height</c>
++    /// clamp it, where the two axes stay tied by the natural ratio (CSS2.1 §10.4), which is what WPT
++    /// <c>css-sizing/replaced-max-size-saturation</c> asserts. Broiler has no 2D context, so the
++    /// bitmap is transparent and only the element's own background and border paint — and, like any
++    /// UA that supports canvas, it never renders the fallback content between the tags. Runs
++    /// post-cascade for the same reason <see cref="CorrectIframeBoxes"/> does: a cascade-time hide of
++    /// a block fallback child can be re-shown afterwards.
++    /// </summary>
++    private static void CorrectCanvasBoxes(CssBox box)
++    {
++        if (box.HtmlTag != null
++            && box.HtmlTag.Name.Equals("canvas", StringComparison.OrdinalIgnoreCase))
++        {
++            // Only the UA default display is replaced by the atomic inline-level box; an author
++            // `display` (block, grid, none, …) is theirs to keep.
++            if (box.Display == CssConstants.Inline)
++                box.Display = CssConstants.InlineBlock;
++
++            box.IntrinsicReplacedSize = new System.Drawing.SizeF(
++                CanvasBitmapDimension(box, "width", 300),
++                CanvasBitmapDimension(box, "height", 150));
++
++            foreach (var child in box.Boxes)
++                child.Display = CssConstants.None;
++            return;
++        }
++
++        foreach (var child in box.Boxes)
++            CorrectCanvasBoxes(child);
++    }
++
++    /// <summary>
++    /// HTML §4.12.5: reads a <c>&lt;canvas&gt;</c>'s <c>width</c>/<c>height</c> content attribute as
++    /// a valid non-negative integer, falling back to the default bitmap dimension when it is absent,
++    /// malformed or zero (a zero-area canvas has no natural size to size the box from).
++    /// </summary>
++    private static float CanvasBitmapDimension(CssBox box, string attribute, float fallback)
++    {
++        var raw = box.HtmlTag?.TryGetAttribute(attribute);
++
++        return !string.IsNullOrWhiteSpace(raw)
++               && uint.TryParse(raw.Trim(), NumberStyles.None, CultureInfo.InvariantCulture, out uint bitmap)
++               && bitmap > 0
++            ? bitmap
++            : fallback;
++    }
++
+     /// <summary>
+     /// Reads a numeric <c>width</c>/<c>height</c> presentation attribute as a pixel length, falling back to
+     /// <paramref name="fallback"/> when the attribute is absent or non-numeric (percentages and other units
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # Submodule patches waiting to be applied
 
-**Three patches are waiting on a maintainer.** See the index below.
+**Four patches are waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -70,17 +70,45 @@ as outstanding work and cannot be applied to find out otherwise.
 
 ## Index
 
-All three come from
-[the test-suite retirement roadmap item](../docs/ROADMAP.md#retire-obsolete-test-suites-and-historical-test-artifacts),
-and all three apply cleanly to the pointers pinned as of this writing. Identify
-them by commit subject rather than by number — the numbering restarts against
-whatever this directory holds.
+The first three come from
+[the test-suite retirement roadmap item](../docs/ROADMAP.md#retire-obsolete-test-suites-and-historical-test-artifacts);
+`0004` is the submodule half of a WPT fix. All four apply cleanly to the pointers
+pinned as of this writing. Identify them by commit subject rather than by number —
+the numbering restarts against whatever this directory holds.
+
+Only `0004` is registered in `scripts/apply-pending-wpt-patches.sh`: it is the
+only one of the four that can move a rendered pixel, so it is the only one a WPT
+run needs applied on top of the pinned pointer.
 
 | # | submodule | subject |
 | --- | --- | --- |
 | `0001` | `Broiler.JS` | Retire the Repro scratch tests and the legacy solution |
 | `0002` | `Broiler.HTML` | Drop the deleted WPF adapter from the public surface |
 | `0003` | `Broiler.HTML` | Keep dashed and dotted strokes on the raster path |
+| `0004` | `Broiler.HTML` | Size a `<canvas>` as a replaced element, not from presentation width/height |
+
+### Size a `<canvas>` as a replaced element, not from presentation width/height — `Broiler.HTML`
+
+HTML §4.12.5 gives a `<canvas>` its bitmap dimensions from the `width`/`height`
+content attributes, defaulting to 300×150. Those are the element's **natural**
+size, and the Rendering section maps no presentation `width`/`height` for it —
+unlike `<img>` or `<table>`. `TranslateAttributes` projected them onto CSS
+`width`/`height` anyway, which made both axes independently *stated*, so
+`max-width` and `max-height` clamped each on its own instead of keeping the
+natural ratio. Left alone entirely, a `<canvas>` laid out as a non-replaced
+inline — the one box type those two properties do not apply to at all.
+
+`CorrectCanvasBoxes` records the attributes as `CssBox.IntrinsicReplacedSize` (a
+main-repo property) and makes the box atomic inline-level, so the layout engine
+sizes it through the CSS2.1 §10.4 replaced-element rules that landed in
+`Broiler.Layout.Engine.ReplacedBoxSizing`. Only the UA default `display` is
+replaced; an author `display` is kept. Fallback content between the tags is
+hidden, as in any UA that supports canvas.
+
+Listed for the WPT run: without it WPT `css-sizing/replaced-max-size-saturation`
+(issue #1624 problem 12) stays at 8.3 %, and every `<canvas>` on every page keeps
+laying out with no size at all. See
+[WPT rendering gaps, #1624](../docs/wpt-rendering-gaps.md#the-next-run-issue-1624-2026-08-12).
 
 ### Retire the Repro scratch tests and the legacy solution — `Broiler.JS`
 

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -103,7 +103,18 @@ set -euo pipefail
 #   * "Drop the deleted WPF adapter from the public surface" (Broiler.HTML) —
 #     documentation and three InternalsVisibleTo grants to an assembly that is
 #     never built. Nothing it removes can move a pixel.
+#
+# The canvas patch (Broiler.HTML, "parse: size a <canvas> as a replaced element,
+# not from presentation width/height") is listed because it is the half of a
+# two-repo fix that decides an element's *box type*. Without it every <canvas>
+# lays out as a non-replaced inline — the one box type max-width/max-height do
+# not apply to at all — and the main-repo half it feeds (CSS2.1 §10.4 in
+# ReplacedBoxSizing, reached through CssBox.IntrinsicReplacedSize) never runs, so
+# WPT css-sizing/replaced-max-size-saturation stays at its 8.3 %. The §10.4 table
+# itself is unit-tested in the main repo (ReplacedBoxSizingTests); only the pixel
+# suite can say a real <canvas> reaches it.
 PENDING_PATCHES=(
+  "Broiler.HTML|patches/0004-html-canvas-replaced-element.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary

This PR fixes four defects in replaced element sizing (particularly `<canvas>` and `<img>` with min/max constraints) and implements CSS Overflow 3 viewport overflow propagation for the `<body>` element. These fixes resolve WPT test failures in `css-sizing` and `css-overflow` suites.

## Key Changes

**Replaced Element Sizing (CSS2.1 §10.4/§10.7)**

- **New `ReplacedBoxSizing` class** (`Engine/ReplacedBoxSizing.cs`): Centralizes the constraint-violation table for replaced elements with intrinsic ratios. When both width and height are auto and both max constraints are violated, the table compares how hard each bound bites (`max-width/w` vs `max-height/h`) and keeps the shape, rather than clamping each axis independently. This fixes `css-sizing/replaced-max-size-saturation` where an 8000×8000 canvas under `max-width: 120px; max-height: 100px` now correctly renders as 100×100 instead of 120×100.

- **`max-height` on `inline-block`** (`Engine/CssBox.Sizing.cs`): `FlowInlineBlock` had no `max-height` arm. Added `ResolveBlockSizeBounds()` to resolve min/max-height constraints, including percentage resolution against the containing block (walking past anonymous boxes to find a definite basis per §10.7).

- **`<canvas>` as a replaced element** (`patches/0004-html-canvas-replaced-element.patch`): HTML §4.12.5 makes canvas `width`/`height` content attributes the bitmap dimensions (natural size), not CSS properties. `CorrectCanvasBoxes` now records them as `IntrinsicReplacedSize` and makes the box atomic inline-level, so layout applies replaced sizing rules. Only the UA default `display` is replaced; author `display` values are preserved. Fallback content is hidden.

- **Blockified inline split tracking** (`patches/0004-html-canvas-replaced-element.patch`): Added `IsBlockifiedInlineSplit` flag to `CssBox` to mark boxes created when breaking an inline around a block-level child (CSS2.1 §9.2.1.1). These boxes must not act as containing blocks for percentage resolution, fixing `css-sizing/block-image-percentage-max-height-inside-inline` where a `display: block` `<img>` inside a `<span>` now correctly resolves `max-height: 100%` against the outer `<div>` rather than an indefinite anonymous block.

- **Percentage basis lookup** (`Engine/CssBox.ContainingBlock.cs`): New `TryGetPercentageBlockSizeBasis()` method walks past anonymous boxes to find the nearest real element with a definite height, fixing percentage resolution in anonymous blocks created by inline splitting.

**Viewport Overflow Propagation (CSS Overflow 3 §3.3)**

- **`ApplyViewportOverflowPropagation()` method** (`Engine/CssBox.Layout.cs`): When the root element's `overflow` is `visible`, a non-`visible` `overflow` on the first `<body>` element (if it generates a box) is applied to the viewport instead of the body's own box. The body's used value becomes `visible`. This fixes `css-overflow/overflow-body-propagation-009` where `body { overflow: hidden }` now clips the viewport rather than the body box itself.

**Test Coverage**

- New `ReplacedBoxSizingTests` class with 13 test cases covering the constraint-violation table, ratio preservation, and min/max interactions.
- New `ReplacedImageSizingTests` additions (6 cases) for percentage max-height resolution and anonymous block handling.
- New `ViewportOverflowPropagationTests` class with 8 test cases covering propagation rules, disqualifications, and edge cases.

**Documentation**

- Updated `docs/wpt-rendering-gaps.md` with issue #1624 section documenting the three defects (min/max pass

https://claude.ai/code/session_01JHgRgAUtWB14ZWuPrN4f4E