### PR TITLE
Aspect-ratio inline sizing and absolute length units

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/AspectRatioInlineSizeTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/AspectRatioInlineSizeTests.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Drawing;
+using System.Globalization;
+using Broiler.CSS;
+using Broiler.Layout.Engine;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// CSS Sizing 4 §4: a box with a preferred <c>aspect-ratio</c> and a definite block size takes
+/// its <c>auto</c> inline size from the ratio, rather than stretching to its containing block.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The engine only had the transfer in the other direction — an auto height derived from a width
+/// that had already filled the containing block — so <c>&lt;div style="height: 100px;
+/// aspect-ratio: 1/1"&gt;</c> painted a viewport-wide 100px band where every engine paints a
+/// 100px square. That is the shape WPT's <c>css-sizing/aspect-ratio</c> tests are built from:
+/// they compare against a filled green 100px square, so the whole assertion is the width.
+/// </para>
+/// <para>
+/// The expected values here were read out of Chromium (<c>getBoundingClientRect</c> on the same
+/// declarations) rather than derived from the prose, because the interesting half of this rule is
+/// which constraint wins where: the transfer reads the <em>used</em> block size, so
+/// <c>min-height</c>/<c>max-height</c> clamp before it, and <c>min-width</c>/<c>max-width</c>
+/// clamp after it — in the box <c>box-sizing</c> names, which is why a padded
+/// <c>content-box</c> box is wider than its <c>max-width</c>.
+/// </para>
+/// </remarks>
+public sealed class AspectRatioInlineSizeTests
+{
+    private static readonly Uri BaseUrl = new("file:///aspect-ratio.html");
+
+    private const float ContainingWidth = 400;
+
+    /// <summary>The rule itself: a definite height and a ratio settle the width.</summary>
+    [Theory]
+    [InlineData("100px", "1/1", 100)]
+    [InlineData("50px", "2/1", 100)]
+    [InlineData("100px", "1/2", 50)]
+    [InlineData("100px", "auto 4/1", 400)]
+    public void A_Definite_Height_And_A_Ratio_Size_The_Inline_Axis(
+        string height, string ratio, double expectedWidth)
+    {
+        var box = BlockIn(Page(), height: height, aspectRatio: ratio);
+
+        Layout(box);
+
+        Assert.Equal(expectedWidth, box.Size.Width, 1);
+    }
+
+    /// <summary>The control, and the behaviour that was already right: with no block size to
+    /// transfer, the auto width still fills the containing block and the ratio gives the
+    /// height.</summary>
+    [Fact]
+    public void An_Auto_Height_Still_Stretches_And_Transfers_The_Other_Way()
+    {
+        var box = BlockIn(Page(), height: null, aspectRatio: "1/1");
+
+        Layout(box);
+
+        Assert.Equal(ContainingWidth, box.Size.Width, 1);
+    }
+
+    /// <summary>A stated width is a stated width — the ratio never overrules one.</summary>
+    [Fact]
+    public void A_Specified_Width_Wins_Over_The_Ratio()
+    {
+        var box = BlockIn(Page(), height: "100px", aspectRatio: "1/1");
+        box.Width = "250px";
+
+        Layout(box);
+
+        Assert.Equal(250, box.Size.Width, 1);
+    }
+
+    /// <summary>The transfer reads the <em>used</em> block size, so the §10.7 block-axis clamp
+    /// happens first and is carried through the ratio.</summary>
+    [Theory]
+    [InlineData("200px", null, 200)]
+    [InlineData(null, "40px", 40)]
+    public void The_Block_Axis_Clamp_Is_Transferred_Too(string minHeight, string maxHeight, double expectedWidth)
+    {
+        var box = BlockIn(Page(), height: "100px", aspectRatio: "1/1");
+        if (minHeight != null)
+            box.MinHeight = minHeight;
+        if (maxHeight != null)
+            box.MaxHeight = maxHeight;
+
+        Layout(box);
+
+        Assert.Equal(expectedWidth, box.Size.Width, 1);
+    }
+
+    /// <summary>CSS2.1 §10.4 still clamps the derived width afterwards, and does not feed the
+    /// clamped value back through the ratio: the height stays what it was declared.</summary>
+    [Theory]
+    [InlineData("150px", null, 150)]
+    [InlineData(null, "40px", 40)]
+    public void The_Inline_Axis_Clamp_Applies_After_The_Transfer(string minWidth, string maxWidth, double expectedWidth)
+    {
+        var box = BlockIn(Page(), height: "100px", aspectRatio: "1/1");
+        if (minWidth != null)
+            box.MinWidth = minWidth;
+        if (maxWidth != null)
+            box.MaxWidth = maxWidth;
+
+        Layout(box);
+
+        Assert.Equal(expectedWidth, box.Size.Width, 1);
+    }
+
+    /// <summary>The ratio relates the two sizes of the box <c>box-sizing</c> names, so a
+    /// <c>content-box</c> box's padding is outside the square and a <c>border-box</c> one's is
+    /// inside it.</summary>
+    [Theory]
+    [InlineData(false, 140)]
+    [InlineData(true, 100)]
+    public void The_Ratio_Applies_To_The_Box_Box_Sizing_Names(bool borderBox, double expectedWidth)
+    {
+        var box = BlockIn(Page(), height: "100px", aspectRatio: "1/1");
+        box.PaddingLeft = "20px";
+        box.PaddingRight = "20px";
+        if (borderBox)
+            box.BoxSizing = "border-box";
+
+        Layout(box);
+
+        Assert.Equal(expectedWidth, box.Size.Width, 1);
+    }
+
+    /// <summary>And so does the inline-axis clamp, which is why a padded <c>content-box</c> box
+    /// ends up wider than its own <c>max-width</c>: the bound caps the content box, and the
+    /// padding is added to the result.</summary>
+    [Fact]
+    public void The_Inline_Clamp_Caps_The_Same_Box_The_Ratio_Sized()
+    {
+        var box = BlockIn(Page(), height: "100px", aspectRatio: "1/1");
+        box.PaddingLeft = "20px";
+        box.PaddingRight = "20px";
+        box.MaxWidth = "60px";
+
+        Layout(box);
+
+        Assert.Equal(100, box.Size.Width, 1);
+    }
+
+    /// <summary>CSS2.1 §10.3.3: the free space a ratio-derived width leaves is still free space,
+    /// so <c>margin: 0 auto</c> centres such a box exactly as it centres a stated one.</summary>
+    [Fact]
+    public void Auto_Margins_Centre_A_Ratio_Derived_Width()
+    {
+        var page = Page();
+        var box = BlockIn(page, height: "100px", aspectRatio: "1/1");
+        box.MarginLeft = CssConstants.Auto;
+        box.MarginRight = CssConstants.Auto;
+
+        Layout(box);
+
+        Assert.Equal(100, box.Size.Width, 1);
+        Assert.Equal((ContainingWidth - 100) / 2, box.ActualMarginLeft, 1);
+    }
+
+    /// <summary>A percentage height counts only when it has something definite to resolve
+    /// against (CSS2.1 §10.5); against an auto-height containing block it computes to
+    /// <c>auto</c> and there is nothing to transfer.</summary>
+    [Fact]
+    public void A_Percentage_Height_Transfers_Against_A_Definite_Containing_Block()
+    {
+        var page = Page();
+        page.Height = "300px";
+
+        var box = BlockIn(page, height: "50%", aspectRatio: "1/1");
+
+        Layout(box);
+
+        Assert.Equal(150, box.Size.Width, 1);
+    }
+
+    [Fact]
+    public void A_Percentage_Height_Against_An_Auto_Height_Container_Does_Not()
+    {
+        var box = BlockIn(Page(), height: "50%", aspectRatio: "1/1");
+
+        Layout(box);
+
+        Assert.Equal(ContainingWidth, box.Size.Width, 1);
+    }
+
+    /// <summary>A box with no ratio is untouched — the whole rule is gated on one.</summary>
+    [Fact]
+    public void Without_A_Ratio_An_Auto_Width_Still_Fills_The_Containing_Block()
+    {
+        var box = BlockIn(Page(), height: "100px", aspectRatio: null);
+
+        Layout(box);
+
+        Assert.Equal(ContainingWidth, box.Size.Width, 1);
+    }
+
+    /// <summary>An absolutely positioned box takes the ratio over the §10.3.7 inset equation:
+    /// the equation answers "how wide is a box with no width of its own?", and a ratio plus a
+    /// definite height is such a width.</summary>
+    [Fact]
+    public void An_Out_Of_Flow_Box_Takes_The_Ratio_Over_Its_Insets()
+    {
+        var page = Page();
+        page.Position = CssConstants.Relative;
+
+        var box = BlockIn(page, height: "100px", aspectRatio: "1/1");
+        box.Position = CssConstants.Absolute;
+        box.Left = "0";
+        box.Right = "0";
+        box.Top = "0";
+
+        Layout(box);
+
+        Assert.Equal(100, box.Size.Width, 1);
+    }
+
+    /// <summary>
+    /// The <c>/</c> is a token of the grammar rather than a character of the numbers around it,
+    /// so whitespace may sit on either side of it. <c>1 / 2</c> is how most of the WPT
+    /// <c>css-sizing</c> tests spell the value, and it used to parse as no ratio at all — the
+    /// lone slash token carried no number, and rejecting it rejected the declaration.
+    /// </summary>
+    [Theory]
+    [InlineData("1/2", 0.5)]
+    [InlineData("1 / 2", 0.5)]
+    [InlineData("1 /2", 0.5)]
+    [InlineData("1/ 2", 0.5)]
+    [InlineData("auto 4 / 1", 4)]
+    [InlineData("4 / 1 auto", 4)]
+    [InlineData("2", 2)]
+    [InlineData("0.5", 0.5)]
+    public void A_Slash_Parses_With_Or_Without_Space_Around_It(string value, double expected)
+    {
+        Assert.True(CssBox.TryParseAspectRatio(value, out double ratio), value);
+        Assert.Equal(expected, ratio, 4);
+    }
+
+    [Theory]
+    [InlineData("auto")]
+    [InlineData("none")]
+    [InlineData("")]
+    [InlineData("0 / 1")]
+    [InlineData("1 / 0")]
+    [InlineData("green")]
+    public void A_Value_That_Names_No_Ratio_Parses_As_None(string value)
+    {
+        Assert.False(CssBox.TryParseAspectRatio(value, out _), value);
+    }
+
+    /// <summary>The end-to-end consequence of the two spellings agreeing.</summary>
+    [Fact]
+    public void A_Spaced_Ratio_Sizes_The_Inline_Axis_Like_An_Unspaced_One()
+    {
+        var spaced = BlockIn(Page(), height: "100px", aspectRatio: "1 / 2");
+        var unspaced = BlockIn(Page(), height: "100px", aspectRatio: "1/2");
+
+        Layout(spaced);
+        Layout(unspaced);
+
+        Assert.Equal(50, spaced.Size.Width, 1);
+        Assert.Equal(unspaced.Size.Width, spaced.Size.Width, 1);
+    }
+
+    // ───────────────────────────────── the shape ─────────────────────────────────
+
+    private static void Layout(CssBox box)
+    {
+        var root = box;
+        while (root.ParentBox != null)
+            root = root.ParentBox;
+
+        root.PerformLayout(root.LayoutEnvironment);
+    }
+
+    /// <summary>root → body, so a percentage height has an ordinary auto-height containing block
+    /// above it rather than the initial one, whose block size is the viewport's and therefore
+    /// always definite. Returns the body: the box under test is its child.</summary>
+    private static CssBox Page()
+    {
+        var root = new CssBox(null, null, BaseUrl)
+        {
+            Location = PointF.Empty,
+            Size = new SizeF(ContainingWidth, 0),
+            Display = CssConstants.Block,
+            FontSize = "16px",
+            LayoutEnvironment = new PagedLayoutEnvironment(99999, pageWidth: ContainingWidth),
+        };
+
+        return new CssBox(root, new HtmlTag("body", false, null), BaseUrl)
+        {
+            Location = PointF.Empty,
+            Display = CssConstants.Block,
+            FontSize = "16px",
+        };
+    }
+
+    private static CssBox BlockIn(CssBox parent, string height, string aspectRatio)
+    {
+        var box = new CssBox(parent, new HtmlTag("div", false, null), BaseUrl)
+        {
+            Location = PointF.Empty,
+            Display = CssConstants.Block,
+            FontSize = "16px",
+        };
+
+        if (height != null)
+            box.Height = height;
+        if (aspectRatio != null)
+            box.AspectRatio = aspectRatio;
+
+        return box;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
@@ -368,12 +368,29 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 width = minW;
         }
 
+        // CSS Sizing 4 §4: a box with a preferred aspect ratio and a definite block size takes
+        // its auto inline size from the ratio instead of the containing block. The transfer
+        // supersedes every auto-width rule below — the block-level stretch-fit, the §10.3.7
+        // inset equation, and the float/abspos shrink-to-fit — because each of those answers
+        // "how wide is a box with no width of its own?", and a ratio plus a definite height is
+        // exactly such a width. Without it `height: 100px; aspect-ratio: 1/1` painted a
+        // viewport-wide band where every engine paints a 100px square.
+        bool inlineSizeFromAspectRatio = false;
+
+        if (!replacedSizeSettled && TryResolveAspectRatioAutoInlineWidth(out double aspectRatioInlineWidth))
+        {
+            inlineSizeFromAspectRatio = true;
+            width = aspectRatioInlineWidth;
+        }
+
         Size = new SizeF((float)width, Size.Height);
 
         // CSS2.1 §10.3.3: For block-level, non-replaced elements in
         // normal flow with an explicit width and auto margins, resolve
         // the auto margins so the element is centered horizontally.
-        if (Width != CssConstants.Auto && !string.IsNullOrEmpty(Width)
+        // A ratio-derived width counts as a resolved one here: it leaves the same free space
+        // for `margin: 0 auto` to split, and CSS Sizing 4 §4 does not exempt it.
+        if ((inlineSizeFromAspectRatio || (Width != CssConstants.Auto && !string.IsNullOrEmpty(Width)))
             && Float == CssConstants.None
             && Position != CssConstants.Absolute && Position != CssConstants.Fixed)
         {
@@ -440,6 +457,12 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             }
         }
 
+        if (inlineSizeFromAspectRatio)
+        {
+            // The ratio already settled this box's inline size, and every branch of this chain
+            // is an answer to the question it just answered — each would overwrite the derived
+            // width with the containing block's or with the content's.
+        }
         // CSS2.1 §10.3.7: Absolutely positioned non-replaced elements
         // with auto width use shrink-to-fit when at least one of
         // left/right is auto.  Shrink-to-fit =
@@ -450,7 +473,7 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         // <img> or <canvas> has none — so an `<img position:absolute; left:4em; top:4em>` came out
         // zero pixels wide and painted nothing at all. With `right` also set the branch was skipped
         // and the same image stretched across the inset box instead; both are now the natural size.
-        if (!replacedSizeSettled
+        else if (!replacedSizeSettled
             && (Width == CssConstants.Auto || string.IsNullOrEmpty(Width))
             && (Position == CssConstants.Absolute || Position == CssConstants.Fixed)
             && (Left == null || Left == CssConstants.Auto

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Sizing.cs
@@ -694,11 +694,92 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             specifiedWidth = contentHeight * ratio;
         }
 
-        // CSS2.1 §10.4: the derived size is still subject to min-/max-width.
-        borderBoxWidth = ResolveInlineSizeBounds().Clamp(ResolveSpecifiedWidthToBorderBox(specifiedWidth));
+        // CSS2.1 §10.4: the derived size is still subject to min-/max-width, and the clamp
+        // happens in the box `box-sizing` names — the same frame the bounds are stated in —
+        // before the result is mapped back to a border box. Clamping the border-box width
+        // instead double-counts padding against the bound: a `content-box` item with
+        // `padding: 0 20px; max-width: 60px` and a 100px transferred content width is 100px
+        // wide (60 + 40), not the 60 a border-box clamp leaves.
+        borderBoxWidth = ResolveSpecifiedWidthToBorderBox(ResolveInlineSizeBounds().Clamp(specifiedWidth));
 
         return borderBoxWidth > 0
             && !double.IsNaN(borderBoxWidth) && !double.IsInfinity(borderBoxWidth);
+    }
+
+    /// <summary>
+    /// CSS Sizing 4 §4: the used border-box width an <c>auto</c> inline axis takes from this
+    /// box's own definite block size through its preferred aspect ratio — the case
+    /// <see cref="TryResolveAspectRatioInlineWidth"/> serves for a grid item, resolved here
+    /// from the box's own <c>height</c> rather than from one a caller has settled.
+    /// </summary>
+    /// <remarks>
+    /// <para>This is the transfer that stops a block-level box stretching. A block's
+    /// <c>auto</c> width normally fills its containing block, and
+    /// <see cref="TryResolveAspectRatioBlockHeight"/> then derives the height from it; when the
+    /// block size is definite the dependency runs the other way and the ratio sizes the inline
+    /// axis instead, so <c>&lt;div style="height: 100px; aspect-ratio: 1/1"&gt;</c> is a 100px
+    /// square rather than a viewport-wide 100px band. Every engine does this, and the WPT
+    /// <c>css-sizing/aspect-ratio</c> tests state it directly.</para>
+    /// <para>The block size is the box's own specified <c>height</c>, clamped by
+    /// <c>min-height</c>/<c>max-height</c> — the transfer reads the <em>used</em> block size, so
+    /// <c>height: 100px; min-height: 200px; aspect-ratio: 1/1</c> is a 200px square. A
+    /// percentage height counts only when it resolves against a definite containing block
+    /// (CSS2.1 §10.5); otherwise it computes to <c>auto</c> and there is nothing to transfer.</para>
+    /// <para>Replaced boxes stay out: an <c>&lt;img&gt;</c> sizes from its natural size and ratio
+    /// through <see cref="ResolveReplacedContentSize"/>, which already resolves both axes
+    /// together.</para>
+    /// </remarks>
+    internal bool TryResolveAspectRatioAutoInlineWidth(out double borderBoxWidth)
+    {
+        borderBoxWidth = 0;
+
+        if (Width != CssConstants.Auto && !string.IsNullOrEmpty(Width))
+            return false;
+
+        if (!TryParseAspectRatio(AspectRatio, out double ratio) || !(ratio > 0))
+            return false;
+
+        if (IsImage || TryGetNaturalReplacedSize(out _))
+            return false;
+
+        if (!TryGetDefiniteSpecifiedBorderBoxHeight(out double borderBoxHeight))
+            return false;
+
+        return TryResolveAspectRatioInlineWidth(borderBoxHeight, out borderBoxWidth);
+    }
+
+    /// <summary>
+    /// The used border-box height this box's own <c>height</c> declares, or <c>false</c> when
+    /// the block axis is indefinite. Mirrors the height resolution in
+    /// <c>ResolveUsedBlockHeight</c>, which runs too late to size the inline axis from.
+    /// </summary>
+    private bool TryGetDefiniteSpecifiedBorderBoxHeight(out double borderBoxHeight)
+    {
+        borderBoxHeight = 0;
+
+        if (Height == CssConstants.Auto || string.IsNullOrEmpty(Height))
+            return false;
+
+        if (IsIntrinsicSizingHeightKeyword(Height)
+            || string.Equals(Height, "inherit", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // CSS2.1 §10.5: a percentage against an auto-height containing block computes to auto.
+        if (HeightPercentageResolvesToAuto())
+            return false;
+
+        double specifiedHeight = Height.Contains('%')
+            ? ParseUsedLength(Height, PercentageHeightContainingBlockHeight())
+            : ParseLengthWithLineHeight(Height, 0);
+
+        if (double.IsNaN(specifiedHeight) || double.IsInfinity(specifiedHeight) || !(specifiedHeight > 0))
+            return false;
+
+        borderBoxHeight = ResolveSpecifiedHeightToBorderBox(ClampSpecifiedHeightToMinMax(specifiedHeight));
+
+        return borderBoxHeight > 0;
     }
 
     /// <summary>Parses an <c>aspect-ratio</c> value (<c>&lt;number&gt; [ /
@@ -714,6 +795,14 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
         double w = double.NaN, h = 1;
 
+        // The `/` is a token of the grammar, not a character of the numbers around it, so
+        // whitespace may sit on either side of it — `1 / 2` and `1/2` are the same value, and
+        // `1 / 2` is how most of the WPT css-sizing tests spell it. Splitting on whitespace can
+        // therefore hand this loop the slash attached to the numerator, attached to the
+        // denominator, in the middle of both, or entirely on its own; only the last of those has
+        // no number in it at all, and rejecting that token used to reject the whole declaration.
+        bool sawSlash = false;
+
         foreach (var token in value.Split((char[])null, StringSplitOptions.RemoveEmptyEntries))
         {
             if (token.Equals("auto", StringComparison.OrdinalIgnoreCase)
@@ -723,21 +812,31 @@ internal partial class CssBox : CssBoxProperties, IDisposable
             int slash = token.IndexOf('/');
             if (slash >= 0)
             {
-                if (!double.TryParse(token[..slash].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out w))
-                    return false;
+                string numerator = token[..slash].Trim();
+                string denominator = token[(slash + 1)..].Trim();
 
-                string rest = token[(slash + 1)..].Trim();
-                if (rest.Length > 0 && !double.TryParse(rest, NumberStyles.Float, CultureInfo.InvariantCulture, out h))
+                if (numerator.Length > 0
+                    && !double.TryParse(numerator, NumberStyles.Float, CultureInfo.InvariantCulture, out w))
+                {
                     return false;
+                }
+
+                sawSlash = true;
+
+                if (denominator.Length > 0
+                    && !double.TryParse(denominator, NumberStyles.Float, CultureInfo.InvariantCulture, out h))
+                {
+                    return false;
+                }
             }
-            else if (double.IsNaN(w))
+            else if (double.IsNaN(w) && !sawSlash)
             {
                 if (!double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out w))
                     return false;
             }
             else
             {
-                // A second bare number is the denominator (e.g. `1 / 1` split on space).
+                // A bare number after the numerator is the denominator (`1 / 1` split on space).
                 if (!double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out h))
                     return false;
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,40 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- A box with an `aspect-ratio` and a definite height is now that shape, and a `border` width may
+  be written in a physical unit. Two unrelated defects, both found by asking why a whole WPT
+  reftest family was failing uniformly rather than by working down the run's biggest-problems
+  list. Over the whole reftest corpus (27 327 tests) they are **18 644 → 18 886 passing, +244 won
+  against 2 lost**. Details in
+  [`docs/wpt-reftests.md`](docs/wpt-reftests.md#a-definite-height-and-an-aspect-ratio-did-not-make-a-square).
+  - **`aspect-ratio` only transferred one way.** The engine took an `auto` *height* from a width
+    that had already filled the containing block, but never the inverse, so
+    `<div style="height: 100px; aspect-ratio: 1/1">` painted a viewport-wide 100px band where
+    every engine paints a 100px square. The transfer now supersedes the block-level stretch-fit,
+    the CSS2.1 §10.3.7 inset equation and the float/abspos shrink-to-fit alike — each of those
+    answers "how wide is a box with no width of its own?", which a ratio plus a definite height
+    already answers. `min-height`/`max-height` clamp before the transfer and
+    `min-width`/`max-width` after it, both in the box `box-sizing` names; the clamp order is now
+    right for the grid-item caller that already existed too.
+  - **`aspect-ratio: 1 / 2` parsed as no ratio at all** — the value is split on whitespace and a
+    lone `/` token carries no number, so the whole declaration was rejected. `1/2` worked and
+    `1 / 2` did not, and the spaced spelling is the one most of these tests use.
+  - **`border: 72pt solid red` painted a 3px black line.** `CssLengthParser.ParseToPixels` left
+    out CSS Values 3 §5.2's absolute units — `pt`, `pc`, `in`, `cm`, `mm`, `Q` — and answered
+    `NaN`, which its callers read as "not a length". The `border` shorthand therefore filed the
+    width under *colour*, dropping both the width and the declared colour; the longhand
+    (`border-left-width: 72pt`) was right the whole time. A media query such as `(min-width: 8in)`
+    and a container query with an absolute length were evaluating as invalid for the same reason.
+    This one is **`patches/0001-resolve-the-absolute-length-units-in-parsetopixels.patch`** —
+    `CssLengthParser` is in the `Broiler.CSS` submodule, whose remote is outside a
+    this-repository session's push scope — and is listed in
+    `scripts/apply-pending-wpt-patches.sh`, so the pixel suites exercise it on top of the pinned
+    pointer. It is worth **+220 of the 244** on its own.
+  - Both losses are `*-print` tests, and both are false passes ending rather than regressions:
+    each states a `border` in inches on the test *and* on its reference, so neither side painted
+    a border and the two matched. They render their borders now, and what separates them is the
+    fragmentation the tests were written to measure, which needs the paged render to judge.
+
 - WPT tests that need a user gesture run again. A test asks for one through
   `test_driver.bless(intent, action)`, which the conformance runner shims — there is no user in a
   headless run and nothing checks activation, so the shim just runs the action. But the shim went in

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -702,40 +702,214 @@ unmapped, and it is the pair to fix against when someone works out the mapping.
 That is also the reason the family only moved 60 of its 224 tests: the rest fail
 on their *test* side, which is what these were written to exercise.
 
-## Next lead: an out-of-flow replaced element with an auto size renders nothing
+## An out-of-flow replaced element renders now — that lead is closed
 
-Diagnosed, not fixed. `css/CSS2/positioning/absolute-replaced-width-*` is 40
-failures at 96.5–98.8 % match, and what the diff is missing is the whole image:
+This section used to be the standing "next lead": an `<img>` painted in flow and
+painted out of flow **only when both dimensions were stated**, which cost
+`css/CSS2/positioning/absolute-replaced-width-*` 40 failures at 96.5–98.8 %
+match. All three of the defects it named are fixed, in two separate pieces of
+work, and re-rendering its own probe on 2026-08-20 paints every image:
 
 ```html
 <div style="position:relative; width:200px; height:60px">
-  <img src="blue15x15.png" style="position:absolute">      <!-- nothing paints -->
-  <img src="blue15x15.png" style="float:left">             <!-- nothing paints -->
-  <img src="blue15x15.png" style="position:absolute; width:40px; height:40px">
-</div>                                                      <!-- this one paints -->
+  <img src="60x60-green.png" style="position:absolute">     <!-- 3 600 px -->
+  <img src="60x60-green.png" style="float:left">            <!-- 3 600 px -->
+  <img src="60x60-green.png" style="position:absolute; width:40px; height:40px">
+                                                            <!-- 1 600 px, and the
+                                                                 only one that used
+                                                                 to paint at all -->
+  text <img src="60x60-green.png" style="float:left"> text  <!-- 3 600 px -->
+</div>                                                      <!-- 12 400 px of green, exactly -->
 ```
 
-An `<img>` paints in flow, and paints out of flow **only when both dimensions are
-stated**. Dumping the fragment tree separates three distinct defects, and each
-wants its own before/after sweep:
+- The **absolutely positioned** halves — auto size, and `display: block` — were
+  `ResolveBlockUsedWidth` running the §10.3.7 *non-replaced* branches over a
+  replaced box, which measured its (nonexistent) children and produced zero. See
+  [the entry in the gaps document](wpt-rendering-gaps-fixed.md#an-absolutely-positioned-img-rendered-nothing-at-all).
+- The **floated** half was CSS2.1 §9.7's other blockification: a floated replaced
+  box stayed inline-level and took `PerformLayoutImp`'s else-branch, which sizes a
+  box from its words and a replaced box has none. `CssBox.IsBlockifiedFloatedReplaced`
+  is the fix and `FloatedReplacedBlockificationTests` pins it, including the
+  deliberate narrowing to *replaced* floats.
 
-1. **Absolutely positioned, auto size.** The box is laid out (it has a line box)
-   but its fragment comes out `0×0`, so nothing of it is painted — not the image,
-   not even a background set on it.
-2. **Floated.** `CreateLineBoxes` skips floats as out-of-flow and the loop that
-   lays them out afterwards iterates the container's own `Boxes` — so a float
-   inside an *anonymous* block (which is where an `<img>` between text nodes ends
-   up) is never reached at all. Its anonymous parent is left `lines=1`, height 0.
-3. **`display: block` and absolutely positioned.** No fragment is produced for the
-   image at all.
+Left here rather than deleted because a stale "next lead" is worse than none, and
+because the shape of the diagnosis — dump the fragment tree, separate one
+symptom into three defects, sweep each on its own — is the part worth reusing.
+The current lead is [a flex item that has a ratio and no
+width](#next-lead-a-flex-items-main-size-ignores-its-aspect-ratio).
 
-The engine is right at the point where the fix belongs: `CssBox.PerformLayout`
-routes `IsBlock || isOutOfFlow` down the block path, and `isOutOfFlow` covers
-`absolute`/`fixed` but not `float`; neither path sizes a *replaced* box from its
-image the way the inline path does. Keep any fix narrow to boxes that carry an
-image word — those render nothing today, so the blast radius of getting them
-wrong is small, while the same change on non-replaced boxes would touch every
-float in the corpus.
+## A definite height and an `aspect-ratio` did not make a square
+
+`aspect-ratio` was implemented in one direction only. `TryResolveAspectRatioBlockHeight`
+takes an auto *height* from a width that has already filled the containing block,
+which is what an ordinary in-flow box needs; the inverse — an auto *width* taken
+from a definite height — existed as `TryResolveAspectRatioInlineWidth` and had
+exactly one caller, a grid item whose `justify-self` is positional. Nothing
+consulted it for an ordinary box, so:
+
+```html
+<div style="background: green; height: 100px; aspect-ratio: 1/1"></div>
+```
+
+painted a **viewport-wide 100px band** where every engine paints a 100px square.
+That is `css-sizing/aspect-ratio/block-aspect-ratio-002`, and it is the shape the
+whole directory is built from: the tests compare against
+`css/reference/ref-filled-green-100px-square`, so the assertion *is* the width.
+
+The fix (`CssBox.TryResolveAspectRatioAutoInlineWidth`, called from
+`ResolveBlockUsedWidth`) supersedes every auto-width rule in that method — the
+block-level stretch-fit, the §10.3.7 inset equation, and the float/abspos
+shrink-to-fit. That breadth is not an over-reach: each of those answers "how wide
+is a box with no width of its own?", and a ratio plus a definite height is such a
+width. Chromium agrees on all of them, including the one that looks wrong — an
+abspos box with `left: 0; right: 0`, `height: 100px` and `aspect-ratio: 1/1` is
+100px wide, not stretched to its insets.
+
+**Which constraint wins where is the whole of the rest of it**, and it was read
+out of Chromium rather than out of the prose:
+
+- The transfer reads the **used** block size, so `min-height`/`max-height` clamp
+  *before* it: `height: 100px; min-height: 200px; aspect-ratio: 1/1` is a 200px
+  square.
+- `min-width`/`max-width` clamp *after* it, and do not feed back through the
+  ratio: `max-width: 40px` on that box gives 40×100, not 40×40.
+- Both clamps and the ratio itself apply to the box `box-sizing` names. A
+  `content-box` box with `padding: 0 20px; max-width: 60px` and a 100px
+  transferred content width is **100px** wide — 60 plus the padding — which is
+  what makes the clamp order observable. `TryResolveAspectRatioInlineWidth`
+  clamped the border-box width against a bound stated in the content box and so
+  came out at 60; it now clamps first and converts second, which also corrects
+  the grid-item caller it already had.
+- Auto margins still centre the result. The free space a ratio-derived width
+  leaves is ordinary free space, so `margin: 0 auto` splits it.
+
+A **column** flex item is the one box that keeps stretching, and it is not an
+exception the transfer has to encode: `ApplyFlexColumnInlineAxisAlignment` runs
+afterwards and widens an `align-items: stretch` item to the container, which is
+what Chromium does too (`400 × 60`, not `60 × 60`).
+
+`AspectRatioInlineSizeTests` pins all of it, Chromium-derived expectations
+included.
+
+### The other half was a `/` with spaces around it
+
+`aspect-ratio: 1 / 2` parsed as **no ratio at all**. `TryParseAspectRatio` splits
+the value on whitespace, so the slash can arrive attached to the numerator, to the
+denominator, in the middle of both, or entirely on its own — and the lone-slash
+token carries no number, so the numerator parse failed and the whole declaration
+was rejected. `1/2` worked; `1 / 2` did not; the two are the same value, and the
+spaced spelling is the one most of these tests use. That was worth **8 tests on
+its own** in `css-sizing/aspect-ratio` after the transfer above had landed, and it
+is invisible in any test that happens to write the value without spaces.
+
+**Together: `css/css-sizing/aspect-ratio` 147 → 168 of 266.** Over the whole
+corpus (27 327 reftests, 2026-08-20) the pair is **18 644 → 18 668 passing, +24
+won and none lost** — 22 of the 24 in `css-sizing/aspect-ratio` itself, plus
+`css-sizing/border-box-and-max-content-002` and
+`css-values/calc-size/calc-size-aspect-ratio-004`.
+
+The narrowness is the interesting part of that number, and it is what says the
+change is the rule and not a bulldozer: a box that has *both* a definite height
+and a ratio is not a common shape outside the directory that tests it, so almost
+nothing else could move. Compare it with the absolute-unit fix below, which is a
+smaller change and worth ten times as much, for the opposite reason.
+
+## `border: 72pt solid red` painted a 3px black line
+
+The biggest single win in this pass is not a layout rule at all, and nothing in
+the failure names points at it. `css/CSS2/positioning`'s `left-*` and `right-*`
+families were failing in a tight cluster at 98.8–98.9 % — 8 928 differing pixels,
+which is 96×93 and looks like a small offset. It is not: the rendered image had
+**no black square and no red one**. Neither border was painted.
+
+`CssLengthParser.ParseToPixels` — the entry point that answers "is this a length,
+and how many pixels is it?" with no font and no viewport to consult — handled
+`px`, the font-relative family and the viewport family, and simply left out CSS
+Values 3 §5.2's **absolute** units: `pt`, `pc`, `in`, `cm`, `mm`, `Q`. Those are
+the easiest of the lot (fixed multiples of the reference pixel, and `CssMetrics`
+already states every factor), and they answered `NaN`.
+
+Its callers read that `NaN` as *"not a length"* and act on it. The `border`
+shorthand is the loud one: `IsLengthOrPercentage` asks whether `72pt` is a length,
+is told no, and the expansion therefore files
+`border-left: 72pt solid red`'s first component under **colour**. The width falls
+back to `medium` and the declared colour is dropped — a declaration that should
+paint a 96px red band paints a 3px black line. The *longhand*
+(`border-left-width: 72pt`) was right the whole time, which is exactly what makes
+this hard to see from the outside: it is not "units are broken", it is "units are
+broken in one shorthand".
+
+**It matters far out of proportion to six keywords, because the CSS2.1 suite
+states its geometry in physical units by convention.** Over the whole corpus it is
+**18 668 → 18 886 passing, +220 won against 2 lost** — nine times what the layout
+rule above is worth, out of twenty lines. The wins are almost entirely
+`css/CSS2`: `margin-padding-clear` +78, `normal-flow` +76, `positioning` +30
+(364 → 394 of 520), `borders` +21, `fonts` +12.
+
+Two quieter callers were answering the same `NaN`: a media query such as
+`(min-width: 8in)`, and a container query with an absolute length, both evaluated
+as *invalid* rather than as the length they name. `css/mediaqueries` is one of
+the +220 for exactly that reason.
+
+**Both losses are false passes ending, and both were checked rather than
+assumed** — this is *do not "fix" a reftest by making both sides equally wrong*
+(below, under [quirks mode](#quirks-mode-reaches-the-render-as-of-the-doctype-round-trip-fix))
+caught in the act. `css-break/overflowing-block-002-print` states
+`border: 0.5in solid purple` on an absolutely positioned box and on an in-flow
+one, and neither side painted a single purple pixel before: the test rendered 984
+black pixels against the reference's 5 106, a 0.5 % difference that fits inside
+the 1 % gate. Both sides paint their border now (69 120 and 84 480 purple pixels),
+and what is left is the real difference between a shrink-to-fit abspos box and a
+stretched in-flow one — which is what the test is about and which needs the paged
+render to judge. `css-break/flexbox/multi-line-row-flex-fragmentation-080-print`
+is the same shape with `border: 0.25in solid black`. Neither was measuring
+anything while the border was missing.
+
+**This one ships as a patch, not as a commit.** `CssLengthParser` is in the
+`Broiler.CSS` submodule and the push is a 403, so it is
+`patches/0001-resolve-the-absolute-length-units-in-parsetopixels.patch` and is
+listed in `scripts/apply-pending-wpt-patches.sh` — which the reftest shard action
+runs, so a CI run exercises it on top of the pinned pointer. There is no
+main-repo half to fall back on: the shorthand expansion is entirely inside
+`Broiler.CSS`. Identify it by its commit subject, *Resolve the absolute length
+units in ParseToPixels*, not by the number — see
+[`patches/README.md`](../patches/README.md) on why the number means nothing.
+
+## Next lead: a flex item's main size ignores its aspect ratio
+
+Diagnosed, not fixed, and measured against Chromium on 2026-08-20. In a **row**
+flex container an item with a ratio and no width paints nothing at all:
+
+```html
+<div style="display: flex; width: 400px; height: 100px">
+  <div style="background: green; height: 60px; width: 50px"></div>        <!-- 50×60 ✔ -->
+  <div style="background: green; height: 60px"></div>                     <!-- 0×60, correct -->
+  <div style="background: green; height: 60px; aspect-ratio: 1/1"></div>  <!-- nothing; Chromium: 60×60 -->
+  <div style="background: green; aspect-ratio: 1/1"></div>                <!-- nothing; Chromium: 100×100 -->
+</div>
+```
+
+The second box is a fair control and shows the rule is specific: an empty item
+with a height and no width genuinely *is* zero wide, in Chromium too. The last two
+are the gap — CSS Flexbox §9.2 step 3 takes the flex base size of an item with a
+preferred aspect ratio and a definite cross size from the **transferred** size,
+and the fourth box's cross size becomes definite by `align-items: stretch` before
+the main size is resolved.
+
+**It is not the transfer added above, and that fix cannot reach it.** A row item's
+width comes from `ResolveFlexItemBaseOuterWidth`, whose three branches are
+`flex-basis`, a stated `width`, and — for everything else —
+`GetMinMaxWidth`'s preferred content width, which is zero for an empty box. The
+aspect ratio is not consulted in any of them, so whatever
+`ResolveBlockUsedWidth` resolved is replaced. The missing branch belongs there,
+between the stated width and the content measurement.
+
+Worth roughly the 20 remaining `css-sizing/aspect-ratio/flex-aspect-ratio-*`
+failures plus whatever a flex container used as a strip contributes elsewhere.
+Probe it against Chromium first: `flex-basis`, `flex-grow` and the item's
+min-content contribution all interact with the transferred size, and the flex
+path is on the order of a thousand reftests, so this is not a change to make on
+one test's evidence.
 
 ## Flex items are stretched now, and what that says about the scoreboard
 

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -6,12 +6,10 @@
 > [How this was verified](wpt-rendering-gaps.md#how-the-2026-08-13-split-was-verified).
 
 Gaps that are closed. Each entry keeps the root cause, what landed, the evidence,
-and — where there was one — the wrong turn worth not repeating. **One is waiting on a
-patch** — the media-element fix, whose `Broiler.HTML` remote is outside a
-this-repository session's push scope; it is listed in
-`scripts/apply-pending-wpt-patches.sh`, so the pixel suites run with it applied on top
-of the pinned pointer. Every other submodule fix named below is an ancestor of that
-pointer.
+and — where there was one — the wrong turn worth not repeating. **Every submodule fix
+named below is now an ancestor of its pinned pointer**, the media-element one included
+(it landed upstream as `Broiler.HTML` `a9be60a`), so all of them reach CI through the
+pointer and none is waiting on `scripts/apply-pending-wpt-patches.sh`.
 
 Where a fix landed in a submodule it is identified by its **commit subject**, not
 by a patch number. Patch numbers named nothing durable — `patches/` was a backlog,
@@ -1511,11 +1509,11 @@ the test that exposed it.
 
 - **Tests:** `conformance-checkers/html/elements/{track,video}/src-isvalid` 14.4% →
   **100%**, and `.../audio/src-isvalid` 19.8% → **100%**.
-- **Owner:** `Broiler.HTML` (`Parse/DomParser.cs`). **Waiting on a patch** —
-  `patches/0008-media-element-painting.patch`, listed in
-  `scripts/apply-pending-wpt-patches.sh` so the pixel suites exercise it. Identify it by
-  its commit subject, *Paint a media element's box only when it shows controls*, not by
-  the number.
+- **Owner:** `Broiler.HTML` (`Parse/DomParser.cs`). It was waiting on a patch while its
+  remote sat outside a this-repository session's push scope; it is upstream now as
+  `a9be60a`, *Paint a media element's box only when it shows controls*, and the pinned
+  pointer contains it, so it reaches CI through the pointer. Identify it by that commit
+  subject, never by the patch number it once had.
 - **What was wrong.** A `<video>` with no decodable media filled its whole box black, and
   an `<audio>` without `controls` laid out as a 300×32 black bar instead of not laying out
   at all. Each of those two test pages is 250 media elements; Chromium renders both as

--- a/docs/wpt-rendering-gaps.md
+++ b/docs/wpt-rendering-gaps.md
@@ -36,15 +36,20 @@ being hidden by [a missing check in the runner](wpt-rendering-gaps-fixed.md#--ve
    ([details](wpt-rendering-gaps-open.md#the-flag-can-be-a-false-negative)). And the
    inverse exists too: two `css-view-transitions` tests
    [pass on CI and are demonstrably wrong](wpt-rendering-gaps-open.md#two-tests-are-green-on-ci-and-wrong).
-3. **One rendering fix on these pages is waiting on a patch, and a patch number
-   identifies nothing.** That fix is
-   [the media-element one](wpt-rendering-gaps-fixed.md#a-media-element-with-nothing-to-show-painted-a-black-box)
-   — *Paint a media element's box only when it shows controls*, in `Broiler.HTML`,
-   listed in `scripts/apply-pending-wpt-patches.sh` so the pixel suites exercise it on
-   top of the pinned pointer. Every *other* submodule fix in these documents is an
-   ancestor of the pointer and live on CI outright, including the SVG-renderer
-   unification and the `object-fit` call site that each held `0001` before it. That is
-   the whole problem with numbering them: [`patches/`](../patches/README.md) is a
+3. **No rendering fix on these pages is waiting on a patch any more, and a patch
+   number identifies nothing.** The last one that was — *Paint a media element's box
+   only when it shows controls*,
+   [the media-element fix](wpt-rendering-gaps-fixed.md#a-media-element-with-nothing-to-show-painted-a-black-box)
+   in `Broiler.HTML` — landed upstream as `a9be60a` and the pinned pointer contains
+   it, so it reaches CI through the pointer and its entry in
+   `scripts/apply-pending-wpt-patches.sh` is gone. Every submodule fix in these
+   documents is now an ancestor of its pointer, including the SVG-renderer
+   unification and the `object-fit` call site that each held `0001` before it. (One
+   patch *is* pending, `Broiler.CSS`'s *Resolve the absolute length units in
+   ParseToPixels*, but it belongs to the
+   [reftest suite's](wpt-reftests.md#border-72pt-solid-red-painted-a-3px-black-line)
+   work rather than to these pages.) That is the whole problem with numbering them:
+   [`patches/`](../patches/README.md) is a
    backlog rather than an archive — a file is deleted once its fix is upstream and
    numbering restarts from `0001` — so the same number names different changes at
    different times, and a `patches/NNNN` reference in an older commit or comment is

--- a/patches/0001-resolve-the-absolute-length-units-in-parsetopixels.patch
+++ b/patches/0001-resolve-the-absolute-length-units-in-parsetopixels.patch
@@ -1,0 +1,61 @@
+From 73adc9a7877f2642a2be6e6d684a362d15405270 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Thu, 20 Aug 2026 11:06:04 +0000
+Subject: [PATCH] Resolve the absolute length units in ParseToPixels
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CSS Values 3 §5.2's absolute units — pt, pc, in, cm, mm, Q — are fixed
+multiples of the reference pixel, so they need no font and no viewport to
+resolve, exactly like px. ParseToPixels handled px and the font- and
+viewport-relative families and simply left these out, returning NaN.
+
+Its callers read that NaN as "this is not a length", and act on it:
+IsLengthOrPercentage asks it whether `72pt` is a length and is told no, so
+the border shorthand classifies `border: 72pt solid red`'s first component
+as a colour. The width falls back to `medium` and the declared colour is
+dropped — every `border: <n>pt|in|pc|cm|mm solid <colour>` in a stylesheet
+painted a 3px black line instead. The same NaN made a media query such as
+`(min-width: 8in)` and a container query with an absolute length evaluate
+as invalid rather than as the length they name.
+
+The `in` spelling is placed after the viewport scan, which claims `vmin`.
+---
+ Broiler.CSS/CssLengthParser.cs | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/Broiler.CSS/CssLengthParser.cs b/Broiler.CSS/CssLengthParser.cs
+index 2fcd3da..3944f37 100644
+--- a/Broiler.CSS/CssLengthParser.cs
++++ b/Broiler.CSS/CssLengthParser.cs
+@@ -980,6 +980,26 @@ public static class CssLengthParser
+ 
+         if (v.EndsWith("px"))
+             return TryParseLeadingNumber(v, 2, out var px) ? px : double.NaN;
++
++        // CSS Values 3 §5.2: the absolute units are fixed multiples of the reference pixel, so
++        // they resolve here with nothing else to consult — no font, no viewport — exactly like
++        // `px` above. They were simply missing, and the callers of this method act on the
++        // answer it gives: `IsLengthOrPercentage` asked it whether `72pt` is a length, was told
++        // no, and the `border` shorthand therefore read `border: 72pt solid red`'s first
++        // component as a *colour* — leaving the width at `medium` and dropping the red. The
++        // `in` spelling has to come after the viewport scan above, which claims `vmin`.
++        if (v.EndsWith("pt"))
++            return TryParseLeadingNumber(v, 2, out var pt) ? pt * CssMetrics.PtToPx : double.NaN;
++        if (v.EndsWith("pc"))
++            return TryParseLeadingNumber(v, 2, out var pc) ? pc * CssMetrics.PxPerPica : double.NaN;
++        if (v.EndsWith("in"))
++            return TryParseLeadingNumber(v, 2, out var inch) ? inch * CssMetrics.PxPerInch : double.NaN;
++        if (v.EndsWith("cm"))
++            return TryParseLeadingNumber(v, 2, out var cm) ? cm * CssMetrics.PxPerCm : double.NaN;
++        if (v.EndsWith("mm"))
++            return TryParseLeadingNumber(v, 2, out var mm) ? mm * CssMetrics.PxPerMm : double.NaN;
++        if (v.EndsWith("q"))
++            return TryParseLeadingNumber(v, 1, out var q) ? q * CssMetrics.PxPerQ : double.NaN;
+         if (v.EndsWith("rem"))
+             return TryParseLeadingNumber(v, 3, out var rem) ? rem * 16.0 : double.NaN;
+         if (v.EndsWith("em"))
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,81 @@
+# Submodule patches waiting to be applied
+
+**One patch is waiting on a maintainer.** See the index below.
+
+`Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
+are git submodules with their own remotes. A session whose GitHub scope is this
+repository alone cannot push to them — the git proxy answers **403** — so a fix
+that belongs in a submodule is committed there, exported with
+`git format-patch`, and left here for a maintainer to apply. The submodule
+working tree is then reverted to its pinned commit and **the gitlink is not
+bumped**: CI clones a submodule by pointer, and a pointer to a commit that was
+never pushed would break the build.
+
+Applying one:
+
+```sh
+cd <Submodule>
+git checkout -b <branch> && git am ../patches/NNNN-<slug>.patch
+git push origin HEAD
+cd .. && git add <Submodule>      # bump the pointer only once the push succeeds
+```
+
+## This directory is a backlog, not an archive
+
+A patch is deleted from here the moment its fix is upstream and the submodule
+pointer is bumped, because from then on it reaches CI through the pointer and a
+file that can only ever be skipped is noise. `scripts/apply-pending-wpt-patches.sh`
+holds the matching list — the subset whose fix can move rendered pixels, so a
+WPT run exercises it rather than testing against the un-fixed pointer — and is
+idempotent, so a patch already contained in the pinned pointer is skipped rather
+than re-applied.
+
+**Check the pointer, not this file, before concluding a fix is pending.** The
+numbering is *recycled*: numbers are assigned from `0001` against whatever the
+directory holds at the time, so a patch number in an older commit message, code
+comment or document does **not** identify the same change as today's patch of
+that number. Prose that names a patch by number alone is evidence about the past
+only. To decide whether a submodule fix is live, look for its commit:
+
+```sh
+git -C <Submodule> log --oneline --grep '<the commit subject>'
+git -C <Submodule> merge-base --is-ancestor <sha> HEAD && echo "live on CI"
+```
+
+The directory was emptied by the previous submodule bump — all six of the
+`mediawiki.org` patches landed upstream — so the numbering restarts at `0001`
+again with the one below.
+
+## The index
+
+| # | submodule | subject |
+| --- | --- | --- |
+| `0001` | `Broiler.CSS` | Resolve the absolute length units in ParseToPixels |
+
+### `0001` — `border: 72pt solid red` painted a thin black line
+
+CSS Values 3 §5.2's absolute units — `pt`, `pc`, `in`, `cm`, `mm`, `Q` — are
+fixed multiples of the reference pixel, so they resolve with nothing else to
+consult: no font, no viewport, exactly like `px`. `CssLengthParser.ParseToPixels`
+handled `px` and the whole font-relative and viewport-relative families and
+simply left these six out, answering `NaN`.
+
+Its callers read that `NaN` as *"this is not a length"*, and act on it. The
+`border` shorthand is the loud one: `IsLengthOrPercentage` asks whether `72pt` is
+a length, is told no, and the expansion therefore classifies
+`border: 72pt solid red`'s first component as a **colour**. The width falls back
+to `medium` and the declared colour is dropped, so the declaration paints a 3px
+black line. The longhand spelling — `border-left-width: 72pt` — was right the
+whole time, which is what makes the failure hard to see: it is not "units are
+broken", it is "units are broken in one shorthand".
+
+That matters far out of proportion to the six keywords, because the CSS2.1 test
+suite states its geometry in physical units by convention. **`css/CSS2/positioning`
+alone goes 364 → 394 of 520 reftests on this patch, with none lost.**
+
+Two quieter callers were answering the same `NaN`: a media query such as
+`(min-width: 8in)` and a container query with an absolute length both evaluated
+as *invalid* rather than as the length they name.
+
+The `in` spelling has to be tested after the viewport-unit scan, which claims
+`vmin`.

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -226,8 +226,22 @@ set -euo pipefail
 #     way has no box for its background to propagate from and the page renders white.
 #   * 0006 (Broiler.HTML, clip an outset box-shadow) — an unclipped outer shadow fills the element
 #     it is cast by, so a card with a shadow paints as a solid block of shadow colour.
+#
+# All six of those landed upstream and the pinned pointers contain them, so each reaches CI
+# through the pointer now and their entries and patch files are gone. The numbering restarted at
+# 0001 against what was left, which was nothing.
+#
+# 0001 (Broiler.CSS, "Resolve the absolute length units in ParseToPixels") is listed, and it is
+# as plain a case as the anonymous-table one above: without it the `border` shorthand reads
+# `border: 72pt solid red`'s first component as a *colour*, so the width falls back to `medium`
+# and the colour is dropped — a declaration that should paint a 96px red band paints a 3px black
+# line instead. The CSS2.1 suite states its geometry in physical units by convention, so this is
+# not a corner: `css/CSS2/positioning` alone goes 364 → 394 of 520 reftests with the patch
+# applied and none lost. There is no main-repo half to fall back on — the shorthand expansion is
+# entirely inside Broiler.CSS — which is precisely why it has to be applied here to reach a run.
 
 PENDING_PATCHES=(
+  "Broiler.CSS|patches/0001-resolve-the-absolute-length-units-in-parsetopixels.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary

Two independent fixes that together improve WPT reftest pass rate from 18,644 to 18,886 (+244 passing, 2 false-pass corrections):

1. **Aspect-ratio now sizes the inline axis from a definite block size** — a box with `height: 100px; aspect-ratio: 1/1` is now a 100px square instead of a viewport-wide band.
2. **Absolute length units (`pt`, `pc`, `in`, `cm`, `mm`, `Q`) now resolve in `ParseToPixels`** — `border: 72pt solid red` now paints a red border instead of a 3px black line.

## Changes

### Aspect-ratio inline sizing (`Broiler.Layout`)

- **`CssBox.TryResolveAspectRatioAutoInlineWidth`** (new method): Resolves an `auto` inline width from a definite block size and aspect ratio, mirroring the existing block-size transfer. Supersedes the block-level stretch-fit, the CSS2.1 §10.3.7 inset equation, and float/abspos shrink-to-fit — each answers "how wide is a box with no width of its own?", which a ratio plus definite height already answers.

- **`CssBox.TryGetDefiniteSpecifiedBorderBoxHeight`** (new method): Determines whether the box's own `height` declaration resolves to a definite border-box value, accounting for percentage resolution against the containing block and `min-height`/`max-height` clamping.

- **`CssBox.TryResolveAspectRatioInlineWidth` (modified)**: Fixed clamp order — now clamps in the box `box-sizing` names before converting to border-box, correcting the grid-item caller that already existed. A `content-box` box with `padding: 0 20px; max-width: 60px` and 100px transferred content width is now correctly 100px wide (60 + padding), not 60.

- **`CssBox.TryParseAspectRatio` (modified)**: Fixed parsing of aspect-ratio values with spaces around the `/` token. `aspect-ratio: 1 / 2` now parses correctly (was rejected as no ratio at all); the slash is a grammar token, not a character of the numbers, so whitespace may surround it.

- **`CssBox.ResolveBlockUsedWidth` (modified)**: Calls `TryResolveAspectRatioAutoInlineWidth` before other auto-width rules, and skips auto-margin centering when the width came from the ratio (it still centers, but the condition was redundant).

- **`AspectRatioInlineSizeTests`** (new test class): 318 lines of comprehensive tests covering the transfer rule, constraint precedence (`min-height`/`max-height` before, `min-width`/`max-width` after), `box-sizing` interaction, percentage heights, out-of-flow boxes, and the spaced-slash parsing fix. All expectations read from Chromium to pin the constraint-win order precisely.

### Absolute length units (`Broiler.CSS` — patch)

- **`CssLengthParser.ParseToPixels` (modified)**: Added resolution for CSS Values 3 §5.2 absolute units — `pt` (points), `pc` (picas), `in` (inches), `cm` (centimeters), `mm` (millimeters), `Q` (quarter-millimeters). Each is a fixed multiple of the reference pixel (already defined in `CssMetrics`) and resolves with no font or viewport context, exactly like `px`.

The `in` spelling is placed after the viewport-unit scan (which claims `vmin`) to avoid collision.

## Impact

- **`css-sizing/aspect-ratio`**: 147 → 168 of 266 tests passing (+21 from the transfer, +8 from the spaced-slash fix).
- **`css/CSS2/positioning`**: 364 → 394 of 520 tests passing (+30 from absolute units).
- **`css

https://claude.ai/code/session_01FXaB425vEvu9BepBevWpJQ