### PR TITLE
Fix layout crash when PerformLayout re-enters from host callbacks

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/LineBoxReentrantLayoutTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/LineBoxReentrantLayoutTests.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using Broiler.CSS;
+using Broiler.Layout.Engine;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// A layout pass that starts while another one is still running over the same box tree
+/// must not fail the outer pass.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Layout calls back into the host while it flows — text measurement is the call it makes
+/// for every word, and an image load can complete on the same stack — and a host that
+/// re-enters <c>PerformLayout</c> from one of those callbacks lands inside an in-flight
+/// <c>CreateLineBoxes</c>. That is not hypothetical: it is the reported crash, an
+/// <c>ArgumentException</c> ("An item with the same key has already been added") from
+/// <c>CssLineBox.AssignRectanglesToBoxes</c>, seen in the browser on pages such as
+/// html5test.com and not in a single-shot capture, which never re-enters.
+/// </para>
+/// <para>
+/// The sequence is a consequence of <c>CreateLineBoxes</c> emptying
+/// <c>CssBox.LineBoxes</c> when it starts. The outer pass clears the list and begins
+/// flowing; the inner pass clears it again — dropping the line the outer pass is still
+/// filling — builds its own lines and assigns them to the boxes; the outer pass then
+/// resumes and walks what is now the inner pass's list, so the first line it assigns has
+/// already been assigned. <c>PerformLayout</c> catches the exception as a layout error, so
+/// the failure is silent and the block simply loses the rest of its lines.
+/// </para>
+/// <para>
+/// The tests drive it through <c>MeasureText</c> because that is a real callback made from
+/// inside <c>FlowBox</c>, which is where the reported stack sits.
+/// </para>
+/// </remarks>
+public sealed class LineBoxReentrantLayoutTests
+{
+    private static readonly Uri BaseUrl = new("file:///reentrant.html");
+
+    // The crash itself: nothing is reported, so the outer pass ran to the end.
+    [Fact]
+    public void A_Layout_Re_Entered_From_A_Host_Callback_Reports_No_Error()
+    {
+        var environment = new ReentrantLayoutEnvironment { ReenterOn = "beta" };
+        var (root, _) = Paragraph(environment);
+        environment.Reenter = () => root.PerformLayout(environment);
+
+        root.PerformLayout(environment);
+
+        Assert.True(environment.ReenterFired, "the callback never re-entered, so nothing was tested");
+        Assert.Empty(environment.Errors);
+    }
+
+    // ...and the pass that finished last is the one the boxes agree with, which is what the
+    // paint walker and FragmentTreeBuilder read back out of CssBox.Rectangles.
+    [Fact]
+    public void The_Boxes_Carry_The_Rectangles_Of_The_Lines_They_Are_On()
+    {
+        var environment = new ReentrantLayoutEnvironment { ReenterOn = "beta" };
+        var (root, paragraph) = Paragraph(environment);
+        environment.Reenter = () => root.PerformLayout(environment);
+
+        root.PerformLayout(environment);
+
+        Assert.NotEmpty(paragraph.LineBoxes);
+
+        foreach (var line in paragraph.LineBoxes)
+        {
+            foreach (var (box, rectangle) in line.Rectangles)
+            {
+                Assert.True(
+                    box.Rectangles.TryGetValue(line, out var assigned),
+                    "a box named by a line box did not receive that line's rectangle");
+                Assert.Equal(rectangle, assigned);
+            }
+        }
+    }
+
+    // The guard against fixing it by making the pass tolerant of anything: an ordinary
+    // layout, with nothing re-entering, still projects every rectangle exactly once.
+    [Fact]
+    public void An_Ordinary_Layout_Still_Assigns_Every_Rectangle()
+    {
+        var environment = new ReentrantLayoutEnvironment();
+        var (root, paragraph) = Paragraph(environment);
+
+        root.PerformLayout(environment);
+
+        Assert.Empty(environment.Errors);
+
+        var line = Assert.Single(paragraph.LineBoxes);
+        Assert.NotEmpty(line.Rectangles);
+
+        foreach (var (box, rectangle) in line.Rectangles)
+            Assert.Equal(rectangle, box.Rectangles[line]);
+    }
+
+    /// <summary>
+    /// A block whose children are three inline boxes with words — the shape the reported
+    /// stack was flowing (a paragraph of inline links) and the smallest one that has a
+    /// word measured after the flow has begun.
+    /// </summary>
+    private static (CssBox Root, CssBox Paragraph) Paragraph(ILayoutEnvironment environment)
+    {
+        var root = new CssBox(null, null, BaseUrl)
+        {
+            Location = new PointF(0, 0),
+            Size = new SizeF(400, 400),
+            Display = CssConstants.Block,
+            FontSize = "16px",
+            LayoutEnvironment = environment,
+        };
+
+        var paragraph = new CssBox(root, null, BaseUrl)
+        {
+            Location = new PointF(0, 0),
+            Size = new SizeF(400, 0),
+            Display = CssConstants.Block,
+            FontSize = "16px",
+        };
+
+        foreach (var word in new[] { "alpha", "beta", "gamma" })
+        {
+            var inline = new CssBox(paragraph, null, BaseUrl)
+            {
+                Display = CssConstants.Inline,
+                FontSize = "16px",
+                Text = word.AsMemory(),
+            };
+
+            inline.ParseToWords();
+        }
+
+        return (root, paragraph);
+    }
+
+    /// <summary>
+    /// A host that re-enters layout once, from the text measurement of
+    /// <see cref="ReenterOn"/> — a callback layout makes from inside <c>FlowBox</c>.
+    /// </summary>
+    private sealed class ReentrantLayoutEnvironment : ILayoutEnvironment
+    {
+        public string? ReenterOn { get; init; }
+
+        public Action? Reenter { get; set; }
+
+        public bool ReenterFired { get; private set; }
+
+        public List<Exception> Errors { get; } = [];
+
+        public SizeF MeasureText(Broiler.Graphics.ILayoutFont font, string text)
+        {
+            if (!ReenterFired && Reenter != null && text == ReenterOn)
+            {
+                ReenterFired = true;
+                Reenter();
+            }
+
+            return new((float)(text.Length * 8), (float)font.Height);
+        }
+
+        public void ReportLayoutError(string message, Exception? exception = null)
+        {
+            if (exception != null)
+                Errors.Add(exception);
+        }
+
+        public Broiler.Graphics.ILayoutFont GetFont(string family, double size, LayoutFontStyle style, string? fontFeatures = null) => new StubFont(size);
+        public void MeasureText(Broiler.Graphics.ILayoutFont font, string text, double maxWidth, out int charFit, out double charFitWidth) { charFit = text.Length; charFitWidth = text.Length * 8; }
+        public double GetWhitespaceWidth(Broiler.Graphics.ILayoutFont font) => 8;
+        public ImageIntrinsics GetImageIntrinsics(object imageHandle) => default;
+        public Broiler.Graphics.BColor ParseColor(string value) => default;
+        public void RequestRefresh(bool relayout) { }
+        public SizeF ViewportSize => new(1000, 1000);
+        public PointF RootLocation => PointF.Empty;
+        public SizeF ActualSize { get; set; }
+        public bool AvoidGeometryAntialias => false;
+        public SizeF PageSize => new(1000, 1000);
+        public int MarginTop => 0;
+        public bool AvoidAsyncImagesLoading => true;
+        public bool AvoidImagesLateLoading => true;
+        public ILayoutImageLoader CreateImageLoader(Action<object?, RectangleF, bool> onComplete) => null!;
+        public string FormatListMarker(int number, string style) => string.Empty;
+    }
+
+    private sealed class StubFont(double size) : Broiler.Graphics.ILayoutFont
+    {
+        public double Size { get; } = size;
+        public double Height => size;
+        public double UnderlineOffset => 0;
+        public double LeftPadding => 0;
+        public string? FontFeatures => null;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout.Tests/LineBoxReentrantLayoutTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/LineBoxReentrantLayoutTests.cs
@@ -97,6 +97,53 @@ public sealed class LineBoxReentrantLayoutTests
             Assert.Equal(rectangle, box.Rectangles[line]);
     }
 
+    // The line the reported exception named had no words: the message renders the key with
+    // CssLineBox.ToString(), which joins the line's words, so it printed as empty. A line box
+    // holds rectangles as well as words — an atomic inline is on the line as a rectangle and
+    // puts no word there — so a wordless line is assigned like any other, and duplicates the
+    // same way when a forced break moves the text that follows onto the next line.
+    [Fact]
+    public void A_Line_With_No_Words_Is_Re_Entered_The_Same_Way()
+    {
+        var environment = new ReentrantLayoutEnvironment { ReenterOn = "beta" };
+        var (root, paragraph) = AtomicInlineThenBrokenText(environment);
+        environment.Reenter = () => root.PerformLayout(environment);
+
+        root.PerformLayout(environment);
+
+        Assert.True(environment.ReenterFired, "the callback never re-entered, so nothing was tested");
+        Assert.Empty(environment.Errors);
+
+        var first = paragraph.LineBoxes[0];
+        Assert.Empty(first.Words);
+        Assert.NotEmpty(first.Rectangles);
+    }
+
+    // ...and the reason a wordless line cannot collide with another one: the map is keyed by
+    // the line box itself, not by its text. Two empty lines both render as "" in the
+    // exception message and are still separate keys. Giving CssLineBox value equality — or a
+    // GetHashCode over its words — would make that message literally true and turn the
+    // duplicate into a real one, so this is what says it must not gain either.
+    [Fact]
+    public void Line_Boxes_Are_Keyed_By_Identity_Rather_Than_By_Their_Text()
+    {
+        var (_, paragraph) = Paragraph(new ReentrantLayoutEnvironment());
+        var box = paragraph.Boxes[0];
+
+        var first = new CssLineBox(paragraph);
+        var second = new CssLineBox(paragraph);
+
+        Assert.Equal(string.Empty, first.ToString());
+        Assert.Equal(first.ToString(), second.ToString());
+
+        box.Rectangles[first] = new RectangleF(0, 0, 10, 10);
+        box.Rectangles[second] = new RectangleF(0, 10, 10, 10);
+
+        Assert.Equal(2, box.Rectangles.Count);
+        Assert.Equal(new RectangleF(0, 0, 10, 10), box.Rectangles[first]);
+        Assert.Equal(new RectangleF(0, 10, 10, 10), box.Rectangles[second]);
+    }
+
     /// <summary>
     /// A block whose children are three inline boxes with words — the shape the reported
     /// stack was flowing (a paragraph of inline links) and the smallest one that has a
@@ -132,6 +179,70 @@ public sealed class LineBoxReentrantLayoutTests
 
             inline.ParseToWords();
         }
+
+        return (root, paragraph);
+    }
+
+    /// <summary>
+    /// A block holding an inline-block, then preserved text that opens with a newline. An
+    /// atomic inline is on its parent's line as a rectangle and puts no word there — its own
+    /// text belongs to its own line boxes — and the forced break moves the text that follows
+    /// onto a second line. The first line is therefore left carrying a rectangle and nothing
+    /// else, which is the wordless line the reported exception named.
+    /// </summary>
+    /// <remarks>
+    /// A soft wrap would not produce it (CSS Text §5.1 forbids breaking a line before its
+    /// first inline content, so the word joins the rectangle-only line instead), and an empty
+    /// plain inline would not either — <c>FlowBox</c> deliberately records those on
+    /// <c>Location</c> rather than as a line rectangle, to keep the line invisible.
+    /// </remarks>
+    private static (CssBox Root, CssBox Paragraph) AtomicInlineThenBrokenText(ILayoutEnvironment environment)
+    {
+        var root = new CssBox(null, null, BaseUrl)
+        {
+            Location = new PointF(0, 0),
+            Size = new SizeF(400, 400),
+            Display = CssConstants.Block,
+            FontSize = "16px",
+            WhiteSpace = CssConstants.Pre,
+            LayoutEnvironment = environment,
+        };
+
+        var paragraph = new CssBox(root, null, BaseUrl)
+        {
+            Location = new PointF(0, 0),
+            Size = new SizeF(400, 0),
+            Display = CssConstants.Block,
+            FontSize = "16px",
+            WhiteSpace = CssConstants.Pre,
+        };
+
+        var atomic = new CssBox(paragraph, null, BaseUrl)
+        {
+            Display = CssConstants.InlineBlock,
+            FontSize = "16px",
+            WhiteSpace = CssConstants.Pre,
+        };
+
+        var inside = new CssBox(atomic, null, BaseUrl)
+        {
+            Display = CssConstants.Inline,
+            FontSize = "16px",
+            WhiteSpace = CssConstants.Pre,
+            Text = "inside".AsMemory(),
+        };
+
+        inside.ParseToWords();
+
+        var text = new CssBox(paragraph, null, BaseUrl)
+        {
+            Display = CssConstants.Inline,
+            FontSize = "16px",
+            WhiteSpace = CssConstants.Pre,
+            Text = "\nbeta".AsMemory(),
+        };
+
+        text.ParseToWords();
 
         return (root, paragraph);
     }

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLineBox.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLineBox.cs
@@ -87,10 +87,29 @@ internal sealed class CssLineBox
             UpdateRectangle(box.ParentBox, x, y, r, b);
     }
 
+    /// <summary>
+    /// Projects this line's per-box rectangles onto the boxes, as the per-line map
+    /// the paint walker and <c>FragmentTreeBuilder</c> read back.
+    /// </summary>
+    /// <remarks>
+    /// The write overwrites rather than inserts, because the projection has to be
+    /// idempotent: a line box can reach this twice. <c>CreateLineBoxes</c> empties
+    /// <see cref="CssBox.LineBoxes"/> when it starts, so a layout pass that lands
+    /// inside another one for the same block — a host callback made from inside the
+    /// flow (text measurement, an image that completes synchronously) that re-enters
+    /// <c>PerformLayout</c> — leaves the inner pass's already-assigned lines in the
+    /// list, and the outer pass then walks the same list and re-projects them. An
+    /// insert throws <see cref="ArgumentException"/> on the second one, which
+    /// <c>PerformLayout</c> catches as a layout error, so the block loses the rest of
+    /// its lines and everything below it lays out from a half-finished pass. The
+    /// outer pass has just recomputed each line's rectangles (BubbleRectangles and
+    /// vertical alignment run immediately before this), so overwriting is also what
+    /// leaves the boxes agreeing with the line boxes they came from.
+    /// </remarks>
     internal void AssignRectanglesToBoxes()
     {
         foreach (CssBox b in Rectangles.Keys)
-            b.Rectangles.Add(this, Rectangles[b]);
+            b.Rectangles[this] = Rectangles[b];
     }
 
     internal void SetBaseLine(CssBox b, double baseline)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,21 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `Broiler.Layout` — a layout pass that started while another one was still running over
+  the same box tree threw `ArgumentException` ("An item with the same key has already been
+  added") out of `CssLineBox.AssignRectanglesToBoxes`, which `CssBox.PerformLayout` caught
+  as a layout error, so the block silently lost the rest of its lines and everything below
+  it was placed from a half-finished pass. Layout calls back into the host while it flows —
+  text measurement runs for every word, and an image load can complete on the same stack —
+  and a host that re-enters `PerformLayout` from one of those callbacks lands inside an
+  in-flight `CreateLineBoxes`. Because `CreateLineBoxes` empties `CssBox.LineBoxes` when it
+  starts, the inner pass drops the line the outer pass is still filling and leaves its own
+  assigned lines in the list; the outer pass then walks that list and assigns the first of
+  them a second time. Projecting a line's rectangles onto its boxes is idempotent by
+  nature, so it now overwrites rather than inserts, and the values written are the ones the
+  surviving pass just recomputed. Seen in the browser on pages such as html5test.com, and
+  not in a single-shot capture, which never re-enters.
+
 - `Broiler.JS` (patch, awaiting a maintainer — see `patches/README.md`) — a closure created by a
   direct `eval` lost the eval site's bindings the moment the eval returned, so
   `eval("(function(){ return b; })")` threw `b is not defined` when the function it returned was


### PR DESCRIPTION
## Summary

Fixes a crash that occurred when a layout pass was re-entered from a host callback (such as text measurement or image load completion) while another layout pass was still running over the same box tree. The crash manifested as `ArgumentException` ("An item with the same key has already been added") from `CssLineBox.AssignRectanglesToBoxes`, which was silently caught as a layout error, causing blocks to lose the rest of their lines.

## Root Cause

`CreateLineBoxes` empties `CssBox.LineBoxes` when it starts. When a layout pass re-enters from a host callback:
1. The outer pass clears the line box list and begins flowing
2. The inner pass clears it again, dropping the line the outer pass is still filling
3. The inner pass builds its own lines and assigns them to boxes
4. The outer pass resumes and walks the inner pass's list, attempting to assign the first line a second time
5. The `Add` call in `AssignRectanglesToBoxes` throws because the key already exists

## Changes

- **CssLineBox.cs**: Changed `AssignRectanglesToBoxes` to use dictionary indexer assignment (`b.Rectangles[this] = ...`) instead of `Add()`, making the projection idempotent. This allows the same line to be safely re-projected when a layout re-enters, and ensures boxes carry the rectangles from the surviving pass (which has just recomputed them via `BubbleRectangles` and vertical alignment).

- **LineBoxReentrantLayoutTests.cs**: Added comprehensive test suite covering:
  - Re-entrant layout reports no error
  - Boxes carry rectangles from the final layout pass
  - Ordinary (non-reentrant) layout still assigns every rectangle correctly
  - Wordless lines (containing only atomic inlines) are handled correctly
  - Line boxes use identity-based keying, not text-based equality

- **CHANGELOG.md**: Documented the fix with details on the root cause and impact.

## Implementation Details

The fix is minimal and correct because:
- Projecting a line's rectangles onto its boxes is inherently idempotent—the same line can safely be assigned multiple times
- The outer pass has just recomputed each line's rectangles immediately before assignment (via `BubbleRectangles` and vertical alignment), so overwriting with the outer pass's values is the correct behavior
- Line boxes are keyed by identity (not text equality), so two empty lines are distinct keys and cannot collide

This issue was observed in the browser on pages such as html5test.com and does not occur in single-shot captures that never re-enter.

https://claude.ai/code/session_01KuMuLMWb5eXhHFcyuWQatn