### PR TITLE
SVG structure scanning, paint servers, and text rendering

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/SvgStructureAndPaintTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/SvgStructureAndPaintTests.cs
@@ -1,0 +1,206 @@
+using System.Drawing;
+using System.Linq;
+using Broiler.Graphics;
+using Broiler.Layout.IR;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// Covers the element structure <see cref="SvgRenderer"/>'s per-shape regexes cannot see —
+/// <see cref="SvgStructure"/> — and the two things that read it: presentation-attribute
+/// inheritance and the paint servers a <c>fill="url(#id)"</c> resolves to.
+/// </summary>
+/// <remarks>
+/// The family that drove it is <c>conformance-checkers/html-svg/pservers-*</c> and
+/// <c>struct-symbol-01-b</c> (issue #1658). Each was a distinct failure of the same blind spot: a
+/// regex over the whole markup draws a <c>&lt;rect&gt;</c> wherever it sits, so the ones inside
+/// <c>&lt;defs&gt;</c>, <c>&lt;symbol&gt;</c> and <c>&lt;pattern&gt;</c> — which SVG renders only
+/// through a reference — were painted where they were declared, and a <c>&lt;g&gt;</c>'s
+/// <c>font-size</c> or <c>transform</c> reached nothing inside it.
+/// </remarks>
+public sealed class SvgStructureAndPaintTests
+{
+    private static readonly RectangleF Bounds = new(0, 0, 100, 100);
+
+    private static string Doc(string body) =>
+        $"<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>{body}</svg>";
+
+    private static List<DisplayItem> Render(string body)
+    {
+        SvgFilterTable.Reset();
+        SvgClipPathTable.Reset();
+        return SvgRenderer.RenderSvgContent(Doc(body), Bounds);
+    }
+
+    private static List<DrawSvgRectItem> Rects(string body) =>
+        [.. Render(body).OfType<DrawSvgRectItem>()];
+
+    // ── Non-rendering containers ──────────────────────────────────────────
+
+    [Theory]
+    [InlineData("defs")]
+    [InlineData("symbol")]
+    [InlineData("pattern")]
+    [InlineData("mask")]
+    [InlineData("clipPath")]
+    public void Shape_Inside_A_NonRendering_Container_Is_Not_Painted(string container)
+    {
+        var rects = Rects($"<{container} id='c'><rect width='10' height='10' fill='red'/></{container}>");
+        Assert.Empty(rects);
+    }
+
+    [Fact]
+    public void Shape_After_A_NonRendering_Container_Is_Still_Painted()
+    {
+        // The container's suppression has to end at its end tag. Tracking it by name alone made a
+        // nested child increment the depth without a matching decrement, which suppressed the
+        // whole rest of the document — every conformance-checkers page starts with a <defs>.
+        var rects = Rects(
+            "<defs><g><rect width='10' height='10' fill='red'/></g></defs>"
+            + "<rect width='20' height='20' fill='blue'/>");
+
+        var painted = Assert.Single(rects);
+        Assert.Equal(BColor.Blue, painted.Fill);
+    }
+
+    [Fact]
+    public void Commented_Out_Markup_Is_Not_Painted()
+    {
+        // Most of the SVG 1.1 suite carries a commented-out <g id="draft-watermark">.
+        Assert.Empty(Rects("<!-- <rect width='10' height='10' fill='red'/> -->"));
+    }
+
+    [Fact]
+    public void Display_None_Suppresses_The_Element_And_Its_Children()
+    {
+        Assert.Empty(Rects("<g display='none'><rect width='10' height='10' fill='red'/></g>"));
+    }
+
+    // ── Inherited presentation attributes ─────────────────────────────────
+
+    [Fact]
+    public void A_Group_Fill_Reaches_A_Child_That_Declares_None()
+    {
+        var rect = Assert.Single(Rects("<g fill='blue'><rect width='10' height='10'/></g>"));
+        Assert.Equal(BColor.Blue, rect.Fill);
+    }
+
+    [Fact]
+    public void A_Child_Fill_Wins_Over_The_Group_It_Inherits_From()
+    {
+        var rect = Assert.Single(Rects("<g fill='blue'><rect width='10' height='10' fill='red'/></g>"));
+        Assert.Equal(BColor.Red, rect.Fill);
+    }
+
+    // ── transform ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void A_Group_Transform_Moves_Its_Children()
+    {
+        var rect = Assert.Single(Rects(
+            "<g transform='translate(40 60)'><rect width='10' height='10' fill='red'/></g>"));
+
+        Assert.Equal(40, rect.X, 3);
+        Assert.Equal(60, rect.Y, 3);
+    }
+
+    [Fact]
+    public void A_Rotated_Transform_Turns_A_Rect_Into_A_Polygon()
+    {
+        // Not a TransformItem: the raster canvas takes only translations and uniform scales, and a
+        // layer it cannot take routes the drawing to a compat backend that renders nothing.
+        var items = Render("<g transform='rotate(45)'><rect width='10' height='10' fill='red'/></g>");
+
+        Assert.Empty(items.OfType<DrawSvgRectItem>());
+        var polygon = Assert.Single(items.OfType<DrawSvgPolygonItem>());
+        Assert.Equal(4, polygon.Points.Count);
+        Assert.Equal(BColor.Red, polygon.Fill);
+    }
+
+    // ── Paint servers ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void An_Unresolvable_Paint_Reference_Takes_Its_Fallback_Colour()
+    {
+        // It used to fall through the colour parser to the caller's default — solid black.
+        var rect = Assert.Single(Rects("<rect width='10' height='10' fill='url(#missing) lime'/>"));
+        Assert.Equal(BColor.FromName("lime"), rect.Fill);
+    }
+
+    [Fact]
+    public void An_Unresolvable_Paint_Reference_With_No_Fallback_Paints_Nothing()
+    {
+        var rect = Assert.Single(Rects("<rect width='10' height='10' fill='url(#missing)'/>"));
+        Assert.True(rect.Fill.IsEmpty);
+    }
+
+    [Fact]
+    public void A_Zero_Sized_Pattern_Falls_Back_Rather_Than_Painting()
+    {
+        var rect = Assert.Single(Rects(
+            "<defs><pattern id='p'><rect width='100%' height='100%' fill='red'/></pattern></defs>"
+            + "<rect width='10' height='10' fill='url(#p) lime'/>"));
+
+        Assert.Equal(BColor.FromName("lime"), rect.Fill);
+    }
+
+    [Fact]
+    public void A_UserSpaceOnUse_Pattern_Tiles_Across_The_Shape()
+    {
+        var items = Render(
+            "<defs><pattern id='p' x='0' y='0' width='10' height='10' patternUnits='userSpaceOnUse'>"
+            + "<rect width='5' height='5' fill='blue'/></pattern></defs>"
+            + "<rect width='40' height='20' fill='url(#p)'/>");
+
+        // 4 columns × 2 rows of the pattern's single child, clipped to the shape.
+        var tiles = items.OfType<DrawSvgRectItem>().Where(r => r.Fill == BColor.Blue).ToList();
+        Assert.Equal(8, tiles.Count);
+        Assert.Single(items.OfType<ClipItem>());
+        Assert.Single(items.OfType<RestoreItem>());
+
+        // The referencing rect keeps no fill of its own — the tiles are the fill.
+        var host = items.OfType<DrawSvgRectItem>().Single(r => r.Width == 40);
+        Assert.True(host.Fill.IsEmpty);
+    }
+
+    [Fact]
+    public void A_Pattern_Inherits_The_One_Its_Href_Points_At()
+    {
+        var items = Render(
+            "<defs>"
+            + "<pattern id='a' x='0' y='0' width='10' height='10' patternUnits='userSpaceOnUse'>"
+            + "<rect width='5' height='5' fill='blue'/></pattern>"
+            + "<pattern id='b' xlink:href='#a' width='10' height='10'/>"
+            + "</defs>"
+            + "<rect width='20' height='10' fill='url(#b)'/>");
+
+        Assert.Equal(2, items.OfType<DrawSvgRectItem>().Count(r => r.Fill == BColor.Blue));
+    }
+
+    // ── use / symbol ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void A_Use_Renders_The_Symbol_It_References_Into_Its_Own_Viewport()
+    {
+        var items = Render(
+            "<symbol id='s' viewBox='0 0 10 10' preserveAspectRatio='none'>"
+            + "<rect width='10' height='10' fill='red'/></symbol>"
+            + "<use x='20' y='30' width='40' height='20' xlink:href='#s'/>");
+
+        var rect = Assert.Single(items.OfType<DrawSvgRectItem>());
+        Assert.Equal(BColor.Red, rect.Fill);
+        // Coordinates are local to the item's Bounds — here the viewport the <use> established.
+        Assert.Equal(20, rect.Bounds.X + rect.X, 3);
+        Assert.Equal(30, rect.Bounds.Y + rect.Y, 3);
+        // preserveAspectRatio="none" stretches each axis independently.
+        Assert.Equal(40, rect.Width, 3);
+        Assert.Equal(20, rect.Height, 3);
+    }
+
+    [Fact]
+    public void A_Use_Pointing_At_Nothing_Renders_Nothing()
+    {
+        Assert.Empty(Render("<use x='10' y='10' width='10' height='10' xlink:href='#missing'/>"));
+    }
+}

--- a/Broiler.Layout/Broiler.Layout.Tests/SvgStructureAndPaintTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/SvgStructureAndPaintTests.cs
@@ -203,4 +203,23 @@ public sealed class SvgStructureAndPaintTests
     {
         Assert.Empty(Render("<use x='10' y='10' width='10' height='10' xlink:href='#missing'/>"));
     }
+
+    [Fact]
+    public void A_Pattern_Fill_Moves_With_The_Transform_On_The_Shape()
+    {
+        // The tiles are separate display items from the shape they fill, so the shape's transform
+        // has to reach them too — otherwise the fill paints where the shape would have been.
+        var items = Render(
+            "<defs><pattern id='p' x='0' y='0' width='10' height='10' patternUnits='userSpaceOnUse'>"
+            + "<rect width='10' height='10' fill='blue'/></pattern></defs>"
+            + "<g transform='translate(40 60)'><rect width='10' height='10' fill='url(#p)'/></g>");
+
+        var tile = Assert.Single(items.OfType<DrawSvgRectItem>().Where(r => r.Fill == BColor.Blue));
+        Assert.Equal(40, tile.Bounds.X + tile.X, 3);
+        Assert.Equal(60, tile.Bounds.Y + tile.Y, 3);
+
+        var clip = Assert.Single(items.OfType<ClipItem>());
+        Assert.Equal(40, clip.ClipRect.X, 3);
+        Assert.Equal(60, clip.ClipRect.Y, 3);
+    }
 }

--- a/Broiler.Layout/Broiler.Layout.Tests/SvgStructureAndPaintTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/SvgStructureAndPaintTests.cs
@@ -222,4 +222,19 @@ public sealed class SvgStructureAndPaintTests
         Assert.Equal(40, clip.ClipRect.X, 3);
         Assert.Equal(60, clip.ClipRect.Y, 3);
     }
+
+    [Fact]
+    public void A_Use_Clones_A_Non_Viewport_Target_At_Its_Own_Offset()
+    {
+        // Anything but a <symbol>/<svg> is a translated deep clone: width/height do not apply, and
+        // a target that is itself rendered keeps painting where it stands as well.
+        var items = Render(
+            "<rect id='r' x='0' y='0' width='10' height='10' fill='red'/>"
+            + "<use x='40' y='60' xlink:href='#r'/>");
+
+        var painted = items.OfType<DrawSvgRectItem>().Where(r => r.Fill == BColor.Red).ToList();
+        Assert.Equal(2, painted.Count);
+        Assert.Contains(painted, r => Math.Abs(r.Bounds.X + r.X) < 0.001 && Math.Abs(r.Bounds.Y + r.Y) < 0.001);
+        Assert.Contains(painted, r => Math.Abs(r.Bounds.X + r.X - 40) < 0.001 && Math.Abs(r.Bounds.Y + r.Y - 60) < 0.001);
+    }
 }

--- a/Broiler.Layout/Broiler.Layout.Tests/SvgTransformTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/SvgTransformTests.cs
@@ -1,0 +1,108 @@
+using System.Drawing;
+using Broiler.Layout.IR;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// Covers <see cref="SvgTransform"/>: parsing an SVG <c>transform</c> list, composing it, inverting
+/// it (which a pattern tiling needs to know which tiles can reach the shape), and conjugating it by
+/// the view-box mapping so it acts on the page coordinates display items carry.
+/// </summary>
+public sealed class SvgTransformTests
+{
+    private static void AssertMaps(SvgTransform transform, float x, float y, float expectedX, float expectedY)
+    {
+        var mapped = transform.Map(x, y);
+        Assert.Equal(expectedX, mapped.X, 3);
+        Assert.Equal(expectedY, mapped.Y, 3);
+    }
+
+    [Fact]
+    public void An_Absent_Or_Unparseable_List_Is_The_Identity()
+    {
+        Assert.True(SvgTransform.Parse(null).IsIdentity);
+        Assert.True(SvgTransform.Parse("   ").IsIdentity);
+        Assert.True(SvgTransform.Parse("wobble(3)").IsIdentity);
+    }
+
+    [Fact]
+    public void Translate_Scale_And_Matrix_Parse()
+    {
+        AssertMaps(SvgTransform.Parse("translate(40 60)"), 1, 2, 41, 62);
+        AssertMaps(SvgTransform.Parse("translate(40)"), 1, 2, 41, 2);
+        AssertMaps(SvgTransform.Parse("scale(2 3)"), 1, 2, 2, 6);
+        AssertMaps(SvgTransform.Parse("scale(2)"), 1, 2, 2, 4);
+        AssertMaps(SvgTransform.Parse("matrix(1 0 0 1 5 7)"), 1, 2, 6, 9);
+    }
+
+    [Fact]
+    public void Rotate_Turns_The_Axes_And_Honours_A_Centre()
+    {
+        AssertMaps(SvgTransform.Parse("rotate(90)"), 1, 0, 0, 1);
+        AssertMaps(SvgTransform.Parse("rotate(90 1 1)"), 1, 0, 2, 1);
+    }
+
+    [Fact]
+    public void A_List_Applies_Left_To_Right()
+    {
+        // SVG 1.1 §7.6: the leftmost function is the outermost, so the rightmost acts first.
+        AssertMaps(SvgTransform.Parse("translate(10 0) scale(2)"), 1, 0, 12, 0);
+        AssertMaps(SvgTransform.Parse("scale(2) translate(10 0)"), 1, 0, 22, 0);
+    }
+
+    [Fact]
+    public void Inverse_Undoes_The_Transform()
+    {
+        var transform = SvgTransform.Parse("translate(40 60) rotate(30) scale(2)");
+        var round = transform.Inverse().Concat(transform);
+
+        AssertMaps(round, 3, 5, 3, 5);
+    }
+
+    [Fact]
+    public void A_Singular_Matrix_Inverts_To_The_Identity_Rather_Than_Infinities()
+    {
+        Assert.True(SvgTransform.Parse("scale(0)").Inverse().IsIdentity);
+    }
+
+    [Fact]
+    public void MapBounds_Is_The_Axis_Aligned_Box_Of_The_Mapped_Rectangle()
+    {
+        var mapped = SvgTransform.Parse("rotate(45)").MapBounds(new RectangleF(0, 0, 10, 10));
+
+        // A 10×10 square rotated 45° spans √2 × 10 on each axis.
+        Assert.Equal(14.142f, mapped.Width, 2);
+        Assert.Equal(14.142f, mapped.Height, 2);
+        Assert.Equal(-7.071f, mapped.Left, 2);
+    }
+
+    [Fact]
+    public void IsAxisAligned_Separates_The_Transforms_A_Rectangle_Survives()
+    {
+        Assert.True(SvgTransform.Parse("translate(4 5) scale(2 3)").IsAxisAligned);
+        Assert.False(SvgTransform.Parse("rotate(30)").IsAxisAligned);
+        Assert.False(SvgTransform.Parse("skewX(20)").IsAxisAligned);
+    }
+
+    [Fact]
+    public void ToPageSpace_Applies_The_User_Space_Transform_To_A_Page_Coordinate()
+    {
+        // A view box scaled 2× whose user-space origin sits at page (100, 50). A user-space
+        // translate(10 0) must move a page point by 20 — the translation scales like any length.
+        var page = SvgTransform.Parse("translate(10 0)").ToPageSpace(2, 2, 100, 50);
+
+        AssertMaps(page, 100, 50, 120, 50);
+        AssertMaps(page, 140, 90, 160, 90);
+    }
+
+    [Fact]
+    public void ToPageSpace_Rotates_About_The_User_Space_Origin()
+    {
+        var page = SvgTransform.Parse("rotate(90)").ToPageSpace(2, 2, 100, 50);
+
+        // The origin is the fixed point of a rotation about it.
+        AssertMaps(page, 100, 50, 100, 50);
+        AssertMaps(page, 110, 50, 100, 60);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/AmbientRenderState.cs
+++ b/Broiler.Layout/Broiler.Layout/AmbientRenderState.cs
@@ -65,7 +65,10 @@ public static class AmbientRenderState
         /// <summary><see cref="DocumentModeContext.CurrentQuirksMode"/>.</summary>
         DocumentMode = 2,
 
-        /// <summary><see cref="IR.SvgFilterTable"/> and <see cref="IR.SvgClipPathTable"/>.</summary>
+        /// <summary>
+        /// <see cref="IR.SvgFilterTable"/>, <see cref="IR.SvgClipPathTable"/> and
+        /// <see cref="IR.SvgTextEnvironment"/>.
+        /// </summary>
         SvgTables = 4,
 
         /// <summary>Everything a thread running layout or paint needs.</summary>
@@ -138,6 +141,7 @@ public static class AmbientRenderState
         DocumentModeContext.CurrentQuirksMode = quirksMode;
         IR.SvgFilterTable.ResetForThread();
         IR.SvgClipPathTable.ResetForThread();
+        IR.SvgTextEnvironment.ResetForThread();
         _established = Slots.All;
     }
 

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
@@ -570,8 +570,17 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     {
         get
         {
-            if (Height != CssConstants.Auto && !string.IsNullOrEmpty(Height))
+            // CSS 2.1 §10.5: a percentage height whose containing block has no definite block size
+            // *computes to* auto, so it qualifies for the transfer exactly as a written `auto` does.
+            // An outer `<svg width="100%" height="100%">` — every conformance-checkers/html-svg page
+            // — is that box, and without this arm it got no height at all once the percentage
+            // stopped being (wrongly) resolved against the containing block's width.
+            if (Height != CssConstants.Auto && !string.IsNullOrEmpty(Height)
+                && !HeightPercentageResolvesToAuto())
+            {
                 return false;
+            }
+
             if (Position == CssConstants.Absolute || Position == CssConstants.Fixed)
                 return false;
             if (IsImage)
@@ -588,7 +597,13 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     {
         borderBoxHeight = 0;
         if (!TryParseAspectRatio(AspectRatio, out double ratio) || !(ratio > 0))
-            return false;
+        {
+            // SVG 2 §8.2: an outer <svg>'s viewBox is its natural ratio. The style pass records it
+            // as an `aspect-ratio` only when the height is written `auto`, so a percentage height
+            // that computes to auto has to read it from the element itself.
+            if (!TryGetSvgViewBoxRatio(out ratio))
+                return false;
+        }
 
         double borderBoxWidth = Size.Width;
         if (!(borderBoxWidth > 0))
@@ -852,5 +867,34 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             if (!CssBoxHelper.EstablishesBfc(child))
                 FindMaxDescendantFloatBottom(child, ref maxBottom);
         }
+    }
+
+    /// <summary>
+    /// SVG 2 §8.2: the natural ratio (width ÷ height) an outer <c>&lt;svg&gt;</c>'s <c>viewBox</c>
+    /// establishes, for the paths that need it when the style pass did not record it as an
+    /// <c>aspect-ratio</c>. The attribute is four unitless numbers; anything else — a wrong count or
+    /// a non-positive extent — is no ratio at all, the same reading the style pass takes.
+    /// </summary>
+    private bool TryGetSvgViewBoxRatio(out double ratio)
+    {
+        ratio = 0;
+        if (HtmlTag == null || !HtmlTag.Name.Equals("svg", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var viewBox = HtmlTag.TryGetAttribute("viewBox");
+        if (string.IsNullOrWhiteSpace(viewBox))
+            return false;
+
+        var parts = viewBox.Split([' ', ',', '\t', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length != 4
+            || !double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out double width)
+            || !double.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out double height)
+            || !(width > 0) || !(height > 0))
+        {
+            return false;
+        }
+
+        ratio = width / height;
+        return true;
     }
 }

--- a/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssLayoutEngine.cs
@@ -1325,9 +1325,8 @@ internal static class CssLayoutEngine
         {
             ibHeight = Math.Max(0, b.ActualBottom - b.Location.Y);
         }
-        else if (b.Height != CssConstants.Auto && !string.IsNullOrEmpty(b.Height))
+        else if (TryResolveAtomicInlineSpecifiedHeight(b, containerWidth, out double cssHeight))
         {
-            double cssHeight = CssLengthParser.ParseLength(b.Height, containerWidth, b.GetEmHeight());
             ibHeight = b.BoxSizing.Equals("border-box", StringComparison.OrdinalIgnoreCase)
                 ? cssHeight
                 : cssHeight
@@ -1430,6 +1429,47 @@ internal static class CssLayoutEngine
                 line.Rectangles[b] = new RectangleF(
                     (float)(ibRect.X + rdx), (float)(ibRect.Y + rdy), ibRect.Width, ibRect.Height);
         }
+    }
+
+    /// <summary>
+    /// The specified block size an atomic inline-level box takes from its own <c>height</c>, or
+    /// <see langword="false"/> when it has none the caller can use — an <c>auto</c> height, or a
+    /// percentage the containing block cannot give a basis for.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A percentage used to be measured against <paramref name="containerWidth"/>: the wrong axis
+    /// outright, and the reason an outer <c>&lt;svg width="100%" height="100%"&gt;</c> — the shape
+    /// every <c>conformance-checkers/html-svg</c> page has — came out as tall as the page is wide
+    /// and then let "xMidYMid meet" centre its drawing a couple of hundred pixels down the box.
+    /// The in-flow grid-item branch above already sidesteps this basis for its own case and names it
+    /// as wrong.
+    /// </para>
+    /// <para>
+    /// CSS 2.1 §10.5: with no definite basis the percentage computes to <c>auto</c>, so this
+    /// declines and the caller falls through to the aspect-ratio transfer — which is what gives that
+    /// <c>&lt;svg&gt;</c> the height its <c>viewBox</c> ratio implies, the same height the reference
+    /// browser uses.
+    /// </para>
+    /// </remarks>
+    private static bool TryResolveAtomicInlineSpecifiedHeight(
+        CssBox b, double containerWidth, out double cssHeight)
+    {
+        cssHeight = 0;
+        if (b.Height == CssConstants.Auto || string.IsNullOrEmpty(b.Height))
+            return false;
+
+        if (!b.Height.Contains('%'))
+        {
+            cssHeight = CssLengthParser.ParseLength(b.Height, containerWidth, b.GetEmHeight());
+            return true;
+        }
+
+        if (!b.TryGetPercentageBlockSizeBasis(out double basis))
+            return false;
+
+        cssHeight = CssLengthParser.ParseLength(b.Height, basis, b.GetEmHeight());
+        return true;
     }
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/IR/FragmentTreeBuilder.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/FragmentTreeBuilder.cs
@@ -23,6 +23,9 @@ internal static class FragmentTreeBuilder
         // `<clipPath>` lives in a different `<svg>` subtree than the referencing element.
         SvgFilterTable.Reset();
         SvgClipPathTable.Reset();
+        // Publish the host's font services for the pass: SvgRenderer has no box to ask for a font,
+        // and a DrawSvgTextItem without one is dropped by the raster backend (see SvgTextEnvironment).
+        SvgTextEnvironment.Reset(root.LayoutEnvironment);
         var tree = BuildFragment(root, parentHasTransform: false);
         CollectSvgDefinitions(tree);
         return tree;

--- a/Broiler.Layout/Broiler.Layout/IR/SvgImageRaster.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgImageRaster.cs
@@ -58,8 +58,31 @@ public static class SvgImageRaster
     /// The display list, empty when <paramref name="svgXml"/> is null, empty, or contains nothing this
     /// renderer draws. An empty list is not an error — it means the document painted nothing.
     /// </returns>
+    /// <remarks>
+    /// <b>An image raster resolves no fonts, deliberately.</b> <see cref="SvgTextEnvironment"/> is
+    /// published for a document's <em>paint</em> pass, and an image raster is not that pass — an
+    /// <c>&lt;img src&gt;</c> is decoded during layout, and <see cref="ImagePrefetch"/> may decode it
+    /// on a worker thread, where the thread-affine slot is deliberately empty. Reading whatever the
+    /// slot happens to hold would make an SVG image's text depend on which thread decoded it and on
+    /// what that pooled thread rendered last: <c>ImagePrefetchTests</c>'s "svg images" case compares
+    /// a serial decode against a concurrent one and catches exactly that. So the slot is cleared for
+    /// the duration, and an SVG image renders the same everywhere — which for text means not at all,
+    /// the behaviour it has always had. Inline <c>&lt;svg&gt;</c>, which does go through the paint
+    /// pass, is unaffected.
+    /// </remarks>
     public static DisplayList BuildDisplayList(string svgXml, RectangleF bounds, double effectiveZoom = 1.0)
-        => new() { Items = SvgRenderer.RenderSvgContent(svgXml, bounds, effectiveZoom) };
+    {
+        var published = SvgTextEnvironment.Current;
+        SvgTextEnvironment.Reset(null);
+        try
+        {
+            return new() { Items = SvgRenderer.RenderSvgContent(svgXml, bounds, effectiveZoom) };
+        }
+        finally
+        {
+            SvgTextEnvironment.Reset(published);
+        }
+    }
 
     /// <summary>
     /// Draws SVG source onto <paramref name="surface"/> through <paramref name="backend"/>.

--- a/Broiler.Layout/Broiler.Layout/IR/SvgItemTransformer.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgItemTransformer.cs
@@ -87,6 +87,24 @@ internal static class SvgItemTransformer
                 };
             }
 
+            case ClipItem clip when transform.IsAxisAligned:
+            {
+                // A nested pattern inside this one clips its own tiling; that clip has to move with
+                // the tile. Under a rotation the mapped box is not a rectangle, so it is left alone
+                // rather than narrowed to the wrong one.
+                var mapped = transform.MapBounds(clip.ClipRect);
+                return new ClipItem
+                {
+                    Bounds = mapped,
+                    ClipRect = mapped,
+                    Polygon = clip.Polygon,
+                    CornerNw = clip.CornerNw, CornerNwY = clip.CornerNwY,
+                    CornerNe = clip.CornerNe, CornerNeY = clip.CornerNeY,
+                    CornerSe = clip.CornerSe, CornerSeY = clip.CornerSeY,
+                    CornerSw = clip.CornerSw, CornerSwY = clip.CornerSwY,
+                };
+            }
+
             case DrawSvgTextItem text:
             {
                 var origin = MapLocal(text.Bounds, text.X, text.Y, transform);

--- a/Broiler.Layout/Broiler.Layout/IR/SvgItemTransformer.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgItemTransformer.cs
@@ -1,0 +1,171 @@
+#nullable disable
+using System.Drawing;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// Rewrites already-positioned SVG display items through an affine transform, so a transformed
+/// subtree can be drawn without asking the backend for a transform layer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The raster canvas takes only translations and uniform scales; anything else routes the whole
+/// layer to a compat backend the image renderer stubs out, and the content disappears. Baking the
+/// transform into the geometry avoids the layer entirely — and a rotated rectangle is still exactly
+/// expressible, as the polygon primitive the backend already draws.
+/// </para>
+/// <para>
+/// A rotated ellipse is not (the primitive has axis-aligned radii), so under a rotation those are
+/// left in place rather than drawn somewhere wrong; that is the one shape this cannot carry.
+/// </para>
+/// </remarks>
+internal static class SvgItemTransformer
+{
+    /// <summary>Maps every item it can express, in order, preserving the ones it cannot.</summary>
+    public static List<DisplayItem> Map(List<DisplayItem> items, SvgTransform transform)
+    {
+        var mapped = new List<DisplayItem>(items.Count);
+        foreach (var item in items)
+            mapped.Add(MapItem(item, transform));
+
+        return mapped;
+    }
+
+    /// <summary>Maps one item, returning it unchanged when the transform cannot be expressed on it.</summary>
+    public static DisplayItem MapItem(DisplayItem item, SvgTransform transform)
+    {
+        switch (item)
+        {
+            case DrawSvgRectItem rect:
+                return MapRect(rect, transform);
+
+            case DrawSvgPolygonItem polygon:
+                return new DrawSvgPolygonItem
+                {
+                    Bounds = polygon.Bounds,
+                    Points = MapPoints(polygon.Bounds, polygon.Points, transform),
+                    Fill = polygon.Fill,
+                    Stroke = polygon.Stroke,
+                    StrokeWidth = polygon.StrokeWidth,
+                };
+
+            case DrawSvgPolylineItem polyline:
+                return new DrawSvgPolylineItem
+                {
+                    Bounds = polyline.Bounds,
+                    Points = MapPoints(polyline.Bounds, polyline.Points, transform),
+                    Fill = polyline.Fill,
+                    Stroke = polyline.Stroke,
+                    StrokeWidth = polyline.StrokeWidth,
+                };
+
+            case DrawSvgLineItem line:
+            {
+                var start = MapLocal(line.Bounds, line.X1, line.Y1, transform);
+                var end = MapLocal(line.Bounds, line.X2, line.Y2, transform);
+                return new DrawSvgLineItem
+                {
+                    Bounds = line.Bounds,
+                    X1 = start.X, Y1 = start.Y, X2 = end.X, Y2 = end.Y,
+                    Stroke = line.Stroke,
+                    StrokeWidth = line.StrokeWidth,
+                };
+            }
+
+            case DrawSvgEllipseItem ellipse when transform.IsAxisAligned:
+            {
+                var centre = MapLocal(ellipse.Bounds, ellipse.Cx, ellipse.Cy, transform);
+                return new DrawSvgEllipseItem
+                {
+                    Bounds = ellipse.Bounds,
+                    Cx = centre.X, Cy = centre.Y,
+                    Rx = ellipse.Rx * Math.Abs(transform.A),
+                    Ry = ellipse.Ry * Math.Abs(transform.D),
+                    Fill = ellipse.Fill,
+                    Stroke = ellipse.Stroke,
+                    StrokeWidth = ellipse.StrokeWidth,
+                };
+            }
+
+            case DrawSvgTextItem text:
+            {
+                var origin = MapLocal(text.Bounds, text.X, text.Y, transform);
+                return new DrawSvgTextItem
+                {
+                    Bounds = text.Bounds,
+                    X = origin.X, Y = origin.Y,
+                    FontSize = text.FontSize,
+                    FontFamily = text.FontFamily,
+                    FontHandle = text.FontHandle,
+                    Fill = text.Fill,
+                    Text = text.Text,
+                };
+            }
+
+            default:
+                return item;
+        }
+    }
+
+    /// <summary>
+    /// A rectangle stays a rectangle under an axis-aligned transform and becomes a quadrilateral
+    /// under anything else — the case a rotated <c>patternTransform</c> produces.
+    /// </summary>
+    private static DisplayItem MapRect(DrawSvgRectItem rect, SvgTransform transform)
+    {
+        if (transform.IsAxisAligned)
+        {
+            var topLeft = MapLocal(rect.Bounds, rect.X, rect.Y, transform);
+            var bottomRight = MapLocal(rect.Bounds, rect.X + rect.Width, rect.Y + rect.Height, transform);
+            return new DrawSvgRectItem
+            {
+                Bounds = rect.Bounds,
+                X = Math.Min(topLeft.X, bottomRight.X),
+                Y = Math.Min(topLeft.Y, bottomRight.Y),
+                Width = Math.Abs(bottomRight.X - topLeft.X),
+                Height = Math.Abs(bottomRight.Y - topLeft.Y),
+                Fill = rect.Fill,
+                Stroke = rect.Stroke,
+                StrokeWidth = rect.StrokeWidth,
+            };
+        }
+
+        return new DrawSvgPolygonItem
+        {
+            Bounds = rect.Bounds,
+            Points =
+            [
+                MapLocal(rect.Bounds, rect.X, rect.Y, transform),
+                MapLocal(rect.Bounds, rect.X + rect.Width, rect.Y, transform),
+                MapLocal(rect.Bounds, rect.X + rect.Width, rect.Y + rect.Height, transform),
+                MapLocal(rect.Bounds, rect.X, rect.Y + rect.Height, transform),
+            ],
+            Fill = rect.Fill,
+            Stroke = rect.Stroke,
+            StrokeWidth = rect.StrokeWidth,
+        };
+    }
+
+    private static List<PointF> MapPoints(
+        RectangleF bounds, IReadOnlyList<PointF> points, SvgTransform transform)
+    {
+        if (points == null)
+            return null;
+
+        var mapped = new List<PointF>(points.Count);
+        foreach (var point in points)
+            mapped.Add(MapLocal(bounds, point.X, point.Y, transform));
+
+        return mapped;
+    }
+
+    /// <summary>
+    /// Maps a coordinate held relative to an item's <c>Bounds</c> origin. The transform is in page
+    /// space, so the point is lifted to page space, mapped, and returned to the item's own frame.
+    /// </summary>
+    private static PointF MapLocal(RectangleF bounds, float x, float y, SvgTransform transform)
+    {
+        var page = transform.Map(bounds.X + x, bounds.Y + y);
+        return new PointF(page.X - bounds.X, page.Y - bounds.Y);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Paint.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Paint.cs
@@ -258,29 +258,42 @@ internal static partial class SvgRenderer
         clipRect = elementTransform.MapBounds(clipRect);
         items.Add(new ClipItem { Bounds = clipRect, ClipRect = clipRect });
 
+        // The tile's content is the same markup at every position, so it is parsed and rendered
+        // once and each further tile is that render translated. Re-rendering per tile parses the
+        // markup up to MaxPatternTiles times for one fill, which a dense pattern over a large shape
+        // reaches easily.
         _patternDepth++;
+        List<DisplayItem> firstTile;
         try
         {
-            for (int row = firstRow; row < lastRow; row++)
-            {
-                for (int column = firstColumn; column < lastColumn; column++)
-                {
-                    var tilePage = new RectangleF(
-                        bounds.X + (tileX + column * tileW) * sx + tx,
-                        bounds.Y + (tileY + row * tileH) * sy + ty,
-                        tileW * sx,
-                        tileH * sy);
-
-                    var tileItems = RenderSvgContent(tileDocument, tilePage);
-                    items.AddRange(pageTransform.IsIdentity
-                        ? tileItems
-                        : SvgItemTransformer.Map(tileItems, pageTransform));
-                }
-            }
+            firstTile = RenderSvgContent(
+                tileDocument,
+                new RectangleF(
+                    bounds.X + (tileX + firstColumn * tileW) * sx + tx,
+                    bounds.Y + (tileY + firstRow * tileH) * sy + ty,
+                    tileW * sx,
+                    tileH * sy));
         }
         finally
         {
             _patternDepth--;
+        }
+
+        for (int row = firstRow; row < lastRow; row++)
+        {
+            for (int column = firstColumn; column < lastColumn; column++)
+            {
+                var placement = pageTransform.Concat(new SvgTransform(
+                    1, 0, 0, 1,
+                    (column - firstColumn) * tileW * sx,
+                    (row - firstRow) * tileH * sy));
+
+                // Identity holds only for the first cell of an untransformed tiling, where the
+                // render is already in place.
+                items.AddRange(placement.IsIdentity
+                    ? firstTile
+                    : SvgItemTransformer.Map(firstTile, placement));
+            }
         }
 
         items.Add(new RestoreItem { Bounds = clipRect });

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Paint.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Paint.cs
@@ -1,0 +1,307 @@
+#nullable disable
+using System.Drawing;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Broiler.Graphics;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// SVG paint-server references — <c>fill="url(#id)"</c> — and the <c>&lt;pattern&gt;</c> tiling
+/// they resolve to.
+/// </summary>
+/// <remarks>
+/// Before this, <c>url(#id)</c> reached the colour parser, matched no named colour and fell through
+/// to the caller's default, so every pattern-filled shape came out solid black — which is what the
+/// <c>conformance-checkers/html-svg/pservers-*</c> family renders as almost its entire canvas. The
+/// tiles are emitted as ordinary display items clipped to the shape, so no new backend primitive is
+/// needed for a paint server the raster backend has never modelled.
+/// </remarks>
+internal static partial class SvgRenderer
+{
+    /// <summary>
+    /// Upper bound on the tiles one pattern fill expands to. A pattern whose tile is a fraction of
+    /// a pixel over a large shape would otherwise emit millions of items for a result no denser
+    /// than the pixels underneath it; past this many the fill is left to its fallback.
+    /// </summary>
+    private const int MaxPatternTiles = 8192;
+
+    /// <summary>How deep a pattern may reference another pattern in its own content.</summary>
+    private const int MaxPatternDepth = 3;
+
+    [ThreadStatic]
+    private static int _patternDepth;
+
+    /// <summary>One <c>&lt;pattern&gt;</c> definition: its attributes and its content markup.</summary>
+    private readonly record struct SvgPattern(Dictionary<string, string> Attributes, string Content);
+
+    /// <summary>
+    /// Splits a paint value into its <c>url(#id)</c> reference and the fallback paint that may
+    /// follow it (SVG 1.1 §13.2.2 / CSS Values 3 <c>&lt;url&gt; &lt;color&gt;?</c>).
+    /// </summary>
+    private static bool TryParsePaintReference(string paint, out string id, out string fallback)
+    {
+        id = null;
+        fallback = null;
+        if (string.IsNullOrEmpty(paint))
+            return false;
+
+        var m = PaintReferenceRegex().Match(paint);
+        if (!m.Success)
+            return false;
+
+        id = m.Groups["id"].Value;
+        var rest = m.Groups["fallback"].Value.Trim();
+        fallback = rest.Length > 0 ? rest : null;
+        return true;
+    }
+
+    /// <summary>
+    /// Collects every <c>&lt;pattern&gt;</c> in the markup by <c>id</c>, resolving the
+    /// <c>href</c>/<c>xlink:href</c> chain SVG 1.1 §13.3 defines: a pattern takes any attribute it
+    /// does not declare, and its content when it has none, from the pattern it points at.
+    /// </summary>
+    private static Dictionary<string, SvgPattern> CollectPatterns(string svgXml)
+    {
+        if (string.IsNullOrEmpty(svgXml)
+            || svgXml.IndexOf("<pattern", StringComparison.OrdinalIgnoreCase) < 0)
+            return null;
+
+        var patterns = new Dictionary<string, SvgPattern>(StringComparer.Ordinal);
+        foreach (Match m in PatternBlockRegex().Matches(svgXml))
+        {
+            var attrs = ParseAttributes(m.Groups["attrs"].Value);
+            if (!attrs.TryGetValue("id", out var id) || string.IsNullOrEmpty(id))
+                continue;
+
+            patterns[id] = new SvgPattern(attrs, m.Groups["content"].Success ? m.Groups["content"].Value : string.Empty);
+        }
+
+        // Resolve the reference chains after collection so a pattern may point forwards.
+        foreach (var id in patterns.Keys.ToList())
+            patterns[id] = ResolveInheritance(patterns, id, MaxPatternDepth);
+
+        return patterns;
+    }
+
+    private static SvgPattern ResolveInheritance(
+        Dictionary<string, SvgPattern> patterns, string id, int budget)
+    {
+        var pattern = patterns[id];
+        if (budget <= 0)
+            return pattern;
+
+        string href = pattern.Attributes.GetValueOrDefault("href")
+            ?? pattern.Attributes.GetValueOrDefault("xlink:href");
+        if (string.IsNullOrEmpty(href) || href.Length < 2 || href[0] != '#')
+            return pattern;
+
+        string target = href[1..];
+        if (target == id || !patterns.ContainsKey(target))
+            return pattern;
+
+        var parent = ResolveInheritance(patterns, target, budget - 1);
+        var merged = new Dictionary<string, string>(pattern.Attributes, StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, value) in parent.Attributes)
+        {
+            if (key is not ("id" or "href" or "xlink:href"))
+                merged.TryAdd(key, value);
+        }
+
+        string content = string.IsNullOrWhiteSpace(pattern.Content) ? parent.Content : pattern.Content;
+        return new SvgPattern(merged, content);
+    }
+
+    /// <summary>
+    /// Resolves a shape's <c>fill</c>, painting the referenced pattern into
+    /// <paramref name="items"/> when there is one.
+    /// </summary>
+    /// <param name="objectBounds">The shape's bounding box in user units — the basis for
+    /// <c>objectBoundingBox</c> units and the region the tiles are clipped to.</param>
+    /// <returns>
+    /// The colour the shape itself should be filled with: empty when the pattern was painted (the
+    /// tiles are the fill), the declared fallback when the reference does not resolve to anything
+    /// paintable, and the plainly parsed value when it is not a reference at all.
+    /// </returns>
+    private static BColor ResolveFill(
+        List<DisplayItem> items, RectangleF bounds, Dictionary<string, SvgPattern> patterns,
+        Dictionary<string, string> attrs, RectangleF objectBounds,
+        float sx, float sy, float tx, float ty, float pctW, float pctH)
+    {
+        string paint = GetPresentationValue(attrs, "fill");
+        if (!TryParsePaintReference(paint, out var id, out var fallback))
+            return GetPaint(attrs, "fill", BColor.Black);
+
+        if (patterns != null && patterns.TryGetValue(id, out var pattern)
+            && EmitPatternTiles(items, bounds, pattern, objectBounds, sx, sy, tx, ty, pctW, pctH))
+        {
+            return BColor.Empty;
+        }
+
+        return FallbackPaint(fallback);
+    }
+
+    /// <summary>
+    /// A shape's <c>fill</c> where a pattern cannot be tiled — every shape but <c>&lt;rect&gt;</c>,
+    /// whose bounding box is the only one this renderer can clip a tiling to.
+    /// </summary>
+    private static BColor ResolveFillWithoutPattern(Dictionary<string, string> attrs, BColor defaultColor)
+        => TryParsePaintReference(GetPresentationValue(attrs, "fill"), out _, out var fallback)
+            ? FallbackPaint(fallback)
+            : GetPaint(attrs, "fill", defaultColor);
+
+    /// <summary>
+    /// SVG 2 §13.2: a reference that resolves to nothing paintable falls back to the paint declared
+    /// after it, and to no paint when none is — not to the initial black, which is what turned every
+    /// pattern-filled shape into a solid black rectangle.
+    /// </summary>
+    private static BColor FallbackPaint(string fallback)
+        => fallback != null ? ParseColorValue(fallback, BColor.Empty) : BColor.Empty;
+
+    /// <summary>
+    /// Paints one pattern over <paramref name="objectBounds"/>, clipped to it.
+    /// </summary>
+    /// <returns><see langword="false"/> when the pattern cannot paint anything — an empty or
+    /// zero-sized tile, or a tile count past <see cref="MaxPatternTiles"/> — so the caller can use
+    /// the fallback paint instead.</returns>
+    private static bool EmitPatternTiles(
+        List<DisplayItem> items, RectangleF bounds, SvgPattern pattern, RectangleF objectBounds,
+        float sx, float sy, float tx, float ty, float pctW, float pctH)
+    {
+        if (_patternDepth >= MaxPatternDepth
+            || string.IsNullOrWhiteSpace(pattern.Content)
+            || objectBounds.Width <= 0 || objectBounds.Height <= 0)
+        {
+            return false;
+        }
+
+        var attrs = pattern.Attributes;
+        bool objectBoundingBoxUnits = !string.Equals(
+            attrs.GetValueOrDefault("patternUnits"), "userSpaceOnUse", StringComparison.OrdinalIgnoreCase);
+
+        // The tile rectangle in user units. objectBoundingBox — the default — makes x/y/width/height
+        // fractions of the shape's bounding box; userSpaceOnUse makes them plain lengths.
+        float tileX, tileY, tileW, tileH;
+        if (objectBoundingBoxUnits)
+        {
+            tileX = objectBounds.X + GetFraction(attrs, "x") * objectBounds.Width;
+            tileY = objectBounds.Y + GetFraction(attrs, "y") * objectBounds.Height;
+            tileW = GetFraction(attrs, "width") * objectBounds.Width;
+            tileH = GetFraction(attrs, "height") * objectBounds.Height;
+        }
+        else
+        {
+            tileX = GetLength(attrs, "x", pctW);
+            tileY = GetLength(attrs, "y", pctH);
+            tileW = GetLength(attrs, "width", pctW);
+            tileH = GetLength(attrs, "height", pctH);
+        }
+
+        if (tileW <= 0 || tileH <= 0)
+            return false;
+
+        // The content's own coordinate system, expressed as the viewBox of the tile-sized document
+        // each tile is rendered as. A viewBox on the pattern is that system outright; otherwise
+        // patternContentUnits decides whether content coordinates are user units (the default, so
+        // the viewBox is the tile itself) or fractions of the shape's bounding box.
+        string viewBox = attrs.GetValueOrDefault("viewBox");
+        if (string.IsNullOrWhiteSpace(viewBox))
+        {
+            bool contentInObjectBoundingBox = string.Equals(
+                attrs.GetValueOrDefault("patternContentUnits"), "objectBoundingBox",
+                StringComparison.OrdinalIgnoreCase);
+
+            viewBox = contentInObjectBoundingBox
+                ? FormattableString.Invariant(
+                    $"0 0 {tileW / objectBounds.Width} {tileH / objectBounds.Height}")
+                : FormattableString.Invariant($"0 0 {tileW} {tileH}");
+        }
+
+        var transform = SvgTransform.Parse(attrs.GetValueOrDefault("patternTransform"));
+
+        // A transformed tiling has to cover the shape's bounding box in the *pattern's* space, which
+        // is the box pulled back through the transform.
+        var coverage = transform.Inverse().MapBounds(objectBounds);
+        int firstColumn = (int)Math.Floor((coverage.Left - tileX) / tileW);
+        int lastColumn = (int)Math.Ceiling((coverage.Right - tileX) / tileW);
+        int firstRow = (int)Math.Floor((coverage.Top - tileY) / tileH);
+        int lastRow = (int)Math.Ceiling((coverage.Bottom - tileY) / tileH);
+
+        long columns = (long)lastColumn - firstColumn;
+        long rows = (long)lastRow - firstRow;
+        if (columns <= 0 || rows <= 0 || columns * rows > MaxPatternTiles)
+            return false;
+
+        string tileDocument = "<svg viewBox=\"" + viewBox + "\">" + pattern.Content + "</svg>";
+        var clipRect = new RectangleF(
+            bounds.X + objectBounds.X * sx + tx, bounds.Y + objectBounds.Y * sy + ty,
+            objectBounds.Width * sx, objectBounds.Height * sy);
+
+        // The same transform in page pixels. Applied to the tiles' own geometry rather than pushed
+        // as a transform layer: the raster canvas cannot express a rotation or a skew, and a layer
+        // it cannot take falls through to a compat backend that the image renderer stubs out — so a
+        // rotated patternTransform drew nothing at all rather than drawing it rotated.
+        var pageTransform = transform.ToPageSpace(sx, sy, bounds.X + tx, bounds.Y + ty);
+
+        items.Add(new ClipItem { Bounds = clipRect, ClipRect = clipRect });
+
+        _patternDepth++;
+        try
+        {
+            for (int row = firstRow; row < lastRow; row++)
+            {
+                for (int column = firstColumn; column < lastColumn; column++)
+                {
+                    var tilePage = new RectangleF(
+                        bounds.X + (tileX + column * tileW) * sx + tx,
+                        bounds.Y + (tileY + row * tileH) * sy + ty,
+                        tileW * sx,
+                        tileH * sy);
+
+                    var tileItems = RenderSvgContent(tileDocument, tilePage);
+                    items.AddRange(pageTransform.IsIdentity
+                        ? tileItems
+                        : SvgItemTransformer.Map(tileItems, pageTransform));
+                }
+            }
+        }
+        finally
+        {
+            _patternDepth--;
+        }
+
+        items.Add(new RestoreItem { Bounds = clipRect });
+        return true;
+    }
+
+    /// <summary>
+    /// An <c>objectBoundingBox</c>-unit attribute: a number or a percentage of the bounding box,
+    /// defaulting to zero, which is what makes an unsized pattern paint nothing.
+    /// </summary>
+    private static float GetFraction(Dictionary<string, string> attrs, string name)
+    {
+        if (!attrs.TryGetValue(name, out var raw))
+            return 0f;
+
+        var value = raw.AsSpan().Trim();
+        if (value.IsEmpty)
+            return 0f;
+
+        bool percent = value[^1] == '%';
+        if (percent)
+            value = value[..^1];
+
+        return float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out float parsed)
+            ? (percent ? parsed / 100f : parsed)
+            : 0f;
+    }
+
+    [GeneratedRegex(@"^\s*url\(\s*['""]?#(?<id>[^)'""\s]+)['""]?\s*\)(?<fallback>.*)$", RegexOptions.IgnoreCase)]
+    private static partial Regex PaintReferenceRegex();
+
+    /// <summary>A <c>&lt;pattern&gt;</c>, whether it has content or is a bare self-closing reference.</summary>
+    [GeneratedRegex(
+        @"<pattern\b(?<attrs>(?:[^>""']|""[^""]*""|'[^']*')*?)(?:/>|>(?<content>.*?)</pattern\s*>)",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex PatternBlockRegex();
+}

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Paint.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Paint.cs
@@ -118,6 +118,10 @@ internal static partial class SvgRenderer
     /// </summary>
     /// <param name="objectBounds">The shape's bounding box in user units — the basis for
     /// <c>objectBoundingBox</c> units and the region the tiles are clipped to.</param>
+    /// <param name="elementTransform">The page-space transform the shape itself is drawn under. The
+    /// tiles are separate display items from the shape, so they need it applied too — otherwise a
+    /// pattern-filled shape inside a <c>&lt;g transform&gt;</c> paints its fill where the shape
+    /// would have been without the transform.</param>
     /// <returns>
     /// The colour the shape itself should be filled with: empty when the pattern was painted (the
     /// tiles are the fill), the declared fallback when the reference does not resolve to anything
@@ -126,14 +130,16 @@ internal static partial class SvgRenderer
     private static BColor ResolveFill(
         List<DisplayItem> items, RectangleF bounds, Dictionary<string, SvgPattern> patterns,
         Dictionary<string, string> attrs, RectangleF objectBounds,
-        float sx, float sy, float tx, float ty, float pctW, float pctH)
+        float sx, float sy, float tx, float ty, float pctW, float pctH,
+        SvgTransform elementTransform)
     {
         string paint = GetPresentationValue(attrs, "fill");
         if (!TryParsePaintReference(paint, out var id, out var fallback))
             return GetPaint(attrs, "fill", BColor.Black);
 
         if (patterns != null && patterns.TryGetValue(id, out var pattern)
-            && EmitPatternTiles(items, bounds, pattern, objectBounds, sx, sy, tx, ty, pctW, pctH))
+            && EmitPatternTiles(
+                items, bounds, pattern, objectBounds, sx, sy, tx, ty, pctW, pctH, elementTransform))
         {
             return BColor.Empty;
         }
@@ -166,7 +172,8 @@ internal static partial class SvgRenderer
     /// the fallback paint instead.</returns>
     private static bool EmitPatternTiles(
         List<DisplayItem> items, RectangleF bounds, SvgPattern pattern, RectangleF objectBounds,
-        float sx, float sy, float tx, float ty, float pctW, float pctH)
+        float sx, float sy, float tx, float ty, float pctW, float pctH,
+        SvgTransform elementTransform)
     {
         if (_patternDepth >= MaxPatternDepth
             || string.IsNullOrWhiteSpace(pattern.Content)
@@ -241,8 +248,14 @@ internal static partial class SvgRenderer
         // as a transform layer: the raster canvas cannot express a rotation or a skew, and a layer
         // it cannot take falls through to a compat backend that the image renderer stubs out — so a
         // rotated patternTransform drew nothing at all rather than drawing it rotated.
-        var pageTransform = transform.ToPageSpace(sx, sy, bounds.X + tx, bounds.Y + ty);
+        // The shape's own transform applies outside the pattern's, since the pattern is expressed
+        // in the shape's user space.
+        var pageTransform = elementTransform.Concat(
+            transform.ToPageSpace(sx, sy, bounds.X + tx, bounds.Y + ty));
 
+        // A rotated element clips to the mapped box rather than the mapped shape: ClipItem is a
+        // rectangle, so this is the tightest clip it can express.
+        clipRect = elementTransform.MapBounds(clipRect);
         items.Add(new ClipItem { Bounds = clipRect, ClipRect = clipRect });
 
         _patternDepth++;

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Text.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Text.cs
@@ -36,16 +36,17 @@ internal static partial class SvgRenderer
     /// inheritable ones its ancestors declared filled in.
     /// </summary>
     /// <remarks>
-    /// An element the scan never reached — markup whose shape the tag regex could not follow —
-    /// is treated as painting with nothing inherited, which is what this renderer did before the
-    /// scan existed. Only an element the scan saw and classified is dropped, so a scanning gap
-    /// cannot silently erase a shape.
+    /// An element the scan never reached — markup whose shape the tag regex could not follow — is
+    /// treated as painting with nothing inherited, which is what this renderer did before the scan
+    /// existed, so a scanning gap cannot silently erase a shape. A match inside a comment or CDATA
+    /// section is the one absence that does mean "does not paint", and the scan records those spans
+    /// explicitly for exactly that reason.
     /// </remarks>
     private static bool TryResolveElement(
         SvgStructure structure, Match match, out Dictionary<string, string> attrs)
     {
         bool paints = structure.TryGetRendered(match.Index, out var inherited);
-        if (!paints && structure.TryGetAttributes(match.Index, out _))
+        if (!paints && (structure.TryGetAttributes(match.Index, out _) || structure.IsInert(match.Index)))
         {
             attrs = null;
             return false;

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Text.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Text.cs
@@ -1,0 +1,269 @@
+#nullable disable
+using System.Drawing;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using Broiler.CSS;
+using Broiler.Graphics;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// SVG <c>&lt;text&gt;</c> painting, and the element lookup the shape loops share with it.
+/// </summary>
+internal static partial class SvgRenderer
+{
+    /// <summary>
+    /// The fraction of a font's line height that sits above the baseline. The same approximation
+    /// <c>CssLayoutEngine</c> uses to place a line box's baseline, reused here because SVG gives
+    /// <c>y</c> as the baseline while the backend's <c>DrawString</c> takes the top of the ascent box.
+    /// </summary>
+    private const double TypicalAscentRatio = 0.8;
+
+    /// <summary>
+    /// The page-space transform the matched element is drawn under: its own and its ancestors'
+    /// <c>transform</c> attributes, conjugated by the view-box mapping so it acts on the
+    /// already-converted page coordinates the display items carry.
+    /// </summary>
+    private static SvgTransform PageTransformOf(
+        SvgStructure structure, Match match, RectangleF bounds,
+        float sx, float sy, float tx, float ty)
+        => structure.TransformAt(match.Index).ToPageSpace(sx, sy, bounds.X + tx, bounds.Y + ty);
+
+    /// <summary>
+    /// Resolves one matched element against the scanned structure: <see langword="false"/> when it
+    /// sits inside a container that does not paint, otherwise its own attributes with the
+    /// inheritable ones its ancestors declared filled in.
+    /// </summary>
+    /// <remarks>
+    /// An element the scan never reached — markup whose shape the tag regex could not follow —
+    /// is treated as painting with nothing inherited, which is what this renderer did before the
+    /// scan existed. Only an element the scan saw and classified is dropped, so a scanning gap
+    /// cannot silently erase a shape.
+    /// </remarks>
+    private static bool TryResolveElement(
+        SvgStructure structure, Match match, out Dictionary<string, string> attrs)
+    {
+        bool paints = structure.TryGetRendered(match.Index, out var inherited);
+        if (!paints && structure.TryGetAttributes(match.Index, out _))
+        {
+            attrs = null;
+            return false;
+        }
+
+        attrs = ParseAttributes(match.Groups[1].Value);
+        if (inherited != null)
+        {
+            foreach (var (property, value) in inherited)
+                attrs.TryAdd(property, value);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Emits the <c>&lt;text&gt;</c> elements that lay their glyphs out along the normal text
+    /// direction — every one that is not a <c>&lt;textPath&gt;</c>, which the caller handles.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A <c>DrawSvgTextItem</c> is only drawn when it carries a resolved font
+    /// (<c>RGraphicsRasterBackend.RenderSvgText</c> returns early otherwise), and nothing ever set
+    /// one, so every SVG <c>&lt;text&gt;</c> in the engine painted nothing at all. The font comes
+    /// from <see cref="SvgTextEnvironment"/>, published for the pass by the fragment-tree build.
+    /// </para>
+    /// <para>
+    /// Child markup is flattened to its text: a <c>&lt;tspan&gt;</c> with its own position is drawn
+    /// in the flow rather than at that position, which is closer than dropping it and much closer
+    /// than drawing the raw <c>&lt;tspan …&gt;</c> tag as literal glyphs — what the old code did,
+    /// since it never stripped the children it captured.
+    /// </para>
+    /// </remarks>
+    private static void EmitTextElements(
+        string svgXml, RectangleF bounds, List<DisplayItem> items, SvgStructure structure,
+        float sx, float sy, float tx, float ty, float pctW, float pctH, float pctD)
+    {
+        foreach (Match m in TextElementRegex().Matches(svgXml))
+        {
+            if (ParseTextPathRegex().IsMatch(m.Groups[2].Value))
+                continue;
+
+            if (!TryResolveElement(structure, m, out var attrs))
+                continue;
+
+            string text = FlattenTextContent(m.Groups[2].Value);
+            if (text.Length == 0)
+                continue;
+
+            float scale = Math.Max(sx, sy);
+            float fontSize = GetLength(attrs, "font-size", pctD, 16) * scale;
+            var font = ResolveFont(attrs, fontSize);
+
+            float x = GetLength(attrs, "x", pctW) * sx + tx;
+            float y = GetLength(attrs, "y", pctH) * sy + ty;
+
+            AddShape(
+                items, bounds, attrs, PageTransformOf(structure, m, bounds, sx, sy, tx, ty),
+                new DrawSvgTextItem
+                {
+                    Bounds = bounds,
+                    X = x - AnchorOffset(attrs, font, text),
+                    // SVG 1.1 §10.4 places the glyphs on the baseline at y; the backend draws from
+                    // the top of the ascent box, so the item carries the top instead.
+                    Y = y - (float)AscentOf(font, fontSize),
+                    FontSize = fontSize,
+                    FontFamily = attrs.GetValueOrDefault("font-family") ?? "Arial",
+                    FontHandle = font,
+                    Fill = GetPaint(attrs, "fill", BColor.Black) is { IsEmpty: false } fill
+                        ? fill
+                        : BColor.Black,
+                    Text = text,
+                });
+        }
+    }
+
+    /// <summary>
+    /// Resolves the font for one text element from its (already inheritance-merged) presentation
+    /// attributes. Returns <see langword="null"/> when no environment is published for this pass —
+    /// an SVG rasterised as a standalone image — leaving the text undrawn as before.
+    /// </summary>
+    private static ILayoutFont ResolveFont(Dictionary<string, string> attrs, float fontSizePx)
+    {
+        var style = LayoutFontStyle.Regular;
+
+        string fontStyle = GetPresentationValue(attrs, "font-style");
+        if (fontStyle != null
+            && (fontStyle.Equals("italic", StringComparison.OrdinalIgnoreCase)
+                || fontStyle.Equals("oblique", StringComparison.OrdinalIgnoreCase)))
+        {
+            style |= LayoutFontStyle.Italic;
+        }
+
+        if (IsBoldWeight(GetPresentationValue(attrs, "font-weight")))
+            style |= LayoutFontStyle.Bold;
+
+        string family = GetPresentationValue(attrs, "font-family");
+        return SvgTextEnvironment.GetFont(
+            string.IsNullOrWhiteSpace(family) ? CssConstants.DefaultFont : family, fontSizePx, style);
+    }
+
+    /// <summary>
+    /// CSS Fonts 4 §2.4: <c>bold</c>, <c>bolder</c> and any numeric weight of 600 or more are bold.
+    /// <c>bolder</c> resolves against the inherited weight, which this renderer does not track, so it
+    /// is read as plain bold — the value it takes from every weight up to 500.
+    /// </summary>
+    private static bool IsBoldWeight(string weight)
+    {
+        if (string.IsNullOrWhiteSpace(weight))
+            return false;
+
+        var trimmed = weight.Trim();
+        if (trimmed.Equals("bold", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("bolder", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return int.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out int numeric)
+            && numeric >= 600;
+    }
+
+    /// <summary>Distance from the top of the ascent box to the baseline, in CSS pixels.</summary>
+    private static double AscentOf(ILayoutFont font, float fontSizePx)
+        => font != null
+            ? font.Height * CssMetrics.PtToPx * TypicalAscentRatio
+            : fontSizePx * TypicalAscentRatio;
+
+    /// <summary>
+    /// How far left of <c>x</c> the run starts, per <c>text-anchor</c> (SVG 1.1 §10.9.1): nothing
+    /// for <c>start</c>, half the advance for <c>middle</c>, all of it for <c>end</c>.
+    /// </summary>
+    private static float AnchorOffset(Dictionary<string, string> attrs, ILayoutFont font, string text)
+    {
+        string anchor = GetPresentationValue(attrs, "text-anchor")?.Trim();
+        if (string.IsNullOrEmpty(anchor)
+            || anchor.Equals("start", StringComparison.OrdinalIgnoreCase))
+            return 0f;
+
+        bool middle = anchor.Equals("middle", StringComparison.OrdinalIgnoreCase);
+        if (!middle && !anchor.Equals("end", StringComparison.OrdinalIgnoreCase))
+            return 0f;
+
+        float width = SvgTextEnvironment.MeasureWidth(font, text);
+        return middle ? width / 2f : width;
+    }
+
+    /// <summary>
+    /// The rendered characters of a text element: child markup removed, entity references resolved,
+    /// and whitespace collapsed the way <c>xml:space="default"</c> asks for (SVG 1.1 §10.15) — every
+    /// run of white space becomes one space, and leading and trailing space is dropped.
+    /// </summary>
+    private static string FlattenTextContent(string content)
+    {
+        string stripped = DrawSvgTextRegex().Replace(content, string.Empty);
+        var sb = new StringBuilder(stripped.Length);
+        bool pendingSpace = false;
+
+        foreach (char ch in DecodeEntities(stripped))
+        {
+            if (char.IsWhiteSpace(ch))
+            {
+                pendingSpace = sb.Length > 0;
+                continue;
+            }
+
+            if (pendingSpace)
+            {
+                sb.Append(' ');
+                pendingSpace = false;
+            }
+
+            sb.Append(ch);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Resolves the XML entity references the SVG serializer writes (<c>&amp;amp;</c>,
+    /// <c>&amp;lt;</c>, <c>&amp;gt;</c>, <c>&amp;quot;</c>, <c>&amp;apos;</c>) plus numeric
+    /// character references. Left as-is when the markup carries none, which is the common case.
+    /// </summary>
+    private static string DecodeEntities(string text)
+    {
+        if (text.IndexOf('&') < 0)
+            return text;
+
+        return EntityRegex().Replace(text, static m =>
+        {
+            string name = m.Groups["name"].Value;
+            switch (name)
+            {
+                case "amp": return "&";
+                case "lt": return "<";
+                case "gt": return ">";
+                case "quot": return "\"";
+                case "apos": return "'";
+                case "nbsp": return " ";
+            }
+
+            var numeric = m.Groups["dec"];
+            var hex = m.Groups["hex"];
+            int code;
+            if (numeric.Success && int.TryParse(numeric.Value, out code))
+                return char.ConvertFromUtf32(code);
+            if (hex.Success && int.TryParse(hex.Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out code))
+                return char.ConvertFromUtf32(code);
+
+            return m.Value;
+        });
+    }
+
+    /// <summary>
+    /// A <c>&lt;text&gt;</c> element and its content. Unlike the attribute-requiring pattern this
+    /// replaced, it also matches a bare <c>&lt;text&gt;</c>.
+    /// </summary>
+    [GeneratedRegex(@"<text\b([^>]*)>(.*?)</text\s*>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex TextElementRegex();
+
+    [GeneratedRegex(@"&(?:(?<name>[A-Za-z][A-Za-z0-9]*)|#(?<dec>[0-9]+)|#[xX](?<hex>[0-9A-Fa-f]+));")]
+    private static partial Regex EntityRegex();
+}

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Use.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Use.cs
@@ -1,0 +1,152 @@
+#nullable disable
+using System.Drawing;
+using System.Text.RegularExpressions;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// <c>&lt;use&gt;</c>, and the <c>&lt;symbol&gt;</c> viewport it establishes.
+/// </summary>
+/// <remarks>
+/// A <c>&lt;symbol&gt;</c> is never drawn where it is declared — only through a reference — and
+/// nothing here drew the reference, so <c>conformance-checkers/html-svg/struct-symbol-01-b</c>
+/// painted the symbol's own contents over the whole canvas and nothing at either place the test
+/// puts them.
+/// </remarks>
+internal static partial class SvgRenderer
+{
+    /// <summary>How deep a <c>&lt;use&gt;</c> may reference another.</summary>
+    private const int MaxUseDepth = 4;
+
+    [ThreadStatic]
+    private static int _useDepth;
+
+    /// <summary>Draws every <c>&lt;use&gt;</c> that paints where it stands.</summary>
+    private static void EmitUseElements(
+        string svgXml, RectangleF bounds, List<DisplayItem> items, SvgStructure structure,
+        float sx, float sy, float tx, float ty, float pctW, float pctH)
+    {
+        if (_useDepth >= MaxUseDepth
+            || svgXml.IndexOf("<use", StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return;
+        }
+
+        foreach (Match m in UseElementRegex().Matches(svgXml))
+        {
+            if (!TryResolveElement(structure, m, out var attrs))
+                continue;
+
+            string href = attrs.GetValueOrDefault("href") ?? attrs.GetValueOrDefault("xlink:href");
+            if (string.IsNullOrEmpty(href) || href.Length < 2 || href[0] != '#')
+                continue;
+
+            if (!structure.TryGetById(href[1..], out var target))
+                continue;
+
+            float x = GetLength(attrs, "x", pctW);
+            float y = GetLength(attrs, "y", pctH);
+
+            // SVG 1.1 §5.6: <use> on a <symbol> (or an <svg>) makes a viewport of its width/height,
+            // both defaulting to 100% of the current viewport; on anything else it is a translated
+            // clone and width/height have no effect.
+            bool establishesViewport =
+                target.Name.Equals("symbol", StringComparison.OrdinalIgnoreCase)
+                || target.Name.Equals("svg", StringComparison.OrdinalIgnoreCase);
+
+            var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+            _useDepth++;
+            try
+            {
+                if (establishesViewport)
+                    EmitSymbolUse(items, bounds, target, attrs, x, y, sx, sy, tx, ty, pctW, pctH, elementTransform);
+                else
+                    EmitCloneUse(items, bounds, target, x, y, sx, sy, tx, ty, elementTransform);
+            }
+            finally
+            {
+                _useDepth--;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Renders a referenced <c>&lt;symbol&gt;</c> into the viewport the <c>&lt;use&gt;</c> gives it,
+    /// carrying the symbol's own <c>viewBox</c> and <c>preserveAspectRatio</c>.
+    /// </summary>
+    private static void EmitSymbolUse(
+        List<DisplayItem> items, RectangleF bounds, SvgStructure.Element target,
+        Dictionary<string, string> useAttrs, float x, float y,
+        float sx, float sy, float tx, float ty, float pctW, float pctH, SvgTransform pageTransform)
+    {
+        float width = useAttrs.TryGetValue("width", out _) ? GetLength(useAttrs, "width", pctW) : pctW;
+        float height = useAttrs.TryGetValue("height", out _) ? GetLength(useAttrs, "height", pctH) : pctH;
+        if (width <= 0 || height <= 0 || string.IsNullOrWhiteSpace(target.Content))
+            return;
+
+        var viewport = new RectangleF(
+            bounds.X + x * sx + tx, bounds.Y + y * sy + ty, width * sx, height * sy);
+
+        // A symbol with no viewBox does not scale its content; its user space is the viewport's,
+        // which a view box matching the viewport expresses exactly.
+        string viewBox = target.Attributes.GetValueOrDefault("viewBox");
+        if (string.IsNullOrWhiteSpace(viewBox))
+            viewBox = FormattableString.Invariant($"0 0 {width} {height}");
+
+        string preserve = target.Attributes.GetValueOrDefault("preserveAspectRatio");
+        string document = "<svg viewBox=\"" + viewBox + "\""
+            + (string.IsNullOrWhiteSpace(preserve) ? string.Empty : " preserveAspectRatio=\"" + preserve + "\"")
+            + ">" + target.Content + "</svg>";
+
+        AddMapped(items, RenderSvgContent(document, viewport), pageTransform);
+    }
+
+    /// <summary>
+    /// Renders a referenced element that is not a viewport-establishing one: a deep clone offset by
+    /// the <c>&lt;use&gt;</c>'s <c>x</c>/<c>y</c>.
+    /// </summary>
+    private static void EmitCloneUse(
+        List<DisplayItem> items, RectangleF bounds, SvgStructure.Element target,
+        float x, float y, float sx, float sy, float tx, float ty, SvgTransform pageTransform)
+    {
+        string markup = RenderMarkupOf(target);
+        if (string.IsNullOrWhiteSpace(markup))
+            return;
+
+        // The clone shares the referencing document's user space, so it renders against the same
+        // origin and scale — expressed as a view box over the whole viewport — shifted by x/y.
+        var clone = RenderSvgContent(
+            FormattableString.Invariant(
+                $"<svg viewBox=\"{-x} {-y} {bounds.Width / sx} {bounds.Height / sy}\" preserveAspectRatio=\"none\">{markup}</svg>"),
+            new RectangleF(bounds.X + tx, bounds.Y + ty, bounds.Width, bounds.Height));
+
+        AddMapped(items, clone, pageTransform);
+    }
+
+    private static void AddMapped(
+        List<DisplayItem> items, List<DisplayItem> produced, SvgTransform pageTransform)
+        => items.AddRange(pageTransform.IsIdentity
+            ? produced
+            : SvgItemTransformer.Map(produced, pageTransform));
+
+    /// <summary>The referenced element re-serialised as markup, so it can be rendered as content.</summary>
+    private static string RenderMarkupOf(SvgStructure.Element target)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append('<').Append(target.Name);
+        foreach (var (name, value) in target.Attributes)
+        {
+            if (name is "id" or "href" or "xlink:href")
+                continue;
+            sb.Append(' ').Append(name).Append("=\"").Append(value).Append('"');
+        }
+
+        if (string.IsNullOrEmpty(target.Content))
+            return sb.Append("/>").ToString();
+
+        return sb.Append('>').Append(target.Content).Append("</").Append(target.Name).Append('>').ToString();
+    }
+
+    [GeneratedRegex(@"<use\b((?:[^>""']|""[^""]*""|'[^']*')*?)/?>", RegexOptions.IgnoreCase)]
+    private static partial Regex UseElementRegex();
+}

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
@@ -146,7 +146,8 @@ internal static partial class SvgRenderer
                 GetLength(attrs, "x", pctW), GetLength(attrs, "y", pctH),
                 GetLength(attrs, "width", pctW), GetLength(attrs, "height", pctH));
             var rectFill = ResolveFill(
-                items, bounds, patterns, attrs, objectBounds, sx, sy, tx, ty, pctW, pctH);
+                items, bounds, patterns, attrs, objectBounds, sx, sy, tx, ty, pctW, pctH,
+                elementTransform);
             var rectStroke = GetPaint(attrs, "stroke", BColor.Empty);
 
             // A colour-only filter chain over a solid fill is equivalent to recolouring the shape;

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
@@ -62,14 +62,13 @@ internal static partial class SvgRenderer
                     float.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out float vbH) &&
                     vbW > 0 && vbH > 0)
                 {
-                    // "xMidYMid meet": scale uniformly to fit, centre
-                    float scaleX = bounds.Width / vbW;
-                    float scaleY = bounds.Height / vbH;
-                    float scale = Math.Min(scaleX, scaleY);
-                    sx = scale;
-                    sy = scale;
-                    tx = -vbX * scale + (bounds.Width - vbW * scale) / 2f;
-                    ty = -vbY * scale + (bounds.Height - vbH * scale) / 2f;
+                    // SVG 1.1 §7.8: preserveAspectRatio decides how the view box maps onto the
+                    // viewport. The default "xMidYMid meet" scales uniformly to fit and centres;
+                    // `none` stretches each axis independently, which is what a <symbol> used at a
+                    // different shape asks for, and `slice` fills instead of fitting.
+                    (sx, sy, tx, ty) = ResolveViewBoxMapping(
+                        svgAttrs.GetValueOrDefault("preserveAspectRatio"),
+                        bounds, vbX, vbY, vbW, vbH);
                     // A viewBox establishes the viewport for its children, so a percentage inside it
                     // resolves against the viewBox extent rather than against the CSS box.
                     viewportW = vbW;
@@ -91,6 +90,15 @@ internal static partial class SvgRenderer
         float pctW = viewportW, pctH = viewportH;
         float pctD = (float)(Math.Sqrt(viewportW * viewportW + viewportH * viewportH) / Math.Sqrt(2));
 
+        // The nesting the per-element regexes below cannot see: which elements are inside a
+        // <defs>/<symbol>/<pattern> (rendered only through a reference) or a comment, and which
+        // presentation attributes each inherits from its ancestors.
+        var structure = SvgStructure.Scan(svgXml);
+
+        // The paint servers a fill may point at. Collected from the whole markup, not just the
+        // rendered part: a <pattern> lives in <defs> precisely so it paints only through a reference.
+        var patterns = CollectPatterns(svgXml);
+
         foreach (Match m in ParseSvgRegex().Matches(svgXml))
         {
             var attrs = ParseAttributes(m.Groups[1].Value);
@@ -105,7 +113,10 @@ internal static partial class SvgRenderer
         // <rect ... /> or <rect ...></rect>
         foreach (Match m in ParseRectRegex().Matches(svgXml))
         {
-            var attrs = ParseAttributes(m.Groups[1].Value);
+            if (!TryResolveElement(structure, m, out var attrs))
+                continue;
+
+            var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
 
             // A rect referencing an feFlood filter is replaced by a solid fill of the flood colour
             // over the filter region — the default objectBoundingBox region is the shape's bounding
@@ -115,7 +126,7 @@ internal static partial class SvgRenderer
                 float bx = GetLength(attrs, "x", pctW), by = GetLength(attrs, "y", pctH);
                 float bw = GetLength(attrs, "width", pctW), bh = GetLength(attrs, "height", pctH);
                 float fx = bx - 0.1f * bw, fy = by - 0.1f * bh, fw = 1.2f * bw, fh = 1.2f * bh;
-                AddShape(items, bounds, attrs, new DrawSvgRectItem
+                AddShape(items, bounds, attrs, elementTransform, new DrawSvgRectItem
                 {
                     Bounds = bounds,
                     X = fx * sx + tx,
@@ -129,7 +140,13 @@ internal static partial class SvgRenderer
                 continue;
             }
 
-            var rectFill = GetPaint(attrs, "fill", BColor.Black);
+            // A pattern fill paints as tiles behind the shape, so it is resolved before the rect
+            // item is added and leaves the rect's own fill empty; a stroke then draws over it.
+            var objectBounds = new RectangleF(
+                GetLength(attrs, "x", pctW), GetLength(attrs, "y", pctH),
+                GetLength(attrs, "width", pctW), GetLength(attrs, "height", pctH));
+            var rectFill = ResolveFill(
+                items, bounds, patterns, attrs, objectBounds, sx, sy, tx, ty, pctW, pctH);
             var rectStroke = GetPaint(attrs, "stroke", BColor.Empty);
 
             // A colour-only filter chain over a solid fill is equivalent to recolouring the shape;
@@ -138,7 +155,7 @@ internal static partial class SvgRenderer
             if (TryResolveColorFilter(attrs, rectFill, rectStroke, out var filteredFill))
                 rectFill = filteredFill;
 
-            AddShape(items, bounds, attrs, new DrawSvgRectItem
+            AddShape(items, bounds, attrs, elementTransform, new DrawSvgRectItem
             {
                 Bounds = bounds,
                 X = GetLength(attrs, "x", pctW) * sx + tx,
@@ -154,16 +171,20 @@ internal static partial class SvgRenderer
         // <circle ... />
         foreach (Match m in ParseCircleRegex().Matches(svgXml))
         {
-            var attrs = ParseAttributes(m.Groups[1].Value);
+            if (!TryResolveElement(structure, m, out var attrs))
+                continue;
+
+            var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+
             float r = GetLength(attrs, "r", pctD);
-            AddShape(items, bounds, attrs, new DrawSvgEllipseItem
+            AddShape(items, bounds, attrs, elementTransform, new DrawSvgEllipseItem
             {
                 Bounds = bounds,
                 Cx = GetLength(attrs, "cx", pctW) * sx + tx,
                 Cy = GetLength(attrs, "cy", pctH) * sy + ty,
                 Rx = r * sx,
                 Ry = r * sy,
-                Fill = GetPaint(attrs, "fill", BColor.Black),
+                Fill = ResolveFillWithoutPattern(attrs, BColor.Black),
                 Stroke = GetPaint(attrs, "stroke", BColor.Empty),
                 StrokeWidth = GetLength(attrs, "stroke-width", pctD, 1) * Math.Max(sx, sy),
             });
@@ -172,15 +193,19 @@ internal static partial class SvgRenderer
         // <ellipse ... />
         foreach (Match m in ParseEllipseRegex().Matches(svgXml))
         {
-            var attrs = ParseAttributes(m.Groups[1].Value);
-            AddShape(items, bounds, attrs, new DrawSvgEllipseItem
+            if (!TryResolveElement(structure, m, out var attrs))
+                continue;
+
+            var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+
+            AddShape(items, bounds, attrs, elementTransform, new DrawSvgEllipseItem
             {
                 Bounds = bounds,
                 Cx = GetLength(attrs, "cx", pctW) * sx + tx,
                 Cy = GetLength(attrs, "cy", pctH) * sy + ty,
                 Rx = GetLength(attrs, "rx", pctW) * sx,
                 Ry = GetLength(attrs, "ry", pctH) * sy,
-                Fill = GetPaint(attrs, "fill", BColor.Black),
+                Fill = ResolveFillWithoutPattern(attrs, BColor.Black),
                 Stroke = GetPaint(attrs, "stroke", BColor.Empty),
                 StrokeWidth = GetLength(attrs, "stroke-width", pctD, 1) * Math.Max(sx, sy),
             });
@@ -189,8 +214,12 @@ internal static partial class SvgRenderer
         // <line ... />
         foreach (Match m in ParseLineRegex().Matches(svgXml))
         {
-            var attrs = ParseAttributes(m.Groups[1].Value);
-            AddShape(items, bounds, attrs, new DrawSvgLineItem
+            if (!TryResolveElement(structure, m, out var attrs))
+                continue;
+
+            var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+
+            AddShape(items, bounds, attrs, elementTransform, new DrawSvgLineItem
             {
                 Bounds = bounds,
                 X1 = GetLength(attrs, "x1", pctW) * sx + tx,
@@ -204,12 +233,16 @@ internal static partial class SvgRenderer
 
         foreach (Match m in ParsePolygonRegex().Matches(svgXml))
         {
-            var attrs = ParseAttributes(m.Groups[1].Value);
-            AddShape(items, bounds, attrs, new DrawSvgPolygonItem
+            if (!TryResolveElement(structure, m, out var attrs))
+                continue;
+
+            var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+
+            AddShape(items, bounds, attrs, elementTransform, new DrawSvgPolygonItem
             {
                 Bounds = bounds,
                 Points = ParsePoints(attrs.GetValueOrDefault("points") ?? string.Empty, sx, sy, tx, ty),
-                Fill = GetPaint(attrs, "fill", BColor.Black),
+                Fill = ResolveFillWithoutPattern(attrs, BColor.Black),
                 Stroke = GetPaint(attrs, "stroke", BColor.Empty),
                 StrokeWidth = GetLength(attrs, "stroke-width", pctD, 1) * Math.Max(sx, sy),
             });
@@ -217,12 +250,16 @@ internal static partial class SvgRenderer
 
         foreach (Match m in ParsePolyLineRegex().Matches(svgXml))
         {
-            var attrs = ParseAttributes(m.Groups[1].Value);
-            AddShape(items, bounds, attrs, new DrawSvgPolylineItem
+            if (!TryResolveElement(structure, m, out var attrs))
+                continue;
+
+            var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+
+            AddShape(items, bounds, attrs, elementTransform, new DrawSvgPolylineItem
             {
                 Bounds = bounds,
                 Points = ParsePoints(attrs.GetValueOrDefault("points") ?? string.Empty, sx, sy, tx, ty),
-                Fill = GetPaint(attrs, "fill", BColor.Empty),
+                Fill = ResolveFillWithoutPattern(attrs, BColor.Empty),
                 Stroke = GetPaint(attrs, "stroke", BColor.Empty),
                 StrokeWidth = GetLength(attrs, "stroke-width", pctD, 1) * Math.Max(sx, sy),
             });
@@ -231,44 +268,80 @@ internal static partial class SvgRenderer
         // <text ...>content</text>
         foreach (Match m in ParseTextRegex().Matches(svgXml))
         {
-            var attrs = ParseAttributes(m.Groups[1].Value);
+            if (!TryResolveElement(structure, m, out var attrs))
+                continue;
+
+            var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+
             var textPathAttrs = ParseAttributes(m.Groups[2].Value);
-            
+
             if (!textPathAttrs.TryGetValue("href", out var href) || !href.StartsWith('#'))
                 continue;
-            
+
             if (!pathStartsById.TryGetValue(href[1..], out var start))
                 continue;
+
+            float textPathSize = GetLength(attrs, "font-size", pctD, 16) * Math.Max(sx, sy);
+            var textPathFont = ResolveFont(attrs, textPathSize);
 
             items.Add(new DrawSvgTextItem
             {
                 Bounds = bounds,
                 X = start.X * sx + tx,
-                Y = start.Y * sy + ty,
-                FontSize = GetLength(attrs, "font-size", pctD, 16) * Math.Max(sx, sy),
+                // The path's start point is on the baseline; the backend draws from the top of the
+                // ascent box (see EmitTextElements).
+                Y = start.Y * sy + ty - (float)AscentOf(textPathFont, textPathSize),
+                FontSize = textPathSize,
                 FontFamily = attrs.GetValueOrDefault("font-family") ?? "Arial",
-                Fill = GetPaint(attrs, "fill", BColor.Black),
-                Text = DrawSvgTextRegex().Replace(m.Groups[3].Value, string.Empty).Trim(),
+                FontHandle = textPathFont,
+                Fill = GetPaint(attrs, "fill", BColor.Black) is { IsEmpty: false } pathFill ? pathFill : BColor.Black,
+                Text = FlattenTextContent(m.Groups[3].Value),
             });
         }
 
-        foreach (Match m in ParseText2RegEx().Matches(svgXml))
-        {
-            if (ParseTextPathRegex().IsMatch(m.Groups[2].Value))
-                continue;
+        EmitTextElements(svgXml, bounds, items, structure, sx, sy, tx, ty, pctW, pctH, pctD);
+        EmitUseElements(svgXml, bounds, items, structure, sx, sy, tx, ty, pctW, pctH);
+    }
 
-            var attrs = ParseAttributes(m.Groups[1].Value);
-            items.Add(new DrawSvgTextItem
-            {
-                Bounds = bounds,
-                X = GetLength(attrs, "x", pctW) * sx + tx,
-                Y = GetLength(attrs, "y", pctH) * sy + ty,
-                FontSize = GetLength(attrs, "font-size", pctD, 16) * Math.Max(sx, sy),
-                FontFamily = attrs.GetValueOrDefault("font-family") ?? "Arial",
-                Fill = GetPaint(attrs, "fill", BColor.Black),
-                Text = m.Groups[2].Value.Trim(),
-            });
-        }
+    /// <summary>
+    /// SVG 1.1 §7.8: the scale and translation that map a view box onto the viewport under a
+    /// <c>preserveAspectRatio</c> value, as <c>(sx, sy, tx, ty)</c>.
+    /// </summary>
+    /// <remarks>
+    /// Only <c>none</c> and the alignment/<c>meet</c>/<c>slice</c> forms are read; a value this
+    /// cannot parse takes the initial <c>xMidYMid meet</c>, which is what the renderer applied
+    /// unconditionally before.
+    /// </remarks>
+    private static (float Sx, float Sy, float Tx, float Ty) ResolveViewBoxMapping(
+        string? preserveAspectRatio, RectangleF bounds, float vbX, float vbY, float vbW, float vbH)
+    {
+        var parts = (preserveAspectRatio ?? string.Empty)
+            .Split([' ', '\t', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries);
+
+        // "defer" is a legacy prefix that only applies to <image>, and is ignored here.
+        int first = parts.Length > 0 && parts[0].Equals("defer", StringComparison.OrdinalIgnoreCase) ? 1 : 0;
+        string align = parts.Length > first ? parts[first] : "xMidYMid";
+        bool slice = parts.Length > first + 1
+            && parts[first + 1].Equals("slice", StringComparison.OrdinalIgnoreCase);
+
+        float scaleX = bounds.Width / vbW;
+        float scaleY = bounds.Height / vbH;
+
+        if (align.Equals("none", StringComparison.OrdinalIgnoreCase))
+            return (scaleX, scaleY, -vbX * scaleX, -vbY * scaleY);
+
+        float scale = slice ? Math.Max(scaleX, scaleY) : Math.Min(scaleX, scaleY);
+        float slackX = bounds.Width - vbW * scale;
+        float slackY = bounds.Height - vbH * scale;
+
+        float alignX = align.Contains("xMin", StringComparison.OrdinalIgnoreCase) ? 0f
+            : align.Contains("xMax", StringComparison.OrdinalIgnoreCase) ? slackX
+            : slackX / 2f;
+        float alignY = align.Contains("YMin", StringComparison.Ordinal) ? 0f
+            : align.Contains("YMax", StringComparison.Ordinal) ? slackY
+            : slackY / 2f;
+
+        return (scale, scale, -vbX * scale + alignX, -vbY * scale + alignY);
     }
 
     private static PointF? TryGetPathStart(string pathData)
@@ -688,6 +761,26 @@ internal static partial class SvgRenderer
     private static void AddShape(
         List<DisplayItem> items, RectangleF bounds, Dictionary<string, string> attrs, DisplayItem shape)
     {
+        AddShape(items, bounds, attrs, SvgTransform.Identity, shape);
+    }
+
+    /// <summary>
+    /// <see cref="AddShape(List{DisplayItem}, RectangleF, Dictionary{string, string}, DisplayItem)"/>
+    /// with the element's user-space <c>transform</c> baked into the shape's geometry.
+    /// </summary>
+    /// <remarks>
+    /// Baked rather than pushed as a transform layer for the reason
+    /// <see cref="SvgItemTransformer"/> records: the raster canvas takes only translations and
+    /// uniform scales, and a layer it cannot take routes the enclosed drawing to a compat backend
+    /// the image renderer stubs out, where it disappears.
+    /// </remarks>
+    private static void AddShape(
+        List<DisplayItem> items, RectangleF bounds, Dictionary<string, string> attrs,
+        SvgTransform pageTransform, DisplayItem shape)
+    {
+        if (!pageTransform.IsIdentity)
+            shape = SvgItemTransformer.MapItem(shape, pageTransform);
+
         string? mode = GetPresentationValue(attrs, "mix-blend-mode");
         bool blended = !string.IsNullOrWhiteSpace(mode)
             && !mode.Equals("normal", StringComparison.OrdinalIgnoreCase);
@@ -858,9 +951,6 @@ internal static partial class SvgRenderer
 
     [GeneratedRegex(@"M\s*(?<x>-?\d*\.?\d+)\s*,?\s*(?<y>-?\d*\.?\d+)", RegexOptions.IgnoreCase)]
     private static partial Regex ParsePathRegEx();
-
-    [GeneratedRegex(@"<text\s+([^>]*)>(.*?)</text>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
-    private static partial Regex ParseText2RegEx();
 
     [GeneratedRegex(@"<\s*textpath\b", RegexOptions.IgnoreCase)]
     private static partial Regex ParseTextPathRegex();

--- a/Broiler.Layout/Broiler.Layout/IR/SvgStructure.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgStructure.cs
@@ -1,0 +1,291 @@
+using System.Text.RegularExpressions;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// The element nesting <see cref="SvgRenderer"/>'s per-element-type regexes cannot see: which
+/// start tags are inside a container that does not paint, and which presentation attributes each
+/// one inherits from its ancestors.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The renderer matches one regex per shape type over the whole markup, so every <c>&lt;rect&gt;</c>
+/// in the document is drawn wherever it sits — including the ones inside <c>&lt;defs&gt;</c>,
+/// <c>&lt;symbol&gt;</c> and <c>&lt;pattern&gt;</c>, which SVG 1.1 §5.5/§12.3/§13.3 render only
+/// through a reference. That is what made <c>conformance-checkers/html-svg/struct-symbol-01-b</c>
+/// paint a symbol's contents across the whole canvas, and what painted a pattern's tile once at the
+/// origin. It equally cannot see that <c>&lt;g font-size="32"&gt;</c> sets the size for the
+/// <c>&lt;text&gt;</c> inside it.
+/// </para>
+/// <para>
+/// This scans the tags once with a stack and records, per start-tag offset, whether the element
+/// paints and what it inherits. The offsets are the ones <see cref="Regex"/> reports as
+/// <see cref="Capture.Index"/> for the same element, so the existing loops stay as they are and
+/// only consult this by index. Anything the scan does not reach — a commented-out element, markup
+/// inside <c>&lt;style&gt;</c> — is absent, and absent means "does not paint", which is the point.
+/// </para>
+/// </remarks>
+internal sealed partial class SvgStructure
+{
+    /// <summary>
+    /// Containers whose children are rendered only when something references them (SVG 1.1 §5.5),
+    /// plus the elements whose content is not graphics at all. A start tag inside one of these does
+    /// not paint where it stands.
+    /// </summary>
+    private static readonly HashSet<string> NonRenderingContainers = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "defs", "symbol", "pattern", "mask", "marker", "clipPath", "filter",
+        "linearGradient", "radialGradient", "style", "script", "title", "desc", "metadata",
+        "font", "font-face", "font-face-src", "font-face-uri", "glyph", "missing-glyph",
+        "altGlyphDef", "view", "hatch", "animate", "animateMotion", "animateTransform", "set",
+    };
+
+    /// <summary>
+    /// The presentation attributes SVG 1.1 §6.4 marks inheritable that this renderer models. Paint
+    /// and font properties only: the geometric attributes (<c>x</c>, <c>width</c>, …) are element
+    /// properties and never inherit.
+    /// </summary>
+    private static readonly string[] InheritableProperties =
+    [
+        "fill", "fill-opacity", "fill-rule",
+        "stroke", "stroke-opacity", "stroke-width", "stroke-linecap", "stroke-linejoin",
+        "stroke-dasharray", "stroke-dashoffset", "stroke-miterlimit",
+        "color", "visibility", "text-anchor", "text-decoration", "direction", "writing-mode",
+        "font-family", "font-size", "font-style", "font-weight", "font-variant", "font-stretch",
+        "letter-spacing", "word-spacing",
+    ];
+
+    /// <summary>Start-tag offset → attributes inherited from that element's ancestors.</summary>
+    private readonly Dictionary<int, IReadOnlyDictionary<string, string>> _rendered = [];
+
+    /// <summary>
+    /// Start-tag offset → the user-space transform in effect for that element: every ancestor's
+    /// <c>transform</c> composed outermost-first, with the element's own applied last.
+    /// </summary>
+    private readonly Dictionary<int, SvgTransform> _transforms = [];
+
+    /// <summary>
+    /// Start-tag offset → the element's own attributes, for every element the scan reached,
+    /// painting or not.
+    /// </summary>
+    private readonly Dictionary<int, IReadOnlyDictionary<string, string>> _attributes = [];
+
+    /// <summary><c>id</c> → the element that declares it, for <c>&lt;use href="#id"&gt;</c>.</summary>
+    private readonly Dictionary<string, Element> _byId = new(StringComparer.Ordinal);
+
+    /// <summary>One element the scan reached, addressable by <c>id</c>.</summary>
+    /// <param name="Name">Its tag name.</param>
+    /// <param name="Attributes">Its own attributes.</param>
+    /// <param name="Content">Its content markup, empty when it is self-closing.</param>
+    public readonly record struct Element(
+        string Name, IReadOnlyDictionary<string, string> Attributes, string Content);
+
+    private SvgStructure() { }
+
+    /// <summary>An empty scan: nothing paints. Used when the markup is empty.</summary>
+    public static SvgStructure Empty { get; } = new();
+
+    /// <summary>
+    /// Whether the element starting at <paramref name="index"/> paints where it stands, and if so
+    /// what it inherits.
+    /// </summary>
+    public bool TryGetRendered(int index, out IReadOnlyDictionary<string, string> inherited)
+        => _rendered.TryGetValue(index, out inherited!);
+
+    /// <summary>
+    /// The user-space transform the element starting at <paramref name="index"/> is drawn under,
+    /// or the identity when it is under none.
+    /// </summary>
+    public SvgTransform TransformAt(int index)
+        => _transforms.TryGetValue(index, out var transform) ? transform : SvgTransform.Identity;
+
+    /// <summary>The attributes of the element starting at <paramref name="index"/>, painting or not.</summary>
+    public bool TryGetAttributes(int index, out IReadOnlyDictionary<string, string> attributes)
+        => _attributes.TryGetValue(index, out attributes!);
+
+    /// <summary>Resolves an <c>id</c> to the element that declares it.</summary>
+    public bool TryGetById(string id, out Element element)
+    {
+        element = default;
+        return !string.IsNullOrEmpty(id) && _byId.TryGetValue(id, out element);
+    }
+
+    /// <summary>
+    /// Walks every start and end tag, tracking the inherited presentation attributes and the depth
+    /// of non-rendering containers.
+    /// </summary>
+    /// <remarks>
+    /// End tags are matched by name rather than trusted blindly: SVG in an HTML document reaches
+    /// here through the box tree, which is well-formed, but an SVG loaded as an image is raw bytes.
+    /// An unmatched end tag pops nothing rather than unbalancing the stack for the rest of the file.
+    /// </remarks>
+    public static SvgStructure Scan(string svgXml)
+    {
+        if (string.IsNullOrEmpty(svgXml))
+            return Empty;
+
+        var structure = new SvgStructure();
+        var open = new List<(string Name, IReadOnlyDictionary<string, string> Inherited,
+            bool Suppresses, SvgTransform Transform, IReadOnlyDictionary<string, string> Attributes,
+            int ContentStart)>();
+        int nonRenderingDepth = 0;
+
+        foreach (Match m in TagRegex().Matches(svgXml))
+        {
+            // A comment, CDATA section, processing instruction or doctype: not an element, and the
+            // markup inside it is text. Matching them here is what keeps a commented-out
+            // <g id="draft-watermark"> — which most of the SVG 1.1 test suite carries — unpainted.
+            if (!m.Groups["name"].Success)
+                continue;
+
+            string name = m.Groups["name"].Value;
+            bool isEnd = m.Groups["close"].Value.Length > 0;
+
+            if (isEnd)
+            {
+                int last = open.FindLastIndex(e => e.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+                if (last < 0)
+                    continue;
+
+                for (int i = open.Count - 1; i >= last; i--)
+                {
+                    if (open[i].Suppresses)
+                        nonRenderingDepth--;
+                }
+
+                // The element is complete, so its content span is known: record it under its id.
+                var closed = open[last];
+                if (closed.Attributes.TryGetValue("id", out var closedId) && closedId.Length > 0)
+                {
+                    structure._byId[closedId] = new Element(
+                        closed.Name, closed.Attributes,
+                        svgXml[closed.ContentStart..m.Index]);
+                }
+
+                open.RemoveRange(last, open.Count - last);
+                continue;
+            }
+
+            var inherited = open.Count > 0 ? open[^1].Inherited : EmptyAttributes;
+            var ancestorTransform = open.Count > 0 ? open[^1].Transform : SvgTransform.Identity;
+            var attributes = ParseAttributes(m.Groups["attrs"].Value);
+            structure._attributes[m.Index] = attributes;
+
+            // SVG 1.1 §7.4: an element's transform applies to it as well as to its children, so the
+            // element itself is recorded under the composition that includes its own.
+            var transform = ancestorTransform.Concat(
+                SvgTransform.Parse(attributes.GetValueOrDefault("transform")));
+
+            bool paints = nonRenderingDepth == 0 && !NonRenderingContainers.Contains(name)
+                && !IsDisplayNone(attributes);
+            if (paints)
+            {
+                structure._rendered[m.Index] = inherited;
+                if (!transform.IsIdentity)
+                    structure._transforms[m.Index] = transform;
+            }
+
+            if (m.Groups["empty"].Value.Length > 0)
+            {
+                if (attributes.TryGetValue("id", out var emptyId) && emptyId.Length > 0)
+                    structure._byId[emptyId] = new Element(name, attributes, string.Empty);
+                continue;
+            }
+
+            // Track the suppression on the open element rather than re-deriving it at the end tag:
+            // an element nested inside a container that does not paint suppresses its own children
+            // too, and matching that against the container list alone would decrement fewer times
+            // than it incremented, leaving the rest of the document permanently suppressed.
+            bool suppresses = !paints;
+            if (suppresses)
+                nonRenderingDepth++;
+
+            open.Add((
+                name, Extend(inherited, attributes), suppresses, transform,
+                attributes, m.Index + m.Length));
+        }
+
+        return structure;
+    }
+
+    private static readonly IReadOnlyDictionary<string, string> EmptyAttributes =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The inherited set an element's children see: its parent's, overridden by whichever
+    /// inheritable properties this element declares. Returns the parent's own map unchanged when
+    /// the element declares none, so a deep tree of plain <c>&lt;g&gt;</c>s allocates nothing.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> Extend(
+        IReadOnlyDictionary<string, string> inherited, IReadOnlyDictionary<string, string> attributes)
+    {
+        Dictionary<string, string>? extended = null;
+        foreach (var property in InheritableProperties)
+        {
+            string? value = ReadPresentation(attributes, property);
+            if (value == null || (inherited.TryGetValue(property, out var existing) && existing == value))
+                continue;
+
+            extended ??= new Dictionary<string, string>(inherited, StringComparer.OrdinalIgnoreCase);
+            extended[property] = value;
+        }
+
+        return extended ?? inherited;
+    }
+
+    /// <summary>
+    /// A property from the element's <c>style</c> declaration if it is there, and from the
+    /// presentation attribute of the same name otherwise — the order SVG 1.1 §6.4 gives them.
+    /// </summary>
+    private static string? ReadPresentation(IReadOnlyDictionary<string, string> attributes, string property)
+    {
+        if (attributes.TryGetValue("style", out var style) && !string.IsNullOrWhiteSpace(style))
+        {
+            foreach (var declaration in style.Split(';'))
+            {
+                int colon = declaration.IndexOf(':');
+                if (colon > 0
+                    && declaration.AsSpan(0, colon).Trim().Equals(property, StringComparison.OrdinalIgnoreCase))
+                {
+                    var value = declaration.AsSpan(colon + 1).Trim();
+                    if (!value.IsEmpty)
+                        return value.ToString();
+                }
+            }
+        }
+
+        return attributes.TryGetValue(property, out var attribute) && !string.IsNullOrWhiteSpace(attribute)
+            ? attribute
+            : null;
+    }
+
+    private static bool IsDisplayNone(IReadOnlyDictionary<string, string> attributes)
+    {
+        string? display = ReadPresentation(attributes, "display");
+        return display != null && display.Trim().Equals("none", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Dictionary<string, string> ParseAttributes(string attrStr)
+    {
+        var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (Match m in AttributeRegex().Matches(attrStr))
+        {
+            var quoted = m.Groups["dq"];
+            dict[m.Groups["name"].Value] = quoted.Success ? quoted.Value : m.Groups["sq"].Value;
+        }
+        return dict;
+    }
+
+    /// <summary>
+    /// One markup construct: a comment/CDATA/PI/doctype (no <c>name</c> group, so it is skipped),
+    /// or a start or end tag. Attribute values are matched as quoted runs so a <c>&gt;</c> inside
+    /// one does not end the tag.
+    /// </summary>
+    [GeneratedRegex(
+        """<!--.*?-->|<!\[CDATA\[.*?\]\]>|<\?.*?\?>|<!DOCTYPE(?:[^>"']|"[^"]*"|'[^']*')*>|<(?<close>/?)(?<name>[A-Za-z_][\w:.\-]*)(?<attrs>(?:[^>"']|"[^"]*"|'[^']*')*?)(?<empty>/?)>""",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex TagRegex();
+
+    [GeneratedRegex("""(?<name>[\w:.\-]+)\s*=\s*(?:"(?<dq>[^"]*)"|'(?<sq>[^']*)')""")]
+    private static partial Regex AttributeRegex();
+}

--- a/Broiler.Layout/Broiler.Layout/IR/SvgStructure.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgStructure.cs
@@ -87,9 +87,24 @@ internal sealed partial class SvgStructure
     /// <summary>One element the scan reached, addressable by <c>id</c>.</summary>
     /// <param name="Name">Its tag name.</param>
     /// <param name="Attributes">Its own attributes.</param>
-    /// <param name="Content">Its content markup, empty when it is self-closing.</param>
+    /// <param name="Source">The whole markup the scan ran over.</param>
+    /// <param name="ContentStart">Where this element's content begins in <paramref name="Source"/>.</param>
+    /// <param name="ContentEnd">Where it ends; equal to the start when the element is self-closing.</param>
+    /// <remarks>
+    /// The content is held as a range rather than a substring so that scanning costs nothing per
+    /// element. Copying it eagerly is quadratic in the document — an element that contains a
+    /// thousand id-bearing descendants copies its own body once per descendant — and a large SVG
+    /// took gigabytes before this was a range.
+    /// </remarks>
     public readonly record struct Element(
-        string Name, IReadOnlyDictionary<string, string> Attributes, string Content);
+        string Name, IReadOnlyDictionary<string, string> Attributes,
+        string Source, int ContentStart, int ContentEnd)
+    {
+        /// <summary>The element's content markup, empty when it is self-closing.</summary>
+        public string Content => ContentEnd > ContentStart
+            ? Source[ContentStart..ContentEnd]
+            : string.Empty;
+    }
 
     private SvgStructure() { }
 
@@ -126,9 +141,18 @@ internal sealed partial class SvgStructure
     /// </remarks>
     public bool IsInert(int index)
     {
-        foreach (var (start, end) in _inertSpans)
+        // The spans are recorded in match order, so they are sorted and disjoint: a binary search
+        // keeps this off the quadratic path when a document carries many comments and many shapes.
+        int low = 0, high = _inertSpans.Count - 1;
+        while (low <= high)
         {
-            if (index >= start && index < end)
+            int mid = (low + high) / 2;
+            var (start, end) = _inertSpans[mid];
+            if (index < start)
+                high = mid - 1;
+            else if (index >= end)
+                low = mid + 1;
+            else
                 return true;
         }
 
@@ -193,8 +217,7 @@ internal sealed partial class SvgStructure
                 if (closed.Attributes.TryGetValue("id", out var closedId) && closedId.Length > 0)
                 {
                     structure._byId[closedId] = new Element(
-                        closed.Name, closed.Attributes,
-                        svgXml[closed.ContentStart..m.Index]);
+                        closed.Name, closed.Attributes, svgXml, closed.ContentStart, m.Index);
                 }
 
                 open.RemoveRange(last, open.Count - last);
@@ -223,7 +246,7 @@ internal sealed partial class SvgStructure
             if (m.Groups["empty"].Value.Length > 0)
             {
                 if (attributes.TryGetValue("id", out var emptyId) && emptyId.Length > 0)
-                    structure._byId[emptyId] = new Element(name, attributes, string.Empty);
+                    structure._byId[emptyId] = new Element(name, attributes, svgXml, 0, 0);
                 continue;
             }
 

--- a/Broiler.Layout/Broiler.Layout/IR/SvgStructure.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgStructure.cs
@@ -19,10 +19,15 @@ namespace Broiler.Layout.IR;
 /// </para>
 /// <para>
 /// This scans the tags once with a stack and records, per start-tag offset, whether the element
-/// paints and what it inherits. The offsets are the ones <see cref="Regex"/> reports as
-/// <see cref="Capture.Index"/> for the same element, so the existing loops stay as they are and
-/// only consult this by index. Anything the scan does not reach — a commented-out element, markup
-/// inside <c>&lt;style&gt;</c> — is absent, and absent means "does not paint", which is the point.
+/// paints, what it inherits and the transform it is under. The offsets are the ones
+/// <see cref="Regex"/> reports as <see cref="Capture.Index"/> for the same element, so the existing
+/// loops stay as they are and only consult this by index.
+/// </para>
+/// <para>
+/// Two kinds of absence are told apart deliberately. Markup inside a comment or a CDATA section is
+/// recorded as an inert span (<see cref="IsInert"/>) and does not paint. An offset that is neither
+/// an element nor inert is markup the tag scan could not follow, and it keeps painting: a scanning
+/// gap must not silently erase a shape the renderer used to draw.
 /// </para>
 /// </remarks>
 internal sealed partial class SvgStructure
@@ -73,6 +78,12 @@ internal sealed partial class SvgStructure
     /// <summary><c>id</c> → the element that declares it, for <c>&lt;use href="#id"&gt;</c>.</summary>
     private readonly Dictionary<string, Element> _byId = new(StringComparer.Ordinal);
 
+    /// <summary>
+    /// The spans of the comments and CDATA sections in the markup, so a shape regex that matches
+    /// inside one can be told apart from an element the scan simply could not follow.
+    /// </summary>
+    private readonly List<(int Start, int End)> _inertSpans = [];
+
     /// <summary>One element the scan reached, addressable by <c>id</c>.</summary>
     /// <param name="Name">Its tag name.</param>
     /// <param name="Attributes">Its own attributes.</param>
@@ -102,6 +113,27 @@ internal sealed partial class SvgStructure
     /// <summary>The attributes of the element starting at <paramref name="index"/>, painting or not.</summary>
     public bool TryGetAttributes(int index, out IReadOnlyDictionary<string, string> attributes)
         => _attributes.TryGetValue(index, out attributes!);
+
+    /// <summary>
+    /// Whether <paramref name="index"/> falls inside a comment or CDATA section — markup that looks
+    /// like an element to a regex and is text to a parser.
+    /// </summary>
+    /// <remarks>
+    /// Asked separately from <see cref="TryGetRendered"/> because the two absences mean opposite
+    /// things: an element the scan could not follow must keep painting (a scanning gap must not
+    /// erase a shape), while one inside a comment must not. Most of the SVG 1.1 suite carries a
+    /// commented-out <c>&lt;g id="draft-watermark"&gt;</c> with a red bar and a DRAFT label.
+    /// </remarks>
+    public bool IsInert(int index)
+    {
+        foreach (var (start, end) in _inertSpans)
+        {
+            if (index >= start && index < end)
+                return true;
+        }
+
+        return false;
+    }
 
     /// <summary>Resolves an <c>id</c> to the element that declares it.</summary>
     public bool TryGetById(string id, out Element element)
@@ -136,7 +168,10 @@ internal sealed partial class SvgStructure
             // markup inside it is text. Matching them here is what keeps a commented-out
             // <g id="draft-watermark"> — which most of the SVG 1.1 test suite carries — unpainted.
             if (!m.Groups["name"].Success)
+            {
+                structure._inertSpans.Add((m.Index, m.Index + m.Length));
                 continue;
+            }
 
             string name = m.Groups["name"].Value;
             bool isEnd = m.Groups["close"].Value.Length > 0;

--- a/Broiler.Layout/Broiler.Layout/IR/SvgTextEnvironment.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgTextEnvironment.cs
@@ -18,8 +18,9 @@ namespace Broiler.Layout.IR;
 /// <para>
 /// Thread-static for the same reason <see cref="SvgFilterTable"/> and <see cref="SvgClipPathTable"/>
 /// are: concurrent renders on different threads must not share a document's state. Unset is a
-/// supported state — <see cref="SvgImageRaster"/> rasterises an SVG image without one — and resolves
-/// to no font, which is the pre-existing behaviour rather than a new failure.
+/// supported state that resolves to no font, which is the pre-existing behaviour rather than a new
+/// failure — and <see cref="SvgImageRaster"/> deliberately clears it, so an SVG rasterised as an
+/// image never depends on which thread decoded it (see the remarks there).
 /// </para>
 /// </remarks>
 public static class SvgTextEnvironment

--- a/Broiler.Layout/Broiler.Layout/IR/SvgTextEnvironment.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgTextEnvironment.cs
@@ -1,0 +1,70 @@
+using Broiler.Graphics;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// The host font services <see cref="SvgRenderer"/> needs to draw an SVG <c>&lt;text&gt;</c>,
+/// published for the duration of one render pass.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="SvgRenderer"/> turns markup into display items with no access to the box tree, so it
+/// has nowhere to ask for a font — and a <c>DrawSvgTextItem</c> whose <c>FontHandle</c> is null is
+/// silently dropped by the raster backend, which is why SVG text used to paint nothing at all. The
+/// paint walker that calls <see cref="SvgRenderer.RenderSvgContent"/> lives in another component, so
+/// the environment is published here by <see cref="FragmentTreeBuilder.Build"/> instead of being
+/// threaded through that call.
+/// </para>
+/// <para>
+/// Thread-static for the same reason <see cref="SvgFilterTable"/> and <see cref="SvgClipPathTable"/>
+/// are: concurrent renders on different threads must not share a document's state. Unset is a
+/// supported state — <see cref="SvgImageRaster"/> rasterises an SVG image without one — and resolves
+/// to no font, which is the pre-existing behaviour rather than a new failure.
+/// </para>
+/// </remarks>
+public static class SvgTextEnvironment
+{
+    [ThreadStatic]
+    private static ILayoutEnvironment? _environment;
+
+    /// <summary>Publishes the environment for this render pass; <c>null</c> clears it.</summary>
+    internal static void Reset(ILayoutEnvironment? environment)
+    {
+        _environment = environment;
+        AmbientRenderState.MarkEstablished(AmbientRenderState.Slots.SvgTables);
+    }
+
+    /// <summary>
+    /// <see cref="Reset"/>, reachable from <see cref="AmbientRenderState.Establish"/> outside this
+    /// namespace. A worker thread establishes the slot by clearing it: no font resolution is the
+    /// safe default, and the thread that actually renders publishes its own environment.
+    /// </summary>
+    public static void ResetForThread() => Reset(null);
+
+    /// <summary>The environment for this pass, or <see langword="null"/> when none was published.</summary>
+    internal static ILayoutEnvironment? Current => _environment;
+
+    /// <summary>
+    /// Resolves a font for SVG text. <paramref name="sizePx"/> is in CSS pixels (SVG user units
+    /// already scaled to the viewport); the environment takes points, the unit
+    /// <see cref="Engine.CssBoxProperties.ActualFont"/> resolves in.
+    /// </summary>
+    internal static ILayoutFont? GetFont(string family, double sizePx, LayoutFontStyle style)
+    {
+        var environment = _environment;
+        if (environment == null || sizePx <= 0)
+            return null;
+
+        return environment.GetFont(family, sizePx * CSS.CssMetrics.PxToPt, style);
+    }
+
+    /// <summary>Measures <paramref name="text"/>, for <c>text-anchor</c> placement.</summary>
+    internal static float MeasureWidth(ILayoutFont? font, string text)
+    {
+        var environment = _environment;
+        if (environment == null || font == null || string.IsNullOrEmpty(text))
+            return 0f;
+
+        return environment.MeasureText(font, text).Width;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/IR/SvgTransform.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgTransform.cs
@@ -1,0 +1,155 @@
+using System.Drawing;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// A 2D affine transform parsed from an SVG <c>transform</c>-list attribute
+/// (<c>translate</c>/<c>scale</c>/<c>rotate</c>/<c>skewX</c>/<c>skewY</c>/<c>matrix</c>,
+/// SVG 1.1 §7.6), in the column-vector convention CSS <c>matrix(a,b,c,d,e,f)</c> uses.
+/// </summary>
+/// <remarks>
+/// Kept as a value rather than folded into the caller so a <c>patternTransform</c> and an element
+/// <c>transform</c> parse the same way, and so the inverse — which a tiling needs to know which
+/// tiles can reach the shape — is written once.
+/// </remarks>
+internal readonly partial record struct SvgTransform(float A, float B, float C, float D, float E, float F)
+{
+    public static SvgTransform Identity { get; } = new(1, 0, 0, 1, 0, 0);
+
+    public bool IsIdentity => this == Identity;
+
+    /// <summary>Parses a transform list; an absent or unparseable list is the identity.</summary>
+    public static SvgTransform Parse(string? transformList)
+    {
+        if (string.IsNullOrWhiteSpace(transformList))
+            return Identity;
+
+        var result = Identity;
+        bool any = false;
+
+        foreach (Match m in FunctionRegex().Matches(transformList))
+        {
+            float[] a = ParseNumbers(m.Groups["args"].Value);
+            SvgTransform step;
+            switch (m.Groups["name"].Value.ToLowerInvariant())
+            {
+                case "translate" when a.Length >= 1:
+                    step = new SvgTransform(1, 0, 0, 1, a[0], a.Length > 1 ? a[1] : 0);
+                    break;
+                case "scale" when a.Length >= 1:
+                    step = new SvgTransform(a[0], 0, 0, a.Length > 1 ? a[1] : a[0], 0, 0);
+                    break;
+                case "rotate" when a.Length >= 1:
+                    step = Rotate(a[0], a.Length >= 3 ? a[1] : 0, a.Length >= 3 ? a[2] : 0);
+                    break;
+                case "skewx" when a.Length >= 1:
+                    step = new SvgTransform(1, 0, (float)Math.Tan(a[0] * Math.PI / 180), 1, 0, 0);
+                    break;
+                case "skewy" when a.Length >= 1:
+                    step = new SvgTransform(1, (float)Math.Tan(a[0] * Math.PI / 180), 0, 1, 0, 0);
+                    break;
+                case "matrix" when a.Length >= 6:
+                    step = new SvgTransform(a[0], a[1], a[2], a[3], a[4], a[5]);
+                    break;
+                default:
+                    continue;
+            }
+
+            result = result.Concat(step);
+            any = true;
+        }
+
+        return any ? result : Identity;
+    }
+
+    /// <summary><c>rotate(angle, cx, cy)</c>: a rotation about an arbitrary centre.</summary>
+    private static SvgTransform Rotate(float degrees, float cx, float cy)
+    {
+        double radians = degrees * Math.PI / 180;
+        float cos = (float)Math.Cos(radians), sin = (float)Math.Sin(radians);
+        return new SvgTransform(
+            cos, sin, -sin, cos,
+            cx - cx * cos + cy * sin,
+            cy - cx * sin - cy * cos);
+    }
+
+    /// <summary>This transform followed by <paramref name="inner"/> applied first (<c>this · inner</c>).</summary>
+    public SvgTransform Concat(SvgTransform inner) => new(
+        A * inner.A + C * inner.B,
+        B * inner.A + D * inner.B,
+        A * inner.C + C * inner.D,
+        B * inner.C + D * inner.D,
+        A * inner.E + C * inner.F + E,
+        B * inner.E + D * inner.F + F);
+
+    /// <summary>The inverse, or the identity when the matrix is singular (a degenerate scale).</summary>
+    public SvgTransform Inverse()
+    {
+        float determinant = A * D - B * C;
+        if (Math.Abs(determinant) < 1e-9f)
+            return Identity;
+
+        float ia = D / determinant, ib = -B / determinant;
+        float ic = -C / determinant, id = A / determinant;
+        return new SvgTransform(ia, ib, ic, id, -(ia * E + ic * F), -(ib * E + id * F));
+    }
+
+    public PointF Map(float x, float y) => new(A * x + C * y + E, B * x + D * y + F);
+
+    /// <summary>The axis-aligned bounding box of a mapped rectangle.</summary>
+    public RectangleF MapBounds(RectangleF rect)
+    {
+        if (IsIdentity)
+            return rect;
+
+        PointF p0 = Map(rect.Left, rect.Top), p1 = Map(rect.Right, rect.Top);
+        PointF p2 = Map(rect.Right, rect.Bottom), p3 = Map(rect.Left, rect.Bottom);
+        float left = Math.Min(Math.Min(p0.X, p1.X), Math.Min(p2.X, p3.X));
+        float right = Math.Max(Math.Max(p0.X, p1.X), Math.Max(p2.X, p3.X));
+        float top = Math.Min(Math.Min(p0.Y, p1.Y), Math.Min(p2.Y, p3.Y));
+        float bottom = Math.Max(Math.Max(p0.Y, p1.Y), Math.Max(p2.Y, p3.Y));
+        return new RectangleF(left, top, right - left, bottom - top);
+    }
+
+    /// <summary>Whether the transform maps axis-aligned rectangles to axis-aligned rectangles.</summary>
+    public bool IsAxisAligned => Math.Abs(B) < 1e-6f && Math.Abs(C) < 1e-6f;
+
+    /// <summary>
+    /// The same transform expressed in page pixels: conjugated by the view-box mapping
+    /// (scale <paramref name="sx"/>/<paramref name="sy"/> about the user-space origin, whose page
+    /// position is <paramref name="originX"/>/<paramref name="originY"/>), so that applying it to a
+    /// page coordinate has the effect of applying this transform to the user coordinate behind it.
+    /// </summary>
+    public SvgTransform ToPageSpace(float sx, float sy, float originX, float originY)
+    {
+        if (IsIdentity || sx == 0 || sy == 0)
+            return Identity;
+
+        float a = A, b = B * sy / sx, c = C * sx / sy, d = D;
+        return new SvgTransform(
+            a, b, c, d,
+            E * sx + originX - (a * originX + c * originY),
+            F * sy + originY - (b * originX + d * originY));
+    }
+
+    [GeneratedRegex(@"(?<name>matrix|translate|scale|rotate|skewX|skewY)\s*\(\s*(?<args>[^)]*)\)",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex FunctionRegex();
+
+    [GeneratedRegex(@"[-+]?(?:\d*\.\d+|\d+\.?)(?:[eE][-+]?\d+)?")]
+    private static partial Regex NumberRegex();
+
+    private static float[] ParseNumbers(string text)
+    {
+        var matches = NumberRegex().Matches(text);
+        var values = new float[matches.Count];
+        for (int i = 0; i < matches.Count; i++)
+        {
+            values[i] = float.TryParse(
+                matches[i].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out float v) ? v : 0f;
+        }
+        return values;
+    }
+}

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -6,9 +6,12 @@
 > [How this was verified](wpt-rendering-gaps.md#how-the-2026-08-13-split-was-verified).
 
 Gaps that are closed. Each entry keeps the root cause, what landed, the evidence,
-and — where there was one — the wrong turn worth not repeating. **Nothing here is
-waiting on a patch:** the `patches/` directory was deleted on 2026-08-13 and every
-submodule fix named below is an ancestor of the pinned pointer.
+and — where there was one — the wrong turn worth not repeating. **One is waiting on a
+patch** — the media-element fix, whose `Broiler.HTML` remote is outside a
+this-repository session's push scope; it is listed in
+`scripts/apply-pending-wpt-patches.sh`, so the pixel suites run with it applied on top
+of the pinned pointer. Every other submodule fix named below is an ancestor of that
+pointer.
 
 Where a fix landed in a submodule it is identified by its **commit subject**, not
 by a patch number. Patch numbers named nothing durable — `patches/` was a backlog,
@@ -84,6 +87,29 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
   mark any test as passing. It changes only which failures are called the run's
   *worst*, and only on evidence the runner produced itself. The reftest suite is
   unaffected — it renders both sides with Broiler, so it never sets the flag.
+
+### `--verify-reference` cleared a test that rendered nothing
+
+- **Owner:** the WPT runner (`src/Broiler.Wpt/WptTestRunner.cs`). Main repo.
+- **Reported as the most consequential defect in [not fixed](wpt-rendering-gaps-open.md)**,
+  because it moved real gaps off the severity ranking silently.
+- **What was wrong.** `VerifyAgainstReferenceHtml` cleared a pixel-mismatch failure
+  whenever Broiler reproduced the test's own `rel=match` reference, without ever asking
+  whether anything had been **drawn**. A test that paints a blank canvas and a reference
+  that paints a blank canvas match at 100%, so the exact "passing by rendering nothing"
+  trap this document set warns about was built into the mechanism that decided what
+  counted as a real bug. The 2026-08-13 triage measured **17 of 28** unexamined flags as
+  blank-on-blank.
+- **What landed.** A clear now additionally requires the render to have content, judged
+  against the committed golden: a uniform render is agreement only when the golden is
+  uniform too. That one condition is both checks the open entry proposed — it rejects a
+  uniform render, and it rejects a contentless render against a golden that has content —
+  and it costs one early-exiting scan of each bitmap on a path that already compares them
+  pixel by pixel.
+- **What it does not do.** A test that draws *something* wrong and reproduces a reference
+  that draws the same something wrong still clears; that is the `grid-lanes` shape, and it
+  needs the test's own reference to be judged rather than the render, which is a different
+  check. A flag is still a triage queue rather than a verdict — just a much shorter one.
 
 ### The runner never performed WPT's `.sub` substitution
 
@@ -857,6 +883,103 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
   the whole subset is two lines — that test, and `fecolormatrix-display-p3` improving
   97.2% → 98.0% without crossing the threshold (its residual is the Display-P3 colour
   space, a separate gap). **Nothing else moved in either direction.**
+
+### SVG text, pattern fills, symbols and transforms were all missing
+
+- **Tests:** seven of the nine `conformance-checkers` entries in
+  [#1658](https://github.com/Broiler-Platform/Broiler/issues/1658). Measured against
+  locally generated Chromium references at the run's own 99% threshold:
+
+  | Test | Was | Now |
+  | --- | --- | --- |
+  | `html-svg/pservers-pattern-03-f-isvalid` | 21.9% | 94.2% |
+  | `html-svg/pservers-grad-03-b-isvalid` | 29.9% | 93.8% |
+  | `html-svg/pservers-pattern-02-f-isvalid` | 19.3% | 92.3% |
+  | `html-svg/struct-symbol-01-b-isvalid` | 30.6% | 81.4% |
+
+- **Owner:** `Broiler.Layout` (`IR/SvgRenderer*.cs`, `IR/SvgStructure.cs`,
+  `IR/SvgTransform.cs`, `IR/SvgItemTransformer.cs`, `IR/SvgTextEnvironment.cs`,
+  `Engine/CssLayoutEngine.cs`, `Engine/CssBox.Sizing.cs`). Main repo, no patch.
+- **Five separate gaps behind one family**, which is why the family had sat as *large
+  documents, not triaged*:
+
+  1. **Every SVG `<text>` painted nothing at all.**
+     `RGraphicsRasterBackend.RenderSvgText` returns early unless the item carries a
+     resolved font, and **nothing in the engine ever set one** — `DrawSvgTextItem`
+     was constructed with a family name and a size and no handle. The renderer builds
+     its items with no box to ask for a font, so the host's font services are now
+     published for the render pass the same way the SVG filter and clip-path tables
+     already are (`SvgTextEnvironment`, seeded by `FragmentTreeBuilder.Build`) — no
+     submodule change, because the item is built in the main repo.
+  2. **The per-shape regexes could not see the tree.** One regex per shape type over
+     the whole markup draws every `<rect>` wherever it sits, including the ones inside
+     `<defs>`, `<symbol>` and `<pattern>` that SVG renders only through a reference —
+     which is why `struct-symbol-01-b` painted a symbol's contents across the whole
+     canvas — and it cannot see that a `<g font-size="32">` sets the size for the text
+     inside it. `SvgStructure` scans the tags once with a stack and records, per
+     start-tag offset, whether the element paints, what it inherits, and the transform
+     it is under; the existing loops consult it by `Match.Index` and are otherwise
+     unchanged.
+  3. **`fill="url(#id)"` reached the colour parser**, matched no named colour, and fell
+     through to the caller's default — solid black, which is most of the canvas in every
+     `pservers-*` test. Patterns are now tiled as ordinary display items clipped to the
+     shape, with `patternUnits`, `patternContentUnits`, `viewBox`, `href` inheritance and
+     `patternTransform`; a reference that resolves to nothing paintable takes its declared
+     fallback paint (SVG 2 §13.2) instead of black.
+  4. **`<use>` drew nothing**, so a `<symbol>` had no way to reach the canvas at all.
+     It now renders its referent, establishing the `<symbol>` viewport, and
+     `preserveAspectRatio` is read rather than assumed to be `xMidYMid meet`.
+  5. **An atomic inline's percentage height resolved against the containing block's
+     *width*.** The wrong axis outright — and the reason
+     `<svg width="100%" height="100%">`, the shape every one of these pages has, came out
+     as tall as the page is wide and then let "xMidYMid meet" centre its drawing a couple
+     of hundred pixels down the box. It resolves against the block size now, or computes
+     to `auto` when there is none (CSS 2.1 §10.5), which lets the viewBox ratio give the
+     height the reference browser uses. The in-flow grid-item branch beside it had already
+     sidestepped that basis for its own case and named it as wrong.
+
+- **A transform is baked into the geometry, not pushed as a layer** — the wrong turn
+  worth not repeating. `TransformItem` exists and the backend takes it, but
+  `GraphicsAdapter.SaveTransformLayer` keeps only translations and uniform scales on the
+  raster canvas; anything else falls through to a compat backend that the image renderer
+  stubs out, and **the enclosed drawing disappears entirely**. A rotated
+  `patternTransform` written that way rendered a blank rectangle. Mapping the tiles'
+  own coordinates instead needs no layer, and a rotated rectangle is still exactly
+  expressible — as the polygon primitive the backend already draws
+  (`SvgItemTransformer`). The one shape it cannot carry under a rotation is an ellipse,
+  whose primitive has axis-aligned radii; those are left in place rather than drawn
+  somewhere wrong.
+- **Verified:** the four tests above, the probe cases behind them (a `userSpaceOnUse`
+  pattern, a rotated `patternTransform` and a `url(#missing) lime` fallback all match
+  Chromium pixel-for-pixel), and 839 `Broiler.Layout.Tests` unchanged.
+
+### A media element with nothing to show painted a black box
+
+- **Tests:** `conformance-checkers/html/elements/{track,video}/src-isvalid` 14.4% →
+  **100%**, and `.../audio/src-isvalid` 19.8% → **100%**.
+- **Owner:** `Broiler.HTML` (`Parse/DomParser.cs`). **Waiting on a patch** —
+  `patches/0008-media-element-painting.patch`, listed in
+  `scripts/apply-pending-wpt-patches.sh` so the pixel suites exercise it. Identify it by
+  its commit subject, *Paint a media element's box only when it shows controls*, not by
+  the number.
+- **What was wrong.** A `<video>` with no decodable media filled its whole box black, and
+  an `<audio>` without `controls` laid out as a 300×32 black bar instead of not laying out
+  at all. Each of those two test pages is 250 media elements; Chromium renders both as
+  blank white pages and Broiler rendered walls of black.
+- **What the reference browser actually does**, checked directly rather than assumed: an
+  empty `<video>`, a `<video src="missing.mp4">` and a `<video autoplay><source></video>`
+  all paint **transparent** — a div behind each one shows through — and only
+  `<video controls>` draws anything, the control scrim. HTML §4.8.9 says as much: with
+  neither poster frame nor video data the element "represents … nothing". The rendering
+  section's UA stylesheet makes `audio:not([controls])` `display: none`, and an
+  `<audio controls>` is 300×**54**, not 32.
+- **So the placeholder follows `controls`, not the element:** a dark scrim under a video's
+  controls, a light bar under an audio's, and nothing at all without them.
+- **The main-repo tests moved with it, but not to the patched behaviour.**
+  `WptCompositingTests`'s three video cases asserted the black fill directly; they now
+  assert the replaced box's *extent* against an author background they set themselves —
+  true with the patch and without it — because a fill the element is not supposed to draw
+  is not something a test should pin. Transparency is pinned by the WPT tests instead.
 
 ### Animated images always painted their first frame
 

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -749,16 +749,28 @@ neither declares a `rel=match`, so the reftest suite cannot judge them, and the
 manifest is a merged file where a test that stops being exercised keeps its old
 entry. Confirm from a run artifact before treating either as closed.
 
-### Large documents, not triaged
+### Large documents — the `conformance-checkers` family is triaged; two remain
 
-| Test | CI |
-| --- | --- |
-| `conformance-checkers/html-svg/*-isvalid` (5) | 11.1–19.3% |
-| `conformance-checkers/html/elements/{track,video}/src-isvalid` (2) | 14.4% |
-| `cssom-view/scrollIntoView-fixed` | 10.9% |
-| `scroll-animations/css/scroll-timeline-nearest-with-absolute-positioned-element` | 11.3% |
+The nine `conformance-checkers` entries in
+[#1658](https://github.com/Broiler-Platform/Broiler/issues/1658) were triaged on
+2026-08-15 and were **nine separate gaps, not one**. Seven are closed — see
+[SVG text, patterns, symbols and transforms](wpt-rendering-gaps-fixed.md#svg-text-pattern-fills-symbols-and-transforms-were-all-missing)
+and [a media element with nothing to show painted a black box](wpt-rendering-gaps-fixed.md#a-media-element-with-nothing-to-show-painted-a-black-box).
+The two that are not each need a subsystem rather than a fix:
 
-None declares a `rel=match`. `scrollIntoView-fixed` needs scripted scrolling.
+| Test | Was | Now | What is missing |
+| --- | --- | --- | --- |
+| `html-svg/types-dom-06-f-isvalid` | 16.4% | 22.5% | the **SVG DOM**: the page scripts `requiredFeatures`, an `SVGStringList` with `getItem`/`appendItem`/`insertItemBefore`, and paints red when any assertion fails |
+| `html-svg/styling-css-05-b-isvalid` | 11.3% | 12.6% | the **CSS cascade reaching SVG paint**. `:lang(en) { fill: green }` in a `<style>` inside the `<svg>` matches every element in an `<html lang=en>` document, and a stylesheet `fill` outranks the `fill="none"` presentation attribute — so the reference browser fills the whole test frame green. `SvgRenderer` reads paint from attributes and inline `style` only; it never sees the cascade, because it works from serialised markup rather than from the boxes the cascade was projected onto |
+
+The other two in this group are unchanged and are not `conformance-checkers`:
+
+| Test | CI | Note |
+| --- | --- | --- |
+| `cssom-view/scrollIntoView-fixed` | 10.9% | needs scripted scrolling |
+| `scroll-animations/css/scroll-timeline-nearest-with-absolute-positioned-element` | 11.3% | not triaged |
+
+None of the four declares a `rel=match`.
 
 ---
 
@@ -799,36 +811,6 @@ is exactly one page area), and on both sides only the first block paints:
 
 Neither can change what CI reports for that test, which is scored unpaginated against
 [a blank Chromium capture](wpt-rendering-gaps-wont-fix.md#page-margin-002-print-is-a-screenshot-artifact).
-
-### `--verify-reference` clears a test that renders nothing
-
-**The most consequential defect on this page**, because it silently moves real gaps
-off the severity list.
-
-`WptTestRunner.VerifyAgainstReferenceHtml` clears a pixel-mismatch failure whenever
-Broiler reproduces the test's own `rel=match` reference. It does not check that
-anything was **drawn**. A test that renders a blank white canvas, whose reference
-also renders a blank white canvas, matches at 100% and is reported as a reference
-disagreement — the exact "passing by rendering nothing" trap this document set warns
-about, now built into the mechanism that decides what counts as a real bug.
-
-**Measured on the 2026-08-13 triage of the 28 unexamined flags: 17 of them are
-blank-on-blank.** Broiler paints a uniform white canvas for the test *and* for the
-reference, while Chromium paints substantial content in both. Every one is a real
-gap that had been moved out of the ranking.
-
-Two cheap checks would separate them, and either alone would have caught all 17:
-
-1. **Reject a clear when the render is uniform.** A test and reference that are both
-   a single colour across the whole canvas are not evidence of agreement. The runner
-   already computes a colour histogram for its `subCategory` classification.
-2. **Compare against the committed golden's content, not just its pixels.** A golden
-   with substantial content and a render with none is the signature; today that pair
-   scores 0.0% and is cleared anyway.
-
-Until one of them lands, **a `suspectReference` flag is a candidate for triage, not a
-verdict** — the tables in [won't fix](wpt-rendering-gaps-wont-fix.md#the-settled-set)
-are the flags that survived being checked by hand.
 
 ### The report cannot distinguish "wrong everywhere" from "wrong only against Chromium"
 

--- a/docs/wpt-rendering-gaps-wont-fix.md
+++ b/docs/wpt-rendering-gaps-wont-fix.md
@@ -311,7 +311,7 @@ upstream rather than fixing — see
 25 wrong out of 28 is not a tuning problem, it is a missing check:
 **`--verify-reference` never asks whether anything was drawn.** Blank-on-blank scores
 100% and clears. The defect and the two cheap fixes for it are recorded under
-[not fixed](wpt-rendering-gaps-open.md#--verify-reference-clears-a-test-that-renders-nothing).
+[fixed](wpt-rendering-gaps-fixed.md#--verify-reference-cleared-a-test-that-rendered-nothing).
 
 Until that lands, treat the *Not ranked* heading in a run as a **triage queue, not a
 verdict**. The [settled set](#the-settled-set) above is the part that has been checked

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -6,14 +6,14 @@ documents, split by verdict:
 
 | Document | What is in it | Tests |
 | --- | --- | --- |
-| [**Not fixed**](wpt-rendering-gaps-open.md) | real gaps, each with an owner, evidence and an exit gate | 55 |
+| [**Not fixed**](wpt-rendering-gaps-open.md) | real gaps, each with an owner, evidence and an exit gate | 50 |
 | [**Won't fix**](wpt-rendering-gaps-wont-fix.md) | tests Broiler renders correctly and the golden image does not | 17 |
-| [**Fixed**](wpt-rendering-gaps-fixed.md) | closed gaps, with root cause, what landed, and the wrong turns | 43 |
+| [**Fixed**](wpt-rendering-gaps-fixed.md) | closed gaps, with root cause, what landed, and the wrong turns | 46 |
 
 Start with *not fixed*. Read *won't fix* before starting on any 0.0% — closing one of
 those means deleting working support. But do not read a run's *Not ranked* heading as
 that verdict: of the 28 such flags checked by hand on 2026-08-13, **25 were real gaps**
-being hidden by [a missing check in the runner](wpt-rendering-gaps-open.md#--verify-reference-clears-a-test-that-renders-nothing).
+being hidden by [a missing check in the runner](wpt-rendering-gaps-fixed.md#--verify-reference-cleared-a-test-that-rendered-nothing), since closed.
 
 ## Read this first — four things that are true of the whole set
 
@@ -28,25 +28,27 @@ being hidden by [a missing check in the runner](wpt-rendering-gaps-open.md#--ver
    nobody had checked by hand, **25 were wrong** — 17 of them because Broiler renders
    a *blank canvas* for the test and for its reference, and blank-on-blank matches at
    100%. `--verify-reference`
-   [never asks whether anything was drawn](wpt-rendering-gaps-open.md#--verify-reference-clears-a-test-that-renders-nothing).
+   [never asked whether anything was drawn](wpt-rendering-gaps-fixed.md#--verify-reference-cleared-a-test-that-rendered-nothing);
+   it does now, so that particular way of hiding a gap is closed.
    Passing a test's own reference is necessary evidence, not sufficient — the same
    way `css-grid/subgrid/orthogonal-writing-mode-006` passes its `rel=match` at 100%
    *because the test and its reference share the broken layout*
    ([details](wpt-rendering-gaps-open.md#the-flag-can-be-a-false-negative)). And the
    inverse exists too: two `css-view-transitions` tests
    [pass on CI and are demonstrably wrong](wpt-rendering-gaps-open.md#two-tests-are-green-on-ci-and-wrong).
-3. **One patch is waiting, and a patch number identifies nothing.** The `patches/`
-   directory holds a single entry — [`0001`](../patches/README.md), the paint call
-   site for
-   [`object-fit` and `object-position`](wpt-rendering-gaps-fixed.md#object-fit-and-object-position-were-not-read-at-all).
-   Every *other* submodule fix in these documents is an ancestor of the pinned
-   pointer and live on CI, including the SVG-renderer unification that was `0001`
-   before this one (`Broiler.HTML` `c77f0f0`, pointer bumped). That is the whole
-   problem with numbering them: `patches/` is a backlog rather than an archive — a
-   file is deleted once its fix is upstream and numbering restarts from `0001` — so
-   the same number names different changes at different times, and a `patches/NNNN`
-   reference in an older commit or comment is almost always dangling. Fixes are
-   identified here by **commit subject**:
+3. **One rendering fix on these pages is waiting on a patch, and a patch number
+   identifies nothing.** That fix is
+   [the media-element one](wpt-rendering-gaps-fixed.md#a-media-element-with-nothing-to-show-painted-a-black-box)
+   — *Paint a media element's box only when it shows controls*, in `Broiler.HTML`,
+   listed in `scripts/apply-pending-wpt-patches.sh` so the pixel suites exercise it on
+   top of the pinned pointer. Every *other* submodule fix in these documents is an
+   ancestor of the pointer and live on CI outright, including the SVG-renderer
+   unification and the `object-fit` call site that each held `0001` before it. That is
+   the whole problem with numbering them: [`patches/`](../patches/README.md) is a
+   backlog rather than an archive — a file is deleted once its fix is upstream and
+   numbering restarts from `0001` — so the same number names different changes at
+   different times, and a `patches/NNNN` reference in an older commit or comment is
+   almost always dangling. Fixes are identified here by **commit subject**:
 
    ```sh
    git -C <Submodule> log --oneline --grep '<commit subject>'

--- a/patches/0008-media-element-painting.patch
+++ b/patches/0008-media-element-painting.patch
@@ -1,0 +1,90 @@
+From 0e3ed6bfbd7999ada712c14cf2aaaee84cb26ec7 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sat, 15 Aug 2026 11:33:01 +0000
+Subject: [PATCH] Paint a media element's box only when it shows controls
+
+---
+ .../Parse/DomParser.cs                        | 38 ++++++++++++++-----
+ 1 file changed, 29 insertions(+), 9 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+index dd827a0..a58e6d7 100644
+--- a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
++++ b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+@@ -219,10 +219,20 @@ internal sealed class DomParser
+             // between the tags; they render the poster frame or first frame
+             // instead.  Since this renderer cannot decode media streams, render
+             // them as inline-block boxes with the default intrinsic dimensions
+-            // (300×150 for video, 300×32 for audio) and a black background.
++            // (300×150 for video, 300×54 for audio with controls).
+             bool isVideo = box.HtmlTag.Name.Equals("video", StringComparison.OrdinalIgnoreCase);
+             bool isAudio = !isVideo && box.HtmlTag.Name.Equals("audio", StringComparison.OrdinalIgnoreCase);
+-            if (isVideo || isAudio)
++            bool hasControls = (isVideo || isAudio) && box.HtmlTag.HasAttribute("controls");
++
++            // HTML rendering §15.4.7 UA stylesheet: `audio:not([controls])` is `display: none`.
++            // Broiler laid it out as a box and filled it black, so a page listing many <audio>
++            // elements — conformance-checkers/html/elements/audio/src-isvalid is 250 of them —
++            // came out as a wall of black bars where the reference browser draws nothing at all.
++            if (isAudio && !hasControls)
++            {
++                box.Display = CssConstants.None;
++            }
++            else if (isVideo || isAudio)
+             {
+                 box.Display = CssConstants.InlineBlock;
+ 
+@@ -236,14 +246,19 @@ internal sealed class DomParser
+                 if (string.IsNullOrEmpty(box.Height) || box.Height == CssConstants.Auto)
+                 {
+                     var attrH = box.HtmlTag.TryGetAttribute("height");
+-                    box.Height = !string.IsNullOrEmpty(attrH) ? attrH + "px" : (isVideo ? "150px" : "32px");
++                    box.Height = !string.IsNullOrEmpty(attrH) ? attrH + "px" : (isVideo ? "150px" : "54px");
+                 }
+ 
+-                // Black background to approximate the default media player frame.
+-                if (string.IsNullOrEmpty(box.BackgroundColor) ||
+-                    box.BackgroundColor.Equals("transparent", StringComparison.OrdinalIgnoreCase))
++                // Only a media element showing controls paints anything without decodable media:
++                // HTML §4.8.9 says a <video> with no poster and no frame "represents nothing", and
++                // the reference browser paints its box transparent — the control bar is the sole
++                // thing on screen. The placeholder fill therefore follows `controls`, not the
++                // element: a dark scrim under a video's controls, the light bar under an audio's.
++                if (hasControls
++                    && (string.IsNullOrEmpty(box.BackgroundColor)
++                        || box.BackgroundColor.Equals("transparent", StringComparison.OrdinalIgnoreCase)))
+                 {
+-                    box.BackgroundColor = "black";
++                    box.BackgroundColor = isVideo ? "black" : "#f1f3f4";
+                 }
+ 
+                 // Hide all children (fallback content, <source>, <track>, etc.)
+@@ -999,10 +1014,14 @@ internal sealed class DomParser
+     /// HTML §4.8.9: a <c>&lt;video&gt;</c> is a replaced element. Broiler cannot decode video streams, so —
+     /// like a supporting UA with no poster/frame to show — it paints as an inline-block replaced box at its
+     /// used size (the CSS-default intrinsic 300×150, or an author CSS size / the <c>width</c>/<c>height</c>
+-    /// presentation attributes) filled black, and its inline fallback content between the tags does not lay
++    /// presentation attributes), and its inline fallback content between the tags does not lay
+     /// out or paint. Runs post-cascade so a cascade-time hide of a block fallback child cannot be re-shown
+     /// (the same reason <see cref="CorrectIframeBoxes"/> is post-cascade). This is the native replacement for
+     /// the bridge's <c>HtmlPostProcessor.ReplaceVideoWithPlaceholder</c> string rewrite.
++    /// <para>The box is filled only when the element shows <c>controls</c>. The spec says a video with
++    /// neither poster nor frame "represents nothing", and the reference browser paints its box
++    /// transparent — a black fill made every source-less <c>&lt;video&gt;</c> on a page a solid black
++    /// rectangle over whatever it sits on.</para>
+     /// </summary>
+     private static void CorrectVideoBoxes(CssBox box)
+     {
+@@ -1016,7 +1035,8 @@ internal sealed class DomParser
+                 box.Width = PresentationLengthPx(box, "width", "300px");
+             if (box.Height == CssConstants.Auto)
+                 box.Height = PresentationLengthPx(box, "height", "150px");
+-            box.BackgroundColor = "black";
++            if (box.HtmlTag.HasAttribute("controls"))
++                box.BackgroundColor = "black";
+             foreach (var child in box.Boxes)
+                 child.Display = CssConstants.None;
+             return;
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # Submodule patches waiting to be applied
 
-**Seven patches are waiting on a maintainer.** See the index below.
+**Eight patches are waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -53,6 +53,7 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD && echo "live on CI"
 | `0005` | `Broiler.DOM` | Parse a `<noscript>` body as raw text, as a scripting-enabled parser must |
 | `0006` | `Broiler.JS/Broiler.Regex` | Tell the end of a pattern apart from a NUL inside one |
 | `0007` | `Broiler.JS` | Say "is not a constructor", as every other construct site does |
+| `0008` | `Broiler.HTML` | Paint a media element's box only when it shows controls |
 
 ### `0001` — a closure a direct eval created lost the eval site's bindings
 
@@ -336,6 +337,39 @@ message, so the un-patched engine behaves exactly as before; the cost of not app
 is a non-standard string in a stack trace.
 
 **When it lands upstream:** bump the pointer and delete this patch.
+
+### `0008` — every `<video>` on a page was a solid black rectangle
+
+A `<video>` with no decodable media painted its whole box black, and an `<audio>`
+without `controls` laid out as a 300×32 black bar instead of not laying out at all.
+`conformance-checkers/html/elements/track/src-isvalid` is 250 `<video>` elements and
+`.../audio/src-isvalid` 250 `<audio>` ones; Chromium renders both as blank white pages
+and Broiler rendered walls of black, matching at **14.4 %** and **19.8 %**.
+
+HTML §4.8.9 is explicit that a video element with neither a poster frame nor video data
+"represents … nothing", and the HTML rendering section's UA stylesheet makes
+`audio:not([controls])` `display: none`. Checked against the reference browser directly:
+an empty `<video>`, a `<video src="missing.mp4">` and a `<video autoplay><source></video>`
+all paint transparent — the div behind each one shows through — and only `<video controls>`
+draws anything, the control scrim. An `<audio controls>` is a 300×**54** light bar, not 32.
+
+So the placeholder fill now follows `controls` rather than the element: a dark scrim under
+a video's controls, a light bar under an audio's, and nothing at all without them. The
+default audio height moves 32 → 54 to match. The three tests go to **100 %**.
+
+**Listed for the pixel suites** (`scripts/apply-pending-wpt-patches.sh`). It moves any page
+that merely contains a media element, and there is no main-repo half to fall back on: the
+fill is set during the style cascade, where nothing downstream can tell a UA-injected
+background from an author one.
+
+**The main-repo tests moved with it, but not to the patched behaviour.**
+`WptCompositingTests`'s three video cases asserted the black fill directly. They now assert
+the replaced box's *extent*, against an author background they set themselves — true with
+the patch and without it — because a fill the element is not supposed to draw is not
+something a test should pin. Transparency is pinned by the WPT tests above instead.
+
+**When it lands upstream:** bump the pointer, drop the entry from
+`scripts/apply-pending-wpt-patches.sh`, and delete this patch.
 
 ## A stale entry in the apply script is not inert
 

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -145,7 +145,18 @@ set -euo pipefail
 # NOT listed. It decides whether page script runs at all rather than what any of it paints, and
 # the pixel suites do not execute a module loader of the shape that trips it. Its behaviour is
 # unit-tested inside the patch itself (DirectEvalClosureScopeTests).
-PENDING_PATCHES=()
+#
+# The media-element patch (Broiler.HTML, "Paint a media element's box only when it shows controls")
+# IS listed, and for the plainest reason there is: without it every <video> on a page is a solid
+# black 300×150 rectangle and every <audio> a black bar, over whatever they sit on, where the
+# reference browser paints nothing at all. It is the whole of
+# conformance-checkers/html/elements/{video,track,audio}/src-isvalid — three tests that go from
+# 14–20 % to 100 % with it — and it moves any page that merely *contains* a media element. There
+# is no main-repo half to fall back on: the fill is set during the style cascade, where nothing
+# downstream can tell it from an author background.
+PENDING_PATCHES=(
+  "Broiler.HTML|patches/0008-media-element-painting.patch"
+)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/src/Broiler.Cli.Tests/SvgReplacedSizingTests.cs
+++ b/src/Broiler.Cli.Tests/SvgReplacedSizingTests.cs
@@ -163,4 +163,68 @@ public sealed class SvgReplacedSizingTests
     {
         AssertSvgSize("width=\"auto\" viewBox=\"0 0 500 250\"", 400, 400, 200);
     }
+
+    /// <summary>
+    /// CSS 2.1 §10.5: a percentage height against a containing block whose block size is
+    /// indefinite computes to <c>auto</c>, so the viewBox ratio supplies the height —
+    /// <c>&lt;svg width="100%" height="100%"&gt;</c>, the shape every
+    /// <c>conformance-checkers/html-svg</c> page has, is a ratio-shaped box and not a
+    /// page-height-shaped one.
+    /// </summary>
+    /// <remarks>
+    /// It used to resolve against the containing block's <em>width</em> — the wrong axis outright.
+    /// A 400px-wide wrapper made the element 400px tall as well, and "xMidYMid meet" then centred
+    /// the drawing 100px down a box that should have been 200px tall (issue #1658).
+    /// </remarks>
+    [Theory]
+    [InlineData("0 0 500 250", 400, 400, 200)]
+    [InlineData("0 0 500 500", 400, 400, 400)]
+    public void PercentageHeight_AgainstAnIndefiniteContainingBlock_TransfersTheRatio(
+        string viewBox, int containerWidth, int expectedWidth, int expectedHeight)
+    {
+        AssertSvgSize(
+            $"width=\"100%\" height=\"100%\" viewBox=\"{viewBox}\"",
+            containerWidth, expectedWidth, expectedHeight);
+    }
+
+    /// <summary>
+    /// With a definite containing-block height the percentage does resolve — against that height,
+    /// and the ratio does not override it.
+    /// </summary>
+    [Theory]
+    [InlineData("100%", 300)]
+    [InlineData("50%", 150)]
+    public void PercentageHeight_AgainstADefiniteContainingBlock_ResolvesAgainstIt(
+        string height, int expectedHeight)
+    {
+        string html =
+            "<!DOCTYPE html><html><head><style>"
+            + ".wrap{width:400px;height:300px;position:relative}"
+            + "</style></head><body style=\"margin:0\"><div class=\"wrap\">"
+            + $"<svg width=\"100%\" height=\"{height}\" viewBox=\"0 0 500 250\" "
+            + "data-offset-x=\"0\" data-offset-y=\"0\" data-expected-width=\"400\" "
+            + $"data-expected-height=\"{expectedHeight}\"></svg>"
+            + "</div></body></html>";
+        AssertCheckLayout(html);
+    }
+
+    /// <summary>
+    /// The same rule for an atomic inline that is not an <c>&lt;svg&gt;</c>: an inline-block's
+    /// percentage height resolves against the containing block's block size, and against nothing
+    /// when there is none.
+    /// </summary>
+    [Fact]
+    public void InlineBlock_PercentageHeight_ResolvesAgainstTheBlockAxis()
+    {
+        string html =
+            "<!DOCTYPE html><html><head><style>"
+            + ".definite{width:400px;height:200px}"
+            + ".indefinite{width:400px}"
+            + "span{display:inline-block;width:10px;height:50%}"
+            + "</style></head><body style=\"margin:0\">"
+            + "<div class=\"definite\"><span data-expected-height=\"100\"></span></div>"
+            + "<div class=\"indefinite\"><span data-expected-height=\"0\"></span></div>"
+            + "</body></html>";
+        AssertCheckLayout(html);
+    }
 }

--- a/src/Broiler.Cli.Tests/WptCompositingTests.cs
+++ b/src/Broiler.Cli.Tests/WptCompositingTests.cs
@@ -1298,21 +1298,30 @@ body { margin: 0; }
     }
 
     // ──────────── Video element placeholder tests ────────────────────────
-    // <video> elements should render as replaced elements with a black
-    // placeholder matching the default browser dimensions (300×150).
+    // <video> is a replaced element that takes the default 300×150 object size
+    // and never lays out the fallback content between its tags.
+    //
+    // These assert the box, not a fill colour. The element's own painting is
+    // "the poster frame, or nothing" (HTML §4.8.9): with neither, the reference
+    // browser paints the box transparent, so a colour assertion here would be
+    // pinning a placeholder the engine is not supposed to draw. The author
+    // background each case sets is what makes the box's extent observable, and
+    // that one *is* the element's to paint. Transparency itself is pinned by
+    // conformance-checkers/html/elements/{video,track}/src-isvalid in the WPT run.
 
     /// <summary>
     /// WPT: css/compositing/mix-blend-mode/reference/mix-blend-mode-video-notref.html
-    /// Verifies that a <c>&lt;video&gt;</c> element is replaced with a black
-    /// placeholder box. The default intrinsic size is 300×150px.
+    /// Verifies that a <c>&lt;video&gt;</c> element is replaced by a box of the
+    /// default 300×150 object size.
     /// </summary>
     [Fact]
-    public void Video_Element_Renders_As_Black_Placeholder()
+    public void Video_Element_Renders_As_Default_Sized_Replaced_Box()
     {
         var html = @"<!DOCTYPE html>
 <html>
 <head><style>
 body { margin: 0; background-color: white; }
+video { background-color: black; }
 </style></head>
 <body>
 <video autoplay>
@@ -1323,13 +1332,13 @@ body { margin: 0; background-color: white; }
 </html>";
 
         using var bitmap = HtmlRender.RenderToImageWithStyleSet(html, 400, 300);
-        // The video placeholder should render as a 300×150 black box.
+        // The replaced box should cover 300×150 from the origin.
         var pInside = bitmap.GetPixel(150, 75);
         Assert.InRange(pInside.R, 0, 20);
         Assert.InRange(pInside.G, 0, 20);
         Assert.InRange(pInside.B, 0, 20);
 
-        // Outside the placeholder (to the right) should be white.
+        // Outside the box (to the right) should be white.
         var pOutside = bitmap.GetPixel(350, 75);
         Assert.InRange(pOutside.R, 245, 255);
         Assert.InRange(pOutside.G, 245, 255);
@@ -1338,7 +1347,7 @@ body { margin: 0; background-color: white; }
 
     /// <summary>
     /// Verifies that explicit width/height on <c>&lt;video&gt;</c> is
-    /// respected in the placeholder dimensions.
+    /// respected in the replaced box's dimensions.
     /// </summary>
     [Fact]
     public void Video_Element_Respects_Explicit_Dimensions()
@@ -1347,6 +1356,7 @@ body { margin: 0; background-color: white; }
 <html>
 <head><style>
 body { margin: 0; background-color: white; }
+video { background-color: black; }
 </style></head>
 <body>
 <video width=""200"" height=""100"" autoplay>
@@ -1356,7 +1366,7 @@ body { margin: 0; background-color: white; }
 </html>";
 
         using var bitmap = HtmlRender.RenderToImageWithStyleSet(html, 400, 300);
-        // 200×100 black box
+        // 200×100 box
         var pInside = bitmap.GetPixel(100, 50);
         Assert.InRange(pInside.R, 0, 20);
         Assert.InRange(pInside.G, 0, 20);
@@ -1388,12 +1398,46 @@ body { margin: 0; background-color: white; font-size: 20px; }
 </html>";
 
         using var bitmap = HtmlRender.RenderToImageWithStyleSet(html, 400, 300);
-        // The video placeholder should be a 300×150 black box.
-        // The fallback text "This is fallback text..." should NOT be rendered.
-        var pCenter = bitmap.GetPixel(150, 75);
-        Assert.InRange(pCenter.R, 0, 20);
-        Assert.InRange(pCenter.G, 0, 20);
-        Assert.InRange(pCenter.B, 0, 20);
+        // The fallback text must not be laid out, so the video's box — which
+        // paints nothing of its own — leaves the page background untouched.
+        for (int x = 0; x < 300; x += 20)
+        {
+            for (int y = 0; y < 150; y += 15)
+            {
+                var pixel = bitmap.GetPixel(x, y);
+                Assert.InRange(pixel.R, 245, 255);
+                Assert.InRange(pixel.G, 245, 255);
+                Assert.InRange(pixel.B, 245, 255);
+            }
+        }
+    }
+
+    /// <summary>
+    /// HTML rendering §15.4.7: <c>audio:not([controls])</c> is <c>display: none</c>,
+    /// so a source-less <c>&lt;audio&gt;</c> occupies no space and paints nothing.
+    /// </summary>
+    [Fact]
+    public void Audio_Element_Without_Controls_Is_Not_Rendered()
+    {
+        var html = @"<!DOCTYPE html>
+<html>
+<head><style>
+body { margin: 0; background-color: white; }
+</style></head>
+<body><audio src=""a.mp3""></audio></body>
+</html>";
+
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(html, 400, 300);
+        for (int x = 0; x < 320; x += 20)
+        {
+            for (int y = 0; y < 80; y += 10)
+            {
+                var pixel = bitmap.GetPixel(x, y);
+                Assert.InRange(pixel.R, 245, 255);
+                Assert.InRange(pixel.G, 245, 255);
+                Assert.InRange(pixel.B, 245, 255);
+            }
+        }
     }
 
     // ──────────── Isolation group tests ────────────────────────────────────

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -1585,7 +1585,25 @@ internal sealed partial class WptTestRunner
     /// Returns null when there is no rel=match reference, it cannot be resolved or
     /// rendered, or Broiler does not match it. Best-effort: never throws.
     /// </summary>
-    private string? VerifyAgainstReferenceHtml(string testPath, string html, string? wptRoot, HTML.Image.BBitmap testRender)
+    /// <remarks>
+    /// <para>
+    /// <b>Agreement is only evidence when something was drawn.</b> A test that renders a blank
+    /// canvas and a reference that renders a blank canvas match at 100%, so a gap that makes
+    /// Broiler paint nothing at all used to clear itself here and move off the severity ranking
+    /// entirely. The 2026-08-13 triage of the flags nobody had checked by hand found 17 of 28 were
+    /// exactly that: a uniform render on both sides while Chromium painted substantial content in
+    /// both (<c>docs/wpt-rendering-gaps-open.md</c>).
+    /// </para>
+    /// <para>
+    /// So a clear now needs the render to have content, judged against the committed golden: a
+    /// uniform render is only agreement when the golden is uniform too. Both of the checks that
+    /// document proposed are in that one condition — it rejects a uniform render, and it rejects a
+    /// render with no content against a golden that has some.
+    /// </para>
+    /// </remarks>
+    private string? VerifyAgainstReferenceHtml(
+        string testPath, string html, string? wptRoot,
+        HTML.Image.BBitmap testRender, HTML.Image.BBitmap committedGolden)
     {
         try
         {
@@ -1596,6 +1614,9 @@ internal sealed partial class WptTestRunner
             {
                 return null;
             }
+
+            if (IsUniform(testRender) && !IsUniform(committedGolden))
+                return null;
 
             using var refRender = RenderHtmlFileBitmap(refPath, wptRoot);
             using var diff = PixelDiffRunner.Compare(testRender, refRender, _pixelDiffConfig);
@@ -1611,6 +1632,29 @@ internal sealed partial class WptTestRunner
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Whether every pixel of <paramref name="bitmap"/> is the same colour — the signature of a
+    /// render that drew nothing, and the one thing a pixel comparison cannot tell apart from
+    /// agreement.
+    /// </summary>
+    internal static bool IsUniform(HTML.Image.BBitmap? bitmap)
+    {
+        if (bitmap is null || bitmap.Width == 0 || bitmap.Height == 0)
+            return true;
+
+        var first = bitmap.GetPixel(0, 0);
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                if (bitmap.GetPixel(x, y) != first)
+                    return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool TryExtractAttributeValue(Regex pattern, string tag, out string value)
@@ -1986,7 +2030,7 @@ internal sealed partial class WptTestRunner
                 // the committed PNG — not Broiler — is the outlier (stale/incorrect
                 // reference), which we surface so triage doesn't chase a non-bug.
                 string? suspectReference = _verifyReferenceHtml
-                    ? VerifyAgainstReferenceHtml(testPath, html, wptRoot, rendered)
+                    ? VerifyAgainstReferenceHtml(testPath, html, wptRoot, rendered, reference)
                     : null;
                 if (suspectReference != null)
                     message = $"{message} [{suspectReference}]";


### PR DESCRIPTION
## Summary

Closes the tractable part of the [#1658](https://github.com/Broiler-Platform/Broiler/issues/1658) WPT severity run. Its largest cluster — nine of the thirty entries, all `conformance-checkers` — had been recorded as *large documents, not triaged*. Triaged, it is **nine separate gaps rather than one**; seven are closed here.

Measured against locally generated Chromium references at the run's own 99% threshold:

| Test | Was | Now |
| --- | --- | --- |
| `html/elements/audio/src-isvalid` | 19.8% | **100%** |
| `html/elements/track/src-isvalid` | 14.4% | **100%** |
| `html/elements/video/src-isvalid` | 14.4% | **100%** |
| `html-svg/pservers-pattern-03-f-isvalid` | 21.9% | 94.2% |
| `html-svg/pservers-grad-03-b-isvalid` | 29.9% | 93.8% |
| `html-svg/pservers-pattern-02-f-isvalid` | 19.3% | 92.3% |
| `html-svg/struct-symbol-01-b-isvalid` | 30.6% | 81.4% |
| `html-svg/types-dom-06-f-isvalid` | 16.4% | 22.5% |
| `html-svg/styling-css-05-b-isvalid` | 11.3% | 12.6% |

## What was wrong

**Every SVG `<text>` in the engine painted nothing at all.** `RGraphicsRasterBackend.RenderSvgText` returns early unless the item carries a resolved font, and **nothing ever set one** — `DrawSvgTextItem` was constructed with a family name, a size, and no handle. The renderer builds its display items in `Broiler.Layout` with no box to ask for a font, so the host's font services are now published for the render pass the way the SVG filter and clip-path tables already are (`SvgTextEnvironment`, seeded by `FragmentTreeBuilder.Build`). No submodule change was needed, because the item is built in the main repo.

**The per-shape regexes could not see the tree.** One regex per shape type over the whole markup draws every `rect` wherever it sits — including the ones inside `defs`, `symbol` and `pattern`, which SVG renders only through a reference. That is why `struct-symbol-01-b` painted a symbol's contents across the whole canvas. It equally cannot see that a `g` element's `font-size` or `transform` applies to what is inside it. `SvgStructure` scans the tags once with a stack and records, per start-tag offset, whether the element paints, what it inherits and the transform it is under; the existing loops consult it by `Match.Index` and are otherwise unchanged.

**`fill="url(#id)"` reached the colour parser,** matched no named colour and fell through to the caller's default — solid black, which is most of the canvas in every `pservers-*` test. Patterns are now tiled as ordinary display items clipped to the shape, with `patternUnits`, `patternContentUnits`, `viewBox`, `href` inheritance and `patternTransform`. A reference that resolves to nothing paintable takes its declared fallback paint (SVG 2 §13.2) instead of black.

**`use` drew nothing,** so a `symbol` had no way to reach the canvas at all. It now renders its referent, establishing the symbol viewport, and `preserveAspectRatio` is read rather than assumed to be `xMidYMid meet`.

**An atomic inline's percentage height resolved against the containing block's *width*.** The wrong axis outright, and the reason `<svg width="100%" height="100%">` — the shape every one of these pages has — came out as tall as the page is wide and then let "xMidYMid meet" centre its drawing a couple of hundred pixels down the box. It resolves against the block size now, or computes to `auto` when there is none (CSS 2.1 §10.5), which lets the viewBox ratio give the height the reference browser uses. The in-flow grid-item branch beside it had already sidestepped that basis for its own case and named it as wrong.

**A media element with nothing to show painted a black box.** HTML §4.8.9 says a video with neither poster frame nor video data "represents … nothing", and the rendering section's UA stylesheet makes `audio:not([controls])` `display: none`. Checked against the reference browser directly rather than assumed: an empty video, a video with a missing `src`, and one with a `source` child all paint **transparent**, and only `controls` draws anything.

**The runner cleared a test that rendered nothing.** `--verify-reference` cleared a pixel-mismatch failure whenever Broiler reproduced the test's own `rel=match` reference, without asking whether anything had been **drawn** — blank-on-blank matches at 100%. The 2026-08-13 triage measured 17 of 28 unexamined flags as exactly that. A clear now additionally requires the render to have content, judged against the committed golden. `docs/wpt-rendering-gaps-open.md` recorded this as *the most consequential defect on this page*.

## The wrong turn worth not repeating

**A transform is baked into the geometry, not pushed as a layer.** `TransformItem` exists and the backend takes it, but `GraphicsAdapter.SaveTransformLayer` keeps only translations and uniform scales on the raster canvas; anything else falls through to a compat backend the image renderer stubs out, and **the enclosed drawing disappears entirely**. A rotated `patternTransform` written that way rendered a blank rectangle. Mapping the tiles' own coordinates instead needs no layer, and a rotated rectangle is still exactly expressible — as the polygon primitive the backend already draws (`SvgItemTransformer`). The one shape it cannot carry under a rotation is an ellipse, whose primitive has axis-aligned radii; those are left in place rather than drawn somewhere wrong.

## Submodule patch

The media-element fix belongs in `Broiler.HTML`, whose remote is outside this session's push scope (403 from the git proxy). It ships as `patches/0008-media-element-painting.patch` with the pointer **not** bumped, and is listed in `scripts/apply-pending-wpt-patches.sh` so the pixel suites exercise it on top of the pinned pointer. `WptCompositingTests`'s three video cases asserted the black fill directly; they now assert the replaced box's *extent* against an author background they set themselves — true with the patch and without it — because a fill the element is not supposed to draw is not something a test should pin.

## Not fixed, and why

Two of the nine need a subsystem rather than a fix, and are written up in `docs/wpt-rendering-gaps-open.md`: `types-dom-06-f` scripts the **SVG DOM** (`requiredFeatures`, an `SVGStringList`), and `styling-css-05-b` needs the **CSS cascade to reach SVG paint** — `SvgRenderer` reads paint from attributes and inline `style` only, because it works from serialised markup rather than from the boxes the cascade was projected onto.

## Verification

- 870 `Broiler.Layout.Tests` pass, including two new files over the new code.
- `ImagePrefetchTests` 51/51 — it caught a real regression the font work introduced (an SVG image decoded on a prefetch worker saw a different thread-affine font slot than a serial decode), fixed by making an image raster resolve no fonts at all, which is the behaviour it has always had.
- Probe cases match Chromium pixel-for-pixel: a `userSpaceOnUse` pattern, a rotated `patternTransform`, a `url(#missing) lime` fallback, a translated pattern-filled rect, and the `use` clone path.
- Three quadratic behaviours found and fixed while running the full suite against the baseline: the scan copied every id-bearing element's content, a pattern re-parsed its tile markup once per tile, and the comment-span lookup was linear per shape.

https://claude.ai/code/session_01KWxvzGupXR63gn5JsqdxWJ