### PR TITLE
Implement flex-wrap and column-reverse for column flex containers

### DIFF
--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
@@ -598,6 +598,377 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         ActualBottom = Math.Max(ActualBottom, cursorY + ActualPaddingBottom + ActualBorderBottomWidth);
     }
 
+    private sealed class FlexColumnLine
+    {
+        public List<CssBox> Items { get; } = [];
+
+        /// <summary>Sum of the items' outer heights and the gaps between them.</summary>
+        public double MainSize { get; set; }
+
+        /// <summary>The line's extent across the inline axis.</summary>
+        public double CrossSize { get; set; }
+    }
+
+    /// <summary>
+    /// CSS Flexbox §9.3/§9.5/§9.6 for a <c>column</c> flex container: breaks its items into flex
+    /// lines along the main (block) axis, stacks those lines across the inline axis, and packs
+    /// each line from the direction's main-start — the block-<em>end</em> edge, for
+    /// <c>column-reverse</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A column container has no flex algorithm of its own here: its items stack through ordinary
+    /// block flow, one per line (the line-break-per-item path in <c>CssLayoutEngine</c>), and the
+    /// two passes that follow this one size and align that single stack. Neither of the two things
+    /// this pass exists for is expressible that way. <c>flex-wrap</c> in a column needs the stack
+    /// broken into several, which no post-pass over one line can do — so a wrapping column
+    /// container rendered every item in one full-width column that overflowed the container
+    /// (WPT css-flexbox/flex-lines/multi-line-wrap-with-column-reverse laid its six items out as
+    /// six stacked bands instead of three columns). And <c>column-reverse</c> reverses the main
+    /// axis, so its items are ordered bottom-to-top and packed from the block-end edge, which the
+    /// block flow that produced them cannot express at all — the keyword was parsed, recognised
+    /// everywhere it selects the column path, and then laid out exactly like <c>column</c>.
+    /// </para>
+    /// <para>
+    /// Returns <see langword="false"/> — leaving the existing single-line passes to run — for the
+    /// case they already handle: one line in ordinary <c>column</c> order. So this changes nothing
+    /// about a container that does not wrap and does not reverse, which is nearly all of them.
+    /// </para>
+    /// <para>
+    /// Line breaking needs a definite main size to break against (§9.3), so a column container
+    /// whose <c>height</c> is <c>auto</c> keeps everything on one line however it is wrapped —
+    /// its main size is what its content adds up to, and nothing can overflow it.
+    /// </para>
+    /// </remarks>
+    private bool PerformFlexColumnLineLayout(ILayoutEnvironment g)
+    {
+        if (!IsFlexContainer() || IsRowFlexContainer())
+            return false;
+
+        // `column` names the *block* axis, so under a vertical writing mode the main axis is
+        // horizontal and the cross axis vertical — the opposite of every axis this pass reads.
+        // The single-line passes it would displace make the same horizontal assumption, so
+        // declining here leaves a vertical container exactly as it was rather than transposed
+        // (WPT css-flexbox/gap-003-lr and -rl are `vertical-lr`/`-rl` column containers).
+        if (IsVerticalWritingMode(WritingMode))
+            return false;
+
+        double contentWidth = Math.Max(0, Size.Width
+            - ActualBorderLeftWidth - ActualBorderRightWidth
+            - ActualPaddingLeft - ActualPaddingRight);
+
+        if (contentWidth <= 0)
+            return false;
+
+        var items = new List<CssBox>();
+
+        foreach (var child in Boxes)
+        {
+            if (!IsInFlowFlexItem(child) || IsCollapsibleWhitespaceItem(child))
+                continue;
+
+            items.Add(child);
+        }
+
+        if (items.Count == 0)
+            return false;
+
+        bool reverse = string.Equals(FlexDirection?.Trim(), "column-reverse", StringComparison.OrdinalIgnoreCase);
+        bool wrap = FlexWrap is "wrap" or "wrap-reverse";
+        double? definiteMain = TryGetDefiniteMainAxisContentHeight();
+        double rowGap = ResolveFlexGap(RowGap, definiteMain ?? 0);
+        double columnGap = ResolveFlexGap(ColumnGap, contentWidth);
+
+        var lines = CollectFlexColumnLines(items, wrap ? definiteMain : null, rowGap);
+
+        if (lines.Count == 1 && !reverse)
+            return false;
+
+        using var trace = LayoutWorkTrace.Measure(LayoutWorkTrace.Ops.Flex);
+
+        ResolveFlexColumnLineCrossSizes(lines, contentWidth, columnGap, out double lineOffset, out double lineGap);
+
+        // `wrap-reverse` flips the cross axis, so the first line is placed at the cross-end.
+        if (FlexWrap == "wrap-reverse")
+            lines.Reverse();
+
+        double cursorX = ClientLeft + lineOffset;
+        double usedMain = 0;
+
+        foreach (var line in lines)
+        {
+            // Each line is laid out against the container's own main size when that is definite;
+            // that is the size the lines were broken against, and what an item's `flex-grow` share
+            // and `justify-content`'s free space are measured from.
+            double lineMain = definiteMain ?? line.MainSize;
+
+            ResolveFlexColumnLineItemSizes(g, line, lineMain, rowGap);
+            PlaceFlexColumnLineItems(line, lineMain, rowGap, cursorX, reverse);
+
+            usedMain = Math.Max(usedMain, Math.Min(lineMain, line.MainSize));
+            cursorX += line.CrossSize + lineGap;
+        }
+
+        // This pass owns the container's in-flow content extent now: without this the block flow's
+        // one-item-per-line stack would still be the height reported, which for a wrapped
+        // container is every line's content added up rather than the tallest line's.
+        ActualBottom = ClientTop + usedMain + ActualPaddingBottom + ActualBorderBottomWidth;
+        return true;
+    }
+
+    /// <summary>
+    /// CSS Flexbox §9.3 step 5: collects the items into flex lines, breaking before an item that
+    /// would not fit in the main size still available on the current line.
+    /// </summary>
+    /// <param name="mainLimit">
+    /// The definite main size to break against, or <c>null</c> for a single-line container — which
+    /// is both what <c>nowrap</c> asks for and all an indefinite main size can produce.
+    /// </param>
+    private static List<FlexColumnLine> CollectFlexColumnLines(List<CssBox> items, double? mainLimit, double rowGap)
+    {
+        var lines = new List<FlexColumnLine>();
+        var current = new FlexColumnLine();
+
+        foreach (var child in items)
+        {
+            double outerHeight = GetFlexItemOuterHeight(child);
+
+            if (mainLimit is { } limit && current.Items.Count > 0
+                && current.MainSize + rowGap + outerHeight > limit + 0.5)
+            {
+                lines.Add(current);
+                current = new FlexColumnLine();
+            }
+
+            if (current.Items.Count > 0)
+                current.MainSize += rowGap;
+
+            current.Items.Add(child);
+            current.MainSize += outerHeight;
+        }
+
+        lines.Add(current);
+        return lines;
+    }
+
+    /// <summary>
+    /// CSS Flexbox §9.4 step 8 and §9.6 step 15/16: sizes each line across the cross (inline) axis
+    /// — the widest item's margin box — and then distributes the container's leftover cross space
+    /// per <c>align-content</c>.
+    /// </summary>
+    private void ResolveFlexColumnLineCrossSizes(
+        List<FlexColumnLine> lines, double contentWidth, double columnGap, out double lineOffset, out double lineGap)
+    {
+        double usedCross = 0;
+
+        foreach (var line in lines)
+        {
+            double cross = 0;
+
+            foreach (var child in line.Items)
+                cross = Math.Max(cross, child.Size.Width + child.ActualMarginLeft + child.ActualMarginRight);
+
+            line.CrossSize = cross;
+            usedCross += cross;
+        }
+
+        double freeCross = contentWidth - usedCross - Math.Max(0, lines.Count - 1) * columnGap;
+        string align = NormalizeBoxAlignment(AlignContent);
+
+        // `normal` behaves as `stretch` for a flex container, and it is what an unstyled one has.
+        if (align is "" or "auto" or "normal")
+            align = "stretch";
+
+        if (align == "stretch")
+        {
+            lineOffset = 0;
+            lineGap = columnGap;
+
+            if (freeCross > 0.5)
+            {
+                double share = freeCross / lines.Count;
+
+                foreach (var line in lines)
+                    line.CrossSize += share;
+            }
+
+            return;
+        }
+
+        ResolveContentDistribution(align, lines.Count, Math.Max(0, freeCross), columnGap, out lineOffset, out lineGap);
+    }
+
+    /// <summary>
+    /// CSS Flexbox §9.7 and §9.4 step 11 for one column flex line: grows the items into the line's
+    /// free main space per <c>flex-grow</c>, and stretches an <c>auto</c>-width item across the
+    /// line's cross size.
+    /// </summary>
+    /// <remarks>
+    /// Both are settled in a single re-layout per item, because they resize different axes of the
+    /// same box: laying an item out at its stretched width and then again at its grown height
+    /// would let the second layout re-derive the width from the <c>auto</c> declaration and undo
+    /// the stretch. Growth only, no shrinking — the same restriction as the single-line pass, and
+    /// for the reason given there.
+    /// </remarks>
+    private void ResolveFlexColumnLineItemSizes(ILayoutEnvironment g, FlexColumnLine line, double lineMain, double rowGap)
+    {
+        double freeMain = lineMain - line.MainSize;
+        double growTotal = 0;
+
+        if (freeMain > 0.5)
+        {
+            foreach (var child in line.Items)
+                growTotal += ParseFlexFactor(child.FlexGrow, 0);
+        }
+
+        double mainSize = 0;
+
+        for (int i = 0; i < line.Items.Count; i++)
+        {
+            var child = line.Items[i];
+            double outerHeight = GetFlexItemOuterHeight(child);
+            double? targetHeight = null;
+            double? targetWidth = null;
+
+            if (growTotal > 0)
+            {
+                double factor = ParseFlexFactor(child.FlexGrow, 0);
+                double grown = outerHeight + freeMain * (factor / growTotal);
+
+                if (factor > 0 && Math.Abs(grown - outerHeight) > 0.5)
+                    targetHeight = Math.Max(0, grown);
+            }
+
+            if (ShouldStretchFlexColumnItemAcrossLine(child, line.CrossSize))
+                targetWidth = line.CrossSize;
+
+            if (targetHeight is not null || targetWidth is not null)
+                LayoutFlexItemAtTargetSize(g, child, targetWidth, targetHeight);
+
+            mainSize += GetFlexItemOuterHeight(child) + (i > 0 ? rowGap : 0);
+        }
+
+        line.MainSize = mainSize;
+    }
+
+    /// <summary>
+    /// CSS Flexbox §9.4 step 11 on the axis a column container crosses: whether an item's
+    /// <c>auto</c> cross size should be stretched to its line.
+    /// </summary>
+    private bool ShouldStretchFlexColumnItemAcrossLine(CssBox child, double lineCrossSize)
+    {
+        if (ResolveFlexItemAlignment(child) != "stretch")
+            return false;
+        if (!string.IsNullOrEmpty(child.Width) && child.Width != CssConstants.Auto)
+            return false;
+        if (child.IsSpecifiedMarginLeftAuto || child.IsSpecifiedMarginRightAuto)
+            return false;
+
+        double outerWidth = child.Size.Width + child.ActualMarginLeft + child.ActualMarginRight;
+        return lineCrossSize - outerWidth > 0.5;
+    }
+
+    /// <summary>
+    /// CSS Flexbox §9.5: places one column flex line's items along the main axis per
+    /// <c>justify-content</c>, and across the line per <c>align-items</c>/<c>align-self</c>.
+    /// </summary>
+    /// <remarks>
+    /// For <c>column-reverse</c> the main-start is the line's block-end edge, so the items run
+    /// bottom-to-top from there: the first item in order-modified document order sits lowest.
+    /// </remarks>
+    private void PlaceFlexColumnLineItems(
+        FlexColumnLine line, double lineMain, double rowGap, double lineLeft, bool reverse)
+    {
+        double freeMain = Math.Max(0, lineMain - line.MainSize);
+        ResolveJustifyContent(line.Items.Count, freeMain, rowGap, out double mainOffset, out double itemGap);
+
+        double cursorY = reverse
+            ? ClientTop + lineMain - mainOffset
+            : ClientTop + mainOffset;
+
+        foreach (var child in line.Items)
+        {
+            double outerHeight = GetFlexItemOuterHeight(child);
+            double outerWidth = child.Size.Width + child.ActualMarginLeft + child.ActualMarginRight;
+            double crossOffset = ResolveFlexColumnCrossOffset(child, line.CrossSize, outerWidth);
+
+            double top = reverse ? cursorY - outerHeight : cursorY;
+            double targetTop = top + child.ActualMarginTop;
+            double targetLeft = lineLeft + crossOffset + child.ActualMarginLeft;
+
+            double dy = targetTop - child.Location.Y;
+            double dx = targetLeft - child.Location.X;
+
+            if (Math.Abs(dy) > 0.1)
+                child.OffsetTop(dy);
+
+            if (Math.Abs(dx) > 0.1)
+                child.OffsetLeft(dx);
+
+            cursorY += reverse ? -(outerHeight + itemGap) : outerHeight + itemGap;
+        }
+    }
+
+    /// <summary>
+    /// Where an item sits across its column flex line, per the cross-axis alignment that
+    /// <c>align-self</c>/<c>align-items</c> resolve to. A stretched item has already been sized to
+    /// the line and lands at 0.
+    /// </summary>
+    private double ResolveFlexColumnCrossOffset(CssBox child, double lineCrossSize, double itemOuterWidth)
+    {
+        double freeSpace = lineCrossSize - itemOuterWidth;
+
+        if (freeSpace <= 0)
+            return 0;
+
+        return ResolveFlexItemAlignment(child) switch
+        {
+            "center" => freeSpace / 2,
+            "end" or "flex-end" or "self-end" or "right" => freeSpace,
+            _ => 0
+        };
+    }
+
+    /// <summary>
+    /// Lays a flex item out again at a target outer width, a target outer height, or both — one
+    /// layout, so neither axis re-derives from the declaration the other one is overriding.
+    /// </summary>
+    private static void LayoutFlexItemAtTargetSize(
+        ILayoutEnvironment g, CssBox child, double? targetOuterWidth, double? targetOuterHeight)
+    {
+        string savedWidth = child.Width;
+        string savedHeight = child.Height;
+
+        if (targetOuterWidth is { } outerWidth)
+        {
+            double borderBoxWidth = Math.Max(0, outerWidth - child.ActualMarginLeft - child.ActualMarginRight);
+            double cssWidth = child.UsesBorderBoxSizing
+                ? borderBoxWidth
+                : borderBoxWidth
+                  - child.ActualPaddingLeft - child.ActualPaddingRight
+                  - child.ActualBorderLeftWidth - child.ActualBorderRightWidth;
+
+            child.Width = FormatCssPx(Math.Max(0, cssWidth));
+        }
+
+        if (targetOuterHeight is { } outerHeight)
+        {
+            double borderBoxHeight = Math.Max(0, outerHeight - child.ActualMarginTop - child.ActualMarginBottom);
+            double cssHeight = child.UsesBorderBoxSizing
+                ? borderBoxHeight
+                : borderBoxHeight
+                  - child.ActualPaddingTop - child.ActualPaddingBottom
+                  - child.ActualBorderTopWidth - child.ActualBorderBottomWidth;
+
+            child.Height = FormatCssPx(Math.Max(0, cssHeight));
+        }
+
+        child.PerformLayout(g);
+
+        child.Width = savedWidth;
+        child.Height = savedHeight;
+    }
+
     /// <summary>
     /// The column flex container's definite main-axis content height — its specified
     /// <c>height</c> clamped by <c>min-height</c>/<c>max-height</c> — or <c>null</c> when
@@ -701,13 +1072,27 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         }
     }
 
-    private void ResolveJustifyContent(int itemCount, double freeSpace, double baseGap, out double lineOffset, out double itemGap)
+    private void ResolveJustifyContent(int itemCount, double freeSpace, double baseGap, out double lineOffset, out double itemGap) =>
+        ResolveContentDistribution(NormalizeBoxAlignment(JustifyContent), itemCount, freeSpace, baseGap,
+            out lineOffset, out itemGap);
+
+    /// <summary>
+    /// CSS Box Alignment 3 §5: turns a content-distribution keyword and the free space on one
+    /// axis into the offset before the first subject and the gap between subjects.
+    /// </summary>
+    /// <remarks>
+    /// Shared by <c>justify-content</c> along a flex line's main axis and by
+    /// <c>align-content</c> across a multi-line container's lines, which distribute the same way.
+    /// <c>stretch</c> is not handled here — it resizes the subjects rather than spacing them, so
+    /// each caller applies it to whatever it is distributing.
+    /// </remarks>
+    private static void ResolveContentDistribution(
+        string keyword, int itemCount, double freeSpace, double baseGap, out double lineOffset, out double itemGap)
     {
         lineOffset = 0;
         itemGap = baseGap;
 
-        string justify = NormalizeBoxAlignment(JustifyContent);
-        switch (justify)
+        switch (keyword)
         {
             case "center":
                 lineOffset = freeSpace / 2;

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Layout.cs
@@ -1456,8 +1456,17 @@ internal partial class CssBox : CssBoxProperties, IDisposable
                 // CSS Box Alignment §6.2: distribute flex/grid items along
                 // the block (cross) axis per align-items / align-self.
                 ApplyFlexGridCrossAxisAlignment();
-                ApplyFlexColumnInlineAxisAlignment(g);
-                ApplyFlexColumnMainAxisSizing(g);
+
+                // CSS Flexbox §9.3/§9.5: a wrapping or reversed column flex container needs its
+                // items broken into lines and packed from the main-start, neither of which a
+                // post-pass over the single block-flow stack below can express. It takes the
+                // placement over when it applies; the one case it declines — a single line in
+                // ordinary `column` order — is what those two passes already handle.
+                if (!PerformFlexColumnLineLayout(g))
+                {
+                    ApplyFlexColumnInlineAxisAlignment(g);
+                    ApplyFlexColumnMainAxisSizing(g);
+                }
             }
             else if (Boxes.Count > 0)
             {

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Margins.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Margins.cs
@@ -192,17 +192,27 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         // every in-flow sibling down with it. A page whose first child is a fixed backdrop or an
         // abspos panel therefore laid its real content out at the wrong offset.
         else if (_parentBox != null && Position is not (CssConstants.Absolute or CssConstants.Fixed)
+            // CSS2.1 §8.3.1 again, for the other kind of out-of-flow box: "margins of floating
+            // boxes do not collapse". A float's margin was propagating into its parent's position
+            // exactly as an abspos child's used to, so a block whose first child is a floated
+            // element was drawn at the float's margin rather than its own — which is what left
+            // css-flexbox/flexbox_item-bottom-float's *reference* an em below its test.
+            && Float == CssConstants.None
             && _parentBox.ActualPaddingTop < 0.1 && _parentBox.ActualPaddingBottom < 0.1 && _parentBox.ActualBorderTopWidth < 0.1 && _parentBox.ActualBorderBottomWidth < 0.1
-            // CSS Box Alignment §5.4: align-content != normal establishes
-            // a BFC, which prevents parent–child margin collapsing.
-            && (_parentBox.AlignContent == null || _parentBox.AlignContent == "normal")
-            // CSS2.1 §8.3.1: margins do not collapse across a block-formatting-context
-            // boundary; overflow != visible establishes a BFC (§9.4.1), so the parent
-            // contains its first in-flow child's top margin instead of collapsing with it
-            // (a bare overflow:auto/hidden/scroll container — e.g. css-anchor-position
-            // anchor-center-scroll-001's scroller — otherwise gets shifted down by the
-            // child's margin via the propagation below).
-            && (_parentBox.Overflow == null || _parentBox.Overflow == CssConstants.Visible))
+            // CSS2.1 §8.3.1: "margins of elements that establish new block formatting contexts
+            // do not collapse with their in-flow children" — so a parent that establishes one
+            // contains its first child's top margin instead of taking it as its own. The two
+            // triggers spelled out here before, `overflow` other than `visible` (§9.4.1, e.g.
+            // css-anchor-position anchor-center-scroll-001's scroller) and CSS Box Alignment
+            // §5.4's `align-content`, are two of the set `EstablishesBfc` already answers for;
+            // the ones it adds are what the rest of this run needed. A **float** parent: the
+            // reference of css-flexbox/flex-lines/multi-line-wrap-with-column-reverse is three
+            // floated columns of `margin-top: 10px` paragraphs, and each float was drawn at its
+            // first paragraph's margin — then the next float below that, so the three columns
+            // stepped 10px further down each. And a **flex or grid container**, which CSS
+            // Flexbox §3 / CSS Grid §6 make an independent formatting context: that test itself
+            // drew its whole flex container 10px below where it belongs.
+            && !CssBoxHelper.EstablishesBfc(_parentBox))
         {
             double parentEffective = Math.Max(_parentBox.ActualMarginTop, _parentBox.CollapsedMarginTop);
 
@@ -249,16 +259,11 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         {
             value = ActualMarginTop;
 
-            // When the parent establishes a BFC (e.g. via align-content),
-            // the first child's margin is fully consumed for positioning.
-            // Record it so that an empty-collapsible sibling can subtract
+            // When the parent establishes a BFC, the first child's margin is fully consumed for
+            // positioning. Record it so that an empty-collapsible sibling can subtract
             // the already-consumed portion during its own collapse.
-            if (_parentBox != null
-                && _parentBox.AlignContent != null
-                && _parentBox.AlignContent != "normal")
-            {
+            if (_parentBox != null && CssBoxHelper.EstablishesBfc(_parentBox))
                 CollapsedMarginTop = value;
-            }
         }
 
         // fix for hr tag

--- a/src/Broiler.Cli.Tests/FlexColumnWrapAndReverseTests.cs
+++ b/src/Broiler.Cli.Tests/FlexColumnWrapAndReverseTests.cs
@@ -1,0 +1,230 @@
+using Broiler.HtmlBridge;
+using Broiler.HtmlBridge.Dom;
+using Broiler.JavaScript.Engine;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// The two things a <c>column</c> flex container could not express while its items stacked
+/// through ordinary block flow, found triaging the 2026-08-21 WPT severity run.
+///
+/// <para>
+/// <b>Wrapping (CSS Flexbox §9.3).</b> <c>flex-wrap</c> in a column needs the stack broken into
+/// several, which no post-pass over one stack can do, so every item rendered in one full-width
+/// column that overflowed the container.
+/// </para>
+/// <para>
+/// <b>Reversal (§9.5).</b> <c>column-reverse</c> reverses the main axis: items run bottom-to-top
+/// and pack from the block-end edge. The keyword was parsed and routed everywhere it selects the
+/// column path, then laid out exactly like <c>column</c>.
+/// </para>
+/// <para>
+/// Together they cover css/css-flexbox/flex-lines/multi-line-wrap-with-column-reverse, which
+/// drew its six items as six stacked bands instead of three columns (37.4% against its own
+/// reference). Its companion — a flex item's margins never collapsing out of the container —
+/// is in <see cref="FlexItemMarginCollapseTests"/>.
+/// </para>
+/// </summary>
+public sealed class FlexColumnWrapAndReverseTests
+{
+    [Fact(Timeout = 600000)]
+    public void A_Column_Reverse_Container_Packs_Its_Items_From_The_Bottom()
+    {
+        // §9.5: main-start is the block-end edge, so the first item in document order sits
+        // lowest and the last sits highest.
+        AssertCheckLayout(
+            "<div style=\"display:flex;flex-direction:column-reverse;height:100px;width:200px\">" +
+            "  <div style=\"height:30px\" data-offset-y=\"70\" data-expected-height=\"30\"></div>" +
+            "  <div style=\"height:20px\" data-offset-y=\"50\" data-expected-height=\"20\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Column_Reverse_Containers_Items_Still_Stretch_Across_The_Cross_Axis()
+    {
+        AssertCheckLayout(
+            "<div style=\"display:flex;flex-direction:column-reverse;height:100px;width:200px\">" +
+            "  <div style=\"height:30px\" data-offset-x=\"0\" data-expected-width=\"200\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Wrapping_Column_Container_Breaks_A_Line_At_Its_Main_Size()
+    {
+        // Three 40px items in a 100px-tall container: two fit on the first line, the third
+        // starts a second. `align-content: stretch` then splits the 200px cross size between
+        // the two lines, so each is 100px wide.
+        AssertCheckLayout(
+            "<div style=\"display:flex;flex-direction:column;flex-wrap:wrap;height:100px;width:200px\">" +
+            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"0\" data-expected-width=\"100\"></div>" +
+            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"40\" data-expected-width=\"100\"></div>" +
+            "  <div style=\"height:40px\" data-offset-x=\"100\" data-offset-y=\"0\" data-expected-width=\"100\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Wrapping_Column_Container_Is_As_Tall_As_Its_Tallest_Line()
+    {
+        // Not as tall as everything it holds added up, which is what the one-item-per-line
+        // block flow underneath reports.
+        AssertCheckLayout(
+            "<div class=\"probe\" style=\"display:flex;flex-direction:column;flex-wrap:wrap;height:100px;width:200px\"" +
+            "     data-expected-height=\"100\">" +
+            "  <div style=\"height:60px\"></div>" +
+            "  <div style=\"height:60px\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Row_Gap_Counts_Against_A_Column_Lines_Main_Size()
+    {
+        // 40 + 20 + 40 = 100 exactly fills the line, so the third item wraps.
+        AssertCheckLayout(
+            "<div style=\"display:flex;flex-direction:column;flex-wrap:wrap;row-gap:20px;height:100px;width:200px\">" +
+            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"0\"></div>" +
+            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"60\"></div>" +
+            "  <div style=\"height:40px\" data-offset-x=\"100\" data-offset-y=\"0\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Column_Gap_Separates_A_Wrapping_Columns_Lines()
+    {
+        // The cross-axis gap is taken out of the space `align-content: stretch` distributes:
+        // 200 - 20 = 180 across two lines.
+        AssertCheckLayout(
+            "<div style=\"display:flex;flex-direction:column;flex-wrap:wrap;column-gap:20px;height:100px;width:200px\">" +
+            "  <div style=\"height:60px\" data-offset-x=\"0\" data-expected-width=\"90\"></div>" +
+            "  <div style=\"height:60px\" data-offset-x=\"110\" data-expected-width=\"90\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Wrap_Reverse_Places_The_First_Line_At_The_Cross_End()
+    {
+        AssertCheckLayout(
+            "<div style=\"display:flex;flex-direction:column;flex-wrap:wrap-reverse;height:100px;width:200px\">" +
+            "  <div style=\"height:60px\" data-offset-x=\"100\"></div>" +
+            "  <div style=\"height:60px\" data-offset-x=\"0\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Both_Together_Order_A_Wrapped_Column_Reverse_Container()
+    {
+        // multi-line-wrap-with-column-reverse in miniature: the items fill the first column
+        // bottom-to-top, then start a second column at its bottom again.
+        AssertCheckLayout(
+            "<div style=\"display:flex;flex-direction:column-reverse;flex-wrap:wrap;height:100px;width:200px\">" +
+            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"60\"></div>" +
+            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"20\"></div>" +
+            "  <div style=\"height:40px\" data-offset-x=\"100\" data-offset-y=\"60\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Align_Content_Center_Groups_The_Lines_In_The_Middle_Of_The_Cross_Axis()
+    {
+        // Two 50px-wide lines in a 200px container: 100px of free cross space, half before.
+        AssertCheckLayout(
+            "<div style=\"display:flex;flex-direction:column;flex-wrap:wrap;align-content:center;" +
+            "            align-items:flex-start;height:100px;width:200px\">" +
+            "  <div style=\"height:60px;width:50px\" data-offset-x=\"50\"></div>" +
+            "  <div style=\"height:60px;width:50px\" data-offset-x=\"100\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Justify_Content_Center_Still_Centres_A_Column_Reverse_Line()
+    {
+        // Free main space is distributed the same way whichever end the line packs from: 60px
+        // spare, 30px of it before the first item — which for `column-reverse` is below it.
+        AssertCheckLayout(
+            "<div style=\"display:flex;flex-direction:column-reverse;justify-content:center;" +
+            "            height:100px;width:200px\">" +
+            "  <div style=\"height:20px\" data-offset-y=\"50\"></div>" +
+            "  <div style=\"height:20px\" data-offset-y=\"30\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void Flex_Grow_Still_Fills_A_Reversed_Containers_Main_Axis()
+    {
+        // §9.7 runs per line, so reversing the axis must not cost an item its growth.
+        AssertCheckLayout(
+            "<div style=\"display:flex;flex-direction:column-reverse;height:100px;width:200px\">" +
+            "  <div style=\"height:20px\" data-offset-y=\"80\" data-expected-height=\"20\"></div>" +
+            "  <div style=\"flex-grow:1\" data-offset-y=\"0\" data-expected-height=\"80\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void An_Auto_Height_Column_Container_Keeps_Everything_On_One_Line()
+    {
+        // §9.3 breaks lines against a *definite* main size. With `height: auto` there is none,
+        // so `flex-wrap: wrap` has nothing to wrap against and the stack stays whole.
+        AssertCheckLayout(
+            "<div style=\"display:flex;flex-direction:column;flex-wrap:wrap;width:200px\">" +
+            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"0\"></div>" +
+            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"40\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Nowrap_Column_Container_Overflows_Rather_Than_Wrapping()
+    {
+        AssertCheckLayout(
+            "<div style=\"display:flex;flex-direction:column;height:50px;width:200px\">" +
+            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"0\"></div>" +
+            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"40\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Row_Container_Is_Left_To_The_Row_Algorithm()
+    {
+        // Guards the direction check: a wrapping *row* container has its own implementation
+        // and must not be routed through the column one.
+        AssertCheckLayout(
+            "<div style=\"display:flex;flex-wrap:wrap;width:100px\">" +
+            "  <div style=\"width:60px;height:10px\" data-offset-x=\"0\" data-offset-y=\"0\"></div>" +
+            "  <div style=\"width:60px;height:10px\" data-offset-x=\"0\" data-offset-y=\"10\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void An_Out_Of_Flow_Child_Is_Not_A_Flex_Item_On_Any_Line()
+    {
+        // §4.1: an abspos child takes no part in flex layout, so it neither occupies main size
+        // on a line nor is repositioned by the packing.
+        AssertCheckLayout(
+            "<div style=\"display:flex;flex-direction:column;flex-wrap:wrap;position:relative;" +
+            "            height:100px;width:200px\">" +
+            "  <div style=\"position:absolute;left:5px;top:7px;width:10px;height:90px\"" +
+            "       data-offset-x=\"5\" data-offset-y=\"7\"></div>" +
+            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"0\"></div>" +
+            "  <div style=\"height:40px\" data-offset-x=\"0\" data-offset-y=\"40\"></div>" +
+            "</div>");
+    }
+
+    internal static void AssertCheckLayout(string body)
+    {
+        const string head =
+            "<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0}</style></head>" +
+            "<body>";
+
+        using var context = new JSContext();
+        var bridge = new DomBridge();
+        bridge.Attach(context, head + body + "</body></html>", "file:///flex.html");
+
+        var assertions = bridge.EvaluateCheckLayoutAssertions();
+        var failures = assertions
+            .Where(a => double.IsNaN(a.Actual) || Math.Abs(a.Expected - a.Actual) > 0.5)
+            .Select(a => $"{a.Element} {a.Property}: expected {a.Expected}, got {a.Actual:0.##}")
+            .ToList();
+
+        Assert.True(assertions.Count > 0, "no check-layout assertions were evaluated");
+        Assert.True(failures.Count == 0,
+            $"{failures.Count}/{assertions.Count} assertions failed:\n" + string.Join("\n", failures));
+    }
+}

--- a/src/Broiler.Cli.Tests/FlexItemMarginCollapseTests.cs
+++ b/src/Broiler.Cli.Tests/FlexItemMarginCollapseTests.cs
@@ -1,0 +1,102 @@
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// CSS2.1 §8.3.1 for two kinds of box whose margins never collapse with their parent's: a flex
+/// or grid item, whose container establishes an independent formatting context (CSS Flexbox §3,
+/// CSS Grid §6), and a float.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A first in-flow child whose top margin exceeds its parent's propagates the excess by moving
+/// the <em>parent</em> down — which is right for an ordinary block and wrong for both of these.
+/// The flex half moved whole containers: WPT
+/// css-flexbox/flex-lines/multi-line-wrap-with-column-reverse gives every item
+/// <c>margin-top: 10px</c>, and the container was drawn 10px below where it belongs, uniformly
+/// enough to survive a whole rewrite of its column layout.
+/// </para>
+/// <para>
+/// The float half showed up on the other side of the same comparison: that test's reference is a
+/// plain block holding floated paragraphs with <c>margin: 2em</c>, and the block was drawn at the
+/// float's margin rather than at its own.
+/// </para>
+/// </remarks>
+public sealed class FlexItemMarginCollapseTests
+{
+    [Fact(Timeout = 600000)]
+    public void A_Flex_Items_Top_Margin_Does_Not_Move_Its_Container()
+    {
+        FlexColumnWrapAndReverseTests.AssertCheckLayout(
+            "<div style=\"height:0\"></div>" +
+            "<div class=\"probe\" style=\"display:flex;flex-direction:column;width:200px\" data-offset-y=\"0\">" +
+            "  <div style=\"margin-top:10px;height:30px\" data-offset-y=\"10\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Row_Flex_Items_Top_Margin_Does_Not_Move_Its_Container_Either()
+    {
+        FlexColumnWrapAndReverseTests.AssertCheckLayout(
+            "<div style=\"height:0\"></div>" +
+            "<div class=\"probe\" style=\"display:flex;width:200px\" data-offset-y=\"0\">" +
+            "  <div style=\"margin-top:10px;width:30px;height:30px\" data-offset-y=\"10\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Grid_Items_Top_Margin_Does_Not_Move_Its_Container()
+    {
+        FlexColumnWrapAndReverseTests.AssertCheckLayout(
+            "<div style=\"height:0\"></div>" +
+            "<div class=\"probe\" style=\"display:grid;width:200px\" data-offset-y=\"0\">" +
+            "  <div style=\"margin-top:10px;height:30px\" data-offset-y=\"10\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Floated_First_Childs_Margin_Does_Not_Move_Its_Parent()
+    {
+        FlexColumnWrapAndReverseTests.AssertCheckLayout(
+            "<div style=\"height:0\"></div>" +
+            "<div class=\"probe\" style=\"width:200px\" data-offset-y=\"0\">" +
+            "  <div style=\"float:left;margin-top:20px;width:30px;height:30px\" data-offset-y=\"20\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void A_Float_Parent_Contains_Its_First_Childs_Top_Margin()
+    {
+        // The reference side of multi-line-wrap-with-column-reverse: three floated columns of
+        // `margin-top: 10px` paragraphs. Each float was drawn at its first paragraph's margin,
+        // and the next float placed below *that*, so the columns stepped 10px further down each.
+        FlexColumnWrapAndReverseTests.AssertCheckLayout(
+            "<div style=\"height:0\"></div>" +
+            "<div style=\"float:left;width:100px\" data-offset-y=\"0\">" +
+            "  <div style=\"margin-top:10px;height:30px\" data-offset-y=\"10\"></div>" +
+            "</div>" +
+            "<div style=\"float:left;width:100px\" data-offset-y=\"0\">" +
+            "  <div style=\"margin-top:10px;height:30px\" data-offset-y=\"10\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void An_Inline_Block_Parent_Contains_Its_First_Childs_Top_Margin()
+    {
+        FlexColumnWrapAndReverseTests.AssertCheckLayout(
+            "<div style=\"height:0\"></div>" +
+            "<div style=\"display:inline-block;width:100px\" data-offset-y=\"0\">" +
+            "  <div style=\"margin-top:10px;height:30px\" data-offset-y=\"10\"></div>" +
+            "</div>");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void An_Ordinary_Blocks_First_Child_Still_Collapses_Through()
+    {
+        // The rule this narrows, still in force where CSS2.1 asks for it: a plain block with no
+        // top border or padding takes its first in-flow child's top margin as its own.
+        FlexColumnWrapAndReverseTests.AssertCheckLayout(
+            "<div style=\"height:0\"></div>" +
+            "<div class=\"probe\" style=\"width:200px\" data-offset-y=\"10\">" +
+            "  <div style=\"margin-top:10px;height:30px\" data-offset-y=\"10\"></div>" +
+            "</div>");
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for `flex-wrap` and `column-reverse` in column flex containers, which previously could not express either feature through the existing single-line block-flow layout pass. These are now handled by a dedicated multi-line flex layout algorithm that breaks items into lines, distributes them across the cross axis, and packs them from the correct main-start edge.

## Key Changes

- **New `PerformFlexColumnLineLayout` method**: Implements CSS Flexbox §9.3/§9.5/§9.6 for column containers. Returns `false` for the common case (single line, no reverse) to leave existing layout unchanged; handles wrapping and reversal when needed.

- **Line collection and sizing**: 
  - `CollectFlexColumnLines` breaks items into lines against a definite main size (§9.3)
  - `ResolveFlexColumnLineCrossSizes` sizes each line across the cross axis and distributes free space per `align-content`
  - `ResolveFlexColumnLineItemSizes` applies `flex-grow` and cross-axis stretch within each line

- **Item placement**: `PlaceFlexColumnLineItems` positions items along the main axis per `justify-content` and across the line per `align-items`/`align-self`, with special handling for `column-reverse` (items pack from block-end, bottom-to-top).

- **Shared alignment logic**: Extracted `ResolveContentDistribution` from `ResolveJustifyContent` to handle both main-axis and cross-axis distribution identically.

- **Margin collapse fix**: Updated `MarginTopCollapse` to prevent flex and grid item margins from collapsing with their container (CSS2.1 §8.3.1), and fixed the same issue for floats. This prevents containers from being shifted down by their first child's margin.

- **Layout integration**: Modified `LayoutBlockChildren` to call the new flex column line layout before the existing single-line passes, allowing it to take ownership of placement when wrapping or reversal is needed.

## Implementation Details

- The algorithm only activates when `flex-wrap: wrap/wrap-reverse` or `flex-direction: column-reverse` is set; single-line `column` containers use the existing fast path unchanged.
- Line breaking requires a definite main size (definite `height`); `auto` height keeps everything on one line.
- Vertical writing modes are declined (they would need axis transposition the single-line passes don't support).
- `wrap-reverse` reverses the line order after layout, placing the first line at the cross-end.
- The container's reported height is now the tallest line's content, not the sum of all lines (fixing WPT css-flexbox/flex-lines/multi-line-wrap-with-column-reverse).

## Tests

Added comprehensive test suite (`FlexColumnWrapAndReverseTests`) covering:
- Basic wrapping and reversal
- Gap handling (row-gap counts toward main size, column-gap separates lines)
- `align-content` and `justify-content` distribution
- `flex-grow` in reversed containers
- Edge cases (auto height, nowrap, out-of-flow children)

Added `FlexItemMarginCollapseTests` to verify margin collapse rules for flex items, grid items, and floats.

https://claude.ai/code/session_01FXP57mxCHGy48PVZV535vj