### PR TITLE
Block off-corpus network fetches in all loaders, not just paint

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/OfflineSubresourcesTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/OfflineSubresourcesTests.cs
@@ -1,0 +1,47 @@
+using Broiler.Layout.Engine;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// Pins the two properties <see cref="OfflineSubresources"/> is only useful if it has: that it
+/// decides nothing until a host installs a policy, and that when one is installed the engine asks
+/// it about the URL rather than about anything of its own.
+/// </summary>
+/// <remarks>
+/// The first is the load-bearing one. Every host but the conformance runner leaves this unset, and
+/// the load sites that consult it (<c>CssBoxImage</c>, <c>CssBox.Background</c>) sit on the render
+/// path of a real browser — so "unset means the engine loads exactly what it always did" is the
+/// property that keeps this lever from being a rendering change.
+/// </remarks>
+public sealed class OfflineSubresourcesTests : IDisposable
+{
+    private readonly Func<string?, bool>? _previous = OfflineSubresources.FetchPolicy;
+
+    public void Dispose() => OfflineSubresources.FetchPolicy = _previous;
+
+    [Theory]
+    [InlineData("http://example.com/x.png")]
+    [InlineData("https://software.hixie.ch/delayed-file?pause=8")]
+    [InlineData("support/pattern.png")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void DeniesNothingWithNoPolicyInstalled(string? url)
+    {
+        OfflineSubresources.FetchPolicy = null;
+        Assert.False(OfflineSubresources.Denies(url), url ?? "(null)");
+    }
+
+    [Fact]
+    public void DeniesExactlyWhatThePolicyDeclines()
+    {
+        OfflineSubresources.FetchPolicy = url => url != "http://example.com/x.png";
+
+        Assert.True(OfflineSubresources.Denies("http://example.com/x.png"));
+        Assert.False(OfflineSubresources.Denies("http://example.com/y.png"));
+
+        // The URL is what is asked about, nulls included: a box with no src still reaches the
+        // load site, and a policy that wants to answer for it must be the one that decides.
+        OfflineSubresources.FetchPolicy = url => url is not null;
+        Assert.True(OfflineSubresources.Denies(null));
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Broiler.Layout.csproj
+++ b/Broiler.Layout/Broiler.Layout/Broiler.Layout.csproj
@@ -32,7 +32,8 @@
          item #12), the same way the tile-scaling mode sets TileParallelReplay's budget. -->
     <InternalsVisibleTo Include="Broiler.Render.Stage.Benchmarks" />
     <!-- The WPT runner sets NativeAnchorPlacement.Enabled around only the final
-         render during the Phase 5 native anchor-placement cutover (P5.8d.2b). -->
+         render during the Phase 5 native anchor-placement cutover (P5.8d.2b), and
+         installs OfflineSubresources.FetchPolicy for the whole run. -->
     <InternalsVisibleTo Include="Broiler.Wpt" />
     <!-- The headless layout view (the script bridge's ILayoutView) enables
          NativeAnchorPlacement around its geometry layout so the live read model

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Background.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Background.cs
@@ -60,8 +60,13 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 deferred is null ? OnImageLoadComplete : deferred.OnCompleted);
 
             _backgroundImageLoadHandlers.Add(imageLoadHandler);
-            LoadImageWithAnimationPolicy(
-                () => imageLoadHandler.LoadImage(src, HtmlTag?.Attributes, BaseUrl));
+
+            // Declined by the host (see OfflineSubresources): the layer paints nothing, which is
+            // where an unreachable background image ends up anyway — after the wait, not instead of
+            // it. The handler is still recorded so the layer indices stay aligned.
+            if (!OfflineSubresources.Denies(src))
+                LoadImageWithAnimationPolicy(
+                    () => imageLoadHandler.LoadImage(src, HtmlTag?.Attributes, BaseUrl));
         }
     }
 

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxImage.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxImage.cs
@@ -77,8 +77,12 @@ internal sealed class CssBoxImage : CssBox
 
         if (Content != null && Content != CssConstants.Normal)
         {
-            LoadImageWithAnimationPolicy(
-                () => _imageLoadHandler.LoadImage(Content, HtmlTag?.Attributes, BaseUrl));
+            // Declined by the host (see OfflineSubresources): not starting the load leaves this box
+            // in exactly the state a load the host marked handled leaves it in — the handler is
+            // built, nothing completes, and the image is the missing one it was always going to be.
+            if (!OfflineSubresources.Denies(Content))
+                LoadImageWithAnimationPolicy(
+                    () => _imageLoadHandler.LoadImage(Content, HtmlTag?.Attributes, BaseUrl));
             return;
         }
 
@@ -98,8 +102,9 @@ internal sealed class CssBoxImage : CssBox
         // <object data="..."> fallback: use 'data' attribute when 'src' is absent
         if (string.IsNullOrEmpty(src))
             src = GetAttribute("data");
-        LoadImageWithAnimationPolicy(
-            () => _imageLoadHandler.LoadImage(src, HtmlTag?.Attributes, BaseUrl));
+        if (!OfflineSubresources.Denies(src))
+            LoadImageWithAnimationPolicy(
+                () => _imageLoadHandler.LoadImage(src, HtmlTag?.Attributes, BaseUrl));
     }
 
     /// <inheritdoc/>

--- a/Broiler.Layout/Broiler.Layout/Engine/OfflineSubresources.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/OfflineSubresources.cs
@@ -1,0 +1,46 @@
+namespace Broiler.Layout.Engine;
+
+/// <summary>
+/// The host's answer to "may this sub-resource URL be fetched over the network at all?", consulted
+/// by the loaders before they start a request. Unset by default, so a renderer with a network
+/// behaves exactly as it always has.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A sub-resource fetch on the render path is synchronous — <c>HtmlRender</c> sets
+/// <c>AvoidAsyncImagesLoading</c>, so the loader blocks the layout thread — and a timeout bounds an
+/// unreachable host without making it free. A host that already knows a URL cannot resolve to
+/// anything pays that bound per URL to be told what it knew: the conformance runner's whole corpus
+/// is a directory on disk, and a test naming three unroutable hosts spends fifteen seconds of a
+/// thirty-second budget waiting for three failures. Answering here costs none of it, and ends where
+/// the fetch was going to end anyway — with the resource not loaded, which is what those tests are
+/// checking the engine does with such a URL.
+/// </para>
+/// <para>
+/// It is a <em>predicate over the URL</em> rather than a flag because the distinction the host draws
+/// is not "network or no network": the WPT runner serves a corpus host from a checkout and declines
+/// only what is off-corpus, and only the host can tell those apart. The engine holds no knowledge of
+/// any of it.
+/// </para>
+/// <para>
+/// A plain static, not <c>[ThreadStatic]</c>, unlike the engine's render levers
+/// (<see cref="NativeZoom.Enabled"/>, <see cref="DocumentRoot.Current"/>): those scope a render, this
+/// scopes a <em>process</em> — a host either has a network to reach or it does not. It has to be
+/// process-wide to work at all, because the image prefetch consults it from
+/// <c>Parallel.For</c> workers, where a thread-local set on the layout thread would be invisible.
+/// </para>
+/// </remarks>
+internal static class OfflineSubresources
+{
+    /// <summary>
+    /// Returns <see langword="false"/> for a URL this process must not fetch, or
+    /// <see langword="null"/> (the default) to allow every one.
+    /// </summary>
+    public static System.Func<string?, bool>? FetchPolicy;
+
+    /// <summary>
+    /// True when <paramref name="url"/> must not be fetched. False whenever no policy is installed,
+    /// which is every host but the conformance runner.
+    /// </summary>
+    public static bool Denies(string? url) => FetchPolicy is { } policy && !policy(url);
+}

--- a/docs/wpt-timeout-causes.md
+++ b/docs/wpt-timeout-causes.md
@@ -37,14 +37,52 @@ Their regression guards are `MulticolCheckLayoutTimeoutTests` and
 | 5 | `html/webappapis/scripting/processing-model-2` | `for(;)` parsed as `for(;;)` — a SyntaxError became an infinite loop. `Broiler.JS`, shipped as a patch. |
 | 28 | `encoding/legacy-mb-*` | Not encoding. Stylesheet discovery re-walked the whole tree once per element resolved. |
 | 3 | `conformance-checkers/…/table/integrity` | The tail of the same discovery quadratic. |
-| 1 | `conformance-checkers/…/img/src-isvalid` | Synchronous image fetch on the layout thread with no `HttpClient` timeout — .NET's 100 s default, per unroutable host, per layout pass. |
+| 1 | `conformance-checkers/…/img/src-isvalid` | Synchronous image fetch on the layout thread with no `HttpClient` timeout — .NET's 100 s default, per unroutable host, per layout pass. Took **two** attempts; see below. |
+| 1 | `css/CSS2/cascade-import/cascade-import-009` | Not the cascade. Three `<link>`s to a CGI that pauses by design, fetched once per pass — and a run has three fetchers, only one of which had a policy. See below. |
 | 1 | `css/css-break/…/special-elements-crash` | Not fragmentation. `elementFromPoint` built and tore down a full geometry snapshot per element visited. |
 | 1 | `css/css-fonts/variations/font-opentype-collections` | Not the TTC parser. The runner's synchronous `requestAnimationFrame` stub had no re-entrancy cap, so a non-converging rAF loop recursed to CLR stack exhaustion. |
 | 20 | `css/css-overflow` | Not overflow. A geometry snapshot was torn down at the end of every read pass, so a `scrollTop` write — which clamps against four extents — laid the whole document out four times. See below. |
 
 Guards: `StyleSheetDiscoveryCacheTests`, `HitTestAndRafBudgetTimeoutTests`,
-`ScrollWriteGeometryTimeoutTests`, `RetainedLayoutSnapshotTests`, and the
-`for`-head theories inside the `Broiler.JS` patch.
+`ScrollWriteGeometryTimeoutTests`, `RetainedLayoutSnapshotTests`,
+`WptResourceHandlersTests`, `OfflineSubresourcesTests`, and the `for`-head
+theories inside the `Broiler.JS` patch.
+
+### The two network timeouts — a policy on one of three fetchers
+
+Both are the same finding, and the first of them is worth reading as a
+**correction**: `src-isvalid` was fixed once, the fix was right, and the test
+timed out again in the next run.
+
+That fix marked an off-corpus `<img>` handled on the container the runner paints
+with, so the engine never reached the downloader. It was verified against all 88
+of the test's sources. What it missed is that **a run lays each document out more
+than once**:
+
+| pass | container / loader | had a policy? |
+| --- | --- | --- |
+| script bridge geometry (`DomBridge` → `HeadlessLayoutView`) | an `HtmlContainer` of its own | no |
+| bridge stylesheet loader, incl. the speculative preload scan | `ResourceLoader`, on a worker | no |
+| the render | the container the runner attaches handlers to | yes |
+
+So the guarded pass was the *last* one. The geometry pass fetched all 31
+off-corpus hosts of `src-isvalid` at the uncapped 100 s default, and finished the
+budget before the render it was feeding began. `cascade-import-009` is the same
+absence read through stylesheets: three `<link>`s to `software.hixie.ch`'s
+`delayed-file` CGI, which pauses 2, 5 and 8 s *by design*, fetched once per pass —
+about 24 s of a 30 s budget.
+
+The fix is one policy asked at every fetch rather than a handler on one
+container: `Broiler.Layout.Engine.OfflineSubresources` (a host-set predicate over
+the URL, unset and therefore inert for a renderer that has a network) consulted at
+the image load sites, and `ResourceLoader.NetworkFetchPolicy` on the bridge's own.
+`cascade-import-009` went 30.7 s → 2.3 s, which is this container's process
+start-up and nothing else.
+
+**What to take from it:** "the runner does not fetch X" is a claim about a
+*container*, and the runner has more than one. Before trusting one, check which
+pass you measured — a `Environment.StackTrace` at the fetch names the caller in
+one run and would have shown this immediately.
 
 ### `css/css-overflow` — how the 20 were fixed
 

--- a/patches/0004-decline-off-corpus-stylesheet-fetch.patch
+++ b/patches/0004-decline-off-corpus-stylesheet-fetch.patch
@@ -1,0 +1,52 @@
+From 2f46265d62dcf2611ce909ee08ba93d87fb0ebd9 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 16 Aug 2026 18:45:26 +0000
+Subject: [PATCH] load: let the host decline a stylesheet fetch it knows cannot
+ succeed
+
+The five-second cap on the external-stylesheet client bounds an unreachable
+<link>; it does not make one free. A host that already knows a URL cannot
+resolve to anything still pays that bound per sheet to be told what it knew,
+and pays it once per container the document is laid out in.
+
+css/CSS2/cascade-import/cascade-import-009.xht is the case that shows it: three
+<link>s to a delayed-file CGI that pauses 2, 5 and 8 seconds by design, on a
+personal server no conformance corpus serves. A run lays the document out twice
+- once headlessly for the script bridge's geometry reads, once to paint it - so
+it spent about twenty-four seconds of a thirty-second budget in this one method
+and was reported as a timeout rather than run.
+
+Consult Broiler.Layout's OfflineSubresources before the fetch. It is unset for
+a renderer that has a network, so this is inert there; the conformance runner
+installs a policy that declines only hosts outside its checkout, and the engine
+holds no knowledge of which those are. A declined sheet returns empty, which is
+where an unreachable one was going to end up anyway.
+---
+ .../Handlers/StylesheetLoadHandler.cs                 | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/Source/Broiler.HTML.Orchestration/Handlers/StylesheetLoadHandler.cs b/Source/Broiler.HTML.Orchestration/Handlers/StylesheetLoadHandler.cs
+index 8060d2f..db6a7fd 100644
+--- a/Source/Broiler.HTML.Orchestration/Handlers/StylesheetLoadHandler.cs
++++ b/Source/Broiler.HTML.Orchestration/Handlers/StylesheetLoadHandler.cs
+@@ -79,6 +79,17 @@ internal sealed class StylesheetLoadHandler : IStylesheetLoader
+         }
+         else
+         {
++            // The host declines URLs it knows cannot resolve to anything (Broiler.Layout's
++            // OfflineSubresources; unset for a renderer with a network, so this is inert there).
++            // The cap below bounds an unreachable sheet, it does not make one free: a conformance
++            // run whose corpus is a directory on disk still spends five seconds per off-corpus
++            // <link> being told what it already knew, and a document with three of them —
++            // css/CSS2/cascade-import/cascade-import-009.xht links a CGI that pauses 2, 5 and 8
++            // seconds by design — spends half a thirty-second budget in this one method, once per
++            // container the document is laid out in.
++            if (Broiler.Layout.Engine.OfflineSubresources.Denies(src))
++                return string.Empty;
++
+             return LoadStylesheetFromUri(uri);
+         }
+     }
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # Submodule patches waiting to be applied
 
-**Three patches are waiting on a maintainer.** See the index below.
+**Four patches are waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -49,6 +49,7 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD && echo "live on CI"
 | `0001` | `Broiler.JS` | Reject a `for` head that carries only one semicolon |
 | `0002` | `Broiler.HTML` | Cap the image fetch timeout, as the stylesheet fetch already is |
 | `0003` | `Broiler.HTML` | parse: generate the anonymous table a misparented table box needs |
+| `0004` | `Broiler.HTML` | load: let the host decline a stylesheet fetch it knows cannot succeed |
 
 The eight patches that held `0001`–`0008` before these two are all upstream and all
 reachable through the pinned pointers, so their files are gone and the numbering has
@@ -153,13 +154,26 @@ renders in ~5 s in this container only because the agent proxy answers those
 instantly, which is precisely why the timeout looked unreproducible locally.
 
 **Why it is NOT listed in `scripts/apply-pending-wpt-patches.sh`.** The main-repo
-half already covers the WPT run: `WptTestRunner`'s image handler now marks an
-off-corpus http(s) `<img>` handled, so the runner never reaches the downloader
-and cannot hit the default this caps. A sandboxed conformance run should not
-touch the network at all, which is the more correct behaviour independently. The
-patch matters for the **real browser**, where there is no such handler and an
-unreachable `<img>` still stalls the render — so it is a correctness fix to land
-upstream, not something a WPT run needs applied on top of the pointer.
+half already covers the WPT run: no `<img>` in a run reaches the downloader with
+an off-corpus http(s) URL, so the default this caps cannot be hit here. A
+sandboxed conformance run should not touch the network at all, which is the more
+correct behaviour independently. The patch matters for the **real browser**,
+where no such policy is installed and an unreachable `<img>` still stalls the
+render — so it is a correctness fix to land upstream, not something a WPT run
+needs applied on top of the pointer.
+
+**That claim was wrong once, and the correction is worth more than the claim.**
+It used to rest on `WptTestRunner`'s image handler marking an off-corpus `<img>`
+handled — which is true of the container the runner *paints* with, and only of
+it. A run lays each document out **twice**: the script bridge lays it out
+headlessly to answer geometry reads, in a container of its own that no handler
+was ever attached to, and that pass fetched all 31 off-corpus hosts of
+`src-isvalid.html` at the uncapped 100-second default, before the guarded render
+had started. The test timed out again on 2026-08-16 with the handler in place,
+which is what showed it. `Broiler.Layout.Engine.OfflineSubresources` now declines
+the load in the engine, at `CssBoxImage`'s and `CssBox.Background`'s load sites,
+so the policy holds for every container rather than one — and the entry can stay
+off the list for the reason originally given.
 
 **Not fixed here:** the missing negative cache. A URL that already failed is
 still re-fetched on the next layout pass; with a 5-second cap that is now an
@@ -200,6 +214,45 @@ at all. Passing by omission; they now render and show the residual geometry gap.
 
 **Why it is listed in `scripts/apply-pending-wpt-patches.sh`.** Without this line the
 main-repo half never runs, so nothing about the fix reaches a WPT run.
+
+**When it lands upstream:** bump the pointer, drop the entry from
+`scripts/apply-pending-wpt-patches.sh`, and delete this patch.
+
+### `0004` — the run had three fetchers and a policy on one of them
+
+A timeout cap bounds an unreachable host; it does not make one free. The external
+stylesheet client is capped at five seconds, and
+`css/CSS2/cascade-import/cascade-import-009.xht` links three sheets to a `delayed-file`
+CGI on a personal server that pauses 2, 5 and 8 seconds by design — so the cap is what
+each of them costs, every time the document is laid out.
+
+**And a run lays each document out more than once.** The script bridge lays it out
+headlessly to answer the geometry reads scripts make (`DomBridge` → `HeadlessLayoutView`),
+the runner lays it out again to paint it, and the bridge fetches external sheets through
+a loader of its own besides — whose *speculative preload scan* puts them on the wire from
+a worker before the parse has even started. Only the paint container had the runner's
+handlers on it. So the same three unreachable sheets were fetched three times over, about
+twenty-four seconds of a thirty-second budget, and the test was reported as a timeout
+rather than run. The same absence is what kept
+`conformance-checkers/html/elements/img/src-isvalid.html` timing out after its own fix had
+landed — see `0002` above, which records the wrong reason it was thought to be covered.
+
+**Only the one-line consult is in this patch.** The policy —
+`Broiler.Layout.Engine.OfflineSubresources`, a host-set predicate over the URL, unset and
+therefore inert for a renderer that has a network — is a main-repo type, as are the image
+load sites (`CssBoxImage`, `CssBox.Background`) and the bridge's own loader. A `<link>` is
+the one sub-resource whose load starts in the submodule (`DomParser` →
+`StylesheetLoadHandler`), which is why this line exists at all.
+
+**Measured** on `cascade-import-009.xht`: 30.7 s → 14.4 s with the main-repo half alone,
+→ 2.3 s with this line as well (2.2 s is the process's own start-up, so that is the whole
+of it). The main-repo half is therefore what stops the timeout; this patch buys back the
+rest of the budget.
+
+**The main repo builds and runs correctly without it.** It names nothing new in
+`Broiler.HTML` — the dependency points the other way, at a main-repo type — so a workflow
+that builds `src/Broiler.Wpt` without applying patches (the WPT Reftests one does exactly
+that) compiles and behaves as it did, only slower on the documents this speeds up.
 
 **When it lands upstream:** bump the pointer, drop the entry from
 `scripts/apply-pending-wpt-patches.sh`, and delete this patch.

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -158,15 +158,32 @@ set -euo pipefail
 # 2.5 minutes of a shard's budget spent waiting on loops that cannot end.
 #
 # 0002 (Broiler.HTML, cap the image fetch timeout) is deliberately NOT listed, even though it
-# fixes a timeout. Its main-repo half already covers the WPT run: WptTestRunner's image handler
-# marks an off-corpus http(s) <img> handled, so the runner never reaches the downloader and the
-# 100-second default it caps cannot be hit here. (Worth recording, because it is the obvious next
-# suspicion and it is wrong: the handler decides from Uri.TryCreate, and of the 88 sources in
-# conformance-checkers/html/elements/img/src-isvalid.html only two fail to parse — `http💩//:foo`
-# and `💩http://foo` — and neither names http(s), so nothing exotic in that file slips past it.)
-# The patch matters for the real browser, where there is no such handler and an unreachable <img>
-# still stalls the render — so it is a correctness fix to land upstream, not something a WPT run
-# needs applied on top of the pointer.
+# fixes a timeout — but the reason recorded here was wrong for one run, and the correction is worth
+# keeping. It said the main-repo half already covered the WPT run: WptTestRunner's image handler
+# marks an off-corpus http(s) <img> handled, so the runner never reaches the downloader. That is
+# true of the container the runner *paints* with, and only of it. A run lays each document out
+# twice — the script bridge lays it out headlessly to answer geometry reads, in a container of its
+# own that no handler was ever attached to — and that pass fetched all 31 off-corpus hosts of
+# conformance-checkers/html/elements/img/src-isvalid.html at the uncapped 100-second default. The
+# test timed out again on 2026-08-16 with the handler in place, which is what showed it.
+# Broiler.Layout's OfflineSubresources now declines those loads in the engine, for every container
+# rather than one, so the claim holds as stated: no <img> in a run reaches the downloader with an
+# off-corpus http(s) URL, and the default this patch caps cannot be hit here. The patch still
+# matters for the real browser, where no such policy is installed and an unreachable <img> stalls
+# the render — a correctness fix to land upstream, not something a WPT run needs on top of the
+# pointer.
+#
+# The off-corpus stylesheet patch (Broiler.HTML, "load: let the host decline a stylesheet fetch it
+# knows cannot succeed") IS listed, and it is the other half of the same finding. Images are
+# reachable from the main repo — the load starts in Broiler.Layout's CssBoxImage — but a <link> is
+# loaded from DomParser through StylesheetLoadHandler, both submodule files, so the geometry pass's
+# sheets cannot be declined without this one line. Without it a run still fetches every off-corpus
+# <link> once, at five seconds each: css/CSS2/cascade-import/cascade-import-009.xht (three <link>s
+# to a CGI that pauses 2, 5 and 8 seconds by design) renders in 14 s instead of 2 s. That is under
+# the 30-second budget — the main-repo half alone already stops it timing out — so this patch buys
+# the rest of the budget back rather than the test, and the main repo builds and runs correctly
+# whether or not it is applied: it names nothing new in the submodule, and the type the patch calls
+# is main-repo.
 #
 # The anonymous-table-parent patch (Broiler.HTML, "parse: generate the anonymous table a
 # misparented table box needs") IS listed, and it is the plainest case for listing there is:
@@ -180,6 +197,7 @@ set -euo pipefail
 PENDING_PATCHES=(
   "Broiler.JS|patches/0001-reject-one-semicolon-for-head.patch"
   "Broiler.HTML|patches/0003-generate-anonymous-table-parents.patch"
+  "Broiler.HTML|patches/0004-decline-off-corpus-stylesheet-fetch.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/Broiler.HtmlBridge.Dom/Runtime/ResourceLoader.cs
+++ b/src/Broiler.HtmlBridge.Dom/Runtime/ResourceLoader.cs
@@ -26,6 +26,25 @@ internal sealed class ResourceLoader
     private static readonly HttpClient SharedClient = new() { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
 
     /// <summary>
+    /// Host policy on which absolute URLs may be fetched over the network at all, or
+    /// <see langword="null"/> (the default) to permit every one — what a browser does. The engine
+    /// side of the same question is <c>Broiler.Layout.Engine.OfflineSubresources</c>; a host that
+    /// sets one normally sets both, since a document's sheets are requested from here and its
+    /// images from there.
+    /// </summary>
+    /// <remarks>
+    /// The timeout above bounds an unreachable host; it does not make one free. A host that knows
+    /// in advance that a URL cannot resolve to anything — the conformance runner, whose whole
+    /// corpus is a directory on disk — pays five seconds per such URL to be told what it already
+    /// knew, and pays it inside a per-test budget of thirty. Declining here reports the resource as
+    /// not loaded, which is where the fetch was going to end anyway.
+    /// </remarks>
+    internal static Func<string?, bool>? NetworkFetchPolicy;
+
+    private static bool MayFetchOverNetwork(string url) =>
+        NetworkFetchPolicy is null || NetworkFetchPolicy(url);
+
+    /// <summary>
     /// Optional local base directory for resolving relative sub-resource URLs to files. When set,
     /// relative URLs are checked against this directory before an HTTP fetch is attempted.
     /// </summary>
@@ -70,6 +89,14 @@ internal sealed class ResourceLoader
             if (uri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase) ||
                 uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
             {
+                // Declined by the host: reported as not loaded, and traced as such, so it is
+                // indistinguishable from the failed fetch it stands in for except in what it cost.
+                if (!MayFetchOverNetwork(url))
+                {
+                    attempt.Completed(null);
+                    return null;
+                }
+
                 var content = GetStringAsync(url).ConfigureAwait(false).GetAwaiter().GetResult();
                 attempt.Completed(content);
                 return content;
@@ -110,7 +137,11 @@ internal sealed class ResourceLoader
         if (urls.Count < minimumToOverlap)
             return;
 
-        Prefetcher().Prefetch(urls.Where(url => Uri.TryCreate(url, UriKind.Absolute, out _)));
+        // A URL the host will not let the consume path fetch must not be speculated on either: the
+        // prefetch is the same request, issued earlier and on a worker, so leaving it unfiltered
+        // would keep the whole cost the policy exists to remove — and pay it before the parse.
+        Prefetcher().Prefetch(urls.Where(url =>
+            Uri.TryCreate(url, UriKind.Absolute, out _) && MayFetchOverNetwork(url)));
     }
 
     /// <summary>

--- a/src/Broiler.Wpt.Tests/WptResourceHandlersTests.cs
+++ b/src/Broiler.Wpt.Tests/WptResourceHandlersTests.cs
@@ -1,0 +1,120 @@
+using System.IO;
+using Broiler.HTML.Core.Entities;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="WptResourceHandlers"/> — the run's sub-resource policy.
+/// </summary>
+/// <remarks>
+/// These pin the decisions, not the plumbing: that an off-corpus host is answered rather than
+/// fetched, on <em>both</em> resource kinds, and that everything the corpus can serve is left
+/// alone. The plumbing they cannot reach — that the policy is attached to the geometry container
+/// and to the bridge's loader as well as to the render — is what the 2026-08-16 timeouts were, and
+/// it is covered by <see cref="WptResourceHandlers.Attach"/>'s single call site rather than here.
+/// </remarks>
+public sealed class WptResourceHandlersTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string? _previousRoot;
+
+    public WptResourceHandlersTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "broiler-wpt-res-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _previousRoot = WptResourceHandlers.Root;
+    }
+
+    public void Dispose()
+    {
+        WptResourceHandlers.Root = _previousRoot;
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private static HtmlStylesheetLoadEventArgs Stylesheet(string src) =>
+        (HtmlStylesheetLoadEventArgs)Activator.CreateInstance(
+            typeof(HtmlStylesheetLoadEventArgs),
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+            binder: null,
+            args: [src, new Dictionary<string, string>()],
+            culture: null)!;
+
+    [Theory]
+    // The three hrefs of css/CSS2/cascade-import/cascade-import-009.xht: a CGI on a personal server
+    // that pauses 2, 5 and 8 seconds by design. Fetching them is 15 s of a 30 s budget, twice over
+    // (the geometry pass lays the document out before the render does), which is the whole timeout.
+    [InlineData("http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=2")]
+    [InlineData("http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=5")]
+    [InlineData("http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=8")]
+    [InlineData("https://example.com/theme.css")]
+    public void Stylesheet_AnswersOffCorpusHostsInsteadOfFetching(string href)
+    {
+        var args = Stylesheet(href);
+        WptResourceHandlers.Stylesheet(_tempDir)(null, args);
+
+        // Non-empty is the load-bearing half: StylesheetLoadHandler reads an empty SetStyleSheet as
+        // "the host supplied nothing" and fetches Src itself, so an empty string would be no guard
+        // at all. And it must not have been rewritten to a path either — there is no such file.
+        Assert.Equal(WptResourceHandlers.OffCorpusStylesheet, args.SetStyleSheet);
+        Assert.False(string.IsNullOrEmpty(args.SetStyleSheet));
+        Assert.Null(args.SetSrc);
+    }
+
+    [Fact]
+    public void Stylesheet_ServesARootRelativeHrefFromTheCheckout()
+    {
+        var onDisk = Path.Combine(_tempDir, "style.css");
+        File.WriteAllText(onDisk, "p { color: green; }");
+
+        var args = Stylesheet("/style.css");
+        WptResourceHandlers.Stylesheet(_tempDir)(null, args);
+
+        Assert.Equal(onDisk, args.SetSrc);
+        Assert.Null(args.SetStyleSheet);
+    }
+
+    [Theory]
+    // Nothing that names no host, or names one the corpus serves, may be suppressed: a relative
+    // href is a file next to the test, and a WPT host resolves to the same checkout.
+    [InlineData("support/base.css")]
+    [InlineData("data:text/css,p{color:green}")]
+    [InlineData("http://web-platform.test:8000/css/support/base.css")]
+    public void Stylesheet_LeavesEverythingTheRunCanServeAlone(string href)
+    {
+        var args = Stylesheet(href);
+        WptResourceHandlers.Stylesheet(_tempDir)(null, args);
+
+        Assert.Null(args.SetStyleSheet);
+        Assert.Null(args.SetSrc);
+    }
+
+    [Fact]
+    public void Install_RegistersThePolicyWithBothLoadersNoContainerEventReaches()
+    {
+        // The module initializer has already run — Install is idempotent, and calling it again is
+        // how this states that it is the thing that registers them.
+        WptResourceHandlers.Install();
+
+        // The engine's (images in every container, and stylesheets once Broiler.HTML carries the
+        // line that consults it) and the script bridge's own (external sheets and the preload scan).
+        var engine = WptResourceHandlers.RegisteredEnginePolicy;
+        var bridge = Broiler.HtmlBridge.Dom.Runtime.ResourceLoader.NetworkFetchPolicy;
+        Assert.NotNull(engine);
+        Assert.NotNull(bridge);
+
+        foreach (var policy in new[] { engine!, bridge! })
+        {
+            WptResourceHandlers.Root = _tempDir;
+            Assert.False(policy("http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=8"));
+            Assert.True(policy("http://web-platform.test:8000/css/support/base.css"));
+            Assert.True(policy("file:///tmp/base.css"));
+            Assert.True(policy("support/pattern.png"));
+
+            // Outside a rooted run — a host embedding this assembly for something other than a
+            // conformance sweep — the policy must permit everything, exactly as no policy would.
+            WptResourceHandlers.Root = null;
+            Assert.True(policy("http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=8"));
+        }
+    }
+
+}

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -11708,8 +11708,8 @@ div {{ width: 256px; height: 768px; }}
     [InlineData("http://192.0x00A80001")]
     [InlineData("http://[2001::1]")]
     [InlineData("http://[2001::1]:80/x.png")]
-    public void IsOffCorpusNetworkImage_FlagsRemoteHosts(string src) =>
-        Assert.True(WptTestRunner.IsOffCorpusNetworkImage(src), src);
+    public void IsOffCorpusNetworkResource_FlagsRemoteHosts(string src) =>
+        Assert.True(WptTestRunner.IsOffCorpusNetworkResource(src), src);
 
     [Theory]
     // Never suppress something the run can actually serve or that names no host at all: the
@@ -11721,17 +11721,17 @@ div {{ width: 256px; height: 768px; }}
     [InlineData("file:///tmp/x.png")]
     [InlineData("")]
     [InlineData(null)]
-    public void IsOffCorpusNetworkImage_LeavesLocalAndNonNetworkSourcesAlone(string? src) =>
-        Assert.False(WptTestRunner.IsOffCorpusNetworkImage(src), src ?? "(null)");
+    public void IsOffCorpusNetworkResource_LeavesLocalAndNonNetworkSourcesAlone(string? src) =>
+        Assert.False(WptTestRunner.IsOffCorpusNetworkResource(src), src ?? "(null)");
 
     [Fact]
-    public void IsOffCorpusNetworkImage_LeavesCorpusServedHostsAlone()
+    public void IsOffCorpusNetworkResource_LeavesCorpusServedHostsAlone()
     {
         // A `.sub` template's URLs are absolute on a WPT host once substituted, and WPT serves
         // every one of those from the same checkout — so they are files, not fetches.
         foreach (var host in WptSubstitution.ServedHosts.Take(8))
         {
-            Assert.False(WptTestRunner.IsOffCorpusNetworkImage($"http://{host}:8000/images/blue.png"),
+            Assert.False(WptTestRunner.IsOffCorpusNetworkResource($"http://{host}:8000/images/blue.png"),
                 $"corpus-served host {host} must not be treated as a network fetch");
         }
     }

--- a/src/Broiler.Wpt/HeadlessLayoutViewRegistration.cs
+++ b/src/Broiler.Wpt/HeadlessLayoutViewRegistration.cs
@@ -8,11 +8,22 @@ namespace Broiler.Wpt;
 /// Phase 1 (HtmlBridge project-graph repair) composition wiring: registers the
 /// renderer-backed <see cref="HeadlessLayoutView"/> as the bridge's
 /// <see cref="DomBridge.LayoutViewFactory"/> when this host assembly loads, so element
-/// geometry resolves through the real layout engine. Idempotent (<c>??=</c>).
+/// geometry resolves through the real layout engine, and registers the run's sub-resource
+/// policy with the loaders that view — and the bridge itself — fetch through. Idempotent.
 /// </summary>
+/// <remarks>
+/// The two belong together: the geometry view is a real layout of the real document, so it loads
+/// what the document names, in a container of its own that the render's handlers never see. Until
+/// the policy was registered here, that pass — and the bridge's preload scan behind it — were the
+/// parts of a run that still went to the network, and a document naming an unroutable host spent
+/// the per-test budget there before the guarded render began. See <see cref="WptResourceHandlers"/>.
+/// </remarks>
 internal static class HeadlessLayoutViewRegistration
 {
     [ModuleInitializer]
-    internal static void Register() =>
+    internal static void Register()
+    {
         DomBridge.LayoutViewFactory ??= static () => new HeadlessLayoutView();
+        WptResourceHandlers.Install();
+    }
 }

--- a/src/Broiler.Wpt/WptResourceHandlers.cs
+++ b/src/Broiler.Wpt/WptResourceHandlers.cs
@@ -1,0 +1,121 @@
+using System;
+using Broiler.HTML.Core.Entities;
+
+namespace Broiler.Wpt;
+
+/// <summary>
+/// The sub-resource load policy of a conformance run: a <c>&lt;link rel="stylesheet"&gt;</c> or an
+/// <c>&lt;img&gt;</c> is served from the checkout when the corpus holds it, and is otherwise
+/// answered rather than fetched. Nothing in a run reaches the network.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A test document routinely names hosts the corpus does not serve — <c>http://example.com/…</c>,
+/// IP and documentation literals, a CGI on someone's personal server. None of them can produce a
+/// resource on a runner, so the only outcome a fetch has is failure; what it costs is the time the
+/// network takes to say so, which on a black-holing host is the client's whole timeout. That is a
+/// timeout, not a render, and it is what the per-test budget is then spent on.
+/// </para>
+/// <para>
+/// <b>The policy has to hold for every loader a test passes through, and that is the part that was
+/// missing.</b> A run lays each document out more than once — the script bridge lays it out
+/// headlessly to answer geometry reads, and the runner lays it out again to paint it — and the
+/// bridge fetches external stylesheets through a loader of its own besides. Only the paint
+/// container had handlers, so the other two fetched everything the document named, and paid for it
+/// before the guarded render started. <see cref="Install"/> covers them; <see cref="Stylesheet"/>
+/// and <see cref="Image"/> remain the paint container's handlers, which do the extra work of
+/// <em>serving</em> a corpus URL from disk rather than merely declining a foreign one.
+/// </para>
+/// </remarks>
+internal static class WptResourceHandlers
+{
+    /// <summary>
+    /// Stands in for an off-corpus stylesheet the run declines to fetch. It has to be non-empty:
+    /// <c>StylesheetLoadHandler</c> reads an empty <c>SetStyleSheet</c> as "the host supplied
+    /// nothing" and falls through to fetching <c>Src</c> itself — the fetch this exists to prevent.
+    /// A comment is the smallest thing that parses to no rules at all.
+    /// </summary>
+    internal const string OffCorpusStylesheet = "/* off-corpus stylesheet: not fetched */";
+
+    /// <summary>
+    /// The checkout this process's run is rooted at, or <see langword="null"/> when the runner was
+    /// given no <c>--wpt-dir</c>. Read at <em>call</em> time by the policies <see cref="Install"/>
+    /// registers, so nothing depends on when they were registered relative to the first test.
+    /// </summary>
+    internal static string? Root { get; set; }
+
+    /// <summary>
+    /// Registers the policy with the two loaders no container event reaches: the engine's, which
+    /// the script bridge's headless geometry layout goes through as much as the render does, and
+    /// the bridge's own, whose speculative preload scan requests a document's external stylesheets
+    /// on a worker before the parse has even started.
+    /// </summary>
+    /// <remarks>
+    /// Both are process-wide and idempotent (<c>??=</c>), and both are inert until a run is rooted,
+    /// so a host that embeds this assembly for something else is unaffected. The engine half is a
+    /// no-op until <c>Broiler.HTML</c>'s stylesheet loader carries the one line that consults it —
+    /// that line is a submodule patch, and this assembly names nothing new in the submodule, so it
+    /// builds and runs either way (the images half is entirely in <c>Broiler.Layout</c> and needs no
+    /// patch at all).
+    /// </remarks>
+    internal static void Install()
+    {
+        Broiler.Layout.Engine.OfflineSubresources.FetchPolicy ??= MayFetch;
+        Broiler.HtmlBridge.Dom.Runtime.ResourceLoader.NetworkFetchPolicy ??= MayFetch;
+    }
+
+    /// <summary>
+    /// False only for a URL naming a host outside the corpus, and only while a run is rooted.
+    /// </summary>
+    private static bool MayFetch(string? url) =>
+        Root is not { Length: > 0 } || !WptTestRunner.IsOffCorpusNetworkResource(url);
+
+    /// <summary>
+    /// The policy actually registered with the engine, so a test can exercise the delegate the
+    /// engine will call rather than a copy of it. Read through here rather than from
+    /// <c>OfflineSubresources</c> directly, because <c>Broiler.Layout</c> keeps its internals
+    /// visible to a deliberately short list of assemblies and this needs no place on it.
+    /// </summary>
+    internal static Func<string?, bool>? RegisteredEnginePolicy =>
+        Broiler.Layout.Engine.OfflineSubresources.FetchPolicy;
+
+    /// <summary>
+    /// The paint container's stylesheet handler for a render rooted at <paramref name="wptRoot"/>.
+    /// </summary>
+    internal static EventHandler<HtmlStylesheetLoadEventArgs> Stylesheet(string wptRoot) =>
+        (_, args) =>
+        {
+            var local = WptTestRunner.TryResolveWptRootRelativePath(args.Src, wptRoot);
+            if (local != null)
+            {
+                args.SetSrc = local;
+                return;
+            }
+
+            // A sheet that parses to no rules, which is what a sheet that cannot load contributes
+            // to the cascade. Answering here rather than leaving it to the engine's own policy
+            // keeps the decision on the path that also knows how to *serve* a corpus URL.
+            if (WptTestRunner.IsOffCorpusNetworkResource(args.Src))
+                args.SetStyleSheet = OffCorpusStylesheet;
+        };
+
+    /// <summary>
+    /// The paint container's image handler for a render rooted at <paramref name="wptRoot"/>.
+    /// </summary>
+    internal static EventHandler<HtmlImageLoadEventArgs> Image(string wptRoot) =>
+        (_, args) =>
+        {
+            var local = WptTestRunner.TryResolveWptRootRelativePath(args.Src, wptRoot);
+            if (local != null)
+            {
+                args.Callback(local);
+                return;
+            }
+
+            // Marked handled, not redirected: the image does not load, which is exactly what these
+            // tests check the parser does with such a URL. `args.Callback` cannot express that — it
+            // throws on an empty path.
+            if (WptTestRunner.IsOffCorpusNetworkResource(args.Src))
+                args.Handled = true;
+        };
+}

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -1943,26 +1943,8 @@ internal sealed partial class WptTestRunner
         EventHandler<HtmlImageLoadEventArgs> imageHandler = null;
         if (wptRoot != null)
         {
-            var capturedWptRoot = wptRoot;
-            stylesheetHandler = (_, args) =>
-            {
-                var local = TryResolveWptRootRelativePath(args.Src, capturedWptRoot);
-                if (local != null)
-                    args.SetSrc = local;
-            };
-            imageHandler = (_, args) =>
-            {
-                var local = TryResolveWptRootRelativePath(args.Src, capturedWptRoot);
-                if (local != null)
-                {
-                    args.Callback(local);
-                    return;
-                }
-
-                // Everything else that names a remote host is a fetch this run must not make.
-                if (IsOffCorpusNetworkImage(args.Src))
-                    args.Handled = true;
-            };
+            stylesheetHandler = WptResourceHandlers.Stylesheet(wptRoot);
+            imageHandler = WptResourceHandlers.Image(wptRoot);
         }
 
         // Render via Broiler HTML stack.
@@ -2569,6 +2551,48 @@ internal sealed partial class WptTestRunner
     }
 
     /// <summary>
+    /// True when <paramref name="src"/> is an absolute http(s) URL on a host the corpus does not
+    /// serve — i.e. a sub-resource the engine would fetch off the real network.
+    /// </summary>
+    /// <remarks>
+    /// A conformance run must not touch the network, and one that does is not merely impure — it
+    /// is slow in a way no per-test budget survives. Both loaders are synchronous on the layout
+    /// thread (<c>HtmlRender</c> sets <c>AvoidAsyncImagesLoading</c>), so a fetch blocks the render
+    /// for as long as the host takes to answer — and an unroutable one never does, so what it costs
+    /// is the client's whole timeout: five seconds for a <c>&lt;link&gt;</c>, and .NET's 100-second
+    /// default for an <c>&lt;img&gt;</c> until the engine-side cap lands. Neither is a render, and
+    /// neither is cached, so the next layout pass pays it again.
+    /// <para>
+    /// Both timed-out tests of the 2026-08-16 run are this and nothing else.
+    /// <c>css/CSS2/cascade-import/cascade-import-009.xht</c> links three stylesheets to a
+    /// <c>delayed-file</c> CGI on a personal server that pauses 2, 5 and 8 seconds by design;
+    /// <c>conformance-checkers/html/elements/img/src-isvalid.html</c> is 88 <c>&lt;img&gt;</c> with
+    /// 88 distinct sources, deliberately including IP literals (<c>http://192.0x00A80001</c>) and
+    /// documentation addresses (<c>http://[2001::1]</c>) that black-hole on a CI runner with real
+    /// internet. One of either is enough to lose the test.
+    /// </para>
+    /// <para>
+    /// Suppressing the load rather than redirecting it is what the corpus wants: the resource does
+    /// not load, which is exactly what these tests are checking the parser does with the URL.
+    /// </para>
+    /// </remarks>
+    internal static bool IsOffCorpusNetworkResource(string? src)
+    {
+        if (string.IsNullOrWhiteSpace(src)
+            || !Uri.TryCreate(src, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+            return false;
+
+        foreach (var served in WptSubstitution.ServedHosts)
+        {
+            if (string.Equals(uri.Host, served, StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Maps a root-relative WPT URL (<c>/images/blue.png</c>, <c>/fonts/Ahem.ttf</c>) — or an
     /// absolute one on a host WPT serves from the same checkout
     /// (<c>http://www.web-platform.test:8000/images/blue.png</c>, which is what a substituted
@@ -2585,51 +2609,6 @@ internal sealed partial class WptTestRunner
     /// (WPT resource-timing/tentative/initiator-url/static-resource, resource-timing/initiator-type/misc).
     /// </para>
     /// </summary>
-    /// <summary>
-    /// True when <paramref name="src"/> is an absolute http(s) URL on a host the corpus does not
-    /// serve — i.e. an image the engine would fetch off the real network.
-    /// </summary>
-    /// <remarks>
-    /// A conformance run must not touch the network, and one that does is not merely impure — it
-    /// is slow in a way no per-test budget survives. Image loading is synchronous here
-    /// (<c>HtmlRender</c> sets <c>AvoidAsyncImagesLoading</c>), so the fetch blocks the layout
-    /// thread, and <c>ImageDownloader</c>'s shared <c>HttpClient</c> sets no <c>Timeout</c> — so an
-    /// unroutable host stalls for .NET's 100-second default, more than three times the whole
-    /// per-test budget, and does it again on the next layout pass because failures are not cached.
-    /// <c>conformance-checkers/html/elements/img/src-isvalid.html</c> is 88 <c>&lt;img&gt;</c> with
-    /// 88 distinct sources, some of them deliberately exotic hosts — IP literals like
-    /// <c>http://192.0x00A80001</c> and documentation addresses like <c>http://[2001::1]</c> — that
-    /// black-hole on a CI runner with real internet. One is enough to time the test out. (It passes
-    /// here only because this container's proxy answers those instantly.)
-    /// <para>
-    /// Suppressing the load rather than redirecting it is what the corpus wants: the image does not
-    /// load, which is exactly what the test is checking the parser does with the URL.
-    /// <c>args.Callback</c> cannot express that — it throws on an empty path — so the load is
-    /// marked handled, which is the flag <c>ImageLoadHandler.LoadImage</c> gates the whole fetch on.
-    /// </para>
-    /// <para>
-    /// The complementary fix belongs in the engine, where <c>ImageDownloader</c>'s client should
-    /// carry a short timeout the way the stylesheet loader's already does (WPT #1147) — that one is
-    /// in the Broiler.HTML submodule and ships as a patch. This is the half that needs no patch and
-    /// is the more correct behaviour for a sandboxed runner regardless.
-    /// </para>
-    /// </remarks>
-    internal static bool IsOffCorpusNetworkImage(string? src)
-    {
-        if (string.IsNullOrWhiteSpace(src)
-            || !Uri.TryCreate(src, UriKind.Absolute, out var uri)
-            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
-            return false;
-
-        foreach (var served in WptSubstitution.ServedHosts)
-        {
-            if (string.Equals(uri.Host, served, StringComparison.OrdinalIgnoreCase))
-                return false;
-        }
-
-        return true;
-    }
-
     internal static string? TryResolveWptRootRelativePath(string? src, string wptRoot)
     {
         // A `.sub` template's URLs are absolute and on a WPT host (`http://www.web-platform.test:8000/…`)
@@ -2735,26 +2714,8 @@ internal sealed partial class WptTestRunner
         EventHandler<HtmlImageLoadEventArgs>? imageHandler = null;
         if (wptRoot != null)
         {
-            var capturedWptRoot = wptRoot;
-            stylesheetHandler = (_, args) =>
-            {
-                var local = TryResolveWptRootRelativePath(args.Src, capturedWptRoot);
-                if (local != null)
-                    args.SetSrc = local;
-            };
-            imageHandler = (_, args) =>
-            {
-                var local = TryResolveWptRootRelativePath(args.Src, capturedWptRoot);
-                if (local != null)
-                {
-                    args.Callback(local);
-                    return;
-                }
-
-                // Everything else that names a remote host is a fetch this run must not make.
-                if (IsOffCorpusNetworkImage(args.Src))
-                    args.Handled = true;
-            };
+            stylesheetHandler = WptResourceHandlers.Stylesheet(wptRoot);
+            imageHandler = WptResourceHandlers.Image(wptRoot);
         }
 
         using var presentation = ImageAnimationClock.Pin(presentationTime);
@@ -3179,6 +3140,12 @@ internal sealed partial class WptTestRunner
         string? wptRoot = null,
         bool batchStyleInvalidations = false)
     {
+        // This method is what drives the bridge's headless geometry pass, and that pass builds a
+        // container of its own — out of reach of the handlers the render is handed afterwards. Tell
+        // the policy which checkout to resolve against here, at the one boundary every caller of the
+        // geometry pass goes through (RunSingleTest, RenderHtmlFileBitmapCore, a worker process).
+        WptResourceHandlers.Root = wptRoot;
+
         var scripts = new List<string>();
         var deferredScripts = new List<string>();
         var microTasks = new MicroTaskQueue();


### PR DESCRIPTION
## Summary

A WPT conformance run lays each document out multiple times — once headlessly in the script bridge for geometry reads, once to paint it — but the sub-resource fetch policy was only installed on the paint container's handlers. This meant stylesheets and images from off-corpus hosts were still fetched in the geometry pass and the bridge's preload scan, causing timeouts on tests with many such resources.

This change installs the policy at the engine level (`Broiler.Layout.Engine.OfflineSubresources`) and the bridge's loader, so it applies to every container and every fetch path. It also extracts the paint container's handlers into a reusable `WptResourceHandlers` class.

## Key Changes

- **New `Broiler.Layout.Engine.OfflineSubresources` class**: A process-wide fetch policy consulted by image and stylesheet loaders before any network request. Unset by default, so renderers with network access behave unchanged.

- **New `Broiler.Wpt.WptResourceHandlers` class**: Extracted the paint container's stylesheet and image handlers from `WptTestRunner` into reusable factory methods. Adds `Install()` to register the policy with both the engine and the bridge's loader.

- **Engine-side enforcement**: `CssBoxImage` and `CssBox.Background` now consult `OfflineSubresources.Denies()` before loading, preventing off-corpus fetches in the geometry pass.

- **Bridge loader enforcement**: `ResourceLoader.FetchAsync()` checks `NetworkFetchPolicy` before attempting http(s) fetches, blocking off-corpus URLs in the preload scan.

- **Renamed method**: `WptTestRunner.IsOffCorpusNetworkImage()` → `IsOffCorpusNetworkResource()` to reflect that it now guards both stylesheets and images.

- **New tests**: `WptResourceHandlersTests` pins the handler behavior; `OfflineSubresourcesTests` pins the engine policy.

- **Submodule patch**: `0004-decline-off-corpus-stylesheet-fetch.patch` for `Broiler.HTML` adds the same check to `StylesheetLoadHandler` so the policy is consulted before the five-second fetch timeout.

## Notable Details

- The policy is a predicate over the URL (`Func<string?, bool>`) rather than a binary flag, because the host (WPT runner) needs to distinguish between corpus and off-corpus hosts — the engine has no knowledge of which is which.

- Off-corpus stylesheets are answered with a non-empty CSS comment (`/* off-corpus stylesheet: not fetched */`) rather than an empty string, because the stylesheet loader treats empty as "host supplied nothing" and falls through to fetching anyway.

- Off-corpus images are marked handled (not redirected), so they don't load — which is the correct behavior these tests are checking for.

- The policy is process-wide (not thread-local) because the image prefetch consults it from `Parallel.For` workers, where a thread-local set on the layout thread would be invisible.

- `HeadlessLayoutViewRegistration` now calls `WptResourceHandlers.Install()` during composition wiring, so the policy is registered before any test runs.

Fixes timeouts on `css/CSS2/cascade-import/cascade-import-009.xht` (three stylesheets to a delayed-file CGI) and the second occurrence of `conformance-checkers/html/elements/img/src-isvalid.html` (88 images with off-corpus sources).

https://claude.ai/code/session_01CQbsZ3PL8m78eC5fpJvTXu