### PR TITLE
Add document.hidden and document.visibilityState polyfills

### DIFF
--- a/docs/google-search-post-consent-challenge.md
+++ b/docs/google-search-post-consent-challenge.md
@@ -1,0 +1,293 @@
+# Why a Google search stalls after the consent page
+
+An investigation into the reported symptom: after accepting Google's consent
+form, a search never reaches its results. The page sits on *"Please click here
+if you are not redirected within a few seconds"*, and the JavaScript log carries
+
+```
+TypeError: Cannot get property length of undefined
+    at Item   D:\Broiler\Broiler.JS\…\Broiler.JavaScript.Runtime\JSUndefined.cs:41
+    at inline  vm97.js:5566          (×12)
+    at ia      inline-3:9
+    at la      inline-3:13
+    at inline  inline-3:13
+```
+
+**The throw is not an engine defect.** `vm97.js` is Google's bot-check VM, and
+the VM contains a watchdog that times itself. Two slices over **16 384 ms** and
+it overwrites its own interpreter-context pointer with the boolean `true`; the
+next opcode that dereferences that pointer reads `true.yl`, gets `undefined`,
+and asks it for `.length`. `JSUndefined.cs:41` is where a correct engine reports
+that, and every browser would report the same thing given the same state.
+
+**What is ours is the speed that gets it there.** On identical bytes Broiler
+runs this VM **250× slower than Chromium**, and the slowest slice is **108×
+longer** — 584 ms against 5.4 ms, into a 16 384 ms budget. That margin is what a
+debug build, a slower machine, or a heavier challenge spends.
+
+| | Chromium 141 | Broiler (Release) | ratio |
+| --- | --- | --- | --- |
+| VM wall time | 24 ms | 5 989 ms | 250× |
+| Slowest watchdog slice | 5.4 ms | 584 ms | 108× |
+| Compile of the 62 887-byte VM source | 3.9 ms | 521 ms | 134× |
+| Run of that source (definitions only) | 1.6 ms | 700 ms | 437× |
+
+Same page, same bytes, replayed from disk. Method under
+[Measuring a build's headroom](#measuring-a-builds-headroom).
+
+## The page
+
+`https://www.google.com/search?q=…` does not always answer with results. When
+Google wants to check the client first it answers with an interstitial titled
+`Google Search` whose whole visible content is
+
+> Please click here if you are not redirected within a few seconds. If you're
+> having trouble accessing Google Search, please click here, or send feedback.
+
+Its scripts solve a challenge, set an `SG_SS` cookie, and `location.replace` to
+the results URL. Post-consent is simply when a browser meets it most reliably —
+it is not conditional on consent, and a bare `Broiler.Cli` capture of
+`search?q=broiler` reproduces it directly:
+
+```sh
+dotnet run --project src/Broiler.Cli -- \
+  --capture-image "https://www.google.com/search?q=broiler" \
+  --output out.png --diagnostic-dir artifacts/google-diag
+```
+
+Two markers identify a bundle as this page: `SG_SS` in the document, and an
+inline script defining `la`/`ia` around `challenge_version` and `cbs`. Its five
+inline scripts land in `resources/` as `inline-0` … `inline-4`; `inline-2` is
+the VM loader and `inline-3` the challenge driver named in the trace.
+
+`inline-3` ends with the two frames the report shows:
+
+```js
+Z.then(function (a) { a || la(); }).catch(function (a) { X(a); });
+```
+
+`la()` calls `ia()`, which hands the challenge program to the VM:
+
+```js
+function ia(a, b) {
+  var c = C[g];                       // C[g] === window.knitsail
+  if (c) { b = c.a; var h = [ja()]; b(p, function (e) { return void e(a, h); }, !1, …, !0); }
+  else b(Error("f"));
+}
+```
+
+## `vm97.js`, and how to get a copy of it
+
+`vm97.js` is not a file Google serves. `inline-2` builds the VM as an array of
+strings, joins it, prefixes `Array(Math.random()*7824|0).join("\n")` and passes
+the result to an **indirect eval** — which is why the program is one 61 798-char
+line preceded by several thousand blank ones, and why its number varies per run.
+Broiler names such programs `vm<N>.js`, and
+[`AnonymousProgramDump`](../Broiler.JS/Broiler.JS/Broiler.JavaScript.Compiler/AnonymousProgramDump.cs)
+writes them out under exactly that name:
+
+```sh
+BROILER_JS_DUMP_PROGRAMS=artifacts/programs \
+  dotnet run --project src/Broiler.Cli -- --capture-image "$URL" --output out.png
+```
+
+The identifiers inside are re-randomised per serve, so names below are from the
+reported `vm97.js` and will differ in a fresh capture. The *shapes* do not.
+
+Note that Broiler has no Trusted Types. Google's loader probes for it, and
+without it falls back to passing a plain string to `eval` — which is what makes
+the instrumentation further down possible at all; under Chromium the argument
+arrives as a `TrustedScript` and has to be stringified first.
+
+## Decoding the trace
+
+Resolving each column against the program's AST gives the whole stack,
+outermost first:
+
+| Frame | Function | Role |
+| --- | --- | --- |
+| `inline-3:13,1126` | `function (a) { a \|\| la() }` | the `Z.then` callback |
+| `inline-3:13,24` | `la` | start the challenge |
+| `inline-3:9,1027` | `ia` | hand it to `window.knitsail.a` |
+| `vm97:5566,22340` | `bQ` | `knitsail.a` |
+| `vm97:5566,1430` | `S` | |
+| `vm97:5566,61690` | `knitsail.crb_` | builds the VM instance |
+| `vm97:5566,22179` | `Ei` | the VM constructor |
+| `vm97:5566,25484` | `xf` | its body — at the `Bz(11, 0, true, W, S([…]))` call |
+| `vm97:5566,4190` | `Bz` | run entry: stamps the clock, then `Fe(…)` |
+| `vm97:5566,15923` | `Fe` | |
+| `vm97:5566,32539` | `IH` | |
+| `vm97:5566,57786` | dispatcher | |
+| `vm97:5566,39658` | `pr` | the interpreter loop |
+| `vm97:5566,29453` | `function (y, C) { iQ("", 104, …, O.J, 361) }` | opcode 9 — push a frame |
+| `vm97:5566,37173` | `iQ` | **throws** |
+
+So it dies inside the constructor, running the VM's own bootstrap program.
+`iQ` is one statement long:
+
+```js
+iQ = function (V, x, F, D, M, z) {
+  M.yl.length > x
+    ? Xa([lQ, 36], M, V, F)                                  // "call stack too deep"
+    : (M.yl.push(M.g.slice()), (M.g[z] = void 0), v(M, z, D));
+};
+```
+
+`M` is `O.J`. `O` is `xf`'s own alias for the VM object `W`, and `W.yl = []` and
+`W.J = W` both run before `Bz(…)` is reached — the `Bz` frame proves the
+constructor got that far. `M.yl` is `undefined`, so **`O.J` is no longer the VM
+object**, and `iQ` reads `length` off the `undefined` that `true.yl` yields.
+
+## The watchdog
+
+`.J` is assigned in seven places, and six of them can only ever store the VM
+object: the constructor's `W.J = W`, two save/restore pairs
+(`z = x.J; x.J = x; try { … } finally { x.J = z }`), and a setter reached
+through `W.z6` that the program never calls — `z6` appears exactly once more, in
+a comparison (`c == y.z6`). The seventh is in `kr`, on the path `pr` takes for
+**every** dispatch — `kr(39, (…, 1), false, D, false, x)`:
+
+```js
+D.J =
+  ( ((D.B += ((d = (…, (P = (q = D.ii == 4) || W ? D.u() : D.Vl), P - D.Vl)),
+              d >> 14 > 0)), D).Z && (D.Z ^= …),
+    D.B + x ) >> 2 != 0 || D.J;
+```
+
+Read plainly, with `x === 1` and `D.B` starting at `1`:
+
+- `D.u()` is `this.NM + performance.now()` — wall-clock milliseconds.
+- `D.ii` counts dispatches; every fourth one takes a fresh reading and resets
+  `D.Vl`. So `d` is the elapsed time of a **four-dispatch slice**.
+- `d >> 14 > 0` is `d > 16383 ms`. Each such slice increments `D.B`.
+- `D.J = ((D.B + 1) >> 2 != 0) || D.J`. That is `false || D.J` — a no-op — while
+  `D.B <= 2`, and `true` from `D.B == 3` onward.
+
+`B` starts at 1, so it takes **two** stalled slices to poison `.J`, and from
+then on every write re-poisons it. The VM carries on until an opcode
+dereferences `.J`; `iQ` (opcode 9, "push a call frame") is the one that did.
+
+Verified against a captured challenge by rewriting the VM's own comparison
+through an `eval` hook so that every slice reports a stall: `B` climbed to 8 and
+the poisoned `true` was written 6 times. That capture still finished, because
+its (small) challenge program never executes opcode 9 — which is also why this
+cannot be reproduced on demand from a plain `Broiler.Cli` run. The reported
+challenge was larger and did.
+
+### What is not the cause
+
+- **The clock.** `performance.now()` and `performance.timeOrigin` are present,
+  positive, non-decreasing and sub-hour, matching Node's on the same probe;
+  `u()`'s constant `NM` base cancels in the subtraction, so a wrong origin could
+  not produce a wrong delta. One caveat for future readers:
+  `WindowDocumentMiscBinding.PerformanceNow` derives from
+  `DateTimeOffset.UtcNow`, so it is whole-millisecond and follows the wall clock
+  rather than a monotonic source. A clock step (an NTP correction, a VM resume)
+  of more than 16.4 s, twice, would trip this same watchdog with the engine
+  entirely idle. Nothing suggests that happened here, but it is the one way to
+  reach the failure without being slow.
+- **`document.hidden`, in this VM.** The full yield predicate is
+  `D.rW > 0 && … && document.hidden == 0`, and `D.rW` is `0` in the reported
+  program — so the predicate is false whatever `document.hidden` says. It was
+  missing anyway, and is [fixed below](#what-changed-here).
+- **Language semantics.** A 124-expression differential probe — `ToInt32` and
+  the shifts on fractional/negative/out-of-range doubles, the abstract-equality
+  corners this obfuscator switches on (`![] == Number()`,
+  `[] == (null != ((true == ![]) != ![]))`), left-to-right evaluation of nested
+  assignment/comma chains, `try`/`finally`, labelled `break`, throwing arrays,
+  accessor properties via `Object.create`/`defineProperty` — matches Node
+  exactly, with `document.hidden` the only divergence.
+
+## Measurements
+
+All figures below are one container, one saved copy of the interstitial, replayed
+from `http://127.0.0.1` so both engines see identical bytes.
+
+Per-opcode profile of the outer dispatch loop (23 dispatches, 16 distinct
+opcodes):
+
+| | Chromium | Broiler |
+| --- | --- | --- |
+| Total dispatch time | 33 ms | 6 302 ms |
+| Slowest single opcode | ~1 ms | 175 ms |
+
+Most of Broiler's time is *not* in opcode bodies: under a second of the 6 302 ms
+is, and the rest is compiling the program and running the constructor's own
+expression. `new Function(src)` on the 62 887-byte VM measures 521 ms against
+Chromium's 3.9 ms, and a second compile of the same text is 2 ms, so the
+compiler's cache works and the cost is a genuine first-compile cost.
+
+A live run measured with the script below: 69 slices, slowest 712 ms, **23×
+headroom**.
+
+This is the engine-throughput campaign's territory, not a bug with a discrete
+fix; it is tracked in
+[`Broiler.JS/docs/roadmap/Roadmap.md`](../Broiler.JS/docs/roadmap/Roadmap.md).
+
+## Measuring a build's headroom
+
+```sh
+python scripts/measure-google-challenge-headroom.py
+python scripts/measure-google-challenge-headroom.py --configuration Debug
+python scripts/measure-google-challenge-headroom.py --page saved-challenge.html
+```
+
+It fetches the interstitial (or reads one), installs an `eval` hook that rewrites
+the VM's timing check so each slice is reported without changing what the VM
+computes, replays the page under `Broiler.Cli --capture-image`, and prints the
+slowest slice against the 16 384 ms budget:
+
+```
+configuration : Release
+challenge     : solved
+VM wall time  : 10712 ms
+slices        : 69 (clock samples: 69)
+slowest slice : 712.0 ms
+watchdog      : 16384 ms per slice, two stalls poison the VM
+headroom      : 23.0x
+```
+
+Google does not serve the interstitial to every request; the script says so and
+exits 2 rather than reporting a number it did not measure. It also exits
+non-zero if the obfuscation has been re-spun far enough that its two rewrite
+patterns no longer match — those patterns are the only part of it that Google
+can invalidate.
+
+## What changed here
+
+`document.hidden` and `document.visibilityState` are now registered on
+`document` (`false` and `"visible"`: a capture renders one document in one
+viewport and never backgrounds it).
+
+This does **not** fix the reported failure — `D.rW == 0` short-circuits the
+predicate before `document.hidden` is reached in this particular program. It is
+worth having regardless. Pages spell the check as a loose comparison, and
+`undefined` is not a third state any of them have a branch for: `document.hidden
+== 0` is `true` for `false` and `false` for `undefined`, so an absent property
+reads as "backgrounded" to the idiom that is actually used. In a serve where
+`rW > 0` it would also decide whether the VM samples per dispatch or per four
+dispatches — a 4× difference in the very quantity the watchdog compares against.
+
+Covered by `Document_Hidden_Is_False_And_Compares_Loosely_To_Zero` and
+`Document_VisibilityState_Is_Visible` in `GoogleSearchPolyfillTests`.
+
+### Other gaps this turned up, not fixed here
+
+Observed missing on `document` while probing, none of them on this failure's
+path: `readyState`, `hasFocus`, `referrer`, `domain`, `lastModified`, `charset`,
+`activeElement`, `currentScript`. On `window`: `trustedTypes`,
+`requestIdleCallback`, `structuredClone`, `OffscreenCanvas`,
+`onvisibilitychange`.
+
+## Reading a future report of this shape
+
+`Cannot get property length of undefined` from a `vmNN.js` frame on a Google
+property is this page until shown otherwise. Before looking at the engine:
+
+1. Dump the program with `BROILER_JS_DUMP_PROGRAMS` and check whether it defines
+   `knitsail` — if it does, it is this VM.
+2. Grep it for `>>14>0`. If that expression is present, the 16 384 ms watchdog
+   is present, and a slow build is the first hypothesis.
+3. Run `scripts/measure-google-challenge-headroom.py` on the same build. A
+   headroom under ~10× makes it the likely explanation; a large headroom points
+   somewhere else and is worth chasing.

--- a/scripts/measure-google-challenge-headroom.py
+++ b/scripts/measure-google-challenge-headroom.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Measure a Broiler build's headroom against Google Search's bot-check watchdog.
+
+Google serves an interstitial before search results ("Please click here if you are
+not redirected within a few seconds") whose JavaScript solves a challenge in an
+obfuscated bytecode VM, sets the `SG_SS` cookie and only then navigates to the
+results.  That VM times itself: once per few dispatches it samples the clock, and
+a sample longer than `1 << 14` = 16384 ms counts as a stall.  On the *second*
+stall it overwrites its own interpreter-context pointer with the boolean `true`,
+and the next opcode that dereferences it dies with
+
+    TypeError: Cannot get property length of undefined
+
+which is reported against `JSUndefined.cs` and an anonymous `vmNN.js` frame.  The
+engine is not at fault at the throw site; it is simply slow enough that the page
+gave up on it.  See docs/google-search-post-consent-challenge.md.
+
+This script measures the margin.  It fetches (or reads) the interstitial, rewrites
+the VM's own timing check through an `eval` hook so each sample is reported, replays
+the page under `Broiler.Cli --capture-image`, and prints the slowest slice against
+the 16384 ms budget.
+
+Usage:
+    python scripts/measure-google-challenge-headroom.py
+    python scripts/measure-google-challenge-headroom.py --configuration Debug
+    python scripts/measure-google-challenge-headroom.py --page saved-challenge.html
+
+Google does not always serve the interstitial.  When it does not, the script says
+so and exits 2; save a page that does and pass it with --page.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.server
+import re
+import shutil
+import socketserver
+import subprocess
+import sys
+import tempfile
+import threading
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+# The VM's own threshold: it stalls on `<sample> >> 14 > 0`.
+WATCHDOG_MS = 1 << 14
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Installed ahead of the page's own scripts.  The VM is built by an inline script as
+# a joined string array and handed to an indirect `eval`, so replacing `window.eval`
+# is enough to see — and rewrite — its source before it compiles.  Both rewrites
+# preserve the VM's semantics exactly: `__uv` and `__probe` are called for effect
+# and the comparison they sit in keeps its original operands.
+INSTRUMENTATION = """<script>
+(function(){
+  var realEval = window.eval;
+  var slices = 0, samples = 0, maxSlice = 0, patched = 0, vmStart = 0, solvedAt = 0;
+  window.__uv = function(){ slices++; };
+  window.__probe = function(delta){ samples++; if (delta > maxSlice) maxSlice = delta; return 0; };
+  // W(a) navigates away once the challenge is solved; window.pr short-circuits that so the
+  // measurement survives to be reported, and tells us the challenge actually succeeded.
+  window.pr = function(){ solvedAt = Date.now(); };
+  window.__report = function(tag){
+    console.log("CHALLENGE " + tag +
+                " patched=" + patched +
+                " solved=" + (solvedAt ? 1 : 0) +
+                " slices=" + slices +
+                " samples=" + samples +
+                " maxSliceMs=" + maxSlice.toFixed(1) +
+                " vmWallMs=" + (vmStart ? ((solvedAt || Date.now()) - vmStart) : -1));
+  };
+  window.eval = function(source){
+    var text = (typeof source === "string") ? source : String(source);
+    if (text.indexOf("document.hidden==0") < 0) return realEval(source);
+    var rewritten = text
+      .replace(/&&document\\.hidden==0,([A-Za-z_$][\\w$]*)\\.([A-Za-z_$][\\w$]*)==4\\)/,
+               "&&document.hidden==0,(window.__uv(),$1.$2)==4)")
+      .replace(/,([A-Za-z_$][\\w$]*)\\)>>14>0/,
+               ",$1)>>14>(window.__probe($1),0)");
+    patched = (rewritten !== text) ? 1 : 0;
+    vmStart = Date.now();
+    return realEval(rewritten);
+  };
+  setTimeout(function(){ window.__report("interim"); }, 2000);
+  setTimeout(function(){ window.__report("final"); }, 20000);
+})();
+</script>
+"""
+
+
+def fetch_challenge(query: str) -> str:
+    url = f"https://www.google.com/search?q={urllib.parse.quote(query)}"
+    request = urllib.request.Request(url, headers={
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Broiler/1.0",
+        "Accept": "text/html,application/xhtml+xml",
+    })
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return response.read().decode("utf-8", "replace")
+
+
+def is_challenge_page(html: str) -> bool:
+    # The interstitial carries the SG cookie name its script sets, and the inline VM
+    # whose throttling check this script rewrites.
+    return "SG_SS" in html and "document.hidden==0" in html
+
+
+def instrument(html: str) -> str:
+    head = re.search(r"<head[^>]*>", html, re.IGNORECASE)
+    if not head:
+        raise SystemExit("page has no <head> to install the eval hook into")
+    return html[: head.end()] + INSTRUMENTATION + html[head.end() :]
+
+
+def serve(directory: Path) -> tuple[socketserver.TCPServer, int]:
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *a, **kw):
+            super().__init__(*a, directory=str(directory), **kw)
+
+        # The page beacons to /gen_204 and asks for assets this directory does not
+        # have; those are expected and say nothing about the measurement.
+        def log_message(self, *_a):
+            pass
+
+    class Quiet(socketserver.TCPServer):
+        allow_reuse_address = True
+
+    server = Quiet(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, server.server_address[1]
+
+
+def run_capture(url: str, configuration: str, workdir: Path) -> list[str]:
+    diagnostics = workdir / "diagnostics"
+    command = [
+        "dotnet", "run", "--project", str(REPO_ROOT / "src" / "Broiler.Cli"),
+        "-c", configuration, "--",
+        "--capture-image", url,
+        "--output", str(workdir / "capture.png"),
+        "--diagnostic-dir", str(diagnostics),
+    ]
+    subprocess.run(command, cwd=REPO_ROOT, check=False,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=900)
+    log = diagnostics / "console.log"
+    return log.read_text("utf-8", "replace").splitlines() if log.exists() else []
+
+
+def parse_report(lines: list[str]) -> dict[str, str] | None:
+    best = None
+    for line in lines:
+        marker = line.find("CHALLENGE ")
+        if marker < 0:
+            continue
+        fields = dict(
+            part.split("=", 1)
+            for part in line[marker + len("CHALLENGE "):].split()
+            if "=" in part
+        )
+        # The later report supersedes the earlier one.
+        best = fields
+    return best
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--page", type=Path,
+                        help="a saved interstitial to replay instead of fetching one")
+    parser.add_argument("--query", default="broiler",
+                        help="search term to request when fetching (default: broiler)")
+    parser.add_argument("--configuration", default="Release",
+                        help="build configuration to measure (default: Release)")
+    parser.add_argument("--keep", action="store_true",
+                        help="keep the working directory and print its path")
+    args = parser.parse_args()
+
+    html = args.page.read_text("utf-8", "replace") if args.page else fetch_challenge(args.query)
+
+    if not is_challenge_page(html):
+        print("The page served is not the bot-check interstitial "
+              "(no SG_SS cookie and no VM throttling check in it).")
+        print("Nothing to measure. Retry, or save a page that is one and pass --page.")
+        return 2
+
+    workdir = Path(tempfile.mkdtemp(prefix="broiler-challenge-"))
+    try:
+        site = workdir / "site"
+        site.mkdir()
+        (site / "challenge.html").write_text(instrument(html), "utf-8")
+
+        server, port = serve(site)
+        try:
+            lines = run_capture(f"http://127.0.0.1:{port}/challenge.html",
+                                args.configuration, workdir)
+        finally:
+            server.shutdown()
+
+        report = parse_report(lines)
+        if report is None:
+            print("The capture produced no measurement. Console output was:")
+            print("\n".join(lines) or "  (empty)")
+            return 1
+        if report.get("patched") != "1":
+            print("The eval hook saw the VM but could not rewrite its timing check; "
+                  "Google has re-spun the obfuscation and the patterns in this script "
+                  "need updating.")
+            return 1
+
+        max_slice = float(report["maxSliceMs"])
+        headroom = WATCHDOG_MS / max_slice if max_slice > 0 else float("inf")
+        print(f"configuration : {args.configuration}")
+        print(f"challenge     : {'solved' if report.get('solved') == '1' else 'NOT solved'}")
+        print(f"VM wall time  : {report['vmWallMs']} ms")
+        print(f"slices        : {report['slices']} (clock samples: {report['samples']})")
+        print(f"slowest slice : {max_slice:.1f} ms")
+        print(f"watchdog      : {WATCHDOG_MS} ms per slice, two stalls poison the VM")
+        print(f"headroom      : {headroom:.1f}x")
+        if headroom < 10:
+            print("\nLess than 10x margin. A heavier challenge, a slower machine or a "
+                  "debug build can cross the threshold, and the page then fails with "
+                  "'TypeError: Cannot get property length of undefined'.")
+        return 0
+    finally:
+        if args.keep:
+            print(f"\nworking directory: {workdir}")
+        else:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/Broiler.Cli.Tests/GoogleSearchPolyfillTests.cs
+++ b/src/Broiler.Cli.Tests/GoogleSearchPolyfillTests.cs
@@ -252,6 +252,40 @@ public class GoogleSearchPolyfillTests
         Assert.Contains("GT0:true", result);
     }
 
+    // ---------------------------------------------------------------
+    //  Page Visibility — document.hidden / document.visibilityState
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// A capture's document is never backgrounded, so <c>document.hidden</c> is <c>false</c> —
+    /// but it has to be present. Scripts read it with a loose comparison, and `undefined` is not
+    /// the same answer as `false`: Google Search's bot-check VM gates its "may I yield?" predicate
+    /// on <c>document.hidden == 0</c>, which an absent property turns permanently false. See
+    /// docs/google-search-post-consent-challenge.md.
+    /// </summary>
+    [Fact]
+    public void Document_Hidden_Is_False_And_Compares_Loosely_To_Zero()
+    {
+        var result = ExecJs(@"
+            document.getElementById('result').textContent =
+                'TYPE:' + typeof document.hidden +
+                ',VALUE:' + document.hidden +
+                ',EQ0:' + (document.hidden == 0);
+        ");
+        Assert.Contains("TYPE:boolean", result);
+        Assert.Contains("VALUE:false", result);
+        Assert.Contains("EQ0:true", result);
+    }
+
+    [Fact]
+    public void Document_VisibilityState_Is_Visible()
+    {
+        var result = ExecJs(@"
+            document.getElementById('result').textContent = 'STATE:' + document.visibilityState;
+        ");
+        Assert.Contains("STATE:visible", result);
+    }
+
     [Fact]
     public void Performance_GetEntriesByType_Returns_Array()
     {

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Document.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Document.cs
@@ -202,5 +202,16 @@ public sealed partial class DomBridge
 
         // document.inputEncoding — alias for characterSet
         document.FastAddProperty((KeyString)"inputEncoding", new JSFunction((in _) => new JSString("UTF-8"), "get inputEncoding"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+        // document.hidden / document.visibilityState (Page Visibility, HTML §6.6). A capture
+        // renders one document in one viewport and never backgrounds it, so the answer is always
+        // "visible" — but it has to be *an* answer. Absent, `document.hidden` reads `undefined`,
+        // and the idiom scripts spell it with is a loose comparison: Google Search's bot-check VM
+        // gates its "may I yield to the event loop?" predicate on `document.hidden == 0`, which is
+        // true for `false` and false for `undefined`. A missing property does not read as
+        // "not hidden"; it reads as a third state no page has a branch for. See
+        // docs/google-search-post-consent-challenge.md.
+        document.FastAddProperty((KeyString)"hidden", new JSFunction((in _) => JavaScript.BuiltIns.Boolean.JSBoolean.False, "get hidden"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
+        document.FastAddProperty((KeyString)"visibilityState", new JSFunction((in _) => new JSString("visible"), "get visibilityState"), null, JSPropertyAttributes.EnumerableConfigurableProperty);
     }
 }


### PR DESCRIPTION
## Summary

Explains the reported `TypeError: Cannot get property length of undefined` at `JSUndefined.cs:41`, under a dozen `vm97.js` frames, seen when a Google search stalls after the consent page — and fixes the one engine-side gap the investigation turned up.

The throw is not an engine defect at the throw site. `vm97.js` is Google's bot-check VM, `eval`'d by the interstitial that stands between the consent form and search results. The VM times itself: once per four dispatches it samples the clock, and `d >> 14 > 0` — a slice longer than **16,384 ms** — increments a counter that starts at 1. From 3 onward it overwrites its own interpreter-context pointer with the boolean `true`, and the next opcode to dereference it reads `true.yl`, gets `undefined`, and asks for `.length`.

What is ours is the speed that gets it there. On identical bytes, replayed from disk, Broiler runs this VM ~250× slower than Chromium (5,989 ms against 24 ms) and its slowest slice is ~108× longer (584 ms against 5.4 ms) into that 16,384 ms budget. A live capture measures 23× headroom; a debug build, slower hardware, or a heavier challenge is what spends it. That root cause is engine throughput and is tracked in the JS engine's roadmap, not fixed here.

## Changes

- **`docs/google-search-post-consent-challenge.md`** (new): the investigation. How to identify the interstitial, how to obtain `vmNN.js` (`BROILER_JS_DUMP_PROGRAMS`), the decode of every frame in the trace against the program's AST, the watchdog with its source, the measurements, and a triage checklist for the next report of this shape. Also records what was ruled out: the clock, and a 124-expression differential probe of the language corners this obfuscator leans on (`ToInt32`/shifts on fractional and out-of-range doubles, the abstract-equality forms it `switch`es on, evaluation order in nested assignment/comma chains, `try`/`finally`, thrown arrays, accessor properties), which matches Node exactly.

- **`scripts/measure-google-challenge-headroom.py`** (new): makes the margin measurable on any build. Fetches (or reads, via `--page`) the interstitial, installs an `eval` hook that rewrites the VM's own timing check so each slice is reported without changing what the VM computes, replays the page under `Broiler.Cli --capture-image`, and prints the slowest slice against the 16,384 ms threshold. Exits 2 when Google did not serve the interstitial and 1 when the rewrite patterns no longer match, rather than reporting a number it did not measure.

- **`Document.cs`**: register `document.hidden` (`false`) and `document.visibilityState` (`"visible"`). A capture renders one document in one viewport and never backgrounds it, so the answer is always "visible" — but it has to be *an* answer. Pages spell the check as a loose comparison, and `document.hidden == 0` is `true` for `false` but `false` for `undefined`, so an absent property reads as "backgrounded" to the idiom that is actually used.

- **`GoogleSearchPolyfillTests.cs`**: `Document_Hidden_Is_False_And_Compares_Loosely_To_Zero` and `Document_VisibilityState_Is_Visible`.

## Scope of the fix

The `document.hidden` change does **not** resolve the reported failure. The VM's full yield predicate is `D.rW > 0 && … && document.hidden == 0`, and `D.rW` — the yield budget, not the watchdog counter — is `0` in the analysed program, so the predicate is false whatever `document.hidden` says. It is worth having regardless, and in a serve where `rW > 0` it would also decide whether the VM samples per dispatch or per four dispatches: a 4× difference in the very quantity the watchdog compares against.

## Verification

148 passed / 12 failed across the touched test classes. The identical 12 fail on a stashed baseline without this change — font-metric and SVG hit-test tests that `CLAUDE.md` flags as environmental in a bare container. The two new tests fail without the fix and pass with it. No submodule changes, so no patch under `patches/` was needed.

https://claude.ai/code/session_01DxaY5zGqNmFX6SRwktWtaa