### PR TITLE
Add sessionStorage and complete Storage interface

### DIFF
--- a/Broiler.Documents/Broiler.Documents.Html/HtmlReader.cs
+++ b/Broiler.Documents/Broiler.Documents.Html/HtmlReader.cs
@@ -49,7 +49,7 @@ internal static class HtmlReader
         HtmlDocumentParseResult parse;
         try
         {
-            parse = new HtmlDocumentParser().ParseDocument(html);
+            parse = HtmlDocumentParser.ParseDocument(html);
         }
         catch (Exception ex)
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,32 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `sessionStorage` exists. Only `localStorage` was ever registered, and because
+  `window` **is** the global object, the bare `sessionStorage` a page writes was a
+  `ReferenceError` rather than an undefined property — which aborts the entire
+  script, not the statement that read it. `www.mediawiki.org` serves its modules
+  as one `load.php` bundle, so that single identifier took ResourceLoader, the
+  Vector skin and every module queued behind them down with it, and the only
+  symptom was `ReferenceError: sessionStorage is not defined` on a page that had
+  quietly lost all of its script-driven behaviour. The two areas are separate
+  stores, as they are in a browser, and a same-origin frame now sees its parent's
+  areas rather than empty ones of its own.
+  - The `Storage` object grew the rest of its interface with them: `length` and
+    `key(n)`, which is how a page walks an area it did not write itself, and
+    named-property access in both directions — `storage.foo = 1` is now the same
+    item as `setItem('foo', '1')`, where a directly-assigned property used to be
+    invisible to `getItem`, `length` and `key()` alike. The methods are
+    non-enumerable, so `Object.keys(storage)` and `for (var k in storage)` yield
+    the stored keys alone rather than four methods among them.
+  - `Storage` is registered as an interface global, because
+    `typeof Storage !== 'undefined'` is the canonical Web Storage feature test: a
+    page that fails it takes its no-storage path however complete the areas
+    themselves are. Like the DOM interface globals it answers `instanceof` from
+    the object's shape.
+  - The CLI's script-only capture path (no DOM) had a second, thinner copy of the
+    same storage stub, reachable only as `window.localStorage`; it now shares the
+    one implementation and registers both areas unqualified as well.
+
 - Nothing in the tree changed for column fragmentation of a box that has content
   in it, and that is the result rather than an omission. It was built — each piece
   a copy of the box carrying the part of its subtree in that piece, a straddling

--- a/docs/mediawiki-vector-rendering.md
+++ b/docs/mediawiki-vector-rendering.md
@@ -127,6 +127,13 @@ rest of what the skin needs turned up in order:
   `requestIdleCallback` were missing, and each threw out of a module the skin loads.
 * `MediaQueryList` had no `addEventListener`/`removeEventListener`/`onchange`, which is how the
   skin watches its own breakpoints.
+* `sessionStorage` did not exist — only `localStorage` did. `window` **is** the global object here,
+  so the bare `sessionStorage` the page writes was a `ReferenceError` rather than an undefined
+  property, and that aborts the whole script. MediaWiki serves its modules as one `load.php`
+  bundle, so a single identifier took ResourceLoader, the skin and every module queued behind them
+  with it. Both areas are now registered, with the `length`/`key()` pair and the named-property
+  access (`storage.foo`) that go with them, and a `Storage` interface global for the
+  `typeof Storage !== 'undefined'` feature test.
 
 ## What is left
 

--- a/src/Broiler.Cli.Tests/GraphicsAbstractionTests.cs
+++ b/src/Broiler.Cli.Tests/GraphicsAbstractionTests.cs
@@ -216,7 +216,7 @@ public class GraphicsAbstractionTests
     public void HtmlContainer_Typed_And_Serialized_Paths_Produce_Equivalent_Fragment_Trees()
     {
         const string html = "<html><body style='margin:0'><div id='target' style='width:20px;height:10px'>value</div></body></html>";
-        var document = new HtmlDocumentParser().ParseDocument(html).Document;
+        var document = HtmlDocumentParser.ParseDocument(html).Document;
 
         using var serialized = new HtmlContainer();
         using var typed = new HtmlContainer();
@@ -236,7 +236,7 @@ public class GraphicsAbstractionTests
     [Fact]
     public void HtmlContainer_Typed_Path_Rebuilds_After_Canonical_Dom_Mutation()
     {
-        var document = new HtmlDocumentParser()
+        var document = HtmlDocumentParser
             .ParseDocument("<html><body style='margin:0'><div id='target' style='width:20px;height:10px'></div></body></html>")
             .Document;
         var target = document.GetElementById("target")!;

--- a/src/Broiler.Cli.Tests/Phase5SharedCascadeTests.cs
+++ b/src/Broiler.Cli.Tests/Phase5SharedCascadeTests.cs
@@ -75,7 +75,7 @@ public sealed class Phase5SharedCascadeTests
 
     private static (Broiler.CSS.Dom.CssStyleEngine Engine, CssBox Root) Build(string html)
     {
-        var document = new HtmlDocumentParser().ParseDocument(html).Document;
+        var document = HtmlDocumentParser.ParseDocument(html).Document;
         var root = HtmlParser.ParseDocument(document, new Uri("file:///t.html"));
         var styleStart = html.IndexOf("<style>", StringComparison.OrdinalIgnoreCase);
         var styleEnd = html.IndexOf("</style>", StringComparison.OrdinalIgnoreCase);

--- a/src/Broiler.Cli.Tests/WebStorageBindingModuleTests.cs
+++ b/src/Broiler.Cli.Tests/WebStorageBindingModuleTests.cs
@@ -1,6 +1,7 @@
-using System.Reflection;
 using Broiler.HtmlBridge.Dom.Features;
 using Broiler.JavaScript.BuiltIns.Function;
+using Broiler.JavaScript.BuiltIns.Null;
+using Broiler.JavaScript.BuiltIns.Number;
 using Broiler.JavaScript.BuiltIns.String;
 using Broiler.JavaScript.Runtime;
 using Broiler.JavaScript.Storage;
@@ -9,14 +10,23 @@ namespace Broiler.Cli.Tests;
 
 /// <summary>
 /// Guards the HtmlBridge complexity-reduction roadmap Phase 3 feature-module extraction of the Web
-/// Storage <c>localStorage</c> object (<see cref="WebStorageBinding"/>) — <c>getItem</c>/<c>setItem</c>/
-/// <c>removeItem</c>/<c>clear</c> over an in-memory string map. A fully self-contained slice (no bridge
-/// state), so — like <c>ClassListBinding</c> — the module is an internal static class with <b>no host
-/// contract</b>. Was the bridge's <c>BuildLocalStorageObject</c> plus <c>JsUtilitiesGetItem029Core</c>..
-/// <c>Clear032Core</c>. The characterization drives the built object's callbacks directly.
+/// Storage areas (<see cref="WebStorageBinding"/>) — <c>getItem</c>/<c>setItem</c>/<c>removeItem</c>/
+/// <c>clear</c>/<c>key</c>/<c>length</c> over an in-memory string map. A fully self-contained slice
+/// (no bridge state), so — like <c>ClassListBinding</c> — the module is an internal static class with
+/// <b>no host contract</b>. Was the bridge's <c>BuildLocalStorageObject</c> plus
+/// <c>JsUtilitiesGetItem029Core</c>..<c>Clear032Core</c>. The characterization drives the built
+/// object's callbacks directly.
 /// </summary>
 public sealed class WebStorageBindingModuleTests
 {
+    private static JSFunction Fn(JSObject o, string name) => (JSFunction)o[(KeyString)name]!;
+
+    private static string? GetItem(JSObject storage, string key) =>
+        Fn(storage, "getItem").InvokeFunction(new Arguments(storage, new JSString(key))) is JSString s ? s.ToString() : null;
+
+    private static void SetItem(JSObject storage, string key, string value) =>
+        Fn(storage, "setItem").InvokeFunction(new Arguments(storage, new JSString(key), new JSString(value)));
+
     [Fact]
     public void WebStorage_Feature_Module_Is_Internal_And_Has_No_Host_Contract()
     {
@@ -30,33 +40,109 @@ public sealed class WebStorageBindingModuleTests
     }
 
     [Fact]
-    public void LocalStorage_Object_Round_Trips_Through_Its_Callbacks()
+    public void Storage_Object_Round_Trips_Through_Its_Callbacks()
     {
-        var storage = WebStorageBinding.BuildLocalStorage();
-
-        static JSFunction Fn(JSObject o, string name) => (JSFunction)o[(KeyString)name]!;
-        string? GetItem(string key) =>
-            Fn(storage, "getItem").InvokeFunction(new Arguments(storage, new JSString(key))) is JSString s ? s.ToString() : null;
+        var storage = WebStorageBinding.BuildStorage();
 
         // setItem then getItem
-        Fn(storage, "setItem").InvokeFunction(new Arguments(storage, new JSString("a"), new JSString("1")));
-        Fn(storage, "setItem").InvokeFunction(new Arguments(storage, new JSString("b"), new JSString("2")));
-        Assert.Equal("1", GetItem("a"));
-        Assert.Equal("2", GetItem("b"));
+        SetItem(storage, "a", "1");
+        SetItem(storage, "b", "2");
+        Assert.Equal("1", GetItem(storage, "a"));
+        Assert.Equal("2", GetItem(storage, "b"));
         // bracket-notation mirror: setItem also writes the value onto the storage object itself
         Assert.Equal("2", (storage[(KeyString)"b"] as JSString)?.ToString());
         // missing key
-        Assert.Null(GetItem("nope"));
+        Assert.Null(GetItem(storage, "nope"));
 
         // removeItem only affects its key
         Fn(storage, "removeItem").InvokeFunction(new Arguments(storage, new JSString("a")));
-        Assert.Null(GetItem("a"));
-        Assert.Equal("2", GetItem("b"));
+        Assert.Null(GetItem(storage, "a"));
+        Assert.Equal("2", GetItem(storage, "b"));
+        Assert.True((storage[(KeyString)"a"] ?? JSUndefined.Value).IsUndefined);
 
         // clear removes everything
-        Fn(storage, "setItem").InvokeFunction(new Arguments(storage, new JSString("c"), new JSString("3")));
+        SetItem(storage, "c", "3");
         Fn(storage, "clear").InvokeFunction(new Arguments(storage));
-        Assert.Null(GetItem("b"));
-        Assert.Null(GetItem("c"));
+        Assert.Null(GetItem(storage, "b"));
+        Assert.Null(GetItem(storage, "c"));
+    }
+
+    [Fact]
+    public void Length_And_Key_Enumerate_The_Area_In_Insertion_Order()
+    {
+        // How a page walks an area it did not write itself: `for (i = 0; i < s.length; i++) s.key(i)`.
+        var storage = WebStorageBinding.BuildStorage();
+        Assert.Equal(0d, (storage[(KeyString)"length"] as JSNumber)?.DoubleValue);
+
+        SetItem(storage, "first", "1");
+        SetItem(storage, "second", "2");
+        SetItem(storage, "first", "1-again");   // an overwrite is not a second key
+
+        Assert.Equal(2d, (storage[(KeyString)"length"] as JSNumber)?.DoubleValue);
+
+        string? Key(double index) =>
+            Fn(storage, "key").InvokeFunction(new Arguments(storage, new JSNumber(index))) is JSString s ? s.ToString() : null;
+
+        Assert.Equal("first", Key(0));
+        Assert.Equal("second", Key(1));
+        // Past the end is null, not a throw — the loop guard above relies on it.
+        Assert.Null(Key(2));
+        Assert.Null(Key(-1));
+
+        Fn(storage, "removeItem").InvokeFunction(new Arguments(storage, new JSString("first")));
+        Assert.Equal(1d, (storage[(KeyString)"length"] as JSNumber)?.DoubleValue);
+        Assert.Equal("second", Key(0));
+    }
+
+    [Fact]
+    public void A_Directly_Assigned_Property_Is_Stored_As_An_Item()
+    {
+        // Storage is a legacy platform object with named property setters, so `s.foo = 1` and
+        // `s.setItem('foo', '1')` are one item — including for length/key, which counted only what
+        // came through setItem before.
+        var storage = WebStorageBinding.BuildStorage();
+
+        storage[(KeyString)"foo"] = new JSString("bar");
+
+        Assert.Equal("bar", GetItem(storage, "foo"));
+        Assert.Equal(1d, (storage[(KeyString)"length"] as JSNumber)?.DoubleValue);
+
+        Fn(storage, "clear").InvokeFunction(new Arguments(storage));
+        Assert.Null(GetItem(storage, "foo"));
+        Assert.Equal(0d, (storage[(KeyString)"length"] as JSNumber)?.DoubleValue);
+    }
+
+    [Fact]
+    public void An_Item_Named_Like_A_Method_Does_Not_Replace_The_Method()
+    {
+        // A browser survives this because its methods sit on Storage.prototype and the named
+        // property merely shadows them; the bridge carries members directly, so mirroring here
+        // would leave the area without the method the page is about to call.
+        var storage = WebStorageBinding.BuildStorage();
+
+        SetItem(storage, "clear", "not-a-function");
+
+        Assert.Equal("not-a-function", GetItem(storage, "clear"));
+        Assert.IsAssignableFrom<JSFunction>(storage[(KeyString)"clear"]);
+
+        Fn(storage, "clear").InvokeFunction(new Arguments(storage));
+        Assert.Null(GetItem(storage, "clear"));
+    }
+
+    [Fact]
+    public void Each_Built_Area_Has_A_Store_Of_Its_Own()
+    {
+        // localStorage and sessionStorage are separate areas: one Build call per area.
+        var local = WebStorageBinding.BuildStorage();
+        var session = WebStorageBinding.BuildStorage();
+
+        SetItem(local, "shared-key", "local-value");
+        SetItem(session, "shared-key", "session-value");
+
+        Assert.Equal("local-value", GetItem(local, "shared-key"));
+        Assert.Equal("session-value", GetItem(session, "shared-key"));
+
+        Fn(session, "clear").InvokeFunction(new Arguments(session));
+        Assert.Equal("local-value", GetItem(local, "shared-key"));
     }
 }

--- a/src/Broiler.Cli.Tests/WebStorageDomTests.cs
+++ b/src/Broiler.Cli.Tests/WebStorageDomTests.cs
@@ -1,0 +1,137 @@
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// The Web Storage areas as a page reaches them: <c>sessionStorage</c> and <c>localStorage</c>
+/// unqualified, the <c>Storage</c> interface global a feature test asks for, and the item surface
+/// behind both.
+/// </summary>
+/// <remarks>
+/// <c>sessionStorage</c> was never registered, and because <c>window</c> IS the global object that
+/// made the bare identifier a <c>ReferenceError</c> rather than an undefined property — which
+/// aborts the whole script. <c>www.mediawiki.org</c> ships its modules as a single <c>load.php</c>
+/// bundle, so the abort took ResourceLoader, the Vector skin and every module queued behind them
+/// with it: "ReferenceError: sessionStorage is not defined" was the only symptom of a page that had
+/// lost all of its script-driven behaviour.
+/// </remarks>
+public class WebStorageDomTests
+{
+    [Fact]
+    public void Unqualified_SessionStorage_Does_Not_Abort_The_Script()
+    {
+        // The failure mode was not "this read returns undefined" but "the script dies here", so the
+        // marker after the reads is the real assertion.
+        var html = @"<!DOCTYPE html>
+<html><body>
+<div id=""result"">script-died</div>
+<script>
+var seen = [];
+seen.push(typeof sessionStorage);
+seen.push(typeof localStorage);
+sessionStorage.setItem('k', 'v');
+seen.push(sessionStorage.getItem('k'));
+seen.push(String(sessionStorage.getItem('absent')));
+document.getElementById('result').textContent = seen.join('|');
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+
+        Assert.DoesNotContain("script-died", result);
+        Assert.Contains("object|object|v|null", result);
+    }
+
+    [Fact]
+    public void The_Two_Areas_Are_Separate_Stores()
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<div id=""result"">script-died</div>
+<script>
+localStorage.setItem('same-key', 'local');
+sessionStorage.setItem('same-key', 'session');
+document.getElementById('result').textContent =
+    localStorage.getItem('same-key') + '|' + sessionStorage.getItem('same-key') +
+    '|' + (localStorage === sessionStorage);
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+
+        Assert.Contains("local|session|false", result);
+    }
+
+    [Fact]
+    public void An_Area_Enumerates_Through_Length_And_Key()
+    {
+        // How a page walks an area it did not write itself. The methods must not show up among the
+        // keys: they are own properties here, where a browser keeps them on Storage.prototype.
+        var html = @"<!DOCTYPE html>
+<html><body>
+<div id=""result"">script-died</div>
+<script>
+sessionStorage.setItem('a', '1');
+sessionStorage.setItem('b', '2');
+var keys = [];
+for (var i = 0; i < sessionStorage.length; i++) keys.push(sessionStorage.key(i));
+document.getElementById('result').textContent =
+    keys.join(',') + '|' + Object.keys(sessionStorage).join(',') + '|' + sessionStorage.length;
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+
+        Assert.Contains("a,b|a,b|2", result);
+    }
+
+    [Fact]
+    public void Named_Access_And_setItem_Address_The_Same_Item()
+    {
+        // Storage is a legacy platform object with named property getters and setters, so pages use
+        // the two spellings interchangeably — including across them, as this does.
+        var html = @"<!DOCTYPE html>
+<html><body>
+<div id=""result"">script-died</div>
+<script>
+localStorage.direct = 'assigned';
+localStorage.setItem('viaMethod', 'set');
+var seen = [
+    localStorage.getItem('direct'),
+    localStorage.viaMethod,
+    localStorage.length
+];
+localStorage.clear();
+seen.push(String(localStorage.getItem('direct')));
+seen.push(localStorage.length);
+document.getElementById('result').textContent = seen.join('|');
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+
+        Assert.Contains("assigned|set|2|null|0", result);
+    }
+
+    [Fact]
+    public void The_Storage_Interface_Global_Answers_Feature_Tests()
+    {
+        // `typeof Storage !== 'undefined'` is the canonical Web Storage feature test: a page that
+        // fails it takes its no-storage path however complete the areas themselves are.
+        var html = @"<!DOCTYPE html>
+<html><body>
+<div id=""result"">script-died</div>
+<script>
+var seen = [
+    typeof Storage,
+    localStorage instanceof Storage,
+    sessionStorage instanceof Storage,
+    ({}) instanceof Storage
+];
+document.getElementById('result').textContent = seen.join('|');
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+
+        Assert.Contains("function|true|true|false", result);
+    }
+}

--- a/src/Broiler.Cli/CaptureService.cs
+++ b/src/Broiler.Cli/CaptureService.cs
@@ -1058,64 +1058,25 @@ public class CaptureService
             document,
             JSPropertyAttributes.EnumerableConfigurableValue);
 
-        // window.localStorage — in-memory stub
-        var storage = new JSObject();
-        var store = new Dictionary<string, string>();
-
-        storage.FastAddValue(
-            (KeyString)"getItem",
-            new JSFunction((in Arguments a) =>
-            {
-                if (a.Length == 0) return JSNull.Value;
-                var key = a[0]?.ToString() ?? string.Empty;
-                return store.TryGetValue(key, out var val) ? new JSString(val) : JSNull.Value;
-            }, "getItem", 1),
-            JSPropertyAttributes.EnumerableConfigurableValue);
-
-        storage.FastAddValue(
-            (KeyString)"setItem",
-            new JSFunction((in Arguments a) =>
-            {
-                if (a.Length >= 2)
-                {
-                    var key = a[0]?.ToString() ?? string.Empty;
-                    var val = a[1]?.ToString() ?? string.Empty;
-                    store[key] = val;
-                    storage[(KeyString)key] = new JSString(val);
-                }
-                return JSUndefined.Value;
-            }, "setItem", 2),
-            JSPropertyAttributes.EnumerableConfigurableValue);
-
-        storage.FastAddValue(
-            (KeyString)"removeItem",
-            new JSFunction((in Arguments a) =>
-            {
-                if (a.Length > 0)
-                {
-                    var key = a[0]?.ToString() ?? string.Empty;
-                    store.Remove(key);
-                    storage.Delete((KeyString)key);
-                }
-                return JSUndefined.Value;
-            }, "removeItem", 1),
-            JSPropertyAttributes.EnumerableConfigurableValue);
-
-        storage.FastAddValue(
-            (KeyString)"clear",
-            new JSFunction((in Arguments a) =>
-            {
-                foreach (var key in store.Keys.ToList())
-                    storage.Delete((KeyString)key);
-                store.Clear();
-                return JSUndefined.Value;
-            }, "clear", 0),
-            JSPropertyAttributes.EnumerableConfigurableValue);
+        // window.localStorage / window.sessionStorage — the same in-memory Storage areas the DOM
+        // path builds, rather than a second, thinner copy of the same code that drifts from it: the
+        // hand-rolled stub here had no `sessionStorage`, no `length` and no `key()`.
+        // Registered on the global as well, because the unqualified spelling is the one page
+        // scripts use and an unqualified miss is a ReferenceError that aborts the whole script.
+        var localStorage = Broiler.HtmlBridge.Dom.Features.WebStorageBinding.BuildStorage();
+        var sessionStorage = Broiler.HtmlBridge.Dom.Features.WebStorageBinding.BuildStorage();
 
         window.FastAddValue(
             (KeyString)"localStorage",
-            storage,
+            localStorage,
             JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue(
+            (KeyString)"sessionStorage",
+            sessionStorage,
+            JSPropertyAttributes.EnumerableConfigurableValue);
+
+        context["localStorage"] = localStorage;
+        context["sessionStorage"] = sessionStorage;
 
         // window.matchMedia(query) — stub returning { matches: false }
         window.FastAddValue(

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Polyfills.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Polyfills.cs
@@ -53,6 +53,41 @@ public sealed partial class DomBridge
 
         // SVGLength interface constants
         RegisterSVGLength(context);
+
+        // Storage interface global — the name a page tests before it touches an area.
+        RegisterStorageConstructor(context);
+    }
+
+    /// <summary>
+    /// The <c>Storage</c> interface global (HTML §12.2.2), as the name a feature test asks for
+    /// rather than as a constructible class: the two areas come from <c>localStorage</c> and
+    /// <c>sessionStorage</c>, never from <c>new Storage()</c>.
+    /// </summary>
+    /// <remarks>
+    /// <c>typeof Storage !== 'undefined'</c> is the canonical Web Storage feature test — MDN
+    /// documents it as such — so an absent global makes a page conclude it has no storage at all
+    /// and take its no-storage path, however complete the two area objects are. Like the DOM
+    /// interface globals (see <c>RegisterDomInterfaceConstructors</c>) it answers
+    /// <c>instanceof</c> from the object's shape, because a bridge storage object carries its
+    /// members directly instead of inheriting them from this constructor's prototype.
+    /// </remarks>
+    private static void RegisterStorageConstructor(JSContext context)
+    {
+        context.Eval(@"
+            function Storage() { throw new TypeError('Illegal constructor'); }
+
+            Object.defineProperty(Storage, Symbol.hasInstance, {
+                value: function (o) {
+                    return !!o && typeof o === 'object'
+                        && typeof o.getItem === 'function'
+                        && typeof o.setItem === 'function'
+                        && typeof o.removeItem === 'function'
+                        && typeof o.key === 'function'
+                        && typeof o.length === 'number';
+                },
+                writable: false, enumerable: false, configurable: true
+            });
+        ");
     }
 
 }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
@@ -16,8 +16,12 @@ public sealed partial class DomBridge
     {
         window.FastAddValue((KeyString)"document", document, JSPropertyAttributes.EnumerableConfigurableValue);
 
-        // window.localStorage — in-memory stub backed by a plain JSObject
-        window.FastAddValue((KeyString)"localStorage", Dom.Features.WebStorageBinding.BuildLocalStorage(), JSPropertyAttributes.EnumerableConfigurableValue);
+        // window.localStorage / window.sessionStorage — the two Web Storage areas (HTML §12.2),
+        // each an in-memory Storage object of its own. Built separately because they are separate
+        // areas: a page that stashes per-tab state in one and durable state in the other must not
+        // see the two answer each other's reads.
+        window.FastAddValue((KeyString)"localStorage", Dom.Features.WebStorageBinding.BuildStorage(), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"sessionStorage", Dom.Features.WebStorageBinding.BuildStorage(), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // window.matchMedia(query) — evaluates basic media queries
         window.FastAddValue((KeyString)"matchMedia", new DomFunction((in a) => Dom.Features.MatchMediaBinding.MatchMedia(this, in a), "matchMedia", 1), JSPropertyAttributes.EnumerableConfigurableValue);

--- a/src/Broiler.HtmlBridge.Dom/Features/SubWindowBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubWindowBinding.cs
@@ -105,6 +105,12 @@ internal sealed class SubWindowBinding(
         "setTimeout", "clearTimeout", "setInterval", "clearInterval",
         "requestAnimationFrame", "cancelAnimationFrame", "queueMicrotask",
         "atob", "btoa", "structuredClone", "performance", "crypto",
+
+        // The two storage areas. A frame gets the parent's objects rather than fresh ones, which
+        // is what a same-origin frame sees in a browser: the Storage object differs there, the
+        // *area* behind it does not, and a frame that cannot read what its opener wrote is the
+        // more visible wrong answer.
+        "localStorage", "sessionStorage",
     ];
 
     /// <summary>Gets or builds the sub-window JS object for a nested-browsing-context container.</summary>

--- a/src/Broiler.HtmlBridge.Dom/Features/WebStorageBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/WebStorageBinding.cs
@@ -1,4 +1,5 @@
 using Broiler.JavaScript.BuiltIns.Null;
+using Broiler.JavaScript.BuiltIns.Number;
 using Broiler.JavaScript.BuiltIns.String;
 using Broiler.JavaScript.BuiltIns.Function;
 using Broiler.JavaScript.Storage;
@@ -7,79 +8,223 @@ using Broiler.JavaScript.Runtime;
 namespace Broiler.HtmlBridge.Dom.Features;
 
 /// <summary>
-/// The Web Storage <c>localStorage</c> object — <c>getItem</c>/<c>setItem</c>/<c>removeItem</c>/
-/// <c>clear</c> over an in-memory string map — co-located as an HtmlBridge feature module (Phase 3).
-/// A fully self-contained slice: the store is a plain <see cref="Dictionary{TKey,TValue}"/> and the
-/// callbacks touch no bridge state, so — like <c>ClassListBinding</c> — it is an <b>internal static
-/// class with no host contract</b>. Bracket-notation access (<c>localStorage["key"]</c>) naturally
-/// falls through to JSObject property lookup, which is why <c>setItem</c>/<c>removeItem</c> also mirror
-/// the value onto the storage object. Was the bridge's <c>BuildLocalStorageObject</c> plus
+/// The Web Storage areas (HTML §12.2) — <c>localStorage</c> and <c>sessionStorage</c>, each a
+/// <c>Storage</c> object over an in-memory string map — co-located as an HtmlBridge feature module
+/// (Phase 3). A fully self-contained slice: the store is a plain dictionary and the callbacks touch
+/// no bridge state, so — like <c>ClassListBinding</c> — it is an <b>internal static class with no
+/// host contract</b>. Was the bridge's <c>BuildLocalStorageObject</c> plus
 /// <c>JsUtilitiesGetItem029Core</c>..<c>Clear032Core</c>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// A capture keeps each area for the life of the page and never persists it: there is no profile to
+/// write to, and a page that reads back what it just wrote — which is what most of this API is used
+/// for — gets a consistent answer either way.
+/// </para>
+/// <para>
+/// Both areas exist because a missing one is not an empty one. <c>sessionStorage</c> was never
+/// registered, and since <c>window</c> IS the global object that made the unqualified
+/// <c>sessionStorage</c> a <c>ReferenceError</c> rather than an undefined property — which aborts
+/// the whole script, not the statement that read it. <c>www.mediawiki.org</c> loads its modules
+/// through one <c>load.php</c> bundle, so the abort took the entire bundle with it (ResourceLoader,
+/// the Vector skin's scripts and every module queued behind them) off one identifier.
+/// </para>
+/// </remarks>
 internal static class WebStorageBinding
 {
-    public static JSObject BuildLocalStorage()
+    /// <summary>
+    /// The <c>Storage</c> interface members. A page's key by the same name must not overwrite the
+    /// method — see <see cref="StorageObject.SetValue"/>.
+    /// </summary>
+    private static readonly HashSet<string> InterfaceMembers = new(StringComparer.Ordinal)
     {
-        var storage = new JSObject();
-        var store = new Dictionary<string, string>();
+        "getItem", "setItem", "removeItem", "clear", "key", "length",
+    };
 
+    /// <summary>
+    /// Builds one storage area. Call it once per area — <c>localStorage</c> and
+    /// <c>sessionStorage</c> are separate areas and must not share a backing store.
+    /// </summary>
+    public static JSObject BuildStorage()
+    {
+        var storage = new StorageObject();
+
+        // Non-enumerable, as they are in a browser: there the members live on Storage.prototype and
+        // only the stored keys are own properties, so `for (var k in storage)` and
+        // `Object.keys(storage)` yield keys alone. Bridge objects carry their members directly
+        // (see RegisterDomInterfaceConstructors), so hiding them from enumeration is what keeps a
+        // page that iterates a storage area from finding four methods among its keys.
         storage.FastAddValue((KeyString)"getItem",
-            new DomFunction((in a) => GetItem(store, in a), "getItem", 1),
-            JSPropertyAttributes.EnumerableConfigurableValue);
+            new DomFunction((in a) => GetItem(storage, in a), "getItem", 1),
+            JSPropertyAttributes.ConfigurableValue);
 
         storage.FastAddValue((KeyString)"setItem",
-            new DomFunction((in a) => SetItem(storage, store, in a), "setItem", 2),
-            JSPropertyAttributes.EnumerableConfigurableValue);
+            new DomFunction((in a) => SetItem(storage, in a), "setItem", 2),
+            JSPropertyAttributes.ConfigurableValue);
 
         storage.FastAddValue((KeyString)"removeItem",
-            new DomFunction((in a) => RemoveItem(storage, store, in a), "removeItem", 1),
-            JSPropertyAttributes.EnumerableConfigurableValue);
+            new DomFunction((in a) => RemoveItem(storage, in a), "removeItem", 1),
+            JSPropertyAttributes.ConfigurableValue);
 
         storage.FastAddValue((KeyString)"clear",
-            new DomFunction((in a) => Clear(storage, store, in a), "clear", 0),
-            JSPropertyAttributes.EnumerableConfigurableValue);
+            new DomFunction((in a) => Clear(storage, in a), "clear", 0),
+            JSPropertyAttributes.ConfigurableValue);
+
+        storage.FastAddValue((KeyString)"key",
+            new DomFunction((in a) => Key(storage, in a), "key", 1),
+            JSPropertyAttributes.ConfigurableValue);
+
+        storage.FastAddProperty((KeyString)"length",
+            new DomFunction((in _) => new JSNumber(storage.Count), "get length"),
+            null,
+            JSPropertyAttributes.ConfigurableProperty);
 
         return storage;
     }
 
-    private static JSValue GetItem(Dictionary<string, string> store, in Arguments a)
+    private static JSValue GetItem(StorageObject storage, in Arguments a)
     {
         if (a.Length == 0)
             return JSNull.Value;
-        var key = a[0].ToString();
-        return store.TryGetValue(key, out var val) ? new JSString(val) : JSNull.Value;
+        return storage.TryGet(a[0].ToString(), out var val) ? new JSString(val) : JSNull.Value;
     }
 
-    private static JSValue SetItem(JSObject storage, Dictionary<string, string> store, in Arguments a)
+    private static JSValue SetItem(StorageObject storage, in Arguments a)
     {
         if (a.Length >= 2)
-        {
-            var key = a[0].ToString();
-            var val = a[1].ToString();
-            store[key] = val;
-            storage[(KeyString)key] = new JSString(val);
-        }
+            storage.Put(a[0].ToString(), a[1].ToString());
 
         return JSUndefined.Value;
     }
 
-    private static JSValue RemoveItem(JSObject storage, Dictionary<string, string> store, in Arguments a)
+    private static JSValue RemoveItem(StorageObject storage, in Arguments a)
     {
         if (a.Length > 0)
-        {
-            var key = a[0].ToString();
-            store.Remove(key);
-            storage.Delete((KeyString)key);
-        }
+            storage.Remove(a[0].ToString());
 
         return JSUndefined.Value;
     }
 
-    private static JSValue Clear(JSObject storage, Dictionary<string, string> store, in Arguments _)
+    private static JSValue Clear(StorageObject storage, in Arguments _)
     {
-        foreach (var key in store.Keys.ToList())
-            storage.Delete((KeyString)key);
-        store.Clear();
+        storage.RemoveAll();
         return JSUndefined.Value;
+    }
+
+    /// <summary>
+    /// <c>key(n)</c> — the <c>n</c>th key in insertion order, or <c>null</c> past the end. Paired
+    /// with <c>length</c> it is how a page enumerates an area it did not write itself; MediaWiki's
+    /// <c>ext.centralNotice</c> key-value store sweeps its own keys exactly that way.
+    /// </summary>
+    private static JSValue Key(StorageObject storage, in Arguments a)
+    {
+        if (a.Length == 0)
+            return JSNull.Value;
+
+        var index = a[0].DoubleValue;
+        if (double.IsNaN(index) || index < 0 || index >= storage.Count)
+            return JSNull.Value;
+
+        return new JSString(storage.KeyAt((int)index));
+    }
+
+    /// <summary>
+    /// A storage area: the ordered key/value map, plus the property mirror that makes
+    /// <c>storage.foo</c> and <c>storage["foo"]</c> address the same item as
+    /// <c>getItem</c>/<c>setItem</c> do.
+    /// </summary>
+    /// <remarks>
+    /// Storage is a legacy platform object with named property getters and setters (HTML §12.2.2),
+    /// so the two spellings are one item in a browser and pages use them interchangeably. The
+    /// mirror runs both ways: an item written with <c>setItem</c> is defined as an own property,
+    /// and a property a page assigns directly is written into the store — otherwise
+    /// <c>storage.foo = 1</c> followed by <c>getItem('foo')</c> answers <c>null</c>, and neither
+    /// <c>length</c> nor <c>key()</c> would count it.
+    /// </remarks>
+    private sealed class StorageObject : JSObject
+    {
+        private readonly Dictionary<string, string> _store = new(StringComparer.Ordinal);
+
+        /// <summary>Insertion order, which is the order <c>key(n)</c> reports.</summary>
+        private readonly List<string> _keys = [];
+
+        public int Count => _keys.Count;
+
+        public string KeyAt(int index) => _keys[index];
+
+        public bool TryGet(string key, out string value)
+        {
+            if (_store.TryGetValue(key, out var found))
+            {
+                value = found;
+                return true;
+            }
+
+            value = string.Empty;
+            return false;
+        }
+
+        public void Put(string key, string value)
+        {
+            Store(key, value);
+
+            // A key named like an interface member would replace the method with a string, leaving
+            // the area without the very method the page is about to call. A browser gets away with
+            // it because its methods live on the prototype and the named property merely shadows
+            // them per-object; here they are own properties, so the item stays readable through
+            // getItem/key/length and only the property mirror is skipped.
+            if (!InterfaceMembers.Contains(key))
+                base.SetValue((KeyString)key, new JSString(value), this, false);
+        }
+
+        public bool Remove(string key)
+        {
+            if (!_store.Remove(key))
+                return false;
+
+            _keys.Remove(key);
+            if (!InterfaceMembers.Contains(key))
+                base.Delete((KeyString)key);
+
+            return true;
+        }
+
+        public void RemoveAll()
+        {
+            foreach (var key in _keys)
+            {
+                if (!InterfaceMembers.Contains(key))
+                    base.Delete((KeyString)key);
+            }
+
+            _store.Clear();
+            _keys.Clear();
+        }
+
+        protected override bool SetValue(KeyString name, JSValue value, JSValue receiver, bool throwError = true)
+        {
+            var key = name.ToString();
+            if (!InterfaceMembers.Contains(key))
+                Store(key, value?.ToString() ?? "undefined");
+
+            return base.SetValue(name, value, receiver, throwError);
+        }
+
+        public override JSValue Delete(in KeyString key)
+        {
+            var name = key.ToString();
+            if (_store.Remove(name))
+                _keys.Remove(name);
+
+            return base.Delete(in key);
+        }
+
+        private void Store(string key, string value)
+        {
+            if (!_store.ContainsKey(key))
+                _keys.Add(key);
+
+            _store[key] = value;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Implements the complete Web Storage API with both `localStorage` and `sessionStorage` areas, plus the missing `Storage` interface members (`length` and `key()`). This fixes a critical issue where the absence of `sessionStorage` caused `ReferenceError` exceptions that aborted entire scripts on sites like mediawiki.org.

## Key Changes

- **Added `sessionStorage`**: Registered as a separate storage area alongside `localStorage`. Both are now available as unqualified globals and on `window`.
  
- **Completed Storage interface**: 
  - Added `length` property (read-only, returns count of stored items)
  - Added `key(n)` method (returns the nth key in insertion order, or null)
  - Made methods non-enumerable so `Object.keys()` and `for...in` loops yield only stored keys, not the four interface methods
  
- **Bidirectional property mirroring**: Direct property assignment (`storage.foo = 'bar'`) now stores the item and is visible to `getItem()`, `length`, and `key()`. Conversely, `setItem()` mirrors the value as a property.

- **Protected interface members**: Items named after interface methods (`getItem`, `setItem`, etc.) are stored but don't replace the actual methods, preventing accidental method shadowing.

- **Refactored implementation**:
  - Extracted storage logic into a `StorageObject` class that extends `JSObject` and maintains insertion-order tracking
  - Unified the DOM and CLI paths to use the same `WebStorageBinding.BuildStorage()` factory
  - Removed duplicate storage stub code from `CaptureService`

- **Added Storage interface global**: Registered `Storage` as a constructor function that answers `instanceof` checks based on the object's shape (presence of required methods and `length` property). This enables the canonical feature test `typeof Storage !== 'undefined'`.

## Implementation Details

- Storage areas are in-memory only; no persistence occurs
- Each call to `BuildStorage()` creates a separate area with its own backing dictionary
- Insertion order is preserved in a parallel list for `key(n)` enumeration
- The `StorageObject` class overrides `SetValue` and `Delete` to keep the property mirror and backing store in sync
- Interface members are tracked in a `HashSet<string>` to prevent accidental shadowing

## Testing

Added comprehensive test coverage in `WebStorageDomTests` and expanded `WebStorageBindingModuleTests` to verify:
- Both areas exist and are separate stores
- Enumeration via `length` and `key()` works correctly
- Bidirectional property/method equivalence
- Protection of interface members from shadowing
- `Storage` instanceof checks

https://claude.ai/code/session_01B6zDRBB4fcNwsBnjqj5api