### PR TITLE
Fix four html5test.com JavaScript exceptions

### DIFF
--- a/docs/html5test-exceptions.md
+++ b/docs/html5test-exceptions.md
@@ -1,0 +1,229 @@
+# html5test.com — the four rendering exceptions
+
+Rendering <https://html5test.com/> reported four distinct JavaScript exceptions. This is what
+each one actually is, what was fixed, and what was deliberately left alone.
+
+Source of the page under test: <https://github.com/WebPlatformTest/HTML5test>.
+
+## Reading the stack traces
+
+Broiler labels each script it executes `inline-{i}`, indexed over the document's `<script>`
+elements in order (`ScriptEngine.ExecuteDetailed`, `src/Broiler.HtmlBridge.Scripting/ScriptEngine.cs`).
+For html5test that gives:
+
+| label | script |
+| --- | --- |
+| `inline-0` | `scripts/base.js` |
+| `inline-1` | `scripts/8/engine.js` — the feature-probe suite |
+| `inline-2` | `scripts/8/data.js` |
+| `inline-3` | the analytics inline script |
+| `inline-4` | Cloudflare's `email-decode.min.js` |
+| `inline-5` | the page's trailing inline script (`waitForWhichBrowser` / `start`) |
+
+So every reported failure is in `engine.js`, reached through `Runner` (`engine.js:4423`) and the
+`testsuite[s](this.list)` dispatch loop (`engine.js:4512`).
+
+## None of the four aborted the page
+
+Every one of the four sites sits inside html5test's own `try { … } catch (e) { }`. That is not
+incidental — `Runner.initialize` wraps the whole testsuite loop in a single
+`try { … } catch (e) { error(e) }` (`engine.js:4423-4519`), so had the first exception escaped, the
+run would have stopped there and the other three could never have been reported. Four reports is
+itself the proof that all four were caught.
+
+They are feature-detection probes: html5test deliberately provokes a throw and reads the failure as
+"unsupported".
+
+**Where the report came from matters.** Broiler's own capture diagnostics would not have listed
+these. The only place a JS error is ever logged is the host `catch` around
+`context.Eval(script, label)` — `src/Broiler.Cli/CaptureService.cs:770-776` and `:789-792`, and the
+equivalents in `src/Broiler.HtmlBridge.Scripting/ScriptEngine.cs` — that is, the *unwind* boundary,
+reached only when an exception escapes an entire script. There is no throw-time hook anywhere:
+`Broiler.JS` never reports, it only *constructs* a `JSException` carrying an origin frame. A caught
+exception therefore produces no `javascript-errors.log` entry at all.
+
+The four traces here interleave C# frames (`JSUndefined.cs:41`) with JS frames and name Windows
+paths (`D:\Broiler\…`), which is what a **first-chance** observer sees: every `JSException` at the
+moment it is constructed, caught or not. That is a strictly noisier view than the capture
+diagnostics, and reading it as a list of page failures overstates what happened — none of these
+stopped html5test, and one of them (WebRTC) is the correct answer.
+
+That does not make them uninteresting — three of the four are real capability gaps, and two were
+outright defects — but it does mean none of them was an emergency.
+
+## (1) `TypeError: Cannot get property nodeName of undefined` — `engine.js:44` — **fixed**
+
+```js
+e.innerHTML = "<div foo<bar=''>";
+result &= e.firstChild.attributes[0].nodeName == "foo<bar" || e.firstChild.attributes[0].name == "foo<bar";
+```
+
+The obvious reading — "the tokenizer drops an attribute whose name contains `<`" — is **wrong**.
+The tokenizer is correct: the attribute-name state appends `<` as an ordinary character
+(`Broiler.DOM/Broiler.Dom.Html/HtmlTokenizer.cs:166-170`), and the DOM really does hold an
+attribute named `foo<bar`. Observed before the fix: `attributes.length === 1`,
+`getAttributeNames() === ["foo<bar"]`, `attributes.item(0).nodeName === "foo<bar"` — all correct.
+
+The defect was that `attributes[0]` was `undefined`. `BuildNamedNodeMap` registered its index
+properties under numeric **string** keys:
+
+```csharp
+map.FastAddProperty((KeyString)idx.ToString(), …);   // AttributesBinding.cs:60
+```
+
+A `JSObject` keeps named and indexed properties in two separate stores. `FastAddProperty(KeyString…)`
+writes the named trie (`JSObject.PropertyStorage.cs:406`), while a JS read of an integer index
+resolves through the `elements` table and never falls back to the named one. So the index properties
+were written where no read ever looks — `Object.keys(attributes)` did not even list `"0"`, and
+`hasOwnProperty("0")` was `false`, which is what gives the mismatch away.
+
+**Fix:** use the `uint` overload, which writes indexed storage — the idiom `FormBinding.cs:56`
+already uses. One line, `src/Broiler.HtmlBridge.Dom/Features/AttributesBinding.cs`.
+
+The blast radius inside html5test is wider than the one assertion: the whole tokenizer block is one
+`try`, so the throw at line 44 skipped the ~20 remaining assertions on lines 46-95 and zeroed the
+entire `parsing.tokenizer` item. Line 50 (`<div "foo=''>`, reading `attributes[0].nodeName`) would
+have thrown for the same reason and is fixed by the same change.
+
+This was never really an html5test problem. Any page looping `el.attributes[i]` hit it, and the WPT
+runner had already had to route around it in its custom-elements shim — *"the bridge's `attributes`
+reports a length but does not answer to numeric indexing, so the obvious loop read `undefined.name`
+and threw out of `customElements.define` — taking the whole page's script with it"*
+(`src/Broiler.Wpt/WptTestRunner.cs`). That workaround can now be retired at leisure.
+
+## (2) `ReferenceError: HTMLElement is not defined` — `engine.js:228` — **fixed**
+
+```js
+passed = element instanceof HTMLElement && !(element instanceof HTMLUnknownElement) && …
+```
+
+Broiler exposed no DOM interface constructors at all beyond `Node`, `Event`, `CustomEvent` and
+`MouseEvent`. `HTMLElement`, `Element`, `HTMLUnknownElement`, `Document`, `Text`, `Comment`,
+`DocumentFragment`, `CharacterData` and `Attr` were all absent, so the bare identifier threw.
+
+There was a second, compounding gap behind it. A bridge DOM object is a plain `JSObject` whose
+prototype is `Object.prototype` (`JsObjects.cs:44`); it carries its members directly rather than
+inheriting them from an interface prototype. The ordinary `instanceof` prototype walk therefore
+cannot match one — which is why the *existing* `Node` global already answered
+`document.createElement('div') instanceof Node === false`. Simply defining the missing names as
+functions would have converted a `ReferenceError` into a silently wrong `false`.
+
+**Fix:** `DomBridge.RegisterDomInterfaceConstructors`
+(`src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.DomInterfaces.cs`) defines the constructors and
+gives each an `@@hasInstance` that answers from the object's own `nodeType` / `namespaceURI` /
+`tagName` instead of from a prototype chain. That is the spec's own extension point — ES §13.10.1
+consults `@@hasInstance` before the prototype walk — so this is a real answer rather than a shim.
+`Node` gains one too, keeping its type constants.
+
+`HTMLUnknownElement` is modelled as the subtype it is: an unknown element is an instance of both it
+and `HTMLElement`, which is exactly what html5test's `instanceof HTMLElement && !(instanceof
+HTMLUnknownElement)` split relies on. A hyphenated name is an undefined custom element, which the
+spec makes an `HTMLElement` rather than an unknown one.
+
+Note it must be installed with `Object.defineProperty`: `Function.prototype[@@hasInstance]` is
+non-writable, so a plain assignment silently does nothing in sloppy mode.
+
+Giving DOM objects genuine per-interface prototype chains would subsume all of this and is the
+better long-term shape. It is also a far larger change to the object model than making
+`instanceof HTMLElement` — the single most common way a page asks "is this an element?" — stop
+throwing.
+
+**Scope, and what is still missing.** This covers the node interfaces. html5test uses `instanceof`
+against roughly two dozen more that remain undefined — `CanvasRenderingContext2D`
+(`canvas.context`), `Blob` (`communication.xmlhttprequest2.response.blob`), `FileList`
+(`form.file.files`), `NodeList`, `HTMLCollection` and the per-tag `HTML*Element` types. Those are
+not node types, so they need a different discriminator than `nodeType`, and the per-tag types need a
+tag→interface table; both are follow-on work rather than part of this fix. Note also that
+`childNodes` returns a `JSArray`, so a `NodeList` global would need to decide what it is claiming
+about that before it would mean anything.
+
+## (3) `TypeError: cannot create instance of undefined` — `engine.js:1986` — **not a defect**
+
+```js
+o = new (window.RTCPeerConnection || window.msRTCPeerConnection || window.mozRTCPeerConnection || window.webkitRTCPeerConnection)(null);
+```
+
+All four are undefined, so this is `new undefined(…)`. Broiler implements no WebRTC surface
+anywhere — no `RTCPeerConnection`, no `RTCDataChannel`, no `navigator.mediaDevices`,
+no `getUserMedia`, in the main repo or any submodule. `webrtc/*` is listed in
+`tests/wpt-baseline/failed-tests.json` as a durable expected failure, and WebRTC does not appear in
+`docs/ROADMAP.md`.
+
+This is the expected outcome of a feature probe against an engine without the feature — a browser
+with WebRTC disabled throws here too. Nothing to fix; implementing WebRTC is a feature project
+(an ICE/DTLS/SCTP stack), not a bug fix.
+
+One cosmetic observation, independent of html5test: Broiler words this `cannot create instance of
+undefined`, where the spec-conventional phrasing — and Broiler's own wording at its other
+construct sites — is `… is not a constructor`. Worth a sweep if error-message consistency is ever
+tidied; it lives in the `Broiler.JS` submodule (`JSUndefined.cs`, `JSNull.cs`), so it would go
+through the patch workflow.
+
+## (4) `TypeError: undefined is not a function` — `engine.js:3030` — **left open, deliberately**
+
+```js
+var data = ctx.getImageData(0, 0, 1, 1);
+```
+
+`getImageData` is absent, and so are `putImageData`, `createImageData`, `ImageData` and
+`canvas.toDataURL`. The absence is structural, not a missing entry in a member list: the 2D context
+is a **style-state stub with no pixels**. `CanvasRenderingContext2D`
+(`src/Broiler.HtmlBridge.Dom/DomBridge/CanvasRenderingContext2D.cs`) keeps `fillStyle`, `lineWidth`,
+`font` and the save/restore stack, and every drawing method is a literal empty body —
+`public void FillRect(float x, float y, float width, float height) { }`. The type's own remarks
+record that Phase 6 removed the former command list because nothing ever rendered it. So there is no
+backing store for `getImageData` to read.
+
+**This was deliberately not stubbed.** Returning zeroed pixels would convert an honest
+`TypeError` — which every feature detector on the web reads correctly as "no canvas readback" —
+into a false claim of support, and pages that branch on `typeof ctx.getImageData === 'function'`
+would then take the canvas path and silently render nothing. Absent is the safer answer until the
+context can actually rasterise.
+
+The real fix is to give the context a real backing store. `Broiler.Graphics` already ships the
+rasteriser and a readable RGBA buffer that would back it, and it is a dependency leaf, so the
+binding could consume it without a cycle. That is a scoped, worthwhile project — it would also make
+`canvas.toDataURL` and canvas painting possible — but it is a feature, not a fix, and it is not
+attempted here.
+
+## Measured end to end
+
+A real capture of the live site before and after
+(`dotnet run --project src/Broiler.Cli -- --capture-image https://html5test.com/ --output <png>
+--diagnostic-dir <dir>`), reading the score out of the post-script document the diagnostics archive:
+
+| | score | rows scoring "Yes" |
+| --- | --- | --- |
+| before | 123 / 555 | 61 |
+| after | 126 / 555 | 64 |
+
+Newly passing: `elements.interactive`, `elements.interactive.menutoolbar`,
+`elements.semantic.ruby` — all of them `instanceof HTMLElement && !(instanceof HTMLUnknownElement)`
+probes. Nothing regressed from "Yes" to "No".
+
+Both runs report **0 JavaScript failures** in the diagnostics, before and after, which is the
+"caught exceptions are not logged" point above made concrete: the fixes are visible in the score,
+not in the failure count.
+
+Two probes named in this document still score "No" for reasons beyond the exception:
+`parsing.tokenizer` runs ~20 further assertions after the one that used to throw, and
+`elements.section` additionally requires `isBlock(element)` and `closesImplicitly(tag)`. Removing
+the throw lets those probes *finish*; it does not by itself make them pass.
+
+## What changed
+
+| file | change |
+| --- | --- |
+| `src/Broiler.HtmlBridge.Dom/Features/AttributesBinding.cs` | index properties into indexed storage |
+| `src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.DomInterfaces.cs` | new — the interface-constructor globals |
+| `src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Polyfills.cs` | register them |
+| `src/Broiler.Wpt/WptTestRunner.cs` | shim guard now probes capability, not name existence |
+| `src/Broiler.Cli.Tests/HtmlDomInterfacesTests.cs` | numeric-index and `foo<bar` regression tests |
+| `src/Broiler.Cli.Tests/DomInterfaceConstructorTests.cs` | new — interface-constructor tests |
+
+The `WptTestRunner.cs` change is a consequence of (2), not an improvement in its own right. Its
+custom-element shim installed a constructible `HTMLElement` only when the name was missing; now that
+the bridge defines the name, that guard would have skipped the shim and left
+`class X extends HTMLElement` building plain objects instead of elements. It now probes the
+capability it actually needs — that `new HTMLElement()` yields an element node — so the override
+still installs, and a future real implementation would pass the probe and win.

--- a/src/Broiler.Cli.Tests/DomInterfaceConstructorTests.cs
+++ b/src/Broiler.Cli.Tests/DomInterfaceConstructorTests.cs
@@ -1,0 +1,178 @@
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// The DOM interface-constructor globals — <c>Element</c>, <c>HTMLElement</c>,
+/// <c>HTMLUnknownElement</c>, <c>Document</c>, <c>DocumentFragment</c>, <c>CharacterData</c>,
+/// <c>Text</c>, <c>Comment</c>, <c>Attr</c> — and the <c>instanceof</c> answers they give
+/// (see <c>DomBridge.RegisterDomInterfaceConstructors</c>).
+///
+/// A bridge DOM object is a plain JSObject with <c>Object.prototype</c> for a prototype, so the
+/// ordinary <c>instanceof</c> prototype walk can never match; each constructor answers from the
+/// object's own <c>nodeType</c>/<c>namespaceURI</c>/<c>tagName</c> through <c>@@hasInstance</c>.
+/// Before this, <c>element instanceof HTMLElement</c> threw
+/// <c>ReferenceError: HTMLElement is not defined</c> — one of the four exceptions
+/// html5test.com's feature probes hit.
+/// </summary>
+public class DomInterfaceConstructorTests
+{
+    private static string Run(string script)
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<div id=""result""></div>
+<script>
+var r = [];
+" + script + @"
+document.getElementById('result').textContent = r.join(',');
+</script>
+</body></html>";
+        return CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+    }
+
+    [Fact]
+    public void Interface_Constructors_Are_Defined_As_Bare_Globals()
+    {
+        var result = Run(@"
+var names = ['Node','Element','HTMLElement','HTMLUnknownElement','Document',
+             'DocumentFragment','CharacterData','Text','Comment','Attr'];
+for (var i = 0; i < names.length; i++) {
+  r.push(typeof window[names[i]] === 'function');
+}
+// Reached by bare name too, not only through window.
+r.push(typeof HTMLElement === 'function');
+r.push(typeof Element === 'function');
+");
+        Assert.Contains("true,true,true,true,true,true,true,true,true,true,true,true", result);
+    }
+
+    [Fact]
+    public void Element_Is_Instance_Of_HTMLElement_Element_And_Node()
+    {
+        var result = Run(@"
+var d = document.createElement('div');
+r.push(d instanceof HTMLElement);
+r.push(d instanceof Element);
+r.push(d instanceof Node);
+r.push(!(d instanceof HTMLUnknownElement));
+r.push(!(d instanceof Text));
+r.push(!(d instanceof Document));
+");
+        Assert.Contains("true,true,true,true,true,true", result);
+    }
+
+    /// <summary>
+    /// The html5test.com probe at <c>engine.js:228</c>:
+    /// <c>element instanceof HTMLElement &amp;&amp; !(element instanceof HTMLUnknownElement)</c>
+    /// over the HTML5 sectioning elements. Each has no dedicated interface of its own, so each is
+    /// a plain HTMLElement and specifically *not* an HTMLUnknownElement.
+    /// </summary>
+    [Fact]
+    public void Html5_Sectioning_Elements_Are_HTMLElement_And_Not_Unknown()
+    {
+        var result = Run(@"
+var els = 'section nav article aside header footer main figure figcaption'.split(' ');
+for (var i = 0; i < els.length; i++) {
+  var el = document.createElement(els[i]);
+  r.push(el instanceof HTMLElement && !(el instanceof HTMLUnknownElement));
+}
+");
+        Assert.Contains("true,true,true,true,true,true,true,true,true", result);
+    }
+
+    /// <summary>
+    /// HTMLUnknownElement is a subtype of HTMLElement, so an unknown element is an instance of
+    /// both. A hyphenated name is a custom element, which the spec makes an HTMLElement rather
+    /// than an unknown one.
+    /// </summary>
+    [Fact]
+    public void Unknown_And_Custom_Element_Names_Are_Distinguished()
+    {
+        var result = Run(@"
+var unknown = document.createElement('foobar');
+r.push(unknown instanceof HTMLElement);
+r.push(unknown instanceof HTMLUnknownElement);
+var custom = document.createElement('my-widget');
+r.push(custom instanceof HTMLElement);
+r.push(!(custom instanceof HTMLUnknownElement));
+");
+        Assert.Contains("true,true,true,true", result);
+    }
+
+    [Fact]
+    public void Character_Data_Document_And_Fragment_Nodes_Answer_Their_Interfaces()
+    {
+        var result = Run(@"
+var t = document.createTextNode('x');
+r.push(t instanceof Text);
+r.push(t instanceof CharacterData);
+r.push(t instanceof Node);
+r.push(!(t instanceof Element));
+
+var c = document.createComment('c');
+r.push(c instanceof Comment);
+r.push(c instanceof CharacterData);
+r.push(!(c instanceof Text));
+
+r.push(document instanceof Document);
+r.push(document instanceof Node);
+
+var f = document.createDocumentFragment();
+r.push(f instanceof DocumentFragment);
+r.push(!(f instanceof Element));
+");
+        Assert.Contains("true,true,true,true,true,true,true,true,true,true,true", result);
+    }
+
+    /// <summary>A non-node value is not an instance of any of them, and does not throw.</summary>
+    [Fact]
+    public void Non_Node_Values_Are_Not_Instances()
+    {
+        var result = Run(@"
+r.push(!(({}) instanceof HTMLElement));
+r.push(!(({ nodeType: 'not a number' }) instanceof Node));
+r.push(!([] instanceof Element));
+r.push(!(null instanceof HTMLElement));
+r.push(!(undefined instanceof Node));
+r.push(!('div' instanceof HTMLElement));
+");
+        Assert.Contains("true,true,true,true,true,true", result);
+    }
+
+    /// <summary>
+    /// The interfaces are not constructible, exactly as in a browser: their objects come from
+    /// <c>document.createElement</c> and friends, so calling one directly throws rather than
+    /// handing back a plain object that merely looks like an element.
+    /// </summary>
+    [Fact]
+    public void Interface_Constructors_Are_Not_Directly_Constructible()
+    {
+        var result = Run(@"
+var names = ['Element','HTMLElement','HTMLUnknownElement','Document',
+             'DocumentFragment','CharacterData','Text','Comment','Attr'];
+for (var i = 0; i < names.length; i++) {
+  var threw = false;
+  try { new window[names[i]](); } catch (e) { threw = e instanceof TypeError; }
+  r.push(threw);
+}
+");
+        Assert.Contains("true,true,true,true,true,true,true,true,true", result);
+    }
+
+    /// <summary>
+    /// The <c>Node</c> global keeps its DOM type constants — it gained an <c>@@hasInstance</c>,
+    /// it was not replaced.
+    /// </summary>
+    [Fact]
+    public void Node_Constants_Survive_Alongside_InstanceOf_Support()
+    {
+        var result = Run(@"
+r.push(Node.ELEMENT_NODE === 1);
+r.push(Node.TEXT_NODE === 3);
+r.push(Node.COMMENT_NODE === 8);
+r.push(Node.DOCUMENT_NODE === 9);
+r.push(Node.DOCUMENT_FRAGMENT_NODE === 11);
+r.push(document.createElement('div') instanceof Node);
+");
+        Assert.Contains("true,true,true,true,true,true", result);
+    }
+}

--- a/src/Broiler.Cli.Tests/HtmlDomInterfacesTests.cs
+++ b/src/Broiler.Cli.Tests/HtmlDomInterfacesTests.cs
@@ -297,6 +297,73 @@ document.getElementById('result').textContent = r.join(',');
         Assert.Contains("true,true,true,true,true", result);
     }
 
+    /// <summary>
+    /// A NamedNodeMap answers numeric indexing, not just <c>length</c> and <c>item()</c>.
+    /// The index properties used to be registered under numeric *string* keys, which the engine's
+    /// integer-index read path never consults, so <c>attributes[0]</c> was <c>undefined</c> while
+    /// <c>attributes.length</c> and <c>attributes.item(0)</c> both answered correctly — the
+    /// obvious `for (i…) attributes[i].name` loop read a property of undefined and threw.
+    /// </summary>
+    [Fact]
+    public void Attributes_Are_Reachable_By_Numeric_Index()
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<div id=""d"" class=""foo"" title=""bar""></div>
+<div id=""result""></div>
+<script>
+var d = document.getElementById('d');
+var attrs = d.attributes;
+var r = [];
+r.push(attrs.length === 3);
+r.push(typeof attrs[0] === 'object');
+r.push(attrs[0].nodeName === 'id');
+r.push(attrs[0].name === 'id');
+r.push(attrs[0].value === 'd');
+// The string spelling of an index reaches the same property.
+r.push(attrs['1'].name === 'class');
+r.push(Object.prototype.hasOwnProperty.call(attrs, '0') === true);
+// Indexing and item() agree across the whole map.
+var agree = true;
+for (var i = 0; i < attrs.length; i++) {
+  if (!attrs[i] || attrs[i].name !== attrs.item(i).name) agree = false;
+}
+r.push(agree);
+r.push(attrs[attrs.length] === undefined);
+document.getElementById('result').textContent = r.join(',');
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+        Assert.Contains("true,true,true,true,true,true,true,true,true", result);
+    }
+
+    /// <summary>
+    /// html5test.com's tokenizer probe: <c>&lt;div foo&lt;bar=''&gt;</c> yields an attribute
+    /// literally named <c>foo&lt;bar</c> (the attribute-name state appends <c>&lt;</c> as an
+    /// ordinary character), reached through <c>attributes[0]</c>.
+    /// </summary>
+    [Fact]
+    public void Attribute_Name_Containing_LessThan_Is_Parsed_And_Indexable()
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<div id=""result""></div>
+<script>
+var r = [];
+var e = document.createElement('div');
+e.innerHTML = ""<div foo<bar=''>"";
+r.push(e.firstChild.attributes.length === 1);
+r.push(e.firstChild.attributes[0].nodeName === 'foo<bar');
+r.push(e.firstChild.attributes[0].name === 'foo<bar');
+document.getElementById('result').textContent = r.join(',');
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+        Assert.Contains("true,true,true", result);
+    }
+
     [Fact]
     public void Element_HasAttributes_Reflects_Attribute_Presence()
     {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Polyfills.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Polyfills.cs
@@ -47,6 +47,10 @@ public sealed partial class DomBridge
         // Node constructor with type constants
         RegisterNodeConstructor(context);
 
+        // Element/HTMLElement/HTMLUnknownElement/… interface globals. After Node, whose
+        // @@hasInstance it installs.
+        RegisterDomInterfaceConstructors(context);
+
         // SVGLength interface constants
         RegisterSVGLength(context);
     }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.DomInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.DomInterfaces.cs
@@ -1,0 +1,122 @@
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.HtmlBridge;
+
+public sealed partial class DomBridge
+{
+    /// <summary>
+    /// Registers the DOM interface-constructor globals a page reaches for by bare name —
+    /// <c>Element</c>, <c>HTMLElement</c>, <c>HTMLUnknownElement</c>, <c>Document</c>,
+    /// <c>DocumentFragment</c>, <c>CharacterData</c>, <c>Text</c>, <c>Comment</c> and
+    /// <c>Attr</c> — and teaches the pre-existing <c>Node</c> global to answer
+    /// <c>instanceof</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A bridge DOM object is a plain <c>JSObject</c> whose prototype is <c>Object.prototype</c>:
+    /// it carries its members directly rather than inheriting them from an interface prototype.
+    /// So the ordinary <c>instanceof</c> walk — follow the operand's prototype chain looking for
+    /// the constructor's <c>prototype</c> — can never succeed for one, which is why the
+    /// long-standing <c>Node</c> global (see <c>RegisterNodeConstructor</c>) reported
+    /// <c>document.createElement('div') instanceof Node === false</c>.
+    /// </para>
+    /// <para>
+    /// Each constructor therefore carries an <c>@@hasInstance</c> that answers from the object's
+    /// own <c>nodeType</c>/<c>namespaceURI</c>/<c>tagName</c> instead of from a prototype chain.
+    /// That is the spec's own extension point (ES §13.10.1 consults <c>@@hasInstance</c> before
+    /// the prototype walk), so this is a real answer rather than a shim — and it is installed with
+    /// <c>Object.defineProperty</c> because <c>Function.prototype[@@hasInstance]</c> is
+    /// non-writable, so a plain assignment would silently do nothing in sloppy mode.
+    /// </para>
+    /// <para>
+    /// Giving DOM objects genuine per-interface prototype chains would subsume this and is the
+    /// better long-term shape; it is a far larger change to the object model than making
+    /// <c>instanceof HTMLElement</c> — the single most common way a page asks "is this an
+    /// element?" — stop throwing <c>ReferenceError</c>.
+    /// </para>
+    /// </remarks>
+    private static void RegisterDomInterfaceConstructors(JSContext context)
+    {
+        context.Eval(@"
+            // Calling one of these directly throws, as it does in a browser: these interfaces are
+            // not constructible, and their objects come from document.createElement and friends.
+            // Answering with a plain object instead would hand back something that looks like an
+            // element to the caller and is not one — worse than the ReferenceError this replaces.
+            function Element() { throw new TypeError('Illegal constructor'); }
+            function HTMLElement() { throw new TypeError('Illegal constructor'); }
+            function HTMLUnknownElement() { throw new TypeError('Illegal constructor'); }
+            function Document() { throw new TypeError('Illegal constructor'); }
+            function DocumentFragment() { throw new TypeError('Illegal constructor'); }
+            function CharacterData() { throw new TypeError('Illegal constructor'); }
+            function Text() { throw new TypeError('Illegal constructor'); }
+            function Comment() { throw new TypeError('Illegal constructor'); }
+            function Attr() { throw new TypeError('Illegal constructor'); }
+
+            (function () {
+                var HTML_NS = 'http://www.w3.org/1999/xhtml';
+
+                // The HTML elements the parser knows. Anything else with no '-' in its name is an
+                // HTMLUnknownElement; a name *with* a '-' is an (undefined) custom element, which
+                // the spec makes an HTMLElement rather than an unknown one.
+                var known = {};
+                var names = ('a abbr acronym address applet area article aside audio b base ' +
+                    'basefont bdi bdo big blockquote body br button canvas caption center cite ' +
+                    'code col colgroup data datalist dd del details dfn dialog dir div dl dt em ' +
+                    'embed fieldset figcaption figure font footer form frame frameset h1 h2 h3 ' +
+                    'h4 h5 h6 head header hgroup hr html i iframe img input ins kbd keygen label ' +
+                    'legend li link listing main map mark marquee menu meta meter nav nobr ' +
+                    'noembed noframes noscript object ol optgroup option output p param picture ' +
+                    'plaintext pre progress q rb rp rt rtc ruby s samp script search section ' +
+                    'select slot small source span strike strong style sub summary sup table ' +
+                    'tbody td template textarea tfoot th thead time title tr track tt u ul var ' +
+                    'video wbr xmp').split(' ');
+                for (var i = 0; i < names.length; i++) known[names[i]] = true;
+
+                function define(ctor, test) {
+                    Object.defineProperty(ctor, Symbol.hasInstance, {
+                        value: test, writable: false, enumerable: false, configurable: true
+                    });
+                }
+
+                function isNode(o) {
+                    return !!o && typeof o === 'object' && typeof o.nodeType === 'number';
+                }
+
+                function isElement(o) {
+                    return isNode(o) && o.nodeType === 1;
+                }
+
+                function isHtmlElement(o) {
+                    if (!isElement(o)) return false;
+                    var ns = o.namespaceURI;
+                    // A bridge element created outside a namespace-aware path may report no
+                    // namespace at all; treat that as HTML rather than as neither.
+                    return ns === HTML_NS || ns === null || typeof ns === 'undefined';
+                }
+
+                define(Node, isNode);
+                define(Element, isElement);
+                define(HTMLElement, isHtmlElement);
+
+                // HTMLUnknownElement is a *subtype* of HTMLElement, so an unknown element is an
+                // instance of both. html5test's `x instanceof HTMLElement &&
+                // !(x instanceof HTMLUnknownElement)` check relies on exactly that split.
+                define(HTMLUnknownElement, function (o) {
+                    if (!isHtmlElement(o)) return false;
+                    var tag = typeof o.tagName === 'string' ? o.tagName.toLowerCase() : '';
+                    if (tag === '' || known[tag] === true) return false;
+                    return tag.indexOf('-') === -1;
+                });
+
+                define(Document, function (o) { return isNode(o) && (o.nodeType === 9 || o.nodeType === 10); });
+                define(DocumentFragment, function (o) { return isNode(o) && o.nodeType === 11; });
+                define(CharacterData, function (o) {
+                    return isNode(o) && (o.nodeType === 3 || o.nodeType === 4 || o.nodeType === 8);
+                });
+                define(Text, function (o) { return isNode(o) && (o.nodeType === 3 || o.nodeType === 4); });
+                define(Comment, function (o) { return isNode(o) && o.nodeType === 8; });
+                define(Attr, function (o) { return isNode(o) && o.nodeType === 2; });
+            })();
+        ");
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/Features/AttributesBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/AttributesBinding.cs
@@ -52,12 +52,23 @@ internal sealed class AttributesBinding(IAttributesHost host)
         // item(index) — returns Attr node at position
         map.FastAddValue((KeyString)"item", new DomFunction((in a) => Item(element, ownerObj, in a), "item", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        // Numeric index access — expose each attribute by index
+        // Numeric index access — expose each attribute by index.
+        //
+        // These have to go into the object's *indexed* storage, not its named storage: an
+        // integer-index key is canonicalized to the element array before the named property
+        // table is ever consulted, so a getter installed under the KeyString "0" is written
+        // where no read ever looks. `attributes.length` and `attributes.item(0)` were right
+        // while `attributes[0]` was undefined — and `Object.keys(attributes)` did not even
+        // list "0", which is what gives the mismatch away. That cost more than an html5test
+        // point: the WPT runner's custom-element shim had to route around it
+        // (WptTestRunner.cs, "the bridge's `attributes` reports a length but does not answer
+        // to numeric indexing"), because the obvious `attributes[i].name` loop read
+        // `undefined.name` and threw out of customElements.define.
         var attrKeys = DomBridge.AttributeNames(element).ToList();
         for (var i = 0; i < attrKeys.Count; i++)
         {
             var idx = i;
-            map.FastAddProperty((KeyString)idx.ToString(), new DomFunction((in _) => IndexedItem(element, idx, ownerObj, in _), "get " + idx), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+            map.FastAddProperty((uint)idx, new DomFunction((in _) => IndexedItem(element, idx, ownerObj, in _), "get " + idx), null, JSPropertyAttributes.EnumerableConfigurableProperty);
         }
 
         return map;

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -705,10 +705,32 @@ internal sealed partial class WptTestRunner
 
     test_driver.Actions = Actions;
   }
-  if (typeof HTMLElement === 'undefined') {
-    window.HTMLElement = function HTMLElement() {
+  // The bridge now defines HTMLElement (see DomBridge RegisterDomInterfaceConstructors), so an
+  // `is it missing?` guard would skip this shim and leave `class X extends HTMLElement` building
+  // plain objects instead of elements. Probe the capability this shim actually needs — that
+  // `new HTMLElement()` yields an element node — rather than the name's mere existence. The
+  // bridge's version answers `instanceof` and is not constructible into an element, so the
+  // override still installs; a future real implementation would pass the probe and win.
+  var __broilerNeedsHtmlElementShim = true;
+  try {
+    if (typeof HTMLElement !== 'undefined') {
+      var __broilerHtmlElementProbe = new HTMLElement();
+      __broilerNeedsHtmlElementShim =
+        !(__broilerHtmlElementProbe && __broilerHtmlElementProbe.nodeType === 1);
+    }
+  } catch (e) {
+    __broilerNeedsHtmlElementShim = true;
+  }
+  if (__broilerNeedsHtmlElementShim) {
+    var __broilerHtmlElementShim = function HTMLElement() {
       return __broilerEnsureAnimate(__broilerNativeCreateElement(__broilerCurrentCustomElementName || 'div'));
     };
+    window.HTMLElement = __broilerHtmlElementShim;
+    // Assigned to the global scope as well as to window. A bare `HTMLElement` in
+    // `class X extends HTMLElement` resolves through the global scope, and the alias loop below
+    // only copies window onto globalThis for names the global scope is *missing* — which this one
+    // no longer is, now that the bridge declares it.
+    try { globalThis.HTMLElement = __broilerHtmlElementShim; } catch (e) {}
   }
   if (typeof customElements === 'undefined') {
     function __broilerUpgradeElement(tagName, ctor, sourceElement) {


### PR DESCRIPTION
## Summary

Investigating the four JavaScript exceptions html5test.com reports found **two real defects** (fixed here), **one absent feature** (deliberately not stubbed) and **one non-defect**. Score on the live site: 123/555 → 126/555.

**None of the four aborted the page.** All four sit inside html5test's own `try`/`catch`, and `Runner.initialize` wraps the whole suite in a single `catch` — so had the first escaped, the other three could never have been reported. They are feature-detection probes that deliberately provoke a throw.

Worth knowing for triage: Broiler only logs an exception that escapes an entire script (the host `catch` around `context.Eval`), and `Broiler.JS` has no throw-time hook — so a capture reports **0 JavaScript failures** both before and after this change. The reported traces interleave C# frames with JS frames, which is what a *first-chance* observer sees. That is a noisier view than the capture diagnostics.

Full reasoning and evidence: `docs/html5test-exceptions.md`.

## Fixed

**1. `element.attributes` was not indexable** (`engine.js:44`)

`attributes[0]` was `undefined` while `attributes.length` and `attributes.item(0)` answered correctly — which is what disguised it. The index properties were registered under numeric *string* keys, landing in the object's named table, while an integer-index read resolves through the element array and never falls back to it; `Object.keys(attributes)` did not even list `"0"`. Fixed by using the `uint` overload, as `FormBinding` already does.

Not really an html5test problem: the WPT runner's custom-element shim already had to route around it, because the obvious `attributes[i].name` loop read `undefined.name` and threw out of `customElements.define`. The tokenizer was never at fault — it correctly keeps the `foo<bar` attribute name.

**2. No DOM interface constructors** (`engine.js:228`)

`HTMLElement`, `Element`, `HTMLUnknownElement`, `Document`, `DocumentFragment`, `CharacterData`, `Text`, `Comment` and `Attr` were all undefined, so the bare name threw `ReferenceError`. Defining the names alone would not have been enough: a bridge DOM object is a plain `JSObject` with `Object.prototype` for a prototype, so the ordinary `instanceof` prototype walk cannot match one — the pre-existing `Node` global already answered `false` for every node.

Each constructor now carries an `@@hasInstance` answering from the object's own `nodeType`/`namespaceURI`/`tagName` — the spec's own extension point (ES §13.10.1), not a shim — and `Node` gains one too. `HTMLUnknownElement` is modelled as the subtype it is, since html5test's `instanceof HTMLElement && !(instanceof HTMLUnknownElement)` split depends on that. The interfaces are not constructible, as in a browser: calling one throws `Illegal constructor` rather than returning something that merely looks like an element.

## Not fixed, deliberately

**3. `ctx.getImageData` is absent** (`engine.js:3030`) — and is **not** addressed by this PR. The 2D context is a style-state stub whose drawing methods are literal empty bodies, with no pixel buffer to read. Stubbing `getImageData` would turn an honest `TypeError` — which feature detectors read correctly as "no canvas readback" — into a false claim of support, and pages branching on `typeof ctx.getImageData === 'function'` would then render nothing. `Broiler.Graphics` already ships the rasteriser that could back a real implementation; that is a scoped feature project, not a bug fix.

**4. WebRTC is unimplemented** (`engine.js:1986`) — `new (window.RTCPeerConnection || …)(null)` where all variants are `undefined`. No WebRTC surface exists anywhere in the repo or submodules, and `webrtc/*` is already a durable expected failure in the WPT baseline. A browser with WebRTC disabled throws here too; this is the correct probe answer.

## Files changed

| File | Change |
| --- | --- |
| `src/Broiler.HtmlBridge.Dom/Features/AttributesBinding.cs` | index properties into indexed storage |
| `src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.DomInterfaces.cs` | new — interface-constructor globals with `@@hasInstance` |
| `src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Polyfills.cs` | register them |
| `src/Broiler.Wpt/WptTestRunner.cs` | shim guard probes capability, not name existence |
| `src/Broiler.Cli.Tests/HtmlDomInterfacesTests.cs` | numeric-index and `foo<bar` regression tests |
| `src/Broiler.Cli.Tests/DomInterfaceConstructorTests.cs` | new — interface-constructor tests |
| `docs/html5test-exceptions.md` | new — the investigation |

The `WptTestRunner.cs` change is a consequence of (2), not an improvement in its own right: its custom-element shim installed a constructible `HTMLElement` only when the name was *missing*, so once the bridge defines it, that guard would have skipped the shim and left `class X extends HTMLElement` building plain objects. It now probes the capability it actually needs.

## Verification

Baselined rather than assumed, since `CLAUDE.md` warns some tests fail environmentally in a bare container:

| suite | before | after |
| --- | --- | --- |
| `Broiler.Wpt.Tests` (982 tests) | 54 failures | 54 failures — identical set |
| `Broiler.Cli.Tests` DOM/bridge subset (1483 tests) | 20 failures | 20 failures — identical set, +10 new passing |
| Acid3 (`Acid3Phase5Tests`, 84 tests) | 4 failures, score 96 | unchanged |

Live-site capture: **123/555 → 126/555**, three rows newly scoring "Yes" (`elements.interactive`, `elements.interactive.menutoolbar`, `elements.semantic.ruby`), none lost.

## Known limits

- `parsing.tokenizer` and `elements.section` still score "No". Removing the throw lets those probes *finish*; each runs further assertions (`isBlock`, `closesImplicitly`, ~20 more tokenizer checks) that fail for unrelated reasons.
- html5test uses `instanceof` against ~20 more non-node interfaces — `CanvasRenderingContext2D`, `Blob`, `FileList`, `NodeList`, `HTMLCollection`, per-tag `HTML*Element` — which remain undefined. They need a discriminator other than `nodeType`, and the per-tag types need a tag→interface table; left as follow-on work rather than guessed at.
- No submodule pointers were touched; every fix is in the main repo, so no patch-workflow entry was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vBoqS33H56RaWWAJaxYjd
