### PR TITLE
Implement flow-relative margins and padding for @page rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,27 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `Broiler.Wpt` — a `@page` rule's flow-relative margins and padding are read.
+  CSS Paged Media 3 §3.2 lets the page box carry `margin-inline-start` and its
+  seven siblings, and neither half of the runner's `@page` model understood them:
+  `WptPageBox` switched on the physical margin longhands alone, so a
+  flow-relative one left the margin at zero, and a flow-relative padding reached
+  the decoration probe — a bare `<div>` whose writing mode is the initial one and
+  whose containing block is not the page, so it resolved to the wrong side and
+  took its percentage against the wrong box. `WptPageAxes` now resolves the
+  page's writing mode — its own declaration where it makes one, the root
+  element's otherwise, which is exactly what `css-page/page-box-008-print` and
+  `-009-print` disagree about on purpose — and maps each flow-relative side to a
+  physical one, with percentages taken against the page-box dimension that side
+  runs along. The two tests go 4.0% → 6.7% and 67.0% → 79.8% against their own
+  references, `css/css-page` 87.86% → 87.93% average with 140 of 223 passing
+  either way, and `css/css-break` does not move: nothing regressed, and the
+  golden-image score for every affected test is unchanged. What still separates
+  them from their references is the sheet, not the ring — an unpaginated `-print`
+  render keeps the runner's viewport instead of the page the document declares;
+  see
+  [`docs/wpt-rendering-gaps-open.md`](docs/wpt-rendering-gaps-open.md#a--print-document-renders-on-the-viewport-not-on-the-page-it-declares).
+
 - A grid container is as wide as the columns it actually has. The shrink-to-fit inline size of
   a grid summed only the tracks named in `grid-template-columns`: implicit columns contributed
   nothing, `grid-auto-columns` was never consulted, and a grid with no template at all fell

--- a/docs/wpt-rendering-gaps-fixed.md
+++ b/docs/wpt-rendering-gaps-fixed.md
@@ -262,6 +262,57 @@ git -C <Submodule> merge-base --is-ancestor <sha> HEAD
   preserved rather than cleared. 204 `manual/`-segment entries are still in that
   file for this reason. They are historical, not current.
 
+### The page box dropped its flow-relative margins and padding
+
+- **Tests:** `css-page/page-box-008-print` (`rel=match` 4.0% → **6.7%**) and
+  `page-box-009-print` (67.0% → **79.8%**), measured 2026-08-20 against the
+  [#1726 reftest run](https://github.com/Broiler-Platform/Broiler/issues/1726),
+  where the first was the run's 16th-biggest problem.
+- **Owner:** the WPT runner (`src/Broiler.Wpt/WptPageBox.cs`,
+  `WptPageDecoration.cs`, and the new `WptPageAxes.cs`). Main repo.
+- **The bug.** CSS Paged Media 3 §3.2 lets the page box carry the flow-relative
+  margin and padding properties, and neither half of the runner's `@page` model
+  understood them. `WptPageBox.Resolve` switched on the four *physical* margin
+  longhands only, so `margin-inline-start` and its siblings fell through the switch
+  and left the margin at zero. The padding reached the decoration probe, but that
+  probe is a bare `<div>`: its writing mode is the initial one, so
+  `padding-block-start` resolved to `padding-top` no matter what the page said, and
+  its containing block is the probe surface, so a percentage resolved against that
+  rather than against the page box.
+- **Where the writing mode comes from, and why it needs saying.** The two tests
+  disagree on purpose. `page-box-008-print` puts `writing-mode: vertical-rl` on the
+  root element and leaves the `@page` silent; `page-box-009-print` puts it on the
+  `@page` rule and leaves the root horizontal. Both expect the same 16/32/48/80
+  ring, so the page's own declaration wins where it makes one and the root
+  element's applies otherwise.
+- **And the percentage basis is per-axis, not the inline size.** Both references
+  spell the expected ring out as `border-width: 16px 32px 48px 80px` on a 400×800
+  page declared as 2%/8%/6%/20% — which only comes out that way if each percentage
+  is taken against the page-box dimension its *physical* side runs along. That is
+  the convention the physical margin longhands in `WptPageBox` already used; the
+  `margin` shorthand beside them still resolves all four against the width.
+- **What landed:** `WptPageAxes` resolves the page's writing mode and direction and
+  maps a flow-relative side to a physical one; `WptPageBox.Resolve` reads the four
+  flow-relative margin longhands through it; and `WptPageDecoration.Resolve` now
+  takes the declared page box and rewrites a flow-relative padding into the
+  physical longhand it means, **in the place it was written**, so the cascade
+  between the two spellings is unchanged.
+- **The wrong turn, and it cost a measurable regression.** The padding was first
+  resolved at probe-build time against the `WptPageBox` the renderer is handed —
+  which, on the unpaginated path, has had its `BoxSize` replaced by the runner's
+  viewport. Percentages then resolved against 1024×768 instead of the declared
+  400×800 and `page-box-009-print` fell from 81.4% to 64.4%. The basis has to be
+  the page box **as declared**, which is why `WptTestRunner` now resolves it once,
+  before the sheet is overridden, and passes it to both readers.
+- **Verified:** nine focused tests across `WptPageBoxTests` and
+  `PagePaintRenderTests` pin the mapping in both writing modes, `direction: rtl`,
+  the initial axes, the source-order cascade against the physical longhands, and
+  the page-box percentage basis. Suite-wide, `css/css-page` moved 87.86% → 87.93%
+  average with the passing count unchanged at 140/223, and `css/css-break` did not
+  move at all — no test regressed. The golden-image score for all three affected
+  tests is byte-identical before and after (98.4%, 98.4%, 98.9% against a locally
+  generated Chromium reference), so the change is free on that side.
+
 ---
 
 ## CSS engine

--- a/docs/wpt-rendering-gaps-open.md
+++ b/docs/wpt-rendering-gaps-open.md
@@ -250,6 +250,30 @@ golden suite never looks at a passing test's own reference.
   [won't fix](wpt-rendering-gaps-wont-fix.md#two-fall-through-the-99-gate). Chasing
   byte-compatibility on a dropped declaration is not the same as implementing
   subgrid.
+- **The reftest suite has since made that call urgent, and put a number on both
+  sides of it.** `grid-lanes` is no longer three subgrid stragglers: it is **500 of
+  the 2 998 failures** in the
+  [#1726 reftest run](https://github.com/Broiler-Platform/Broiler/issues/1726) —
+  one failure in six, the largest single cause in the suite, and twelve of that
+  run's top thirty. It has to be that large, because the suite's references
+  *implement* the feature by hand (`column-align-items-001-ref` builds the lanes
+  out of a `display: grid` of flex columns), so dropping the declaration fails them
+  by construction. Measured locally on 2026-08-20, `css-grid/grid-lanes/alignment`
+  is 9 passed / 114 failed out of 123.
+- **And implementing it would cost more than it wins, on the suite the project
+  scores itself by.** The checkout carries 870 `grid-lanes` tests with a
+  `rel=match` and 976 candidate documents overall; the golden-image manifest lists
+  **193** `grid-lanes` failures, so on the order of 780 currently do *not* fail it
+  — they match Chromium's pixels precisely because Chromium drops the declaration
+  too and both engines render the identical fallback. Shipping `grid-lanes` trades
+  up to 500 reftest wins for most of those. (The manifest records failures only, so
+  that 780 includes any skips; treat it as an upper bound on what is at risk, not
+  an exact count.)
+- **Do not flip this as a side effect of anything else.** The rejection is stated
+  in three places — `Broiler.Layout/Engine/CssUtils.cs`,
+  `Broiler.CSS.Dom/CssStyleEngine.Values.cs`, and this entry — and the two suites
+  genuinely want opposite behaviour. What is needed is a decision about which suite
+  governs an unshipped draft feature, not a patch.
 
 ### A subgrid does not resolve `repeat(auto-fill, <line-names>)`
 
@@ -908,6 +932,40 @@ Worth separating from the rest, because the test itself may be at fault:
   path. "page-margin" in the name means the page's margin, not a margin box.
 - **Exit gate:** the four `body-background-*-print` tests match, and a horizontal-writing-mode
   paged test does not move.
+
+### A `-print` document renders on the viewport, not on the page it declares
+
+- **Tests:** the whole `-print` corpus, but the two that isolate it are
+  `css-page/page-box-008-print` (`rel=match` **6.7%**) and `page-box-009-print`
+  (**79.8%**) — measured 2026-08-20, after
+  [the flow-relative page insets fix](wpt-rendering-gaps-fixed.md#the-page-box-dropped-its-flow-relative-margins-and-padding),
+  which resolved their margin and padding rings correctly and still left them here.
+- **Owner:** the WPT runner (`src/Broiler.Wpt/WptTestRunner.cs`). Main repo.
+- **Root cause.** The unpaginated path — the default for every `-print` reftest —
+  reads the `@page`'s *margins* from the rule but throws its `size` away, keeping
+  the runner's 1024×768 viewport as the sheet. Both tests declare `size: 400px
+  800px` and both references spell their expected geometry out in absolute pixels,
+  so the rings land at the right widths on a sheet of the wrong size and the
+  content inside them is laid out against the wrong page area.
+- **The obvious fix is measurably wrong, which is the point of this entry.**
+  Honouring the declared box for every `-print` document — rendering the flow into
+  the page area and compositing onto a sheet of the declared size — was tried on
+  2026-08-20 and **regressed** the suite: `css/css-page` 140 → 128 passed,
+  `css/css-break` 107 → 104. The reason is asymmetry, not the geometry. A reference
+  such as `page-box-008-print-ref` declares the same `size` but paints nothing on
+  the sheet, so it takes the undecorated path and keeps the viewport; resizing only
+  the side that carries a decoration resizes one half of the comparison. This is
+  the same trap the existing code comment warns about.
+- **So the exit is pagination, not a sheet size.** The sheet can only be the
+  declared page once *both* sides of a comparison are laid out against it, which
+  means the paged path — and that path is off by default because it currently
+  scores worse (`css/css-page` 140 → 125 passed with `BROILER_WPT_PAGED_PRINT=1`,
+  measured the same day). It shares a root cause with
+  [the physical-Y-axis pagination entry](#pagination-runs-along-the-physical-y-axis-only)
+  above: fix the block-axis abstraction there first, then re-measure the paged lever
+  before touching the sheet size here.
+- **Exit gate:** `page-box-008-print` and `-009-print` match, and the unpaginated
+  `-print` corpus does not lose a test.
 
 ## Transforms
 

--- a/docs/wpt-rendering-gaps-wont-fix.md
+++ b/docs/wpt-rendering-gaps-wont-fix.md
@@ -232,6 +232,49 @@ sides only the first block paints. **It cannot change what CI reports for this
 test in any case** — CI scores it unpaginated against Chromium's blank
 `vertical-rl` viewport capture.
 
+## The inverse case: a reftest reference no shipping engine matches
+
+Everything above is *golden fails, reftest passes*. The reftest suite produces the
+mirror image of it, and the
+[#1726 run](https://github.com/Broiler-Platform/Broiler/issues/1726) ranked one at
+the very top of its severity list, so it is worth writing down before someone
+spends a day on it.
+
+### `CSS2/box-display/root-box-003` — Chromium renders it blank too
+
+The test styles the root element `display: none; background: green` and its
+reference paints the canvas green through `body`; the title promises "a big green
+expanse". Broiler renders a blank white page and scores **0.0%**, which put it
+first in that run's thirty.
+
+Rendered in the Chromium that generates this project's references (2026-08-20,
+`file://`, 800×600): the **test comes out blank white** and the **reference comes
+out solid green**. Chromium fails this reftest against its own reference, and
+Broiler renders exactly what Chromium renders.
+
+So this 0.0% is not an engine gap in the sense the rest of the *not fixed* list
+uses. Making it pass means propagating a `display: none` root element's background
+to the canvas — behaviour the reference browser does not implement — and the
+golden-image suite scores against that browser's screenshot, so closing it here
+would open it there. It needs the same maintainer's call as
+[`grid-lanes`](wpt-rendering-gaps-open.md#grid-lanes-is-an-unshipped-draft-feature):
+which suite governs, not a patch.
+
+**The general lesson, and it applies to every 0.0% in a reftest report.** The
+reftest suite removes Chromium from the *comparison*, which is what makes it
+independent — but it does not make the test's own reference authoritative. Before
+treating a low reftest score as a gap, open the test **and** the file its
+`<link rel="match">` names in the pinned Chromium (`tests/wpt/node_modules`, launched
+with `executablePath: '/opt/pw-browsers/chromium'` — the bundled build the pinned
+Playwright wants is not the one installed) and screenshot both at the runner's
+viewport. If the reference browser does not reproduce its own reference, the test is
+not measuring Broiler.
+
+`css-page/root-element-display-none-print` is the neighbouring case that is
+**not** this: it matches a deliberately blank reference, and Broiler passes it. A
+`display: none` root generating no page is settled; a `display: none` root
+propagating its background to the canvas is not.
+
 ## Two fall through the 99% gate
 
 `--verify-reference` only sets `suspectReference` when Broiler *reproduces* the

--- a/src/Broiler.Wpt.Tests/PagePaintRenderTests.cs
+++ b/src/Broiler.Wpt.Tests/PagePaintRenderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Drawing;
 using System.IO;
 using Broiler.HTML.Image;
 using Xunit;
@@ -139,12 +140,12 @@ public sealed class PagePaintRenderTests : IDisposable
     [InlineData("@page { padding: 1px; }", true)]
     [InlineData("@page :first { background: yellow; }", false)]
     public void A_Page_Is_Decorated_Only_When_It_Paints(string css, bool decorated) =>
-        Assert.Equal(decorated, WptPageDecoration.Resolve("<style>" + css + "</style>") is not null);
+        Assert.Equal(decorated, Decoration("<style>" + css + "</style>") is not null);
 
     [Fact]
     public void Later_Declarations_Win_And_Land_On_The_Box_They_Belong_To()
     {
-        var decoration = WptPageDecoration.Resolve(
+        var decoration = Decoration(
             "<style>@page { background: red; border: 1px solid; }</style>"
             + "<style>@page { background: green; }</style>");
 
@@ -159,11 +160,62 @@ public sealed class PagePaintRenderTests : IDisposable
     [Fact]
     public void A_Border_Radius_Alone_Insets_Nothing()
     {
-        var decoration = WptPageDecoration.Resolve("<style>@page { border-radius: 4px; }</style>");
+        var decoration = Decoration("<style>@page { border-radius: 4px; }</style>");
 
         Assert.NotNull(decoration);
         Assert.False(decoration!.HasInsets);
     }
+
+    // The probe the decoration renders on is horizontal-tb and its containing block is not the
+    // page, so neither the axis mapping nor the percentage basis of a flow-relative padding can be
+    // left to it. page-box-008-print and -009-print both expect a 16/32/48/80 ring on a 400x800
+    // page from 2/8/6/20 %, and state the writing mode in different places.
+    [Theory]
+    [InlineData(":root { writing-mode: vertical-rl; }", "")]
+    [InlineData("", "writing-mode: vertical-rl;")]
+    public void Logical_Padding_Becomes_The_Physical_Longhand_It_Means(string rootCss, string pageCss)
+    {
+        var decoration = Decoration(
+            "<style>" + rootCss + "@page { " + pageCss + "size: 400px 800px;"
+            + "padding-inline-start: 2%; padding-block-start: 8%;"
+            + "padding-inline-end: 6%; padding-block-end: 20%; }</style>");
+
+        Assert.NotNull(decoration);
+        Assert.Equal(
+            "padding-top:16px;padding-right:32px;padding-bottom:48px;padding-left:80px;",
+            decoration!.BoxCss);
+        Assert.True(decoration.HasInsets);
+    }
+
+    // A percentage is taken against the page box, not the box the page's margins leave: the ring
+    // above is 2 % of 800 even though the border box is only 736 tall.
+    [Fact]
+    public void Logical_Padding_Percentages_Resolve_Against_The_Whole_Page_Box()
+    {
+        var decoration = Decoration(
+            "<style>@page { size: 400px 800px; margin: 100px; padding-block-start: 10%; }</style>");
+
+        Assert.Equal("padding-top:80px;", decoration!.BoxCss);
+    }
+
+    // Physical and flow-relative padding are both longhands, so the later one wins wherever they
+    // name the same side.
+    [Fact]
+    public void Logical_Padding_Cascades_With_The_Physical_Longhand()
+    {
+        var decoration = Decoration(
+            "<style>@page { padding-top: 1px; padding-block-start: 2px; }</style>");
+
+        Assert.Equal("padding-top:2px;", decoration!.BoxCss);
+    }
+
+    /// <summary>
+    /// The decoration a document declares, resolved against its own page box the way
+    /// <c>WptTestRunner</c> resolves it — the box is what a flow-relative padding's percentage
+    /// needs.
+    /// </summary>
+    private static WptPageDecoration? Decoration(string html) =>
+        WptPageDecoration.Resolve(html, WptPageBox.Resolve(html, new SizeF(800, 600)));
 
     private static void AssertColor(BBitmap bitmap, int x, int y, int r, int g, int b)
     {

--- a/src/Broiler.Wpt.Tests/WptPageBoxTests.cs
+++ b/src/Broiler.Wpt.Tests/WptPageBoxTests.cs
@@ -198,6 +198,90 @@ public sealed class WptPageBoxTests
         Assert.Equal(new SizeF(320, 256), box.AreaSize);
     }
 
+    // ---- flow-relative margins ----
+
+    // css-page-3 §3.2 lets the page box carry the flow-relative margins, and the two tests that
+    // state them disagree on purpose about where the writing mode comes from: page-box-008-print
+    // puts `vertical-rl` on the root element, page-box-009-print puts it on the `@page` rule. Both
+    // expect the same 16/32/48/80 ring on a 400x800 page from 2/8/6/20 %, which is each percentage
+    // taken against the dimension its physical side runs along.
+    [Theory]
+    [InlineData(":root { writing-mode: vertical-rl; }", "")]
+    [InlineData("", "writing-mode: vertical-rl;")]
+    public void Logical_Margins_Resolve_Through_The_Pages_Writing_Mode(string rootCss, string pageCss)
+    {
+        var html = "<!DOCTYPE html><html><head><style>" + rootCss + "@page { " + pageCss
+            + "size: 400px 800px;"
+            + "margin-inline-start: 2%; margin-block-start: 8%;"
+            + "margin-inline-end: 6%; margin-block-end: 20%; }"
+            + "</style></head><body></body></html>";
+
+        var box = WptPageBox.Resolve(html, DefaultBox);
+
+        Assert.Equal(16, box.MarginTop, 3);      // inline-start, 2 % of the 800px height
+        Assert.Equal(32, box.MarginRight, 3);    // block-start,  8 % of the 400px width
+        Assert.Equal(48, box.MarginBottom, 3);   // inline-end,   6 % of the height
+        Assert.Equal(80, box.MarginLeft, 3);     // block-end,   20 % of the width
+    }
+
+    // The initial axes map block to vertical and inline to horizontal, so a document that states no
+    // writing mode reads the flow-relative names as the physical ones they coincide with.
+    [Fact]
+    public void Logical_Margins_On_The_Initial_Axes_Are_The_Physical_Ones()
+    {
+        var box = WptPageBox.Resolve(
+            Page("margin-block-start: 1px; margin-block-end: 2px;"
+                + "margin-inline-start: 3px; margin-inline-end: 4px;"),
+            DefaultBox);
+
+        Assert.Equal(1, box.MarginTop, 3);
+        Assert.Equal(2, box.MarginBottom, 3);
+        Assert.Equal(3, box.MarginLeft, 3);
+        Assert.Equal(4, box.MarginRight, 3);
+    }
+
+    // `direction: rtl` reverses the inline axis and leaves the block axis alone.
+    [Fact]
+    public void Rtl_Swaps_The_Inline_Sides()
+    {
+        const string html = "<!DOCTYPE html><html><head><style>"
+            + "html { direction: rtl; }"
+            + "@page { margin-inline-start: 3px; margin-block-start: 1px; }"
+            + "</style></head><body></body></html>";
+
+        var box = WptPageBox.Resolve(html, DefaultBox);
+
+        Assert.Equal(3, box.MarginRight, 3);
+        Assert.Equal(1, box.MarginTop, 3);
+    }
+
+    // A writing mode further down the tree styles a box inside the page, not the page.
+    [Fact]
+    public void Only_The_Root_Elements_Writing_Mode_Turns_The_Page()
+    {
+        const string html = "<!DOCTYPE html><html><head><style>"
+            + "body { writing-mode: vertical-rl; }"
+            + "@page { margin-block-start: 7px; }"
+            + "</style></head><body></body></html>";
+
+        Assert.Equal(7, WptPageBox.Resolve(html, DefaultBox).MarginTop, 3);
+    }
+
+    // A flow-relative longhand is a longhand: it overrides the shorthand it follows, and is
+    // overridden by the physical longhand that follows it.
+    [Fact]
+    public void Logical_And_Physical_Margins_Cascade_In_Source_Order()
+    {
+        var box = WptPageBox.Resolve(
+            Page("margin: 10px; margin-block-start: 20px; margin-inline-start: 30px;"
+                + "margin-left: 40px;"),
+            DefaultBox);
+
+        Assert.Equal(20, box.MarginTop, 3);
+        Assert.Equal(40, box.MarginLeft, 3);
+        Assert.Equal(10, box.MarginRight, 3);
+    }
+
     [Theory]
     [InlineData("size: nonsense")]
     [InlineData("margin: nonsense")]

--- a/src/Broiler.Wpt/WptPageAxes.cs
+++ b/src/Broiler.Wpt/WptPageAxes.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using Broiler.CSS;
+
+namespace Broiler.Wpt;
+
+/// <summary>A physical side of the page box — what a logical <c>@page</c> inset resolves to.</summary>
+internal enum WptPageSide
+{
+    Top,
+    Right,
+    Bottom,
+    Left,
+}
+
+/// <summary>
+/// The axes the page box's logical properties resolve through: its <c>writing-mode</c> and inline
+/// direction.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CSS Paged Media 3 §3.2 lets the page box carry the flow-relative margin and padding properties,
+/// and they mean nothing without knowing which physical side each one names. Two tests state the two
+/// places the answer comes from, and they disagree on purpose: <c>page-box-008-print</c> puts
+/// <c>writing-mode: vertical-rl</c> on the root element and leaves the <c>@page</c> silent, while
+/// <c>page-box-009-print</c> puts it on the <c>@page</c> rule itself and leaves the root horizontal.
+/// Both expect the same 16/32/48/80 ring, so the page's own declaration wins where it makes one and
+/// the root element's applies otherwise.
+/// </para>
+/// <para>
+/// The root element's value is read by a scan of the same style sources
+/// <see cref="WptPageBox.EnumerateUnconditionalPageBlocks"/> reads, for the same reason: this runs
+/// before the document is built, to decide the surface it will be rendered on. Only a rule that
+/// selects the root element counts — <c>html</c>, <c>:root</c> or <c>*</c> — because a
+/// <c>writing-mode</c> further down the tree changes a box inside the page, not the page.
+/// </para>
+/// </remarks>
+/// <param name="WritingMode">The page box's used <c>writing-mode</c> keyword.</param>
+/// <param name="Rtl">Whether its inline direction runs right-to-left (<c>direction: rtl</c>).</param>
+internal readonly record struct WptPageAxes(string WritingMode, bool Rtl)
+{
+    /// <summary>The initial axes: <c>horizontal-tb</c> running left-to-right.</summary>
+    internal static WptPageAxes Initial => new("horizontal-tb", Rtl: false);
+
+    /// <summary>
+    /// Resolves the page box's axes for <paramref name="html"/> — the <c>@page</c>'s own
+    /// <c>writing-mode</c>/<c>direction</c> where it states them, the root element's otherwise.
+    /// </summary>
+    internal static WptPageAxes Resolve(string html)
+    {
+        var (rootMode, rootRtl) = RootElementAxes(html);
+        string? pageMode = null;
+        bool? pageRtl = null;
+
+        foreach (var (declarations, _) in WptPageBox.EnumerateUnconditionalPageBlocks(html))
+        {
+            foreach (var declaration in declarations.Declarations)
+            {
+                var value = declaration.Value.Text.Trim();
+                switch (declaration.Name.Trim().ToLowerInvariant())
+                {
+                    case "writing-mode":
+                        pageMode = value.ToLowerInvariant();
+                        break;
+                    case "direction":
+                        pageRtl = value.Equals("rtl", StringComparison.OrdinalIgnoreCase);
+                        break;
+                }
+            }
+        }
+
+        return new WptPageAxes(pageMode ?? rootMode, pageRtl ?? rootRtl);
+    }
+
+    /// <summary>
+    /// The <c>writing-mode</c> and <c>direction</c> the document's style sheets give the root
+    /// element, or the initial values when they give it none.
+    /// </summary>
+    private static (string Mode, bool Rtl) RootElementAxes(string html)
+    {
+        var initial = Initial;
+        string mode = initial.WritingMode;
+        bool rtl = initial.Rtl;
+
+        foreach (var source in WptPageBox.EnumerateStyleSources(html))
+        {
+            CssStyleSheet sheet;
+            try { sheet = new CssParser().ParseStyleSheet(source); }
+            catch { continue; }
+
+            foreach (var rule in sheet.Rules)
+            {
+                if (rule is not CssStyleRule styleRule || !SelectsRootElement(styleRule.Selectors))
+                    continue;
+
+                foreach (var declaration in styleRule.Declarations.Declarations)
+                {
+                    var value = declaration.Value.Text.Trim();
+                    switch (declaration.Name.Trim().ToLowerInvariant())
+                    {
+                        case "writing-mode":
+                            mode = value.ToLowerInvariant();
+                            break;
+                        case "direction":
+                            rtl = value.Equals("rtl", StringComparison.OrdinalIgnoreCase);
+                            break;
+                    }
+                }
+            }
+        }
+
+        return (mode, rtl);
+    }
+
+    /// <summary>
+    /// Whether any of <paramref name="selectors"/> names the root element on its own. A compound
+    /// such as <c>html.foo</c> or a descendant such as <c>html div</c> does not: the first may not
+    /// match, and the second styles something else.
+    /// </summary>
+    private static bool SelectsRootElement(CssSelectorList selectors)
+    {
+        foreach (var selector in selectors.Selectors)
+        {
+            var text = selector.Text.Trim();
+            if (text is "html" or ":root" or "*" || text.Equals("HTML", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>The physical side the block-start of these axes points at.</summary>
+    private WptPageSide BlockStart => WritingMode switch
+    {
+        "vertical-rl" or "sideways-rl" => WptPageSide.Right,
+        "vertical-lr" or "sideways-lr" => WptPageSide.Left,
+        _ => WptPageSide.Top,
+    };
+
+    /// <summary>The physical side the inline-start of these axes points at.</summary>
+    /// <remarks>
+    /// The inline axis is perpendicular to the block axis, so it runs vertically in a vertical
+    /// writing mode. It runs downwards in all of them but <c>sideways-lr</c>, which is the one that
+    /// rotates the other way; <c>direction: rtl</c> then reverses whichever way it runs.
+    /// </remarks>
+    private WptPageSide InlineStart => WritingMode switch
+    {
+        "vertical-rl" or "vertical-lr" or "sideways-rl" =>
+            Rtl ? WptPageSide.Bottom : WptPageSide.Top,
+        "sideways-lr" =>
+            Rtl ? WptPageSide.Top : WptPageSide.Bottom,
+        _ => Rtl ? WptPageSide.Right : WptPageSide.Left,
+    };
+
+    /// <summary>The physical side a flow-relative one names on these axes.</summary>
+    /// <param name="inline">Whether the side is on the inline axis rather than the block axis.</param>
+    /// <param name="start">Whether it is the start side of that axis rather than the end side.</param>
+    internal WptPageSide Side(bool inline, bool start)
+    {
+        var startSide = inline ? InlineStart : BlockStart;
+        return start ? startSide : Opposite(startSide);
+    }
+
+    private static WptPageSide Opposite(WptPageSide side) => side switch
+    {
+        WptPageSide.Top => WptPageSide.Bottom,
+        WptPageSide.Bottom => WptPageSide.Top,
+        WptPageSide.Left => WptPageSide.Right,
+        _ => WptPageSide.Left,
+    };
+
+    /// <summary>
+    /// The flow-relative longhands of <paramref name="property"/> — <c>margin</c> or
+    /// <c>padding</c> — keyed by their full property name, each mapped to the axis and end it names.
+    /// </summary>
+    internal static IEnumerable<(string Name, bool Inline, bool Start)> LogicalLonghands(string property)
+    {
+        yield return (property + "-block-start", false, true);
+        yield return (property + "-block-end", false, false);
+        yield return (property + "-inline-start", true, true);
+        yield return (property + "-inline-end", true, false);
+    }
+}

--- a/src/Broiler.Wpt/WptPageBox.cs
+++ b/src/Broiler.Wpt/WptPageBox.cs
@@ -46,6 +46,15 @@ internal readonly record struct WptPageBox(
         Math.Max(1, BoxSize.Width - MarginLeft - MarginRight),
         Math.Max(1, BoxSize.Height - MarginTop - MarginBottom));
 
+    /// <summary>This box with the margin on one physical <paramref name="side"/> replaced.</summary>
+    internal WptPageBox WithMargin(WptPageSide side, float margin) => side switch
+    {
+        WptPageSide.Top => this with { MarginTop = margin },
+        WptPageSide.Right => this with { MarginRight = margin },
+        WptPageSide.Bottom => this with { MarginBottom = margin },
+        _ => this with { MarginLeft = margin },
+    };
+
     /// <summary>
     /// Resolves the page box for <paramref name="html"/>, starting from a default box of
     /// <paramref name="defaultBoxSize"/> with no margins.
@@ -60,6 +69,7 @@ internal readonly record struct WptPageBox(
     {
         var box = new WptPageBox(defaultBoxSize, 0, 0, 0, 0);
         double? areaWidth = null, areaHeight = null;
+        var axes = WptPageAxes.Resolve(html);
 
         foreach (var (declarations, _) in EnumerateUnconditionalPageBlocks(html))
         {
@@ -68,7 +78,26 @@ internal readonly record struct WptPageBox(
             foreach (var declaration in declarations.Declarations)
             {
                 var value = declaration.Value.Text.Trim();
-                switch (declaration.Name.ToLowerInvariant())
+                var name = declaration.Name.ToLowerInvariant();
+
+                // The flow-relative margins name a physical side through the page's own axes, and
+                // then behave exactly like the physical longhand they resolved to — percentage
+                // included. `page-box-008-print` and `-009-print` state the same 16/32/48/80 ring
+                // from `margin-inline-start: 2%` and friends on a 400×800 page, which only comes out
+                // if each percentage is taken against the dimension its physical side runs along.
+                if (TryLogicalMargin(name, out bool inline, out bool start))
+                {
+                    var side = axes.Side(inline, start);
+                    float basis = side is WptPageSide.Top or WptPageSide.Bottom
+                        ? box.BoxSize.Height
+                        : box.BoxSize.Width;
+
+                    if (TryParseLength(value, basis, fontSize, out var logical))
+                        box = box.WithMargin(side, logical);
+                    continue;
+                }
+
+                switch (name)
                 {
                     // `width` and `height` size the page *area* — the box less its margins — the
                     // way they size any other box's content. margin-boxes/dimensions-011 states the
@@ -161,11 +190,31 @@ internal readonly record struct WptPageBox(
     }
 
     /// <summary>
+    /// Whether <paramref name="name"/> is one of the four flow-relative margin longhands, and which
+    /// axis and end it names. The <c>margin-block</c> and <c>margin-inline</c> shorthands are not
+    /// among them: they set two sides at once and no page test states one.
+    /// </summary>
+    private static bool TryLogicalMargin(string name, out bool inline, out bool start)
+    {
+        foreach (var (longhand, isInline, isStart) in WptPageAxes.LogicalLonghands("margin"))
+        {
+            if (!name.Equals(longhand, StringComparison.Ordinal))
+                continue;
+
+            (inline, start) = (isInline, isStart);
+            return true;
+        }
+
+        (inline, start) = (false, false);
+        return false;
+    }
+
+    /// <summary>
     /// The text of each <c>&lt;style&gt;</c> element in the markup. Deliberately a scan rather than
     /// a parse: this runs before the document is built, to decide the surface it will be rendered
     /// on, and a <c>@page</c> rule can only come from a style sheet the document carries.
     /// </summary>
-    private static IEnumerable<string> EnumerateStyleSources(string html)
+    internal static IEnumerable<string> EnumerateStyleSources(string html)
     {
         int index = 0;
         while (true)

--- a/src/Broiler.Wpt/WptPageDecoration.cs
+++ b/src/Broiler.Wpt/WptPageDecoration.cs
@@ -55,19 +55,46 @@ internal sealed record WptPageDecoration(string BackgroundCss, string BoxCss, bo
     /// <c>null</c> when they declare none — which is every document that does not style the sheet,
     /// and the reason this costs nothing for the rest of the suite.
     /// </summary>
-    internal static WptPageDecoration? Resolve(string html)
+    /// <param name="html">The document's markup.</param>
+    /// <param name="page">
+    /// The page box as the document declares it — the surface a paged render would use, which is
+    /// what a flow-relative padding's percentage resolves against even when the render is
+    /// unpaginated onto the runner's viewport.
+    /// </param>
+    internal static WptPageDecoration? Resolve(string html, WptPageBox page)
     {
         // Later declarations win, and a shorthand must not be reordered behind the longhand that
         // follows it, so the cascade is kept as a name-keyed list in source order.
         var background = new List<CssDeclaration>();
         var box = new List<CssDeclaration>();
         bool paints = false, insets = false;
+        var axes = WptPageAxes.Resolve(html);
 
         foreach (var (declarations, _) in WptPageBox.EnumerateUnconditionalPageBlocks(html))
         {
+            double fontSize = WptPageBox.FontSizeOf(declarations.Declarations.ToList());
+
             foreach (var declaration in declarations.Declarations)
             {
                 var name = declaration.Name.Trim().ToLowerInvariant();
+
+                // Flow-relative padding names a physical side through the page's own axes and takes
+                // its percentage against the page box, neither of which the probe below can work out
+                // for itself — its writing mode is the initial one, and its containing block is the
+                // probe surface rather than the page. So it is rewritten here into the physical
+                // longhand it means, in the place it was written so the cascade is unchanged.
+                //
+                // A value this cannot resolve to a length falls through to the general box branch
+                // below and reaches the probe as written, which is what it did before any of this:
+                // the rewrite is an improvement on that path, not a gate in front of it.
+                if (TryLogicalPadding(name, out bool inline, out bool start)
+                    && Physical(declaration, axes.Side(inline, start), page, fontSize) is { } physical)
+                {
+                    Replace(box, physical.Name, physical);
+                    paints = true;
+                    insets = true;
+                    continue;
+                }
 
                 // `visibility` applies to the page context and to nothing else in the document
                 // (css-page-3 §5.1), so it goes on both boxes: a hidden page keeps the space its
@@ -107,6 +134,57 @@ internal sealed record WptPageDecoration(string BackgroundCss, string BoxCss, bo
             into.Add(declaration);
         }
     }
+
+    /// <summary>
+    /// Whether <paramref name="name"/> is one of the four flow-relative padding longhands, and which
+    /// axis and end it names.
+    /// </summary>
+    private static bool TryLogicalPadding(string name, out bool inline, out bool start)
+    {
+        foreach (var (longhand, isInline, isStart) in WptPageAxes.LogicalLonghands("padding"))
+        {
+            if (!name.Equals(longhand, StringComparison.Ordinal))
+                continue;
+
+            (inline, start) = (isInline, isStart);
+            return true;
+        }
+
+        (inline, start) = (false, false);
+        return false;
+    }
+
+    /// <summary>
+    /// <paramref name="declaration"/> rewritten as the physical longhand for <paramref name="side"/>,
+    /// with its length resolved against <paramref name="page"/>, or <c>null</c> when the value is not
+    /// a length this can resolve.
+    /// </summary>
+    /// <remarks>
+    /// The percentage basis is the page box dimension the side runs along, not the box's inline size:
+    /// <c>page-box-008-print</c> and <c>-009-print</c> both state a 16/32/48/80 ring from 2/8/6/20 %
+    /// on a 400×800 page, which only comes out that way per-axis.
+    /// </remarks>
+    private static CssDeclaration? Physical(
+        CssDeclaration declaration, WptPageSide side, WptPageBox page, double fontSize)
+    {
+        double basis = side is WptPageSide.Top or WptPageSide.Bottom
+            ? page.BoxSize.Height
+            : page.BoxSize.Width;
+
+        if (WptPageBox.TryLength(declaration.Value.Text.Trim(), basis, fontSize) is not { } pixels)
+            return null;
+
+        return new CssDeclaration(
+            "padding-" + PhysicalName(side), new CssValue(Px(pixels)), declaration.Important);
+    }
+
+    private static string PhysicalName(WptPageSide side) => side switch
+    {
+        WptPageSide.Top => "top",
+        WptPageSide.Right => "right",
+        WptPageSide.Bottom => "bottom",
+        _ => "left",
+    };
 
     /// <summary>
     /// Renders the sheet's backdrop: the page background over the whole page box, and the page's

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -2793,13 +2793,19 @@ internal sealed partial class WptTestRunner
             // nothing else — and for both sides of one, since PrintMedia is set from the test path
             // for the whole reftest. A document with no page background, border or padding resolves
             // to null here and renders exactly as it always has.
-            var decoration = PrintMedia ? WptPageDecoration.Resolve(html) : null;
+            //
+            // The page box comes first because the decoration needs it: it is the surface a paged
+            // render lays out on, and it is the basis a `@page` percentage resolves against — in the
+            // unpaginated render below too, whose sheet is the runner's viewport instead.
+            var declaredPage = PrintMedia
+                ? WptPageBox.Resolve(html, new System.Drawing.SizeF(_width, _height))
+                : default;
+            var decoration = PrintMedia ? WptPageDecoration.Resolve(html, declaredPage) : null;
 
             if (PagedRender)
             {
-                var page = WptPageBox.Resolve(html, new System.Drawing.SizeF(_width, _height));
                 return RenderWithNativeAnchor(html, () => WptDocumentRenderer.RenderPaged(
-                    renderDocument, html, page,
+                    renderDocument, html, declaredPage,
                     backgroundColor: BColor.White,
                     stylesheetLoad: stylesheetHandler, imageLoad: imageHandler, baseUrl: testBaseUrl,
                     decoration: decoration));
@@ -2810,8 +2816,7 @@ internal sealed partial class WptTestRunner
                 // Unpaginated, so the surface stays the runner's viewport and only the `@page`'s
                 // margins are taken from the rule: taking its `size` too would resize one side of a
                 // comparison whose reference states no size of its own.
-                var sheet = WptPageBox.Resolve(html, new System.Drawing.SizeF(_width, _height))
-                    with { BoxSize = new System.Drawing.SizeF(_width, _height) };
+                var sheet = declaredPage with { BoxSize = new System.Drawing.SizeF(_width, _height) };
                 return RenderWithNativeAnchor(html, () => WptDocumentRenderer.RenderDecorated(
                     renderDocument, html, sheet, decoration,
                     backgroundColor: BColor.White,


### PR DESCRIPTION
## Summary

Implements support for CSS Paged Media 3 §3.2 flow-relative margin and padding properties on `@page` rules. Previously, `margin-inline-start`, `margin-block-start`, and their siblings were ignored, leaving page margins at zero and padding resolving to incorrect sides and percentage bases.

## Key Changes

- **New `WptPageAxes` type** (`src/Broiler.Wpt/WptPageAxes.cs`): Resolves the page box's writing mode and inline direction, determining which physical side each flow-relative property names. The page's own `writing-mode`/`direction` declarations take precedence over the root element's, matching the intent of `page-box-008-print` and `page-box-009-print` which disagree on purpose about where the axis comes from.

- **`WptPageBox.Resolve` enhancement**: Now reads the four flow-relative margin longhands (`margin-block-start`, `margin-block-end`, `margin-inline-start`, `margin-inline-end`) and resolves them through `WptPageAxes` to physical sides. Percentages are taken against the page-box dimension each physical side runs along (height for top/bottom, width for left/right), not the inline size.

- **`WptPageDecoration.Resolve` enhancement**: Now accepts the declared `WptPageBox` and rewrites flow-relative padding longhands into their physical equivalents **in source order**, preserving cascade semantics with physical longhands. Percentages resolve against the page box, not the probe's containing block.

- **`WptTestRunner` coordination**: Resolves the declared page box once before rendering and passes it to both `WptPageBox.Resolve` and `WptPageDecoration.Resolve`, ensuring consistent percentage bases.

## Implementation Details

- Flow-relative sides map through writing modes (`horizontal-tb`, `vertical-rl`, `vertical-lr`, `sideways-rl`, `sideways-lr`) and `direction: rtl`, with the inline axis perpendicular to the block axis.
- The root element's writing mode is scanned from style sources using the same rules as `WptPageBox.EnumerateUnconditionalPageBlocks`, reading only selectors that match the root element alone (`html`, `:root`, `*`).
- Padding rewrite happens at declaration time, preserving the cascade: a physical longhand following a flow-relative one wins, and vice versa.
- Tests verify both writing-mode sources, `direction: rtl`, initial axes, cascade behavior, and percentage basis correctness.

## Test Results

- `css-page/page-box-008-print`: 4.0% → 6.7%
- `css-page/page-box-009-print`: 67.0% → 79.8%
- `css/css-page` average: 87.86% → 87.93% (140/223 passing, unchanged count)
- `css/css-break`: no change
- No regressions; golden-image scores unchanged for all affected tests

https://claude.ai/code/session_015Yf5EAwb4cxneVmu3yUeex