### PR TITLE
Carry direct eval bindings into nested closures and callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,22 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `Broiler.JS` (patch `0002`) — a closure that a directly-evalled function created was
+  handed none of the eval's bindings, so one level of nesting decided whether a name
+  resolved: `f = eval("0,function(){ return function(){ return b; }; }")` gave `f()`
+  the caller's `b` and `f()()` a `ReferenceError`. The eval's overlay is withdrawn when
+  it returns, and the snapshot the *outer* function carries was not consulted when the
+  inner one was built — although it is the only trace of that scope left. Google Search's
+  bot-detection VM is exactly that shape, evaluating its opcode handlers with
+  `function(X){return eval(X)}(src)` and building a closure inside them on nearly every
+  step, so the challenge died on a `g is not defined` and the page rendered as the
+  interstitial. Two neighbours dropped the same scope and are fixed with it: a function
+  invoked from a builtin's callback (`Array.prototype.map`, `Set`/`Map.prototype.forEach`,
+  a JSON reviver or replacer) had neither its eval bindings nor its captured `with` chain
+  re-established, so the same closure worked when JavaScript called it and threw when a
+  builtin did; and `typeof` answered `"undefined"` for a name the very next read produced
+  a value for, because its non-throwing resolver never consulted the capture.
+
 - `Broiler.Layout` — an `<img>` whose source came from `srcset` loaded nothing at all.
   The engine read the `src` attribute and nothing else, so a responsive image and every
   `<picture>` had no source and painted the missing-image border. HTML §4.8.4.3's *select

--- a/patches/0002-carry-eval-bindings-into-nested-closures.patch
+++ b/patches/0002-carry-eval-bindings-into-nested-closures.patch
@@ -1,0 +1,354 @@
+From 028cefc0b665e9f332be874494a046f3551ec9bc Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Tue, 18 Aug 2026 21:17:44 +0000
+Subject: [PATCH] Carry a direct eval's bindings into the closures its
+ functions create
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+A function a direct eval produced keeps the eval site's bindings: it carries a
+snapshot of the overlay, taken while the eval was still running. A function
+*that* function creates when it later runs was handed nothing, because by then
+the eval had returned and there was no overlay left to snapshot. So one level of
+nesting decided whether a name resolved:
+
+    f = eval("0,function(){ return function(){ return b; }; }");
+    f()      // fine
+    f()()    // ReferenceError: b is not defined
+
+google.com's bot-detection VM is exactly that shape — its opcode handlers are
+evaluated with `function(X){return eval(X)}(src)` and build a closure inside them
+on nearly every step — which is what made it a "g is not defined" there, one
+nesting level past the "b is not defined" the capture already fixed.
+
+The scope the RUNNING function carries is the lexical environment of everything
+it creates, and it is the only trace of the eval left once the eval has returned,
+so CaptureDirectEvalBindings now folds it in — outermost, so an inner scope's
+binding of the same name still wins.
+
+Two more places dropped the same scope:
+
+- A native callback site is a [[Call]] like any other, but InvokeCallback
+  re-established none of the scopes a function closed over. A closure resolved
+  its free names from JavaScript and threw the moment it was handed to
+  Array.prototype.map, Set/Map.prototype.forEach, a JSON reviver or replacer —
+  and a function created inside `with (o)` lost o the same way. It now enters
+  the same four scopes InvokeFunction does, and only when the function actually
+  carries some, so an ordinary callback costs what it did.
+
+- `typeof` resolves through its own non-throwing path, which never consulted the
+  capture: it answered "undefined" for a name the very next read produced a value
+  for. It consults it now, skipping a deleted binding — `delete` unresolves the
+  reference, so there a read throws and `typeof` is genuinely "undefined".
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01XWeFAXx84RrmBr8zNwmDUn
+---
+ .../Function/JSFunction.cs                    |  49 ++++++++
+ .../CapturedScopeCallbackTests.cs             | 114 ++++++++++++++++++
+ .../DirectEvalClosureScopeTests.cs            |  37 ++++++
+ .../Broiler.JavaScript.Engine/JSContext.cs    |  39 +++++-
+ 4 files changed, 238 insertions(+), 1 deletion(-)
+ create mode 100644 Broiler.JS/Broiler.JavaScript.Compiler.Tests/CapturedScopeCallbackTests.cs
+
+diff --git a/Broiler.JS/Broiler.JavaScript.BuiltIns/Function/JSFunction.cs b/Broiler.JS/Broiler.JavaScript.BuiltIns/Function/JSFunction.cs
+index c7d05da0..be9181b8 100644
+--- a/Broiler.JS/Broiler.JavaScript.BuiltIns/Function/JSFunction.cs
++++ b/Broiler.JS/Broiler.JavaScript.BuiltIns/Function/JSFunction.cs
+@@ -1032,10 +1032,59 @@ public partial class JSFunction : JSObject, IPropertyAccessor, IJSFunction
+             CallPathDiagnostics.RecordCallbackCall();
+ 
+         using var realmScope = EnterRealm();
++        // A native callback site is still a [[Call]], and the scopes a function CLOSED OVER are
++        // part of what it is. Skipping them here made a closure resolve its free names when
++        // called directly and fail the moment it was handed to Array.prototype.map,
++        // Set/Map.prototype.forEach, a JSON reviver or replacer — `eval("0,function(x){ return
++        // b + x; }")` threw "b is not defined" from inside map and returned b + x from a plain
++        // call, and a function created inside `with (o)` lost o the same way.
++        using var capturedScopes = EnterCapturedScopes();
+         var invocationDelegate = SelectInvocationDelegate();
+         return JSTailCall.Resolve((CoerceThisOnInvoke ? invocationDelegate(a.OverrideThis(CoerceNonStrictThis(a.This))) : invocationDelegate(in a)) ?? JSUndefined.Value);
+     }
+ 
++    /// <summary>
++    /// Re-establishes, for the duration of one invocation, the scopes this function closed over
++    /// but which are not part of its compiled body: a captured <c>with</c> chain, the <c>with</c>
++    /// lexical fallbacks, and the bindings of the direct eval that created it. The same four
++    /// scopes <see cref="InvokeFunction"/> pushes, in the same order.
++    /// </summary>
++    /// <remarks>
++    /// Returns a disposable that does nothing for a function carrying none of them — which is
++    /// almost every function — so the callback path keeps costing what it did.
++    /// </remarks>
++    private CapturedScopeGuard EnterCapturedScopes()
++    {
++        if (CapturedDirectEvalBindings == null && CapturedWithObjects == null && CapturedWithFallbackScopes == null)
++            return default;
++
++        if (JSEngine.Current is not JSContext context)
++            return default;
++
++        return new CapturedScopeGuard(
++            context.Options.ScriptHostMode ? context.SuspendWithScopes() : null,
++            context.PushWithFallbackScopes(CapturedWithFallbackScopes),
++            context.PushWithScopes(CapturedWithObjects),
++            context.PushDirectEvalBindings(CapturedDirectEvalBindings));
++    }
++
++    // Disposes the four scopes in the reverse order they were established, which is what the
++    // stacked `using var` declarations in InvokeFunction do.
++    private readonly struct CapturedScopeGuard(
++        IDisposable suspendedWithScope,
++        IDisposable withFallbackScope,
++        IDisposable withScope,
++        IDisposable directEvalScope) : IDisposable
++    {
++        public void Dispose()
++        {
++            directEvalScope?.Dispose();
++            withScope?.Dispose();
++            withFallbackScope?.Dispose();
++            suspendedWithScope?.Dispose();
++        }
++    }
++
+     // Function.prototype has no own `valueOf`: per the spec it simply inherits
+     // %Object.prototype.valueOf%, so `Function.prototype.hasOwnProperty("valueOf")`
+     // must be false (test262: built-ins/Function/prototype/S15.3.4_A4).
+diff --git a/Broiler.JS/Broiler.JavaScript.Compiler.Tests/CapturedScopeCallbackTests.cs b/Broiler.JS/Broiler.JavaScript.Compiler.Tests/CapturedScopeCallbackTests.cs
+new file mode 100644
+index 00000000..d37c0f5b
+--- /dev/null
++++ b/Broiler.JS/Broiler.JavaScript.Compiler.Tests/CapturedScopeCallbackTests.cs
+@@ -0,0 +1,114 @@
++using Broiler.JavaScript.Engine;
++
++namespace Broiler.JavaScript.Compiler.Tests;
++
++// A closure carries the scopes it was CREATED in — the bindings of the direct eval that created
++// it (see DirectEvalClosureScopeTests) and the `with` chain it was written inside. Neither is part
++// of the compiled body: both are re-established for the duration of a call.
++//
++// [[Call]] from a native builtin took a separate, cheaper path that re-established neither. So the
++// same function resolved its free names when called from JavaScript and threw "b is not defined"
++// the moment it was handed to Array.prototype.map, Set/Map.prototype.forEach, a JSON reviver, or
++// any other builtin that calls back into script — an error that names a binding the reader can see
++// two lines up, raised only on the callback path.
++//
++// google.com reaches this: its bot-detection VM evaluates its own opcode handlers with
++// `function(X){return eval(X)}(src)` and drives them through builtin callbacks.
++public class CapturedScopeCallbackTests
++{
++    private static string Eval(string expression)
++    {
++        using var context = new JSContext();
++        return context.Eval($"String({expression})", "t.js").ToString();
++    }
++
++    // `f` is created by a direct eval and closes over the caller's `b`; `body` then calls it
++    // through one builtin or another.
++    private static string ThroughCallback(string body)
++        => Eval("(function(){ var b = 21;"
++            + " var f = eval('0,function(x){ return b + (x|0); }');"
++            + $" {body} }})()");
++
++    [Theory]
++    // The reported shape: a direct-eval closure handed straight to a builtin.
++    [InlineData("return [1].map(f)[0];", "22")]
++    [InlineData("var r; [1].forEach(function(x){ r = f(x); }); return r;", "22")]
++    [InlineData("var r; [1].forEach(f); return 'ran';", "ran")]
++    [InlineData("return [1].filter(f).length;", "1")]
++    [InlineData("return [1].find(f);", "1")]
++    [InlineData("return [1].some(f);", "true")]
++    [InlineData("return [1].every(f);", "true")]
++    [InlineData("return [1].flatMap(f)[0];", "22")]
++    [InlineData("return [1].reduce(function(a, x){ return f(x); }, 0);", "22")]
++    [InlineData("return [2,1].sort(f).length;", "2")]
++    [InlineData("new Set([1]).forEach(f); return 'ran';", "ran")]
++    [InlineData("new Map([[1,1]]).forEach(f); return 'ran';", "ran")]
++    // A reviver/replacer is called with (key, value), so `f` adds b to the key (""|0 === 0).
++    [InlineData("return JSON.parse('1', f);", "21")]
++    [InlineData("return JSON.stringify(1, f);", "21")]
++    [InlineData("return new Int32Array([1]).map(f)[0];", "22")]
++    [InlineData("return new Int32Array([1]).filter(f).length;", "1")]
++    [InlineData("return Array.from([1], f)[0];", "22")]
++    public void ADirectEvalClosure_ResolvesItsBinding_WhenABuiltinCallsIt(string body, string expected)
++    {
++        Assert.Equal(expected, ThroughCallback(body));
++    }
++
++    // The same call, made from JavaScript — what already worked, and what the callback path
++    // now agrees with.
++    [Fact]
++    public void ADirectEvalClosure_ResolvesItsBinding_WhenCalledDirectly()
++    {
++        Assert.Equal("22", ThroughCallback("return f(1);"));
++    }
++
++    // A `with`-captured closure loses its object environment the same way.
++    [Fact]
++    public void AWithClosure_ResolvesThroughItsObject_WhenABuiltinCallsIt()
++    {
++        Assert.Equal(
++            "22",
++            Eval("(function(){ var o = { b: 21 }; var f;"
++                + " with (o) { f = function(x){ return b + x; }; }"
++                + " return [1].map(f)[0]; })()"));
++    }
++
++    // The binding is shared, not snapshotted, on the callback path too: a write made after the
++    // function was created is visible to the builtin's call of it.
++    [Fact]
++    public void TheBindingIsShared_OnTheCallbackPath()
++    {
++        Assert.Equal(
++            "5",
++            Eval("(function(){ var b = 1; var f = eval('0,function(){ return b; }'); b = 5;"
++                + " return [0].map(f)[0]; })()"));
++    }
++
++    // ...and a write from inside the callback reaches the caller's binding rather than creating
++    // a global.
++    [Fact]
++    public void AWriteFromTheCallback_ReachesTheCallersBinding()
++    {
++        Assert.Equal(
++            "7,undefined",
++            Eval("(function(){ var b = 1; var f = eval('0,function(){ b = 7; }');"
++                + " [0].forEach(f); return b + ',' + typeof globalThis.b; })()"));
++    }
++
++    // What must NOT change: an ordinary closure keeps resolving through its own compiled body,
++    // and a genuinely undeclared name still throws from a callback.
++    [Fact]
++    public void AnOrdinaryClosure_IsUnaffected()
++    {
++        Assert.Equal("22", Eval("(function(){ var b = 21; return [1].map(function(x){ return b + x; })[0]; })()"));
++    }
++
++    [Fact]
++    public void AGenuinelyUndeclaredName_StillThrowsFromACallback()
++    {
++        Assert.Equal(
++            "ReferenceError",
++            Eval("(function(){ var b = 1; var f = eval('0,function(){ return zzNopeCallback; }');"
++                + " try { return [0].map(f)[0]; } catch (e) { return e.constructor.name; } })()"));
++    }
++}
+diff --git a/Broiler.JS/Broiler.JavaScript.Compiler.Tests/DirectEvalClosureScopeTests.cs b/Broiler.JS/Broiler.JavaScript.Compiler.Tests/DirectEvalClosureScopeTests.cs
+index 249e4373..9bcd56cd 100644
+--- a/Broiler.JS/Broiler.JavaScript.Compiler.Tests/DirectEvalClosureScopeTests.cs
++++ b/Broiler.JS/Broiler.JavaScript.Compiler.Tests/DirectEvalClosureScopeTests.cs
+@@ -110,4 +110,41 @@ public class DirectEvalClosureScopeTests
+             Eval("(function(){ var b = 1; try { var f = eval('0,function(){return zzNope;}'); return f(); }" +
+                  " catch (x) { return x.constructor.name; } })()"));
+     }
++
++    // A function the EVALLED function creates when it runs is written inside the eval's scope too,
++    // and until the capture was made to carry through it was handed nothing: the eval had long
++    // returned, so there was no overlay left to snapshot. `f()` resolved `b` and `f()()` threw
++    // "b is not defined" — one level of nesting apart.
++    //
++    // google.com's bot-detection VM is this shape. Its opcode handlers are evaluated with
++    // `function(X){return eval(X)}(src)` and build closures on nearly every step, which is what
++    // made it a "g is not defined" there rather than the "b is not defined" above.
++    [Theory]
++    [InlineData("(function(){ var b = 42; var f = eval('0,function(){ return function(){ return b; }; }'); return f()(); })()", "42")]
++    [InlineData("(function(){ var b = 42; var f = eval('0,function(){ return function(){ return function(){ return b; }; }; }'); return f()()(); })()", "42")]
++    // Created while the evalled function runs, invoked long after everything has returned.
++    [InlineData("(function(){ var b = 42; var s = []; var f = eval('0,function(){ s.push(function(){ return b; }); }');"
++        + " f(); return s[0](); })()", "42")]
++    // Reached through a builtin's callback rather than a plain call.
++    [InlineData("(function(){ var b = 42; var f = eval('0,function(){ return [0].map(function(){ return b; })[0]; }'); return f(); })()", "42")]
++    // A nested direct eval inside the evalled function sees the outer eval's bindings as well.
++    [InlineData("(function(){ var b = 42; var f = eval('0,function(){ return eval(\"0,function(){ return b; }\"); }'); return f()(); })()", "42")]
++    public void AClosureCreatedByAnEvalledFunction_KeepsTheEvalsBindings(string source, string expected)
++    {
++        Assert.Equal(expected, Eval(source));
++    }
++
++    // `typeof` resolves through its own non-throwing path, which did not consult the capture: it
++    // answered "undefined" for a name the very next read produced a value for.
++    [Fact]
++    public void Typeof_AgreesWithTheRead()
++    {
++        Assert.Equal("number,42", Eval("(function(){ var b = 42; var f = eval('0,function(){ return typeof b + \",\" + b; }'); return f(); })()"));
++    }
++
++    [Fact]
++    public void Typeof_StillAnswersUndefined_ForAGenuinelyUndeclaredName()
++    {
++        Assert.Equal("undefined", Eval("(function(){ var b = 1; var f = eval('0,function(){ return typeof zzNopeTypeof; }'); return f(); })()"));
++    }
+ }
+diff --git a/Broiler.JS/Broiler.JavaScript.Engine/JSContext.cs b/Broiler.JS/Broiler.JavaScript.Engine/JSContext.cs
+index ad5ad27c..594e2bb1 100644
+--- a/Broiler.JS/Broiler.JavaScript.Engine/JSContext.cs
++++ b/Broiler.JS/Broiler.JavaScript.Engine/JSContext.cs
+@@ -730,6 +730,20 @@ public class JSContext : JSObject, IJSExecutionContext, IJSFeatureResolver, IDis
+     /// <summary>Snapshots the direct-eval bindings in scope, for a function to carry.</summary>
+     public Dictionary<uint, JSVariable>[] CaptureDirectEvalBindings()
+     {
++        // The eval scope the RUNNING function carries is the lexical environment of every function
++        // it creates, and it is the only trace of the eval left once the eval has returned. A
++        // function the eval produced keeps working — it carries the snapshot — but a function
++        // *that* function creates when it runs was, until this line, handed nothing:
++        //
++        //   f = eval("0,function(){ return function(){ return b; }; }");  f()()  // b is not defined
++        //
++        // The inner function is written inside the eval's scope exactly as the outer one is, so it
++        // must carry the same bindings. Collected FIRST, so an inner scope's binding of the same
++        // name overwrites it below. (google.com's bot-detection VM evaluates its opcode handlers
++        // this way and builds a closure inside them on nearly every step, which is what made this
++        // a "g is not defined" there.)
++        var carried = capturedDirectEvalScope;
++
+         // The caller's bindings reach a direct eval as an overlay on globalVars, installed for the
+         // duration of the eval and withdrawn when it returns. That is why a closure the eval
+         // creates loses them: nothing is wrong while the eval runs, and the names simply cease to
+@@ -737,10 +751,24 @@ public class JSContext : JSObject, IJSExecutionContext, IJSFeatureResolver, IDis
+         if (activeDirectEvalScopes.Count == 0)
+         {
+             var fromFrames = Frames.CaptureDirectEvalBindings();
+-            return fromFrames;
++            if (carried == null)
++                return fromFrames;
++
++            // Frame bindings are inner to the carried snapshot, so they come after it: the walk in
++            // TryResolveCapturedDirectEvalBinding runs from the end and takes the first hit.
++            return fromFrames == null ? carried : [.. carried, .. fromFrames];
+         }
+ 
+         var bindings = new Dictionary<uint, JSVariable>();
++        if (carried != null)
++        {
++            foreach (var map in carried)
++            {
++                foreach (var pair in map)
++                    bindings[pair.Key] = pair.Value;
++            }
++        }
++
+         // Outermost first, so an inner scope's binding overwrites an outer one of the same name.
+         for (var i = 0; i < activeDirectEvalScopes.Count; i++)
+             activeDirectEvalScopes[i].CollectOverlayBindings(bindings);
+@@ -1588,6 +1616,15 @@ public class JSContext : JSObject, IJSExecutionContext, IJSFeatureResolver, IDis
+         if (!GetInternalProperty(name).IsEmpty)
+             return this[name];
+ 
++        // The same last resort ResolveIdentifierWithoutWithScopes takes, so `typeof` agrees with a
++        // read: a closure a direct eval created resolves the eval site's bindings, and answering
++        // "undefined" here said the binding did not exist while reading it produced its value.
++        // A DELETED binding is the one case where the two must differ — `delete` unresolves the
++        // reference, so a read throws and `typeof` is "undefined" — and an uninitialized one still
++        // throws through GetValue, which is what `typeof` owes a binding in its temporal dead zone.
++        if (TryResolveCapturedDirectEvalBinding(name, out var capturedBinding) && !capturedBinding.IsDeleted)
++            return capturedBinding.GetValue();
++
+         return JSUndefined.Value;
+     }
+ 
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # Submodule patches waiting to be applied
 
-**One patch is waiting on a maintainer.** See the index below.
+**Two patches are waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -53,6 +53,7 @@ pointer and its file is deleted — this directory is a backlog, not an archive.
 | # | submodule | subject |
 | --- | --- | --- |
 | `0001` | `Broiler.JS` | Name the character a token cannot start with |
+| `0002` | `Broiler.JS` | Carry a direct eval's bindings into the closures its functions create |
 
 ### `0001` — the report that named neither a token nor a character
 
@@ -104,3 +105,53 @@ every `<script>` in a document whatever its `type`, so JSON-LD, framework state,
 speculation rules, import maps and client-side templates were all compiled as
 JavaScript. This patch is what makes the *next* report of this shape legible; it
 is not what stops it happening.
+
+### `0002` — one level of nesting decided whether a name resolved
+
+A function a direct eval produced keeps the eval site's bindings: it carries a
+snapshot of the overlay, taken while the eval was still running. A function
+*that* function creates when it later runs was handed nothing, because by then
+the eval had returned and there was no overlay left to snapshot:
+
+```js
+f = eval("0,function(){ return function(){ return b; }; }");
+f()      // fine
+f()()    // ReferenceError: b is not defined
+```
+
+google.com's bot-detection VM is that shape. It evaluates its own opcode
+handlers with `function(X){return eval(X)}(src)` and builds a closure inside
+them on nearly every step, so the first such closure threw **`g is not
+defined`** and the challenge never finished — one nesting level past the
+`b is not defined` the capture already fixed (`Broiler.JS` 60c9182a).
+
+The scope the *running* function carries is the lexical environment of
+everything it creates, and it is the only trace of the eval left once the eval
+has returned, so `JSContext.CaptureDirectEvalBindings` folds it in — outermost,
+so an inner scope's binding of the same name still wins.
+
+Two more places dropped the same scope, both reproduced from the same payload:
+
+* `JSFunction.InvokeCallback` — a native callback site is a `[[Call]]` like any
+  other, but it re-established none of the scopes a function closed over. A
+  closure resolved its free names when JavaScript called it and threw the moment
+  it was handed to `Array.prototype.map`, `Set`/`Map.prototype.forEach`, a JSON
+  reviver or replacer; a function created inside `with (o)` lost `o` the same
+  way. It now enters the same four scopes `InvokeFunction` does, and only when
+  the function actually carries some, so an ordinary callback costs what it did.
+* `JSContext.ResolveIdentifierOrUndefined` — `typeof` resolves through its own
+  non-throwing path, which never consulted the capture: it answered `"undefined"`
+  for a name the very next read produced a value for. It consults it now,
+  skipping a *deleted* binding, which is the one case where the two must
+  genuinely differ.
+
+**Why it is listed in `scripts/apply-pending-wpt-patches.sh`.** That script also
+runs for the real-world render suite, and google.com is where this moves pixels:
+without the patch the challenge never completes and what renders is the
+interstitial rather than the page. The semantics are pinned by unit tests in the
+submodule (`DirectEvalClosureScopeTests`, `CapturedScopeCallbackTests`); only a
+real page can say the VM got through.
+
+**There is no main-repo fallback.** The defect is entirely inside the JavaScript
+engine's scope resolution — there is no layer above it where the same fix could
+be written — so until this patch is applied the engine behaves as it did.

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -194,7 +194,21 @@ set -euo pipefail
 # it from the box fix-ups, so without the patch applied the main-repo half never runs and every
 # css/CSS2/tables/table-anonymous-objects-* test still renders its bare red table with the green
 # layer missing.
+#
+# 0002 (Broiler.JS, "Carry a direct eval's bindings into the closures its functions create") IS
+# listed, and the suite it is listed for is the real-world render one rather than WPT — the same
+# script runs both. Its fix decides whether google.com's bot-detection VM completes: the VM
+# evaluates its opcode handlers with `function(X){return eval(X)}(src)` and builds a closure inside
+# them on nearly every step, and without the patch the first such closure throws "g is not defined"
+# and the challenge never finishes. What renders then is the interstitial rather than the page, so
+# the difference is a whole screenshot. The engine's own suites pin the semantics
+# (DirectEvalClosureScopeTests, CapturedScopeCallbackTests); only a real page can say the VM got
+# through. Its predecessor — the direct-eval capture itself, Broiler.JS 60c9182a — was deliberately
+# NOT listed on the ground that it decides whether page script runs rather than what it paints;
+# that reasoning holds for the golden-image suite and not for the real-world one, which is the
+# difference here.
 PENDING_PATCHES=(
+  "Broiler.JS|patches/0002-carry-eval-bindings-into-nested-closures.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary

Fixes a scope resolution bug where closures created by directly-evalled functions lost access to the eval site's bindings, and where functions invoked through native callbacks lost their captured scopes. This resolves a critical issue affecting google.com's bot-detection VM, which evaluates opcode handlers via `function(X){return eval(X)}(src)` and builds closures inside them.

## Changes

**`Broiler.JS` patch `0002`** — Carry a direct eval's bindings into the closures its functions create

- **`JSContext.CaptureDirectEvalBindings`** — Now folds in the scope carried by the currently-running function, so closures created by that function inherit the eval's bindings. This fixes the case where `f = eval("0,function(){ return function(){ return b; }; }")` would have `f()` work but `f()()` throw `ReferenceError: b is not defined`.

- **`JSFunction.InvokeCallback`** — Re-establishes the four captured scopes (direct eval bindings, with chain, with fallback scopes, and suspended with scope) when a function is invoked through a native callback. Previously, callbacks to `Array.prototype.map`, `Set`/`Map.prototype.forEach`, JSON revivers/replacers, and similar builtins would lose these scopes, causing the same closure to work when called directly but fail when passed to a builtin.

- **`JSContext.ResolveIdentifierOrUndefined`** — Now consults captured direct eval bindings when resolving names for `typeof` expressions, ensuring `typeof` agrees with actual reads. Skips deleted bindings (where `typeof` correctly returns `"undefined"` while a read throws).

- **Test coverage** — Added `DirectEvalClosureScopeTests` (nested closure scenarios, builtin callbacks, nested evals) and `CapturedScopeCallbackTests` (direct-eval and with-closures through various Array/Set/Map/JSON methods).

## Impact

Without this patch, google.com's bot-detection VM fails on the first nested closure with `g is not defined`, preventing the challenge from completing and rendering the interstitial instead of the page. The fix ensures one level of nesting does not decide whether a name resolves.

## Notes

- Patch is applied via `scripts/apply-pending-wpt-patches.sh` for the real-world render suite (not WPT), since only a real page can confirm the VM completes.
- No main-repo fallback exists; the defect is entirely in the JavaScript engine's scope resolution.

https://claude.ai/code/session_01XWeFAXx84RrmBr8zNwmDUn