### PR TITLE
Fix view transition snapshots in vertical writing modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ capture.png
 
 # WPT testsuite results (generated at runtime)
 tests/wpt-results/
+tests/wpt-reftest-results/
 tests/wpt/checkout/
 
 # Octane benchmark suite (cloned at runtime); results are committed.

--- a/Broiler.Layout/Broiler.Layout.Tests/VerticalFlowWordListSyncTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/VerticalFlowWordListSyncTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using Broiler.Layout.Engine;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// The vertical-flow rotation decomposes a multi-glyph run into per-glyph cells stacked along the
+/// inline axis, and a word lives in two lists: <c>CssLineBox.Words</c> (what paint walks) and
+/// <c>CssBox.Words</c> (what <c>OffsetTop</c>/<c>OffsetLeft</c> walk). Replacing only the line's copy
+/// leaves the two describing different runs, and every later pass that translates a subtree then
+/// moves the run nobody paints while the painted glyphs stay put.
+/// </summary>
+/// <remarks>
+/// That is not hypothetical: <c>PerformLayout</c> runs the rotation and <em>then</em>
+/// <c>RunScrollSimulation</c>, which is exactly such a translation. A scrolled
+/// vertical-writing-mode page therefore painted its backgrounds at the scrolled offset and its text
+/// at the unscrolled one — the residual on WPT
+/// <c>css/css-view-transitions/massive-element-left-of-viewport-partially-onscreen</c>, whose
+/// reference scrolls a vertical-lr document to its far end: the green and blue bands moved and the
+/// Ahem glyphs stayed at the document origin.
+/// </remarks>
+public sealed class VerticalFlowWordListSyncTests
+{
+    private static readonly Uri BaseUrl = new("file:///vertical.html");
+
+    private const string Text = "ABCDEFGH";
+
+    /// <summary>A vertical-lr rotation root (no parent, so the rotation runs) holding one inline run.</summary>
+    private static CssBox VerticalRootWithRun()
+    {
+        var root = new CssBox(null, new HtmlTag("div", false, null), BaseUrl)
+        {
+            Display = "block",
+            Location = new PointF(0, 0),
+            Size = new SizeF(400, 200),
+            WritingMode = "vertical-lr",
+            LayoutEnvironment = new MeasuringLayoutEnvironment(),
+        };
+
+        var span = new CssBox(root, new HtmlTag("span", false, null), BaseUrl) { Display = "inline" };
+        span.Words.Add(new CssRectWord(span, Text, false, false));
+
+        return root;
+    }
+
+    private static List<CssBox> Tree(CssBox box)
+    {
+        var all = new List<CssBox> { box };
+        foreach (var child in box.Boxes)
+            all.AddRange(Tree(child));
+        return all;
+    }
+
+    /// <summary>Every word the line boxes would paint, in order.</summary>
+    private static List<CssRect> PaintedWords(CssBox root) =>
+        [.. Tree(root).SelectMany(b => b.LineBoxes).SelectMany(l => l.Words)];
+
+    [Fact]
+    public void EveryPaintedGlyphIsRegisteredOnItsOwnerBox()
+    {
+        var root = VerticalRootWithRun();
+        root.PerformLayout(root.LayoutEnvironment);
+
+        var painted = PaintedWords(root);
+        Assert.NotEmpty(painted);
+
+        // The run was decomposed, so this is genuinely exercising the substitution rather than
+        // passing because nothing was replaced.
+        Assert.True(painted.Count > 1, $"expected the {Text.Length}-glyph run to be decomposed, got {painted.Count} word(s)");
+
+        foreach (var word in painted)
+        {
+            Assert.NotNull(word.OwnerBox);
+            Assert.Contains(word, word.OwnerBox.Words);
+        }
+    }
+
+    [Fact]
+    public void APostRotationOffsetMovesThePaintedGlyphs()
+    {
+        var root = VerticalRootWithRun();
+        root.PerformLayout(root.LayoutEnvironment);
+
+        var painted = PaintedWords(root);
+        var before = painted.Select(w => (w.Left, w.Top)).ToList();
+
+        const double dx = 50;
+        const double dy = 7;
+        root.OffsetLeft(dx);
+        root.OffsetTop(dy);
+
+        // The same CssRect instances the line boxes hold must have moved — if the box kept a
+        // separate pre-rotation copy, these are untouched and the page paints text at the old place.
+        Assert.Equal(before.Count, painted.Count);
+        for (int i = 0; i < painted.Count; i++)
+        {
+            Assert.Equal(before[i].Left + dx, painted[i].Left, 3);
+            Assert.Equal(before[i].Top + dy, painted[i].Top, 3);
+        }
+    }
+
+    /// <summary>Measures a fixed 10px advance per character so a run has a width to divide into
+    /// per-glyph cells; the rotation skips a zero-width run's decomposition entirely.</summary>
+    private sealed class MeasuringLayoutEnvironment : Broiler.Layout.ILayoutEnvironment
+    {
+        private const double CharWidth = 10;
+        private static readonly Broiler.Graphics.ILayoutFont TheFont = new FakeFont();
+
+        public Broiler.Graphics.ILayoutFont GetFont(string family, double size, LayoutFontStyle style, string? fontFeatures = null) => TheFont;
+        public SizeF MeasureText(Broiler.Graphics.ILayoutFont font, string text) => new((float)(text.Length * CharWidth), 16);
+
+        public void MeasureText(Broiler.Graphics.ILayoutFont font, string text, double maxWidth, out int charFit, out double charFitWidth)
+        {
+            charFit = text.Length;
+            charFitWidth = text.Length * CharWidth;
+        }
+
+        public double GetWhitespaceWidth(Broiler.Graphics.ILayoutFont font) => CharWidth;
+        public Broiler.Layout.ImageIntrinsics GetImageIntrinsics(object imageHandle) => default;
+        public Broiler.Graphics.BColor ParseColor(string value) => default;
+        public void RequestRefresh(bool relayout) { }
+        public SizeF ViewportSize => new(1000, 1000);
+        public PointF RootLocation => PointF.Empty;
+        public SizeF ActualSize { get; set; }
+        public bool AvoidGeometryAntialias => false;
+        public SizeF PageSize => new(1000, 1000);
+        public int MarginTop => 0;
+        public void ReportLayoutError(string message, Exception? exception = null) { }
+        public bool AvoidAsyncImagesLoading => true;
+        public bool AvoidImagesLateLoading => true;
+        public Broiler.Layout.ILayoutImageLoader CreateImageLoader(Action<object?, RectangleF, bool> onComplete) => null!;
+        public string FormatListMarker(int number, string style) => string.Empty;
+    }
+
+    private sealed class FakeFont : Broiler.Graphics.ILayoutFont
+    {
+        public double Size => 16;
+        public double Height => 16;
+        public double UnderlineOffset => 0;
+        public double LeftPadding => 0;
+        public string? FontFeatures => null;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.WritingMode.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.WritingMode.cs
@@ -166,6 +166,20 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             box.Rectangles[k] = RotateRect(box.Rectangles[k], rootX, rootY, blockExtent, mirror, blockOffset);
 
         // --- Line boxes owned by this box: words + per-box rectangles ---
+        //
+        // A run decomposed into per-glyph cells below replaces the original CssRect in the LINE's
+        // word list, but a word lives in two lists: CssLineBox.Words (what paint walks) and
+        // CssBox.Words (what OffsetTop/OffsetLeft walk). Leaving the box's copy behind desynchronises
+        // them, and every post-rotation pass that translates a subtree then moves the run nobody
+        // paints while the glyphs that are painted stay put. RunScrollSimulation is exactly such a
+        // pass and runs after this one (PerformLayout calls the rotation, then the scroll post-pass),
+        // so a scrolled vertical-writing-mode page painted its backgrounds at the scrolled offset and
+        // its text at the unscrolled one — visible on WPT massive-element-left-of-viewport-
+        // partially-onscreen-ref, whose green/blue bands scrolled while the Ahem glyphs stayed at the
+        // document origin. Substituting the glyphs into the owner box's list keeps the two views of
+        // the same run in agreement.
+        Dictionary<CssBox, Dictionary<CssRect, List<CssRect>>>? decomposedByOwner = null;
+
         foreach (var line in box.LineBoxes)
         {
             var rotatedWords = new List<CssRect>(line.Words.Count);
@@ -198,6 +212,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 if (text != null && text.Length > 1 && !word.IsLineBreak)
                 {
                     double advance = word.Width / text.Length;
+                    var glyphs = new List<CssRect>(text.Length);
 
                     for (int i = 0; i < text.Length; i++)
                     {
@@ -209,7 +224,16 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                             Height = word.Height,
                         };
 
+                        glyphs.Add(glyph);
                         rotatedWords.Add(glyph);
+                    }
+
+                    if (word.OwnerBox is { } owner)
+                    {
+                        decomposedByOwner ??= [];
+                        if (!decomposedByOwner.TryGetValue(owner, out var map))
+                            decomposedByOwner[owner] = map = [];
+                        map[word] = glyphs;
                     }
                 }
                 else
@@ -227,6 +251,28 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
             foreach (var k in keys)
                 line.Rectangles[k] = RotateRect(line.Rectangles[k], rootX, rootY, blockExtent, mirror, blockOffset);
+        }
+
+        // Mirror the line-level substitution onto each owner box's own word list, in place, so the
+        // two stay the same run in the same order. A word not decomposed above (a single glyph, a
+        // line break) was rotated by mutation and is already shared by both lists.
+        if (decomposedByOwner is not null)
+        {
+            foreach (var (owner, map) in decomposedByOwner)
+            {
+                var rebuilt = new List<CssRect>(owner.Words.Count);
+
+                foreach (var existing in owner.Words)
+                {
+                    if (map.TryGetValue(existing, out var glyphs))
+                        rebuilt.AddRange(glyphs);
+                    else
+                        rebuilt.Add(existing);
+                }
+
+                owner.Words.Clear();
+                owner.Words.AddRange(rebuilt);
+            }
         }
 
         foreach (var child in box.Boxes)

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.ViewTransition.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.ViewTransition.cs
@@ -534,6 +534,63 @@ public sealed partial class DomBridge
         return false;
     }
 
+    /// <summary>The writing modes whose block flow is horizontal, so a box in one is laid out in a
+    /// logical frame and rotated into physical space.</summary>
+    private static bool IsVerticalWritingMode(string? writingMode) =>
+        writingMode?.Trim().ToLowerInvariant() is "vertical-rl" or "vertical-lr" or "sideways-rl" or "sideways-lr";
+
+    /// <summary>
+    /// Whether the live layout transposes <paramref name="element"/> — i.e. whether it lies inside a
+    /// vertical <em>rotation root</em> (a vertical-writing-mode box whose parent is not vertical),
+    /// reached without first crossing an out-of-flow box, which establishes its own untransposed
+    /// rotation context.
+    /// <para>
+    /// This deliberately mirrors <c>CssBox.WillBeVerticalTransposed</c> over the DOM rather than
+    /// asking a spec question, because it decides how the <em>snapshot</em> is built and a snapshot's
+    /// only job is to reproduce what the live layout painted. The engine's vertical flow is a
+    /// prototype that does not rotate out-of-flow boxes, so a <c>position: fixed</c> vertical element
+    /// nested in a vertical root is laid out untransposed; a snapshot of it that <em>is</em> transposed
+    /// would disagree with the very page it was captured from. Both halves are exercised by the WPT
+    /// <c>massive-element-*</c> family, which splits exactly along this line: the in-flow variants
+    /// (<c>-partially-onscreen</c> with a scroll) need the transposition, and the <c>position: fixed</c>
+    /// ones (<c>-offscreen</c>, <c>right-and-left-</c>) need its absence.
+    /// </para>
+    /// </summary>
+    private bool CapturedElementIsVerticallyTransposed(DomElement element)
+    {
+        for (DomNode? node = element; node is not null; node = node.ParentNode)
+        {
+            if (node is not DomElement ctx)
+                continue;
+
+            var style = UsedStyleForCapture(ctx);
+            var parent = ParentElementForCapture(ctx);
+            bool parentVertical = parent is not null
+                && IsVerticalWritingMode(UsedStyleForCapture(parent).GetValueOrDefault("writing-mode"));
+
+            if (IsVerticalWritingMode(style.GetValueOrDefault("writing-mode")) && !parentVertical)
+                return true;
+
+            var position = style.GetValueOrDefault("position");
+            if (string.Equals(position, "absolute", System.StringComparison.OrdinalIgnoreCase)
+                || string.Equals(position, "fixed", System.StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+
+        return false;
+    }
+
+    private static DomElement? ParentElementForCapture(DomElement element)
+    {
+        for (DomNode? node = element.ParentNode; node is not null; node = node.ParentNode)
+        {
+            if (node is DomElement parent)
+                return parent;
+        }
+
+        return null;
+    }
+
     /// <summary>
     /// Applies the author rules a running transition activates to the live DOM, so the "new" snapshot
     /// the pseudo tree captures reflects them. Two selector forms are handled (css-view-transitions-2):
@@ -807,8 +864,12 @@ public sealed partial class DomBridge
             // box, e.g. an absolutely-positioned child above the box (WPT
             // capture-with-offscreen-child-translated). Root and old-only/unknown captures keep the
             // clip (viewport / prior behaviour).
+            var capturedElement = capture.Name == rootName
+                ? DocumentElement
+                : elementByName.GetValueOrDefault(capture.Name);
+
             bool clipsContent = true;
-            if (capture.Name != rootName && elementByName.TryGetValue(capture.Name, out var capturedElement))
+            if (capture.Name != rootName && capturedElement is not null)
                 clipsContent = CapturedElementClipsContent(UsedStyleForCapture(capturedElement));
 
             var group = CreateStyledBox(BaseStyle(
@@ -836,26 +897,39 @@ public sealed partial class DomBridge
             // element's own paint (background, opacity, text) so an element's opacity composites over
             // the backdrop rather than over an opaque snapshot fill.
             //
-            // Each snapshot box also resets `writing-mode`, and the reason is structural rather than
-            // cosmetic. css-view-transitions-1 gives the pseudo tree the *captured element's*
-            // writing mode — which BuildViewTransitionSnapshotContent already bakes onto the content
-            // box — not the originating root's; the pseudo boxes are real <div>s under <html>, so
-            // without a reset they inherit `:root { writing-mode: vertical-lr }` as well. That is
-            // not merely redundant: Broiler rotates a vertical subtree from its *rotation root*,
-            // defined as a vertical box whose parent is not vertical, so an inherited vertical mode
-            // all the way down means the content box is never a root, WillBeVerticalTransposed
-            // reports false, and ResolvePhysicalSize maps block-size onto physical height
-            // un-swapped. `.middle { block-size: 39800px }` then became a 39800px-tall band instead
-            // of a 39800px-wide one — the whole of the massive-element-*-partially-onscreen failure.
+            // A snapshot box resets `writing-mode` when — and only when — the live layout transposes
+            // the element it captured, and the reason is structural rather than cosmetic.
+            // css-view-transitions-1 gives the pseudo tree the *captured element's* writing mode —
+            // which BuildViewTransitionSnapshotContent already bakes onto the content box — not the
+            // originating root's; the pseudo boxes are real <div>s under <html>, so without a reset
+            // they inherit `:root { writing-mode: vertical-lr }` as well. That is not merely
+            // redundant: Broiler rotates a vertical subtree from its *rotation root*, defined as a
+            // vertical box whose parent is not vertical, so an inherited vertical mode all the way
+            // down means the content box is never a root, WillBeVerticalTransposed reports false,
+            // and ResolvePhysicalSize maps block-size onto physical height un-swapped.
+            // `.middle { block-size: 39800px }` then became a 39800px-tall band instead of a
+            // 39800px-wide one — the whole of the massive-element-*-partially-onscreen failure.
+            //
+            // Resetting it *unconditionally* is the opposite error, and the same family catches it:
+            // the engine's vertical flow does not rotate out-of-flow boxes, so the `position: fixed`
+            // variants (-offscreen, right-and-left-) are laid out untransposed on the live page, and
+            // a transposed snapshot of them disagrees with the page it was captured from — measured
+            // as right-and-left-of-viewport-partially-onscreen falling from 100% to 2.9%. Mirroring
+            // the engine's own predicate keeps the snapshot honest in both directions.
+            //
             // An author `::view-transition-old(x) { writing-mode: … }` still wins: CreateStyledBox
             // layers the author declarations on top of BaseStyle. It is deliberately not in
             // PseudoBoxAuthorReset, which is skipped wholesale when the author paints a background.
+            var snapshotWritingMode = capturedElement is not null
+                && CapturedElementIsVerticallyTransposed(capturedElement)
+                    ? "horizontal-tb"
+                    : null;
+
             if (capture.HasOld)
             {
                 var scale = SnapshotScale(capture.OldWidth, groupW);
-                var oldBox = CreateStyledBox(BaseStyle(
-                    ("position", "absolute"), ("left", "0"), ("top", "0"),
-                    ("width", Px(capture.OldWidth * scale)), ("height", Px(capture.OldHeight * scale))),
+                var oldBox = CreateStyledBox(SnapshotBoxStyle(
+                    capture.OldWidth * scale, capture.OldHeight * scale, snapshotWritingMode),
                     LookupPseudo(pseudoRules, "old", capture));
                 AttachSnapshotPaint(
                     oldBox, capture.OldContent, capture.OldBackground,
@@ -866,9 +940,8 @@ public sealed partial class DomBridge
             if (capture.HasNew)
             {
                 var scale = SnapshotScale(capture.NewWidth, groupW);
-                var newBox = CreateStyledBox(BaseStyle(
-                    ("position", "absolute"), ("left", "0"), ("top", "0"),
-                    ("width", Px(capture.NewWidth * scale)), ("height", Px(capture.NewHeight * scale))),
+                var newBox = CreateStyledBox(SnapshotBoxStyle(
+                    capture.NewWidth * scale, capture.NewHeight * scale, snapshotWritingMode),
                     LookupPseudo(pseudoRules, "new", capture));
                 AttachSnapshotPaint(
                     newBox, capture.NewContent, capture.NewBackground,
@@ -914,6 +987,22 @@ public sealed partial class DomBridge
         }
 
         AppendBridgeChild(root, overlay);
+    }
+
+    /// <summary>The base style of a <c>::view-transition-old</c>/<c>-new</c> box: the captured rect's
+    /// size at the group's scale, plus the <c>writing-mode</c> reset when the captured element is one
+    /// the live layout transposes (<paramref name="writingMode"/> is null when it is not, leaving the
+    /// inherited mode alone).</summary>
+    private static Dictionary<string, string> SnapshotBoxStyle(double width, double height, string? writingMode)
+    {
+        var style = BaseStyle(
+            ("position", "absolute"), ("left", "0"), ("top", "0"),
+            ("width", Px(width)), ("height", Px(height)));
+
+        if (writingMode is not null)
+            style["writing-mode"] = writingMode;
+
+        return style;
     }
 
     private static Dictionary<string, string> BaseStyle(params (string Key, string Value)[] entries)
@@ -1044,23 +1133,48 @@ public sealed partial class DomBridge
 
         var clone = CloneSnapshotContentForRender(content);
 
-        if (scale is not 1 && capturedWidth > 0 && capturedHeight > 0)
+        if (capturedWidth > 0 && capturedHeight > 0)
         {
-            // The snapshot must grow from its top-left corner, but the paint walker applies every
-            // transform about the box's centre and does not read `transform-origin`. Composing a
-            // translate of half the growth ahead of the scale expresses a top-left-origin scale in
-            // terms of the centre-origin one it does implement: a point p maps to C + T·S·(p - C),
-            // so t = C(s - 1) puts the corner back at the origin. Without it the snapshot expands
-            // equally in all four directions and the group clips away everything above and left of
-            // its centre — which is exactly what this looked like: a 200x120 capture scaled 5.12x
-            // showed 612x368 of blue instead of filling the group.
-            var growthX = capturedWidth * (scale - 1) / 2;
-            var growthY = capturedHeight * (scale - 1) / 2;
             var style = InlineStyle(clone);
+
+            // Pin the content box to the captured pixel size instead of leaving it at the `100%`
+            // BuildViewTransitionSnapshotContent gives it. At a scale other than 1 that is what the
+            // summary above describes; at scale 1 the two are identical in a horizontal writing mode
+            // (100% of a box that is itself the captured size) — but NOT in a vertical one, and that
+            // is the reason this is unconditional.
+            //
+            // The content box carries the captured element's `writing-mode`, and the snapshot box
+            // above it resets to `horizontal-tb`, so the content box is a vertical *rotation root*:
+            // laid out in a logical frame whose frame-width is its inline size and frame-height its
+            // block size, then transposed into physical space. ResolvePhysicalSize feeds that frame
+            // from the swapped physical properties (frame-width ← CSS height, frame-height ← CSS
+            // width) precisely so an authored physical width/height survives the rotation. A
+            // percentage does not survive it: the swapped property still resolves against the
+            // containing block's same-named axis, so `height: 100%` became frame-width = the box's
+            // *width*, and the rotation handed back a content box 100x40000 where the capture was
+            // 40000x100. Measured on WPT massive-element-{left,right}-of-viewport-partially-onscreen,
+            // whose `:root { writing-mode: vertical-lr }` is the single line separating them from the
+            // -on-top-of-/below- variants that already passed: the 100px band rendered as a
+            // viewport-tall slab. A length resolves on the axis it is authored for, so it is the only
+            // form that crosses the rotation intact.
             style["width"] = Px(capturedWidth);
             style["height"] = Px(capturedHeight);
-            style["transform"] =
-                $"translate({Px(growthX)}, {Px(growthY)}) scale({scale.ToString("0.#####", System.Globalization.CultureInfo.InvariantCulture)})";
+
+            if (scale is not 1)
+            {
+                // The snapshot must grow from its top-left corner, but the paint walker applies every
+                // transform about the box's centre and does not read `transform-origin`. Composing a
+                // translate of half the growth ahead of the scale expresses a top-left-origin scale in
+                // terms of the centre-origin one it does implement: a point p maps to C + T·S·(p - C),
+                // so t = C(s - 1) puts the corner back at the origin. Without it the snapshot expands
+                // equally in all four directions and the group clips away everything above and left of
+                // its centre — which is exactly what this looked like: a 200x120 capture scaled 5.12x
+                // showed 612x368 of blue instead of filling the group.
+                var growthX = capturedWidth * (scale - 1) / 2;
+                var growthY = capturedHeight * (scale - 1) / 2;
+                style["transform"] =
+                    $"translate({Px(growthX)}, {Px(growthY)}) scale({scale.ToString("0.#####", System.Globalization.CultureInfo.InvariantCulture)})";
+            }
         }
 
         AppendBridgeChild(box, clone);


### PR DESCRIPTION
## Summary

Fixes view transition snapshot rendering for elements in vertical writing modes, particularly when they are positioned out-of-flow (e.g., `position: fixed`). The snapshot pseudo-tree now correctly mirrors the live layout's transposition behavior, and vertical-flow word decomposition is kept in sync across both the line-level and box-level word lists.

## Key Changes

- **Vertical writing mode detection**: Added `IsVerticalWritingMode()` helper to identify vertical writing modes (`vertical-rl`, `vertical-lr`, `sideways-rl`, `sideways-lr`).

- **Transposition predicate**: Implemented `CapturedElementIsVerticallyTransposed()` to determine whether the live layout transposes a captured element. This mirrors the engine's own `CssBox.WillBeVerticalTransposed` logic over the DOM, accounting for rotation roots and out-of-flow positioning. Out-of-flow boxes (absolute/fixed) establish their own untransposed rotation context, matching the engine's behavior.

- **Conditional writing-mode reset**: The snapshot box now resets `writing-mode` to `horizontal-tb` only when the captured element is transposed by the live layout. This prevents double-transposition of in-flow elements while preserving correct layout for out-of-flow elements that are not transposed.

- **Content box sizing**: Pinned snapshot content boxes to explicit pixel dimensions (captured size) instead of `100%`. This is critical in vertical writing modes where percentages resolve against the wrong axis after rotation, causing dimensions to swap incorrectly.

- **Word list synchronization**: Fixed vertical-flow rotation to keep decomposed per-glyph cells synchronized between `CssLineBox.Words` (used by paint) and `CssBox.Words` (used by offset queries). Previously, only the line's word list was updated, causing post-rotation translations (like scroll simulation) to move backgrounds but not text.

- **Test coverage**: Added `VerticalFlowWordListSyncTests` to verify that painted glyphs remain registered on their owner boxes and move correctly when the tree is offset after rotation.

## Implementation Details

The snapshot writing-mode reset is now conditional: it only applies when `CapturedElementIsVerticallyTransposed()` returns true. This matches the engine's own transposition logic, which does not rotate out-of-flow boxes. The predicate walks up the DOM tree checking for vertical rotation roots (vertical writing mode with non-vertical parent) while stopping at out-of-flow positioning boundaries.

The vertical-flow word decomposition fix maintains a map of decomposed runs during rotation and applies the same substitution to each owner box's word list after the line-level rotation completes. This ensures that subsequent passes like scroll simulation move the same word instances that paint walks, keeping text and backgrounds in sync.

The content box sizing change applies pixel dimensions unconditionally when the captured size is non-zero, with the transform (scale + translate) applied only when scale ≠ 1. This ensures percentages don't cause dimension swaps in vertical rotation contexts.

https://claude.ai/code/session_01UMkc8d27ZLVoo4gtLyqKTp