### PR TITLE
Add timeout-only issue ranking tests by source size

### DIFF
--- a/.github/workflows/wpt-reftests.yml
+++ b/.github/workflows/wpt-reftests.yml
@@ -34,9 +34,10 @@ name: WPT Reftests
 #
 # The manually dispatched workflow can target every reftest, a subset, a single
 # shard, or only the previously-failed reftests. Every run merges the shard results
-# and, when failures exist, files the same two GitHub issues the golden-image suite
-# does (most common failure groups, and the run's biggest problems), titled so the
-# two suites' issues are never confused.
+# and, when failures exist, files the same three GitHub issues the golden-image suite
+# does (most common failure groups; the run's biggest problems; and the tests that hit
+# the per-test timeout, smallest source first), titled so the two suites' issues are
+# never confused.
 #
 # Any shard that aborts abnormally — evicted runner, hard crash, i.e. no conclusive
 # report — is rerun once at the end of the workflow by the `retry` job, before the
@@ -92,6 +93,12 @@ on:
         description: Maximum number of biggest problems to include in the second (severity-focused) GitHub issue.
         required: false
         default: '3'
+      timeout_problems_limit:
+        description: >
+          Maximum number of timed-out reftests to list in the third (timeouts-only)
+          GitHub issue, smallest source file first.
+        required: false
+        default: '10'
 
 permissions:
   contents: write   # persist-failed commits the failing-reftest manifest
@@ -110,6 +117,7 @@ env:
   FAILED_TESTS_FILE: tests/wpt-baseline/failed-reftests.json
   MOST_COMMON_PROBLEMS_LIMIT: ${{ github.event.inputs.most_common_problems_limit || '10' }}
   BIGGEST_PROBLEMS_LIMIT: ${{ github.event.inputs.biggest_problems_limit || '3' }}
+  TIMEOUT_PROBLEMS_LIMIT: ${{ github.event.inputs.timeout_problems_limit || '10' }}
 
 jobs:
   # ── Resolve the shard matrix and whether to run incrementally ────────────
@@ -342,8 +350,10 @@ jobs:
             --merged-json wpt-merged/wpt-results.json \
             --issue-md wpt-merged/issue.md \
             --biggest-issue-md wpt-merged/biggest-issue.md \
+            --timeout-issue-md wpt-merged/timeout-issue.md \
             --problem-limit "$MOST_COMMON_PROBLEMS_LIMIT" \
             --biggest-problem-limit "$BIGGEST_PROBLEMS_LIMIT" \
+            --timeout-limit "$TIMEOUT_PROBLEMS_LIMIT" \
             --expected-shards "${{ needs.plan.outputs.expected-shards }}" \
             --github-output "$GITHUB_OUTPUT"
 
@@ -410,6 +420,31 @@ jobs:
               body,
             });
             core.info(`Created biggest-problems issue #${issue.data.number}: ${issue.data.html_url}`);
+
+      # Timeouts on their own terms: neither issue above ranks them usefully (a
+      # timed-out reftest never produced the pixel score the severity view ranks
+      # on), so they get their own, ranked smallest source file first.
+      - name: Create GitHub issue for the timed-out reftests
+        if: steps.merge.outputs.create_timeout_issue == 'true'
+        uses: actions/github-script@v8
+        env:
+          TIMEOUT_COUNT: ${{ steps.merge.outputs.timeout_count }}
+        with:
+          # Prefer the configured PAT/App token, then use this workflow's token.
+          github-token: ${{ secrets.ISSUE_TOKEN || github.token }}
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('wpt-merged/timeout-issue.md', 'utf8').trim();
+            const today = new Date().toISOString().slice(0, 10);
+            const count = Number(process.env.TIMEOUT_COUNT || 0);
+            const title = `WPT reftest run: ${count} timed-out reftest(s) (${today})`;
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+            });
+            core.info(`Created timeouts issue #${issue.data.number}: ${issue.data.html_url}`);
 
   # ── Persist the failing-reftest manifest for incremental reruns ──────────
   persist-failed:

--- a/.github/workflows/wpt-tests.yml
+++ b/.github/workflows/wpt-tests.yml
@@ -11,10 +11,13 @@ name: WPT Tests
 #
 # The manually dispatched workflow can target the full suite, a subset, a
 # single shard, or only the previously-failed tests. Every run merges the shard
-# results and, when failures exist, files two GitHub issues: one ranking the
-# most common failure groups (by frequency) and a second, severity-focused issue
+# results and, when failures exist, files three GitHub issues: one ranking the
+# most common failure groups (by frequency); a second, severity-focused issue
 # listing the run's few biggest problems (crashes, low-percent matches, and
-# incomplete shards, ranked by blast radius).
+# incomplete shards, ranked by blast radius); and a third listing only the tests
+# that hit the per-test timeout, ranked by the size of the test's own source,
+# smallest first — a hang on a tiny document is an engine that does not
+# terminate, whereas one on a huge document may only mean the budget is tight.
 #
 # Reference generation (Chromium via Playwright) is expensive, so each shard
 # caches its reference slice. Bump CACHE_EPOCH to refresh WPT master + refs.
@@ -80,6 +83,12 @@ on:
         description: Maximum number of biggest problems to include in the second (severity-focused) GitHub issue.
         required: false
         default: '3'
+      timeout_problems_limit:
+        description: >
+          Maximum number of timed-out tests to list in the third (timeouts-only)
+          GitHub issue, smallest source file first.
+        required: false
+        default: '10'
 
 permissions:
   contents: write   # persist-failed commits the failing-test manifest
@@ -95,6 +104,7 @@ env:
   FAILED_TESTS_FILE: tests/wpt-baseline/failed-tests.json
   MOST_COMMON_PROBLEMS_LIMIT: ${{ github.event.inputs.most_common_problems_limit || '10' }}
   BIGGEST_PROBLEMS_LIMIT: ${{ github.event.inputs.biggest_problems_limit || '3' }}
+  TIMEOUT_PROBLEMS_LIMIT: ${{ github.event.inputs.timeout_problems_limit || '10' }}
 
 jobs:
   # ── Resolve the shard matrix and whether to run incrementally ────────────
@@ -332,8 +342,10 @@ jobs:
             --merged-json wpt-merged/wpt-results.json \
             --issue-md wpt-merged/issue.md \
             --biggest-issue-md wpt-merged/biggest-issue.md \
+            --timeout-issue-md wpt-merged/timeout-issue.md \
             --problem-limit "$MOST_COMMON_PROBLEMS_LIMIT" \
             --biggest-problem-limit "$BIGGEST_PROBLEMS_LIMIT" \
+            --timeout-limit "$TIMEOUT_PROBLEMS_LIMIT" \
             --expected-shards "${{ needs.plan.outputs.expected-shards }}" \
             --github-output "$GITHUB_OUTPUT"
 
@@ -397,6 +409,33 @@ jobs:
               body,
             });
             core.info(`Created biggest-problems issue #${issue.data.number}: ${issue.data.html_url}`);
+
+      # A timeout carries no match percentage, so the two issues above rank it
+      # poorly — the frequency view collapses every timeout into one `Timeout` row
+      # and the severity view ranks on pixel scores a timed-out test never
+      # produced. This third issue reports them on their own terms, smallest
+      # source file first.
+      - name: Create GitHub issue for the timed-out tests
+        if: steps.merge.outputs.create_timeout_issue == 'true'
+        uses: actions/github-script@v8
+        env:
+          TIMEOUT_COUNT: ${{ steps.merge.outputs.timeout_count }}
+        with:
+          # Prefer the configured PAT/App token, then use this workflow's token.
+          github-token: ${{ secrets.ISSUE_TOKEN || github.token }}
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('wpt-merged/timeout-issue.md', 'utf8').trim();
+            const today = new Date().toISOString().slice(0, 10);
+            const count = Number(process.env.TIMEOUT_COUNT || 0);
+            const title = `WPT run: ${count} timed-out test(s) (${today})`;
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+            });
+            core.info(`Created timeouts issue #${issue.data.number}: ${issue.data.html_url}`);
 
   # ── Persist the failing-test manifest for incremental reruns ─────────────
   persist-failed:

--- a/scripts/merge-wpt-shards.py
+++ b/scripts/merge-wpt-shards.py
@@ -32,6 +32,21 @@ own ``wpt-results.json``. This script combines those shard reports to produce:
   out the ``--render`` command to reproduce a listed test, so every entry points
   at its cause. This is the "what hurt most this run" companion to the
   frequency-ranked ``--issue-md`` view.
+* ``--timeout-issue-md`` — a Markdown body for a *third* issue listing only the
+  tests the runner had to abort at the per-test timeout, ranked by the size of
+  the test's own source, **smallest first**. A timeout is not a mismatch you can
+  read a percentage off, so neither of the other two issues ranks it usefully:
+  the frequency view collapses every timeout into one ``Timeout`` row, and the
+  severity view ranks on pixel scores a timed-out test never produced. Source
+  size is the signal that separates them, and it separates them the counter-
+  intuitive way round: the *less* there is in a document, the less of it can be
+  legitimately slow, so the likelier its timeout is an engine hang — a layout
+  loop that never terminates, a parser that never advances — rather than a heavy
+  page that merely wants more than the budget. A 30s timeout on a 40 MB stress
+  test says the budget is tight; the same timeout on a 400-byte document says
+  something does not terminate, and that bug usually gates far more than the one
+  test. The issue also clusters the timeouts by directory, because a directory
+  full of them is one hang gating a feature area rather than N problems.
 
 When ``--merge-into`` names an existing manifest, the run's failures are folded
 into it *by scope* instead of replacing it: entries for tests this run actually
@@ -52,11 +67,11 @@ happened to.
 When ``--github-output`` is given (the ``$GITHUB_OUTPUT`` file), the script also
 writes ``failed_count``, ``total_count``, ``incomplete_shard_count``,
 ``create_issue``, ``biggest_problem_count``, ``create_biggest_issue``,
-``incomplete_shard_indexes``, ``incomplete_shard_matrix``,
-``has_incomplete_shards`` and ``retried_shard_count`` step outputs.
-``create_(biggest_)issue`` drive the two issues; the ``incomplete_shard_*``
-trio drives the retry pass, which re-dispatches exactly the shards flagged
-incomplete.
+``timeout_count``, ``create_timeout_issue``, ``incomplete_shard_indexes``,
+``incomplete_shard_matrix``, ``has_incomplete_shards`` and
+``retried_shard_count`` step outputs. ``create_(biggest_|timeout_)issue`` drive
+the three issues; the ``incomplete_shard_*`` trio drives the retry pass, which
+re-dispatches exactly the shards flagged incomplete.
 """
 
 from __future__ import annotations
@@ -93,6 +108,29 @@ DEFAULT_LOW_MATCH_THRESHOLD = 50.0
 # misses still surfaces its worst renders instead of an empty severity issue.
 LOW_MATCH_THRESHOLD_STEP = 10.0
 LOW_MATCH_THRESHOLD_CEILING = 100.0
+
+# The third, timeout-only issue lists at most this many timed-out tests, smallest
+# source first. Ten is enough to show the whole small-file head of the ranking —
+# past that the entries are large documents whose timeout says little.
+DEFAULT_TIMEOUT_LIMIT = 10
+
+#: Source-size bands used to label a timeout's severity, as
+#: ``(upper bound in bytes, label)`` ordered by ascending bound; anything above
+#: the last bound gets ``TIMEOUT_LARGE_LABEL``. The bounds are deliberately
+#: coarse — the ranking is the file size itself, and these only exist so a reader
+#: does not have to hold "is 3 KiB small for a WPT test?" in their head. For
+#: calibration: a WPT test that is nothing but a fragment of markup plus a
+#: stylesheet link lands around 0.5–2 KiB, and one carrying its own script
+#: harness around 4–8 KiB.
+TIMEOUT_SIZE_BANDS = (
+    (2 * 1024, "critical"),
+    (8 * 1024, "high"),
+    (32 * 1024, "medium"),
+)
+TIMEOUT_LARGE_LABEL = "low"
+#: Label for a timeout whose source size could not be read. It is not a severity
+#: — nothing is known — so it sorts last rather than anywhere on the scale.
+TIMEOUT_UNKNOWN_LABEL = "unranked"
 
 
 def _bucket_directory(relative_path: str) -> str:
@@ -659,12 +697,97 @@ def _rank_biggest_problems_escalating(
         threshold = min(threshold + LOW_MATCH_THRESHOLD_STEP, LOW_MATCH_THRESHOLD_CEILING)
 
 
+def _timeout_directory(relative_path: str) -> str:
+    """The directory a timed-out test lives in, mirroring the runner's own bucket
+    (``Program.GetBucketDirectory``): the test's parent directory, or ``.`` at the
+    root. Only used for reports predating ``triage.timeoutFailures``, which carry
+    the directory the runner computed."""
+    directory, _, _filename = relative_path.rpartition("/")
+    return directory or "."
+
+
+def _record_timeout(
+    store: dict[str, dict],
+    relative_path: str,
+    directory: str,
+    message: str | None,
+    size_bytes: int | None,
+) -> None:
+    """Remember one timed-out test, preferring the record that knows its size.
+
+    A test can be described twice — once by ``triage.timeoutFailures`` (with its
+    source size) and once by the bare ``results`` entry the fallback scan reads
+    (without one). Whichever arrives first, the sized record wins, so the ranking
+    never loses a measurement it was given.
+    """
+    existing = store.get(relative_path)
+    if existing is not None and (existing.get("fileSizeBytes") is not None or size_bytes is None):
+        return
+    store[relative_path] = {
+        "relativeTestPath": relative_path,
+        "directory": directory,
+        "message": message,
+        "fileSizeBytes": size_bytes,
+    }
+
+
+def _timeout_severity(size_bytes: int | None) -> str:
+    """Coarse severity label for a timeout, read off the test's source size."""
+    if size_bytes is None:
+        return TIMEOUT_UNKNOWN_LABEL
+    for upper_bound, label in TIMEOUT_SIZE_BANDS:
+        if size_bytes < upper_bound:
+            return label
+    return TIMEOUT_LARGE_LABEL
+
+
+def _format_file_size(size_bytes: int | None) -> str:
+    """Human-readable byte count, matching the runner's own formatting."""
+    if size_bytes is None:
+        return "size unknown"
+    if size_bytes >= 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.1f} MiB"
+    # Bytes, not "0.0 KiB", below a kilobyte: the head of this ranking is made of
+    # exactly those files, and rounding them all to the same 0.0 would hide the
+    # one distinction the report exists to draw.
+    if size_bytes >= 1024:
+        return f"{size_bytes / 1024:.1f} KiB"
+    return f"{size_bytes} B"
+
+
+def _rank_timeouts(timeout_tests: dict[str, dict], limit: int) -> list[dict]:
+    """The run's timed-out tests, smallest source first, bounded to ``limit``.
+
+    Ascending size is the whole ranking, and it is the point of this report: the
+    smaller the document, the less of it can be legitimately slow, so the likelier
+    its timeout is an engine hang than a heavy page (see the module docstring). A
+    test whose size could not be read sorts last — it carries no signal either way
+    and must not displace a measured small file.
+    """
+    ranked = sorted(
+        timeout_tests.values(),
+        key=lambda test: (
+            test["fileSizeBytes"] is None,
+            test["fileSizeBytes"] if test["fileSizeBytes"] is not None else 0,
+            test["relativeTestPath"],
+        ),
+    )
+    return [
+        {
+            **test,
+            "severity": _timeout_severity(test["fileSizeBytes"]),
+        }
+        for test in ranked[:limit]
+    ]
+
+
 def merge(
     shard_dir: Path,
     problem_limit: int = DEFAULT_PROBLEM_LIMIT,
     biggest_problem_limit: int = DEFAULT_BIGGEST_PROBLEM_LIMIT,
     low_match_threshold: float = DEFAULT_LOW_MATCH_THRESHOLD,
     expected_shard_indexes: set[int] | None = None,
+    timeout_limit: int = DEFAULT_TIMEOUT_LIMIT,
 ) -> dict:
     passed = failed = skipped = total = 0
     shard_count = 0
@@ -676,6 +799,7 @@ def merge(
     exception_signature_counter: Counter[str] = Counter()
     exception_examples: dict[str, list[str]] = {}
     low_match_tests: list[dict] = []
+    timeout_tests: dict[str, dict] = {}
     problem_groups: dict[str, dict] = {}
     family_groups: dict[str, dict] = {}
     reported_shard_indexes: set[int] = set()
@@ -768,6 +892,26 @@ def merge(
                     }
                 )
 
+            # Tests the runner aborted at the per-test timeout, each with the size
+            # of its own source — the signal the timeouts issue ranks on. The
+            # results loop below re-reads the same failures for reports that predate
+            # this triage entry, so the issue is complete either way; only the sizes
+            # (and therefore the ranking) need this.
+            for entry in triage.get("timeoutFailures", []) or []:
+                if not isinstance(entry, dict):
+                    continue
+                relative_path = entry.get("testPath") or entry.get("relativeTestPath")
+                if not relative_path:
+                    continue
+                size_bytes = entry.get("fileSizeBytes")
+                _record_timeout(
+                    timeout_tests,
+                    str(relative_path),
+                    str(entry.get("directory") or _timeout_directory(str(relative_path))),
+                    str(entry["message"]) if entry.get("message") else None,
+                    int(size_bytes) if isinstance(size_bytes, (int, float)) else None,
+                )
+
         for result in report.get("results", []):
             if not isinstance(result, dict):
                 continue
@@ -796,6 +940,21 @@ def merge(
             failures.append(failure)
             directory_counter[_bucket_directory(relative_path)] += 1
             category_counter[category] += 1
+
+            # Every timeout, counted here rather than from triage.timeoutFailures:
+            # this loop sees the authoritative per-test verdicts, so the timeouts
+            # issue reports the same number the category breakdown does even for a
+            # report that carries no timeout triage at all (an older shard, or one
+            # merged from a runner build predating it). _record_timeout keeps the
+            # sized triage record when there is one, so nothing is downgraded.
+            if category == "Timeout":
+                _record_timeout(
+                    timeout_tests,
+                    relative_path,
+                    _timeout_directory(relative_path),
+                    str(result["message"]) if result.get("message") else None,
+                    None,
+                )
 
             group = problem_groups.setdefault(
                 problem_key,
@@ -968,6 +1127,18 @@ def merge(
         "biggestProblemLimit": biggest_problem_limit,
         "lowMatchThreshold": effective_low_match_threshold,
         "biggestProblems": biggest_problems,
+        "timeoutLimit": timeout_limit,
+        # Every timeout the run saw, even when only `timeout_limit` of them are
+        # listed in the issue — the count is what says whether the listed head is
+        # the whole story.
+        "timeoutCount": len(timeout_tests),
+        "timeouts": _rank_timeouts(timeout_tests, timeout_limit),
+        # Counted from the same deduped set the ranking is drawn from, so the
+        # clusters always add up to `timeoutCount` rather than to whichever of the
+        # two sources happened to describe a given test.
+        "timeoutDirectories": Counter(
+            test["directory"] for test in timeout_tests.values()
+        ).most_common(problem_limit),
         "referenceDisagreements": _reference_disagreements(low_match_tests),
         "results": failures,
     }
@@ -1239,6 +1410,94 @@ def render_biggest_problems_markdown(merged: dict, run_url: str | None) -> str:
     return "\n".join(lines) + "\n"
 
 
+def render_timeout_issue_markdown(merged: dict, run_url: str | None) -> str:
+    """Render the body of the third issue: only the tests that timed out, ranked
+    by their own source size, smallest first (see ``_rank_timeouts``)."""
+    timeouts = merged.get("timeouts") or []
+    total = merged.get("timeoutCount", len(timeouts))
+    limit = merged.get("timeoutLimit", DEFAULT_TIMEOUT_LIMIT)
+    lines = [
+        f"## WPT run — {total} timed-out test(s)",
+        "",
+        "_Only the tests the runner had to abort at the per-test timeout. They are"
+        " ranked by the size of the test's own source, **smallest first**: the less"
+        " there is in a document, the less of it can be legitimately slow, so the"
+        " likelier its timeout is an engine hang — a layout loop that never"
+        " terminates, a parser that never advances — than a heavy page that merely"
+        " wants more than the budget. A timeout on a multi-megabyte stress test says"
+        " the budget is tight; the same timeout on a sub-kilobyte document says"
+        " something does not terminate, and that bug usually gates far more than the"
+        " one test._",
+        "",
+        f"- Timed out: {total}",
+        f"- Listed below: {min(total, limit)}"
+        + (f" (of {total}; raise `timeout_problems_limit` for more)" if total > limit else ""),
+        "",
+        "### Timed-out tests, smallest source first",
+        "",
+    ]
+    if timeouts:
+        for index, timeout in enumerate(timeouts, start=1):
+            lines.append(
+                f"{index}. **{_format_file_size(timeout['fileSizeBytes'])}** —"
+                f" `{timeout['relativeTestPath']}` ({timeout['severity']})"
+            )
+            if timeout.get("message"):
+                lines.append(f"   - {timeout['message']}")
+    else:
+        lines.append("- None — no test hit the per-test timeout.")
+
+    # A directory with several timeouts is one hang gating a feature area rather
+    # than N independent problems, and it is the cheapest thing to act on: the
+    # subset command reruns exactly that slice.
+    directories = merged.get("timeoutDirectories") or []
+    if directories:
+        lines += [
+            "",
+            "### Timeout clusters",
+            "",
+            "_Directories with more than one timeout are usually a single hang gating a"
+            " whole feature area. Rerun one with the subset command beside it._",
+            "",
+        ]
+        for directory, count in directories:
+            lines.append(
+                f"- `{directory}` — {count} timeout(s) —"
+                f' `./scripts/run-wpt-tests.sh --subset "{directory}"`'
+            )
+
+    if timeouts:
+        first = timeouts[0]["relativeTestPath"]
+        lines += [
+            "",
+            "### Reproduce locally",
+            "",
+            "_Render the smallest timed-out test — the top of the ranking — against the"
+            " live engine. It hangs where the suite gave up, so a debugger attached here"
+            " lands directly in the non-terminating code._",
+            "",
+            "```sh",
+            "dotnet run --project src/Broiler.Wpt -- \\",
+            f"  --wpt-dir {WPT_CHECKOUT_DIR} --render {WPT_CHECKOUT_DIR}/{first}",
+            "```",
+            "",
+            "_Raise `--timeout` (or `BROILER_WPT_TIMEOUT_SECONDS`) to tell a genuine hang"
+            " apart from a test that is merely slower than the budget: a hang still does"
+            " not finish with the limit lifted._",
+        ]
+
+    lines += [
+        "",
+        "### CI metadata",
+        f"- Workflow run: {run_url}" if run_url else "- Workflow run: (unknown)",
+        "- Artifact: `wpt-merged`",
+        "",
+        "_Auto-generated by `.github/workflows/wpt-tests.yml`. See the companion"
+        " most-common-failures and biggest-problems issues for the rest of the run._",
+    ]
+    return "\n".join(lines) + "\n"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--shard-dir", required=True, type=Path, help="Directory containing per-shard JSON reports")
@@ -1256,6 +1515,11 @@ def main() -> int:
         help="Where to write the Markdown body for the second, biggest-problems issue",
     )
     parser.add_argument(
+        "--timeout-issue-md",
+        type=Path,
+        help="Where to write the Markdown body for the third, timeouts-only issue",
+    )
+    parser.add_argument(
         "--problem-limit",
         type=int,
         default=DEFAULT_PROBLEM_LIMIT,
@@ -1267,6 +1531,13 @@ def main() -> int:
         default=DEFAULT_BIGGEST_PROBLEM_LIMIT,
         help="Maximum biggest problems to report in the second issue "
         f"(default: {DEFAULT_BIGGEST_PROBLEM_LIMIT})",
+    )
+    parser.add_argument(
+        "--timeout-limit",
+        type=int,
+        default=DEFAULT_TIMEOUT_LIMIT,
+        help="Maximum timed-out tests to list in the third issue, smallest source "
+        f"first (default: {DEFAULT_TIMEOUT_LIMIT})",
     )
     parser.add_argument(
         "--low-match-threshold",
@@ -1290,6 +1561,8 @@ def main() -> int:
         parser.error("--problem-limit must be a positive integer")
     if args.biggest_problem_limit < 1:
         parser.error("--biggest-problem-limit must be a positive integer")
+    if args.timeout_limit < 1:
+        parser.error("--timeout-limit must be a positive integer")
     if not 0 <= args.low_match_threshold <= 100:
         parser.error("--low-match-threshold must be between 0 and 100")
 
@@ -1308,6 +1581,7 @@ def main() -> int:
         args.biggest_problem_limit,
         args.low_match_threshold,
         expected_shard_indexes=expected_shard_indexes,
+        timeout_limit=args.timeout_limit,
     )
 
     if args.merge_into:
@@ -1329,10 +1603,17 @@ def main() -> int:
             render_biggest_problems_markdown(merged, args.run_url), encoding="utf-8"
         )
 
+    if args.timeout_issue_md:
+        args.timeout_issue_md.parent.mkdir(parents=True, exist_ok=True)
+        args.timeout_issue_md.write_text(
+            render_timeout_issue_markdown(merged, args.run_url), encoding="utf-8"
+        )
+
     failed = merged["summary"]["failed"]
     total = merged["summary"]["total"]
     incomplete_shard_count = len(merged["incompleteShards"])
     biggest_problem_count = len(merged.get("biggestProblems") or [])
+    timeout_count = merged.get("timeoutCount", 0)
     print(f"Merged {merged['shardCount']} shard(s): {merged['summary']['passed']} passed, "
           f"{failed} failed, {merged['summary']['skipped']} skipped, {total} total.")
 
@@ -1352,6 +1633,8 @@ def main() -> int:
             handle.write(f"create_issue={'true' if failed > 0 or incomplete_shard_count > 0 else 'false'}\n")
             handle.write(f"biggest_problem_count={biggest_problem_count}\n")
             handle.write(f"create_biggest_issue={'true' if biggest_problem_count > 0 else 'false'}\n")
+            handle.write(f"timeout_count={timeout_count}\n")
+            handle.write(f"create_timeout_issue={'true' if timeout_count > 0 else 'false'}\n")
             handle.write(
                 "incomplete_shard_indexes="
                 + ",".join(str(index) for index in incomplete_indexes)

--- a/scripts/tests/test_merge_wpt_shards.py
+++ b/scripts/tests/test_merge_wpt_shards.py
@@ -1563,6 +1563,247 @@ class MergeWptShardsTests(unittest.TestCase):
                 [entry["relativeTestPath"] for entry in written["results"]],
             )
 
+    def _write_timeout_report(
+        self,
+        root: Path,
+        name: str,
+        shard_index: int,
+        timeouts: list[tuple[str, int | None]],
+        extra_results: list[dict] | None = None,
+    ) -> None:
+        """A shard report whose failures are timeouts, with the triage entry the
+        runner emits for each (test path + the size of its own source)."""
+        results = [self._failure(path, "Timeout") for path, _size in timeouts]
+        results += extra_results or []
+        (root / name).write_text(
+            json.dumps(
+                {
+                    "summary": {
+                        "passed": 1,
+                        "failed": len(results),
+                        "skipped": 0,
+                        "total": len(results) + 1,
+                    },
+                    "shard": {"index": shard_index, "count": 8},
+                    "triage": {
+                        "timeoutFailures": [
+                            {
+                                "testPath": path,
+                                "directory": path.rpartition("/")[0],
+                                "message": f"Test timed out after 30 second(s): {path}",
+                                "fileSizeBytes": size,
+                            }
+                            for path, size in timeouts
+                        ]
+                    },
+                    "results": results,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_timeouts_rank_smallest_source_first(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._write_timeout_report(
+                shard_dir,
+                "shard-0.json",
+                0,
+                [
+                    ("css/css-tables/huge-generated-table.html", 4_000_000),
+                    ("css/css-grid/tiny-hang.html", 380),
+                ],
+            )
+            self._write_timeout_report(
+                shard_dir,
+                "shard-1.json",
+                1,
+                [("html/parser/medium.html", 6_000)],
+                extra_results=[self._failure("html/other/pixel.html", "PixelMismatch")],
+            )
+
+            merged = MODULE.merge(shard_dir)
+
+            self.assertEqual(3, merged["timeoutCount"])
+            # Ascending source size *is* the ranking: the 380-byte document that
+            # hung is the strongest hang signal in the run, the 4 MB one the weakest.
+            self.assertEqual(
+                [
+                    "css/css-grid/tiny-hang.html",
+                    "html/parser/medium.html",
+                    "css/css-tables/huge-generated-table.html",
+                ],
+                [timeout["relativeTestPath"] for timeout in merged["timeouts"]],
+            )
+            self.assertEqual(
+                ["critical", "high", "low"],
+                [timeout["severity"] for timeout in merged["timeouts"]],
+            )
+            # The pixel mismatch is a failure but not a timeout, so it appears in
+            # neither the count nor the ranking.
+            self.assertNotIn(
+                "html/other/pixel.html",
+                [timeout["relativeTestPath"] for timeout in merged["timeouts"]],
+            )
+
+    def test_timeouts_bounded_by_limit_and_clustered_by_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._write_timeout_report(
+                shard_dir,
+                "shard-0.json",
+                0,
+                [
+                    ("css/css-grid/hang-1.html", 300),
+                    ("css/css-grid/hang-2.html", 400),
+                    ("css/css-grid/hang-3.html", 500),
+                    ("html/parser/hang.html", 900),
+                ],
+            )
+
+            merged = MODULE.merge(shard_dir, timeout_limit=2)
+
+            # The count reports every timeout; only `timeout_limit` are listed.
+            self.assertEqual(4, merged["timeoutCount"])
+            self.assertEqual(
+                ["css/css-grid/hang-1.html", "css/css-grid/hang-2.html"],
+                [timeout["relativeTestPath"] for timeout in merged["timeouts"]],
+            )
+            self.assertEqual(
+                [("css/css-grid", 3), ("html/parser", 1)],
+                merged["timeoutDirectories"],
+            )
+
+            markdown = MODULE.render_timeout_issue_markdown(merged, None)
+            self.assertIn("## WPT run — 4 timed-out test(s)", markdown)
+            self.assertIn("- Listed below: 2 (of 4; raise `timeout_problems_limit` for more)", markdown)
+            # Sub-kilobyte sources print as bytes: this is the head of the ranking,
+            # and rounding every entry in it to "0.0 KiB" would flatten the one
+            # distinction the report draws.
+            self.assertIn("**300 B** — `css/css-grid/hang-1.html` (critical)", markdown)
+            self.assertIn("### Timeout clusters", markdown)
+            self.assertIn(
+                '`css/css-grid` — 3 timeout(s) — `./scripts/run-wpt-tests.sh --subset "css/css-grid"`',
+                markdown,
+            )
+            # The reproduction points at the top of the ranking — the smallest file.
+            self.assertIn(
+                "--wpt-dir tests/wpt/checkout --render tests/wpt/checkout/css/css-grid/hang-1.html",
+                markdown,
+            )
+
+    def test_timeouts_without_triage_sizes_are_still_reported_last(self) -> None:
+        """A report predating ``triage.timeoutFailures`` (or one whose size could
+        not be stat'd) still contributes its timeouts — unranked, sorted after
+        every measured one, because nothing is known about how big it is."""
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp)
+            self._write_report(
+                shard_dir,
+                "shard-0.json",
+                0,
+                [
+                    self._failure("css/legacy/no-triage.html", "Timeout"),
+                    self._failure("css/legacy/pixel.html", "PixelMismatch"),
+                ],
+            )
+            self._write_timeout_report(
+                shard_dir,
+                "shard-1.json",
+                1,
+                [("css/modern/sized.html", 12_000)],
+            )
+
+            merged = MODULE.merge(shard_dir)
+
+            self.assertEqual(2, merged["timeoutCount"])
+            self.assertEqual(
+                ["css/modern/sized.html", "css/legacy/no-triage.html"],
+                [timeout["relativeTestPath"] for timeout in merged["timeouts"]],
+            )
+            self.assertEqual(
+                ["medium", "unranked"],
+                [timeout["severity"] for timeout in merged["timeouts"]],
+            )
+            markdown = MODULE.render_timeout_issue_markdown(merged, None)
+            self.assertIn("**size unknown** — `css/legacy/no-triage.html` (unranked)", markdown)
+
+    def test_timeout_issue_written_and_gated_on_step_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp) / "shards"
+            shard_dir.mkdir()
+            self._write_timeout_report(
+                shard_dir,
+                "shard-0.json",
+                0,
+                [("css/css-grid/tiny-hang.html", 380)],
+            )
+            timeout_md = Path(temp) / "timeout-issue.md"
+            github_output = Path(temp) / "github-output"
+            github_output.touch()
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--shard-dir",
+                    str(shard_dir),
+                    "--timeout-issue-md",
+                    str(timeout_md),
+                    "--github-output",
+                    str(github_output),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            outputs = dict(
+                line.split("=", 1)
+                for line in github_output.read_text(encoding="utf-8").splitlines()
+                if "=" in line
+            )
+            self.assertEqual("1", outputs["timeout_count"])
+            self.assertEqual("true", outputs["create_timeout_issue"])
+            self.assertIn("`css/css-grid/tiny-hang.html`", timeout_md.read_text(encoding="utf-8"))
+
+    def test_timeout_issue_not_created_when_nothing_timed_out(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            shard_dir = Path(temp) / "shards"
+            shard_dir.mkdir()
+            self._write_report(
+                shard_dir,
+                "shard-0.json",
+                0,
+                [self._failure("css/a/one.html", "PixelMismatch", "MissingContent")],
+            )
+            github_output = Path(temp) / "github-output"
+            github_output.touch()
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--shard-dir",
+                    str(shard_dir),
+                    "--github-output",
+                    str(github_output),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            outputs = dict(
+                line.split("=", 1)
+                for line in github_output.read_text(encoding="utf-8").splitlines()
+                if "=" in line
+            )
+            self.assertEqual("0", outputs["timeout_count"])
+            self.assertEqual("false", outputs["create_timeout_issue"])
+
     @staticmethod
     def _failure(path: str, category: str, sub_category: str | None = None) -> dict:
         result = {

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -4913,6 +4913,12 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
             File.WriteAllText(timeoutPath, "<html><body>Timeout</body></html>");
         }
 
+        // One deliberately larger source, so the report's ordering has something to
+        // order: timeouts are ranked by source size ascending (a hang on a small
+        // document is the stronger signal), not alphabetically.
+        var largestTimeoutPath = timeoutPaths[0];
+        File.WriteAllText(largestTimeoutPath, $"<html><body>{new string('x', 4096)}</body></html>");
+
         Program.RunTestExecutor = static (runner, testPath, referenceDir, wptPath) => new WptTestResult
         {
             TestPath = testPath,
@@ -4947,6 +4953,18 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
         Assert.Contains(timeoutFailures, failure => failure.GetProperty("testPath").GetString() == "css/css-grid/parsing/grid-template-columns-crash.html");
         Assert.Contains(timeoutFailures, failure => failure.GetProperty("testPath").GetString() == "css/css-tables/html5-table-formatting-3.html");
 
+        // Each timeout carries the size of the test's own source — the signal
+        // scripts/merge-wpt-shards.py ranks the timeouts issue on.
+        Assert.All(timeoutFailures, failure => Assert.True(failure.GetProperty("fileSizeBytes").GetInt64() > 0));
+        // …and the list is already ranked by it, smallest first, so the largest
+        // source sorts last however early its path sorts alphabetically.
+        Assert.Equal(
+            "css/css-grid/parsing/grid-template-columns-crash.html",
+            timeoutFailures[^1].GetProperty("testPath").GetString());
+        Assert.Equal(
+            timeoutFailures.Select(failure => failure.GetProperty("fileSizeBytes").GetInt64()).Order(),
+            timeoutFailures.Select(failure => failure.GetProperty("fileSizeBytes").GetInt64()));
+
         var timeoutSubsetCommands = triage.GetProperty("timeoutSubsetCommands")
             .EnumerateArray()
             .Select(entry => new
@@ -4968,14 +4986,14 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
         var markdown = File.ReadAllText(markdownPath);
         Assert.Contains("## Timeout failures", markdown);
         Assert.Contains($"- Render backend: {BGraphicsBackend.CurrentLabel}", markdown);
-        Assert.Contains("`css/css-grid/parsing/grid-template-columns-crash.html`", markdown);
-        Assert.Contains("`css/css-tables/html5-table-formatting-3.html`", markdown);
+        Assert.Contains("`css/css-grid/parsing/grid-template-columns-crash.html` — 4.0 KiB", markdown);
+        Assert.Contains("`css/css-tables/html5-table-formatting-3.html` — 33 B", markdown);
         Assert.Contains("### Suggested timeout subset commands", markdown);
         Assert.Contains("./scripts/run-wpt-tests.sh --subset \"css/css-overflow/scroll-markers\"", markdown);
         Assert.Contains("./scripts/run-wpt-tests.sh --subset \"css/css-tables/height-distribution\"", markdown);
 
         var output = consoleOutput.ToString();
-        Assert.Contains("Timeout failures:", output);
+        Assert.Contains("Timeout failures (smallest source first — the likeliest engine hangs):", output);
         Assert.Contains("css/css-grid/parsing/grid-template-columns-crash.html", output);
         Assert.Contains("css/css-tables/html5-table-formatting-3.html", output);
         Assert.Contains("Timeout subset commands:", output);

--- a/src/Broiler.Wpt/Program.cs
+++ b/src/Broiler.Wpt/Program.cs
@@ -2705,7 +2705,7 @@ public class Program
     {
         var timeoutSummary = GetTimeoutSummary(failures, wptPath);
 
-        Console.WriteLine("Timeout failures:");
+        Console.WriteLine("Timeout failures (smallest source first — the likeliest engine hangs):");
         if (timeoutSummary.Failures.Count == 0)
         {
             Console.WriteLine("  (none)");
@@ -2714,7 +2714,7 @@ public class Program
         {
             foreach (var failure in timeoutSummary.Failures)
             {
-                Console.WriteLine($"  • {failure.RelativePath}");
+                Console.WriteLine($"  • {FormatFileSize(failure.FileSizeBytes),12}  {failure.RelativePath}");
                 if (!string.IsNullOrWhiteSpace(failure.Message))
                     Console.WriteLine($"    {failure.Message}");
             }
@@ -2756,10 +2756,59 @@ public class Program
             .Select(result =>
             {
                 var relativePath = Path.GetRelativePath(wptPath, result.TestPath).Replace('\\', '/');
-                return new TimeoutFailure(relativePath, GetBucketDirectory(result.TestPath, wptPath), result.Message);
+                return new TimeoutFailure(
+                    relativePath,
+                    GetBucketDirectory(result.TestPath, wptPath),
+                    result.Message,
+                    TryGetFileSizeBytes(result.TestPath));
             })
-            .OrderBy(result => result.RelativePath, StringComparer.Ordinal)
+            // Smallest source first — that ordering *is* the triage ranking. See
+            // TimeoutFailure for why a small file makes a timeout more serious, not
+            // less. A size that could not be read sorts last: nothing is known about
+            // it, so it must not outrank a measured tiny file.
+            .OrderBy(failure => failure.FileSizeBytes ?? long.MaxValue)
+            .ThenBy(failure => failure.RelativePath, StringComparer.Ordinal)
             .ToList();
+
+    /// <summary>
+    /// Size of a test's source on disk in bytes, or null when it cannot be read
+    /// (deleted between the run and the report, or unreadable). Never throws: a
+    /// missing size only costs the entry its ranking, and losing the whole report
+    /// over one stat call would be a far worse trade.
+    /// </summary>
+    private static long? TryGetFileSizeBytes(string testPath)
+    {
+        try
+        {
+            var info = new FileInfo(testPath);
+            return info.Exists ? info.Length : null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Human-readable byte count for the timeout report (<c>1.4 KiB</c>). Mirrors
+    /// <c>scripts/merge-wpt-shards.py</c>'s formatting so a per-shard line and the
+    /// merged issue print the same test the same way.
+    /// </summary>
+    private static string FormatFileSize(long? bytes) =>
+        bytes switch
+        {
+            null => "size unknown",
+            >= 1024 * 1024 => $"{bytes.Value / (1024.0 * 1024.0):0.0} MiB",
+            >= 1024 => $"{bytes.Value / 1024.0:0.0} KiB",
+            // Bytes rather than "0.0 KiB" below a kilobyte: the head of this
+            // ranking is made of exactly those files, and rounding them all to the
+            // same 0.0 would hide the one distinction the ordering exists to draw.
+            _ => $"{bytes.Value} B",
+        };
 
     private static TimeoutSummary GetTimeoutSummary(IEnumerable<WptTestResult> failures, string wptPath)
     {
@@ -2984,16 +3033,34 @@ public class Program
         };
     }
 
+    /// <summary>
+    /// One test the runner had to abort at the per-test timeout.
+    /// </summary>
+    /// <param name="FileSizeBytes">
+    /// Size of the test's own source on disk, null when it could not be read. This
+    /// is what ranks the timeout report, and it ranks it <em>ascending</em>: the
+    /// smaller the document that hung, the less there is in it to be legitimately
+    /// slow, so the likelier the timeout is an engine hang — an unterminated layout
+    /// loop, a parser that never advances, a promise that never settles — rather
+    /// than a genuinely heavy page that merely wants more than the budget. A 30s
+    /// timeout on a 40 MB generated stress test says the budget is tight; the same
+    /// timeout on a 400-byte document says something in the engine does not
+    /// terminate, and that one usually gates many more tests than itself.
+    /// </param>
     private sealed record TimeoutFailure(
         string RelativePath,
         string Directory,
-        string? Message)
+        string? Message,
+        long? FileSizeBytes = null)
     {
         public Dictionary<string, object?> ToJsonObject() => new()
         {
             ["testPath"] = RelativePath,
             ["directory"] = Directory,
             ["message"] = Message,
+            // Consumed by scripts/merge-wpt-shards.py, which ranks the merged
+            // timeouts issue on it exactly as this file ranks the per-shard list.
+            ["fileSizeBytes"] = FileSizeBytes,
         };
     }
 
@@ -3015,9 +3082,14 @@ public class Program
         }
         else
         {
+            writer.WriteLine(
+                "_Smallest source first: the less there is in a document, the less of it can be" +
+                " legitimately slow, so the likelier its timeout is an engine hang rather than a" +
+                " heavy page._");
+            writer.WriteLine();
             foreach (var failure in timeoutFailures)
             {
-                writer.WriteLine($"- `{failure.RelativePath}`");
+                writer.WriteLine($"- `{failure.RelativePath}` — {FormatFileSize(failure.FileSizeBytes)}");
                 if (!string.IsNullOrWhiteSpace(failure.Message))
                     writer.WriteLine($"  - {failure.Message}");
             }


### PR DESCRIPTION
## Summary

Adds a third GitHub issue to WPT test runs that lists only the tests hitting the per-test timeout, ranked by source file size (smallest first). This complements the existing frequency-ranked and severity-ranked issues, since timeouts don't produce match percentages and thus rank poorly in those views.

The key insight: a timeout on a tiny document (< 2 KiB) is more likely an engine hang (unterminated layout loop, parser that never advances) than a heavy page that merely needs more time. A timeout on a 40 MB stress test says the budget is tight; the same timeout on a 400-byte document says something doesn't terminate — a bug that usually gates far more than one test.

## Key Changes

**Python merge script (`scripts/merge-wpt-shards.py`)**
- Added `--timeout-issue-md` flag to write a third Markdown issue body
- Added `--timeout-limit` flag (default 10) to bound the listed timeouts
- Implemented `_rank_timeouts()` to sort by ascending file size, with unmeasured sizes sorting last
- Implemented `_timeout_severity()` to label timeouts by source size bands (critical < 2 KiB, high < 8 KiB, medium < 32 KiB, low ≥ 32 KiB)
- Implemented `_record_timeout()` to deduplicate timeouts from two sources: `triage.timeoutFailures` (with sizes) and bare `results` entries (without sizes), preferring sized records
- Implemented `render_timeout_issue_markdown()` to format the issue with:
  - Ranked list of timed-out tests with file sizes and severity labels
  - Directory clusters (directories with multiple timeouts are likely a single hang gating a feature area)
  - Reproduction command pointing at the smallest (most suspicious) timeout
- Added `timeout_count`, `create_timeout_issue` to GitHub step outputs
- Updated module docstring to document the new issue

**C# runner (`src/Broiler.Wpt/Program.cs`)**
- Modified `GetTimeoutFailures()` to call `TryGetFileSizeBytes()` for each timeout and rank by size ascending (not alphabetically)
- Implemented `TryGetFileSizeBytes()` to safely read file size, returning null on I/O errors rather than throwing
- Implemented `FormatFileSize()` to match Python's formatting (bytes for < 1 KiB, KiB for < 1 MiB, MiB for larger)
- Updated `PrintTimeoutSummary()` to display file sizes and note the ranking rationale
- Updated `TimeoutFailure` record to include `FileSizeBytes` field and serialize it to JSON for the merge script

**Workflows (`.github/workflows/wpt-tests.yml` and `wpt-reftests.yml`)**
- Added `timeout_problems_limit` input parameter (default 10)
- Updated merge script invocation to pass `--timeout-issue-md` and `--timeout-limit`
- Added GitHub issue creation step for timeouts (gated on `create_timeout_issue` output)
- Updated workflow documentation to describe the three-issue model

**Tests (`scripts/tests/test_merge_wpt_shards.py` and `src/Broiler.Wpt.Tests/WptTestRunnerTests.cs`)**
- Added comprehensive test coverage for timeout ranking, limiting, and clustering
- Added test for handling timeouts without triage sizes (older reports)
- Added test for GitHub output generation and issue creation gating
- Added test for per-shard timeout summary formatting with file sizes

## Notable Implementation Details

- **Deduplication:** Timeouts can appear in both `triage.timeoutFailures` (with sizes) and `results` (without). The merge script prefers the sized record, ensuring the ranking never loses a measurement.
- **Fallback for old reports:** Reports predating `triage.timeoutFailures` still contribute their timeouts, but unranked (sorted last) since size is unknown.
- **File size formatting:** Deliberately uses bytes (not "0.0 KiB") for sub-kilobyte files, since the ranking head is

https://claude.ai/code/session_013JZ4PXpxZPZ5Z4ymy6qF6d