### PR TITLE
Number the anonymous programs in stack traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,17 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `Broiler.JS` (patch, awaiting a maintainer — see `patches/README.md`) — `eval` and the
+  `Function` constructor's body were all compiled as `vm.js`, one name for every program that
+  has no script of its own. A stack trace through a module loader is then unreadable, because
+  its frames cannot be attributed: `vm.js:1,14` and `vm.js:5060,25473` give no way to tell
+  whether that is one program or two, and which it is decides whether the failing function was
+  defined where it was called or somewhere else entirely. They are numbered now, the way
+  devtools shows `VM123` — `vm1.js`, `vm2.js`, one name per compiled program. A script that
+  already has a name keeps it; only the fallback changed. Re-evaluating identical source may
+  reuse a cached compilation, and its name with it, which is right: the name still identifies
+  exactly one piece of code.
+
 - `Broiler.HtmlBridge` — CSS Font Loading (css-font-loading-3): `FontFace` and the
   `document.fonts` `FontFaceSet` did not exist, so `document.fonts` was undefined and
   `document.fonts.load(…)` a TypeError. That does not stop at the font code asking for it — on

--- a/patches/0001-number-anonymous-programs.patch
+++ b/patches/0001-number-anonymous-programs.patch
@@ -1,0 +1,158 @@
+From f5888958353cbca89a27ea08f64d8037e6f4603a Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Thu, 13 Aug 2026 18:52:32 +0000
+Subject: [PATCH] Number the programs that have no script name of their own
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+eval, and the Function constructor's body, were all compiled as "vm.js". One
+name for every such program makes a stack trace through a module loader
+unreadable, because the frames cannot be attributed to anything: two frames
+reading `vm.js:1,14` and `vm.js:5060,25473` give no way to tell whether that
+is one program or two — and which it is decides whether the failing function
+was defined where it was called or somewhere else entirely.
+
+That is not hypothetical. A `b is not defined` on google.com has been
+reported four times with exactly that pair of frames, and the ambiguity is
+the reason it cannot be read: the identifier is in a module payload the
+loader evaluates, but the trace cannot say which payload, or even that a
+payload is involved at all rather than one program calling itself.
+
+So number them, the way a browser's devtools does with VM123. Frames now read
+vm1.js, vm2.js and so on, one name per compiled program, and a trace spanning
+several says which is which. A script that already has a name — every script
+that comes from the document, since #1636 — keeps it; this only replaces the
+fallback.
+
+Re-evaluating identical source may reuse a cached compilation and its name
+with it, which is right: the name still identifies exactly one piece of code.
+
+Compiler 1297 passed (3 new), Parser 111, BuiltIns 2118, Integration 4598
+(the one failure is an unrelated docs/roadmap.md existence check).
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01725QNtRPh4U2BQhxuubox3
+---
+ .../AnonymousProgramNamingTests.cs            | 74 +++++++++++++++++++
+ .../FastCompiler.cs                           | 14 +++-
+ 2 files changed, 87 insertions(+), 1 deletion(-)
+ create mode 100644 Broiler.JS/Broiler.JavaScript.Compiler.Tests/AnonymousProgramNamingTests.cs
+
+diff --git a/Broiler.JS/Broiler.JavaScript.Compiler.Tests/AnonymousProgramNamingTests.cs b/Broiler.JS/Broiler.JavaScript.Compiler.Tests/AnonymousProgramNamingTests.cs
+new file mode 100644
+index 00000000..0c0f47cc
+--- /dev/null
++++ b/Broiler.JS/Broiler.JavaScript.Compiler.Tests/AnonymousProgramNamingTests.cs
+@@ -0,0 +1,74 @@
++using Broiler.JavaScript.Engine;
++
++namespace Broiler.JavaScript.Compiler.Tests;
++
++// Naming for programs that have no script of their own: eval, and the Function constructor's body.
++//
++// They were all compiled as "vm.js". One name for every such program makes a stack trace through a
++// module loader unreadable, because the frames cannot be attributed: two frames reading
++// `vm.js:1,14` and `vm.js:5060,25473` give no way to tell whether that is one program or two — and
++// which it is decides whether the failing function was defined where it was called or somewhere
++// else entirely. Numbering them (the way devtools shows VM123) makes each program identifiable.
++public class AnonymousProgramNamingTests
++{
++    private static string StackOf(JSContext context, string script, string label) =>
++        context.Eval($"(function(){{ try {{ {script} }} catch (e) {{ return e.stack; }} }})()", label).ToString();
++
++    // The reported shape: one eval'd program defines a function, a second calls it. The two frames
++    // have to name different programs.
++    [Fact]
++    public void TwoEvaluatedPrograms_AreNamedApart()
++    {
++        using var context = new JSContext();
++
++        var stack = StackOf(
++            context,
++            "globalThis.NS = {};" +
++            " (0,eval)('(function(_){ _.f = function(){ return nosuchvalue; }; })(globalThis.NS)');" +
++            " (0,eval)('(function(){ return globalThis.NS.f(); })()');",
++            "outer.js");
++
++        var names = new HashSet<string>();
++        foreach (var line in stack.Split('\n'))
++        {
++            var start = line.IndexOf("vm", StringComparison.Ordinal);
++            if (start < 0)
++                continue;
++            var end = line.IndexOf(".js", start, StringComparison.Ordinal);
++            if (end > start)
++                names.Add(line.Substring(start, end - start + 3));
++        }
++
++        // Both programs appear, under names that differ.
++        Assert.True(names.Count >= 2, $"expected at least two distinct program names, got [{string.Join(", ", names)}] in: {stack}");
++        Assert.DoesNotContain("vm.js", names);
++    }
++
++    // Distinct sources get distinct names, so a name never covers two different programs.
++    // (Re-evaluating the *same* source may reuse a cached compilation, and reusing its name with
++    // it is right — the name still identifies exactly one piece of code.)
++    [Fact]
++    public void DistinctEvaluatedSources_GetDistinctNames()
++    {
++        using var context = new JSContext();
++
++        var first = StackOf(context, "(0,eval)('nosuchvalue;');", "outer.js");
++        var second = StackOf(context, "(0,eval)('\\n nosuchvalue;');", "outer.js");
++
++        Assert.NotEqual(first, second);
++        Assert.DoesNotContain("vm.js", first);
++        Assert.DoesNotContain("vm.js", second);
++    }
++
++    // A script that HAS a name keeps it — the numbering is only the fallback.
++    [Fact]
++    public void ANamedScript_KeepsItsName()
++    {
++        using var context = new JSContext();
++
++        var stack = StackOf(context, "nosuchvalue;", "inline-3");
++
++        Assert.Contains("inline-3", stack);
++        Assert.DoesNotContain("vm.js", stack);
++    }
++}
+diff --git a/Broiler.JS/Broiler.JavaScript.Compiler/FastCompiler.cs b/Broiler.JS/Broiler.JavaScript.Compiler/FastCompiler.cs
+index cfa5d4a1..015795fb 100644
+--- a/Broiler.JS/Broiler.JavaScript.Compiler/FastCompiler.cs
++++ b/Broiler.JS/Broiler.JavaScript.Compiler/FastCompiler.cs
+@@ -1,4 +1,5 @@
+ ﻿using System;
++using System.Threading;
+ using System.Collections.Generic;
+ using System.Reflection;
+ using Broiler.JavaScript.ExpressionCompiler.Expressions;
+@@ -76,11 +77,22 @@ public partial class FastCompiler : AstMapVisitor<BExpression>
+ 
+     public BExpression<JSFunctionDelegate> Method { get; }
+ 
++    // Numbers the anonymous programs above. Static and interlocked because compilation is not
++    // confined to one thread, and a repeated name would defeat the point of numbering at all.
++    private static int anonymousProgramSequence;
++
+     public FastCompiler(in StringSpan code, string location = null, IList<string> argsList = null, ICodeCache codeCache = null)
+     {
+         pool = new FastPool();
+ 
+-        location = location ?? "vm.js";
++        // Code with no script of its own — eval, and the Function constructor's body — was named
++        // "vm.js" without distinction, so every such program shared one name. A stack trace
++        // spanning several of them then could not be read: frames reading `vm.js:1,14` and
++        // `vm.js:5060,25473` give no way to tell whether that is one program or two, which is
++        // exactly what a trace through a module loader looks like. Number them, the way a
++        // browser's devtools does with VM123, so each compiled program is identifiable and its
++        // frames can be attributed to it.
++        location = location ?? "vm" + Interlocked.Increment(ref anonymousProgramSequence).ToString() + ".js";
+         this.location = location;
+         var context = JSEngine.Current as JSContext;
+         isDirectEvalCompilation = context?.IsCompilingDirectEval ?? false;
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,7 +1,6 @@
 # Submodule patches waiting to be applied
 
-**Nothing is waiting on a maintainer right now.** This directory is empty of
-patches, which is the expected steady state — see below.
+**One patch is waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -45,25 +44,50 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD && echo "live on CI"
 
 ## The index
 
-_Empty._ The two patches that were here — the `Broiler.JS` postfix-`++` parser fix and the
-`Broiler.CSS` `@supports` evaluator — both landed upstream, and both pinned pointers carry
-them (`434db760` and `8be7a65`). They reach CI through the pointer now, so their files and
-their `scripts/apply-pending-wpt-patches.sh` entries are gone with them: this directory is a
-backlog, not an archive.
+| # | submodule | subject |
+| --- | --- | --- |
+| `0001` | `Broiler.JS` | Number the programs that have no script name of their own |
 
-Numbering therefore restarts at `0001` for the next patch added.
+### `0001` — every anonymous program was called `vm.js`
+
+`eval`, and the `Function` constructor's body, were all compiled as `vm.js`. One
+name for every such program makes a stack trace through a module loader
+unreadable, because the frames cannot be attributed: two frames reading
+`vm.js:1,14` and `vm.js:5060,25473` give no way to tell whether that is one
+program or two — and which it is decides whether the failing function was
+defined where it was called or somewhere else entirely.
+
+That is not hypothetical. A `b is not defined` on google.com has been reported
+four times with exactly that pair of frames, and this ambiguity is why it cannot
+be read: the identifier is in a module payload the loader evaluates, but the
+trace cannot say *which* payload, or even that a payload is involved at all
+rather than one program calling itself.
+
+So the fallback numbers them, the way devtools shows `VM123`: frames read
+`vm1.js`, `vm2.js` and so on, one name per compiled program. A script that
+already has a name — every script from the document, since the script-naming
+work — keeps it; only the fallback changes.
+
+**Why it is not listed for the pixel suites.** It changes what a frame is
+*called* and nothing about what any program computes, so no pixel moves either
+way. Its behaviour is unit-tested inside the patch
+(`AnonymousProgramNamingTests`), and listing it would add a patch application to
+every pixel run for no observable difference.
+
+**When it lands upstream:** bump the pointer and delete this patch.
 
 ## A stale entry in the apply script is not inert
 
-An earlier `0001` (`Broiler.HTML`, root-relative stylesheet href) had **landed upstream** — the
-pinned pointer *was* its commit — but was still listed. The idempotence guard did not save it:
-the guard skips a patch whose *reverse* apply succeeds, and the upstream commit was not
-byte-identical to the patch as exported, so the reverse check failed too. Applying neither way,
-it was reported as drifted and `scripts/apply-pending-wpt-patches.sh` exited 1 on **every** run
-— taking down the suites it exists to serve, and every later entry with it.
+An earlier `0001` (`Broiler.HTML`, root-relative stylesheet href) had **landed
+upstream** — the pinned pointer *was* its commit — but was still listed. The
+idempotence guard did not save it: the guard skips a patch whose *reverse* apply
+succeeds, and the upstream commit was not byte-identical to the patch as
+exported, so the reverse check failed too. Applying neither way, it was reported
+as drifted and `scripts/apply-pending-wpt-patches.sh` exited 1 on **every** run —
+taking down the suites it exists to serve, and every later entry with it.
 
-So when that script reports drift, check whether the fix is simply upstream before regenerating
-anything:
+So when that script reports drift, check whether the fix is simply upstream
+before regenerating anything:
 
 ```sh
 git -C <Submodule> log --oneline --grep '<the commit subject>'

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -136,11 +136,13 @@ set -euo pipefail
 # The postfix-++ parser patch that was 0001 before this one landed upstream as Broiler.JS
 # 434db760 — the pinned pointer itself — so it reaches CI through the pointer and its entry and
 # file are gone with it. The @supports-evaluator patch that replaced it went the same way, as
-# Broiler.CSS 8be7a65, which is why nothing is listed below.
+# Broiler.CSS 8be7a65.
 #
-# Nothing pending. This is the expected steady state, not a sign the mechanism is unused: a
-# patch is added here only while its submodule fix is waiting, and removed the moment the
-# pointer carries it.
+# 0001 (Broiler.JS, number the programs that have no script name) is deliberately NOT listed. It
+# changes what a stack frame is *called* — "vm1.js" where every anonymous program used to be
+# "vm.js" — and nothing about what any of them computes. No pixel moves either way, and its
+# behaviour is unit-tested inside the patch itself (AnonymousProgramNamingTests). Listing it
+# would only add a patch application to every pixel run for no observable difference.
 PENDING_PATCHES=()
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
> [!WARNING]
> **This does not fix `b is not defined`.** It makes the next report of it legible. I want that stated up front rather than buried — the investigation is genuinely unresolved, and the section at the bottom says exactly what is and is not established.

## The gap

`eval`, and the `Function` constructor's body, were all compiled as `vm.js` — one name for every program with no script of its own. A stack trace through a module loader is then unreadable, because its frames cannot be attributed:

```
at inline:vm.js:1,14
at inline:vm.js:5060,25473
```

Is that one program or two? Which it is decides whether the failing function was defined where it was called or somewhere else entirely, and the trace cannot say.

That is not hypothetical. `b is not defined` on google.com has now been reported **four times** with exactly that pair of frames, and this ambiguity is why I cannot read them: the identifier is in a module payload the loader evaluates, but the trace cannot say *which* payload — or even that a payload is involved at all, rather than one program calling itself.

## The change

The fallback numbers them, the way devtools shows `VM123`: `vm1.js`, `vm2.js`, one name per compiled program. Before and after, for one program calling a function the other defined:

| before | after |
| --- | --- |
| `at inline:vm.js:1,33`<br>`at inline:vm.js:4,13` | `at inline:vm1.js:1,33`<br>`at inline:vm2.js:4,13` |

A script that already has a name — every script from the document, since the script-naming work — keeps it. Only the fallback changed.

Re-evaluating identical source may reuse a cached compilation and its name with it, which is right: the name still identifies exactly one piece of code. The tests assert that property rather than "every call gets a fresh number", which was my first (wrong) guess and which the compilation cache correctly refutes.

## Shipping

The fix is in `Broiler.JS`, whose remote answers **403** from this session, so it ships as `patches/0001-number-anonymous-programs.patch` with the pointer unbumped. Its tests travel inside the patch — until it is applied, a main-repo test asserting the new names would fail CI.

It is **deliberately not listed** in `scripts/apply-pending-wpt-patches.sh`: it changes what a frame is *called* and nothing about what any program computes, so no pixel moves either way, and listing it would add a patch application to every pixel run for no observable difference.

## Verification

`Broiler.JS` with the patch applied: Compiler **1297** passed (3 new), Parser 111, BuiltIns 2118, Integration 4598 — the single failure there is an unrelated `docs/roadmap.md` existence check. This repo: 334 passed with the 18 pre-existing baseline failures, name for name.

`ScriptNameInStackTraceTests` still passes, which is worth stating explicitly since it asserts `DoesNotContain("vm.js")`: `vm1.js` does not contain the substring `vm.js`. I checked rather than assumed.

## Where `b is not defined` actually stands

**What the frames establish.** `(function(_){` is exactly thirteen characters, so a function body at column 14 of line 1 is that wrapper — Google's module-payload IIFE. The ten frames above it share one line and differ only in column, so they are ten functions minified onto one line of a much larger program. A payload, called from a bundle. Across all four reports the columns are byte-identical and only the line moves (5693 → 3297 → 1793 → 5060), which is different Google builds placing the same module at a different line.

**Eight mechanisms tested directly, all correct** — so none of them is the cause:

| | |
| --- | --- |
| direct + indirect `eval` scoping | closures captured across eval boundaries |
| cross-script `var`/`let`/`function`, `new Function` | `try`/`catch` catching `ReferenceError` |
| `with` scopes (the frame names `ResolveIdentifier**WithoutWithScopes**`) | Annex B block-function hoisting |
| `this` at the top level of eval'd code | eval line numbering |

**Two dead ends worth recording**, so nobody re-walks them: I claimed the shifting line number was a Broiler bug — it is not, eval line numbering is correct and stable, retracted. And I suspected dynamically injected `<script>` elements were the source of the `vm.js` frames — they do not execute in Broiler at all, so the frames are genuine `eval`.

**What is still needed.** The cause is in code I cannot reach: anti-bot blocks every SERP fetch, and the reported page differs from anything I can retrieve — its loader script has 13+ lines and calls `eval`, while today's homepage version of the same script has 11 lines and no `eval` at all. Either the page HTML or just that loader script (the one defining `ia` and `la`) would let me reproduce it directly. Failing that, a re-run with this patch applied narrows it on its own, since the trace will finally say whether the payload defining the function is the same program that calls it.

## Also still open

- **`inline-10`** — `Cannot get property substring of undefined`, in the 37 KB `pmc` page-config script. Untouched here, separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01725QNtRPh4U2BQhxuubox3

---
_Generated by [Claude Code](https://claude.ai/code/session_01725QNtRPh4U2BQhxuubox3)_