### PR TITLE
Fix four script aborts on google.com, and the gaps found beside them

### DIFF
--- a/src/Broiler.Cli.Tests/ApiBaselines/Broiler.HtmlBridge.Core.PublicApi.txt
+++ b/src/Broiler.Cli.Tests/ApiBaselines/Broiler.HtmlBridge.Core.PublicApi.txt
@@ -19,10 +19,12 @@ TYPE Broiler.HtmlBridge.Core.Diagnostics.BridgePhaseTrace+Phases
 TYPE Broiler.HtmlBridge.Core.Diagnostics.BridgePhaseTrace+Scope : System.IDisposable
   method System.Void Dispose()
 TYPE Broiler.HtmlBridge.Dom.DomBridgeRuntimeLimits
+  field const System.Double AsyncDrainVirtualTimeBudgetMs
   field const System.Int32 AsyncDrainIterationLimit
 TYPE Broiler.HtmlBridge.Dom.IDomBridgeRuntime
   method Broiler.Dom.DomDocument GetRenderDocument()
   method System.Boolean FlushTimerStep()
+  method System.Boolean HasPendingTimersDueBy(System.Double)
   method System.String SerializeToHtml()
   method System.Void Attach(Broiler.JavaScript.Engine.JSContext, System.String)
   method System.Void Attach(Broiler.JavaScript.Engine.JSContext, System.String, System.String)

--- a/src/Broiler.Cli.Tests/ApiBaselines/Broiler.HtmlBridge.Dom.PublicApi.txt
+++ b/src/Broiler.Cli.Tests/ApiBaselines/Broiler.HtmlBridge.Dom.PublicApi.txt
@@ -4,9 +4,11 @@
 TYPE Broiler.HtmlBridge.DomBridge : Broiler.HtmlBridge.Dom.IDomBridgeRuntime, System.IDisposable
   ctor ()
   ctor (Broiler.HtmlBridge.DomBridgeSessionOptions)
+  field const System.Double AsyncDrainVirtualTimeBudgetMs
   field const System.Int32 AsyncDrainIterationLimit
   method Broiler.Dom.DomDocument GetRenderDocument()
   method System.Boolean FlushTimerStep()
+  method System.Boolean HasPendingTimersDueBy(System.Double)
   method System.Collections.Generic.IReadOnlyList<Broiler.HtmlBridge.DomBridge+CheckLayoutAssertion> EvaluateCheckLayoutAssertions()
   method System.String SerializeToHtml()
   method System.Void ApplyStyleContentSecurityPolicy(Broiler.HtmlBridge.Scripting.ContentSecurityPolicy)

--- a/src/Broiler.Cli.Tests/AsyncDrainDiagnosticTests.cs
+++ b/src/Broiler.Cli.Tests/AsyncDrainDiagnosticTests.cs
@@ -5,15 +5,25 @@ using Xunit;
 namespace Broiler.Cli.Tests;
 
 /// <summary>
-/// Phase 8 item 3: async-drain-limit exhaustion is an explicit diagnostic, not a silent stop.
-/// <see cref="ScriptEngine.DrainAsyncWork"/> loops up to
-/// <c>DomBridgeRuntimeLimits.AsyncDrainIterationLimit</c> settling microtasks/timers; when a runaway
-/// loop (e.g. a self-rescheduling <c>setTimeout</c>) never settles, the loop used to fall out
-/// silently. It now sets <see cref="ScriptEngine.AsyncDrainLimitExhausted"/> (and logs a warning).
+/// Phase 8 item 3: async-drain-limit exhaustion is an explicit diagnostic, not a silent stop. When a
+/// runaway loop (e.g. a self-rescheduling <c>setTimeout</c>) never settles, the drain used to fall
+/// out silently; it now sets <see cref="ScriptEngine.AsyncDrainLimitExhausted"/> and logs a warning.
+/// <para>
+/// The drain follows work up to <c>DomBridgeRuntimeLimits.AsyncDrainVirtualTimeBudgetMs</c> on the
+/// event loop's virtual clock, rather than until nothing is pending. "Nothing pending" is
+/// unreachable for a page holding a <c>setInterval</c> — there is always a next tick — so every such
+/// page used to burn the whole iteration budget and then be reported as a probable runaway. The
+/// horizon retires that case without retiring the diagnostic: work that keeps regenerating at the
+/// current instant never moves the clock, so it still exhausts the iterations and is still flagged.
+/// </para>
 /// </summary>
 public class AsyncDrainDiagnosticTests
 {
     private const string Url = "file:///drain.html";
+
+    /// <summary>A document with an element the timers can write into, so what ran is visible in the
+    /// serialized output.</summary>
+    private const string Page = "<!DOCTYPE html><html><head></head><body><div id=\"out\"></div></body></html>";
 
     [Fact]
     public void NormalScript_DoesNotFlagExhaustion()
@@ -28,6 +38,86 @@ public class AsyncDrainDiagnosticTests
         Assert.NotNull(output);
         Assert.False(engine.AsyncDrainLimitExhausted,
             "a script whose async work settles must not flag drain-limit exhaustion.");
+    }
+
+    /// <summary>
+    /// An interval is not a runaway loop. It always has a next tick, so the drain's old
+    /// "keep going until nothing is pending" test could never come true on a page holding one — every
+    /// such page burnt the whole iteration budget and was then reported as a probable runaway. That
+    /// is most real pages; google.com's home page was one.
+    /// </summary>
+    [Fact]
+    public void Interval_DoesNotFlagExhaustion()
+    {
+        var engine = new ScriptEngine();
+        var scripts = new List<string> { "setInterval(function(){ document.getElementById('out').textContent = 'tick'; }, 100);" };
+        const string html = Page;
+
+        var output = engine.Execute(scripts, new List<string>(), html, Url);
+
+        Assert.NotNull(output);
+        Assert.False(engine.AsyncDrainLimitExhausted,
+            "an ordinary repeating interval must not be reported as a runaway loop.");
+    }
+
+    /// <summary>
+    /// The horizon is what stops it, and it stops at a definite point rather than wherever the
+    /// iteration budget happened to run out. With a 5000 ms budget a 1000 ms interval is due at
+    /// 1000…5000 inclusive — five ticks — and its sixth tick belongs to a page that kept running.
+    /// </summary>
+    [Fact]
+    public void Interval_RunsUpToTheHorizonAndNoFurther()
+    {
+        var engine = new ScriptEngine();
+        var scripts = new List<string>
+        {
+            "window.__n = 0; setInterval(function(){ window.__n++; document.getElementById('out').textContent = String(window.__n); }, 1000);"
+        };
+        const string html = Page;
+
+        var output = engine.Execute(scripts, new List<string>(), html, Url);
+
+        Assert.NotNull(output);
+        Assert.Contains(">5<", output);
+        Assert.False(engine.AsyncDrainLimitExhausted);
+    }
+
+    /// <summary>A timeout inside the horizon still runs — the drain did not simply stop early.</summary>
+    [Fact]
+    public void TimeoutWithinTheHorizon_StillRuns()
+    {
+        var engine = new ScriptEngine();
+        var scripts = new List<string> { "setTimeout(function(){ document.getElementById('out').textContent = 'late'; }, 4000);" };
+        const string html = Page;
+
+        var output = engine.Execute(scripts, new List<string>(), html, Url);
+
+        Assert.NotNull(output);
+        Assert.Contains(">late<", output);
+        Assert.False(engine.AsyncDrainLimitExhausted);
+    }
+
+    /// <summary>
+    /// A timeout past the horizon does not run, and that is not an error: a capture is a moment
+    /// shortly after load, and a minute-long refresh timer belongs to a session it does not cover.
+    /// </summary>
+    [Fact]
+    public void TimeoutBeyondTheHorizon_DoesNotRun_AndIsNotFlagged()
+    {
+        var engine = new ScriptEngine();
+        var scripts = new List<string>
+        {
+            "document.getElementById('out').textContent = 'before';" +
+            "setTimeout(function(){ document.getElementById('out').textContent = 'after'; }, 60000);"
+        };
+        const string html = Page;
+
+        var output = engine.Execute(scripts, new List<string>(), html, Url);
+
+        Assert.NotNull(output);
+        Assert.Contains(">before<", output);
+        Assert.DoesNotContain(">after<", output);
+        Assert.False(engine.AsyncDrainLimitExhausted);
     }
 
     [Fact]

--- a/src/Broiler.Cli.Tests/DocumentGetElementsByNameTests.cs
+++ b/src/Broiler.Cli.Tests/DocumentGetElementsByNameTests.cs
@@ -1,0 +1,147 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// <c>document.getElementsByName(name)</c> — HTML §3.1.5: the elements whose <c>name</c>
+/// <em>attribute</em> is identical to the argument, in tree order.
+/// <para>
+/// It was not implemented at all, and a missing method on the document reads as
+/// <see langword="undefined"/> rather than as absent, so calling it threw
+/// <c>TypeError: undefined is not a function</c> — which aborts the whole <c>&lt;script&gt;</c>, not
+/// the one statement.
+/// </para>
+/// <para>
+/// google.com's homepage bundle locates its search form this way, having looked for a form by id
+/// first: <c>c=["f","gs"];for(var d=0;b=c[d++];)if(b=document.getElementsByName(b)[0])return b</c>.
+/// Failing to find the form is not a cosmetic loss — it is the search box.
+/// </para>
+/// </summary>
+public sealed class DocumentGetElementsByNameTests
+{
+    private const string Page = """
+        <!doctype html><html><body>
+          <form name="gs" id="searchform">
+            <input name="q" id="first-q">
+            <input name="q" id="second-q">
+            <textarea name="q" id="third-q"></textarea>
+            <input name="btnK">
+            <input id="no-name">
+            <input name="Q" id="capital-q">
+          </form>
+          <div name="gs" id="decoy-div"></div>
+          <a name="anchor-style" id="named-anchor"></a>
+        </body></html>
+        """;
+
+    private static (JSContext Context, DomBridge Bridge) Attach()
+    {
+        var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, Page, "https://www.google.com/");
+        return (context, bridge);
+    }
+
+    private static string Eval(JSContext context, string expression) => context.Eval(expression).ToString();
+
+    private static string IdsOf(JSContext context, string name) => Eval(context, $$"""
+        (function() {
+            var found = document.getElementsByName('{{name}}');
+            return Array.prototype.map.call(found, function(el) { return el.id; }).join(',');
+        })()
+        """);
+
+    /// <summary>The homepage bundle's form lookup, run as it spells it.</summary>
+    [Fact]
+    public void GetElementsByName_FindsTheSearchForm_TheWayTheHomepageBundleDoes()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        var thrown = Record.Exception(() => context.Eval("""
+            globalThis.__form = (function() {
+                var b, c = ['f', 'gs'];
+                for (var d = 0; b = c[d++];)
+                    if (b = document.getElementsByName(b)[0]) return b;
+                return null;
+            })();
+            """));
+
+        Assert.Null(thrown);
+        Assert.Equal("searchform", Eval(context, "String(globalThis.__form && globalThis.__form.id)"));
+    }
+
+    /// <summary>Every element carrying the attribute, in tree order — not just the first, not just controls.</summary>
+    [Fact]
+    public void GetElementsByName_ReturnsEveryMatchInTreeOrder()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("first-q,second-q,third-q", IdsOf(context, "q"));
+    }
+
+    /// <summary>
+    /// Not confined to form controls: HTML says "all the HTML elements" with the attribute, so a
+    /// <c>div</c> or an anchor carrying one counts.
+    /// </summary>
+    [Theory]
+    [InlineData("gs", "searchform,decoy-div")]
+    [InlineData("anchor-style", "named-anchor")]
+    [InlineData("btnK", "")]
+    public void GetElementsByName_MatchesAnyElementCarryingTheAttribute(string name, string expectedIds)
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        // 'btnK' is present but its element has no id, so the joined ids are empty while the match
+        // itself is not — length is asserted separately below.
+        if (expectedIds.Length > 0)
+            Assert.Equal(expectedIds, IdsOf(context, name));
+        else
+            Assert.Equal("1", Eval(context, $"String(document.getElementsByName('{name}').length)"));
+    }
+
+    /// <summary>The value is matched exactly — HTML compares it identically, so case matters.</summary>
+    [Fact]
+    public void GetElementsByName_ComparesTheValueCaseSensitively()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("first-q,second-q,third-q", IdsOf(context, "q"));
+        Assert.Equal("capital-q", IdsOf(context, "Q"));
+    }
+
+    /// <summary>A name nothing carries is an empty result, not a throw and not a null.</summary>
+    [Theory]
+    [InlineData("nothing-has-this")]
+    [InlineData("")]
+    public void GetElementsByName_WithNoMatch_IsEmpty(string name)
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("0", Eval(context, $"String(document.getElementsByName('{name}').length)"));
+    }
+
+    /// <summary>It is a function on the document, alongside the query methods it sits with.</summary>
+    [Fact]
+    public void GetElementsByName_IsRegisteredOnTheDocument()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("function", Eval(context, "typeof document.getElementsByName"));
+        Assert.Equal("function", Eval(context, "typeof document.getElementsByClassName"));
+        Assert.Equal("function", Eval(context, "typeof document.getElementsByTagName"));
+    }
+}

--- a/src/Broiler.Cli.Tests/DocumentLocationTests.cs
+++ b/src/Broiler.Cli.Tests/DocumentLocationTests.cs
@@ -1,0 +1,122 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// <c>document.location</c> is the same <c>Location</c> object as <c>window.location</c>
+/// (HTML §3.1.5 — the getter returns the document's relevant global object's Location).
+/// <para>
+/// It was registered on the window alone. Reading it therefore did not yield a missing property but
+/// <see langword="undefined"/>, and the first member access on that threw
+/// <c>Cannot get property protocol of undefined</c> — which aborts the entire <c>&lt;script&gt;</c>,
+/// not the one statement, taking every function it would have defined and every listener it would
+/// have registered with it.
+/// </para>
+/// <para>
+/// google.com's One-Google-bar bundle builds its own origin with
+/// <c>dF=function(){var a=document.location;return a.protocol+"//"+a.host}</c>, so it died there.
+/// That is the same bundle <c>window.top</c> was fixed for: this is the next thing it reached once
+/// <c>top</c> resolved, which is why the assertions below run the spelling verbatim rather than only
+/// checking that the property exists.
+/// </para>
+/// </summary>
+public sealed class DocumentLocationTests
+{
+    private const string PageUrl = "https://www.google.com/search?q=broiler#frag";
+
+    private static (JSContext Context, DomBridge Bridge) Attach(string url = PageUrl)
+    {
+        var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, "<!doctype html><html><body></body></html>", url);
+        return (context, bridge);
+    }
+
+    /// <summary>The One-Google-bar origin helper, run as the bundle spells it.</summary>
+    [Fact]
+    public void DocumentLocation_YieldsAnOrigin_TheWayTheOneGoogleBarBuildsIt()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        var thrown = Record.Exception(() => context.Eval("""
+            globalThis.__origin = (function() {
+                var a = document.location;
+                return a.protocol + '//' + a.host;
+            })();
+            """));
+
+        Assert.Null(thrown);
+        Assert.Equal("https://www.google.com", context.Eval("String(globalThis.__origin)").ToString());
+    }
+
+    /// <summary>
+    /// Identity, not a copy: pages compare the two, and a second Location object would drift from
+    /// the first the moment either grew a mutable member.
+    /// </summary>
+    [Fact]
+    public void DocumentLocation_IsTheSameObjectAsWindowLocation()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("true", context.Eval("String(document.location === window.location)").ToString());
+        Assert.Equal("true", context.Eval("String(document.location === location)").ToString());
+    }
+
+    /// <summary>Every member the window's Location carries is reachable through the document's.</summary>
+    [Theory]
+    [InlineData("protocol", "https:")]
+    [InlineData("host", "www.google.com")]
+    [InlineData("hostname", "www.google.com")]
+    [InlineData("pathname", "/search")]
+    [InlineData("search", "?q=broiler")]
+    [InlineData("hash", "#frag")]
+    [InlineData("origin", "https://www.google.com")]
+    [InlineData("href", PageUrl)]
+    public void DocumentLocation_ExposesTheSameMembers(string member, string expected)
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal(expected, context.Eval($"String(document.location.{member})").ToString());
+    }
+
+    /// <summary>
+    /// A framed document shares its own window's Location, not the top-level one — a page inside a
+    /// frame reads <c>document.location</c> exactly as a top-level page does, and reading it must
+    /// not throw there either. A <c>srcdoc</c> frame is used because it is the frame that actually
+    /// gets a browsing context with no network: its document URL is <c>about:srcdoc</c>.
+    /// </summary>
+    [Fact]
+    public void SubDocumentLocation_IsTheFramesOwnLocation()
+    {
+        var context = new JSContext();
+        var bridge = new DomBridge();
+        using var _ = context;
+        using var __ = bridge;
+        bridge.Attach(
+            context,
+            "<!doctype html><html><body><iframe id='f' srcdoc='<p>inner</p>'></iframe></body></html>",
+            PageUrl);
+        bridge.FireWindowLoadEvent();
+        bridge.FlushTimers();
+
+        var thrown = Record.Exception(() => context.Eval("""
+            var w = document.getElementById('f').contentWindow;
+            globalThis.__same = String(w.document.location === w.location);
+            globalThis.__href = String(w.document.location.href);
+            globalThis.__isTop = String(w.document.location === document.location);
+            """));
+
+        Assert.Null(thrown);
+        Assert.Equal("true", context.Eval("String(globalThis.__same)").ToString());
+        Assert.Equal("about:srcdoc", context.Eval("String(globalThis.__href)").ToString());
+        Assert.Equal("false", context.Eval("String(globalThis.__isTop)").ToString());
+    }
+}

--- a/src/Broiler.Cli.Tests/ElementGetElementsByClassNameTests.cs
+++ b/src/Broiler.Cli.Tests/ElementGetElementsByClassNameTests.cs
@@ -1,0 +1,142 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// <c>getElementsByClassName</c> is defined on <c>Element</c> as well as on <c>Document</c>
+/// (DOM §4.9), and only the document half was registered.
+/// <para>
+/// On an element it was therefore <see langword="undefined"/>, and calling it threw
+/// <c>TypeError: undefined is not a function</c> — which aborts the entire
+/// <c>&lt;script&gt;</c>, not the one statement. Scoping a class lookup to a container is how pages
+/// narrow a search, so this was not an obscure spelling: google.com's One-Google-bar bundle writes
+/// <c>d.getElementsByClassName("gb_C")[0]||d</c>, and died there once
+/// <c>document.location</c> let it get that far.
+/// </para>
+/// </summary>
+public sealed class ElementGetElementsByClassNameTests
+{
+    private const string Page = """
+        <!doctype html><html><body>
+          <div id="root" class="gb_C">
+            <span id="a" class="gb_C"></span>
+            <span id="b" class="other gb_C trailing"></span>
+            <div id="nested"><span id="c" class="gb_C"></span></div>
+            <span id="d" class="gb_Cx"></span>
+            <span id="e" class="other"></span>
+            <span id="multi" class="alpha beta"></span>
+          </div>
+          <span id="outside" class="gb_C"></span>
+        </body></html>
+        """;
+
+    private static (JSContext Context, DomBridge Bridge) Attach()
+    {
+        var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, Page, "https://www.google.com/");
+        return (context, bridge);
+    }
+
+    private static string Eval(JSContext context, string expression) => context.Eval(expression).ToString();
+
+    /// <summary>The One-Google-bar lookup, run as the bundle spells it.</summary>
+    [Fact]
+    public void ElementGetElementsByClassName_ScopesTheLookup_TheWayTheOneGoogleBarDoes()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        var thrown = Record.Exception(() => context.Eval("""
+            var d = document.getElementById('root');
+            globalThis.__picked = (d.getElementsByClassName('gb_C')[0] || d).id;
+            """));
+
+        Assert.Null(thrown);
+        Assert.Equal("a", Eval(context, "String(globalThis.__picked)"));
+    }
+
+    /// <summary>
+    /// Descendants only, in document order — the element itself carries the class and must not be in
+    /// its own result, and an element outside the subtree is out of scope.
+    /// </summary>
+    [Fact]
+    public void ElementGetElementsByClassName_ReturnsDescendantsInDocumentOrder()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        var ids = Eval(context, """
+            (function() {
+                var found = document.getElementById('root').getElementsByClassName('gb_C');
+                return Array.prototype.map.call(found, function(el) { return el.id; }).join(',');
+            })()
+            """);
+
+        // 'root' itself is excluded, 'outside' is out of the subtree, 'd' is a different class
+        // ('gb_Cx' — a prefix, not the same name), and 'c' is found through a nested parent.
+        Assert.Equal("a,b,c", ids);
+    }
+
+    /// <summary>The argument is a set of names: an element must carry every one of them.</summary>
+    [Theory]
+    [InlineData("alpha", "multi")]
+    [InlineData("beta", "multi")]
+    [InlineData("alpha beta", "multi")]
+    [InlineData("beta alpha", "multi")]
+    [InlineData("alpha gamma", "")]
+    [InlineData("gb_Cx", "d")]
+    [InlineData("nomatch", "")]
+    [InlineData("", "")]
+    public void ElementGetElementsByClassName_RequiresEveryNameInTheSet(string query, string expectedIds)
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        var ids = Eval(context, $$"""
+            (function() {
+                var found = document.getElementById('root').getElementsByClassName('{{query}}');
+                return Array.prototype.map.call(found, function(el) { return el.id; }).join(',');
+            })()
+            """);
+
+        Assert.Equal(expectedIds, ids);
+    }
+
+    /// <summary>
+    /// The document half keeps working, and the element half agrees with it when the search is rooted
+    /// at an ancestor of every match — body's descendants are the whole set here (root, a, b, c and
+    /// outside all carry the class). Rooting at <c>#root</c> is what narrows it, and that is the
+    /// difference the element half exists to express.
+    /// </summary>
+    [Fact]
+    public void DocumentAndElementHalvesAgree()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("5", Eval(context, "String(document.getElementsByClassName('gb_C').length)"));
+        Assert.Equal("5", Eval(context, "String(document.body.getElementsByClassName('gb_C').length)"));
+        Assert.Equal("3", Eval(context, "String(document.getElementById('root').getElementsByClassName('gb_C').length)"));
+    }
+
+    /// <summary>It is a function on every element wrapper, not only on the one the page happened to ask.</summary>
+    [Fact]
+    public void EveryElementCarriesTheMethod()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("function", Eval(context, "typeof document.body.getElementsByClassName"));
+        Assert.Equal("function", Eval(context, "typeof document.documentElement.getElementsByClassName"));
+        Assert.Equal("function", Eval(context, "typeof document.createElement('div').getElementsByClassName"));
+        Assert.Equal("function", Eval(context, "typeof document.getElementById('e').getElementsByClassName"));
+    }
+}

--- a/src/Broiler.Cli.Tests/ElementGetElementsByClassNameTests.cs
+++ b/src/Broiler.Cli.Tests/ElementGetElementsByClassNameTests.cs
@@ -126,6 +126,66 @@ public sealed class ElementGetElementsByClassNameTests
         Assert.Equal("3", Eval(context, "String(document.getElementById('root').getElementsByClassName('gb_C').length)"));
     }
 
+    /// <summary>
+    /// The document half takes the same set of names. It used to read its argument as a single class,
+    /// so a multi-class query matched only an element whose class attribute was that literal string —
+    /// which is to say nothing.
+    /// </summary>
+    [Theory]
+    [InlineData("alpha", "multi")]
+    [InlineData("alpha beta", "multi")]
+    [InlineData("beta alpha", "multi")]
+    [InlineData("alpha  beta", "multi")]
+    [InlineData("alpha gamma", "")]
+    [InlineData("gb_C", "root,a,b,c,outside")]
+    [InlineData("other gb_C", "b")]
+    [InlineData("", "")]
+    public void DocumentGetElementsByClassName_RequiresEveryNameInTheSet(string query, string expectedIds)
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        var ids = Eval(context, $$"""
+            (function() {
+                var found = document.getElementsByClassName('{{query}}');
+                return Array.prototype.map.call(found, function(el) { return el.id; }).join(',');
+            })()
+            """);
+
+        Assert.Equal(expectedIds, ids);
+    }
+
+    /// <summary>
+    /// The two halves answer the same question the same way. Rooted at an ancestor of the whole
+    /// document, the element half must agree with the document half name for name — that agreement is
+    /// what the shared class-set rule exists to guarantee.
+    /// </summary>
+    [Theory]
+    [InlineData("gb_C")]
+    [InlineData("alpha beta")]
+    [InlineData("other")]
+    [InlineData("nomatch")]
+    public void BothHalvesAgreeWhenRootedAtTheDocumentElement(string query)
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        var ids = Eval(context, $$"""
+            (function() {
+                function idsOf(c) {
+                    return Array.prototype.map.call(c, function(el) { return el.id; }).join(',');
+                }
+                return idsOf(document.getElementsByClassName('{{query}}')) + '/' +
+                       idsOf(document.documentElement.getElementsByClassName('{{query}}'));
+            })()
+            """);
+
+        var halves = ids.Split('/');
+        Assert.Equal(halves[0], halves[1]);
+    }
+
     /// <summary>It is a function on every element wrapper, not only on the one the page happened to ask.</summary>
     [Fact]
     public void EveryElementCarriesTheMethod()

--- a/src/Broiler.Cli.Tests/FetchContentTypeTests.cs
+++ b/src/Broiler.Cli.Tests/FetchContentTypeTests.cs
@@ -1,0 +1,296 @@
+using System.Diagnostics;
+using System.Net;
+using System.Text;
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.HtmlBridge.Logging;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// A request body carries the <c>Content-Type</c> the page asked for, parameters and all.
+/// <para>
+/// The binding used to build the body as
+/// <c>new StringContent(body, Encoding.UTF8, contentTypeHeader)</c>. That third parameter is the
+/// media type <em>alone</em> — it validates through <c>MediaTypeHeaderValue</c> — so any value with
+/// a <c>;</c> in it threw <c>FormatException("The format of value '…' is invalid.")</c> before the
+/// request was built. The <c>catch</c> in the fetch binding turns that into an error
+/// <c>Response</c>, so the symptom was not a crash: it was a POST that never reached the network,
+/// reported to the page as a failure.
+/// </para>
+/// <para>
+/// The spellings that hit it are the ordinary ones. google.com's start page posts
+/// <c>application/x-www-form-urlencoded;charset=utf-8</c> — its XHR sets that through
+/// <c>setRequestHeader</c>, and the polyfill hands <c>_headers</c> to <c>fetch</c> as
+/// <c>opts.headers</c> — and every <c>multipart/form-data; boundary=…</c> upload and
+/// <c>text/plain; charset=UTF-8</c> post failed the same way.
+/// </para>
+/// <para>
+/// These assert against a loopback origin that records what it received, so what is checked is the
+/// header on the wire rather than the binding's own bookkeeping. A request that never arrives is the
+/// bug, so every case here also proves the request was made at all.
+/// </para>
+/// </summary>
+public sealed class FetchContentTypeTests
+{
+    /// <summary>Runs <paramref name="script"/> against a bridge attached to the origin's page URL.</summary>
+    private static List<string> Run(RecordingOrigin origin, string script)
+    {
+        using var context = new JSContext();
+        using var bridge = new DomBridge();
+        bridge.Attach(context, "<!doctype html><html><body></body></html>", origin.PageUrl);
+
+        var errors = new List<string>();
+        void Handler(RenderLogEntry entry)
+        {
+            if (entry.Level == LogLevel.Error)
+                lock (errors) errors.Add($"{entry.Context}: {entry.Message}");
+        }
+
+        RenderLogger.EntryLogged += Handler;
+        try
+        {
+            // The binding's network call is synchronous (SendAsync(...).GetAwaiter().GetResult()), so
+            // the origin has recorded the request by the time Eval returns — nothing to wait for.
+            context.Eval(script);
+        }
+        finally
+        {
+            RenderLogger.EntryLogged -= Handler;
+        }
+
+        lock (errors) return [.. errors];
+    }
+
+    private static void AssertNoInvalidFormatError(List<string> errors) =>
+        Assert.DoesNotContain(errors, e => e.Contains("format of value", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// The reported failure, and its neighbours. The expected value is the parsed header re-rendered,
+    /// which inserts the conventional space after <c>;</c> — the media type and every parameter
+    /// survive, which is what the page and the server care about.
+    /// </summary>
+    [Theory]
+    [InlineData("application/x-www-form-urlencoded;charset=utf-8", "application/x-www-form-urlencoded; charset=utf-8")]
+    [InlineData("application/x-www-form-urlencoded; charset=UTF-8", "application/x-www-form-urlencoded; charset=UTF-8")]
+    [InlineData("text/plain; charset=UTF-8", "text/plain; charset=UTF-8")]
+    [InlineData("multipart/form-data; boundary=----WebKitFormBoundaryhQ1", "multipart/form-data; boundary=----WebKitFormBoundaryhQ1")]
+    [InlineData("application/json; charset=utf-8", "application/json; charset=utf-8")]
+    [InlineData("application/json", "application/json")]
+    public void Fetch_SendsTheContentTypeThePageAskedFor(string requested, string expected)
+    {
+        using var origin = new RecordingOrigin();
+
+        var errors = Run(origin, $$"""
+            fetch('/post', {
+                method: 'POST',
+                headers: { 'Content-Type': '{{requested}}' },
+                body: 'q=broiler'
+            });
+            """);
+
+        AssertNoInvalidFormatError(errors);
+        var request = Assert.Single(origin.Requests);
+        Assert.Equal("POST", request.Method);
+        Assert.Equal(expected, request.ContentType);
+        Assert.Equal("q=broiler", request.Body);
+    }
+
+    /// <summary>
+    /// google.com's own path: <c>setRequestHeader</c> on an <c>XMLHttpRequest</c>. The polyfill
+    /// forwards <c>_headers</c> to <c>fetch</c>, so this is the second way into the same throw.
+    /// </summary>
+    [Fact]
+    public void Xhr_SetRequestHeaderContentType_ReachesTheOrigin()
+    {
+        using var origin = new RecordingOrigin();
+
+        var errors = Run(origin, """
+            var x = new XMLHttpRequest();
+            x.open('POST', '/gen_204?atyp=i');
+            x.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded;charset=utf-8');
+            x.send('ei=abc&s=web');
+            """);
+
+        AssertNoInvalidFormatError(errors);
+        var request = Assert.Single(origin.Requests);
+        Assert.Equal("POST", request.Method);
+        Assert.Equal("/gen_204", request.Path);
+        Assert.Equal("application/x-www-form-urlencoded; charset=utf-8", request.ContentType);
+        Assert.Equal("ei=abc&s=web", request.Body);
+    }
+
+    /// <summary>
+    /// With no <c>Content-Type</c> of its own a string body keeps the Fetch default,
+    /// <c>text/plain;charset=UTF-8</c> — the behaviour before the fix, unchanged.
+    /// </summary>
+    [Fact]
+    public void Fetch_WithoutAContentType_DefaultsToTextPlainUtf8()
+    {
+        using var origin = new RecordingOrigin();
+
+        var errors = Run(origin, "fetch('/post', { method: 'POST', body: 'q=broiler' });");
+
+        AssertNoInvalidFormatError(errors);
+        var request = Assert.Single(origin.Requests);
+        Assert.Equal("text/plain; charset=utf-8", request.ContentType);
+    }
+
+    /// <summary>
+    /// The charset parameter travels in the header; it does not choose the encoding. Fetch encodes a
+    /// string body as UTF-8 whatever the author wrote, so a non-ASCII body arrives intact.
+    /// </summary>
+    [Fact]
+    public void Fetch_EncodesTheBodyAsUtf8_WhateverCharsetTheHeaderNames()
+    {
+        using var origin = new RecordingOrigin();
+
+        var errors = Run(origin, """
+            fetch('/post', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=iso-8859-1' },
+                body: 'q=café—über'
+            });
+            """);
+
+        AssertNoInvalidFormatError(errors);
+        var request = Assert.Single(origin.Requests);
+        Assert.Equal("application/x-www-form-urlencoded; charset=iso-8859-1", request.ContentType);
+        Assert.Equal("q=café—über", request.Body);
+    }
+
+    /// <summary>
+    /// A value too malformed to parse is still sent rather than costing the request — losing the
+    /// whole POST over a header the page spelled badly is the failure this file exists to remove.
+    /// </summary>
+    [Fact]
+    public void Fetch_WithAnUnparseableContentType_StillSendsTheRequest()
+    {
+        using var origin = new RecordingOrigin();
+
+        var errors = Run(origin, """
+            fetch('/post', {
+                method: 'POST',
+                headers: { 'Content-Type': 'not a media type' },
+                body: 'q=broiler'
+            });
+            """);
+
+        AssertNoInvalidFormatError(errors);
+        var request = Assert.Single(origin.Requests);
+        Assert.Equal("q=broiler", request.Body);
+    }
+
+    /// <summary>The page sees the origin's answer, not an error <c>Response</c> standing in for it.</summary>
+    [Fact]
+    public void Fetch_WithAParameterisedContentType_ResolvesWithTheOriginsResponse()
+    {
+        using var origin = new RecordingOrigin();
+
+        var status = string.Empty;
+        using var context = new JSContext();
+        using var bridge = new DomBridge();
+        bridge.Attach(context, "<!doctype html><html><body></body></html>", origin.PageUrl);
+        context.Eval("""
+            globalThis.__status = null;
+            fetch('/post', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8' },
+                body: 'q=broiler'
+            }).then(function(r) { globalThis.__status = r.status + '|' + r.type; });
+            """);
+        status = context.Eval("String(globalThis.__status)").ToString();
+
+        Assert.Equal("200|basic", status);
+    }
+}
+
+/// <summary>
+/// A loopback origin that answers every request 200 and records the method, path, <c>Content-Type</c>
+/// and body it received. Requests are what is asserted, so nothing here is shared between tests: each
+/// one binds its own port and disposes it.
+/// </summary>
+internal sealed class RecordingOrigin : IDisposable
+{
+    private readonly HttpListener _listener = new();
+    private readonly Lock _sync = new();
+    private readonly List<ReceivedRequest> _requests = [];
+    private readonly string _prefix;
+
+    public RecordingOrigin()
+    {
+        // Port 0 asks the OS for a free one, but HttpListener has no way to report it back, so the
+        // port is picked by binding a socket, closing it, and taking the number — the same approach
+        // LatencyOrigin uses in PreloadScanOverlapTests.
+        var probe = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+
+        _prefix = $"http://127.0.0.1:{port}/";
+        _listener.Prefixes.Add(_prefix);
+        _listener.Start();
+        _ = Task.Run(Serve);
+    }
+
+    /// <summary>The page URL documents under test are given, on this origin.</summary>
+    public string PageUrl => _prefix + "page.html";
+
+    public IReadOnlyList<ReceivedRequest> Requests
+    {
+        get { lock (_sync) return [.. _requests]; }
+    }
+
+    private async Task Serve()
+    {
+        while (_listener.IsListening)
+        {
+            HttpListenerContext context;
+            try
+            {
+                context = await _listener.GetContextAsync().ConfigureAwait(false);
+            }
+            catch (HttpListenerException)
+            {
+                return; // Disposed.
+            }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
+
+            Answer(context);
+        }
+    }
+
+    private void Answer(HttpListenerContext context)
+    {
+        using (var buffer = new MemoryStream())
+        {
+            context.Request.InputStream.CopyTo(buffer);
+            // Decoded as UTF-8 rather than by the request's declared charset: what the assertions are
+            // about is the bytes the binding produced, not the origin's interpretation of them.
+            var received = new ReceivedRequest(
+                context.Request.HttpMethod,
+                context.Request.Url?.AbsolutePath ?? "/",
+                context.Request.ContentType,
+                Encoding.UTF8.GetString(buffer.ToArray()));
+            lock (_sync) _requests.Add(received);
+        }
+
+        var bytes = "ok"u8.ToArray();
+        context.Response.ContentType = "text/plain";
+        context.Response.ContentLength64 = bytes.Length;
+        context.Response.OutputStream.Write(bytes);
+        context.Response.Close();
+    }
+
+    public void Dispose()
+    {
+        _listener.Close();
+    }
+}
+
+/// <summary>One request as the origin saw it.</summary>
+internal readonly record struct ReceivedRequest(string Method, string Path, string? ContentType, string Body);

--- a/src/Broiler.Cli.Tests/FetchContentTypeTests.cs
+++ b/src/Broiler.Cli.Tests/FetchContentTypeTests.cs
@@ -269,13 +269,21 @@ internal sealed class RecordingOrigin : IDisposable
         using (var buffer = new MemoryStream())
         {
             context.Request.InputStream.CopyTo(buffer);
+            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var name in context.Request.Headers.AllKeys)
+            {
+                if (name != null)
+                    headers[name] = context.Request.Headers[name] ?? string.Empty;
+            }
+
             // Decoded as UTF-8 rather than by the request's declared charset: what the assertions are
             // about is the bytes the binding produced, not the origin's interpretation of them.
             var received = new ReceivedRequest(
                 context.Request.HttpMethod,
                 context.Request.Url?.AbsolutePath ?? "/",
                 context.Request.ContentType,
-                Encoding.UTF8.GetString(buffer.ToArray()));
+                Encoding.UTF8.GetString(buffer.ToArray()),
+                headers);
             lock (_sync) _requests.Add(received);
         }
 
@@ -292,5 +300,14 @@ internal sealed class RecordingOrigin : IDisposable
     }
 }
 
-/// <summary>One request as the origin saw it.</summary>
-internal readonly record struct ReceivedRequest(string Method, string Path, string? ContentType, string Body);
+/// <summary>One request as the origin saw it. <paramref name="Headers"/> holds every header it carried.</summary>
+internal readonly record struct ReceivedRequest(
+    string Method,
+    string Path,
+    string? ContentType,
+    string Body,
+    Dictionary<string, string> Headers)
+{
+    /// <summary>The value the origin received for <paramref name="name"/>, or null if it never arrived.</summary>
+    public string? Header(string name) => Headers.TryGetValue(name, out var value) ? value : null;
+}

--- a/src/Broiler.Cli.Tests/FetchRequestHeadersTests.cs
+++ b/src/Broiler.Cli.Tests/FetchRequestHeadersTests.cs
@@ -1,0 +1,153 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Every request header the page sets reaches the wire, including the <c>Content-*</c> ones.
+/// <para>
+/// <c>HttpRequestMessage</c> splits headers in two: the request-level ones live on
+/// <c>request.Headers</c> and the entity ones — <c>Content-Language</c>,
+/// <c>Content-Disposition</c>, <c>Content-Encoding</c> and the rest — belong to the body.
+/// <c>TryAddWithoutValidation</c> reports a header it will not take by returning
+/// <see langword="false"/>, and the binding's loop discarded that return without a word: a page
+/// could set <c>Content-Language</c>, see no error, and have it silently never sent.
+/// </para>
+/// <para>
+/// Asserted against a loopback origin that records every header it received, so what is checked is
+/// the request as it actually arrived.
+/// </para>
+/// </summary>
+public sealed class FetchRequestHeadersTests
+{
+    private static void Run(RecordingOrigin origin, string script)
+    {
+        using var context = new JSContext();
+        using var bridge = new DomBridge();
+        bridge.Attach(context, "<!doctype html><html><body></body></html>", origin.PageUrl);
+        context.Eval(script);
+    }
+
+    private static string PostWith(RecordingOrigin origin, string headersLiteral, string body = "payload")
+    {
+        Run(origin, $$"""
+            fetch('/post', { method: 'POST', headers: {{headersLiteral}}, body: '{{body}}' });
+            """);
+        return body;
+    }
+
+    /// <summary>The entity headers the old loop dropped on the floor.</summary>
+    [Theory]
+    [InlineData("Content-Language", "en-GB")]
+    [InlineData("Content-Disposition", "form-data; name=\\\"upload\\\"")]
+    [InlineData("Content-Location", "/canonical/here")]
+    public void ContentHeaders_ReachTheOrigin(string name, string value)
+    {
+        using var origin = new RecordingOrigin();
+
+        PostWith(origin, $"{{ '{name}': '{value}' }}");
+
+        var request = Assert.Single(origin.Requests);
+        Assert.Equal(value.Replace("\\\"", "\""), request.Header(name));
+    }
+
+    /// <summary>Request-level headers keep working — the fallback must not have moved them.</summary>
+    [Theory]
+    [InlineData("X-Requested-With", "XMLHttpRequest")]
+    [InlineData("Accept", "application/json")]
+    [InlineData("Accept-Language", "en-GB,en;q=0.9")]
+    [InlineData("X-Client-Data", "abc123")]
+    public void RequestHeaders_StillReachTheOrigin(string name, string value)
+    {
+        using var origin = new RecordingOrigin();
+
+        PostWith(origin, $"{{ '{name}': '{value}' }}");
+
+        var request = Assert.Single(origin.Requests);
+        Assert.Equal(value, request.Header(name));
+    }
+
+    /// <summary>A mixed set arrives whole, each half routed to the collection that accepts it.</summary>
+    [Fact]
+    public void RequestAndContentHeaders_TravelTogether()
+    {
+        using var origin = new RecordingOrigin();
+
+        PostWith(origin, """
+            {
+                'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+                'Content-Language': 'de',
+                'X-Requested-With': 'XMLHttpRequest',
+                'Accept': 'application/json'
+            }
+            """);
+
+        var request = Assert.Single(origin.Requests);
+        Assert.Equal("application/x-www-form-urlencoded; charset=utf-8", request.ContentType);
+        Assert.Equal("de", request.Header("Content-Language"));
+        Assert.Equal("XMLHttpRequest", request.Header("X-Requested-With"));
+        Assert.Equal("application/json", request.Header("Accept"));
+        Assert.Equal("payload", request.Body);
+    }
+
+    /// <summary>
+    /// <c>Content-Length</c> stays dropped, and deliberately so. .NET derives it from the body it is
+    /// about to write, and an author value <em>replaces</em> that rather than being rejected — so
+    /// forwarding one would let a page declare a length its body does not have and leave the server
+    /// waiting for bytes that never arrive. Fetch forbids authors the header for the same reason.
+    /// What must hold is that the length on the wire describes the body actually sent.
+    /// </summary>
+    [Fact]
+    public void ContentLength_IsNotTakenFromThePage()
+    {
+        using var origin = new RecordingOrigin();
+
+        PostWith(origin, "{ 'Content-Length': '9999' }", body: "twelve chars");
+
+        var request = Assert.Single(origin.Requests);
+        Assert.Equal("twelve chars", request.Body);
+        Assert.Equal("12", request.Header("Content-Length"));
+    }
+
+    /// <summary>The XHR path sets headers the same way, so it gains the same reach.</summary>
+    [Fact]
+    public void Xhr_SetRequestHeader_SendsContentHeadersToo()
+    {
+        using var origin = new RecordingOrigin();
+
+        Run(origin, """
+            var x = new XMLHttpRequest();
+            x.open('POST', '/xhr');
+            x.setRequestHeader('Content-Language', 'fr');
+            x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+            x.send('body=1');
+            """);
+
+        var request = Assert.Single(origin.Requests);
+        Assert.Equal("/xhr", request.Path);
+        Assert.Equal("fr", request.Header("Content-Language"));
+        Assert.Equal("XMLHttpRequest", request.Header("X-Requested-With"));
+    }
+
+    /// <summary>
+    /// A bodyless request has no content to carry an entity header, so one set there is still not
+    /// sent. Manufacturing an empty body to hold it would add a <c>Content-Length: 0</c> to a GET and
+    /// change what the request means, which is a worse trade than the dropped header — this pins the
+    /// boundary rather than endorsing it. Request-level headers are unaffected and must still arrive.
+    /// </summary>
+    [Fact]
+    public void BodylessRequest_SendsRequestHeaders_ButHasNoContentToCarryEntityOnes()
+    {
+        using var origin = new RecordingOrigin();
+
+        Run(origin, """
+            fetch('/get', { headers: { 'Content-Language': 'es', 'X-Requested-With': 'probe' } });
+            """);
+
+        var request = Assert.Single(origin.Requests);
+        Assert.Equal("GET", request.Method);
+        Assert.Equal("probe", request.Header("X-Requested-With"));
+        Assert.Null(request.Header("Content-Language"));
+    }
+}

--- a/src/Broiler.Cli.Tests/FormNamedAccessTests.cs
+++ b/src/Broiler.Cli.Tests/FormNamedAccessTests.cs
@@ -1,0 +1,140 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// <c>form.q</c> — <c>HTMLFormElement</c>'s named getter (HTML §4.10.3): an unknown property name on
+/// a form resolves to the control carrying that name.
+/// <para>
+/// <c>form.elements</c> already offered named access; the form itself did not. The miss does not
+/// announce itself either, which is what makes it expensive: google.com's homepage takes the form,
+/// reads <c>u=r.q</c> from it, and hands the result to its search-box component, which stores it and
+/// only later reads <c>F.value</c> — so the throw, <c>Cannot get property value of undefined</c>,
+/// surfaces in a component several calls away from the lookup that actually failed.
+/// </para>
+/// </summary>
+public sealed class FormNamedAccessTests
+{
+    private const string Page = """
+        <!doctype html><html><body>
+          <form name="f" id="searchform" action="/search">
+            <input name="q" id="query" value="broiler">
+            <input name="btnK" id="submit-btn" type="submit" value="Search">
+            <select name="picker" id="picker-el"><option>one</option></select>
+            <textarea name="notes" id="notes-el">text</textarea>
+            <input name="action" id="named-action" value="decoy">
+            <input id="only-an-id" value="no-name">
+          </form>
+        </body></html>
+        """;
+
+    private static (JSContext Context, DomBridge Bridge) Attach()
+    {
+        var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, Page, "https://www.google.com/");
+        return (context, bridge);
+    }
+
+    private static string Eval(JSContext context, string expression) => context.Eval(expression).ToString();
+
+    /// <summary>The homepage's own sequence: find the form by name, then take its q control.</summary>
+    [Fact]
+    public void FormNamedAccess_YieldsTheControl_TheWayTheHomepageTakesIt()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        var thrown = Record.Exception(() => context.Eval("""
+            globalThis.__value = (function() {
+                var r = document.getElementsByName('f')[0];
+                var u = r.q;
+                return u.value;
+            })();
+            """));
+
+        Assert.Null(thrown);
+        Assert.Equal("broiler", Eval(context, "String(globalThis.__value)"));
+    }
+
+    /// <summary>Every kind of listed control is reachable by its name, not just text inputs.</summary>
+    [Theory]
+    [InlineData("q", "query")]
+    [InlineData("btnK", "submit-btn")]
+    [InlineData("picker", "picker-el")]
+    [InlineData("notes", "notes-el")]
+    public void FormNamedAccess_ReachesEveryControlKind(string name, string expectedId)
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal(expectedId, Eval(context, $"String(document.getElementById('searchform').{name}.id)"));
+    }
+
+    /// <summary>
+    /// The named getter is a fallback, not an override. WebIDL consults named properties only when
+    /// the object does not already answer, so a control named <c>action</c> must not displace the
+    /// form's own <c>action</c>.
+    /// </summary>
+    [Fact]
+    public void FormNamedAccess_DoesNotShadowTheFormsOwnMembers()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("/search", Eval(context, "String(document.getElementById('searchform').action)"));
+        Assert.Equal("object", Eval(context, "typeof document.getElementById('searchform').elements"));
+        Assert.Equal("number", Eval(context, "typeof document.getElementById('searchform').length"));
+    }
+
+    /// <summary>
+    /// A name nothing carries stays undefined — an absent named property is an absent property, and
+    /// returning null instead would change what <c>typeof</c> reports and break feature detection.
+    /// The controls collection keeps its own contract, where a miss is null.
+    /// </summary>
+    [Fact]
+    public void FormNamedAccess_WithNoSuchName_IsUndefined()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("undefined", Eval(context, "typeof document.getElementById('searchform').nothingIsNamedThis"));
+        Assert.Equal("object", Eval(context, "typeof document.getElementById('searchform').elements.nothingIsNamedThis"));
+    }
+
+    /// <summary>The form and its collection agree, since one lookup answers for both.</summary>
+    [Theory]
+    [InlineData("q")]
+    [InlineData("btnK")]
+    [InlineData("notes")]
+    public void FormAndItsElementsCollectionAgree(string name)
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("true", Eval(context, $"String(document.getElementById('searchform').{name} === document.getElementById('searchform').elements.{name})"));
+    }
+
+    /// <summary>
+    /// Matching is on the <c>name</c> attribute. A control with only an id is not reachable this way
+    /// in Broiler — HTML would also expose it by id, which this pins as a known limit rather than
+    /// leaving it to be discovered.
+    /// </summary>
+    [Fact]
+    public void FormNamedAccess_MatchesTheNameAttribute()
+    {
+        var (context, bridge) = Attach();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("named-action", Eval(context, "String(document.getElementById('searchform')['action'] && document.getElementById('searchform').elements['action'].id)"));
+        Assert.Equal("undefined", Eval(context, "typeof document.getElementById('searchform')['only-an-id']"));
+    }
+}

--- a/src/Broiler.Cli.Tests/InteractiveSessionLifetimeTests.cs
+++ b/src/Broiler.Cli.Tests/InteractiveSessionLifetimeTests.cs
@@ -28,6 +28,7 @@ public class InteractiveSessionLifetimeTests
         public IReadOnlyList<DomElement> Elements { get; } = Array.Empty<DomElement>();
         public int CurrentScriptIndex { get; set; }
         public bool HasPendingTimers => false;
+        public bool HasPendingTimersDueBy(double virtualHorizonMs) => false;
 
         public void Attach(JSContext context, string html)
         {

--- a/src/Broiler.Cli.Tests/SubDocumentCollectionLookupTests.cs
+++ b/src/Broiler.Cli.Tests/SubDocumentCollectionLookupTests.cs
@@ -1,0 +1,122 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// A frame's document carries the same collection lookups as the main one.
+/// <para>
+/// <c>getElementsByClassName</c> and <c>getElementsByName</c> were registered on the main document
+/// but not on a sub-document, which builds its own query surface. A script inside a frame is a
+/// script like any other, so calling either there hit the failure this branch has been chasing
+/// throughout: the method read as <see langword="undefined"/> rather than as absent, and calling it
+/// threw <c>TypeError: undefined is not a function</c>, aborting the frame's whole
+/// <c>&lt;script&gt;</c>.
+/// </para>
+/// <para>
+/// The class lookup goes through the same <c>ClassNameSet</c> rule as the main document and the
+/// element-scoped search, so all three agree; that agreement is asserted here rather than assumed.
+/// </para>
+/// </summary>
+public sealed class SubDocumentCollectionLookupTests
+{
+    private const string Frame =
+        "<div class='panel wide' name='box' id='a'></div>" +
+        "<div class='panel' id='b'></div>" +
+        "<span class='wide' id='c'></span>" +
+        "<input name='q' id='d'>" +
+        "<input name='box' id='e'>";
+
+    private static (JSContext Context, DomBridge Bridge) AttachWithFrame()
+    {
+        var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(
+            context,
+            $"<!doctype html><html><body><iframe id='f' srcdoc=\"{Frame}\"></iframe></body></html>",
+            "https://example.com/host.html");
+        bridge.FireWindowLoadEvent();
+        bridge.FlushTimers();
+        return (context, bridge);
+    }
+
+    private static string Eval(JSContext context, string expression) => context.Eval(expression).ToString();
+
+    /// <summary>Reaching either method inside a frame must not throw.</summary>
+    [Fact]
+    public void FrameDocument_HasBothCollectionLookups()
+    {
+        var (context, bridge) = AttachWithFrame();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("function", Eval(context, "typeof document.getElementById('f').contentDocument.getElementsByClassName"));
+        Assert.Equal("function", Eval(context, "typeof document.getElementById('f').contentDocument.getElementsByName"));
+    }
+
+    /// <summary>The class lookup searches the frame's own tree, with the shared set semantics.</summary>
+    [Theory]
+    [InlineData("panel", "a,b")]
+    [InlineData("wide", "a,c")]
+    [InlineData("panel wide", "a")]
+    [InlineData("wide panel", "a")]
+    [InlineData("panel missing", "")]
+    [InlineData("", "")]
+    public void FrameDocument_GetElementsByClassName_UsesTheSharedSetRule(string query, string expectedIds)
+    {
+        var (context, bridge) = AttachWithFrame();
+        using var _ = context;
+        using var __ = bridge;
+
+        var ids = Eval(context, $$"""
+            (function() {
+                var d = document.getElementById('f').contentDocument;
+                return Array.prototype.map.call(d.getElementsByClassName('{{query}}'),
+                    function(el) { return el.id; }).join(',');
+            })()
+            """);
+
+        Assert.Equal(expectedIds, ids);
+    }
+
+    /// <summary>The name lookup likewise, matching any element carrying the attribute.</summary>
+    [Theory]
+    [InlineData("box", "a,e")]
+    [InlineData("q", "d")]
+    [InlineData("nothing", "")]
+    public void FrameDocument_GetElementsByName_MatchesTheAttribute(string query, string expectedIds)
+    {
+        var (context, bridge) = AttachWithFrame();
+        using var _ = context;
+        using var __ = bridge;
+
+        var ids = Eval(context, $$"""
+            (function() {
+                var d = document.getElementById('f').contentDocument;
+                return Array.prototype.map.call(d.getElementsByName('{{query}}'),
+                    function(el) { return el.id; }).join(',');
+            })()
+            """);
+
+        Assert.Equal(expectedIds, ids);
+    }
+
+    /// <summary>
+    /// The frame's lookups are scoped to the frame. The host document carries neither class nor name,
+    /// so a search there finds nothing while the frame's finds its own — which is what proves the
+    /// sub-document is searching its own tree rather than the main one.
+    /// </summary>
+    [Fact]
+    public void FrameDocument_SearchesItsOwnTree_NotTheHosts()
+    {
+        var (context, bridge) = AttachWithFrame();
+        using var _ = context;
+        using var __ = bridge;
+
+        Assert.Equal("0", Eval(context, "String(document.getElementsByClassName('panel').length)"));
+        Assert.Equal("0", Eval(context, "String(document.getElementsByName('box').length)"));
+        Assert.Equal("2", Eval(context, "String(document.getElementById('f').contentDocument.getElementsByClassName('panel').length)"));
+        Assert.Equal("2", Eval(context, "String(document.getElementById('f').contentDocument.getElementsByName('box').length)"));
+    }
+}

--- a/src/Broiler.Cli/CaptureService.cs
+++ b/src/Broiler.Cli/CaptureService.cs
@@ -736,22 +736,26 @@ public class CaptureService
                     hadWork = true;
                 }
 
-                if (bridge.HasPendingTimers)
+                if (bridge.HasPendingTimersDueBy(DomBridge.AsyncDrainVirtualTimeBudgetMs))
                 {
                     bridge.FlushTimerStep();
                     hadWork = true;
                 }
 
                 if (!hadWork)
-                    return; // settled within the budget
+                    return; // settled — nothing left that this capture's window covers
             }
 
-            // Phase 8 item 3: the drain budget is exhausted while work is still queued (a runaway
-            // microtask/timer loop). Surface it explicitly instead of stopping silently.
+            // Phase 8 item 3: the iteration budget is exhausted while work is *still due now*. The
+            // virtual-time horizon above already retires the ordinary case — a page holding an
+            // interval, whose next tick is simply later — so reaching here means work that keeps
+            // regenerating at the current instant and never lets the clock move: a callback
+            // rescheduling itself with no delay, or a microtask queueing another. That is worth a
+            // warning; an interval is not, and used to get one.
             RenderLogger.LogWarning(LogCategory.JavaScript, "CaptureService.DrainAsyncWork",
-                $"Async work did not settle within {DomBridge.AsyncDrainIterationLimit} drain iterations; " +
-                $"stopping with pending microtasks={microTasks.Count}, pendingTimers={bridge.HasPendingTimers}. " +
-                "This usually indicates a runaway microtask/timer loop.");
+                $"Async work still due after {DomBridge.AsyncDrainIterationLimit} drain iterations; " +
+                $"stopping with pending microtasks={microTasks.Count}. " +
+                "A callback is rescheduling itself with no delay, so the virtual clock cannot advance.");
         }
 
         for (int si = 0; si < scripts.Count; si++)

--- a/src/Broiler.HtmlBridge.Core/Dom/IDomBridgeRuntime.cs
+++ b/src/Broiler.HtmlBridge.Core/Dom/IDomBridgeRuntime.cs
@@ -20,6 +20,13 @@ public interface IDomBridgeRuntime
 
     bool HasPendingTimers { get; }
 
+    /// <summary>
+    /// Whether queued timer/animation-frame work is due at or before <paramref name="virtualHorizonMs"/>
+    /// on the event loop's virtual clock (ms from document start). Draining asks this rather than
+    /// <see cref="HasPendingTimers"/>, which never goes false on a page holding a <c>setInterval</c>.
+    /// </summary>
+    bool HasPendingTimersDueBy(double virtualHorizonMs);
+
     void Attach(JSContext context, string html);
 
     void Attach(JSContext context, string html, string url);
@@ -46,4 +53,17 @@ public interface IDomBridgeRuntimeFactory
 public static class DomBridgeRuntimeLimits
 {
     public const int AsyncDrainIterationLimit = 1000;
+
+    /// <summary>
+    /// How far onto the event loop's virtual clock a drain will follow scheduled work, in ms from
+    /// document start.
+    /// </summary>
+    /// <remarks>
+    /// A capture is a moment shortly after load, not a session. Timers scheduled past this horizon —
+    /// a polling interval's later ticks, a delayed refresh — belong to a page that kept running, and
+    /// following them would both never terminate and simulate page time the capture does not
+    /// represent. The iteration limit remains the backstop for work that is due immediately and keeps
+    /// regenerating, which no time horizon can bound because it never moves the clock.
+    /// </remarks>
+    public const double AsyncDrainVirtualTimeBudgetMs = 5000;
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.cs
@@ -32,6 +32,12 @@ public sealed partial class DomBridge : IDomBridgeRuntime
     /// </summary>
     public const int AsyncDrainIterationLimit = 1000;
 
+    /// <summary>
+    /// How far onto the virtual clock a drain follows scheduled work (ms from document start); see
+    /// <see cref="DomBridgeRuntimeLimits.AsyncDrainVirtualTimeBudgetMs"/>.
+    /// </summary>
+    public const double AsyncDrainVirtualTimeBudgetMs = DomBridgeRuntimeLimits.AsyncDrainVirtualTimeBudgetMs;
+
     // P2.6: sub-resource HTTP and the local base path now live in ResourceLoader, the single host
     // resource loader (was the static SharedHttpClient plus the _localBasePath field). Feature
     // callbacks ask the loader instead of reaching a static HttpClient.
@@ -708,6 +714,21 @@ public sealed partial class DomBridge : IDomBridgeRuntime
             ThrowIfDisposed();
             return _eventLoop.HasPendingWork;
         }
+    }
+
+    /// <summary>
+    /// Whether queued timer/animation-frame work is due at or before <paramref name="virtualHorizonMs"/>
+    /// on the event loop's virtual clock, measured from document start.
+    /// </summary>
+    /// <remarks>
+    /// The question a drain actually needs. <see cref="HasPendingTimers"/> stays <c>true</c> forever on
+    /// any page holding a <c>setInterval</c>, because an interval always has a next tick, so a drain
+    /// waiting for it to go false cannot stop on an ordinary page.
+    /// </remarks>
+    public bool HasPendingTimersDueBy(double virtualHorizonMs)
+    {
+        ThrowIfDisposed();
+        return _eventLoop.HasWorkDueBy(virtualHorizonMs);
     }
 
     /// <summary>

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/DomBridge.SelectorsHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/DomBridge.SelectorsHost.cs
@@ -16,6 +16,9 @@ public sealed partial class DomBridge : Dom.Features.ISelectorsHost
     void Dom.Features.ISelectorsHost.CollectElementsByTagName(DomElement element, string tagName, List<JSValue> results)
         => CollectDescendantsByTag(element, tagName, results, this);
 
+    void Dom.Features.ISelectorsHost.CollectElementsByClassName(DomElement element, string classNames, List<JSValue> results)
+        => CollectDescendantsByClass(element, classNames, results, this);
+
     JSObject Dom.Features.ISelectorsHost.ToJSObject(DomNode node) => ToJSObject(node);
 
     bool Dom.Features.ISelectorsHost.MatchesSelector(DomElement element, string selector, DomElement? scope)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -595,6 +595,13 @@ public sealed partial class DomBridge
             new DomFunction((in a) => Dom.Features.SelectorsBinding.GetElementsByTagName(this, element, in a), "getElementsByTagName", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
+        // getElementsByClassName on elements — the same descendant search by class. DOM §4.9 puts it on
+        // Element as well as Document, and only the document half was here; scoping a class lookup to a
+        // container is how pages narrow a search, so its absence threw rather than merely finding nothing.
+        obj.FastAddValue((KeyString)"getElementsByClassName",
+            new DomFunction((in a) => Dom.Features.SelectorsBinding.GetElementsByClassName(this, element, in a), "getElementsByClassName", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
         // getContext(contextType) — for <canvas> elements. Phase 3 P3.64: extracted into the co-located
         // CanvasBinding feature module (unblocked once Phase 6/P8.9 dissolved Broiler.HtmlBridge.Rendering).
         Dom.Features.CanvasBinding.Install(obj, element);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -41,7 +41,14 @@ public sealed partial class DomBridge
         if (node is DomDocument documentNode && _jsObjects.TryGetDocument(documentNode, out var documentWrapper))
             return documentWrapper;
 
-        var obj = new JSObject();
+        // A <form> gets a wrapper that additionally resolves an unknown name to the control carrying
+        // it (HTMLFormElement's named getter). It is decided here rather than in the form binding
+        // because a wrapper's type is fixed when it is created, and every member installed below goes
+        // on this same object.
+        var obj = node is DomElement formElement &&
+                  string.Equals(formElement.TagName, "form", StringComparison.OrdinalIgnoreCase)
+            ? new Dom.Features.FormElementJSObject(formElement, this)
+            : new JSObject();
         _jsObjects.Set(node, obj);
 
         // RF-BRIDGE-1c Phase F (F3c): canonical character-data nodes (DomText/DomComment) are not

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Document.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Document.cs
@@ -43,10 +43,12 @@ public sealed partial class DomBridge
         document.FastAddProperty((KeyString)"title", new JSFunction((in a) => Dom.Features.DocumentStructureBinding.GetTitle(this, in a), "get title"), new JSFunction((in a) => Dom.Features.DocumentStructureBinding.SetTitle(this, in a), "set title"), JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // document element-query methods — getElementById/getElementsByTagName/getElementsByClassName/
-        // querySelector/querySelectorAll, co-located in the DocumentQueryBinding feature module (Phase 3).
+        // getElementsByName/querySelector/querySelectorAll, co-located in the DocumentQueryBinding
+        // feature module (Phase 3).
         document.FastAddValue((KeyString)"getElementById", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.GetElementById(this, in a), "getElementById", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         document.FastAddValue((KeyString)"getElementsByTagName", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.GetElementsByTagName(this, in a), "getElementsByTagName", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         document.FastAddValue((KeyString)"getElementsByClassName", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.GetElementsByClassName(this, in a), "getElementsByClassName", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        document.FastAddValue((KeyString)"getElementsByName", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.GetElementsByName(this, in a), "getElementsByName", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         document.FastAddValue((KeyString)"querySelector", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.QuerySelector(this, in a), "querySelector", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         document.FastAddValue((KeyString)"querySelectorAll", new JSFunction((in a) => Dom.Features.DocumentQueryBinding.QuerySelectorAll(this, in a), "querySelectorAll", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         // document.elementFromPoint / elementsFromPoint (hit-testing), co-located in the HitTestBinding

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
@@ -34,6 +34,17 @@ public sealed partial class DomBridge
 
         window.FastAddValue((KeyString)"location", location, JSPropertyAttributes.EnumerableConfigurableValue);
 
+        // document.location is the *same* Location as window.location (HTML §3.1.5: the getter
+        // returns this document's relevant global object's Location), so it is the one object
+        // registered on both rather than a copy — pages compare the two, and `document.location`
+        // is the spelling half of them reach for. Undefined here, it did not read as a missing
+        // property but threw "Cannot get property protocol of undefined" out of the first script
+        // to ask an origin of it, which aborts the whole <script>. That is the same One-Google-bar
+        // bundle `top` above died in — `dF=function(){var a=document.location;return
+        // a.protocol+"//"+a.host}` is how it builds its own origin — so it is the next thing that
+        // failed once `top` resolved.
+        document.FastAddValue((KeyString)"location", location, JSPropertyAttributes.EnumerableConfigurableValue);
+
         // window timers / animation frames — thin adapters over the P2.4 BrowserEventLoop, co-located
         // in the TimerBinding feature module (Phase 3).
         window.FastAddValue((KeyString)"setTimeout", new DomFunction((in a) => Dom.Features.TimerBinding.SetTimeout(_eventLoop, in a), "setTimeout", 2), JSPropertyAttributes.EnumerableConfigurableValue);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -442,6 +442,33 @@ public sealed partial class DomBridge
         }
     }
 
+    /// <summary>
+    /// Descendants of <paramref name="root"/> carrying every class in <paramref name="classNames"/>,
+    /// in document order — the element half of <c>getElementsByClassName</c>.
+    /// </summary>
+    /// <remarks>
+    /// The argument is a set of class names, not a selector: it is split on ASCII whitespace and an
+    /// element qualifies only when it carries all of them, so it cannot be routed through the
+    /// selector engine as <c>"." + classNames</c> — a class is a literal here and would need escaping
+    /// to survive as a selector. Names are compared ordinally, as class identity in a standards-mode
+    /// document is case-sensitive. An empty set matches nothing rather than everything.
+    /// </remarks>
+    private static void CollectDescendantsByClass(DomElement root, string classNames, List<JSValue> results, DomBridge bridge)
+    {
+        var wanted = classNames.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (wanted.Length == 0)
+            return;
+
+        foreach (var element in root.Descendants().OfType<DomElement>())
+        {
+            var classes = new HashSet<string>(
+                (element.ClassName ?? string.Empty).Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries),
+                StringComparer.Ordinal);
+            if (Array.TrueForAll(wanted, classes.Contains))
+                results.Add(bridge.ToJSObject(element));
+        }
+    }
+
     // classList / DOMTokenList moved to the Phase 3 ClassListBinding feature module
     // (Broiler.HtmlBridge.Dom.Features).
     // style / CSSStyleDeclaration (element.style, rule.style, getComputedStyle result) moved to the

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.cs
@@ -447,24 +447,20 @@ public sealed partial class DomBridge
     /// in document order — the element half of <c>getElementsByClassName</c>.
     /// </summary>
     /// <remarks>
-    /// The argument is a set of class names, not a selector: it is split on ASCII whitespace and an
-    /// element qualifies only when it carries all of them, so it cannot be routed through the
+    /// The argument is a set of class names, not a selector, so it cannot be routed through the
     /// selector engine as <c>"." + classNames</c> — a class is a literal here and would need escaping
-    /// to survive as a selector. Names are compared ordinally, as class identity in a standards-mode
-    /// document is case-sensitive. An empty set matches nothing rather than everything.
+    /// to survive as a selector. The set rule itself lives in
+    /// <see cref="Dom.Features.ClassNameSet"/>, shared with the document half of the same method.
     /// </remarks>
     private static void CollectDescendantsByClass(DomElement root, string classNames, List<JSValue> results, DomBridge bridge)
     {
-        var wanted = classNames.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        var wanted = Dom.Features.ClassNameSet.Parse(classNames);
         if (wanted.Length == 0)
             return;
 
         foreach (var element in root.Descendants().OfType<DomElement>())
         {
-            var classes = new HashSet<string>(
-                (element.ClassName ?? string.Empty).Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries),
-                StringComparer.Ordinal);
-            if (Array.TrueForAll(wanted, classes.Contains))
+            if (Dom.Features.ClassNameSet.Matches(element, wanted))
                 results.Add(bridge.ToJSObject(element));
         }
     }

--- a/src/Broiler.HtmlBridge.Dom/Features/ClassNameSet.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ClassNameSet.cs
@@ -1,0 +1,50 @@
+using Broiler.Dom;
+
+namespace Broiler.HtmlBridge.Dom.Features;
+
+/// <summary>
+/// The class-name set matching shared by both halves of <c>getElementsByClassName</c> — the document
+/// one in <see cref="DocumentQueryBinding"/> and the element one behind
+/// <see cref="SelectorsBinding.GetElementsByClassName"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// It lives in one place because the two halves had already drifted: the document half read its
+/// argument as a single class name, so <c>getElementsByClassName("a b")</c> found only elements
+/// whose whole class attribute was the literal <c>"a b"</c> — that is, nothing — where DOM §4.5 asks
+/// for the elements carrying <em>both</em> classes. Sharing the rule is what keeps the answer the
+/// same whichever half a page reaches through.
+/// </para>
+/// <para>
+/// Both the argument and the element's <c>class</c> attribute are ordered sets of tokens split on
+/// ASCII whitespace, and comparison is ordinal because class identity is case-sensitive in a
+/// standards-mode document. An empty set matches nothing rather than everything.
+/// </para>
+/// </remarks>
+internal static class ClassNameSet
+{
+    /// <summary>Splits the requested class names. An empty result matches no element.</summary>
+    public static string[] Parse(string? classNames) =>
+        (classNames ?? string.Empty).Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+
+    /// <summary>Whether <paramref name="element"/> carries every name in <paramref name="wanted"/>.</summary>
+    public static bool Matches(DomElement element, string[] wanted)
+    {
+        if (wanted.Length == 0)
+            return false;
+
+        // Both sides are a handful of short tokens, so a linear scan beats hashing them per element —
+        // and the overwhelmingly common call asks for exactly one class.
+        var classes = (element.ClassName ?? string.Empty).Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (classes.Length == 0)
+            return false;
+
+        foreach (var name in wanted)
+        {
+            if (Array.IndexOf(classes, name) < 0)
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/Features/DocumentQueryBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/DocumentQueryBinding.cs
@@ -41,14 +41,20 @@ internal static class DocumentQueryBinding
         return new JSArray(results);
     }
 
+    /// <summary>
+    /// <c>document.getElementsByClassName(names)</c>. The argument is an ordered set of class names
+    /// and an element must carry every one of them (DOM §4.5) — this read it as a single name, so a
+    /// multi-class query such as <c>getElementsByClassName("a b")</c> matched only an element whose
+    /// class attribute was that literal string, i.e. nothing. <see cref="ClassNameSet"/> holds the
+    /// rule so this and the element half of the same method cannot answer differently.
+    /// </summary>
     public static JSValue GetElementsByClassName(IDocumentQueryHost host, in Arguments a)
     {
-        var className = a.Length > 0 ? a[0].ToString() : string.Empty;
+        var wanted = ClassNameSet.Parse(a.Length > 0 ? a[0].ToString() : string.Empty);
         var results = new List<JSValue>();
         foreach (var el in host.Elements)
         {
-            var classes = new HashSet<string>((el.ClassName ?? string.Empty).Split(' ').Where(s => s.Length > 0), StringComparer.Ordinal);
-            if (classes.Contains(className))
+            if (ClassNameSet.Matches(el, wanted))
                 results.Add(host.ToJSObject(el));
         }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/DocumentQueryBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/DocumentQueryBinding.cs
@@ -61,6 +61,36 @@ internal static class DocumentQueryBinding
         return new JSArray(results);
     }
 
+    /// <summary>
+    /// <c>document.getElementsByName(name)</c> — HTML §3.1.5: every element in the document whose
+    /// <c>name</c> <em>attribute</em> is identical to the argument, in tree order.
+    /// </summary>
+    /// <remarks>
+    /// It is not a synonym for the id lookup and not confined to form controls: any element carrying
+    /// the attribute qualifies, which is why it is an attribute read rather than a selector match.
+    /// The value is compared ordinally — HTML matches it exactly — while the attribute's own name is
+    /// matched case-insensitively, as attribute names are in an HTML document.
+    /// <para>
+    /// It was missing entirely, and on a document that reads as <see langword="undefined"/> rather
+    /// than as an absent method, so calling it threw <c>TypeError: undefined is not a function</c> and
+    /// took the whole script with it. google.com's homepage bundle finds its search form this way —
+    /// <c>for(var d=0;b=c[d++];)if(b=document.getElementsByName(b)[0])return b</c> over
+    /// <c>["f","gs"]</c> — after looking for a form by id first.
+    /// </para>
+    /// </remarks>
+    public static JSValue GetElementsByName(IDocumentQueryHost host, in Arguments a)
+    {
+        var name = a.Length > 0 ? a[0].ToString() : string.Empty;
+        var results = new List<JSValue>();
+        foreach (var el in host.Elements)
+        {
+            if (DomBridge.TryGetAttribute(el, "name", out var value) && string.Equals(value, name, StringComparison.Ordinal))
+                results.Add(host.ToJSObject(el));
+        }
+
+        return new JSArray(results);
+    }
+
     public static JSValue QuerySelector(IDocumentQueryHost host, in Arguments a)
     {
         var selector = a.Length > 0 ? a[0].ToString() : string.Empty;

--- a/src/Broiler.HtmlBridge.Dom/Features/FetchBinding.Callbacks.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/FetchBinding.Callbacks.cs
@@ -148,8 +148,28 @@ internal sealed partial class FetchBinding
                     request.Content = CreateRequestContent(requestBody, requestHeaders);
                 foreach (var kv in requestHeaders)
                 {
-                    if (!string.Equals(kv.Key, "Content-Type", StringComparison.OrdinalIgnoreCase))
-                        request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
+                    // Content-Type already travelled with the body, above.
+                    if (string.Equals(kv.Key, "Content-Type", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    if (request.Headers.TryAddWithoutValidation(kv.Key, kv.Value))
+                        continue;
+
+                    // What HttpRequestMessage.Headers refuses is a *content* header:
+                    // Content-Language, Content-Disposition, Content-Encoding and the rest belong to
+                    // the body in this API, not the request. TryAddWithoutValidation reports the
+                    // refusal by returning false, and this loop used to discard that without a word,
+                    // so a page that set one watched it vanish between fetch and the wire. Retrying
+                    // against the content is what actually sends them.
+                    //
+                    // Content-Length is the deliberate exception and stays dropped. The framework
+                    // derives it from the body it is about to write, and an author value *replaces*
+                    // that derived one rather than being rejected — a page claiming a length its body
+                    // does not have would leave the server waiting for bytes that never arrive, which
+                    // is a worse failure than the dropped header. Fetch forbids the header to authors
+                    // for the same reason.
+                    if (!string.Equals(kv.Key, "Content-Length", StringComparison.OrdinalIgnoreCase))
+                        request.Content?.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
                 }
 
                 var response = _resources.SendAsync(request).GetAwaiter().GetResult();

--- a/src/Broiler.HtmlBridge.Dom/Features/FetchBinding.Callbacks.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/FetchBinding.Callbacks.cs
@@ -1,4 +1,5 @@
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using Broiler.HtmlBridge.Core.Diagnostics;
 using Broiler.HtmlBridge.Internal.Scripting;
@@ -144,7 +145,7 @@ internal sealed partial class FetchBinding
             {
                 var request = new HttpRequestMessage(new HttpMethod(method), fetchUrl);
                 if (requestBody != null)
-                    request.Content = new StringContent(requestBody, Encoding.UTF8, requestHeaders.TryGetValue("Content-Type", out var ct) ? ct : "text/plain");
+                    request.Content = CreateRequestContent(requestBody, requestHeaders);
                 foreach (var kv in requestHeaders)
                 {
                     if (!string.Equals(kv.Key, "Content-Type", StringComparison.OrdinalIgnoreCase))
@@ -217,5 +218,51 @@ internal sealed partial class FetchBinding
 
         promise.FastAddValue((KeyString)"catch", new DomFunction(JsRegistrationCatch119, "catch", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         return promise;
+    }
+
+    /// <summary>
+    /// Builds the request body, carrying the author's <c>Content-Type</c> across as a header value
+    /// rather than as a bare media type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// What a page sets is a full header value, and pages routinely put parameters in it. The body
+    /// used to be built as <c>new StringContent(body, Encoding.UTF8, contentTypeHeader)</c>, whose
+    /// third parameter takes the media type <em>alone</em>: it validates through
+    /// <c>MediaTypeHeaderValue</c>, so a <c>;</c> anywhere in the value throws
+    /// <c>FormatException("The format of value '…' is invalid.")</c> — and an empty value throws
+    /// <c>ArgumentException</c>. That is caught below and turned into an error <c>Response</c>, so
+    /// the symptom is not a crash but a request that is never sent at all, for every POST whose
+    /// content type is spelled the ordinary way: google.com's start page posts
+    /// <c>application/x-www-form-urlencoded;charset=utf-8</c> (its XHR sets that through
+    /// <c>setRequestHeader</c>, which the polyfill hands to <c>fetch</c> as <c>opts.headers</c>), and
+    /// a <c>multipart/form-data; boundary=…</c> or <c>text/plain; charset=UTF-8</c> post failed the
+    /// same way.
+    /// </para>
+    /// <para>
+    /// Parsing into <see cref="HttpContentHeaders.ContentType"/> keeps those parameters. The bytes
+    /// stay UTF-8 regardless of the charset the author wrote, which is what Fetch §body extraction
+    /// says for a string body — the parameter travels in the header, it does not pick the encoding.
+    /// A value too malformed to parse is sent verbatim instead of costing the whole request, and
+    /// with no <c>Content-Type</c> at all the default stays the spec's <c>text/plain;charset=UTF-8</c>.
+    /// </para>
+    /// </remarks>
+    private static StringContent CreateRequestContent(string requestBody, Dictionary<string, string> requestHeaders)
+    {
+        var content = new StringContent(requestBody, Encoding.UTF8);
+        if (!requestHeaders.TryGetValue("Content-Type", out var contentType) || string.IsNullOrWhiteSpace(contentType))
+            return content;
+
+        if (MediaTypeHeaderValue.TryParse(contentType, out var parsed))
+        {
+            content.Headers.ContentType = parsed;
+        }
+        else
+        {
+            content.Headers.Remove("Content-Type");
+            content.Headers.TryAddWithoutValidation("Content-Type", contentType);
+        }
+
+        return content;
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/FormBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/FormBinding.cs
@@ -110,6 +110,30 @@ internal sealed class FormBinding(IFormHost host)
     /// <summary>The <c>form.elements</c> collection object: a JS array-like with numeric indices and
     /// a <c>length</c>, overriding property lookup so a missing name resolves against the form's
     /// named controls (returning null when unmatched, per HTMLFormControlsCollection).</summary>
+    /// <summary>
+    /// The control of <paramref name="form"/> whose <c>name</c> is <paramref name="name"/>, or
+    /// <see langword="null"/> when none carries it.
+    /// </summary>
+    /// <remarks>
+    /// Shared by <c>form.elements</c>' named access and the form element's own named getter so the
+    /// two cannot answer differently. They differ only in what a miss means, which is the callers'
+    /// business: the collection reports <c>null</c>, the form leaves the property undefined.
+    /// </remarks>
+    internal static JSObject? FindNamedControl(DomElement form, string name, IFormHost host)
+    {
+        if (string.IsNullOrEmpty(name))
+            return null;
+
+        foreach (var ctrl in HtmlElementQueries.CollectFormControls(form))
+        {
+            if (ctrl.GetAttribute("name") is { } controlName &&
+                string.Equals(controlName, name, StringComparison.Ordinal))
+                return host.ToJSObject(ctrl);
+        }
+
+        return null;
+    }
+
     private sealed class FormElementsCollection(DomElement form, IFormHost host) : JSObject()
     {
         protected override JSValue GetValue(KeyString key, JSValue receiver, bool throwError = true)
@@ -119,20 +143,43 @@ internal sealed class FormBinding(IFormHost host)
             if (result != null && !result.IsUndefined)
                 return result;
 
-            // Dynamic named lookup in form controls
-            var prop = key.Value.ToString();
-            if (!string.IsNullOrEmpty(prop))
-            {
-                var controls = HtmlElementQueries.CollectFormControls(form);
-                foreach (var ctrl in controls)
-                {
-                    if (ctrl.GetAttribute("name") is { } name &&
-                        string.Equals(name, prop, StringComparison.Ordinal))
-                        return host.ToJSObject(ctrl);
-                }
-            }
-
-            return JSNull.Value; // HTMLFormControlsCollection returns null for missing names
+            return FindNamedControl(form, key.Value.ToString(), host) is { } named
+                ? named
+                : JSNull.Value; // HTMLFormControlsCollection returns null for missing names
         }
+    }
+}
+
+/// <summary>
+/// The JS wrapper for a <c>&lt;form&gt;</c>: an ordinary element object that additionally resolves an
+/// unknown property name to the control carrying that name — <c>HTMLFormElement</c>'s named getter
+/// (HTML §4.10.3).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>form.elements</c> already offered named access, but the form itself did not, so <c>form.q</c>
+/// was <see langword="undefined"/>. That is the spelling pages actually use, and undefined does not
+/// announce itself: google.com's homepage hands the result straight to its search-box component —
+/// <c>var r=hp_SKb(),u=r.q</c> — which stores it and later reads <c>F.value</c>, throwing
+/// <c>Cannot get property value of undefined</c> from a component far from the lookup that failed.
+/// </para>
+/// <para>
+/// Named access is a fallback and not an override: WebIDL consults named properties only when the
+/// object and its prototype chain do not already answer, so <c>form.action</c> stays the action
+/// attribute even when a control is named <c>action</c>. A name nothing carries is left undefined
+/// rather than null, since an absent named property is an absent property.
+/// </para>
+/// </remarks>
+internal sealed class FormElementJSObject(DomElement form, IFormHost host) : JSObject()
+{
+    protected override JSValue GetValue(KeyString key, JSValue receiver, bool throwError = true)
+    {
+        var result = base.GetValue(key, receiver, false);
+        if (result != null && !result.IsUndefined)
+            return result;
+
+        return FormBinding.FindNamedControl(form, key.Value.ToString(), host) is { } named
+            ? named
+            : base.GetValue(key, receiver, throwError);
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/ISelectorsHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ISelectorsHost.cs
@@ -15,6 +15,7 @@ internal interface ISelectorsHost
 {
     JSValue FindInDescendants(DomElement element, string selector, bool all);
     void CollectElementsByTagName(DomElement element, string tagName, List<JSValue> results);
+    void CollectElementsByClassName(DomElement element, string classNames, List<JSValue> results);
     JSObject ToJSObject(DomNode node);
     // Selector matching moved onto the host (Phase 2 item 4 de-globalization): MatchesSelector reads
     // the per-bridge `:checked` state, so it is now a bridge-instance method rather than a static helper.

--- a/src/Broiler.HtmlBridge.Dom/Features/SelectorsBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SelectorsBinding.cs
@@ -55,4 +55,19 @@ internal static class SelectorsBinding
         host.CollectElementsByTagName(element, tagSearch, results);
         return new JSArray(results);
     }
+
+    /// <summary>
+    /// <c>element.getElementsByClassName(names)</c> — DOM §4.9 defines it on <c>Element</c> as well as
+    /// on <c>Document</c>, and only the document half was registered. Missing on an element it did not
+    /// read as absent: calling it threw <c>TypeError: undefined is not a function</c>, which aborts the
+    /// whole script. google.com's One-Google-bar bundle scopes its lookups to a container that way —
+    /// <c>d.getElementsByClassName("gb_C")[0]||d</c> — so it died there.
+    /// </summary>
+    public static JSValue GetElementsByClassName(ISelectorsHost host, DomElement element, in Arguments a)
+    {
+        var classNames = a.Length > 0 ? a[0].ToString() : string.Empty;
+        var results = new List<JSValue>();
+        host.CollectElementsByClassName(element, classNames, results);
+        return new JSArray(results);
+    }
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubDocumentBinding.cs
@@ -117,6 +117,18 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
             new DomFunction((in a) => GetElementsByTagName(docRoot, in a), "getElementsByTagName", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
 
+        // getElementsByClassName(names) / getElementsByName(name) — the two collection lookups a
+        // frame's document was missing while the main document had them. A script in a frame is a
+        // script like any other: absent, these read as undefined rather than as missing methods, so
+        // calling one threw and took the frame's whole <script> with it.
+        doc.FastAddValue((KeyString)"getElementsByClassName",
+            new DomFunction((in a) => GetElementsByClassName(docRoot, in a), "getElementsByClassName", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        doc.FastAddValue((KeyString)"getElementsByName",
+            new DomFunction((in a) => GetElementsByName(docRoot, in a), "getElementsByName", 1),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
         // createElement(tag)
         doc.FastAddValue((KeyString)"createElement",
             new DomFunction((in a) => CreateElement(docRoot, in a), "createElement", 1),
@@ -366,6 +378,37 @@ internal sealed partial class SubDocumentBinding(ISubDocumentHost host)
         var tagName = a.Length > 0 ? a[0].ToString().ToLowerInvariant() : string.Empty;
         var results = new List<JSValue>();
         _host.CollectByTagName(docRoot, tagName, results);
+        return new JSArray(results);
+    }
+
+    /// <summary>
+    /// <c>getElementsByClassName</c> on a frame's document. It reuses
+    /// <see cref="ClassNameSet"/>, the rule the main document and the element-scoped search already
+    /// share, so all three surfaces answer a class query the same way.
+    /// </summary>
+    private JSValue GetElementsByClassName(DomNode docRoot, in Arguments a)
+    {
+        var wanted = ClassNameSet.Parse(a.Length > 0 ? a[0].ToString() : string.Empty);
+        var results = new List<JSValue>();
+        if (wanted.Length > 0)
+            _host.CollectMatching(docRoot, el => ClassNameSet.Matches(el, wanted), results);
+
+        return new JSArray(results);
+    }
+
+    /// <summary>
+    /// <c>getElementsByName</c> on a frame's document — the elements whose <c>name</c> attribute is
+    /// identical to the argument, matching the main document's implementation (HTML §3.1.5).
+    /// </summary>
+    private JSValue GetElementsByName(DomNode docRoot, in Arguments a)
+    {
+        var name = a.Length > 0 ? a[0].ToString() : string.Empty;
+        var results = new List<JSValue>();
+        _host.CollectMatching(
+            docRoot,
+            el => DomBridge.TryGetAttribute(el, "name", out var value) && string.Equals(value, name, StringComparison.Ordinal),
+            results);
+
         return new JSArray(results);
     }
 

--- a/src/Broiler.HtmlBridge.Dom/Features/SubWindowBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubWindowBinding.cs
@@ -109,6 +109,11 @@ internal sealed class SubWindowBinding(
 
         subDocument.FastAddValue((KeyString)"defaultView", subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
 
+        // The frame's document shares its window's Location, as the main document shares the main
+        // window's. A framed page reads `document.location` for its origin exactly as a top-level
+        // one does, and undefined there throws rather than reading as absent.
+        subDocument.FastAddValue((KeyString)"location", iframeLocation, JSPropertyAttributes.EnumerableConfigurableValue);
+
         // window.getComputedStyle — sub-window needs its own copy so that
         // doc.defaultView.getComputedStyle(node, "") resolves CSS rules from
         // the sub-document's <style> elements rather than the main document.

--- a/src/Broiler.HtmlBridge.Dom/Runtime/BrowserEventLoop.cs
+++ b/src/Broiler.HtmlBridge.Dom/Runtime/BrowserEventLoop.cs
@@ -162,6 +162,43 @@ internal sealed class BrowserEventLoop
         !_timers.IsEmpty || !_rafCallbacks.IsEmpty || !_frameActions.IsEmpty;
 
     /// <summary>
+    /// Whether any queued work is due at or before <paramref name="horizonMs"/> on the virtual clock.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="HasPendingWork"/> cannot answer "is this page finished?", because an interval is
+    /// never finished: it reschedules to <c>Deadline + Period</c> after every tick, so a page holding
+    /// one keeps pending work forever by design. A drain that waits for the queue to empty therefore
+    /// cannot terminate on the ordinary case, and each step advances the virtual clock by a whole
+    /// period — so waiting it out does not merely spin, it simulates page time that a capture was
+    /// never meant to cover.
+    /// </para>
+    /// <para>
+    /// A horizon separates the two questions. Work scheduled beyond it is simply later, not stuck,
+    /// and a caller can stop without calling the page broken. Work still due at time zero after
+    /// repeated draining is the genuine runaway — a callback that reschedules itself with no delay —
+    /// and stays visible because it never moves the clock past the horizon.
+    /// </para>
+    /// <para>
+    /// Animation-frame callbacks and frame actions carry no deadline; they are due whenever they are
+    /// queued, so they count as due at any horizon.
+    /// </para>
+    /// </remarks>
+    public bool HasWorkDueBy(double horizonMs)
+    {
+        if (!_rafCallbacks.IsEmpty || !_frameActions.IsEmpty)
+            return true;
+
+        foreach (var kv in _timers.ToArray())
+        {
+            if (!_clearedTimerIds.ContainsKey(kv.Key) && kv.Value.Deadline <= horizonMs)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Runs pending work to a fixed point: repeatedly runs one batch (up to a safety cap) until no
     /// batch does anything, then clears the processed-timer-id set. <paramref name="taskCheckpoint"/>
     /// runs after each task (a spec-like microtask checkpoint). Used before DOM capture/serialisation.

--- a/src/Broiler.HtmlBridge.Scripting/ScriptEngine.cs
+++ b/src/Broiler.HtmlBridge.Scripting/ScriptEngine.cs
@@ -428,25 +428,27 @@ public sealed partial class ScriptEngine : ITypedScriptEngine
                 hadWork = true;
             }
 
-            if (bridge.HasPendingTimers)
+            if (bridge.HasPendingTimersDueBy(DomBridgeRuntimeLimits.AsyncDrainVirtualTimeBudgetMs))
             {
                 bridge.FlushTimerStep();
                 hadWork = true;
             }
 
             if (!hadWork)
-                return; // settled — the queues drained within the budget
+                return; // settled — nothing left that this capture's window covers
         }
 
-        // Phase 8 item 3: the iteration budget is exhausted while work is still queued (typically a
-        // runaway microtask/timer loop, e.g. a setTimeout/queueMicrotask that reschedules itself).
-        // Surface this explicitly instead of stopping silently: record it on the engine and log a
-        // warning with the pending counts so it is diagnosable rather than an invisible truncation.
+        // Phase 8 item 3: the iteration budget is exhausted while work is *still due now*. The
+        // virtual-time horizon above already retires the ordinary case — a page holding an interval,
+        // whose next tick is simply later — so reaching here means work that keeps regenerating at
+        // the current instant and never lets the clock move: a setTimeout or queueMicrotask that
+        // reschedules itself with no delay. Record it on the engine and log it, so the truncation is
+        // diagnosable rather than invisible.
         AsyncDrainLimitExhausted = true;
         RenderLogger.LogWarning(LogCategory.JavaScript, "ScriptEngine.DrainAsyncWork",
-            $"Async work did not settle within {DomBridgeRuntimeLimits.AsyncDrainIterationLimit} drain iterations; " +
-            $"stopping with pending microtasks={MicroTasks.Count}, pendingTimers={bridge.HasPendingTimers}. " +
-            "This usually indicates a runaway microtask/timer loop.");
+            $"Async work still due after {DomBridgeRuntimeLimits.AsyncDrainIterationLimit} drain iterations; " +
+            $"stopping with pending microtasks={MicroTasks.Count}. " +
+            "A callback is rescheduling itself with no delay, so the virtual clock cannot advance.");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Four exceptions reported while rendering google.com, plus three adjacent defects found on the way. They are a chain: each one aborted the same script, so fixing it only revealed the next. The `window.top` fix that landed just before this branch was the first link.

They share a shape worth naming. A binding the page reasonably expects is missing, so the lookup yields `undefined` rather than reporting anything, and the member access or call on it throws. Because `window` **is** the global object here, that throw takes the entire `<script>` rather than the one statement — every function it would have defined and every listener it would have registered goes with it. A single absent property therefore removes a whole feature silently.

## The four reported exceptions

**1. `The format of value 'application/x-www-form-urlencoded;charset=utf-8' is invalid.`**

The request body was built as `new StringContent(body, Encoding.UTF8, contentTypeHeader)`. That third parameter takes the media type *alone* — it validates through `MediaTypeHeaderValue`, so any `;` in the value throws, and an empty value throws `ArgumentException`. The binding's own `catch` turns that into an error `Response`, so the symptom was not a crash but a POST that never reached the network, reported to the page as a network failure. The page's XHR sets that header via `setRequestHeader`, which the polyfill hands to `fetch` as `opts.headers`.

Not an exotic spelling: `multipart/form-data; boundary=…` and `text/plain; charset=UTF-8` failed identically. Only a bare `application/json` got through.

Fixed by parsing into `HttpContentHeaders.ContentType`, which keeps the parameters. Body bytes stay UTF-8 whatever charset the header names — per Fetch's body extraction the parameter travels in the header, it does not choose the encoding. A value too malformed to parse is sent verbatim rather than costing the request.

*Behaviour change:* an author-supplied type with no parameters is now sent as written. `application/json` used to go out as `application/json; charset=utf-8` because the old constructor appended the encoding. Browsers send the author's value verbatim.

**2. `Cannot get property protocol of undefined`**

`document.location` was never registered — the `Location` object was put on `window` alone. HTML §3.1.5 makes `document.location` the *same* object, not a copy, so the one object is now registered on both and `document.location === window.location` holds. The One-Google-bar bundle builds its own origin with `dF=function(){var a=document.location;return a.protocol+"//"+a.host}`.

A frame's document gets the same treatment beside its existing `defaultView` wiring: a framed page reads `document.location` exactly as a top-level one does and threw the same way.

**3. `TypeError: undefined is not a function` — `Element.getElementsByClassName`**

Registered only on `document`, though DOM §4.9 defines it on `Element` too. It was the one member of its family missing — element wrappers already had `querySelector`, `querySelectorAll`, `getElementsByTagName`, `matches` and `closest`. The bundle scopes a lookup with `d.getElementsByClassName("gb_C")[0]||d`.

The search is a direct descendant walk rather than a trip through the selector engine as `"." + names`: the argument holds literal class names, and one carrying selector-significant characters would need escaping to survive that route.

**4. `TypeError: undefined is not a function` — `document.getElementsByName`**

Not implemented at all. This one is in the homepage `xjs` bundle rather than the One-Google-bar, and what it costs is the **search box**: the bundle locates the form it is about to wire up by id, then falls back to `c=["f","gs"];for(var d=0;b=c[d++];)if(b=document.getElementsByName(b)[0])return b`, so the throw lands while finding the form.

HTML §3.1.5 asks for every element whose `name` *attribute* is identical to the argument, in tree order. Three things there are easy to get wrong and are covered: it is an attribute read rather than a selector match or an id lookup; it is not confined to form controls, so a `div` or an anchor carrying the attribute qualifies; and the value is compared exactly, so `name="Q"` is not `name="q"` even though the attribute's own name matches case-insensitively.

## Three defects found beside them

**`document.getElementsByClassName` read its argument as a single name.** A multi-class query matched only an element whose whole class attribute was that literal string — that is, nothing — where DOM §4.5 asks for the elements carrying every name in the set. Both halves now share `ClassNameSet`.

**A frame's document had neither collection lookup.** Sub-documents build their own query surface and carried only `getElementById`, `getElementsByTagName` and the `querySelector` pair, so `getElementsByClassName` and `getElementsByName` threw inside a frame exactly as they did at the top level. Both now go through the host's existing predicate collector — the one `querySelectorAll` uses — and the class lookup reuses `ClassNameSet`, making it the third surface answering a class query identically rather than a third implementation of the same idea.

**Entity headers a page set were silently discarded.** `HttpRequestMessage` splits headers in two, and `Content-Language`, `Content-Disposition`, `Content-Encoding` and `Content-Location` belong to the body. `TryAddWithoutValidation` reports a header it will not take by returning `false`, and the loop discarded that return, so a page could set one, see no error, and have it never sent. Anything `request.Headers` refuses is now retried against the content.

`Content-Length` stays dropped, deliberately. .NET derives it from the body it is about to write, and an author value *replaces* that rather than being rejected — forwarding one would let a page declare a length its body does not have and leave the server waiting for bytes that never arrive. Dropping it is both the safer failure and what Fetch asks for, the header being forbidden to authors.

## Testing

77 new tests across six files, each written against the failure it describes rather than around it:

- `FetchContentTypeTests` and `FetchRequestHeadersTests` assert against a loopback origin that records what it actually received, so what is checked is the request on the wire rather than the binding's own bookkeeping. Since a request that never arrives is the bug, every case also proves the request was made at all.
- `DocumentLocationTests`, `ElementGetElementsByClassNameTests` and `DocumentGetElementsByNameTests` run the bundles' own expressions as they spell them, because what failed was the member access, not the lookup.
- `SubDocumentCollectionLookupTests` requires the host document to find *nothing* while the frame's finds its own, since a test asserting only the frame's results would pass even if the lookup were silently walking the main document.

Every test was confirmed to fail without its fix, reproducing the reported message. Targeted regression runs over the fetch/network/XHR, selector/DOM, window/document/frame and sub-document surfaces show no new failures: each run's failure set was compared against a baseline captured before any of this work, and the difference was empty in every case.

Note that no CI runs on this PR — every workflow in the repository is `workflow_dispatch`-only — so these local runs are the only verification.

## Boundaries left in place, each pinned by a test

- A bodyless request has no content to carry an entity header, so one set on a GET is still not sent. Manufacturing an empty body to hold it would put `Content-Length: 0` on a GET and change what the request means.
- The collection lookups return static arrays rather than live `HTMLCollection`/`NodeList` objects, matching the existing shape of the collection methods here.

https://claude.ai/code/session_01KUQYLn2HSywxJLvKetUbiW