### PR TITLE
Fix mismatch reftest comparison to use inequality instead of threshold

### DIFF
--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -82,13 +82,63 @@ Implemented in
 2. **Render.** The test is rendered by Broiler. A reference href naming a bitmap
    (`.png`, `.jpg`, …) is decoded as-is; any other reference is rendered by
    Broiler too.
-3. **Compare** at the run's pixel pass threshold (99% by default, i.e. at most 1%
-   of pixels may differ) — the same threshold and comparer the golden-image suite
-   uses.
+3. **Compare** with the same comparer the golden-image suite uses. A
+   `rel="match"` pair is judged at the run's pixel pass threshold (99% by
+   default, i.e. at most 1% of pixels may differ); a `rel="mismatch"` pair is
+   judged on inequality instead — see below.
 4. **Verdict.** A `rel="match"` reference must be reproduced; with several of
    them the test passes on the first one it reproduces (WPT's own rule) and the
    closest candidate is what a failure reports. A test whose references are all
    `rel="mismatch"` passes only when it differs from every one of them.
+
+### A `rel="mismatch"` is decided on inequality, not on the pass threshold
+
+The two relations ask opposite questions, and only one of them wants a
+tolerance. `rel="match"` asks *are these the same picture?* — a question a 99%
+threshold answers usefully, because anti-aliasing and rounding should not fail a
+pair that agrees. `rel="mismatch"` asks *are these **not** the same picture?*,
+and running that through the same gate inverts it: any difference smaller than
+1% of the viewport gets reported as "identical", so a test the engine rendered
+**correctly** fails.
+
+That is the normal size of what these tests assert, because a mismatch reference
+is deliberately minimal — it differs from the test by one glyph, one rule, one
+box. `css/css-text/white-space/control-chars-*` is the worked example: 63 tests,
+each rendering a single 4em control-character glyph against a reference that has
+none. That glyph moves **2 217** pixels of a 1024×768 page, against the **7 864**
+that 1% of 786 432 absorbs — so 62 of the 63 were reported as matching the
+reference they were asserting they differ from, and failed, with the glyph on
+screen the whole time. Fixing the comparison — not the renderer, which was
+already right — passed all 62.
+
+Across the corpus it is not a niche correction: 559 of the reftests are
+mismatch-only. Re-running the 3 331 failures
+[issue #1716](https://github.com/Broiler-Platform/Broiler/issues/1716) recorded,
+before and after the change, takes them from **11 passing to 253** — **242
+recovered, 0 regressed**. The change can only move a test in that direction: a
+mismatch test that passed before differed from its reference by *more* than the
+threshold, so it still differs by more than zero. The largest groups are
+`control-chars` (62), `html-ruby-extensions` (48, which declares up to ten
+mismatch references per test), `css/css-writing-modes/forms` (27) and
+`css/css-text/text-align` (16). The golden-image suite is untouched — this code
+path only runs under `--reftests-only`.
+
+Upstream wptrunner compares reftest screenshots for equality and applies a
+tolerance only where the test opts in through `fuzzy` metadata, so inequality is
+also what WPT means by the relation. Broiler still applies the per-channel
+`ColorTolerance`, so "differs" means a visibly different pixel rather than a
+rounding wobble; both sides come out of the same deterministic renderer, so two
+renders of the same picture are byte-identical regardless.
+
+**The lesson generalises past this one comparison.** A whole family of tests
+failing together, at a suspiciously uniform match percentage, is as likely to be
+the harness measuring the wrong thing as it is to be an engine gap — and the
+family's *size* is what puts it high on a failure list, which then reads as
+evidence that the gap is real. `control-chars` was the second-largest failure
+family in [issue #1716](https://github.com/Broiler-Platform/Broiler/issues/1716)
+(39 of its listed failures) and had never been a rendering gap at all. When a
+family fails uniformly, render one member and its reference and *look at them*
+before believing the score.
 
 Manual tests, variant tests, and media-playback tests are skipped exactly as in
 the golden-image path. Reference *chains* — a reference that itself declares a
@@ -189,6 +239,21 @@ against white for the second, on both engines. **When the oracle reproduces the
 disagreement, stop: there is nothing here to fix, and the pair will head the
 next biggest-problems list too.** That the list ranks by blast radius does not
 make its top entry winnable, and two of three is a fair rate to expect.
+
+**It held exactly to that prediction in
+[issue #1716](https://github.com/Broiler-Platform/Broiler/issues/1716)**, where
+`root-box-003` and `forced-colors-mode-49` head the list again and the third
+entry is a new instance of the *unwinnable-by-construction* kind: `html/rendering/
+replaced-elements/images/abs-pos-transferred-max-width-from-percentage-max-height-in-
+auto-height-containing-block.html` declares `<link rel=match href="/css/support/60x60-green.png">`
+— a bare 60×60 bitmap, compared against a 1024×768 full-page render that also
+carries the test's `<p>` of instructions. No threshold can reconcile those, and
+it is the corpus's **only** bitmap-reference reftest, so there is no category
+here to fix either. Three for three now: **the biggest-problems list has not
+produced a real defect in two consecutive runs**, which is the strongest
+argument for reading it as a ranking of blast radius rather than a work queue.
+Issue #1716's actual defect was found by ignoring that list and asking why a
+63-test family was failing uniformly — see the mismatch-comparison section above.
 
 - **The runner cannot represent what the test builds.** The rarest answer and
   the hardest to see, because the render is neither wrong nor honest — it is of

--- a/src/Broiler.Wpt.Tests/ReferenceTestModeTests.cs
+++ b/src/Broiler.Wpt.Tests/ReferenceTestModeTests.cs
@@ -236,6 +236,30 @@ public class ReferenceTestModeTests : IDisposable
     }
 
     [Fact]
+    public void RunReferenceTest_Passes_When_A_Mismatch_Reference_Differs_By_Less_Than_The_Pass_Threshold()
+    {
+        // The assertion a rel=mismatch test makes is "these are not the same picture",
+        // and it is routinely made with a very small mark: the difference below is a
+        // 20x20 square on a 320x240 page — 400 of 76 800 pixels, 0.52%, comfortably
+        // under the 1% the pass threshold allows a rel=match pair to differ by.
+        //
+        // Deciding this with the rel=match gate reported the pair as identical and
+        // failed the test while the square was on screen the whole time. That is what
+        // sank the css/css-text/white-space/control-chars-* family (63 tests, one 4em
+        // glyph each against a reference with none, ~0.17% of the page): the engine
+        // rendered them correctly and the threshold erased the evidence.
+        var test = WriteFile(
+            "small-difference.html",
+            PageWithLink("mismatch", "small-difference-notref.html",
+                "<div style=\"width:20px;height:20px;background:green\"></div>"));
+        WriteFile("small-difference-notref.html", Page(string.Empty));
+
+        var result = CreateRunner().RunReferenceTest(test, _tempDir);
+
+        Assert.True(result.Passed, result.Message);
+    }
+
+    [Fact]
     public void RunReferenceTest_Passes_On_The_Second_Match_Reference_When_The_First_Differs()
     {
         // WPT's own rule for several rel=match links: the test passes if it

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -2411,6 +2411,35 @@ internal sealed partial class WptTestRunner
     /// The <c>rel="mismatch"</c> half of <see cref="RunReferenceTest"/>: the render has
     /// to differ from every declared reference, so any one it reproduces is a failure.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>A mismatch is decided on inequality, not on the pass threshold.</b> The
+    /// <c>rel="match"</c> half asks "are these the same picture?" and answers it with a
+    /// tolerance — at the default threshold, up to 1% of the pixels may differ. Reusing that
+    /// gate here inverts the assertion the test is making: <c>rel="mismatch"</c> says the two
+    /// renders must not be the same picture, and a difference smaller than 1% of the viewport
+    /// is still a difference. Under the old <c>diff.IsMatch</c> test anything below the
+    /// threshold was reported as "identical", so a test that Broiler rendered *correctly*
+    /// failed: the engine drew exactly the thing the test asked for, and the gate absorbed it.
+    /// </para>
+    /// <para>
+    /// That is the normal size of what these tests assert, because a mismatch reference is
+    /// deliberately minimal — it differs from the test by one glyph, one rule, one box. The
+    /// <c>css/css-text/white-space/control-chars-*</c> family (63 tests) renders one 4em glyph
+    /// against a reference that has none: 2 217 differing pixels on a 1024×768 page, against
+    /// the 7 864 that 1% of 786 432 absorbs. 62 of the 63 failed with the glyph on screen the
+    /// whole time, which is also why the family topped the suite's failure list. Upstream
+    /// wptrunner compares reftest screenshots for equality and applies a tolerance only where
+    /// the test itself opts in via <c>fuzzy</c> metadata, so inequality is also what WPT means
+    /// by the relation.
+    /// </para>
+    /// <para>
+    /// The per-channel <see cref="HTML.Core.IR.DeterministicRenderConfig.ColorTolerance"/> still
+    /// applies, so "differs" means a visibly different pixel rather than a rounding wobble. Both
+    /// sides come out of the same deterministic renderer, so two renders of the same picture are
+    /// byte-identical and land on 0 differing pixels regardless.
+    /// </para>
+    /// </remarks>
     private WptTestResult CompareAgainstMismatchReferences(
         string testPath,
         string? wptRoot,
@@ -2426,18 +2455,20 @@ internal sealed partial class WptTestRunner
             using (reference)
             {
                 using var diff = PixelDiffRunner.Compare(rendered, reference, _pixelDiffConfig);
-                if (!diff.IsMatch)
+                if (diff.DiffPixelCount > 0)
                     continue;
 
-                double matchPct = (1.0 - diff.DiffRatio) * 100;
+                // Reaching here means zero differing pixels, so the match is 100% by
+                // construction — reported as such rather than recomputed from the ratio,
+                // which can only be 0 at this point.
                 var images = SaveFailureImages(testPath, wptRoot, rendered, reference, diff.DiffBitmap);
                 return new WptTestResult
                 {
                     TestPath = testPath,
                     Passed = false,
-                    MatchPercent = matchPct,
+                    MatchPercent = 100,
                     Message =
-                        $"Render is identical ({matchPct:F1}%) to {DescribeReference(referencePath, wptRoot)}, " +
+                        $"Render is pixel-identical to {DescribeReference(referencePath, wptRoot)}, " +
                         "which the test declares it must differ from (rel=mismatch).",
                     Category = FailureCategory.PixelMismatch,
                     RenderedImagePath = images.Rendered,


### PR DESCRIPTION
## Summary

Fixes the comparison logic for `rel="mismatch"` reftests to decide on pixel inequality rather than applying the pass threshold. This corrects a fundamental inversion of the test assertion that was causing mismatch tests to fail when the renderer was actually correct.

## Changes

- **WptTestRunner.cs**: Modified `CompareAgainstMismatchReferences()` to check `diff.DiffPixelCount > 0` instead of `!diff.IsMatch`. A mismatch test now passes only when the renders differ by at least one pixel, not when they differ by more than the 1% threshold. Updated the failure message to report "pixel-identical" rather than a match percentage.

- **wpt-reftests.md**: Added comprehensive documentation explaining why mismatch tests require inequality comparison:
  - Clarifies that `rel="match"` asks "are these the same?" (needs tolerance) while `rel="mismatch"` asks "are these **not** the same?" (needs inequality)
  - Documents the `control-chars-*` family (63 tests) as a worked example: each test renders a single 4em glyph (~2,217 pixels) against a reference with none, but 62 failed because the difference was absorbed by the 1% threshold
  - Notes that re-running 3,331 failures from issue #1716 recovers 242 tests (11→253 passing) with zero regressions
  - Explains that upstream wptrunner uses equality comparison with optional fuzzy metadata, so inequality is also WPT's intent
  - Adds guidance on interpreting uniformly-failing test families: render one member and look at it before trusting the score

- **ReferenceTestModeTests.cs**: Added `RunReferenceTest_Passes_When_A_Mismatch_Reference_Differs_By_Less_Than_The_Pass_Threshold()` test case demonstrating that a mismatch test with a 0.52% pixel difference (well under the 1% threshold) now correctly passes.

## Impact

This change only affects `--reftests-only` mode and does not touch the golden-image suite. The per-channel `ColorTolerance` still applies, so "differs" means a visibly different pixel rather than rounding noise. Both sides render from the same deterministic engine, so identical pictures produce byte-identical output regardless.

https://claude.ai/code/session_01NjUFWXtGZWPZDBLaPg3nCZ