### PR TITLE
Fix private-name key classification and fieldset legend layout

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Fieldset.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Fieldset.cs
@@ -22,10 +22,18 @@ namespace Broiler.Layout.Engine;
 /// the fieldset's own padding.
 /// </para>
 /// <para>
+/// The legend's inline size is the other half of the rule and is resolved earlier, in
+/// <c>ResolveBlockUsedWidth</c>: an <c>auto</c> inline size is the <em>fit-content</em> inline
+/// size, so the legend shrink-wraps rather than stretching to the fieldset's content width the way
+/// an ordinary block child would. <see cref="IsRenderedLegend"/> is what that branch asks.
+/// </para>
+/// <para>
 /// Applied after the children are laid out, because the legend's margin box is only measured then —
 /// the same shape as every other post-layout placement here. What is <em>not</em> done is the
 /// notch: the block-start border is still painted behind the legend, where it should stop at the
-/// legend's margin box and resume after it.
+/// legend's margin box and resume after it. Nor is the block-size rule that goes with a
+/// non-<c>auto</c> <c>block-size</c> (subtract the part of the legend's margin box that spills past
+/// the border), which is what WPT's <c>fieldset-block-size</c> asks for.
 /// </para>
 /// </remarks>
 internal partial class CssBox
@@ -55,8 +63,8 @@ internal partial class CssBox
 
         // The content starts below whichever of the border and the legend reaches further down —
         // the legend's margin-box bottom is `border/2 + legendBox/2` by the centring above.
-        double moveRest = Location.Y + Math.Max(border, (border + legendBox) / 2) + ActualPaddingTop
-            - marginBoxBottom;
+        double contentTop = Location.Y + Math.Max(border, (border + legendBox) / 2) + ActualPaddingTop;
+        double moveRest = contentTop - marginBoxBottom;
 
         if (Math.Abs(moveRest) <= 0.01)
             return;
@@ -72,10 +80,43 @@ internal partial class CssBox
 
             child.OffsetTop(moveRest);
         }
+
+        // The children moved, so the auto height measured from them is stale by the same amount.
+        // MarginBottomCollapse cannot be re-run to find out — it only ever grows ActualBottom
+        // (`Math.Max(ActualBottom, …)`), and the move that matters here is upwards: the legend had
+        // been laid out in the flow, so the fieldset was left as tall as if the border carried the
+        // content *and* a legend-sized block below it. WPT's `legend-block-position-centering`
+        // rendered a 100px-bordered fieldset 315px tall where every engine draws 218.
+        //
+        // Every in-flow child shifted by exactly `moveRest`, and the legend itself never reaches
+        // below `contentTop` (it is centred on the border, so its margin box ends at
+        // `border/2 + legendBox/2`, which is where the content begins whenever the legend is the
+        // taller). So the measured bottom shifts with the children, floored at an empty content box.
+        if (Height == CssConstants.Auto || string.IsNullOrEmpty(Height))
+        {
+            ActualBottom = Math.Max(
+                contentTop + ActualPaddingBottom + ActualBorderBottomWidth,
+                ActualBottom + moveRest);
+        }
     }
 
     private bool IsFieldset =>
         string.Equals(HtmlTag?.Name, "fieldset", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Whether this box is the rendered legend of the fieldset it is a child of.
+    /// </summary>
+    /// <remarks>
+    /// HTML §15.5.13 gives the rendered legend a fit-content inline size when its own
+    /// <c>inline-size</c> is <c>auto</c> — it is blockified, but it is not stretched to the
+    /// fieldset's content width the way an ordinary block child would be. Layout asks this before
+    /// resolving the used width; see <c>ResolveBlockUsedWidth</c>.
+    /// </remarks>
+    internal bool IsRenderedLegend =>
+        string.Equals(HtmlTag?.Name, "legend", StringComparison.OrdinalIgnoreCase)
+        && ParentBox is { } parent
+        && parent.IsFieldset
+        && ReferenceEquals(parent.RenderedLegend(), this);
 
     /// <summary>
     /// The fieldset's rendered legend: its first in-flow <c>&lt;legend&gt;</c> child. A second one

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
@@ -584,6 +584,59 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
             Size = new SizeF((float)stfWidth, Size.Height);
         }
+        else if (!replacedSizeSettled
+            && (Width == CssConstants.Auto || string.IsNullOrEmpty(Width))
+            && IsRenderedLegend)
+        {
+            // HTML §15.5.13: "If the computed value of 'inline-size' is 'auto', then the used
+            // value is the fit-content inline size." A rendered legend is blockified, but unlike
+            // an ordinary block child it does not stretch to the fieldset's content width — it
+            // shrink-wraps, and the fieldset's block-start border is then painted around it.
+            // Without this the legend filled the fieldset, so WPT's
+            // `the-fieldset-and-legend-elements/legend-block-position-centering` drew a
+            // fieldset-wide legend border where every engine draws a content-wide one.
+            EnsureDescendantWordsMeasured(g);
+
+            double ownPadBorder = ActualBorderLeftWidth + ActualBorderRightWidth
+                                + ActualPaddingLeft + ActualPaddingRight;
+
+            // Same framing as the intrinsic-keyword branch below: ComputeShrinkToFitWidth is a
+            // content-box width and GetMinMaxWidth a border-box one, so strip this box's own
+            // padding and border off the min side before combining the two.
+            double maxContent = ComputeShrinkToFitWidth();
+
+            GetMinMaxWidth(out double legendMinBorderBox, out _);
+
+            if (double.IsNaN(legendMinBorderBox))
+                legendMinBorderBox = 0;
+
+            if (double.IsNaN(maxContent))
+                maxContent = 0;
+
+            double legendMinContent = Math.Max(0, legendMinBorderBox - ownPadBorder);
+            double legendAvailable = Math.Max(0, width - ActualMarginLeft - ActualMarginRight - ownPadBorder);
+
+            double legendWidth = Math.Min(Math.Max(legendMinContent, legendAvailable), maxContent);
+
+            if (MaxWidth != "none" && !string.IsNullOrEmpty(MaxWidth))
+            {
+                double maxW = ResolveMaxWidthLength(width);
+
+                if (legendWidth > maxW)
+                    legendWidth = maxW;
+            }
+
+            if (MinWidth != "0" && !string.IsNullOrEmpty(MinWidth))
+            {
+                double minW = ResolveMinWidthLength(width);
+
+                if (legendWidth < minW)
+                    legendWidth = minW;
+            }
+
+            legendWidth += ownPadBorder;
+            Size = new SizeF((float)legendWidth, Size.Height);
+        }
         else if ((Width == CssConstants.Auto || string.IsNullOrEmpty(Width))
             && Float == CssConstants.None
             && Position != CssConstants.Absolute && Position != CssConstants.Fixed

--- a/patches/0001-js-private-name-key-classification.patch
+++ b/patches/0001-js-private-name-key-classification.patch
@@ -1,0 +1,90 @@
+From 7060575b4e0bdc4c1362ba16363379749e62a8b8 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 21 Aug 2026 18:19:12 +0000
+Subject: [PATCH] Classify a private-name key by its marker and '#', not the
+ marker alone
+
+A private name's property key is the U+0001 marker followed by the name,
+and the name always carries its leading '#'. KeyStrings.Classify tested
+only the marker, so every ordinary string key that merely begins with
+U+0001 was treated as a private name: writing one threw the brand-check
+TypeError, and reflection and enumeration hid it.
+
+WPT's testharness.js does exactly that while building its escape map --
+formatEscapeMap[String.fromCharCode(p)] for p = 1 -- so the harness threw
+while loading and every testharness-based test in the suite produced no
+results at all.
+---
+ .../Issue693Tests.cs                             | 16 ++++++++++++++++
+ .../StorageTests.cs                              |  8 ++++++++
+ .../Broiler.JavaScript.Storage/KeyStrings.cs     |  9 ++++++++-
+ 3 files changed, 32 insertions(+), 1 deletion(-)
+
+diff --git a/Broiler.JS/Broiler.JavaScript.Integration.Tests/Issue693Tests.cs b/Broiler.JS/Broiler.JavaScript.Integration.Tests/Issue693Tests.cs
+index fa511b3d..d76e9d27 100644
+--- a/Broiler.JS/Broiler.JavaScript.Integration.Tests/Issue693Tests.cs
++++ b/Broiler.JS/Broiler.JavaScript.Integration.Tests/Issue693Tests.cs
+@@ -523,4 +523,20 @@ public class Issue693Tests
+             "class A { #v = 1; get(){ return this.#v; } }"
+             + "class B { #v = 2; get(){ return this.#v; } }"
+             + "new A().get() + '|' + new B().get();").ToString());
++
++    // The private-name namespace is the marker *and* the '#' that every private name carries.
++    // Matching the marker on its own claimed ordinary string keys that happen to begin with
++    // U+0001: the write threw the brand-check TypeError and reflection hid the key. WPT's
++    // testharness.js builds its escape map with `formatEscapeMap[String.fromCharCode(p)]`, so
++    // p = 1 threw while the harness was loading and no testharness test reported anything.
++    [Fact(Timeout = 600000)]
++    public void MarkerPrefixedStringPropertyIsAnOrdinaryProperty()
++    {
++        Assert.Equal("v|1", Eval(
++            "var o = {}; o[String.fromCharCode(1)] = 'v';"
++            + "o[String.fromCharCode(1)] + '|' + Object.keys(o).length;").ToString());
++        Assert.Equal("v|1", Eval(
++            "var o = {}; o[String.fromCharCode(1) + 'tail'] = 'v';"
++            + "o[String.fromCharCode(1) + 'tail'] + '|' + Object.keys(o).length;").ToString());
++    }
+ }
+diff --git a/Broiler.JS/Broiler.JavaScript.Storage.Tests/StorageTests.cs b/Broiler.JS/Broiler.JavaScript.Storage.Tests/StorageTests.cs
+index 18978397..36a20f4e 100644
+--- a/Broiler.JS/Broiler.JavaScript.Storage.Tests/StorageTests.cs
++++ b/Broiler.JS/Broiler.JavaScript.Storage.Tests/StorageTests.cs
+@@ -185,6 +185,14 @@ public class StorageTests
+         Assert.False(KeyStrings.GetOrCreate("4294967295").Metadata.IsArrayIndex);
+         Assert.False(KeyStrings.GetOrCreate("01").Metadata.IsArrayIndex);
+         Assert.True(KeyStrings.GetOrCreate("\u0001#secret").Metadata.IsPrivateName);
++
++        // The marker alone is not the classification: a private name always carries its '#', so
++        // an ordinary string key that merely begins with the marker stays an ordinary key.
++        // Reading it as private made writing it throw the brand-check TypeError and hid it from
++        // reflection, which is what broke WPT's testharness.js on `String.fromCharCode(1)`.
++        Assert.False(KeyStrings.GetOrCreate("\u0001").Metadata.IsPrivateName);
++        Assert.False(KeyStrings.GetOrCreate("\u0001tail").Metadata.IsPrivateName);
++        Assert.False(KeyStrings.GetOrCreate("#secret").Metadata.IsPrivateName);
+         Assert.Equal(index.Metadata.StableOrdinalHash, KeyStrings.GetOrCreate("4294967294").Metadata.StableOrdinalHash);
+     }
+ 
+diff --git a/Broiler.JS/Broiler.JavaScript.Storage/KeyStrings.cs b/Broiler.JS/Broiler.JavaScript.Storage/KeyStrings.cs
+index b6a62bca..4a10454c 100644
+--- a/Broiler.JS/Broiler.JavaScript.Storage/KeyStrings.cs
++++ b/Broiler.JS/Broiler.JavaScript.Storage/KeyStrings.cs
+@@ -214,8 +214,15 @@ public static class KeyStrings
+     {
+         var isArrayIndex = TryGetArrayIndex(text.AsSpan(), out var arrayIndex);
+         var isCanonicalNumeric = TryGetCanonicalNumericIndex(text, isArrayIndex, arrayIndex, out var numericIndex);
++        // A private name's key is the marker followed by the name, and a private name always
++        // carries its leading '#' (JSObject.MintPrivateName / FastCompiler.KeyOfPrivateName), so
++        // both characters have to be there. Testing the marker alone claimed every ordinary string
++        // key that merely begins with the marker: writing one threw the brand-check TypeError, and
++        // reflection and enumeration hid it. WPT's testharness.js does exactly that while building
++        // its escape map (`formatEscapeMap[String.fromCharCode(p)]` with p = 1), so the harness
++        // threw on load and every testharness-based test in the suite reported nothing at all.
+         return new KeyMetadata(
+-            text.Length != 0 && text[0] == '\u0001',
++            text.Length >= 2 && text[0] == '\u0001' && text[1] == '#',
+             isArrayIndex,
+             arrayIndex,
+             isCanonicalNumeric,
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,49 @@
+# Submodule patches
+
+Changes that belong in a submodule but could not be pushed to its remote: the
+session's git proxy only injects a credential for repositories in the session's
+GitHub scope, and `Broiler-Platform/Broiler.*` is outside it, so
+`git push origin HEAD` from inside a submodule returns **403**. Per
+`CLAUDE.md` → "Submodules: modify them; push if allowed, otherwise deliver as a
+PATCH", the change is exported here instead and **no gitlink is bumped** — CI
+clones each submodule by pointer, and a pointer moved to a commit that was never
+pushed would break it.
+
+Apply one with `git am` from inside the submodule it names, then bump the
+pointer in the parent:
+
+```sh
+cd <Submodule>
+git am ../patches/NNNN-<slug>.patch
+git push origin HEAD          # from a session/CI with the broader scope
+cd ..
+git add <Submodule> && git commit -m "Update submodules"
+```
+
+This directory is a backlog, not an archive: a patch is deleted once its fix is
+upstream and the numbering restarts from `0001` against whatever is left. A
+`patches/NNNN` reference in an older commit message or document is therefore
+almost always dangling — name the **commit subject** instead. To check whether a
+fix is already live:
+
+```sh
+git -C <Submodule> log --oneline --grep '<subject>'
+```
+
+## Index
+
+| Patch | Submodule | Commit subject | Why |
+| --- | --- | --- | --- |
+| `0001-js-private-name-key-classification.patch` | `Broiler.JS` | Classify a private-name key by its marker and `#`, not the marker alone | A private name's property key is the U+0001 marker followed by the name, and the name always carries its leading `#` (`JSObject.MintPrivateName`, `FastCompiler.KeyOfPrivateName`). `KeyStrings.Classify` tested only the marker, so **every ordinary string key beginning with U+0001** was taken for a private name: writing one threw the brand-check `TypeError`, and reflection and enumeration hid it. WPT's `testharness.js` does exactly that while building its escape map — `formatEscapeMap[String.fromCharCode(p)]` with `p = 1` — so the harness threw *while loading* and **every testharness-based test in the suite reported no results at all**. With the patch applied the harness loads and the usual pass/fail table renders. |
+
+The main repo builds and passes without it, and there is no main-repo seam that
+can stand in: the classification lives entirely in
+`Broiler.JavaScript.Storage`, so there is no equivalent fallback fix to carry
+here in the meantime.
+
+It is listed in `scripts/apply-pending-wpt-patches.sh`, which the privacy
+test-page and real-world render workflows run before their builds — so it
+reaches those on top of the pinned pointer. The **WPT** workflows
+(`wpt-tests.yml`, `wpt-reftests.yml`) do not run that script today, so the WPT
+suite only picks this up once a maintainer lands it upstream and bumps the
+pointer.

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -295,7 +295,25 @@ set -euo pipefail
 # unit-tested in UnobservableIsolationGroupTests), and that half is narrower by construction: it
 # cannot reach a group opened for `opacity` or for a real `mix-blend-mode`. Only this patch keeps
 # those, and only the pixel suite can say the subtree reached the canvas.
+# That compositing-group patch landed upstream and its pointer is bumped, so it reaches CI through
+# the pointer and its file is gone with it — which emptied patches/ again and restarted the
+# numbering, so the 0001 below is a different change once more.
+#
+# 0001 (Broiler.JS, "Classify a private-name key by its marker and '#', not the marker alone") IS
+# listed, and for the widest reason anything here has been: without it WPT's testharness.js throws
+# while loading. It builds its escape map with `formatEscapeMap[String.fromCharCode(p)]`, and for
+# p = 1 that key begins with the private-name marker, which the classifier read as a private name
+# — so the write raised the brand-check TypeError and took the whole harness down with it. A
+# testharness test whose harness never loaded reports nothing at all and renders none of the
+# pass/fail table its reference shows, so this is not one element mispainted but every
+# testharness-based page in the corpus. Its unit tests pin the classification (StorageTests,
+# Issue693Tests); only a run of a real harness page can say the harness survives loading.
+#
+# NOTE: the WPT workflows do not run this script — only privacy-test-pages.yml and
+# real-world-render-tests.yml do — so the entry below serves those two. The WPT suite picks the
+# fix up when a maintainer lands it upstream and bumps the pointer.
 PENDING_PATCHES=(
+  "Broiler.JS|patches/0001-js-private-name-key-classification.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/Broiler.Wpt.Tests/FieldsetLegendRenderTests.cs
+++ b/src/Broiler.Wpt.Tests/FieldsetLegendRenderTests.cs
@@ -116,6 +116,47 @@ public sealed class FieldsetLegendRenderTests : IDisposable
         Assert.False(IsGreen(rendered, 100, 30), "but no taller than its maximum block size");
     }
 
+    // HTML §15.5.13: "If the computed value of 'inline-size' is 'auto', then the used value is the
+    // fit-content inline size." The rendered legend is blockified but does not stretch to the
+    // fieldset's content width the way an ordinary block child would.
+    [Fact(Timeout = 600000)]
+    public void A_Rendered_Legend_Shrink_Wraps_Rather_Than_Filling_The_Fieldset()
+    {
+        using var rendered = Render(
+            "<!DOCTYPE html><meta charset=\"utf-8\"><style>"
+            + "* { margin: 0; padding: 0; } body { background: #fff; }"
+            + "fieldset { border: 4px solid #008000; width: 300px; }"
+            + "legend { display: block; background: #000; }"
+            + "legend span { display: inline-block; width: 40px; height: 20px; }"
+            + "</style><fieldset><legend><span></span></legend></fieldset>");
+
+        // The legend's width is its own content's, not the fieldset's: it runs from the content
+        // edge (x=4) for 40px and no further.
+        Assert.True(IsBlack(rendered, 20, 8), "the legend is drawn at its content's width");
+        Assert.False(IsBlack(rendered, 200, 8), "and does not stretch across the fieldset");
+    }
+
+    // The legend belongs to the block-start border, not to the content, so it must not also be
+    // counted as a block in the fieldset's auto height — which left the fieldset a legend taller
+    // than every engine draws it (WPT legend-block-position-centering rendered a 100px-bordered
+    // fieldset 315px tall against a 218px reference).
+    [Fact(Timeout = 600000)]
+    public void A_Rendered_Legend_Is_Not_Counted_Twice_In_The_Auto_Height()
+    {
+        using var rendered = Render(
+            "<!DOCTYPE html><meta charset=\"utf-8\"><style>"
+            + "* { margin: 0; padding: 0; } body { background: #fff; }"
+            + "fieldset { border: 30px solid #008000; width: 300px; }"
+            + "legend { display: block; background: #000; width: 40px; height: 20px; }"
+            + "div { height: 20px; background: #0000ff; }"
+            + "</style><fieldset><legend></legend><div></div></fieldset>");
+
+        // Border 30 + content 20 + border 30 = 80: the bottom border runs 50..80, and nothing of
+        // the fieldset is drawn past it. The legend's 20px box is inside the border, not below it.
+        Assert.True(IsGreen(rendered, 200, 60), "the bottom border sits directly below the content");
+        Assert.False(IsGreen(rendered, 200, 85), "and the fieldset ends there");
+    }
+
     private static bool IsBlack(BBitmap bitmap, int x, int y) => IsColor(bitmap, x, y, 0, 0, 0);
 
     private static bool IsBlue(BBitmap bitmap, int x, int y) => IsColor(bitmap, x, y, 0, 0, 255);


### PR DESCRIPTION
## Summary

This PR addresses two distinct issues:

1. **Private-name key classification bug in Broiler.JS** (via patch): The `KeyStrings.Classify` method was incorrectly identifying any string key beginning with the U+0001 marker as a private name, when it should only match the marker followed by `#`. This caused WPT's testharness.js to fail during loading, breaking all testharness-based tests.

2. **Fieldset legend layout issues in Broiler.Layout**: The rendered legend's inline size was not being computed as fit-content (causing it to fill the fieldset width instead of shrink-wrapping), and the legend was being double-counted in the fieldset's auto height calculation.

## Key Changes

### Broiler.JS (patch: `0001-js-private-name-key-classification.patch`)

- **KeyStrings.cs**: Changed private-name classification from checking only the U+0001 marker (`text[0] == '\u0001'`) to checking both the marker and the `#` character (`text.Length >= 2 && text[0] == '\u0001' && text[1] == '#'`)
- **StorageTests.cs**: Added tests verifying that strings beginning with U+0001 alone or with other suffixes are treated as ordinary properties, not private names
- **Issue693Tests.cs**: Added integration test confirming that `String.fromCharCode(1)` can be used as an ordinary property key

**Why this matters**: WPT's testharness.js builds an escape map using `formatEscapeMap[String.fromCharCode(1)]`, which was incorrectly treated as a private name. This caused the harness to throw during loading, preventing any testharness-based test from reporting results.

### Broiler.Layout

- **CssBox.Layout.cs**: Added fit-content width resolution for rendered legends with `auto` inline-size, implementing HTML §15.5.13 shrink-wrap behavior instead of stretching to fieldset width
- **CssBox.Fieldset.cs**: 
  - Added `IsRenderedLegend` property to identify when a box is the rendered legend of its parent fieldset
  - Modified `ApplyFieldsetLegendPlacement()` to recalculate the fieldset's auto height after repositioning children, preventing the legend from being double-counted
  - Updated documentation to clarify the legend's fit-content sizing and height adjustment rules
- **FieldsetLegendRenderTests.cs**: Added tests verifying that rendered legends shrink-wrap to their content width and are not double-counted in auto height calculations

## Implementation Details

The private-name fix is delivered as a patch file (`patches/0001-js-private-name-key-classification.patch`) because the Broiler.JS submodule remote is outside the session's GitHub scope. The patch is registered in `scripts/apply-pending-wpt-patches.sh` so it reaches privacy-test-pages and real-world render workflows. The WPT workflows will pick up the fix once it lands upstream and the pointer is bumped.

The fieldset legend layout changes ensure that:
- A legend with `auto` inline-size uses fit-content sizing (shrink-wraps) rather than stretching to the fieldset's content width
- The legend's repositioning during `ApplyFieldsetLegendPlacement()` is reflected in the fieldset's auto height calculation, preventing the legend from being counted twice

https://claude.ai/code/session_01JRk2jx5mVJne5iygyfBUCe