### PR TITLE
Identify all HTTP requests with a User-Agent header

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/BroilerUserAgentTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/BroilerUserAgentTests.cs
@@ -1,0 +1,93 @@
+using System.Net.Http;
+using Broiler.Layout.Net;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// The one string every Broiler loader identifies itself with, and the helper that puts it on a
+/// client.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The bug this exists for is an <em>absent</em> header rather than a wrong one: <c>HttpClient</c>
+/// sends no <c>User-Agent</c> at all by default, and Wikimedia's policy answers a request carrying
+/// none with <c>403 Forbidden</c> before anything else about it matters. So the cases worth pinning
+/// are that the value is not empty and that <see cref="BroilerUserAgent.Apply"/> actually lands it
+/// on the wire — not the exact wording, which sites are free to disagree about.
+/// </para>
+/// <para>
+/// Asserted through a handler rather than off <c>DefaultRequestHeaders</c>, because
+/// <c>User-Agent</c> is a <em>typed</em> header: <c>TryGetValues</c> hands back the three product
+/// tokens (<c>Mozilla/5.0</c>, <c>(Windows NT 10.0; Win64; x64)</c>, <c>Broiler/1.0</c>) that .NET
+/// re-joins with spaces on the way out. Comparing against the collection would test that split, not
+/// the header a server reads.
+/// </para>
+/// </remarks>
+public sealed class BroilerUserAgentTests
+{
+    [Fact]
+    public void The_Value_Is_A_Non_Empty_Token_Naming_The_Product()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(BroilerUserAgent.Value));
+        Assert.Contains("Broiler", BroilerUserAgent.Value);
+    }
+
+    [Fact]
+    public void Apply_Returns_The_Client_It_Identified()
+    {
+        using var client = new HttpClient();
+
+        Assert.Same(client, BroilerUserAgent.Apply(client));
+    }
+
+    [Fact]
+    public async Task An_Applied_Client_Puts_The_Value_On_The_Wire()
+    {
+        Assert.Equal(BroilerUserAgent.Value, await SentUserAgentAsync(chosen: null));
+    }
+
+    /// <summary>
+    /// A default, not an override. A caller that has already chosen a <c>User-Agent</c> for a
+    /// request keeps it — which is what <c>fetch()</c> with an explicit header in its init relies on.
+    /// </summary>
+    [Fact]
+    public async Task A_Request_That_Names_Its_Own_User_Agent_Keeps_It()
+    {
+        Assert.Equal("Chosen/9", await SentUserAgentAsync(chosen: "Chosen/9"));
+    }
+
+    /// <summary>
+    /// The <c>User-Agent</c> an identified client actually sends for one request, joined as the
+    /// header is written. Empty string when none was sent, so the original defect — no header at
+    /// all — reads as a failed comparison rather than an absent one.
+    /// </summary>
+    private static async Task<string> SentUserAgentAsync(string? chosen)
+    {
+        using var handler = new CapturingHandler();
+        using var client = BroilerUserAgent.Apply(new HttpClient(handler));
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.invalid/");
+        if (chosen is not null)
+            request.Headers.TryAddWithoutValidation("User-Agent", chosen);
+
+        using var response = await client.SendAsync(request);
+        return handler.SeenUserAgent;
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        internal string SeenUserAgent { get; private set; } = string.Empty;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            System.Threading.CancellationToken cancellationToken)
+        {
+            SeenUserAgent = request.Headers.TryGetValues("User-Agent", out var values)
+                ? string.Join(" ", values)
+                : string.Empty;
+
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+        }
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Net/BroilerUserAgent.cs
+++ b/Broiler.Layout/Broiler.Layout/Net/BroilerUserAgent.cs
@@ -1,0 +1,63 @@
+using System.Net.Http;
+
+namespace Broiler.Layout.Net;
+
+/// <summary>
+/// The product token Broiler puts in the HTTP <c>User-Agent</c> request header, and the one
+/// <c>navigator.userAgent</c> reports to script — one string, so the engine tells the network and
+/// the page the same thing about itself.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="HttpClient"/> sends <em>no</em> <c>User-Agent</c> at all unless one is configured, and
+/// a missing header is not the same as an unrecognised one: Wikimedia's User-Agent policy rejects a
+/// request that carries none with <c>403 Forbidden</c> before it looks at anything else, so
+/// <c>https://www.mediawiki.org/wiki/MediaWiki</c> failed instantly for every Broiler entry point —
+/// the CLI capture, the browser window, and every sub-resource each of them went on to request. Any
+/// non-empty token is accepted there; what the policy will not have is silence.
+/// </para>
+/// <para>
+/// It lives in <c>Broiler.Layout</c> because that is the one assembly every requesting layer already
+/// references — <c>Broiler.Cli</c> and <c>Broiler.Browser.Core</c> reach it through
+/// <c>Broiler.HtmlBridge.Dom</c>, and the <c>Broiler.HTML</c> submodule's own loaders (stylesheets,
+/// images, web fonts) reference it directly. A constant duplicated per requesting assembly is a
+/// constant that drifts, and the header drifting away from <c>navigator.userAgent</c> is exactly the
+/// inconsistency a site sniffing both would catch.
+/// </para>
+/// <para>
+/// Unrelated to <c>CssUserAgentDefaults</c> despite the shared words: that is the CSS <em>user-agent
+/// stylesheet</em>, the engine's built-in presentation defaults. This is the network identity, which
+/// is why it sits under a <c>Net</c> namespace.
+/// </para>
+/// </remarks>
+public static class BroilerUserAgent
+{
+    /// <summary>
+    /// The full <c>User-Agent</c> value. The <c>Mozilla/5.0</c> prefix is not a claim to be Gecko —
+    /// it is the compatibility token every engine has carried since Netscape, and a server sniffing
+    /// for it is the reason to keep it. <c>Broiler/1.0</c> is the part that actually names the
+    /// product.
+    /// </summary>
+    public const string Value = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Broiler/1.0";
+
+    /// <summary>
+    /// Makes <see cref="Value"/> the default <c>User-Agent</c> of <paramref name="client"/> and
+    /// returns it, so a client can be identified where it is constructed:
+    /// <c>BroilerUserAgent.Apply(new HttpClient { Timeout = … })</c>.
+    /// </summary>
+    /// <remarks>
+    /// Added without validation because the value is a compile-time constant that has already been
+    /// checked, and because a parse failure here would cost the request the header it is being given
+    /// — the failure this exists to prevent. It is a <em>default</em>: a request that carries its own
+    /// <c>User-Agent</c> (a <c>fetch()</c> whose init named one) keeps it, which is the precedence
+    /// <see cref="HttpClient.DefaultRequestHeaders"/> already defines.
+    /// </remarks>
+    /// <param name="client">The client to identify.</param>
+    /// <returns><paramref name="client"/>, for chaining at a field initialiser.</returns>
+    public static HttpClient Apply(HttpClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", Value);
+        return client;
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,38 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- Broiler now says who is asking. `HttpClient` sends **no** `User-Agent` unless one is
+  configured, and a request carrying none is not one every server will answer: Wikimedia's
+  User-Agent policy replies `403 Forbidden` before content negotiation, before the redirect,
+  before the page is even looked up. So `https://www.mediawiki.org/wiki/MediaWiki` failed
+  instantly in both the CLI and the browser window — "Capture failed: Response status code
+  does not indicate success: 403 (Forbidden)" — with nothing about the page involved. Any
+  non-empty token is accepted there; what the policy will not have is silence. Full account in
+  [`docs/mediawiki-user-agent-403.md`](docs/mediawiki-user-agent-403.md).
+  - **It was every loader, not one.** Each of Broiler's loaders builds its own `HttpClient`, so
+    each was independently unidentified, and a header set only where the failure was reported
+    buys a page that loads and then fails again per resource. With just the document fixed, a
+    `--diagnostic-dir` capture of that page still lost
+    `load.php?modules=startup` — the bootstrap that pulls in every other module on the page — to
+    the same `403`. The header now comes from one constant,
+    `Broiler.Layout.Net.BroilerUserAgent`, applied at the document (`Broiler.Cli`), navigation
+    (`Broiler.Browser.Core`), external-script (`Broiler.HtmlBridge.Core`), and
+    stylesheet/sub-resource/`fetch()`/XHR (`Broiler.HtmlBridge.Dom`) loaders alike, plus the
+    engine-baseline tool. A capture of the page goes from an instant failure to 13 resources and
+    0 failures.
+  - `Broiler.Layout` is the home because it is the one assembly every loader already reaches —
+    including the `<link>`, `<img>` and web-font loaders inside the `Broiler.HTML` submodule,
+    which reference it for `OfflineSubresources`. Their identical one-line fix ships as
+    `patches/0002-say-who-is-asking.patch`; until it is applied and the pointer bumped, a build
+    against the pinned pointer still renders that page unstyled and pictureless, because
+    `HtmlRender` fetches a page's sheets through the submodule's loader rather than the bridge's.
+  - `navigator.userAgent` reads the same constant instead of a second literal of the same string,
+    so a page comparing what it was told with what its own `fetch()` reports gets one answer. The
+    value it reports is unchanged.
+  - Not only mediawiki.org: `tests/real-world-sites/sites.json` already tracked
+    `https://en.wikipedia.org/wiki/Web_browser`, which refused an unidentified request for the
+    same reason.
+
 - `Broiler.HtmlBridge.Dom` — `document.currentScript` was not bound, so it read `undefined`
   and the idiomatic dereference threw. Google's tag-manager loader, served on
   `about.google` — where `google.com`'s "About" link leads — opens with

--- a/docs/mediawiki-user-agent-403.md
+++ b/docs/mediawiki-user-agent-403.md
@@ -1,0 +1,97 @@
+# `mediawiki.org` — the instant `403 Forbidden`
+
+Opening `https://www.mediawiki.org/wiki/MediaWiki` in either entry point failed before anything was
+parsed:
+
+```
+$ dotnet run --project src/Broiler.Cli -- --url https://www.mediawiki.org/wiki/MediaWiki --output mw.html
+Capture failed: Response status code does not indicate success: 403 (Forbidden).
+```
+
+Nothing about the page is involved. The request never carried a `User-Agent`.
+
+## Why a missing header is not a mild version of an unrecognised one
+
+`HttpClient` sends **no** `User-Agent` at all unless one is configured — it is not a header .NET
+fills in. Wikimedia's [User-Agent policy][policy] refuses a request that carries none, and refuses
+it early: the status is decided before content negotiation, before the redirect, before the page is
+looked up. Any non-empty token is accepted, so this is not a matter of naming the right browser:
+
+| `User-Agent` sent | `https://www.mediawiki.org/wiki/MediaWiki` |
+| --- | --- |
+| *header absent* | `403` |
+| `Broiler/1.0` | `200` |
+| `Mozilla/5.0 (Windows NT 10.0; Win64; x64) Broiler/1.0` | `200` |
+| a current Chrome token | `200` |
+
+Reproduce the boundary without Broiler at all:
+
+```sh
+curl -s -o /dev/null -w '%{http_code}\n' -H 'User-Agent:' https://www.mediawiki.org/wiki/MediaWiki   # 403
+curl -s -o /dev/null -w '%{http_code}\n' -A 'Broiler/1.0'  https://www.mediawiki.org/wiki/MediaWiki   # 200
+```
+
+## It was every loader, not one
+
+The document is the request that produced the reported message, and fixing only that one produces a
+page that loads and then fails a second time per resource — each of Broiler's loaders builds its own
+`HttpClient`, so each was independently unidentified. After the document was fixed, a capture with
+`--diagnostic-dir` reported:
+
+```
+Diagnostics: 2 JavaScript failure(s), 12 resource(s)
+
+## Resources that failed to load
+
+- `https://www.mediawiki.org/w/load.php?lang=en&modules=startup&only=scripts&raw=1&skin=vector-2022`
+  — Response status code does not indicate success: 403 (Forbidden).
+```
+
+`load.php?modules=startup` is the bootstrap that pulls in every other module on the page, so the
+whole skin's JavaScript was gone for the same reason the page had been. The photographs are on
+`upload.wikimedia.org`, which applies the same policy, and so are the `<link>` stylesheets.
+
+The fix is therefore one constant — `Broiler.Layout.Net.BroilerUserAgent` — applied at every
+construction site, rather than a header set where the bug was noticed:
+
+| Loader | Where | Fetches |
+| --- | --- | --- |
+| `CaptureService.CreateHttpClient` | `src/Broiler.Cli` | the CLI's document (and any followed link) |
+| `BrowserApp.CreatePageHttpClient` | `src/Broiler.Browser.Core` | every browser-window navigation |
+| `ScriptExtractionService.SharedHttpClient` | `src/Broiler.HtmlBridge.Core` | external `<script src>` |
+| `ResourceLoader.SharedClient` | `src/Broiler.HtmlBridge.Dom` | stylesheets, sub-resources, `fetch()`, XHR |
+| `Program.HttpClient` | `src/Broiler.Engines.Baseline` | test262 sources and dependency metadata |
+| `StylesheetLoadHandler.SharedHttpClient` | `Broiler.HTML` (submodule) | `<link rel=stylesheet>` on the render path |
+| `ImageDownloader.SharedHttpClient` | `Broiler.HTML` (submodule) | `<img>` |
+| `HtmlContainerInt.TryLoadRemoteFont` | `Broiler.HTML` (submodule) | web fonts |
+
+`Broiler.Layout` is the home because it is the one assembly all of them already reach — including
+the three inside the `Broiler.HTML` submodule, which reference it for `OfflineSubresources`. That
+keeps the submodule side of the fix to one line per loader.
+
+### The same string script is told
+
+`navigator.userAgent` already reported `Mozilla/5.0 (Windows NT 10.0; Win64; x64) Broiler/1.0` from
+a literal of its own. It now reads the constant, so a page that compares what it was told with what
+its own `fetch()` reports gets one answer. The value is unchanged; only the number of copies is.
+
+## What the header does not fix
+
+The three submodule loaders are delivered as a patch under `patches/` (the submodule remote is
+outside this session's push scope — see `patches/README.md`), so until a maintainer applies it and
+bumps the pointer, a build against the pinned pointer still fetches `<link>` sheets, images and web
+fonts unidentified. Concretely, on `mediawiki.org` that is the difference between a styled render
+and a bare document flow — `HtmlRender` fetches the page's stylesheets through the submodule's
+`StylesheetLoadHandler`, not through the bridge's `ResourceLoader`.
+
+The document, the external scripts, `fetch()` and XHR are all in the main repository and are fixed
+without the patch, which is what makes the reported failure go away.
+
+## It was not only mediawiki.org
+
+`tests/real-world-sites/sites.json` already tracks `wikipedia-browser`
+(`https://en.wikipedia.org/wiki/Web_browser`), which answers `403` to an unidentified request for
+exactly the same reason. Of the eight sites in that suite it is the only other one that does; the
+rest were served anyway, which is why the policy had not been noticed.
+
+[policy]: https://meta.wikimedia.org/wiki/User-Agent_policy

--- a/patches/0002-say-who-is-asking.patch
+++ b/patches/0002-say-who-is-asking.patch
@@ -1,0 +1,81 @@
+From 9434fde1ffcaf1f04a178c911c52e2542adc32a2 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Wed, 19 Aug 2026 14:37:52 +0000
+Subject: [PATCH] Say who is asking
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+HttpClient sends no User-Agent unless one is configured, and a request that
+carries none is not a request every server will answer: Wikimedia's User-Agent
+policy replies 403 Forbidden before anything else about the request matters. So
+each loader here refused its resource on www.mediawiki.org — the <link>
+stylesheets, the <img> photographs on upload.wikimedia.org, and any web font the
+page asked for — for want of one header, and the page rendered unstyled and
+pictureless even once the document itself had loaded.
+
+Identify all three clients with the engine's own token. It lives in the main
+repository as Broiler.Layout.Net.BroilerUserAgent — already referenced from here
+for OfflineSubresources — so that these loaders and the document, script and
+fetch/XHR loaders outside the submodule cannot drift apart, and so that what a
+server is told matches what navigator.userAgent tells the page.
+---
+ Source/Broiler.HTML.Core/Handlers/ImageDownloader.cs        | 6 +++++-
+ .../Handlers/StylesheetLoadHandler.cs                       | 6 +++++-
+ Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs       | 4 +++-
+ 3 files changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Core/Handlers/ImageDownloader.cs b/Source/Broiler.HTML.Core/Handlers/ImageDownloader.cs
+index 120ea07..c240255 100644
+--- a/Source/Broiler.HTML.Core/Handlers/ImageDownloader.cs
++++ b/Source/Broiler.HTML.Core/Handlers/ImageDownloader.cs
+@@ -23,8 +23,12 @@ internal sealed class ImageDownloader : IDisposable
+     // conformance-checkers/html/elements/img/src-isvalid.html, whose 88 <img> include IP literals
+     // and documentation addresses (http://192.0x00A80001, http://[2001::1]) that black-hole on a
+     // CI runner with real internet.
++    //
++    // Identified, too: HttpClient sends no User-Agent unless given one, and a host that refuses an
++    // unidentified request refuses the image rather than serving a different one — every
++    // upload.wikimedia.org image on a mediawiki.org page came back 403 Forbidden.
+     private static readonly HttpClient SharedHttpClient =
+-        new() { Timeout = TimeSpan.FromSeconds(5) };
++        Broiler.Layout.Net.BroilerUserAgent.Apply(new HttpClient { Timeout = TimeSpan.FromSeconds(5) });
+     private readonly Dictionary<string, List<DownloadFileAsyncCallback>> _imageDownloadCallbacks = [];
+     private readonly CancellationTokenSource _cts = new();
+ 
+diff --git a/Source/Broiler.HTML.Orchestration/Handlers/StylesheetLoadHandler.cs b/Source/Broiler.HTML.Orchestration/Handlers/StylesheetLoadHandler.cs
+index 175fc6e..eae9278 100644
+--- a/Source/Broiler.HTML.Orchestration/Handlers/StylesheetLoadHandler.cs
++++ b/Source/Broiler.HTML.Orchestration/Handlers/StylesheetLoadHandler.cs
+@@ -173,8 +173,12 @@ internal sealed class StylesheetLoadHandler : IStylesheetLoader
+     // any per-test budget — a hang, not a render.  Cap it short so an
+     // unreachable sheet fails fast and the page renders without it (WPT #1147
+     // Timeout cluster, e.g. CSS2/cascade-import-* linking delayed-file CGI URLs).
++    //
++    // Identified, too: HttpClient sends no User-Agent unless given one, and a host that refuses an
++    // unidentified request refuses the sheet rather than serving a different one — the load.php
++    // stylesheets of a mediawiki.org page came back 403 Forbidden, so the page rendered unstyled.
+     private static readonly HttpClient SharedHttpClient =
+-        new() { Timeout = TimeSpan.FromSeconds(5) };
++        Broiler.Layout.Net.BroilerUserAgent.Apply(new HttpClient { Timeout = TimeSpan.FromSeconds(5) });
+ 
+     private string LoadStylesheetFromUri(Uri uri)
+     {
+diff --git a/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs b/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
+index cc65aba..e77f809 100644
+--- a/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
++++ b/Source/Broiler.HTML.Orchestration/HtmlContainerInt.cs
+@@ -601,7 +601,9 @@ public sealed class HtmlContainerInt : IHtmlContainerInt, IDisposable
+         string tempPath = null;
+         try
+         {
+-            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
++            // Identified: a host that refuses an unidentified request refuses the font file too.
++            using var client = Broiler.Layout.Net.BroilerUserAgent.Apply(
++                new HttpClient { Timeout = TimeSpan.FromSeconds(10) });
+             byte[] bytes = client.GetByteArrayAsync(fontUri).GetAwaiter().GetResult();
+             if (bytes == null || bytes.Length == 0)
+                 return;
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # Submodule patches waiting to be applied
 
-**One patch is waiting on a maintainer.** See the index below.
+**Two patches are waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -66,6 +66,37 @@ git -C Broiler.JS merge-base --is-ancestor e75de4ae HEAD
 | # | submodule | subject |
 | --- | --- | --- |
 | `0001` | `Broiler.JS` | Collect a JavaScript stack once, render it as often as asked |
+| `0002` | `Broiler.HTML` | Say who is asking |
+
+### `0002` — the sheets, pictures and fonts a server will not serve an anonymous client
+
+`HttpClient` sends no `User-Agent` unless one is configured, and Wikimedia's User-Agent policy
+answers a request that carries none with `403 Forbidden` before anything else about it matters. Each
+of the three loaders in this submodule builds its own client, so each refused its resource on
+`https://www.mediawiki.org/wiki/MediaWiki`: the `<link>` stylesheets, the `<img>` photographs on
+`upload.wikimedia.org`, and any web font the page asked for. The patch gives all three the engine's
+own token, `Broiler.Layout.Net.BroilerUserAgent` — a main-repository type this submodule already
+references for `OfflineSubresources` — so it is one line per loader and adds no dependency.
+
+**What is live without it, and what is not.** The reported failure — the instant `403` on the
+document itself — is fixed in the main repository and needs nothing from here, as are the external
+scripts, `fetch()` and XHR. What still fails against the pinned pointer is the *render*:
+`HtmlRender` fetches a page's stylesheets through this submodule's `StylesheetLoadHandler` rather
+than through the bridge's `ResourceLoader`, so a capture of that page comes back as bare document
+flow instead of the Vector skin, with the photographs missing. Applying this patch is the whole
+difference. The account is in `docs/mediawiki-user-agent-403.md`.
+
+**Why it is not listed in `scripts/apply-pending-wpt-patches.sh`.** It can only change a resource
+fetched over the network, and the WPT corpus is a directory on disk — the runner installs
+`OfflineSubresources.FetchPolicy` and declines off-corpus URLs before a request is made. No WPT
+pixel can move, so there is nothing for that script to exercise. The suite it *would* show up in is
+`tests/real-world-sites`, which is observational and not part of the WPT gate.
+
+**Why the main repository has no equivalent fallback.** The capture path renders through the static
+`HtmlRender.RenderToFile*` helpers, which construct their own container: there is no host-side
+`StylesheetLoad` handler to answer from, and the alternative — inlining every external sheet into
+the document before handing it over — would mean re-implementing this submodule's relative-URL
+rebasing in the caller, which is a larger change than the patch and a worse one.
 
 ### `0001` — one throw, five frames
 

--- a/src/Broiler.Browser.Core.Tests/BrowserPageClientUserAgentTests.cs
+++ b/src/Broiler.Browser.Core.Tests/BrowserPageClientUserAgentTests.cs
@@ -1,0 +1,29 @@
+using Broiler.Layout.Net;
+
+namespace Broiler.Browser.Core.Tests;
+
+/// <summary>
+/// The browser window's own navigations are identified, not just the CLI's captures.
+/// </summary>
+/// <remarks>
+/// Both entry points had the same defect and only one of them is exercised by a capture test: a
+/// <c>User-Agent</c> added to <c>CaptureService</c> alone would leave <c>Broiler.App</c> answering
+/// <c>403 Forbidden</c> on <c>https://www.mediawiki.org/wiki/MediaWiki</c> exactly as reported. The
+/// browser builds one process-wide client for every navigation, so asserting on that client is
+/// asserting on every page the window will ever load.
+/// </remarks>
+public class BrowserPageClientUserAgentTests
+{
+    [Fact]
+    public void The_Page_Client_Sends_A_User_Agent()
+    {
+        using var client = BrowserApp.CreatePageHttpClient();
+
+        // Joined rather than compared element-wise: User-Agent is a typed header, so the collection
+        // holds the three product tokens .NET re-joins with spaces when it writes the header.
+        Assert.True(
+            client.DefaultRequestHeaders.TryGetValues("User-Agent", out var values),
+            "the browser's page client sends no User-Agent, which mediawiki.org answers 403");
+        Assert.Equal(BroilerUserAgent.Value, string.Join(" ", values!));
+    }
+}

--- a/src/Broiler.Browser.Core/BrowserApp.cs
+++ b/src/Broiler.Browser.Core/BrowserApp.cs
@@ -8,6 +8,7 @@ using Broiler.HtmlBridge;
 using Broiler.Input.Keyboard;
 using Broiler.Input.Mouse;
 using Broiler.Input.Touch;
+using Broiler.Layout.Net;
 using Broiler.UI;
 using Broiler.UI.Button.Standard;
 using Broiler.UI.Dialog;
@@ -451,7 +452,7 @@ internal sealed class BrowserApp : IDisposable
     // Never disposed: it is owned by the process, and outliving every navigation is the point.
     private static readonly HttpClient PageHttpClient = CreatePageHttpClient();
 
-    private static HttpClient CreatePageHttpClient()
+    internal static HttpClient CreatePageHttpClient()
     {
         SocketsHttpHandler handler = new()
         {
@@ -464,7 +465,10 @@ internal sealed class BrowserApp : IDisposable
             ConnectTimeout = TimeSpan.FromSeconds(15),
         };
 
-        return new HttpClient(handler);
+        // Without this the client sends no User-Agent at all, and a server whose policy rejects an
+        // unidentified request answers the navigation itself — mediawiki.org replies 403 Forbidden
+        // before the first byte of the page. See Broiler.Layout.Net.BroilerUserAgent.
+        return BroilerUserAgent.Apply(new HttpClient(handler));
     }
 
     private static async Task<NavigationLoadResult> LoadUrlOnWorkerAsync(PageRequest request, CancellationToken cancellationToken)

--- a/src/Broiler.Cli.Tests/UserAgentHeaderTests.cs
+++ b/src/Broiler.Cli.Tests/UserAgentHeaderTests.cs
@@ -1,0 +1,219 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text;
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+using Broiler.Layout.Net;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Every request Broiler makes says who is making it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>HttpClient</c> sends no <c>User-Agent</c> unless one is configured, and a missing header is
+/// not a milder version of an unrecognised one — it is grounds for refusal. Wikimedia's User-Agent
+/// policy answers an unidentified request <c>403 Forbidden</c> without looking further, so
+/// <c>https://www.mediawiki.org/wiki/MediaWiki</c> failed instantly in both the CLI and the browser,
+/// and went on failing per sub-resource once the document was fixed: the stylesheets, the
+/// <c>load.php?modules=startup</c> bootstrap that pulls in every other module, and the photographs
+/// on <c>upload.wikimedia.org</c> each refused separately, for the same missing header.
+/// </para>
+/// <para>
+/// So the assertion is per resource kind rather than per call site: a header set on the document's
+/// client and nowhere else looks fixed from the outside and still renders an unstyled, script-less
+/// page. What it cannot cover is the loaders inside the <c>Broiler.HTML</c> submodule — the
+/// <c>&lt;link&gt;</c>, <c>&lt;img&gt;</c> and web-font fetchers — whose identical fix ships as a
+/// patch under <c>patches/</c> until a maintainer applies it; asserting on those here would fail
+/// against the pinned pointer CI builds.
+/// </para>
+/// </remarks>
+public sealed class UserAgentHeaderTests : IDisposable
+{
+    private readonly RecordingOrigin _origin = new();
+
+    public void Dispose() => _origin.Dispose();
+
+    /// <summary>
+    /// The reported bug exactly: the top-level document. This is the request that answered 403
+    /// before Broiler had parsed a single byte.
+    /// </summary>
+    [Fact]
+    public async Task The_Document_Request_Is_Identified()
+    {
+        _origin.Serve("page.html", "text/html", "<!DOCTYPE html><html><body>hi</body></html>");
+
+        var output = Path.Combine(Path.GetTempPath(), $"broiler-ua-{Guid.NewGuid():N}.html");
+        try
+        {
+            await new CaptureService().CaptureAsync(new CaptureOptions
+            {
+                Url = _origin.Url("page.html"),
+                OutputPath = output,
+            });
+        }
+        finally
+        {
+            File.Delete(output);
+        }
+
+        AssertEveryRequestIdentified("/page.html");
+    }
+
+    /// <summary>
+    /// The sub-resource half. mediawiki.org served the document once the header was on that one
+    /// client and still refused these, which is what left the page unstyled and its modules unloaded.
+    /// </summary>
+    [Fact]
+    public void Stylesheet_And_Script_Requests_Are_Identified()
+    {
+        _origin.Serve("sheet.css", "text/css", "body { color: red }");
+        _origin.Serve("app.js", "text/javascript", "var loaded = 1;");
+
+        var html = new StringBuilder("<!DOCTYPE html><html><head>")
+            .Append($"""<link rel="stylesheet" href="{_origin.Url("sheet.css")}">""")
+            .Append("</head><body>")
+            .Append($"""<script src="{_origin.Url("app.js")}"></script>""")
+            .Append("</body></html>")
+            .ToString();
+
+        using var context = new JSContext();
+        new DomBridge().Attach(context, html, _origin.Url("page.html"));
+        CaptureService.ExecuteScriptsWithDom(html, _origin.Url("page.html"));
+
+        AssertEveryRequestIdentified("/sheet.css");
+        AssertEveryRequestIdentified("/app.js");
+    }
+
+    /// <summary>
+    /// Asserts <paramref name="path"/> was requested, and that <em>every</em> request for it carried
+    /// the header.
+    /// </summary>
+    /// <remarks>
+    /// Not "exactly one request": a sheet the speculative preload scan has already asked for is
+    /// asked for again by the post-parse collection, and how many round trips a resource costs is a
+    /// different question from whether they identify themselves. Asserting a count here would make
+    /// this test fail for a change to the preload scan.
+    /// </remarks>
+    private void AssertEveryRequestIdentified(string path)
+    {
+        var seen = _origin.UserAgentsFor(path);
+
+        Assert.NotEmpty(seen);
+        Assert.All(seen, agent => Assert.Equal(BroilerUserAgent.Value, agent));
+    }
+
+    /// <summary>
+    /// A page that reads <c>navigator.userAgent</c> and a server that reads the header are asking
+    /// the same question, so they get the same answer. Two literals is how they drift apart.
+    /// </summary>
+    [Fact]
+    public void What_Script_Is_Told_Is_What_The_Network_Is_Told()
+    {
+        const string Html = """<!DOCTYPE html><html><body><div id="out"></div></body></html>""";
+
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, Html, _origin.Url("page.html"));
+
+        var reported = context.Eval("String(navigator.userAgent)").ToString();
+
+        Assert.Equal(BroilerUserAgent.Value, reported);
+    }
+
+    /// <summary>A loopback origin that answers a fixed set of paths and records each request's
+    /// <c>User-Agent</c>.</summary>
+    private sealed class RecordingOrigin : IDisposable
+    {
+        private readonly HttpListener _listener = new();
+        private readonly ConcurrentDictionary<string, (string ContentType, string Body)> _routes = new();
+        private readonly ConcurrentDictionary<string, ConcurrentQueue<string>> _userAgents = new();
+        private readonly string _prefix;
+
+        public RecordingOrigin()
+        {
+            // HttpListener cannot report an OS-assigned port, so one is taken by binding a socket
+            // and closing it — the same pattern LatencyOrigin uses in this project.
+            var probe = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+
+            _prefix = $"http://127.0.0.1:{port}/";
+            _listener.Prefixes.Add(_prefix);
+            _listener.Start();
+            _ = Task.Run(Serve);
+        }
+
+        public string Url(string path) => _prefix + path;
+
+        public void Serve(string path, string contentType, string body) =>
+            _routes["/" + path] = (contentType, body);
+
+        /// <summary>
+        /// Every <c>User-Agent</c> seen on <paramref name="path"/>. A request that carried none
+        /// contributes the empty string rather than nothing, so "the header was missing" fails the
+        /// assertion instead of emptying the collection and passing a sloppier one.
+        /// </summary>
+        public string[] UserAgentsFor(string path) =>
+            _userAgents.TryGetValue(path, out var seen) ? [.. seen] : [];
+
+        private async Task Serve()
+        {
+            while (_listener.IsListening)
+            {
+                HttpListenerContext context;
+                try
+                {
+                    context = await _listener.GetContextAsync().ConfigureAwait(false);
+                }
+                catch (HttpListenerException)
+                {
+                    return; // Disposed.
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
+                }
+
+                _ = Task.Run(() => Answer(context));
+            }
+        }
+
+        private void Answer(HttpListenerContext context)
+        {
+            var path = context.Request.Url?.AbsolutePath ?? "/";
+            _userAgents.GetOrAdd(path, _ => new ConcurrentQueue<string>())
+                .Enqueue(context.Request.Headers["User-Agent"] ?? string.Empty);
+
+            try
+            {
+                if (_routes.TryGetValue(path, out var route))
+                {
+                    var bytes = Encoding.UTF8.GetBytes(route.Body);
+                    context.Response.StatusCode = 200;
+                    context.Response.ContentType = route.ContentType;
+                    context.Response.ContentLength64 = bytes.Length;
+                    context.Response.OutputStream.Write(bytes, 0, bytes.Length);
+                }
+                else
+                {
+                    context.Response.StatusCode = 404;
+                }
+
+                context.Response.Close();
+            }
+            catch (HttpListenerException)
+            {
+                // The client gave up on the response; the header it sent is already recorded.
+            }
+        }
+
+        public void Dispose()
+        {
+            _listener.Close();
+            ((IDisposable)_listener).Dispose();
+        }
+    }
+}

--- a/src/Broiler.Cli/CaptureService.cs
+++ b/src/Broiler.Cli/CaptureService.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Broiler.HTML.Image;
 using Broiler.HtmlBridge.Core.Diagnostics;
+using Broiler.Layout.Net;
 using Broiler.JavaScript.BuiltIns.Null;
 using Broiler.JavaScript.BuiltIns.Boolean;
 using Broiler.JavaScript.Storage;
@@ -256,10 +257,7 @@ public class CaptureService
             throw new IOException($"Cannot create output directory: {ex.Message}", ex);
         }
 
-        using var httpClient = new HttpClient
-        {
-            Timeout = TimeSpan.FromSeconds(options.TimeoutSeconds),
-        };
+        using var httpClient = CreateHttpClient(options.TimeoutSeconds);
 
         var html = await FetchDocumentAsync(httpClient, new Uri(options.Url));
 
@@ -286,6 +284,22 @@ public class CaptureService
             await File.WriteAllTextAsync(options.OutputPath, html);
         }
     }
+
+    /// <summary>
+    /// The client both capture entry points fetch the document (and any followed link) on.
+    /// </summary>
+    /// <remarks>
+    /// It carries a <c>User-Agent</c>, which <see cref="HttpClient"/> otherwise omits entirely. A
+    /// server is free to refuse an unidentified request outright rather than serve it differently,
+    /// and Wikimedia's User-Agent policy does exactly that: <c>https://www.mediawiki.org/wiki/MediaWiki</c>
+    /// answered every capture <c>403 Forbidden</c> — before a redirect, before any content
+    /// negotiation — for want of this one header. See <see cref="BroilerUserAgent"/>.
+    /// </remarks>
+    private static HttpClient CreateHttpClient(int timeoutSeconds) =>
+        BroilerUserAgent.Apply(new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(timeoutSeconds),
+        });
 
     /// <summary>
     /// Fetches the top-level document, recording it when a diagnostic run is listening. The page
@@ -350,10 +364,7 @@ public class CaptureService
 
         string html;
         var uri = new Uri(options.Url);
-        using var httpClient = new HttpClient
-        {
-            Timeout = TimeSpan.FromSeconds(options.TimeoutSeconds),
-        };
+        using var httpClient = CreateHttpClient(options.TimeoutSeconds);
 
         if (uri.IsFile)
         {

--- a/src/Broiler.Engines.Baseline/Program.cs
+++ b/src/Broiler.Engines.Baseline/Program.cs
@@ -40,7 +40,11 @@ internal static partial class Program
         "bridge.mutation",
     };
 
-    private static readonly HttpClient HttpClient = new() { Timeout = TimeSpan.FromSeconds(30) };
+    // Identified like the engine's own loaders — this one fetches test262 sources and dependency
+    // metadata from hosts (github.com among them) that are entitled to refuse a request carrying no
+    // User-Agent at all, which is what HttpClient sends by default.
+    private static readonly HttpClient HttpClient =
+        Broiler.Layout.Net.BroilerUserAgent.Apply(new HttpClient { Timeout = TimeSpan.FromSeconds(30) });
 
     public static async Task<int> Main(string[] args)
     {

--- a/src/Broiler.HtmlBridge.Core/Broiler.HtmlBridge.Core.csproj
+++ b/src/Broiler.HtmlBridge.Core/Broiler.HtmlBridge.Core.csproj
@@ -23,6 +23,14 @@
     <ProjectReference Include="..\..\Broiler.DOM\Broiler.Dom\Broiler.Dom.csproj" />
     <ProjectReference Include="..\..\Broiler.DOM\Broiler.Dom.Html\Broiler.Dom.Html.csproj" />
     <ProjectReference Include="..\..\Broiler.JS\Broiler.JS\Broiler.JavaScript.Engine\Broiler.JavaScript.Engine.csproj" />
+    <!-- For Broiler.Layout.Net.BroilerUserAgent alone: the external-script fetcher here is one of
+         the loaders that has to identify itself, and the engine gets to say what it is called in
+         exactly one place. Broiler.Layout is the assembly every other loader — including the ones
+         inside the Broiler.HTML submodule — already reaches, so putting the constant anywhere else
+         buys this reference back somewhere worse. Nothing in Broiler.Layout's own closure references
+         HtmlBridge, so it cannot cycle, and every consumer of this project already had Broiler.Layout
+         in its closure. -->
+    <ProjectReference Include="..\..\Broiler.Layout\Broiler.Layout\Broiler.Layout.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs
+++ b/src/Broiler.HtmlBridge.Core/Scripting/ScriptExtractionService.cs
@@ -35,7 +35,16 @@ public static partial class ScriptExtractionService
     /// <see cref="HttpClient"/> instances to benefit from connection pooling
     /// and avoid socket exhaustion.
     /// </summary>
-    private static readonly HttpClient SharedHttpClient = new() { Timeout = TimeSpan.FromSeconds(30) };
+    /// <remarks>
+    /// Identified, like every other loader: <see cref="HttpClient"/> sends no <c>User-Agent</c> of its
+    /// own, and a host whose policy rejects an unidentified request rejects the script rather than
+    /// serving a plainer one. mediawiki.org's <c>load.php?modules=startup</c> — the bootstrap that
+    /// loads every other module on the page — answered <c>403 Forbidden</c> for exactly that reason,
+    /// after the document and its stylesheets had already been fixed.
+    /// See <see cref="Broiler.Layout.Net.BroilerUserAgent"/>.
+    /// </remarks>
+    private static readonly HttpClient SharedHttpClient =
+        Layout.Net.BroilerUserAgent.Apply(new HttpClient { Timeout = TimeSpan.FromSeconds(30) });
 
     private static string? GetNonce(IReadOnlyDictionary<string, string> attrs) =>
         attrs.TryGetValue("nonce", out var nonce) ? nonce : null;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
@@ -149,7 +149,9 @@ public sealed partial class DomBridge
     {
         // TODO-G3: navigator object with sendBeacon, userAgent, language, etc.
         var navigatorObj = new JSObject();
-        navigatorObj.FastAddValue((KeyString)"userAgent", new JSString("Mozilla/5.0 (Windows NT 10.0; Win64; x64) Broiler/1.0"), JSPropertyAttributes.EnumerableConfigurableValue);
+        // The same string the network sees, rather than a second copy of it: a page that compares
+        // what it was told with what its own fetches report is entitled to one answer.
+        navigatorObj.FastAddValue((KeyString)"userAgent", new JSString(Layout.Net.BroilerUserAgent.Value), JSPropertyAttributes.EnumerableConfigurableValue);
         navigatorObj.FastAddValue((KeyString)"language", new JSString("en-US"), JSPropertyAttributes.EnumerableConfigurableValue);
         navigatorObj.FastAddValue((KeyString)"languages", new JSArray([new JSString("en-US"), new JSString("en")]), JSPropertyAttributes.EnumerableConfigurableValue);
         navigatorObj.FastAddValue((KeyString)"cookieEnabled", JSBoolean.True, JSPropertyAttributes.EnumerableConfigurableValue);

--- a/src/Broiler.HtmlBridge.Dom/Runtime/ResourceLoader.cs
+++ b/src/Broiler.HtmlBridge.Dom/Runtime/ResourceLoader.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using Broiler.HtmlBridge.Core.Diagnostics;
+using Broiler.Layout.Net;
 
 namespace Broiler.HtmlBridge.Dom.Runtime;
 
@@ -23,7 +24,13 @@ internal sealed class ResourceLoader
     // environment external hosts are unreachable, so a short timeout fails fast (several sequential
     // unreachable fetches still stay well under the per-test budget) instead of hanging the shard.
     private const int TimeoutSeconds = 5;
-    private static readonly HttpClient SharedClient = new() { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
+
+    // Identified, because an unidentified request is one some servers refuse outright rather than
+    // serve differently: Wikimedia answers a request with no User-Agent 403 Forbidden, so every
+    // stylesheet, script, fetch() and XHR a mediawiki.org page asked for here failed even once the
+    // document itself had loaded. See Broiler.Layout.Net.BroilerUserAgent.
+    private static readonly HttpClient SharedClient =
+        BroilerUserAgent.Apply(new HttpClient { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) });
 
     /// <summary>
     /// Host policy on which absolute URLs may be fetched over the network at all, or


### PR DESCRIPTION
## Summary

Broiler now identifies itself in all HTTP requests by sending a `User-Agent` header. This fixes instant `403 Forbidden` responses from servers with User-Agent policies (notably Wikimedia properties like mediawiki.org and wikipedia.org), which reject requests carrying no User-Agent before any other processing.

## Problem

`HttpClient` sends **no** `User-Agent` header by default. Wikimedia's User-Agent policy treats a missing header as grounds for immediate rejection with `403 Forbidden` — before content negotiation, redirects, or page lookup. This caused:
- The CLI to fail instantly on `https://www.mediawiki.org/wiki/MediaWiki`
- The browser window to fail on the same URL
- Every sub-resource (stylesheets, scripts, images, fonts) to fail independently because each loader built its own unidentified `HttpClient`

## Solution

Introduced `Broiler.Layout.Net.BroilerUserAgent` — a single constant and helper method applied at every HTTP client construction site:

- **Main repository loaders** (5 sites):
  - `CaptureService.CreateHttpClient` — CLI document fetches
  - `BrowserApp.CreatePageHttpClient` — browser window navigations
  - `ScriptExtractionService.SharedHttpClient` — external `<script src>`
  - `ResourceLoader.SharedClient` — stylesheets, sub-resources, `fetch()`, XHR
  - `Program.HttpClient` in `Broiler.Engines.Baseline` — test262 sources

- **Submodule loaders** (3 sites, via patch `0002-say-who-is-asking.patch`):
  - `StylesheetLoadHandler.SharedHttpClient` — `<link rel=stylesheet>`
  - `ImageDownloader.SharedHttpClient` — `<img>`
  - `HtmlContainerInt.TryLoadRemoteFont` — web fonts

The constant lives in `Broiler.Layout` because all loaders already reference it (for `OfflineSubresources`), ensuring the header value never drifts and matches what `navigator.userAgent` reports to scripts.

## Key Changes

- Added `Broiler.Layout/Broiler.Layout/Net/BroilerUserAgent.cs` with the constant `"Mozilla/5.0 (Windows NT 10.0; Win64; x64) Broiler/1.0"` and `Apply()` helper
- Updated all HTTP client construction sites in the main repository to call `BroilerUserAgent.Apply()`
- Added comprehensive tests:
  - `BroilerUserAgentTests` — constant value and `Apply()` behavior
  - `UserAgentHeaderTests` — document, stylesheet, and script requests all carry the header
  - `BrowserPageClientUserAgentTests` — browser window client is identified
- Added `docs/mediawiki-user-agent-403.md` documenting the issue, fix scope, and what remains pending
- Updated `CHANGELOG.md` with full account of the fix
- Created `patches/0002-say-who-is-asking.patch` for the three submodule loaders (awaiting maintainer application)

## Implementation Details

- `BroilerUserAgent.Apply()` uses `TryAddWithoutValidation()` to avoid parse failures that would strip the header
- It is a *default*, not an override: requests with their own `User-Agent` (e.g., `fetch()` with an explicit header) keep it
- The header is applied at construction time, not per-request, for efficiency and consistency
- The submodule patch is minimal (one line per loader) because the type is defined in the main repository

https://claude.ai/code/session_01EL2Uu5ZkTrxvQpD7hApcbP