### PR TITLE
Fix the ScriptCompileAhead retention: a site's id is an index, not a handle

### DIFF
--- a/docs/xunit-suite-status.md
+++ b/docs/xunit-suite-status.md
@@ -134,13 +134,27 @@ failed in one full run and passed in the next and in isolation.
   engine-only module path and is listed above. With that unblocked the project
   runs end to end for the first time — 3 485 tests in 5.3 minutes.
 * **`ScriptCompileAheadOverlapTests` is a benchmark, not a unit test.** Its
-  collection takes the test host from nothing to ~8.7 GB in 140 seconds — it
-  compiles ~60 000 functions across its repetitions, and the memory is
-  *reachable*, not garbage (an aggressive blocking compacting `GC.Collect`
-  after every test in the class recovers almost none of it). All 49 tests pass,
-  and a retention that size in the script-compile path is worth a look on its
-  own account. Filter the collection out when running the project for a quick
-  answer.
+  collection compiles ~60 000 functions across its repetitions and takes a
+  couple of minutes; filter it out when running the project for a quick answer.
+
+  It used to take the test host from nothing to **8.7 GB in 140 seconds**, and
+  the memory was *reachable*, not garbage — an aggressive blocking compacting
+  `GC.Collect` after every test in the class recovered almost none of it. That
+  was not the benchmark's doing. `MethodRepository` addressed each compiled
+  inner-lambda site by the address of a `GCHandle` it never freed, so every site
+  a compilation registered was rooted for the life of the process: a
+  `DynamicMethod` for an eagerly generated site, and for a deferred one the
+  whole un-emitted expression tree — and a function that is compiled and never
+  called never reaches `DeferredMethod.Force`, which is what would have released
+  it. It measured ~86 KB retained per compiled function, linear, on any path
+  that compiles (the ahead compile, the serial compile and the full capture all
+  showed it; a bare `JSContext` showed none).
+
+  A site is addressed by its index in the repository now, so the sites live and
+  die with the compiled code that can still reach them. Same 49 tests, same
+  runtime, ~1 KB retained per function instead of ~86 KB, and the collection's
+  peak is ~1.5 GB and bounded rather than 8.7 GB and climbing. The fix is in
+  `Broiler.JS` — see `patches/` if the pointer has not been bumped yet.
 * Some `Wpt_*_MatchesReference` tests and the PDF conversion tests can fail in a
   bare container for environmental reasons. Baseline before attributing a
   failure to your change.

--- a/patches/0001-js-method-repository-site-lifetime.patch
+++ b/patches/0001-js-method-repository-site-lifetime.patch
@@ -1,0 +1,239 @@
+From 98149f864f1b5cce9336af71b8e4330d46da7f99 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 21 Aug 2026 12:40:59 +0000
+Subject: [PATCH] Address a compiled site by its index, not by a GCHandle never
+ freed
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+MethodRepository handed the emitter the address of a GCHandle as a site's id and
+never freed the handle. So every inner-lambda site a compilation registered was
+rooted for the life of the process, whatever became of the code: for an eagerly
+generated site that is a DynamicMethod, and for a deferred one it is the whole
+un-emitted expression tree — which DeferredMethod.Force releases, and a function
+that is compiled and never called never reaches Force.
+
+The comment above DeferredMethod.lambda has recorded this since item 1-1 landed,
+and CompilePhaseMetrics works around it by measuring one corpus per process.
+What it costs, measured here: a script of 250 such functions retains ~86 KB per
+function — 8.6 MB per compile, linear in the number of compiles and in the
+number of functions, on every path that compiles (the serial compile, the
+compile-ahead and a whole capture all show it; a JSContext that compiles nothing
+shows none). A heap walk over a process that had compiled 2 000 such functions
+and dropped every reference found 190 MB live, in FastToken, the BExpression
+tree and FastFunctionScope, under a StrongHandle to MethodRepository.RuntimeMethod.
+
+An index needs no handle, because the lookup already has the repository. Create
+is an instance method and the creation site the emitter builds calls it on the
+Closures.Repository the closure chain carries, so an id is only ever resolved
+against the repository that issued it — one per compilation. Addressing sites by
+index gives them the lifetime they should have had: they are released with the
+compiled code that can still reach them.
+
+The store is copy-on-write behind a lock, because a deferred site registers its
+own nested sites when it is first invoked and that can race a closure creation.
+Readers are a plain array index, as they were through the handle, and an id
+issued against an earlier array still resolves against it.
+
+Broiler.Cli.Tests' ScriptCompileAhead collection, which compiles ~60 000
+functions across its repetitions and is the reason this was looked at: peak
+resident 8.7 GB -> 1.5 GB, bounded rather than climbing, same 49 tests passing
+in the same time. Per compiled function ~86 KB -> ~1 KB.
+
+Verified: Compiler 1402/1402, BuiltIns 2173/2173, Integration 4998/4999 (the
+one failure is a missing docs/roadmap.md), Runtime, Ast, Parser, Portable,
+Storage, Clr, Debugger and ModuleExtensions all green. Core.Tests and
+Modules.Tests fail identically before and after — they do not reference the
+assembly whose module initializer registers the DynamicMethod back end, so this
+code cannot run in them at all.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ .../Runtime/DeferredMethod.cs                 | 18 +++--
+ .../Runtime/MethodRepository.cs               | 77 ++++++++++++++++---
+ .../CompilePhaseMetrics.cs                    |  9 ++-
+ 3 files changed, 86 insertions(+), 18 deletions(-)
+
+diff --git a/Broiler.JS/Broiler.JavaScript.ExpressionCompiler/Runtime/DeferredMethod.cs b/Broiler.JS/Broiler.JavaScript.ExpressionCompiler/Runtime/DeferredMethod.cs
+index efd28186..826a51e3 100644
+--- a/Broiler.JS/Broiler.JavaScript.ExpressionCompiler/Runtime/DeferredMethod.cs
++++ b/Broiler.JS/Broiler.JavaScript.ExpressionCompiler/Runtime/DeferredMethod.cs
+@@ -50,12 +50,18 @@ internal sealed class DeferredMethod
+     /// </summary>
+     private readonly Type delegateType;
+ 
+-    // Cleared by Force. A site is registered under a GCHandle that is never freed, so anything
+-    // still referenced here is retained for the life of the process: eagerly that is a
+-    // DynamicMethod, and while deferred it is the whole expression tree, which is far larger.
+-    // Keeping them past generation would turn every compiled script into a permanent copy of
+-    // its own tree — measurably, on a probe that compiles six corpora in one process, the
+-    // corpora measured last paid for the ones before them.
++    // Cleared by Force, because the tree is far larger than the code it generates and a site that
++    // has generated has no further use for it. Keeping it past generation would turn every
++    // compiled script into a permanent copy of its own tree — measurably, on a probe that
++    // compiles six corpora in one process, the corpora measured last paid for the ones before
++    // them.
++    //
++    // Force is not the only way it is released now. A site used to be registered under a GCHandle
++    // that was never freed, so a function that was compiled and never called — which never
++    // reaches Force — held its tree for the life of the process no matter what became of the
++    // code. MethodRepository addresses its sites by index instead, so an unforced site is
++    // released with the repository, and this clear is the earlier of the two rather than the
++    // only one.
+     private BLambdaExpression lambda;
+     private IMethodBuilder methodBuilder;
+ 
+diff --git a/Broiler.JS/Broiler.JavaScript.ExpressionCompiler/Runtime/MethodRepository.cs b/Broiler.JS/Broiler.JavaScript.ExpressionCompiler/Runtime/MethodRepository.cs
+index 1e380e7a..fbddca44 100644
+--- a/Broiler.JS/Broiler.JavaScript.ExpressionCompiler/Runtime/MethodRepository.cs
++++ b/Broiler.JS/Broiler.JavaScript.ExpressionCompiler/Runtime/MethodRepository.cs
+@@ -2,10 +2,41 @@
+ using System;
+ using System.Reflection;
+ using System.Reflection.Emit;
+-using System.Runtime.InteropServices;
++using System.Threading;
+ 
+ namespace Broiler.JavaScript.ExpressionCompiler.Runtime;
+ 
++/// <summary>
++/// The compiled inner-lambda sites of one compilation, addressed by the opaque id the
++/// creation site emitted for each.
++/// </summary>
++/// <remarks>
++/// <para>
++/// <b>A site's id is its index here, not the address of a <c>GCHandle</c>.</b> It used to be
++/// the latter, and the handle was never freed — so every site a compilation registered was
++/// rooted for the life of the process. For a site whose IL was generated eagerly that is a
++/// <c>DynamicMethod</c>; for a deferred one it is the whole un-emitted expression tree, and a
++/// function that is compiled but never called never reaches <c>DeferredMethod.Force</c> to
++/// release it. Measured on a script of 250 such functions, that was ~86 KB retained per
++/// function — 8.6 MB per compile that nothing could reclaim, whatever the caller did with the
++/// code.
++/// </para>
++/// <para>
++/// An index needs no handle because the lookup already has the repository:
++/// <see cref="Create"/> is an instance method, and the creation site the emitter builds
++/// (<c>RuntimeMethodBuilder.Relay</c>) calls it on the <see cref="Closures.Repository"/> the
++/// closure chain carries. So every id is resolved against the repository that issued it, and
++/// the sites live and die with the compiled code that can still reach them — which is the
++/// lifetime they always should have had.
++/// </para>
++/// <para>
++/// The store is copy-on-write: a site can be registered while another thread creates a
++/// closure, because a deferred site registers its own nested sites when it is first invoked.
++/// Growing copies rather than mutates, so a reader holding an earlier array still resolves
++/// every id issued before it — and a reader is a plain array index, as it was through the
++/// handle.
++/// </para>
++/// </remarks>
+ public class MethodRepository : IMethodRepository
+ {
+ 
+@@ -14,6 +45,10 @@ public class MethodRepository : IMethodRepository
+     public string IL;
+     public string Exp;
+ 
++    private readonly object gate = new();
++    private RuntimeMethod[] sites = new RuntimeMethod[8];
++    private int count;
++
+     public class RuntimeMethod
+     {
+         // MethodInfo, not DynamicMethod, to match IMethodRepository.RegisterNew — which is typed
+@@ -32,35 +67,57 @@ public class MethodRepository : IMethodRepository
+     }
+ 
+     public ulong RegisterNew(MethodInfo d, string il, string exp, Type type)
+-    {
+-        var x = GCHandle.Alloc(new RuntimeMethod {
++        => Register(new RuntimeMethod
++        {
+             Method = d,
+             IL = il,
+             Exp = exp,
+             Type = type
+         });
+-        return (ulong)(IntPtr)x;
+-    }
+ 
+     /// <summary>
+-    /// Registers a site whose IL has not been generated, returning the same kind of handle
++    /// Registers a site whose IL has not been generated, returning the same kind of id
+     /// <see cref="RegisterNew"/> does so the creation site emitted for it is unchanged.
+     /// </summary>
+     internal ulong RegisterDeferred(DeferredMethod deferred, Type type)
+-    {
+-        var x = GCHandle.Alloc(new RuntimeMethod
++        => Register(new RuntimeMethod
+         {
+             Deferred = deferred,
+             IL = string.Empty,
+             Exp = string.Empty,
+             Type = type
+         });
+-        return (ulong)(IntPtr)x;
++
++    private ulong Register(RuntimeMethod site)
++    {
++        lock (gate)
++        {
++            var current = sites;
++            if (count == current.Length)
++            {
++                var grown = new RuntimeMethod[current.Length * 2];
++                Array.Copy(current, grown, count);
++                current = grown;
++            }
++
++            current[count] = site;
++
++            // A reader cannot reach a slot before the id that names it, and the only way
++            // an id reaches a reader is the creation site the emitter builds from this
++            // return value — so the store above is ordered ahead of every read of it by
++            // the same chain that delivers the id, which is what the GCHandle this
++            // replaces relied on too. The release write is what a *grown* array
++            // additionally needs: it publishes the new array with its contents, and the
++            // old one stays valid for every id issued against it, so a reader holding
++            // either resolves correctly.
++            Volatile.Write(ref sites, current);
++            return (ulong)count++;
++        }
+     }
+ 
+     public object Create(Box[] boxes, ulong id)
+     {
+-        var rm = GCHandle.FromIntPtr((IntPtr)id).Target as RuntimeMethod;
++        var rm = Volatile.Read(ref sites)[(int)id];
+         // A deferred site hands back a thunk over this instance's boxes; the boxes are captured
+         // here, at closure creation, exactly as they are for a generated one. What is postponed
+         // is the machine code, which is shared by every instance of the site and belongs to
+diff --git a/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/CompilePhaseMetrics.cs b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/CompilePhaseMetrics.cs
+index fdd7a6ad..2daa436a 100644
+--- a/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/CompilePhaseMetrics.cs
++++ b/Broiler.JS/benchmarks/Broiler.JavaScript.Engine.Benchmarks/CompilePhaseMetrics.cs
+@@ -187,13 +187,18 @@ internal static class CompilePhaseMetrics
+         var stopwatch = new Stopwatch();
+ 
+         // The decomposition's own check, and it is taken FIRST. Every compile in this method
+-        // registers a deferred site per relayed lambda, each rooted by a GCHandle that is never
+-        // freed and each holding its subtree — so a phase measured late in the sequence pays
++        // registers a deferred site per relayed lambda, each holding its subtree until the site
++        // generates or its repository is released — so a phase measured late in the sequence pays
+         // collection time the phases before it caused. Measured last, this column read 3.4x the
+         // sum of the phases on Box2D and 1.0x on jQuery, and the difference between those two
+         // corpora is exactly how many sites a deferred compile registers: 982 against 1. That is
+         // item 1-1's own retained-tree artifact, one level down from where the roadmap records
+         // it. Taken first, against a fresh collection, it is comparable with the sum.
++        //
++        // Those figures were taken when a site was rooted by a GCHandle that was never freed,
++        // so the trees outlived every compile unconditionally. They are released with the
++        // repository now (see MethodRepository), which should narrow the gap between the
++        // corpora without closing it: within one sequence the repositories are still all live.
+         GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+         var previousForEndToEnd = DeferredMethodCompilation.Enabled;
+         DeferredMethodCompilation.Enabled = true;
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,41 @@
+# Submodule patches
+
+Changes that belong in a submodule but could not be pushed to its remote: the
+session's git proxy only injects a credential for repositories in the session's
+GitHub scope, and `Broiler-Platform/Broiler.*` is outside it, so
+`git push origin HEAD` from inside a submodule returns **403**. Per
+`CLAUDE.md` → "Submodules: modify them; push if allowed, otherwise deliver as a
+PATCH", the change is exported here instead and **no gitlink is bumped** — CI
+clones each submodule by pointer, and a pointer moved to a commit that was never
+pushed would break it.
+
+Apply one with `git am` from inside the submodule it names, then bump the
+pointer in the parent:
+
+```sh
+cd <Submodule>
+git am ../patches/NNNN-<slug>.patch
+git push origin HEAD          # from a session/CI with the broader scope
+cd ..
+git add <Submodule> && git commit -m "Update submodules"
+```
+
+This directory is a backlog, not an archive: a patch is deleted once its fix is
+upstream and the numbering restarts from `0001` against whatever is left. A
+`patches/NNNN` reference in an older commit message or document is therefore
+almost always dangling — name the **commit subject** instead. To check whether a
+fix is already live:
+
+```sh
+git -C <Submodule> log --oneline --grep '<subject>'
+```
+
+## Index
+
+| Patch | Submodule | Commit subject | Why |
+| --- | --- | --- | --- |
+| `0001-js-method-repository-site-lifetime.patch` | `Broiler.JS` | Address a compiled site by its index, not by a GCHandle never freed | `MethodRepository` used the address of a never-freed `GCHandle` as a compiled site's id, so every inner-lambda site a compilation registered stayed rooted for the life of the process — a `DynamicMethod` for an eagerly generated site, and the whole un-emitted expression tree for a deferred one that is never called. ~86 KB retained per compiled function, linear. Addressing sites by index inside the repository gives them the lifetime of the code that can reach them: `Broiler.Cli.Tests`' `ScriptCompileAhead` collection drops from a peak of 8.7 GB to 1.5 GB, bounded, with the same 49 tests passing in the same time. |
+
+Until `0001` is applied and the pointer bumped, `docs/xunit-suite-status.md`
+describes the retention as fixed — which it is in this tree only once the patch
+is applied. Nothing in the main repo depends on it to build or pass.


### PR DESCRIPTION
`docs/xunit-suite-status.md` recorded the `ScriptCompileAhead` collection taking the test host from nothing to **8.7 GB in 140 seconds**, reachable rather than garbage, and said a retention that size in the script-compile path was worth a look on its own account. This is that look. It was not the benchmark's doing.

## The cause

`Broiler.JS`'s `MethodRepository` handed the emitter **the address of a `GCHandle` as a compiled inner-lambda site's id, and never freed the handle**. Every site a compilation registered was therefore rooted for the life of the process, whatever became of the code:

* for an eagerly generated site, a `DynamicMethod`;
* for a **deferred** site, the whole un-emitted expression tree — which only `DeferredMethod.Force` releases, and a function that is compiled and never called never reaches `Force`.

The comment above `DeferredMethod.lambda` has recorded the never-freed handle since item 1-1 landed, and `CompilePhaseMetrics` works around it by measuring one corpus per process. What it cost had not been measured.

## How it was found

Reading the code kept dead-ending, so this was measured instead:

* **~86 KB retained per compiled function**, perfectly linear in both functions and compiles, on every path that compiles — the serial compile, the compile-ahead and a whole capture all show it. A `JSContext` that compiles nothing shows none.
* Only **1 of 10** successive contexts survived a full collect, so the retention was not reachable from `JSContext` at all — the surviving one is pinned by `JSEngine.Current`.
* `dotnet-dump` and `dotnet-gcdump` both fail to install from the feed in this environment, so a small ClrMD heap walker was used against a live process. Over a process that had compiled 2 000 such functions and dropped every reference, **190 MB was live** — `FastToken` (268 002 instances), the `BExpression` tree, `FastFunctionScope` — and the root path came back:

```
StrongHandle → MethodRepository+RuntimeMethod → DeferredMethod → BExpression<JSFunctionDelegate> → … → FastFunctionScope
```

## The fix

A site's id is now its **index in the repository**. No handle is needed, because the lookup already has the repository: `Create` is an instance method, and the creation site the emitter builds (`RuntimeMethodBuilder.Relay`) calls it on the `Closures.Repository` the closure chain carries — so an id is only ever resolved against the repository that issued it, one per compilation. Sites now live and die with the compiled code that can still reach them, which is the lifetime they always should have had.

The store is copy-on-write behind a lock, because a deferred site registers its own nested sites when it is first invoked and that can race a closure creation. Readers are a plain array index, as they were through the handle, and an id issued against an earlier array still resolves against it.

|  | before | after |
| --- | --- | --- |
| retained per compiled function | ~86 KB | ~1 KB |
| `ScriptCompileAhead` collection peak | 8.7 GB, climbing | 1.5 GB, bounded |
| that collection | 49 green, 2m26s | 49 green, 2m21s |

## Delivered as a patch, not a pointer bump

Pushing to `Broiler-Platform/Broiler.JS` returns 403 from this session, so per `CLAUDE.md` the change ships as `patches/0001-js-method-repository-site-lifetime.patch` and **no gitlink is bumped**. The patch applies cleanly to the pinned pointer and does not reverse-apply. Nothing in the main repo depends on it to build or pass.

`MethodRepository.cs` and `CompilePhaseMetrics.cs` are mixed CRLF/LF, one with a BOM. A first pass renormalised them — a 6-line comment edit showed as 153 changed lines — so both were redone as byte-level replacements; the diffs are 77 and 9 lines with terminators and BOM intact.

## Verification

**Engine suites** (with the patch applied): Compiler 1402/1402, BuiltIns 2173/2173, Integration 4998/4999 (the one failure is a missing `docs/roadmap.md`), plus Runtime, Ast, Parser, Portable, Storage, Clr, Debugger and ModuleExtensions all green. `Core.Tests` (16) and `Modules.Tests` (10) fail *identically before and after* — they do not reference the assembly whose module initializer registers the `DynamicMethod` back end, so this code cannot run in them at all; that was confirmed by baselining against the unmodified submodule.

**Main repo:** `Broiler.Cli.Tests` 3448/3502 and `Broiler.Wpt.Tests` 1029/1083 — the same failure sets as before, bar two timing-sensitive tests that pass in isolation (three consecutive runs each): the compile-ahead overlap benchmark, already noted as load-sensitive in the status doc, and a `requestIdleCallback` deadline flag reading `idle:frame(false)` instead of `(true)` under load. `Broiler.Layout.Tests` 1126/1126 and `Broiler.Browser.Core.Tests` 105/105 stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyDFAtBbXaNejMw5ar2SHc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyDFAtBbXaNejMw5ar2SHc)_