### PR TITLE
Add context menu and clipboard shortcuts to StandardEdit

### DIFF
--- a/Broiler.UI/Broiler.UI.slnx
+++ b/Broiler.UI/Broiler.UI.slnx
@@ -498,6 +498,12 @@
     </Project>
   </Folder>
   <Folder Name="/tests/Text/">
+    <Project Path="tests/Text/Broiler.UI.Edit.Standard.Tests/Broiler.UI.Edit.Standard.Tests.csproj">
+      <BuildType Project="Debug" Solution="Debug-Linux|*" />
+      <BuildType Project="Release" Solution="Release-Linux|*" />
+      <BuildType Project="Debug" Solution="Debug-Windows|*" />
+      <BuildType Project="Release" Solution="Release-Windows|*" />
+    </Project>
     <Project Path="tests/Text/Broiler.UI.FormatCodeView.Tests/Broiler.UI.FormatCodeView.Tests.csproj">
       <BuildType Project="Debug" Solution="Debug-Linux|*" />
       <BuildType Project="Release" Solution="Release-Linux|*" />

--- a/Broiler.UI/src/Implementations/Standard/Text/Broiler.UI.Edit.Standard/StandardEdit.ContextMenu.cs
+++ b/Broiler.UI/src/Implementations/Standard/Text/Broiler.UI.Edit.Standard/StandardEdit.ContextMenu.cs
@@ -1,0 +1,486 @@
+using System;
+using System.Collections.Generic;
+using Broiler.Graphics;
+using Broiler.Input.Keyboard;
+using Broiler.Input.Mouse;
+using Broiler.UI.Standard;
+
+namespace Broiler.UI.Edit.Standard;
+
+/// <summary>
+/// The editing context menu — undo, the clipboard commands, delete, and select
+/// all. The menu is drawn by the edit rather than composed from a
+/// <c>UiMenu</c>: it is an intrinsic part of the control the way the ComboBox
+/// drop-down is, so it neither adds an assembly dependency nor requires a host
+/// to hand a menu to every edit it creates.
+///
+/// While the menu is open the edit holds the input capture and consumes
+/// keyboard and pointer input, so the field behind it cannot be typed into.
+/// </summary>
+public sealed partial class StandardEdit
+{
+    private const double ContextMenuPaddingX = 10;
+    private const double ContextMenuPaddingY = 4;
+    private const double ContextMenuShortcutGap = 28;
+    private const double ContextMenuSeparatorHeight = 7;
+    private const double ContextMenuMinWidth = 168;
+
+    private readonly List<StandardEditContextMenuItem> _contextMenuItems = [];
+    private BPoint _contextMenuAnchor;
+    private bool _isContextMenuOpen;
+    private int _contextMenuHighlightedIndex = -1;
+
+    public BColor ContextMenuBackground { get; set; } = StandardControlPaint.Surface;
+
+    public BColor ContextMenuForeground { get; set; } = StandardControlPaint.Text;
+
+    public BColor ContextMenuDisabledForeground { get; set; } = StandardControlPaint.TextDisabled;
+
+    public BColor ContextMenuHighlight { get; set; } = StandardControlPaint.AccentSoft;
+
+    public BColor ContextMenuBorderColor { get; set; } = StandardControlPaint.Border;
+
+    public double ContextMenuItemHeight { get; set; } = 26;
+
+    public bool IsContextMenuOpen => _isContextMenuOpen;
+
+    /// <summary>
+    /// The rows of the open menu, with the enablement they were built with.
+    /// Empty while the menu is closed.
+    /// </summary>
+    public IReadOnlyList<StandardEditContextMenuItem> ContextMenuItems => _contextMenuItems;
+
+    /// <summary>The highlighted row, or -1 when no row is highlighted.</summary>
+    public int ContextMenuHighlightedIndex => _contextMenuHighlightedIndex;
+
+    /// <summary>The popup rectangle in session coordinates, empty while closed.</summary>
+    public BRect ContextMenuBounds => _isContextMenuOpen ? GetContextMenuBounds() : BRect.Empty;
+
+    /// <summary>
+    /// Opens the menu with its top-left corner at <paramref name="position"/>,
+    /// flipping and clamping it to stay inside the viewport. Enablement is a
+    /// snapshot of the control's state taken here, which is also when the
+    /// clipboard is read to decide whether Paste can run.
+    /// </summary>
+    public bool OpenContextMenu(BPoint position)
+    {
+        ThrowIfDisposed();
+        if (!IsEnabled)
+            return false;
+
+        BuildContextMenuItems();
+        _contextMenuAnchor = position;
+        _isContextMenuOpen = true;
+        _contextMenuHighlightedIndex = -1;
+        Session?.SetFocus(this);
+        Session?.CaptureInput(this);
+        Invalidate(UiInvalidationKind.Render | UiInvalidationKind.Semantic);
+        return true;
+    }
+
+    public bool CloseContextMenu()
+    {
+        if (!_isContextMenuOpen)
+            return false;
+
+        _isContextMenuOpen = false;
+        _contextMenuHighlightedIndex = -1;
+        _contextMenuItems.Clear();
+        Session?.ReleaseInputCapture(this);
+        Invalidate(UiInvalidationKind.Render | UiInvalidationKind.Semantic);
+        return true;
+    }
+
+    /// <summary>
+    /// Runs a context-menu command against the control. Public so a host that
+    /// shows a platform menu can drive the same behavior as the drawn one.
+    /// </summary>
+    public bool InvokeContextMenuCommand(StandardEditContextMenuCommand command)
+    {
+        ThrowIfDisposed();
+        if (!IsEnabled)
+            return false;
+
+        return command switch
+        {
+            StandardEditContextMenuCommand.Undo => Undo(),
+            StandardEditContextMenuCommand.Cut => Cut(),
+            StandardEditContextMenuCommand.Copy => Copy(),
+            StandardEditContextMenuCommand.Paste => Paste(),
+            StandardEditContextMenuCommand.Delete => DeleteSelection(),
+            StandardEditContextMenuCommand.SelectAll => SelectAllText(),
+            _ => false,
+        };
+    }
+
+    private bool DeleteSelection()
+    {
+        if (IsReadOnly || !HasSelection)
+            return false;
+
+        PushUndo();
+        bool changed = DeleteRange(SelectionStart, SelectionLength);
+        EnsureCaretVisible();
+        return changed;
+    }
+
+    private bool SelectAllText()
+    {
+        if (Text.Length == 0)
+            return false;
+
+        SelectAll();
+        EnsureCaretVisible();
+        return true;
+    }
+
+    private void BuildContextMenuItems()
+    {
+        bool editable = !IsReadOnly;
+
+        // A password field never copies out, so Cut and Copy stay disabled there
+        // regardless of the selection — the same rule that makes Copy() refuse.
+        bool copyable = HasSelection && !IsPassword;
+
+        _contextMenuItems.Clear();
+        _contextMenuItems.Add(new StandardEditContextMenuItem(StandardEditContextMenuCommand.Undo, "Undo", "Ctrl+Z", editable && _undoStack.Count > 0));
+        _contextMenuItems.Add(StandardEditContextMenuItem.Separator);
+        _contextMenuItems.Add(new StandardEditContextMenuItem(StandardEditContextMenuCommand.Cut, "Cut", "Ctrl+X", editable && copyable));
+        _contextMenuItems.Add(new StandardEditContextMenuItem(StandardEditContextMenuCommand.Copy, "Copy", "Ctrl+C", copyable));
+        _contextMenuItems.Add(new StandardEditContextMenuItem(StandardEditContextMenuCommand.Paste, "Paste", "Ctrl+V", editable && CanPasteFromClipboard()));
+        _contextMenuItems.Add(new StandardEditContextMenuItem(StandardEditContextMenuCommand.Delete, "Delete", "Del", editable && HasSelection));
+        _contextMenuItems.Add(StandardEditContextMenuItem.Separator);
+        _contextMenuItems.Add(new StandardEditContextMenuItem(StandardEditContextMenuCommand.SelectAll, "Select All", "Ctrl+A", Text.Length > 0));
+    }
+
+    /// <summary>
+    /// Whether a paste would actually insert something: the clipboard has text,
+    /// that text survives the single-line sanitizer, and the result fits within
+    /// <see cref="UiEdit.MaxLength"/> once the selection it replaces is removed.
+    /// </summary>
+    private bool CanPasteFromClipboard()
+    {
+        if (Session?.Host is not IUiClipboardHost clipboard || !clipboard.TryGetText(out string text))
+            return false;
+
+        return SanitizeCommittedText(text).Length > 0 && Text.Length - SelectionLength < MaxLength;
+    }
+
+    /// <summary>
+    /// A right-click on the field. The click inside an existing selection keeps
+    /// it — that is the selection the menu's Cut and Copy act on — while a click
+    /// outside moves the caret first, matching every platform edit control.
+    /// </summary>
+    private bool HandleContextMenuPointerRequest(UiInputEvent input)
+    {
+        if (input.MouseButtonTransition != MouseButtonTransition.Down)
+            return false;
+
+        Session?.SetFocus(this);
+        if (!IsPointInSelection(input.Position))
+            SetCaretFromPoint(input.Position);
+
+        return OpenContextMenu(input.Position);
+    }
+
+    private bool HandleContextMenuInput(UiInputEvent input)
+    {
+        switch (input.Kind)
+        {
+            case UiInputEventKind.PointerMove:
+                if (TryGetContextMenuItemAt(input.Position, out int hovered) && IsSelectable(_contextMenuItems[hovered]))
+                    SetContextMenuHighlight(hovered);
+                return true;
+
+            case UiInputEventKind.PointerButton:
+                return HandleContextMenuPointerButton(input);
+
+            case UiInputEventKind.KeyboardKey:
+                return HandleContextMenuKeyboard(input);
+
+            case UiInputEventKind.TextInput:
+                HandleContextMenuAccessKey(input.Text);
+                return true;
+
+            case UiInputEventKind.TextComposition:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private bool HandleContextMenuPointerButton(UiInputEvent input)
+    {
+        // The release that follows the right-click which opened the menu, and the
+        // release of a click on a row, both belong to the menu rather than to the
+        // text field underneath it.
+        if (input.MouseButtonTransition != MouseButtonTransition.Down)
+            return true;
+
+        if (!TryGetContextMenuItemAt(input.Position, out int index))
+        {
+            CloseContextMenu();
+            return true;
+        }
+
+        StandardEditContextMenuItem item = _contextMenuItems[index];
+        if (!IsSelectable(item) || item.Command is not StandardEditContextMenuCommand command)
+            return true;
+
+        CloseContextMenu();
+        InvokeContextMenuCommand(command);
+        return true;
+    }
+
+    private bool HandleContextMenuKeyboard(UiInputEvent input)
+    {
+        if (input.KeyTransition != KeyboardKeyTransition.Down)
+            return true;
+
+        if (IsKey(input, BVirtualKey.Escape, "Escape"))
+        {
+            CloseContextMenu();
+            return true;
+        }
+        if (IsKey(input, BVirtualKey.Down, "Down"))
+        {
+            MoveContextMenuHighlight(1);
+            return true;
+        }
+        if (IsKey(input, BVirtualKey.Up, "Up"))
+        {
+            MoveContextMenuHighlight(-1);
+            return true;
+        }
+        if (IsKey(input, BVirtualKey.Home, "Home"))
+        {
+            _contextMenuHighlightedIndex = -1;
+            MoveContextMenuHighlight(1);
+            return true;
+        }
+        if (IsKey(input, BVirtualKey.End, "End"))
+        {
+            _contextMenuHighlightedIndex = -1;
+            MoveContextMenuHighlight(-1);
+            return true;
+        }
+        if (IsKey(input, BVirtualKey.Enter, "Enter") || IsKey(input, BVirtualKey.Space, "Space"))
+        {
+            InvokeHighlightedContextMenuCommand();
+            return true;
+        }
+
+        // Anything else is swallowed: an open menu owns the keyboard, so a
+        // shortcut cannot edit the text behind it.
+        return true;
+    }
+
+    /// <summary>
+    /// Moves the highlight to the next row whose first letter matches, cycling
+    /// so repeated presses walk the rows that share a letter (Cut and Copy).
+    /// </summary>
+    private bool HandleContextMenuAccessKey(string? text)
+    {
+        int count = _contextMenuItems.Count;
+        if (string.IsNullOrEmpty(text) || count == 0)
+            return false;
+
+        char key = char.ToUpperInvariant(text[0]);
+        int start = _contextMenuHighlightedIndex < 0 ? count - 1 : _contextMenuHighlightedIndex;
+        for (int offset = 1; offset <= count; offset++)
+        {
+            int index = (start + offset) % count;
+            StandardEditContextMenuItem item = _contextMenuItems[index];
+            if (IsSelectable(item) && item.Text.Length > 0 && char.ToUpperInvariant(item.Text[0]) == key)
+            {
+                SetContextMenuHighlight(index);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool InvokeHighlightedContextMenuCommand()
+    {
+        if ((uint)_contextMenuHighlightedIndex >= (uint)_contextMenuItems.Count)
+            return false;
+
+        StandardEditContextMenuItem item = _contextMenuItems[_contextMenuHighlightedIndex];
+        if (!IsSelectable(item) || item.Command is not StandardEditContextMenuCommand command)
+            return false;
+
+        CloseContextMenu();
+        return InvokeContextMenuCommand(command);
+    }
+
+    private bool MoveContextMenuHighlight(int delta)
+    {
+        int count = _contextMenuItems.Count;
+        if (count == 0)
+            return false;
+
+        int index = _contextMenuHighlightedIndex;
+        for (int step = 0; step < count; step++)
+        {
+            index = index < 0
+                ? (delta > 0 ? 0 : count - 1)
+                : (index + delta + count) % count;
+            if (IsSelectable(_contextMenuItems[index]))
+            {
+                SetContextMenuHighlight(index);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void SetContextMenuHighlight(int index)
+    {
+        if (_contextMenuHighlightedIndex == index)
+            return;
+
+        _contextMenuHighlightedIndex = index;
+        Invalidate(UiInvalidationKind.Render | UiInvalidationKind.Semantic);
+    }
+
+    private bool OpenContextMenuAtCaret()
+    {
+        BRect caret = GetCaretBounds();
+        return OpenContextMenu(new BPoint(caret.Left, caret.Bottom + 2));
+    }
+
+    /// <summary>
+    /// Whether a point falls inside the current selection, which decides whether
+    /// a right-click keeps the selection or moves the caret to the click.
+    /// </summary>
+    private bool IsPointInSelection(BPoint point)
+    {
+        if (!HasSelection)
+            return false;
+
+        BRect inner = GetInnerBounds();
+        string display = GetDisplayText();
+        double origin = GetTextOriginX(inner, display);
+        double start = origin + BTextMeasurer.MeasureAdvance(display[..SelectionStart], Font);
+        double end = origin + BTextMeasurer.MeasureAdvance(display[..SelectionEnd], Font);
+        return point.X >= start && point.X <= end;
+    }
+
+    private bool TryGetContextMenuItemAt(BPoint point, out int index)
+    {
+        index = -1;
+        BRect menu = GetContextMenuBounds();
+        if (!menu.Contains(point))
+            return false;
+
+        double top = menu.Top + ContextMenuPaddingY;
+        for (int item = 0; item < _contextMenuItems.Count; item++)
+        {
+            double height = _contextMenuItems[item].IsSeparator ? ContextMenuSeparatorHeight : ContextMenuItemHeight;
+            if (point.Y >= top && point.Y < top + height)
+            {
+                index = item;
+                return true;
+            }
+
+            top += height;
+        }
+
+        return false;
+    }
+
+    private BRect GetContextMenuBounds()
+    {
+        double width = ContextMenuMinWidth;
+        double height = ContextMenuPaddingY * 2;
+        foreach (StandardEditContextMenuItem item in _contextMenuItems)
+        {
+            if (item.IsSeparator)
+            {
+                height += ContextMenuSeparatorHeight;
+                continue;
+            }
+
+            height += ContextMenuItemHeight;
+            double row = BTextMeasurer.MeasureAdvance(item.Text, Font) + (ContextMenuPaddingX * 2);
+            if (item.Shortcut.Length > 0)
+                row += ContextMenuShortcutGap + BTextMeasurer.MeasureAdvance(item.Shortcut, Font);
+            width = Math.Max(width, row);
+        }
+
+        BSize viewport = Session?.Host.ViewportSize ?? new BSize(_contextMenuAnchor.X + width, _contextMenuAnchor.Y + height);
+
+        // A menu taller or wider than the viewport is clamped to it rather than
+        // hanging off the edge: rendering clips to these bounds and hit testing
+        // reads from them, so the two stay in step.
+        width = Math.Min(width, Math.Max(0, viewport.Width));
+        height = Math.Min(height, Math.Max(0, viewport.Height));
+        double left = _contextMenuAnchor.X + width > viewport.Width
+            ? Math.Max(0, viewport.Width - width)
+            : _contextMenuAnchor.X;
+
+        // Below the anchor when it fits, flipped above it when it does not — the
+        // caret or the click stays visible either way.
+        double top = _contextMenuAnchor.Y + height > viewport.Height
+            ? Math.Max(0, _contextMenuAnchor.Y - height)
+            : _contextMenuAnchor.Y;
+        return new BRect(left, top, width, height);
+    }
+
+    private void RenderContextMenu(UiRenderContext context)
+    {
+        BRect menu = GetContextMenuBounds();
+        StandardControlPaint.FillRounded(context.RenderList, menu, ContextMenuBackground, CornerRadius);
+        StandardControlPaint.StrokeRounded(context.RenderList, menu, ContextMenuBorderColor, CornerRadius, 1);
+
+        double lineHeight = BTextMeasurer.GetLineHeight(Font);
+        double top = menu.Top + ContextMenuPaddingY;
+        context.RenderList.PushClip(menu);
+        for (int index = 0; index < _contextMenuItems.Count; index++)
+        {
+            StandardEditContextMenuItem item = _contextMenuItems[index];
+            if (item.IsSeparator)
+            {
+                double middle = top + Math.Floor(ContextMenuSeparatorHeight / 2);
+                context.RenderList.FillRect(new BRect(menu.Left + ContextMenuPaddingX, middle, Math.Max(0, menu.Width - (ContextMenuPaddingX * 2)), 1), ContextMenuBorderColor);
+                top += ContextMenuSeparatorHeight;
+                continue;
+            }
+
+            var row = new BRect(menu.Left, top, menu.Width, ContextMenuItemHeight);
+            if (index == _contextMenuHighlightedIndex)
+                StandardControlPaint.FillRounded(context.RenderList, StandardControlPaint.Inset(row, 2), ContextMenuHighlight, StandardControlPaint.SmallRadius);
+
+            BColor foreground = item.IsEnabled ? ContextMenuForeground : ContextMenuDisabledForeground;
+            double baseline = row.Top + Math.Max(0, (row.Height - lineHeight) / 2);
+            context.RenderList.DrawText(new BTextRun(item.Text, Font, foreground), new BPoint(row.Left + ContextMenuPaddingX, baseline));
+            if (item.Shortcut.Length > 0)
+            {
+                double shortcutWidth = BTextMeasurer.MeasureAdvance(item.Shortcut, Font);
+                context.RenderList.DrawText(new BTextRun(item.Shortcut, Font, ContextMenuDisabledForeground), new BPoint(row.Right - ContextMenuPaddingX - shortcutWidth, baseline));
+            }
+
+            top += ContextMenuItemHeight;
+        }
+
+        context.RenderList.PopClip();
+    }
+
+    private UiSemanticNode CreateContextMenuSemanticNode() =>
+        new(
+            UiSemanticRole.Menu,
+            "Edit commands",
+            GetContextMenuBounds(),
+            UiSemanticState.Visible | UiSemanticState.Enabled | UiSemanticState.Expanded,
+            []);
+
+    private static bool IsSelectable(StandardEditContextMenuItem item) => !item.IsSeparator && item.IsEnabled;
+
+    private static bool IsContextMenuKey(UiInputEvent input, bool shift) =>
+        IsKey(input, 0x5D, "ContextMenu") ||
+        string.Equals(input.KeyName, "Apps", StringComparison.OrdinalIgnoreCase) ||
+        (shift && IsKey(input, 0x79, "F10"));
+}

--- a/Broiler.UI/src/Implementations/Standard/Text/Broiler.UI.Edit.Standard/StandardEdit.cs
+++ b/Broiler.UI/src/Implementations/Standard/Text/Broiler.UI.Edit.Standard/StandardEdit.cs
@@ -8,7 +8,7 @@ using Broiler.UI.Standard;
 
 namespace Broiler.UI.Edit.Standard;
 
-public sealed class StandardEdit : UiEdit, IStandardThemedControl, IUiTextEditor
+public sealed partial class StandardEdit : UiEdit, IStandardThemedControl, IUiTextEditor
 {
     public void ApplyTheme(StandardThemeTokens theme)
     {
@@ -19,6 +19,11 @@ public sealed class StandardEdit : UiEdit, IStandardThemedControl, IUiTextEditor
         FocusRing = theme.FocusRing;
         SelectionBackground = theme.AccentSoft;
         CaretColor = theme.Text;
+        ContextMenuBackground = theme.Surface;
+        ContextMenuForeground = theme.Text;
+        ContextMenuDisabledForeground = theme.TextDisabled;
+        ContextMenuHighlight = theme.AccentSoft;
+        ContextMenuBorderColor = theme.Border;
     }
 
     private readonly List<string> _undoStack = [];
@@ -181,12 +186,23 @@ public sealed class StandardEdit : UiEdit, IStandardThemedControl, IUiTextEditor
         DrawCaret(context, inner);
         context.RenderList.PopClip();
         PublishCaretGeometry();
+
+        // Deferred so the popup paints over later siblings instead of being
+        // covered by whatever is arranged after this control.
+        if (IsContextMenuOpen)
+            context.Defer(RenderContextMenu);
     }
 
     protected override bool OnInput(UiInputEvent input)
     {
         if (!IsEnabled)
+        {
+            CloseContextMenu();
             return false;
+        }
+
+        if (IsContextMenuOpen && HandleContextMenuInput(input))
+            return true;
 
         return input.Kind switch
         {
@@ -200,6 +216,9 @@ public sealed class StandardEdit : UiEdit, IStandardThemedControl, IUiTextEditor
 
     private bool HandlePointerButton(UiInputEvent input)
     {
+        if (input.MouseButton == MouseButton.Right)
+            return HandleContextMenuPointerRequest(input);
+
         if (input.MouseButton != MouseButton.Left)
             return false;
 
@@ -248,10 +267,17 @@ public sealed class StandardEdit : UiEdit, IStandardThemedControl, IUiTextEditor
 
     protected override void OnDetached()
     {
+        CloseContextMenu();
         if (Session?.Host is IUiTextInputHost textInput)
             textInput.ClearCaret(this);
 
         base.OnDetached();
+    }
+
+    protected override UiSemanticNode GetSemanticNodeCore()
+    {
+        UiSemanticNode node = base.GetSemanticNodeCore();
+        return IsContextMenuOpen ? node with { Children = [CreateContextMenuSemanticNode()] } : node;
     }
 
     private bool HandleKeyboard(UiInputEvent input)
@@ -261,6 +287,9 @@ public sealed class StandardEdit : UiEdit, IStandardThemedControl, IUiTextEditor
 
         bool control = input.KeyModifiers.HasFlag(KeyboardModifierState.Control);
         bool shift = input.KeyModifiers.HasFlag(KeyboardModifierState.Shift);
+
+        if (IsContextMenuKey(input, shift))
+            return OpenContextMenuAtCaret();
 
         if (control && IsKey(input, BVirtualKey.A, "A"))
         {
@@ -275,6 +304,20 @@ public sealed class StandardEdit : UiEdit, IStandardThemedControl, IUiTextEditor
             return Paste();
         if (control && IsKey(input, 0x5A, "Z"))
             return Undo();
+
+        // The Insert-key clipboard chords predate the Ctrl-letter ones and are
+        // still what several editors and terminals send.
+        if (IsKey(input, 0x2D, "Insert"))
+        {
+            if (control)
+                return Copy();
+            if (shift)
+                return Paste();
+
+            return false;
+        }
+        if (shift && IsKey(input, 0x2E, "Delete"))
+            return Cut();
 
         if (IsKey(input, BVirtualKey.Enter, "Enter"))
         {

--- a/Broiler.UI/src/Implementations/Standard/Text/Broiler.UI.Edit.Standard/StandardEditContextMenuCommand.cs
+++ b/Broiler.UI/src/Implementations/Standard/Text/Broiler.UI.Edit.Standard/StandardEditContextMenuCommand.cs
@@ -1,0 +1,17 @@
+namespace Broiler.UI.Edit.Standard;
+
+/// <summary>
+/// An editing command offered by the single-line edit's context menu. A host
+/// that presents a native menu instead of the drawn one runs the same commands
+/// through <see cref="StandardEdit.InvokeContextMenuCommand"/>, so both menus
+/// stay in step with the control's clipboard and undo behavior.
+/// </summary>
+public enum StandardEditContextMenuCommand
+{
+    Undo,
+    Cut,
+    Copy,
+    Paste,
+    Delete,
+    SelectAll,
+}

--- a/Broiler.UI/src/Implementations/Standard/Text/Broiler.UI.Edit.Standard/StandardEditContextMenuItem.cs
+++ b/Broiler.UI/src/Implementations/Standard/Text/Broiler.UI.Edit.Standard/StandardEditContextMenuItem.cs
@@ -1,0 +1,25 @@
+namespace Broiler.UI.Edit.Standard;
+
+/// <summary>
+/// One row of the single-line edit's context menu, as it stood when the menu
+/// opened. <see cref="Command"/> is null for a separator, which is the only row
+/// that carries no command and can never be highlighted or invoked.
+/// </summary>
+/// <param name="Command">The command the row runs, or null for a separator.</param>
+/// <param name="Text">The row label.</param>
+/// <param name="Shortcut">The keyboard shortcut shown alongside the label.</param>
+/// <param name="IsEnabled">
+/// Whether the command can run against the control's state at the moment the
+/// menu opened — a disabled row is drawn muted and does not respond.
+/// </param>
+public readonly record struct StandardEditContextMenuItem(
+    StandardEditContextMenuCommand? Command,
+    string Text,
+    string Shortcut,
+    bool IsEnabled)
+{
+    /// <summary>A divider between groups of commands.</summary>
+    public static StandardEditContextMenuItem Separator { get; } = new(null, string.Empty, string.Empty, false);
+
+    public bool IsSeparator => Command is null;
+}

--- a/Broiler.UI/tests/Text/Broiler.UI.Edit.Standard.Tests/Broiler.UI.Edit.Standard.Tests.csproj
+++ b/Broiler.UI/tests/Text/Broiler.UI.Edit.Standard.Tests/Broiler.UI.Edit.Standard.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Broiler.UI.Edit.Standard.Tests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Implementations\Standard\Text\Broiler.UI.Edit.Standard\Broiler.UI.Edit.Standard.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Broiler.UI/tests/Text/Broiler.UI.Edit.Standard.Tests/EditStandardHarness.cs
+++ b/Broiler.UI/tests/Text/Broiler.UI.Edit.Standard.Tests/EditStandardHarness.cs
@@ -1,0 +1,185 @@
+using Broiler.Graphics;
+using Broiler.Input;
+using Broiler.Input.Keyboard;
+using Broiler.Input.Mouse;
+using Broiler.Input.Text;
+using Broiler.UI.Standard;
+
+namespace Broiler.UI.Edit.Standard.Tests;
+
+/// <summary>Virtual key codes the edit's shortcuts switch on.</summary>
+internal static class TestKey
+{
+    public const int A = 0x41;
+    public const int C = 0x43;
+    public const int V = 0x56;
+    public const int X = 0x58;
+    public const int Z = 0x5A;
+    public const int Insert = 0x2D;
+    public const int Delete = 0x2E;
+    public const int ContextMenu = 0x5D;
+    public const int F10 = 0x79;
+}
+
+internal sealed class TestHost : IUiHost, IUiTextInputHost
+{
+    public TestHost(BSize viewportSize) => ViewportSize = viewportSize;
+
+    public BSize ViewportSize { get; }
+
+    public double Scale => 1;
+
+    public UiTextCaretInfo? LastCaret { get; private set; }
+
+    public BRenderList CreateRenderList(int capacity = 0) => new(capacity);
+
+    public void Invalidate(UiInvalidation invalidation)
+    {
+    }
+
+    public void Present(BRenderList renderList)
+    {
+    }
+
+    public void PublishCaret(UiTextCaretInfo caret) => LastCaret = caret;
+
+    public void ClearCaret(UiElement owner) => LastCaret = null;
+}
+
+/// <summary>A host that also owns a clipboard, as every real desktop host does.</summary>
+internal sealed class ClipboardTestHost : IUiHost, IUiClipboardHost
+{
+    public ClipboardTestHost(BSize viewportSize) => ViewportSize = viewportSize;
+
+    public BSize ViewportSize { get; }
+
+    public double Scale => 1;
+
+    /// <summary>Null means the clipboard holds no text at all, not empty text.</summary>
+    public string? ClipboardText { get; set; }
+
+    public int SetTextCount { get; private set; }
+
+    public BRenderList CreateRenderList(int capacity = 0) => new(capacity);
+
+    public void Invalidate(UiInvalidation invalidation)
+    {
+    }
+
+    public void Present(BRenderList renderList)
+    {
+    }
+
+    public bool TryGetText(out string text)
+    {
+        text = ClipboardText ?? string.Empty;
+        return ClipboardText is not null;
+    }
+
+    public void SetText(string text)
+    {
+        ClipboardText = text;
+        SetTextCount++;
+    }
+}
+
+internal sealed class EditScene
+{
+    public required UiSession Session { get; init; }
+
+    public required StandardEdit Edit { get; init; }
+
+    public required ClipboardTestHost Host { get; init; }
+
+    public required StandardInputRoute Route { get; init; }
+
+    public BRenderList Render() => Session.RenderFrame();
+
+    /// <summary>The x coordinate of the caret position for <paramref name="index"/>.</summary>
+    public double TextX(int index) =>
+        Edit.Bounds.Left + Edit.PaddingX + BTextMeasurer.MeasureAdvance(Edit.Text[..index], Edit.Font);
+
+    public double CenterY() => Edit.Bounds.Top + (Edit.Bounds.Height / 2);
+}
+
+internal static class EditStandardHarness
+{
+    public static EditScene Create(string text = "", BSize? viewportSize = null, string? clipboardText = null)
+    {
+        BSize size = viewportSize ?? new BSize(400, 300);
+        var host = new ClipboardTestHost(size) { ClipboardText = clipboardText };
+        UiSession session = new StandardUiSessionBuilder()
+            .WithDispatcher(new ImmediateUiDispatcher())
+            .Build(host);
+        var edit = new StandardEdit { Text = text, PreferredSize = new BSize(240, 32) };
+        var root = new EditRoot(edit);
+        session.AddRoot(root);
+
+        var scene = new EditScene
+        {
+            Session = session,
+            Edit = edit,
+            Host = host,
+            Route = new StandardInputRoute(session),
+        };
+
+        // One frame so bounds, and with them every hit test, are real.
+        scene.Render();
+        session.SetFocus(edit);
+        return scene;
+    }
+
+    public static InputEventHeader Header(string id) =>
+        new(InputDeviceId.FromOpaqueValue(id), new InputTimestamp(1, TimeSpan.TicksPerSecond, "edit"), 1);
+
+    public static KeyboardKeyEvent Key(
+        string name,
+        int nativeKeyCode,
+        KeyboardModifierState modifiers = KeyboardModifierState.None,
+        KeyboardKeyTransition transition = KeyboardKeyTransition.Down) =>
+        new(Header("keyboard"), KeyboardKey.FromName(name), transition, modifiers, nativeKeyCode, 0, 0, false, false, Source: InputEventSource.Synthetic);
+
+    public static TextInputEvent Text(string text) => new(Header("text"), text, InputEventSource.Synthetic);
+
+    public static MouseButtonEvent MouseDown(double x, double y, MouseButton button = MouseButton.Left) =>
+        new(
+            Header("mouse"),
+            InputPoint.ClientDeviceIndependentPixels(x, y),
+            button == MouseButton.Right ? MouseButtons.Right : MouseButtons.Left,
+            button,
+            MouseButtonTransition.Down,
+            InputEventSource.Synthetic);
+
+    public static MouseButtonEvent MouseUp(double x, double y, MouseButton button = MouseButton.Left) =>
+        new(
+            Header("mouse"),
+            InputPoint.ClientDeviceIndependentPixels(x, y),
+            MouseButtons.None,
+            button,
+            MouseButtonTransition.Up,
+            InputEventSource.Synthetic);
+
+    public static MouseMoveEvent MouseMove(double x, double y) =>
+        new(Header("mouse"), InputPoint.ClientDeviceIndependentPixels(x, y), MouseButtons.None, InputEventSource.Synthetic);
+
+    /// <summary>Places the edit at a fixed offset so pointer coordinates are unambiguous.</summary>
+    private sealed class EditRoot : UiElement
+    {
+        private readonly UiElement _edit;
+
+        public EditRoot(UiElement edit)
+        {
+            _edit = edit;
+            AddChild(edit);
+        }
+
+        protected override BSize MeasureCore(BSize availableSize)
+        {
+            _edit.Measure(availableSize);
+            return availableSize;
+        }
+
+        protected override void ArrangeCore(BRect finalRect) =>
+            _edit.Arrange(new BRect(20, 20, 240, 32));
+    }
+}

--- a/Broiler.UI/tests/Text/Broiler.UI.Edit.Standard.Tests/StandardEditClipboardTests.cs
+++ b/Broiler.UI/tests/Text/Broiler.UI.Edit.Standard.Tests/StandardEditClipboardTests.cs
@@ -1,0 +1,155 @@
+using Broiler.Graphics;
+using Broiler.Input.Keyboard;
+using Broiler.UI.Standard;
+
+using static Broiler.UI.Edit.Standard.Tests.EditStandardHarness;
+
+namespace Broiler.UI.Edit.Standard.Tests;
+
+public sealed class StandardEditClipboardTests
+{
+    [Fact]
+    public void Control_C_Copies_The_Selection_Without_Changing_The_Text()
+    {
+        EditScene scene = Create("Hello world");
+        scene.Edit.SetSelection(0, 5);
+
+        Assert.True(scene.Route.Dispatch(Key("C", TestKey.C, KeyboardModifierState.Control)));
+
+        Assert.Equal("Hello", scene.Host.ClipboardText);
+        Assert.Equal("Hello world", scene.Edit.Text);
+    }
+
+    [Fact]
+    public void Control_X_Cuts_The_Selection_And_Control_Z_Restores_It()
+    {
+        EditScene scene = Create("Hello world");
+        scene.Edit.SetSelection(5, 6);
+
+        Assert.True(scene.Route.Dispatch(Key("X", TestKey.X, KeyboardModifierState.Control)));
+
+        Assert.Equal(" world", scene.Host.ClipboardText);
+        Assert.Equal("Hello", scene.Edit.Text);
+
+        Assert.True(scene.Route.Dispatch(Key("Z", TestKey.Z, KeyboardModifierState.Control)));
+        Assert.Equal("Hello world", scene.Edit.Text);
+    }
+
+    [Fact]
+    public void Control_V_Replaces_The_Selection_And_Leaves_The_Caret_After_The_Insert()
+    {
+        EditScene scene = Create("Hello world", clipboardText: "brave new");
+        scene.Edit.SetSelection(6, 5);
+
+        Assert.True(scene.Route.Dispatch(Key("V", TestKey.V, KeyboardModifierState.Control)));
+
+        Assert.Equal("Hello brave new", scene.Edit.Text);
+        Assert.Equal(15, scene.Edit.CaretIndex);
+        Assert.False(scene.Edit.HasSelection);
+    }
+
+    [Fact]
+    public void Control_Insert_Copies_And_Shift_Insert_Pastes()
+    {
+        EditScene scene = Create("Hello world");
+        scene.Edit.SetSelection(0, 5);
+
+        Assert.True(scene.Route.Dispatch(Key("Insert", TestKey.Insert, KeyboardModifierState.Control)));
+        Assert.Equal("Hello", scene.Host.ClipboardText);
+
+        scene.Edit.SetSelection(11, 0);
+        Assert.True(scene.Route.Dispatch(Key("Insert", TestKey.Insert, KeyboardModifierState.Shift)));
+        Assert.Equal("Hello worldHello", scene.Edit.Text);
+    }
+
+    [Fact]
+    public void Shift_Delete_Cuts_While_Plain_Delete_Still_Deletes_Forward()
+    {
+        EditScene scene = Create("Hello world");
+        scene.Edit.SetSelection(0, 6);
+
+        Assert.True(scene.Route.Dispatch(Key("Delete", TestKey.Delete, KeyboardModifierState.Shift)));
+        Assert.Equal("Hello ", scene.Host.ClipboardText);
+        Assert.Equal("world", scene.Edit.Text);
+
+        scene.Edit.SetSelection(0, 0);
+        Assert.True(scene.Route.Dispatch(Key("Delete", TestKey.Delete)));
+        Assert.Equal("orld", scene.Edit.Text);
+        Assert.Equal("Hello ", scene.Host.ClipboardText);
+    }
+
+    [Fact]
+    public void Plain_Insert_Is_Left_To_The_Host()
+    {
+        EditScene scene = Create("Hello", clipboardText: "pasted");
+
+        Assert.False(scene.Route.Dispatch(Key("Insert", TestKey.Insert)));
+        Assert.Equal("Hello", scene.Edit.Text);
+    }
+
+    [Fact]
+    public void A_Password_Field_Neither_Copies_Nor_Cuts()
+    {
+        EditScene scene = Create("secret");
+        scene.Edit.IsPassword = true;
+        scene.Edit.SelectAll();
+
+        Assert.False(scene.Route.Dispatch(Key("C", TestKey.C, KeyboardModifierState.Control)));
+        Assert.False(scene.Route.Dispatch(Key("X", TestKey.X, KeyboardModifierState.Control)));
+
+        Assert.Null(scene.Host.ClipboardText);
+        Assert.Equal("secret", scene.Edit.Text);
+    }
+
+    [Fact]
+    public void A_Read_Only_Field_Copies_But_Neither_Cuts_Nor_Pastes()
+    {
+        EditScene scene = Create("Hello world", clipboardText: "replacement");
+        scene.Edit.IsReadOnly = true;
+        scene.Edit.SetSelection(0, 5);
+
+        Assert.True(scene.Route.Dispatch(Key("C", TestKey.C, KeyboardModifierState.Control)));
+        Assert.Equal("Hello", scene.Host.ClipboardText);
+
+        Assert.False(scene.Route.Dispatch(Key("X", TestKey.X, KeyboardModifierState.Control)));
+        Assert.False(scene.Route.Dispatch(Key("V", TestKey.V, KeyboardModifierState.Control)));
+        Assert.Equal("Hello world", scene.Edit.Text);
+    }
+
+    [Fact]
+    public void Pasting_Multiple_Lines_Keeps_The_Single_Line_Field_On_One_Line()
+    {
+        EditScene scene = Create(string.Empty, clipboardText: "first\r\nsecond\tthird");
+
+        Assert.True(scene.Route.Dispatch(Key("V", TestKey.V, KeyboardModifierState.Control)));
+
+        Assert.Equal("firstsecondthird", scene.Edit.Text);
+    }
+
+    [Fact]
+    public void Pasting_Stops_At_MaxLength()
+    {
+        EditScene scene = Create("abc", clipboardText: "defgh");
+        scene.Edit.MaxLength = 5;
+        scene.Edit.SetSelection(3, 0);
+
+        Assert.True(scene.Route.Dispatch(Key("V", TestKey.V, KeyboardModifierState.Control)));
+
+        Assert.Equal("abcde", scene.Edit.Text);
+    }
+
+    [Fact]
+    public void Copy_Without_A_Clipboard_Host_Reports_Unhandled_Rather_Than_Throwing()
+    {
+        var host = new TestHost(new BSize(400, 300));
+        using UiSession session = new StandardUiSessionBuilder().Build(host);
+        var edit = new StandardEdit { Text = "Hello" };
+        session.AddRoot(edit);
+        session.SetFocus(edit);
+        edit.SelectAll();
+
+        Assert.False(edit.Copy());
+        Assert.False(edit.Paste());
+        Assert.Equal("Hello", edit.Text);
+    }
+}

--- a/Broiler.UI/tests/Text/Broiler.UI.Edit.Standard.Tests/StandardEditContextMenuTests.cs
+++ b/Broiler.UI/tests/Text/Broiler.UI.Edit.Standard.Tests/StandardEditContextMenuTests.cs
@@ -1,0 +1,399 @@
+using Broiler.Graphics;
+using Broiler.Input.Keyboard;
+using Broiler.Input.Mouse;
+
+using static Broiler.UI.Edit.Standard.Tests.EditStandardHarness;
+
+namespace Broiler.UI.Edit.Standard.Tests;
+
+public sealed class StandardEditContextMenuTests
+{
+    [Fact]
+    public void Right_Click_Opens_The_Menu_Focuses_The_Field_And_Captures_Input()
+    {
+        EditScene scene = Create("Hello world");
+
+        Assert.True(scene.Session.DispatchInput(UiInputEvent.FromMouseButton(MouseDown(scene.TextX(5), scene.CenterY(), MouseButton.Right))));
+
+        Assert.True(scene.Edit.IsContextMenuOpen);
+        Assert.Same(scene.Edit, scene.Session.FocusedElement);
+        Assert.Same(scene.Edit, scene.Session.CapturedElement);
+
+        // The release of the opening click belongs to the menu, not to the field.
+        Assert.True(scene.Session.DispatchInput(UiInputEvent.FromMouseButton(MouseUp(scene.TextX(5), scene.CenterY(), MouseButton.Right))));
+        Assert.True(scene.Edit.IsContextMenuOpen);
+    }
+
+    [Fact]
+    public void Right_Click_Outside_The_Selection_Moves_The_Caret_And_Drops_The_Selection()
+    {
+        EditScene scene = Create("Hello world");
+        scene.Edit.SetSelection(0, 5);
+
+        scene.Session.DispatchInput(UiInputEvent.FromMouseButton(MouseDown(scene.TextX(9), scene.CenterY(), MouseButton.Right)));
+
+        Assert.False(scene.Edit.HasSelection);
+        Assert.Equal(9, scene.Edit.CaretIndex);
+        Assert.False(FindItem(scene.Edit, StandardEditContextMenuCommand.Copy).IsEnabled);
+    }
+
+    [Fact]
+    public void Right_Click_Inside_The_Selection_Keeps_It_So_Copy_Acts_On_It()
+    {
+        EditScene scene = Create("Hello world");
+        scene.Edit.SetSelection(0, 5);
+
+        scene.Session.DispatchInput(UiInputEvent.FromMouseButton(MouseDown(scene.TextX(2), scene.CenterY(), MouseButton.Right)));
+
+        Assert.Equal(0, scene.Edit.SelectionStart);
+        Assert.Equal(5, scene.Edit.SelectionLength);
+        Assert.True(FindItem(scene.Edit, StandardEditContextMenuCommand.Copy).IsEnabled);
+    }
+
+    [Fact]
+    public void Clicking_Copy_Copies_The_Selection_And_Closes_The_Menu()
+    {
+        EditScene scene = Create("Hello world");
+        scene.Edit.SetSelection(0, 5);
+        OpenMenuAt(scene, scene.TextX(2));
+
+        ClickItem(scene, StandardEditContextMenuCommand.Copy);
+
+        Assert.Equal("Hello", scene.Host.ClipboardText);
+        Assert.Equal("Hello world", scene.Edit.Text);
+        Assert.False(scene.Edit.IsContextMenuOpen);
+        Assert.Null(scene.Session.CapturedElement);
+    }
+
+    [Fact]
+    public void Clicking_Cut_Then_Paste_Moves_Text_Through_The_Clipboard()
+    {
+        EditScene scene = Create("Hello world");
+        scene.Edit.SetSelection(0, 6);
+        OpenMenuAt(scene, scene.TextX(2));
+        ClickItem(scene, StandardEditContextMenuCommand.Cut);
+
+        Assert.Equal("world", scene.Edit.Text);
+        Assert.Equal("Hello ", scene.Host.ClipboardText);
+
+        scene.Edit.SetSelection(5, 0);
+        OpenMenuAt(scene, scene.TextX(5));
+        ClickItem(scene, StandardEditContextMenuCommand.Paste);
+
+        Assert.Equal("worldHello ", scene.Edit.Text);
+    }
+
+    [Fact]
+    public void Clicking_Delete_Removes_The_Selection_Without_Touching_The_Clipboard()
+    {
+        EditScene scene = Create("Hello world", clipboardText: "untouched");
+        scene.Edit.SetSelection(5, 6);
+        OpenMenuAt(scene, scene.TextX(7));
+
+        ClickItem(scene, StandardEditContextMenuCommand.Delete);
+
+        Assert.Equal("Hello", scene.Edit.Text);
+        Assert.Equal("untouched", scene.Host.ClipboardText);
+    }
+
+    [Fact]
+    public void Clicking_Select_All_Selects_The_Whole_Field()
+    {
+        EditScene scene = Create("Hello world");
+        OpenMenuAt(scene, scene.TextX(3));
+
+        ClickItem(scene, StandardEditContextMenuCommand.SelectAll);
+
+        Assert.Equal(0, scene.Edit.SelectionStart);
+        Assert.Equal(11, scene.Edit.SelectionLength);
+    }
+
+    [Fact]
+    public void A_Disabled_Row_Neither_Runs_Nor_Closes_The_Menu()
+    {
+        EditScene scene = Create("Hello world");
+        OpenMenuAt(scene, scene.TextX(3));
+        Assert.False(FindItem(scene.Edit, StandardEditContextMenuCommand.Copy).IsEnabled);
+
+        ClickItem(scene, StandardEditContextMenuCommand.Copy);
+
+        Assert.Null(scene.Host.ClipboardText);
+        Assert.True(scene.Edit.IsContextMenuOpen);
+    }
+
+    [Fact]
+    public void Enablement_Reflects_Selection_Clipboard_And_Undo_State()
+    {
+        EditScene scene = Create("Hello world");
+        OpenMenuAt(scene, scene.TextX(3));
+
+        Assert.False(FindItem(scene.Edit, StandardEditContextMenuCommand.Undo).IsEnabled);
+        Assert.False(FindItem(scene.Edit, StandardEditContextMenuCommand.Cut).IsEnabled);
+        Assert.False(FindItem(scene.Edit, StandardEditContextMenuCommand.Copy).IsEnabled);
+        Assert.False(FindItem(scene.Edit, StandardEditContextMenuCommand.Paste).IsEnabled);
+        Assert.False(FindItem(scene.Edit, StandardEditContextMenuCommand.Delete).IsEnabled);
+        Assert.True(FindItem(scene.Edit, StandardEditContextMenuCommand.SelectAll).IsEnabled);
+
+        scene.Edit.CloseContextMenu();
+        scene.Host.ClipboardText = "ready";
+        scene.Edit.SetSelection(0, 5);
+        scene.Edit.InsertCommittedText("Howdy");
+        scene.Edit.SetSelection(0, 5);
+        OpenMenuAt(scene, scene.TextX(2));
+
+        Assert.True(FindItem(scene.Edit, StandardEditContextMenuCommand.Undo).IsEnabled);
+        Assert.True(FindItem(scene.Edit, StandardEditContextMenuCommand.Cut).IsEnabled);
+        Assert.True(FindItem(scene.Edit, StandardEditContextMenuCommand.Copy).IsEnabled);
+        Assert.True(FindItem(scene.Edit, StandardEditContextMenuCommand.Paste).IsEnabled);
+        Assert.True(FindItem(scene.Edit, StandardEditContextMenuCommand.Delete).IsEnabled);
+    }
+
+    [Fact]
+    public void A_Password_Field_Offers_Paste_But_Not_Cut_Or_Copy()
+    {
+        EditScene scene = Create("secret", clipboardText: "ready");
+        scene.Edit.IsPassword = true;
+        scene.Edit.SelectAll();
+        OpenMenuAt(scene, scene.TextX(0));
+
+        Assert.False(FindItem(scene.Edit, StandardEditContextMenuCommand.Cut).IsEnabled);
+        Assert.False(FindItem(scene.Edit, StandardEditContextMenuCommand.Copy).IsEnabled);
+        Assert.True(FindItem(scene.Edit, StandardEditContextMenuCommand.Paste).IsEnabled);
+        Assert.True(FindItem(scene.Edit, StandardEditContextMenuCommand.Delete).IsEnabled);
+    }
+
+    [Fact]
+    public void A_Read_Only_Field_Offers_Only_Copy_And_Select_All()
+    {
+        EditScene scene = Create("Hello world", clipboardText: "ready");
+        scene.Edit.IsReadOnly = true;
+        scene.Edit.SetSelection(0, 5);
+        OpenMenuAt(scene, scene.TextX(2));
+
+        Assert.True(FindItem(scene.Edit, StandardEditContextMenuCommand.Copy).IsEnabled);
+        Assert.True(FindItem(scene.Edit, StandardEditContextMenuCommand.SelectAll).IsEnabled);
+        Assert.False(FindItem(scene.Edit, StandardEditContextMenuCommand.Cut).IsEnabled);
+        Assert.False(FindItem(scene.Edit, StandardEditContextMenuCommand.Paste).IsEnabled);
+        Assert.False(FindItem(scene.Edit, StandardEditContextMenuCommand.Delete).IsEnabled);
+    }
+
+    [Fact]
+    public void Paste_Stays_Disabled_When_The_Clipboard_Holds_Nothing_Insertable()
+    {
+        EditScene scene = Create("Hello", clipboardText: "\r\n\t");
+        OpenMenuAt(scene, scene.TextX(2));
+
+        Assert.False(FindItem(scene.Edit, StandardEditContextMenuCommand.Paste).IsEnabled);
+    }
+
+    [Fact]
+    public void The_Menu_Key_And_Shift_F10_Open_The_Menu_Below_The_Caret()
+    {
+        EditScene scene = Create("Hello world");
+        scene.Edit.SetSelection(5, 0);
+
+        Assert.True(scene.Route.Dispatch(Key("F10", TestKey.F10, KeyboardModifierState.Shift)));
+        Assert.True(scene.Edit.IsContextMenuOpen);
+        Assert.True(scene.Edit.ContextMenuBounds.Top >= scene.Edit.Bounds.Top);
+
+        Assert.True(scene.Route.Dispatch(Key("Escape", 0x1B)));
+        Assert.False(scene.Edit.IsContextMenuOpen);
+
+        Assert.True(scene.Route.Dispatch(Key("ContextMenu", TestKey.ContextMenu)));
+        Assert.True(scene.Edit.IsContextMenuOpen);
+    }
+
+    [Fact]
+    public void Arrow_Keys_Skip_Separators_And_Disabled_Rows_Before_Enter_Runs_The_Row()
+    {
+        EditScene scene = Create("Hello world");
+        scene.Edit.SetSelection(0, 5);
+        OpenMenuAt(scene, scene.TextX(2));
+
+        Assert.True(scene.Route.Dispatch(Key("Down", 0x28)));
+        Assert.Equal(StandardEditContextMenuCommand.Cut, scene.Edit.ContextMenuItems[scene.Edit.ContextMenuHighlightedIndex].Command);
+
+        Assert.True(scene.Route.Dispatch(Key("Down", 0x28)));
+        Assert.Equal(StandardEditContextMenuCommand.Copy, scene.Edit.ContextMenuItems[scene.Edit.ContextMenuHighlightedIndex].Command);
+
+        Assert.True(scene.Route.Dispatch(Key("Up", 0x26)));
+        Assert.Equal(StandardEditContextMenuCommand.Cut, scene.Edit.ContextMenuItems[scene.Edit.ContextMenuHighlightedIndex].Command);
+
+        Assert.True(scene.Route.Dispatch(Key("Enter", 0x0D)));
+        Assert.False(scene.Edit.IsContextMenuOpen);
+        Assert.Equal("Hello", scene.Host.ClipboardText);
+        Assert.Equal(" world", scene.Edit.Text);
+    }
+
+    [Fact]
+    public void End_Highlights_The_Last_Runnable_Row()
+    {
+        EditScene scene = Create("Hello world");
+        OpenMenuAt(scene, scene.TextX(2));
+
+        Assert.True(scene.Route.Dispatch(Key("End", 0x23)));
+
+        Assert.Equal(StandardEditContextMenuCommand.SelectAll, scene.Edit.ContextMenuItems[scene.Edit.ContextMenuHighlightedIndex].Command);
+    }
+
+    [Fact]
+    public void Typing_A_Row_Letter_Cycles_Between_Rows_That_Share_It()
+    {
+        EditScene scene = Create("Hello world", clipboardText: "ready");
+        scene.Edit.SetSelection(0, 5);
+        OpenMenuAt(scene, scene.TextX(2));
+
+        Assert.True(scene.Route.Dispatch(Text("c")));
+        Assert.Equal(StandardEditContextMenuCommand.Cut, scene.Edit.ContextMenuItems[scene.Edit.ContextMenuHighlightedIndex].Command);
+
+        Assert.True(scene.Route.Dispatch(Text("c")));
+        Assert.Equal(StandardEditContextMenuCommand.Copy, scene.Edit.ContextMenuItems[scene.Edit.ContextMenuHighlightedIndex].Command);
+    }
+
+    [Fact]
+    public void Hovering_A_Row_Highlights_It()
+    {
+        EditScene scene = Create("Hello world");
+        OpenMenuAt(scene, scene.TextX(2));
+        BPoint row = RowCenter(scene.Edit, StandardEditContextMenuCommand.SelectAll);
+
+        Assert.True(scene.Session.DispatchInput(UiInputEvent.FromMouseMove(MouseMove(row.X, row.Y))));
+
+        Assert.Equal(StandardEditContextMenuCommand.SelectAll, scene.Edit.ContextMenuItems[scene.Edit.ContextMenuHighlightedIndex].Command);
+    }
+
+    [Fact]
+    public void Typing_While_The_Menu_Is_Open_Does_Not_Reach_The_Field()
+    {
+        EditScene scene = Create("Hello");
+        OpenMenuAt(scene, scene.TextX(2));
+
+        Assert.True(scene.Route.Dispatch(Text("z")));
+        Assert.True(scene.Route.Dispatch(Key("Backspace", 0x08)));
+
+        Assert.Equal("Hello", scene.Edit.Text);
+    }
+
+    [Fact]
+    public void A_Click_Outside_The_Menu_Dismisses_It_Without_Editing()
+    {
+        EditScene scene = Create("Hello world");
+        scene.Edit.SetSelection(0, 5);
+        OpenMenuAt(scene, scene.TextX(2));
+
+        Assert.True(scene.Session.DispatchInput(UiInputEvent.FromMouseButton(MouseDown(2, 2))));
+
+        Assert.False(scene.Edit.IsContextMenuOpen);
+        Assert.Null(scene.Session.CapturedElement);
+        Assert.Equal("Hello world", scene.Edit.Text);
+        Assert.Null(scene.Host.ClipboardText);
+    }
+
+    [Fact]
+    public void The_Menu_Stays_Inside_The_Viewport_When_Opened_At_A_Corner()
+    {
+        EditScene scene = Create("Hello world", viewportSize: new BSize(300, 120));
+
+        Assert.True(scene.Edit.OpenContextMenu(new BPoint(295, 118)));
+
+        BRect menu = scene.Edit.ContextMenuBounds;
+        Assert.True(menu.Left >= 0);
+        Assert.True(menu.Top >= 0);
+        Assert.True(menu.Right <= 300);
+        Assert.True(menu.Bottom <= 120);
+    }
+
+    [Fact]
+    public void The_Open_Menu_Paints_Over_Later_Siblings_And_Appears_In_The_Semantic_Tree()
+    {
+        EditScene scene = Create("Hello world");
+        scene.Edit.ContextMenuBackground = BColor.FromArgb(255, 17, 29, 43);
+        OpenMenuAt(scene, scene.TextX(2));
+
+        BRenderList rendered = scene.Render();
+
+        Assert.Contains(
+            rendered.Commands,
+            command => command is BRenderCommand.FillRoundedRect fill && fill.Color == scene.Edit.ContextMenuBackground);
+
+        UiSemanticNode semantic = scene.Edit.GetSemanticNode();
+        Assert.Equal(UiSemanticRole.Edit, semantic.Role);
+        UiSemanticNode menu = Assert.Single(semantic.Children);
+        Assert.Equal(UiSemanticRole.Menu, menu.Role);
+        Assert.True(menu.State.HasFlag(UiSemanticState.Expanded));
+
+        scene.Edit.CloseContextMenu();
+        Assert.Empty(scene.Edit.GetSemanticNode().Children);
+    }
+
+    [Fact]
+    public void Detaching_The_Field_Closes_The_Menu_And_Releases_The_Capture()
+    {
+        EditScene scene = Create("Hello world");
+        OpenMenuAt(scene, scene.TextX(2));
+
+        scene.Edit.Dispose();
+
+        Assert.False(scene.Edit.IsContextMenuOpen);
+        Assert.Null(scene.Session.CapturedElement);
+    }
+
+    [Fact]
+    public void A_Disabled_Field_Dismisses_The_Menu_And_Refuses_To_Open_One()
+    {
+        EditScene scene = Create("Hello world");
+        OpenMenuAt(scene, scene.TextX(2));
+
+        scene.Edit.IsEnabled = false;
+        Assert.False(scene.Session.DispatchInput(UiInputEvent.FromMouseButton(MouseDown(scene.TextX(2), scene.CenterY(), MouseButton.Right))));
+
+        Assert.False(scene.Edit.IsContextMenuOpen);
+        Assert.False(scene.Edit.OpenContextMenu(new BPoint(30, 30)));
+    }
+
+    /// <summary>A host-driven menu runs the same commands as the drawn one.</summary>
+    [Fact]
+    public void Commands_Can_Be_Invoked_Without_Opening_The_Drawn_Menu()
+    {
+        EditScene scene = Create("Hello world");
+        scene.Edit.SetSelection(0, 5);
+
+        Assert.True(scene.Edit.InvokeContextMenuCommand(StandardEditContextMenuCommand.Cut));
+
+        Assert.False(scene.Edit.IsContextMenuOpen);
+        Assert.Equal("Hello", scene.Host.ClipboardText);
+        Assert.Equal(" world", scene.Edit.Text);
+    }
+
+    private static void OpenMenuAt(EditScene scene, double x) =>
+        scene.Session.DispatchInput(UiInputEvent.FromMouseButton(MouseDown(x, scene.CenterY(), MouseButton.Right)));
+
+    private static void ClickItem(EditScene scene, StandardEditContextMenuCommand command)
+    {
+        BPoint point = RowCenter(scene.Edit, command);
+        scene.Session.DispatchInput(UiInputEvent.FromMouseButton(MouseDown(point.X, point.Y, MouseButton.Left)));
+    }
+
+    private static StandardEditContextMenuItem FindItem(StandardEdit edit, StandardEditContextMenuCommand command) =>
+        edit.ContextMenuItems.Single(item => item.Command == command);
+
+    /// <summary>
+    /// The middle of a row, walked the same way the control lays the popup out —
+    /// separators are shorter than command rows.
+    /// </summary>
+    private static BPoint RowCenter(StandardEdit edit, StandardEditContextMenuCommand command)
+    {
+        BRect menu = edit.ContextMenuBounds;
+        double top = menu.Top + 4;
+        foreach (StandardEditContextMenuItem item in edit.ContextMenuItems)
+        {
+            double height = item.IsSeparator ? 7 : edit.ContextMenuItemHeight;
+            if (item.Command == command)
+                return new BPoint(menu.Left + (menu.Width / 2), top + (height / 2));
+
+            top += height;
+        }
+
+        throw new InvalidOperationException($"The context menu has no '{command}' row.");
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ are versioned in lockstep during the preview.
 
 ### Added
 
+- `Broiler.UI.Edit` — an editing context menu on the single-line edit, plus the
+  clipboard shortcuts that were missing next to `Ctrl+C`/`X`/`V`: `Ctrl+Insert`
+  copies, `Shift+Insert` pastes and `Shift+Delete` cuts, the chords several
+  editors and terminals still send. Right-clicking the field — or pressing
+  `Shift+F10` or the menu key — offers Undo, Cut, Copy, Paste, Delete and Select
+  All, each enabled against the state the menu opened with: Paste only when the
+  clipboard holds text a single-line field would actually insert, and a password
+  field offers neither Cut nor Copy, the rule that already made `Copy()` refuse.
+  A right-click inside the selection keeps it, since that is what Cut and Copy
+  act on, while a click outside moves the caret there first. The menu is drawn by
+  the control the way the ComboBox draws its drop-down rather than composed from a
+  `UiMenu`, so an edit still costs one assembly and no host has to hand a menu to
+  every field it creates; while it is open the edit holds the input capture, so
+  the text behind it cannot be typed into, and it appears in the semantic tree as
+  an expanded menu. A host that would rather show a platform menu runs the same
+  commands through `StandardEdit.InvokeContextMenuCommand`.
 - `Broiler.Layout` — CSS Images 3 §5.5 `object-fit` and §5.6 `object-position`,
   which nothing read: every replaced element was stretched to its content box, so
   `object-fit-contain-svg-001i`, `-fill-svg-001i` and `-none-svg-001i` rendered to

--- a/src/Broiler.Browser.Core/HtmlFormEditor.cs
+++ b/src/Broiler.Browser.Core/HtmlFormEditor.cs
@@ -195,7 +195,7 @@ internal sealed class HtmlFormEditor
 
         if (zoom <= 0 || viewportBounds.IsEmpty)
         {
-            _edit.Visibility = UiVisibility.Collapsed;
+            Hide();
             return;
         }
 
@@ -208,7 +208,7 @@ internal sealed class HtmlFormEditor
         // A field scrolled out of view must neither paint nor swallow pointer input.
         if (target.Intersect(viewportBounds).IsEmpty)
         {
-            _edit.Visibility = UiVisibility.Collapsed;
+            Hide();
             return;
         }
 
@@ -231,6 +231,17 @@ internal sealed class HtmlFormEditor
         FieldType = string.Empty;
         _edit.Text = string.Empty;
         _edit.IsPassword = false;
+        Hide();
+    }
+
+    /// <summary>
+    /// Takes the overlay out of the tree's visible set. An open context menu goes
+    /// with it: a hidden control receives no input, so a menu left open would hold
+    /// the session's input capture with nothing able to dismiss it.
+    /// </summary>
+    private void Hide()
+    {
+        _edit.CloseContextMenu();
         _edit.Visibility = UiVisibility.Collapsed;
     }
 }


### PR DESCRIPTION
Implements a right-click context menu for `StandardEdit` with Undo, Cut, Copy, Paste, Delete, and Select All commands, plus missing clipboard keyboard shortcuts.

## Summary

Adds a fully-featured editing context menu to the single-line text edit control, drawn as an intrinsic part of the control (like ComboBox's dropdown) rather than composed from a separate menu component. Also implements clipboard shortcuts that were missing: `Ctrl+Insert` (copy), `Shift+Insert` (paste), and `Shift+Delete` (cut), which several editors and terminals still send.

## Key Changes

- **StandardEdit.ContextMenu.cs** (new, 486 lines): Complete context menu implementation
  - Menu opens on right-click, `Shift+F10`, or the menu key; positioned below the caret or anchor point
  - Flips and clamps to stay inside the viewport
  - Keyboard navigation with arrow keys, Home/End, Enter to invoke, and access keys (first letter cycling)
  - Hover highlighting with mouse support
  - Command enablement snapshots control state when menu opens (undo stack, selection, clipboard, read-only/password status)
  - Rendering with rounded corners, borders, separators, and disabled-state styling
  - Input capture prevents editing while menu is open

- **StandardEditContextMenuCommand.cs** (new): Enum for the six menu commands (Undo, Cut, Copy, Paste, Delete, SelectAll)

- **StandardEditContextMenuItem.cs** (new): Record struct representing a menu row with command, label, shortcut text, and enablement state; supports separators

- **StandardEdit.cs** (modified): 
  - Marked as `partial` to split context menu logic into separate file
  - Added context menu color properties (background, foreground, disabled, highlight, border)
  - Integrated menu input handling and deferred rendering
  - Closes menu when control is disabled
  - Theme application includes context menu colors

- **StandardEditClipboardTests.cs** (new, 155 lines): Tests for clipboard shortcuts (`Ctrl+C/X/V`, `Ctrl+Insert`, `Shift+Insert`, `Shift+Delete`)
  - Verifies copy/cut/paste behavior, undo integration, MaxLength enforcement
  - Tests password and read-only field restrictions
  - Tests multi-line sanitization

- **StandardEditContextMenuTests.cs** (new, 399 lines): Comprehensive context menu tests
  - Right-click behavior (focus, capture, selection preservation)
  - Menu keyboard navigation and access keys
  - Command execution and enablement rules
  - Password/read-only field restrictions
  - Viewport clamping and rendering
  - Semantic tree integration
  - Host-driven command invocation

- **EditStandardHarness.cs** (new, 185 lines): Test infrastructure
  - `EditScene` wrapper with clipboard host and input routing
  - Helper methods for keyboard/mouse/text input events
  - Fixed-position edit root for unambiguous pointer hit testing

- **Broiler.UI.Edit.Standard.Tests.csproj** (new): Test project for the edit control

- **CHANGELOG.md** (modified): Documents the new feature

## Implementation Details

- The menu holds input capture while open, consuming all keyboard and pointer input so the field behind cannot be edited
- Enablement is determined once when the menu opens (snapshot of undo stack, selection, clipboard state, field mode)
- Password fields block Copy and Cut but allow Paste
- Read-only fields allow Copy and Select All only
- Paste validates that clipboard text survives single-line sanitization and fits within MaxLength
- Menu rendering is deferred so it paints over later siblings
- Semantic tree includes the menu as a child with `Expanded` state when open
- Public `InvokeContextMenuCommand` method allows hosts to drive the same commands from a native platform menu

https://claude.ai/code/session_011rPndFT1k1PNRbemu6KDgi