### PR TITLE
Make window the global object, not a separate object

### DIFF
--- a/docs/architecture/htmlbridge.md
+++ b/docs/architecture/htmlbridge.md
@@ -89,6 +89,22 @@ under [`src/Broiler.Cli.Tests`](../../src/Broiler.Cli.Tests/).
 6. Session disposal tears down queued work, layout resources, bridge state, and
    the JavaScript context.
 
+`window` is the global object, not a separate object published under that name.
+A page's `window.x = …` and its unqualified `x` therefore name one property, in
+one script as in the next, which is what every real page assumes. The bridge
+formerly published a distinct `window` and copied its members onto the global
+afterwards; that copy could never cover a write and a read inside a single
+script, because no host runs between them. `MirrorWindowMembersOntoGlobal` and
+its public re-run `SyncWindowMembersOntoGlobal` are retained but return
+immediately when the two are the same object.
+
+A nested browsing context still gets its own `window`, built by
+`SubWindowBinding`. Frame scripts run in the shared context with the
+`window`/`document`/`location`/`parent`/`self`/`top` globals swapped to that
+frame for the duration (`WindowContextManager.RunWithWindowContext`), and a
+top-level window is its own `parent`, so any walk up the frame tree must stop
+at the window that parents itself.
+
 ## Layout and geometry
 
 `DomBridge` obtains real box geometry through the neutral

--- a/src/Broiler.Cli.Tests/WindowGlobalSyncTests.cs
+++ b/src/Broiler.Cli.Tests/WindowGlobalSyncTests.cs
@@ -5,16 +5,23 @@ using Broiler.JavaScript.Engine;
 namespace Broiler.Cli.Tests;
 
 /// <summary>
-/// <c>DomBridge.SyncWindowMembersOntoGlobal</c>: the window → global mirror re-run over whatever
-/// the scripts that have run since last time added to <c>window</c>.
+/// A member a script adds to <c>window</c> is reachable unqualified — the behaviour
+/// <c>DomBridge.SyncWindowMembersOntoGlobal</c> used to have to manufacture.
 /// <para>
 /// In a browser <c>window</c> <em>is</em> the global object, so a library's
-/// <c>window.foo = …</c> makes the unqualified <c>foo</c> work for free. The bridge keeps the two
-/// apart, so that unqualified reference is a <c>ReferenceError</c> — which aborts the whole
-/// <c>&lt;script&gt;</c> that made it, not just the one statement. That is the shape of every WPT
+/// <c>window.foo = …</c> makes the unqualified <c>foo</c> work for free. The bridge used to keep the
+/// two apart, which made that reference a <c>ReferenceError</c> — and that aborts the whole
+/// <c>&lt;script&gt;</c> which made it, not just the one statement. That is the shape of every WPT
 /// support library, <c>/css/support/interpolation-testcommon.js</c> most of all: it exports
 /// <c>test_interpolation</c> and five siblings, and each of the ~100 <c>*-interpolation</c> tests
-/// calls them unqualified from its own inline script (issue #1552 problems 4, 18 and 22).
+/// calls them unqualified from its own inline script (issue #1552 problems 4, 18 and 22). The sync
+/// closed that gap after the fact, once per script, and every host had to remember to call it.
+/// </para>
+/// <para>
+/// The bridge now makes <c>window</c> the global object outright
+/// (<see cref="WindowIsTheGlobalObjectTests"/>), so these hold with no sync at all — asserted here
+/// <em>before</em> the sync runs, because that is the property the pages depend on. The sync itself
+/// stays exercised: it is public API a host may still call, and it must remain harmless.
 /// </para>
 /// </summary>
 public sealed class WindowGlobalSyncTests
@@ -35,20 +42,20 @@ public sealed class WindowGlobalSyncTests
         context.Eval($"String({expression})").ToString();
 
     /// <summary>
-    /// The bug itself: a member a script adds to <c>window</c> is not reachable unqualified until
-    /// the mirror is re-run. Both halves are asserted, so a change that made the two objects one
-    /// (the real fix, were the bridge ever to make <c>window</c> the global object) fails the
-    /// first assertion loudly rather than silently making the test vacuous.
+    /// The bug this file was written for: a member a script adds to <c>window</c> used to be
+    /// unreachable unqualified until the mirror was re-run. It is reachable immediately now, so the
+    /// assertion is made before the sync — the sync is then run to prove it changes nothing.
     /// </summary>
     [Fact]
-    public void RuntimeWindowMember_IsUnreachableUnqualified_UntilSynced()
+    public void RuntimeWindowMember_IsReachableUnqualified_WithoutSyncing()
     {
         var (context, bridge) = Attach();
         using var _ = context;
         using var __ = bridge;
 
         context.Eval("window.test_interpolation = function() { return 'called'; };");
-        Assert.Equal("undefined", TypeOf(context, "typeof test_interpolation === 'undefined' ? undefined : test_interpolation"));
+        Assert.Equal("function", TypeOf(context, "test_interpolation"));
+        Assert.Equal("called", ValueOf(context, "test_interpolation()"));
 
         bridge.SyncWindowMembersOntoGlobal();
 
@@ -132,20 +139,32 @@ Object.defineProperty(window, 'liveTick', { configurable: true, get: function() 
     }
 
     /// <summary>
-    /// A name the global already has wins: the sweep fills gaps and never overwrites, so an engine
-    /// builtin cannot be shadowed by a same-named window member.
+    /// Publishing the DOM surface leaves the engine's own builtins intact — <c>window.document</c>,
+    /// <c>window.location</c> and the rest land on the global object itself now, so a name collision
+    /// would overwrite a builtin outright rather than being skipped by a gap-filling sweep.
+    /// <para>
+    /// A <em>page</em> that assigns <c>window.JSON = …</c> does replace the global <c>JSON</c>, and
+    /// that is correct: those are writable, configurable properties of the global object, and a
+    /// browser lets a page clobber them exactly this way. The guarantee is about registration, not
+    /// about defending the realm from the page.
+    /// </para>
     /// </summary>
     [Fact]
-    public void ExistingGlobal_IsNotOverwritten()
+    public void EngineBuiltins_SurviveRegistration()
     {
         var (context, bridge) = Attach();
         using var _ = context;
         using var __ = bridge;
 
-        context.Eval("window.JSON = 'not the real JSON';");
         bridge.SyncWindowMembersOntoGlobal();
 
         Assert.Equal("function", TypeOf(context, "JSON.stringify"));
+        Assert.Equal("function", TypeOf(context, "Object"));
+        Assert.Equal("function", TypeOf(context, "Array"));
+        Assert.Equal("function", TypeOf(context, "Promise"));
+        Assert.Equal("object", TypeOf(context, "Math"));
+        Assert.Equal("function", TypeOf(context, "setTimeout"));
+        Assert.Equal("object", TypeOf(context, "document"));
     }
 
     /// <summary>

--- a/src/Broiler.Cli.Tests/WindowIsTheGlobalObjectTests.cs
+++ b/src/Broiler.Cli.Tests/WindowIsTheGlobalObjectTests.cs
@@ -1,0 +1,136 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// <c>window</c> is the global object, as it is in a browser.
+/// <para>
+/// The bridge used to publish <c>window</c> as a <em>separate</em> <c>JSObject</c> and copy its
+/// members onto the global afterwards (<c>MirrorWindowMembersOntoGlobal</c>). That covers the
+/// members the bridge itself installs, and — via <c>SyncWindowMembersOntoGlobal</c>, if the host
+/// remembers to call it between scripts — the ones a page adds. It cannot cover a page that writes
+/// <c>window.x</c> and reads the unqualified <c>x</c> <em>inside one script</em>: there is no moment
+/// between the two at which a host could run.
+/// </para>
+/// <para>
+/// That is not a hypothetical. It is how google.com bootstraps, in its first real inline script:
+/// <c>window.google=_g</c> in one IIFE and <c>google.sn='webhp'</c> in the next. The unqualified read
+/// raised <c>ReferenceError: google is not defined</c>, which aborts the whole
+/// <c>&lt;script&gt;</c> — so the <c>google</c> namespace was never finished, and every later script
+/// on the page died on the same name. The rendered page had none of its script-driven content.
+/// </para>
+/// </summary>
+public sealed class WindowIsTheGlobalObjectTests
+{
+    private static (JSContext Context, DomBridge Bridge) Attach(string url = "https://www.google.com/")
+    {
+        var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, "<!doctype html><html><body></body></html>", url);
+        return (context, bridge);
+    }
+
+    private static string ValueOf(JSContext context, string expression) =>
+        context.Eval($"String({expression})").ToString();
+
+    /// <summary>
+    /// The identity itself, plus the three self-references a browser exposes alongside it. A
+    /// top-level window is its own <c>parent</c>; it used to be the bare global object instead,
+    /// which is what let <c>GetWindowOrigin</c>'s parent walk terminate by accident.
+    /// </summary>
+    [Fact]
+    public void Window_IsTheGlobalObject()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("true", ValueOf(context, "window === globalThis"));
+        Assert.Equal("true", ValueOf(context, "window.self === window"));
+        Assert.Equal("true", ValueOf(context, "window.parent === window"));
+        Assert.Equal("true", ValueOf(context, "document.defaultView === window"));
+    }
+
+    /// <summary>
+    /// The reported failure, reduced to the shape google.com actually ships: the namespace is
+    /// published through <c>window</c> and consumed unqualified in the same script. No host runs
+    /// between the two, so no amount of window→global syncing could have made this work.
+    /// </summary>
+    [Fact]
+    public void GoogleBootstrapShape_WithinOneScript_DoesNotThrow()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        var thrown = Record.Exception(() => context.Eval(
+            "(function(){var _g={kEI:'trp9ar'};" +
+            "(function(){var a;((a=window.google)==null?0:a.stvsc)?google.kEI=_g.kEI:window.google=_g;}).call(this);})();" +
+            "(function(){google.sn='webhp';google.kHL='en';google.usb=true;})();"));
+
+        Assert.Null(thrown);
+        Assert.Equal("webhp", ValueOf(context, "window.google.sn"));
+        Assert.Equal("trp9ar", ValueOf(context, "google.kEI"));
+    }
+
+    /// <summary>
+    /// The same namespace across two <c>&lt;script&gt;</c> elements — google.com's later scripts
+    /// open with a bare <c>google.kEXPI=…</c>. This half a between-scripts sync could reach, but
+    /// only if every host remembered to call one; sharing the object removes the requirement.
+    /// </summary>
+    [Fact]
+    public void GoogleBootstrapShape_AcrossScripts_DoesNotThrow()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        context.Eval("window.google = {kEI:'trp9ar'};");
+        var thrown = Record.Exception(() => context.Eval("google.kEXPI='0,4254156';google.sn='webhp';"));
+
+        Assert.Null(thrown);
+        Assert.Equal("0,4254156", ValueOf(context, "google.kEXPI"));
+    }
+
+    /// <summary>Both spellings name one property, in both directions, with no sync in between.</summary>
+    [Fact]
+    public void WindowAndGlobal_AreOneNamespace()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        context.Eval("window.viaWindow = 1; globalThis.viaGlobal = 2; viaBare = 3;");
+
+        Assert.Equal("1", ValueOf(context, "viaWindow"));
+        Assert.Equal("2", ValueOf(context, "window.viaGlobal"));
+        Assert.Equal("3", ValueOf(context, "window.viaBare"));
+
+        context.Eval("viaWindow = 11;");
+        Assert.Equal("11", ValueOf(context, "window.viaWindow"));
+    }
+
+    /// <summary>
+    /// A top-level <c>about:blank</c> document can post a message. <c>GetWindowOrigin</c> follows
+    /// <c>parent</c> to inherit an origin an <c>about:blank</c> document does not have of its own,
+    /// and a top-level window is its own parent — so without a base case the walk never terminates.
+    /// It used to terminate only because the top window's <c>parent</c> was the bare global object,
+    /// which had no <c>location</c> to recurse on. A regression here is a stack overflow, which
+    /// takes the test host down rather than failing this assertion.
+    /// </summary>
+    [Fact]
+    public void TopLevelAboutBlank_CanPostMessage_WithoutRecursingForever()
+    {
+        var (context, bridge) = Attach("about:blank");
+        using var _ = context;
+        using var __ = bridge;
+
+        var thrown = Record.Exception(() => context.Eval(
+            "window.addEventListener('message', function(e) { window.__got = e.data; });" +
+            "window.postMessage('hello', '*');"));
+
+        Assert.Null(thrown);
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.WindowLoad.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.WindowLoad.cs
@@ -36,7 +36,12 @@ public sealed partial class DomBridge
         ThrowIfDisposed();
         if (_jsContext == null) return;
 
-        _jsContext["frames"] = BuildWindowFramesArray();
+        // Building the frames array is what mints each nested browsing context's window — and so
+        // what runs that frame's scripts — so it is done eagerly here, before load fires, rather
+        // than left until a page happens to read `frames`. The result is deliberately discarded:
+        // `frames` is a live accessor on the window, which IS the global object, so assigning the
+        // array here would replace that accessor with a snapshot frozen at load time.
+        BuildWindowFramesArray();
 
         FireDomContentLoadedEvent();
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Registration.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Registration.cs
@@ -113,7 +113,22 @@ public sealed partial class DomBridge
         _documentJSObject = document;
         context["document"] = document;
 
-        var window = new JSObject();
+        // `window` IS the global object, exactly as it is in a browser — the JSContext derives from
+        // JSObject and is the realm's global. It used to be a separate `new JSObject()`, which made
+        // every `window.foo = …` invisible to the unqualified `foo` that a page writes next, because
+        // identifier resolution consults the global object and nothing else. That is not a corner
+        // case: it is how google.com bootstraps itself, in one script —
+        //   (function(){var _g={kEI:…}; (function(){… window.google=_g;}).call(this);})();
+        //   (function(){google.sn='webhp'; google.kHL='en';})();
+        // — so the second IIFE threw `google is not defined`, which aborts the whole <script>. Every
+        // later Google script then referenced the `google` namespace the aborted one would have
+        // published and died the same way, and the page rendered with none of its script-driven
+        // content. The window→global mirror (MirrorWindowMembersOntoGlobal) papered over the
+        // between-scripts half of this by copying window members onto the global after the fact; it
+        // could never cover the within-one-script half, because there is no point between the write
+        // and the read at which a host could run. Making the two one object removes the class of bug
+        // rather than the symptom, and the mirror becomes the no-op it should always have been.
+        JSObject window = context;
         _windowJSObject = window;
 
         var windowBasicsScope = Broiler.HtmlBridge.Core.Diagnostics.BridgePhaseTrace.Measure(Broiler.HtmlBridge.Core.Diagnostics.BridgePhaseTrace.Phases.RegWindowBasics);
@@ -195,6 +210,16 @@ public sealed partial class DomBridge
     /// </summary>
     private static void MirrorWindowMembersOntoGlobal(JSContext context, JSObject window)
     {
+        // The bridge now makes `window` the global object (see RegisterDocumentCore), so there is
+        // nothing to copy and no gap to close — the sweep would define every own property of the
+        // global onto itself. Returning here keeps that off the per-script path a host runs
+        // (WptTestRunner calls SyncWindowMembersOntoGlobal after every script) instead of paying for
+        // an Object.getOwnPropertyNames walk of the whole global that skips all of its own results.
+        // The sweep is kept rather than deleted because it is still correct for any realm where the
+        // two are genuinely distinct objects.
+        if (ReferenceEquals(context, window))
+            return;
+
         context["__broilerWindowForGlobalMirror"] = window;
         try
         {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
@@ -161,8 +161,12 @@ public sealed partial class DomBridge
 
         _messaging.RegisterWindowMessaging(window);
 
+        // `frames` is the one member registered twice with *different* shapes: a live getter on the
+        // window and, historically, a static snapshot on the global for the unqualified spelling.
+        // Now that the window IS the global the second write would simply overwrite the first,
+        // freezing `frames` to whatever existed before any <iframe> was scripted. The accessor is
+        // the correct one for both spellings, so it is the only registration.
         window.FastAddProperty((KeyString)"frames", new DomFunction((in _) => BuildWindowFramesArray(), "get frames"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
-        context["frames"] = BuildWindowFramesArray();
 
         // window.screen — basic stub for screen dimensions
         var screenObj = new JSObject();

--- a/src/Broiler.HtmlBridge.Dom/Features/MessagingBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/MessagingBinding.cs
@@ -392,7 +392,17 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
             if (string.Equals(href, "about:srcdoc", StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(href, "about:blank", StringComparison.OrdinalIgnoreCase))
             {
-                return GetWindowOrigin(window[(KeyString)"parent"] as JSObject);
+                // An about:blank / about:srcdoc document has no origin of its own and inherits its
+                // parent's — but only while there IS a parent above it. A top-level window is its own
+                // parent (`window.parent === window`, in a browser and now here too), so following the
+                // link unconditionally never terminates for a top-level about:blank document; it used
+                // to terminate only because `window.parent` was the raw global object, which carried no
+                // `location` for the next round to recurse on. Stopping at the window that parents
+                // itself is the real base case, and it is the one a frame tree actually defines.
+                var parent = window[(KeyString)"parent"] as JSObject;
+                return parent == null || ReferenceEquals(parent, window)
+                    ? string.Empty
+                    : GetWindowOrigin(parent);
             }
 
             var origin = location[(KeyString)"origin"]?.ToString() ?? string.Empty;


### PR DESCRIPTION
## Summary

The bridge now makes `window` the global object itself (the `JSContext`), rather than publishing it as a separate `JSObject` and copying its members onto the global afterwards. This fixes a class of bugs where a page writes `window.x` and reads the unqualified `x` in the same script — a pattern that occurs in real pages like google.com and cannot be covered by post-script syncing.

## Key Changes

- **Registration.cs**: Changed `window` from `new JSObject()` to `context` (the global object itself). The `MirrorWindowMembersOntoGlobal` sweep now returns immediately when the two are the same object, avoiding redundant work on the per-script path.

- **MessagingBinding.cs**: Fixed `GetWindowOrigin` to recognize that a top-level window is its own parent (`window.parent === window`), preventing infinite recursion when walking the frame tree for an `about:blank` document. The base case is now "the window that parents itself" rather than relying on the parent being a bare global object with no `location`.

- **Window.cs**: Removed the duplicate registration of `frames` on the global object. Since `window` is now the global, the live accessor registered on `window` serves both `window.frames` and the unqualified `frames` spelling.

- **DomBridge.WindowLoad.cs**: Changed `FireWindowLoadEvent` to call `BuildWindowFramesArray()` for its side effect (minting nested browsing contexts) but discard the result, since assigning it would overwrite the live `frames` accessor with a static snapshot.

- **WindowIsTheGlobalObjectTests.cs** (new): Comprehensive test suite verifying that `window === globalThis`, the three self-references (`self`, `parent`, `document.defaultView`), and the specific google.com bootstrap pattern that motivated this fix — both within a single script and across multiple scripts.

- **WindowGlobalSyncTests.cs**: Updated to reflect the new behavior. Tests now verify that window members are reachable unqualified *before* syncing (the property pages depend on), then confirm the sync remains harmless. Renamed `RuntimeWindowMember_IsUnreachableUnqualified_UntilSynced` to `RuntimeWindowMember_IsReachableUnqualified_WithoutSyncing` and updated `ExistingGlobal_IsNotOverwritten` to `EngineBuiltins_SurviveRegistration` with clarified semantics.

- **htmlbridge.md**: Documented the architectural change, explaining why the two objects are now one and how nested browsing contexts still get their own window via `SubWindowBinding` and `WindowContextManager.RunWithWindowContext`.

## Implementation Details

- The fix is minimal and surgical: `window` assignment changes from `new JSObject()` to `context`, and the mirror sweep gains an early return for the same-object case.
- `MirrorWindowMembersOntoGlobal` and its public re-run `SyncWindowMembersOntoGlobal` are retained for backward compatibility but become no-ops when the two are identical.
- Nested frames still work correctly: each frame gets its own window object, and frame scripts run in a shared context with window/document/location/parent/self/top swapped for the duration.
- The fix eliminates an entire class of bugs (write and read in one script) rather than just papering over symptoms.

https://claude.ai/code/session_01725QNtRPh4U2BQhxuubox3