### PR TITLE
Implement btoa and atob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,18 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `Broiler.HtmlBridge` — `btoa` and `atob`, the base64 pair on
+  `WindowOrWorkerGlobalScope` (HTML §8.3), which the bridge did not provide at all. An
+  unqualified `atob(…)` was a `ReferenceError`, and that aborts the whole script that
+  called it rather than the one call — the failure mode google.com's script loader hit.
+  Both work on *binary strings* rather than text: `btoa` treats each code point as one
+  byte and throws `InvalidCharacterError` above U+00FF instead of mangling it, and
+  `atob` returns a string built the same way, so the two round-trip arbitrary bytes.
+  Decoding follows Infra's *forgiving-base64*, written out rather than delegated to
+  `Convert.FromBase64String` because the two disagree exactly where pages notice: ASCII
+  whitespace is stripped from anywhere, unpadded input decodes, and the one-character
+  tail that cannot encode a byte is rejected rather than silently truncated.
+
 - `Broiler.HtmlBridge` — `Element.dataset`, the HTML `DOMStringMap` view over an
   element's `data-*` attributes (HTML §3.2.6.6), which did not exist at all. A missing
   object is not a quiet failure here: reading through it throws, and a thrown error

--- a/src/Broiler.Cli.Tests/Base64Tests.cs
+++ b/src/Broiler.Cli.Tests/Base64Tests.cs
@@ -1,0 +1,123 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// <c>btoa</c> / <c>atob</c> — the base64 pair on <c>WindowOrWorkerGlobalScope</c> (HTML §8.3).
+/// <para>
+/// Neither existed, so an unqualified <c>atob(…)</c> was a <c>ReferenceError</c> — which aborts the
+/// whole script that called it, not just the call. Both are asserted unqualified as well as through
+/// <c>window</c>, because the unqualified spelling is the one pages use and the one that used to
+/// fail.
+/// </para>
+/// </summary>
+public sealed class Base64Tests
+{
+    private static (JSContext Context, DomBridge Bridge) Attach()
+    {
+        var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, "<!doctype html><html><body></body></html>", "https://example.com/");
+        return (context, bridge);
+    }
+
+    private static string Eval(JSContext context, string expression) =>
+        context.Eval($"String({expression})").ToString();
+
+    [Fact]
+    public void BothAreReachable_QualifiedAndUnqualified()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("function", Eval(context, "typeof atob"));
+        Assert.Equal("function", Eval(context, "typeof btoa"));
+        Assert.Equal("function", Eval(context, "typeof window.atob"));
+        Assert.Equal("function", Eval(context, "typeof window.btoa"));
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("f", "Zg==")]
+    [InlineData("fo", "Zm8=")]
+    [InlineData("foo", "Zm9v")]
+    [InlineData("foob", "Zm9vYg==")]
+    [InlineData("hello", "aGVsbG8=")]
+    public void EncodesTheKnownVectors(string plain, string encoded)
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal(encoded, Eval(context, $"btoa('{plain}')"));
+        Assert.Equal(plain, Eval(context, $"atob('{encoded}')"));
+    }
+
+    /// <summary>
+    /// The pair moves bytes, not text: each code unit is one byte in and one byte out, which is what
+    /// makes it usable for the binary payloads pages base64 around.
+    /// </summary>
+    [Fact]
+    public void RoundTripsABinaryString()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("true", Eval(context,
+            "(function(){var s=''; for (var i=0;i<256;i++) s+=String.fromCharCode(i); return atob(btoa(s))===s;})()"));
+    }
+
+    /// <summary>A code point above U+00FF is not a byte, and the spec makes that an error rather than a truncation.</summary>
+    [Fact]
+    public void Btoa_RejectsBeyondLatin1()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("InvalidCharacterError", Eval(context,
+            "(function(){try{ btoa('\\u20ac'); return 'no throw'; }catch(e){ return e.name; }})()"));
+    }
+
+    /// <summary>
+    /// Forgiving-base64 decode: ASCII whitespace anywhere is ignored, and input whose length is not
+    /// a multiple of four decodes without its padding.
+    /// </summary>
+    [Theory]
+    [InlineData("aGVs bG8=", "hello")]
+    [InlineData("aGVs\\nbG8=", "hello")]
+    [InlineData("aGVsbG8", "hello")]
+    [InlineData("Zm9v", "foo")]
+    public void Atob_IsForgiving(string encoded, string expected)
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal(expected, Eval(context, $"atob('{encoded}')"));
+    }
+
+    /// <summary>
+    /// What forgiving does not mean. A one-character tail carries six bits and cannot encode a byte,
+    /// and a character outside the alphabet is not decodable — both are errors, not silent
+    /// truncations that would hand a page the wrong bytes.
+    /// </summary>
+    [Theory]
+    [InlineData("a")]
+    [InlineData("aGVsbG8=a")]
+    [InlineData("aG!s")]
+    [InlineData("a=GVsbG8")]
+    public void Atob_RejectsWhatCannotDecode(string encoded)
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("InvalidCharacterError", Eval(context,
+            $"(function(){{try{{ atob('{encoded}'); return 'no throw'; }}catch(e){{ return e.name; }}}})()"));
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
@@ -46,6 +46,12 @@ public sealed partial class DomBridge
         // window.alert(msg) — logs to debug output
         window.FastAddValue((KeyString)"alert", new DomFunction(Dom.Features.WindowDocumentMiscBinding.Alert, "alert", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
+        // btoa / atob — the WindowOrWorkerGlobalScope base64 pair (HTML §8.3), co-located in the
+        // Base64Binding feature module. The window IS the global object, so registering here is
+        // what makes the unqualified `atob(…)` a page writes resolve as well.
+        window.FastAddValue((KeyString)"btoa", new DomFunction((in a) => Dom.Features.Base64Binding.Btoa(_jsContext!, in a), "btoa", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"atob", new DomFunction((in a) => Dom.Features.Base64Binding.Atob(_jsContext!, in a), "atob", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+
         // console object (shared between window.console and global console)
         var console = Dom.Features.ConsoleBinding.Build();
         window.FastAddValue((KeyString)"console", console, JSPropertyAttributes.EnumerableConfigurableValue);

--- a/src/Broiler.HtmlBridge.Dom/Features/Base64Binding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/Base64Binding.cs
@@ -1,0 +1,139 @@
+using System.Text;
+using Broiler.JavaScript.BuiltIns.String;
+using Broiler.JavaScript.Engine;
+using Broiler.JavaScript.Runtime;
+
+namespace Broiler.HtmlBridge.Dom.Features;
+
+/// <summary>
+/// <c>btoa</c> and <c>atob</c> — the base64 pair on <c>WindowOrWorkerGlobalScope</c>
+/// (HTML §8.3), which the bridge did not provide at all. An unqualified <c>atob(…)</c> was a
+/// <c>ReferenceError</c>, and that aborts the whole script rather than the one call.
+/// <para>
+/// Both work on <em>binary strings</em>, not text: <c>btoa</c> takes a string whose code points are
+/// all ≤ U+00FF and treats each as one byte, and <c>atob</c> returns a string built the same way.
+/// That is why neither is a UTF-8 round trip and why <c>btoa</c> throws on ordinary non-Latin text
+/// — a mistake worth failing loudly rather than mangling, since the alternative silently corrupts
+/// the bytes a page is trying to move.
+/// </para>
+/// </summary>
+internal static class Base64Binding
+{
+    /// <summary>
+    /// <c>btoa(data)</c> — base64-encodes a binary string. Throws <c>InvalidCharacterError</c> for a
+    /// code point above U+00FF, which cannot be one byte.
+    /// </summary>
+    internal static JSValue Btoa(JSContext context, in Arguments a)
+    {
+        var input = a.Length > 0 ? a[0].ToString() : "undefined";
+        var bytes = new byte[input.Length];
+        for (var i = 0; i < input.Length; i++)
+        {
+            if (input[i] > 0xFF)
+            {
+                DomBridge.ThrowDOMException(context,
+                    "The string to be encoded contains characters outside of the Latin1 range.",
+                    "InvalidCharacterError");
+                return JSUndefined.Value;
+            }
+
+            bytes[i] = (byte)input[i];
+        }
+
+        return new JSString(Convert.ToBase64String(bytes));
+    }
+
+    /// <summary>
+    /// <c>atob(data)</c> — decodes base64 to a binary string, by Infra's <em>forgiving-base64
+    /// decode</em>. Throws <c>InvalidCharacterError</c> when the input cannot be decoded.
+    /// </summary>
+    internal static JSValue Atob(JSContext context, in Arguments a)
+    {
+        var input = a.Length > 0 ? a[0].ToString() : "undefined";
+        if (!TryForgivingBase64Decode(input, out var bytes))
+        {
+            DomBridge.ThrowDOMException(context,
+                "The string to be decoded is not correctly encoded.",
+                "InvalidCharacterError");
+            return JSUndefined.Value;
+        }
+
+        // Each byte becomes one code unit, which is what makes the result a binary string rather
+        // than decoded text — the inverse of what Btoa consumed.
+        return new JSString(string.Create(bytes.Length, bytes, static (chars, source) =>
+        {
+            for (var i = 0; i < source.Length; i++)
+                chars[i] = (char)source[i];
+        }));
+    }
+
+    /// <summary>
+    /// Infra's forgiving-base64 decode. Written out rather than delegated to
+    /// <see cref="Convert.FromBase64String"/> because the two disagree at the edges that matter
+    /// here: this one strips ASCII whitespace anywhere, accepts unpadded input whose length is not a
+    /// multiple of four, and rejects the one-character tail that cannot encode any byte —
+    /// distinctions a page relying on the platform's behaviour will hit.
+    /// </summary>
+    internal static bool TryForgivingBase64Decode(string input, out byte[] bytes)
+    {
+        bytes = [];
+
+        var builder = new StringBuilder(input.Length);
+        foreach (var c in input)
+        {
+            // The ASCII whitespace set Infra defines — notably not every Unicode space.
+            if (c is '\t' or '\n' or '\f' or '\r' or ' ')
+                continue;
+            builder.Append(c);
+        }
+
+        var data = builder.ToString();
+
+        // Padding is stripped only from input that is already a multiple of four; anywhere else an
+        // '=' is simply a character outside the alphabet, and so a failure.
+        if (data.Length % 4 == 0)
+        {
+            if (data.EndsWith("==", StringComparison.Ordinal))
+                data = data[..^2];
+            else if (data.EndsWith('='))
+                data = data[..^1];
+        }
+
+        // A single leftover character carries six bits: not enough for a byte, and not a tail any
+        // encoder produces.
+        if (data.Length % 4 == 1)
+            return false;
+
+        var output = new byte[data.Length * 3 / 4];
+        var written = 0;
+        var buffer = 0;
+        var bits = 0;
+        foreach (var c in data)
+        {
+            var value = DecodeChar(c);
+            if (value < 0)
+                return false;
+
+            buffer = (buffer << 6) | value;
+            bits += 6;
+            if (bits >= 8)
+            {
+                bits -= 8;
+                output[written++] = (byte)((buffer >> bits) & 0xFF);
+            }
+        }
+
+        bytes = written == output.Length ? output : output[..written];
+        return true;
+    }
+
+    private static int DecodeChar(char c) => c switch
+    {
+        >= 'A' and <= 'Z' => c - 'A',
+        >= 'a' and <= 'z' => c - 'a' + 26,
+        >= '0' and <= '9' => c - '0' + 52,
+        '+' => 62,
+        '/' => 63,
+        _ => -1,
+    };
+}


### PR DESCRIPTION
Fixes the `atob is not defined` exception reported on the google.com search page.

## The gap

The bridge provided neither half of the `WindowOrWorkerGlobalScope` base64 pair (HTML §8.3). Probing a freshly attached bridge:

```
typeof atob         => undefined
typeof btoa         => undefined
typeof window.atob  => undefined
typeof window.btoa  => undefined
```

An unqualified `atob(…)` is therefore a `ReferenceError`, and that aborts the whole script that called it rather than just the call. On the reported page the caller is a module loader, so everything it would have gone on to load never loaded either.

## The implementation

Both work on **binary strings** rather than text, which is the part that is easy to get wrong. `btoa` treats each code point as one byte and throws `InvalidCharacterError` above U+00FF rather than truncating it; `atob` returns a string built the same way. That is what lets the two round-trip arbitrary bytes, and it is why `btoa` is not a UTF-8 encoder — a page passing it ordinary non-Latin text has made a mistake worth failing loudly, since the alternative silently corrupts the bytes it is trying to move.

Decoding is Infra's *forgiving-base64*, written out rather than delegated to `Convert.FromBase64String` because the two disagree precisely where a page will notice:

- ASCII whitespace is stripped from anywhere in the input, not just the ends.
- Unpadded input whose length is not a multiple of four decodes.
- The one-character tail carries six bits and cannot encode a byte, so it is rejected. Silently truncating it would hand a page bytes it never encoded.
- `=` is only padding on input already a multiple of four; anywhere else it is a character outside the alphabet, and so a failure.

Registered on `window`, which since #1634 *is* the global object — that is what makes the unqualified spelling a page actually writes resolve.

## Verification

17 tests: the RFC 4648 vectors both directions, a round trip over all 256 byte values, the Latin-1 rejection, the forgiving cases (embedded space, embedded newline, unpadded), and four rejection cases (`a`, `aGVsbG8=a`, `aG!s`, `a=GVsbG8`) each asserting the `InvalidCharacterError` name rather than merely that something threw.

Across `Base64`, `Dataset`, `ScriptEngineExecute`, `WindowIsTheGlobalObject`, `WindowGlobalSync`, `WindowGlobalMirror`, `HtmlBridgePublicApiSnapshot` and `GoogleSearchPolyfill`: **209 passed, 16 failed**, and all 16 are in this container's pre-existing baseline, name for name (12 `GoogleSearchPolyfillTests` SVG-hit-testing / scroll / font-relative-unit cases and 4 `ScriptEngineExecuteTests` serialization cases).

## One thing in the report that is *not* a bug

Most frames of the trace read `vm.js:5730` rather than a script name, which looks like a regression against #1636. It is not: those frames are page-invoked `eval()`. Evaluating one and reading its stack confirms eval'd code names itself `vm.js`, which is the same synthetic naming a browser uses (DevTools' `VM<n>`). The named frames in the same trace — `ia in inline-3:9`, `la in inline-3:13` — are the document's own scripts, so script naming is working as intended. `inline-3` is a small loader `eval`ing a large minified bundle, which is why the two alternate.

## Still open on this page

Neither is in this PR:

- **Google's main `/xjs/` bundle fails to parse**: `Unexpected token BooleanAnd: && at 466, 301`. A gap in the JS parser, and the largest script on the page never runs at all.
- **`document.fonts` is undefined** — the page's first script dies on `document.fonts.load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01725QNtRPh4U2BQhxuubox3

---
_Generated by [Claude Code](https://claude.ai/code/session_01725QNtRPh4U2BQhxuubox3)_