### PR TITLE
Name the property in "Cannot read properties of undefined"

### DIFF
--- a/patches/0002-name-property-in-typeerror.patch
+++ b/patches/0002-name-property-in-typeerror.patch
@@ -1,0 +1,165 @@
+From 7259b19e869c211d3b099f41c57bc2f24eb4e497 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 14 Aug 2026 06:13:35 +0000
+Subject: [PATCH] Name the property in "Cannot read properties of undefined"
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The message said only that something was read off nothing. On minified code
+that is not enough to find the line, let alone the cause: the report this came
+from is a TypeError at column 33839 of a 61 908-character line, and the message
+narrowed it not at all.
+
+Browsers append "(reading 'foo')". So does this now.
+
+Only the COMPUTED read was affected. A static one (`u.foo`) already named its
+property, and a literal computed key folds into that same path — which is why
+this went unnoticed: it is the variable-key form, `I[Y]`, that minified code
+actually emits, and the only one that reached the generic message.
+
+An object key is deliberately left undescribed. GetValue throws before
+ToPropertyKey precisely because ToObject(base) comes first (6.2.5.5), so
+describing such a key would run its toString/@@toPrimitive — user code, in an
+order the spec forbids. A diagnostic does not get to change evaluation, so an
+object key is left alone rather than coerced for a message.
+
+Noted while testing and NOT addressed here: a numeric variable key
+(`var k = 3; u[k]`) does not throw at all, it evaluates to undefined. That is a
+separate defect in the indexed read path; the test says so rather than covering
+for it.
+
+Compiler 1306 passed (5 new), BuiltIns 2118, Integration 4598 with only the
+unrelated docs/roadmap.md check failing.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01725QNtRPh4U2BQhxuubox3
+---
+ .../UndefinedPropertyReadMessageTests.cs      | 68 +++++++++++++++++++
+ .../Broiler.JavaScript.Runtime/JSValue.cs     | 30 +++++++-
+ 2 files changed, 97 insertions(+), 1 deletion(-)
+ create mode 100644 Broiler.JS/Broiler.JavaScript.Compiler.Tests/UndefinedPropertyReadMessageTests.cs
+
+diff --git a/Broiler.JS/Broiler.JavaScript.Compiler.Tests/UndefinedPropertyReadMessageTests.cs b/Broiler.JS/Broiler.JavaScript.Compiler.Tests/UndefinedPropertyReadMessageTests.cs
+new file mode 100644
+index 00000000..7698329c
+--- /dev/null
++++ b/Broiler.JS/Broiler.JavaScript.Compiler.Tests/UndefinedPropertyReadMessageTests.cs
+@@ -0,0 +1,68 @@
++using Broiler.JavaScript.Engine;
++
++namespace Broiler.JavaScript.Compiler.Tests;
++
++// Naming the property in "Cannot read properties of undefined".
++//
++// The static path (`u.foo`) already said which property. The COMPUTED path (`u[k]`) did not, and
++// that is the one minified code takes: a bundle reads `I[Y]`, so the message named nothing at all
++// and the trace gave a column in a 61 908-character line. Browsers append "(reading 'foo')"; so
++// does this now.
++public class UndefinedPropertyReadMessageTests
++{
++    private static string MessageOf(string source)
++    {
++        using var context = new JSContext();
++        return context.Eval($"String((function(){{ try {{ {source} }} catch (e) {{ return e.message; }} return 'no throw'; }})())", "t.js")
++            .ToString();
++    }
++
++    // The reported shape: a computed read off a call that returned undefined.
++    [Fact]
++    public void AComputedRead_NamesTheProperty()
++    {
++        Assert.Equal(
++            "Cannot read properties of undefined (reading 'p')",
++            MessageOf("var A = function(){ return undefined; }; var I = A(); var Y = 'p'; return I[Y];"));
++    }
++
++    // A key held in a variable is what reaches the dynamic path; a literal one is folded into the
++    // static read, which has its own (already-naming) message.
++    //
++    // Only the string key is covered: a NUMERIC variable key (`var k = 3; u[k]`) does not throw at
++    // all today, it evaluates to undefined. That is a separate defect in the indexed read path,
++    // not something this message change causes or fixes, and it is left for its own change rather
++    // than smuggled in here.
++    [Theory]
++    [InlineData("var u; var k = 'bar'; return u[k];", "Cannot read properties of undefined (reading 'bar')")]
++    public void PrimitiveKeys_AreNamed(string source, string expected)
++    {
++        Assert.Equal(expected, MessageOf(source));
++    }
++
++    // An OBJECT key is deliberately left undescribed. GetValue throws before ToPropertyKey because
++    // ToObject(base) comes first (6.2.5.5); describing the key would run its toString/@@toPrimitive
++    // — user code, in an order the spec forbids. A diagnostic does not get to change evaluation.
++    [Fact]
++    public void AnObjectKey_IsNotCoercedForTheMessage()
++    {
++        var message = MessageOf("var u; var k = { toString: function(){ throw new Error('key coerced'); } }; return u[k];");
++
++        Assert.Equal("Cannot read properties of undefined", message);
++    }
++
++    // The static path already named the property and keeps its own wording.
++    [Fact]
++    public void AStaticReadIsUnchanged()
++    {
++        Assert.Equal("Cannot get property foo of undefined", MessageOf("var u; return u.foo;"));
++        Assert.Equal("Cannot get property foo of null", MessageOf("return null.foo;"));
++    }
++
++    // A read that succeeds is untouched.
++    [Fact]
++    public void ASuccessfulReadStillSucceeds()
++    {
++        Assert.Equal("1", MessageOf("var o = { a: 1 }; return String(o['a']);"));
++    }
++}
+diff --git a/Broiler.JS/Broiler.JavaScript.Runtime/JSValue.cs b/Broiler.JS/Broiler.JavaScript.Runtime/JSValue.cs
+index 1197a3e6..f1fb3333 100644
+--- a/Broiler.JS/Broiler.JavaScript.Runtime/JSValue.cs
++++ b/Broiler.JS/Broiler.JavaScript.Runtime/JSValue.cs
+@@ -1290,12 +1290,40 @@ public abstract partial class JSValue : IDynamicMetaObjectProvider, IPropertyAcc
+         return UndefinedValue;
+     }
+ 
++    /// <summary>
++    /// Names the property in a "Cannot read properties of undefined" message, as a browser does
++    /// ("... (reading 'foo')"). Without it the message says only that *something* was read off
++    /// nothing, which on minified code is not enough to find the line, let alone the cause.
++    /// </summary>
++    /// <remarks>
++    /// Only a key that is already a primitive is named. Converting one is what the caller must
++    /// NOT do here — GetValue throws before ToPropertyKey precisely because ToObject(base)
++    /// comes first (6.2.5.5), and an object key's toString/@@toPrimitive is user code that would
++    /// then run in an order the spec forbids. So an object key is left undescribed rather than
++    /// coerced for a diagnostic.
++    /// </remarks>
++    private static string DescribeKeyForDiagnostic(JSValue key)
++    {
++        if (key == null || !(key.IsString || key.IsNumber || key.IsSymbol))
++            return string.Empty;
++
++        try
++        {
++            return $" (reading '{key}')";
++        }
++        catch (Exception)
++        {
++            // A description must never replace the error it is describing.
++            return string.Empty;
++        }
++    }
++
+     internal JSValue GetValue(JSValue key, JSValue receiver, bool throwError = true)
+     {
+         // Per spec (6.2.5.5 GetValue), ToObject(base) must precede ToPropertyKey(key).
+         // For null/undefined, ToObject throws TypeError before the key is converted.
+         if (IsNullOrUndefined)
+-            throw NewTypeError?.Invoke($"Cannot read properties of {this}")
++            throw NewTypeError?.Invoke($"Cannot read properties of {this}{DescribeKeyForDiagnostic(key)}")
+                 ?? new InvalidOperationException("JSValue.NewTypeError delegate is not initialized. Ensure the BuiltIns assembly module initializer has run.");
+ 
+         var k = key.ToKey(false);
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # Submodule patches waiting to be applied
 
-**One patch is waiting on a maintainer.** See the index below.
+**Two patches are waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -47,6 +47,7 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD && echo "live on CI"
 | # | submodule | subject |
 | --- | --- | --- |
 | `0001` | `Broiler.JS` | Keep a direct eval's scope alive for the closures it creates |
+| `0002` | `Broiler.JS` | Name the property in "Cannot read properties of undefined" |
 
 ### `0001` — a closure a direct eval created lost the eval site's bindings
 
@@ -86,6 +87,33 @@ that purpose, which has since landed upstream.
 runs at all rather than what any of it paints, and the pixel suites do not
 execute a loader of this shape. Its behaviour is unit-tested inside the patch
 (`DirectEvalClosureScopeTests`).
+
+**When it lands upstream:** bump the pointer and delete this patch.
+
+### `0002` — the message said only that *something* was read off nothing
+
+`Cannot read properties of undefined`, with no property named. On minified code
+that does not locate the line, let alone the cause: the report it came from is a
+TypeError at column 33839 of a 61 908-character line. Browsers append
+`(reading 'foo')`; so does this.
+
+Only the **computed** read was affected. A static one (`u.foo`) already named its
+property, and a literal computed key (`u['foo']`) folds into that same path —
+which is why it went unnoticed. The variable-key form `I[Y]` is what minified
+code actually emits, and the only one that reached the generic message.
+
+An **object** key is deliberately left undescribed: `GetValue` throws before
+`ToPropertyKey` precisely because `ToObject(base)` comes first (6.2.5.5), so
+describing such a key would run its `toString`/`@@toPrimitive` — user code, in an
+order the spec forbids. A diagnostic does not get to change evaluation.
+
+**Found while testing and not fixed here:** a numeric variable key
+(`var k = 3; u[k]`) does not throw at all, it evaluates to `undefined`. That is a
+separate defect in the indexed read path; the test records it rather than
+covering for it.
+
+**Not listed for the pixel suites** — it changes an error message, nothing a page
+paints. `UndefinedPropertyReadMessageTests` covers it.
 
 **When it lands upstream:** bump the pointer and delete this patch.
 


### PR DESCRIPTION
## First: the direct-eval fix worked

`b is not defined` is gone. The evalled payload (`vm16`) no longer appears in the trace **at all**, and google.com's bundle now runs deeper before failing. That confirms #1644 end to end against the real page.

## What it fails with now

A TypeError whose message says only that *something* was read off nothing:

```
TypeError: Cannot read properties of undefined
    at inline:vm15.js:1753,33839
```

Column 33839 of a **61,908-character line**. The message locates nothing. Browsers append `(reading 'foo')`; so does this now.

The failing expression is:

```js
I = A(x, (Y = K(W, r), e));   ← col 33839
while (…) if (a(P, x, I[Y]), true) break;
```

`A` returns `z.prototype` and evidently returned `undefined`, so `I[Y]` throws — the variable-key computed read, exactly the shape this PR makes legible.

## Why it went unnoticed

Only the **computed** read was affected:

| form | message before |
| --- | --- |
| `u.foo` (static) | `Cannot get property foo of undefined` — already named |
| `u['foo']` (literal key) | folds into the static path — already named |
| `u[k]` (variable key) | `Cannot read properties of undefined` — **named nothing** |

The variable-key form is the one minified code actually emits, and the only one that reached the generic message.

## What it deliberately does not do

An **object** key is left undescribed. `GetValue` throws before `ToPropertyKey` precisely because `ToObject(base)` comes first (6.2.5.5), so describing such a key would run its `toString`/`@@toPrimitive` — user code, in an order the spec forbids. A diagnostic does not get to change evaluation, so an object key is left alone rather than coerced for a message. There's a test asserting a throwing `toString` is never invoked.

## A separate defect found while testing, not fixed here

A **numeric** variable key does not throw at all:

```js
var u; var k = 3; u[k]   // → undefined, should be a TypeError
```

That's in the indexed read path, unrelated to this message change. The test records it explicitly rather than covering for it — worth its own change.

## Verification

Compiler **1306** passed (5 new), BuiltIns 2118, Integration 4598 with only the unrelated `docs/roadmap.md` check failing.

## Shipping

`Broiler.JS` answers **403**, so this is `patches/0002-name-property-in-typeerror.patch`. Note `0001` (the direct-eval fix) is **still pending** — I verified `0002` applies both independently and on top of `0001`, since they touch different files. Neither is listed for the pixel suites; this one changes an error message, nothing a page paints.

## What closes out the current failure

With this applied, the next trace will read `(reading 'x')` and name what `A` failed to return — which should point straight at the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01725QNtRPh4U2BQhxuubox3

---
_Generated by [Claude Code](https://claude.ai/code/session_01725QNtRPh4U2BQhxuubox3)_