### PR TITLE
Fix www.7-zip.org rendering: stylesheet fetch and quirks-mode table fonts

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/DocumentModeContextTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/DocumentModeContextTests.cs
@@ -1,0 +1,60 @@
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// <see cref="DocumentModeContext.IsQuirksHtml"/> against the HTML Standard's DOCTYPE conditions
+/// ("The initial insertion mode"). The public-identifier cases are the point: a doctype whose *name*
+/// is <c>html</c> can still select quirks mode, and every legacy page that relies on quirks-mode
+/// behaviour is written that way.
+/// </summary>
+public sealed class DocumentModeContextTests
+{
+    [Theory]
+    // No doctype at all, and a doctype that is not html.
+    [InlineData("<html><body>x</body></html>", true)]
+    [InlineData("<!DOCTYPE foo><html></html>", true)]
+    // The standards-mode doctype, in the forms a page actually writes it.
+    [InlineData("<!DOCTYPE html><html></html>", false)]
+    [InlineData("<!doctype html>\n<html></html>", false)]
+    [InlineData("<!DOCTYPE HTML>", false)]
+    // about:legacy-compat is standards mode: the name is html and neither identifier is listed.
+    [InlineData("""<!DOCTYPE html SYSTEM "about:legacy-compat">""", false)]
+    // www.7-zip.org's doctype, and the whole HTML 4.0 family with it.
+    [InlineData("""<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">""", true)]
+    [InlineData("""<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Frameset//EN">""", true)]
+    [InlineData("""<!DOCTYPE html PUBLIC "-//IETF//DTD HTML 2.0//EN">""", true)]
+    [InlineData("""<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">""", true)]
+    // Exact-match public identifiers.
+    [InlineData("""<!DOCTYPE html PUBLIC "HTML">""", true)]
+    [InlineData("""<!DOCTYPE html PUBLIC "-/W3C/DTD HTML 4.0 Transitional/EN">""", true)]
+    // The listed system identifier selects quirks whatever the public identifier says.
+    [InlineData("""<!DOCTYPE html PUBLIC "" "http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd">""", true)]
+    // HTML 4.01 Transitional/Frameset: full quirks without a system identifier, limited-quirks with
+    // one — and limited-quirks is not what this predicate reports.
+    [InlineData("""<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">""", true)]
+    [InlineData("""<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">""", false)]
+    [InlineData("""<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "http://www.w3.org/TR/html4/frameset.dtd">""", false)]
+    // HTML 4.01 Strict is standards mode either way — it is on neither list.
+    [InlineData("""<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">""", false)]
+    // XHTML 1.0 Transitional is limited-quirks, so not full quirks.
+    [InlineData("""<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">""", false)]
+    [InlineData("""<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">""", false)]
+    public void Classifies(string html, bool quirks) =>
+        Assert.Equal(quirks, DocumentModeContext.IsQuirksHtml(html));
+
+    // The spec compares both identifiers ASCII case-insensitively, and the keyword and quoting style
+    // vary across real documents.
+    [Theory]
+    [InlineData("""<!doctype html public "-//w3c//dtd html 4.0 transitional//en">""")]
+    [InlineData("""<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'>""")]
+    [InlineData("""<!DoCtYpE   hTmL   pUbLiC   "-//W3C//DTD HTML 4.0 Transitional//EN"  >""")]
+    public void Identifier_Matching_Is_Case_Insensitive(string html) =>
+        Assert.True(DocumentModeContext.IsQuirksHtml(html));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Empty_Input_Is_Quirks(string? html) =>
+        Assert.True(DocumentModeContext.IsQuirksHtml(html!));
+}

--- a/Broiler.Layout/Broiler.Layout.Tests/TableFontInheritanceQuirkTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/TableFontInheritanceQuirkTests.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Drawing;
+using Broiler.CSS;
+using Broiler.Graphics;
+using Broiler.Layout.Engine;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// The HTML Standard's quirks-mode table font reset (Rendering §Tables): a <c>&lt;table&gt;</c> in a
+/// quirks-mode document starts <c>font-weight</c>, <c>font-style</c>, <c>font-variant</c>,
+/// <c>font-size</c>, <c>line-height</c>, <c>white-space</c> and <c>text-align</c> from their initial
+/// values instead of inheriting its parent's.
+/// </summary>
+/// <remarks>
+/// The font-size half is the one with teeth, and the shape that motivated it is www.7-zip.org:
+/// a quirks-mode page whose sheet says <c>BODY { font-size: 80% }</c> and <c>TD { font-size: 80% }</c>
+/// while nesting tables three deep. Without the reset the 80% compounds once per level and the page
+/// ends up in a ~6px font; with it every cell is 12.8px at every depth, which is what browsers show.
+/// Both are asserted here through <c>ActualFont.Size</c>, using the echoing font environment so the
+/// numbers are the requested sizes rather than whatever a real font rounds to.
+/// </remarks>
+public sealed class TableFontInheritanceQuirkTests
+{
+    private static readonly Uri BaseUrl = new("file:///table-font-quirk.html");
+
+    [Fact]
+    public void A_Table_Does_Not_Inherit_The_Parents_Font_Size()
+    {
+        InQuirksMode(() =>
+        {
+            var (_, body) = Document();
+            body.FontSize = "80%";
+
+            var table = Cascade(body, "table");
+
+            Assert.Equal(CssConstants.Medium, table.FontSize);
+        });
+    }
+
+    // The 7-Zip shape. Three nested tables, each cell asking for 80%: every cell resolves against
+    // its table's reset size, so all three land on the same 12.8px rather than 10.24 / 8.19 / 6.55.
+    [Fact]
+    public void A_Cells_Percentage_Does_Not_Compound_Through_Nested_Tables()
+    {
+        InQuirksMode(() =>
+        {
+            var (root, body) = Document();
+            root.FontSize = "16px";
+            body.FontSize = "80%";
+
+            var cell1 = Cell(body);
+            var cell2 = Cell(cell1);
+            var cell3 = Cell(cell2);
+
+            var expected = body.ActualFont.Size;   // 80% of the root: the size every cell should get
+            Assert.Equal(expected, cell1.ActualFont.Size, 4);
+            Assert.Equal(expected, cell2.ActualFont.Size, 4);
+            Assert.Equal(expected, cell3.ActualFont.Size, 4);
+        });
+    }
+
+    // The same document in standards mode is the control: there the table inherits, so the 80%
+    // compounds and each level is 80% of the one above it.
+    [Fact]
+    public void The_Same_Nesting_Still_Compounds_In_Standards_Mode()
+    {
+        InStandardsMode(() =>
+        {
+            var (root, body) = Document();
+            root.FontSize = "16px";
+            body.FontSize = "80%";
+
+            var cell1 = Cell(body);
+            var cell2 = Cell(cell1);
+
+            Assert.Equal(0.8, cell1.ActualFont.Size / body.ActualFont.Size, 4);
+            Assert.Equal(0.8, cell2.ActualFont.Size / cell1.ActualFont.Size, 4);
+        });
+    }
+
+    [Fact]
+    public void The_Other_Six_Properties_Are_Reset_Too()
+    {
+        InQuirksMode(() =>
+        {
+            var (_, body) = Document();
+            body.FontWeight = "bold";
+            body.FontStyle = CssConstants.Italic;
+            body.FontVariant = "small-caps";
+            body.LineHeight = "3em";
+            body.WhiteSpace = "pre";
+            body.TextAlign = CssConstants.Right;
+
+            var table = Cascade(body, "table");
+
+            Assert.Equal(CssConstants.Normal, table.FontWeight);
+            Assert.Equal(CssConstants.Normal, table.FontStyle);
+            Assert.Equal(CssConstants.Normal, table.FontVariant);
+            Assert.Equal(CssConstants.Normal, table.LineHeight);
+            Assert.Equal(CssConstants.Normal, table.WhiteSpace);
+            Assert.Equal(string.Empty, table.TextAlign);
+        });
+    }
+
+    // font-family is not in the spec's list, so a quirks-mode table keeps the page's typeface and
+    // only loses the size. 7-Zip's tables still render in the body's Verdana.
+    [Fact]
+    public void Font_Family_Is_Still_Inherited()
+    {
+        InQuirksMode(() =>
+        {
+            var (_, body) = Document();
+            body.FontFamily = "Verdana";
+
+            var table = Cascade(body, "table");
+
+            Assert.Equal("Verdana", table.FontFamily);
+        });
+    }
+
+    // The spec states the reset as a UA-origin rule, and the cascade applies the element's own
+    // declarations after inheriting — so an author font-size on the table itself still wins.
+    [Fact]
+    public void An_Author_Declaration_On_The_Table_Overrides_The_Reset()
+    {
+        InQuirksMode(() =>
+        {
+            var (_, body) = Document();
+            body.FontSize = "80%";
+
+            var table = Cascade(body, "table");
+            table.FontSize = "20px";   // what a `table { font-size: 20px }` declaration does
+
+            // Asserted as the used size rather than the declaration text, which the setter
+            // normalises: 20px is 15pt, where the reset would have left it at medium's 12pt.
+            Assert.Equal(15.0, table.ActualFont.Size, 4);
+        });
+    }
+
+    [Fact]
+    public void Nothing_Happens_In_Standards_Mode()
+    {
+        InStandardsMode(() =>
+        {
+            var (_, body) = Document();
+            body.FontSize = "10px";
+            body.WhiteSpace = "pre";
+
+            var table = Cascade(body, "table");
+
+            Assert.Equal(body.FontSize, table.FontSize);
+            Assert.Equal("pre", table.WhiteSpace);
+        });
+    }
+
+    // The selector in the spec's rule is an element selector, so a box that merely lays out as a
+    // table is unaffected — as is any other element.
+    [Fact]
+    public void Only_The_Table_Element_Is_Reset()
+    {
+        InQuirksMode(() =>
+        {
+            var (_, body) = Document();
+            body.FontSize = "10px";
+
+            var div = Cascade(body, "div");
+            div.Display = CssConstants.Table;
+            var cell = Cascade(body, "td");
+
+            Assert.Equal(body.FontSize, div.FontSize);
+            Assert.Equal(body.FontSize, cell.FontSize);
+        });
+    }
+
+    // `everything: true` is the inline-splitting path, which clones an already-cascaded box onto
+    // its two halves — HtmlTag included. Re-running the reset there would throw away the author
+    // values the original ended up with, so it must not fire.
+    [Fact]
+    public void The_Clone_Path_Keeps_The_Originals_Values()
+    {
+        InQuirksMode(() =>
+        {
+            var (_, body) = Document();
+
+            var table = Cascade(body, "table");
+            table.FontSize = "20px";
+            table.WhiteSpace = "pre";
+
+            var half = new CssBox(body, new HtmlTag("table", isSingle: false, attributes: null), BaseUrl);
+            half.InheritStyle(table, everything: true);
+
+            Assert.Equal(table.FontSize, half.FontSize);
+            Assert.NotEqual(CssConstants.Medium, half.FontSize);
+            Assert.Equal("pre", half.WhiteSpace);
+        });
+    }
+
+    /// <summary>A child box whose inherited values come through <c>InheritStyle</c>, the way the
+    /// cascade produces them, so the quirk runs exactly where it does in a real render.</summary>
+    private static CssBox Cascade(CssBox parent, string tagName)
+    {
+        var box = new CssBox(parent, new HtmlTag(tagName, isSingle: false, attributes: null), BaseUrl)
+        {
+            Location = new PointF(0, 0),
+            Size = new SizeF(400, 0),
+        };
+
+        box.InheritStyle(parent);
+        return box;
+    }
+
+    /// <summary>A <c>&lt;table&gt;</c>/<c>&lt;td&gt;</c> pair with the cell asking for 80%, which is
+    /// how the pages this quirk exists for are written.</summary>
+    private static CssBox Cell(CssBox parent)
+    {
+        var cell = Cascade(Cascade(parent, "table"), "td");
+        cell.FontSize = "80%";
+        return cell;
+    }
+
+    private static (CssBox Root, CssBox Body) Document()
+    {
+        var root = new CssBox(null, null, BaseUrl)
+        {
+            Location = new PointF(0, 0),
+            Size = new SizeF(400, 400),
+            Display = CssConstants.Block,
+            FontSize = "16px",
+            LayoutEnvironment = new EchoFontEnvironment(),
+        };
+
+        var html = Cascade(root, "html");
+        return (root, Cascade(html, "body"));
+    }
+
+    private static void InQuirksMode(Action body) => WithDocumentMode(true, body);
+
+    private static void InStandardsMode(Action body) => WithDocumentMode(false, body);
+
+    private static void WithDocumentMode(bool quirks, Action body)
+    {
+        var previous = DocumentModeContext.CurrentQuirksMode;
+        try
+        {
+            DocumentModeContext.CurrentQuirksMode = quirks;
+            body();
+        }
+        finally
+        {
+            DocumentModeContext.CurrentQuirksMode = previous;
+        }
+    }
+
+    /// <summary>Reports the requested point size back verbatim, so a test can assert on the size a
+    /// box asked for without a real font's rounding in the way.</summary>
+    private sealed class EchoFontEnvironment : ILayoutEnvironment
+    {
+        public ILayoutFont GetFont(string family, double size, LayoutFontStyle style, string? fontFeatures = null) => new EchoFont(size);
+        public SizeF MeasureText(ILayoutFont font, string text) => SizeF.Empty;
+        public void MeasureText(ILayoutFont font, string text, double maxWidth, out int charFit, out double charFitWidth) { charFit = 0; charFitWidth = 0; }
+        public double GetWhitespaceWidth(ILayoutFont font) => 0;
+        public ImageIntrinsics GetImageIntrinsics(object imageHandle) => default;
+        public BColor ParseColor(string value) => default;
+        public void RequestRefresh(bool relayout) { }
+        public SizeF ViewportSize => new(1000, 1000);
+        public PointF RootLocation => PointF.Empty;
+        public SizeF ActualSize { get; set; }
+        public bool AvoidGeometryAntialias => false;
+        public SizeF PageSize => new(1000, 1000);
+        public int MarginTop => 0;
+        public void ReportLayoutError(string message, Exception? exception = null) { }
+        public bool AvoidAsyncImagesLoading => true;
+        public bool AvoidImagesLateLoading => true;
+        public ILayoutImageLoader CreateImageLoader(Action<object?, RectangleF, bool> onComplete) => null!;
+        public string FormatListMarker(int number, string style) => string.Empty;
+    }
+
+    private sealed class EchoFont(double size) : ILayoutFont
+    {
+        public double Size { get; } = size;
+        public double Height => size;
+        public double UnderlineOffset => 0;
+        public double LeftPadding => 0;
+        public string? FontFeatures => null;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/DocumentModeContext.cs
+++ b/Broiler.Layout/Broiler.Layout/DocumentModeContext.cs
@@ -49,20 +49,169 @@ public static partial class DocumentModeContext
     }
 
     /// <summary>
-    /// Lightweight quirks-mode determination from raw HTML. A document with no
-    /// doctype, or any doctype whose name is not a bare <c>html</c>, is in quirks
-    /// mode; a bare <c>&lt;!DOCTYPE html&gt;</c> selects standards mode.
+    /// Quirks-mode determination from raw HTML, following the HTML Standard's DOCTYPE conditions.
+    /// A document with no doctype, or one whose name is not <c>html</c>, is in quirks mode; a bare
+    /// <c>&lt;!DOCTYPE html&gt;</c> selects standards mode; and a name of <c>html</c> carrying one
+    /// of the legacy public identifiers selects quirks mode too.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The public identifier half is not a refinement anyone can skip: the doctypes real legacy
+    /// pages carry are exactly the ones it recognises. www.7-zip.org declares
+    /// <c>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"&gt;</c>, whose name *is*
+    /// <c>html</c> — so on a name-only test it read as standards mode, and every quirks-mode
+    /// behaviour keyed off this flag (the body/html fill, both table quirks) was silently inert on
+    /// the pages that need them most.
+    /// </para>
+    /// <para>
+    /// This reads the doctype out of the markup rather than from a parsed tree because both callers
+    /// have only the string: the flag is published before the document is built. The regex takes the
+    /// first <c>&lt;!doctype&gt;</c> in the source, as it always has.
+    /// </para>
+    /// </remarks>
     public static bool IsQuirksHtml(string html)
     {
         if (string.IsNullOrEmpty(html))
             return true;
 
         var match = QuirksRegex().Match(html);
-        return !(match.Success
-            && match.Groups[1].Value.Equals("html", StringComparison.OrdinalIgnoreCase));
+        if (!match.Success || !match.Groups["name"].Value.Equals("html", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // "PUBLIC <public id> [<system id>]" versus "SYSTEM <system id>": the first quoted string
+        // means different things in the two forms, so which group is which depends on the keyword.
+        var kind = match.Groups["kind"].Value;
+        var first = Unquote(match.Groups["first"].Value);
+        var second = Unquote(match.Groups["second"].Value);
+
+        bool isPublic = kind.Equals("public", StringComparison.OrdinalIgnoreCase);
+        string publicId = isPublic ? first : string.Empty;
+        string systemId = isPublic ? second : first;
+
+        return SelectsQuirksMode(publicId, systemId);
     }
 
-    [GeneratedRegex(@"<!doctype\s+([^\s>]+)", RegexOptions.IgnoreCase)]
+    /// <summary>
+    /// The HTML Standard's quirks-mode conditions for a DOCTYPE whose name is <c>html</c>
+    /// (<see href="https://html.spec.whatwg.org/multipage/parsing.html#the-initial-insertion-mode">"The
+    /// initial insertion mode"</see>). Both identifiers are compared ASCII case-insensitively, and an
+    /// empty system identifier counts as missing, as the spec requires.
+    /// </summary>
+    /// <remarks>
+    /// Limited-quirks mode is deliberately not modelled: this predicate answers "full quirks?", and
+    /// the two limited-quirks families (XHTML 1.0 Transitional/Frameset, and HTML 4.01
+    /// Transitional/Frameset <em>with</em> a system identifier) fall through to <c>false</c> — which
+    /// is what the callers, all of them full-quirks behaviours, need.
+    /// </remarks>
+    private static bool SelectsQuirksMode(string publicId, string systemId)
+    {
+        foreach (var exact in QuirksPublicIdentifiers)
+            if (publicId.Equals(exact, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+        if (systemId.Equals(
+                "http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd",
+                StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        foreach (var prefix in QuirksPublicIdentifierPrefixes)
+            if (publicId.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+        // HTML 4.01 Transitional/Frameset are full quirks only without a system identifier; with one
+        // they are limited-quirks, which is not this predicate's answer.
+        if (systemId.Length == 0)
+            foreach (var prefix in QuirksPublicIdentifierPrefixesWithoutSystemId)
+                if (publicId.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+        return false;
+    }
+
+    /// <summary>Strips the surrounding quotes the DOCTYPE regex captures with an identifier.</summary>
+    private static string Unquote(string value) =>
+        value.Length >= 2 ? value[1..^1] : string.Empty;
+
+    /// <summary>Public identifiers that select quirks mode by exact match.</summary>
+    private static readonly string[] QuirksPublicIdentifiers =
+    [
+        "-//W3O//DTD W3 HTML Strict 3.0//EN//",
+        "-/W3C/DTD HTML 4.0 Transitional/EN",
+        "HTML",
+    ];
+
+    /// <summary>Public-identifier prefixes that select quirks mode regardless of system identifier.</summary>
+    private static readonly string[] QuirksPublicIdentifierPrefixes =
+    [
+        "+//Silmaril//dtd html Pro v0r11 19970101//",
+        "-//AS//DTD HTML 3.0 asWedit + extensions//",
+        "-//AdvaSoft Ltd//DTD HTML 3.0 asWedit + extensions//",
+        "-//IETF//DTD HTML 2.0 Level 1//",
+        "-//IETF//DTD HTML 2.0 Level 2//",
+        "-//IETF//DTD HTML 2.0 Strict Level 1//",
+        "-//IETF//DTD HTML 2.0 Strict Level 2//",
+        "-//IETF//DTD HTML 2.0 Strict//",
+        "-//IETF//DTD HTML 2.0//",
+        "-//IETF//DTD HTML 2.1E//",
+        "-//IETF//DTD HTML 3.0//",
+        "-//IETF//DTD HTML 3.2 Final//",
+        "-//IETF//DTD HTML 3.2//",
+        "-//IETF//DTD HTML 3//",
+        "-//IETF//DTD HTML Level 0//",
+        "-//IETF//DTD HTML Level 1//",
+        "-//IETF//DTD HTML Level 2//",
+        "-//IETF//DTD HTML Level 3//",
+        "-//IETF//DTD HTML Strict Level 0//",
+        "-//IETF//DTD HTML Strict Level 1//",
+        "-//IETF//DTD HTML Strict Level 2//",
+        "-//IETF//DTD HTML Strict Level 3//",
+        "-//IETF//DTD HTML Strict//",
+        "-//IETF//DTD HTML//",
+        "-//Metrius//DTD Metrius Presentational//",
+        "-//Microsoft//DTD Internet Explorer 2.0 HTML Strict//",
+        "-//Microsoft//DTD Internet Explorer 2.0 HTML//",
+        "-//Microsoft//DTD Internet Explorer 2.0 Tables//",
+        "-//Microsoft//DTD Internet Explorer 3.0 HTML Strict//",
+        "-//Microsoft//DTD Internet Explorer 3.0 HTML//",
+        "-//Microsoft//DTD Internet Explorer 3.0 Tables//",
+        "-//Netscape Comm. Corp.//DTD HTML//",
+        "-//Netscape Comm. Corp.//DTD Strict HTML//",
+        "-//O'Reilly and Associates//DTD HTML 2.0//",
+        "-//O'Reilly and Associates//DTD HTML Extended 1.0//",
+        "-//O'Reilly and Associates//DTD HTML Extended Relaxed 1.0//",
+        "-//SQ//DTD HTML 2.0 HoTMetaL + extensions//",
+        "-//SoftQuad Software//DTD HoTMetaL PRO 6.0::19990601::extensions to HTML 4.0//",
+        "-//SoftQuad//DTD HoTMetaL PRO 4.0::19971010::extensions to HTML 4.0//",
+        "-//Spyglass//DTD HTML 2.0 Extended//",
+        "-//Sun Microsystems Corp.//DTD HotJava HTML//",
+        "-//Sun Microsystems Corp.//DTD HotJava Strict HTML//",
+        "-//W3C//DTD HTML 3 1995-03-24//",
+        "-//W3C//DTD HTML 3.2 Draft//",
+        "-//W3C//DTD HTML 3.2 Final//",
+        "-//W3C//DTD HTML 3.2//",
+        "-//W3C//DTD HTML 3.2S Draft//",
+        "-//W3C//DTD HTML 4.0 Frameset//",
+        "-//W3C//DTD HTML 4.0 Transitional//",
+        "-//W3C//DTD HTML Experimental 19960712//",
+        "-//W3C//DTD HTML Experimental 970421//",
+        "-//W3C//DTD W3 HTML//",
+        "-//W3O//DTD W3 HTML 3.0//",
+        "-//WebTechs//DTD Mozilla HTML 2.0//",
+        "-//WebTechs//DTD Mozilla HTML//",
+    ];
+
+    /// <summary>
+    /// Public-identifier prefixes that select quirks mode only when the system identifier is missing
+    /// or empty; with one present these are limited-quirks instead.
+    /// </summary>
+    private static readonly string[] QuirksPublicIdentifierPrefixesWithoutSystemId =
+    [
+        "-//W3C//DTD HTML 4.01 Frameset//",
+        "-//W3C//DTD HTML 4.01 Transitional//",
+    ];
+
+    [GeneratedRegex(
+        """<!doctype\s+(?<name>[^\s>]+)(?:\s+(?<kind>public|system)\s+(?<first>"[^"]*"|'[^']*')(?:\s+(?<second>"[^"]*"|'[^']*'))?)?""",
+        RegexOptions.IgnoreCase)]
     private static partial Regex QuirksRegex();
 }

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxProperties.cs
@@ -2713,8 +2713,23 @@ internal abstract partial class CssBoxProperties
         BlockEllipsis = p.BlockEllipsis;
         WebkitBoxOrient = p.WebkitBoxOrient;
 
+        // HTML Rendering §Tables: in quirks mode a <table> starts the font and text properties from
+        // their initial values instead of inheriting them. Applied at the end of the inherited-value
+        // copy so that the element's own declarations, which the cascade applies next, still win —
+        // the spec states the reset as a UA-origin rule — and so that a descendant cell's percentage
+        // font-size, resolved eagerly when it is set, resolves against the reset size.
+        //
+        // Deliberately not on the `everything` path. That one is a *clone* rather than an
+        // inheritance: the inline-splitting code copies an already-cascaded box's own values onto
+        // the two halves it splits it into, carrying the original's HtmlTag with them, so re-running
+        // the reset there would throw away the author values the original had ended up with.
         if (!everything)
+        {
+            if (this is CssBox self && TableFontInheritanceQuirk.AppliesTo(self))
+                TableFontInheritanceQuirk.Apply(self);
+
             return;
+        }
 
         BackgroundColor = p.BackgroundColor;
         BackgroundGradient = p.BackgroundGradient;

--- a/Broiler.Layout/Broiler.Layout/Engine/TableFontInheritanceQuirk.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/TableFontInheritanceQuirk.cs
@@ -1,0 +1,97 @@
+using System;
+using Broiler.CSS;
+
+namespace Broiler.Layout.Engine;
+
+/// <summary>
+/// The quirks-mode table font reset from the HTML Standard's
+/// <see href="https://html.spec.whatwg.org/multipage/rendering.html#tables-2">Rendering</see>
+/// section: in quirks mode a <c>&lt;table&gt;</c> does not inherit its parent's font and text
+/// properties, but starts again from their initial values.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The spec states it as a UA rule that applies only in quirks mode:
+/// </para>
+/// <code>
+/// table {
+///   font-weight: initial; font-style: initial; font-variant: initial;
+///   font-size: initial; line-height: initial; white-space: initial; text-align: initial;
+/// }
+/// </code>
+/// <para>
+/// <b>Why it matters.</b> Legacy pages size their text with compounding percentages and nest
+/// tables for layout. www.7-zip.org is the canonical example: it is a quirks-mode document whose
+/// sheet says <c>BODY { font-size: 80% }</c> and <c>TD { font-size: 80% }</c>, and it nests tables
+/// three deep. Without the reset each <c>TD</c> resolves its 80% against the enclosing cell, so the
+/// text shrinks once per level — 12.8px, then 10.24px, then 8.19px, then 6.55px — and the page
+/// renders in a font nobody can read. With it, every table restarts at <c>medium</c> and every cell
+/// on the page is 12.8px, which is what browsers show. The engine was not resolving percentages
+/// wrongly: its chain matched the *standards-mode* chain exactly, and only the quirk was missing.
+/// </para>
+/// <para>
+/// <b>Why this runs during inheritance rather than as a pass over the finished tree,</b> unlike its
+/// neighbour <see cref="TablesInheritColorFromBodyQuirk"/>. That quirk has to run afterwards
+/// because it reads the *document's* body, which need not be an ancestor of the table and may not
+/// have been cascaded yet. This one reads nothing outside the box: it only declines to copy the
+/// parent's values. Doing it inline also gets the ordering right for free — the cascade is strictly
+/// top-down, so a cell's <c>80%</c> is resolved after its table has been reset and therefore
+/// against the reset size. A later pass could not fix that without re-resolving every descendant's
+/// font size, because <see cref="CssBoxProperties.FontSize"/> resolves percentages eagerly, at the
+/// moment they are set.
+/// </para>
+/// <para>
+/// <b>Author declarations still win.</b> The spec models this as a UA-origin rule, and the cascade
+/// applies element declarations after <c>InheritStyle</c> — so <c>table { font-size: 20px }</c> is
+/// applied over the reset, and an explicit <c>table { font-size: inherit }</c> still reaches the
+/// parent's value. Resetting during inheritance reproduces UA-origin precedence without needing a
+/// quirks-mode UA stylesheet, which the renderer does not have.
+/// </para>
+/// <para>
+/// <b>What is deliberately not reset.</b> <c>font-family</c> is absent from the spec's list and is
+/// inherited normally — a table on 7-Zip still gets the body's Verdana, only at the initial size.
+/// So are <c>letter-spacing</c>, <c>word-spacing</c>, <c>text-transform</c> and <c>font-stretch</c>.
+/// <c>color</c> is not reset here either; in quirks mode it has its own, different rule, which is
+/// <see cref="TablesInheritColorFromBodyQuirk"/>. Blink additionally resets <c>text-indent</c>,
+/// which is not in the spec's list; this follows the spec.
+/// </para>
+/// <para>
+/// The element is matched by tag name, not by <c>display: table</c>, because the spec's selector is
+/// an element selector — a <c>&lt;div style="display: table"&gt;</c> inherits normally.
+/// </para>
+/// </remarks>
+internal static class TableFontInheritanceQuirk
+{
+    /// <summary>
+    /// Whether <paramref name="box"/> is a <c>&lt;table&gt;</c> element in a quirks-mode document,
+    /// and so starts its font and text properties from the initial values.
+    /// </summary>
+    /// <remarks>
+    /// The tag test is first and the document-mode test second on purpose: this is consulted for
+    /// every box that inherits, and <see cref="CssBox.DocumentQuirksMode"/> walks to the tree root
+    /// and reads thread-affine state (<see cref="AmbientRenderState"/>). Ordering it after the tag
+    /// name keeps that walk to the handful of boxes that are actually tables.
+    /// </remarks>
+    internal static bool AppliesTo(CssBox box) =>
+        box.HtmlTag is { } tag
+        && tag.Name.Equals("table", StringComparison.OrdinalIgnoreCase)
+        && box.DocumentQuirksMode;
+
+    /// <summary>
+    /// Replaces the values <paramref name="box"/> just inherited from its parent with the initial
+    /// values of the seven properties the spec's rule names.
+    /// </summary>
+    internal static void Apply(CssBox box)
+    {
+        box.FontWeight = CssConstants.Normal;
+        box.FontStyle = CssConstants.Normal;
+        box.FontVariant = CssConstants.Normal;
+        box.FontSize = CssConstants.Medium;
+        box.LineHeight = CssConstants.Normal;
+        box.WhiteSpace = CssConstants.Normal;
+
+        // text-align's initial value is represented as the empty string throughout the box model
+        // (the layout code reads "" alongside "left"/"start"), not by a keyword.
+        box.TextAlign = string.Empty;
+    }
+}

--- a/docs/seven-zip-font-sizing-investigation.md
+++ b/docs/seven-zip-font-sizing-investigation.md
@@ -1,0 +1,257 @@
+# Why www.7-zip.org renders with very small fonts
+
+An investigation into the reported symptom: the real-world suite's `seven-zip`
+case (<https://www.7-zip.org/>) renders in Broiler with text far smaller than
+Chromium produces.
+
+**Two independent defects are involved**, and they mask each other. The page's
+stylesheet is currently dropped entirely, so today's CLI render shows *unstyled,
+too-large* text; the moment that first defect is fixed, the second one takes over
+and the page renders with the tiny text that was reported.
+
+| | Chromium | Broiler |
+| --- | --- | --- |
+| `TD` at table nesting depth 1 | 12.8px | 10.22px |
+| `TD` at table nesting depth 2 | 12.8px | 8.18px |
+| `TD` at table nesting depth 3 | 12.8px | 6.49px |
+
+Numbers measured with the calibrated probe described under
+[Measurement method](#measurement-method).
+
+## The page
+
+`https://www.7-zip.org/` is legacy HTML. Two properties of it drive everything
+below:
+
+1. Its doctype is `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">`
+   with **no system identifier**. That public identifier is on the HTML
+   Standard's unconditional quirks list, so the document is in **quirks mode** —
+   Chromium reports `document.compatMode === "BackCompat"`.
+2. Its stylesheet is linked root-relative, `<LINK href="/style.css" rel="stylesheet">`,
+   and consists almost entirely of compounding percentages:
+
+   ```css
+   BODY { font-family: Verdana, Arial, Helvetica; font-size: 80% }
+   TH   { font-size: 80% }
+   TD   { font-size: 80% }
+   H1   { text-align: center; font-size: 140% }
+   ```
+
+The page nests tables three deep (outer layout table → content-column table →
+data/news table), so `TD { font-size: 80% }` is encountered three times along a
+single ancestor chain.
+
+## Finding 1 — a root-relative stylesheet href is never fetched (Unix only)
+
+Rendering the page today produces **no styling at all**: `H1`/`H2` are not
+centred, no table has its background colour, and the body's 80% is absent. A
+request log from a local server confirms Broiler never asks for the sheet — it
+fetches only the document and `/7ziplogo.png`.
+
+Isolated with a matrix of link forms against a logging server (background set to
+lime by the linked sheet):
+
+| `href` form | doctype | sheet applied |
+| --- | --- | --- |
+| `probe.css` (document-relative) | HTML 4.0 Transitional | yes |
+| `/probe.css` (root-relative) | HTML 4.0 Transitional | **no** |
+| `probe.css`, uppercase `<LINK>` | HTML 4.0 Transitional | yes |
+| `/probe.css`, uppercase `<LINK>` | HTML 4.0 Transitional | **no** |
+| `/probe.css` | `<!DOCTYPE html>` | **no** |
+| `/probe.css`, unquoted attributes | HTML 4.0 Transitional | **no** |
+
+Tag case and doctype are irrelevant; the leading `/` is the whole trigger.
+
+### Root cause
+
+`Broiler.HTML/Source/Broiler.HTML.Orchestration/Handlers/StylesheetLoadHandler.cs`,
+`ResolveStylesheetSource`:
+
+```csharp
+if (Uri.TryCreate(src, UriKind.Absolute, out _))
+    return src;                                   // treated as already absolute
+```
+
+On Unix, `Uri.TryCreate("/style.css", UriKind.Absolute, out _)` returns **`true`**,
+yielding `file:///style.css`. (Verified directly: on the same runtime,
+`"probe.css"` returns `false` and `"/probe.css"` returns `true` with
+`Scheme == "file"`.) So the root-relative href is misclassified as absolute and
+returned unrebased. `LoadStylesheet` then takes the `uri.Scheme == "file"` branch
+and tries to read `/style.css` **off the local filesystem**, which does not exist —
+the failure is swallowed as a `CssParsing` error and the page renders unstyled.
+
+This is platform-specific: on Windows the same call returns `false`, so the sheet
+would resolve and load correctly. That asymmetry is a plausible reason it has gone
+unnoticed.
+
+The correct idiom already exists a few files away, in
+`HtmlContainerInt.TryResolveHttpFontUrl`, which guards the same call with a scheme
+check:
+
+```csharp
+if (Uri.TryCreate(src, UriKind.Absolute, out var abs) && IsHttp(abs))
+```
+
+**Confirmed by experiment.** Adding the equivalent guard to
+`ResolveStylesheetSource` and rebuilding makes the root-relative probe fetch and
+apply its sheet (`GET /probe.css` appears in the request log, background turns
+lime), and makes the live 7-Zip page load `style.css`. The change was reverted
+after measuring; no submodule edit is carried in this branch.
+
+`HtmlContainerInt.ResolveHref` (used for link clicks and form actions) contains the
+same unguarded idiom and is likely affected in the same way. Image loading is *not*
+affected — `/7ziplogo.png` resolves and loads correctly through a different path.
+
+## Finding 2 — the quirks-mode table font reset is not implemented
+
+This is the actual cause of the small fonts. With the stylesheet loading, Broiler
+renders 7-Zip with text at roughly half Chromium's size, shrinking further with
+each level of table nesting.
+
+In quirks mode a `<table>` does **not** inherit the font properties of its parent.
+The HTML Standard's Rendering section specifies it directly:
+
+> In quirks mode, the following rules are also expected to apply:
+>
+> ```css
+> @namespace "http://www.w3.org/1999/xhtml";
+> table {
+>   font-weight: initial;
+>   font-style: initial;
+>   font-variant: initial;
+>   font-size: initial;
+>   line-height: initial;
+>   white-space: initial;
+>   text-align: initial;
+> }
+> ```
+
+Because of this, on 7-Zip every `<table>` resets to 16px and each `TD { font-size:
+80% }` resolves against 16px — so **every** cell is 12.8px, no matter how deep.
+Broiler inherits `font-size` into the table instead, so the 80% compounds:
+12.8 → 10.24 → 8.19 → 6.55px.
+
+Measured in Chromium against the same probe, quirks vs. standards mode:
+
+| | body | `table` d1 | `td` d1 | `table` d2 | `td` d2 |
+| --- | --- | --- | --- | --- | --- |
+| Quirks (`BackCompat`) | 12.8px | 16px | 12.8px | 16px | 12.8px |
+| Standards (`CSS1Compat`) | 12.8px | 12.8px | 10.24px | 10.24px | 8.192px |
+
+Broiler's numbers match the **standards-mode** column exactly. The cascade is
+behaving correctly; what is missing is the quirks-mode reset.
+
+Probing which properties actually reset on a `<table>` in Chromium's quirks mode
+reproduces the spec list, plus `text-indent`:
+
+| Reset on `<table>` | Inherited normally |
+| --- | --- |
+| `font-size` → `medium` | `font-family` |
+| `font-weight` → `normal` | `font-stretch` |
+| `font-style` → `normal` | `letter-spacing` |
+| `font-variant` → `normal` | `word-spacing` |
+| `line-height` → `normal` | `text-transform` |
+| `white-space` → `normal` | `color` (has its own separate quirk) |
+| `text-align` → `start` | |
+| `text-indent` → `0` (Blink extra, not in the spec list) | |
+
+Note `font-size: initial` resolves to `medium`, which is the *default size for the
+resolved font family* — 16px for proportional families but 13px for `monospace`.
+Chromium reproduces that; a body at `200%` or at `10px` both yield a 13px
+monospace table.
+
+### Where it belongs
+
+Broiler currently has **no quirks-mode UA stylesheet at all**. `CssDefaults.cs`
+carries a single unconditional sheet, and searching `Broiler.HTML.Core` and
+`Broiler.CSS` for quirks handling returns nothing. The two quirks that do exist are
+implemented ad hoc in `Broiler.Layout`:
+
+- `Broiler.Layout/Engine/TablesInheritColorFromBodyQuirk.cs` — the colour quirk,
+  applied as a pass over the finished box tree.
+- The body/html fill-viewport behaviour, via `DocumentModeContext.CurrentQuirksMode`.
+
+`DocumentModeContext.CurrentQuirksMode` is already published on both render paths
+and cached on the tree root, and `CssBox.DocumentQuirksMode` is already how
+`TablesInheritColorFromBodyQuirk` gates itself — so the quirks-mode signal needed
+here is in place. The reset is a natural sibling of the existing colour quirk, and
+`TablesInheritColorFromBodyQuirk` is a good structural precedent for it (including
+its handling of re-inheritance into descendants after the value changes).
+
+One caveat for whoever implements it: `DocumentModeContext.IsQuirksHtml` decides
+quirks mode with a regex that only accepts a bare `<!DOCTYPE html>` as standards
+mode. That happens to give the right answer for 7-Zip, but it is not the HTML
+Standard's algorithm — `HTML 4.01 Transitional` **with** a system identifier is
+limited-quirks, not full quirks, and would be misclassified. Worth checking which
+of the two quirks-mode sources actually feeds the render path before relying on it
+for a new rule.
+
+### Verification
+
+Injecting the spec's seven declarations into the page as an author rule and
+re-rendering:
+
+- The calibrated probe reports **12.80px at all three nesting depths**, matching
+  Chromium exactly (was 10.22 / 8.18 / 6.49px).
+- The full 7-Zip page renders at Chromium's typographic scale; content-match
+  against the Chromium reference rises from 17.5% to 22.2%.
+
+The residual gap is unrelated to font sizing — `TABLE.News { width: 220px }` is not
+honoured, `TD.NewsTitle { color: white }` does not apply, and cell padding differs.
+Those are separate issues and were not investigated here.
+
+## Measurement method
+
+Broiler's CLI has no computed-style dump, so font sizes were measured optically
+with a self-calibrating probe. A single page carries a ladder of `<div>`s at known
+absolute sizes (16, 12.8, 11.2, 10.24, 8.192, 6.554, 5.243, 4.194px) followed by
+the nested-table structure under test, all in one font family and the same
+16-character string. The render is scanned for horizontal bands of ink; band width
+is linear in font size, so the ladder converts a measured width directly into a
+size. Recovered ladder values were 16.00, 12.80, 11.20, 10.22, 8.18, 6.58, 5.24 and
+4.18px against nominals — accurate to well under a tenth of a pixel, which bounds
+the error on the reported cell sizes.
+
+Both engines were pointed at a byte-identical local snapshot of the page served
+over `127.0.0.1`, so the comparison is not subject to live-site drift. Chromium's
+side is read directly from `getComputedStyle`.
+
+## Adjacent finding (not a contributor here)
+
+Broiler's absolute-size keyword table is *additive in points* rather than the CSS
+scaling table. From `CssBoxProperties.ComputedFontSizePoints` (and duplicated near
+line 2170 of the same file), `xx-small` is `medium - 4pt`, `x-large` is
+`medium + 3pt`, and so on. Measured against spec:
+
+| keyword | Broiler | CSS |
+| --- | --- | --- |
+| `xx-small` | 10.7px | 9px |
+| `x-small` | 12.0px | 10px |
+| `small` | 13.3px | 13px |
+| `medium` | 16.0px | 16px |
+| `large` | 18.6px | 18px |
+| `x-large` | 20.0px | 24px |
+| `xx-large` | 21.3px | 32px |
+
+7-Zip uses no keyword sizes, so this does not contribute to the reported symptom.
+It is worth noting only because the fix for Finding 2 is expressed as
+`font-size: initial` — which resolves to `medium`, the one entry Broiler already
+gets right.
+
+## Ruled out
+
+- **Broiler's default font size.** `CssMetrics.DefaultFontSizePt` is 12pt = 16px,
+  matching the browser default; the root and `<body>` resolve correctly.
+- **Percentage font-size resolution.** Percentages resolve against the parent's
+  computed size and are eagerly resolved to an absolute length by the `FontSize`
+  setter, so an inheriting descendant does not re-apply them. Broiler's chain
+  matches Chromium's standards-mode chain exactly, which would not happen if
+  percentage handling were wrong.
+- **Uppercase tag/selector matching.** The page and its stylesheet are uppercase
+  throughout; type selectors match case-insensitively, and the link matrix above
+  shows tag case makes no difference.
+- **A missing minimum font size.** Chromium applies a 6px "smart minimum" to sizes
+  derived from percentages and keywords, and Broiler has no equivalent clamp. On
+  this page Chromium never goes below 12.8px, so the clamp is never reached and is
+  not what separates the two engines. It would only matter as a safety net for the
+  compounding in Finding 2 — which is better fixed at its cause.

--- a/docs/seven-zip-font-sizing-investigation.md
+++ b/docs/seven-zip-font-sizing-investigation.md
@@ -5,18 +5,22 @@ case (<https://www.7-zip.org/>) renders in Broiler with text far smaller than
 Chromium produces.
 
 **Two independent defects are involved**, and they mask each other. The page's
-stylesheet is currently dropped entirely, so today's CLI render shows *unstyled,
-too-large* text; the moment that first defect is fixed, the second one takes over
-and the page renders with the tiny text that was reported.
+stylesheet was dropped entirely, so the CLI render showed *unstyled, too-large*
+text; the moment that first defect is fixed, the second one takes over and the
+page renders with the tiny text that was reported.
 
-| | Chromium | Broiler |
-| --- | --- | --- |
-| `TD` at table nesting depth 1 | 12.8px | 10.22px |
-| `TD` at table nesting depth 2 | 12.8px | 8.18px |
-| `TD` at table nesting depth 3 | 12.8px | 6.49px |
+| | Chromium | Broiler (before) | Broiler (after) |
+| --- | --- | --- | --- |
+| `TD` at table nesting depth 1 | 12.8px | 10.22px | 12.80px |
+| `TD` at table nesting depth 2 | 12.8px | 8.18px | 12.80px |
+| `TD` at table nesting depth 3 | 12.8px | 6.49px | 12.80px |
 
 Numbers measured with the calibrated probe described under
 [Measurement method](#measurement-method).
+
+**Both are fixed**; see [Resolution](#resolution). One of the two lives in the
+`Broiler.HTML` submodule and ships as a patch under `patches/`, because the
+submodule remote is outside this session's GitHub scope.
 
 ## The page
 
@@ -95,8 +99,8 @@ if (Uri.TryCreate(src, UriKind.Absolute, out var abs) && IsHttp(abs))
 **Confirmed by experiment.** Adding the equivalent guard to
 `ResolveStylesheetSource` and rebuilding makes the root-relative probe fetch and
 apply its sheet (`GET /probe.css` appears in the request log, background turns
-lime), and makes the live 7-Zip page load `style.css`. The change was reverted
-after measuring; no submodule edit is carried in this branch.
+lime), and makes the live 7-Zip page load `style.css`. This is the fix that
+shipped, as a submodule patch.
 
 `HtmlContainerInt.ResolveHref` (used for link clicks and form actions) contains the
 same unguarded idiom and is likely affected in the same way. Image loading is *not*
@@ -178,27 +182,61 @@ here is in place. The reset is a natural sibling of the existing colour quirk, a
 `TablesInheritColorFromBodyQuirk` is a good structural precedent for it (including
 its handling of re-inheritance into descendants after the value changes).
 
-One caveat for whoever implements it: `DocumentModeContext.IsQuirksHtml` decides
-quirks mode with a regex that only accepts a bare `<!DOCTYPE html>` as standards
-mode. That happens to give the right answer for 7-Zip, but it is not the HTML
-Standard's algorithm — `HTML 4.01 Transitional` **with** a system identifier is
-limited-quirks, not full quirks, and would be misclassified. Worth checking which
-of the two quirks-mode sources actually feeds the render path before relying on it
-for a new rule.
+### The quirks-mode flag was itself wrong, and 7-Zip was on the wrong side of it
+
+`DocumentModeContext.IsQuirksHtml` decided the mode from the doctype **name**
+alone: no doctype, or a name that is not `html`, meant quirks. 7-Zip's doctype is
+`<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">`, whose name *is*
+`html` — so the page was classified **standards mode**, and every quirks-mode
+behaviour keyed off the flag (the body/html viewport fill, the colour quirk, and
+the reset above) was silently inert on it. `WptDocumentRenderer.SelectsQuirksMode`
+had the same limitation independently.
+
+This is not a detail that can be deferred: the whole point of the reset is legacy
+pages, and legacy pages are exactly the ones that declare a public identifier. The
+fix implements the HTML Standard's DOCTYPE conditions — the exact-match and
+prefix lists for the public identifier, the listed system identifier, and the
+HTML 4.01 Transitional/Frameset rule whose answer depends on whether a system
+identifier is present (full quirks without one, limited-quirks with one, and
+limited-quirks is not what this predicate reports).
 
 ### Verification
 
-Injecting the spec's seven declarations into the page as an author rule and
-re-rendering:
-
-- The calibrated probe reports **12.80px at all three nesting depths**, matching
-  Chromium exactly (was 10.22 / 8.18 / 6.49px).
-- The full 7-Zip page renders at Chromium's typographic scale; content-match
-  against the Chromium reference rises from 17.5% to 22.2%.
+With the reset in place the calibrated probe reports **12.80px at all three
+nesting depths**, matching Chromium exactly (was 10.22 / 8.18 / 6.49px), and the
+full 7-Zip page renders at Chromium's typographic scale.
 
 The residual gap is unrelated to font sizing — `TABLE.News { width: 220px }` is not
 honoured, `TD.NewsTitle { color: white }` does not apply, and cell padding differs.
 Those are separate issues and were not investigated here.
+
+## Resolution
+
+| defect | where the fix lives | ships as |
+| --- | --- | --- |
+| Root-relative stylesheet href read off the local disk | `Broiler.HTML`, `StylesheetLoadHandler.ResolveStylesheetSource` | `patches/0001-stylesheet-root-relative-href.patch` |
+| Quirks-mode table font reset missing | `Broiler.Layout.Engine.TableFontInheritanceQuirk`, applied from `CssBoxProperties.InheritStyle` | in-repo |
+| Quirks mode decided from the doctype name alone | `Broiler.Layout.DocumentModeContext.IsQuirksHtml` | in-repo |
+
+The reset runs during inheritance rather than as a pass over the finished tree,
+which is what separates it from its neighbour `TablesInheritColorFromBodyQuirk`.
+That quirk has to run afterwards because it reads the *document's* body, which need
+not be an ancestor. This one reads nothing outside the box — it only declines to
+copy the parent's values — and doing it inline gets the ordering right for free:
+the cascade is strictly top-down, so a cell's `80%` is resolved after its table has
+been reset. A later pass could not fix that without re-resolving every descendant's
+font size, because `FontSize` resolves percentages eagerly when they are set. It is
+also what gives the spec's UA-origin precedence for free: the element's own
+declarations are applied next and still win.
+
+The submodule half could not be pushed — the git proxy answers 403 for
+`Broiler-Platform/Broiler.HTML`, which is outside this session's GitHub scope — so
+it follows the repository's patch workflow: committed in the submodule, exported
+with `git format-patch`, the working tree reverted, and **the gitlink left
+unbumped**. It is registered in `scripts/apply-pending-wpt-patches.sh`, which the
+real-world render workflow runs, so the `seven-zip` case exercises the fix rather
+than testing against the un-fixed pointer. Until a maintainer applies it, a build
+from the pinned pointer still drops the sheet and renders 7-Zip unstyled.
 
 ## Measurement method
 

--- a/patches/0001-stylesheet-root-relative-href.patch
+++ b/patches/0001-stylesheet-root-relative-href.patch
@@ -1,0 +1,53 @@
+From 304e3403cfff07f5cada742d8d68a8097f3786c2 Mon Sep 17 00:00:00 2001
+From: Claude <enrico.bartky@gmail.com>
+Date: Thu, 13 Aug 2026 11:34:24 +0000
+Subject: [PATCH] Fetch a root-relative stylesheet href from the origin, not
+ the filesystem
+
+ResolveStylesheetSource asked "is this already absolute?" with
+Uri.TryCreate(src, UriKind.Absolute). On Unix that is not the same question:
+"/style.css" parses absolute there, as file:///style.css. So a root-relative
+<link href> looked already-resolved, was never rebased on the document URL, and
+LoadStylesheet then took its file: branch and looked for the sheet on the local
+disk. The miss is swallowed as a CssParsing error, so the page simply renders
+unstyled -- www.7-zip.org, which links its sheet that way, got none of its CSS.
+
+Windows returns false for the same call, so the page styled correctly there,
+which is the likely reason this went unnoticed.
+
+Guard the test with a scheme check, the way TryResolveHttpFontUrl in
+HtmlContainerInt already does for @font-face src. A genuine file: URL is
+unaffected: it falls through to the rebase, and resolving an absolute URI
+against a base returns that URI unchanged.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01D9m1eA7NK5gH85o9TsycrZ
+---
+ .../Handlers/StylesheetLoadHandler.cs                 | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/Source/Broiler.HTML.Orchestration/Handlers/StylesheetLoadHandler.cs b/Source/Broiler.HTML.Orchestration/Handlers/StylesheetLoadHandler.cs
+index ea14b57..c3c32c3 100644
+--- a/Source/Broiler.HTML.Orchestration/Handlers/StylesheetLoadHandler.cs
++++ b/Source/Broiler.HTML.Orchestration/Handlers/StylesheetLoadHandler.cs
+@@ -88,7 +88,16 @@ internal sealed class StylesheetLoadHandler : IStylesheetLoader
+         if (string.IsNullOrWhiteSpace(src))
+             return src;
+ 
+-        if (Uri.TryCreate(src, UriKind.Absolute, out _))
++        // Only a src that is absolute *and carries a real scheme* is already resolved. The
++        // UriKind.Absolute test alone is not that question on Unix: there, "/style.css" parses
++        // absolute, as file:///style.css, so a root-relative href looked already-resolved, was
++        // never rebased on the document URL, and was then read off the local filesystem instead of
++        // being fetched from the page's origin — the sheet silently did not apply (www.7-zip.org
++        // links its stylesheet that way). On Windows the same call returns false, which is why the
++        // page styled correctly there. A genuine file: URL still resolves as before, because the
++        // rebase below leaves an absolute file: src unchanged.
++        if (Uri.TryCreate(src, UriKind.Absolute, out var absolute)
++            && absolute.Scheme != Uri.UriSchemeFile)
+             return src;
+ 
+         if (!string.IsNullOrWhiteSpace(_htmlContainer.BaseUrl) &&
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,88 @@
+# Submodule patches waiting to be applied
+
+**One patch is waiting on a maintainer.** See the index below.
+
+`Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
+are git submodules with their own remotes. A session whose GitHub scope is this
+repository alone cannot push to them — the git proxy answers **403** — so a fix
+that belongs in a submodule is committed there, exported with
+`git format-patch`, and left here for a maintainer to apply. The submodule
+working tree is then reverted to its pinned commit and **the gitlink is not
+bumped**: CI clones a submodule by pointer, and a pointer to a commit that was
+never pushed would break the build.
+
+Applying one:
+
+```sh
+cd <Submodule>
+git checkout -b <branch> && git am ../patches/NNNN-<slug>.patch
+git push origin HEAD
+cd .. && git add <Submodule>      # bump the pointer only once the push succeeds
+```
+
+## This directory is a backlog, not an archive
+
+A patch is deleted from here the moment its fix is upstream and the submodule
+pointer is bumped, because from then on it reaches CI through the pointer and a
+file that can only ever be skipped is noise. `scripts/apply-pending-wpt-patches.sh`
+holds the matching list — the subset whose fix can move rendered pixels, so a
+WPT run exercises it rather than testing against the un-fixed pointer — and is
+idempotent, so a patch already contained in the pinned pointer is skipped rather
+than re-applied.
+
+**Check the pointer, not this file, before concluding a fix is pending.** The
+numbering is *recycled*: numbers are assigned from `0001` against whatever the
+directory holds at the time, so a patch number in an older commit message, code
+comment or document does **not** identify the same change as today's patch of
+that number. Prose that names a patch by number alone is evidence about the past
+only. To decide whether a submodule fix is live, look for its commit:
+
+```sh
+git -C <Submodule> log --oneline --grep '<the commit subject>'
+git -C <Submodule> merge-base --is-ancestor <sha> HEAD && echo "live on CI"
+```
+
+## The index
+
+| # | submodule | subject |
+| --- | --- | --- |
+| `0001` | `Broiler.HTML` | Fetch a root-relative stylesheet href from the origin, not the filesystem |
+
+### `0001` — a root-relative `<link href>` was read off the local disk
+
+`ResolveStylesheetSource` decided "is this href already absolute?" with
+`Uri.TryCreate(src, UriKind.Absolute)`. On Unix that is a different question from
+the one it means to ask: `/style.css` parses absolute there, as
+`file:///style.css`. So a root-relative href looked already-resolved, was never
+rebased on the document URL, and `LoadStylesheet` then took its `file:` branch and
+looked for the sheet on the local filesystem. The miss is swallowed as a
+`CssParsing` error, so the page renders **completely unstyled** with no diagnostic
+and no HTTP request. On Windows the same call returns `false`, so the sheet loaded
+correctly there — which is the likely reason it went unnoticed.
+
+The fix is the scheme guard `HtmlContainerInt.TryResolveHttpFontUrl` already
+applies to the same call for `@font-face src`. Ten lines, eight of them comment.
+
+**Why it is listed for the pixel suites.** www.7-zip.org links its stylesheet as
+`<LINK href="/style.css">`, so the `seven-zip` case of the real-world render suite
+renders with none of the page's CSS until this is applied — no table backgrounds,
+no centred headings, and the body's `font-size: 80%` absent. That is as
+pixel-moving as a change gets. The real-world workflow runs
+`scripts/apply-pending-wpt-patches.sh`, which is where the entry lives.
+
+**It does not move WPT pixels**, and that is not an oversight. The WPT runner
+installs its own stylesheet-load handler (`WptTestRunner`, the `wptRoot` mapper)
+that resolves root-relative paths such as `/fonts/ahem.css` to local files and
+hands them back through `args.SetSrc` — which short-circuits
+`ResolveStylesheetSource` entirely. WPT never exercised the broken path, which is
+the second reason this survived so long.
+
+**The main-repo half of the same investigation is already in the tree** and needs
+nothing from this patch: the quirks-mode table font reset
+(`Broiler.Layout.Engine.TableFontInheritanceQuirk`) and the DOCTYPE public-identifier
+half of `DocumentModeContext.IsQuirksHtml`. They are what make 7-Zip's nested-table
+text the right *size*; this patch is what makes its stylesheet *arrive*. Applying
+this one without them renders the page styled but in a ~6px font.
+
+**When it lands upstream:** bump the pointer, delete this patch and its entry in
+`scripts/apply-pending-wpt-patches.sh`.

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -118,14 +118,22 @@ set -euo pipefail
 # Broiler.Layout's SvgRenderer") landed upstream as Broiler.HTML c77f0f0 and its pointer
 # is bumped, so it reaches CI through the pointer and its entry is gone with it.
 #
-# 0001 (Broiler.HTML, object-fit and object-position at the paint site) is listed because
-# without it EmitReplacedImage draws every replaced element into its content box — `fill`
-# behaviour whatever the author wrote — and background-position keeps reading a <position>
-# positionally, which drops the three- and four-component edge-offset forms silently. Both
-# are plainly pixel-moving, and between them they are 28 tests in css/css-images alone. Its
-# logic is all main-repo (Broiler.Layout.IR.ObjectFitPlacement and IR.CssPositionValue);
-# this patch is the call site. See patches/README.md.
+# The object-fit patch that was 0001 before this one ("paint: place replaced content by
+# object-fit and object-position") landed upstream as Broiler.HTML d762937 and its pointer
+# is bumped, so it reaches CI through the pointer and its entry is gone with it. That
+# emptied patches/ entirely, which is why the numbering restarts at 0001 below.
+#
+# 0001 (Broiler.HTML, root-relative stylesheet href) is listed because without it a
+# `<link href="/style.css">` is looked for on the local filesystem instead of being fetched
+# from the page's origin, so the sheet silently does not apply and the page renders wholly
+# unstyled. That is the `seven-zip` case of the real-world render suite, whose workflow also
+# runs this script. It moves no WPT pixels — the WPT runner installs its own `wptRoot`
+# stylesheet handler, which resolves root-relative paths through args.SetSrc before this
+# code is reached, and that is also why the bug survived so long — but it is listed because
+# the real-world suite is a pixel suite too, and there it is the difference between a styled
+# page and none. See patches/README.md.
 PENDING_PATCHES=(
+  "Broiler.HTML|patches/0001-stylesheet-root-relative-href.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary

Fixes two independent defects that caused www.7-zip.org to render with extremely small fonts in Broiler. The first prevented root-relative stylesheet hrefs from loading on Unix; the second was a missing quirks-mode table font reset specified by the HTML Standard.

## Changes

### 1. Root-relative stylesheet href fetched from filesystem instead of origin (Broiler.HTML patch)

**Problem:** On Unix, `Uri.TryCreate("/style.css", UriKind.Absolute)` returns `true` and parses as `file:///style.css`. This caused root-relative stylesheet links to be misclassified as absolute, never rebased on the document URL, and then read off the local filesystem instead of being fetched from the page's origin. The failure was silently swallowed as a CSS parsing error, leaving pages completely unstyled. Windows was unaffected because the same call returns `false` there.

**Fix:** Guard the absolute-URI test with a scheme check (already used in `HtmlContainerInt.TryResolveHttpFontUrl` for `@font-face src`). A genuine `file:` URL is unaffected—resolving an absolute URI against a base returns that URI unchanged.

**Delivered as:** `patches/0001-stylesheet-root-relative-href.patch` (submodule push denied; pointer left unbumped per workflow)

### 2. Quirks-mode table font reset not implemented

**Problem:** The HTML Standard specifies that in quirks mode, `<table>` elements do not inherit font properties from their parent but reset to initial values. This is critical for legacy pages that use compounding percentages with nested tables. www.7-zip.org declares `BODY { font-size: 80% }` and `TD { font-size: 80% }` across three levels of table nesting. Without the reset, each cell's 80% compounds against the enclosing cell (12.8px → 10.24px → 8.19px → 6.55px). With it, every table resets to `medium` (16px) and every cell resolves to 12.8px, matching browser behavior.

**Root cause:** The quirks-mode flag itself was also broken—it decided the mode from the doctype *name* alone, ignoring the public and system identifiers. www.7-zip.org's doctype is `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">`, whose name *is* `html`, so it was classified as standards mode and all quirks-mode behaviors were silently inert.

**Fixes:**
- **`DocumentModeContext.IsQuirksHtml`:** Reimplemented to follow the HTML Standard's DOCTYPE conditions—exact-match and prefix lists for public identifiers, the listed system identifier, and the HTML 4.01 Transitional/Frameset rule (full quirks without system ID, limited-quirks with one).
- **`TableFontInheritanceQuirk`:** New engine that resets `font-weight`, `font-style`, `font-variant`, `font-size`, `line-height`, `white-space`, and `text-align` to initial values for `<table>` elements in quirks mode. Applied during `CssBoxProperties.InheritStyle` so that the cascade ordering is correct (element declarations applied next still win) and percentage font-sizes resolve against the reset size.
- **`CssBoxProperties.InheritStyle`:** Calls the quirk at the end of inherited-value copy.

**Delivered as:** In-repo changes to `Broiler.Layout`

### 3. Test coverage

- **`DocumentModeContextTests`:** Validates DOCTYPE parsing against the HTML Standard's conditions, including the 7-Zip doctype and the full HTML 4.x family.
- **`TableFontInheritanceQuirkTests`:** Verifies the reset applies only in quirks mode, only to `<table>` elements (not `display: table`), that percentages don't compound through nested tables, that author declarations override the reset, and that `font-family` is still inherited.

## Measurement

Fonts were measured optically using a self

https://claude.ai/code/session_01D9m1eA7NK5gH85o9TsycrZ