### PR TITLE
Give an iframe's contentWindow the standard JavaScript globals, and make caught throws visible

### DIFF
--- a/src/Broiler.HtmlBridge.Dom/Features/SubWindowBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubWindowBinding.cs
@@ -39,6 +39,74 @@ internal sealed class SubWindowBinding(
     private readonly EventTargetRegistry _eventTargets = eventTargets;
     private readonly MessagingBinding _messaging = messaging;
 
+    /// <summary>
+    /// The globals published on a sub-window: the event constructors it has always mirrored, plus the
+    /// standard JavaScript ones.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A sub-window used to carry <c>document</c>, <c>location</c> and the event constructors and
+    /// nothing else, so <c>iframe.contentWindow.String</c> — and <c>Object</c>, <c>Array</c>,
+    /// <c>Function</c>, <c>JSON</c>, <c>Math</c>, every one of them — read as <c>undefined</c>. In a
+    /// browser a nested browsing context is a full global object, and script reaches for exactly
+    /// these: taking a reference to a built-in from a fresh frame, rather than from the current
+    /// global, is the standard way to get one that page script has not patched. Google Search's
+    /// anti-abuse bundle does it on the first run of its interpreter — <c>contentWindow.String</c>,
+    /// then <c>.prototype</c> — and reading <c>prototype</c> off <c>undefined</c> threw, which
+    /// derailed the interpreter into decoding its own bytecode wrongly for the rest of the page.
+    /// </para>
+    /// <para>
+    /// These are the PARENT realm's objects, not a realm of the frame's own: <c>contentWindow.String
+    /// === String</c> here, where a browser gives two distinct functions. Broiler runs every document
+    /// in one JavaScript context, so a per-frame realm is not something this binding can conjure —
+    /// and identity is the lesser problem. Code that harvests a built-in gets a working built-in;
+    /// only code that compares the two for identity can tell, and it gets a defensible answer either
+    /// way, where <c>undefined</c> was defensible to nobody.
+    /// </para>
+    /// <para>
+    /// Names the context does not define are skipped, so this list may name more than Broiler has.
+    /// </para>
+    /// </remarks>
+    private static readonly string[] MirroredGlobals =
+    [
+        // Event constructors — mirrored since P3.17.
+        "Event", "CustomEvent", "MouseEvent", "FocusEvent", "KeyboardEvent",
+        "WheelEvent", "UIEvent", "MessageChannel",
+
+        // Fundamental objects and their namespaces.
+        "Object", "Function", "Boolean", "Symbol", "Math", "JSON", "Reflect",
+
+        // Numbers, text and time.
+        "Number", "BigInt", "String", "Date", "RegExp",
+
+        // Collections.
+        "Array", "Map", "Set", "WeakMap", "WeakSet", "WeakRef",
+
+        // Errors.
+        "Error", "TypeError", "RangeError", "SyntaxError", "ReferenceError",
+        "EvalError", "URIError", "AggregateError",
+
+        // Binary data.
+        "ArrayBuffer", "SharedArrayBuffer", "DataView", "Int8Array", "Uint8Array",
+        "Uint8ClampedArray", "Int16Array", "Uint16Array", "Int32Array", "Uint32Array",
+        "Float32Array", "Float64Array", "BigInt64Array", "BigUint64Array",
+
+        // Control flow and metaprogramming.
+        "Promise", "Proxy", "Intl",
+
+        // Global functions and value properties.
+        "eval", "parseInt", "parseFloat", "isNaN", "isFinite",
+        "encodeURI", "encodeURIComponent", "decodeURI", "decodeURIComponent",
+        "NaN", "Infinity", "undefined",
+
+        // Web globals a frame's script reaches for as readily as the language ones.
+        "console", "navigator", "fetch", "XMLHttpRequest", "URL", "URLSearchParams",
+        "TextEncoder", "TextDecoder", "Blob", "AbortController", "Headers",
+        "setTimeout", "clearTimeout", "setInterval", "clearInterval",
+        "requestAnimationFrame", "cancelAnimationFrame", "queueMicrotask",
+        "atob", "btoa", "structuredClone", "performance", "crypto",
+    ];
+
     /// <summary>Gets or builds the sub-window JS object for a nested-browsing-context container.</summary>
     public JSObject GetOrCreate(DomElement containerElement)
     {
@@ -89,11 +157,9 @@ internal sealed class SubWindowBinding(
         subWindow.FastAddValue((KeyString)"self", subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
         subWindow.FastAddValue((KeyString)"window", subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
 
-        foreach (var ctorName in new[]
-                 {
-                     "Event", "CustomEvent", "MouseEvent", "FocusEvent", "KeyboardEvent",
-                     "WheelEvent", "UIEvent", "MessageChannel",
-                 })
+        subWindow.FastAddValue((KeyString)"globalThis", subWindow, JSPropertyAttributes.EnumerableConfigurableValue);
+
+        foreach (var ctorName in MirroredGlobals)
         {
             if (_host.GetGlobal(ctorName) is { } ctor)
                 subWindow.FastAddValue((KeyString)ctorName, ctor, JSPropertyAttributes.EnumerableConfigurableValue);


### PR DESCRIPTION
## Summary

Google Search still failed after the parser fix that landed in #1702, with the same
`TypeError: Cannot read properties of undefined (reading 'removeEventListener')` deep in its
anti-abuse bundle. This is the second, independent cause — plus the diagnostic that made it
findable.

Two changes:

1. **`Broiler.JS`** — an opt-in sink that reports null/undefined property throws *at the point they
   are raised*, so a throw the page catches is still visible.
2. **`Broiler.HtmlBridge.Dom`** — an iframe's `contentWindow` now exposes the standard JavaScript
   globals. This is the actual bug.

## Why the crash was invisible

The reported exception is raised and then **caught by the page**. `javascript-errors.log` only
records what escapes to the host, so a caught throw leaves no trace — the right default, since
feature detection reads properties off `undefined` constantly. Visual Studio showed it only because
a debugger breaks on first-chance exceptions; without one it was silent.

`JSException.LogThrows` could not close that gap: it is compiled out of Release, and the
property-access TypeErrors never reach `JSException.Throw` in *any* configuration — they are raised
straight from `JSValue`/`JSUndefined`/`JSNull`. The one thing its documentation promised to cover
was the one thing it could not.

`JSThrowDiagnostics` is that equivalent: present in Release, called at the raise point, and carrying
the **JavaScript** stack (the CLR frames are the same few engine methods every time; the script
frames name the line that did the read, and they are gone by the time a handler sees the exception).

```
BROILER_LOG_JS_THROWS=1              # stderr
BROILER_LOG_JS_THROWS=/path/to.log   # append to a file (a windowed host has no console)
```

```
[js-throw] read: Cannot read properties of undefined (reading 'removeEventListener')
    at inline:vm12.js:5538,33783
    ...
    at ia:inline-3:9,1027
    at la:inline-3:13,24
```

Off unless asked for; costs one static read when no sink is installed.

## The bug

With that logging, the failure reproduced immediately — and a deterministic offline replay of a
captured page let the bundle's interpreter be traced against Chromium opcode-by-opcode. The first
divergence is its **99th instruction**:

| step | operation | Chromium | Broiler |
| --- | --- | --- | --- |
| op96 | read `contentWindow` off a hidden iframe | object | object |
| op98 | read `String` off that window | object | object |
| op99 | read `prototype` off that | **`function`** | **`undefined`** |

A sub-window carried `document`, `location` and eight event constructors and nothing else, so
`contentWindow.String` — and `Object`, `Array`, `Function`, `JSON`, `Math`, every one of them — read
as `undefined`. Taking a built-in from a fresh frame rather than the current global is the standard
way to get one page script has not patched, so this is a shape real sites rely on.

Reading `prototype` off `undefined` threw, and from there the interpreter decoded its own bytecode
wrongly for the rest of the page: its remove-listener opcode ran **210 times** against register
slots holding a sentinel number instead of a listener triple — which is exactly the reported crash.
Chromium never reaches that opcode at all.

## Results

On the captured page that reproduces it:

| measure | before | after | Chromium |
| --- | --- | --- | --- |
| `removeEventListener` TypeErrors | 210 | **0** | 0 |
| interpreter-internal errors | 3000+ (capped) | **30** | 11 |
| opcodes executed | 7702 | **597** | 829 |
| first trace divergence | op 347 | **op 549** | — |

Live, across 8 captures of the reported URL: JavaScript throws **~29,000 → 4**.

A residual remains (1 `removeEventListener` in 8 live runs, matching the op-549 divergence) — real
but now rare, and no longer the dominant failure.

## Note on the realm

These are the **parent realm's** objects, not a realm of the frame's own: `contentWindow.String ===
String` here, where a browser gives two distinct functions. Broiler runs every document in one
JavaScript context, so a per-frame realm is not something this binding can conjure. Code that
harvests a built-in now gets a working one; only an identity comparison can tell the difference,
and it gets a defensible answer either way, where `undefined` was defensible to nobody.

## Testing

| suite | result |
| --- | --- |
| `Broiler.JavaScript.Compiler.Tests` | 1343 / 1343 |
| `Broiler.JavaScript.BuiltIns.Tests` | 2139 / 2139 |
| `Broiler.JavaScript.Integration.Tests` | 4966 / 4967 (1 pre-existing: `docs/roadmap.md` fixture) |
| `Broiler.JavaScript.Runtime.Tests` | 11 / 11 |
| `Broiler.Browser.Core.Tests` | 98 / 98 |
| `Broiler.Cli.Tests` (Google / iframe / script-engine classes) | 23 failures **with and without** these changes — exact parity, pre-existing/environmental |

The remaining `Broiler.Cli.Tests` failures are the PDF-conversion, flex-layout, WPT-render and
CSS-extraction classes CLAUDE.md documents as failing in a bare container (missing `Broiler.HTML`
sources, fonts, `Broiler.Pdf`). The engine change is inert without a sink; the iframe change only
adds properties.

Line endings in the mixed CRLF/LF submodule files were verified byte-for-byte unchanged (83 / 7 / 3
CRLF lines preserved), keeping the diff at 28 insertions rather than a whole-file rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wSPjtZDRNS22i4gx5tzqd

---
_Generated by [Claude Code](https://claude.ai/code/session_011wSPjtZDRNS22i4gx5tzqd)_