### PR TITLE
Fix flex and grid layout for out-of-flow and column-flex children

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
@@ -247,7 +247,61 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
         ActualBottom = cursorY + ActualPaddingBottom + ActualBorderBottomWidth;
         ActualRight = Location.X + Size.Width;
+
+        LayoutOutOfFlowFlexChildren(g, contentLeft, contentTop);
     }
+
+    /// <summary>
+    /// CSS Flexbox §4.1: an absolutely-positioned child of a flex container takes no part in
+    /// flex layout, but it is still laid out — and painted — with the container's content-box
+    /// start corner as its static position.
+    /// </summary>
+    /// <remarks>
+    /// This path replaces the ordinary block-flow child loop wholesale, and that loop is what
+    /// calls <see cref="PerformLayout"/> on every child. Without this, an out-of-flow child of a
+    /// flex container was never laid out at all and so never reached the canvas: a
+    /// <c>body { display: flex }</c> holding a fixed backdrop and an abspos panel painted
+    /// neither (WPT css-transforms/dynamic-fixed-pos-cb-change, whose test *and* reference both
+    /// rendered a bare background).
+    /// </remarks>
+    private void LayoutOutOfFlowFlexChildren(ILayoutEnvironment g, double contentLeft, double contentTop)
+    {
+        foreach (var child in Boxes)
+        {
+            if (child.Display == CssConstants.None
+                || child.Position is not (CssConstants.Absolute or CssConstants.Fixed))
+                continue;
+
+            child.Location = new PointF((float)contentLeft, (float)contentTop);
+            child.ActualBottom = contentTop;
+            child.PerformLayout(g);
+
+            // §4.1 again, for the axes no inset pinned: the static position is where the child
+            // would sit "as if it were the sole flex item", which is the container's content-box
+            // start corner. PerformLayout derives a *block container's* static position instead —
+            // the in-flow advance past the preceding sibling — so without this an all-`auto`
+            // child of a flex container holding one 10px-tall item landed 10px too low.
+            bool hasLeft = IsSpecifiedInset(child.Left), hasRight = IsSpecifiedInset(child.Right);
+            bool hasTop = IsSpecifiedInset(child.Top), hasBottom = IsSpecifiedInset(child.Bottom);
+
+            if (!hasLeft && !hasRight)
+            {
+                double dx = contentLeft + child.ActualMarginLeft - child.Location.X;
+                if (Math.Abs(dx) > 0.1)
+                    child.OffsetLeft(dx);
+            }
+
+            if (!hasTop && !hasBottom)
+            {
+                double dy = contentTop + child.ActualMarginTop - child.Location.Y;
+                if (Math.Abs(dy) > 0.1)
+                    child.OffsetTop(dy);
+            }
+        }
+    }
+
+    private static bool IsSpecifiedInset(string value) =>
+        !string.IsNullOrEmpty(value) && value != CssConstants.Auto;
 
     private static bool IsInFlowFlexItem(CssBox child) =>
         child.Display != CssConstants.None
@@ -380,6 +434,174 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// CSS Flexbox §9.7: distributes a <c>column</c> flex container's positive free space along
+    /// its main (block) axis, per <c>flex-grow</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A column container has no flex algorithm of its own here — its children stack through
+    /// ordinary block flow — so until this ran, <c>flex-grow</c> did nothing at all in a column:
+    /// a lone <c>flex-grow: 1</c> item in a 100px-tall container stayed at its content height.
+    /// This is the resolve-flexible-lengths step over that stack, applied afterwards.
+    /// </para>
+    /// <para>
+    /// It runs only when the container's main size is <b>definite</b>, which per §9.2 means a
+    /// specified <c>height</c> (then clamped by <c>min-height</c>/<c>max-height</c>) — not a
+    /// <c>min-height</c> alone. The distinction is exactly what
+    /// css-flexbox/percentage-heights-003 pins: its <c>height: 0; min-height: 100%</c> containers
+    /// flex their items to the clamped 100px, and its <c>min-height: 100%</c>-only containers,
+    /// whose main size stays content-based, leave them at zero.
+    /// </para>
+    /// <para>
+    /// Each grown item is laid out again at its target height rather than resized in place,
+    /// because a percentage-height descendant resolves against the item's used height — the
+    /// <c>span { height: 100% }</c> the same test measures — and poking <c>Size</c> alone would
+    /// leave it reading the pre-flex one. Single-line only: <c>column wrap</c> with items that
+    /// overflow the main axis needs real line breaking, which this does not attempt.
+    /// </para>
+    /// </remarks>
+    private void ApplyFlexColumnMainAxisSizing(ILayoutEnvironment g)
+    {
+        if (!IsFlexContainer() || IsRowFlexContainer())
+            return;
+
+        if (TryGetDefiniteMainAxisContentHeight() is not { } mainSize)
+            return;
+
+        var items = new List<CssBox>();
+        double usedOuterHeight = 0;
+
+        foreach (var child in Boxes)
+        {
+            if (!IsInFlowFlexItem(child) || IsCollapsibleWhitespaceItem(child))
+                continue;
+
+            items.Add(child);
+            usedOuterHeight += GetFlexItemOuterHeight(child);
+        }
+
+        if (items.Count == 0)
+            return;
+
+        double rowGap = ResolveFlexGap(RowGap, mainSize);
+        double freeSpace = mainSize - usedOuterHeight - Math.Max(0, items.Count - 1) * rowGap;
+
+        // Growth only. Shrinking is the other half of §9.7 and is deliberately left out:
+        // `flex-shrink` defaults to 1, so implementing it here would make every column
+        // container whose content overflows squash its items — and squash them further than
+        // §4.5 allows, because that clamp (an item's min-content size as the floor for an
+        // `auto` `min-height`) does not exist yet. Not shrinking is the better of the two
+        // wrong answers until it does.
+        if (freeSpace <= 0.5)
+            return;
+
+        double growTotal = 0;
+
+        foreach (var child in items)
+            growTotal += ParseFlexFactor(child.FlexGrow, 0);
+
+        if (growTotal <= 0)
+            return;
+
+        double cursorY = ClientTop;
+        bool moved = false;
+
+        foreach (var child in items)
+        {
+            double outerHeight = GetFlexItemOuterHeight(child);
+            double factor = ParseFlexFactor(child.FlexGrow, 0);
+            double target = outerHeight + freeSpace * (factor / growTotal);
+
+            if (factor > 0 && Math.Abs(target - outerHeight) > 0.5)
+            {
+                LayoutFlexItemAtTargetHeight(g, child, Math.Max(0, target));
+                moved = true;
+            }
+
+            // Re-stack from the top even for an item that did not flex: an earlier sibling that
+            // did has moved everything after it.
+            double top = cursorY + child.ActualMarginTop;
+            double dy = top - child.Location.Y;
+
+            if (Math.Abs(dy) > 0.1)
+            {
+                child.OffsetTop(dy);
+                moved = true;
+            }
+
+            cursorY += GetFlexItemOuterHeight(child) + rowGap;
+        }
+
+        if (!moved)
+            return;
+
+        cursorY -= rowGap;   // the trailing gap the loop added after the last item
+        ActualBottom = Math.Max(ActualBottom, cursorY + ActualPaddingBottom + ActualBorderBottomWidth);
+    }
+
+    /// <summary>
+    /// The column flex container's definite main-axis content height — its specified
+    /// <c>height</c> clamped by <c>min-height</c>/<c>max-height</c> — or <c>null</c> when
+    /// <c>height</c> is <c>auto</c> and the main size is therefore content-based.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="TryGetDefiniteContentHeight"/> answers a narrower question and cannot be reused:
+    /// it drops a zero result, and <c>height: 0</c> under a <c>min-height</c> is precisely the
+    /// definite-but-clamped case this exists to catch.
+    /// </remarks>
+    private double? TryGetDefiniteMainAxisContentHeight()
+    {
+        if (string.IsNullOrEmpty(Height) || Height == CssConstants.Auto || HeightPercentageResolvesToAuto())
+            return null;
+
+        double basis = PercentageHeightContainingBlockHeight();
+        double em = GetEmHeight();
+
+        double ToContentHeight(double specified) =>
+            ResolveSpecifiedHeightToBorderBox(specified)
+            - ActualPaddingTop - ActualPaddingBottom
+            - ActualBorderTopWidth - ActualBorderBottomWidth;
+
+        double height = ToContentHeight(CssLengthParser.ParseLength(Height, basis, em));
+
+        if (double.IsNaN(height) || double.IsInfinity(height))
+            return null;
+
+        if (!string.IsNullOrEmpty(MinHeight) && MinHeight != CssConstants.Auto)
+        {
+            double min = ToContentHeight(CssLengthParser.ParseLength(MinHeight, basis, em));
+            if (!double.IsNaN(min) && !double.IsInfinity(min) && min > height)
+                height = min;
+        }
+
+        if (!string.IsNullOrEmpty(MaxHeight) && MaxHeight != CssConstants.Auto
+            && !MaxHeight.Equals("none", StringComparison.OrdinalIgnoreCase))
+        {
+            double max = ToContentHeight(CssLengthParser.ParseLength(MaxHeight, basis, em));
+            if (!double.IsNaN(max) && !double.IsInfinity(max) && max < height)
+                height = max;
+        }
+
+        return height > 0 ? height : null;
+    }
+
+    private static void LayoutFlexItemAtTargetHeight(ILayoutEnvironment g, CssBox child, double targetOuterHeight)
+    {
+        double targetBorderBoxHeight = Math.Max(0, targetOuterHeight - child.ActualMarginTop - child.ActualMarginBottom);
+        double cssHeight = child.UsesBorderBoxSizing
+            ? targetBorderBoxHeight
+            : targetBorderBoxHeight
+              - child.ActualPaddingTop - child.ActualPaddingBottom
+              - child.ActualBorderTopWidth - child.ActualBorderBottomWidth;
+
+        string savedHeight = child.Height;
+
+        child.Height = FormatCssPx(Math.Max(0, cssHeight));
+        child.PerformLayout(g);
+        child.Height = savedHeight;
     }
 
     private static void LayoutFlexItemAtTargetWidth(ILayoutEnvironment g, CssBox child, double targetOuterWidth)

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
@@ -1275,6 +1275,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 // the block (cross) axis per align-items / align-self.
                 ApplyFlexGridCrossAxisAlignment();
                 ApplyFlexColumnInlineAxisAlignment(g);
+                ApplyFlexColumnMainAxisSizing(g);
             }
             else if (Boxes.Count > 0)
             {
@@ -1359,6 +1360,11 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
                 if (Display is "grid" or "inline-grid")
                     ApplyGridLayoutAfterInline();
+
+                // A column flex container's children stack through this block path, so the
+                // resolve-flexible-lengths step over them has to run here, once they are laid
+                // out and their content heights are known.
+                ApplyFlexColumnMainAxisSizing(g);
             }
         }
     }

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -292,7 +292,16 @@ internal partial class CssBox
             });
         }
 
-        if (placements.Count == 0)
+        // A grid with no in-flow items has no tracks to size *from*, so the pass
+        // normally declines to the approximation. It must not when the grid carries
+        // absolutely-positioned children, though: their grid areas are their
+        // containing blocks (CSS Grid §9), and those areas come from the explicit
+        // template, which sizes perfectly well with nothing placed in it. Declining
+        // here left every abspos child of an item-less grid resolving against the
+        // container's padding box instead — the whole of
+        // css-grid/abspos/grid-sizing-positioned-items-001, whose eight grids hold
+        // nothing but abspos children.
+        if (placements.Count == 0 && absposItems == null)
             return false;
 
         int explicitRowStart;
@@ -525,7 +534,15 @@ internal partial class CssBox
             PlaceAbsposGridItems(absposItems, colStartEdge, colEndEdge, rowStartEdge, rowEndEdge,
                 colSizes.Length, rowSizes.Length, contentLeft, contentTop,
                 colSpecs.Count, rowSpecs.Count, explicitColStart, explicitRowStart,
-                colNames, rowNames, rtl);
+                colNames, rowNames, rtl,
+                // The block extent of the padding box an `auto` grid line resolves to.
+                // `gridHeight` above is the track sum, which is what this box is sized
+                // to only while its height is indefinite; a definite height is the
+                // container's used content height whether the tracks fill it or not,
+                // and is re-applied to the box after this pass returns. Reading
+                // ActualBottom here would take the stale, track-derived value.
+                contentTop + AbsposContainingBlockContentHeight(em, rowDefinite, definiteHeight, gridHeight)
+                    + ActualPaddingBottom);
 
         _gridTrackLayoutApplied = true;
         return true;
@@ -956,12 +973,12 @@ internal partial class CssBox
         int colCount, int rowCount, double contentLeft, double contentTop,
         int explicitCols, int explicitRows, int explicitColStart, int explicitRowStart,
         IReadOnlyDictionary<string, List<int>> colNames, IReadOnlyDictionary<string, List<int>> rowNames,
-        bool rtl)
+        bool rtl, double paddingBoxBottom)
     {
         double padLeft = Location.X + ActualBorderLeftWidth;
         double padRight = Location.X + Size.Width - ActualBorderRightWidth;
         double padTop = Location.Y + ActualBorderTopWidth;
-        double padBottom = ActualBottom - ActualBorderBottomWidth;
+        double padBottom = paddingBoxBottom;
 
         foreach (var item in items)
         {
@@ -979,7 +996,7 @@ internal partial class CssBox
             }
 
             var (top, bottom) = ResolveAbsposAxis(rowStartLine, rowEndLine, rowStartEdge, rowEndEdge, rowCount, contentTop, padTop, padBottom);
-            PlaceAbsposItemInArea(item, left, top, right - left, bottom - top);
+            PlaceAbsposItemInArea(item, left, top, right - left, bottom - top, rtl);
         }
     }
 
@@ -1071,9 +1088,14 @@ internal partial class CssBox
     /// <c>start</c>, not <c>stretch</c>, by default) unless both insets pin it.
     /// The area is recorded on the item so any later abspos re-resolution
     /// (<see cref="GetAbsoluteContainingBlockPaddingBox"/>) uses it too.
+    /// <para>
+    /// With both inline insets <c>auto</c> the used value is the static position
+    /// (CSS2.1 §10.3.7), which for a grid item is its area's <em>inline-start</em>
+    /// corner — the area's right edge when <paramref name="rtl"/>, not its left.
+    /// </para>
     /// </summary>
     private static void PlaceAbsposItemInArea(CssBox item,
-        double areaLeft, double areaTop, double areaWidth, double areaHeight)
+        double areaLeft, double areaTop, double areaWidth, double areaHeight, bool rtl)
     {
         item.GridAreaContainingBlock =
             new RectangleF((float)areaLeft, (float)areaTop, (float)areaWidth, (float)areaHeight);
@@ -1091,6 +1113,7 @@ internal partial class CssBox
 
         if (left.HasValue) x = areaLeft + left.Value + marginL;
         else if (right.HasValue) x = areaLeft + areaWidth - right.Value - marginR - width;
+        else if (rtl) x = areaLeft + areaWidth - marginR - width;
         else x = areaLeft + marginL;
 
         double marginT = item.ActualMarginTop, marginB = item.ActualMarginBottom;
@@ -2179,6 +2202,42 @@ internal partial class CssBox
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// The used content-box height an absolutely-positioned grid child's containing
+    /// block is measured from (CSS Grid §9: the padding box, for an <c>auto</c> line).
+    /// <para>
+    /// A definite height is the container's used content height whether or not the
+    /// tracks fill it, so the track sum is the answer only for an indefinite one.
+    /// <see cref="TryGetDefiniteContentHeight"/> deliberately declines a percentage
+    /// height — resolving one there would change which grids size their rows against a
+    /// definite basis, and with it <c>align-content</c> and every percentage track.
+    /// This reads no further than the abspos containing block, where the percentage is
+    /// simply the used height and nothing about track sizing depends on it.
+    /// </para>
+    /// </summary>
+    private double AbsposContainingBlockContentHeight(
+        double em, bool rowDefinite, double definiteHeight, double trackSum)
+    {
+        if (rowDefinite)
+            return definiteHeight;
+
+        if (string.IsNullOrEmpty(Height) || !Height.EndsWith('%'))
+            return trackSum;
+
+        double basis = PercentageHeightContainingBlockHeight();
+        if (basis <= 0)
+            return trackSum;
+
+        double h = CssLengthParser.ParseLength(Height, basis, em);
+        if (double.IsNaN(h) || double.IsInfinity(h) || h <= 0)
+            return trackSum;
+
+        if (UsesBorderBoxSizing)
+            h -= ActualPaddingTop + ActualPaddingBottom + ActualBorderTopWidth + ActualBorderBottomWidth;
+
+        return h > 0 ? h : trackSum;
     }
 
     /// <summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,42 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `Broiler.Layout` — an absolutely-positioned or fixed child of a **row** flex container
+  was never laid out, and so never painted. `PerformFlexRowLayout` replaces the ordinary
+  block-flow child loop wholesale, and that loop is the only thing that calls
+  `PerformLayout` on a child; the flex path walks the same list but skips out-of-flow
+  children, correctly excluding them from flex layout (CSS Flexbox §4.1) and then never
+  laying them out anywhere else. The visible effect was not a misplaced box but a missing
+  one: `body { display: flex }` holding a fixed backdrop and an absolutely-positioned
+  panel painted neither, which is a common enough shape that it made a WPT test and its
+  own reference agree with each other on a blank page. Out-of-flow children are now laid
+  out after the flex lines, from the container's content-box start corner as their static
+  position. Column containers were unaffected — they fall through to block flow, which
+  already laid them out.
+
+- `Broiler.Layout` — `flex-grow` did nothing at all along a column flex container's main
+  axis. A column container has no flex algorithm here; its children stack through ordinary
+  block flow, which never resolves flexible lengths, so a lone `flex-grow: 1` item in a
+  100px-tall container stayed at its content height and a `height: 100%` child of it
+  measured zero. The positive half of §9.7 now runs over that stack once the children are
+  laid out, when — and only when — the container's main size is definite (a specified
+  `height`, then clamped by `min-height`/`max-height`; a `min-height` alone leaves the main
+  size content-based, and items correctly do not flex). Each grown item is laid out again
+  at its target height rather than resized in place, so percentage-height descendants
+  resolve against the flexed size. Shrinking is deliberately not implemented yet: it would
+  need CSS Flexbox §4.5's automatic minimum size to avoid squashing content past its
+  min-content size.
+
+- `Broiler.Layout` — a CSS grid whose children are *all* absolutely positioned resolved no
+  grid areas for them. The definite-track pass declined outright when no in-flow item was
+  placed, so no track was sized and every abspos child fell back to the grid container's
+  padding box instead of the grid area CSS Grid §9 makes its containing block. Two smaller
+  defects sat behind it: the padding box's block extent was read from the container's
+  track-derived height rather than its used height, so an `auto` grid line resolved against
+  a box hundreds of pixels too short whenever the container had a definite height; and in
+  `rtl` the resolved area was mirrored correctly and the item then placed at its *left*
+  edge, where CSS2.1 §10.3.7's static position is the inline-start — the right — one.
+
 - `Broiler.HtmlBridge` — `window.top` did not exist, so the unqualified `top` a page
   writes raised `ReferenceError: top is not defined`. Because `window` *is* the global
   object here, an unregistered member is not an undefined property but a reference

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,14 @@ something to attempt from inside the container.
   Pixel pass threshold defaults to 99% match (≤1% differing pixels) and is
   configurable: `--pass-threshold <percent>`, `BROILER_WPT_PASS_THRESHOLD`, or the
   `pass_threshold` input of the WPT Tests workflow.
+- **Judging a `check-layout` test needs no reference image.** A WPT test carrying
+  `data-expected-*` / `data-offset-*` states its own expected geometry, so
+  `--render --check-layout` reports it from one render:
+  `dotnet run --project src/Broiler.Wpt -- --wpt-dir tests/wpt/checkout --check-layout
+  --render <FILE>` prints `check-layout: N/M passed (±1px)` and lists each failure.
+  Use it instead of reading a CI artifact — the pixel suite can only *skip* these
+  tests, so a CI mismatch percentage says much less about them than their own
+  assertions do.
 - WPT **reftest** runner — a second, independent suite that uses no other engine:
   `./scripts/run-wpt-reftests.sh --wpt-dir tests/wpt/checkout [--subset <path>]`,
   or `dotnet run --project src/Broiler.Wpt -- --wpt-dir <dir> --reftests-only`.

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -447,6 +447,105 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
 
 ## Layout
 
+### A grid with only out-of-flow children resolved no grid areas
+
+**[Issue #1667](https://github.com/Broiler-Platform/Broiler/issues/1667).12.**
+
+- **Test:** `css-grid/abspos/grid-sizing-positioned-items-001`, CI 9.1%. It declares no
+  `rel=match`, so the pixel score can only be read off a CI artifact — but it is a
+  `check-layout-th.js` test, and those state their expected geometry in the markup.
+  Its assertions went **39 / 128 → 128 / 128**.
+- **The abspos pass was written and then never reached.** `PlaceAbsposGridItems` has
+  resolved a grid area per §9.2 since [#1624](https://github.com/Broiler-Platform/Broiler/issues/1624),
+  and the entry for this test read the symptom — every `offset-*` coming back as the
+  container's 15px padding — as that pass being absent. It is not: `TryApplyGridTrackLayout`
+  **declines the whole definite-track pass when no in-flow item is placed**
+  (`placements.Count == 0`), which is exactly the shape of this test. All eight of its
+  grids hold nothing but abspos children, so the pass returned before sizing a single
+  track and every child fell back to the container's padding box. A grid with no in-flow
+  items still has an explicit template to size, and §9 makes those tracks the containing
+  blocks; the guard now also asks whether anything is waiting on them.
+- **Two smaller defects were behind it**, invisible until the pass ran at all:
+  1. **The block extent was read from a box that was not finished.**
+     `PlaceAbsposGridItems` took the padding box's bottom from `ActualBottom`, which at
+     that point holds the *track sum* — the used height only while the container's own
+     height is indefinite. A definite height is re-applied after the pass returns, so an
+     `auto` grid line resolved to 230px on a grid that is 1030px tall. It now resolves
+     the container's used content height itself, including the percentage case, which
+     `TryGetDefiniteContentHeight` deliberately declines: widening *that* would change
+     which grids size their rows against a definite basis, and with them `align-content`
+     and every percentage track. The abspos containing block needs none of that.
+  2. **`rtl` mirrored the area and then placed the item at its left edge.** With both
+     inline insets `auto` the used value is the static position (CSS2.1 §10.3.7), which
+     is the area's *inline-start* corner — the right edge in `rtl`. Eight of the test's
+     offsets are that one rule, and the four `sizedToGridArea` rows hid it by filling
+     their area, where both edges coincide.
+- **Exit gate:** the test's 128 assertions pass. They do.
+
+### An out-of-flow child of a flex container was never laid out
+
+**[Issue #1667](https://github.com/Broiler-Platform/Broiler/issues/1667).22.**
+
+- **Test:** `css-transforms/dynamic-fixed-pos-cb-change`, CI 18.9%. It now renders
+  **byte-identical to the reference it declares**, and — the part that matters — both
+  sides render the content the test is about, where before both rendered a bare
+  background.
+- **This was a blank-on-blank pass in waiting**, the trap
+  [the whole set warns about](wpt-rendering-gaps.md#read-this-first--four-things-that-are-true-of-the-whole-set):
+  the test and its reference agreed with each other at ~100% while agreeing with the
+  golden at 18.9%, because Broiler drew nothing in either.
+- **Cause.** `PerformFlexRowLayout` replaces the ordinary block-flow child loop
+  wholesale, and that loop is the only thing that calls `PerformLayout` on a child. It
+  walks `Boxes` through `IsInFlowFlexItem`, which correctly excludes out-of-flow children
+  from flex layout (§4.1) — and nothing else ever laid them out. So an abspos or fixed
+  child of a **row** flex container was not merely mispositioned; it never reached the
+  canvas at all. `body { display: flex }` holding a fixed backdrop and an abspos panel
+  painted neither, and `body { display: flex }` is not an exotic shape.
+- **Only the row path.** A column flex container falls through to ordinary block/inline
+  flow over the same list, so its out-of-flow children were always laid out; the same
+  probe on `flex-direction: column` was correct before and after.
+- **The static position is the container's content-box start corner** (§4.1), seeded
+  before `PerformLayout` so an all-`auto` child lands there rather than at whatever
+  coordinates the last laid-out box left behind.
+- **Exit gate:** an abspos and a fixed child of a row flex container render exactly as
+  they do with the `display: flex` removed. They do, pixel for pixel.
+
+### `flex-grow` did nothing at all in a column flex container
+
+**[Issue #1667](https://github.com/Broiler-Platform/Broiler/issues/1667).20.**
+
+- **Test:** `css-flexbox/percentage-heights-003`, CI 15.4% — **4 / 9 assertions → 7 / 9**.
+- **A column flex container had no flex algorithm.** `PerformFlexRowLayout` is the only
+  one there is; a column container's children stack through ordinary block flow, which
+  never resolves flexible lengths. So `flex-grow` was inert along a column's main axis:
+  a lone `flex-grow: 1` item in a 100px-tall container stayed at its content height, and
+  a `height: 100%` child of it measured 0. Two constructed probes covering
+  `flex-grow`/`flex`/`flex-basis`, one item and two, went **1 / 6 → 6 / 6** and
+  **2 / 6 → 6 / 6**.
+- **Definite main size only, and the test is what pins the distinction.** §9.2 makes the
+  main size definite from a specified `height` — then clamped by `min-height`/`max-height`
+  — and *not* from a `min-height` alone. So this test's `height: 0; min-height: 100%`
+  containers flex their items to the clamped 100px, while its `min-height: 100%`-only
+  containers, whose main size stays content-based, correctly leave them at zero. Reusing
+  `TryGetDefiniteContentHeight` would have got this wrong in both directions: it drops a
+  zero result, and `height: 0` under a `min-height` is precisely the definite-but-clamped
+  case.
+- **Each grown item is laid out again at its target height** rather than resized in
+  place, because a percentage-height descendant resolves against the item's used height —
+  the `span { height: 100% }` this test measures — and poking `Size` alone leaves it
+  reading the pre-flex value. That is the same reason the row path re-lays-out at the
+  target *width* instead of resizing.
+- **Growth only, on purpose.** `flex-shrink` defaults to `1`, so implementing the negative
+  half here would make *every* column container whose content overflows squash its items —
+  and squash them further than §4.5 allows, because that clamp (an item's min-content size
+  as the floor for an `auto` `min-height`) does not exist yet. Not shrinking is the better
+  of the two wrong answers until it does; §4.5 is the prerequisite, not more of §9.7.
+- **Not attempted:** `column wrap` with items that overflow the main axis, which needs
+  real line breaking. Single-line is what the tests on this page exercise.
+- **Exit gate:** `flex-grow` distributes a definite column container's free space, and
+  the two residual assertions in the test are the orthogonal-writing-mode ones
+  [tracked with the crossed-axes grid item](wpt-rendering-gaps-open.md#not-triaged-3).
+
 ### A replaced element's two axes were sized independently
 
 - **Tests:** `css-sizing/replaced-max-size-saturation` (8.3% on CI),

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -26,6 +26,7 @@ measured 2026-08-13; CI is the golden-image score from the
 - [Grid](#grid)
 - [Sizing and layout](#sizing-and-layout)
 - [Images](#images)
+- [Transforms](#transforms)
 - [Masking](#masking)
 - [Dynamic stylesheets](#dynamic-stylesheets)
 - [Quirks](#quirks)
@@ -269,24 +270,10 @@ golden suite never looks at a passing test's own reference.
 
 ### Not triaged
 
-- `css-grid/abspos/grid-sizing-positioned-items-001`, CI 9.1%
-  ([#1661](https://github.com/Broiler-Platform/Broiler/issues/1661).13). Declares no
-  `rel=match`, so the pixel score can only be judged from a CI artifact — but its
-  `check-layout-th.js` assertions can be read locally and say the abspos grid child is
-  placed at the padding edge rather than at its grid area, and sized against the wrong
-  box:
-
-  ```
-  div.absolute  offset-x  expected   0  actual   15
-  div.absolute  offset-y  expected   0  actual   15
-  div.absolute  height    expected 1030 actual   30
-  div.absolute  offset-x  expected 115  actual   15
-  div.absolute  width     expected 915  actual 1030
-  ```
-
-  Every `offset-*` is the container's 15px padding, so **the grid area is not being
-  used as the containing block for an absolutely positioned grid child at all**
-  (CSS Grid §9). That is one cause for the whole test, not eleven separate ones.
+- `css-grid/abspos/grid-sizing-positioned-items-001` (CI 9.1%,
+  [#1661](https://github.com/Broiler-Platform/Broiler/issues/1661).13) — **fixed**, see
+  [a grid with only out-of-flow children resolved no grid areas](wpt-rendering-gaps-fixed.md#a-grid-with-only-out-of-flow-children-resolved-no-grid-areas).
+  Its `check-layout-th.js` assertions read **128 / 128**, up from 39.
 
 ---
 
@@ -360,7 +347,14 @@ other direction. None is a sizing bug.
 ### Not triaged
 
 - `css-flexbox/percentage-heights-003`, CI 15.4%. A `check-layout-th.js` test with
-  no `rel=match`.
+  no `rel=match`. **7 of its 9 assertions now pass**, up from 4, since
+  [`flex-grow` started doing anything in a column container](wpt-rendering-gaps-fixed.md#flex-grow-did-nothing-at-all-in-a-column-flex-container).
+  The residual two are its orthogonal-writing-mode groups: a `vertical-rl` flex item
+  in a horizontal container, and the reverse. Both ask for a span of 100px and get
+  1008 — the viewport, not the item — so the item's main size is being read from the
+  wrong axis. **The same crossed-axes shape as
+  [the orthogonal grid item](#a-definite-inline-size-does-not-drive-the-block-axis-through-an-aspect-ratio),
+  and worth fixing with it rather than separately.**
 - `css-flexbox/flexbox-min-width-auto-002b` (98.5% against a 99% threshold), which
   fell out of the
   [abspos replaced fix](wpt-rendering-gaps-fixed.md#an-absolutely-positioned-img-rendered-nothing-at-all).
@@ -704,6 +698,30 @@ Worth separating from the rest, because the test itself may be at fault:
   engines failing by the same margin points at the test or its reference rather than
   at either engine; check it upstream before spending time on it.
 
+## Transforms
+
+### A perspective-transformed box is not rasterised in 3D
+
+- **Test:** `css-transforms/perspective-split-by-zero-w`, CI 24.9%
+  ([#1667](https://github.com/Broiler-Platform/Broiler/issues/1667).25). Broiler
+  reproduces its own reference here, so this reads like a reference disagreement and is
+  not one — the reference is *the test plus a red patch at `z-index: -1`*, drawn so that
+  anything the engine fails to paint shows through as red. Broiler paints the red patch
+  in full, which is the reference telling us the answer is wrong.
+- **What the test asks.** A 1140×990 box under `perspective: 500px` with
+  `transform-style: preserve-3d`, rotated 64° about Y and 90° about X so that part of it
+  crosses the `w = 0` plane. The parts with `w > 0` must still rasterise correctly.
+- **What we draw.** An axis-aligned tile block in the top-left corner — the box's
+  background at its untransformed geometry, clipped to the viewport. The 3D transform
+  chain reaches paint as something close to a 2D fallback, so nothing covers the patch.
+- **Owner:** `Broiler.Graphics`. This is not a transform-parsing or containing-block
+  gap; it needs perspective-correct rasterisation with clipping against the `w = 0`
+  plane, which is a rasteriser feature rather than a layout one.
+- **Exit gate:** the red patch is fully covered — i.e. the test matches its own
+  reference *and* both differ from a render with the transform removed.
+
+---
+
 ## Masking
 
 ### SVG `<clipPath>` referenced by `url()`
@@ -812,6 +830,22 @@ is worth more than the one test that names it.
 These fail for reasons that are not rendering gaps in the usual sense. They are
 listed so they are not mistaken for untriaged mismatches.
 
+**One class of them is no longer in this position.** A `check-layout-th.js` test states
+its expected geometry in `data-expected-*` / `data-offset-*` attributes, so it can be
+judged with no reference image at all — the pixel suite could only skip it, and this
+page kept saying such tests "can only be judged from a CI artifact". The runner now
+reports those assertions from a single render:
+
+```sh
+dotnet run --project src/Broiler.Wpt -- --wpt-dir tests/wpt/checkout \
+  --check-layout --render tests/wpt/checkout/css/css-grid/abspos/grid-sizing-positioned-items-001.html
+```
+
+It prints `check-layout: 128/128 passed (±1px)` and lists each failure as
+`element property: expected E, actual A`. Two of the entries on this page were triaged
+that way and closed. **Prefer it to reading a CI artifact** for anything carrying those
+attributes.
+
 ### Testharness tests, whose reference is a results table
 
 Closing one means passing its subtests, not making one fix.
@@ -911,6 +945,15 @@ is exactly one page area), and on both sides only the first block paints:
 
 Neither can change what CI reports for that test, which is scored unpaginated against
 [a blank Chromium capture](wpt-rendering-gaps-wont-fix.md#page-margin-002-print-is-a-screenshot-artifact).
+
+**A second test belongs here rather than with the transforms it looks like.**
+`css-page/body-background-vrl-print` (CI 34.9%,
+[#1667](https://github.com/Broiler-Platform/Broiler/issues/1667).30) asks that the
+body's background fragment correctly across two 800×600 pages in `vertical-rl`. Rendered
+unpaginated — which is how CI scores it — Broiler puts both `.fullpager` blocks and the
+whole gradient on one canvas, so what the test is *about* is never exercised. It needs
+the same paged pipeline as the entry above, plus fragmentation of a propagated body
+background, and it cannot be judged from an unpaginated render at all.
 
 ### The report cannot distinguish "wrong everywhere" from "wrong only against Chromium" — **fixed**
 

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -6,9 +6,9 @@ documents, split by verdict:
 
 | Document | What is in it | Tests |
 | --- | --- | --- |
-| [**Not fixed**](wpt-rendering-gaps-open.md) | real gaps, each with an owner, evidence and an exit gate | 50 |
+| [**Not fixed**](wpt-rendering-gaps-open.md) | real gaps, each with an owner, evidence and an exit gate | 51 |
 | [**Won't fix**](wpt-rendering-gaps-wont-fix.md) | tests Broiler renders correctly and the golden image does not | 17 |
-| [**Fixed**](wpt-rendering-gaps-fixed.md) | closed gaps, with root cause, what landed, and the wrong turns | 48 |
+| [**Fixed**](wpt-rendering-gaps-fixed.md) | closed gaps, with root cause, what landed, and the wrong turns | 50 |
 
 Start with *not fixed*. Read *won't fix* before starting on any 0.0% — closing one of
 those means deleting working support. But do not read a run's *Not ranked* heading as

--- a/src/Broiler.Cli.Tests/FlexOutOfFlowAndColumnSizingTests.cs
+++ b/src/Broiler.Cli.Tests/FlexOutOfFlowAndColumnSizingTests.cs
@@ -1,0 +1,175 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Two flex gaps found triaging the 2026-08-15 WPT severity run, both of which left whole
+/// boxes at the wrong size — or off the canvas entirely.
+///
+/// <para>
+/// <b>Out-of-flow children (CSS Flexbox §4.1).</b> An abspos or fixed child of a <em>row</em>
+/// flex container was never laid out at all: <c>PerformFlexRowLayout</c> replaces the block-flow
+/// child loop, and that loop is the only caller of <c>PerformLayout</c>. Covers
+/// css/css-transforms/dynamic-fixed-pos-cb-change, whose test and reference both rendered a bare
+/// background because <c>body { display: flex }</c> swallowed both of its children.
+/// </para>
+/// <para>
+/// <b>Main-axis sizing (§9.7).</b> A column flex container had no flex algorithm, so
+/// <c>flex-grow</c> distributed nothing along its main axis. Covers
+/// css/css-flexbox/percentage-heights-003 (4/9 assertions → 7/9).
+/// </para>
+/// </summary>
+public sealed class FlexOutOfFlowAndColumnSizingTests
+{
+    [Fact]
+    public void An_Abspos_Child_Of_A_Row_Flex_Container_Is_Laid_Out()
+    {
+        AssertCheckLayout(
+            "<div style=\"display:flex;position:relative;width:400px;height:200px\">" +
+            "  <div class=\"probe\" style=\"position:absolute;left:0;top:0;width:60px;height:30px\"" +
+            "       data-offset-x=\"0\" data-offset-y=\"0\"" +
+            "       data-expected-width=\"60\" data-expected-height=\"30\"></div>" +
+            "</div>");
+    }
+
+    [Fact]
+    public void An_Abspos_Child_With_All_Auto_Insets_Takes_The_Content_Box_Start_Corner()
+    {
+        // §4.1: the static position is the container's content-box start corner, so the
+        // padding is included and the child does not land on some earlier box's coordinates.
+        AssertCheckLayout(
+            "<div style=\"display:flex;position:relative;width:400px;height:200px;padding:20px\">" +
+            "  <div style=\"width:50px;height:10px\"></div>" +
+            "  <div class=\"probe\" style=\"position:absolute;width:60px;height:30px\"" +
+            "       data-offset-x=\"20\" data-offset-y=\"20\"" +
+            "       data-expected-width=\"60\" data-expected-height=\"30\"></div>" +
+            "</div>");
+    }
+
+    [Fact]
+    public void An_Abspos_Child_Of_A_Flex_Container_Matches_The_Same_Markup_Without_Flex()
+    {
+        // The regression that started this: `display: flex` must not change where an
+        // out-of-flow child ends up, only whether it is a flex item.
+        const string child =
+            "  <div class=\"probe\" style=\"position:absolute;left:10px;top:15px;width:60px;height:30px\"" +
+            "       data-offset-x=\"10\" data-offset-y=\"15\"" +
+            "       data-expected-width=\"60\" data-expected-height=\"30\"></div>";
+
+        AssertCheckLayout("<div style=\"position:relative;width:400px;height:200px\">" + child + "</div>");
+        AssertCheckLayout("<div style=\"display:flex;position:relative;width:400px;height:200px\">" + child + "</div>");
+    }
+
+    [Fact]
+    public void Flex_Grow_Fills_A_Definite_Column_Containers_Main_Axis()
+    {
+        AssertCheckLayout(
+            "<div class=\"probe\" style=\"display:flex;flex-direction:column;height:100px\">" +
+            "  <div style=\"flex-grow:1\" data-expected-height=\"100\"></div>" +
+            "</div>");
+    }
+
+    [Fact]
+    public void Two_Grow_Factors_Share_A_Column_Containers_Free_Space()
+    {
+        AssertCheckLayout(
+            "<div class=\"probe\" style=\"display:flex;flex-direction:column;height:120px\">" +
+            "  <div style=\"flex-grow:1\" data-offset-y=\"0\" data-expected-height=\"40\"></div>" +
+            "  <div style=\"flex-grow:2\" data-offset-y=\"40\" data-expected-height=\"80\"></div>" +
+            "</div>");
+    }
+
+    [Fact]
+    public void A_Fixed_Size_Sibling_Keeps_Its_Size_While_The_Grower_Takes_The_Rest()
+    {
+        AssertCheckLayout(
+            "<div class=\"probe\" style=\"display:flex;flex-direction:column;height:100px\">" +
+            "  <div style=\"height:20px\" data-offset-y=\"0\" data-expected-height=\"20\"></div>" +
+            "  <div style=\"flex-grow:1\" data-offset-y=\"20\" data-expected-height=\"80\"></div>" +
+            "</div>");
+    }
+
+    [Fact]
+    public void A_Percentage_Height_Child_Resolves_Against_The_Flexed_Item()
+    {
+        // The reason a grown item is laid out again rather than resized in place: this is
+        // exactly what percentage-heights-003 measures.
+        AssertCheckLayout(
+            "<div class=\"probe\" style=\"display:flex;flex-direction:column;height:100px\">" +
+            "  <div style=\"flex-grow:1\">" +
+            "    <span style=\"display:block;height:100%\" data-expected-height=\"100\"></span>" +
+            "  </div>" +
+            "</div>");
+    }
+
+    [Fact]
+    public void A_Min_Height_Clamps_A_Zero_Height_Column_Containers_Main_Size()
+    {
+        // §9.2: `height: 0` is a definite main size, then clamped by `min-height` — so the
+        // items flex to the clamped 100px, not to zero.
+        AssertCheckLayout(
+            "<div style=\"height:100px\">" +
+            "  <div class=\"probe\" style=\"display:flex;flex-direction:column;min-height:100%;height:0\">" +
+            "    <div style=\"flex-grow:1\" data-expected-height=\"100\"></div>" +
+            "  </div>" +
+            "</div>");
+    }
+
+    [Fact]
+    public void A_Min_Height_Alone_Leaves_The_Main_Size_Content_Based()
+    {
+        // The other half of the same rule, and the half that is easy to get wrong: with
+        // `height` auto the main size is indefinite, so nothing flexes even though
+        // `min-height` will grow the container afterwards. percentage-heights-003 asserts 0.
+        AssertCheckLayout(
+            "<div style=\"height:100px\">" +
+            "  <div class=\"probe\" style=\"display:flex;flex-direction:column;min-height:100%\">" +
+            "    <div style=\"flex-grow:1\" data-expected-height=\"0\"></div>" +
+            "  </div>" +
+            "</div>");
+    }
+
+    [Fact]
+    public void A_Column_Container_Without_Grow_Factors_Is_Left_Alone()
+    {
+        AssertCheckLayout(
+            "<div class=\"probe\" style=\"display:flex;flex-direction:column;height:100px\">" +
+            "  <div style=\"height:20px\" data-offset-y=\"0\" data-expected-height=\"20\"></div>" +
+            "  <div style=\"height:30px\" data-offset-y=\"20\" data-expected-height=\"30\"></div>" +
+            "</div>");
+    }
+
+    [Fact]
+    public void A_Row_Containers_Items_Do_Not_Grow_Along_The_Block_Axis()
+    {
+        // Guards the direction check: the new pass must not touch a row container, whose
+        // main axis is inline and whose block axis is governed by align-items instead.
+        AssertCheckLayout(
+            "<div class=\"probe\" style=\"display:flex;width:200px;height:100px\">" +
+            "  <div style=\"flex-grow:1\" data-expected-width=\"200\"></div>" +
+            "</div>");
+    }
+
+    private static void AssertCheckLayout(string body)
+    {
+        const string head =
+            "<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0}</style></head>" +
+            "<body>";
+
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, head + body + "</body></html>", "file:///flex.html");
+
+        var assertions = bridge.EvaluateCheckLayoutAssertions();
+        var failures = assertions
+            .Where(a => double.IsNaN(a.Actual) || Math.Abs(a.Expected - a.Actual) > 0.5)
+            .Select(a => $"{a.Element} {a.Property}: expected {a.Expected}, got {a.Actual:0.##}")
+            .ToList();
+
+        Assert.True(assertions.Count > 0, "no check-layout assertions were evaluated");
+        Assert.True(failures.Count == 0,
+            $"{failures.Count}/{assertions.Count} assertions failed:\n" + string.Join("\n", failures));
+    }
+}

--- a/src/Broiler.Cli.Tests/GridAbsposContainingBlockTests.cs
+++ b/src/Broiler.Cli.Tests/GridAbsposContainingBlockTests.cs
@@ -1,0 +1,138 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// CSS Grid §9 (Absolute Positioning): an absolutely-positioned child of a positioned grid
+/// container takes its containing block from the grid area its lines resolve to, with an
+/// <c>auto</c> line resolving to the container's padding edge.
+///
+/// Covers the three defects behind
+/// css/css-grid/abspos/grid-sizing-positioned-items-001 (39/128 assertions → 128/128):
+/// the definite-track pass declining outright when nothing in-flow is placed, the padding
+/// box's block extent being read from a container that was not finished, and the `rtl`
+/// static position landing on the wrong edge of the area.
+/// </summary>
+public sealed class GridAbsposContainingBlockTests
+{
+    // A 100px + 200px × 50px + 150px grid, 15px padding, no border, `position: relative`
+    // so it is the containing block. Column edges therefore sit at x = 15, 115 and 315;
+    // row edges at y = 15, 65 and 215. `data-offset-*` is measured from the padding edge.
+    private const string GridStyle =
+        "display:grid;grid-template-columns:100px 200px;grid-template-rows:50px 150px;" +
+        "padding:15px;position:relative;";
+
+    [Fact]
+    public void Grid_With_Only_Abspos_Children_Still_Resolves_Their_Grid_Areas()
+    {
+        // The whole test file is this shape: every grid holds abspos children and nothing
+        // else. `placements.Count == 0` used to decline the definite-track pass, so no
+        // track was sized and every child fell back to the container's padding box.
+        AssertCheckLayout(
+            Doc(width: "500px", height: "400px", children:
+                Item("grid-column:1/2;grid-row:1/2;width:100%;height:100%", x: 15, y: 15, w: 100, h: 50) +
+                Item("grid-column:2/3;grid-row:2/3;width:100%;height:100%", x: 115, y: 65, w: 200, h: 150)));
+    }
+
+    [Fact]
+    public void An_Auto_Grid_Line_Resolves_To_The_Padding_Edge()
+    {
+        // §9.2: `auto` is the container's padding edge, not a track line — so an auto/auto
+        // child spans the whole padding box (500 + 30 wide, 400 + 30 tall), and a child
+        // with only a start line runs from that line to the padding edge.
+        AssertCheckLayout(
+            Doc(width: "500px", height: "400px", children:
+                Item("width:100%;height:100%", x: 0, y: 0, w: 530, h: 430) +
+                Item("grid-column:2;grid-row:2;width:100%;height:100%", x: 115, y: 65, w: 415, h: 365)));
+    }
+
+    [Fact]
+    public void The_Padding_Box_Uses_The_Containers_Definite_Height_Not_Its_Track_Sum()
+    {
+        // The tracks total 200px; the container is 400px tall. The block extent an `auto`
+        // line resolves to is the container's used content height, so the child is 430
+        // tall — reading the just-computed track-derived `ActualBottom` gave 230.
+        AssertCheckLayout(
+            Doc(width: "500px", height: "400px", children:
+                Item("width:100%;height:100%", x: 0, y: 0, w: 530, h: 430)));
+    }
+
+    [Fact]
+    public void A_Percentage_Height_Container_Also_Sizes_The_Padding_Box()
+    {
+        // Same again where the height arrives as a percentage of a definite parent, which
+        // the track-sizing pass deliberately treats as indefinite. The abspos containing
+        // block must still be the used 400px.
+        AssertCheckLayout(
+            Doc(width: "100%", height: "100%", outerStyle: "width:500px;height:400px;", children:
+                Item("width:100%;height:100%", x: 0, y: 0, w: 530, h: 430)));
+    }
+
+    [Fact]
+    public void An_Rtl_Item_Takes_The_Inline_Start_Edge_Of_Its_Area_As_Its_Static_Position()
+    {
+        // CSS2.1 §10.3.7: with both inline insets `auto` the used value is the static
+        // position — the area's inline-start corner, which in `rtl` is its right edge.
+        // The mirrored areas are [415, 515] for column 1 and [0, 415] for `grid-column: 2`,
+        // so a 50px-wide item sits at 465 and at 365 respectively.
+        AssertCheckLayout(
+            Doc(width: "500px", height: "400px", extra: "direction:rtl;", children:
+                Item("grid-column:1/2;grid-row:1/2;width:50px;height:20px", x: 465, y: 15, w: 50, h: 20) +
+                Item("grid-column:2;grid-row:2;width:50px;height:20px", x: 365, y: 65, w: 50, h: 20)));
+    }
+
+    [Fact]
+    public void An_Rtl_Item_With_A_Left_Inset_Is_Still_Placed_From_The_Left()
+    {
+        // The static-position rule applies only when both insets are `auto`; a specified
+        // `left` is physical and offsets from the area's left edge in either direction.
+        AssertCheckLayout(
+            Doc(width: "500px", height: "400px", extra: "direction:rtl;", children:
+                Item("grid-column:1/2;grid-row:1/2;left:5px;width:50px;height:20px", x: 420, y: 15, w: 50, h: 20)));
+    }
+
+    [Fact]
+    public void An_In_Flow_Item_Beside_An_Abspos_One_Is_Unaffected()
+    {
+        // The guard change must not alter a grid that already had in-flow items: the
+        // in-flow child keeps its track geometry while the abspos one gets its area.
+        AssertCheckLayout(
+            Doc(width: "500px", height: "400px", children:
+                "<div style=\"grid-column:1/2;grid-row:1/2\" " +
+                "data-offset-x=\"15\" data-offset-y=\"15\" " +
+                "data-expected-width=\"100\" data-expected-height=\"50\"></div>" +
+                Item("grid-column:2/3;grid-row:2/3;width:100%;height:100%", x: 115, y: 65, w: 200, h: 150)));
+    }
+
+    private static string Item(string style, double x, double y, double w, double h) =>
+        $"<div class=\"a\" style=\"{style}\" data-offset-x=\"{x}\" data-offset-y=\"{y}\" " +
+        $"data-expected-width=\"{w}\" data-expected-height=\"{h}\"></div>";
+
+    private static string Doc(string width, string height, string children,
+        string outerStyle = "", string extra = "") =>
+        "<!DOCTYPE html><html><head><style>" +
+        ".g{" + GridStyle + extra + "width:" + width + ";height:" + height + "}" +
+        ".a{position:absolute}" +
+        "</style></head><body style=\"margin:0\">" +
+        "<div style=\"" + outerStyle + "\"><div class=\"g\">" + children + "</div></div>" +
+        "</body></html>";
+
+    private static void AssertCheckLayout(string html)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///grid-abspos.html");
+
+        var assertions = bridge.EvaluateCheckLayoutAssertions();
+        var failures = assertions
+            .Where(a => double.IsNaN(a.Actual) || Math.Abs(a.Expected - a.Actual) > 0.5)
+            .Select(a => $"{a.Element} {a.Property}: expected {a.Expected}, got {a.Actual:0.##}")
+            .ToList();
+
+        Assert.True(assertions.Count > 0, "no check-layout assertions were evaluated");
+        Assert.True(failures.Count == 0,
+            $"{failures.Count}/{assertions.Count} assertions failed:\n" + string.Join("\n", failures));
+    }
+}

--- a/src/Broiler.Wpt/Program.cs
+++ b/src/Broiler.Wpt/Program.cs
@@ -108,6 +108,7 @@ public class Program
         int shardIndex = WptTestRunner.AllShards;
         bool nonJavaScriptOnly = false;
         bool referenceTestsOnly = false;
+        bool reportLayoutAssertions = false;
         bool verifyReference = false;
         bool workerMode = false;
         bool noWorkerIsolation = false;
@@ -225,6 +226,9 @@ public class Program
                 case "--verify-reference":
                     verifyReference = true;
                     break;
+                case "--check-layout":
+                    reportLayoutAssertions = true;
+                    break;
                 case "--wpt-dir":
                 case "--reference-dir":
                 case "--json-output":
@@ -269,7 +273,7 @@ public class Program
         // wpt-root-relative resource resolution, otherwise the file renders
         // standalone.  This deliberately bypasses test discovery.
         if (renderPath != null)
-            return RunRenderMode(renderPath, renderOutPath, wptPath);
+            return RunRenderMode(renderPath, renderOutPath, wptPath, reportLayoutAssertions);
 
         if (wptPath is null)
         {
@@ -3111,6 +3115,9 @@ public class Program
         Console.WriteLine("                             The fast 'reproduce against the live renderer' path; --wpt-dir is");
         Console.WriteLine("                             optional (supplies WPT fonts/resource resolution when given).");
         Console.WriteLine("  --render-out <PATH>        Output PNG path for --render (default: <FILE> with a .png extension)");
+        Console.WriteLine("  --check-layout             With --render, also report the check-layout-th.js assertions the");
+        Console.WriteLine("                             document declares. Judges a check-layout test with no reference");
+        Console.WriteLine("                             image at all, which the pixel suite can only skip.");
         Console.WriteLine("  --help                     Show this help message");
     }
 
@@ -3121,7 +3128,8 @@ public class Program
     /// <paramref name="wptPath"/> is supplied it loads the WPT fonts and resolves
     /// wpt-root-relative sub-resources; otherwise the file renders standalone.
     /// </summary>
-    private static int RunRenderMode(string renderPath, string? renderOutPath, string? wptPath)
+    private static int RunRenderMode(string renderPath, string? renderOutPath, string? wptPath,
+        bool reportLayoutAssertions)
     {
         if (!File.Exists(renderPath))
         {
@@ -3137,9 +3145,10 @@ public class Program
         // A --wpt-dir is optional in render mode; only use it when it exists.
         var wptRoot = wptPath != null && Directory.Exists(wptPath) ? wptPath : null;
 
+        var runner = new WptTestRunner();
+
         try
         {
-            var runner = new WptTestRunner();
             using var bitmap = runner.RenderHtmlFileBitmapPublic(renderPath, wptRoot);
             bitmap.Save(outPath);
         }
@@ -3150,6 +3159,39 @@ public class Program
         }
 
         Console.WriteLine($"Rendered {renderPath} -> {outPath}");
+
+        if (reportLayoutAssertions)
+            PrintRenderedLayoutAssertions(runner.LastLayoutAssertions);
+
         return 0;
+    }
+
+    /// <summary>
+    /// Reports the <c>check-layout-th.js</c> assertions a <c>--render</c> evaluated. A
+    /// <c>check-layout</c> test carries its own expected geometry in <c>data-expected-*</c>
+    /// attributes, so this judges it without a reference image — the class of test the pixel
+    /// suite can only skip, and which otherwise has to be read off a CI artifact.
+    /// </summary>
+    private static void PrintRenderedLayoutAssertions(
+        IReadOnlyList<Broiler.HtmlBridge.DomBridge.CheckLayoutAssertion> assertions)
+    {
+        if (assertions.Count == 0)
+        {
+            Console.WriteLine("check-layout: the document declared no assertions.");
+            return;
+        }
+
+        var failures = assertions
+            .Where(a => double.IsNaN(a.Actual) || Math.Abs(a.Expected - a.Actual) > 1.0)
+            .ToList();
+
+        Console.WriteLine($"check-layout: {assertions.Count - failures.Count}/{assertions.Count} passed (±1px).");
+
+        foreach (var f in failures)
+        {
+            var actual = double.IsNaN(f.Actual) ? "(no value)" : f.Actual.ToString("0.##", CultureInfo.InvariantCulture);
+            Console.WriteLine($"  {f.Element}  {f.Property}: expected " +
+                              $"{f.Expected.ToString("0.##", CultureInfo.InvariantCulture)}, actual {actual}");
+        }
     }
 }

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -2597,6 +2597,14 @@ internal sealed partial class WptTestRunner
     }
 
     /// <summary>
+    /// The <c>check-layout-th.js</c> assertions the most recent render evaluated, or an empty
+    /// list when the document declared none. A <c>check-layout</c> test states its expected
+    /// geometry in the markup, so this is the one signal about it that needs no reference image
+    /// — which is what <c>--render --check-layout</c> reports.
+    /// </summary>
+    internal IReadOnlyList<DomBridge.CheckLayoutAssertion> LastLayoutAssertions { get; private set; } = [];
+
+    /// <summary>
     /// Renders an HTML file through the full Broiler pipeline (script execution,
     /// anchor resolution, rendering) and returns the resulting bitmap.
     /// </summary>
@@ -2640,6 +2648,7 @@ internal sealed partial class WptTestRunner
             var executed = ExecuteScriptsWithDom(html, testBaseUrl, wptRoot);
             html = executed.Html ?? html;
             renderDocument = executed.Document;
+            LastLayoutAssertions = executed.LayoutAssertions;
         }
 
         using (WptPhaseTrace.Measure(WptPhaseTrace.Phases.PostProcess))


### PR DESCRIPTION
## Summary

Fixes three layout gaps affecting flexbox and grid containers:

1. **Out-of-flow children of row flex containers were never laid out** — they were excluded from flex layout (correctly, per §4.1) but then never laid out anywhere else, leaving them off the canvas entirely.

2. **`flex-grow` did nothing in column flex containers** — column containers use ordinary block flow rather than a flex algorithm, so flexible lengths were never resolved along the main axis.

3. **Grid containers with only out-of-flow children skipped track sizing** — the definite-track pass declined when no in-flow items were placed, leaving abspos children to resolve against the padding box instead of their grid areas.

## Key Changes

- **`CssBox.Flex.cs`**
  - Added `LayoutOutOfFlowFlexChildren()` to lay out abspos/fixed children of row flex containers after flex lines are resolved, using the container's content-box start corner as their static position (§4.1).
  - Added `ApplyFlexColumnMainAxisSizing()` to distribute positive free space along a column container's main axis per `flex-grow` (§9.7), but only when the main size is definite (specified `height`, clamped by `min-height`/`max-height`).
  - Added `TryGetDefiniteMainAxisContentHeight()` to resolve the column container's definite main-axis content height, distinguishing between a specified `height` (definite) and `min-height` alone (content-based).
  - Added `LayoutFlexItemAtTargetHeight()` to re-layout grown items at their target height so percentage-height descendants resolve correctly.
  - Added `IsSpecifiedInset()` helper to check whether an inset property is specified (not `auto` or empty).

- **`CssBoxGrid.cs`**
  - Modified `TryApplyGridTrackLayout()` to run the definite-track pass even when no in-flow items are placed, if abspos items exist (they need their grid areas as containing blocks per §9).
  - Modified `PlaceAbsposGridItems()` to accept and use the padding box's definite bottom edge rather than reading the stale track-derived `ActualBottom`.
  - Fixed `PlaceAbsposItemInArea()` to respect the `rtl` direction when resolving `auto` inline insets — the static position is the area's inline-start corner (right edge in `rtl`), not its left edge.
  - Added `AbsposContainingBlockContentHeight()` to compute the padding box's block extent independently of the container's track-derived size.

- **`CssBox.Layout.cs`**
  - Integrated `ApplyFlexColumnMainAxisSizing()` into the layout flow after `LayoutBlockChildren()` completes.

- **Tests**
  - Added `FlexOutOfFlowAndColumnSizingTests` covering out-of-flow flex children, `flex-grow` in columns, percentage-height resolution, and definite vs. content-based main sizes.
  - Added `GridAbsposContainingBlockTests` covering grid areas as containing blocks for abspos children, `auto` line resolution, and `rtl` static positioning.

- **Documentation**
  - Updated `wpt-rendering-gaps-fixed.md` with detailed entries for all three fixes, including test coverage and exit gates.
  - Updated `wpt-rendering-gaps-open.md` to move the grid test from "not triaged" to "fixed" and note the column flex test's improvement (4/9 → 7/9 assertions).
  - Updated `CHANGELOG.md` with user-facing descriptions of the fixes.

## Implementation Notes

- Out-of-flow flex children are laid out *after* flex lines are resolved, ensuring the container's geometry is finalized before positioning them.
- Column flex growth only applies when the container's main size is definite; a `min-height` alone leaves the main size content-based, and items correctly do not flex.
- Grown items are re-laid out (not just resized) so that percentage-height descendants resolve against the flexed size, not the pre-flex one.
- Grid abspos containing

https://claude.ai/code/session_01JJcpsjwAj11TU98TRCiAd2