### PR TITLE
Fix containing block walk and aspect-ratio transfers for grid items

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/AtomicInlineContainingBlockTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/AtomicInlineContainingBlockTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Drawing;
+using Broiler.CSS;
+using Broiler.Layout.Engine;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// CSS2.1 §10.1: a box's containing block is established by its nearest ancestor
+/// <em>block container</em>. An atomic inline-level box — <c>inline-block</c>,
+/// <c>inline-table</c>, <c>inline-flex</c>, <c>inline-grid</c> — is one: it is inline-level
+/// on the outside but establishes an independent formatting context on the inside
+/// (§9.4.1; CSS Display 3 §2.5 for the inline-* flex/grid/table forms).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Only <c>inline-block</c> was named in the walk, so the other three were transparent to
+/// it and a descendant's containing block came back as whatever block ancestor lay beyond
+/// them. Everything resolved against a containing block was then resolved against the wrong
+/// box — a percentage height most visibly, since the ancestor's height is usually
+/// <c>auto</c> and the percentage therefore computes to <c>auto</c> rather than to a size.
+/// </para>
+/// <para>
+/// Found on WPT <c>css-grid/alignment/grid-item-aspect-ratio-justify-self-001</c>: a
+/// <c>height: 100%</c> item in a 24×32 <c>inline-grid</c> rendered <b>1008×2016</b>, the
+/// page's width taken through the item's <c>aspect-ratio</c>.
+/// </para>
+/// <para>These assertions read <see cref="CssBox.ContainingBlock"/> directly, which is the
+/// rule itself rather than one of its consequences; the end-to-end sizing it fixes is
+/// pinned by <c>Broiler.Cli.Tests.AtomicInlineContainingBlockTests</c>.</para>
+/// </remarks>
+public sealed class AtomicInlineContainingBlockTests
+{
+    private static readonly Uri BaseUrl = new("file:///containing-block.html");
+
+    /// <summary>The four atomic inline-level displays. Each establishes a containing block
+    /// for its contents exactly as its block-level counterpart does.</summary>
+    [Theory]
+    [InlineData(CssConstants.InlineBlock)]
+    [InlineData("inline-table")]
+    [InlineData("inline-flex")]
+    [InlineData("inline-grid")]
+    public void AnAtomicInlineLevelBoxIsTheContainingBlockForItsContents(string display)
+    {
+        var (wrapper, child) = PageWithAWrapper(display);
+
+        Assert.Same(wrapper, child.ContainingBlock);
+    }
+
+    /// <summary>The block-level counterparts, which were already right — kept beside the
+    /// theory above so the pairing is the assertion rather than a comment about one.</summary>
+    [Theory]
+    [InlineData(CssConstants.Block)]
+    [InlineData(CssConstants.Table)]
+    [InlineData("flex")]
+    [InlineData("grid")]
+    public void SoIsItsBlockLevelCounterpart(string display)
+    {
+        var (wrapper, child) = PageWithAWrapper(display);
+
+        Assert.Same(wrapper, child.ContainingBlock);
+    }
+
+    /// <summary>The control that keeps the rule to <em>atomic</em> inline-level boxes: a
+    /// non-replaced <c>display: inline</c> box is not a block container and establishes no
+    /// containing block, so the walk still passes straight through it to the block above.
+    /// </summary>
+    [Fact]
+    public void APlainInlineIsStillTransparentToTheWalk()
+    {
+        var (wrapper, child) = PageWithAWrapper(CssConstants.Inline);
+
+        Assert.NotSame(wrapper, child.ContainingBlock);
+        Assert.Same(wrapper.ParentBox, child.ContainingBlock);
+    }
+
+    // ───────────────────────────────── the shape ─────────────────────────────────
+
+    private const float PageWidth = 400;
+
+    /// <summary>root → body → wrapper → child, the chain the walk climbs.</summary>
+    private static (CssBox Wrapper, CssBox Child) PageWithAWrapper(string wrapperDisplay)
+    {
+        var root = new CssBox(null, null, BaseUrl)
+        {
+            Location = PointF.Empty,
+            Size = new SizeF(PageWidth, PageWidth),
+            Display = CssConstants.Block,
+            FontSize = "16px",
+        };
+
+        var body = new CssBox(root, new HtmlTag("body", false, null), BaseUrl)
+        {
+            Display = CssConstants.Block,
+            FontSize = "16px",
+        };
+
+        var wrapper = new CssBox(body, new HtmlTag("div", false, null), BaseUrl)
+        {
+            Display = wrapperDisplay,
+            Height = "32px",
+            FontSize = "16px",
+        };
+
+        var child = new CssBox(wrapper, new HtmlTag("div", false, null), BaseUrl)
+        {
+            Display = CssConstants.Block,
+            Height = "100%",
+            FontSize = "16px",
+        };
+
+        return (wrapper, child);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.ContainingBlock.cs
@@ -18,21 +18,32 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             // CSS2.1 §10.1: The containing block for a box is the nearest
             // ancestor that is a block container.  Block containers include:
             //   - block-level boxes (display:block, flex, grid)
-            //   - inline-block boxes (display:inline-block)
+            //   - atomic inline-level boxes (inline-block, inline-table,
+            //     inline-flex, inline-grid)
             //   - list-item boxes
             //   - table cells (display:table-cell)
             //   - table boxes (display:table)
             //   - table captions (display:table-caption)
-            // Inline-block establishes a BFC (§9.4.1), so its block-level
-            // children must use it as their containing block.  A table caption
-            // is a block container that establishes an independent BFC
-            // (CSS2.1 §17.4), so its in-flow children resolve their width and
-            // position against the caption's content box, not a further-up
-            // ancestor — critical when the caption is sized/rotated by its own
-            // writing mode (its children must inherit its inline size, not the
-            // viewport's).
+            // An atomic inline-level box establishes an independent formatting
+            // context for its contents (§9.4.1 for inline-block; CSS Display 3
+            // §2.5 for the inline-* flex/grid/table forms), so its in-flow
+            // descendants resolve their sizes and positions against it and not
+            // against a further-up ancestor.  Listing only `inline-block` here
+            // left the other three transparent, and a percentage height inside
+            // one then resolved against whatever block ancestor lay beyond it:
+            // an `inline-grid` of a stated height holding a `height: 100%` item
+            // saw `<body>`'s auto height, so the percentage computed to auto —
+            // which an `aspect-ratio` on the item then turned into the *body's*
+            // width transferred through the ratio, escaping the grid entirely
+            // (WPT css-grid/alignment/grid-item-aspect-ratio-justify-self-001,
+            // where a 16×32 item rendered 24×2016).  A table caption is a
+            // block container that establishes an independent BFC (CSS2.1
+            // §17.4), so its in-flow children resolve their width and position
+            // against the caption's content box — critical when the caption is
+            // sized/rotated by its own writing mode (its children must inherit
+            // its inline size, not the viewport's).
             while (!box.IsBlock
-                   && box.Display != CssConstants.InlineBlock
+                   && !CssBoxHelper.IsAtomicInlineLevel(box.Display)
                    && box.Display != CssConstants.ListItem
                    && box.Display != CssConstants.Table
                    && box.Display != CssConstants.TableCell
@@ -529,7 +540,10 @@ internal partial class CssBox : CssBoxProperties, IDisposable
     /// block's padding box (the viewport when that is the initial containing
     /// block) — an abspos box's containing block always has a definite height,
     /// unlike the flow containing block, whose height may be auto/indefinite.
-    /// Otherwise the flow containing block's used height is returned.
+    /// Otherwise the flow containing block's used <em>content</em> height is
+    /// returned: §10.5 resolves a percentage against the containing block's
+    /// content box, so the containing block's own padding and border are not part
+    /// of the basis in either branch below.
     /// </summary>
     private double PercentageHeightContainingBlockHeight()
     {
@@ -562,11 +576,26 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         {
             double cssHeight = CssLengthParser.ParseLength(flowCb.Height, 0, flowCb.GetEmHeight());
 
+            // §10.5 resolves the percentage against the containing block's *content* box.
+            // Normalising the specified height to a border box instead added the containing
+            // block's own padding and border to every percentage inside it: a `height: 100%`
+            // child of a `height: 32px` box with a 2px border came out 36px, and 42px with
+            // 5px of padding. It went unnoticed because the two coincide whenever the
+            // containing block has neither, and because `box-sizing: border-box` — where the
+            // specified height already *is* the border box — takes the no-op path through
+            // both conversions.
             if (cssHeight > 0)
-                return flowCb.ResolveSpecifiedHeightToBorderBox(cssHeight);
+                return flowCb.ResolveSpecifiedHeightToContentBox(cssHeight);
         }
 
-        return flowCb?.Size.Height ?? 0;
+        // Size.Height is a border box, so the padding and border come off it to leave the
+        // content height, exactly as TryGetPercentageBlockSizeBasis does for the same box.
+        if (flowCb == null)
+            return 0;
+
+        return Math.Max(0, flowCb.Size.Height
+            - flowCb.ActualPaddingTop - flowCb.ActualPaddingBottom
+            - flowCb.ActualBorderTopWidth - flowCb.ActualBorderBottomWidth);
     }
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
@@ -633,6 +633,58 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             && !double.IsNaN(borderBoxHeight) && !double.IsInfinity(borderBoxHeight);
     }
 
+    /// <summary>
+    /// CSS Sizing 4 §4 in the other direction: the used border-box <em>width</em> this box's
+    /// <c>auto</c> inline axis takes from a definite block size and its preferred aspect ratio.
+    /// </summary>
+    /// <remarks>
+    /// <para><see cref="TryResolveAspectRatioBlockHeight"/> is the width→height transfer, which
+    /// is the one an ordinary in-flow box needs: its auto inline size fills the containing
+    /// block, so the width is known first. This is the inverse, and it applies wherever the
+    /// inline axis is <em>not</em> filled and so has no size of its own — a grid item whose
+    /// <c>justify-self</c> is positional rather than stretching being the case it was written
+    /// for. Until now only a replaced box could transfer this way
+    /// (<see cref="ResolveReplacedContentSize"/>).</para>
+    /// <para><paramref name="borderBoxHeight"/> is the block size the caller has already
+    /// settled — for a grid item, the one its area gave it — because this transfer is only
+    /// unambiguous when the block axis does not itself depend on the width being derived.</para>
+    /// </remarks>
+    internal bool TryResolveAspectRatioInlineWidth(double borderBoxHeight, out double borderBoxWidth)
+    {
+        borderBoxWidth = 0;
+
+        if (!TryParseAspectRatio(AspectRatio, out double ratio) || !(ratio > 0))
+            return false;
+
+        if (!(borderBoxHeight > 0))
+            return false;
+
+        // The ratio relates the two sizes of the box named by box-sizing, so the transfer
+        // happens in that box and the result is mapped back to a border box — the mirror of
+        // TryResolveAspectRatioBlockHeight, and the reason a bordered `box-sizing: content-box`
+        // item cannot simply multiply.
+        double specifiedWidth;
+        if (UsesBorderBoxSizing)
+        {
+            specifiedWidth = borderBoxHeight * ratio;
+        }
+        else
+        {
+            double contentHeight = borderBoxHeight
+                - ActualPaddingTop - ActualPaddingBottom
+                - ActualBorderTopWidth - ActualBorderBottomWidth;
+            if (!(contentHeight > 0))
+                return false;
+            specifiedWidth = contentHeight * ratio;
+        }
+
+        // CSS2.1 §10.4: the derived size is still subject to min-/max-width.
+        borderBoxWidth = ResolveInlineSizeBounds().Clamp(ResolveSpecifiedWidthToBorderBox(specifiedWidth));
+
+        return borderBoxWidth > 0
+            && !double.IsNaN(borderBoxWidth) && !double.IsInfinity(borderBoxWidth);
+    }
+
     /// <summary>Parses an <c>aspect-ratio</c> value (<c>&lt;number&gt; [ /
     /// &lt;number&gt; ]?</c>, ignoring a leading/trailing <c>auto</c> keyword)
     /// into a width/height ratio. Returns <c>false</c> for <c>auto</c>/<c>none</c>

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -799,6 +799,25 @@ internal partial class CssBox
             if (h > 0) newHeight = h;
         }
 
+        // CSS Sizing 4 §4: an item whose inline axis is not stretched has an *auto* inline
+        // size, so a preferred aspect ratio takes it from the block size the area just gave
+        // it. Ordinary boxes only ever transfer width→height, because their auto width fills
+        // the containing block and so is known first; a non-stretching justify-self is the
+        // case where that is not true and the transfer has to run the other way. Without it
+        // the item kept the width it had filled its containing block with and the ratio never
+        // applied at all — WPT css-grid/alignment/grid-item-aspect-ratio-justify-self-001 asks
+        // for 16×32 in a 24×32 area and got 24×32.
+        // Only an *auto* inline size is the ratio's to fill in. `widthFills` is already false
+        // for a stated `width: 20px` — that item does not fill its area either — so testing it
+        // alone would have let the ratio overwrite an author's width.
+        bool widthIsAuto = string.IsNullOrEmpty(item.Width) || item.Width == CssConstants.Auto;
+
+        if (!widthFills && widthIsAuto && replacedDefiniteH <= 0
+            && item.TryResolveAspectRatioInlineWidth(newHeight, out double ratioWidth))
+        {
+            newWidth = ratioWidth;
+        }
+
         // Alignment of a non-filling item within its area (start by default).
         if (!widthFills)
         {

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -715,6 +715,119 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
   half holding the test at 2.26%. Re-measured 2026-08-13: it renders the reference
   exactly and is absent from the CI failure manifest.
 
+### An atomic inline-level box was not a containing block, and a percentage height included its border
+
+Two CSS2.1 defects in one file, found together on one grid test and each far wider than
+the test that exposed it.
+
+- **Test:** `css-grid/alignment/grid-item-aspect-ratio-justify-self-001`, CI 3.9%
+  ([#1661](https://github.com/Broiler-Platform/Broiler/issues/1661).11). Its
+  `check-layout-th.js` assertions go **2 / 40 → 20 / 40**: 18 of the 20 height assertions
+  pass, where none did. The 20 that remain are one unimplemented rule and stay open as
+  [`justify-self` on a grid item is not honoured](wpt-rendering-gaps-open.md#justify-self-on-a-grid-item-is-not-honoured).
+- **Owner:** `Broiler.Layout` (`Engine/CssBox.ContainingBlock.cs`). Main repo, no patch.
+- **The entry this replaces had the right bisect and the wrong suspect, twice.** It ruled
+  out `CanTransferAspectRatioToBlockHeight` correctly, then reasoned that "the item's
+  containing block is the `height: 32px` grid container". It is not — it is `<body>`, and
+  the entry's own instruction to confirm that under a debugger before changing anything
+  is what turned a plausible story into the actual cause.
+
+**1. An atomic inline-level box was transparent to the containing-block walk.**
+
+- §10.1 puts a box's containing block at its nearest ancestor **block container**, and
+  `inline-block`, `inline-table`, `inline-flex` and `inline-grid` are all block
+  containers: inline-level on the outside, an independent formatting context on the
+  inside. The walk named only `inline-block`, so the other three were climbed straight
+  past and a descendant's containing block came back as whatever block ancestor lay
+  beyond them.
+- **Why it presented as an `aspect-ratio` bug.** The wrong containing block is `<body>`,
+  whose height is `auto`, so `height: 100%` computes to `auto` (§10.5). That is
+  ordinarily invisible in a grid — stretch alignment fills the area with the right size
+  anyway, which is why the item measures a correct 24×32 *without* the ratio. An
+  `aspect-ratio` is what turns that `auto` into a **transfer from the used width**, and
+  the used width came from the wrong containing block too: 1008 × 2 = **2016**, the
+  height this test rendered for a 32px item.
+- Neither condition alone reproduces, in any container. Measured on a 24×32 container
+  holding one `height: 100%` item, on a 1024px-wide page:
+
+  | Container | Item | Before | After |
+  | --- | --- | --- | --- |
+  | `inline-grid` | `height: 100%` | 24×32 | 24×32 |
+  | `inline-grid` | `height: 100%` + `aspect-ratio` | **24×2048** | **24×32** |
+  | `grid` | `height: 100%` + `aspect-ratio` | 24×32 | 24×32 |
+  | `block` | `height: 100%` + `aspect-ratio` | 24×32 | 24×32 |
+  | `inline-block` | `height: 100%` + `aspect-ratio` | 24×32 | 24×32 |
+
+**2. A percentage height resolved against the containing block's border box.**
+
+- `PercentageHeightContainingBlockHeight` normalised the containing block's specified
+  height **to a border box** before resolving the percentage against it. §10.5 resolves
+  against the **content** box, and the same file already carries
+  `ResolveSpecifiedHeightToContentBox`, documented for exactly this and used by the
+  sibling `min-`/`max-height` path (`TryGetPercentageBlockSizeBasis`). The two disagreed
+  with each other, and only one of them was right.
+- **Measured on a `height: 100%` child of a `height: 32px` box**, which is 32 in every
+  row a browser renders:
+
+  | Containing block | Before | After |
+  | --- | --- | --- |
+  | `height: 32px` | 32 | 32 |
+  | `+ border: 2px` | **36** | 32 |
+  | `+ padding: 5px` | **42** | 32 |
+  | `+ box-sizing: border-box`, with the 2px border | 28 | 28 |
+
+- **It hid behind two coincidences.** The border box and the content box are the same
+  height whenever the containing block has neither border nor padding — the common case —
+  and under `box-sizing: border-box` the specified height already *is* the border box, so
+  both conversions are no-ops and the answer came out right by not doing anything. The
+  same slip sat in the fallback that reads a settled `Size.Height`; it is stripped now,
+  the way the min/max path already stripped it.
+
+- **Sweep: 5 112 reftests over `css-grid`, `css-flexbox`, `css-sizing`, `css-tables`,
+  `css-display`, `css-inline`, `css-writing-modes` and `css-position`, before and after
+  on the same build — 2 397 → 2 395 passing, +7 and −9.** A net −2, and worth reading
+  rather than summing:
+  - **The 7 gains are real features on both sides**: five `css-grid/subgrid` tests
+    (`repeat-auto-fill-002/-003/-004` at 95.3% → 100.0%, 89.6% → 99.2%,
+    `placement-implicit-001` 97.9% → 100.0%, `orthogonal-writing-mode-005` 96.9% →
+    99.7%) and two `grid-lanes` gap tests at 96.5% → 100.0%.
+  - **All 9 losses are `grid-lanes/subgrid/grid-subgridded-to-grid-lanes`, and every one
+    of them is a fake pass unmasked on the *reference* side.** Those tests declare
+    `display: inline-grid-lanes`, which Broiler
+    [deliberately drops](wpt-rendering-gaps-open.md#grid-lanes-is-an-unshipped-draft-feature)
+    so the element keeps its default `block`; their references declare a real
+    `display: inline-grid`. Rendering both sides of `row-subgrid-grid-gap-013` on both
+    builds settles it: **the test render is byte-identical** (same MD5 before and after),
+    and only the reference moved — from an inner subgrid stretched across the full
+    1024px page to one honouring its `min-width: 30px`. The pair had been agreeing at
+    99.07% because the reference shared the bug; it is 74.02% now because it does not.
+    The eight others are the same shape, all previously sitting at 99.07–99.78%, just
+    over the gate.
+  - **Attributed, not assumed.** All 16 moved tests were re-run on a third build carrying
+    only the containing-block walk: every move reproduces there, so **the percentage-basis
+    fix moved no test in the 5 112**. It is spec-correct and inert on this corpus, and its
+    effect is on the layout assertions above, which the pixel suite never reaches — the
+    test declares no `rel=match`.
+- **Unit suites: `Broiler.Layout.Tests` 908 / 908, and `Broiler.Cli.Tests` holds its
+  baseline** — 53 pre-existing failures before, the same 53 after, plus the 13 new tests
+  passing. One test differed between the two full runs
+  (`ScriptCompileAheadOverlapTests.Every_Source_Is_Compiled_By_A_Worker_When_The_Budget_Is_On`)
+  and is **not** this change: it is a worker-scheduling budget assertion that touches no
+  layout code, and it passes in isolation on both builds. Re-run before believing it, the
+  way [the flaky view-transition test](wpt-rendering-gaps-open.md#one-test-is-flaky) had
+  to be.
+- **Tests:** `Broiler.Layout.Tests/AtomicInlineContainingBlockTests.cs` reads
+  `CssBox.ContainingBlock` directly — the four atomic inline displays, their four
+  block-level counterparts, and a plain `display: inline` control that must stay
+  transparent to the walk (three of the four atomic cases fail without the fix).
+  `Broiler.Cli.Tests/AtomicInlineContainingBlockTests.cs` drives the same claim through
+  real pages, as a parity assertion rather than absolute numbers: an atomic inline-level
+  container must size its descendants exactly as its block-level counterpart does. That
+  keeps it honest about the pairs whose shared behaviour is still wrong for other reasons
+  — a percentage height inside a `table` resolves no better than inside an
+  `inline-table`, and pinning today's number there would fail the day that separate gap
+  is closed.
+
 ---
 
 ## Paint and the renderer

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -809,13 +809,13 @@ the test that exposed it.
     effect is on the layout assertions above, which the pixel suite never reaches — the
     test declares no `rel=match`.
 - **Unit suites: `Broiler.Layout.Tests` 908 / 908, and `Broiler.Cli.Tests` holds its
-  baseline** — 53 pre-existing failures before, the same 53 after, plus the 13 new tests
-  passing. One test differed between the two full runs
-  (`ScriptCompileAheadOverlapTests.Every_Source_Is_Compiled_By_A_Worker_When_The_Budget_Is_On`)
-  and is **not** this change: it is a worker-scheduling budget assertion that touches no
-  layout code, and it passes in isolation on both builds. Re-run before believing it, the
-  way [the flaky view-transition test](wpt-rendering-gaps-open.md#one-test-is-flaky) had
-  to be.
+  baseline exactly** — 53 pre-existing failures before, the same 53 after, the failing set
+  identical name for name, plus the new tests passing. One intermediate run reported a 54th
+  (`ScriptCompileAheadOverlapTests.Every_Source_Is_Compiled_By_A_Worker_When_The_Budget_Is_On`);
+  it did not recur, it passes in isolation on both builds, and it is a worker-scheduling
+  budget assertion that touches no layout code — the machine was under memory pressure from
+  a concurrent sweep. Re-run before believing a diff, the way
+  [the flaky view-transition test](wpt-rendering-gaps-open.md#one-test-is-flaky) had to be.
 - **Tests:** `Broiler.Layout.Tests/AtomicInlineContainingBlockTests.cs` reads
   `CssBox.ContainingBlock` directly — the four atomic inline displays, their four
   block-level counterparts, and a plain `display: inline` control that must stay
@@ -862,6 +862,14 @@ the test that exposed it.
   arithmetic for the content-box row said 18 and was wrong; the engine and Chromium both
   say 20 × 36. The three rows whose block axis Chromium drives back through the ratio are
   recorded as the remaining gap rather than pinned at today's value.
+- **Sweep: the same 5 112 reftests, and it moves nothing at all** — 2 395 passing before and
+  after, `+0 / −0`, average match identical to three decimals. That is the expected result
+  rather than a disappointing one: the transfer fires only for a grid item that carries an
+  `aspect-ratio`, has an auto inline size *and* is not stretched, and no reftest in this
+  corpus combines the three. **The evidence for this change is the layout assertions and the
+  Chromium comparison, not the pixel suite** — the test it was written for declares no
+  `rel=match`, so the reftest runner never sees it. Worth stating plainly, because a `+0/−0`
+  sweep is only reassuring once you know it was capable of showing something.
 - **Tests:** `Broiler.Cli.Tests/GridItemAspectRatioInlineSizeTests.cs` — the nine
   non-stretching `justify-self` values, the `normal`/`stretch` control that must still fill
   its area (a fix that applied the ratio unconditionally would pass the first and fail the

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -828,6 +828,45 @@ the test that exposed it.
   `inline-table`, and pinning today's number there would fail the day that separate gap
   is closed.
 
+### A non-stretching grid item could not take its inline size from its `aspect-ratio`
+
+- **Test:** `css-grid/alignment/grid-item-aspect-ratio-justify-self-001`, whose assertions
+  go **20 / 40 → 29 / 40** on top of the containing-block fixes above. All nine
+  non-stretching rows of the first group now measure **16×32** exactly, where they measured
+  24×32. What remains is
+  [two other rules](wpt-rendering-gaps-open.md#a-definite-inline-size-does-not-drive-the-block-axis-through-an-aspect-ratio).
+- **Owner:** `Broiler.Layout` (`Engine/CssBox.Sizing.cs`, `Engine/CssBoxGrid.cs`). Main
+  repo, no patch.
+- **`justify-self` was implemented; the ratio could not run in the direction it needed.**
+  `PlaceItemInArea` already declines to stretch an item whose `justify-self` is positional
+  and aligns it in its area instead — the item simply *arrived* 24 wide, having filled its
+  containing block during ordinary layout, and nothing then re-derived it. Reading the
+  alignment code as missing would have been the wrong repair.
+- **Only one of the two transfer directions existed for a non-replaced box.**
+  `CanTransferAspectRatioToBlockHeight` takes an auto *height* from the used width, which is
+  the direction an ordinary in-flow box needs: its auto width fills the containing block, so
+  the width is known first. A grid item that is **not** stretched is the case where that is
+  untrue — its inline size is auto and its block size is the definite one the area gave it —
+  and the transfer has to run block→inline. Until now only a replaced box could do that
+  (`ResolveReplacedContentSize` fills in whichever axis is auto).
+  `TryResolveAspectRatioInlineWidth` is the new mirror of the existing helper, applying the
+  ratio in the box named by `box-sizing` and clamping the result to `min-`/`max-width`.
+- **The guard is the part worth keeping.** A first draft fired whenever the item did not
+  fill its area, which is also true of an item with a stated `width: 20px` — and it
+  overwrote that 20 with the ratio's 16. Only an *auto* inline size is the ratio's to fill
+  in. The test that caught it is in the landed set.
+- **Checked against Chromium on five shapes, not derived on paper.** All five widths agree:
+  16 for the plain border-box case, 20 for `box-sizing: content-box` with 2px of padding
+  (the ratio halves the *content* height, and the padding brings the border box back to 20),
+  20 under a `min-width` floor, 20 for a stated width, and 24 when stretched. The paper
+  arithmetic for the content-box row said 18 and was wrong; the engine and Chromium both
+  say 20 × 36. The three rows whose block axis Chromium drives back through the ratio are
+  recorded as the remaining gap rather than pinned at today's value.
+- **Tests:** `Broiler.Cli.Tests/GridItemAspectRatioInlineSizeTests.cs` — the nine
+  non-stretching `justify-self` values, the `normal`/`stretch` control that must still fill
+  its area (a fix that applied the ratio unconditionally would pass the first and fail the
+  second), the stated-width and `min-width` guards, and the `box-sizing` case.
+
 ---
 
 ## Paint and the renderer

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -201,42 +201,71 @@ golden suite never looks at a passing test's own reference.
   the check that subgrid stays a no-op while that is fixed, since the reference
   depends on it being one.
 
-### `justify-self` on a grid item is not honoured
+### A definite inline size does not drive the block axis through an `aspect-ratio`
 
 - **Test:** `css-grid/alignment/grid-item-aspect-ratio-justify-self-001`, CI 3.9%
   ([#1661](https://github.com/Broiler-Platform/Broiler/issues/1661).11). Its own
-  `check-layout-th.js` assertions read **20 / 40**, up from 2 / 40 on
-  [two containing-block fixes](wpt-rendering-gaps-fixed.md#an-atomic-inline-level-box-was-not-a-containing-block-and-a-percentage-height-included-its-border).
-  The escape this entry used to describe — a 16×32 item rendering **24×2016**, with the
-  orthogonal group at 1008×1008 — is closed: **18 of the 20 height assertions pass**,
-  where none did. What is left is one rule.
+  `check-layout-th.js` assertions read **29 / 40**, up from 2 / 40 over two changes: the
+  [two containing-block fixes](wpt-rendering-gaps-fixed.md#an-atomic-inline-level-box-was-not-a-containing-block-and-a-percentage-height-included-its-border)
+  and then
+  [the block→inline ratio transfer](wpt-rendering-gaps-fixed.md#a-non-stretching-grid-item-could-not-take-its-inline-size-from-its-aspect-ratio).
+  Two separate rules remain, and neither is `justify-self`, which this entry was briefly
+  named for and which turned out to be implemented already.
 - **What the test asks.** Eleven grid items, each `aspect-ratio: 1/2` and `height: 100%`
   of a 24×32 `inline-grid`, one per `justify-self` value. The nine *non-stretching*
-  values (`start`, `end`, `self-start`, `self-end`, `flex-start`, `flex-end`, `left`,
-  `right`, `center`) must leave the inline axis free, so it is derived from the definite
-  height through the ratio: **16×32**. Only `normal` and `stretch` fill the 24px area,
-  and there the definite *width* feeds the ratio back the other way: **24×48**. A second
-  group repeats the nine with the item in an orthogonal writing mode.
-- **The 20 failures are 18 of one kind and 2 of another.**
-  - **18 — every non-stretching row, in both groups — report `width 24`.** The item is
-    stretched to the full 24px inline size of its grid area whatever `justify-self` says,
-    so the axis is never left free for the ratio to size. `justify-self` is not honoured:
-    a non-`normal`/`stretch` value has to make a grid item's auto inline size
-    **shrink-to-fit its area rather than fill it** (CSS Grid §10.2, CSS Box Alignment
-    §6.2). That is the whole of this entry.
-  - **2 — the `normal` and `stretch` rows — report `height 32` where the test asks 48**,
-    with their widths correct at 24. **This one is not explained yet.** 32 is `height:
-    100%` of the 32px grid; 48 is the ratio applied to the stretched 24px width, so the
-    test asserts that the ratio displaces the percentage here. Whether that follows from
-    the row being indefinite at the time the item is sized, or is a second gap, needs
-    measuring against Chromium's box tree before anything is claimed — note the test's
-    own author dropped these two rows from the orthogonal group with a `TODO` saying
-    *"these ones behave differently in every browser"*.
-- **What is no longer in question:** `aspect-ratio` itself. It transfers correctly in
-  every case the four-container table exercises, which is what made the old reading of
-  this test — an `aspect-ratio` bug — wrong.
-- **Exit gate:** the test's 40 assertions pass, with the container table pinned by
-  `Broiler.Cli.Tests.AtomicInlineContainingBlockTests` staying correct in every row.
+  values must leave the inline axis free so it comes from the height through the ratio —
+  **16×32**, which now passes. `normal` and `stretch` fill the 24px area, and there the
+  definite *width* feeds the ratio back the other way: **24×48**. A second group repeats
+  the nine with the item in an orthogonal writing mode.
+
+**1. The inline→block direction of the transfer is missing (2 failures).**
+
+- The `normal` and `stretch` rows are 24 wide, correctly, and **32 tall where the test
+  asks 48**. Once the item's inline size is definite, the ratio has to derive the block
+  size from it and displace the `height: 100%`.
+- **Measured against Chromium rather than reasoned about**, on three shapes that isolate
+  it from grid alignment entirely — the inline size is made definite three different ways
+  and the block axis follows it every time:
+
+  | Item in a 24×32 area, `aspect-ratio: 1/2`, `height: 100%` | Chromium | Broiler |
+  | --- | --- | --- |
+  | `justify-self: stretch` | 24 × **48** | 24 × 32 |
+  | `width: 20px` | 20 × **40** | 20 × 32 |
+  | `min-width: 20px` (floor beats the ratio's 16) | 20 × **40** | 20 × 32 |
+
+  Every width already agrees; every height is the same single missing rule. `height: 100%`
+  losing to a ratio-derived height is the part worth pinning in a focused test, since it
+  is the surprising half.
+- **Owner:** `Broiler.Layout`. The inverse already exists in both directions for a
+  *replaced* box (`ResolveReplacedContentSize` fills in whichever axis is auto), and
+  block→inline now exists for a grid item (`TryResolveAspectRatioInlineWidth`); this is the
+  remaining quadrant.
+
+**2. An orthogonal grid item's two axes are crossed in `PlaceItemInArea` (9 failures).**
+
+- The nine non-stretching rows of the *orthogonal* group still report **width 24** where
+  the first group now gives 16 — the fix that closed the first group does not reach them.
+- **Traced, not guessed.** `PlaceItemInArea` decides whether an item fills its area from
+  `item.Width`/`item.Height`, but works in physical space (`areaWidth`/`areaHeight`,
+  `Location.X`/`Y`). For a box the vertical-flow rotation will transpose,
+  `CssBoxProperties.ResolvePhysicalSize` reports **logical** sizes — and for
+  `.item { height: 100% }` in `vertical-rl` **both `Width` and `Height` come back
+  `"100%"`**, so the two physical axes cannot be told apart there at all. The "a
+  percentage always fills its area" shortcut then fires on the inline axis of an item
+  whose `justify-self` says not to fill it, and `widthFills` is `true` under
+  `justify-self: start`.
+- **Why it was not fixed with the rest.** The repair is an accessor for the author's
+  physical declarations, which is small — but it changes which orthogonal grid items fill
+  their area *in general*, not only ones carrying a ratio, so it needs its own before/after
+  sweep rather than riding along on a narrower change.
+- Note the test's own author dropped the `normal`/`stretch` rows from this group with a
+  `TODO` saying *"these ones behave differently in every browser"*, so the orthogonal group
+  is nine assertions, not eleven.
+
+- **Exit gate:** the test's 40 assertions pass; the tables in
+  `Broiler.Cli.Tests.GridItemAspectRatioInlineSizeTests` and
+  `AtomicInlineContainingBlockTests` stay correct in every row; and the three Chromium
+  shapes above agree.
 
 ### Not triaged
 

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -201,53 +201,42 @@ golden suite never looks at a passing test's own reference.
   the check that subgrid stays a no-op while that is fixed, since the reference
   depends on it being one.
 
-### `aspect-ratio` on a grid item escapes an `inline-grid`
+### `justify-self` on a grid item is not honoured
 
 - **Test:** `css-grid/alignment/grid-item-aspect-ratio-justify-self-001`, CI 3.9%
-  ([#1661](https://github.com/Broiler-Platform/Broiler/issues/1661).11). Was listed
-  here as not triaged; it now has an isolated repro.
-- **What the test asks.** A grid item with `aspect-ratio: 1/2`, `height: 100%` of a
-  32px grid and a *non-stretching* `justify-self` must take its inline size from the
-  height through the ratio: **16×32**. With `justify-self: normal`/`stretch` it fills
-  the 24px area instead and is 24×48.
-- **What we produce: 1008×2016** — the item escapes the grid entirely and fills the
-  page. `check-layout-th.js` reports it directly, which is what makes this precise
-  rather than a pixel percentage:
-
-  ```
-  div.item  width   expected 16  actual 1008
-  div.item  height  expected 32  actual 2016
-  ```
-
-- **It is the `inline-grid`, not the ratio and not the alignment.** Bisected with a
-  four-case repro:
-
-  | Container | Item | Result |
-  | --- | --- | --- |
-  | `inline-grid` | `height: 100%` | **correct** |
-  | `inline-grid` | `height: 100%` + `aspect-ratio` | **escapes** — 24 wide, the page's height tall |
-  | `grid` (block-level) | `height: 100%` + `aspect-ratio` | correct |
-  | `block` | `height: 100%` + `aspect-ratio` | correct |
-  | `inline-block` | `height: 100%` + `aspect-ratio` | correct |
-
-  So neither `aspect-ratio` alone nor an item's percentage height in an `inline-grid`
-  alone is broken; only the pair. The percentage height stops resolving against the
-  grid area and resolves against the initial containing block, and the ratio then
-  carries that wrong height into the inline axis.
-- **Where to look — and one place it is *not*.** The obvious suspect,
-  `CssBox.Sizing.cs`'s `CanTransferAspectRatioToBlockHeight`, is **ruled out**: the
-  item's containing block is the `height: 32px` grid container, so
-  `HeightPercentageResolvesToAuto()` is false, and that guard returns false before the
-  width→height transfer is reached. The remaining candidate is the path an
-  *inline-level* container's contents take — `CssBox.ContainingBlock.cs` notes that an
-  atomic inline computes its height in `CssLayoutEngine`'s inline flow rather than in
-  `ResolveUsedBlockHeight`, and `inline-grid` is the only row of the table that goes
-  through it. **Confirm that with a debugger before changing anything**; this entry
-  records a bisect, not a root cause.
-- **Exit gate:** the four-case table above stays correct in every row, and the test's
-  22 assertions pass.
-- `justify-self`'s eleven values are a *second* requirement the test makes and are
-  not measured yet: nothing can be said about them until the item stays in its area.
+  ([#1661](https://github.com/Broiler-Platform/Broiler/issues/1661).11). Its own
+  `check-layout-th.js` assertions read **20 / 40**, up from 2 / 40 on
+  [two containing-block fixes](wpt-rendering-gaps-fixed.md#an-atomic-inline-level-box-was-not-a-containing-block-and-a-percentage-height-included-its-border).
+  The escape this entry used to describe — a 16×32 item rendering **24×2016**, with the
+  orthogonal group at 1008×1008 — is closed: **18 of the 20 height assertions pass**,
+  where none did. What is left is one rule.
+- **What the test asks.** Eleven grid items, each `aspect-ratio: 1/2` and `height: 100%`
+  of a 24×32 `inline-grid`, one per `justify-self` value. The nine *non-stretching*
+  values (`start`, `end`, `self-start`, `self-end`, `flex-start`, `flex-end`, `left`,
+  `right`, `center`) must leave the inline axis free, so it is derived from the definite
+  height through the ratio: **16×32**. Only `normal` and `stretch` fill the 24px area,
+  and there the definite *width* feeds the ratio back the other way: **24×48**. A second
+  group repeats the nine with the item in an orthogonal writing mode.
+- **The 20 failures are 18 of one kind and 2 of another.**
+  - **18 — every non-stretching row, in both groups — report `width 24`.** The item is
+    stretched to the full 24px inline size of its grid area whatever `justify-self` says,
+    so the axis is never left free for the ratio to size. `justify-self` is not honoured:
+    a non-`normal`/`stretch` value has to make a grid item's auto inline size
+    **shrink-to-fit its area rather than fill it** (CSS Grid §10.2, CSS Box Alignment
+    §6.2). That is the whole of this entry.
+  - **2 — the `normal` and `stretch` rows — report `height 32` where the test asks 48**,
+    with their widths correct at 24. **This one is not explained yet.** 32 is `height:
+    100%` of the 32px grid; 48 is the ratio applied to the stretched 24px width, so the
+    test asserts that the ratio displaces the percentage here. Whether that follows from
+    the row being indefinite at the time the item is sized, or is a second gap, needs
+    measuring against Chromium's box tree before anything is claimed — note the test's
+    own author dropped these two rows from the orthogonal group with a `TODO` saying
+    *"these ones behave differently in every browser"*.
+- **What is no longer in question:** `aspect-ratio` itself. It transfers correctly in
+  every case the four-container table exercises, which is what made the old reading of
+  this test — an `aspect-ratio` bug — wrong.
+- **Exit gate:** the test's 40 assertions pass, with the container table pinned by
+  `Broiler.Cli.Tests.AtomicInlineContainingBlockTests` staying correct in every row.
 
 ### Not triaged
 

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -8,7 +8,7 @@ documents, split by verdict:
 | --- | --- | --- |
 | [**Not fixed**](wpt-rendering-gaps-open.md) | real gaps, each with an owner, evidence and an exit gate | 50 |
 | [**Won't fix**](wpt-rendering-gaps-wont-fix.md) | tests Broiler renders correctly and the golden image does not | 17 |
-| [**Fixed**](wpt-rendering-gaps-fixed.md) | closed gaps, with root cause, what landed, and the wrong turns | 47 |
+| [**Fixed**](wpt-rendering-gaps-fixed.md) | closed gaps, with root cause, what landed, and the wrong turns | 48 |
 
 Start with *not fixed*. Read *won't fix* before starting on any 0.0% — closing one of
 those means deleting working support. But do not read a run's *Not ranked* heading as

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -8,7 +8,7 @@ documents, split by verdict:
 | --- | --- | --- |
 | [**Not fixed**](wpt-rendering-gaps-open.md) | real gaps, each with an owner, evidence and an exit gate | 50 |
 | [**Won't fix**](wpt-rendering-gaps-wont-fix.md) | tests Broiler renders correctly and the golden image does not | 17 |
-| [**Fixed**](wpt-rendering-gaps-fixed.md) | closed gaps, with root cause, what landed, and the wrong turns | 46 |
+| [**Fixed**](wpt-rendering-gaps-fixed.md) | closed gaps, with root cause, what landed, and the wrong turns | 47 |
 
 Start with *not fixed*. Read *won't fix* before starting on any 0.0% — closing one of
 those means deleting working support. But do not read a run's *Not ranked* heading as

--- a/src/Broiler.Cli.Tests/AtomicInlineContainingBlockTests.cs
+++ b/src/Broiler.Cli.Tests/AtomicInlineContainingBlockTests.cs
@@ -1,0 +1,120 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// CSS2.1 §10.1: a box's containing block is established by its nearest ancestor
+/// <em>block container</em>, and an atomic inline-level box — <c>inline-block</c>,
+/// <c>inline-table</c>, <c>inline-flex</c>, <c>inline-grid</c> — is one. Only
+/// <c>inline-block</c> was recognised, so the other three were transparent: the
+/// containing-block walk climbed straight past them to whatever block ancestor lay
+/// beyond, and every size a descendant resolved against its containing block was
+/// resolved against the wrong box.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Found on WPT <c>css-grid/alignment/grid-item-aspect-ratio-justify-self-001</c>, where a
+/// <c>height: 100%</c> item inside a 24×32 <c>inline-grid</c> came out <b>1008×2016</b> —
+/// the width of the page, carried into the block axis by the item's <c>aspect-ratio</c>.
+/// The two conditions are why it took a bisect to find: the percentage saw
+/// <c>&lt;body&gt;</c>'s auto height and so computed to <c>auto</c>, which is ordinarily
+/// harmless (grid stretch then fills the area with the right size anyway), and it is only
+/// an <c>aspect-ratio</c> on the item that turns that <c>auto</c> into a transfer from the
+/// item's used width — a width taken from the wrong containing block as well.
+/// </para>
+/// <para>
+/// The assertions are written as a parity claim rather than as absolute numbers: an atomic
+/// inline-level container must size its descendants exactly as its block-level counterpart
+/// does (<c>inline-grid</c> like <c>grid</c>, <c>inline-flex</c> like <c>flex</c>, and so
+/// on). That is the rule the fix implements, and it stays true of the pairs whose shared
+/// behaviour is still wrong for other reasons — a percentage height inside a
+/// <c>table</c> resolves no better than inside an <c>inline-table</c>, and pinning today's
+/// number there would fail the day that separate gap is closed.
+/// </para>
+/// </remarks>
+public sealed class AtomicInlineContainingBlockTests
+{
+    private const double ContainerWidth = 24;
+    private const double ContainerHeight = 32;
+
+    /// <summary>A container of a stated size holding one <c>height: 100%</c> item, optionally
+    /// carrying the <c>aspect-ratio</c> that is the second half of the bisect.</summary>
+    private static (double width, double height) Item(string containerDisplay, bool aspectRatio)
+    {
+        string html =
+            "<!DOCTYPE html><html><head><style>"
+            + $".container{{display:{containerDisplay};"
+            + $"width:{ContainerWidth}px;height:{ContainerHeight}px;position:relative}}"
+            + ".item{height:100%;" + (aspectRatio ? "aspect-ratio:1/2;" : "") + "}"
+            + "</style></head><body style=\"margin:0\"><div class=\"container\">"
+            + "<div class=\"item\" data-expected-width=\"0\" data-expected-height=\"0\"></div>"
+            + "</div></body></html>";
+
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///atomic-inline-containing-block.html");
+
+        var byProperty = bridge.EvaluateCheckLayoutAssertions()
+            .Where(a => a.Element.Contains("item"))
+            .ToDictionary(a => a.Property, a => a.Actual);
+
+        double Read(string property) =>
+            byProperty.TryGetValue(property, out double value) ? value : double.NaN;
+
+        return (Read("width"), Read("height"));
+    }
+
+    // ───────────── the rule: an atomic inline sizes like its block-level twin ─────────────
+
+    /// <summary>The general claim. Each pair is the same <c>display</c> keyword with and
+    /// without its <c>inline-</c> prefix, which changes only whether the container is
+    /// inline-level — never what containing block it establishes for its contents.</summary>
+    [Theory]
+    [InlineData("inline-block", "block", false)]
+    [InlineData("inline-block", "block", true)]
+    [InlineData("inline-grid", "grid", false)]
+    [InlineData("inline-grid", "grid", true)]
+    [InlineData("inline-flex", "flex", false)]
+    [InlineData("inline-flex", "flex", true)]
+    [InlineData("inline-table", "table", false)]
+    [InlineData("inline-table", "table", true)]
+    public void AnAtomicInlineContainerSizesItsItemLikeItsBlockLevelCounterpart(
+        string inlineLevel, string blockLevel, bool aspectRatio)
+    {
+        var inlineLevelItem = Item(inlineLevel, aspectRatio);
+        var blockLevelItem = Item(blockLevel, aspectRatio);
+
+        Assert.Equal(blockLevelItem.width, inlineLevelItem.width, 3);
+        Assert.Equal(blockLevelItem.height, inlineLevelItem.height, 3);
+    }
+
+    // ───────────────────────────── the defect it was found on ─────────────────────────────
+
+    /// <summary>The bisect table from the WPT triage, as an exit gate. Every row was already
+    /// correct except <c>inline-grid</c> with an <c>aspect-ratio</c>, which escaped the grid
+    /// and filled the page; neither condition alone reproduces it, so all four rows are
+    /// pinned.</summary>
+    [Theory]
+    [InlineData("inline-grid", false)]
+    [InlineData("inline-grid", true)]
+    [InlineData("grid", true)]
+    [InlineData("block", true)]
+    [InlineData("inline-block", true)]
+    public void APercentageHeightItemStaysInsideItsContainer(string containerDisplay, bool aspectRatio)
+    {
+        var item = Item(containerDisplay, aspectRatio);
+
+        Assert.Equal(ContainerWidth, item.width, 3);
+        Assert.Equal(ContainerHeight, item.height, 3);
+    }
+
+    // The control that keeps the rule to *atomic* inline-level boxes — a plain
+    // `display: inline` box establishes no containing block and the walk must still pass
+    // through it — is asserted against CssBox.ContainingBlock itself, in
+    // Broiler.Layout.Tests.AtomicInlineContainingBlockTests. Read through a page it would
+    // measure something else: a block inside an inline is split by the CSS2.1 §9.2.1.1
+    // block-inside-inline correction and lands in an anonymous auto-height block, so its
+    // percentage height computes to auto for a reason that has nothing to do with the walk.
+}

--- a/src/Broiler.Cli.Tests/GridItemAspectRatioInlineSizeTests.cs
+++ b/src/Broiler.Cli.Tests/GridItemAspectRatioInlineSizeTests.cs
@@ -1,0 +1,123 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// CSS Sizing 4 §4, the block→inline direction of the <c>aspect-ratio</c> transfer: a grid
+/// item whose <c>justify-self</c> is positional rather than stretching has an <c>auto</c>
+/// inline size, so its preferred ratio derives that size from the definite block size its
+/// grid area gave it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Broiler only ever transferred width→height for a non-replaced box, which is the direction
+/// an ordinary in-flow box needs — its auto width fills the containing block, so the width is
+/// known first and the height follows. A non-stretching grid item is the case where that is
+/// not true, and without the inverse the item simply kept the width it had filled its
+/// containing block with: WPT <c>css-grid/alignment/grid-item-aspect-ratio-justify-self-001</c>
+/// asks for a 16×32 item in a 24×32 area and got 24×32.
+/// </para>
+/// <para>
+/// The pairing with <c>normal</c>/<c>stretch</c> is the point of the theory below: the same
+/// item, in the same area, must be 24 wide when it is stretched and 16 when it is not. A fix
+/// that simply applied the ratio everywhere would pass the first half and fail the second.
+/// </para>
+/// </remarks>
+public sealed class GridItemAspectRatioInlineSizeTests
+{
+    /// <summary>The WPT shape: a 24×32 <c>inline-grid</c> holding one <c>height: 100%</c>
+    /// item with <c>aspect-ratio: 1/2</c>.</summary>
+    private static (double width, double height) Item(string justifySelf, string itemExtra = "")
+    {
+        string html =
+            "<!DOCTYPE html><html><head><style>"
+            + ".grid{display:inline-grid;width:24px;height:32px;position:relative}"
+            + ".item{height:100%;box-sizing:border-box;aspect-ratio:1/2;"
+            + $"justify-self:{justifySelf};{itemExtra}}}"
+            + "</style></head><body style=\"margin:0\"><div class=\"grid\">"
+            + "<div class=\"item\" data-expected-width=\"0\" data-expected-height=\"0\"></div>"
+            + "</div></body></html>";
+
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///grid-item-aspect-ratio.html");
+
+        var byProperty = bridge.EvaluateCheckLayoutAssertions()
+            .Where(a => a.Element.Contains("item"))
+            .ToDictionary(a => a.Property, a => a.Actual);
+
+        double Read(string property) =>
+            byProperty.TryGetValue(property, out double value) ? value : double.NaN;
+
+        return (Read("width"), Read("height"));
+    }
+
+    /// <summary>Every non-stretching <c>justify-self</c> the test names. The item's height is
+    /// the area's 32px and the 1/2 ratio makes it 16 wide — not the 24 of the area.</summary>
+    [Theory]
+    [InlineData("start")]
+    [InlineData("end")]
+    [InlineData("self-start")]
+    [InlineData("self-end")]
+    [InlineData("flex-start")]
+    [InlineData("flex-end")]
+    [InlineData("left")]
+    [InlineData("right")]
+    [InlineData("center")]
+    public void ANonStretchingItemTakesItsInlineSizeFromTheRatio(string justifySelf)
+    {
+        var item = Item(justifySelf);
+
+        Assert.Equal(16, item.width, 3);
+        Assert.Equal(32, item.height, 3);
+    }
+
+    /// <summary>The control, and the half that keeps the rule from being "apply the ratio
+    /// always": a stretching <c>justify-self</c> still fills the area's 24px inline size,
+    /// because there the inline axis is not auto for the ratio to fill in.</summary>
+    [Theory]
+    [InlineData("normal")]
+    [InlineData("stretch")]
+    public void AStretchingItemStillFillsItsArea(string justifySelf) =>
+        Assert.Equal(24, Item(justifySelf).width, 3);
+
+    /// <summary>An item with a stated width has no auto inline axis either, so the ratio has
+    /// nothing to fill in and the stated size stands whatever <c>justify-self</c> says. This
+    /// is the case that caught the first draft, where testing "does not fill its area" alone
+    /// let the ratio overwrite the author's 20px with its own 16.</summary>
+    [Fact]
+    public void AStatedWidthIsNotOverriddenByTheRatio() =>
+        Assert.Equal(20, Item("start", "width:20px;").width, 3);
+
+    /// <summary>CSS2.1 §10.4: the derived inline size is still subject to
+    /// <c>min-width</c>/<c>max-width</c>. The ratio asks for 16; the floor says 20.</summary>
+    [Fact]
+    public void TheDerivedInlineSizeIsClampedToMinWidth() =>
+        Assert.Equal(20, Item("start", "min-width:20px;").width, 3);
+
+    /// <summary>
+    /// The ratio relates the two sizes of the box named by <c>box-sizing</c>, so a
+    /// <c>content-box</c> item with padding cannot simply multiply the border box. Its
+    /// <c>height: 100%</c> is a 32px *content* height, making the border box 36; the ratio
+    /// halves the content height to a 16px content width, and the padding brings the border
+    /// box to 20. Measured in Chromium as 20.00 × 36.00 rather than derived on paper — the
+    /// arithmetic this test first shipped with said 18 and was wrong.
+    /// </summary>
+    [Fact]
+    public void TheRatioAppliesInTheBoxNamedByBoxSizing()
+    {
+        var item = Item("start", "box-sizing:content-box;padding:2px;");
+
+        Assert.Equal(20, item.width, 3);
+        Assert.Equal(36, item.height, 3);
+    }
+
+    // Only the inline axis is asserted above wherever the item's width ends up definite
+    // (`stretch`, a stated `width`, a `min-width` floor). Chromium then drives the *block*
+    // axis back through the ratio — 24×48, 20×40, 20×40 — overriding the `height: 100%`,
+    // and Broiler keeps 32 in all three. That is the one rule still missing, it is not this
+    // one, and it is recorded as such in docs/wpt-rendering-gaps-open.md. Asserting 32 here
+    // would pin the bug; asserting 48 would fail a test of a rule this file does not claim.
+}


### PR DESCRIPTION
## Summary

Fixes two CSS2.1 defects in layout that were found together on a single grid test but are each far wider in scope:

1. **Atomic inline-level boxes were transparent to the containing-block walk**, causing descendants to resolve sizes against the wrong ancestor. Only `inline-block` was recognized; `inline-table`, `inline-flex`, and `inline-grid` were skipped.

2. **Percentage heights resolved against the containing block's border box instead of its content box**, violating §10.5. This was hidden by coincidences (border/padding-less containers, `box-sizing: border-box`).

Additionally, implements the missing **block→inline direction of the aspect-ratio transfer** for non-stretching grid items, which cannot use the width→height path that ordinary in-flow boxes need.

## Changes

### Layout Engine (`Broiler.Layout`)

- **`CssBox.ContainingBlock.cs`**: Expanded the containing-block walk to recognize all four atomic inline-level displays (`inline-block`, `inline-table`, `inline-flex`, `inline-grid`), not just `inline-block`. Updated comments to explain why atomic inline boxes establish containing blocks for their contents.

- **`CssBox.Sizing.cs`**: 
  - Fixed `PercentageHeightContainingBlockHeight` to resolve percentages against the containing block's **content box** (not border box), using the existing `ResolveSpecifiedHeightToContentBox` helper that was already used by the min/max-height path.
  - Added `TryResolveAspectRatioInlineWidth`: new method implementing the block→inline direction of the aspect-ratio transfer. Mirrors the existing `TryResolveAspectRatioBlockHeight` but applies the ratio in the box named by `box-sizing` and clamps to `min-`/`max-width`.

- **`CssBoxGrid.cs`**: Modified `PlaceItemInArea` to apply the aspect-ratio inline-width transfer when a grid item has an auto inline size (i.e., when `justify-self` is positional rather than stretching). Guards against overwriting stated widths by checking that the inline axis is actually auto.

### Tests

- **`Broiler.Layout.Tests/AtomicInlineContainingBlockTests.cs`** (new): Unit tests reading `CssBox.ContainingBlock` directly, verifying that all four atomic inline displays establish containing blocks for their contents, and that plain `display: inline` remains transparent to the walk.

- **`Broiler.Cli.Tests/AtomicInlineContainingBlockTests.cs`** (new): End-to-end tests via real pages, asserting parity: an atomic inline-level container must size its descendants exactly as its block-level counterpart does.

- **`Broiler.Cli.Tests/GridItemAspectRatioInlineSizeTests.cs`** (new): Tests the block→inline aspect-ratio transfer on grid items, verifying that non-stretching `justify-self` values derive inline size from the block size and ratio, while stretching values still fill the area.

### Documentation

- **`docs/wpt-rendering-gaps-fixed.md`**: Added two new entries documenting both fixes with detailed explanations, measurement tables, and sweep results (5,112 reftests: 2,397 → 2,395 passing, with 7 real gains and 9 fake-pass unmasking on the reference side).

- **`docs/wpt-rendering-gaps-open.md`**: Updated the entry for `css-grid/alignment/grid-item-aspect-ratio-justify-self-001` to reflect the fixes applied and the two remaining rules still needed (inline→block ratio transfer and orthogonal grid item axis handling).

## Test Results

- **WPT**: `css-grid/alignment/grid-item-aspect-ratio-justify-self-001` assertions improve from **2/40 → 29/40** (18 height assertions now pass; 20 remain open for other rules).
- **Unit suites**: `Broiler.Layout.Tests` 908/908 passing; `Broiler.Cli.Tests` baseline unchanged

https://claude.ai/code/session_01STaSos7mt7hs32D16MWCJa