### PR TITLE
Fix Content-Type header duplication in form submissions

### DIFF
--- a/docs/architecture/browser-form-controls.md
+++ b/docs/architecture/browser-form-controls.md
@@ -141,6 +141,17 @@ in whichever encoding `enctype` asks for:
 
 A GET ignores `enctype` entirely — it has no body to encode.
 
+That media type is also the one the request goes out under, and it must be the **only**
+`Content-Type` on it. `StringContent`'s constructor already sets one
+(`text/plain; charset=utf-8` for the UTF-8 overload) and `TryAddWithoutValidation`
+*appends* to a header rather than replacing it, so `PageLoader` used to post the
+two-valued `text/plain; charset=utf-8, application/x-www-form-urlencoded`. A server
+reading the first value sees `text/plain`, never decodes the body, and rejects the
+submission — google's cookie-consent dialog answered `POST https://consent.google.de/save`
+with `400 Bad Request`, stranding a search behind the consent page. `PageLoader.WithContentType`
+clears the default before setting the media type; the bytes stay UTF-8 either way, so
+dropping the constructor's `charset` changes nothing on the wire.
+
 One definition of "successful control" feeds all three: `BuildEntryList` is the single
 walk of the form, and the encoders are pure functions over its output, so they cannot
 disagree about which controls submit.

--- a/src/Broiler.App/Rendering/PageLoader.cs
+++ b/src/Broiler.App/Rendering/PageLoader.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using System.Text;
 
 namespace Broiler.App.Rendering;
@@ -91,17 +92,50 @@ public sealed class PageLoader : IPageLoader
 
         // A multipart body carries file bytes verbatim, so it must not be re-encoded
         // as text. Its media type already includes the boundary parameter, which
-        // StringContent's constructor would reject, so it is set on the header.
+        // StringContent's constructor would reject anyway.
         if (request.BinaryBody is { } bytes)
-        {
-            ByteArrayContent content = new(bytes);
-            content.Headers.TryAddWithoutValidation("Content-Type", mediaType);
-            return content;
-        }
+            return WithContentType(new ByteArrayContent(bytes), mediaType);
 
-        StringContent text = new(request.Body ?? string.Empty, Encoding.UTF8);
-        text.Headers.TryAddWithoutValidation("Content-Type", mediaType);
-        return text;
+        return WithContentType(new StringContent(request.Body ?? string.Empty, Encoding.UTF8), mediaType);
+    }
+
+    /// <summary>
+    /// Makes <paramref name="mediaType"/> the <em>only</em> <c>Content-Type</c> on
+    /// <paramref name="content"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="StringContent"/>'s constructor already sets one — <c>text/plain; charset=utf-8</c>
+    /// for the <see cref="Encoding.UTF8"/> overload — and <c>TryAddWithoutValidation</c>
+    /// <em>appends</em> to a header rather than replacing it. A urlencoded form therefore went out
+    /// as the two-valued
+    /// <c>Content-Type: text/plain; charset=utf-8, application/x-www-form-urlencoded</c>,
+    /// and a server reading the first value sees <c>text/plain</c>, never decodes the body, and
+    /// rejects the submission: google's cookie-consent dialog answered
+    /// <c>POST https://consent.google.de/save</c> with <c>400 Bad Request</c>, which stranded a
+    /// search behind the consent page. Removing the default first leaves the media type the form
+    /// actually chose.
+    /// </para>
+    /// <para>
+    /// The bytes stay UTF-8 whatever the media type says, so dropping the constructor's
+    /// <c>charset=utf-8</c> does not change what is on the wire — and a bare
+    /// <c>application/x-www-form-urlencoded</c> is what browsers send for a urlencoded form.
+    /// Parsing into <see cref="System.Net.Http.Headers.HttpContentHeaders.ContentType"/> keeps
+    /// parameters such as multipart's <c>boundary</c>; a value too malformed to parse is sent
+    /// verbatim rather than costing the whole request.
+    /// </para>
+    /// </remarks>
+    private static T WithContentType<T>(T content, string mediaType)
+        where T : HttpContent
+    {
+        content.Headers.Remove("Content-Type");
+
+        if (MediaTypeHeaderValue.TryParse(mediaType, out var parsed))
+            content.Headers.ContentType = parsed;
+        else
+            content.Headers.TryAddWithoutValidation("Content-Type", mediaType);
+
+        return content;
     }
 
     /// <inheritdoc />

--- a/src/Broiler.Browser.Core.Tests/PageLoaderContentTypeTests.cs
+++ b/src/Broiler.Browser.Core.Tests/PageLoaderContentTypeTests.cs
@@ -1,0 +1,149 @@
+using System.Net;
+using System.Net.Http;
+using Broiler.App.Rendering;
+
+namespace Broiler.Browser.Core.Tests;
+
+/// <summary>
+/// A form submission must reach the origin under the media type the form chose, and under that
+/// one alone.
+/// </summary>
+/// <remarks>
+/// <see cref="StringContent"/>'s constructor sets <c>text/plain; charset=utf-8</c>, and
+/// <c>TryAddWithoutValidation</c> appends rather than replaces, so the loader used to post the
+/// two-valued <c>Content-Type: text/plain; charset=utf-8, application/x-www-form-urlencoded</c>.
+/// A server reading the first value sees <c>text/plain</c> and never decodes the body: google's
+/// cookie-consent dialog answered <c>POST https://consent.google.de/save</c> with
+/// <c>400 Bad Request</c>, so accepting or declining cookies stranded the search behind the
+/// consent page.
+/// </remarks>
+public class PageLoaderContentTypeTests
+{
+    /// <summary>Captures the request instead of sending it, so the tests touch no socket.</summary>
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        internal HttpRequestMessage? Request { get; private set; }
+
+        internal string? Body { get; private set; }
+
+        internal byte[]? Bytes { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Request = request;
+
+            // The loader disposes the content once the send returns, so the body has to be
+            // taken here rather than off the captured request.
+            if (request.Content is { } content)
+            {
+                Bytes = await content.ReadAsByteArrayAsync(cancellationToken);
+                Body = await content.ReadAsStringAsync(cancellationToken);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("<html><body>ok</body></html>"),
+                RequestMessage = request,
+            };
+        }
+    }
+
+    private static async Task<CapturingHandler> SubmitAsync(PageRequest request)
+    {
+        CapturingHandler handler = new();
+        using HttpClient client = new(handler);
+        using PageLoader loader = new(client);
+
+        _ = await loader.FetchAsync(request);
+        return handler;
+    }
+
+    private static string[] ContentTypeValues(CapturingHandler handler) =>
+        handler.Request!.Content!.Headers.GetValues("Content-Type").ToArray();
+
+    [Fact]
+    public async Task UrlEncodedForm_PostsThatMediaTypeAndNoOther()
+    {
+        // The consent dialog's own body, shortened.
+        const string Body = "bl=boq_identityfrontenduiserver&gl=DE&continue=https%3A%2F%2Fwww.google.de%2F";
+
+        var handler = await SubmitAsync(new PageRequest(
+            "https://consent.google.de/save",
+            PageRequest.Post,
+            PageRequest.FormUrlEncoded,
+            Body));
+
+        // The regression is a second value here — the origin reads the first and sees text/plain.
+        Assert.Equal(
+            ["application/x-www-form-urlencoded"],
+            ContentTypeValues(handler));
+        Assert.Equal(Body, handler.Body);
+    }
+
+    [Fact]
+    public async Task ContentTypeIsAbsentFromTheDefaultedCase()
+    {
+        // No media type on the request: the loader falls back to the form default, and that
+        // fallback must replace StringContent's text/plain just the same.
+        var handler = await SubmitAsync(new PageRequest(
+            "https://consent.google.de/save",
+            PageRequest.Post,
+            ContentType: null,
+            Body: "q=test"));
+
+        Assert.Equal(["application/x-www-form-urlencoded"], ContentTypeValues(handler));
+    }
+
+    [Fact]
+    public async Task TextPlainForm_KeepsTheMediaTypeTheFormChose()
+    {
+        var handler = await SubmitAsync(new PageRequest(
+            "https://example.com/submit",
+            PageRequest.Post,
+            "text/plain",
+            "q=test\r\n"));
+
+        Assert.Equal(["text/plain"], ContentTypeValues(handler));
+    }
+
+    [Fact]
+    public async Task MultipartForm_KeepsItsBoundaryParameterAndItsBytes()
+    {
+        byte[] body = [0x2D, 0x2D, 0x78, 0x79, 0x7A, 0xFF, 0xFE, 0x0D, 0x0A];
+
+        var handler = await SubmitAsync(new PageRequest(
+            "https://example.com/upload",
+            PageRequest.Post,
+            "multipart/form-data; boundary=xyz")
+        {
+            BinaryBody = body,
+        });
+
+        Assert.Equal(["multipart/form-data; boundary=xyz"], ContentTypeValues(handler));
+
+        // A file part is arbitrary binary; it must not be re-encoded as text.
+        Assert.Equal(body, handler.Bytes);
+    }
+
+    [Fact]
+    public async Task AnUnparseableMediaTypeStillGoesOutRatherThanFailingTheRequest()
+    {
+        var handler = await SubmitAsync(new PageRequest(
+            "https://example.com/submit",
+            PageRequest.Post,
+            "not a media type",
+            "q=test"));
+
+        Assert.Equal(["not a media type"], ContentTypeValues(handler));
+    }
+
+    [Fact]
+    public async Task AGetNavigationSendsNoBodyAndNoContentType()
+    {
+        var handler = await SubmitAsync(PageRequest.ForUrl("https://www.google.de/search?q=test"));
+
+        Assert.Null(handler.Request!.Content);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a bug where form submissions were sent with duplicate `Content-Type` headers, causing servers to reject requests when they read the first value. This was particularly problematic with Google's cookie-consent dialog, which returned `400 Bad Request` when the first `Content-Type` value was `text/plain` instead of the intended `application/x-www-form-urlencoded`.

## Changes

- **PageLoader.cs**: Refactored `CreateContent` to use a new `WithContentType<T>` helper method that:
  - Removes any existing `Content-Type` header before setting the form's media type
  - Properly parses the media type to preserve parameters (e.g., multipart's `boundary`)
  - Falls back to `TryAddWithoutValidation` for unparseable media types rather than failing the request
  - Handles both text and binary content correctly

- **PageLoaderContentTypeTests.cs**: Added comprehensive test suite covering:
  - URL-encoded forms post only their declared media type
  - Defaulted content type (null) correctly uses form default
  - Text/plain forms preserve their chosen media type
  - Multipart forms preserve boundary parameters and binary bytes
  - Unparseable media types are sent verbatim
  - GET requests send no body or Content-Type header

- **browser-form-controls.md**: Updated architecture documentation to explain the fix and why the charset parameter can be safely dropped from the wire format.

## Implementation Details

The root cause was that `StringContent`'s constructor sets `text/plain; charset=utf-8` by default, and `TryAddWithoutValidation` *appends* to headers rather than replacing them. This resulted in requests like:
```
Content-Type: text/plain; charset=utf-8, application/x-www-form-urlencoded
```

Servers reading the first value would see `text/plain` and fail to decode the body. The fix clears the default header before setting the form's media type, ensuring only the intended media type is sent. The bytes remain UTF-8 encoded regardless, so dropping the charset parameter changes nothing on the wire.

https://claude.ai/code/session_013kBgS8NddCfAyUu9pwhH33