### PR TITLE
Canvas 2D context now rasterises into a bitmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,51 @@ are versioned in lockstep during the preview.
   settable directly, as the other compiler switches are. A failure to write is swallowed — a
   diagnostic must never be able to break the execution it observes.
 
+- `Broiler.HtmlBridge` — the Canvas 2D context has pixels. It owns a
+  `Broiler.Graphics` `BBitmap` the size of the canvas and rasterises into it through
+  `BCanvas`, so `getImageData`, `putImageData`, `createImageData` and
+  `canvas.toDataURL` — all previously absent, so all previously a `TypeError` —
+  report what was actually drawn. `fillRect`, `clearRect`, `strokeRect`, the path
+  operations and `fillText` were empty method bodies before this: the context kept
+  the drawing state and painted nothing, a Phase 6 leftover from removing a command
+  recorder no renderer ever read.
+  - The pixel API was deliberately left *absent* rather than stubbed while that was
+    true, because zeroed pixels would have turned an honest `TypeError` — which
+    every feature detector reads as "no canvas readback" — into a false claim of
+    support. A real backing store is what retires that reasoning, and the same care
+    is why `toDataURL` of a type with no encoder falls back to `image/png` (as HTML
+    requires) rather than pretending: `image/webp` and `image/vnd.ms-photo` still
+    correctly report themselves unsupported.
+  - `getContext('2d')` returns the same context object every call, as the spec
+    requires. That was invisible while the context held nothing worth keeping and
+    decisive once it held a bitmap — every call was handing back a blank canvas.
+  - `canvas.width`/`canvas.height` are reflected, and assigning either resets the
+    bitmap to transparent black and the context to its default state — so
+    `canvas.width = canvas.width`, the idiomatic way to clear a canvas, clears it.
+  - `globalCompositeOperation` is a real accessor that applies the separable blend
+    modes through a `BCanvas` blend layer and ignores an operator it cannot
+    composite. It used to be nothing at all: the assignment merely created an own
+    property on an extensible object, so the value read back because it had been
+    stored, not because anything blended.
+  - `ctx.canvas` is the canvas element rather than a fresh empty object, and the
+    `HTMLCanvasElement` members are installed only on a `<canvas>` — `getContext`
+    was previously on every element and answered `null` from a tag check inside,
+    which made the call right and the name wrong.
+  - `CanvasRenderingContext2D` and `ImageData` join the DOM interface-constructor
+    globals. Neither is a node, so they answer `instanceof` from the members that
+    define the interface rather than from `nodeType`; `ImageData` is additionally
+    constructible, as HTML defines it.
+  - The bitmap is script-visible, not yet page-visible: nothing outside the binding
+    reads it, so a `<canvas>` still lays out as an empty replaced box and paints
+    nothing into the page. A page that draws a chart and shows it still renders
+    blank; one that reads its pixels back, or serialises them through `toDataURL`,
+    now gets the real image.
+  - Measured on html5test.com: 126/555 → 141/555, its 2D Graphics section 2/25 →
+    17/25, with no row regressing. Still absent, and still honestly absent:
+    `drawImage`, gradients and patterns, `clip`, `ellipse`, `setLineDash`, `Path2D`,
+    `toBlob`, and any transform beyond the identity. See
+    `docs/html5test-exceptions.md`.
+
 ### Changed
 
 - `Broiler.Browser.Core` and `Broiler.Writer` — the UI hosts no longer keep a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,17 @@ are versioned in lockstep during the preview.
 
 ### Changed
 
+- `Broiler.JS` (patch, pending upstream) — `new undefined()` and `new null()` report
+  `undefined is not a constructor` / `null is not a constructor` instead of
+  `cannot create instance of …`. No browser used the old wording and neither did
+  the rest of the engine — `JSFunction`, `JSSymbol`, `JSGenerator`, `JSReflect` and
+  `JSPromisePrototype` all already said "is not a constructor"; these two sites were
+  the only holdouts. It matters because the throw itself is usually *correct*: it is
+  what a feature probe such as html5test's
+  `new (window.RTCPeerConnection || …)(null)` gets from an engine without WebRTC, and
+  a wording no browser produces makes a right answer read as an engine fault.
+  `undefined is not a function` is deliberately unchanged — that one already matches.
+
 - `Broiler.Browser.Core` and `Broiler.Writer` — the UI hosts no longer keep a
   private clipboard string for when the shell wired no platform accessor. A
   fallback that only this process can see makes copy and paste appear to work

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1036,10 +1036,16 @@ are the contract.
 | Runtime and execution responsibilities in `Broiler.HtmlBridge.Core` | Runtime interfaces to `Broiler.HtmlBridge.Dom`; module execution plus execution DTOs/profiling to `Broiler.HtmlBridge.Scripting`; generic meta discovery to `Broiler.Dom.Html` | Host orchestration and public v2 forwarding facades until a major-version boundary |
 | Logging, URL/origin/CSP, and resource responsibilities in `Broiler.HtmlBridge.Core` | `RenderLogger` to `Broiler.Diagnostics`; injected web URL/origin/security/resource primitives to a small host-services component only after its dependency seam is proven | Security decisions, credentials/network policy, and browser API bindings |
 
-Canvas is deliberately not a current extraction candidate: its implementation is
-primarily JS-observable state and the draw calls are still no-ops. A future real
-display-list or raster contract belongs in `Broiler.Graphics`; moving the stub
-would only put bridge behavior in the wrong assembly.
+Canvas is deliberately not a current extraction candidate, though no longer for the
+reason first written here — the draw calls are no longer no-ops. The 2D context now
+owns a `Broiler.Graphics` `BBitmap` and rasterises into it through `BCanvas`, which
+is what makes `getImageData` and `toDataURL` report real pixels
+(`docs/html5test-exceptions.md`). The raster contract that was described as future
+work is therefore already `Broiler.Graphics`', and what remains in the bridge is
+argument conversion and the drawing state — bridge behavior, which is where it
+belongs. What would justify revisiting this is the paint path: nothing outside the
+binding reads the bitmap, so a `<canvas>` still paints nothing into the page, and
+connecting it means a display item in `Broiler.Layout` sourced from that bitmap.
 
 #### DOM component rehoming
 

--- a/docs/html5test-exceptions.md
+++ b/docs/html5test-exceptions.md
@@ -58,6 +58,12 @@ defects — but it does mean none of them was an emergency.
 
 ---
 
+# Third report: `1986` alone
+
+The canvas fix below landed, and `3030`, `3055` and `3071` are gone from the report with it. What
+remains is the WebRTC probe, on its own — and it is the one of the four that was never a defect. Its
+message is now fixed too (see the section on it); the throw itself is correct and stays.
+
 # Second report: `1986`, `3030`, `3055`, `3071`
 
 Two of the first report's four are gone, which is the first thing worth reading off it: the
@@ -93,11 +99,32 @@ This is the expected outcome of a feature probe against an engine without the fe
 WebRTC disabled throws here too. Nothing to fix; implementing WebRTC is a feature project (an
 ICE/DTLS/SCTP stack), not a bug fix.
 
-One cosmetic observation, independent of html5test: Broiler words this `cannot create instance of
-undefined`, where the spec-conventional phrasing — and Broiler's own wording at its other construct
-sites — is `… is not a constructor`. Worth a sweep if error-message consistency is ever tidied; it
-lives in the `Broiler.JS` submodule (`JSUndefined.cs`, `JSNull.cs`), so it would go through the patch
-workflow.
+### The message was wrong even though the throw was right — **fixed**
+
+Broiler worded this `cannot create instance of undefined`. No browser does: V8, SpiderMonkey and JSC
+all say `undefined is not a constructor`, and so does the rest of this engine — `JSFunction`,
+`JSSymbol`, `JSGenerator`, `JSGeneratorFunctionV2`, `JSReflect` and `JSPromisePrototype` all raise
+`… is not a constructor`. `JSUndefined.CreateInstance` and its `JSNull` sibling were the only two
+sites left with a wording of their own.
+
+That is worth fixing precisely *because* the throw is correct. This trace is the engine giving the
+right answer to a feature probe, and a message no browser produces makes it read as an engine fault —
+which is exactly how it arrived here, twice. `InvokeFunction`'s `undefined is not a function` is
+deliberately untouched: that one already matches the browsers.
+
+Both sites live in the `Broiler.JS` submodule, whose remote is outside this session's GitHub scope, so
+the fix ships through the patch workflow rather than as a pointer bump — the commit
+*"Say "is not a constructor", as every other construct site does"*, exported under `patches/` with its
+tests (`ConstructNonConstructorMessageTests`). Nothing in the main repository asserts either message,
+so the engine behaves identically until a maintainer applies it; the cost of not applying it is a
+non-standard string in a stack trace.
+
+**This does not remove the exception, and nothing short of implementing WebRTC would.** The page
+evaluates `new (A || B || C || D)(null)` where all four are undefined; the only way not to throw is to
+define one of them, and defining one that cannot open a peer connection would be the false claim of
+support that the canvas section above spends its length avoiding. A browser with WebRTC disabled
+throws here too. The 45 points html5test allots to `Peer To Peer` require a working implementation, not
+a name.
 
 ## (2) `undefined is not a function` — `engine.js:3030`, `3055`, `3071` — **fixed**
 
@@ -359,6 +386,7 @@ Second round:
 | `src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs` | pass the bridge to `CanvasBinding.Install` |
 | `src/Broiler.HtmlBridge.Dom/Broiler.HtmlBridge.Dom.csproj` | reference `Broiler.Graphics` and `Broiler.Media.Image` |
 | `src/Broiler.Cli.Tests/CanvasPixelSurfaceTests.cs` | new — the pixel surface, and the html5test probes verbatim |
+| `patches/0007-not-a-constructor-message.patch` | `Broiler.JS` — `new undefined()` says "is not a constructor" |
 
 First round:
 

--- a/docs/html5test-exceptions.md
+++ b/docs/html5test-exceptions.md
@@ -1,7 +1,7 @@
-# html5test.com — the four rendering exceptions
+# html5test.com — the rendering exceptions
 
-Rendering <https://html5test.com/> reported four distinct JavaScript exceptions. This is what
-each one actually is, what was fixed, and what was deliberately left alone.
+Rendering <https://html5test.com/> has been reported twice, each time as four distinct JavaScript
+exceptions. This is what each one actually is, what was fixed, and what was deliberately left alone.
 
 Source of the page under test: <https://github.com/WebPlatformTest/HTML5test>.
 
@@ -23,33 +23,224 @@ For html5test that gives:
 So every reported failure is in `engine.js`, reached through `Runner` (`engine.js:4423`) and the
 `testsuite[s](this.list)` dispatch loop (`engine.js:4512`).
 
-## None of the four aborted the page
+**Line numbers are the live file's, not GitHub's.** The copy html5test.com serves carries one extra
+line near the top (a bare `Test =` on line 2) that the repository's does not, so every line below it
+is off by one between the two. Fetch `https://html5test.com/scripts/8/engine.js` when checking a
+trace.
 
-Every one of the four sites sits inside html5test's own `try { … } catch (e) { }`. That is not
-incidental — `Runner.initialize` wraps the whole testsuite loop in a single
-`try { … } catch (e) { error(e) }` (`engine.js:4423-4519`), so had the first exception escaped, the
-run would have stopped there and the other three could never have been reported. Four reports is
-itself the proof that all four were caught.
+## None of them aborted the page
+
+Every reported site sits inside html5test's own `try { … } catch (e) { }`. That is not incidental —
+`Runner.initialize` wraps the whole testsuite loop in a single `try { … } catch (e) { error(e) }`
+(`engine.js:4423-4519`), so had the first exception escaped, the run would have stopped there and the
+others could never have been reported. Four reports is itself the proof that all four were caught.
 
 They are feature-detection probes: html5test deliberately provokes a throw and reads the failure as
 "unsupported".
 
-**Where the report came from matters.** Broiler's own capture diagnostics would not have listed
-these. The only place a JS error is ever logged is the host `catch` around
-`context.Eval(script, label)` — `src/Broiler.Cli/CaptureService.cs:770-776` and `:789-792`, and the
-equivalents in `src/Broiler.HtmlBridge.Scripting/ScriptEngine.cs` — that is, the *unwind* boundary,
-reached only when an exception escapes an entire script. There is no throw-time hook anywhere:
-`Broiler.JS` never reports, it only *constructs* a `JSException` carrying an origin frame. A caught
-exception therefore produces no `javascript-errors.log` entry at all.
+**Where the report came from matters.** Broiler's own capture diagnostics do not list these. The only
+place a JS error is ever logged is the host `catch` around `context.Eval(script, label)` —
+`src/Broiler.Cli/CaptureService.cs` and the equivalents in
+`src/Broiler.HtmlBridge.Scripting/ScriptEngine.cs` — that is, the *unwind* boundary, reached only when
+an exception escapes an entire script. There is no throw-time hook anywhere: `Broiler.JS` never
+reports, it only *constructs* a `JSException` carrying an origin frame. A caught exception therefore
+produces no `javascript-errors.log` entry at all, and a `--diagnostic-dir` capture of this page reports
+**0 JavaScript failures** both before and after every fix below.
 
-The four traces here interleave C# frames (`JSUndefined.cs:41`) with JS frames and name Windows
-paths (`D:\Broiler\…`), which is what a **first-chance** observer sees: every `JSException` at the
-moment it is constructed, caught or not. That is a strictly noisier view than the capture
-diagnostics, and reading it as a list of page failures overstates what happened — none of these
-stopped html5test, and one of them (WebRTC) is the correct answer.
+The reported traces interleave C# frames (`JSUndefined.cs:62`) with JS frames and name Windows paths
+(`D:\Broiler\…`), which is what a **first-chance** observer sees: every `JSException` at the moment it
+is constructed, caught or not. That is a strictly noisier view than the capture diagnostics, and
+reading it as a list of page failures overstates what happened — none of these stopped html5test, and
+one of them (WebRTC) is the correct answer.
 
-That does not make them uninteresting — three of the four are real capability gaps, and two were
-outright defects — but it does mean none of them was an emergency.
+That does not make them uninteresting — they are real capability gaps, and several were outright
+defects — but it does mean none of them was an emergency.
+
+---
+
+# Second report: `1986`, `3030`, `3055`, `3071`
+
+Two of the first report's four are gone, which is the first thing worth reading off it: the
+`attributes[0]` and `HTMLElement` fixes below landed and their probes no longer throw. What is left is
+**two root causes**, not four:
+
+| trace | probe | cause |
+| --- | --- | --- |
+| `engine.js:1986` | `new (window.RTCPeerConnection \|\| …)(null)` | no WebRTC — **not a defect** |
+| `engine.js:3030` | `ctx.getImageData(0, 0, 1, 1)` | canvas had no pixels — **fixed** |
+| `engine.js:3055` | `canvas.toDataURL('image/png')` | canvas had no pixels — **fixed** |
+| `engine.js:3071` | `canvas.toDataURL('image/jpeg')` | canvas had no pixels — **fixed** |
+
+Two further sites, `engine.js:3087` (`image/vnd.ms-photo`) and `:3103` (`image/webp`), are the same
+`toDataURL` call and threw identically; they are absent from the report. Why is not determinable from
+this side — the observer that produced it is not code in this repository, and its de-duplication is not
+described by the traces (each block repeats its frame list two or three times, with no consistent
+relation to the number of call sites). They are fixed by the same change and are covered by a test.
+
+## (1) `TypeError: cannot create instance of undefined` — `engine.js:1986` — **not a defect**
+
+```js
+o = new (window.RTCPeerConnection || window.msRTCPeerConnection || window.mozRTCPeerConnection || window.webkitRTCPeerConnection)(null);
+```
+
+All four are undefined, so this is `new undefined(…)`. Broiler implements no WebRTC surface anywhere —
+no `RTCPeerConnection`, no `RTCDataChannel`, no `navigator.mediaDevices`, no `getUserMedia`, in the main
+repo or any submodule. `webrtc/*` is listed in `tests/wpt-baseline/failed-tests.json` as a durable
+expected failure, and WebRTC does not appear in `docs/ROADMAP.md`. The whole `Peer To Peer` section of
+html5test scores 0/45 and did so before and after this round.
+
+This is the expected outcome of a feature probe against an engine without the feature — a browser with
+WebRTC disabled throws here too. Nothing to fix; implementing WebRTC is a feature project (an
+ICE/DTLS/SCTP stack), not a bug fix.
+
+One cosmetic observation, independent of html5test: Broiler words this `cannot create instance of
+undefined`, where the spec-conventional phrasing — and Broiler's own wording at its other construct
+sites — is `… is not a constructor`. Worth a sweep if error-message consistency is ever tidied; it
+lives in the `Broiler.JS` submodule (`JSUndefined.cs`, `JSNull.cs`), so it would go through the patch
+workflow.
+
+## (2) `undefined is not a function` — `engine.js:3030`, `3055`, `3071` — **fixed**
+
+```js
+var data = ctx.getImageData(0, 0, 1, 1);                                   // 3030
+passed = canvas.toDataURL('image/png').substring(5, 14) == 'image/png';    // 3055
+passed = canvas.toDataURL('image/jpeg').substring(5, 15) == 'image/jpeg';  // 3071
+```
+
+`getImageData`, `putImageData`, `createImageData`, `ImageData` and `toDataURL` were all absent. The
+absence was structural rather than a missing entry in a member list: the 2D context was a **style-state
+stub with no pixels**. `CanvasRenderingContext2D` kept `fillStyle`, `lineWidth`, `font` and the
+save/restore stack, and every drawing method was a literal empty body —
+`public void FillRect(float x, float y, float width, float height) { }`. Phase 6 had removed a
+`CanvasDrawCommand` recorder that no renderer ever read, and what remained recorded nothing. So there
+was no backing store for `getImageData` to read or for `toDataURL` to encode.
+
+**The previous round deliberately did not stub them**, and that call was right at the time: returning
+zeroed pixels would have converted an honest `TypeError` — which every feature detector on the web
+reads correctly as "no canvas readback" — into a false claim of support, and pages that branch on
+`typeof ctx.getImageData === 'function'` would then take the canvas path and silently render nothing.
+Absent is the safer answer *until the context can actually rasterise*. That is the condition this round
+removes.
+
+### The fix: the context has a bitmap
+
+`CanvasRenderingContext2D` now owns a `Broiler.Graphics` `BBitmap` the size of the canvas and
+rasterises into it through `BCanvas`, the CPU raster canvas that already backs the rest of the engine's
+software rendering. `Broiler.Graphics` depends only on `Broiler.Media.Image` and nothing depends on the
+bridge, so `Broiler.HtmlBridge.Dom` can reference it without a cycle.
+
+Nothing in the JS surface gained or lost a *name* as a result of rasterising — `fillRect`, `arc`,
+`fill`, `stroke`, `fillText` and the rest were already there. They stopped being empty bodies:
+
+- **Rects and paths.** `fillRect`/`strokeRect` go to `BCanvas.FillRect`/`DrawRectangleStroke`;
+  `clearRect` writes transparent pixels straight to the bitmap, because every blending path would
+  leave a fully transparent source with no effect. Paths accumulate as flattened subpaths — `arc` is
+  flattened so the chord's sagitta stays under a quarter pixel — and `fill`/`stroke` go to
+  `FillPolygon`/`DrawPathStroke`.
+- **Text** goes through `BImageRenderer`'s `DrawText`, so the glyphs are real outlines from the system
+  font rather than boxes. That renderer clears whatever surface it is given, so a run is drawn on a
+  scratch bitmap sized to the run — not to the canvas — and composited.
+- **`globalAlpha`** folds into the resolved colour's alpha. **`globalCompositeOperation`** wraps a
+  single draw in a `BCanvas` blend layer for the modes that rasteriser implements (`multiply`,
+  `screen`, `overlay`, `darken`, `lighten`, `difference`, `plus-lighter`).
+- **`getImageData`/`putImageData`/`createImageData`** read and write the bitmap directly.
+  `BBitmap` holds straight-alpha RGBA, which is exactly what `ImageData` wants, so no conversion is
+  needed. Out-of-bounds reads come back transparent black, as the spec requires.
+- **`toDataURL`** encodes through `BBitmap.Encode`, which reaches `Broiler.Media.Image.Managed`'s
+  encoders — PNG, JPEG, BMP and GIF.
+
+Three things about that are worth keeping straight, because each is the difference between an honest
+answer and a plausible-looking wrong one:
+
+**`toDataURL` of an unsupported type falls back to PNG rather than throwing.** HTML requires it, and it
+is also what keeps the answer honest: there is no JPEG-XR or WebP encoder, so `canvas.jpegxr` and
+`canvas.webp` still read `image/png` out of the returned URL and still report **No**. A test pins that
+they do — becoming Yes there would be the false claim of support this whole section is about.
+
+**`getContext('2d')` now returns the same object every call.** It always should have — the spec
+requires it — but while the context had no state worth keeping, building a fresh one per call was
+merely wasteful. With a bitmap behind it, it decides whether anything a page draws survives: every
+`getContext` handed back a blank canvas. The context is keyed off the `DomElement` rather than off its
+JS wrapper, so it also survives the wrapper being rebuilt.
+
+**`globalCompositeOperation` is a real accessor now, and rejects what it cannot do.** It used to be
+nothing at all: the context object is extensible, so `ctx.globalCompositeOperation = 'screen'` merely
+created an own property, and reading it back returned `'screen'` because the assignment had stored the
+string — not because anything composited. That round-trip is exactly what a feature detector tests. The
+setter now ignores an operator the rasteriser cannot apply, so the value that reads back is one that
+was honoured.
+
+Two smaller defects fell out of the same file:
+
+- **`ctx.canvas` returned a fresh empty object**, so `ctx.canvas === theCanvas` was false and
+  `ctx.canvas.width` did not answer. It returns the canvas element's JS object.
+- **An `#if BROILER_CLI` branch claimed `getContext("2d")` returned `null` in the CLI.** It never did.
+  `BROILER_CLI` is defined by `Broiler.Cli.csproj` for *its own* compilation, and `DefineConstants`
+  does not reach a referenced project, so the constant was never set while `Broiler.HtmlBridge.Dom` was
+  compiled and the branch was unreachable. Removing it changed no behaviour; what it cost was a comment
+  that described a host difference that did not exist.
+
+### What is exact and what is approximate
+
+Rect fills, `clearRect`, path fills and strokes, `globalAlpha` and the blend modes are as exact as
+`BCanvas` is. Two things are not, and are documented on the type rather than left to be discovered:
+
+- **`measureText`** reports `BImageRenderer`'s own per-character block advance, not a shaped advance
+  from the font. The non-`start` `textAlign` values derive from it and are approximate for the same
+  reason.
+- **There is no transform stack.** The binding exposes no `translate`/`rotate`/`scale`/`setTransform`,
+  so none is needed — and `BCanvas` is a translate+uniform-scale rasteriser that could not carry a
+  general affine anyway. Adding the transform methods means teaching the rasteriser affines first.
+
+Also still absent, and still honestly absent: `drawImage`, gradients and patterns, `clip`, `ellipse`,
+`setLineDash`, `Path2D`, `toBlob`. Their html5test rows (`canvas.path`, `canvas.ellipse`,
+`canvas.dashed`, `canvas.focusring`, `canvas.hittest`) still read No.
+
+### The bitmap is script-visible, not yet page-visible
+
+**A `<canvas>` still paints nothing into the page.** Nothing outside the binding reads the context —
+`Broiler.Layout` has no canvas display item, and a `<canvas>` lays out as an empty replaced box exactly
+as before. So a page that draws a chart and shows it still renders blank in a capture; what changed is
+that the same page can now read those pixels back, and that a page which *serialises* its canvas —
+`toDataURL` into an `<img>`, or a data URL posted to a server — gets the real image.
+
+That is a smaller gap than it was: the pixels now exist, in a `BBitmap` the display list's own
+rasteriser already knows how to draw. Connecting them is a `DrawImageItem` sourced from the context's
+bitmap plus an invalidation when a drawing call dirties it, in the shape `SvgImageRaster` already uses
+for SVG-as-image. It is deliberately not attempted here — this change is about the exceptions, and
+wiring the paint path is a separate piece of work with its own invalidation questions.
+
+## Measured end to end
+
+A real capture of the live site before and after
+(`dotnet run --project src/Broiler.Cli -- --capture-image https://html5test.com/ --output <png>
+--diagnostic-dir <dir>`), reading the score out of the post-script document the diagnostics archive:
+
+| | score | rows scoring "Yes" | 2D Graphics section |
+| --- | --- | --- | --- |
+| before | 126 / 555 | 66 | 2 / 25 |
+| after | **141 / 555** | **70** | **17 / 25** |
+
+Newly passing: `canvas.context`, `canvas.blending`, `canvas.png`, `canvas.jpeg`. Every other row is
+unchanged and **nothing regressed from "Yes" to "No"** — verified by diffing all 276 rows, not by
+comparing totals.
+
+`canvas.context` is in that list because it needs `CanvasRenderingContext2D` to exist as a global and
+answer `instanceof`; that constructor and `ImageData` join the interface constructors from the previous
+round in `DomBridge.RegisterDomInterfaceConstructors`. They are not node types, so they answer from the
+members that define the interface rather than from `nodeType`. `ImageData` is additionally
+*constructible*, as HTML defines it, and its `@@hasInstance` accepts both one the constructor produced
+and one `getImageData` returned — those are different objects, and the readback is the commoner of the
+two.
+
+Both runs still report **0 JavaScript failures** in the diagnostics, which is the "caught exceptions are
+not logged" point above made concrete: the fix is visible in the score, not in the failure count.
+
+---
+
+# First report: `44`, `228`, `1986`, `3030`
+
+Kept because two of these are why the second report is shorter than the first.
 
 ## (1) `TypeError: Cannot get property nodeName of undefined` — `engine.js:44` — **fixed**
 
@@ -89,7 +280,7 @@ This was never really an html5test problem. Any page looping `el.attributes[i]` 
 runner had already had to route around it in its custom-elements shim — *"the bridge's `attributes`
 reports a length but does not answer to numeric indexing, so the obvious loop read `undefined.name`
 and threw out of `customElements.define` — taking the whole page's script with it"*
-(`src/Broiler.Wpt/WptTestRunner.cs`). That workaround can now be retired at leisure.
+(`src/Broiler.Wpt/WptTestRunner.cs`).
 
 ## (2) `ReferenceError: HTMLElement is not defined` — `engine.js:228` — **fixed**
 
@@ -128,69 +319,15 @@ better long-term shape. It is also a far larger change to the object model than 
 `instanceof HTMLElement` — the single most common way a page asks "is this an element?" — stop
 throwing.
 
-**Scope, and what is still missing.** This covers the node interfaces. html5test uses `instanceof`
-against roughly two dozen more that remain undefined — `CanvasRenderingContext2D`
-(`canvas.context`), `Blob` (`communication.xmlhttprequest2.response.blob`), `FileList`
-(`form.file.files`), `NodeList`, `HTMLCollection` and the per-tag `HTML*Element` types. Those are
-not node types, so they need a different discriminator than `nodeType`, and the per-tag types need a
-tag→interface table; both are follow-on work rather than part of this fix. Note also that
-`childNodes` returns a `JSArray`, so a `NodeList` global would need to decide what it is claiming
-about that before it would mean anything.
+**Scope, and what is still missing.** This covers the node interfaces, and the second round adds
+`CanvasRenderingContext2D` and `ImageData`. html5test uses `instanceof` against roughly two dozen more
+that remain undefined — `Blob` (`communication.xmlhttprequest2.response.blob`), `FileList`
+(`form.file.files`), `NodeList`, `HTMLCollection` and the per-tag `HTML*Element` types. Those are not
+node types, so they need a different discriminator than `nodeType`, and the per-tag types need a
+tag→interface table. Note also that `childNodes` returns a `JSArray`, so a `NodeList` global would need
+to decide what it is claiming about that before it would mean anything.
 
-## (3) `TypeError: cannot create instance of undefined` — `engine.js:1986` — **not a defect**
-
-```js
-o = new (window.RTCPeerConnection || window.msRTCPeerConnection || window.mozRTCPeerConnection || window.webkitRTCPeerConnection)(null);
-```
-
-All four are undefined, so this is `new undefined(…)`. Broiler implements no WebRTC surface
-anywhere — no `RTCPeerConnection`, no `RTCDataChannel`, no `navigator.mediaDevices`,
-no `getUserMedia`, in the main repo or any submodule. `webrtc/*` is listed in
-`tests/wpt-baseline/failed-tests.json` as a durable expected failure, and WebRTC does not appear in
-`docs/ROADMAP.md`.
-
-This is the expected outcome of a feature probe against an engine without the feature — a browser
-with WebRTC disabled throws here too. Nothing to fix; implementing WebRTC is a feature project
-(an ICE/DTLS/SCTP stack), not a bug fix.
-
-One cosmetic observation, independent of html5test: Broiler words this `cannot create instance of
-undefined`, where the spec-conventional phrasing — and Broiler's own wording at its other
-construct sites — is `… is not a constructor`. Worth a sweep if error-message consistency is ever
-tidied; it lives in the `Broiler.JS` submodule (`JSUndefined.cs`, `JSNull.cs`), so it would go
-through the patch workflow.
-
-## (4) `TypeError: undefined is not a function` — `engine.js:3030` — **left open, deliberately**
-
-```js
-var data = ctx.getImageData(0, 0, 1, 1);
-```
-
-`getImageData` is absent, and so are `putImageData`, `createImageData`, `ImageData` and
-`canvas.toDataURL`. The absence is structural, not a missing entry in a member list: the 2D context
-is a **style-state stub with no pixels**. `CanvasRenderingContext2D`
-(`src/Broiler.HtmlBridge.Dom/DomBridge/CanvasRenderingContext2D.cs`) keeps `fillStyle`, `lineWidth`,
-`font` and the save/restore stack, and every drawing method is a literal empty body —
-`public void FillRect(float x, float y, float width, float height) { }`. The type's own remarks
-record that Phase 6 removed the former command list because nothing ever rendered it. So there is no
-backing store for `getImageData` to read.
-
-**This was deliberately not stubbed.** Returning zeroed pixels would convert an honest
-`TypeError` — which every feature detector on the web reads correctly as "no canvas readback" —
-into a false claim of support, and pages that branch on `typeof ctx.getImageData === 'function'`
-would then take the canvas path and silently render nothing. Absent is the safer answer until the
-context can actually rasterise.
-
-The real fix is to give the context a real backing store. `Broiler.Graphics` already ships the
-rasteriser and a readable RGBA buffer that would back it, and it is a dependency leaf, so the
-binding could consume it without a cycle. That is a scoped, worthwhile project — it would also make
-`canvas.toDataURL` and canvas painting possible — but it is a feature, not a fix, and it is not
-attempted here.
-
-## Measured end to end
-
-A real capture of the live site before and after
-(`dotnet run --project src/Broiler.Cli -- --capture-image https://html5test.com/ --output <png>
---diagnostic-dir <dir>`), reading the score out of the post-script document the diagnostics archive:
+## Measured end to end (first round)
 
 | | score | rows scoring "Yes" |
 | --- | --- | --- |
@@ -199,18 +336,31 @@ A real capture of the live site before and after
 
 Newly passing: `elements.interactive`, `elements.interactive.menutoolbar`,
 `elements.semantic.ruby` — all of them `instanceof HTMLElement && !(instanceof HTMLUnknownElement)`
-probes. Nothing regressed from "Yes" to "No".
+probes.
 
-Both runs report **0 JavaScript failures** in the diagnostics, before and after, which is the
-"caught exceptions are not logged" point above made concrete: the fixes are visible in the score,
-not in the failure count.
+Two probes named above still score "No" for reasons beyond the exception: `parsing.tokenizer` runs
+~20 further assertions after the one that used to throw, and `elements.section` additionally requires
+`isBlock(element)` and `closesImplicitly(tag)`. Removing the throw lets those probes *finish*; it does
+not by itself make them pass.
 
-Two probes named in this document still score "No" for reasons beyond the exception:
-`parsing.tokenizer` runs ~20 further assertions after the one that used to throw, and
-`elements.section` additionally requires `isBlock(element)` and `closesImplicitly(tag)`. Removing
-the throw lets those probes *finish*; it does not by itself make them pass.
+---
 
 ## What changed
+
+Second round:
+
+| file | change |
+| --- | --- |
+| `src/Broiler.HtmlBridge.Dom/DomBridge/CanvasRenderingContext2D.cs` | rewritten — the `BBitmap` backing store and the rasterising drawing operations |
+| `src/Broiler.HtmlBridge.Dom/Features/CanvasBinding.cs` | pixel APIs, `toDataURL`, one context per canvas, real `ctx.canvas`, `globalCompositeOperation`/`textAlign` accessors |
+| `src/Broiler.HtmlBridge.Dom/Features/ICanvasHost.cs` | new — the host contract for reaching the realm's `Uint8ClampedArray` |
+| `src/Broiler.HtmlBridge.Dom/DomBridge/DomBridge.CanvasHost.cs` | new — its explicit implementation |
+| `src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.DomInterfaces.cs` | `CanvasRenderingContext2D` and `ImageData` globals |
+| `src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs` | pass the bridge to `CanvasBinding.Install` |
+| `src/Broiler.HtmlBridge.Dom/Broiler.HtmlBridge.Dom.csproj` | reference `Broiler.Graphics` and `Broiler.Media.Image` |
+| `src/Broiler.Cli.Tests/CanvasPixelSurfaceTests.cs` | new — the pixel surface, and the html5test probes verbatim |
+
+First round:
 
 | file | change |
 | --- | --- |
@@ -221,9 +371,9 @@ the throw lets those probes *finish*; it does not by itself make them pass.
 | `src/Broiler.Cli.Tests/HtmlDomInterfacesTests.cs` | numeric-index and `foo<bar` regression tests |
 | `src/Broiler.Cli.Tests/DomInterfaceConstructorTests.cs` | new — interface-constructor tests |
 
-The `WptTestRunner.cs` change is a consequence of (2), not an improvement in its own right. Its
-custom-element shim installed a constructible `HTMLElement` only when the name was missing; now that
-the bridge defines the name, that guard would have skipped the shim and left
-`class X extends HTMLElement` building plain objects instead of elements. It now probes the
-capability it actually needs — that `new HTMLElement()` yields an element node — so the override
-still installs, and a future real implementation would pass the probe and win.
+The `WptTestRunner.cs` change was a consequence of the `HTMLElement` fix, not an improvement in its own
+right. Its custom-element shim installed a constructible `HTMLElement` only when the name was missing;
+once the bridge defined the name, that guard would have skipped the shim and left
+`class X extends HTMLElement` building plain objects instead of elements. It now probes the capability
+it actually needs — that `new HTMLElement()` yields an element node — so the override still installs,
+and a future real implementation would pass the probe and win.

--- a/patches/0007-not-a-constructor-message.patch
+++ b/patches/0007-not-a-constructor-message.patch
@@ -1,0 +1,155 @@
+From 9ecf377f9f02b8ec162c94e7e49b2bb29f521d99 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sat, 15 Aug 2026 10:08:41 +0000
+Subject: [PATCH] Say "is not a constructor", as every other construct site
+ does
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+`new undefined()` reported "cannot create instance of undefined" and `new null()`
+the matching "... of null". No browser words it that way — V8, SpiderMonkey and
+JSC all say "X is not a constructor" — and neither does the rest of this engine:
+JSFunction, JSSymbol, JSGenerator, JSGeneratorFunctionV2, JSReflect and
+JSPromisePrototype already raise "... is not a constructor". These two were the
+only sites left with a wording of their own.
+
+Where it surfaced: a report of html5test.com, whose WebRTC probe is
+
+    new (window.RTCPeerConnection || window.msRTCPeerConnection ||
+         window.mozRTCPeerConnection || window.webkitRTCPeerConnection)(null)
+
+Against an engine with no WebRTC all four are undefined, so this throws — which
+is correct, and the page catches it and records the feature as unsupported. The
+throw is not the defect; the message is. A wording no browser produces reads as
+an engine fault in a trace where the right answer was in fact given.
+
+`InvokeFunction`'s "undefined is not a function" is deliberately untouched: that
+one already matches the browsers, and sweeping it along would have moved it away
+from the wording every engine agrees on.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ .../Null/JSNull.cs                            |  4 +-
+ .../ConstructNonConstructorMessageTests.cs    | 74 +++++++++++++++++++
+ .../Broiler.JavaScript.Runtime/JSUndefined.cs |  8 +-
+ 3 files changed, 84 insertions(+), 2 deletions(-)
+ create mode 100644 Broiler.JS/Broiler.JavaScript.Integration.Tests/ConstructNonConstructorMessageTests.cs
+
+diff --git a/Broiler.JS/Broiler.JavaScript.BuiltIns/Null/JSNull.cs b/Broiler.JS/Broiler.JavaScript.BuiltIns/Null/JSNull.cs
+index b2a16ef4..8c716cb3 100644
+--- a/Broiler.JS/Broiler.JavaScript.BuiltIns/Null/JSNull.cs
++++ b/Broiler.JS/Broiler.JavaScript.BuiltIns/Null/JSNull.cs
+@@ -79,7 +79,9 @@ public sealed class JSNull : JSValue
+ 
+     public override bool StrictEquals(JSValue value) => ReferenceEquals(this, value);
+ 
+-    public override JSValue CreateInstance(in Arguments a) => throw JSEngine.NewTypeError("cannot create instance of null");
++    // Worded as its JSUndefined sibling is, and as the engine's other construct sites are: browsers
++    // report "null is not a constructor" for `new null()`.
++    public override JSValue CreateInstance(in Arguments a) => throw JSEngine.NewTypeError("null is not a constructor");
+ 
+     public override JSValue InvokeFunction(in Arguments a) => throw JSEngine.NewTypeError("null is not a function");
+ 
+diff --git a/Broiler.JS/Broiler.JavaScript.Integration.Tests/ConstructNonConstructorMessageTests.cs b/Broiler.JS/Broiler.JavaScript.Integration.Tests/ConstructNonConstructorMessageTests.cs
+new file mode 100644
+index 00000000..3e436736
+--- /dev/null
++++ b/Broiler.JS/Broiler.JavaScript.Integration.Tests/ConstructNonConstructorMessageTests.cs
+@@ -0,0 +1,74 @@
++using Broiler.JavaScript.Engine;
++
++namespace Broiler.JavaScript.Integration.Tests;
++
++// `new undefined()` and `new null()` reported "cannot create instance of undefined" / "... of null".
++// No browser words it that way — all three major engines say "X is not a constructor" — and neither
++// does the rest of THIS engine: JSFunction, JSSymbol, JSGenerator, JSGeneratorFunctionV2, JSReflect
++// and JSPromisePrototype all raise "... is not a constructor". These two were the only sites left
++// with a wording of their own.
++//
++// Where it showed up: html5test.com probes for WebRTC with
++//
++//     new (window.RTCPeerConnection || window.msRTCPeerConnection ||
++//          window.mozRTCPeerConnection || window.webkitRTCPeerConnection)(null)
++//
++// All four are undefined in an engine with no WebRTC, so this throws — correctly, and the page
++// catches it and records "unsupported". But the reported trace then carried a message no browser
++// produces, which reads as an engine fault rather than as the expected answer to a feature probe.
++// The throw is right; only the wording was wrong.
++public class ConstructNonConstructorMessageTests
++{
++    private static string MessageOf(string source)
++    {
++        using var context = new JSContext();
++        return context.Eval(
++            """
++            String((function () {
++                try { SOURCE }
++                catch (e) { return e.message; }
++                return 'no throw';
++            })())
++            """.Replace("SOURCE", source),
++            "t.js").ToString();
++    }
++
++    [Fact]
++    public void New_Undefined_Is_Not_A_Constructor()
++    {
++        Assert.Equal("undefined is not a constructor", MessageOf("new undefined();"));
++    }
++
++    [Fact]
++    public void New_Null_Is_Not_A_Constructor()
++    {
++        Assert.Equal("null is not a constructor", MessageOf("new null();"));
++    }
++
++    [Fact]
++    public void An_Undefined_Property_Constructed_Reports_The_Same_Way()
++    {
++        // The shape a feature probe actually takes: every alternative is missing, so the whole
++        // parenthesised expression is undefined and `new` is applied to that.
++        Assert.Equal(
++            "undefined is not a constructor",
++            MessageOf("var w = {}; new (w.A || w.B || w.C)(null);"));
++    }
++
++    [Fact]
++    public void Calling_Undefined_Still_Reports_Not_A_Function()
++    {
++        // Unchanged, and deliberately so: "undefined is not a function" is already the browser
++        // wording. Only the construct path was inconsistent, and a sweep that "tidied" this one
++        // too would have moved it away from the message every engine agrees on.
++        Assert.Equal("undefined is not a function", MessageOf("var f; f();"));
++    }
++
++    [Fact]
++    public void The_Message_Matches_The_Wording_Used_For_A_Real_Non_Constructor()
++    {
++        // The point of the change is consistency, so pin the neighbour it now agrees with: an
++        // arrow function is not a constructor either, and has always said so.
++        Assert.EndsWith("is not a constructor", MessageOf("var f = () => 1; new f();"));
++    }
++}
+diff --git a/Broiler.JS/Broiler.JavaScript.Runtime/JSUndefined.cs b/Broiler.JS/Broiler.JavaScript.Runtime/JSUndefined.cs
+index b5c385af..6014ce2a 100644
+--- a/Broiler.JS/Broiler.JavaScript.Runtime/JSUndefined.cs
++++ b/Broiler.JS/Broiler.JavaScript.Runtime/JSUndefined.cs
+@@ -59,7 +59,13 @@ public sealed class JSUndefined : JSValue
+ 
+     public override bool StrictEquals(JSValue value) => ReferenceEquals(this, value);
+ 
+-    public override JSValue CreateInstance(in Arguments a) => throw NewTypeError("cannot create instance of undefined");
++    // "X is not a constructor" is what every browser reports for `new undefined()`, and what this
++    // engine already reports at each of its other construct sites (JSFunction, JSSymbol, JSGenerator,
++    // JSReflect). "cannot create instance of undefined" was the odd one out, and it is the message a
++    // reader meets in a feature-probe trace — `new (window.RTCPeerConnection || ...)()` against an
++    // engine with no WebRTC — where a non-standard wording reads as an engine fault rather than as the
++    // expected answer.
++    public override JSValue CreateInstance(in Arguments a) => throw NewTypeError("undefined is not a constructor");
+ 
+     public override JSValue InvokeFunction(in Arguments a) => throw NewTypeError("undefined is not a function");
+ 
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # Submodule patches waiting to be applied
 
-**Six patches are waiting on a maintainer.** See the index below.
+**Seven patches are waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -52,6 +52,7 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD && echo "live on CI"
 | `0004` | `Broiler.JS` | Record where an error was raised, not where its factory was wired |
 | `0005` | `Broiler.DOM` | Parse a `<noscript>` body as raw text, as a scripting-enabled parser must |
 | `0006` | `Broiler.JS/Broiler.Regex` | Tell the end of a pattern apart from a NUL inside one |
+| `0007` | `Broiler.JS` | Say "is not a constructor", as every other construct site does |
 
 ### `0001` — a closure a direct eval created lost the eval site's bindings
 
@@ -303,6 +304,38 @@ compiles through the .NET translator with or without the patch, so no pixel move
 either way. Its behaviour is unit-tested inside the patch (`NulCharacterTests`).
 
 **When it lands upstream:** bump both pointers and delete this patch.
+
+### `0007` — two construct sites had a wording of their own
+
+`new undefined()` said `cannot create instance of undefined`, and `new null()` the
+matching `... of null`. No browser words it that way — V8, SpiderMonkey and JSC all
+say `X is not a constructor` — and neither does the rest of this engine: `JSFunction`,
+`JSSymbol`, `JSGenerator`, `JSGeneratorFunctionV2`, `JSReflect` and
+`JSPromisePrototype` already raise `... is not a constructor`. These two were the only
+sites left disagreeing, so this is a consistency fix rather than a new opinion.
+
+**The throw it appears in is correct**, which is the part worth keeping straight.
+html5test.com probes for WebRTC with
+`new (window.RTCPeerConnection || window.msRTCPeerConnection || window.mozRTCPeerConnection || window.webkitRTCPeerConnection)(null)`.
+Against an engine with no WebRTC every alternative is `undefined`, so this throws, the
+page catches it, and the feature is correctly recorded as unsupported — a browser with
+WebRTC disabled does the same. Only the message was wrong, and a wording no browser
+produces reads as an engine fault in a trace where the right answer was in fact given.
+See `docs/html5test-exceptions.md`.
+
+**`InvokeFunction` is deliberately untouched.** `undefined is not a function` already
+matches the browsers; sweeping it along "for consistency" would have moved it away from
+the wording every engine agrees on.
+
+**Not listed for the pixel suites** — it changes an error message, nothing a page
+paints. `ConstructNonConstructorMessageTests` travels inside the patch and covers it,
+including that the call-path message did not move.
+
+**No main-repo fallback, and none is needed.** Nothing in this repository asserts either
+message, so the un-patched engine behaves exactly as before; the cost of not applying it
+is a non-standard string in a stack trace.
+
+**When it lands upstream:** bump the pointer and delete this patch.
 
 ## A stale entry in the apply script is not inert
 

--- a/src/Broiler.Cli.Tests/CanvasContextBindingTests.cs
+++ b/src/Broiler.Cli.Tests/CanvasContextBindingTests.cs
@@ -11,7 +11,13 @@ namespace Broiler.Cli.Tests;
 /// no renderer ever read. That unused command storage was removed and the context internalized into the
 /// Canvas binding, keeping only the script-observable state (current styles + the save/restore stack).
 /// These tests pin that observable behaviour: the context exists, style properties round-trip,
-/// save/restore is a real state stack, and the (now no-op) drawing methods stay callable without throwing.
+/// save/restore is a real state stack, and the drawing methods stay callable without throwing.
+///
+/// The drawing methods are no longer the empty bodies that internalization left behind — the context
+/// rasterises into a real bitmap now, and what it paints is covered by
+/// <see cref="CanvasPixelSurfaceTests"/>. These tests deliberately stay at the binding level: what they
+/// guard is that the JS surface is present and its state round-trips, which is what the P6.1 change put
+/// at risk and is orthogonal to any pixel landing anywhere.
 /// </summary>
 public sealed class CanvasContextBindingTests
 {
@@ -64,7 +70,8 @@ public sealed class CanvasContextBindingTests
     [Fact]
     public void Drawing_Methods_Are_Callable_And_Do_Not_Throw()
     {
-        // The drawing surface is a no-op on a headless canvas, but the JS API must stay callable.
+        // Every drawing entry point stays callable and total — a malformed or degenerate call must not
+        // throw out of the page's script, whatever it does or does not paint.
         Assert.Equal("ok", Eval(
             "(function(){var ctx=document.getElementById('c').getContext('2d');" +
             "ctx.beginPath();ctx.moveTo(0,0);ctx.lineTo(10,10);ctx.arc(5,5,3,0,6.28);ctx.closePath();" +

--- a/src/Broiler.Cli.Tests/CanvasPixelSurfaceTests.cs
+++ b/src/Broiler.Cli.Tests/CanvasPixelSurfaceTests.cs
@@ -1,0 +1,481 @@
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// The Canvas 2D context's pixel surface: drawing rasterises into a real bitmap, and
+/// <c>getImageData</c>/<c>putImageData</c>/<c>createImageData</c>/<c>toDataURL</c> read it back.
+///
+/// Before this, the context was a style-state stub whose drawing methods were empty bodies and whose
+/// pixel API did not exist, so <c>ctx.getImageData(...)</c> and <c>canvas.toDataURL(...)</c> threw
+/// <c>TypeError: undefined is not a function</c> — three of the four exceptions html5test.com's feature
+/// probes hit (<c>engine.js</c> lines 3030, 3055 and 3071). The last three tests here are those probes
+/// verbatim. See <c>docs/html5test-exceptions.md</c>.
+/// </summary>
+public class CanvasPixelSurfaceTests
+{
+    private static string Run(string script)
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<div id=""result""></div>
+<script>
+var r = [];
+" + script + @"
+document.getElementById('result').textContent = r.join(',');
+</script>
+</body></html>";
+        return CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+    }
+
+    [Fact]
+    public void GetContext_Returns_The_Same_Context_Every_Call()
+    {
+        // Not a nicety: a fresh context per call would hand back a fresh blank bitmap, so nothing a
+        // page drew through an earlier reference would ever be readable.
+        var result = Run(@"
+var c = document.createElement('canvas');
+r.push(c.getContext('2d') === c.getContext('2d'));
+r.push(c.getContext('2d') !== document.createElement('canvas').getContext('2d'));
+r.push(c.getContext('2d').canvas === c);
+");
+        Assert.Contains("true,true,true", result);
+    }
+
+    [Fact]
+    public void FillRect_Is_Readable_Through_GetImageData()
+    {
+        var result = Run(@"
+var c = document.createElement('canvas');
+c.width = 4; c.height = 4;
+var ctx = c.getContext('2d');
+ctx.fillStyle = 'rgb(10, 20, 30)';
+ctx.fillRect(0, 0, 2, 2);
+var d = ctx.getImageData(0, 0, 1, 1).data;
+r.push(d[0] + '/' + d[1] + '/' + d[2] + '/' + d[3]);
+// Outside the filled rect the canvas is still transparent black.
+var outside = ctx.getImageData(3, 3, 1, 1).data;
+r.push(outside[0] + '/' + outside[3]);
+");
+        Assert.Contains("10/20/30/255,0/0", result);
+    }
+
+    [Fact]
+    public void ClearRect_Restores_Transparency()
+    {
+        var result = Run(@"
+var c = document.createElement('canvas');
+c.width = 2; c.height = 2;
+var ctx = c.getContext('2d');
+ctx.fillStyle = '#ffffff';
+ctx.fillRect(0, 0, 2, 2);
+r.push(ctx.getImageData(0, 0, 1, 1).data[3]);
+ctx.clearRect(0, 0, 1, 1);
+r.push(ctx.getImageData(0, 0, 1, 1).data[3]);
+// The pixel next to it is untouched.
+r.push(ctx.getImageData(1, 0, 1, 1).data[3]);
+");
+        Assert.Contains("255,0,255", result);
+    }
+
+    [Fact]
+    public void GlobalAlpha_Is_Composited_Into_The_Fill()
+    {
+        var result = Run(@"
+var c = document.createElement('canvas');
+c.width = 1; c.height = 1;
+var ctx = c.getContext('2d');
+ctx.globalAlpha = 0.5;
+ctx.fillStyle = '#ffffff';
+ctx.fillRect(0, 0, 1, 1);
+var a = ctx.getImageData(0, 0, 1, 1).data[3];
+r.push(a > 100 && a < 155);
+");
+        Assert.Contains("true", result);
+    }
+
+    [Fact]
+    public void GetImageData_Reads_Out_Of_Bounds_As_Transparent_Black()
+    {
+        var result = Run(@"
+var c = document.createElement('canvas');
+c.width = 1; c.height = 1;
+var ctx = c.getContext('2d');
+ctx.fillStyle = '#ffffff';
+ctx.fillRect(0, 0, 1, 1);
+var d = ctx.getImageData(0, 0, 2, 2);
+r.push(d.width + 'x' + d.height);
+r.push(d.data.length);
+r.push(d.data[3]);   // inside  -> opaque
+r.push(d.data[7]);   // outside -> transparent
+");
+        Assert.Contains("2x2,16,255,0", result);
+    }
+
+    [Fact]
+    public void PutImageData_Writes_Pixels_Back()
+    {
+        var result = Run(@"
+var c = document.createElement('canvas');
+c.width = 2; c.height = 1;
+var ctx = c.getContext('2d');
+var img = ctx.createImageData(1, 1);
+r.push(img.width + 'x' + img.height + '/' + img.data.length);
+img.data[0] = 1; img.data[1] = 2; img.data[2] = 3; img.data[3] = 255;
+ctx.putImageData(img, 1, 0);
+var back = ctx.getImageData(1, 0, 1, 1).data;
+r.push(back[0] + '/' + back[1] + '/' + back[2] + '/' + back[3]);
+// putImageData ignores globalAlpha and the composite operator, and leaves its neighbour alone.
+r.push(ctx.getImageData(0, 0, 1, 1).data[3]);
+");
+        Assert.Contains("1x1/4,1/2/3/255,0", result);
+    }
+
+    [Fact]
+    public void ImageData_Data_Is_A_Real_Uint8ClampedArray()
+    {
+        var result = Run(@"
+var ctx = document.createElement('canvas').getContext('2d');
+var d = ctx.createImageData(1, 1);
+r.push(d.data instanceof Uint8ClampedArray);
+r.push(Object.prototype.toString.call(d.data));
+// Clamping is the typed array's, not ours.
+d.data[0] = 300; r.push(d.data[0]);
+d.data[1] = -5;  r.push(d.data[1]);
+");
+        Assert.Contains("true,[object Uint8ClampedArray],255,0", result);
+    }
+
+    [Fact]
+    public void Canvas_And_ImageData_Interfaces_Answer_Instanceof()
+    {
+        var result = Run(@"
+var c = document.createElement('canvas');
+var ctx = c.getContext('2d');
+r.push(typeof CanvasRenderingContext2D === 'function');
+r.push(ctx instanceof CanvasRenderingContext2D);
+r.push(!(c instanceof CanvasRenderingContext2D));
+r.push(typeof ImageData === 'function');
+r.push(ctx.createImageData(1, 1) instanceof ImageData);
+r.push(new ImageData(2, 2) instanceof ImageData);
+r.push(new ImageData(2, 2).data.length);
+");
+        Assert.Contains("true,true,true,true,true,true,16", result);
+    }
+
+    [Fact]
+    public void ToDataUrl_Encodes_Png_And_Jpeg_And_Falls_Back_For_Unsupported_Types()
+    {
+        // HTML: an image format the user agent does not support falls back to image/png rather than
+        // throwing, so the returned URL names the type actually produced.
+        var result = Run(@"
+var c = document.createElement('canvas');
+c.width = 2; c.height = 2;
+var ctx = c.getContext('2d');
+ctx.fillStyle = '#ff0000';
+ctx.fillRect(0, 0, 2, 2);
+r.push(c.toDataURL().substring(0, 22));
+r.push(c.toDataURL('image/png').substring(0, 22));
+r.push(c.toDataURL('image/jpeg').substring(0, 23));
+r.push(c.toDataURL('image/webp').substring(0, 22));
+r.push(c.toDataURL('image/vnd.ms-photo').substring(0, 22));
+r.push(c.toDataURL().length > 30);
+");
+        Assert.Contains(
+            "data:image/png;base64,,data:image/png;base64,,data:image/jpeg;base64,," +
+            "data:image/png;base64,,data:image/png;base64,,true",
+            result);
+    }
+
+    [Fact]
+    public void ToDataUrl_On_A_Zero_Area_Canvas_Is_The_Empty_Data_Url()
+    {
+        var result = Run(@"
+var c = document.createElement('canvas');
+c.setAttribute('width', '0');
+r.push(c.toDataURL());
+r.push(c.toDataURL('image/png'));
+");
+        Assert.Contains("data:,,data:,", result);
+    }
+
+    [Fact]
+    public void GlobalCompositeOperation_Rejects_An_Operator_It_Cannot_Composite()
+    {
+        // An unrecognised value must be ignored and the state keep its previous value. The context
+        // treats an operator it cannot actually apply the same way, so the round-trip a feature
+        // detector reads is never a claim it did not honour.
+        var result = Run(@"
+var ctx = document.createElement('canvas').getContext('2d');
+r.push(ctx.globalCompositeOperation);
+ctx.globalCompositeOperation = 'screen';
+r.push(ctx.globalCompositeOperation);
+ctx.globalCompositeOperation = 'not-a-real-operator';
+r.push(ctx.globalCompositeOperation);
+");
+        Assert.Contains("source-over,screen,screen", result);
+    }
+
+    [Fact]
+    public void Paths_And_Text_Put_Pixels_On_The_Bitmap()
+    {
+        // The point is not the exact coverage — it is that these are no longer empty bodies, so a
+        // readback of a canvas that was drawn on does not report a blank one.
+        var result = Run(@"
+var c = document.createElement('canvas');
+c.width = 40; c.height = 40;
+var ctx = c.getContext('2d');
+ctx.fillStyle = '#000000';
+ctx.beginPath();
+ctx.moveTo(2, 2); ctx.lineTo(38, 2); ctx.lineTo(38, 38); ctx.closePath();
+ctx.fill();
+var painted = 0, d = ctx.getImageData(0, 0, 40, 40).data;
+for (var i = 3; i < d.length; i += 4) if (d[i] > 0) painted++;
+r.push(painted > 100);
+
+var t = document.createElement('canvas');
+t.width = 120; t.height = 40;
+var tctx = t.getContext('2d');
+tctx.font = '20px sans-serif';
+tctx.fillStyle = '#000000';
+tctx.fillText('Hi', 10, 30);
+var inked = 0, td = tctx.getImageData(0, 0, 120, 40).data;
+for (var j = 3; j < td.length; j += 4) if (td[j] > 0) inked++;
+r.push(inked > 0);
+");
+        Assert.Contains("true,true", result);
+    }
+
+    [Fact]
+    public void Width_And_Height_Default_And_Reflect_The_Content_Attribute()
+    {
+        var result = Run(@"
+var c = document.createElement('canvas');
+r.push(c.width + 'x' + c.height);
+c.width = 40; c.height = 20;
+r.push(c.width + 'x' + c.height);
+r.push(c.getAttribute('width') + 'x' + c.getAttribute('height'));
+// The bitmap follows the attribute, so the readback bounds move with it.
+var ctx = c.getContext('2d');
+ctx.fillStyle = '#ffffff';
+ctx.fillRect(0, 0, 40, 20);
+r.push(ctx.getImageData(39, 19, 1, 1).data[3]);
+");
+        Assert.Contains("300x150,40x20,40x20,255", result);
+    }
+
+    [Fact]
+    public void Assigning_Width_Resets_The_Bitmap_And_The_Drawing_State()
+    {
+        // `canvas.width = canvas.width` is the idiomatic way to clear a canvas: HTML resets the
+        // bitmap on every assignment, including one that does not change the value.
+        var result = Run(@"
+var c = document.createElement('canvas');
+c.width = 4; c.height = 4;
+var ctx = c.getContext('2d');
+ctx.fillStyle = '#ff0000';
+ctx.globalAlpha = 0.25;
+ctx.fillRect(0, 0, 4, 4);
+r.push(ctx.getImageData(0, 0, 1, 1).data[3] > 0);
+
+c.width = c.width;
+
+r.push(ctx.getImageData(0, 0, 1, 1).data[3]);   // cleared to transparent black
+r.push(ctx.fillStyle);                          // state reset to its default
+r.push(ctx.globalAlpha);
+r.push(c.getContext('2d') === ctx);             // still the same context object
+");
+        Assert.Contains("true,0,#000000,1,true", result);
+    }
+
+    [Fact]
+    public void Canvas_Members_Are_Not_Installed_On_Other_Elements()
+    {
+        // These names belong to HTMLCanvasElement. getContext used to be installed on every element
+        // and answer null from a tag check inside, which made the call right and the name wrong;
+        // width/height would additionally have shadowed the reflected dimensions elsewhere.
+        var result = Run(@"
+var div = document.createElement('div');
+r.push('getContext' in div);
+r.push('toDataURL' in div);
+r.push(typeof div.width);
+var c = document.createElement('canvas');
+r.push('getContext' in c);
+r.push('toDataURL' in c);
+// An image keeps the reflected dimensions its own interface defines.
+var img = document.createElement('img');
+img.width = 12;
+r.push(img.getAttribute('width'));
+");
+        Assert.Contains("false,false,undefined,true,true,12", result);
+    }
+
+    [Fact]
+    public void GetContext_Answers_Null_For_A_Context_Type_This_Engine_Has_Not_Got()
+    {
+        var result = Run(@"
+var c = document.createElement('canvas');
+r.push(c.getContext('webgl') === null);
+r.push(c.getContext('bitmaprenderer') === null);
+r.push(c.getContext('2d') !== null);
+");
+        Assert.Contains("true,true,true", result);
+    }
+
+    [Fact]
+    public void FillText_Of_Enormous_Text_Is_Bounded_By_The_Canvas()
+    {
+        // The scratch surface a run is rasterised on is sized to the part of it the canvas can show,
+        // not to the run: sized to the run, this call would ask for a bitmap of some 10^11 pixels.
+        // What is asserted is only that it returns — whether any ink lands in a 60x30 window on the
+        // bottom-left corner of a 1000px glyph is a question about that glyph's shape, not about this.
+        var result = Run(@"
+var c = document.createElement('canvas');
+c.width = 60; c.height = 30;
+var ctx = c.getContext('2d');
+ctx.font = '1000px sans-serif';
+ctx.fillStyle = '#000000';
+var huge = new Array(20000).join('W');
+try { ctx.fillText(huge, 0, 25); r.push('survived'); }
+catch (e) { r.push('threw: ' + e); }
+");
+        Assert.Contains("survived", result);
+    }
+
+    [Fact]
+    public void FillText_Starting_Off_The_Left_Edge_Still_Paints_What_Is_On_Canvas()
+    {
+        // Clipping the scratch to the visible region must move no glyph: the run's origin is shifted
+        // by however much of it falls off the edge. A run starting left of the canvas is where an
+        // error in that shift would show up as either blank output or text in the wrong place.
+        var result = Run(@"
+var c = document.createElement('canvas');
+c.width = 60; c.height = 30;
+var ctx = c.getContext('2d');
+ctx.font = '20px sans-serif';
+ctx.fillStyle = '#000000';
+ctx.fillText('MMMM', -25, 20);
+var d = ctx.getImageData(0, 0, 60, 30).data, inked = 0;
+for (var i = 3; i < d.length; i += 4) if (d[i] > 0) inked++;
+r.push(inked > 0 ? 'painted' : 'blank');
+");
+        Assert.Contains("painted", result);
+    }
+
+    [Fact]
+    public void FillText_Entirely_Off_Canvas_Draws_Nothing_And_Does_Not_Throw()
+    {
+        var result = Run(@"
+var c = document.createElement('canvas');
+c.width = 20; c.height = 20;
+var ctx = c.getContext('2d');
+ctx.font = '10px sans-serif';
+ctx.fillStyle = '#000000';
+ctx.fillText('far away', 5000, 5000);
+ctx.fillText('far away', -5000, -5000);
+var d = ctx.getImageData(0, 0, 20, 20).data, inked = 0;
+for (var i = 3; i < d.length; i += 4) if (d[i] > 0) inked++;
+r.push(inked);
+");
+        Assert.Contains("0", result);
+    }
+
+    [Fact]
+    public void GetImageData_Refuses_A_Rectangle_Too_Large_To_Allocate()
+    {
+        // The rectangle is not clipped to the canvas, so its size comes from the arguments alone.
+        var result = Run(@"
+var ctx = document.createElement('canvas').getContext('2d');
+try { ctx.getImageData(0, 0, 100000, 100000); r.push('no throw'); }
+catch (e) { r.push('threw'); }
+");
+        Assert.Contains("threw", result);
+    }
+
+    // ---- the html5test probes, verbatim -----------------------------------------------------------
+
+    [Fact]
+    public void Html5Test_Canvas_Blending_Probe_Completes()
+    {
+        // engine.js:3013-3041 (`canvas.blending`). Line 3030 is the getImageData that used to throw.
+        var result = Run(@"
+var canvas = document.createElement('canvas');
+var passed = false;
+if (canvas.getContext) {
+    canvas.width = 1;
+    canvas.height = 1;
+    try {
+        var ctx = canvas.getContext('2d');
+        ctx.fillStyle = '#fff';
+        ctx.fillRect(0, 0, 1, 1);
+        ctx.globalCompositeOperation = 'screen';
+        ctx.fillStyle = '#000';
+        ctx.fillRect(0, 0, 1, 1);
+
+        var data = ctx.getImageData(0, 0, 1, 1);
+
+        passed = ctx.globalCompositeOperation == 'screen' && data.data[0] == 255;
+    }
+    catch (e) {
+        passed = 'threw: ' + e;
+    }
+}
+r.push(passed);
+");
+        Assert.Contains("true", result);
+    }
+
+    [Fact]
+    public void Html5Test_Canvas_Png_Probe_Passes()
+    {
+        // engine.js:3047-3064 (`canvas.png`). Line 3055 used to throw.
+        var result = Run(@"
+var canvas = document.createElement('canvas');
+var passed = false;
+if (canvas.getContext) {
+    try {
+        passed = canvas.toDataURL('image/png').substring(5, 14) == 'image/png';
+    }
+    catch (e) {
+        passed = 'threw: ' + e;
+    }
+}
+r.push(passed);
+");
+        Assert.Contains("true", result);
+    }
+
+    [Fact]
+    public void Html5Test_Canvas_Jpeg_Probe_Passes()
+    {
+        // engine.js:3066-3080 (`canvas.jpeg`). Line 3071 used to throw.
+        var result = Run(@"
+var canvas = document.createElement('canvas');
+var passed = false;
+if (canvas.getContext) {
+    try {
+        passed = canvas.toDataURL('image/jpeg').substring(5, 15) == 'image/jpeg';
+    }
+    catch (e) {
+        passed = 'threw: ' + e;
+    }
+}
+r.push(passed);
+");
+        Assert.Contains("true", result);
+    }
+
+    [Fact]
+    public void Html5Test_Canvas_JpegXr_And_Webp_Probes_Still_Report_No()
+    {
+        // engine.js:3084-3112. There is no JPEG-XR or WebP encoder, so the PNG fallback is the right
+        // answer and these must keep reporting "no" rather than becoming a false claim of support.
+        var result = Run(@"
+var canvas = document.createElement('canvas');
+var jpegxr = false, webp = false;
+try { jpegxr = canvas.toDataURL('image/vnd.ms-photo').substring(5, 23) == 'image/vnd.ms-photo'; } catch (e) { jpegxr = 'threw'; }
+try { webp = canvas.toDataURL('image/webp').substring(5, 15) == 'image/webp'; } catch (e) { webp = 'threw'; }
+r.push(jpegxr);
+r.push(webp);
+");
+        Assert.Contains("false,false", result);
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/Broiler.HtmlBridge.Dom.csproj
+++ b/src/Broiler.HtmlBridge.Dom/Broiler.HtmlBridge.Dom.csproj
@@ -37,6 +37,12 @@
     <ProjectReference Include="..\..\Broiler.DOM\Broiler.Dom\Broiler.Dom.csproj" />
     <ProjectReference Include="..\Broiler.HtmlBridge.Core\Broiler.HtmlBridge.Core.csproj" />
     <ProjectReference Include="..\..\Broiler.HTML\Source\Broiler.HTML.Dom\Broiler.HTML.Dom.csproj" />
+    <!-- The canvas 2D context rasterises into a Broiler.Graphics BBitmap and encodes it through the
+         media image abstraction, which is what makes getImageData/toDataURL report real pixels. Both
+         are dependency leaves here: Broiler.Graphics references only Broiler.Media.Image, and neither
+         references this assembly, so there is no cycle. -->
+    <ProjectReference Include="..\..\Broiler.Graphics\Broiler.Graphics\Broiler.Graphics.csproj" />
+    <ProjectReference Include="..\..\Broiler.Media\Broiler.Media.Image\Broiler.Media.Image.csproj" />
     <ProjectReference Include="..\..\Broiler.JS\Broiler.JS\Broiler.JavaScript.Engine\Broiler.JavaScript.Engine.csproj" />
     <ProjectReference Include="..\..\Broiler.JS\Broiler.JS\Broiler.JavaScript.BuiltIns\Broiler.JavaScript.BuiltIns.csproj" />
     <ProjectReference Include="..\..\Broiler.JS\Broiler.JS\Broiler.JavaScript.Globals\Broiler.JavaScript.Globals.csproj" />

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/CanvasRenderingContext2D.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/CanvasRenderingContext2D.cs
@@ -1,37 +1,75 @@
+using System.Drawing;
+using Broiler.CSS;
+using Broiler.Graphics;
+using Broiler.Media.Image;
+
 namespace Broiler.HtmlBridge;
 
 /// <summary>
-/// Script-observable state for the HTML5 Canvas 2D context that backs the
-/// <c>canvas.getContext("2d")</c> binding (see the <c>CanvasBinding</c> feature module — Phase 3 P3.64 —
-/// which builds the context and its drawing callbacks). Internal to the Canvas binding.
+/// The HTML5 Canvas 2D context that backs the <c>canvas.getContext("2d")</c> binding (see the
+/// <c>CanvasBinding</c> feature module — Phase 3 P3.64 — which builds the context and its drawing
+/// callbacks). Internal to the Canvas binding.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Phase 6 (P6.1): this was formerly <c>CanvasRenderingContext2D</c> in the standalone
-/// <c>Broiler.HtmlBridge.Rendering</c> project, where every drawing call appended a
-/// <c>CanvasDrawCommand</c> to a growing <c>List</c>. That command list was written by the
-/// script-facing draw methods but <b>never read by any renderer</b> — no code path retrieved a
-/// canvas element's recorded commands to paint them — so it was unbounded dead storage. Per the
-/// Phase 6 exit criterion ("Canvas commands are either rendered and bounded or are not recorded"),
-/// the recorder and its <c>CanvasDrawCommand</c> / <c>CanvasDrawCommandType</c> DTOs are removed and
-/// the type is internalized into the Canvas binding.
+/// <b>This context has pixels.</b> It owns a <see cref="BBitmap"/> the size of the canvas and rasterises
+/// every drawing call into it through <see cref="BCanvas"/>, so <c>getImageData</c> and <c>toDataURL</c>
+/// report what was actually drawn.
 /// </para>
 /// <para>
-/// What remains is the script-observable state a canvas program can read back: the current styles
-/// (<see cref="FillStyle"/>, <see cref="StrokeStyle"/>, <see cref="LineWidth"/>, <see cref="Font"/>,
-/// <see cref="TextAlign"/>, <see cref="GlobalAlpha"/>) and the <see cref="Save"/>/<see cref="Restore"/>
-/// state stack that restores them. The pure drawing methods (fillRect, arc, fillText, …) keep their
-/// signatures so the JS API stays callable, but perform no work: nothing renders a headless canvas.
-/// If a renderer ever consumes canvas output, this becomes a real immutable Broiler.Graphics display
-/// list rather than growing an in-memory command log again.
+/// It has not always. Phase 6 (P6.1) removed a <c>CanvasDrawCommand</c> recorder that no renderer ever
+/// read, leaving every drawing method a literal empty body — a style-state stub with no backing store.
+/// The pixel-readback API was then deliberately left <em>absent</em> rather than stubbed, because
+/// returning zeroed pixels would have turned an honest <c>TypeError</c> (which every feature detector on
+/// the web reads correctly as "no canvas readback") into a false claim of support. That reasoning held
+/// only while nothing rasterised; a real backing store is what retires it, and it is what this type now
+/// is. See <c>docs/html5test-exceptions.md</c>.
+/// </para>
+/// <para>
+/// <b>What is exact and what is approximate.</b> Rect fills, <c>clearRect</c>, path fills and strokes,
+/// <c>globalAlpha</c> and the separable <c>globalCompositeOperation</c> blend modes rasterise through
+/// <see cref="BCanvas"/> and are as exact as that rasteriser is. Text goes through
+/// <see cref="BImageRenderer"/>'s glyph path — real outlines from the system font — but the pen advance
+/// <see cref="MeasureTextWidth"/> reports is the renderer's own estimate rather than a shaped advance,
+/// so <c>measureText</c> and the non-<c>start</c> <c>textAlign</c> values that derive from it are
+/// approximate. There is no transform stack: the binding exposes no <c>translate</c>/<c>rotate</c>/
+/// <c>scale</c>, so none is needed, and <see cref="BCanvas"/> is a translate+uniform-scale rasteriser
+/// that could not carry a general affine anyway.
+/// </para>
+/// <para>
+/// <b>A zero-area canvas has no bitmap.</b> <c>&lt;canvas width="0"&gt;</c> is legal and
+/// <see cref="BBitmap"/> rejects a zero dimension, so <see cref="_bitmap"/> is null there and every
+/// operation degrades to the answer the spec gives for an empty bitmap. The same null stands in when the
+/// requested bitmap is too large to allocate.
+/// </para>
+/// <para>
+/// <b>Not <see cref="IDisposable"/>.</b> The bitmap is a <c>byte[]</c> and <see cref="BBitmap"/>'s own
+/// <c>Dispose</c> only sets a flag, so there is nothing to release deterministically; the context lives
+/// as long as the canvas element that owns it and the GC reclaims both. A <c>Dispose</c> nothing calls
+/// would be a footgun rather than hygiene — calling it would leave every later drawing call throwing
+/// <c>ObjectDisposedException</c> on a canvas the page still holds.
 /// </para>
 /// </remarks>
-internal sealed class CanvasRenderingContext2D(int width, int height)
+internal sealed class CanvasRenderingContext2D
 {
+    /// <summary>
+    /// Largest bitmap this context will allocate, in pixels (256 MiB of RGBA). A page is free to ask for
+    /// a canvas far larger than it can use — <c>width</c> and <c>height</c> are unsigned longs in the IDL
+    /// — and the spec's answer to a bitmap that cannot be allocated is to have no bitmap rather than to
+    /// fault, so an over-large request degrades exactly as a zero-area one does.
+    /// </summary>
+    private const long MaxBitmapPixels = 64L * 1024 * 1024;
+
+    private BBitmap? _bitmap;
+    private readonly Stack<CanvasState> _stateStack = new();
+    private readonly List<List<PointF>> _subpaths = [];
+
+    public CanvasRenderingContext2D(int width, int height) => Allocate(width, height);
+
     /// <summary>Canvas width in pixels.</summary>
-    public int Width { get; } = width;
+    public int Width { get; private set; }
     /// <summary>Canvas height in pixels.</summary>
-    public int Height { get; } = height;
+    public int Height { get; private set; }
     /// <summary>Current fill color.</summary>
     public string FillStyle { get; set; } = "#000000";
     /// <summary>Current stroke color.</summary>
@@ -44,46 +82,259 @@ internal sealed class CanvasRenderingContext2D(int width, int height)
     public string TextAlign { get; set; } = "start";
     /// <summary>Current global alpha (transparency).</summary>
     public float GlobalAlpha { get; set; } = 1.0f;
+    /// <summary>Current compositing/blending operator.</summary>
+    public string GlobalCompositeOperation { get; set; } = "source-over";
 
-    private readonly Stack<CanvasState> _stateStack = new();
+    /// <summary>True when this context has a bitmap to draw into and read back from.</summary>
+    public bool HasBitmap => _bitmap is not null;
 
-    // Pure drawing operations. Kept callable for the JS API surface; no-ops because a headless
-    // canvas is never painted and nothing consumes recorded commands (see the type remarks).
+    /// <summary>
+    /// Reacts to <c>canvas.width</c>/<c>canvas.height</c> being assigned: HTML resets the bitmap to
+    /// transparent black and the context to its default state on <em>every</em> assignment, even one
+    /// that does not change the value — which is what makes <c>canvas.width = canvas.width</c> the
+    /// idiomatic way to clear a canvas. Doing this only on a size change would break that idiom
+    /// silently, so the caller decides when it happens and this always resets.
+    /// </summary>
+    public void ResetSurface(int width, int height)
+    {
+        _bitmap?.Dispose();
+        Allocate(width, height);
+
+        _stateStack.Clear();
+        _subpaths.Clear();
+        FillStyle = "#000000";
+        StrokeStyle = "#000000";
+        LineWidth = 1.0f;
+        Font = "10px sans-serif";
+        TextAlign = "start";
+        GlobalAlpha = 1.0f;
+        GlobalCompositeOperation = "source-over";
+    }
+
+    private void Allocate(int width, int height)
+    {
+        Width = Math.Max(0, width);
+        Height = Math.Max(0, height);
+        _bitmap = Width > 0 && Height > 0 && (long)Width * Height <= MaxBitmapPixels
+            ? new BBitmap(Width, Height)
+            : null;
+    }
+
+    // ---- rectangles -------------------------------------------------------------------------------
+
     /// <summary>Fills a rectangle at the specified position and size.</summary>
-    public void FillRect(float x, float y, float width, float height) { }
+    public void FillRect(float x, float y, float width, float height)
+    {
+        if (width == 0 || height == 0)
+            return;
+        Draw(canvas => canvas.FillRect(Normalize(x, y, width, height), ResolveColor(FillStyle)));
+    }
 
     /// <summary>Strokes a rectangle outline at the specified position and size.</summary>
-    public void StrokeRect(float x, float y, float width, float height) { }
+    public void StrokeRect(float x, float y, float width, float height) =>
+        Draw(canvas => canvas.DrawRectangleStroke(
+            Normalize(x, y, width, height), ResolveColor(StrokeStyle), Math.Max(LineWidth, 0f)));
 
-    /// <summary>Clears a rectangular area, making it fully transparent.</summary>
-    public void ClearRect(float x, float y, float width, float height) { }
+    /// <summary>
+    /// Clears a rectangular area, making it fully transparent. This <em>replaces</em> the pixels rather
+    /// than compositing onto them, so it is written straight to the bitmap: every blending path in
+    /// <see cref="BCanvas"/> would leave a fully transparent source with no effect at all.
+    /// </summary>
+    public void ClearRect(float x, float y, float width, float height)
+    {
+        if (_bitmap is null || width == 0 || height == 0)
+            return;
+
+        RectangleF rect = Normalize(x, y, width, height);
+        int minX = Math.Max(0, (int)MathF.Floor(rect.Left));
+        int minY = Math.Max(0, (int)MathF.Floor(rect.Top));
+        int maxX = Math.Min(Width - 1, (int)MathF.Ceiling(rect.Right) - 1);
+        int maxY = Math.Min(Height - 1, (int)MathF.Ceiling(rect.Bottom) - 1);
+
+        for (int py = minY; py <= maxY; py++)
+        {
+            for (int px = minX; px <= maxX; px++)
+                _bitmap.SetPixel(px, py, BColor.Transparent);
+        }
+    }
+
+    // ---- paths ------------------------------------------------------------------------------------
 
     /// <summary>Begins a new drawing path.</summary>
-    public void BeginPath() { }
+    public void BeginPath() => _subpaths.Clear();
 
     /// <summary>Moves the pen to the specified point without drawing.</summary>
-    public void MoveTo(float x, float y) { }
+    public void MoveTo(float x, float y) => _subpaths.Add([new PointF(x, y)]);
 
     /// <summary>Draws a straight line from the current point to the specified point.</summary>
-    public void LineTo(float x, float y) { }
+    public void LineTo(float x, float y) => CurrentSubpath().Add(new PointF(x, y));
 
-    /// <summary>Draws an arc centered at (x, y) with the given radius and angles.</summary>
-    public void Arc(float x, float y, float radius, float startAngle, float endAngle) { }
+    /// <summary>
+    /// Draws an arc centered at (x, y) with the given radius and angles, flattened into line segments
+    /// fine enough that the chord never departs from the true arc by more than a quarter pixel.
+    /// </summary>
+    public void Arc(float x, float y, float radius, float startAngle, float endAngle)
+    {
+        if (radius <= 0)
+        {
+            CurrentSubpath().Add(new PointF(x, y));
+            return;
+        }
+
+        double sweep = endAngle - startAngle;
+        // A canvas arc without an explicit direction runs clockwise, wrapping at most one full turn.
+        if (sweep > Math.Tau)
+            sweep = Math.Tau;
+        else if (sweep < -Math.Tau)
+            sweep = -Math.Tau;
+
+        int steps = FlatteningSteps(radius, Math.Abs(sweep));
+        List<PointF> subpath = CurrentSubpath();
+        for (int i = 0; i <= steps; i++)
+        {
+            double angle = startAngle + (sweep * i / steps);
+            subpath.Add(new PointF(
+                x + (float)(radius * Math.Cos(angle)),
+                y + (float)(radius * Math.Sin(angle))));
+        }
+    }
 
     /// <summary>Closes the current path by connecting the last point to the first.</summary>
-    public void ClosePath() { }
+    public void ClosePath()
+    {
+        if (_subpaths.Count == 0)
+            return;
+        List<PointF> subpath = _subpaths[^1];
+        if (subpath.Count > 1 && subpath[0] != subpath[^1])
+            subpath.Add(subpath[0]);
+    }
 
     /// <summary>Fills the current path with the current fill style.</summary>
-    public void Fill() { }
+    public void Fill()
+    {
+        if (_subpaths.Count == 0)
+            return;
+        Draw(canvas =>
+        {
+            BColor color = ResolveColor(FillStyle);
+            foreach (List<PointF> subpath in _subpaths)
+            {
+                if (subpath.Count >= 3)
+                    canvas.FillPolygon([.. subpath], color);
+            }
+        });
+    }
 
     /// <summary>Strokes the current path with the current stroke style.</summary>
-    public void Stroke() { }
+    public void Stroke()
+    {
+        if (_subpaths.Count == 0 || LineWidth <= 0)
+            return;
+        Draw(canvas =>
+        {
+            BColor color = ResolveColor(StrokeStyle);
+            foreach (List<PointF> subpath in _subpaths)
+            {
+                if (subpath.Count >= 2)
+                    canvas.DrawPathStroke(subpath, color, LineWidth);
+            }
+        });
+    }
 
-    /// <summary>Fills text at the specified position.</summary>
-    public void FillText(string text, float x, float y) { }
+    // ---- text -------------------------------------------------------------------------------------
 
-    /// <summary>Strokes text at the specified position.</summary>
-    public void StrokeText(string text, float x, float y) { }
+    /// <summary>Fills text at the specified position, where <paramref name="y"/> is the baseline.</summary>
+    public void FillText(string text, float x, float y) => DrawText(text, x, y, ResolveColor(FillStyle));
+
+    /// <summary>
+    /// Strokes text at the specified position. The glyph rasteriser fills outlines rather than stroking
+    /// them, so this paints the same glyphs in the stroke colour — the shape is right and the hairline
+    /// interior of an outlined glyph is not.
+    /// </summary>
+    public void StrokeText(string text, float x, float y) => DrawText(text, x, y, ResolveColor(StrokeStyle));
+
+    /// <summary>
+    /// Advance width of <paramref name="text"/> in the current font. This is the same per-character
+    /// estimate <see cref="BImageRenderer"/> uses for its own block advance rather than a shaped
+    /// advance, so it tracks the drawn text's extent only approximately.
+    /// </summary>
+    public double MeasureTextWidth(string text) =>
+        string.IsNullOrEmpty(text) ? 0.0 : text.Length * Math.Max(1.0, FontSizePixels() * 0.62);
+
+    // ---- pixel access -----------------------------------------------------------------------------
+
+    /// <summary>
+    /// Reads back a rectangle of straight-alpha RGBA pixels. Out-of-bounds pixels read as transparent
+    /// black, as the spec requires, so the returned buffer is always <c>width * height * 4</c> bytes.
+    /// </summary>
+    public byte[] GetImageData(int sx, int sy, int width, int height)
+    {
+        var data = new byte[(long)width * height * 4];
+        if (_bitmap is null)
+            return data;
+
+        for (int row = 0; row < height; row++)
+        {
+            int srcY = sy + row;
+            if (srcY < 0 || srcY >= Height)
+                continue;
+            for (int column = 0; column < width; column++)
+            {
+                int srcX = sx + column;
+                if (srcX < 0 || srcX >= Width)
+                    continue;
+
+                BColor pixel = _bitmap.GetPixel(srcX, srcY);
+                int offset = ((row * width) + column) * 4;
+                data[offset] = pixel.R;
+                data[offset + 1] = pixel.G;
+                data[offset + 2] = pixel.B;
+                data[offset + 3] = pixel.A;
+            }
+        }
+
+        return data;
+    }
+
+    /// <summary>
+    /// Writes a block of straight-alpha RGBA pixels back into the bitmap at
+    /// (<paramref name="dx"/>, <paramref name="dy"/>). The pixels <em>replace</em> what is there —
+    /// putImageData is not affected by <c>globalAlpha</c>, the composite operator or the clip.
+    /// </summary>
+    public void PutImageData(byte[] data, int dataWidth, int dataHeight, int dx, int dy)
+    {
+        if (_bitmap is null)
+            return;
+
+        for (int row = 0; row < dataHeight; row++)
+        {
+            int destY = dy + row;
+            if (destY < 0 || destY >= Height)
+                continue;
+            for (int column = 0; column < dataWidth; column++)
+            {
+                int destX = dx + column;
+                if (destX < 0 || destX >= Width)
+                    continue;
+
+                int offset = ((row * dataWidth) + column) * 4;
+                if (offset + 3 >= data.Length)
+                    return;
+
+                _bitmap.SetPixel(destX, destY, new BColor(
+                    data[offset], data[offset + 1], data[offset + 2], data[offset + 3]));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Encodes the bitmap in <paramref name="format"/> and reports the media type actually produced,
+    /// which the caller needs because it may not be the one asked for.
+    /// </summary>
+    public byte[] Encode(ImageEncodeFormat format, int quality) =>
+        _bitmap is null ? [] : _bitmap.Encode(format, quality);
+
+    // ---- state ------------------------------------------------------------------------------------
 
     /// <summary>Saves the current drawing state onto a stack.</summary>
     public void Save() => _stateStack.Push(new CanvasState
@@ -94,6 +345,7 @@ internal sealed class CanvasRenderingContext2D(int width, int height)
         Font = Font,
         TextAlign = TextAlign,
         GlobalAlpha = GlobalAlpha,
+        GlobalCompositeOperation = GlobalCompositeOperation,
     });
 
     /// <summary>Restores the most recently saved drawing state from the stack.</summary>
@@ -108,15 +360,214 @@ internal sealed class CanvasRenderingContext2D(int width, int height)
         Font = state.Font;
         TextAlign = state.TextAlign;
         GlobalAlpha = state.GlobalAlpha;
+        GlobalCompositeOperation = state.GlobalCompositeOperation;
     }
+
+    // ---- internals --------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Runs one drawing operation against the bitmap, wrapped in a blend layer when
+    /// <see cref="GlobalCompositeOperation"/> asks for one. The layer is per-operation because a canvas
+    /// operator applies to each draw against the accumulated bitmap, not to a group of them.
+    /// </summary>
+    private void Draw(Action<BCanvas> operation)
+    {
+        if (_bitmap is null)
+            return;
+
+        using BCanvas canvas = _bitmap.OpenCanvas();
+        string? blendMode = BlendModeFor(GlobalCompositeOperation);
+        if (blendMode is null)
+        {
+            operation(canvas);
+            return;
+        }
+
+        canvas.SaveBlendLayer(blendMode);
+        operation(canvas);
+        canvas.RestoreBlendLayer();
+    }
+
+    /// <summary>
+    /// Maps a <c>globalCompositeOperation</c> to the blend mode <see cref="BCanvas"/> implements, or
+    /// null for plain source-over.
+    /// </summary>
+    private static string? BlendModeFor(string operation) => operation?.ToLowerInvariant() switch
+    {
+        "multiply" or "screen" or "overlay" or "darken" or "lighten"
+            or "difference" or "plus-lighter" => operation.ToLowerInvariant(),
+        _ => null,
+    };
+
+    /// <summary>
+    /// Whether the setter should accept this <c>globalCompositeOperation</c>. HTML requires an
+    /// unrecognised value to be ignored — the state keeps its previous value — and this context treats
+    /// an operator it cannot actually composite as unrecognised for the same reason the pixel APIs were
+    /// absent rather than stubbed: a value that reads back as if it had been applied is a claim of
+    /// support, and every canvas feature detector tests exactly this round-trip.
+    /// </summary>
+    public static bool IsSupportedCompositeOperation(string? operation) =>
+        string.Equals(operation, "source-over", StringComparison.OrdinalIgnoreCase)
+        || BlendModeFor(operation ?? string.Empty) is not null;
+
+    private List<PointF> CurrentSubpath()
+    {
+        if (_subpaths.Count == 0)
+            _subpaths.Add([]);
+        return _subpaths[^1];
+    }
+
+    /// <summary>
+    /// Segment count for flattening an arc so the chord's sagitta stays under a quarter pixel:
+    /// <c>r(1 - cos(θ/2)) ≤ ¼</c>. Bounded at both ends so a hairline arc still gets a few segments and
+    /// a huge one cannot produce an unbounded polygon.
+    /// </summary>
+    private static int FlatteningSteps(double radius, double sweep)
+    {
+        if (sweep <= 0)
+            return 1;
+        double maxAngle = 2 * Math.Acos(Math.Max(-1.0, 1.0 - (0.25 / radius)));
+        int steps = maxAngle <= 0 ? int.MaxValue : (int)Math.Ceiling(sweep / maxAngle);
+        return Math.Clamp(steps, 4, 4096);
+    }
+
+    /// <summary>Turns a possibly negative-extent rectangle into the positive one the rasteriser wants.</summary>
+    private static RectangleF Normalize(float x, float y, float width, float height) =>
+        new(
+            width < 0 ? x + width : x,
+            height < 0 ? y + height : y,
+            Math.Abs(width),
+            Math.Abs(height));
+
+    /// <summary>
+    /// Resolves a CSS colour string and folds <see cref="GlobalAlpha"/> into it. An unparseable style is
+    /// the spec's no-op — the style keeps its previous value — but by the time it reaches here the
+    /// setter has already accepted it, so black is the fallback the reference implementations use.
+    /// </summary>
+    private BColor ResolveColor(string style)
+    {
+        if (!CssValueParser.TryParseColor(style, out CssColor color))
+            color = new CssColor(0, 0, 0);
+
+        float alpha = color.Alpha * Math.Clamp(GlobalAlpha, 0f, 1f);
+        return new BColor(color.Red, color.Green, color.Blue, (byte)Math.Clamp((int)MathF.Round(alpha), 0, 255));
+    }
+
+    /// <summary>
+    /// Rasterises one text run through <see cref="BImageRenderer"/>, which owns the glyph outlines, and
+    /// composites the result.
+    /// </summary>
+    /// <remarks>
+    /// The renderer clears whatever surface it is handed, so the run cannot be drawn straight onto the
+    /// canvas and goes to a scratch bitmap first. That scratch is sized to <b>the part of the run the
+    /// canvas can actually show</b>, not to the run: a page may draw a megabyte of text at
+    /// <c>font: 1000px</c>, and a scratch sized to that would be an allocation no machine has — while
+    /// every pixel of it outside the canvas is discarded on composite anyway. The run's origin is
+    /// shifted by however much of it falls off the left or top edge, so clipping the surface moves no
+    /// glyph.
+    /// </remarks>
+    private void DrawText(string text, float x, float y, BColor color)
+    {
+        if (_bitmap is null || string.IsNullOrEmpty(text) || color.A == 0)
+            return;
+
+        double fontSize = FontSizePixels();
+        double runWidth = MeasureTextWidth(text);
+
+        // Where the run would land on the canvas, with a margin for glyphs that overhang their advance.
+        double margin = fontSize;
+        double left = x - AlignmentOffset(runWidth) - margin;
+        double top = y - fontSize;
+        double right = left + runWidth + (margin * 2);
+        double bottom = top + (fontSize * 2);
+
+        // Intersect with the canvas; everything outside it is discarded on composite regardless.
+        double visibleLeft = Math.Max(0, left);
+        double visibleTop = Math.Max(0, top);
+        int scratchWidth = (int)Math.Ceiling(Math.Min(Width, right) - visibleLeft);
+        int scratchHeight = (int)Math.Ceiling(Math.Min(Height, bottom) - visibleTop);
+        if (scratchWidth <= 0 || scratchHeight <= 0)
+            return;
+
+        // BImageRenderer places a run's baseline at origin.Y + fontSize * 0.8, so an origin this far
+        // above the baseline puts it where the caller asked. Both coordinates are relative to the
+        // scratch, which starts at the visible corner rather than at the run's own.
+        var origin = new BPoint(
+            left + margin - visibleLeft,
+            (y - (fontSize * 0.8)) - visibleTop);
+
+        var renderList = new BRenderList(1);
+        renderList.DrawText(
+            new BTextRun(text, new BFontStyle(FontFamily(), fontSize, FontWeight()), color),
+            origin);
+
+        using var renderer = new BImageRenderer();
+        using BBitmap scratch = renderer.RenderToImage(
+            renderList,
+            new BSurfaceDescriptor(new BSize(scratchWidth, scratchHeight), 1.0),
+            new BFrameContext(BColor.Transparent));
+
+        var destination = new RectangleF((float)visibleLeft, (float)visibleTop, scratchWidth, scratchHeight);
+        var source = new RectangleF(0, 0, scratchWidth, scratchHeight);
+        Draw(canvas => canvas.DrawBitmap(scratch, destination, source));
+    }
+
+    /// <summary>
+    /// Leftward shift for the current <c>textAlign</c>. <c>start</c>/<c>end</c> resolve as for
+    /// left-to-right text: this context has no direction of its own to consult.
+    /// </summary>
+    private float AlignmentOffset(double runWidth) => TextAlign?.ToLowerInvariant() switch
+    {
+        "center" => (float)(runWidth / 2),
+        "right" or "end" => (float)runWidth,
+        _ => 0f,
+    };
+
+    /// <summary>
+    /// Pulls the pixel size out of the CSS shorthand held in <c>font</c>. Only <c>px</c> is read: the
+    /// context has no element to resolve <c>em</c>, percentages or keywords against.
+    /// </summary>
+    private double FontSizePixels()
+    {
+        foreach (string token in (Font ?? string.Empty).Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!token.EndsWith("px", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (double.TryParse(
+                    token[..^2],
+                    System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out double size) && size > 0)
+                return size;
+        }
+
+        return 10.0;
+    }
+
+    private string FontFamily()
+    {
+        string font = Font ?? string.Empty;
+        int lastSize = font.LastIndexOf("px", StringComparison.OrdinalIgnoreCase);
+        if (lastSize < 0 || lastSize + 2 >= font.Length)
+            return "sans-serif";
+
+        string family = font[(lastSize + 2)..].Trim().Split(',')[0].Trim().Trim('"', '\'');
+        return family.Length == 0 ? "sans-serif" : family;
+    }
+
+    private BFontWeight FontWeight() =>
+        (Font ?? string.Empty).Contains("bold", StringComparison.OrdinalIgnoreCase)
+            ? BFontWeight.Bold
+            : BFontWeight.Normal;
 
     private sealed class CanvasState
     {
-        public string FillStyle { get; set; } = string.Empty;
-        public string StrokeStyle { get; set; } = string.Empty;
-        public float LineWidth { get; set; }
-        public string Font { get; set; } = string.Empty;
-        public string TextAlign { get; set; } = string.Empty;
-        public float GlobalAlpha { get; set; }
+        public string FillStyle { get; init; } = string.Empty;
+        public string StrokeStyle { get; init; } = string.Empty;
+        public float LineWidth { get; init; }
+        public string Font { get; init; } = string.Empty;
+        public string TextAlign { get; init; } = string.Empty;
+        public float GlobalAlpha { get; init; }
+        public string GlobalCompositeOperation { get; init; } = string.Empty;
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/DomBridge.CanvasHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/DomBridge.CanvasHost.cs
@@ -1,0 +1,11 @@
+using Broiler.JavaScript.Runtime;
+
+namespace Broiler.HtmlBridge;
+
+// Explicit ICanvasHost implementation for the CanvasBinding feature module: the canvas context reaches
+// the realm's Uint8ClampedArray constructor through the window object and nothing else, so the module
+// touches no bridge private state and the public surface is unchanged.
+public sealed partial class DomBridge : Dom.Features.ICanvasHost
+{
+    JSObject? Dom.Features.ICanvasHost.WindowJSObject => _windowJSObject;
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/JsObjects.cs
@@ -611,7 +611,7 @@ public sealed partial class DomBridge
 
         // getContext(contextType) — for <canvas> elements. Phase 3 P3.64: extracted into the co-located
         // CanvasBinding feature module (unblocked once Phase 6/P8.9 dissolved Broiler.HtmlBridge.Rendering).
-        Dom.Features.CanvasBinding.Install(obj, element);
+        Dom.Features.CanvasBinding.Install(this, obj, element);
 
         // <iframe> browsing-context accessors (contentDocument/contentWindow/getSVGDocument, src/srcdoc
         // read/write, sandbox reflection) — Phase 3 P3.55: extracted into the co-located IframeElementBinding

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.DomInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.DomInterfaces.cs
@@ -51,6 +51,30 @@ public sealed partial class DomBridge
             function Text() { throw new TypeError('Illegal constructor'); }
             function Comment() { throw new TypeError('Illegal constructor'); }
             function Attr() { throw new TypeError('Illegal constructor'); }
+            function CanvasRenderingContext2D() { throw new TypeError('Illegal constructor'); }
+
+            // ImageData, unlike the interfaces above, *is* constructible — HTML defines
+            // new ImageData(w, h) and new ImageData(data, w, h) — so it gets a real body rather
+            // than an illegal-constructor throw.
+            function ImageData(a, b, c) {
+                var data, width, height;
+                if (typeof a === 'object' && a !== null) {
+                    data = a;
+                    width = b >>> 0;
+                    height = arguments.length > 2 ? (c >>> 0) : (data.length / 4) / width;
+                    if (data.length !== width * height * 4)
+                        throw new TypeError(""ImageData: the source data length is not a multiple of the row length."");
+                } else {
+                    width = a >>> 0;
+                    height = b >>> 0;
+                    data = new Uint8ClampedArray(width * height * 4);
+                }
+                if (width === 0 || height === 0)
+                    throw new TypeError(""ImageData: the source dimensions are zero."");
+                this.width = width;
+                this.height = height;
+                this.data = data;
+            }
 
             (function () {
                 var HTML_NS = 'http://www.w3.org/1999/xhtml';
@@ -116,6 +140,27 @@ public sealed partial class DomBridge
                 define(Text, function (o) { return isNode(o) && (o.nodeType === 3 || o.nodeType === 4); });
                 define(Comment, function (o) { return isNode(o) && o.nodeType === 8; });
                 define(Attr, function (o) { return isNode(o) && o.nodeType === 2; });
+
+                // The canvas types are not nodes, so nodeType cannot discriminate them; they answer
+                // from the members that define the interface instead. A 2D context is the only
+                // object in the bridge carrying the drawing surface and the pixel readback together.
+                define(CanvasRenderingContext2D, function (o) {
+                    return !!o && typeof o === 'object'
+                        && typeof o.getImageData === 'function'
+                        && typeof o.fillRect === 'function'
+                        && typeof o.fillStyle === 'string';
+                });
+
+                // Accepts an ImageData this constructor produced and one getImageData returned,
+                // which are different objects: the readback is built in C# and does not run through
+                // the constructor, so a prototype walk would answer false for the commoner of the two.
+                define(ImageData, function (o) {
+                    return !!o && typeof o === 'object'
+                        && typeof o.width === 'number' && typeof o.height === 'number'
+                        && !!o.data && typeof o.data === 'object'
+                        && typeof o.data.length === 'number'
+                        && o.data.length === o.width * o.height * 4;
+                });
             })();
         ");
     }

--- a/src/Broiler.HtmlBridge.Dom/Features/CanvasBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/CanvasBinding.cs
@@ -1,72 +1,168 @@
+using System.Runtime.CompilerServices;
 using Broiler.JavaScript.BuiltIns.Null;
 using Broiler.JavaScript.BuiltIns.Number;
 using Broiler.JavaScript.BuiltIns.String;
 using Broiler.JavaScript.BuiltIns.Function;
+using Broiler.JavaScript.BuiltIns.Array;
+using Broiler.JavaScript.BuiltIns.Array.Typed;
 using Broiler.JavaScript.Runtime;
 using Broiler.JavaScript.Storage;
 using Broiler.Dom;
+using Broiler.Graphics;
+using Broiler.Media.Image;
 
 namespace Broiler.HtmlBridge.Dom.Features;
 
 /// <summary>
 /// The HTML <c>canvas.getContext("2d")</c> binding and its 2D drawing context, co-located as an HtmlBridge
 /// feature module (Phase 3): <c>getContext</c> resolves a <c>&lt;canvas&gt;</c> element to a
-/// <see cref="CanvasRenderingContext2D"/>-backed JS object exposing the drawing-state properties
-/// (<c>fillStyle</c>/<c>strokeStyle</c>/<c>lineWidth</c>/<c>font</c>/<c>globalAlpha</c>), the
-/// <c>save</c>/<c>restore</c> state stack, and the (headless no-op) drawing methods. Was the bridge's
-/// <c>JsJsObjectsGetContext134Core</c> + <c>BuildCanvas2DContext</c> + the scattered
-/// <c>JsUtilities…034…058Core</c> canvas callbacks.
+/// <see cref="CanvasRenderingContext2D"/>-backed JS object exposing the drawing-state properties, the
+/// <c>save</c>/<c>restore</c> state stack, the drawing methods, and the pixel APIs
+/// (<c>getImageData</c>/<c>putImageData</c>/<c>createImageData</c>/<c>toDataURL</c>).
 /// </summary>
 /// <remarks>
-/// This was the last element-member callback still living in the mixed <c>JsObjects.cs</c> file. It could not
-/// be extracted earlier because the canvas context was tied to the standalone <c>Broiler.HtmlBridge.Rendering</c>
-/// project's <c>CanvasCommandRecorder</c>; Phase 6 (P6.1) internalized the context into the Canvas binding and
-/// Phase 8 F1 (P8.9) dissolved <c>Rendering</c> into this <c>Dom</c> assembly, which unblocks this move. The
-/// binding is fully static — it navigates with <see cref="DomBridge.TryGetAttribute"/> and needs no host
-/// contract. The <c>#if BROILER_CLI</c> guard preserves the original behaviour: the CLI build has no 2D
-/// context, so <c>getContext("2d")</c> returns <c>null</c> there.
+/// <para>
+/// <b>One context per canvas.</b> <c>getContext</c> returns the <em>same</em> object every call — the
+/// spec requires it, and with a real backing store it also decides whether anything drawn survives:
+/// building a fresh context per call handed back a blank bitmap each time. The context is keyed off the
+/// element rather than off its JS wrapper so it survives the wrapper being rebuilt.
+/// </para>
+/// <para>
+/// The <c>#if BROILER_CLI</c> guard that claimed to make <c>getContext("2d")</c> return <c>null</c> in
+/// the CLI is gone, and removing it changed no behaviour: <c>BROILER_CLI</c> is defined by
+/// <c>Broiler.Cli.csproj</c> for <em>its own</em> compilation, and a <c>DefineConstants</c> does not
+/// reach a referenced project, so the constant was never set while this assembly was compiled and the
+/// guarded branch was unreachable. What it cost was accuracy — it read as a live host difference that
+/// did not exist, which is worse than no comment.
+/// </para>
 /// </remarks>
 internal static class CanvasBinding
 {
-    /// <summary>Installs the <c>getContext</c> method on <paramref name="obj"/> (for <c>&lt;canvas&gt;</c>).</summary>
-    public static void Install(JSObject obj, DomElement element)
+    // Keyed off the element: a DomElement can be handed a new JS wrapper (a re-projection, a re-entry
+    // through a different accessor), and the pixels a page has already drawn must not depend on that.
+    private static readonly ConditionalWeakTable<DomElement, CanvasContext> Contexts = new();
+
+    /// <summary>
+    /// The JS context object a page holds and the C# context that owns its bitmap, kept together so the
+    /// element's own <c>toDataURL</c> can reach the pixels the context's drawing calls wrote.
+    /// </summary>
+    private sealed record CanvasContext(JSObject JsObject, CanvasRenderingContext2D State);
+
+    /// <summary>
+    /// Installs the <c>HTMLCanvasElement</c> members on <paramref name="obj"/>. Called for every
+    /// element, so it does nothing unless this one is a <c>&lt;canvas&gt;</c>: these names belong to
+    /// that interface, and a page asking <c>'getContext' in el</c> or <c>el.width</c> must not find
+    /// them on a <c>&lt;div&gt;</c>. <c>getContext</c> used to be installed unconditionally and
+    /// answered <c>null</c> from a tag check inside — which made the *call* right and the *name*
+    /// wrong, and <c>width</c>/<c>height</c> could not have been staged that way at all: they would
+    /// have shadowed the reflected dimensions every other element has.
+    /// </summary>
+    public static void Install(ICanvasHost host, JSObject obj, DomElement element)
     {
+        if (!string.Equals(element.TagName, "canvas", StringComparison.OrdinalIgnoreCase))
+            return;
+
         obj.FastAddValue((KeyString)"getContext",
-            new DomFunction((in a) => GetContext(element, in a), "getContext", 1),
+            new DomFunction((in a) => GetContext(host, obj, element, in a), "getContext", 1),
             JSPropertyAttributes.EnumerableConfigurableValue);
+
+        obj.FastAddValue((KeyString)"toDataURL",
+            new DomFunction((in a) => ElementToDataUrl(host, obj, element, in a), "toDataURL", 2),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // width/height are unsigned longs reflecting the content attributes, and assigning either
+        // resets the bitmap. Without these the canvas kept whatever size it had when getContext was
+        // first called, so a page that sized its canvas afterwards — or cleared it with the standard
+        // `canvas.width = canvas.width` — drew into a bitmap of the wrong size and never cleared.
+        InstallDimension(obj, element, "width", DefaultWidth);
+        InstallDimension(obj, element, "height", DefaultHeight);
+    }
+
+    private const int DefaultWidth = 300;
+    private const int DefaultHeight = 150;
+
+    /// <summary>Largest rectangle <c>getImageData</c>/<c>createImageData</c> will allocate, in pixels.</summary>
+    private const long MaxImageDataPixels = 64L * 1024 * 1024;
+
+    private static void InstallDimension(JSObject obj, DomElement element, string name, int fallback)
+    {
+        obj.FastAddProperty((KeyString)name,
+            new DomFunction((in _) => new JSNumber(Dimension(element, name, fallback)), "get " + name),
+            new DomFunction((in a) => SetDimension(element, name, in a), "set " + name),
+            JSPropertyAttributes.EnumerableConfigurableProperty);
+    }
+
+    private static int Dimension(DomElement element, string name, int fallback) =>
+        DomBridge.TryGetAttribute(element, name, out var raw)
+        && int.TryParse(raw, out var parsed)
+        && parsed >= 0
+            ? parsed
+            : fallback;
+
+    private static JSValue SetDimension(DomElement element, string name, in Arguments a)
+    {
+        if (a.Length == 0)
+            return JSUndefined.Value;
+
+        // A value that is not a valid non-negative integer reverts to the default, per the reflection
+        // rules for an unsigned long — it does not leave the previous value in place.
+        int value = ToInt(a[0]);
+        if (value < 0)
+            value = name == "width" ? DefaultWidth : DefaultHeight;
+        DomBridge.SetAttr(element, name, value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        if (Contexts.TryGetValue(element, out var context))
+        {
+            context.State.ResetSurface(
+                Dimension(element, "width", DefaultWidth),
+                Dimension(element, "height", DefaultHeight));
+        }
+
+        return JSUndefined.Value;
     }
 
     // getContext(contextType) — returns the 2D context for a <canvas>, else null (only "2d" is supported).
-    private static JSValue GetContext(DomElement element, in Arguments a)
+    private static JSValue GetContext(ICanvasHost host, JSObject canvasObject, DomElement element, in Arguments a)
     {
         if (a.Length == 0)
             return JSNull.Value;
-        var contextType = a[0].ToString();
-        if (!string.Equals(contextType, "2d", StringComparison.OrdinalIgnoreCase))
+        // Any context type other than "2d" is one this engine does not implement, and null is what the
+        // spec says to answer for an unsupported type.
+        if (!string.Equals(a[0].ToString(), "2d", StringComparison.OrdinalIgnoreCase))
             return JSNull.Value;
-        if (!string.Equals(element.TagName, "canvas", StringComparison.OrdinalIgnoreCase))
-            return JSNull.Value;
-#if BROILER_CLI
-        return JSNull.Value; // Canvas 2D context not available in CLI mode
-#else
-        return BuildCanvas2DContext(element);
-#endif
+
+        return GetOrCreateContext(host, canvasObject, element).JsObject;
     }
 
-#if !BROILER_CLI
+    private static CanvasContext GetOrCreateContext(ICanvasHost host, JSObject canvasObject, DomElement element)
+    {
+        if (Contexts.TryGetValue(element, out var existing))
+            return existing;
+
+        var created = BuildCanvas2DContext(host, canvasObject, element);
+        // GetValue rather than Add: two lookups racing on the same element must agree on one context,
+        // because the loser's bitmap is the one a page would silently keep drawing into.
+        return Contexts.GetValue(element, _ => created);
+    }
+
     /// <summary>
-    /// Builds a minimal Canvas 2D rendering context exposing basic drawing operations as defined in the HTML
-    /// Canvas 2D Context specification. Drawing commands are no-ops on a headless canvas (nothing rasterises
-    /// them); only the script-observable style/save-restore state round-trips.
+    /// <c>canvas.toDataURL(type, quality)</c> — on the element, not the context. A canvas that was never
+    /// asked for a context still has a bitmap to serialize (a transparent one), which is why this does
+    /// not require <c>getContext</c> to have been called first.
     /// </summary>
-    private static JSObject BuildCanvas2DContext(DomElement canvas)
+    private static JSValue ElementToDataUrl(ICanvasHost host, JSObject canvasObject, DomElement element, in Arguments a) =>
+        ToDataUrl(GetOrCreateContext(host, canvasObject, element).State, in a);
+
+    /// <summary>
+    /// Builds the Canvas 2D rendering context: the drawing-state properties, the drawing methods that
+    /// now rasterise into the context's bitmap, and the pixel APIs that read it back.
+    /// </summary>
+    private static CanvasContext BuildCanvas2DContext(ICanvasHost host, JSObject canvasObject, DomElement canvas)
     {
         var ctx = new JSObject();
-        int width = 300, height = 150;
-        if (DomBridge.TryGetAttribute(canvas, "width", out var w) && int.TryParse(w, out var pw)) width = pw;
-        if (DomBridge.TryGetAttribute(canvas, "height", out var h) && int.TryParse(h, out var ph)) height = ph;
-
-        var context2d = new CanvasRenderingContext2D(width, height);
+        var context2d = new CanvasRenderingContext2D(
+            Dimension(canvas, "width", DefaultWidth),
+            Dimension(canvas, "height", DefaultHeight));
 
         // fillStyle (get/set)
         ctx.FastAddProperty((KeyString)"fillStyle",
@@ -92,15 +188,31 @@ internal static class CanvasBinding
             new DomFunction((in a) => SetFont(context2d, in a), "set font"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
+        // textAlign (get/set)
+        ctx.FastAddProperty((KeyString)"textAlign",
+            new DomFunction((in _) => new JSString(context2d.TextAlign), "get textAlign"),
+            new DomFunction((in a) => SetTextAlign(context2d, in a), "set textAlign"),
+            JSPropertyAttributes.EnumerableConfigurableProperty);
+
         // globalAlpha (get/set)
         ctx.FastAddProperty((KeyString)"globalAlpha",
             new DomFunction((in _) => new JSNumber(context2d.GlobalAlpha), "get globalAlpha"),
             new DomFunction((in a) => SetGlobalAlpha(context2d, in a), "set globalAlpha"),
             JSPropertyAttributes.EnumerableConfigurableProperty);
 
-        // canvas property
+        // globalCompositeOperation (get/set) — a real accessor rather than the plain own property an
+        // extensible object grew on assignment, so an operator the rasteriser cannot honour is rejected
+        // at the setter (the spec's "ignore an invalid value") instead of round-tripping as if it had
+        // been applied.
+        ctx.FastAddProperty((KeyString)"globalCompositeOperation",
+            new DomFunction((in _) => new JSString(context2d.GlobalCompositeOperation), "get globalCompositeOperation"),
+            new DomFunction((in a) => SetGlobalCompositeOperation(context2d, in a), "set globalCompositeOperation"),
+            JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        // canvas — the element that owns this context. Was a fresh empty object, so ctx.canvas.width did
+        // not answer and ctx.canvas === theCanvas was false.
         ctx.FastAddProperty((KeyString)"canvas",
-            new DomFunction((in _) => new JSObject(), "get canvas"),
+            new DomFunction((in _) => canvasObject, "get canvas"),
             null, JSPropertyAttributes.EnumerableConfigurableProperty);
 
         // Drawing methods
@@ -118,6 +230,8 @@ internal static class CanvasBinding
 
         ctx.FastAddValue((KeyString)"arc", new DomFunction((in a) => Arc(context2d, in a), "arc", 5), JSPropertyAttributes.EnumerableConfigurableValue);
 
+        ctx.FastAddValue((KeyString)"rect", new DomFunction((in a) => Rect(context2d, in a), "rect", 4), JSPropertyAttributes.EnumerableConfigurableValue);
+
         ctx.FastAddValue((KeyString)"closePath", new DomFunction((in _) => ClosePath(context2d, in _), "closePath", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         ctx.FastAddValue((KeyString)"fill", new DomFunction((in _) => Fill(context2d, in _), "fill", 0), JSPropertyAttributes.EnumerableConfigurableValue);
@@ -133,10 +247,21 @@ internal static class CanvasBinding
         ctx.FastAddValue((KeyString)"restore", new DomFunction((in _) => Restore(context2d, in _), "restore", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // measureText(text) — returns { width: ... }
-        ctx.FastAddValue((KeyString)"measureText", new DomFunction((in a) => MeasureText(in a), "measureText", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        ctx.FastAddValue((KeyString)"measureText", new DomFunction((in a) => MeasureText(context2d, in a), "measureText", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        return ctx;
+        // Pixel access
+        ctx.FastAddValue((KeyString)"getImageData", new DomFunction((in a) => GetImageData(context2d, host, in a), "getImageData", 4), JSPropertyAttributes.EnumerableConfigurableValue);
+
+        ctx.FastAddValue((KeyString)"putImageData", new DomFunction((in a) => PutImageData(context2d, in a), "putImageData", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+
+        ctx.FastAddValue((KeyString)"createImageData", new DomFunction((in a) => CreateImageData(host, in a), "createImageData", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // No toDataURL here: HTML puts it on HTMLCanvasElement only, and a page reaches it from a context
+        // through ctx.canvas. Adding it to the context would be a name feature detection could trip on.
+        return new CanvasContext(ctx, context2d);
     }
+
+    // ---- drawing-state setters --------------------------------------------------------------------
 
     private static JSValue SetFillStyle(CanvasRenderingContext2D context2d, in Arguments a)
     {
@@ -166,12 +291,33 @@ internal static class CanvasBinding
         return JSUndefined.Value;
     }
 
+    private static JSValue SetTextAlign(CanvasRenderingContext2D context2d, in Arguments a)
+    {
+        if (a.Length == 0)
+            return JSUndefined.Value;
+        var value = a[0].ToString();
+        if (value is "start" or "end" or "left" or "right" or "center")
+            context2d.TextAlign = value;
+        return JSUndefined.Value;
+    }
+
     private static JSValue SetGlobalAlpha(CanvasRenderingContext2D context2d, in Arguments a)
     {
-        if (a.Length > 0 && a[0] is JSNumber n)
+        // Out-of-range and non-finite values are ignored rather than clamped (HTML §canvas): the state
+        // keeps its previous value.
+        if (a.Length > 0 && a[0] is JSNumber n && n.DoubleValue is >= 0 and <= 1)
             context2d.GlobalAlpha = (float)n.DoubleValue;
         return JSUndefined.Value;
     }
+
+    private static JSValue SetGlobalCompositeOperation(CanvasRenderingContext2D context2d, in Arguments a)
+    {
+        if (a.Length > 0 && CanvasRenderingContext2D.IsSupportedCompositeOperation(a[0].ToString()))
+            context2d.GlobalCompositeOperation = a[0].ToString();
+        return JSUndefined.Value;
+    }
+
+    // ---- drawing ----------------------------------------------------------------------------------
 
     private static JSValue FillRect(CanvasRenderingContext2D context2d, in Arguments a)
     {
@@ -221,6 +367,21 @@ internal static class CanvasBinding
         return JSUndefined.Value;
     }
 
+    private static JSValue Rect(CanvasRenderingContext2D context2d, in Arguments a)
+    {
+        if (a.Length >= 4)
+        {
+            float x = (float)a[0].DoubleValue, y = (float)a[1].DoubleValue;
+            float w = (float)a[2].DoubleValue, h = (float)a[3].DoubleValue;
+            context2d.MoveTo(x, y);
+            context2d.LineTo(x + w, y);
+            context2d.LineTo(x + w, y + h);
+            context2d.LineTo(x, y + h);
+            context2d.ClosePath();
+        }
+        return JSUndefined.Value;
+    }
+
     private static JSValue ClosePath(CanvasRenderingContext2D context2d, in Arguments _)
     {
         context2d.ClosePath();
@@ -265,12 +426,201 @@ internal static class CanvasBinding
         return JSUndefined.Value;
     }
 
-    private static JSValue MeasureText(in Arguments a)
+    private static JSValue MeasureText(CanvasRenderingContext2D context2d, in Arguments a)
     {
         var text = a.Length > 0 ? a[0].ToString() : string.Empty;
         var result = new JSObject();
-        result.FastAddValue((KeyString)"width", new JSNumber(text.Length * 8.0), JSPropertyAttributes.EnumerableConfigurableValue);
+        result.FastAddValue((KeyString)"width", new JSNumber(context2d.MeasureTextWidth(text)), JSPropertyAttributes.EnumerableConfigurableValue);
         return result;
     }
-#endif
+
+    // ---- pixel access -----------------------------------------------------------------------------
+
+    private static JSValue GetImageData(CanvasRenderingContext2D context2d, ICanvasHost host, in Arguments a)
+    {
+        if (a.Length < 4)
+            throw new JSException(
+                "Failed to execute 'getImageData' on 'CanvasRenderingContext2D': 4 arguments required.");
+
+        int sx = ToInt(a[0]), sy = ToInt(a[1]);
+        int width = ToInt(a[2]), height = ToInt(a[3]);
+        // Negative extents address the rectangle in the other direction rather than being an error.
+        if (width < 0) { sx += width; width = -width; }
+        if (height < 0) { sy += height; height = -height; }
+        if (width == 0 || height == 0)
+            throw new JSException(
+                "Failed to execute 'getImageData' on 'CanvasRenderingContext2D': the source rectangle is empty.");
+        // The rectangle is not clipped to the canvas — out-of-bounds pixels read as transparent black —
+        // so its size is bounded by the argument alone and a page can name one no allocation could hold.
+        if ((long)width * height > MaxImageDataPixels)
+            throw new JSException(
+                "Failed to execute 'getImageData' on 'CanvasRenderingContext2D': the source rectangle is too large.");
+
+        byte[] pixels = context2d.GetImageData(sx, sy, width, height);
+        return BuildImageData(host, pixels, width, height);
+    }
+
+    private static JSValue PutImageData(CanvasRenderingContext2D context2d, in Arguments a)
+    {
+        if (a.Length < 3)
+            throw new JSException(
+                "Failed to execute 'putImageData' on 'CanvasRenderingContext2D': 3 arguments required.");
+        if (a[0] is not JSObject imageData)
+            throw new JSException(
+                "Failed to execute 'putImageData' on 'CanvasRenderingContext2D': parameter 1 is not of type 'ImageData'.");
+
+        int width = ToInt(imageData[(KeyString)"width"]);
+        int height = ToInt(imageData[(KeyString)"height"]);
+        if (width <= 0 || height <= 0)
+            return JSUndefined.Value;
+
+        byte[] pixels = ReadPixelBytes(imageData[(KeyString)"data"], width, height);
+        context2d.PutImageData(pixels, width, height, ToInt(a[1]), ToInt(a[2]));
+        return JSUndefined.Value;
+    }
+
+    // No context parameter: createImageData yields transparent black of the requested size and reads
+    // nothing from the canvas it was called on.
+    private static JSValue CreateImageData(ICanvasHost host, in Arguments a)
+    {
+        int width, height;
+        if (a.Length >= 2)
+        {
+            // Magnitude, not Math.Abs: the sign is ignored here, and Math.Abs(int.MinValue) throws.
+            width = Magnitude(ToInt(a[0]));
+            height = Magnitude(ToInt(a[1]));
+        }
+        else if (a.Length == 1 && a[0] is JSObject source)
+        {
+            // createImageData(imagedata) — same dimensions, but transparent black rather than a copy.
+            width = ToInt(source[(KeyString)"width"]);
+            height = ToInt(source[(KeyString)"height"]);
+        }
+        else
+        {
+            throw new JSException(
+                "Failed to execute 'createImageData' on 'CanvasRenderingContext2D': 2 arguments required.");
+        }
+
+        if (width == 0 || height == 0)
+            throw new JSException(
+                "Failed to execute 'createImageData' on 'CanvasRenderingContext2D': the source dimensions are zero.");
+        if ((long)width * height > MaxImageDataPixels)
+            throw new JSException(
+                "Failed to execute 'createImageData' on 'CanvasRenderingContext2D': the dimensions are too large.");
+
+        return BuildImageData(host, new byte[(long)width * height * 4], width, height);
+    }
+
+    private static int Magnitude(int value) => value == int.MinValue ? int.MaxValue : Math.Abs(value);
+
+    /// <summary>
+    /// Builds an <c>ImageData</c>: <c>width</c>, <c>height</c> and a <c>data</c> array holding
+    /// straight-alpha RGBA. <c>data</c> is built through the realm's <c>Uint8ClampedArray</c> so it is a
+    /// real typed array; a realm without one falls back to a plain array, which keeps indexing working
+    /// where the alternative would be no <c>ImageData</c> at all.
+    /// </summary>
+    private static JSObject BuildImageData(ICanvasHost host, byte[] pixels, int width, int height)
+    {
+        var imageData = new JSObject();
+        imageData.FastAddValue((KeyString)"width", new JSNumber(width), JSPropertyAttributes.EnumerableConfigurableValue);
+        imageData.FastAddValue((KeyString)"height", new JSNumber(height), JSPropertyAttributes.EnumerableConfigurableValue);
+        imageData.FastAddValue((KeyString)"data", BuildPixelArray(host, pixels), JSPropertyAttributes.EnumerableConfigurableValue);
+        return imageData;
+    }
+
+    private static JSValue BuildPixelArray(ICanvasHost host, byte[] pixels)
+    {
+        if (host.WindowJSObject?[(KeyString)"Uint8ClampedArray"] is JSFunction clampedArrayCtor)
+        {
+            try
+            {
+                return clampedArrayCtor.CreateInstance(new Arguments(JSUndefined.Value, new JSArrayBuffer(pixels)));
+            }
+            catch
+            {
+                // Fall through to the plain array below.
+            }
+        }
+
+        var values = new JSValue[pixels.Length];
+        for (int i = 0; i < pixels.Length; i++)
+            values[i] = new JSNumber(pixels[i]);
+        return new JSArray(values);
+    }
+
+    /// <summary>
+    /// Reads an <c>ImageData.data</c> back into bytes, whichever of the two shapes
+    /// <see cref="BuildPixelArray"/> produced — and equally an <c>ImageData</c> the page built itself.
+    /// </summary>
+    private static byte[] ReadPixelBytes(JSValue? data, int width, int height)
+    {
+        var pixels = new byte[(long)width * height * 4];
+        if (data is not JSObject source)
+            return pixels;
+
+        for (uint i = 0; i < pixels.Length; i++)
+        {
+            var value = source.GetValue(i, source, throwError: false);
+            if (value is null || value.IsUndefined)
+                continue;
+            pixels[i] = (byte)Math.Clamp((int)Math.Round(value.DoubleValue), 0, 255);
+        }
+
+        return pixels;
+    }
+
+    // ---- serialization ----------------------------------------------------------------------------
+
+    /// <summary>
+    /// <c>toDataURL(type, quality)</c>. An image format the encoders do not support is <b>not</b> an
+    /// error: HTML requires falling back to <c>image/png</c>, and the returned URL names the type that
+    /// was actually produced — which is exactly how a feature detector tells the difference.
+    /// </summary>
+    private static JSValue ToDataUrl(CanvasRenderingContext2D context2d, in Arguments a)
+    {
+        // "data:," is the spec's answer for a canvas with no pixels to serialize.
+        if (!context2d.HasBitmap || !BImageCodecs.IsRegistered)
+            return new JSString("data:,");
+
+        string requested = a.Length > 0 && !a[0].IsUndefined ? a[0].ToString() : "image/png";
+        (ImageEncodeFormat format, string mediaType) = ResolveEncodeFormat(requested);
+
+        int quality = 92;
+        if (a.Length > 1 && a[1] is JSNumber q && q.DoubleValue is >= 0 and <= 1)
+            quality = (int)Math.Round(q.DoubleValue * 100);
+
+        byte[] encoded;
+        try
+        {
+            encoded = context2d.Encode(format, quality);
+        }
+        catch (Exception)
+        {
+            // An encoder that cannot produce this bitmap leaves the canvas unserializable rather than
+            // taking the page's script down with it.
+            return new JSString("data:,");
+        }
+
+        return encoded.Length == 0
+            ? new JSString("data:,")
+            : new JSString($"data:{mediaType};base64,{Convert.ToBase64String(encoded)}");
+    }
+
+    private static (ImageEncodeFormat Format, string MediaType) ResolveEncodeFormat(string requested) =>
+        requested.Trim().ToLowerInvariant() switch
+        {
+            "image/jpeg" or "image/jpg" => (ImageEncodeFormat.Jpeg, "image/jpeg"),
+            "image/bmp" => (ImageEncodeFormat.Bmp, "image/bmp"),
+            "image/gif" => (ImageEncodeFormat.Gif, "image/gif"),
+            _ => (ImageEncodeFormat.Png, "image/png"),
+        };
+
+    private static int ToInt(JSValue? value)
+    {
+        double number = value?.DoubleValue ?? 0;
+        if (double.IsNaN(number) || double.IsInfinity(number))
+            return 0;
+        return (int)Math.Clamp(Math.Truncate(number), int.MinValue, int.MaxValue);
+    }
 }

--- a/src/Broiler.HtmlBridge.Dom/Features/ICanvasHost.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ICanvasHost.cs
@@ -1,0 +1,20 @@
+using Broiler.JavaScript.Runtime;
+
+namespace Broiler.HtmlBridge.Dom.Features;
+
+/// <summary>
+/// What <see cref="CanvasBinding"/> needs from the bridge: the window object, so that
+/// <c>getImageData</c>/<c>createImageData</c> can build their <c>data</c> array with the realm's own
+/// <c>Uint8ClampedArray</c> constructor rather than a look-alike.
+/// </summary>
+/// <remarks>
+/// A typed array's prototype comes from the constructor it was called through, so one built directly in
+/// C# would carry the wrong prototype and answer <c>false</c> to <c>instanceof Uint8ClampedArray</c> —
+/// which is exactly the check a page runs before trusting an <c>ImageData</c>. Going through the global
+/// is what makes the result a real typed array; <c>FetchBinding</c>'s <c>Uint8Array</c> construction
+/// takes the same route.
+/// </remarks>
+internal interface ICanvasHost
+{
+    JSObject? WindowJSObject { get; }
+}


### PR DESCRIPTION
The Canvas 2D context has been upgraded from a style-state stub to a real rasterising context with a pixel backing store. Drawing operations now produce readable pixels, and the pixel-readback APIs (`getImageData`, `putImageData`, `createImageData`, `toDataURL`) are now functional.

## Summary

`CanvasRenderingContext2D` previously kept only drawing state (fill/stroke styles, line width, font, global alpha) and the save/restore stack, while every drawing method was an empty body. This was a Phase 6 leftover from removing a `CanvasDrawCommand` recorder that no renderer ever read. The pixel-readback APIs were deliberately left absent rather than stubbed, because returning zeroed pixels would have falsely claimed support to feature detectors.

This change gives the context a real `BBitmap` backing store (sized to the canvas) and rasterises all drawing operations into it through `BCanvas`. The pixel APIs now report what was actually drawn.

## Key Changes

- **CanvasRenderingContext2D** now owns a `BBitmap` and rasterises drawing calls into it:
  - `FillRect`, `StrokeRect`, `ClearRect` now paint rectangles
  - Path operations (`BeginPath`, `MoveTo`, `LineTo`, `Arc`, `ClosePath`, `Fill`, `Stroke`) now draw paths with flattened arcs
  - `FillText` now rasterises text glyphs
  - `GlobalAlpha` and `GlobalCompositeOperation` are composited during rasterisation
  - Zero-area canvases have no bitmap (null), degrading gracefully per spec

- **Pixel APIs** are now implemented:
  - `getImageData(x, y, w, h)` reads pixels from the bitmap
  - `putImageData(imageData, x, y)` writes pixels directly (bypassing compositing)
  - `createImageData(w, h)` and `new ImageData(w, h)` create `Uint8ClampedArray`-backed image data
  - `canvas.toDataURL(type, quality)` encodes the bitmap to PNG or JPEG data URLs

- **Canvas element integration**:
  - `canvas.width` and `canvas.height` are now settable properties that reset the bitmap and drawing state (per HTML spec)
  - `canvas.toDataURL()` is now a method on the element itself
  - One context per canvas is guaranteed (same object returned on every `getContext("2d")` call)

- **CanvasBinding** feature module refactored:
  - Installs `getContext`, `toDataURL`, `width`, and `height` only on `<canvas>` elements (not on other elements)
  - Manages context lifecycle with `ConditionalWeakTable` keyed off the element
  - Removed the unreachable `#if BROILER_CLI` guard that claimed to disable canvas in CLI builds

- **New test suite** (`CanvasPixelSurfaceTests`) covering:
  - Pixel readback and writethrough
  - `globalAlpha` compositing
  - Out-of-bounds reads
  - `ImageData` construction and `Uint8ClampedArray` semantics
  - `toDataURL` encoding and fallback
  - Canvas dimension changes and state reset
  - Path and text rasterisation

## Implementation Details

- Arc flattening uses a chord-error heuristic to determine segment count, ensuring the approximation never departs from the true arc by more than a quarter pixel
- `ClearRect` writes directly to the bitmap (replacing pixels rather than compositing) since a fully transparent source has no effect through any blend mode
- Bitmap allocation respects a 256 MiB limit (`MaxBitmapPixels`); over-large requests degrade to no bitmap, matching the spec's answer for allocation failure
- Text measurement (`MeasureTextWidth`) returns the renderer's estimate rather than a shaped advance, so `measureText` and non-`start` `textAlign` values are approximate
- No transform stack is exposed (no `translate`/`rotate`/`scale`), so `BCanvas` (a translate+uniform-scale rasteriser) is sufficient

## Fixes

This resolves

https://claude.ai/code/session_01Ay49sFyCx8FUKWcUYukeJe