### PR TITLE
Implement Element.dataset, the DOMStringMap over data-* attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,23 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `Broiler.HtmlBridge` — `Element.dataset`, the HTML `DOMStringMap` view over an
+  element's `data-*` attributes (HTML §3.2.6.6), which did not exist at all. A missing
+  object is not a quiet failure here: reading through it throws, and a thrown error
+  aborts the whole `<script>`. google.com's async-request module — `inline-6`, the code
+  that runs *when a search is issued* — reads `b.dataset.ved` and writes ids back
+  through the same map, so its absence stopped that script with `Cannot set property
+  eqid of undefined` and took every later statement and listener with it. The map is a
+  `Proxy` over the element's attributes rather than a snapshot object: a page may read
+  an attribute the markup carries, overwrite it, **or invent one no attribute backs
+  yet**, and a snapshot serves the first two while silently dropping the third onto a
+  throwaway copy. Nothing is cached, so `getAttribute` and `dataset` cannot disagree;
+  names map both ways (`dataset.fooBar` ↔ `data-foo-bar`); and `in`, `delete`,
+  `Object.keys` and `JSON.stringify` all work, the latter two because the proxy answers
+  `getOwnPropertyDescriptor` as well as `ownKeys` — answering only `ownKeys` enumerates
+  as empty. Built on first read and memoized, so a document's thousands of elements do
+  not each allocate a map that nothing asks for, and `el.dataset === el.dataset` holds.
+
 - `Broiler.HtmlBridge` — `window` is the global object, as it is in a browser, so a
   page's `window.x = …` and its unqualified `x` name one property. They were separate
   objects, and identifier resolution consults only the global, so `window.google = _g`

--- a/src/Broiler.Cli.Tests/DatasetTests.cs
+++ b/src/Broiler.Cli.Tests/DatasetTests.cs
@@ -1,0 +1,180 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// <c>Element.dataset</c> — the HTML <c>DOMStringMap</c> view over an element's <c>data-*</c>
+/// attributes (HTML §3.2.6.6).
+/// <para>
+/// It did not exist, and a missing object is not a quiet failure: reading through it throws, and a
+/// thrown error aborts the whole <c>&lt;script&gt;</c>. google.com's async-request module — the code
+/// that runs when a search is issued — reads <c>b.dataset.ved</c> and writes ids back through the
+/// same map, so its absence stopped that script with <c>Cannot set property eqid of undefined</c>
+/// and took every later statement with it.
+/// </para>
+/// </summary>
+public sealed class DatasetTests
+{
+    private static (JSContext Context, DomBridge Bridge) Attach(string body)
+    {
+        var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, $"<!doctype html><html><body>{body}</body></html>", "https://example.com/");
+        return (context, bridge);
+    }
+
+    private static string Eval(JSContext context, string expression) =>
+        context.Eval($"String({expression})").ToString();
+
+    /// <summary>
+    /// The reported failure, reduced: a property written through <c>dataset</c> onto an element that
+    /// carries no such attribute yet. This is the case a snapshot object cannot serve — the write
+    /// has to reach the element, not a throwaway copy — so it asserts the attribute afterwards.
+    /// </summary>
+    [Fact]
+    public void WritingANewKey_ReachesTheElementAsADataAttribute()
+    {
+        var (context, bridge) = Attach("<div id='t'></div>");
+        using var _ = context;
+        using var __ = bridge;
+
+        var thrown = Record.Exception(() => context.Eval("document.getElementById('t').dataset.eqid = 'q1';"));
+
+        Assert.Null(thrown);
+        Assert.Equal("q1", Eval(context, "document.getElementById('t').getAttribute('data-eqid')"));
+        Assert.Equal("q1", Eval(context, "document.getElementById('t').dataset.eqid"));
+    }
+
+    /// <summary>An attribute the markup carries is readable without anything having written it.</summary>
+    [Fact]
+    public void MarkupAttributes_AreReadable()
+    {
+        var (context, bridge) = Attach("<div id='t' data-ved='abc' data-eqid='q1'></div>");
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("abc", Eval(context, "document.getElementById('t').dataset.ved"));
+        Assert.Equal("q1", Eval(context, "document.getElementById('t').dataset.eqid"));
+    }
+
+    /// <summary>
+    /// The name mapping runs both ways: <c>dataset.fooBar</c> is <c>data-foo-bar</c>, and an
+    /// attribute set directly is visible under its camel-cased name.
+    /// </summary>
+    [Fact]
+    public void NamesMapBetweenCamelCaseAndDashes_InBothDirections()
+    {
+        var (context, bridge) = Attach("<div id='t'></div>");
+        using var _ = context;
+        using var __ = bridge;
+
+        context.Eval("document.getElementById('t').dataset.fooBar = 'k';");
+        Assert.Equal("k", Eval(context, "document.getElementById('t').getAttribute('data-foo-bar')"));
+
+        context.Eval("document.getElementById('t').setAttribute('data-a-b', 'v');");
+        Assert.Equal("v", Eval(context, "document.getElementById('t').dataset.aB"));
+    }
+
+    /// <summary>
+    /// The map enumerates. <c>Object.keys</c>, the spread operator and <c>JSON.stringify</c> all
+    /// filter the key list through <c>getOwnPropertyDescriptor</c>, so a map that answers only
+    /// <c>ownKeys</c> enumerates as empty — which is why both are asserted.
+    /// </summary>
+    [Fact]
+    public void TheMapEnumerates_AndSerializes()
+    {
+        var (context, bridge) = Attach("<div id='t' data-one='1' data-two-part='2' class='c'></div>");
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("one,twoPart", Eval(context, "Object.keys(document.getElementById('t').dataset).sort().join(',')"));
+        Assert.Equal("1", Eval(context, "JSON.parse(JSON.stringify(document.getElementById('t').dataset)).one"));
+    }
+
+    /// <summary>Non-<c>data-</c> attributes are not part of the map.</summary>
+    [Fact]
+    public void OtherAttributes_AreNotInTheMap()
+    {
+        var (context, bridge) = Attach("<div id='t' data-one='1' title='hello'></div>");
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("false", Eval(context, "'title' in document.getElementById('t').dataset"));
+        Assert.Equal("undefined", Eval(context, "typeof document.getElementById('t').dataset.title"));
+    }
+
+    /// <summary><c>in</c> distinguishes a present key from an absent one.</summary>
+    [Fact]
+    public void MembershipIsAnswered()
+    {
+        var (context, bridge) = Attach("<div id='t' data-ved='abc'></div>");
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("true", Eval(context, "'ved' in document.getElementById('t').dataset"));
+        Assert.Equal("false", Eval(context, "'nope' in document.getElementById('t').dataset"));
+    }
+
+    /// <summary>Deleting through the map removes the attribute from the element.</summary>
+    [Fact]
+    public void DeletingAKey_RemovesTheAttribute()
+    {
+        var (context, bridge) = Attach("<div id='t' data-ved='abc'></div>");
+        using var _ = context;
+        using var __ = bridge;
+
+        context.Eval("delete document.getElementById('t').dataset.ved;");
+
+        Assert.Equal("null", Eval(context, "document.getElementById('t').getAttribute('data-ved')"));
+        Assert.Equal("false", Eval(context, "'ved' in document.getElementById('t').dataset"));
+    }
+
+    /// <summary>
+    /// An empty attribute value is a value, not an absence — the distinction the traps have to keep
+    /// so <c>data-x=""</c> reads as <c>""</c> and enumerates, rather than looking like no attribute.
+    /// </summary>
+    [Fact]
+    public void AnEmptyValue_IsAValueNotAnAbsence()
+    {
+        var (context, bridge) = Attach("<div id='t' data-empty=''></div>");
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("", Eval(context, "document.getElementById('t').dataset.empty"));
+        Assert.Equal("true", Eval(context, "'empty' in document.getElementById('t').dataset"));
+        Assert.Equal("empty", Eval(context, "Object.keys(document.getElementById('t').dataset).join(',')"));
+    }
+
+    /// <summary>
+    /// The map is live and singular: it reads the element's attributes on every access, so a change
+    /// made through <c>setAttribute</c> is visible through a reference taken beforehand, and the
+    /// element hands back the same object each time as a browser does.
+    /// </summary>
+    [Fact]
+    public void TheMapIsLive_AndTheSameObjectEachTime()
+    {
+        var (context, bridge) = Attach("<div id='t' data-n='1'></div>");
+        using var _ = context;
+        using var __ = bridge;
+
+        context.Eval("globalThis.held = document.getElementById('t').dataset;");
+        context.Eval("document.getElementById('t').setAttribute('data-n', '2');");
+
+        Assert.Equal("2", Eval(context, "globalThis.held.n"));
+        Assert.Equal("true", Eval(context, "document.getElementById('t').dataset === document.getElementById('t').dataset"));
+    }
+
+    /// <summary>An element created by script has the map too, not only one parsed from markup.</summary>
+    [Fact]
+    public void ACreatedElement_HasTheMap()
+    {
+        var (context, bridge) = Attach("");
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("object", Eval(context, "typeof document.createElement('div').dataset"));
+        Assert.Equal("v", Eval(context, "(function(){var e = document.createElement('div'); e.dataset.k = 'v'; return e.getAttribute('data-k');})()"));
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -132,6 +132,31 @@ public sealed partial class DomBridge
             Dom.Features.ClassListBinding.Build(element, bridge.InvalidateStyleScope),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
+        // dataset — the live DOMStringMap over the element's data-* attributes.
+        //
+        // Built on first read rather than with the rest of the element: a document has thousands of
+        // elements and few of them are ever asked for their dataset, so building every map up front
+        // would allocate a proxy and four callbacks per element for nothing. The built map replaces
+        // this accessor with a value property, which both memoizes it and keeps
+        // `el.dataset === el.dataset` true as it is in a browser — the map reads and writes the
+        // attributes on every trap, so one instance is already live and a second would be redundant
+        // rather than fresher.
+        obj.FastAddProperty((KeyString)"dataset",
+            new DomFunction((in _) =>
+            {
+                if (bridge._jsContext is not { } datasetContext
+                    || Dom.Features.DatasetBinding.Build(datasetContext, element, bridge.InvalidateStyleScope) is not { } dataset)
+                {
+                    // No Proxy in this realm to build the map from. Undefined is honest: an absent
+                    // dataset is at least not one that silently drops writes.
+                    return JSUndefined.Value;
+                }
+
+                obj.FastAddValue((KeyString)"dataset", dataset, JSPropertyAttributes.EnumerableConfigurableValue);
+                return dataset;
+            }, "get dataset"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
         // attributes — NamedNodeMap interface
         obj.FastAddProperty((KeyString)"attributes",
             new DomFunction((in _) => _attributes.BuildNamedNodeMap(element, obj), "get attributes"),

--- a/src/Broiler.HtmlBridge.Dom/Features/DatasetBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/DatasetBinding.cs
@@ -1,0 +1,212 @@
+using Broiler.Dom;
+using Broiler.JavaScript.BuiltIns.Array;
+using Broiler.JavaScript.BuiltIns.Boolean;
+using Broiler.JavaScript.BuiltIns.Function;
+using Broiler.JavaScript.BuiltIns.Null;
+using Broiler.JavaScript.BuiltIns.String;
+using Broiler.JavaScript.Engine;
+using Broiler.JavaScript.Runtime;
+using Broiler.JavaScript.Storage;
+
+namespace Broiler.HtmlBridge.Dom.Features;
+
+/// <summary>
+/// <c>Element.dataset</c> — the HTML <c>DOMStringMap</c> view over an element's <c>data-*</c>
+/// attributes (HTML §3.2.6.6).
+/// <para>
+/// It was missing entirely, and reading a property of a missing object is not a quiet failure: it
+/// throws, which aborts the whole script. google.com's async-request module — the code that runs
+/// <em>when a search is issued</em> — reads <c>b.dataset.ved</c> and writes ids back through the
+/// same map, so the map's absence stopped that script dead with
+/// <c>Cannot set property eqid of undefined</c>.
+/// </para>
+/// <para>
+/// The map has to be live and open-ended: a page may read a <c>data-*</c> attribute the markup
+/// carries, overwrite it, or invent one that no attribute backs yet. A snapshot object built from
+/// the attributes present at the time would serve the first two and silently drop the third — the
+/// write would land on a throwaway object and never reach the element. So this is a
+/// <c>Proxy</c> whose traps read and write the attributes themselves, and the element's attributes
+/// remain the single source of truth: nothing is cached, and <c>getAttribute</c> and
+/// <c>dataset</c> cannot disagree.
+/// </para>
+/// </summary>
+internal static class DatasetBinding
+{
+    /// <summary>
+    /// The JavaScript half: a factory taking the four accessors as functions and returning the
+    /// proxy. It is a compile-time constant of this assembly, evaluated once per context (and
+    /// served from the shared code cache during registration like the bridge's other sources).
+    /// <para>
+    /// <c>getOwnPropertyDescriptor</c> is not optional decoration: <c>Object.keys</c>,
+    /// <c>JSON.stringify</c> and the spread operator all filter <c>ownKeys</c> through it, so a
+    /// proxy that answers <c>ownKeys</c> alone enumerates as empty.
+    /// </para>
+    /// </summary>
+    private const string FactorySource = @"
+(function(get, set, del, keys) {
+  return new Proxy({}, {
+    get: function(target, name) {
+      if (typeof name !== 'string') return undefined;
+      var value = get(name);
+      return value === null ? undefined : value;
+    },
+    set: function(target, name, value) {
+      if (typeof name === 'string') set(name, String(value));
+      return true;
+    },
+    has: function(target, name) {
+      return typeof name === 'string' && get(name) !== null;
+    },
+    deleteProperty: function(target, name) {
+      if (typeof name === 'string') del(name);
+      return true;
+    },
+    ownKeys: function() { return keys(); },
+    getOwnPropertyDescriptor: function(target, name) {
+      if (typeof name !== 'string') return undefined;
+      var value = get(name);
+      if (value === null) return undefined;
+      return { value: value, writable: true, enumerable: true, configurable: true };
+    },
+  });
+})";
+
+    /// <summary>
+    /// Builds the live <c>DOMStringMap</c> for <paramref name="element"/>. Returns <c>null</c> when
+    /// the engine has no <c>Proxy</c> to build it from, so the caller can leave <c>dataset</c>
+    /// unregistered rather than publish a map that silently drops writes.
+    /// </summary>
+    // The factory is a per-realm constant, so it is compiled and evaluated once per context rather
+    // than once per element: a document has thousands of elements and would otherwise pay an Eval
+    // and a fresh closure for each. Keyed weakly so a finished document's context is collectable.
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<JSContext, JSFunction> Factories = new();
+
+    private static JSFunction? FactoryFor(JSContext context)
+    {
+        if (Factories.TryGetValue(context, out var cached))
+            return cached;
+
+        if (context.Eval(FactorySource, "broiler:dataset") is not JSFunction factory)
+            return null;
+
+        Factories.AddOrUpdate(context, factory);
+        return factory;
+    }
+
+    internal static JSObject? Build(JSContext context, DomElement element, Action<DomElement>? onAttributeChanged)
+    {
+        if (FactoryFor(context) is not { } factory)
+            return null;
+
+        var get = new DomFunction((in a) =>
+        {
+            var attribute = AttributeNameOf(NameArgument(in a));
+            if (attribute == null)
+                return JSNull.Value;
+
+            // JSNull rather than undefined so the traps can tell "no such data-* attribute" from an
+            // attribute whose value is the empty string, which is a real, readable value.
+            return element.GetAttribute(attribute) is { } value ? new JSString(value) : JSNull.Value;
+        }, "get", 1);
+
+        var set = new DomFunction((in a) =>
+        {
+            var attribute = AttributeNameOf(NameArgument(in a));
+            if (attribute != null)
+            {
+                element.SetAttribute(attribute, a.Length > 1 ? a[1].ToString() : string.Empty);
+                onAttributeChanged?.Invoke(element);
+            }
+
+            return JSUndefined.Value;
+        }, "set", 2);
+
+        var del = new DomFunction((in a) =>
+        {
+            var attribute = AttributeNameOf(NameArgument(in a));
+            if (attribute != null && element.RemoveAttribute(attribute))
+                onAttributeChanged?.Invoke(element);
+
+            return JSUndefined.Value;
+        }, "delete", 1);
+
+        var keys = new DomFunction((in _) =>
+        {
+            var names = new JSArray();
+            foreach (var (key, _) in element.Attributes)
+            {
+                if (PropertyNameOf(key.LocalName) is { } propertyName)
+                    names.Add(new JSString(propertyName));
+            }
+
+            return names;
+        }, "keys", 0);
+
+        return factory.InvokeFunction(new Arguments(JSUndefined.Value, get, set, del, keys)) as JSObject;
+    }
+
+    private static string? NameArgument(in Arguments a) => a.Length > 0 ? a[0].ToString() : null;
+
+    /// <summary>
+    /// The <c>data-*</c> attribute a <c>dataset</c> property name addresses: each ASCII uppercase
+    /// letter becomes <c>-</c> plus its lowercase form, and the whole is prefixed with <c>data-</c>
+    /// (so <c>dataset.fooBar</c> is <c>data-foo-bar</c>).
+    /// <para>
+    /// A name that already contains <c>-</c> followed by an ASCII lowercase letter has no attribute:
+    /// the mapping back from attributes never produces one, so honouring it would let
+    /// <c>dataset.fooBar</c> and <c>dataset['foo-bar']</c> address the same attribute under two
+    /// spellings. The spec makes it a <c>SyntaxError</c>; this reports "no such property", which is
+    /// what the traps need and what keeps a page's stray read from aborting its script.
+    /// </para>
+    /// </summary>
+    internal static string? AttributeNameOf(string? propertyName)
+    {
+        if (string.IsNullOrEmpty(propertyName))
+            return null;
+
+        var builder = new System.Text.StringBuilder("data-", propertyName.Length + 6);
+        for (var i = 0; i < propertyName.Length; i++)
+        {
+            var c = propertyName[i];
+            if (c == '-' && i + 1 < propertyName.Length && propertyName[i + 1] is >= 'a' and <= 'z')
+                return null;
+
+            if (c is >= 'A' and <= 'Z')
+            {
+                builder.Append('-').Append((char)(c + ('a' - 'A')));
+                continue;
+            }
+
+            builder.Append(c);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// The <c>dataset</c> property name a <c>data-*</c> attribute is seen under — the inverse of
+    /// <see cref="AttributeNameOf"/>. Returns <c>null</c> for an attribute that is not
+    /// <c>data-</c>-prefixed, which is how enumeration skips the element's other attributes.
+    /// </summary>
+    internal static string? PropertyNameOf(string attributeName)
+    {
+        const string Prefix = "data-";
+        if (!attributeName.StartsWith(Prefix, StringComparison.Ordinal) || attributeName.Length == Prefix.Length)
+            return null;
+
+        var builder = new System.Text.StringBuilder(attributeName.Length - Prefix.Length);
+        for (var i = Prefix.Length; i < attributeName.Length; i++)
+        {
+            var c = attributeName[i];
+            if (c == '-' && i + 1 < attributeName.Length && attributeName[i + 1] is >= 'a' and <= 'z')
+            {
+                builder.Append((char)(attributeName[++i] - ('a' - 'A')));
+                continue;
+            }
+
+            builder.Append(c);
+        }
+
+        return builder.ToString();
+    }
+}


### PR DESCRIPTION
Fixes the `Cannot set property eqid of undefined` exception reported on the google.com search page.

## Finding it

The exception named its script once #1636 made traces carry script names — `inline-6`, which on google.com is the `google.ia` async-request module, the code that runs *when a search is issued*. The repeating three-frame cycle in the report is its recursive tree-walker (`function t(a,b){…for(let c of a.children)t(c,!0)}`), six levels deep.

Running that page's scripts against the bridge reproduces the failure one step earlier:

```
inline-6 THREW: Cannot get property ved of undefined
```

which is its `b.dataset.ved`. That reduces to three lines:

```js
<div id="t" data-ved="abc"></div>
document.getElementById('t').dataset            // undefined
document.getElementById('t').dataset.eqid = 'z'
// TypeError: Cannot set property eqid of undefined
```

`Element.dataset` did not exist. That is not a quiet failure: reading through a missing object throws, and a thrown error aborts the whole `<script>`, so the module stopped dead and took every later statement and every listener it would have registered with it.

Worth noting for anyone who tries to grep for it: `eqid` never appears in Google's source. It is a *runtime* key — the code assigns through a computed name — which is why searching the page for it finds nothing and why the property in the message is not a clue to the source line.

## The implementation

A `Proxy` over the element's attributes, not a snapshot object. That distinction is the bug itself: a page may read an attribute the markup carries, overwrite it, **or invent one that no attribute backs yet**, and a snapshot object serves the first two while silently dropping the third onto a throwaway copy. The reported case is the third. With the attributes as the only state, `getAttribute` and `dataset` cannot disagree.

- `getOwnPropertyDescriptor` is implemented alongside `ownKeys`, because `Object.keys`, `JSON.stringify` and spread all filter the key list through it — a proxy answering `ownKeys` alone enumerates as empty.
- The traps return null rather than undefined for "no such attribute", so `data-x=""` reads as `""` and still enumerates instead of looking absent.
- Names map both ways: `dataset.fooBar` ↔ `data-foo-bar`. A property name that already contains `-` followed by a lowercase letter has no attribute (the reverse mapping never produces one), so it reports "no such property" rather than letting two spellings address one attribute.

**Cost.** Built on first read, and the built map replaces its own accessor — so a document's thousands of elements do not each allocate a proxy and four callbacks nothing asks for, and `el.dataset === el.dataset` stays true as it is in a browser. The JS factory is compiled once per realm via a weak per-context cache rather than once per element.

## Verification

`inline-6` runs clean on the real google.com page after this change; before it, it threw.

10 new `DatasetTests` cover the reported case (writing a key no attribute backs), markup reads, both name-mapping directions, enumeration and serialization, `in`, `delete`, empty-vs-absent, liveness and identity, and script-created elements.

Across `ScriptEngineExecute`, `DomTraversalAndRange`, `Dataset`, `WindowIsTheGlobalObject`, `FetchRelativeUrl`, `ScriptNameInStackTrace`, `HtmlBridgePublicApiSnapshot` and `WebMessaging`: **158 passed, 5 failed**, and all 5 are in the pre-existing baseline for this container (4 `ScriptEngineExecuteTests` SVG-zoom/serialization cases and one `Range_GetBoundingClientRect` case). Adding a new enumerable property to every element changed none of them.

## Two things this turned up that are *not* in this PR

Flagging rather than expanding scope:

- **Google's main `/xjs/` bundle fails to parse**: `deferred-0 THREW: Unexpected token BooleanAnd: && at 466, 301`. A gap in the JS parser, and it means the largest script on the page never runs at all — likely the highest-value item left on this page.
- **`document.fonts` is undefined** — the page's first script dies on `document.fonts.load` (Font Loading API missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01725QNtRPh4U2BQhxuubox3

---
_Generated by [Claude Code](https://claude.ai/code/session_01725QNtRPh4U2BQhxuubox3)_