### PR TITLE
Fix grid intrinsic width and item placement with fixed implicit tracks

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -213,8 +213,27 @@ internal partial class CssBox
         // Grids with an explicit template on the affected axis keep going through
         // this pass exactly as before; only the implicit-only takeover is gated.
 
+        // Implicit tracks (grid-auto-columns/rows); default 'auto'.
+        GridTrackSpec implicitCol = ParseSingleImplicitSpec(GridAutoColumns, em);
+        GridTrackSpec implicitRow = ParseSingleImplicitSpec(GridAutoRows, em);
+
+        // The item-shape half of that gate exists to protect a track whose size
+        // comes from an item's measurement. When every track on both axes is a
+        // definite fixed length — templates and `grid-auto-*` alike — no
+        // measurement reaches a track at all, so no item shape can mis-size one and
+        // the gate has nothing left to protect. Declining anyway is what left an
+        // `inline-grid { grid-auto-columns: 15px; grid-auto-rows: 8px }` holding a
+        // nested grid to the approximation, which ignores the child's
+        // `grid-column: 3 / span 4` and stretches it across the whole container
+        // (WPT css-grid/subgrid/repeat-auto-fill-002/-003/-004). The baseline half
+        // stays unconditional: a shared baseline shifts items *within* a row, which
+        // fixed tracks do not make safe.
+        bool allTracksFixed = AllTrackSizesAreFixed(colSpecs, implicitCol)
+            && AllTrackSizesAreFixed(rowSpecs, implicitRow);
+
         if ((colImplicitOnly || rowImplicitOnly)
-            && (GridUsesBaselineSelfAlignment() || !GridImplicitPathItemsAreSimple()))
+            && (GridUsesBaselineSelfAlignment()
+                || !(allTracksFixed || GridImplicitPathItemsAreSimple())))
             return false;
 
         // Implicit tracks are allowed to carry the whole axis for a subgrid, an
@@ -231,10 +250,6 @@ internal partial class CssBox
 
         if (colSpecs.Count > MaxGridLine || rowSpecs.Count > MaxGridLine)
             return false;
-
-        // Implicit tracks (grid-auto-columns/rows); default 'auto'.
-        GridTrackSpec implicitCol = ParseSingleImplicitSpec(GridAutoColumns, em);
-        GridTrackSpec implicitRow = ParseSingleImplicitSpec(GridAutoRows, em);
 
         // Collect in-flow grid items in document order. Absolutely-positioned
         // children are gathered separately: they take no part in track sizing or
@@ -1419,6 +1434,26 @@ internal partial class CssBox
             && value.Contains("baseline", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
+    /// True when every track an axis can produce is a definite fixed length — each
+    /// explicit sizing function in <paramref name="specs"/> on both its
+    /// <c>minmax()</c> sides, and the <c>grid-auto-*</c> function any implicit track
+    /// takes. Such an axis is sized entirely from its declarations, so nothing an
+    /// item measures can change a track size on it. <c>grid-auto-*</c> defaults to
+    /// <c>auto</c>, so an axis that declares none is not fixed.
+    /// </summary>
+    private static bool AllTrackSizesAreFixed(List<GridTrackSpec> specs, GridTrackSpec implicitSpec)
+    {
+        if (implicitSpec.Min.Kind != GridSizeKind.Fixed || implicitSpec.Max.Kind != GridSizeKind.Fixed)
+            return false;
+
+        foreach (var spec in specs)
+            if (spec.Min.Kind != GridSizeKind.Fixed || spec.Max.Kind != GridSizeKind.Fixed)
+                return false;
+
+        return true;
+    }
+
+    /// <summary>
     /// True when every in-flow item of this grid is a plain box whose used block
     /// size the bounded track pass can trust from a single measurement — used to
     /// gate the implicit-only takeover away from item shapes the pass sizes worse
@@ -1553,9 +1588,8 @@ internal partial class CssBox
         }
 
         double gap = ResolveGridGap(ColumnGap, 0, em);
-        GridSize implicitSide = useMax
-            ? ParseSingleImplicitSpec(GridAutoColumns, em).Max
-            : ParseSingleImplicitSpec(GridAutoColumns, em).Min;
+        GridTrackSpec implicitCol = ParseSingleImplicitSpec(GridAutoColumns, em);
+        GridSize implicitSide = useMax ? implicitCol.Max : implicitCol.Min;
 
         // `grid-auto-columns` defaults to `auto`, and an intrinsic implicit track
         // is sized by its items — the real track pass' job. Answer such a grid from
@@ -1574,9 +1608,10 @@ internal partial class CssBox
         if (!TryCountGridIntrinsicColumns(specs.Count, em, out int colCount))
             return false;
 
-        // Every track outside [explicitStart, explicitStart + specs.Count) — the
-        // leading implicit tracks as well as the trailing ones — is an implicit
-        // column, and gaps are charged between all of them (§7.2).
+        // Every column the placement produced beyond the template — the leading
+        // implicit tracks a before-grid line references as well as the trailing
+        // ones — is an implicit track, and gaps are charged between all of the
+        // columns rather than just the template's (§7.2).
         contentWidth = explicitSum
             + (colCount - specs.Count) * Math.Max(0, implicitSide.Value)
             + gap * (colCount - 1);

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBoxGrid.cs
@@ -242,55 +242,13 @@ internal partial class CssBox
         // (i.e. it is positioned) their grid area forms their containing block
         // (CSS Grid §9), which the abspos pass below resolves once tracks exist.
         bool gridIsAbsposContainingBlock = Position is CssConstants.Relative or CssConstants.Absolute or CssConstants.Fixed;
-        var placements = new List<GridPlacement>();
-        List<CssBox> absposItems = null;
 
         var colNames = ParseLineNames(GridTemplateColumns);
         var rowNames = ParseLineNames(GridTemplateRows);
 
-        foreach (var child in Boxes)
-        {
-            if (child.Display == CssConstants.None)
-                continue;
-
-            // CSS Grid §4: every in-flow child becomes a grid item, EXCEPT a
-            // contiguous run of collapsible white space that is not contained in
-            // a non-anonymous box — such an anonymous box "is not rendered (just
-            // as if it were display:none)" and must not occupy a track. Broiler's
-            // box tree keeps the inter-item white space between block-level grid
-            // items as anonymous whitespace-only boxes; left in, each auto-places
-            // into its own phantom track and inflates the grid (e.g. the
-            // grid-lanes subgrid reftests gained spurious rows).
-            if (IsCollapsibleWhitespaceItem(child))
-                continue;
-
-            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
-            {
-                if (gridIsAbsposContainingBlock)
-                    (absposItems ??= []).Add(child);
-
-                continue;
-            }
-
-            var (rowStart, rowSpan) = ParseGridLine(child.GridRow, rowSpecs.Count, rowNames);
-            var (colStart, colSpan) = ParseGridLine(child.GridColumn, colSpecs.Count, colNames);
-
-            // Decline rather than lay out an implausibly large grid. A negative
-            // start references a leading implicit track (normalised below), so bound
-            // its magnitude too.
-            if (rowSpan > MaxGridLine || colSpan > MaxGridLine
-                || Math.Abs(rowStart ?? 0) > MaxGridLine || Math.Abs(colStart ?? 0) > MaxGridLine)
-                return false;
-
-            placements.Add(new GridPlacement
-            {
-                Item = child,
-                RowStart = rowStart,
-                RowSpan = rowSpan,
-                ColStart = colStart,
-                ColSpan = colSpan,
-            });
-        }
+        if (!TryCollectGridPlacements(colSpecs.Count, rowSpecs.Count, colNames, rowNames,
+                gridIsAbsposContainingBlock, out var placements, out List<CssBox> absposItems))
+            return false;
 
         // A grid with no in-flow items has no tracks to size *from*, so the pass
         // normally declines to the approximation. It must not when the grid carries
@@ -304,62 +262,9 @@ internal partial class CssBox
         if (placements.Count == 0 && absposItems == null)
             return false;
 
-        int explicitRowStart;
-
-        // CSS Grid §8.3: a definite line that resolves before the explicit grid
-        // (a negative index here) references a *leading* implicit track. Normalise
-        // by shifting every placement right/down so the leftmost/topmost referenced
-        // line is index 0; the explicit grid then begins at explicitColStart /
-        // explicitRowStart. leading == 0 for every grid without a before-grid line,
-        // so those are byte-identical to before. Auto-placement into leading tracks
-        // is out of scope, so decline when an auto-placed item coexists with them.
-        int explicitColStart;
-        int minCol = 0, minRow = 0;
-
-        foreach (var p in placements)
-        {
-            if (p.ColStart.HasValue) minCol = Math.Min(minCol, p.ColStart.Value);
-            if (p.RowStart.HasValue) minRow = Math.Min(minRow, p.RowStart.Value);
-        }
-
-        explicitColStart = -minCol;
-        explicitRowStart = -minRow;
-
-        if (explicitColStart > 0 || explicitRowStart > 0)
-        {
-            foreach (var p in placements)
-                if (!p.ColStart.HasValue || !p.RowStart.HasValue)
-                    return false;
-
-            for (int i = 0; i < placements.Count; i++)
-            {
-                var p = placements[i];
-                p.ColStart += explicitColStart;
-                p.RowStart += explicitRowStart;
-                placements[i] = p;
-            }
-        }
-
-        bool flowRow = (GridAutoFlow ?? "row").IndexOf("column", StringComparison.OrdinalIgnoreCase) < 0;
-        bool dense = (GridAutoFlow ?? "").Contains("dense", StringComparison.OrdinalIgnoreCase);
-
-        PlaceItems(placements, colSpecs.Count + explicitColStart, rowSpecs.Count + explicitRowStart, flowRow, dense);
-
-        // Track counts after placement, including any implicit tracks.
-        int maxColEnd = 0, maxRowEnd = 0;
-        foreach (var p in placements)
-        {
-            maxColEnd = Math.Max(maxColEnd, p.PlacedCol + p.ColSpan);
-            maxRowEnd = Math.Max(maxRowEnd, p.PlacedRow + p.RowSpan);
-        }
-
-        if (maxColEnd > MaxGridLine || maxRowEnd > MaxGridLine)
+        if (!TryPlaceGridItems(placements, colSpecs.Count, rowSpecs.Count,
+                out int explicitColStart, out int explicitRowStart, out int colCount, out int rowCount))
             return false;
-
-        // The explicit tracks occupy [explicitColStart, explicitColStart+count); any
-        // leading implicit tracks precede them, so the axis is at least that wide.
-        int colCount = Math.Max(maxColEnd, explicitColStart + colSpecs.Count);
-        int rowCount = Math.Max(maxRowEnd, explicitRowStart + rowSpecs.Count);
 
         // A subgridded axis adopts the parent grid's gutter (CSS Grid L2 §7.3).
         double colGap = colSubgrid && SubgridColumnGap.HasValue
@@ -584,6 +489,141 @@ internal partial class CssBox
             total += (span - 1) * gap;
 
         return total;
+    }
+
+    /// <summary>
+    /// CSS Grid §4 + §8.3: collects this container's in-flow children as grid
+    /// placements in document order, resolving each one's <c>grid-row</c>/
+    /// <c>grid-column</c> against the two explicit track counts. Absolutely-
+    /// positioned children take no part in track sizing or auto-placement and come
+    /// back separately in <paramref name="absposItems"/> — only when
+    /// <paramref name="collectAbspos"/> says this container is their containing
+    /// block, in which case their grid areas are resolved once tracks exist
+    /// (§9). Returns <c>false</c> for an implausibly large placement, which
+    /// declines the caller's whole pass.
+    /// </summary>
+    private bool TryCollectGridPlacements(int explicitCols, int explicitRows,
+        IReadOnlyDictionary<string, List<int>> colNames, IReadOnlyDictionary<string, List<int>> rowNames,
+        bool collectAbspos, out List<GridPlacement> placements, out List<CssBox> absposItems)
+    {
+        placements = [];
+        absposItems = null;
+
+        foreach (var child in Boxes)
+        {
+            if (child.Display == CssConstants.None)
+                continue;
+
+            // CSS Grid §4: every in-flow child becomes a grid item, EXCEPT a
+            // contiguous run of collapsible white space that is not contained in
+            // a non-anonymous box — such an anonymous box "is not rendered (just
+            // as if it were display:none)" and must not occupy a track. Broiler's
+            // box tree keeps the inter-item white space between block-level grid
+            // items as anonymous whitespace-only boxes; left in, each auto-places
+            // into its own phantom track and inflates the grid (e.g. the
+            // grid-lanes subgrid reftests gained spurious rows).
+            if (IsCollapsibleWhitespaceItem(child))
+                continue;
+
+            if (child.Position == CssConstants.Absolute || child.Position == CssConstants.Fixed)
+            {
+                if (collectAbspos)
+                    (absposItems ??= []).Add(child);
+
+                continue;
+            }
+
+            var (rowStart, rowSpan) = ParseGridLine(child.GridRow, explicitRows, rowNames);
+            var (colStart, colSpan) = ParseGridLine(child.GridColumn, explicitCols, colNames);
+
+            // Decline rather than lay out an implausibly large grid. A negative
+            // start references a leading implicit track (normalised by
+            // TryPlaceGridItems), so bound its magnitude too.
+            if (rowSpan > MaxGridLine || colSpan > MaxGridLine
+                || Math.Abs(rowStart ?? 0) > MaxGridLine || Math.Abs(colStart ?? 0) > MaxGridLine)
+                return false;
+
+            placements.Add(new GridPlacement
+            {
+                Item = child,
+                RowStart = rowStart,
+                RowSpan = rowSpan,
+                ColStart = colStart,
+                ColSpan = colSpan,
+            });
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// CSS Grid §8.3 + §8.5: normalises leading implicit tracks, runs
+    /// auto-placement over <paramref name="placements"/>, and reports the track
+    /// count each axis ends up with (explicit template plus any implicit tracks the
+    /// placement generated) together with the index the explicit tracks start at.
+    /// Returns <c>false</c> for a grid this bounded pass declines to lay out.
+    /// </summary>
+    private bool TryPlaceGridItems(List<GridPlacement> placements, int explicitCols, int explicitRows,
+        out int explicitColStart, out int explicitRowStart, out int colCount, out int rowCount)
+    {
+        colCount = 0;
+        rowCount = 0;
+
+        // CSS Grid §8.3: a definite line that resolves before the explicit grid
+        // (a negative index here) references a *leading* implicit track. Normalise
+        // by shifting every placement right/down so the leftmost/topmost referenced
+        // line is index 0; the explicit grid then begins at explicitColStart /
+        // explicitRowStart. leading == 0 for every grid without a before-grid line,
+        // so those are byte-identical to before. Auto-placement into leading tracks
+        // is out of scope, so decline when an auto-placed item coexists with them.
+        int minCol = 0, minRow = 0;
+
+        foreach (var p in placements)
+        {
+            if (p.ColStart.HasValue) minCol = Math.Min(minCol, p.ColStart.Value);
+            if (p.RowStart.HasValue) minRow = Math.Min(minRow, p.RowStart.Value);
+        }
+
+        explicitColStart = -minCol;
+        explicitRowStart = -minRow;
+
+        if (explicitColStart > 0 || explicitRowStart > 0)
+        {
+            foreach (var p in placements)
+                if (!p.ColStart.HasValue || !p.RowStart.HasValue)
+                    return false;
+
+            for (int i = 0; i < placements.Count; i++)
+            {
+                var p = placements[i];
+                p.ColStart += explicitColStart;
+                p.RowStart += explicitRowStart;
+                placements[i] = p;
+            }
+        }
+
+        bool flowRow = (GridAutoFlow ?? "row").IndexOf("column", StringComparison.OrdinalIgnoreCase) < 0;
+        bool dense = (GridAutoFlow ?? "").Contains("dense", StringComparison.OrdinalIgnoreCase);
+
+        PlaceItems(placements, explicitCols + explicitColStart, explicitRows + explicitRowStart, flowRow, dense);
+
+        // Track counts after placement, including any implicit tracks.
+        int maxColEnd = 0, maxRowEnd = 0;
+        foreach (var p in placements)
+        {
+            maxColEnd = Math.Max(maxColEnd, p.PlacedCol + p.ColSpan);
+            maxRowEnd = Math.Max(maxRowEnd, p.PlacedRow + p.RowSpan);
+        }
+
+        if (maxColEnd > MaxGridLine || maxRowEnd > MaxGridLine)
+            return false;
+
+        // The explicit tracks occupy [explicitColStart, explicitColStart+count); any
+        // leading implicit tracks precede them, so the axis is at least that wide.
+        colCount = Math.Max(maxColEnd, explicitColStart + explicitCols);
+        rowCount = Math.Max(maxRowEnd, explicitRowStart + explicitRows);
+
+        return true;
     }
 
     /// <summary>
@@ -1455,17 +1495,26 @@ internal partial class CssBox
     /// <summary>
     /// CSS Grid §5.1 / Sizing 3: the grid container's intrinsic (min-content when
     /// <paramref name="useMax"/> is false, else max-content) **content-box** width —
-    /// the sum of its <c>grid-template-columns</c> track sizes plus gaps, for a
-    /// horizontal writing mode (a vertical grid's physical-width axis is the rows,
-    /// applied through the rotation — declined below). Bounded to templates whose
-    /// tracks are all definite fixed lengths (a plain length or a <c>minmax()</c>
-    /// with fixed sides — <c>repeat(&lt;int&gt;,…)</c> already expanded by
+    /// the sum of its column track sizes plus gaps, for a horizontal writing mode
+    /// (a vertical grid's physical-width axis is the rows, applied through the
+    /// rotation — declined below). The column axis is the one the real pass would
+    /// resolve: the <c>grid-template-columns</c> tracks, plus every *implicit*
+    /// column that auto-placement or a definite <c>grid-column</c> generates (§7.5),
+    /// each sized from <c>grid-auto-columns</c>. Bounded to tracks that are all
+    /// definite fixed lengths (a plain length or a <c>minmax()</c> with fixed sides
+    /// — <c>repeat(&lt;int&gt;,…)</c> already expanded by
     /// <see cref="ParseTrackList"/>): declines for <c>fr</c>/<c>auto</c>/
     /// content/percentage/<c>auto-fill</c> tracks, whose size needs the real track
-    /// pass (and the items). Lets a shrink-to-fit grid (float, <c>inline-grid</c>,
+    /// pass (and the items). Since <c>grid-auto-columns</c> defaults to <c>auto</c>,
+    /// that bound confines the implicit half of this to grids declaring a definite
+    /// <c>grid-auto-columns</c>: every other grid keeps its previous answer — the
+    /// explicit template alone, or a decline to the content-based fallback when it
+    /// has no template. Lets a shrink-to-fit grid (float, <c>inline-grid</c>,
     /// <c>fit-content</c>/<c>min-content</c>/<c>max-content</c>) size to its tracks
-    /// instead of collapsing to its (often empty) inline content
-    /// (WPT css-grid grid-gutters-and-tracks-001, …-margin-border-padding-vertical-rl).
+    /// instead of collapsing to its (often empty) inline content (WPT css-grid
+    /// grid-gutters-and-tracks-001, …-margin-border-padding-vertical-rl, and the
+    /// <c>grid-auto-columns</c> grids of
+    /// css-grid/…/track-sizing/column-subgrid-auto-fill-008).
     /// </summary>
     private bool TryComputeGridIntrinsicContentWidth(bool useMax, out double contentWidth)
     {
@@ -1482,24 +1531,94 @@ internal partial class CssBox
 
         double em = GetEmHeight();
         var specs = ParseTrackList(GridTemplateColumns, em);
-        if (specs == null || specs.Count == 0 || specs.Count > MaxGridLine)
+
+        // A `none`/empty template is not "no grid": the axis is implicit-only and
+        // takes all of its tracks from auto-placement, sized by grid-auto-columns.
+        // An *unsupported* token (subgrid, auto-fill, a bare `auto`, …) also parses
+        // to null and still declines — its size needs the real track pass.
+        if (specs == null && IsNoneOrEmptyTemplate(GridTemplateColumns))
+            specs = [];
+
+        if (specs == null || specs.Count > MaxGridLine)
             return false;
 
-        double sum = 0;
+        double explicitSum = 0;
         foreach (var spec in specs)
         {
             GridSize side = useMax ? spec.Max : spec.Min;
             if (side.Kind != GridSizeKind.Fixed)
                 return false;                 // needs the real track pass
 
-            sum += Math.Max(0, side.Value);
+            explicitSum += Math.Max(0, side.Value);
         }
 
         double gap = ResolveGridGap(ColumnGap, 0, em);
-        sum += gap * (specs.Count - 1);
-        contentWidth = sum;
+        GridSize implicitSide = useMax
+            ? ParseSingleImplicitSpec(GridAutoColumns, em).Max
+            : ParseSingleImplicitSpec(GridAutoColumns, em).Min;
+
+        // `grid-auto-columns` defaults to `auto`, and an intrinsic implicit track
+        // is sized by its items — the real track pass' job. Answer such a grid from
+        // the explicit template alone, and decline outright when it has none: this
+        // is the pre-existing behaviour, so only a grid declaring a definite
+        // `grid-auto-columns` reaches the placement replay below.
+        if (implicitSide.Kind != GridSizeKind.Fixed)
+        {
+            if (specs.Count == 0)
+                return false;
+
+            contentWidth = explicitSum + gap * (specs.Count - 1);
+            return true;
+        }
+
+        if (!TryCountGridIntrinsicColumns(specs.Count, em, out int colCount))
+            return false;
+
+        // Every track outside [explicitStart, explicitStart + specs.Count) — the
+        // leading implicit tracks as well as the trailing ones — is an implicit
+        // column, and gaps are charged between all of them (§7.2).
+        contentWidth = explicitSum
+            + (colCount - specs.Count) * Math.Max(0, implicitSide.Value)
+            + gap * (colCount - 1);
 
         return true;
+    }
+
+    /// <summary>
+    /// The number of columns the real track pass would resolve for this grid: the
+    /// explicit template extended by every implicit column that auto-placement or a
+    /// definite <c>grid-column</c> generates, leading implicit tracks included. Runs
+    /// the same collection and placement that pass runs, so the two agree on the
+    /// count; declines (<c>false</c>) wherever it would, and for a row template this
+    /// size query cannot resolve — auto-placement flows through the rows, and a
+    /// <c>repeat(auto-fill, …)</c> row count needs a block size that is not
+    /// available while an inline size is still being computed.
+    /// </summary>
+    private bool TryCountGridIntrinsicColumns(int explicitCols, double em, out int colCount)
+    {
+        colCount = explicitCols;
+
+        var rowSpecs = ParseTrackList(GridTemplateRows, em);
+        if (rowSpecs == null && IsNoneOrEmptyTemplate(GridTemplateRows))
+            rowSpecs = [];
+
+        if (rowSpecs == null || rowSpecs.Count > MaxGridLine)
+            return false;
+
+        if (!TryCollectGridPlacements(explicitCols, rowSpecs.Count,
+                ParseLineNames(GridTemplateColumns), ParseLineNames(GridTemplateRows),
+                collectAbspos: false, out var placements, out _))
+            return false;
+
+        // Nothing placed: the explicit template is the whole axis, exactly as
+        // before. With no template either there are no tracks at all, so an
+        // item-less implicit-only grid keeps the content-based fallback.
+        if (placements.Count == 0)
+            return explicitCols > 0;
+
+        return TryPlaceGridItems(placements, explicitCols, rowSpecs.Count,
+                   out _, out _, out colCount, out _)
+               && colCount > 0;
     }
 
     /// <summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,38 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- A grid container is as wide as the columns it actually has. The shrink-to-fit inline size of
+  a grid summed only the tracks named in `grid-template-columns`: implicit columns contributed
+  nothing, `grid-auto-columns` was never consulted, and a grid with no template at all fell
+  back to measuring inline content — 0, for a grid of empty boxes. So
+  `<div style="display: inline-grid; grid-auto-columns: 15px; border: 1px solid">` holding one
+  child at `grid-column: 3 / span 4` painted a 2px border and nothing else, where it is six
+  15px tracks wide. Details in
+  [`docs/wpt-reftests.md`](docs/wpt-reftests.md#a-grid-built-from-implicit-columns-was-as-wide-as-its-border).
+  - The definite-width pass was already right, so the intrinsic path stopped answering
+    separately: item collection and auto-placement are shared between the two, and the column
+    count the size is built from is the one the real pass will resolve. Tracks past the
+    template are sized from `grid-auto-columns`, and gaps are charged across all the columns
+    rather than the template's. `grid-auto-columns` defaults to `auto`, whose size is its
+    items', so a grid that does not declare a definite one is answered exactly as before.
+  - Fixing the width exposed a placement bug behind it: a grid whose every track is a definite
+    fixed length now runs the real track pass even when an item is a nested grid, flex or
+    table container, so that child lands in the columns its `grid-column` asks for instead of
+    being stretched across the container by the fallback. The gate it relaxes exists to
+    distrust an item's measured height when a row is auto-sized — which cannot arise when no
+    track takes its size from a measurement.
+  - **On the reftest scoreboard this is 4 tests worse, and that is the change working.**
+    Over 5 140 reftests in `css-grid`, `css-flexbox`, `css-sizing`, `css-tables`,
+    `css-display`, `css-inline`, `css-writing-modes` and `css-position`: **2 494 → 2 490
+    passing**, with exactly 10 tests moving at all. The four that flip —
+    `css-grid/subgrid/repeat-auto-fill-002/-003/-004` and `orthogonal-writing-mode-005` — were
+    passing because the test *and its reference* both collapsed to a 2px border on a blank
+    page and so matched each other. Both sides render at their true width now, and the
+    disagreement that was always underneath them is filed as its own gap: a subgrid resolves
+    neither `repeat(auto-fill, <line-names>)` nor the name-plus-index lines the tests place
+    items with. The `css-grid/grid-lanes` subset, which the gap entry named as the thing not
+    to regress, is unchanged at 195 of 869 passing.
+
 - A box with an `aspect-ratio` and a definite height is now that shape, and a `border` width may
   be written in a physical unit. Two unrelated defects, both found by asking why a whole WPT
   reftest family was failing uniformly rather than by working down the run's biggest-problems

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -875,6 +875,72 @@ main-repo half to fall back on: the shorthand expansion is entirely inside
 units in ParseToPixels*, not by the number — see
 [`patches/README.md`](../patches/README.md) on why the number means nothing.
 
+## A grid built from implicit columns was as wide as its border
+
+`inline-grid` with no `grid-template-columns` at all, one child, and a
+`grid-auto-columns` to size the tracks it generates:
+
+```html
+<div style="display: inline-grid; grid-auto-columns: 15px; border: 1px solid">
+  <div style="grid-column: 3 / span 4; background: grey"></div>
+</div>
+```
+
+`grid-column: 3 / span 4` puts the child in columns 3–6, so the grid is six 15px
+tracks — 90px of content inside a 1px border. Broiler made it **2px**: the border,
+and nothing else. The child came out 0px wide at x 1 instead of 60px at x 31.
+
+`TryComputeGridIntrinsicContentWidth` summed only the tracks named in
+`grid-template-columns`. Implicit columns contributed nothing, `grid-auto-columns`
+was never consulted on that path, and a grid with no template bailed out entirely
+so the caller measured inline *content* instead — 0, for a grid of empty divs.
+That is the shape every test in
+`css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/track-sizing` and
+`css-grid/subgrid/repeat-auto-fill-*` is built from.
+
+The definite-width pass had always been right, so the repair was to stop having
+two answers: `TryApplyGridTrackLayout`'s item collection and auto-placement moved
+into `TryCollectGridPlacements` and `TryPlaceGridItems`, and the intrinsic path
+now runs the same two. The count it sizes from is the count the real pass will
+resolve, by construction, rather than a second implementation that can drift.
+`grid-auto-columns` bounds the change: it defaults to `auto`, whose size is its
+items' and therefore the track pass' job, so a grid that does not declare a
+definite one is answered exactly as before.
+
+**Fixing the width exposed the next bug in the same document.** With the container
+finally 92px, a layout assertion showed the child ignoring its `grid-column` and
+spanning all six tracks. The implicit-only pass declines for a nested
+grid/flex/table item, because sizing an *auto* row from a single measurement of a
+nested container collapses it — but when every track is a declared fixed length,
+no measurement reaches a track at all and the gate is protecting nothing.
+`AllTrackSizesAreFixed` relaxes that half; the baseline half stays, since a shared
+baseline shifts items within a row no matter how the tracks are sized.
+
+### The scoreboard goes down, and it is worth reading rather than summing
+
+**5 140 reftests, before and after on the same build: 2 494 → 2 490 passing, +0
+and −4.** Ten tests in 5 140 move at all — two up, eight down — and every one of
+the eight is the same `inline-grid` + fixed `grid-auto-columns` shape.
+
+The four that flip were passing **because the test and its reference both
+collapsed**. Rendered side by side on both builds, before is four thin black lines
+on a white page, on the test side and the reference side alike — an identical
+blank, scored 100.0%. After, both render 92px boxes, and the boxes disagree. The
+disagreement was always there; nothing was drawing it.
+
+So the honest summary of this change is that it makes the renders substantially
+more correct and the *scoreboard* four worse, and the two facts are the same fact.
+The residual is now filed as its own gap: a subgrid resolves neither
+`repeat(auto-fill, <line-names>)` nor the name-plus-index lines (`grid-column:
+y 5`) the tests place items with. Widening the item gate further was tried and
+reverted — it fixes the isolated placement (a probe goes 10/12 → 12/12) while
+leaving all four tests red and pushing two of them further down.
+
+The gap entry that predicted this asked for one thing: that
+`css/css-grid/grid-lanes` not regress, because so many of its passes are grids
+agreeing with their reference on a shared collapse. **869 tests, 195 → 195, +0 /
+−0.**
+
 ## Next lead: a flex item's main size ignores its aspect ratio
 
 Diagnosed, not fixed, and measured against Chromium on 2026-08-20. In a **row**

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -1093,6 +1093,68 @@ the test that exposed it.
   its area (a fix that applied the ratio unconditionally would pass the first and fail the
   second), the stated-width and `min-width` guards, and the `box-sizing` case.
 
+### A grid's intrinsic inline size counted only its explicit tracks
+
+- **Tests:** `css-grid/grid-lanes/subgrid/…/track-sizing/column-subgrid-auto-fill-008`
+  ([#1723](https://github.com/Broiler-Platform/Broiler/issues/1723).8) goes **0.2% → 16.8%**
+  against its own reference, and `column-subgrid-orthogonal-writing-mode-004` 95.0% → 95.5%.
+  Neither passes; see the cost below, which is the more important half of this entry.
+- **Owner:** `Broiler.Layout` (`Engine/CssBoxGrid.cs`). Main repo, no patch.
+- **Root cause.** The shrink-to-fit inline size of a grid container summed only the tracks
+  listed in `grid-template-columns`. Implicit columns — from auto-placement past the
+  template, or from a `grid-column` reaching past it — contributed nothing, and
+  `grid-auto-columns` was never consulted on that path at all; with no template the method
+  bailed outright and the caller fell back to measuring inline *content*, which for a grid
+  of empty divs is 0. So a grid built entirely from implicit columns painted its border and
+  nothing else.
+- **The definite-width pass was already correct, and the intrinsic path duplicated none of
+  it.** Rather than write the column count a second way, `TryApplyGridTrackLayout`'s item
+  collection and auto-placement were extracted to `TryCollectGridPlacements` and
+  `TryPlaceGridItems`, and the intrinsic path runs the same two — so the count it sizes from
+  is the count the real pass will resolve, by construction. Tracks outside the template are
+  sized from `grid-auto-columns`, and gaps are charged across the full column count.
+- **`grid-auto-columns` bounds it.** It defaults to `auto`, whose size is its items' and so
+  the real track pass' job, so a grid that does not declare a definite `grid-auto-columns`
+  returns exactly what it returned before and never reaches the placement replay.
+- **A second bug fell out of it, and is fixed here too.** With the container finally 92px
+  wide, a layout assertion showed the child ignoring `grid-column: 3 / span 4` and stretching
+  across all six tracks. The implicit-only pass declines for a nested grid/flex/table item
+  because sizing an *auto* row from one measurement of a nested container is untrustworthy —
+  but that premise fails when every track is a declared fixed length, since then no
+  measurement reaches a track at all. `AllTrackSizesAreFixed` relaxes exactly that half of
+  the gate; the baseline half stays unconditional.
+- **The cost: 8 reftests moved down, 4 of them out of passing, and every one is a false pass
+  ending.** `css-grid/subgrid/repeat-auto-fill-002` and `-004` (100.0% → 87.9%), `-003`
+  (99.2% → 74.3%) and `orthogonal-writing-mode-005` (99.7% → 98.4%) were passing because the
+  test **and its reference** both collapsed to a 2px border on a blank page and matched each
+  other. Rendering both at their true 92px is what exposes the disagreement, which is now
+  filed as
+  [a subgrid does not resolve `repeat(auto-fill, <line-names>)`](wpt-rendering-gaps-open.md#a-subgrid-does-not-resolve-repeatauto-fill-line-names).
+  This was checked by rendering test and reference side by side on both builds rather than
+  inferred: before, four thin black lines; after, four correctly-sized boxes whose contents
+  differ.
+- **Sweep: 5 140 reftests over `css-grid`, `css-flexbox`, `css-sizing`, `css-tables`,
+  `css-display`, `css-inline`, `css-writing-modes` and `css-position`, before and after on
+  the same build — 2 494 → 2 490 passing, +0 and −4.** Exactly **10 tests in 5 140 move at
+  all**, and all 8 of the losers are the one shape this fix widens: an `inline-grid` with a
+  fixed `grid-auto-columns`. `Broiler.Layout.Tests`, `Broiler.Wpt.Tests` and the
+  grid/sizing slice of `Broiler.Cli.Tests` are byte-identical before and after.
+- **The gap's own exit gate is met.** It asked that the `css/css-grid/grid-lanes` subset not
+  regress, on the stated grounds that many of its passes are grids agreeing with their
+  reference *because both sides collapse*: 869 tests, **195 → 195 passing, +0 / −0**. The
+  collapse-pairs that did break are all in the plain-subgrid twins the same entry named.
+- **What was tried and rejected.** Widening the item gate so a nested grid is always "simple"
+  does fix the placement in isolation (a four-way probe goes 10/12 → 12/12), but leaves all
+  four tests failing and drives two of them *further* down (87.9% → 83.9%), because the
+  residual is the unimplemented subgrid auto-fill rather than the gate. Reverted.
+- **Tests:** `Broiler.Cli.Tests/GridImplicitColumnIntrinsicWidthTests.cs` — the definite
+  `grid-column` past the template, the templateless auto-placed item, implicit columns
+  extending rather than replacing a template, gaps charged between implicit columns, and the
+  guard that an intrinsic `grid-auto-columns` leaves the old answer alone.
+  `Broiler.Cli.Tests/GridFixedTrackItemPlacementTests.cs` — a plain block, a nested grid and
+  a nested subgrid child all landing in the columns they asked for, plus the auto-row case
+  that must still be gated away.
+
 ---
 
 ## Paint and the renderer

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -251,43 +251,33 @@ golden suite never looks at a passing test's own reference.
   byte-compatibility on a dropped declaration is not the same as implementing
   subgrid.
 
-### A grid's intrinsic inline size counts only its explicit tracks
+### A subgrid does not resolve `repeat(auto-fill, <line-names>)`
 
-- **Tests:** `css-grid/grid-lanes/subgrid/…/track-sizing/column-subgrid-auto-fill-008`
-  ([#1670](https://github.com/Broiler-Platform/Broiler/issues/1670).17, **0.2%** against its
-  own reference — the worst real render in that run), and the plain-subgrid twins
-  `css-grid/subgrid/repeat-auto-fill-001` and `-008`.
-- **Owner:** `Broiler.Layout` (`Engine/CssBoxGrid.cs`, `TryComputeGridIntrinsicContentWidth`).
-  Main repo.
-- **Root cause, and it is on the *reference* side.** The shrink-to-fit inline size of a grid
-  container sums only the tracks listed in `grid-template-columns`. Implicit columns — from
-  auto-placement past the template, or from a `grid-column` reaching past it — contribute
-  nothing, and `grid-auto-columns` is never consulted on that path at all. With no template
-  the method bails outright and the caller falls back to measuring inline *content*, which
-  for a grid of empty divs is 0. The definite-width pass is correct and already does all of
-  this (`colCount = Math.Max(maxColEnd, explicitColStart + colSpecs.Count)`,
-  `ParseSingleImplicitSpec(GridAutoColumns, em)`); the intrinsic path duplicates none of it.
-- **Measured by probe.** `display: inline-grid; grid-auto-columns: 15px` with one
-  auto-placed item paints nothing and reports content width 0 where 15px is required;
-  `grid-column: 3 / span 4` gives 0 where 90px is; the same grid at `width: 300px` places
-  the item at x 30..89, so only intrinsic sizing is wrong. The `-008` reference is 20 boxes
-  that should each be 92px wide and come out 2px — border only.
-- **The four edits are known** and are all inside that one method: drop the
-  `specs.Count == 0` half of the early-out; derive the column count from the same placement
-  the real pass runs; size a track beyond the template from `grid-auto-columns`, returning
-  false the moment that spec is intrinsic so today's content-based fallback is preserved for
-  the common `auto` case; and charge gaps for the full column count. That last guard is what
-  bounds the blast radius — only grids declaring a fixed-length `grid-auto-columns` change.
-- **It will not make `-008` pass**, and the entry should not pretend otherwise: the test and
-  its reference remain structurally different documents (see the `grid-lanes` entry above).
-  What it buys is that the reference stops being a lie, and that a real class of
-  shrink-to-fit grids — `inline-grid`, floats, `fit-content`, nested grid items — stops
-  collapsing to zero. **64 files under `tests/wpt/checkout/css` combine `grid-auto-columns`
-  with an intrinsically-sized container.**
-- **Exit gate:** the probes above report the required widths, and the full
-  `css/css-grid/grid-lanes` subset (850 tests, 193 passing) does not regress — a large
-  share of those passes are grids that agree with their reference *because both sides
-  collapse*.
+- **Tests:** `css-grid/subgrid/repeat-auto-fill-001` … `-006` and
+  `orthogonal-writing-mode-005`, plus the `grid-lanes` twins under
+  `grid-subgridded-to-grid-lanes/track-sizing`. `-002` and `-004` sit at 87.9%
+  against their own reference, `-003` at 74.3%, `-001` at 66.7%.
+- **Owner:** `Broiler.Layout` (`Engine/CssBoxGrid.cs`, `ExpandAutoRepeatTrackList`
+  and `ParseGridLine`). Main repo.
+- **Newly visible, and that is the point.** These tests were *passing* until the
+  [intrinsic inline size fix](wpt-rendering-gaps-fixed.md#a-grids-intrinsic-inline-size-counted-only-its-explicit-tracks),
+  and they were passing because the test and its reference **both collapsed to a
+  2px border on a blank page** and therefore matched each other. Both sides now
+  render at their true 92px, and what is left is a real disagreement that was
+  always there. Do not read the flip as a regression; read it as the false pass
+  ending.
+- **Two things are missing, and the second is the harder one.**
+  `ExpandAutoRepeatTrackList` declines outright for any `repeat()` combined with
+  `subgrid`, so a subgridded template's auto-repeat produces no tracks and no line
+  names — CSS Grid 2 §7.2.3.1 counts those repetitions from the subgrid's *span in
+  its parent*, not from an available size. And the items are placed by
+  **name-plus-index** lines (`grid-column: y 5`, `grid-column: y -1`), which
+  `ParseSingleGridLine` does not parse at all: a named line falls back to `auto`.
+  Neither half is worth anything without the other.
+- **Exit gate:** `repeat-auto-fill-002` and `-004` reach 100% against
+  `repeat-auto-fill-001-ref`, and the `-008` pair in
+  `grid-subgridded-to-grid-lanes/track-sizing` — currently 16.8% — moves with them,
+  since it is the same two features over a `grid-lanes` parent.
 
 ### The flag can be a false negative
 

--- a/src/Broiler.Cli.Tests/GridFixedTrackItemPlacementTests.cs
+++ b/src/Broiler.Cli.Tests/GridFixedTrackItemPlacementTests.cs
@@ -1,0 +1,98 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// The implicit-only track pass (a <c>none</c> template carried entirely by
+/// <c>grid-auto-columns</c>/<c>grid-auto-rows</c>) declines for an item whose used
+/// block size it cannot trust from one measurement — a nested flex/grid/table
+/// container, a replaced or form-control item, a scroll container — because sizing
+/// an <em>auto</em> row from that measurement collapses or mis-stretches the item.
+/// Declining costs the item's placement too: the fallback approximation ignores
+/// <c>grid-column</c> and stretches the child across the container.
+///
+/// The premise of that gate is the auto row. When every track the grid can produce
+/// is a definite fixed length, no item measurement reaches a track at all, so no
+/// item shape can mis-size one — and the pass must run, so the child lands in the
+/// columns it asked for. The last test holds the other side of the line: with
+/// <c>grid-auto-rows</c> left at <c>auto</c> the row really is content-sized, and
+/// the gate still fires.
+/// </summary>
+public sealed class GridFixedTrackItemPlacementTests
+{
+    private static Dictionary<string, Dictionary<string, double>> Measure(string html)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///grid-fixed-track-placement.html");
+
+        return bridge.EvaluateCheckLayoutAssertions()
+            .GroupBy(a => a.Element)
+            .ToDictionary(g => g.Key, g => g.ToDictionary(a => a.Property, a => a.Actual));
+    }
+
+    private static double Value(string id, string property,
+        Dictionary<string, Dictionary<string, double>> by)
+        => by.TryGetValue(id, out var m) && m.TryGetValue(property, out double v) ? v : double.NaN;
+
+    // Six 15px implicit columns inside a 1px border: the child at `grid-column:
+    // 3 / span 4` covers columns 3..6, so it starts at 1 + 2*15 and is 4*15 wide.
+    private const string Head =
+        "<!DOCTYPE html><html><head><style>"
+        + "html,body{margin:0;padding:0;font:10px/1 monospace}"
+        + ".grid{display:inline-grid;grid-auto-columns:15px;grid-auto-rows:8px;border:1px solid}"
+        + ".item{grid-column:3 / span 4;background:grey}"
+        + "</style></head><body>";
+
+    private const string Tail = "</div></body></html>";
+
+    private static void AssertPlacedInColumnsThreeToSix(string childStyle)
+    {
+        var by = Measure(Head
+            + "<div id=\"g\" class=\"grid\" data-expected-width=\"92\">"
+            + $"<div id=\"c\" class=\"item\" style=\"{childStyle}\""
+            + " data-offset-x=\"31\" data-expected-width=\"60\"></div>"
+            + Tail);
+
+        Assert.Equal(92, Value("div#g", "width", by), 1);
+        Assert.Equal(31, Value("div#c", "offset-x", by), 1);
+        Assert.Equal(60, Value("div#c", "width", by), 1);
+    }
+
+    [Fact]
+    public void APlainBlockChild_LandsInTheColumnsItAskedFor() =>
+        AssertPlacedInColumnsThreeToSix("");
+
+    [Fact]
+    public void ANestedGridChild_LandsInTheColumnsItAskedFor() =>
+        AssertPlacedInColumnsThreeToSix("display:grid");
+
+    [Fact]
+    public void ANestedSubgridChild_LandsInTheColumnsItAskedFor() =>
+        AssertPlacedInColumnsThreeToSix("display:grid;grid-template-columns:subgrid");
+
+    [Fact]
+    public void AnAutoRow_StillGatesTheNestedGridChildAway()
+    {
+        // No `grid-auto-rows`: the parent's rows are content-sized from the nested
+        // grid's measured height, which is exactly what the gate exists to distrust.
+        // The container still takes its width from the implicit columns, but the
+        // child is laid out by the approximation and spans the whole content box.
+        // Placing it correctly needs the row axis to stop depending on a single
+        // measurement, not a wider hole in this gate.
+        var by = Measure(
+            "<!DOCTYPE html><html><head><style>"
+            + "html,body{margin:0;padding:0;font:10px/1 monospace}"
+            + ".grid{display:inline-grid;grid-auto-columns:15px;border:1px solid}"
+            + "</style></head><body>"
+            + "<div id=\"g\" class=\"grid\" data-expected-width=\"92\">"
+            + "<div id=\"c\" style=\"display:grid;grid-column:3 / span 4;"
+            + "grid-auto-rows:8px;background:grey\" data-expected-width=\"90\"></div>"
+            + "</div></body></html>");
+
+        Assert.Equal(92, Value("div#g", "width", by), 1);
+        Assert.Equal(90, Value("div#c", "width", by), 1);
+    }
+}

--- a/src/Broiler.Cli.Tests/GridImplicitColumnIntrinsicWidthTests.cs
+++ b/src/Broiler.Cli.Tests/GridImplicitColumnIntrinsicWidthTests.cs
@@ -1,0 +1,125 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// CSS Grid §5.1 / §7.5: the shrink-to-fit inline size of a grid container is the
+/// sum of its column tracks — and the implicit columns auto-placement or a definite
+/// <c>grid-column</c> generates are tracks like any other, sized by
+/// <c>grid-auto-columns</c>. Broiler summed only the tracks named in
+/// <c>grid-template-columns</c>, so a grid whose columns all come from
+/// <c>grid-auto-columns</c> reported width 0 and painted nothing but its border —
+/// the shape every grid in WPT
+/// css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/track-sizing is built
+/// from (<c>display: inline grid; grid-auto-columns: 15px</c> around a child at
+/// <c>grid-column: 3 / span 4</c>), and the same collapse for any float,
+/// <c>inline-grid</c>, <c>fit-content</c> or nested grid item on that path.
+///
+/// The bound is <c>grid-auto-columns</c> itself: it defaults to <c>auto</c>, whose
+/// size is its items' — the real track pass' job — so only a grid declaring a
+/// definite <c>grid-auto-columns</c> takes its intrinsic width from implicit tracks.
+/// The last test here holds that line.
+/// </summary>
+public sealed class GridImplicitColumnIntrinsicWidthTests
+{
+    private static Dictionary<string, Dictionary<string, double>> Measure(string html)
+    {
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, html, "file:///grid-implicit-columns.html");
+
+        return bridge.EvaluateCheckLayoutAssertions()
+            .GroupBy(a => a.Element)
+            .ToDictionary(g => g.Key, g => g.ToDictionary(a => a.Property, a => a.Actual));
+    }
+
+    private static double Value(string id, string property,
+        Dictionary<string, Dictionary<string, double>> by)
+        => by.TryGetValue(id, out var m) && m.TryGetValue(property, out double v) ? v : double.NaN;
+
+    private const string Head =
+        "<!DOCTYPE html><html><head><style>"
+        + "html,body{margin:0;padding:0;font:10px/1 monospace}"
+        + ".grid{display:inline-grid;grid-auto-columns:15px;border:1px solid}"
+        + ".item{background:grey;height:8px}"
+        + "</style></head><body>";
+
+    [Fact]
+    public void DefiniteGridColumn_PastTheTemplate_SizesTheContainerFromGridAutoColumns()
+    {
+        // `grid-column: 3 / span 4` occupies columns 3..6, so the grid is six
+        // 15px implicit tracks wide: 90px of tracks inside a 1px border.
+        var by = Measure(Head
+            + "<div id=\"g\" class=\"grid\" data-expected-width=\"92\">"
+            + "<div id=\"a\" class=\"item\" style=\"grid-column:3 / span 4\""
+            + " data-offset-x=\"31\" data-expected-width=\"60\"></div>"
+            + "</div></body></html>");
+
+        Assert.Equal(92, Value("div#g", "width", by), 1);
+        Assert.Equal(31, Value("div#a", "offset-x", by), 1);
+        Assert.Equal(60, Value("div#a", "width", by), 1);
+    }
+
+    [Fact]
+    public void AutoPlacedItem_InATemplatelessGrid_SizesTheContainerFromGridAutoColumns()
+    {
+        // No template at all: the single auto-placed item generates the one
+        // implicit column, so the grid is 15px of track inside its border.
+        var by = Measure(Head
+            + "<div id=\"g\" class=\"grid\" data-expected-width=\"17\">"
+            + "<div id=\"a\" class=\"item\" data-offset-x=\"1\" data-expected-width=\"15\"></div>"
+            + "</div></body></html>");
+
+        Assert.Equal(17, Value("div#g", "width", by), 1);
+        Assert.Equal(15, Value("div#a", "width", by), 1);
+    }
+
+    [Fact]
+    public void ImplicitColumns_ExtendTheTemplate_RatherThanReplacingIt()
+    {
+        // Two 20px explicit tracks, then two 15px implicit ones for the item at
+        // column 4: 70px of tracks, and the item starts after 20+20+15.
+        var by = Measure(Head
+            + "<div id=\"g\" class=\"grid\" style=\"grid-template-columns:20px 20px\""
+            + " data-expected-width=\"72\">"
+            + "<div id=\"a\" class=\"item\" style=\"grid-column:4\""
+            + " data-offset-x=\"56\" data-expected-width=\"15\"></div>"
+            + "</div></body></html>");
+
+        Assert.Equal(72, Value("div#g", "width", by), 1);
+        Assert.Equal(56, Value("div#a", "offset-x", by), 1);
+    }
+
+    [Fact]
+    public void ColumnGap_IsChargedBetweenTheImplicitColumnsToo()
+    {
+        // Three implicit tracks carry two gaps: 3×15 + 2×10 = 65, plus the border.
+        var by = Measure(Head
+            + "<div id=\"g\" class=\"grid\" style=\"column-gap:10px\" data-expected-width=\"67\">"
+            + "<div id=\"a\" class=\"item\" style=\"grid-column:1 / span 3\""
+            + " data-expected-width=\"65\"></div>"
+            + "</div></body></html>");
+
+        Assert.Equal(67, Value("div#g", "width", by), 1);
+    }
+
+    [Fact]
+    public void AnIntrinsicGridAutoColumns_LeavesTheIntrinsicWidthAlone()
+    {
+        // `grid-auto-columns` is left at its initial `auto`, whose size comes from
+        // the items — which this declaration-only pass cannot resolve. It must not
+        // guess: the grid keeps the width it had before implicit columns were
+        // counted at all (the explicit template, 20+20, inside its border), and
+        // widening it is the real track pass' job, not this one's.
+        var by = Measure(Head
+            + "<div id=\"g\" class=\"grid\""
+            + " style=\"grid-template-columns:20px 20px;grid-auto-columns:auto\""
+            + " data-expected-width=\"42\">"
+            + "<div id=\"a\" class=\"item\" style=\"grid-column:4\"></div>"
+            + "</div></body></html>");
+
+        Assert.Equal(42, Value("div#g", "width", by), 1);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two related bugs in CSS Grid layout:

1. **Intrinsic width calculation** now accounts for implicit columns generated by auto-placement or definite `grid-column` values, sized from `grid-auto-columns`. Previously, only explicit template tracks were counted, causing grids built entirely from implicit columns to collapse to their border width.

2. **Item placement** in the implicit-only track pass now runs correctly when all tracks are definite fixed lengths, allowing items to land in their requested columns instead of being stretched across the container by the fallback approximation.

## Key Changes

- **Refactored grid item collection and placement** into `TryCollectGridPlacements` and `TryPlaceGridItems` methods, extracted from `TryApplyGridTrackLayout`. This allows the intrinsic width calculation path to reuse the same logic as the definite-width pass, ensuring both paths agree on column counts.

- **Enhanced intrinsic width calculation** (`TryComputeGridIntrinsicContentWidth`):
  - Now handles implicit-only grids (no `grid-template-columns`)
  - Counts implicit columns via `TryCountGridIntrinsicColumns`, which replays item collection and placement
  - Sizes implicit tracks from `grid-auto-columns` and charges gaps across all columns
  - Preserves backward compatibility: grids without a definite `grid-auto-columns` return their previous answer

- **Added `AllTrackSizesAreFixed` check** to relax the implicit-only pass gate. When every track is a declared fixed length, no item measurement reaches a track, so the gate protecting against mis-sized auto tracks has nothing to protect. The baseline alignment gate remains unconditional.

- **Added comprehensive test coverage** in `GridImplicitColumnIntrinsicWidthTests` and `GridFixedTrackItemPlacementTests` validating the fixes across various grid configurations.

## Implementation Details

- `grid-auto-columns` defaults to `auto`, whose size depends on items and requires the real track pass. This bounds the change: only grids declaring a definite `grid-auto-columns` see different behavior.
- The refactored methods maintain the same validation logic (max grid line checks, leading implicit track normalization, auto-placement) ensuring consistency between paths.
- Documentation updated in `docs/wpt-reftests.md` and `docs/wpt-rendering-gaps-fixed.md` with detailed analysis of the fixes and their impact on the reftest scoreboard.

## Reftest Impact

This fix exposes a pre-existing subgrid limitation: `repeat(auto-fill, <line-names>)` is not resolved. Four tests that were passing due to both test and reference collapsing to 2px borders now render correctly at 92px, revealing the underlying disagreement. This is filed as a separate gap in the rendering issues.

https://claude.ai/code/session_01QX9FqQL2YYMLSrCbYK3WcY