### PR TITLE
Fix frame deferred callbacks and idle callback deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,25 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- `img.src` is a string. `HTMLImageElement` carried nothing but `width`/`height`,
+  so every other IDL attribute in the interface read back as `undefined` — not the
+  empty string a missing content attribute reflects as — and the first string
+  method a caller reached for threw on it. `www.mediawiki.org`'s start page died
+  exactly there: MultimediaViewer walks the page's thumbnails, hands each one's
+  `src` to `mw.util.parseImageUrl`, and that function opens with `url.match( … )`.
+  Because MediaWiki serves its modules as one `load.php` bundle, the throw took
+  the thumbnail walk and everything queued behind it down with it.
+  - `src` and `currentSrc` are resolved URLs, as they are in a browser, and the
+    absolute one even when the content attribute is relative. `currentSrc` reports
+    the empty string when there is no `src` to settle on, so the
+    `img.currentSrc || img.src` idiom reaches its second operand rather than a
+    page URL manufactured out of an absent attribute.
+  - `alt`, `srcset`, `sizes`, `useMap`, `isMap`, `crossOrigin`, `referrerPolicy`,
+    `decoding`, `loading` and `fetchPriority` reflect their content attributes in
+    both directions. Writing one used to set a plain JS property on the wrapper
+    that no content attribute — and so no layout, cascade or serialization — ever
+    saw.
+
 - `sessionStorage` exists. Only `localStorage` was ever registered, and because
   `window` **is** the global object, the bare `sessionStorage` a page writes was a
   `ReferenceError` rather than an undefined property — which aborts the entire

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,26 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- Work a frame defers runs in the frame's browsing context. Every document shares
+  one JavaScript context here and the queue drain runs from C# with no context
+  pushed, so a callback woke up in the **main** one: a frame's `setTimeout`,
+  `setInterval`, `requestAnimationFrame` and `requestIdleCallback` callbacks saw
+  the *parent's* `document`, `location` and `window`. Looking up one of the
+  frame's own elements returned null, and the callback then either threw — caught
+  by the drain and logged, leaving no trace in the page at all — or quietly
+  mutated the wrong document. The frame's synchronous script was always correct,
+  which made the failure look like "frames don't run scripts" rather than what it
+  was; deferring to a timer is how most framed script does anything, so this was
+  most of what a frame could do.
+  - A callback is now bound to the browsing context that registered it and
+    re-enters it when the queue drains — including a callback registered from
+    inside another frame callback, which is the shape of every self-rescheduling
+    loop. The rAF timestamp and the `IdleDeadline` are forwarded through the
+    switch rather than dropped.
+  - Only frames pay for it. A main-window registration is left unwrapped, so
+    `setTimeout` — which busy pages call constantly — keeps its allocation-free
+    path and no per-tick save/restore.
+
 - An idle callback is handed an `IdleDeadline`. `requestIdleCallback` was a bare
   alias of `setTimeout`, which invokes its callback with no arguments at all, so
   the parameter every caller destructures was `undefined` and the first thing they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,27 @@ are versioned in lockstep during the preview.
 
 ### Fixed
 
+- An idle callback is handed an `IdleDeadline`. `requestIdleCallback` was a bare
+  alias of `setTimeout`, which invokes its callback with no arguments at all, so
+  the parameter every caller destructures was `undefined` and the first thing they
+  do with it — `deadline.timeRemaining()` — threw. That is not a peripheral API:
+  MediaWiki's ResourceLoader *evaluates its module implementations* inside an idle
+  callback, looping until `timeRemaining()` reaches 0, and its key-value store
+  walks `localStorage` in another.
+  - `timeRemaining()` reports a 50 ms budget — Background Tasks §2.2's cap —
+    measured from the moment the callback is entered, so a page draining a queue
+    makes progress and then yields. A budget pinned at 0 would be worse than the
+    throw for the common `while (deadline.timeRemaining() > n) { … }` loop: it
+    reschedules for ever without shifting a single item.
+  - `didTimeout` is true when the page passed a `{ timeout }`, because a headless
+    drain has no idle period the callback could have been run in earlier — it is
+    running because that deadline arrived.
+  - The second argument is an options dictionary, not a delay. Read through the
+    `setTimeout` adapter it came out `NaN` and was clamped to 0, so a page's
+    timeout was silently discarded; it is read out of the dictionary now.
+  - `cancelIdleCallback` still cancels: the handle comes from the timer id space,
+    which is what makes it the same thing `clearTimeout` acts on.
+
 - `img.src` is a string. `HTMLImageElement` carried nothing but `width`/`height`,
   so every other IDL attribute in the interface read back as `undefined` — not the
   empty string a missing content attribute reflects as — and the first string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,14 @@ are versioned in lockstep during the preview.
     timeout was silently discarded; it is read out of the dictionary now.
   - `cancelIdleCallback` still cancels: the handle comes from the timer id space,
     which is what makes it the same thing `clearTimeout` acts on.
+  - Both are mirrored onto a nested browsing context's `window`, beside the
+    animation-frame pair they were the only scheduling API missing next to. The
+    bare name always resolved — it is a context global and every document shares
+    the one context — so what was `undefined` is the qualified read, which is the
+    spelling pages actually use: the standard feature test is
+    `window.requestIdleCallback ? … : fallback`, and inside a frame `window` **is**
+    the sub-window. A framed page therefore took its no-native path, and one that
+    called `window.requestIdleCallback(cb)` unguarded got a TypeError.
 
 - `img.src` is a string. `HTMLImageElement` carried nothing but `width`/`height`,
   so every other IDL attribute in the interface read back as `undefined` — not the

--- a/docs/mediawiki-vector-rendering.md
+++ b/docs/mediawiki-vector-rendering.md
@@ -134,6 +134,13 @@ rest of what the skin needs turned up in order:
   with it. Both areas are now registered, with the `length`/`key()` pair and the named-property
   access (`storage.foo`) that go with them, and a `Storage` interface global for the
   `typeof Storage !== 'undefined'` feature test.
+* `HTMLImageElement` carried nothing but `width`/`height`, so **`img.src` was `undefined`** — not
+  the empty string a missing content attribute reflects as. MultimediaViewer's bootstrap walks the
+  page's thumbnails and hands each one's `src` to `mw.util.parseImageUrl`, which opens with
+  `url.match( … )`: "Cannot get property match of undefined". One bundle again, so that throw took
+  the rest of it. `src` and `currentSrc` are now resolved URLs, and `alt`, `srcset`, `sizes`,
+  `useMap`, `isMap` and the fetch hints reflect their content attributes in both directions —
+  writing one used to set a plain JS property on the wrapper that nothing else in the engine saw.
 
 ## What is left
 

--- a/docs/mediawiki-vector-rendering.md
+++ b/docs/mediawiki-vector-rendering.md
@@ -125,6 +125,15 @@ rest of what the skin needs turned up in order:
   stayed in the page column (~130px of displacement) and the site notice never appeared.
 * `history.pushState`/`replaceState`/`state`/`scrollRestoration`, `PerformanceObserver` and
   `requestIdleCallback` were missing, and each threw out of a module the skin loads.
+* `requestIdleCallback` then existed but was a bare alias of `setTimeout`, which invokes its callback
+  with no arguments — so the `IdleDeadline` parameter was `undefined` and `deadline.timeRemaining()`
+  threw. ResourceLoader **evaluates its module implementations** inside an idle callback
+  (`asyncEvalTask` loops until `timeRemaining() <= 0`) and the storage store walks `localStorage` in
+  another, so this was the last two failures on the page. The callback now gets a real deadline: a
+  50ms budget (Background Tasks §2.2's cap) measured from the moment it is entered, and a
+  `didTimeout` that is true when the page passed `{ timeout }` — there being no idle period here for
+  the callback to have run in earlier. The options dictionary was also being read as if it were
+  `setTimeout`'s delay, so it came out `NaN` and the page's timeout was discarded.
 * `MediaQueryList` had no `addEventListener`/`removeEventListener`/`onchange`, which is how the
   skin watches its own breakpoints.
 * `sessionStorage` did not exist — only `localStorage` did. `window` **is** the global object here,

--- a/src/Broiler.Cli.Tests/FrameDeferredCallbackRealmTests.cs
+++ b/src/Broiler.Cli.Tests/FrameDeferredCallbackRealmTests.cs
@@ -1,0 +1,176 @@
+using Broiler.HtmlBridge;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// Work a frame defers — <c>setTimeout</c>, <c>setInterval</c>, <c>requestAnimationFrame</c>,
+/// <c>requestIdleCallback</c> — runs in that frame's browsing context when the queue drains.
+/// <para>
+/// Every document shares one JavaScript context here, and the drain runs from C# with no browsing
+/// context pushed, so it ran in the main one. A frame's <em>synchronous</em> script was already
+/// correct — the sub-document script runner pushes the frame's context around it — but the moment
+/// that script deferred anything, the callback woke up in the parent: its <c>document</c> was the
+/// parent's document, so looking up one of its own elements returned null and the callback either
+/// threw (swallowed by the drain's catch, leaving no trace at all) or quietly mutated the wrong
+/// document. Deferring work to a timer is how most framed script does anything.
+/// </para>
+/// </summary>
+public sealed class FrameDeferredCallbackRealmTests
+{
+    /// <summary>
+    /// Runs a page with one <c>srcdoc</c> frame carrying <paramref name="frameScript"/>, drains the
+    /// queue, and returns what the whole run left on <c>globalThis.probe</c>. The frame's script is
+    /// embedded in an attribute, so it is written with entity-escaped quotes.
+    /// </summary>
+    private static string RunFramed(string frameScript, string readBack)
+    {
+        var html =
+            "<!DOCTYPE html><html><body><div id='parentOnly'></div>" +
+            "<iframe id='f' srcdoc='<!DOCTYPE html><body><div id=&quot;m&quot;></div>" +
+            "<script>" + frameScript + "</script>" +
+            "</body>'></iframe>" +
+            "</body></html>";
+
+        using var context = new JSContext();
+        using var bridge = new DomBridge();
+        bridge.Attach(context, html, "https://example.com/index.html");
+        bridge.FireWindowLoadEvent();
+        bridge.FlushTimers();
+
+        return context.Eval(readBack).ToString();
+    }
+
+    /// <summary>
+    /// The gap itself. <c>whose()</c> asks which document the callback is looking at by naming an
+    /// element only the frame has, and only the parent has.
+    /// </summary>
+    [Fact]
+    public void A_Frames_Timeout_Callback_Runs_Against_The_Frames_Document()
+    {
+        const string frameScript =
+            "function whose() {" +
+            " if (document.getElementById(&quot;m&quot;)) return &quot;frame&quot;;" +
+            " if (document.getElementById(&quot;parentOnly&quot;)) return &quot;parent&quot;;" +
+            " return &quot;neither&quot;; }" +
+            "globalThis.probe = &quot;sync:&quot; + whose();" +
+            "setTimeout(function () { globalThis.probe += &quot;|timeout:&quot; + whose(); }, 0);";
+
+        Assert.Equal("sync:frame|timeout:frame", RunFramed(frameScript, "String(globalThis.probe)"));
+    }
+
+    /// <summary>
+    /// Not just <c>document</c>: the whole browsing context switches, so the callback's
+    /// <c>location</c> is the frame's too. It used to read the parent's URL, which is what a framed
+    /// script checking its own origin would have acted on.
+    /// </summary>
+    [Fact]
+    public void A_Frames_Timeout_Callback_Sees_The_Frames_Location()
+    {
+        const string frameScript =
+            "setTimeout(function () {" +
+            " globalThis.probe = document.location.href + &quot;|&quot; + (window === parent ? &quot;same&quot; : &quot;nested&quot;);" +
+            "}, 0);";
+
+        Assert.Equal("about:srcdoc|nested", RunFramed(frameScript, "String(globalThis.probe)"));
+    }
+
+    /// <summary>The callback reaches the frame's DOM for real, not just a document object that
+    /// answers lookups — the mutation lands on the node the parent can read back.</summary>
+    [Fact]
+    public void A_Frames_Timeout_Callback_Mutates_The_Frames_Own_Dom()
+    {
+        const string frameScript =
+            "setTimeout(function () {" +
+            " document.getElementById(&quot;m&quot;).setAttribute(&quot;data-ran&quot;, &quot;1&quot;);" +
+            "}, 0);";
+
+        Assert.Equal("1", RunFramed(frameScript,
+            "String(document.getElementById('f').contentDocument.getElementById('m').getAttribute('data-ran'))"));
+    }
+
+    /// <summary>
+    /// A timer registered from inside a frame's timer callback is itself a frame registration — the
+    /// context is pushed while the outer callback runs, so the inner one is bound to it too. This is
+    /// the shape of every self-rescheduling loop, so without it a frame would fall back to the parent
+    /// on its second tick.
+    /// </summary>
+    [Fact]
+    public void A_Timer_Registered_Inside_A_Frames_Callback_Stays_In_The_Frame()
+    {
+        const string frameScript =
+            "function whose() { return document.getElementById(&quot;m&quot;) ? &quot;frame&quot; : &quot;parent&quot;; }" +
+            "setTimeout(function () {" +
+            " globalThis.probe = &quot;outer:&quot; + whose();" +
+            " setTimeout(function () { globalThis.probe += &quot;|inner:&quot; + whose(); }, 0);" +
+            "}, 0);";
+
+        Assert.Equal("outer:frame|inner:frame", RunFramed(frameScript, "String(globalThis.probe)"));
+    }
+
+    /// <summary>
+    /// The other three queues behave the same, and their callbacks keep the argument they are
+    /// supposed to be handed: a <c>DOMHighResTimeStamp</c> for the animation frame, a working
+    /// <c>IdleDeadline</c> for the idle callback. The context switch forwards the call rather than
+    /// replacing it.
+    /// </summary>
+    [Fact]
+    public void The_Interval_AnimationFrame_And_Idle_Queues_Switch_Context_And_Keep_Their_Arguments()
+    {
+        const string frameScript =
+            "function whose() { return document.getElementById(&quot;m&quot;) ? &quot;frame&quot; : &quot;parent&quot;; }" +
+            "globalThis.probe = &quot;&quot;;" +
+            "var h = setInterval(function () { globalThis.probe += &quot;interval:&quot; + whose(); clearInterval(h); }, 0);" +
+            "requestAnimationFrame(function (ts) { globalThis.probe += &quot;|raf:&quot; + whose() + &quot;(&quot; + typeof ts + &quot;)&quot;; });" +
+            "requestIdleCallback(function (d) { globalThis.probe += &quot;|idle:&quot; + whose() + &quot;(&quot; + (d.timeRemaining() > 0) + &quot;)&quot;; });";
+
+        var probe = RunFramed(frameScript, "String(globalThis.probe)");
+
+        // Asserted piecewise rather than as one string: the order across the three queues is the
+        // drain's business (timers first, animation frames after them), not this test's.
+        Assert.Contains("interval:frame", probe);
+        Assert.Contains("raf:frame(number)", probe);
+        Assert.Contains("idle:frame(true)", probe);
+    }
+
+    /// <summary>
+    /// The switch is scoped to the callback: the main context is restored afterwards, so a top-level
+    /// timer queued alongside a frame's still sees the parent's document — and the page the drain
+    /// returns to is the page it left.
+    /// </summary>
+    [Fact]
+    public void The_Main_Context_Is_Restored_Around_A_Frames_Callback()
+    {
+        const string html =
+            "<!DOCTYPE html><html><body><div id='parentOnly'></div>" +
+            "<iframe id='f' srcdoc='<!DOCTYPE html><body><div id=&quot;m&quot;></div>" +
+            "<script>setTimeout(function () {" +
+            " globalThis.probe += &quot;|frame:&quot; + (document.getElementById(&quot;m&quot;) ? &quot;frame&quot; : &quot;parent&quot;);" +
+            "}, 0);</script>" +
+            "</body>'></iframe>" +
+            "</body></html>";
+
+        using var context = new JSContext();
+        using var bridge = new DomBridge();
+        bridge.Attach(context, html, "https://example.com/index.html");
+
+        // The main document's own timer, registered from the main context (Attach does not run this
+        // harness's inline scripts; the frame's are run when its browsing context is minted).
+        context.Eval("""
+            globalThis.probe = '';
+            setTimeout(function () {
+              globalThis.probe += '|main:' + (document.getElementById('parentOnly') ? 'parent' : 'frame');
+            }, 0);
+            """);
+
+        bridge.FireWindowLoadEvent();
+        bridge.FlushTimers();
+
+        // Both ran, each against its own document, and the main document is still current afterwards.
+        var probe = context.Eval("String(globalThis.probe)").ToString();
+        Assert.Contains("|frame:frame", probe);
+        Assert.Contains("|main:parent", probe);
+        Assert.Equal("parent",
+            context.Eval("document.getElementById('parentOnly') ? 'parent' : 'frame'").ToString());
+    }
+}

--- a/src/Broiler.Cli.Tests/ImageElementIdlTests.cs
+++ b/src/Broiler.Cli.Tests/ImageElementIdlTests.cs
@@ -1,0 +1,191 @@
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// HTMLImageElement's IDL attributes (HTML §4.8.3). The interface used to carry nothing but
+/// <c>width</c>/<c>height</c>: <c>src</c>, <c>currentSrc</c>, <c>alt</c>, <c>srcset</c>, <c>sizes</c>,
+/// <c>useMap</c>, <c>isMap</c> and the fetch hints were all absent, so reading one gave
+/// <c>undefined</c> — not the empty string a missing content attribute reflects as — and writing one
+/// set a plain JS property on the wrapper that no content attribute, and so no layout or
+/// serialization, ever saw. www.mediawiki.org's start page died on the read half; see
+/// <see cref="Reading_Src_Off_A_Parsed_Image_Survives_The_MediaWiki_Thumbnail_Walk"/>.
+/// </summary>
+public sealed class ImageElementIdlTests
+{
+    // The reported throw, reduced to the code that produced it. mmv.bootstrap walks the page's
+    // thumbnails and, for each, calls mw.Title.newFromImg( $thumb ) — `img[0].src` — and hands the
+    // result to mw.util.parseImageUrl, which opens with `url.match( … )`. src was undefined, so the
+    // property read on it threw "Cannot get property match of undefined (evaluating 'url.match')",
+    // and because mediawiki.org serves its modules as one load.php bundle that throw took
+    // processThumbs and everything queued behind it down with it. The two functions below are the
+    // real ones, transcribed; what matters is that they now run to a Title instead of throwing.
+    [Fact]
+    public void Reading_Src_Off_A_Parsed_Image_Survives_The_MediaWiki_Thumbnail_Walk()
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<a class=""mw-file-description"" href=""/wiki/File:Example.png""><img class=""mw-file-element""
+   src=""//upload.wikimedia.org/wikipedia/commons/thumb/a/a9/Example.png/120px-Example.png""
+   srcset=""//upload.wikimedia.org/wikipedia/commons/thumb/a/a9/Example.png/240px-Example.png 2x""
+   alt=""Example"" width=""120"" height=""90""></a>
+<div id=""result""></div>
+<script>
+// mw.util.parseImageUrl, reduced to the branch the page takes.
+function parseImageUrl( url ) {
+    var regexes = [
+        /\/[\da-f]\/[\da-f]{2}\/([^\s\/]+)\/(?:[^\s\/]+-)?(\d+)px-(?:\1|thumbnail)(?:\.[^\s\/?]+)?$/,
+        /\/[\da-f]\/[\da-f]{2}\/([^\s\/?]+)$/
+    ];
+    for ( var i = 0; i < regexes.length; i++ ) {
+        var match = url.match( regexes[ i ] );
+        if ( match ) {
+            return { name: match[ 1 ], width: match[ 2 ] || null };
+        }
+    }
+    return null;
+}
+// mw.Title.newFromImg, and mmv.bootstrap's old-version guard right behind it.
+function newFromImg( img ) {
+    var src = img.jquery ? img[ 0 ].src : img.src;
+    var data = parseImageUrl( src );
+    return data ? 'File:' + data.name : null;
+}
+function isOldFileVersionThumb( src ) {
+    return src.includes( '/archive/' );
+}
+
+var img = document.querySelector( 'img.mw-file-element' );
+var parts = [];
+try {
+    parts.push( 'title=' + newFromImg( img ) );
+    parts.push( 'old=' + isOldFileVersionThumb( img.currentSrc || img.src ) );
+} catch ( e ) {
+    parts.push( 'threw=' + e.message );
+}
+document.getElementById( 'result' ).textContent = parts.join( '|' );
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "https://www.mediawiki.org/wiki/MediaWiki");
+
+        Assert.Contains(">title=File:Example.png|old=false<", result);
+    }
+
+    [Fact]
+    public void Src_Getter_Resolves_Against_The_Page_Url_And_The_Setter_Writes_The_Content_Attribute()
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<img id=""parsed"" src=""thumb/pic.png"">
+<div id=""result""></div>
+<script>
+var parsed = document.getElementById( 'parsed' );
+var made = document.createElement( 'img' );
+made.src = 'other/deep.png';
+document.body.appendChild( made );
+document.getElementById( 'result' ).textContent =
+    'parsed=' + parsed.src +
+    '|made=' + made.src +
+    '|attr=' + made.getAttribute( 'src' );
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "https://example.org/dir/page.html");
+
+        // The IDL getter is an absolute URL either way; the content attribute keeps what was written.
+        Assert.Contains(
+            ">parsed=https://example.org/dir/thumb/pic.png" +
+            "|made=https://example.org/dir/other/deep.png" +
+            "|attr=other/deep.png<",
+            result);
+    }
+
+    // A missing content attribute reflects as the empty string, and currentSrc reports the URL the
+    // element settled on — nothing at all when there is no src to settle on. `img.currentSrc ||
+    // img.src` (mmv.bootstrap's idiom) has to reach the second operand rather than a page URL that
+    // resolving an absent src would otherwise manufacture.
+    [Fact]
+    public void An_Image_Without_A_Src_Reports_Empty_Strings_Not_Undefined()
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<img id=""bare"">
+<div id=""result""></div>
+<script>
+var bare = document.getElementById( 'bare' );
+document.getElementById( 'result' ).textContent =
+    'src=' + JSON.stringify( bare.src ) +
+    '|currentSrc=' + JSON.stringify( bare.currentSrc ) +
+    '|alt=' + JSON.stringify( bare.alt ) +
+    '|srcset=' + JSON.stringify( bare.srcset ) +
+    '|isMap=' + bare.isMap;
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "https://example.org/dir/page.html");
+
+        // The JSON.stringify quotes come back escaped, because textContent serializes as markup.
+        const string emptyString = "&quot;&quot;";
+        Assert.Contains(
+            $">src={emptyString}|currentSrc={emptyString}|alt={emptyString}|srcset={emptyString}|isMap=false<",
+            result);
+    }
+
+    [Fact]
+    public void The_Plain_String_Idl_Attributes_Round_Trip_Through_The_Content_Attributes()
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<script>
+var img = document.createElement( 'img' );
+img.alt = 'Example';
+img.srcset = 'wide.png 2x';
+img.sizes = '(max-width: 600px) 100vw';
+img.useMap = '#map';
+img.crossOrigin = 'anonymous';
+img.referrerPolicy = 'no-referrer';
+img.decoding = 'async';
+img.loading = 'lazy';
+img.fetchPriority = 'low';
+img.isMap = true;
+document.body.appendChild( img );
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "https://example.org/dir/page.html");
+
+        foreach (var attribute in new[]
+                 {
+                     @"alt=""Example""", @"srcset=""wide.png 2x""",
+                     @"sizes=""(max-width: 600px) 100vw""", @"usemap=""#map""",
+                     @"crossorigin=""anonymous""", @"referrerpolicy=""no-referrer""",
+                     @"decoding=""async""", @"loading=""lazy""", @"fetchpriority=""low""",
+                     "ismap",
+                 })
+        {
+            Assert.Contains(attribute, result);
+        }
+    }
+
+    // isMap is boolean-reflected: present or absent, never the string "false". Setting it back to
+    // false has to remove the attribute, or the getter reads the empty-but-present value as true.
+    [Fact]
+    public void IsMap_Set_Back_To_False_Removes_The_Content_Attribute()
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<img id=""m"" src=""pic.png"" ismap>
+<div id=""result""></div>
+<script>
+var img = document.getElementById( 'm' );
+var before = img.isMap;
+img.isMap = false;
+document.getElementById( 'result' ).textContent =
+    'before=' + before + '|after=' + img.isMap + '|has=' + img.hasAttribute( 'ismap' );
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "https://example.org/dir/page.html");
+
+        Assert.Contains(">before=true|after=false|has=false<", result);
+    }
+}

--- a/src/Broiler.Cli.Tests/SubWindowBindingModuleTests.cs
+++ b/src/Broiler.Cli.Tests/SubWindowBindingModuleTests.cs
@@ -67,4 +67,71 @@ public sealed class SubWindowBindingModuleTests
 
         Assert.Equal("function|number|function|true|true", result.ToString());
     }
+
+    /// <summary>
+    /// A frame gets the idle-callback pair its parent has, alongside the animation-frame pair it was
+    /// the only scheduling API missing next to. The bare name always resolved — it is a context
+    /// global and every document shares the one context — so what was <c>undefined</c> is the
+    /// qualified read, which is the one pages actually write: the standard feature test is
+    /// <c>window.requestIdleCallback ? … : fallback</c>, and inside a frame <c>window</c> is the
+    /// sub-window. A framed page therefore took its no-native path, and one that called
+    /// <c>window.requestIdleCallback(cb)</c> unguarded got a TypeError.
+    /// </summary>
+    [Fact]
+    public void A_Frame_Gets_The_Idle_Callback_Pair_Its_Parent_Has()
+    {
+        const string html =
+            "<!DOCTYPE html><html><body>" +
+            "<iframe id='f' srcdoc='<!DOCTYPE html><body>" +
+            "<script>var seen = typeof window.requestIdleCallback;</script>" +
+            "</body>'></iframe>" +
+            "</body></html>";
+        using var bridge = Attach(out var context, html);
+        bridge.FireWindowLoadEvent();
+        bridge.FlushTimers();
+
+        var result = context.Eval("""
+            (() => {
+              const w = document.getElementById('f').contentWindow;
+              return [
+                'contentWindow=' + typeof w.requestIdleCallback,
+                'cancel=' + typeof w.cancelIdleCallback,
+                'frames=' + typeof frames[0].requestIdleCallback,
+                'insideTheFrame=' + w.seen
+              ].join('|');
+            })()
+            """);
+
+        Assert.Equal("contentWindow=function|cancel=function|frames=function|insideTheFrame=function",
+            result.ToString());
+    }
+
+    /// <summary>
+    /// The mirrored pair is the parent's own function, so a frame that registers through it schedules
+    /// on the bridge's one event loop and gets the same <c>IdleDeadline</c> a top-level caller does —
+    /// the identity the whole mirror rests on. (Whether a sub-document's <em>own</em> scheduled
+    /// callbacks are ever drained is a separate question this does not touch: they are not today, and
+    /// a frame's <c>setTimeout</c> is not either.)
+    /// </summary>
+    [Fact]
+    public void The_Mirrored_Idle_Pair_Is_The_Parents_Own_Function()
+    {
+        const string html =
+            "<!DOCTYPE html><html><body>" +
+            "<iframe id='f' srcdoc='<!DOCTYPE html><body></body>'></iframe>" +
+            "</body></html>";
+        using var bridge = Attach(out var context, html);
+
+        var result = context.Eval("""
+            (() => {
+              const w = document.getElementById('f').contentWindow;
+              return [
+                w.requestIdleCallback === window.requestIdleCallback,
+                w.cancelIdleCallback === window.cancelIdleCallback
+              ].join('|');
+            })()
+            """);
+
+        Assert.Equal("true|true", result.ToString());
+    }
 }

--- a/src/Broiler.Cli.Tests/VectorSkinPlatformApiTests.cs
+++ b/src/Broiler.Cli.Tests/VectorSkinPlatformApiTests.cs
@@ -134,6 +134,131 @@ document.body.appendChild(el);
     }
 
     /// <summary>
+    /// Background Tasks §2.3 hands the callback an <c>IdleDeadline</c>. <c>requestIdleCallback</c>
+    /// was a bare alias of <c>setTimeout</c>, which invokes its callback with no arguments at all, so
+    /// the parameter was <c>undefined</c> and the first thing every caller does with it —
+    /// <c>deadline.timeRemaining()</c> — threw "Cannot get property timeRemaining of undefined".
+    /// mediawiki.org reported it twice per load.
+    /// </summary>
+    [Fact]
+    public void An_Idle_Callback_Is_Handed_A_Deadline_It_Can_Read()
+    {
+        const string html = """
+<!DOCTYPE html>
+<html><body>
+<div id="result"></div>
+<script>
+requestIdleCallback(function (deadline) {
+  var text;
+  try {
+    text = 'type=' + typeof deadline.timeRemaining +
+           '|budget=' + (deadline.timeRemaining() > 0 && deadline.timeRemaining() <= 50) +
+           '|didTimeout=' + deadline.didTimeout;
+  } catch (e) {
+    text = 'threw=' + e.message;
+  }
+  document.getElementById('result').textContent = text;
+});
+</script>
+</body></html>
+""";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///idle.html");
+
+        Assert.Contains(">type=function|budget=true|didTimeout=false<", result);
+    }
+
+    /// <summary>
+    /// The shape the deadline actually exists for, and the one MediaWiki runs its module evaluation
+    /// through: a loop that drains a queue while the budget lasts and reschedules itself when it does
+    /// not. It has to both make progress and terminate — a <c>timeRemaining()</c> stuck at 0 would
+    /// reschedule for ever without shifting a single item.
+    /// </summary>
+    [Fact]
+    public void A_Queue_Draining_Idle_Loop_Makes_Progress_And_Terminates()
+    {
+        const string html = """
+<!DOCTYPE html>
+<html><body>
+<div id="result"></div>
+<script>
+var queue = [1, 2, 3, 4, 5, 6, 7, 8], done = [], rounds = 0;
+function drain(deadline) {
+  rounds++;
+  while (queue.length && deadline.timeRemaining() > 3) {
+    done.push(queue.shift());
+  }
+  if (queue.length) {
+    requestIdleCallback(drain);
+  } else {
+    document.getElementById('result').textContent =
+        'done=' + done.join(',') + '|left=' + queue.length + '|rounded=' + (rounds >= 1);
+  }
+}
+requestIdleCallback(drain);
+</script>
+</body></html>
+""";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///idle-drain.html");
+
+        Assert.Contains(">done=1,2,3,4,5,6,7,8|left=0|rounded=true<", result);
+    }
+
+    /// <summary>
+    /// The second argument is an options dictionary, not a delay. Routed through the
+    /// <c>setTimeout</c> adapter it was read as a number, came out <c>NaN</c> and was clamped to 0,
+    /// so a page's timeout was silently discarded. A callback that carries one is running because
+    /// that deadline arrived — there is no idle period here it could have been run in earlier — which
+    /// is what <c>didTimeout</c> reports.
+    /// </summary>
+    [Fact]
+    public void An_Idle_Callback_Given_A_Timeout_Reports_That_It_Timed_Out()
+    {
+        const string html = """
+<!DOCTYPE html>
+<html><body>
+<div id="result"></div>
+<script>
+requestIdleCallback(function (deadline) {
+  document.getElementById('result').textContent = 'didTimeout=' + deadline.didTimeout;
+}, { timeout: 50 });
+</script>
+</body></html>
+""";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///idle-timeout.html");
+
+        Assert.Contains(">didTimeout=true<", result);
+    }
+
+    /// <summary>
+    /// The handle is cancellable. It comes out of the same id space <c>clearTimeout</c> acts on, so a
+    /// cancelled callback has to stay uncalled rather than run anyway.
+    /// </summary>
+    [Fact]
+    public void A_Cancelled_Idle_Callback_Does_Not_Run()
+    {
+        const string html = """
+<!DOCTYPE html>
+<html><body>
+<div id="result">not-run</div>
+<script>
+var handle = requestIdleCallback(function () {
+  document.getElementById('result').textContent = 'ran';
+});
+cancelIdleCallback(handle);
+</script>
+</body></html>
+""";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///idle-cancel.html");
+
+        Assert.Contains(">not-run<", result);
+        Assert.DoesNotContain(">ran<", result);
+    }
+
+    /// <summary>
     /// CSSOM View §4.2: a <c>MediaQueryList</c> is an <c>EventTarget</c>. The skin watches its own
     /// breakpoints through one, and <c>addListener</c> alone (the deprecated spelling, which did
     /// exist) is not what current code calls.

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/ElementInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/ElementInterfaces.cs
@@ -58,6 +58,28 @@ public sealed partial class DomBridge
         ("noModule", "nomodule"),
     ];
 
+    /// <summary>
+    /// HTMLImageElement's plain reflected DOMString IDL attributes (HTML §4.8.3), as IDL name →
+    /// content-attribute name. <c>src</c> is URL-typed and wired separately, <c>isMap</c> is boolean,
+    /// and <c>width</c>/<c>height</c> report the used dimension rather than the raw attribute.
+    /// <c>crossOrigin</c>, <c>decoding</c>, <c>loading</c>, <c>fetchPriority</c> and
+    /// <c>referrerPolicy</c> are enumerated in the IDL and so read back a limited value in a browser;
+    /// they reflect plainly here, which is what a page setting them expects and what the content
+    /// attribute they write carries.
+    /// </summary>
+    private static readonly (string IdlName, string AttributeName)[] ImageReflectedAttributes =
+    [
+        ("alt", "alt"),
+        ("srcset", "srcset"),
+        ("sizes", "sizes"),
+        ("useMap", "usemap"),
+        ("crossOrigin", "crossorigin"),
+        ("referrerPolicy", "referrerpolicy"),
+        ("decoding", "decoding"),
+        ("loading", "loading"),
+        ("fetchPriority", "fetchpriority"),
+    ];
+
     private void AddElementSpecificMembers(JSObject obj, Broiler.Dom.DomElement element)
     {
         // -- Phase 5: HTML DOM Interfaces --
@@ -249,6 +271,46 @@ public sealed partial class DomBridge
                 obj.FastAddProperty((KeyString)dimName,
                     new DomFunction((in _) => Dom.Features.ComputedStyleBinding.GetUsedDimension(this, dimName, element, in _), "get " + dimName),
                     new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedDimension(dimName, element, in a), "set " + dimName),
+                    JSPropertyAttributes.EnumerableConfigurableProperty);
+            }
+
+            // .src — a reflected URL, resolved against the page URL exactly as on <script>/<a>/<link>.
+            // It was missing entirely, so reading an image's URL the ordinary way produced *undefined*
+            // rather than a string, and every caller that went straight on to a string method died on
+            // it: mediawiki.org's start page reached mw.Title.newFromImg(), which hands img.src to
+            // mw.util.parseImageUrl(), whose first act is url.match(...) — "Cannot get property match
+            // of undefined". That throw took MultimediaViewerBootstrap.processThumbs down and, with
+            // it, the rest of the single load.php bundle queued behind it.
+            obj.FastAddProperty((KeyString)"src",
+                new DomFunction((in _) => Dom.Features.ElementReflectionBinding.GetSrc(this, element, in _), "get src"),
+                new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetSrc(element, in a), "set src"),
+                JSPropertyAttributes.EnumerableConfigurableProperty);
+
+            // .currentSrc — read-only, the URL of the image the element actually settled on. Srcset
+            // candidate selection happens down in layout and is not visible from here, so this reports
+            // the resolved src, and the empty string when there is no src at all. That is the pair of
+            // answers the `img.currentSrc || img.src` idiom is written against (mmv.bootstrap's
+            // processThumb reads exactly that, then calls .includes() on the result).
+            obj.FastAddProperty((KeyString)"currentSrc",
+                new DomFunction((in _) => Dom.Features.ElementReflectionBinding.GetCurrentSrc(this, element, in _), "get currentSrc"),
+                null, JSPropertyAttributes.EnumerableConfigurableProperty);
+
+            // .isMap — the one boolean in the interface: present or absent, never the string "false".
+            obj.FastAddProperty((KeyString)"isMap",
+                new DomFunction((in _) => HasAttr(element, "ismap") ? JSBoolean.True : JSBoolean.False, "get isMap"),
+                new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedBoolean("ismap", element, in a), "set isMap"),
+                JSPropertyAttributes.EnumerableConfigurableProperty);
+
+            // The rest of HTMLImageElement's plain reflected DOMStrings — alt, srcset, sizes, useMap
+            // and the enumerated fetch hints. Same gap as .src: reading any of them returned undefined
+            // and writing one set a plain JS property on the wrapper that no content attribute, and so
+            // no layout or serialization, ever saw.
+            foreach (var (idlName, attrName) in ImageReflectedAttributes)
+            {
+                var captured = attrName; // capture for closure
+                obj.FastAddProperty((KeyString)idlName,
+                    new DomFunction((in _) => TryGetAttribute(element, captured, out var v) ? new JSString(v) : new JSString(string.Empty), "get " + idlName),
+                    new DomFunction((in a) => Dom.Features.ElementReflectionBinding.SetReflectedAttribute(captured, element, in a), "set " + idlName),
                     JSPropertyAttributes.EnumerableConfigurableProperty);
             }
         }

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
@@ -57,11 +57,11 @@ public sealed partial class DomBridge
 
         // window timers / animation frames — thin adapters over the P2.4 BrowserEventLoop, co-located
         // in the TimerBinding feature module (Phase 3).
-        window.FastAddValue((KeyString)"setTimeout", new DomFunction((in a) => Dom.Features.TimerBinding.SetTimeout(_eventLoop, in a), "setTimeout", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"setTimeout", new DomFunction((in a) => Dom.Features.TimerBinding.SetTimeout(_eventLoop, _windowContext, in a), "setTimeout", 2), JSPropertyAttributes.EnumerableConfigurableValue);
         window.FastAddValue((KeyString)"clearTimeout", new DomFunction((in a) => Dom.Features.TimerBinding.ClearTimeout(_eventLoop, in a), "clearTimeout", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"setInterval", new DomFunction((in a) => Dom.Features.TimerBinding.SetInterval(_eventLoop, in a), "setInterval", 2), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"setInterval", new DomFunction((in a) => Dom.Features.TimerBinding.SetInterval(_eventLoop, _windowContext, in a), "setInterval", 2), JSPropertyAttributes.EnumerableConfigurableValue);
         window.FastAddValue((KeyString)"clearInterval", new DomFunction((in a) => Dom.Features.TimerBinding.ClearInterval(_eventLoop, in a), "clearInterval", 1), JSPropertyAttributes.EnumerableConfigurableValue);
-        window.FastAddValue((KeyString)"requestAnimationFrame", new DomFunction((in a) => Dom.Features.TimerBinding.RequestAnimationFrame(_eventLoop, in a), "requestAnimationFrame", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        window.FastAddValue((KeyString)"requestAnimationFrame", new DomFunction((in a) => Dom.Features.TimerBinding.RequestAnimationFrame(_eventLoop, _windowContext, in a), "requestAnimationFrame", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         window.FastAddValue((KeyString)"cancelAnimationFrame", new DomFunction((in a) => Dom.Features.TimerBinding.CancelAnimationFrame(_eventLoop, in a), "cancelAnimationFrame", 1), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // window.alert(msg) — logs to debug output
@@ -242,7 +242,7 @@ public sealed partial class DomBridge
 
         if (window[(KeyString)"requestIdleCallback"] is JSUndefined)
         {
-            var requestIdle = new DomFunction((in a) => Dom.Features.TimerBinding.RequestIdleCallback(_eventLoop, in a), "requestIdleCallback", 1);
+            var requestIdle = new DomFunction((in a) => Dom.Features.TimerBinding.RequestIdleCallback(_eventLoop, _windowContext, in a), "requestIdleCallback", 1);
             window.FastAddValue((KeyString)"requestIdleCallback", requestIdle, JSPropertyAttributes.EnumerableConfigurableValue);
             context["requestIdleCallback"] = requestIdle;
 

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
@@ -208,7 +208,9 @@ public sealed partial class DomBridge
     /// promise the module was resolving, and every module waiting on that one stayed unresolved —
     /// which is how a page can lose behaviour that has nothing to do with performance timing.
     /// <c>requestIdleCallback</c> runs its callback on a timer instead of dropping it, because
-    /// what pages defer to idle is often the work that produces visible content.
+    /// what pages defer to idle is often the work that produces visible content — and it hands that
+    /// callback a real <c>IdleDeadline</c> (see <c>TimerBinding.RequestIdleCallback</c>), because a
+    /// callback that receives no deadline throws on the first thing it does with the parameter.
     /// </remarks>
     private void RegisterObservationStubs(JSContext context, JSObject window)
     {
@@ -240,11 +242,11 @@ public sealed partial class DomBridge
 
         if (window[(KeyString)"requestIdleCallback"] is JSUndefined)
         {
-            var requestIdle = new DomFunction((in a) => Dom.Features.TimerBinding.SetTimeout(_eventLoop, in a), "requestIdleCallback", 1);
+            var requestIdle = new DomFunction((in a) => Dom.Features.TimerBinding.RequestIdleCallback(_eventLoop, in a), "requestIdleCallback", 1);
             window.FastAddValue((KeyString)"requestIdleCallback", requestIdle, JSPropertyAttributes.EnumerableConfigurableValue);
             context["requestIdleCallback"] = requestIdle;
 
-            var cancelIdle = new DomFunction((in a) => Dom.Features.TimerBinding.ClearTimeout(_eventLoop, in a), "cancelIdleCallback", 1);
+            var cancelIdle = new DomFunction((in a) => Dom.Features.TimerBinding.CancelIdleCallback(_eventLoop, in a), "cancelIdleCallback", 1);
             window.FastAddValue((KeyString)"cancelIdleCallback", cancelIdle, JSPropertyAttributes.EnumerableConfigurableValue);
             context["cancelIdleCallback"] = cancelIdle;
         }

--- a/src/Broiler.HtmlBridge.Dom/Features/ElementReflectionBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/ElementReflectionBinding.cs
@@ -10,8 +10,10 @@ namespace Broiler.HtmlBridge.Dom.Features;
 /// Reflected content-attribute IDL accessors for various HTML element interfaces, co-located as an
 /// HtmlBridge feature module (Phase 3): the plain string reflectors (<c>label.htmlFor</c> ↔ <c>for</c>,
 /// <c>meta.httpEquiv</c> ↔ <c>http-equiv</c>, <c>.type</c>, and the generic named string / numeric
-/// dimension setters) and the URL-typed getters (<c>&lt;object&gt;.data</c> and
-/// <c>&lt;a&gt;/&lt;area&gt;/&lt;base&gt;/&lt;link&gt;.href</c>), which resolve their relative content
+/// dimension setters) and the URL-typed getters (<c>&lt;object&gt;.data</c>,
+/// <c>&lt;a&gt;/&lt;area&gt;/&lt;base&gt;/&lt;link&gt;.href</c> and
+/// <c>&lt;script&gt;/&lt;img&gt;.src</c>, with <c>&lt;img&gt;.currentSrc</c> alongside it), which
+/// resolve their relative content
 /// attribute against the live page URL. Content-attribute reads/writes use the bridge's neutral
 /// <c>internal static</c> <c>TryGetAttribute</c>/<c>SetAttr</c> helpers directly; only the page URL — read
 /// at call time — comes through the one-member <see cref="IElementReflectionHost"/> contract. Was the
@@ -47,11 +49,20 @@ internal static class ElementReflectionBinding
     public static JSValue GetHref(IElementReflectionHost host, DomElement element, in Arguments _)
         => new JSString(ResolveReflectedUrl(host.PageUrl, element, "href"));
 
-    // <script>.src getter — reflected URL, resolved against the page URL like href/data. Absolute is
-    // what the IDL returns even when the content attribute is relative, which is what a page
-    // comparing script.src against a known URL expects.
+    // <script>/<img>.src getter — reflected URL, resolved against the page URL like href/data.
+    // Absolute is what the IDL returns even when the content attribute is relative, which is what a
+    // page comparing script.src against a known URL — or handing img.src to a URL parser — expects.
     public static JSValue GetSrc(IElementReflectionHost host, DomElement element, in Arguments _)
         => new JSString(ResolveReflectedUrl(host.PageUrl, element, "src"));
+
+    // <img>.currentSrc getter — read-only, the URL the element settled on. Srcset candidate selection
+    // happens in layout and is not visible from here, so a src is reported as the URL that was chosen
+    // and no src at all as the empty string: the two answers `img.currentSrc || img.src` is written
+    // against. Never the bare page URL, which is what resolving an absent (or empty) src would give.
+    public static JSValue GetCurrentSrc(IElementReflectionHost host, DomElement element, in Arguments a)
+        => DomBridge.TryGetAttribute(element, "src", out var value) && value.Length > 0
+            ? GetSrc(host, element, in a)
+            : new JSString(string.Empty);
 
     public static JSValue SetSrc(DomElement element, in Arguments a)
     {

--- a/src/Broiler.HtmlBridge.Dom/Features/SubWindowBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/SubWindowBinding.cs
@@ -104,6 +104,17 @@ internal sealed class SubWindowBinding(
         "TextEncoder", "TextDecoder", "Blob", "AbortController", "Headers",
         "setTimeout", "clearTimeout", "setInterval", "clearInterval",
         "requestAnimationFrame", "cancelAnimationFrame", "queueMicrotask",
+        // The idle pair belongs with the animation-frame pair it sits beside on the main window; it
+        // was the only scheduling API missing here. The bare name always resolved (it is a context
+        // global, and every document shares the one context), so what was undefined is the qualified
+        // read — `contentWindow.requestIdleCallback` and `frames[0].requestIdleCallback` from the
+        // parent, and `window.requestIdleCallback` from inside the frame, where `window` IS the
+        // sub-window. That last one is the idiomatic spelling: the standard feature test is
+        // `window.requestIdleCallback ? … : fallback` (MediaWiki writes exactly that), so a framed
+        // page took its no-native path, and one that called `window.requestIdleCallback(cb)`
+        // unguarded got a TypeError. They schedule on the bridge's one event loop, as the mirrored
+        // timers already do.
+        "requestIdleCallback", "cancelIdleCallback",
         "atob", "btoa", "structuredClone", "performance", "crypto",
 
         // The two storage areas. A frame gets the parent's objects rather than fresh ones, which

--- a/src/Broiler.HtmlBridge.Dom/Features/TimerBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TimerBinding.cs
@@ -16,14 +16,16 @@ namespace Broiler.HtmlBridge.Dom.Features;
 /// module (Phase 3). Each entry point is a thin adapter that
 /// unwraps the JS arguments and delegates to the P2.4 <see cref="BrowserEventLoop"/> task-queue
 /// owner. It holds no state of its own, so it takes the owner as a parameter rather than through a
-/// host contract. Previously the bridge's
+/// host contract — and, for the three that register a callback, the P3.18
+/// <see cref="WindowContextManager"/> as well, because deferred work has to remember which browsing
+/// context handed it over. Previously the bridge's
 /// <c>JsRegistrationSetTimeout070Core</c>..<c>CancelAnimationFrame075Core</c> in the shared
 /// JsFunctionCallbacks/Registration.cs grab-bag.
 /// </summary>
 internal static class TimerBinding
 {
-    public static JSValue SetTimeout(BrowserEventLoop loop, in Arguments a) =>
-        new JSNumber(loop.SetTimeout(a.Length > 0 ? a[0] as JSFunction : null, ReadDelayMs(a)));
+    public static JSValue SetTimeout(BrowserEventLoop loop, WindowContextManager windows, in Arguments a) =>
+        new JSNumber(loop.SetTimeout(BindToRegisteringContext(windows, a.Length > 0 ? a[0] as JSFunction : null), ReadDelayMs(a)));
 
     // The delay argument (a[1]) in ms; absent / NaN / negative are treated as 0 (the event loop clamps too).
     private static double ReadDelayMs(in Arguments a) => a.Length > 1 ? a[1].DoubleValue : 0;
@@ -36,8 +38,8 @@ internal static class TimerBinding
         return JSUndefined.Value;
     }
 
-    public static JSValue SetInterval(BrowserEventLoop loop, in Arguments a) =>
-        new JSNumber(loop.SetInterval(a.Length > 0 ? a[0] as JSFunction : null, ReadDelayMs(a)));
+    public static JSValue SetInterval(BrowserEventLoop loop, WindowContextManager windows, in Arguments a) =>
+        new JSNumber(loop.SetInterval(BindToRegisteringContext(windows, a.Length > 0 ? a[0] as JSFunction : null), ReadDelayMs(a)));
 
     public static JSValue ClearInterval(BrowserEventLoop loop, in Arguments a)
     {
@@ -47,8 +49,8 @@ internal static class TimerBinding
         return JSUndefined.Value;
     }
 
-    public static JSValue RequestAnimationFrame(BrowserEventLoop loop, in Arguments a) =>
-        new JSNumber(loop.RequestAnimationFrame(a.Length > 0 ? a[0] as JSFunction : null));
+    public static JSValue RequestAnimationFrame(BrowserEventLoop loop, WindowContextManager windows, in Arguments a) =>
+        new JSNumber(loop.RequestAnimationFrame(BindToRegisteringContext(windows, a.Length > 0 ? a[0] as JSFunction : null)));
 
     public static JSValue CancelAnimationFrame(BrowserEventLoop loop, in Arguments a)
     {
@@ -56,6 +58,52 @@ internal static class TimerBinding
             loop.CancelAnimationFrame((int)a[0].DoubleValue);
 
         return JSUndefined.Value;
+    }
+
+    /// <summary>
+    /// Ties a callback to the browsing context that registered it, so that when the queue drains it
+    /// runs against its own <c>document</c>/<c>location</c>/<c>window</c> rather than against
+    /// whichever context happens to be current at that moment.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every document shares one JavaScript context here, and the drain runs from C# with no
+    /// browsing context pushed — so it ran in the main one. A frame's synchronous script was already
+    /// correct (the sub-document script runner pushes the frame's context around it), but the moment
+    /// that script deferred anything, the callback woke up in the parent: its <c>document</c> was the
+    /// parent's document, so <c>document.getElementById(…)</c> for one of its own elements returned
+    /// null and the callback either threw — swallowed by the drain's catch, leaving no trace at all —
+    /// or quietly mutated the wrong document. Deferring work to a timer is how most framed script
+    /// does anything, so this was most of what a frame's scripting could do.
+    /// </para>
+    /// <para>
+    /// The main window is the overwhelmingly common case and is returned unwrapped: the drain already
+    /// runs in its context, so wrapping would buy nothing and cost an allocation per registration
+    /// plus <c>RunWithWindowContext</c>'s save/restore on every tick — on the one call busy pages
+    /// make constantly. Only a frame pays for being a frame.
+    /// </para>
+    /// </remarks>
+    private static JSFunction? BindToRegisteringContext(WindowContextManager windows, JSFunction? callback)
+    {
+        if (callback is null || windows.ResolveCurrentSubWindow() is not { } frameWindow)
+            return callback;
+
+        return new DomFunction((in a) =>
+        {
+            // A queued callback is invoked with at most one real argument — a rAF timestamp, an
+            // IdleDeadline — and `in` parameters cannot be captured, so the call is read out into
+            // locals here. Arguments' first constructor parameter is `this`; Length and the indexer
+            // count only the real arguments, so the one to forward is a[0].
+            var thisValue = a.This ?? JSUndefined.Value;
+            var argument = a.Length > 0 ? a[0] : null;
+
+            JSValue result = JSUndefined.Value;
+            windows.RunWithWindowContext(frameWindow, () =>
+                result = callback.InvokeFunction(argument is null
+                    ? new Arguments(thisValue)
+                    : new Arguments(thisValue, argument)));
+            return result;
+        }, "callback", 0);
     }
 
     /// <summary>
@@ -80,9 +128,9 @@ internal static class TimerBinding
     /// <see cref="ReadDelayMs"/> read <c>NaN</c> off the object and scheduled at 0 regardless of what
     /// the page asked for; <c>timeout</c> is read out of it properly here.
     /// </remarks>
-    public static JSValue RequestIdleCallback(BrowserEventLoop loop, in Arguments a)
+    public static JSValue RequestIdleCallback(BrowserEventLoop loop, WindowContextManager windows, in Arguments a)
     {
-        if (a.Length == 0 || a[0] as JSFunction is not { } callback)
+        if (a.Length == 0 || BindToRegisteringContext(windows, a[0] as JSFunction) is not { } callback)
             return new JSNumber(loop.SetTimeout(null));
 
         // A timeout means "run by then at the latest". There is no idle period here for the callback

--- a/src/Broiler.HtmlBridge.Dom/Features/TimerBinding.cs
+++ b/src/Broiler.HtmlBridge.Dom/Features/TimerBinding.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Diagnostics;
 using Broiler.HtmlBridge.Dom.Runtime;
 using Broiler.JavaScript.Runtime;
+using Broiler.JavaScript.Storage;
+using Broiler.JavaScript.BuiltIns.Boolean;
 using Broiler.JavaScript.BuiltIns.Function;
 using Broiler.JavaScript.BuiltIns.Number;
 
@@ -8,7 +12,8 @@ namespace Broiler.HtmlBridge.Dom.Features;
 /// <summary>
 /// The window timer / animation-frame scheduling API — <c>setTimeout</c>/<c>clearTimeout</c>,
 /// <c>setInterval</c>/<c>clearInterval</c>, <c>requestAnimationFrame</c>/<c>cancelAnimationFrame</c>
-/// — co-located as an HtmlBridge feature module (Phase 3). Each entry point is a thin adapter that
+/// and <c>requestIdleCallback</c>/<c>cancelIdleCallback</c> — co-located as an HtmlBridge feature
+/// module (Phase 3). Each entry point is a thin adapter that
 /// unwraps the JS arguments and delegates to the P2.4 <see cref="BrowserEventLoop"/> task-queue
 /// owner. It holds no state of its own, so it takes the owner as a parameter rather than through a
 /// host contract. Previously the bridge's
@@ -51,5 +56,95 @@ internal static class TimerBinding
             loop.CancelAnimationFrame((int)a[0].DoubleValue);
 
         return JSUndefined.Value;
+    }
+
+    /// <summary>
+    /// The budget an idle callback is given, in milliseconds — Background Tasks §2.2 caps
+    /// <c>timeRemaining()</c> at 50 ms, and that cap is what a page draining a queue actually
+    /// measures itself against.
+    /// </summary>
+    private const double IdleBudgetMs = 50;
+
+    /// <summary>
+    /// <c>requestIdleCallback(callback, { timeout })</c> — Background Tasks §2.3, queued as an
+    /// ordinary task because a headless drain has no idle period to wait for. What makes it work is
+    /// the <c>IdleDeadline</c> the callback is handed: it used to be a bare alias of
+    /// <c>setTimeout</c>, so the callback got the timer's zero arguments and the first thing every
+    /// caller does with the parameter — <c>deadline.timeRemaining()</c> — threw "Cannot get property
+    /// timeRemaining of undefined". That is not a peripheral API: MediaWiki's ResourceLoader
+    /// evaluates its module implementations inside one (<c>asyncEvalTask</c> loops until
+    /// <c>timeRemaining() &lt;= 0</c>), and its storage store walks localStorage in another.
+    /// </summary>
+    /// <remarks>
+    /// The second argument is an options dictionary, not a delay, so routing it through
+    /// <see cref="ReadDelayMs"/> read <c>NaN</c> off the object and scheduled at 0 regardless of what
+    /// the page asked for; <c>timeout</c> is read out of it properly here.
+    /// </remarks>
+    public static JSValue RequestIdleCallback(BrowserEventLoop loop, in Arguments a)
+    {
+        if (a.Length == 0 || a[0] as JSFunction is not { } callback)
+            return new JSNumber(loop.SetTimeout(null));
+
+        // A timeout means "run by then at the latest". There is no idle period here for the callback
+        // to have been run in earlier, so a callback that carries one is always running because that
+        // deadline arrived — which is what didTimeout reports.
+        var timeoutMs = ReadIdleTimeoutMs(a);
+        var didTimeout = timeoutMs > 0;
+
+        // The deadline is minted when the callback runs, not when it is registered: the budget is the
+        // time this invocation has used, so a re-registered callback gets a fresh one each time.
+        var withDeadline = new DomFunction((in _) =>
+        {
+            callback.InvokeFunction(new Arguments(JSUndefined.Value, CreateIdleDeadline(didTimeout)));
+            return JSUndefined.Value;
+        }, "requestIdleCallback callback", 0);
+
+        // Scheduling it on the timer queue is what keeps the handle cancellable: the id comes from the
+        // same space clearTimeout/cancelIdleCallback act on.
+        return new JSNumber(loop.SetTimeout(withDeadline, timeoutMs));
+    }
+
+    /// <summary>
+    /// <c>cancelIdleCallback</c> — the handle came from the timer id space, so this is
+    /// <see cref="ClearTimeout"/> under the name Background Tasks gives it.
+    /// </summary>
+    public static JSValue CancelIdleCallback(BrowserEventLoop loop, in Arguments a) => ClearTimeout(loop, in a);
+
+    // The `timeout` member of the options dictionary (a[1]), in ms. Absent, non-numeric or
+    // non-positive means the page asked for no deadline at all.
+    private static double ReadIdleTimeoutMs(in Arguments a)
+    {
+        if (a.Length < 2 || a[1] is not JSObject options)
+            return 0;
+
+        var timeout = options[(KeyString)"timeout"];
+        if (timeout is null || timeout.IsNull || timeout.IsUndefined)
+            return 0;
+
+        var ms = timeout.DoubleValue;
+        return double.IsNaN(ms) || ms <= 0 ? 0 : ms;
+    }
+
+    /// <summary>
+    /// An <c>IdleDeadline</c> (Background Tasks §2.2) over the wall clock, measured from the moment
+    /// the callback is entered. Real elapsed time rather than the event loop's virtual clock,
+    /// because the budget is what bounds the work the callback does inside a single synchronous
+    /// call, which the virtual clock knows nothing about — and because a budget that never runs down
+    /// is a page's `while (deadline.timeRemaining() > n)` loop that never yields.
+    /// </summary>
+    private static JSObject CreateIdleDeadline(bool didTimeout)
+    {
+        var enteredAt = Stopwatch.GetTimestamp();
+
+        var deadline = new JSObject();
+        deadline.FastAddValue((KeyString)"didTimeout",
+            didTimeout ? JSBoolean.True : JSBoolean.False,
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        deadline.FastAddValue((KeyString)"timeRemaining",
+            new DomFunction((in _) => new JSNumber(
+                Math.Max(0, IdleBudgetMs - Stopwatch.GetElapsedTime(enteredAt).TotalMilliseconds)),
+                "timeRemaining", 0),
+            JSPropertyAttributes.EnumerableConfigurableValue);
+        return deadline;
     }
 }

--- a/src/Broiler.HtmlBridge.Dom/Runtime/WindowContextManager.cs
+++ b/src/Broiler.HtmlBridge.Dom/Runtime/WindowContextManager.cs
@@ -32,6 +32,15 @@ internal sealed class WindowContextManager(
     public JSObject? ResolveCurrentWindow()
         => GetCanonicalWindow(_browsingContexts.CurrentWindowOverride ?? _host.GetGlobal("window") as JSObject ?? _host.WindowJSObject);
 
+    /// <summary>
+    /// The sub-window whose browsing context is current, or <c>null</c> when that is the main window
+    /// (or there is no window at all). What a caller registering deferred work needs in order to ask
+    /// "was this handed to me by a frame?" — the main-window answer being the one it can ignore,
+    /// since the main context is the one everything already runs in.
+    /// </summary>
+    public JSObject? ResolveCurrentSubWindow()
+        => ResolveCurrentWindow() is { } current && _browsingContexts.IsSubWindow(current) ? current : null;
+
     public JSObject? ResolveOwnerWindow(JSObject target)
         => _eventTargets.TryGetOwnerWindow(target, out var ownerWindow) ? GetCanonicalWindow(ownerWindow) : ResolveCurrentWindow();
 


### PR DESCRIPTION
## Summary

Fixes two critical issues with deferred work in frames and the idle callback API:

1. **Frame context switching for deferred callbacks**: Callbacks registered via `setTimeout`, `setInterval`, `requestAnimationFrame`, and `requestIdleCallback` from within a frame now execute in the frame's browsing context rather than the parent's. This ensures they see the correct `document`, `location`, and `window`.

2. **Idle callback deadline implementation**: `requestIdleCallback` now properly hands the callback an `IdleDeadline` object with `timeRemaining()` and `didTimeout` properties, instead of invoking it with no arguments.

## Key Changes

- **TimerBinding.cs**: Modified timer registration functions to bind callbacks to their registering browsing context via `BindToRegisteringContext()`. Added full `RequestIdleCallback()` implementation with proper `IdleDeadline` support and timeout handling. Only frames pay the cost of context switching; main-window registrations remain unwrapped.

- **WindowContextManager.cs**: Added `ResolveCurrentSubWindow()` to identify when code is running in a frame's context, enabling proper context binding for deferred callbacks.

- **Window.cs**: Updated timer function registrations to pass `WindowContextManager` alongside `BrowserEventLoop`.

- **SubWindowBinding.cs**: Mirrored `requestIdleCallback` and `cancelIdleCallback` onto frame windows, alongside the existing animation-frame pair.

- **ElementInterfaces.cs & ElementReflectionBinding.cs**: Implemented `HTMLImageElement` IDL attributes including `src` (URL-typed, resolved against page URL), `currentSrc` (read-only, reports settled image URL), and plain reflected string attributes (`alt`, `srcset`, `sizes`, `useMap`, `crossOrigin`, `referrerPolicy`, `decoding`, `loading`, `fetchPriority`). Added `isMap` as a boolean-reflected attribute.

- **Test coverage**: Added comprehensive test suites:
  - `FrameDeferredCallbackRealmTests`: Validates frame context switching for all four timer/callback APIs
  - `ImageElementIdlTests`: Tests image element IDL attribute reflection and URL resolution
  - `VectorSkinPlatformApiTests`: Tests idle callback deadline, timeout, and cancellation
  - `SubWindowBindingModuleTests`: Tests idle callback pair mirroring to frames

## Implementation Details

- Frame callbacks are wrapped in a `DomFunction` that calls `RunWithWindowContext()` to re-enter the frame's context when the queue drains. The wrapper forwards the callback's argument (rAF timestamp or `IdleDeadline`) through the context switch.

- `IdleDeadline` provides a 50 ms budget (per Background Tasks §2.2) measured from callback entry, allowing queue-draining loops to make progress and terminate. The `didTimeout` flag is true when a timeout was specified, since a headless drain has no idle period.

- Image `src` resolution uses the same URL resolution as `<script>` and `<a>` elements, fixing MediaWiki's thumbnail walk which calls `img.src` and expects a string, not `undefined`.

- Boolean-reflected `isMap` removes the attribute when set to false, ensuring the getter reads the correct value.

https://claude.ai/code/session_018RXNCQaqnvU3VmZ29oaKuH