### PR TITLE
Parse minified JavaScript that real sites serve

### DIFF
--- a/patches/0001-parse-minified-javascript.patch
+++ b/patches/0001-parse-minified-javascript.patch
@@ -1,0 +1,915 @@
+From 746e5d8549d3dc2827d1b8c7ac8e9d0eeaeb987c Mon Sep 17 00:00:00 2001
+From: Claude <enrico.bartky@gmail.com>
+Date: Mon, 17 Aug 2026 09:36:04 +0000
+Subject: [PATCH] Parse the minified JavaScript real sites serve
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+FastParser rejected five shapes that minifier output produces constantly, and
+a rejection is total: one bad token and the whole script fails to compile, so
+nothing on the page runs. Each was found by running the parser over the scripts
+live sites actually serve, and each is named below by the script that produced
+it.
+
+  * A `/` directly after the `)` of an `if`/`for`/`while`/`with` head was read
+    as division. That head is followed by a Statement, which may perfectly well
+    begin with a regular expression — marked.js (bundled into monaco-editor and
+    into several news sites' page bundles) walks a markdown table's alignment
+    row with `for(...)/^ *-+: *$/.test(...)`. The scanner now tracks, per open
+    paren, whether it opened a statement head, so only those `)` allow a regex
+    after them; every other `)` still divides.
+
+  * A template substitution parsed only an AssignmentExpression, but
+    `${ Expression }` is a full Expression and may be a comma sequence.
+    swiper-bundle.min.js folds an entire initialisation into one interpolation.
+
+  * An object *binding* pattern rejected a reserved word as a PropertyName, so
+    TypeScript's own bundle could not be parsed: it destructures groupBy's
+    result as `const { false: decorators, true: metadata } = ...`. A
+    PropertyName is an IdentifierName, and the object *literal* path already
+    accepted these; only the pattern path did not, because `false`/`true`/
+    `null`/`in`/`instanceof` lex to token types of their own. The shorthand form
+    stays rejected — a reserved word is never a BindingIdentifier. `export
+    { x as in }` is allowed for the same reason (a ModuleExportName is an
+    IdentifierName), which is what minified re-export lists come to.
+
+  * The `[~In]` a `for` head imposes leaked into every nested context, so an
+    `in` inside a function body, an arrow, a call's arguments or a template
+    substitution within the head was rejected. core-js and its many re-bundles
+    install properties from exactly that shape. Those contexts are `[+In]` in
+    their own right; the head's own top level still suppresses `in`, so a
+    for-in loop is unaffected.
+
+  * An Annex B IdentityEscape was neutralised for the .NET validity check only
+    outside a character class, so `/[^0-9a-zA-Z\-\_]/` failed to validate, the
+    scanner fell back to reading the `/` as division, and the file failed.
+    ClassEscape reaches IdentityEscape too. `\-` keeps its backslash inside a
+    class, where `-` is the range operator.
+
+Also: the report a failed statement produces. When a production gives up by
+returning false it rewinds to where the statement started, so the only token
+left to blame is the statement's first one — and in a minified bundle that is
+character 1 of the file. Every such failure therefore read "Unexpected token
+Negate: ! at 1, 1", pointing at the `!` of a `!function(){...}()` wrapper
+however far away the real problem was. The stream now keeps a high-water mark
+that survives the rewind, and the report names where the parse actually
+stopped, including "the end of the script" for a source that ends early.
+
+Tests: 54 parser cases for the shapes and their counterparts (a `/` after any
+other `)` still divides, a for-in head still suppresses `in`, a reserved-word
+shorthand is still an error), plus MinifiedScriptParsingTests, which evaluates
+each shape — two of these fixes change how a token is *read*, and "it parses"
+is not evidence that it parses correctly.
+---
+ .../MinifiedScriptParsingTests.cs             | 134 +++++++++++
+ .../ParserTests.cs                            | 218 ++++++++++++++++++
+ .../FastParser.ArrayExpression.cs             |  53 +++--
+ .../FastParser.AssignmentLeftPattern.cs       |  34 ++-
+ .../FastParser.Block.cs                       |   5 +-
+ .../FastParser.Expression.cs                  |   5 +
+ .../FastParser.Function.cs                    |   7 +
+ .../FastParser.PropertyName.cs                |  13 ++
+ .../FastParser.Template.cs                    |  42 +++-
+ .../Broiler.JavaScript.Parser/FastScanner.cs  |  45 ++++
+ .../FastTokenStream.cs                        |  48 ++++
+ .../RegExpValidator.cs                        |  13 +-
+ 12 files changed, 590 insertions(+), 27 deletions(-)
+ create mode 100644 Broiler.JS/Broiler.JavaScript.Integration.Tests/MinifiedScriptParsingTests.cs
+
+diff --git a/Broiler.JS/Broiler.JavaScript.Integration.Tests/MinifiedScriptParsingTests.cs b/Broiler.JS/Broiler.JavaScript.Integration.Tests/MinifiedScriptParsingTests.cs
+new file mode 100644
+index 00000000..857a99f8
+--- /dev/null
++++ b/Broiler.JS/Broiler.JavaScript.Integration.Tests/MinifiedScriptParsingTests.cs
+@@ -0,0 +1,134 @@
++using Broiler.JavaScript.Engine;
++
++namespace Broiler.JavaScript.Integration.Tests;
++
++// Parse-level regressions found by running FastParser over the scripts real sites
++// actually serve — minifier output that the parser rejected outright, so nothing on the
++// page ran. The parser tests assert that each shape parses; these assert that it also
++// *means* what it should, because two of the five fixes change how a token is read
++// (`/` as a regex delimiter rather than division, `in` as an operator rather than a
++// for-in marker) and "it parses" is not evidence that it parses correctly.
++//
++// Reported as: FastParseException "Unexpected token Negate: ! at 1, 1" — the report a
++// failed statement produces once the parser has rewound to its first token, which for a
++// `!function(){…}()` bundle is character 1. FastTokenStream.UnexpectedStatement now also
++// names where the parse actually stopped.
++public class MinifiedScriptParsingTests
++{
++    private static string Eval(string code)
++    {
++        using var ctx = new JSContext();
++        return ctx.Eval(code).ToString();
++    }
++
++    // ---- A `/` after the `)` of a statement head opens a regex, not a division ----
++
++    // marked.js (bundled into monaco-editor and into several news sites' page bundles)
++    // walks a markdown table's alignment row with the regex as the loop body.
++    [Fact]
++    public void RegularExpression_AsStatementBodyOfFor_Matches()
++    {
++        Assert.Equal("right,center,left", Eval(@"
++            var align = ['---:', ':--:', ':---'], out = [];
++            for (var i = 0; i < align.length; i++)
++                /^ *-+: *$/.test(align[i]) ? out.push('right')
++                    : /^ *:-+: *$/.test(align[i]) ? out.push('center')
++                    : out.push('left');
++            out.join(',');"));
++    }
++
++    [Fact]
++    public void RegularExpression_AsStatementBodyOfIf_Matches()
++    {
++        Assert.Equal("true", Eval("var r = false; if (1) /ab/.test('xaby') && (r = true); r;"));
++    }
++
++    [Fact]
++    public void RegularExpression_AsStatementBodyOfWhile_Matches()
++    {
++        Assert.Equal("3", Eval("var n = 0; while (n < 3) /x/.test('x') && n++; n;"));
++    }
++
++    // The other half of the same decision: a `)` that closed a call or a grouping is still
++    // followed by division. Getting this wrong would silently turn arithmetic into a regex.
++    [Fact]
++    public void SlashAfterCallOrGrouping_StillDivides()
++    {
++        Assert.Equal("5", Eval("var f = function (x) { return x; }; (4 + 6) / 2;"));
++        Assert.Equal("3", Eval("var f = function (x) { return x; }; f(12) / 4;"));
++        Assert.Equal("2", Eval("var a = 8, b = 2, c = 2; (a) / b / c;"));
++    }
++
++    // ---- `in` is an operator again inside anything nested in a `for` head ----
++
++    // core-js and its re-bundles install properties from a `for` head whose initialiser is
++    // a function expression that tests `e in C`. The `[~In]` of the head leaked into the
++    // function body and rejected the script at that `in`.
++    [Fact]
++    public void In_InsideAFunctionExpressionOfAForHead_IsAnOperator()
++    {
++        Assert.Equal("true,false", Eval(@"
++            var out = [], C = { a: 1 };
++            for (var i = 0, has = function (e) { return e in C; }; i < 1; i++)
++                out.push(has('a'), has('b'));
++            out.join(',');"));
++    }
++
++    [Fact]
++    public void In_InsideCallArgumentsOfAForHead_IsAnOperator()
++    {
++        Assert.Equal("true", Eval("var C = { a: 1 }, id = function (v) { return v; }; for (var r = id('a' in C); 0;); r;"));
++    }
++
++    [Fact]
++    public void In_InsideATemplateSubstitutionOfAForHead_IsAnOperator()
++    {
++        Assert.Equal("true", Eval("var C = { a: 1 }; for (var s = `${'a' in C}`; 0;); s;"));
++    }
++
++    // And the head's own `[~In]` is untouched: a for-in loop must still be a for-in loop.
++    [Fact]
++    public void ForInHead_StillIteratesProperties()
++    {
++        Assert.Equal("a,b", Eval("var out = []; for (var k in { a: 1, b: 2 }) out.push(k); out.join(',');"));
++    }
++
++    // ---- A template substitution takes a full Expression ----
++
++    // swiper-bundle.min.js folds a whole initialisation sequence into one interpolation.
++    [Fact]
++    public void TemplateSubstitution_CommaSequence_EvaluatesToItsLastElement()
++    {
++        Assert.Equal("id-16", Eval("var n; `id-${n = 16, void 0 === n && (n = 1), n}`;"));
++    }
++
++    [Fact]
++    public void TemplateSubstitution_CommaSequence_EvaluatesEveryElement()
++    {
++        Assert.Equal("2:done", Eval("var calls = 0, bump = function () { calls++; }; var s = `${bump(), bump(), 'done'}`; calls + ':' + s;"));
++    }
++
++    // ---- A binding pattern's PropertyName may be a reserved word ----
++
++    // TypeScript's own bundle destructures groupBy's result by its boolean keys.
++    [Fact]
++    public void ObjectBindingPattern_ReservedWordPropertyNames_BindTheRightValues()
++    {
++        Assert.Equal("d,m", Eval("var { false: decorators, true: metadata } = { false: 'd', true: 'm' }; decorators + ',' + metadata;"));
++        Assert.Equal("n", Eval("var { null: x } = { null: 'n' }; x;"));
++        Assert.Equal("i", Eval("function f({ in: v }) { return v; } f({ in: 'i' });"));
++    }
++
++    // ---- Annex B identity escapes are valid inside a character class ----
++
++    // Adobe Launch's bundle sanitises input with this exact pattern; rejecting `\_` made
++    // the scanner re-read the `/` as division and fail the file.
++    [Fact]
++    public void RegularExpressionClass_IdentityEscape_MatchesTheLiteralCharacter()
++    {
++        Assert.Equal("a-b_c", Eval(@"'a-b_c!?'.replace(/[^0-9a-zA-Z\-\_]/g, '');"));
++        Assert.Equal("__", Eval(@"'_x_'.replace(/[^\_]/g, '');"));
++        // An escaped `-` between two atoms stays a literal `-`, not a range.
++        Assert.Equal("a-z", Eval(@"'a-zq'.replace(/[^a\-z]/g, '');"));
++    }
++}
+diff --git a/Broiler.JS/Broiler.JavaScript.Parser.Tests/ParserTests.cs b/Broiler.JS/Broiler.JavaScript.Parser.Tests/ParserTests.cs
+index 58c7a1ab..240c74ef 100644
+--- a/Broiler.JS/Broiler.JavaScript.Parser.Tests/ParserTests.cs
++++ b/Broiler.JS/Broiler.JavaScript.Parser.Tests/ParserTests.cs
+@@ -737,4 +737,222 @@ public class ParserTests
+ 
+         Assert.Equal(2, program.Statements.ToArray().Length);
+     }
++
++    /// <summary>
++    /// TemplateSubstitution is `${ Expression }` — a full Expression, so a comma sequence
++    /// belongs there. Parsing only an AssignmentExpression left the `,` unconsumed and
++    /// rejected the whole script; swiper-bundle.min.js interpolates exactly this shape.
++    /// </summary>
++    [Theory]
++    [InlineData("var x = `${a,b}`;")]
++    [InlineData("var x = `a${b,c}d`;")]
++    [InlineData("var x = `${1,2}${3,4}`;")]
++    [InlineData("function f(n){ return `x${n=16,void 0===n&&(n=16),n}`; }")]
++    [InlineData("var x = tag`${a,b}`;")]
++    public void ParseProgram_TemplateSubstitution_AcceptsCommaSequence(string source)
++    {
++        var stream = new FastTokenStream(new StringSpan(source));
++        var parser = new FastParser(stream);
++
++        Assert.NotNull(parser.ParseProgram());
++    }
++
++    /// <summary>
++    /// BindingProperty is `PropertyName : BindingElement`, and a PropertyName is an
++    /// IdentifierName — reserved words included. The object *literal* path already accepted
++    /// them; the binding-pattern path did not, because `false`/`true`/`null`/`in`/`instanceof`
++    /// lex to token types of their own rather than Identifier. TypeScript's own bundle
++    /// destructures `const { false: decorators, true: metadata } = groupBy(…)`.
++    /// </summary>
++    [Theory]
++    [InlineData("var {false: a} = b;")]
++    [InlineData("const {false: a, true: b} = c;")]
++    [InlineData("let {null: a} = b;")]
++    [InlineData("var {in: a, instanceof: b} = c;")]
++    [InlineData("function f({null: a}) { return a; }")]
++    [InlineData("var {false: {true: a}} = b;")]
++    [InlineData("var {false: a = 1} = b;")]
++    public void ParseProgram_ObjectBindingPattern_AcceptsReservedWordPropertyNames(string source)
++    {
++        var stream = new FastTokenStream(new StringSpan(source));
++        var parser = new FastParser(stream);
++
++        Assert.NotNull(parser.ParseProgram());
++    }
++
++    /// <summary>
++    /// A reserved word is a legal PropertyName but never a legal BindingIdentifier, so the
++    /// shorthand form still has to be rejected — accepting the key must not accept `var { false }`.
++    /// </summary>
++    [Theory]
++    [InlineData("var {false} = b;")]
++    [InlineData("const {null} = b;")]
++    [InlineData("var {in} = b;")]
++    public void ParseProgram_ObjectBindingPattern_RejectsReservedWordShorthand(string source)
++    {
++        var stream = new FastTokenStream(new StringSpan(source));
++        var parser = new FastParser(stream);
++
++        Assert.ThrowsAny<FastParseException>(() => parser.ParseProgram());
++    }
++
++    /// <summary>
++    /// `export { x as in }` renames to a ModuleExportName, which is an IdentifierName and so
++    /// may be a reserved word — a bundler that minifies export names down to two letters emits
++    /// `in`, `if`, `do` and friends.
++    /// </summary>
++    [Theory]
++    [InlineData("export {a as in} from \"m\";")]
++    [InlineData("export {a as b, c as null} from \"m\";")]
++    public void ParseProgram_ExportSpecifier_AcceptsReservedWordExportName(string source)
++    {
++        var stream = new FastTokenStream(new StringSpan(source));
++        var parser = new FastParser(stream);
++
++        Assert.NotNull(parser.ParseProgram());
++    }
++
++    /// <summary>
++    /// The body of an `if`/`for`/`while`/`with` is a Statement, which may begin with a regular
++    /// expression literal. The scanner read every `/` after a `)` as division, so the regex never
++    /// closed and the script was rejected — marked.js (bundled into monaco-editor, and into the
++    /// page bundles of several news sites) opens a table-alignment loop with exactly this.
++    /// </summary>
++    [Theory]
++    [InlineData("for(;;)/a/.test(x);")]
++    [InlineData("for(i=0;i<n;i++)/^ *-+: *$/.test(a[i])?b():c();")]
++    [InlineData("if(a)/b/.test(x);")]
++    [InlineData("while(a)/b/.test(x);")]
++    [InlineData("with(a)/b/.test(x);")]
++    [InlineData("for(x in y)/b/.test(x);")]
++    [InlineData("for(var x of y)/b/.test(x);")]
++    [InlineData("if(a)/b/.test(x);else/c/.test(x);")]
++    public void ParseProgram_RegularExpression_MayFollowAStatementHead(string source)
++    {
++        var stream = new FastTokenStream(new StringSpan(source));
++        var parser = new FastParser(stream);
++
++        Assert.NotNull(parser.ParseProgram());
++    }
++
++    /// <summary>
++    /// The counterpart of the case above: a `/` after any other `)` is still division. This is
++    /// the regression the statement-head tracking has to avoid — a call or a grouping followed
++    /// by a division must not start reading a regular expression.
++    /// </summary>
++    [Theory]
++    [InlineData("var x = (a+b)/2;")]
++    [InlineData("var x = f(a)/2;")]
++    [InlineData("var x = (a)/b/c;")]
++    [InlineData("var x = f(g(a))/h(b);")]
++    [InlineData("function f(){ return (a)/2; }")]
++    [InlineData("for(var i=(a+b)/2;i<n;i++);")]
++    [InlineData("if(a)b=(c)/2;")]
++    public void ParseProgram_SlashAfterOtherParenthesis_IsStillDivision(string source)
++    {
++        var stream = new FastTokenStream(new StringSpan(source));
++        var parser = new FastParser(stream);
++
++        Assert.NotNull(parser.ParseProgram());
++    }
++
++    /// <summary>
++    /// A `for` head suppresses `in` only at its own top level. Every nested context — a call's
++    /// arguments, a template substitution, a function body, an arrow — is `[+In]` again. Leaking
++    /// the suppression into them rejected `for (var i = 0, f = function (e) { e in C || … }; …)`,
++    /// the shape core-js and its many re-bundles use to install a property.
++    /// </summary>
++    [Theory]
++    [InlineData("for(var a=1,E=function(e){return e in C};0;);")]
++    [InlineData("for(var a=1,E=function(e){e in C||g(e)};0;);")]
++    [InlineData("for(var i=0,f=function(){return \"a\" in b};i<1;i++);")]
++    [InlineData("for(var a=f(x in y);0;);")]
++    [InlineData("for(var a=`${x in y}`;0;);")]
++    [InlineData("for(var a=(()=>x in y);0;);")]
++    [InlineData("for(var a=(x in y);0;);")]
++    [InlineData("for(var a=[x in y];0;);")]
++    [InlineData("for(var a={b:x in y};0;);")]
++    public void ParseProgram_In_IsAnOperatorInsideANestedContextOfAForHead(string source)
++    {
++        var stream = new FastTokenStream(new StringSpan(source));
++        var parser = new FastParser(stream);
++
++        Assert.NotNull(parser.ParseProgram());
++    }
++
++    /// <summary>
++    /// `for (x in y)` must keep working: restoring `[+In]` for nested contexts must not restore
++    /// it for the head itself, or a for-in loop parses as a relational expression instead.
++    /// </summary>
++    [Theory]
++    [InlineData("for(x in y);")]
++    [InlineData("for(var x in y);")]
++    [InlineData("for(let x in y);")]
++    [InlineData("for(const [a,b] in y);")]
++    public void ParseProgram_ForInHead_StillSuppressesInAtItsTopLevel(string source)
++    {
++        var stream = new FastTokenStream(new StringSpan(source));
++        var parser = new FastParser(stream);
++        var program = parser.ParseProgram();
++
++        Assert.Single(program.Statements.ToArray());
++    }
++
++    /// <summary>
++    /// ClassEscape reaches IdentityEscape, so an Annex B identity escape is as valid inside a
++    /// character class as outside it. Rejecting `[\_]` made the scanner fall back to reading the
++    /// `/` as division, which fails the whole script — Adobe Launch's bundle sanitises input with
++    /// `String(e).replace(/[^0-9a-zA-Z\-\_]/g,"")`.
++    /// </summary>
++    [Theory]
++    [InlineData("x.replace(/[\\_]/g,\"\");")]
++    [InlineData("x.replace(/[^0-9a-zA-Z\\-\\_]/g,\"\");")]
++    [InlineData("x.replace(/[\\C\\P]/g,\"\");")]
++    // Outside a class these already worked; they are here so the two paths stay in step.
++    [InlineData("x.replace(/\\_/g,\"\");")]
++    [InlineData("x.replace(/\\-/g,\"\");")]
++    // A `-` between two ordinary atoms is still a range, escaped or not: both must parse.
++    [InlineData("x.replace(/[a-z]/g,\"\");")]
++    [InlineData("x.replace(/[a\\-z]/g,\"\");")]
++    public void ParseProgram_RegularExpressionClass_AcceptsAnnexBIdentityEscapes(string source)
++    {
++        var stream = new FastTokenStream(new StringSpan(source));
++        var parser = new FastParser(stream);
++
++        Assert.NotNull(parser.ParseProgram());
++    }
++
++    /// <summary>
++    /// When a statement cannot be parsed the parser has rewound to the statement's first token,
++    /// so that token is all it can name — and in a minified bundle that is character 1 of the
++    /// file, which says nothing at all. The report now also names where the parse actually
++    /// stopped, which for a script that ends early is the end of the script.
++    /// </summary>
++    [Fact]
++    public void ParseProgram_UnparseableStatement_ReportsWhereTheParseStopped()
++    {
++        var stream = new FastTokenStream(new StringSpan("!"));
++        var parser = new FastParser(stream);
++
++        var error = Assert.ThrowsAny<FastParseException>(() => parser.ParseProgram());
++
++        Assert.Contains("Unexpected token Negate: ! at 1, 1", error.Message);
++        Assert.Contains("the end of the script", error.Message);
++    }
++
++    /// <summary>
++    /// And when the parse stopped at a real token, that token is named with its position rather
++    /// than the statement's.
++    /// </summary>
++    [Fact]
++    public void ParseProgram_UnparseableStatement_NamesTheTokenItStoppedAt()
++    {
++        var stream = new FastTokenStream(new StringSpan("!;"));
++        var parser = new FastParser(stream);
++
++        var error = Assert.ThrowsAny<FastParseException>(() => parser.ParseProgram());
++
++        Assert.Contains("Unexpected token Negate: ! at 1, 1", error.Message);
++        Assert.Contains("SemiColon at 1, 2", error.Message);
++    }
+ }
+diff --git a/Broiler.JS/Broiler.JavaScript.Parser/FastParser.ArrayExpression.cs b/Broiler.JS/Broiler.JavaScript.Parser/FastParser.ArrayExpression.cs
+index 98c0c898..bd097b74 100644
+--- a/Broiler.JS/Broiler.JavaScript.Parser/FastParser.ArrayExpression.cs
++++ b/Broiler.JS/Broiler.JavaScript.Parser/FastParser.ArrayExpression.cs
+@@ -16,34 +16,49 @@ partial class FastParser
+     bool ArrayExpression(out IFastEnumerable<AstExpression> nodes, TokenTypes endsWith = TokenTypes.BracketEnd)
+     {
+         var list = new Sequence<AstExpression>();
+-        do
++
++        // Arguments : ( ArgumentList ) — every argument is an AssignmentExpression[+In],
++        // so `in` is an ordinary binary operator inside the parentheses even when the
++        // enclosing context suppressed it to disambiguate a for-in head. Without this,
++        // `for (var i = 0, f = fn("a" in b); …; …)` was rejected at the `in`.
++        var savedIn = considerInOfAsOperators;
++        considerInOfAsOperators = true;
++
++        try
+         {
+-            stream.SkipNewLines();
++            do
++            {
++                stream.SkipNewLines();
+ 
+-            if (stream.CheckAndConsumeAny(endsWith, TokenTypes.EOF))
+-                break;
++                if (stream.CheckAndConsumeAny(endsWith, TokenTypes.EOF))
++                    break;
+ 
+-            var isSpread = stream.CheckAndConsume(TokenTypes.TripleDots, out var token);
++                var isSpread = stream.CheckAndConsume(TokenTypes.TripleDots, out var token);
+ 
+-            if (Expression(out var node))
+-            {
+-                if (isSpread)
+-                    node = new AstSpreadElement(token, node.End, node);
++                if (Expression(out var node))
++                {
++                    if (isSpread)
++                        node = new AstSpreadElement(token, node.End, node);
+ 
+-                list.Add(node);
+-            }
++                    list.Add(node);
++                }
+ 
+-            if (stream.CheckAndConsumeAny(endsWith, TokenTypes.EOF))
+-                break;
++                if (stream.CheckAndConsumeAny(endsWith, TokenTypes.EOF))
++                    break;
+ 
+-            if (stream.CheckAndConsume(TokenTypes.Comma))
+-                continue;
++                if (stream.CheckAndConsume(TokenTypes.Comma))
++                    continue;
+ 
+-            if (stream.LineTerminator())
+-                continue;
++                if (stream.LineTerminator())
++                    continue;
+ 
+-            throw stream.Unexpected();
+-        } while (true);
++                throw stream.Unexpected();
++            } while (true);
++        }
++        finally
++        {
++            considerInOfAsOperators = savedIn;
++        }
+ 
+         nodes = list;
+         return true;
+diff --git a/Broiler.JS/Broiler.JavaScript.Parser/FastParser.AssignmentLeftPattern.cs b/Broiler.JS/Broiler.JavaScript.Parser/FastParser.AssignmentLeftPattern.cs
+index eeb95829..9ab8eb56 100644
+--- a/Broiler.JS/Broiler.JavaScript.Parser/FastParser.AssignmentLeftPattern.cs
++++ b/Broiler.JS/Broiler.JavaScript.Parser/FastParser.AssignmentLeftPattern.cs
+@@ -73,10 +73,26 @@ partial class FastParser
+                     break;
+ 
+                 bool computed = false;
++                bool keywordName = false;
+                 if (Identitifer(out var id))
+                 {
+                     left = id;
+                 }
++                else if (IsKeywordPropertyName(stream.Current.Type))
++                {
++                    // BindingProperty : PropertyName : BindingElement, and a PropertyName
++                    // is an IdentifierName — every reserved word included. The object
++                    // *literal* path already accepts these (PropertyName(acceptKeywords)),
++                    // but `false` / `true` / `null` / `in` / `instanceof` lex to their own
++                    // token types rather than Identifier, so the pattern path rejected
++                    // `const { false: a, true: b } = groupBy(…)` — a shape real code uses.
++                    // A reserved word is never a valid BindingIdentifier, so the `:` form
++                    // is the only one allowed; the shorthand branch below rejects it.
++                    var keywordToken = stream.Current;
++                    stream.Consume();
++                    left = new AstIdentifier(keywordToken.AsString());
++                    keywordName = true;
++                }
+                 else if (StringLiteral(out var str))
+                 {
+                     left = str;
+@@ -123,7 +139,18 @@ partial class FastParser
+ 
+                 if (renamed)
+                 {
+-                    if (Identitifer(out var rid))
++                    // `export { x as in }` renames to a ModuleExportName, which is an
++                    // IdentifierName and so may be a reserved word — a bundler emits
++                    // these when it minifies export names down to two letters. Only the
++                    // module form: a binding pattern's target is a BindingIdentifier,
++                    // where `in` stays illegal.
++                    if (modulePattern && IsKeywordPropertyName(stream.Current.Type))
++                    {
++                        var exportName = stream.Current;
++                        stream.Consume();
++                        right = new AstIdentifier(exportName.AsString());
++                    }
++                    else if (Identitifer(out var rid))
+                     {
+                         if (rid.Start.IsEscapedReservedWord)
+                             throw new FastParseException(rid.Start, "Keyword must not contain escaped characters");
+@@ -137,8 +164,9 @@ partial class FastParser
+                 }
+                 else
+                 {
+-                    // A computed key has no implicit shorthand binding target.
+-                    if (computed || left is AstLiteral)
++                    // A computed key has no implicit shorthand binding target, and neither
++                    // has a reserved word — `var { false }` binds nothing nameable.
++                    if (computed || keywordName || left is AstLiteral)
+                         throw stream.Unexpected();
+                     // A shorthand property's name is also its BindingIdentifier, so it
+                     // follows the same rules as a simple binding: contextual keywords
+diff --git a/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Block.cs b/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Block.cs
+index 6e5925a8..c002cd78 100644
+--- a/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Block.cs
++++ b/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Block.cs
+@@ -56,7 +56,10 @@ partial class FastParser
+                 if (stream.CheckAndConsume(terminator))
+                     break;
+ 
+-                throw stream.Unexpected();
++                // Statement() rewound to its first token when it gave up, so that token is
++                // all this frame knows about — and on a minified bundle it is character 1
++                // of the file. UnexpectedStatement adds where the parse actually stopped.
++                throw stream.UnexpectedStatement();
+             } while (true);
+ 
+             node = new AstBlock(begin, PreviousToken, list)
+diff --git a/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Expression.cs b/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Expression.cs
+index 50fc7048..34e59500 100644
+--- a/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Expression.cs
++++ b/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Expression.cs
+@@ -199,6 +199,10 @@ partial class FastParser
+                 functionDepth++;
+                 var previousInGeneratorBody = inGeneratorBody;
+                 var previousInAsyncFunctionBody = inAsyncFunctionBody;
++                // An arrow's body — a Block or a concise AssignmentExpression[+In] — is
++                // its own [+In] context, so a `for` head's `[~In]` does not reach into it.
++                var previousConsiderIn = considerInOfAsOperators;
++                considerInOfAsOperators = true;
+                 inGeneratorBody = isGenerator;
+                 inAsyncFunctionBody = isAsync;
+                 try
+@@ -222,6 +226,7 @@ partial class FastParser
+                 {
+                     inGeneratorBody = previousInGeneratorBody;
+                     inAsyncFunctionBody = previousInAsyncFunctionBody;
++                    considerInOfAsOperators = previousConsiderIn;
+                     functionDepth--;
+                 }
+             }
+diff --git a/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Function.cs b/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Function.cs
+index 4a26b2bc..c0db833a 100644
+--- a/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Function.cs
++++ b/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Function.cs
+@@ -107,6 +107,12 @@ partial class FastParser
+         var previousInGeneratorBody = inGeneratorBody;
+         var previousInAsyncFunctionBody = inAsyncFunctionBody;
+         var previousInFormalParameters = inFormalParameters;
++        // A FormalParameters list and a FunctionBody are [+In] contexts of their own: the
++        // `[~In]` a for-head imposes stops at the function's boundary. `for (var i = 0,
++        // f = function (e) { e in C || define(C, e) }; …; …)` — a shape core-js and
++        // similar libraries emit — was otherwise rejected at the `in` inside the body.
++        var previousConsiderIn = considerInOfAsOperators;
++        considerInOfAsOperators = true;
+         try
+         {
+             functionDepth++;
+@@ -142,6 +148,7 @@ partial class FastParser
+             inGeneratorBody = previousInGeneratorBody;
+             inAsyncFunctionBody = previousInAsyncFunctionBody;
+             inFormalParameters = previousInFormalParameters;
++            considerInOfAsOperators = previousConsiderIn;
+             functionDepth--;
+             scope.Dispose();
+             this.isAsync = isRootAsync;
+diff --git a/Broiler.JS/Broiler.JavaScript.Parser/FastParser.PropertyName.cs b/Broiler.JS/Broiler.JavaScript.Parser/FastParser.PropertyName.cs
+index e7addfb0..365cd600 100644
+--- a/Broiler.JS/Broiler.JavaScript.Parser/FastParser.PropertyName.cs
++++ b/Broiler.JS/Broiler.JavaScript.Parser/FastParser.PropertyName.cs
+@@ -8,6 +8,19 @@ namespace Broiler.JavaScript.Parser;
+ 
+ partial class FastParser
+ {
++    /// <summary>
++    /// Reserved words that the scanner gives a token type of their own rather than
++    /// <see cref="TokenTypes.Identifier"/>. A PropertyName is an IdentifierName, so all
++    /// of them are legal property keys (<c>{ null: 1 }</c>, <c>{ in: 2 }</c>) — in an
++    /// object literal, in a binding pattern, and after a <c>.</c>.
++    /// </summary>
++    internal static bool IsKeywordPropertyName(TokenTypes type)
++        => type is TokenTypes.True
++            or TokenTypes.False
++            or TokenTypes.In
++            or TokenTypes.InstanceOf
++            or TokenTypes.Null;
++
+     bool PropertyName(out AstExpression node, out bool computed, out bool isPrivate, bool acceptKeywords = false)
+     {
+         var begin = BeginUndo();
+diff --git a/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Template.cs b/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Template.cs
+index efd941c8..3e9de5ba 100644
+--- a/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Template.cs
++++ b/Broiler.JS/Broiler.JavaScript.Parser/FastParser.Template.cs
+@@ -26,7 +26,7 @@ partial class FastParser
+                 continue;
+             }
+ 
+-            if (Expression(out var exp))
++            if (Substitution(out var exp))
+             {
+                 nodes.Add(exp);
+                 continue;
+@@ -36,5 +36,45 @@ partial class FastParser
+         }
+ 
+         return new AstTemplateExpression(begin, PreviousToken, nodes);
++
++        // TemplateSubstitution : ${ Expression[+In] }. That is a full Expression, so a
++        // comma sequence is legal and evaluates to its last element — the shape a
++        // minifier produces when it folds statements into an interpolation
++        // (`` `swiper-wrapper-${n=16,void 0===n&&(n=16),rnd(n)}` ``). Parsing only an
++        // AssignmentExpression left the `,` unconsumed and rejected the script.
++        // Being an [+In] context also means `in` is an operator here even when the
++        // substitution sits inside a `for` head.
++        bool Substitution(out AstExpression node)
++        {
++            var start = stream.Current;
++            var savedIn = considerInOfAsOperators;
++            considerInOfAsOperators = true;
++
++            try
++            {
++                if (!Expression(out node))
++                    return false;
++
++                if (stream.Current.Type != TokenTypes.Comma)
++                    return true;
++
++                var parts = new Sequence<AstExpression> { node };
++
++                while (stream.CheckAndConsume(TokenTypes.Comma))
++                {
++                    if (!Expression(out var part))
++                        throw stream.Unexpected();
++
++                    parts.Add(part);
++                }
++
++                node = new AstSequenceExpression(start, PreviousToken, parts);
++                return true;
++            }
++            finally
++            {
++                considerInOfAsOperators = savedIn;
++            }
++        }
+     }
+ }
+diff --git a/Broiler.JS/Broiler.JavaScript.Parser/FastScanner.cs b/Broiler.JS/Broiler.JavaScript.Parser/FastScanner.cs
+index cd84d0f6..5deb7133 100644
+--- a/Broiler.JS/Broiler.JavaScript.Parser/FastScanner.cs
++++ b/Broiler.JS/Broiler.JavaScript.Parser/FastScanner.cs
+@@ -79,6 +79,26 @@ public class FastScanner
+ 
+     private FastToken lastToken = EmptyToken;
+ 
++    // The last token that was not a LineTerminator. `lastToken` alone cannot answer
++    // "what precedes this `(`" because a head may be written across lines
++    // (`if\n(a)`), and the paren bookkeeping below needs the significant token.
++    private FastToken lastSignificantToken = EmptyToken;
++
++    // One entry per currently-open `(`: whether it opened the head of an
++    // `if` / `for` / `while` / `with` statement. Popped by the matching `)` into
++    // <see cref="lastCloseParenEndedStatementHead"/>, which is what tells a `/`
++    // directly after that `)` apart from division — see ReadCommentsOrRegExOrSymbol.
++    private readonly System.Collections.Generic.Stack<bool> parenIsStatementHead = new();
++    private bool lastCloseParenEndedStatementHead;
++
++    // `if` / `for` / `while` / `with` are the statements whose parenthesised head is
++    // followed by a Statement, so a `/` after the closing `)` begins a regular
++    // expression literal rather than dividing the head's value.
++    private static bool OpensStatementHead(FastToken token)
++        => token.IsKeyword
++            && token.Keyword is FastKeywords.@if or FastKeywords.@for
++                or FastKeywords.@while or FastKeywords.with;
++
+     /// <summary>
+     /// Whether <c>yield</c> is currently a keyword (set by the parser when it enters
+     /// a generator body). This governs the regex-vs-division decision for a <c>/</c>
+@@ -238,6 +258,8 @@ public class FastScanner
+     private FastToken ReadToken()
+     {
+         lastToken = _ReadToken();
++        if (lastToken.Type != TokenTypes.LineTerminator)
++            lastSignificantToken = lastToken;
+         return lastToken;
+     }
+ 
+@@ -324,9 +346,14 @@ public class FastScanner
+                 return ReadSymbol(state, TokenTypes.Comma);
+ 
+             case '(':
++                parenIsStatementHead.Push(OpensStatementHead(lastSignificantToken));
+                 return ReadSymbol(state, TokenTypes.BracketStart);
+ 
+             case ')':
++                // An unbalanced `)` is a syntax error the parser reports; here it only
++                // has to not corrupt the stack for whatever follows.
++                lastCloseParenEndedStatementHead = parenIsStatementHead.Count > 0
++                    && parenIsStatementHead.Pop();
+                 return ReadSymbol(state, TokenTypes.BracketEnd);
+ 
+             case '[':
+@@ -1046,6 +1073,15 @@ public class FastScanner
+         switch (last.Type)
+         {
+             case TokenTypes.BracketEnd:
++                // A `/` after `)` divides the parenthesised value — unless that `)`
++                // closed the head of an `if` / `for` / `while` / `with`, whose body is a
++                // Statement and may perfectly well start with a regular-expression
++                // literal. Minifiers emit exactly that shape for a one-statement body:
++                // `for(i=0;i<n;i++)/^ *-+: *$/.test(a[i])?…`. Read as division the regex
++                // then fails to close and the whole script is rejected.
++                scanRegExp = lastCloseParenEndedStatementHead;
++                break;
++
+             case TokenTypes.SquareBracketEnd:
+             case TokenTypes.Number:
+                 // probably not regexp...
+@@ -1133,6 +1169,15 @@ public class FastScanner
+                     break;
+ 
+                 case TokenTypes.BracketEnd:
++                    // See the BracketEnd case above: only a `)` that closed an
++                    // `if`/`for`/`while`/`with` head can be followed by a regex.
++                    if (!lastCloseParenEndedStatementHead)
++                    {
++                        token = null;
++                        return false;
++                    }
++                    break;
++
+                 case TokenTypes.SquareBracketEnd:
+                     token = null;
+                     return false;
+diff --git a/Broiler.JS/Broiler.JavaScript.Parser/FastTokenStream.cs b/Broiler.JS/Broiler.JavaScript.Parser/FastTokenStream.cs
+index 2e31a988..9bf057ee 100644
+--- a/Broiler.JS/Broiler.JavaScript.Parser/FastTokenStream.cs
++++ b/Broiler.JS/Broiler.JavaScript.Parser/FastTokenStream.cs
+@@ -22,6 +22,51 @@ public class FastTokenStream
+         return new FastParseException(c, $"Unexpected token {c.Type}: {c.Span} at {c.Start}");
+     }
+ 
++    /// <summary>
++    /// Reports a statement that could not be parsed, naming both its first token and the
++    /// point the parse actually reached.
++    /// </summary>
++    /// <remarks>
++    /// A production that gives up by returning false (rather than throwing) rewinds the
++    /// stream to where it started, so the only token left to blame is the one the
++    /// statement began with. On a minified bundle — one statement per file, starting at
++    /// character 1 — that turned every such failure into the same unusable report,
++    /// "Unexpected token Negate: ! at 1, 1", pointing at the `!` of a `!function(){…}()`
++    /// wrapper hundreds of kilobytes away from the actual problem. <see cref="Furthest"/>
++    /// survives the rewind and says where the parser really stopped.
++    /// </remarks>
++    internal Exception UnexpectedStatement()
++    {
++        var c = Current;
++        var stopped = furthest;
++
++        if (stopped == null || ReferenceEquals(stopped, c))
++            return Unexpected();
++
++        // The EOF token is a shared singleton with no source position, so it can only be
++        // named, not located — and naming it is the important case: it is what a truncated
++        // script (a response that ended early) looks like from in here.
++        var where = stopped.Type == TokenTypes.EOF
++            ? "the end of the script"
++            : stopped.Span.Offset > c.Span.Offset
++                ? $"{stopped.Type} at {stopped.Start}"
++                : null;
++
++        if (where == null)
++            return Unexpected();
++
++        return new FastParseException(c,
++            $"Unexpected token {c.Type}: {c.Span} at {c.Start}"
++            + $" — the statement starting here could not be parsed; the parse stopped at {where}");
++    }
++
++    /// <summary>
++    /// The furthest token the parser has advanced to. Backtracking rewinds
++    /// <see cref="Current"/> through the already-scanned token list, so this high-water
++    /// mark is the only surviving record of how far a failed parse got.
++    /// </summary>
++    private FastToken furthest;
++
+     public override string ToString() => $"{Current} {Next}";
+ 
+     public readonly FastKeywordMap Keywords;
+@@ -338,6 +383,9 @@ public class FastTokenStream
+             current ??= scanner.Token;
+         }
+ 
++        if (furthest == null || current.Span.Offset > furthest.Span.Offset)
++            furthest = current;
++
+         return current;
+     }
+ 
+diff --git a/Broiler.JS/Broiler.JavaScript.Parser/RegExpValidator.cs b/Broiler.JS/Broiler.JavaScript.Parser/RegExpValidator.cs
+index 305cb025..01e67419 100644
+--- a/Broiler.JS/Broiler.JavaScript.Parser/RegExpValidator.cs
++++ b/Broiler.JS/Broiler.JavaScript.Parser/RegExpValidator.cs
+@@ -652,15 +652,22 @@ internal static class RegExpValidator
+                         sb.Append(pattern[++i]);
+                     continue;
+                 }
+-                else if (!inClass
+-                    && !IsRegExpSyntaxCharacter(next)
++                else if (!IsRegExpSyntaxCharacter(next)
+                     && !(next >= '0' && next <= '9')
+-                    && RecognizedEscapeLetters.IndexOf(next) < 0)
++                    && RecognizedEscapeLetters.IndexOf(next) < 0
++                    // Inside a character class `-` is the range operator, so `\-` has to
++                    // keep its backslash — dropping it turns `[a\-z]` (three literals)
++                    // into the range `[a-z]`.
++                    && !(inClass && next == '-'))
+                 {
+                     // Annex B IdentityEscape of any character that is not a recognized
+                     // escape and not a SyntaxCharacter (`\C`, `\P`, `\_`, an accented
+                     // letter, a combining mark, …) → the literal character. .NET rejects
+                     // `\` + such a character; escaped or not it matches the same thing.
++                    // ClassEscape reaches CharacterEscape → IdentityEscape too, so this
++                    // holds inside a character class as well: `/[^0-9a-zA-Z\-\_]/` is a
++                    // valid literal, and rejecting it made the scanner re-read the `/`
++                    // as division and fail the whole script.
+                     sb.Append(next);
+                     i++;
+                     continue;
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,149 @@
+# Submodule patches waiting to be applied
+
+**One patch is waiting on a maintainer.** See the index below.
+
+`Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
+are git submodules with their own remotes. A session whose GitHub scope is this
+repository alone cannot push to them — the git proxy answers **403** — so a fix
+that belongs in a submodule is committed there, exported with
+`git format-patch`, and left here for a maintainer to apply. The submodule
+working tree is then reverted to its pinned commit and **the gitlink is not
+bumped**: CI clones a submodule by pointer, and a pointer to a commit that was
+never pushed would break the build.
+
+Applying one:
+
+```sh
+cd <Submodule>
+git checkout -b <branch> && git am ../patches/NNNN-<slug>.patch
+git push origin HEAD
+cd .. && git add <Submodule>      # bump the pointer only once the push succeeds
+```
+
+## This directory is a backlog, not an archive
+
+A patch is deleted from here the moment its fix is upstream and the submodule
+pointer is bumped, because from then on it reaches CI through the pointer and a
+file that can only ever be skipped is noise. `scripts/apply-pending-wpt-patches.sh`
+holds the matching list — the subset whose fix can move rendered pixels, so a
+WPT run exercises it rather than testing against the un-fixed pointer — and is
+idempotent, so a patch already contained in the pinned pointer is skipped rather
+than re-applied.
+
+**Check the pointer, not this file, before concluding a fix is pending.** The
+numbering is *recycled*: numbers are assigned from `0001` against whatever the
+directory holds at the time, so a patch number in an older commit message, code
+comment or document does **not** identify the same change as today's patch of
+that number. Prose that names a patch by number alone is evidence about the past
+only. To decide whether a submodule fix is live, look for its commit:
+
+```sh
+git -C <Submodule> log --oneline --grep '<the commit subject>'
+git -C <Submodule> merge-base --is-ancestor <sha> HEAD && echo "live on CI"
+```
+
+The directory was empty when this patch was added, which is why the numbering
+restarts at `0001` again.
+
+## The index
+
+| # | submodule | subject |
+| --- | --- | --- |
+| `0001` | `Broiler.JS` | Parse the minified JavaScript real sites serve |
+
+### `0001` — five shapes that minifier output produces and FastParser rejected
+
+A parse failure is total. One token the parser will not accept and the whole
+script fails to compile, so nothing on the page runs — which is why each of
+these is worth more than the small grammar corner it looks like. All five were
+found the same way: by running `FastParser` over the scripts live sites actually
+serve, so each is named here by the script that produced it.
+
+* **A `/` after the `)` of a statement head was read as division.** The head of
+  an `if` / `for` / `while` / `with` is followed by a *Statement*, which may
+  perfectly well begin with a regular expression literal. marked.js — bundled
+  into monaco-editor, and into the page bundles of several news sites — walks a
+  markdown table's alignment row with
+  `for(i=0;i<n;i++)/^ *-+: *$/.test(a[i])?…`. Read as division the regex never
+  closes and the file is rejected. The scanner now records, for each open paren,
+  whether it opened a statement head, and only a `)` that closed one allows a
+  regex after it. Every other `)` still divides, which the
+  `SlashAfterOtherParenthesis_IsStillDivision` theory and the evaluating
+  `SlashAfterCallOrGrouping_StillDivides` test bound from the other side.
+
+* **A template substitution parsed only an AssignmentExpression.** `${ … }` is a
+  full `Expression`, so a comma sequence belongs there; swiper-bundle.min.js
+  folds an entire initialisation into one interpolation. The `,` was left
+  unconsumed and the script rejected.
+
+* **An object *binding* pattern rejected a reserved word as a PropertyName.** A
+  PropertyName is an IdentifierName, and the object *literal* path already
+  accepted these — only the pattern path did not, because `false` / `true` /
+  `null` / `in` / `instanceof` lex to token types of their own rather than
+  `Identifier`. TypeScript's own bundle destructures groupBy's result as
+  `const { false: decorators, true: metadata } = …`. The shorthand form stays an
+  error: a reserved word is a legal key and never a legal BindingIdentifier.
+  `export { x as in }` is allowed for the same reason — a ModuleExportName is an
+  IdentifierName, and it is what minified re-export lists come to.
+
+* **The `[~In]` of a `for` head leaked into every nested context.** A function
+  body, an arrow, a call's arguments and a template substitution are each `[+In]`
+  in their own right, so an `in` inside one of them within a for-head is an
+  ordinary operator. core-js and its many re-bundles install properties from
+  exactly that shape: `for (var i = 0, E = function (e) { e in C || define(C, e) }; …)`.
+  The head's own top level still suppresses `in`, so a for-in loop is unaffected
+  (`ForInHead_StillSuppressesInAtItsTopLevel`).
+
+* **An Annex B IdentityEscape was neutralised only outside a character class.**
+  `ClassEscape` reaches `IdentityEscape` too, so `/[^0-9a-zA-Z\-\_]/` is a valid
+  literal — Adobe Launch's bundle sanitises input with precisely it. Failing the
+  .NET validity check made the scanner fall back to reading the `/` as division
+  and the file failed. `\-` keeps its backslash inside a class, where `-` is the
+  range operator.
+
+**Also in this patch: the report a failed statement produces.** When a production
+gives up by returning false rather than throwing, it rewinds to where the
+statement started, so the only token left to blame is the statement's first one —
+and in a minified bundle that is character 1 of the file. Every such failure
+therefore read `Unexpected token Negate: ! at 1, 1`, pointing at the `!` of a
+`!function(){…}()` wrapper however far away the real problem was. That is the
+report this patch started from. `FastTokenStream` now keeps a high-water mark
+that survives the rewind, and `UnexpectedStatement` names where the parse
+actually stopped — including "the end of the script" for a source that ended
+early, which is what a truncated response looks like from inside the parser.
+
+**Tests.** 54 parser cases covering each shape and its counterpart, plus
+`MinifiedScriptParsingTests`, which *evaluates* every shape rather than only
+parsing it: two of these fixes change how a token is read (`/` as a regex
+delimiter, `in` as an operator), and a source that parses into the wrong tree is
+exactly the failure parse-success cannot see. `Broiler.JavaScript.Parser.Tests`
+is 184/184, `Broiler.JavaScript.Integration.Tests` 4627/4628 (the one failure,
+`M8ValidationTests.M8_DocumentationFiles_Exist`, is a docs-layout check that
+fails identically on the un-patched pointer) and
+`Broiler.JavaScript.Compiler.Tests` 1318/1318.
+
+**Why it is not listed in `scripts/apply-pending-wpt-patches.sh`.** It could be —
+a script that does not parse renders nothing, which is the failure a pixel suite
+exists to catch — but that argument needs a WPT test that actually uses one of
+these shapes, and there is no evidence any does: every one of the five was found
+in *minifier output*, and WPT's tests are hand-written. Listing an entry that can
+only ever skip is noise, and a listed entry that later drifts against the pointer
+fails the script and takes the whole run down with it. The precedent is the
+direct-eval patch (`Broiler.JS` 60c9182a), which was never listed for the same
+reason: it decides whether page script runs at all rather than what any of it
+paints.
+
+**Where it came from.** A `FastParseException` from a Google search page, reported
+as `Unexpected token Negate: ! at 1, 1` — a report that, for the reason above,
+does not say which script failed or where. The five fixes here are what a sweep of
+real-world scripts turned up while chasing it; whether one of them is *that*
+script's failure is not established, because the page that produced it could not
+be reproduced from this container (Google serves it a script-light variant).
+
+**A gap this patch does not close.** `export { a, b };` — a NamedExports list with
+no `from` clause — is still rejected outright ("Expecting keyword from"), which
+takes down a whole module. It accounted for 12 of the 21 remaining failures in the
+sweep. It is not fixed here because the parser is only half of it: `AstExportStatement`
+has no shape for a source-less export list and `VisitExportStatement` has no case
+for one, so accepting it in the parser alone would produce a module that parses
+and then exports nothing. That is module-linking work, not a parser fix.


### PR DESCRIPTION
This patch fixes five parsing failures in FastParser that occur with minified JavaScript from production sites. Each failure is total — one rejected token and the entire script fails to compile, preventing any code on the page from running.

## Summary

The parser rejected valid JavaScript shapes that minifiers produce constantly. All five issues were discovered by running FastParser against scripts from live sites. This patch also improves error reporting for failed statements by tracking how far parsing actually progressed, rather than only reporting the statement's first token.

## Key Changes

**Parser fixes for minified code:**

- **Regex after statement heads**: A `/` directly after `)` in `if`/`for`/`while`/`with` statements now correctly opens a regex literal rather than being read as division. The scanner tracks which open parens opened statement heads, allowing only those closing parens to be followed by regex. This fixes marked.js (bundled in monaco-editor and news site bundles) which uses `for(...)/^ *-+: *$/.test(...)` to walk markdown table alignment rows.

- **Template substitution comma sequences**: Template substitutions now parse full `Expression` instead of just `AssignmentExpression`, allowing comma sequences like `` `${a, b}` ``. This fixes swiper-bundle.min.js which folds entire initializations into interpolations.

- **Reserved words in binding patterns**: Object binding patterns now accept reserved words (`false`, `true`, `null`, `in`, `instanceof`) as property names, matching the object literal path. The shorthand form correctly remains rejected since reserved words are never valid BindingIdentifiers. This fixes TypeScript's own bundle which destructures `const { false: decorators, true: metadata } = groupBy(...)`.

- **`in` operator in nested contexts of for-heads**: The `[~In]` suppression of a `for` head no longer leaks into nested contexts (function bodies, arrows, call arguments, template substitutions), which are `[+In]` in their own right. For-in loops remain unaffected at the head's top level. This fixes core-js and its re-bundles which use `for (var i = 0, f = function(e) { e in C || ... }; ...)`.

- **Identity escapes in regex character classes**: Annex B identity escapes like `\-` and `\_` are now valid inside character classes. This fixes Adobe Launch's bundle which sanitizes with `/[^0-9a-zA-Z\-\_]/g`.

**Error reporting improvement:**

- Failed statements now report where parsing actually stopped (via a high-water mark in `FastTokenStream`) rather than only the statement's first token. For truncated scripts, the report includes "the end of the script" instead of pointing at character 1 of a minified bundle.

## Testing

- 54 new parser test cases covering each shape and its counterpart (e.g., `/` after other `)` still divides, for-in heads still suppress `in`, reserved-word shorthands still error)
- New `MinifiedScriptParsingTests` integration tests that *evaluate* each shape to verify correct parsing, not just successful parsing — two fixes change token reading (`/` as regex vs division, `in` as operator vs for-in marker)

## Files Modified

- `FastParser.Template.cs`: Template substitutions now parse full expressions with comma support
- `FastParser.ArrayExpression.cs`: Arguments restore `[+In]` context
- `FastParser.Expression.cs`: Arrow functions restore `[+In]` context  
- `FastParser.Function.cs`: Function bodies and parameters restore `[+In]` context
- `FastParser.AssignmentLeftPattern.cs`: Binding patterns accept reserved word property names
- `FastParser.PropertyName.cs`: New `IsKeywordPropertyName` helper for reserved words as identifiers
- `FastScanner.cs`: Tracks statement-head parens to distinguish regex from division after `)`
- `FastTokenStream.cs`: High-water mark for error reporting and `UnexpectedStatement` method
- `RegExpValidator.cs`: Identity escapes valid in character classes
- Tests: 54 parser cases + 8 integration evaluation tests

https://claude.ai/code/session_012UZP4yc8L1ouwtJpjeb6gE