### PR TITLE
Add SVG path support and fix paint order and viewport issues

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/SvgColorFilterTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/SvgColorFilterTests.cs
@@ -221,4 +221,94 @@ public sealed class SvgColorFilterTests
 
         Assert.Equal(BColor.FromArgb(255, 0, 128, 0), fill);
     }
+
+    // ── feFlood as a backdrop, not as the result ──────────────────────────
+
+    /// <summary>
+    /// A flood that another primitive consumes describes a <em>backdrop</em>, not the filter's
+    /// result. Treating any filter containing an <c>feFlood</c> as flood-only replaced the shape
+    /// with a solid flood-coloured rectangle 20% larger than itself — which is what the whole
+    /// <c>css/filter-effects/tainting-*</c> family and
+    /// <c>conformance-checkers/html-svg/filters-blend-01-b</c> rendered as.
+    /// </summary>
+    [Fact]
+    public void AFloodFeedingAnotherPrimitive_DoesNotFloodTheShape()
+    {
+        var filter = @"<filter id=""f"">
+            <feFlood flood-color=""green"" result=""bg"" />
+            <feOffset in=""bg"" dx=""1"" />
+        </filter>";
+        var fill = RenderedRectFill(Doc(filter,
+            "<rect x=\"0\" y=\"0\" width=\"100\" height=\"100\" fill=\"red\" filter=\"url(#f)\"></rect>"));
+
+        // feOffset is not modelled, so the shape renders unfiltered — but it must not be flooded.
+        Assert.Equal(BColor.Red, fill);
+    }
+
+    [Theory]
+    // Opaque lime over opaque blue: each mode is its own channel function.
+    [InlineData("normal", 0, 0, 255)]
+    [InlineData("multiply", 0, 0, 0)]
+    [InlineData("screen", 0, 255, 255)]
+    [InlineData("darken", 0, 0, 0)]
+    [InlineData("lighten", 0, 255, 255)]
+    public void AFloodBlendedUnderTheSource_ProducesTheBlendedColour(
+        string mode, int r, int g, int b)
+    {
+        var filter = $@"<filter id=""f"" color-interpolation-filters=""sRGB"">
+            <feFlood flood-color=""#0f0"" result=""bg"" />
+            <feBlend in=""SourceGraphic"" in2=""bg"" mode=""{mode}"" />
+        </filter>";
+        var fill = RenderedRectFill(Doc(filter,
+            "<rect x=\"0\" y=\"0\" width=\"100\" height=\"100\" fill=\"#00f\" filter=\"url(#f)\"></rect>"));
+
+        Assert.Equal(BColor.FromArgb(255, r, g, b), fill);
+    }
+
+    [Fact]
+    public void AFloodsOpacityReachesTheBlend()
+    {
+        // A half-transparent lime backdrop under opaque blue: source-over leaves the source, so the
+        // flood's alpha must not be dropped on the way in — it is what makes this differ from the
+        // opaque case for every non-normal mode.
+        var filter = @"<filter id=""f"" color-interpolation-filters=""sRGB"">
+            <feFlood flood-color=""#0f0"" flood-opacity=""0.5"" result=""bg"" />
+            <feBlend in=""SourceGraphic"" in2=""bg"" mode=""multiply"" />
+        </filter>";
+        var fill = RenderedRectFill(Doc(filter,
+            "<rect x=\"0\" y=\"0\" width=\"100\" height=\"100\" fill=\"#00f\" filter=\"url(#f)\"></rect>"));
+
+        // αs = 1, so the result is fully opaque and is B(cb, cs) weighted by αb plus the source
+        // where the backdrop is transparent: blue × 0.5 in the blue channel.
+        Assert.Equal(255, fill.A);
+        Assert.Equal(0, fill.R);
+        Assert.Equal(0, fill.G);
+        Assert.InRange(fill.B, 126, 129);
+    }
+
+    [Fact]
+    public void AnUnmodelledBlendMode_LeavesTheShapeUnfiltered()
+    {
+        var filter = @"<filter id=""f"" color-interpolation-filters=""sRGB"">
+            <feFlood flood-color=""#0f0"" result=""bg"" />
+            <feBlend in=""SourceGraphic"" in2=""bg"" mode=""color-dodge"" />
+        </filter>";
+        var fill = RenderedRectFill(Doc(filter,
+            "<rect x=\"0\" y=\"0\" width=\"100\" height=\"100\" fill=\"#00f\" filter=\"url(#f)\"></rect>"));
+
+        Assert.Equal(BColor.Blue, fill);
+    }
+
+    [Fact]
+    public void ABlendWhoseBackdropIsNotAFlood_LeavesTheShapeUnfiltered()
+    {
+        // in2 names something this model cannot reduce to one colour, so the whole chain declines.
+        var filter = @"<filter id=""f"" color-interpolation-filters=""sRGB"">
+            <feBlend in=""SourceGraphic"" in2=""BackgroundImage"" mode=""multiply"" />
+        </filter>";
+        var fill = RenderedRectFill(Doc(filter,
+            "<rect x=\"0\" y=\"0\" width=\"100\" height=\"100\" fill=\"#00f\" filter=\"url(#f)\"></rect>"));
+
+        Assert.Equal(BColor.Blue, fill);
+    }
 }

--- a/Broiler.Layout/Broiler.Layout.Tests/SvgPathAndViewportTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/SvgPathAndViewportTests.cs
@@ -1,0 +1,240 @@
+using System.Drawing;
+using System.Linq;
+using Broiler.Graphics;
+using Broiler.Layout.IR;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// The four gaps behind the <c>conformance-checkers/html-svg</c> entries of issue #1661:
+/// <c>&lt;path&gt;</c> was never drawn at all, the shape passes painted out of document order, a
+/// nested <c>&lt;svg&gt;</c> established no viewport, and a CSS system colour reached the SVG paint
+/// parser as an unknown name and fell through to black.
+/// </summary>
+public sealed class SvgPathAndViewportTests
+{
+    private static readonly RectangleF Bounds = new(0, 0, 100, 100);
+
+    private static string Doc(string body) =>
+        $"<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>{body}</svg>";
+
+    private static List<DisplayItem> Render(string body)
+    {
+        SvgFilterTable.Reset();
+        SvgClipPathTable.Reset();
+        return SvgRenderer.RenderSvgContent(Doc(body), Bounds);
+    }
+
+    // ── <path> ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void A_Path_Is_Painted()
+    {
+        // Nothing drew <path> before: the only pass over it harvested start points for <textPath>.
+        var polygon = Assert.Single(
+            Render("<path d='M10,10 L90,10 L90,90 Z' fill='red'/>").OfType<DrawSvgPolygonItem>());
+
+        Assert.Equal(BColor.Red, polygon.Fill);
+        Assert.Contains(polygon.Points, p => p.X == 10 && p.Y == 10);
+        Assert.Contains(polygon.Points, p => p.X == 90 && p.Y == 90);
+    }
+
+    [Theory]
+    [InlineData("M10,10 H90 V90 Z")]          // absolute shorthand
+    [InlineData("m10,10 h80 v80 z")]          // relative shorthand
+    [InlineData("M10 10L90 10L90 90Z")]       // no separators before a command
+    [InlineData("M10,10L90,10 90,90Z")]       // an implicit repeat of the last command
+    public void Equivalent_Path_Spellings_Reach_The_Same_Corners(string d)
+    {
+        var polygon = Assert.Single(
+            Render($"<path d='{d}' fill='red'/>").OfType<DrawSvgPolygonItem>());
+
+        Assert.Contains(polygon.Points, p => p.X == 10 && p.Y == 10);
+        Assert.Contains(polygon.Points, p => p.X == 90 && p.Y == 10);
+        Assert.Contains(polygon.Points, p => p.X == 90 && p.Y == 90);
+    }
+
+    [Fact]
+    public void A_Curve_Is_Flattened_Into_Chords_That_Stay_Inside_Its_Hull()
+    {
+        var polygon = Assert.Single(
+            Render("<path d='M0,0 C0,100 100,100 100,0' fill='red'/>").OfType<DrawSvgPolygonItem>());
+
+        Assert.True(polygon.Points.Count > 8, "a cubic must be subdivided, not drawn as one chord");
+        Assert.All(polygon.Points, p =>
+        {
+            Assert.InRange(p.X, 0, 100);
+            Assert.InRange(p.Y, 0, 75);
+        });
+    }
+
+    [Fact]
+    public void An_Arc_Command_Reaches_Its_Endpoint()
+    {
+        var polygon = Assert.Single(
+            Render("<path d='M10,50 A40,40 0 0 1 90,50' fill='red'/>").OfType<DrawSvgPolygonItem>());
+
+        var last = polygon.Points[^1];
+        Assert.Equal(90, last.X, 1);
+        Assert.Equal(50, last.Y, 1);
+    }
+
+    [Fact]
+    public void An_Unclosed_Subpath_Strokes_As_A_Polyline_And_A_Closed_One_As_A_Polygon()
+    {
+        // The difference is whether the stroke runs all the way round: only Z asks for that.
+        var open = Render("<path d='M10,10 L90,10 L90,90' fill='none' stroke='red'/>");
+        Assert.Single(open.OfType<DrawSvgPolylineItem>());
+        Assert.Empty(open.OfType<DrawSvgPolygonItem>());
+
+        var closed = Render("<path d='M10,10 L90,10 L90,90 Z' fill='none' stroke='red'/>");
+        Assert.Single(closed.OfType<DrawSvgPolygonItem>());
+    }
+
+    [Fact]
+    public void A_Paths_SubPaths_Fill_As_One_Shape_So_An_Inner_Ring_Can_Be_A_Hole()
+    {
+        // Filling each subpath as its own opaque polygon painted over the hole; the rasterizer's
+        // fill is an even-odd crossing test, so the two rings must reach it as one ring.
+        var fills = Render(
+                "<path d='M0,0 H100 V100 H0 Z M25,25 H75 V75 H25 Z' fill='red'/>")
+            .OfType<DrawSvgPolygonItem>()
+            .Where(p => !p.Fill.IsEmpty)
+            .ToList();
+
+        Assert.Single(fills);
+        Assert.Contains(fills[0].Points, p => p.X == 25 && p.Y == 25);
+        Assert.Contains(fills[0].Points, p => p.X == 100 && p.Y == 100);
+    }
+
+    [Fact]
+    public void An_Unparseable_Path_Draws_Nothing()
+    {
+        Assert.Empty(Render("<path d='nonsense' fill='red'/>").OfType<DrawSvgPolygonItem>());
+        Assert.Empty(Render("<path fill='red'/>").OfType<DrawSvgPolygonItem>());
+    }
+
+    // ── Document order ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Shapes_Paint_In_Document_Order_Across_Element_Types()
+    {
+        // One regex per shape type, each sweeping the whole markup, emitted every rect before every
+        // circle before every text — so a later sibling could not cover an earlier one.
+        var items = Render(
+            "<circle cx='10' cy='10' r='5' fill='red'/>"
+            + "<rect width='10' height='10' fill='lime'/>"
+            + "<circle cx='20' cy='20' r='5' fill='blue'/>");
+
+        Assert.Collection(
+            items,
+            item => Assert.Equal(BColor.Red, Assert.IsType<DrawSvgEllipseItem>(item).Fill),
+            item => Assert.Equal(BColor.FromName("lime"), Assert.IsType<DrawSvgRectItem>(item).Fill),
+            item => Assert.Equal(BColor.Blue, Assert.IsType<DrawSvgEllipseItem>(item).Fill));
+    }
+
+    // ── Nested <svg> viewports ────────────────────────────────────────────
+
+    [Fact]
+    public void A_Nested_Svg_Places_Its_Content_In_Its_Own_Viewport()
+    {
+        // The child is 100×100 in a viewport of its own, which sits at 50,50 and is 50 wide: it
+        // must land there at half scale, not at the root's origin and scale.
+        var rect = Assert.Single(Render(
+                "<svg x='50' y='50' width='50' height='50' viewBox='0 0 100 100'>"
+                + "<rect width='100' height='100' fill='red'/></svg>")
+            .OfType<DrawSvgRectItem>());
+
+        // A display item's X/Y are relative to the Bounds it carries, which for the nested content
+        // is the viewport rather than the root box.
+        Assert.Equal(50, rect.Bounds.X + rect.X, 3);
+        Assert.Equal(50, rect.Bounds.Y + rect.Y, 3);
+        Assert.Equal(50, rect.Width, 3);
+        Assert.Equal(50, rect.Height, 3);
+    }
+
+    [Fact]
+    public void A_Nested_Svgs_Content_Is_Not_Also_Painted_By_The_Outer_Pass()
+    {
+        var rects = Render(
+                "<svg x='0' y='0' width='50' height='50'><rect width='10' height='10' fill='red'/></svg>")
+            .OfType<DrawSvgRectItem>()
+            .ToList();
+
+        Assert.Single(rects);
+    }
+
+    [Fact]
+    public void A_Nested_Svg_Keeps_Inheriting_Across_The_Viewport_Boundary()
+    {
+        var rect = Assert.Single(Render(
+                "<g fill='lime'><svg x='0' y='0' width='100' height='100'>"
+                + "<rect width='10' height='10'/></svg></g>")
+            .OfType<DrawSvgRectItem>());
+
+        Assert.Equal(BColor.FromName("lime"), rect.Fill);
+    }
+
+    // ── clip-path on a shape ──────────────────────────────────────────────
+
+    [Fact]
+    public void A_Shapes_ClipPath_Reference_Narrows_What_It_Paints()
+    {
+        var items = Render(
+            "<clipPath id='c'><rect x='0' y='0' width='50' height='50'/></clipPath>"
+            + "<rect width='100' height='100' fill='red' clip-path='url(#c)'/>");
+
+        var clip = Assert.Single(items.OfType<ClipItem>());
+        Assert.Equal(new RectangleF(0, 0, 50, 50), clip.ClipRect);
+        Assert.Single(items.OfType<RestoreItem>());
+    }
+
+    // ── vector-effect ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void A_NonScaling_Stroke_Does_Not_Take_The_View_Box_Scale()
+    {
+        // The view box maps 10 user units onto 100 px, so an ordinary 2-unit stroke is 20 px wide
+        // and a non-scaling one stays 2.
+        string doc = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'>"
+            + "<rect width='5' height='5' fill='none' stroke='red' stroke-width='2'{0}/></svg>";
+
+        var scaling = SvgRenderer
+            .RenderSvgContent(string.Format(doc, string.Empty), Bounds)
+            .OfType<DrawSvgRectItem>()
+            .Single();
+        var nonScaling = SvgRenderer
+            .RenderSvgContent(string.Format(doc, " vector-effect='non-scaling-stroke'"), Bounds)
+            .OfType<DrawSvgRectItem>()
+            .Single();
+
+        Assert.Equal(20, scaling.StrokeWidth, 3);
+        Assert.Equal(2, nonScaling.StrokeWidth, 3);
+    }
+
+    // ── System colours ────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Canvas", 255, 255, 255)]
+    [InlineData("CanvasText", 0, 0, 0)]
+    [InlineData("ButtonFace", 239, 239, 239)]
+    public void A_System_Colour_Is_A_Valid_Svg_Paint(string name, int r, int g, int b)
+    {
+        // It matched no named colour and fell through to the caller's default — black — so a page
+        // painted entirely in system colours came out as one black rectangle.
+        var rect = Assert.Single(
+            Render($"<rect width='10' height='10' fill='{name}'/>").OfType<DrawSvgRectItem>());
+
+        Assert.Equal(BColor.FromArgb(255, r, g, b), rect.Fill);
+    }
+
+    [Fact]
+    public void A_Named_Colour_Still_Wins_Over_The_System_Table()
+    {
+        var rect = Assert.Single(
+            Render("<rect width='10' height='10' fill='red'/>").OfType<DrawSvgRectItem>());
+
+        Assert.Equal(BColor.Red, rect.Fill);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/IR/SvgColorFilter.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgColorFilter.cs
@@ -30,7 +30,7 @@ public sealed class SvgColorFilter
 
     internal SvgColorFilter(List<Step> steps) => _steps = steps;
 
-    /// <summary>One modelled primitive. Exactly one of the two forms is populated.</summary>
+    /// <summary>One modelled primitive. Exactly one of the three forms is populated.</summary>
     internal readonly struct Step
     {
         /// <summary>The 20 <c>feColorMatrix</c> values in row-major order, or <c>null</c> for a composite.</summary>
@@ -38,6 +38,16 @@ public sealed class SvgColorFilter
 
         /// <summary><c>feComposite operator="arithmetic"</c> coefficients k1..k4.</summary>
         public (float K1, float K2, float K3, float K4) Arithmetic { get; init; }
+
+        /// <summary>
+        /// An <c>&lt;feBlend&gt;</c> of the running colour over a constant backdrop — the colour an
+        /// <c>&lt;feFlood&gt;</c> earlier in the same filter produced. Null when this step is not a
+        /// blend.
+        /// </summary>
+        public BColor? BlendBackdrop { get; init; }
+
+        /// <summary>The <c>feBlend</c> mode, when <see cref="BlendBackdrop"/> is set.</summary>
+        public string? BlendMode { get; init; }
     }
 
     /// <summary>
@@ -59,6 +69,12 @@ public sealed class SvgColorFilter
                 float nb = m[10] * r + m[11] * g + m[12] * b + m[13] * a + m[14];
                 float na = m[15] * r + m[16] * g + m[17] * b + m[18] * a + m[19];
                 r = Clamp01(nr); g = Clamp01(ng); b = Clamp01(nb); a = Clamp01(na);
+                continue;
+            }
+
+            if (step.BlendBackdrop is { } backdrop)
+            {
+                (r, g, b, a) = Blend(r, g, b, a, backdrop, step.BlendMode);
                 continue;
             }
 
@@ -88,6 +104,61 @@ public sealed class SvgColorFilter
             (int)MathF.Round(g * 255f),
             (int)MathF.Round(b * 255f));
     }
+
+    /// <summary>
+    /// Filter Effects §feBlend: the source colour composited over a constant backdrop under one of
+    /// the separable blend modes, in non-premultiplied sRGB.
+    /// </summary>
+    /// <remarks>
+    /// The general primitive blends two images; this is the case where the backdrop is a single
+    /// colour, which is what an <c>&lt;feFlood&gt;</c> produces over the whole filter region — the
+    /// shape <c>conformance-checkers/html-svg/filters-blend-01-b</c> uses five times over. Only the
+    /// five separable modes SVG 1.1 defines are taken; anything else leaves the colour alone rather
+    /// than guessing.
+    /// <para>
+    /// The compositing is Porter-Duff source-over with the blended colour, per the Compositing and
+    /// Blending model: the blend function applies where both are opaque, and each input shows
+    /// through unblended where the other is transparent.
+    /// </para>
+    /// </remarks>
+    private static (float R, float G, float B, float A) Blend(
+        float r, float g, float b, float a, BColor backdrop, string? mode)
+    {
+        float br = backdrop.R / 255f, bg = backdrop.G / 255f, bb = backdrop.B / 255f;
+        float ba = backdrop.A / 255f;
+
+        float outA = a + ba * (1 - a);
+        if (outA <= 0f)
+            return (0f, 0f, 0f, 0f);
+
+        return (
+            Clamp01(Composite(r, br)), Clamp01(Composite(g, bg)), Clamp01(Composite(b, bb)),
+            Clamp01(outA));
+
+        float Composite(float source, float back)
+        {
+            float blended = BlendChannel(source, back, mode);
+
+            // Compositing and Blending §9: co = cs × αs × (1 − αb) + cb × αb × (1 − αs)
+            //                                  + B(cb, cs) × αs × αb, then un-premultiply.
+            float premultiplied =
+                source * a * (1 - ba) + back * ba * (1 - a) + blended * a * ba;
+            return premultiplied / outA;
+        }
+    }
+
+    private static float BlendChannel(float source, float backdrop, string? mode) => mode switch
+    {
+        "multiply" => source * backdrop,
+        "screen" => source + backdrop - source * backdrop,
+        "darken" => MathF.Min(source, backdrop),
+        "lighten" => MathF.Max(source, backdrop),
+        _ => source,
+    };
+
+    /// <summary>The <c>feBlend</c> modes this models — SVG 1.1's five separable ones.</summary>
+    internal static bool IsModelledBlendMode(string mode) =>
+        mode is "normal" or "multiply" or "screen" or "darken" or "lighten";
 
     private static float Clamp01(float v) => v < 0f ? 0f : v > 1f ? 1f : v;
 }

--- a/Broiler.Layout/Broiler.Layout/IR/SvgPaintOrder.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgPaintOrder.cs
@@ -1,0 +1,92 @@
+#nullable disable
+using System.Drawing;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// Collects each element's display items against the document offset of its start tag, so the
+/// finished list paints in document order however the per-element passes are sequenced.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="SvgRenderer"/> finds elements with one regex per shape type, each sweeping the whole
+/// markup — so every <c>&lt;rect&gt;</c> was emitted, then every <c>&lt;circle&gt;</c>, and text
+/// last of all. SVG paints in document order (SVG 1.1 §3.3), and a display list is drawn in the
+/// order it is built, so an element that a later sibling must cover was painted <em>over</em> that
+/// sibling instead: in <c>conformance-checkers/html-svg/color-prop-04-t</c> the dropdown panel's
+/// opaque rectangles sit after the paragraph text in the markup and must hide it, and the text
+/// showed through them.
+/// </para>
+/// <para>
+/// Segments rather than single items, because one element can emit several — a pattern fill is a
+/// clip, its tiles and a restore, and a blend mode wraps its shape in a layer pair — and those must
+/// stay adjacent and in the order the element produced them. Sorting is stable on the offset so a
+/// container and the content it expands to (a <c>&lt;use&gt;</c> and its referent) keep the order
+/// they were opened in when both report the same offset.
+/// </para>
+/// </remarks>
+internal sealed class SvgPaintOrder
+{
+    private readonly List<Segment> _segments = [];
+
+    private sealed class Segment(int offset, int sequence, List<DisplayItem> items)
+    {
+        public int Offset { get; } = offset;
+
+        public int Sequence { get; } = sequence;
+
+        public List<DisplayItem> Items { get; } = items;
+
+        /// <summary>The region this element's drawing is clipped to, when it has one.</summary>
+        public RectangleF? Clip { get; set; }
+    }
+
+    /// <summary>
+    /// Clips everything the most recently opened element emits to <paramref name="rect"/>.
+    /// </summary>
+    /// <remarks>
+    /// Recorded against the segment rather than pushed into it by the caller so that the clip
+    /// encloses <em>all</em> of the element's items however many it turns out to emit — a pattern
+    /// fill's tiles and a blend layer's pair as well as the shape itself.
+    /// </remarks>
+    public void ClipLast(RectangleF rect)
+    {
+        if (_segments.Count > 0)
+            _segments[^1].Clip = rect;
+    }
+
+    /// <summary>
+    /// Opens a buffer for the element whose start tag begins at <paramref name="documentOffset"/>.
+    /// The caller fills it; it is placed by offset when the list is flushed.
+    /// </summary>
+    public List<DisplayItem> Open(int documentOffset)
+    {
+        var items = new List<DisplayItem>();
+        _segments.Add(new Segment(documentOffset, _segments.Count, items));
+        return items;
+    }
+
+    /// <summary>Appends every segment to <paramref name="destination"/> in document order.</summary>
+    public void Flush(List<DisplayItem> destination)
+    {
+        // List.Sort is unstable, so the open sequence is part of the key rather than relied on.
+        _segments.Sort(static (a, b) =>
+            a.Offset != b.Offset ? a.Offset.CompareTo(b.Offset) : a.Sequence.CompareTo(b.Sequence));
+
+        foreach (var segment in _segments)
+        {
+            if (segment.Items.Count == 0)
+                continue;
+
+            if (segment.Clip is not { } clip)
+            {
+                destination.AddRange(segment.Items);
+                continue;
+            }
+
+            destination.Add(new ClipItem { Bounds = clip, ClipRect = clip });
+            destination.AddRange(segment.Items);
+            destination.Add(new RestoreItem { Bounds = clip });
+        }
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/IR/SvgPathData.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgPathData.cs
@@ -1,0 +1,496 @@
+#nullable disable
+using System.Drawing;
+using System.Globalization;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// Flattens an SVG <c>&lt;path&gt;</c>'s <c>d</c> attribute into straight-line subpaths.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>&lt;path&gt;</c> is the commonest shape in SVG and the renderer drew <em>none</em> of them:
+/// the only pass over <c>&lt;path&gt;</c> harvested each one's start point so a
+/// <c>&lt;textPath&gt;</c> could be positioned, and there is no path display item for a backend to
+/// draw. Flattening to polylines reuses <see cref="DrawSvgPolygonItem"/> and
+/// <see cref="DrawSvgPolylineItem"/>, which the raster backend already fills and strokes, so path
+/// support needs no new backend primitive.
+/// </para>
+/// <para>
+/// The output is in the path's own user units; the caller maps it to page space, which is why the
+/// curve subdivision is length-based rather than pixel-based — the scale is not known here. The
+/// segment counts are chosen so that a curve spanning a whole 480-unit view box is smooth at the
+/// sizes WPT renders at.
+/// </para>
+/// </remarks>
+internal static class SvgPathData
+{
+    /// <summary>One subpath: the points it visits, and whether a <c>Z</c> closed it.</summary>
+    internal readonly record struct SubPath(List<PointF> Points, bool Closed);
+
+    /// <summary>Shortest curve subdivision, so even a tiny curve is not a single chord.</summary>
+    private const int MinCurveSegments = 8;
+
+    /// <summary>Longest curve subdivision, bounding the work one pathological path can cause.</summary>
+    private const int MaxCurveSegments = 96;
+
+    /// <summary>
+    /// Parses <paramref name="d"/> and returns its subpaths. Returns an empty list for markup this
+    /// cannot follow, so an unparseable path draws nothing rather than drawing something wrong.
+    /// </summary>
+    public static List<SubPath> Flatten(string d)
+    {
+        var result = new List<SubPath>();
+        if (string.IsNullOrWhiteSpace(d))
+            return result;
+
+        var reader = new Reader(d);
+        List<PointF> current = null;
+
+        // The current point, the subpath's start (where Z returns to), and the previous segment's
+        // second control point — which S and T reflect to get their implied one (SVG 1.1 §8.3.6).
+        float cx = 0, cy = 0, startX = 0, startY = 0;
+        float lastControlX = 0, lastControlY = 0;
+        char lastCommand = '\0';
+
+        void Begin(float x, float y)
+        {
+            Flush(false);
+            current = [new PointF(x, y)];
+            startX = x;
+            startY = y;
+        }
+
+        void Flush(bool closed)
+        {
+            if (current is { Count: > 1 })
+                result.Add(new SubPath(current, closed));
+            current = null;
+        }
+
+        void LineTo(float x, float y)
+        {
+            // A path may begin with a command other than M; SVG treats that as an error, but a
+            // subpath rooted at the origin is closer to the intent than dropping the whole path.
+            current ??= [new PointF(cx, cy)];
+            current.Add(new PointF(x, y));
+        }
+
+        while (reader.TryReadCommand(out char command))
+        {
+            bool relative = char.IsLower(command);
+            char kind = char.ToUpperInvariant(command);
+
+            // Z takes no parameters; every other command takes at least one parameter set, and
+            // repeats for as many further sets as follow it.
+            if (kind == 'Z')
+            {
+                if (current is { Count: > 1 })
+                {
+                    Flush(true);
+                    cx = startX;
+                    cy = startY;
+                }
+
+                lastCommand = kind;
+                continue;
+            }
+
+            bool first = true;
+            while (true)
+            {
+                if (!reader.PeekIsNumber())
+                {
+                    // A command letter with no parameters at all is malformed; one that has already
+                    // consumed a set has simply run out of repeats.
+                    break;
+                }
+
+                switch (kind)
+                {
+                    case 'M':
+                    {
+                        if (!reader.TryReadPoint(out float x, out float y))
+                            goto done;
+
+                        if (relative) { x += cx; y += cy; }
+
+                        // Only the first pair of an M is a moveto; the rest are implicit linetos
+                        // into the same subpath (SVG 1.1 §8.3.2).
+                        if (first)
+                            Begin(x, y);
+                        else
+                            LineTo(x, y);
+
+                        cx = x; cy = y;
+                        break;
+                    }
+
+                    case 'L':
+                    {
+                        if (!reader.TryReadPoint(out float x, out float y))
+                            goto done;
+
+                        if (relative) { x += cx; y += cy; }
+                        LineTo(x, y);
+                        cx = x; cy = y;
+                        break;
+                    }
+
+                    case 'H':
+                    {
+                        if (!reader.TryReadNumber(out float x))
+                            goto done;
+
+                        if (relative) x += cx;
+                        LineTo(x, cy);
+                        cx = x;
+                        break;
+                    }
+
+                    case 'V':
+                    {
+                        if (!reader.TryReadNumber(out float y))
+                            goto done;
+
+                        if (relative) y += cy;
+                        LineTo(cx, y);
+                        cy = y;
+                        break;
+                    }
+
+                    case 'C':
+                    case 'S':
+                    {
+                        float x1, y1;
+                        if (kind == 'C')
+                        {
+                            if (!reader.TryReadPoint(out x1, out y1))
+                                goto done;
+                            if (relative) { x1 += cx; y1 += cy; }
+                        }
+                        else
+                        {
+                            // S implies the reflection of the previous cubic's second control point
+                            // about the current point; after anything else it is the current point.
+                            bool reflect = lastCommand is 'C' or 'S';
+                            x1 = reflect ? 2 * cx - lastControlX : cx;
+                            y1 = reflect ? 2 * cy - lastControlY : cy;
+                        }
+
+                        if (!reader.TryReadPoint(out float x2, out float y2)
+                            || !reader.TryReadPoint(out float x, out float y))
+                        {
+                            goto done;
+                        }
+
+                        if (relative) { x2 += cx; y2 += cy; x += cx; y += cy; }
+
+                        AppendCubic(ref current, cx, cy, x1, y1, x2, y2, x, y);
+                        lastControlX = x2; lastControlY = y2;
+                        cx = x; cy = y;
+                        lastCommand = kind;
+                        break;
+                    }
+
+                    case 'Q':
+                    case 'T':
+                    {
+                        float qx, qy;
+                        if (kind == 'Q')
+                        {
+                            if (!reader.TryReadPoint(out qx, out qy))
+                                goto done;
+                            if (relative) { qx += cx; qy += cy; }
+                        }
+                        else
+                        {
+                            bool reflect = lastCommand is 'Q' or 'T';
+                            qx = reflect ? 2 * cx - lastControlX : cx;
+                            qy = reflect ? 2 * cy - lastControlY : cy;
+                        }
+
+                        if (!reader.TryReadPoint(out float x, out float y))
+                            goto done;
+
+                        if (relative) { x += cx; y += cy; }
+
+                        AppendQuadratic(ref current, cx, cy, qx, qy, x, y);
+                        lastControlX = qx; lastControlY = qy;
+                        cx = x; cy = y;
+                        lastCommand = kind;
+                        break;
+                    }
+
+                    case 'A':
+                    {
+                        if (!reader.TryReadNumber(out float rx)
+                            || !reader.TryReadNumber(out float ry)
+                            || !reader.TryReadNumber(out float rotation)
+                            || !reader.TryReadFlag(out bool largeArc)
+                            || !reader.TryReadFlag(out bool sweep)
+                            || !reader.TryReadPoint(out float x, out float y))
+                        {
+                            goto done;
+                        }
+
+                        if (relative) { x += cx; y += cy; }
+
+                        AppendArc(ref current, cx, cy, rx, ry, rotation, largeArc, sweep, x, y);
+                        cx = x; cy = y;
+                        break;
+                    }
+
+                    default:
+                        // An unknown command letter: the rest of the data is unreliable, so stop
+                        // rather than mis-attribute its numbers to the wrong command.
+                        goto done;
+                }
+
+                if (kind is not ('C' or 'S' or 'Q' or 'T'))
+                    lastCommand = kind;
+
+                first = false;
+            }
+        }
+
+    done:
+        Flush(false);
+        return result;
+
+        void AppendCubic(
+            ref List<PointF> points, float x0, float y0,
+            float x1, float y1, float x2, float y2, float x3, float y3)
+        {
+            points ??= [new PointF(x0, y0)];
+            int steps = SegmentsFor(
+                Distance(x0, y0, x1, y1) + Distance(x1, y1, x2, y2) + Distance(x2, y2, x3, y3));
+
+            for (int i = 1; i <= steps; i++)
+            {
+                float t = (float)i / steps;
+                float u = 1 - t;
+                float a = u * u * u, b = 3 * u * u * t, c = 3 * u * t * t, e = t * t * t;
+                points.Add(new PointF(
+                    a * x0 + b * x1 + c * x2 + e * x3,
+                    a * y0 + b * y1 + c * y2 + e * y3));
+            }
+        }
+
+        void AppendQuadratic(
+            ref List<PointF> points, float x0, float y0, float qx, float qy, float x1, float y1)
+        {
+            points ??= [new PointF(x0, y0)];
+            int steps = SegmentsFor(Distance(x0, y0, qx, qy) + Distance(qx, qy, x1, y1));
+
+            for (int i = 1; i <= steps; i++)
+            {
+                float t = (float)i / steps;
+                float u = 1 - t;
+                points.Add(new PointF(
+                    u * u * x0 + 2 * u * t * qx + t * t * x1,
+                    u * u * y0 + 2 * u * t * qy + t * t * y1));
+            }
+        }
+
+        // SVG 1.1 §F.6.5: the endpoint parameterisation the `A` command uses converted to the
+        // centre parameterisation the sampling needs.
+        void AppendArc(
+            ref List<PointF> points, float x0, float y0,
+            float rx, float ry, float rotationDegrees, bool largeArc, bool sweep, float x1, float y1)
+        {
+            points ??= [new PointF(x0, y0)];
+
+            // Out-of-range radii: zero means a straight line, negatives take their magnitude
+            // (§F.6.6), and radii too small to span the endpoints are scaled up until they fit.
+            rx = Math.Abs(rx);
+            ry = Math.Abs(ry);
+            if (rx == 0 || ry == 0 || (x0 == x1 && y0 == y1))
+            {
+                points.Add(new PointF(x1, y1));
+                return;
+            }
+
+            double phi = rotationDegrees * Math.PI / 180.0;
+            double cosPhi = Math.Cos(phi), sinPhi = Math.Sin(phi);
+
+            double dx2 = (x0 - x1) / 2.0, dy2 = (y0 - y1) / 2.0;
+            double x1p = cosPhi * dx2 + sinPhi * dy2;
+            double y1p = -sinPhi * dx2 + cosPhi * dy2;
+
+            double lambda = (x1p * x1p) / (rx * rx) + (y1p * y1p) / (ry * ry);
+            if (lambda > 1)
+            {
+                double scale = Math.Sqrt(lambda);
+                rx = (float)(rx * scale);
+                ry = (float)(ry * scale);
+            }
+
+            double sign = largeArc == sweep ? -1 : 1;
+            double numerator = rx * rx * ry * ry - rx * rx * y1p * y1p - ry * ry * x1p * x1p;
+            double denominator = rx * rx * y1p * y1p + ry * ry * x1p * x1p;
+            double coefficient = denominator == 0 ? 0 : sign * Math.Sqrt(Math.Max(0, numerator / denominator));
+
+            double cxp = coefficient * rx * y1p / ry;
+            double cyp = -coefficient * ry * x1p / rx;
+
+            double centreX = cosPhi * cxp - sinPhi * cyp + (x0 + x1) / 2.0;
+            double centreY = sinPhi * cxp + cosPhi * cyp + (y0 + y1) / 2.0;
+
+            double startAngle = Angle(1, 0, (x1p - cxp) / rx, (y1p - cyp) / ry);
+            double sweepAngle = Angle(
+                (x1p - cxp) / rx, (y1p - cyp) / ry, (-x1p - cxp) / rx, (-y1p - cyp) / ry);
+
+            if (!sweep && sweepAngle > 0)
+                sweepAngle -= 2 * Math.PI;
+            else if (sweep && sweepAngle < 0)
+                sweepAngle += 2 * Math.PI;
+
+            int steps = SegmentsFor((float)(Math.Abs(sweepAngle) * Math.Max(rx, ry)));
+            for (int i = 1; i <= steps; i++)
+            {
+                double angle = startAngle + sweepAngle * i / steps;
+                double px = rx * Math.Cos(angle), py = ry * Math.Sin(angle);
+                points.Add(new PointF(
+                    (float)(cosPhi * px - sinPhi * py + centreX),
+                    (float)(sinPhi * px + cosPhi * py + centreY)));
+            }
+        }
+    }
+
+    /// <summary>The angle from one vector to another, signed, as §F.6.5's <c>θ</c> function.</summary>
+    private static double Angle(double ux, double uy, double vx, double vy)
+    {
+        double dot = ux * vx + uy * vy;
+        double lengths = Math.Sqrt((ux * ux + uy * uy) * (vx * vx + vy * vy));
+        if (lengths == 0)
+            return 0;
+
+        double angle = Math.Acos(Math.Clamp(dot / lengths, -1.0, 1.0));
+        return ux * vy - uy * vx < 0 ? -angle : angle;
+    }
+
+    private static float Distance(float x0, float y0, float x1, float y1)
+        => MathF.Sqrt((x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0));
+
+    /// <summary>How many chords a curve of the given rough length is flattened into.</summary>
+    private static int SegmentsFor(float length)
+        => Math.Clamp((int)MathF.Ceiling(length / 2f), MinCurveSegments, MaxCurveSegments);
+
+    /// <summary>
+    /// A reader over path data. Numbers may run together without separators
+    /// (<c>10-20</c>, <c>.5.5</c>) and the arc flags are single digits that need no separator at
+    /// all, so the scanning is done here rather than by splitting on whitespace and commas.
+    /// </summary>
+    private sealed class Reader(string text)
+    {
+        private readonly string _text = text;
+        private int _index;
+
+        private void SkipSeparators()
+        {
+            while (_index < _text.Length && (char.IsWhiteSpace(_text[_index]) || _text[_index] == ','))
+                _index++;
+        }
+
+        public bool TryReadCommand(out char command)
+        {
+            SkipSeparators();
+            if (_index < _text.Length && char.IsLetter(_text[_index]))
+            {
+                command = _text[_index++];
+                return true;
+            }
+
+            command = '\0';
+            return false;
+        }
+
+        /// <summary>Whether a number starts here, without consuming it.</summary>
+        public bool PeekIsNumber()
+        {
+            SkipSeparators();
+            if (_index >= _text.Length)
+                return false;
+
+            char c = _text[_index];
+            return char.IsAsciiDigit(c) || c is '-' or '+' or '.';
+        }
+
+        public bool TryReadNumber(out float value)
+        {
+            SkipSeparators();
+            value = 0;
+            int start = _index;
+
+            if (_index < _text.Length && (_text[_index] == '-' || _text[_index] == '+'))
+                _index++;
+
+            while (_index < _text.Length && char.IsAsciiDigit(_text[_index]))
+                _index++;
+
+            if (_index < _text.Length && _text[_index] == '.')
+            {
+                _index++;
+                while (_index < _text.Length && char.IsAsciiDigit(_text[_index]))
+                    _index++;
+            }
+
+            // An exponent only counts when digits actually follow it, so the `e` of a stray token is
+            // not swallowed into the number.
+            if (_index < _text.Length && (_text[_index] == 'e' || _text[_index] == 'E'))
+            {
+                int save = _index;
+                _index++;
+                if (_index < _text.Length && (_text[_index] == '-' || _text[_index] == '+'))
+                    _index++;
+
+                if (_index < _text.Length && char.IsAsciiDigit(_text[_index]))
+                {
+                    while (_index < _text.Length && char.IsAsciiDigit(_text[_index]))
+                        _index++;
+                }
+                else
+                {
+                    _index = save;
+                }
+            }
+
+            if (_index == start)
+                return false;
+
+            if (float.TryParse(
+                _text.AsSpan(start, _index - start), NumberStyles.Float, CultureInfo.InvariantCulture,
+                out value))
+            {
+                return true;
+            }
+
+            value = 0;
+            return false;
+        }
+
+        public bool TryReadPoint(out float x, out float y)
+        {
+            y = 0;
+            return TryReadNumber(out x) && TryReadNumber(out y);
+        }
+
+        /// <summary>
+        /// An arc flag: exactly one character, <c>0</c> or <c>1</c>. Read separately because
+        /// <c>a1 1 0 011 1</c> is legal and a general number scan would take <c>011</c> as one value.
+        /// </summary>
+        public bool TryReadFlag(out bool value)
+        {
+            SkipSeparators();
+            if (_index < _text.Length && (_text[_index] == '0' || _text[_index] == '1'))
+            {
+                value = _text[_index++] == '1';
+                return true;
+            }
+
+            value = false;
+            return false;
+        }
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Text.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Text.cs
@@ -52,6 +52,15 @@ internal static partial class SvgRenderer
             return false;
         }
 
+        // Inside a nested <svg> the element belongs to that viewport's own coordinate system, and
+        // the nested-viewport pass renders it there. Drawing it here as well would put a second copy
+        // on the canvas at the outer scale.
+        if (structure.IsInNestedViewport(match.Index))
+        {
+            attrs = null;
+            return false;
+        }
+
         attrs = ParseAttributes(match.Groups[1].Value);
         if (inherited != null)
         {
@@ -81,7 +90,7 @@ internal static partial class SvgRenderer
     /// </para>
     /// </remarks>
     private static void EmitTextElements(
-        string svgXml, RectangleF bounds, List<DisplayItem> items, SvgStructure structure,
+        string svgXml, RectangleF bounds, SvgPaintOrder order, SvgStructure structure,
         float sx, float sy, float tx, float ty, float pctW, float pctH, float pctD)
     {
         foreach (Match m in TextElementRegex().Matches(svgXml))
@@ -96,6 +105,7 @@ internal static partial class SvgRenderer
             if (text.Length == 0)
                 continue;
 
+            var items = order.Open(m.Index);
             float scale = Math.Max(sx, sy);
             float fontSize = GetLength(attrs, "font-size", pctD, 16) * scale;
             var font = ResolveFont(attrs, fontSize);

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Use.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Use.cs
@@ -23,7 +23,7 @@ internal static partial class SvgRenderer
 
     /// <summary>Draws every <c>&lt;use&gt;</c> that paints where it stands.</summary>
     private static void EmitUseElements(
-        string svgXml, RectangleF bounds, List<DisplayItem> items, SvgStructure structure,
+        string svgXml, RectangleF bounds, SvgPaintOrder order, SvgStructure structure,
         float sx, float sy, float tx, float ty, float pctW, float pctH)
     {
         if (_useDepth >= MaxUseDepth
@@ -54,6 +54,7 @@ internal static partial class SvgRenderer
                 target.Name.Equals("symbol", StringComparison.OrdinalIgnoreCase)
                 || target.Name.Equals("svg", StringComparison.OrdinalIgnoreCase);
 
+            var items = order.Open(m.Index);
             var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
             _useDepth++;
             try

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Viewport.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Viewport.cs
@@ -1,0 +1,143 @@
+#nullable disable
+using System.Drawing;
+using System.Text;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// The nested <c>&lt;svg&gt;</c> element, which establishes a viewport of its own.
+/// </summary>
+/// <remarks>
+/// SVG 1.1 §7.2: an <c>&lt;svg&gt;</c> inside another one gives its children a new viewport at its
+/// <c>x</c>/<c>y</c>/<c>width</c>/<c>height</c>, with its own <c>viewBox</c> mapping. The renderer's
+/// shape passes sweep the whole markup and knew only the root's mapping, so the children of a
+/// nested <c>&lt;svg&gt;</c> were drawn at the root's scale and origin — the six panels of
+/// <c>conformance-checkers/html-svg/coords-viewattr-03-b</c> all landed on the first one, and
+/// <c>struct-image-02-b</c>'s aqua panel filled the canvas instead of its own quarter of it.
+/// </remarks>
+internal static partial class SvgRenderer
+{
+    /// <summary>How deep nested viewports are followed before the recursion is cut off.</summary>
+    private const int MaxViewportDepth = 6;
+
+    [ThreadStatic]
+    private static int _viewportDepth;
+
+    /// <summary>Renders each nested <c>&lt;svg&gt;</c>'s content into the viewport it establishes.</summary>
+    private static void EmitNestedViewports(
+        string svgXml, RectangleF bounds, SvgPaintOrder order, SvgStructure structure,
+        float sx, float sy, float tx, float ty, float pctW, float pctH)
+    {
+        if (structure.NestedViewports.Count == 0 || _viewportDepth >= MaxViewportDepth)
+            return;
+
+        // A reference inside a nested viewport may point at a definition declared outside it, so the
+        // enclosing document's <clipPath>s travel with the content into its own document — where the
+        // recursive scan is the only thing that can resolve them.
+        string definitions = CollectReferencedDefinitions(svgXml);
+
+        foreach (var viewport in structure.NestedViewports)
+        {
+            // A viewport inside another one is rendered by that one's own recursive pass, not twice
+            // from here.
+            if (structure.IsInNestedViewport(viewport.Index))
+                continue;
+
+            string content = viewport.Content;
+            if (string.IsNullOrWhiteSpace(content))
+                continue;
+
+            var attrs = new Dictionary<string, string>(viewport.Attributes, StringComparer.OrdinalIgnoreCase);
+
+            // SVG 1.1 §7.2: x/y default to 0 and width/height to 100% of the enclosing viewport.
+            float x = GetLength(attrs, "x", pctW);
+            float y = GetLength(attrs, "y", pctH);
+            float width = attrs.ContainsKey("width") ? GetLength(attrs, "width", pctW) : pctW;
+            float height = attrs.ContainsKey("height") ? GetLength(attrs, "height", pctH) : pctH;
+            if (width <= 0 || height <= 0)
+                continue;
+
+            var destination = new RectangleF(
+                bounds.X + x * sx + tx, bounds.Y + y * sy + ty, width * sx, height * sy);
+
+            // With no viewBox the child user space is the viewport's own, which a view box matching
+            // it expresses exactly — the same equivalence EmitSymbolUse relies on.
+            string viewBox = attrs.GetValueOrDefault("viewBox");
+            if (string.IsNullOrWhiteSpace(viewBox))
+                viewBox = FormattableString.Invariant($"0 0 {width} {height}");
+
+            var items = order.Open(viewport.Index);
+            _viewportDepth++;
+            try
+            {
+                AddMapped(
+                    items,
+                    RenderSvgContent(
+                        WrapViewportDocument(viewBox, attrs.GetValueOrDefault("preserveAspectRatio"),
+                            viewport.Inherited, definitions, content),
+                        destination),
+                    structure.TransformAt(viewport.Index).ToPageSpace(sx, sy, bounds.X + tx, bounds.Y + ty));
+            }
+            finally
+            {
+                _viewportDepth--;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The nested viewport's content as a standalone document: a root <c>&lt;svg&gt;</c> carrying
+    /// the view-box mapping, and the presentation attributes in force outside it so its content
+    /// keeps inheriting them across the boundary.
+    /// </summary>
+    private static string WrapViewportDocument(
+        string viewBox, string preserveAspectRatio,
+        IReadOnlyDictionary<string, string> inherited, string definitions, string content)
+    {
+        var sb = new StringBuilder("<svg viewBox=\"").Append(viewBox).Append('"');
+
+        if (!string.IsNullOrWhiteSpace(preserveAspectRatio))
+            sb.Append(" preserveAspectRatio=\"").Append(preserveAspectRatio).Append('"');
+
+        if (inherited != null)
+        {
+            foreach (var (property, value) in inherited)
+            {
+                // A value holding a double quote came from single-quoted source; it would need
+                // escaping to survive re-serialisation, and dropping it only loses an inherited
+                // default the content can still declare for itself.
+                if (value.IndexOf('"') >= 0)
+                    continue;
+
+                sb.Append(' ').Append(property).Append("=\"").Append(value).Append('"');
+            }
+        }
+
+        sb.Append('>');
+
+        if (!string.IsNullOrEmpty(definitions))
+            sb.Append("<defs>").Append(definitions).Append("</defs>");
+
+        return sb.Append(content).Append("</svg>").ToString();
+    }
+
+    /// <summary>
+    /// The enclosing document's <c>&lt;clipPath&gt;</c> definitions, concatenated, so a nested
+    /// viewport rendered as its own document can still resolve a <c>clip-path</c> that points at
+    /// one of them. Returns an empty string when there are none, which is the usual case.
+    /// </summary>
+    private static string CollectReferencedDefinitions(string svgXml)
+    {
+        if (string.IsNullOrEmpty(svgXml)
+            || svgXml.IndexOf("<clippath", StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        foreach (System.Text.RegularExpressions.Match cm in ClipPathBlockRegex().Matches(svgXml))
+            sb.Append(cm.Value);
+
+        return sb.ToString();
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
@@ -33,8 +33,12 @@ internal static partial class SvgRenderer
         return items;
     }
 
-    private static void ParseElements(string svgXml, RectangleF bounds, List<DisplayItem> items, double effectiveZoom)
+    private static void ParseElements(string svgXml, RectangleF bounds, List<DisplayItem> output, double effectiveZoom)
     {
+        // Each element's items are collected against its start-tag offset and flushed in document
+        // order at the end, because the per-shape passes below each sweep the whole markup and would
+        // otherwise paint every rect before every circle before every text. See SvgPaintOrder.
+        var order = new SvgPaintOrder();
         // Parse the viewBox from the root <svg> element to compute the
         // coordinate transform.  When a viewBox is present, SVG coordinates
         // are in viewBox space and must be scaled/translated to CSS bounds.
@@ -44,6 +48,11 @@ internal static partial class SvgRenderer
         // 1:1 to CSS pixels, so they must scale by zoom like any other used length. A viewBox overrides
         // this below with a scale derived from the (already-zoomed) bounds, so it is not compounded.
         float sx = (float)effectiveZoom, sy = (float)effectiveZoom, tx = 0f, ty = 0f;
+        // How many device pixels one unit of the *viewport* coordinate system is — the basis a
+        // non-scaling stroke is drawn in (SVG 2 §14.2), which is the user-unit scale only when no
+        // view box remaps it. Derived below from the root's declared width against the box it was
+        // laid out into, so a CSS zoom or a width in other units is already folded in.
+        float viewportScale = (float)effectiveZoom;
         // The viewport a percentage length resolves against, in user units (SVG 1.1 §7.10). Zero until
         // a viewBox establishes one; the fallback below derives it from the bounds instead.
         float viewportW = 0f, viewportH = 0f;
@@ -52,6 +61,21 @@ internal static partial class SvgRenderer
         if (svgMatch.Success)
         {
             var svgAttrs = ParseAttributes(svgMatch.Groups[1].Value);
+
+            // A declared width names the viewport in its own units; the box it was laid out into is
+            // that viewport in device pixels, so their ratio is the viewport scale. A percentage or
+            // absent width leaves the zoom-derived seed, since neither states a unit count.
+            if (svgAttrs.TryGetValue("width", out var declaredWidth)
+                && !declaredWidth.Contains('%')
+                && float.TryParse(
+                    declaredWidth.Replace("px", string.Empty), NumberStyles.Float,
+                    CultureInfo.InvariantCulture, out float widthUnits)
+                && widthUnits > 0
+                && bounds.Width > 0)
+            {
+                viewportScale = bounds.Width / widthUnits;
+            }
+
             if (svgAttrs.TryGetValue("viewBox", out var vb))
             {
                 var parts = vb.Split([' ', ',', '\t', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries);
@@ -99,6 +123,9 @@ internal static partial class SvgRenderer
         // rendered part: a <pattern> lives in <defs> precisely so it paints only through a reference.
         var patterns = CollectPatterns(svgXml);
 
+        // The <clipPath> rectangles a shape's own clip-path attribute may point at.
+        var clipRects = CollectClipRects(svgXml);
+
         foreach (Match m in ParseSvgRegex().Matches(svgXml))
         {
             var attrs = ParseAttributes(m.Groups[1].Value);
@@ -116,7 +143,10 @@ internal static partial class SvgRenderer
             if (!TryResolveElement(structure, m, out var attrs))
                 continue;
 
+            var items = order.Open(m.Index);
             var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+            if (ClipRectFor(attrs, clipRects, bounds, sx, sy, tx, ty, elementTransform) is { } clip)
+                order.ClipLast(clip);
 
             // A rect referencing an feFlood filter is replaced by a solid fill of the flood colour
             // over the filter region — the default objectBoundingBox region is the shape's bounding
@@ -165,7 +195,7 @@ internal static partial class SvgRenderer
                 Height = GetLength(attrs, "height", pctH) * sy,
                 Fill = rectFill,
                 Stroke = rectStroke,
-                StrokeWidth = GetLength(attrs, "stroke-width", pctD, 1) * Math.Max(sx, sy),
+                StrokeWidth = StrokeWidthOf(attrs, pctD, sx, sy, viewportScale),
             });
         }
 
@@ -175,7 +205,10 @@ internal static partial class SvgRenderer
             if (!TryResolveElement(structure, m, out var attrs))
                 continue;
 
+            var items = order.Open(m.Index);
             var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+            if (ClipRectFor(attrs, clipRects, bounds, sx, sy, tx, ty, elementTransform) is { } clip)
+                order.ClipLast(clip);
 
             float r = GetLength(attrs, "r", pctD);
             AddShape(items, bounds, attrs, elementTransform, new DrawSvgEllipseItem
@@ -187,7 +220,7 @@ internal static partial class SvgRenderer
                 Ry = r * sy,
                 Fill = ResolveFillWithoutPattern(attrs, BColor.Black),
                 Stroke = GetPaint(attrs, "stroke", BColor.Empty),
-                StrokeWidth = GetLength(attrs, "stroke-width", pctD, 1) * Math.Max(sx, sy),
+                StrokeWidth = StrokeWidthOf(attrs, pctD, sx, sy, viewportScale),
             });
         }
 
@@ -197,7 +230,10 @@ internal static partial class SvgRenderer
             if (!TryResolveElement(structure, m, out var attrs))
                 continue;
 
+            var items = order.Open(m.Index);
             var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+            if (ClipRectFor(attrs, clipRects, bounds, sx, sy, tx, ty, elementTransform) is { } clip)
+                order.ClipLast(clip);
 
             AddShape(items, bounds, attrs, elementTransform, new DrawSvgEllipseItem
             {
@@ -208,7 +244,7 @@ internal static partial class SvgRenderer
                 Ry = GetLength(attrs, "ry", pctH) * sy,
                 Fill = ResolveFillWithoutPattern(attrs, BColor.Black),
                 Stroke = GetPaint(attrs, "stroke", BColor.Empty),
-                StrokeWidth = GetLength(attrs, "stroke-width", pctD, 1) * Math.Max(sx, sy),
+                StrokeWidth = StrokeWidthOf(attrs, pctD, sx, sy, viewportScale),
             });
         }
 
@@ -218,7 +254,10 @@ internal static partial class SvgRenderer
             if (!TryResolveElement(structure, m, out var attrs))
                 continue;
 
+            var items = order.Open(m.Index);
             var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+            if (ClipRectFor(attrs, clipRects, bounds, sx, sy, tx, ty, elementTransform) is { } clip)
+                order.ClipLast(clip);
 
             AddShape(items, bounds, attrs, elementTransform, new DrawSvgLineItem
             {
@@ -228,7 +267,7 @@ internal static partial class SvgRenderer
                 X2 = GetLength(attrs, "x2", pctW) * sx + tx,
                 Y2 = GetLength(attrs, "y2", pctH) * sy + ty,
                 Stroke = GetPaint(attrs, "stroke", BColor.Black),
-                StrokeWidth = GetLength(attrs, "stroke-width", pctD, 1) * Math.Max(sx, sy),
+                StrokeWidth = StrokeWidthOf(attrs, pctD, sx, sy, viewportScale),
             });
         }
 
@@ -237,7 +276,10 @@ internal static partial class SvgRenderer
             if (!TryResolveElement(structure, m, out var attrs))
                 continue;
 
+            var items = order.Open(m.Index);
             var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+            if (ClipRectFor(attrs, clipRects, bounds, sx, sy, tx, ty, elementTransform) is { } clip)
+                order.ClipLast(clip);
 
             AddShape(items, bounds, attrs, elementTransform, new DrawSvgPolygonItem
             {
@@ -245,7 +287,7 @@ internal static partial class SvgRenderer
                 Points = ParsePoints(attrs.GetValueOrDefault("points") ?? string.Empty, sx, sy, tx, ty),
                 Fill = ResolveFillWithoutPattern(attrs, BColor.Black),
                 Stroke = GetPaint(attrs, "stroke", BColor.Empty),
-                StrokeWidth = GetLength(attrs, "stroke-width", pctD, 1) * Math.Max(sx, sy),
+                StrokeWidth = StrokeWidthOf(attrs, pctD, sx, sy, viewportScale),
             });
         }
 
@@ -254,7 +296,10 @@ internal static partial class SvgRenderer
             if (!TryResolveElement(structure, m, out var attrs))
                 continue;
 
+            var items = order.Open(m.Index);
             var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+            if (ClipRectFor(attrs, clipRects, bounds, sx, sy, tx, ty, elementTransform) is { } clip)
+                order.ClipLast(clip);
 
             AddShape(items, bounds, attrs, elementTransform, new DrawSvgPolylineItem
             {
@@ -262,8 +307,81 @@ internal static partial class SvgRenderer
                 Points = ParsePoints(attrs.GetValueOrDefault("points") ?? string.Empty, sx, sy, tx, ty),
                 Fill = ResolveFillWithoutPattern(attrs, BColor.Empty),
                 Stroke = GetPaint(attrs, "stroke", BColor.Empty),
-                StrokeWidth = GetLength(attrs, "stroke-width", pctD, 1) * Math.Max(sx, sy),
+                StrokeWidth = StrokeWidthOf(attrs, pctD, sx, sy, viewportScale),
             });
+        }
+
+        // <path d="..." />
+        foreach (Match m in PathElementRegex().Matches(svgXml))
+        {
+            if (!TryResolveElement(structure, m, out var attrs))
+                continue;
+
+            var subPaths = SvgPathData.Flatten(attrs.GetValueOrDefault("d"));
+            if (subPaths.Count == 0)
+                continue;
+
+            var items = order.Open(m.Index);
+            var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+            if (ClipRectFor(attrs, clipRects, bounds, sx, sy, tx, ty, elementTransform) is { } pathClip)
+                order.ClipLast(pathClip);
+
+            var pathFill = ResolveFillWithoutPattern(attrs, BColor.Black);
+            var pathStroke = GetPaint(attrs, "stroke", BColor.Empty);
+            float pathStrokeWidth = StrokeWidthOf(attrs, pctD, sx, sy, viewportScale);
+
+            var mapped = new List<List<PointF>>(subPaths.Count);
+            foreach (var subPath in subPaths)
+            {
+                var points = new List<PointF>(subPath.Points.Count);
+                foreach (var point in subPath.Points)
+                    points.Add(new PointF(point.X * sx + tx, point.Y * sy + ty));
+                mapped.Add(points);
+            }
+
+            // The whole path fills as one shape, so its subpaths go into a single polygon rather
+            // than one each: the rasterizer's fill is an even-odd crossing test, which gives a
+            // subpath enclosed by another the hole SVG's fill rules ask for, where separate opaque
+            // polygons would paint over it. Filling each one alone turned the three overlapping
+            // rings of conformance-checkers/html-svg/coords-viewattr-03-b into a solid blob.
+            if (!pathFill.IsEmpty && pathFill.A > 0)
+            {
+                AddShape(items, bounds, attrs, elementTransform, new DrawSvgPolygonItem
+                {
+                    Bounds = bounds,
+                    Points = StitchSubPaths(mapped),
+                    Fill = pathFill,
+                    Stroke = BColor.Empty,
+                    StrokeWidth = 0,
+                });
+            }
+
+            if (pathStroke.IsEmpty || pathStroke.A == 0 || pathStrokeWidth <= 0)
+                continue;
+
+            // The stroke, by contrast, is per subpath: it follows each one's own outline, and only
+            // a subpath that Z closed is stroked all the way round — which is the difference
+            // between the polygon item and the polyline item.
+            for (int i = 0; i < mapped.Count; i++)
+            {
+                AddShape(items, bounds, attrs, elementTransform, subPaths[i].Closed
+                    ? new DrawSvgPolygonItem
+                    {
+                        Bounds = bounds,
+                        Points = mapped[i],
+                        Fill = BColor.Empty,
+                        Stroke = pathStroke,
+                        StrokeWidth = pathStrokeWidth,
+                    }
+                    : new DrawSvgPolylineItem
+                    {
+                        Bounds = bounds,
+                        Points = mapped[i],
+                        Fill = BColor.Empty,
+                        Stroke = pathStroke,
+                        StrokeWidth = pathStrokeWidth,
+                    });
+            }
         }
 
         // <text ...>content</text>
@@ -285,7 +403,7 @@ internal static partial class SvgRenderer
             float textPathSize = GetLength(attrs, "font-size", pctD, 16) * Math.Max(sx, sy);
             var textPathFont = ResolveFont(attrs, textPathSize);
 
-            items.Add(new DrawSvgTextItem
+            order.Open(m.Index).Add(new DrawSvgTextItem
             {
                 Bounds = bounds,
                 X = start.X * sx + tx,
@@ -300,8 +418,11 @@ internal static partial class SvgRenderer
             });
         }
 
-        EmitTextElements(svgXml, bounds, items, structure, sx, sy, tx, ty, pctW, pctH, pctD);
-        EmitUseElements(svgXml, bounds, items, structure, sx, sy, tx, ty, pctW, pctH);
+        EmitTextElements(svgXml, bounds, order, structure, sx, sy, tx, ty, pctW, pctH, pctD);
+        EmitUseElements(svgXml, bounds, order, structure, sx, sy, tx, ty, pctW, pctH);
+        EmitNestedViewports(svgXml, bounds, order, structure, sx, sy, tx, ty, pctW, pctH);
+
+        order.Flush(output);
     }
 
     /// <summary>
@@ -835,6 +956,139 @@ internal static partial class SvgRenderer
             : defaultValue;
     }
 
+    /// <summary>
+    /// The rectangles the document's <c>&lt;clipPath&gt;</c> definitions clip to, by <c>id</c>, in
+    /// user units — the ones this renderer can express, which is a single <c>&lt;rect&gt;</c> child
+    /// in <c>userSpaceOnUse</c> units.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="CollectClipPaths"/>, which publishes to the document-wide table a
+    /// CSS <c>clip-path</c> on an <em>HTML</em> element reads. This is the SVG side: a
+    /// <c>clip-path</c> attribute on a shape, which nothing honoured — so the black 200×200 rect of
+    /// <c>conformance-checkers/html-svg/masking-path-14-f</c> covered the panel it should have been
+    /// clipped to a corner of.
+    /// </remarks>
+    private static Dictionary<string, RectangleF> CollectClipRects(string svgXml)
+    {
+        if (string.IsNullOrEmpty(svgXml)
+            || svgXml.IndexOf("<clippath", StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return null;
+        }
+
+        Dictionary<string, RectangleF> rects = null;
+        foreach (Match cm in ClipPathBlockRegex().Matches(svgXml))
+        {
+            var clipAttrs = ParseAttributes(cm.Groups[1].Value);
+            if (!clipAttrs.TryGetValue("id", out var id) || string.IsNullOrEmpty(id))
+                continue;
+
+            // objectBoundingBox units would need each referencing shape's own box, which is not
+            // known here; those keep painting unclipped rather than being clipped to the wrong box.
+            if (clipAttrs.TryGetValue("clipPathUnits", out var units)
+                && units.Trim().Equals("objectBoundingBox", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var rectMatch = ParseRectRegex().Match(cm.Groups[2].Value);
+            if (!rectMatch.Success)
+                continue;
+
+            var shapeAttrs = ParseAttributes(rectMatch.Groups[1].Value);
+            float width = GetLength(shapeAttrs, "width", 0);
+            float height = GetLength(shapeAttrs, "height", 0);
+            if (width <= 0 || height <= 0)
+                continue;
+
+            rects ??= new Dictionary<string, RectangleF>(StringComparer.Ordinal);
+            rects[id] = new RectangleF(
+                GetLength(shapeAttrs, "x", 0), GetLength(shapeAttrs, "y", 0), width, height);
+        }
+
+        return rects;
+    }
+
+    /// <summary>
+    /// The page-space region an element's <c>clip-path="url(#id)"</c> narrows its drawing to, or
+    /// <see langword="null"/> when it carries none or the reference cannot be expressed as a rect.
+    /// </summary>
+    private static RectangleF? ClipRectFor(
+        Dictionary<string, string> attrs, Dictionary<string, RectangleF> clipRects,
+        RectangleF bounds, float sx, float sy, float tx, float ty, SvgTransform elementTransform)
+    {
+        if (clipRects == null)
+            return null;
+
+        string clipPath = GetPresentationValue(attrs, "clip-path");
+        if (string.IsNullOrWhiteSpace(clipPath)
+            || !TryParsePaintReference(clipPath, out var id, out _)
+            || !clipRects.TryGetValue(id, out var rect))
+        {
+            return null;
+        }
+
+        return elementTransform.MapBounds(new RectangleF(
+            bounds.X + rect.X * sx + tx, bounds.Y + rect.Y * sy + ty,
+            rect.Width * sx, rect.Height * sy));
+    }
+
+    /// <summary>
+    /// Joins a path's subpaths into the single closed ring the polygon item takes, so an even-odd
+    /// fill over it is the fill of the whole path.
+    /// </summary>
+    /// <remarks>
+    /// Each subpath is closed back to its own start and then followed by a return to the first
+    /// subpath's start. That makes every bridge edge between subpaths appear twice, once in each
+    /// direction, so its crossings cancel and it contributes nothing to the fill — the standard way
+    /// to express a multi-contour region as one ring. Chaining the subpaths end to end instead
+    /// would leave a closing edge that does not retrace any bridge, and it would toggle a spurious
+    /// wedge between them.
+    /// </remarks>
+    private static List<PointF> StitchSubPaths(List<List<PointF>> subPaths)
+    {
+        if (subPaths.Count == 1)
+            return subPaths[0];
+
+        var anchor = subPaths[0][0];
+        var stitched = new List<PointF>();
+
+        foreach (var subPath in subPaths)
+        {
+            stitched.AddRange(subPath);
+            stitched.Add(subPath[0]);
+            stitched.Add(anchor);
+        }
+
+        return stitched;
+    }
+
+    /// <summary>
+    /// A shape's stroke width in page pixels: the declared length taken through the user-unit scale,
+    /// unless <c>vector-effect: non-scaling-stroke</c> holds it at its declared width.
+    /// </summary>
+    /// <remarks>
+    /// SVG 2 §14.2 defines <c>non-scaling-stroke</c> as stroking in the viewport's coordinate system
+    /// rather than the element's, so the user-space scale must not be applied. It only became visible
+    /// once <c>&lt;path&gt;</c> painted at all: <c>svg/painting/reftests/non-scaling-stroke-precision-loss</c>
+    /// draws a hairline under a view box 0.375 units tall over 344 pixels, and scaling its width by
+    /// that 917× factor turns the hairline into a band across the whole canvas.
+    /// </remarks>
+    private static float StrokeWidthOf(
+        Dictionary<string, string> attrs, float pctD, float sx, float sy, float viewportScale)
+    {
+        float declared = GetLength(attrs, "stroke-width", pctD, 1);
+        string effect = GetPresentationValue(attrs, "vector-effect");
+        bool nonScaling = effect != null
+            && effect.Trim().Equals("non-scaling-stroke", StringComparison.OrdinalIgnoreCase);
+
+        // "Non-scaling" means the view box does not scale it, not that nothing does: the stroke is
+        // drawn in the viewport's coordinate system, so it still takes that viewport's own scale.
+        // Dropping it too left non-scaling-stroke-008's 25-unit stroke at half its width, because
+        // the zoom that doubles the viewport applies to the stroke as well.
+        return nonScaling ? declared * viewportScale : declared * Math.Max(sx, sy);
+    }
+
     private static BColor GetColor(Dictionary<string, string> attrs, string name, BColor defaultColor)
     {
         if (!attrs.TryGetValue(name, out var val))
@@ -892,7 +1146,18 @@ internal static partial class SvgRenderer
 
         // Handle named colors
         var named = BColor.FromName(val);
-        return named.IsEmpty ? defaultColor : named;
+        if (!named.IsEmpty)
+            return named;
+
+        // A CSS system color (CSS Color 4 §6) is a <color> keyword like every other, and SVG paint
+        // takes any <color>. The named-color table does not know them, so `fill="Window"` used to
+        // fall through to the caller's default — solid black — and a page built out of them painted
+        // as one black rectangle. Consulted after the named lookup so the two names CSS and X11
+        // share keep their named-color meaning.
+        if (Broiler.CSS.CssSystemColors.TryResolve(val, out var system))
+            return BColor.FromArgb(system.Alpha, system.Red, system.Green, system.Blue);
+
+        return defaultColor;
     }
 
     private static bool TryParseHexColor(string val, out BColor color)
@@ -925,6 +1190,14 @@ internal static partial class SvgRenderer
     
     [GeneratedRegex(@"<path\s+([^/>]*)/?>", RegexOptions.IgnoreCase)]
     private static partial Regex ParseSvgRegex();
+
+    /// <summary>
+    /// A <c>&lt;path&gt;</c> element. Quote-aware, unlike <see cref="ParseSvgRegex"/>, which stops
+    /// at the first <c>/</c> — and so misses any path whose <c>d</c> holds one, as an
+    /// <c>a</c> (arc) command written <c>a5,5 0 0 1 …</c> does not but a <c>url(…)</c> paint does.
+    /// </summary>
+    [GeneratedRegex(@"<path\b((?:[^>""']|""[^""]*""|'[^']*')*?)/?>", RegexOptions.IgnoreCase)]
+    private static partial Regex PathElementRegex();
 
     [GeneratedRegex(@"<rect\s+([^/>]*)/?>", RegexOptions.IgnoreCase)]
     private static partial Regex ParseRectRegex();

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
@@ -582,14 +582,38 @@ internal static partial class SvgRenderer
             if (!flood.Success)
                 continue;
 
-            var floodAttrs = ParseAttributes(flood.Groups[1].Value);
-            var color = GetColor(floodAttrs, "flood-color", BColor.Black);
-            if (floodAttrs.TryGetValue("flood-opacity", out var opStr)
-                && float.TryParse(opStr, NumberStyles.Float, CultureInfo.InvariantCulture, out var op))
-                color = BColor.FromArgb((int)(Math.Clamp(op, 0f, 1f) * color.A), color.R, color.G, color.B);
+            // "A flood filter" means the flood is the *whole* filter. A flood that another
+            // primitive then consumes describes a backdrop, not the result: registering
+            // filters-blend-01-b's five feFlood+feBlend chains here replaced each thin blended
+            // band with a solid flood-coloured rectangle 20% larger than the shape.
+            if (FilterPrimitiveRegex().Matches(body).Count > 1)
+                continue;
 
-            SvgFilterTable.AddFlood(id, color);
+            SvgFilterTable.AddFlood(id, ParseFloodColor(ParseAttributes(flood.Groups[1].Value)));
         }
+    }
+
+    /// <summary>
+    /// The colour an <c>&lt;feFlood&gt;</c> produces: its <c>flood-color</c> with
+    /// <c>flood-opacity</c> folded into the alpha channel.
+    /// </summary>
+    /// <remarks>
+    /// Takes the parsed attributes rather than the match, because the two regexes that find an
+    /// <c>&lt;feFlood&gt;</c> put them in different groups — <see cref="FeFloodRegex"/> in group 1
+    /// and <see cref="FilterPrimitiveRegex"/> in group 2, group 1 there being the element name.
+    /// </remarks>
+    private static BColor ParseFloodColor(Dictionary<string, string> floodAttrs)
+    {
+        var color = GetColor(floodAttrs, "flood-color", BColor.Black);
+
+        if (floodAttrs.TryGetValue("flood-opacity", out var opStr)
+            && float.TryParse(opStr, NumberStyles.Float, CultureInfo.InvariantCulture, out var op))
+        {
+            color = BColor.FromArgb(
+                (int)(Math.Clamp(op, 0f, 1f) * color.A), color.R, color.G, color.B);
+        }
+
+        return color;
     }
 
     /// <summary>
@@ -639,10 +663,42 @@ internal static partial class SvgRenderer
         string? previousResult = null;
         bool first = true;
 
+        // The colours an feFlood in this filter produced, by its `result` name. A flood is a
+        // constant over the whole filter region, so a later primitive that consumes one is
+        // consuming a known colour rather than an image the model cannot represent.
+        Dictionary<string, BColor>? floods = null;
+
         foreach (Match pm in primitives)
         {
             var name = pm.Groups[1].Value;
             var attrs = ParseAttributes(pm.Groups[2].Value);
+
+            if (name.Equals("feFlood", StringComparison.OrdinalIgnoreCase))
+            {
+                // A flood ignores its `in` entirely, so it neither continues nor breaks the chain;
+                // it contributes a named constant for a later feBlend to use as its backdrop.
+                if (!attrs.TryGetValue("result", out var floodResult) || floodResult.Length == 0)
+                    return null;
+
+                floods ??= new Dictionary<string, BColor>(StringComparer.Ordinal);
+                floods[floodResult] = ParseFloodColor(attrs);
+                continue;
+            }
+
+            if (name.Equals("feBlend", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!TryResolveBlendBackdrop(attrs, floods, previousResult, first, out var backdrop))
+                    return null;
+
+                string mode = (attrs.GetValueOrDefault("mode") ?? "normal").Trim().ToLowerInvariant();
+                if (!SvgColorFilter.IsModelledBlendMode(mode))
+                    return null;
+
+                steps.Add(new SvgColorFilter.Step { BlendBackdrop = backdrop, BlendMode = mode });
+                attrs.TryGetValue("result", out previousResult);
+                first = false;
+                continue;
+            }
 
             // The chain must be straight: each primitive consumes the previous one's output (an
             // absent `in` means exactly that), and the first consumes the source graphic.
@@ -694,6 +750,41 @@ internal static partial class SvgRenderer
         }
 
         return new SvgColorFilter(steps);
+    }
+
+    /// <summary>
+    /// Resolves an <c>&lt;feBlend&gt;</c>'s two inputs to "the running colour, over this constant
+    /// backdrop".
+    /// </summary>
+    /// <remarks>
+    /// One input must name an <c>&lt;feFlood&gt;</c> declared earlier in the same filter — the only
+    /// second image a single-colour model can represent — and the other must be the running result.
+    /// Either order is accepted: the blend is not commutative, but <c>in</c> is always the source
+    /// and <c>in2</c> the backdrop, so the flood being named by <c>in</c> instead makes the flood
+    /// the source and the running colour the backdrop.
+    /// </remarks>
+    private static bool TryResolveBlendBackdrop(
+        Dictionary<string, string> attrs, Dictionary<string, BColor>? floods,
+        string? previousResult, bool first, out BColor backdrop)
+    {
+        backdrop = default;
+        if (floods == null)
+            return false;
+
+        string? input = attrs.GetValueOrDefault("in");
+        string? input2 = attrs.GetValueOrDefault("in2");
+
+        // in2 names the flood: the ordinary spelling, source over flood.
+        if (input2 != null && floods.TryGetValue(input2, out backdrop))
+            return ConsumesPreviousResult(attrs, "in", previousResult, first);
+
+        // in names the flood instead. The running colour is then the backdrop, which this model
+        // cannot express — it applies the blend to the running colour, not to the flood — so it is
+        // declined rather than rendered the wrong way round.
+        if (input != null && floods.ContainsKey(input))
+            return false;
+
+        return false;
     }
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/IR/SvgStructure.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgStructure.cs
@@ -84,6 +84,43 @@ internal sealed partial class SvgStructure
     /// </summary>
     private readonly List<(int Start, int End)> _inertSpans = [];
 
+    /// <summary>
+    /// The <c>&lt;svg&gt;</c> elements below the root, in document order, and the content spans they
+    /// own — see <see cref="NestedViewports"/>.
+    /// </summary>
+    private readonly List<NestedViewport> _nestedViewports = [];
+
+    /// <summary>
+    /// Every <c>&lt;svg&gt;</c> that is not the outermost one, each of which establishes a viewport
+    /// of its own (SVG 1.1 §7.2) rather than drawing its children in the enclosing user space.
+    /// </summary>
+    /// <remarks>
+    /// The renderer's shape passes sweep the whole markup, so before this the children of a nested
+    /// <c>&lt;svg x y width height viewBox&gt;</c> were drawn in the <em>root's</em> coordinate
+    /// system — every one of the six panels of
+    /// <c>conformance-checkers/html-svg/coords-viewattr-03-b</c> landed on top of the first, at the
+    /// root's scale. They are collected here so the renderer can render each one's content as its
+    /// own document and skip it in the outer passes.
+    /// </remarks>
+    public IReadOnlyList<NestedViewport> NestedViewports => _nestedViewports;
+
+    /// <summary>One nested <c>&lt;svg&gt;</c>: where it is, what it declares, and what it contains.</summary>
+    /// <param name="Index">Its start-tag offset, which orders it against its siblings.</param>
+    /// <param name="Attributes">Its own attributes — <c>x</c>/<c>y</c>/<c>width</c>/<c>height</c>,
+    /// <c>viewBox</c> and <c>preserveAspectRatio</c>.</param>
+    /// <param name="Inherited">The presentation attributes in force where it sits, which its
+    /// content must keep inheriting although it is rendered as a separate document.</param>
+    public readonly record struct NestedViewport(
+        int Index, IReadOnlyDictionary<string, string> Attributes,
+        IReadOnlyDictionary<string, string> Inherited,
+        string Source, int ContentStart, int ContentEnd)
+    {
+        /// <summary>The markup this viewport contains.</summary>
+        public string Content => ContentEnd > ContentStart
+            ? Source[ContentStart..ContentEnd]
+            : string.Empty;
+    }
+
     /// <summary>One element the scan reached, addressable by <c>id</c>.</summary>
     /// <param name="Name">Its tag name.</param>
     /// <param name="Attributes">Its own attributes.</param>
@@ -159,6 +196,26 @@ internal sealed partial class SvgStructure
         return false;
     }
 
+    /// <summary>
+    /// Whether <paramref name="index"/> falls inside a nested <c>&lt;svg&gt;</c>, whose content the
+    /// nested-viewport pass renders as its own document and the outer shape passes must therefore
+    /// leave alone.
+    /// </summary>
+    /// <remarks>
+    /// Scanned rather than binary-searched because these spans nest inside one another, so they are
+    /// not disjoint; a document has a handful of them at most.
+    /// </remarks>
+    public bool IsInNestedViewport(int index)
+    {
+        foreach (var viewport in _nestedViewports)
+        {
+            if (index > viewport.Index && index < viewport.ContentEnd)
+                return true;
+        }
+
+        return false;
+    }
+
     /// <summary>Resolves an <c>id</c> to the element that declares it.</summary>
     public bool TryGetById(string id, out Element element)
     {
@@ -183,8 +240,10 @@ internal sealed partial class SvgStructure
         var structure = new SvgStructure();
         var open = new List<(string Name, IReadOnlyDictionary<string, string> Inherited,
             bool Suppresses, SvgTransform Transform, IReadOnlyDictionary<string, string> Attributes,
-            int ContentStart)>();
+            int ContentStart, int StartIndex, bool IsNestedViewport,
+            IReadOnlyDictionary<string, string> ParentInherited)>();
         int nonRenderingDepth = 0;
+        int svgDepth = 0;
 
         foreach (Match m in TagRegex().Matches(svgXml))
         {
@@ -210,6 +269,8 @@ internal sealed partial class SvgStructure
                 {
                     if (open[i].Suppresses)
                         nonRenderingDepth--;
+                    if (open[i].Name.Equals("svg", StringComparison.OrdinalIgnoreCase))
+                        svgDepth--;
                 }
 
                 // The element is complete, so its content span is known: record it under its id.
@@ -218,6 +279,16 @@ internal sealed partial class SvgStructure
                 {
                     structure._byId[closedId] = new Element(
                         closed.Name, closed.Attributes, svgXml, closed.ContentStart, m.Index);
+                }
+
+                // A nested <svg> that paints where it stands establishes its own viewport, so its
+                // content is rendered separately rather than by the outer passes. One inside <defs>
+                // is not recorded: it paints only through a <use>, which renders it itself.
+                if (closed.IsNestedViewport)
+                {
+                    structure._nestedViewports.Add(new NestedViewport(
+                        closed.StartIndex, closed.Attributes, closed.ParentInherited,
+                        svgXml, closed.ContentStart, m.Index));
                 }
 
                 open.RemoveRange(last, open.Count - last);
@@ -250,6 +321,11 @@ internal sealed partial class SvgStructure
                 continue;
             }
 
+            bool isSvg = name.Equals("svg", StringComparison.OrdinalIgnoreCase);
+            bool nestedViewport = isSvg && svgDepth > 0 && paints;
+            if (isSvg)
+                svgDepth++;
+
             // Track the suppression on the open element rather than re-deriving it at the end tag:
             // an element nested inside a container that does not paint suppresses its own children
             // too, and matching that against the container list alone would decrement fewer times
@@ -260,9 +336,12 @@ internal sealed partial class SvgStructure
 
             open.Add((
                 name, Extend(inherited, attributes), suppresses, transform,
-                attributes, m.Index + m.Length));
+                attributes, m.Index + m.Length, m.Index, nestedViewport, inherited));
         }
 
+        // Recorded as each end tag is met, so an outer viewport lands after the inner ones it
+        // contains; the renderer paints them in document order and needs them that way round.
+        structure._nestedViewports.Sort(static (a, b) => a.Index.CompareTo(b.Index));
         return structure;
     }
 

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -111,6 +111,42 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
   needs the test's own reference to be judged rather than the render, which is a different
   check. A flag is still a triage queue rather than a verdict — just a much shorter one.
 
+### The reference score was measured and then thrown away
+
+- **Owner:** the WPT runner (`src/Broiler.Wpt`) and the shard merger
+  (`scripts/merge-wpt-shards.py`). Main repo.
+- **The bug.** `VerifyAgainstReferenceHtml` rendered the test's own `rel=match`
+  reference, compared Broiler's render to it, computed the percentage — and then
+  `return null`ed unless that percentage cleared the pass threshold. The one
+  measurement that separates a reference disagreement from an engine gap was
+  discarded in exactly the cases where it was needed, so a test at 94% against its own
+  reference and 0.8% against the committed golden was reported as though nothing at
+  all were known about it, indistinguishable from one that is wrong against both.
+- **The two need opposite work**, which is why the conflation mattered: the first says
+  the goldens disagree and "fixing" it would mean rendering *less* than the test asks
+  for; the second is a real gap.
+- **What landed.** The percentage is recorded on the result
+  (`WptTestResult.ReferenceMatchPercent`), serialised into the JSON report, carried
+  through the shard merge, printed beside the golden score in the run summary, and
+  written into the severity issue's per-problem detail. A gap of 25 points or more
+  between the two is called out in words. `SuspectReference` keeps its narrower
+  meaning — Broiler *reproduced* the declared reference — because the ranking uses it
+  to drop a test out of the candidate set, and whether these near-misses belong in
+  [won't fix](wpt-rendering-gaps-wont-fix.md) is a maintainer's call rather than the
+  report's.
+- **A margin, not a second threshold.** The claim it supports is comparative — far
+  closer to one reference than the other — so it needs no tuning against the run's own
+  gate.
+- **Measured** on the three `grid-lanes` tests the open entry named. The runner now
+  prints `0.8% … (rel=match 94.0%)` and `0.9% … (rel=match 94.8%)` for the two
+  reference disagreements, and `11.5% … (rel=match 10.4%)` for
+  `column-subgrid-auto-fill-008` — which is wrong against both and stays ranked as the
+  real gap it is. 36 existing merger tests unchanged, 3 added.
+- **What it does not do.** The inverse case — a test that passes the golden while
+  failing its own reference — is still unreported, because the check only runs on
+  golden failures. Widening it to passes would re-render a reference for every passing
+  reftest in the suite.
+
 ### The runner never performed WPT's `.sub` substitution
 
 - **Test:** `css/css-color-adjust/…/color-scheme-iframe-background-mismatch-opaque-cross-origin-002.sub`.
@@ -952,6 +988,72 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
 - **Verified:** the four tests above, the probe cases behind them (a `userSpaceOnUse`
   pattern, a rotated `patternTransform` and a `url(#missing) lime` fallback all match
   Chromium pixel-for-pixel), and 839 `Broiler.Layout.Tests` unchanged.
+
+### `<path>` was never drawn, and three more gaps behind the same family
+
+- **Tests:** the six `conformance-checkers/html-svg` entries of
+  [#1661](https://github.com/Broiler-Platform/Broiler/issues/1661), and a great deal
+  of the rest of that family with them. Measured against locally generated Chromium
+  references over `conformance-checkers/html-svg`, `svg` and `css/filter-effects`
+  (1682 tests): **78 improve by more than a point, 4 worsen, mean +0.41**.
+
+  | Test | Was | Now |
+  | --- | --- | --- |
+  | `html-svg/color-prop-04-t-isvalid` | 32.1% | 79.3% |
+  | `html-svg/struct-group-02-b-isvalid` | 68.6% | 97.1% |
+  | `html-svg/render-elems-01-t-isvalid` | 68.2% | 96.4% |
+  | `html-svg/linking-a-07-t-isvalid` | 74.2% | 95.7% |
+  | `html-svg/filters-example-01-b-isvalid` | 56.1% | 86.8% |
+  | `html-svg/struct-image-02-b-isvalid` | 30.7% | 51.0% |
+
+- **Owner:** `Broiler.Layout` (`IR/SvgPathData.cs`, `IR/SvgPaintOrder.cs`,
+  `IR/SvgRenderer.Viewport.cs`, `IR/SvgRenderer*.cs`, `IR/SvgStructure.cs`). Main
+  repo, no patch.
+- **Five gaps, one family** — the same shape as the earlier `pservers-*` triage:
+
+  1. **`<path>` painted nothing at all**, which is the commonest shape in SVG. There
+     is no path display item, and the only pass over `<path>` harvested each one's
+     start point so a `<textPath>` could be positioned. Paths are now flattened to
+     straight-line subpaths and emitted through the **polygon and polyline items the
+     backend already fills and strokes** — so this needed no new backend primitive
+     and no submodule change, which is the whole reason it could land here.
+  2. **The shape passes painted out of document order.** One regex per shape type,
+     each sweeping the whole markup, emitted every rect, then every circle, then all
+     the text — so an element a later sibling had to cover was painted over it
+     instead. `color-prop-04-t`'s dropdown panel is opaque and sits after the
+     paragraph text in the markup; the text showed through it.
+  3. **A nested `<svg>` established no viewport.** Its children were drawn in the
+     *root's* coordinate system, so the six panels of `coords-viewattr-03-b` all
+     landed on the first one at the root's scale.
+  4. **A `clip-path` on a shape did nothing.** The existing collection publishes to
+     the table a CSS `clip-path` on an *HTML* element reads; the SVG attribute had no
+     path at all.
+  5. **A CSS system colour was not a colour.** `fill="Window"` matched no named
+     colour and fell through to the caller's default — black — so a page built out of
+     system colours painted as one black rectangle. `Broiler.CSS` already carries the
+     table; nothing consulted it from here.
+
+- **A path's subpaths fill as one ring, not one polygon each.** The rasterizer's fill
+  is an even-odd crossing test, so joining them with bridge edges that retrace — and
+  therefore cancel — gives an enclosed subpath the hole it should have. Filling each
+  separately painted over it, which is what turned the three overlapping rings of
+  `coords-viewattr-03-b` into a solid blob. Chaining them end to end instead would
+  leave a closing edge that retraces no bridge and toggles a spurious wedge.
+- **Drawing paths at all exposed `vector-effect: non-scaling-stroke`**, which was
+  unimplemented. `svg/painting/reftests/non-scaling-stroke-precision-loss` draws a
+  hairline under a view box 0.375 units tall over 344 pixels; scaling its width by
+  that 917× factor put a band across the whole canvas. A non-scaling stroke now takes
+  the viewport's scale rather than the view box's — *not* no scale at all, which
+  halved the stroke of a zoomed viewport.
+- **Two tests drop below the gate, and both are honest.**
+  `non-scaling-stroke-008` (99.7% → 99.0%) passed while its stroke was ten times too
+  wide and covered the canvas; `svg/types/scripted/SVGGraphicsElement.getBBox-10`
+  reports geometry the renderer does not compute. `masking-path-14-f` regressed on
+  the way and was closed by gap 4 above. `svg/interact/scripted/rect-hittest-002`
+  appears in the diff and is **not** caused by this: it scores 97.7% on an unmodified
+  build too — the flakiness
+  [the method notes warn about](wpt-rendering-gaps-open.md#one-test-is-flaky), caught
+  by re-running it against the unmodified build exactly as they say to.
 
 ### A media element with nothing to show painted a black box
 

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -1055,6 +1055,34 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
   [the method notes warn about](wpt-rendering-gaps-open.md#one-test-is-flaky), caught
   by re-running it against the unmodified build exactly as they say to.
 
+### An `feFlood` feeding another primitive flooded the shape
+
+- **Tests:** the whole `css/filter-effects/tainting-*` family — **31 tests crossed the
+  99% gate**, from 98.4% to 99.2–100% — plus
+  `conformance-checkers/html-svg/filters-blend-01-b` 31.1% → **38.2%**.
+- **Owner:** `Broiler.Layout` (`IR/SvgRenderer.cs`, `IR/SvgColorFilter.cs`). Main repo.
+- **The bug.** `CollectFloodFilters` registered a filter as flood-only whenever its body
+  contained an `<feFlood>` *anywhere*, and a shape referencing a flood filter is replaced
+  by a solid rectangle of the flood colour over the filter region — 20% larger than the
+  shape on each axis. But a flood that another primitive then consumes describes a
+  **backdrop**, not the result. Every `tainting-*` test floods and then composites, and
+  each rendered as one solid flood-coloured rectangle. A flood is now taken as the whole
+  filter only when it is the only primitive in it.
+- **`feFlood` + `feBlend` is closed-form over a solid fill**, so it joins the two
+  primitives [`SvgColorFilter`](#svg-text-pattern-fills-symbols-and-transforms-were-all-missing)
+  already models: the backdrop is a single colour by construction, and the five separable
+  SVG 1.1 blend modes composite with it under the ordinary source-over rule. A flood is
+  not a chain step — it ignores its own `in` — so it contributes a named constant rather
+  than continuing the chain, and a blend whose backdrop is anything else declines and
+  leaves the shape unfiltered.
+- **What it does not do.** A blend that names the flood as `in` rather than `in2` is
+  declined rather than rendered the wrong way round: the running colour would then be the
+  backdrop, which a one-colour model cannot express. `filters-blend-01-b`'s residual is
+  the element `opacity` on each band, which is group compositing rather than recolouring
+  and is deliberately outside this model.
+- **Measured:** 0 tests lost across the 1682 in `conformance-checkers/html-svg`, `svg`
+  and `css/filter-effects`; 9 `SvgColorFilterTests` added.
+
 ### A media element with nothing to show painted a black box
 
 - **Tests:** `conformance-checkers/html/elements/{track,video}/src-isvalid` 14.4% →

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -749,19 +749,34 @@ neither declares a `rel=match`, so the reftest suite cannot judge them, and the
 manifest is a merged file where a test that stops being exercised keeps its old
 entry. Confirm from a run artifact before treating either as closed.
 
-### Large documents — the `conformance-checkers` family is triaged; two remain
+### Large documents — the `conformance-checkers` family, round two
 
 The nine `conformance-checkers` entries in
 [#1658](https://github.com/Broiler-Platform/Broiler/issues/1658) were triaged on
-2026-08-15 and were **nine separate gaps, not one**. Seven are closed — see
+2026-08-15 and were **nine separate gaps, not one**. Seven closed then — see
 [SVG text, patterns, symbols and transforms](wpt-rendering-gaps-fixed.md#svg-text-pattern-fills-symbols-and-transforms-were-all-missing)
 and [a media element with nothing to show painted a black box](wpt-rendering-gaps-fixed.md#a-media-element-with-nothing-to-show-painted-a-black-box).
-The two that are not each need a subsystem rather than a fix:
+[#1661](https://github.com/Broiler-Platform/Broiler/issues/1661) then surfaced six
+more from the same family, of which four closed — see
+[`<path>` was never drawn](wpt-rendering-gaps-fixed.md#path-was-never-drawn-and-three-more-gaps-behind-the-same-family).
+**The pattern has held twice: a family that looks like one gap is a handful of
+unrelated ones, and only the residue needs a subsystem.**
 
-| Test | Was | Now | What is missing |
+Three remain, and each needs a subsystem rather than a fix:
+
+| Test | CI | Now | What is missing |
 | --- | --- | --- | --- |
-| `html-svg/types-dom-06-f-isvalid` | 16.4% | 22.5% | the **SVG DOM**: the page scripts `requiredFeatures`, an `SVGStringList` with `getItem`/`appendItem`/`insertItemBefore`, and paints red when any assertion fails |
-| `html-svg/styling-css-05-b-isvalid` | 11.3% | 12.6% | the **CSS cascade reaching SVG paint**. `:lang(en) { fill: green }` in a `<style>` inside the `<svg>` matches every element in an `<html lang=en>` document, and a stylesheet `fill` outranks the `fill="none"` presentation attribute — so the reference browser fills the whole test frame green. `SvgRenderer` reads paint from attributes and inline `style` only; it never sees the cascade, because it works from serialised markup rather than from the boxes the cascade was projected onto |
+| `html-svg/types-dom-06-f-isvalid` | 22.5% | 22.5% | the **SVG DOM**: the page scripts `requiredFeatures`, an `SVGStringList` with `getItem`/`appendItem`/`insertItemBefore`, and paints red when any assertion fails |
+| `html-svg/struct-dom-06-b-isvalid` | 16.5% | 16.5% | the **SVG DOM** again, from the other side: an `onload` on the root `<svg>` drives `setAttribute`, `removeChild`, `createElementNS` and `appendChild`, and the renderer works from serialised markup rather than from a live tree |
+| `html-svg/styling-css-05-b-isvalid` | 12.6% | 12.6% | the **CSS cascade reaching SVG paint**. `:lang(en) { fill: green }` in a `<style>` inside the `<svg>` matches every element in an `<html lang=en>` document, and a stylesheet `fill` outranks the `fill="none"` presentation attribute — so the reference browser fills the whole test frame green. `SvgRenderer` reads paint from attributes and inline `style` only; it never sees the cascade, because it works from serialised markup rather than from the boxes the cascade was projected onto |
+
+The three share one root: **`SvgRenderer` renders serialised markup, not the box tree
+the cascade and the DOM act on.** Two of the four just closed were fixable precisely
+because they were about geometry and paint the markup already states. These are not,
+and a fourth — `filters-blend-01-b` (31.1% → **34.6%**) — sits between the two groups:
+its `feFlood`+`feBlend` chain is analytically closed-form over a solid fill, the shape
+[`SvgColorFilter`](#) already models for `feColorMatrix` and `feComposite`, so it is
+reachable without the box tree.
 
 The other two in this group are unchanged and are not `conformance-checkers`:
 
@@ -812,19 +827,22 @@ is exactly one page area), and on both sides only the first block paints:
 Neither can change what CI reports for that test, which is scored unpaginated against
 [a blank Chromium capture](wpt-rendering-gaps-wont-fix.md#page-margin-002-print-is-a-screenshot-artifact).
 
-### The report cannot distinguish "wrong everywhere" from "wrong only against Chromium"
+### The report cannot distinguish "wrong everywhere" from "wrong only against Chromium" — **fixed**
 
-`--verify-reference` sets `suspectReference` only when Broiler clears the same 99%
-gate against the test's own reference, so a test at 94–95% against its own reference
-and 0.8–8.0% against the golden is ranked as though nothing were known about it. Four
-entries fall through: two `grid-lanes` tests above, and
-[two in won't fix](wpt-rendering-gaps-wont-fix.md#two-fall-through-the-99-gate).
+The reference score is now
+[recorded alongside the golden one](wpt-rendering-gaps-fixed.md#the-reference-score-was-measured-and-then-thrown-away)
+rather than discarded whenever it misses the gate, so the four entries that fell
+through — two `grid-lanes` tests above, and
+[two in won't fix](wpt-rendering-gaps-wont-fix.md#two-fall-through-the-99-gate) —
+now carry both numbers in the run summary and in the severity issue's detail. The run
+prints `0.8% … (rel=match 94.0%)` for a reference disagreement and
+`11.5% … (rel=match 10.4%)` for the real gap beside it.
 
-**Recording the reference score alongside the golden one, rather than only using it as
-a pass/fail gate, would separate the two classes** without needing a second threshold
-to be tuned. The same change would surface
-[the inverse case](#two-tests-are-green-on-ci-and-wrong) — a test that passes the
-golden while failing its own reference — which nothing reports today.
+**What remains is the inverse case** — [a test that passes the
+golden while failing its own reference](#two-tests-are-green-on-ci-and-wrong) — which
+nothing reports, because the check runs only on golden *failures*. Widening it to
+passes would re-render a reference for every passing reftest in the suite, so it wants
+a cheaper trigger than "always".
 
 ---
 

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -771,12 +771,15 @@ Three remain, and each needs a subsystem rather than a fix:
 | `html-svg/styling-css-05-b-isvalid` | 12.6% | 12.6% | the **CSS cascade reaching SVG paint**. `:lang(en) { fill: green }` in a `<style>` inside the `<svg>` matches every element in an `<html lang=en>` document, and a stylesheet `fill` outranks the `fill="none"` presentation attribute — so the reference browser fills the whole test frame green. `SvgRenderer` reads paint from attributes and inline `style` only; it never sees the cascade, because it works from serialised markup rather than from the boxes the cascade was projected onto |
 
 The three share one root: **`SvgRenderer` renders serialised markup, not the box tree
-the cascade and the DOM act on.** Two of the four just closed were fixable precisely
-because they were about geometry and paint the markup already states. These are not,
-and a fourth — `filters-blend-01-b` (31.1% → **34.6%**) — sits between the two groups:
-its `feFlood`+`feBlend` chain is analytically closed-form over a solid fill, the shape
-[`SvgColorFilter`](#) already models for `feColorMatrix` and `feComposite`, so it is
-reachable without the box tree.
+the cascade and the DOM act on.** The four that closed were fixable precisely because
+they were about geometry and paint the markup already states. These are not.
+
+`filters-blend-01-b` is the fourth of the six and is
+[closed as far as its filters go](wpt-rendering-gaps-fixed.md#an-feflood-feeding-another-primitive-flooded-the-shape)
+— 31.1% → **38.2%**. Its residual is the one thing the shape model states it does not
+cover: the element `opacity` on each band, which composites fill and stroke together
+as a group rather than recolouring the shape, and which
+[`AddShape` deliberately does not model](wpt-rendering-gaps-fixed.md#svg-text-pattern-fills-symbols-and-transforms-were-all-missing).
 
 The other two in this group are unchanged and are not `conformance-checkers`:
 

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -201,10 +201,70 @@ golden suite never looks at a passing test's own reference.
   the check that subgrid stays a no-op while that is fixed, since the reference
   depends on it being one.
 
+### `aspect-ratio` on a grid item escapes an `inline-grid`
+
+- **Test:** `css-grid/alignment/grid-item-aspect-ratio-justify-self-001`, CI 3.9%
+  ([#1661](https://github.com/Broiler-Platform/Broiler/issues/1661).11). Was listed
+  here as not triaged; it now has an isolated repro.
+- **What the test asks.** A grid item with `aspect-ratio: 1/2`, `height: 100%` of a
+  32px grid and a *non-stretching* `justify-self` must take its inline size from the
+  height through the ratio: **16×32**. With `justify-self: normal`/`stretch` it fills
+  the 24px area instead and is 24×48.
+- **What we produce: 1008×2016** — the item escapes the grid entirely and fills the
+  page. `check-layout-th.js` reports it directly, which is what makes this precise
+  rather than a pixel percentage:
+
+  ```
+  div.item  width   expected 16  actual 1008
+  div.item  height  expected 32  actual 2016
+  ```
+
+- **It is the `inline-grid`, not the ratio and not the alignment.** Bisected with a
+  four-case repro:
+
+  | Container | Item | Result |
+  | --- | --- | --- |
+  | `inline-grid` | `height: 100%` | **correct** |
+  | `inline-grid` | `height: 100%` + `aspect-ratio` | **escapes** — 24 wide, the page's height tall |
+  | `grid` (block-level) | `height: 100%` + `aspect-ratio` | correct |
+  | `block` | `height: 100%` + `aspect-ratio` | correct |
+  | `inline-block` | `height: 100%` + `aspect-ratio` | correct |
+
+  So neither `aspect-ratio` alone nor an item's percentage height in an `inline-grid`
+  alone is broken; only the pair. The percentage height stops resolving against the
+  grid area and resolves against the initial containing block, and the ratio then
+  carries that wrong height into the inline axis.
+- **Where to look:** `CssBox.Sizing.cs` — `CanTransferAspectRatioToBlockHeight`
+  admits a box whose percentage height "computes to auto"
+  (`HeightPercentageResolvesToAuto`), which is right for an outer `<svg>` and wrong
+  for a grid item, whose area *is* a definite containing block.
+- **Exit gate:** the four-case table above stays correct in every row, and the test's
+  22 assertions pass. **Do not fix the transfer without the table** — the
+  computes-to-auto arm is what gives every `conformance-checkers/html-svg` page its
+  height, and narrowing it carelessly would take that back.
+- `justify-self`'s eleven values are a *second* requirement the test makes and are
+  not measured yet: nothing can be said about them until the item stays in its area.
+
 ### Not triaged
 
-- `css-grid/abspos/grid-sizing-positioned-items-001`, CI 9.1%. Declares no
-  `rel=match`, so it can only be judged from a CI artifact.
+- `css-grid/abspos/grid-sizing-positioned-items-001`, CI 9.1%
+  ([#1661](https://github.com/Broiler-Platform/Broiler/issues/1661).13). Declares no
+  `rel=match`, so the pixel score can only be judged from a CI artifact — but its
+  `check-layout-th.js` assertions can be read locally and say the abspos grid child is
+  placed at the padding edge rather than at its grid area, and sized against the wrong
+  box:
+
+  ```
+  div.absolute  offset-x  expected   0  actual   15
+  div.absolute  offset-y  expected   0  actual   15
+  div.absolute  height    expected 1030 actual   30
+  div.absolute  offset-x  expected 115  actual   15
+  div.absolute  width     expected 915  actual 1030
+  ```
+
+  Every `offset-*` is the container's 15px padding, so **the grid area is not being
+  used as the containing block for an absolutely positioned grid child at all**
+  (CSS Grid §9). That is one cause for the whole test, not eleven separate ones.
 
 ---
 

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -234,14 +234,18 @@ golden suite never looks at a passing test's own reference.
   alone is broken; only the pair. The percentage height stops resolving against the
   grid area and resolves against the initial containing block, and the ratio then
   carries that wrong height into the inline axis.
-- **Where to look:** `CssBox.Sizing.cs` — `CanTransferAspectRatioToBlockHeight`
-  admits a box whose percentage height "computes to auto"
-  (`HeightPercentageResolvesToAuto`), which is right for an outer `<svg>` and wrong
-  for a grid item, whose area *is* a definite containing block.
+- **Where to look — and one place it is *not*.** The obvious suspect,
+  `CssBox.Sizing.cs`'s `CanTransferAspectRatioToBlockHeight`, is **ruled out**: the
+  item's containing block is the `height: 32px` grid container, so
+  `HeightPercentageResolvesToAuto()` is false, and that guard returns false before the
+  width→height transfer is reached. The remaining candidate is the path an
+  *inline-level* container's contents take — `CssBox.ContainingBlock.cs` notes that an
+  atomic inline computes its height in `CssLayoutEngine`'s inline flow rather than in
+  `ResolveUsedBlockHeight`, and `inline-grid` is the only row of the table that goes
+  through it. **Confirm that with a debugger before changing anything**; this entry
+  records a bisect, not a root cause.
 - **Exit gate:** the four-case table above stays correct in every row, and the test's
-  22 assertions pass. **Do not fix the transfer without the table** — the
-  computes-to-auto arm is what gives every `conformance-checkers/html-svg` page its
-  height, and narrowing it carelessly would take that back.
+  22 assertions pass.
 - `justify-self`'s eleven values are a *second* requirement the test makes and are
   not measured yet: nothing can be said about them until the item stays in its area.
 

--- a/scripts/merge-wpt-shards.py
+++ b/scripts/merge-wpt-shards.py
@@ -310,6 +310,44 @@ def _problem_identity(result: dict) -> tuple[str, str, str | None]:
     return category, category, None
 
 
+def _reference_score_note(test: dict) -> str:
+    """
+    Describe how the test scored against the reference it declares itself, when the
+    runner measured it.
+
+    ``suspectReference`` is only set when Broiler *clears the pass threshold* against
+    that reference, so a test at 94% against its own reference and 0.8% against the
+    committed golden carried no signal at all and was ranked as though nothing were
+    known about it — indistinguishable from one that is wrong against both. The two
+    need opposite work: the first says the goldens disagree and "fixing" it would mean
+    rendering less than the test asks for, the second is a real engine gap. Printing the
+    second number says which one this is.
+    """
+    reference_percent = test.get("referenceMatchPercent")
+    if reference_percent is None:
+        return ""
+
+    match_percent = test["matchPercent"]
+    note = (
+        f" Against the reference the test itself declares via `rel=match` it scores"
+        f" {reference_percent:.1f}%"
+    )
+    if reference_percent - match_percent >= REFERENCE_DISAGREEMENT_MARGIN:
+        note += (
+            " — far closer than to the committed golden, so most of this gap is the two"
+            " references disagreeing rather than the feature under test"
+        )
+
+    return note + "."
+
+
+#: How far a test's score against its own ``rel=match`` reference must exceed its score
+#: against the committed golden before the gap is attributed to the references
+#: disagreeing rather than to the engine. Mirrors the runner's own margin; it is a
+#: comparative claim, so it needs no tuning against the run's pass threshold.
+REFERENCE_DISAGREEMENT_MARGIN = 25.0
+
+
 def _rank_biggest_problems(
     incomplete_shards: list[dict],
     exception_signatures: Counter[str],
@@ -419,6 +457,7 @@ def _rank_biggest_problems(
                 "detail": (
                     f"Rendered output matches the reference by only "
                     f"{test['matchPercent']:.1f}% ({label})."
+                    + _reference_score_note(test)
                 ),
             }
         )
@@ -630,6 +669,18 @@ def merge(
                         # render, so it is ranked separately (see _rank_biggest_problems).
                         "suspectReference": (
                             str(suspect_reference) if suspect_reference else None
+                        ),
+                        # The score against that same reference whether or not it
+                        # cleared the gate. A test far closer to its own reference than
+                        # to the golden is a reference disagreement too, and without
+                        # this number nothing in the report could say so.
+                        "referenceMatchPercent": (
+                            float(reference_percent)
+                            if isinstance(
+                                (reference_percent := entry.get("referenceMatchPercent")),
+                                (int, float),
+                            )
+                            else None
                         ),
                     }
                 )

--- a/scripts/tests/test_merge_wpt_shards.py
+++ b/scripts/tests/test_merge_wpt_shards.py
@@ -917,6 +917,115 @@ class MergeWptShardsTests(unittest.TestCase):
             self.assertEqual([], merged["biggestProblems"])
             self.assertEqual(2, len(merged["referenceDisagreements"]))
 
+    def _scored_report(
+        self, root: Path, name: str, entries: list[tuple[str, float, float | None]]
+    ) -> None:
+        """Write a shard report whose lowestMatchTests carry a ``referenceMatchPercent``
+        — the score against the test's own rel=match reference, short of the gate."""
+        (root / name).write_text(
+            json.dumps(
+                {
+                    "summary": {
+                        "passed": 0,
+                        "failed": len(entries),
+                        "skipped": 0,
+                        "total": len(entries),
+                    },
+                    "shard": {"index": 0, "count": 1},
+                    "triage": {
+                        "lowestMatchTests": [
+                            {
+                                "testPath": path,
+                                "matchPercent": match,
+                                "category": "PixelMismatch",
+                                "subCategory": "LayoutShift",
+                                **(
+                                    {"referenceMatchPercent": reference}
+                                    if reference is not None
+                                    else {}
+                                ),
+                            }
+                            for path, match, reference in entries
+                        ]
+                    },
+                    "results": [
+                        self._failure(path, "PixelMismatch", "LayoutShift")
+                        for path, _, _ in entries
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_a_sub_threshold_reference_score_is_reported_beside_the_golden(self) -> None:
+        # The case the runner used to say nothing about: `suspectReference` is only set
+        # when Broiler *clears the gate* against the test's own reference, so a test at
+        # 94% against it and 0.8% against the golden was ranked as though nothing were
+        # known — indistinguishable from one that is wrong against both.
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._scored_report(
+                shard_dir,
+                "shard-0.json",
+                [
+                    ("css/css-grid/column-subgrid-auto-fill-003.html", 0.8, 94.0),
+                    ("css/css-grid/column-subgrid-auto-fill-008.html", 11.5, 10.4),
+                ],
+            )
+
+            merged = MODULE.merge(
+                shard_dir, biggest_problem_limit=5, low_match_threshold=50.0
+            )
+            details = {
+                problem["relativeTestPath"]: problem["detail"]
+                for problem in merged["biggestProblems"]
+            }
+
+            # Far closer to its own reference than to the golden: the references
+            # disagree, and chasing it would mean rendering less than the test asks for.
+            disagreement = details["css/css-grid/column-subgrid-auto-fill-003.html"]
+            self.assertIn("94.0%", disagreement)
+            self.assertIn("references disagreeing", disagreement)
+
+            # Wrong against both, so the second number must not excuse it.
+            real_gap = details["css/css-grid/column-subgrid-auto-fill-008.html"]
+            self.assertIn("10.4%", real_gap)
+            self.assertNotIn("references disagreeing", real_gap)
+
+    def test_both_classes_stay_ranked_as_biggest_problems(self) -> None:
+        # Recording the second score annotates the ranking; it does not silently drop a
+        # test out of it. Only a reference Broiler actually reproduced does that, and
+        # whether these belong in won't-fix is a maintainer's call, not the report's.
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._scored_report(
+                shard_dir, "shard-0.json", [("css/a/near.html", 0.8, 94.0)]
+            )
+
+            merged = MODULE.merge(
+                shard_dir, biggest_problem_limit=5, low_match_threshold=50.0
+            )
+
+            self.assertEqual(
+                ["css/a/near.html"],
+                [p["relativeTestPath"] for p in merged["biggestProblems"]],
+            )
+            self.assertEqual([], merged["referenceDisagreements"])
+
+    def test_a_report_without_reference_scores_reads_as_before(self) -> None:
+        # A run without --verify-reference carries no referenceMatchPercent key at all.
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._scored_report(shard_dir, "shard-0.json", [("css/a/plain.html", 4.0, None)])
+
+            merged = MODULE.merge(
+                shard_dir, biggest_problem_limit=5, low_match_threshold=50.0
+            )
+            detail = merged["biggestProblems"][0]["detail"]
+
+            self.assertNotIn("rel=match", detail)
+            self.assertTrue(detail.endswith("(PixelMismatch / LayoutShift)."))
+
     def test_low_match_tests_without_verification_are_ranked_as_before(self) -> None:
         # Reports from a run without --verify-reference carry no suspectReference
         # key at all; ranking must be unchanged for them.

--- a/src/Broiler.Wpt/Program.cs
+++ b/src/Broiler.Wpt/Program.cs
@@ -2076,6 +2076,10 @@ public class Program
                     // own rel=match reference but not the committed golden: the
                     // reference is the outlier, not the render.
                     ["suspectReference"] = r.SuspectReference,
+                    // The score against that same reference whether or not it cleared the gate,
+                    // so a test that is far closer to its own reference than to the golden can be
+                    // told apart from one that is wrong against both.
+                    ["referenceMatchPercent"] = r.ReferenceMatchPercent,
                 })
                 .ToList();
 
@@ -2608,7 +2612,15 @@ public class Program
             foreach (var failure in lowestMatchFailures)
             {
                 var relativePath = Path.GetRelativePath(wptPath, failure.TestPath).Replace('\\', '/');
-                Console.WriteLine($"  {failure.MatchPercent!.Value,5:F1}%  {relativePath}");
+
+                // The score against the test's own reference, when --verify-reference measured it:
+                // a test far closer to that than to the golden is a reference disagreement, and
+                // reading the two numbers side by side is what says so.
+                string against = failure.ReferenceMatchPercent is { } refPct
+                    ? $"  (rel=match {refPct,5:F1}%)"
+                    : string.Empty;
+
+                Console.WriteLine($"  {failure.MatchPercent!.Value,5:F1}%  {relativePath}{against}");
             }
         }
 

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -189,6 +189,22 @@ internal sealed class WptTestResult
     public string? SuspectReference { get; init; }
 
     /// <summary>
+    /// How closely Broiler's render matched the test's own <c>rel="match"</c> reference
+    /// <em>HTML</em>, as a percentage, whenever <c>--verify-reference</c> ran that comparison —
+    /// whether or not it cleared the pass threshold. Null when the check did not run or the test
+    /// declares no reference.
+    /// </summary>
+    /// <remarks>
+    /// The score used to be computed and then discarded unless it passed the gate, so a test at 94%
+    /// against its own reference and 0.8% against the committed golden was reported as though
+    /// nothing at all were known about it — indistinguishable from one that is wrong against both.
+    /// Those are opposite triage outcomes: the first says the golden is the outlier and "fixing" it
+    /// would mean rendering *less* than the test asks for; the second is a real engine gap. Keeping
+    /// the number separates them without a second threshold to tune.
+    /// </remarks>
+    public double? ReferenceMatchPercent { get; init; }
+
+    /// <summary>
     /// <c>check-layout-th.js</c> geometry assertions whose computed value diverged
     /// from the test's <c>data-offset-*</c> / <c>data-expected-*</c> attribute, with
     /// the expected and actual values. Null/empty when the test carries no such
@@ -316,6 +332,9 @@ internal sealed class WptTestResult
 
         if (SuspectReference is not null)
             obj["suspectReference"] = SuspectReference;
+
+        if (ReferenceMatchPercent is not null)
+            obj["referenceMatchPercent"] = ReferenceMatchPercent;
 
         return obj;
     }
@@ -1601,9 +1620,22 @@ internal sealed partial class WptTestRunner
     /// render with no content against a golden that has some.
     /// </para>
     /// </remarks>
-    private string? VerifyAgainstReferenceHtml(
+    /// <summary>
+    /// Renders the test's own <c>rel="match"</c> reference and compares Broiler's render to it.
+    /// </summary>
+    /// <returns>
+    /// The match percentage against that reference, and the note to append to the failure message
+    /// when the comparison says something triage needs. Both are null when the check could not run.
+    /// </returns>
+    /// <remarks>
+    /// The percentage is returned whether or not it clears the pass threshold. Gating on the
+    /// threshold and returning nothing otherwise threw away the one measurement that tells a
+    /// reference disagreement apart from an engine gap — see
+    /// <see cref="WptTestResult.ReferenceMatchPercent"/>.
+    /// </remarks>
+    private (double? Percent, string? Note) VerifyAgainstReferenceHtml(
         string testPath, string html, string? wptRoot,
-        HTML.Image.BBitmap testRender, HTML.Image.BBitmap committedGolden)
+        HTML.Image.BBitmap testRender, HTML.Image.BBitmap committedGolden, double goldenPercent)
     {
         try
         {
@@ -1612,27 +1644,55 @@ internal sealed partial class WptTestRunner
             if (!TryResolveReferenceHref(ExtractMatchHref(html), testPath, wptRoot, out var refPath)
                 || !File.Exists(refPath))
             {
-                return null;
+                return (null, null);
             }
 
+            // A render that drew nothing agrees with any other blank render, so it cannot be used
+            // as evidence that the golden is the outlier.
             if (IsUniform(testRender) && !IsUniform(committedGolden))
-                return null;
+                return (null, null);
 
             using var refRender = RenderHtmlFileBitmap(refPath, wptRoot);
             using var diff = PixelDiffRunner.Compare(testRender, refRender, _pixelDiffConfig);
-            if (!diff.IsMatch)
-                return null;
-
             double pct = (1.0 - diff.DiffRatio) * 100;
-            return $"⚠ suspect reference: Broiler matches its rel=match reference HTML " +
-                   $"({pct:F1}%) but not the committed reference PNG — the committed reference " +
-                   "is likely stale/incorrect, not a Broiler bug";
+
+            if (diff.IsMatch)
+            {
+                return (pct,
+                    $"⚠ suspect reference: Broiler matches its rel=match reference HTML " +
+                    $"({pct:F1}%) but not the committed reference PNG — the committed reference " +
+                    "is likely stale/incorrect, not a Broiler bug");
+            }
+
+            // Short of the gate, but far closer to the test's own reference than to the golden:
+            // the two engines disagree about the reference, so most of the golden's mismatch is
+            // not something the engine is getting wrong about this test.
+            if (pct - goldenPercent >= ReferenceDisagreementMargin)
+            {
+                return (pct,
+                    $"ℹ reference disagreement: Broiler is {pct:F1}% against the test's own " +
+                    $"rel=match reference and {goldenPercent:F1}% against the committed PNG — " +
+                    "most of this gap is the two references disagreeing, not the test's own feature");
+            }
+
+            return (pct, null);
         }
         catch
         {
-            return null;
+            return (null, null);
         }
     }
+
+    /// <summary>
+    /// How far a test's score against its own reference must exceed its score against the committed
+    /// golden before the gap is attributed to the references disagreeing rather than to the engine.
+    /// </summary>
+    /// <remarks>
+    /// A margin rather than a second pass threshold, so it does not need tuning against the run's
+    /// own gate: the claim it supports is comparative ("far better against one than the other"),
+    /// not absolute. The cases it was sized for sit at 94% versus 0.8%.
+    /// </remarks>
+    private const double ReferenceDisagreementMargin = 25.0;
 
     /// <summary>
     /// Whether every pixel of <paramref name="bitmap"/> is the same colour — the signature of a
@@ -2029,11 +2089,18 @@ internal sealed partial class WptTestRunner
                 // and see whether Broiler's render actually matches it. If it does,
                 // the committed PNG — not Broiler — is the outlier (stale/incorrect
                 // reference), which we surface so triage doesn't chase a non-bug.
-                string? suspectReference = _verifyReferenceHtml
-                    ? VerifyAgainstReferenceHtml(testPath, html, wptRoot, rendered, reference)
-                    : null;
-                if (suspectReference != null)
-                    message = $"{message} [{suspectReference}]";
+                var (referencePercent, referenceNote) = _verifyReferenceHtml
+                    ? VerifyAgainstReferenceHtml(testPath, html, wptRoot, rendered, reference, matchPct)
+                    : (null, null);
+                if (referenceNote != null)
+                    message = $"{message} [{referenceNote}]";
+
+                // SuspectReference keeps its narrower meaning — Broiler *reproduced* the declared
+                // reference — because the ranking uses it to drop a test out of the candidates.
+                string? suspectReference =
+                    referenceNote != null && referencePercent is not null && referenceNote[0] == '⚠'
+                        ? referenceNote
+                        : null;
 
                 // Capture rendered / reference / diff PNGs for visual triage (#6).
                 var images = SaveFailureImages(testPath, wptRoot, rendered, reference, diff.DiffBitmap);
@@ -2048,6 +2115,7 @@ internal sealed partial class WptTestRunner
                     MismatchDiagnostics = diagnostics,
                     DisplacementProfile = displacementProfile,
                     SuspectReference = suspectReference,
+                    ReferenceMatchPercent = referencePercent,
                     LayoutAssertionFailures = layoutAssertionFailures,
                     RenderedImagePath = images.Rendered,
                     ReferenceImagePath = images.Reference,


### PR DESCRIPTION
## Summary

This PR adds support for rendering SVG `<path>` elements (which were previously ignored), fixes paint order so shapes render in document order rather than by type, establishes proper viewports for nested `<svg>` elements, and improves stroke width handling for non-scaling strokes.

## Key Changes

### SVG Path Support
- **New `SvgPathData.cs`**: Implements a complete SVG path `d` attribute parser that flattens curves into polylines
  - Supports all SVG path commands: M, L, H, V, C, S, Q, T, A, Z
  - Handles both absolute and relative coordinates
  - Subdivides cubic and quadratic Bézier curves into line segments (8-96 segments based on curve length)
  - Subdivides elliptical arcs into chords
  - Returns subpaths with closure information so closed paths render as polygons and open ones as polylines
  - Gracefully returns empty list for unparseable paths rather than rendering incorrect content

### Paint Order Fix
- **New `SvgPaintOrder.cs`**: Collects display items by document offset and sorts them before emission
  - Previously, one regex per shape type swept the whole markup, causing all rects to paint before all circles before all text
  - Now segments are opened at their start-tag offset and flushed in document order
  - Supports clipping regions that apply to individual elements
  - Maintains stable sort so containers and their expanded content preserve relative order

### Nested Viewport Support
- **New `SvgRenderer.Viewport.cs`**: Implements proper viewport handling for nested `<svg>` elements
  - Nested `<svg>` elements now establish their own coordinate systems per SVG 1.1 §7.2
  - Recursively renders nested viewport content with proper coordinate transforms
  - Collects referenced definitions so external references work within nested viewports
  - Limits recursion depth to 6 to prevent pathological nesting
  - Properly inherits presentation attributes into nested content

### Stroke Width Improvements
- **New `StrokeWidthOf` method**: Correctly handles non-scaling strokes (SVG 2 §14.2)
  - Computes viewport scale from declared width vs. layout bounds
  - Applies viewport scale to stroke-width for non-scaling stroke behavior
  - Replaces previous `Math.Max(sx, sy)` approach which was incorrect for non-uniform scaling

### Filter Improvements
- **Enhanced `SvgColorFilter.cs`**: Adds support for `feBlend` with `feFlood` backdrops
  - Distinguishes between flood-only filters (which replace the shape) and floods that feed other primitives (which don't)
  - Implements blend mode application when a flood serves as a backdrop

### Clip Path Support
- **New `CollectClipRects` method**: Extracts rectangular clip regions from `<clipPath>` elements
- **New `ClipRectFor` method**: Applies clip paths to individual elements
- Integrates with paint order system to apply clips at the right document position

### Structure Tracking
- **Enhanced `SvgStructure.cs`**: Tracks nested viewports and their content spans
  - Collects all non-root `<svg>` elements with their attributes and content
  - Prevents double-rendering of nested viewport content in outer passes

## Testing

- **New `SvgPathAndViewportTests.cs`**: Comprehensive test suite covering:
  - Path rendering with various command spellings
  - Curve flattening and arc handling
  - Closed vs. open subpath rendering
  - Multi-subpath fills with holes
  - Document order across element types
  - Nested viewport coordinate transforms
  - Clip path application

- **Enhanced `SvgColorFilterTests.cs`**: Tests for flood-as-backdrop vs. flood-only distinction

## Notable Implementation Details

- Path parsing uses a custom `Reader` class that handles SVG's flexible whitespace and number formatting
- Curve subdivision is length-based (not pixel-based) since viewport scale is unknown during parsing
- The paint order system uses stable sorting to preserve relative order of containers and their expanded content
- Nested viewports are rendered as separate documents with

https://claude.ai/code/session_01Meud5QyvnQCSU6GDTzmrY1