### PR TITLE
Paint mirrored transforms (scaleX(-1), rotate(180deg), etc.)

### DIFF
--- a/Broiler.Documents/Broiler.Documents.Html/HtmlReader.cs
+++ b/Broiler.Documents/Broiler.Documents.Html/HtmlReader.cs
@@ -49,7 +49,7 @@ internal static class HtmlReader
         HtmlDocumentParseResult parse;
         try
         {
-            parse = new HtmlDocumentParser().ParseDocument(html);
+            parse = HtmlDocumentParser.ParseDocument(html);
         }
         catch (Exception ex)
         {

--- a/docs/wpt-reftests.md
+++ b/docs/wpt-reftests.md
@@ -1112,3 +1112,80 @@ absent because the script replaced the document element *before* EOF — not
 because head-only documents lack one. Passing them that way would be the same
 "both sides equally wrong" failure this document warns about elsewhere, bought
 at the price of a real regression.
+
+## A mirrored element painted nothing, and issue #1732's 0.0% list
+
+Issue #1732 ranks five reftests at a 0.0% match. Three of them are the ones the
+top-thirty triage above already names, and wpt.fyi settles them: **no shipping
+engine passes any of the three** on the aligned stable runs — Chrome, Edge,
+Firefox and Safari all fail `css/CSS2/box-display/root-box-003.xht`,
+`forced-colors-mode/forced-colors-mode-49.html` and
+`html/rendering/replaced-elements/images/abs-pos-transferred-max-width-from-percentage-max-height-in-auto-height-containing-block.html`.
+That is worth having on the record rather than re-derived each time the list
+regenerates: `root-box-003` asserts a `display: none` root propagating its
+background to the canvas, which every engine and this one deliberately decline
+(`PaintWalker.FindCanvasBackgroundAndImage`); `forced-colors-mode-49` is
+meaningful only when the run is in forced-colors mode, which neither this suite
+nor wpt.fyi's runs are; and the third names a bare 60×60 PNG as the `rel=match`
+of a full page that also carries a `<p>` of instructions. A fix for any of them
+would be a deviation, not a gain.
+
+The remaining two do pass in Chrome and Edge, and pulling on one of them found a
+bug much larger than the test:
+
+```sh
+dotnet run --project src/Broiler.Wpt -- --render /tmp/t.html   # <div style="transform:rotate(180deg);background:red">
+```
+
+**rendered a blank page.** So did `scaleX(-1)`, `scaleY(-1)` and `scale(-1)`:
+every axis-mirroring transform painted no pixels at all — background, borders,
+children and text alike — while `translate` and a positive `scale` were fine.
+
+The reason is one line deep. `GraphicsAdapter.SaveTransformLayer` prefers the
+raster canvas, which maps a point per axis as `p * scale + translation`, and
+`BCanvas.TrySaveTransform` accepts any matrix whose rotation/skew terms are zero
+— which a mirror is, and which `rotate(180deg)` becomes once its sine terms round
+away. But `BCanvas.Translate(RectangleF)` mapped a rectangle by scaling its
+*extent*, and a negative factor made that extent negative. Every primitive walks
+the rows and columns between `Left`/`Right` and `Top`/`Bottom`, so the rectangle
+spanned nothing. The transform was accepted, and then drew zero pixels; the
+compat backend that would otherwise have caught it is an inert stub here.
+
+That is why `css-break/transform-024-print` scored 0.0% rather than the partial
+score a mis-paginated five-page test would get: nothing inside the rotated
+container reached the canvas. It still fails — it is a `-print` test, so the
+default screen-mode run cannot measure what it was written to measure, and under
+`BROILER_WPT_PAGED_PRINT=1` it is at 10.0% — but it fails for its own reason now.
+
+The fix (submodule patch, subject *"Paint an element its transform mirrors"*)
+normalises the mapped rectangle and mirrors the primitives whose sampling reads
+*across* it rather than merely inside it — a bitmap, a tile phase, a gradient's
+endpoints, a radial or conic centre and sweep, a corner radius. Glyph outlines go
+through the per-point mapping and mirror on their own.
+
+**The scoreboard barely moves, and that is the point.** Across
+`css/css-transforms`, `css/compositing`, `css/css-backgrounds` and
+`css/css-images` — 2 020 reftests — it goes 1 242 → **1 243**. Three tests are
+gained (`transform-background-003`, `-004`, `ttwf-reftest-rotate`) and two are
+lost, both of which were passing for the wrong reason: a mirror on *each* side
+rendered nothing on *both*, so blank matched blank. `transform3d-scale-007` now
+shows the `rotateX(180deg)` its test side still does not support, and
+`animation/transform-interpolation-matrix` shows that its reference builds no
+boxes at all. This is the "both sides equally wrong" failure this document warns
+about elsewhere, caught in the act — and a reminder that a suite this narrow
+cannot score "a mirrored element renders at all", which is what actually changed.
+
+### `rotateX(180deg)` is exactly `scaleY(-1)`, and it was still not taken
+
+The obvious follow-on — reducing a half-turn about X or Y to the mirror it
+provably is, the same bargain `translate3d` and a 2D `matrix3d` already get in
+`PaintWalker.ParseCssTransformMatrix` — was written, measured and **reverted**.
+It gains `transform3d-scale-007` and `transform3d-sorting-002` and loses
+`backface-visibility-hidden-animated-001` and `-002`, because an element whose
+own transform is a half-turn about X or Y has its *back* face toward the viewer:
+with `backface-visibility: hidden` it must not be painted at all, and painting it
+mirrored is a new wrong answer where there was previously no answer. Deciding
+that needs the facing parity accumulated down each `preserve-3d` chain — the
+ancestor half-turn in those tests' references is exactly what cancels the
+element's own — which is the 3D pipeline this renderer does not have. The
+reduction is correct and worth taking *after* that, not before.

--- a/patches/0006-paint-an-element-its-transform-mirrors.patch
+++ b/patches/0006-paint-an-element-its-transform-mirrors.patch
@@ -1,0 +1,298 @@
+From 454886e72f312991723cd914c329729c985a413e Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 21 Aug 2026 07:11:18 +0000
+Subject: [PATCH] Paint an element its transform mirrors
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The raster canvas maps a point per axis as p * scale + translation, so a
+negative factor is expressible and TrySaveTransform accepts one: scaleX(-1),
+scale(-1) and rotate(180deg) — whose sine terms round to zero — all fold into
+_scaleX/_scaleY rather than falling back to the compat backend, which is a stub
+in the headless configuration.
+
+Expressible, but not drawn. Translate(RectangleF) mapped a rectangle by scaling
+its *extent*, which a negative factor made negative, and every primitive walks
+the rows and columns between Left/Right and Top/Bottom. A mirrored element
+therefore spanned nothing and painted no pixels at all — background, borders,
+children and text alike vanished, which is how css-break/transform-024-print
+came out blank where five coloured bands belong.
+
+Normalise the mapped rectangle so its extents are non-negative, and mirror the
+primitives whose sampling reads across it rather than merely inside it: a
+bitmap and a tile phase are read from the far end, a linear gradient's two
+endpoints are reflected in the rectangle, a radial or conic centre is measured
+from the opposite edge and the conic sweep runs the other way, and a corner
+radius travels to the corner the mirror moves it to. Glyph outlines already go
+through the per-point mapping, so they mirror on their own. Non-negative scale
+takes none of these branches and its arithmetic is untouched.
+
+Two WPT reftests stop passing for the wrong reason: transform3d-scale-007 and
+animation/transform-interpolation-matrix matched only because a mirror on each
+side rendered nothing on both. Both now show the gap they always had — an
+unsupported rotateX(180deg) on one side, an un-run animation on the other.
+---
+ Source/Broiler.HTML.Image/BCanvas.cs | 156 ++++++++++++++++++++++++---
+ 1 file changed, 142 insertions(+), 14 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Image/BCanvas.cs b/Source/Broiler.HTML.Image/BCanvas.cs
+index 4b7455c..8131c02 100644
+--- a/Source/Broiler.HTML.Image/BCanvas.cs
++++ b/Source/Broiler.HTML.Image/BCanvas.cs
+@@ -38,6 +38,18 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+     private float _scaleX = 1f;
+     private float _scaleY = 1f;
+ 
++    /// <summary>Whether the current mapping mirrors the X axis (a negative <see cref="_scaleX"/>).</summary>
++    /// <remarks>
++    /// <see cref="Translate(RectangleF)"/> normalises a mirrored rectangle so it encloses the right
++    /// pixels, which is all a solid fill needs. A primitive that samples <em>content</em> across
++    /// that rectangle — a bitmap, a tile phase, a gradient ramp — needs the mirror as well, or it
++    /// paints the unmirrored picture in the mirrored place. These two say which axes to reverse.
++    /// </remarks>
++    private bool FlipX => _scaleX < 0f;
++
++    /// <summary>Whether the current mapping mirrors the Y axis (a negative <see cref="_scaleY"/>).</summary>
++    private bool FlipY => _scaleY < 0f;
++
+     /// <summary>
+     /// A view of <paramref name="source"/>'s surface restricted to <paramref name="deviceTile"/>,
+     /// carrying the transform and clip state <paramref name="source"/> has right now. See
+@@ -120,6 +132,12 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+     /// including <em>non-uniform</em> scale (<c>scaleX</c>/<c>scaleY</c>/<c>scale(x, y)</c>) — are
+     /// folded into <see cref="_scaleX"/>/<see cref="_scaleY"/>/<see cref="_translation"/> so
+     /// transformed content actually rasterises instead of vanishing when the compat backend is a stub.
++    /// <para>
++    /// A <em>negative</em> factor is one of those: a mirror (<c>scaleX(-1)</c>, <c>scale(-1)</c>)
++    /// and the half-turn <c>rotate(180deg)</c> — whose <c>b</c>/<c>c</c> terms are zero — map each
++    /// axis onto itself reversed, which this canvas expresses. See <see cref="FlipX"/> for what the
++    /// primitives do with it.
++    /// </para>
+     /// </summary>
+     public bool TrySaveTransform(float[] matrix, float originX, float originY)
+     {
+@@ -191,13 +209,36 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+         double cornerSe,
+         double cornerSeY,
+         double cornerSw,
+-        double cornerSwY) =>
++        double cornerSwY)
++    {
++        // A mirrored axis moves each corner to the opposite side of the normalised rectangle, so
++        // the radii travel with it: the north-west corner of a horizontally mirrored box is drawn
++        // where north-east now is. Scaling a radius by a negative axis would also make it negative,
++        // which no corner can be.
++        float sx = MathF.Abs(_scaleX);
++        float sy = MathF.Abs(_scaleY);
++        var corners = new[]
++        {
++            ((float)cornerNw * sx, (float)cornerNwY * sy),
++            ((float)cornerNe * sx, (float)cornerNeY * sy),
++            ((float)cornerSe * sx, (float)cornerSeY * sy),
++            ((float)cornerSw * sx, (float)cornerSwY * sy),
++        };
++
++        // Indices into `corners` for NW, NE, SE, SW after the mirrors.
++        int nw = 0, ne = 1, se = 2, sw = 3;
++        if (FlipX)
++            (nw, ne, se, sw) = (ne, nw, sw, se);
++        if (FlipY)
++            (nw, ne, se, sw) = (sw, se, ne, nw);
++
+         AddClip(ClipOperation.IncludeRounded(
+             Translate(rect),
+-            (float)cornerNw * _scaleX, (float)cornerNwY * _scaleY,
+-            (float)cornerNe * _scaleX, (float)cornerNeY * _scaleY,
+-            (float)cornerSe * _scaleX, (float)cornerSeY * _scaleY,
+-            (float)cornerSw * _scaleX, (float)cornerSwY * _scaleY));
++            corners[nw].Item1, corners[nw].Item2,
++            corners[ne].Item1, corners[ne].Item2,
++            corners[se].Item1, corners[se].Item2,
++            corners[sw].Item1, corners[sw].Item2));
++    }
+ 
+     public void PopClip()
+     {
+@@ -299,7 +340,9 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+         var p2 = Translate(end);
+         // Stroke width has no single value under non-uniform scale; use the geometric mean of the
+         // axis scales (equal to the uniform scale when scaleX == scaleY, so byte-identical there).
+-        float radius = Math.Max(0.5f, strokeWidth * MathF.Sqrt(_scaleX * _scaleY) / 2f);
++        // Absolute values: a mirrored axis is still the same magnification, and a single negative
++        // factor would make the product negative and the square root NaN.
++        float radius = Math.Max(0.5f, strokeWidth * MathF.Sqrt(MathF.Abs(_scaleX * _scaleY)) / 2f);
+ 
+         int minX = (int)Math.Floor(Math.Min(p1.X, p2.X) - radius);
+         int minY = (int)Math.Floor(Math.Min(p1.Y, p2.Y) - radius);
+@@ -588,6 +631,9 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+         if (!NarrowToClip(ref startX, ref startY, ref endX, ref endY))
+             return;
+ 
++        bool flipX = FlipX;
++        bool flipY = FlipY;
++
+         // A scaled draw needs a filter. Point sampling is exact when the destination is the
+         // source's own size, but at any other size it quantises every sample to one source
+         // pixel: at a 330->320 downscale it drops ten columns outright, and a photo comes out
+@@ -610,6 +656,13 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+                     if (normalizedX < 0f || normalizedX >= 1f || normalizedY < 0f || normalizedY >= 1f)
+                         continue;
+ 
++                    // Under a mirrored axis the destination rectangle was normalised, so walking it
++                    // left-to-right walks the source right-to-left: read the source from the far end.
++                    if (flipX)
++                        normalizedX = 1f - normalizedX;
++                    if (flipY)
++                        normalizedY = 1f - normalizedY;
++
+                     BColor sample;
+                     if (scaled)
+                     {
+@@ -702,6 +755,9 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+         if (!NarrowToClip(ref minX, ref minY, ref maxX, ref maxY))
+             return;
+ 
++        bool flipX = FlipX;
++        bool flipY = FlipY;
++
+         ForEachBand(minY, maxY, minX, maxX, (fromY, toY) =>
+         {
+             for (int y = fromY; y <= toY; y++)
+@@ -713,12 +769,23 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+ 
+                     float sampleX = x + 0.5f;
+                     float sampleY = y + 0.5f;
++
++                    // The tile phase runs along the element's own axes. A mirrored axis reverses
++                    // the offset from the tile origin, which mirrors both the tiling order and the
++                    // tile's own content — reading the source at the local coordinate does both.
++                    float phaseX = sampleX - translatedOrigin.X;
++                    float phaseY = sampleY - translatedOrigin.Y;
++                    if (flipX)
++                        phaseX = -phaseX;
++                    if (flipY)
++                        phaseY = -phaseY;
++
+                     int srcX = Math.Clamp(
+-                        (int)Math.Floor(srcRect.Left + PositiveModulo(sampleX - translatedOrigin.X, srcRect.Width)),
++                        (int)Math.Floor(srcRect.Left + PositiveModulo(phaseX, srcRect.Width)),
+                         0,
+                         source.Width - 1);
+                     int srcY = Math.Clamp(
+-                        (int)Math.Floor(srcRect.Top + PositiveModulo(sampleY - translatedOrigin.Y, srcRect.Height)),
++                        (int)Math.Floor(srcRect.Top + PositiveModulo(phaseY, srcRect.Height)),
+                         0,
+                         source.Height - 1);
+                     BlendPixel(CurrentTarget, x, y, source.GetPixel(srcX, srcY), blendMode: "normal");
+@@ -747,6 +814,13 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+             return;
+         var normalizedPositions = NormalizeGradientPositions(colors.Count, positions);
+         var (startPoint, endPoint) = GetGradientEndpoints(translatedRect, angle);
++
++        // The gradient line is stated in the element's own space. A mirrored axis reflects it
++        // inside the (already normalised) rectangle — reflecting the two endpoints is that same
++        // reflection, and it keeps the ramp attached to the edges the author aimed it at.
++        startPoint = MirrorInto(startPoint, translatedRect);
++        endPoint = MirrorInto(endPoint, translatedRect);
++
+         float gradientX = endPoint.X - startPoint.X;
+         float gradientY = endPoint.Y - startPoint.Y;
+         float gradientLengthSquared = (gradientX * gradientX) + (gradientY * gradientY);
+@@ -804,8 +878,10 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+ 
+         var normalizedPositions = NormalizeGradientPositions(colors.Count, positions);
+ 
+-        float cx = translatedRect.Left + (centerX * translatedRect.Width);
+-        float cy = translatedRect.Top + (centerY * translatedRect.Height);
++        // The centre is a fraction of the element's own box, so a mirrored axis measures it from
++        // the opposite edge of the (already normalised) rectangle.
++        float cx = translatedRect.Left + ((FlipX ? 1f - centerX : centerX) * translatedRect.Width);
++        float cy = translatedRect.Top + ((FlipY ? 1f - centerY : centerY) * translatedRect.Height);
+ 
+         // Radii to farthest corner (elliptical, one per axis).
+         float rx = Math.Max(Math.Abs(cx - translatedRect.Left), Math.Abs(cx - translatedRect.Right));
+@@ -862,8 +938,13 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+ 
+         var normalizedPositions = NormalizeGradientPositions(colors.Count, positions);
+ 
+-        float cx = translatedRect.Left + (centerX * translatedRect.Width);
+-        float cy = translatedRect.Top + (centerY * translatedRect.Height);
++        // The centre is a fraction of the element's own box, so a mirrored axis measures it from
++        // the opposite edge of the (already normalised) rectangle.
++        float cx = translatedRect.Left + ((FlipX ? 1f - centerX : centerX) * translatedRect.Width);
++        float cy = translatedRect.Top + ((FlipY ? 1f - centerY : centerY) * translatedRect.Height);
++
++        bool flipX = FlipX;
++        bool flipY = FlipY;
+ 
+         ForEachBand(minY, maxY, minX, maxX, (fromY, toY) =>
+         {
+@@ -877,6 +958,14 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+                     float dx = x + 0.5f - cx;
+                     float dy = y + 0.5f - cy;
+ 
++                    // The sweep is measured in the element's own space. Reversing the offset on a
++                    // mirrored axis reflects the sweep with the element, so a single mirrored axis
++                    // reverses the colour order and mirroring both is the 180deg rotation it is.
++                    if (flipX)
++                        dx = -dx;
++                    if (flipY)
++                        dy = -dy;
++
+                     // atan2(dx, -dy) yields 0 at 12 o'clock and increases clockwise.
+                     float angleDeg = (float)(Math.Atan2(dx, -dy) * 180.0 / Math.PI);
+                     float t = PositiveModulo(angleDeg - fromAngleDeg, 360f) / 360f;
+@@ -941,8 +1030,47 @@ internal sealed class BCanvas(BBitmap bitmap) : IDisposable
+ 
+     private BBitmap CurrentTarget => _layerStack.Count > 0 ? _layerStack.Peek().Bitmap : _rootBitmap;
+ 
+-    private RectangleF Translate(RectangleF rect) =>
+-        new(rect.X * _scaleX + _translation.X, rect.Y * _scaleY + _translation.Y, rect.Width * _scaleX, rect.Height * _scaleY);
++    /// <summary>
++    /// Maps a canvas-local rectangle to device space, normalised so the extents are non-negative.
++    /// </summary>
++    /// <remarks>
++    /// A negative axis scale — <c>scaleX(-1)</c>, <c>scale(-1)</c>, <c>rotate(180deg)</c> — mirrors
++    /// the rectangle about that axis, which leaves the mapped X/Y on what is now the far edge and
++    /// the extent negative. Every primitive here reads <c>Left</c>/<c>Top</c>/<c>Right</c>/
++    /// <c>Bottom</c> and walks the rows and columns between them, so an un-normalised rectangle
++    /// spans nothing and the mirrored element vanishes outright. Non-negative scale takes neither
++    /// branch, so its arithmetic is untouched.
++    /// </remarks>
++    private RectangleF Translate(RectangleF rect)
++    {
++        float x = rect.X * _scaleX + _translation.X;
++        float y = rect.Y * _scaleY + _translation.Y;
++        float width = rect.Width * _scaleX;
++        float height = rect.Height * _scaleY;
++
++        if (width < 0f)
++        {
++            x += width;
++            width = -width;
++        }
++
++        if (height < 0f)
++        {
++            y += height;
++            height = -height;
++        }
++
++        return new RectangleF(x, y, width, height);
++    }
++
++    /// <summary>
++    /// Reflects a device-space point inside <paramref name="bounds"/> across whichever axes the
++    /// current mapping mirrors. A point already in the rectangle stays in it.
++    /// </summary>
++    private PointF MirrorInto(PointF point, RectangleF bounds) =>
++        new(
++            FlipX ? bounds.Left + bounds.Right - point.X : point.X,
++            FlipY ? bounds.Top + bounds.Bottom - point.Y : point.Y);
+ 
+     private PointF Translate(PointF point) =>
+         new(point.X * _scaleX + _translation.X, point.Y * _scaleY + _translation.Y);
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # Submodule patches waiting to be applied
 
-**Five patches are waiting on a maintainer.** See the index below.
+**Six patches are waiting on a maintainer.** See the index below.
 
 `Broiler.HTML`, `Broiler.CSS`, `Broiler.DOM`, `Broiler.JS` and `Broiler.Graphics`
 are git submodules with their own remotes. A session whose GitHub scope is this
@@ -55,6 +55,7 @@ again with the one below.
 | `0003` | `Broiler.HTML` | Carry a block image's page name onto the box that replaces it |
 | `0004` | `Broiler.CSS` | Give `<legend>` the user-agent `display: block` it has in HTML |
 | `0005` | `Broiler.HTML` | The same, in the default style sheet |
+| `0006` | `Broiler.HTML` | Paint an element its transform mirrors |
 
 ### `0001` — `border: 72pt solid red` painted a thin black line
 
@@ -203,3 +204,44 @@ content in it and does not get there on the legend alone. `css/css-sizing` holds
 at 74 of 112 with both of its fieldset `aspect-ratio` tests at 100%, and
 `css/css-page` (paged and default), `css/CSS2`, `css/css-backgrounds` and
 `css/css-values` do not move.
+
+### `0006` — a mirrored element painted nothing at all
+
+The raster canvas maps a point per axis as `p * scale + translation`, so a
+*negative* factor is expressible on it and `TrySaveTransform` accepts one:
+`scaleX(-1)`, `scaleY(-1)`, `scale(-1)` and the half-turn `rotate(180deg)` —
+whose sine terms round to zero — all fold into `_scaleX`/`_scaleY` rather than
+falling back to the compat backend, which is an inert stub on a host with no OS
+backend.
+
+Expressible, but not drawn. `Translate(RectangleF)` mapped a rectangle by scaling
+its **extent**, which a negative factor made negative, and every primitive walks
+the rows and columns between `Left`/`Right` and `Top`/`Bottom`. A mirrored
+element therefore spanned nothing: background, borders, children and text all
+vanished. It is the same shape of failure as a stroke that misses the raster fast
+path — not coarser output, *absent* output — and it is why
+`css-break/transform-024-print` rendered a blank page where five coloured bands
+belong.
+
+The fix normalises the mapped rectangle and mirrors the primitives whose sampling
+reads *across* it rather than merely inside it: a bitmap and a tile phase are read
+from the far end, a linear gradient's endpoints are reflected in the rectangle, a
+radial or conic centre is measured from the opposite edge and the conic sweep runs
+the other way, and a corner radius travels to the corner the mirror moves it to.
+Glyph outlines already go through the per-point mapping, so they mirror on their
+own. Non-negative scale takes none of the new branches and its arithmetic is
+untouched.
+
+**Measured** across `css/css-transforms`, `css/compositing`, `css/css-backgrounds`
+and `css/css-images` — 2020 reftests — the suite goes 1242 → **1243** passing.
+The gains are `transform-background-003`, `-004` and `ttwf-reftest-rotate`; the
+two losses were passing for the wrong reason and now show the gap they always
+had, a mirror on each side having rendered nothing on both:
+`transform3d-scale-007` (an unsupported `rotateX(180deg)` on the test side) and
+`animation/transform-interpolation-matrix` (its reference builds no boxes).
+That small a net move understates it — what the patch buys is that a mirrored
+element renders *at all*, which no count of a suite this narrow shows.
+
+The main-repo half is `src/Broiler.Cli.Tests/MirroredTransformPaintTests.cs`,
+which feature-probes the pinned pointer and self-skips there. `scripts/apply-pending-wpt-patches.sh`
+lists this patch, so a WPT run exercises it.

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -253,7 +253,16 @@ set -euo pipefail
 # was being dropped — `page-name-img-003`/`-004` broke a page their references do not. It only
 # moves pixels under BROILER_WPT_PAGED_PRINT=1, where the page name is read at all; the default
 # unpaginated render is unchanged.
+# 0006 paints an element its transform mirrors. Without it a `scaleX(-1)`, `scale(-1)` or
+# `rotate(180deg)` box paints *nothing at all* — the raster canvas mapped its rectangle to a
+# negative extent, which spans no rows or columns — and the compat backend it would otherwise
+# fall back to is an inert stub on a host with no OS backend. That is the same failure mode as
+# the dashed-stroke and anonymous-table entries above: not slower or coarser output, but absent
+# output. Its geometry is unit-tested in the main repo (MirroredTransformPaintTests), which
+# feature-probes and self-skips until this is applied; only the pixel suite can say a mirrored
+# element reached the canvas.
 PENDING_PATCHES=(
+  "Broiler.HTML|patches/0006-paint-an-element-its-transform-mirrors.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/Broiler.Cli.Tests/GraphicsAbstractionTests.cs
+++ b/src/Broiler.Cli.Tests/GraphicsAbstractionTests.cs
@@ -216,7 +216,7 @@ public class GraphicsAbstractionTests
     public void HtmlContainer_Typed_And_Serialized_Paths_Produce_Equivalent_Fragment_Trees()
     {
         const string html = "<html><body style='margin:0'><div id='target' style='width:20px;height:10px'>value</div></body></html>";
-        var document = new HtmlDocumentParser().ParseDocument(html).Document;
+        var document = HtmlDocumentParser.ParseDocument(html).Document;
 
         using var serialized = new HtmlContainer();
         using var typed = new HtmlContainer();
@@ -236,7 +236,7 @@ public class GraphicsAbstractionTests
     [Fact]
     public void HtmlContainer_Typed_Path_Rebuilds_After_Canonical_Dom_Mutation()
     {
-        var document = new HtmlDocumentParser()
+        var document = HtmlDocumentParser
             .ParseDocument("<html><body style='margin:0'><div id='target' style='width:20px;height:10px'></div></body></html>")
             .Document;
         var target = document.GetElementById("target")!;

--- a/src/Broiler.Cli.Tests/MirroredTransformPaintTests.cs
+++ b/src/Broiler.Cli.Tests/MirroredTransformPaintTests.cs
@@ -1,0 +1,145 @@
+using Broiler.HTML.Image;
+using BColor = Broiler.Graphics.BColor;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Pixel-level regression tests for transforms that <em>mirror</em> an axis — <c>scaleX(-1)</c>,
+/// <c>scaleY(-1)</c>, <c>scale(-1)</c> and the half-turn <c>rotate(180deg)</c>, whose matrix is
+/// <c>scale(-1, -1)</c> once the vanishing sine terms are rounded away.
+/// <para>
+/// The raster canvas maps a point per axis as <c>p * scale + translation</c>, so a negative factor
+/// is expressible — but it mapped a rectangle by scaling its <em>extent</em>, which came out
+/// negative. Every primitive walks the rows and columns between <c>Left</c>/<c>Right</c> and
+/// <c>Top</c>/<c>Bottom</c>, so such a rectangle spanned nothing: a mirrored element painted no
+/// pixels at all, background and children alike. (The compat backend that the fuller transforms
+/// fall back to is a stub in this configuration, so nothing picked the work back up.)
+/// </para>
+/// <para>
+/// Ships as a <c>Broiler.HTML</c> submodule change — commit subject <c>"Paint an element its
+/// transform mirrors"</c> — which the session cannot push, so it is carried as a file under
+/// <c>patches/</c> until a maintainer applies it. The pinned pointer therefore still vanishes the
+/// mirrored box, and these cases feature-probe and self-skip there rather than going red; they
+/// verify the fix on the patched engine. Check whether it is live with
+/// <c>git -C Broiler.HTML log --oneline --grep 'Paint an element its transform mirrors'</c>.
+/// </para>
+/// </summary>
+public sealed class MirroredTransformPaintTests
+{
+    private static bool Near(BColor c, int r, int g, int b) =>
+        Math.Abs(c.R - r) <= 6 && Math.Abs(c.G - g) <= 6 && Math.Abs(c.B - b) <= 6;
+
+    private static string Describe(BColor c) => $"rgb({c.R},{c.G},{c.B})";
+
+    /// <summary>
+    /// A 200×100 red container whose first 50×50 is a blue child, so the two halves of the box are
+    /// told apart by colour and a mirror is visible as the blue square changing corners.
+    /// </summary>
+    private static string Doc(string transform) =>
+        "<!DOCTYPE html><html><head></head>"
+        + "<body style=\"margin:0\">"
+        + $"<div style=\"width:200px;height:100px;background:#ff0000;transform:{transform}\">"
+        + "<div style=\"width:50px;height:50px;background:#0000ff\"></div>"
+        + "</div></body></html>";
+
+    /// <summary>
+    /// Does the pinned engine paint a mirrored element at all? The centre of the container is red
+    /// under every transform here and white only when the whole box was dropped.
+    /// </summary>
+    private static bool MirroredTransformsPaint()
+    {
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(Doc("rotate(180deg)"), 300, 200);
+        return Near(bitmap.GetPixel(100, 50), 255, 0, 0);
+    }
+
+    /// <summary>
+    /// The blue child sits at the container's top-left. Each mirror moves it to the corner the
+    /// mirror maps that one to, and the corner it left becomes the container's red.
+    /// <list type="bullet">
+    /// <item><c>scaleX(-1)</c>: top-left → top-right.</item>
+    /// <item><c>scaleY(-1)</c>: top-left → bottom-left.</item>
+    /// <item><c>scale(-1)</c> and <c>rotate(180deg)</c>: top-left → bottom-right.</item>
+    /// </list>
+    /// Coordinates are the centres of the 50×50 quadrant squares of the 200×100 box.
+    /// </summary>
+    [Theory]
+    [InlineData("none", 25, 25)]
+    [InlineData("scaleX(-1)", 175, 25)]
+    [InlineData("scaleY(-1)", 25, 75)]
+    [InlineData("scale(-1)", 175, 75)]
+    [InlineData("rotate(180deg)", 175, 75)]
+    public void MirroredTransform_MovesTheChildToTheMirroredCorner(string transform, int blueX, int blueY)
+    {
+        if (!MirroredTransformsPaint())
+            return; // submodule patch not applied to the pinned pointer; see class remarks.
+
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(Doc(transform), 300, 200);
+
+        var atChild = bitmap.GetPixel(blueX, blueY);
+        Assert.True(Near(atChild, 0, 0, 255),
+            $"[transform:{transform}] the child should land at ({blueX},{blueY}), got {Describe(atChild)}");
+
+        // The corner it came from — mirrored back — is now the container's own red.
+        int fromX = blueX == 25 ? 175 : 25;
+        int fromY = blueY == 25 ? 75 : 25;
+        var vacated = bitmap.GetPixel(fromX, fromY);
+        Assert.True(Near(vacated, 255, 0, 0),
+            $"[transform:{transform}] ({fromX},{fromY}) should be the container's red, got {Describe(vacated)}");
+    }
+
+    /// <summary>
+    /// The mirrored box still covers exactly the box it covered before — a mirror about the
+    /// element's own centre is area-preserving. Guards the normalisation against moving the
+    /// rectangle instead of reversing it: a point just inside each edge is painted, and a point
+    /// just outside is the white canvas.
+    /// </summary>
+    [Fact]
+    public void MirroredTransform_KeepsTheBoxWhereItWas()
+    {
+        if (!MirroredTransformsPaint())
+            return; // submodule patch not applied to the pinned pointer; see class remarks.
+
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(Doc("rotate(180deg)"), 300, 200);
+
+        var inside = bitmap.GetPixel(198, 98);
+        Assert.False(Near(inside, 255, 255, 255),
+            $"(198,98) is inside the 200x100 box and must be painted, got {Describe(inside)}");
+
+        var outside = bitmap.GetPixel(202, 50);
+        Assert.True(Near(outside, 255, 255, 255),
+            $"(202,50) is past the box's right edge and must stay white, got {Describe(outside)}");
+    }
+
+    /// <summary>
+    /// A gradient is stated along the element's own axes, so a horizontal mirror reverses which
+    /// edge each end of the ramp is attached to. Without that the ramp would keep its device-space
+    /// direction and the mirrored element would be painted with an unmirrored fill.
+    /// </summary>
+    [Fact]
+    public void MirroredTransform_ReversesALinearGradient()
+    {
+        if (!MirroredTransformsPaint())
+            return; // submodule patch not applied to the pinned pointer; see class remarks.
+
+        static string Gradient(string transform) =>
+            "<!DOCTYPE html><html><head></head><body style=\"margin:0\">"
+            + $"<div style=\"width:200px;height:100px;transform:{transform};"
+            + "background:linear-gradient(to right, #0000ff, #ff0000)\"></div>"
+            + "</body></html>";
+
+        using var plain = HtmlRender.RenderToImageWithStyleSet(Gradient("none"), 300, 200);
+        using var mirrored = HtmlRender.RenderToImageWithStyleSet(Gradient("scaleX(-1)"), 300, 200);
+
+        // `to right` ramps blue -> red, so unmirrored the left end is the blue one and the right
+        // end the red one. Mirrored, each column carries what the column opposite it carried.
+        Assert.True(plain.GetPixel(10, 50).B > plain.GetPixel(190, 50).B,
+            "sanity: the unmirrored ramp should start blue at the left");
+
+        var left = mirrored.GetPixel(10, 50);
+        var right = mirrored.GetPixel(190, 50);
+        Assert.True(left.R > left.B,
+            $"scaleX(-1) should put the gradient's red end on the left, got {Describe(left)}");
+        Assert.True(right.B > right.R,
+            $"scaleX(-1) should put the gradient's blue end on the right, got {Describe(right)}");
+    }
+}

--- a/src/Broiler.Cli.Tests/Phase5SharedCascadeTests.cs
+++ b/src/Broiler.Cli.Tests/Phase5SharedCascadeTests.cs
@@ -75,7 +75,7 @@ public sealed class Phase5SharedCascadeTests
 
     private static (Broiler.CSS.Dom.CssStyleEngine Engine, CssBox Root) Build(string html)
     {
-        var document = new HtmlDocumentParser().ParseDocument(html).Document;
+        var document = HtmlDocumentParser.ParseDocument(html).Document;
         var root = HtmlParser.ParseDocument(document, new Uri("file:///t.html"));
         var styleStart = html.IndexOf("<style>", StringComparison.OrdinalIgnoreCase);
         var styleEnd = html.IndexOf("</style>", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
## Summary

Fixes a critical bug where elements with axis-mirroring transforms (`scaleX(-1)`, `scaleY(-1)`, `scale(-1)`, `rotate(180deg)`) painted no pixels at all — background, borders, children, and text all vanished. The raster canvas accepted these transforms but failed to render them because rectangle mapping produced negative extents that spanned zero rows/columns.

## Changes

**Submodule patch** (`patches/0006-paint-an-element-its-transform-mirrors.patch`):
- Normalizes mapped rectangles so extents are always non-negative, allowing primitives to walk valid row/column ranges
- Mirrors content-sampling primitives across the appropriate axes:
  - Bitmaps and tile phases read from the far end
  - Linear gradient endpoints are reflected in the rectangle
  - Radial/conic gradient centres measure from the opposite edge; conic sweeps reverse direction
  - Corner radii travel to the mirrored corner
- Glyph outlines already mirror correctly via per-point mapping
- Non-negative scale paths remain untouched

**Main repo**:
- `src/Broiler.Cli.Tests/MirroredTransformPaintTests.cs`: Pixel-level regression tests verifying mirrored transforms render correctly and preserve element bounds. Tests feature-probe the pinned pointer and self-skip if the patch is not yet applied.
- `docs/wpt-reftests.md`: Documents the bug, fix, and WPT impact (1242 → 1243 passing across 2020 transforms/compositing/backgrounds/images tests)
- `patches/README.md`: Adds patch index entry and detailed explanation
- `scripts/apply-pending-wpt-patches.sh`: Includes patch in WPT test runs

## Impact

- **WPT**: +3 tests passing (`transform-background-003`, `-004`, `ttwf-reftest-rotate`); −2 tests that were passing for the wrong reason (both sides rendered nothing, now showing actual gaps)
- **Correctness**: Mirrored elements now render at all, fixing blank output in tests like `css-break/transform-024-print`
- **Scope**: Patch is in `Broiler.HTML` submodule; pointer bump pending maintainer application

https://claude.ai/code/session_017YHqh4bZdboDyEKWciN7ML