### PR TITLE
Document xUnit suite status and fix test failures

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -53,6 +53,54 @@ else
   fi
 fi
 
+# --- 1b. The SDK the Phase 0 fixture pins ---------------------------------------
+# tests/broiler-code-phase0/fixture/global.json pins an SDK *feature band*, and the
+# design-time evaluator honours it rather than substituting the SDK it is running
+# under — that is the behaviour Broiler.Code.Language.CSharp.Tests exercises. So "a
+# .NET 10 SDK" is not enough: the Ubuntu archive ships 10.0.1xx, the fixture asks
+# for 10.0.3xx, and `rollForward: latestFeature` will not go *down* a band. Without
+# a satisfying SDK those tests fail with "A compatible .NET SDK was not found",
+# which reads like a product bug and is not one.
+#
+# `dotnet --version` run inside the fixture is the resolver's own answer, so it is
+# the check: non-zero means nothing installed satisfies the pin.
+ensure_fixture_sdk() {
+  local fixture="$REPO_DIR/tests/broiler-code-phase0/fixture"
+  [ -f "$fixture/global.json" ] || return 0
+  command -v dotnet >/dev/null 2>&1 || return 0
+
+  if (cd "$fixture" && dotnet --version >/dev/null 2>&1); then
+    return 0
+  fi
+
+  local pinned
+  pinned="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    "$fixture/global.json" | head -1)"
+  if [ -z "$pinned" ]; then
+    log "war: could not read the SDK version pinned by the Phase 0 fixture"
+    return 0
+  fi
+
+  log "Installing the .NET SDK $pinned pinned by the Phase 0 fixture ..."
+  local script root
+  script="$(mktemp)"
+  # Install beside the SDK already on PATH so `dotnet` finds both bands.
+  root="$(dirname "$(readlink -f "$(command -v dotnet)")")"
+  if curl -sSL --connect-timeout 20 "https://dot.net/v1/dotnet-install.sh" -o "$script"; then
+    chmod +x "$script"
+    if "$script" --version "$pinned" --install-dir "$root" --no-path >/dev/null 2>&1; then
+      log ".NET SDK $pinned installed."
+    else
+      log "war: could not install the .NET SDK $pinned — the Phase 0 evaluation tests"
+      log "      (Broiler.Code.Language.CSharp.Tests) will report no compatible SDK."
+    fi
+  else
+    log "war: dotnet-install.sh unreachable (egress policy?) — skipping the $pinned SDK"
+  fi
+  rm -f "$script"
+}
+ensure_fixture_sdk
+
 # Make sure dotnet is on PATH for the rest of the session.
 if command -v dotnet >/dev/null 2>&1; then
   echo "export PATH=\"\$PATH:$(dirname "$(command -v dotnet)")\"" >> "${CLAUDE_ENV_FILE:-/dev/null}"

--- a/Broiler.Layout/Broiler.Layout.Tests/NamedPageTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/NamedPageTests.cs
@@ -196,17 +196,47 @@ public sealed class NamedPageTests
         Assert.Equal(PageHeight, container.Location.Y, 3);
     }
 
-    // An out-of-flow subtree is positioned against its containing block rather than following the
-    // flow, so a page name inside it has no page boundary to name (css-page/page-name-abspos-002).
+    // Being out of flow is not one of these. An out-of-flow box does not carry its *own* name into
+    // its parent's flow — that is a separate rule, pinned below — but its children are stacked in
+    // its own block flow, and a name change between two of them is still a page break
+    // (css-page/page-name-003, citing the Chromium bug that established it).
+    // css-page/page-name-abspos-002 states the opposite on near-identical markup and is the odd one
+    // out: Chromium fails it against its own reference too. See docs/wpt-rendering-gaps-wont-fix.md.
     [Theory]
     [InlineData(CssConstants.Absolute)]
     [InlineData(CssConstants.Fixed)]
-    public void A_Page_Name_Inside_An_Out_Of_Flow_Subtree_Breaks_Nothing(string position)
+    public void A_Page_Name_Change_Inside_An_Out_Of_Flow_Subtree_Still_Breaks(string position)
     {
-        AssertNamesChangeNothing((container, first, second) =>
-        {
-            container.Position = position;
-        });
+        var root = Root();
+        var container = Block(root, height: null);
+        container.Position = position;
+        Block(container, ChildHeight, page: "a");
+        var second = Block(container, ChildHeight, page: "b");
+
+        root.PerformLayout(root.LayoutEnvironment);
+
+        Assert.Equal(PageHeight, second.Location.Y, 3);
+    }
+
+    // ...and the other half of that pair: the out-of-flow box's own name never reaches the flow it
+    // was taken out of, so the two in-flow siblings around it share a page and nothing breaks
+    // (css-page/page-name-abspos-001).
+    [Theory]
+    [InlineData(CssConstants.Absolute)]
+    [InlineData(CssConstants.Fixed)]
+    public void An_Out_Of_Flow_Boxs_Own_Page_Name_Stays_Out_Of_The_Flow(string position)
+    {
+        var root = Root();
+        Block(root, ChildHeight, page: "a");
+
+        var outOfFlow = Block(root, ChildHeight, page: "b");
+        outOfFlow.Position = position;
+
+        var third = Block(root, ChildHeight, page: "a");
+
+        root.PerformLayout(root.LayoutEnvironment);
+
+        Assert.Equal(ChildHeight, third.Location.Y, 3);
     }
 
     // A box whose block axis is not the page's stacks its children sideways, where a page boundary
@@ -240,8 +270,8 @@ public sealed class NamedPageTests
     /// </summary>
     /// <remarks>
     /// The comparison is against the same tree rather than against a stated coordinate because
-    /// these are the cases where the container places its children itself: a flex container, an
-    /// out-of-flow box, a box writing sideways. Where those put their children is the container's
+    /// these are the cases where the container places its children itself: a flex or grid
+    /// container, a box writing sideways. Where those put their children is the container's
     /// business, and asserting a number here would be asserting that as well. What the rule claims
     /// is only that the names change nothing, which is exactly what this measures.
     /// </remarks>

--- a/docs/xunit-suite-status.md
+++ b/docs/xunit-suite-status.md
@@ -1,0 +1,146 @@
+# xUnit suite status
+
+What `dotnet test` reports across the main repo's xUnit projects, why the failures
+are there, and what it takes to run the suite at all. Measured on Linux, 4 cores,
+16 GB, .NET SDK 10.0.302, submodules at the pinned pointers.
+
+Keep it current when a project's result changes — the point of the file is that
+"is this failure mine?" is answerable without a bisect.
+
+## Nothing in CI runs `dotnet test`
+
+`.github/workflows/` holds six workflows — preview packaging, NuGet packaging,
+Octane, real-world renders, WPT reftests and WPT tests. None of them runs the
+xUnit suite. The WPT workflows run `src/Broiler.Wpt` (the standards runner) and
+score it against `tests/wpt-baseline`; that is a different thing from
+`Broiler.Wpt.Tests`, which is the hand-written xUnit coverage *of* that runner
+and is not gated anywhere.
+
+So a change can turn an xUnit test red and land. That is the mechanism behind
+most of what is listed below, and it is worth fixing before the list is.
+
+## Where it stands
+
+29 xUnit projects, ~4 800 `[Fact]`s plus theory cases. 27 are green:
+
+| Project group | Projects | Result |
+| --- | --- | --- |
+| `Broiler.Documents.*.Tests` | 7 | green |
+| `Broiler.UI.*.Tests` | 11 | green |
+| `Broiler.Layout.Tests` | 1 | green — 1 126 tests |
+| `src/*.Tests` except the two below | 8 | green |
+| `src/Broiler.Wpt.Tests` | 1 | **54 failing** of 1 083 |
+| `src/Broiler.Cli.Tests` | 1 | **52 failing** of 3 485 (48 distinct tests) |
+
+`Broiler.Media.*` and `Broiler.Input.*` also live under `*.Tests` names but are
+not xUnit — they are `Exe` projects with their own `Main`, and nothing here
+covers them.
+
+## These failures are not new
+
+A 372-test slice covering nine of the failing classes was run against a build of
+`bd23ca0` — the oldest commit this repository's history contains (2026-08-17;
+`main` is force-rewritten as changes land, so that is the whole visible history).
+It produced the same failure set there, give or take two tests fixed since. So
+for the classes checked there is no regression point to bisect to, and the suite
+has not been green in any history available here.
+
+The ones that *were* traceable to a change are fixed, and they share a shape:
+a deliberate behaviour change landed with its own reasoning, and the test that
+pinned the old behaviour was left behind.
+
+* **`NamedPageTests.A_Page_Name_Inside_An_Out_Of_Flow_Subtree_Breaks_Nothing`**
+  asserted that a page-name change inside an out-of-flow subtree does not break.
+  "Break on a page name inside an out-of-flow subtree" made it break on purpose,
+  adjudicated the two WPT tests that state the rule opposite ways, and wrote the
+  losing one up in `docs/wpt-rendering-gaps-wont-fix.md` — without touching this
+  test. It now pins the rule that shipped, alongside a new one for the half that
+  still holds (an out-of-flow box's own name stays out of its parent's flow).
+* **`GraphicsAbstractionTests`** (3 tests) asserted nearest-neighbour sampling
+  on an upscaled blit. `Broiler.HTML`'s "Filter a bitmap when it is drawn at a
+  size other than its own" made scaled blits bilinear on purpose and measured
+  the gain; the tests now draw 1:1, which is what they were pinning.
+* **`WptTestRunnerTests.RunTempScriptExecution`** reflected into
+  `ExecuteScriptsWithDom` and cast its result to `string`. That method returns an
+  `ExecutedDocument` now — HTML *or* a `DomDocument`, whichever the render path
+  wants — so six tests failed before reaching their own assertions.
+* **`CssExtractionPhaseZeroTests`** (3 tests) had been overtaken by the
+  retirement they guard: a directory the test enumerates is gone (so
+  `EnumerateFiles` threw where an empty directory would have passed), `CssData`
+  shed two more members, and `Broiler.Layout`'s friend surface grew by five
+  grants that each carry their reason in the csproj beside them.
+* **`Broiler.Browser.Core.Tests`** did not compile at all —
+  `HtmlDocumentParser.ParseDocument` is static and one call site still
+  constructed a parser (CS0176), the same fix `Broiler.Documents.Html` and
+  `Broiler.Cli.Tests` already took. `Broiler.DOM`'s own `Broiler.Dom.Html.Tests`
+  has it too, in two files; that fix is `patches/0001-…` (its remote is outside
+  this session's scope, so the pointer is not bumped) and takes that project
+  from "does not build" to 41 green tests.
+
+## `src/Broiler.Wpt.Tests` — 54
+
+| Kind | Count | What it means |
+| --- | --- | --- |
+| Pixel comparison below threshold | 31 | The render differs from the checked-in Chromium reference by more than 1%. Real layout/paint gaps: `align-content-block-00{2,4,6,8,10}` land at 92–96% with content displaced by tens of pixels, the six `position-area-*` tests at 90–96%, `writing-modes/select[size]` at 55.6%. |
+| Scripted DOM / geometry assertion | 21 | A feature the test drives from script does not behave as asserted: SVG hit-testing through `elementFromPoint`, `scrollIntoView` axis mapping under writing modes, `position-visibility`, `position-try` fallbacks, keyframes collected from a `<style>` element's text content. |
+| Wall-clock | 2 | `ScrollWriteGeometryTimeoutTests.OverflowAlignment_ScrollWrites_RenderWellWithinRunnerTimeout` (20 s budget) and `WptTestRunnerTests.RunTestWithTimeout_GridTemplateColumnsCrash_Completes_Without_Timing_Out` (6 s). Both are sensitive to what else is running on the box. |
+
+The scripted-DOM group overlaps `Broiler.Cli.Tests` almost test for test — the
+same features are covered on both sides of the bridge, so a fix there closes
+two failures at once. `Wpt_CssomView_ElementFromPoint_Uses_Svg_Groups_…` and
+`GoogleSearchPolyfillTests.Document_HitTesting_Uses_Svg_Groups_…` are the same
+assertion.
+
+## `src/Broiler.Cli.Tests` — 48 distinct tests (52 cases)
+
+| Kind | Count | Examples |
+| --- | --- | --- |
+| Engine feature gaps | 37 | `GoogleSearchPolyfillTests` alone is 11 of them: SVG hit-testing, `scrollIntoView` under writing modes, `ch`/`lh`/`rlh` under `zoom`, scroll-offset clamping. The rest spread over `background-clip: border-area`, `var()` in shorthands, `:lang` against `xml:lang`, grid/flex content sizing, serialization of mutated iframe scroll state, and the sub-document module drain described below. |
+| Acid targets not yet met | 4 | Acid3 scores 96; `PhaseD_…_At_Least_97` and `PhaseE_…_At_Least_100` state the targets, and `V7_Acid3_Image_Capture_Produces_Valid_Output` asserts 100. These are goals, not regressions. |
+| Architecture guards the code has drifted past | 4 | `HtmlBridgeArchitectureGuardTests` (files over the 750-line limit), `HtmlBridgeBoundaryGuardTests` (the frozen `Broiler.JavaScript.*` dependency set has grown to three), `DomWrapperFunctionTests` (`new JSFunction(` where `DomFunction` is wanted), `CssExtractionPhaseThreeTests`. Each names the refactor it wants; none can be closed by editing the test, which is the difference between these and the `CssExtractionPhaseZeroTests` fixed above. |
+| Missing artifact | 1 | `AcidRenderComparisonInfrastructureTests.Acid_Umbrella_Roadmap_Covers_All_Three_Tests` requires `docs/roadmap/acid-test-triage.md` with `## Acid1`, `## Acid2` and `## Acid3` headings. No such file has existed in this history, and writing one to satisfy the assertion would be inventing the plan it is meant to check. |
+| Environmental | 2 | `PdfToWordConverterTests` needs the `Broiler.Pdf` app, which a bare container does not build. |
+
+One more is load-sensitive rather than broken:
+`ScriptCompileAheadOverlapTests.Every_Source_Is_Compiled_By_A_Worker_When_The_Budget_Is_On`
+failed in one full run and passed in the next and in isolation.
+
+## Running it
+
+* **The Phase 0 fixture pins an SDK feature band.**
+  `tests/broiler-code-phase0/fixture/global.json` asks for 10.0.302 with
+  `rollForward: latestFeature`, which will not roll *down* a band — so the
+  Ubuntu archive's 10.0.1xx does not satisfy it and
+  `Broiler.Code.Language.CSharp.Tests` reports "A compatible .NET SDK was not
+  found" for two tests. `.claude/hooks/session-start.sh` installs a satisfying
+  SDK beside whatever is on PATH; `cd tests/broiler-code-phase0/fixture &&
+  dotnet --version` is the check.
+* **`Broiler.Cli.Tests` used to hang, and it was one test.**
+  `SubDocumentEngineModuleTests.Iframe_Module_Runs_Through_Engine_Path_When_Parent_Is_ModuleContext`
+  assigns an iframe's `srcdoc` from script, so `DomBridge.ExecuteSubDocumentScripts`
+  ran the frame's ES-module root *while the parent's script was still on the
+  stack* — and awaited it synchronously. The engine queues a module's
+  continuations to run when the outermost execution finishes, which is the call
+  that was blocking, so the thread deadlocked. It is a hang rather than a
+  failure, and a synchronous `[Fact]` at that: xUnit 2.5.3 ignores `Timeout` on
+  one, so nothing ever cancelled it and no test scheduled after it in the run
+  executed. That is why the project appeared to stop around test ~3 200 with a
+  large heap — the heap was a symptom of a run that never ended, not the cause.
+
+  The module root is now started and not awaited (it is deferred anyway), with
+  a continuation to report a failure that would otherwise go unobserved. The
+  test now *fails* in two seconds instead of hanging: the frame's DOM effect
+  needs a drain that nothing in the test performs, which is a real gap in the
+  engine-only module path and is listed above. With that unblocked the project
+  runs end to end for the first time — 3 485 tests in 5.3 minutes.
+* **`ScriptCompileAheadOverlapTests` is a benchmark, not a unit test.** Its
+  collection takes the test host from nothing to ~8.7 GB in 140 seconds — it
+  compiles ~60 000 functions across its repetitions, and the memory is
+  *reachable*, not garbage (an aggressive blocking compacting `GC.Collect`
+  after every test in the class recovers almost none of it). All 49 tests pass,
+  and a retention that size in the script-compile path is worth a look on its
+  own account. Filter the collection out when running the project for a quick
+  answer.
+* Some `Wpt_*_MatchesReference` tests and the PDF conversion tests can fail in a
+  bare container for environmental reasons. Baseline before attributing a
+  failure to your change.

--- a/patches/0001-dom-static-parsedocument-in-tests.patch
+++ b/patches/0001-dom-static-parsedocument-in-tests.patch
@@ -1,0 +1,112 @@
+From 8e8e50e40a4fac49d155ba9f44a7cded2aa34708 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 21 Aug 2026 10:54:41 +0000
+Subject: [PATCH] Call HtmlDocumentParser.ParseDocument on the type, not an
+ instance
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+ParseDocument and ParseFragment are static, and Broiler.Dom.Html.Tests still
+constructs a parser to call them on in two files. That is CS0176, so the test
+project does not compile at all — its 41 tests have not run since the methods
+became static.
+
+No behaviour changes; the calls are the same calls.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ Broiler.Dom.Html.Tests/HtmlDocumentParserTests.cs | 13 ++++++-------
+ Broiler.Dom.Html.Tests/NoscriptRawTextTests.cs    |  6 +++---
+ 2 files changed, 9 insertions(+), 10 deletions(-)
+
+diff --git a/Broiler.Dom.Html.Tests/HtmlDocumentParserTests.cs b/Broiler.Dom.Html.Tests/HtmlDocumentParserTests.cs
+index 9efc069..55f99dc 100644
+--- a/Broiler.Dom.Html.Tests/HtmlDocumentParserTests.cs
++++ b/Broiler.Dom.Html.Tests/HtmlDocumentParserTests.cs
+@@ -49,7 +49,7 @@ public sealed class HtmlDocumentParserTests
+     [Fact(Timeout = 600000)]
+     public void Document_Parser_Carries_Doctype_Identifiers_Onto_The_DocumentType_Node()
+     {
+-        var result = new HtmlDocumentParser().ParseDocument(
++        var result = HtmlDocumentParser.ParseDocument(
+             "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\" " +
+             "\"http://www.w3.org/TR/html4/strict.dtd\"><html><body>x</body></html>");
+ 
+@@ -63,7 +63,7 @@ public sealed class HtmlDocumentParserTests
+     [Fact(Timeout = 600000)]
+     public void Document_Parser_Creates_Implicit_Structure_And_Table_Section()
+     {
+-        var result = new HtmlDocumentParser().ParseDocument(
++        var result = HtmlDocumentParser.ParseDocument(
+             "<title>Shared</title><table><tr><td>cell</td></tr></table>");
+ 
+         Assert.Equal("Shared", result.Title);
+@@ -81,7 +81,7 @@ public sealed class HtmlDocumentParserTests
+         // text (ubiquitous in WPT reftests: "Test passes if …") must place that
+         // text in the body, not the head — otherwise it never renders and the
+         // following content shifts up by a line.
+-        var result = new HtmlDocumentParser().ParseDocument(
++        var result = HtmlDocumentParser.ParseDocument(
+             "<style>.x{}</style>\nTest passes if no red is visible.\n<div></div>");
+ 
+         var bodyText = result.Document.Body!.ChildNodes
+@@ -100,7 +100,7 @@ public sealed class HtmlDocumentParserTests
+     [Fact(Timeout = 600000)]
+     public void Fragment_Parser_Uses_Context_Sensitive_Table_Rules()
+     {
+-        var result = new HtmlDocumentParser().ParseFragment(
++        var result = HtmlDocumentParser.ParseFragment(
+             "<td id='cell'>value</td>",
+             "tr");
+ 
+@@ -112,13 +112,12 @@ public sealed class HtmlDocumentParserTests
+     [Fact(Timeout = 600000)]
+     public void Serialization_RoundTrip_Is_Deterministic()
+     {
+-        var parser = new HtmlDocumentParser();
+-        var firstDocument = parser.ParseDocument(
++        var firstDocument = HtmlDocumentParser.ParseDocument(
+             "<main id='host'><span class='value'>hello</span><!--note--></main>").Document;
+         var first = HtmlSerializer.Serialize(
+             firstDocument.DocumentElement!,
+             new HtmlSerializationOptions(IncludeHtmlDoctype: true));
+-        var secondDocument = parser.ParseDocument(first).Document;
++        var secondDocument = HtmlDocumentParser.ParseDocument(first).Document;
+         var second = HtmlSerializer.Serialize(
+             secondDocument.DocumentElement!,
+             new HtmlSerializationOptions(IncludeHtmlDoctype: true));
+diff --git a/Broiler.Dom.Html.Tests/NoscriptRawTextTests.cs b/Broiler.Dom.Html.Tests/NoscriptRawTextTests.cs
+index aeb571a..63fe2d9 100644
+--- a/Broiler.Dom.Html.Tests/NoscriptRawTextTests.cs
++++ b/Broiler.Dom.Html.Tests/NoscriptRawTextTests.cs
+@@ -47,7 +47,7 @@ public sealed class NoscriptRawTextTests
+     [Fact(Timeout = 600000)]
+     public void AScriptInsideIsTextAndNotAScriptElement()
+     {
+-        var document = new HtmlDocumentParser()
++        var document = HtmlDocumentParser
+             .ParseDocument("<html><body><noscript><script>boom()</script></noscript></body></html>")
+             .Document;
+ 
+@@ -59,7 +59,7 @@ public sealed class NoscriptRawTextTests
+     [Fact(Timeout = 600000)]
+     public void TheContentBecomesASingleTextChild()
+     {
+-        var document = new HtmlDocumentParser()
++        var document = HtmlDocumentParser
+             .ParseDocument("<html><body><noscript><p>a</p><p>b</p></noscript></body></html>")
+             .Document;
+ 
+@@ -86,7 +86,7 @@ public sealed class NoscriptRawTextTests
+     [Fact(Timeout = 600000)]
+     public void ParsingResumesNormallyAfterTheEndTag()
+     {
+-        var document = new HtmlDocumentParser()
++        var document = HtmlDocumentParser
+             .ParseDocument("<html><body><noscript><p>hidden</p></noscript><div id='after'>x</div></body></html>")
+             .Document;
+ 
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,41 @@
+# Submodule patches
+
+Changes that belong in a submodule but could not be pushed to its remote: the
+session's git proxy only injects a credential for repositories in the session's
+GitHub scope, and `Broiler-Platform/Broiler.*` is outside it, so
+`git push origin HEAD` from inside a submodule returns **403**. Per
+`CLAUDE.md` → "Submodules: modify them; push if allowed, otherwise deliver as a
+PATCH", the change is exported here instead and **no gitlink is bumped** — CI
+clones each submodule by pointer, and a pointer moved to a commit that was never
+pushed would break it.
+
+Apply one with `git am` from inside the submodule it names, then bump the
+pointer in the parent:
+
+```sh
+cd <Submodule>
+git am ../patches/NNNN-<slug>.patch
+git push origin HEAD          # from a session/CI with the broader scope
+cd ..
+git add <Submodule> && git commit -m "Update submodules"
+```
+
+This directory is a backlog, not an archive: a patch is deleted once its fix is
+upstream and the numbering restarts from `0001` against whatever is left. A
+`patches/NNNN` reference in an older commit message or document is therefore
+almost always dangling — name the **commit subject** instead. To check whether a
+fix is already live:
+
+```sh
+git -C <Submodule> log --oneline --grep '<subject>'
+```
+
+## Index
+
+| Patch | Submodule | Commit subject | Why |
+| --- | --- | --- | --- |
+| `0001-dom-static-parsedocument-in-tests.patch` | `Broiler.DOM` | Call HtmlDocumentParser.ParseDocument on the type, not an instance | `ParseDocument`/`ParseFragment` are static; two files in `Broiler.Dom.Html.Tests` still construct a parser to call them on. That is CS0176, so the test project does not compile and its 41 tests do not run. With the patch applied they compile and all 41 pass. |
+
+`Broiler.DOM` is checked out twice — at `Broiler.DOM` and, at the same commit, at
+`Broiler.CSS/Broiler.DOM` (`scripts/check-submodule-sha-drift.sh` enforces that
+they match). Patch `0001` is applied once and both gitlinks move together.

--- a/src/Broiler.Browser.Core.Tests/HtmlFormSerializerTests.cs
+++ b/src/Broiler.Browser.Core.Tests/HtmlFormSerializerTests.cs
@@ -13,7 +13,7 @@ namespace Broiler.Browser.Core.Tests;
 public class HtmlFormSerializerTests
 {
     private static DomElement Parse(string html) =>
-        new HtmlDocumentParser().ParseDocument(html).Document.DocumentElement
+        HtmlDocumentParser.ParseDocument(html).Document.DocumentElement
         ?? throw new InvalidOperationException("No document element.");
 
     private static DomElement Form(string html) =>

--- a/src/Broiler.Cli.Tests/CssExtractionPhaseZeroTests.cs
+++ b/src/Broiler.Cli.Tests/CssExtractionPhaseZeroTests.cs
@@ -16,10 +16,13 @@ public sealed class CssExtractionPhaseZeroTests
         var htmlSource = Path.Combine(root, "Broiler.HTML", "Source");
 
         Assert.False(File.Exists(Path.Combine(htmlSource, "Broiler.HTML.CSS", "Broiler.HTML.CSS.csproj")));
-        Assert.Empty(Directory.EnumerateFiles(
-            Path.Combine(htmlSource, "Broiler.HTML.Orchestration", "CompatibilityCss"),
-            "*.cs",
-            SearchOption.AllDirectories));
+
+        // The directory is gone once the last shim in it is retired, which is this assertion's
+        // point rather than a case it has to survive — but EnumerateFiles on a missing path throws
+        // where an empty one returns nothing, so the strongest outcome would fail the test.
+        var compatibilityCss = Path.Combine(htmlSource, "Broiler.HTML.Orchestration", "CompatibilityCss");
+        if (Directory.Exists(compatibilityCss))
+            Assert.Empty(Directory.EnumerateFiles(compatibilityCss, "*.cs", SearchOption.AllDirectories));
 
         var legacyModels = new[]
         {
@@ -64,9 +67,9 @@ public sealed class CssExtractionPhaseZeroTests
             .OrderBy(static member => member, StringComparer.Ordinal)
             .ToArray();
 
-        Assert.Equal(
-            ["Method:Clone", "Method:Combine", "Property:StyleSet", "Property:StyleSheet"],
-            members);
+        // Clone and Combine went with the compatibility window they were kept open for; what is
+        // left is the wrapper this asserts CssData is, and nothing may be added back to it.
+        Assert.Equal(["Property:StyleSet", "Property:StyleSheet"], members);
     }
 
     [Fact(Timeout = 600000)]
@@ -119,15 +122,20 @@ public sealed class CssExtractionPhaseZeroTests
             .Select(static line => line.Trim())
             .ToArray();
 
-        // RF-LAYOUT-1 trimmed the friend surface to seven direct box-tree consumers
-        // (three production: Broiler.HTML.Dom/.HTML/.Orchestration; plus DevConsole and
-        // three focused test assemblies). Keep this count in sync with the csproj.
-        Assert.Equal(7, grants.Length);
+        // RF-LAYOUT-1 trimmed the friend surface to seven direct box-tree consumers; the five
+        // added since each carry their reason in the csproj beside them (a nested browsing
+        // context's canvas opacity, the two benchmark/runner knobs, and the two assemblies that
+        // set NativeAnchorPlacement around a geometry pass). Keep this count in sync with the
+        // csproj — a grant added without one is what this is here to catch.
+        Assert.Equal(12, grants.Length);
         Assert.DoesNotContain(grants, static line => line.Contains("Broiler.HTML.Core", StringComparison.Ordinal));
         Assert.DoesNotContain(grants, static line => line.Contains("Broiler.HTML.Image.Compat", StringComparison.Ordinal));
         Assert.DoesNotContain(grants, static line => line.Contains("Broiler.HTML.Image.Tests", StringComparison.Ordinal));
         Assert.DoesNotContain(grants, static line => line.Contains("Broiler.HTML.WPF", StringComparison.Ordinal));
-        Assert.DoesNotContain(grants, static line => line.Contains("Broiler.HtmlBridge", StringComparison.Ordinal));
+        // Broiler.HtmlBridge itself, not Broiler.HtmlBridge.Dom — the bridge assembly reaches the
+        // box tree through the renderer, while .Dom is one of the two that set
+        // NativeAnchorPlacement directly and is granted deliberately above.
+        Assert.DoesNotContain(grants, static line => line.Contains("Broiler.HtmlBridge\"", StringComparison.Ordinal));
         Assert.DoesNotContain(grants, static line => line.Contains("Broiler.Cli\"", StringComparison.Ordinal));
     }
 

--- a/src/Broiler.Cli.Tests/GraphicsAbstractionTests.cs
+++ b/src/Broiler.Cli.Tests/GraphicsAbstractionTests.cs
@@ -376,11 +376,23 @@ public class GraphicsAbstractionTests
     [Fact(Timeout = 600000)]
     public void Raster_Stream_Image_Load_Uses_BackendNeutral_Bitmap_Without_Materializing_Skia_Compat_Bitmap()
     {
-        using var source = new BBitmap(2, 2);
-        source.SetPixel(0, 0, new BColor(255, 0, 0, 255));
-        source.SetPixel(1, 0, new BColor(0, 255, 0, 255));
-        source.SetPixel(0, 1, new BColor(0, 0, 255, 255));
-        source.SetPixel(1, 1, new BColor(255, 255, 0, 255));
+        // Quadrants of a 4x4, blitted 1:1 — a scaled blit is sampled bilinearly now and would not
+        // land the source's own colours on the pixels asserted below. See the blit test further
+        // down; what this one is about is that neither side materialises a Skia bitmap.
+        using var source = new BBitmap(4, 4);
+        for (int y = 0; y < 4; y++)
+        {
+            for (int x = 0; x < 4; x++)
+            {
+                source.SetPixel(x, y, (x < 2, y < 2) switch
+                {
+                    (true, true) => new BColor(255, 0, 0, 255),
+                    (false, true) => new BColor(0, 255, 0, 255),
+                    (true, false) => new BColor(0, 0, 255, 255),
+                    (false, false) => new BColor(255, 255, 0, 255),
+                });
+            }
+        }
 
         using var loaded = Assert.IsType<ImageAdapter>(
             StubImageAdapter.Instance.ImageFromStream(new MemoryStream(source.Encode(ImageEncodeFormat.Png))));
@@ -1136,9 +1148,18 @@ public class GraphicsAbstractionTests
     [Fact(Timeout = 600000)]
     public void BBitmap_OpenGraphics_Routes_Image_Blit_Through_Backend_Neutral_Primitives()
     {
-        using var source = new BBitmap(2, 1);
-        source.SetPixel(0, 0, new BColor(255, 0, 0, 255));
-        source.SetPixel(1, 0, new BColor(0, 0, 255, 255));
+        // Drawn 1:1. BCanvas.DrawBitmap samples bilinearly whenever the destination is not the
+        // source's own size ("Filter a bitmap when it is drawn at a size other than its own"), so
+        // a scaled blit no longer lands exact source colours on the edge pixels. What this pins is
+        // the routing, not the sampling, and at 1:1 the two are separable again.
+        using var source = new BBitmap(4, 2);
+        for (int y = 0; y < 2; y++)
+        {
+            source.SetPixel(0, y, new BColor(255, 0, 0, 255));
+            source.SetPixel(1, y, new BColor(255, 0, 0, 255));
+            source.SetPixel(2, y, new BColor(0, 0, 255, 255));
+            source.SetPixel(3, y, new BColor(0, 0, 255, 255));
+        }
 
         using var dest = new BBitmap(4, 2);
         dest.Clear(BColor.White);
@@ -1156,9 +1177,17 @@ public class GraphicsAbstractionTests
     [Fact(Timeout = 600000)]
     public void HtmlContainer_PerformPaint_With_BBitmap_Surface_Renders_Background_Image()
     {
-        using var source = new BBitmap(2, 1);
-        source.SetPixel(0, 0, new BColor(255, 0, 0, 255));
-        source.SetPixel(1, 0, new BColor(0, 0, 255, 255));
+        // 4x2 and painted at 4px x 2px: the background is drawn at the image's own size, which is
+        // the path that samples a source pixel exactly. See the sibling blit test above.
+        using var source = new BBitmap(4, 2);
+        for (int y = 0; y < 2; y++)
+        {
+            source.SetPixel(0, y, new BColor(255, 0, 0, 255));
+            source.SetPixel(1, y, new BColor(255, 0, 0, 255));
+            source.SetPixel(2, y, new BColor(0, 0, 255, 255));
+            source.SetPixel(3, y, new BColor(0, 0, 255, 255));
+        }
+
         string pngBase64 = Convert.ToBase64String(source.Encode(ImageEncodeFormat.Png, 100));
 
         using var container = new HtmlContainer();

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/SubDocuments.cs
@@ -405,8 +405,28 @@ public sealed partial class DomBridge
                 {
                     try
                     {
-                        subModuleContext.RunScriptAsync(root.Source, root.BaseUrl ?? subBaseUrl ?? string.Empty,
-                            uniqueModuleID: root.Key).GetAwaiter().GetResult();
+                        // Started here, awaited only if it is already done. Unlike the main page's roots
+                        // (ScriptEngine.RunPageScripts, which runs between executions), this code is
+                        // reached *from inside* one: a frame's srcdoc is assigned by the parent's script,
+                        // so that script is still on the stack. The engine queues a module's
+                        // continuations to run when the outermost execution finishes, so blocking here
+                        // waits for work that cannot start until this call returns — the thread
+                        // deadlocks outright. An iframe module with a static `data:` import is enough to
+                        // do it, and it is a *hang*, not a failure: the whole process stops there.
+                        //
+                        // Not awaiting is also what a module means. Modules are deferred, so the frame's
+                        // DOM effects are due when the engine drains at the end of the outer execution —
+                        // before anything the page does next can observe them — rather than at the
+                        // assignment that queued them.
+                        var run = subModuleContext.RunScriptAsync(
+                            root.Source,
+                            root.BaseUrl ?? subBaseUrl ?? string.Empty,
+                            uniqueModuleID: root.Key);
+
+                        if (run.IsCompleted)
+                            run.GetAwaiter().GetResult();
+                        else
+                            LogSubDocumentModuleFailure(run, root.Key);
                     }
                     catch (Exception ex)
                     {
@@ -421,6 +441,27 @@ public sealed partial class DomBridge
             RecordSubDocumentGlobals(containerElement, globalsBefore);
         });
     }
+
+    /// <summary>
+    /// Reports a sub-document module root that failed after the call that started it had returned.
+    /// </summary>
+    /// <remarks>
+    /// The root above is not awaited, so nothing else observes its exception; without this the module
+    /// would simply appear not to have run, which is the one outcome that looks identical to the
+    /// documented limitation and so hides a real failure inside it.
+    /// </remarks>
+    private static void LogSubDocumentModuleFailure(System.Threading.Tasks.Task run, string key) =>
+        run.ContinueWith(
+            completed => RenderLogger.LogWarning(
+                LogCategory.JavaScript,
+                "DomBridge.ExecuteSubDocumentScripts",
+                $"Sub-document module root {key} error: " +
+                    $"{completed.Exception?.GetBaseException().Message}",
+                completed.Exception),
+            System.Threading.CancellationToken.None,
+            System.Threading.Tasks.TaskContinuationOptions.OnlyOnFaulted
+                | System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously,
+            System.Threading.Tasks.TaskScheduler.Default);
 
     /// <summary>
     /// Returns true if the content type indicates XML-family content

--- a/src/Broiler.Wpt.Tests/DomRenderCollection.cs
+++ b/src/Broiler.Wpt.Tests/DomRenderCollection.cs
@@ -1,0 +1,13 @@
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// Serializes the classes that toggle the process-wide <see cref="WptTestRunner.DomRender"/>
+/// lever around a render or a script pass. It selects which form
+/// <c>WptTestRunner.ExecuteScriptsWithDom</c> hands back — the serialised HTML, or the
+/// <c>DomDocument</c> itself — so a class that sets it can change what another class's
+/// concurrently-running test is given back. That is a shared-static race rather than a product
+/// bug; membership in this collection makes xUnit run these classes sequentially, the same way
+/// <see cref="NativeAnchorWptCollection"/> does for the anchor-placement lever.
+/// </summary>
+[Xunit.CollectionDefinition("DomRender", DisableParallelization = true)]
+public sealed class DomRenderCollection { }

--- a/src/Broiler.Wpt.Tests/DomRenderFidelityTests.cs
+++ b/src/Broiler.Wpt.Tests/DomRenderFidelityTests.cs
@@ -20,6 +20,7 @@ namespace Broiler.Wpt.Tests;
 /// body-targeted style, and an ordinary document must render the same on both paths.
 /// </para>
 /// </remarks>
+[Collection("DomRender")]
 public sealed class DomRenderFidelityTests : IDisposable
 {
     private readonly string _tempDir;

--- a/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
+++ b/src/Broiler.Wpt.Tests/WptTestRunnerTests.cs
@@ -9,6 +9,7 @@ namespace Broiler.Wpt.Tests;
 /// Unit tests for <see cref="WptTestRunner"/> — validates test discovery,
 /// rendering pipeline, and result reporting.
 /// </summary>
+[Collection("DomRender")]
 public class WptTestRunnerTests : IDisposable
 {
     private readonly string _tempDir;
@@ -75,6 +76,16 @@ public class WptTestRunnerTests : IDisposable
         return runner.RunMatchTest(testFile, refFile, _tempDir);
     }
 
+    /// <summary>
+    /// Runs a document's scripts through the runner's script/DOM pass and returns the document they
+    /// left behind, as HTML.
+    /// </summary>
+    /// <remarks>
+    /// The pass hands back whichever form the render path wants — the serialised HTML, or the
+    /// <c>DomDocument</c> itself on the direct path (<see cref="WptTestRunner.DomRender"/>, which is
+    /// on by default). Only the bridge can serialise the latter, and it is gone by the time the pass
+    /// returns, so the lever is set here rather than read: every caller of this asserts on the text.
+    /// </remarks>
     private string RunTempScriptExecution(string testHtml, string namePrefix)
     {
         var testFile = Path.Combine(_tempDir, $"{namePrefix}.html");
@@ -85,9 +96,22 @@ public class WptTestRunnerTests : IDisposable
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
         Assert.NotNull(method);
 
-        return Assert.IsType<string>(method!.Invoke(
-            null,
-            [testHtml, new Uri(Path.GetFullPath(testFile)).AbsoluteUri, _tempDir, false]));
+        var previousDomRender = WptTestRunner.DomRender;
+        WptTestRunner.DomRender = false;
+        object? executed;
+        try
+        {
+            executed = method!.Invoke(
+                null,
+                [testHtml, new Uri(Path.GetFullPath(testFile)).AbsoluteUri, _tempDir, false]);
+        }
+        finally
+        {
+            WptTestRunner.DomRender = previousDomRender;
+        }
+
+        Assert.NotNull(executed);
+        return Assert.IsType<string>(executed!.GetType().GetProperty("Html")!.GetValue(executed));
     }
 
     private void WriteTempSupportFile(string relativePath, string content)


### PR DESCRIPTION
## Summary

This PR documents the current state of the xUnit test suite across 29 projects (~4,800 tests), identifies why 106 tests are failing across two projects, and fixes several categories of failures. It also includes a patch for a submodule compilation error and infrastructure improvements for test isolation.

## Key Changes

**Documentation & Analysis**
- Added `docs/xunit-suite-status.md` cataloging all 29 xUnit projects, their pass/fail status, and detailed analysis of the 106 failing tests across `Broiler.Wpt.Tests` (54 failures) and `Broiler.Cli.Tests` (52 failures)
- Documented that failures fall into categories: pixel comparison gaps, scripted DOM/geometry assertions, wall-clock timeouts, engine feature gaps, Acid targets, architecture guards, and environmental issues
- Noted that the xUnit suite is not gated in CI, allowing regressions to land

**Test Fixes**
- **`NamedPageTests`**: Split `A_Page_Name_Inside_An_Out_Of_Flow_Subtree_Breaks_Nothing` into two tests reflecting the actual CSS spec behavior: one asserting page-name changes *inside* out-of-flow subtrees still break (matching css-page/page-name-003), and another asserting the out-of-flow box's *own* name stays out of flow (css-page/page-name-abspos-001)
- **`GraphicsAbstractionTests`**: Updated three tests to draw bitmaps at 1:1 scale instead of scaled, since scaled blits now use bilinear sampling by design; added explanatory comments
- **`WptTestRunnerTests.RunTempScriptExecution`**: Fixed reflection-based test that was casting `ExecuteScriptsWithDom` result to `string` when it now returns `ExecutedDocument`; added logic to toggle `WptTestRunner.DomRender` to ensure HTML serialization
- **`CssExtractionPhaseZeroTests`**: Made directory enumeration defensive (check existence before enumerating), updated expected member counts for `CssData` (removed `Clone`/`Combine`) and `Broiler.Layout` friend surface (increased from 7 to 12 grants with documented reasons)
- **`HtmlBrowser.Core.Tests`**: Fixed static method call on `HtmlDocumentParser.ParseDocument` (was constructing instance)

**Submodule Patch**
- Added `patches/0001-dom-static-parsedocument-in-tests.patch` for `Broiler.DOM`: fixes CS0176 compilation error in `Broiler.Dom.Html.Tests` where two files construct a parser to call static methods; enables 41 previously-unrun tests
- Added `patches/README.md` documenting the patch workflow and index

**Infrastructure**
- Added `DomRenderCollection.cs` with xUnit collection definition to serialize tests that toggle the process-wide `WptTestRunner.DomRender` lever, preventing race conditions
- Marked `WptTestRunnerTests` and `DomRenderFidelityTests` with `[Collection("DomRender")]` to enforce sequential execution
- Enhanced `.claude/hooks/session-start.sh` with `ensure_fixture_sdk()` to install the .NET SDK feature band pinned by `tests/broiler-code-phase0/fixture/global.json`, fixing "A compatible .NET SDK was not found" failures in `Broiler.Code.Language.CSharp.Tests`

**Documentation**
- Added detailed comments explaining why tests were changed (e.g., bilinear sampling behavior, module execution deadlock prevention, directory retirement)
- Documented the sub-document module hang fix: modules are now started but not awaited to prevent deadlock when `srcdoc` is assigned from parent script; added continuation to log failures

## Notable Implementation Details

- The `SubDocuments.cs` fix prevents a deadlock where awaiting a sub-document module synchronously while the parent's script is still on the stack would block forever (the engine queues continuations to run after the outermost execution finishes)
- Test isolation via `DomRenderCollection` mirrors the existing `NativeAnchorWptCollection` pattern

https://claude.ai/code/session_01SyDFAtBbXaNejMw5ar2SHc