### PR TITLE
Finish the google.com start-page fixes: parent origin, and fetch URL resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,40 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `Broiler.HtmlBridge` — `window` is the global object, as it is in a browser, so a
+  page's `window.x = …` and its unqualified `x` name one property. They were separate
+  objects, and identifier resolution consults only the global, so `window.google = _g`
+  left the bare `google` a `ReferenceError` — which aborts the whole `<script>`, not
+  just the statement. google.com bootstraps exactly that way *within one script*
+  (`window.google=_g` in one IIFE, `google.sn='webhp'` in the next), so its namespace
+  was never finished and every later script that named it died the same way: five
+  `google is not defined` errors from one broken script, and a homepage with none of
+  its script-driven content. The window→global mirror covered the between-scripts
+  half by copying members across afterwards; nothing could cover the within-one-script
+  half, because no host runs between the write and the read. The mirror and its public
+  re-run `SyncWindowMembersOntoGlobal` are kept and return immediately when the two
+  objects are one. Three things the split had hidden came with it: `frames` was
+  registered twice with different shapes (a live getter on the window, a static
+  snapshot on the global) and is now the accessor alone; `GetWindowOrigin` walked
+  `parent` to inherit an `about:blank` document's origin and only terminated because
+  the top window's `parent` used to be the bare global, so a top-level `about:blank`
+  page now recursed 33 707 frames into a stack overflow; and the top window's origin
+  can no longer be read back out of its `location`, because `RunWithWindowContext`
+  swaps that to a frame's while the frame's scripts run — which is when a frame calls
+  `parent.postMessage` — so it comes from the document through a new
+  `IMessagingHost.PageOrigin` seam.
+- `Broiler.HtmlBridge` — `fetch` resolves its input against the document's base URL
+  (Fetch §5.4) instead of handing the string to `HttpClient` untouched. A relative
+  request URI with no `BaseAddress` is not a request at all: `PrepareRequestMessage`
+  throws `InvalidOperationException("An invalid request URI was provided…")` before
+  anything reaches the wire. google.com hits it on every page view, beaconing timing to
+  `/gen_204?atyp=i&…` through `navigator.sendBeacon`, which delegates to this `fetch`;
+  so does any `XMLHttpRequest` opened on a path, because the XHR polyfill calls
+  `fetch(this._url)`. It adopts the same `UrlResolver` that `Response.redirect`
+  already used, which also makes `response.url` the resolved URL as the spec requires.
+  A target that resolves against nothing is reported as an error `Response`, like any
+  other failed fetch, rather than thrown — throwing would abort the calling script over
+  one beacon.
 - `Broiler.Layout` — `position: relative` now offsets an inline-level box. CSS 2.1
   §9.4.3's offset is visual, so it has to reach the box's words; `PerformLayout`
   applied it for every box it lays out, but an inline-level box is laid out by

--- a/src/Broiler.Cli.Tests/FetchRelativeUrlTests.cs
+++ b/src/Broiler.Cli.Tests/FetchRelativeUrlTests.cs
@@ -1,0 +1,138 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.HtmlBridge.Logging;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// <c>fetch</c> parses its input against the document's base URL (Fetch §5.4), so a page may name a
+/// target the way pages actually do — <c>/gen_204</c>, <c>./ping</c>, <c>//host/path</c>.
+/// <para>
+/// The binding used to hand the string to <c>HttpClient</c> untouched. A relative request URI with no
+/// <c>BaseAddress</c> is not a request at all: <c>HttpClient.PrepareRequestMessage</c> throws
+/// <c>InvalidOperationException("An invalid request URI was provided…")</c> before anything reaches
+/// the wire. google.com hits this on every page view — it beacons timing to
+/// <c>/gen_204?atyp=i&amp;…</c> through <c>navigator.sendBeacon</c>, which delegates to this
+/// <c>fetch</c> — and so does any <c>XMLHttpRequest</c> opened on a path, because the XHR polyfill
+/// calls <c>fetch(this._url)</c>.
+/// </para>
+/// <para>
+/// What is asserted is the URL the binding resolved, not a response body. The page URLs use the
+/// reserved <c>.invalid</c> TLD (RFC 2606), which cannot resolve anywhere, so these reach no host:
+/// the request fails, and the resolved URL is still what the binding reports as
+/// <c>response.url</c> — on the error path as much as the success path. A request that fails is the
+/// expected outcome here; a request that was never made because the URI would not parse is the bug.
+/// </para>
+/// </summary>
+public sealed class FetchRelativeUrlTests
+{
+    private const string PageUrl = "https://page.invalid/search?q=x";
+
+    private static (JSContext Context, DomBridge Bridge) Attach(string url = PageUrl)
+    {
+        var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, "<!doctype html><html><body></body></html>", url);
+        return (context, bridge);
+    }
+
+    /// <summary>Collects the errors the bridge logs while <paramref name="action"/> runs.</summary>
+    private static List<string> ErrorsDuring(Action action)
+    {
+        var errors = new List<string>();
+        void Handler(RenderLogEntry entry)
+        {
+            if (entry.Level == LogLevel.Error)
+                lock (errors) errors.Add($"{entry.Context}: {entry.Message}");
+        }
+
+        RenderLogger.EntryLogged += Handler;
+        try
+        {
+            action();
+        }
+        finally
+        {
+            RenderLogger.EntryLogged -= Handler;
+        }
+
+        lock (errors) return [.. errors];
+    }
+
+    private static void AssertNoInvalidUriError(List<string> errors) =>
+        Assert.DoesNotContain(errors, e => e.Contains("invalid request URI", StringComparison.OrdinalIgnoreCase));
+
+    [Theory]
+    [InlineData("/gen_204?atyp=i", "https://page.invalid/gen_204?atyp=i")]
+    [InlineData("gen_204", "https://page.invalid/gen_204")]
+    [InlineData("./ping", "https://page.invalid/ping")]
+    [InlineData("//cdn.invalid/og/ping", "https://cdn.invalid/og/ping")]
+    [InlineData("https://absolute.invalid/kept", "https://absolute.invalid/kept")]
+    public void FetchResolvesItsInputAgainstThePageUrl(string requested, string expected)
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        var errors = ErrorsDuring(() => context.Eval(
+            $"globalThis.__resolved = null; fetch('{requested}').then(function(r) {{ globalThis.__resolved = r.url; }});"));
+
+        AssertNoInvalidUriError(errors);
+        Assert.Equal(expected, context.Eval("String(globalThis.__resolved)").ToString());
+    }
+
+    /// <summary>
+    /// The reported failure end to end: google.com's own beacon call. <c>sendBeacon</c> reports
+    /// <see langword="true"/> when it queued the request, and the URI error must not appear.
+    /// </summary>
+    [Fact]
+    public void SendBeacon_ToARootRelativeTarget_DoesNotRaiseTheInvalidUriError()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        var errors = ErrorsDuring(() => context.Eval(
+            "globalThis.__queued = navigator.sendBeacon('/gen_204?atyp=i&ei=abc', 'payload');"));
+
+        AssertNoInvalidUriError(errors);
+        Assert.Equal("true", context.Eval("String(globalThis.__queued)").ToString());
+    }
+
+    /// <summary>
+    /// An <c>XMLHttpRequest</c> opened on a path reaches the same resolution — the polyfill's
+    /// <c>send</c> calls <c>fetch(this._url)</c>, so this was the second way into the same throw.
+    /// </summary>
+    [Fact]
+    public void Xhr_OpenedOnAPath_DoesNotRaiseTheInvalidUriError()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        var errors = ErrorsDuring(() => context.Eval(
+            "var x = new XMLHttpRequest(); x.open('GET', '/client_204?atyp=i'); x.send();"));
+
+        AssertNoInvalidUriError(errors);
+    }
+
+    /// <summary>
+    /// A target that resolves against nothing is a failed request, not a failed script: the binding
+    /// reports an error <c>Response</c> the way it reports any other network failure. Throwing would
+    /// abort the whole calling script over one beacon.
+    /// </summary>
+    [Fact]
+    public void AnUnresolvableTarget_YieldsAnErrorResponse_RatherThanThrowing()
+    {
+        var (context, bridge) = Attach(url: string.Empty);
+        using var _ = context;
+        using var __ = bridge;
+
+        var thrown = Record.Exception(() => context.Eval(
+            "globalThis.__type = null; fetch('/gen_204').then(function(r) { globalThis.__type = r.type; });"));
+
+        Assert.Null(thrown);
+        Assert.Equal("error", context.Eval("String(globalThis.__type)").ToString());
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.MessagingHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.MessagingHost.cs
@@ -18,6 +18,8 @@ public sealed partial class DomBridge : IMessagingHost
 {
     JSObject? IMessagingHost.WindowJSObject => _windowJSObject;
 
+    string IMessagingHost.PageOrigin => _pageOrigin;
+
     JSContext? IMessagingHost.JsContext => _jsContext;
 
     JSObject? IMessagingHost.ResolveCurrentWindow() => ResolveCurrentWindow();

--- a/src/Broiler.HtmlBridge.Dom/Features/FetchBinding.Callbacks.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/FetchBinding.Callbacks.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Text;
+using Broiler.HtmlBridge.Internal.Scripting;
 using Broiler.HtmlBridge.Logging;
 using Broiler.JavaScript.BuiltIns.Boolean;
 using Broiler.JavaScript.BuiltIns.Function;
@@ -59,11 +60,22 @@ internal sealed partial class FetchBinding
     {
         if (a.Length == 0)
             throw new JSException("Failed to execute 'fetch': 1 argument required.");
-        var fetchUrl = a[0].ToString();
+        var requestedUrl = a[0].ToString();
         if (a[0] is JSObject requestInput)
         {
-            fetchUrl = tryGetJsPropertyString(requestInput, "url", "href") ?? fetchUrl;
+            requestedUrl = tryGetJsPropertyString(requestInput, "url", "href") ?? requestedUrl;
         }
+
+        // §5.4 of Fetch: the input is parsed against the entry settings object's base URL. This is
+        // the same one shared resolver Response.redirect uses (Phase 7 item 4) — an absolute URL is
+        // kept, a relative or root-relative one resolves against the page. Without it a root-relative
+        // target went to HttpClient verbatim as a relative request URI, which is an
+        // InvalidOperationException out of PrepareRequestMessage rather than a request. That is not
+        // an exotic spelling: google.com beacons its timing to `/gen_204?atyp=i&…` through
+        // navigator.sendBeacon, which delegates to this fetch, and so does every XMLHttpRequest
+        // opened on a path (the XHR polyfill calls fetch(this._url)).
+        var resolvedUri = UrlResolver.Resolve(requestedUrl, _host.PageUrl);
+        var fetchUrl = resolvedUri?.AbsoluteUri ?? requestedUrl;
 
         JSValue responseObj = new JSObject();
         // Parse options (method, headers, body)
@@ -107,7 +119,19 @@ internal sealed partial class FetchBinding
 
         try
         {
-            if (!rejected)
+            if (!rejected && resolvedUri == null)
+            {
+                // A URL that will not parse against the page's base is the spec's "network error"
+                // for this binding's error model, which reports every failed fetch as an error
+                // Response rather than throwing. Throwing here would abort the whole calling script,
+                // which for a relative URL is a far worse outcome than one failed request.
+                RenderLogger.LogError(LogCategory.JavaScript, "DomBridge.fetch",
+                    $"Fetch error: '{requestedUrl}' is not an absolute URL and does not resolve against the page URL '{_host.PageUrl}'.",
+                    new JSException("Failed to parse URL"));
+                responseObj = createResponse(string.Empty, 0, "Invalid URL", requestedUrl, "error", false,
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+            }
+            else if (!rejected)
             {
                 var request = new HttpRequestMessage(new HttpMethod(method), fetchUrl);
                 if (requestBody != null)

--- a/src/Broiler.HtmlBridge.Dom/Features/IMessagingHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/IMessagingHost.cs
@@ -20,6 +20,19 @@ internal interface IMessagingHost
     /// <summary>The top-level window JS wrapper (<c>null</c> before attach).</summary>
     JSObject? WindowJSObject { get; }
 
+    /// <summary>
+    /// The document's own origin, as parsed from the page URL at attach.
+    /// <para>
+    /// The top window's origin cannot be read back out of its <c>location</c> property: the window
+    /// IS the global object, and <see cref="RunWithWindowContext"/> temporarily swaps
+    /// <c>location</c> (with <c>document</c>, <c>self</c>, <c>parent</c> and the rest) to a frame's
+    /// while that frame's scripts run — which is exactly when a frame posts to its parent. Reading
+    /// the property there yields the frame's own <c>about:srcdoc</c>, not the page's origin. This is
+    /// the fact rather than the mutable view of it.
+    /// </para>
+    /// </summary>
+    string PageOrigin { get; }
+
     /// <summary>The active JS execution context (<c>null</c> before attach), used to raise
     /// <c>DataCloneError</c> and to structured-clone message payloads.</summary>
     JSContext? JsContext { get; }

--- a/src/Broiler.HtmlBridge.Dom/Features/MessagingBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/MessagingBinding.cs
@@ -386,6 +386,16 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
         if (window == null)
             return string.Empty;
 
+        // The top window's origin is the document's, taken from the host rather than read back out
+        // of `location`. The window IS the global object, and RunWithWindowContext swaps `location`
+        // (and `document`/`self`/`parent`) to a frame's for the duration of that frame's scripts —
+        // which is precisely when a frame calls parent.postMessage. Reading the property there would
+        // see the frame's own about:srcdoc and report the parent as having no origin. Taking the
+        // fact instead of the mutable view is also what terminates the walk below: a top-level
+        // window is its own `parent`, so an about:blank page has no further parent to inherit from.
+        if (ReferenceEquals(window, _host.WindowJSObject))
+            return _host.PageOrigin;
+
         if (window[(KeyString)"location"] is JSObject location)
         {
             var href = location[(KeyString)"href"]?.ToString() ?? string.Empty;
@@ -393,12 +403,8 @@ internal sealed class MessagingBinding(IMessagingHost host, EventTargetRegistry 
                 string.Equals(href, "about:blank", StringComparison.OrdinalIgnoreCase))
             {
                 // An about:blank / about:srcdoc document has no origin of its own and inherits its
-                // parent's — but only while there IS a parent above it. A top-level window is its own
-                // parent (`window.parent === window`, in a browser and now here too), so following the
-                // link unconditionally never terminates for a top-level about:blank document; it used
-                // to terminate only because `window.parent` was the raw global object, which carried no
-                // `location` for the next round to recurse on. Stopping at the window that parents
-                // itself is the real base case, and it is the one a frame tree actually defines.
+                // parent's. A window that parents itself is the top of the tree and has nothing left
+                // to inherit from, so it ends the walk rather than recurring forever.
                 var parent = window[(KeyString)"parent"] as JSObject;
                 return parent == null || ReferenceEquals(parent, window)
                     ? string.Empty


### PR DESCRIPTION
Two follow-ups to #1634, which made `window` the global object. The first repairs a regression that change introduced; the second fixes the *next* exception the start page threw once the scripts got far enough to run.

## 1. Take the top window's origin from the document, not its swapped `location`

`RunWithWindowContext` fakes a per-frame realm by swapping the global `window`/`document`/`location`/`parent`/`self`/`top` to the frame's while that frame's scripts run. Those globals used to live on an object distinct from the top window, so the swap left the top window untouched. Now they are the same object, so while a frame's scripts run the top window's own `location` **is** the frame's.

That is exactly when a frame calls `parent.postMessage`, and `MessagingBinding.GetWindowOrigin` walks `parent` to give an `about:srcdoc` document its parent's origin. The walk reached the top window, read the frame's own `about:srcdoc` back out of it, and reported the message as having no origin at all:

```
Expected: "7|true|about:srcdoc|https://example.com"
Actual:   "7|true|about:srcdoc|"
```

The top window's origin is the document's, parsed from the page URL at attach and not swappable out from under. `GetWindowOrigin` takes it from there through a new `IMessagingHost.PageOrigin` seam instead of reading a mutable view of it. That also gives the parent walk its base case outright, so the self-parent guard added in #1634 is only the belt to this braces.

Caught by `WebMessagingTests.Window_PostMessage_From_Iframe_To_Parent_Exposes_Source_And_Origin`, which now passes.

## 2. Resolve `fetch`'s input against the page URL instead of sending it raw

Navigating to google.com threw:

```
System.InvalidOperationException: An invalid request URI was provided. Either the
request URI must be an absolute URI or BaseAddress must be set.
   at System.Net.Http.HttpClient.PrepareRequestMessage(HttpRequestMessage request)
```

The fetch binding took its input string and built an `HttpRequestMessage` from it verbatim, so a relative target never became a request at all — it failed before reaching the wire.

Fetch §5.4 parses the input against the entry settings object's base URL, which is what makes `/gen_204` mean something. google.com beacons its timing to `/gen_204?atyp=i&…` through `navigator.sendBeacon` on every page view, and `sendBeacon` delegates to `window.fetch`; every `XMLHttpRequest` opened on a path arrives the same way, because the XHR polyfill's `send` calls `fetch(this._url)`. Both page-facing networking entry points were reaching `HttpClient` with a URI it cannot send.

The resolver already exists and this module already uses it — `Response.redirect` resolves against `IFetchHost.PageUrl` through `UrlResolver`, whose comment says fetch adopts the one shared resolver. The fetch call itself had never been converted. Doing so also makes `response.url` the resolved URL rather than whatever the caller typed, which is what the spec asks for.

A target that resolves against nothing is reported as an error `Response`, the way this binding reports every other failed fetch, rather than thrown: throwing would abort the whole calling script over one beacon — the same failure shape as the `google is not defined` cascade #1634 fixed.

## Verification

**End to end.** `--capture-image https://www.google.com` completes with **zero** JavaScript errors: no `is not defined`, no invalid-request-URI, no `JSException`. Before these changes the same navigation logged five `google is not defined` errors and then the URI exception.

**New tests.** `FetchRelativeUrlTests` covers root-relative, bare-relative, `./`, protocol-relative and absolute inputs, plus the `sendBeacon` and `XMLHttpRequest` paths and the unresolvable case. They assert the URL the binding resolved rather than a response body, and use the reserved `.invalid` TLD (RFC 2606) so they contact no host.

**Targeted suite** (`FetchRelativeUrl`, `WebMessaging`, `WindowIsTheGlobalObject`, `WindowGlobalSync`, `WindowGlobalMirror`, `HttpSubResource`): 56 passed, 1 failed — `Iframe_Wpt_CrossOrigin_Template_Src_Loads_From_Local_Wpt_Root_But_Stays_CrossOrigin`, which fails identically on the baseline in this container.

**Regression sweep for #1634** (`Broiler.Cli.Tests`, before vs after):

| | |
|---|---|
| Baseline failures (pre-existing / environmental) | 54 |
| Still failing after | 52 |
| Newly passing | 2 — `HttpSubResourceTests.Iframe_Nested_Subdocument_Scripts_Resolve_Relative_Iframe_Sources`, `Iframe_ScriptAssigned_Srcdoc_Loads_ContentDocument_Through_Frames` |
| New failures | 2 |

Of the two new failures, the `WebMessagingTests` one is item 1 above and is fixed here. `ImagePrefetchTests.A_Host_That_Permits_Late_Image_Loading_Is_Skipped` is a race on `ImagePrefetch`'s static diagnostics counters — all 51 tests in that class pass in isolation, and it was only perturbed by the test filter used for the sweep. It is untouched here.

Two limits on that coverage, both pre-existing and both in unmodified code: the full suite does not complete in a bare container — it hangs in `Acid3Phase5Tests.PhaseE_Acid3_Score_At_Least_100` with the test host at 14 GB RSS — so tests after that point are unverified by either run; and the PDF-conversion tests fail environmentally, as `CLAUDE.md` documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01725QNtRPh4U2BQhxuubox3

---
_Generated by [Claude Code](https://claude.ai/code/session_01725QNtRPh4U2BQhxuubox3)_