### PR TITLE
Implement object-fit and object-position for replaced elements

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/CssPositionValueTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/CssPositionValueTests.cs
@@ -1,0 +1,139 @@
+using System.Drawing;
+using Broiler.Layout.IR;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// CSS Values 4 §6.9 <c>&lt;position&gt;</c>. Paint read the components positionally — first
+/// horizontal, second vertical — which is only the one- and two-component forms; the three- and
+/// four-component edge-offset forms were dropped on the floor, silently, resolving to the origin.
+/// </summary>
+/// <remarks>
+/// Every <c>css-images/object-fit-*</c> reference states four of its seven positions in that syntax
+/// (<c>top 25% left 25%</c>, <c>bottom 1px right 2px</c>, <c>top 3px center</c>,
+/// <c>center right 25%</c>), so the reference side of those 200-odd reftests was wrong before the
+/// test side had a chance to be.
+/// </remarks>
+public sealed class CssPositionValueTests
+{
+    /// <summary>A 100×100 area holding a 20×40 object: 80 of free width and 60 of free height.</summary>
+    private static PointF Resolve(string position) =>
+        CssPositionValue.Resolve(position, new SizeF(100, 100), new SizeF(20, 40), emSize: 16);
+
+    // ─────────────────────────── one and two components ───────────────────────────
+
+    [Theory]
+    [InlineData("left", 0, 30)]
+    [InlineData("right", 80, 30)]
+    [InlineData("top", 40, 0)]
+    [InlineData("bottom", 40, 60)]
+    [InlineData("center", 40, 30)]
+    [InlineData("25%", 20, 30)]
+    public void A_Single_Component_Centres_The_Other_Axis(string position, float x, float y) =>
+        Assert.Equal(new PointF(x, y), Resolve(position));
+
+    /// <summary>A keyword pair may be written either way round; a length pair may not.</summary>
+    [Theory]
+    [InlineData("left top", 0, 0)]
+    [InlineData("top left", 0, 0)]
+    [InlineData("top right", 80, 0)]
+    [InlineData("bottom left", 0, 60)]
+    [InlineData("center right", 80, 30)]
+    [InlineData("right center", 80, 30)]
+    [InlineData("25% 50%", 20, 30)]
+    [InlineData("10px 20px", 10, 20)]
+    public void Two_Components_Are_Horizontal_Then_Vertical(string position, float x, float y) =>
+        Assert.Equal(new PointF(x, y), Resolve(position));
+
+    /// <summary>
+    /// A percentage is a fraction of the free space, not of the area — so <c>100%</c> puts the
+    /// object's far edge on the area's, rather than a whole area-width past it.
+    /// </summary>
+    [Theory]
+    [InlineData("0% 0%", 0, 0)]
+    [InlineData("50% 50%", 40, 30)]
+    [InlineData("100% 100%", 80, 60)]
+    public void A_Percentage_Resolves_Against_The_Free_Space(string position, float x, float y) =>
+        Assert.Equal(new PointF(x, y), Resolve(position));
+
+    // ───────────────────────── three and four components ─────────────────────────
+
+    /// <summary>
+    /// The edge-offset form names the edge each offset is measured from, so <c>right 25%</c> is 25%
+    /// of the free space in from the right — 60 here, not 20.
+    /// </summary>
+    [Theory]
+    [InlineData("top 25% left 25%", 20, 15)]
+    [InlineData("left 25% top 25%", 20, 15)]
+    [InlineData("bottom 1px right 2px", 78, 59)]
+    [InlineData("top 3px center", 40, 3)]
+    [InlineData("center right 25%", 60, 30)]
+    [InlineData("right 25% center", 60, 30)]
+    [InlineData("bottom 10px left 10px", 10, 50)]
+    public void An_Edge_Keyword_Says_Which_Side_Its_Offset_Is_Measured_From(
+        string position, float x, float y) =>
+        Assert.Equal(new PointF(x, y), Resolve(position));
+
+    /// <summary>
+    /// Component count is the spec's own disambiguation, and the reason it cannot be skipped:
+    /// <c>right 25%</c> is the two-component form (x flush right, y a quarter down) while
+    /// <c>center right 25%</c> is the edge-offset one (a quarter of the free width in from the
+    /// right). The same two tokens, read two ways.
+    /// </summary>
+    [Fact]
+    public void Two_Components_Are_Positional_Where_Three_Are_Edge_Offsets()
+    {
+        Assert.Equal(new PointF(80, 15), Resolve("right 25%"));
+        Assert.Equal(new PointF(60, 30), Resolve("center right 25%"));
+    }
+
+    /// <summary>An edge with no offset of its own is that edge flush.</summary>
+    [Theory]
+    [InlineData("right top 10px", 80, 10)]
+    [InlineData("left 10px bottom", 10, 60)]
+    public void An_Edge_Without_An_Offset_Is_Flush(string position, float x, float y) =>
+        Assert.Equal(new PointF(x, y), Resolve(position));
+
+    // ───────────────────────────────── edge cases ─────────────────────────────────
+
+    /// <summary>
+    /// An object wider than its area has negative free space, and an offset from the far edge
+    /// subtracts from that: 20px in from the right of a 100px area holding a 120px object is −40.
+    /// </summary>
+    [Fact]
+    public void An_Offset_May_Leave_The_Area() =>
+        Assert.Equal(new PointF(-40, 60), CssPositionValue.Resolve(
+            "bottom right 20px", new SizeF(100, 100), new SizeF(120, 40), emSize: 16));
+
+    /// <summary>An object larger than its area has negative free space, and centring halves it.</summary>
+    [Fact]
+    public void An_Object_Larger_Than_Its_Area_Centres_Negatively() =>
+        Assert.Equal(new PointF(-25, -25), CssPositionValue.Resolve(
+            "center", new SizeF(100, 100), new SizeF(150, 150), emSize: 16));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void An_Empty_Declaration_Resolves_To_The_Origin(string? position) =>
+        Assert.Equal(PointF.Empty, CssPositionValue.Resolve(
+            position, new SizeF(100, 100), new SizeF(20, 40), emSize: 16));
+
+    /// <summary>An offset in font-relative units resolves against the element's font size.</summary>
+    [Fact]
+    public void An_Em_Offset_Resolves_Against_The_Font_Size() =>
+        Assert.Equal(new PointF(32, 30), CssPositionValue.Resolve(
+            "2em center", new SizeF(100, 100), new SizeF(20, 40), emSize: 16));
+
+    /// <summary>
+    /// A <c>calc()</c> is one component however much whitespace it contains. Splitting on
+    /// whitespace alone made <c>calc(50% - 10px) center</c> four components, and four components
+    /// are read as the edge-offset form — a different grammar, and an unrelated answer.
+    /// </summary>
+    [Theory]
+    [InlineData("calc(50% - 10px) center", 30, 30)]
+    [InlineData("calc(10px + 10px) calc(100% - 20px)", 20, 40)]
+    public void A_Calc_Is_One_Component(string position, float x, float y) =>
+        Assert.Equal(new PointF(x, y), Resolve(position));
+}

--- a/Broiler.Layout/Broiler.Layout.Tests/ObjectFitPlacementTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/ObjectFitPlacementTests.cs
@@ -1,0 +1,222 @@
+using System.Drawing;
+using Broiler.Layout.IR;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// CSS Images 3 §5.5 <c>object-fit</c> and §5.6 <c>object-position</c>: nothing read either
+/// property, so every replaced element stretched to its content box — <c>fill</c> behaviour under
+/// whatever the author wrote. <c>object-fit-contain-svg-001i</c>, <c>-fill-svg-001i</c> and
+/// <c>-none-svg-001i</c> differ only in that one declaration and rendered to byte-identical PNGs.
+/// </summary>
+/// <remarks>
+/// The cases below are the ones the 42 <c>css-images/object-fit-*i</c> tests turn on: the four fit
+/// keywords against a box both wider and narrower than the content's ratio, <c>scale-down</c>'s
+/// choice between two of them, content that carries a ratio but no intrinsic size (an SVG with only
+/// a <c>viewBox</c> — which reports the 300×150 default object size and must not be sized by it),
+/// and the clip that an object overflowing its content box needs.
+/// </remarks>
+public sealed class ObjectFitPlacementTests
+{
+    /// <summary>A 16×8 content box's worth of image — the WPT tests' <c>colors-16x8.svg</c>.</summary>
+    private static readonly SizeF Wide = new(16, 8);
+
+    private static ObjectFitPlacement.Placement Resolve(
+        RectangleF contentBox, SizeF intrinsic, string fit, string position = "50% 50%", float ratio = 0)
+        => ObjectFitPlacement.Resolve(contentBox, intrinsic, ratio, fit, position, emSize: 16);
+
+    // ───────────────────────────── the concrete object size ─────────────────────────────
+
+    /// <summary><c>fill</c> is the initial value and stretches to the box, which is what every
+    /// replaced element did before any of this was read.</summary>
+    [Theory]
+    [InlineData("fill")]
+    [InlineData("")]
+    [InlineData("not-a-keyword")]
+    public void Fill_Stretches_To_The_Content_Box(string fit)
+    {
+        var placement = Resolve(new RectangleF(10, 20, 48, 32), Wide, fit);
+
+        Assert.Equal(new RectangleF(10, 20, 48, 32), placement.Dest);
+        Assert.False(placement.NeedsClip);
+    }
+
+    /// <summary>
+    /// <c>contain</c> is the largest rectangle of the content's ratio that fits: a 2∶1 image in a
+    /// 48×32 box is 48×24, and in a 32×48 box is 32×16.
+    /// </summary>
+    [Theory]
+    [InlineData(48, 32, 48, 24)]
+    [InlineData(32, 48, 32, 16)]
+    [InlineData(8, 8, 8, 4)]
+    public void Contain_Fits_Inside_The_Content_Box(float boxW, float boxH, float fitW, float fitH)
+    {
+        var placement = Resolve(new RectangleF(0, 0, boxW, boxH), Wide, "contain", "left top");
+
+        Assert.Equal(new RectangleF(0, 0, fitW, fitH), placement.Dest);
+        Assert.False(placement.NeedsClip);
+    }
+
+    /// <summary>
+    /// <c>cover</c> is the smallest rectangle of the content's ratio that covers the box, so it
+    /// always overflows on one axis unless the ratios match exactly.
+    /// </summary>
+    [Theory]
+    [InlineData(48, 32, 64, 32)]
+    [InlineData(32, 48, 96, 48)]
+    public void Cover_Covers_The_Content_Box_And_Is_Clipped(float boxW, float boxH, float fitW, float fitH)
+    {
+        var placement = Resolve(new RectangleF(0, 0, boxW, boxH), Wide, "cover", "left top");
+
+        Assert.Equal(new RectangleF(0, 0, fitW, fitH), placement.Dest);
+        Assert.True(placement.NeedsClip);
+    }
+
+    /// <summary>A box already at the content's ratio needs no clip under <c>cover</c>.</summary>
+    [Fact]
+    public void Cover_At_The_Contents_Own_Ratio_Needs_No_Clip()
+    {
+        var placement = Resolve(new RectangleF(0, 0, 32, 16), Wide, "cover");
+
+        Assert.Equal(new RectangleF(0, 0, 32, 16), placement.Dest);
+        Assert.False(placement.NeedsClip);
+    }
+
+    /// <summary><c>none</c> is the intrinsic size, whether that overflows the box or not.</summary>
+    [Theory]
+    [InlineData(48, 32, false)]
+    [InlineData(8, 8, true)]
+    public void None_Uses_The_Intrinsic_Size(float boxW, float boxH, bool clipped)
+    {
+        var placement = Resolve(new RectangleF(0, 0, boxW, boxH), Wide, "none", "left top");
+
+        Assert.Equal(new SizeF(16, 8), placement.Dest.Size);
+        Assert.Equal(clipped, placement.NeedsClip);
+    }
+
+    /// <summary>
+    /// <c>scale-down</c> is whichever of <c>none</c> and <c>contain</c> is smaller: the intrinsic
+    /// size while it fits, and the contained size once it does not.
+    /// </summary>
+    [Theory]
+    [InlineData(48, 32, 16, 8)]
+    [InlineData(8, 8, 8, 4)]
+    public void ScaleDown_Takes_The_Smaller_Of_None_And_Contain(float boxW, float boxH, float fitW, float fitH)
+    {
+        var placement = Resolve(new RectangleF(0, 0, boxW, boxH), Wide, "scale-down", "left top");
+
+        Assert.Equal(new SizeF(fitW, fitH), placement.Dest.Size);
+        Assert.False(placement.NeedsClip);
+    }
+
+    // ─────────────────────── content with a ratio but no intrinsic size ───────────────────────
+
+    /// <summary>
+    /// An SVG with a <c>viewBox</c> and no <c>width</c>/<c>height</c> has a ratio and no size, and
+    /// the size reported for it is the 300×150 default object size — whose ratio is 2∶1 and has
+    /// nothing to do with the content's. Sizing <c>contain</c> by it put a 1∶2 image in a 48×24 box
+    /// instead of a 16×32 one, which is what regressed <c>object-fit-cover-svg-004i</c> when the
+    /// ratio was first taken from the reported size.
+    /// </summary>
+    [Fact]
+    public void A_Ratio_Without_An_Intrinsic_Size_Sizes_By_The_Ratio()
+    {
+        var placement = Resolve(
+            new RectangleF(0, 0, 48, 32), SizeF.Empty, "contain", "left top", ratio: 0.5f);
+
+        Assert.Equal(new RectangleF(0, 0, 16, 32), placement.Dest);
+    }
+
+    /// <summary>
+    /// With no intrinsic size, <c>none</c> falls through the default sizing algorithm (§5.1) onto
+    /// the default object size constrained by the ratio — the same answer as <c>contain</c>.
+    /// </summary>
+    [Theory]
+    [InlineData("none")]
+    [InlineData("scale-down")]
+    [InlineData("contain")]
+    public void Without_An_Intrinsic_Size_None_And_ScaleDown_Are_Contain(string fit)
+    {
+        var placement = Resolve(
+            new RectangleF(0, 0, 48, 32), SizeF.Empty, fit, "left top", ratio: 0.5f);
+
+        Assert.Equal(new RectangleF(0, 0, 16, 32), placement.Dest);
+    }
+
+    /// <summary>
+    /// Content with neither a size nor a ratio has nothing to fit against, so every keyword is
+    /// <c>fill</c> — the box itself, drawn exactly as it was before this property was read.
+    /// </summary>
+    [Theory]
+    [InlineData("contain")]
+    [InlineData("cover")]
+    [InlineData("none")]
+    public void Without_A_Size_Or_A_Ratio_Every_Keyword_Fills(string fit)
+    {
+        var placement = Resolve(new RectangleF(5, 5, 48, 32), SizeF.Empty, fit);
+
+        Assert.Equal(new RectangleF(5, 5, 48, 32), placement.Dest);
+        Assert.False(placement.NeedsClip);
+    }
+
+    // ───────────────────────────────── object-position ─────────────────────────────────
+
+    /// <summary>
+    /// <c>object-position</c> places the concrete object in the free space the fit left over. A 2∶1
+    /// image contained in a 48×32 box is 48×24, so the 8px of free height is all there is to move
+    /// through — and the width has none, which is what makes the <c>right</c> cases land at 0.
+    /// </summary>
+    [Theory]
+    [InlineData("top right", 0, 0)]
+    [InlineData("bottom left", 0, 8)]
+    [InlineData("50% 50%", 0, 4)]
+    [InlineData("top 25% left 25%", 0, 2)]
+    [InlineData("top 3px left 50%", 0, 3)]
+    [InlineData("top 50% right 25%", 0, 4)]
+    public void Object_Position_Places_The_Object_In_The_Free_Space(string position, float x, float y)
+    {
+        var placement = Resolve(new RectangleF(100, 200, 48, 32), Wide, "contain", position);
+
+        Assert.Equal(new PointF(100 + x, 200 + y), placement.Dest.Location);
+    }
+
+    /// <summary>
+    /// An offset from the far edge can push the object out of its box when the free space on that
+    /// axis is smaller than the offset — <c>bottom 1px right 2px</c> against zero free width is 2px
+    /// off the left edge, and needs the clip that says so.
+    /// </summary>
+    [Fact]
+    public void An_Offset_Past_The_Free_Space_Overflows_And_Clips()
+    {
+        var placement = Resolve(new RectangleF(0, 0, 48, 32), Wide, "contain", "bottom 1px right 2px");
+
+        Assert.Equal(new RectangleF(-2, 7, 48, 24), placement.Dest);
+        Assert.True(placement.NeedsClip);
+    }
+
+    /// <summary>
+    /// <c>fill</c> leaves no free space, so a percentage position cannot move the object — but an
+    /// absolute offset from an edge still does, and the fast path for "nothing declared" must not
+    /// swallow it.
+    /// </summary>
+    [Fact]
+    public void Fill_Still_Honours_An_Absolute_Object_Position()
+    {
+        var placement = Resolve(new RectangleF(0, 0, 48, 32), Wide, "fill", "bottom 1px right 2px");
+
+        Assert.Equal(new RectangleF(-2, -1, 48, 32), placement.Dest);
+        Assert.True(placement.NeedsClip);
+    }
+
+    /// <summary>A degenerate content box has nothing to place into and is returned unchanged.</summary>
+    [Theory]
+    [InlineData(0, 32)]
+    [InlineData(48, 0)]
+    public void A_Degenerate_Content_Box_Paints_Nothing(float boxW, float boxH)
+    {
+        var placement = Resolve(new RectangleF(0, 0, boxW, boxH), Wide, "contain");
+
+        Assert.True(placement.IsEmpty);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -690,6 +690,19 @@ internal abstract partial class CssBoxProperties
     public SizeF? IntrinsicReplacedSize { get; set; }
 
     /// <summary>
+    /// CSS Images 3 §5.5 <c>object-fit</c> — how a replaced element's content is scaled into its
+    /// content box. Resolved at paint time by <see cref="IR.ObjectFitPlacement"/>; it moves and
+    /// resizes the drawn content only, never the box, so layout does not read it.
+    /// </summary>
+    public string ObjectFit { get; set; } = "fill";
+
+    /// <summary>
+    /// CSS Images 3 §5.6 <c>object-position</c> — where that content sits inside the content box
+    /// once <see cref="ObjectFit"/> has sized it.
+    /// </summary>
+    public string ObjectPosition { get; set; } = "50% 50%";
+
+    /// <summary>
     /// CSS2.1 §9.2.1.1: set on an <b>inline</b> element's box that the block-inside-inline
     /// correction has blockified in order to break it around a block-level child. The element is
     /// still inline as far as CSS is concerned — the block-level <c>display</c> is an artefact of
@@ -2765,6 +2778,8 @@ internal abstract partial class CssBoxProperties
         MinHeight = p.MinHeight;
         MaxHeight = p.MaxHeight;
         IntrinsicReplacedSize = p.IntrinsicReplacedSize;
+        ObjectFit = p.ObjectFit;
+        ObjectPosition = p.ObjectPosition;
         _wordSpacing = p._wordSpacing;
         Opacity = p.Opacity;
         BoxShadow = p.BoxShadow;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -87,6 +87,8 @@ internal static partial class CssUtils
             "background-size" => cssBox.BackgroundSize,
             "background-gradient" => cssBox.BackgroundGradient,
             "background-gradient-angle" => cssBox.BackgroundGradientAngle,
+            "object-fit" => cssBox.ObjectFit,
+            "object-position" => cssBox.ObjectPosition,
             "content" => cssBox.Content,
             "color" => cssBox.Color,
             "display" => cssBox.Display,
@@ -655,6 +657,12 @@ internal static partial class CssUtils
                 break;
             case "background-position":
                 cssBox.BackgroundPosition = value;
+                break;
+            case "object-fit":
+                cssBox.ObjectFit = value;
+                break;
+            case "object-position":
+                cssBox.ObjectPosition = value;
                 break;
             case "background-repeat":
                 cssBox.BackgroundRepeat = value;

--- a/Broiler.Layout/Broiler.Layout/IR/ComputedStyle.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/ComputedStyle.cs
@@ -131,6 +131,14 @@ public sealed class ComputedStyle
     /// <summary>The resolved <c>src</c> attribute for image elements, or null if not applicable.</summary>
     public string? ImageSource { get; init; }
 
+    // --- Replaced content placement ---
+
+    /// <summary>CSS Images 3 §5.5 <c>object-fit</c>. See <see cref="ObjectFitPlacement"/>.</summary>
+    public string ObjectFit { get; init; } = "fill";
+
+    /// <summary>CSS Images 3 §5.6 <c>object-position</c>. See <see cref="ObjectFitPlacement"/>.</summary>
+    public string ObjectPosition { get; init; } = "50% 50%";
+
     // --- Opacity ---
 
     public string Opacity { get; init; } = "1";

--- a/Broiler.Layout/Broiler.Layout/IR/ComputedStyleBuilder.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/ComputedStyleBuilder.cs
@@ -151,6 +151,10 @@ internal static class ComputedStyleBuilder
             // Phase 2: Image source
             ImageSource = box.ImageSource,
 
+            // Replaced content placement
+            ObjectFit = box.ObjectFit,
+            ObjectPosition = box.ObjectPosition,
+
             // Opacity
             Opacity = box.Opacity,
 

--- a/Broiler.Layout/Broiler.Layout/IR/CssPositionValue.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/CssPositionValue.cs
@@ -1,0 +1,243 @@
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using Broiler.CSS;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// CSS Values 4 §6.9 <c>&lt;position&gt;</c>: where an object of a known size sits inside an area of
+/// a known size. The grammar is shared by <c>background-position</c> and <c>object-position</c>, and
+/// this resolves both.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The whole grammar is four forms, and the last one is what engines commonly skip:
+/// </para>
+/// <code>
+///   [ left | center | right | top | bottom | &lt;length-percentage&gt; ]
+/// | [ left | center | right ] &amp;&amp; [ top | center | bottom ]
+/// | [ left | center | right | &lt;length-percentage&gt; ] [ top | center | bottom | &lt;length-percentage&gt; ]
+/// | [ center | [ left | right ] &lt;length-percentage&gt;? ] &amp;&amp;
+///   [ center | [ top | bottom ] &lt;length-percentage&gt;? ]
+/// </code>
+/// <para>
+/// The last form names the edge an offset is measured <em>from</em>, so <c>bottom 1px right 2px</c>
+/// is 1px up from the bottom edge and 2px left of the right one — an offset the two-component form
+/// has no way to express, and one that every <c>css-images/object-fit-*</c> reference uses.
+/// Component count is what tells the two readings apart, and the spec's own disambiguation:
+/// <c>right 25%</c> is two components, so it is <c>x: right, y: 25%</c>, while
+/// <c>center right 25%</c> is three and so is 25% of the free space in from the right edge.
+/// </para>
+/// <para>
+/// A percentage resolves against the <em>free space</em> (area − object), not the area, so
+/// <c>100%</c> aligns the object's far edge with the area's rather than pushing it a full
+/// area-width out. That is CSS 2.1 §14.2.1's rule for <c>background-position</c>, and CSS Images 3
+/// §5.6 restates it for <c>object-position</c>.
+/// </para>
+/// </remarks>
+public static class CssPositionValue
+{
+    /// <summary>
+    /// Resolves <paramref name="position"/> to the object's offset from the area's top-left corner.
+    /// </summary>
+    /// <param name="position">The declared <c>&lt;position&gt;</c>, e.g. <c>top 25% left 25%</c>.</param>
+    /// <param name="areaSize">The positioning area — a content box, or a background positioning area.</param>
+    /// <param name="objectSize">The object being placed — a concrete object size, or a tile.</param>
+    /// <param name="emSize">Font size in px, for an offset stated in font-relative units.</param>
+    /// <returns>
+    /// The offset in px, which may be negative or exceed the free space when the declaration says so.
+    /// An empty declaration resolves to the origin, which is what dropping it means.
+    /// </returns>
+    public static PointF Resolve(string? position, SizeF areaSize, SizeF objectSize, double emSize)
+    {
+        if (string.IsNullOrWhiteSpace(position))
+            return PointF.Empty;
+
+        var tokens = Tokenize(position);
+        if (tokens.Count == 0)
+            return PointF.Empty;
+
+        float freeX = areaSize.Width - objectSize.Width;
+        float freeY = areaSize.Height - objectSize.Height;
+
+        return tokens.Count >= 3
+            ? ResolveEdgeOffsets(tokens, freeX, freeY, emSize)
+            : ResolveShort(tokens, freeX, freeY, emSize);
+    }
+
+    /// <summary>
+    /// Splits the declaration on whitespace, but not inside parentheses — the component count is
+    /// what tells the two- and three-component forms apart, so a <c>calc(50% - 10px)</c> counted as
+    /// three tokens would be read as an edge-offset form and resolve to something unrelated.
+    /// </summary>
+    private static List<string> Tokenize(string position)
+    {
+        var tokens = new List<string>(4);
+        int depth = 0, start = -1;
+
+        for (int i = 0; i < position.Length; i++)
+        {
+            char c = position[i];
+
+            if (c == '(')
+                depth++;
+            else if (c == ')' && depth > 0)
+                depth--;
+
+            if (depth == 0 && char.IsWhiteSpace(c))
+            {
+                if (start >= 0)
+                {
+                    tokens.Add(position[start..i]);
+                    start = -1;
+                }
+
+                continue;
+            }
+
+            if (start < 0)
+                start = i;
+        }
+
+        if (start >= 0)
+            tokens.Add(position[start..]);
+
+        return tokens;
+    }
+
+    /// <summary>
+    /// The one- and two-component forms: each component is a keyword or a length, the horizontal one
+    /// first unless a pair of keywords states otherwise (<c>top right</c> is as valid as
+    /// <c>right top</c>). An omitted component is <c>center</c>.
+    /// </summary>
+    private static PointF ResolveShort(List<string> tokens, float freeX, float freeY, double emSize)
+    {
+        string? x, y;
+
+        if (tokens.Count == 1)
+        {
+            // A lone vertical keyword sets the vertical axis; everything else — a horizontal keyword,
+            // `center`, or a length — sets the horizontal one. The other axis centres.
+            (x, y) = IsVerticalKeyword(tokens[0]) ? (null, tokens[0]) : (tokens[0], (string?)null);
+        }
+        else if (IsVerticalKeyword(tokens[0]) || IsHorizontalKeyword(tokens[1]))
+        {
+            // A keyword pair may be written either way round. A length is only ever positional, so a
+            // swap is considered only when a keyword puts the axes beyond doubt.
+            (x, y) = (tokens[1], tokens[0]);
+        }
+        else
+        {
+            (x, y) = (tokens[0], tokens[1]);
+        }
+
+        return new PointF(
+            ResolveComponent(x, fromStartEdge: true, freeX, emSize),
+            ResolveComponent(y, fromStartEdge: true, freeY, emSize));
+    }
+
+    /// <summary>
+    /// The three- and four-component form: a sequence of groups, each an edge keyword with an
+    /// optional offset, or a bare <c>center</c>. Each edge keyword fixes its own axis, so an axis
+    /// left without one centres — which is exactly what a <c>center</c> in the other group asks for,
+    /// and is why <c>center right 25%</c> and <c>right 25% center</c> mean the same thing.
+    /// </summary>
+    private static PointF ResolveEdgeOffsets(List<string> tokens, float freeX, float freeY, double emSize)
+    {
+        string? xEdge = null, xOffset = null, yEdge = null, yOffset = null;
+
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            string token = tokens[i];
+            if (!IsEdgeKeyword(token))
+                continue;
+
+            // The offset is the next token when there is one and it is not itself a keyword:
+            // `left top` is two bare edges, `left 25% top 1px` two edge-and-offset groups.
+            string? offset = i + 1 < tokens.Count && !IsKeyword(tokens[i + 1]) ? tokens[++i] : null;
+
+            if (IsHorizontalKeyword(token))
+                (xEdge, xOffset) = (token, offset);
+            else
+                (yEdge, yOffset) = (token, offset);
+        }
+
+        return new PointF(
+            ResolveAxis(xEdge, xOffset, freeX, emSize),
+            ResolveAxis(yEdge, yOffset, freeY, emSize));
+    }
+
+    /// <summary>
+    /// One axis of the edge-offset form: no edge centres, and an edge without an offset is that edge
+    /// flush (<c>right</c> alone is <c>right 0</c>).
+    /// </summary>
+    private static float ResolveAxis(string? edge, string? offset, float freeSpace, double emSize)
+    {
+        if (edge == null)
+            return freeSpace / 2f;
+
+        return ResolveComponent(offset ?? "0", fromStartEdge: !IsFarEdge(edge), freeSpace, emSize);
+    }
+
+    /// <summary>
+    /// One component: a keyword, or an offset measured from <paramref name="fromStartEdge"/>'s side
+    /// of the free space. A null component centres, which is the initial value on both axes.
+    /// </summary>
+    private static float ResolveComponent(string? value, bool fromStartEdge, float freeSpace, double emSize)
+    {
+        if (string.IsNullOrEmpty(value))
+            return freeSpace / 2f;
+
+        if (value.Equals("left", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("top", StringComparison.OrdinalIgnoreCase))
+        {
+            return 0;
+        }
+
+        if (IsFarEdge(value))
+            return freeSpace;
+
+        if (value.Equals("center", StringComparison.OrdinalIgnoreCase))
+            return freeSpace / 2f;
+
+        // A percentage is a fraction of the free space; every other unit is an absolute offset. The
+        // length parser reads both, given the free space as its 100% basis.
+        double offset = CssLengthParser.ParseLength(value, freeSpace, emSize, defaultUnit: null);
+
+        // A unitless number is not a valid <length-percentage> and the parser answers 0 for it.
+        // Reading it as px is a tolerance the background-position code carried, kept here so
+        // consolidating the two readings changes only what it set out to change.
+        if (offset == 0
+            && !value.Equals("0", StringComparison.Ordinal)
+            && double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double raw))
+        {
+            offset = raw;
+        }
+
+        if (double.IsNaN(offset) || double.IsInfinity(offset))
+            return fromStartEdge ? 0 : freeSpace;
+
+        return fromStartEdge ? (float)offset : freeSpace - (float)offset;
+    }
+
+    /// <summary>The edges an offset is measured backwards from — <c>right</c> and <c>bottom</c>.</summary>
+    private static bool IsFarEdge(string value) =>
+        value.Equals("right", StringComparison.OrdinalIgnoreCase)
+        || value.Equals("bottom", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsHorizontalKeyword(string value) =>
+        value.Equals("left", StringComparison.OrdinalIgnoreCase)
+        || value.Equals("right", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsVerticalKeyword(string value) =>
+        value.Equals("top", StringComparison.OrdinalIgnoreCase)
+        || value.Equals("bottom", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>An edge keyword — the four that can carry an offset, excluding <c>center</c>.</summary>
+    private static bool IsEdgeKeyword(string value) =>
+        IsHorizontalKeyword(value) || IsVerticalKeyword(value);
+
+    private static bool IsKeyword(string value) =>
+        IsEdgeKeyword(value) || value.Equals("center", StringComparison.OrdinalIgnoreCase);
+}

--- a/Broiler.Layout/Broiler.Layout/IR/Fragment.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/Fragment.cs
@@ -66,6 +66,23 @@ public sealed class Fragment
     public RectangleF ImageSourceRect { get; init; }
 
     /// <summary>
+    /// Intrinsic size of <see cref="ImageHandle"/> in CSS px, or <see cref="SizeF.Empty"/> when the
+    /// content has none (or there is no content). Paint needs it to resolve <c>object-fit</c>, which
+    /// scales the content against its natural size rather than against the box — see
+    /// <see cref="ObjectFitPlacement"/>. It is not the used size: the box is already laid out at
+    /// that, and the two differ by exactly the ratio <c>object-fit</c> exists to control.
+    /// </summary>
+    public SizeF ImageIntrinsicSize { get; init; }
+
+    /// <summary>
+    /// Intrinsic aspect ratio (width ÷ height) of <see cref="ImageHandle"/>, or 0 when it has none.
+    /// Separate from <see cref="ImageIntrinsicSize"/> because content can carry a ratio without a
+    /// size — an SVG with only a <c>viewBox</c> — and <c>object-fit: contain</c>/<c>cover</c> are
+    /// defined over the ratio, not the size.
+    /// </summary>
+    public float ImageIntrinsicRatio { get; init; }
+
+    /// <summary>
     /// SVG markup for replaced elements (e.g. <c>&lt;object data="file.svg"&gt;</c>)
     /// that should be rendered via <c>SvgRenderer</c> instead of as a raster image.
     /// </summary>

--- a/Broiler.Layout/Broiler.Layout/IR/FragmentTreeBuilder.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/FragmentTreeBuilder.cs
@@ -106,6 +106,8 @@ internal static class FragmentTreeBuilder
         // Phase 3: Capture replaced image handle (e.g. <img> elements)
         object? imgHandle = null;
         RectangleF imgSourceRect = RectangleF.Empty;
+        SizeF imgIntrinsicSize = SizeF.Empty;
+        float imgIntrinsicRatio = 0;
         string svgContent = null;
         if (box is CssBoxImage imgBox)
         {
@@ -113,6 +115,20 @@ internal static class FragmentTreeBuilder
             // CssBoxImage stores source rect on its internal CssRectImage word
             if (imgBox.Words.Count > 0 && imgBox.Words[0] is CssRectImage rectImage)
                 imgSourceRect = rectImage.ImageRectangle;
+
+            // The natural size and ratio `object-fit` scales against. Layout has already consumed
+            // them to size the box, but not in a form paint can recover — a box sized by the CSS
+            // alone keeps no trace of either — so they are carried onto the fragment. Content with
+            // a ratio and no size reports the default object size here, which is not intrinsic and
+            // must not be read as though it were.
+            if (imgHandle != null && box.LayoutEnvironment?.GetImageIntrinsics(imgHandle) is { } intrinsics)
+            {
+                if (intrinsics.HasIntrinsicSize)
+                    imgIntrinsicSize = new SizeF((float)intrinsics.Width, (float)intrinsics.Height);
+
+                if (intrinsics.HasIntrinsicRatio)
+                    imgIntrinsicRatio = (float)intrinsics.AspectRatio;
+            }
         }
 
         // Check for <object> elements referencing SVG content.  When the
@@ -202,6 +218,8 @@ internal static class FragmentTreeBuilder
             BackgroundImageHandle = bgImage,
             ImageHandle = imgHandle,
             ImageSourceRect = imgSourceRect,
+            ImageIntrinsicSize = imgIntrinsicSize,
+            ImageIntrinsicRatio = imgIntrinsicRatio,
             SvgContent = svgContent,
             EmbeddedDocumentHtml = embeddedHtml,
             EmbeddedDocumentBaseUrl = embeddedBaseUrl,

--- a/Broiler.Layout/Broiler.Layout/IR/ObjectFitPlacement.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/ObjectFitPlacement.cs
@@ -1,0 +1,156 @@
+using System.Drawing;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// CSS Images 3 §5.5 <c>object-fit</c> and §5.6 <c>object-position</c>: the rectangle a replaced
+/// element's content is drawn into, given its content box and its intrinsic size.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two steps, in the order the spec states them. First <c>object-fit</c> picks the
+/// <em>concrete object size</em> from the intrinsic size and the content box — stretch to it
+/// (<c>fill</c>), scale to fit inside it (<c>contain</c>), scale to cover it (<c>cover</c>), leave it
+/// alone (<c>none</c>), or the smaller of the last two (<c>scale-down</c>). Then
+/// <c>object-position</c> places an object of that size inside the content box, by the same
+/// <c>&lt;position&gt;</c> grammar <c>background-position</c> uses — see <see cref="CssPositionValue"/>.
+/// </para>
+/// <para>
+/// The result can be larger than the content box (<c>cover</c> always is on one axis, and
+/// <c>none</c> is whenever the image is bigger than its box), in which case the overflow is clipped
+/// to the content box rather than cropped out of the source bitmap. Clipping is what the spec
+/// describes, and it is also the only reading that stays correct when the decoded bitmap is not the
+/// intrinsic size — an SVG rasterised at 2× for quality, say, whose bitmap is twice the size the
+/// crop would have been measured in. <see cref="Placement.NeedsClip"/> says when the caller has to
+/// emit one; the common case of an object that fits needs none, and paints exactly as it did before
+/// this property was read at all.
+/// </para>
+/// </remarks>
+public static class ObjectFitPlacement
+{
+    /// <summary>Where a replaced element's content paints, and whether it overflows its box.</summary>
+    /// <param name="Dest">The rectangle to draw the whole image into, in absolute coordinates.</param>
+    /// <param name="NeedsClip">
+    /// Whether <paramref name="Dest"/> leaves the content box, so the caller must clip to it.
+    /// </param>
+    public readonly record struct Placement(RectangleF Dest, bool NeedsClip)
+    {
+        /// <summary>Whether the placement paints nothing — a degenerate or fully clipped box.</summary>
+        public bool IsEmpty => Dest.Width <= 0 || Dest.Height <= 0;
+    }
+
+    /// <summary>
+    /// Resolves the placement of <paramref name="intrinsicSize"/> inside <paramref name="contentBox"/>.
+    /// </summary>
+    /// <param name="contentBox">The element's content box, in absolute coordinates.</param>
+    /// <param name="intrinsicSize">
+    /// The content's intrinsic size in CSS px, or <see cref="SizeF.Empty"/> when it has none — an SVG
+    /// with a <c>viewBox</c> and no <c>width</c>/<c>height</c> being the usual case.
+    /// </param>
+    /// <param name="intrinsicRatio">
+    /// The content's intrinsic aspect ratio (width ÷ height), or 0 when it has none. Reported apart
+    /// from the size because an image can carry a ratio without one, and because the two disagree
+    /// when it does.
+    /// </param>
+    /// <param name="objectFit">The computed <c>object-fit</c>; <c>fill</c> when not declared.</param>
+    /// <param name="objectPosition">The computed <c>object-position</c>; <c>50% 50%</c> when not declared.</param>
+    /// <param name="emSize">Font size in px, for an <c>object-position</c> offset in font-relative units.</param>
+    public static Placement Resolve(
+        RectangleF contentBox,
+        SizeF intrinsicSize,
+        float intrinsicRatio,
+        string? objectFit,
+        string? objectPosition,
+        double emSize)
+    {
+        if (contentBox.Width <= 0 || contentBox.Height <= 0)
+            return new Placement(contentBox, NeedsClip: false);
+
+        // Neither property declared is the overwhelmingly common case and the whole of the old
+        // behaviour, so it answers before anything is parsed. It is a fast path rather than the
+        // rule: `fill` still has to go through the general path once a position is stated, because
+        // an offset in absolute units moves the object even across zero free space.
+        if (IsInitial(objectFit, "fill") && IsInitial(objectPosition, "50% 50%"))
+            return new Placement(contentBox, NeedsClip: false);
+
+        var size = ConcreteObjectSize(contentBox.Size, intrinsicSize, intrinsicRatio, objectFit);
+
+        var offset = CssPositionValue.Resolve(
+            string.IsNullOrWhiteSpace(objectPosition) ? "50% 50%" : objectPosition,
+            contentBox.Size,
+            size,
+            emSize);
+
+        var dest = new RectangleF(contentBox.X + offset.X, contentBox.Y + offset.Y, size.Width, size.Height);
+
+        bool needsClip = dest.X < contentBox.X
+            || dest.Y < contentBox.Y
+            || dest.Right > contentBox.Right
+            || dest.Bottom > contentBox.Bottom;
+
+        return new Placement(dest, needsClip);
+    }
+
+    /// <summary>Whether a declaration is absent or spelled exactly as its initial value.</summary>
+    private static bool IsInitial(string? value, string initial) =>
+        string.IsNullOrWhiteSpace(value) || value.Trim().Equals(initial, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// CSS Images 3 §5.5: the concrete object size <c>object-fit</c> asks for. Returns the content
+    /// box's own size whenever the fit cannot be applied — an unrecognised keyword, or content with
+    /// neither an intrinsic size nor a ratio — which is <c>fill</c>, the initial value.
+    /// </summary>
+    private static SizeF ConcreteObjectSize(
+        SizeF contentBox, SizeF intrinsicSize, float intrinsicRatio, string? objectFit)
+    {
+        bool hasSize = intrinsicSize.Width > 0 && intrinsicSize.Height > 0;
+
+        // The ratio comes from the content when it states one and from its intrinsic size otherwise;
+        // the two agree except for content that has a ratio and no size, which is why it is reported
+        // separately at all.
+        float ratio = intrinsicRatio > 0
+            ? intrinsicRatio
+            : hasSize ? intrinsicSize.Width / intrinsicSize.Height : 0;
+
+        string fit = objectFit?.Trim() ?? string.Empty;
+
+        // `scale-down` is whichever of `none` and `contain` gives the smaller concrete size, which
+        // is `none` exactly when the content already fits — so it resolves to one of the other two
+        // here rather than repeating their arithmetic. With no intrinsic size the two coincide.
+        if (fit.Equals("scale-down", StringComparison.OrdinalIgnoreCase))
+        {
+            fit = hasSize
+                  && intrinsicSize.Width <= contentBox.Width
+                  && intrinsicSize.Height <= contentBox.Height
+                ? "none"
+                : "contain";
+        }
+
+        if (fit.Equals("none", StringComparison.OrdinalIgnoreCase))
+        {
+            // The default sizing algorithm (§5.1) with no specified size: the intrinsic size when
+            // there is one, otherwise the default object size — the content box — constrained by
+            // the ratio, which is the contain constraint below.
+            if (hasSize)
+                return intrinsicSize;
+
+            fit = "contain";
+        }
+
+        bool contain = fit.Equals("contain", StringComparison.OrdinalIgnoreCase);
+        bool cover = fit.Equals("cover", StringComparison.OrdinalIgnoreCase);
+
+        // Both constraints in §5.1 are stated over the ratio alone — the largest (contain) or the
+        // smallest (cover) rectangle of that ratio that fits within, or covers, the content box.
+        // Without a ratio there is nothing to preserve and the constraint rectangle is the answer.
+        if (ratio <= 0 || (!contain && !cover))
+            return contentBox;
+
+        float boxRatio = contentBox.Height > 0 ? contentBox.Width / contentBox.Height : 0;
+
+        // A content box wider than the ratio has to lose width to fit and gain it to cover.
+        return (boxRatio > ratio) == contain
+            ? new SizeF(contentBox.Height * ratio, contentBox.Height)
+            : new SizeF(contentBox.Width, contentBox.Width / ratio);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/ImageIntrinsics.cs
+++ b/Broiler.Layout/Broiler.Layout/ImageIntrinsics.cs
@@ -11,4 +11,21 @@ namespace Broiler.Layout;
 /// <param name="HasIntrinsicRatio">
 /// Whether the image carries an intrinsic aspect ratio usable for sizing.
 /// </param>
-public readonly record struct ImageIntrinsics(double Width, double Height, bool HasIntrinsicRatio);
+/// <param name="AspectRatio">
+/// The intrinsic aspect ratio (width ÷ height) when <paramref name="HasIntrinsicRatio"/> says there
+/// is one, or 0. It is <em>not</em> always <paramref name="Width"/> ÷ <paramref name="Height"/>: an
+/// SVG with a <c>viewBox</c> and no <c>width</c>/<c>height</c> has a ratio but no intrinsic size, and
+/// the size reported for it is the 300×150 default object size, which carries a different ratio.
+/// </param>
+/// <param name="HasIntrinsicSize">
+/// Whether <paramref name="Width"/> and <paramref name="Height"/> are the content's own dimensions
+/// rather than the default object size standing in for them. Replaced <em>sizing</em> uses the
+/// default either way (CSS Images 3 §5.1, matching Chromium), so it does not need to tell them
+/// apart; <c>object-fit</c> does — <c>none</c> means "the intrinsic size" and there is not one.
+/// </param>
+public readonly record struct ImageIntrinsics(
+    double Width,
+    double Height,
+    bool HasIntrinsicRatio,
+    double AspectRatio = 0,
+    bool HasIntrinsicSize = true);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ are versioned in lockstep during the preview.
 
 ### Added
 
+- `Broiler.Layout` — CSS Images 3 §5.5 `object-fit` and §5.6 `object-position`,
+  which nothing read: every replaced element was stretched to its content box, so
+  `object-fit-contain-svg-001i`, `-fill-svg-001i` and `-none-svg-001i` rendered to
+  byte-identical PNGs. `IR.ObjectFitPlacement` resolves the concrete object size and
+  where it sits, clipping to the content box when it overflows, and
+  `IR.CssPositionValue` reads the whole `<position>` grammar — including the three-
+  and four-component edge-offset forms (`top 25% left 25%`), which paint dropped
+  silently and which `background-position` and gradient layers now share. `css/css-images`
+  goes 234 → 262 of 460 reftests with no losses; the 42 `object-fit-*i` tests go 21 → 42.
+  `ImageIntrinsics` reports the intrinsic aspect ratio and whether its size is real
+  alongside them, since an SVG with only a `viewBox` has a ratio and no size.
 - `Broiler.Wpt` — a WPT `-print` reftest now renders the paint its own `@page`
   rule puts on the sheet (CSS Paged Media 3 §7): the page background over the
   whole page box, margins included, and the page's border and padding on the box

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -891,6 +891,68 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
   holds the green frame Chromium never shows. See
   [won't fix](wpt-rendering-gaps-wont-fix.md#image-animation-paused--the-worked-example-of-the-cost).
 
+### `object-fit` and `object-position` were not read at all
+
+- **Tests:** the 42 `css/css-images/object-fit-*i` (the `<img>` variants), **21 → 42 of
+  42**. Every one of the five fit keywords, against a raster image and against three
+  kinds of SVG, at seven `object-position` values each.
+- **Owner:** `Broiler.Layout` (`IR/ObjectFitPlacement.cs`, `IR/CssPositionValue.cs`) with
+  a 21-line call site in `Broiler.HTML` (`IR/PaintWalker.Decorations.cs`).
+- **The gap was total.** `EmitReplacedImage` drew every replaced element into its content
+  box, which is `fill` behaviour whatever the author wrote. `object-fit-contain-svg-001i`,
+  `-fill-svg-001i` and `-none-svg-001i` differ only in that one declaration and rendered
+  to **byte-identical PNGs**; the `object-position` classes in them (`top right`,
+  `bottom 1px right 2px`, …) had no effect either. Nothing in the engine named either
+  property outside `Broiler.CSS`'s list of ones it claims to support.
+- **Half the fix is on the reference side, and that is the part worth recording.** Each of
+  these tests states its reference with `background-size` and `background-position` rather
+  than with `object-fit`, and **four of its seven positions are written in the
+  three- or four-component edge-offset syntax** — `top 25% left 25%`,
+  `bottom 1px right 2px`, `top 3px center`, `center right 25%`. Paint read a
+  `<position>` positionally, first component horizontal and second vertical, which is only
+  the one- and two-component forms; the longer ones resolved to the origin, silently. So
+  the reference was wrong before the test had a chance to be, and implementing
+  `object-fit` alone would have moved nothing.
+- **One resolver, three callers.** `CssPositionValue` reads the whole grammar and is
+  shared by `object-position`, `background-position` on an image layer, and
+  `background-position` on a gradient layer — which were two copies of the positional
+  reading, so the same declaration could mean two things depending on whether the layer
+  behind it was a bitmap or a gradient. The count of components is the spec's own
+  disambiguation and the reason a `<position>` cannot be read token by token:
+  `right 25%` is two components and means *x: right, y: 25%*, while `center right 25%` is
+  three and means *25% of the free width in from the right edge*.
+- **The concrete object size is defined over the ratio, not the size, and an SVG can carry
+  one without the other.** `colors-8x16-noSize.svg` has a `viewBox` and no
+  `width`/`height`, and `GetImageIntrinsics` reports the 300×150 default object size for
+  it — deliberately, since that is what replaced *sizing* uses. Taking the ratio from that
+  size put a 1∶2 image in a 48×24 box and cost `object-fit-cover-svg-004i`, which had been
+  passing. `ImageIntrinsics` now reports the aspect ratio and whether the size is real
+  alongside it, so `contain`/`cover` use the ratio and `none` can tell "no intrinsic size"
+  from "an intrinsic size of 300×150" — which is exactly the distinction §5.1's default
+  sizing algorithm turns on.
+- **Overflow is clipped, not cropped.** `cover` always leaves the content box on one axis
+  and `none` does whenever the image is larger than its box, so the call site emits a clip
+  to the content box and draws the whole image into a rectangle that may exceed it.
+  Cropping the *source* rectangle instead would have been wrong for the same reason the
+  ratio was: the decoded bitmap is not the intrinsic size when an SVG is
+  [supersampled at 2×](wpt-rendering-gaps-open.md#svg-as-an-image-went-through-a-second-weaker-svg-renderer--fixed).
+  An object that fits emits no clip and paints exactly as it did before.
+- **Measured.** `css/css-images` **234 → 262 of 460**, +28 and **−0**. By element:
+  `<img>` **21 → 42 of 42**, `<object>` 5 → 12 of 40. The `<object>` gains are all the
+  `<position>` half rather than this one — `<object data="…svg">` paints through
+  `EmitSvgContent`, which this does not touch, so those seven crossed the threshold on
+  their references alone (98.81% → 99.11%) and the rest stay just under it. `<embed>`,
+  `<canvas>` and `<video poster>` do not move, and none of them is blocked on
+  `object-fit`: their content is not painted at all, which for `<canvas>` is
+  [the bitmap gap](wpt-rendering-gaps-open.md#canvas-cannot-paint-its-bitmap)
+  and for the other two is element support Broiler does not have.
+- **Tests:** `Broiler.Layout.Tests/ObjectFitPlacementTests.cs` (the five keywords against
+  a box wider and narrower than the content's ratio, `scale-down`'s choice between two of
+  them, a ratio without an intrinsic size, and which placements need the clip) and
+  `CssPositionValueTests.cs` (all four grammar forms, the two-versus-three component
+  disambiguation, percentages against the free space, and a `calc()` staying one component
+  however much whitespace it holds).
+
 ---
 
 ## DOM and the bridge

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -25,6 +25,7 @@ measured 2026-08-13; CI is the golden-image score from the
 - [View transitions](#view-transitions)
 - [Grid](#grid)
 - [Sizing and layout](#sizing-and-layout)
+- [Images](#images)
 - [Masking](#masking)
 - [Dynamic stylesheets](#dynamic-stylesheets)
 - [Quirks](#quirks)
@@ -383,9 +384,11 @@ the two defects at the end of this entry.
   Chromium golden — `transform-root-bg-001`/`-004` and `transform-background-007` from 49.1% to 60.8%,
   `perspective-svg-001` from 27.3% to 47.1%.
 - **Where it landed.** `SvgImageRaster` and the percentage support are main repo. The image backend's
-  six-line call site is `patches/0001` — the push to `Broiler.HTML` is denied (403), so it ships as a
-  patch registered in `scripts/apply-pending-wpt-patches.sh`. **The two halves must land together:**
-  the patch alone regresses ~70 `background-size/vector` tests, which is exactly what percentages fix.
+  six-line call site shipped as a patch while the push to `Broiler.HTML` was denied (403); it has
+  since landed upstream as `Broiler.HTML` **`c77f0f0`** ("image: render an SVG image through
+  Broiler.Layout's SvgRenderer") and the submodule pointer is bumped, so it reaches CI through the
+  pointer. **The two halves must stay together:** the submodule half alone regresses ~70
+  `background-size/vector` tests, which is exactly what percentages fix.
 - **Two smaller things the attempt exposed**, both pre-existing and both invisible while SVG images
   rendered nothing:
   - **A supersampled SVG tiles at its raster size, not its intrinsic size.** `GetSvgRasterizationScale`
@@ -414,6 +417,28 @@ Each renders blank, each was cleared by the same flag, and each is its own gap:
 
 The canvas gap is the same one that keeps
 [three `<canvas>` sizing tests](#canvas-cannot-paint-its-bitmap) from passing.
+
+### A replaced element other than `<img>` paints no image, and an SVG one ignores `object-fit`
+
+Named by the 178 non-`<img>` members of the `css-images/object-fit-*` family, which
+[the `<img>` fix](wpt-rendering-gaps-fixed.md#object-fit-and-object-position-were-not-read-at-all)
+left where they were. They are two gaps, not one, and each of the five element variants of
+every one of those tests is one or the other:
+
+- **`<embed>`, `<video poster>` and `<object data="…png">` paint no content at all.** All
+  three report `MissingContent` at 98.4–98.5% against references whose marks are small —
+  `object-fit-contain-png-001{e,o,c}` are 98.50% each. The `<canvas>` variants are the
+  already-recorded [bitmap gap](#canvas-cannot-paint-its-bitmap); the other three are
+  element support that does not exist. **Nothing here is an `object-fit` gap** — there is
+  no content to place.
+- **`<object data="…svg">` paints, and stretches.** It goes through
+  `PaintWalker.EmitSvgContent` rather than the `<img>` path, and that renders the document
+  into the content box unconditionally. Seven of the 40 crossed the 99% threshold on the
+  reference-side `<position>` fix alone (98.81% → 99.11%) and the rest sit at 98.4–98.6%.
+- **Exit gate:** `EmitSvgContent` places its document by the same
+  `Broiler.Layout.IR.ObjectFitPlacement` the `<img>` path uses — it needs the SVG's own
+  intrinsic size and ratio on the fragment, which `<img>` gets from the decoded image and
+  this path does not have — and the `-svg-*o` tests match.
 
 ### Six that render content and are still wrong
 
@@ -464,8 +489,9 @@ the other five are unexamined.
 - **The gap it exposed is separate, real, and much bigger than these tests** — see
   [a floated image disappears](#a-floated-image-disappears-entirely--fixed) below, now fixed. Every
   `<img>` in all 80 of those tests is `float: left`.
-- **Exit gate — met.** The 80 are ordinary comparisons now: 14 of them pass, and the rest fail on
-  [`object-fit`](#object-fit-and-object-position-are-not-implemented), which is the honest verdict.
+- **Exit gate — met.** The 80 are ordinary comparisons now: 14 of them passed at the time, and the
+  rest failed on `object-fit`, which was the honest verdict —
+  [since implemented](wpt-rendering-gaps-fixed.md#object-fit-and-object-position-were-not-read-at-all).
 
 ### A floated image disappears entirely — **fixed**
 
@@ -509,7 +535,9 @@ the other five are unexamined.
     two branches above.
 - **`object-fit-contain-svg-001i` renders.** It went from a canvas with **0** non-white pixels to
   24 061, against a reference with 13 849, and the float rows, box sizes, `clear: both` and dashed
-  borders line up with the reference exactly. What is left between them is `object-fit` itself.
+  borders line up with the reference exactly. What was left between them was `object-fit` itself, and
+  [that is read now](wpt-rendering-gaps-fixed.md#object-fit-and-object-position-were-not-read-at-all):
+  the test passes.
 - **Sweep: net zero, and that is the interesting part.** The same 3 974 reftests stay at **2 680**
   passing, +14 and −14, and every move is an `<img>` variant of `css-images/object-fit-*`:
 
@@ -524,8 +552,8 @@ the other five are unexamined.
   The `none` and `scale-down` rows were passing at 99.5% **because the image did not draw** — a
   mostly-white canvas against a reference whose marks are small. They now draw at the wrong size, which
   is worse against the reference and truer about the engine. `fill` passes because stretching to the
-  box is what `fill` means. See
-  [`object-fit` is not implemented](#object-fit-and-object-position-are-not-implemented).
+  box is what `fill` means. All five rows are 8 / 8 now that
+  [`object-fit` is read](wpt-rendering-gaps-fixed.md#object-fit-and-object-position-were-not-read-at-all).
 - **The two `svg/painting/reftests/non-scaling-stroke-00{2,3}` moves in that diff are not this change.**
   Both are `reftest-wait` animation tests; re-run single-worker they give 98.86% and 99.29% identically
   with and against the fix, so the sweep-to-sweep difference is scheduling under four workers.
@@ -538,19 +566,6 @@ the other five are unexamined.
   floated image overlaps it. That is not replaced-specific — see
   [text does not flow around a float](#text-does-not-flow-around-a-float) — and is unchanged by this
   fix in both directions.
-
-### `object-fit` and `object-position` are not implemented
-
-- **Owner:** `Broiler.Layout`. Surfaced by the float fix above, which is what made these tests draw.
-- **Nothing reads either property.** `object-fit-contain-svg-001i`, `object-fit-fill-svg-001i` and
-  `object-fit-none-svg-001i` differ only in that one declaration, and Broiler renders all three to
-  **byte-identical PNGs**: every image is stretched to its box, which is `fill` behaviour. The
-  `object-position` classes in those tests (`top right`, `bottom 1px right 2px`, …) have no effect
-  either.
-- **Scored:** of the 40 `css-images/object-fit-*-00Ni` tests, 18 pass — the `fill` and `cover` families
-  and one `contain` — and the remaining 22 fail between 97.3% and 98.4%.
-- **Exit gate:** `object-fit-contain-svg-001i` and `object-fit-none-svg-001i` render differently from
-  each other, and the `contain`, `none` and `scale-down` families pass.
 
 ### `cross-fade()` is unimplemented, and Chromium does not implement it either
 

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -36,16 +36,17 @@ being hidden by [a missing check in the runner](wpt-rendering-gaps-open.md#--ver
    inverse exists too: two `css-view-transitions` tests
    [pass on CI and are demonstrably wrong](wpt-rendering-gaps-open.md#two-tests-are-green-on-ci-and-wrong).
 3. **One patch is waiting, and a patch number identifies nothing.** The `patches/`
-   directory was emptied on 2026-08-13 (main `d710a02`) when its last file landed
-   upstream, and refilled the same day with a single entry —
-   [`0001`](../patches/README.md), the image backend's six-line call site for
-   [the SVG-renderer unification](wpt-rendering-gaps-open.md#svg-as-an-image-went-through-a-second-weaker-svg-renderer--fixed).
+   directory holds a single entry — [`0001`](../patches/README.md), the paint call
+   site for
+   [`object-fit` and `object-position`](wpt-rendering-gaps-fixed.md#object-fit-and-object-position-were-not-read-at-all).
    Every *other* submodule fix in these documents is an ancestor of the pinned
-   pointer and live on CI. `patches/` is a backlog rather than an archive — a file is
-   deleted once its fix is upstream and numbering restarts from `0001` — so the same
-   number names different changes at different times, and a `patches/NNNN` reference
-   in an older commit or comment is almost always dangling. Fixes are identified here
-   by **commit subject**:
+   pointer and live on CI, including the SVG-renderer unification that was `0001`
+   before this one (`Broiler.HTML` `c77f0f0`, pointer bumped). That is the whole
+   problem with numbering them: `patches/` is a backlog rather than an archive — a
+   file is deleted once its fix is upstream and numbering restarts from `0001` — so
+   the same number names different changes at different times, and a `patches/NNNN`
+   reference in an older commit or comment is almost always dangling. Fixes are
+   identified here by **commit subject**:
 
    ```sh
    git -C <Submodule> log --oneline --grep '<commit subject>'

--- a/patches/0001-paint-place-replaced-content-by-object-fit-and-objec.patch
+++ b/patches/0001-paint-place-replaced-content-by-object-fit-and-objec.patch
@@ -1,0 +1,261 @@
+From 2d7049fde86002aaebc84a071f5b90253aa47c00 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Thu, 13 Aug 2026 11:08:36 +0000
+Subject: [PATCH] paint: place replaced content by object-fit and
+ object-position
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+EmitReplacedImage drew every replaced element into its content box, which is
+`fill` behaviour whatever the author wrote: object-fit-contain-svg-001i,
+-fill-svg-001i and -none-svg-001i differ only in that one declaration and
+rendered to byte-identical PNGs. It now asks Broiler.Layout.IR.ObjectFitPlacement
+where the content goes, and clips to the content box when the concrete object
+size leaves it — `cover` always does on one axis, and `none` does whenever the
+image is larger than its box. Clipping rather than cropping the source rectangle
+is what CSS Images 3 describes, and it is also the only reading that survives a
+decoded bitmap that is not the intrinsic size, as a supersampled SVG's is not.
+
+The other half of those tests is their references, which state the same layout
+with background-position — and four of their seven positions are written in the
+three- or four-component edge-offset syntax (`top 25% left 25%`,
+`bottom 1px right 2px`). A <position> was read positionally here, first component
+horizontal and second vertical, which is only the one- and two-component forms;
+the longer ones resolved to the origin, silently. Both background-position call
+sites now go through Broiler.Layout.IR.CssPositionValue, which reads the whole
+grammar — so the image-layer and gradient-layer copies of the positional reading
+are gone with it, and one declaration can no longer mean two things depending on
+which kind of layer is behind it.
+
+GetImageIntrinsics reports the intrinsic aspect ratio and whether the size it
+returns is real, alongside the size itself. They are not derivable from each
+other: an SVG with a viewBox and no width/height has a ratio and no size, and the
+size reported for it is the 300x150 default object size, whose ratio is unrelated.
+Sizing `contain` by that ratio put a 1:2 image in a 48x24 box and cost
+object-fit-cover-svg-004i, which had been passing.
+
+css/css-images goes 234 -> 262 of 460 reftests, +28 and -0; the 42 object-fit-*i
+tests go 21 -> 42.
+---
+ Source/Broiler.HTML.Dom/LayoutEnvironment.cs  |  6 +-
+ .../IR/PaintWalker.Background.cs              | 83 +++----------------
+ .../IR/PaintWalker.Decorations.cs             | 23 ++++-
+ .../IR/PaintWalker.Gradients.cs               | 37 +++------
+ 4 files changed, 48 insertions(+), 101 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Dom/LayoutEnvironment.cs b/Source/Broiler.HTML.Dom/LayoutEnvironment.cs
+index b6d86f0..07d251c 100644
+--- a/Source/Broiler.HTML.Dom/LayoutEnvironment.cs
++++ b/Source/Broiler.HTML.Dom/LayoutEnvironment.cs
+@@ -64,7 +64,11 @@ internal sealed class HtmlLayoutEnvironment(IHtmlContainerInt container) : ILayo
+         bool bothIntrinsic = image.HasIntrinsicWidth && image.HasIntrinsicHeight;
+         double width = bothIntrinsic ? image.IntrinsicWidth : DefaultObjectWidth;
+         double height = bothIntrinsic ? image.IntrinsicHeight : DefaultObjectHeight;
+-        return new ImageIntrinsics(width, height, image.HasIntrinsicRatio);
++
++        // The ratio and whether the size above is real are reported separately, because paint needs
++        // to tell "16×8" from "no size, but 2∶1" and the two report the same width and height here.
++        return new ImageIntrinsics(
++            width, height, image.HasIntrinsicRatio, image.IntrinsicAspectRatio, bothIntrinsic);
+     }
+ 
+     public BColor ParseColor(string value) => container.ParseColor(value);
+diff --git a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Background.cs b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Background.cs
+index 38fc616..5bf3b89 100644
+--- a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Background.cs
++++ b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Background.cs
+@@ -270,28 +270,17 @@ internal static partial class PaintWalker
+         if (string.IsNullOrEmpty(position))
+             return;
+ 
+-        var parts = position.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+-        string? xVal = null, yVal = null;
+-        foreach (var p in parts)
+-        {
+-            if (IsHorizontalKeyword(p))
+-                xVal = p;
+-            else if (IsVerticalKeyword(p))
+-                yVal = p;
+-            else if (p.Equals("center", StringComparison.OrdinalIgnoreCase))
+-            {
+-                if (xVal == null) xVal = p;
+-                else yVal ??= p;
+-            }
+-            else
+-            {
+-                if (xVal == null) xVal = p;
+-                else yVal ??= p;
+-            }
+-        }
+-
+-        tileOrigin.X += ParsePositionValue(xVal, containerWidth, imageWidth, emSize);
+-        tileOrigin.Y += ParsePositionValue(yVal, containerHeight, imageHeight, emSize);
++        // `background-position` and `object-position` are the same <position> grammar, resolved by
++        // the same code — which is what brings the three- and four-component edge-offset forms
++        // (`top 25% left 25%`) here; reading the components positionally dropped them silently.
++        var offset = CssPositionValue.Resolve(
++            position,
++            new SizeF(containerWidth, containerHeight),
++            new SizeF(imageWidth, imageHeight),
++            emSize);
++
++        tileOrigin.X += offset.X;
++        tileOrigin.Y += offset.Y;
+     }
+ 
+     /// <summary>
+@@ -314,48 +303,6 @@ internal static partial class PaintWalker
+         }
+     }
+ 
+-    /// <summary>Parses a single CSS background-position value (keyword, px, %, or length).</summary>
+-    /// <param name="val">The position token (e.g. "right", "50%", "10px").</param>
+-    /// <param name="containerSize">Width or height of the positioning area.</param>
+-    /// <param name="imageSize">Width or height of the background image.</param>
+-    /// <returns>Offset in pixels from the origin.</returns>
+-    private static float ParsePositionValue(string val, float containerSize, float imageSize, float emSize)
+-    {
+-        if (string.IsNullOrEmpty(val)) return 0;
+-
+-        // CSS2.1 §14.2.1 keyword equivalences.
+-        if (val.Equals("left", StringComparison.OrdinalIgnoreCase)
+-            || val.Equals("top", StringComparison.OrdinalIgnoreCase))
+-            return 0;
+-        if (val.Equals("right", StringComparison.OrdinalIgnoreCase)
+-            || val.Equals("bottom", StringComparison.OrdinalIgnoreCase))
+-            return containerSize - imageSize;
+-        if (val.Equals("center", StringComparison.OrdinalIgnoreCase))
+-            return (containerSize - imageSize) / 2f;
+-
+-        if (val.EndsWith("px", StringComparison.OrdinalIgnoreCase))
+-        {
+-            if (float.TryParse(val.AsSpan(0, val.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out float px))
+-                return px;
+-        }
+-        else if (val.EndsWith('%'))
+-        {
+-            // CSS2.1 §14.2.1: percentage positions use (container - image) as
+-            // the reference length so that 100% places the image flush-right.
+-            if (float.TryParse(val.AsSpan(0, val.Length - 1), NumberStyles.Float, CultureInfo.InvariantCulture, out float pct))
+-                return (containerSize - imageSize) * pct / 100f;
+-        }
+-        else if (CssLengthParser.IsValidLength(val))
+-        {
+-            return (float)CssLengthParser.ParseLength(val, hundredPercent: 0, emFactor: emSize, defaultUnit: null);
+-        }
+-        else if (float.TryParse(val, NumberStyles.Float, CultureInfo.InvariantCulture, out float raw))
+-        {
+-            return raw;
+-        }
+-        return 0;
+-    }
+-
+     private static float GetPositionEmSize(ComputedStyle style)
+     {
+         float fontSize;
+@@ -377,14 +324,6 @@ internal static partial class PaintWalker
+         return fontSize > 0 ? fontSize : DefaultFontSize;
+     }
+ 
+-    private static bool IsHorizontalKeyword(string val) =>
+-        val.Equals("left", StringComparison.OrdinalIgnoreCase)
+-        || val.Equals("right", StringComparison.OrdinalIgnoreCase);
+-
+-    private static bool IsVerticalKeyword(string val) =>
+-        val.Equals("top", StringComparison.OrdinalIgnoreCase)
+-        || val.Equals("bottom", StringComparison.OrdinalIgnoreCase);
+-
+     /// <summary>
+     /// CSS Backgrounds Level 4 <c>background-clip: border-area</c>:
+     /// Emits 4 tiled-image items, one for each border strip.
+diff --git a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Decorations.cs b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Decorations.cs
+index 0fe8dea..11a00c2 100644
+--- a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Decorations.cs
++++ b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Decorations.cs
+@@ -440,13 +440,32 @@ internal static partial class PaintWalker
+ 
+             if (r.Width > 0 && r.Height > 0)
+             {
++                // CSS Images 3 §5.5/§5.6: object-fit sizes the content against its intrinsic size
++                // and object-position places it, so the drawn rectangle is only the content box
++                // when object-fit is `fill` — which is the initial value, and returned as-is.
++                var placement = ObjectFitPlacement.Resolve(
++                    r, fragment.ImageIntrinsicSize, fragment.ImageIntrinsicRatio,
++                    fragment.Style.ObjectFit, fragment.Style.ObjectPosition,
++                    GetPositionEmSize(fragment.Style));
++
++                if (placement.IsEmpty)
++                    continue;
++
++                // The concrete object size can leave the content box — `cover` always does on one
++                // axis — and CSS Images 3 clips the overflow to it rather than scaling it away.
++                if (placement.NeedsClip)
++                    items.Add(new ClipItem { Bounds = r, ClipRect = r });
++
+                 items.Add(new DrawImageItem
+                 {
+-                    Bounds = r,
++                    Bounds = placement.Dest,
+                     ImageHandle = fragment.ImageHandle,
+                     SourceRect = fragment.ImageSourceRect,
+-                    DestRect = r,
++                    DestRect = placement.Dest,
+                 });
++
++                if (placement.NeedsClip)
++                    items.Add(new RestoreItem { Bounds = r });
+             }
+         }
+     }
+diff --git a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Gradients.cs b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Gradients.cs
+index 02876ef..01c6e4b 100644
+--- a/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Gradients.cs
++++ b/Source/Broiler.HTML.Orchestration/IR/PaintWalker.Gradients.cs
+@@ -117,32 +117,17 @@ internal static partial class PaintWalker
+             float tileH = positioningArea.Height;
+             ParseBackgroundSize(sizeStr, positioningArea.Width, positioningArea.Height, out tileW, out tileH);
+ 
+-            // Apply background-position offset.
+-            var posParts = posStr.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+-            if (posParts.Length >= 1)
+-            {
+-                string xVal = null, yVal = null;
+-                foreach (var p in posParts)
+-                {
+-                    if (IsHorizontalKeyword(p))
+-                        xVal = p;
+-                    else if (IsVerticalKeyword(p))
+-                        yVal = p;
+-                    else if (p.Equals("center", StringComparison.OrdinalIgnoreCase))
+-                    {
+-                        if (xVal == null) xVal = p;
+-                        else if (yVal == null) yVal = p;
+-                    }
+-                    else
+-                    {
+-                        if (xVal == null) xVal = p;
+-                        else if (yVal == null) yVal = p;
+-                    }
+-                }
+-                float emSize = GetPositionEmSize(style);
+-                tileOrigin.X += ParsePositionValue(xVal, positioningArea.Width, tileW, emSize);
+-                tileOrigin.Y += ParsePositionValue(yVal, positioningArea.Height, tileH, emSize);
+-            }
++            // Apply background-position offset, through the same <position> resolver a background
++            // image and an object-position go through — one declaration must not mean two things
++            // depending on whether the layer behind it is a gradient or a bitmap.
++            var gradientOffset = CssPositionValue.Resolve(
++                posStr,
++                new SizeF(positioningArea.Width, positioningArea.Height),
++                new SizeF(tileW, tileH),
++                GetPositionEmSize(style));
++
++            tileOrigin.X += gradientOffset.X;
++            tileOrigin.Y += gradientOffset.Y;
+ 
+             items.Add(new DrawTiledGradientItem
+             {
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -46,44 +46,36 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD && echo "live on CI"
 
 | # | submodule | subject |
 | --- | --- | --- |
-| `0001` | `Broiler.HTML` | image: render an SVG image through Broiler.Layout's SvgRenderer |
+| `0001` | `Broiler.HTML` | paint: place replaced content by object-fit and object-position |
 
-### `0001` — one SVG renderer instead of two
+The number was last used for "image: render an SVG image through Broiler.Layout's
+SvgRenderer", which landed upstream as `Broiler.HTML` `c77f0f0` and whose pointer
+is bumped. It is a different change; see the warning above.
 
-Six lines at the seam, and it is the second half of a two-repo change; the first
-half is already in the main repo and is where all the logic lives
-(`Broiler.Layout.IR.SvgImageRaster`, plus percentage-length support in
-`SvgRenderer`). Issue
-[#1627](https://github.com/Broiler-Platform/Broiler/issues/1627) has the full
-story.
+### `0001` — read `object-fit` and `object-position` at the paint site
 
-**Why it is listed for the WPT run.** Without it, every SVG used as an image is
-still drawn by the image backend's own regex renderer, which has no `<polygon>`
-arm — so the document renders as a fully transparent bitmap and the image does
-not appear. That is squarely a pixel-moving change, which is the bar for this
-list.
+The second half of a two-repo change, and the small half: all of the logic is in
+the main repo (`Broiler.Layout.IR.ObjectFitPlacement` for the placement,
+`IR.CssPositionValue` for the `<position>` grammar), and this is the call site
+plus the two lines that report an image's aspect ratio and whether its reported
+size is really intrinsic. Recorded in
+[the gaps document](../docs/wpt-rendering-gaps-fixed.md#object-fit-and-object-position-were-not-read-at-all).
 
-**Measured before landing**, over 3 974 reftests in `css-masking`, `css-images`,
-`css-transforms`, `css-backgrounds`, `compositing`, `filter-effects`, `css-ui`
-and `svg`, with the main-repo half in place on both sides:
+**Why it is listed for the WPT run.** Without it `EmitReplacedImage` draws every
+replaced element into its content box — `fill` behaviour whatever the author
+wrote — and `background-position` keeps reading a `<position>` positionally, which
+drops the three- and four-component edge-offset forms (`top 25% left 25%`)
+silently. Both are plainly pixel-moving.
 
-- **2 675 → 2 756 passing**, +95 and −14, and average match 98.562% → 98.599%.
-- `css-images/object-fit-*-svg-*` goes **52/120 → 120/120**.
-- Of the 14 losses, five were *passing by rendering nothing* — the test and its
-  reference were both blank, so they matched at 100% — and now render real
-  content that exposes two separate pre-existing bugs, both recorded in
-  [the gaps document](../docs/wpt-rendering-gaps-open.md#svg-as-an-image-went-through-a-second-weaker-svg-renderer--fixed).
-  The other nine are sub-1.5% differences that fall just under the 99% threshold.
+**Measured** over the full reftest suite with the main-repo half in place on both
+sides: `css/css-images` **234 → 262 of 460**, with the 42 `object-fit-*i` tests
+going 21 → 42 and no losses anywhere in that directory. The whole-suite numbers
+are in the gaps document.
 
-**Do not apply this patch without the main-repo half.** On its own it regresses
-~70 `css-backgrounds/background-size/vector` tests, whose SVGs are built on
-percentage lengths that `SvgRenderer` did not resolve until the same change
-taught it to. The two are one fix in two repositories.
+**Do not apply this patch without the main-repo half.** It calls types that only
+exist there, so it does not compile on its own. The main-repo half is inert
+without it — the new types are simply unreferenced — which is why the pointer can
+stay where it is.
 
-**When it lands upstream:** bump the pointer, delete this patch and its entry in
-`scripts/apply-pending-wpt-patches.sh`, and delete the now-unreachable private
-renderers in `BSvgRasterizer` (`RenderRectangles`, `RenderCircles`,
-`RenderEllipses`, `RenderLines`, `RenderPaths`, `RenderText` and the helpers only
-they use — roughly 450 lines). They are deliberately left in place here to keep
-the patch to 23 lines and so hand-applying it cannot conflict; removing them is a
-trivial in-repo follow-up once the pointer moves.
+**When it lands upstream:** bump the pointer, and delete this patch and its entry
+in `scripts/apply-pending-wpt-patches.sh`.

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -114,15 +114,19 @@ set -euo pipefail
 # itself is unit-tested in the main repo (ReplacedBoxSizingTests); only the pixel
 # suite can say a real <canvas> reaches it.
 #
-# 0001 (Broiler.HTML, SVG image through SvgRenderer) is listed because without it every
-# SVG used as an image is drawn by the image backend's own regex renderer, which has no
-# <polygon> arm — the document rasterises to a fully transparent bitmap and the image
-# does not appear at all. That is the plainest kind of pixel-moving change. Its logic is
-# all main-repo (Broiler.Layout.IR.SvgImageRaster and the percentage-length support in
-# SvgRenderer, and its attribute-quoting fix); this patch is the six-line call site.
-# Measured over 3974 reftests with the main-repo half on both sides: 2675 -> 2756
-# passing. See patches/README.md.
+# The SVG-image patch that was 0001 before this one ("image: render an SVG image through
+# Broiler.Layout's SvgRenderer") landed upstream as Broiler.HTML c77f0f0 and its pointer
+# is bumped, so it reaches CI through the pointer and its entry is gone with it.
+#
+# 0001 (Broiler.HTML, object-fit and object-position at the paint site) is listed because
+# without it EmitReplacedImage draws every replaced element into its content box — `fill`
+# behaviour whatever the author wrote — and background-position keeps reading a <position>
+# positionally, which drops the three- and four-component edge-offset forms silently. Both
+# are plainly pixel-moving, and between them they are 28 tests in css/css-images alone. Its
+# logic is all main-repo (Broiler.Layout.IR.ObjectFitPlacement and IR.CssPositionValue);
+# this patch is the call site. See patches/README.md.
 PENDING_PATCHES=(
+  "Broiler.HTML|patches/0001-paint-place-replaced-content-by-object-fit-and-objec.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary

Implements CSS Images 3 §5.5 `object-fit` and §5.6 `object-position` properties, which were previously ignored entirely. Every replaced element was stretched to its content box regardless of the declared fit mode. This change adds proper sizing and positioning of replaced content (images, SVGs) within their content boxes.

Additionally fixes a critical bug in `<position>` parsing where the three- and four-component edge-offset syntax (e.g., `top 25% left 25%`, `bottom 1px right 2px`) was silently dropped, affecting both `object-position` and `background-position` declarations.

## Key Changes

**New modules:**
- `Broiler.Layout/IR/ObjectFitPlacement.cs` — Resolves the concrete object size and placement rectangle for replaced elements based on `object-fit` and `object-position` values
- `Broiler.Layout/IR/CssPositionValue.cs` — Unified `<position>` grammar parser supporting all four forms (one-, two-, three-, and four-component), shared by `object-position` and `background-position`
- `Broiler.Layout.Tests/ObjectFitPlacementTests.cs` — 22 test cases covering all fit keywords, ratios without intrinsic sizes, and positioning edge cases
- `Broiler.Layout.Tests/CssPositionValueTests.cs` — 15 test cases for position parsing including edge-offset forms

**Modified modules:**
- `Broiler.Layout/ImageIntrinsics.cs` — Extended to report intrinsic aspect ratio and whether the reported size is real (distinguishing "16×8" from "no size, but 2∶1 ratio")
- `Broiler.Layout/IR/Fragment.cs` — Added `ImageIntrinsicSize` and `ImageIntrinsicRatio` properties to carry sizing data to paint
- `Broiler.Layout/Engine/CssBoxProperties.cs` — Added `ObjectFit` and `ObjectPosition` properties
- `Broiler.Layout/IR/ComputedStyle.cs` — Added `ObjectFit` and `ObjectPosition` fields
- `Broiler.Layout/IR/ComputedStyleBuilder.cs` — Populates new object-fit/position fields
- `Broiler.Layout/IR/FragmentTreeBuilder.cs` — Captures intrinsic size and ratio during fragment building

**Paint integration (Broiler.HTML submodule patch):**
- `IR/PaintWalker.Decorations.cs` — Calls `ObjectFitPlacement.Resolve()` to determine where replaced content draws; clips to content box when needed
- `IR/PaintWalker.Background.cs` — Replaced positional position parsing with `CssPositionValue.Resolve()` call; removed `ParsePositionValue()` and keyword helpers
- `IR/PaintWalker.Gradients.cs` — Updated to use unified `CssPositionValue` for gradient positioning
- `LayoutEnvironment.cs` — Extended `GetImageIntrinsics()` to report ratio and size validity

## Notable Implementation Details

- **Clipping vs. cropping:** When `object-fit: cover` or `none` causes overflow, the implementation clips to the content box rather than cropping the source bitmap. This matches CSS Images 3 and correctly handles supersampled SVGs whose raster size differs from intrinsic size.

- **Ratio without size:** An SVG with only a `viewBox` (no `width`/`height`) carries an aspect ratio but no intrinsic size. The code reports the 300×150 default object size separately from the ratio, allowing `contain` to size by the ratio rather than the default size's ratio.

- **Position grammar unification:** The three- and four-component edge-offset forms (`top 25% left 25%`) were previously silently dropped by positional parsing. All `css-images/object-fit-*` reference images use these forms in their `background-position` declarations, making the references incorrect before the tests could be. The unified parser now handles all forms correctly.

- **Fast path:** When both `object-fit` and `object-position` are at their initial values

https://claude.ai/code/session_01E4Sbt3NHZcJ9TBBXnKbmqr