### PR TITLE
Fix regex parser to distinguish NUL character from end-of-pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,43 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `Broiler.HtmlBridge` — `window.top` did not exist, so the unqualified `top` a page
+  writes raised `ReferenceError: top is not defined`. Because `window` *is* the global
+  object here, an unregistered member is not an undefined property but a reference
+  error, and that aborts the entire `<script>` rather than the one statement — taking
+  every function it would have defined and every listener it would have registered with
+  it. `top` was the one member of the `self`/`parent`/`top` trio never registered on the
+  main window: sub-documents got one from `SubWindowBinding`, and `WindowContextManager`
+  dutifully saved and restored a global that had never been defined in the first place,
+  so after the first frame ran the main document's `top` was `undefined` instead of
+  missing. A framing check (`if (top != self)`) is among the first things a page's
+  boilerplate runs, which is where this surfaced: google.com's One-Google-bar bundle died
+  on it. A top-level window's `top` is now that window, as its `parent` and `self` already
+  were, and it is bound to the global object so `top.foo()` reaches page globals the way
+  `parent.foo()` does.
+
+- `Broiler.JS`/`Broiler.Regex` (patch, awaiting a maintainer — see `patches/README.md`) —
+  the pattern parser could not tell the end of a pattern from a U+0000 inside one. Its
+  cursor reports "past the last character" by returning `'\0'` from `Peek()`, and every
+  end-of-pattern test compared against that sentinel, so a pattern that merely *contained*
+  a NUL appeared to end there. google.com's start page compiles a "no letters" character
+  class whose first range runs from NUL to space, and it failed at the very first atom
+  with `Unterminated character class`. The NUL is decoded by the time the parser sees it
+  because the page builds the class with `new RegExp(<string>)` — the string literal's
+  `\0` is consumed by the *string* grammar and never reaches the pattern grammar — so the
+  spelling a regex literal preserves, `[\0-…]`, parsed correctly all along; the two are
+  different inputs and only the decoded one was broken. It was not confined to character
+  classes either: a NUL as an atom, as a range end, in a group name or inside `\p{…}`
+  truncated the parse the same way. Every end-of-pattern test now goes through an explicit
+  `AtEnd`. Separating the two also fixed the mirror-image bug at the real end of input: a
+  pattern ending in a lone `\` had no guard on the path that reads the escaped character,
+  so it ran off the end of the string and raised `IndexOutOfRangeException` in non-Unicode
+  mode, where callers catch `RegexSyntaxException`. Nothing a page renders changes today —
+  `JSRegExp.TryBuildBroilerForGaps` catches the parse failure and falls back to the .NET
+  translator, so this pattern was mis-routed rather than fatal — but the exception was
+  real, and a NUL-bearing pattern that *does* need Broiler.Regex's semantics now reaches
+  it instead of silently falling back.
+
 - `Broiler.Layout` — a layout pass that started while another one was still running over
   the same box tree threw `ArgumentException` ("An item with the same key has already been
   added") out of `CssLineBox.AssignRectanglesToBoxes`, which `CssBox.PerformLayout` caught

--- a/patches/0006-regex-nul-vs-end-of-pattern.patch
+++ b/patches/0006-regex-nul-vs-end-of-pattern.patch
@@ -1,0 +1,302 @@
+From 329aecd80eca11f78f97837d998ad6c9d99ab000 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 14 Aug 2026 19:45:00 +0000
+Subject: [PATCH] Tell the end of a pattern apart from a NUL inside one
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The parser's cursor reports "past the last character" by returning '\0' from
+Peek(), and every end-of-pattern test compared against that sentinel. U+0000 is
+an ordinary pattern character, so a pattern that merely contained one looked as
+though it ended there.
+
+google.com's start page compiles a "no letters" character class whose first
+range runs from NUL to space. It reaches the parser as a decoded U+0000 — the
+page builds it with new RegExp(<string>), so the string literal's \0 is consumed
+by the string grammar and never reaches the pattern grammar — and the parse died
+on the very first atom with "Unterminated character class". The escaped spelling
+a regex literal preserves, [\0-...], was fine all along; only the decoded one
+was broken.
+
+The class was not confined to character classes: a NUL as an atom, as a range
+end, in a group name or inside \p{...} truncated the parse in the same way.
+
+Route every end-of-pattern test through an explicit AtEnd (and HasAt for the
+one lookahead that needed bounds rather than a value) so the sentinel is no
+longer load-bearing. Peek() still returns '\0' past the end — nothing reads it
+as a signal now.
+
+Separating the two also fixes the mirror-image bug at the real end of input: a
+pattern ending in a lone '\' had no EOF guard on the path that reads the escaped
+character, so ReadCharacterEscape ran off the end of the string and raised
+IndexOutOfRangeException in non-Unicode mode, where callers catch
+RegexSyntaxException. It is now reported as the syntax error it is.
+---
+ Broiler.Regex.Tests/NulCharacterTests.cs | 149 +++++++++++++++++++++++
+ Broiler.Regex/Parsing/RegexParser.cs     |  36 ++++--
+ 2 files changed, 177 insertions(+), 8 deletions(-)
+ create mode 100644 Broiler.Regex.Tests/NulCharacterTests.cs
+
+diff --git a/Broiler.Regex.Tests/NulCharacterTests.cs b/Broiler.Regex.Tests/NulCharacterTests.cs
+new file mode 100644
+index 0000000..5859878
+--- /dev/null
++++ b/Broiler.Regex.Tests/NulCharacterTests.cs
+@@ -0,0 +1,149 @@
++namespace Broiler.Regex.Tests;
++
++/// <summary>
++/// U+0000 is an ordinary pattern character, and the end of the pattern is a
++/// separate condition from it.
++/// <para>
++/// The parser's cursor returns <c>'\0'</c> for "past the last character", and every
++/// end-of-pattern test used to compare against that sentinel. A pattern that merely
++/// <em>contained</em> a NUL therefore looked as though it had ended there: the
++/// "no letters" character class google.com compiles on its start page — whose first
++/// range runs from NUL to space — failed with <c>Unterminated character class</c> at
++/// the very first atom.
++/// </para>
++/// <para>
++/// It arrives as a decoded U+0000 because the page builds it with
++/// <c>new RegExp(<em>string</em>)</c>: the string literal's <c>\0</c> is consumed by
++/// the *string* grammar, never reaching the pattern grammar. So the two spellings are
++/// different inputs to this parser, and only the decoded one was broken — a regex
++/// literal keeps its backslash, and <c>[\0-…]</c> parsed correctly all along. Both are
++/// covered below.
++/// </para>
++/// <para>
++/// Every NUL here is written as a <c>\uXXXX</c> escape. Raw control bytes in the source
++/// would be invisible to a reviewer, and would make <c>git format-patch</c> treat this
++/// file as binary — which matters while the fix travels to the submodule as a patch.
++/// </para>
++/// </summary>
++public class NulCharacterTests
++{
++    /// <summary>
++    /// The reported pattern, decoded exactly as <c>new RegExp(string)</c> hands it over,
++    /// with one range per line so the leading NUL is legible.
++    /// </summary>
++    private const string GoogleNoLetterClass =
++        "^[" +
++        "\u0000- " + // NUL … space — the range that used to end the parse
++        "!-@" +          // U+0021 … U+0040
++        "[-`" +          // U+005B … U+0060
++        "{-¿" +          // U+007B … U+00BF
++        "×÷" +           // U+00D7 and U+00F7
++        "ʹ-˿" +          // U+02B9 … U+02FF
++        "\u2000-⯿" +   // U+2000 … U+2BFF
++        "]*$";
++
++    [Fact]
++    public void GoogleNoLetterClass_Compiles_AndMatchesOnlyNonLetters()
++    {
++        var re = new BroilerRegex(GoogleNoLetterClass);
++
++        Assert.True(re.IsMatch(" ,.!"));
++        Assert.True(re.IsMatch("\u0000"));
++        Assert.True(re.IsMatch("×÷"));
++        Assert.False(re.IsMatch("a"));
++        Assert.False(re.IsMatch("abc"));
++    }
++
++    /// <summary>
++    /// The two spellings of one class — a decoded NUL and the <c>\0</c> escape —
++    /// compile and agree. Only the first was broken.
++    /// </summary>
++    [Theory]
++    [InlineData("[\u0000- ]")]
++    [InlineData("[\\0- ]")]
++    public void NulStartedRange_MatchesControlsAndSpace(string pattern)
++    {
++        var re = new BroilerRegex(pattern);
++        Assert.True(re.IsMatch("\u0000"));
++        Assert.True(re.IsMatch(" "));
++        Assert.True(re.IsMatch("\n"));
++        Assert.False(re.IsMatch("a"));
++    }
++
++    [Fact]
++    public void NulInsideClass_IsAMember_NotTheEndOfTheClass()
++    {
++        var re = new BroilerRegex("[a\u0000b]");
++        Assert.True(re.IsMatch("\u0000"));
++        Assert.True(re.IsMatch("a"));
++        Assert.True(re.IsMatch("b"));
++        Assert.False(re.IsMatch("c"));
++    }
++
++    [Fact]
++    public void NulAsRangeEnd_IsARange_NotTheEndOfTheClass()
++    {
++        // '-' before a NUL is a range operator like any other: [\0-\0] is the
++        // one-member class, and the range is still validated for order.
++        Assert.True(new BroilerRegex("[\u0000-\u0000]").IsMatch("\u0000"));
++        Assert.Throws<RegexSyntaxException>(() => new BroilerRegex("[a-\u0000]"));
++    }
++
++    [Fact]
++    public void NulAsAtom_IsMatchedLiterally_AndDoesNotTruncateThePattern()
++    {
++        var re = new BroilerRegex("a\u0000b");
++        Assert.True(re.IsMatch("a\u0000b"));
++        Assert.False(re.IsMatch("ab"));
++
++        // Everything after the NUL is still parsed: the quantifier binds to 'b'.
++        var quantified = new BroilerRegex("^a\u0000b+$");
++        Assert.True(quantified.IsMatch("a\u0000bbb"));
++        Assert.False(quantified.IsMatch("a\u0000"));
++    }
++
++    [Fact]
++    public void NulSurvivesAlternationAndQuantifiers()
++    {
++        var re = new BroilerRegex("^(x\u0000|y)*$");
++        Assert.True(re.IsMatch("x\u0000y"));
++        Assert.False(re.IsMatch("x"));
++
++        Assert.True(new BroilerRegex("^\u0000*$").IsMatch("\u0000\u0000"));
++    }
++
++    [Fact]
++    public void NulInAGroupName_IsPartOfTheName()
++    {
++        var re = new BroilerRegex("(?<a\u0000b>x)");
++        Assert.Equal(1, re.GroupNames["a\u0000b"]);
++        Assert.Equal("x", re.Match("x").Groups[1].Value);
++    }
++
++    /// <summary>
++    /// The other half of telling end-of-pattern apart from the sentinel: a pattern
++    /// ending in a lone '\' has no character to escape. Reading it used to run off the
++    /// end of the string and raise <see cref="System.IndexOutOfRangeException"/> in
++    /// non-Unicode mode — an unhandled runtime fault where callers catch
++    /// <see cref="RegexSyntaxException"/>.
++    /// </summary>
++    [Theory]
++    [InlineData(null)]
++    [InlineData("u")]
++    public void TrailingBackslash_IsASyntaxError(string? flags)
++    {
++        Assert.Throws<RegexSyntaxException>(() => new BroilerRegex("a\\", flags));
++        Assert.Throws<RegexSyntaxException>(() => new BroilerRegex("[a\\", flags));
++    }
++
++    [Fact]
++    public void GenuinelyUnterminatedConstructs_AreStillReported()
++    {
++        // The end-of-pattern rewrite must not soften these: each really does end
++        // before its closer.
++        Assert.Throws<RegexSyntaxException>(() => new BroilerRegex("[a"));
++        Assert.Throws<RegexSyntaxException>(() => new BroilerRegex("[a-"));
++        Assert.Throws<RegexSyntaxException>(() => new BroilerRegex("(a"));
++        Assert.Throws<RegexSyntaxException>(() => new BroilerRegex("(?<name"));
++    }
++}
+diff --git a/Broiler.Regex/Parsing/RegexParser.cs b/Broiler.Regex/Parsing/RegexParser.cs
+index ce0fa5e..14ecbd0 100644
+--- a/Broiler.Regex/Parsing/RegexParser.cs
++++ b/Broiler.Regex/Parsing/RegexParser.cs
+@@ -116,8 +116,7 @@ public sealed class RegexParser
+         var terms = new List<RegexNode>();
+         while (true)
+         {
+-            var c = Peek();
+-            if (c is '\0' or '|' or ')')
++            if (AtEnd || Peek() is '|' or ')')
+                 break;
+             terms.Add(ParseTerm());
+         }
+@@ -254,6 +253,9 @@ public sealed class RegexParser
+ 
+     private RegexNode ParseAtom()
+     {
++        if (AtEnd)
++            throw new RegexSyntaxException("Unexpected end of atom", _pos);
++
+         var c = Peek();
+         switch (c)
+         {
+@@ -268,7 +270,6 @@ public sealed class RegexParser
+                 return ParseAtomEscape();
+             case ')':
+             case '|':
+-            case '\0':
+                 throw new RegexSyntaxException("Unexpected end of atom", _pos);
+             case '*':
+             case '+':
+@@ -431,9 +432,10 @@ public sealed class RegexParser
+ 
+         while (true)
+         {
+-            var c = Peek();
+-            if (c == '\0')
++            if (AtEnd)
+                 throw new RegexSyntaxException("Unterminated character class", _pos);
++
++            var c = Peek();
+             if (c == ']')
+             {
+                 _pos++;
+@@ -452,7 +454,7 @@ public sealed class RegexParser
+ 
+             // A range "a-z": only when '-' is followed by another class atom (not
+             // the closing ']') and both ends are literal code points.
+-            if (firstIsLiteral && Peek() == '-' && PeekAt(1) != ']' && PeekAt(1) != '\0')
++            if (firstIsLiteral && Peek() == '-' && HasAt(1) && PeekAt(1) != ']')
+             {
+                 _pos++; // consume '-'
+                 var second = ReadClassAtom(set, out var secondIsLiteral);
+@@ -528,6 +530,13 @@ public sealed class RegexParser
+     /// <summary>Reads a CharacterEscape (the '\' already consumed): \n \r \xHH \uHHHH \u{…} \cX \0 identity.</summary>
+     private int ReadCharacterEscape()
+     {
++        // A '\' with nothing after it: \ is never a pattern character of its own
++        // (ECMA-262 §22.2.1 — every production that admits it consumes a second
++        // character). Reported as a syntax error rather than running off the end of
++        // the string in ReadSourceCodePoint below.
++        if (AtEnd)
++            throw new RegexSyntaxException("Trailing '\\' at end of pattern", _pos);
++
+         var c = Peek();
+         switch (c)
+         {
+@@ -648,7 +657,7 @@ public sealed class RegexParser
+             throw new RegexSyntaxException("Expected '{' after \\p", _pos);
+         _pos++;
+         var sb = new StringBuilder();
+-        while (Peek() != '}' && Peek() != '\0')
++        while (!AtEnd && Peek() != '}')
+             sb.Append(_src[_pos++]);
+         if (Peek() != '}')
+             throw new RegexSyntaxException("Unterminated \\p{…}", _pos);
+@@ -679,7 +688,7 @@ public sealed class RegexParser
+     private string ReadGroupName()
+     {
+         var sb = new StringBuilder();
+-        while (Peek() != '>' && Peek() != '\0')
++        while (!AtEnd && Peek() != '>')
+         {
+             // RegExpIdentifierName allows \u escapes; decode them so the stored
+             // name matches a JS string key.
+@@ -702,6 +711,17 @@ public sealed class RegexParser
+ 
+     // ----- Low-level cursor helpers ------------------------------------------
+ 
++    /// <summary>
++    /// True once the cursor is past the last character. Every end-of-pattern test
++    /// goes through this rather than through <see cref="Peek"/>'s <c>'\0'</c>: U+0000
++    /// is a perfectly ordinary pattern character, so comparing against the sentinel
++    /// would end the parse in the middle of a pattern that merely contains one.
++    /// </summary>
++    private bool AtEnd => _pos >= _src.Length;
++
++    /// <summary>True when a character exists <paramref name="offset"/> ahead of the cursor.</summary>
++    private bool HasAt(int offset) => _pos + offset < _src.Length;
++
+     private char Peek() => _pos < _src.Length ? _src[_pos] : '\0';
+     private char PeekAt(int offset) => _pos + offset < _src.Length ? _src[_pos + offset] : '\0';
+ 
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # Submodule patches waiting to be applied
 
-**Five patches are waiting on a maintainer.** See the index below.
+**Six patches are waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -51,6 +51,7 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD && echo "live on CI"
 | `0003` | `Broiler.JS` | Report promises rejected with nobody to handle them |
 | `0004` | `Broiler.JS` | Record where an error was raised, not where its factory was wired |
 | `0005` | `Broiler.DOM` | Parse a `<noscript>` body as raw text, as a scripting-enabled parser must |
+| `0006` | `Broiler.JS/Broiler.Regex` | Tell the end of a pattern apart from a NUL inside one |
 
 ### `0001` — a closure a direct eval created lost the eval site's bindings
 
@@ -255,6 +256,53 @@ rendering half is already live in this repository.
 
 **When it lands upstream:** bump the pointer and delete this patch. The
 `CaptureService` skip stays: it is about that host's regex extraction, not the parser.
+
+### `0006` — a NUL inside a pattern looked exactly like the end of one
+
+`Broiler.Regex`'s cursor reports "past the last character" by returning `'\0'` from
+`Peek()`, and every end-of-pattern test compared against that sentinel. U+0000 is an
+ordinary pattern character, so a pattern that merely *contained* one appeared to end
+there. google.com's start page compiles a "no letters" character class whose first
+range runs from NUL to space, and it died on the very first atom with
+`Unterminated character class`.
+
+**It arrives decoded**, which is the part worth keeping straight: the page builds the
+class with `new RegExp(`*string*`)`, so the string literal's `\0` is consumed by the
+*string* grammar and a real U+0000 is what reaches the pattern grammar. The escaped
+spelling a regex **literal** preserves, `[\0-…]`, parsed correctly all along — the two
+are different inputs to this parser, and only the decoded one was broken. Both are
+covered by the tests, so the distinction cannot quietly rot.
+
+Nor was it confined to character classes: a NUL as an atom, as a range end, in a group
+name or inside `\p{…}` truncated the parse the same way. Every end-of-pattern test now
+goes through an explicit `AtEnd` (plus `HasAt` for the one lookahead that wanted bounds
+rather than a value); `Peek()` still returns `'\0'` past the end, but nothing reads it
+as a signal.
+
+**Separating the two fixed the mirror-image bug at the real end of input.** A pattern
+ending in a lone `\` had no end-of-input guard on the path that reads the escaped
+character, so it ran off the end of the string and raised `IndexOutOfRangeException` in
+non-Unicode mode — an unhandled runtime fault where every caller catches
+`RegexSyntaxException`. It is now the syntax error it always was.
+
+**A nested submodule.** `Broiler.Regex` sits inside `Broiler.JS`, so applying this one
+means committing in `Broiler.JS/Broiler.Regex`, pushing, bumping the gitlink **in
+`Broiler.JS`**, and only then bumping `Broiler.JS` in this repository — two pointer
+bumps, not one.
+
+**No main-repo fallback, and none needed.** `JSRegExp.TryBuildBroilerForGaps` already
+wraps the parse in a `try`/`catch` and falls back to the .NET translator on failure, so
+the un-patched engine mis-routes this pattern rather than breaking the page — the
+exception is real but swallowed, which is why it surfaced from a debugger rather than
+as a page error. The fix cannot be staged at a main-repo layer either: the parser is
+the whole of it, and nothing here can stand in for it.
+
+**Not listed for the pixel suites.** Routing to `Broiler.Regex` happens only for
+patterns that exercise a JS/.NET semantic gap (`GapScan`), and this class has none — it
+compiles through the .NET translator with or without the patch, so no pixel moves
+either way. Its behaviour is unit-tested inside the patch (`NulCharacterTests`).
+
+**When it lands upstream:** bump both pointers and delete this patch.
 
 ## A stale entry in the apply script is not inert
 

--- a/src/Broiler.Cli.Tests/WindowIsTheGlobalObjectTests.cs
+++ b/src/Broiler.Cli.Tests/WindowIsTheGlobalObjectTests.cs
@@ -50,7 +50,91 @@ public sealed class WindowIsTheGlobalObjectTests
         Assert.Equal("true", ValueOf(context, "window === globalThis"));
         Assert.Equal("true", ValueOf(context, "window.self === window"));
         Assert.Equal("true", ValueOf(context, "window.parent === window"));
+        Assert.Equal("true", ValueOf(context, "window.top === window"));
         Assert.Equal("true", ValueOf(context, "document.defaultView === window"));
+    }
+
+    /// <summary>
+    /// <c>top</c> resolves unqualified. It was the one member of the
+    /// <c>self</c>/<c>parent</c>/<c>top</c> trio never registered on the main window — only
+    /// sub-documents got one (<c>SubWindowBinding</c>), and <c>WindowContextManager</c> saved
+    /// and restored a global that had never been defined in the first place.
+    /// <para>
+    /// Because <c>window</c> is the global object, an unregistered member is not an undefined
+    /// property but a <c>ReferenceError</c>, and that aborts the entire <c>&lt;script&gt;</c>.
+    /// A framing check is the first thing a page's boilerplate runs, so the whole bundle went
+    /// down with it: google.com's One-Google-bar script raised
+    /// <c>ReferenceError: top is not defined</c> and registered none of its listeners.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void Top_ResolvesUnqualified_AndIsTheSameWindow()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("true", ValueOf(context, "top === window"));
+        Assert.Equal("true", ValueOf(context, "top === self"));
+        Assert.Equal("true", ValueOf(context, "top === parent"));
+
+        // The framing check itself, in the shape pages actually write it: it must run to
+        // completion, and a top-level document must not think it is framed.
+        var thrown = Record.Exception(() => context.Eval(
+            "if (top != self) { window.__framed = true; } window.__checked = true;"));
+
+        Assert.Null(thrown);
+        Assert.Equal("true", ValueOf(context, "window.__checked"));
+        Assert.Equal("undefined", ValueOf(context, "window.__framed"));
+    }
+
+    /// <summary>
+    /// <c>top</c> reaches globals the page defined, the same way <c>parent</c> does — the
+    /// reason both are bound to the global object rather than to a bare stand-in window.
+    /// </summary>
+    [Fact]
+    public void Top_ReachesPageGlobals()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        context.Eval("window.notify = function() { return 'notified'; };");
+
+        Assert.Equal("notified", ValueOf(context, "top.notify()"));
+        Assert.Equal("true", ValueOf(context, "typeof top.document === 'object'"));
+    }
+
+    /// <summary>
+    /// A framed document's <c>top</c> is the main window, and the main document still has its
+    /// own <c>top</c> afterwards. <c>WindowContextManager</c> swaps the global <c>top</c> while a
+    /// sub-window's script runs and restores what was there before; the main window had none to
+    /// begin with, so the restore put back <c>undefined</c>. From the first frame onwards the
+    /// main document's <c>top</c> was therefore wrong in the quieter way — no longer a
+    /// <c>ReferenceError</c>, just not the window.
+    /// </summary>
+    [Fact]
+    public void Top_FromInsideAFrame_IsTheMainWindow_AndSurvivesTheContextSwitch()
+    {
+        const string html = """
+<!DOCTYPE html>
+<html><body>
+<iframe id="frame" srcdoc="<!DOCTYPE html><html><body><script>top.__markedByFrame = 'yes';</script></body></html>"></iframe>
+</body></html>
+""";
+
+        using var context = new JSContext();
+        using var bridge = new DomBridge();
+        bridge.Attach(context, html, "https://example.com/index.html");
+        bridge.FireWindowLoadEvent();
+        bridge.FlushTimers();
+
+        // The frame reached the main window through `top`, so the write landed here.
+        Assert.Equal("yes", ValueOf(context, "window.__markedByFrame"));
+
+        // …and the main document's own `top` is intact, not the undefined the restore left.
+        Assert.Equal("true", ValueOf(context, "top === window"));
+        Assert.Equal("true", ValueOf(context, "document.getElementById('frame').contentWindow.top === window"));
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
@@ -80,6 +80,18 @@ public sealed partial class DomBridge
         // window.self — refers to this window
         window.FastAddValue((KeyString)"self", window, JSPropertyAttributes.EnumerableConfigurableValue);
 
+        // window.top — the topmost browsing context. This document is the top-level one, so
+        // `top`, `parent` and `self` are all this window; a sub-document's window instead gets
+        // a `top` pointing back here (SubWindowBinding). It was the one member of that trio
+        // never registered, and because `window` IS the global object that made the unqualified
+        // `top` a ReferenceError rather than merely an undefined property — which aborts the
+        // whole <script>, not just the statement that read it. Framing checks spell it
+        // unqualified (`if (top != self)`), so this is the first thing a page's boilerplate
+        // touches: google.com's One-Google-bar bundle died on it, taking with it every listener
+        // the rest of that script would have registered.
+        window.FastAddValue((KeyString)"top", globalThis, JSPropertyAttributes.EnumerableConfigurableValue);
+        context["top"] = globalThis;
+
         // document.defaultView — returns the window object
         document.FastAddValue((KeyString)"defaultView", window, JSPropertyAttributes.EnumerableConfigurableValue);
         context["console"] = console;


### PR DESCRIPTION
## Summary

The regex parser could not distinguish a U+0000 (NUL) character inside a pattern from the end of the pattern itself. The cursor reports "past the last character" by returning `'\0'` from `Peek()`, and every end-of-pattern test compared against that sentinel. This caused patterns containing a NUL to appear truncated. Additionally, a pattern ending in a lone backslash would run off the end of the string instead of reporting a syntax error.

## Changes

**`Broiler.Regex/Parsing/RegexParser.cs`**
- Added explicit `AtEnd` property to test whether the cursor is past the last character, separate from the `'\0'` sentinel value
- Added `HasAt(int offset)` helper to check bounds for lookahead operations
- Routed all end-of-pattern tests through `AtEnd` instead of comparing `Peek()` against `'\0'`
- Added EOF guard in `ReadCharacterEscape()` to catch trailing backslash and report it as a syntax error instead of raising `IndexOutOfRangeException`
- Updated character class parsing to use `AtEnd` and `HasAt` for bounds checking

**`Broiler.Regex.Tests/NulCharacterTests.cs`** (new file)
- Comprehensive test suite covering NUL in various contexts: as a class member, range endpoint, atom, in group names, and inside `\p{…}` constructs
- Tests for the real-world case: google.com's "no letters" character class with a NUL-to-space range
- Tests for trailing backslash syntax errors in both Unicode and non-Unicode modes
- Verification that genuinely unterminated constructs are still properly reported

**`src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs`**
- Registered `window.top` on the main window, binding it to the global object (matching `self` and `parent`)
- Added documentation explaining why `top` was missing and its impact on page initialization

**`src/Broiler.Cli.Tests/WindowIsTheGlobalObjectTests.cs`**
- Added assertion for `window.top === window`
- Added three new test methods covering `top` resolution, access to page globals through `top`, and `top` behavior across frame boundaries

**`patches/0006-regex-nul-vs-end-of-pattern.patch`** (new file)
- Patch file capturing the regex parser fix for application to the `Broiler.JS/Broiler.Regex` submodule

**`patches/README.md`**
- Updated patch count and added entry for patch 0006

**`CHANGELOG.md`**
- Documented both fixes: the regex parser NUL handling and the `window.top` registration

## Implementation Details

The fix separates the two concerns:
- `AtEnd` explicitly checks `_pos >= _src.Length` for end-of-pattern conditions
- `Peek()` continues to return `'\0'` past the end, but nothing interprets that as a signal anymore
- This allows U+0000 to be treated as an ordinary pattern character throughout

The `window.top` fix ensures that framing checks (`if (top != self)`) in page boilerplate can execute without raising `ReferenceError`, which was aborting entire scripts and preventing event listeners from being registered.

## Notes

The regex parser fix is delivered as a patch (`0006`) because the `Broiler.Regex` submodule remote is outside the session's GitHub scope. The patch is ready for a maintainer to apply to `Broiler.JS/Broiler.Regex` and bump the pointer. The `window.top` fix is applied directly in the main repository.

https://claude.ai/code/session_01H8PdhwQiX8v4Rot16dE1Ku