### PR TITLE
Give the desktop applications the machine's clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ are versioned in lockstep during the preview.
 
 ### Added
 
+- The desktop applications use the machine's clipboard. Broiler.UI has always had
+  a clipboard *port* — `IUiClipboardHost`, which every text control copies and
+  pastes through — but on Windows and Linux nothing was plugged into it: the
+  Browser and Writer hosts answered from a private string, so copying in Broiler
+  and pasting into a terminal produced whatever had been copied before, and text
+  copied anywhere else could not be pasted in. (Android and the WebAssembly
+  Writer were already wired to `ClipboardManager` and the browser's clipboard
+  events; Code on Windows already had the Win32 one.)
+  - `Broiler.App.LinuxX11Clipboard` — the X11 CLIPBOARD and PRIMARY selections.
+    X11 has no clipboard daemon holding a string: the application that copied
+    last owns a selection and every paste is a request answered by that owner, so
+    this owns one on a display connection of its own and answers
+    `SelectionRequest` from the head's existing loop. It offers and accepts
+    `UTF8_STRING`, `STRING` and `TEXT`, answers `TARGETS`, reads a chunked `INCR`
+    transfer from owners that send one, and gives the selection up when the
+    process exits rather than leaving other applications to find a dead owner.
+    PRIMARY goes with CLIPBOARD, so a middle-click paste into a terminal gets the
+    same text Ctrl+V does. It needed no Broiler.Graphics change: draining the
+    window's own queue for this would swallow the focus, resize and close events
+    the surface is waiting for.
+  - The Win32 clipboard moved from the Code head to `Broiler.App` and is now
+    shared by Browser, Writer and Code alike rather than existing once and being
+    reachable only from Code.
+  - Broiler Code on Linux consequently reports `clipboard: native` from
+    `--services` and enables Cut, Copy and Paste, where it previously declared
+    the service unavailable because "X11 selection ownership is not implemented".
+  - Where a machine has no clipboard to offer — no X display — the commands
+    report themselves unavailable. There is deliberately still no in-process
+    buffer standing in for one: that is the thing that made copy and paste look
+    like they worked while interoperating with nothing.
+
 - `Broiler.UI.Edit` — an editing context menu on the single-line edit, plus the
   clipboard shortcuts that were missing next to `Ctrl+C`/`X`/`V`: `Ctrl+Insert`
   copies, `Shift+Insert` pastes and `Shift+Delete` cuts, the chords several
@@ -79,6 +110,16 @@ are versioned in lockstep during the preview.
   diagnostic must never be able to break the execution it observes.
 
 ### Changed
+
+- `Broiler.Browser.Core` and `Broiler.Writer` — the UI hosts no longer keep a
+  private clipboard string for when the shell wired no platform accessor. A
+  fallback that only this process can see makes copy and paste appear to work
+  while interoperating with nothing on the machine, which is why the Code
+  heads already refused to carry one; with the desktop shells now wiring real
+  clipboards, the fallback's only remaining effect would be to hide a host
+  that has none. A host without an accessor reports no text, and the editing
+  commands show themselves unavailable — the single-line edit's context menu
+  greys Paste out on such a host rather than offering a no-op.
 
 - `Broiler.HtmlBridge` — a script names itself in the stack traces of the errors it
   raises. `JSContext.Eval` takes the location it reports in stack frames and every

--- a/docs/broiler-code-roadmap.md
+++ b/docs/broiler-code-roadmap.md
@@ -1,7 +1,7 @@
 # Broiler Code roadmap
 
 - **Status:** Phases 0-3 delivered. The composed shell runs on Windows and
-  Linux; the Linux head reports its clipboard and IME as unavailable, and its
+  Linux; the Linux head reports its IME as unavailable, and its
   window has not yet been exercised on a Linux display
 - **Scope:** A C#/.NET IDE that reuses the Broiler Writer application stack and
   supports multi-project workspaces, live diagnostics, and builds for ordinary
@@ -614,22 +614,26 @@ the real thing.
 | --- | --- | --- |
 | UI-thread dispatcher | Native — queued, drained on the message-loop thread | Native — drained on the event-loop thread |
 | Input routing | Native — explicit Broiler.Input with device identity and a monotonic sequence | Native — same, over evdev |
-| Clipboard | Native — Win32, no in-memory fallback | **Unavailable** — X11 selection ownership is not implemented |
+| Clipboard | Native — Win32, no in-memory fallback | Native — the X11 CLIPBOARD and PRIMARY selections, owned on the head's own display connection |
 | Text input and IME | Native — IMM32 composition, candidates placed at the caret | **Unavailable** — no XIM, ibus, or Wayland backend exists; US-layout typing only |
 | File dialogs | Native — the common dialogs, through comdlg32 | Native where zenity or kdialog is installed; **Unavailable** otherwise |
 
-The two Linux gaps are structural rather than unfinished wiring. Its graphics
-stack is an X11 surface driven by a polling loop and its input arrives through
-evdev — raw device events, not X11 key events — and an input method speaks XIM,
-ibus, or the Wayland text-input protocol. None of those are reachable from
-evdev, and the only `ITextInputProvider` in the repository is Android's. The
-head therefore reports both as unavailable and disables the affected commands,
-rather than substituting an in-process buffer that would make copy and paste
-appear to work while interoperating with nothing.
+The remaining Linux gap is structural rather than unfinished wiring. Its input
+arrives through evdev — raw device events, not X11 key events — and an input
+method speaks XIM, ibus, or the Wayland text-input protocol. None of those are
+reachable from evdev, and the only `ITextInputProvider` in the repository is
+Android's. The head therefore reports IME as unavailable, rather than
+substituting something that appears to work while dropping candidates.
 
-Closing them means adding a Linux text-input backend and X11 selection
-ownership, which is Broiler.Input and Broiler.Graphics work rather than the
-head's.
+The clipboard gap is closed. `LinuxX11Clipboard` owns the CLIPBOARD and PRIMARY
+selections on a display connection of its own and answers other applications'
+`SelectionRequest` events from the head's loop, so a copy here is a paste
+anywhere on the display and vice versa. It is the head's own connection rather
+than the renderer's because draining the window's queue here would swallow the
+focus, resize and close events the surface is waiting for — which is also why
+it needed no Broiler.Graphics change. Where there is no display to own a
+selection on, the service reports unavailable and the commands stay disabled;
+there is still no in-process buffer standing in for a clipboard.
 
 **The Linux head now runs the shell.** It opens an X11/OpenGL window through
 `Broiler.Graphics.Linux.OpenGL`, composes the same shell from the same
@@ -667,7 +671,8 @@ that genuinely lacks the service. `file dialogs` joined `HostServiceReport` for
 exactly that reason: a head without it cannot run those commands, so it belongs
 in the claim rather than in an implementation detail.
 
-Clipboard and IME remain unavailable, unchanged and for the reasons above.
+IME remains unavailable, unchanged and for the reason above; the clipboard is
+now native, and `--services` says so.
 
 **What could not be verified here.** This work was done on Windows. The Linux
 head builds clean and its `--services` claim runs and prints correctly, because
@@ -686,8 +691,10 @@ renders by visible range and is keyboard accessible; both generated desktop
 solution closures verify and build. Dispatcher and input-routing tests pass for
 both heads and no head carries any of Writer's three substitutes.
 
-Three clauses remain open. The Linux clipboard and IME integration tests cannot
-pass until the backends above exist. The gate's requirement that a newly
+Three clauses remain open. The Linux IME integration tests cannot pass until
+that backend exists; the Linux clipboard now has one, exercised against a real
+X server (`xvfb-run -a dotnet test src/Broiler.App.Tests`), including a paste
+of what Broiler copied by a second X client. The gate's requirement that a newly
 templated solution build its declared graph is covered here by a load-back test
 rather than by a reference CLI build — the templated output is asserted to
 contain only standard SDK files and to reload as a declared workspace with its

--- a/src/Broiler.App.Tests/Broiler.App.Tests.csproj
+++ b/src/Broiler.App.Tests/Broiler.App.Tests.csproj
@@ -19,6 +19,11 @@
        directly to allow the tests to run on any platform. -->
   <ItemGroup>
     <Compile Include="..\Broiler.App\FavoritesManager.cs" Link="FavoritesManager.cs" />
+    <Compile Include="..\Broiler.App\LinuxX11Clipboard.cs" Link="LinuxX11Clipboard.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Broiler.UI\src\Foundation\Broiler.UI\Broiler.UI.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Broiler.App.Tests/LinuxX11ClipboardTests.cs
+++ b/src/Broiler.App.Tests/LinuxX11ClipboardTests.cs
@@ -1,0 +1,176 @@
+using Broiler.App;
+
+namespace Broiler.App.Tests;
+
+/// <summary>
+/// Exercises the X11 clipboard against a real X server.
+///
+/// Where there is no display — a bare container, a build agent — every test
+/// here returns early rather than failing: reporting no clipboard is the
+/// documented behavior on such a machine, not a defect. Run them under
+/// `xvfb-run -a dotnet test src/Broiler.App.Tests` to see them actually talk to
+/// an X server.
+/// </summary>
+public sealed class LinuxX11ClipboardTests
+{
+    [Fact]
+    public void Copied_Text_Comes_Back_From_The_Selection()
+    {
+        using LinuxX11Clipboard? clipboard = TryOpen();
+        if (clipboard is null)
+            return;
+
+        clipboard.SetText("hello from Broiler");
+
+        Assert.True(clipboard.OwnsClipboard);
+        Assert.True(clipboard.TryGetText(out string text));
+        Assert.Equal("hello from Broiler", text);
+    }
+
+    /// <summary>
+    /// The one that matters: a second connection is a separate X client, so this
+    /// is a real paste of what Broiler copied by something that is not Broiler —
+    /// the thing a private in-process string cannot do.
+    /// </summary>
+    [Fact]
+    public void Another_Client_Pastes_What_Broiler_Copied()
+    {
+        using LinuxX11Clipboard? broiler = TryOpen();
+        using LinuxX11Clipboard? otherApplication = TryOpen();
+        if (broiler is null || otherApplication is null)
+            return;
+
+        broiler.SetText("crossed the client boundary");
+
+        Assert.True(TryGetTextWhileServing(otherApplication, broiler, out string text));
+        Assert.Equal("crossed the client boundary", text);
+        Assert.False(otherApplication.OwnsClipboard);
+    }
+
+    [Fact]
+    public void Text_Outside_Latin1_Survives_The_Round_Trip()
+    {
+        using LinuxX11Clipboard? broiler = TryOpen();
+        using LinuxX11Clipboard? otherApplication = TryOpen();
+        if (broiler is null || otherApplication is null)
+            return;
+
+        const string original = "grüße — naïve café 日本語 🎉";
+        broiler.SetText(original);
+
+        Assert.True(TryGetTextWhileServing(otherApplication, broiler, out string text));
+        Assert.Equal(original, text);
+    }
+
+    /// <summary>
+    /// A document-sized selection, to prove the transfer is not silently capped
+    /// at one small property. Both ends here are this class, which answers in a
+    /// single property; the chunked INCR path exists for owners that do not.
+    /// </summary>
+    [Fact]
+    public void A_Document_Sized_Selection_Survives_The_Round_Trip()
+    {
+        using LinuxX11Clipboard? broiler = TryOpen();
+        using LinuxX11Clipboard? otherApplication = TryOpen();
+        if (broiler is null || otherApplication is null)
+            return;
+
+        string original = string.Concat(Enumerable.Repeat("0123456789abcdef", 8 * 1024));
+        broiler.SetText(original);
+
+        Assert.True(TryGetTextWhileServing(otherApplication, broiler, out string text));
+        Assert.Equal(original.Length, text.Length);
+        Assert.Equal(original, text);
+    }
+
+    [Fact]
+    public void A_Later_Copy_By_Another_Client_Takes_Ownership_Away()
+    {
+        using LinuxX11Clipboard? broiler = TryOpen();
+        using LinuxX11Clipboard? otherApplication = TryOpen();
+        if (broiler is null || otherApplication is null)
+            return;
+
+        broiler.SetText("first");
+        otherApplication.SetText("second");
+
+        // Broiler has to notice the loss when it pumps rather than keep serving
+        // a string that is no longer the clipboard's content.
+        broiler.ProcessPendingEvents();
+
+        Assert.False(broiler.OwnsClipboard);
+        Assert.True(TryGetTextWhileServing(broiler, otherApplication, out string text));
+        Assert.Equal("second", text);
+    }
+
+    [Fact]
+    public void Releasing_The_Connection_Gives_Up_Ownership()
+    {
+        using LinuxX11Clipboard? observer = TryOpen();
+        LinuxX11Clipboard? broiler = TryOpen();
+        if (observer is null || broiler is null)
+        {
+            broiler?.Dispose();
+            return;
+        }
+
+        broiler.SetText("goes away with the process");
+        Assert.True(broiler.OwnsClipboard);
+
+        broiler.Dispose();
+
+        observer.ProcessPendingEvents();
+        Assert.False(observer.TryGetText(out _));
+    }
+
+    [Fact]
+    public void A_Disposed_Clipboard_Reports_No_Text_Instead_Of_Throwing()
+    {
+        LinuxX11Clipboard? clipboard = TryOpen();
+        if (clipboard is null)
+            return;
+
+        clipboard.SetText("before");
+        clipboard.Dispose();
+
+        clipboard.SetText("after");
+        Assert.False(clipboard.TryGetText(out _));
+        Assert.False(clipboard.OwnsClipboard);
+        clipboard.ProcessPendingEvents();
+        clipboard.Dispose();
+    }
+
+    private static LinuxX11Clipboard? TryOpen() =>
+        OperatingSystem.IsLinux() && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DISPLAY"))
+            ? LinuxX11Clipboard.TryOpen()
+            : null;
+
+    /// <summary>
+    /// Pastes on one connection while pumping the other, because an X11 paste is
+    /// a conversation: the owner has to answer the request for the reader to see
+    /// anything. In an application that pumping is the host loop; here it is a
+    /// second thread, so the two run at once as two processes would.
+    /// </summary>
+    private static bool TryGetTextWhileServing(LinuxX11Clipboard reader, LinuxX11Clipboard owner, out string text)
+    {
+        using var stop = new CancellationTokenSource();
+        Task serving = Task.Run(() =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                owner.ProcessPendingEvents();
+                Thread.Sleep(1);
+            }
+        });
+
+        try
+        {
+            return reader.TryGetText(out text);
+        }
+        finally
+        {
+            stop.Cancel();
+            serving.Wait(TimeSpan.FromSeconds(5));
+        }
+    }
+}

--- a/src/Broiler.App/LinuxX11Clipboard.cs
+++ b/src/Broiler.App/LinuxX11Clipboard.cs
@@ -1,0 +1,627 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using Broiler.UI;
+
+namespace Broiler.App;
+
+/// <summary>
+/// The X11 CLIPBOARD selection, as the UI layer's clipboard port.
+///
+/// X11 has no clipboard daemon holding a string: the application that copied
+/// last *owns* a selection and every paste is a request answered by that owner.
+/// So a copy is `XSetSelectionOwner` plus a promise to answer `SelectionRequest`
+/// for as long as the process lives, and a paste is `XConvertSelection` followed
+/// by a wait for the owner's reply. Both halves need an X connection whose event
+/// queue is pumped, which is why <see cref="ProcessPendingEvents"/> exists and
+/// why the host loop has to call it.
+///
+/// The connection is this class's own rather than the renderer's: Xlib is not
+/// thread-safe per connection, the renderer's queue belongs to the window, and
+/// draining it here would swallow the focus, resize and close events the window
+/// is waiting for. A private connection also keeps the whole thing inside the
+/// application head, with no change to the graphics component.
+///
+/// There is deliberately no in-memory fallback. A private string that stands in
+/// for the clipboard makes copy and paste appear to work while interoperating
+/// with nothing else on the machine — the user copies from Broiler, pastes into
+/// a terminal, and gets whatever they copied before. <see cref="TryOpen"/>
+/// returns null when there is no X display, and the commands then report
+/// themselves unavailable.
+/// </summary>
+internal sealed class LinuxX11Clipboard : IUiClipboardHost, IDisposable
+{
+    private const int SelectionClear = 29;
+    private const int SelectionRequest = 30;
+    private const int SelectionNotify = 31;
+    private const int PropertyNotify = 28;
+
+    private const int PropertyNewValue = 0;
+    private const long PropertyChangeMask = 1L << 22;
+    private const int PropModeReplace = 0;
+    private const int XaAtom = 4;
+    private const int XaString = 31;
+
+    /// <summary>
+    /// How long a paste waits for the owning application to answer. A frozen or
+    /// very busy owner must not freeze Broiler with it, and a paste that returns
+    /// nothing is recoverable where a hung UI is not.
+    /// </summary>
+    private static readonly TimeSpan ConvertTimeout = TimeSpan.FromSeconds(1);
+
+    private readonly IntPtr _display;
+    private readonly IntPtr _window;
+    private readonly IntPtr _clipboard;
+    private readonly IntPtr _primary;
+    private readonly IntPtr _targets;
+    private readonly IntPtr _utf8String;
+    private readonly IntPtr _text;
+    private readonly IntPtr _incr;
+    private readonly IntPtr _transferProperty;
+    private string? _ownedText;
+    private bool _isDisposed;
+
+    private LinuxX11Clipboard(IntPtr display, IntPtr window)
+    {
+        _display = display;
+        _window = window;
+        _clipboard = InternAtom(display, "CLIPBOARD");
+        _primary = InternAtom(display, "PRIMARY");
+        _targets = InternAtom(display, "TARGETS");
+        _utf8String = InternAtom(display, "UTF8_STRING");
+        _text = InternAtom(display, "TEXT");
+        _incr = InternAtom(display, "INCR");
+        _transferProperty = InternAtom(display, "BROILER_CLIPBOARD");
+    }
+
+    /// <summary>
+    /// Connects to the X display and creates the unmapped 1×1 window that owns
+    /// the selection — X11 addresses a selection owner by window, so there has to
+    /// be one, but it never needs to be seen. Returns null when there is no
+    /// display to connect to, which is the signal that this machine has no
+    /// clipboard to offer rather than a reason to invent one.
+    /// </summary>
+    public static LinuxX11Clipboard? TryOpen()
+    {
+        IntPtr display;
+        try
+        {
+            display = XOpenDisplay(IntPtr.Zero);
+        }
+        catch (DllNotFoundException)
+        {
+            // No libX11 on the machine at all: a headless or framebuffer-only
+            // system. Same answer as a missing display.
+            return null;
+        }
+
+        if (display == IntPtr.Zero)
+            return null;
+
+        int screen = XDefaultScreen(display);
+        IntPtr window = XCreateSimpleWindow(display, XRootWindow(display, screen), 0, 0, 1, 1, 0, IntPtr.Zero, IntPtr.Zero);
+        if (window == IntPtr.Zero)
+        {
+            XCloseDisplay(display);
+            return null;
+        }
+
+        // PropertyChangeMask is what makes an INCR paste possible: the owner
+        // signals each chunk by replacing a property on this window.
+        XSelectInput(display, window, PropertyChangeMask);
+        XFlush(display);
+        return new LinuxX11Clipboard(display, window);
+    }
+
+    /// <summary>Whether this process currently owns the CLIPBOARD selection.</summary>
+    public bool OwnsClipboard => !_isDisposed && XGetSelectionOwner(_display, _clipboard) == _window;
+
+    public bool TryGetText(out string text)
+    {
+        text = string.Empty;
+        if (_isDisposed)
+            return false;
+
+        IntPtr owner = XGetSelectionOwner(_display, _clipboard);
+        if (owner == IntPtr.Zero)
+            return false;
+
+        // Asking ourselves would work, but only by round-tripping through the
+        // server and our own request handler for a string we are already holding.
+        if (owner == _window)
+        {
+            text = _ownedText ?? string.Empty;
+            return text.Length > 0;
+        }
+
+        // UTF8_STRING is what everything modern publishes; STRING is Latin-1 and
+        // is what an older owner offers instead, so an owner that cannot produce
+        // the first is asked for the second before giving up.
+        if (TryConvert(_utf8String, Encoding.UTF8, out text) && text.Length > 0)
+            return true;
+        if (TryConvert(new IntPtr(XaString), Encoding.Latin1, out text) && text.Length > 0)
+            return true;
+
+        text = string.Empty;
+        return false;
+    }
+
+    public void SetText(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        if (_isDisposed)
+            return;
+
+        _ownedText = text;
+        XSetSelectionOwner(_display, _clipboard, _window, IntPtr.Zero);
+
+        // Ownership can be refused, and a copy that did not take must not leave a
+        // string behind that TryGetText would serve as though it had.
+        if (XGetSelectionOwner(_display, _clipboard) != _window)
+        {
+            _ownedText = null;
+            return;
+        }
+
+        // PRIMARY too, so a middle-click paste into a terminal gets the same text
+        // that Ctrl+V does. Losing PRIMARY is not worth failing a copy over.
+        XSetSelectionOwner(_display, _primary, _window, IntPtr.Zero);
+        XFlush(_display);
+    }
+
+    /// <summary>
+    /// Answers whatever the server has queued for this connection. The host loop
+    /// must call this regularly: between calls, another application's paste from
+    /// Broiler goes unanswered and appears to it as an empty clipboard.
+    /// </summary>
+    public void ProcessPendingEvents()
+    {
+        if (_isDisposed)
+            return;
+
+        while (XPending(_display) > 0)
+        {
+            XNextEvent(_display, out XEvent nextEvent);
+            HandleEvent(ref nextEvent);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed)
+            return;
+
+        _isDisposed = true;
+        _ownedText = null;
+
+        // Releasing ownership before the connection closes tells the server the
+        // selection is gone now, rather than leaving other applications to
+        // discover it when their next paste finds a dead owner.
+        if (XGetSelectionOwner(_display, _clipboard) == _window)
+            XSetSelectionOwner(_display, _clipboard, IntPtr.Zero, IntPtr.Zero);
+        if (XGetSelectionOwner(_display, _primary) == _window)
+            XSetSelectionOwner(_display, _primary, IntPtr.Zero, IntPtr.Zero);
+
+        XDestroyWindow(_display, _window);
+        XCloseDisplay(_display);
+    }
+
+    private void HandleEvent(ref XEvent nextEvent)
+    {
+        switch (nextEvent.Type)
+        {
+            case SelectionRequest:
+                AnswerSelectionRequest(ref Unsafe.As<XEvent, XSelectionRequestEvent>(ref nextEvent));
+                break;
+
+            case SelectionClear:
+                // Another application copied. Ours is no longer the clipboard's
+                // content, and holding the string would make a later paste serve
+                // a stale one.
+                _ownedText = null;
+                break;
+        }
+    }
+
+    private void AnswerSelectionRequest(ref XSelectionRequestEvent request)
+    {
+        // A requestor from before ICCCM names no property and expects the answer
+        // under the target's own name.
+        IntPtr property = request.Property == IntPtr.Zero ? request.Target : request.Property;
+        bool answered = _ownedText is string owned && TryWriteRequestedTarget(ref request, property, owned);
+
+        var reply = new XSelectionEvent
+        {
+            Type = SelectionNotify,
+            Display = request.Display,
+            Requestor = request.Requestor,
+            Selection = request.Selection,
+            Target = request.Target,
+            Property = answered ? property : IntPtr.Zero,
+            Time = request.Time,
+        };
+
+        // Sent through a full-size XEvent rather than the selection event alone:
+        // XSendEvent takes the union, and handing it the smaller struct would
+        // have it reading past the end of this frame.
+        XEvent sendEvent = default;
+        Unsafe.As<XEvent, XSelectionEvent>(ref sendEvent) = reply;
+
+        // Every request is answered, refusals included: a requestor blocks until
+        // the SelectionNotify arrives, so staying silent hangs the other
+        // application rather than telling it we have nothing.
+        XSendEvent(_display, request.Requestor, 0, 0, ref sendEvent);
+        XFlush(_display);
+    }
+
+    private bool TryWriteRequestedTarget(ref XSelectionRequestEvent request, IntPtr property, string owned)
+    {
+        if (request.Target == _targets)
+        {
+            // What we can convert to, so a requestor can pick before asking.
+            IntPtr[] supported = [_targets, _utf8String, new IntPtr(XaString), _text];
+            XChangeProperty(_display, request.Requestor, property, new IntPtr(XaAtom), 32, PropModeReplace, supported, supported.Length);
+            return true;
+        }
+
+        Encoding? encoding = null;
+        if (request.Target == _utf8String || request.Target == _text)
+            encoding = Encoding.UTF8;
+        else if (request.Target == new IntPtr(XaString))
+            encoding = Encoding.Latin1;
+
+        if (encoding is null)
+            return false;
+
+        byte[] bytes = encoding.GetBytes(owned);
+
+        // Everything goes in one property. A selection too large for a single
+        // request would need the chunked INCR protocol on this side too, which
+        // is not implemented; refusing is the honest answer, where sending it
+        // anyway would be a protocol error and a truncated paste.
+        if (bytes.Length > MaxPropertyBytes())
+            return false;
+
+        XChangeProperty(_display, request.Requestor, property, request.Target, 8, PropModeReplace, bytes, bytes.Length);
+        return true;
+    }
+
+    /// <summary>
+    /// What one request can carry, less the room the request header itself
+    /// needs. The server reports it in 4-byte units, and the extended limit is
+    /// the far larger one negotiated by the BIG-REQUESTS extension.
+    /// </summary>
+    private long MaxPropertyBytes()
+    {
+        long units = XExtendedMaxRequestSize(_display);
+        if (units <= 0)
+            units = XMaxRequestSize(_display);
+
+        return Math.Max(0, (units * 4) - 1024);
+    }
+
+    private bool TryConvert(IntPtr target, Encoding encoding, out string text)
+    {
+        text = string.Empty;
+        XDeleteProperty(_display, _window, _transferProperty);
+        XConvertSelection(_display, _clipboard, target, _transferProperty, _window, IntPtr.Zero);
+        XFlush(_display);
+
+        if (!TryWaitForSelectionNotify(target, out bool refused) || refused)
+            return false;
+
+        if (!TryReadProperty(delete: true, out byte[] data, out IntPtr type))
+            return false;
+
+        // A payload too large for one property arrives as a byte count and a
+        // promise, with the data following in chunks.
+        if (type == _incr)
+            return TryReadIncrementally(encoding, out text);
+
+        text = encoding.GetString(data);
+        return true;
+    }
+
+    /// <summary>
+    /// Pumps this connection until the owner answers or the timeout expires.
+    /// Other events keep being handled meanwhile — an application we are pasting
+    /// from may be pasting from us at the same moment, and ignoring its request
+    /// until ours completes would deadlock the pair.
+    /// </summary>
+    private bool TryWaitForSelectionNotify(IntPtr target, out bool refused)
+    {
+        refused = false;
+        long deadline = Deadline();
+        while (Stopwatch.GetTimestamp() < deadline)
+        {
+            if (XPending(_display) == 0)
+            {
+                Thread.Sleep(1);
+                continue;
+            }
+
+            XNextEvent(_display, out XEvent nextEvent);
+            if (nextEvent.Type != SelectionNotify)
+            {
+                HandleEvent(ref nextEvent);
+                continue;
+            }
+
+            ref XSelectionEvent notify = ref Unsafe.As<XEvent, XSelectionEvent>(ref nextEvent);
+            if (notify.Requestor != _window || notify.Target != target)
+                continue;
+
+            // A property of None is the owner saying it cannot produce this
+            // target, which is a refusal rather than a failure to answer.
+            refused = notify.Property == IntPtr.Zero;
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryReadIncrementally(Encoding encoding, out string text)
+    {
+        text = string.Empty;
+        using var buffer = new MemoryStream();
+
+        // The deadline guards against an owner that stopped answering, not
+        // against a large payload, so every chunk that arrives extends it.
+        long deadline = Deadline();
+        while (Stopwatch.GetTimestamp() < deadline)
+        {
+            if (XPending(_display) == 0)
+            {
+                Thread.Sleep(1);
+                continue;
+            }
+
+            XNextEvent(_display, out XEvent nextEvent);
+            if (nextEvent.Type != PropertyNotify)
+            {
+                HandleEvent(ref nextEvent);
+                continue;
+            }
+
+            ref XPropertyEvent property = ref Unsafe.As<XEvent, XPropertyEvent>(ref nextEvent);
+            if (property.Window != _window || property.Atom != _transferProperty || property.State != PropertyNewValue)
+                continue;
+
+            // Deleting the property is the acknowledgement that moves the owner
+            // on to the next chunk; a zero-length one ends the transfer.
+            if (!TryReadProperty(delete: true, out byte[] chunk, out _))
+                return false;
+            if (chunk.Length == 0)
+            {
+                text = encoding.GetString(buffer.ToArray());
+                return true;
+            }
+
+            buffer.Write(chunk, 0, chunk.Length);
+            deadline = Deadline();
+        }
+
+        return false;
+    }
+
+    private static long Deadline() =>
+        Stopwatch.GetTimestamp() + (long)(ConvertTimeout.TotalSeconds * Stopwatch.Frequency);
+
+    private bool TryReadProperty(bool delete, out byte[] data, out IntPtr type)
+    {
+        data = [];
+        type = IntPtr.Zero;
+
+        // Read with a zero length first: that reports the size without
+        // transferring anything, so the real read asks for exactly what is there.
+        if (XGetWindowProperty(
+                _display,
+                _window,
+                _transferProperty,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                0,
+                IntPtr.Zero,
+                out type,
+                out int format,
+                out IntPtr items,
+                out IntPtr remaining,
+                out IntPtr peek) != 0)
+        {
+            return false;
+        }
+
+        if (peek != IntPtr.Zero)
+            XFree(peek);
+        if (type == IntPtr.Zero)
+            return false;
+
+        long bytes = (long)remaining;
+        // XGetWindowProperty counts its length in 32-bit units.
+        var length = new IntPtr((bytes + 3) / 4);
+        if (XGetWindowProperty(
+                _display,
+                _window,
+                _transferProperty,
+                IntPtr.Zero,
+                length,
+                delete ? 1 : 0,
+                IntPtr.Zero,
+                out type,
+                out format,
+                out items,
+                out remaining,
+                out IntPtr value) != 0)
+        {
+            return false;
+        }
+
+        if (value == IntPtr.Zero)
+            return type != IntPtr.Zero;
+
+        try
+        {
+            // Xlib's "32-bit format" hands back an array of C long, which is 64
+            // bits here — the one place the wire format and the client array
+            // disagree. Text arrives as format 8, so this only guards the
+            // property reads that are not text.
+            long count = format switch
+            {
+                32 => (long)items * IntPtr.Size,
+                16 => (long)items * 2,
+                _ => (long)items,
+            };
+            if (count <= 0)
+                return true;
+
+            data = new byte[count];
+            Marshal.Copy(value, data, 0, data.Length);
+            return true;
+        }
+        finally
+        {
+            XFree(value);
+        }
+    }
+
+    private static IntPtr InternAtom(IntPtr display, string name) => XInternAtom(display, name, 0);
+
+    [StructLayout(LayoutKind.Sequential, Size = 192)]
+    private struct XEvent
+    {
+        public int Type;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XSelectionRequestEvent
+    {
+        public int Type;
+        public IntPtr Serial;
+        public int SendEvent;
+        public IntPtr Display;
+        public IntPtr Owner;
+        public IntPtr Requestor;
+        public IntPtr Selection;
+        public IntPtr Target;
+        public IntPtr Property;
+        public IntPtr Time;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XSelectionEvent
+    {
+        public int Type;
+        public IntPtr Serial;
+        public int SendEvent;
+        public IntPtr Display;
+        public IntPtr Requestor;
+        public IntPtr Selection;
+        public IntPtr Target;
+        public IntPtr Property;
+        public IntPtr Time;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XPropertyEvent
+    {
+        public int Type;
+        public IntPtr Serial;
+        public int SendEvent;
+        public IntPtr Display;
+        public IntPtr Window;
+        public IntPtr Atom;
+        public IntPtr Time;
+        public int State;
+    }
+
+    [DllImport("libX11.so.6", EntryPoint = "XOpenDisplay")]
+    private static extern IntPtr XOpenDisplay(IntPtr name);
+
+    [DllImport("libX11.so.6", EntryPoint = "XCloseDisplay")]
+    private static extern int XCloseDisplay(IntPtr display);
+
+    [DllImport("libX11.so.6", EntryPoint = "XDefaultScreen")]
+    private static extern int XDefaultScreen(IntPtr display);
+
+    [DllImport("libX11.so.6", EntryPoint = "XRootWindow")]
+    private static extern IntPtr XRootWindow(IntPtr display, int screen);
+
+    [DllImport("libX11.so.6", EntryPoint = "XCreateSimpleWindow")]
+    private static extern IntPtr XCreateSimpleWindow(
+        IntPtr display,
+        IntPtr parent,
+        int x,
+        int y,
+        uint width,
+        uint height,
+        uint borderWidth,
+        IntPtr border,
+        IntPtr background);
+
+    [DllImport("libX11.so.6", EntryPoint = "XDestroyWindow")]
+    private static extern int XDestroyWindow(IntPtr display, IntPtr window);
+
+    [DllImport("libX11.so.6", EntryPoint = "XSelectInput")]
+    private static extern int XSelectInput(IntPtr display, IntPtr window, long mask);
+
+    [DllImport("libX11.so.6", EntryPoint = "XInternAtom")]
+    private static extern IntPtr XInternAtom(IntPtr display, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, int onlyIfExists);
+
+    [DllImport("libX11.so.6", EntryPoint = "XSetSelectionOwner")]
+    private static extern int XSetSelectionOwner(IntPtr display, IntPtr selection, IntPtr owner, IntPtr time);
+
+    [DllImport("libX11.so.6", EntryPoint = "XGetSelectionOwner")]
+    private static extern IntPtr XGetSelectionOwner(IntPtr display, IntPtr selection);
+
+    [DllImport("libX11.so.6", EntryPoint = "XConvertSelection")]
+    private static extern int XConvertSelection(IntPtr display, IntPtr selection, IntPtr target, IntPtr property, IntPtr requestor, IntPtr time);
+
+    [DllImport("libX11.so.6", EntryPoint = "XChangeProperty")]
+    private static extern int XChangeProperty(IntPtr display, IntPtr window, IntPtr property, IntPtr type, int format, int mode, byte[] data, int elements);
+
+    [DllImport("libX11.so.6", EntryPoint = "XChangeProperty")]
+    private static extern int XChangeProperty(IntPtr display, IntPtr window, IntPtr property, IntPtr type, int format, int mode, IntPtr[] data, int elements);
+
+    [DllImport("libX11.so.6", EntryPoint = "XDeleteProperty")]
+    private static extern int XDeleteProperty(IntPtr display, IntPtr window, IntPtr property);
+
+    [DllImport("libX11.so.6", EntryPoint = "XGetWindowProperty")]
+    private static extern int XGetWindowProperty(
+        IntPtr display,
+        IntPtr window,
+        IntPtr property,
+        IntPtr offset,
+        IntPtr length,
+        int delete,
+        IntPtr requestedType,
+        out IntPtr actualType,
+        out int actualFormat,
+        out IntPtr items,
+        out IntPtr bytesAfter,
+        out IntPtr value);
+
+    [DllImport("libX11.so.6", EntryPoint = "XSendEvent")]
+    private static extern int XSendEvent(IntPtr display, IntPtr window, int propagate, long mask, ref XEvent sendEvent);
+
+    [DllImport("libX11.so.6", EntryPoint = "XMaxRequestSize")]
+    private static extern long XMaxRequestSize(IntPtr display);
+
+    [DllImport("libX11.so.6", EntryPoint = "XExtendedMaxRequestSize")]
+    private static extern long XExtendedMaxRequestSize(IntPtr display);
+
+    [DllImport("libX11.so.6", EntryPoint = "XPending")]
+    private static extern int XPending(IntPtr display);
+
+    [DllImport("libX11.so.6", EntryPoint = "XNextEvent")]
+    private static extern int XNextEvent(IntPtr display, out XEvent nextEvent);
+
+    [DllImport("libX11.so.6", EntryPoint = "XFlush")]
+    private static extern int XFlush(IntPtr display);
+
+    [DllImport("libX11.so.6", EntryPoint = "XFree")]
+    private static extern int XFree(IntPtr data);
+}

--- a/src/Broiler.App/WindowsClipboard.cs
+++ b/src/Broiler.App/WindowsClipboard.cs
@@ -3,20 +3,26 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Broiler.UI;
 
-namespace Broiler.Code.Windows;
+namespace Broiler.App;
 
 /// <summary>
-/// The Win32 clipboard.
+/// The Win32 clipboard, shared by the Browser, Writer and Code heads.
 ///
-/// There is deliberately no in-memory fallback. Writer's host keeps a private
-/// string and serves it when no OS accessor is wired, which makes copy and
-/// paste appear to work while silently not interoperating with anything else on
-/// the machine — a user copies from the editor, pastes into a browser, and gets
-/// their previous clipboard contents. This reports failure instead, and the
-/// caller shows the command as unavailable.
+/// There is deliberately no in-memory fallback. A private string standing in
+/// for the clipboard makes copy and paste appear to work while silently not
+/// interoperating with anything else on the machine — a user copies from the
+/// editor, pastes into a browser, and gets their previous clipboard contents.
+/// The Browser and Writer hosts did exactly that until they were wired to this;
+/// it reports failure instead, and the caller shows the command as unavailable.
+///
+/// The bindings are <c>DllImport</c> rather than <c>LibraryImport</c> on
+/// purpose: this file is compiled into the Browser, Writer and Code heads
+/// alike, and the generated marshalling stubs would require
+/// <c>AllowUnsafeBlocks</c> in every one of them. The two application heads use
+/// <c>DllImport</c> for their own interop for the same reason.
 /// </summary>
 [SupportedOSPlatform("windows5.0")]
-internal sealed partial class WindowsClipboard(IntPtr ownerWindow) : IUiClipboardHost
+internal sealed class WindowsClipboard(IntPtr ownerWindow) : IUiClipboardHost
 {
     private const uint CfUnicodeText = 13;
     private const uint GmemMoveable = 0x0002;
@@ -103,38 +109,38 @@ internal sealed partial class WindowsClipboard(IntPtr ownerWindow) : IUiClipboar
         }
     }
 
-    [LibraryImport("user32.dll", SetLastError = true)]
+    [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool OpenClipboard(IntPtr owner);
+    private static extern bool OpenClipboard(IntPtr owner);
 
-    [LibraryImport("user32.dll", SetLastError = true)]
+    [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool CloseClipboard();
+    private static extern bool CloseClipboard();
 
-    [LibraryImport("user32.dll", SetLastError = true)]
+    [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool EmptyClipboard();
+    private static extern bool EmptyClipboard();
 
-    [LibraryImport("user32.dll", SetLastError = true)]
+    [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool IsClipboardFormatAvailable(uint format);
+    private static extern bool IsClipboardFormatAvailable(uint format);
 
-    [LibraryImport("user32.dll", SetLastError = true)]
-    private static partial IntPtr GetClipboardData(uint format);
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr GetClipboardData(uint format);
 
-    [LibraryImport("user32.dll", SetLastError = true)]
-    private static partial IntPtr SetClipboardData(uint format, IntPtr data);
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr SetClipboardData(uint format, IntPtr data);
 
-    [LibraryImport("kernel32.dll", SetLastError = true)]
-    private static partial IntPtr GlobalAlloc(uint flags, UIntPtr bytes);
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr GlobalAlloc(uint flags, UIntPtr bytes);
 
-    [LibraryImport("kernel32.dll", SetLastError = true)]
-    private static partial IntPtr GlobalFree(IntPtr handle);
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr GlobalFree(IntPtr handle);
 
-    [LibraryImport("kernel32.dll", SetLastError = true)]
-    private static partial IntPtr GlobalLock(IntPtr handle);
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr GlobalLock(IntPtr handle);
 
-    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool GlobalUnlock(IntPtr handle);
+    private static extern bool GlobalUnlock(IntPtr handle);
 }

--- a/src/Broiler.Browser.Core.Tests/BrowserUiHostClipboardTests.cs
+++ b/src/Broiler.Browser.Core.Tests/BrowserUiHostClipboardTests.cs
@@ -1,0 +1,72 @@
+using Broiler.Browser;
+using Broiler.Graphics;
+
+namespace Broiler.Browser.Core.Tests;
+
+/// <summary>
+/// The host's clipboard port. What it must never do is hold a private string:
+/// that was what made copy and paste look like they worked while nothing
+/// outside the process could see either one.
+/// </summary>
+public sealed class BrowserUiHostClipboardTests
+{
+    [Fact]
+    public void A_Host_With_No_Platform_Clipboard_Reports_No_Text()
+    {
+        using BrowserUiHost host = CreateHost(null, null);
+
+        host.SetText("copied");
+
+        Assert.False(host.TryGetText(out string text));
+        Assert.Empty(text);
+    }
+
+    [Fact]
+    public void A_Copy_Reaches_The_Platform_Clipboard()
+    {
+        string? written = null;
+        using BrowserUiHost host = CreateHost(() => written, text => written = text);
+
+        host.SetText("copied");
+
+        Assert.Equal("copied", written);
+        Assert.True(host.TryGetText(out string text));
+        Assert.Equal("copied", text);
+    }
+
+    [Fact]
+    public void A_Paste_Reads_The_Platform_Clipboard_Every_Time()
+    {
+        string? platform = "first";
+        using BrowserUiHost host = CreateHost(() => platform, text => platform = text);
+
+        Assert.True(host.TryGetText(out string before));
+        Assert.Equal("first", before);
+
+        // Another application copied. Nothing may be cached from the earlier
+        // read, or Broiler pastes what the clipboard used to hold.
+        platform = "second";
+
+        Assert.True(host.TryGetText(out string after));
+        Assert.Equal("second", after);
+    }
+
+    [Fact]
+    public void An_Empty_Platform_Clipboard_Reports_No_Text()
+    {
+        using BrowserUiHost host = CreateHost(static () => string.Empty, static _ => { });
+
+        Assert.False(host.TryGetText(out string text));
+        Assert.Empty(text);
+    }
+
+    private static BrowserUiHost CreateHost(Func<string?>? read, Action<string>? write) =>
+        new(
+            static () => new BSize(800, 600),
+            static () => 1.0,
+            static () => { },
+            static _ => { },
+            static _ => true,
+            read,
+            write);
+}

--- a/src/Broiler.Browser.Core/BrowserUiHost.cs
+++ b/src/Broiler.Browser.Core/BrowserUiHost.cs
@@ -13,7 +13,6 @@ internal sealed class BrowserUiHost : IUiHost, IUiClipboardHost, IUiTextInputHos
     private readonly Func<string?>? _getClipboardText;
     private readonly Action<string>? _setClipboardText;
     private readonly Action<UiTextCaretInfo?>? _caretChanged;
-    private string _clipboardText = string.Empty;
 
     public BrowserUiHost(
         Func<BSize> getViewportSize,
@@ -64,24 +63,22 @@ internal sealed class BrowserUiHost : IUiHost, IUiClipboardHost, IUiTextInputHos
         IsInvalidated = false;
     }
 
+    /// <summary>
+    /// The platform clipboard, or none at all.
+    ///
+    /// There is deliberately no private string standing in when the shell wired
+    /// no accessor: a fallback makes copy and paste appear to work while
+    /// interoperating with nothing else on the machine — copy in Broiler, paste
+    /// in a terminal, and the terminal produces whatever was copied before. With
+    /// none, the editing commands report themselves unavailable, which is true.
+    /// </summary>
     public bool TryGetText(out string text)
     {
-        if (_getClipboardText is not null)
-        {
-            text = _getClipboardText() ?? string.Empty;
-            return text.Length > 0;
-        }
-
-        text = _clipboardText;
-        return _clipboardText.Length > 0;
+        text = _getClipboardText?.Invoke() ?? string.Empty;
+        return text.Length > 0;
     }
 
-    public void SetText(string text)
-    {
-        text ??= string.Empty;
-        _clipboardText = text;
-        _setClipboardText?.Invoke(text);
-    }
+    public void SetText(string text) => _setClipboardText?.Invoke(text ?? string.Empty);
 
     public void PublishCaret(UiTextCaretInfo caret)
     {

--- a/src/Broiler.Browser.Linux/Broiler.Browser.Linux.csproj
+++ b/src/Broiler.Browser.Linux/Broiler.Browser.Linux.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <Compile Include="..\Broiler.App\LinuxInputCoordinator.cs" Link="LinuxInputCoordinator.cs" />
+    <Compile Include="..\Broiler.App\LinuxX11Clipboard.cs" Link="LinuxX11Clipboard.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Broiler.Browser.Linux/LinuxBrowserRunner.cs
+++ b/src/Broiler.Browser.Linux/LinuxBrowserRunner.cs
@@ -42,6 +42,13 @@ internal static class LinuxBrowserRunner
         LinuxOpenGlX11WindowSurface? x11Window = surface as LinuxOpenGlX11WindowSurface;
         bool canUseEvdev = x11Window is not null;
 
+        // The X11 clipboard, on its own connection. Absent when running
+        // offscreen with no display, and then copy and paste report themselves
+        // unavailable rather than silently working only inside this process.
+        using LinuxX11Clipboard? clipboard = x11Window is not null ? LinuxX11Clipboard.TryOpen() : null;
+        if (x11Window is not null && clipboard is null)
+            Console.WriteLine("No X11 clipboard is available; copy and paste are disabled.");
+
         using BrowserUiHost host = new(
             () => surface.Size,
             () => surface.DpiScale,
@@ -55,7 +62,9 @@ internal static class LinuxBrowserRunner
             {
                 postedActions.Enqueue(action);
                 return true;
-            });
+            },
+            () => clipboard is not null && clipboard.TryGetText(out string text) ? text : null,
+            text => clipboard?.SetText(text));
         using BrowserApp app = new(host, () => renderer, options.InitialUrl, static _ => { });
 
         await using LinuxInputCoordinator input = new(
@@ -73,6 +82,10 @@ internal static class LinuxBrowserRunner
         {
             cancellationToken.ThrowIfCancellationRequested();
             bool processedWindowEvents = false;
+
+            // An X11 copy is a promise to answer requests: between these calls,
+            // another application pasting from Broiler sees an empty clipboard.
+            clipboard?.ProcessPendingEvents();
             if (x11Window is not null)
             {
                 processedWindowEvents = x11Window.ProcessPendingEvents();

--- a/src/Broiler.Browser.Windows/Broiler.Browser.Windows.csproj
+++ b/src/Broiler.Browser.Windows/Broiler.Browser.Windows.csproj
@@ -18,6 +18,11 @@
     <RuntimeIdentifier Condition="'$(Configuration)' == 'Debug-Windows' Or '$(Configuration)' == 'Release-Windows'">win-x64</RuntimeIdentifier>
   </PropertyGroup>
 
+  <!-- The Win32 clipboard, shared with the other desktop heads. -->
+  <ItemGroup>
+    <Compile Include="..\Broiler.App\WindowsClipboard.cs" Link="WindowsClipboard.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\Broiler.Graphics\Broiler.Graphics.Windows\Broiler.Graphics.Direct2D.csproj" />
     <ProjectReference Include="..\Broiler.Browser.Core\Broiler.Browser.Core.csproj" />

--- a/src/Broiler.Browser.Windows/BrowserWindow.cs
+++ b/src/Broiler.Browser.Windows/BrowserWindow.cs
@@ -1,4 +1,5 @@
 using System.Runtime.Versioning;
+using Broiler.App;
 using Broiler.Graphics;
 using Broiler.Graphics.Windows;
 using Broiler.Input;
@@ -24,6 +25,10 @@ internal sealed class BrowserWindow : Direct2DWindow, IWindowsInputHost
     private readonly WindowsInputMessageSubscription[] _inputSubscriptions;
     private int _hostThreadId = Environment.CurrentManagedThreadId;
 
+    // Created in OnCreated: the Win32 clipboard is addressed by window handle,
+    // and there is no handle until the window exists.
+    private WindowsClipboard? _clipboard;
+
     public BrowserWindow(string? initialUrl)
         : base(new BWindowOptions
         {
@@ -39,7 +44,9 @@ internal sealed class BrowserWindow : Direct2DWindow, IWindowsInputHost
             () => DpiScale,
             Invalidate,
             static _ => { },
-            PostToUiThread);
+            PostToUiThread,
+            ReadClipboardText,
+            WriteClipboardText);
         _app = new BrowserApp(_host, () => Renderer, initialUrl, SetAnimationActive);
         _inputDispatcher = new WindowsInputMessageDispatcher(this);
         _keyboardProvider = new WindowsKeyboardProvider();
@@ -76,7 +83,18 @@ internal sealed class BrowserWindow : Direct2DWindow, IWindowsInputHost
     protected override void OnCreated()
     {
         _hostThreadId = Environment.CurrentManagedThreadId;
+        _clipboard = new WindowsClipboard(NativeHandle);
     }
+
+    /// <summary>
+    /// Null rather than empty when there is no clipboard to read: the host
+    /// treats that as "this machine offers none", which is what the window
+    /// reports before it exists and if the OS refuses the clipboard.
+    /// </summary>
+    private string? ReadClipboardText() =>
+        _clipboard is not null && _clipboard.TryGetText(out string text) ? text : null;
+
+    private void WriteClipboardText(string text) => _clipboard?.SetText(text);
 
     protected override BRenderList? BuildRenderList(BSize clientSize) => _app.RenderFrame();
 

--- a/src/Broiler.Code.Linux/Broiler.Code.Linux.csproj
+++ b/src/Broiler.Code.Linux/Broiler.Code.Linux.csproj
@@ -17,6 +17,11 @@
     <RuntimeIdentifier Condition="'$(Configuration)' == 'Debug-Linux' Or '$(Configuration)' == 'Release-Linux'">linux-x64</RuntimeIdentifier>
   </PropertyGroup>
 
+  <!-- The X11 clipboard, shared with the Browser and Writer heads. -->
+  <ItemGroup>
+    <Compile Include="..\Broiler.App\LinuxX11Clipboard.cs" Link="LinuxX11Clipboard.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Broiler.Code.Core\Broiler.Code.Core.csproj" />
     <ProjectReference Include="..\..\Broiler.UI\src\Implementations\Standard\Text\Broiler.UI.CodeEditor.Standard\Broiler.UI.CodeEditor.Standard.csproj" />

--- a/src/Broiler.Code.Linux/CodeHost.cs
+++ b/src/Broiler.Code.Linux/CodeHost.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Broiler.App;
 using Broiler.Code.Core.Hosting;
 using Broiler.Code.Core.Shell;
 using Broiler.Graphics;
@@ -32,7 +33,12 @@ namespace Broiler.Code.Linux;
 /// </summary>
 internal static class CodeHost
 {
-    public static HostServiceReport DescribeServices(string? fileDialogHelper = null) =>
+    /// <summary>
+    /// What this head provides. <paramref name="hasClipboard"/> and
+    /// <paramref name="fileDialogHelper"/> are passed in rather than probed
+    /// here, so the report describes the services this run actually opened.
+    /// </summary>
+    public static HostServiceReport DescribeServices(string? fileDialogHelper = null, bool hasClipboard = false) =>
         new("Broiler Code (Linux)",
     [
         new HostService(
@@ -43,11 +49,20 @@ internal static class CodeHost
             HostServiceReport.InputRouting,
             HostServiceQuality.Native,
             "explicit Broiler.Input events; evdev devices keep their own identity"),
-        new HostService(
-            HostServiceReport.Clipboard,
-            HostServiceQuality.Unavailable,
-            "X11 selection ownership is not implemented; copy and paste are " +
-            "disabled rather than backed by an in-process buffer"),
+        // Native rather than a substitute: the process owns the X11 CLIPBOARD
+        // selection and answers other applications' requests for it, so a copy
+        // here is a paste anywhere on the display.
+        hasClipboard
+            ? new HostService(
+                HostServiceReport.Clipboard,
+                HostServiceQuality.Native,
+                "the X11 CLIPBOARD and PRIMARY selections, owned on the head's " +
+                "own display connection")
+            : new HostService(
+                HostServiceReport.Clipboard,
+                HostServiceQuality.Unavailable,
+                "no X display to own a selection on; copy and paste are " +
+                "disabled rather than backed by an in-process buffer"),
         new HostService(
             HostServiceReport.TextInput,
             HostServiceQuality.Unavailable,
@@ -109,10 +124,13 @@ internal static class CodeHost
         var size = new BSize(1280, 840);
         var dialogs = new LinuxFileDialogs();
 
-        Console.WriteLine(DescribeServices(dialogs.Helper).Describe());
+        // The window opens first because it owns the clipboard connection, and
+        // the report describes the services this run actually has.
+        await using var window = new CodeWindow(size, Console.WriteLine, ignoreFocus);
+
+        Console.WriteLine(DescribeServices(dialogs.Helper, window.HasClipboard).Describe());
         Console.WriteLine();
 
-        await using var window = new CodeWindow(size, Console.WriteLine, ignoreFocus);
         (CodeShell shell, StandardCodeEditor editor) = CodeShellFactory.Create(size);
 
         // The real dispatcher, not the Standard immediate one. Everything the

--- a/src/Broiler.Code.Linux/CodeWindow.cs
+++ b/src/Broiler.Code.Linux/CodeWindow.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Broiler.App;
 using Broiler.Code.Core.Hosting;
 using Broiler.Code.Core.Shell;
 using Broiler.Graphics;
@@ -19,7 +20,7 @@ namespace Broiler.Code.Linux;
 /// and renders, in that order, and everything the analysis layers post is
 /// executed by it rather than on the thread that produced it.
 /// </summary>
-internal sealed class CodeWindow : IUiHost, IAsyncDisposable
+internal sealed class CodeWindow : IUiHost, IUiClipboardHost, IAsyncDisposable
 {
     private static readonly BRenderOptions RenderOptions =
         new(Antialias: true, VSync: true, SubpixelText: true);
@@ -31,6 +32,13 @@ internal sealed class CodeWindow : IUiHost, IAsyncDisposable
     private readonly LinuxCodeInput _input;
     private readonly TimeSpan _pollInterval;
     private readonly bool _ignoreFocus;
+
+    /// <summary>
+    /// The X11 selection, on its own connection. Null where there is no display
+    /// to own one on, and then the clipboard commands report themselves
+    /// unavailable rather than being backed by a buffer only this process sees.
+    /// </summary>
+    private readonly LinuxX11Clipboard? _clipboard = LinuxX11Clipboard.TryOpen();
     private CodeShell? _shell;
     private UiSession? _session;
     private UiElement? _editor;
@@ -62,7 +70,21 @@ internal sealed class CodeWindow : IUiHost, IAsyncDisposable
 
     public LinuxCodeInput Input => _input;
 
+    /// <summary>Whether this host has a real clipboard to offer.</summary>
+    public bool HasClipboard => _clipboard is not null;
+
     public BRenderList CreateRenderList(int capacity = 0) => new(capacity);
+
+    public bool TryGetText(out string text)
+    {
+        if (_clipboard is not null)
+            return _clipboard.TryGetText(out text);
+
+        text = string.Empty;
+        return false;
+    }
+
+    public void SetText(string text) => _clipboard?.SetText(text);
 
     public void Invalidate(UiInvalidation invalidation) => _invalidated = true;
 
@@ -102,6 +124,11 @@ internal sealed class CodeWindow : IUiHost, IAsyncDisposable
             cancellationToken.ThrowIfCancellationRequested();
 
             bool windowEvents = _surface.ProcessPendingEvents();
+
+            // An X11 copy is a promise to answer requests for as long as this
+            // process owns the selection: between these calls, another
+            // application pasting from Code sees an empty clipboard.
+            _clipboard?.ProcessPendingEvents();
             _router.SetViewport(_surface.Size);
 
             // Devices are only read while the window has focus, so typing into
@@ -139,6 +166,11 @@ internal sealed class CodeWindow : IUiHost, IAsyncDisposable
 
         _disposed = true;
         await _input.DisposeAsync().ConfigureAwait(false);
+
+        // Before the connection goes: releasing the selection tells other
+        // applications the clipboard is gone now rather than leaving them to
+        // find a dead owner at their next paste.
+        _clipboard?.Dispose();
         _surface.Dispose();
         _renderer.Dispose();
     }

--- a/src/Broiler.Code.Linux/Program.cs
+++ b/src/Broiler.Code.Linux/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Broiler.App;
 using Broiler.Code.Core.Hosting;
 
 namespace Broiler.Code.Linux;
@@ -16,7 +17,11 @@ internal static class Program
         // what works.
         if (Array.IndexOf(args, "--services") >= 0)
         {
-            HostServiceReport report = CodeHost.DescribeServices(new LinuxFileDialogs().Helper);
+            // Probed rather than assumed: --services must answer for this
+            // machine, and whether a selection can be owned depends on whether
+            // there is a display to own it on.
+            using LinuxX11Clipboard? clipboard = LinuxX11Clipboard.TryOpen();
+            HostServiceReport report = CodeHost.DescribeServices(new LinuxFileDialogs().Helper, clipboard is not null);
             Console.WriteLine(report.Describe());
 
             IReadOnlyList<string> unavailable = CodeHost.UnavailableCommands(report);

--- a/src/Broiler.Code.Windows/Broiler.Code.Windows.csproj
+++ b/src/Broiler.Code.Windows/Broiler.Code.Windows.csproj
@@ -19,6 +19,12 @@
     <RuntimeIdentifier Condition="'$(Configuration)' == 'Debug-Windows' Or '$(Configuration)' == 'Release-Windows'">win-x64</RuntimeIdentifier>
   </PropertyGroup>
 
+  <!-- The Win32 clipboard is shared with the Browser and Writer heads rather
+       than reimplemented in each. -->
+  <ItemGroup>
+    <Compile Include="..\Broiler.App\WindowsClipboard.cs" Link="WindowsClipboard.cs" />
+  </ItemGroup>
+
   <!--
     A thin head: the window, the platform services, and nothing else. Shell and
     workspace behaviour lives in Broiler.Code.Core, and an architecture test

--- a/src/Broiler.Code.Windows/CodeWindow.cs
+++ b/src/Broiler.Code.Windows/CodeWindow.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Versioning;
+using Broiler.App;
 using Broiler.Code.Core.Hosting;
 using Broiler.Code.Core.Shell;
 using Broiler.Graphics;

--- a/src/Broiler.Writer.Linux/Broiler.Writer.Linux.csproj
+++ b/src/Broiler.Writer.Linux/Broiler.Writer.Linux.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <Compile Include="..\Broiler.App\LinuxInputCoordinator.cs" Link="LinuxInputCoordinator.cs" />
+    <Compile Include="..\Broiler.App\LinuxX11Clipboard.cs" Link="LinuxX11Clipboard.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Broiler.Writer.Linux/LinuxWriterRunner.cs
+++ b/src/Broiler.Writer.Linux/LinuxWriterRunner.cs
@@ -44,6 +44,13 @@ internal static class LinuxWriterRunner
         if (options.EnableEvdevInput && x11Window is null)
             Console.WriteLine("evdev input requested, but no focus-capable X11 window exists; input is disabled.");
 
+        // The X11 clipboard, on its own connection. Absent when running
+        // offscreen with no display, and then copy and paste report themselves
+        // unavailable rather than silently working only inside this process.
+        using LinuxX11Clipboard? clipboard = x11Window is not null ? LinuxX11Clipboard.TryOpen() : null;
+        if (x11Window is not null && clipboard is null)
+            Console.WriteLine("No X11 clipboard is available; copy and paste are disabled.");
+
         using WriterUiHost host = new(
             () => surface.Size,
             () => surface.DpiScale,
@@ -53,6 +60,8 @@ internal static class LinuxWriterRunner
                 lastFrameContext = new BFrameContext(WriterPalette.Canvas, frameIndex++, RenderOptions);
                 renderer.Render(surface, renderList, lastFrameContext);
             },
+            () => clipboard is not null && clipboard.TryGetText(out string text) ? text : null,
+            text => clipboard?.SetText(text),
             getRenderer: () => renderer);
         using WriterApp app = new(host, () => closeRequested = true);
 
@@ -65,6 +74,10 @@ internal static class LinuxWriterRunner
         {
             cancellationToken.ThrowIfCancellationRequested();
             bool processedWindowEvents = false;
+
+            // An X11 copy is a promise to answer requests: between these calls,
+            // another application pasting from Writer sees an empty clipboard.
+            clipboard?.ProcessPendingEvents();
             if (x11Window is not null)
             {
                 processedWindowEvents = x11Window.ProcessPendingEvents();

--- a/src/Broiler.Writer.Windows/Broiler.Writer.Windows.csproj
+++ b/src/Broiler.Writer.Windows/Broiler.Writer.Windows.csproj
@@ -18,6 +18,11 @@
     <RuntimeIdentifier Condition="'$(Configuration)' == 'Debug-Windows' Or '$(Configuration)' == 'Release-Windows'">win-x64</RuntimeIdentifier>
   </PropertyGroup>
 
+  <!-- The Win32 clipboard, shared with the other desktop heads. -->
+  <ItemGroup>
+    <Compile Include="..\Broiler.App\WindowsClipboard.cs" Link="WindowsClipboard.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Broiler.Writer\Broiler.Writer.Core.csproj" />
     <ProjectReference Include="..\..\Broiler.Media\Broiler.Media.Image.Managed\Broiler.Media.Image.Managed.csproj" />

--- a/src/Broiler.Writer.Windows/WriterWindow.cs
+++ b/src/Broiler.Writer.Windows/WriterWindow.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using Broiler.App;
 using Broiler.Graphics;
 using Broiler.Graphics.Windows;
 using Broiler.Input.Keyboard;
@@ -15,6 +16,10 @@ internal sealed class WriterWindow : Direct2DWindow
 {
     private readonly WriterUiHost _host;
     private readonly WriterApp _app;
+
+    // Created in OnCreated: the Win32 clipboard is addressed by window handle,
+    // and there is no handle until the window exists.
+    private WindowsClipboard? _clipboard;
 
 #pragma warning disable CS0618
     private readonly StandardLegacyGraphicsInputAdapter _legacyInput = new("broiler-writer");
@@ -35,9 +40,23 @@ internal sealed class WriterWindow : Direct2DWindow
             () => DpiScale,
             Invalidate,
             static _ => { },
+            ReadClipboardText,
+            WriteClipboardText,
             getRenderer: () => Renderer);
         _app = new WriterApp(_host, CloseNativeWindow);
     }
+
+    protected override void OnCreated() => _clipboard = new WindowsClipboard(NativeHandle);
+
+    /// <summary>
+    /// Null rather than empty when there is no clipboard to read: the host
+    /// treats that as "this machine offers none", which is what the window
+    /// reports before it exists and if the OS refuses the clipboard.
+    /// </summary>
+    private string? ReadClipboardText() =>
+        _clipboard is not null && _clipboard.TryGetText(out string text) ? text : null;
+
+    private void WriteClipboardText(string text) => _clipboard?.SetText(text);
 
     protected override BRenderList? BuildRenderList(BSize clientSize) => _app.RenderFrame();
 

--- a/src/Broiler.Writer/WriterUiHost.cs
+++ b/src/Broiler.Writer/WriterUiHost.cs
@@ -14,7 +14,6 @@ internal sealed class WriterUiHost : IUiHost, IUiClipboardHost, IUiTextInputHost
     private readonly Action<string>? _setClipboardText;
     private readonly Action<UiTextCaretInfo?>? _caretChanged;
     private readonly Func<IBroilerRenderer?>? _getRenderer;
-    private string _clipboardText = string.Empty;
 
     public WriterUiHost(
         Func<BSize> getViewportSize,
@@ -63,24 +62,22 @@ internal sealed class WriterUiHost : IUiHost, IUiClipboardHost, IUiTextInputHost
         IsInvalidated = false;
     }
 
+    /// <summary>
+    /// The platform clipboard, or none at all.
+    ///
+    /// There is deliberately no private string standing in when the shell wired
+    /// no accessor: a fallback makes copy and paste appear to work while
+    /// interoperating with nothing else on the machine — copy in Writer, paste
+    /// in a browser, and the browser produces whatever was copied before. With
+    /// none, the editing commands report themselves unavailable, which is true.
+    /// </summary>
     public bool TryGetText(out string text)
     {
-        if (_getClipboardText is not null)
-        {
-            text = _getClipboardText() ?? string.Empty;
-            return text.Length > 0;
-        }
-
-        text = _clipboardText;
-        return _clipboardText.Length > 0;
+        text = _getClipboardText?.Invoke() ?? string.Empty;
+        return text.Length > 0;
     }
 
-    public void SetText(string text)
-    {
-        text ??= string.Empty;
-        _clipboardText = text;
-        _setClipboardText?.Invoke(text);
-    }
+    public void SetText(string text) => _setClipboardText?.Invoke(text ?? string.Empty);
 
     public void PublishCaret(UiTextCaretInfo caret)
     {


### PR DESCRIPTION
Broiler.UI has always had the clipboard *port* — `IUiClipboardHost`, which every text control copies and pastes through — but on Windows and Linux nothing was plugged into it. `BrowserUiHost` and `WriterUiHost` take an optional pair of platform accessors and, finding none wired, answered from a private string field. So copy and paste appeared to work and interoperated with nothing: copy in Broiler, paste in a terminal, and the terminal produced whatever had been copied before it; text copied anywhere else could not be pasted in at all.

Android and the WebAssembly Writer were already wired — `ClipboardManager` and the browser's clipboard events — and Code on Windows already had a real Win32 one, whose own doc comment names this exact failure as the reason it refuses to carry an in-memory fallback. It was the three desktop shells that had none.

## What changed

**`Broiler.App.LinuxX11Clipboard`** is the missing half. X11 has no clipboard daemon holding a string: the application that copied last *owns* a selection, and every paste is a request answered by that owner. So a copy is `XSetSelectionOwner` plus a standing promise to answer `SelectionRequest`, and a paste is `XConvertSelection` followed by a wait for the reply. It offers and accepts `UTF8_STRING`, `STRING` and `TEXT`, answers `TARGETS`, reads a chunked `INCR` transfer from owners that send one, takes PRIMARY along with CLIPBOARD so a middle-click paste gets the same text, and releases both before its connection closes rather than leaving other applications to find a dead owner at their next paste.

It runs on a display connection of its own, pumped by each head's existing loop. Not the renderer's connection: draining that queue here would swallow the focus, resize and close events the surface is waiting for, and Xlib is not thread-safe per connection. That choice is also why this needed **no `Broiler.Graphics` change** — the X11 window keeps its handles private, and nothing here wants them.

**The Win32 clipboard** moves from the Code head into `src/Broiler.App` and is linked into all three Windows heads, so it exists once instead of being reimplemented per application. Its bindings become `DllImport`: the generated `LibraryImport` stubs need `AllowUnsafeBlocks` in every project that compiles the file, and the Browser and Writer heads deliberately do not enable it.

**Broiler Code on Linux** consequently reports `clipboard: native` from `--services` and stops disabling Cut, Copy and Paste. Its `HostServiceReport` said "X11 selection ownership is not implemented"; that was true and now is not, so the claim, the roadmap's service table and its "two structural gaps" paragraph are updated to match. One gap remains, and it is IME.

**The private fallback is gone** from both hosts. With real clipboards wired, its only remaining effect would be to hide a host that has none — and hiding that is what made this bug invisible for so long. A host without an accessor now reports no text and the commands show themselves unavailable; the single-line edit's context menu greys Paste out rather than offering a no-op.

| Head | Before | After |
| --- | --- | --- |
| Browser / Writer, Windows | private in-process string | Win32 |
| Browser / Writer, Linux | private in-process string | X11 CLIPBOARD + PRIMARY |
| Code, Linux | declared unavailable | X11 CLIPBOARD + PRIMARY |
| Code, Windows | Win32 | Win32 (now the shared copy) |
| Browser / Writer, Android | `ClipboardManager` | unchanged |
| Writer, WebAssembly | browser clipboard events | unchanged |

## Verification

Against a real X server rather than reasoned about. `Broiler.App.Tests` covers the round trip, ownership takeover, release on exit, text outside Latin-1 and a 128 KB selection, with a second connection standing in for another application. The tests return early where there is no display, so run them under `xvfb-run -a dotnet test src/Broiler.App.Tests`.

Because two instances of one class share their bugs, both directions were also checked against a throwaway clipboard client written straight against Xlib in C: it pasted what Broiler copied, em dash and emoji intact, and Broiler pasted what it copied. Code Linux's `--services` output flips from unavailable to native with `DISPLAY` set.

The suites that are clean in this container pass, with 11 tests new to them: App 18, Browser.Core 95, Code.Core 117, Code.Workspaces 77, DevConsole 33, Playback 17, Writer.FormatCodes 34. Broiler.UI stays at 335, untouched. All seven affected solutions build clean, Windows heads included.

**Failures that remain are pre-existing**, and none of them read anything this changes: `Broiler.Wpt.Tests` (54) and two `Broiler.Code.Language.CSharp.Tests` evaluation tests fail identically on pristine `main`, and `Broiler.Cli.Tests` fails its PDF conversions on "codec exploded" — the bare-container gaps `CLAUDE.md` records. That last one rests on the documented gap rather than a completed baseline: its run here was abandoned after half an hour of thrashing.

## Not covered

- The Broiler.UI sample demos still use in-process clipboard strings. They live in the Broiler.UI component and cannot reference these application-level sources.
- A selection too large for one X request is refused rather than truncated — INCR *sending* is not implemented, only receiving.
- Wayland has no native path; the Linux heads are X11 surfaces throughout, so they reach the clipboard through XWayland as they reach everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rPndFT1k1PNRbemu6KDgi

---
_Generated by [Claude Code](https://claude.ai/code/session_011rPndFT1k1PNRbemu6KDgi)_