### PR TITLE
Generate anonymous table parents for misparented table boxes

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/AnonymousTableBoxes.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/AnonymousTableBoxes.cs
@@ -1,0 +1,244 @@
+using Broiler.CSS;
+
+
+namespace Broiler.Layout.Engine;
+
+/// <summary>
+/// CSS 2.1 §17.2.1 <em>generate missing parents</em>: wraps table-internal boxes whose
+/// parent is not the table box they require in the anonymous <c>table-row</c> /
+/// <c>table</c> boxes the spec calls for.
+/// <para>
+/// <see cref="CssLayoutEngineTable"/> already implements the other half of §17.2.1 —
+/// <em>generate missing children</em> — but it only ever runs on a box that is already
+/// a table, so it could not see the mirror-image case: a <c>table-row</c>,
+/// <c>table-row-group</c> or <c>table-cell</c> sitting directly inside a block or an
+/// inline. Such a box is neither <c>IsBlock</c> nor <c>IsInline</c>, so block layout
+/// walked straight past it and it was **dropped** — it never laid out, never painted,
+/// and contributed no height. WPT's <c>css/CSS2/tables/table-anonymous-objects-*</c>
+/// family is built almost entirely out of that pattern (its green "should be no red"
+/// layer is spans carrying nothing but <c>display: table-row-group</c>), which is why
+/// those tests rendered a bare red table with the green overlay missing.
+/// </para>
+/// <para>
+/// The pass runs over the whole box tree after the other box fix-ups, before the
+/// inline/block corrections, so the anonymous table it inserts takes part in the
+/// inline↔block splitting as the block-level (or inline-level) box it is.
+/// </para>
+/// </summary>
+internal static class AnonymousTableBoxes
+{
+    /// <summary>
+    /// Applies §17.2.1's missing-parent generation to <paramref name="root"/> and every
+    /// box beneath it. Safe to call repeatedly: a tree that already has the required
+    /// parents is left untouched.
+    /// </summary>
+    /// <param name="root">Root of the box tree to fix up.</param>
+    /// <param name="baseUrl">Base URL carried onto the anonymous boxes.</param>
+    internal static void Generate(CssBox root, Uri baseUrl)
+    {
+        if (root == null)
+            return;
+
+        GenerateMissingParents(root, baseUrl);
+    }
+
+    private static void GenerateMissingParents(CssBox box, Uri baseUrl)
+    {
+        // A proper table parent's interior is CssLayoutEngineTable's job: it generates the
+        // missing *children* there (anonymous rows for stray cells in a table or a row
+        // group, anonymous cells for stray content in a row). Leaving those alone keeps
+        // this pass strictly additive — it only reaches boxes that are dropped today.
+        //
+        // A flex or grid container is skipped for a different reason: CSS Display 3 §2.7
+        // blockifies its children, so a `display: table-cell` flex item computes to `block`
+        // and there is no table-internal box left for §17.2.1 to find a parent for. Wrapping
+        // one would put an anonymous table between the container and its item — the item
+        // would stop being a flex/grid item at all, which is a worse answer than the
+        // blockification Broiler has yet to implement, and it would land in css-grid and
+        // css-flexbox, the two largest failing areas.
+        if (!IsProperTableParent(box.Display) && !IsBlockifyingContainer(box.Display))
+        {
+            WrapCellRunsInAnonymousRows(box, baseUrl);
+            WrapProperTableChildRunsInAnonymousTables(box, baseUrl);
+        }
+
+        // Indexed, and deliberately not over a copy: this pass runs on every layout, so a
+        // defensive snapshot per box would be an allocation per box. The recursion below only
+        // ever rewrites the *child's* own Boxes list, never this one — and the two passes
+        // above have already finished rewriting it — so it is stable for the walk. The
+        // anonymous boxes they inserted are walked too; their children are well parented by
+        // construction, so those calls terminate immediately.
+        for (int i = 0; i < box.Boxes.Count; i++)
+            GenerateMissingParents(box.Boxes[i], baseUrl);
+    }
+
+    /// <summary>
+    /// §17.2.1 missing parents, rule 1: a <c>table-cell</c> whose parent is not a
+    /// <c>table-row</c> is wrapped — together with its consecutive <c>table-cell</c>
+    /// siblings — in one anonymous <c>table-row</c>.
+    /// </summary>
+    private static void WrapCellRunsInAnonymousRows(CssBox box, Uri baseUrl) =>
+        WrapRuns(
+            box,
+            baseUrl,
+            isRunMember: static child => child.Display == CssConstants.TableCell && !IsBlockified(child),
+            wrapperDisplay: CssConstants.TableRow);
+
+    /// <summary>
+    /// §17.2.1 missing parents, rule 2: a misparented proper table child is wrapped —
+    /// together with its consecutive proper-table-child siblings — in one anonymous
+    /// <c>table</c>, or <c>inline-table</c> when the parent is an inline box.
+    /// <para>
+    /// Every proper table child is misparented here by construction: this only runs on a
+    /// box that is not a proper table parent, and each of §17.2.1's misparenting clauses
+    /// ("a row group … is misparented if its parent is neither a 'table' box nor an
+    /// 'inline-table' box", and likewise for rows and columns) holds for exactly those
+    /// parents.
+    /// </para>
+    /// </summary>
+    private static void WrapProperTableChildRunsInAnonymousTables(CssBox box, Uri baseUrl) =>
+        WrapRuns(
+            box,
+            baseUrl,
+            isRunMember: static child => IsProperTableChild(child.Display) && !IsBlockified(child),
+            wrapperDisplay: box.Display == CssConstants.Inline
+                ? CssConstants.InlineTable
+                : CssConstants.Table);
+
+    /// <summary>
+    /// Replaces each maximal run of children matching <paramref name="isRunMember"/> with a
+    /// single anonymous box of <paramref name="wrapperDisplay"/> holding that run, keeping
+    /// document order for everything else.
+    /// </summary>
+    private static void WrapRuns(
+        CssBox box,
+        Uri baseUrl,
+        Func<CssBox, bool> isRunMember,
+        string wrapperDisplay)
+    {
+        bool anyRunMember = false;
+        foreach (var child in box.Boxes)
+        {
+            if (isRunMember(child))
+            {
+                anyRunMember = true;
+                break;
+            }
+        }
+
+        if (!anyRunMember)
+            return;
+
+        var children = new List<CssBox>(box.Boxes);
+        box.Boxes.Clear();
+
+        // Pending run members, plus any whitespace-only boxes seen since the last run
+        // member. §17.2.1: "anonymous inline boxes which contain only white space and are
+        // between two immediate siblings each of which is a table-non-root element" are
+        // treated as display:none — so whitespace *inside* a run is dropped, while
+        // whitespace that turns out to be trailing is put back outside the wrapper.
+        List<CssBox> pending = [];
+        List<CssBox> pendingWhitespace = [];
+
+        void Flush()
+        {
+            if (pending.Count > 0)
+            {
+                // The CssBox(parent, tag) constructor appends to box.Boxes, so creating the
+                // wrapper here places it exactly where the run began.
+                var wrapper = CssBoxHelper.CreateBox(box, baseUrl);
+                wrapper.Display = wrapperDisplay;
+
+                foreach (var member in pending)
+                    member.ParentBox = wrapper;
+
+                pending.Clear();
+            }
+
+            // Whitespace after the final run member was never between two run members, so
+            // it is ordinary whitespace and keeps its place after the wrapper.
+            foreach (var whitespace in pendingWhitespace)
+                box.Boxes.Add(whitespace);
+
+            pendingWhitespace.Clear();
+        }
+
+        foreach (var child in children)
+        {
+            if (isRunMember(child))
+            {
+                // Whitespace between two run members is dropped by simply not re-adding it.
+                pendingWhitespace.Clear();
+                pending.Add(child);
+            }
+            else if (pending.Count > 0 && IsIgnorableWhitespace(child))
+            {
+                pendingWhitespace.Add(child);
+            }
+            else
+            {
+                Flush();
+                box.Boxes.Add(child);
+            }
+        }
+
+        Flush();
+    }
+
+    /// <summary>
+    /// Whether the box is an anonymous run of white space that §17.2.1 treats as
+    /// <c>display:none</c> when it falls between two table-internal siblings. A
+    /// <c>pre</c>-family <c>white-space</c> makes the run meaningful, so it is excluded.
+    /// </summary>
+    private static bool IsIgnorableWhitespace(CssBox box) =>
+        box.Boxes.Count == 0
+        && !box.Text.IsEmpty
+        && box.Text.Span.IsWhiteSpace()
+        && box.WhiteSpace != CssConstants.Pre
+        && box.WhiteSpace != CssConstants.PreWrap
+        && box.WhiteSpace != "pre-line"
+        && box.WhiteSpace != "break-spaces";
+
+    /// <summary>
+    /// Whether an out-of-flow or floated box, whose computed <c>display</c> CSS Display 3
+    /// §2.7 blockifies, so it is no longer a proper table child and neither joins a run nor
+    /// starts one. It splits a run for the same reason.
+    /// </summary>
+    private static bool IsBlockified(CssBox box) =>
+        box.Float != CssConstants.None
+        || box.Position is CssConstants.Absolute or CssConstants.Fixed;
+
+    /// <summary>
+    /// Whether a box with this display blockifies its children (CSS Display 3 §2.7), leaving
+    /// no table-internal child for §17.2.1 to act on.
+    /// </summary>
+    private static bool IsBlockifyingContainer(string display) =>
+        display is "flex" or "inline-flex" or "grid" or "inline-grid";
+
+    /// <summary>
+    /// Whether a box with this display may legally parent table-internal boxes, i.e.
+    /// whether <see cref="CssLayoutEngineTable"/> owns its interior.
+    /// </summary>
+    private static bool IsProperTableParent(string display) =>
+        display is CssConstants.Table
+            or CssConstants.InlineTable
+            or CssConstants.TableRow
+            or CssConstants.TableRowGroup
+            or CssConstants.TableHeaderGroup
+            or CssConstants.TableFooterGroup
+            or CssConstants.TableColumnGroup;
+
+    /// <summary>
+    /// The "proper table child" set of CSS 2.1 §17.2.1 — the displays that require a
+    /// <c>table</c> or <c>inline-table</c> ancestry. <c>table-cell</c> is deliberately
+    /// absent: it needs a <c>table-row</c> parent, which rule 1 supplies first.
+    /// </summary>
+    private static bool IsProperTableChild(string display) =>
+        display is CssConstants.TableRow
+            or CssConstants.TableRowGroup
+            or CssConstants.TableHeaderGroup
+            or CssConstants.TableFooterGroup
+            or CssConstants.TableColumn
+            or CssConstants.TableColumnGroup
+            or CssConstants.TableCaption;
+}

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -505,6 +505,50 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
 
 ## Layout
 
+### A table box outside a table painted nothing at all
+
+- **Tests:** the `css/CSS2/tables/table-anonymous-objects-*` family — **103 of its
+  members** were in the failure manifest for
+  [#1688](https://github.com/Broiler-Platform/Broiler/issues/1688), the single largest
+  numbered family in `css/CSS2`. On the family's own `rel=match` references: 46 → **48
+  passing**, 60 tests improved against 7 regressed.
+- **Owner:** `Broiler.Layout` for the pass, `Broiler.HTML` for the one line that calls
+  it (patch: *"parse: generate the anonymous table a misparented table box needs"*).
+- **CSS 2.1 §17.2.1 has two halves, and only one was implemented.**
+  `CssLayoutEngineTable` generates the missing *children* — an anonymous row for a
+  stray cell in a table or a row group, an anonymous cell for stray content in a row.
+  But it only ever runs on a box that already *is* a table, so nothing generated the
+  missing *parents*: a `table-row`, row group or `table-cell` sitting directly inside a
+  block or an inline. Such a box is neither `IsBlock` nor `IsInline`, so block layout
+  walked straight past it — it never laid out, never painted, and contributed no
+  height. `Broiler.Layout/Engine/AnonymousTableBoxes.cs` is the landed pass;
+  `AnonymousTableBoxParentTests` is the landed check.
+- **The classification split was one bug, not two.** The family's failures were
+  divided between `MissingContent` and `ReferenceOverlayExposed`, which reads like two
+  causes. It is one: every test in it stacks a green layer over a red one, and the
+  green layer is spans carrying nothing but `display: table-row-group`. Whichever layer
+  the test put on top decided which bucket the same absence landed in.
+- **Four tests moved from passing to failing, and that is the fix working.** In those
+  the *red* layer is the one built from bare table boxes, so they had been passing
+  because the content under test rendered nothing at all — passing by omission. They
+  now render, and show the residual geometry gap between a generated anonymous table
+  and the real `<table>` it is compared against.
+- **A flex or grid container is deliberately excluded.** CSS Display 3 §2.7 blockifies
+  those children, so a `display: table-cell` flex item computes to `block` and §17.2.1
+  has nothing to find a parent for. Wrapping one would insert an anonymous table
+  *between* the container and its item, so the item would stop being a flex/grid item
+  altogether — a worse answer than the blockification Broiler still owes, and one that
+  would land squarely in `css-grid` and `css-flexbox`, the two largest failing areas.
+  An out-of-flow or floated box is excluded for the same reason, and it splits a run
+  rather than joining one. (The exclusion is not hypothetical bookkeeping: an earlier
+  build without it changed how `display: table-cell` flex items sized.)
+- **A bare container cannot judge this family by pixels.** Broiler resolves no
+  `font-family` there — `monospace`, `serif` and a named family all render in one
+  sans face — so every golden comparison against Chromium sits at a ~96 % floor from
+  glyph shapes alone, well under the 99 % pass threshold, before any engine
+  difference is counted. The `rel=match` reftest suite renders both sides with
+  Broiler and is unaffected, which is why the numbers above are quoted from it.
+
 ### An out-of-flow first child propagated its top margin into its parent
 
 - **Tests:** `css/CSS2/margin-padding-clear/margin-006` … `-009`, failing → **passing**.

--- a/patches/0003-generate-anonymous-table-parents.patch
+++ b/patches/0003-generate-anonymous-table-parents.patch
@@ -1,0 +1,52 @@
+From 3905e7db6805ba1536501bb2a0c026db51164e48 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 16 Aug 2026 15:41:37 +0000
+Subject: [PATCH] parse: generate the anonymous table a misparented table box
+ needs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CSS2.1 §17.2.1 has two halves. CssLayoutEngineTable implements "generate
+missing children" — anonymous rows for stray cells in a table or a row group,
+anonymous cells for stray content in a row — but it only ever runs on a box
+that is already a table, so nothing implemented "generate missing parents": a
+table-row, row group or table-cell sitting directly inside a block or an
+inline. Such a box is neither IsBlock nor IsInline, so block layout walked
+straight past it and it was dropped — never laid out, never painted, and
+contributing no height.
+
+Call the new Broiler.Layout.Engine.AnonymousTableBoxes pass from the box
+fix-ups, before the inline/block corrections so the generated table takes part
+in them as the block-level box it is.
+
+WPT css/CSS2/tables/table-anonymous-objects-* is built almost entirely out of
+that pattern: its green "there should be no red" layer is spans carrying
+nothing but display:table-row-group, so the layer meant to cover the red one
+painted nothing at all. 103 of the family were failing.
+---
+ Source/Broiler.HTML.Orchestration/Parse/DomParser.cs | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+index a58e6d7..cf4c054 100644
+--- a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
++++ b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+@@ -125,6 +125,14 @@ internal sealed class DomParser
+             CorrectProgressBoxes(root, baseUrl);
+             CorrectSelectMultipleBoxes(root, baseUrl);
+ 
++            // CSS2.1 §17.2.1 'generate missing parents': a table-row / row group /
++            // table-cell sitting outside the table box it requires is neither block nor
++            // inline, so block layout walked past it and it was dropped. Wrap it in the
++            // anonymous table (and row) the spec calls for before the inline/block
++            // corrections below, so the generated table takes part in them as the
++            // block-level box it is.
++            Broiler.Layout.Engine.AnonymousTableBoxes.Generate(root, baseUrl);
++
+             bool followingBlock = true;
+             CorrectLineBreaksBlocks(root, ref followingBlock);
+             CorrectInlineBoxesParent(root, baseUrl);
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # Submodule patches waiting to be applied
 
-**Two patches are waiting on a maintainer.** See the index below.
+**Three patches are waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -48,6 +48,7 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD && echo "live on CI"
 | --- | --- | --- |
 | `0001` | `Broiler.JS` | Reject a `for` head that carries only one semicolon |
 | `0002` | `Broiler.HTML` | Cap the image fetch timeout, as the stylesheet fetch already is |
+| `0003` | `Broiler.HTML` | parse: generate the anonymous table a misparented table box needs |
 
 The eight patches that held `0001`–`0008` before these two are all upstream and all
 reachable through the pinned pointers, so their files are gone and the numbering has
@@ -165,6 +166,43 @@ still re-fetched on the next layout pass; with a 5-second cap that is now an
 annoyance rather than a lost test, but it is the other half of the defect.
 
 **When it lands upstream:** bump the pointer and delete this patch.
+
+### `0003` — a table box outside a table painted nothing at all
+
+CSS 2.1 §17.2.1 has two halves, and only one of them was implemented.
+`CssLayoutEngineTable` generates the missing **children** — an anonymous row for a
+stray cell in a table or a row group, an anonymous cell for stray content in a row.
+But it only ever runs on a box that *is* a table, so nothing generated the missing
+**parents**: a `table-row`, row group or `table-cell` sitting directly inside a block
+or an inline. Such a box is neither `IsBlock` nor `IsInline`, so block layout walked
+straight past it — it never laid out, never painted, and contributed no height.
+
+**Where it came from.** WPT's `css/CSS2/tables/table-anonymous-objects-*` family, 103
+of whose members were failing. Each is a "there should be no red" test that stacks a
+green layer over a red one; the green layer is built out of spans carrying nothing but
+`display: table-row-group`, so it painted nothing and the red layer underneath showed
+through in full. That is also why the family's failures were split between
+`MissingContent` and `ReferenceOverlayExposed` — the same absence, classified by which
+of the two layers the test happened to put on top.
+
+**Only the one-line call is in this patch.** The pass itself —
+`Broiler.Layout.Engine.AnonymousTableBoxes` — is a main-repo file, so the patch is the
+single line that reaches it from `DomParser`'s box fix-ups. It is placed before the
+inline/block corrections so the generated table takes part in them as the block-level
+box it is.
+
+**Measured** on the family's own `rel=match` references (font-neutral, unlike a golden
+comparison in a bare container): 46 → 48 passing, 60 tests improved against 7
+regressed. Four tests moved from passing to failing and are worth understanding rather
+than treating as a regression — in those the *red* layer is the one built from bare
+table boxes, so they had been passing because the content under test rendered nothing
+at all. Passing by omission; they now render and show the residual geometry gap.
+
+**Why it is listed in `scripts/apply-pending-wpt-patches.sh`.** Without this line the
+main-repo half never runs, so nothing about the fix reaches a WPT run.
+
+**When it lands upstream:** bump the pointer, drop the entry from
+`scripts/apply-pending-wpt-patches.sh`, and delete this patch.
 
 ## A stale entry in the apply script is not inert
 

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -167,8 +167,19 @@ set -euo pipefail
 # The patch matters for the real browser, where there is no such handler and an unreachable <img>
 # still stalls the render — so it is a correctness fix to land upstream, not something a WPT run
 # needs applied on top of the pointer.
+#
+# The anonymous-table-parent patch (Broiler.HTML, "parse: generate the anonymous table a
+# misparented table box needs") IS listed, and it is the plainest case for listing there is:
+# without it a `display: table-row` / `table-row-group` / `table-cell` box with no table around
+# it is neither IsBlock nor IsInline, so block layout walks past it and it paints *nothing*.
+# The pass it calls lives in the main repo (Broiler.Layout.Engine.AnonymousTableBoxes) and its
+# behaviour is unit-tested there (AnonymousTableBoxParentTests); this one line is what reaches
+# it from the box fix-ups, so without the patch applied the main-repo half never runs and every
+# css/CSS2/tables/table-anonymous-objects-* test still renders its bare red table with the green
+# layer missing.
 PENDING_PATCHES=(
   "Broiler.JS|patches/0001-reject-one-semicolon-for-head.patch"
+  "Broiler.HTML|patches/0003-generate-anonymous-table-parents.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/Broiler.Wpt.Tests/AnonymousTableBoxParentTests.cs
+++ b/src/Broiler.Wpt.Tests/AnonymousTableBoxParentTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// CSS 2.1 §17.2.1 <em>generate missing parents</em> — the mirror image of
+/// <see cref="TableRowGroupAnonymousRowTests"/>, which covers the <em>missing children</em>
+/// half of the same section.
+///
+/// <para><c>CssLayoutEngineTable</c> only ever runs on a box that is already a table, so it
+/// could not see a <c>table-row</c>, row group or <c>table-cell</c> sitting outside the table
+/// box it requires. Such a box is neither <c>IsBlock</c> nor <c>IsInline</c>, so block layout
+/// walked straight past it: it never laid out, never painted, and contributed no height.</para>
+///
+/// <para>Regression for WPT's <c>css/CSS2/tables/table-anonymous-objects-*</c> family (103 of
+/// its members were failing), whose green "there should be no red" layer is built almost
+/// entirely out of bare <c>display: table-row-group</c> / <c>table-row</c> spans with no table
+/// around them — so the layer that is supposed to cover the red one painted nothing at all.</para>
+/// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
+public class AnonymousTableBoxParentTests
+{
+    private const int Size = 200;
+
+    private static BBitmap Render(string html)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-anontableparent-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "t.html");
+            File.WriteAllText(file, html);
+            return new WptTestRunner(Size, Size).RenderHtmlFileBitmapPublic(file, dir);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    private static void AssertPixel(BBitmap bmp, int x, int y, byte r, byte g, byte b, string because)
+    {
+        var actual = bmp.GetPixel(x, y);
+        Assert.True(actual.R == r && actual.G == g && actual.B == b,
+            $"({x},{y}) was rgb({actual.R},{actual.G},{actual.B}), expected rgb({r},{g},{b}) — {because}");
+    }
+
+    [Fact]
+    public void RowWithoutATable_IsWrappedAndPainted()
+    {
+        // A table-row whose parent is a plain block. §17.2.1 generates an anonymous table
+        // around it; without one the row — and both its cells — were dropped entirely.
+        const string Html = """
+<!DOCTYPE html><meta charset="utf-8"><style>body{margin:0}</style>
+<div>
+  <div style="display:table-row">
+    <div style="display:table-cell; width:60px; height:60px; background:hotpink;"></div>
+    <div style="display:table-cell; width:60px; height:60px; background:yellow;"></div>
+  </div>
+</div>
+""";
+        using var bmp = Render(Html);
+
+        AssertPixel(bmp, 30, 30, 255, 105, 180, "the misparented row's first cell did not paint");
+        AssertPixel(bmp, 90, 30, 255, 255, 0, "the misparented row's second cell did not paint");
+    }
+
+    [Fact]
+    public void RowGroupWithoutATable_IsWrappedAndPainted()
+    {
+        // The shape WPT's table-anonymous-objects family is built from: bare row groups
+        // holding bare cells, with no table anywhere above them.
+        const string Html = """
+<!DOCTYPE html><meta charset="utf-8"><style>body{margin:0}</style>
+<div>
+  <div style="display:table-row-group">
+    <div style="display:table-cell; width:60px; height:60px; background:hotpink;"></div>
+  </div>
+</div>
+""";
+        using var bmp = Render(Html);
+
+        AssertPixel(bmp, 30, 30, 255, 105, 180, "the misparented row group's cell did not paint");
+    }
+
+    [Fact]
+    public void CellWithoutARow_IsWrappedAndPainted()
+    {
+        // A table-cell needs a table-row parent (rule 1) before the generated row needs a
+        // table (rule 2) — both wrappers have to appear for this to paint.
+        const string Html = """
+<!DOCTYPE html><meta charset="utf-8"><style>body{margin:0}</style>
+<div>
+  <div style="display:table-cell; width:60px; height:60px; background:hotpink;"></div>
+</div>
+""";
+        using var bmp = Render(Html);
+
+        AssertPixel(bmp, 30, 30, 255, 105, 180, "the misparented cell did not paint");
+    }
+
+    [Fact]
+    public void ConsecutiveRowGroups_ShareOneAnonymousTable()
+    {
+        // §17.2.1 wraps a *run* of consecutive proper table children in ONE anonymous table,
+        // so two row groups form a single two-row table and their cells share a column — the
+        // second group's cell must line up under the first's, not start its own table.
+        // The whitespace between them is "treated as if it were display:none", so it must not
+        // split the run either.
+        const string Html = """
+<!DOCTYPE html><meta charset="utf-8"><style>body{margin:0}</style>
+<div>
+  <div style="display:table-row-group">
+    <div style="display:table-cell; width:120px; height:50px; background:hotpink;"></div>
+  </div>
+  <div style="display:table-row-group">
+    <div style="display:table-cell; width:20px; height:50px; background:yellow;"></div>
+  </div>
+</div>
+""";
+        using var bmp = Render(Html);
+
+        AssertPixel(bmp, 60, 25, 255, 105, 180, "the first row group's cell did not paint");
+
+        // One shared table means one shared column, so the narrow second cell is stretched to
+        // the column width the first cell established. Two separate tables would leave this
+        // point on the page background.
+        AssertPixel(bmp, 100, 75, 255, 255, 0,
+            "the second row group started its own table instead of joining the first's");
+    }
+
+    [Fact]
+    public void RowInsideARowGroup_IsNotRewrapped()
+    {
+        // Well-parented content must be left exactly as it is: a row inside a row group inside
+        // a table is already correct, and generating anything around it would be a regression.
+        const string Html = """
+<!DOCTYPE html><meta charset="utf-8"><style>body{margin:0}</style>
+<div style="display:table">
+  <div style="display:table-row-group">
+    <div style="display:table-row">
+      <div style="display:table-cell; width:60px; height:50px; background:hotpink;"></div>
+    </div>
+    <div style="display:table-row">
+      <div style="display:table-cell; width:60px; height:50px; background:yellow;"></div>
+    </div>
+  </div>
+</div>
+""";
+        using var bmp = Render(Html);
+
+        AssertPixel(bmp, 30, 25, 255, 105, 180, "the first row moved");
+        AssertPixel(bmp, 30, 75, 255, 255, 0, "the second row moved");
+    }
+
+    [Fact]
+    public void NonTableContentAroundARun_KeepsItsPlace()
+    {
+        // The generated table replaces only the run itself; siblings before and after it stay
+        // in document order around it, and the anonymous table is block-level so it sits on
+        // its own lines between them.
+        const string Html = """
+<!DOCTYPE html><meta charset="utf-8"><style>body{margin:0}</style>
+<div>
+  <div style="width:120px; height:40px; background:blue;"></div>
+  <div style="display:table-row">
+    <div style="display:table-cell; width:120px; height:40px; background:hotpink;"></div>
+  </div>
+  <div style="width:120px; height:40px; background:yellow;"></div>
+</div>
+""";
+        using var bmp = Render(Html);
+
+        AssertPixel(bmp, 60, 20, 0, 0, 255, "the block before the run moved");
+        AssertPixel(bmp, 60, 60, 255, 105, 180, "the wrapped row did not land between its siblings");
+        AssertPixel(bmp, 60, 100, 255, 255, 0, "the block after the run moved");
+    }
+}


### PR DESCRIPTION
Implements the missing-parents half of CSS 2.1 §17.2.1, which wraps table-internal boxes (`table-row`, `table-row-group`, `table-cell`) that lack the required table ancestry in anonymous `table` or `inline-table` boxes.

## Summary

A `table-row`, row group, or `table-cell` sitting directly inside a block or inline container is neither `IsBlock` nor `IsInline`, so block layout walked past it entirely — it never laid out, never painted, and contributed no height. This fix adds `AnonymousTableBoxes`, a layout engine pass that generates the required anonymous parents before inline/block corrections run, so the generated table takes part in them as the block-level box it is.

## Changes

- **`Broiler.Layout/Engine/AnonymousTableBoxes.cs`** (new): Implements §17.2.1's missing-parent generation. The pass:
  - Wraps consecutive `table-cell` boxes lacking a `table-row` parent in an anonymous row (rule 1)
  - Wraps consecutive proper table children (`table-row`, row groups, columns, caption) lacking a table parent in an anonymous `table` or `inline-table` (rule 2)
  - Preserves document order for non-table content
  - Treats whitespace between table-internal siblings as `display:none` per spec
  - Skips well-parented content, flex/grid containers, and blockified boxes (floated or out-of-flow)

- **`AnonymousTableBoxParentTests.cs`** (new): Unit tests covering:
  - Misparented rows, row groups, and cells rendering correctly
  - Consecutive row groups sharing a single anonymous table (column alignment)
  - Well-parented content left untouched
  - Non-table siblings maintaining document order around the generated wrapper

- **`DomParser.cs`**: Single-line call to `AnonymousTableBoxes.Generate()` in the box fix-ups, before inline/block corrections

- **Documentation**: Updated `wpt-rendering-gaps-fixed.md` and `patches/README.md` with detailed analysis of the fix and its WPT impact (103 tests in the `table-anonymous-objects-*` family were failing; 46 → 48 passing on `rel=match` references)

## Implementation Notes

- The pass is deliberately placed before inline/block corrections so the generated anonymous table participates in them
- Flex and grid containers are excluded because CSS Display 3 §2.7 blockifies their children, making an anonymous table wrapper incorrect
- Out-of-flow and floated boxes are excluded for the same blockification reason and split runs rather than joining them
- The pass is safe to call repeatedly; well-parented trees are left untouched

https://claude.ai/code/session_016SvX4PzZwJmyF5RXbmY7v6