### PR TITLE
Register per-tag HTML element interfaces and fix isolation groups

### DIFF
--- a/Broiler.Layout/Broiler.Layout/IR/ComputedStyleBuilder.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/ComputedStyleBuilder.cs
@@ -34,7 +34,13 @@ internal static class ComputedStyleBuilder
     /// <summary>
     /// Snapshots the computed style of a CssBox, capturing all resolved actual values.
     /// </summary>
-    public static ComputedStyle FromBox(CssBoxProperties box, string? tagName = null)
+    /// <param name="isolationObservable">
+    /// Whether an <c>isolation: isolate</c> on this box can make any difference to the picture —
+    /// see <c>FragmentTreeBuilder.DocumentHasBlending</c>. When it cannot, the box computes to
+    /// <c>isolation: auto</c> so paint does not open a compositing group whose only possible
+    /// contribution is the one thing nothing in the document asks for.
+    /// </param>
+    public static ComputedStyle FromBox(CssBoxProperties box, string? tagName = null, bool isolationObservable = true)
     {
         return new ComputedStyle
         {
@@ -162,7 +168,7 @@ internal static class ComputedStyleBuilder
             MixBlendMode = box.MixBlendMode,
             BackgroundBlendMode = box.BackgroundBlendMode,
             Filter = box.Filter,
-            Isolation = box.Isolation,
+            Isolation = isolationObservable ? box.Isolation : "auto",
             BackgroundClip = box.BackgroundClip,
             // CSS 2.1 §11.1.2's `clip` is the same rectangular clip `clip-path: inset()` names, so
             // it is resolved into one here rather than applied a second time in paint.

--- a/Broiler.Layout/Broiler.Layout/IR/FragmentTreeBuilder.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/FragmentTreeBuilder.cs
@@ -26,9 +26,62 @@ internal static class FragmentTreeBuilder
         // Publish the host's font services for the pass: SvgRenderer has no box to ask for a font,
         // and a DrawSvgTextItem without one is dropped by the raster backend (see SvgTextEnvironment).
         SvgTextEnvironment.Reset(root.LayoutEnvironment);
-        var tree = BuildFragment(root, parentHasTransform: false, isRoot: true);
+        var tree = BuildFragment(root, parentHasTransform: false, isRoot: true,
+            isolationObservable: DocumentHasBlending(root));
         CollectSvgDefinitions(tree);
         return tree;
+    }
+
+    /// <summary>
+    /// Whether any box in the document blends with its backdrop — i.e. carries a
+    /// <c>mix-blend-mode</c> other than <c>normal</c>. One pass over the tree, before the fragments
+    /// are built, because the answer is the same for every box in the pass.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is what decides whether <c>isolation: isolate</c> is worth honouring at paint time.
+    /// CSS Compositing §2.2 gives an isolation group exactly one job: to stop a <em>descendant's</em>
+    /// blending from reaching the backdrop outside the group. With nothing in the document blending
+    /// at all, the group has no job to do, and compositing its contents through a
+    /// <c>normal</c>-blend layer produces the very same pixels as drawing them straight onto the
+    /// surface. So dropping it is not an approximation — it is the same picture, one layer cheaper.
+    /// </para>
+    /// <para>
+    /// <c>background-blend-mode</c> is deliberately not consulted: it blends an element's own
+    /// background layers with each other, never with the backdrop behind the element, so no ancestor's
+    /// isolation can be observed through it.
+    /// </para>
+    /// <para>
+    /// The isolation group still <em>creates a stacking context</em> either way — see
+    /// <see cref="IsStackingContext"/>, which reads the box and is untouched by this. Only the paint
+    /// layer goes away, so paint order is unchanged.
+    /// </para>
+    /// <para>
+    /// <b>This also stands in for a renderer fix that cannot land here.</b> A compositing group
+    /// whose contents are not raster-compatible — one transformed descendant is enough — used to be
+    /// routed to a stub compat backend that dropped the group's entire subtree, so an isolation
+    /// group over a page with a transform under it rendered as an empty viewport. That belongs in
+    /// <c>Broiler.HTML</c>'s <c>GraphicsAdapter</c> and ships as the <c>patches/</c> entry
+    /// "Keep a compositing group's contents when the group cannot use the raster canvas"; until that
+    /// is applied, not emitting the unobservable group is what keeps such a page visible.
+    /// <c>duckduckgo.com</c>'s start page is the case: all of its content sits under
+    /// <c>#__next { isolation: isolate }</c>, it has transforms beneath that, and it uses no blend
+    /// mode anywhere.
+    /// </para>
+    /// </remarks>
+    private static bool DocumentHasBlending(CssBox box)
+    {
+        if (!string.IsNullOrEmpty(box.MixBlendMode)
+            && !box.MixBlendMode.Equals("normal", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        foreach (var child in box.Boxes)
+        {
+            if (DocumentHasBlending(child))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>Walks the fragment tree and registers every modelled SVG filter (see
@@ -75,7 +128,8 @@ internal static class FragmentTreeBuilder
     /// references state the same layout with one absolutely-positioned copy per page.
     /// </para>
     /// </remarks>
-    private static List<Fragment> RepeatedFixedFragments(CssBox root, bool hasTransformAncestor)
+    private static List<Fragment> RepeatedFixedFragments(CssBox root, bool hasTransformAncestor,
+        bool isolationObservable)
     {
         var repeats = new List<Fragment>();
 
@@ -101,7 +155,8 @@ internal static class FragmentTreeBuilder
             for (int page = 1; page < pages; page++)
             {
                 box.OffsetTop(pageHeight);
-                repeats.Add(BuildFragment(box, hasTransformAncestor));
+                repeats.Add(BuildFragment(box, hasTransformAncestor,
+                    isolationObservable: isolationObservable));
             }
 
             // Put it back where layout left it: the fragment already built for page one refers to
@@ -136,9 +191,10 @@ internal static class FragmentTreeBuilder
     /// </summary>
     private const double UnpaginatedPageExtent = 90000;
 
-    private static Fragment BuildFragment(CssBox box, bool parentHasTransform, bool isRoot = false)
+    private static Fragment BuildFragment(CssBox box, bool parentHasTransform, bool isRoot = false,
+        bool isolationObservable = true)
     {
-        var style = ComputedStyleBuilder.FromBox(box, box.HtmlTag?.Name);
+        var style = ComputedStyleBuilder.FromBox(box, box.HtmlTag?.Name, isolationObservable);
         bool hasTransformAncestor = parentHasTransform
             || (!string.IsNullOrEmpty(style.Transform)
             && !style.Transform.Equals("none", StringComparison.OrdinalIgnoreCase));
@@ -168,7 +224,8 @@ internal static class FragmentTreeBuilder
                 // and not its own background or borders either.
                 if (child.ClampedAway)
                     continue;
-                children.Add(BuildFragment(child, hasTransformAncestor));
+                children.Add(BuildFragment(child, hasTransformAncestor,
+                    isolationObservable: isolationObservable));
             }
         }
 
@@ -177,7 +234,7 @@ internal static class FragmentTreeBuilder
         // where its containing block is; the rest of its appearances are copies of that subtree,
         // one page further down each time.
         if (isRoot && !contentHidden)
-            children.AddRange(RepeatedFixedFragments(box, hasTransformAncestor));
+            children.AddRange(RepeatedFixedFragments(box, hasTransformAncestor, isolationObservable));
 
         List<LineFragment>? lines = null;
         if (!contentHidden && box.LineBoxes.Count > 0)

--- a/patches/0001-compositing-group-transform-content.patch
+++ b/patches/0001-compositing-group-transform-content.patch
@@ -1,0 +1,142 @@
+From e1d2839a4a67f57063d1b8924603d57c178405a9 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 21 Aug 2026 14:10:01 +0000
+Subject: [PATCH] Keep a compositing group's contents when the group cannot use
+ the raster canvas
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+A group opened for opacity, mix-blend-mode or isolation is put on the raster
+canvas only when every display item it encloses is one the raster canvas can
+draw. RGraphicsRasterBackend.IsRasterCompatibleItem answers no for a
+TransformItem, so one transformed descendant — however deep, and however
+ordinary the rest of the subtree — sent the whole group to the compat backend
+instead. That backend is a stub in this image renderer, and switching to it also
+turns CanUseRaster off for every draw the group encloses, so all of them landed
+nowhere: the group and its entire subtree disappeared from the output.
+
+SaveOpacityLayer and SaveBlendLayer now skip the layer in that case and let the
+contents draw straight onto the surface, which is what SaveFilterLayer already
+does and what SaveTransformLayer's comment describes about the same
+fall-through. An opacity group then paints at full opacity and a blend group
+unblended — visible inaccuracies, where the alternative was painting nothing —
+and for the normal-blend group isolation emits, nothing is lost at all:
+isolation is only observable to a descendant that blends.
+
+duckduckgo.com is the page that showed this. Its start page wraps all of its
+content in #__next { isolation: isolate } and has transforms beneath it, so it
+rendered as an empty white viewport.
+---
+ .../Adapters/GraphicsAdapter.cs               | 59 +++++++++++--------
+ 1 file changed, 35 insertions(+), 24 deletions(-)
+
+diff --git a/Source/Broiler.HTML.Image/Adapters/GraphicsAdapter.cs b/Source/Broiler.HTML.Image/Adapters/GraphicsAdapter.cs
+index 6c69fff..b3efda8 100644
+--- a/Source/Broiler.HTML.Image/Adapters/GraphicsAdapter.cs
++++ b/Source/Broiler.HTML.Image/Adapters/GraphicsAdapter.cs
+@@ -385,32 +385,44 @@ internal sealed class GraphicsAdapter : RGraphics, ITileParallelSurface, IBounds
+     public override void HintNextLayerCanUseRaster(bool canUseRaster) =>
+         _nextLayerCanUseRaster = canUseRaster;
+ 
++    /// <summary>
++    /// Opens the compositing group for <c>0 &lt; opacity &lt; 1</c>. When the group's contents are
++    /// raster-compatible it becomes a real opacity layer; otherwise the contents are drawn
++    /// directly, at full opacity.
++    /// </summary>
++    /// <remarks>
++    /// <para>
++    /// Drawing at the wrong opacity is a visible inaccuracy; the alternative it replaces was not
++    /// drawing at all. The fall-through used to open the layer on the compat backend, which
++    /// switches <see cref="CanUseRaster"/> off for every draw the group encloses — and against the
++    /// stub compat backend this image renderer ships with, every one of those draws lands nowhere.
++    /// The group and its whole subtree simply disappeared. <see cref="SaveTransformLayer"/> says
++    /// the same thing about the same fall-through, and <see cref="SaveFilterLayer"/> already
++    /// degrades this way.
++    /// </para>
++    /// <para>
++    /// What made the difference between an inaccuracy and a blank page is that a group is declared
++    /// non-raster by its <em>contents</em>: one <c>TransformItem</c> anywhere inside is enough
++    /// (<c>RGraphicsRasterBackend.IsRasterCompatibleItem</c>), however ordinary everything else in
++    /// it is. <c>duckduckgo.com</c> wraps its entire page in <c>#__next { isolation: isolate }</c>
++    /// and has transforms under it, so the start page rendered as an empty white viewport — the
++    /// blend-layer counterpart of this method, with <c>isolation</c>'s own <c>normal</c> blend.
++    /// </para>
++    /// </remarks>
+     public override void SaveOpacityLayer(float opacity)
+     {
+         bool useRaster = _rasterCanvas is not null && _activeCompatLayerDepth == 0 && _nextLayerCanUseRaster;
+         _nextLayerCanUseRaster = false;
+         _rasterLayerStack.Push(useRaster);
+         if (useRaster)
+-        {
+             _rasterCanvas!.SaveOpacityLayer(opacity);
+-            return;
+-        }
+-
+-        _activeCompatLayerDepth++;
+-        ApplyCanvasOperation(canvas => _canvasCompat.SaveOpacityLayer(canvas, opacity));
+     }
+ 
+     public override void RestoreOpacityLayer()
+     {
+         bool usedRaster = _rasterLayerStack.Count > 0 && _rasterLayerStack.Pop();
+         if (usedRaster)
+-        {
+             _rasterCanvas!.RestoreOpacityLayer();
+-            return;
+-        }
+-
+-        ApplyCanvasOperation(CompatCanvasOperations.Restore);
+-        _activeCompatLayerDepth = Math.Max(0, _activeCompatLayerDepth - 1);
+     }
+ 
+     public override void SaveFilterLayer(string filter)
+@@ -433,6 +445,17 @@ internal sealed class GraphicsAdapter : RGraphics, ITileParallelSurface, IBounds
+             _rasterCanvas!.RestoreFilterLayer();
+     }
+ 
++    /// <summary>
++    /// Opens the compositing group for a <c>mix-blend-mode</c>, and for the <c>normal</c>-blend
++    /// group <c>isolation: isolate</c> emits. When the group's contents are raster-compatible it
++    /// becomes a real blend layer; otherwise the contents are drawn directly, unblended.
++    /// </summary>
++    /// <remarks>
++    /// See <see cref="SaveOpacityLayer"/> for why the compat fall-through this replaces lost the
++    /// group's whole subtree. For an isolation group the degradation costs nothing at all: the mode
++    /// is <c>normal</c>, and isolation is only observable to a descendant that blends, so drawing
++    /// the contents straight onto the surface is what the layer would have composited anyway.
++    /// </remarks>
+     public override void SaveBlendLayer(string blendMode)
+     {
+         bool useRaster = _rasterCanvas is not null
+@@ -441,26 +464,14 @@ internal sealed class GraphicsAdapter : RGraphics, ITileParallelSurface, IBounds
+         _nextLayerCanUseRaster = false;
+         _rasterLayerStack.Push(useRaster);
+         if (useRaster)
+-        {
+             _rasterCanvas!.SaveBlendLayer(blendMode);
+-            return;
+-        }
+-
+-        _activeCompatLayerDepth++;
+-        ApplyCanvasOperation(canvas => _canvasCompat.SaveBlendLayer(canvas, blendMode));
+     }
+ 
+     public override void RestoreBlendLayer()
+     {
+         bool usedRaster = _rasterLayerStack.Count > 0 && _rasterLayerStack.Pop();
+         if (usedRaster)
+-        {
+             _rasterCanvas!.RestoreBlendLayer();
+-            return;
+-        }
+-
+-        ApplyCanvasOperation(CompatCanvasOperations.Restore);
+-        _activeCompatLayerDepth = Math.Max(0, _activeCompatLayerDepth - 1);
+     }
+ 
+     public override void SaveTransformLayer(float[] matrix, float originX, float originY)
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,51 @@
+# Submodule patches
+
+Changes that belong in a submodule but could not be pushed to its remote: the
+session's git proxy only injects a credential for repositories in the session's
+GitHub scope, and `Broiler-Platform/Broiler.*` is outside it, so
+`git push origin HEAD` from inside a submodule returns **403**. Per
+`CLAUDE.md` → "Submodules: modify them; push if allowed, otherwise deliver as a
+PATCH", the change is exported here instead and **no gitlink is bumped** — CI
+clones each submodule by pointer, and a pointer moved to a commit that was never
+pushed would break it.
+
+Apply one with `git am` from inside the submodule it names, then bump the
+pointer in the parent:
+
+```sh
+cd <Submodule>
+git am ../patches/NNNN-<slug>.patch
+git push origin HEAD          # from a session/CI with the broader scope
+cd ..
+git add <Submodule> && git commit -m "Update submodules"
+```
+
+This directory is a backlog, not an archive: a patch is deleted once its fix is
+upstream and the numbering restarts from `0001` against whatever is left. A
+`patches/NNNN` reference in an older commit message or document is therefore
+almost always dangling — name the **commit subject** instead. To check whether a
+fix is already live:
+
+```sh
+git -C <Submodule> log --oneline --grep '<subject>'
+```
+
+## Index
+
+| Patch | Submodule | Commit subject | Why |
+| --- | --- | --- | --- |
+| `0001-compositing-group-transform-content.patch` | `Broiler.HTML` | Keep a compositing group's contents when the group cannot use the raster canvas | A group opened for `opacity`, `mix-blend-mode` or `isolation` stays on the raster canvas only when every display item it encloses is one the raster canvas can draw, and `RGraphicsRasterBackend.IsRasterCompatibleItem` answers no for a `TransformItem`. One transformed descendant — however deep, and however ordinary the rest of the subtree — therefore sent the whole group to the compat seam, which on a host with no OS backend is an inert stub, and switching to it also turns `CanUseRaster` off for every draw the group encloses: the group and its entire subtree painted **nothing**. `SaveOpacityLayer`/`SaveBlendLayer` now skip the layer instead and let the contents draw straight onto the surface, which is what `SaveFilterLayer` already does and what `SaveTransformLayer`'s own comment describes about the same fall-through. `duckduckgo.com` is the page that showed it: its start page wraps all of its content in `#__next { isolation: isolate }` and has transforms beneath it, so it rendered as an empty white viewport. |
+
+The same failure mode as the dashed-stroke patch that
+`scripts/apply-pending-wpt-patches.sh` used to carry — a draw that misses the
+raster path and falls through to the stub seam paints nothing at all — so this
+one is listed there too, and reaches the WPT and real-world render runs on top
+of the pinned pointer until a maintainer lands it.
+
+The main repo builds and passes without it. `Broiler.Layout` carries the half of
+the `duckduckgo.com` fix that is expressible there — an `isolation: isolate`
+group is unobservable when nothing in the document blends, so it is no longer
+emitted at paint time (`UnobservableIsolationGroupTests`) — which is what makes
+that page render in this tree. That is a narrower fix than this patch by
+construction: it cannot help a group opened for `opacity` or for a real
+`mix-blend-mode`, and both still lose their subtree until this lands.

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -280,7 +280,23 @@ set -euo pipefail
 # Deliberately NOT listed:
 #   * 0001 (Broiler.JS, compiled-site lifetime) — a retention fix with no effect on rendered
 #     output, so a pixel run has nothing to say about it.
+#
+# Those three landed upstream together, which emptied patches/ and restarted the numbering, so
+# the 0001 below is a different change from the one named just above.
+#
+# 0001 (Broiler.HTML, "Keep a compositing group's contents when the group cannot use the raster
+# canvas") IS listed, for the same reason the dashed-stroke patch was: a draw that misses the
+# raster fast path falls through to the compat seam, which on a host with no OS backend is an
+# inert stub, so it paints *nothing*. Here it is not one edge but a whole compositing group —
+# `opacity`, `mix-blend-mode`, or the `normal`-blend group `isolation: isolate` emits — and every
+# descendant under it, dropped whenever the group encloses a single `TransformItem`, which
+# `IsRasterCompatibleItem` rejects. The main repo carries the half of the fix expressible there
+# (Broiler.Layout stops emitting an isolation group when nothing in the document blends,
+# unit-tested in UnobservableIsolationGroupTests), and that half is narrower by construction: it
+# cannot reach a group opened for `opacity` or for a real `mix-blend-mode`. Only this patch keeps
+# those, and only the pixel suite can say the subtree reached the canvas.
 PENDING_PATCHES=(
+  "Broiler.HTML|patches/0001-compositing-group-transform-content.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/Broiler.Cli.Tests/DomInterfaceConstructorTests.cs
+++ b/src/Broiler.Cli.Tests/DomInterfaceConstructorTests.cs
@@ -175,4 +175,137 @@ r.push(document.createElement('div') instanceof Node);
 ");
         Assert.Contains("true,true,true,true,true,true", result);
     }
+
+    /// <summary>
+    /// The per-tag interfaces beneath <c>HTMLElement</c> exist as bare globals. Absent, a page does
+    /// not merely fail the test that names one — the bare name is a <c>ReferenceError</c>, which
+    /// aborts the whole statement and everything after it in that script.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void Per_Tag_Interface_Constructors_Are_Defined_As_Bare_Globals()
+    {
+        var result = Run(@"
+var names = ['HTMLFormElement','HTMLInputElement','HTMLAnchorElement','HTMLImageElement',
+             'HTMLButtonElement','HTMLTextAreaElement','HTMLSelectElement','HTMLOptionElement',
+             'HTMLDivElement','HTMLSpanElement','HTMLScriptElement','HTMLLinkElement',
+             'HTMLStyleElement','HTMLCanvasElement','HTMLIFrameElement','HTMLTemplateElement',
+             'HTMLVideoElement','HTMLAudioElement','HTMLMediaElement','HTMLTableElement',
+             'HTMLLabelElement','HTMLHeadingElement','HTMLParagraphElement','HTMLUListElement',
+             'HTMLLIElement','HTMLBodyElement','HTMLHtmlElement','HTMLHeadElement',
+             'HTMLMetaElement','SVGElement'];
+var allDefined = true;
+for (var i = 0; i < names.length; i++) {
+  if (typeof window[names[i]] !== 'function') allDefined = false;
+}
+r.push(allDefined);
+// Reached by bare name too, not only through window.
+r.push(typeof HTMLFormElement === 'function');
+r.push(typeof HTMLInputElement === 'function');
+");
+        Assert.Contains("true,true,true", result);
+    }
+
+    /// <summary>
+    /// Each per-tag interface answers for its own tag and refuses every other one, so the test a
+    /// page writes to tell one element from another gets a real answer rather than a name that
+    /// merely exists.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void Per_Tag_Interfaces_Match_Their_Own_Tag_And_No_Other()
+    {
+        var result = Run(@"
+var pairs = [['form','HTMLFormElement'],['input','HTMLInputElement'],['a','HTMLAnchorElement'],
+             ['img','HTMLImageElement'],['div','HTMLDivElement'],['p','HTMLParagraphElement'],
+             ['select','HTMLSelectElement'],['textarea','HTMLTextAreaElement'],
+             ['table','HTMLTableElement'],['li','HTMLLIElement']];
+var matchesOwn = true, matchesOther = false;
+for (var i = 0; i < pairs.length; i++) {
+  var el = document.createElement(pairs[i][0]);
+  if (!(el instanceof window[pairs[i][1]])) matchesOwn = false;
+  for (var j = 0; j < pairs.length; j++) {
+    if (i !== j && el instanceof window[pairs[j][1]]) matchesOther = true;
+  }
+  if (!(el instanceof HTMLElement) || !(el instanceof Element)) matchesOwn = false;
+}
+r.push(matchesOwn);
+r.push(!matchesOther);
+");
+        Assert.Contains("true,true", result);
+    }
+
+    /// <summary>
+    /// The spec's grouped interfaces: one interface serving several tags
+    /// (<c>HTMLQuoteElement</c>, <c>HTMLHeadingElement</c>, <c>HTMLTableCellElement</c>), and the
+    /// abstract <c>HTMLMediaElement</c> that both media tags derive from without either naming it.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void Grouped_And_Abstract_Interfaces_Answer_For_Every_Tag_They_Cover()
+    {
+        var result = Run(@"
+r.push(document.createElement('blockquote') instanceof HTMLQuoteElement);
+r.push(document.createElement('q') instanceof HTMLQuoteElement);
+r.push(document.createElement('h1') instanceof HTMLHeadingElement);
+r.push(document.createElement('h6') instanceof HTMLHeadingElement);
+r.push(document.createElement('td') instanceof HTMLTableCellElement);
+r.push(document.createElement('th') instanceof HTMLTableCellElement);
+r.push(document.createElement('audio') instanceof HTMLMediaElement);
+r.push(document.createElement('video') instanceof HTMLMediaElement);
+r.push(document.createElement('video') instanceof HTMLVideoElement);
+r.push(!(document.createElement('video') instanceof HTMLAudioElement));
+r.push(!(document.createElement('div') instanceof HTMLMediaElement));
+");
+        Assert.Contains("true,true,true,true,true,true,true,true,true,true,true", result);
+    }
+
+    /// <summary>
+    /// The per-tag interfaces are as unconstructible as the ones above them.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void Per_Tag_Interface_Constructors_Throw_When_Called_With_New()
+    {
+        var result = Run(@"
+var names = ['HTMLFormElement','HTMLInputElement','HTMLDivElement','SVGElement'];
+for (var i = 0; i < names.length; i++) {
+  var threw = false;
+  try { new window[names[i]](); } catch (e) { threw = e instanceof TypeError; }
+  r.push(threw);
+}
+");
+        Assert.Contains("true,true,true,true", result);
+    }
+
+    /// <summary>
+    /// The <c>duckduckgo.com</c> statement itself. Its SSG bootstrap sets each search form's method
+    /// behind <c>form instanceof HTMLFormElement</c>; the <c>ReferenceError</c> that used to raise
+    /// aborted the rest of the enclosing <c>try</c> block, whose last statement added the
+    /// <c>partially-hydrated</c> class the page's own
+    /// <c>html.partially-hydrated body { display: block }</c> rule waits for — so the start page
+    /// stayed <c>display: none</c> and rendered as an empty white viewport.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void Form_InstanceOf_Check_Does_Not_Abort_The_Statements_After_It()
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<form class=""searchFormSSG""></form>
+<script>
+try {
+  Array.from(document.querySelectorAll('.searchFormSSG')).forEach(function (f) {
+    if (f instanceof HTMLFormElement) f.method = 'POST';
+  });
+  document.documentElement.classList.add('partially-hydrated');
+} catch (e) {
+  document.documentElement.setAttribute('data-ssg-error', String(e));
+}
+</script>
+</body></html>";
+
+        var result = CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+
+        Assert.Contains("partially-hydrated", result);
+
+        // The serialized document still carries the <script> source, so the catch block's own
+        // 'data-ssg-error' string is in it either way; only the written attribute has an '='.
+        Assert.DoesNotContain("data-ssg-error=", result);
+    }
 }

--- a/src/Broiler.Cli.Tests/PerformanceTimelineApiTests.cs
+++ b/src/Broiler.Cli.Tests/PerformanceTimelineApiTests.cs
@@ -1,0 +1,125 @@
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// The <c>performance</c> object's Performance Timeline surface
+/// (see <c>DomBridge.RegisterPerformanceObject</c>).
+/// </summary>
+/// <remarks>
+/// A capture records no performance entries, so the getters answer with an empty list — the answer
+/// a browser gives before anything has been recorded, and not the same thing as the method being
+/// absent. <c>getEntriesByName</c> was missing, and a page does not reach it behind a feature test:
+/// <c>performance</c> and <c>PerformanceObserver</c> both existing is the guard it writes, and the
+/// call comes after it. <c>duckduckgo.com</c>'s first-contentful-paint pixel opens with
+/// <c>performance.getEntriesByName('first-contentful-paint')</c> on exactly that guard, and threw
+/// <c>TypeError: undefined is not a function</c> — taking the <c>PerformanceObserver</c> fallback
+/// in the same <c>try</c> block with it, so the page never observed the paint it was asking about
+/// either.
+/// </remarks>
+public class PerformanceTimelineApiTests
+{
+    private static string Run(string script)
+    {
+        var html = @"<!DOCTYPE html>
+<html><body>
+<div id=""result""></div>
+<script>
+var r = [];
+" + script + @"
+document.getElementById('result').textContent = r.join(',');
+</script>
+</body></html>";
+        return CaptureService.ExecuteScriptsWithDom(html, "file:///test.html");
+    }
+
+    /// <summary>
+    /// What the script actually wrote, rather than the whole serialized document — which still
+    /// carries the <c>&lt;script&gt;</c> source, so a marker word searched for across it would match
+    /// the code that pushes the marker as readily as the marker itself.
+    /// </summary>
+    private static string ResultText(string document) =>
+        System.Text.RegularExpressions.Regex.Match(
+            document,
+            @"id=""result""[^>]*>(?<text>.*?)</div>",
+            System.Text.RegularExpressions.RegexOptions.Singleline)
+            .Groups["text"].Value;
+
+    [Fact(Timeout = 600000)]
+    public void Performance_Timeline_Members_Are_Callable()
+    {
+        var result = Run(@"
+var names = ['now','getEntries','getEntriesByType','getEntriesByName','mark','measure',
+             'clearMarks','clearMeasures','clearResourceTimings','setResourceTimingBufferSize',
+             'toJSON'];
+var allCallable = true;
+for (var i = 0; i < names.length; i++) {
+  if (typeof performance[names[i]] !== 'function') allCallable = false;
+}
+r.push(allCallable);
+r.push(typeof performance.timeOrigin === 'number');
+");
+        Assert.Contains("true,true", result);
+    }
+
+    /// <summary>
+    /// The three getters return a real (empty) entry list, so the indexing and length reads a
+    /// caller does next work rather than throwing on <c>undefined</c>.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void Entry_Getters_Return_An_Empty_List()
+    {
+        var result = Run(@"
+var byName = performance.getEntriesByName('first-contentful-paint');
+var byType = performance.getEntriesByType('navigation');
+var all = performance.getEntries();
+r.push(Array.isArray(byName) && byName.length === 0);
+r.push(Array.isArray(byType) && byType.length === 0);
+r.push(Array.isArray(all) && all.length === 0);
+r.push(byName[0] === undefined);
+");
+        Assert.Contains("true,true,true,true", result);
+    }
+
+    /// <summary>
+    /// <c>duckduckgo.com</c>'s first-contentful-paint pixel, in the shape the page ships it: the
+    /// <c>getEntriesByName</c> call and, when it reports nothing, the <c>PerformanceObserver</c>
+    /// that waits for the paint instead. Both live in one <c>try</c>, so the throw cost the page
+    /// the observer as well as the reading.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void Fcp_Pixel_Reaches_Its_PerformanceObserver_Fallback()
+    {
+        var result = Run(@"
+if (typeof PerformanceObserver === 'undefined' || typeof performance === 'undefined') {
+  r.push('guard-returned-early');
+} else {
+  try {
+    var entries = performance.getEntriesByName('first-contentful-paint');
+    if (entries[0]) {
+      r.push('reported-directly');
+    } else {
+      new PerformanceObserver(function () {}).observe({ type: 'paint', buffered: true });
+      r.push('observer-installed');
+    }
+  } catch (e) {
+    r.push('threw:' + e.message);
+  }
+}
+");
+        Assert.Equal("observer-installed", ResultText(result));
+    }
+
+    /// <summary>
+    /// Telemetry that ships timings reaches <c>toJSON</c> through <c>JSON.stringify(performance)</c>
+    /// as often as by name.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void Performance_Serialises_Through_JSON_Stringify()
+    {
+        var result = Run(@"
+var text = JSON.stringify(performance);
+r.push(typeof text === 'string');
+r.push(text.indexOf('timeOrigin') !== -1);
+");
+        Assert.Contains("true,true", result);
+    }
+}

--- a/src/Broiler.Cli.Tests/UnobservableIsolationGroupTests.cs
+++ b/src/Broiler.Cli.Tests/UnobservableIsolationGroupTests.cs
@@ -1,0 +1,136 @@
+using Broiler.HTML.Image;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// <c>isolation: isolate</c> on a document where nothing blends
+/// (<c>FragmentTreeBuilder.DocumentHasBlending</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// CSS Compositing §2.2 gives an isolation group one job: to stop a descendant's blending from
+/// reaching the backdrop outside the group. With no <c>mix-blend-mode</c> anywhere in the document
+/// the group has no job to do, so paint does not open a compositing layer for it — the same picture,
+/// one layer cheaper.
+/// </para>
+/// <para>
+/// It is also what keeps such a page visible at all today. A compositing group whose contents are
+/// not raster-compatible — one transformed descendant is enough — is routed to a compat backend
+/// that is a stub in this image renderer, and the group's entire subtree is dropped. The fix for
+/// that is in <c>Broiler.HTML</c>'s <c>GraphicsAdapter</c> and ships as the <c>patches/</c> entry
+/// "Keep a compositing group's contents when the group cannot use the raster canvas"; the
+/// <c>opacity</c> and <c>mix-blend-mode</c> groups it also covers are still lost until that is
+/// applied, which is why the cases below are the isolation ones.
+/// </para>
+/// <para>
+/// <c>duckduckgo.com</c> is the page this came from: its start page puts all of its content under
+/// <c>#__next { isolation: isolate }</c>, has transforms beneath that, and uses no blend mode
+/// anywhere — so it rendered as an empty white viewport.
+/// </para>
+/// </remarks>
+public class UnobservableIsolationGroupTests
+{
+    /// <summary>Counts pixels that are neither white nor near-white — i.e. that something painted.</summary>
+    private static int PaintedPixels(BBitmap bitmap)
+    {
+        int painted = 0;
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                var pixel = bitmap.GetPixel(x, y);
+                if (pixel.R < 240 || pixel.G < 240 || pixel.B < 240)
+                    painted++;
+            }
+        }
+
+        return painted;
+    }
+
+    private static string Page(string wrapperStyle, string extra = "") => $@"<!DOCTYPE html>
+<html><head><style>
+#wrapper {{ {wrapperStyle} }}
+</style></head>
+<body>
+  <div id=""wrapper"">
+    <p style=""color: black; font-size: 30px"">PLAIN CONTENT</p>
+    <div style=""transform: translateX(10px); color: black; font-size: 30px"">MOVED</div>
+    {extra}
+  </div>
+</body></html>";
+
+    /// <summary>
+    /// The transform is what makes the group non-raster, and it must not cost the page the content
+    /// that has nothing to do with it.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void Isolation_Group_Containing_A_Transform_Still_Paints_Its_Contents()
+    {
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(Page("isolation: isolate;"), 600, 250);
+
+        Assert.True(
+            PaintedPixels(bitmap) > 0,
+            "A wrapper with 'isolation: isolate' and a transformed descendant painted nothing at all.");
+    }
+
+    /// <summary>
+    /// With nothing blending, the group is not merely non-empty — it is the same picture it would be
+    /// with no group at all.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void Isolation_Group_Paints_As_Much_As_No_Group_At_All()
+    {
+        using var isolated = HtmlRender.RenderToImageWithStyleSet(Page("isolation: isolate;"), 600, 250);
+        using var plain = HtmlRender.RenderToImageWithStyleSet(Page(string.Empty), 600, 250);
+
+        Assert.Equal(PaintedPixels(plain), PaintedPixels(isolated));
+    }
+
+    /// <summary>
+    /// The <c>duckduckgo.com</c> shape: the page's whole content under one isolation group, with the
+    /// transform that makes the group non-raster somewhere inside it.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void Page_Wrapped_In_An_Isolation_Group_Is_Not_Blank()
+    {
+        const string html = @"<!DOCTYPE html>
+<html><head><style>
+#__next, #root { isolation: isolate; }
+.rotated { transform: rotate(3deg); }
+</style></head>
+<body>
+  <div id=""__next"">
+    <header style=""color: black; font-size: 24px"">HEADER TEXT</header>
+    <main style=""color: black; font-size: 24px"">
+      MAIN CONTENT
+      <span class=""rotated"">badge</span>
+    </main>
+  </div>
+</body></html>";
+
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(html, 600, 300);
+
+        Assert.True(
+            PaintedPixels(bitmap) > 0,
+            "A page wrapped in '#__next { isolation: isolate }' rendered completely blank.");
+    }
+
+    /// <summary>
+    /// The suppression is conditional, not unconditional: a document that does blend keeps its
+    /// isolation group, because there the group is the thing deciding what the blend sees.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void A_Blending_Descendant_Keeps_The_Isolation_Group()
+    {
+        var blending = Page(
+            "isolation: isolate;",
+            @"<div style=""mix-blend-mode: multiply; background: #808080; width: 40px; height: 40px""></div>");
+
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(blending, 600, 250);
+
+        // The group is honoured, so it goes through the layer path rather than being dropped from
+        // the computed style. Rendering must still complete and produce a picture.
+        Assert.NotNull(bitmap);
+        Assert.True(bitmap.Width > 0 && bitmap.Height > 0);
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Registration/Window.cs
@@ -139,12 +139,47 @@ public sealed partial class DomBridge
         performanceObj.FastAddValue((KeyString)"timeOrigin", new JSNumber(performanceTimeOrigin), JSPropertyAttributes.EnumerableConfigurableValue);
         performanceObj.FastAddValue((KeyString)"now", new DomFunction((in _) => Dom.Features.WindowDocumentMiscBinding.PerformanceNow(performanceTimeOrigin, in _), "now", 0), JSPropertyAttributes.EnumerableConfigurableValue);
 
-        // performance.getEntriesByType() — stub returning empty array
+        // The Performance Timeline getters (Performance Timeline §3). A capture records no
+        // performance entries, so all three answer with an empty list — which is a buffer that holds
+        // nothing, the same answer a browser gives before anything has been recorded, and not the
+        // same thing as the method being absent.
+        //
+        // getEntriesByName was the one of the three missing, and a page does not reach it behind a
+        // feature test: performance and PerformanceObserver both existing is the guard it writes, and
+        // this call comes after it. duckduckgo.com's first-contentful-paint pixel opens with
+        // `performance.getEntriesByName('first-contentful-paint')` on exactly that guard, which threw
+        // "undefined is not a function" — taking the PerformanceObserver fallback in the same try
+        // block with it, so the page never observed the paint it was asking about either.
+        performanceObj.FastAddValue((KeyString)"getEntries", new DomFunction((in _) => new JSArray(), "getEntries", 0), JSPropertyAttributes.EnumerableConfigurableValue);
         performanceObj.FastAddValue((KeyString)"getEntriesByType", new DomFunction((in _) => new JSArray(), "getEntriesByType", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObj.FastAddValue((KeyString)"getEntriesByName", new DomFunction((in _) => new JSArray(), "getEntriesByName", 2), JSPropertyAttributes.EnumerableConfigurableValue);
 
         // performance.mark() / performance.measure() — no-op stubs
         performanceObj.FastAddValue((KeyString)"mark", UndefinedFunction("mark", 1), JSPropertyAttributes.EnumerableConfigurableValue);
         performanceObj.FastAddValue((KeyString)"measure", UndefinedFunction("measure", 3), JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // The clear/resize counterparts to mark, measure and the resource buffer. Nothing is recorded
+        // for them to clear, but a page that marks commonly clears in the same breath, and the throw
+        // would land on the clear rather than on the mark it pairs with.
+        performanceObj.FastAddValue((KeyString)"clearMarks", UndefinedFunction("clearMarks", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObj.FastAddValue((KeyString)"clearMeasures", UndefinedFunction("clearMeasures", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObj.FastAddValue((KeyString)"clearResourceTimings", UndefinedFunction("clearResourceTimings", 0), JSPropertyAttributes.EnumerableConfigurableValue);
+        performanceObj.FastAddValue((KeyString)"setResourceTimingBufferSize", UndefinedFunction("setResourceTimingBufferSize", 1), JSPropertyAttributes.EnumerableConfigurableValue);
+
+        // toJSON is how the interface serialises, and telemetry that ships timings reaches it through
+        // JSON.stringify(performance) as often as by name.
+        performanceObj.FastAddValue(
+            (KeyString)"toJSON",
+            new DomFunction(
+                (in _) =>
+                {
+                    var json = new JSObject();
+                    json.FastAddValue((KeyString)"timeOrigin", new JSNumber(performanceTimeOrigin), JSPropertyAttributes.EnumerableConfigurableValue);
+                    return json;
+                },
+                "toJSON",
+                0),
+            JSPropertyAttributes.EnumerableConfigurableValue);
 
         window.FastAddValue((KeyString)"performance", performanceObj, JSPropertyAttributes.EnumerableConfigurableValue);
         context["performance"] = performanceObj;

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.DomInterfaces.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Utilities.DomInterfaces.cs
@@ -1,9 +1,103 @@
+using System.Text;
+
 using Broiler.JavaScript.Engine;
 
 namespace Broiler.HtmlBridge;
 
 public sealed partial class DomBridge
 {
+    /// <summary>
+    /// The per-tag HTML element interfaces (HTML §4, "Element interfaces"), as the pairs
+    /// <c>interface name → the tag names whose elements implement it</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>HTMLElement</c> answers for every HTML element and is registered separately; this table is
+    /// only the subtypes below it. A tag absent from the table implements <c>HTMLElement</c> itself
+    /// (<c>span</c> is the exception — it has a named interface that adds nothing — and the grouped
+    /// entries are the spec's own: one interface serving several tags, as <c>HTMLQuoteElement</c>
+    /// does for <c>blockquote</c> and <c>q</c>).
+    /// </para>
+    /// <para>
+    /// <c>HTMLMediaElement</c> is the one abstract entry: it is never an element's own interface, but
+    /// <c>audio</c> and <c>video</c> both derive from it, so it has to answer for both — which is why
+    /// the mapping is interface-to-tags rather than the tag-to-interface direction a lookup would
+    /// suggest. The same shape leaves room for any other interface that acquires a second tag.
+    /// </para>
+    /// </remarks>
+    private static readonly (string Interface, string Tags)[] HtmlElementInterfaces =
+    [
+        ("HTMLAnchorElement", "a"),
+        ("HTMLAreaElement", "area"),
+        ("HTMLMediaElement", "audio video"),
+        ("HTMLAudioElement", "audio"),
+        ("HTMLBaseElement", "base"),
+        ("HTMLQuoteElement", "blockquote q"),
+        ("HTMLBodyElement", "body"),
+        ("HTMLBRElement", "br"),
+        ("HTMLButtonElement", "button"),
+        ("HTMLCanvasElement", "canvas"),
+        ("HTMLTableCaptionElement", "caption"),
+        ("HTMLTableColElement", "col colgroup"),
+        ("HTMLDataElement", "data"),
+        ("HTMLDataListElement", "datalist"),
+        ("HTMLModElement", "del ins"),
+        ("HTMLDetailsElement", "details"),
+        ("HTMLDialogElement", "dialog"),
+        ("HTMLDirectoryElement", "dir"),
+        ("HTMLDivElement", "div"),
+        ("HTMLDListElement", "dl"),
+        ("HTMLEmbedElement", "embed"),
+        ("HTMLFieldSetElement", "fieldset"),
+        ("HTMLFontElement", "font"),
+        ("HTMLFormElement", "form"),
+        ("HTMLFrameElement", "frame"),
+        ("HTMLFrameSetElement", "frameset"),
+        ("HTMLHeadingElement", "h1 h2 h3 h4 h5 h6"),
+        ("HTMLHeadElement", "head"),
+        ("HTMLHRElement", "hr"),
+        ("HTMLHtmlElement", "html"),
+        ("HTMLIFrameElement", "iframe"),
+        ("HTMLImageElement", "img"),
+        ("HTMLInputElement", "input"),
+        ("HTMLLabelElement", "label"),
+        ("HTMLLegendElement", "legend"),
+        ("HTMLLIElement", "li"),
+        ("HTMLLinkElement", "link"),
+        ("HTMLPreElement", "listing plaintext pre xmp"),
+        ("HTMLMapElement", "map"),
+        ("HTMLMarqueeElement", "marquee"),
+        ("HTMLMenuElement", "menu"),
+        ("HTMLMetaElement", "meta"),
+        ("HTMLMeterElement", "meter"),
+        ("HTMLObjectElement", "object"),
+        ("HTMLOListElement", "ol"),
+        ("HTMLOptGroupElement", "optgroup"),
+        ("HTMLOptionElement", "option"),
+        ("HTMLOutputElement", "output"),
+        ("HTMLParagraphElement", "p"),
+        ("HTMLParamElement", "param"),
+        ("HTMLPictureElement", "picture"),
+        ("HTMLProgressElement", "progress"),
+        ("HTMLScriptElement", "script"),
+        ("HTMLSelectElement", "select"),
+        ("HTMLSlotElement", "slot"),
+        ("HTMLSourceElement", "source"),
+        ("HTMLSpanElement", "span"),
+        ("HTMLStyleElement", "style"),
+        ("HTMLTableElement", "table"),
+        ("HTMLTableSectionElement", "tbody tfoot thead"),
+        ("HTMLTableCellElement", "td th"),
+        ("HTMLTemplateElement", "template"),
+        ("HTMLTextAreaElement", "textarea"),
+        ("HTMLTimeElement", "time"),
+        ("HTMLTitleElement", "title"),
+        ("HTMLTableRowElement", "tr"),
+        ("HTMLTrackElement", "track"),
+        ("HTMLUListElement", "ul"),
+        ("HTMLVideoElement", "video"),
+    ];
+
     /// <summary>
     /// Registers the DOM interface-constructor globals a page reaches for by bare name —
     /// <c>Element</c>, <c>HTMLElement</c>, <c>HTMLUnknownElement</c>, <c>Document</c>,
@@ -51,6 +145,7 @@ public sealed partial class DomBridge
             function Text() { throw new TypeError('Illegal constructor'); }
             function Comment() { throw new TypeError('Illegal constructor'); }
             function Attr() { throw new TypeError('Illegal constructor'); }
+            function SVGElement() { throw new TypeError('Illegal constructor'); }
             function CanvasRenderingContext2D() { throw new TypeError('Illegal constructor'); }
 
             // ImageData, unlike the interfaces above, *is* constructible — HTML defines
@@ -161,7 +256,87 @@ public sealed partial class DomBridge
                         && typeof o.data.length === 'number'
                         && o.data.length === o.width * o.height * 4;
                 });
+
+                // SVGElement is the namespace's counterpart to HTMLElement, and the one interface
+                // here that HTML_NS excludes rather than selects.
+                define(SVGElement, function (o) {
+                    return isElement(o) && o.namespaceURI === 'http://www.w3.org/2000/svg';
+                });
             })();
         ");
+
+        RegisterHtmlElementInterfaces(context);
+    }
+
+    /// <summary>
+    /// The per-tag HTML element interfaces from <see cref="HtmlElementInterfaces"/> —
+    /// <c>HTMLFormElement</c>, <c>HTMLInputElement</c>, <c>HTMLAnchorElement</c> and the rest —
+    /// as globals that answer <c>instanceof</c> from the element's tag name.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These sit under the <c>HTMLElement</c> the method above registers, and they are what a page
+    /// uses when it has an element in hand and wants to know <em>which</em> element it is. Only the
+    /// bare name existing is not enough for that: it has to answer, so each one carries the same
+    /// <c>@@hasInstance</c> the interfaces above do, reading <c>tagName</c> rather than walking a
+    /// prototype chain a bridge DOM object does not have.
+    /// </para>
+    /// <para>
+    /// Their absence is a whole-page failure rather than a missing feature, because a bare name that
+    /// does not exist is a <c>ReferenceError</c> — which aborts the script at that statement, not
+    /// merely the test that named it. <c>duckduckgo.com</c> is the case that prompted this: its SSG
+    /// bootstrap sets each search form's method behind
+    /// <c>form instanceof HTMLFormElement</c>, and the two statements it never reached afterwards
+    /// were the <c>--vh</c> custom property and
+    /// <c>documentElement.classList.add('partially-hydrated')</c>. The page ships
+    /// <c>body { display: none }</c> with <c>html.partially-hydrated body { display: block }</c>, so
+    /// losing that one class left the start page rendering as an empty white viewport.
+    /// </para>
+    /// <para>
+    /// The declarations are generated rather than written out because the table is the interface
+    /// list: a <c>function</c> declaration per name is what makes the bare identifier resolve (the
+    /// same mechanism the hand-written interfaces above use), and pairing each with its tags in one
+    /// place keeps the name and the test it answers with from drifting apart.
+    /// </para>
+    /// </remarks>
+    private static void RegisterHtmlElementInterfaces(JSContext context)
+    {
+        var script = new StringBuilder();
+
+        foreach (var (name, _) in HtmlElementInterfaces)
+            script.Append("function ").Append(name).Append("() { throw new TypeError('Illegal constructor'); }\n");
+
+        script.Append("(function () {\n");
+        script.Append("    var byInterface = {\n");
+        foreach (var (name, tags) in HtmlElementInterfaces)
+            script.Append("        ").Append(name).Append(": [").Append(name).Append(", '").Append(tags).Append("'],\n");
+        script.Append("    };\n");
+        script.Append("""
+                for (var key in byInterface) {
+                    if (!Object.prototype.hasOwnProperty.call(byInterface, key)) continue;
+                    var ctor = byInterface[key][0];
+                    var tags = byInterface[key][1].split(' ');
+                    var set = {};
+                    for (var i = 0; i < tags.length; i++) set[tags[i]] = true;
+                    // `set` is captured per iteration through the factory rather than through the
+                    // loop body, whose `var` bindings are one shared pair by the time a test runs.
+                    Object.defineProperty(ctor, Symbol.hasInstance, {
+                        value: (function (tagSet) {
+                            return function (o) {
+                                if (!o || typeof o !== 'object' || o.nodeType !== 1) return false;
+                                var ns = o.namespaceURI;
+                                if (ns !== 'http://www.w3.org/1999/xhtml' && ns !== null && typeof ns !== 'undefined')
+                                    return false;
+                                var tag = typeof o.tagName === 'string' ? o.tagName.toLowerCase() : '';
+                                return tagSet[tag] === true;
+                            };
+                        })(set),
+                        writable: false, enumerable: false, configurable: true
+                    });
+                }
+            })();
+            """);
+
+        context.Eval(script.ToString());
     }
 }


### PR DESCRIPTION
## Summary

This change fixes two critical rendering issues that caused pages to render blank or incomplete:

1. **Missing per-tag HTML element interfaces** (`HTMLFormElement`, `HTMLInputElement`, etc.) — their absence caused `ReferenceError` exceptions that aborted script execution, breaking pages that relied on `instanceof` checks for these interfaces.

2. **Isolation groups with non-raster-compatible contents** — compositing groups that contained transforms were routed to a stub compatibility backend, causing their entire subtree to disappear from the rendered output.

## Key Changes

### DOM Bridge: Register Per-Tag HTML Element Interfaces
- Added `HtmlElementInterfaces` table mapping 50+ HTML element interface names to their corresponding tag names
- Implemented `RegisterHtmlElementInterfaces()` to generate and register these as bare globals with proper `Symbol.hasInstance` support
- Each interface answers `instanceof` checks based on element tag name, matching the HTML spec's per-tag interface hierarchy
- Includes grouped interfaces (`HTMLQuoteElement` for `blockquote`/`q`, `HTMLHeadingElement` for `h1`-`h6`) and abstract interfaces (`HTMLMediaElement` for `audio`/`video`)
- Added `SVGElement` constructor alongside the HTML interfaces

### Layout: Suppress Unobservable Isolation Groups
- Added `DocumentHasBlending()` method to detect whether any element in the document uses `mix-blend-mode` other than `normal`
- Pass `isolationObservable` flag through fragment tree building to `ComputedStyleBuilder`
- When `isolation: isolate` is present but no blending exists in the document, the isolation group is not emitted at paint time (it has no observable effect per CSS Compositing §2.2)
- This is a workaround for a graphics rendering issue where non-raster-compatible groups are dropped entirely

### Performance Timeline API
- Added missing `getEntriesByName()` method to the `performance` object
- Added `getEntries()` method for completeness
- All three entry getters (`getEntries`, `getEntriesByType`, `getEntriesByName`) now return empty arrays instead of being undefined

### Tests
- Added `UnobservableIsolationGroupTests` covering isolation groups with transforms
- Added `PerformanceTimelineApiTests` covering the Performance Timeline API surface
- Extended `DomInterfaceConstructorTests` with comprehensive tests for per-tag interface registration, grouped interfaces, and the `duckduckgo.com` use case

### Patch
- Added `0002-compositing-group-transform-content.patch` targeting `Broiler.HTML`'s `GraphicsAdapter` to prevent compositing groups with non-raster-compatible contents from being dropped entirely

## Notable Details

- The per-tag interface declarations are generated from the `HtmlElementInterfaces` table to keep the interface names and their tag mappings synchronized
- Each interface uses a factory-captured closure to avoid variable binding issues in the loop
- The isolation group suppression is conditional: groups are only suppressed when no blending exists in the document, preserving correctness when blend modes are present
- `duckduckgo.com`'s start page is the primary case: it wraps all content in `#__next { isolation: isolate }` with transforms beneath, and uses no blend modes — without these fixes it rendered as a blank white viewport

https://claude.ai/code/session_01GAmeV1w8LCkyoEQPn9ZYfN