### PR TITLE
Fix test_driver.bless override by testdriver.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,22 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- WPT tests that need a user gesture run again. A test asks for one through
+  `test_driver.bless(intent, action)`, which the conformance runner shims — there is no user in a
+  headless run and nothing checks activation, so the shim just runs the action. But the shim went in
+  *ahead* of the page's scripts and installed itself only if the name was free, and
+  `/resources/testdriver.js` — inlined from the checkout like any other external script — then
+  assigned `window.test_driver` wholesale. Upstream's `bless` appends a "This test requires user
+  interaction" button and waits for a WebDriver click routed through `test_driver_internal`, whose
+  in-tree implementation file is empty, so the promise never settled: **the action never ran, and the
+  button was rendered into the screenshot.** The shim is now its own injected source, assigns
+  unconditionally, and is appended to every `testdriver*.js` the runner inlines, so it wins whatever
+  the page loads and in whichever order. The reftest suite goes **880 → 910 of 1258** across the
+  directories holding a reftest that loads testdriver.js in a partial checkout, nothing regressed —
+  `fullscreen/rendering` from 3/6 to 6/6, the rest customizable-`select`, `interestfor` and
+  `css/css-shadow/part`. See
+  [`docs/wpt-reftests.md`](docs/wpt-reftests.md#testdriverjs-overwrote-the-shim-that-drives-it).
+
 - `https://www.mediawiki.org/` now renders like the same page in the reference browser: 38.9 % of
   pixels matched a Chromium capture of identical bytes at 1024×768 before this work, 82.7 % after,
   and the page is vertically aligned with the reference to the pixel. Everything behind that is a general engine defect that the Vector 2022 skin

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -166,15 +166,29 @@ problems, all at 0.0–1.4% match):
   asserts that `html { display: none; background: green }` still paints the
   canvas green. Chromium renders it white, and so does Broiler — because
   `css/css-backgrounds/background-color-root-propagation-001` asserts the
-  opposite and is the modern rule. Making it pass means regressing that one.
-  **A reftest failing is not by itself evidence of a defect**, and this suite
-  will never tell you which of a contradictory pair to believe.
+  opposite — its title is "don't propagate html background when display:none" —
+  and is the modern rule. Making it pass means regressing that one, which
+  Broiler passes. **A reftest failing is not by itself evidence of a defect**,
+  and this suite will never tell you which of a contradictory pair to believe.
 - **A feature nothing here implements**, where the render is honest and the
   match is 0% anyway: the three `jpegxl/` tests need a JPEG XL decoder (Chromium
-  has none either), the `fullscreen/` and customizable-`select` ones need
-  `testdriver.js` to drive them, `forced-colors-mode-49` needs the run to be in
+  has none either), `forced-colors-mode-49` needs the run to be in
   forced-colors mode, and the two `*.sub.html` colour-scheme tests need the WPT
-  server for their cross-origin substitution.
+  server for their cross-origin substitution. The `fullscreen/` and
+  customizable-`select` ones used to be read this way too — they are not: the
+  runner drives them, and when they fail it is because that driving broke. See
+  [the testdriver override](#testdriverjs-overwrote-the-shim-that-drives-it).
+
+**Both of the first two answers came up again in
+[issue #1714](https://github.com/Broiler-Platform/Broiler/issues/1714)**, whose
+three biggest problems were all at 0.0%. Only the third, `backdrop-iframe`, was
+a defect. `root-box-003` and `forced-colors-mode-49` were each re-checked in
+Chromium on 2026-08-20 by the oracle recipe above, and Chromium splits test from
+reference exactly as Broiler does — white against green for the first, green
+against white for the second, on both engines. **When the oracle reproduces the
+disagreement, stop: there is nothing here to fix, and the pair will head the
+next biggest-problems list too.** That the list ranks by blast radius does not
+make its top entry winnable, and two of three is a fair rate to expect.
 
 - **The runner cannot represent what the test builds.** The rarest answer and
   the hardest to see, because the render is neither wrong nor honest — it is of
@@ -442,6 +456,69 @@ today.
 **The tell for this class of bug is a test that renders its "before" state.**
 Nothing errors, nothing is skipped, and the rendered image is a plausible render
 — of the document as it stood before a script it never ran.
+
+## testdriver.js overwrote the shim that drives it
+
+The same tell, from the other direction, and it is the reason
+`fullscreen/rendering/backdrop-iframe` headed
+[issue #1714](https://github.com/Broiler-Platform/Broiler/issues/1714)'s biggest
+problems at 0.0%. The render was not blank. It showed the test's un-fullscreened
+state **plus a grey box reading "This test requires user interaction. Please
+click here to allow fullscreen."** — which is upstream `testdriver.js` announcing
+that it is waiting for a WebDriver click nobody is going to send.
+
+A test that needs a user gesture asks for one through testdriver:
+
+```js
+test_driver.bless('fullscreen', () => {
+  document.querySelector('iframe').requestFullscreen();
+});
+```
+
+The runner has always shimmed `bless` — there is no user here and nothing checks
+activation, so it just runs the action. What it could not survive was **being
+injected first**. `BrowserApiStubs` goes in at position 0, ahead of the page's
+scripts; `/resources/testdriver.js` is inlined from the checkout like any other
+external script and assigns `window.test_driver` wholesale. The shim's
+`if (typeof test_driver.bless === 'undefined')` guard ran while the name was
+still free, installed, and was overwritten seconds later. Upstream's `bless`
+then appends its button and awaits `test_driver.click`, which routes through
+`test_driver_internal` — and WPT's in-tree `testdriver-vendor.js`, the file a
+vendor is expected to substitute its own implementations into, **is empty**. The
+promise never settles, the action never runs, `reftest-wait` is never dropped.
+
+The fix is to stop guarding and start winning: `TestDriverStubs` is its own
+constant now, it assigns unconditionally, and the runner appends it to every
+`testdriver*.js` it inlines as well as to `BrowserApiStubs`. Whatever the page
+loads, and in whichever order, the runner's `bless` and `Actions` are what the
+page's own scripts see.
+
+- **The reftest suite: 880 → 910 of 1258, nothing regressed.** A paired A/B over
+  every directory holding a reftest that loads testdriver.js, in a checkout
+  sparse to `css/`, `html/semantics/`, `fullscreen/` and `forced-colors-mode/` —
+  so the figure is a floor, not the corpus-wide total. `fullscreen/rendering`
+  went 3/6 → 6/6, and the `::backdrop` trio landed back on exactly the figures
+  [wont-fix](wpt-rendering-gaps-wont-fix.md#fullscreen-backdrop--the-reference-never-entered-fullscreen)
+  recorded for it on 2026-08-13 — 99.1%, 100%, 100% — which is what says this
+  was a regression rather than a gap. The other 27 are
+  customizable-`select`, `interestfor` and `css/css-shadow/part`.
+- **The golden-image suite: +5, −3**, over five of the affected directories (823
+  tests). Both directions are the same trade, because the reference generator
+  drives nothing either: five tests were nearer Chromium's screenshot once
+  Broiler stopped painting a differently-sized interaction button, and three are
+  now *further* from it because Broiler runs the test and Chromium does not.
+  `css/css-pseudo/pseudo-element-removal` is the clean example — its
+  `test_driver.Actions().send()` used to reject, abandoning the promise_test
+  before it removed the pseudo-element, and both engines rendered the leftover.
+  That is the cost [wont-fix](wpt-rendering-gaps-wont-fix.md) exists to record,
+  and it is why this suite is the one that can judge the change.
+
+**A capability guard is only right when nothing can arrive later and claim the
+name.** The `typeof … === 'undefined'` idiom is correct for the rest of
+`BrowserApiStubs`, which fills in APIs the bridge lacks and would be wrong to
+override. It is exactly backwards for a name the *page* is about to define, and
+the failure is silent: the shim installs, reports nothing, and is gone by the
+time anything calls it.
 
 ## `clip` is implemented, and most of what it clips is nothing
 

--- a/docs/wpt-rendering-gaps-wont-fix.md
+++ b/docs/wpt-rendering-gaps-wont-fix.md
@@ -136,6 +136,16 @@ backdrop painted indiscriminately: it sets `--bg: red` on `body` and `--bg: gree
 on the `div`, and asserts `div::backdrop` inherits from the *fullscreen element*.
 Broiler renders green. A backdrop painted from the wrong parent would be red.
 
+> **If a re-measurement shows these at 0.0% on `rel=match` too, the shim has
+> stopped winning rather than the backdrop having broken.** All three read 0.0%
+> / 0.0% / 1.1% in the [#1714](https://github.com/Broiler-Platform/Broiler/issues/1714)
+> reftest run because upstream `testdriver.js` was overwriting the runner's
+> `test_driver` after it was injected, so no blessed callback ran at all; the
+> settled set's 99.1% / 100% / 100% came straight back once it stopped. The give-away is the
+> render, which carries testdriver's own "This test requires user interaction"
+> button. See
+> [testdriver.js overwrote the shim that drives it](wpt-reftests.md#testdriverjs-overwrote-the-shim-that-drives-it).
+
 > `backdrop-object` is new to this list. The
 > [#1618 write-up](https://github.com/Broiler-Platform/Broiler/issues/1618) named
 > it as one of two "tests worth a maintainer's time" once the six then-known

--- a/src/Broiler.Wpt.Tests/TestDriverBlessOverrideTests.cs
+++ b/src/Broiler.Wpt.Tests/TestDriverBlessOverrideTests.cs
@@ -1,0 +1,185 @@
+using System.IO;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// The runner's <c>test_driver</c> implementation must survive the real
+/// <c>/resources/testdriver.js</c>, which a test loads <em>after</em> the injected stubs and which
+/// replaces every method with one that funnels through <c>test_driver_internal</c> — unimplemented
+/// here, because WPT's in-tree <c>testdriver-vendor.js</c> is an empty file.
+/// <para>
+/// <c>bless(intent, action)</c> is where that mattered. Upstream it appends a
+/// <c>This test requires user interaction. Please click here to allow &lt;intent&gt;.</c> button and
+/// awaits a WebDriver click on it, so with the real file in charge the action never ran: the test
+/// rendered its un-activated state <em>and</em> the button appeared in the screenshot. The stub's
+/// <c>typeof … === 'undefined'</c> guard could not catch this — it ran while the name was still
+/// free, and testdriver.js overwrote it afterwards. Every <c>fullscreen/rendering</c> reftest failed
+/// that way, including <c>backdrop-iframe</c>, the third of issue #1714's biggest problems.
+/// </para>
+/// </summary>
+public class TestDriverBlessOverrideTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public TestDriverBlessOverrideTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "broiler-wpt-testdriver-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (!Directory.Exists(_tempDir))
+            return;
+
+        try
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Leaving a directory under %TEMP% behind is not a test failure.
+        }
+    }
+
+    private string WriteFile(string relativePath, string content)
+    {
+        var fullPath = Path.Combine(_tempDir, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, content);
+        return fullPath;
+    }
+
+    /// <summary>
+    /// Upstream testdriver.js in miniature: it claims <c>window.test_driver</c> for itself and its
+    /// <c>bless</c> both mutates the document and returns a promise that never settles — the two
+    /// symptoms the real file produced. Written under the WPT root the runner resolves
+    /// <c>/resources/…</c> against, so the runner loads it exactly as it loads the real one.
+    /// </summary>
+    private void WriteUpstreamStyleTestDriver() =>
+        WriteFile(
+            "resources/testdriver.js",
+            """
+            (function() {
+              window.test_driver = {
+                bless: function(intent, action) {
+                  var button = document.createElement('button');
+                  button.setAttribute(
+                    'style',
+                    'display:block;width:320px;height:240px;background:red;border:0;margin:0');
+                  document.body.appendChild(button);
+                  return new Promise(function() {});
+                }
+              };
+            })();
+            """);
+
+    private static string BlessPage(string href) =>
+        $$"""
+        <!DOCTYPE html>
+        <html><head>
+        <link rel="match" href="{{href}}">
+        <style>body { margin: 0 } #box { width: 100px; height: 100px; background: red }</style>
+        <script src="/resources/testdriver.js"></script>
+        </head>
+        <body>
+        <div id="box"></div>
+        <script>
+        test_driver.bless('fullscreen', () => {
+          document.getElementById('box').style.background = 'green';
+        });
+        </script>
+        </body></html>
+        """;
+
+    /// <summary>
+    /// The blessed action runs even though testdriver.js has already installed its own
+    /// <c>bless</c>, so the document reaches the state the reference states.
+    /// </summary>
+    [Fact]
+    public void BlessedAction_Runs_Even_When_Upstream_TestDriver_Has_Claimed_test_driver()
+    {
+        WriteUpstreamStyleTestDriver();
+        var test = WriteFile("bless.html", BlessPage("bless-ref.html"));
+        WriteFile(
+            "bless-ref.html",
+            "<!DOCTYPE html><html><head><style>body { margin: 0 }</style></head>"
+            + "<body><div style=\"width:100px;height:100px;background:green\"></div></body></html>");
+
+        var result = new WptTestRunner(320, 240, referenceTestsOnly: true).RunReferenceTest(test, _tempDir);
+
+        Assert.True(result.Passed, result.Message);
+    }
+
+    /// <summary>
+    /// The vendor hook is re-topped too, so it does not matter which half of the pair a test
+    /// includes last. Upstream's <c>testdriver-vendor.js</c> is empty and wptrunner substitutes its
+    /// own implementations there, so a file that arrives after testdriver.js and defines
+    /// <c>bless</c> is the shape this has to survive — and it is why
+    /// <c>IsTestDriverScript</c> matches the stem rather than <c>testdriver.js</c> exactly.
+    /// </summary>
+    [Fact]
+    public void Override_Also_Survives_A_Vendor_Hook_Loaded_After_TestDriver()
+    {
+        WriteUpstreamStyleTestDriver();
+        WriteFile(
+            "resources/testdriver-vendor.js",
+            """
+            (function() {
+              window.test_driver.bless = function(intent, action) {
+                return new Promise(function() {});
+              };
+            })();
+            """);
+
+        var test = WriteFile(
+            "bless-vendor.html",
+            BlessPage("bless-vendor-ref.html").Replace(
+                "<script src=\"/resources/testdriver.js\"></script>",
+                "<script src=\"/resources/testdriver.js\"></script>"
+                + "<script src=\"/resources/testdriver-vendor.js\"></script>",
+                StringComparison.Ordinal));
+        WriteFile(
+            "bless-vendor-ref.html",
+            "<!DOCTYPE html><html><head><style>body { margin: 0 }</style></head>"
+            + "<body><div style=\"width:100px;height:100px;background:green\"></div></body></html>");
+
+        var result = new WptTestRunner(320, 240, referenceTestsOnly: true).RunReferenceTest(test, _tempDir);
+
+        Assert.True(result.Passed, result.Message);
+    }
+
+    /// <summary>
+    /// The interaction button upstream <c>bless</c> appends never reaches the document, so it
+    /// cannot land in the screenshot. Its fixture's <c>bless</c> action is a no-op, so the only
+    /// thing separating a pass from a viewport-filling red rectangle is which <c>bless</c> ran —
+    /// which is what the <c>fullscreen/rendering</c> renders showed before the fix.
+    /// </summary>
+    [Fact]
+    public void BlessedAction_Does_Not_Append_The_User_Interaction_Button()
+    {
+        WriteUpstreamStyleTestDriver();
+        var test = WriteFile(
+            "bless-button.html",
+            """
+            <!DOCTYPE html>
+            <html><head>
+            <link rel="match" href="bless-button-ref.html">
+            <style>body { margin: 0 }</style>
+            <script src="/resources/testdriver.js"></script>
+            </head>
+            <body>
+            <script>
+            test_driver.bless('fullscreen', () => {});
+            </script>
+            </body></html>
+            """);
+        WriteFile(
+            "bless-button-ref.html",
+            "<!DOCTYPE html><html><head><style>body { margin: 0 }</style></head><body></body></html>");
+
+        var result = new WptTestRunner(320, 240, referenceTestsOnly: true).RunReferenceTest(test, _tempDir);
+
+        Assert.True(result.Passed, result.Message);
+    }
+}

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -593,6 +593,109 @@ internal sealed partial class WptTestRunner
 ";
 
     /// <summary>
+    /// The runner's <c>test_driver</c> implementation — the parts of the testdriver API that
+    /// can mean something without a WebDriver session behind them.
+    /// <para>
+    /// Injected twice, and the second time is the point. It rides along with
+    /// <see cref="BrowserApiStubs"/> so a test that never pulls in testdriver.js still gets a
+    /// <c>test_driver</c>, and it is re-injected immediately after the real
+    /// <c>/resources/testdriver.js</c> whenever a test does load it (see
+    /// <see cref="IsTestDriverScript"/>). Without that second injection the real file — which the
+    /// runner serves verbatim out of the checkout, and which loads *after* the stubs — replaced
+    /// every method here with one that funnels through <c>test_driver_internal</c>. WPT's in-tree
+    /// <c>testdriver-vendor.js</c> is an empty file, so nothing implements that side and the
+    /// promises never settle.
+    /// </para>
+    /// <para>
+    /// Each method therefore assigns unconditionally rather than filling a gap: the definition it
+    /// overwrites is the real testdriver's, and in this environment that one cannot work.
+    /// </para>
+    /// </summary>
+    private const string TestDriverStubs = @"
+(function() {
+  var test_driver = window.test_driver || {};
+  window.test_driver = test_driver;
+  // testdriver `bless(name, action)`: in wptrunner this grants transient user activation and then
+  // runs the action, so a test can call an API that requires a user gesture — requestFullscreen()
+  // in fullscreen/rendering, showPicker() in the customizable-select tests. There is no user here
+  // and nothing checks activation, so the activation half is a no-op and the action is what
+  // matters: without it the callback never runs and the test renders its un-activated state.
+  // Returns a promise resolving to the action's result, which is what callers await.
+  //
+  // The real testdriver.js instead appends a `This test requires user interaction. Please click
+  // here to allow <intent>.` button to the document and awaits a click on it delivered through
+  // WebDriver — so leaving it in place both stranded the action *and* painted that button into
+  // the reftest screenshot.
+  test_driver.bless = function(name, action) {
+    try {
+      return Promise.resolve(typeof action === 'function' ? action() : undefined);
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  };
+  function Actions() {
+    this._pointers = Object.create(null);
+  }
+
+  Actions.prototype.addPointer = function(name, type) {
+    this._pointers[String(name || 'pointer')] = {
+      type: String(type || 'mouse'),
+      moves: []
+    };
+    return this;
+  };
+
+  Actions.prototype.pointerMove = function(x, y, options) {
+    var sourceName = options && options.sourceName
+      ? String(options.sourceName)
+      : Object.keys(this._pointers)[0] || 'pointer';
+    if (!this._pointers[sourceName]) {
+      this.addPointer(sourceName, 'mouse');
+    }
+
+    this._pointers[sourceName].moves.push({
+      x: Number(x) || 0,
+      y: Number(y) || 0
+    });
+    return this;
+  };
+
+  Actions.prototype.pointerDown = function() { return this; };
+  Actions.prototype.pointerUp = function() { return this; };
+  Actions.prototype.pause = function() { return this; };
+  Actions.prototype.keyDown = function() { return this; };
+  Actions.prototype.keyUp = function() { return this; };
+  Actions.prototype.scroll = function() { return this; };
+  Actions.prototype.send = function() {
+    var touchPointers = Object.keys(this._pointers)
+      .map((name) => this._pointers[name])
+      .filter((pointer) => pointer.type === 'touch' && pointer.moves.length > 0);
+
+    if (touchPointers.length >= 2 &&
+        window.visualViewport &&
+        typeof visualViewport.scale !== 'undefined') {
+      var first = touchPointers[0];
+      var second = touchPointers[1];
+      var firstStart = first.moves[0];
+      var secondStart = second.moves[0];
+      var firstEnd = first.moves[first.moves.length - 1];
+      var secondEnd = second.moves[second.moves.length - 1];
+      var startDistance = Math.hypot(firstStart.x - secondStart.x, firstStart.y - secondStart.y);
+      var endDistance = Math.hypot(firstEnd.x - secondEnd.x, firstEnd.y - secondEnd.y);
+
+      if (endDistance > startDistance + 1) {
+        visualViewport.scale = Math.max(Number(visualViewport.scale) || 1, 2);
+      }
+    }
+
+    return Promise.resolve();
+  };
+
+  test_driver.Actions = Actions;
+})();
+";
+
+    /// <summary>
     /// Minimal stubs for browser APIs that the DomBridge JavaScript context
     /// does not natively provide.  These are injected unconditionally before
     /// any test scripts execute so that common Web APIs (such as
@@ -600,7 +703,14 @@ internal sealed partial class WptTestRunner
     /// is not referenced.  WPT tests that use <c>requestAnimationFrame</c>
     /// inside <c>window.onload</c> handlers depend on this.
     /// </summary>
-    private const string BrowserApiStubs = @"
+    private const string BrowserApiStubs = BrowserApiStubsCore + TestDriverStubs;
+
+    /// <summary>
+    /// Everything in <see cref="BrowserApiStubs"/> except the testdriver half, which is a separate
+    /// source only because the runner also injects it a second time (see
+    /// <see cref="TestDriverStubs"/>). Nothing should reference this directly.
+    /// </summary>
+    private const string BrowserApiStubsCore = @"
 (function() {
   var __broilerCustomElementRegistry = Object.create(null);
   var __broilerCurrentCustomElementName = null;
@@ -666,84 +776,6 @@ internal sealed partial class WptTestRunner
   }
   __broilerEnsureAnimate(document.documentElement);
   __broilerEnsureAnimate(document.body);
-  var test_driver = window.test_driver || {};
-  window.test_driver = test_driver;
-  // testdriver `bless(name, action)`: in wptrunner this grants transient user activation and then
-  // runs the action, so a test can call an API that requires a user gesture — requestFullscreen()
-  // in fullscreen/rendering, showPicker() in the customizable-select tests. There is no user here
-  // and nothing checks activation, so the activation half is a no-op and the action is what
-  // matters: without it the callback never runs and the test renders its un-activated state.
-  // Returns a promise resolving to the action's result, which is what callers await.
-  if (typeof test_driver.bless === 'undefined') {
-    test_driver.bless = function(name, action) {
-      try {
-        return Promise.resolve(typeof action === 'function' ? action() : undefined);
-      } catch (e) {
-        return Promise.reject(e);
-      }
-    };
-  }
-  if (typeof test_driver.Actions === 'undefined') {
-    function Actions() {
-      this._pointers = Object.create(null);
-    }
-
-    Actions.prototype.addPointer = function(name, type) {
-      this._pointers[String(name || 'pointer')] = {
-        type: String(type || 'mouse'),
-        moves: []
-      };
-      return this;
-    };
-
-    Actions.prototype.pointerMove = function(x, y, options) {
-      var sourceName = options && options.sourceName
-        ? String(options.sourceName)
-        : Object.keys(this._pointers)[0] || 'pointer';
-      if (!this._pointers[sourceName]) {
-        this.addPointer(sourceName, 'mouse');
-      }
-
-      this._pointers[sourceName].moves.push({
-        x: Number(x) || 0,
-        y: Number(y) || 0
-      });
-      return this;
-    };
-
-    Actions.prototype.pointerDown = function() { return this; };
-    Actions.prototype.pointerUp = function() { return this; };
-    Actions.prototype.pause = function() { return this; };
-    Actions.prototype.keyDown = function() { return this; };
-    Actions.prototype.keyUp = function() { return this; };
-    Actions.prototype.scroll = function() { return this; };
-    Actions.prototype.send = function() {
-      var touchPointers = Object.keys(this._pointers)
-        .map((name) => this._pointers[name])
-        .filter((pointer) => pointer.type === 'touch' && pointer.moves.length > 0);
-
-      if (touchPointers.length >= 2 &&
-          window.visualViewport &&
-          typeof visualViewport.scale !== 'undefined') {
-        var first = touchPointers[0];
-        var second = touchPointers[1];
-        var firstStart = first.moves[0];
-        var secondStart = second.moves[0];
-        var firstEnd = first.moves[first.moves.length - 1];
-        var secondEnd = second.moves[second.moves.length - 1];
-        var startDistance = Math.hypot(firstStart.x - secondStart.x, firstStart.y - secondStart.y);
-        var endDistance = Math.hypot(firstEnd.x - secondEnd.x, firstEnd.y - secondEnd.y);
-
-        if (endDistance > startDistance + 1) {
-          visualViewport.scale = Math.max(Number(visualViewport.scale) || 1, 2);
-        }
-      }
-
-      return Promise.resolve();
-    };
-
-    test_driver.Actions = Actions;
-  }
   // The bridge now defines HTMLElement (see DomBridge RegisterDomInterfaceConstructors), so an
   // `is it missing?` guard would skip this shim and leave `class X extends HTMLElement` building
   // plain objects instead of elements. Probe the capability this shim actually needs — that
@@ -3207,6 +3239,16 @@ internal sealed partial class WptTestRunner
                 if (localScript != null && File.Exists(localScript))
                 {
                     var scriptContent = File.ReadAllText(localScript);
+
+                    // testdriver.js is served verbatim — it carries API surface the runner does
+                    // not shim — but it also overwrites the methods the runner *does* implement
+                    // with WebDriver-backed ones that cannot settle here. Re-install the runner's
+                    // versions on the same script, so they win regardless of where in the document
+                    // the include sits. Appending rather than inserting a list entry keeps the
+                    // page-script indices (and so the phase-trace labels) matching the document.
+                    if (IsTestDriverScript(src))
+                        scriptContent += Environment.NewLine + TestDriverStubs;
+
                     if (isDefer)
                         deferredScripts.Add(scriptContent);
                     else
@@ -3557,6 +3599,17 @@ internal sealed partial class WptTestRunner
             catch { return tag; }
         });
     }
+
+    /// <summary>
+    /// Whether an external script <c>src</c> names one of WPT's testdriver sources:
+    /// <c>/resources/testdriver.js</c>, the vendor hook <c>testdriver-vendor.js</c> that is meant
+    /// to implement it, or <c>testdriver-actions.js</c>, which supplies
+    /// <c>test_driver.Actions</c> on its own. Each is re-topped with
+    /// <see cref="TestDriverStubs"/> — matching the whole family rather than testdriver.js alone
+    /// is what makes the runner's methods survive whichever of them a test includes last.
+    /// </summary>
+    private static bool IsTestDriverScript(string src) =>
+        src.Contains("testdriver", StringComparison.OrdinalIgnoreCase);
 
     private static string? ResolveExternalScriptPath(string src, string? testDir, string? wptRoot)
     {


### PR DESCRIPTION
## Summary

The runner's `test_driver.bless()` shim was being overwritten by the real `/resources/testdriver.js` that tests load, causing blessed actions to never run. The shim used a capability guard (`if (typeof test_driver.bless === 'undefined')`) that could not survive being injected first — testdriver.js would claim `window.test_driver` wholesale and replace every method with WebDriver-backed versions that cannot settle in a headless environment.

This manifested as tests requiring user gestures (like fullscreen requests) failing to execute their actions, and upstream's interaction button appearing in reftest screenshots.

## Changes

- **Extract `TestDriverStubs` as a separate constant** that assigns unconditionally rather than guarding with capability checks. This constant contains the `bless()` and `Actions` implementations.

- **Refactor `BrowserApiStubs`** to compose `BrowserApiStubsCore` (the non-testdriver stubs) with `TestDriverStubs`, keeping the testdriver portion separate for reuse.

- **Append `TestDriverStubs` to every testdriver script the runner inlines** (`/resources/testdriver.js`, `testdriver-vendor.js`, `testdriver-actions.js`) via a new `IsTestDriverScript()` helper. This ensures the runner's implementations win regardless of load order.

- **Add comprehensive test coverage** (`TestDriverBlessOverrideTests.cs`) validating that:
  - Blessed actions run even when upstream testdriver.js has claimed `test_driver`
  - The override survives vendor hooks loaded after testdriver.js
  - The interaction button never reaches the document

- **Update documentation** in `docs/wpt-reftests.md` and `docs/wpt-rendering-gaps-wont-fix.md` explaining the issue, the fix, and the measurement results.

- **Update CHANGELOG.md** with the fix details and reftest suite improvement (880 → 910 of 1258 across affected directories; `fullscreen/rendering` 3/6 → 6/6).

## Implementation Details

The key insight is that **a capability guard is only correct when nothing can arrive later and claim the name.** For APIs the bridge lacks, `typeof … === 'undefined'` is right. For names the *page* is about to define (like `test_driver`), it is backwards — the shim installs silently and is gone by the time anything calls it.

The fix stops guarding and starts winning: `TestDriverStubs` assigns unconditionally and is injected both at position 0 (with `BrowserApiStubs`) and appended to every testdriver script the runner inlines. Whatever the page loads, and in whichever order, the runner's `bless` and `Actions` are what the page's own scripts see.

**Reftest suite results:** 880 → 910 of 1258 across directories holding a reftest that loads testdriver.js in a partial checkout (css/, html/semantics/, fullscreen/, forced-colors-mode/). Nothing regressed. `fullscreen/rendering` went 3/6 → 6/6; the other 27 gains are in customizable-`select`, `interestfor`, and `css/css-shadow/part`.

https://claude.ai/code/session_01AryamXzTGi3WwB6wRQyBjN