### PR TITLE
Fix the four defects behind the html5test.com TypeError

### DIFF
--- a/patches/0004-record-where-an-error-was-raised.patch
+++ b/patches/0004-record-where-an-error-was-raised.patch
@@ -1,0 +1,416 @@
+From 40d07acc92af26ffd675cf14e0b31323d708690c Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 14 Aug 2026 09:36:32 +0000
+Subject: [PATCH] Record where an error was raised, not where its factory was
+ wired
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+A TypeError from a page reported its origin as
+
+    at InitializeFactories:...\Engine\Core\JSValueCoreExtensions.cs:17,1
+
+which is the module initializer that installs the error factories at startup.
+It reads as an engine crash during initialization, and it is the same line for
+every TypeError the engine can raise, so it identifies nothing. A report of
+html5test.com's "Cannot get property length of undefined" arrived under that
+heading, pointing at the wrong file.
+
+JSException records the engine method that raised an error as the first frame
+of the JavaScript stack, from the [CallerMemberName]/[CallerFilePath]/
+[CallerLineNumber] trio JSEngine's NewTypeError and its siblings declare. The
+lower assemblies cannot call those directly — Runtime and Storage do not
+reference the Engine assembly that knows how to build a JSError — so they go
+through a factory delegate. Those delegates were Func<string, Exception>, which
+has nowhere to carry the caller info, so the compiler filled it in at the one
+place the arguments were actually written: the wiring lambda in the initializer.
+Nine delegates across three initializers collapsed to nine constants.
+
+Caller-info attributes are honoured on a delegate's Invoke parameters, so the
+factories are now named delegates that declare them — JSErrorFactory in Storage
+(where PropertySequence also needs it) and JSExceptionFactory in Runtime for the
+sites that need the JSException itself. Each throw site captures its own
+position and the initializers forward what they are handed.
+
+Same TypeError now reports its real origin:
+
+    at Item:...\Runtime\JSUndefined.cs:41,1
+
+The JavaScript frames below it are unchanged; this is the frame above them.
+
+Not addressed here, both visible in the same trace and both changes to a
+web-visible API rather than corrections of wrong data: error.stack still opens
+with an empty line where a browser writes "TypeError: <message>", and it still
+carries an engine source path that page script can read.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F8PXevAKfy36kyD3roFaJ2
+---
+ .../Core/JSValueCoreExtensions.cs             |   6 +-
+ .../Storage/PropertySequenceCoreExtensions.cs |   3 +-
+ .../EngineAssemblyInitializer.cs              |  24 ++--
+ .../EngineErrorOriginFrameTests.cs            | 110 ++++++++++++++++++
+ .../Broiler.JavaScript.Runtime/JSException.cs |   6 +-
+ .../JSExceptionFactory.cs                     |  21 ++++
+ .../Broiler.JavaScript.Runtime/JSObject.cs    |   4 +-
+ .../Broiler.JavaScript.Runtime/JSValue.cs     |   2 +-
+ .../Broiler.JavaScript.Runtime/JSVariable.cs  |   2 +-
+ .../Broiler.JavaScript.Runtime/UriHelper.cs   |   2 +-
+ .../JSErrorFactory.cs                         |  35 ++++++
+ .../PropertySequence.cs                       |   2 +-
+ 12 files changed, 199 insertions(+), 18 deletions(-)
+ create mode 100644 Broiler.JS/Broiler.JavaScript.Integration.Tests/EngineErrorOriginFrameTests.cs
+ create mode 100644 Broiler.JS/Broiler.JavaScript.Runtime/JSExceptionFactory.cs
+ create mode 100644 Broiler.JS/Broiler.JavaScript.Storage/JSErrorFactory.cs
+
+diff --git a/Broiler.JS/Broiler.JavaScript.Engine/Core/JSValueCoreExtensions.cs b/Broiler.JS/Broiler.JavaScript.Engine/Core/JSValueCoreExtensions.cs
+index 88c1e6a5..64b9ec9a 100644
+--- a/Broiler.JS/Broiler.JavaScript.Engine/Core/JSValueCoreExtensions.cs
++++ b/Broiler.JS/Broiler.JavaScript.Engine/Core/JSValueCoreExtensions.cs
+@@ -14,7 +14,11 @@ internal static class JSValueCoreExtensions
+     {
+         JSValue.UndefinedValue = JSUndefined.Value;
+ 
+-        JSValue.NewTypeError = msg => JSEngine.NewTypeError(msg);
++        // Forward the caller info the throw site captured. Dropping it here — the
++        // shape this had while the field was a Func<string, Exception> — made this
++        // line the recorded origin of every TypeError the engine raises.
++        JSValue.NewTypeError = static (msg, function, filePath, line) =>
++            JSEngine.NewTypeError(msg, function, filePath, line);
+         JSValue.ForceConvertHelper = (jsValue, type, _) =>
+         {
+             var protoObj = (jsValue.prototypeChain as IJSPrototype)?.Object as JSObject;
+diff --git a/Broiler.JS/Broiler.JavaScript.Engine/Core/Storage/PropertySequenceCoreExtensions.cs b/Broiler.JS/Broiler.JavaScript.Engine/Core/Storage/PropertySequenceCoreExtensions.cs
+index 6cd03a7e..d28bf04c 100644
+--- a/Broiler.JS/Broiler.JavaScript.Engine/Core/Storage/PropertySequenceCoreExtensions.cs
++++ b/Broiler.JS/Broiler.JavaScript.Engine/Core/Storage/PropertySequenceCoreExtensions.cs
+@@ -20,6 +20,7 @@ public static class PropertySequenceCoreExtensions
+     [ModuleInitializer]
+     internal static void InitializeTypeErrorFactory()
+     {
+-        PropertySequence.TypeErrorFactory = msg => JSEngine.NewTypeError(msg);
++        PropertySequence.TypeErrorFactory = static (msg, function, filePath, line) =>
++            JSEngine.NewTypeError(msg, function, filePath, line);
+     }
+ }
+diff --git a/Broiler.JS/Broiler.JavaScript.Engine/EngineAssemblyInitializer.cs b/Broiler.JS/Broiler.JavaScript.Engine/EngineAssemblyInitializer.cs
+index b156e774..aae38cf7 100644
+--- a/Broiler.JS/Broiler.JavaScript.Engine/EngineAssemblyInitializer.cs
++++ b/Broiler.JS/Broiler.JavaScript.Engine/EngineAssemblyInitializer.cs
+@@ -22,8 +22,13 @@ internal static class EngineAssemblyInitializer
+         JSEngine.CreateObjectClass = ObjectClassFactory.CreateObjectClass;
+ 
+         // ── JSObject factory delegates ──────────────────────────────
+-        JSObject.NewTypeError = static msg => JSEngine.NewTypeError(msg);
+-        JSObject.NewRangeError = static msg => JSEngine.NewRangeError(msg);
++        // Each of these forwards the caller info its throw site captured, so the
++        // JavaScript stack names the engine method that raised the error rather
++        // than the line below that installed the factory.
++        JSObject.NewTypeError = static (msg, function, filePath, line) =>
++            JSEngine.NewTypeError(msg, function, filePath, line);
++        JSObject.NewRangeError = static (msg, function, filePath, line) =>
++            JSEngine.NewRangeError(msg, function, filePath, line);
+         JSObject.CoerceToNumber = static str => NumberParser.CoerceToNumber(str);
+         JSObject.CreatePrimitiveObject ??= static p => p is JSPrimitive primitive
+             ? new JSPrimitiveObject(primitive)
+@@ -32,18 +37,23 @@ internal static class EngineAssemblyInitializer
+         JSObject.TryUnmarshalObject = CoreInternalHelpers.TryUnmarshal;
+ 
+         // ── JSException delegates ───────────────────────────────────
+-        JSException.NewSyntaxErrorFactory = static msg => JSEngine.NewSyntaxError(msg);
+-        JSException.NewTypeErrorFactory = static msg => JSEngine.NewTypeError(msg);
+-        JSException.NewReferenceErrorFactory = static msg => JSEngine.NewReferenceError(msg);
++        JSException.NewSyntaxErrorFactory = static (msg, function, filePath, line) =>
++            JSEngine.NewSyntaxError(msg, function, filePath, line);
++        JSException.NewTypeErrorFactory = static (msg, function, filePath, line) =>
++            JSEngine.NewTypeError(msg, function, filePath, line);
++        JSException.NewReferenceErrorFactory = static (msg, function, filePath, line) =>
++            JSEngine.NewReferenceError(msg, function, filePath, line);
+         JSException.AppendStackTraceHelper = static (sb, trace) => JSEngine.AppendStackTrace?.Invoke(sb, trace);
+ 
+         // ── JSVariable delegate ─────────────────────────────────────
+         JSVariable.GetCurrentContext = static () => JSEngine.Current;
+         JSVariable.IsStrictMode = static () => JSEngine.IsStrictMode;
+-        JSVariable.NewReferenceErrorFactory = static msg => JSEngine.NewReferenceError(msg);
++        JSVariable.NewReferenceErrorFactory = static (msg, function, filePath, line) =>
++            JSEngine.NewReferenceError(msg, function, filePath, line);
+ 
+         // ── UriHelper delegate ──────────────────────────────────────
+-        UriHelper.NewURIError = static message => JSEngine.NewURIError(message);
++        UriHelper.NewURIError = static (message, function, filePath, line) =>
++            JSEngine.NewURIError(message, function, filePath, line);
+ 
+         // ── JSValue.MarshalObject delegate ──────────────────────────
+         JSValue.IsStrictModeEnabled = static () => JSEngine.IsStrictMode;
+diff --git a/Broiler.JS/Broiler.JavaScript.Integration.Tests/EngineErrorOriginFrameTests.cs b/Broiler.JS/Broiler.JavaScript.Integration.Tests/EngineErrorOriginFrameTests.cs
+new file mode 100644
+index 00000000..54246e2e
+--- /dev/null
++++ b/Broiler.JS/Broiler.JavaScript.Integration.Tests/EngineErrorOriginFrameTests.cs
+@@ -0,0 +1,110 @@
++using Broiler.JavaScript.Engine;
++
++namespace Broiler.JavaScript.Integration.Tests;
++
++// The first frame of a JavaScript stack trace is the ENGINE method that raised the error — the
++// [CallerMemberName]/[CallerFilePath]/[CallerLineNumber] trio the JSException constructor
++// captures — followed by the JavaScript frames.
++//
++// Every error raised from a lower assembly reaches the Engine through a factory delegate, because
++// Runtime and Storage cannot reference the assembly that knows how to build a JSError. While those
++// delegates were shaped `Func<string, Exception>` there was nowhere to carry the caller info, so
++// the compiler filled it in at the line that WIRED the delegate rather than at the throw. Every
++// TypeError the engine could raise then reported the same origin —
++//
++//     at InitializeFactories:...\Engine\Core\JSValueCoreExtensions.cs:17,1
++//
++// — the module initializer, which has nothing to do with any failure. That is the shape a report
++// of html5test.com arrived in: a `Cannot get property length of undefined` whose only non-JS frame
++// named a line that installs a delegate at startup, sending the reader to the wrong file entirely.
++//
++// The delegates now declare the caller-info parameters themselves (JSErrorFactory /
++// JSExceptionFactory), so each throw site records its own position and the initializer forwards
++// what it is handed.
++public class EngineErrorOriginFrameTests
++{
++    /// <summary>The first <c>at</c> line of the stack of whatever <paramref name="source"/> throws.</summary>
++    /// <remarks>
++    /// The source runs as the whole body of its own function so that a leading <c>'use strict'</c>
++    /// is a directive prologue. Inlined into the <c>try</c> below it would be an ordinary
++    /// expression statement instead, and the cases that need strict mode to throw at all — a
++    /// <c>delete</c> of a non-configurable property — would quietly return false.
++    /// </remarks>
++    private static string OriginFrameOf(string source)
++    {
++        using var context = new JSContext();
++        return context.Eval(
++            """
++            String((function () {
++                try { (function () { SOURCE })(); }
++                catch (e) {
++                    var frames = e.stack.split('\n').filter(function (l) { return l.indexOf('    at ') === 0; });
++                    return frames.length ? frames[0].trim() : 'no frame';
++                }
++                return 'no throw';
++            })())
++            """.Replace("SOURCE", source),
++            "t.js").ToString();
++    }
++
++    // The regression itself. A module initializer runs once at startup and cannot be the origin of
++    // anything a script provokes, so naming one is always wrong — whichever of them it names.
++    //
++    // The cases cover the rewired factory delegates — JSValue.NewTypeError, JSObject.NewTypeError
++    // and NewRangeError, JSVariable.NewReferenceErrorFactory, UriHelper.NewURIError,
++    // PropertySequence.TypeErrorFactory — plus a few that always reached the Engine directly and
++    // so have to stay right.
++    [Theory]
++    [InlineData("var u; u.foo;")]
++    [InlineData("var u; u();")]
++    [InlineData("'use strict'; var o = {}; Object.defineProperty(o, 'x', { value: 1, configurable: false }); delete o.x;")]
++    [InlineData("decodeURIComponent('%');")]
++    [InlineData("{ q; let q; }")]
++    [InlineData("new Array(-1);")]
++    [InlineData("Object.create(5);")]
++    [InlineData("someGlobalThatIsNotDefined;")]
++    [InlineData("var o = {}; [...o];")]
++    [InlineData("'use strict'; var o = Object.freeze({}); Object.defineProperty(o, 'a', { value: 1 });")]
++    public void TheOriginFrameIsNeverAModuleInitializer(string source)
++    {
++        var frame = OriginFrameOf(source);
++
++        Assert.StartsWith("at ", frame);
++        Assert.DoesNotContain("JSValueCoreExtensions", frame);
++        Assert.DoesNotContain("EngineAssemblyInitializer", frame);
++        Assert.DoesNotContain("PropertySequenceCoreExtensions", frame);
++    }
++
++    // Being "not the initializer" is satisfied by any constant, so this pins that the frame tracks
++    // the throw site: two failures that reach the SAME factory delegate — both of these go through
++    // JSValue.NewTypeError — have to be told apart. Before the fix both read
++    // `InitializeFactories:JSValueCoreExtensions.cs:17,1`.
++    [Fact]
++    public void DistinctThrowSitesSharingAFactoryReportDistinctOrigins()
++    {
++        var read = OriginFrameOf("var u; u.foo;");
++        var call = OriginFrameOf("var u; u();");
++
++        Assert.NotEqual(read, call);
++    }
++
++    // The JavaScript frames are the part a page author can act on, and they sit below the origin
++    // frame. A trace that lost them would still pass the assertions above.
++    [Fact]
++    public void TheJavaScriptFramesFollowTheOriginFrame()
++    {
++        using var context = new JSContext();
++        var frames = context.Eval(
++            """
++            (function () {
++                function inner() { var u; return u.foo; }
++                function outer() { return inner(); }
++                try { outer(); } catch (e) { return e.stack; }
++            })()
++            """,
++            "t.js").ToString();
++
++        Assert.Contains("inner", frames);
++        Assert.Contains("outer", frames);
++    }
++}
+diff --git a/Broiler.JS/Broiler.JavaScript.Runtime/JSException.cs b/Broiler.JS/Broiler.JavaScript.Runtime/JSException.cs
+index 2d8cb2b7..5471f6d5 100644
+--- a/Broiler.JS/Broiler.JavaScript.Runtime/JSException.cs
++++ b/Broiler.JS/Broiler.JavaScript.Runtime/JSException.cs
+@@ -19,9 +19,9 @@ public class JSException : Exception
+     // ── Delegates for engine-level functionality (wired by Core's initializer) ──
+     // These replace the direct JSEngine references that existed when JSException
+     // lived inside the Core assembly.
+-    internal static Func<string, JSException> NewSyntaxErrorFactory;
+-    internal static Func<string, JSException> NewTypeErrorFactory;
+-    internal static Func<string, JSException> NewReferenceErrorFactory;
++    internal static JSExceptionFactory NewSyntaxErrorFactory;
++    internal static JSExceptionFactory NewTypeErrorFactory;
++    internal static JSExceptionFactory NewReferenceErrorFactory;
+     internal static Action<StringBuilder, List<(StringSpan target, string file, int line, int column)>> AppendStackTraceHelper;
+ 
+     // Error message constants (moved from JSError for Core accessibility)
+diff --git a/Broiler.JS/Broiler.JavaScript.Runtime/JSExceptionFactory.cs b/Broiler.JS/Broiler.JavaScript.Runtime/JSExceptionFactory.cs
+new file mode 100644
+index 00000000..5a67fd50
+--- /dev/null
++++ b/Broiler.JS/Broiler.JavaScript.Runtime/JSExceptionFactory.cs
+@@ -0,0 +1,21 @@
++using System.Runtime.CompilerServices;
++using Broiler.JavaScript.Storage;
++
++namespace Broiler.JavaScript.Runtime;
++
++/// <summary>
++/// Creates an engine-raised <see cref="JSException"/>, recording the engine call site
++/// that raised it.
++/// </summary>
++/// <remarks>
++/// The <see cref="JSErrorFactory"/> counterpart for the throw sites that need the
++/// <see cref="JSException"/> itself — to read its <see cref="JSException.Error"/>, or
++/// to reject a promise with it — rather than a bare <see cref="System.Exception"/>.
++/// See <see cref="JSErrorFactory"/> for why the caller-info parameters are declared
++/// on the delegate.
++/// </remarks>
++public delegate JSException JSExceptionFactory(
++    string message,
++    [CallerMemberName] string function = null,
++    [CallerFilePath] string filePath = null,
++    [CallerLineNumber] int line = 0);
+diff --git a/Broiler.JS/Broiler.JavaScript.Runtime/JSObject.cs b/Broiler.JS/Broiler.JavaScript.Runtime/JSObject.cs
+index 39101805..ea59cd49 100644
+--- a/Broiler.JS/Broiler.JavaScript.Runtime/JSObject.cs
++++ b/Broiler.JS/Broiler.JavaScript.Runtime/JSObject.cs
+@@ -34,8 +34,8 @@ public partial class JSObject : JSValue
+     // ── Factory delegates for abstracting Core dependencies ──
+     // These are wired by CoreAssemblyInitializer so that JSObject
+     // (in Runtime) can access Core functionality without a direct reference.
+-    internal new static Func<string, Exception> NewTypeError;
+-    internal static Func<string, Exception> NewRangeError;
++    internal new static JSErrorFactory NewTypeError;
++    internal static JSErrorFactory NewRangeError;
+     internal static Func<JSObject> GetCurrentObjectPrototype;
+     internal static Func<string, double> CoerceToNumber;
+     internal static Func<JSValue, JSValue> CreatePrimitiveObject;
+diff --git a/Broiler.JS/Broiler.JavaScript.Runtime/JSValue.cs b/Broiler.JS/Broiler.JavaScript.Runtime/JSValue.cs
+index f1fb3333..13a3ed52 100644
+--- a/Broiler.JS/Broiler.JavaScript.Runtime/JSValue.cs
++++ b/Broiler.JS/Broiler.JavaScript.Runtime/JSValue.cs
+@@ -50,7 +50,7 @@ public abstract partial class JSValue : IDynamicMetaObjectProvider, IPropertyAcc
+     /// </summary>
+     internal static Func<string, KeyString, JSValue> CreateStringWithKey;
+ 
+-    internal static Func<string, Exception> NewTypeError;
++    internal static JSErrorFactory NewTypeError;
+     internal static Func<bool> IsStrictModeEnabled;
+     internal static Func<object, JSValue> MarshalObject;
+     internal static Func<JSObject, int, bool> IsFeatureEnabledFactory;
+diff --git a/Broiler.JS/Broiler.JavaScript.Runtime/JSVariable.cs b/Broiler.JS/Broiler.JavaScript.Runtime/JSVariable.cs
+index d97ec2ba..1df40520 100644
+--- a/Broiler.JS/Broiler.JavaScript.Runtime/JSVariable.cs
++++ b/Broiler.JS/Broiler.JavaScript.Runtime/JSVariable.cs
+@@ -273,7 +273,7 @@ public class JSVariable
+     /// </summary>
+     internal static Func<object> GetCurrentContext;
+     internal static Func<bool> IsStrictMode;
+-    internal static Func<string, JSException> NewReferenceErrorFactory;
++    internal static JSExceptionFactory NewReferenceErrorFactory;
+ 
+     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+     public JSVariable(JSValue v, string name)
+diff --git a/Broiler.JS/Broiler.JavaScript.Runtime/UriHelper.cs b/Broiler.JS/Broiler.JavaScript.Runtime/UriHelper.cs
+index ad32f0df..3591e71e 100644
+--- a/Broiler.JS/Broiler.JavaScript.Runtime/UriHelper.cs
++++ b/Broiler.JS/Broiler.JavaScript.Runtime/UriHelper.cs
+@@ -5,7 +5,7 @@ namespace Broiler.JavaScript.Runtime;
+ 
+ internal static class UriHelper
+ {
+-    internal static Func<string, JSException> NewURIError = _ =>
++    internal static JSExceptionFactory NewURIError = static (_, _, _, _) =>
+         throw new InvalidOperationException("UriHelper.NewURIError delegate is not initialized.");
+ 
+     // Strict UTF-8 decoder: rejects overlong forms, values above U+10FFFF, and
+diff --git a/Broiler.JS/Broiler.JavaScript.Storage/JSErrorFactory.cs b/Broiler.JS/Broiler.JavaScript.Storage/JSErrorFactory.cs
+new file mode 100644
+index 00000000..4f7d7700
+--- /dev/null
++++ b/Broiler.JS/Broiler.JavaScript.Storage/JSErrorFactory.cs
+@@ -0,0 +1,35 @@
++using System;
++using System.Runtime.CompilerServices;
++
++namespace Broiler.JavaScript.Storage;
++
++/// <summary>
++/// Creates an engine-raised JavaScript error, recording the engine call site that
++/// raised it.
++/// </summary>
++/// <remarks>
++/// <para>
++/// The error factories are delegates because the lower assemblies — this one and
++/// Runtime — have to raise a real JavaScript error without referencing the Engine
++/// assembly that knows how to build one.
++/// </para>
++/// <para>
++/// The caller-info parameters are why this is a named delegate rather than a
++/// <c>Func&lt;string, Exception&gt;</c>. A <c>JSException</c> records the engine
++/// method that raised it as the first frame of the JavaScript stack, and the
++/// compiler fills those parameters in at the <c>throw</c> site. A plain
++/// <c>Func&lt;string, Exception&gt;</c> has nowhere to put them, so they were
++/// instead captured where the delegate was *wired* — collapsing the origin of every
++/// error in the engine to the one lambda in the module initializer. Every TypeError
++/// a page could provoke, from a property read on <c>undefined</c> on down, reported
++/// <c>at InitializeFactories:JSValueCoreExtensions.cs:17</c>, which named the line
++/// that installed the factory rather than anything to do with the failure. Declaring
++/// the parameters here lets each throw site record its own position; the initializer
++/// forwards what it is handed instead of substituting itself.
++/// </para>
++/// </remarks>
++public delegate Exception JSErrorFactory(
++    string message,
++    [CallerMemberName] string function = null,
++    [CallerFilePath] string filePath = null,
++    [CallerLineNumber] int line = 0);
+diff --git a/Broiler.JS/Broiler.JavaScript.Storage/PropertySequence.cs b/Broiler.JS/Broiler.JavaScript.Storage/PropertySequence.cs
+index 0e4625ea..19671830 100644
+--- a/Broiler.JS/Broiler.JavaScript.Storage/PropertySequence.cs
++++ b/Broiler.JS/Broiler.JavaScript.Storage/PropertySequence.cs
+@@ -123,7 +123,7 @@ public struct PropertySequence
+     /// Core assembly during initialization to produce the correct JavaScript
+     /// TypeError exception. If not set, falls back to InvalidOperationException.
+     /// </summary>
+-    public static Func<string, Exception>? TypeErrorFactory { get; set; }
++    public static JSErrorFactory? TypeErrorFactory { get; set; }
+ 
+     private SAUint32Map<JSObjectProperty> map;
+     private uint head;
+-- 
+2.43.0
+

--- a/patches/0005-parse-a-noscript-body-as-raw-text.patch
+++ b/patches/0005-parse-a-noscript-body-as-raw-text.patch
@@ -1,0 +1,177 @@
+From 029d081e2a610acd10804b29773f6b7523a28441 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 14 Aug 2026 10:44:10 +0000
+Subject: [PATCH] Parse a <noscript> body as raw text, as a scripting-enabled
+ parser must
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The tokenizer parsed <noscript> contents as ordinary markup, so the fallback
+became a live subtree: elements a page could reach with querySelector or
+getElementById, an <img> that would be requested, a nested <script> the host
+would find and run. All of it is content a page supplies precisely for the case
+where scripts are OFF.
+
+A scripting-enabled parser instead follows the generic raw text element parsing
+algorithm for noscript, exactly as for <script> and <style>: the body becomes
+one text node and nothing in it is live. That is the whole mechanism by which
+the fallback is inert, and it is why character references are not decoded there
+either.
+
+So noscript joins RawTextElements. Being in that set is conditional on scripting
+being enabled — with scripting off the body must parse as markup so it can
+render — and the comment says so, because this engine has no scripting-disabled
+mode and that is the only reason the set can be flat. If one is ever added, this
+is the line that has to consult it.
+
+The serializer already listed noscript among the raw-text elements, so a text
+child round-trips back to the same markup and nothing downstream sees a
+difference in the serialized document. HtmlScriptScanner, which is tokenizer-
+backed, stops reporting a <script> nested inside a noscript — which is what the
+preload scanner already documented as true ("Broiler runs scripts, so the parser
+treats a noscript body as text and nothing in it is ever loaded") back when it
+was not.
+
+Found while investigating html5test.com, whose "you need to enable Javascript"
+banner was rendering above the content its own scripts had built.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F8PXevAKfy36kyD3roFaJ2
+---
+ .../NoscriptRawTextTests.cs                   | 97 +++++++++++++++++++
+ Broiler.Dom.Html/HtmlTokenizer.cs             | 12 ++-
+ 2 files changed, 107 insertions(+), 2 deletions(-)
+ create mode 100644 Broiler.Dom.Html.Tests/NoscriptRawTextTests.cs
+
+diff --git a/Broiler.Dom.Html.Tests/NoscriptRawTextTests.cs b/Broiler.Dom.Html.Tests/NoscriptRawTextTests.cs
+new file mode 100644
+index 0000000..e4ae3b0
+--- /dev/null
++++ b/Broiler.Dom.Html.Tests/NoscriptRawTextTests.cs
+@@ -0,0 +1,97 @@
++using System.Linq;
++using Broiler.Dom.Html;
++using Broiler.Dom;
++using Xunit;
++
++namespace Broiler.Dom.Html.Tests;
++
++/// <summary>
++/// A scripting-enabled parser takes a <c>&lt;noscript&gt;</c> body as raw text.
++/// </summary>
++/// <remarks>
++/// <para>
++/// This is what makes the fallback inert. Parsed as markup — which is what happened before — the
++/// contents are live: a nested <c>&lt;script&gt;</c> is a script the page will run, an
++/// <c>&lt;img&gt;</c> is a request, and <c>querySelector</c> walks into a subtree no browser would
++/// expose. The condition is only that scripting is on; with it off the fallback is meant to render,
++/// and is parsed as markup so it can.
++/// </para>
++/// <para>
++/// Raw text also means character references are NOT decoded, the same as
++/// <c>&lt;script&gt;</c>/<c>&lt;style&gt;</c> content.
++/// </para>
++/// </remarks>
++public sealed class NoscriptRawTextTests
++{
++    [Fact]
++    public void TheBodyIsOneRawTextTokenRatherThanTags()
++    {
++        var tokens = new HtmlTokenizer()
++            .Tokenize("<noscript><h2>enable js</h2></noscript>")
++            .ToArray();
++
++        Assert.Equal(TokenType.StartTag, tokens[0].Type);
++        Assert.Equal("noscript", tokens[0].Name);
++
++        // The markup arrives verbatim as character data — no StartTag token for the <h2>.
++        Assert.Equal(TokenType.Character, tokens[1].Type);
++        Assert.Equal("<h2>enable js</h2>", tokens[1].Data);
++
++        Assert.Equal(TokenType.EndTag, tokens[2].Type);
++        Assert.Equal("noscript", tokens[2].Name);
++        Assert.DoesNotContain(tokens, t => t.Type == TokenType.StartTag && t.Name == "h2");
++    }
++
++    // The point of the change: nothing inside is live. A script here must never become a script
++    // element the host can find and execute.
++    [Fact]
++    public void AScriptInsideIsTextAndNotAScriptElement()
++    {
++        var document = new HtmlDocumentParser()
++            .ParseDocument("<html><body><noscript><script>boom()</script></noscript></body></html>")
++            .Document;
++
++        Assert.Empty(document.DocumentElement.Descendants()
++            .OfType<DomElement>()
++            .Where(e => e.LocalName.Equals("script", System.StringComparison.OrdinalIgnoreCase)));
++    }
++
++    [Fact]
++    public void TheContentBecomesASingleTextChild()
++    {
++        var document = new HtmlDocumentParser()
++            .ParseDocument("<html><body><noscript><p>a</p><p>b</p></noscript></body></html>")
++            .Document;
++
++        var noscript = document.DocumentElement.Descendants()
++            .OfType<DomElement>()
++            .Single(e => e.LocalName.Equals("noscript", System.StringComparison.OrdinalIgnoreCase));
++
++        Assert.Empty(noscript.ChildNodes.OfType<DomElement>());
++        Assert.Equal("<p>a</p><p>b</p>", string.Concat(noscript.ChildNodes.Select(n => n.TextContent)));
++    }
++
++    // Raw text is not entity-decoded, matching <script>/<style>.
++    [Fact]
++    public void CharacterReferencesAreLeftUndecoded()
++    {
++        var tokens = new HtmlTokenizer()
++            .Tokenize("<noscript>a &amp; b</noscript>")
++            .ToArray();
++
++        Assert.Equal("a &amp; b", tokens[1].Data);
++    }
++
++    // Content around it keeps parsing normally once the end tag closes the raw-text run.
++    [Fact]
++    public void ParsingResumesNormallyAfterTheEndTag()
++    {
++        var document = new HtmlDocumentParser()
++            .ParseDocument("<html><body><noscript><p>hidden</p></noscript><div id='after'>x</div></body></html>")
++            .Document;
++
++        Assert.Contains(
++            document.DocumentElement.Descendants().OfType<DomElement>(),
++            e => e.LocalName.Equals("div", System.StringComparison.OrdinalIgnoreCase));
++    }
++}
+diff --git a/Broiler.Dom.Html/HtmlTokenizer.cs b/Broiler.Dom.Html/HtmlTokenizer.cs
+index f0699c4..e6f0805 100644
+--- a/Broiler.Dom.Html/HtmlTokenizer.cs
++++ b/Broiler.Dom.Html/HtmlTokenizer.cs
+@@ -61,10 +61,18 @@ public sealed class HtmlTokenizer
+         Doctype, RawText
+     }
+ 
+-    // Raw text elements: content is treated as text until matching end tag
++    // Raw text elements: content is treated as text until the matching end tag.
++    //
++    // `noscript` is in the set because scripting is ENABLED. That is the whole condition: with
++    // scripting off a browser parses a noscript body as ordinary markup so the fallback can
++    // render, and with it on the body is raw text, which is what makes everything inside inert
++    // — a nested <script> never runs, an <img> never loads, and the DOM holds one text node
++    // rather than a subtree a page can walk into. Broiler has no scripting-disabled mode (no
++    // such flag exists anywhere), so the set is flat; if one is ever added, this is the line
++    // that has to consult it.
+     private static readonly HashSet<string> RawTextElements = new(StringComparer.OrdinalIgnoreCase)
+     {
+-        "script", "style"
++        "script", "style", "noscript"
+     };
+ 
+     private string _rawTextTag; // tag name for raw text end tag matching
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # Submodule patches waiting to be applied
 
-**Four patches are waiting on a maintainer.** See the index below.
+**Five patches are waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -50,6 +50,7 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD && echo "live on CI"
 | `0002` | `Broiler.JS` | Name the property in "Cannot read properties of undefined" |
 | `0003` | `Broiler.JS` | Report promises rejected with nobody to handle them |
 | `0004` | `Broiler.JS` | Record where an error was raised, not where its factory was wired |
+| `0005` | `Broiler.DOM` | Parse a `<noscript>` body as raw text, as a scripting-enabled parser must |
 
 ### `0001` — a closure a direct eval created lost the eval site's bindings
 
@@ -212,6 +213,48 @@ report — that page script can read.
 page paints.
 
 **When it lands upstream:** bump the pointer and delete this patch.
+
+### `0005` — a `<noscript>` body was live content instead of raw text
+
+The tokenizer parsed `<noscript>` contents as ordinary markup, which made the
+fallback a live subtree: elements reachable with `querySelector`/`getElementById`,
+an `<img>` that would be requested, a nested `<script>` a host would find and run.
+All of it is content a page supplies for the case where scripts are **off**.
+
+A scripting-enabled parser instead follows the generic raw text element parsing
+algorithm for `noscript`, exactly as for `<script>` and `<style>`: the body becomes
+one text node, nothing in it is live, and character references are not decoded. So
+`noscript` joins `RawTextElements` in `HtmlTokenizer`.
+
+Membership is **conditional on scripting being enabled** — with scripting off the
+body must parse as markup so it can render — and the comment says so. The set can
+be flat only because this engine has no scripting-disabled mode; if one is ever
+added, that is the line that has to consult it.
+
+**Nothing downstream sees a different serialized document.** `HtmlSerializer`
+already listed `noscript` among the raw-text elements, so a text child round-trips
+back to the same markup. `HtmlScriptScanner`, which is tokenizer-backed, stops
+reporting a `<script>` nested inside a `noscript` — making true what
+`PreloadScanner` already documented as true ("Broiler runs scripts, so the parser
+treats a `noscript` body as text and nothing in it is ever loaded").
+
+**The main repo does not depend on it, and CI is green without it.** The two
+user-visible halves are fixed in this repository and stand alone:
+`HtmlPostProcessor.StripNoscriptContent` stops the fallback rendering (commit
+"Stop rendering `<noscript>` fallback while scripting is enabled"), and
+`CaptureService`'s `NoscriptSpans` skip stops a `<script>` inside one executing —
+that host extracts scripts with its own regex pass rather than through the parser,
+so it needs its own skip whether or not this patch is applied. `NoscriptRenderingTests`
+covers both and passes against the un-patched pointer; verified by reverting the
+submodule and re-running. The DOM half — the fallback being raw text rather than a
+reachable subtree — is what this patch adds, and its tests (`NoscriptRawTextTests`)
+travel inside it.
+
+**Not listed for the pixel suites** — it changes what the DOM holds, and the
+rendering half is already live in this repository.
+
+**When it lands upstream:** bump the pointer and delete this patch. The
+`CaptureService` skip stays: it is about that host's regex extraction, not the parser.
 
 ## A stale entry in the apply script is not inert
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # Submodule patches waiting to be applied
 
-**Three patches are waiting on a maintainer.** See the index below.
+**Four patches are waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -49,6 +49,7 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD && echo "live on CI"
 | `0001` | `Broiler.JS` | Keep a direct eval's scope alive for the closures it creates |
 | `0002` | `Broiler.JS` | Name the property in "Cannot read properties of undefined" |
 | `0003` | `Broiler.JS` | Report promises rejected with nobody to handle them |
+| `0004` | `Broiler.JS` | Record where an error was raised, not where its factory was wired |
 
 ### `0001` — a closure a direct eval created lost the eval site's bindings
 
@@ -160,6 +161,57 @@ what a page paints.
 
 **When it lands upstream:** bump the pointer, delete this patch, and drop the two
 `BroilerJsRejectionTracking` probes with their `#if`s.
+
+### `0004` — every engine error blamed the line that installed the error factories
+
+A TypeError raised while navigating to html5test.com reported its origin as
+
+```
+at InitializeFactories:...\Engine\Core\JSValueCoreExtensions.cs:17,1
+```
+
+which reads as a crash inside engine start-up. It is not one. Line 17 installs a
+factory delegate; the actual failure was an ordinary
+`Cannot get property length of undefined` in the page's fourth inline script.
+Worse, that frame was the same for **every** TypeError the engine can raise, so
+it distinguished nothing — and it sent the first reader of the report into the
+wrong file.
+
+`JSException` records the engine method that raised an error as the first frame
+of the JavaScript stack, taken from the
+`[CallerMemberName]`/`[CallerFilePath]`/`[CallerLineNumber]` trio that
+`JSEngine.NewTypeError` and its siblings declare. Runtime and Storage cannot call
+those directly — they do not reference the Engine assembly that knows how to
+build a `JSError` — so they raise through a factory delegate. The delegates were
+`Func<string, Exception>`, which has nowhere to carry caller info, so the
+compiler filled it in at the only place those arguments were written: the wiring
+lambda in the module initializer. **Nine delegates across three initializers,
+nine constants.**
+
+Caller-info attributes are honoured on a delegate's `Invoke` parameters, so the
+factories are now named delegates that declare them — `JSErrorFactory` in Storage
+(where `PropertySequence` needs it too) and `JSExceptionFactory` in Runtime for
+the sites that want the `JSException` itself. Each throw site captures its own
+position; the initializers forward what they are handed. The same TypeError now
+reports `at Item:...\Runtime\JSUndefined.cs:41,1`, and two failures reaching one
+factory can be told apart — which is what `EngineErrorOriginFrameTests` pins,
+since "not the initializer" alone would be satisfied by any other constant.
+
+**The JavaScript frames are untouched.** This is the frame above them, and it was
+the only wrong one.
+
+**Two things in the same trace are deliberately left alone**, because each is a
+change to a web-visible API rather than a correction of wrong data, and the call
+belongs to whoever owns that surface: `error.stack` opens with an **empty line**
+where a browser writes `TypeError: <message>` (the `JSError` constructor computes
+the stack before the `message` property exists), and it still carries an engine
+source path — an absolute build-machine path, `D:\Broiler\...` in the original
+report — that page script can read.
+
+**Not listed for the pixel suites** — it changes a diagnostic, not anything a
+page paints.
+
+**When it lands upstream:** bump the pointer and delete this patch.
 
 ## A stale entry in the apply script is not inert
 

--- a/src/Broiler.Cli.Tests/DocumentCollectionBindingModuleTests.cs
+++ b/src/Broiler.Cli.Tests/DocumentCollectionBindingModuleTests.cs
@@ -6,7 +6,8 @@ namespace Broiler.Cli.Tests;
 /// <summary>
 /// Guards the HtmlBridge complexity-reduction roadmap Phase 3 feature-module extraction of the
 /// <c>document</c> live-collection accessors (<see cref="DocumentCollectionBinding"/>):
-/// <c>document.forms</c>, <c>document.images</c>, <c>document.links</c>, <c>document.styleSheets</c>.
+/// <c>document.forms</c>, <c>document.images</c>, <c>document.links</c>, <c>document.scripts</c>,
+/// <c>document.styleSheets</c>.
 /// The callbacks — previously the bridge's <c>JsRegistrationGetForms050Core</c> etc. in the shared
 /// JsFunctionCallbacks/Registration.cs grab-bag — are now co-located; the document root, element
 /// list, wrapper factory, tree-order link collector and stylesheet-object builder are reached through
@@ -61,5 +62,67 @@ document.body.appendChild(out);
         var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
 
         Assert.Contains("forms=2|named=yes|images=3|links=2|sheets=2", result);
+    }
+
+    // document.scripts, in tree order and counting <script src> as well as inline ones.
+    [Fact]
+    public void Scripts_Enumerates_Every_Script_Element_In_Tree_Order()
+    {
+        var html = @"<!DOCTYPE html>
+<html><head><script src=""head.js""></script></head><body>
+<script src=""body.js""></script>
+<script>
+var s = document.scripts;
+var out = document.createElement('div');
+out.id = 'result';
+out.textContent =
+  'scripts=' + s.length +
+  '|first=' + (s[0].getAttribute('src') || 'inline') +
+  '|second=' + (s[1].getAttribute('src') || 'inline') +
+  '|third=' + (s[2].getAttribute('src') || 'inline');
+document.body.appendChild(out);
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+
+        Assert.Contains("scripts=3|first=head.js|second=body.js|third=inline", result);
+    }
+
+    // The reported failure, reduced to the line that produced it. Cloudflare's
+    // email-decode.min.js ends with
+    //
+    //     var e = document.currentScript || document.scripts[document.scripts.length - 1];
+    //     e.parentNode.removeChild(e);
+    //
+    // — how a classic script finds its own element in order to remove it, since during synchronous
+    // execution it is the last script in the document. `document.scripts` was absent, so reading
+    // `.length` off it threw `Cannot get property length of undefined` and took the whole script
+    // down. `document.currentScript` is also unbound, so the `||` did not short-circuit past it.
+    // Cloudflare injects that script into every page it serves with email obfuscation on, which is
+    // how it reached a report about html5test.com.
+    [Fact]
+    public void AScriptCanFindAndRemoveItselfThroughTheScriptsCollection()
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<div id=""result""></div>
+<script>
+var outcome;
+try {
+    var e = document.currentScript || document.scripts[document.scripts.length - 1];
+    e.parentNode.removeChild(e);
+    outcome = 'removed';
+} catch (err) {
+    outcome = 'threw: ' + err.message;
+}
+document.getElementById('result').textContent = outcome;
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+
+        Assert.Contains("removed", result);
+        Assert.DoesNotContain("threw:", result);
     }
 }

--- a/src/Broiler.Cli.Tests/NoscriptRenderingTests.cs
+++ b/src/Broiler.Cli.Tests/NoscriptRenderingTests.cs
@@ -91,4 +91,31 @@ public sealed class NoscriptRenderingTests
 
         Assert.DoesNotContain("no js", result, StringComparison.Ordinal);
     }
+
+    // Not rendering it is half of it; the other half is that nothing inside is live. A <script>
+    // written inside a <noscript> is exactly the code a page wants to run ONLY when scripts are
+    // off, so running it is worse than a cosmetic bug.
+    //
+    // This capture host does not extract scripts through the parser — it runs its own regex pass
+    // over the source, and a regex for <script> matches one nested inside a <noscript> — so the
+    // skip is its own, and this covers it. The DOM side of inertness (the fallback parsing as raw
+    // text rather than elements, so nothing inside it is even reachable) belongs to the HTML
+    // tokenizer in the Broiler.DOM submodule and is covered there, by NoscriptRawTextTests.
+    [Fact]
+    public void AScriptInsideTheFallbackDoesNotRun()
+    {
+        const string html = @"<!DOCTYPE html>
+<html><body>
+<noscript><script>window.__ranInsideNoscript = true;</script></noscript>
+<div id=""result""></div>
+<script>
+document.getElementById('result').textContent =
+    'ranInsideNoscript=' + (window.__ranInsideNoscript === true);
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+
+        Assert.Contains("ranInsideNoscript=false", result, StringComparison.Ordinal);
+    }
 }

--- a/src/Broiler.Cli.Tests/NoscriptRenderingTests.cs
+++ b/src/Broiler.Cli.Tests/NoscriptRenderingTests.cs
@@ -1,0 +1,94 @@
+using Broiler.HtmlBridge;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// <c>&lt;noscript&gt;</c> holds what a browser shows when it is <em>not</em> running scripts, so a
+/// scripting-enabled engine renders none of it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Broiler rendered it. On html5test.com that put the page's "To view the results of your browser
+/// you need to enable Javascript!" banner directly above the content its own scripts had just
+/// built — the fallback and the thing it stands in for, stacked.
+/// </para>
+/// <para>
+/// The assertions are against <see cref="HtmlPostProcessor"/> because that is what decides this:
+/// the capture serializes the post-script document and hands the HTML to the rendering surface,
+/// which re-parses it, so nothing the bridge computes about <c>display</c> reaches the renderer.
+/// </para>
+/// <para>
+/// The CSSOM is deliberately not asserted here. <c>getComputedStyle</c> reports <c>inline</c> for a
+/// <c>noscript</c> — but it reports <c>inline</c> for a <c>&lt;script&gt;</c> too, and for every
+/// other element the UA stylesheet hides, so that is one pre-existing gap on a different path
+/// (the JS binding does not consult <c>ApplyUserAgentDisplayDefaults</c>) rather than anything
+/// specific to <c>noscript</c>. Special-casing this one element there would have made it an
+/// arbitrary exception among equals; it wants its own change.
+/// </para>
+/// </remarks>
+public sealed class NoscriptRenderingTests
+{
+    // Both render profiles — production browsing and the Acid/WPT harness — run scripts, so both
+    // must drop the fallback.
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Both_Profiles_Remove_Noscript_And_Its_Content(bool browsing)
+    {
+        const string html =
+            "<p>before</p>" +
+            "<noscript><h2>enable javascript</h2></noscript>" +
+            "<p>after</p>";
+
+        var result = browsing
+            ? HtmlPostProcessor.ProcessForBrowsing(html)
+            : HtmlPostProcessor.Process(html);
+
+        Assert.DoesNotContain("<noscript", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("enable javascript", result, StringComparison.OrdinalIgnoreCase);
+
+        // Only the noscript goes: the content around it is untouched.
+        Assert.Contains("before", result, StringComparison.Ordinal);
+        Assert.Contains("after", result, StringComparison.Ordinal);
+    }
+
+    // The element is removed whole, not merely emptied — unlike an <iframe>, which still paints its
+    // own replaced box once the fallback is gone. A <noscript> paints nothing, so an empty
+    // <noscript></noscript> left behind would be wrong (and would still take part in selector
+    // matching on the render side).
+    [Fact]
+    public void TheElementIsRemovedWholeRatherThanEmptied()
+    {
+        var result = HtmlPostProcessor.ProcessForBrowsing("<noscript><img src=\"a.png\"></noscript>");
+
+        Assert.DoesNotContain("noscript", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("a.png", result, StringComparison.Ordinal);
+    }
+
+    // Several on a page, and attributes on the tag, both of which real pages have.
+    [Fact]
+    public void EveryNoscriptGoes_IncludingOnesCarryingAttributes()
+    {
+        const string html =
+            "<noscript class=\"warn\" data-x=\"1\"><p>one</p></noscript>" +
+            "<div>keep</div>" +
+            "<noscript><p>two</p></noscript>";
+
+        var result = HtmlPostProcessor.ProcessForBrowsing(html);
+
+        Assert.DoesNotContain("one", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("two", result, StringComparison.Ordinal);
+        Assert.Contains("keep", result, StringComparison.Ordinal);
+    }
+
+    // The fallback goes even when the scripts it stands in for did nothing visible — the trigger is
+    // that scripting is ON, not that any particular script succeeded.
+    [Fact]
+    public void TheFallbackGoesRegardlessOfWhatTheScriptsDid()
+    {
+        var result = HtmlPostProcessor.ProcessForBrowsing(
+            "<noscript><p>no js</p></noscript><script>/* did nothing */</script>");
+
+        Assert.DoesNotContain("no js", result, StringComparison.Ordinal);
+    }
+}

--- a/src/Broiler.Cli/CaptureService.cs
+++ b/src/Broiler.Cli/CaptureService.cs
@@ -191,6 +191,14 @@ public class CaptureService
         @"<script(?<attrs>[^>]*)>(?<content>[\s\S]*?)</script>",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+    /// <summary>
+    /// Matches <c>&lt;noscript …&gt;…&lt;/noscript&gt;</c> blocks, so the scripts inside one can be
+    /// skipped.
+    /// </summary>
+    private static readonly Regex NoscriptBlockPattern = new(
+        @"<noscript[^>]*>[\s\S]*?</noscript>",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     private static readonly Regex SrcAttrPattern = new(
         @"\ssrc\s*=\s*(?:""(?<uri>data:[^""]+)""|'(?<uri>data:[^']+)'|(?<uri>data:[^\s>]+))",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -439,6 +447,41 @@ public class CaptureService
     }
 
     /// <summary>
+    /// The source spans covered by <c>&lt;noscript&gt;</c> blocks.
+    /// </summary>
+    /// <remarks>
+    /// A <c>noscript</c> body is what a browser shows when it is <em>not</em> running scripts, so
+    /// with scripting enabled it is inert and a <c>&lt;script&gt;</c> written inside one must never
+    /// execute. The HTML parser gets this right on its own — it takes a <c>noscript</c> body as raw
+    /// text, so no script element ever reaches the DOM — but the two hosts below do not go through
+    /// it: they extract scripts with their own regex pass over the source, and a regex for
+    /// <c>&lt;script&gt;</c> matches one nested inside a <c>noscript</c> just as happily. Hence the
+    /// explicit skip. A host moved onto the tokenizer-backed <c>HtmlScriptScanner</c> — which
+    /// <c>ScriptExtractionService</c> already uses — would not need it.
+    /// </remarks>
+    private static List<(int Start, int End)> NoscriptSpans(string html)
+    {
+        var spans = new List<(int Start, int End)>();
+        foreach (Match match in NoscriptBlockPattern.Matches(html))
+            spans.Add((match.Index, match.Index + match.Length));
+        return spans;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="index"/> falls inside one of <paramref name="spans"/>.
+    /// </summary>
+    private static bool IsInsideNoscript(List<(int Start, int End)> spans, int index)
+    {
+        foreach (var span in spans)
+        {
+            if (index >= span.Start && index < span.End)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Extracts and executes inline scripts using Broiler.JavaScript.
     /// This exercises the YantraJS engine as part of the rendering pipeline;
     /// script results can be extended in future to influence output content.
@@ -446,8 +489,12 @@ public class CaptureService
     private static void ExecuteScripts(string html, string url)
     {
         var scripts = new List<string>();
+        var noscriptSpans = NoscriptSpans(html);
         foreach (Match match in ScriptPattern.Matches(html))
         {
+            if (IsInsideNoscript(noscriptSpans, match.Index))
+                continue;
+
             var content = match.Groups["content"].Value.Trim();
             if (!string.IsNullOrEmpty(content))
             {
@@ -541,8 +588,12 @@ public class CaptureService
         var moduleRoots = new List<string>();
         var csp = ContentSecurityPolicy.FromHtml(html);
         var scriptPrefetcher = StartScriptPrefetch(html, url, csp);
+        var noscriptSpans = NoscriptSpans(html);
         foreach (Match match in AnyScriptPattern.Matches(html))
         {
+            if (IsInsideNoscript(noscriptSpans, match.Index))
+                continue;
+
             var attrs = match.Groups["attrs"].Value;
             var isDefer = DeferAttrPattern.IsMatch(attrs);
             var isModule = TypeModuleAttrPattern.IsMatch(attrs);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/DomBridge.DocumentCollectionHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/DomBridge.DocumentCollectionHost.cs
@@ -18,6 +18,9 @@ public sealed partial class DomBridge : Dom.Features.IDocumentCollectionHost
     void Dom.Features.IDocumentCollectionHost.CollectLinksInTreeOrder(DomElement root, List<JSValue> results)
         => CollectLinksInTreeOrder(root, results);
 
+    void Dom.Features.IDocumentCollectionHost.CollectByTagName(DomNode root, string tag, List<JSValue> results)
+        => CollectByTagName(root, tag, results);
+
     JSObject Dom.Features.IDocumentCollectionHost.BuildStyleSheetObject(DomElement styleElement)
         => BuildStyleSheetObject(styleElement);
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Document.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Document.cs
@@ -137,6 +137,9 @@ public sealed partial class DomBridge
         // Uses tree-order traversal so dynamically appended elements are reflected.
         document.FastAddProperty((KeyString)"links", new JSFunction((in a) => Dom.Features.DocumentCollectionBinding.GetLinks(this, in a), "get links"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
+        // document.scripts — collection of all <script> elements, in tree order.
+        document.FastAddProperty((KeyString)"scripts", new JSFunction((in a) => Dom.Features.DocumentCollectionBinding.GetScripts(this, in a), "get scripts"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
         // document.styleSheets — collection of stylesheet objects for main document
         document.FastAddProperty((KeyString)"styleSheets", new JSFunction((in a) => Dom.Features.DocumentCollectionBinding.GetStyleSheets(this, in a), "get styleSheets"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
 

--- a/src/Broiler.HtmlBridge.Dom/Features/DocumentCollectionBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/DocumentCollectionBinding.cs
@@ -7,7 +7,7 @@ namespace Broiler.HtmlBridge.Dom.Features;
 
 /// <summary>
 /// The <c>document</c> live-collection accessors — <c>document.forms</c>, <c>document.images</c>,
-/// <c>document.links</c>, <c>document.styleSheets</c> — co-located as an HtmlBridge feature module
+/// <c>document.links</c>, <c>document.scripts</c>, <c>document.styleSheets</c> — co-located as an HtmlBridge feature module
 /// (Phase 3). Each scans the document for the relevant elements and returns a JS array of their
 /// wrappers (<c>forms</c> additionally exposes named access by the form's <c>name</c> attribute;
 /// <c>styleSheets</c> returns stylesheet objects rather than element wrappers). The document root,
@@ -59,6 +59,27 @@ internal static class DocumentCollectionBinding
     {
         var results = new List<JSValue>();
         host.CollectLinksInTreeOrder(host.DocumentElement, results);
+        return new JSArray(results);
+    }
+
+    /// <summary>
+    /// <c>document.scripts</c> — every <c>&lt;script&gt;</c> element in tree order.
+    /// </summary>
+    /// <remarks>
+    /// Tree order rather than a scan of <see cref="IDocumentCollectionHost.Elements"/>, for the same
+    /// reason <c>links</c> traverses: the position within the collection is the property's entire
+    /// purpose. The idiom that wants it is
+    /// <c>document.currentScript || document.scripts[document.scripts.length - 1]</c> — how a
+    /// classic script finds its own element while it runs, since during synchronous execution it is
+    /// the last one in the document. Cloudflare's <c>email-decode.min.js</c> ends with exactly that
+    /// line, and it is on every page Cloudflare serves with email obfuscation enabled, so the
+    /// property being absent threw a TypeError out of a script the page never asked for. It was
+    /// reported against html5test.com; nothing about that site is special.
+    /// </remarks>
+    public static JSValue GetScripts(IDocumentCollectionHost host, in Arguments a)
+    {
+        var results = new List<JSValue>();
+        host.CollectByTagName(host.DocumentElement, "script", results);
         return new JSArray(results);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/IDocumentCollectionHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/IDocumentCollectionHost.cs
@@ -16,5 +16,14 @@ internal interface IDocumentCollectionHost
     IReadOnlyList<DomElement> Elements { get; }
 
     void CollectLinksInTreeOrder(DomElement root, List<JSValue> results);
+
+    /// <summary>
+    /// Collects the elements named <paramref name="tag"/> under <paramref name="root"/> in tree
+    /// order. The same collector <see cref="ISubDocumentHost"/> already exposes, needed here for
+    /// <c>document.scripts</c>: a script element's position in the collection is the whole point of
+    /// that property, and <see cref="Elements"/> cannot supply it.
+    /// </summary>
+    void CollectByTagName(DomNode root, string tag, List<JSValue> results);
+
     JSObject BuildStyleSheetObject(DomElement styleElement);
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.cs
@@ -184,6 +184,11 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
             new DomFunction((in _) => GetLinks(docRoot), "get links"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
+        // document.scripts
+        doc.FastAddProperty((KeyString)"scripts",
+            new DomFunction((in _) => GetScripts(docRoot), "get scripts"),
+            null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
         // document.styleSheets
         doc.FastAddProperty((KeyString)"styleSheets",
             new DomFunction((in _) => _host.BuildStyleSheetsCollection(docRoot), "get styleSheets"),
@@ -395,6 +400,13 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
     {
         var results = new List<JSValue>();
         _host.CollectByTagName(docRoot, "img", results);
+        return new JSArray(results);
+    }
+
+    private JSValue GetScripts(DomNode docRoot)
+    {
+        var results = new List<JSValue>();
+        _host.CollectByTagName(docRoot, "script", results);
         return new JSArray(results);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/HtmlPostProcessor.cs
+++ b/src/Broiler.HtmlBridge.Dom/HtmlPostProcessor.cs
@@ -24,6 +24,18 @@ internal static class HtmlPostProcessor
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     /// <summary>
+    /// Matches all <c>&lt;noscript …&gt;…&lt;/noscript&gt;</c> blocks, including their fallback
+    /// content.
+    /// </summary>
+    /// <remarks>
+    /// Non-greedy to the first <c>&lt;/noscript&gt;</c>, which cannot mis-nest: a
+    /// <c>noscript</c> may not contain another one.
+    /// </remarks>
+    private static readonly Regex NoscriptTagPattern = new(
+        @"<noscript(?<attrs>[^>]*)>(?<content>[\s\S]*?)</noscript>",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
     /// Matches <c>&lt;iframe …&gt;…&lt;/iframe&gt;</c> elements including
     /// their inline fallback content.
     /// </summary>
@@ -111,6 +123,7 @@ internal static class HtmlPostProcessor
     private static string ApplyReplacedElementPasses(string html)
     {
         html = StripScriptTags(html);
+        html = StripNoscriptContent(html);
         html = StripIframeContent(html);
         return html;
     }
@@ -227,6 +240,36 @@ internal static class HtmlPostProcessor
     internal static string StripScriptTags(string html)
     {
         return ScriptTagPattern.Replace(html, string.Empty);
+    }
+
+    /// <summary>
+    /// Removes every <c>&lt;noscript&gt;</c> element together with its content.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>noscript</c> holds what a browser shows when it is <em>not</em> running scripts, so with
+    /// scripting enabled it renders nothing at all — no box, not even for its text. Broiler runs
+    /// scripts on both profiles here, and has no scripting-disabled mode, so the element is dropped
+    /// unconditionally. Removed whole rather than emptied, unlike
+    /// <see cref="StripIframeContent"/>: an <c>iframe</c> still paints its own replaced box once
+    /// the fallback is gone, a <c>noscript</c> paints nothing.
+    /// </para>
+    /// <para>
+    /// The same reason <see cref="StripScriptTags"/> exists, one step further on. A page's
+    /// "you need to enable JavaScript" block was rendering above the content its own scripts had
+    /// just built — the two stacked, because nothing suppressed the fallback once the scripts it
+    /// stands in for had run. html5test.com is the page that showed it.
+    /// </para>
+    /// <para>
+    /// This suppresses the rendering, not the DOM. Broiler's parser builds <c>noscript</c> content
+    /// as real elements; the HTML parsing spec says a scripting-enabled parser takes it as raw
+    /// text, so a page can still see markup inside a <c>noscript</c> through the DOM that a browser
+    /// would not. That is a parser conformance gap, separate from what this fixes.
+    /// </para>
+    /// </remarks>
+    internal static string StripNoscriptContent(string html)
+    {
+        return NoscriptTagPattern.Replace(html, string.Empty);
     }
 
     /// <summary>


### PR DESCRIPTION
Investigating a reported exception on html5test.com:

```
Cannot get property length of undefined
    at InitializeFactories in D:\Broiler\...\Core\JSValueCoreExtensions.cs:line 17
    at inline:inline-4:1,1131
    at inline:inline-4:1,1108
```

That trace is wrong about where it came from, and behind it were three genuine engine gaps. All four are fixed here, each verified against the live site.

## 1. The stack blamed the module initializer

`JSValueCoreExtensions.cs:17` installs an error factory at start-up. It is not a throw site — and it was the reported origin of **every** `TypeError` the engine can raise, so it identified nothing and sent the first reader into the wrong file.

`JSException` records the engine method that raised an error as the first frame, from the `[CallerMemberName]`/`[CallerFilePath]`/`[CallerLineNumber]` trio `JSEngine.NewTypeError` and its siblings declare. Runtime and Storage cannot call those directly, so they raise through a factory delegate — and the delegates were `Func<string, Exception>`, which has nowhere to carry caller info. The compiler filled it in at the one place the arguments were written: the wiring lambda. **Nine delegates across three initializers, nine constants.**

Caller-info attributes are honoured on a delegate's `Invoke` parameters, so the factories become named delegates that declare them (`JSErrorFactory`, `JSExceptionFactory`). Each throw site records its own position; the initializers forward what they are handed. The same error now reports `at Item:...\Runtime\JSUndefined.cs:41,1`. JavaScript frames are unchanged — this was the frame above them.

## 2. `document.scripts` was missing

`inline-4` is not html5test's code. It is Cloudflare's `email-decode.min.js`, injected into every page Cloudflare serves with email obfuscation on. Column 1131 is its last statement:

```js
var e = document.currentScript || document.scripts[document.scripts.length - 1];
e.parentNode.removeChild(e);
```

That is how a classic script finds its own element to remove it — during synchronous execution it is the last script in the document. Neither half existed: `document.currentScript` is unbound so the `||` did not short-circuit, and `document.scripts` was absent so `.length` on `undefined` threw.

Added for the main document and sub-documents, in tree order (order is the point of this one). After: **zero JavaScript failures** on the live site, and the post-script document is 1,483 bytes smaller because the script now reaches its own removal.

## 3. `<noscript>` fallback was rendering

The page painted its "To view the results of your browser you need to enable Javascript!" banner directly above the content its own scripts had just built. A reduction confirmed the scope: `<style>`, `<script>` and `<template>` are correctly absent and only `<noscript>` came through.

Fixed in `HtmlPostProcessor` next to `StripScriptTags`, because that is the layer that decides it — the capture serializes the post-script document and hands **HTML** to the rendering surface, which re-parses it, so nothing the bridge computes about `display` ever reaches the renderer. Removed whole rather than emptied, unlike `StripIframeContent`: an iframe still paints its own replaced box once the fallback is gone, a `noscript` paints nothing.

## 4. A `<script>` inside a `<noscript>` executed

Not rendering it is half; the other half is that nothing inside is live. `CaptureService` never asks the parser — both entry points walk the source with their own regex for `<script>`, which matches one nested inside a `<noscript>`. A reduction that set a window flag from inside a `noscript` came back `true`.

Both extraction loops now skip those spans. This is needed **whether or not** the parser patch below is applied, and stays after it lands.

## Submodule patches

`Broiler.JS` and `Broiler.DOM` are outside this session's GitHub scope (push → 403), so two fixes ship as patch files with **both pointers left unmodified**. Each `git apply --check`s clean against its pinned commit; `patches/README.md` carries the reasoning.

- **`0004` (`Broiler.JS`)** — item 1 above.
- **`0005` (`Broiler.DOM`)** — the parser half of `noscript`: a scripting-enabled parser follows the generic raw-text algorithm, so the body becomes one text node and nothing inside is reachable. Membership in `RawTextElements` is conditional on scripting being enabled, and the comment says so — the set can be flat only because this engine has no scripting-disabled mode.

**CI is green without either patch.** The user-visible symptoms are all fixed in this repository; only the DOM-inertness half waits on `0005`. Verified by reverting the submodule and re-running:

| | script runs? | DOM exposes fallback? |
| --- | --- | --- |
| `0005` not applied | no | yes — still elements |
| `0005` applied | no | no — single text node |

## Testing

- `EngineErrorOriginFrameTests` (12, in patch `0004`) — 4 fail with the defect reintroduced.
- `NoscriptRawTextTests` (5, in patch `0005`) — 4 fail without the change.
- `DocumentCollectionBindingModuleTests` (+2) and `NoscriptRenderingTests` (6) — all fail with their fix disabled, and all pass against the **un-patched** pointers.
- `Broiler.JS`: Compiler 1318/1318, BuiltIns 2118/2118, Integration 4610/4611, Runtime 11/11, Storage 46/46. `Broiler.Dom.Html`: 41/41.
- `Broiler.Cli.Tests` pixel/harness classes: the **same 19 pre-existing failures** with and without every change here, compared per test name.

Two pre-existing failures are unrelated and untouched: `M8_DocumentationFiles_Exist` looks for a `docs/roadmap.md` that is a directory, and `Both_Profiles_Apply_The_Shared_Render_Preparation` expects `<video>` stripping the code deliberately stopped doing.

## Found, deliberately not fixed

Each is wider than this change and wants its own:

- `error.stack` opens with an **empty line** where a browser writes `TypeError: <message>`, and it exposes an engine source path (`D:\Broiler\...`) that page script can read. Both are changes to a web-visible API rather than corrections of wrong data.
- `getComputedStyle` reports `inline` for a `<noscript>` — and for a `<script>`, and every other UA-hidden element, because the JS binding does not consult `ApplyUserAgentDisplayDefaults`. An entry for one element would be an arbitrary exception among equals.
- `document.currentScript`, `history.pushState` and `performance.timing.navigationStart` are all unbound. The latter two were blamed by the Cloudflare beacon; they did not recur after the fixes, but the beacon loads asynchronously and one failure came from a timer callback, so that is timing rather than anything here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PXevAKfy36kyD3roFaJ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8PXevAKfy36kyD3roFaJ2)_