### PR TITLE
Fix SVG gradients, transform-origin, opacity, and scripted onload

### DIFF
--- a/Broiler.Layout/Broiler.Layout.Tests/SvgElementOpacityTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/SvgElementOpacityTests.cs
@@ -1,0 +1,159 @@
+using System.Drawing;
+using System.Linq;
+using Broiler.Layout.IR;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// SVG 1.1 §14.5 <c>opacity</c>. It is not <c>fill-opacity</c>: that one is folded into the paint
+/// colour by <c>GetPaint</c>, which is exact because it applies to the fill operation itself, while
+/// <c>opacity</c> composites the element as a whole — fill and stroke together — and so needs a
+/// layer. Nothing emitted one, so the property was dropped outright and
+/// <c>&lt;rect fill="blue" opacity="0.5"&gt;</c> painted solid blue.
+///
+/// <para>
+/// It reaches a group the long way round. <c>opacity</c> does not inherit, so it is deliberately
+/// absent from <c>SvgStructure.InheritableProperties</c> — but this renderer matches one regex per
+/// shape type and draws leaves, so a <c>&lt;g opacity&gt;</c> has no group of its own to hang a
+/// layer on. <c>SvgStructure</c> therefore carries the ancestors' composed opacity down to each
+/// shape, which multiplies it into its own. That is exact while a group's children do not overlap
+/// one another; where they do, true group compositing would flatten first and fade once.
+/// </para>
+///
+/// <para>
+/// Found while triaging the <c>conformance-checkers/html-svg</c> cluster of the 2026-08-21 WPT run
+/// (issue #1770): <c>filters-blend-01-b-isvalid</c> draws seven <c>opacity="0.5"</c> bars and
+/// Broiler painted every one of them opaque.
+/// </para>
+/// </summary>
+public class SvgElementOpacityTests
+{
+    private static readonly RectangleF Viewport = new(0, 0, 200, 200);
+
+    private static System.Collections.Generic.List<DisplayItem> Render(string body) =>
+        SvgRenderer.RenderSvgContent(
+            $"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"200\" height=\"200\">{body}</svg>",
+            Viewport,
+            1f);
+
+    /// <summary>
+    /// The opacity of the layer wrapping the first shape, or <c>null</c> when no layer was pushed.
+    /// </summary>
+    private static float? LayerOpacity(string body)
+    {
+        var items = Render(body);
+        var opacity = items.OfType<OpacityItem>().FirstOrDefault();
+        return opacity?.Opacity;
+    }
+
+    private static void AssertLayer(string body, float expected)
+    {
+        var actual = LayerOpacity(body);
+        Assert.True(actual is not null, $"expected an opacity layer for: {body}");
+        Assert.Equal(expected, actual!.Value, 3);
+    }
+
+    [Fact]
+    public void PlainShape_PushesNoLayer()
+    {
+        Assert.Null(LayerOpacity("<rect width='50' height='50' fill='blue'/>"));
+    }
+
+    [Fact]
+    public void OpacityOne_PushesNoLayer()
+    {
+        Assert.Null(LayerOpacity("<rect width='50' height='50' fill='blue' opacity='1'/>"));
+    }
+
+    /// <summary>
+    /// <c>fill-opacity</c> keeps its old route — folded into the paint, no layer — so the two
+    /// properties stay distinct rather than one starting to double for the other.
+    /// </summary>
+    [Fact]
+    public void FillOpacity_StillFoldsIntoThePaintAndPushesNoLayer()
+    {
+        Assert.Null(LayerOpacity("<rect width='50' height='50' fill='blue' fill-opacity='0.5'/>"));
+    }
+
+    [Fact]
+    public void OpacityAttribute_PushesTheLayer()
+    {
+        AssertLayer("<rect width='50' height='50' fill='blue' opacity='0.5'/>", 0.5f);
+    }
+
+    /// <summary>SVG 1.1 §6.4 gives a <c>style</c> declaration precedence over the attribute.</summary>
+    [Fact]
+    public void OpacityInStyleAttribute_PushesTheLayer()
+    {
+        AssertLayer("<rect width='50' height='50' fill='blue' style='opacity:0.25'/>", 0.25f);
+    }
+
+    [Fact]
+    public void PercentageOpacity_Resolves()
+    {
+        AssertLayer("<rect width='50' height='50' fill='blue' opacity='50%'/>", 0.5f);
+    }
+
+    /// <summary>SVG 1.1 §4.4 clamps rather than rejecting an out-of-range alpha.</summary>
+    [Theory]
+    [InlineData("-1", 0f)]
+    [InlineData("0", 0f)]
+    [InlineData("2", 1f)]
+    public void OutOfRangeOpacity_Clamps(string declared, float expected)
+    {
+        string body = $"<rect width='50' height='50' fill='blue' opacity='{declared}'/>";
+        if (expected >= 1f)
+            Assert.Null(LayerOpacity(body));
+        else
+            AssertLayer(body, expected);
+    }
+
+    [Fact]
+    public void GroupOpacity_ReachesTheShapeInside()
+    {
+        AssertLayer("<g opacity='0.5'><rect width='50' height='50' fill='blue'/></g>", 0.5f);
+    }
+
+    [Fact]
+    public void GroupOpacity_MultipliesWithTheShapesOwn()
+    {
+        AssertLayer(
+            "<g opacity='0.5'><rect width='50' height='50' fill='blue' opacity='0.5'/></g>", 0.25f);
+    }
+
+    [Fact]
+    public void NestedGroupOpacity_Multiplies()
+    {
+        AssertLayer(
+            "<g opacity='0.5'><g opacity='0.5'><rect width='50' height='50' fill='blue'/></g></g>",
+            0.25f);
+    }
+
+    /// <summary>
+    /// The group's opacity must not leak sideways: a shape outside the faded group keeps its own.
+    /// </summary>
+    [Fact]
+    public void GroupOpacity_DoesNotEscapeTheGroup()
+    {
+        var items = Render(
+            "<g opacity='0.5'><rect width='10' height='10' fill='blue'/></g>"
+            + "<rect x='20' width='10' height='10' fill='green'/>");
+
+        Assert.Single(items.OfType<OpacityItem>());
+    }
+
+    /// <summary>Every layer pushed is popped, so the display list stays balanced.</summary>
+    [Fact]
+    public void EveryOpacityLayer_IsRestored()
+    {
+        var items = Render(
+            "<g opacity='0.5'>"
+            + "<rect width='10' height='10' fill='blue' opacity='0.5'/>"
+            + "<circle cx='30' cy='30' r='5' fill='red'/>"
+            + "</g>");
+
+        Assert.Equal(items.OfType<OpacityItem>().Count(), items.OfType<RestoreOpacityItem>().Count());
+        Assert.Equal(2, items.OfType<OpacityItem>().Count());
+    }
+}

--- a/Broiler.Layout/Broiler.Layout.Tests/SvgGradientFillTests.cs
+++ b/Broiler.Layout/Broiler.Layout.Tests/SvgGradientFillTests.cs
@@ -1,0 +1,213 @@
+using System.Drawing;
+using System.Linq;
+using Broiler.Layout.IR;
+using Xunit;
+
+namespace Broiler.Layout.Tests;
+
+/// <summary>
+/// SVG gradient paint servers: <c>&lt;linearGradient&gt;</c> and <c>&lt;radialGradient&gt;</c>
+/// reached through <c>fill="url(#id)"</c>.
+///
+/// <para>
+/// A gradient fill painted <b>nothing at all</b>. <c>ResolveFill</c> recognised the reference,
+/// looked for a <c>&lt;pattern&gt;</c> under that id, found none, and fell through to the fallback
+/// paint — which for the ordinary <c>fill="url(#grad)"</c> with no colour written after it is "no
+/// paint". Every gradient-filled shape was invisible.
+/// </para>
+///
+/// <para>
+/// Found triaging WPT issue #1770 by clustering the run's failures rather than by working down the
+/// list: the 82 <c>css-transforms/transform-origin/svg-origin-*</c> tests all scored an identical
+/// 97.21%, and they fill with a gradient precisely to avoid a false positive — so the shape was
+/// blank on <em>both</em> sides of their own comparison.
+/// </para>
+///
+/// <para>
+/// The gradient is emitted as a <see cref="DrawTiledGradientItem"/>, the display item CSS
+/// backgrounds already use, so the raster backend needs no new primitive.
+/// </para>
+/// </summary>
+public class SvgGradientFillTests
+{
+    private static readonly RectangleF Viewport = new(0, 0, 200, 200);
+
+    private static System.Collections.Generic.List<DisplayItem> Render(string body) =>
+        SvgRenderer.RenderSvgContent(
+            $"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"200\" height=\"200\">{body}</svg>",
+            Viewport,
+            1f);
+
+    private static DrawTiledGradientItem Gradient(string body) =>
+        Render(body).OfType<DrawTiledGradientItem>().FirstOrDefault();
+
+    private const string LinearRedBlue =
+        "<linearGradient id='g'><stop offset='0%' stop-color='red'/>"
+        + "<stop offset='100%' stop-color='blue'/></linearGradient>";
+
+    [Fact]
+    public void GradientFill_EmitsAGradient()
+    {
+        var g = Gradient($"<defs>{LinearRedBlue}</defs><rect width='100' height='50' fill='url(#g)'/>");
+
+        Assert.NotNull(g);
+        Assert.Equal(2, g.Stops.Count);
+        Assert.Equal(255, g.Stops[0].Color.R);
+        Assert.Equal(255, g.Stops[1].Color.B);
+    }
+
+    /// <summary>
+    /// SVG 1.1 §13.2.2 defaults x1,y1 = 0%,0% and x2,y2 = 100%,0% — left to right. In the CSS
+    /// gradient angle this renderer emits, whose zero points to the top and which turns clockwise,
+    /// that is 90°.
+    /// </summary>
+    [Fact]
+    public void DefaultLinearGradient_RunsLeftToRight()
+    {
+        var g = Gradient($"<defs>{LinearRedBlue}</defs><rect width='100' height='50' fill='url(#g)'/>");
+        Assert.Equal(90f, g.Angle, 1);
+    }
+
+    /// <summary>A vertical gradient vector is 180° — top to bottom.</summary>
+    [Fact]
+    public void VerticalLinearGradient_RunsTopToBottom()
+    {
+        var g = Gradient(
+            "<defs><linearGradient id='g' x2='0%' y2='100%'>"
+            + "<stop offset='0%' stop-color='red'/><stop offset='100%' stop-color='blue'/>"
+            + "</linearGradient></defs><rect width='100' height='50' fill='url(#g)'/>");
+
+        Assert.Equal(180f, g.Angle, 1);
+    }
+
+    [Fact]
+    public void RadialGradient_IsMarkedRadial()
+    {
+        var g = Gradient(
+            "<defs><radialGradient id='g'><stop offset='0%' stop-color='lime'/>"
+            + "<stop offset='100%' stop-color='black'/></radialGradient></defs>"
+            + "<rect width='100' height='100' fill='url(#g)'/>");
+
+        Assert.NotNull(g);
+        Assert.True(g.IsRadial);
+        Assert.Equal(0.5f, g.CenterX, 2);
+        Assert.Equal(0.5f, g.CenterY, 2);
+    }
+
+    /// <summary><c>stop-opacity</c> folds into the stop's alpha.</summary>
+    [Fact]
+    public void StopOpacity_FoldsIntoTheStopAlpha()
+    {
+        var g = Gradient(
+            "<defs><linearGradient id='g'>"
+            + "<stop offset='0%' stop-color='red' stop-opacity='0.5'/>"
+            + "<stop offset='100%' stop-color='blue'/></linearGradient></defs>"
+            + "<rect width='100' height='50' fill='url(#g)'/>");
+
+        Assert.InRange(g.Stops[0].Color.A, 120, 136);
+        Assert.Equal(255, g.Stops[1].Color.A);
+    }
+
+    /// <summary>SVG 1.1 §13.2.4: offsets are clamped to 0..1 and kept non-decreasing.</summary>
+    [Fact]
+    public void StopOffsets_AreClampedAndNonDecreasing()
+    {
+        var g = Gradient(
+            "<defs><linearGradient id='g'>"
+            + "<stop offset='-1' stop-color='red'/>"
+            + "<stop offset='0.7' stop-color='green'/>"
+            + "<stop offset='0.2' stop-color='blue'/>"
+            + "<stop offset='5' stop-color='black'/></linearGradient></defs>"
+            + "<rect width='100' height='50' fill='url(#g)'/>");
+
+        Assert.Equal([0f, 0.7f, 0.7f, 1f], g.Stops.Select(s => s.Position).ToArray());
+    }
+
+    /// <summary>A gradient takes its stops from the one its <c>href</c> points at.</summary>
+    [Fact]
+    public void HrefInheritance_CopiesTheStops()
+    {
+        var g = Gradient(
+            $"<defs>{LinearRedBlue}<linearGradient id='copy' href='#g'/></defs>"
+            + "<rect width='100' height='50' fill='url(#copy)'/>");
+
+        Assert.NotNull(g);
+        Assert.Equal(2, g.Stops.Count);
+        Assert.Equal(255, g.Stops[0].Color.R);
+    }
+
+    /// <summary>
+    /// SVG 2 §6.5: where both spellings are present the unprefixed <c>href</c> wins. The attribute
+    /// parser drops the namespace prefix, so both land under the same key and the last one written
+    /// would otherwise win — which is what
+    /// <c>svg/linking/reftests/href-gradient-element</c> is built to catch.
+    /// </summary>
+    [Fact]
+    public void PlainHref_BeatsXlinkHref()
+    {
+        var g = Gradient(
+            "<defs>"
+            + "<linearGradient id='wanted'><stop offset='0%' stop-color='lime'/>"
+            + "<stop offset='100%' stop-color='lime'/></linearGradient>"
+            + "<linearGradient id='unwanted'><stop offset='0%' stop-color='red'/>"
+            + "<stop offset='100%' stop-color='red'/></linearGradient>"
+            + "<linearGradient id='copy' href='#wanted' xlink:href='#unwanted'/>"
+            + "</defs><rect width='100' height='50' fill='url(#copy)'/>");
+
+        Assert.NotNull(g);
+        Assert.Equal(0, g.Stops[0].Color.R);
+        Assert.True(g.Stops[0].Color.G > 200, "the href gradient's lime should win over xlink:href's red");
+    }
+
+    /// <summary>An <c>xlink:href</c> on its own still resolves.</summary>
+    [Fact]
+    public void XlinkHrefAlone_StillResolves()
+    {
+        var g = Gradient(
+            $"<defs>{LinearRedBlue}<linearGradient id='copy' xlink:href='#g'/></defs>"
+            + "<rect width='100' height='50' fill='url(#copy)'/>");
+
+        Assert.NotNull(g);
+        Assert.Equal(2, g.Stops.Count);
+    }
+
+    /// <summary>A reference that names nothing paints nothing — no gradient, and no black box.</summary>
+    [Fact]
+    public void UnresolvableReference_EmitsNoGradient()
+    {
+        Assert.Null(Gradient("<rect width='100' height='50' fill='url(#missing)'/>"));
+    }
+
+    /// <summary>
+    /// A gradient with no stops cannot paint, so the shape keeps its fallback rather than getting
+    /// an empty ramp.
+    /// </summary>
+    [Fact]
+    public void GradientWithNoStops_EmitsNoGradient()
+    {
+        Assert.Null(Gradient(
+            "<defs><linearGradient id='g'/></defs><rect width='100' height='50' fill='url(#g)'/>"));
+    }
+
+    /// <summary>A shape with an ordinary colour fill emits no gradient at all.</summary>
+    [Fact]
+    public void PlainColourFill_EmitsNoGradient()
+    {
+        Assert.Null(Gradient($"<defs>{LinearRedBlue}</defs><rect width='100' height='50' fill='blue'/>"));
+    }
+
+    /// <summary>
+    /// The gradient is mapped by the element's own transform, exactly as AddShape maps the shape it
+    /// fills: a quarter turn takes the default left-to-right ramp to top-to-bottom.
+    /// </summary>
+    [Fact]
+    public void ElementTransform_TurnsTheGradientWithTheShape()
+    {
+        var g = Gradient(
+            $"<defs>{LinearRedBlue}</defs>"
+            + "<rect width='100' height='100' fill='url(#g)' transform='rotate(90)'/>");
+
+        Assert.NotNull(g);
+        Assert.Equal(180f, g.Angle, 1);
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssBox.Flex.cs
@@ -339,6 +339,29 @@ internal partial class CssBox : CssBoxProperties, IDisposable
         return borderBoxWidth + child.ActualMarginLeft + child.ActualMarginRight;
     }
 
+    /// <summary>
+    /// CSS Flexbox §4.5 <em>specified size suggestion</em>: the item's own <c>width</c> as a
+    /// border-box length when that width is definite, which is what caps the content-based
+    /// minimum. An <c>auto</c> width, an intrinsic keyword or an absent one has no suggestion —
+    /// the minimum is then the content size suggestion alone.
+    /// </summary>
+    private static bool TryGetSpecifiedSizeSuggestion(
+        CssBox child, double containerContentWidth, out double borderBoxWidth)
+    {
+        borderBoxWidth = 0;
+
+        if (child.Width == CssConstants.Auto
+            || string.IsNullOrEmpty(child.Width)
+            || IsIntrinsicWidthKeyword(child.Width))
+        {
+            return false;
+        }
+
+        borderBoxWidth = child.ResolveSpecifiedWidthToBorderBox(
+            ParseFlexLengthOrZero(child, child.Width, containerContentWidth));
+        return true;
+    }
+
     private static double ParseFlexLengthOrZero(CssBox box, string value, double percentBase)
     {
         try
@@ -366,7 +389,27 @@ internal partial class CssBox : CssBoxProperties, IDisposable
 
         if (useAutomaticMinWidth)
         {
-            child.GetMinMaxWidth(out double minContentWidth, out _);
+            // CSS Flexbox §4.5 automatic minimum size. The content-based minimum is the *content
+            // size suggestion* — the item's min-content size — and, when the item has a definite
+            // specified main size, no larger than that *specified size suggestion* either.
+            //
+            // GetMinMaxWidth folds the box's own `width` into what it reports, so it answered the
+            // specified width rather than the content's: a `width: 300px` item declared a 300px
+            // floor, and `flex-shrink` — which defaults to 1 — could not move it at all. A 300px
+            // item in a 100px container simply overflowed, and every flex layout that relies on
+            // shrinking an explicitly-sized item was wrong by the amount it should have shrunk.
+            // GetContentMinMaxWidth is the same measurement with the box's own width suppressed,
+            // which is the suggestion §4.5 actually asks for. `min-width: 0` was the workaround
+            // that worked, because it takes the branch below instead of this one.
+            child.GetContentMinMaxWidth(out double contentSuggestion, out _);
+
+            double minContentWidth = contentSuggestion;
+
+            if (TryGetSpecifiedSizeSuggestion(child, containerContentWidth, out double specified)
+                && specified < minContentWidth)
+            {
+                minContentWidth = specified;
+            }
 
             if (!double.IsNaN(minContentWidth) && minContentWidth > 0)
             {

--- a/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
+++ b/Broiler.Layout/Broiler.Layout/Engine/CssUtils.cs
@@ -239,10 +239,34 @@ internal static partial class CssUtils
         if (grow is null)
             return;
 
+        // CSS Flexbox §7.1: `<'flex-basis'>` is `content | <'width'>`, and a `<'width'>` is never a
+        // bare non-zero number. A unitless zero *is* one — the spec's own note says a unitless zero
+        // already preceded by two flex factors reads as the basis rather than a third factor — so
+        // `flex: 0 0 0` is valid where `flex: 0 0 4` is not. An invalid component invalidates the
+        // whole shorthand, which then leaves `flex` at the value it already had.
+        //
+        // Taking `4` as a basis instead made every item in the four WPT
+        // css-flexbox/flexbox_flex-*-unitless-basis tests size to its content rather than keeping
+        // the `width: 5em` the dropped declaration leaves in force.
+        if (basis is not null && IsUnitlessNonZeroNumber(basis))
+            return;
+
         cssBox.FlexGrow = grow;
         cssBox.FlexShrink = shrink ?? "1";
         cssBox.FlexBasis = basis ?? "0%";
     }
+
+    /// <summary>
+    /// Whether <paramref name="token"/> is a plain number with no unit and a non-zero value — the
+    /// one shape that is a valid flex <em>factor</em> but never a valid <c>flex-basis</c>.
+    /// </summary>
+    private static bool IsUnitlessNonZeroNumber(string token) =>
+        double.TryParse(
+            token,
+            System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out double parsed)
+        && parsed != 0;
 
     public static void SetPropertyValue(CssBox cssBox, string propName, string value)
     {

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Gradients.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Gradients.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Broiler.Graphics;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// SVG gradient paint servers — <c>&lt;linearGradient&gt;</c> and <c>&lt;radialGradient&gt;</c>
+/// reached through <c>fill="url(#id)"</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A gradient fill painted <b>nothing at all</b>: <see cref="ResolveFill"/> recognised the
+/// reference, found no <c>&lt;pattern&gt;</c> under that id, and fell through to the fallback paint
+/// — which for the ordinary <c>fill="url(#grad)"</c> with no colour after it is "no paint". Every
+/// gradient-filled shape was therefore invisible, and a test that fills with a gradient
+/// specifically to avoid a false positive (the whole
+/// <c>css-transforms/transform-origin/svg-origin-*</c> family, 82 of them scoring an identical
+/// 97.21%) rendered a blank box on both sides of its own comparison.
+/// </para>
+/// <para>
+/// The gradient is emitted as a <see cref="DrawTiledGradientItem"/> — the same display item CSS
+/// backgrounds already use, so the raster backend needs no new primitive — sized to a single
+/// non-repeating tile over the shape's bounding box. Like <see cref="EmitPatternTiles"/> this is
+/// offered for <c>&lt;rect&gt;</c> only: the tile is clipped to a rectangle, which is the shape
+/// whose bounding box *is* its geometry. Any other shape would take the gradient over its bounding
+/// box rather than its outline, which is worse than the fallback it keeps instead.
+/// </para>
+/// </remarks>
+internal static partial class SvgRenderer
+{
+    /// <summary>How far an <c>href</c> chain between gradients is followed (SVG 1.1 §13.2.4).</summary>
+    private const int MaxGradientHrefDepth = 4;
+
+    /// <summary>One gradient definition: its attributes, its stop markup, and which kind it is.</summary>
+    private readonly record struct SvgGradient(
+        Dictionary<string, string> Attributes, string Content, bool IsRadial);
+
+    /// <summary>
+    /// Collects every gradient in the markup by <c>id</c>. Like <c>&lt;pattern&gt;</c>, a gradient
+    /// takes any attribute it does not declare — and its stops when it declares none — from the
+    /// gradient its <c>href</c>/<c>xlink:href</c> points at, so the chains are resolved after the
+    /// whole document has been seen and a gradient may point forwards.
+    /// </summary>
+    private static Dictionary<string, SvgGradient> CollectGradients(string svgXml)
+    {
+        if (string.IsNullOrEmpty(svgXml)
+            || svgXml.IndexOf("Gradient", StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return null;
+        }
+
+        var gradients = new Dictionary<string, SvgGradient>(StringComparer.Ordinal);
+        foreach (Match m in GradientBlockRegex().Matches(svgXml))
+        {
+            var attrs = ParseAttributes(m.Groups["attrs"].Value);
+            if (!attrs.TryGetValue("id", out var id) || string.IsNullOrEmpty(id))
+                continue;
+
+            // ParseAttributes' name pattern excludes ':', so `xlink:href` lands under the same
+            // "href" key as a plain `href` and whichever is written last wins. SVG 2 §6.5 says the
+            // unprefixed one wins whenever both are present, so it is recovered from the raw
+            // attribute text and reinstated. svg/linking/reftests/href-gradient-element states
+            // exactly this, with the two spellings pointing at different gradients on purpose.
+            var plainHref = UnprefixedHrefRegex().Match(m.Groups["attrs"].Value);
+            if (plainHref.Success)
+                attrs["href"] = plainHref.Groups["value"].Value;
+
+            bool radial = m.Groups["kind"].Value.StartsWith("radial", StringComparison.OrdinalIgnoreCase);
+            gradients[id] = new SvgGradient(
+                attrs, m.Groups["content"].Success ? m.Groups["content"].Value : string.Empty, radial);
+        }
+
+        if (gradients.Count == 0)
+            return null;
+
+        foreach (var id in gradients.Keys.ToList())
+            gradients[id] = ResolveGradientInheritance(gradients, id, MaxGradientHrefDepth);
+
+        return gradients;
+    }
+
+    private static SvgGradient ResolveGradientInheritance(
+        Dictionary<string, SvgGradient> gradients, string id, int budget)
+    {
+        var gradient = gradients[id];
+        if (budget <= 0)
+            return gradient;
+
+        // Either spelling arrives under "href" (see CollectGradients), with the unprefixed one
+        // already preferred where a gradient carries both.
+        string href = gradient.Attributes.GetValueOrDefault("href");
+
+        if (string.IsNullOrWhiteSpace(href) || href.Length < 2 || href[0] != '#')
+            return gradient;
+
+        string parentId = href[1..];
+        if (!gradients.TryGetValue(parentId, out _) || string.Equals(parentId, id, StringComparison.Ordinal))
+            return gradient;
+
+        var parent = ResolveGradientInheritance(gradients, parentId, budget - 1);
+
+        var merged = new Dictionary<string, string>(parent.Attributes, StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, value) in gradient.Attributes)
+            merged[key] = value;
+
+        string content = string.IsNullOrWhiteSpace(gradient.Content) ? parent.Content : gradient.Content;
+        return new SvgGradient(merged, content, gradient.IsRadial);
+    }
+
+    /// <summary>
+    /// Paints the gradient <paramref name="id"/> names over <paramref name="objectBounds"/>.
+    /// </summary>
+    /// <returns>
+    /// <see langword="false"/> when the id names no gradient, or it carries fewer than the two
+    /// stops a ramp needs, so the caller can use the fallback paint instead.
+    /// </returns>
+    private static bool TryEmitGradientFill(
+        List<DisplayItem> items, RectangleF bounds, Dictionary<string, SvgGradient> gradients,
+        string id, RectangleF objectBounds, float sx, float sy, float tx, float ty,
+        float pctW, float pctH, SvgTransform elementTransform)
+    {
+        if (gradients == null
+            || !gradients.TryGetValue(id, out var gradient)
+            || objectBounds.Width <= 0 || objectBounds.Height <= 0)
+        {
+            return false;
+        }
+
+        var stops = ParseGradientStops(gradient.Content);
+        if (stops.Count == 0)
+            return false;
+
+        // A single stop is a solid fill of that colour, which the ramp below cannot express.
+        if (stops.Count == 1)
+            stops = [stops[0], new GradientStop { Color = stops[0].Color, Position = 1f }];
+
+        var attrs = gradient.Attributes;
+        bool objectBoundingBoxUnits = !string.Equals(
+            attrs.GetValueOrDefault("gradientUnits"), "userSpaceOnUse", StringComparison.OrdinalIgnoreCase);
+
+        // The gradient's geometry in user units, whichever system it was written in. Fractions of
+        // the shape's bounding box is the default (SVG 1.1 §13.2.2); userSpaceOnUse means the
+        // attributes are plain lengths already.
+        float Coordinate(string name, float defaultFraction, bool horizontal)
+        {
+            if (objectBoundingBoxUnits)
+            {
+                float fraction = attrs.ContainsKey(name) ? GetFraction(attrs, name) : defaultFraction;
+                return horizontal
+                    ? objectBounds.X + fraction * objectBounds.Width
+                    : objectBounds.Y + fraction * objectBounds.Height;
+            }
+
+            if (!attrs.ContainsKey(name))
+            {
+                return horizontal
+                    ? objectBounds.X + defaultFraction * objectBounds.Width
+                    : objectBounds.Y + defaultFraction * objectBounds.Height;
+            }
+
+            return GetLength(attrs, name, horizontal ? pctW : pctH);
+        }
+
+        // Page pixels, then through the element's own transform — the shape it fills is mapped the
+        // same way by AddShape. Without this a `rotate(90)` rect kept an unrotated ramp, which is
+        // what css-transforms/transform-origin/svg-origin-* measures: the whole point of those
+        // tests is that the gradient turns with the box.
+        PointF ToPage(float ux, float uy) =>
+            elementTransform.Map(bounds.X + ux * sx + tx, bounds.Y + uy * sy + ty);
+
+        var fillRect = elementTransform.MapBounds(new RectangleF(
+            bounds.X + objectBounds.X * sx + tx,
+            bounds.Y + objectBounds.Y * sy + ty,
+            objectBounds.Width * sx,
+            objectBounds.Height * sy));
+
+        float angle = 90f;
+        float centerX = 0.5f, centerY = 0.5f;
+
+        if (gradient.IsRadial)
+        {
+            // SVG 1.1 §13.2.3 defaults: cx/cy at the centre of the bounding box.
+            var centre = ToPage(
+                Coordinate("cx", 0.5f, horizontal: true), Coordinate("cy", 0.5f, horizontal: false));
+            centerX = fillRect.Width > 0 ? (centre.X - fillRect.X) / fillRect.Width : 0.5f;
+            centerY = fillRect.Height > 0 ? (centre.Y - fillRect.Y) / fillRect.Height : 0.5f;
+        }
+        else
+        {
+            // SVG 1.1 §13.2.2 defaults: x1,y1 = 0%,0% and x2,y2 = 100%,0% — a left-to-right ramp.
+            var start = ToPage(
+                Coordinate("x1", 0f, horizontal: true), Coordinate("y1", 0f, horizontal: false));
+            var end = ToPage(
+                Coordinate("x2", 1f, horizontal: true), Coordinate("y2", 0f, horizontal: false));
+            angle = GradientAngleDegrees(end.X - start.X, end.Y - start.Y);
+        }
+
+        items.Add(new DrawTiledGradientItem
+        {
+            Bounds = bounds,
+            FillRect = fillRect,
+            TileOrigin = new PointF(fillRect.X, fillRect.Y),
+            TileWidth = Math.Max(1f, fillRect.Width),
+            TileHeight = Math.Max(1f, fillRect.Height),
+            Repeat = "no-repeat",
+            Stops = stops,
+            Angle = angle,
+            IsRadial = gradient.IsRadial,
+            CenterX = Math.Clamp(centerX, 0f, 1f),
+            CenterY = Math.Clamp(centerY, 0f, 1f),
+        });
+
+        return true;
+    }
+
+    /// <summary>
+    /// The gradient vector as a CSS gradient angle, whose zero points to the top and which turns
+    /// clockwise — so a vector pointing right (SVG's default) is 90°. Screen coordinates run down,
+    /// which is why the y component is negated. A degenerate vector keeps the default.
+    /// </summary>
+    private static float GradientAngleDegrees(float dx, float dy)
+    {
+        if (Math.Abs(dx) < 1e-6f && Math.Abs(dy) < 1e-6f)
+            return 90f;
+
+        double degrees = Math.Atan2(dx, -dy) * (180.0 / Math.PI);
+        if (degrees < 0)
+            degrees += 360.0;
+
+        return (float)degrees;
+    }
+
+    /// <summary>
+    /// Reads the <c>&lt;stop&gt;</c> children of a gradient in document order. <c>stop-color</c>
+    /// and <c>stop-opacity</c> are presentation attributes, so a <c>style</c> declaration on the
+    /// stop wins over the attribute of the same name; the opacity folds into the stop's alpha.
+    /// Offsets are clamped to 0..1 and kept non-decreasing, which is what SVG 1.1 §13.2.4 asks for.
+    /// </summary>
+    private static List<GradientStop> ParseGradientStops(string content)
+    {
+        var stops = new List<GradientStop>();
+        if (string.IsNullOrWhiteSpace(content))
+            return stops;
+
+        float previous = 0f;
+        foreach (Match m in GradientStopRegex().Matches(content))
+        {
+            var attrs = ParseAttributes(m.Groups["attrs"].Value);
+
+            float offset = Math.Clamp(GetFraction(attrs, "offset"), 0f, 1f);
+            if (offset < previous)
+                offset = previous;
+            previous = offset;
+
+            var color = ParseColorValue(GetPresentationValue(attrs, "stop-color") ?? "black", BColor.Black);
+            float opacity = ParseAlpha(GetPresentationValue(attrs, "stop-opacity"));
+            if (opacity < 1f)
+                color = BColor.FromArgb((int)Math.Round(color.A * opacity), color.R, color.G, color.B);
+
+            stops.Add(new GradientStop { Color = color, Position = offset });
+        }
+
+        return stops;
+    }
+
+    /// <summary>A <c>&lt;linearGradient&gt;</c> or <c>&lt;radialGradient&gt;</c>, with or without stops.</summary>
+    [GeneratedRegex(
+        @"<(?<kind>linear|radial)Gradient\b(?<attrs>(?:[^>""']|""[^""]*""|'[^']*')*?)(?:/>|>(?<content>.*?)</(?:linear|radial)Gradient\s*>)",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex GradientBlockRegex();
+
+    /// <summary>
+    /// An <c>href</c> attribute with no namespace prefix — the lookbehind is what keeps it from
+    /// matching the <c>href</c> inside <c>xlink:href</c>.
+    /// </summary>
+    [GeneratedRegex(
+        @"(?<![\w:.-])href\s*=\s*(?:""(?<value>[^""]*)""|'(?<value>[^']*)')",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex UnprefixedHrefRegex();
+
+    /// <summary>One <c>&lt;stop&gt;</c> inside a gradient.</summary>
+    [GeneratedRegex(
+        @"<stop\b(?<attrs>(?:[^>""']|""[^""]*""|'[^']*')*?)(?:/>|>.*?</stop\s*>)",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex GradientStopRegex();
+}

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Paint.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.Paint.cs
@@ -129,6 +129,7 @@ internal static partial class SvgRenderer
     /// </returns>
     private static BColor ResolveFill(
         List<DisplayItem> items, RectangleF bounds, Dictionary<string, SvgPattern> patterns,
+        Dictionary<string, SvgGradient> gradients,
         Dictionary<string, string> attrs, RectangleF objectBounds,
         float sx, float sy, float tx, float ty, float pctW, float pctH,
         SvgTransform elementTransform)
@@ -143,6 +144,13 @@ internal static partial class SvgRenderer
         {
             return BColor.Empty;
         }
+
+        // The other paint server a fill may name. Tried after patterns because the two never share
+        // an id, and before the fallback because reaching the fallback with a gradient present is
+        // exactly the bug: `fill="url(#grad)"` has no colour after it, so the shape painted nothing.
+        if (TryEmitGradientFill(
+                items, bounds, gradients, id, objectBounds, sx, sy, tx, ty, pctW, pctH, elementTransform))
+            return BColor.Empty;
 
         return FallbackPaint(fallback);
     }

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.TransformOrigin.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.TransformOrigin.cs
@@ -80,12 +80,21 @@ internal static partial class SvgRenderer
         float centreX = box.X + box.Width / 2f;
         float centreY = box.Y + box.Height / 2f;
 
+        // CSS Transforms 1 §8: an SVG element has no CSS layout box, and for one of those the used
+        // value of an *unspecified* `transform-origin` is `0 0` — the reference box's own corner,
+        // not its centre. An invalid declaration is dropped whole and takes that same initial
+        // value. Falling back to the centre instead is what kept the twelve WPT
+        // svg-origin-relative-length-invalid-* cases failing: each is built so that its transform
+        // maps the square onto itself about `0 0`, matching a reference that draws the rect with no
+        // transform at all, and a centre origin threw the square hundreds of pixels away.
+        var initial = new PointF(box.X, box.Y);
+
         if (string.IsNullOrWhiteSpace(value))
-            return new PointF(centreX, centreY);
+            return initial;
 
         var parts = value.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length == 0)
-            return new PointF(centreX, centreY);
+            return initial;
 
         if (parts.Length == 1)
         {
@@ -96,7 +105,7 @@ internal static partial class SvgRenderer
 
             return IsHorizontalCompatible(parts[0])
                 ? new PointF(ResolveOriginComponent(parts[0], box.X, box.Width, horizontal: true, centreX), centreY)
-                : new PointF(centreX, centreY);
+                : initial;
         }
 
         // The pair may be written the other way round — but only when *both* halves are keywords.
@@ -109,13 +118,13 @@ internal static partial class SvgRenderer
         if (IsVerticalKeyword(first))
         {
             if (!IsHorizontalKeyword(second))
-                return new PointF(centreX, centreY);
+                return initial;
 
             (first, second) = (second, first);
         }
 
         if (!IsHorizontalCompatible(first) || !IsVerticalCompatible(second))
-            return new PointF(centreX, centreY);
+            return initial;
 
         return new PointF(
             ResolveOriginComponent(first, box.X, box.Width, horizontal: true, centreX),

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.TransformOrigin.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.TransformOrigin.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+
+namespace Broiler.Layout.IR;
+
+/// <summary>
+/// CSS Transforms 1 §6/§8: <c>transform-box</c> and <c>transform-origin</c> on an SVG element.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An SVG <c>transform</c> was applied about the user-space origin and nothing else — which is
+/// what SVG 1.1 did, and is still right for the initial <c>transform-box: view-box</c>. What was
+/// missing is the box-relative case: <c>transform-box: fill-box</c> makes the element's own fill
+/// bounding box the reference box, and <c>transform-origin</c> then names a point inside it (the
+/// centre, <c>50% 50%</c>, when it is not written). The element's own transform has to be
+/// conjugated by that point — <c>T(o) · M · T(-o)</c> — and it was not, so a
+/// <c>rotate(90)</c> about a box centre turned about the viewport corner instead and swung the
+/// element clean off its intended place.
+/// </para>
+/// <para>
+/// The 45 <c>css-transforms/transform-origin/svg-origin-*</c> tests of the 2026-08-21 run scored an
+/// identical 97.14% on this: each declares <c>transform-box: fill-box</c> on a 150×150 rect, and
+/// 150×150 is 2.86% of the canvas — the whole of their disagreement.
+/// </para>
+/// <para>
+/// Only the box-relative <c>transform-box</c> values take this path. Under the initial
+/// <c>view-box</c> the transform keeps the meaning it already had, so a document that never
+/// mentions <c>transform-box</c> renders exactly as before.
+/// </para>
+/// </remarks>
+internal static partial class SvgRenderer
+{
+    /// <summary>
+    /// The element's own transform, conjugated by its <c>transform-origin</c> when
+    /// <c>transform-box</c> makes a box the reference. <paramref name="fillBox"/> is the element's
+    /// fill bounding box in user units.
+    /// </summary>
+    private static SvgTransform OwnTransformAbout(
+        Dictionary<string, string> attrs, RectangleF fillBox)
+    {
+        var own = SvgTransform.Parse(attrs.GetValueOrDefault("transform"));
+
+        if (own.IsIdentity || !UsesBoxRelativeTransformBox(attrs))
+            return own;
+
+        var origin = ResolveTransformOrigin(GetPresentationValue(attrs, "transform-origin"), fillBox);
+        if (Math.Abs(origin.X) < 1e-6f && Math.Abs(origin.Y) < 1e-6f)
+            return own;
+
+        var toOrigin = new SvgTransform(1, 0, 0, 1, origin.X, origin.Y);
+        var fromOrigin = new SvgTransform(1, 0, 0, 1, -origin.X, -origin.Y);
+        return toOrigin.Concat(own).Concat(fromOrigin);
+    }
+
+    /// <summary>
+    /// Whether <c>transform-box</c> names a box of the element rather than the viewport. The
+    /// initial value is <c>view-box</c>, under which the transform keeps SVG 1.1's meaning; every
+    /// other value makes the element's own box the reference. <c>stroke-box</c>, <c>content-box</c>
+    /// and <c>border-box</c> differ from <c>fill-box</c> only by the stroke and by box decorations
+    /// this renderer does not give a shape, so they resolve to the same rectangle here.
+    /// </summary>
+    private static bool UsesBoxRelativeTransformBox(Dictionary<string, string> attrs)
+    {
+        string box = GetPresentationValue(attrs, "transform-box")?.Trim();
+        return !string.IsNullOrEmpty(box)
+            && !box.Equals("view-box", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// CSS Transforms 1 §8: <c>transform-origin</c> as a point in user units, relative to
+    /// <paramref name="box"/>. One value gives the x with the y centred; a keyword names an edge or
+    /// the centre; a percentage resolves against the box. The z component a third value carries is
+    /// dropped — nothing here is 3D. An absent or unreadable value is the initial
+    /// <c>50% 50%</c>: the centre of the box.
+    /// </summary>
+    private static PointF ResolveTransformOrigin(string value, RectangleF box)
+    {
+        float centreX = box.X + box.Width / 2f;
+        float centreY = box.Y + box.Height / 2f;
+
+        if (string.IsNullOrWhiteSpace(value))
+            return new PointF(centreX, centreY);
+
+        var parts = value.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+            return new PointF(centreX, centreY);
+
+        if (parts.Length == 1)
+        {
+            // One value sets that axis and centres the other. `top`/`bottom` name the vertical one,
+            // so a lone one of those moves y rather than x.
+            if (IsVerticalKeyword(parts[0]))
+                return new PointF(centreX, ResolveOriginComponent(parts[0], box.Y, box.Height, horizontal: false, centreY));
+
+            return IsHorizontalCompatible(parts[0])
+                ? new PointF(ResolveOriginComponent(parts[0], box.X, box.Width, horizontal: true, centreX), centreY)
+                : new PointF(centreX, centreY);
+        }
+
+        // The pair may be written the other way round — but only when *both* halves are keywords.
+        // `top left` is the keyword form; `top 100%` is not a form at all, because a
+        // length-percentage may not follow a vertical keyword. An invalid declaration is dropped
+        // whole, leaving the initial `50% 50%` — which is what the twelve WPT
+        // css-transforms/transform-origin/svg-origin-relative-length-invalid-* cases assert, and
+        // what accepting `top 100%` as `100% top` got wrong.
+        string first = parts[0], second = parts[1];
+        if (IsVerticalKeyword(first))
+        {
+            if (!IsHorizontalKeyword(second))
+                return new PointF(centreX, centreY);
+
+            (first, second) = (second, first);
+        }
+
+        if (!IsHorizontalCompatible(first) || !IsVerticalCompatible(second))
+            return new PointF(centreX, centreY);
+
+        return new PointF(
+            ResolveOriginComponent(first, box.X, box.Width, horizontal: true, centreX),
+            ResolveOriginComponent(second, box.Y, box.Height, horizontal: false, centreY));
+    }
+
+    /// <summary>A keyword naming a position on the horizontal axis.</summary>
+    private static bool IsHorizontalKeyword(string token) =>
+        token.Equals("left", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("right", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("center", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Whether the token may occupy the horizontal slot: a keyword for it, or a length.</summary>
+    private static bool IsHorizontalCompatible(string token) =>
+        IsHorizontalKeyword(token) || IsLengthOrPercentage(token);
+
+    /// <summary>Whether the token may occupy the vertical slot: a keyword for it, or a length.</summary>
+    private static bool IsVerticalCompatible(string token) =>
+        IsVerticalKeyword(token)
+        || token.Equals("center", StringComparison.OrdinalIgnoreCase)
+        || IsLengthOrPercentage(token);
+
+    private static bool IsLengthOrPercentage(string token)
+    {
+        var span = token.AsSpan().Trim();
+        if (span.Length == 0)
+            return false;
+
+        if (span[^1] == '%')
+            span = span[..^1];
+
+        return float.TryParse(
+            span.ToString().Replace("px", string.Empty), NumberStyles.Float,
+            CultureInfo.InvariantCulture, out _);
+    }
+
+    private static bool IsVerticalKeyword(string token) =>
+        token.Equals("top", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("bottom", StringComparison.OrdinalIgnoreCase);
+
+    private static float ResolveOriginComponent(
+        string token, float origin, float extent, bool horizontal, float fallback)
+    {
+        if (token.Equals("center", StringComparison.OrdinalIgnoreCase))
+            return origin + extent / 2f;
+
+        if (horizontal)
+        {
+            if (token.Equals("left", StringComparison.OrdinalIgnoreCase))
+                return origin;
+            if (token.Equals("right", StringComparison.OrdinalIgnoreCase))
+                return origin + extent;
+        }
+        else
+        {
+            if (token.Equals("top", StringComparison.OrdinalIgnoreCase))
+                return origin;
+            if (token.Equals("bottom", StringComparison.OrdinalIgnoreCase))
+                return origin + extent;
+        }
+
+        var span = token.AsSpan().Trim();
+        if (span.Length > 0 && span[^1] == '%')
+        {
+            return float.TryParse(
+                span[..^1], NumberStyles.Float, CultureInfo.InvariantCulture, out float percent)
+                ? origin + extent * percent / 100f
+                : fallback;
+        }
+
+        // A bare number, or one carrying a unit this renderer treats as pixels — the same reading
+        // GetLength gives an attribute length. The origin is measured from the box's own corner.
+        return float.TryParse(
+            token.Replace("px", string.Empty), NumberStyles.Float, CultureInfo.InvariantCulture,
+            out float length)
+            ? origin + length
+            : fallback;
+    }
+}

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
@@ -998,6 +998,22 @@ internal static partial class SvgRenderer
         bool blended = !string.IsNullOrWhiteSpace(mode)
             && !mode.Equals("normal", StringComparison.OrdinalIgnoreCase);
 
+        // SVG 1.1 §14.5 `opacity`: unlike `fill-opacity`, which GetPaint folds into the paint
+        // colour, this one composites the element as a whole — fill and stroke together — and so
+        // needs a real layer. Nothing emitted one, so `opacity` was dropped outright on every
+        // shape: `<rect fill="blue" opacity="0.5">` painted solid blue. OpacityItem is the layer
+        // the CSS paint path already pushes for the same property (PaintWalker.Stacking), so the
+        // raster backend composites this exactly as it does an HTML element's opacity.
+        // The element's own opacity, times whatever its ancestors contribute: a `<g opacity>` has
+        // no group layer to hang its value on here, so SvgStructure carries the ancestors' product
+        // down to the leaves for this multiplication (see SvgStructure.AncestorOpacityOf).
+        float opacity = ParseAlpha(GetPresentationValue(attrs, "opacity"))
+            * SvgStructure.AncestorOpacityOf(attrs);
+        bool faded = opacity < 1f;
+
+        if (faded)
+            items.Add(new OpacityItem { Bounds = bounds, Opacity = opacity });
+
         if (blended)
             items.Add(new BlendModeItem { Bounds = bounds, Mode = mode! });
 
@@ -1005,6 +1021,9 @@ internal static partial class SvgRenderer
 
         if (blended)
             items.Add(new RestoreBlendModeItem { Bounds = bounds });
+
+        if (faded)
+            items.Add(new RestoreOpacityItem { Bounds = bounds });
     }
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
@@ -147,7 +147,17 @@ internal static partial class SvgRenderer
                 continue;
 
             var items = order.Open(m.Index);
-            var elementTransform = PageTransformOf(structure, m, bounds, sx, sy, tx, ty);
+
+            // The rect's own geometry, needed before the transform because `transform-box:
+            // fill-box` makes this rectangle the reference box its `transform-origin` is measured
+            // in. It depends only on the attributes, so computing it first changes nothing else.
+            var rectBox = new RectangleF(
+                GetLength(attrs, "x", pctW), GetLength(attrs, "y", pctH),
+                GetLength(attrs, "width", pctW), GetLength(attrs, "height", pctH));
+
+            var elementTransform = structure.AncestorTransformAt(m.Index)
+                .Concat(OwnTransformAbout(attrs, rectBox))
+                .ToPageSpace(sx, sy, bounds.X + tx, bounds.Y + ty);
             if (ClipRectFor(attrs, clipRects, bounds, sx, sy, tx, ty, elementTransform) is { } clip)
                 order.ClipLast(clip);
 
@@ -175,9 +185,7 @@ internal static partial class SvgRenderer
 
             // A pattern fill paints as tiles behind the shape, so it is resolved before the rect
             // item is added and leaves the rect's own fill empty; a stroke then draws over it.
-            var objectBounds = new RectangleF(
-                GetLength(attrs, "x", pctW), GetLength(attrs, "y", pctH),
-                GetLength(attrs, "width", pctW), GetLength(attrs, "height", pctH));
+            var objectBounds = rectBox;
             var rectFill = ResolveFill(
                 items, bounds, patterns, gradients, attrs, objectBounds, sx, sy, tx, ty, pctW, pctH,
                 elementTransform);

--- a/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgRenderer.cs
@@ -123,6 +123,9 @@ internal static partial class SvgRenderer
         // rendered part: a <pattern> lives in <defs> precisely so it paints only through a reference.
         var patterns = CollectPatterns(svgXml);
 
+        // The gradient paint servers, collected the same way and for the same reason.
+        var gradients = CollectGradients(svgXml);
+
         // The <clipPath> rectangles a shape's own clip-path attribute may point at.
         var clipRects = CollectClipRects(svgXml);
 
@@ -176,7 +179,7 @@ internal static partial class SvgRenderer
                 GetLength(attrs, "x", pctW), GetLength(attrs, "y", pctH),
                 GetLength(attrs, "width", pctW), GetLength(attrs, "height", pctH));
             var rectFill = ResolveFill(
-                items, bounds, patterns, attrs, objectBounds, sx, sy, tx, ty, pctW, pctH,
+                items, bounds, patterns, gradients, attrs, objectBounds, sx, sy, tx, ty, pctW, pctH,
                 elementTransform);
             var rectStroke = GetPaint(attrs, "stroke", BColor.Empty);
 

--- a/Broiler.Layout/Broiler.Layout/IR/SvgStructure.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgStructure.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace Broiler.Layout.IR;
@@ -367,7 +368,62 @@ internal sealed partial class SvgStructure
             extended[property] = value;
         }
 
+        // `opacity` is deliberately NOT in InheritableProperties above, because it does not inherit:
+        // SVG 1.1 §14.5 applies it to the element it is written on, that element's children
+        // included, as one composite. But this renderer draws leaves — it matches one regex per
+        // shape type and has no group to hang a layer on — so a `<g opacity="0.5">` had nowhere to
+        // put its value and dropped it. Carrying the running product of the ancestors' opacity
+        // lets each shape apply its share of it.
+        float declared = ParseOpacity(ReadPresentation(attributes, "opacity"));
+        if (declared < 1f)
+        {
+            extended ??= new Dictionary<string, string>(inherited, StringComparer.OrdinalIgnoreCase);
+            extended[AncestorOpacityKey] =
+                (AncestorOpacityOf(inherited) * declared).ToString(CultureInfo.InvariantCulture);
+        }
+
         return extended ?? inherited;
+    }
+
+    /// <summary>
+    /// The key the ancestors' composed <c>opacity</c> travels under in an element's inherited map.
+    /// Not an SVG property — the leading marker keeps it out of the way of anything an author can
+    /// write, and it is read back only by <see cref="AncestorOpacityOf"/>.
+    /// </summary>
+    internal const string AncestorOpacityKey = "-broiler-ancestor-opacity";
+
+    /// <summary>
+    /// The product of the <c>opacity</c> values on an element's ancestors, or <c>1</c> when none of
+    /// them fades it.
+    /// </summary>
+    /// <remarks>
+    /// Multiplying the group's opacity into each leaf is exact while the group's children do not
+    /// overlap one another, which is the ordinary case and the one the SVG test suites are built
+    /// from. Where they do overlap, true group compositing flattens the children first and fades
+    /// the result once, so the overlap would come out slightly darker there than here. That is a
+    /// far smaller error than dropping the group's opacity altogether, which is what happened
+    /// before.
+    /// </remarks>
+    internal static float AncestorOpacityOf(IReadOnlyDictionary<string, string> attributes)
+        => attributes.TryGetValue(AncestorOpacityKey, out var raw)
+            && float.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out float value)
+            ? value
+            : 1f;
+
+    /// <summary>An SVG <c>&lt;alpha-value&gt;</c> — a number or a percentage — clamped to 0..1.</summary>
+    private static float ParseOpacity(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return 1f;
+
+        var value = raw.AsSpan().Trim();
+        bool percent = value.Length > 0 && value[^1] == '%';
+        if (percent)
+            value = value[..^1];
+
+        return float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out float parsed)
+            ? Math.Clamp(percent ? parsed / 100f : parsed, 0f, 1f)
+            : 1f;
     }
 
     /// <summary>

--- a/Broiler.Layout/Broiler.Layout/IR/SvgStructure.cs
+++ b/Broiler.Layout/Broiler.Layout/IR/SvgStructure.cs
@@ -71,6 +71,13 @@ internal sealed partial class SvgStructure
     private readonly Dictionary<int, SvgTransform> _transforms = [];
 
     /// <summary>
+    /// Start-tag offset → the transform in effect for that element's <em>ancestors</em> alone,
+    /// without its own. <c>transform-origin</c> conjugates an element's own transform and only its
+    /// own, so the two halves have to be separable.
+    /// </summary>
+    private readonly Dictionary<int, SvgTransform> _ancestorTransforms = [];
+
+    /// <summary>
     /// Start-tag offset → the element's own attributes, for every element the scan reached,
     /// painting or not.
     /// </summary>
@@ -162,6 +169,13 @@ internal sealed partial class SvgStructure
     /// </summary>
     public SvgTransform TransformAt(int index)
         => _transforms.TryGetValue(index, out var transform) ? transform : SvgTransform.Identity;
+
+    /// <summary>
+    /// The transform the element's ancestors put it under, without its own — the half a
+    /// <c>transform-origin</c> leaves alone.
+    /// </summary>
+    public SvgTransform AncestorTransformAt(int index)
+        => _ancestorTransforms.TryGetValue(index, out var transform) ? transform : SvgTransform.Identity;
 
     /// <summary>The attributes of the element starting at <paramref name="index"/>, painting or not.</summary>
     public bool TryGetAttributes(int index, out IReadOnlyDictionary<string, string> attributes)
@@ -313,6 +327,8 @@ internal sealed partial class SvgStructure
                 structure._rendered[m.Index] = inherited;
                 if (!transform.IsIdentity)
                     structure._transforms[m.Index] = transform;
+                if (!ancestorTransform.IsIdentity)
+                    structure._ancestorTransforms[m.Index] = ancestorTransform;
             }
 
             if (m.Groups["empty"].Value.Length > 0)

--- a/patches/0002-html-outermost-svg-author-display.patch
+++ b/patches/0002-html-outermost-svg-author-display.patch
@@ -1,0 +1,108 @@
+From fecba675ca98b408110d2d4f761acf1db3ace1a2 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 21 Aug 2026 21:06:28 +0000
+Subject: [PATCH] Let an outermost <svg> keep the display the author cascaded
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+An outermost <svg> is a replaced element in the host document, and like every
+replaced element its `display` is *initially* `inline` — not fixed there. The
+box tree substitutes `inline-block` for that initial value, which is how an
+inline replaced box is laid out here, but it applied the substitution to the
+cascaded value as well, so whatever the author wrote was discarded.
+
+Two things fell out of that:
+
+  * `svg { display: block }` — the ordinary way to take an SVG off the text
+    baseline — laid the element out inline. Siblings sat side by side instead
+    of stacking, and `margin: 0 auto` computed to zero on an inline box rather
+    than centring it. WPT css/compositing/line-with-svg-background is ten such
+    block <svg>s and rendered them two to a row.
+  * `display: none` was overridden into a visible box, so the hidden <svg> that
+    pages use to carry nothing but a <filter> or <defs> painted. WPT
+    css/filter-effects/tainting-css-dropshadow-currentcolor is exactly that
+    shape and goes 97.4% -> 100%.
+
+Read the cascaded value only on the *outermost* <svg>. A nested <svg> is SVG
+content rather than a CSS box, and the element above it deliberately hides
+every box beneath it, so reading a display off one would read that hiding back
+as `display: none` and drop the inner viewport for good.
+
+Verified against the WPT reftest suite: 6369 tests over svg, css/compositing,
+css/css-backgrounds, css/filter-effects, css/css-transforms, css/css-flexbox,
+css/css-grid, css/css-sizing, css/cssom-view, css/css-break, css/printing,
+fullscreen and encoding, with two tests improving and none regressing.
+---
+ .../Parse/DomParser.cs                        | 48 ++++++++++++++++++-
+ 1 file changed, 47 insertions(+), 1 deletion(-)
+
+diff --git a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+index 15f2716..6451024 100644
+--- a/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
++++ b/Source/Broiler.HTML.Orchestration/Parse/DomParser.cs
+@@ -292,7 +292,31 @@ internal sealed class DomParser
+             if (!isVideo && !isAudio &&
+                 box.HtmlTag.Name.Equals("svg", StringComparison.OrdinalIgnoreCase))
+             {
+-                box.Display = CssConstants.InlineBlock;
++                // CSS Display 3 §2 / SVG 2 §7.1: `inline` is an *outermost* <svg>'s initial
++                // display, not a fixed one, and `inline-block` is how an inline replaced box is
++                // laid out here — so that substitution belongs to the initial value alone.
++                // Applying it to every value discarded the author's `display` outright:
++                // `svg { display: block }` — the ordinary way to take an SVG off the text
++                // baseline — laid the element out inline, so siblings sat side by side instead
++                // of stacking and `margin: 10px auto` computed to zero rather than centring it
++                // (css/compositing/line-with-svg-background is ten such block <svg>s and came
++                // out two to a row), and `svg { display: none }` was overridden into a visible
++                // box, so an author-hidden SVG painted.
++                //
++                // A *nested* <svg> is SVG content rather than a CSS box, and the loop below
++                // deliberately hides every child of the SVG it sits in. Reading the author's
++                // display off such a box would read that hiding back as `display: none` and
++                // drop the inner viewport for good, so only the outermost <svg> — the one that
++                // really is a replaced element in the host document — takes the cascaded value.
++                if (!HasSvgAncestor(box))
++                {
++                    if (box.Display == CssConstants.Inline)
++                        box.Display = CssConstants.InlineBlock;
++                }
++                else
++                {
++                    box.Display = CssConstants.InlineBlock;
++                }
+ 
+                 ApplySvgReplacedSizing(box);
+ 
+@@ -2173,6 +2197,28 @@ internal sealed class DomParser
+             box.Height = "150px";
+     }
+ 
++    /// <summary>
++    /// True when <paramref name="box"/> sits inside another <c>&lt;svg&gt;</c> — i.e. it is a
++    /// nested SVG viewport rather than the outermost <c>&lt;svg&gt;</c> the host document lays
++    /// out as a replaced element. The distinction matters because the outer element hides every
++    /// box beneath it (SVG internals are not CSS-visible here), so a nested <c>&lt;svg&gt;</c>
++    /// arrives at the cascade already carrying <c>display: none</c> from its ancestor rather
++    /// than from the stylesheet.
++    /// </summary>
++    private static bool HasSvgAncestor(CssBox box)
++    {
++        for (var ancestor = box.ParentBox; ancestor != null; ancestor = ancestor.ParentBox)
++        {
++            if (ancestor.HtmlTag != null &&
++                ancestor.HtmlTag.Name.Equals("svg", StringComparison.OrdinalIgnoreCase))
++            {
++                return true;
++            }
++        }
++
++        return false;
++    }
++
+     /// <summary>Reads an outer <c>&lt;svg&gt;</c>'s <c>width</c>/<c>height</c>
+     /// presentation attribute as a CSS length, mapping an absent, empty or
+     /// <c>auto</c> value back to <c>auto</c> so the caller's sizing rules apply.
+-- 
+2.43.0
+

--- a/patches/0003-css-link-matches-xlink-href.patch
+++ b/patches/0003-css-link-matches-xlink-href.patch
@@ -1,0 +1,49 @@
+From 2eafcf9c0dde48792d14d17033dad7d93395029b Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sat, 22 Aug 2026 06:41:11 +0000
+Subject: [PATCH] Match :link on an SVG <a> that links through xlink:href
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+SVG 1.1 §17.1 gives the `a` element its link through `xlink:href`, and SVG 2
+§14.1 adds plain `href` alongside it without retiring the older attribute — so
+either one on its own makes the element a link. `:link` tested `href` alone, so
+an `<a xlink:href="…">` with no `href` matched nothing and any `a:link` rule
+styling it was dropped.
+
+WPT svg/linking/reftests/href-a-element-attr-change states exactly that: it
+removes `href` at load and asserts the element keeps its link status, so
+`a:link rect { fill: lime }` must still paint the rectangle lime. It was
+repainted red.
+
+The test only reaches the assertion once the <svg> root's onload fires, which
+is a separate main-repo fix in the same change; before that the handler never
+ran, `href` was never removed, and the test passed without ever testing what it
+was written to test.
+---
+ Broiler.CSS.Dom/CssSelectorMatcher.cs | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/Broiler.CSS.Dom/CssSelectorMatcher.cs b/Broiler.CSS.Dom/CssSelectorMatcher.cs
+index 4aa9c7f..de26f26 100644
+--- a/Broiler.CSS.Dom/CssSelectorMatcher.cs
++++ b/Broiler.CSS.Dom/CssSelectorMatcher.cs
+@@ -191,7 +191,13 @@ public sealed partial class CssSelectorMatcher(ICssSelectorStateProvider? stateP
+                 "invalid" => IsConstraintValidationCandidate(element) && HasConstraintViolation(element),
+                 "required" => SupportsRequiredState(element) && IsRequiredControl(element),
+                 "optional" => SupportsRequiredState(element) && !IsRequiredControl(element),
+-                "link" => IsNamed(element, "a", "area") && element.HasAttribute("href"),
++                // SVG 1.1 §17.1 / SVG 2 §14.1: an SVG <a> is a link through `xlink:href` as well
++                // as `href`, and the deprecated attribute still carries the link on its own — WPT
++                // svg/linking/reftests/href-a-element-attr-change removes `href` at load and
++                // asserts the element keeps its link status, so `a:link rect { fill: lime }` must
++                // still match. Testing `href` alone repainted that rect red.
++                "link" => IsNamed(element, "a", "area") &&
++                    (element.HasAttribute("href") || element.HasAttribute("xlink:href")),
+                 // Selectors 4 §7.1 pairs :link and :visited, but they are not synonyms —
+                 // :visited matches a link this user has been to. A static render has no
+                 // history to consult, and :visited is the one selector a page must never be
+-- 
+2.43.0
+

--- a/patches/README.md
+++ b/patches/README.md
@@ -36,9 +36,10 @@ git -C <Submodule> log --oneline --grep '<subject>'
 | --- | --- | --- | --- |
 | `0001-js-private-name-key-classification.patch` | `Broiler.JS` | Classify a private-name key by its marker and `#`, not the marker alone | A private name's property key is the U+0001 marker followed by the name, and the name always carries its leading `#` (`JSObject.MintPrivateName`, `FastCompiler.KeyOfPrivateName`). `KeyStrings.Classify` tested only the marker, so **every ordinary string key beginning with U+0001** was taken for a private name: writing one threw the brand-check `TypeError`, and reflection and enumeration hid it. WPT's `testharness.js` does exactly that while building its escape map — `formatEscapeMap[String.fromCharCode(p)]` with `p = 1` — so the harness threw *while loading* and **every testharness-based test in the suite reported no results at all**. With the patch applied the harness loads and the usual pass/fail table renders. |
 | `0002-html-outermost-svg-author-display.patch` | `Broiler.HTML` | Let an outermost `<svg>` keep the display the author cascaded | An outermost `<svg>` is a replaced element, so its `display` is *initially* `inline`; the box tree substitutes `inline-block` for that (how an inline replaced box is laid out here) but applied the substitution to the **cascaded** value too, discarding whatever the author wrote. `svg { display: block }` therefore laid out inline — siblings side by side instead of stacked, and `margin: 0 auto` computing to zero rather than centring (`css/compositing/line-with-svg-background` is ten block `<svg>`s and came out two to a row) — and `svg { display: none }` was overridden into a visible box, so the hidden `<svg>` a page uses to carry nothing but a `<filter>` or `<defs>` painted (`css/filter-effects/tainting-css-dropshadow-currentcolor`, 97.4 % → 100 %). The cascaded value is now read on the outermost `<svg>` only: a nested one is SVG content rather than a CSS box and arrives already carrying its ancestor's `display: none`. |
+| `0003-css-link-matches-xlink-href.patch` | `Broiler.CSS` | Match `:link` on an SVG `<a>` that links through `xlink:href` | SVG 1.1 §17.1 gives `<a>` its link through `xlink:href`, and SVG 2 §14.1 adds plain `href` without retiring it, so either attribute alone makes the element a link. `CssSelectorMatcher` tested `href` alone, so an `<a xlink:href="…">` matched no `a:link` rule and the whole rule was dropped — `a:link rect { fill: lime }` left the red rectangle beneath it showing. Pairs with the main-repo fix that fires `load` at an outermost inline `<svg>`: WPT `svg/linking/reftests/href-a-element-attr-change` removes `href` from its own load handler and asserts the element keeps its link status, so until that handler ran the test passed without reaching its assertion at all. |
 
-Neither is bumped as a pointer, and the main repo builds and passes without
-either.
+None is bumped as a pointer, and the main repo builds and passes without any of
+them.
 
 For `0001` there is no main-repo seam that can stand in: the classification
 lives entirely in `Broiler.JavaScript.Storage`, so there is no equivalent
@@ -47,8 +48,13 @@ substitution is made in `Broiler.HTML`'s own box-tree cascade — but its
 behaviour is pinned in the main repo by
 `src/Broiler.Cli.Tests/SvgAuthorDisplayTests.cs`, which feature-probes the
 pinned pointer and self-skips the cases the patch enables rather than going red.
+`0003` is the SVG-linking half of the scripted-`<svg>` work whose other three
+fixes are main-repo; those are pinned unconditionally by
+`src/Broiler.Wpt.Tests/SvgScriptedOnloadTests.cs`, and this patch is what takes
+`svg/linking/reftests/href-a-element-attr-change` the rest of the way once they
+let its load handler run.
 
-Both are listed in `scripts/apply-pending-wpt-patches.sh`, which the privacy
+All three are listed in `scripts/apply-pending-wpt-patches.sh`, which the privacy
 test-page and real-world render workflows run before their builds — so they
 reach those on top of the pinned pointer. The **WPT** workflows
 (`wpt-tests.yml`, `wpt-reftests.yml`) do not run that script today, so the WPT

--- a/patches/README.md
+++ b/patches/README.md
@@ -35,15 +35,22 @@ git -C <Submodule> log --oneline --grep '<subject>'
 | Patch | Submodule | Commit subject | Why |
 | --- | --- | --- | --- |
 | `0001-js-private-name-key-classification.patch` | `Broiler.JS` | Classify a private-name key by its marker and `#`, not the marker alone | A private name's property key is the U+0001 marker followed by the name, and the name always carries its leading `#` (`JSObject.MintPrivateName`, `FastCompiler.KeyOfPrivateName`). `KeyStrings.Classify` tested only the marker, so **every ordinary string key beginning with U+0001** was taken for a private name: writing one threw the brand-check `TypeError`, and reflection and enumeration hid it. WPT's `testharness.js` does exactly that while building its escape map — `formatEscapeMap[String.fromCharCode(p)]` with `p = 1` — so the harness threw *while loading* and **every testharness-based test in the suite reported no results at all**. With the patch applied the harness loads and the usual pass/fail table renders. |
+| `0002-html-outermost-svg-author-display.patch` | `Broiler.HTML` | Let an outermost `<svg>` keep the display the author cascaded | An outermost `<svg>` is a replaced element, so its `display` is *initially* `inline`; the box tree substitutes `inline-block` for that (how an inline replaced box is laid out here) but applied the substitution to the **cascaded** value too, discarding whatever the author wrote. `svg { display: block }` therefore laid out inline — siblings side by side instead of stacked, and `margin: 0 auto` computing to zero rather than centring (`css/compositing/line-with-svg-background` is ten block `<svg>`s and came out two to a row) — and `svg { display: none }` was overridden into a visible box, so the hidden `<svg>` a page uses to carry nothing but a `<filter>` or `<defs>` painted (`css/filter-effects/tainting-css-dropshadow-currentcolor`, 97.4 % → 100 %). The cascaded value is now read on the outermost `<svg>` only: a nested one is SVG content rather than a CSS box and arrives already carrying its ancestor's `display: none`. |
 
-The main repo builds and passes without it, and there is no main-repo seam that
-can stand in: the classification lives entirely in
-`Broiler.JavaScript.Storage`, so there is no equivalent fallback fix to carry
-here in the meantime.
+Neither is bumped as a pointer, and the main repo builds and passes without
+either.
 
-It is listed in `scripts/apply-pending-wpt-patches.sh`, which the privacy
-test-page and real-world render workflows run before their builds — so it
-reaches those on top of the pinned pointer. The **WPT** workflows
+For `0001` there is no main-repo seam that can stand in: the classification
+lives entirely in `Broiler.JavaScript.Storage`, so there is no equivalent
+fallback fix to carry here in the meantime. `0002` is the same — the
+substitution is made in `Broiler.HTML`'s own box-tree cascade — but its
+behaviour is pinned in the main repo by
+`src/Broiler.Cli.Tests/SvgAuthorDisplayTests.cs`, which feature-probes the
+pinned pointer and self-skips the cases the patch enables rather than going red.
+
+Both are listed in `scripts/apply-pending-wpt-patches.sh`, which the privacy
+test-page and real-world render workflows run before their builds — so they
+reach those on top of the pinned pointer. The **WPT** workflows
 (`wpt-tests.yml`, `wpt-reftests.yml`) do not run that script today, so the WPT
-suite only picks this up once a maintainer lands it upstream and bumps the
-pointer.
+suite only picks these up once a maintainer lands them upstream and bumps the
+pointers.

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -309,11 +309,25 @@ set -euo pipefail
 # testharness-based page in the corpus. Its unit tests pin the classification (StorageTests,
 # Issue693Tests); only a run of a real harness page can say the harness survives loading.
 #
+# 0002 (Broiler.HTML, "Let an outermost <svg> keep the display the author cascaded") IS listed,
+# and one half of it is the same absent-output failure mode as the anonymous-table and
+# dashed-stroke entries above, only inverted: an outermost <svg> was forced to `inline-block`
+# whatever the cascade said, so `svg { display: none }` painted a box the author had removed —
+# the shape every page that keeps a bare <filter> or <defs> in a hidden <svg> uses, and what
+# css/filter-effects/tainting-css-dropshadow-currentcolor asserts (97.4 % -> 100 %). The other
+# half is `svg { display: block }` laying out inline, so a column of SVGs came out as rows and
+# `margin: 0 auto` centred nothing (css/compositing/line-with-svg-background is ten of them).
+# Both decide where — and whether — an element reaches the canvas, which is what a pixel run
+# measures. Its behaviour is unit-tested in the main repo (SvgAuthorDisplayTests), which
+# feature-probes and self-skips until this is applied; there is no main-repo seam that can stand
+# in for it, because the substitution is made in Broiler.HTML's own box-tree cascade.
+#
 # NOTE: the WPT workflows do not run this script — only privacy-test-pages.yml and
-# real-world-render-tests.yml do — so the entry below serves those two. The WPT suite picks the
+# real-world-render-tests.yml do — so the entries below serve those two. The WPT suite picks each
 # fix up when a maintainer lands it upstream and bumps the pointer.
 PENDING_PATCHES=(
   "Broiler.JS|patches/0001-js-private-name-key-classification.patch"
+  "Broiler.HTML|patches/0002-html-outermost-svg-author-display.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/apply-pending-wpt-patches.sh
+++ b/scripts/apply-pending-wpt-patches.sh
@@ -325,9 +325,19 @@ set -euo pipefail
 # NOTE: the WPT workflows do not run this script — only privacy-test-pages.yml and
 # real-world-render-tests.yml do — so the entries below serve those two. The WPT suite picks each
 # fix up when a maintainer lands it upstream and bumps the pointer.
+# 0003 (Broiler.CSS, "Match :link on an SVG <a> that links through xlink:href") IS listed: a
+# pseudo-class that does not match is a whole rule that does not apply, so `a:link rect { fill:
+# lime }` over an `<a xlink:href="…">` painted the red rectangle underneath instead of the lime
+# one — the absent-output failure mode again, and one only a pixel run can see. It pairs with the
+# main-repo fix that fires `load` at an outermost inline <svg>: WPT
+# svg/linking/reftests/href-a-element-attr-change removes `href` from its handler and asserts the
+# element keeps its link status, so before that handler ran the test passed without ever reaching
+# its own assertion. With the handler firing and this patch absent the test fails honestly; with
+# both it passes for the right reason.
 PENDING_PATCHES=(
   "Broiler.JS|patches/0001-js-private-name-key-classification.patch"
   "Broiler.HTML|patches/0002-html-outermost-svg-author-display.patch"
+  "Broiler.CSS|patches/0003-css-link-matches-xlink-href.patch"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/Broiler.Cli.Tests/SvgAuthorDisplayTests.cs
+++ b/src/Broiler.Cli.Tests/SvgAuthorDisplayTests.cs
@@ -1,0 +1,173 @@
+using Broiler.HTML.Image;
+using BColor = Broiler.Graphics.BColor;
+
+namespace Broiler.Cli.Tests;
+
+/// <summary>
+/// An outermost <c>&lt;svg&gt;</c> is a replaced element in the host document, and like every
+/// replaced element its <c>display</c> is <em>initially</em> <c>inline</c> — not fixed there.
+/// The box tree substitutes <c>inline-block</c> for that initial value, which is how an inline
+/// replaced box is laid out here, but it applied the substitution to the cascaded value as well
+/// and so discarded whatever the author had written.
+/// <para>
+/// Two things fell out of that. <c>svg { display: block }</c> — the ordinary way to take an SVG
+/// off the text baseline — laid the element out inline, so siblings sat side by side instead of
+/// stacking and <c>margin: 0 auto</c> computed to zero on an inline box rather than centring it.
+/// WPT <c>css/compositing/line-with-svg-background</c> is ten such block <c>&lt;svg&gt;</c>s and
+/// came out two to a row. And <c>display: none</c> was overridden into a visible box, so the
+/// hidden <c>&lt;svg&gt;</c> that pages use to carry nothing but a <c>&lt;filter&gt;</c> or
+/// <c>&lt;defs&gt;</c> painted — WPT
+/// <c>css/filter-effects/tainting-css-dropshadow-currentcolor</c> is exactly that shape.
+/// </para>
+/// <para>
+/// Ships as a <c>Broiler.HTML</c> submodule change — commit subject <c>"Let an outermost
+/// &lt;svg&gt; keep the display the author cascaded"</c> — which the session cannot push, so it is
+/// carried as a file under <c>patches/</c> until a maintainer applies it. The pinned pointer
+/// therefore still overrides the author's <c>display</c>, and these cases feature-probe and
+/// self-skip there rather than going red. Check whether it is live with
+/// <c>git -C Broiler.HTML log --oneline --grep 'Let an outermost'</c>.
+/// </para>
+/// </summary>
+public sealed class SvgAuthorDisplayTests
+{
+    private const int ViewportWidth = 400;
+    private const int ViewportHeight = 300;
+
+    private static bool IsBlue(BColor c) =>
+        Math.Abs(c.R - 0) <= 6 && Math.Abs(c.G - 0) <= 6 && Math.Abs(c.B - 255) <= 6;
+
+    private static bool IsWhite(BColor c) =>
+        c.R >= 250 && c.G >= 250 && c.B >= 250;
+
+    private static string Describe(BColor c) => $"rgb({c.R},{c.G},{c.B})";
+
+    /// <summary>
+    /// Two 100×40 <c>&lt;svg&gt;</c> boxes in a 400px viewport, painted through the CSS
+    /// <c>background</c> of the SVG box itself so the assertions do not depend on the SVG
+    /// renderer. <paramref name="extraStyle"/> carries the declaration under test.
+    /// </summary>
+    private static string Doc(string extraStyle) =>
+        "<!DOCTYPE html><html><head><style>"
+        + "body { margin: 0 }"
+        + "svg { width: 100px; height: 40px; background: #0000ff; " + extraStyle + " }"
+        + "</style></head><body><svg></svg><svg></svg></body></html>";
+
+    /// <summary>
+    /// Does the pinned engine read the author's <c>display</c> off an outermost
+    /// <c>&lt;svg&gt;</c> at all? <c>display: none</c> is the cheapest question to ask: unpatched,
+    /// the element is forced back to <c>inline-block</c> and paints its blue box at the origin.
+    /// </summary>
+    private static bool SvgHonoursAuthorDisplay()
+    {
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(
+            Doc("display: none"), ViewportWidth, ViewportHeight);
+        return IsWhite(bitmap.GetPixel(50, 20));
+    }
+
+    [Fact(Timeout = 600000)]
+    public void SvgDisplayNone_PaintsNothing()
+    {
+        if (!SvgHonoursAuthorDisplay())
+            return; // submodule patch not applied to the pinned pointer; see class remarks.
+
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(
+            Doc("display: none"), ViewportWidth, ViewportHeight);
+
+        var atFirst = bitmap.GetPixel(50, 20);
+        Assert.True(IsWhite(atFirst),
+            $"a display:none <svg> must paint nothing, got {Describe(atFirst)} at (50,20)");
+    }
+
+    /// <summary>
+    /// With no author <c>display</c> the initial <c>inline</c> still holds, so the two boxes share
+    /// a line: the second sits to the right of the first, at x 100–200.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void SvgWithoutAuthorDisplay_StaysInline()
+    {
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(
+            Doc(string.Empty), ViewportWidth, ViewportHeight);
+
+        var atFirst = bitmap.GetPixel(50, 20);
+        Assert.True(IsBlue(atFirst),
+            $"the first <svg> should paint at (50,20), got {Describe(atFirst)}");
+
+        var besideIt = bitmap.GetPixel(150, 20);
+        Assert.True(IsBlue(besideIt),
+            $"an <svg> with no author display is inline, so the second should sit beside the "
+            + $"first at (150,20), got {Describe(besideIt)}");
+    }
+
+    /// <summary>
+    /// <c>display: block</c> stacks them instead: the first occupies y 0–40 and the second y 40–80,
+    /// and nothing is painted to the right of either.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void SvgDisplayBlock_StacksSiblings()
+    {
+        if (!SvgHonoursAuthorDisplay())
+            return; // submodule patch not applied to the pinned pointer; see class remarks.
+
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(
+            Doc("display: block"), ViewportWidth, ViewportHeight);
+
+        var first = bitmap.GetPixel(50, 20);
+        Assert.True(IsBlue(first),
+            $"the first block <svg> should paint at (50,20), got {Describe(first)}");
+
+        var second = bitmap.GetPixel(50, 60);
+        Assert.True(IsBlue(second),
+            $"the second block <svg> should stack below the first at (50,60), got {Describe(second)}");
+
+        var besideFirst = bitmap.GetPixel(150, 20);
+        Assert.True(IsWhite(besideFirst),
+            $"a block <svg> takes its own line, so (150,20) should be blank, got {Describe(besideFirst)}");
+    }
+
+    /// <summary>
+    /// CSS 2.1 §10.3.3: a block-level box resolves <c>margin-left</c>/<c>margin-right: auto</c>
+    /// into the space its containing block leaves, so a 100px <c>&lt;svg&gt;</c> in a 400px
+    /// viewport is centred at x 150–250. On an inline box the same declaration computes to zero
+    /// and leaves it flush left.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void SvgDisplayBlock_ResolvesAutoSideMargins()
+    {
+        if (!SvgHonoursAuthorDisplay())
+            return; // submodule patch not applied to the pinned pointer; see class remarks.
+
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(
+            Doc("display: block; margin: 0 auto"), ViewportWidth, ViewportHeight);
+
+        var atCentre = bitmap.GetPixel(200, 20);
+        Assert.True(IsBlue(atCentre),
+            $"margin:0 auto should centre the block <svg> over (200,20), got {Describe(atCentre)}");
+
+        var atLeftEdge = bitmap.GetPixel(20, 20);
+        Assert.True(IsWhite(atLeftEdge),
+            $"a centred block <svg> leaves the left edge blank, got {Describe(atLeftEdge)} at (20,20)");
+    }
+
+    /// <summary>
+    /// A <em>nested</em> <c>&lt;svg&gt;</c> is SVG content rather than a CSS box, and the outer
+    /// element hides every box beneath it. Reading an author display off such a box would read
+    /// that hiding back as <c>display: none</c> and drop the inner viewport, so the inner green
+    /// rectangle has to survive.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void NestedSvg_KeepsItsViewport()
+    {
+        const string html =
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<svg width=\"200\" height=\"100\" xmlns=\"http://www.w3.org/2000/svg\">"
+            + "<svg width=\"200\" height=\"100\">"
+            + "<rect width=\"100%\" height=\"100%\" fill=\"#00ff00\" />"
+            + "</svg></svg></body></html>";
+
+        using var bitmap = HtmlRender.RenderToImageWithStyleSet(html, ViewportWidth, ViewportHeight);
+
+        var inside = bitmap.GetPixel(100, 50);
+        Assert.True(Math.Abs(inside.R - 0) <= 6 && inside.G >= 200 && Math.Abs(inside.B - 0) <= 6,
+            $"the nested <svg>'s rectangle should still paint at (100,50), got {Describe(inside)}");
+    }
+}

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.SvgZoom.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.Serialization.SvgZoom.cs
@@ -24,6 +24,17 @@ public sealed partial class DomBridge
         ApplySvgPresentationAttribute(element, props, "stroke", cascadeWins: true);
         ApplySvgPresentationAttribute(element, props, "stroke-width", preferInlineStyle: true);
 
+        // CSS Transforms 1 §6/§8. Both are presentation attributes in SVG 2 and both are read off
+        // the serialized markup by SvgRenderer, which sees no stylesheet of its own — so a
+        // `rect { transform-box: fill-box }` rule reached nothing at all, and the element's
+        // `transform` kept turning about the viewport origin instead of about its own box. That is
+        // the whole of what the 45 css-transforms/transform-origin/svg-origin-* tests measure;
+        // every one of them declares transform-box in a <style> block rather than as an attribute.
+        // Neither inherits, so the cascaded value is this element's own and may overwrite the
+        // attribute — the same reasoning `fill` and `stroke` are given above.
+        ApplySvgPresentationAttribute(element, props, "transform-box", cascadeWins: true);
+        ApplySvgPresentationAttribute(element, props, "transform-origin", cascadeWins: true);
+
         if (tag is "text" or "textpath")
         {
             ApplySvgPresentationAttribute(element, props, "font-size", preferInlineStyle: true);

--- a/src/Broiler.HtmlBridge.Dom/DomBridge.WindowLoad.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge.WindowLoad.cs
@@ -59,6 +59,76 @@ public sealed partial class DomBridge
     }
 
     /// <summary>
+    /// Fires the <c>load</c> event on every outermost inline <c>&lt;svg&gt;</c> beneath
+    /// <paramref name="element"/> — the SVG counterpart of the stylesheet-link and
+    /// nested-browsing-context passes either side of it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// SVG 1.1 §16.2 puts a <c>load</c> event on the outermost <c>&lt;svg&gt;</c> once the element
+    /// and its children are parsed, and <c>onload</c> on that element is its handler. It is the
+    /// entry point the SVG test suites are written against: they define a function in a
+    /// <c>&lt;script&gt;</c> inside the fragment and call it from <c>&lt;svg onload="…"&gt;</c>.
+    /// Nothing fired it here, so the handler never ran — and because those suites are written to
+    /// paint a red "not supported" rectangle that the handler is supposed to clear, the page
+    /// rendered its own failure state. Every <c>conformance-checkers/html-svg</c> case built that
+    /// way was affected; <c>struct-dom-06-b-isvalid</c> is one, ranked at 16.5 % in the
+    /// 2026-08-21 run.
+    /// </para>
+    /// <para>
+    /// A <em>nested</em> <c>&lt;svg&gt;</c> is part of the fragment its outermost ancestor roots,
+    /// not a root of its own, so the walk stops at the first <c>&lt;svg&gt;</c> it meets rather
+    /// than dispatching again for every inner viewport.
+    /// </para>
+    /// </remarks>
+    private void FireInlineSvgRootLoads(DomElement element)
+    {
+        if (_jsContext == null)
+            return;
+
+        if (string.Equals(element.TagName, "svg", StringComparison.OrdinalIgnoreCase))
+        {
+            FireInlineSvgRootLoad(element);
+            return;
+        }
+
+        // Snapshot before iterating: a load handler can structurally mutate the tree mid-walk —
+        // the same hazard FireDescendantOnloads documents, and exactly what these tests do (the
+        // SVG DOM cases remove the element that carries the failure text).
+        foreach (var child in SnapshotChildren(element))
+        {
+            if (child is DomElement childElement)
+                FireInlineSvgRootLoads(childElement);
+        }
+    }
+
+    /// <summary>
+    /// Dispatches <c>load</c> at one outermost inline <c>&lt;svg&gt;</c>, once. Runs the
+    /// <c>onload</c> content attribute and any <c>addEventListener('load', …)</c> registered on
+    /// the element, and gives the handler the <c>evt.target</c> the SVG suites read their
+    /// <c>ownerDocument</c> from.
+    /// </summary>
+    private void FireInlineSvgRootLoad(DomElement element)
+    {
+        if (_browsingContexts.HasOnloadFired(element))
+            return;
+        _browsingContexts.MarkOnloadFired(element);
+
+        try
+        {
+            var evt = new JSObject();
+            evt.FastAddValue((KeyString)"type", new JSString("load"), JSPropertyAttributes.EnumerableConfigurableValue);
+            evt.FastAddValue((KeyString)"bubbles", JSBoolean.False, JSPropertyAttributes.EnumerableConfigurableValue);
+            DispatchEventOnElement(element, evt);
+        }
+        catch (Exception ex)
+        {
+            RenderLogger.LogWarning(LogCategory.JavaScript, "DomBridge.FireInlineSvgRootLoad",
+                $"svg load handler error: {ex.Message}", ex);
+        }
+    }
+
+    /// <summary>
     /// Fires the <c>load</c> event on the <c>&lt;body&gt;</c> element, which
     /// triggers the inline <c>onload</c> attribute handler as well as any
     /// <c>addEventListener('load', …)</c> listeners registered on the body.
@@ -94,6 +164,7 @@ public sealed partial class DomBridge
             // sheets, so by the time anything below runs their `load` events have already fired.
             FireDescendantStylesheetLinkLoads(htmlEl);
             FireDescendantOnloads(htmlEl);
+            FireInlineSvgRootLoads(htmlEl);
         }
 
         SetDocumentReadyState("complete");

--- a/src/Broiler.HtmlBridge.Dom/DomBridge/Events.cs
+++ b/src/Broiler.HtmlBridge.Dom/DomBridge/Events.cs
@@ -70,6 +70,23 @@ public sealed partial class DomBridge
     }
 
     /// <summary>
+    /// Whether <paramref name="element"/> is SVG content — the <c>&lt;svg&gt;</c> element itself or
+    /// anything inside one. Decided by walking ancestors rather than reading a namespace, so it
+    /// holds for a fragment the HTML parser built as well as one script created with
+    /// <c>createElementNS</c>.
+    /// </summary>
+    private static bool IsInSvgContent(DomElement element)
+    {
+        for (var node = element; node != null; node = ParentEl(node))
+        {
+            if (string.Equals(node.TagName, "svg", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Compiles a single <c>on*</c> attribute value into a <see cref="JSFunction"/>
     /// and stores it in <see cref="bridge-owned inline event handler state"/>.
     /// </summary>
@@ -85,7 +102,18 @@ public sealed partial class DomBridge
 
         try
         {
-            var fn = _jsContext.Eval($"(function(event) {{ {code} }})") as JSFunction;
+            // SVG 1.1 §16.2.2 names the event object `evt` inside an event-handler attribute,
+            // where HTML §8.1.5.1 names it `event`. Both are real: an element in SVG content is
+            // reached through the SVG rule, and the SVG test suites are written to it —
+            // `<svg onload="domTest(evt)">` calling a function defined in a <script> inside the
+            // fragment is the entry point of every conformance-checkers/html-svg case. With only
+            // `event` bound, `evt` was undefined, the handler threw before its first statement,
+            // and the page kept the red "not supported" state the handler exists to clear.
+            //
+            // The alias is added for SVG content only. Binding `evt` on an HTML element would
+            // shadow a page's own global of that name inside its handlers, which no browser does.
+            var svgEventAlias = IsInSvgContent(element) ? "var evt = event; " : string.Empty;
+            var fn = _jsContext.Eval($"(function(event) {{ {svgEventAlias}{code} }})") as JSFunction;
             if (fn != null)
                 GetInlineEventHandlers(element)[eventName] = fn;
         }

--- a/src/Broiler.Wpt.Tests/FlexAutomaticMinimumSizeTests.cs
+++ b/src/Broiler.Wpt.Tests/FlexAutomaticMinimumSizeTests.cs
@@ -1,0 +1,259 @@
+using System;
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// CSS Flexbox §4.5 <em>automatic minimum size</em>, and the <c>flex-shrink</c> it was silently
+/// disabling.
+///
+/// <para>
+/// A flex item's <c>min-width: auto</c> resolves to a content-based minimum: the <em>content size
+/// suggestion</em> — the min-content size of the item's <b>contents</b> — capped by the
+/// <em>specified size suggestion</em> when the item has a definite <c>width</c>.
+/// <c>ClampFlexItemBorderBoxWidth</c> asked <c>GetMinMaxWidth</c>, which folds the box's own
+/// <c>width</c> into the number it returns, so the minimum came back equal to the specified width.
+/// A <c>width: 300px</c> item therefore declared a 300px floor and <c>flex-shrink</c> — whose
+/// initial value is <c>1</c> — could not move it: a 300px item in a 100px container simply
+/// overflowed by 200px.
+/// </para>
+///
+/// <para>
+/// Only two spellings shrank before, and both bypassed the clamp rather than fixing it: a definite
+/// <c>flex-basis</c>, and <c>min-width: 0</c>. Sizing an item with <c>width</c> is the ordinary way
+/// to write one, so this reached most flex layouts that depend on shrinking.
+/// </para>
+///
+/// <para>
+/// Found triaging WPT issue #1770, whose top 30 carries two flexbox entries —
+/// <c>flex-minimum-width-flex-items-013</c> (37.2%) and <c>percentage-heights-003</c> (41.0%).
+/// </para>
+/// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
+public class FlexAutomaticMinimumSizeTests
+{
+    private const int Width = 400;
+    private const int Height = 120;
+
+    private static BBitmap Render(string html)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-flexmin-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "t.html");
+            File.WriteAllText(file, html);
+            return new WptTestRunner(Width, Height).RenderHtmlFileBitmapPublic(file, dir);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    private static bool IsBlue(BBitmap bmp, int x, int y)
+    {
+        var p = bmp.GetPixel(x, y);
+        return p.R < 80 && p.G < 80 && p.B > 180;
+    }
+
+    /// <summary>
+    /// How far the blue item extends along row <paramref name="y"/> — its used border-box width,
+    /// measured off the canvas rather than read from the box tree.
+    /// </summary>
+    /// <remarks>
+    /// The <em>extent</em> of the blue, not the length of an unbroken run from x=0: where an item
+    /// carries text, the glyphs are dark pixels sitting on the blue and a run-scan stops at the
+    /// first of them. Row 0 — the item's top edge, above the glyphs — is the row sampled for the
+    /// same reason.
+    /// </remarks>
+    private static int BlueExtent(BBitmap bmp, int y = 0)
+    {
+        int extent = 0;
+        for (int x = 0; x < Width; x++)
+        {
+            if (IsBlue(bmp, x, y))
+                extent = x + 1;
+        }
+
+        return extent;
+    }
+
+    /// <summary>
+    /// A 100px-wide flex container holding one blue item, whose style is the case under test. The
+    /// item is 10px tall so it cannot be confused with anything else on the row sampled.
+    /// </summary>
+    private static string Row(string itemStyle, string content = "") =>
+        "<!DOCTYPE html><html><body style=\"margin:0\">"
+        + "<div style=\"display:flex; width:100px; height:30px\">"
+        + $"<div style=\"height:10px; background:blue; {itemStyle}\">{content}</div>"
+        + "</div></body></html>";
+
+    /// <summary>
+    /// The case the fix is about: an item sized by <c>width</c>, everything else initial. Its
+    /// contents are empty so the content size suggestion is 0, and it must shrink to the
+    /// container's 100px.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void WidthSizedItem_ShrinksToTheContainer()
+    {
+        Assert.Equal(100, BlueExtent(Render(Row("width:300px"))));
+    }
+
+    /// <summary>
+    /// The workaround that always worked, kept so the two routes cannot drift apart:
+    /// <c>min-width: 0</c> takes the specified-minimum branch rather than the automatic one.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void ExplicitZeroMinWidth_StillShrinks()
+    {
+        Assert.Equal(100, BlueExtent(Render(Row("min-width:0; width:300px"))));
+    }
+
+    /// <summary>The other route that always worked: a definite <c>flex-basis</c>.</summary>
+    [Fact(Timeout = 600000)]
+    public void FlexBasisSizedItem_StillShrinks()
+    {
+        Assert.Equal(100, BlueExtent(Render(Row("flex:0 1 300px"))));
+    }
+
+    /// <summary>An item that already fits is not resized by any of this.</summary>
+    [Fact(Timeout = 600000)]
+    public void ItemThatFits_IsUntouched()
+    {
+        Assert.Equal(40, BlueExtent(Render(Row("width:40px"))));
+    }
+
+    /// <summary>
+    /// <c>flex-shrink: 0</c> opts out, so the item keeps its width and overflows. The shrink step
+    /// must not start ignoring the factor.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void FlexShrinkZero_KeepsTheSpecifiedWidth()
+    {
+        Assert.Equal(300, BlueExtent(Render(Row("flex-shrink:0; width:300px"))));
+    }
+
+    /// <summary>
+    /// An explicit <c>min-width</c> larger than the container still floors the shrink — the
+    /// automatic-minimum branch is not the only one, and the specified one must keep working.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void ExplicitMinWidth_StillFloorsTheShrink()
+    {
+        // The container is narrowed to 50px so the 80px floor is what stops the shrink; against
+        // the usual 100px container the item simply reaches the container first and 80 never binds.
+        var bmp = Render(
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<div style=\"display:flex; width:50px; height:30px\">"
+            + "<div style=\"min-width:80px; width:300px; height:10px; background:blue\"></div>"
+            + "</div></body></html>");
+
+        Assert.Equal(80, BlueExtent(bmp));
+    }
+
+    /// <summary>
+    /// The floor is real and must survive: an unbreakable word gives the contents a min-content
+    /// size, and the item may not shrink past it even though the container is narrower. Measured
+    /// as a band rather than an exact width because the number is the font's, not the layout's.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void ContentMinimum_StillFloorsTheShrink()
+    {
+        var bmp = Render(
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<div style=\"display:flex; width:50px; height:30px; font:16px monospace\">"
+            + "<div style=\"width:300px; height:10px; background:blue\">WWWWWWWWWW</div>"
+            + "</div></body></html>");
+
+        int run = BlueExtent(bmp);
+        Assert.True(run > 50,
+            $"an unbreakable word must stop the shrink above the container's 50px, got {run}");
+        Assert.True(run < 300, $"the item should still have shrunk from its 300px width, got {run}");
+    }
+
+    /// <summary>
+    /// §4.5 caps the content-based minimum by the specified size suggestion, so a <c>width</c>
+    /// smaller than the contents' min-content wins and the content overflows the item — which is
+    /// what a browser does.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void SpecifiedWidthSmallerThanContent_CapsTheMinimum()
+    {
+        var bmp = Render(
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<div style=\"display:flex; width:10px; height:30px; font:16px monospace\">"
+            + "<div style=\"width:20px; height:10px; background:blue\">WWWWWWWWWW</div>"
+            + "</div></body></html>");
+
+        Assert.Equal(20, BlueExtent(bmp));
+    }
+
+    /// <summary>
+    /// Two items share the deficit in proportion to their base sizes — the ordinary multi-item
+    /// case, and the one most likely to notice a change in the minimum. 150 + 150 into 100 leaves
+    /// 50 each, so the blue first item ends where the green second one starts.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void TwoItems_ShareTheDeficit()
+    {
+        var bmp = Render(
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<div style=\"display:flex; width:100px; height:30px\">"
+            + "<div style=\"width:150px; height:10px; background:blue\"></div>"
+            + "<div style=\"width:150px; height:10px; background:green\"></div>"
+            + "</div></body></html>");
+
+        Assert.Equal(50, BlueExtent(bmp));
+
+        var second = bmp.GetPixel(75, 5);
+        Assert.True(second.R < 80 && second.G > 100 && second.B < 80,
+            $"the second item should occupy 50..100, got rgb({second.R},{second.G},{second.B}) at x=75");
+    }
+
+    // ─────────── CSS Flexbox §7.1: what may follow two flex factors ───────────
+
+    /// <summary>
+    /// <c>&lt;'flex-basis'&gt;</c> is <c>content | &lt;'width'&gt;</c>, and a <c>&lt;'width'&gt;</c>
+    /// is never a bare non-zero number, so <c>flex: 0 0 4</c> is invalid and the whole shorthand is
+    /// dropped — leaving <c>flex</c> at its initial <c>0 1 auto</c>, under which the item's own
+    /// <c>width</c> still applies. Broiler took the <c>4</c> as the basis instead.
+    /// </summary>
+    /// <remarks>
+    /// Only visible once the automatic minimum size above stopped propping the item up at its
+    /// specified width: the four WPT <c>css-flexbox/flexbox_flex-*-unitless-basis</c> tests passed
+    /// on that accident, and each item sized to its text the moment it was removed.
+    /// </remarks>
+    [Theory(Timeout = 600000)]
+    [InlineData("flex:0 0 4")]
+    [InlineData("flex:0 1 4")]
+    [InlineData("flex:1 1 2.5")]
+    public void UnitlessNonZeroFlexBasis_InvalidatesTheShorthand(string invalid)
+    {
+        // width:40px would survive an invalid `flex` (initial 0 1 auto, and 40px fits in 100px).
+        Assert.Equal(40, BlueExtent(Render(Row($"{invalid}; width:40px"))));
+    }
+
+    /// <summary>
+    /// A unitless <em>zero</em> after two flex factors is a valid basis — the spec's own note says
+    /// a unitless zero not already preceded by two factors reads as a factor, so one that is
+    /// preceded by two reads as the basis. <c>flex: 0 0 0</c> must therefore still apply, giving a
+    /// 0 basis that no longer grows, against the item's own width.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void UnitlessZeroFlexBasis_IsStillValid()
+    {
+        Assert.Equal(0, BlueExtent(Render(Row("flex:0 0 0; width:40px"))));
+    }
+
+    /// <summary>A basis with a unit is unaffected, as is the two-factor form.</summary>
+    [Theory(Timeout = 600000)]
+    [InlineData("flex:0 0 60px", 60)]
+    [InlineData("flex:0 0 auto; width:60px", 60)]
+    [InlineData("flex:0 1 300px", 100)]
+    public void ValidFlexShorthands_StillApply(string style, int expected)
+    {
+        Assert.Equal(expected, BlueExtent(Render(Row(style))));
+    }
+}

--- a/src/Broiler.Wpt.Tests/SvgScriptedOnloadTests.cs
+++ b/src/Broiler.Wpt.Tests/SvgScriptedOnloadTests.cs
@@ -1,0 +1,207 @@
+using System;
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// The three gaps that kept a scripted inline <c>&lt;svg&gt;</c> from running its own test code,
+/// found while triaging the <c>conformance-checkers/html-svg</c> cluster of the 2026-08-21 WPT
+/// run. The SVG 1.1 suite the corpus is generated from writes every case the same way — a
+/// function in a <c>&lt;script&gt;</c> inside the fragment, called from
+/// <c>&lt;svg onload="domTest(evt)"&gt;</c>, which clears a red "not supported" rectangle the
+/// markup paints up front — so all three had to hold before any of them rendered.
+///
+/// <list type="number">
+/// <item>
+/// The runner's own script scan accepted three MIME types where HTML §4.12.1 defines sixteen, so
+/// <c>type="text/ecmascript"</c> — what the SVG suite writes — was skipped, along with
+/// <c>text/jscript</c>, the versioned <c>text/javascript1.x</c> aliases, and any type carrying a
+/// <c>; charset=…</c> parameter. The engine underneath runs all of them; only the harness
+/// disagreed, so the test was scored on a page whose script had never executed.
+/// </item>
+/// <item>
+/// Nothing fired <c>load</c> at an outermost inline <c>&lt;svg&gt;</c> (SVG 1.1 §16.2), so the
+/// <c>onload</c> attribute on it never ran.
+/// </item>
+/// <item>
+/// An inline handler bound the event as <c>event</c> only. SVG 1.1 §16.2.2 names it <c>evt</c>,
+/// so <c>onload="domTest(evt)"</c> threw <c>ReferenceError</c> before its first statement.
+/// </item>
+/// </list>
+/// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
+public class SvgScriptedOnloadTests
+{
+    private const int Size = 200;
+
+    private static BBitmap Render(string html)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-svgscript-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "t.html");
+            File.WriteAllText(file, html);
+            return new WptTestRunner(Size, Size).RenderHtmlFileBitmapPublic(file, dir);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// A 200×200 box that starts red. Script that runs turns it green, so one pixel at the centre
+    /// says whether the script executed — the same "no red" convention the SVG suite itself uses.
+    /// </summary>
+    private static string RedBoxPage(string markup) =>
+        "<!DOCTYPE html><html><body style=\"margin:0\">"
+        + "<div id=\"box\" style=\"width:200px;height:200px;background:red\"></div>"
+        + markup
+        + "</body></html>";
+
+    private const string PaintGreen = "document.getElementById('box').style.background = 'green';";
+
+    private static void AssertGreen(BBitmap bmp, string because)
+    {
+        var p = bmp.GetPixel(Size / 2, Size / 2);
+        Assert.True(p.R < 80 && p.G > 100 && p.B < 80,
+            $"{because} — expected the box to be green, got rgb({p.R},{p.G},{p.B})");
+    }
+
+    private static void AssertRed(BBitmap bmp, string because)
+    {
+        var p = bmp.GetPixel(Size / 2, Size / 2);
+        Assert.True(p.R > 180 && p.G < 80 && p.B < 80,
+            $"{because} — expected the box to stay red, got rgb({p.R},{p.G},{p.B})");
+    }
+
+    // ---------------------------------------------------------------
+    //  1. The JavaScript MIME essences HTML §4.12.1 defines
+    // ---------------------------------------------------------------
+
+    [Theory(Timeout = 600000)]
+    [InlineData("text/ecmascript")]
+    [InlineData("application/ecmascript")]
+    [InlineData("text/x-ecmascript")]
+    [InlineData("text/jscript")]
+    [InlineData("text/livescript")]
+    [InlineData("text/javascript1.5")]
+    [InlineData("application/x-javascript")]
+    [InlineData("text/javascript; charset=utf-8")]
+    [InlineData("text/javascript")]
+    [InlineData("application/javascript")]
+    public void LegacyJavaScriptMimeType_Executes(string type)
+    {
+        var bmp = Render(RedBoxPage($"<script type=\"{type}\">{PaintGreen}</script>"));
+        AssertGreen(bmp, $"type=\"{type}\" is a JavaScript MIME essence and must run");
+    }
+
+    /// <summary>
+    /// The other half of the same rule: a data block is not a script. Widening the accepted set
+    /// must not start executing JSON-LD, import maps or client-side templates.
+    /// </summary>
+    [Theory(Timeout = 600000)]
+    [InlineData("text/template")]
+    [InlineData("application/ld+json")]
+    [InlineData("application/json")]
+    [InlineData("text/x-handlebars-template")]
+    [InlineData("importmap")]
+    [InlineData("speculationrules")]
+    public void DataBlockType_DoesNotExecute(string type)
+    {
+        var bmp = Render(RedBoxPage($"<script type=\"{type}\">{PaintGreen}</script>"));
+        AssertRed(bmp, $"type=\"{type}\" marks a data block and must never be executed");
+    }
+
+    // ---------------------------------------------------------------
+    //  2. load fires at an outermost inline <svg>
+    // ---------------------------------------------------------------
+
+    [Fact(Timeout = 600000)]
+    public void SvgRoot_OnloadAttribute_Fires()
+    {
+        var bmp = Render(RedBoxPage(
+            $"<svg width=\"10\" height=\"10\" onload=\"{PaintGreen}\"></svg>"));
+        AssertGreen(bmp, "SVG 1.1 §16.2 fires load at the outermost <svg>, running its onload");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void SvgRoot_LoadListener_Fires()
+    {
+        var bmp = Render(RedBoxPage(
+            "<svg id=\"s\" width=\"10\" height=\"10\"></svg>"
+            + "<script>document.getElementById('s').addEventListener('load', function () { "
+            + PaintGreen + " });</script>"));
+        AssertGreen(bmp, "an addEventListener('load') on the <svg> root must fire too");
+    }
+
+    // ---------------------------------------------------------------
+    //  3. `evt` inside an SVG event-handler attribute
+    // ---------------------------------------------------------------
+
+    [Fact(Timeout = 600000)]
+    public void SvgInlineHandler_BindsEvt()
+    {
+        var bmp = Render(RedBoxPage(
+            "<svg width=\"10\" height=\"10\" onload=\"if (evt &amp;&amp; evt.type === 'load') { "
+            + PaintGreen + " }\"></svg>"));
+        AssertGreen(bmp, "SVG 1.1 §16.2.2 binds the event object as `evt` in a handler attribute");
+    }
+
+    [Fact(Timeout = 600000)]
+    public void SvgInlineHandler_StillBindsEvent()
+    {
+        var bmp = Render(RedBoxPage(
+            "<svg width=\"10\" height=\"10\" onload=\"if (event &amp;&amp; event.type === 'load') { "
+            + PaintGreen + " }\"></svg>"));
+        AssertGreen(bmp, "the HTML name `event` keeps working alongside the SVG alias");
+    }
+
+    /// <summary>
+    /// The alias is SVG-only. Binding <c>evt</c> on an HTML element would shadow a page's own
+    /// global of that name inside its handlers, which no browser does — so an HTML handler must
+    /// still see the global.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void HtmlInlineHandler_DoesNotShadowAGlobalNamedEvt()
+    {
+        var bmp = Render(
+            "<!DOCTYPE html><html><body style=\"margin:0\" onload=\"if (evt === 'the-global') { "
+            + PaintGreen + " }\">"
+            + "<div id=\"box\" style=\"width:200px;height:200px;background:red\"></div>"
+            + "<script>var evt = 'the-global';</script>"
+            + "</body></html>");
+        AssertGreen(bmp, "an HTML handler must still resolve `evt` to the page's own global");
+    }
+
+    // ---------------------------------------------------------------
+    //  All three together — the shape the SVG conformance suite uses
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// <c>conformance-checkers/html-svg/struct-dom-06-b-isvalid</c> in miniature: a red rectangle
+    /// inside the fragment, a <c>text/ecmascript</c> script defining the handler, and
+    /// <c>onload="domTest(evt)"</c> reaching the document through <c>evt.target.ownerDocument</c>
+    /// to clear it. Any one of the three gaps leaves the rectangle painted.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void ScriptedSvgConformanceShape_ClearsItsOwnFailureState()
+    {
+        var bmp = Render(
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<svg width=\"200\" height=\"200\" viewBox=\"0 0 200 200\" onload=\"domTest(evt)\">"
+            + "<script type=\"text/ecmascript\"><![CDATA[\n"
+            + "  function domTest(evt) {\n"
+            + "    var doc = evt.target.ownerDocument;\n"
+            + "    doc.getElementById('errorRect').setAttribute('width', '0');\n"
+            + "  }\n"
+            + "]]></script>"
+            + "<rect width=\"200\" height=\"200\" fill=\"green\"/>"
+            + "<rect id=\"errorRect\" width=\"200\" height=\"200\" fill=\"red\"/>"
+            + "</svg></body></html>");
+
+        AssertGreen(bmp, "the onload handler must run and shrink the red rectangle away");
+    }
+}

--- a/src/Broiler.Wpt.Tests/SvgTransformOriginTests.cs
+++ b/src/Broiler.Wpt.Tests/SvgTransformOriginTests.cs
@@ -1,0 +1,205 @@
+using System;
+using System.IO;
+using Broiler.HTML.Image;
+
+namespace Broiler.Wpt.Tests;
+
+/// <summary>
+/// CSS Transforms 1 §6/§8 — <c>transform-box</c> and <c>transform-origin</c> on an SVG element.
+///
+/// <para>
+/// An SVG <c>transform</c> was applied about the user-space origin and nothing else. That is what
+/// SVG 1.1 did and is still right under the initial <c>transform-box: view-box</c>, but
+/// <c>fill-box</c> makes the element's own bounding box the reference box, and
+/// <c>transform-origin</c> then names a point inside it — the centre when it is not written. The
+/// element's own transform has to be conjugated by that point, <c>T(o) · M · T(-o)</c>, so a
+/// <c>rotate(90)</c> meant about a box centre turned about the viewport corner instead and swung
+/// the element off the canvas.
+/// </para>
+///
+/// <para>
+/// A second gap kept the first invisible: <c>SvgRenderer</c> reads the serialized markup and sees
+/// no stylesheet, and the projection that writes cascaded SVG presentation properties back as
+/// attributes (<c>DomBridge.Serialization.SvgZoom</c>) carried a fixed list that did not include
+/// these two. Every one of the WPT cases declares <c>transform-box</c> in a <c>&lt;style&gt;</c>
+/// block, so the rule reached nothing at all.
+/// </para>
+///
+/// <para>
+/// Measured in pixels rather than off the display list because a rotation does not leave a rect
+/// item behind to inspect — <c>SvgItemTransformer</c> maps it to another primitive.
+/// </para>
+/// </summary>
+[Xunit.Collection("NativeAnchorWpt")]
+public class SvgTransformOriginTests
+{
+    private const int Canvas = 300;
+
+    private static BBitmap Render(string rectAttributes)
+    {
+        string html =
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<svg width=\"200\" height=\"200\" xmlns=\"http://www.w3.org/2000/svg\">"
+            + $"<rect width=\"100\" height=\"100\" fill=\"blue\" {rectAttributes}/>"
+            + "</svg></body></html>";
+
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-torigin-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "t.html");
+            File.WriteAllText(file, html);
+            return new WptTestRunner(Canvas, Canvas).RenderHtmlFileBitmapPublic(file, dir);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    private static bool IsBlue(BBitmap bmp, int x, int y)
+    {
+        var p = bmp.GetPixel(x, y);
+        return p.R < 80 && p.G < 80 && p.B > 180;
+    }
+
+    /// <summary>
+    /// Whether the square is still where it started — sampled at its centre, (50,50). A rotate that
+    /// turns about the box centre maps the square onto itself; one that turns about the viewport
+    /// origin takes it to negative x, off the canvas entirely.
+    /// </summary>
+    private static bool SquareStaysPut(string rectAttributes) => IsBlue(Render(rectAttributes), 50, 50);
+
+    /// <summary>The baseline: no transform at all, so the square is simply there.</summary>
+    [Fact(Timeout = 600000)]
+    public void NoTransform_LeavesTheSquareInPlace()
+    {
+        Assert.True(SquareStaysPut(string.Empty));
+    }
+
+    /// <summary>
+    /// The case that must NOT move: with no <c>transform-box</c> the initial <c>view-box</c>
+    /// applies and a quarter turn is about the user-space origin, taking the square off the canvas
+    /// exactly as it did before this change.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void NoTransformBox_KeepsTheViewBoxMeaning()
+    {
+        Assert.False(SquareStaysPut("transform=\"rotate(90)\""),
+            "without transform-box the rotate is about the viewport origin, so the square leaves the canvas");
+    }
+
+    /// <summary><c>fill-box</c> with no origin written uses the box centre, so the square holds.</summary>
+    [Fact(Timeout = 600000)]
+    public void FillBox_DefaultsToTheBoxCentre()
+    {
+        Assert.True(SquareStaysPut("transform=\"rotate(90)\" style=\"transform-box: fill-box\""));
+    }
+
+    /// <summary>
+    /// The cascade route: <c>transform-box</c> from a stylesheet rule rather than an attribute,
+    /// which is how every WPT case in this family writes it and what reached nothing before.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void TransformBoxFromAStylesheetRule_Applies()
+    {
+        string html =
+            "<!DOCTYPE html><html><head><style>rect { transform-box: fill-box; }</style></head>"
+            + "<body style=\"margin:0\">"
+            + "<svg width=\"200\" height=\"200\" xmlns=\"http://www.w3.org/2000/svg\">"
+            + "<rect width=\"100\" height=\"100\" fill=\"blue\" transform=\"rotate(90)\"/>"
+            + "</svg></body></html>";
+
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-torigin-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "t.html");
+            File.WriteAllText(file, html);
+            var bmp = new WptTestRunner(Canvas, Canvas).RenderHtmlFileBitmapPublic(file, dir);
+            Assert.True(IsBlue(bmp, 50, 50),
+                "a `rect { transform-box: fill-box }` rule must reach the SVG renderer");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    /// <summary>An origin at the box's own corner turns about that corner, so the square leaves.</summary>
+    [Fact(Timeout = 600000)]
+    public void OriginAtTheCorner_TurnsAboutThatCorner()
+    {
+        Assert.False(SquareStaysPut(
+            "transform=\"rotate(90)\" transform-origin=\"0 0\" style=\"transform-box: fill-box\""));
+    }
+
+    /// <summary>A single value gives x and centres y; 50 is the centre of a 100-wide box.</summary>
+    [Fact(Timeout = 600000)]
+    public void SingleOriginValue_CentresTheOtherAxis()
+    {
+        Assert.True(SquareStaysPut(
+            "transform=\"rotate(90)\" transform-origin=\"50\" style=\"transform-box: fill-box\""));
+    }
+
+    /// <summary>Percentages resolve against the reference box.</summary>
+    [Theory(Timeout = 600000)]
+    [InlineData("50% 50%", true)]
+    [InlineData("0% 0%", false)]
+    public void PercentageOrigin_ResolvesAgainstTheBox(string origin, bool staysPut)
+    {
+        Assert.Equal(staysPut, SquareStaysPut(
+            $"transform=\"rotate(90)\" transform-origin=\"{origin}\" style=\"transform-box: fill-box\""));
+    }
+
+    /// <summary>
+    /// The keyword forms, including the pair written the other way round — which CSS allows only
+    /// when both halves are keywords.
+    /// </summary>
+    [Theory(Timeout = 600000)]
+    [InlineData("center center", true)]
+    [InlineData("left top", false)]
+    [InlineData("top left", false)]
+    public void OriginKeywords_Resolve(string origin, bool staysPut)
+    {
+        Assert.Equal(staysPut, SquareStaysPut(
+            $"transform=\"rotate(90)\" transform-origin=\"{origin}\" style=\"transform-box: fill-box\""));
+    }
+
+    /// <summary>
+    /// A length-percentage may not follow a vertical keyword, so `top 100%` is not a form at all.
+    /// The declaration is dropped whole and the initial `50% 50%` stands — which keeps the square
+    /// in place. Reading it as `100% top` instead is what the twelve WPT
+    /// <c>svg-origin-relative-length-invalid-*</c> cases catch.
+    /// </summary>
+    [Theory(Timeout = 600000)]
+    [InlineData("top 100%")]
+    [InlineData("bottom 50px")]
+    [InlineData("50% left")]
+    public void InvalidOrigin_FallsBackToTheInitialCentre(string origin)
+    {
+        Assert.True(SquareStaysPut(
+            $"transform=\"rotate(90)\" transform-origin=\"{origin}\" style=\"transform-box: fill-box\""),
+            $"transform-origin: {origin} is invalid, so the initial 50% 50% must stand");
+    }
+
+    /// <summary><c>transform-box</c> with no transform must not invent one.</summary>
+    [Fact(Timeout = 600000)]
+    public void TransformBoxWithoutATransform_ChangesNothing()
+    {
+        Assert.True(SquareStaysPut("style=\"transform-box: fill-box\" transform-origin=\"0 0\""));
+    }
+
+    /// <summary>
+    /// The other box-relative keywords. A shape here carries no box decorations to tell them apart
+    /// from <c>fill-box</c>, so they resolve to the same rectangle rather than to the viewport.
+    /// </summary>
+    [Theory(Timeout = 600000)]
+    [InlineData("stroke-box")]
+    [InlineData("content-box")]
+    [InlineData("border-box")]
+    public void OtherBoxRelativeValues_AlsoUseTheElementsBox(string box)
+    {
+        Assert.True(SquareStaysPut($"transform=\"rotate(90)\" style=\"transform-box: {box}\""));
+    }
+}

--- a/src/Broiler.Wpt.Tests/SvgTransformOriginTests.cs
+++ b/src/Broiler.Wpt.Tests/SvgTransformOriginTests.cs
@@ -89,11 +89,49 @@ public class SvgTransformOriginTests
             "without transform-box the rotate is about the viewport origin, so the square leaves the canvas");
     }
 
-    /// <summary><c>fill-box</c> with no origin written uses the box centre, so the square holds.</summary>
+    /// <summary>
+    /// CSS Transforms 1 §8: an SVG element has no CSS layout box, and for one of those the used
+    /// value of an unspecified <c>transform-origin</c> is <c>0 0</c> — the reference box's own
+    /// corner, not its centre. For a rect already at the origin that is the user-space origin too,
+    /// so the quarter turn still carries the square off the canvas.
+    /// </summary>
     [Fact(Timeout = 600000)]
-    public void FillBox_DefaultsToTheBoxCentre()
+    public void FillBox_WithNoOriginWritten_UsesTheBoxCorner()
     {
-        Assert.True(SquareStaysPut("transform=\"rotate(90)\" style=\"transform-box: fill-box\""));
+        Assert.False(SquareStaysPut("transform=\"rotate(90)\" style=\"transform-box: fill-box\""));
+    }
+
+    /// <summary>
+    /// And the corner is the <em>box's</em> corner, which is what tells <c>fill-box</c> apart from
+    /// <c>view-box</c>: a rect away from the origin turns about itself, so it holds its place.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public void FillBoxCorner_IsTheElementsOwnCorner()
+    {
+        string html =
+            "<!DOCTYPE html><html><body style=\"margin:0\">"
+            + "<svg width=\"200\" height=\"200\" xmlns=\"http://www.w3.org/2000/svg\">"
+            + "<rect x=\"50\" y=\"50\" width=\"100\" height=\"100\" fill=\"blue\""
+            + " transform=\"rotate(90)\" style=\"transform-box: fill-box\"/>"
+            + "</svg></body></html>";
+
+        string dir = Path.Combine(Path.GetTempPath(), "broiler-torigin-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string file = Path.Combine(dir, "t.html");
+            File.WriteAllText(file, html);
+            var bmp = new WptTestRunner(Canvas, Canvas).RenderHtmlFileBitmapPublic(file, dir);
+
+            // rotate(90) about the box corner (50,50) takes (50,50)..(150,150) to
+            // (-50,50)..(50,150), so the square's right edge lands just past x = 50 at y = 100.
+            Assert.True(IsBlue(bmp, 25, 100),
+                "fill-box measures 0 0 from the element's own corner, not the viewport's");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
     }
 
     /// <summary>
@@ -107,7 +145,7 @@ public class SvgTransformOriginTests
             "<!DOCTYPE html><html><head><style>rect { transform-box: fill-box; }</style></head>"
             + "<body style=\"margin:0\">"
             + "<svg width=\"200\" height=\"200\" xmlns=\"http://www.w3.org/2000/svg\">"
-            + "<rect width=\"100\" height=\"100\" fill=\"blue\" transform=\"rotate(90)\"/>"
+            + "<rect x=\"50\" y=\"50\" width=\"100\" height=\"100\" fill=\"blue\" transform=\"rotate(90)\"/>"
             + "</svg></body></html>";
 
         string dir = Path.Combine(Path.GetTempPath(), "broiler-torigin-" + Guid.NewGuid().ToString("N"));
@@ -117,7 +155,11 @@ public class SvgTransformOriginTests
             string file = Path.Combine(dir, "t.html");
             File.WriteAllText(file, html);
             var bmp = new WptTestRunner(Canvas, Canvas).RenderHtmlFileBitmapPublic(file, dir);
-            Assert.True(IsBlue(bmp, 50, 50),
+
+            // The rule reaching the renderer is what is under test, so the rect is placed away
+            // from the origin: under view-box the quarter turn would take it off the canvas, and
+            // under fill-box it turns about its own corner and stays partly on it.
+            Assert.True(IsBlue(bmp, 25, 100),
                 "a `rect { transform-box: fill-box }` rule must reach the SVG renderer");
         }
         finally
@@ -168,19 +210,20 @@ public class SvgTransformOriginTests
 
     /// <summary>
     /// A length-percentage may not follow a vertical keyword, so `top 100%` is not a form at all.
-    /// The declaration is dropped whole and the initial `50% 50%` stands — which keeps the square
-    /// in place. Reading it as `100% top` instead is what the twelve WPT
-    /// <c>svg-origin-relative-length-invalid-*</c> cases catch.
+    /// The declaration is dropped whole and the initial value stands — which for an SVG element is
+    /// `0 0`, the reference box's corner. Two separate errors here kept the twelve WPT
+    /// <c>svg-origin-relative-length-invalid-*</c> cases red: first reading `top 100%` as
+    /// `100% top`, then falling back to the box centre rather than to `0 0`.
     /// </summary>
     [Theory(Timeout = 600000)]
     [InlineData("top 100%")]
     [InlineData("bottom 50px")]
     [InlineData("50% left")]
-    public void InvalidOrigin_FallsBackToTheInitialCentre(string origin)
+    public void InvalidOrigin_FallsBackToTheInitialCorner(string origin)
     {
-        Assert.True(SquareStaysPut(
+        Assert.False(SquareStaysPut(
             $"transform=\"rotate(90)\" transform-origin=\"{origin}\" style=\"transform-box: fill-box\""),
-            $"transform-origin: {origin} is invalid, so the initial 50% 50% must stand");
+            $"transform-origin: {origin} is invalid, so the initial 0 0 must stand — not the centre");
     }
 
     /// <summary><c>transform-box</c> with no transform must not invent one.</summary>
@@ -200,6 +243,10 @@ public class SvgTransformOriginTests
     [InlineData("border-box")]
     public void OtherBoxRelativeValues_AlsoUseTheElementsBox(string box)
     {
-        Assert.True(SquareStaysPut($"transform=\"rotate(90)\" style=\"transform-box: {box}\""));
+        // `center` is what distinguishes them from view-box: resolved against the element's own
+        // 100x100 box it is (50,50) and the quarter turn maps the square onto itself, where
+        // view-box would not reach this path at all and carry the square off the canvas.
+        Assert.True(SquareStaysPut(
+            $"transform=\"rotate(90)\" transform-origin=\"center\" style=\"transform-box: {box}\""));
     }
 }

--- a/src/Broiler.Wpt/WptTestRunner.cs
+++ b/src/Broiler.Wpt/WptTestRunner.cs
@@ -3258,20 +3258,30 @@ internal sealed partial class WptTestRunner
             var attrs = match.Groups["attrs"].Value;
 
             // Skip non-JavaScript types (e.g. type="text/template").
+            //
+            // Ask the engine's own classifier rather than re-listing the types here. The three
+            // this scan used to accept — `text/javascript`, `application/javascript`, `module` —
+            // are a fraction of the JavaScript MIME essences HTML §4.12.1 defines, so the runner
+            // skipped scripts the engine underneath it runs perfectly well, and the test was
+            // scored on a page whose script had never executed. `text/ecmascript` is the costly
+            // omission: it is what the SVG 1.1 test suite writes, so every
+            // conformance-checkers/html-svg case carrying a `domTest` handler rendered its own
+            // "not supported" red rectangle (struct-dom-06-b-isvalid, ranked at 16.5 % in the
+            // 2026-08-21 run, is one). `text/jscript` and the versioned `text/javascript1.x`
+            // aliases were skipped for the same reason.
+            //
+            // The old pattern also stopped the value at the first space, so a perfectly ordinary
+            // `type="text/javascript; charset=utf-8"` captured `text/javascript;` and matched
+            // nothing. Capture the quoted value whole and let ScriptMimeType strip the
+            // parameters, which is where that rule already lives.
             if (attrs.Contains("type=", StringComparison.OrdinalIgnoreCase))
             {
-                var typeMatch = Regex.Match(attrs, @"type\s*=\s*[""']?([^""'\s>]+)", RegexOptions.IgnoreCase);
-                if (typeMatch.Success)
-                {
-                    var type = typeMatch.Groups[1].Value;
-                    if (!string.IsNullOrEmpty(type)
-                        && !type.Equals("text/javascript", StringComparison.OrdinalIgnoreCase)
-                        && !type.Equals("application/javascript", StringComparison.OrdinalIgnoreCase)
-                        && !type.Equals("module", StringComparison.OrdinalIgnoreCase))
-                    {
-                        continue;
-                    }
-                }
+                var typeMatch = Regex.Match(
+                    attrs,
+                    @"type\s*=\s*(?:""(?<v>[^""]*)""|'(?<v>[^']*)'|(?<v>[^\s>]+))",
+                    RegexOptions.IgnoreCase);
+                if (typeMatch.Success && !ScriptMimeType.IsExecutable(typeMatch.Groups["v"].Value))
+                    continue;
             }
 
             bool isDefer = attrs.Contains("defer", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
## Summary

This PR fixes four separate gaps in SVG rendering and script execution that were discovered while triaging WPT issue #1770. The changes restore gradient fills, transform-origin conjugation, element opacity compositing, and SVG onload event dispatch.

## Key Changes

### SVG Gradient Paint Servers
- **New file:** `SvgRenderer.Gradients.cs` — implements `<linearGradient>` and `<radialGradient>` paint servers referenced via `fill="url(#id)"`
- Collects gradient definitions from markup, resolves inheritance chains (following `href`/`xlink:href` references), and emits them as `DrawTiledGradientItem` display items
- Handles gradient stop collection, offset clamping, and opacity folding
- **Tests:** `SvgGradientFillTests` validates gradient parsing, angle calculation, radial gradients, and stop opacity

### CSS Transforms on SVG Elements
- **New file:** `SvgRenderer.TransformOrigin.cs` — implements `transform-box` and `transform-origin` per CSS Transforms 1 §6/§8
- Conjugates an element's own transform by its origin point when `transform-box` names a box-relative value (not the initial `view-box`)
- Resolves `transform-origin` keywords and percentages against the element's fill bounding box
- **Modified:** `SvgStructure.cs` — tracks ancestor transforms separately from element transforms so origin conjugation applies only to the element's own transform
- **Tests:** `SvgTransformOriginTests` verifies that rotations about box centres keep elements in place while viewport-origin rotations move them off-canvas

### SVG Element Opacity
- **New file:** `SvgElementOpacityTests` — validates that `opacity` attribute creates compositing layers
- `opacity` (element compositing) is now distinct from `fill-opacity` (paint folding)
- Ancestor opacity is composed down to each shape for approximate group compositing
- **Modified:** `SvgRenderer.Paint.cs` — passes gradient dictionary to fill resolution

### SVG Scripted Onload
- **New file:** `SvgScriptedOnloadTests` — validates script execution and SVG onload dispatch
- **Modified:** `WptTestRunner.cs` — expands JavaScript MIME type acceptance from 3 to 16 essences per HTML §4.12.1 (including `text/ecmascript`, `text/jscript`, versioned `text/javascript1.x`, and types with charset parameters)
- **Modified:** `DomBridge.WindowLoad.cs` — fires `load` event on outermost inline `<svg>` elements after parsing
- **Modified:** `DomBridge/Events.cs` — binds inline event handlers with `evt` parameter for SVG content (SVG 1.1 §16.2.2 names the event `evt`, not `event`)

### Flexbox Automatic Minimum Size
- **New file:** `FlexAutomaticMinimumSizeTests` — validates flex item shrinking with `width`-sized items
- **Modified:** `CssBox.Flex.cs` — separates content-size and specified-size suggestions for `min-width: auto` resolution
- Items sized by `width` now correctly shrink to container when `flex-shrink` is non-zero, fixing overflow in flex layouts

### SVG Author Display
- **Patch file:** `0002-html-outermost-svg-author-display.patch` (Broiler.HTML submodule)
- Allows outermost `<svg>` elements to keep the `display` value the author cascaded instead of forcing `inline-block`
- Fixes `display: block` layouts and `display: none` hiding
- **Tests:** `SvgAuthorDisplayTests` feature-probes for the patch and validates block layout and display:none behavior

### SVG Link Matching
- **Patch file:** `0003-css-link-matches-xlink-href.patch` (Broiler.CSS submodule)
- `:link` pseudo-class now matches SVG `

https://claude.ai/code/session_01Df2T57qA7Kd4VW3K5w43y2