### PR TITLE
Two conformance fixes found while chasing the fourth google.com failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,18 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `Broiler.JS` (patch `0002`) — `String(Math.pow(2, -25))` answered
+  `2.980232238769531e-8`, which reads back as a *different* double, so a page that
+  round-tripped a value through a string got a different value back than it put in.
+  `Number::toString` owes the shortest string that reads back as the same Number, and
+  .NET's `"R"` specifier — documented as unreliable — drops the seventeenth
+  significant digit for this value. The short form is now verified by parsing and
+  widened to 17 digits only where it fails, so everything that already round-tripped
+  keeps its shortest form (`String(0.1)` is still `"0.1"`). Found by differentially
+  fuzzing the engine against V8, along with `"abc".lastIndexOf("")` answering 2
+  instead of 3 — the position clamps into `[0, length]`, not `[0, length - 1]`, and a
+  negative position answered "not found" for the empty string, which is always found.
+
 - `Broiler.HtmlBridge.Dom` — `location.replace(url)` was `TypeError: undefined is not a
   function`. The bridge defined the Location's URL components and none of its methods, so
   `assign`, `replace` and `reload` were all missing — and a missing method is not something a

--- a/patches/0002-number-roundtrip-and-lastindexof.patch
+++ b/patches/0002-number-roundtrip-and-lastindexof.patch
@@ -1,0 +1,256 @@
+From 4636c19c13d866b362b1011b09cd6c40ea3fb154 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Wed, 19 Aug 2026 07:13:40 +0000
+Subject: [PATCH] Render a number as the number it was asked about, and find
+ the empty string at the end
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Two conformance defects, both found by differentially fuzzing this engine against
+V8 while chasing a Google Search failure. Neither is exotic: each is the answer a
+page gets for ordinary input.
+
+**Number::toString dropped a digit it needed.** The specification asks for the
+shortest string that reads back as the same Number — no shorter string may denote
+it. .NET's "R" specifier is documented as unreliable and, for 2**-25, it drops the
+seventeenth significant digit: it renders 2.980232238769531E-08, which parses back
+as 0x1.fffffffffffffp-26, a DIFFERENT double. So `String(Math.pow(2, -25))` named a
+number that is not the one it was asked about, and a page round-tripping a value
+through a string — a hash, a serialized payload, a cache key — got a different
+value back than it put in. The short form is now verified by parsing and widened to
+17 digits only where it fails, so everything that already round-tripped keeps its
+shortest form: String(0.1) is still "0.1", not "0.10000000000000001". The same
+digits feed toFixed/toPrecision/toExponential, so their source is fixed with it.
+
+**lastIndexOf could not find the empty string at the end.** The position clamps
+into [0, length], not [0, length - 1]. The difference is only visible for the empty
+search string, which is found AT every position including one past the end:
+"abc".lastIndexOf("") is 3 and this answered 2. A negative position was worse — it
+answered -1, "not found", for a string that is always found. The conversion to
+.NET's LastIndexOf, which takes the index a match must END at rather than the one
+it may start at, is now done once and explicitly rather than by two stacked clamps.
+
+34 tests pin both, including what must not move: the shortest form for every value
+that already had one, and an ordinary search's answer.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01XWeFAXx84RrmBr8zNwmDUn
+---
+ .../NumberRoundTripAndLastIndexOfTests.cs     | 96 +++++++++++++++++++
+ .../Number/JSNumber.cs                        | 26 ++++-
+ .../Number/JSNumberPrototype.cs               |  2 +-
+ .../String/JSStringPrototype.Search.cs        | 35 ++++---
+ 4 files changed, 144 insertions(+), 15 deletions(-)
+ create mode 100644 Broiler.JS/Broiler.JavaScript.BuiltIns.Tests/NumberRoundTripAndLastIndexOfTests.cs
+
+diff --git a/Broiler.JS/Broiler.JavaScript.BuiltIns.Tests/NumberRoundTripAndLastIndexOfTests.cs b/Broiler.JS/Broiler.JavaScript.BuiltIns.Tests/NumberRoundTripAndLastIndexOfTests.cs
+new file mode 100644
+index 00000000..c887a5af
+--- /dev/null
++++ b/Broiler.JS/Broiler.JavaScript.BuiltIns.Tests/NumberRoundTripAndLastIndexOfTests.cs
+@@ -0,0 +1,96 @@
++using System.Runtime.CompilerServices;
++using Broiler.JavaScript.Engine;
++
++namespace Broiler.JavaScript.BuiltIns.Tests;
++
++// Two conformance defects found by differentially fuzzing the engine against V8 while chasing a
++// Google Search failure. Neither is exotic: both are answers a page gets for ordinary input.
++public class NumberRoundTripAndLastIndexOfTests
++{
++    private static void Load() => RuntimeHelpers.RunClassConstructor(typeof(Clr.DefaultClrInterop).TypeHandle);
++
++    private static string Eval(string source)
++    {
++        Load();
++        using var ctx = new JSContext();
++        return ctx.Eval(source).ToString();
++    }
++
++    // Number::toString is defined to produce the SHORTEST string that reads back as the same Number
++    // (no shorter string may denote it). .NET's "R" specifier is documented as unreliable and, for
++    // 2**-25, drops the seventeenth significant digit: it renders 2.980232238769531E-08, which parses
++    // back as 0x1.fffffffffffffp-26 — a different double. So `String(2**-25)` named a number that was
++    // not the one it was asked about, and any page round-tripping a value through a string got a
++    // different value back than it put in.
++    [Theory]
++    [InlineData("String(Math.pow(2, -25))", "2.9802322387695312e-8")]
++    [InlineData("String(0.5 / 16777216)", "2.9802322387695312e-8")]
++    [InlineData("String(1 / 33554432)", "2.9802322387695312e-8")]
++    [InlineData("String(64 / 2147483648)", "2.9802322387695312e-8")]
++    [InlineData("JSON.stringify(Math.pow(2, -25))", "2.9802322387695312e-8")]
++    [InlineData("String(-Math.pow(2, -25))", "-2.9802322387695312e-8")]
++    public void AValueNeedingSeventeenDigits_KeepsThemAll(string source, string expected)
++    {
++        Assert.Equal(expected, Eval(source));
++    }
++
++    /// <summary>The property that makes it a defect rather than a preference.</summary>
++    [Fact]
++    public void TheRenderedNumber_ReadsBackAsItself()
++    {
++        Assert.Equal("true", Eval("String(Number(String(Math.pow(2, -25))) === Math.pow(2, -25))"));
++    }
++
++    // ...and the shortest form is still the shortest: widening happens only where the short one fails
++    // to round-trip, so nothing that already worked grows digits.
++    [Theory]
++    [InlineData("String(0.1)", "0.1")]
++    [InlineData("String(0.1 + 0.2)", "0.30000000000000004")]
++    [InlineData("String(1 / 3)", "0.3333333333333333")]
++    [InlineData("String(Math.PI)", "3.141592653589793")]
++    [InlineData("String(1e21)", "1e+21")]
++    [InlineData("String(5e-324)", "5e-324")]
++    [InlineData("String(1.7976931348623157e308)", "1.7976931348623157e+308")]
++    [InlineData("String(100)", "100")]
++    [InlineData("(0.1).toFixed(20)", "0.10000000000000000555")]
++    [InlineData("(255).toString(16)", "ff")]
++    public void EveryOtherValue_KeepsItsShortestForm(string source, string expected)
++    {
++        Assert.Equal(expected, Eval(source));
++    }
++
++    // String.prototype.lastIndexOf clamps its position into [0, length] — NOT [0, length - 1]. The
++    // distinction is only visible for the empty search string, which is found AT every position
++    // including one past the end. Clamping to length - 1 answered 2 for "abc".lastIndexOf(""), and a
++    // negative position answered -1: "not found", for a string that is always found.
++    [Theory]
++    [InlineData("'abc'.lastIndexOf('')", "3")]
++    [InlineData("'abc'.lastIndexOf('', 99)", "3")]
++    [InlineData("'abc'.lastIndexOf('', NaN)", "3")]
++    [InlineData("'abc'.lastIndexOf('', -1)", "0")]
++    [InlineData("'abc'.lastIndexOf('', 1)", "1")]
++    [InlineData("''.lastIndexOf('')", "0")]
++    public void TheEmptySearchString_IsFoundAtEveryPositionUpToTheLength(string source, string expected)
++    {
++        Assert.Equal(expected, Eval(source));
++    }
++
++    // What must not change: an ordinary search still answers where the match starts, and a search
++    // that cannot fit still answers -1.
++    [Theory]
++    [InlineData("'abc'.lastIndexOf('c')", "2")]
++    [InlineData("'abc'.lastIndexOf('a')", "0")]
++    [InlineData("'aXbXc'.lastIndexOf('X')", "3")]
++    [InlineData("'aXbXc'.lastIndexOf('X', 2)", "1")]
++    [InlineData("'abc'.lastIndexOf('d')", "-1")]
++    [InlineData("'abc'.lastIndexOf('abcd')", "-1")]
++    [InlineData("''.lastIndexOf('a')", "-1")]
++    [InlineData("'abc'.lastIndexOf('bc')", "1")]
++    [InlineData("'abc'.lastIndexOf('bc', 0)", "-1")]
++    [InlineData("'abcabc'.lastIndexOf('abc')", "3")]
++    [InlineData("'abcabc'.lastIndexOf('abc', 2)", "0")]
++    public void AnOrdinarySearch_IsUnchanged(string source, string expected)
++    {
++        Assert.Equal(expected, Eval(source));
++    }
++}
+diff --git a/Broiler.JS/Broiler.JavaScript.BuiltIns/Number/JSNumber.cs b/Broiler.JS/Broiler.JavaScript.BuiltIns/Number/JSNumber.cs
+index 817d92aa..fa99eef6 100644
+--- a/Broiler.JS/Broiler.JavaScript.BuiltIns/Number/JSNumber.cs
++++ b/Broiler.JS/Broiler.JavaScript.BuiltIns/Number/JSNumber.cs
+@@ -372,6 +372,30 @@ public sealed partial class JSNumber : JSPrimitive
+     /// IEEE 754 double-precision, formatted using ECMAScript rules for when
+     /// to use decimal vs scientific notation.
+     /// </summary>
++    /// <summary>
++    /// The shortest decimal string that reads back as <paramref name="value"/> exactly, which is what
++    /// Number::toString is defined to produce: the digits are chosen so that no shorter string denotes
++    /// the same Number.
++    /// </summary>
++    /// <remarks>
++    /// <c>"R"</c> alone does not give it. The specifier is documented as unreliable and, for 2**-25, it
++    /// drops the seventeenth significant digit: .NET renders <c>2.980232238769531E-08</c>, which parses
++    /// back as a DIFFERENT double (0x1.fffffffffffffp-26 rather than 0x1.0p-25). So <c>String(2**-25)</c>
++    /// answered a number that is not the one it was asked about, and a page round-tripping a value
++    /// through a string - a hash, a serialized payload, a cache key - got a different value back than it
++    /// put in. The short form is verified by parsing and only widened to 17 digits when it fails, so
++    /// every value that already round-trips keeps its shortest form: <c>String(0.1)</c> stays
++    /// <c>"0.1"</c> rather than becoming <c>"0.10000000000000001"</c>.
++    /// </remarks>
++    internal static string RoundTrippable(double value)
++    {
++        var shortest = value.ToString("R", CultureInfo.InvariantCulture);
++        return double.TryParse(shortest, NumberStyles.Float, CultureInfo.InvariantCulture, out var reparsed)
++            && reparsed.Equals(value)
++                ? shortest
++                : value.ToString("G17", CultureInfo.InvariantCulture);
++    }
++
+     internal static string ToECMAString(double value)
+     {
+         if (double.IsNaN(value))
+@@ -391,7 +415,7 @@ public sealed partial class JSNumber : JSPrimitive
+ 
+         // Get the round-trip representation using InvariantCulture
+         // to ensure '.' as decimal separator.
+-        string repr = value.ToString("R", CultureInfo.InvariantCulture);
++        string repr = RoundTrippable(value);
+ 
+         // Parse repr into significand digits and base-10 exponent
+         // such that value = significand × 10^exp  (significand is an integer string).
+diff --git a/Broiler.JS/Broiler.JavaScript.BuiltIns/Number/JSNumberPrototype.cs b/Broiler.JS/Broiler.JavaScript.BuiltIns/Number/JSNumberPrototype.cs
+index ba061c42..5a638cb6 100644
+--- a/Broiler.JS/Broiler.JavaScript.BuiltIns/Number/JSNumberPrototype.cs
++++ b/Broiler.JS/Broiler.JavaScript.BuiltIns/Number/JSNumberPrototype.cs
+@@ -529,7 +529,7 @@ partial class JSNumber
+     /// </summary>
+     private static (string digits, int e) ShortestSignificantDigits(double x)
+     {
+-        var repr = x.ToString("R", CultureInfo.InvariantCulture);
++        var repr = JSNumber.RoundTrippable(x);
+ 
+         var eIdx = repr.IndexOf('E');
+         string mantissa;
+diff --git a/Broiler.JS/Broiler.JavaScript.BuiltIns/String/JSStringPrototype.Search.cs b/Broiler.JS/Broiler.JavaScript.BuiltIns/String/JSStringPrototype.Search.cs
+index 3d0efeb3..4b2fb035 100644
+--- a/Broiler.JS/Broiler.JavaScript.BuiltIns/String/JSStringPrototype.Search.cs
++++ b/Broiler.JS/Broiler.JavaScript.BuiltIns/String/JSStringPrototype.Search.cs
+@@ -133,21 +133,30 @@ public partial class JSString
+         // Spec order: ToString(this), then ToString(searchString), then
+         // ToNumber(position). Read searchString BEFORE coercing position.
+         var search = (a[0] ?? JSUndefined.Value).StringValue;
+-        var fromIndex = a[1]?.DoubleValue ?? int.MaxValue;
+-        var startIndex = double.IsNaN(fromIndex) ? int.MaxValue : (int)(((long)fromIndex << 32) >> 32);
+-
+-        startIndex = Math.Min(startIndex, @this.Length - 1);
+-        startIndex = Math.Min(startIndex + search.Length - 1, @this.Length - 1);
+-
+-        if (startIndex < 0)
+-        {
+-            if (@this == string.Empty && search.Length == 0)
+-                return NumberZero;
+-
++        var fromIndex = a[1]?.DoubleValue ?? double.NaN;
++        var length = @this.Length;
++
++        // \u00a7String.prototype.lastIndexOf steps 4-6: a NaN position (which is also what an absent one
++        // coerces to) means +\u221e, and the result is clamped into [0, length] \u2014 NOT [0, length - 1].
++        // The distinction is only visible for the empty search string, which is found AT every
++        // position including one past the end: `"abc".lastIndexOf("")` is 3, and clamping to
++        // length - 1 answered 2. A negative position clamps to 0 and still finds it, where this
++        // returned -1 \u2014 "not found" for a string that is always found.
++        var start = double.IsNaN(fromIndex)
++            ? length
++            : fromIndex <= 0 ? 0 : fromIndex >= length ? length : (int)fromIndex;
++
++        // StringLastIndexOf: the largest k <= start with k + searchLength <= length that matches.
++        var lastPossible = Math.Min(start, length - search.Length);
++        if (lastPossible < 0)
+             return NumberMinusOne;
+-        }
+ 
+-        return CreateNumber(@this.LastIndexOf(search, startIndex, StringComparison.Ordinal));
++        if (search.Length == 0)
++            return CreateNumber(lastPossible);
++
++        // .NET's LastIndexOf takes the index the match must END at or before, not the one it may
++        // start at, so the spec's start is converted rather than passed through.
++        return CreateNumber(@this.LastIndexOf(search, lastPossible + search.Length - 1, StringComparison.Ordinal));
+     }
+ 
+     [JSPrototypeMethod]
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # Submodule patches waiting to be applied
 
-**One patch is waiting on a maintainer.** See the index below.
+**Two patches are waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -59,6 +59,7 @@ keeps its number: the numbering restarts only when the directory empties.
 | # | submodule | subject |
 | --- | --- | --- |
 | `0001` | `Broiler.JS` | Name the character a token cannot start with |
+| `0002` | `Broiler.JS` | Render a number as the number it was asked about, and find the empty string at the end |
 
 ### `0001` — the report that named neither a token nor a character
 
@@ -110,3 +111,42 @@ every `<script>` in a document whatever its `type`, so JSON-LD, framework state,
 speculation rules, import maps and client-side templates were all compiled as
 JavaScript. This patch is what makes the *next* report of this shape legible; it
 is not what stops it happening.
+
+### `0002` — two answers that were wrong for ordinary input
+
+Both were found by differentially fuzzing the engine against V8 (node stands in for
+it — same language semantics, no browser needed) while chasing a Google Search
+failure. Neither is what that investigation was looking for, and both are real.
+
+**`String(Math.pow(2, -25))` named a number that is not the one it was asked
+about.** `Number::toString` is defined to produce the shortest string that reads
+back as the same Number. .NET's `"R"` specifier is documented as unreliable and, for
+this value, drops the seventeenth significant digit:
+
+```
+"R"   → 2.980232238769531E-08   → parses back as 0x1.fffffffffffffp-26   ✗
+"G17" → 2.9802322387695312E-08  → parses back as 0x1.0p-25               ✓
+```
+
+So a page round-tripping a value through a string — a hash, a serialized payload, a
+cache key — got a different value back than it put in. The short form is now
+verified by parsing and widened to 17 digits only where it fails, so every value
+that already round-tripped keeps its shortest form (`String(0.1)` is still `"0.1"`,
+not `"0.10000000000000001"`). One value in 900 tested doubles was affected, and one
+is enough: the failure is silent and the corrupted value travels.
+
+**`"abc".lastIndexOf("")` answered 2, and `"abc".lastIndexOf("", -1)` answered
+-1.** The position clamps into `[0, length]`, not `[0, length - 1]`. The difference
+is visible only for the empty search string, which is found *at* every position
+including one past the end — so the first should be 3, and the second should be 0
+rather than "not found" for a string that is always found. The conversion to .NET's
+`LastIndexOf`, which takes the index a match must END at rather than the one it may
+start at, is now done once and explicitly instead of by two stacked clamps.
+
+34 tests pin both, including what must not move.
+
+**Why it is not listed in `scripts/apply-pending-wpt-patches.sh`.** Neither answer
+can move a rendered pixel on a WPT test or a real-world capture: no page in either
+suite round-trips a 17-digit double through a string or searches for the empty
+string at a negative position. They are engine conformance, and the engine's own
+tests cover them.


### PR DESCRIPTION
**The failure this started from is not fixed.** It is characterised, and the characterisation is the second half of this description. What is fixed are two defects the investigation turned up on the way — both real, both what a page gets for ordinary input, neither related to the failure.

The code is `patches/0002`: the `Broiler.JS` push returns 403 (the submodule remote is outside this session's GitHub scope), so the fix is captured as a patch and **the submodule pointer is deliberately not bumped**.

## What is fixed

### `String(Math.pow(2, -25))` named a number that is not the one it was asked about

`Number::toString` owes the shortest string that reads back as the same Number. .NET's `"R"` specifier is documented as unreliable and, for this value, drops the seventeenth significant digit:

```
"R"   → 2.980232238769531E-08   → parses back as 0x1.fffffffffffffp-26   ✗
"G17" → 2.9802322387695312E-08  → parses back as 0x1.0p-25               ✓
```

So a page round-tripping a value through a string — a hash, a serialized payload, a cache key — got a different value back than it put in, silently, and the corrupted value travels. The short form is now verified by parsing and widened to 17 digits **only where it fails**, so every value that already round-tripped keeps its shortest form: `String(0.1)` is still `"0.1"`, not `"0.10000000000000001"`. The same digits feed `toFixed`/`toPrecision`/`toExponential`, so their source is fixed with it.

One value in 900 tested doubles was affected. One is enough.

### `"abc".lastIndexOf("")` answered 2, and with a negative position answered "not found"

The position clamps into `[0, length]`, not `[0, length - 1]`. The difference is visible only for the empty search string, which is found *at* every position including one past the end — so `"abc".lastIndexOf("")` should be 3, and `"abc".lastIndexOf("", -1)` should be 0 rather than `-1` for a string that is always found.

The conversion to .NET's `LastIndexOf` — which takes the index a match must END at, not the one it may start at — is now done once and explicitly instead of by two stacked clamps.

### How they were found

By differentially fuzzing the engine against V8: 4000 generated arithmetic/bitwise expressions, 900 doubles, and 70 builtin cases, each evaluated in both and diffed. That harness is the part of this worth keeping — it is how two silent wrong answers surfaced in an engine whose own suites were green.

## The failure itself, which remains open

```
{TypeError: Cannot read properties of undefined (reading '8')}
  at GetValue in JSValue.cs:1326
  at inline in vm35.js:1,19     ← K(B,J,z){z=B.J[J]}  — the register read
  at inline in vm52.js:1,27     ← the VM's eval opcode handler, K(x.L, P)
  at inline in vm16.js:5462  ×10
  at ia / la / inline in inline-3
```

Reproduced locally with an identical stack shape. Then:

**Part of it is the page's own control flow.** On one saved results page Chromium throws the identical error twice — `Cannot read properties of undefined (reading '473')` — from the same bit-reader. Like the `[lQ,30,N]` sentinels of the previous report, botguard throws and catches these deliberately.

**But Broiler diverges, deterministically.** Same bytes, same page:

| | eval'd programs | register-miss sentinels | this TypeError |
| --- | --- | --- | --- |
| Chromium 1194 | 170 | 74 | 2 |
| Broiler | 90 | 368 | 10 |

The two engines eval **76 byte-identical programs**, agreeing exactly, and then Broiler stalls precisely where Chromium goes on to run a second-stage unpacker that evals ~90 more. Broiler's last botguard program is `vm88`; the ten failures then fire consecutively and nothing follows.

**Ruled out by measurement, not by argument:**

| Hypothesis | Test | Result |
| --- | --- | --- |
| The capture's time budget | `--timeout 30` vs `--timeout 300` | 90 programs both times |
| `document.hidden` (the VM's watchdog reads it; Broiler answers `undefined`) | shimmed to `false` | no change |
| The missing-platform-API surface | diffed 142 members against Chromium, found **84** Broiler answers `undefined` for, shimmed all | 91 programs instead of 90 |
| int32 / bitwise semantics | 4000 fuzzed expressions vs V8 | no numeric mismatch |

Neither fix in this PR changes it: re-running the saved page afterwards still gives 90 programs. Closing it means building a differential opcode trace between Chromium and Broiler to find the first divergent step, which is a piece of work in its own right rather than a follow-up.

One further divergence was found and deliberately **not** touched: Broiler accepts `--Infinity` where V8 rejects it. That is the same parser area as a recent fix, no real page writes it, and it is not worth the risk without a reason.

## Verification

| Suite | Result |
| --- | --- |
| `Broiler.JavaScript.BuiltIns.Tests` | **2173** pass (2139 + the 34 new) |
| `Broiler.JavaScript.Compiler.Tests` | **1373** pass |
| `Broiler.JavaScript.Integration.Tests` | 4966 / 4967 — the one failure is `M8_DocumentationFiles_Exist`, which wants a `docs/roadmap.md` this checkout does not have and fails on a clean tree too |
| `Runtime` / `Parser` / `Storage` | 11 / 198 / 46, all green |
| Builtin differential vs V8 | 2 mismatches → **0** of 70 |
| Number→string differential | 1 mismatch → **0** of 900 doubles |
| Arithmetic fuzz | **0** numeric mismatches of 4000 |

Not listed in `scripts/apply-pending-wpt-patches.sh`: neither answer can move a rendered pixel in the suites that script serves — no page in either round-trips a 17-digit double through a string or searches for the empty string at a negative position. They are engine conformance, and the engine's own tests cover them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XWeFAXx84RrmBr8zNwmDUn)_