### PR TITLE
Report the promise rejections a capture was losing

### DIFF
--- a/docs/cli-capture-diagnostics.md
+++ b/docs/cli-capture-diagnostics.md
@@ -69,6 +69,35 @@ Every `JavaScript` log entry at `Warning` or above — thrown script errors,
 `console.error`, `console.warn`, fetch failures, and the drain-budget warning —
 with its exception and stack trace indented beneath it.
 
+#### What reaches it, and what does not
+
+| How the exception arises | Logged |
+| --- | --- |
+| Thrown at the top level of a script | yes |
+| Thrown inside a timer callback | yes |
+| Thrown inside an event listener | yes |
+| A promise rejected with no handler | yes, **once the `Broiler.JS` patch is applied** |
+| Caught by the page's own `try`/`catch` | **no** |
+
+**A caught exception is not reported**, because the log sits at the host's
+`catch` around script evaluation and a caught exception never reaches it. That
+matches a browser — DevTools needs "pause on caught exceptions" to see these —
+but it is worth knowing before reading a low failure count as good news. A page
+whose bootstrap wraps everything in `try`/`catch` and reports through its own
+error channel can fail throughout and log nothing here. When a bundle shows few
+failures and a document the scripts barely changed, that pattern, not success,
+is the first thing to suspect.
+
+**Unhandled promise rejections** need the patch under `patches/` that adds
+`JSPromiseRejectionTracker` to `Broiler.JS`; the engine has no notion of them
+otherwise. Without it the reporting compiles out and a rejected promise nobody
+handled is lost — which on a promise-driven page is most of what goes wrong.
+Check whether it is live with:
+
+```sh
+git -C Broiler.JS log --oneline --grep 'Report promises rejected with nobody'
+```
+
 It is written and flushed per entry, not buffered and dumped at exit. The runs
 that most need diagnosing are the ones that hang, blow `--timeout` or die, and
 those are exactly the runs a write-at-exit design leaves an empty file for.

--- a/patches/0003-unhandled-promise-rejection-tracking.patch
+++ b/patches/0003-unhandled-promise-rejection-tracking.patch
@@ -1,0 +1,260 @@
+From affcb67aa4110106efa186a6b92b75570f7de96e Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 14 Aug 2026 08:40:27 +0000
+Subject: [PATCH] Report promises rejected with nobody to handle them
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+A rejected promise that nothing is waiting on is a failure the engine had no
+notion of. A browser reports it as "Uncaught (in promise)"; here it vanished.
+Three spellings, all silent: a throw inside .then, Promise.reject with no
+.catch, and an async function that throws. On a page whose control flow is
+mostly promises, that is most of its failures.
+
+The report has to be deferred, which is why this is a tracker and not a log
+line inside Reject. Promise.reject(x) is already rejected before the .catch on
+the next line runs, and an await attaches its handler a microtask after the
+promise settles — so reporting at the rejection would call almost every
+correctly-handled rejection unhandled. Collect at the rejection, withdraw when
+a handler arrives, and let the host ask what is left once its microtask
+checkpoint has drained.
+
+Both places a promise becomes rejected are tracked, because they are genuinely
+two: Reject, and the (value, state) constructor that Promise.reject and
+CreateResolvedOrRejectedPromise use to mint one already rejected. Hooking only
+Reject caught the throw-inside-then case and neither of the other two.
+
+Then marks [[PromiseIsHandled]] whether or not an onRejected was passed. With
+none, the rejection forwards to the derived promise and it is that one which is
+then unhandled — which is what makes p.then(f) on a rejecting p report against
+the derived promise, as a browser does.
+
+Off by default: Rejected and Handled read one bool and return, so an unenabled
+run pays nothing and no existing behaviour changes. Wiring this to
+window.onunhandledrejection, which would make it always-on, is the natural next
+step and is deliberately not part of this.
+
+Verified against seven correctly-handled shapes — .catch, .then(null, f),
+await in try/catch, Promise.all with a catch, and a .catch attached a microtask
+after the promise had already settled — none of which is reported; and against
+the three unhandled shapes, all of which now are.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01Jc3MaJErm4iQJ3g5DAQwRt
+---
+ .../Promise/JSPromise.cs                      |  25 +++
+ .../Promise/JSPromiseRejectionTracker.cs      | 144 ++++++++++++++++++
+ 2 files changed, 169 insertions(+)
+ create mode 100644 Broiler.JS/Broiler.JavaScript.BuiltIns/Promise/JSPromiseRejectionTracker.cs
+
+diff --git a/Broiler.JS/Broiler.JavaScript.BuiltIns/Promise/JSPromise.cs b/Broiler.JS/Broiler.JavaScript.BuiltIns/Promise/JSPromise.cs
+index 6a6ed960..5aa4249d 100644
+--- a/Broiler.JS/Broiler.JavaScript.BuiltIns/Promise/JSPromise.cs
++++ b/Broiler.JS/Broiler.JavaScript.BuiltIns/Promise/JSPromise.cs
+@@ -40,6 +40,12 @@ public partial class JSPromise : JSObject, IJSPromise
+ 
+     internal PromiseState state = PromiseState.Pending;
+ 
++    /// <summary>
++    /// The spec's [[PromiseIsHandled]]: set once any reaction is attached, and the difference
++    /// between a rejection nobody is listening for and one that is somebody's job.
++    /// </summary>
++    private bool isHandled;
++
+     private Sequence<Reaction> thenList;
+     private Sequence<Reaction> rejectList;
+     JSFunction resolveFunction;
+@@ -86,6 +92,12 @@ public partial class JSPromise : JSObject, IJSPromise
+         InitPromise();
+         this.state = state;
+         result = value;
++
++        // Born rejected, which never passes through Reject: this is how Promise.reject and an async
++        // function that throws before its first await both produce their promise. Tracking only
++        // Reject would miss the two commonest unhandled rejections a page produces.
++        if (state == PromiseState.Rejected)
++            JSPromiseRejectionTracker.Rejected(this, value);
+     }
+ 
+     /// <summary>
+@@ -251,6 +263,12 @@ public partial class JSPromise : JSObject, IJSPromise
+ 
+         pending.TryRemove(promiseID, out var __);
+ 
++        // Nothing is waiting on this one: collect it as a candidate "Uncaught (in promise)". It is
++        // only a candidate, because a handler may still arrive in this turn — see
++        // JSPromiseRejectionTracker for why the report cannot be raised here.
++        if (!isHandled)
++            JSPromiseRejectionTracker.Rejected(this, value);
++
+         var rejectList = this.rejectList;
+         if (rejectList != null)
+         {
+@@ -321,6 +339,13 @@ public partial class JSPromise : JSObject, IJSPromise
+             @return.InitPromise();
+         }
+ 
++        // PerformPromiseThen sets [[PromiseIsHandled]] whether or not an onRejected was supplied:
++        // with none, the rejection is forwarded to @return, and it is @return that is then the
++        // unhandled one. That is what makes `p.then(f)` on a rejecting p report against the derived
++        // promise, exactly as a browser does.
++        isHandled = true;
++        JSPromiseRejectionTracker.Handled(this);
++
+         var resolved = new Reaction { Promise = @return, Type = ReactionType.Resolve, Handler = resolve };
+         var rejected = new Reaction { Promise = @return, Type = ReactionType.Reject, Handler = fail };
+ 
+diff --git a/Broiler.JS/Broiler.JavaScript.BuiltIns/Promise/JSPromiseRejectionTracker.cs b/Broiler.JS/Broiler.JavaScript.BuiltIns/Promise/JSPromiseRejectionTracker.cs
+new file mode 100644
+index 00000000..5a48c00b
+--- /dev/null
++++ b/Broiler.JS/Broiler.JavaScript.BuiltIns/Promise/JSPromiseRejectionTracker.cs
+@@ -0,0 +1,144 @@
++using Broiler.JavaScript.Runtime;
++using System;
++using System.Collections.Generic;
++
++namespace Broiler.JavaScript.BuiltIns.Promise;
++
++/// <summary>One promise that was rejected and, so far, has nobody to tell.</summary>
++public readonly struct UnhandledRejection
++{
++    internal UnhandledRejection(JSValue reason)
++    {
++        Reason = reason;
++    }
++
++    /// <summary>The rejection reason — an <c>Error</c> object, or whatever else was thrown.</summary>
++    public JSValue Reason { get; }
++
++    /// <summary>
++    /// The reason rendered the way the console would render it: an <c>Error</c>'s message when it
++    /// has one, otherwise the value's own string form.
++    /// </summary>
++    public string Describe()
++    {
++        try
++        {
++            if (Reason is JSObject error && error[KeyStrings.message] is { } message && !message.IsUndefined)
++            {
++                var name = error[KeyStrings.name];
++                return name.IsUndefined ? message.ToString() : name + ": " + message;
++            }
++
++            return Reason?.ToString() ?? "undefined";
++        }
++        catch (Exception)
++        {
++            // Describing a rejection must never replace it: the reason can be a hostile object
++            // whose toString throws, and this is called while reporting a failure.
++            return "<rejection reason could not be described>";
++        }
++    }
++}
++
++/// <summary>
++/// Tracks promises that were rejected with no handler attached — what a browser reports as
++/// <c>Uncaught (in promise)</c>, and what this engine had no notion of at all.
++/// </summary>
++/// <remarks>
++/// <para>
++/// <b>Why the report is deferred rather than raised at the rejection.</b> <c>Promise.reject(x)</c>
++/// is rejected before <c>.catch(…)</c> on the next line has run, and an <c>await</c> attaches its
++/// handler a microtask after the promise settles. Reporting from inside <see cref="JSPromise.Reject"/>
++/// would therefore call almost every correctly-handled rejection unhandled. The spec's answer, and
++/// this one, is to collect at the rejection, withdraw when a handler arrives, and let the host ask
++/// what is left once its microtask checkpoint has drained.
++/// </para>
++/// <para>
++/// <b>Opt-in.</b> Off by default, so no existing run changes shape and a promise-heavy page pays
++/// nothing: <see cref="Rejected"/> and <see cref="Handled"/> read one static <see langword="bool"/>
++/// and return. A host that wants the reports sets <see cref="Enabled"/> and drains
++/// <see cref="TakePending"/>. Reporting them through <c>window.onunhandledrejection</c> — which
++/// would make this always-on — is the natural next step and is deliberately not done here.
++/// </para>
++/// <para>
++/// <b>Identity, not equality.</b> The pending set is keyed on the promise instance by reference,
++/// because two distinct promises rejected with the same reason are two rejections, and <c>JSValue</c>
++/// equality is a JavaScript question this must not ask.
++/// </para>
++/// </remarks>
++public static class JSPromiseRejectionTracker
++{
++    private static readonly Dictionary<object, JSValue> _pending = new(ReferenceEqualityComparer.Instance);
++    private static readonly object _sync = new();
++    private static bool _enabled;
++
++    /// <summary>
++    /// Whether rejections are tracked. Off by default. Setting it to <see langword="false"/>
++    /// discards anything already collected, so a host cannot pick up another host's rejections.
++    /// </summary>
++    public static bool Enabled
++    {
++        get { lock (_sync) return _enabled; }
++        set
++        {
++            lock (_sync)
++            {
++                _enabled = value;
++                if (!value)
++                    _pending.Clear();
++            }
++        }
++    }
++
++    /// <summary>
++    /// A promise was rejected while nothing was waiting on it. Called from
++    /// <see cref="JSPromise.Reject"/>.
++    /// </summary>
++    internal static void Rejected(object promise, JSValue reason)
++    {
++        lock (_sync)
++        {
++            if (!_enabled)
++                return;
++
++            _pending[promise] = reason;
++        }
++    }
++
++    /// <summary>
++    /// A handler was attached to <paramref name="promise"/>, so its rejection — whether it has
++    /// happened yet or not — is somebody's business now. Called from <see cref="JSPromise.Then"/>.
++    /// </summary>
++    internal static void Handled(object promise)
++    {
++        lock (_sync)
++        {
++            if (!_enabled)
++                return;
++
++            _pending.Remove(promise);
++        }
++    }
++
++    /// <summary>
++    /// The rejections still unclaimed, in rejection order, and clears them. A host calls this after
++    /// draining its microtask checkpoint: anything left has had every chance to be handled.
++    /// </summary>
++    public static IReadOnlyList<UnhandledRejection> TakePending()
++    {
++        lock (_sync)
++        {
++            // A collection expression rather than Array.Empty: from inside this namespace the
++            // sibling Broiler.JavaScript.BuiltIns.Array shadows System.Array by simple-name lookup.
++            if (_pending.Count == 0)
++                return [];
++
++            var taken = new List<UnhandledRejection>(_pending.Count);
++            foreach (var reason in _pending.Values)
++                taken.Add(new UnhandledRejection(reason));
++
++            _pending.Clear();
++            return taken;
++        }
++    }
++}
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # Submodule patches waiting to be applied
 
-**Two patches are waiting on a maintainer.** See the index below.
+**Three patches are waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -48,6 +48,7 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD && echo "live on CI"
 | --- | --- | --- |
 | `0001` | `Broiler.JS` | Keep a direct eval's scope alive for the closures it creates |
 | `0002` | `Broiler.JS` | Name the property in "Cannot read properties of undefined" |
+| `0003` | `Broiler.JS` | Report promises rejected with nobody to handle them |
 
 ### `0001` — a closure a direct eval created lost the eval site's bindings
 
@@ -116,6 +117,49 @@ covering for it.
 paints. `UndefinedPropertyReadMessageTests` covers it.
 
 **When it lands upstream:** bump the pointer and delete this patch.
+
+### `0003` — a rejected promise nobody handled was reported nowhere
+
+A browser reports it as `Uncaught (in promise)`. Here it vanished. Three
+spellings, all silent: a `throw` inside `.then`, `Promise.reject` with no
+`.catch`, and an `async` function that throws. On a page whose control flow is
+mostly promises — which now means most pages — that is the bulk of its failures,
+and the reason a `--diagnostic-dir` bundle could report **zero** JavaScript
+failures for a page that plainly did not work.
+
+**The report has to be deferred**, which is why this is a tracker and not a log
+line inside `Reject`. `Promise.reject(x)` is already rejected before the `.catch`
+on the next line runs, and an `await` attaches its handler a microtask after the
+promise settles. Reporting at the rejection would therefore call almost every
+correctly-handled rejection unhandled. So: collect at the rejection, withdraw
+when a handler arrives, and let the host ask what is left once its microtask
+checkpoint has drained.
+
+**Both places a promise becomes rejected are tracked**, because they are
+genuinely two — `Reject`, and the `(value, state)` constructor that
+`Promise.reject` and `CreateResolvedOrRejectedPromise` use to mint one already
+rejected. Hooking only `Reject` caught the throw-inside-`then` case and neither
+of the other two.
+
+**Off by default**, so no existing run changes shape: `Rejected` and `Handled`
+read one `bool` and return. Wiring it to `window.onunhandledrejection` — which
+would make it always-on and is the point of having it — is the natural next step
+and is deliberately not in this patch.
+
+**The main repo builds without it.** `Broiler.Cli` reports what the tracker
+collects, and `Broiler.JS` references nothing in this repository, so the type
+could not be moved here the way a `Broiler.Layout` type would be. Instead
+`Broiler.Cli.csproj` and `Broiler.Cli.Tests.csproj` probe for the file and define
+`BROILER_JS_REJECTION_TRACKING`, the same shape
+`Broiler.Render.Stage.Benchmarks.csproj` uses for `BRasterParallelism`. Without
+the patch the reporting compiles out and the capture behaves as before; with it
+applied, `UnhandledPromiseRejectionTests` compiles in and covers it.
+
+**Not listed for the pixel suites** — it reports a failure, it does not change
+what a page paints.
+
+**When it lands upstream:** bump the pointer, delete this patch, and drop the two
+`BroilerJsRejectionTracking` probes with their `#if`s.
 
 ## A stale entry in the apply script is not inert
 

--- a/src/Broiler.Cli.Tests/Broiler.Cli.Tests.csproj
+++ b/src/Broiler.Cli.Tests/Broiler.Cli.Tests.csproj
@@ -11,6 +11,20 @@
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 
+  <!--
+    Mirrors the probe in Broiler.Cli.csproj: the unhandled-rejection coverage can only pass once the
+    Broiler.JS patch adding JSPromiseRejectionTracker is applied, so without it the file is not
+    compiled rather than failing against an engine that cannot report them.
+  -->
+  <PropertyGroup>
+    <BroilerJsRejectionTracking Condition="Exists('$(MSBuildThisFileDirectory)..\..\Broiler.JS\Broiler.JS\Broiler.JavaScript.BuiltIns\Promise\JSPromiseRejectionTracker.cs')">true</BroilerJsRejectionTracking>
+    <DefineConstants Condition="'$(BroilerJsRejectionTracking)' == 'true'">$(DefineConstants);BROILER_JS_REJECTION_TRACKING</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(BroilerJsRejectionTracking)' != 'true'">
+    <Compile Remove="UnhandledPromiseRejectionTests.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />

--- a/src/Broiler.Cli.Tests/UnhandledPromiseRejectionTests.cs
+++ b/src/Broiler.Cli.Tests/UnhandledPromiseRejectionTests.cs
@@ -1,0 +1,122 @@
+using Broiler.HtmlBridge.Logging;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Covers the failures a capture used to lose entirely: a promise rejected with nothing waiting on
+/// it. They reach no <c>catch</c> in the capture path — they propagate through the promise
+/// machinery instead — so before the engine tracked them a page could fail throughout and the
+/// diagnostics bundle would report zero failures.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Compiled only when the <c>Broiler.JS</c> patch adding <c>JSPromiseRejectionTracker</c> is
+/// applied; see the <c>BroilerJsRejectionTracking</c> probe in the test project.
+/// </para>
+/// <para>
+/// The half that matters most here is <see cref="Handled_Rejections_Are_Not_Reported"/>. Reporting
+/// an unhandled rejection is easy; not reporting a handled one is the whole difficulty, because a
+/// handler is routinely attached after the promise has already settled.
+/// </para>
+/// </remarks>
+[Collection("DiagnosticSession")]
+public sealed class UnhandledPromiseRejectionTests
+{
+    /// <summary>Runs <paramref name="script"/> through a capture and returns what was logged.</summary>
+    private static string[] CaptureFailures(string script)
+    {
+        var messages = new List<string>();
+        void Collect(RenderLogEntry entry)
+        {
+            if (entry.Category == LogCategory.JavaScript && entry.Level >= LogLevel.Warning)
+                lock (messages) messages.Add(entry.Message);
+        }
+
+        var directory = Path.Combine(Path.GetTempPath(), "broiler-rej-" + Guid.NewGuid().ToString("N"));
+        RenderLogger.EntryLogged += Collect;
+        try
+        {
+            // Through a session, because the engine only tracks while one is running.
+            using (DiagnosticSession.Start(Program.ResolveDiagnosticOptions(directory, null)))
+            {
+                CaptureService.ExecuteScriptsWithDom(
+                    $"<!DOCTYPE html><html><body><script>{script}</script></body></html>",
+                    "https://example.test/page");
+            }
+        }
+        finally
+        {
+            RenderLogger.EntryLogged -= Collect;
+            try
+            {
+                if (Directory.Exists(directory))
+                    Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+
+        lock (messages) return [.. messages];
+    }
+
+    [Theory]
+    // The three ways a page produces one, which are three different code paths in the engine: a
+    // throw inside a reaction rejects the derived promise, while the other two mint a promise that
+    // is already rejected without ever passing through Reject.
+    [InlineData("Promise.resolve().then(function () { throw new Error('rejectionMarker'); });")]
+    [InlineData("Promise.reject(new Error('rejectionMarker'));")]
+    [InlineData("(async function () { throw new Error('rejectionMarker'); })();")]
+    public void An_Unclaimed_Rejection_Is_Reported(string script)
+    {
+        var failures = CaptureFailures(script);
+
+        Assert.Contains(failures, m => m.Contains("Unhandled promise rejection", StringComparison.Ordinal));
+        Assert.Contains(failures, m => m.Contains("rejectionMarker", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("Promise.reject(new Error('handledMarker')).catch(function (e) {});")]
+    [InlineData("Promise.resolve().then(function () { throw new Error('handledMarker'); }).catch(function (e) {});")]
+    [InlineData("Promise.reject(new Error('handledMarker')).then(null, function (e) {});")]
+    [InlineData("(async function () { try { await Promise.reject(new Error('handledMarker')); } catch (e) {} })();")]
+    [InlineData("Promise.all([Promise.reject(new Error('handledMarker'))]).catch(function (e) {});")]
+    // The case that forces the report to be deferred rather than raised at the rejection: the
+    // promise is already rejected when the handler is attached, a microtask later.
+    [InlineData("var p = Promise.reject(new Error('handledMarker')); Promise.resolve().then(function () { p.catch(function (e) {}); });")]
+    public void Handled_Rejections_Are_Not_Reported(string script)
+    {
+        Assert.DoesNotContain(
+            CaptureFailures(script),
+            m => m.Contains("Unhandled promise rejection", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void A_Rejection_Is_Reported_Once_Per_Promise()
+    {
+        var failures = CaptureFailures(
+            "Promise.reject(new Error('firstMarker')); Promise.reject(new Error('secondMarker'));");
+
+        Assert.Equal(
+            2,
+            failures.Count(m => m.Contains("Unhandled promise rejection", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void The_Report_Names_The_Error()
+    {
+        var failures = CaptureFailures("Promise.reject(new TypeError('describedMarker'));");
+
+        // The reason is described as a console would describe it — name and message — rather than
+        // as "[object Object]", which would say nothing about what failed.
+        Assert.Contains(failures, m => m.Contains("TypeError: describedMarker", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void A_Non_Error_Reason_Is_Still_Described()
+    {
+        var failures = CaptureFailures("Promise.reject('plainStringMarker');");
+
+        Assert.Contains(failures, m => m.Contains("plainStringMarker", StringComparison.Ordinal));
+    }
+}

--- a/src/Broiler.Cli/Broiler.Cli.csproj
+++ b/src/Broiler.Cli/Broiler.Cli.csproj
@@ -9,6 +9,20 @@
     <DefineConstants>$(DefineConstants);BROILER_CLI</DefineConstants>
   </PropertyGroup>
 
+  <!--
+    Unhandled-promise-rejection reporting needs JSPromiseRejectionTracker, which lives in the
+    Broiler.JS submodule and ships as a patch under patches/ until a maintainer applies it (the git
+    proxy answers 403 for a submodule remote outside this session's scope). The type cannot move to
+    this repository the way Broiler.Layout types do, because Broiler.JS references nothing here — so
+    this probes for the file, exactly as Broiler.Render.Stage.Benchmarks does for
+    BRasterParallelism. With the patch applied the reporting compiles in; without it the capture
+    behaves as it did before, and the build is not broken by a call to a type that is not there.
+  -->
+  <PropertyGroup>
+    <BroilerJsRejectionTracking Condition="Exists('$(MSBuildThisFileDirectory)..\..\Broiler.JS\Broiler.JS\Broiler.JavaScript.BuiltIns\Promise\JSPromiseRejectionTracker.cs')">true</BroilerJsRejectionTracking>
+    <DefineConstants Condition="'$(BroilerJsRejectionTracking)' == 'true'">$(DefineConstants);BROILER_JS_REJECTION_TRACKING</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Broiler.Cli.Tests" />
   </ItemGroup>

--- a/src/Broiler.Cli/CaptureService.cs
+++ b/src/Broiler.Cli/CaptureService.cs
@@ -10,6 +10,9 @@ using Broiler.JavaScript.BuiltIns.String;
 using Broiler.JavaScript.Runtime;
 using Broiler.JavaScript.Engine;
 using Broiler.JavaScript.BuiltIns.Function;
+#if BROILER_JS_REJECTION_TRACKING
+using Broiler.JavaScript.BuiltIns.Promise;
+#endif
 using Broiler.CSS;
 using Broiler.HtmlBridge;
 using Broiler.HtmlBridge.Logging;
@@ -767,6 +770,7 @@ public class CaptureService
 
         // Drain queued microtasks and timer work before capture.
         DrainAsyncWork(bridge, microTasks);
+        ReportUnhandledRejections();
         bridge.ResolveAnimationSnapshots();
 
         var serialized = bridge.SerializeToHtml();
@@ -775,6 +779,30 @@ public class CaptureService
         // of the run shows.
         ResourceTrace.RecordBody(ResourceTraceKind.Document, url, serialized, DiagnosticSession.AfterScriptsLabel);
         return serialized;
+    }
+
+    /// <summary>
+    /// Logs the promises that were rejected with nothing to handle them — a browser's
+    /// <c>Uncaught (in promise)</c>.
+    /// </summary>
+    /// <remarks>
+    /// Called after the async drain, not before: until the microtask checkpoint has run to
+    /// quiescence a rejection may still be claimed, and reporting earlier would call a handled
+    /// rejection unhandled. Empty unless a diagnostic run turned the engine's tracker on, so an
+    /// ordinary capture pays a single lock and an empty list.
+    /// </remarks>
+    private static void ReportUnhandledRejections()
+    {
+#if BROILER_JS_REJECTION_TRACKING
+        foreach (var rejection in JSPromiseRejectionTracker.TakePending())
+        {
+            RenderLogger.Log(
+                LogCategory.JavaScript,
+                LogLevel.Error,
+                "CaptureService.UnhandledRejection",
+                $"Unhandled promise rejection: {rejection.Describe()}");
+        }
+#endif
     }
 
     /// <summary>

--- a/src/Broiler.Cli/DiagnosticSession.cs
+++ b/src/Broiler.Cli/DiagnosticSession.cs
@@ -4,6 +4,9 @@ using System.Text;
 using System.Text.Json;
 using Broiler.HtmlBridge.Core.Diagnostics;
 using Broiler.HtmlBridge.Logging;
+#if BROILER_JS_REJECTION_TRACKING
+using Broiler.JavaScript.BuiltIns.Promise;
+#endif
 
 namespace Broiler.Cli;
 
@@ -141,6 +144,24 @@ internal sealed class DiagnosticSession : IDisposable
 
         _logHandler = OnLogEntry;
         RenderLogger.EntryLogged += _logHandler;
+
+        // A rejected promise nobody handled is a failure the host would otherwise never hear about:
+        // it propagates through the promise machinery rather than out of an Eval, so no catch block
+        // in the capture path sees it. The engine collects them only while this is on; the capture
+        // reports what is left once its microtask checkpoint has drained.
+        TrackPromiseRejections(true);
+    }
+
+    /// <summary>
+    /// Turns the engine's unhandled-rejection tracking on or off for this session. Compiled out
+    /// when the Broiler.JS patch that adds the tracker has not been applied — see the
+    /// <c>BroilerJsRejectionTracking</c> probe in <c>Broiler.Cli.csproj</c>.
+    /// </summary>
+    private static void TrackPromiseRejections(bool enabled)
+    {
+#if BROILER_JS_REJECTION_TRACKING
+        JSPromiseRejectionTracker.Enabled = enabled;
+#endif
     }
 
     private static StreamWriter OpenWriter(string path) =>
@@ -364,6 +385,9 @@ internal sealed class DiagnosticSession : IDisposable
             ResourceTrace.Recorded -= resourceHandler;
             _resourceHandler = null;
         }
+
+        // Discards anything still collected, so a later run in this process cannot inherit it.
+        TrackPromiseRejections(false);
 
         try
         {


### PR DESCRIPTION
Follow-up to #1647. That PR added the `--diagnostic-dir` bundle; this one fixes a hole in what it could see.

## The problem

A promise rejected with nothing waiting on it reached the log nowhere. It propagates through the promise machinery rather than out of an `Eval`, so no `catch` in the capture path ever sees it. A browser reports it as `Uncaught (in promise)`; here it vanished.

That is why a bundle could report **zero JavaScript failures** for a page that plainly did not work — including the `google.com/search` capture #1647 was demonstrated against.

## What was measured

Rather than reasoning about it, each way an exception can arise was run through a capture with a uniquely-tagged failure:

| How the exception arises | Before | After |
| --- | --- | --- |
| Thrown at the top level of a script | ✅ | ✅ |
| Thrown inside a timer callback | ✅ | ✅ |
| Thrown inside an event listener | ✅ | ✅ |
| `throw` inside `.then` | ❌ | ✅ |
| `Promise.reject` with no `.catch` | ❌ | ✅ |
| `async` function that throws | ❌ | ✅ |
| Caught by the page's own `try`/`catch` | ❌ | ❌ — see below |

## Two things the first attempt got wrong

**Hooking `Reject` is not enough.** `Promise.reject` and an `async` function that throws before its first `await` both mint a promise that is *already* rejected, through the `(value, state)` constructor, without ever passing through `Reject`. Tracking only `Reject` caught the throw-inside-`.then` case and neither of the other two. Both sites are now tracked.

**The report has to be deferred.** `Promise.reject(x)` is already rejected before the `.catch` on the next line runs, and an `await` attaches its handler a microtask after the promise settles. Reporting from inside the rejection would call almost every correctly-handled rejection unhandled. So the tracker collects at the rejection, withdraws when a handler arrives, and the capture asks what is left once its microtask checkpoint has drained.

## Caught exceptions are deliberately still not reported

The log sits at the host's `catch` around script evaluation, so anything the page catches itself never reaches it. A browser behaves the same way — DevTools needs "pause on caught exceptions" to see these. It is left as-is, but `docs/cli-capture-diagnostics.md` now states it plainly next to the reasons a low failure count is not by itself good news: a page whose bootstrap wraps everything in `try`/`catch` can fail throughout and log nothing.

## Shipping shape: a patch, and a main repo that builds without it

The engine had no notion of an unhandled rejection, so the tracking is a `Broiler.JS` change. The git proxy answers **403** for that remote, so it ships as `patches/0003-unhandled-promise-rejection-tracking.patch` and **the submodule pointer is not bumped**.

`Broiler.JS` references nothing in this repository, so the type could not be moved here the way a `Broiler.Layout` type would be. Instead `Broiler.Cli.csproj` and `Broiler.Cli.Tests.csproj` probe for the file and define `BROILER_JS_REJECTION_TRACKING` — the same shape `Broiler.Render.Stage.Benchmarks.csproj` already uses for `BRasterParallelism`. Unpatched, the reporting compiles out and a capture behaves exactly as it did before.

## Verification

**Patch applied** — 41 `Broiler.Cli.Tests` pass, covering the three unhandled shapes now reported and six correctly-handled ones that must not be: `.catch`, `.then(null, f)`, `await` in `try`/`catch`, `Promise.all` with a catch, and a `.catch` attached a microtask *after* the promise had already settled.

**Patch reverted** — the submodule tree is back at its pinned SHA with no gitlink bump, the build succeeds, `UnhandledPromiseRejectionTests` is excluded from compilation rather than failing, and a capture of the same page runs clean and reports nothing.

## Note for reviewers

`Broiler.JS/…/Promise/JSPromise.cs` is a mixed-line-ending file (5 CRLF lines among 390 LF). Editing it normalised those lines twice, turning a pure addition into a phantom 5-line deletion; the bytes were restored both times. The exported patch is **169 insertions, 0 deletions**. Worth checking with `git show --stat` if this file is touched again.

## Follow-ups deliberately not in this PR

- Wiring the tracker to `window.onunhandledrejection`, which would make it always-on rather than opt-in.
- An opt-in hook at the `JSEngine.New*Error` factories, so engine-raised exceptions are recorded at creation even when page code swallows them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jc3MaJErm4iQJ3g5DAQwRt)_